### PR TITLE
feat(skillopt): measure the judge — judge↔human agreement harness (#344)

### DIFF
--- a/internal/cli/agent_dispatch_live_ab.go
+++ b/internal/cli/agent_dispatch_live_ab.go
@@ -200,8 +200,12 @@ func runLiveABChallenger(ctx context.Context, store *db.Store, request localAgen
 
 	// Route through the EXACT #473 record path: same RankedFeedbackEvent shape,
 	// source tag, run-id prefix, and per-pick SourceURL as a manual `skillopt ab`.
+	// Each intercepted ask is its OWN comparison (its own live prompt, its own
+	// challenger answer, the champion resolved right now), so it mints its own
+	// comparison token — the live path is exactly the many-picks-per-challenger
+	// shape that makes per-comparison joining in the #344 harness mandatory.
 	runID := skillOptABRunIDPrefix + challenger.version.ID
-	pickSourceURL := skillOptABPickSourceURL(challenger.version.ID)
+	pickSourceURL := skillOptABPickSourceURL(challenger.version.ID, skillOptABComparisonToken())
 	if err := recordSkillOptABPick(ctx, store, paths, runID, pickSourceURL, templateID, champion, challenger, championDelivery, challengerDelivery, winnerLabel, loserLabel, prompt); err != nil {
 		return fmt.Errorf("live_ab record pick: %w", err)
 	}

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -106,6 +106,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt ab <agent> \"<prompt>\" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]")
 	fmt.Fprintln(w, "  gitmoot skillopt pairwise import <packet-dir> [--packet path] [--secret-map path] [--picks path] [--reviewer name] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge-report [--template id]")
+	fmt.Fprintln(w, "  gitmoot skillopt judge agreement [--template <id>] [--home <h>] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <h>] [--yes] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt train init --name <name> --template <id> --review-repo owner/repo --artifact-kind kind --preview kind (--request text|--request-file path)")
 	fmt.Fprintln(w, "  gitmoot skillopt train init templates --json")
@@ -11848,6 +11849,8 @@ func runSkillOptJudge(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "promote":
 		return runSkillOptJudgePromote(args[1:], stdout, stderr)
+	case "agreement":
+		return runSkillOptJudgeAgreement(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown skillopt judge command %q\n\n", args[0])
 		printSkillOptJudgeUsage(stderr)
@@ -11858,6 +11861,7 @@ func runSkillOptJudge(args []string, stdout, stderr io.Writer) int {
 func printSkillOptJudgeUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <h>] [--yes] [--json]")
+	fmt.Fprintln(w, "  gitmoot skillopt judge agreement [--template <id>] [--home <h>] [--json]")
 }
 
 // skillOptJudgePromoteResult is the machine-readable preview/apply summary for

--- a/internal/cli/skillopt_ab.go
+++ b/internal/cli/skillopt_ab.go
@@ -593,7 +593,7 @@ func recordSkillOptABPick(ctx context.Context, store *db.Store, paths config.Pat
 	if err := ensureSkillOptABRunRows(ctx, store, paths, runID, skillOptABItemID, templateID, champion, challenger, championDelivery, challengerDelivery, prompt, skillOptABSource, skillOptABFeedbackSource); err != nil {
 		return err
 	}
-	return upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, winnerLabel, loserLabel, "human", skillOptABSource, pickSourceURL)
+	return upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, winnerLabel, loserLabel, "human", skillOptABSource, pickSourceURL, "")
 }
 
 // ensureSkillOptABRunRows idempotently upserts the shared pairwise scaffolding for
@@ -668,8 +668,10 @@ func ensureSkillOptABRunRows(ctx context.Context, store *db.Store, paths config.
 // row (reviewer=human,source=skillopt-ab) and the judge row
 // (reviewer=skillopt-ab-judge,source=skillopt-ab-judge) as SEPARATE coexisting
 // rows on the same run/item, and what makes repeated picks each persist via a
-// distinct per-pick source_url.
-func upsertSkillOptABRankedEvent(ctx context.Context, store *db.Store, runID, itemID, winnerLabel, loserLabel, reviewer, source, sourceURL string) error {
+// distinct per-pick source_url. reasoning is stored verbatim (the judge/juror
+// paths pass the machine-readable position blob from
+// skillOptABJudgePickPositionJSON; the human paths pass "").
+func upsertSkillOptABRankedEvent(ctx context.Context, store *db.Store, runID, itemID, winnerLabel, loserLabel, reviewer, source, sourceURL, reasoning string) error {
 	ranking, err := json.Marshal([]string{winnerLabel, loserLabel})
 	if err != nil {
 		return err
@@ -684,10 +686,52 @@ func upsertSkillOptABRankedEvent(ctx context.Context, store *db.Store, runID, it
 		RankingJSON:   string(ranking),
 		TieGroupsJSON: string(tieGroups),
 		Winner:        winnerLabel,
+		Reasoning:     reasoning,
 		Reviewer:      reviewer,
 		Source:        source,
 		SourceURL:     sourceURL,
 	})
+}
+
+// skillOptABJudgePickPositionJSON encodes the judge's RAW presented-position
+// pick (a|b) as a tiny machine-readable JSON blob carried on the judge/juror
+// RankedFeedbackEvent.Reasoning field. This is the MINIMAL ADDITIVE persistence
+// the position-bias audit needs (#344, "Reliability without Validity"): the
+// stored Winner is the UNBLINDED role (champion|challenger), so without this
+// blob the presented position is unrecoverable and |P(pick=a) - 0.5| cannot be
+// measured. Reasoning is an existing opaque passthrough (no schema change), it
+// was previously always empty on judge/juror rows, and judge rows are
+// source-tagged + weighted below human downstream, so filling it changes no
+// existing flow.
+func skillOptABJudgePickPositionJSON(pick string) string {
+	data, err := json.Marshal(map[string]string{"judge_pick_position": pick})
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// skillOptABJudgePickPosition decodes the position blob written by
+// skillOptABJudgePickPositionJSON. ok is false for rows that predate the
+// position capture (empty/free-text reasoning) or carry anything other than a
+// valid a|b position, so the audit silently skips unmeasurable rows instead of
+// fabricating positions.
+func skillOptABJudgePickPosition(reasoning string) (string, bool) {
+	reasoning = strings.TrimSpace(reasoning)
+	if reasoning == "" {
+		return "", false
+	}
+	var decoded struct {
+		JudgePickPosition string `json:"judge_pick_position"`
+	}
+	if err := json.Unmarshal([]byte(reasoning), &decoded); err != nil {
+		return "", false
+	}
+	pick := strings.ToLower(strings.TrimSpace(decoded.JudgePickPosition))
+	if pick != "a" && pick != "b" {
+		return "", false
+	}
+	return pick, true
 }
 
 // skillOptABPickSourceURL mints a unique-per-pick SourceURL for the Mode B
@@ -852,7 +896,11 @@ func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths
 		return
 	}
 	judgeSourceURL := skillOptABJudgeSourceURL(challenger.version.ID)
-	if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, winnerLabel, loserLabel, skillOptABJudgeReviewer, skillOptABJudgeSource, judgeSourceURL); err != nil {
+	// The reasoning blob records the judge's RAW presented-position pick so the
+	// position-bias audit (`skillopt judge agreement`, #344) can measure
+	// |P(pick=a) - 0.5| — the stored Winner alone is the unblinded role and
+	// cannot recover the position.
+	if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, winnerLabel, loserLabel, skillOptABJudgeReviewer, skillOptABJudgeSource, judgeSourceURL, skillOptABJudgePickPositionJSON(pick)); err != nil {
 		log.Printf("skillopt ab judge: record judge pick: %v", err)
 		return
 	}
@@ -865,10 +913,12 @@ func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths
 }
 
 // skillOptABJuror is one surviving jury member's parsed verdict: its resolved
-// family, the role it picked (champion|challenger), and whether that pick means
-// the challenger won (the boolean the pure aggregator votes on).
+// family, the RAW presented position it picked (a|b — persisted for the #344
+// position-bias audit), the role it picked (champion|challenger), and whether
+// that pick means the challenger won (the boolean the pure aggregator votes on).
 type skillOptABJuror struct {
 	family         string
+	pick           string
 	winnerLabel    string
 	challengerWins bool
 }
@@ -910,6 +960,7 @@ func runSkillOptABJudgeJury(ctx context.Context, store *db.Store, paths config.P
 		}
 		jurors = append(jurors, skillOptABJuror{
 			family:         reviewer.Runtime,
+			pick:           pick,
 			winnerLabel:    pickedDelivery.label,
 			challengerWins: pickedDelivery.label == skillOptABChallengerLabel,
 		})
@@ -955,7 +1006,9 @@ func runSkillOptABJudgeJury(ctx context.Context, store *db.Store, paths config.P
 		}
 		reviewer := skillOptABJurorReviewerPrefix + j.family
 		sourceURL := skillOptABJurorSourceURL(challenger.version.ID, j.family)
-		if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, j.winnerLabel, loserLabel, reviewer, skillOptABJurorSource, sourceURL); err != nil {
+		// Each juror row carries its RAW presented-position pick for the #344
+		// position-bias audit, exactly like the single-judge row.
+		if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, j.winnerLabel, loserLabel, reviewer, skillOptABJurorSource, sourceURL, skillOptABJudgePickPositionJSON(j.pick)); err != nil {
 			log.Printf("skillopt ab jury: record juror %s row: %v", j.family, err)
 			return
 		}
@@ -969,7 +1022,10 @@ func runSkillOptABJudgeJury(ctx context.Context, store *db.Store, paths config.P
 	if decision.Decision {
 		aggWinner, aggLoser = skillOptABChallengerLabel, skillOptABChampionLabel
 	}
-	if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, aggWinner, aggLoser, skillOptABJudgeReviewer, skillOptABJudgeSource, skillOptABJudgeSourceURL(challenger.version.ID)); err != nil {
+	// The jury AGGREGATE verdict is a majority over jurors, not one positional
+	// pick, so it carries no position blob (reasoning "") — only the per-juror
+	// rows above are position-auditable.
+	if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, aggWinner, aggLoser, skillOptABJudgeReviewer, skillOptABJudgeSource, skillOptABJudgeSourceURL(challenger.version.ID), ""); err != nil {
 		log.Printf("skillopt ab jury: record aggregate verdict: %v", err)
 		return
 	}

--- a/internal/cli/skillopt_ab.go
+++ b/internal/cli/skillopt_ab.go
@@ -368,6 +368,18 @@ func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.P
 	// and item so it coexists with the human row instead of forming a parallel run.
 	runID := skillOptABRunIDPrefix + challenger.version.ID
 
+	// comparisonToken identifies THIS invocation's single comparison. (run_id,
+	// item_id) alone is the CHALLENGER, not the comparison — run_id is
+	// "skillopt-ab:<challengerVersion>" and item_id is always "ab", so every
+	// repeated A/B of one challenger (each with its own prompt, freshly
+	// regenerated answers, its own shuffle, and the champion resolved at
+	// invocation time) would collide into one bucket. The token is embedded in
+	// the SourceURL of EVERY row this invocation records (human pick, judge
+	// aggregate, per-juror details) so the #344 agreement harness can join judge
+	// vs human PER COMPARISON instead of pooling verdicts made on different
+	// comparisons (cross-item contamination).
+	comparisonToken := skillOptABComparisonToken()
+
 	// OFF-BY-DEFAULT cross-family LLM-judge auto-pairwise (#483). When neither the
 	// --judge flag nor [skillopt].mode_b_judge_enabled is set, judgeEnabled is false
 	// and this whole branch is skipped — no cross-family reviewer is selected, no
@@ -377,7 +389,7 @@ func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.P
 	// sees the SAME shuffled Option A/B as the human (it never learns champion vs
 	// challenger), and its pick maps back through the SAME optionA/optionB mapping.
 	if skillOptABJudgeEnabled(paths, options) {
-		runSkillOptABJudge(ctx, store, paths, runtimeAgent, agent, runID, templateID, champion, challenger, optionA, optionB, options, stdout, stderr)
+		runSkillOptABJudge(ctx, store, paths, runtimeAgent, agent, runID, comparisonToken, templateID, champion, challenger, optionA, optionB, options, stdout, stderr)
 	}
 
 	// --judge-only records ONLY the judge row above and skips the human pick + bandit
