### PR TITLE
feat(daemon): warm-reconfigure worker/scheduler/poll via SIGHUP (#577)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -213,9 +213,11 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "daemon run does not accept positional arguments")
 		return 2
 	}
-	explicitWorkers, explicitScheduler, explicitParallel := false, false, false
+	explicitPoll, explicitWorkers, explicitScheduler, explicitParallel := false, false, false, false
 	fs.Visit(func(f *flag.Flag) {
 		switch f.Name {
+		case "poll":
+			explicitPoll = true
 		case "workers":
 			explicitWorkers = true
 		case "scheduler":
@@ -236,6 +238,10 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		}
 		*workers = *parallel
 		*scheduler = "pool"
+		// --parallel makes BOTH knobs explicit for warm-reload override purposes
+		// (#577): the operator named the goal, so a start-time [daemon].workers /
+		// scheduler must not silently override the launch flag.
+		explicitWorkers = true
 		explicitScheduler = true
 	}
 	if *poll <= 0 {
@@ -289,6 +295,27 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	// Warm-reconfigure path (#577): the live supervisor settings (poll, worker-pool
+	// size, scheduler mode) are held behind a mutex so a SIGHUP can re-read the
+	// [daemon] config section and apply the changes WITHOUT a `daemon restart`. A
+	// restart tears down in-flight supervision and re-inherits the launching shell's
+	// environment, dropping runtime auth (the #559 disaster); a warm reload never
+	// touches the process, its env, or in-flight jobs. CLI flags remain the initial
+	// value: a start-time [daemon] key is applied only where the operator did not pass
+	// the matching flag (flag = override). SIGHUP is deliberately kept OUT of the
+	// SIGINT/SIGTERM shutdown context above so a reload never cancels the daemon.
+	live := newDaemonReloadableConfig(*poll, *workers, usePool)
+	if reloadPaths, reloadErr := initializedPaths(*home); reloadErr == nil {
+		if start, cfgErr := config.LoadDaemonRuntimeConfig(reloadPaths); cfgErr != nil {
+			writeLine(stdout, "daemon: [daemon] config load error, using CLI flags: %v", cfgErr)
+		} else if applied := live.applyStart(start, explicitPoll, explicitWorkers, explicitScheduler); applied != "" {
+			writeLine(stdout, "daemon: applied [daemon] config at start (%s); CLI flags override", applied)
+		}
+		installDaemonReloadHandler(ctx, reloadPaths, live, stdout)
+	} else {
+		writeLine(stdout, "daemon: warm reload disabled (paths unavailable): %v", reloadErr)
+	}
+
 	// Self-register so `daemon status` / the dashboard recognize a `daemon run`
 	// launched directly (e.g. under `systemd --user`), not only one spawned by
 	// `daemon start` (#505 gap 3), and reconcile any phantom "running" runtime
@@ -300,7 +327,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	defer daemonRunStartupReconcile(ctx, *home, os.Args, stdout)()
 
 	if *repoFlag == "" {
-		err := runRegisteredRepoSupervisor(ctx, *home, *poll, *workers, *dryRun, *watchSkillOptReviews, *watchIssues, usePool, session, stdout)
+		err := runRegisteredRepoSupervisor(ctx, *home, live, *dryRun, *watchSkillOptReviews, *watchIssues, session, stdout)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return 0
 		}
@@ -346,7 +373,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			WatchIssues:            *watchIssues,
 			EscalationTTL:          resolveEscalationTTL(*home),
 			RevertDetectionEnabled: resolveRevertDetectionEnabled(*home),
-		}, store, *workers, usePool, session, stdout)
+		}, store, live, session, stdout)
 	})
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return 0
@@ -1374,21 +1401,21 @@ func hasWhitespace(value string) bool {
 	return strings.ContainsAny(value, " \t\r\n")
 }
 
