### PR TITLE
fix(daemon): a stuck/long job no longer wedges the single-repo worker (#562)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2627,7 +2627,15 @@ func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
 	return runQueuedJobsForRepo(ctx, worker, limit, "", "")
 }
 
-func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) error {
+// retryPendingJobAdvancements re-runs the post-delivery workflow for terminal
+// jobs whose advancement previously failed. checkoutHeld (nil ⇒ no gate, the
+// legacy inline-tick behavior) reports whether an in-flight dispatched job
+// currently holds a checkout key: a candidate whose own checkout key is held is
+// skipped this tick (#562 review) — advancement mutates that checkout, and the
+// live path only ever runs it under the job's own key — and retried on a later
+// tick once the key frees, instead of gating ALL retries on whole-repo idleness
+// (which a steady backlog can prevent indefinitely, freezing merge retries).
+func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool) error {
 	jobs, err := worker.Store.ListJobs(ctx)
 	if err != nil {
 		return err
@@ -2641,6 +2649,9 @@ func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilt
 			return err
 		}
 		if !needsRetry {
+			continue
+		}
+		if checkoutHeld != nil && checkoutHeld(queuedJobCheckoutKey(ctx, worker.Store, job)) {
 			continue
 		}
 		if err := worker.advanceJob(ctx, job); err != nil {
@@ -2690,7 +2701,15 @@ func (w jobWorker) delegationWorktreeCleanupPending(ctx context.Context, jobID s
 // reads just those. Correctness is unchanged: a worktree that genuinely needs
 // reclaiming still carries that marker and is still reclaimed; once reclaimed it
 // emits delegation_worktree_removed and drops out of the candidate set.
-func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) error {
+// checkoutHeld (nil ⇒ no gate, the legacy inline-tick behavior) skips a
+// candidate while an in-flight job holds either the terminal child's own
+// worktree key (someone is running in the worktree being reclaimed — e.g. a
+// continuation reusing it) or the repo's shared checkout key (the reclaim's git
+// commands run from the parent checkout). Skipped candidates keep their pending
+// marker and are reclaimed on a later tick, so under a steady backlog preserved
+// worktrees are still reclaimed instead of leaking until full idleness (#562
+// review).
+func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool) error {
 	jobIDs, err := worker.Store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
 	if err != nil {
 		return err
@@ -2707,6 +2726,14 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 		}
 		if !jobStateCanRetryAdvancement(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
+		}
+		if checkoutHeld != nil {
+			if checkoutHeld(queuedJobCheckoutKey(ctx, worker.Store, job)) {
+				continue
+			}
+			if repoFilter != "" && checkoutHeld("repo:"+repoFilter) {
+				continue
+			}
 		}
 		engine := worker.WorkflowFactory(worker.delegationParentCheckout(ctx, job))
 		if err := engine.ReclaimTerminalDelegationWorktree(ctx, jobID); err != nil {
@@ -2731,11 +2758,14 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 //   - the expired runtime-lock reaper likewise skips locks owned by in-flight
 //     jobs (their goroutine is alive; releasing the lock could double-run the
 //     session);
-//   - checkout-mutating maintenance (advancement retries, delegation worktree
-//     reclaims, comment retries) runs only on an IDLE tick — the same cadence
-//     inline execution used to allow, made explicit — so it never mutates the
-//     checkout under a running job;
-//   - dispatch goes through dispatchQueuedJobsTracked, which returns promptly.
+//   - comment retries (no checkout touched) run every tick; checkout-mutating
+//     maintenance (advancement retries, delegation worktree reclaims) skips any
+//     candidate whose checkout key an in-flight job holds — so it never mutates
+//     a checkout under a running job, without being starved forever by a repo
+//     that always has SOMETHING in flight;
+//   - dispatch goes through dispatchQueuedJobsTracked, which returns promptly
+//     and bounds in-flight jobs by both the repo limit and the host-global
+//     --workers cap.
 func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, rootFilter string, stdout io.Writer, now time.Time, tracker *inflightJobTracker) error {
 	if dryRun {
 		return nil
@@ -2747,16 +2777,34 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	if err := recoverExpiredRuntimeSessionLocksSkipping(ctx, store, stdout, now, inflightIDs); err != nil {
 		return err
 	}
-	if !tracker.busy(repoFilter) {
-		if err := retryPendingJobAdvancements(ctx, worker, repoFilter, rootFilter); err != nil {
+	// Checkout-mutating maintenance (advancement/merge retries, delegation
+	// worktree reclaims) is gated on the ACTUAL mutation hazard — each
+	// candidate is skipped while an in-flight job holds the checkout key the
+	// retry would touch — not on whole-repo idleness, which a steady staggered
+	// backlog can prevent indefinitely (main's blocking barrier guaranteed an
+	// idle point between batches; tracked dispatch does not). The per-key gate
+	// mirrors the live path: a finishing job runs this same advancement inline
+	// under its own key while other keys stay busy. It is race-free on the
+	// barrier because begin() only ever runs on THIS goroutine (in the dispatch
+	// below) and end() only frees keys; a live background POOL pass begins jobs
+	// on its own goroutine, so it still defers the whole block (matching main,
+	// where a live pool pass blocked the tick entirely).
+	if !tracker.poolRunning(repoFilter) {
+		if err := retryPendingJobAdvancements(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld); err != nil {
 			return err
 		}
-		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter); err != nil {
+		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld); err != nil {
 			return err
 		}
-		if err := retryPendingJobComments(ctx, worker, repoFilter, rootFilter); err != nil {
-			return err
-		}
+	}
+	// Comment retries only post PR comments through the commenter — they never
+	// touch a checkout — so they run EVERY tick regardless of in-flight work,
+	// exactly main's cadence (and main's advancements→reclaims→comments order).
+	// Gating them on an idle repo would let one multi-hour in-flight job delay a
+	// transiently-failed result comment (and any downstream automation waiting
+	// on it) for the job's whole duration.
+	if err := retryPendingJobComments(ctx, worker, repoFilter, rootFilter); err != nil {
+		return err
 	}
 	// Per-repo concurrency override (#576): a [repos."owner/repo"] section caps
 	// THIS repo's in-flight concurrency (and may flip its scheduler) without a
@@ -2770,7 +2818,7 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	if tracker == nil {
 		return runQueuedJobsForRepo(ctx, worker, limit, repoFilter, rootFilter)
 	}
-	return dispatchQueuedJobsTracked(ctx, worker, limit, repoFilter, rootFilter, tracker)
+	return dispatchQueuedJobsTracked(ctx, worker, limit, workers, repoFilter, rootFilter, tracker)
 }
 
 func runEnabledRepoWorkerTicks(ctx context.Context, store *db.Store, worker jobWorker, workers int, stdout io.Writer, now time.Time) error {
@@ -3128,7 +3176,20 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 // dispatcher goroutine; worker goroutines communicate only via the done channel,
 // so no lock is required.
 func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, repoFilter string, rootFilter string) error {
-	return runQueuedJobsForRepoPoolTracked(ctx, worker, limit, repoFilter, rootFilter, nil)
+	return runQueuedJobsForRepoPoolTracked(ctx, worker, limit, limit, repoFilter, rootFilter, nil)
+}
+
+// poolDispatchSlots is a pool pass's dispatch budget: the repo's free slots,
+// clamped by the host-global remainder (hostCap − tracked in-flight across ALL
+// repos) so concurrent per-repo passes never exceed the daemon-wide cap. With a
+// nil tracker total() is 0 and hostCap == limit, so the clamp is inert and the
+// result is exactly the historical limit − running.
+func poolDispatchSlots(limit, running, hostCap int, tracker *inflightJobTracker) int {
+	slots := limit - running
+	if hostSlots := hostCap - tracker.total(); hostSlots < slots {
+		slots = hostSlots
+	}
+	return slots
 }
 
 // runQueuedJobsForRepoPoolTracked is the pool pass with the supervisor's
@@ -3136,9 +3197,12 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 // poller/maintenance gates and the shutdown drain see pool work, the tracker's
 // keys are unioned into the selection seeds so a pool pass never dispatches
 // beside a tracked non-pool job holding the same checkout/runtime key (a warm
-// scheduler flip mid-run), and jobs already in flight are filtered out. A nil
-// tracker is byte-identical to the historical pool.
-func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limit int, repoFilter string, rootFilter string, tracker *inflightJobTracker) error {
+// scheduler flip mid-run), and jobs already in flight are filtered out. hostCap
+// additionally clamps each dispatch by the tracker's HOST-global in-flight
+// count, so concurrent per-repo pool passes cannot multiply --workers by the
+// number of enabled repos. A nil tracker (hostCap == limit, total() == 0) is
+// byte-identical to the historical pool.
+func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limit int, hostCap int, repoFilter string, rootFilter string, tracker *inflightJobTracker) error {
 	if limit <= 0 {
 		return nil
 	}
@@ -3153,7 +3217,11 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 		runtimeKey   string
 		worktreePath string
 		repoCheckout string
-		err          error
+		// payloadBeforeIsolation is the job's payload as it was before an
+		// isolation worktree was allocated and written into it; non-empty only
+		// for isolation-dispatched jobs.
+		payloadBeforeIsolation string
+		err                    error
 	}
 	inflightCheckouts := map[string]bool{}
 	inflightRuntimes := map[string]bool{}
@@ -3165,6 +3233,16 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 		delete(inflightCheckouts, f.checkoutKey)
 		if f.runtimeKey != "" {
 			delete(inflightRuntimes, f.runtimeKey)
+		}
+		// An isolation-dispatched job that bounced errRuntimeSessionBusy was never
+		// claimed and stays queued — but its payload was rewritten to point at the
+		// isolation worktree this reap is about to delete. Restore the
+		// pre-isolation payload (best-effort, non-cancellable like the worktree
+		// removal) so its next dispatch re-evaluates cleanly instead of
+		// preflight-failing terminally on a reaped path. Done before tracker.end
+		// so no other selector can re-dispatch it mid-restore.
+		if f.payloadBeforeIsolation != "" && errors.Is(f.err, errRuntimeSessionBusy) {
+			_ = worker.Store.UpdateJobPayload(context.WithoutCancel(ctx), f.jobID, f.payloadBeforeIsolation)
 		}
 		tracker.end(f.jobID)
 		// Release the host-global admission reservation (#365) keyed by job ID,
@@ -3209,7 +3287,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 			pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter)
 			if err != nil {
 				firstErr = err
-			} else if slots := limit - running; slots > 0 {
+			} else if slots := poolDispatchSlots(limit, running, hostCap, tracker); slots > 0 {
 				// Union in the supervisor tracker's in-flight keys (#562): a tracked
 				// non-pool job (e.g. dispatched before a warm scheduler flip) must
 				// block same-key pool dispatch exactly like a pool-local one. Jobs
@@ -3245,7 +3323,10 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					}
 					checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
 					runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
-					if !tracker.begin(job.ID, repoFilter, checkoutKey, runtimeKey) {
+					// beginWithin re-checks the host-global cap atomically with
+					// registration: a concurrent pass for another repo may have consumed
+					// the headroom this pass's slot computation saw.
+					if !tracker.beginWithin(hostCap, job.ID, repoFilter, checkoutKey, runtimeKey) {
 						worker.Admission.Release(job.ID)
 						continue
 					}
@@ -3264,19 +3345,31 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 				// the holder in an auto-created detached worktree — the distinct
 				// worktree:<path> key is safe to parallelize. This is what lets an awaited
 				// same-repo follow-up (the #394 deadlock) make progress.
+				// The checks below consult the LIVE inflightCheckouts/inflightRuntimes
+				// maps as well as the seed unions: seedCheckouts/seedRuntimes are
+				// per-pass COPIES when a tracker is present, so a job dispatched by the
+				// loop above (which mutates only the live maps) would otherwise be
+				// invisible here — letting a same-runtime-session job be
+				// isolation-dispatched beside its just-started sibling. The loser of
+				// that session-lock race would bounce busy AFTER its payload was
+				// rewritten to the isolation worktree, which reap() then deletes,
+				// leaving a queued job pointing at a reaped path that terminally fails
+				// on its next run. With a nil tracker the seed and live maps are the
+				// same object, so this is byte-identical to the historical pool.
 				for _, job := range remaining {
-					if running >= limit {
+					if running >= limit || tracker.total() >= hostCap {
 						break
 					}
 					payload, perr := daemonJobPayload(job)
 					if perr != nil || !poolIsolationEligible(job, payload) {
 						continue
 					}
-					if queuedJobCheckoutKey(ctx, worker.Store, job) != "repo:"+payload.Repo || !seedCheckouts["repo:"+payload.Repo] {
+					if queuedJobCheckoutKey(ctx, worker.Store, job) != "repo:"+payload.Repo ||
+						!(inflightCheckouts["repo:"+payload.Repo] || seedCheckouts["repo:"+payload.Repo]) {
 						continue // not blocked by a contended same-repo checkout
 					}
 					runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
-					if runtimeKey != "" && (seedRuntimes[runtimeKey] || runtimeResourceLocked(ctx, worker.Store, runtimeKey)) {
+					if runtimeKey != "" && (inflightRuntimes[runtimeKey] || seedRuntimes[runtimeKey] || runtimeResourceLocked(ctx, worker.Store, runtimeKey)) {
 						continue // also runtime-contended; leave it to the runtime/temp-worker path
 					}
 					// Host-global admission gate (#365): reserve before creating the
@@ -3287,13 +3380,19 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						}
 						continue
 					}
+					payloadBeforeIsolation := job.Payload
 					iso, ok := worker.allocatePoolIsolationWorktree(ctx, job, payload)
 					if !ok {
 						worker.Admission.Release(job.ID)
 						continue
 					}
-					if !tracker.begin(iso.job.ID, repoFilter, iso.checkoutKey, iso.runtimeKey) {
+					if !tracker.beginWithin(hostCap, iso.job.ID, repoFilter, iso.checkoutKey, iso.runtimeKey) {
 						worker.Admission.Release(iso.job.ID)
+						// Undo the allocation completely: the payload now points at the
+						// isolation worktree being removed, and the job stays queued — a
+						// host-cap or double-dispatch refusal must not strand it on a
+						// reaped path.
+						_ = worker.Store.UpdateJobPayload(context.WithoutCancel(ctx), iso.job.ID, payloadBeforeIsolation)
 						_ = gitutil.Client{Dir: iso.repoCheckout}.RemoveWorktreeForce(context.WithoutCancel(ctx), iso.worktreePath)
 						continue
 					}
@@ -3304,7 +3403,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					running++
 					dispatched++
 					go func() {
-						done <- finished{jobID: iso.job.ID, checkoutKey: iso.checkoutKey, runtimeKey: iso.runtimeKey, worktreePath: iso.worktreePath, repoCheckout: iso.repoCheckout, err: runPoolJobRecovered(ctx, worker, iso.job)}
+						done <- finished{jobID: iso.job.ID, checkoutKey: iso.checkoutKey, runtimeKey: iso.runtimeKey, worktreePath: iso.worktreePath, repoCheckout: iso.repoCheckout, payloadBeforeIsolation: payloadBeforeIsolation, err: runPoolJobRecovered(ctx, worker, iso.job)}
 					}()
 				}
 			}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1480,6 +1480,15 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 			if err := recoverCancelledRunningJobsForEnabledRepos(ctx, store, rootFilter, stdout); err != nil {
 				return err
 			}
+			// The in-flight tracker (#562) keeps one hung/long job on any repo
+			// from wedging the whole sweep: ticks claim + dispatch async and
+			// return promptly. The poller consults it so a repo with in-flight
+			// jobs degrades to the recovery-only poll instead of mutating the
+			// checkout under a running job. The deferred drain cancels + waits
+			// (bounded) for in-flight jobs on exit.
+			tracker := newInflightJobTracker(ctx)
+			defer tracker.drain(stdout, daemonShutdownDrainTimeout)
+			poller.Inflight = tracker
 			workerErr = startSupervisorWorkerLoopRecovering(ctx, daemonWorkerLoopInterval, stdout, func(now time.Time) error {
 				// Read the warm-reloadable worker count + scheduler mode each tick
 				// (#577). The worker is copied per tick so setting UsePool is race-free
@@ -1488,7 +1497,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 				_, workers, usePool := live.snapshot()
 				w := worker
 				w.UsePool = usePool
-				return runEnabledRepoWorkerTicksWithLocks(ctx, store, w, workers, rootFilter, stdout, now, checkoutLocks)
+				return runEnabledRepoWorkerTicksTracked(ctx, store, w, workers, rootFilter, stdout, now, checkoutLocks, tracker)
 			})
 			startCockpitReconcileLoop(ctx, store, paths.Home, stdout)
 		}
@@ -1544,17 +1553,13 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	worker.CommenterFactory = worker.defaultCommenter
 	worker.Admission = worker.loadAdmissionBudget()
 	var checkoutLock sync.Mutex
-	workerErr := startSupervisorWorkerLoopRecovering(ctx, daemonWorkerLoopInterval, stdout, func(now time.Time) error {
-		checkoutLock.Lock()
-		defer checkoutLock.Unlock()
-		// Read the warm-reloadable worker count + scheduler mode each tick (#577);
-		// the worker is copied per tick so UsePool is race-free with the SIGHUP
-		// reload goroutine.
-		_, workers, usePool := live.snapshot()
-		w := worker
-		w.UsePool = usePool
-		return runDaemonWorkerTick(ctx, store, w, workers, false, d.Repo.FullName(), rootFilter, stdout, now)
-	})
+	// The in-flight tracker (#562) is what keeps ONE hung/long job from wedging
+	// this whole loop: ticks claim + dispatch async and return, while the tracker
+	// preserves same-repo serialization, concurrency caps, and poller exclusion.
+	// The deferred drain cancels + waits (bounded) for in-flight jobs on exit.
+	tracker := newInflightJobTracker(ctx)
+	defer tracker.drain(stdout, daemonShutdownDrainTimeout)
+	workerErr := startSingleRepoWorkerLoop(ctx, daemonWorkerLoopInterval, store, worker, live, &checkoutLock, tracker, d.Repo.FullName(), rootFilter, stdout)
 	startCockpitReconcileLoop(ctx, store, home, stdout)
 	// Heartbeat schedules (#533) must also fire in the single-repo daemon, or a
 	// single-repo daemon would silently never run them. Off-by-default: with no
@@ -1572,10 +1577,21 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 		if err := receiveSupervisorWorkerError(workerErr); err != nil {
 			return err
 		}
+		// A full PollOnce may mutate the shared checkout (merge retries, task
+		// reconciles), so it needs BOTH the checkout lock (excludes the tick, and
+		// — because dispatch happens under that lock — excludes NEW jobs starting
+		// mid-poll) AND an idle tracker (excludes already in-flight jobs, which
+		// the tick no longer holds the lock for while they run, #562). Otherwise
+		// fall back to the recovery-command-only poll, exactly as before.
+		polledFull := false
 		if checkoutLock.TryLock() {
-			_ = runDaemonPollWithTimeout(ctx, daemonPollTimeout, d.PollOnce)
+			if !tracker.busy(d.Repo.FullName()) {
+				_ = runDaemonPollWithTimeout(ctx, daemonPollTimeout, d.PollOnce)
+				polledFull = true
+			}
 			checkoutLock.Unlock()
-		} else {
+		}
+		if !polledFull {
 			_ = runDaemonPollWithTimeout(ctx, daemonPollTimeout, d.PollRecoveryCommandsOnce)
 		}
 		if heartbeatPathsErr == nil {
@@ -1818,6 +1834,31 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 	return enqueueErr
 }
 
+// startSingleRepoWorkerLoop wires the single-repo supervisor's per-tick worker
+// closure — the checkout-lock discipline, the warm-reloadable worker/scheduler
+// snapshot (#577), and the tracked worker tick (#562) — and starts it on the
+// recovering loop. It is the ONE production wiring runSingleRepoSupervisor
+// uses; the #562 wedge E2E drives this exact function so the tested loop can
+// never drift from the deployed one.
+func startSingleRepoWorkerLoop(ctx context.Context, interval time.Duration, store *db.Store, worker jobWorker, live *daemonReloadableConfig, checkoutLock *sync.Mutex, tracker *inflightJobTracker, repo string, rootFilter string, stdout io.Writer) <-chan error {
+	return startSupervisorWorkerLoopRecovering(ctx, interval, stdout, func(now time.Time) error {
+		// The checkout lock now guards the TICK (maintenance + claim/dispatch),
+		// not whole job runs: dispatched jobs execute on their own goroutines
+		// after this returns, tracked by the in-flight tracker (#562). Holding it
+		// across dispatch is still what makes the poller's full-PollOnce gate
+		// race-free (no new checkout-occupying job can start mid-poll).
+		checkoutLock.Lock()
+		defer checkoutLock.Unlock()
+		// Read the warm-reloadable worker count + scheduler mode each tick (#577);
+		// the worker is copied per tick so UsePool is race-free with the SIGHUP
+		// reload goroutine.
+		_, workers, usePool := live.snapshot()
+		w := worker
+		w.UsePool = usePool
+		return runDaemonWorkerTickTracked(ctx, store, w, workers, false, repo, rootFilter, stdout, now, tracker)
+	})
+}
+
 func startSupervisorWorkerLoop(ctx context.Context, interval time.Duration, run func(time.Time) error) <-chan error {
 	return startSupervisorWorkerLoopInternal(ctx, interval, nil, run, false)
 }
@@ -2022,8 +2063,14 @@ type registeredRepoPoller struct {
 	EscalationTTL          time.Duration
 	RevertDetectionEnabled bool
 	CheckoutLocks          *repoCheckoutLocks
-	GitHubClient           func(checkout string) github.Client
-	WorkflowFactory        func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
+	// Inflight is the supervisor's in-flight job tracker (#562). A repo with
+	// dispatched jobs still running gets the recovery-command-only poll: a full
+	// PollOnce may mutate the shared checkout, which used to be excluded by the
+	// per-repo lock being held for entire job runs. nil (legacy/test callers)
+	// behaves as always-idle.
+	Inflight        *inflightJobTracker
+	GitHubClient    func(checkout string) github.Client
+	WorkflowFactory func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
 }
 
 // defaultRegisteredRepoPoller wires the registered-repo supervisor's per-tick
@@ -2169,6 +2216,15 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 		} else {
 			recoveryOnly = true
 		}
+	}
+	// In-flight gate (#562): jobs no longer run under the per-repo lock, so a
+	// held lock alone can't prove the checkout is quiet. While this repo has
+	// dispatched jobs still running, degrade to the recovery-only poll — the
+	// same exclusion inline execution used to give. Checked AFTER TryLock: new
+	// checkout-occupying jobs dispatch only under the lock we now hold, so an
+	// idle verdict cannot be raced by a fresh dispatch mid-poll.
+	if p.Inflight.busy(repoRecord.FullName()) {
+		recoveryOnly = true
 	}
 	d := daemon.Daemon{
 		Repo:                   repo,
@@ -2396,6 +2452,17 @@ func recoverRunningJobs(ctx context.Context, store *db.Store, stdout io.Writer) 
 }
 
 func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time) error {
+	return recoverExpiredRuntimeSessionLocksSkipping(ctx, store, stdout, now, nil)
+}
+
+// recoverExpiredRuntimeSessionLocksSkipping is recoverExpiredRuntimeSessionLocks
+// with an in-flight owner exclusion (#562): a lock whose owner job is currently
+// being run BY THIS PROCESS is neither requeued nor reaped even if its lease has
+// expired — the owning goroutine is still alive (a ctx-deaf runtime overrunning
+// its timeout), and releasing its lock would let a second run of the same
+// session start beside it (the #536 hazard). A nil skip set is byte-identical
+// to the unskipped recovery.
+func recoverExpiredRuntimeSessionLocksSkipping(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time, skipOwners map[string]bool) error {
 	expiredRuntimeLocks, err := store.ListExpiredRuntimeSessionLocks(ctx, now)
 	if err != nil {
 		return err
@@ -2410,7 +2477,7 @@ func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, std
 	// (which would strand those owners as 'running' until the coarse 30m window).
 	// TransitionJobStateWithEvent is a no-op unless the owner is still 'running'.
 	for _, lock := range expiredRuntimeLocks {
-		if strings.TrimSpace(lock.OwnerJobID) == "" {
+		if strings.TrimSpace(lock.OwnerJobID) == "" || skipOwners[lock.OwnerJobID] {
 			continue
 		}
 		recovered, err := store.TransitionJobStateWithEvent(ctx, lock.OwnerJobID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
@@ -2425,7 +2492,7 @@ func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, std
 			writeLine(stdout, "requeued running job %s after runtime session lock expired", lock.OwnerJobID)
 		}
 	}
-	deleted, err := store.DeleteExpiredResourceLocks(ctx, now)
+	deleted, err := store.DeleteExpiredResourceLocksExcludingOwners(ctx, now, sortedStringSetKeys(skipOwners))
 	if err != nil {
 		return err
 	}
@@ -2490,11 +2557,24 @@ func recoverCancelledRunningJobsForRepo(ctx context.Context, store *db.Store, st
 }
 
 func recoverRunningJobsBeforeForRepo(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time, before time.Time, repoFilter string, rootFilter string) error {
+	return recoverRunningJobsBeforeForRepoSkipping(ctx, store, stdout, now, before, repoFilter, rootFilter, nil)
+}
+
+// recoverRunningJobsBeforeForRepoSkipping is recoverRunningJobsBeforeForRepo
+// with an in-flight exclusion (#562): a job THIS process is currently running is
+// never treated as crashed-stale, even past the coarse 30m backstop with no
+// runtime lease (e.g. a long shell-runtime job holds no lease at all). Inline
+// execution used to guarantee this by never scanning while a job ran; the async
+// dispatcher must guarantee it explicitly. A nil skip set is byte-identical.
+func recoverRunningJobsBeforeForRepoSkipping(ctx context.Context, store *db.Store, stdout io.Writer, now time.Time, before time.Time, repoFilter string, rootFilter string, skipJobs map[string]bool) error {
 	jobs, err := store.ListRunningJobsUpdatedBefore(ctx, before)
 	if err != nil {
 		return err
 	}
 	for _, job := range jobs {
+		if skipJobs[job.ID] {
+			continue
+		}
 		if !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
@@ -2637,23 +2717,46 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 }
 
 func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, rootFilter string, stdout io.Writer, now time.Time) error {
+	return runDaemonWorkerTickTracked(ctx, store, worker, workers, dryRun, repoFilter, rootFilter, stdout, now, nil)
+}
+
+// runDaemonWorkerTickTracked is the per-tick worker pass. With a nil tracker it
+// is byte-identical to the historical runDaemonWorkerTick: maintenance scans,
+// then a BLOCKING runQueuedJobsForRepo dispatch. The supervisors pass a live
+// tracker (#562), which changes the tick to claim-and-dispatch-async:
+//
+//   - recovery scans skip jobs THIS process is running (an in-flight >30m job
+//     with no runtime lease — e.g. a shell-runtime job — must not be requeued
+//     out from under its own live worker by its own daemon's tick);
+//   - the expired runtime-lock reaper likewise skips locks owned by in-flight
+//     jobs (their goroutine is alive; releasing the lock could double-run the
+//     session);
+//   - checkout-mutating maintenance (advancement retries, delegation worktree
+//     reclaims, comment retries) runs only on an IDLE tick — the same cadence
+//     inline execution used to allow, made explicit — so it never mutates the
+//     checkout under a running job;
+//   - dispatch goes through dispatchQueuedJobsTracked, which returns promptly.
+func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, rootFilter string, stdout io.Writer, now time.Time, tracker *inflightJobTracker) error {
 	if dryRun {
 		return nil
 	}
-	if err := recoverRunningJobsBeforeForRepo(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter(stdout)), repoFilter, rootFilter); err != nil {
+	inflightIDs := tracker.inflightIDs()
+	if err := recoverRunningJobsBeforeForRepoSkipping(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter(stdout)), repoFilter, rootFilter, inflightIDs); err != nil {
 		return err
 	}
-	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, now); err != nil {
+	if err := recoverExpiredRuntimeSessionLocksSkipping(ctx, store, stdout, now, inflightIDs); err != nil {
 		return err
 	}
-	if err := retryPendingJobAdvancements(ctx, worker, repoFilter, rootFilter); err != nil {
-		return err
-	}
-	if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter); err != nil {
-		return err
-	}
-	if err := retryPendingJobComments(ctx, worker, repoFilter, rootFilter); err != nil {
-		return err
+	if !tracker.busy(repoFilter) {
+		if err := retryPendingJobAdvancements(ctx, worker, repoFilter, rootFilter); err != nil {
+			return err
+		}
+		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter); err != nil {
+			return err
+		}
+		if err := retryPendingJobComments(ctx, worker, repoFilter, rootFilter); err != nil {
+			return err
+		}
 	}
 	// Per-repo concurrency override (#576): a [repos."owner/repo"] section caps
 	// THIS repo's in-flight concurrency (and may flip its scheduler) without a
@@ -2664,14 +2767,21 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 	// local to this tick's dispatch and never leaks to sibling repos.
 	limit, usePool := worker.resolveRepoScheduler(repoFilter, workers)
 	worker.UsePool = usePool
-	return runQueuedJobsForRepo(ctx, worker, limit, repoFilter, rootFilter)
+	if tracker == nil {
+		return runQueuedJobsForRepo(ctx, worker, limit, repoFilter, rootFilter)
+	}
+	return dispatchQueuedJobsTracked(ctx, worker, limit, repoFilter, rootFilter, tracker)
 }
 
 func runEnabledRepoWorkerTicks(ctx context.Context, store *db.Store, worker jobWorker, workers int, stdout io.Writer, now time.Time) error {
-	return runEnabledRepoWorkerTicksWithLocks(ctx, store, worker, workers, "", stdout, now, nil)
+	return runEnabledRepoWorkerTicksTracked(ctx, store, worker, workers, "", stdout, now, nil, nil)
 }
 
 func runEnabledRepoWorkerTicksWithLocks(ctx context.Context, store *db.Store, worker jobWorker, workers int, rootFilter string, stdout io.Writer, now time.Time, locks *repoCheckoutLocks) error {
+	return runEnabledRepoWorkerTicksTracked(ctx, store, worker, workers, rootFilter, stdout, now, locks, nil)
+}
+
+func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, worker jobWorker, workers int, rootFilter string, stdout io.Writer, now time.Time, locks *repoCheckoutLocks, tracker *inflightJobTracker) error {
 	repos, err := store.ListRepos(ctx)
 	if err != nil {
 		return err
@@ -2697,7 +2807,7 @@ func runEnabledRepoWorkerTicksWithLocks(ctx context.Context, store *db.Store, wo
 		if lock != nil {
 			lock.Lock()
 		}
-		tickErr := runDaemonWorkerTick(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now)
+		tickErr := runDaemonWorkerTickTracked(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now, tracker)
 		if lock != nil {
 			lock.Unlock()
 		}
@@ -3018,6 +3128,17 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 // dispatcher goroutine; worker goroutines communicate only via the done channel,
 // so no lock is required.
 func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, repoFilter string, rootFilter string) error {
+	return runQueuedJobsForRepoPoolTracked(ctx, worker, limit, repoFilter, rootFilter, nil)
+}
+
+// runQueuedJobsForRepoPoolTracked is the pool pass with the supervisor's
+// in-flight tracker mirrored in (#562): each dispatched job is registered so the
+// poller/maintenance gates and the shutdown drain see pool work, the tracker's
+// keys are unioned into the selection seeds so a pool pass never dispatches
+// beside a tracked non-pool job holding the same checkout/runtime key (a warm
+// scheduler flip mid-run), and jobs already in flight are filtered out. A nil
+// tracker is byte-identical to the historical pool.
+func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limit int, repoFilter string, rootFilter string, tracker *inflightJobTracker) error {
 	if limit <= 0 {
 		return nil
 	}
@@ -3045,6 +3166,7 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 		if f.runtimeKey != "" {
 			delete(inflightRuntimes, f.runtimeKey)
 		}
+		tracker.end(f.jobID)
 		// Release the host-global admission reservation (#365) keyed by job ID,
 		// alongside the checkout/runtime release. Release is idempotent and a nil
 		// budget is a no-op, so this is safe on every reap path incl. panic
@@ -3088,7 +3210,26 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 			if err != nil {
 				firstErr = err
 			} else if slots := limit - running; slots > 0 {
-				queued, remaining := selectRunnableQueuedJobsSeeded(ctx, worker.Store, pending, slots, policy, inflightCheckouts, inflightRuntimes)
+				// Union in the supervisor tracker's in-flight keys (#562): a tracked
+				// non-pool job (e.g. dispatched before a warm scheduler flip) must
+				// block same-key pool dispatch exactly like a pool-local one. Jobs
+				// already in flight anywhere in this process are filtered by ID.
+				// The union is a fresh per-pass COPY: the pool's own maps stay
+				// reap-owned, so a foreign key never lingers after its job ends.
+				seedCheckouts, seedRuntimes := inflightCheckouts, inflightRuntimes
+				if tracker != nil {
+					trackerCheckouts, trackerRuntimes := tracker.seeds()
+					eligible := pending[:0]
+					for _, job := range pending {
+						if !tracker.inflightJob(job.ID) {
+							eligible = append(eligible, job)
+						}
+					}
+					pending = eligible
+					seedCheckouts = unionStringSets(inflightCheckouts, trackerCheckouts)
+					seedRuntimes = unionStringSets(inflightRuntimes, trackerRuntimes)
+				}
+				queued, remaining := selectRunnableQueuedJobsSeeded(ctx, worker.Store, pending, slots, policy, seedCheckouts, seedRuntimes)
 				for _, job := range queued {
 					job := job
 					// Host-global admission gate (#365): reserve a session slot + RAM
@@ -3097,10 +3238,17 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 					// pool re-queries on the next pass once a reap frees a slot — never
 					// failed/dropped. A nil budget always admits ⇒ byte-identical default.
 					if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
+						if tracker != nil {
+							warnJobHeldBack(worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
+						}
 						continue
 					}
 					checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
 					runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
+					if !tracker.begin(job.ID, repoFilter, checkoutKey, runtimeKey) {
+						worker.Admission.Release(job.ID)
+						continue
+					}
 					inflightCheckouts[checkoutKey] = true
 					if runtimeKey != "" {
 						inflightRuntimes[runtimeKey] = true
@@ -3124,21 +3272,29 @@ func runQueuedJobsForRepoPool(ctx context.Context, worker jobWorker, limit int, 
 					if perr != nil || !poolIsolationEligible(job, payload) {
 						continue
 					}
-					if queuedJobCheckoutKey(ctx, worker.Store, job) != "repo:"+payload.Repo || !inflightCheckouts["repo:"+payload.Repo] {
+					if queuedJobCheckoutKey(ctx, worker.Store, job) != "repo:"+payload.Repo || !seedCheckouts["repo:"+payload.Repo] {
 						continue // not blocked by a contended same-repo checkout
 					}
 					runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
-					if runtimeKey != "" && (inflightRuntimes[runtimeKey] || runtimeResourceLocked(ctx, worker.Store, runtimeKey)) {
+					if runtimeKey != "" && (seedRuntimes[runtimeKey] || runtimeResourceLocked(ctx, worker.Store, runtimeKey)) {
 						continue // also runtime-contended; leave it to the runtime/temp-worker path
 					}
 					// Host-global admission gate (#365): reserve before creating the
 					// isolation worktree so a deferred job leaves no orphan worktree behind.
 					if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
+						if tracker != nil {
+							warnJobHeldBack(worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
+						}
 						continue
 					}
 					iso, ok := worker.allocatePoolIsolationWorktree(ctx, job, payload)
 					if !ok {
 						worker.Admission.Release(job.ID)
+						continue
+					}
+					if !tracker.begin(iso.job.ID, repoFilter, iso.checkoutKey, iso.runtimeKey) {
+						worker.Admission.Release(iso.job.ID)
+						_ = gitutil.Client{Dir: iso.repoCheckout}.RemoveWorktreeForce(context.WithoutCancel(ctx), iso.worktreePath)
 						continue
 					}
 					inflightCheckouts[iso.checkoutKey] = true

--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -29,15 +29,21 @@ import (
 //     shared checkout (the barrier used to get this from one wg.Wait()).
 //   - concurrency caps: dispatch slots are limit minus the repo's tracked
 //     in-flight count, so --workers / per-repo max_parallel (#576) still bound
-//     TOTAL in-flight jobs, not just per-batch ones.
+//     TOTAL in-flight jobs, not just per-batch ones — AND the shared tracker's
+//     host-global count clamps the sum across repos, so a multi-repo daemon
+//     never runs more than max(--workers, the repo's explicit override)
+//     jobs host-wide (main's inline sweep gave this for free by blocking).
 //   - poller exclusion: the poller only runs a full PollOnce when the tracker is
 //     idle for the repo, so PollOnce never mutates a checkout under a running job
 //     (previously guaranteed by the tick holding the checkout lock for the whole
 //     run).
-//   - maintenance exclusion: checkout-mutating tick maintenance (advancement
-//     retries, worktree reclaims, comment retries) runs only on an idle tick,
-//     exactly the cadence inline execution allowed; DB-only recovery scans keep
-//     running every tick but skip jobs this process is itself running.
+//   - maintenance exclusion: comment retries never touch a checkout and run
+//     every tick (main's cadence); checkout-mutating maintenance (advancement
+//     retries, worktree reclaims) is gated per candidate on the checkout key it
+//     would mutate being free of in-flight holders — NOT on whole-repo
+//     idleness, which a steady staggered backlog could prevent indefinitely,
+//     starving merge retries forever. DB-only recovery scans keep running
+//     every tick but skip jobs this process is itself running.
 //   - #570 escalation: an async infra error (job-level failures already resolve
 //     to nil inside worker.run) is recorded per repo and surfaced as the NEXT
 //     tick's error, so a persistent store fault still trips the ceiling.
@@ -106,6 +112,17 @@ func (t *inflightJobTracker) jobContext(fallback context.Context) context.Contex
 // double-dispatch guard for the window in which a claimed job is still 'queued'
 // in the DB.
 func (t *inflightJobTracker) begin(jobID, repo, checkoutKey, runtimeKey string) bool {
+	return t.beginWithin(0, jobID, repo, checkoutKey, runtimeKey)
+}
+
+// beginWithin is begin with an ATOMIC host-global admission check: when
+// hostCap > 0 it refuses (registering nothing) if the tracker already has
+// hostCap jobs in flight across all repos. The check must live under the same
+// mutex as the registration: concurrent per-repo pool passes each compute
+// their slot budgets from a snapshot, so two passes could both see one slot of
+// host headroom and both dispatch past the cap if the check were external.
+// hostCap <= 0 means unbounded (plain begin).
+func (t *inflightJobTracker) beginWithin(hostCap int, jobID, repo, checkoutKey, runtimeKey string) bool {
 	if t == nil {
 		return true
 	}
@@ -116,6 +133,15 @@ func (t *inflightJobTracker) begin(jobID, repo, checkoutKey, runtimeKey string) 
 	}
 	if _, exists := t.jobs[jobID]; exists {
 		return false
+	}
+	if hostCap > 0 {
+		total := 0
+		for _, count := range t.perRepo {
+			total += count
+		}
+		if total >= hostCap {
+			return false
+		}
 	}
 	t.jobs[jobID] = inflightDispatch{repo: repo, checkoutKey: checkoutKey, runtimeKey: runtimeKey}
 	if checkoutKey != "" {
@@ -224,6 +250,37 @@ func (t *inflightJobTracker) inflight(repo string) int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return t.perRepo[repo]
+}
+
+// total reports the in-flight dispatched jobs across ALL repos — the host-global
+// counterpart of inflight(repo). The registered-repo supervisor shares one
+// tracker across every enabled repo, and clamping dispatch by this keeps
+// --workers a HOST-wide bound: without it, per-repo async dispatch would
+// multiply the cap by the number of enabled repos (main's inline sweep ran one
+// repo's batch at a time, so at most `workers` jobs ever ran host-wide).
+func (t *inflightJobTracker) total() int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := 0
+	for _, count := range t.perRepo {
+		n += count
+	}
+	return n
+}
+
+// checkoutHeld reports whether an in-flight dispatched job currently holds the
+// given checkout key. Nil-receiver safe (a nil tracker never holds anything),
+// so a method value taken from a nil tracker is a valid always-false predicate.
+func (t *inflightJobTracker) checkoutHeld(key string) bool {
+	if t == nil || key == "" {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.checkouts[key] > 0
 }
 
 // busy reports whether the repo has any in-flight dispatched job or a live
@@ -469,16 +526,31 @@ func explainHeldBackJobs(ctx context.Context, worker jobWorker, tracker *infligh
 // returns promptly (surfacing any async error a previously dispatched job
 // recorded) so the supervisor worker loop keeps ticking while jobs run.
 //
+// limit is the repo's resolved concurrency (global --workers or a per-repo
+// max_parallel override, #576); globalLimit is the daemon-wide --workers count.
+// Dispatch is clamped by BOTH the per-repo limit and the host-global remainder
+// max(globalLimit, limit) − tracker.total(): the registered-repo supervisor
+// runs this pass for every enabled repo with a shared tracker, and without the
+// global clamp each repo would independently fill `limit` slots — up to
+// workers × repos in-flight runtime subprocesses where main's inline sweep
+// never exceeded `workers` host-wide. Taking the max keeps an EXPLICIT
+// per-repo override able to raise its own repo's share (main's inline batch
+// honored it); with no override the host cap is exactly `workers`.
+//
 // Pool mode starts runQueuedJobsForRepoPool as a SINGLE-FLIGHT background pass
 // per repo: the pool already re-queries continuously and does its own in-flight
 // accounting (which it mirrors into the tracker for poller/maintenance gating),
 // so one live pass is both necessary and sufficient.
-func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int, repoFilter string, rootFilter string, tracker *inflightJobTracker) error {
+func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int, globalLimit int, repoFilter string, rootFilter string, tracker *inflightJobTracker) error {
 	if obs := dispatchLimitObserver; obs != nil {
 		obs(limit)
 	}
 	if limit <= 0 {
 		return tracker.takeErr(repoFilter)
+	}
+	hostCap := globalLimit
+	if limit > hostCap {
+		hostCap = limit
 	}
 	if serializingConfig(worker.UsePool, limit) {
 		warnSerializedParallelJobs(ctx, worker, limit, repoFilter, rootFilter)
@@ -488,7 +560,7 @@ func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int,
 			runCtx := tracker.jobContext(ctx)
 			go func() {
 				defer tracker.endPool(repoFilter)
-				err := runQueuedJobsForRepoPoolTracked(runCtx, worker, limit, repoFilter, rootFilter, tracker)
+				err := runQueuedJobsForRepoPoolTracked(runCtx, worker, limit, hostCap, repoFilter, rootFilter, tracker)
 				if err != nil && !errors.Is(err, context.Canceled) {
 					tracker.recordErr(repoFilter, err)
 				}
@@ -521,6 +593,11 @@ func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int,
 		}
 	}
 	slots := limit - tracker.inflight(repoFilter)
+	// Host-global clamp: never dispatch past the daemon-wide in-flight budget,
+	// whatever this repo's own remainder is (see the function comment).
+	if hostSlots := hostCap - tracker.total(); hostSlots < slots {
+		slots = hostSlots
+	}
 	if slots <= 0 || len(eligible) == 0 {
 		return tracker.takeErr(repoFilter)
 	}
@@ -540,7 +617,10 @@ func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int,
 		}
 		checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
 		runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
-		if !tracker.begin(job.ID, repoFilter, checkoutKey, runtimeKey) {
+		// beginWithin re-checks the host-global cap atomically with registration:
+		// a concurrent pool pass for another repo may have consumed the headroom
+		// this pass's slot computation saw.
+		if !tracker.beginWithin(hostCap, job.ID, repoFilter, checkoutKey, runtimeKey) {
 			worker.Admission.Release(job.ID)
 			continue
 		}

--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -1,0 +1,557 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// This file is the #562 fix: job execution runs OFF the supervisor worker-tick /
+// checkout-lock critical path, so one hung or multi-hour job can no longer wedge
+// the whole daemon (queued jobs unclaimed, recovery scans stalled) while `daemon
+// status` still reports running.
+//
+// The tick now CLAIMS runnable jobs and dispatches them to tracked goroutines,
+// returning promptly so the loop keeps ticking. Correctness that inline
+// execution used to provide by accident is preserved EXPLICITLY:
+//
+//   - same-repo serialization: an in-flight job's checkout/runtime keys are held
+//     in the tracker and seeded into selectRunnableQueuedJobsSeeded, so a
+//     same-repo no-worktree job is never dispatched beside the job occupying the
+//     shared checkout (the barrier used to get this from one wg.Wait()).
+//   - concurrency caps: dispatch slots are limit minus the repo's tracked
+//     in-flight count, so --workers / per-repo max_parallel (#576) still bound
+//     TOTAL in-flight jobs, not just per-batch ones.
+//   - poller exclusion: the poller only runs a full PollOnce when the tracker is
+//     idle for the repo, so PollOnce never mutates a checkout under a running job
+//     (previously guaranteed by the tick holding the checkout lock for the whole
+//     run).
+//   - maintenance exclusion: checkout-mutating tick maintenance (advancement
+//     retries, worktree reclaims, comment retries) runs only on an idle tick,
+//     exactly the cadence inline execution allowed; DB-only recovery scans keep
+//     running every tick but skip jobs this process is itself running.
+//   - #570 escalation: an async infra error (job-level failures already resolve
+//     to nil inside worker.run) is recorded per repo and surfaced as the NEXT
+//     tick's error, so a persistent store fault still trips the ceiling.
+//   - graceful shutdown: every dispatched job runs on the tracker's runCtx;
+//     drain() cancels it and waits (bounded) for in-flight jobs to finish.
+
+// daemonShutdownDrainTimeout bounds how long the daemon waits for in-flight
+// dispatched jobs to observe cancellation on shutdown before abandoning them
+// (a truly ctx-deaf subprocess must not block daemon stop forever).
+const daemonShutdownDrainTimeout = 15 * time.Second
+
+// heldBackLogInterval throttles the per-job "held back" observability lines
+// (#562 point 5): a job that stays excluded for the same reason re-logs at most
+// once per interval instead of every ~1s tick.
+const heldBackLogInterval = 5 * time.Minute
+
+type inflightDispatch struct {
+	repo        string
+	checkoutKey string
+	runtimeKey  string
+}
+
+// inflightJobTracker owns the cross-tick in-flight job accounting for a
+// supervisor. All methods are nil-receiver safe (a nil tracker means "untracked
+// / legacy inline path" and behaves as permanently idle).
+type inflightJobTracker struct {
+	mu        sync.Mutex
+	wg        sync.WaitGroup
+	runCtx    context.Context
+	cancelRun context.CancelFunc
+	draining  bool // set once drain() starts: no new work may begin
+	jobs      map[string]inflightDispatch
+	checkouts map[string]int // key -> holder count (counted to stay robust)
+	runtimes  map[string]int
+	perRepo   map[string]int
+	poolRuns  map[string]bool // repos with a background pool pass in flight
+	errs      map[string][]error
+}
+
+func newInflightJobTracker(ctx context.Context) *inflightJobTracker {
+	runCtx, cancel := context.WithCancel(ctx)
+	return &inflightJobTracker{
+		runCtx:    runCtx,
+		cancelRun: cancel,
+		jobs:      map[string]inflightDispatch{},
+		checkouts: map[string]int{},
+		runtimes:  map[string]int{},
+		perRepo:   map[string]int{},
+		poolRuns:  map[string]bool{},
+		errs:      map[string][]error{},
+	}
+}
+
+// jobContext returns the context dispatched jobs must run on: cancelled when
+// the supervisor context is cancelled OR drain() begins. A nil tracker falls
+// back to the caller's context.
+func (t *inflightJobTracker) jobContext(fallback context.Context) context.Context {
+	if t == nil {
+		return fallback
+	}
+	return t.runCtx
+}
+
+// begin registers a job as in flight, holding its checkout/runtime keys. It
+// returns false (and registers nothing) when the job is already in flight — the
+// double-dispatch guard for the window in which a claimed job is still 'queued'
+// in the DB.
+func (t *inflightJobTracker) begin(jobID, repo, checkoutKey, runtimeKey string) bool {
+	if t == nil {
+		return true
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.draining {
+		return false
+	}
+	if _, exists := t.jobs[jobID]; exists {
+		return false
+	}
+	t.jobs[jobID] = inflightDispatch{repo: repo, checkoutKey: checkoutKey, runtimeKey: runtimeKey}
+	if checkoutKey != "" {
+		t.checkouts[checkoutKey]++
+	}
+	if runtimeKey != "" {
+		t.runtimes[runtimeKey]++
+	}
+	t.perRepo[repo]++
+	t.wg.Add(1)
+	return true
+}
+
+// end releases everything begin registered for jobID. Idempotent.
+func (t *inflightJobTracker) end(jobID string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	dispatch, exists := t.jobs[jobID]
+	if !exists {
+		return
+	}
+	delete(t.jobs, jobID)
+	decrementCount(t.checkouts, dispatch.checkoutKey)
+	decrementCount(t.runtimes, dispatch.runtimeKey)
+	decrementCount(t.perRepo, dispatch.repo)
+	t.wg.Done()
+}
+
+// unionStringSets returns a fresh set containing every true key of a and b;
+// neither input is mutated.
+func unionStringSets(a, b map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(a)+len(b))
+	for key, held := range a {
+		if held {
+			out[key] = true
+		}
+	}
+	for key, held := range b {
+		if held {
+			out[key] = true
+		}
+	}
+	return out
+}
+
+// sortedStringSetKeys returns the set's keys sorted (nil for an empty set), for
+// deterministic SQL exclusion lists and log lines.
+func sortedStringSetKeys(set map[string]bool) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(set))
+	for key := range set {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func decrementCount(m map[string]int, key string) {
+	if key == "" {
+		return
+	}
+	if m[key] <= 1 {
+		delete(m, key)
+		return
+	}
+	m[key]--
+}
+
+func (t *inflightJobTracker) inflightJob(jobID string) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	_, exists := t.jobs[jobID]
+	return exists
+}
+
+// inflightIDs snapshots the in-flight job IDs (jobs THIS process is running),
+// used to keep the tick's recovery scans away from live work.
+func (t *inflightJobTracker) inflightIDs() map[string]bool {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.jobs) == 0 {
+		return nil
+	}
+	ids := make(map[string]bool, len(t.jobs))
+	for id := range t.jobs {
+		ids[id] = true
+	}
+	return ids
+}
+
+func (t *inflightJobTracker) inflight(repo string) int {
+	if t == nil {
+		return 0
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.perRepo[repo]
+}
+
+// busy reports whether the repo has any in-flight dispatched job or a live
+// background pool pass — the gate for checkout-mutating maintenance and for the
+// poller's full PollOnce.
+func (t *inflightJobTracker) busy(repo string) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.perRepo[repo] > 0 || t.poolRuns[repo]
+}
+
+// poolRunning reports whether a background pool pass is live for repo.
+func (t *inflightJobTracker) poolRunning(repo string) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.poolRuns[repo]
+}
+
+// holderOf returns the job ID currently holding checkoutKey, if any.
+func (t *inflightJobTracker) holderOf(checkoutKey string) string {
+	if t == nil || checkoutKey == "" {
+		return ""
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for id, dispatch := range t.jobs {
+		if dispatch.checkoutKey == checkoutKey {
+			return id
+		}
+	}
+	return ""
+}
+
+// seeds snapshots the in-flight checkout/runtime key sets in the shape
+// selectRunnableQueuedJobsSeeded consumes.
+func (t *inflightJobTracker) seeds() (map[string]bool, map[string]bool) {
+	if t == nil {
+		return nil, nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	checkouts := make(map[string]bool, len(t.checkouts))
+	for key := range t.checkouts {
+		checkouts[key] = true
+	}
+	runtimes := make(map[string]bool, len(t.runtimes))
+	for key := range t.runtimes {
+		runtimes[key] = true
+	}
+	return checkouts, runtimes
+}
+
+// tryBeginPool marks a background pool pass in flight for repo. Single-flight:
+// it refuses while a pass is already running, and also while tracked non-pool
+// jobs are still in flight (a scheduler flip mid-run must not start a pool pass
+// whose fresh accounting could double-dispatch beside them).
+func (t *inflightJobTracker) tryBeginPool(repo string) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.draining || t.poolRuns[repo] || t.perRepo[repo] > 0 {
+		return false
+	}
+	t.poolRuns[repo] = true
+	t.wg.Add(1)
+	return true
+}
+
+func (t *inflightJobTracker) endPool(repo string) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.poolRuns[repo] {
+		return
+	}
+	delete(t.poolRuns, repo)
+	t.wg.Done()
+}
+
+// recordErr stores an async infra error for the repo so the NEXT tick can
+// surface it to the recovering supervisor (#570 escalation still sees it).
+func (t *inflightJobTracker) recordErr(repo string, err error) {
+	if t == nil || err == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.errs[repo] = append(t.errs[repo], err)
+}
+
+// takeErr drains one recorded async error for the repo (oldest first).
+func (t *inflightJobTracker) takeErr(repo string) error {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	pending := t.errs[repo]
+	if len(pending) == 0 {
+		return nil
+	}
+	err := pending[0]
+	if len(pending) == 1 {
+		delete(t.errs, repo)
+	} else {
+		t.errs[repo] = pending[1:]
+	}
+	return err
+}
+
+// drain cancels every dispatched job's context and waits (bounded) for the
+// in-flight jobs to finish, logging what it had to abandon. Called on
+// supervisor exit so daemon stop cancels + drains in-flight work. From the
+// moment drain starts, begin/tryBeginPool refuse new work, so a worker tick
+// racing the shutdown cannot spawn a job the drain would never see.
+func (t *inflightJobTracker) drain(stdout io.Writer, timeout time.Duration) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.draining = true
+	t.mu.Unlock()
+	t.cancelRun()
+	done := make(chan struct{})
+	go func() {
+		t.wg.Wait()
+		close(done)
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		t.mu.Lock()
+		remaining := len(t.jobs)
+		t.mu.Unlock()
+		writeLine(stdout, "daemon shutdown: abandoned %d in-flight job(s) still running after %s drain", remaining, timeout)
+	}
+}
+
+// heldBackWarnState throttles the per-job held-back observability lines. Keyed
+// by job ID; an unchanged reason stays quiet for heldBackLogInterval.
+type heldBackWarnState struct {
+	reason string
+	at     time.Time
+}
+
+var (
+	heldBackWarnMu    sync.Mutex
+	heldBackWarnByJob = map[string]heldBackWarnState{}
+)
+
+// resetHeldBackWarnThrottle clears the held-back log de-dup state. Test-only.
+func resetHeldBackWarnThrottle() {
+	heldBackWarnMu.Lock()
+	defer heldBackWarnMu.Unlock()
+	heldBackWarnByJob = map[string]heldBackWarnState{}
+}
+
+// warnJobHeldBack emits ONE throttled line explaining why a queued job was not
+// dispatched this tick (#562 point 5: these exclusions used to be silent). The
+// wording reuses the #552 why-stuck vocabulary where it applies.
+func warnJobHeldBack(stdout io.Writer, jobID string, reason string) {
+	if strings.TrimSpace(reason) == "" {
+		return
+	}
+	now := time.Now()
+	heldBackWarnMu.Lock()
+	prev, seen := heldBackWarnByJob[jobID]
+	if seen && prev.reason == reason && now.Sub(prev.at) < heldBackLogInterval {
+		heldBackWarnMu.Unlock()
+		return
+	}
+	// Bound the throttle map for a long-lived daemon: entries for jobs that
+	// stopped being held back (ran or were cancelled) are dead weight, so once
+	// the map grows past a small cap, sweep everything past its re-log window.
+	if len(heldBackWarnByJob) > 1024 {
+		for id, state := range heldBackWarnByJob {
+			if now.Sub(state.at) >= heldBackLogInterval {
+				delete(heldBackWarnByJob, id)
+			}
+		}
+	}
+	heldBackWarnByJob[jobID] = heldBackWarnState{reason: reason, at: now}
+	heldBackWarnMu.Unlock()
+	writeLine(stdout, "job %s held back: %s", jobID, reason)
+}
+
+// admissionSkipReason describes an admission-budget refusal (#365) for the
+// held-back log, distinguishing a transient "does not fit right now" from a
+// configuration never-fit (the job alone exceeds the configured cap, so waiting
+// can never admit it).
+func admissionSkipReason(budget *admissionBudget, est admissionEstimate) string {
+	if budget == nil {
+		return ""
+	}
+	reservedCount, reservedMemGB, maxSessions, maxMemoryGB := budget.snapshot()
+	if maxMemoryGB > 0 && est.memGB > maxMemoryGB {
+		return fmt.Sprintf("admission budget can NEVER fit it (estimated %.1f GB > max_memory_gb %.1f); raise [admission].max_memory_gb or lower the runtime's estimate", est.memGB, maxMemoryGB)
+	}
+	return fmt.Sprintf("waiting on admission budget (%d/%d sessions, %.1f/%.1f GB reserved)", reservedCount, maxSessions, reservedMemGB, maxMemoryGB)
+}
+
+// explainHeldBackJobs logs (throttled) why each still-queued job was excluded
+// from this dispatch pass: a checkout key held by an in-flight job, or a held /
+// stranded runtime-session resource lock. Best-effort observability only.
+func explainHeldBackJobs(ctx context.Context, worker jobWorker, tracker *inflightJobTracker, remaining []db.Job) {
+	for _, job := range remaining {
+		checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
+		if holder := tracker.holderOf(checkoutKey); holder != "" && holder != job.ID {
+			warnJobHeldBack(worker.Stdout, job.ID, fmt.Sprintf("waiting on checkout %s (held by in-flight job %s)", checkoutKey, holder))
+			continue
+		}
+		runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
+		if runtimeKey == "" {
+			continue
+		}
+		if lock, err := worker.Store.GetResourceLock(ctx, runtimeKey); err == nil {
+			reason := fmt.Sprintf("waiting on runtime session lock %s", runtimeKey)
+			if owner := strings.TrimSpace(lock.OwnerJobID); owner != "" && owner != job.ID {
+				reason += fmt.Sprintf(" (held by job %s)", owner)
+			}
+			if expires := strings.TrimSpace(lock.ExpiresAt); expires != "" {
+				reason += fmt.Sprintf(", lease expires %s", expires)
+			}
+			warnJobHeldBack(worker.Stdout, job.ID, reason)
+		}
+	}
+}
+
+// dispatchQueuedJobsTracked is the daemon's non-blocking dispatch pass (#562).
+// It claims runnable queued jobs and hands them to tracked goroutines, then
+// returns promptly (surfacing any async error a previously dispatched job
+// recorded) so the supervisor worker loop keeps ticking while jobs run.
+//
+// Pool mode starts runQueuedJobsForRepoPool as a SINGLE-FLIGHT background pass
+// per repo: the pool already re-queries continuously and does its own in-flight
+// accounting (which it mirrors into the tracker for poller/maintenance gating),
+// so one live pass is both necessary and sufficient.
+func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int, repoFilter string, rootFilter string, tracker *inflightJobTracker) error {
+	if obs := dispatchLimitObserver; obs != nil {
+		obs(limit)
+	}
+	if limit <= 0 {
+		return tracker.takeErr(repoFilter)
+	}
+	if serializingConfig(worker.UsePool, limit) {
+		warnSerializedParallelJobs(ctx, worker, limit, repoFilter, rootFilter)
+	}
+	if worker.UsePool {
+		if tracker.tryBeginPool(repoFilter) {
+			runCtx := tracker.jobContext(ctx)
+			go func() {
+				defer tracker.endPool(repoFilter)
+				err := runQueuedJobsForRepoPoolTracked(runCtx, worker, limit, repoFilter, rootFilter, tracker)
+				if err != nil && !errors.Is(err, context.Canceled) {
+					tracker.recordErr(repoFilter, err)
+				}
+			}()
+		}
+		return tracker.takeErr(repoFilter)
+	}
+
+	// Single-selector invariant: a still-live background pool pass (a warm
+	// pool->barrier scheduler flip mid-run, #577) keeps OWNING dispatch for this
+	// repo until it drains. Two concurrent selectors could each snapshot seeds
+	// before the other's begin() and dispatch two jobs onto one checkout key,
+	// breaking same-repo serialization. Symmetric to tryBeginPool refusing while
+	// tracked non-pool jobs are in flight; queued jobs simply wait a tick.
+	if tracker.poolRunning(repoFilter) {
+		return tracker.takeErr(repoFilter)
+	}
+
+	pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter)
+	if err != nil {
+		return err
+	}
+	// Drop jobs this process is already running: a freshly dispatched job stays
+	// 'queued' in the DB until engine.RunJob claims it, and that window must not
+	// double-dispatch it.
+	eligible := pending[:0]
+	for _, job := range pending {
+		if !tracker.inflightJob(job.ID) {
+			eligible = append(eligible, job)
+		}
+	}
+	slots := limit - tracker.inflight(repoFilter)
+	if slots <= 0 || len(eligible) == 0 {
+		return tracker.takeErr(repoFilter)
+	}
+	policy, err := worker.parallelSessionPolicy()
+	if err != nil {
+		policy = config.ParallelSessionPolicy{SameSession: config.ParallelSessionQueue}
+	}
+	seedCheckouts, seedRuntimes := tracker.seeds()
+	queued, remaining := selectRunnableQueuedJobsSeeded(ctx, worker.Store, eligible, slots, policy, seedCheckouts, seedRuntimes)
+	explainHeldBackJobs(ctx, worker, tracker, remaining)
+	runCtx := tracker.jobContext(ctx)
+	for _, job := range queued {
+		job := job
+		if !worker.Admission.Reserve(job.ID, func() admissionEstimate { return worker.admissionEstimate(ctx, job) }) {
+			warnJobHeldBack(worker.Stdout, job.ID, admissionSkipReason(worker.Admission, worker.admissionEstimate(ctx, job)))
+			continue
+		}
+		checkoutKey := queuedJobCheckoutKey(ctx, worker.Store, job)
+		runtimeKey := queuedJobRuntimeResourceKey(ctx, worker.Store, job)
+		if !tracker.begin(job.ID, repoFilter, checkoutKey, runtimeKey) {
+			worker.Admission.Release(job.ID)
+			continue
+		}
+		go func() {
+			defer tracker.end(job.ID)
+			defer worker.Admission.Release(job.ID)
+			err := runPoolJobRecovered(runCtx, worker, job)
+			if err != nil && !errors.Is(err, errRuntimeSessionBusy) && !errors.Is(err, context.Canceled) {
+				tracker.recordErr(repoFilter, err)
+			}
+		}()
+	}
+	return tracker.takeErr(repoFilter)
+}

--- a/internal/cli/daemon_dispatch_tracked_test.go
+++ b/internal/cli/daemon_dispatch_tracked_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,6 +16,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -208,7 +211,7 @@ func TestTrackedBarrierDefersToLivePoolPass(t *testing.T) {
 	}
 
 	// While the pool pass is live, the barrier dispatch must claim nothing.
-	if err := dispatchQueuedJobsTracked(ctx, worker, 2, "owner/repo", "", tracker); err != nil {
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, 2, "owner/repo", "", tracker); err != nil {
 		t.Fatalf("dispatchQueuedJobsTracked (pool live): %v", err)
 	}
 	time.Sleep(100 * time.Millisecond)
@@ -222,7 +225,7 @@ func TestTrackedBarrierDefersToLivePoolPass(t *testing.T) {
 
 	// Once the pool pass drains, the same barrier dispatch runs the job.
 	tracker.endPool("owner/repo")
-	if err := dispatchQueuedJobsTracked(ctx, worker, 2, "owner/repo", "", tracker); err != nil {
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, 2, "owner/repo", "", tracker); err != nil {
 		t.Fatalf("dispatchQueuedJobsTracked (pool drained): %v", err)
 	}
 	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
@@ -382,7 +385,7 @@ func TestTrackedDispatchLogsAdmissionNeverFit(t *testing.T) {
 	worker.Admission = newAdmissionBudget(config.AdmissionPolicy{MaxMemoryGB: 0.1})
 	tracker := newInflightJobTracker(ctx)
 
-	if err := dispatchQueuedJobsTracked(ctx, worker, 2, "owner/repo", "", tracker); err != nil {
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, 2, "owner/repo", "", tracker); err != nil {
 		t.Fatalf("dispatchQueuedJobsTracked: %v", err)
 	}
 	out := stdout.String()
@@ -395,5 +398,245 @@ func TestTrackedDispatchLogsAdmissionNeverFit(t *testing.T) {
 	}
 	if job.State != string(workflow.JobQueued) {
 		t.Fatalf("job-big state = %q, want queued (admission skip must leave it queued)", job.State)
+	}
+}
+
+// TestTrackedDispatchBoundsHostTotalAcrossRepos pins the #562 review fix for
+// registered-repo mode: every enabled repo shares ONE tracker, and dispatch is
+// clamped by the HOST-global in-flight count, so --workers bounds total
+// in-flight jobs across repos. Main's inline sweep gave this for free (one
+// repo's blocking batch at a time); per-repo slots alone would allow
+// workers × repos concurrent runtime subprocesses. Four parallelizable
+// (distinct-worktree) jobs across two repos at workers=2 must never exceed 2
+// concurrent deliveries — for the tracked barrier and the tracked pool alike.
+func TestTrackedDispatchBoundsHostTotalAcrossRepos(t *testing.T) {
+	for _, usePool := range []bool{false, true} {
+		name := "Barrier"
+		if usePool {
+			name = "Pool"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			store := daemonWorkerStore(t)
+			seedDaemonWorkerRepo(t, store, "owner/repo-a", t.TempDir())
+			seedDaemonWorkerRepo(t, store, "owner/repo-b", t.TempDir())
+			seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo-a")
+			if err := store.AllowAgentRepo(ctx, "audit", "owner/repo-b"); err != nil {
+				t.Fatalf("AllowAgentRepo: %v", err)
+			}
+			concurrency := &poolConcurrencyTracker{}
+			adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+			adapter.onDeliver = concurrency.span
+			ids := make([]string, 0, 4)
+			for i, repo := range []string{"owner/repo-a", "owner/repo-a", "owner/repo-b", "owner/repo-b"} {
+				id := fmt.Sprintf("job-%d", i+1)
+				ids = append(ids, id)
+				enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: i + 1, WorktreePath: filepath.Join(t.TempDir(), "wt-"+id)})
+			}
+			worker := poolSchedulerWorker(t, store, adapter, usePool)
+			tracker := newInflightJobTracker(ctx)
+			t.Cleanup(func() { tracker.drain(io.Discard, 5*time.Second) })
+			locks := &repoCheckoutLocks{}
+			// The REAL registered-repo per-tick sweep, at a fast interval.
+			_ = startSupervisorWorkerLoopRecovering(ctx, 2*time.Millisecond, io.Discard, func(now time.Time) error {
+				return runEnabledRepoWorkerTicksTracked(ctx, store, worker, 2, "", io.Discard, now, locks, tracker)
+			})
+			for _, id := range ids {
+				if got := waitForJobState(t, store, id, string(workflow.JobSucceeded), 15*time.Second); got != string(workflow.JobSucceeded) {
+					t.Fatalf("%s state = %q, want succeeded (usePool=%v)", id, got, usePool)
+				}
+			}
+			if peak := concurrency.peak(); peak > 2 {
+				t.Fatalf("host-wide peak concurrency = %d, want <= 2 (--workers must bound TOTAL in-flight jobs across repos, not per repo)", peak)
+			}
+		})
+	}
+}
+
+// TestTrackedPoolIsolationHonorsSamePassRuntimeSibling pins the #562 review fix
+// for the pool's isolation loop: the loop must consult the LIVE in-flight maps,
+// not just the per-pass seed-union copies. A same-runtime-session sibling
+// dispatched moments earlier IN THE SAME PASS is invisible in the stale copies
+// (and its DB session lock may not be acquired yet), so before the fix the
+// contended no-worktree job could be isolation-dispatched beside it — the loser
+// of the session-lock race then bounced busy with its payload rewritten to an
+// isolation worktree that reap() deletes. Here: while job-wt (session sess-1)
+// is in flight, job-iso (same session, blocked on the externally-held shared
+// checkout) must stay queued with an untouched payload; once job-wt finishes,
+// job-iso must run — via an isolation worktree, since the shared checkout stays
+// held — proving the fix holds it back without starving it.
+func TestTrackedPoolIsolationHonorsSamePassRuntimeSibling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	// ONE codex agent with a session ref: both jobs share runtime key
+	// "runtime:codex:sess-1", so only one may run at a time.
+	seedDaemonWorkerAgent(t, store, "coder", runtime.CodexRuntime, "sess-1", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-wt", Agent: "coder", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1, WorktreePath: filepath.Join(t.TempDir(), "wt-job-wt")})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-iso", Agent: "coder", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 2})
+
+	adapter := newWedgeBlockingAdapter("job-wt")
+	worker := poolSchedulerWorker(t, store, adapter, true)
+	worker.ConfigHome = home // enable pool isolation worktrees
+	tracker := newInflightJobTracker(ctx)
+	// An external in-flight job holds the shared checkout for the whole test, so
+	// job-iso is always checkout-contended (isolation is its only way to run).
+	if !tracker.begin("external-hold", "owner/repo", "repo:owner/repo", "") {
+		t.Fatalf("begin(external-hold) refused on a fresh tracker")
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- runQueuedJobsForRepoPoolTracked(ctx, worker, 2, 8, "owner/repo", "", tracker) }()
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-wt never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+	// While the same-session sibling is in flight, job-iso must NOT be
+	// isolation-dispatched: still queued, payload untouched, never delivered.
+	time.Sleep(250 * time.Millisecond)
+	job, err := store.GetJob(ctx, "job-iso")
+	if err != nil {
+		t.Fatalf("GetJob job-iso: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job-iso state = %q while its same-session sibling runs, want queued", job.State)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload job-iso: %v", err)
+	}
+	if payload.WorktreePath != "" {
+		t.Fatalf("job-iso payload was rewritten to isolation worktree %q beside a live same-session sibling (stale-seed isolation dispatch)", payload.WorktreePath)
+	}
+	if delivered := adapter.deliveredJobs(); len(delivered) != 1 || delivered[0] != "job-wt" {
+		t.Fatalf("delivered = %v, want only job-wt while it holds runtime session sess-1", delivered)
+	}
+
+	// Sibling finishes -> the session frees -> job-iso must now run via an
+	// isolation worktree (the shared checkout is STILL externally held).
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-wt", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-wt state = %q after release, want succeeded", got)
+	}
+	if got := waitForJobState(t, store, "job-iso", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-iso state = %q after the session freed, want succeeded (held back forever instead of isolated)", got)
+	}
+	job, err = store.GetJob(ctx, "job-iso")
+	if err != nil {
+		t.Fatalf("GetJob job-iso (final): %v", err)
+	}
+	if payload, err = daemonJobPayload(job); err != nil || payload.WorktreePath == "" {
+		t.Fatalf("job-iso final payload worktree = %q err=%v, want an isolation worktree (must have run beside the held shared checkout)", payload.WorktreePath, err)
+	}
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("pool pass returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("pool pass did not return after the queue drained")
+	}
+	tracker.end("external-hold")
+	tracker.drain(io.Discard, 5*time.Second)
+}
+
+// TestTrackedTickMaintenanceNotStarvedByInFlightJobs pins the #562 review fix
+// for tick maintenance: it must not be gated on WHOLE-repo idleness, which a
+// steady staggered backlog can prevent indefinitely (main's blocking barrier
+// guaranteed an idle point between batches). While an in-flight job holds the
+// shared repo checkout:
+//   - a transiently-failed result comment IS retried (comments never touch a
+//     checkout),
+//   - a pending advancement whose own checkout key is FREE (its worktree) IS
+//     retried,
+//   - a pending advancement that would mutate the HELD shared checkout is
+//     skipped (the safety half) — and retried once the holder finishes.
+func TestTrackedTickMaintenanceNotStarvedByInFlightJobs(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+
+	mustCreateTerminalJob := func(id string, state string, payload workflow.JobPayload, extraEvents ...db.JobEvent) {
+		t.Helper()
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("Marshal %s: %v", id, err)
+		}
+		if err := store.CreateJobWithEvent(ctx, db.Job{ID: id, Agent: "reviewer", Type: "review", State: state, Payload: string(encoded)}, db.JobEvent{JobID: id, Kind: state, Message: "seed"}); err != nil {
+			t.Fatalf("CreateJobWithEvent %s: %v", id, err)
+		}
+		for _, event := range extraEvents {
+			event.JobID = id
+			if err := store.AddJobEvent(ctx, event); err != nil {
+				t.Fatalf("AddJobEvent %s: %v", id, err)
+			}
+		}
+	}
+	approved := &workflow.AgentResult{Decision: "approved", Summary: "approved"}
+	// Failed result comment awaiting retry (posting is GitHub-API-only).
+	mustCreateTerminalJob("job-comment", string(workflow.JobFailed),
+		workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 7},
+		db.JobEvent{Kind: "comment_post_failed", Message: "temporary github error"})
+	// Pending advancement keyed on its OWN worktree (free while job-live runs).
+	mustCreateTerminalJob("job-adv-wt", string(workflow.JobSucceeded),
+		workflow.JobPayload{Repo: "owner/repo", Branch: "task-wt", PullRequest: 1, TaskID: "task-wt", WorktreePath: filepath.Join(t.TempDir(), "wt-adv"), Result: approved},
+		db.JobEvent{Kind: "advance_started", Message: "workflow advancement started"})
+	// Pending advancement keyed on the SHARED repo checkout (held by job-live).
+	mustCreateTerminalJob("job-adv-repo", string(workflow.JobSucceeded),
+		workflow.JobPayload{Repo: "owner/repo", Branch: "task-repo", PullRequest: 2, TaskID: "task-repo", Result: approved},
+		db.JobEvent{Kind: "advance_started", Message: "workflow advancement started"})
+
+	comments := &cliPollFakeGitHub{}
+	gate := &cliWorkerFakeMergeGate{decision: workflow.MergeDecision{Ready: true}}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, MergeGate: gate}
+	}
+	worker.CommenterFactory = func(string) github.Client {
+		return comments
+	}
+
+	tracker := newInflightJobTracker(ctx)
+	// A long-running in-flight job occupying the shared checkout — on the old
+	// whole-repo busy gate this starved ALL maintenance below.
+	if !tracker.begin("job-live", "owner/repo", "repo:owner/repo", "") {
+		t.Fatalf("begin(job-live) refused on a fresh tracker")
+	}
+
+	hasEvent := func(jobID, kind string) bool {
+		events, err := store.ListJobEvents(ctx, jobID)
+		if err != nil {
+			t.Fatalf("ListJobEvents %s: %v", jobID, err)
+		}
+		return daemonWorkerHasEvent(events, kind)
+	}
+
+	if err := runDaemonWorkerTickTracked(ctx, store, worker, 2, false, "owner/repo", "", io.Discard, time.Now().UTC(), tracker); err != nil {
+		t.Fatalf("tick (busy repo): %v", err)
+	}
+	if len(comments.posted) != 1 {
+		t.Fatalf("posted comments = %d, want 1 (comment retry starved by an in-flight job)", len(comments.posted))
+	}
+	if !hasEvent("job-adv-wt", "advance_retried") {
+		t.Fatalf("job-adv-wt not advanced while its own worktree key is free (advancement starved by an in-flight job)")
+	}
+	if hasEvent("job-adv-repo", "advance_retried") {
+		t.Fatalf("job-adv-repo advanced while an in-flight job holds the shared checkout it would mutate")
+	}
+
+	// Holder finishes -> the shared-checkout advancement is retried next tick.
+	tracker.end("job-live")
+	if err := runDaemonWorkerTickTracked(ctx, store, worker, 2, false, "owner/repo", "", io.Discard, time.Now().UTC(), tracker); err != nil {
+		t.Fatalf("tick (idle repo): %v", err)
+	}
+	if !hasEvent("job-adv-repo", "advance_retried") {
+		t.Fatalf("job-adv-repo still not advanced after the shared checkout freed")
 	}
 }

