### PR TITLE
feat(cli): harden daemon runtime-auth recovery (#588)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -578,10 +578,16 @@ func warnIfDaemonStartLosesClaudeAuth(w io.Writer, restart bool, priorDaemonHadC
 // Claude auth, but the persisted value carries NO expiry or validation metadata,
 // so it may be STALE or REVOKED. This deliberately does not fully suppress the
 // #581 "no auth" signal — it substitutes a softer note. The token VALUE is never
-// printed; only the fact of recovery and how to verify it.
+// printed; only the fact of recovery and how to verify it. It points at
+// `gitmoot doctor` (a LIVE token probe) rather than `gitmoot daemon status`,
+// which only confirms a token is SET, not valid, and would still report a revoked
+// recovered token as "ok" — the exact silent-auth-failure class #559/#581/#588
+// set out to eliminate.
 func noteRecoveredRuntimeAuthMayBeStale(w io.Writer) {
 	fmt.Fprintln(w, "ℹ️  NOTE: the recovered Claude auth token was restored from persisted state and has NO")
-	fmt.Fprintln(w, "    expiry/validation metadata — it may be STALE or REVOKED. Verify with `gitmoot daemon status`.")
+	fmt.Fprintln(w, "    expiry/validation metadata — it may be STALE or REVOKED. `gitmoot daemon status` only")
+	fmt.Fprintln(w, "    confirms a token is PRESENT, not that it is valid; run `gitmoot doctor` for a live")
+	fmt.Fprintln(w, "    validity probe that surfaces a revoked token.")
 }
 
 func runDaemonStatus(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -63,13 +63,16 @@ func printDaemonUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot daemon start [--repo owner/repo] [--poll 30s] [--workers 1 | --parallel N] [--scheduler barrier|pool] [--watch-skillopt-reviews] [--watch-issues]")
 	fmt.Fprintln(w, "  gitmoot daemon run [--repo owner/repo] [--poll 30s] [--workers 1 | --parallel N] [--scheduler barrier|pool] [--watch-skillopt-reviews] [--watch-issues]")
-	fmt.Fprintln(w, "  gitmoot daemon stop")
+	fmt.Fprintln(w, "  gitmoot daemon stop [--forget-runtime-auth]")
 	fmt.Fprintln(w, "  gitmoot daemon restart")
 	fmt.Fprintln(w, "  gitmoot daemon status")
 	fmt.Fprintln(w, "  gitmoot daemon logs")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "  --repo sets the daemon's LAUNCH CONTEXT (working dir / preflight checkout) only; it does NOT")
 	fmt.Fprintln(w, "  scope supervision — the daemon supervises ALL subscribed repos regardless.")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "  --forget-runtime-auth (stop) deletes the persisted owner-only daemon-runtime.env so a later")
+	fmt.Fprintln(w, "  restart cannot recover the token; a plain restart still recovers it.")
 }
 
 func runDaemonStart(args []string, stdout, stderr io.Writer) int {
@@ -134,9 +137,22 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart boo
 	if err := persistDaemonRuntimeAuth(paths.Home, claudeAuthEnvLookup); err != nil {
 		fmt.Fprintf(stderr, "daemon start: warning: could not persist runtime auth: %v\n", err)
 	}
-	recoveredEnv := recoverDaemonChildAuthEnv(paths.Home, claudeAuthEnvLookup)
+	// Recovery is RESTART-ONLY (#588): only an internal `daemon restart` — which
+	// tears the prior daemon down and re-inherits the launching shell's env — may
+	// recover the persisted token so a restart never silently drops Claude auth
+	// (the #559 root cause). A plain `daemon start` from a shell that deliberately
+	// unset the token must NOT resurrect the old persisted token; it warns instead
+	// (#581). Persistence above still runs on BOTH paths so the file stays fresh.
+	var recoveredEnv []string
+	if restart {
+		recoveredEnv = recoverDaemonChildAuthEnv(paths.Home, claudeAuthEnvLookup)
+	}
 	if len(recoveredEnv) > 0 {
 		writeLine(stdout, "recovered persisted runtime auth from %s (launching env lacked it)", daemonRuntimeAuthFileName)
+		// Do NOT fully suppress the #581 "no auth" signal (#588): the recovered
+		// token carries no expiry/validation metadata, so emit an INFORMATIONAL
+		// note that it may be STALE or REVOKED. The token VALUE is never printed.
+		noteRecoveredRuntimeAuthMayBeStale(stderr)
 	} else {
 		warnIfDaemonStartLosesClaudeAuth(stderr, restart, priorDaemonHadClaudeAuth)
 	}
@@ -389,6 +405,11 @@ func runDaemonStop(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("daemon stop", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	// #588: opt-in teardown of the persisted 0600 daemon-runtime.env so a stopped
+	// daemon does not leave a recoverable token on disk. The INTERNAL restart's stop
+	// call must NOT pass this (it relies on recovery); only an explicit operator
+	// `daemon stop --forget-runtime-auth` forgets the token.
+	forgetRuntimeAuth := fs.Bool("forget-runtime-auth", false, "delete the persisted daemon runtime-auth file (daemon-runtime.env) after stopping")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -410,12 +431,25 @@ func runDaemonStop(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "daemon stop: %v\n", err)
 		return 1
 	}
+	forgetPersistedRuntimeAuth := func() {
+		if !*forgetRuntimeAuth {
+			return
+		}
+		path := daemonRuntimeAuthFilePath(paths.Home)
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "daemon stop: warning: could not forget runtime auth: %v\n", err)
+			return
+		}
+		writeLine(stdout, "forgot persisted runtime auth (%s)", daemonRuntimeAuthFileName)
+	}
 	if stale {
 		writeLine(stdout, "removed stale daemon pid file")
+		forgetPersistedRuntimeAuth()
 		return 0
 	}
 	if pid == 0 {
 		writeLine(stdout, "daemon not running")
+		forgetPersistedRuntimeAuth()
 		return 0
 	}
 	if err := stopDaemonPID(pid); err != nil {
@@ -424,6 +458,7 @@ func runDaemonStop(args []string, stdout, stderr io.Writer) int {
 	}
 	_ = os.Remove(state.PIDFile)
 	writeLine(stdout, "daemon stopped pid %d", pid)
+	forgetPersistedRuntimeAuth()
 	return 0
 }
 
