### PR TITLE
fix(workflow): close the merge-gate no-CI race with a grace window + workflow awareness (#596)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -446,10 +446,13 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    observation — GitHub Actions creates a check-run a few seconds after a push,
    so the gate stays **pending** and only stamps the synthetic `gitmoot/ci`
    success after a second consecutive zero-external observation at the same head,
-   at least `[merge_gate] min_ci_wait` (default `60s`) later. It also never
-   concludes no-CI when `.github/workflows/` exists at the head tree. Set
-   `[merge_gate] require_external_ci = true` (global or per-repo) to hard-block an
-   empty gate instead of ever stamping `gitmoot/ci` (see
+   at least `[merge_gate] min_ci_wait` (default `60s`) later. When
+   `.github/workflows/` exists at the head tree it instead waits up to
+   `[merge_gate] max_ci_wait` (default `10m`) for a check to appear, then concludes
+   no-CI so a PR whose workflows never trigger for it still merges rather than
+   wedging forever. Set `[merge_gate] require_external_ci = true` (global or
+   per-repo) to hard-block an empty gate once that window elapses instead of ever
+   stamping `gitmoot/ci` (see
    [`skills/gitmoot/references/SAFETY.md`](../skills/gitmoot/references/SAFETY.md)).
 
 9. Merge and continue.

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -441,6 +441,17 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    the PR branch with the expected head SHA and leaves the merge gate pending so
    the daemon can reload the new head and checks on a later poll tick.
 
+   When a head reports **no** external CI at all (zero commit-statuses and zero
+   check-runs), Gitmoot does not conclude "this repo has no CI" from a single
+   observation — GitHub Actions creates a check-run a few seconds after a push,
+   so the gate stays **pending** and only stamps the synthetic `gitmoot/ci`
+   success after a second consecutive zero-external observation at the same head,
+   at least `[merge_gate] min_ci_wait` (default `60s`) later. It also never
+   concludes no-CI when `.github/workflows/` exists at the head tree. Set
+   `[merge_gate] require_external_ci = true` (global or per-repo) to hard-block an
+   empty gate instead of ever stamping `gitmoot/ci` (see
+   [`skills/gitmoot/references/SAFETY.md`](../skills/gitmoot/references/SAFETY.md)).
+
 9. Merge and continue.
 
    By default Gitmoot merges with a squash merge guarded by the current head SHA.

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -183,7 +183,10 @@ mirrors the off-by-default `[events]` stream.
   external CI at head) → **near-neutral** (`soft ≈ 0.5`, `choice = a`), never a
   strong positive. Rewarding an empty gate would optimize toward "merges that
   pass no real CI"; the no-CI guard reads the combined status at the merged head
-  SHA and demotes it.
+  SHA and demotes it. (On the merge side, an empty gate is itself deferred by a
+  grace window and workflow-awareness before it ever stamps `gitmoot/ci` — see
+  [`SAFETY.md`](../skills/gitmoot/references/SAFETY.md); #596 — so this
+  near-neutral band applies only to genuinely CI-less heads.)
 - **Blocked at the merge gate** → authoritative gate-fail (`hard = 0`,
   `choice = b`).
 - **Review changes_requested** → graded negative (`choice = b`) whose score

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -529,14 +529,19 @@ Fixes:
   `gitmoot task list` / `gitmoot job events <job-id>`. Resolve the conflict
   manually or run an explicit implement/fix job, then rerun review/merge.
 - Fix failing external CI or Gitmoot statuses.
-- If the reason reads `waiting to confirm no external CI`, the gate saw **zero**
-  external commit-statuses and check-runs at the head and is deferring by one
-  grace window rather than merging before GitHub Actions creates its run (#596).
-  A genuinely CI-less repo merges on the next tick after `[merge_gate]
-  min_ci_wait` (default `60s`) has elapsed with the head unchanged; a
-  CI-configured repo (has `.github/workflows/`) stays pending until the real
-  check appears. Set `[merge_gate] require_external_ci = true` (global or per-repo
-  `[repos."owner/repo".merge_gate]`) to hard-block an empty gate instead.
+- If the reason reads `waiting to confirm no external CI` (or `waiting … for CI
+  to be created`), the gate saw **zero** external commit-statuses and check-runs
+  at the head and is deferring rather than merging before GitHub Actions creates
+  its run (#596). A genuinely CI-less repo merges on the next tick after
+  `[merge_gate] min_ci_wait` (default `60s`) has elapsed with the head unchanged.
+  A CI-configured repo (has `.github/workflows/`) stays pending until the real
+  check appears, but only up to `[merge_gate] max_ci_wait` (default `10m`) — past
+  that bound, with the head unchanged and still no check, the gate concludes no-CI
+  and merges anyway, so a PR whose workflows never trigger for it (docs-only under
+  paths filters, tag-only / `workflow_dispatch`-only workflows, a non-targeted
+  branch) is not wedged forever. Set `[merge_gate] require_external_ci = true`
+  (global or per-repo `[repos."owner/repo".merge_gate]`) to hard-block an empty
+  gate instead of stamping `gitmoot/ci` once that window elapses.
 - Rerun reviews after the PR head SHA changes.
 - If a merged task reports a worktree cleanup warning, inspect the stored task
   worktree path, clean or remove that worktree manually, then clear stale local

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -529,6 +529,14 @@ Fixes:
   `gitmoot task list` / `gitmoot job events <job-id>`. Resolve the conflict
   manually or run an explicit implement/fix job, then rerun review/merge.
 - Fix failing external CI or Gitmoot statuses.
+- If the reason reads `waiting to confirm no external CI`, the gate saw **zero**
+  external commit-statuses and check-runs at the head and is deferring by one
+  grace window rather than merging before GitHub Actions creates its run (#596).
+  A genuinely CI-less repo merges on the next tick after `[merge_gate]
+  min_ci_wait` (default `60s`) has elapsed with the head unchanged; a
+  CI-configured repo (has `.github/workflows/`) stays pending until the real
+  check appears. Set `[merge_gate] require_external_ci = true` (global or per-repo
+  `[repos."owner/repo".merge_gate]`) to hard-block an empty gate instead.
 - Rerun reviews after the PR head SHA changes.
 - If a merged task reports a worktree cleanup warning, inspect the stored task
   worktree path, clean or remove that worktree manually, then clear stale local

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -400,9 +400,11 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		}
 		checkout := repoRecord.CheckoutPath
 		gh := github.NewClient(checkout)
+		mergeGate := newDaemonPolicyMergeGate(store, gh, checkout)
+		applyMergeGatePolicy(&mergeGate, *home, repo.FullName())
 		engine := workflow.Engine{
 			Store:     store,
-			MergeGate: newDaemonPolicyMergeGate(store, gh, checkout),
+			MergeGate: mergeGate,
 		}
 		// Honor the opt-in [orchestrate] policy (artifact-body inlining + per-root
 		// delegation token budget) on this single-repo engine too; fail-safe to the
@@ -5728,7 +5730,7 @@ var (
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, home string) workflow.Engine {
 	engine := workflow.Engine{
 		Store:                   store,
-		MergeGate:               daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout},
+		MergeGate:               daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout, Home: home},
 		ImplementationFinalizer: daemonImplementationFinalizer{Store: store, GitHub: gh, FallbackCheckout: checkout},
 		// escalate_human (#340): @-tag the human on the tree's PR/issue when a leg
 		// pauses awaiting a decision. Best-effort and nil-safe in the engine; the
@@ -6149,6 +6151,9 @@ type daemonMergeGate struct {
 	Store            *db.Store
 	GitHub           github.Client
 	FallbackCheckout string
+	// Home is the resolved <home>/.gitmoot root (or raw --home) used to load the
+	// [merge_gate] policy (#596). Empty => the off-by-default merge-gate behavior.
+	Home string
 }
 
 func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeRequest) (workflow.MergeDecision, error) {
@@ -6162,7 +6167,9 @@ func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeReq
 	if err != nil {
 		return workflow.MergeDecision{}, err
 	}
-	return newDaemonPolicyMergeGate(g.Store, g.githubClient(checkout), checkout).Evaluate(ctx, request)
+	gate := newDaemonPolicyMergeGate(g.Store, g.githubClient(checkout), checkout)
+	applyMergeGatePolicy(&gate, g.Home, request.Repo)
+	return gate.Evaluate(ctx, request)
 }
 
 func nativeMergeGateDisabled() bool {

--- a/internal/cli/merge_gate_policy.go
+++ b/internal/cli/merge_gate_policy.go
@@ -6,11 +6,11 @@ import (
 )
 
 // applyMergeGatePolicy loads the [merge_gate] policy for `home` and applies the
-// per-repo resolved knobs (require_external_ci, min_ci_wait) onto a constructed
-// merge gate (#596). It is fail-safe: an empty home, a missing config, or a parse
-// error leaves the gate at its off-by-default behavior (no external CI required,
-// built-in grace window) rather than erroring the daemon — mirroring how
-// loadEventsPolicy / resolveEscalationTTL degrade to defaults.
+// per-repo resolved knobs (require_external_ci, min_ci_wait, max_ci_wait) onto a
+// constructed merge gate (#596). It is fail-safe: an empty home, a missing config,
+// or a parse error leaves the gate at its off-by-default behavior (no external CI
+// required, built-in grace/max windows) rather than erroring the daemon —
+// mirroring how loadEventsPolicy / resolveEscalationTTL degrade to defaults.
 func applyMergeGatePolicy(gate *workflow.PolicyMergeGate, home string, repo string) {
 	cfg := resolveConfigFile(home)
 	if cfg == "" {
@@ -23,4 +23,5 @@ func applyMergeGatePolicy(gate *workflow.PolicyMergeGate, home string, repo stri
 	policy := loaded.For(repo)
 	gate.RequireExternalCI = policy.RequireExternalCI
 	gate.MinCIWait = policy.MinCIWait
+	gate.MaxCIWait = policy.MaxCIWait
 }

--- a/internal/cli/merge_gate_policy.go
+++ b/internal/cli/merge_gate_policy.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// applyMergeGatePolicy loads the [merge_gate] policy for `home` and applies the
+// per-repo resolved knobs (require_external_ci, min_ci_wait) onto a constructed
+// merge gate (#596). It is fail-safe: an empty home, a missing config, or a parse
+// error leaves the gate at its off-by-default behavior (no external CI required,
+// built-in grace window) rather than erroring the daemon — mirroring how
+// loadEventsPolicy / resolveEscalationTTL degrade to defaults.
+func applyMergeGatePolicy(gate *workflow.PolicyMergeGate, home string, repo string) {
+	cfg := resolveConfigFile(home)
+	if cfg == "" {
+		return
+	}
+	loaded, err := config.LoadMergeGatePolicy(config.Paths{ConfigFile: cfg})
+	if err != nil {
+		return
+	}
+	policy := loaded.For(repo)
+	gate.RequireExternalCI = policy.RequireExternalCI
+	gate.MinCIWait = policy.MinCIWait
+}

--- a/internal/cli/merge_gate_policy_test.go
+++ b/internal/cli/merge_gate_policy_test.go
@@ -24,6 +24,9 @@ func TestApplyMergeGatePolicyOffByDefault(t *testing.T) {
 	if gate.MinCIWait != config.DefaultMinCIWait {
 		t.Fatalf("MinCIWait = %v, want default %v", gate.MinCIWait, config.DefaultMinCIWait)
 	}
+	if gate.MaxCIWait != config.DefaultMaxCIWait {
+		t.Fatalf("MaxCIWait = %v, want default %v", gate.MaxCIWait, config.DefaultMaxCIWait)
+	}
 }
 
 func TestApplyMergeGatePolicyReadsPerRepoKnob(t *testing.T) {
@@ -35,6 +38,7 @@ func TestApplyMergeGatePolicyReadsPerRepoKnob(t *testing.T) {
 	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+`
 [merge_gate]
 min_ci_wait = "45s"
+max_ci_wait = "7m"
 
 [repos."jerryfane/noted".merge_gate]
 require_external_ci = true
@@ -50,6 +54,9 @@ require_external_ci = true
 	if noted.MinCIWait != 45*time.Second {
 		t.Fatalf("noted MinCIWait = %v, want inherited 45s", noted.MinCIWait)
 	}
+	if noted.MaxCIWait != 7*time.Minute {
+		t.Fatalf("noted MaxCIWait = %v, want inherited 7m", noted.MaxCIWait)
+	}
 
 	other := workflow.PolicyMergeGate{}
 	applyMergeGatePolicy(&other, paths.Home, "jerryfane/gitmoot")
@@ -59,12 +66,15 @@ require_external_ci = true
 	if other.MinCIWait != 45*time.Second {
 		t.Fatalf("non-override repo MinCIWait = %v, want global 45s", other.MinCIWait)
 	}
+	if other.MaxCIWait != 7*time.Minute {
+		t.Fatalf("non-override repo MaxCIWait = %v, want global 7m", other.MaxCIWait)
+	}
 }
 
 func TestApplyMergeGatePolicyEmptyHomeIsNoop(t *testing.T) {
 	gate := workflow.PolicyMergeGate{}
 	applyMergeGatePolicy(&gate, "", "jerryfane/noted")
-	if gate.RequireExternalCI || gate.MinCIWait != 0 {
+	if gate.RequireExternalCI || gate.MinCIWait != 0 || gate.MaxCIWait != 0 {
 		t.Fatalf("empty home must leave the gate untouched, got %+v", gate)
 	}
 }

--- a/internal/cli/merge_gate_policy_test.go
+++ b/internal/cli/merge_gate_policy_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestApplyMergeGatePolicyOffByDefault(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+
+	gate := workflow.PolicyMergeGate{}
+	applyMergeGatePolicy(&gate, paths.Home, "jerryfane/noted")
+	if gate.RequireExternalCI {
+		t.Fatalf("RequireExternalCI = true, want off by default")
+	}
+	if gate.MinCIWait != config.DefaultMinCIWait {
+		t.Fatalf("MinCIWait = %v, want default %v", gate.MinCIWait, config.DefaultMinCIWait)
+	}
+}
+
+func TestApplyMergeGatePolicyReadsPerRepoKnob(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+`
+[merge_gate]
+min_ci_wait = "45s"
+
+[repos."jerryfane/noted".merge_gate]
+require_external_ci = true
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	noted := workflow.PolicyMergeGate{}
+	applyMergeGatePolicy(&noted, paths.Home, "jerryfane/noted")
+	if !noted.RequireExternalCI {
+		t.Fatalf("noted RequireExternalCI = false, want true from per-repo override")
+	}
+	if noted.MinCIWait != 45*time.Second {
+		t.Fatalf("noted MinCIWait = %v, want inherited 45s", noted.MinCIWait)
+	}
+
+	other := workflow.PolicyMergeGate{}
+	applyMergeGatePolicy(&other, paths.Home, "jerryfane/gitmoot")
+	if other.RequireExternalCI {
+		t.Fatalf("non-override repo RequireExternalCI = true, want false")
+	}
+	if other.MinCIWait != 45*time.Second {
+		t.Fatalf("non-override repo MinCIWait = %v, want global 45s", other.MinCIWait)
+	}
+}
+
+func TestApplyMergeGatePolicyEmptyHomeIsNoop(t *testing.T) {
+	gate := workflow.PolicyMergeGate{}
+	applyMergeGatePolicy(&gate, "", "jerryfane/noted")
+	if gate.RequireExternalCI || gate.MinCIWait != 0 {
+		t.Fatalf("empty home must leave the gate untouched, got %+v", gate)
+	}
+}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -130,6 +130,9 @@ func validateConfigFile(paths Paths) error {
 	if _, err := LoadDaemonRuntimeConfig(paths); err != nil {
 		return err
 	}
+	if _, err := LoadMergeGatePolicy(paths); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -251,12 +251,17 @@ path = ""
 # external CI (issue #596). By default (no section) the gate defers concluding
 # "no CI" until a SECOND consecutive zero-external observation at the same head,
 # at least min_ci_wait later, so a fresh head cannot merge before GitHub Actions
-# creates its check run; it also never concludes no-CI when .github/workflows/
-# exists at the head. Set require_external_ci = true to instead HARD-BLOCK an
-# empty gate (for repos you know always have CI). Both keys can be set globally
-# and overridden per repo under [repos."owner/repo".merge_gate].
+# creates its check run. When .github/workflows/ exists at the head it instead
+# waits up to max_ci_wait (default 10m) for a check to appear, then concludes
+# no-CI so a PR whose workflows never trigger for it (docs-only under paths
+# filters, tag-only or workflow_dispatch-only workflows, a non-targeted branch)
+# still merges rather than wedging forever. Set require_external_ci = true to
+# instead HARD-BLOCK an empty gate once that window elapses (for repos you know
+# always have CI). All keys can be set globally and overridden per repo under
+# [repos."owner/repo".merge_gate].
 # [merge_gate]
 # require_external_ci = false
 # min_ci_wait = "60s"
+# max_ci_wait = "10m"
 `, paths.Database, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs)
 }

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -246,5 +246,17 @@ path = ""
 # claude_memory_gb = 0.85
 # kimi_memory_gb = 0.5
 # default_memory_gb = 0.5
+
+# [merge_gate] tunes how the native merge gate handles a PR head that reports NO
+# external CI (issue #596). By default (no section) the gate defers concluding
+# "no CI" until a SECOND consecutive zero-external observation at the same head,
+# at least min_ci_wait later, so a fresh head cannot merge before GitHub Actions
+# creates its check run; it also never concludes no-CI when .github/workflows/
+# exists at the head. Set require_external_ci = true to instead HARD-BLOCK an
+# empty gate (for repos you know always have CI). Both keys can be set globally
+# and overridden per repo under [repos."owner/repo".merge_gate].
+# [merge_gate]
+# require_external_ci = false
+# min_ci_wait = "60s"
 `, paths.Database, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs)
 }

--- a/internal/config/merge_gate.go
+++ b/internal/config/merge_gate.go
@@ -16,6 +16,16 @@ import (
 // window later.
 const DefaultMinCIWait = 60 * time.Second
 
+// DefaultMaxCIWait is the upper bound the merge gate waits when `.github/workflows/`
+// exists at the head but no external check ever appears (#596, layer 2). Past this
+// window with the head unchanged and still zero external CI, the gate concludes
+// no-CI and stamps the synthetic gitmoot/ci success instead of staying pending
+// forever, so a PR whose workflows never trigger for it (docs-only under paths
+// filters, tag-only / workflow_dispatch-only workflows, or a non-targeted branch)
+// still merges. It is wide (GitHub Actions creates a check-run within seconds) yet
+// finite to restore liveness.
+const DefaultMaxCIWait = 10 * time.Minute
+
 // MergeGatePolicy is the resolved merge-gate behavior for a repo (#596). It is
 // OFF BY DEFAULT in the sense that the historical behavior — conclude "no CI"
 // from a zero-external observation — still happens, just deferred by one grace
@@ -28,14 +38,20 @@ type MergeGatePolicy struct {
 	RequireExternalCI bool
 	// MinCIWait is the grace window between the first and second zero-external
 	// observation at the same head before the gate concludes no-CI. Default
-	// DefaultMinCIWait (60s). It is ignored when RequireExternalCI is true.
+	// DefaultMinCIWait (60s).
 	MinCIWait time.Duration
+	// MaxCIWait is the upper bound the gate waits when `.github/workflows/` exists at
+	// the head but no external check appears (#596, layer 2). Past it the gate
+	// concludes no-CI instead of staying pending forever. Default DefaultMaxCIWait
+	// (10m).
+	MaxCIWait time.Duration
 }
 
 // DefaultMergeGatePolicy returns the off-by-default policy: no external CI is not
-// required, and the no-CI conclusion is deferred by the default grace window.
+// required, and the no-CI conclusion is deferred by the default grace window (and
+// bounded by the default max window when workflows exist at the head).
 func DefaultMergeGatePolicy() MergeGatePolicy {
-	return MergeGatePolicy{RequireExternalCI: false, MinCIWait: DefaultMinCIWait}
+	return MergeGatePolicy{RequireExternalCI: false, MinCIWait: DefaultMinCIWait, MaxCIWait: DefaultMaxCIWait}
 }
 
 // MergeGateConfig is the parsed [merge_gate] configuration: a global default plus
@@ -53,6 +69,7 @@ type MergeGateConfig struct {
 type mergeGateOverride struct {
 	requireExternalCI *bool
 	minCIWait         *time.Duration
+	maxCIWait         *time.Duration
 }
 
 // For resolves the effective policy for a repo: the global default with any
@@ -63,6 +80,9 @@ func (c MergeGateConfig) For(repo string) MergeGatePolicy {
 	if policy.MinCIWait <= 0 {
 		policy.MinCIWait = DefaultMinCIWait
 	}
+	if policy.MaxCIWait <= 0 {
+		policy.MaxCIWait = DefaultMaxCIWait
+	}
 	override, ok := c.repos[strings.TrimSpace(repo)]
 	if !ok {
 		return policy
@@ -72,6 +92,9 @@ func (c MergeGateConfig) For(repo string) MergeGatePolicy {
 	}
 	if override.minCIWait != nil {
 		policy.MinCIWait = *override.minCIWait
+	}
+	if override.maxCIWait != nil {
+		policy.MaxCIWait = *override.maxCIWait
 	}
 	return policy
 }
@@ -182,6 +205,13 @@ func applyMergeGateGlobalField(policy *MergeGatePolicy, key string, value string
 		}
 		policy.MinCIWait = parsed
 		return nil
+	case "max_ci_wait":
+		parsed, err := parseConfigDuration(value)
+		if err != nil {
+			return err
+		}
+		policy.MaxCIWait = parsed
+		return nil
 	default:
 		return nil
 	}
@@ -203,6 +233,13 @@ func applyMergeGateOverrideField(override *mergeGateOverride, key string, value 
 		}
 		override.minCIWait = &parsed
 		return nil
+	case "max_ci_wait":
+		parsed, err := parseConfigDuration(value)
+		if err != nil {
+			return err
+		}
+		override.maxCIWait = &parsed
+		return nil
 	default:
 		return nil
 	}
@@ -211,6 +248,9 @@ func applyMergeGateOverrideField(override *mergeGateOverride, key string, value 
 func validateMergeGatePolicy(label string, policy MergeGatePolicy) error {
 	if policy.MinCIWait < 0 {
 		return fmt.Errorf("%s: min_ci_wait must be a non-negative duration", label)
+	}
+	if policy.MaxCIWait < 0 {
+		return fmt.Errorf("%s: max_ci_wait must be a non-negative duration", label)
 	}
 	return nil
 }

--- a/internal/config/merge_gate.go
+++ b/internal/config/merge_gate.go
@@ -1,0 +1,216 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultMinCIWait is the grace window the merge gate waits between two
+// consecutive zero-external-CI observations at the same head before it concludes
+// a repo has no CI (#596). It is deliberately a few GitHub-Actions run-creation
+// latencies wide: the observed live race (issue #596) hit a ~4s window, so 60s
+// leaves comfortable margin while a genuinely CI-less repo merges only one grace
+// window later.
+const DefaultMinCIWait = 60 * time.Second
+
+// MergeGatePolicy is the resolved merge-gate behavior for a repo (#596). It is
+// OFF BY DEFAULT in the sense that the historical behavior — conclude "no CI"
+// from a zero-external observation — still happens, just deferred by one grace
+// window (MinCIWait) instead of instantly, and require_external_ci defaults false.
+type MergeGatePolicy struct {
+	// RequireExternalCI, when true, HARD-BLOCKS a merge whose head reports zero
+	// external CI (no external commit-statuses AND no check-runs) instead of ever
+	// stamping the synthetic gitmoot/ci success. Use it for repos the operator
+	// knows always have CI. Default false.
+	RequireExternalCI bool
+	// MinCIWait is the grace window between the first and second zero-external
+	// observation at the same head before the gate concludes no-CI. Default
+	// DefaultMinCIWait (60s). It is ignored when RequireExternalCI is true.
+	MinCIWait time.Duration
+}
+
+// DefaultMergeGatePolicy returns the off-by-default policy: no external CI is not
+// required, and the no-CI conclusion is deferred by the default grace window.
+func DefaultMergeGatePolicy() MergeGatePolicy {
+	return MergeGatePolicy{RequireExternalCI: false, MinCIWait: DefaultMinCIWait}
+}
+
+// MergeGateConfig is the parsed [merge_gate] configuration: a global default plus
+// optional per-repo [repos."owner/repo".merge_gate] overrides (#596). It mirrors
+// how [repos."owner/repo"] scopes RepoConcurrency — a repo with no override uses
+// the global default, which itself defaults to DefaultMergeGatePolicy.
+type MergeGateConfig struct {
+	Global MergeGatePolicy
+	repos  map[string]mergeGateOverride
+}
+
+// mergeGateOverride tracks which per-repo keys were explicitly set so an override
+// merges onto the global default field-by-field (a missing key inherits the
+// global value rather than resetting it to a zero value).
+type mergeGateOverride struct {
+	requireExternalCI *bool
+	minCIWait         *time.Duration
+}
+
+// For resolves the effective policy for a repo: the global default with any
+// per-repo override applied on top (#596). A repo with no override returns the
+// global policy verbatim.
+func (c MergeGateConfig) For(repo string) MergeGatePolicy {
+	policy := c.Global
+	if policy.MinCIWait <= 0 {
+		policy.MinCIWait = DefaultMinCIWait
+	}
+	override, ok := c.repos[strings.TrimSpace(repo)]
+	if !ok {
+		return policy
+	}
+	if override.requireExternalCI != nil {
+		policy.RequireExternalCI = *override.requireExternalCI
+	}
+	if override.minCIWait != nil {
+		policy.MinCIWait = *override.minCIWait
+	}
+	return policy
+}
+
+// LoadMergeGatePolicy parses the [merge_gate] section (global) and every
+// [repos."owner/repo".merge_gate] section (per-repo override) from the config
+// file (#596). It is OFF BY DEFAULT: a config with neither section yields the
+// default policy for every repo (no external CI required, default grace window).
+//
+// It reuses the same naive line-scanner shape as LoadRepoConcurrency /
+// LoadAdmissionPolicy. Unrelated sections are ignored.
+func LoadMergeGatePolicy(paths Paths) (MergeGateConfig, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return MergeGateConfig{}, err
+	}
+	cfg := MergeGateConfig{Global: DefaultMergeGatePolicy(), repos: map[string]mergeGateOverride{}}
+	// section is "" for the global [merge_gate], a repo full name for a per-repo
+	// override, and unset (inSection=false) for any other section.
+	var repo string
+	inSection := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			repo, inSection = parseMergeGateSection(section)
+			if inSection && repo != "" {
+				if _, ok := cfg.repos[repo]; !ok {
+					cfg.repos[repo] = mergeGateOverride{}
+				}
+			}
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if repo == "" {
+			if err := applyMergeGateGlobalField(&cfg.Global, key, value); err != nil {
+				return MergeGateConfig{}, fmt.Errorf("parse [merge_gate].%s: %w", key, err)
+			}
+			continue
+		}
+		override := cfg.repos[repo]
+		if err := applyMergeGateOverrideField(&override, key, value); err != nil {
+			return MergeGateConfig{}, fmt.Errorf("parse [repos.%q.merge_gate].%s: %w", repo, key, err)
+		}
+		cfg.repos[repo] = override
+	}
+	if err := validateMergeGatePolicy("[merge_gate]", cfg.Global); err != nil {
+		return MergeGateConfig{}, err
+	}
+	for name := range cfg.repos {
+		if err := validateMergeGatePolicy(fmt.Sprintf("[repos.%q.merge_gate]", name), cfg.For(name)); err != nil {
+			return MergeGateConfig{}, err
+		}
+	}
+	return cfg, nil
+}
+
+// parseMergeGateSection classifies a section header. It returns ("", true) for the
+// global [merge_gate], (repo, true) for a per-repo [repos."owner/repo".merge_gate],
+// and ("", false) for any other section (which the loader ignores).
+func parseMergeGateSection(section string) (string, bool) {
+	section = strings.TrimSpace(section)
+	if section == "merge_gate" {
+		return "", true
+	}
+	if !strings.HasPrefix(section, "repos.") || !strings.HasSuffix(section, ".merge_gate") {
+		return "", false
+	}
+	rest := strings.TrimSuffix(strings.TrimPrefix(section, "repos."), ".merge_gate")
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return "", false
+	}
+	if strings.HasPrefix(rest, "\"") {
+		unquoted, err := strconv.Unquote(rest)
+		if err != nil || strings.TrimSpace(unquoted) == "" {
+			return "", false
+		}
+		return strings.TrimSpace(unquoted), true
+	}
+	return rest, true
+}
+
+func applyMergeGateGlobalField(policy *MergeGatePolicy, key string, value string) error {
+	switch key {
+	case "require_external_ci":
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		policy.RequireExternalCI = parsed
+		return nil
+	case "min_ci_wait":
+		parsed, err := parseConfigDuration(value)
+		if err != nil {
+			return err
+		}
+		policy.MinCIWait = parsed
+		return nil
+	default:
+		return nil
+	}
+}
+
+func applyMergeGateOverrideField(override *mergeGateOverride, key string, value string) error {
+	switch key {
+	case "require_external_ci":
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+		override.requireExternalCI = &parsed
+		return nil
+	case "min_ci_wait":
+		parsed, err := parseConfigDuration(value)
+		if err != nil {
+			return err
+		}
+		override.minCIWait = &parsed
+		return nil
+	default:
+		return nil
+	}
+}
+
+func validateMergeGatePolicy(label string, policy MergeGatePolicy) error {
+	if policy.MinCIWait < 0 {
+		return fmt.Errorf("%s: min_ci_wait must be a non-negative duration", label)
+	}
+	return nil
+}

--- a/internal/config/merge_gate_test.go
+++ b/internal/config/merge_gate_test.go
@@ -14,6 +14,9 @@ func TestDefaultMergeGatePolicyOff(t *testing.T) {
 	if policy.MinCIWait != DefaultMinCIWait {
 		t.Fatalf("default MinCIWait = %v, want %v", policy.MinCIWait, DefaultMinCIWait)
 	}
+	if policy.MaxCIWait != DefaultMaxCIWait {
+		t.Fatalf("default MaxCIWait = %v, want %v", policy.MaxCIWait, DefaultMaxCIWait)
+	}
 }
 
 func TestLoadMergeGatePolicyAbsentKeepsDefaults(t *testing.T) {
@@ -40,6 +43,7 @@ func TestLoadMergeGatePolicyGlobalSection(t *testing.T) {
 [merge_gate]
 require_external_ci = true
 min_ci_wait = "90s"
+max_ci_wait = "5m"
 `), 0o600); err != nil {
 		t.Fatalf("WriteFile returned error: %v", err)
 	}
@@ -54,6 +58,9 @@ min_ci_wait = "90s"
 	if got.MinCIWait != 90*time.Second {
 		t.Fatalf("global MinCIWait = %v, want 90s", got.MinCIWait)
 	}
+	if got.MaxCIWait != 5*time.Minute {
+		t.Fatalf("global MaxCIWait = %v, want 5m", got.MaxCIWait)
+	}
 }
 
 func TestLoadMergeGatePolicyPerRepoOverride(t *testing.T) {
@@ -67,6 +74,7 @@ min_ci_wait = "30s"
 
 [repos."jerryfane/noted".merge_gate]
 require_external_ci = true
+max_ci_wait = "3m"
 `), 0o600); err != nil {
 		t.Fatalf("WriteFile returned error: %v", err)
 	}
@@ -75,7 +83,8 @@ require_external_ci = true
 		t.Fatalf("LoadMergeGatePolicy returned error: %v", err)
 	}
 
-	// The override repo inherits the global min_ci_wait but flips require_external_ci.
+	// The override repo inherits the global min_ci_wait, flips require_external_ci,
+	// and sets its own max_ci_wait.
 	noted := cfg.For("jerryfane/noted")
 	if !noted.RequireExternalCI {
 		t.Fatalf("override require_external_ci = false, want true")
@@ -83,14 +92,21 @@ require_external_ci = true
 	if noted.MinCIWait != 30*time.Second {
 		t.Fatalf("override MinCIWait = %v, want inherited 30s", noted.MinCIWait)
 	}
+	if noted.MaxCIWait != 3*time.Minute {
+		t.Fatalf("override MaxCIWait = %v, want 3m", noted.MaxCIWait)
+	}
 
-	// A repo with no override keeps the global default (require_external_ci off).
+	// A repo with no override keeps the global default (require_external_ci off) and
+	// the default max_ci_wait.
 	other := cfg.For("jerryfane/gitmoot")
 	if other.RequireExternalCI {
 		t.Fatalf("non-override repo require_external_ci = true, want false")
 	}
 	if other.MinCIWait != 30*time.Second {
 		t.Fatalf("non-override repo MinCIWait = %v, want 30s", other.MinCIWait)
+	}
+	if other.MaxCIWait != DefaultMaxCIWait {
+		t.Fatalf("non-override repo MaxCIWait = %v, want default %v", other.MaxCIWait, DefaultMaxCIWait)
 	}
 }
 

--- a/internal/config/merge_gate_test.go
+++ b/internal/config/merge_gate_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDefaultMergeGatePolicyOff(t *testing.T) {
+	policy := DefaultMergeGatePolicy()
+	if policy.RequireExternalCI {
+		t.Fatalf("default require_external_ci = true, want false (off)")
+	}
+	if policy.MinCIWait != DefaultMinCIWait {
+		t.Fatalf("default MinCIWait = %v, want %v", policy.MinCIWait, DefaultMinCIWait)
+	}
+}
+
+func TestLoadMergeGatePolicyAbsentKeepsDefaults(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	cfg, err := LoadMergeGatePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadMergeGatePolicy returned error: %v", err)
+	}
+	got := cfg.For("jerryfane/noted")
+	if got != DefaultMergeGatePolicy() {
+		t.Fatalf("absent [merge_gate] For() = %+v, want defaults %+v", got, DefaultMergeGatePolicy())
+	}
+}
+
+func TestLoadMergeGatePolicyGlobalSection(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[merge_gate]
+require_external_ci = true
+min_ci_wait = "90s"
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	cfg, err := LoadMergeGatePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadMergeGatePolicy returned error: %v", err)
+	}
+	got := cfg.For("jerryfane/noted")
+	if !got.RequireExternalCI {
+		t.Fatalf("global require_external_ci = false, want true")
+	}
+	if got.MinCIWait != 90*time.Second {
+		t.Fatalf("global MinCIWait = %v, want 90s", got.MinCIWait)
+	}
+}
+
+func TestLoadMergeGatePolicyPerRepoOverride(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[merge_gate]
+min_ci_wait = "30s"
+
+[repos."jerryfane/noted".merge_gate]
+require_external_ci = true
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	cfg, err := LoadMergeGatePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadMergeGatePolicy returned error: %v", err)
+	}
+
+	// The override repo inherits the global min_ci_wait but flips require_external_ci.
+	noted := cfg.For("jerryfane/noted")
+	if !noted.RequireExternalCI {
+		t.Fatalf("override require_external_ci = false, want true")
+	}
+	if noted.MinCIWait != 30*time.Second {
+		t.Fatalf("override MinCIWait = %v, want inherited 30s", noted.MinCIWait)
+	}
+
+	// A repo with no override keeps the global default (require_external_ci off).
+	other := cfg.For("jerryfane/gitmoot")
+	if other.RequireExternalCI {
+		t.Fatalf("non-override repo require_external_ci = true, want false")
+	}
+	if other.MinCIWait != 30*time.Second {
+		t.Fatalf("non-override repo MinCIWait = %v, want 30s", other.MinCIWait)
+	}
+}
+
+func TestLoadMergeGatePolicyRejectsBadValues(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[merge_gate]
+require_external_ci = maybe
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	if _, err := LoadMergeGatePolicy(paths); err == nil {
+		t.Fatal("LoadMergeGatePolicy accepted a non-bool require_external_ci")
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -490,6 +490,21 @@ type MergeGate struct {
 	Reason       string
 }
 
+// NoCIObservation records the first merge-gate evaluation that saw zero external
+// CI (no external commit-statuses AND no check-runs) at a given head SHA (#596).
+// The merge gate uses it to defer concluding "no CI" until a second consecutive
+// zero-external observation at the SAME head, at least a grace window later, so a
+// fresh head cannot merge before GitHub Actions has created its check run. A new
+// head resets the observation.
+type NoCIObservation struct {
+	RepoFullName string
+	PullRequest  int64
+	HeadSHA      string
+	// FirstZeroAt is the RFC3339Nano timestamp of the first zero-external
+	// observation at HeadSHA.
+	FirstZeroAt string
+}
+
 type Pinger interface {
 	Close() error
 	Ping(ctx context.Context) error
@@ -5488,6 +5503,34 @@ func (s *Store) GetMergeGate(ctx context.Context, repoFullName string, pullReque
 	return gate, nil
 }
 
+// UpsertNoCIObservation records (or refreshes) the first zero-external CI
+// observation for a PR (#596). Recording at a new head SHA overwrites the prior
+// observation, which is exactly the reset-on-new-head semantics the merge gate
+// relies on.
+func (s *Store) UpsertNoCIObservation(ctx context.Context, obs NoCIObservation) error {
+	_, err := s.db.ExecContext(ctx, `INSERT INTO merge_gate_ci_observations(repo_full_name, pull_request, head_sha, first_zero_at, updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(repo_full_name, pull_request) DO UPDATE SET
+			head_sha = excluded.head_sha,
+			first_zero_at = excluded.first_zero_at,
+			updated_at = CURRENT_TIMESTAMP`,
+		obs.RepoFullName, obs.PullRequest, obs.HeadSHA, obs.FirstZeroAt)
+	return err
+}
+
+// GetNoCIObservation returns the recorded first zero-external CI observation for
+// a PR, or sql.ErrNoRows if none has been recorded yet (#596).
+func (s *Store) GetNoCIObservation(ctx context.Context, repoFullName string, pullRequest int64) (NoCIObservation, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, pull_request, head_sha, first_zero_at
+		FROM merge_gate_ci_observations WHERE repo_full_name = ? AND pull_request = ?`,
+		repoFullName, pullRequest)
+	var obs NoCIObservation
+	if err := row.Scan(&obs.RepoFullName, &obs.PullRequest, &obs.HeadSHA, &obs.FirstZeroAt); err != nil {
+		return NoCIObservation{}, err
+	}
+	return obs, nil
+}
+
 func (s *Store) HasTable(ctx context.Context, name string) (bool, error) {
 	if strings.ContainsAny(name, "'\"`;") {
 		return false, fmt.Errorf("unsafe table name: %s", name)
@@ -6803,6 +6846,25 @@ CREATE TABLE issue_comment_poll_state (
 	repo_full_name TEXT PRIMARY KEY,
 	last_seen_comment_at TEXT NOT NULL DEFAULT '',
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+	`,
+	// #596 merge-gate no-CI race: one row per PR recording the FIRST evaluation at
+	// which the merge gate saw zero external commit-statuses AND zero check-runs at
+	// a given head. The gate defers concluding "this repo has no CI" until a SECOND
+	// consecutive zero-external observation at the SAME head, at least min_ci_wait
+	// later — closing the window where a fresh head merges before GitHub Actions has
+	// created its check run. A new head resets the observation. Pure additive append
+	// (CREATE TABLE only); the table stays empty until a zero-external evaluation
+	// occurs and is read only on the no-CI path, so every existing DB reads
+	// identically.
+	`
+CREATE TABLE merge_gate_ci_observations (
+	repo_full_name TEXT NOT NULL,
+	pull_request INTEGER NOT NULL,
+	head_sha TEXT NOT NULL DEFAULT '',
+	first_zero_at TEXT NOT NULL DEFAULT '',
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	UNIQUE(repo_full_name, pull_request)
 );
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -48,6 +48,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"skillopt_review_watches",
 		"skillopt_judge_outcomes",
 		"interactive_prompts",
+		"merge_gate_ci_observations",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -105,6 +106,44 @@ func TestOpenConfiguresSQLiteContentionPragmas(t *testing.T) {
 	}
 	if busyTimeout != sqliteBusyTimeoutMillis {
 		t.Fatalf("read-only busy_timeout = %d, want %d", busyTimeout, sqliteBusyTimeoutMillis)
+	}
+}
+
+func TestNoCIObservationRoundTripAndReset(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if _, err := store.GetNoCIObservation(ctx, "jerryfane/noted", 11); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetNoCIObservation on empty table error = %v, want sql.ErrNoRows", err)
+	}
+
+	first := NoCIObservation{RepoFullName: "jerryfane/noted", PullRequest: 11, HeadSHA: "aaaa111", FirstZeroAt: "2026-07-01T22:23:32Z"}
+	if err := store.UpsertNoCIObservation(ctx, first); err != nil {
+		t.Fatalf("UpsertNoCIObservation returned error: %v", err)
+	}
+	got, err := store.GetNoCIObservation(ctx, "jerryfane/noted", 11)
+	if err != nil {
+		t.Fatalf("GetNoCIObservation returned error: %v", err)
+	}
+	if got != first {
+		t.Fatalf("observation = %+v, want %+v", got, first)
+	}
+
+	// A new head overwrites the prior observation in place (reset-on-new-head).
+	second := NoCIObservation{RepoFullName: "jerryfane/noted", PullRequest: 11, HeadSHA: "bbbb222", FirstZeroAt: "2026-07-01T22:25:00Z"}
+	if err := store.UpsertNoCIObservation(ctx, second); err != nil {
+		t.Fatalf("second UpsertNoCIObservation returned error: %v", err)
+	}
+	got, err = store.GetNoCIObservation(ctx, "jerryfane/noted", 11)
+	if err != nil {
+		t.Fatalf("GetNoCIObservation after reset returned error: %v", err)
+	}
+	if got != second {
+		t.Fatalf("observation after reset = %+v, want %+v", got, second)
 	}
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -905,6 +905,28 @@ func (c *GhClient) GetCombinedStatus(ctx context.Context, repo Repository, ref s
 	return status, err
 }
 
+// WorkflowsExistAtRef reports whether the repository has a `.github/workflows`
+// directory at the given ref (#596). The merge gate uses it as a cheap, one-read
+// workflow-awareness signal: if the head tree demonstrably carries workflow
+// files, a zero-external-CI observation means GitHub Actions has not created the
+// run yet (or it is queued), so the gate must NOT conclude "no CI". A 404 (no
+// such path) reports false; any other error is returned so the caller can fail
+// safe toward the grace path rather than instant-stamping.
+func (c *GhClient) WorkflowsExistAtRef(ctx context.Context, repo Repository, ref string) (bool, error) {
+	args := []string{"api", "-X", "GET", endpoint(repo, "contents", ".github/workflows")}
+	if r := strings.TrimSpace(ref); r != "" {
+		args = append(args, "-f", "ref="+r)
+	}
+	result, err := c.run(ctx, false, args...)
+	if err == nil {
+		return true, nil
+	}
+	if isNotFound(result) {
+		return false, nil
+	}
+	return false, err
+}
+
 func (c *GhClient) CompareCommits(ctx context.Context, repo Repository, base string, head string) (CompareResult, error) {
 	var result CompareResult
 	err := c.apiJSON(ctx, false, &result, endpoint(repo, "compare", url.PathEscape(base+"..."+head)))

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1119,6 +1119,52 @@ func TestEnsurePullRequest(t *testing.T) {
 	})
 }
 
+func TestWorkflowsExistAtRef(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+
+	t.Run("present", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: `[{"name":"ci.yml"}]`}}}
+		client := GhClient{Runner: runner}
+		exists, err := client.WorkflowsExistAtRef(context.Background(), repo, "d342f97")
+		if err != nil {
+			t.Fatalf("WorkflowsExistAtRef returned error: %v", err)
+		}
+		if !exists {
+			t.Fatalf("exists = false, want true")
+		}
+		args := strings.Join(runner.calls[0], " ")
+		if !strings.Contains(args, "repos/o/r/contents/.github/workflows") || !strings.Contains(args, "ref=d342f97") {
+			t.Fatalf("call args = %q, want contents/.github/workflows at ref", args)
+		}
+	})
+
+	t.Run("absent 404 is false not error", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{{Stderr: "HTTP 404: Not Found (https://api.github.com/repos/o/r/contents/.github/workflows)"}},
+			errs:    []error{errors.New("exit status 1")},
+		}
+		client := GhClient{Runner: runner}
+		exists, err := client.WorkflowsExistAtRef(context.Background(), repo, "d342f97")
+		if err != nil {
+			t.Fatalf("WorkflowsExistAtRef 404 returned error: %v", err)
+		}
+		if exists {
+			t.Fatalf("exists = true on 404, want false")
+		}
+	})
+
+	t.Run("other error surfaces", func(t *testing.T) {
+		runner := &fakeRunner{
+			results: []subprocess.Result{{Stderr: "HTTP 500: Server Error"}},
+			errs:    []error{errors.New("exit status 1")},
+		}
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.WorkflowsExistAtRef(context.Background(), repo, "d342f97"); err == nil {
+			t.Fatal("WorkflowsExistAtRef swallowed a non-404 error; caller must be able to fail safe")
+		}
+	})
+}
+
 type fakeRunner struct {
 	results []subprocess.Result
 	errs    []error

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -61,6 +61,13 @@ type PolicyMergeGate struct {
 	// zero-external observation at the same head before the gate concludes no-CI
 	// (#596, layer 1). Zero means use the built-in default (defaultMinCIWait).
 	MinCIWait time.Duration
+	// MaxCIWait BOUNDS layer 2 (#596): when `.github/workflows/` exists at the head
+	// but no external check ever appears (docs-only PRs under paths filters,
+	// tag-only / workflow_dispatch-only workflows, or a branch the workflows do not
+	// target), the gate stays pending only until MaxCIWait has elapsed with the head
+	// unchanged, then falls through to conclude no-CI so such PRs still merge instead
+	// of wedging forever. Zero means use the built-in default (defaultMaxCIWait).
+	MaxCIWait time.Duration
 	// Clock is injectable for deterministic tests. Nil means time.Now.
 	Clock func() time.Time
 }
@@ -69,6 +76,14 @@ type PolicyMergeGate struct {
 // mirrors config.DefaultMinCIWait; the workflow package keeps its own copy to
 // avoid a config import cycle.
 const defaultMinCIWait = 60 * time.Second
+
+// defaultMaxCIWait is the built-in upper bound for layer 2 (workflow-awareness)
+// used when MaxCIWait is unset. It mirrors config.DefaultMaxCIWait. It is
+// deliberately wide (GitHub Actions creates a check-run within seconds even when
+// the run itself is slow, so the only way to stay empty this long is that the
+// workflows genuinely do not run for this head), yet finite so a workflow-present
+// repo whose workflows never trigger for a given PR still merges.
+const defaultMaxCIWait = 10 * time.Minute
 
 func (g PolicyMergeGate) now() time.Time {
 	if g.Clock != nil {
@@ -82,6 +97,13 @@ func (g PolicyMergeGate) minCIWait() time.Duration {
 		return g.MinCIWait
 	}
 	return defaultMinCIWait
+}
+
+func (g PolicyMergeGate) maxCIWait() time.Duration {
+	if g.MaxCIWait > 0 {
+		return g.MaxCIWait
+	}
+	return defaultMaxCIWait
 }
 
 // workflowAwareGitHub is an OPTIONAL capability the merge gate probes for on its
@@ -178,8 +200,17 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 		}
 		var blocked mergeBlocked
 		if errors.As(err, &blocked) {
-			// An external CI failure is an authoritative template-quality rejection.
-			return g.block(ctx, request, headSHA, blocked.reason, MergeBlockQuality)
+			// An external CI FAILURE is an authoritative template-quality rejection
+			// (MergeBlockQuality, the default class). A require_external_ci empty-gate
+			// block instead carries an explicit MergeBlockTransient class: an ABSENT
+			// external CI is a repo-config/operator-policy condition, not a template
+			// defect, so the trace-harvester must not score it as a false Hard=0
+			// negative (#465 INFRA-NOISE-FILTERED).
+			class := MergeBlockQuality
+			if blocked.class != MergeBlockNone {
+				class = blocked.class
+			}
+			return g.block(ctx, request, headSHA, blocked.reason, class)
 		}
 		return MergeDecision{}, err
 	}
@@ -574,80 +605,77 @@ func (g PolicyMergeGate) ensureStatuses(ctx context.Context, repo github.Reposit
 
 // concludeNoExternalCI is the layered defense for the #596 no-CI race. When a
 // head reports zero external commit-statuses AND zero check-runs, it decides —
-// across daemon polls — whether that truly means "this repo has no CI" or merely
-// "GitHub Actions has not created the run yet".
-//
-// Layer 3 (require_external_ci): if the operator requires external CI, an empty
-// gate hard-blocks rather than ever stamping gitmoot/ci.
+// across daemon polls — whether that truly means "this repo has no CI at this
+// head" or merely "GitHub Actions has not created the run yet". Every layer is
+// TIME-BOUNDED and measured from a SINGLE persisted first-zero observation at the
+// head (recordOrLoadFirstZero), so no path can hold the gate pending forever and
+// a new head resets every window together.
 //
 // Layer 2 (workflow-awareness): if `.github/workflows/` demonstrably exists at
-// the head tree, a zero observation means Actions is lagging, so the gate never
-// concludes no-CI (stays pending). A read error fails SAFE toward the grace path
-// (treated as workflows-unknown), never toward an instant stamp.
+// the head tree, a zero observation is most likely an Actions creation lag, so
+// the gate stays pending — but only until MaxCIWait has elapsed with the head
+// unchanged. Past that bound the workflows demonstrably never produce a check for
+// this head (docs-only PRs under paths filters, tag-only / workflow_dispatch-only
+// workflows, or a branch the workflows do not target), so the gate falls through
+// and concludes no-CI rather than wedging the merge forever. A workflow-read error
+// fails SAFE toward the grace path (treated as workflows-unknown), never toward an
+// instant stamp.
 //
 // Layer 1 (grace deferral): otherwise, require TWO consecutive zero-external
-// observations at the SAME head, at least MinCIWait apart, before stamping the
-// synthetic gitmoot/ci success. The first observation (head SHA + time) is
-// persisted; a new head resets it. The gate is retried every daemon poll, so a
-// pending return is cheap and a genuinely CI-less repo merges exactly one grace
-// window later.
+// observations at the SAME head, at least MinCIWait apart, before concluding. The
+// gate is retried every daemon poll, so a pending return is cheap and a genuinely
+// CI-less repo merges exactly one grace window later.
+//
+// Layer 3 (require_external_ci): reached only AFTER the window above elapses with
+// still-zero external CI (i.e. NOT during the creation-lag race). If the operator
+// requires external CI, the empty gate hard-blocks rather than ever stamping
+// gitmoot/ci — but as a MergeBlockTransient (an absent external CI is a
+// repo-config/operator-policy condition, not a template-quality defect), so the
+// trace-harvester never scores it as a false negative (#465).
 func (g PolicyMergeGate) concludeNoExternalCI(ctx context.Context, repo github.Repository, pullRequest int64, headSHA string) error {
 	shortHead := shortSHA(headSHA)
-
-	// Layer 3: operator requires external CI — never stamp the empty gate.
-	if g.RequireExternalCI {
-		return mergeBlocked{reason: fmt.Sprintf("merge gate requires external CI but head %s reports none; set [merge_gate] require_external_ci = false to allow no-CI merges, or ensure the CI workflow runs on this pull request", shortHead)}
-	}
-
-	// Layer 2: the repo demonstrably has workflows at this head — a zero
-	// observation is an Actions creation lag, not a CI-less repo.
-	if g.headHasWorkflows(ctx, repo, headSHA) {
-		return mergePending{reason: fmt.Sprintf("repository has GitHub Actions workflows but no check run has appeared yet at head %s; waiting for CI to be created", shortHead)}
-	}
-
-	// Layer 1: grace deferral — need a second zero-external observation at the same
-	// head, at least MinCIWait later, before concluding no external CI.
-	repoFullName := repo.FullName()
 	now := g.now()
-	obs, err := g.Store.GetNoCIObservation(ctx, repoFullName, pullRequest)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+
+	// Persist (or read) the first zero-external observation at this head. All layers
+	// measure their windows from this single persisted clock, and a new head resets
+	// it — so no layer can conclude in the Actions creation-lag window and none can
+	// hold pending forever.
+	firstZero, err := g.recordOrLoadFirstZero(ctx, repo.FullName(), pullRequest, headSHA, now)
+	if err != nil {
 		return err
 	}
-	if errors.Is(err, sql.ErrNoRows) || obs.HeadSHA != headSHA {
-		// First zero observation at this head (no prior row, or the head changed):
-		// record & defer.
-		if recordErr := g.Store.UpsertNoCIObservation(ctx, db.NoCIObservation{
-			RepoFullName: repoFullName,
-			PullRequest:  pullRequest,
-			HeadSHA:      headSHA,
-			FirstZeroAt:  now.Format(time.RFC3339Nano),
-		}); recordErr != nil {
-			return recordErr
-		}
-		return mergePending{reason: fmt.Sprintf("waiting to confirm no external CI at head %s; will re-check after the grace window in case GitHub Actions is still creating the run", shortHead)}
-	}
+	elapsed := now.Sub(firstZero)
 
-	firstZero, parseErr := time.Parse(time.RFC3339Nano, obs.FirstZeroAt)
-	if parseErr != nil {
-		// A corrupt timestamp must fail SAFE toward the grace path: re-record and
-		// defer rather than instant-stamp.
-		if recordErr := g.Store.UpsertNoCIObservation(ctx, db.NoCIObservation{
-			RepoFullName: repoFullName,
-			PullRequest:  pullRequest,
-			HeadSHA:      headSHA,
-			FirstZeroAt:  now.Format(time.RFC3339Nano),
-		}); recordErr != nil {
-			return recordErr
+	// Layer 2: workflows demonstrably exist at this head — a zero observation is
+	// almost certainly an Actions creation lag, so stay pending, BOUNDED by
+	// MaxCIWait. Past that bound with the head unchanged and still zero external CI,
+	// the workflows genuinely never produce a check for this head, so fall through.
+	if g.headHasWorkflows(ctx, repo, headSHA) {
+		if elapsed < g.maxCIWait() {
+			return mergePending{reason: fmt.Sprintf("repository has GitHub Actions workflows but no check run has appeared yet at head %s; waiting up to %s for CI to be created", shortHead, g.maxCIWait())}
 		}
-		return mergePending{reason: fmt.Sprintf("re-confirming no external CI at head %s after an unreadable observation timestamp", shortHead)}
-	}
-
-	if now.Sub(firstZero) < g.minCIWait() {
+		// Bound elapsed: conclude no external CI for this head.
+	} else if elapsed < g.minCIWait() {
+		// Layer 1: grace deferral — no workflows detected, but wait one grace window
+		// in case GitHub Actions simply has not created the run yet.
 		return mergePending{reason: fmt.Sprintf("waiting to confirm no external CI at head %s; grace window has not elapsed since the first zero observation", shortHead)}
 	}
 
-	// Two consecutive zero-external observations at the same head, grace elapsed:
-	// this repo genuinely reports no external CI at this head.
+	// Confident that no external CI will appear at this head (the workflow/grace
+	// window elapsed with the head unchanged and still zero external observations).
+
+	// Layer 3: operator requires external CI — never stamp the empty gate. This is
+	// a repo-config/operator-policy condition, not a template defect, so it blocks
+	// as MergeBlockTransient (unharvested), and only here — never during the
+	// creation-lag race handled above.
+	if g.RequireExternalCI {
+		return mergeBlocked{
+			reason: fmt.Sprintf("merge gate requires external CI but head %s still reports none after waiting for CI to appear; set [merge_gate] require_external_ci = false to allow no-CI merges, or ensure the CI workflow runs on this pull request", shortHead),
+			class:  MergeBlockTransient,
+		}
+	}
+
+	// Genuinely no external CI at this head: stamp the synthetic gitmoot/ci success.
 	_, err = g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
 		Repo:        repo,
 		SHA:         headSHA,
@@ -656,6 +684,34 @@ func (g PolicyMergeGate) concludeNoExternalCI(ctx context.Context, repo github.R
 		Description: "No external CI reported",
 	})
 	return err
+}
+
+// recordOrLoadFirstZero persists (or reads) the first zero-external CI observation
+// at headSHA and returns the effective first-zero timestamp used to measure the
+// grace/max windows. A missing row, a head change, or an unreadable stored
+// timestamp all (re)record `now` and return it — the fail-SAFE direction, so the
+// caller measures a full window from a trustworthy clock instead of concluding
+// early off a stale or corrupt observation.
+func (g PolicyMergeGate) recordOrLoadFirstZero(ctx context.Context, repoFullName string, pullRequest int64, headSHA string, now time.Time) (time.Time, error) {
+	obs, err := g.Store.GetNoCIObservation(ctx, repoFullName, pullRequest)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, err
+	}
+	if err == nil && obs.HeadSHA == headSHA {
+		if firstZero, parseErr := time.Parse(time.RFC3339Nano, obs.FirstZeroAt); parseErr == nil {
+			return firstZero, nil
+		}
+		// Corrupt timestamp: fall through to re-record `now`.
+	}
+	if recordErr := g.Store.UpsertNoCIObservation(ctx, db.NoCIObservation{
+		RepoFullName: repoFullName,
+		PullRequest:  pullRequest,
+		HeadSHA:      headSHA,
+		FirstZeroAt:  now.Format(time.RFC3339Nano),
+	}); recordErr != nil {
+		return time.Time{}, recordErr
+	}
+	return now, nil
 }
 
 // headHasWorkflows reports whether the head tree carries a `.github/workflows/`
@@ -775,6 +831,13 @@ func (g PolicyMergeGate) recordMerged(ctx context.Context, request MergeRequest,
 
 type mergeBlocked struct {
 	reason string
+	// class, when non-zero (MergeBlockNone), overrides the default MergeBlockQuality
+	// classification the ensureStatuses handler assigns a mergeBlocked. It lets the
+	// require_external_ci empty-gate block surface as MergeBlockTransient so the
+	// trace-harvester does not score an absent-CI/operator-policy condition as a
+	// template-quality negative (#465 INFRA-NOISE-FILTERED). Zero means "use the
+	// default classification for this error site".
+	class MergeBlockClass
 }
 
 type mergePending struct {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -53,6 +53,43 @@ type PolicyMergeGate struct {
 	CheckoutPath string
 	DeleteBranch bool
 	MergeMethod  string
+	// RequireExternalCI hard-blocks a merge whose head reports zero external CI
+	// instead of ever stamping the synthetic gitmoot/ci success (#596, layer 3 —
+	// the [merge_gate] require_external_ci knob). Default false.
+	RequireExternalCI bool
+	// MinCIWait is the grace window between the first and second consecutive
+	// zero-external observation at the same head before the gate concludes no-CI
+	// (#596, layer 1). Zero means use the built-in default (defaultMinCIWait).
+	MinCIWait time.Duration
+	// Clock is injectable for deterministic tests. Nil means time.Now.
+	Clock func() time.Time
+}
+
+// defaultMinCIWait is the built-in grace window used when MinCIWait is unset. It
+// mirrors config.DefaultMinCIWait; the workflow package keeps its own copy to
+// avoid a config import cycle.
+const defaultMinCIWait = 60 * time.Second
+
+func (g PolicyMergeGate) now() time.Time {
+	if g.Clock != nil {
+		return g.Clock()
+	}
+	return time.Now().UTC()
+}
+
+func (g PolicyMergeGate) minCIWait() time.Duration {
+	if g.MinCIWait > 0 {
+		return g.MinCIWait
+	}
+	return defaultMinCIWait
+}
+
+// workflowAwareGitHub is an OPTIONAL capability the merge gate probes for on its
+// GitHub client (#596, layer 2). The real *github.GhClient implements it; a
+// client that does not is treated as "workflows unknown", which fails safe
+// toward the grace path (never toward an instant no-CI stamp).
+type workflowAwareGitHub interface {
+	WorkflowsExistAtRef(ctx context.Context, repo github.Repository, ref string) (bool, error)
 }
 
 func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (MergeDecision, error) {
@@ -530,16 +567,124 @@ func (g PolicyMergeGate) ensureStatuses(ctx context.Context, repo github.Reposit
 		}
 	}
 	if externalCheckCount == 0 && externalStatusCount == 0 {
-		_, err := g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
-			Repo:        repo,
-			SHA:         headSHA,
-			State:       "success",
-			Context:     gitmootNoCIContext,
-			Description: "No external CI reported",
-		})
-		return err
+		return g.concludeNoExternalCI(ctx, repo, pullRequest, headSHA)
 	}
 	return nil
+}
+
+// concludeNoExternalCI is the layered defense for the #596 no-CI race. When a
+// head reports zero external commit-statuses AND zero check-runs, it decides —
+// across daemon polls — whether that truly means "this repo has no CI" or merely
+// "GitHub Actions has not created the run yet".
+//
+// Layer 3 (require_external_ci): if the operator requires external CI, an empty
+// gate hard-blocks rather than ever stamping gitmoot/ci.
+//
+// Layer 2 (workflow-awareness): if `.github/workflows/` demonstrably exists at
+// the head tree, a zero observation means Actions is lagging, so the gate never
+// concludes no-CI (stays pending). A read error fails SAFE toward the grace path
+// (treated as workflows-unknown), never toward an instant stamp.
+//
+// Layer 1 (grace deferral): otherwise, require TWO consecutive zero-external
+// observations at the SAME head, at least MinCIWait apart, before stamping the
+// synthetic gitmoot/ci success. The first observation (head SHA + time) is
+// persisted; a new head resets it. The gate is retried every daemon poll, so a
+// pending return is cheap and a genuinely CI-less repo merges exactly one grace
+// window later.
+func (g PolicyMergeGate) concludeNoExternalCI(ctx context.Context, repo github.Repository, pullRequest int64, headSHA string) error {
+	shortHead := shortSHA(headSHA)
+
+	// Layer 3: operator requires external CI — never stamp the empty gate.
+	if g.RequireExternalCI {
+		return mergeBlocked{reason: fmt.Sprintf("merge gate requires external CI but head %s reports none; set [merge_gate] require_external_ci = false to allow no-CI merges, or ensure the CI workflow runs on this pull request", shortHead)}
+	}
+
+	// Layer 2: the repo demonstrably has workflows at this head — a zero
+	// observation is an Actions creation lag, not a CI-less repo.
+	if g.headHasWorkflows(ctx, repo, headSHA) {
+		return mergePending{reason: fmt.Sprintf("repository has GitHub Actions workflows but no check run has appeared yet at head %s; waiting for CI to be created", shortHead)}
+	}
+
+	// Layer 1: grace deferral — need a second zero-external observation at the same
+	// head, at least MinCIWait later, before concluding no external CI.
+	repoFullName := repo.FullName()
+	now := g.now()
+	obs, err := g.Store.GetNoCIObservation(ctx, repoFullName, pullRequest)
+	switch {
+	case errors.Is(err, sql.ErrNoRows) || obs.HeadSHA != headSHA:
+		// First zero observation at this head (or the head changed): record & defer.
+		if recordErr := g.Store.UpsertNoCIObservation(ctx, db.NoCIObservation{
+			RepoFullName: repoFullName,
+			PullRequest:  pullRequest,
+			HeadSHA:      headSHA,
+			FirstZeroAt:  now.Format(time.RFC3339Nano),
+		}); recordErr != nil {
+			return recordErr
+		}
+		return mergePending{reason: fmt.Sprintf("waiting to confirm no external CI at head %s; will re-check after the grace window in case GitHub Actions is still creating the run", shortHead)}
+	case err != nil:
+		return err
+	}
+
+	firstZero, parseErr := time.Parse(time.RFC3339Nano, obs.FirstZeroAt)
+	if parseErr != nil {
+		// A corrupt timestamp must fail SAFE toward the grace path: re-record and
+		// defer rather than instant-stamp.
+		if recordErr := g.Store.UpsertNoCIObservation(ctx, db.NoCIObservation{
+			RepoFullName: repoFullName,
+			PullRequest:  pullRequest,
+			HeadSHA:      headSHA,
+			FirstZeroAt:  now.Format(time.RFC3339Nano),
+		}); recordErr != nil {
+			return recordErr
+		}
+		return mergePending{reason: fmt.Sprintf("re-confirming no external CI at head %s after an unreadable observation timestamp", shortHead)}
+	}
+
+	if now.Sub(firstZero) < g.minCIWait() {
+		return mergePending{reason: fmt.Sprintf("waiting to confirm no external CI at head %s; grace window has not elapsed since the first zero observation", shortHead)}
+	}
+
+	// Two consecutive zero-external observations at the same head, grace elapsed:
+	// this repo genuinely reports no external CI at this head.
+	_, err = g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
+		Repo:        repo,
+		SHA:         headSHA,
+		State:       "success",
+		Context:     gitmootNoCIContext,
+		Description: "No external CI reported",
+	})
+	return err
+}
+
+// headHasWorkflows reports whether the head tree carries a `.github/workflows/`
+// directory (#596, layer 2). It probes the OPTIONAL workflowAwareGitHub
+// capability and caches the immutable per-head result. A client without the
+// capability, or a read error, returns false so the caller falls through to the
+// grace path — the fail-safe direction (never an instant no-CI stamp).
+func (g PolicyMergeGate) headHasWorkflows(ctx context.Context, repo github.Repository, headSHA string) bool {
+	aware, ok := g.GitHub.(workflowAwareGitHub)
+	if !ok {
+		return false
+	}
+	if present, cached := lookupWorkflowPresence(repo.FullName(), headSHA); cached {
+		return present
+	}
+	present, err := aware.WorkflowsExistAtRef(ctx, repo, headSHA)
+	if err != nil {
+		// Fail safe toward grace; do NOT cache a transient error.
+		return false
+	}
+	storeWorkflowPresence(repo.FullName(), headSHA, present)
+	return present
+}
+
+func shortSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
 }
 
 func reviewRoundAfter(left string, right string) bool {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -610,9 +610,12 @@ func (g PolicyMergeGate) concludeNoExternalCI(ctx context.Context, repo github.R
 	repoFullName := repo.FullName()
 	now := g.now()
 	obs, err := g.Store.GetNoCIObservation(ctx, repoFullName, pullRequest)
-	switch {
-	case errors.Is(err, sql.ErrNoRows) || obs.HeadSHA != headSHA:
-		// First zero observation at this head (or the head changed): record & defer.
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	if errors.Is(err, sql.ErrNoRows) || obs.HeadSHA != headSHA {
+		// First zero observation at this head (no prior row, or the head changed):
+		// record & defer.
 		if recordErr := g.Store.UpsertNoCIObservation(ctx, db.NoCIObservation{
 			RepoFullName: repoFullName,
 			PullRequest:  pullRequest,
@@ -622,8 +625,6 @@ func (g PolicyMergeGate) concludeNoExternalCI(ctx context.Context, repo github.R
 			return recordErr
 		}
 		return mergePending{reason: fmt.Sprintf("waiting to confirm no external CI at head %s; will re-check after the grace window in case GitHub Actions is still creating the run", shortHead)}
-	case err != nil:
-		return err
 	}
 
 	firstZero, parseErr := time.Parse(time.RFC3339Nano, obs.FirstZeroAt)

--- a/internal/workflow/merge_gate_cache.go
+++ b/internal/workflow/merge_gate_cache.go
@@ -1,0 +1,48 @@
+package workflow
+
+import "sync"
+
+// workflowPresence caches the per-head result of the #596 layer-2 workflow-
+// awareness lookup (does `.github/workflows/` exist at this head SHA). A head SHA
+// is immutable, so a cached answer never goes stale; caching it means the merge
+// gate makes at most one contents read per head across the many daemon polls that
+// re-evaluate a PR stuck in the no-CI grace window. It is process-global because
+// the daemon rebuilds the PolicyMergeGate value on every evaluation.
+var workflowPresence = struct {
+	sync.Mutex
+	byHead map[string]bool
+}{byHead: map[string]bool{}}
+
+// workflowPresenceCap bounds the cache so a long-lived daemon cannot grow it
+// without limit. On overflow the whole map is dropped (a subsequent lookup simply
+// re-reads from GitHub — correctness is unaffected since the key is an immutable
+// SHA).
+const workflowPresenceCap = 4096
+
+func workflowPresenceKey(repoFullName string, headSHA string) string {
+	return repoFullName + "@" + headSHA
+}
+
+func lookupWorkflowPresence(repoFullName string, headSHA string) (present bool, cached bool) {
+	workflowPresence.Lock()
+	defer workflowPresence.Unlock()
+	present, cached = workflowPresence.byHead[workflowPresenceKey(repoFullName, headSHA)]
+	return present, cached
+}
+
+func storeWorkflowPresence(repoFullName string, headSHA string, present bool) {
+	workflowPresence.Lock()
+	defer workflowPresence.Unlock()
+	if len(workflowPresence.byHead) >= workflowPresenceCap {
+		workflowPresence.byHead = map[string]bool{}
+	}
+	workflowPresence.byHead[workflowPresenceKey(repoFullName, headSHA)] = present
+}
+
+// resetWorkflowPresenceCache clears the cache. It exists for deterministic tests
+// that assert on the number of workflow-awareness reads.
+func resetWorkflowPresenceCache() {
+	workflowPresence.Lock()
+	defer workflowPresence.Unlock()
+	workflowPresence.byHead = map[string]bool{}
+}

--- a/internal/workflow/merge_gate_noci_race_test.go
+++ b/internal/workflow/merge_gate_noci_race_test.go
@@ -1,0 +1,336 @@
+package workflow
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+// workflowAwareFakeGitHub extends fakeMergeGateGitHub with the OPTIONAL #596
+// layer-2 workflow-awareness capability so tests can exercise the ".github/
+// workflows exists at head" path (and its error/fail-safe branch).
+type workflowAwareFakeGitHub struct {
+	*fakeMergeGateGitHub
+	workflowsExist bool
+	workflowsErr   error
+	workflowCalls  int
+}
+
+func (f *workflowAwareFakeGitHub) WorkflowsExistAtRef(context.Context, github.Repository, string) (bool, error) {
+	f.workflowCalls++
+	if f.workflowsErr != nil {
+		return false, f.workflowsErr
+	}
+	return f.workflowsExist, nil
+}
+
+// setupApprovedNoCIPR wires the minimum state for a mergeable, review-approved PR
+// whose head reports ZERO external CI (only the gitmoot/merge-gate contexts,
+// which the gate skips). It is the shared fixture for the no-CI race tests.
+func setupApprovedNoCIPR(t *testing.T, store *db.Store, headSHA string) *fakeMergeGateGitHub {
+	t.Helper()
+	ctx := context.Background()
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "jerryfane/noted", Branch: "task-11", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "jerryfane/noted",
+		Branch:      "task-11",
+		PullRequest: 11,
+		HeadSHA:     headSHA,
+		TaskID:      "task-11",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	return &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number:    11,
+			Title:     "Task 11",
+			State:     "open",
+			URL:       "https://github.com/jerryfane/noted/pull/11",
+			HeadRef:   "task-11",
+			BaseRef:   "main",
+			HeadSHA:   headSHA,
+			Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success"},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge-11"},
+	}
+}
+
+func noCIRequest() MergeRequest {
+	return MergeRequest{Repo: "jerryfane/noted", PullRequest: 11, TaskID: "task-11", Reviewer: "audit"}
+}
+
+// TestPolicyMergeGateNoCIRaceDefersThenRequiresLateCheck is the #596 regression:
+// evaluation 1 sees zero external statuses/checks (the GitHub Actions creation-lag
+// window); a check-run APPEARS before evaluation 2 (as in the live table where the
+// run was created 2s after the old code stamped gitmoot/ci). With the grace fix,
+// evaluation 1 defers (mergePending) instead of stamping gitmoot/ci and merging
+// unguarded, so evaluation 2 observes and requires the check that has since
+// appeared — and the PR merges only after the check passes.
+func TestPolicyMergeGateNoCIRaceDefersThenRequiresLateCheck(t *testing.T) {
+	resetWorkflowPresenceCache()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	gh := setupApprovedNoCIPR(t, store, "d342f97")
+	clock := &fakeClock{now: time.Date(2026, 7, 1, 22, 23, 32, 0, time.UTC)}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, Clock: clock.Now}
+
+	// Evaluation 1: zero external CI in the Actions lag window -> defer, do NOT
+	// stamp gitmoot/ci, do NOT merge.
+	d1, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 1 returned error: %v", err)
+	}
+	if d1.Merged {
+		t.Fatal("evaluation 1 merged in the Actions lag window — the #596 race is not closed")
+	}
+	if !d1.Ready || !strings.Contains(d1.Reason, "waiting to confirm no external CI") {
+		t.Fatalf("evaluation 1 decision = %+v, want pending waiting-to-confirm", d1)
+	}
+	if hasStatus(gh.statuses, gitmootNoCIContext, "success") {
+		t.Fatalf("evaluation 1 stamped gitmoot/ci — the empty gate must defer, statuses=%+v", gh.statuses)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("evaluation 1 issued a merge, merges=%+v", gh.merges)
+	}
+
+	// The CI check-run appears (pending) between evaluations, exactly as observed
+	// live 2s after the old stamp.
+	gh.checks = []github.PullRequestCheck{{Name: "ci", Bucket: "pending", State: "IN_PROGRESS"}}
+	clock.advance(2 * time.Second)
+
+	// Evaluation 2: the now-visible check gates the merge (pending), still no merge
+	// and still no synthetic gitmoot/ci stamp.
+	d2, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 2 returned error: %v", err)
+	}
+	if d2.Merged {
+		t.Fatal("evaluation 2 merged while the external CI check was pending")
+	}
+	if !strings.Contains(d2.Reason, "pending") {
+		t.Fatalf("evaluation 2 decision = %+v, want pending-on-external-check", d2)
+	}
+	if hasStatus(gh.statuses, gitmootNoCIContext, "success") {
+		t.Fatalf("evaluation 2 stamped gitmoot/ci despite a visible check, statuses=%+v", gh.statuses)
+	}
+
+	// The check passes; the PR merges — gated by real CI, never through an empty gate.
+	gh.checks = []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}}
+	clock.advance(5 * time.Second)
+	d3, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 3 returned error: %v", err)
+	}
+	if !d3.Merged {
+		t.Fatalf("evaluation 3 decision = %+v, want merged after CI passed", d3)
+	}
+	if hasStatus(gh.statuses, gitmootNoCIContext, "success") {
+		t.Fatalf("gitmoot/ci was stamped even though real CI existed, statuses=%+v", gh.statuses)
+	}
+}
+
+// TestPolicyMergeGateNoCIMergesAfterGraceWindow pins that a GENUINELY CI-less repo
+// still merges — one grace window later. The first evaluation records the zero
+// observation and defers; the second, past MinCIWait with the head unchanged and
+// still zero external CI, concludes no-CI, stamps gitmoot/ci, and merges.
+func TestPolicyMergeGateNoCIMergesAfterGraceWindow(t *testing.T) {
+	resetWorkflowPresenceCache()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	gh := setupApprovedNoCIPR(t, store, "cico001")
+	clock := &fakeClock{now: time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, Clock: clock.Now}
+
+	d1, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 1 returned error: %v", err)
+	}
+	if d1.Merged {
+		t.Fatal("evaluation 1 merged before the grace window elapsed")
+	}
+	obs, err := store.GetNoCIObservation(ctx, "jerryfane/noted", 11)
+	if err != nil {
+		t.Fatalf("expected a recorded observation after evaluation 1: %v", err)
+	}
+	if obs.HeadSHA != "cico001" {
+		t.Fatalf("observation head = %q, want cico001", obs.HeadSHA)
+	}
+
+	clock.advance(90 * time.Second) // past MinCIWait
+	d2, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 2 returned error: %v", err)
+	}
+	if !d2.Merged {
+		t.Fatalf("evaluation 2 decision = %+v, want merged after the grace window", d2)
+	}
+	if !hasStatus(gh.statuses, gitmootNoCIContext, "success") {
+		t.Fatalf("genuinely CI-less repo should stamp gitmoot/ci once, statuses=%+v", gh.statuses)
+	}
+}
+
+// TestPolicyMergeGateNoCIObservationResetsOnNewHead pins that a fresh head between
+// the two observations restarts the grace window: the gate never merges off the
+// old head's clock even after MinCIWait has elapsed.
+func TestPolicyMergeGateNoCIObservationResetsOnNewHead(t *testing.T) {
+	resetWorkflowPresenceCache()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	gh := setupApprovedNoCIPR(t, store, "headAAA")
+	clock := &fakeClock{now: time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, Clock: clock.Now}
+
+	if _, err := gate.Evaluate(ctx, noCIRequest()); err != nil {
+		t.Fatalf("evaluation 1 returned error: %v", err)
+	}
+
+	// A new head is pushed AND the grace window elapses. The gate must NOT merge:
+	// the observation belongs to the old head, so this counts as a fresh first
+	// observation for headBBB.
+	clock.advance(90 * time.Second)
+	gh.pr.HeadSHA = "headBBB"
+	// The review must also match the new head for the gate to reach ensureStatuses.
+	insertCompletedJob(t, store, db.Job{ID: "review-job-2", Agent: "audit", Type: "review"}, JobPayload{
+		Repo: "jerryfane/noted", Branch: "task-11", PullRequest: 11, HeadSHA: "headBBB", TaskID: "task-11",
+		ReviewRound: "review-2", Result: &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+
+	d2, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 2 returned error: %v", err)
+	}
+	if d2.Merged {
+		t.Fatal("evaluation 2 merged off the stale head's grace clock — the observation did not reset on the new head")
+	}
+	obs, err := store.GetNoCIObservation(ctx, "jerryfane/noted", 11)
+	if err != nil {
+		t.Fatalf("GetNoCIObservation returned error: %v", err)
+	}
+	if obs.HeadSHA != "headBBB" {
+		t.Fatalf("observation head = %q, want reset to headBBB", obs.HeadSHA)
+	}
+
+	// One grace window past the reset at the new head -> merges.
+	clock.advance(90 * time.Second)
+	d3, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 3 returned error: %v", err)
+	}
+	if !d3.Merged {
+		t.Fatalf("evaluation 3 decision = %+v, want merged one grace window after the new-head reset", d3)
+	}
+}
+
+// TestPolicyMergeGateWorkflowAwarenessNeverConcludesNoCI pins layer 2: when the
+// head tree demonstrably carries .github/workflows, a zero-external observation is
+// an Actions creation lag, so the gate NEVER concludes no-CI — even long past the
+// grace window — and never stamps gitmoot/ci.
+func TestPolicyMergeGateWorkflowAwarenessNeverConcludesNoCI(t *testing.T) {
+	resetWorkflowPresenceCache()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	base := setupApprovedNoCIPR(t, store, "wfhead1")
+	gh := &workflowAwareFakeGitHub{fakeMergeGateGitHub: base, workflowsExist: true}
+	clock := &fakeClock{now: time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC)}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, Clock: clock.Now}
+
+	for i, wait := range []time.Duration{0, 5 * time.Minute, 30 * time.Minute} {
+		clock.advance(wait)
+		d, err := gate.Evaluate(ctx, noCIRequest())
+		if err != nil {
+			t.Fatalf("evaluation %d returned error: %v", i+1, err)
+		}
+		if d.Merged {
+			t.Fatalf("evaluation %d merged a workflow-configured repo with no check run yet", i+1)
+		}
+		if !strings.Contains(d.Reason, "workflows") {
+			t.Fatalf("evaluation %d reason = %q, want a workflow-awareness pending reason", i+1, d.Reason)
+		}
+	}
+	if hasStatus(base.statuses, gitmootNoCIContext, "success") {
+		t.Fatalf("workflow-aware repo stamped gitmoot/ci, statuses=%+v", base.statuses)
+	}
+	if gh.workflowCalls != 1 {
+		t.Fatalf("workflow-awareness reads = %d, want 1 (cached per head)", gh.workflowCalls)
+	}
+}
+
+// TestPolicyMergeGateWorkflowReadErrorFailsSafeToGrace pins that a FAILED
+// workflow-awareness read fails safe toward the grace path (never an instant
+// stamp): evaluation 1 still defers, and the repo only merges after a second
+// zero observation past the grace window.
+func TestPolicyMergeGateWorkflowReadErrorFailsSafeToGrace(t *testing.T) {
+	resetWorkflowPresenceCache()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	base := setupApprovedNoCIPR(t, store, "wferr01")
+	gh := &workflowAwareFakeGitHub{fakeMergeGateGitHub: base, workflowsErr: errors.New("HTTP 500")}
+	clock := &fakeClock{now: time.Date(2026, 7, 1, 7, 0, 0, 0, time.UTC)}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, Clock: clock.Now}
+
+	d1, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 1 returned error: %v", err)
+	}
+	if d1.Merged {
+		t.Fatal("evaluation 1 merged despite a workflow-read error — must fail safe to grace, not instant-stamp")
+	}
+
+	clock.advance(90 * time.Second)
+	d2, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 2 returned error: %v", err)
+	}
+	if !d2.Merged {
+		t.Fatalf("evaluation 2 decision = %+v, want merged via the grace path after the read error", d2)
+	}
+}
+
+// TestPolicyMergeGateRequireExternalCIHardBlocks pins layer 3: with
+// require_external_ci, an empty gate hard-blocks with an actionable reason rather
+// than ever stamping gitmoot/ci.
+func TestPolicyMergeGateRequireExternalCIHardBlocks(t *testing.T) {
+	resetWorkflowPresenceCache()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	gh := setupApprovedNoCIPR(t, store, "reqci01")
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), RequireExternalCI: true}
+
+	d, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if d.Ready || d.Merged {
+		t.Fatalf("decision = %+v, want a hard block (not ready, not merged)", d)
+	}
+	if !strings.Contains(d.Reason, "requires external CI") {
+		t.Fatalf("block reason = %q, want an actionable require-external-CI message", d.Reason)
+	}
+	if d.BlockClass != MergeBlockQuality {
+		t.Fatalf("block class = %v, want MergeBlockQuality", d.BlockClass)
+	}
+	if hasStatus(gh.statuses, gitmootNoCIContext, "success") {
+		t.Fatalf("require_external_ci stamped gitmoot/ci, statuses=%+v", gh.statuses)
+	}
+	if _, err := store.GetNoCIObservation(ctx, "jerryfane/noted", 11); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("require_external_ci recorded a grace observation; err=%v", err)
+	}
+}
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.now }
+
+func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }

