### PR TITLE
feat(daemon): per-repo concurrency config (tune parallelism without a global restart) (#576)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2602,7 +2602,16 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 	if err := retryPendingJobComments(ctx, worker, repoFilter, rootFilter); err != nil {
 		return err
 	}
-	return runQueuedJobsForRepo(ctx, worker, workers, repoFilter, rootFilter)
+	// Per-repo concurrency override (#576): a [repos."owner/repo"] section caps
+	// THIS repo's in-flight concurrency (and may flip its scheduler) without a
+	// global daemon restart. With no matching section this returns (workers,
+	// worker.UsePool) unchanged, so the run path is byte-identical to today. The
+	// override is re-read here every tick, which is precisely what makes it
+	// tunable live. worker is passed by value, so the per-repo UsePool flip is
+	// local to this tick's dispatch and never leaks to sibling repos.
+	limit, usePool := worker.resolveRepoScheduler(repoFilter, workers)
+	worker.UsePool = usePool
+	return runQueuedJobsForRepo(ctx, worker, limit, repoFilter, rootFilter)
 }
 
 func runEnabledRepoWorkerTicks(ctx context.Context, store *db.Store, worker jobWorker, workers int, stdout io.Writer, now time.Time) error {
@@ -3696,6 +3705,56 @@ func (w jobWorker) parallelSessionPolicy() (config.ParallelSessionPolicy, error)
 		return config.ParallelSessionPolicy{}, err
 	}
 	return config.LoadParallelSessionPolicy(paths)
+}
+
+// repoConcurrency loads the per-repo [repos."owner/repo"] scheduler overrides
+// (#576), mirroring parallelSessionPolicy: an implicit/empty config home has no
+// overrides (nil ⇒ every repo uses the global default), and an explicit home
+// loads them from the config file. Errors are surfaced to the caller, which
+// fails safe to the global default.
+func (w jobWorker) repoConcurrency() ([]config.RepoConcurrency, error) {
+	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
+		return nil, nil
+	}
+	paths, err := w.configPaths()
+	if err != nil {
+		return nil, err
+	}
+	return config.LoadRepoConcurrency(paths)
+}
+
+// resolveRepoScheduler resolves the effective worker limit and pool toggle for a
+// repo's queued-job run (#576). It is behavior-preserving by default: with no
+// repoFilter, no [repos."owner/repo"] section, an implicit config home, or a
+// config-load error, it returns (globalLimit, w.UsePool) unchanged. A configured
+// max_parallel>0 caps THAT repo's concurrency; max_parallel<=0/missing keeps the
+// global default (never zero ⇒ never a stalled repo). A configured scheduler
+// ("pool"/"barrier") overrides the pool toggle for that repo only.
+func (w jobWorker) resolveRepoScheduler(repoFilter string, globalLimit int) (int, bool) {
+	limit := globalLimit
+	usePool := w.UsePool
+	repo := strings.TrimSpace(repoFilter)
+	if repo == "" {
+		return limit, usePool
+	}
+	configs, err := w.repoConcurrency()
+	if err != nil || len(configs) == 0 {
+		return limit, usePool
+	}
+	entry, ok := config.RepoConcurrencyFor(configs, repo)
+	if !ok {
+		return limit, usePool
+	}
+	if entry.MaxParallel > 0 {
+		limit = entry.MaxParallel
+	}
+	switch entry.Scheduler {
+	case "pool":
+		usePool = true
+	case "barrier":
+		usePool = false
+	}
+	return limit, usePool
 }
 
 // admissionPolicy loads the host-level [admission] budget config, mirroring

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -5696,6 +5696,121 @@ func enqueueDaemonWorkerJob(t *testing.T, store *db.Store, request workflow.JobR
 	}
 }
 
