### PR TITLE
chore(dashboard): bump gitmoot-dashboard for galaxy custom hit-testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702115600-5ceea0c4fc2d
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702123637-aaa230cd865a
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702115600-5ceea0c4fc2d h1:vLiRRMP5azHTGlKqscbllGMWZ8a6kYsdG/ogXblmevg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702115600-5ceea0c4fc2d/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702123637-aaa230cd865a h1:YHmQ4RI4S6b99D5QRkl92BQ9wM3UnGIrMp5wkXnPB2I=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702123637-aaa230cd865a/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps the `gitmoot-dashboard` dependency to `aaa230c` ([gitmoot-dashboard#16](https://github.com/jerryfane/gitmoot-dashboard/pull/16)).

That PR replaces force-graph@1.43.5's built-in pointer hit-detection — unusable at the Galaxy view's scale/zoom (a hardcoded 45-graph-unit painted hit radius still only produced a ~2px effective hit area, so the central repo hub and any imprecise click were dead) — with custom screen-space nearest-node picking (`galaxyNodeAt`), giving a generous constant-px hit radius per node type at any zoom.

Verified live on the 1617-node graph: hub hover 9/9 offsets to 20px (was 1/9), hub-centre clicks open the hub detail (was dead), broad selectability 46/46, 0 idle long-tasks.

Go-only diff is the `go.mod`/`go.sum` version bump; the UI change lives in the embedded `web/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)