-func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Duration, workers int, dryRun bool, watchSkillOptReviews bool, watchIssues bool, usePool bool, rootFilter string, stdout io.Writer) error {
+func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonReloadableConfig, dryRun bool, watchSkillOptReviews bool, watchIssues bool, rootFilter string, stdout io.Writer) error {
 	return withStoreAndPaths(home, func(paths config.Paths, store *db.Store) error {
 		schedule := registeredRepoSchedule{
 			NextPoll:    map[string]time.Time{},
 			ErrorStreak: map[string]int{},
 		}
+		_, initialWorkers, _ := live.snapshot()
 		// rawHome (the function's own param) feeds the read-only policy loaders;
 		// paths.Home (the resolved <home>/.gitmoot root) feeds the engine wiring (#459).
-		poller := defaultRegisteredRepoPoller(store, workers, dryRun, stdout, home, paths.Home)
+		poller := defaultRegisteredRepoPoller(store, initialWorkers, dryRun, stdout, home, paths.Home)
 		poller.WatchIssues = watchIssues
 		blobStore := artifact.NewStore(paths.ArtifactBlobs)
 		reviewGitHub := newSkillOptGitHubClient()
 		worker := defaultJobWorker(store, stdout, home)
 		worker.CommenterFactory = worker.defaultCommenter
-		worker.UsePool = usePool
 		worker.Admission = worker.loadAdmissionBudget()
 		checkoutLocks := &repoCheckoutLocks{}
 		poller.CheckoutLocks = checkoutLocks
@@ -1401,7 +1428,14 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 				return err
 			}
 			workerErr = startSupervisorWorkerLoopRecovering(ctx, daemonWorkerLoopInterval, stdout, func(now time.Time) error {
-				return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, rootFilter, stdout, now, checkoutLocks)
+				// Read the warm-reloadable worker count + scheduler mode each tick
+				// (#577). The worker is copied per tick so setting UsePool is race-free
+				// with the SIGHUP reload goroutine, and the pool is re-dispatched each
+				// tick so a resize applies live without disturbing in-flight jobs.
+				_, workers, usePool := live.snapshot()
+				w := worker
+				w.UsePool = usePool
+				return runEnabledRepoWorkerTicksWithLocks(ctx, store, w, workers, rootFilter, stdout, now, checkoutLocks)
 			})
 			startCockpitReconcileLoop(ctx, store, paths.Home, stdout)
 		}
@@ -1413,7 +1447,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 			if err := receiveSupervisorWorkerError(workerErr); err != nil {
 				return err
 			}
-			wait, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), poll)
+			wait, err := pollRegisteredReposWithPoller(ctx, poller, schedule, time.Now().UTC(), live.pollInterval())
 			if err != nil {
 				return err
 			}
@@ -1443,7 +1477,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, poll time.Dur
 	})
 }
 
-func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, store *db.Store, workers int, usePool bool, rootFilter string, stdout io.Writer) error {
+func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, store *db.Store, live *daemonReloadableConfig, rootFilter string, stdout io.Writer) error {
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
 		return err
 	}
@@ -1453,19 +1487,20 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	if err := recoverCancelledRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName(), rootFilter); err != nil {
 		return err
 	}
-	interval := d.PollInterval
-	if interval <= 0 {
-		interval = 30 * time.Second
-	}
 	worker := defaultJobWorker(store, stdout, home)
 	worker.CommenterFactory = worker.defaultCommenter
-	worker.UsePool = usePool
 	worker.Admission = worker.loadAdmissionBudget()
 	var checkoutLock sync.Mutex
 	workerErr := startSupervisorWorkerLoopRecovering(ctx, daemonWorkerLoopInterval, stdout, func(now time.Time) error {
 		checkoutLock.Lock()
 		defer checkoutLock.Unlock()
-		return runDaemonWorkerTick(ctx, store, worker, workers, false, d.Repo.FullName(), rootFilter, stdout, now)
+		// Read the warm-reloadable worker count + scheduler mode each tick (#577);
+		// the worker is copied per tick so UsePool is race-free with the SIGHUP
+		// reload goroutine.
+		_, workers, usePool := live.snapshot()
+		w := worker
+		w.UsePool = usePool
+		return runDaemonWorkerTick(ctx, store, w, workers, false, d.Repo.FullName(), rootFilter, stdout, now)
 	})
 	startCockpitReconcileLoop(ctx, store, home, stdout)
 	// Heartbeat schedules (#533) must also fire in the single-repo daemon, or a
@@ -1494,6 +1529,13 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 			if err := runHeartbeatScanOnce(ctx, heartbeatPaths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
 				writeLine(stdout, "heartbeat scan error: %s", err)
 			}