+// writeRepoConcurrencyConfigHome initializes a config home and appends body to
+// its default config, returning the raw --home. Used to drive the per-repo
+// concurrency override (#576) through the real jobWorker config loaders.
+func writeRepoConcurrencyConfigHome(t *testing.T, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return home
+}
+
+// runRepoConcurrencyTickPeak drives the REAL per-repo run path
+// (runDaemonWorkerTick -> resolveRepoScheduler -> runQueuedJobsForRepo) for one
+// repo and returns the observed peak concurrent deliveries. The two seeded jobs
+// carry DISTINCT worktree paths, so their checkout keys differ and nothing but
+// the scheduler's concurrency limit can serialize them — which is exactly what a
+// [repos."owner/repo"] max_parallel override changes.
+func runRepoConcurrencyTickPeak(t *testing.T, configHome string, repo string) int {
+	t.Helper()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-1", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1, WorktreePath: filepath.Join(t.TempDir(), "wt-1")})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-2", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 2, WorktreePath: filepath.Join(t.TempDir(), "wt-2")})
+
+	tracker := &poolConcurrencyTracker{}
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	adapter.onDeliver = tracker.span
+	// Global config: pool scheduler, workers=2 (would run both in parallel).
+	worker := poolSchedulerWorker(t, store, adapter, true)
+	worker.ConfigHome = configHome
+	worker.ConfigHomeExplicit = true
+
+	if err := runDaemonWorkerTick(ctx, store, worker, 2, false, repo, "", io.Discard, time.Now().UTC()); err != nil {
+		t.Fatalf("runDaemonWorkerTick(%s): %v", repo, err)
+	}
+	for _, id := range []string{"job-1", "job-2"} {
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob %s: %v", id, err)
+		}
+		if job.State != string(workflow.JobSucceeded) {
+			t.Fatalf("%s state = %q, want succeeded", id, job.State)
+		}
+	}
+	return tracker.peak()
+}
+
+// TestRunDaemonWorkerTickHonorsPerRepoMaxParallel pins the #576 daemon half: a
+// [repos."owner/repo"] max_parallel=1 override caps THAT repo's in-flight
+// concurrency to serial, while a repo with no override is unaffected by the same
+// override file and keeps the global pool/workers=2 parallelism. Same config
+// home, same job shape — the ONLY difference is which repo the section names, so
+// the peak split proves the override is what serializes repo-a.
+func TestRunDaemonWorkerTickHonorsPerRepoMaxParallel(t *testing.T) {
+	configHome := writeRepoConcurrencyConfigHome(t, `
+[repos."owner/repo-a"]
+max_parallel = 1
+`)
+	if peak := runRepoConcurrencyTickPeak(t, configHome, "owner/repo-a"); peak != 1 {
+		t.Fatalf("owner/repo-a peak concurrency = %d, want 1 (max_parallel=1 must serialize)", peak)
+	}
+	if peak := runRepoConcurrencyTickPeak(t, configHome, "owner/repo-b"); peak != 2 {
+		t.Fatalf("owner/repo-b peak concurrency = %d, want 2 (no override ⇒ global pool/workers=2 unaffected)", peak)
+	}
+}
+
+// TestRunDaemonWorkerTickNoRepoConfigIsUnchanged pins behavior preservation
+// (#576): with NO [repos.*] section anywhere, the per-repo tick runs at the
+// global limit exactly as today — the override plumbing is inert when unset.
+func TestRunDaemonWorkerTickNoRepoConfigIsUnchanged(t *testing.T) {
+	configHome := writeRepoConcurrencyConfigHome(t, "")
+	if peak := runRepoConcurrencyTickPeak(t, configHome, "owner/repo-a"); peak != 2 {
+		t.Fatalf("no-config peak concurrency = %d, want 2 (global pool/workers=2 unchanged)", peak)
+	}
+}
+
+// TestJobWorkerResolveRepoSchedulerFallsBackToGlobal pins the resolver's
+// fail-safe defaults (#576): an implicit config home, an empty repo filter, and
+// an unmatched repo all return the global limit and the worker's UsePool
+// unchanged, so the run path is byte-identical to today when the feature is off.
+func TestJobWorkerResolveRepoSchedulerFallsBackToGlobal(t *testing.T) {
+	// Implicit config home (no explicit --home) ⇒ no overrides possible.
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard)
+	worker.UsePool = true
+	if limit, usePool := worker.resolveRepoScheduler("owner/repo-a", 3); limit != 3 || !usePool {
+		t.Fatalf("implicit home: got (%d, %v), want (3, true)", limit, usePool)
+	}
+	// Explicit home with a section for a DIFFERENT repo ⇒ unmatched ⇒ global.
+	configHome := writeRepoConcurrencyConfigHome(t, `
+[repos."owner/repo-a"]
+max_parallel = 1
+scheduler = "barrier"
+`)
+	worker2 := defaultJobWorker(daemonWorkerStore(t), io.Discard, configHome)
+	worker2.UsePool = true
+	if limit, usePool := worker2.resolveRepoScheduler("owner/repo-b", 4); limit != 4 || !usePool {
+		t.Fatalf("unmatched repo: got (%d, %v), want (4, true)", limit, usePool)
+	}
+	// Empty repo filter ⇒ global default (never reads config).
+	if limit, usePool := worker2.resolveRepoScheduler("", 4); limit != 4 || !usePool {
+		t.Fatalf("empty repo: got (%d, %v), want (4, true)", limit, usePool)
+	}
+	// Matched repo ⇒ capped limit and scheduler flip (pool -> barrier).
+	if limit, usePool := worker2.resolveRepoScheduler("owner/repo-a", 4); limit != 1 || usePool {
+		t.Fatalf("matched repo: got (%d, %v), want (1, false)", limit, usePool)
+	}
+}
+
 // TestRunQueuedJobsForRepoSkipsChildrenOfKilledRoot pins the #341 daemon half of
 // the operator kill switch: once a tree's root is marked killed, a queued CHILD
 // of that root is skipped by runQueuedJobsForRepo (never delivered, stays

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -121,6 +121,9 @@ func validateConfigFile(paths Paths) error {
 	if _, err := LoadHeartbeats(paths); err != nil {
 		return err
 	}
+	if _, err := LoadRepoConcurrency(paths); err != nil {
+		return err
+	}
 	if _, err := LoadTemplateRemote(paths); err != nil {
 		return err
 	}

--- a/internal/config/repo_concurrency.go
+++ b/internal/config/repo_concurrency.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// RepoConcurrency is one per-repo daemon scheduler override parsed from a
+// [repos."owner/repo"] config section (#576). It lets an operator cap a single
+// repo's daemon parallelism — or flip its scheduler — WITHOUT restarting the
+// shared daemon (the #559 restart footgun: a restart re-inherits the launching
+// shell's env and resets in-flight scheduler state). The daemon re-reads this on
+// every worker tick, so an edit takes effect on the next tick.
+//
+// It is OFF BY DEFAULT: a config with no [repos.*] sections yields an empty
+// slice and a repo with no matching section behaves EXACTLY as today (the global
+// --workers/--parallel + --scheduler apply). The loader mirrors LoadHeartbeats
+// (Load/applyField/validate, config order preserved).
+type RepoConcurrency struct {
+	// Repo is the full name "owner/repo" the section keys on.
+	Repo string
+	// MaxParallel caps THIS repo's in-flight concurrency. <=0 (missing) means use
+	// the global --workers/--parallel default — never "zero concurrency" (a
+	// stalled repo). A positive value overrides the global for this repo only.
+	MaxParallel int
+	// Scheduler optionally overrides the queued-job scheduler for this repo:
+	// "pool" (continuous worker pool) or "barrier" (per-tick). "" (missing) keeps
+	// the daemon's global scheduler.
+	Scheduler string
+}
+
+// LoadRepoConcurrency collects every [repos."owner/repo"] section from the config
+// file into a stable, validated slice (config order preserved). It is OFF BY
+// DEFAULT: a config with no [repos.*] subsections returns an empty slice and
+// never errors, so callers that find an empty slice do no further work and every
+// repo keeps today's global behavior.
+//
+// It reuses the same naive line-scanner shape as LoadHeartbeats. Unrelated
+// sections (agents.*, admission, skillopt, …) are ignored; a repo name contains
+// a '/', so the section key is the TOML quoted-key form repos."owner/repo".
+func LoadRepoConcurrency(paths Paths) ([]RepoConcurrency, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	collected := map[string]*RepoConcurrency{}
+	order := make([]string, 0)
+	var current *RepoConcurrency
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = nil
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			repo, ok := parseRepoConcurrencySection(section)
+			if !ok {
+				continue
+			}
+			if collected[repo] == nil {
+				collected[repo] = &RepoConcurrency{Repo: repo}
+				order = append(order, repo)
+			}
+			current = collected[repo]
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		field, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyRepoConcurrencyField(current, strings.TrimSpace(field), strings.TrimSpace(value)); err != nil {
+			return nil, fmt.Errorf("parse [repos.%q].%s: %w", current.Repo, strings.TrimSpace(field), err)
+		}
+	}
+	repos := make([]RepoConcurrency, 0, len(order))
+	for _, repo := range order {
+		entry := collected[repo]
+		applyRepoConcurrencyDefaults(entry)
+		if err := validateRepoConcurrency(*entry); err != nil {
+			return nil, err
+		}
+		repos = append(repos, *entry)
+	}
+	return repos, nil
+}
+
+// RepoConcurrencyFor returns the override for repo, if any. Matching is exact on
+// the full name; a caller that finds ok=false uses the global default.
+func RepoConcurrencyFor(list []RepoConcurrency, repo string) (RepoConcurrency, bool) {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return RepoConcurrency{}, false
+	}
+	for _, entry := range list {
+		if entry.Repo == repo {
+			return entry, true
+		}
+	}
+	return RepoConcurrency{}, false
+}
+
+// parseRepoConcurrencySection extracts the "owner/repo" from a section of the
+// form repos."owner/repo" (or a bare repos.<key>). It returns ok=false for any
+// other section so unrelated sections are ignored. A repo name contains a '/',
+// which is not a legal TOML bare key, so the quoted-key form is the expected
+// shape; a bare remainder is still accepted for leniency.
+func parseRepoConcurrencySection(section string) (string, bool) {
+	section = strings.TrimSpace(section)
+	if !strings.HasPrefix(section, "repos.") {
+		return "", false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(section, "repos."))
+	if rest == "" {
+		return "", false
+	}
+	if strings.HasPrefix(rest, "\"") {
+		unquoted, err := strconv.Unquote(rest)
+		if err != nil || strings.TrimSpace(unquoted) == "" {
+			return "", false
+		}
+		return strings.TrimSpace(unquoted), true
+	}
+	return rest, true
+}
+
+func applyRepoConcurrencyField(entry *RepoConcurrency, key string, value string) error {
+	switch key {
+	case "max_parallel":
+		parsed, err := strconv.Atoi(value)
+		entry.MaxParallel = parsed
+		return err
+	case "scheduler":
+		parsed, err := parseConfigString(value)
+		entry.Scheduler = parsed
+		return err
+	default:
+		return nil
+	}
+}
+
+func applyRepoConcurrencyDefaults(entry *RepoConcurrency) {
+	entry.Repo = strings.TrimSpace(entry.Repo)
+	entry.Scheduler = strings.TrimSpace(entry.Scheduler)
+}
+
+// validateRepoConcurrency enforces the contract with explicit errors (matching
+// the heartbeat/admission validation style). A negative max_parallel is a
+// mistake (0/missing already means "use the global default"); an unknown
+// scheduler is rejected rather than silently ignored.
+func validateRepoConcurrency(entry RepoConcurrency) error {
+	if entry.MaxParallel < 0 {
+		return fmt.Errorf("repo concurrency [repos.%q]: max_parallel must be 0 (use the global default) or positive", entry.Repo)
+	}
+	switch entry.Scheduler {
+	case "", "pool", "barrier":
+		return nil
+	default:
+		return fmt.Errorf("repo concurrency [repos.%q]: unsupported scheduler %q; use %q or %q", entry.Repo, entry.Scheduler, "pool", "barrier")
+	}
+}