--- a/internal/workflow/merge_gate_noci_race_test.go
+++ b/internal/workflow/merge_gate_noci_race_test.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"strings"
 	"testing"
@@ -231,37 +230,101 @@ func TestPolicyMergeGateNoCIObservationResetsOnNewHead(t *testing.T) {
 	}
 }
 
-// TestPolicyMergeGateWorkflowAwarenessNeverConcludesNoCI pins layer 2: when the
-// head tree demonstrably carries .github/workflows, a zero-external observation is
-// an Actions creation lag, so the gate NEVER concludes no-CI — even long past the
-// grace window — and never stamps gitmoot/ci.
-func TestPolicyMergeGateWorkflowAwarenessNeverConcludesNoCI(t *testing.T) {
+// TestPolicyMergeGateWorkflowAwarenessBoundsPendingThenConcludes pins the bounded
+// layer 2 (#596 review fix): when the head tree demonstrably carries
+// .github/workflows, a zero-external observation is treated as an Actions creation
+// lag and the gate stays pending — but only until MaxCIWait elapses with the head
+// unchanged. Past that bound the workflows demonstrably never produce a check for
+// this head (docs-only under paths filters, tag-only / dispatch-only workflows, a
+// non-targeted branch), so the gate concludes no-CI, stamps gitmoot/ci, and merges
+// instead of wedging forever. This restores the liveness main had while keeping the
+// creation-lag protection.
+func TestPolicyMergeGateWorkflowAwarenessBoundsPendingThenConcludes(t *testing.T) {
 	resetWorkflowPresenceCache()
 	ctx := context.Background()
 	store := openEngineStore(t)
 	base := setupApprovedNoCIPR(t, store, "wfhead1")
 	gh := &workflowAwareFakeGitHub{fakeMergeGateGitHub: base, workflowsExist: true}
 	clock := &fakeClock{now: time.Date(2026, 7, 1, 8, 0, 0, 0, time.UTC)}
-	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, Clock: clock.Now}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, MaxCIWait: 10 * time.Minute, Clock: clock.Now}
 