+		}
+		// Read the warm-reloadable poll interval each cycle (#577) so a SIGHUP
+		// change takes effect on the next tick. Fall back to the historical 30s
+		// default if it was somehow left non-positive.
+		interval := live.pollInterval()
+		if interval <= 0 {
+			interval = 30 * time.Second
 		}
 		timer := time.NewTimer(interval)
 		select {

--- a/internal/cli/daemon_reload.go
+++ b/internal/cli/daemon_reload.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// daemonReloadableConfig holds the daemon's live, WARM-reloadable runtime settings
+// (issue #577): the poll interval, the worker-pool size, and the scheduler mode.
+// It exists so a running daemon can pick these up from a SIGHUP WITHOUT a
+// `daemon restart` — a restart tears down in-flight supervision and re-inherits the
+// launching shell's environment, dropping runtime auth (the #559 disaster).
+//
+// A single mutex guards all fields because they are shared between the SIGHUP reload
+// goroutine (writer) and the supervisor/worker goroutines (readers, once per
+// tick/cycle). The reload NEVER touches the process, its env, or in-flight jobs: the
+// supervisor loops simply read the current snapshot each cycle and the worker pool is
+// re-dispatched per tick, so a changed value takes effect on the next iteration while
+// everything in flight completes untouched.
+type daemonReloadableConfig struct {
+	mu      sync.Mutex
+	poll    time.Duration
+	workers int
+	usePool bool
+}
+
+func newDaemonReloadableConfig(poll time.Duration, workers int, usePool bool) *daemonReloadableConfig {
+	return &daemonReloadableConfig{poll: poll, workers: workers, usePool: usePool}
+}
+
+// snapshot returns the current live settings atomically. Supervisor loops call it
+// each cycle (poll) and each worker tick (workers/usePool) so a warm reload is
+// observed without any per-value locking at the call sites.
+func (c *daemonReloadableConfig) snapshot() (poll time.Duration, workers int, usePool bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.poll, c.workers, c.usePool
+}
+
+// pollInterval returns just the live poll interval.
+func (c *daemonReloadableConfig) pollInterval() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.poll
+}
+
+func schedulerName(usePool bool) string {
+	if usePool {
+		return "pool"
+	}
+	return "barrier"
+}
+
+// applyStart merges a start-time [daemon] config into the live settings, applying a
+// key ONLY when the operator did not pass the matching CLI flag (flag = override).
+// This is what "read the config layer at start, keep CLI flags as the initial value /
+// override" means: an explicit flag always wins at launch; the file fills in the rest.
+// It returns a human-readable summary of what the file contributed (empty when it
+// contributed nothing), so startup can log it without pretending a no-op happened.
+func (c *daemonReloadableConfig) applyStart(next config.DaemonRuntimeConfig, explicitPoll, explicitWorkers, explicitScheduler bool) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var applied []string
+	if next.PollSet && !explicitPoll {
+		c.poll = next.Poll
+		applied = append(applied, "poll="+next.Poll.String())
+	}
+	if next.WorkersSet && !explicitWorkers {
+		c.workers = next.Workers
+		applied = append(applied, fmt.Sprintf("workers=%d", next.Workers))
+	}
+	if next.SchedulerSet && !explicitScheduler {
+		c.usePool = next.Scheduler == "pool"
+		applied = append(applied, "scheduler="+next.Scheduler)
+	}
+	return strings.Join(applied, ", ")
+}
+
+// apply merges a re-read [daemon] config into the live settings on SIGHUP. Only keys
+// PRESENT in the file are applied; every other live value (including one set from a
+// CLI flag at launch) is preserved, so an absent/empty [daemon] section reloads to a
+// no-op. It returns a concise one-line summary of what was re-read and what actually
+// changed (deliverable 3). The worker-pool size is applied LIVE because the pool is
+// re-dispatched every tick (a safe resize): the summary calls that out so the operator
+// knows a worker-count change took effect without a restart and without disturbing
+// in-flight jobs.
+func (c *daemonReloadableConfig) apply(next config.DaemonRuntimeConfig) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var reread, changed []string
+	if next.PollSet {
+		reread = append(reread, "poll="+next.Poll.String())
+		if next.Poll != c.poll {
+			changed = append(changed, fmt.Sprintf("poll %s->%s", c.poll, next.Poll))
+			c.poll = next.Poll
+		}
+	}
+	if next.WorkersSet {
+		reread = append(reread, fmt.Sprintf("workers=%d", next.Workers))
+		if next.Workers != c.workers {
+			changed = append(changed, fmt.Sprintf("workers %d->%d (live pool resize; in-flight jobs unaffected)", c.workers, next.Workers))
+			c.workers = next.Workers
+		}
+	}
+	if next.SchedulerSet {
+		usePool := next.Scheduler == "pool"
+		reread = append(reread, "scheduler="+next.Scheduler)
+		if usePool != c.usePool {
+			changed = append(changed, fmt.Sprintf("scheduler %s->%s", schedulerName(c.usePool), schedulerName(usePool)))
+			c.usePool = usePool
+		}
+	}
+	if len(reread) == 0 {
+		return "no [daemon] settings found; nothing to reload"
+	}
+	summary := "re-read " + strings.Join(reread, ", ")
+	if len(changed) == 0 {
+		return summary + "; no changes"
+	}
+	return summary + "; changed " + strings.Join(changed, ", ")
+}
+
+// reloadDaemonConfig re-reads the [daemon] config section and applies it to the live
+// supervisor settings, logging a concise summary. A config read/parse error keeps the
+// CURRENT live settings (a bad edit never disrupts a healthy daemon) and is logged.
+// It never touches the process, its environment, or in-flight jobs.
+func reloadDaemonConfig(paths config.Paths, live *daemonReloadableConfig, stdout io.Writer) {
+	next, err := config.LoadDaemonRuntimeConfig(paths)
+	if err != nil {
+		writeLine(stdout, "daemon reload (SIGHUP): config error, keeping current settings: %v", err)
+		return
+	}
+	writeLine(stdout, "daemon reload (SIGHUP): %s", live.apply(next))
+}
+
+// installDaemonReloadHandler wires SIGHUP to a warm config reload for the lifetime of
+// ctx. The handler runs in its own goroutine and stops when ctx is cancelled (daemon
+// shutdown), so it never outlives the run loop. SIGHUP is deliberately separate from
+// the SIGINT/SIGTERM shutdown context: it must NOT cancel the daemon.
+func installDaemonReloadHandler(ctx context.Context, paths config.Paths, live *daemonReloadableConfig, stdout io.Writer) {
+	hupCh := make(chan os.Signal, 1)
+	signal.Notify(hupCh, syscall.SIGHUP)
+	go func() {
+		defer signal.Stop(hupCh)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-hupCh:
+				reloadDaemonConfig(paths, live, stdout)
+			}
+		}
+	}()
+}