--- a/internal/config/repo_concurrency_test.go
+++ b/internal/config/repo_concurrency_test.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func writeRepoConcurrencyConfig(t *testing.T, body string) Paths {
+	t.Helper()
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return paths
+}
+
+func TestLoadRepoConcurrencyParsesValidSections(t *testing.T) {
+	paths := writeRepoConcurrencyConfig(t, `
+[repos."jerryfane/gitmoot"]
+max_parallel = 1
+
+[repos."owner/other"]
+max_parallel = 4
+scheduler = "pool"
+`)
+	repos, err := LoadRepoConcurrency(paths)
+	if err != nil {
+		t.Fatalf("LoadRepoConcurrency returned error: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repo overrides, got %d: %+v", len(repos), repos)
+	}
+	// Config order is preserved.
+	first := repos[0]
+	if first.Repo != "jerryfane/gitmoot" || first.MaxParallel != 1 || first.Scheduler != "" {
+		t.Fatalf("first override = %+v", first)
+	}
+	second := repos[1]
+	if second.Repo != "owner/other" || second.MaxParallel != 4 || second.Scheduler != "pool" {
+		t.Fatalf("second override = %+v", second)
+	}
+
+	got, ok := RepoConcurrencyFor(repos, "owner/other")
+	if !ok || got.MaxParallel != 4 || got.Scheduler != "pool" {
+		t.Fatalf("RepoConcurrencyFor(owner/other) = %+v ok=%v", got, ok)
+	}
+	if _, ok := RepoConcurrencyFor(repos, "owner/absent"); ok {
+		t.Fatalf("RepoConcurrencyFor(owner/absent) should not match")
+	}
+}
+
+func TestLoadRepoConcurrencyAbsentDefaultsToEmpty(t *testing.T) {
+	// No [repos.*] section at all: off by default (empty slice, no error), so
+	// every repo keeps the global scheduler behavior.
+	paths := writeRepoConcurrencyConfig(t, "")
+	repos, err := LoadRepoConcurrency(paths)
+	if err != nil {
+		t.Fatalf("LoadRepoConcurrency returned error: %v", err)
+	}
+	if len(repos) != 0 {
+		t.Fatalf("expected no overrides for a config without [repos.*], got %+v", repos)
+	}
+	if _, ok := RepoConcurrencyFor(repos, "jerryfane/gitmoot"); ok {
+		t.Fatalf("RepoConcurrencyFor on an empty list must not match")
+	}
+}
+
+func TestLoadRepoConcurrencyZeroMaxParallelIsAllowed(t *testing.T) {
+	// max_parallel = 0 explicitly means "use the global default" — it must NOT
+	// error (never a zero-concurrency stalled repo), and it must not override.
+	paths := writeRepoConcurrencyConfig(t, `
+[repos."jerryfane/gitmoot"]
+max_parallel = 0
+`)
+	repos, err := LoadRepoConcurrency(paths)
+	if err != nil {
+		t.Fatalf("LoadRepoConcurrency returned error: %v", err)
+	}
+	if len(repos) != 1 || repos[0].MaxParallel != 0 {
+		t.Fatalf("expected one override with max_parallel 0, got %+v", repos)
+	}
+}
+
+func TestLoadRepoConcurrencyRejectsNegativeMaxParallel(t *testing.T) {
+	paths := writeRepoConcurrencyConfig(t, `
+[repos."jerryfane/gitmoot"]
+max_parallel = -1
+`)
+	_, err := LoadRepoConcurrency(paths)
+	if err == nil || !strings.Contains(err.Error(), "max_parallel") {
+		t.Fatalf("expected a max_parallel validation error, got %v", err)
+	}
+}
+
+func TestLoadRepoConcurrencyRejectsUnknownScheduler(t *testing.T) {
+	paths := writeRepoConcurrencyConfig(t, `
+[repos."jerryfane/gitmoot"]
+max_parallel = 2
+scheduler = "turbo"
+`)
+	_, err := LoadRepoConcurrency(paths)
+	if err == nil || !strings.Contains(err.Error(), "scheduler") {
+		t.Fatalf("expected a scheduler validation error, got %v", err)
+	}
+}
+
+func TestLoadRepoConcurrencyRejectsNonIntMaxParallel(t *testing.T) {
+	paths := writeRepoConcurrencyConfig(t, `
+[repos."jerryfane/gitmoot"]
+max_parallel = "two"
+`)
+	_, err := LoadRepoConcurrency(paths)
+	if err == nil {
+		t.Fatalf("expected a parse error for a non-integer max_parallel")
+	}
+}


