### PR TITLE
feat(daemon): classify operational blockers and defer failed jobs for auto-retry (#532 slice 1)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -20,6 +20,7 @@ The pilot emits a tight allowlist of event types over the webhook transport:
 | `job.failed`                    | a job reaches the `failed` terminal state                                          |
 | `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
 | `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
+| `job.deferred`                  | the daemon re-queued a job that just emitted `job.failed` because the failure classified as a retryable operational blocker (runtime auth, rate limit/quota) — it will be re-dispatched automatically |
 | `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
 | `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current` (also the canary GRADUATE event) |
 | `candidate.canary_started`      | the off-by-default `[skillopt].auto_promote_canary` policy promoted a candidate to the `canary` state behind the live champion |
@@ -30,6 +31,17 @@ succeeded/failed/blocked emit on its `Mailbox` terminal path; the daemon owns th
 pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
 pass through that path. `job.needs_attention` is emitted once per fresh
 escalation round (a re-advance does not re-emit).
+
+**`job.failed` followed by `job.deferred` is NOT terminal.** When a run fails on
+a classified operational blocker (runtime auth rejected, provider rate
+limit/quota), the engine has already emitted `job.failed` for that run before the
+daemon decides to defer; the daemon then emits `job.deferred` for the same
+`job_id` (detail carries the blocker class, the `attempt N/M` retry budget, and
+the earliest `retry at` timestamp) and silently re-dispatches the job after the
+hold. Consumers acting on `job.failed` (recovery, alerting, cleanup) should
+suppress terminal handling for a job whose `job.failed` is followed by a
+`job.deferred`, and treat only a `job.failed` with no subsequent `job.deferred`
+as final.
 
 The two `candidate.*` events come from the `skillopt import` / `train continue`
 CLI path, NOT the daemon (#471). When a candidate becomes `pending`,

--- a/internal/cli/blocker_defer_e2e_test.go
+++ b/internal/cli/blocker_defer_e2e_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -111,21 +112,26 @@ func TestE2E532QuotaBlockerDeferredAndAutoRedispatched(t *testing.T) {
 	state := t.TempDir()
 	marker := filepath.Join(state, "delivered")
 	countFile := filepath.Join(state, "count")
+	promptFile := filepath.Join(state, "retry-prompt")
 	// Fail the first delivery with a fabricated 429 carrying a relative reset;
-	// succeed on the second. $0/$1 (the "gitmoot" argv + prompt) are unused.
+	// succeed on the second, capturing the retried prompt ($1) so the
+	// at-least-once reconciliation notice is provable end to end.
 	script := fmt.Sprintf(`printf x >> %q
 if [ ! -f %q ]; then
   : > %q
   echo "HTTP 429 Too Many Requests: rate limit reached; try again in 3 seconds" 1>&2
   exit 1
 fi
-printf '%%s' '%s'`, countFile, marker, marker, blockerE2EApprovedResult)
+printf '%%s' "$1" > %q
+printf '%%s' '%s'`, countFile, marker, marker, promptFile, blockerE2EApprovedResult)
 	seedDaemonWorkerAgent(t, store, "opsbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
 		ID: "job-quota", Agent: "opsbot", Action: "ask", Repo: "owner/repo",
 		Branch: "main", PullRequest: 1,
 	})
 	worker := blockerE2EWorker(store, home, checkout)
+	sink := &recordingSink{}
+	worker.EventSinkOverride = sink
 
 	// First dispatch: the delivery fails 429 → the job must be DEFERRED
 	// (blocked-operational), not terminally failed.
@@ -149,11 +155,26 @@ printf '%%s' '%s'`, countFile, marker, marker, blockerE2EApprovedResult)
 	if err != nil {
 		t.Fatalf("parse blocker_retry_at %q: %v", payload.BlockerRetryAt, err)
 	}
-	if until := time.Until(retryAt); until <= 0 || until > 4*time.Second {
-		t.Fatalf("blocker_retry_at %s not within the fabricated 3s reset window (until=%s)", payload.BlockerRetryAt, until)
+	// The fabricated 3s reset is floored to quotaBlockerMinParsedDelay (5s), plus
+	// up to 10% jitter.
+	if until := time.Until(retryAt); until <= 0 || until > quotaBlockerMinParsedDelay+time.Second {
+		t.Fatalf("blocker_retry_at %s not within the floored reset window (until=%s)", payload.BlockerRetryAt, until)
 	}
 	if !blockerE2EHasEventKind(t, store, "job-quota", blockerDeferredEventKind) {
 		t.Fatalf("missing %s job event", blockerDeferredEventKind)
+	}
+	// The [events] stream must carry the additive job.deferred so external
+	// consumers acting on the already-emitted job.failed can suppress terminal
+	// handling for a job the daemon is about to retry.
+	deferredEvents := sink.byType(events.EventJobDeferred)
+	if len(deferredEvents) != 1 {
+		t.Fatalf("job.deferred emissions = %d, want 1", len(deferredEvents))
+	}
+	if ev := deferredEvents[0]; ev.JobID != "job-quota" || ev.Repo != "owner/repo" ||
+		!strings.Contains(ev.Detail, string(blockerClassRuntimeQuota)) ||
+		!strings.Contains(ev.Detail, "attempt 1/") ||
+		!strings.Contains(ev.Detail, "retry at ") {
+		t.Fatalf("job.deferred event = %+v, want class/attempt/retry_at in detail", ev)
 	}
 
 	// The #552 stuck-reason surface (job list/show) must explain the hold.
@@ -219,6 +240,16 @@ printf '%%s' '%s'`, countFile, marker, marker, blockerE2EApprovedResult)
 	}
 	if payload.BlockerAttempts != 1 {
 		t.Fatalf("blocker_attempts after success = %d, want 1 (single deferral)", payload.BlockerAttempts)
+	}
+	// The retried delivery is at-least-once for side effects, so its prompt must
+	// carry the reconciliation notice telling the agent to verify prior work.
+	retryPrompt, err := os.ReadFile(promptFile)
+	if err != nil {
+		t.Fatalf("read captured retry prompt: %v", err)
+	}
+	if !strings.Contains(string(retryPrompt), "operational blocker (runtime_quota)") ||
+		!strings.Contains(string(retryPrompt), "reconcile") {
+		t.Fatalf("retried prompt is missing the at-least-once reconciliation notice:\n%s", retryPrompt)
 	}
 }
 