--- a/internal/cli/daemon_reload_test.go
+++ b/internal/cli/daemon_reload_test.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// reloadFixture initializes a home + config file with the given [daemon] body and
+// returns the resolved paths. It mirrors the other cli daemon tests (DefaultConfig +
+// body) so the reload path is exercised against a real on-disk config, not a stub.
+func reloadFixture(t *testing.T, body string) config.Paths {
+	t.Helper()
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return paths
+}
+
+// TestReloadDaemonConfigAppliesLiveSettings drives the warm-reload path directly
+// (deliverables 1-3): a re-read [daemon] section is applied to the LIVE supervisor
+// settings, the poll/worker/scheduler snapshot updates without any restart, and a
+// concise summary of what was re-read and what changed is logged.
+func TestReloadDaemonConfigAppliesLiveSettings(t *testing.T) {
+	paths := reloadFixture(t, "\n[daemon]\npoll = \"45s\"\nworkers = 4\nscheduler = \"pool\"\n")
+	live := newDaemonReloadableConfig(30*time.Second, 1, false)
+
+	var buf bytes.Buffer
+	reloadDaemonConfig(paths, live, &buf)
+
+	poll, workers, usePool := live.snapshot()
+	if poll != 45*time.Second {
+		t.Fatalf("poll = %v after reload, want 45s", poll)
+	}
+	if workers != 4 {
+		t.Fatalf("workers = %d after reload, want 4", workers)
+	}
+	if !usePool {
+		t.Fatalf("usePool = false after reload, want true (scheduler=pool)")
+	}
+	out := buf.String()
+	for _, want := range []string{"poll 30s->45s", "workers 1->4", "scheduler barrier->pool"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("reload summary %q missing %q", strings.TrimSpace(out), want)
+		}
+	}
+}
+
+// TestReloadDaemonConfigPreservesFlagValues asserts a CLI-flag value (a live value the
+// file does NOT set) survives a reload untouched, and an absent/empty [daemon] section
+// reloads to a no-op — so a warm reload never silently drops in-flight-configured knobs.
+func TestReloadDaemonConfigPreservesFlagValues(t *testing.T) {
+	// Only poll is in the file; workers/scheduler were "set from a flag" at launch.
+	paths := reloadFixture(t, "\n[daemon]\npoll = \"10s\"\n")
+	live := newDaemonReloadableConfig(30*time.Second, 8, true)
+
+	var buf bytes.Buffer
+	reloadDaemonConfig(paths, live, &buf)
+
+	poll, workers, usePool := live.snapshot()
+	if poll != 10*time.Second {
+		t.Fatalf("poll = %v, want 10s", poll)
+	}
+	if workers != 8 || !usePool {
+		t.Fatalf("flag-set workers/scheduler changed: workers=%d usePool=%v, want 8/true", workers, usePool)
+	}
+
+	// A second reload with no [daemon] keys must be a no-op that preserves everything.
+	noop := reloadFixture(t, "\n")
+	// Point the live config at the empty-section home by reloading from it.
+	buf.Reset()
+	reloadDaemonConfig(noop, live, &buf)
+	if p, w, u := live.snapshot(); p != 10*time.Second || w != 8 || !u {
+		t.Fatalf("no-op reload changed live settings: poll=%v workers=%d usePool=%v", p, w, u)
+	}
+	if !strings.Contains(buf.String(), "nothing to reload") {
+		t.Fatalf("empty [daemon] reload summary = %q, want a no-op notice", strings.TrimSpace(buf.String()))
+	}
+}
+
+// TestReloadDaemonConfigBadEditKeepsCurrent asserts a broken [daemon] edit never
+// disrupts a healthy daemon: the live settings are kept and the error is logged.
+func TestReloadDaemonConfigBadEditKeepsCurrent(t *testing.T) {
+	paths := reloadFixture(t, "\n[daemon]\npoll = \"not-a-duration\"\n")
+	live := newDaemonReloadableConfig(30*time.Second, 2, false)
+
+	var buf bytes.Buffer
+	reloadDaemonConfig(paths, live, &buf)
+
+	if p, w, u := live.snapshot(); p != 30*time.Second || w != 2 || u {
+		t.Fatalf("bad edit mutated live settings: poll=%v workers=%d usePool=%v", p, w, u)
+	}
+	if !strings.Contains(buf.String(), "keeping current settings") {
+		t.Fatalf("bad-edit reload summary = %q, want a keep-current notice", strings.TrimSpace(buf.String()))
+	}
+}
+
+// TestReloadDaemonConfigDoesNotReinheritEnv is the #559 regression guard: a warm reload
+// re-reads ONLY the config file + the live struct, never the process environment. It
+// proves that mutating a runtime-auth-shaped env var between start and reload has NO
+// effect on the reload outcome (the reload does not re-inherit the launching shell's
+// env) and that the reload itself does not clear or rewrite the env.
+func TestReloadDaemonConfigDoesNotReinheritEnv(t *testing.T) {
+	// A stand-in for the runtime auth token a `daemon restart` would re-inherit.
+	t.Setenv("GITMOOT_TEST_RUNTIME_TOKEN", "sk-live-inflight")
+	paths := reloadFixture(t, "\n[daemon]\nworkers = 5\n")
+	live := newDaemonReloadableConfig(30*time.Second, 1, false)
+
+	// Corrupt the env AFTER start, exactly as a fresh shell on restart would. A warm
+	// reload must ignore it entirely.
+	os.Setenv("GITMOOT_TEST_RUNTIME_TOKEN", "")
+
+	var buf bytes.Buffer
+	reloadDaemonConfig(paths, live, &buf)
+
+	if _, workers, _ := live.snapshot(); workers != 5 {
+		t.Fatalf("workers = %d after reload, want 5 (reload is env-independent)", workers)
+	}
+	// The reload never writes the environment either.
+	if got := os.Getenv("GITMOOT_TEST_RUNTIME_TOKEN"); got != "" {
+		t.Fatalf("reload rewrote env: GITMOOT_TEST_RUNTIME_TOKEN = %q", got)
+	}
+}
+
+// TestInstallDaemonReloadHandlerAppliesOnSIGHUP exercises the real SIGHUP wiring
+// (deliverable 1) against an in-test supervisor config: signal.Notify is registered
+// synchronously by installDaemonReloadHandler before it returns, so delivering SIGHUP
+// to our own process is caught (never the default terminate) and drives a live apply.
+// The handler stops when the context is cancelled, so it never outlives the run loop.
+func TestInstallDaemonReloadHandlerAppliesOnSIGHUP(t *testing.T) {
+	paths := reloadFixture(t, "\n[daemon]\nworkers = 6\n")
+	live := newDaemonReloadableConfig(30*time.Second, 1, false)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	installDaemonReloadHandler(ctx, paths, live, &bytes.Buffer{})
+
+	if err := syscall.Kill(syscall.Getpid(), syscall.SIGHUP); err != nil {
+		t.Fatalf("send SIGHUP: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if _, workers, _ := live.snapshot(); workers == 6 {
+			return
+		}
+		select {
+		case <-deadline:
+			_, workers, _ := live.snapshot()
+			t.Fatalf("SIGHUP did not apply reload in time: workers=%d, want 6", workers)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/internal/config/daemon_runtime.go
+++ b/internal/config/daemon_runtime.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DaemonRuntimeConfig is the daemon's WARM-reloadable runtime settings, read from
+// the optional [daemon] section of the config file (issue #577). It is the concrete
+// reload source that lets a running daemon pick up poll/worker/scheduler changes on
+// SIGHUP WITHOUT a `daemon restart` — a restart tears down in-flight supervision and
+// re-inherits the launching shell's environment, dropping runtime auth (the #559
+// disaster).
+//
+// Each field carries a companion *Set bool reporting whether the key was PRESENT in
+// the file. This is what makes the source COMPOSE cleanly with CLI flags and with a
+// warm reload:
+//   - at start, CLI flags remain the authoritative initial value; a [daemon] key is
+//     applied only where the operator did not pass the matching flag (flag = override);
+//   - on SIGHUP, only keys actually present in the file are applied to the live
+//     supervisor, leaving every other live value (e.g. one set from a CLI flag)
+//     untouched. An absent-or-empty [daemon] section therefore reloads to a NO-OP,
+//     so behavior is byte-identical for daemons that never write the section.
+//
+// Per-repo concurrency caps (#576, built in parallel) plug into the SAME reload path
+// once merged: they live in the config layer and are re-read each tick, so a warm
+// reload composes with them without this type hard-coding global-only scope.
+type DaemonRuntimeConfig struct {
+	// Poll is the [daemon].poll interval. Applied live: the supervisor re-reads the
+	// live poll each cycle, so a change takes effect on the next tick.
+	Poll    time.Duration
+	PollSet bool
+	// Workers is the [daemon].workers count (worker-pool size). Applied live: the
+	// worker limit is re-read per tick and the pool is re-dispatched each tick, so a
+	// resize takes effect on the next tick without disturbing in-flight jobs.
+	Workers    int
+	WorkersSet bool
+	// Scheduler is the [daemon].scheduler mode ("barrier" | "pool"). Applied live: the
+	// per-tick worker dispatch reads the live mode each tick.
+	Scheduler    string
+	SchedulerSet bool
+}
+
+// LoadDaemonRuntimeConfig parses the [daemon] section. A file with no [daemon]
+// section (or an empty one) returns a zero-value DaemonRuntimeConfig with every
+// *Set false — i.e. "nothing to reload", which the caller treats as a no-op. The
+// `parallel` key is intent-level sugar for `workers = N` + `scheduler = "pool"`
+// together (mirroring the CLI --parallel flag); it conflicts with an explicit
+// workers/scheduler in the same section so it can never silently win.
+func LoadDaemonRuntimeConfig(paths Paths) (DaemonRuntimeConfig, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return DaemonRuntimeConfig{}, err
+	}
+	var cfg DaemonRuntimeConfig
+	parallel := 0
+	parallelSet := false
+	current := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = strings.TrimSpace(section) == "daemon"
+			continue
+		}
+		if !current {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "poll":
+			parsed, err := parseConfigDuration(value)
+			if err != nil {
+				return DaemonRuntimeConfig{}, fmt.Errorf("parse [daemon].poll: %w", err)
+			}
+			cfg.Poll = parsed
+			cfg.PollSet = true
+		case "workers":
+			parsed, err := strconv.Atoi(value)
+			if err != nil {
+				return DaemonRuntimeConfig{}, fmt.Errorf("parse [daemon].workers: %w", err)
+			}
+			cfg.Workers = parsed
+			cfg.WorkersSet = true
+		case "scheduler":
+			parsed, err := parseConfigString(value)
+			if err != nil {
+				return DaemonRuntimeConfig{}, fmt.Errorf("parse [daemon].scheduler: %w", err)
+			}
+			cfg.Scheduler = strings.TrimSpace(parsed)
+			cfg.SchedulerSet = true
+		case "parallel":
+			parsed, err := strconv.Atoi(value)
+			if err != nil {
+				return DaemonRuntimeConfig{}, fmt.Errorf("parse [daemon].parallel: %w", err)
+			}
+			parallel = parsed
+			parallelSet = true
+		default:
+			// Unknown keys are ignored so the section can grow (e.g. #576 per-repo
+			// caps) without breaking older binaries.
+		}
+	}
+	if parallelSet {
+		if cfg.WorkersSet || cfg.SchedulerSet {
+			return DaemonRuntimeConfig{}, fmt.Errorf("[daemon].parallel cannot be combined with workers or scheduler")
+		}
+		if parallel <= 0 {
+			return DaemonRuntimeConfig{}, fmt.Errorf("[daemon].parallel must be positive")
+		}
+		cfg.Workers = parallel
+		cfg.WorkersSet = true
+		cfg.Scheduler = "pool"
+		cfg.SchedulerSet = true
+	}
+	if err := validateDaemonRuntimeConfig(cfg); err != nil {
+		return DaemonRuntimeConfig{}, err
+	}
+	return cfg, nil
+}
+
+// parseConfigDuration accepts either a bare Go duration token (30s) or a quoted
+// one ("30s"), so [daemon].poll can be written in the natural TOML style either way.
+func parseConfigDuration(value string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "\"") {
+		unquoted, err := parseConfigString(value)
+		if err != nil {
+			return 0, err
+		}
+		value = strings.TrimSpace(unquoted)
+	}
+	return time.ParseDuration(value)
+}
+
+func validateDaemonRuntimeConfig(cfg DaemonRuntimeConfig) error {
+	if cfg.PollSet && cfg.Poll <= 0 {
+		return fmt.Errorf("[daemon].poll must be positive")
+	}
+	if cfg.WorkersSet && cfg.Workers <= 0 {
+		return fmt.Errorf("[daemon].workers must be positive")
+	}
+	if cfg.SchedulerSet {
+		switch cfg.Scheduler {
+		case "barrier", "pool":
+		default:
+			return fmt.Errorf("unsupported [daemon].scheduler %q; use barrier or pool", cfg.Scheduler)
+		}
+	}
+	return nil
+}