### PR DESCRIPTION
## What & why

Adds an opt-in, additive per-repo concurrency knob so an operator can cap (or flip the scheduler of) a **single** repo's daemon parallelism **without restarting the shared daemon**. This avoids the #559 restart footgun: a `daemon restart` re-inherits the launching shell's environment (can silently drop runtime auth) and resets in-flight scheduler state. The override is re-read on every worker tick, so editing the config takes effect on the next tick — no restart.

Closes #576.

## Design

### Config layer (`internal/config/repo_concurrency.go`)
- New `[repos."owner/repo"]` section with:
  - `max_parallel` (int) — caps that repo's in-flight concurrency.
  - `scheduler` (optional) — `"pool"` or `"barrier"`, overrides the global scheduler for that repo only.
- `LoadRepoConcurrency` mirrors `LoadHeartbeats`: same naive line-scanner, config order preserved, **off by default** (no `[repos.*]` section ⇒ empty slice, no error). Unrelated sections are ignored; the repo name contains a `/`, so the TOML quoted-key form `repos."owner/repo"` is expected (a bare remainder is still accepted for leniency).
- Validation: negative `max_parallel` and unknown `scheduler` are hard errors; `max_parallel = 0` is explicitly allowed and means "use the global default".
- Wired into `edit.go`'s `validateConfigFile` so an in-place `SetConfigScalar` edit that breaks a `[repos.*]` section reverts, like every other section.

