### PR TITLE
fix(daemon): flock backstop closes the concurrent daemon-run TOCTOU (#556)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -293,6 +293,24 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	if code := guardDaemonRunSingleton(*home, stderr); code != 0 {
 		return code
 	}
+	// Test seam (#556): deterministically widen the window between the liveness
+	// guard above and the flock/self-registration below so the singleton E2E can
+	// observe the simultaneous-launch TOCTOU. No-op outside tests (env unset).
+	daemonRunWidenGuardWindow()
+
+	// Airtight singleton backstop (#556). The liveness guard above is friendly
+	// diagnostics but racy: two `daemon run` launched simultaneously on a clean
+	// home can BOTH pass it before either self-registers. flock(LOCK_EX|LOCK_NB)
+	// on a dedicated lockfile is atomic in the kernel — exactly one process ever
+	// holds it — and the fd stays open for the process lifetime, so the kernel
+	// releases the lock on ANY death (SIGKILL included): no stale-lock lockout,
+	// no unlink dance. The loser exits with the same "daemon already running"
+	// UX as the guard.
+	releaseDaemonRunLock, lockCode := acquireDaemonRunLock(*home, stderr)
+	if lockCode != 0 {
+		return lockCode
+	}
+	defer releaseDaemonRunLock()
 
 	// Seed the persisted runtime-auth file from THIS process's inherited
 	// environment (#578). `daemon start` persists before spawning the child, but
