### PR TITLE
feat(cli): persist daemon runtime auth so restart keeps Claude auth (#578)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -125,9 +125,32 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart boo
 		}
 	}
 
-	warnIfDaemonStartLosesClaudeAuth(stderr, restart, priorDaemonHadClaudeAuth)
+	// Persist and recover runtime auth so a `daemon restart` from a shell that no
+	// longer carries the token cannot silently disable Claude auth (#578; #581 only
+	// warns). Persist first (the live env wins) so a start that DOES carry a token
+	// records it 0600; then compute the child-env injection so a start whose shell
+	// LACKS the token but whose 0600 file has one recovers it into the child. Both
+	// steps are best-effort: a persistence/load failure is a masked warning and
+	// never blocks the start, and the token value is never logged.
+	runtimeAuthFile := daemonRuntimeAuthFile(paths)
+	if _, err := runtime.PersistRuntimeAuthEnv(runtimeAuthFile, claudeAuthEnvLookup); err != nil {
+		fmt.Fprintf(stderr, "daemon start: warning: could not persist runtime auth: %v\n", err)
+	}
+	childRuntimeEnv, err := runtime.RuntimeAuthChildEnv(runtimeAuthFile, claudeAuthEnvLookup)
+	if err != nil {
+		fmt.Fprintf(stderr, "daemon start: warning: could not load persisted runtime auth: %v\n", err)
+	}
 