### Daemon scheduler (`internal/cli/daemon.go`)
- The narrowest correct seam is `runDaemonWorkerTick` (always called per-repo with the repo full name as `repoFilter`, from both the multi-repo sweep and the single-repo supervisor). Just before dispatching a repo's queued jobs it calls `jobWorker.resolveRepoScheduler(repoFilter, globalWorkers)`:
  - No `repoFilter`, no matching section, implicit config home, or a config-load error ⇒ returns `(globalLimit, worker.UsePool)` **unchanged**.
  - `max_parallel > 0` ⇒ caps that repo's limit; `<= 0`/missing ⇒ keeps the global default (never zero ⇒ never a stalled repo).
  - `scheduler` ⇒ flips pool/barrier for that repo only.
- `worker` is passed by value, so the per-repo `UsePool` flip is local to that tick's dispatch and never leaks to sibling repos.
- `jobWorker.repoConcurrency()` mirrors `parallelSessionPolicy()`/`admissionPolicy()`: an implicit/empty config home has no overrides.

## Behavior preservation
- With **no** `[repos.*]` config, the run path is byte-identical to today: `resolveRepoScheduler` returns the global `--workers`/`--parallel` + `--scheduler` verbatim. Global behavior is untouched when no repo has a section.
- `max_parallel <= 0`/missing never yields zero concurrency.