--- a/internal/cli/daemon_dispatch_tracked_test.go
+++ b/internal/cli/daemon_dispatch_tracked_test.go
@@ -1,0 +1,399 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// syncBuffer is a mutex-guarded bytes.Buffer so loop goroutines can writeLine
+// into it while the test reads.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// startTrackedWedgeLoop wires the common scaffolding for the tracked-loop
+// regression tests: a real store, one repo + shell agent, the given adapter, and
+// the REAL production single-repo worker loop at a fast interval.
+func startTrackedWedgeLoop(t *testing.T, ctx context.Context, store *db.Store, adapter workflow.DeliveryAdapter, workers int, usePool bool, stdout io.Writer) (*inflightJobTracker, <-chan error) {
+	t.Helper()
+	worker := poolSchedulerWorker(t, store, adapter, usePool)
+	live := newDaemonReloadableConfig(30*time.Second, workers, usePool)
+	var checkoutLock sync.Mutex
+	tracker := newInflightJobTracker(ctx)
+	t.Cleanup(func() { tracker.drain(io.Discard, 5*time.Second) })
+	errCh := startSingleRepoWorkerLoop(ctx, 5*time.Millisecond, store, worker, live, &checkoutLock, tracker, "owner/repo", "", stdout)
+	return tracker, errCh
+}
+
+// TestTrackedDispatchPreservesSameRepoSerialization pins the #562 preserved
+// invariant: two same-repo jobs WITHOUT worktrees share one checkout, so they
+// must still never run concurrently — now enforced explicitly by the tracker's
+// in-flight checkout-key seeding rather than by accident of inline execution.
+// workers=2 proves the serialization comes from the shared key, not the limit.
+func TestTrackedDispatchPreservesSameRepoSerialization(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	_, _ = startTrackedWedgeLoop(t, ctx, store, adapter, 2, false, io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering")
+	}
+	// job-b: SAME repo, NO worktree -> same "repo:owner/repo" checkout key.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 2})
+
+	// Across many ticks, job-b must NOT be claimed while job-a occupies the
+	// shared checkout: it stays queued and is never delivered.
+	time.Sleep(300 * time.Millisecond)
+	if delivered := adapter.deliveredJobs(); len(delivered) != 1 || delivered[0] != "job-a" {
+		t.Fatalf("delivered = %v, want only job-a while it holds the shared checkout (same-repo serialization regressed)", delivered)
+	}
+	job, err := store.GetJob(ctx, "job-b")
+	if err != nil {
+		t.Fatalf("GetJob job-b: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job-b state = %q while job-a runs on the shared checkout, want queued", job.State)
+	}
+
+	// Once job-a releases the checkout, job-b runs to completion.
+	close(adapter.release)
+	for _, id := range []string{"job-a", "job-b"} {
+		if got := waitForJobState(t, store, id, string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+			t.Fatalf("%s state = %q after release, want succeeded", id, got)
+		}
+	}
+}
+
+// trackedConcurrencyLimit runs `jobs` parallelizable (distinct-worktree) queued
+// jobs through the REAL tracked loop at the given worker limit and scheduler,
+// returning the peak concurrent deliveries observed.
+func trackedConcurrencyLimit(t *testing.T, jobs, workers int, usePool bool) int {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	concurrency := &poolConcurrencyTracker{}
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	adapter.onDeliver = concurrency.span
+	ids := make([]string, 0, jobs)
+	for i := 0; i < jobs; i++ {
+		id := "job-" + strconv.Itoa(i+1)
+		ids = append(ids, id)
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: i + 1, WorktreePath: filepath.Join(t.TempDir(), "wt-"+id)})
+	}
+	_, _ = startTrackedWedgeLoop(t, ctx, store, adapter, workers, usePool, io.Discard)
+	for _, id := range ids {
+		if got := waitForJobState(t, store, id, string(workflow.JobSucceeded), 15*time.Second); got != string(workflow.JobSucceeded) {
+			t.Fatalf("%s state = %q, want succeeded (usePool=%v workers=%d)", id, got, usePool, workers)
+		}
+	}
+	return concurrency.peak()
+}
+
+// TestTrackedDispatchRespectsWorkerLimit pins the #562 preserved invariant that
+// --workers still bounds TOTAL in-flight jobs across ticks (not merely one
+// tick's batch), for both the tracked barrier and the tracked background pool.
+func TestTrackedDispatchRespectsWorkerLimit(t *testing.T) {
+	if peak := trackedConcurrencyLimit(t, 4, 2, false); peak > 2 {
+		t.Fatalf("barrier: peak concurrency = %d, want <= 2 (workers cap must bound cross-tick in-flight jobs)", peak)
+	}
+	if peak := trackedConcurrencyLimit(t, 4, 2, true); peak > 2 {
+		t.Fatalf("pool: peak concurrency = %d, want <= 2", peak)
+	}
+}
+
+// TestTrackedLoopShutdownDrainsInFlightJobs pins the #562 graceful-shutdown
+// contract: cancelling the supervisor context makes drain() cancel in-flight
+// job contexts and wait for them to finish, so daemon stop is clean.
+func TestTrackedLoopShutdownDrainsInFlightJobs(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult, waitForContextCancel: true}
+	// Cancel only once the job is INSIDE Deliver: tracker.busy flips at begin(),
+	// before the worker reaches the adapter, and a cancel landing in that gap
+	// aborts worker.run before Deliver so the job never observes cancellation
+	// (flaked under -race). Once Deliver has been entered, even an
+	// already-cancelled ctx still records the cancellation.
+	deliverStarted := make(chan struct{})
+	var deliverOnce sync.Once
+	adapter.onDeliver = func() { deliverOnce.Do(func() { close(deliverStarted) }) }
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	tracker, errCh := startTrackedWedgeLoop(t, ctx, store, adapter, 1, false, io.Discard)
+
+	select {
+	case <-deliverStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("job-a never started delivering")
+	}
+	if !tracker.busy("owner/repo") {
+		t.Fatalf("tracker not busy while job-a is inside Deliver")
+	}
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		tracker.drain(io.Discard, 10*time.Second)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(11 * time.Second):
+		t.Fatal("drain did not return after context cancellation")
+	}
+	if !adapter.observedContextCancel() {
+		t.Fatalf("in-flight job never observed cancellation during drain")
+	}
+	if tracker.busy("owner/repo") {
+		t.Fatalf("tracker still busy after drain; in-flight accounting leaked")
+	}
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker loop did not stop after context cancellation")
+	}
+}
+
+// TestTrackedBarrierDefersToLivePoolPass pins the single-selector invariant: a
+// still-live background pool pass (a warm pool->barrier scheduler flip mid-run,
+// #577) owns dispatch for the repo, so the barrier path must refuse until it
+// drains — two concurrent selectors could each snapshot the tracker's seeds
+// before the other's begin() and put two jobs on one checkout key.
+func TestTrackedBarrierDefersToLivePoolPass(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+
+	worker := poolSchedulerWorker(t, store, &cliWorkerFakeAdapter{output: poolSchedulerAskResult}, false)
+	tracker := newInflightJobTracker(ctx)
+	if !tracker.tryBeginPool("owner/repo") {
+		t.Fatalf("tryBeginPool refused on an idle tracker")
+	}
+
+	// While the pool pass is live, the barrier dispatch must claim nothing.
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, "owner/repo", "", tracker); err != nil {
+		t.Fatalf("dispatchQueuedJobsTracked (pool live): %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job-a state = %q while a pool pass is live, want queued (barrier dispatched beside a live pool selector)", job.State)
+	}
+
+	// Once the pool pass drains, the same barrier dispatch runs the job.
+	tracker.endPool("owner/repo")
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, "owner/repo", "", tracker); err != nil {
+		t.Fatalf("dispatchQueuedJobsTracked (pool drained): %v", err)
+	}
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q after the pool pass drained, want succeeded", got)
+	}
+	tracker.drain(io.Discard, 5*time.Second)
+}
+
+// TestRecoverRunningJobsSkipsInFlightJobs pins the #562 self-requeue guard: a
+// running job past the coarse stale window with NO runtime lease (e.g. a long
+// shell-runtime job) must NOT be requeued by its own daemon's recovery scan
+// while this process is still running it. Inline execution made that impossible
+// by construction; the tracked scan must skip in-flight IDs explicitly.
+func TestRecoverRunningJobsSkipsInFlightJobs(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-live", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-live", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState: %v", err)
+	}
+	staleBy := time.Now().UTC().Add(time.Hour)
+
+	// In flight in this process -> skipped, stays running.
+	skip := map[string]bool{"job-live": true}
+	if err := recoverRunningJobsBeforeForRepoSkipping(ctx, store, io.Discard, staleBy, staleBy, "owner/repo", "", skip); err != nil {
+		t.Fatalf("recoverRunningJobsBeforeForRepoSkipping: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-live")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("in-flight job state = %q after recovery scan, want running (scan requeued live work)", job.State)
+	}
+
+	// Same scan without the skip (a genuinely crashed worker) -> requeued.
+	if err := recoverRunningJobsBeforeForRepoSkipping(ctx, store, io.Discard, staleBy, staleBy, "owner/repo", "", nil); err != nil {
+		t.Fatalf("recoverRunningJobsBeforeForRepoSkipping(nil): %v", err)
+	}
+	job, err = store.GetJob(ctx, "job-live")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("stale job state = %q, want queued (crash recovery regressed)", job.State)
+	}
+}
+
+// TestExpiredRuntimeLockReaperSkipsInFlightOwners pins the companion guard: an
+// EXPIRED runtime-session lock whose owner is in flight in this process is
+// neither requeued nor reaped (its goroutine is alive; releasing the lock could
+// double-run the session), while the same lock is recovered normally once the
+// owner is no longer in flight.
+func TestExpiredRuntimeLockReaperSkipsInFlightOwners(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-live", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-live", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState: %v", err)
+	}
+	now := time.Now().UTC()
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey:   "runtime:codex:session-live",
+		OwnerJobID:    "job-live",
+		OwnerToken:    "token-live",
+		OwnerPID:      int64(os.Getpid()),
+		OwnerHostname: "test-host",
+		ExpiresAt:     now.Add(-time.Minute).Format(time.RFC3339Nano),
+	}, now.Add(-time.Hour))
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock acquired=%v err=%v", acquired, err)
+	}
+
+	skip := map[string]bool{"job-live": true}
+	if err := recoverExpiredRuntimeSessionLocksSkipping(ctx, store, io.Discard, now, skip); err != nil {
+		t.Fatalf("recoverExpiredRuntimeSessionLocksSkipping: %v", err)
+	}
+	if job, _ := store.GetJob(ctx, "job-live"); job.State != string(workflow.JobRunning) {
+		t.Fatalf("in-flight owner state = %q, want running (reaper requeued live work)", job.State)
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:session-live"); err != nil {
+		t.Fatalf("in-flight owner's lock was reaped: %v", err)
+	}
+
+	// Without the skip the normal recovery applies: owner requeued, lock reaped.
+	if err := recoverExpiredRuntimeSessionLocksSkipping(ctx, store, io.Discard, now, nil); err != nil {
+		t.Fatalf("recoverExpiredRuntimeSessionLocksSkipping(nil): %v", err)
+	}
+	if job, _ := store.GetJob(ctx, "job-live"); job.State != string(workflow.JobQueued) {
+		t.Fatalf("stale owner state = %q, want queued", job.State)
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:session-live"); err == nil {
+		t.Fatalf("expired lock still present, want reaped")
+	}
+}
+
+// TestTrackedDispatchLogsHeldBackJobs pins the #562 observability slice: a
+// queued job excluded because an in-flight job holds its checkout gets ONE
+// throttled explanatory log line (reusing the #552 why-stuck vocabulary), not
+// silence and not a line per 1s tick.
+func TestTrackedDispatchLogsHeldBackJobs(t *testing.T) {
+	resetHeldBackWarnThrottle()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	stdout := &syncBuffer{}
+	worker := poolSchedulerWorker(t, store, adapter, false)
+	worker.Stdout = stdout
+	live := newDaemonReloadableConfig(30*time.Second, 2, false)
+	var checkoutLock sync.Mutex
+	tracker := newInflightJobTracker(ctx)
+	t.Cleanup(func() { tracker.drain(io.Discard, 5*time.Second) })
+	_ = startSingleRepoWorkerLoop(ctx, 5*time.Millisecond, store, worker, live, &checkoutLock, tracker, "owner/repo", "", io.Discard)
+
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering")
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 2})
+
+	const wantLine = "job job-b held back: waiting on checkout repo:owner/repo (held by in-flight job job-a)"
+	if !waitForCondition(t, 5*time.Second, func() bool { return strings.Contains(stdout.String(), wantLine) }) {
+		t.Fatalf("held-back reason never logged; output=%q", stdout.String())
+	}
+	// Throttle: many more ticks must not repeat the identical line.
+	time.Sleep(200 * time.Millisecond)
+	if got := strings.Count(stdout.String(), wantLine); got != 1 {
+		t.Fatalf("held-back line logged %d times, want 1 (throttle regressed)", got)
+	}
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-b", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-b state = %q after release, want succeeded", got)
+	}
+}
+
+// TestTrackedDispatchLogsAdmissionNeverFit pins the admission half of the #562
+// observability slice: a queued job whose RAM estimate alone exceeds the
+// configured [admission] cap can NEVER be admitted — previously a silent
+// skip-forever — and now logs a throttled NEVER-fit line naming the cap.
+func TestTrackedDispatchLogsAdmissionNeverFit(t *testing.T) {
+	resetHeldBackWarnThrottle()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	// A codex agent is session-counted with a 0.2 GB default estimate.
+	seedDaemonWorkerAgent(t, store, "coder", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-big", Agent: "coder", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+
+	stdout := &syncBuffer{}
+	worker := poolSchedulerWorker(t, store, &cliWorkerFakeAdapter{output: poolSchedulerAskResult}, false)
+	worker.Stdout = stdout
+	// Cap below the smallest estimate: the job can never fit.
+	worker.Admission = newAdmissionBudget(config.AdmissionPolicy{MaxMemoryGB: 0.1})
+	tracker := newInflightJobTracker(ctx)
+
+	if err := dispatchQueuedJobsTracked(ctx, worker, 2, "owner/repo", "", tracker); err != nil {
+		t.Fatalf("dispatchQueuedJobsTracked: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "job job-big held back:") || !strings.Contains(out, "NEVER fit") {
+		t.Fatalf("never-fit admission skip not logged; output=%q", out)
+	}
+	job, err := store.GetJob(ctx, "job-big")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job-big state = %q, want queued (admission skip must leave it queued)", job.State)
+	}
+}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4570,7 +4570,7 @@ func TestRunQueuedJobsRecordsPostDeliveryWorkflowErrorForRetry(t *testing.T) {
 	}
 	gate.err = nil
 	gate.decision = workflow.MergeDecision{Ready: true}
-	if err := retryPendingJobAdvancements(ctx, worker, "", ""); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 	if adapter.calls != 1 {
@@ -4627,7 +4627,7 @@ func TestRetryPendingJobAdvancementsRecoversStartedAdvancement(t *testing.T) {
 		return workflow.Engine{Store: store, MergeGate: gate}
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, "", ""); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -4681,7 +4681,7 @@ func TestRetryPendingJobAdvancementsAdvancesFailedStoredResult(t *testing.T) {
 		return workflow.Engine{Store: store}
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, "", ""); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -4789,7 +4789,7 @@ func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *t
 		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, "", ""); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -5149,7 +5149,7 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 				}
 			}
 