-	for i, wait := range []time.Duration{0, 5 * time.Minute, 30 * time.Minute} {
+	// Within the MaxCIWait bound: stay pending on the workflow-awareness reason and
+	// never stamp gitmoot/ci, even well past the (shorter) grace window.
+	for i, wait := range []time.Duration{0, 5 * time.Minute} {
 		clock.advance(wait)
 		d, err := gate.Evaluate(ctx, noCIRequest())
 		if err != nil {
 			t.Fatalf("evaluation %d returned error: %v", i+1, err)
 		}
 		if d.Merged {
-			t.Fatalf("evaluation %d merged a workflow-configured repo with no check run yet", i+1)
+			t.Fatalf("evaluation %d merged a workflow-configured repo inside the CI-creation bound", i+1)
 		}
 		if !strings.Contains(d.Reason, "workflows") {
 			t.Fatalf("evaluation %d reason = %q, want a workflow-awareness pending reason", i+1, d.Reason)
 		}
+		if hasStatus(base.statuses, gitmootNoCIContext, "success") {
+			t.Fatalf("evaluation %d stamped gitmoot/ci inside the CI-creation bound, statuses=%+v", i+1, base.statuses)
+		}
 	}
-	if hasStatus(base.statuses, gitmootNoCIContext, "success") {
-		t.Fatalf("workflow-aware repo stamped gitmoot/ci, statuses=%+v", base.statuses)
+
+	// Past MaxCIWait with the head unchanged and still zero external CI: the gate
+	// falls through, stamps gitmoot/ci once, and merges (liveness restored).
+	clock.advance(6 * time.Minute) // total ~11m > MaxCIWait
+	d, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("final evaluation returned error: %v", err)
+	}
+	if !d.Merged {
+		t.Fatalf("final evaluation decision = %+v, want merged after the CI-creation bound elapsed", d)
+	}
+	if !hasStatus(base.statuses, gitmootNoCIContext, "success") {
+		t.Fatalf("bounded workflow-aware repo should stamp gitmoot/ci once past MaxCIWait, statuses=%+v", base.statuses)
 	}
 	if gh.workflowCalls != 1 {
 		t.Fatalf("workflow-awareness reads = %d, want 1 (cached per head)", gh.workflowCalls)
+	}
+}
+
+// TestPolicyMergeGateWorkflowAwarenessRequireExternalCIBlocksAfterBound pins that a
+// workflow-present head under require_external_ci waits out the MaxCIWait bound
+// (rather than hard-blocking during the Actions creation-lag race) and only then
+// hard-blocks — as a TRANSIENT block the harvester ignores, never a gitmoot/ci stamp.
+func TestPolicyMergeGateWorkflowAwarenessRequireExternalCIBlocksAfterBound(t *testing.T) {
+	resetWorkflowPresenceCache()
+	ctx := context.Background()
+	store := openEngineStore(t)
+	base := setupApprovedNoCIPR(t, store, "wfreq01")
+	gh := &workflowAwareFakeGitHub{fakeMergeGateGitHub: base, workflowsExist: true}
+	clock := &fakeClock{now: time.Date(2026, 7, 1, 6, 0, 0, 0, time.UTC)}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, MaxCIWait: 10 * time.Minute, RequireExternalCI: true, Clock: clock.Now}
+
+	// Inside the bound: pending (waiting for CI), NOT a hard block during the race.
+	d1, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 1 returned error: %v", err)
+	}
+	if !d1.Ready || d1.Merged {
+		t.Fatalf("evaluation 1 decision = %+v, want pending (not blocked) inside the CI-creation bound", d1)
+	}
+
+	// Past the bound: hard-block, but as MergeBlockTransient (unharvested) and with
+	// no gitmoot/ci stamp.
+	clock.advance(11 * time.Minute)
+	d2, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 2 returned error: %v", err)
+	}
+	if d2.Ready || d2.Merged {
+		t.Fatalf("evaluation 2 decision = %+v, want a hard block past the bound", d2)
+	}
+	if !strings.Contains(d2.Reason, "requires external CI") {
+		t.Fatalf("evaluation 2 reason = %q, want a require-external-CI message", d2.Reason)
+	}
+	if d2.BlockClass != MergeBlockTransient {
+		t.Fatalf("evaluation 2 block class = %v, want MergeBlockTransient (unharvested)", d2.BlockClass)
+	}
+	if hasStatus(base.statuses, gitmootNoCIContext, "success") {
+		t.Fatalf("require_external_ci stamped gitmoot/ci, statuses=%+v", base.statuses)
 	}
 }
 