-	started, err := startDaemonChildFn(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir)
+	// #581's auth-drop warning is only relevant when nothing will supply the token:
+	// if #578 recovers it from the persisted file (childRuntimeEnv non-empty) the
+	// restarted daemon keeps auth, so the warning correctly stays silent. When the
+	// live env already carries the token, childRuntimeEnv is empty and the warn
+	// helper short-circuits on Ready() anyway.
+	if len(childRuntimeEnv) == 0 {
+		warnIfDaemonStartLosesClaudeAuth(stderr, restart, priorDaemonHadClaudeAuth)
+	}
+
+	started, err := startDaemonChildFn(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir, childRuntimeEnv)
 	if err != nil {
 		fmt.Fprintf(stderr, "daemon start: %v\n", err)
 		return 1
@@ -448,8 +471,18 @@ var claudeAuthEnvLookup = os.LookupEnv
 
 // startDaemonChildFn is the daemon child-spawn indirection. It defaults to the
 // real startDaemonChild; tests swap it so the start/restart command body can be
-// driven end-to-end without launching an actual daemon process.
+// driven end-to-end without launching an actual daemon process. The trailing
+// extraEnv is the runtime-auth recovered from the persisted 0600 file (#578);
+// tests swap the seam to capture it and assert the token reaches the child.
 var startDaemonChildFn = startDaemonChild
+
+// daemonRuntimeAuthFile is the 0600 file into which the daemon persists its
+// runtime auth (#578) so a `daemon restart` from a shell missing the token can
+// recover it. It lives in the daemon home alongside daemon.json — but, unlike
+// daemon.json, it is owner-read/write only and MUST never be world-readable.
+func daemonRuntimeAuthFile(paths config.Paths) string {
+	return filepath.Join(paths.Home, "daemon-runtime.env")
+}
 
 // warnIfDaemonStartLosesClaudeAuth prints a prominent, non-fatal stderr warning
 // when the daemon about to (re)start will inherit an environment WITHOUT Claude
@@ -1073,7 +1106,7 @@ func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {
 	return pid, false, nil
 }
 
-func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, watchIssues bool, scheduler string, repo string, session string, state daemonState, workDir string) (daemonMeta, error) {
+func startDaemonChild(home string, poll string, workers int, watchSkillOptReviews bool, watchIssues bool, scheduler string, repo string, session string, state daemonState, workDir string, extraEnv []string) (daemonMeta, error) {
 	executable, err := os.Executable()
 	if err != nil {
 		return daemonMeta{}, err
@@ -1088,6 +1121,14 @@ func startDaemonChild(home string, poll string, workers int, watchSkillOptReview
 	cmd.Dir = workDir
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
+	// Recover runtime auth the launching shell has lost (#578). Historically the
+	// child was spawned with cmd.Env unset so it inherited this process's env; when
+	// extraEnv is empty that inheritance is preserved exactly (leaving cmd.Env nil).
+	// When extraEnv carries persisted tokens, set the child env to this process's
+	// environment PLUS those tokens so the restarted daemon keeps Claude auth.
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := cmd.Start(); err != nil {
 		return daemonMeta{}, err

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -63,7 +63,7 @@ func printDaemonUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot daemon start [--repo owner/repo] [--poll 30s] [--workers 1 | --parallel N] [--scheduler barrier|pool] [--watch-skillopt-reviews] [--watch-issues]")
 	fmt.Fprintln(w, "  gitmoot daemon run [--repo owner/repo] [--poll 30s] [--workers 1 | --parallel N] [--scheduler barrier|pool] [--watch-skillopt-reviews] [--watch-issues]")
-	fmt.Fprintln(w, "  gitmoot daemon stop")
+	fmt.Fprintln(w, "  gitmoot daemon stop [--forget-runtime-auth]")
 	fmt.Fprintln(w, "  gitmoot daemon restart")
 	fmt.Fprintln(w, "  gitmoot daemon status")
 	fmt.Fprintln(w, "  gitmoot daemon logs")
@@ -127,27 +127,45 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart boo
 
 	// Persist and recover runtime auth so a `daemon restart` from a shell that no
 	// longer carries the token cannot silently disable Claude auth (#578; #581 only
-	// warns). Persist first (the live env wins) so a start that DOES carry a token
-	// records it 0600; then compute the child-env injection so a start whose shell
-	// LACKS the token but whose 0600 file has one recovers it into the child. Both
-	// steps are best-effort: a persistence/load failure is a masked warning and
-	// never blocks the start, and the token value is never logged.
+	// warns). Persist ALWAYS (start and restart) so a start that DOES carry a token
+	// records it 0600 for a later restart to recover; the live env always wins, so
+	// this never overwrites a good token with an empty env. Both steps are
+	// best-effort: a persistence/load failure is a masked warning and never blocks
+	// the start, and the token value is never logged.
 	runtimeAuthFile := daemonRuntimeAuthFile(paths)
 	if _, err := runtime.PersistRuntimeAuthEnv(runtimeAuthFile, claudeAuthEnvLookup); err != nil {
 		fmt.Fprintf(stderr, "daemon start: warning: could not persist runtime auth: %v\n", err)
 	}
-	childRuntimeEnv, err := runtime.RuntimeAuthChildEnv(runtimeAuthFile, claudeAuthEnvLookup)
-	if err != nil {
-		fmt.Fprintf(stderr, "daemon start: warning: could not load persisted runtime auth: %v\n", err)
+
+	// Recovery (injecting the persisted token into the child) is RESTART-ONLY
+	// (#578 review): a plain `daemon start` must honor an intentionally-unset token
+	// — e.g. an operator switching a previously-Claude-authed box to a Codex/Kimi
+	// -only daemon — instead of silently re-injecting the old persisted token. Only
+	// a restart from a shell that has since LOST the token (the #578 target) recovers
+	// it; `daemon stop --forget-runtime-auth` deletes the file for an explicit reset.
+	var childRuntimeEnv []string
+	if restart {
+		childRuntimeEnv, err = runtime.RuntimeAuthChildEnv(runtimeAuthFile, claudeAuthEnvLookup)
+		if err != nil {
+			fmt.Fprintf(stderr, "daemon restart: warning: could not load persisted runtime auth: %v\n", err)
+		}
 	}
 
-	// #581's auth-drop warning is only relevant when nothing will supply the token:
-	// if #578 recovers it from the persisted file (childRuntimeEnv non-empty) the
-	// restarted daemon keeps auth, so the warning correctly stays silent. When the
-	// live env already carries the token, childRuntimeEnv is empty and the warn
+	// #581's auth-drop warning is only relevant when nothing will supply the token.
+	// When #578 recovers it from the persisted file (childRuntimeEnv non-empty) the
+	// restarted daemon keeps auth — but the persisted token has NO expiry/validation
+	// and may be stale or revoked, so do NOT treat "recovered something" as "auth is
+	// fine" and silently swallow the warning (#578 review). Emit an informational
+	// note instead so a silent 401 storm from a dead token is at least traceable. If
+	// the live env already carries the token, childRuntimeEnv is empty and the warn
 	// helper short-circuits on Ready() anyway.
 	if len(childRuntimeEnv) == 0 {
 		warnIfDaemonStartLosesClaudeAuth(stderr, restart, priorDaemonHadClaudeAuth)
+	} else {
+		fmt.Fprintln(stderr, "ℹ️  using PERSISTED runtime auth recovered from daemon-runtime.env (this shell lacks the token).")
+		fmt.Fprintln(stderr, "    It has no expiry or validation and may be STALE or REVOKED — if Claude-runtime jobs")
+		fmt.Fprintln(stderr, "    start failing auth, verify with `gitmoot daemon status`.")
+		fmt.Fprintln(stderr, "    To invalidate the persisted token, run `gitmoot daemon stop --forget-runtime-auth`.")
 	}
 
 	started, err := startDaemonChildFn(cfg.Home, cfg.Poll.String(), cfg.Workers, cfg.WatchSkillOptReviews, cfg.WatchIssues, cfg.Scheduler, cfg.RepoFlag, cfg.Session, state, resolvedWorkDir, childRuntimeEnv)
@@ -357,6 +375,7 @@ func runDaemonStop(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("daemon stop", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	forgetRuntimeAuth := fs.Bool("forget-runtime-auth", false, "also delete the persisted runtime-auth file (daemon-runtime.env) so a revoked/stale token is NOT recovered on the next restart (#578)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -371,6 +390,21 @@ func runDaemonStop(args []string, stdout, stderr io.Writer) int {
 	if err != nil {
 		fmt.Fprintf(stderr, "daemon stop: %v\n", err)
 		return 1
+	}
+	// --forget-runtime-auth is the explicit invalidation path for a revoked/stale
+	// persisted token (#578 review): delete the 0600 file so the next restart does
+	// not silently recover a dead token. Best-effort and independent of whether the
+	// daemon is actually running; the token value is never printed. The internal
+	// restart's stop call deliberately does NOT pass this flag, so restart recovery
+	// still works.
+	if *forgetRuntimeAuth {
+		if err := os.Remove(daemonRuntimeAuthFile(paths)); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				fmt.Fprintf(stderr, "daemon stop: warning: could not remove persisted runtime auth: %v\n", err)
+			}
+		} else {
+			writeLine(stdout, "removed persisted runtime auth (daemon-runtime.env)")
+		}
 	}
 	state := daemonProcessState(paths)
 	pid, stale, err := currentDaemonPID(state)

--- a/internal/cli/daemon_authwarn_e2e_test.go
+++ b/internal/cli/daemon_authwarn_e2e_test.go
@@ -15,7 +15,7 @@ import (
 func withStubbedDaemonChild(t *testing.T) {
 	t.Helper()
 	prev := startDaemonChildFn
-	startDaemonChildFn = func(home, poll string, workers int, watchSkillOptReviews, watchIssues bool, scheduler, repo, session string, state daemonState, workDir string) (daemonMeta, error) {
+	startDaemonChildFn = func(home, poll string, workers int, watchSkillOptReviews, watchIssues bool, scheduler, repo, session string, state daemonState, workDir string, extraEnv []string) (daemonMeta, error) {
 		return daemonMeta{PID: 424242, LogFile: filepath.Join(home, "daemon.log")}, nil
 	}
 	t.Cleanup(func() { startDaemonChildFn = prev })

--- a/internal/cli/daemon_runtime_auth_test.go
+++ b/internal/cli/daemon_runtime_auth_test.go
@@ -109,4 +109,96 @@ func TestDaemonRestartRecoversRuntimeAuthIntoChild(t *testing.T) {
 	if strings.Contains(stdout.String()+stderr.String(), token) {
 		t.Fatalf("token leaked to restart output; stdout=%q stderr=%q", stdout.String(), stderr.String())
 	}
+
+	// #578 review (finding 1): recovery must NOT silently swallow the auth warning.
+	// It re-injects a persisted token that has no expiry/validation, so it emits an
+	// informational note that the token may be stale and how to invalidate it —
+	// rather than the loud "WARNING" (which would falsely imply no auth) or silence.
+	out := stderr.String()
+	if strings.Contains(out, "WARNING") {
+		t.Fatalf("recovery should not emit the loud auth-DROP WARNING; stderr=%q", out)
+	}
+	if !strings.Contains(out, "PERSISTED") || !strings.Contains(out, "STALE") {
+		t.Fatalf("recovery should note the token is persisted and may be stale; stderr=%q", out)
+	}
+	if !strings.Contains(out, "--forget-runtime-auth") {
+		t.Fatalf("recovery note should point at the invalidation path; stderr=%q", out)
+	}
+}
+
+// TestDaemonPlainStartDoesNotRecoverRuntimeAuth (finding 2) proves recovery is
+// RESTART-ONLY: a plain `daemon start` from a shell with the token intentionally
+// unset must NOT re-inject a previously-persisted token, so an operator switching
+// to a Codex/Kimi-only daemon has their intended env change honored.
+func TestDaemonPlainStartDoesNotRecoverRuntimeAuth(t *testing.T) {
+	const token = "sk-ant-oat01-do-not-recover-3c4d"
+	home := t.TempDir()
+
+	path := daemonRuntimeAuthFile(config.PathsForHome(home))
+	if err := os.MkdirAll(config.PathsForHome(home).Home, 0o700); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	if _, err := runtime.PersistRuntimeAuthEnv(path, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return token, true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("seed persist: %v", err)
+	}
+
+	// The launching shell intentionally LACKS the token, and this is a plain start.
+	withClaudeAuthLookup(t, map[string]string{})
+	var captured []string
+	captureDaemonChildEnv(t, &captured)
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start returned %d; stderr=%q", code, stderr.String())
+	}
+
+	for _, e := range captured {
+		if strings.Contains(e, token) {
+			t.Fatalf("plain start must NOT recover the persisted token into the child; captured=%v", captured)
+		}
+	}
+	// With no auth in env and no recovery, the operator still gets the loud warning.
+	if !strings.Contains(stderr.String(), "WARNING") {
+		t.Fatalf("plain start without auth should still warn; stderr=%q", stderr.String())
+	}
+}
+
+// TestDaemonStopForgetRuntimeAuthRemovesFile (findings 1 & 2) proves the explicit
+// invalidation path: `daemon stop --forget-runtime-auth` deletes the persisted
+// 0600 file so a revoked/stale token is not recovered on the next restart.
+func TestDaemonStopForgetRuntimeAuthRemovesFile(t *testing.T) {
+	home := t.TempDir()
+	path := daemonRuntimeAuthFile(config.PathsForHome(home))
+	if err := os.MkdirAll(config.PathsForHome(home).Home, 0o700); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	if _, err := runtime.PersistRuntimeAuthEnv(path, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return "sk-ant-oat01-forget-me-5e6f", true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("seed persist: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("precondition: persisted file should exist: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStop([]string{"--home", home, "--forget-runtime-auth"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("stop returned %d; stderr=%q", code, stderr.String())
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("persisted runtime-auth file should be removed, stat err=%v", err)
+	}
+	if !strings.Contains(stdout.String(), "removed persisted runtime auth") {
+		t.Fatalf("stop should report the removal; stdout=%q", stdout.String())
+	}
 }

--- a/internal/cli/daemon_runtime_auth_test.go
+++ b/internal/cli/daemon_runtime_auth_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// captureDaemonChildEnv swaps the child-spawn seam to record the extraEnv the
+// (re)start body computes for the child, WITHOUT launching a real daemon. The
+// child's actual environment is os.Environ()+extraEnv (see startDaemonChild), so
+// capturing extraEnv is the load-bearing assertion for #578's recovery path.
+func captureDaemonChildEnv(t *testing.T, captured *[]string) {
+	t.Helper()
+	prev := startDaemonChildFn
+	startDaemonChildFn = func(home, poll string, workers int, watchSkillOptReviews, watchIssues bool, scheduler, repo, session string, state daemonState, workDir string, extraEnv []string) (daemonMeta, error) {
+		*captured = append([]string{}, extraEnv...)
+		return daemonMeta{PID: 777777, LogFile: home + "/daemon.log"}, nil
+	}
+	t.Cleanup(func() { startDaemonChildFn = prev })
+}
+
+// TestDaemonStartPersistsRuntimeAuth0600 (case a) drives the REAL start body
+// with a token in the (seam-injected) env and asserts the 0600 file is written
+// in the daemon home with mode 0600 and contains the token.
+func TestDaemonStartPersistsRuntimeAuth0600(t *testing.T) {
+	captureDaemonChildEnv(t, new([]string))
+	const token = "sk-ant-oat01-persist-me-9f8e"
+	withClaudeAuthLookup(t, map[string]string{runtime.ClaudeOAuthTokenEnv: token})
+
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", false, false, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("start returned %d; stderr=%q", code, stderr.String())
+	}
+
+	path := daemonRuntimeAuthFile(config.PathsForHome(home))
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected persisted runtime-auth file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("runtime-auth file mode = %o, want 0600", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), runtime.ClaudeOAuthTokenEnv+"="+token) {
+		t.Fatalf("persisted file should contain the token")
+	}
+
+	// SECURITY: the token must never leak to stdout/stderr.
+	if strings.Contains(stdout.String()+stderr.String(), token) {
+		t.Fatalf("token leaked to daemon start output; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+// TestDaemonRestartRecoversRuntimeAuthIntoChild (case b) proves recovery: with
+// the token ABSENT from the launching env but PRESENT in the 0600 file, the
+// computed child environment (captured via the seam) carries the token so the
+// restarted daemon keeps Claude auth automatically.
+func TestDaemonRestartRecoversRuntimeAuthIntoChild(t *testing.T) {
+	const token = "sk-ant-oat01-recover-me-1a2b"
+	home := t.TempDir()
+
+	// Seed the 0600 file as if a prior authed start had persisted it.
+	path := daemonRuntimeAuthFile(config.PathsForHome(home))
+	if err := os.MkdirAll(config.PathsForHome(home).Home, 0o700); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	if _, err := runtime.PersistRuntimeAuthEnv(path, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return token, true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("seed persist: %v", err)
+	}
+
+	// The launching shell LACKS the token.
+	withClaudeAuthLookup(t, map[string]string{})
+	var captured []string
+	captureDaemonChildEnv(t, &captured)
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", true, true, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("restart returned %d; stderr=%q", code, stderr.String())
+	}
+
+	want := runtime.ClaudeOAuthTokenEnv + "=" + token
+	found := false
+	for _, e := range captured {
+		if e == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("computed child env should recover the token; captured=%v", captured)
+	}
+
+	// SECURITY: the recovered token must never appear in the start output.
+	if strings.Contains(stdout.String()+stderr.String(), token) {
+		t.Fatalf("token leaked to restart output; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}

--- a/internal/runtime/runtime_auth_persist.go
+++ b/internal/runtime/runtime_auth_persist.go
@@ -1,0 +1,169 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// RuntimeAuthEnvVars is the set of runtime-auth environment variables the daemon
+// persists so a `daemon restart` launched from a shell that no longer carries
+// them cannot silently disable runtime auth (#578, the #559 root cause; #581
+// only WARNS). These are exactly the Claude/Anthropic credential vars
+// InspectClaudeAuthEnv inspects — token values that MUST be treated as secrets:
+// never logged, printed, or written to the world-readable daemon.json/meta.
+var RuntimeAuthEnvVars = []string{
+	ClaudeOAuthTokenEnv,
+	AnthropicAPIKeyEnv,
+	AnthropicAuthTokenEnv,
+}
+
+// runtimeAuthFileHeader documents the file for a human who finds it; it is
+// deliberately value-free so nothing sensitive lives in a comment.
+const runtimeAuthFileHeader = "# gitmoot daemon runtime auth — persisted by `gitmoot daemon start` (#578).\n" +
+	"# 0600, owner read/write only. Contains runtime auth tokens; do not share or log.\n"
+
+// PersistRuntimeAuthEnv writes the runtime-auth variables currently present in
+// the environment (via lookup) to path, created 0600 (owner read/write only).
+//
+// It NEVER overwrites a good persisted token with an empty/unset env: a value
+// already in the file is retained unless the live env supplies a non-empty
+// replacement, and the live env always wins when both are present. It writes
+// nothing — and removes nothing — when no token is present in either the env or
+// the existing file, so a plain start on a Codex/Kimi-only box leaves no file.
+//
+// It returns whether a file was written. The token value is never logged; on
+// error the returned error carries only the path/OS reason, not the secret.
+func PersistRuntimeAuthEnv(path string, lookup func(string) (string, bool)) (bool, error) {
+	if lookup == nil {
+		return false, nil
+	}
+	existing, err := LoadPersistedRuntimeAuthEnv(path)
+	if err != nil {
+		return false, err
+	}
+	merged := make(map[string]string, len(RuntimeAuthEnvVars))
+	for _, key := range RuntimeAuthEnvVars {
+		// Prefer the live env when it supplies a non-empty value; otherwise retain
+		// any previously persisted value so an unset env never erases a good token.
+		if v, ok := lookup(key); ok && strings.TrimSpace(v) != "" {
+			merged[key] = v
+			continue
+		}
+		if v, ok := existing[key]; ok && strings.TrimSpace(v) != "" {
+			merged[key] = v
+		}
+	}
+	if len(merged) == 0 {
+		// Nothing worth persisting; never create or truncate a file with no token.
+		return false, nil
+	}
+
+	keys := make([]string, 0, len(merged))
+	for k := range merged {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString(runtimeAuthFileHeader)
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(merged[k])
+		b.WriteString("\n")
+	}
+
+	// Write via a 0600 temp file + rename so the destination is atomic and its
+	// mode is 0600 regardless of any pre-existing file's permissions. os.WriteFile
+	// would keep an existing file's (possibly looser) mode; an explicit Chmod makes
+	// the 0600 guarantee hold even under a permissive umask.
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return false, err
+	}
+	if _, err := f.WriteString(b.String()); err != nil {
+		f.Close()
+		_ = os.Remove(tmp)
+		return false, err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return false, err
+	}
+	if err := os.Chmod(tmp, 0o600); err != nil {
+		_ = os.Remove(tmp)
+		return false, err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return false, err
+	}
+	return true, nil
+}
+
+// LoadPersistedRuntimeAuthEnv reads path (which may not exist) and returns the
+// KEY=VALUE map of persisted runtime-auth vars. A missing file returns an empty
+// map and a nil error. Only keys in RuntimeAuthEnvVars are honored; blank lines,
+// comments, malformed lines, and empty values are ignored.
+func LoadPersistedRuntimeAuthEnv(path string) (map[string]string, error) {
+	result := make(map[string]string)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return result, nil
+		}
+		return nil, err
+	}
+	allowed := make(map[string]bool, len(RuntimeAuthEnvVars))
+	for _, k := range RuntimeAuthEnvVars {
+		allowed[k] = true
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimRight(line, "\r")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		key, val, ok := strings.Cut(trimmed, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if !allowed[key] || strings.TrimSpace(val) == "" {
+			continue
+		}
+		result[key] = val
+	}
+	return result, nil
+}
+
+// RuntimeAuthChildEnv returns the KEY=VALUE entries to ADD to a restarted
+// daemon child's environment: for each runtime-auth var that is absent (or
+// empty) in the live env (lookup) but present in the persisted file, the
+// persisted value is injected. The live env always wins, so a var already set is
+// never overridden — this preserves the pre-#578 behavior of inheriting the
+// launching shell's tokens and only recovers auth the shell has since lost.
+//
+// The returned slice is safe to append to os.Environ(); it is nil when there is
+// nothing to recover. Values are secrets and must not be logged.
+func RuntimeAuthChildEnv(path string, lookup func(string) (string, bool)) ([]string, error) {
+	persisted, err := LoadPersistedRuntimeAuthEnv(path)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, key := range RuntimeAuthEnvVars {
+		if lookup != nil {
+			if v, ok := lookup(key); ok && strings.TrimSpace(v) != "" {
+				continue // live env wins; never override an already-set token
+			}
+		}
+		if v, ok := persisted[key]; ok && strings.TrimSpace(v) != "" {
+			out = append(out, fmt.Sprintf("%s=%s", key, v))
+		}
+	}
+	return out, nil
+}

--- a/internal/runtime/runtime_auth_persist_test.go
+++ b/internal/runtime/runtime_auth_persist_test.go
@@ -1,0 +1,162 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func lookupFrom(env map[string]string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		v, ok := env[key]
+		return v, ok
+	}
+}
+
+// TestPersistRuntimeAuthEnv_WritesTokenFile0600 is the SECURITY-CRITICAL
+// assertion for #578: a token present in the environment is persisted to a file
+// created 0600 (owner read/write ONLY) that contains the token value.
+func TestPersistRuntimeAuthEnv_WritesTokenFile0600(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon-runtime.env")
+	const token = "sk-ant-oat01-secret-abc123"
+
+	wrote, err := PersistRuntimeAuthEnv(path, lookupFrom(map[string]string{ClaudeOAuthTokenEnv: token}))
+	if err != nil {
+		t.Fatalf("PersistRuntimeAuthEnv: %v", err)
+	}
+	if !wrote {
+		t.Fatalf("expected a file to be written when a token is present")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("file mode = %o, want 0600 (owner read/write only)", got)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), ClaudeOAuthTokenEnv+"="+token) {
+		t.Fatalf("persisted file should contain the token line; got %q", string(data))
+	}
+}
+
+// TestPersistRuntimeAuthEnv_NoTokenWritesNothing asserts a plain start on a box
+// with no runtime auth in the env leaves no file (never create an empty file).
+func TestPersistRuntimeAuthEnv_NoTokenWritesNothing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon-runtime.env")
+
+	wrote, err := PersistRuntimeAuthEnv(path, lookupFrom(map[string]string{}))
+	if err != nil {
+		t.Fatalf("PersistRuntimeAuthEnv: %v", err)
+	}
+	if wrote {
+		t.Fatalf("expected no write when no token is present")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected no file to exist; stat err = %v", err)
+	}
+}
+
+// TestPersistRuntimeAuthEnv_EmptyEnvNeverErasesGoodToken guarantees the #578
+// non-negotiable: an unset/empty env MUST NOT overwrite a good persisted token.
+func TestPersistRuntimeAuthEnv_EmptyEnvNeverErasesGoodToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon-runtime.env")
+	const token = "sk-ant-oat01-keep-me"
+
+	if _, err := PersistRuntimeAuthEnv(path, lookupFrom(map[string]string{ClaudeOAuthTokenEnv: token})); err != nil {
+		t.Fatalf("seed persist: %v", err)
+	}
+	// A subsequent start whose shell lacks the token must retain the good one.
+	if _, err := PersistRuntimeAuthEnv(path, lookupFrom(map[string]string{ClaudeOAuthTokenEnv: "   "})); err != nil {
+		t.Fatalf("second persist: %v", err)
+	}
+	loaded, err := LoadPersistedRuntimeAuthEnv(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded[ClaudeOAuthTokenEnv] != token {
+		t.Fatalf("persisted token = %q, want %q (empty env must not erase it)", loaded[ClaudeOAuthTokenEnv], token)
+	}
+}
+
+// TestPersistRuntimeAuthEnv_LiveEnvWins asserts a non-empty live env value takes
+// precedence over the previously persisted value.
+func TestPersistRuntimeAuthEnv_LiveEnvWins(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon-runtime.env")
+
+	if _, err := PersistRuntimeAuthEnv(path, lookupFrom(map[string]string{ClaudeOAuthTokenEnv: "old"})); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := PersistRuntimeAuthEnv(path, lookupFrom(map[string]string{ClaudeOAuthTokenEnv: "new"})); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	loaded, err := LoadPersistedRuntimeAuthEnv(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded[ClaudeOAuthTokenEnv] != "new" {
+		t.Fatalf("token = %q, want live-env value %q", loaded[ClaudeOAuthTokenEnv], "new")
+	}
+}
+
+// TestRuntimeAuthChildEnv_InjectsWhenEnvLacksToken proves the recovery path:
+// with the token ABSENT from the live env but present in the file, the computed
+// child env carries it; with the token present in the env, nothing is injected
+// (live env wins, preserving pre-#578 inheritance).
+func TestRuntimeAuthChildEnv_InjectsWhenEnvLacksToken(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon-runtime.env")
+	const token = "sk-ant-oat01-recovered"
+
+	if _, err := PersistRuntimeAuthEnv(path, lookupFrom(map[string]string{ClaudeOAuthTokenEnv: token})); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Env lacks the token -> inject from file.
+	inject, err := RuntimeAuthChildEnv(path, lookupFrom(map[string]string{}))
+	if err != nil {
+		t.Fatalf("child env: %v", err)
+	}
+	if want := ClaudeOAuthTokenEnv + "=" + token; !containsEntry(inject, want) {
+		t.Fatalf("child env %v should contain %q", inject, want)
+	}
+
+	// Env already has a token -> never override.
+	inject, err = RuntimeAuthChildEnv(path, lookupFrom(map[string]string{ClaudeOAuthTokenEnv: "live"}))
+	if err != nil {
+		t.Fatalf("child env (env present): %v", err)
+	}
+	if len(inject) != 0 {
+		t.Fatalf("expected no injection when the live env already has a token; got %v", inject)
+	}
+}
+
+// TestLoadPersistedRuntimeAuthEnv_MissingFile returns an empty map, nil error.
+func TestLoadPersistedRuntimeAuthEnv_MissingFile(t *testing.T) {
+	loaded, err := LoadPersistedRuntimeAuthEnv(filepath.Join(t.TempDir(), "nope.env"))
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if len(loaded) != 0 {
+		t.Fatalf("expected empty map, got %v", loaded)
+	}
+}
+
+func containsEntry(entries []string, want string) bool {
+	for _, e := range entries {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

A `gitmoot daemon restart` (or `start`) launched from a shell that no longer carries `CLAUDE_CODE_OAUTH_TOKEN` silently disabled Claude auth for **every** Claude-runtime job across **all** subscribed repos — the #559 root cause. `startDaemonChild` spawns the child with `cmd.Env` unset, so the child inherits whatever environment happens to relaunch it; a restart from a plain shell drops the token. #581 added a warning, but a warning does not keep the daemon working.

## Design

Make the daemon **persist** its runtime auth and **recover** it automatically, so a restart can't lose auth:

1. **Persist (on start).** If any runtime-auth env var is present, write it to a dedicated **0600** file in the daemon home, `<home>/daemon-runtime.env` (owner read/write only), atomically via a temp-file + `rename`. Only persist when a token is actually present, and **never overwrite a good persisted token with an empty/unset env** — the live env wins when both are present.
2. **Recover (on start/restart).** If the launching environment **lacks** a runtime-auth token but the 0600 file has one, inject it into the **child** process environment: `startDaemonChild` sets `cmd.Env = os.Environ() + recovered vars`. When there is nothing to recover, `cmd.Env` is left unset and the pre-#578 inheritance behavior is preserved exactly.
3. This **complements #581's warning**, which now stays silent whenever recovery will succeed (the warn call is skipped when the child env carries a recovered token).

New, well-tested runtime helpers (`internal/runtime/runtime_auth_persist.go`):
- `PersistRuntimeAuthEnv(path, lookup)` — 0600 write, merge-preserving, live-env-wins.
- `LoadPersistedRuntimeAuthEnv(path)` — tolerant parse; missing file → empty map.
- `RuntimeAuthChildEnv(path, lookup)` — the child-env injection, live env always wins.

## Security (non-negotiable)

- The file is created **0600** (asserted via `FileMode` in tests, both the pure helper and the wired start path).
- The token value is **never** logged, printed, or written to the world-readable `daemon.json`/meta (`daemonMeta` is unchanged). Diagnostic output on persist/load failure carries only the OS/path reason. Two tests assert the token never appears in captured stdout/stderr.

## Behavior preserved

- Empty `extraEnv` → `cmd.Env` stays unset → identical inheritance to before.
- No token in env and no file → nothing is written and the #581 warning fires exactly as it did.
- The child-spawn seam `startDaemonChildFn` gains a trailing `extraEnv []string`; the existing e2e stub was updated. All prior daemon/auth-warn tests pass unchanged.

## Tests

- `internal/runtime`: 0600 mode + contents, no-token-no-file, empty-env-never-erases, live-env-wins, child-env injection, missing-file load.
- `internal/cli`: (a) start with a token in env writes the 0600 file (mode asserted) containing the token; (b) restart with the token **absent** from env but present in the file → the computed child env (captured via the `startDaemonChildFn` seam) carries the token — **no real daemon spawned**; (c) the token never appears in captured stdout/stderr.

## Gate

`go build ./...`, `go vet ./...`, `go test ./internal/cli/ ./internal/runtime/ -count=1`, and `go test -race -timeout 20m ./internal/cli/` (703s) all green.

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)