-			if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", ""); err != nil {
+			if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil); err != nil {
 				t.Fatalf("reclaimSkippedDelegationWorktrees returned error: %v", err)
 			}
 
@@ -5247,7 +5247,7 @@ func TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs(t *testing.T) {
 		}
 	}
 
-	if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", ""); err != nil {
+	if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil); err != nil {
 		t.Fatalf("reclaimSkippedDelegationWorktrees returned error: %v", err)
 	}
 

--- a/internal/cli/wedged_inline_job_e2e_test.go
+++ b/internal/cli/wedged_inline_job_e2e_test.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// wedgeBlockingAdapter is a delivery adapter whose Deliver BLOCKS for the job
+// named in blockJob until release is closed (or the job's ctx is cancelled),
+// standing in for a hung/very-long runtime subprocess. Every other job returns a
+// successful ask result immediately. It records delivery order and lets the test
+// observe (a) that the blocking job is genuinely in flight and (b) whether a
+// second job was delivered WHILE the first one was still blocked.
+type wedgeBlockingAdapter struct {
+	mu        sync.Mutex
+	blockJob  string
+	release   chan struct{}
+	delivered []string
+	blocked   bool
+	output    string
+}
+
+func newWedgeBlockingAdapter(blockJob string) *wedgeBlockingAdapter {
+	return &wedgeBlockingAdapter{
+		blockJob: blockJob,
+		release:  make(chan struct{}),
+		output:   poolSchedulerAskResult,
+	}
+}
+
+func (a *wedgeBlockingAdapter) Name() string { return "wedge-fake" }
+
+func (a *wedgeBlockingAdapter) Start(context.Context, runtime.StartRequest) (runtime.StartResult, error) {
+	return runtime.StartResult{RuntimeRef: "550e8400-e29b-41d4-a716-446655440000"}, nil
+}
+
+func (a *wedgeBlockingAdapter) Validate(context.Context, runtime.Agent) error { return nil }
+
+func (a *wedgeBlockingAdapter) Deliver(ctx context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	a.mu.Lock()
+	a.delivered = append(a.delivered, job.ID)
+	blocking := job.ID == a.blockJob
+	if blocking {
+		a.blocked = true
+	}
+	a.mu.Unlock()
+	if blocking {
+		select {
+		case <-a.release:
+		case <-ctx.Done():
+			a.mu.Lock()
+			a.blocked = false
+			a.mu.Unlock()
+			return runtime.Result{}, ctx.Err()
+		}
+		a.mu.Lock()
+		a.blocked = false
+		a.mu.Unlock()
+	}
+	return runtime.Result{Raw: a.output}, nil
+}
+
+func (a *wedgeBlockingAdapter) Health(context.Context, runtime.Agent) error { return nil }
+
+func (a *wedgeBlockingAdapter) Capabilities(context.Context) ([]string, error) { return nil, nil }
+
+func (a *wedgeBlockingAdapter) stillBlocked() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.blocked
+}
+
+func (a *wedgeBlockingAdapter) deliveredJobs() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]string, len(a.delivered))
+	copy(out, a.delivered)
+	return out
+}
+
+// waitForJobState polls the store until jobID reaches wantState or the deadline
+// elapses, returning the last observed state.
+func waitForJobState(t *testing.T, store *db.Store, jobID string, wantState string, deadline time.Duration) string {
+	t.Helper()
+	stop := time.Now().Add(deadline)
+	last := ""
+	for time.Now().Before(stop) {
+		job, err := store.GetJob(context.Background(), jobID)
+		if err == nil {
+			last = job.State
+			if last == wantState {
+				return last
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return last
+}
+
+// waitForCondition polls fn until it returns true or the deadline elapses.
+func waitForCondition(t *testing.T, deadline time.Duration, fn func() bool) bool {
+	t.Helper()
+	stop := time.Now().Add(deadline)
+	for time.Now().Before(stop) {
+		if fn() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return fn()
+}
+
+// TestWedgedInlineJobE2E is the #562 end-to-end reproduction and fix proof.
+//
+// Scenario: a single-repo daemon worker loop (the REAL production wiring:
+// startSingleRepoWorkerLoop -> startSupervisorWorkerLoopRecovering ->
+// runDaemonWorkerTickTracked, exactly what runSingleRepoSupervisor starts) runs
+// with 2 workers against a real store. Job A (no worktree, so it occupies the
+// shared checkout key) starts and HANGS inside its runtime adapter — a stand-in
+// for a hung subprocess or a legitimate multi-hour delegation. While A is still
+// in flight, job B — a parallelizable same-repo job with its own worktree, so
+// nothing but the scheduler can serialize it — is enqueued.
+//
+// DESIRED behavior (this test): B is claimed and completes within a bounded
+// wait while A is STILL blocked, because job execution runs off the worker-tick
+// critical path and later ticks keep claiming queued work.
+//
+// FAILED ON UNMODIFIED MAIN (the #562 wedge, reproduced before the fix): the
+// tick ran jobs INLINE while holding the supervisor checkout lock —
+// runQueuedJobsForRepo blocked on wg.Wait() until A returned — so B was never
+// claimed (state stayed "queued" for the whole bounded wait) even though the
+// daemon stayed alive and polling. Mutation proof: forcing the tracker to nil in
+// startSingleRepoWorkerLoop (re-enabling inline execution) turns this test red.
+func TestWedgedInlineJobE2E(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const repo = "owner/repo"
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, repo, t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, repo)
+
+	adapter := newWedgeBlockingAdapter("job-a")
+	worker := poolSchedulerWorker(t, store, adapter, false)
+
+	// Job A occupies the shared repo checkout (no worktree -> "repo:owner/repo").
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 1})
+
+	// Drive the REAL single-repo supervisor worker loop with a fast interval:
+	// same closure, same checkout lock discipline, same tick function that
+	// runSingleRepoSupervisor wires in production.
+	live := newDaemonReloadableConfig(30*time.Second, 2, false)
+	var checkoutLock sync.Mutex
+	tracker := newInflightJobTracker(ctx)
+	defer tracker.drain(io.Discard, 5*time.Second)
+	errCh := startSingleRepoWorkerLoop(ctx, 5*time.Millisecond, store, worker, live, &checkoutLock, tracker, repo, "", io.Discard)
+
+	// Wait until A is genuinely in flight (blocked inside its adapter).
+	if !waitForCondition(t, 5*time.Second, adapter.stillBlocked) {
+		t.Fatalf("job-a never started delivering; delivered=%v", adapter.deliveredJobs())
+	}
+
+	// NOW enqueue B: same repo, distinct worktree -> a distinct checkout key, so
+	// only the (wedged) scheduler could keep it from running.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: repo, Branch: "main", PullRequest: 2, WorktreePath: filepath.Join(t.TempDir(), "wt-job-b")})
+
+	// THE #562 ASSERTION: B completes within a bounded wait while A still hangs.
+	if got := waitForJobState(t, store, "job-b", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-b state = %q after bounded wait while job-a hangs, want succeeded (the #562 wedge: a stuck inline job starves all queued work)", got)
+	}
+	if !adapter.stillBlocked() {
+		t.Fatalf("job-a unexpectedly finished before job-b was claimed; the scenario did not exercise the wedge")
+	}
+
+	// The hung job is still recorded running, not clobbered by B's dispatch.
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobRunning), 2*time.Second); got != string(workflow.JobRunning) {
+		t.Fatalf("job-a state = %q while blocked, want running", got)
+	}
+
+	// Release A; it must complete normally (the fix never abandons the slow job).
+	close(adapter.release)
+	if got := waitForJobState(t, store, "job-a", string(workflow.JobSucceeded), 10*time.Second); got != string(workflow.JobSucceeded) {
+		t.Fatalf("job-a state = %q after release, want succeeded", got)
+	}
+
+	// Graceful shutdown: cancel the supervisor ctx; the loop channel must close.
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker loop did not stop after context cancellation")
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -5186,6 +5186,38 @@ func (s *Store) DeleteExpiredResourceLocks(ctx context.Context, now time.Time) (
 	return result.RowsAffected()
 }
 
+// DeleteExpiredResourceLocksExcludingOwners is DeleteExpiredResourceLocks minus
+// locks held by the given owner job IDs (#562): the daemon's recovery tick skips
+// reaping a lock whose owner job is in flight in this very process (its worker
+// goroutine is alive — e.g. a ctx-deaf runtime overrunning its lease), because
+// deleting it would let a second run of the same session start beside the live
+// one. An empty exclusion list is byte-identical to DeleteExpiredResourceLocks.
+func (s *Store) DeleteExpiredResourceLocksExcludingOwners(ctx context.Context, now time.Time, excludeOwners []string) (int64, error) {
+	if len(excludeOwners) == 0 {
+		return s.DeleteExpiredResourceLocks(ctx, now)
+	}
+	placeholders := strings.Repeat("?,", len(excludeOwners))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, 0, len(excludeOwners)+1)
+	args = append(args, formatResourceLockTime(now))
+	for _, owner := range excludeOwners {
+		args = append(args, owner)
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
+		WHERE expires_at <= ?
+			AND (owner_pid <= 0 OR resource_key LIKE 'runtime:%')
+			AND (resource_key LIKE 'runtime:%' OR NOT EXISTS (
+				SELECT 1 FROM jobs
+				WHERE jobs.id = resource_locks.owner_job_id
+					AND jobs.state = 'running'
+			))
+			AND owner_job_id NOT IN (`+placeholders+`)`, args...)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 func formatResourceLockTime(value time.Time) string {
 	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
 }


### PR DESCRIPTION
## Problem (#562)

The single-repo supervisor ran every job **synchronously, inline, in the worker tick while holding the checkout lock**: `runSingleRepoSupervisor`'s worker closure did `checkoutLock.Lock()` → `runDaemonWorkerTick` → `runQueuedJobsForRepo`, which blocks on `wg.Wait()` until every job in the batch returns. One hung runtime subprocess — or one perfectly legitimate multi-hour delegation — froze the loop: no new queued jobs claimed, recovery scans stalled, full `PollOnce` permanently suppressed, while `daemon status` kept reporting "running". (#570 already fixed aggravators 1–3: the `jobTimeout==0` deadline gap, worker-loop supervision + escalation, and the poll timeout. This PR is the remaining structural fix — points 1 and 5 of the issue's fix direction.)

## Design: claim-and-dispatch-async with an in-flight tracker

This is the **real fix** (not the lock-release fallback): the tick now CLAIMS runnable jobs and dispatches them to goroutines registered in a new `inflightJobTracker` (`internal/cli/daemon_dispatch_tracked.go`), returning promptly so the loop keeps ticking while jobs run. Everything inline execution guaranteed *by accident* is preserved *explicitly*:

- **Same-repo serialization** — an in-flight job's checkout/runtime keys are held in the tracker and seeded into `selectRunnableQueuedJobsSeeded`, so a same-repo no-worktree job is never dispatched beside the job occupying the shared checkout — now **cross-tick**, not just per-batch.
- **Concurrency caps** — dispatch slots are `limit − tracked in-flight`, so `--workers`, warm-reloaded counts (#577), and per-repo `max_parallel` (#576/#589) bound TOTAL in-flight jobs.
- **Pool semantics (#394)** — the pool runs as a single-flight background pass per repo, mirrored into the tracker and seeded from it. A warm scheduler flip can never race two selectors: `tryBeginPool` refuses while tracked non-pool jobs are in flight, and the barrier dispatch defers while a pool pass is live (two concurrent selectors could each snapshot seeds before the other's `begin()` and put two jobs on one checkout key).
- **Poller exclusion** — full `PollOnce` runs only under the checkout lock AND an idle tracker (registered-repo poller gets the same gate via `poller.Inflight`), so the poller never mutates a checkout under a running job; otherwise it degrades to the recovery-command-only poll, exactly as before.
- **Recovery-scan self-requeue guards** — DB-only recovery scans keep running every tick but skip jobs THIS process is running: a live >30m leaseless job (e.g. shell runtime) is no longer requeued out from under its own worker, and the expired runtime-lock reaper skips in-flight owners (new `DeleteExpiredResourceLocksExcludingOwners`; releasing a live owner's lock could double-run the session, the #536 hazard). Checkout-mutating maintenance runs only on an idle tick — the same cadence inline execution allowed.
- **#570 escalation preserved** — async infra errors are recorded per repo and surfaced as the NEXT tick's error, so a persistent store fault still trips the escalation ceiling.
- **Graceful shutdown** — every dispatched job runs on the tracker's `runCtx`; a deferred `drain()` cancels it and waits (bounded, 15s) for in-flight jobs on daemon stop.

A nil tracker keeps `runDaemonWorkerTickTracked` byte-identical to the historical inline tick (legacy/test callers unchanged).

## Observability (#562 point 5)

A queued job skipped by the dispatcher — previously **silent** — now logs a throttled (5m/job/reason) `job X held back: ...` line:
- checkout held by an in-flight job (with the holder's job ID),
- held/stranded `runtime:<rt>:<session>` resource lock (with owner + lease expiry),
- admission-budget refusal, distinguishing a transient wait from a **NEVER-fit** (estimate above the configured `[admission]` cap, with the remedy named).

## E2E proof: failed on unmodified main / mutation-red

`TestWedgedInlineJobE2E` drives the **real production loop wiring** — `startSingleRepoWorkerLoop` (extracted so the tested loop can never drift from what `runSingleRepoSupervisor` deploys) → `startSupervisorWorkerLoopRecovering` → `runDaemonWorkerTickTracked` — with a real store and a blocking delivery adapter: job A hangs inside its adapter occupying the shared checkout; job B (own worktree, so only the scheduler could hold it back) is enqueued while A is in flight; the test asserts B completes within a bounded wait while A is STILL blocked, then that A completes normally after release, then that shutdown is clean.

**Verified mutation-red in this session**: forcing the tracker to `nil` in `startSingleRepoWorkerLoop` (which by construction re-enables main's exact inline behavior in the production wiring) makes the E2E fail with `job-b state = "queued" after bounded wait while job-a hangs` — the reproduced #562 wedge. The new pool-flip guard was mutation-checked the same way (disabling it turns `TestTrackedBarrierDefersToLivePoolPass` red).

## Regression tests

- `TestTrackedDispatchPreservesSameRepoSerialization` — two same-repo no-worktree jobs still never run concurrently (workers=2, so it's the shared key, not the limit).
- `TestTrackedDispatchRespectsWorkerLimit` — cross-tick TOTAL in-flight cap holds for both tracked barrier and tracked pool.
- `TestTrackedBarrierDefersToLivePoolPass` — the single-selector invariant across warm scheduler flips.
- `TestTrackedLoopShutdownDrainsInFlightJobs` — drain cancels + waits; accounting doesn't leak.
- `TestRecoverRunningJobsSkipsInFlightJobs` / `TestExpiredRuntimeLockReaperSkipsInFlightOwners` — in-flight guards, with the no-skip (genuine crash) recovery path pinned as still working.
- `TestTrackedDispatchLogsHeldBackJobs` / `TestTrackedDispatchLogsAdmissionNeverFit` — the observability lines + their throttle.

Full gate (build, vet, package tests, `-race -timeout 20m` on cli+workflow) green.

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)