@@ -315,6 +346,99 @@ func TestE2E532ProductFailureIsNeverRetried(t *testing.T) {
 	job, _ = blockerE2EJobPayload(t, store, "job-product")
 	if job.State != string(workflow.JobFailed) {
 		t.Fatalf("product failure left terminal state: %q", job.State)
+	}
+}
+
+// A repair-exhausted gitmoot_result CONTRACT failure — the agent delivered
+// output every time but never a valid envelope, and the final error text is
+// agent-authored (here an unsupported decision that mentions "rate limit") —
+// is a product failure: it must never classify as an operational blocker, no
+// matter what quota/auth words the agent's text contains.
+func TestE2E532ContractValidationFailureIsNeverRetried(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	countFile := filepath.Join(t.TempDir(), "count")
+	malformed := `{"gitmoot_result":{"decision":"blocked: rate limit","summary":"quota","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+	script := fmt.Sprintf("printf x >> %q\nprintf '%%s' '%s'", countFile, malformed)
+	seedDaemonWorkerAgent(t, store, "contractbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-contract", Agent: "contractbot", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 6,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-contract")
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("contract failure state = %q, want %q (a deferral means agent-authored text classified)", job.State, workflow.JobFailed)
+	}
+	if payload.BlockerClass != "" || payload.BlockerRetryAt != "" {
+		t.Fatalf("contract failure acquired blocker fields: %+v", payload)
+	}
+	if blockerE2EHasEventKind(t, store, "job-contract", blockerDeferredEventKind) {
+		t.Fatal("contract failure recorded a blocker_deferred event")
+	}
+	// First delivery + the repair re-asks — but never a #532 auto-retry.
+	deliveries := blockerE2EDeliveryCount(t, countFile)
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("second dispatch returned error: %v", err)
+	}
+	if got := blockerE2EDeliveryCount(t, countFile); got != deliveries {
+		t.Fatalf("contract failure was re-delivered (count %d -> %d)", deliveries, got)
+	}
+}
+
+// A 429 that hits the REPAIR delivery — i.e. after a first delivery that
+// completed a full, potentially side-effectful agent turn — must not defer:
+// the persisted raw output proves execution, and an auto-retry would re-run
+// the entire prompt (duplicate pushes/PRs). The job keeps today's terminal
+// path.
+func TestE2E532RepairDeliveryQuotaFailureIsNotRetried(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	state := t.TempDir()
+	marker := filepath.Join(state, "delivered")
+	countFile := filepath.Join(state, "count")
+	// First delivery SUCCEEDS but with no gitmoot_result envelope (a completed
+	// turn); every repair delivery then fails with a classified 429.
+	script := fmt.Sprintf(`printf x >> %q
+if [ ! -f %q ]; then
+  : > %q
+  printf '%%s' "did the work, pushed the branch, forgot the envelope"
+  exit 0
+fi
+echo "HTTP 429 Too Many Requests: rate limit reached; try again in 3 seconds" 1>&2
+exit 1`, countFile, marker, marker)
+	seedDaemonWorkerAgent(t, store, "repairbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-repair", Agent: "repairbot", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 7,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-repair")
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("repair-delivery 429 state = %q, want %q (deferring would re-run an already-executed job)", job.State, workflow.JobFailed)
+	}
+	if len(payload.RawOutputs) == 0 {
+		t.Fatal("first delivery's raw output was not persisted; the side-effect guard has nothing to key on")
+	}
+	if payload.BlockerClass != "" || payload.BlockerRetryAt != "" {
+		t.Fatalf("already-executed job acquired blocker fields: %+v", payload)
+	}
+	if blockerE2EHasEventKind(t, store, "job-repair", blockerDeferredEventKind) {
+		t.Fatal("already-executed job recorded a blocker_deferred event")
 	}
 }
 

--- a/internal/cli/blocker_defer_e2e_test.go
+++ b/internal/cli/blocker_defer_e2e_test.go
@@ -1,0 +1,393 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// E2E for the #532 first slice (operational-blocker classification + deferred
+// auto-redispatch), deterministic and LLM-free: a REAL shell-runtime agent whose
+// script fails the FIRST delivery with a fabricated 429-with-reset and succeeds
+// on the second, driven through the REAL daemon dispatch entry
+// (runQueuedJobsForRepo → listPendingQueuedJobs → jobWorker.run → engine.RunJob
+// → ShellAdapter → real subprocess → Mailbox.fail → deferOperationalBlocker).
+//
+// MUTATION PROOF: disable the classification match (make
+// classifyOperationalBlocker return false, or drop the "throttled" case) and
+// the first dispatch terminally fails the job — the `queued` assertion and the
+// second-attempt success assertion below flip RED.
+
+// blockerE2EHome initializes an isolated gitmoot home (no GITMOOT_HOME / live
+// home reads) and opens its store.
+func blockerE2EHome(t *testing.T) (*db.Store, string) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	return store, home
+}
+
+// blockerE2EWorker builds a jobWorker on the isolated home with only the
+// checkout resolution stubbed (checkout state is not under test); the adapter is
+// the REAL ShellAdapter built by the default factory from the agent's runtime.
+func blockerE2EWorker(store *db.Store, home string, checkout string) jobWorker {
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	return worker
+}
+
+func blockerE2EDeliveryCount(t *testing.T, countFile string) int {
+	t.Helper()
+	data, err := os.ReadFile(countFile)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read count file: %v", err)
+	}
+	return strings.Count(string(data), "x")
+}
+
+func blockerE2EJobPayload(t *testing.T, store *db.Store, jobID string) (db.Job, workflow.JobPayload) {
+	t.Helper()
+	job, err := store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("parse payload: %v", err)
+	}
+	return job, payload
+}
+
+func blockerE2EHasEventKind(t *testing.T, store *db.Store, jobID string, kind string) bool {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+const blockerE2EApprovedResult = `{"gitmoot_result":{"decision":"approved","summary":"second attempt succeeded","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+
+func TestE2E532QuotaBlockerDeferredAndAutoRedispatched(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	state := t.TempDir()
+	marker := filepath.Join(state, "delivered")
+	countFile := filepath.Join(state, "count")
+	// Fail the first delivery with a fabricated 429 carrying a relative reset;
+	// succeed on the second. $0/$1 (the "gitmoot" argv + prompt) are unused.
+	script := fmt.Sprintf(`printf x >> %q
+if [ ! -f %q ]; then
+  : > %q
+  echo "HTTP 429 Too Many Requests: rate limit reached; try again in 3 seconds" 1>&2
+  exit 1
+fi
+printf '%%s' '%s'`, countFile, marker, marker, blockerE2EApprovedResult)
+	seedDaemonWorkerAgent(t, store, "opsbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-quota", Agent: "opsbot", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 1,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+
+	// First dispatch: the delivery fails 429 → the job must be DEFERRED
+	// (blocked-operational), not terminally failed.
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("first dispatch returned error: %v", err)
+	}
+	if got := blockerE2EDeliveryCount(t, countFile); got != 1 {
+		t.Fatalf("delivery count after first dispatch = %d, want 1", got)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-quota")
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state after classified 429 = %q, want %q (terminal fail means classification is broken)", job.State, workflow.JobQueued)
+	}
+	if payload.BlockerClass != string(blockerClassRuntimeQuota) {
+		t.Fatalf("blocker_class = %q, want %q", payload.BlockerClass, blockerClassRuntimeQuota)
+	}
+	if payload.BlockerAttempts != 1 {
+		t.Fatalf("blocker_attempts = %d, want 1", payload.BlockerAttempts)
+	}
+	retryAt, err := time.Parse(time.RFC3339Nano, payload.BlockerRetryAt)
+	if err != nil {
+		t.Fatalf("parse blocker_retry_at %q: %v", payload.BlockerRetryAt, err)
+	}
+	if until := time.Until(retryAt); until <= 0 || until > 4*time.Second {
+		t.Fatalf("blocker_retry_at %s not within the fabricated 3s reset window (until=%s)", payload.BlockerRetryAt, until)
+	}
+	if !blockerE2EHasEventKind(t, store, "job-quota", blockerDeferredEventKind) {
+		t.Fatalf("missing %s job event", blockerDeferredEventKind)
+	}
+
+	// The #552 stuck-reason surface (job list/show) must explain the hold.
+	reason := loadStuckReason(store, job)
+	if !strings.HasPrefix(reason.Reason, "blocked-operational: "+string(blockerClassRuntimeQuota)) {
+		t.Fatalf("stuck reason = %q, want blocked-operational %s prefix", reason.Reason, blockerClassRuntimeQuota)
+	}
+	if reason.NextRetryAt != payload.BlockerRetryAt {
+		t.Fatalf("stuck next_retry_at = %q, want %q", reason.NextRetryAt, payload.BlockerRetryAt)
+	}
+
+	// While inside the hold window, the queue gate must keep the job out of the
+	// pending listing and re-dispatch attempts must not deliver.
+	if time.Now().UTC().Before(retryAt) {
+		pending, err := listPendingQueuedJobs(ctx, worker, "", "")
+		if err != nil {
+			t.Fatalf("listPendingQueuedJobs returned error: %v", err)
+		}
+		for _, p := range pending {
+			if p.ID == "job-quota" {
+				t.Fatal("held job is listed as pending inside its hold window")
+			}
+		}
+	}
+	for {
+		if !time.Now().UTC().Before(retryAt) {
+			break
+		}
+		if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+			t.Fatalf("held-window dispatch returned error: %v", err)
+		}
+		// Only judge deliveries observed strictly inside the window; a dispatch
+		// that legitimately started at/after retryAt is not a gate violation.
+		if time.Now().UTC().Before(retryAt) {
+			if got := blockerE2EDeliveryCount(t, countFile); got != 1 {
+				t.Fatalf("job was re-dispatched before earliest-retry-at (deliveries=%d)", got)
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// After the reset elapses the daemon must re-dispatch automatically and the
+	// job must SUCCEED on the second attempt.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+			t.Fatalf("post-window dispatch returned error: %v", err)
+		}
+		job, payload = blockerE2EJobPayload(t, store, "job-quota")
+		if job.State == string(workflow.JobSucceeded) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job never succeeded after the reset window; state=%q", job.State)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if got := blockerE2EDeliveryCount(t, countFile); got != 2 {
+		t.Fatalf("delivery count after success = %d, want exactly 2", got)
+	}
+	if payload.Result == nil || payload.Result.Decision != "approved" {
+		t.Fatalf("stored result = %+v, want approved decision", payload.Result)
+	}
+	if payload.BlockerAttempts != 1 {
+		t.Fatalf("blocker_attempts after success = %d, want 1 (single deferral)", payload.BlockerAttempts)
+	}
+}
+
+func TestE2E532AuthBlockerDeferredAndHeld(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	countFile := filepath.Join(t.TempDir(), "count")
+	script := fmt.Sprintf(`printf x >> %q
+echo "Failed to authenticate. API Error: 401 authentication_error: invalid x-api-key" 1>&2
+exit 1`, countFile)
+	seedDaemonWorkerAgent(t, store, "authbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-auth", Agent: "authbot", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 2,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+
+	before := time.Now().UTC()
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-auth")
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state after classified auth failure = %q, want %q", job.State, workflow.JobQueued)
+	}
+	if payload.BlockerClass != string(blockerClassRuntimeAuth) {
+		t.Fatalf("blocker_class = %q, want %q", payload.BlockerClass, blockerClassRuntimeAuth)
+	}
+	retryAt, err := time.Parse(time.RFC3339Nano, payload.BlockerRetryAt)
+	if err != nil {
+		t.Fatalf("parse blocker_retry_at %q: %v", payload.BlockerRetryAt, err)
+	}
+	if min, max := before.Add(authBlockerRetryDelay-time.Minute), before.Add(authBlockerRetryDelay+time.Minute); retryAt.Before(min) || retryAt.After(max) {
+		t.Fatalf("auth blocker_retry_at %s outside expected ~%s window", payload.BlockerRetryAt, authBlockerRetryDelay)
+	}
+	// Held: an immediate re-dispatch must not deliver again.
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("held dispatch returned error: %v", err)
+	}
+	if got := blockerE2EDeliveryCount(t, countFile); got != 1 {
+		t.Fatalf("delivery count while held = %d, want 1", got)
+	}
+	reason := loadStuckReason(store, job)
+	if !strings.HasPrefix(reason.Reason, "blocked-operational: "+string(blockerClassRuntimeAuth)) {
+		t.Fatalf("stuck reason = %q, want blocked-operational %s prefix", reason.Reason, blockerClassRuntimeAuth)
+	}
+}
+
+// A PRODUCT failure — the agent answered with a parseable gitmoot_result whose
+// decision is "failed" — must NEVER be classified or auto-retried, even though
+// the summary text mentions a rate limit.
+func TestE2E532ProductFailureIsNeverRetried(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	countFile := filepath.Join(t.TempDir(), "count")
+	result := `{"gitmoot_result":{"decision":"failed","summary":"could not finish: upstream rate limit made the approach infeasible","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+	script := fmt.Sprintf("printf x >> %q\nprintf '%%s' '%s'", countFile, result)
+	seedDaemonWorkerAgent(t, store, "prodbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-product", Agent: "prodbot", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 3,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-product")
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("product failure state = %q, want %q", job.State, workflow.JobFailed)
+	}
+	if payload.Result == nil || payload.Result.Decision != "failed" {
+		t.Fatalf("stored result = %+v, want failed decision", payload.Result)
+	}
+	if payload.BlockerClass != "" || payload.BlockerAttempts != 0 || payload.BlockerRetryAt != "" {
+		t.Fatalf("product failure acquired blocker fields: %+v", payload)
+	}
+	if blockerE2EHasEventKind(t, store, "job-product", blockerDeferredEventKind) {
+		t.Fatal("product failure recorded a blocker_deferred event")
+	}
+	// A later dispatch pass must not resurrect it.
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("second dispatch returned error: %v", err)
+	}
+	if got := blockerE2EDeliveryCount(t, countFile); got != 1 {
+		t.Fatalf("product failure was re-delivered (count=%d)", got)
+	}
+	job, _ = blockerE2EJobPayload(t, store, "job-product")
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("product failure left terminal state: %q", job.State)
+	}
+}
+
+// An unclassified operational error keeps today's byte-identical terminal path.
+func TestE2E532UnclassifiedFailureStaysTerminal(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	script := `echo "boom: something unrelated broke" 1>&2
+exit 2`
+	seedDaemonWorkerAgent(t, store, "plainbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-plain", Agent: "plainbot", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 4,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-plain")
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("unclassified failure state = %q, want %q", job.State, workflow.JobFailed)
+	}
+	if payload.BlockerClass != "" || payload.BlockerRetryAt != "" {
+		t.Fatalf("unclassified failure acquired blocker fields: %+v", payload)
+	}
+	if blockerE2EHasEventKind(t, store, "job-plain", blockerDeferredEventKind) {
+		t.Fatal("unclassified failure recorded a blocker_deferred event")
+	}
+}
+
+// The auto-retry budget is a hard bound: a classified blocker recurring after
+// maxOperationalBlockerRetries deferrals leaves the job terminally failed with a
+// blocker_retries_exhausted event.
+func TestE2E532BlockerRetryBudgetExhausted(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	script := `echo "HTTP 429 Too Many Requests: rate limit reached; try again in 1 seconds" 1>&2
+exit 1`
+	seedDaemonWorkerAgent(t, store, "capbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-cap", Agent: "capbot", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 5,
+	})
+	// Simulate a job that already spent its full auto-retry budget.
+	job, payload := blockerE2EJobPayload(t, store, "job-cap")
+	payload.BlockerAttempts = maxOperationalBlockerRetries
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload returned error: %v", err)
+	}
+	worker := blockerE2EWorker(store, home, checkout)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, _ = blockerE2EJobPayload(t, store, "job-cap")
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("exhausted-budget state = %q, want %q", job.State, workflow.JobFailed)
+	}
+	if !blockerE2EHasEventKind(t, store, "job-cap", blockerExhaustedEventKind) {
+		t.Fatalf("missing %s job event", blockerExhaustedEventKind)
+	}
+	if blockerE2EHasEventKind(t, store, "job-cap", blockerDeferredEventKind) {
+		t.Fatal("exhausted-budget job was deferred again")
+	}
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3509,6 +3509,13 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 		if queuedChildOfKilledRoot(ctx, worker.Store, job) {
 			continue
 		}
+		// Operational-blocker hold (#532): a job deferred behind a classified
+		// blocker is not eligible until its earliest-retry-at passes. Both
+		// schedulers (barrier and pool) funnel through this listing, so the hold
+		// is honored everywhere; jobs without the payload field are unaffected.
+		if queuedJobBlockerHeld(job, time.Now().UTC()) {
+			continue
+		}
 		pending = append(pending, job)
 	}
 	return pending, nil
@@ -4339,6 +4346,21 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	if err != nil {
 		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
 			return markErr
+		}
+		// Operational-blocker deferral (#532): a run that terminally failed on a
+		// classified OPERATIONAL blocker (runtime auth rejected, rate limit/quota)
+		// is re-queued with an earliest-retry-at hold instead of staying failed
+		// indistinguishably from a product failure. Strictly additive and off the
+		// hot path: deferOperationalBlocker only diverts when the error matches a
+		// classified blocker AND the job failed without a stored result AND it is
+		// not a delegation child; every other failure takes the path below
+		// byte-identically. A deferral error is logged and falls through so the
+		// job is never left in limbo.
+		if deferred, deferErr := w.deferOperationalBlocker(ctx, job.ID, err); deferErr != nil {
+			writeLine(w.Stdout, "job %s blocker deferral failed: %v", job.ID, deferErr)
+		} else if deferred {
+			writeLine(w.Stdout, "job %s deferred on operational blocker: %v", job.ID, err)
+			return nil
 		}
 		commentErr := err
 		if job.Type == "implement" && runtimePermissionFailure(err) {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4360,11 +4360,13 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		// classified OPERATIONAL blocker (runtime auth rejected, rate limit/quota)
 		// is re-queued with an earliest-retry-at hold instead of staying failed
 		// indistinguishably from a product failure. Strictly additive and off the
-		// hot path: deferOperationalBlocker only diverts when the error matches a
-		// classified blocker AND the job failed without a stored result AND it is
-		// not a delegation child; every other failure takes the path below
-		// byte-identically. A deferral error is logged and falls through so the
-		// job is never left in limbo.
+		// hot path: deferOperationalBlocker only diverts when the error is a typed
+		// delivery-seam failure matching a classified blocker AND the job failed
+		// without a stored result AND no delivery ever completed (no persisted raw
+		// outputs — the duplicate-side-effect gate) AND it is not a delegation
+		// child; every other failure takes the path below byte-identically. A
+		// deferral error is logged and falls through so the job is never left in
+		// limbo.
 		if deferred, deferErr := w.deferOperationalBlocker(ctx, job.ID, err); deferErr != nil {
 			writeLine(w.Stdout, "job %s blocker deferral failed: %v", job.ID, deferErr)
 		} else if deferred {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3605,6 +3605,15 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 		// so no other selector can re-dispatch it mid-restore.
 		if f.payloadBeforeIsolation != "" && errors.Is(f.err, errRuntimeSessionBusy) {
 			_ = worker.Store.UpdateJobPayload(context.WithoutCancel(ctx), f.jobID, f.payloadBeforeIsolation)
+		} else if f.payloadBeforeIsolation != "" {
+			// Operational-blocker deferral (#532) × pool isolation: a deferred job
+			// is queued again but its payload still points at the isolation
+			// worktree this reap is about to delete. Restore the pre-isolation
+			// payload (carrying the blocker hold fields over) so its re-dispatch
+			// after the hold re-evaluates cleanly instead of preflight-failing on
+			// a reaped path. No-op for any job that is not queued with a blocker
+			// hold, so terminal outcomes are byte-identical.
+			restorePreIsolationPayloadForDeferredJob(context.WithoutCancel(ctx), worker.Store, f.jobID, f.payloadBeforeIsolation)
 		}
 		tracker.end(f.jobID)
 		// Release the host-global admission reservation (#365) keyed by job ID,

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -1,0 +1,271 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// Issue #532 (first slice): classify OPERATIONAL blockers — failures caused by
+// the environment the job ran in (runtime auth rejected, provider rate
+// limit/quota), not by the agent's work — and defer the job for automatic
+// re-dispatch instead of terminally failing it indistinguishably from a product
+// failure.
+//
+// Scope discipline (all guards below are load-bearing):
+//   - Only a job that ended JobFailed WITHOUT a stored gitmoot_result is
+//     eligible: a stored result means the agent DID answer (a `failed` decision
+//     is a product failure and must never be auto-retried).
+//   - Delegation children (ParentJobID set) are excluded: their retry/failure
+//     policy belongs to the delegation DAG (finalizeTimedOutDelegationChild →
+//     advanceDelegations), which already owns retry semantics for children.
+//   - Only the two cleanest classes are matched (runtime_auth, runtime_quota),
+//     reusing the #552 classifyAuthQuota signatures plus the adapters' typed
+//     runtime.ErrClaudeAuthFailed sentinel, so detection stays grounded in
+//     strings the adapters actually emit.
+//   - Auto-retries are hard-bounded by maxOperationalBlockerRetries; when the
+//     budget is exhausted the job stays terminally failed exactly like today.
+//
+// Every job that does not hit a classified blocker takes the existing path
+// byte-identically: the hook in jobWorker.run only diverts when
+// deferOperationalBlocker returns true.
+
+// blockerClass names a class of operational blocker. Persisted in the job
+// payload (blocker_class) and rendered by the #552 stuck-reason surface, so the
+// values are part of the observable CLI surface — do not rename casually.
+type blockerClass string
+
+const (
+	blockerClassRuntimeAuth  blockerClass = "runtime_auth"
+	blockerClassRuntimeQuota blockerClass = "runtime_quota"
+)
+
+// blockerDeferredEventKind is the job_event kind recorded when a failed job is
+// re-queued behind an operational blocker. It is a #552 stuck-reason event kind
+// (see stuckReasonEventKinds) so `job list`/`job show` explain the held job.
+const blockerDeferredEventKind = "blocker_deferred"
+
+// blockerExhaustedEventKind is recorded when a classified blocker recurs after
+// the auto-retry budget is spent; the job stays terminally failed and this event
+// documents why no further auto-retry happened.
+const blockerExhaustedEventKind = "blocker_retries_exhausted"
+
+// maxOperationalBlockerRetries hard-bounds automatic re-dispatches per job. It
+// counts classified deferrals over the job's lifetime (persisted in the payload
+// as blocker_attempts), so a flapping blocker can never retry a job forever.
+const maxOperationalBlockerRetries = 3
+
+// authBlockerRetryDelay is the earliest-retry delay for a runtime auth failure.
+// Token rotation/re-login is a human action with no machine-readable ETA, so the
+// deferral simply re-probes on a coarse cadence (bounded by the retry budget)
+// instead of hammering the provider. A future slice can tighten this to
+// "next tick after a doctor-style probe passes" (#532 design comment).
+const authBlockerRetryDelay = 5 * time.Minute
+
+// quotaBlockerFallbackDelay is used when a rate-limit/quota error carries no
+// parseable reset time.
+const quotaBlockerFallbackDelay = 15 * time.Minute
+
+// quotaBlockerMaxParsedDelay caps a parsed reset delay so a garbled "try again
+// in N hours" can never park a job for days.
+const quotaBlockerMaxParsedDelay = 24 * time.Hour
+
+// blockerClassification is the classifier verdict for one failed run.
+type blockerClassification struct {
+	Class   blockerClass
+	RetryAt time.Time // earliest safe automatic re-dispatch (UTC)
+	Detail  string    // first line of the causing error, for events/UX
+}
+
+// classifyOperationalBlocker inspects a RunJob error and reports whether it is a
+// classifiable operational blocker. Detection composes with #552: the string
+// signatures are the SAME classifyAuthQuota matcher `job list` already uses to
+// label stuck jobs, plus the typed runtime.ErrClaudeAuthFailed sentinel the
+// Claude adapter attaches to genuine credential rejections. Engine-routed
+// outcomes (awaiting-human, blocked) and cancellations are never classified.
+func classifyOperationalBlocker(cause error, now time.Time) (blockerClassification, bool) {
+	if cause == nil {
+		return blockerClassification{}, false
+	}
+	var awaiting workflow.AwaitingHumanError
+	var blocked workflow.BlockedError
+	if errors.As(cause, &awaiting) || errors.As(cause, &blocked) ||
+		errors.Is(cause, context.Canceled) || errors.Is(cause, context.DeadlineExceeded) {
+		return blockerClassification{}, false
+	}
+	text := cause.Error()
+	detail := firstLineTrimmed(text)
+	if errors.Is(cause, runtime.ErrClaudeAuthFailed) {
+		return blockerClassification{Class: blockerClassRuntimeAuth, RetryAt: now.Add(authBlockerRetryDelay), Detail: detail}, true
+	}
+	switch classifyAuthQuota(text) {
+	case "throttled":
+		delay := parseQuotaResetDelay(text)
+		return blockerClassification{Class: blockerClassRuntimeQuota, RetryAt: now.Add(delay + blockerRetryJitter(delay)), Detail: detail}, true
+	case "auth failing":
+		return blockerClassification{Class: blockerClassRuntimeAuth, RetryAt: now.Add(authBlockerRetryDelay), Detail: detail}, true
+	}
+	return blockerClassification{}, false
+}
+
+// quotaResetInRe matches relative reset hints the runtimes actually emit, e.g.
+// codex's "Please try again in 32 seconds", generic "retry after 60 s(econds)",
+// and HTTP "Retry-After: 120" (bare integers are seconds).
+var quotaResetInRe = regexp.MustCompile(`(?i)(?:try again in|retry after|retry in|retry-after:?)\s*(\d+)\s*(seconds?|minutes?|hours?|s\b|m\b|h\b)?`)
+
+// quotaResetEpochRe matches the Claude CLI usage-limit shape
+// "Claude AI usage limit reached|<unix-epoch>".
+var quotaResetEpochRe = regexp.MustCompile(`\|(\d{10})\b`)
+
+// parseQuotaResetDelay extracts the provider-declared reset delay from a
+// rate-limit/quota error. Unparseable messages (e.g. codex's "try again at Jun
+// 14th") fall back to quotaBlockerFallbackDelay; parsed values are clamped to
+// (0, quotaBlockerMaxParsedDelay].
+func parseQuotaResetDelay(text string) time.Duration {
+	if m := quotaResetInRe.FindStringSubmatch(text); m != nil {
+		n, err := strconv.Atoi(m[1])
+		if err == nil && n > 0 {
+			unit := time.Second
+			switch {
+			case strings.HasPrefix(strings.ToLower(m[2]), "m"):
+				unit = time.Minute
+			case strings.HasPrefix(strings.ToLower(m[2]), "h"):
+				unit = time.Hour
+			}
+			return clampQuotaDelay(time.Duration(n) * unit)
+		}
+	}
+	if m := quotaResetEpochRe.FindStringSubmatch(text); m != nil {
+		epoch, err := strconv.ParseInt(m[1], 10, 64)
+		if err == nil {
+			if until := time.Until(time.Unix(epoch, 0)); until > 0 {
+				return clampQuotaDelay(until)
+			}
+		}
+	}
+	return quotaBlockerFallbackDelay
+}
+
+func clampQuotaDelay(d time.Duration) time.Duration {
+	if d <= 0 {
+		return quotaBlockerFallbackDelay
+	}
+	if d > quotaBlockerMaxParsedDelay {
+		return quotaBlockerMaxParsedDelay
+	}
+	return d
+}
+
+// blockerRetryJitter returns a small random smear (up to 10% of the delay,
+// capped at 30s) added to a quota reset so a fleet of deferred jobs does not
+// re-dispatch in the same instant the window opens.
+func blockerRetryJitter(delay time.Duration) time.Duration {
+	max := delay / 10
+	if max > 30*time.Second {
+		max = 30 * time.Second
+	}
+	if max <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int64N(int64(max)))
+}
+
+// deferOperationalBlocker re-queues a job that just terminally failed on a
+// classifiable operational blocker, preserving its resumable context. Called by
+// jobWorker.run strictly AFTER RunJob returned an error, i.e. off the hot path:
+// it reads the (already failed) job back, and only when every scope guard passes
+// does it write the blocker fields into the payload and flip failed→queued with
+// a blocker_deferred event. It returns (true, nil) exactly when the job was
+// deferred, so the caller skips the terminal failure comment/log; every other
+// outcome leaves the job exactly as the existing path put it.
+func (w jobWorker) deferOperationalBlocker(ctx context.Context, jobID string, cause error) (bool, error) {
+	classification, ok := classifyOperationalBlocker(cause, time.Now().UTC())
+	if !ok {
+		return false, nil
+	}
+	latest, err := w.Store.GetJob(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	// Only a run that Mailbox.fail closed as JobFailed is eligible; a blocked/
+	// cancelled/queued job belongs to other machinery (permission block, kill,
+	// pre-flight) that already owns its semantics.
+	if latest.State != string(workflow.JobFailed) {
+		return false, nil
+	}
+	payload, err := daemonJobPayload(latest)
+	if err != nil {
+		return false, nil
+	}
+	// A stored result means the agent answered: decision=failed is a PRODUCT
+	// failure and is never auto-retried. Delegation children keep the DAG's own
+	// retry/failure-policy path (#409 machinery), untouched by this slice.
+	if payload.Result != nil || strings.TrimSpace(payload.ParentJobID) != "" {
+		return false, nil
+	}
+	attempt := payload.BlockerAttempts + 1
+	if attempt > maxOperationalBlockerRetries {
+		_ = w.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID: jobID,
+			Kind:  blockerExhaustedEventKind,
+			Message: fmt.Sprintf("operational blocker %s recurred after %d auto-retries; job stays failed: %s",
+				classification.Class, maxOperationalBlockerRetries, classification.Detail),
+		})
+		return false, nil
+	}
+	retryAt := classification.RetryAt.Format(time.RFC3339Nano)
+	payload.BlockerClass = string(classification.Class)
+	payload.BlockerAttempts = attempt
+	payload.BlockerRetryAt = retryAt
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return false, err
+	}
+	// Payload first, transition second: a crash in between leaves the job
+	// terminally failed (today's behavior) with extra context in the payload —
+	// never a queued job missing its hold timestamp.
+	if err := w.Store.UpdateJobPayload(ctx, jobID, string(encoded)); err != nil {
+		return false, err
+	}
+	transitioned, err := w.Store.TransitionJobStateWithEvent(ctx, jobID, string(workflow.JobFailed), string(workflow.JobQueued), db.JobEvent{
+		JobID: jobID,
+		Kind:  blockerDeferredEventKind,
+		Message: fmt.Sprintf("%s: attempt %d/%d, retry at %s: %s",
+			classification.Class, attempt, maxOperationalBlockerRetries, retryAt, classification.Detail),
+	})
+	if err != nil {
+		return false, err
+	}
+	return transitioned, nil
+}
+
+// queuedJobBlockerHeld reports whether a queued job is still inside its
+// operational-blocker hold window (payload.blocker_retry_at in the future).
+// Jobs without the field — every job that never hit a classified blocker —
+// return false on the cheap empty-string check, and a malformed timestamp also
+// returns false so a bad write can strand nothing.
+func queuedJobBlockerHeld(job db.Job, now time.Time) bool {
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return false
+	}
+	raw := strings.TrimSpace(payload.BlockerRetryAt)
+	if raw == "" {
+		return false
+	}
+	retryAt, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return false
+	}
+	return now.Before(retryAt)
+}

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -249,6 +249,37 @@ func (w jobWorker) deferOperationalBlocker(ctx context.Context, jobID string, ca
 	return transitioned, nil
 }
 
+// restorePreIsolationPayloadForDeferredJob handles the pool-isolation ×
+// blocker-deferral interaction: an isolation-dispatched job (#394) that
+// DEFERRED on an operational blocker is queued again, but
+// allocatePoolIsolationWorktree rewrote its payload to point at the isolation
+// worktree the pool reap removes on completion. Restore the pre-isolation
+// payload while carrying the blocker fields over, so the held job re-evaluates
+// (and can be re-isolated) cleanly on re-dispatch. Best-effort and strictly
+// scoped: any job that is not queued with a live blocker hold is left untouched.
+func restorePreIsolationPayloadForDeferredJob(ctx context.Context, store *db.Store, jobID string, payloadBeforeIsolation string) {
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil || job.State != string(workflow.JobQueued) {
+		return
+	}
+	current, err := daemonJobPayload(job)
+	if err != nil || strings.TrimSpace(current.BlockerRetryAt) == "" {
+		return
+	}
+	var restored workflow.JobPayload
+	if err := json.Unmarshal([]byte(payloadBeforeIsolation), &restored); err != nil {
+		return
+	}
+	restored.BlockerClass = current.BlockerClass
+	restored.BlockerAttempts = current.BlockerAttempts
+	restored.BlockerRetryAt = current.BlockerRetryAt
+	encoded, err := json.Marshal(restored)
+	if err != nil {
+		return
+	}
+	_ = store.UpdateJobPayload(ctx, jobID, string(encoded))
+}
+
 // queuedJobBlockerHeld reports whether a queued job is still inside its
 // operational-blocker hold window (payload.blocker_retry_at in the future).
 // Jobs without the field — every job that never hit a classified blocker —

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -10,8 +10,11 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -30,9 +33,15 @@ import (
 //     policy belongs to the delegation DAG (finalizeTimedOutDelegationChild →
 //     advanceDelegations), which already owns retry semantics for children.
 //   - Only the two cleanest classes are matched (runtime_auth, runtime_quota),
-//     reusing the #552 classifyAuthQuota signatures plus the adapters' typed
+//     reusing the #552 classifyAuthQuota signatures (per line, with tightened
+//     HTTP-status arms — see classifyAuthQuotaStrict) plus the adapters' typed
 //     runtime.ErrClaudeAuthFailed sentinel, so detection stays grounded in
-//     strings the adapters actually emit.
+//     strings the adapters actually emit. String matching additionally requires
+//     the typed workflow.DeliveryError marker, so only errors from the delivery
+//     seam — never agent-authored contract/validation text — can classify.
+//   - A run whose delivery COMPLETED (persisted RawOutputs) is never deferred,
+//     and every deferred retry is at-least-once for side effects: Mailbox.Run
+//     prepends a reconciliation notice to a blocker-retried prompt.
 //   - Auto-retries are hard-bounded by maxOperationalBlockerRetries; when the
 //     budget is exhausted the job stays terminally failed exactly like today.
 //
@@ -80,6 +89,11 @@ const quotaBlockerFallbackDelay = 15 * time.Minute
 // in N hours" can never park a job for days.
 const quotaBlockerMaxParsedDelay = 24 * time.Hour
 
+// quotaBlockerMinParsedDelay floors a parsed reset delay so a sub-second
+// provider hint ("try again in 1.898s") plus jitter can never re-dispatch
+// inside a still-closed window and burn the retry budget in seconds.
+const quotaBlockerMinParsedDelay = 5 * time.Second
+
 // blockerClassification is the classifier verdict for one failed run.
 type blockerClassification struct {
 	Class   blockerClass
@@ -89,10 +103,20 @@ type blockerClassification struct {
 
 // classifyOperationalBlocker inspects a RunJob error and reports whether it is a
 // classifiable operational blocker. Detection composes with #552: the string
-// signatures are the SAME classifyAuthQuota matcher `job list` already uses to
-// label stuck jobs, plus the typed runtime.ErrClaudeAuthFailed sentinel the
+// signatures are the classifyAuthQuota matcher `job list` already uses to label
+// stuck jobs — applied per line and with tightened HTTP-status arms (see
+// classifyAuthQuotaStrict) because HERE a match triggers automatic re-runs, not
+// a cosmetic label — plus the typed runtime.ErrClaudeAuthFailed sentinel the
 // Claude adapter attaches to genuine credential rejections. Engine-routed
 // outcomes (awaiting-human, blocked) and cancellations are never classified.
+//
+// String matching only runs for an error that provably originated from the
+// DELIVERY seam (workflow.DeliveryError): a gitmoot_result contract/validation
+// failure — including the post-repair-loop parse error, whose text is
+// agent-authored and can mention "quota"/"rate limit" in a summary or a
+// delegation id — is a PRODUCT failure and must never be auto-retried (#532
+// design: "missing gitmoot_result contract output ... treat as
+// product/contract, not operational").
 func classifyOperationalBlocker(cause error, now time.Time) (blockerClassification, bool) {
 	if cause == nil {
 		return blockerClassification{}, false
@@ -106,9 +130,15 @@ func classifyOperationalBlocker(cause error, now time.Time) (blockerClassificati
 	text := cause.Error()
 	detail := firstLineTrimmed(text)
 	if errors.Is(cause, runtime.ErrClaudeAuthFailed) {
+		// Typed sentinel: attached by the Claude adapter to a classified genuine
+		// credential rejection, so it is trustworthy without the delivery gate.
 		return blockerClassification{Class: blockerClassRuntimeAuth, RetryAt: now.Add(authBlockerRetryDelay), Detail: detail}, true
 	}
-	switch classifyAuthQuota(text) {
+	var delivery workflow.DeliveryError
+	if !errors.As(cause, &delivery) {
+		return blockerClassification{}, false
+	}
+	switch classifyAuthQuotaStrict(text) {
 	case "throttled":
 		delay := parseQuotaResetDelay(text)
 		return blockerClassification{Class: blockerClassRuntimeQuota, RetryAt: now.Add(delay + blockerRetryJitter(delay)), Detail: detail}, true
@@ -118,31 +148,84 @@ func classifyOperationalBlocker(cause error, now time.Time) (blockerClassificati
 	return blockerClassification{}, false
 }
 
-// quotaResetInRe matches relative reset hints the runtimes actually emit, e.g.
-// codex's "Please try again in 32 seconds", generic "retry after 60 s(econds)",
-// and HTTP "Retry-After: 120" (bare integers are seconds).
-var quotaResetInRe = regexp.MustCompile(`(?i)(?:try again in|retry after|retry in|retry-after:?)\s*(\d+)\s*(seconds?|minutes?|hours?|s\b|m\b|h\b)?`)
+// code429Re / code401Re match an HTTP status code as a standalone token, so a
+// bare digit run embedded in a hex job id ("local-ask-18be4290fad9"), a PR
+// number ("#4291"), or a SHA never satisfies the status-code arm.
+var (
+	code429Re = regexp.MustCompile(`\b429\b`)
+	code401Re = regexp.MustCompile(`\b401\b`)
+)
+
+// classifyAuthQuotaStrict is the #552 classifyAuthQuota matcher with the extra
+// precision the BEHAVIORAL #532 call site needs. Adapter failures concatenate a
+// whole stderr dump plus commandError's trailing exec suffix ("...: exit status
+// N"), so a whole-text scan lets "status" from the exec suffix combine with an
+// unrelated "429" digit run on a DIFFERENT line into a false runtime_quota.
+// Here the matcher runs per line, requires the 401/429 token (word-boundary)
+// to be co-located with genuine HTTP context on the SAME line, and "HTTP
+// context" means http/status code/retry-after — NOT the bare "status" that
+// every "exit status N" exec error carries. The word signatures (usage/rate
+// limit, quota, authentication, unauthorized, auth+invalid) are unchanged from
+// #552. The first matching line wins.
+func classifyAuthQuotaStrict(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		l := strings.ToLower(strings.TrimSpace(line))
+		if l == "" {
+			continue
+		}
+		httpCtx := strings.Contains(l, "http") || strings.Contains(l, "status code") || strings.Contains(l, "retry-after")
+		switch {
+		case strings.Contains(l, "usage limit"), strings.Contains(l, "rate limit"),
+			strings.Contains(l, "quota"), strings.Contains(l, "limit resets"),
+			httpCtx && code429Re.MatchString(l):
+			return "throttled"
+		case strings.Contains(l, "authentication"), strings.Contains(l, "unauthorized"),
+			httpCtx && code401Re.MatchString(l),
+			authWordRe.MatchString(l) && strings.Contains(l, "invalid"):
+			return "auth failing"
+		}
+	}
+	return ""
+}
+
+// quotaResetInRe matches relative reset hints the providers actually emit, e.g.
+// codex's "Please try again in 32 seconds", OpenAI's decimal "try again in
+// 1.898s", abbreviated "retry in 5 min", and HTTP "Retry-After: 120" (bare
+// integers are seconds). Each unit alternation ends on \b so an unknown unit
+// WORD ("5 mint") never half-matches; the number/unit separator is [ \t]* (not
+// \s*) so the unit is only ever taken from the SAME line as the number.
+var quotaResetInRe = regexp.MustCompile(`(?i)(?:try again in|retry after|retry in|retry-after:?)\s*(\d+(?:\.\d+)?)[ \t]*(seconds?\b|secs?\b|s\b|minutes?\b|mins?\b|m\b|hours?\b|hrs?\b|h\b)?`)
 
 // quotaResetEpochRe matches the Claude CLI usage-limit shape
 // "Claude AI usage limit reached|<unix-epoch>".
 var quotaResetEpochRe = regexp.MustCompile(`\|(\d{10})\b`)
 
 // parseQuotaResetDelay extracts the provider-declared reset delay from a
-// rate-limit/quota error. Unparseable messages (e.g. codex's "try again at Jun
-// 14th") fall back to quotaBlockerFallbackDelay; parsed values are clamped to
-// (0, quotaBlockerMaxParsedDelay].
+// rate-limit/quota error. A bare number with no unit is seconds (the
+// Retry-After header shape) — but a number followed by an UNRECOGNIZED unit
+// word ("try again in 5 fortnights") is unparseable, because reading it as
+// seconds would re-dispatch inside a still-closed window and burn the retry
+// budget. Unparseable messages (e.g. codex's "try again at Jun 14th") fall
+// back to quotaBlockerFallbackDelay; parsed values are clamped to
+// [quotaBlockerMinParsedDelay, quotaBlockerMaxParsedDelay].
 func parseQuotaResetDelay(text string) time.Duration {
-	if m := quotaResetInRe.FindStringSubmatch(text); m != nil {
-		n, err := strconv.Atoi(m[1])
-		if err == nil && n > 0 {
-			unit := time.Second
-			switch {
-			case strings.HasPrefix(strings.ToLower(m[2]), "m"):
-				unit = time.Minute
-			case strings.HasPrefix(strings.ToLower(m[2]), "h"):
-				unit = time.Hour
+	if idx := quotaResetInRe.FindStringSubmatchIndex(text); idx != nil {
+		unit := ""
+		if idx[4] >= 0 {
+			unit = text[idx[4]:idx[5]]
+		}
+		if unit != "" || !startsWithLetter(text[idx[1]:]) {
+			n, err := strconv.ParseFloat(text[idx[2]:idx[3]], 64)
+			if err == nil && n > 0 {
+				scale := time.Second
+				switch {
+				case strings.HasPrefix(strings.ToLower(unit), "m"):
+					scale = time.Minute
+				case strings.HasPrefix(strings.ToLower(unit), "h"):
+					scale = time.Hour
+				}
+				return clampQuotaDelay(time.Duration(n * float64(scale)))
 			}
-			return clampQuotaDelay(time.Duration(n) * unit)
 		}
 	}
 	if m := quotaResetEpochRe.FindStringSubmatch(text); m != nil {
@@ -156,9 +239,29 @@ func parseQuotaResetDelay(text string) time.Duration {
 	return quotaBlockerFallbackDelay
 }
 
+// startsWithLetter reports whether rest — the text immediately after a matched
+// bare number — begins (after spaces/tabs) with a letter, i.e. the number
+// carried a unit word quotaResetInRe does not recognize, so the bare-integer-
+// seconds default would mis-schedule the retry and the caller must treat the
+// message as unparseable.
+func startsWithLetter(rest string) bool {
+	rest = strings.TrimLeft(rest, " \t")
+	if rest == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(rest)
+	return unicode.IsLetter(r)
+}
+
 func clampQuotaDelay(d time.Duration) time.Duration {
 	if d <= 0 {
 		return quotaBlockerFallbackDelay
+	}
+	// Floor, not fallback: a genuinely short provider reset ("try again in
+	// 1.898s") is honored, but never so tight that clock skew/jitter re-dispatches
+	// inside a still-closed window.
+	if d < quotaBlockerMinParsedDelay {
+		return quotaBlockerMinParsedDelay
 	}
 	if d > quotaBlockerMaxParsedDelay {
 		return quotaBlockerMaxParsedDelay
@@ -188,6 +291,16 @@ func blockerRetryJitter(delay time.Duration) time.Duration {
 // a blocker_deferred event. It returns (true, nil) exactly when the job was
 // deferred, so the caller skips the terminal failure comment/log; every other
 // outcome leaves the job exactly as the existing path put it.
+//
+// SIDE-EFFECT SEMANTICS: the auto-retry is AT-LEAST-ONCE. A run whose FIRST
+// delivery completed (persisted RawOutputs) is never deferred — completed
+// delivery proves side-effectful execution, so the repair-loop failure of an
+// already-executed job keeps today's terminal path. A blocker that hits
+// MID-first-turn can still have executed partial work (pushed a branch, opened
+// a PR) before the provider cut it off; that retry cannot be made exactly-once
+// from here, so Mailbox.Run prepends a reconciliation notice to every
+// blocker-retried prompt (payload.BlockerAttempts > 0) telling the agent to
+// verify and reuse prior artifacts instead of duplicating them.
 func (w jobWorker) deferOperationalBlocker(ctx context.Context, jobID string, cause error) (bool, error) {
 	classification, ok := classifyOperationalBlocker(cause, time.Now().UTC())
 	if !ok {
@@ -211,6 +324,13 @@ func (w jobWorker) deferOperationalBlocker(ctx context.Context, jobID string, ca
 	// failure and is never auto-retried. Delegation children keep the DAG's own
 	// retry/failure-policy path (#409 machinery), untouched by this slice.
 	if payload.Result != nil || strings.TrimSpace(payload.ParentJobID) != "" {
+		return false, nil
+	}
+	// Duplicate-side-effect gate: persisted raw outputs prove a delivery COMPLETED
+	// a full agent turn (the #495 repair loop persists them before re-asking), so
+	// this failure came after side-effectful execution — re-running the full
+	// prompt could push duplicate branches / open duplicate PRs. Keep it terminal.
+	if len(payload.RawOutputs) > 0 {
 		return false, nil
 	}
 	attempt := payload.BlockerAttempts + 1
@@ -245,6 +365,17 @@ func (w jobWorker) deferOperationalBlocker(ctx context.Context, jobID string, ca
 	})
 	if err != nil {
 		return false, err
+	}
+	if transitioned {
+		// The engine already emitted a terminal job.failed for this run
+		// (Mailbox.fail), so [events] consumers acting on job.failed would race the
+		// hidden retry. Emit an additive job.deferred so stream consumers can
+		// suppress terminal handling: job.failed followed by job.deferred is NOT
+		// terminal (see events.EventJobDeferred). Best-effort and nil-safe when
+		// [events] is OFF, mirroring the daemon's other emits.
+		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, events.EventJobDeferred, string(workflow.JobQueued),
+			fmt.Sprintf("%s: attempt %d/%d, retry at %s: %s",
+				classification.Class, attempt, maxOperationalBlockerRetries, retryAt, classification.Detail))
 	}
 	return transitioned, nil
 }

--- a/internal/cli/job_blocker_test.go
+++ b/internal/cli/job_blocker_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -181,4 +182,103 @@ func TestQueuedJobBlockerHeld(t *testing.T) {
 	if queuedJobBlockerHeld(db.Job{ID: "job-1", State: string(workflow.JobQueued), Payload: "{"}, now) {
 		t.Fatal("malformed payload must never strand a job")
 	}
+}
+
+func TestRestorePreIsolationPayloadForDeferredJob(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "iso", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+
+	seed := func(t *testing.T, id string, mutate func(*workflow.JobPayload)) (string, workflow.JobPayload) {
+		t.Helper()
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: id, Agent: "iso", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+		})
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob: %v", err)
+		}
+		before := job.Payload
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("parse payload: %v", err)
+		}
+		mutate(&payload)
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := store.UpdateJobPayload(ctx, id, string(encoded)); err != nil {
+			t.Fatalf("UpdateJobPayload: %v", err)
+		}
+		return before, payload
+	}
+
+	t.Run("deferred isolation job restores worktree and keeps hold", func(t *testing.T) {
+		hold := time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano)
+		before, _ := seed(t, "job-iso-deferred", func(p *workflow.JobPayload) {
+			p.WorktreePath = "/reaped/isolation/path"
+			p.BlockerClass = string(blockerClassRuntimeQuota)
+			p.BlockerAttempts = 1
+			p.BlockerRetryAt = hold
+		})
+		restorePreIsolationPayloadForDeferredJob(ctx, store, "job-iso-deferred", before)
+		_, got := func() (db.Job, workflow.JobPayload) {
+			job, err := store.GetJob(ctx, "job-iso-deferred")
+			if err != nil {
+				t.Fatalf("GetJob: %v", err)
+			}
+			payload, err := daemonJobPayload(job)
+			if err != nil {
+				t.Fatalf("parse payload: %v", err)
+			}
+			return job, payload
+		}()
+		if got.WorktreePath != "" {
+			t.Fatalf("worktree path = %q, want restored empty pre-isolation value", got.WorktreePath)
+		}
+		if got.BlockerClass != string(blockerClassRuntimeQuota) || got.BlockerAttempts != 1 || got.BlockerRetryAt != hold {
+			t.Fatalf("blocker hold fields were not carried over: %+v", got)
+		}
+	})
+
+	t.Run("terminal job is untouched", func(t *testing.T) {
+		before, mutated := seed(t, "job-iso-failed", func(p *workflow.JobPayload) {
+			p.WorktreePath = "/reaped/isolation/path"
+			p.BlockerRetryAt = time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano)
+		})
+		if _, err := store.TransitionJobStateWithEvent(ctx, "job-iso-failed", string(workflow.JobQueued), string(workflow.JobFailed), db.JobEvent{JobID: "job-iso-failed", Kind: "failed", Message: "boom"}); err != nil {
+			t.Fatalf("transition: %v", err)
+		}
+		restorePreIsolationPayloadForDeferredJob(ctx, store, "job-iso-failed", before)
+		job, err := store.GetJob(ctx, "job-iso-failed")
+		if err != nil {
+			t.Fatalf("GetJob: %v", err)
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("parse payload: %v", err)
+		}
+		if payload.WorktreePath != mutated.WorktreePath {
+			t.Fatalf("terminal job payload was rewritten: %+v", payload)
+		}
+	})
+
+	t.Run("queued job without hold is untouched", func(t *testing.T) {
+		before, mutated := seed(t, "job-iso-nohold", func(p *workflow.JobPayload) {
+			p.WorktreePath = "/reaped/isolation/path"
+		})
+		restorePreIsolationPayloadForDeferredJob(ctx, store, "job-iso-nohold", before)
+		job, err := store.GetJob(ctx, "job-iso-nohold")
+		if err != nil {
+			t.Fatalf("GetJob: %v", err)
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("parse payload: %v", err)
+		}
+		if payload.WorktreePath != mutated.WorktreePath {
+			t.Fatalf("hold-less queued job payload was rewritten: %+v", payload)
+		}
+	})
 }

--- a/internal/cli/job_blocker_test.go
+++ b/internal/cli/job_blocker_test.go
@@ -23,17 +23,18 @@ func TestClassifyOperationalBlocker(t *testing.T) {
 	}{
 		{
 			name:      "codex usage limit without parseable reset",
-			err:       errors.New("delivery failed: You've hit your usage limit. try again at Jun 14th: exit status 1"),
+			err:       workflow.DeliveryError{Err: errors.New("You've hit your usage limit. try again at Jun 14th: exit status 1")},
 			wantOK:    true,
 			wantClass: blockerClassRuntimeQuota,
 		},
 		{
 			name:      "http 429 with relative reset",
-			err:       errors.New("delivery failed: HTTP 429 Too Many Requests: rate limit reached; try again in 30 seconds: exit status 1"),
+			err:       workflow.DeliveryError{Err: errors.New("HTTP 429 Too Many Requests: rate limit reached; try again in 30 seconds: exit status 1")},
 			wantOK:    true,
 			wantClass: blockerClassRuntimeQuota,
 		},
 		{
+			// The typed sentinel is trustworthy without the DeliveryError marker.
 			name:      "typed claude auth sentinel",
 			err:       fmt.Errorf("delivery failed: %w", runtime.ErrClaudeAuthFailed),
 			wantOK:    true,
@@ -41,13 +42,13 @@ func TestClassifyOperationalBlocker(t *testing.T) {
 		},
 		{
 			name:      "textual 401 authentication_error",
-			err:       errors.New("delivery failed: Failed to authenticate. API Error: 401 authentication_error: invalid x-api-key: exit status 1"),
+			err:       workflow.DeliveryError{Err: errors.New("Failed to authenticate. API Error: 401 authentication_error: invalid x-api-key: exit status 1")},
 			wantOK:    true,
 			wantClass: blockerClassRuntimeAuth,
 		},
 		{
 			name:   "unclassified runtime error stays terminal",
-			err:    errors.New("delivery failed: boom: exit status 2"),
+			err:    workflow.DeliveryError{Err: errors.New("boom: exit status 2")},
 			wantOK: false,
 		},
 		{
@@ -57,12 +58,40 @@ func TestClassifyOperationalBlocker(t *testing.T) {
 		},
 		{
 			name:   "context cancellation is never a blocker",
-			err:    fmt.Errorf("delivery failed: %w", context.Canceled),
+			err:    workflow.DeliveryError{Err: fmt.Errorf("delivery failed: %w", context.Canceled)},
 			wantOK: false,
 		},
 		{
 			name:   "run deadline is never a blocker",
-			err:    fmt.Errorf("delivery failed: %w", context.DeadlineExceeded),
+			err:    workflow.DeliveryError{Err: fmt.Errorf("delivery failed: %w", context.DeadlineExceeded)},
+			wantOK: false,
+		},
+		{
+			// A repair-exhausted gitmoot_result VALIDATION error is agent-authored
+			// text (no DeliveryError marker): a delegation id mentioning "quota" must
+			// never classify as an operational blocker (product/contract failure).
+			name:   "contract validation error mentioning quota is never a blocker",
+			err:    errors.New(`delegation "audit-quota-enforcement" references unknown dep "quota-schema"`),
+			wantOK: false,
+		},
+		{
+			// Same for a malformed decision whose text contains rate-limit words.
+			name:   "contract decision error mentioning rate limit is never a blocker",
+			err:    errors.New(`unsupported gitmoot_result decision "blocked: rate limit"`),
+			wantOK: false,
+		},
+		{
+			// The "exit status N" exec suffix must not provide HTTP context for a
+			// bare digit run on ANOTHER line (hex job ids are full of 429s).
+			name:   "exec exit-status plus hex job id never classifies",
+			err:    workflow.DeliveryError{Err: errors.New("adapter exited with status 1\njob local-ask-18be4290fad9 failed\nexit status 1")},
+			wantOK: false,
+		},
+		{
+			// A URL plus an unrelated PR number carrying a 429 digit run must not
+			// combine across lines into a throttle classification.
+			name:   "url and PR number digits never classify",
+			err:    workflow.DeliveryError{Err: errors.New("failed to open pull request: see https://github.com/o/r\nhint: PR #4291 already exists")},
 			wantOK: false,
 		},
 		{
@@ -102,7 +131,7 @@ func TestClassifyOperationalBlocker(t *testing.T) {
 
 func TestClassifyOperationalBlockerQuotaUsesParsedReset(t *testing.T) {
 	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
-	got, ok := classifyOperationalBlocker(errors.New("delivery failed: rate limit reached; try again in 30 seconds"), now)
+	got, ok := classifyOperationalBlocker(workflow.DeliveryError{Err: errors.New("rate limit reached; try again in 30 seconds")}, now)
 	if !ok {
 		t.Fatal("expected quota classification")
 	}
@@ -132,7 +161,13 @@ func TestParseQuotaResetDelay(t *testing.T) {
 	}{
 		{"codex relative seconds", "Rate limit reached. Please try again in 32 seconds.", 32 * time.Second},
 		{"relative minutes", "usage limit; retry in 5 minutes", 5 * time.Minute},
+		{"abbreviated min", "Rate limit reached. Please try again in 5 min", 5 * time.Minute},
+		{"abbreviated hrs", "usage limit; retry in 2 hrs", 2 * time.Hour},
+		{"openai decimal seconds floored", "Rate limit reached. Please try again in 1.898s.", quotaBlockerMinParsedDelay},
+		{"decimal minutes", "rate limit; try again in 1.5 minutes", 90 * time.Second},
+		{"short reset floored", "rate limit reached; try again in 3 seconds", quotaBlockerMinParsedDelay},
 		{"retry-after header style", "429 Too Many Requests. Retry-After: 120", 120 * time.Second},
+		{"unknown unit word falls back", "rate limit; try again in 5 fortnights", quotaBlockerFallbackDelay},
 		{"unparseable absolute date falls back", "You've hit your usage limit. try again at Jun 14th", quotaBlockerFallbackDelay},
 		{"no hint falls back", "quota exceeded", quotaBlockerFallbackDelay},
 	}

--- a/internal/cli/job_blocker_test.go
+++ b/internal/cli/job_blocker_test.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestClassifyOperationalBlocker(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		err       error
+		wantOK    bool
+		wantClass blockerClass
+	}{
+		{
+			name:      "codex usage limit without parseable reset",
+			err:       errors.New("delivery failed: You've hit your usage limit. try again at Jun 14th: exit status 1"),
+			wantOK:    true,
+			wantClass: blockerClassRuntimeQuota,
+		},
+		{
+			name:      "http 429 with relative reset",
+			err:       errors.New("delivery failed: HTTP 429 Too Many Requests: rate limit reached; try again in 30 seconds: exit status 1"),
+			wantOK:    true,
+			wantClass: blockerClassRuntimeQuota,
+		},
+		{
+			name:      "typed claude auth sentinel",
+			err:       fmt.Errorf("delivery failed: %w", runtime.ErrClaudeAuthFailed),
+			wantOK:    true,
+			wantClass: blockerClassRuntimeAuth,
+		},
+		{
+			name:      "textual 401 authentication_error",
+			err:       errors.New("delivery failed: Failed to authenticate. API Error: 401 authentication_error: invalid x-api-key: exit status 1"),
+			wantOK:    true,
+			wantClass: blockerClassRuntimeAuth,
+		},
+		{
+			name:   "unclassified runtime error stays terminal",
+			err:    errors.New("delivery failed: boom: exit status 2"),
+			wantOK: false,
+		},
+		{
+			name:   "nil error",
+			err:    nil,
+			wantOK: false,
+		},
+		{
+			name:   "context cancellation is never a blocker",
+			err:    fmt.Errorf("delivery failed: %w", context.Canceled),
+			wantOK: false,
+		},
+		{
+			name:   "run deadline is never a blocker",
+			err:    fmt.Errorf("delivery failed: %w", context.DeadlineExceeded),
+			wantOK: false,
+		},
+		{
+			// A BlockedError whose reason mentions quota is still an engine-routed
+			// outcome, not an operational blocker.
+			name:   "engine BlockedError is never a blocker",
+			err:    workflow.BlockedError{Reason: "task blocked: quota policy"},
+			wantOK: false,
+		},
+		{
+			name:   "escalate-human pause is never a blocker",
+			err:    workflow.AwaitingHumanError{Reason: "rate limit decision needs a human"},
+			wantOK: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := classifyOperationalBlocker(tc.err, now)
+			if ok != tc.wantOK {
+				t.Fatalf("classifyOperationalBlocker ok = %v, want %v (got %+v)", ok, tc.wantOK, got)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got.Class != tc.wantClass {
+				t.Fatalf("class = %q, want %q", got.Class, tc.wantClass)
+			}
+			if !got.RetryAt.After(now) {
+				t.Fatalf("RetryAt %s is not after now %s", got.RetryAt, now)
+			}
+			if got.Detail == "" {
+				t.Fatal("Detail is empty")
+			}
+		})
+	}
+}
+
+func TestClassifyOperationalBlockerQuotaUsesParsedReset(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	got, ok := classifyOperationalBlocker(errors.New("delivery failed: rate limit reached; try again in 30 seconds"), now)
+	if !ok {
+		t.Fatal("expected quota classification")
+	}
+	min := now.Add(30 * time.Second)
+	max := min.Add(30 * time.Second) // parsed delay + max jitter headroom
+	if got.RetryAt.Before(min) || got.RetryAt.After(max) {
+		t.Fatalf("RetryAt %s outside [%s, %s]", got.RetryAt, min, max)
+	}
+}
+
+func TestClassifyOperationalBlockerAuthUsesFixedDelay(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	got, ok := classifyOperationalBlocker(fmt.Errorf("delivery failed: %w", runtime.ErrClaudeAuthFailed), now)
+	if !ok {
+		t.Fatal("expected auth classification")
+	}
+	if want := now.Add(authBlockerRetryDelay); !got.RetryAt.Equal(want) {
+		t.Fatalf("RetryAt = %s, want %s", got.RetryAt, want)
+	}
+}
+
+func TestParseQuotaResetDelay(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want time.Duration
+	}{
+		{"codex relative seconds", "Rate limit reached. Please try again in 32 seconds.", 32 * time.Second},
+		{"relative minutes", "usage limit; retry in 5 minutes", 5 * time.Minute},
+		{"retry-after header style", "429 Too Many Requests. Retry-After: 120", 120 * time.Second},
+		{"unparseable absolute date falls back", "You've hit your usage limit. try again at Jun 14th", quotaBlockerFallbackDelay},
+		{"no hint falls back", "quota exceeded", quotaBlockerFallbackDelay},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseQuotaResetDelay(tc.text); got != tc.want {
+				t.Fatalf("parseQuotaResetDelay(%q) = %s, want %s", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseQuotaResetDelayClaudeEpoch(t *testing.T) {
+	// The Claude CLI usage-limit shape carries a unix epoch after a pipe:
+	// "Claude AI usage limit reached|<epoch>". Use a future epoch and accept the
+	// small elapsed-time skew of time.Until.
+	epoch := time.Now().Add(90 * time.Second).Unix()
+	got := parseQuotaResetDelay(fmt.Sprintf("Claude AI usage limit reached|%d", epoch))
+	if got < 80*time.Second || got > 90*time.Second {
+		t.Fatalf("parseQuotaResetDelay epoch = %s, want ~90s", got)
+	}
+	// A past epoch must never yield a non-positive hold.
+	if got := parseQuotaResetDelay("Claude AI usage limit reached|1000000000"); got != quotaBlockerFallbackDelay {
+		t.Fatalf("past epoch = %s, want fallback %s", got, quotaBlockerFallbackDelay)
+	}
+}
+
+func TestQueuedJobBlockerHeld(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	job := func(payload string) db.Job {
+		return db.Job{ID: "job-1", State: string(workflow.JobQueued), Payload: payload}
+	}
+	if queuedJobBlockerHeld(job(`{"repo":"o/r","task_id":"","task_title":"","sender":"","instructions":"","constraints":null,"branch":"main","pull_request":1}`), now) {
+		t.Fatal("job without blocker fields must never be held")
+	}
+	future := now.Add(time.Minute).Format(time.RFC3339Nano)
+	if !queuedJobBlockerHeld(job(fmt.Sprintf(`{"repo":"o/r","task_id":"","task_title":"","sender":"","instructions":"","constraints":null,"branch":"main","pull_request":1,"blocker_retry_at":%q}`, future)), now) {
+		t.Fatal("job inside its hold window must be held")
+	}
+	past := now.Add(-time.Minute).Format(time.RFC3339Nano)
+	if queuedJobBlockerHeld(job(fmt.Sprintf(`{"repo":"o/r","task_id":"","task_title":"","sender":"","instructions":"","constraints":null,"branch":"main","pull_request":1,"blocker_retry_at":%q}`, past)), now) {
+		t.Fatal("job past its hold window must be released")
+	}
+	if queuedJobBlockerHeld(job(fmt.Sprintf(`{"repo":"o/r","task_id":"","task_title":"","sender":"","instructions":"","constraints":null,"branch":"main","pull_request":1,"blocker_retry_at":%q}`, "not-a-time")), now) {
+		t.Fatal("malformed retry-at must never strand a job")
+	}
+	if queuedJobBlockerHeld(db.Job{ID: "job-1", State: string(workflow.JobQueued), Payload: "{"}, now) {
+		t.Fatal("malformed payload must never strand a job")
+	}
+}

--- a/internal/cli/job_stuck.go
+++ b/internal/cli/job_stuck.go
@@ -21,6 +21,7 @@ var authWordRe = regexp.MustCompile(`\bauth\b`)
 // deliberately excluded so a healthy queued job stays silent and its `job list`
 // row keeps its existing shape.
 var stuckReasonEventKinds = []string{
+	blockerDeferredEventKind,
 	"runtime_lock_wait",
 	"advance_blocked",
 	"advance_awaiting_human",
@@ -75,6 +76,16 @@ func deriveStuckReason(job db.Job, reasonEvent db.JobEvent, hasReasonEvent bool,
 	}
 	msg := firstLineTrimmed(reasonEvent.Message)
 	switch reasonEvent.Kind {
+	case blockerDeferredEventKind:
+		// Operational-blocker deferral (#532): the job is held awaiting an
+		// external condition (auth fixed, quota reset), then auto re-dispatched.
+		// The event message already names the class + attempt budget; the payload
+		// carries the authoritative earliest-retry-at the queue gate honors.
+		next := ""
+		if payload, err := daemonJobPayload(job); err == nil {
+			next = strings.TrimSpace(payload.BlockerRetryAt)
+		}
+		return stuckReason{Reason: withDetail("blocked-operational", msg), NextRetryAt: next}
 	case "runtime_lock_wait":
 		reason := "waiting on runtime session lock"
 		next := ""

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -46,6 +46,16 @@ const (
 	// human (the escalate_human pause today; the #445 ask-gate next). detail
 	// carries the redacted question.
 	EventJobNeedsAttention EventType = "job.needs_attention"
+	// EventJobDeferred is emitted when the daemon re-queues a job that just
+	// emitted job.failed because the failure classified as a retryable
+	// OPERATIONAL blocker (#532: runtime auth rejected, provider rate
+	// limit/quota) — the daemon will automatically re-dispatch it after the
+	// hold. Detail carries the blocker class, the attempt budget, and the
+	// earliest retry-at. CONSUMER CONTRACT: a job.failed immediately followed by
+	// a job.deferred for the same job id is NOT terminal — suppress terminal
+	// handling (recovery, alerting, cleanup) for that job until a later
+	// job.failed arrives WITHOUT a following job.deferred.
+	EventJobDeferred EventType = "job.deferred"
 
 	// EventCandidateAwaitingPromotion is emitted once when a SkillOpt template
 	// candidate becomes PENDING (the post-import notify, #471): a new pending

--- a/internal/events/sink_test.go
+++ b/internal/events/sink_test.go
@@ -56,6 +56,7 @@ func TestEventTypeEnumValues(t *testing.T) {
 		EventJobFailed:                  "job.failed",
 		EventJobBlocked:                 "job.blocked",
 		EventJobNeedsAttention:          "job.needs_attention",
+		EventJobDeferred:                "job.deferred",
 		EventCandidateAwaitingPromotion: "candidate.awaiting_promotion",
 		EventCandidateAutoPromoted:      "candidate.auto_promoted",
 		EventJobStarted:                 "job.started",

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -37,6 +37,14 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 		return db.Job{}, err
 	}
 	payload.Result = nil
+	// A human-requested retry is a fresh lifecycle for the operational-blocker
+	// machinery (#532): drop any deferral hold so the retried job dispatches now
+	// (a stale blocker_retry_at would silently park a cancel→retried job behind
+	// the old hold with a contradictory stuck reason), and reset the attempt
+	// budget so a post-exhaustion manual retry regains full deferral tolerance.
+	payload.BlockerClass = ""
+	payload.BlockerAttempts = 0
+	payload.BlockerRetryAt = ""
 	if manualRetryShouldClearReadOnlyWorktree(job, payload) {
 		payload.WorktreePath = ""
 		payload.HeadSHA = ""

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -47,6 +47,40 @@ func TestRetryJobRequeuesTerminalJobAndPreservesPayload(t *testing.T) {
 	}
 }
 
+// TestRetryJobClearsOperationalBlockerContext proves a human-requested retry is
+// a fresh lifecycle for the #532 machinery: (a) a cancel→retry of a held job
+// must not silently re-enter the old hold (a stale blocker_retry_at hours out
+// would park the retried job with a contradictory #552 stuck reason), and (b) a
+// post-exhaustion retry must regain the full deferral budget instead of
+// terminally failing on its first ordinary transient 429.
+func TestRetryJobClearsOperationalBlockerContext(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	hold := time.Now().UTC().Add(6 * time.Hour).Format(time.RFC3339Nano)
+	payload := `{"repo":"owner/repo","branch":"main","blocker_class":"runtime_quota","blocker_attempts":3,"blocker_retry_at":"` + hold + `"}`
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-held", Agent: "audit", Type: "ask", State: string(JobFailed), Payload: payload}, db.JobEvent{
+		Kind:    string(JobFailed),
+		Message: "operational blocker exhausted",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	job, err := RetryJob(ctx, store, "job-held")
+	if err != nil {
+		t.Fatalf("RetryJob returned error: %v", err)
+	}
+	if job.State != string(JobQueued) {
+		t.Fatalf("job after retry = %+v", job)
+	}
+	stored, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if stored.BlockerClass != "" || stored.BlockerAttempts != 0 || stored.BlockerRetryAt != "" {
+		t.Fatalf("payload after manual retry still carries blocker context: %+v", stored)
+	}
+}
+
 func TestRetryJobClearsReadOnlyNoTaskWorktreePath(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -168,6 +168,15 @@ type JobPayload struct {
 	HumanAnswer            string         `json:"human_answer,omitempty"`
 	RawOutputs             []string       `json:"raw_outputs,omitempty"`
 	Result                 *AgentResult   `json:"result,omitempty"`
+	// Operational-blocker deferral context (#532, additive — all omitempty, so a
+	// job that never hit a classified blocker serializes byte-identically).
+	// BlockerClass is the last classified blocker (e.g. "runtime_auth",
+	// "runtime_quota"); BlockerAttempts counts classified deferrals over the
+	// job's lifetime (hard-bounded by the daemon); BlockerRetryAt is the
+	// RFC3339Nano earliest automatic re-dispatch time the queue gate honors.
+	BlockerClass    string `json:"blocker_class,omitempty"`
+	BlockerAttempts int    `json:"blocker_attempts,omitempty"`
+	BlockerRetryAt  string `json:"blocker_retry_at,omitempty"`
 }
 
 type DeliveryAdapter interface {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -356,6 +356,33 @@ func (m Mailbox) canaryDraw() float64 {
 	return rand.Float64()
 }
 
+// DeliveryError marks an error that provably originated from the runtime
+// DELIVERY seam — adapter.Deliver itself failed (runtime CLI exited nonzero,
+// provider rejected the request) — as opposed to an error ABOUT the agent's
+// delivered output (gitmoot_result contract/validation failures, which are
+// product failures the agent authored). The daemon's operational-blocker
+// classifier (#532) requires this marker before doing ANY string matching, so
+// agent-authored text that merely mentions "quota"/"rate limit" (a summary, a
+// delegation id such as "audit-quota-enforcement") can never be misclassified
+// as a retryable operational blocker. Error() is transparent so every existing
+// string-based consumer of a delivery failure stays byte-identical.
+type DeliveryError struct{ Err error }
+
+func (e DeliveryError) Error() string { return e.Err.Error() }
+func (e DeliveryError) Unwrap() error { return e.Err }
+
+// blockerRetryReconciliationNotice is prepended to the prompt of a job the
+// daemon re-dispatches after an operational-blocker deferral (#532). The
+// auto-retry is AT-LEAST-ONCE for side effects: a blocker that hit mid-turn may
+// have interrupted an attempt that already pushed branches, opened PRs, or
+// posted comments, and (for ephemeral/fresh-session workers) the retried run
+// has no memory of it — so tell the agent to reconcile instead of duplicating.
+func blockerRetryReconciliationNotice(class string) string {
+	return fmt.Sprintf("IMPORTANT: a previous attempt of this exact job was interrupted by an operational blocker (%s) "+
+		"and may have already performed side effects — pushed branches, opened pull requests, posted comments, or made commits. "+
+		"Before doing any work, check for artifacts from that interrupted attempt and reuse/reconcile them instead of redoing or duplicating the work.", class)
+}
+
 func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, adapter DeliveryAdapter) (AgentResult, error) {
 	if m.Store == nil {
 		return AgentResult{}, errors.New("mailbox store is required")
@@ -384,10 +411,18 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	}
 
 	prompt := prompts.RenderJob(payload.prompt(job.Type))
+	if payload.BlockerAttempts > 0 && strings.TrimSpace(payload.BlockerClass) != "" {
+		// This run is an automatic operational-blocker retry (#532): the previous
+		// attempt may have executed side effects before the blocker hit, so ask the
+		// agent to reconcile prior artifacts rather than duplicate them.
+		prompt = blockerRetryReconciliationNotice(payload.BlockerClass) + "\n\n" + prompt
+	}
 	firstRaw, firstRefreshedRef, firstErr := m.deliver(ctx, adapter, agent, job, payload, prompt)
 	if firstErr != nil {
 		_ = m.fail(ctx, job.ID, fmt.Sprintf("delivery failed: %v", firstErr))
-		return AgentResult{}, firstErr
+		// Typed DeliveryError: this error is FROM the delivery seam (not about the
+		// agent's output), the precondition for #532 operational classification.
+		return AgentResult{}, DeliveryError{Err: firstErr}
 	}
 	m.persistRefreshedRuntimeRef(ctx, job.ID, agent, firstRefreshedRef)
 	// If the first delivery self-healed a dead session (#443), adopt the freshly
@@ -430,7 +465,10 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			repairRaw, repairRefreshedRef, repairErr := m.deliver(ctx, adapter, agent, job, payload, repairPrompt)
 			if repairErr != nil {
 				_ = m.fail(ctx, job.ID, fmt.Sprintf("repair delivery failed: %v", repairErr))
-				return AgentResult{}, repairErr
+				// Typed like the first-delivery failure. Note the #532 deferral still
+				// refuses this job: the persisted RawOutputs from the completed first
+				// delivery prove side-effectful execution (see deferOperationalBlocker).
+				return AgentResult{}, DeliveryError{Err: repairErr}
 			}
 			m.persistRefreshedRuntimeRef(ctx, job.ID, agent, repairRefreshedRef)
 			// Adopt a freshly minted session ref so the next repair re-ask resumes the

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -20,6 +20,7 @@ The pilot emits a tight allowlist of event types over the webhook transport:
 | `job.failed`                    | a job reaches the `failed` terminal state                                          |
 | `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
 | `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
+| `job.deferred`                  | the daemon re-queued a job that just emitted `job.failed` because the failure classified as a retryable operational blocker (runtime auth, rate limit/quota) — it will be re-dispatched automatically |
 | `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
 | `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current` (also the canary GRADUATE event) |
 | `candidate.canary_started`      | the off-by-default `[skillopt].auto_promote_canary` policy promoted a candidate to the `canary` state behind the live champion |
@@ -30,6 +31,17 @@ succeeded/failed/blocked emit on its `Mailbox` terminal path; the daemon owns th
 pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
 pass through that path. `job.needs_attention` is emitted once per fresh
 escalation round (a re-advance does not re-emit).
+
+**`job.failed` followed by `job.deferred` is NOT terminal.** When a run fails on
+a classified operational blocker (runtime auth rejected, provider rate
+limit/quota), the engine has already emitted `job.failed` for that run before the
+daemon decides to defer; the daemon then emits `job.deferred` for the same
+`job_id` (detail carries the blocker class, the `attempt N/M` retry budget, and
+the earliest `retry at` timestamp) and silently re-dispatches the job after the
+hold. Consumers acting on `job.failed` (recovery, alerting, cleanup) should
+suppress terminal handling for a job whose `job.failed` is followed by a
+`job.deferred`, and treat only a `job.failed` with no subsequent `job.deferred`
+as final.
 
 The two `candidate.*` events come from the `skillopt import` / `train continue`
 CLI path, NOT the daemon. When a candidate becomes `pending`,


### PR DESCRIPTION
## Summary

First slice of the **#532 spike** (operational-blocker classification + resumable job context). **Design taxonomy: https://github.com/jerryfane/gitmoot/issues/532#issuecomment-4862249006** — it grounds every class in the error signals that exist in the tree today, maps what #552/#570/lease-recovery already own, and lists the remaining slices.

When a job fails on a classifiable **operational** blocker, the daemon now re-queues it with structured classification + an earliest-retry-at hold, instead of terminally failing it indistinguishably from a product failure:

- **Classes in this slice** (the two cleanest): `runtime_auth` (401/revoked — the typed `runtime.ErrClaudeAuthFailed` sentinel + the #552 `classifyAuthQuota` auth signatures) and `runtime_quota` (429/usage-limit, with the provider-declared reset parsed when present: `try again in N <unit>`, `Retry-After: N`, the Claude `|<epoch>` shape; 15m fallback otherwise; clamp 24h; + jitter).
- **Persistence** (least invasive, additive): three `omitempty` payload fields — `blocker_class`, `blocker_attempts`, `blocker_retry_at` — plus a `blocker_deferred` job_event. No schema migration; a job that never hits a blocker serializes byte-identically.
- **Surfacing** composes with #552 (no new rendering): `blocker_deferred` is a stuck-reason event kind, so `job list`/`job show` render `blocked-operational: <class>: attempt n/N ...` with `next_retry_at` = the hold expiry.
- **Auto re-dispatch**: both schedulers funnel through `listPendingQueuedJobs`, which holds a deferred job until `blocker_retry_at`; the next tick after re-dispatches it. A pool-isolation-dispatched job that defers gets its pre-isolation payload restored (hold fields carried) so it re-evaluates cleanly.
- **Hard bounds**: max **3** auto-retries per job (`maxOperationalBlockerRetries`); on recurrence past the budget the job stays terminally failed with a `blocker_retries_exhausted` event.
- **Never diverted (byte-identical)**: product failures (stored `gitmoot_result`, incl. `decision=failed`), delegation children (the DAG retry/failure-policy path, #305/#409, owns those), permission blocks, awaiting-human/blocked outcomes, cancellations/timeouts, and any unclassified error.

## E2E (deterministic, no LLM) — `internal/cli/blocker_defer_e2e_test.go`

Real chain: shell-runtime agent → real subprocess → `Mailbox.fail` → classifier → queue gate → `runQueuedJobsForRepo` re-dispatch.

- `TestE2E532QuotaBlockerDeferredAndAutoRedispatched` — fabricated `HTTP 429 ... try again in 3 seconds` on the first delivery: job ends **queued** (blocked-operational) with class/attempt/retry-at persisted, the #552 stuck-reason surface explains it, the queue gate holds it for the whole window (re-dispatch attempts inside the window deliver nothing), and after the reset elapses the daemon re-dispatches automatically and the job **succeeds on attempt 2** (exactly 2 deliveries).
- `TestE2E532AuthBlockerDeferredAndHeld` — fabricated `401 authentication_error: invalid x-api-key`: classified `runtime_auth`, held at ~`authBlockerRetryDelay`.
- `TestE2E532ProductFailureIsNeverRetried` — a parseable `gitmoot_result` `decision=failed` (whose summary even mentions a rate limit) stays terminally failed, acquires no blocker fields/events, is never re-delivered.
- `TestE2E532UnclassifiedFailureStaysTerminal` — plain failure keeps today's path byte-identically.
- `TestE2E532BlockerRetryBudgetExhausted` — budget-spent job stays failed with `blocker_retries_exhausted`.

**Mutation proof** (run locally): renaming the classifier's `"throttled"` case so the 429 no longer matches →

```
--- FAIL: TestE2E532QuotaBlockerDeferredAndAutoRedispatched (0.10s)
    blocker_defer_e2e_test.go:140: job state after classified 429 = "failed", want "queued" (terminal fail means classification is broken)
```

## Gate

`go build ./...` ✓ · `go vet ./...` ✓ · `go test ./...` ✓ · `go test -race ./internal/workflow/` ✓

References #532 (spike slice — does **not** close it; the design comment lists the remaining classes/increments: doctor-gated auth re-probe, checkout-contention class, typed GitHub/network errors, pre-terminal classification in the mailbox seam, warn-level prompt context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