## Tests
Config (`repo_concurrency_test.go`): valid multi-section parse + `RepoConcurrencyFor` lookup, absent ⇒ empty-default, `max_parallel = 0` allowed, and invalid (negative `max_parallel`, unknown `scheduler`, non-int `max_parallel`) rejected.

Scheduler (`daemon_test.go`) — drives the **real** per-repo run path (`runDaemonWorkerTick` → `resolveRepoScheduler` → `runQueuedJobsForRepo`) against a seeded store, no real daemon:
- `TestRunDaemonWorkerTickHonorsPerRepoMaxParallel`: same config home + identical two-job shape (distinct worktree keys ⇒ nothing but the limit serializes them); `owner/repo-a` (`max_parallel = 1`) peaks at 1 while `owner/repo-b` (no section) peaks at 2.
- `TestRunDaemonWorkerTickNoRepoConfigIsUnchanged`: no `[repos.*]` ⇒ global pool/workers=2 peak of 2.
- `TestJobWorkerResolveRepoSchedulerFallsBackToGlobal`: implicit home, empty filter, and unmatched repo all fall back to global; a matched section caps the limit and flips the scheduler.

## Gate
`go build ./... && go vet ./... && go test ./internal/config/ ./internal/cli/ -count=1 && go test -race -timeout 20m ./internal/cli/` — all green (race suite exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)