@@ -535,6 +570,18 @@ func warnIfDaemonStartLosesClaudeAuth(w io.Writer, restart bool, priorDaemonHadC
 	fmt.Fprintln(w, "    Every Claude-runtime job across ALL subscribed repos will fail auth.")
 	fmt.Fprintln(w, "    Set the token in this shell before (re)starting, or run the daemon via its systemd service")
 	fmt.Fprintln(w, "    (which loads the token from its EnvironmentFile). See `gitmoot daemon status`.")
+}
+
+// noteRecoveredRuntimeAuthMayBeStale prints a NON-fatal INFORMATIONAL stderr note
+// (#588) after a restart recovers a persisted runtime-auth token from the 0600
+// daemon-runtime.env. Recovery keeps a token-less restart from silently dropping
+// Claude auth, but the persisted value carries NO expiry or validation metadata,
+// so it may be STALE or REVOKED. This deliberately does not fully suppress the
+// #581 "no auth" signal — it substitutes a softer note. The token VALUE is never
+// printed; only the fact of recovery and how to verify it.
+func noteRecoveredRuntimeAuthMayBeStale(w io.Writer) {
+	fmt.Fprintln(w, "ℹ️  NOTE: the recovered Claude auth token was restored from persisted state and has NO")
+	fmt.Fprintln(w, "    expiry/validation metadata — it may be STALE or REVOKED. Verify with `gitmoot daemon status`.")
 }
 
 func runDaemonStatus(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/daemon_runtime_auth_e2e_test.go
+++ b/internal/cli/daemon_runtime_auth_e2e_test.go
@@ -93,6 +93,13 @@ func TestDaemonRestartOnlyRecovery_E2E(t *testing.T) {
 		if !strings.Contains(stderr.String(), "STALE or REVOKED") {
 			t.Fatalf("RESTART recovery must emit the stale-token note; stderr=%q", stderr.String())
 		}
+		// The stale note must steer operators at a LIVE validity probe (`gitmoot
+		// doctor`), not at `daemon status`, which only confirms a token is SET
+		// (not valid) and would report a revoked recovered token as "ok" — the
+		// silent-auth-failure class #588 exists to eliminate.
+		if !strings.Contains(stderr.String(), "gitmoot doctor") {
+			t.Fatalf("stale note must recommend the live `gitmoot doctor` probe; stderr=%q", stderr.String())
+		}
 		assertNoTokenLeak(t, stdout.String(), stderr.String())
 	})
 