@@ -296,34 +359,53 @@ func TestPolicyMergeGateWorkflowReadErrorFailsSafeToGrace(t *testing.T) {
 	}
 }
 
-// TestPolicyMergeGateRequireExternalCIHardBlocks pins layer 3: with
-// require_external_ci, an empty gate hard-blocks with an actionable reason rather
-// than ever stamping gitmoot/ci.
-func TestPolicyMergeGateRequireExternalCIHardBlocks(t *testing.T) {
+// TestPolicyMergeGateRequireExternalCIWaitsThenHardBlocks pins layer 3 (#596 review
+// fix): with require_external_ci and a head with no detectable workflows, an empty
+// gate first WAITS the grace window (rather than hard-blocking during the Actions
+// creation-lag race, which would strand the task in the un-re-driven blocked state
+// and be harvested as a false template negative). Only once the window elapses with
+// still-zero external CI does it hard-block — with an actionable reason, as a
+// TRANSIENT block the harvester ignores, and never stamping gitmoot/ci.
+func TestPolicyMergeGateRequireExternalCIWaitsThenHardBlocks(t *testing.T) {
 	resetWorkflowPresenceCache()
 	ctx := context.Background()
 	store := openEngineStore(t)
 	gh := setupApprovedNoCIPR(t, store, "reqci01")
-	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), RequireExternalCI: true}
+	clock := &fakeClock{now: time.Date(2026, 7, 1, 5, 0, 0, 0, time.UTC)}
+	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}, CheckoutPath: t.TempDir(), MinCIWait: time.Minute, RequireExternalCI: true, Clock: clock.Now}
 