@@ -1155,6 +1173,87 @@ func guardDaemonRunSingleton(home string, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+// daemonRunLockPath is the flock target for the daemon-run singleton backstop
+// (#556): a dedicated sibling file under the resolved daemon home. Deliberately
+// NOT gitmoot.db itself — SQLite manages its own fcntl/WAL locking on the
+// database file and an unrelated flock there is asking for interference.
+func daemonRunLockPath(paths config.Paths) string {
+	return filepath.Join(paths.Home, "daemon.lock")
+}
+
+// daemonRunWidenGuardWindowEnv, when set to a positive Go duration, makes
+// `daemon run` sleep between passing the liveness guard and taking the flock /
+// self-registering. Test-only seam (#556): the guard→register TOCTOU window is
+// normally microseconds, so the singleton E2E widens it deterministically to
+// prove the flock backstop (and to fail loudly if the flock is ever removed).
+const daemonRunWidenGuardWindowEnv = "GITMOOT_TEST_WIDEN_DAEMON_RUN_GUARD_WINDOW"
+
+func daemonRunWidenGuardWindow() {
+	raw := os.Getenv(daemonRunWidenGuardWindowEnv)
+	if raw == "" {
+		return
+	}
+	if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+		time.Sleep(d)
+	}
+}
+
+// acquireDaemonRunLock closes the residual #550 TOCTOU (#556): two `daemon run`
+// launched simultaneously on a clean home can both pass guardDaemonRunSingleton
+// before either self-registers. flock(LOCK_EX|LOCK_NB) on <home>/daemon.lock is
+// atomic, so exactly one acquires; the loser refuses with the guard's "daemon
+// already running" UX. The winner keeps the fd open for its whole lifetime (the
+// returned release closes it on clean shutdown) and the kernel drops the lock on
+// ANY process death — SIGKILL included — so a stale lockfile can never lock a
+// fresh daemon out, and no unlink is ever needed (flock on an existing file just
+// works). The lockfile's pid content is best-effort diagnostics only; the LOCK
+// is what is authoritative.
+func acquireDaemonRunLock(home string, stderr io.Writer) (release func(), code int) {
+	paths, err := initializedPaths(home)
+	if err != nil {
+		fmt.Fprintf(stderr, "daemon run: %v\n", err)
+		return nil, 1
+	}
+	lockPath := daemonRunLockPath(paths)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		fmt.Fprintf(stderr, "daemon run: open daemon lock: %v\n", err)
+		return nil, 1
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		holder := daemonRunLockHolder(f)
+		_ = f.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			fmt.Fprintf(stderr, "daemon already running%s (%s is flock-held by another daemon run)\n", holder, lockPath)
+			return nil, 1
+		}
+		fmt.Fprintf(stderr, "daemon run: lock %s: %v\n", lockPath, err)
+		return nil, 1
+	}
+	// Record the holder's pid for the loser's message. Best-effort: a loser can
+	// race this write (empty read) or see a SIGKILLed predecessor's pid; either
+	// way only the diagnostic suffix degrades, never the mutual exclusion.
+	_ = f.Truncate(0)
+	_, _ = f.WriteAt([]byte(strconv.Itoa(os.Getpid())+"\n"), 0)
+	return func() { _ = f.Close() }, 0
+}
+
+// daemonRunLockHolder reads the pid the current lock holder recorded in the
+// lockfile, returning a " with pid N" suffix for the refusal message, or "" when
+// the content is absent/unreadable (best-effort diagnostics only).
+func daemonRunLockHolder(f *os.File) string {
+	buf := make([]byte, 32)
+	n, _ := f.ReadAt(buf, 0)
+	if n <= 0 {
+		return ""
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if err != nil || pid <= 0 {
+		return ""
+	}
+	return fmt.Sprintf(" with pid %d", pid)
 }
 
 func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -121,6 +121,17 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, restart boo
 	if stale {
 		writeLine(stdout, "removed stale daemon pid file")
 	}
+	// #556 aftermath (#597 review): the pidfile check above cannot see a live
+	// daemon that flock-holds <home>/daemon.lock WITHOUT being registered (e.g.
+	// the corpse of a concurrent-start race clobbered daemon.pid, which the
+	// next status check then removed as stale). Spawning against such a holder
+	// produces a child that instantly loses the flock and dies with its refusal
+	// visible only in daemon.log while this parent printed "daemon started" —
+	// a false green. Probe the flock the same way the child will and refuse up
+	// front, naming the holder, instead of spawning a doomed child.
+	if code := refuseWhenDaemonRunLockHeld("daemon start", cfg.Home, stderr); code != 0 {
+		return code
+	}
 	if cfg.RepoSet {
 		if err := preflightDaemonRepoStart(context.Background(), cfg.Home, cfg.Repo, cfg.Poll.String(), resolvedWorkDir); err != nil {
 			fmt.Fprintf(stderr, "daemon start: %v\n", err)
@@ -460,13 +471,24 @@ func runDaemonStop(args []string, stdout, stderr io.Writer) int {
 		}
 		writeLine(stdout, "forgot persisted runtime auth (%s)", daemonRuntimeAuthFileName)
 	}
-	if stale {
-		writeLine(stdout, "removed stale daemon pid file")
-		forgetPersistedRuntimeAuth()
-		return 0
-	}
-	if pid == 0 {
-		writeLine(stdout, "daemon not running")
+	if stale || pid == 0 {
+		if stale {
+			writeLine(stdout, "removed stale daemon pid file")
+		}
+		// #597 review: an absent/stale pidfile is NOT proof no daemon is running
+		// — an untracked `daemon run` may still flock-hold <home>/daemon.lock
+		// (e.g. after a concurrent-start race clobbered its registration). Stop
+		// the verified holder instead of lying "daemon not running", so `daemon
+		// restart` can actually terminate it.
+		if handled, code := stopUntrackedDaemonLockHolder(paths, stdout, stderr); handled {
+			if code == 0 {
+				forgetPersistedRuntimeAuth()
+			}
+			return code
+		}
+		if pid == 0 && !stale {
+			writeLine(stdout, "daemon not running")
+		}
 		forgetPersistedRuntimeAuth()
 		return 0
 	}
@@ -1244,16 +1266,241 @@ func acquireDaemonRunLock(home string, stderr io.Writer) (release func(), code i
 // lockfile, returning a " with pid N" suffix for the refusal message, or "" when
 // the content is absent/unreadable (best-effort diagnostics only).
 func daemonRunLockHolder(f *os.File) string {
-	buf := make([]byte, 32)
-	n, _ := f.ReadAt(buf, 0)
-	if n <= 0 {
-		return ""
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
-	if err != nil || pid <= 0 {
+	pid := daemonRunLockHolderPID(f)
+	if pid <= 0 {
 		return ""
 	}
 	return fmt.Sprintf(" with pid %d", pid)
+}
+
+// daemonRunLockHolderPID reads the pid the current lock holder recorded in the
+// lockfile, or 0 when the content is absent/unreadable (best-effort
+// diagnostics only — the flock itself is what is authoritative).
+func daemonRunLockHolderPID(f *os.File) int {
+	buf := make([]byte, 32)
+	n, _ := f.ReadAt(buf, 0)
+	if n <= 0 {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if err != nil || pid <= 0 {
+		return 0
+	}
+	return pid
+}
+
+// tryDaemonRunLock probes <home>/daemon.lock without keeping it: it reports
+// whether the flock is currently held by another process — i.e. a `daemon run`
+// is alive on this home regardless of what the registration files say — and
+// the holder's best-effort recorded pid. When the probe acquires the lock it
+// releases it immediately (held=false): the caller is NOT the daemon and must
+// not keep it. flock is on the open file description, so the deferred Close
+// releases an acquired probe with no residue.
+func tryDaemonRunLock(paths config.Paths) (held bool, holderPID int, err error) {
+	lockPath := daemonRunLockPath(paths)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return false, 0, fmt.Errorf("open daemon lock: %w", err)
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return true, daemonRunLockHolderPID(f), nil
+		}
+		return false, 0, fmt.Errorf("lock %s: %w", lockPath, err)
+	}
+	return false, 0, nil
+}
+
+// refuseWhenDaemonRunLockHeld is the `daemon start`/`daemon restart` parent's
+// pre-spawn probe (#597 review): it checks <home>/daemon.lock the same way the
+// spawned `daemon run` child will and refuses — with the untracked holder's
+// pid and the same "daemon already running" UX as the child's own #556 flock
+// refusal — instead of spawning a child that is guaranteed to lose the flock
+// and die with the refusal visible only in daemon.log. Returns 0 to proceed.
+func refuseWhenDaemonRunLockHeld(cmdName, home string, stderr io.Writer) int {
+	paths, err := initializedPaths(home)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)
+		return 1
+	}
+	held, holderPID, err := tryDaemonRunLock(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: %v\n", cmdName, err)
+		return 1
+	}
+	if !held {
+		return 0
+	}
+	holder := ""
+	if holderPID > 0 {
+		holder = fmt.Sprintf(" with pid %d", holderPID)
+	}
+	fmt.Fprintf(stderr, "daemon already running%s (%s is flock-held by another daemon run)\n", holder, daemonRunLockPath(paths))
+	return 1
+}
+
+// daemonStartConfirmWindow bounds how long `daemon start` waits to confirm the
+// spawned `daemon run` child survived its startup guards. The healthy path
+// exits the window in milliseconds (the child self-registers, which is the
+// early-out), and a flock loser dies in milliseconds (wait4 reaps it, which is
+// the failure-out). The full window is only ever paid in the pathological
+// "alive but never self-registered" case, where proceeding as success is the
+// correct fail-safe: registration is best-effort inside the child.
+const daemonStartConfirmWindow = 3 * time.Second
+
+// confirmDaemonRunChildSurvived verifies a freshly spawned `daemon run` child
+// did not die inside its startup guards (#597 review — the flock loser exits 1
+// within milliseconds, refusal only in daemon.log). It polls wait4(WNOHANG):
+// even after Process.Release the child is still OUR direct child (Setsid
+// detaches the session, not the parent link), so a plain kill(pid, 0) liveness
+// probe would see the unreaped zombie as "running" forever; wait4 both detects
+// and reaps the corpse. Success is the child's self-registration (daemon.pid
+// records its pid) or still-alive at the deadline; failure returns an error
+// carrying the child's exit cause and the daemon.log tail (where its refusal
+// was written).
+func confirmDaemonRunChildSurvived(pid int, state daemonState) error {
+	deadline := time.Now().Add(daemonStartConfirmWindow)
+	for {
+		var status syscall.WaitStatus
+		reaped, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+		if err == nil && reaped == pid {
+			detail := fmt.Sprintf("exit status %d", status.ExitStatus())
+			if status.Signaled() {
+				detail = "signal " + status.Signal().String()
+			}
+			return fmt.Errorf("daemon run child pid %d exited immediately (%s) — daemon NOT started%s", pid, detail, daemonLogTail(state.LogFile))
+		}
+		if raw, rerr := os.ReadFile(state.PIDFile); rerr == nil {
+			if registered, perr := strconv.Atoi(strings.TrimSpace(string(raw))); perr == nil && registered == pid {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// daemonLogTail returns a "; <log> tail:\n..." suffix with the trailing bytes
+// of the daemon log for start-failure errors — the dead child's stdout/stderr
+// (including the #556 "daemon already running ... flock-held" refusal) go only
+// there. Best-effort: an unreadable or empty log yields a pointer to the file.
+func daemonLogTail(logFile string) string {
+	const maxTail = 2048
+	fallback := fmt.Sprintf("; see %s", logFile)
+	f, err := os.Open(logFile)
+	if err != nil {
+		return fallback
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || info.Size() == 0 {
+		return fallback
+	}
+	offset := int64(0)
+	if info.Size() > maxTail {
+		offset = info.Size() - maxTail
+	}
+	buf := make([]byte, info.Size()-offset)
+	n, _ := f.ReadAt(buf, offset)
+	text := strings.TrimSpace(string(buf[:n]))
+	if text == "" {
+		return fallback
+	}
+	return fmt.Sprintf("; %s tail:\n%s", logFile, text)
+}
+
+// stopUntrackedDaemonLockHolder handles `daemon stop` for the "live but
+// untracked daemon" state (#597 review): the registration files say nothing is
+// running (pidfile absent or stale) yet <home>/daemon.lock is flock-held by a
+// live `daemon run` — e.g. the aftermath of a concurrent-start race that
+// clobbered daemon.pid. Reporting "daemon not running" there is a lie that
+// also makes `daemon restart` a silent no-op against the real daemon.
+//
+// It returns handled=false when the lock is free or unprobeable (the normal
+// "daemon not running" path proceeds). When the lock IS held it either stops
+// the holder — but ONLY when the recorded pid can be positively verified as a
+// gitmoot `daemon run` process (the lockfile's pid content is best-effort, and
+// SIGTERMing an unverified pid risks hitting a recycled one) — or reports the
+// untracked holder truthfully with a non-zero code.
+func stopUntrackedDaemonLockHolder(paths config.Paths, stdout, stderr io.Writer) (handled bool, code int) {
+	held, holderPID, err := tryDaemonRunLock(paths)
+	if err != nil || !held {
+		return false, 0
+	}
+	lockPath := daemonRunLockPath(paths)
+	if holderPID > 0 && processIsGitmootDaemonRun(holderPID, lockPath) {
+		if err := stopDaemonPID(holderPID); err != nil {
+			fmt.Fprintf(stderr, "daemon stop: %v\n", err)
+			return true, 1
+		}
+		writeLine(stdout, "daemon stopped pid %d (untracked %s holder)", holderPID, lockPath)
+		return true, 0
+	}
+	fmt.Fprintf(stderr, "daemon stop: %s is flock-held by a live but UNTRACKED daemon (recorded holder pid %d could not be verified); refusing to signal an unverified pid — find and stop it manually\n", lockPath, holderPID)
+	return true, 1
+}
+
+// processIsGitmootDaemonRun reports whether pid is positively identifiable as a
+// live gitmoot `daemon run` process. It is a KILL-guard, so it errs on the side
+// of false: the argv must contain adjacent "daemon run" tokens, and — where the
+// host exposes /proc/<pid>/fd — the process must actually hold lockPath open
+// (closing the microscopic window where the lockfile still carries a dead
+// predecessor's since-recycled pid).
+func processIsGitmootDaemonRun(pid int, lockPath string) bool {
+	if running, err := processRunning(pid); err != nil || !running {
+		return false
+	}
+	argv := processArgv(pid)
+	looksLikeDaemonRun := false
+	for i := 0; i+1 < len(argv); i++ {
+		if argv[i] == "daemon" && argv[i+1] == "run" {
+			looksLikeDaemonRun = true
+			break
+		}
+	}
+	if !looksLikeDaemonRun {
+		return false
+	}
+	if holds, verifiable := processHoldsFileOpen(pid, lockPath); verifiable && !holds {
+		return false
+	}
+	return true
+}
+
+// processArgv returns pid's argv via /proc (exact) or a ps fallback
+// (whitespace-split, best-effort), or nil when neither is available.
+func processArgv(pid int) []string {
+	if raw, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline")); err == nil {
+		return strings.Split(strings.TrimRight(string(raw), "\x00"), "\x00")
+	}
+	if out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output(); err == nil {
+		return strings.Fields(strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// processHoldsFileOpen reports whether pid has path among its open file
+// descriptors, via /proc/<pid>/fd. verifiable=false when the host cannot
+// answer (no /proc, or the fd table is unreadable) so callers can fall back to
+// weaker evidence instead of hard-failing on non-Linux hosts.
+func processHoldsFileOpen(pid int, path string) (holds bool, verifiable bool) {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	fdDir := filepath.Join("/proc", strconv.Itoa(pid), "fd")
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		return false, false
+	}
+	for _, entry := range entries {
+		if target, err := os.Readlink(filepath.Join(fdDir, entry.Name())); err == nil && target == path {
+			return true, true
+		}
+	}
+	return false, true
 }
 
 func currentDaemonPID(state daemonState) (pid int, stale bool, err error) {
@@ -1309,6 +1556,15 @@ func startDaemonChild(home string, poll string, workers int, watchSkillOptReview
 	}
 	pid := cmd.Process.Pid
 	if err := cmd.Process.Release(); err != nil {
+		return daemonMeta{}, err
+	}
+	// #597 review: a child that loses the daemon.lock flock (#556) — or dies for
+	// any other startup reason — exits within milliseconds, with its refusal
+	// written only to daemon.log. Without this check the caller would print
+	// "daemon started pid N", exit 0, and register the corpse's pid, leaving an
+	// operator with a false green and (in the flock case) a live daemon no CLI
+	// command can see. Confirm the child survived before declaring success.
+	if err := confirmDaemonRunChildSurvived(pid, state); err != nil {
 		return daemonMeta{}, err
 	}
 	return daemonMeta{

--- a/internal/cli/daemon_flock_singleton_e2e_test.go
+++ b/internal/cli/daemon_flock_singleton_e2e_test.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// daemonRunChildHomeEnv, when set, flips the re-exec'd test binary into a REAL
+// `gitmoot daemon run --home <value>` process (see TestMain). flock(2) is
+// process-scoped — two goroutines cannot exercise it — so the #556 singleton
+// E2E must launch genuine child processes, and re-exec'ing the already-built
+// test binary is how it gets them without shelling out to `go build`.
+const daemonRunChildHomeEnv = "GITMOOT_TEST_DAEMON_RUN_CHILD_HOME"
+
+func TestMain(m *testing.M) {
+	if home := os.Getenv(daemonRunChildHomeEnv); home != "" {
+		os.Exit(Run([]string{"daemon", "run", "--home", home}, os.Stdout, os.Stderr))
+	}
+	os.Exit(m.Run())
+}
+
+// daemonRunProc is one real `daemon run` child process launched by the E2E.
+// stdout/stderr buffers must only be read AFTER done has delivered (cmd.Wait
+// has returned), or the exec copier goroutines race the reader.
+type daemonRunProc struct {
+	cmd    *exec.Cmd
+	stdout bytes.Buffer
+	stderr bytes.Buffer
+	done   chan error
+	reaped bool
+}
+
+// startDaemonRunProc launches the test binary as a real `daemon run` on home,
+// with the #556 widening seam enabled so BOTH simultaneous children are
+// guaranteed past the friendly liveness guard before either self-registers —
+// making the TOCTOU window deterministic instead of microseconds wide.
+func startDaemonRunProc(t *testing.T, exe, home string) *daemonRunProc {
+	t.Helper()
+	p := &daemonRunProc{done: make(chan error, 1)}
+	p.cmd = exec.Command(exe)
+	env := os.Environ()
+	scrubbed := env[:0]
+	for _, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "GITMOOT_HOME="),
+			strings.HasPrefix(kv, "HERDR_ENV="),
+			strings.HasPrefix(kv, "HERDR_SOCKET_PATH="),
+			strings.HasPrefix(kv, daemonRunChildHomeEnv+"="),
+			strings.HasPrefix(kv, daemonRunWidenGuardWindowEnv+"="):
+			continue
+		}
+		scrubbed = append(scrubbed, kv)
+	}
+	p.cmd.Env = append(scrubbed,
+		daemonRunChildHomeEnv+"="+home,
+		daemonRunWidenGuardWindowEnv+"=500ms",
+	)
+	p.cmd.Stdout = &p.stdout
+	p.cmd.Stderr = &p.stderr
+	if err := p.cmd.Start(); err != nil {
+		t.Fatalf("start daemon run child: %v", err)
+	}
+	go func() { p.done <- p.cmd.Wait() }()
+	t.Cleanup(func() { p.kill(t) })
+	return p
+}
+
+// kill SIGKILLs the child (if still running) and reaps it. Idempotent.
+func (p *daemonRunProc) kill(t *testing.T) {
+	t.Helper()
+	if p.reaped {
+		return
+	}
+	_ = p.cmd.Process.Kill()
+	select {
+	case <-p.done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("daemon run child pid %d did not reap after SIGKILL", p.cmd.Process.Pid)
+	}
+	p.reaped = true
+}
+
+func exitCodeOf(err error) int {
+	if err == nil {
+		return 0
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
+}
+
+// waitForDaemonRegistration polls until <home>/.gitmoot/daemon.pid records
+// wantPID — the winner's self-registration, proof it survived the race and
+// entered its startup path rather than merely not having exited yet.
+func waitForDaemonRegistration(t *testing.T, home string, wantPID int, timeout time.Duration) {
+	t.Helper()
+	state := daemonProcessState(config.PathsForHome(home))
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if raw, err := os.ReadFile(state.PIDFile); err == nil {
+			if pid, perr := strconv.Atoi(strings.TrimSpace(string(raw))); perr == nil && pid == wantPID {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("winner pid %d never self-registered in %s", wantPID, state.PIDFile)
+}
+
+// TestDaemonRunFlockSingletonE2E is the #556 regression, mutation-proven: the
+// residual #550 TOCTOU where two `daemon run` launched SIMULTANEOUSLY on a
+// clean home both pass the liveness guard before either self-registers, so
+// both enter the supervisor loop and race the shared SQLite store.
+//
+// Each round launches two REAL child processes (flock is process-scoped) on
+// one shared temp home, with the widening seam holding both past the friendly
+// guard so the race window is deterministic, and asserts:
+//   - EXACTLY ONE child exits, code 1, printing the "daemon already running"
+//     refusal (the flock loser);
+//   - the other child stays alive and self-registers (the flock winner);
+//   - after the winner is SIGKILLed — the harshest death, no cleanup runs —
+//     the next round's children acquire immediately: the kernel released the
+//     flock with the process, so a stale lockfile can never cause a lockout.
+//
+// Mutation: removing the acquireDaemonRunLock call in runDaemonRun makes both
+// children survive every round — neither exits — and the round times out red.
+func TestDaemonRunFlockSingletonE2E(t *testing.T) {
+	t.Parallel()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	home := t.TempDir()
+
+	const rounds = 20
+	for round := 0; round < rounds; round++ {
+		a := startDaemonRunProc(t, exe, home)
+		b := startDaemonRunProc(t, exe, home)
+
+		var winner, loser *daemonRunProc
+		var loserErr error
+		select {
+		case loserErr = <-a.done:
+			loser, winner = a, b
+		case loserErr = <-b.done:
+			loser, winner = b, a
+		case <-time.After(60 * time.Second):
+			t.Fatalf("round %d: NEITHER simultaneous daemon run refused — double-run (flock backstop missing or inert)", round)
+		}
+		loser.reaped = true
+
+		if code := exitCodeOf(loserErr); code != 1 {
+			t.Fatalf("round %d: loser exit = %d (err=%v), want 1; stderr=%q stdout=%q",
+				round, code, loserErr, loser.stderr.String(), loser.stdout.String())
+		}
+		if !strings.Contains(loser.stderr.String(), "daemon already running") {
+			t.Fatalf("round %d: loser stderr = %q, want the 'daemon already running' refusal", round, loser.stderr.String())
+		}
+
+		// The winner must be alive AND self-registered — not merely slow to lose.
+		waitForDaemonRegistration(t, home, winner.cmd.Process.Pid, 30*time.Second)
+		select {
+		case winnerErr := <-winner.done:
+			winner.reaped = true
+			t.Fatalf("round %d: BOTH runs exited — no daemon survived (winner err=%v stderr=%q)",
+				round, winnerErr, winner.stderr.String())
+		default:
+		}
+
+		// SIGKILL the winner; the next round (and the final check below) proves
+		// the flock was released by the kernel with no stale-lock lockout.
+		winner.kill(t)
+	}
+
+	// Explicit stale-lock check after the final SIGKILL: a lone fresh run must
+	// acquire immediately and register — the lockfile left behind by 20 dead
+	// winners never blocks a new daemon.
+	fresh := startDaemonRunProc(t, exe, home)
+	waitForDaemonRegistration(t, home, fresh.cmd.Process.Pid, 30*time.Second)
+	select {
+	case freshErr := <-fresh.done:
+		fresh.reaped = true
+		t.Fatalf("fresh run after SIGKILLed winner exited (err=%v stderr=%q) — stale-lock lockout", freshErr, fresh.stderr.String())
+	default:
+	}
+	fresh.kill(t)
+}

--- a/internal/cli/daemon_flock_singleton_e2e_test.go
+++ b/internal/cli/daemon_flock_singleton_e2e_test.go
@@ -42,10 +42,14 @@ type daemonRunProc struct {
 // with the #556 widening seam enabled so BOTH simultaneous children are
 // guaranteed past the friendly liveness guard before either self-registers —
 // making the TOCTOU window deterministic instead of microseconds wide.
-func startDaemonRunProc(t *testing.T, exe, home string) *daemonRunProc {
+//
+// argv is cosmetic: TestMain re-execs on the env var alone and ignores the
+// arguments, but tests of the untracked-holder kill-guard (#597 review) pass
+// "daemon run ..." so the child's /proc cmdline looks like a real daemon run.
+func startDaemonRunProc(t *testing.T, exe, home string, argv ...string) *daemonRunProc {
 	t.Helper()
 	p := &daemonRunProc{done: make(chan error, 1)}
-	p.cmd = exec.Command(exe)
+	p.cmd = exec.Command(exe, argv...)
 	env := os.Environ()
 	scrubbed := env[:0]
 	for _, kv := range env {

--- a/internal/cli/daemon_singleton_test.go
+++ b/internal/cli/daemon_singleton_test.go
@@ -127,6 +127,43 @@ func TestGuardDaemonRunSingleton(t *testing.T) {
 	}
 }
 
+// TestAcquireDaemonRunLock covers the in-process seams of the #556 flock
+// backstop: a second acquire on the same home must refuse with the "daemon
+// already running" UX while the first holds the lock (flock conflicts across
+// separate open file descriptions even within one process), and releasing must
+// free it for the next acquire — including when the lockfile already exists
+// (no stale-lockfile unlink dance is ever needed). The process-scoped kill -9
+// semantics are covered by TestDaemonRunFlockSingletonE2E.
+func TestAcquireDaemonRunLock(t *testing.T) {
+	t.Parallel()
+	home := t.TempDir()
+
+	var stderr bytes.Buffer
+	release, code := acquireDaemonRunLock(home, &stderr)
+	if code != 0 {
+		t.Fatalf("first acquire code = %d, stderr=%q", code, stderr.String())
+	}
+
+	var stderr2 bytes.Buffer
+	release2, code2 := acquireDaemonRunLock(home, &stderr2)
+	if code2 == 0 {
+		release2()
+		t.Fatalf("second acquire succeeded while the lock was held")
+	}
+	if !strings.Contains(stderr2.String(), "daemon already running") {
+		t.Fatalf("second acquire stderr = %q, want 'daemon already running'", stderr2.String())
+	}
+
+	release()
+
+	var stderr3 bytes.Buffer
+	release3, code3 := acquireDaemonRunLock(home, &stderr3)
+	if code3 != 0 {
+		t.Fatalf("re-acquire after release code = %d, stderr=%q", code3, stderr3.String())
+	}
+	release3()
+}
+
 // TestDaemonRunCommandRefusesSecondDaemon binds the regression to the real command
 // surface: with a live daemon already registered, `gitmoot daemon run` must return
 // promptly with a non-zero exit and a clear message instead of entering its

--- a/internal/cli/daemon_singleton_test.go
+++ b/internal/cli/daemon_singleton_test.go
@@ -134,8 +134,16 @@ func TestGuardDaemonRunSingleton(t *testing.T) {
 // free it for the next acquire — including when the lockfile already exists
 // (no stale-lockfile unlink dance is ever needed). The process-scoped kill -9
 // semantics are covered by TestDaemonRunFlockSingletonE2E.
+//
+// Deliberately NOT t.Parallel(), and the post-release re-acquire retries
+// briefly: flock lives on the open file description, and a concurrently
+// fork+exec'ing test (several in this package launch real child processes)
+// briefly shares every fd between fork and exec — during that window the lock
+// survives the parent's close, so an instant re-acquire can transiently see
+// EWOULDBLOCK. The kernel guarantees release once no reference remains; only
+// the test's timing needs the slack, not the daemon (whose children exec with
+// CLOEXEC and whose lock dies with the process).
 func TestAcquireDaemonRunLock(t *testing.T) {
-	t.Parallel()
 	home := t.TempDir()
 
 	var stderr bytes.Buffer
@@ -156,12 +164,19 @@ func TestAcquireDaemonRunLock(t *testing.T) {
 
 	release()
 
-	var stderr3 bytes.Buffer
-	release3, code3 := acquireDaemonRunLock(home, &stderr3)
-	if code3 != 0 {
-		t.Fatalf("re-acquire after release code = %d, stderr=%q", code3, stderr3.String())
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var stderr3 bytes.Buffer
+		release3, code3 := acquireDaemonRunLock(home, &stderr3)
+		if code3 == 0 {
+			release3()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("re-acquire after release code = %d, stderr=%q", code3, stderr3.String())
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
-	release3()
 }
 
 // TestDaemonRunCommandRefusesSecondDaemon binds the regression to the real command

--- a/internal/cli/daemon_start_visibility_e2e_test.go
+++ b/internal/cli/daemon_start_visibility_e2e_test.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// These tests bind the #597 review findings: the #556 flock refusal must be
+// VISIBLE through the composed `daemon start`/`daemon restart`/`daemon stop`
+// surfaces, not only on the raw `daemon run` child's stderr (which start
+// redirects to daemon.log). Before the fixes, a start against an untracked
+// flock-holding daemon printed "daemon started pid N" and exited 0 while the
+// child died instantly, writeDaemonState registered the corpse, and stop/status
+// then reported "not running" — a stable silent lie in unattended automation.
+
+// isolateDaemonChildEnv pins the env the re-exec'd test binary children inherit:
+// the TestMain re-exec home, no widening seam, a throwaway herdr socket (so a
+// prod HERDR_ENV inherited from the outer environment can never leak panes),
+// and GITMOOT_HOME matching the test home.
+func isolateDaemonChildEnv(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv(daemonRunChildHomeEnv, home)
+	t.Setenv(daemonRunWidenGuardWindowEnv, "")
+	t.Setenv("GITMOOT_HOME", home)
+	t.Setenv("HERDR_SOCKET_PATH", filepath.Join(t.TempDir(), "herdr.sock"))
+}
+
+// holdDaemonRunLock takes <home>/daemon.lock in-process (flock conflicts across
+// open file descriptions even within one process) and releases it on cleanup,
+// standing in for the live-but-untracked daemon of the #597 scenario.
+func holdDaemonRunLock(t *testing.T, home string) {
+	t.Helper()
+	var stderr bytes.Buffer
+	release, code := acquireDaemonRunLock(home, &stderr)
+	if code != 0 {
+		t.Fatalf("acquireDaemonRunLock code = %d, stderr=%q", code, stderr.String())
+	}
+	t.Cleanup(release)
+}
+
+// TestDaemonStartRefusesWhenDaemonRunLockHeld is the #597 pre-spawn probe
+// regression: with <home>/daemon.lock flock-held by an UNTRACKED daemon (no
+// pidfile — exactly what the start path's pidfile check cannot see), `daemon
+// start` must refuse up front with the "daemon already running" UX naming the
+// holder, WITHOUT spawning a child and WITHOUT registering any pid.
+//
+// Mutation: removing the refuseWhenDaemonRunLockHeld call in
+// runDaemonStartWithWorkDirRestart makes this spawn (spawned=true) and print
+// "daemon started" — red.
+func TestDaemonStartRefusesWhenDaemonRunLockHeld(t *testing.T) {
+	home := t.TempDir()
+	holdDaemonRunLock(t, home)
+
+	spawned := false
+	prev := startDaemonChildFn
+	startDaemonChildFn = func(h, poll string, workers int, wsor, wi bool, scheduler, repo, session string, state daemonState, workDir string, extraEnv []string) (daemonMeta, error) {
+		spawned = true
+		return daemonMeta{PID: 424242, LogFile: filepath.Join(h, "daemon.log")}, nil
+	}
+	t.Cleanup(func() { startDaemonChildFn = prev })
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStartWithWorkDirRestart([]string{"--home", home}, "", false, false, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("daemon start code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if spawned {
+		t.Fatalf("daemon start spawned a child despite the held daemon.lock")
+	}
+	if !strings.Contains(stderr.String(), "daemon already running") || !strings.Contains(stderr.String(), "flock-held") {
+		t.Fatalf("stderr = %q, want the 'daemon already running ... flock-held' refusal", stderr.String())
+	}
+	// The refusal must name the holder (this process wrote its pid on acquire).
+	if !strings.Contains(stderr.String(), fmt.Sprintf("with pid %d", os.Getpid())) {
+		t.Fatalf("stderr = %q, want the holder pid %d", stderr.String(), os.Getpid())
+	}
+	if strings.Contains(stdout.String(), "daemon started") {
+		t.Fatalf("stdout = %q claims success despite the refusal", stdout.String())
+	}
+	state := daemonProcessState(config.PathsForHome(home))
+	if _, err := os.Stat(state.PIDFile); !os.IsNotExist(err) {
+		t.Fatalf("daemon.pid exists after a refused start (stat err=%v)", err)
+	}
+}
+
+// TestStartDaemonChildSurfacesInstantFlockLoser drives the REAL startDaemonChild
+// (the same function `daemon start`/`daemon restart` use behind the seam)
+// against a home whose daemon.lock is already held: the spawned child is a real
+// `daemon run` (via the TestMain re-exec) that loses the flock and exits 1
+// within milliseconds. startDaemonChild must report that death as an error —
+// carrying the child's refusal from the daemon.log tail — instead of returning
+// a corpse pid for the caller to register and celebrate.
+//
+// Mutation: removing the confirmDaemonRunChildSurvived call in startDaemonChild
+// makes this return nil error with the dead child's pid — red.
+func TestStartDaemonChildSurfacesInstantFlockLoser(t *testing.T) {
+	home := t.TempDir()
+	isolateDaemonChildEnv(t, home)
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths: %v", err)
+	}
+	state := daemonProcessState(paths)
+	holdDaemonRunLock(t, home)
+
+	meta, err := startDaemonChild(home, "30s", 1, false, false, "", "", "", state, t.TempDir(), nil)
+	if err == nil {
+		_ = syscall.Kill(meta.PID, syscall.SIGKILL)
+		reapChildProcess(t, meta.PID)
+		t.Fatalf("startDaemonChild succeeded (pid %d) despite the held daemon.lock", meta.PID)
+	}
+	if !strings.Contains(err.Error(), "exited immediately") {
+		t.Fatalf("err = %q, want the instant-death diagnosis", err)
+	}
+	if !strings.Contains(err.Error(), "daemon already running") {
+		t.Fatalf("err = %q, want the child's 'daemon already running' refusal surfaced from the log tail", err)
+	}
+	if _, statErr := os.Stat(state.PIDFile); !os.IsNotExist(statErr) {
+		t.Fatalf("daemon.pid exists after a failed start (stat err=%v)", statErr)
+	}
+}
+
+// TestStartDaemonChildConfirmsHealthySurvivor is the no-regression half of the
+// #597 survival check: on a free home the REAL startDaemonChild must still
+// succeed, returning only after the child proved it survived its startup guards
+// by self-registering its pid — not merely "hasn't died yet".
+func TestStartDaemonChildConfirmsHealthySurvivor(t *testing.T) {
+	home := t.TempDir()
+	isolateDaemonChildEnv(t, home)
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths: %v", err)
+	}
+	state := daemonProcessState(paths)
+
+	meta, err := startDaemonChild(home, "30s", 1, false, false, "", "", "", state, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("startDaemonChild: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(meta.PID, syscall.SIGKILL)
+		reapChildProcess(t, meta.PID)
+	})
+	// The survival confirmation normally returns only after self-registration
+	// (its early-out); the poll below covers the deadline fallback path so a
+	// slow-but-healthy child never flakes this test.
+	waitForDaemonRegistration(t, home, meta.PID, 30*time.Second)
+}
+
+// reapChildProcess waits (blocking, EINTR-tolerant) for a direct child spawned
+// by the REAL startDaemonChild, so no zombie outlives the test.
+func reapChildProcess(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		var status syscall.WaitStatus
+		reaped, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+		if err == syscall.EINTR {
+			continue
+		}
+		if err != nil || reaped == pid {
+			return // reaped, or already gone (ECHILD)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child pid %d did not exit for reaping", pid)
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestDaemonStopStopsUntrackedFlockHolder: with a LIVE `daemon run` holding the
+// flock but its registration lost (the #597 aftermath state), `daemon stop`
+// must find the holder via daemon.lock, verify it, and actually stop it —
+// instead of reporting "daemon not running" and leaving the daemon immortal to
+// the CLI (which also made `daemon restart` a silent no-op).
+func TestDaemonStopStopsUntrackedFlockHolder(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	home := t.TempDir()
+	// Cosmetic "daemon run" argv so the kill-guard can verify the holder by its
+	// cmdline, as it would a production `gitmoot daemon run`.
+	p := startDaemonRunProc(t, exe, home, "daemon", "run", "--home", home)
+	waitForDaemonRegistration(t, home, p.cmd.Process.Pid, 30*time.Second)
+
+	// Lose the registration out from under the live daemon (what the clobber
+	// race + stale-pid cleanup produce organically).
+	state := daemonProcessState(config.PathsForHome(home))
+	if err := os.Remove(state.PIDFile); err != nil {
+		t.Fatalf("remove pidfile: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"daemon", "stop", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("daemon stop code = %d; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), fmt.Sprintf("daemon stopped pid %d", p.cmd.Process.Pid)) || !strings.Contains(stdout.String(), "untracked") {
+		t.Fatalf("stdout = %q, want 'daemon stopped pid %d (untracked ...)'", stdout.String(), p.cmd.Process.Pid)
+	}
+	select {
+	case <-p.done:
+		p.reaped = true
+	case <-time.After(30 * time.Second):
+		t.Fatalf("untracked daemon pid %d still alive after daemon stop", p.cmd.Process.Pid)
+	}
+	// The flock must now be free: a fresh acquire succeeds immediately.
+	release, lockCode := acquireDaemonRunLock(home, io.Discard)
+	if lockCode != 0 {
+		t.Fatalf("daemon.lock still held after stopping the untracked holder")
+	}
+	release()
+}
+
+// TestDaemonStopRefusesUnverifiedUntrackedHolder: when the flock is held but
+// the recorded holder cannot be positively verified as a gitmoot `daemon run`
+// (here: the lock is held by the TEST process, whose cmdline has no `daemon
+// run`), `daemon stop` must NOT signal the pid — but it must also NOT lie
+// "daemon not running": it reports the untracked holder and exits non-zero.
+func TestDaemonStopRefusesUnverifiedUntrackedHolder(t *testing.T) {
+	home := t.TempDir()
+	holdDaemonRunLock(t, home)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"daemon", "stop", "--home", home}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("daemon stop code = %d, want 1; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "daemon not running") {
+		t.Fatalf("stdout = %q lies 'daemon not running' while the flock is held", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "UNTRACKED") {
+		t.Fatalf("stderr = %q, want the untracked-holder report", stderr.String())
+	}
+}


### PR DESCRIPTION
## Problem

#550/#551 added a liveness guard so a second `daemon run` refuses when a prior daemon is still registered. A residual TOCTOU remained: two `daemon run` launched **simultaneously** on a clean home can both pass `guardDaemonRunSingleton` before either self-registers (`registerDaemonRunState` runs later, and its ok=false path deliberately does not abort), yielding an untracked second daemon racing the shared SQLite store.

## Design

- **flock backstop**: at `daemon run` startup — after the friendly liveness guard, before self-registration — acquire `flock(LOCK_EX|LOCK_NB)` on a dedicated `<home>/.gitmoot/daemon.lock`. flock is atomic in the kernel, so exactly one process ever holds it; the loser exits 1 with the same "daemon already running" UX as the #550 guard (plus the holder pid, best-effort, and the lock path).
- **Lifetime = process**: the winner keeps the fd open for its whole life; the kernel releases the lock on ANY death (SIGKILL included). No stale-lock lockout, no unlink dance — flock on a pre-existing lockfile just works.
- **Not gitmoot.db**: a dedicated sibling file, deliberately not the SQLite database, so the lock can never interfere with SQLite's own fcntl/WAL locking.
- **Layering kept**: the #550 liveness guard stays as the friendly-diagnostics layer (accurate pid of a live registered daemon); the flock is the airtight backstop for the simultaneous window.
- **Portability**: `syscall.Flock` + `LOCK_EX|LOCK_NB` exist on all four release targets (linux/darwin x amd64/arm64, per `release.yml`); all four cross-compile clean. The `cli` package is already unix-only (`SysProcAttr{Setsid}`), so no build tags needed.
- **Deterministic test seam**: `GITMOOT_TEST_WIDEN_DAEMON_RUN_GUARD_WINDOW` (unset in production, so a no-op) sleeps between the guard and the flock, letting the E2E hold two real processes inside the normally-microseconds TOCTOU window.

## What the E2E proves (and mutation-red)

`TestDaemonRunFlockSingletonE2E` (flock is process-scoped, so it re-execs the test binary via a `TestMain` hook into a REAL `daemon run` child):

- 20 rounds on one shared temp home: two real `daemon run` children launched near-simultaneously, both held past the liveness guard by the widening seam. Asserts **exactly one** child exits (code 1, printing the `daemon already running` refusal) while the other stays alive **and self-registers** (pidfile carries its pid).
- Each round SIGKILLs the winner (harshest death, no cleanup runs) and the next round — plus an explicit final single-run check — proves a fresh run **acquires immediately**: no stale-lock lockout.

**Mutation-red demonstrated**: with the `acquireDaemonRunLock` call in `runDaemonRun` replaced by a no-op, the E2E fails at round 0 with `NEITHER simultaneous daemon run refused — double-run (flock backstop missing or inert)` (both children survived the race); restoring the flock turns it green again (~11s). The test does not compile on main (it exercises the new symbols), so mutation-red is the fail-without-fix proof.

Also added `TestAcquireDaemonRunLock` (in-process: second acquire refuses while held; release frees it; re-acquire over an existing lockfile works — no unlink needed).

## Gate

`go build ./... && go vet ./... && go test ./internal/cli/ ./internal/config/ ./internal/db/ ./internal/daemon/ ./internal/workflow/ ./internal/runtime/ -count=1 && go test -race -timeout 20m ./internal/cli/ ./internal/workflow/` — all green locally.

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)