@@ -408,8 +420,10 @@ func runSkillOptABWithStore(ctx context.Context, store *db.Store, paths config.P
 	// (run_id, item_id, reviewer, source, source_url), and the first four are
 	// identical across repeated A/Bs of the same challenger, so without a unique
 	// source_url an ON CONFLICT DO UPDATE would overwrite every prior pick and only
-	// the last preference would survive as evidence.
-	pickSourceURL := skillOptABPickSourceURL(challenger.version.ID)
+	// the last preference would survive as evidence. It carries the SHARED
+	// per-invocation comparison token so the human row and this invocation's
+	// judge/juror rows join as ONE comparison in the #344 harness.
+	pickSourceURL := skillOptABPickSourceURL(challenger.version.ID, comparisonToken)
 	if err := recordSkillOptABPick(ctx, store, paths, runID, pickSourceURL, templateID, champion, challenger, championDelivery, challengerDelivery, winnerLabel, loserLabel, options.prompt); err != nil {
 		fmt.Fprintf(stderr, "skillopt ab: record pick: %v\n", err)
 		return 1
@@ -734,19 +748,55 @@ func skillOptABJudgePickPosition(reasoning string) (string, bool) {
 	return pick, true
 }
 
-// skillOptABPickSourceURL mints a unique-per-pick SourceURL for the Mode B
-// RankedFeedbackEvent. The run id, item id, reviewer, and source are constant
-// across repeated A/Bs of one challenger, so this token is what differentiates
-// each pick's conflict key; it embeds the version id for separability and a
-// strictly increasing nanosecond+counter suffix so a tight loop of picks never
-// collides on a single row.
-func skillOptABPickSourceURL(versionID string) string {
+// skillOptABComparisonMarker is the SourceURL fragment marker that carries the
+// per-invocation comparison token. It is deliberately distinct from the legacy
+// "#<nano>-<seq>" suffix (which was minted PER ROW, so the human row and the
+// judge row of the same comparison never shared it): a SourceURL without this
+// marker is a legacy row the #344 agreement harness must treat as unmeasurable
+// rather than pool by challenger.
+const skillOptABComparisonMarker = "#cmp:"
+
+// skillOptABComparisonToken mints ONE token per `skillopt ab` invocation — i.e.
+// per COMPARISON: one prompt, one pair of freshly generated answers, one
+// shuffle, one champion resolved at that instant. Every row the invocation
+// records (human pick, judge aggregate, per-juror details) embeds this SAME
+// token in its SourceURL, which is what lets the agreement harness join judge
+// verdicts against human verdicts of the SAME comparison. The
+// nanosecond+counter shape also keeps each invocation's conflict keys distinct
+// (the uniqueness role the old per-row suffix played).
+func skillOptABComparisonToken() string {
 	seq := atomic.AddUint64(&skillOptABPickSeq, 1)
-	return fmt.Sprintf("%s%s#%d-%d", skillOptABRunIDPrefix, versionID, time.Now().UnixNano(), seq)
+	return fmt.Sprintf("%d-%d", time.Now().UnixNano(), seq)
+}
+
+// skillOptABComparisonTokenFromSourceURL recovers the per-invocation comparison
+// token from a recorded SourceURL. ok=false for legacy rows written before the
+// token existed (their "#<nano>-<seq>" suffix carries no marker), so the
+// agreement harness can exclude them loudly instead of fabricating a join.
+func skillOptABComparisonTokenFromSourceURL(sourceURL string) (string, bool) {
+	index := strings.LastIndex(sourceURL, skillOptABComparisonMarker)
+	if index < 0 {
+		return "", false
+	}
+	token := strings.TrimSpace(sourceURL[index+len(skillOptABComparisonMarker):])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+// skillOptABPickSourceURL mints the human pick's SourceURL for the Mode B
+// RankedFeedbackEvent. The run id, item id, reviewer, and source are constant
+// across repeated A/Bs of one challenger, so the embedded per-invocation
+// comparison token is what differentiates each pick's conflict key (a tight
+// loop of picks never collides on a single row) AND what joins this pick with
+// the same invocation's judge/juror rows in the #344 agreement harness.
+func skillOptABPickSourceURL(versionID, comparisonToken string) string {
+	return fmt.Sprintf("%s%s%s%s", skillOptABRunIDPrefix, versionID, skillOptABComparisonMarker, comparisonToken)
 }
 
 // skillOptABPickSeq is a process-local monotonic counter that guarantees two
-// picks recorded within the same nanosecond still get distinct SourceURLs.
+// comparison tokens minted within the same nanosecond are still distinct.
 var skillOptABPickSeq uint64
 
 // answerOrPlaceholder guarantees a non-empty artifact body (the blob path rejects
@@ -817,7 +867,7 @@ func skillOptABJurySize(paths config.Paths, options skillOptABOptions) int {
 // skillopt-ab-judge RankedFeedbackEvent that coexists with the human row. It NEVER
 // touches the promotion bandit and NEVER fails the command: every error path logs a
 // best-effort note and returns, leaving the human path intact (fail-safe).
-func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths, runtimeAgent runtime.Agent, agent db.Agent, runID, templateID string, champion, challenger skillOptABVariant, optionA, optionB skillOptABDelivery, options skillOptABOptions, stdout, stderr io.Writer) {
+func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths, runtimeAgent runtime.Agent, agent db.Agent, runID, comparisonToken, templateID string, champion, challenger skillOptABVariant, optionA, optionB skillOptABDelivery, options skillOptABOptions, stdout, stderr io.Writer) {
 	// authedRuntimes probes which families can actually run, so an ephemeral judge
 	// leg is only materialized on an authed DIFFERENT family. The probe is injectable
 	// so unit tests stay deterministic/offline.
@@ -838,7 +888,7 @@ func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths
 			return
 		}
 		if len(jury) >= 2 {
-			runSkillOptABJudgeJury(ctx, store, paths, runID, templateID, champion, challenger, optionA, optionB, options, jury, stdout)
+			runSkillOptABJudgeJury(ctx, store, paths, runID, comparisonToken, templateID, champion, challenger, optionA, optionB, options, jury, stdout)
 			return
 		}
 		// < 2 distinct families: graceful degradation to the single-judge path.
@@ -895,7 +945,7 @@ func runSkillOptABJudge(ctx context.Context, store *db.Store, paths config.Paths
 		log.Printf("skillopt ab judge: ensure run rows: %v", err)
 		return
 	}
-	judgeSourceURL := skillOptABJudgeSourceURL(challenger.version.ID)
+	judgeSourceURL := skillOptABJudgeSourceURL(challenger.version.ID, comparisonToken)
 	// The reasoning blob records the judge's RAW presented-position pick so the
 	// position-bias audit (`skillopt judge agreement`, #344) can measure
 	// |P(pick=a) - 0.5| — the stored Winner alone is the unblinded role and
@@ -935,7 +985,7 @@ type skillOptABJuror struct {
 // returns, leaving the human path intact). Candidate origin is blinded to every
 // juror exactly as the single judge blinds it. When NO juror survives it writes no
 // row (same as the single judge's unparseable drop).
-func runSkillOptABJudgeJury(ctx context.Context, store *db.Store, paths config.Paths, runID, templateID string, champion, challenger skillOptABVariant, optionA, optionB skillOptABDelivery, options skillOptABOptions, jury []workflow.CrossFamilyReviewer, stdout io.Writer) {
+func runSkillOptABJudgeJury(ctx context.Context, store *db.Store, paths config.Paths, runID, comparisonToken, templateID string, champion, challenger skillOptABVariant, optionA, optionB skillOptABDelivery, options skillOptABOptions, jury []workflow.CrossFamilyReviewer, stdout io.Writer) {
 	prompt := buildSkillOptABJudgePrompt(options.prompt, optionA.answer, optionB.answer)
 
 	var jurors []skillOptABJuror
@@ -1005,7 +1055,7 @@ func runSkillOptABJudgeJury(ctx context.Context, store *db.Store, paths config.P
 			loserLabel = skillOptABChallengerLabel
 		}
 		reviewer := skillOptABJurorReviewerPrefix + j.family
-		sourceURL := skillOptABJurorSourceURL(challenger.version.ID, j.family)
+		sourceURL := skillOptABJurorSourceURL(challenger.version.ID, j.family, comparisonToken)
 		// Each juror row carries its RAW presented-position pick for the #344
 		// position-bias audit, exactly like the single-judge row.
 		if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, j.winnerLabel, loserLabel, reviewer, skillOptABJurorSource, sourceURL, skillOptABJudgePickPositionJSON(j.pick)); err != nil {
@@ -1025,7 +1075,7 @@ func runSkillOptABJudgeJury(ctx context.Context, store *db.Store, paths config.P
 	// The jury AGGREGATE verdict is a majority over jurors, not one positional
 	// pick, so it carries no position blob (reasoning "") — only the per-juror
 	// rows above are position-auditable.
-	if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, aggWinner, aggLoser, skillOptABJudgeReviewer, skillOptABJudgeSource, skillOptABJudgeSourceURL(challenger.version.ID), ""); err != nil {
+	if err := upsertSkillOptABRankedEvent(ctx, store, runID, skillOptABItemID, aggWinner, aggLoser, skillOptABJudgeReviewer, skillOptABJudgeSource, skillOptABJudgeSourceURL(challenger.version.ID, comparisonToken), ""); err != nil {
 		log.Printf("skillopt ab jury: record aggregate verdict: %v", err)
 		return
 	}
@@ -1067,12 +1117,13 @@ func skillOptABJuryMetadata(decision skillopt.JuryDecision, jurors []skillOptABJ
 	return string(raw)
 }
 
-// skillOptABJurorSourceURL mints a unique-per-juror SourceURL embedding the juror
+// skillOptABJurorSourceURL mints a per-juror SourceURL embedding the juror
 // family so each juror's detail row has a distinct (run,item,reviewer,source,url)
-// conflict key and repeated jury runs each persist without colliding.
-func skillOptABJurorSourceURL(versionID, family string) string {
-	seq := atomic.AddUint64(&skillOptABPickSeq, 1)
-	return fmt.Sprintf("%s%s:juror:%s#%d-%d", skillOptABRunIDPrefix, versionID, family, time.Now().UnixNano(), seq)
+// conflict key and repeated jury runs each persist without colliding. Like the
+// human and judge URLs it carries the invocation's SHARED comparison token so
+// every juror verdict joins the same single comparison in the #344 harness.
+func skillOptABJurorSourceURL(versionID, family, comparisonToken string) string {
+	return fmt.Sprintf("%s%s:juror:%s%s%s", skillOptABRunIDPrefix, versionID, family, skillOptABComparisonMarker, comparisonToken)
 }
 
 // optionAToDelivery recovers the champion/challenger delivery from the shuffled
@@ -1157,11 +1208,12 @@ func parseSkillOptABJudgePick(raw string) (string, bool) {
 	return "", false
 }
 
-// skillOptABJudgeSourceURL mints a unique-per-judgment SourceURL for the judge's
-// RankedFeedbackEvent, mirroring skillOptABPickSourceURL but with a distinct judge
-// prefix so the judge row's (run_id,item_id,reviewer,source,source_url) conflict key
-// never collides with a human pick's and repeated judge runs each persist.
-func skillOptABJudgeSourceURL(versionID string) string {
-	seq := atomic.AddUint64(&skillOptABPickSeq, 1)
-	return fmt.Sprintf("%s%s:judge#%d-%d", skillOptABRunIDPrefix, versionID, time.Now().UnixNano(), seq)
+// skillOptABJudgeSourceURL mints the judge's SourceURL, mirroring
+// skillOptABPickSourceURL but with a distinct :judge segment so the judge row's
+// (run_id,item_id,reviewer,source,source_url) conflict key never collides with a
+// human pick's and repeated judge runs each persist. It embeds the SAME
+// per-invocation comparison token as the human pick it was made alongside, which
+// is the join key the #344 agreement harness pairs the two verdicts on.
+func skillOptABJudgeSourceURL(versionID, comparisonToken string) string {
+	return fmt.Sprintf("%s%s:judge%s%s", skillOptABRunIDPrefix, versionID, skillOptABComparisonMarker, comparisonToken)
 }

--- a/internal/cli/skillopt_judge_agreement.go
+++ b/internal/cli/skillopt_judge_agreement.go
@@ -1,0 +1,465 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// `gitmoot skillopt judge agreement` (#344, MEASURE the judge) — the read-only
+// judge<->human agreement measurement harness. It joins the stored LLM-judge
+// verdicts against the stored HUMAN verdicts on the SAME items and reports
+// chance-corrected agreement, with Cohen's kappa as the HEADLINE metric (raw
+// agreement overstates judge quality because it does not correct for chance —
+// the epic's "Reliability without Validity" note).
+//
+// Two slices are measured:
+//
+//  1. PAIRWISE slice — Mode B A/B judge rows (source=skillopt-ab-judge, single
+//     judge or jury aggregate) joined per (run_id, item_id) against the human
+//     ranked rows (source=skillopt-ab, live-pairwise, markdown, github, ...)
+//     on the same item. This is the slice skillopt_ab.go explicitly defers as
+//     "NOT calibrated against human gold ... until a judge<->human agreement
+//     capture lands (#344)". Multiple rows per rater side collapse to a
+//     per-item MAJORITY verdict (ties are skipped and counted) so repeated
+//     picks never inflate N. It also runs the position-bias audit over judge
+//     rows carrying the recorded raw a|b pick: |P(pick=a) - 0.5|.
+//  2. CANDIDATE slice — the #345 skillopt_judge_outcomes capture (judge
+//     accept/reject vs human promote/reject), summarized here with the SAME
+//     kappa-headline framing; `skillopt judge-report` remains the full
+//     calibration view (confusion matrix, soft-score bands, dimensions).
+//
+// The command is off-by-default (it only runs when invoked), read-only over
+// the store, and changes no existing flow.
+
+// skillOptAgreementSmallNThreshold is the loud small-N caveat boundary: below
+// this many joined observations the numbers are reported but flagged as not
+// yet trustworthy. Sample size is the epic's own stated limiter (#344).
+const skillOptAgreementSmallNThreshold = 30
+
+// skillOptJudgeAgreementStats is one measured slice: N joined observations,
+// how many agreed, the raw agreement rate, and Cohen's kappa (the headline).
+// KappaDefined mirrors judge-report's degenerate-marginals stance: when chance
+// agreement pe == 1 (both raters used one identical label for every row),
+// kappa is 1.000 only if observed agreement is also perfect, otherwise
+// undefined — never a misleading 1.0.
+type skillOptJudgeAgreementStats struct {
+	N            int     `json:"n"`
+	Agreements   int     `json:"agreements"`
+	Agreement    float64 `json:"agreement"`
+	Kappa        float64 `json:"kappa"`
+	KappaDefined bool    `json:"kappa_defined"`
+	KappaNote    string  `json:"kappa_note,omitempty"`
+}
+
+// skillOptJudgeAgreementBreakdown is one keyed sub-slice (per human source or
+// per juror family) with its own stats.
+type skillOptJudgeAgreementBreakdown struct {
+	Key string `json:"key"`
+	skillOptJudgeAgreementStats
+}
+
+// skillOptJudgeAgreementPosition is the position-bias audit over judge/juror
+// rows that carry the recorded raw presented-position pick: P(pick=a) should
+// hover near 0.5 under the randomized label shuffle; a large |P(a) - 0.5| is
+// position bias ("Reliability without Validity": a stable-but-biased judge is
+// a failure mode, not a strength).
+type skillOptJudgeAgreementPosition struct {
+	N      int     `json:"n"`
+	PickA  int     `json:"pick_a"`
+	PPickA float64 `json:"p_pick_a"`
+	Bias   float64 `json:"bias"`
+}
+
+// skillOptJudgeAgreementPairwise is the pairwise-slice report.
+type skillOptJudgeAgreementPairwise struct {
+	skillOptJudgeAgreementStats
+	JudgeRows      int                               `json:"judge_rows"`
+	HumanRows      int                               `json:"human_rows"`
+	JurorRows      int                               `json:"juror_rows"`
+	TiesSkipped    int                               `json:"ties_skipped"`
+	PerSource      []skillOptJudgeAgreementBreakdown `json:"per_source,omitempty"`
+	PerJurorFamily []skillOptJudgeAgreementBreakdown `json:"per_juror_family,omitempty"`
+	Position       *skillOptJudgeAgreementPosition   `json:"position,omitempty"`
+}
+
+// skillOptJudgeAgreementReport is the full machine-readable report (--json).
+type skillOptJudgeAgreementReport struct {
+	Template        string                         `json:"template,omitempty"`
+	Pairwise        skillOptJudgeAgreementPairwise `json:"pairwise"`
+	Candidate       skillOptJudgeAgreementStats    `json:"candidate"`
+	SmallNThreshold int                            `json:"small_n_threshold"`
+	SmallNWarning   bool                           `json:"small_n_warning"`
+}
+
+func runSkillOptJudgeAgreement(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt judge agreement", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	templateID := fs.String("template", "", "template id to filter")
+	jsonOutput := fs.Bool("json", false, "print the report as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt judge agreement does not accept positional arguments")
+		return 2
+	}
+	var events []db.RankedFeedbackEventWithTemplate
+	var outcomes []db.SkillOptJudgeOutcome
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		events, err = store.ListRankedFeedbackEventsAcrossRuns(context.Background(), *templateID)
+		if err != nil {
+			return err
+		}
+		outcomes, err = store.ListSkillOptJudgeOutcomes(context.Background(), *templateID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt judge agreement: %v\n", err)
+		return 1
+	}
+	report := buildSkillOptJudgeAgreementReport(strings.TrimSpace(*templateID), events, outcomes)
+	if *jsonOutput {
+		encoded, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "skillopt judge agreement: encode report: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, string(encoded))
+		return 0
+	}
+	renderSkillOptJudgeAgreementReport(stdout, report)
+	return 0
+}
+
+// buildSkillOptJudgeAgreementReport computes the full report from the stored
+// rows. Pure over its inputs so the math is unit-testable with exact fixtures.
+func buildSkillOptJudgeAgreementReport(templateID string, events []db.RankedFeedbackEventWithTemplate, outcomes []db.SkillOptJudgeOutcome) skillOptJudgeAgreementReport {
+	report := skillOptJudgeAgreementReport{
+		Template:        templateID,
+		Pairwise:        buildSkillOptJudgeAgreementPairwise(events),
+		Candidate:       skillOptCandidateAgreementStats(outcomes),
+		SmallNThreshold: skillOptAgreementSmallNThreshold,
+	}
+	report.SmallNWarning = report.Pairwise.N < skillOptAgreementSmallNThreshold || report.Candidate.N < skillOptAgreementSmallNThreshold
+	return report
+}
+
+// skillOptAgreementRowKind classifies one ranked feedback row for the join.
+const (
+	skillOptAgreementRowJudge = "judge"
+	skillOptAgreementRowJuror = "juror"
+	skillOptAgreementRowHuman = "human"
+	skillOptAgreementRowOther = "other"
+)
+
+// classifySkillOptAgreementRow decides which rater a ranked feedback row
+// belongs to. Judge and juror rows are positively identified by their
+// dedicated source tags; every machine writer of ranked feedback today uses
+// one of the three machine sources (skillopt-ab-judge, skillopt-ab-juror,
+// auto-trace — the auto-trace source also covers the gitmoot-review
+// cross-family rubric rows, which ride the auto-trace run), so anything else
+// is a human verdict (skillopt-ab, live-pairwise, markdown, github, ...). The
+// auto-trace reviewer sentinel is ALSO excluded defensively in case a future
+// writer reuses the reviewer without the source.
+func classifySkillOptAgreementRow(event db.RankedFeedbackEvent) string {
+	switch event.Source {
+	case skillOptABJudgeSource:
+		return skillOptAgreementRowJudge
+	case skillOptABJurorSource:
+		return skillOptAgreementRowJuror
+	case skillopt.AutoTraceSource:
+		return skillOptAgreementRowOther
+	}
+	if event.Reviewer == skillopt.AutoTraceReviewer {
+		return skillOptAgreementRowOther
+	}
+	return skillOptAgreementRowHuman
+}
+
+// skillOptAgreementItem is the per-(run_id, item_id) join bucket: all judge,
+// juror, and human winner votes on one item.
+type skillOptAgreementItem struct {
+	judgeWinners []string
+	humanWinners []string
+	humanSources map[string][]string // human source -> winners from that source
+	jurorWinners map[string][]string // juror family -> winners from that family
+}
+
+// skillOptAgreementMajority collapses one side's votes to a single verdict:
+// the strictly-most-frequent winner label, or ok=false on a tie (the item is
+// skipped rather than resolved arbitrarily) or no votes.
+func skillOptAgreementMajority(winners []string) (string, bool) {
+	if len(winners) == 0 {
+		return "", false
+	}
+	counts := map[string]int{}
+	for _, winner := range winners {
+		counts[winner]++
+	}
+	best, bestCount, tied := "", 0, false
+	// Deterministic iteration so a tie is detected identically on every run.
+	labels := make([]string, 0, len(counts))
+	for label := range counts {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	for _, label := range labels {
+		switch {
+		case counts[label] > bestCount:
+			best, bestCount, tied = label, counts[label], false
+		case counts[label] == bestCount:
+			tied = true
+		}
+	}
+	if tied {
+		return "", false
+	}
+	return best, true
+}
+
+// skillOptAgreementStats computes raw agreement + multi-class Cohen's kappa
+// over paired (judge label, human label) observations. po is the observed
+// agreement; pe is the chance agreement from the two raters' label marginals;
+// kappa = (po - pe) / (1 - pe). Degenerate pe >= 1 (both raters used one
+// identical label everywhere) reports kappa=1 only when po is also perfect,
+// otherwise undefined — mirroring judge-report's stance.
+func skillOptAgreementStats(pairs [][2]string) skillOptJudgeAgreementStats {
+	stats := skillOptJudgeAgreementStats{N: len(pairs)}
+	if stats.N == 0 {
+		return stats
+	}
+	judgeMarginals := map[string]int{}
+	humanMarginals := map[string]int{}
+	for _, pair := range pairs {
+		if pair[0] == pair[1] {
+			stats.Agreements++
+		}
+		judgeMarginals[pair[0]]++
+		humanMarginals[pair[1]]++
+	}
+	total := float64(stats.N)
+	po := float64(stats.Agreements) / total
+	stats.Agreement = po
+	pe := 0.0
+	for label, judgeCount := range judgeMarginals {
+		pe += (float64(judgeCount) / total) * (float64(humanMarginals[label]) / total)
+	}
+	switch {
+	case pe < 1:
+		stats.Kappa = (po - pe) / (1 - pe)
+		stats.KappaDefined = true
+	case po >= 1:
+		stats.Kappa = 1
+		stats.KappaDefined = true
+	default:
+		stats.KappaNote = "degenerate: a rater used a single label"
+	}
+	return stats
+}
+
+// buildSkillOptJudgeAgreementPairwise runs the pairwise-slice join: bucket
+// rows by (run_id, item_id), collapse each side to its per-item majority,
+// pair judge-vs-human per item, then compute overall/per-source/per-juror
+// stats and the position audit.
+func buildSkillOptJudgeAgreementPairwise(events []db.RankedFeedbackEventWithTemplate) skillOptJudgeAgreementPairwise {
+	pairwise := skillOptJudgeAgreementPairwise{}
+	items := map[string]*skillOptAgreementItem{}
+	itemKeys := []string{}
+	position := skillOptJudgeAgreementPosition{}
+	positionSeen := false
+	for _, event := range events {
+		kind := classifySkillOptAgreementRow(event.RankedFeedbackEvent)
+		if kind == skillOptAgreementRowOther || strings.TrimSpace(event.Winner) == "" {
+			continue
+		}
+		key := event.RunID + "\x00" + event.ItemID
+		item := items[key]
+		if item == nil {
+			item = &skillOptAgreementItem{humanSources: map[string][]string{}, jurorWinners: map[string][]string{}}
+			items[key] = item
+			itemKeys = append(itemKeys, key)
+		}
+		switch kind {
+		case skillOptAgreementRowJudge:
+			pairwise.JudgeRows++
+			item.judgeWinners = append(item.judgeWinners, event.Winner)
+		case skillOptAgreementRowJuror:
+			pairwise.JurorRows++
+			family := strings.TrimPrefix(event.Reviewer, skillOptABJurorReviewerPrefix)
+			item.jurorWinners[family] = append(item.jurorWinners[family], event.Winner)
+		case skillOptAgreementRowHuman:
+			pairwise.HumanRows++
+			item.humanWinners = append(item.humanWinners, event.Winner)
+			item.humanSources[event.Source] = append(item.humanSources[event.Source], event.Winner)
+		}
+		// Position audit: any judge/juror row carrying a recorded raw pick.
+		if kind == skillOptAgreementRowJudge || kind == skillOptAgreementRowJuror {
+			if pick, ok := skillOptABJudgePickPosition(event.Reasoning); ok {
+				positionSeen = true
+				position.N++
+				if pick == "a" {
+					position.PickA++
+				}
+			}
+		}
+	}
+	sort.Strings(itemKeys)
+
+	var overallPairs [][2]string
+	sourcePairs := map[string][][2]string{}
+	jurorPairs := map[string][][2]string{}
+	for _, key := range itemKeys {
+		item := items[key]
+		humanWinner, humanOK := skillOptAgreementMajority(item.humanWinners)
+		judgeWinner, judgeOK := skillOptAgreementMajority(item.judgeWinners)
+		if len(item.humanWinners) > 0 && len(item.judgeWinners) > 0 && (!humanOK || !judgeOK) {
+			// The item HAS both verdicts but one side is internally tied: skip it
+			// loudly (counted) instead of resolving the tie arbitrarily.
+			pairwise.TiesSkipped++
+		}
+		if humanOK && judgeOK {
+			overallPairs = append(overallPairs, [2]string{judgeWinner, humanWinner})
+			// Per-source: compare the judge verdict against each contributing human
+			// source's OWN majority, so a per-source line reflects that source's
+			// reviewers only.
+			for source, winners := range item.humanSources {
+				if sourceWinner, ok := skillOptAgreementMajority(winners); ok {
+					sourcePairs[source] = append(sourcePairs[source], [2]string{judgeWinner, sourceWinner})
+				}
+			}
+		}
+		// Per-juror-family: each family's own majority against the human majority
+		// (independent of the aggregate judge verdict).
+		if humanOK {
+			for family, winners := range item.jurorWinners {
+				if jurorWinner, ok := skillOptAgreementMajority(winners); ok {
+					jurorPairs[family] = append(jurorPairs[family], [2]string{jurorWinner, humanWinner})
+				}
+			}
+		}
+	}
+
+	pairwise.skillOptJudgeAgreementStats = skillOptAgreementStats(overallPairs)
+	pairwise.PerSource = skillOptAgreementBreakdowns(sourcePairs)
+	pairwise.PerJurorFamily = skillOptAgreementBreakdowns(jurorPairs)
+	if positionSeen {
+		position.PPickA = float64(position.PickA) / float64(position.N)
+		position.Bias = math.Abs(position.PPickA - 0.5)
+		pairwise.Position = &position
+	}
+	return pairwise
+}
+
+// skillOptAgreementBreakdowns turns keyed pair sets into sorted breakdown rows.
+func skillOptAgreementBreakdowns(pairsByKey map[string][][2]string) []skillOptJudgeAgreementBreakdown {
+	if len(pairsByKey) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(pairsByKey))
+	for key := range pairsByKey {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	breakdowns := make([]skillOptJudgeAgreementBreakdown, 0, len(keys))
+	for _, key := range keys {
+		breakdowns = append(breakdowns, skillOptJudgeAgreementBreakdown{Key: key, skillOptJudgeAgreementStats: skillOptAgreementStats(pairsByKey[key])})
+	}
+	return breakdowns
+}
+
+// skillOptCandidateAgreementStats maps the #345 candidate-level judge outcomes
+// (accept/reject vs promote/reject directions) onto the same paired-label
+// stats, so the candidate slice's kappa is computed by the identical formula
+// as the pairwise slice (and matches judge-report's 2x2 kappa exactly).
+func skillOptCandidateAgreementStats(outcomes []db.SkillOptJudgeOutcome) skillOptJudgeAgreementStats {
+	var pairs [][2]string
+	for _, outcome := range outcomes {
+		switch outcome.Direction {
+		case db.SkillOptJudgeDirectionAgreeAccept:
+			pairs = append(pairs, [2]string{"accept", "accept"})
+		case db.SkillOptJudgeDirectionAgreeReject:
+			pairs = append(pairs, [2]string{"reject", "reject"})
+		case db.SkillOptJudgeDirectionJudgeAcceptHumanReject:
+			pairs = append(pairs, [2]string{"accept", "reject"})
+		case db.SkillOptJudgeDirectionJudgeRejectHumanAccept:
+			pairs = append(pairs, [2]string{"reject", "accept"})
+		}
+	}
+	return skillOptAgreementStats(pairs)
+}
+
+func skillOptAgreementKappaText(stats skillOptJudgeAgreementStats) string {
+	if stats.KappaDefined {
+		return fmt.Sprintf("%.3f", stats.Kappa)
+	}
+	if stats.KappaNote != "" {
+		return "n/a (" + stats.KappaNote + ")"
+	}
+	return "n/a"
+}
+
+func renderSkillOptJudgeAgreementReport(stdout io.Writer, report skillOptJudgeAgreementReport) {
+	writeLine(stdout, "judge <-> human agreement (#344 measure-the-judge)")
+	if report.Template != "" {
+		writeLine(stdout, "template: %s", report.Template)
+	}
+	writeLine(stdout, "")
+
+	pairwise := report.Pairwise
+	writeLine(stdout, "pairwise slice (A/B judge vs human ranked feedback, per-item majority join)")
+	writeLine(stdout, "  items joined: %d (judge rows: %d, human rows: %d, juror rows: %d, tied items skipped: %d)",
+		pairwise.N, pairwise.JudgeRows, pairwise.HumanRows, pairwise.JurorRows, pairwise.TiesSkipped)
+	if pairwise.N == 0 {
+		writeLine(stdout, "  no overlap yet: no item carries BOTH a judge verdict and a human verdict")
+	} else {
+		writeLine(stdout, "  cohen's kappa (headline): %s", skillOptAgreementKappaText(pairwise.skillOptJudgeAgreementStats))
+		writeLine(stdout, "  raw agreement: %.3f (%d/%d)", pairwise.Agreement, pairwise.Agreements, pairwise.N)
+	}
+	if len(pairwise.PerSource) > 0 {
+		writeLine(stdout, "  per human source:")
+		for _, breakdown := range pairwise.PerSource {
+			writeLine(stdout, "    %-16s N=%-4d kappa %-8s agreement %.3f (%d/%d)", breakdown.Key, breakdown.N, skillOptAgreementKappaText(breakdown.skillOptJudgeAgreementStats), breakdown.Agreement, breakdown.Agreements, breakdown.N)
+		}
+	}
+	if len(pairwise.PerJurorFamily) > 0 {
+		writeLine(stdout, "  per juror family (juror majority vs human majority):")
+		for _, breakdown := range pairwise.PerJurorFamily {
+			writeLine(stdout, "    %-16s N=%-4d kappa %-8s agreement %.3f (%d/%d)", breakdown.Key, breakdown.N, skillOptAgreementKappaText(breakdown.skillOptJudgeAgreementStats), breakdown.Agreement, breakdown.Agreements, breakdown.N)
+		}
+	}
+	if pairwise.Position != nil {
+		writeLine(stdout, "  position audit (judge/juror rows with a recorded raw pick):")
+		writeLine(stdout, "    N=%d  P(pick=a)=%.3f  position bias |P(a)-0.5|=%.3f", pairwise.Position.N, pairwise.Position.PPickA, pairwise.Position.Bias)
+	} else {
+		writeLine(stdout, "  position audit: no judge rows carry a recorded pick position yet (rows written before this capture are not measurable)")
+	}
+	writeLine(stdout, "")
+
+	candidate := report.Candidate
+	writeLine(stdout, "candidate slice (judge accept/reject vs human promote/reject — full calibration: `skillopt judge-report`)")
+	if candidate.N == 0 {
+		writeLine(stdout, "  no judge outcomes captured")
+	} else {
+		writeLine(stdout, "  N=%d  cohen's kappa (headline): %s  raw agreement: %.3f (%d/%d)", candidate.N, skillOptAgreementKappaText(candidate), candidate.Agreement, candidate.Agreements, candidate.N)
+	}
+	writeLine(stdout, "")
+
+	if report.SmallNWarning {
+		writeLine(stdout, "WARNING: small sample (pairwise N=%d, candidate N=%d; threshold %d): these numbers are NOT yet trustworthy — sample size is the limiter (#344). Accumulate more human picks/decisions before acting on them.",
+			pairwise.N, candidate.N, report.SmallNThreshold)
+	}
+}

--- a/internal/cli/skillopt_judge_agreement.go
+++ b/internal/cli/skillopt_judge_agreement.go
@@ -25,14 +25,27 @@ import (
 // Two slices are measured:
 //
 //  1. PAIRWISE slice — Mode B A/B judge rows (source=skillopt-ab-judge, single
-//     judge or jury aggregate) joined per (run_id, item_id) against the human
-//     ranked rows (source=skillopt-ab, live-pairwise, markdown, github, ...)
-//     on the same item. This is the slice skillopt_ab.go explicitly defers as
-//     "NOT calibrated against human gold ... until a judge<->human agreement
-//     capture lands (#344)". Multiple rows per rater side collapse to a
-//     per-item MAJORITY verdict (ties are skipped and counted) so repeated
-//     picks never inflate N. It also runs the position-bias audit over judge
-//     rows carrying the recorded raw a|b pick: |P(pick=a) - 0.5|.
+//     judge or jury aggregate) joined against the human ranked rows
+//     (source=skillopt-ab, live-pairwise, markdown, github, ...) on the SAME
+//     COMPARISON. For skillopt-ab runs the join key is (run_id, item_id,
+//     comparison_token): run_id is "skillopt-ab:<challengerVersion>" and
+//     item_id is always "ab", so (run_id, item_id) alone identifies the
+//     CHALLENGER, not the comparison — every repeated A/B of one challenger
+//     (its own prompt, freshly regenerated answers, its own shuffle, its own
+//     champion resolution) would pool into one bucket and pair judge verdicts
+//     against human verdicts made on DIFFERENT comparisons. The per-invocation
+//     token embedded in each row's SourceURL is what restores the true
+//     granularity; legacy skillopt-ab rows without it are EXCLUDED and counted
+//     loudly (unmeasurable — distinct from "no overlap yet") instead of being
+//     pooled. Rows on other run families keep the (run_id, item_id) join
+//     (there each item IS one comparison). This is the slice skillopt_ab.go
+//     explicitly defers as "NOT calibrated against human gold ... until a
+//     judge<->human agreement capture lands (#344)". Multiple rows per rater
+//     side within one comparison collapse to a MAJORITY verdict (ties are
+//     skipped and counted) so true re-votes never inflate N. It also runs the
+//     position-bias audit over judge rows carrying the recorded raw a|b pick
+//     (see skillOptJudgeAgreementPosition for the assignment-corrected
+//     estimator).
 //  2. CANDIDATE slice — the #345 skillopt_judge_outcomes capture (judge
 //     accept/reject vs human promote/reject), summarized here with the SAME
 //     kappa-headline framing; `skillopt judge-report` remains the full
@@ -69,27 +82,55 @@ type skillOptJudgeAgreementBreakdown struct {
 }
 
 // skillOptJudgeAgreementPosition is the position-bias audit over judge/juror
-// rows that carry the recorded raw presented-position pick: P(pick=a) should
-// hover near 0.5 under the randomized label shuffle; a large |P(a) - 0.5| is
-// position bias ("Reliability without Validity": a stable-but-biased judge is
-// a failure mode, not a strength).
+// rows that carry the recorded raw presented-position pick ("Reliability
+// without Validity": a stable-but-biased judge is a failure mode, not a
+// strength).
+//
+// Raw |P(pick=a) - 0.5| is only a bias measure when the position ASSIGNMENT is
+// balanced — under a fixed --seed (a documented flag; seed 0 pins the champion
+// at Option A on every run) it reports the judge's genuine CONTENT preference
+// as "position bias". The champion's presented position IS recoverable per row
+// (champion was at Option A iff (Winner==champion) == (pick=="a"), because the
+// stored Winner was unblinded through that same mapping), so the audit
+// stratifies by it:
+//
+//	Bias = |(P(pick=a | champion at A) + P(pick=a | champion at B) - 1) / 2|
+//
+// For a content-only judge with champion-preference p the two conditionals are
+// p and 1-p, so the estimate is 0 regardless of the assignment split; a judge
+// that always picks Option A scores 0.5; and under a perfectly balanced
+// assignment the estimate equals the old |P(pick=a) - 0.5| exactly. When every
+// measured row presented the champion at the SAME position (e.g. a fixed
+// --seed) one stratum is empty and the bias is reported as UNDEFINED
+// (BiasDefined=false, mirroring the kappa degenerate-marginals stance) instead
+// of a fabricated number. PChampionA (the assignment split) is always reported
+// alongside P(pick=a) so a skewed shuffle is visible at a glance.
 type skillOptJudgeAgreementPosition struct {
-	N      int     `json:"n"`
-	PickA  int     `json:"pick_a"`
-	PPickA float64 `json:"p_pick_a"`
-	Bias   float64 `json:"bias"`
+	N           int     `json:"n"`
+	PickA       int     `json:"pick_a"`
+	PPickA      float64 `json:"p_pick_a"`
+	ChampionA   int     `json:"champion_a"`
+	PChampionA  float64 `json:"p_champion_a"`
+	Bias        float64 `json:"bias"`
+	BiasDefined bool    `json:"bias_defined"`
+	BiasNote    string  `json:"bias_note,omitempty"`
 }
 
 // skillOptJudgeAgreementPairwise is the pairwise-slice report.
+// LegacyRowsExcluded counts skillopt-ab rows written BEFORE the per-comparison
+// token existed: their (run_id, item_id) is the challenger, not the comparison,
+// so they cannot be joined truthfully and are excluded loudly (unmeasurable —
+// a different condition than "no overlap yet") rather than pooled.
 type skillOptJudgeAgreementPairwise struct {
 	skillOptJudgeAgreementStats
-	JudgeRows      int                               `json:"judge_rows"`
-	HumanRows      int                               `json:"human_rows"`
-	JurorRows      int                               `json:"juror_rows"`
-	TiesSkipped    int                               `json:"ties_skipped"`
-	PerSource      []skillOptJudgeAgreementBreakdown `json:"per_source,omitempty"`
-	PerJurorFamily []skillOptJudgeAgreementBreakdown `json:"per_juror_family,omitempty"`
-	Position       *skillOptJudgeAgreementPosition   `json:"position,omitempty"`
+	JudgeRows          int                               `json:"judge_rows"`
+	HumanRows          int                               `json:"human_rows"`
+	JurorRows          int                               `json:"juror_rows"`
+	TiesSkipped        int                               `json:"ties_skipped"`
+	LegacyRowsExcluded int                               `json:"legacy_rows_excluded"`
+	PerSource          []skillOptJudgeAgreementBreakdown `json:"per_source,omitempty"`
+	PerJurorFamily     []skillOptJudgeAgreementBreakdown `json:"per_juror_family,omitempty"`
+	Position           *skillOptJudgeAgreementPosition   `json:"position,omitempty"`
 }
 
 // skillOptJudgeAgreementReport is the full machine-readable report (--json).
@@ -190,8 +231,10 @@ func classifySkillOptAgreementRow(event db.RankedFeedbackEvent) string {
 	return skillOptAgreementRowHuman
 }
 
-// skillOptAgreementItem is the per-(run_id, item_id) join bucket: all judge,
-// juror, and human winner votes on one item.
+// skillOptAgreementItem is the per-comparison join bucket — keyed by
+// (run_id, item_id, comparison_token) for skillopt-ab runs and by
+// (run_id, item_id) elsewhere: all judge, juror, and human winner votes on ONE
+// comparison.
 type skillOptAgreementItem struct {
 	judgeWinners []string
 	humanWinners []string
@@ -272,21 +315,61 @@ func skillOptAgreementStats(pairs [][2]string) skillOptJudgeAgreementStats {
 }
 
 // buildSkillOptJudgeAgreementPairwise runs the pairwise-slice join: bucket
-// rows by (run_id, item_id), collapse each side to its per-item majority,
-// pair judge-vs-human per item, then compute overall/per-source/per-juror
-// stats and the position audit.
+// rows by comparison — (run_id, item_id, comparison_token) for skillopt-ab
+// runs (where run/item alone is the challenger, not the comparison), plain
+// (run_id, item_id) elsewhere — collapse each side to its per-comparison
+// majority, pair judge-vs-human per comparison, then compute
+// overall/per-source/per-juror stats and the position audit. Legacy
+// skillopt-ab rows without a comparison token are excluded and counted, never
+// pooled. The position audit is PER ROW (a judge row's presented pick and
+// recovered champion position are valid measurements whether or not the row
+// joins a human verdict), so it runs before the join-eligibility check.
 func buildSkillOptJudgeAgreementPairwise(events []db.RankedFeedbackEventWithTemplate) skillOptJudgeAgreementPairwise {
 	pairwise := skillOptJudgeAgreementPairwise{}
 	items := map[string]*skillOptAgreementItem{}
 	itemKeys := []string{}
 	position := skillOptJudgeAgreementPosition{}
 	positionSeen := false
+	positionPickAChampionA := 0
 	for _, event := range events {
 		kind := classifySkillOptAgreementRow(event.RankedFeedbackEvent)
 		if kind == skillOptAgreementRowOther || strings.TrimSpace(event.Winner) == "" {
 			continue
 		}
+		// Position audit: any judge/juror row carrying a recorded raw pick whose
+		// Winner is one of the two role labels (which is what makes the champion's
+		// presented position recoverable: champion at A iff the unblinded winner
+		// and the raw pick point the same way).
+		if kind == skillOptAgreementRowJudge || kind == skillOptAgreementRowJuror {
+			if pick, ok := skillOptABJudgePickPosition(event.Reasoning); ok &&
+				(event.Winner == skillOptABChampionLabel || event.Winner == skillOptABChallengerLabel) {
+				positionSeen = true
+				position.N++
+				championAtA := (event.Winner == skillOptABChampionLabel) == (pick == "a")
+				if pick == "a" {
+					position.PickA++
+				}
+				if championAtA {
+					position.ChampionA++
+					if pick == "a" {
+						positionPickAChampionA++
+					}
+				}
+			}
+		}
 		key := event.RunID + "\x00" + event.ItemID
+		if strings.HasPrefix(event.RunID, skillOptABRunIDPrefix) {
+			// skillopt-ab runs: (run_id, item_id) is the CHALLENGER (item is always
+			// "ab"), so the per-invocation comparison token is REQUIRED to identify
+			// the comparison. A tokenless row is a legacy row: unmeasurable, counted,
+			// and never pooled with other comparisons of the same challenger.
+			token, ok := skillOptABComparisonTokenFromSourceURL(event.SourceURL)
+			if !ok {
+				pairwise.LegacyRowsExcluded++
+				continue
+			}
+			key += "\x00" + token
+		}
 		item := items[key]
 		if item == nil {
 			item = &skillOptAgreementItem{humanSources: map[string][]string{}, jurorWinners: map[string][]string{}}
@@ -305,16 +388,6 @@ func buildSkillOptJudgeAgreementPairwise(events []db.RankedFeedbackEventWithTemp
 			pairwise.HumanRows++
 			item.humanWinners = append(item.humanWinners, event.Winner)
 			item.humanSources[event.Source] = append(item.humanSources[event.Source], event.Winner)
-		}
-		// Position audit: any judge/juror row carrying a recorded raw pick.
-		if kind == skillOptAgreementRowJudge || kind == skillOptAgreementRowJuror {
-			if pick, ok := skillOptABJudgePickPosition(event.Reasoning); ok {
-				positionSeen = true
-				position.N++
-				if pick == "a" {
-					position.PickA++
-				}
-			}
 		}
 	}
 	sort.Strings(itemKeys)
@@ -358,7 +431,22 @@ func buildSkillOptJudgeAgreementPairwise(events []db.RankedFeedbackEventWithTemp
 	pairwise.PerJurorFamily = skillOptAgreementBreakdowns(jurorPairs)
 	if positionSeen {
 		position.PPickA = float64(position.PickA) / float64(position.N)
-		position.Bias = math.Abs(position.PPickA - 0.5)
+		position.PChampionA = float64(position.ChampionA) / float64(position.N)
+		// Assignment-corrected position bias (see skillOptJudgeAgreementPosition):
+		// stratify P(pick=a) by the champion's recovered presented position so a
+		// content preference under a skewed assignment (e.g. a fixed --seed pinning
+		// the champion at Option A) is never reported as position bias. With an
+		// empty stratum the bias is UNDEFINED — reported as such, never fabricated.
+		championAtA := position.ChampionA
+		championAtB := position.N - position.ChampionA
+		if championAtA > 0 && championAtB > 0 {
+			pPickAChampionA := float64(positionPickAChampionA) / float64(championAtA)
+			pPickAChampionB := float64(position.PickA-positionPickAChampionA) / float64(championAtB)
+			position.Bias = math.Abs((pPickAChampionA + pPickAChampionB - 1) / 2)
+			position.BiasDefined = true
+		} else {
+			position.BiasNote = "degenerate position assignment: the champion was presented at the same position in every measured row (e.g. a fixed --seed pins the shuffle), so position bias cannot be separated from content preference"
+		}
 		pairwise.Position = &position
 	}
 	return pairwise
@@ -420,11 +508,14 @@ func renderSkillOptJudgeAgreementReport(stdout io.Writer, report skillOptJudgeAg
 	writeLine(stdout, "")
 
 	pairwise := report.Pairwise
-	writeLine(stdout, "pairwise slice (A/B judge vs human ranked feedback, per-item majority join)")
-	writeLine(stdout, "  items joined: %d (judge rows: %d, human rows: %d, juror rows: %d, tied items skipped: %d)",
+	writeLine(stdout, "pairwise slice (A/B judge vs human ranked feedback, per-comparison majority join)")
+	writeLine(stdout, "  comparisons joined: %d (judge rows: %d, human rows: %d, juror rows: %d, tied comparisons skipped: %d)",
 		pairwise.N, pairwise.JudgeRows, pairwise.HumanRows, pairwise.JurorRows, pairwise.TiesSkipped)
+	if pairwise.LegacyRowsExcluded > 0 {
+		writeLine(stdout, "  legacy rows excluded: %d (written before the per-comparison token; unmeasurable — these cannot be joined truthfully and are NEVER pooled by challenger)", pairwise.LegacyRowsExcluded)
+	}
 	if pairwise.N == 0 {
-		writeLine(stdout, "  no overlap yet: no item carries BOTH a judge verdict and a human verdict")
+		writeLine(stdout, "  no overlap yet: no comparison carries BOTH a judge verdict and a human verdict")
 	} else {
 		writeLine(stdout, "  cohen's kappa (headline): %s", skillOptAgreementKappaText(pairwise.skillOptJudgeAgreementStats))
 		writeLine(stdout, "  raw agreement: %.3f (%d/%d)", pairwise.Agreement, pairwise.Agreements, pairwise.N)
@@ -443,7 +534,11 @@ func renderSkillOptJudgeAgreementReport(stdout io.Writer, report skillOptJudgeAg
 	}
 	if pairwise.Position != nil {
 		writeLine(stdout, "  position audit (judge/juror rows with a recorded raw pick):")
-		writeLine(stdout, "    N=%d  P(pick=a)=%.3f  position bias |P(a)-0.5|=%.3f", pairwise.Position.N, pairwise.Position.PPickA, pairwise.Position.Bias)
+		if pairwise.Position.BiasDefined {
+			writeLine(stdout, "    N=%d  P(pick=a)=%.3f  P(option A=champion)=%.3f  position bias=%.3f (assignment-corrected)", pairwise.Position.N, pairwise.Position.PPickA, pairwise.Position.PChampionA, pairwise.Position.Bias)
+		} else {
+			writeLine(stdout, "    N=%d  P(pick=a)=%.3f  P(option A=champion)=%.3f  position bias: n/a (%s)", pairwise.Position.N, pairwise.Position.PPickA, pairwise.Position.PChampionA, pairwise.Position.BiasNote)
+		}
 	} else {
 		writeLine(stdout, "  position audit: no judge rows carry a recorded pick position yet (rows written before this capture are not measurable)")
 	}

--- a/internal/cli/skillopt_judge_agreement_test.go
+++ b/internal/cli/skillopt_judge_agreement_test.go
@@ -173,6 +173,169 @@ func TestBuildSkillOptJudgeAgreementPairwiseMajorityAndTies(t *testing.T) {
 	if pairwise.HumanRows != 5 || pairwise.JudgeRows != 3 {
 		t.Fatalf("human rows = %d judge rows = %d, want 5 and 3", pairwise.HumanRows, pairwise.JudgeRows)
 	}
+	if pairwise.LegacyRowsExcluded != 0 {
+		t.Fatalf("legacy rows excluded = %d, want 0 (non-skillopt-ab runs need no comparison token)", pairwise.LegacyRowsExcluded)
+	}
+}
+
+// TestSkillOptABComparisonTokenRoundTrip pins the per-comparison join channel:
+// all three writers (human pick, judge, juror) embed the SAME invocation token
+// and the extractor recovers it; legacy pre-token SourceURLs (the old per-row
+// "#<nano>-<seq>" suffixes) must NOT parse — they are the unmeasurable rows the
+// agreement harness excludes instead of pooling.
+func TestSkillOptABComparisonTokenRoundTrip(t *testing.T) {
+	token := skillOptABComparisonToken()
+	if strings.TrimSpace(token) == "" {
+		t.Fatal("comparison token is empty")
+	}
+	if second := skillOptABComparisonToken(); second == token {
+		t.Fatalf("two invocations minted the same comparison token %q", token)
+	}
+	for name, url := range map[string]string{
+		"human pick": skillOptABPickSourceURL("planner@v2", token),
+		"judge":      skillOptABJudgeSourceURL("planner@v2", token),
+		"juror":      skillOptABJurorSourceURL("planner@v2", "claude", token),
+	} {
+		got, ok := skillOptABComparisonTokenFromSourceURL(url)
+		if !ok || got != token {
+			t.Fatalf("%s url %q -> token %q ok=%v, want %q", name, url, got, ok, token)
+		}
+	}
+	for _, legacy := range []string{
+		"skillopt-ab:planner@v2#1750000000000-1",
+		"skillopt-ab:planner@v2:judge#1750000000000-2",
+		"skillopt-ab:planner@v2:juror:claude#1750000000000-3",
+		"",
+		"skillopt-ab:planner@v2#cmp:",
+	} {
+		if got, ok := skillOptABComparisonTokenFromSourceURL(legacy); ok {
+			t.Fatalf("legacy url %q parsed to token %q, want unmeasurable", legacy, got)
+		}
+	}
+}
+
+// TestBuildSkillOptJudgeAgreementPairwisePerComparisonAndLegacy pins the
+// cross-item-contamination fix at the unit level: on a skillopt-ab run the
+// bucket is (run_id, item_id, comparison_token) — two comparisons of the SAME
+// challenger stay two observations (the old (run_id, item_id) pooling would
+// collapse all six rows below to N=1 agreements=0 by comparing side
+// majorities across different comparisons) — and legacy tokenless rows are
+// excluded and counted, never pooled.
+func TestBuildSkillOptJudgeAgreementPairwisePerComparisonAndLegacy(t *testing.T) {
+	event := func(winner, reviewer, source, sourceURL string) db.RankedFeedbackEventWithTemplate {
+		return db.RankedFeedbackEventWithTemplate{
+			RankedFeedbackEvent: db.RankedFeedbackEvent{RunID: "skillopt-ab:planner@v2", ItemID: "ab", Winner: winner, Reviewer: reviewer, Source: source, SourceURL: sourceURL},
+			TemplateID:          "planner",
+		}
+	}
+	events := []db.RankedFeedbackEventWithTemplate{
+		// Comparison c1: judge and human agree (champion).
+		event("champion", "human", "skillopt-ab", "skillopt-ab:planner@v2#cmp:c1"),
+		event("champion", "skillopt-ab-judge", "skillopt-ab-judge", "skillopt-ab:planner@v2:judge#cmp:c1"),
+		// Comparison c2 (same run, same item id): judge and human disagree —
+		// its OWN observation, never merged into c1's bucket.
+		event("challenger", "human", "skillopt-ab", "skillopt-ab:planner@v2#cmp:c2"),
+		event("champion", "skillopt-ab-judge", "skillopt-ab-judge", "skillopt-ab:planner@v2:judge#cmp:c2"),
+		// Legacy rows (pre-token per-row suffixes): unmeasurable, excluded, counted.
+		event("challenger", "human", "skillopt-ab", "skillopt-ab:planner@v2#1750000000000-1"),
+		event("challenger", "skillopt-ab-judge", "skillopt-ab-judge", "skillopt-ab:planner@v2:judge#1750000000000-2"),
+	}
+	pairwise := buildSkillOptJudgeAgreementPairwise(events)
+	if pairwise.N != 2 || pairwise.Agreements != 1 {
+		t.Fatalf("N=%d agreements=%d, want 2/1 (per-comparison buckets; pooled join would give 1/0)", pairwise.N, pairwise.Agreements)
+	}
+	if pairwise.LegacyRowsExcluded != 2 {
+		t.Fatalf("legacy rows excluded = %d, want 2", pairwise.LegacyRowsExcluded)
+	}
+	if pairwise.JudgeRows != 2 || pairwise.HumanRows != 2 {
+		t.Fatalf("judge rows = %d human rows = %d, want 2 and 2 (legacy rows never enter the join)", pairwise.JudgeRows, pairwise.HumanRows)
+	}
+}
+
+// TestBuildSkillOptJudgeAgreementPositionAssignmentCorrected pins the
+// position-bias estimator's two key properties under an IMBALANCED (3:1) but
+// non-degenerate position assignment, where the raw |P(pick=a) - 0.5| would
+// fabricate a bias for a content-driven judge:
+//
+//   - a purely content-driven judge (always picks the champion, wherever it is
+//     presented) measures bias 0 even though P(pick=a)=0.75;
+//   - a purely position-driven judge (always picks Option A) measures the full
+//     0.5 bias.
+//
+// The champion's presented position is recovered per row from the unblinded
+// Winner and the recorded raw pick: champion at A iff (Winner==champion) ==
+// (pick=="a").
+func TestBuildSkillOptJudgeAgreementPositionAssignmentCorrected(t *testing.T) {
+	judgeRow := func(winner, pick, sourceURL string) db.RankedFeedbackEventWithTemplate {
+		return db.RankedFeedbackEventWithTemplate{
+			RankedFeedbackEvent: db.RankedFeedbackEvent{
+				RunID:     "skillopt-ab:planner@v2",
+				ItemID:    "ab",
+				Winner:    winner,
+				Reviewer:  "skillopt-ab-judge",
+				Source:    "skillopt-ab-judge",
+				SourceURL: sourceURL,
+				Reasoning: skillOptABJudgePickPositionJSON(pick),
+			},
+			TemplateID: "planner",
+		}
+	}
+	t.Run("content-driven judge measures zero bias", func(t *testing.T) {
+		events := []db.RankedFeedbackEventWithTemplate{
+			// Champion at A on three comparisons (pick a = champion)...
+			judgeRow("champion", "a", "skillopt-ab:planner@v2:judge#cmp:c1"),
+			judgeRow("champion", "a", "skillopt-ab:planner@v2:judge#cmp:c2"),
+			judgeRow("champion", "a", "skillopt-ab:planner@v2:judge#cmp:c3"),
+			// ...champion at B on one (pick b = champion): same content preference.
+			judgeRow("champion", "b", "skillopt-ab:planner@v2:judge#cmp:c4"),
+		}
+		position := buildSkillOptJudgeAgreementPairwise(events).Position
+		if position == nil {
+			t.Fatal("position audit missing")
+		}
+		if position.N != 4 || position.PickA != 3 || position.PPickA != 0.75 {
+			t.Fatalf("position = %+v, want N=4 pick_a=3 p_pick_a=0.75", position)
+		}
+		if position.ChampionA != 3 || position.PChampionA != 0.75 {
+			t.Fatalf("position = %+v, want champion_a=3 p_champion_a=0.75", position)
+		}
+		if !position.BiasDefined || position.Bias != 0 {
+			t.Fatalf("position = %+v, want DEFINED bias 0 (raw |P(a)-0.5| would fabricate 0.25)", position)
+		}
+	})
+	t.Run("position-driven judge measures full bias", func(t *testing.T) {
+		events := []db.RankedFeedbackEventWithTemplate{
+			// Same 3:1 assignment; the judge always picks Option A regardless of
+			// which role is presented there.
+			judgeRow("champion", "a", "skillopt-ab:planner@v2:judge#cmp:c1"),
+			judgeRow("champion", "a", "skillopt-ab:planner@v2:judge#cmp:c2"),
+			judgeRow("champion", "a", "skillopt-ab:planner@v2:judge#cmp:c3"),
+			judgeRow("challenger", "a", "skillopt-ab:planner@v2:judge#cmp:c4"),
+		}
+		position := buildSkillOptJudgeAgreementPairwise(events).Position
+		if position == nil {
+			t.Fatal("position audit missing")
+		}
+		if !position.BiasDefined || position.Bias != 0.5 {
+			t.Fatalf("position = %+v, want DEFINED bias 0.5 (always-pick-A)", position)
+		}
+	})
+	t.Run("single-position assignment is undefined", func(t *testing.T) {
+		events := []db.RankedFeedbackEventWithTemplate{
+			judgeRow("champion", "a", "skillopt-ab:planner@v2:judge#cmp:c1"),
+			judgeRow("challenger", "b", "skillopt-ab:planner@v2:judge#cmp:c2"),
+		}
+		position := buildSkillOptJudgeAgreementPairwise(events).Position
+		if position == nil {
+			t.Fatal("position audit missing")
+		}
+		if position.ChampionA != 2 || position.PChampionA != 1.0 {
+			t.Fatalf("position = %+v, want champion_a=2 (both rows presented the champion at A)", position)
+		}
+		if position.BiasDefined || position.BiasNote == "" {
+			t.Fatalf("position = %+v, want UNDEFINED bias with a degenerate-assignment note", position)
+		}
+	})
 }
 
 // multiChallengerABFixture builds on skillOptABFixture with three MORE pending
@@ -220,36 +383,44 @@ func settableSkillOptABJudgeFake(t *testing.T) *string {
 // --judge` rounds through the REAL command path (real store writes, real
 // shuffle/unblinding, real judge + human row recording — only the LLM Deliver
 // seams are fakes), engineered so the judge agrees with the human on exactly
-// 3 of 4 items, then runs the REAL `skillopt judge agreement` CLI and asserts
-// the hand-computed numbers EXACTLY:
+// 3 of 4 comparisons, then runs the REAL `skillopt judge agreement` CLI and
+// asserts the hand-computed numbers EXACTLY:
 //
 //	agreement = 3/4 = 0.750
 //	kappa     = (0.75 - 0.5) / (1 - 0.5) = 0.500
 //	          (judge marginals champion=3/challenger=1; human 2/2 -> pe=0.5)
-//	position  = picks a,a,b,a -> P(a)=0.750, bias 0.250
+//	position  = picks a,a,b,a with the champion presented at A on rounds 1-2
+//	          (seed 0) and at B on rounds 3-4 (seed 1):
+//	          P(pick=a)=0.750, P(option A=champion)=0.500,
+//	          P(pick=a|champion at A)=1.0, P(pick=a|champion at B)=0.5
+//	          -> assignment-corrected bias |(1.0+0.5-1)/2| = 0.250 (defined)
 //
 // Any break in the judge-row/human-row join (wrong field, wrong source tag,
-// wrong unblinding) shifts these exact numbers and turns the test red.
+// wrong unblinding, wrong comparison token) shifts these exact numbers and
+// turns the test red.
 func TestSkillOptJudgeAgreementE2EMeasuresKnownAgreement(t *testing.T) {
 	home, _, challengers := multiChallengerABFixture(t)
 	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
 	judgeRaw := settableSkillOptABJudgeFake(t)
 
-	// All rounds use --seed 0 (no swap): Option A=champion, Option B=challenger.
+	// The seed pins the label shuffle: seed 0 -> no swap (Option A=champion),
+	// seed 1 -> swap (Option A=challenger). Mixing both makes the position
+	// assignment balanced, so the assignment-corrected bias is DEFINED.
 	rounds := []struct {
+		seed      string // label-shuffle seed: 0=champion at A, 1=champion at B
 		judgePick string // raw position the judge returns
 		humanPick string // raw position the human picks
 	}{
-		{"a", "a"}, // both champion -> agree
-		{"a", "a"}, // both champion -> agree
-		{"b", "b"}, // both challenger -> agree
-		{"a", "b"}, // judge champion vs human challenger -> disagree
+		{"0", "a", "a"}, // champion at A: both pick champion -> agree
+		{"0", "a", "b"}, // champion at A: judge champion vs human challenger -> disagree
+		{"1", "b", "b"}, // champion at B: both pick champion -> agree
+		{"1", "a", "a"}, // champion at B: both pick challenger -> agree
 	}
 	for index, round := range rounds {
 		*judgeRaw = fmt.Sprintf(`{"pick":%q}`, round.judgePick)
 		var stdout, stderr bytes.Buffer
 		code := runSkillOptAB([]string{"planner-bot", "Plan the migration.", "--home", home,
-			"--challenger", challengers[index], "--pick", round.humanPick, "--seed", "0", "--judge"}, &stdout, &stderr)
+			"--challenger", challengers[index], "--pick", round.humanPick, "--seed", round.seed, "--judge"}, &stdout, &stderr)
 		if code != 0 {
 			t.Fatalf("round %d: runSkillOptAB exit = %d, stderr: %s", index+1, code, stderr.String())
 		}
@@ -277,14 +448,23 @@ func TestSkillOptJudgeAgreementE2EMeasuresKnownAgreement(t *testing.T) {
 	if report.Pairwise.JudgeRows != 4 || report.Pairwise.HumanRows != 4 || report.Pairwise.TiesSkipped != 0 {
 		t.Fatalf("rows judge=%d human=%d ties=%d, want 4/4/0", report.Pairwise.JudgeRows, report.Pairwise.HumanRows, report.Pairwise.TiesSkipped)
 	}
+	if report.Pairwise.LegacyRowsExcluded != 0 {
+		t.Fatalf("legacy rows excluded = %d, want 0 (every row was written with a comparison token)", report.Pairwise.LegacyRowsExcluded)
+	}
 	if len(report.Pairwise.PerSource) != 1 || report.Pairwise.PerSource[0].Key != skillOptABSource || report.Pairwise.PerSource[0].N != 4 {
 		t.Fatalf("per-source breakdown = %+v, want a single skillopt-ab entry with N=4", report.Pairwise.PerSource)
 	}
 	if report.Pairwise.Position == nil {
 		t.Fatalf("position audit missing: the judge rows must carry recorded picks\n%s", stdout.String())
 	}
-	if report.Pairwise.Position.N != 4 || report.Pairwise.Position.PickA != 3 || report.Pairwise.Position.PPickA != 0.75 || report.Pairwise.Position.Bias != 0.25 {
-		t.Fatalf("position audit = %+v, want N=4 pick_a=3 p=0.75 bias=0.25", report.Pairwise.Position)
+	if report.Pairwise.Position.N != 4 || report.Pairwise.Position.PickA != 3 || report.Pairwise.Position.PPickA != 0.75 {
+		t.Fatalf("position audit = %+v, want N=4 pick_a=3 p=0.75", report.Pairwise.Position)
+	}
+	if report.Pairwise.Position.ChampionA != 2 || report.Pairwise.Position.PChampionA != 0.5 {
+		t.Fatalf("position assignment = %+v, want champion_a=2 p_champion_a=0.5 (seeds 0,0,1,1)", report.Pairwise.Position)
+	}
+	if !report.Pairwise.Position.BiasDefined || report.Pairwise.Position.Bias != 0.25 {
+		t.Fatalf("position bias = %+v, want defined assignment-corrected bias 0.25", report.Pairwise.Position)
 	}
 	if report.Candidate.N != 0 {
 		t.Fatalf("candidate N = %d, want 0 (no judge outcomes seeded)", report.Candidate.N)
@@ -305,16 +485,119 @@ func TestSkillOptJudgeAgreementE2EMeasuresKnownAgreement(t *testing.T) {
 	for _, want := range []string{
 		"judge <-> human agreement (#344 measure-the-judge)",
 		"pairwise slice",
-		"items joined: 4 (judge rows: 4, human rows: 4, juror rows: 0, tied items skipped: 0)",
+		"comparisons joined: 4 (judge rows: 4, human rows: 4, juror rows: 0, tied comparisons skipped: 0)",
 		"cohen's kappa (headline): 0.500",
 		"raw agreement: 0.750 (3/4)",
 		"per human source:",
 		"skillopt-ab",
 		"position audit",
-		"N=4  P(pick=a)=0.750  position bias |P(a)-0.5|=0.250",
+		"N=4  P(pick=a)=0.750  P(option A=champion)=0.500  position bias=0.250 (assignment-corrected)",
 		"candidate slice",
 		"no judge outcomes captured",
 		"WARNING: small sample (pairwise N=4, candidate N=0; threshold 30)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("text output missing %q\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "legacy rows excluded") {
+		t.Fatalf("text output reports excluded legacy rows on an all-token store\n%s", output)
+	}
+}
+
+// TestSkillOptJudgeAgreementE2EJoinsPerComparisonNotPerChallenger is the
+// regression E2E for the cross-item-contamination bug: (run_id, item_id) alone
+// is the CHALLENGER (run "skillopt-ab:<version>", item always "ab"), so
+// repeated A/B rounds against the SAME challenger used to pool into ONE bucket
+// and compare side majorities across DIFFERENT comparisons. Three real
+// `skillopt ab --judge --pick` rounds against the same challenger, judge
+// agreeing with the human on exactly 2 of 3 comparisons, used to report N=1,
+// agreement=0.000 (the two side majorities disagreed) — a confident number
+// computed over fabricated pairings. With the per-invocation comparison token
+// the harness must report the true per-comparison numbers:
+//
+//	N = 3, agreement = 2/3
+//	kappa: judge marginals champion=2/challenger=1, human 1/2
+//	       -> pe = (2*1 + 1*2)/9 = 4/9, kappa = (2/3 - 4/9)/(5/9) = 0.4
+//
+// All rounds use --seed 0, which pins the champion at Option A on every run —
+// so this E2E ALSO pins the position audit's degenerate-assignment stance: a
+// fixed seed makes position bias unmeasurable (undefined), never a fabricated
+// |P(pick=a) - 0.5| that actually reflects content preference.
+func TestSkillOptJudgeAgreementE2EJoinsPerComparisonNotPerChallenger(t *testing.T) {
+	home, _, _, _ := skillOptABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	judgeRaw := settableSkillOptABJudgeFake(t)
+
+	// Same (sole pending) challenger every round; seed 0 -> champion at A.
+	rounds := []struct {
+		judgePick string
+		humanPick string
+	}{
+		{"a", "a"}, // both champion -> agree
+		{"b", "b"}, // both challenger -> agree
+		{"a", "b"}, // judge champion vs human challenger -> disagree
+	}
+	for index, round := range rounds {
+		*judgeRaw = fmt.Sprintf(`{"pick":%q}`, round.judgePick)
+		var stdout, stderr bytes.Buffer
+		code := runSkillOptAB([]string{"planner-bot", fmt.Sprintf("Plan step %d.", index+1), "--home", home,
+			"--pick", round.humanPick, "--seed", "0", "--judge"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("round %d: runSkillOptAB exit = %d, stderr: %s", index+1, code, stderr.String())
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge", "agreement", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt judge agreement exit = %d, stderr: %s", code, stderr.String())
+	}
+	var report skillOptJudgeAgreementReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	// The old pooled join reported N=1 agreements=0 for this exact scenario.
+	if report.Pairwise.N != 3 || report.Pairwise.Agreements != 2 {
+		t.Fatalf("pairwise N=%d agreements=%d, want 3 and 2 (per-comparison join, not per-challenger pooling)\n%s",
+			report.Pairwise.N, report.Pairwise.Agreements, stdout.String())
+	}
+	if math.Abs(report.Pairwise.Agreement-2.0/3.0) > 1e-9 {
+		t.Fatalf("pairwise agreement = %v, want 2/3", report.Pairwise.Agreement)
+	}
+	if !report.Pairwise.KappaDefined || math.Abs(report.Pairwise.Kappa-0.4) > 1e-9 {
+		t.Fatalf("pairwise kappa = %v (defined=%v), want 0.4", report.Pairwise.Kappa, report.Pairwise.KappaDefined)
+	}
+	if report.Pairwise.JudgeRows != 3 || report.Pairwise.HumanRows != 3 || report.Pairwise.TiesSkipped != 0 || report.Pairwise.LegacyRowsExcluded != 0 {
+		t.Fatalf("rows judge=%d human=%d ties=%d legacy=%d, want 3/3/0/0",
+			report.Pairwise.JudgeRows, report.Pairwise.HumanRows, report.Pairwise.TiesSkipped, report.Pairwise.LegacyRowsExcluded)
+	}
+	// Degenerate position assignment (--seed 0 on every round: champion always
+	// at Option A): the audit must refuse to fabricate a bias number.
+	position := report.Pairwise.Position
+	if position == nil {
+		t.Fatalf("position audit missing\n%s", stdout.String())
+	}
+	if position.N != 3 || position.PickA != 2 || position.ChampionA != 3 || position.PChampionA != 1.0 {
+		t.Fatalf("position audit = %+v, want N=3 pick_a=2 champion_a=3 p_champion_a=1.0", position)
+	}
+	if position.BiasDefined || position.BiasNote == "" {
+		t.Fatalf("position bias = %+v, want UNDEFINED with a degenerate-assignment note under a fixed --seed", position)
+	}
+
+	// Text path: the degenerate stance is loud and the legacy line is absent.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "judge", "agreement", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt judge agreement (text) exit = %d, stderr: %s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"comparisons joined: 3 (judge rows: 3, human rows: 3, juror rows: 0, tied comparisons skipped: 0)",
+		"raw agreement: 0.667 (2/3)",
+		"cohen's kappa (headline): 0.400",
+		"position bias: n/a (degenerate position assignment",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("text output missing %q\n%s", want, output)

--- a/internal/cli/skillopt_judge_agreement_test.go
+++ b/internal/cli/skillopt_judge_agreement_test.go
@@ -1,0 +1,396 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// TestSkillOptAgreementStatsExactKappa pins the agreement math to
+// hand-computed fixtures — the exact numbers the E2E later asserts through the
+// real CLI. Cohen's kappa: po = observed agreement, pe = chance agreement from
+// the two raters' label marginals, kappa = (po - pe) / (1 - pe).
+func TestSkillOptAgreementStatsExactKappa(t *testing.T) {
+	cases := []struct {
+		name          string
+		pairs         [][2]string
+		wantN         int
+		wantAgree     int
+		wantAgreement float64
+		wantKappa     float64
+		wantDefined   bool
+	}{
+		{
+			// The canonical 3-agree/1-disagree fixture: judge marginals
+			// champion=3/challenger=1, human marginals champion=2/challenger=2.
+			// po=0.75, pe=(3*2+1*2)/16=0.5, kappa=(0.75-0.5)/0.5=0.5.
+			name: "three agree one disagree",
+			pairs: [][2]string{
+				{"champion", "champion"},
+				{"champion", "champion"},
+				{"challenger", "challenger"},
+				{"champion", "challenger"},
+			},
+			wantN: 4, wantAgree: 3, wantAgreement: 0.75, wantKappa: 0.5, wantDefined: true,
+		},
+		{
+			// Agreement at chance level: judge always champion, human split.
+			// po=0.5, pe=(2*1+0*1)/4=0.5, kappa=0.
+			name:  "chance-level agreement is kappa zero",
+			pairs: [][2]string{{"champion", "champion"}, {"champion", "challenger"}},
+			wantN: 2, wantAgree: 1, wantAgreement: 0.5, wantKappa: 0, wantDefined: true,
+		},
+		{
+			// Perfect agreement with both labels used: po=1, pe=0.5, kappa=1.
+			name:  "perfect agreement",
+			pairs: [][2]string{{"champion", "champion"}, {"challenger", "challenger"}},
+			wantN: 2, wantAgree: 2, wantAgreement: 1, wantKappa: 1, wantDefined: true,
+		},
+		{
+			// Degenerate: both raters used ONE identical label everywhere, so
+			// pe=1; kappa is reported as 1 only because po is also perfect.
+			name:  "single shared label degenerates to kappa one",
+			pairs: [][2]string{{"champion", "champion"}, {"champion", "champion"}},
+			wantN: 2, wantAgree: 2, wantAgreement: 1, wantKappa: 1, wantDefined: true,
+		},
+		{
+			// Total systematic disagreement: po=0, pe=0, kappa=0 — chance
+			// correction does not reward a judge that inverts every human pick.
+			name:  "total disagreement",
+			pairs: [][2]string{{"champion", "challenger"}, {"champion", "challenger"}},
+			wantN: 2, wantAgree: 0, wantAgreement: 0, wantKappa: 0, wantDefined: true,
+		},
+		{
+			// Multi-class: labels a/b/c. po=0.5; both marginals a=2,b=1,c=1 so
+			// pe=(2*2+1*1+1*1)/16=0.375; kappa=(0.5-0.375)/0.625=0.2.
+			name: "multi-class kappa",
+			pairs: [][2]string{
+				{"a", "a"},
+				{"b", "b"},
+				{"c", "a"},
+				{"a", "c"},
+			},
+			wantN: 4, wantAgree: 2, wantAgreement: 0.5, wantKappa: 0.2, wantDefined: true,
+		},
+		{
+			name:  "empty",
+			pairs: nil,
+			wantN: 0, wantAgree: 0, wantAgreement: 0, wantKappa: 0, wantDefined: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stats := skillOptAgreementStats(tc.pairs)
+			if stats.N != tc.wantN || stats.Agreements != tc.wantAgree {
+				t.Fatalf("N=%d agreements=%d, want N=%d agreements=%d", stats.N, stats.Agreements, tc.wantN, tc.wantAgree)
+			}
+			if math.Abs(stats.Agreement-tc.wantAgreement) > 1e-12 {
+				t.Fatalf("agreement = %v, want %v", stats.Agreement, tc.wantAgreement)
+			}
+			if stats.KappaDefined != tc.wantDefined {
+				t.Fatalf("kappa defined = %v (note %q), want %v", stats.KappaDefined, stats.KappaNote, tc.wantDefined)
+			}
+			if tc.wantDefined && math.Abs(stats.Kappa-tc.wantKappa) > 1e-12 {
+				t.Fatalf("kappa = %v, want %v", stats.Kappa, tc.wantKappa)
+			}
+		})
+	}
+}
+
+// TestSkillOptAgreementMajority pins the per-item vote collapse: strict
+// majority wins, ties and empty sides are not resolvable.
+func TestSkillOptAgreementMajority(t *testing.T) {
+	if winner, ok := skillOptAgreementMajority([]string{"champion", "challenger", "champion"}); !ok || winner != "champion" {
+		t.Fatalf("majority = %q ok=%v, want champion true", winner, ok)
+	}
+	if _, ok := skillOptAgreementMajority([]string{"champion", "challenger"}); ok {
+		t.Fatal("tie must not resolve to a winner")
+	}
+	if _, ok := skillOptAgreementMajority(nil); ok {
+		t.Fatal("empty votes must not resolve to a winner")
+	}
+}
+
+// TestSkillOptABJudgePickPositionRoundTrip proves the additive position
+// persistence channel: the writer's blob parses back to the same pick, and
+// legacy/free-text/invalid reasoning is skipped (never fabricated).
+func TestSkillOptABJudgePickPositionRoundTrip(t *testing.T) {
+	for _, pick := range []string{"a", "b"} {
+		blob := skillOptABJudgePickPositionJSON(pick)
+		got, ok := skillOptABJudgePickPosition(blob)
+		if !ok || got != pick {
+			t.Fatalf("round trip %q -> %q ok=%v (blob %q)", pick, got, ok, blob)
+		}
+	}
+	for _, reasoning := range []string{"", "the answer was clearer", `{"judge_pick_position":"c"}`, `{"other":"a"}`, "{"} {
+		if got, ok := skillOptABJudgePickPosition(reasoning); ok {
+			t.Fatalf("reasoning %q parsed to position %q, want skipped", reasoning, got)
+		}
+	}
+}
+
+// TestBuildSkillOptJudgeAgreementPairwiseMajorityAndTies covers the join
+// edge-paths without the CLI: repeated rows on one item collapse to a majority
+// (never inflating N), an internally-tied side skips the item and counts it,
+// and auto-trace rows are excluded from both sides.
+func TestBuildSkillOptJudgeAgreementPairwiseMajorityAndTies(t *testing.T) {
+	event := func(runID, itemID, winner, reviewer, source, sourceURL string) db.RankedFeedbackEventWithTemplate {
+		return db.RankedFeedbackEventWithTemplate{
+			RankedFeedbackEvent: db.RankedFeedbackEvent{RunID: runID, ItemID: itemID, Winner: winner, Reviewer: reviewer, Source: source, SourceURL: sourceURL},
+			TemplateID:          "planner",
+		}
+	}
+	events := []db.RankedFeedbackEventWithTemplate{
+		// Item 1: three human picks collapse to champion (2:1); judge says
+		// champion -> ONE agreeing observation, not three.
+		event("run-1", "ab", "champion", "human", "skillopt-ab", "u1"),
+		event("run-1", "ab", "champion", "human", "skillopt-ab", "u2"),
+		event("run-1", "ab", "challenger", "human", "skillopt-ab", "u3"),
+		event("run-1", "ab", "champion", "skillopt-ab-judge", "skillopt-ab-judge", "j1"),
+		// Item 2: human side is tied 1:1 -> skipped and counted.
+		event("run-2", "ab", "champion", "human", "skillopt-ab", "u4"),
+		event("run-2", "ab", "challenger", "human", "skillopt-ab", "u5"),
+		event("run-2", "ab", "challenger", "skillopt-ab-judge", "skillopt-ab-judge", "j2"),
+		// Auto-trace rows never join either side.
+		event("run-3", "ab", "champion", "gitmoot-auto", "auto-trace", "u6"),
+		event("run-3", "ab", "champion", "skillopt-ab-judge", "skillopt-ab-judge", "j3"),
+	}
+	pairwise := buildSkillOptJudgeAgreementPairwise(events)
+	if pairwise.N != 1 || pairwise.Agreements != 1 {
+		t.Fatalf("N=%d agreements=%d, want 1/1 (majority collapse, tie skipped, auto-trace excluded)", pairwise.N, pairwise.Agreements)
+	}
+	if pairwise.TiesSkipped != 1 {
+		t.Fatalf("ties skipped = %d, want 1", pairwise.TiesSkipped)
+	}
+	if pairwise.HumanRows != 5 || pairwise.JudgeRows != 3 {
+		t.Fatalf("human rows = %d judge rows = %d, want 5 and 3", pairwise.HumanRows, pairwise.JudgeRows)
+	}
+}
+
+// multiChallengerABFixture builds on skillOptABFixture with three MORE pending
+// challenger versions, so the E2E can drive four independent A/B items (each
+// challenger keys its own skillopt-ab:<version> run).
+func multiChallengerABFixture(t *testing.T) (string, *db.Store, []string) {
+	t.Helper()
+	home, store, _, firstChallenger := skillOptABFixture(t)
+	ctx := context.Background()
+	challengers := []string{firstChallenger}
+	for i := 2; i <= 4; i++ {
+		version, err := store.AddPendingAgentTemplateVersion(ctx, cliSkillOptTemplate("planner", fmt.Sprintf("Challenger guidance variant %d.", i)))
+		if err != nil {
+			t.Fatalf("AddPendingAgentTemplateVersion %d: %v", i, err)
+		}
+		challengers = append(challengers, version.ID)
+	}
+	return home, store, challengers
+}
+
+// settableSkillOptABJudgeFake swaps the judge seam for a fake whose raw output
+// is read from the returned pointer AT CALL TIME (so each E2E round can steer
+// the judge's pick), and stubs the authed probe so a cross-family judge
+// (claude vs the codex agent) is always available.
+func settableSkillOptABJudgeFake(t *testing.T) *string {
+	t.Helper()
+	raw := `{"pick":"a"}`
+	prevDeliver := skillOptABJudgeDeliver
+	skillOptABJudgeDeliver = func(_ context.Context, _ runtime.Agent, _ string) (string, error) {
+		return raw, nil
+	}
+	prevAuthed := skillOptABJudgeAuthedRuntimes
+	skillOptABJudgeAuthedRuntimes = func(string) reviewAuthedRuntimes {
+		return func(context.Context) map[string]bool { return map[string]bool{runtime.ClaudeRuntime: true} }
+	}
+	t.Cleanup(func() {
+		skillOptABJudgeDeliver = prevDeliver
+		skillOptABJudgeAuthedRuntimes = prevAuthed
+	})
+	return &raw
+}
+
+// TestSkillOptJudgeAgreementE2EMeasuresKnownAgreement is the mutation-proven
+// E2E for the #344 measurement harness: it drives FOUR real `skillopt ab
+// --judge` rounds through the REAL command path (real store writes, real
+// shuffle/unblinding, real judge + human row recording — only the LLM Deliver
+// seams are fakes), engineered so the judge agrees with the human on exactly
+// 3 of 4 items, then runs the REAL `skillopt judge agreement` CLI and asserts
+// the hand-computed numbers EXACTLY:
+//
+//	agreement = 3/4 = 0.750
+//	kappa     = (0.75 - 0.5) / (1 - 0.5) = 0.500
+//	          (judge marginals champion=3/challenger=1; human 2/2 -> pe=0.5)
+//	position  = picks a,a,b,a -> P(a)=0.750, bias 0.250
+//
+// Any break in the judge-row/human-row join (wrong field, wrong source tag,
+// wrong unblinding) shifts these exact numbers and turns the test red.
+func TestSkillOptJudgeAgreementE2EMeasuresKnownAgreement(t *testing.T) {
+	home, _, challengers := multiChallengerABFixture(t)
+	withFakeSkillOptABDeliver(t, "Champion answer.", "Challenger answer.")
+	judgeRaw := settableSkillOptABJudgeFake(t)
+
+	// All rounds use --seed 0 (no swap): Option A=champion, Option B=challenger.
+	rounds := []struct {
+		judgePick string // raw position the judge returns
+		humanPick string // raw position the human picks
+	}{
+		{"a", "a"}, // both champion -> agree
+		{"a", "a"}, // both champion -> agree
+		{"b", "b"}, // both challenger -> agree
+		{"a", "b"}, // judge champion vs human challenger -> disagree
+	}
+	for index, round := range rounds {
+		*judgeRaw = fmt.Sprintf(`{"pick":%q}`, round.judgePick)
+		var stdout, stderr bytes.Buffer
+		code := runSkillOptAB([]string{"planner-bot", "Plan the migration.", "--home", home,
+			"--challenger", challengers[index], "--pick", round.humanPick, "--seed", "0", "--judge"}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("round %d: runSkillOptAB exit = %d, stderr: %s", index+1, code, stderr.String())
+		}
+	}
+
+	// JSON path: exact machine-readable numbers through the real CLI.
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge", "agreement", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt judge agreement exit = %d, stderr: %s", code, stderr.String())
+	}
+	var report skillOptJudgeAgreementReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if report.Pairwise.N != 4 || report.Pairwise.Agreements != 3 {
+		t.Fatalf("pairwise N=%d agreements=%d, want 4 and 3\n%s", report.Pairwise.N, report.Pairwise.Agreements, stdout.String())
+	}
+	if report.Pairwise.Agreement != 0.75 {
+		t.Fatalf("pairwise agreement = %v, want exactly 0.75", report.Pairwise.Agreement)
+	}
+	if !report.Pairwise.KappaDefined || report.Pairwise.Kappa != 0.5 {
+		t.Fatalf("pairwise kappa = %v (defined=%v), want exactly 0.5", report.Pairwise.Kappa, report.Pairwise.KappaDefined)
+	}
+	if report.Pairwise.JudgeRows != 4 || report.Pairwise.HumanRows != 4 || report.Pairwise.TiesSkipped != 0 {
+		t.Fatalf("rows judge=%d human=%d ties=%d, want 4/4/0", report.Pairwise.JudgeRows, report.Pairwise.HumanRows, report.Pairwise.TiesSkipped)
+	}
+	if len(report.Pairwise.PerSource) != 1 || report.Pairwise.PerSource[0].Key != skillOptABSource || report.Pairwise.PerSource[0].N != 4 {
+		t.Fatalf("per-source breakdown = %+v, want a single skillopt-ab entry with N=4", report.Pairwise.PerSource)
+	}
+	if report.Pairwise.Position == nil {
+		t.Fatalf("position audit missing: the judge rows must carry recorded picks\n%s", stdout.String())
+	}
+	if report.Pairwise.Position.N != 4 || report.Pairwise.Position.PickA != 3 || report.Pairwise.Position.PPickA != 0.75 || report.Pairwise.Position.Bias != 0.25 {
+		t.Fatalf("position audit = %+v, want N=4 pick_a=3 p=0.75 bias=0.25", report.Pairwise.Position)
+	}
+	if report.Candidate.N != 0 {
+		t.Fatalf("candidate N = %d, want 0 (no judge outcomes seeded)", report.Candidate.N)
+	}
+	if !report.SmallNWarning || report.SmallNThreshold != skillOptAgreementSmallNThreshold {
+		t.Fatalf("small-N caveat missing: warning=%v threshold=%d", report.SmallNWarning, report.SmallNThreshold)
+	}
+
+	// Text path: the human-readable shape carries the same exact numbers, with
+	// kappa as the HEADLINE metric and the loud small-N warning.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "judge", "agreement", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt judge agreement (text) exit = %d, stderr: %s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"judge <-> human agreement (#344 measure-the-judge)",
+		"pairwise slice",
+		"items joined: 4 (judge rows: 4, human rows: 4, juror rows: 0, tied items skipped: 0)",
+		"cohen's kappa (headline): 0.500",
+		"raw agreement: 0.750 (3/4)",
+		"per human source:",
+		"skillopt-ab",
+		"position audit",
+		"N=4  P(pick=a)=0.750  position bias |P(a)-0.5|=0.250",
+		"candidate slice",
+		"no judge outcomes captured",
+		"WARNING: small sample (pairwise N=4, candidate N=0; threshold 30)",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("text output missing %q\n%s", want, output)
+		}
+	}
+}
+
+// TestSkillOptJudgeAgreementCandidateSliceMatchesJudgeReport seeds the SAME
+// candidate-outcome fixture the judge-report test uses and asserts the
+// candidate slice computes the identical 2x2 kappa: directions AA/AR/AR-human
+// give po=2/3, pe=4/9, kappa=(2/3-4/9)/(5/9)=0.4.
+func TestSkillOptJudgeAgreementCandidateSliceMatchesJudgeReport(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	for index, outcome := range []db.SkillOptJudgeOutcome{
+		{ID: "agree-1", CandidateVersionID: "planner@v2", TemplateID: "planner", HumanDecision: "promoted", Direction: db.SkillOptJudgeDirectionAgreeAccept},
+		{ID: "agree-2", CandidateVersionID: "planner@v3", TemplateID: "planner", HumanDecision: "rejected", Direction: db.SkillOptJudgeDirectionAgreeReject},
+		{ID: "disagree-1", CandidateVersionID: "planner@v4", TemplateID: "planner", HumanDecision: "rejected", Direction: db.SkillOptJudgeDirectionJudgeAcceptHumanReject},
+	} {
+		if err := store.InsertSkillOptJudgeOutcome(context.Background(), outcome); err != nil {
+			t.Fatalf("InsertSkillOptJudgeOutcome %d returned error: %v", index, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge", "agreement", "--home", home, "--template", "planner", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt judge agreement exit = %d, stderr: %s", code, stderr.String())
+	}
+	var report skillOptJudgeAgreementReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, stdout.String())
+	}
+	if report.Template != "planner" {
+		t.Fatalf("template = %q, want planner", report.Template)
+	}
+	if report.Candidate.N != 3 || report.Candidate.Agreements != 2 {
+		t.Fatalf("candidate N=%d agreements=%d, want 3 and 2", report.Candidate.N, report.Candidate.Agreements)
+	}
+	if math.Abs(report.Candidate.Agreement-2.0/3.0) > 1e-9 {
+		t.Fatalf("candidate agreement = %v, want 2/3", report.Candidate.Agreement)
+	}
+	if !report.Candidate.KappaDefined || math.Abs(report.Candidate.Kappa-0.4) > 1e-9 {
+		t.Fatalf("candidate kappa = %v (defined=%v), want 0.4", report.Candidate.Kappa, report.Candidate.KappaDefined)
+	}
+	if report.Pairwise.N != 0 {
+		t.Fatalf("pairwise N = %d, want 0 (no ranked feedback seeded)", report.Pairwise.N)
+	}
+}
+
+// TestSkillOptJudgeAgreementEmptyStore proves the no-data path is calm and
+// non-erroring (read-only harness over a fresh home).
+func TestSkillOptJudgeAgreementEmptyStore(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "judge", "agreement", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("skillopt judge agreement exit = %d, stderr: %s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, want := range []string{
+		"no overlap yet",
+		"no judge outcomes captured",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("empty-store output missing %q\n%s", want, output)
+		}
+	}
+}

--- a/internal/cli/skillopt_pairwise.go
+++ b/internal/cli/skillopt_pairwise.go
@@ -280,7 +280,7 @@ func importPairwisePacket(ctx context.Context, store *db.Store, paths config.Pat
 		// re-import of the same reviewed packet, so the ranked event is upserted in
 		// place and never double-counted.
 		sourceURL := skillOptPairwiseSourceURL(packet.RunID, result.ItemID)
-		if err := upsertSkillOptABRankedEvent(ctx, store, runID, result.ItemID, result.WinnerLabel, result.LoserLabel, options.reviewer, skillOptPairwiseSource, sourceURL); err != nil {
+		if err := upsertSkillOptABRankedEvent(ctx, store, runID, result.ItemID, result.WinnerLabel, result.LoserLabel, options.reviewer, skillOptPairwiseSource, sourceURL, ""); err != nil {
 			itemResult.Status = "skipped"
 			itemResult.Message = fmt.Sprintf("record pick: %v", err)
 			summary.Skipped++

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4644,6 +4644,52 @@ func scanRankedFeedbackEvent(row interface{ Scan(dest ...any) error }) (RankedFe
 	return event, nil
 }
 
+// RankedFeedbackEventWithTemplate pairs a ranked feedback event with the
+// template id of the eval run it belongs to, so cross-run measurement joins
+// (`skillopt judge agreement`, #344) can scope by template without a second
+// per-run lookup loop.
+type RankedFeedbackEventWithTemplate struct {
+	RankedFeedbackEvent
+	TemplateID string
+}
+
+// ListRankedFeedbackEventsAcrossRuns returns every ranked feedback event joined
+// with its eval run's template id, ordered deterministically, optionally
+// filtered to one template (templateID == "" lists all). It is read-only and
+// exists for the judge<->human agreement measurement harness (#344): the
+// pairwise judge rows (source=skillopt-ab-judge) and the human rows they must
+// be compared against live in the SAME (run_id, item_id) but across MANY runs,
+// so the per-run ListRankedFeedbackEvents cannot serve the whole-store join.
+func (s *Store) ListRankedFeedbackEventsAcrossRuns(ctx context.Context, templateID string) ([]RankedFeedbackEventWithTemplate, error) {
+	query := `SELECT e.id, e.run_id, e.item_id, e.ranking_json, e.tie_groups_json, e.winner, e.useful_traits_json, e.rejected_traits_json,
+			e.required_improvements_json, e.quality, e.continue_mode, e.promote, e.reasoning, e.reviewer, e.source, e.source_url, e.created_at,
+			r.template_id
+		FROM ranked_feedback_events e
+		JOIN eval_runs r ON r.id = e.run_id`
+	args := []any{}
+	if trimmed := strings.TrimSpace(templateID); trimmed != "" {
+		query += ` WHERE r.template_id = ?`
+		args = append(args, trimmed)
+	}
+	query += ` ORDER BY e.run_id, e.item_id, e.reviewer, e.source, e.source_url`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var events []RankedFeedbackEventWithTemplate
+	for rows.Next() {
+		var event RankedFeedbackEventWithTemplate
+		if err := rows.Scan(&event.ID, &event.RunID, &event.ItemID, &event.RankingJSON, &event.TieGroupsJSON, &event.Winner, &event.UsefulTraitsJSON, &event.RejectedTraitsJSON,
+			&event.RequiredImprovementsJSON, &event.Quality, &event.ContinueMode, &event.Promote, &event.Reasoning, &event.Reviewer, &event.Source, &event.SourceURL, &event.CreatedAt,
+			&event.TemplateID); err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
 // GetBanditArm reads the #473 Mode B bandit arm for a (templateID,
 // versionID) variant. A missing row is NOT an error: it returns ok=false with a
 // zero arm, and the caller treats that as the uniform Beta(1,1) prior

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -741,6 +741,78 @@ func TestRankedReviewStorageAndPairwisePreferences(t *testing.T) {
 	}
 }
 
+// TestListRankedFeedbackEventsAcrossRuns proves the cross-run measurement join
+// (#344): events from runs of DIFFERENT templates come back with the correct
+// eval-run template id attached, the template filter scopes correctly, and the
+// stored Reasoning (the judge position blob channel) round-trips verbatim.
+func TestListRankedFeedbackEventsAcrossRuns(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	seedRun := func(runID, templateID, reviewer, source, winner, loser, reasoning string) {
+		t.Helper()
+		if err := store.UpsertEvalRun(ctx, EvalRun{ID: runID, TemplateID: templateID, State: "complete", Mode: EvalRunModeValidate, OptionsCount: 2}); err != nil {
+			t.Fatalf("UpsertEvalRun %s returned error: %v", runID, err)
+		}
+		if err := store.UpsertEvalReviewItem(ctx, EvalReviewItem{RunID: runID, ItemID: "ab", Title: "prompt"}); err != nil {
+			t.Fatalf("UpsertEvalReviewItem %s returned error: %v", runID, err)
+		}
+		for _, label := range []string{winner, loser} {
+			if err := store.UpsertEvalReviewOption(ctx, EvalReviewOption{RunID: runID, ItemID: "ab", Label: label, ArtifactID: "artifact-" + label}); err != nil {
+				t.Fatalf("UpsertEvalReviewOption %s/%s returned error: %v", runID, label, err)
+			}
+		}
+		ranking, _ := json.Marshal([]string{winner, loser})
+		if err := store.UpsertRankedFeedbackEvent(ctx, RankedFeedbackEvent{
+			RunID:       runID,
+			ItemID:      "ab",
+			RankingJSON: string(ranking),
+			Winner:      winner,
+			Reasoning:   reasoning,
+			Reviewer:    reviewer,
+			Source:      source,
+			SourceURL:   "sourceurl-" + runID,
+		}); err != nil {
+			t.Fatalf("UpsertRankedFeedbackEvent %s returned error: %v", runID, err)
+		}
+	}
+	seedRun("run-planner", "planner", "human", "skillopt-ab", "champion", "challenger", "")
+	seedRun("run-writer", "writer", "skillopt-ab-judge", "skillopt-ab-judge", "challenger", "champion", `{"judge_pick_position":"b"}`)
+
+	all, err := store.ListRankedFeedbackEventsAcrossRuns(ctx, "")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEventsAcrossRuns returned error: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("all events = %d, want 2: %+v", len(all), all)
+	}
+	byRun := map[string]RankedFeedbackEventWithTemplate{}
+	for _, event := range all {
+		byRun[event.RunID] = event
+	}
+	if byRun["run-planner"].TemplateID != "planner" || byRun["run-writer"].TemplateID != "writer" {
+		t.Fatalf("template join wrong: planner=%q writer=%q", byRun["run-planner"].TemplateID, byRun["run-writer"].TemplateID)
+	}
+	if byRun["run-writer"].Reasoning != `{"judge_pick_position":"b"}` {
+		t.Fatalf("reasoning did not round-trip: %q", byRun["run-writer"].Reasoning)
+	}
+	if byRun["run-writer"].Winner != "challenger" || byRun["run-writer"].Source != "skillopt-ab-judge" {
+		t.Fatalf("event fields wrong: %+v", byRun["run-writer"])
+	}
+
+	filtered, err := store.ListRankedFeedbackEventsAcrossRuns(ctx, "planner")
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEventsAcrossRuns(planner) returned error: %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].RunID != "run-planner" || filtered[0].TemplateID != "planner" {
+		t.Fatalf("filtered events = %+v, want the single planner event", filtered)
+	}
+}
+
 func TestRankedReviewTieGroupsSkipInGroupPairwisePreferences(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -711,12 +711,18 @@ disagreement. Pass `--template <id>` to scope the report to one template, and
 
 `skillopt judge agreement` is the judge↔human agreement measurement harness
 (#344). It joins the stored A/B judge verdicts (`skillopt ab --judge` /
-jury rows) against the human ranked/pairwise feedback on the same items
-(per-item majority; internal ties are skipped and counted) and reports Cohen's
-κ as the **headline** metric (raw agreement overstates judge quality because
-it does not correct for chance), the raw agreement rate, per-human-source and
-per-juror-family breakdowns, a position-bias audit over judge rows that carry
-the recorded raw a/b pick (`|P(pick=a) − 0.5|`), and a summary of the
+jury rows) against the human ranked/pairwise feedback on the same
+**comparison**: each `skillopt ab` invocation stamps a shared per-comparison
+token on all of its rows, so repeated A/Bs of one challenger stay separate
+observations (older tokenless rows are excluded and counted as unmeasurable,
+never pooled; internal ties within one comparison are skipped and counted).
+It reports Cohen's κ as the **headline** metric (raw agreement overstates
+judge quality because it does not correct for chance), the raw agreement
+rate, per-human-source and per-juror-family breakdowns, an
+assignment-corrected position-bias audit over judge rows that carry the
+recorded raw a/b pick (`P(pick=a)` stratified by the champion's presented
+position and reported alongside `P(option A = champion)`; undefined when a
+fixed `--seed` pinned the champion to one position), and a summary of the
 candidate-level judge outcomes above. Small samples get a loud warning —
 sample size is the limiter. `--json` emits the machine-readable report. It is
 read-only.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -605,6 +605,7 @@ gitmoot skillopt train continue --session <id> [--generator-type skillopt-genera
 gitmoot skillopt train recover --session <id> [--out-root path] [--generation [--abort | --advance-state]] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 gitmoot skillopt judge-report [--template <id>] [--home <path>]
+gitmoot skillopt judge agreement [--template <id>] [--home <path>] [--json]
 gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <path>] [--yes] [--json]
 ```
 
@@ -707,6 +708,18 @@ LLM judge is calibrated against human verdicts. It prints a confusion matrix
 buckets (judge soft-score versus the human decision), and per-dimension
 disagreement. Pass `--template <id>` to scope the report to one template, and
 `--home <path>` to read from a non-default Gitmoot home. It is read-only.
+
+`skillopt judge agreement` is the judge↔human agreement measurement harness
+(#344). It joins the stored A/B judge verdicts (`skillopt ab --judge` /
+jury rows) against the human ranked/pairwise feedback on the same items
+(per-item majority; internal ties are skipped and counted) and reports Cohen's
+κ as the **headline** metric (raw agreement overstates judge quality because
+it does not correct for chance), the raw agreement rate, per-human-source and
+per-juror-family breakdowns, a position-bias audit over judge rows that carry
+the recorded raw a/b pick (`|P(pick=a) − 0.5|`), and a summary of the
+candidate-level judge outcomes above. Small samples get a loud warning —
+sample size is the limiter. `--json` emits the machine-readable report. It is
+read-only.
 
 `skillopt judge promote` closes the judge-prompt optimization loop: it applies an
 **accepted** judge-prompt variant (from the judge-prompt optimizer's

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -294,6 +294,13 @@ soft-score versus the human decision), and per-dimension disagreement — useful
 to tell whether the LLM judge is well-calibrated against human verdicts before
 you trust it to gate candidates.
 
+`gitmoot skillopt judge agreement [--template <id>] [--json]` extends the
+measurement to the pairwise slice: it joins the A/B judge rows (`skillopt ab
+--judge` / jury) against human ranked/pairwise picks on the same items and
+reports Cohen's κ as the headline, raw agreement, per-source/per-juror
+breakdowns, and a position-bias audit (`|P(pick=a) − 0.5|`), with a loud
+small-sample warning. Read-only.
+
 Those captured outcomes feed judge-prompt optimization. The contract carries a
 per-`task_kind` judge prompt
 (`evaluator_profile.judge.config.judge_prompt_templates[task_kind]` +

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -296,10 +296,15 @@ you trust it to gate candidates.
 
 `gitmoot skillopt judge agreement [--template <id>] [--json]` extends the
 measurement to the pairwise slice: it joins the A/B judge rows (`skillopt ab
---judge` / jury) against human ranked/pairwise picks on the same items and
-reports Cohen's κ as the headline, raw agreement, per-source/per-juror
-breakdowns, and a position-bias audit (`|P(pick=a) − 0.5|`), with a loud
-small-sample warning. Read-only.
+--judge` / jury) against human ranked/pairwise picks on the same
+**comparison** (each `skillopt ab` invocation stamps a shared per-comparison
+token on all of its rows; older tokenless rows are excluded and counted as
+unmeasurable, never pooled by challenger) and reports Cohen's κ as the
+headline, raw agreement, per-source/per-juror breakdowns, and an
+assignment-corrected position-bias audit (stratified by the champion's
+presented position, reported alongside `P(pick=a)` and
+`P(option A = champion)`; undefined when a fixed `--seed` pinned the champion
+to one position), with a loud small-sample warning. Read-only.
 
 Those captured outcomes feed judge-prompt optimization. The contract carries a
 per-`task_kind` judge prompt

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -699,12 +699,18 @@ disagreement. Pass `--template <id>` to scope the report to one template, and
 
 `skillopt judge agreement` is the judge↔human agreement measurement harness
 (#344). It joins the stored A/B judge verdicts (`skillopt ab --judge` /
-jury rows) against the human ranked/pairwise feedback on the same items
-(per-item majority; internal ties are skipped and counted) and reports Cohen's
-κ as the **headline** metric (raw agreement overstates judge quality because
-it does not correct for chance), the raw agreement rate, per-human-source and
-per-juror-family breakdowns, a position-bias audit over judge rows that carry
-the recorded raw a/b pick (`|P(pick=a) − 0.5|`), and a summary of the
+jury rows) against the human ranked/pairwise feedback on the same
+**comparison**: each `skillopt ab` invocation stamps a shared per-comparison
+token on all of its rows, so repeated A/Bs of one challenger stay separate
+observations (older tokenless rows are excluded and counted as unmeasurable,
+never pooled; internal ties within one comparison are skipped and counted).
+It reports Cohen's κ as the **headline** metric (raw agreement overstates
+judge quality because it does not correct for chance), the raw agreement
+rate, per-human-source and per-juror-family breakdowns, an
+assignment-corrected position-bias audit over judge rows that carry the
+recorded raw a/b pick (`P(pick=a)` stratified by the champion's presented
+position and reported alongside `P(option A = champion)`; undefined when a
+fixed `--seed` pinned the champion to one position), and a summary of the
 candidate-level judge outcomes above. Small samples get a loud warning —
 sample size is the limiter. `--json` emits the machine-readable report. It is
 read-only.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -577,6 +577,7 @@ gitmoot skillopt train continue --session <id> [--generator-type skillopt-genera
 gitmoot skillopt train recover --session <id> [--out-root path] [--generation [--abort | --advance-state]] [--json]
 gitmoot skillopt train stop --session <id> --reason <text>
 gitmoot skillopt judge-report [--template <id>] [--home <path>]
+gitmoot skillopt judge agreement [--template <id>] [--home <path>] [--json]
 gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <path>] [--yes] [--json]
 ```
 
@@ -695,6 +696,18 @@ LLM judge is calibrated against human verdicts. It prints a confusion matrix
 buckets (judge soft-score versus the human decision), and per-dimension
 disagreement. Pass `--template <id>` to scope the report to one template, and
 `--home <path>` to read from a non-default Gitmoot home. It is read-only.
+
+`skillopt judge agreement` is the judge↔human agreement measurement harness
+(#344). It joins the stored A/B judge verdicts (`skillopt ab --judge` /
+jury rows) against the human ranked/pairwise feedback on the same items
+(per-item majority; internal ties are skipped and counted) and reports Cohen's
+κ as the **headline** metric (raw agreement overstates judge quality because
+it does not correct for chance), the raw agreement rate, per-human-source and
+per-juror-family breakdowns, a position-bias audit over judge rows that carry
+the recorded raw a/b pick (`|P(pick=a) − 0.5|`), and a summary of the
+candidate-level judge outcomes above. Small samples get a loud warning —
+sample size is the limiter. `--json` emits the machine-readable report. It is
+read-only.
 
 `skillopt judge promote` closes the judge-prompt optimization loop: it applies an
 **accepted** judge-prompt variant (from the judge-prompt optimizer's

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -732,11 +732,20 @@ the gate before relying on it for candidate decisions.
 `gitmoot skillopt judge agreement [--template <id>] [--json]` extends the
 measurement to the **pairwise** slice: it joins the A/B judge rows
 (`skillopt ab --judge` / jury) against the human ranked/pairwise picks on the
-same items (per-item majority; ties skipped and counted) and reports Cohen's κ
-as the headline metric, raw agreement, per-human-source and per-juror-family
-breakdowns, and a position-bias audit over judge rows carrying the recorded raw
-a/b pick (`|P(pick=a) − 0.5|`). Small samples get a loud warning — sample size
-is the limiter. It is read-only; `--json` emits the machine-readable report.
+same **comparison** — each `skillopt ab` invocation stamps a shared
+per-comparison token on all of its rows, so repeated A/Bs of one challenger
+never pool into a single bucket; older tokenless rows are excluded and counted
+as unmeasurable, never pooled (majority collapse applies only to true re-votes
+of one comparison; ties skipped and counted). It reports Cohen's κ as the
+headline metric, raw agreement, per-human-source and per-juror-family
+breakdowns, and an assignment-corrected position-bias audit over judge rows
+carrying the recorded raw a/b pick: `P(pick=a)` is stratified by the champion's
+presented position (recovered per row) and reported alongside
+`P(option A = champion)`, so a content preference under a skewed shuffle (e.g.
+a fixed `--seed`) is never mislabeled as position bias — a single-position
+assignment reports the bias as undefined instead. Small samples get a loud
+warning — sample size is the limiter. It is read-only; `--json` emits the
+machine-readable report.
 
 ### Optimizing the judge prompt
 

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -729,6 +729,15 @@ scopes the report to one template, and `--home` reads from a non-default Gitmoot
 home. Use it to decide whether the judge is well-calibrated enough to trust at
 the gate before relying on it for candidate decisions.
 
+`gitmoot skillopt judge agreement [--template <id>] [--json]` extends the
+measurement to the **pairwise** slice: it joins the A/B judge rows
+(`skillopt ab --judge` / jury) against the human ranked/pairwise picks on the
+same items (per-item majority; ties skipped and counted) and reports Cohen's κ
+as the headline metric, raw agreement, per-human-source and per-juror-family
+breakdowns, and a position-bias audit over judge rows carrying the recorded raw
+a/b pick (`|P(pick=a) − 0.5|`). Small samples get a loud warning — sample size
+is the limiter. It is read-only; `--json` emits the machine-readable report.
+
 ### Optimizing the judge prompt
 
 The captured outcomes are the substrate for tuning the judge itself. The


### PR DESCRIPTION
## What

Adds `gitmoot skillopt judge agreement [--template <id>] [--home <path>] [--json]` — the read-only judge↔human agreement measurement harness for the **MEASURE** step of #344.

## Why this is the remaining MEASURE gap (scope note)

The epic's candidate-level measurement (#345, `skillopt judge-report`) already shipped, so this does **not** rebuild it. What was still unmeasured is the **pairwise slice**: the Mode B A/B judge rows are explicitly marked in-code as *"NOT calibrated against human gold … until a judge↔human agreement capture lands (#344)"* (`internal/cli/skillopt_ab.go`). The maintainer's 2026-06-30 epic comment ("Reliability without Validity", arXiv:2606.19544) also asks for κ-as-headline and position-swap/bias auditing. This PR delivers exactly that slice:

- **Pairwise slice** — joins judge rows (`source=skillopt-ab-judge`, single judge or jury aggregate) against human ranked/pairwise rows (`skillopt-ab`, `live-pairwise`, `markdown`, `github`, …) on the same `(run_id, item_id)`. Each side collapses to a per-item **majority** verdict (internal ties are skipped and counted — repeated picks never inflate N). Reports **Cohen's κ as the headline** (multi-class, marginal-based chance correction; degenerate marginals reported as undefined, never a misleading 1.0), raw agreement second, **per-human-source** and **per-juror-family** breakdowns, and **N with a loud small-N warning** (threshold 30 — sample size is the epic's own stated limiter).
- **Position-bias audit** — judge/juror rows now persist the RAW presented `a|b` pick as a tiny JSON blob on the previously-always-empty `Reasoning` field (minimal **additive** persistence, no schema change, no new deps; the stored `Winner` is the unblinded role, so without this the presented position is unrecoverable). The harness reports `|P(pick=a) − 0.5|` over rows that carry it; legacy rows are skipped, never fabricated.
- **Candidate slice** — the #345 `skillopt_judge_outcomes` capture summarized with the same κ-headline framing (computes the identical 2×2 κ as `judge-report`, which stays the full calibration view with confusion matrix / soft-score bands / per-dimension disagreement — per-dimension breakdown lives there because the pairwise rows carry no dimensions).
- **db** — additive read-only `ListRankedFeedbackEventsAcrossRuns` (ranked feedback joined with the eval run's template id, optional template filter).
- `--json` for automation; text output leads with κ.

Off-by-default (runs only when invoked), read-only over the store (except the additive judge-verdict position persistence), zero behavior change to existing flows (the Reasoning blob is consumed only by this command — bandit/preference/optimizer paths read `Winner`/ranking, verified).

## Tests

- `TestSkillOptAgreementStatsExactKappa` — hand-computed κ fixtures (3-agree/1-disagree → 0.75 / κ=0.5; chance-level → κ=0; perfect; degenerate marginals; total disagreement; multi-class κ=0.2).
- `TestSkillOptAgreementMajority`, `TestBuildSkillOptJudgeAgreementPairwiseMajorityAndTies` — majority collapse, tie-skip counting, auto-trace exclusion.
- `TestSkillOptABJudgePickPositionRoundTrip` — the additive position-persistence channel round-trips; legacy/free-text/invalid reasoning is skipped.
- `TestListRankedFeedbackEventsAcrossRuns` — store round-trip for the new cross-run join (template join + filter + Reasoning verbatim).
- `TestSkillOptJudgeAgreementCandidateSliceMatchesJudgeReport` — candidate slice reproduces judge-report's 2×2 κ (κ=0.4 fixture).
- `TestSkillOptJudgeAgreementEmptyStore` — calm no-data path.

## E2E (mutation-proven)

`TestSkillOptJudgeAgreementE2EMeasuresKnownAgreement` drives **four real `skillopt ab --judge` rounds through the real command path** (real store writes, real shuffle/unblinding, real judge + human row recording — only the LLM `Deliver` seams are fakes), engineered so the judge agrees with the human on exactly **3 of 4** items, then runs the real `skillopt judge agreement` CLI (JSON and text) and asserts the hand-computed numbers **exactly**: agreement `0.750 (3/4)`, **κ = 0.500** (judge marginals 3/1, human 2/2 → pe=0.5), position audit `P(a)=0.750, bias=0.250`, small-N warning present.

**Mutation red (verified in this run):** breaking the join — pairing the judge verdict against the judge's own label instead of the human majority (`[2]string{judgeWinner, judgeWinner}`) — flips the result to `agreements=4/4` and the E2E fails: `pairwise N=4 agreements=4, want 4 and 3`. Restored; the test file also does not exist on `main`, so the E2E trivially cannot pass there.

## Docs

Both trees updated: `skills/gitmoot/references/CLI.md`, `skills/gitmoot/references/WORKFLOWS.md`, `website/docs/reference/cli.md`, `website/docs/workflows/skillopt-train-workflow.md`.

## Epic bookkeeping

References #344 — ticks the remaining MEASURE-step gaps (pairwise-slice agreement, κ-as-headline, position-bias audit substrate, loud small-N caveat). Does **NOT** close the epic: #347 (rubric induction) and #348 Phase 2 stay open, both blocked on accumulated data, not effort.

Gate: `go build ./... && go vet ./... && go test ./internal/cli/ ./internal/config/ ./internal/db/ ./internal/daemon/ ./internal/workflow/ ./internal/runtime/ -count=1 && go test -race -timeout 20m ./internal/cli/ ./internal/workflow/` — green (race leg rerun after an unrelated sibling-process kill; workflow race passed first run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