-	d, err := gate.Evaluate(ctx, noCIRequest())
+	// Evaluation 1 (inside the grace window): pending, NOT a hard block — this is the
+	// creation-lag race window #596 targets. No gitmoot/ci stamp, no merge.
+	d1, err := gate.Evaluate(ctx, noCIRequest())
 	if err != nil {
-		t.Fatalf("Evaluate returned error: %v", err)
+		t.Fatalf("evaluation 1 returned error: %v", err)
 	}
-	if d.Ready || d.Merged {
-		t.Fatalf("decision = %+v, want a hard block (not ready, not merged)", d)
+	if !d1.Ready || d1.Merged {
+		t.Fatalf("evaluation 1 decision = %+v, want pending (not a hard block) inside the grace window", d1)
 	}
-	if !strings.Contains(d.Reason, "requires external CI") {
-		t.Fatalf("block reason = %q, want an actionable require-external-CI message", d.Reason)
+	if d1.BlockClass != MergeBlockNone {
+		t.Fatalf("evaluation 1 block class = %v, want MergeBlockNone for a pending decision", d1.BlockClass)
 	}
-	if d.BlockClass != MergeBlockQuality {
-		t.Fatalf("block class = %v, want MergeBlockQuality", d.BlockClass)
+
+	// Evaluation 2 (grace elapsed, still zero external CI): hard block.
+	clock.advance(90 * time.Second)
+	d2, err := gate.Evaluate(ctx, noCIRequest())
+	if err != nil {
+		t.Fatalf("evaluation 2 returned error: %v", err)
+	}
+	if d2.Ready || d2.Merged {
+		t.Fatalf("evaluation 2 decision = %+v, want a hard block (not ready, not merged)", d2)
+	}
+	if !strings.Contains(d2.Reason, "requires external CI") {
+		t.Fatalf("block reason = %q, want an actionable require-external-CI message", d2.Reason)
+	}
+	// Absent-CI + operator policy is an infra/config condition, NOT a template defect:
+	// it must be MergeBlockTransient so the trace-harvester does not score it (#465).
+	if d2.BlockClass != MergeBlockTransient {
+		t.Fatalf("block class = %v, want MergeBlockTransient (unharvested infra/config block)", d2.BlockClass)
 	}
 	if hasStatus(gh.statuses, gitmootNoCIContext, "success") {
 		t.Fatalf("require_external_ci stamped gitmoot/ci, statuses=%+v", gh.statuses)
-	}
-	if _, err := store.GetNoCIObservation(ctx, "jerryfane/noted", 11); !errors.Is(err, sql.ErrNoRows) {
-		t.Fatalf("require_external_ci recorded a grace observation; err=%v", err)
 	}
 }
 

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -45,7 +45,10 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 				{Context: gitmootMergeGateContext, State: "failure"},
 			},
 		},