--- a/internal/cli/daemon_runtime_auth_e2e_test.go
+++ b/internal/cli/daemon_runtime_auth_e2e_test.go
@@ -1,0 +1,154 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// seedPersistedRuntimeAuth writes the 0600 daemon-runtime.env for home as if a
+// prior token-bearing start had persisted it, and returns the home dir.
+func seedPersistedRuntimeAuth(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(config.PathsForHome(home).Home, 0o700); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	if err := persistDaemonRuntimeAuth(config.PathsForHome(home).Home, func(k string) (string, bool) {
+		if k == runtime.ClaudeOAuthTokenEnv {
+			return secretToken, true
+		}
+		return "", false
+	}); err != nil {
+		t.Fatalf("seed persist: %v", err)
+	}
+	return home
+}
+
+// captureChildRecoveredEnv swaps the child-spawn seam to record the recoveredEnv
+// the (re)start body computes and passes to the child, without launching a real
+// daemon. It returns a pointer whose slice is set when the stub fires.
+func captureChildRecoveredEnv(t *testing.T) *[]string {
+	t.Helper()
+	captured := new([]string)
+	prev := startDaemonChildFn
+	startDaemonChildFn = func(h, poll string, workers int, wsor, wi bool, scheduler, repo, session string, state daemonState, workDir string, extraEnv []string) (daemonMeta, error) {
+		*captured = extraEnv
+		return daemonMeta{PID: 424242, LogFile: filepath.Join(h, "daemon.log")}, nil
+	}
+	t.Cleanup(func() { startDaemonChildFn = prev })
+	return captured
+}
+
+func childEnvHasToken(entries []string) bool {
+	want := runtime.ClaudeOAuthTokenEnv + "=" + secretToken
+	for _, e := range entries {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDaemonRestartOnlyRecovery_E2E is the #588 mutation-proven end-to-end proof
+// that persisted runtime-auth recovery is RESTART-ONLY. It drives the real
+// (re)start command body (runDaemonStartWithWorkDirRestart) with the child spawn
+// stubbed and the auth-readiness seam seeded to an EMPTY live env — i.e. the
+// launching shell lacks the token but the 0600 daemon-runtime.env holds it.
+//
+//   - RESTART (restart=true): the recoveredEnv handed to the child CONTAINS the
+//     token AND the informational stale-token note is emitted (no drop warning).
+//   - PLAIN START (restart=false): the recoveredEnv does NOT contain the token —
+//     the operator's deliberately-unset token is not resurrected; the #581 drop
+//     warning fires instead.
+//
+// The token VALUE must never appear on stdout/stderr in either case.
+//
+// MUTATION PROOF: in runDaemonStartWithWorkDirRestart, dropping the `if restart`
+// gate (calling recoverDaemonChildAuthEnv on the plain-start path too) makes the
+// plain-start subtest below go RED — the child env would then carry the token.
+func TestDaemonRestartOnlyRecovery_E2E(t *testing.T) {
+	t.Run("restart_recovers_token_and_notes_stale", func(t *testing.T) {
+		home := seedPersistedRuntimeAuth(t)
+		withClaudeAuthLookup(t, map[string]string{}) // launching shell lacks the token
+		captured := captureChildRecoveredEnv(t)
+
+		var stdout, stderr bytes.Buffer
+		if code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", true, false, &stdout, &stderr); code != 0 {
+			t.Fatalf("restart returned %d; stderr=%q", code, stderr.String())
+		}
+
+		if !childEnvHasToken(*captured) {
+			t.Fatalf("RESTART: child env must carry the recovered token; got %v (redacted)", redactEnvKeys(*captured))
+		}
+		// Recovery substitutes an informational stale note for the #581 drop warning.
+		if strings.Contains(stderr.String(), "WARNING") {
+			t.Fatalf("RESTART recovery must not emit a drop WARNING; stderr=%q", stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "STALE or REVOKED") {
+			t.Fatalf("RESTART recovery must emit the stale-token note; stderr=%q", stderr.String())
+		}
+		assertNoTokenLeak(t, stdout.String(), stderr.String())
+	})
+
+	t.Run("plain_start_does_not_recover_token", func(t *testing.T) {
+		home := seedPersistedRuntimeAuth(t)
+		withClaudeAuthLookup(t, map[string]string{}) // launching shell lacks the token
+		captured := captureChildRecoveredEnv(t)
+
+		var stdout, stderr bytes.Buffer
+		if code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", false, false, &stdout, &stderr); code != 0 {
+			t.Fatalf("start returned %d; stderr=%q", code, stderr.String())
+		}
+
+		// The mutation-sensitive assertion: a plain start must NOT resurrect the
+		// deliberately-unset token. Removing the restart-only gate flips this red.
+		if childEnvHasToken(*captured) {
+			t.Fatalf("PLAIN START must NOT recover the persisted token into the child env; got %v (redacted)", redactEnvKeys(*captured))
+		}
+		// With no auth and no recovery, the #581 drop warning must fire.
+		if !strings.Contains(stderr.String(), "WARNING") {
+			t.Fatalf("PLAIN START without auth should warn; stderr=%q", stderr.String())
+		}
+		assertNoTokenLeak(t, stdout.String(), stderr.String())
+	})
+}
+
+// TestDaemonStopForgetRuntimeAuth_E2E proves the #588 `daemon stop
+// --forget-runtime-auth` flag deletes the persisted 0600 file, while a plain
+// `daemon stop` leaves it intact so a later restart can still recover it. No
+// daemon is running (pid==0), which exercises the teardown branch deterministically.
+func TestDaemonStopForgetRuntimeAuth_E2E(t *testing.T) {
+	t.Run("plain_stop_keeps_file", func(t *testing.T) {
+		home := seedPersistedRuntimeAuth(t)
+		path := daemonRuntimeAuthFilePath(config.PathsForHome(home).Home)
+
+		var stdout, stderr bytes.Buffer
+		if code := runDaemonStop([]string{"--home", home}, &stdout, &stderr); code != 0 {
+			t.Fatalf("stop returned %d; stderr=%q", code, stderr.String())
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("plain stop must LEAVE the persisted file; stat err=%v", err)
+		}
+		assertNoTokenLeak(t, stdout.String(), stderr.String())
+	})
+
+	t.Run("forget_deletes_file", func(t *testing.T) {
+		home := seedPersistedRuntimeAuth(t)
+		path := daemonRuntimeAuthFilePath(config.PathsForHome(home).Home)
+
+		var stdout, stderr bytes.Buffer
+		if code := runDaemonStop([]string{"--home", home, "--forget-runtime-auth"}, &stdout, &stderr); code != 0 {
+			t.Fatalf("stop --forget-runtime-auth returned %d; stderr=%q", code, stderr.String())
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("--forget-runtime-auth must DELETE the persisted file; stat err=%v", err)
+		}
+		assertNoTokenLeak(t, stdout.String(), stderr.String())
+	})
+}


### PR DESCRIPTION
Hardens the merged #578 runtime-auth persistence so a `daemon restart` never silently drops Claude auth, yet a plain `daemon start` never resurrects a token the operator deliberately unset. Additive and behavior-scoped; the token value never touches stdout/stderr/log. Closes #588.

## What changed (3 hardening changes)

1. **RESTART-ONLY recovery.** `recoverDaemonChildAuthEnv` is now gated on the `restart` bool in `runDaemonStartWithWorkDirRestart`. Only an internal `daemon restart` (which tears the prior daemon down and re-inherits the launching shell env — the #559 root cause) recovers the persisted token into the child env. A plain `daemon start` from a token-less shell warns (#581) instead of resurrecting the old token. **Persistence (`persistDaemonRuntimeAuth`) still runs on BOTH paths** so the 0600 file stays fresh.
2. **Stale-token note.** When a restart DOES recover a persisted token, we no longer fully suppress the #581 "no auth" signal — we emit an INFORMATIONAL stderr note that the recovered token has no expiry/validation metadata and may be STALE or REVOKED (verify with `gitmoot daemon status`). The token VALUE is never printed.
3. **`gitmoot daemon stop --forget-runtime-auth`.** New flag on `runDaemonStop` that deletes the persisted 0600 `daemon-runtime.env` after stopping. The INTERNAL restart's stop call does NOT pass the flag, so restart recovery still works. Usage/help updated.

## What the E2E proves (`internal/cli/daemon_runtime_auth_e2e_test.go`)

Reuses the `startDaemonChildFn` seam (captures the `recoveredEnv` passed to the child) and the `claudeAuthEnvLookup` seam (empty live env = token-less shell):

- **(a) RESTART** with the token absent from the live env but present in the 0600 file → the `recoveredEnv` passed to the child CONTAINS the token AND the stale-token note is emitted (no drop WARNING).
- **(b) plain START** in the same situation → `recoveredEnv` does NOT contain the token (the restart-only gate).
- **(c)** `daemon stop --forget-runtime-auth` deletes the file (asserted gone) while a plain `daemon stop` leaves it.
- The token value never appears in captured stdout/stderr.

## Why it goes red when broken

Removing the restart-only gate (calling `recoverDaemonChildAuthEnv` on the plain-start path too) flips subtest (b) `plain_start_does_not_recover_token` RED — the child env then carries the token. Verified locally:

```
--- FAIL: TestDaemonRestartOnlyRecovery_E2E/plain_start_does_not_recover_token
    PLAIN START must NOT recover the persisted token into the child env; got [CLAUDE_CODE_OAUTH_TOKEN=<redacted>]
```

Gate: `go build ./...`, `go vet ./...`, `go test ./internal/cli/ -count=1`, and `go test -race ./internal/cli/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)