--- a/internal/config/daemon_runtime_test.go
+++ b/internal/config/daemon_runtime_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeConfig(t *testing.T, paths Paths, body string) {
+	t.Helper()
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func TestLoadDaemonRuntimeConfigAbsentIsNoOp(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	cfg, err := LoadDaemonRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("LoadDaemonRuntimeConfig: %v", err)
+	}
+	if cfg.PollSet || cfg.WorkersSet || cfg.SchedulerSet {
+		t.Fatalf("absent [daemon] section must set nothing, got %+v", cfg)
+	}
+}
+
+func TestLoadDaemonRuntimeConfigParsesFields(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	writeConfig(t, paths, "[daemon]\npoll = \"45s\"\nworkers = 4\nscheduler = \"pool\"\n")
+	cfg, err := LoadDaemonRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("LoadDaemonRuntimeConfig: %v", err)
+	}
+	if !cfg.PollSet || cfg.Poll != 45*time.Second {
+		t.Fatalf("poll = %v (set=%v), want 45s", cfg.Poll, cfg.PollSet)
+	}
+	if !cfg.WorkersSet || cfg.Workers != 4 {
+		t.Fatalf("workers = %d (set=%v), want 4", cfg.Workers, cfg.WorkersSet)
+	}
+	if !cfg.SchedulerSet || cfg.Scheduler != "pool" {
+		t.Fatalf("scheduler = %q (set=%v), want pool", cfg.Scheduler, cfg.SchedulerSet)
+	}
+}
+
+func TestLoadDaemonRuntimeConfigBareDuration(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	writeConfig(t, paths, "[daemon]\npoll = 1m\n")
+	cfg, err := LoadDaemonRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("LoadDaemonRuntimeConfig: %v", err)
+	}
+	if !cfg.PollSet || cfg.Poll != time.Minute {
+		t.Fatalf("poll = %v, want 1m", cfg.Poll)
+	}
+}
+
+func TestLoadDaemonRuntimeConfigParallelSugar(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	writeConfig(t, paths, "[daemon]\nparallel = 3\n")
+	cfg, err := LoadDaemonRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("LoadDaemonRuntimeConfig: %v", err)
+	}
+	if !cfg.WorkersSet || cfg.Workers != 3 || !cfg.SchedulerSet || cfg.Scheduler != "pool" {
+		t.Fatalf("parallel=3 must set workers=3 + scheduler=pool, got %+v", cfg)
+	}
+}
+
+func TestLoadDaemonRuntimeConfigRejectsBadValues(t *testing.T) {
+	cases := map[string]string{
+		"bad poll":             "[daemon]\npoll = \"nope\"\n",
+		"nonpositive poll":     "[daemon]\npoll = \"0s\"\n",
+		"bad workers":          "[daemon]\nworkers = 0\n",
+		"bad scheduler":        "[daemon]\nscheduler = \"turbo\"\n",
+		"parallel+workers":     "[daemon]\nparallel = 2\nworkers = 3\n",
+		"nonpositive parallel": "[daemon]\nparallel = 0\n",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			writeConfig(t, paths, body)
+			if _, err := LoadDaemonRuntimeConfig(paths); err == nil {
+				t.Fatalf("expected error for %q", strings.TrimSpace(body))
+			}
+		})
+	}
+}
+
+func TestLoadDaemonRuntimeConfigIgnoresUnknownKeys(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// An unknown key (e.g. a future #576 per-repo cap) must not break older binaries.
+	writeConfig(t, paths, "[daemon]\nworkers = 2\nmax_per_repo = 1\n")
+	cfg, err := LoadDaemonRuntimeConfig(paths)
+	if err != nil {
+		t.Fatalf("LoadDaemonRuntimeConfig: %v", err)
+	}
+	if !cfg.WorkersSet || cfg.Workers != 2 {
+		t.Fatalf("workers = %d, want 2", cfg.Workers)
+	}
+}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -124,6 +124,9 @@ func validateConfigFile(paths Paths) error {
 	if _, err := LoadTemplateRemote(paths); err != nil {
 		return err
 	}
+	if _, err := LoadDaemonRuntimeConfig(paths); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -37,6 +37,21 @@ workspaces = %q
 evals = %q
 artifact_blobs = %q
 
+# [daemon] is the OPTIONAL warm-reloadable runtime config (issue #577). CLI flags to
+# "daemon start" / "daemon run" remain the initial value; a key here is applied only
+# where the matching flag was NOT passed (flag = override). Its real purpose is WARM
+# RELOAD: send the running daemon SIGHUP (kill -HUP <pid>) and it RE-READS this section
+# and applies poll/workers/scheduler to the live supervisor WITHOUT a restart — a
+# restart tears down in-flight supervision and re-inherits the launching shell's env,
+# dropping runtime auth (#559). With no [daemon] section behavior is byte-identical.
+# poll is a Go duration; workers is the worker-pool size (applied live — the pool is
+# re-dispatched each tick); scheduler is barrier|pool. "parallel = N" is sugar for
+# workers=N + scheduler=pool and conflicts with an explicit workers/scheduler here.
+# [daemon]
+# poll = "30s"
+# workers = 1
+# scheduler = "barrier"
+
 [parallel_sessions]
 same_session = "fork_temp_session"
 merge_back = "summary"


### PR DESCRIPTION
## Summary

Adds a **warm-reconfigure path** so the daemon's worker / scheduler / poll settings
change **without a `daemon restart`**. A restart tears down in-flight supervision and
re-inherits the launching shell's environment, dropping runtime auth — the #559
disaster. A warm reload never touches the process, its env, or in-flight jobs.

Send the running daemon `SIGHUP` (`kill -HUP <pid>`) and it **re-reads** the optional
`[daemon]` config section and applies `poll` / `workers` / `scheduler` to the **live**
supervisor, logging a concise one-line summary of what was re-read and what changed.

Closes #577.

## Design

- **Reloadable config source** (`internal/config/daemon_runtime.go`): a new optional
  `[daemon]` section (`poll`, `workers`, `scheduler`, plus `parallel = N` sugar =
  `workers=N` + `scheduler=pool`, mirroring the CLI flag). `LoadDaemonRuntimeConfig`
  returns each field with a companion `*Set` bool so the source **composes** with both
  CLI flags and warm reload: only keys actually present in the file are applied.
  Unknown keys are ignored so the section can grow (e.g. #576 per-repo caps) without
  breaking older binaries. Routing the reload through the config layer is deliberate so
  it composes with #576 once that lands — see note below.
- **Live settings holder** (`internal/cli/daemon_reload.go`): `daemonReloadableConfig`
  holds `poll`/`workers`/`usePool` behind a single mutex. The SIGHUP goroutine is the
  writer; the supervisor loops are readers that take a `snapshot()` **each cycle / each
  worker tick**, so a changed value takes effect on the next iteration while everything
  in flight completes untouched. `SIGHUP` is installed on its own channel, deliberately
  **separate** from the `SIGINT`/`SIGTERM` shutdown context, so a reload never cancels
  the daemon.
- **Wiring** (`internal/cli/daemon.go`): both the registered-repo and single-repo
  supervisors now read the poll interval per cycle and the worker count + scheduler mode
  per tick from the live holder. **CLI flags remain the initial value / override**: at
  start a `[daemon]` key is applied only where the operator did **not** pass the matching
  flag. `--parallel N` marks both `workers` and `scheduler` explicit so a start-time
  file can't silently override the named launch goal.

### Deliverable 2 — worker-pool size

The worker limit is applied **live**: the worker is re-dispatched every tick, so a
resize (`workers`) takes effect on the next tick **without disturbing in-flight jobs**.
This is a safe live resize, so there is no "needs a restart" fallback case — and
crucially **no silent cap**: the reload summary explicitly reports the resize
(`workers M->N (live pool resize; in-flight jobs unaffected)`) so the operator sees it
took effect warm.

### Deliverable 3 — reload log line

On SIGHUP the daemon prints one concise line, e.g.:

```
daemon reload (SIGHUP): re-read poll=45s, workers=4, scheduler=pool; changed poll 30s->45s, workers 1->4 (live pool resize; in-flight jobs unaffected), scheduler barrier->pool
```

An absent/empty `[daemon]` section reloads to a **no-op** (`no [daemon] settings found;
nothing to reload`); a broken edit **keeps the current live settings** and logs the
error, so a bad edit never disrupts a healthy daemon.

## Preserving existing behavior

- With no `[daemon]` section (the default; the template ships it commented out),
  behavior is **byte-identical** — every `*Set` is false, so start applies nothing and
  SIGHUP is a no-op.
- CLI flags are unchanged and still win at launch.
- The supervisor loops read the same values they did before; only the *source* of those
  values moved behind a snapshot, so the non-reload path is unchanged.

## Tests

Config layer (`internal/config/daemon_runtime_test.go`): parse/validate, bare vs quoted
duration, `parallel` sugar, bad-value rejection, unknown-key tolerance, absent = no-op.

CLI layer (`internal/cli/daemon_reload_test.go`) drives the reload path directly with a
seeded on-disk config (no real daemon spawned):

- `TestReloadDaemonConfigAppliesLiveSettings` — a re-read section updates the live
  poll/workers/scheduler snapshot and logs the change summary.
- `TestReloadDaemonConfigPreservesFlagValues` — a flag-set live value the file doesn't
  set survives; an empty section is a no-op.
- `TestReloadDaemonConfigBadEditKeepsCurrent` — a broken edit keeps current settings.
- `TestReloadDaemonConfigDoesNotReinheritEnv` — the **#559 regression guard**: mutating
  a runtime-auth-shaped env var between start and reload has no effect on the reload
  (the reload is env-independent — it re-reads only the file + live struct — and never
  rewrites the env).
- `TestInstallDaemonReloadHandlerAppliesOnSIGHUP` — exercises the real SIGHUP wiring
  against an in-test supervisor (signal.Notify is registered synchronously before the
  handler returns, so self-delivering SIGHUP is caught, never the default terminate).

## Note on #576

Per-repo concurrency (#576) is being built in parallel. This change routes the reload
through the config layer and ignores unknown `[daemon]` keys precisely so per-repo caps
plug into the **same** SIGHUP reload path once #576 merges — full per-repo warm-reload
composes then, with no change to this wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