-		checks:      []github.PullRequestCheck{{Name: gitmootMergeGateContext, Bucket: "fail", State: "FAILURE"}},
+		checks: []github.PullRequestCheck{
+			{Name: gitmootMergeGateContext, Bucket: "fail", State: "FAILURE"},
+			{Name: "ci", Bucket: "pass", State: "SUCCESS"},
+		},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	git := &fakeMergeGateGit{clean: true}
@@ -62,7 +65,10 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	if len(gh.merges) != 1 || gh.merges[0].Method != "squash" || gh.merges[0].MatchHeadCommit != "head123" || !gh.merges[0].DeleteBranch {
 		t.Fatalf("merge inputs = %+v", gh.merges)
 	}
-	if !hasStatus(gh.statuses, gitmootNoCIContext, "success") || !hasStatus(gh.statuses, gitmootMergeGateContext, "success") {
+	// A PR with a passing external check merges through the gate WITHOUT the
+	// synthetic gitmoot/ci no-CI stamp (#596: that stamp is only for genuinely
+	// CI-less heads, and only after the grace window).
+	if !hasStatus(gh.statuses, gitmootMergeGateContext, "success") || hasStatus(gh.statuses, gitmootNoCIContext, "success") {
 		t.Fatalf("statuses = %+v", gh.statuses)
 	}
 	if _, err := store.GetBranchLock(ctx, "jerryfane/gitmoot", "task-9"); !errors.Is(err, sql.ErrNoRows) {
@@ -108,7 +114,7 @@ func TestPolicyMergeGateCleansTaskWorktreeAfterMerge(t *testing.T) {
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	cleaner := &fakeWorktreeCleaner{}
@@ -155,7 +161,7 @@ func TestPolicyMergeGateReportsWorktreeCleanupWarning(t *testing.T) {
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	cleaner := &fakeWorktreeCleaner{err: errors.New("worktree has uncommitted files")}
@@ -199,7 +205,7 @@ func TestPolicyMergeGateDoesNotCleanWorktreeForMismatchedTaskBranch(t *testing.T
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	cleaner := &fakeWorktreeCleaner{}
@@ -248,7 +254,7 @@ func TestPolicyMergeGateLocksCheckoutDuringLocalBaseUpdate(t *testing.T) {
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	git := &fakeMergeGateGit{clean: true, onUpdate: func() {
@@ -298,7 +304,7 @@ func TestPolicyMergeGateReturnsRetryableErrorForBusyCheckout(t *testing.T) {
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, State: "open", URL: "https://github.com/jerryfane/gitmoot/pull/9", HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	git := &fakeMergeGateGit{clean: true}
@@ -354,7 +360,7 @@ func TestPolicyMergeGateDoesNotRecordPreMergeSyntheticSHA(t *testing.T) {
 			MergeSHA:  "synthetic-premerge-sha",
 			Mergeable: &mergeable,
 		},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true},
 	}
 	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
@@ -706,7 +712,7 @@ func TestPolicyMergeGateKeepsQueuedMergePending(t *testing.T) {
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Message: "pull request merge is pending"},
 	}
 	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
@@ -736,7 +742,7 @@ func TestPolicyMergeGateAllowsReviewOptionalPullRequest(t *testing.T) {
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
@@ -843,7 +849,7 @@ func TestPolicyMergeGateUsesLatestNumericReviewRound(t *testing.T) {
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
@@ -910,7 +916,7 @@ func TestPolicyMergeGateBlocksLegacyReviewWithoutHeadSHA(t *testing.T) {
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
@@ -959,7 +965,7 @@ func TestPolicyMergeGateAdvancesIntegrationWorktreeReviewWithoutHeadSHA(t *testi
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr:          github.PullRequest{Number: 9, HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123", Mergeable: &mergeable},
-		status:      github.CombinedStatus{State: "success"},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	gate := PolicyMergeGate{Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -37,15 +37,21 @@ at the same head**, at least `min_ci_wait` (default `60s`) later. The gate is
 re-evaluated every daemon poll, so a genuinely CI-less repo merges exactly one
 grace window later. Two extra guards layer on top:
 
-- **Workflow-aware:** if `.github/workflows/` exists at the head tree, the gate
-  never concludes no-CI from a zero observation — it stays pending until a real
-  check appears (a demonstrably CI-configured repo whose Actions run is merely
-  queued must never merge gatelessly).
+- **Workflow-aware (bounded):** if `.github/workflows/` exists at the head tree,
+  the gate treats a zero observation as an Actions creation lag and stays pending
+  — but only up to `max_ci_wait` (default `10m`) with the head unchanged. Past
+  that bound it concludes no-CI, so a PR whose workflows never produce a check for
+  it (docs-only under paths filters, tag-only / `workflow_dispatch`-only
+  workflows, a non-targeted branch) still merges instead of wedging forever, while
+  the ~seconds creation lag is still covered.
 - **`[merge_gate] require_external_ci`** (global, or per-repo under
   `[repos."owner/repo".merge_gate]`; default `false`): when `true`, an empty gate
-  **hard-blocks** with an actionable reason instead of ever stamping `gitmoot/ci`
-  — use it for repos you know always have CI. Optionally tune `min_ci_wait` in the
-  same section.
+  **hard-blocks** with an actionable reason — *after* the wait window above, never
+  during the creation-lag race — instead of ever stamping `gitmoot/ci`. Use it for
+  repos you know always have CI. The block is classified transient (it is a
+  repo-config/operator-policy condition, not a template defect), so it is not
+  scored against the implement template. Optionally tune `min_ci_wait` /
+  `max_ci_wait` in the same section.
 
 Useful commands:
 

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -24,6 +24,29 @@ conflict. When an **external** system owns the merge decision instead, set
 then **abstains** from its native merge gate — fail-closed, meaning it never
 merges gatelessly; the external gate makes the call.
 
+### No external CI: grace window, not instant pass (#596)
+
+When a PR head reports **zero** external commit-statuses **and** zero check-runs,
+Gitmoot does **not** immediately treat the repo as CI-less and stamp the
+synthetic `gitmoot/ci` success. GitHub Actions creates a check-run a few seconds
+*after* a head is pushed, so a single zero observation cannot distinguish "no CI
+configured" from "CI not created yet" — and a fast approve path could otherwise
+merge inside that window before CI exists. Instead the gate returns **pending**
+and only concludes "no CI" after a **second consecutive zero-external observation
+at the same head**, at least `min_ci_wait` (default `60s`) later. The gate is
+re-evaluated every daemon poll, so a genuinely CI-less repo merges exactly one
+grace window later. Two extra guards layer on top:
+
+- **Workflow-aware:** if `.github/workflows/` exists at the head tree, the gate
+  never concludes no-CI from a zero observation — it stays pending until a real
+  check appears (a demonstrably CI-configured repo whose Actions run is merely
+  queued must never merge gatelessly).
+- **`[merge_gate] require_external_ci`** (global, or per-repo under
+  `[repos."owner/repo".merge_gate]`; default `false`): when `true`, an empty gate
+  **hard-blocks** with an actionable reason instead of ever stamping `gitmoot/ci`
+  — use it for repos you know always have CI. Optionally tune `min_ci_wait` in the
+  same section.
+
 Useful commands:
 
 ```sh

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -198,7 +198,12 @@ mirrors the off-by-default `[events]` stream.
   external CI at head) → **near-neutral** (`soft ≈ 0.5`, `choice = a`), never a
   strong positive. Rewarding an empty gate would optimize toward "merges that
   pass no real CI"; the no-CI guard reads the combined status at the merged head
-  SHA and demotes it.
+  SHA and demotes it. (On the merge side, an empty gate is itself deferred by a
+  grace window — a second zero-external observation at the same head at least
+  `[merge_gate] min_ci_wait` later — plus `.github/workflows/` awareness before it
+  ever stamps `gitmoot/ci` (#596), so this near-neutral band applies only to
+  genuinely CI-less heads. Set `[merge_gate] require_external_ci = true` to
+  hard-block an empty gate instead.)
 - **Blocked at the merge gate** → authoritative gate-fail (`hard = 0`,
   `choice = b`).
 - **Review changes_requested** → graded negative (`choice = b`) whose score


### PR DESCRIPTION
## The race (issue #596)

On a repo **with** a GitHub Actions `ci` workflow, the merge gate merged a PR **before its CI run existed**. `internal/workflow/merge_gate.go` `ensureStatuses` treated a single evaluation that saw **zero** external commit-statuses **AND** zero check-runs as "this repo has no CI", instantly stamped the synthetic `gitmoot/ci` success, and let the merge proceed — but GitHub Actions creates the check-run a few seconds after the head is pushed. A fast approve path (bot reviewer, small fix round) lands the gate inside that creation-lag window and merges unguarded.

## The three-layer defense (all implemented)

1. **Grace deferral (core):** when both external counts are zero, the gate no longer stamps `gitmoot/ci`. It returns `mergePending` and only concludes no-CI after a **second consecutive zero-external observation at the same head, at least `min_ci_wait` apart** (default 60s). The first observation (head SHA + observed-at) is persisted in a new **additive** `merge_gate_ci_observations` table; a **new head resets** it. The gate is re-evaluated every daemon poll, so pending is cheap; a genuinely CI-less repo merges exactly one grace window later.
2. **Workflow-awareness:** one cheap contents read — if `.github/workflows/` exists at the head tree, the gate **never** concludes no-CI (stays pending; Actions just hasn't created the run yet). The lookup is cached per head. A contents-read error **fails safe toward the grace path** (workflows-unknown), never toward an instant stamp.
3. **Config knob:** `[merge_gate] require_external_ci = true` (global or per-repo `[repos."owner/repo".merge_gate]`; default false) → an empty gate **hard-blocks** (`mergeBlocked`, actionable reason) instead of ever stamping `gitmoot/ci`. Wired into the config validate-all path (`internal/config/edit.go`).

## E2E-first + mutation proof

- Deterministic E2E against a fake GitHub client (`internal/workflow/merge_gate_noci_race_test.go`): evaluation 1 sees zero statuses/checks (Actions lag) → `mergePending`, **no** `gitmoot/ci` stamp, **no** merge; a check-run **appears** before evaluation 2 → the gate requires it (pending until it passes; merge only after success). Plus: genuinely CI-less repo merges after the grace window; new head between observations resets the window; workflows-dir-exists never concludes no-CI; workflow-read error fails safe to grace; `require_external_ci=true` hard-blocks with an actionable reason.
- **Race reproduced first:** on unmodified `ensureStatuses` the race test merges unguarded and stamps `gitmoot/ci` (red-as-desired).
- **Mutation proof:** reverting `concludeNoExternalCI` to the instant-stamp turns the race test red.

## Scope

Change lives in `internal/workflow/`, `internal/config/`, `internal/db/` (additive migration), `internal/github/` (one cheap `WorkflowsExistAtRef` read), with **minimal** `internal/cli/daemon.go` call-site wiring only. Docs updated in both trees + the skill references.

Closes #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)
