### PR TITLE
fix(daemon,workflow): eliminate steady-state CPU burn — bounded tick scans, no dispatcher busy-spin, indexed escalation finalize (#598)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2755,28 +2755,72 @@ var errRuntimeSessionBusy = errors.New("runtime session is busy")
 // first busy since it last acquired its runtime lock, or since daemon start — not
 // one per attempt. Before #598 a permanently-contended job wrote a runtime_lock_wait
 // row on EVERY dispatch pass (~76k rows / 56% of the whole job_events table), which
-// then bloated every per-job ListJobEvents scan the retry/recovery passes run. A
-// job id is present in the map while it has an open, already-emitted wait episode;
-// it is cleared when the job actually acquires its runtime lock so the next wait
-// re-emits. In-memory ⇒ resets on daemon start (matching the "since daemon start"
-// episode boundary), and bounded by the number of distinct waiting jobs. Mirrors
-// the preflightWarnByRepo/preflightWarnMu throttle style above.
-var (
-	runtimeLockWaitMu       sync.Mutex
-	runtimeLockWaitEpisodes = map[string]bool{}
+// then bloated every per-job ListJobEvents scan the retry/recovery passes run.
+//
+// The map records, per job id, WHEN that job's episode event was last EMITTED. An
+// episode is "open" (suppress further writes) while an entry exists AND is younger
+// than runtimeLockWaitEpisodeTTL; the id is cleared outright when the job acquires
+// its runtime lock, so the next wait re-emits immediately. For a job that stays
+// contended longer than the TTL the episode re-opens and re-emits at most one event
+// per TTL — a deliberate liveness signal that the wait is still ongoing, not a
+// per-pass flood. Entries also expire: a job that terminates WITHOUT ever acquiring
+// (so endRuntimeLockWaitEpisode never runs for it) leaves a stale entry that ages
+// past the "open" window and is pruned once the map grows beyond
+// runtimeLockWaitEpisodeMax, so terminal-without-acquire jobs can no longer grow the
+// map unboundedly. In-memory ⇒ resets on daemon start (matching the "since daemon
+// start" episode boundary). Mirrors the preflightWarnByRepo/preflightWarnMu throttle
+// style above.
+const (
+	// runtimeLockWaitEpisodeTTL re-opens a still-contended job's wait episode after
+	// this long, so a very long wait re-emits one liveness event per TTL rather than
+	// staying silent forever.
+	runtimeLockWaitEpisodeTTL = 15 * time.Minute
+	// runtimeLockWaitEpisodeMax bounds the episode map: once it exceeds this many
+	// entries, markRuntimeLockWaitEpisode prunes every entry older than the TTL
+	// (terminal-without-acquire leftovers that endRuntimeLockWaitEpisode will never
+	// clear).
+	runtimeLockWaitEpisodeMax = 512
 )
 
-// beginRuntimeLockWaitEpisode reports whether a runtime_lock_wait event should be
-// WRITTEN for jobID now — true exactly once per episode (the first busy bounce),
-// false for every subsequent bounce until endRuntimeLockWaitEpisode clears it.
-func beginRuntimeLockWaitEpisode(jobID string) bool {
+var (
+	runtimeLockWaitMu       sync.Mutex
+	runtimeLockWaitEpisodes = map[string]time.Time{}
+)
+
+// runtimeLockWaitEpisodeOpen reports whether jobID currently has an open, already-
+// emitted wait episode: an entry exists AND its event was emitted within the last
+// runtimeLockWaitEpisodeTTL. It is READ-ONLY — it never mutates the map — so a
+// failed event write (which skips markRuntimeLockWaitEpisode) leaves the episode
+// closed and the next bounce re-attempts the write. Call it BEFORE writing; write
+// the event iff it returns false.
+func runtimeLockWaitEpisodeOpen(jobID string) bool {
 	runtimeLockWaitMu.Lock()
 	defer runtimeLockWaitMu.Unlock()
-	if runtimeLockWaitEpisodes[jobID] {
+	emitted, ok := runtimeLockWaitEpisodes[jobID]
+	if !ok {
 		return false
 	}
-	runtimeLockWaitEpisodes[jobID] = true
-	return true
+	return time.Since(emitted) < runtimeLockWaitEpisodeTTL
+}
+
+// markRuntimeLockWaitEpisode records that a runtime_lock_wait event was just emitted
+// for jobID, opening (or refreshing) its wait episode. Call it ONLY AFTER AddJobEvent
+// succeeds, so a failed write is retried on the next bounce instead of being
+// suppressed. It also opportunistically bounds the map: once it exceeds
+// runtimeLockWaitEpisodeMax entries, every entry older than the TTL is dropped (these
+// are terminal-without-acquire leftovers past their liveness window — a live episode
+// is refreshed on each re-emit and so never ages out here).
+func markRuntimeLockWaitEpisode(jobID string) {
+	runtimeLockWaitMu.Lock()
+	defer runtimeLockWaitMu.Unlock()
+	runtimeLockWaitEpisodes[jobID] = time.Now()
+	if len(runtimeLockWaitEpisodes) > runtimeLockWaitEpisodeMax {
+		for id, emitted := range runtimeLockWaitEpisodes {
+			if time.Since(emitted) >= runtimeLockWaitEpisodeTTL {
+				delete(runtimeLockWaitEpisodes, id)
+			}
+		}
+	}
 }
 
 // endRuntimeLockWaitEpisode clears jobID's wait episode once it acquires its
@@ -2785,16 +2829,6 @@ func endRuntimeLockWaitEpisode(jobID string) {
 	runtimeLockWaitMu.Lock()
 	defer runtimeLockWaitMu.Unlock()
 	delete(runtimeLockWaitEpisodes, jobID)
-}
-
-// resetRuntimeLockWaitEpisodes clears the dedup state. Test-only: the package-global
-// map persists across tests in a package run, so tests that assert a
-// runtime_lock_wait row is written must reset it first (a neighboring test reusing
-// the same job id could otherwise leave an open episode that suppresses the write).
-func resetRuntimeLockWaitEpisodes() {
-	runtimeLockWaitMu.Lock()
-	defer runtimeLockWaitMu.Unlock()
-	runtimeLockWaitEpisodes = map[string]bool{}
 }
 
 type tempWorkerEligibility struct {
@@ -3029,14 +3063,6 @@ func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
 	return runQueuedJobsForRepo(ctx, worker, limit, "", "")
 }
 
-// retryPendingJobAdvancements re-runs the post-delivery workflow for terminal
-// jobs whose advancement previously failed. checkoutHeld (nil ⇒ no gate, the
-// legacy inline-tick behavior) reports whether an in-flight dispatched job
-// currently holds a checkout key: a candidate whose own checkout key is held is
-// skipped this tick (#562 review) — advancement mutates that checkout, and the
-// live path only ever runs it under the job's own key — and retried on a later
-// tick once the key frees, instead of gating ALL retries on whole-repo idleness
-// (which a steady backlog can prevent indefinitely, freezing merge retries).
 // retryPendingJobAdvancements re-fires the post-delivery advancement for any
 // terminal job whose latest advancement event is still an unreconciled attempt
 // marker (advance_started/advance_retry). It is BOUNDED, not a full-table scan
@@ -3047,6 +3073,14 @@ func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
 // marker, and GetJob's just those. Each candidate is then re-verified with the Go
 // predicate jobNeedsAdvanceRetry, so behavior is identical to the old per-job walk;
 // the state/repo/session filters and the checkoutHeld gate are preserved verbatim.
+//
+// checkoutHeld (nil ⇒ no gate, the legacy inline-tick behavior) reports whether an
+// in-flight dispatched job currently holds a checkout key: a candidate whose own
+// checkout key is held is skipped this tick (#562 review) — advancement mutates that
+// checkout, and the live path only ever runs it under the job's own key — and
+// retried on a later tick once the key frees, instead of gating ALL retries on
+// whole-repo idleness (which a steady backlog can prevent indefinitely, freezing
+// merge retries).
 func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool) error {
 	jobIDs, err := worker.Store.JobIDsWithPendingAdvanceRetry(ctx)
 	if err != nil {
@@ -3680,6 +3714,14 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 	// is retried on a later worker tick.
 	bouncedBusy := map[string]bool{}
 	bouncedBusyRuntimes := map[string]bool{}
+	// runtimeKeyMemo caches queuedJobRuntimeResourceKey per job id for the lifetime of
+	// this dispatcher invocation (#615 review). excludeBouncedBusy re-derives the key
+	// for every still-pending job on every dispatch pass, and each miss is a GetAgent
+	// read, so a job that stays pending across N passes otherwise costs N GetAgent
+	// reads. The key is stable while a job sits queued (it depends only on the job's
+	// agent + payload runtime override), so caching it bounds the cost at one read per
+	// job per invocation. Dispatcher-goroutine-owned like the sets above.
+	runtimeKeyMemo := map[string]string{}
 	done := make(chan finished, limit)
 	var firstErr error
 
@@ -3769,7 +3811,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 				// re-incremented for it: once every remaining pending job is
 				// busy-excluded the loop reaches dispatched==0 && running==0 and
 				// returns, so "busy must not count as progress" holds structurally.
-				pending = excludeBouncedBusy(ctx, worker, pending, bouncedBusy, bouncedBusyRuntimes)
+				pending = excludeBouncedBusy(ctx, worker, pending, bouncedBusy, bouncedBusyRuntimes, runtimeKeyMemo)
 				// Union in the supervisor tracker's in-flight keys (#562): a tracked
 				// non-pool job (e.g. dispatched before a warm scheduler flip) must
 				// block same-key pool dispatch exactly like a pool-local one. Jobs
@@ -4050,7 +4092,11 @@ func copyStringSet(src map[string]bool) map[string]bool {
 // and are retried on a later worker tick (a fresh invocation, fresh sets), instead
 // of being re-selected every pass in a tight, event-table-poisoning spin. Empty
 // sets ⇒ pending is returned unchanged, so the no-busy common case pays nothing.
-func excludeBouncedBusy(ctx context.Context, worker jobWorker, pending []db.Job, bouncedIDs, bouncedRuntimes map[string]bool) []db.Job {
+//
+// runtimeKeyMemo caches queuedJobRuntimeResourceKey across the invocation's dispatch
+// passes so each still-pending job costs at most one GetAgent read per invocation
+// (#615 review) rather than one per pass; a nil memo disables caching.
+func excludeBouncedBusy(ctx context.Context, worker jobWorker, pending []db.Job, bouncedIDs, bouncedRuntimes map[string]bool, runtimeKeyMemo map[string]string) []db.Job {
 	if len(bouncedIDs) == 0 && len(bouncedRuntimes) == 0 {
 		return pending
 	}
@@ -4060,13 +4106,29 @@ func excludeBouncedBusy(ctx context.Context, worker jobWorker, pending []db.Job,
 			continue
 		}
 		if len(bouncedRuntimes) > 0 {
-			if rk := queuedJobRuntimeResourceKey(ctx, worker.Store, job); rk != "" && bouncedRuntimes[rk] {
+			if rk := memoizedRuntimeResourceKey(ctx, worker.Store, job, runtimeKeyMemo); rk != "" && bouncedRuntimes[rk] {
 				continue
 			}
 		}
 		kept = append(kept, job)
 	}
 	return kept
+}
+
+// memoizedRuntimeResourceKey returns queuedJobRuntimeResourceKey for job, caching the
+// result in memo keyed by job id so repeated lookups for the same job across a
+// dispatcher invocation's passes reuse the single GetAgent read. A nil memo bypasses
+// the cache and calls through directly.
+func memoizedRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Job, memo map[string]string) string {
+	if memo == nil {
+		return queuedJobRuntimeResourceKey(ctx, store, job)
+	}
+	if key, ok := memo[job.ID]; ok {
+		return key
+	}
+	key := queuedJobRuntimeResourceKey(ctx, store, job)
+	memo[job.ID] = key
+	return key
 }
 
 func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store, job db.Job, selected int) bool {
@@ -4410,10 +4472,11 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		// (#598): a permanently-contended job otherwise wrote one row per dispatch
 		// pass. The busy error is returned UNCONDITIONALLY (outside the episode
 		// gate) so the pool dispatcher still sees the bounce and holds the job back.
-		if beginRuntimeLockWaitEpisode(job.ID) {
+		if !runtimeLockWaitEpisodeOpen(job.ID) {
 			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
 				return eventErr
 			}
+			markRuntimeLockWaitEpisode(job.ID)
 			writeLine(w.Stdout, "job %s waiting: %s", job.ID, message)
 		}
 		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, message)
@@ -5110,10 +5173,11 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		waitMessage := fmt.Sprintf("%s; temp worker start failed: %v", reason, err)
 		// Once per wait episode (#598); busy error returned unconditionally so the
 		// pool dispatcher observes the bounce.
-		if beginRuntimeLockWaitEpisode(job.ID) {
+		if !runtimeLockWaitEpisodeOpen(job.ID) {
 			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: waitMessage}); eventErr != nil {
 				return eventErr
 			}
+			markRuntimeLockWaitEpisode(job.ID)
 			writeLine(w.Stdout, "job %s waiting: %s", job.ID, waitMessage)
 		}
 		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, waitMessage)
@@ -5175,10 +5239,11 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		message := fmt.Sprintf("runtime session %s is busy", lockKey)
 		// Once per wait episode (#598); busy error returned unconditionally so the
 		// pool dispatcher observes the bounce.
-		if beginRuntimeLockWaitEpisode(delegatedJob.ID) {
+		if !runtimeLockWaitEpisodeOpen(delegatedJob.ID) {
 			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: delegatedJob.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
 				return eventErr
 			}
+			markRuntimeLockWaitEpisode(delegatedJob.ID)
 			writeLine(w.Stdout, "job %s waiting: %s", delegatedJob.ID, message)
 		}
 		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, message)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2750,6 +2750,53 @@ const cockpitReconcileInterval = 5 * time.Minute
 
 var errRuntimeSessionBusy = errors.New("runtime session is busy")
 
+// runtimeLockWaitEpisodes dedups the runtime_lock_wait job_event: a job that
+// bounces busy every dispatcher pass records ONE event per wait EPISODE — the
+// first busy since it last acquired its runtime lock, or since daemon start — not
+// one per attempt. Before #598 a permanently-contended job wrote a runtime_lock_wait
+// row on EVERY dispatch pass (~76k rows / 56% of the whole job_events table), which
+// then bloated every per-job ListJobEvents scan the retry/recovery passes run. A
+// job id is present in the map while it has an open, already-emitted wait episode;
+// it is cleared when the job actually acquires its runtime lock so the next wait
+// re-emits. In-memory ⇒ resets on daemon start (matching the "since daemon start"
+// episode boundary), and bounded by the number of distinct waiting jobs. Mirrors
+// the preflightWarnByRepo/preflightWarnMu throttle style above.
+var (
+	runtimeLockWaitMu       sync.Mutex
+	runtimeLockWaitEpisodes = map[string]bool{}
+)
+
+// beginRuntimeLockWaitEpisode reports whether a runtime_lock_wait event should be
+// WRITTEN for jobID now — true exactly once per episode (the first busy bounce),
+// false for every subsequent bounce until endRuntimeLockWaitEpisode clears it.
+func beginRuntimeLockWaitEpisode(jobID string) bool {
+	runtimeLockWaitMu.Lock()
+	defer runtimeLockWaitMu.Unlock()
+	if runtimeLockWaitEpisodes[jobID] {
+		return false
+	}
+	runtimeLockWaitEpisodes[jobID] = true
+	return true
+}
+
+// endRuntimeLockWaitEpisode clears jobID's wait episode once it acquires its
+// runtime lock, so a later wait is recorded as a fresh episode.
+func endRuntimeLockWaitEpisode(jobID string) {
+	runtimeLockWaitMu.Lock()
+	defer runtimeLockWaitMu.Unlock()
+	delete(runtimeLockWaitEpisodes, jobID)
+}
+
+// resetRuntimeLockWaitEpisodes clears the dedup state. Test-only: the package-global
+// map persists across tests in a package run, so tests that assert a
+// runtime_lock_wait row is written must reset it first (a neighboring test reusing
+// the same job id could otherwise leave an open episode that suppresses the write).
+func resetRuntimeLockWaitEpisodes() {
+	runtimeLockWaitMu.Lock()
+	defer runtimeLockWaitMu.Unlock()
+	runtimeLockWaitEpisodes = map[string]bool{}
+}
+
 type tempWorkerEligibility struct {
 	Eligible bool
 	Reason   string
@@ -3624,6 +3671,15 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 	inflightCheckouts := map[string]bool{}
 	inflightRuntimes := map[string]bool{}
 	running := 0
+	// bouncedBusy / bouncedBusyRuntimes track jobs (and their runtime-session keys)
+	// that returned errRuntimeSessionBusy earlier in THIS pool invocation (#598).
+	// A busy job re-queues immediately once reaped, so without this it was
+	// re-selected and re-dispatched every pass in a tight spin (~36 attempts/s,
+	// poisoning job_events with runtime_lock_wait rows). Dispatcher-goroutine-owned
+	// (like inflightCheckouts), so no lock; reset each invocation, so a bounced job
+	// is retried on a later worker tick.
+	bouncedBusy := map[string]bool{}
+	bouncedBusyRuntimes := map[string]bool{}
 	done := make(chan finished, limit)
 	var firstErr error
 
@@ -3668,6 +3724,16 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 		if f.err != nil && firstErr == nil && !errors.Is(f.err, errRuntimeSessionBusy) {
 			firstErr = f.err
 		}
+		// A job that bounced busy must not be re-selected/re-dispatched again in
+		// THIS invocation — by id, and by runtime-session key so every sibling
+		// contending the same busy session is held back too (#598). It stays queued
+		// and is retried on a later worker tick (a fresh invocation with fresh sets).
+		if errors.Is(f.err, errRuntimeSessionBusy) {
+			bouncedBusy[f.jobID] = true
+			if f.runtimeKey != "" {
+				bouncedBusyRuntimes[f.runtimeKey] = true
+			}
+		}
 	}
 
 	for {
@@ -3695,6 +3761,15 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 			if err != nil {
 				firstErr = err
 			} else if slots := poolDispatchSlots(limit, running, hostCap, tracker); slots > 0 {
+				// Drop jobs that already bounced busy this invocation before ANY
+				// selection (#598). pending is fresh each pass and feeds BOTH the
+				// primary selection and the isolation `remaining` loop below, so
+				// filtering it here excludes bounced jobs from both. A bounced job
+				// removed from pending is never re-selected, so dispatched is not
+				// re-incremented for it: once every remaining pending job is
+				// busy-excluded the loop reaches dispatched==0 && running==0 and
+				// returns, so "busy must not count as progress" holds structurally.
+				pending = excludeBouncedBusy(ctx, worker, pending, bouncedBusy, bouncedBusyRuntimes)
 				// Union in the supervisor tracker's in-flight keys (#562): a tracked
 				// non-pool job (e.g. dispatched before a warm scheduler flip) must
 				// block same-key pool dispatch exactly like a pool-local one. Jobs
@@ -3967,6 +4042,31 @@ func copyStringSet(src map[string]bool) map[string]bool {
 		}
 	}
 	return dst
+}
+
+// excludeBouncedBusy drops queued jobs that already bounced errRuntimeSessionBusy
+// earlier in THIS pool invocation — by job id, and by runtime-session key so every
+// job contending the same busy session is held back too (#598). They stay queued
+// and are retried on a later worker tick (a fresh invocation, fresh sets), instead
+// of being re-selected every pass in a tight, event-table-poisoning spin. Empty
+// sets ⇒ pending is returned unchanged, so the no-busy common case pays nothing.
+func excludeBouncedBusy(ctx context.Context, worker jobWorker, pending []db.Job, bouncedIDs, bouncedRuntimes map[string]bool) []db.Job {
+	if len(bouncedIDs) == 0 && len(bouncedRuntimes) == 0 {
+		return pending
+	}
+	kept := pending[:0]
+	for _, job := range pending {
+		if bouncedIDs[job.ID] {
+			continue
+		}
+		if len(bouncedRuntimes) > 0 {
+			if rk := queuedJobRuntimeResourceKey(ctx, worker.Store, job); rk != "" && bouncedRuntimes[rk] {
+				continue
+			}
+		}
+		kept = append(kept, job)
+	}
+	return kept
 }
 
 func (s queuedJobResourceSelector) selects(ctx context.Context, store *db.Store, job db.Job, selected int) bool {
@@ -4306,12 +4406,21 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		} else if strings.TrimSpace(eligibility.Reason) != "" {
 			message = fmt.Sprintf("%s; temp worker ineligible: %s", message, eligibility.Reason)
 		}
-		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
-			return eventErr
+		// Dedup the runtime_lock_wait row + flood log to once per wait episode
+		// (#598): a permanently-contended job otherwise wrote one row per dispatch
+		// pass. The busy error is returned UNCONDITIONALLY (outside the episode
+		// gate) so the pool dispatcher still sees the bounce and holds the job back.
+		if beginRuntimeLockWaitEpisode(job.ID) {
+			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
+				return eventErr
+			}
+			writeLine(w.Stdout, "job %s waiting: %s", job.ID, message)
 		}
-		writeLine(w.Stdout, "job %s waiting: %s", job.ID, message)
 		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, message)
 	}
+	// Acquired the runtime lock: close any open wait episode so a future contention
+	// is recorded as a fresh episode.
+	endRuntimeLockWaitEpisode(job.ID)
 	defer func() {
 		if err := releaseLock(context.Background()); err != nil {
 			writeLine(w.Stdout, "job %s runtime lock release failed: %v", job.ID, err)
@@ -4999,10 +5108,14 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 			return eventErr
 		}
 		waitMessage := fmt.Sprintf("%s; temp worker start failed: %v", reason, err)
-		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: waitMessage}); eventErr != nil {
-			return eventErr
+		// Once per wait episode (#598); busy error returned unconditionally so the
+		// pool dispatcher observes the bounce.
+		if beginRuntimeLockWaitEpisode(job.ID) {
+			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: waitMessage}); eventErr != nil {
+				return eventErr
+			}
+			writeLine(w.Stdout, "job %s waiting: %s", job.ID, waitMessage)
 		}
-		writeLine(w.Stdout, "job %s waiting: %s", job.ID, waitMessage)
 		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, waitMessage)
 	}
 	// A per-delegation timeout on the payload overrides the agent-type job
@@ -5060,12 +5173,19 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 	}
 	if !acquired {
 		message := fmt.Sprintf("runtime session %s is busy", lockKey)
-		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: delegatedJob.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
-			return eventErr
+		// Once per wait episode (#598); busy error returned unconditionally so the
+		// pool dispatcher observes the bounce.
+		if beginRuntimeLockWaitEpisode(delegatedJob.ID) {
+			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: delegatedJob.ID, Kind: "runtime_lock_wait", Message: message}); eventErr != nil {
+				return eventErr
+			}
+			writeLine(w.Stdout, "job %s waiting: %s", delegatedJob.ID, message)
 		}
-		writeLine(w.Stdout, "job %s waiting: %s", delegatedJob.ID, message)
 		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, message)
 	}
+	// Acquired the temp worker's runtime lock (delegatedJob.ID == job.ID; the
+	// delegation keeps the same job id): close any open wait episode.
+	endRuntimeLockWaitEpisode(delegatedJob.ID)
 	defer func() {
 		if err := releaseLock(context.Background()); err != nil {
 			writeLine(w.Stdout, "job %s temp runtime lock release failed: %v", delegatedJob.ID, err)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2990,12 +2990,31 @@ func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
 // live path only ever runs it under the job's own key — and retried on a later
 // tick once the key frees, instead of gating ALL retries on whole-repo idleness
 // (which a steady backlog can prevent indefinitely, freezing merge retries).
+// retryPendingJobAdvancements re-fires the post-delivery advancement for any
+// terminal job whose latest advancement event is still an unreconciled attempt
+// marker (advance_started/advance_retry). It is BOUNDED, not a full-table scan
+// (#598): rather than list EVERY job and re-read each terminal job's full event
+// history (ListJobEvents) on every 1s worker tick — O(jobs × events), which burned
+// a core once a few hundred terminal jobs had accumulated — it asks the store for
+// ONLY the (small) set of jobs whose latest tracked advancement event is a pending
+// marker, and GetJob's just those. Each candidate is then re-verified with the Go
+// predicate jobNeedsAdvanceRetry, so behavior is identical to the old per-job walk;
+// the state/repo/session filters and the checkoutHeld gate are preserved verbatim.
 func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool) error {
-	jobs, err := worker.Store.ListJobs(ctx)
+	jobIDs, err := worker.Store.JobIDsWithPendingAdvanceRetry(ctx)
 	if err != nil {
 		return err
 	}
-	for _, job := range jobs {
+	for _, jobID := range jobIDs {
+		job, err := worker.Store.GetJob(ctx, jobID)
+		if errors.Is(err, sql.ErrNoRows) {
+			// A marker event with no surviving job row (e.g. a pruned job): nothing
+			// to advance, and erroring here would abort the whole tick.
+			continue
+		}
+		if err != nil {
+			return err
+		}
 		if !jobStateCanRetryAdvancement(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
@@ -3245,12 +3264,29 @@ func jobStateCanRetryAdvancement(state string) bool {
 	}
 }
 
+// retryPendingJobComments re-posts the result comment for any terminal job whose
+// latest comment event is comment_post_failed. Like retryPendingJobAdvancements it
+// is BOUNDED (#598): it asks the store for ONLY the jobs whose latest comment event
+// is a failure marker instead of listing EVERY job and re-reading each terminal
+// job's full event history on every 1s worker tick. Each candidate is re-verified
+// with the Go predicate jobNeedsCommentRetry, so behavior is identical. Comment
+// retries never touch a checkout, so (unlike advancements) they take no checkoutHeld
+// gate.
 func retryPendingJobComments(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) error {
-	jobs, err := worker.Store.ListJobs(ctx)
+	jobIDs, err := worker.Store.JobIDsWithPendingCommentRetry(ctx)
 	if err != nil {
 		return err
 	}
-	for _, job := range jobs {
+	for _, jobID := range jobIDs {
+		job, err := worker.Store.GetJob(ctx, jobID)
+		if errors.Is(err, sql.ErrNoRows) {
+			// A marker event with no surviving job row (e.g. a pruned job): skip
+			// rather than abort the tick.
+			continue
+		}
+		if err != nil {
+			return err
+		}
 		if !jobStateCanRetryComment(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -7024,19 +7024,15 @@ func queuePolicyBusyRuntimeStore(t *testing.T) (*db.Store, jobWorker, *int64) {
 	return store, worker, &attempts
 }
 
-func countDaemonWorkerEvents(t *testing.T, store *db.Store, jobID, kind string) int {
-	t.Helper()
-	events, err := store.ListJobEvents(context.Background(), jobID)
-	if err != nil {
-		t.Fatalf("ListJobEvents(%s) returned error: %v", jobID, err)
-	}
-	n := 0
-	for _, e := range events {
-		if e.Kind == kind {
-			n++
-		}
-	}
-	return n
+// resetRuntimeLockWaitEpisodes clears the #598 runtime_lock_wait dedup state. Test-
+// only (it mutates the package-global map), which is why it lives here rather than in
+// daemon.go: the map persists across tests in a package run, so a test that asserts a
+// runtime_lock_wait row is written must reset it first (a neighboring test reusing the
+// same job id could otherwise leave an open episode that suppresses the write).
+func resetRuntimeLockWaitEpisodes() {
+	runtimeLockWaitMu.Lock()
+	defer runtimeLockWaitMu.Unlock()
+	runtimeLockWaitEpisodes = map[string]time.Time{}
 }
 
 // TestRuntimeLockWaitEventDedupedPerEpisode proves the #598 dedup: repeated busy
@@ -7055,7 +7051,7 @@ func TestRuntimeLockWaitEventDedupedPerEpisode(t *testing.T) {
 			t.Fatalf("runQueuedJobs attempt %d returned error: %v", i, err)
 		}
 	}
-	if n := countDaemonWorkerEvents(t, store, "job-a", "runtime_lock_wait"); n != 1 {
+	if n := countWorkerJobEvents(t, store, "job-a", "runtime_lock_wait"); n != 1 {
 		t.Fatalf("runtime_lock_wait rows after 5 busy attempts = %d, want 1 (deduped per episode)", n)
 	}
 
@@ -7064,8 +7060,75 @@ func TestRuntimeLockWaitEventDedupedPerEpisode(t *testing.T) {
 	if err := runQueuedJobs(ctx, worker, 1); err != nil {
 		t.Fatalf("runQueuedJobs after episode end returned error: %v", err)
 	}
-	if n := countDaemonWorkerEvents(t, store, "job-a", "runtime_lock_wait"); n != 2 {
+	if n := countWorkerJobEvents(t, store, "job-a", "runtime_lock_wait"); n != 2 {
 		t.Fatalf("runtime_lock_wait rows after new episode = %d, want 2", n)
+	}
+}
+
+// TestRuntimeLockWaitEpisodeMarkAfterWrite pins the #615-review helper contract
+// directly (no store mocking): the episode is opened only by an explicit mark (which
+// the call sites run ONLY after AddJobEvent succeeds), so a failed write — modeled by
+// simply not calling mark — leaves the episode closed and the next bounce re-attempts
+// the write. Once marked the episode dedups further bounces until its recorded emit
+// ages past the TTL, at which point it re-opens as a liveness re-emit.
+func TestRuntimeLockWaitEpisodeMarkAfterWrite(t *testing.T) {
+	resetRuntimeLockWaitEpisodes()
+	defer resetRuntimeLockWaitEpisodes()
+
+	const jobID = "job-mark-after-write"
+	if runtimeLockWaitEpisodeOpen(jobID) {
+		t.Fatal("episode should be closed before any event is emitted")
+	}
+	// Simulate a FAILED AddJobEvent: the call site would return without marking.
+	// The episode must stay closed so the next bounce retries the write.
+	if runtimeLockWaitEpisodeOpen(jobID) {
+		t.Fatal("episode must stay closed when the event write failed (mark not called)")
+	}
+	// Successful write → mark. Now the episode is open and dedups further bounces.
+	markRuntimeLockWaitEpisode(jobID)
+	if !runtimeLockWaitEpisodeOpen(jobID) {
+		t.Fatal("episode should be open after a successful write is marked")
+	}
+	// Age the recorded emit past the TTL: the episode re-opens (liveness re-emit).
+	runtimeLockWaitMu.Lock()
+	runtimeLockWaitEpisodes[jobID] = time.Now().Add(-2 * runtimeLockWaitEpisodeTTL)
+	runtimeLockWaitMu.Unlock()
+	if runtimeLockWaitEpisodeOpen(jobID) {
+		t.Fatal("episode should re-open once the recorded emit is older than the TTL")
+	}
+}
+
+// TestRuntimeLockWaitEpisodePrunesExpired proves the #615-review map bound: a job that
+// hits contention and then terminates WITHOUT ever acquiring (so
+// endRuntimeLockWaitEpisode never clears its entry) leaves a stale timestamp behind,
+// and mark's over-cap sweep drops it once it is older than the TTL — so such jobs can
+// no longer grow the episode map unboundedly.
+func TestRuntimeLockWaitEpisodePrunesExpired(t *testing.T) {
+	resetRuntimeLockWaitEpisodes()
+	defer resetRuntimeLockWaitEpisodes()
+
+	runtimeLockWaitMu.Lock()
+	// The terminal-without-acquire leftover, emitted long ago.
+	runtimeLockWaitEpisodes["terminal-no-acquire"] = time.Now().Add(-2 * runtimeLockWaitEpisodeTTL)
+	// Fill up to the cap with fresh entries so the next mark pushes len over the
+	// threshold and triggers the expiry sweep.
+	for i := 0; i < runtimeLockWaitEpisodeMax; i++ {
+		runtimeLockWaitEpisodes[fmt.Sprintf("fresh-%d", i)] = time.Now()
+	}
+	runtimeLockWaitMu.Unlock()
+
+	// This mark takes len past runtimeLockWaitEpisodeMax, triggering the sweep.
+	markRuntimeLockWaitEpisode("trigger")
+
+	runtimeLockWaitMu.Lock()
+	_, stale := runtimeLockWaitEpisodes["terminal-no-acquire"]
+	_, fresh := runtimeLockWaitEpisodes["fresh-0"]
+	runtimeLockWaitMu.Unlock()
+	if stale {
+		t.Fatal("expected the expired terminal-without-acquire entry to be pruned")
+	}
+	if !fresh {
+		t.Fatal("a still-fresh entry must NOT be pruned (only entries older than the TTL)")
 	}
 }
 
@@ -7096,7 +7159,7 @@ func TestPoolDoesNotRespinRuntimeBusyJob(t *testing.T) {
 	if got := atomic.LoadInt64(attempts); got != 1 {
 		t.Fatalf("dispatch attempts = %d, want exactly 1 (busy job re-selected)", got)
 	}
-	if n := countDaemonWorkerEvents(t, store, "job-a", "runtime_lock_wait"); n != 1 {
+	if n := countWorkerJobEvents(t, store, "job-a", "runtime_lock_wait"); n != 1 {
 		t.Fatalf("runtime_lock_wait rows = %d, want 1", n)
 	}
 	job, err := store.GetJob(ctx, "job-a")

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1628,6 +1629,7 @@ func TestRunQueuedJobsAllowsDifferentRuntimeSessionsAcrossRepos(t *testing.T) {
 }
 
 func TestRunQueuedJobsLeavesBusyRuntimeSessionQueued(t *testing.T) {
+	resetRuntimeLockWaitEpisodes() // #598: the runtime_lock_wait dedup is package-global; a neighbor reusing job-a could otherwise suppress our write.
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	home := t.TempDir()
@@ -1685,6 +1687,7 @@ func TestRunQueuedJobsLeavesBusyRuntimeSessionQueued(t *testing.T) {
 }
 
 func TestRunQueuedJobsDelegatesBusyRuntimeToTempWorker(t *testing.T) {
+	resetRuntimeLockWaitEpisodes() // #598: package-global runtime_lock_wait dedup; reset so a neighbor reusing job-a-merge-back can't suppress our write.
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	checkout := t.TempDir()
@@ -6982,5 +6985,155 @@ func TestRetryPendingJobCommentsBoundedToCandidates(t *testing.T) {
 
 	if len(comments.posted) != 1 || comments.posted[0].issueNumber != 9 {
 		t.Fatalf("posted comments = %+v, want exactly one on PR 9 (the pending candidate)", comments.posted)
+	}
+}
+
+// queuePolicyBusyRuntimeStore builds a worker whose parallel-session policy is
+// "queue" (so a runtime-busy job bounces errRuntimeSessionBusy instead of forking a
+// temp worker) with the codex "audit" agent's runtime session runtime:codex:session-1
+// already externally locked. Each returned dispatch attempt bounces busy. Used by
+// the #598 spin/dedup tests.
+func queuePolicyBusyRuntimeStore(t *testing.T) (*db.Store, jobWorker, *int64) {
+	t.Helper()
+	store := daemonWorkerStore(t)
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	content := strings.Replace(config.DefaultConfig(paths), `same_session = "fork_temp_session"`, `same_session = "queue"`, 1)
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile config returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.CodexRuntime, "session-1", []string{"ask"}, "owner/repo")
+	if acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: "runtime:codex:session-1",
+		OwnerJobID:  "other-job",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	var attempts int64
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		atomic.AddInt64(&attempts, 1)
+		return t.TempDir(), nil
+	}
+	return store, worker, &attempts
+}
+
+func countDaemonWorkerEvents(t *testing.T, store *db.Store, jobID, kind string) int {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s) returned error: %v", jobID, err)
+	}
+	n := 0
+	for _, e := range events {
+		if e.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// TestRuntimeLockWaitEventDedupedPerEpisode proves the #598 dedup: repeated busy
+// dispatch attempts of the same job write exactly ONE runtime_lock_wait row per wait
+// episode, and closing the episode (a successful acquire) lets the next wait record
+// a fresh row.
+func TestRuntimeLockWaitEventDedupedPerEpisode(t *testing.T) {
+	resetRuntimeLockWaitEpisodes()
+	ctx := context.Background()
+	store, worker, _ := queuePolicyBusyRuntimeStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+
+	// Five dispatch attempts, all bounce busy → exactly ONE runtime_lock_wait row.
+	for i := 0; i < 5; i++ {
+		if err := runQueuedJobs(ctx, worker, 1); err != nil {
+			t.Fatalf("runQueuedJobs attempt %d returned error: %v", i, err)
+		}
+	}
+	if n := countDaemonWorkerEvents(t, store, "job-a", "runtime_lock_wait"); n != 1 {
+		t.Fatalf("runtime_lock_wait rows after 5 busy attempts = %d, want 1 (deduped per episode)", n)
+	}
+
+	// A successful acquire closes the episode; the next busy wait is a fresh episode.
+	endRuntimeLockWaitEpisode("job-a")
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs after episode end returned error: %v", err)
+	}
+	if n := countDaemonWorkerEvents(t, store, "job-a", "runtime_lock_wait"); n != 2 {
+		t.Fatalf("runtime_lock_wait rows after new episode = %d, want 2", n)
+	}
+}
+
+// TestPoolDoesNotRespinRuntimeBusyJob proves the #598 spin-stop: a queued job whose
+// runtime session is externally locked bounces busy, and the pool dispatcher must
+// dispatch it at most once per invocation and then RETURN, instead of re-selecting
+// it every pass in a tight spin. Mutation proof: dropping the excludeBouncedBusy
+// call makes the attempt count unbounded (the goroutine below never returns and the
+// wall-clock guard trips).
+func TestPoolDoesNotRespinRuntimeBusyJob(t *testing.T) {
+	resetRuntimeLockWaitEpisodes()
+	ctx := context.Background()
+	store, worker, attempts := queuePolicyBusyRuntimeStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runQueuedJobsForRepoPoolTracked(ctx, worker, 1, 1, "owner/repo", "", nil)
+	}()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runQueuedJobsForRepoPoolTracked returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatalf("pool did not return within 15s (busy job re-spinning); attempts so far = %d", atomic.LoadInt64(attempts))
+	}
+	if got := atomic.LoadInt64(attempts); got != 1 {
+		t.Fatalf("dispatch attempts = %d, want exactly 1 (busy job re-selected)", got)
+	}
+	if n := countDaemonWorkerEvents(t, store, "job-a", "runtime_lock_wait"); n != 1 {
+		t.Fatalf("runtime_lock_wait rows = %d, want 1", n)
+	}
+	job, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued (held for a later tick)", job.State)
+	}
+}
+
+// TestSameSessionSiblingsHeldBackOnBusy proves the #598 runtime-key holdback: two
+// queued jobs share a runtime session; once the first bounces busy, its sibling
+// (same session key) must NOT be dispatched in the same invocation. With only the
+// job-id set (no bouncedBusyRuntimes) the sibling would be dispatched after the
+// first is reaped, giving 2 attempts; the runtime-key holdback keeps it at 1.
+func TestSameSessionSiblingsHeldBackOnBusy(t *testing.T) {
+	resetRuntimeLockWaitEpisodes()
+	ctx := context.Background()
+	store, worker, attempts := queuePolicyBusyRuntimeStore(t)
+	// Both jobs use the same audit agent ⇒ the same runtime:codex:session-1 key.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-a", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 2})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- runQueuedJobsForRepoPoolTracked(ctx, worker, 2, 2, "owner/repo", "", nil)
+	}()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("runQueuedJobsForRepoPoolTracked returned error: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatalf("pool did not return within 15s; attempts so far = %d", atomic.LoadInt64(attempts))
+	}
+	if got := atomic.LoadInt64(attempts); got != 1 {
+		t.Fatalf("dispatch attempts = %d, want exactly 1 (same-session sibling must be held back)", got)
 	}
 }

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -6819,3 +6819,168 @@ func TestBuildAskGateComment(t *testing.T) {
 		t.Fatalf("ask-gate comment parsed into %d command(s); want 0: %+v\nbody:\n%s", len(cmds), cmds, body)
 	}
 }
+
+// TestRetryPendingJobAdvancementsBoundedToCandidates proves the bounded (#598)
+// advancement retry pass acts on ONLY the jobs whose latest advancement event is a
+// pending marker: a large backlog of terminal jobs whose advancement already
+// completed is never GetJob'd or advanced, a #602-deferred (state=queued) job with
+// an unresolved advance_started is filtered by state, and a candidate id whose job
+// row was pruned is skipped without aborting the tick.
+func TestRetryPendingJobAdvancementsBoundedToCandidates(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+
+	validPayload := func(pr int) string {
+		encoded, err := json.Marshal(workflow.JobPayload{
+			Repo: "owner/repo", Branch: "task-1", PullRequest: pr, TaskID: "task-1",
+			Result: &workflow.AgentResult{Decision: "approved", Summary: "ok"},
+		})
+		if err != nil {
+			t.Fatalf("Marshal payload returned error: %v", err)
+		}
+		return string(encoded)
+	}
+
+	// Large backlog of terminal jobs whose advancement already reconciled
+	// (advance_started -> advance_completed): NOT candidates.
+	for i := 0; i < 50; i++ {
+		id := "adv-done-" + strconv.Itoa(i)
+		if err := store.CreateJobWithEvent(ctx, db.Job{
+			ID: id, Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded), Payload: validPayload(1000 + i),
+		}, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: "seed"}); err != nil {
+			t.Fatalf("CreateJobWithEvent(%s) returned error: %v", id, err)
+		}
+		for _, kind := range []string{"advance_started", "advance_completed", "queued"} {
+			if err := store.AddJobEvent(ctx, db.JobEvent{JobID: id, Kind: kind, Message: "noise"}); err != nil {
+				t.Fatalf("AddJobEvent returned error: %v", err)
+			}
+		}
+	}
+
+	// The one genuinely-pending advancement (latest tracked event = advance_started).
+	pendingID := "adv-pending"
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: pendingID, Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded), Payload: validPayload(7),
+	}, db.JobEvent{Kind: string(workflow.JobSucceeded), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(pending) returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: pendingID, Kind: "advance_started", Message: "started"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+
+	// #602: a job deferred back to queued still carries an unresolved advance_started
+	// so the candidate query returns it, but the state filter rejects it (identical
+	// to the old ListJobs gate).
+	deferredID := "adv-deferred-queued"
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: deferredID, Agent: "reviewer", Type: "review", State: string(workflow.JobQueued), Payload: validPayload(8),
+	}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(deferred) returned error: %v", err)
+	}
+	for _, kind := range []string{"advance_started", "blocker_deferred"} {
+		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: deferredID, Kind: kind, Message: "m"}); err != nil {
+			t.Fatalf("AddJobEvent returned error: %v", err)
+		}
+	}
+
+	// Pruned row: a candidate marker with no surviving jobs row.
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "adv-pruned-orphan", Kind: "advance_started", Message: "orphan"}); err != nil {
+		t.Fatalf("AddJobEvent(orphan) returned error: %v", err)
+	}
+
+	var advanced []string
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(_ context.Context, job db.Job, _ workflow.JobPayload, _ runtime.Agent) (string, error) {
+		advanced = append(advanced, job.ID)
+		// Short-circuit before any workflow engine call; advanceJob records an
+		// advance_retry event and returns nil. The spy captured the job id, which
+		// is all this bounded-dispatch test asserts.
+		return "", errors.New("stop after capture")
+	}
+
+	if err := retryPendingJobAdvancements(ctx, worker, "owner/repo", "", nil); err != nil {
+		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
+	}
+
+	if len(advanced) != 1 || advanced[0] != pendingID {
+		t.Fatalf("advanceJob reached %v, want exactly [%s]", advanced, pendingID)
+	}
+}
+
+// TestRetryPendingJobCommentsBoundedToCandidates is the comment-retry analogue: the
+// bounded pass re-posts ONLY the jobs whose latest comment event is
+// comment_post_failed, ignoring a backlog of already-posted jobs, a #602-deferred
+// queued job, and a pruned-row candidate.
+func TestRetryPendingJobCommentsBoundedToCandidates(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+
+	payloadFor := func(pr int) string {
+		encoded, err := json.Marshal(workflow.JobPayload{
+			Repo: "owner/repo", Branch: "main", PullRequest: pr,
+			Result: &workflow.AgentResult{Decision: "approved", Summary: "ok"},
+		})
+		if err != nil {
+			t.Fatalf("Marshal payload returned error: %v", err)
+		}
+		return string(encoded)
+	}
+
+	// Backlog of jobs whose comment already posted (failed -> posted): NOT candidates.
+	for i := 0; i < 40; i++ {
+		id := "cmt-done-" + strconv.Itoa(i)
+		if err := store.CreateJobWithEvent(ctx, db.Job{
+			ID: id, Agent: "audit", Type: "ask", State: string(workflow.JobFailed), Payload: payloadFor(2000 + i),
+		}, db.JobEvent{Kind: string(workflow.JobFailed), Message: "seed"}); err != nil {
+			t.Fatalf("CreateJobWithEvent(%s) returned error: %v", id, err)
+		}
+		for _, kind := range []string{"comment_post_failed", "comment_posted"} {
+			if err := store.AddJobEvent(ctx, db.JobEvent{JobID: id, Kind: kind, Message: "noise"}); err != nil {
+				t.Fatalf("AddJobEvent returned error: %v", err)
+			}
+		}
+	}
+
+	// The one genuinely-pending comment retry.
+	pendingID := "cmt-pending"
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: pendingID, Agent: "audit", Type: "ask", State: string(workflow.JobFailed), Payload: payloadFor(9),
+	}, db.JobEvent{Kind: string(workflow.JobFailed), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(pending) returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: pendingID, Kind: "comment_post_failed", Message: "temporary github error"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+
+	// #602: comment_post_failed but state=queued → rejected by state filter.
+	deferredID := "cmt-deferred-queued"
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: deferredID, Agent: "audit", Type: "ask", State: string(workflow.JobQueued), Payload: payloadFor(10),
+	}, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(deferred) returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: deferredID, Kind: "comment_post_failed", Message: "m"}); err != nil {
+		t.Fatalf("AddJobEvent returned error: %v", err)
+	}
+
+	// Pruned row: candidate marker with no surviving job row.
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "cmt-pruned-orphan", Kind: "comment_post_failed", Message: "orphan"}); err != nil {
+		t.Fatalf("AddJobEvent(orphan) returned error: %v", err)
+	}
+
+	comments := &cliPollFakeGitHub{}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CommenterFactory = func(string) github.Client { return comments }
+
+	if err := retryPendingJobComments(ctx, worker, "owner/repo", ""); err != nil {
+		t.Fatalf("retryPendingJobComments returned error: %v", err)
+	}
+
+	if len(comments.posted) != 1 || comments.posted[0].issueNumber != 9 {
+		t.Fatalf("posted comments = %+v, want exactly one on PR 9 (the pending candidate)", comments.posted)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2811,6 +2811,28 @@ func (s *Store) LatestJobEventsOfKinds(ctx context.Context, kinds []string) (map
 	return out, rows.Err()
 }
 
+// jobIDsByQuery runs a query whose rows are each a single job_id column and
+// collects them into a slice. The bounded-candidate passes (#598) and the
+// delegation-worktree reclaim pass all share this identical rows-scan boilerplate;
+// each supplies its own SELECT and defers the row handling here.
+func (s *Store) jobIDsByQuery(ctx context.Context, query string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobIDs []string
+	for rows.Next() {
+		var jobID string
+		if err := rows.Scan(&jobID); err != nil {
+			return nil, err
+		}
+		jobIDs = append(jobIDs, jobID)
+	}
+	return jobIDs, rows.Err()
+}
+
 // JobIDsWithPendingDelegationWorktreeReclaim returns the IDs of jobs whose most
 // recent terminal delegation-worktree cleanup outcome was a PRESERVE
 // (delegation_worktree_cleanup_skipped) NOT yet followed by a removal
@@ -2830,7 +2852,7 @@ func (s *Store) LatestJobEventsOfKinds(ctx context.Context, kinds []string) (map
 // is a skip — exactly mirroring the per-job lastCleanupOutcomeIsSkip walk, but
 // set-at-once.
 func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT job_id FROM job_events
+	return s.jobIDsByQuery(ctx, `SELECT job_id FROM job_events
 		WHERE kind = 'delegation_worktree_cleanup_skipped'
 		  AND id IN (
 			SELECT MAX(id) FROM job_events
@@ -2838,20 +2860,6 @@ func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) 
 			GROUP BY job_id
 		)
 		ORDER BY job_id`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var jobIDs []string
-	for rows.Next() {
-		var jobID string
-		if err := rows.Scan(&jobID); err != nil {
-			return nil, err
-		}
-		jobIDs = append(jobIDs, jobID)
-	}
-	return jobIDs, rows.Err()
 }
 
 // JobIDsWithPendingAdvanceRetry returns the IDs of jobs whose LATEST post-delivery
@@ -2871,7 +2879,7 @@ func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) 
 // switch's default: no-op for every other kind) and the outer filter keeps a job
 // iff that latest tracked event is positive. One row per job (its unique MAX id).
 func (s *Store) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT job_id FROM job_events
+	return s.jobIDsByQuery(ctx, `SELECT job_id FROM job_events
 		WHERE kind IN ('advance_started', 'advance_retry')
 		  AND id IN (
 			SELECT MAX(id) FROM job_events
@@ -2880,20 +2888,6 @@ func (s *Store) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, er
 			GROUP BY job_id
 		)
 		ORDER BY job_id`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var jobIDs []string
-	for rows.Next() {
-		var jobID string
-		if err := rows.Scan(&jobID); err != nil {
-			return nil, err
-		}
-		jobIDs = append(jobIDs, jobID)
-	}
-	return jobIDs, rows.Err()
 }
 
 // JobIDsWithPendingCommentRetry returns the IDs of jobs whose LATEST comment event
@@ -2904,7 +2898,7 @@ func (s *Store) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, er
 // tick (#598). The pass re-verifies each candidate with the Go predicate, so this
 // only has to be a superset; it is in fact exact.
 func (s *Store) JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT job_id FROM job_events
+	return s.jobIDsByQuery(ctx, `SELECT job_id FROM job_events
 		WHERE kind = 'comment_post_failed'
 		  AND id IN (
 			SELECT MAX(id) FROM job_events
@@ -2912,20 +2906,6 @@ func (s *Store) JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, er
 			GROUP BY job_id
 		)
 		ORDER BY job_id`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var jobIDs []string
-	for rows.Next() {
-		var jobID string
-		if err := rows.Scan(&jobID); err != nil {
-			return nil, err
-		}
-		jobIDs = append(jobIDs, jobID)
-	}
-	return jobIDs, rows.Err()
 }
 
 // JobIDsWithOpenEscalation returns the IDs of coordinator jobs with an OPEN
@@ -2945,26 +2925,12 @@ func (s *Store) JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, er
 // strings MUST equal the escalationRequestedEvent/escalationResolvedEvent constants;
 // a store test pins this.
 func (s *Store) JobIDsWithOpenEscalation(ctx context.Context) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT job_id FROM job_events
+	return s.jobIDsByQuery(ctx, `SELECT job_id FROM job_events
 		WHERE kind IN ('delegation_escalation_requested', 'delegation_escalation_resolved')
 		GROUP BY job_id
 		HAVING SUM(CASE WHEN kind = 'delegation_escalation_requested' THEN 1 ELSE 0 END)
 		     > SUM(CASE WHEN kind = 'delegation_escalation_resolved' THEN 1 ELSE 0 END)
 		ORDER BY job_id`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var jobIDs []string
-	for rows.Next() {
-		var jobID string
-		if err := rows.Scan(&jobID); err != nil {
-			return nil, err
-		}
-		jobIDs = append(jobIDs, jobID)
-	}
-	return jobIDs, rows.Err()
 }
 
 func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) error {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2928,6 +2928,45 @@ func (s *Store) JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, er
 	return jobIDs, rows.Err()
 }
 
+// JobIDsWithOpenEscalation returns the IDs of coordinator jobs with an OPEN
+// escalation round — strictly more delegation_escalation_requested than
+// delegation_escalation_resolved events — the same requested>resolved rule
+// Engine.escalationOpen applies per job (engine.go), evaluated set-at-once over
+// idx_job_events_kind. It lets AutoFinalizeExpiredEscalations iterate only the
+// (small) set of trees currently paused awaiting a human instead of listing EVERY
+// job and re-reading each one's full event history TWICE on every repo poll — which
+// sustained ~37MB/s and ~1108 queries per poll x18 repos (#598/#340). Zero rows =>
+// the caller returns with no further per-job queries.
+//
+// Both ask-gate (#445) and failure escalations ride these same two kinds, and the
+// per-job candidate gate is purely count-based on them (never branching on the
+// record's Kind), so this count reproduces the exact candidate set the original
+// loadEscalation(exists) + !escalationResolved(open) gates passed. The literal
+// strings MUST equal the escalationRequestedEvent/escalationResolvedEvent constants;
+// a store test pins this.
+func (s *Store) JobIDsWithOpenEscalation(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT job_id FROM job_events
+		WHERE kind IN ('delegation_escalation_requested', 'delegation_escalation_resolved')
+		GROUP BY job_id
+		HAVING SUM(CASE WHEN kind = 'delegation_escalation_requested' THEN 1 ELSE 0 END)
+		     > SUM(CASE WHEN kind = 'delegation_escalation_resolved' THEN 1 ELSE 0 END)
+		ORDER BY job_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobIDs []string
+	for rows.Next() {
+		var jobID string
+		if err := rows.Scan(&jobID); err != nil {
+			return nil, err
+		}
+		jobIDs = append(jobIDs, jobID)
+	}
+	return jobIDs, rows.Err()
+}
+
 func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) error {
 	artifact, err := normalizeEvalArtifact(artifact)
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2854,6 +2854,80 @@ func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) 
 	return jobIDs, rows.Err()
 }
 
+// JobIDsWithPendingAdvanceRetry returns the IDs of jobs whose LATEST post-delivery
+// advancement event (by id) is still an unreconciled attempt marker
+// (advance_started/advance_retry) — exactly jobWorker.jobNeedsAdvanceRetry's
+// last-one-wins rule (daemon.go), evaluated set-at-once so the retry pass iterates
+// only genuine candidates instead of a full ListJobs + a per-terminal-job
+// ListJobEvents on every 1s worker tick — which was O(jobs × events) and burned a
+// core once a few hundred terminal jobs had accumulated (#598). The pass
+// re-verifies each candidate with the Go predicate, so this only has to be a
+// superset; it is in fact exact.
+//
+// The order of the tracked kinds matters (a job can be started, then completed,
+// then retried), so the LAST one wins: a job is a candidate iff the highest-id
+// event among exactly the predicate's tracked kinds is a positive attempt marker.
+// The MAX(id) subquery is restricted to those tracked kinds only (mirroring the Go
+// switch's default: no-op for every other kind) and the outer filter keeps a job
+// iff that latest tracked event is positive. One row per job (its unique MAX id).
+func (s *Store) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT job_id FROM job_events
+		WHERE kind IN ('advance_started', 'advance_retry')
+		  AND id IN (
+			SELECT MAX(id) FROM job_events
+			WHERE kind IN ('advance_started', 'advance_retry', 'advance_completed',
+			               'advance_retried', 'advance_blocked', 'advance_retry_skipped', 'retry_queued')
+			GROUP BY job_id
+		)
+		ORDER BY job_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobIDs []string
+	for rows.Next() {
+		var jobID string
+		if err := rows.Scan(&jobID); err != nil {
+			return nil, err
+		}
+		jobIDs = append(jobIDs, jobID)
+	}
+	return jobIDs, rows.Err()
+}
+
+// JobIDsWithPendingCommentRetry returns the IDs of jobs whose LATEST comment event
+// (by id) is comment_post_failed with no subsequent comment_posted or retry_queued
+// — exactly jobWorker.jobNeedsCommentRetry's last-one-wins rule (daemon.go),
+// evaluated set-at-once so the comment-retry pass iterates only genuine candidates
+// instead of a full ListJobs + per-terminal-job ListJobEvents on every 1s worker
+// tick (#598). The pass re-verifies each candidate with the Go predicate, so this
+// only has to be a superset; it is in fact exact.
+func (s *Store) JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT job_id FROM job_events
+		WHERE kind = 'comment_post_failed'
+		  AND id IN (
+			SELECT MAX(id) FROM job_events
+			WHERE kind IN ('comment_post_failed', 'comment_posted', 'retry_queued')
+			GROUP BY job_id
+		)
+		ORDER BY job_id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobIDs []string
+	for rows.Next() {
+		var jobID string
+		if err := rows.Scan(&jobID); err != nil {
+			return nil, err
+		}
+		jobIDs = append(jobIDs, jobID)
+	}
+	return jobIDs, rows.Err()
+}
+
 func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) error {
 	artifact, err := normalizeEvalArtifact(artifact)
 	if err != nil {

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"math/rand"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -4081,6 +4082,301 @@ func TestJobIDsWithPendingDelegationWorktreeReclaimRaceSafe(t *testing.T) {
 		wantPending := i%2 == 1
 		if gotSet[jobID] != wantPending {
 			t.Fatalf("job %s pending=%v, want %v (set=%v)", jobID, gotSet[jobID], wantPending, got)
+		}
+	}
+}
+
+// referenceJobNeedsAdvanceRetry mirrors jobWorker.jobNeedsAdvanceRetry
+// (internal/cli/daemon.go) exactly: a last-one-wins walk over the tracked
+// advancement kinds, every other kind ignored. It is the source-of-truth the
+// bounded JobIDsWithPendingAdvanceRetry candidate query must reproduce set-at-once
+// — the mutation guard below cross-checks the two agree (#598). Keeping a copy here
+// (package db cannot import package cli) is deliberate: if a future edit adds a
+// positive kind to the daemon predicate without updating the store literals, the
+// TestJobIDsWithPendingAdvanceRetry cases that seed that kind flip red.
+func referenceJobNeedsAdvanceRetry(kinds []string) bool {
+	needsRetry := false
+	for _, kind := range kinds {
+		switch kind {
+		case "advance_started", "advance_retry":
+			needsRetry = true
+		case "advance_completed", "advance_retried", "advance_blocked", "advance_retry_skipped":
+			needsRetry = false
+		case "retry_queued":
+			needsRetry = false
+		}
+	}
+	return needsRetry
+}
+
+// referenceJobNeedsCommentRetry mirrors jobWorker.jobNeedsCommentRetry.
+func referenceJobNeedsCommentRetry(kinds []string) bool {
+	needsRetry := false
+	for _, kind := range kinds {
+		switch kind {
+		case "comment_post_failed":
+			needsRetry = true
+		case "comment_posted":
+			needsRetry = false
+		case "retry_queued":
+			needsRetry = false
+		}
+	}
+	return needsRetry
+}
+
+func TestJobIDsWithPendingAdvanceRetry(t *testing.T) {
+	cases := []struct {
+		name        string
+		events      []string // in insertion order
+		wantPending bool
+	}{
+		{name: "no events", events: nil, wantPending: false},
+		{name: "unrelated events only", events: []string{"queued", "running", "succeeded"}, wantPending: false},
+		{name: "advance started pending", events: []string{"advance_started"}, wantPending: true},
+		{name: "advance retry pending", events: []string{"advance_retry"}, wantPending: true},
+		{name: "started then completed", events: []string{"advance_started", "advance_completed"}, wantPending: false},
+		{name: "started then retry last wins pending", events: []string{"advance_started", "advance_retry"}, wantPending: true},
+		{name: "retry then retried", events: []string{"advance_retry", "advance_retried"}, wantPending: false},
+		{name: "started then blocked", events: []string{"advance_started", "advance_blocked"}, wantPending: false},
+		{name: "started then retry skipped", events: []string{"advance_started", "advance_retry_skipped"}, wantPending: false},
+		{name: "started then retry_queued 602 reset", events: []string{"advance_started", "retry_queued"}, wantPending: false},
+		{name: "completed then started reopened pending", events: []string{"advance_completed", "advance_started"}, wantPending: true},
+		{name: "started trailing noise ignored still pending", events: []string{"advance_started", "queued", "route_selected"}, wantPending: true},
+		{name: "completed trailing noise ignored not pending", events: []string{"advance_started", "advance_completed", "queued", "succeeded"}, wantPending: false},
+	}
+
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	want := map[string]bool{}
+	for i, tc := range cases {
+		jobID := "adv-job-" + string(rune('a'+i))
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "producer", Type: "implement", State: "failed"}); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", jobID, err)
+		}
+		for _, kind := range tc.events {
+			if err := store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: kind, Message: "m"}); err != nil {
+				t.Fatalf("AddJobEvent(%s, %s) returned error: %v", jobID, kind, err)
+			}
+		}
+		// Mutation guard: the crafted expectation must equal the Go predicate.
+		if got := referenceJobNeedsAdvanceRetry(tc.events); got != tc.wantPending {
+			t.Fatalf("case %q: reference predicate = %v, wantPending %v", tc.name, got, tc.wantPending)
+		}
+		if tc.wantPending {
+			want[jobID] = true
+		}
+	}
+
+	got, err := store.JobIDsWithPendingAdvanceRetry(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithPendingAdvanceRetry returned error: %v", err)
+	}
+	assertJobIDSet(t, got, want)
+}
+
+func TestJobIDsWithPendingCommentRetry(t *testing.T) {
+	cases := []struct {
+		name        string
+		events      []string
+		wantPending bool
+	}{
+		{name: "no events", events: nil, wantPending: false},
+		{name: "unrelated only", events: []string{"queued", "succeeded"}, wantPending: false},
+		{name: "failed pending", events: []string{"comment_post_failed"}, wantPending: true},
+		{name: "failed then posted", events: []string{"comment_post_failed", "comment_posted"}, wantPending: false},
+		{name: "failed then retry_queued reset", events: []string{"comment_post_failed", "retry_queued"}, wantPending: false},
+		{name: "posted then failed last wins pending", events: []string{"comment_posted", "comment_post_failed"}, wantPending: true},
+		{name: "failed trailing noise still pending", events: []string{"comment_post_failed", "queued", "succeeded"}, wantPending: true},
+	}
+
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	want := map[string]bool{}
+	for i, tc := range cases {
+		jobID := "cmt-job-" + string(rune('a'+i))
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "producer", Type: "implement", State: "failed"}); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", jobID, err)
+		}
+		for _, kind := range tc.events {
+			if err := store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: kind, Message: "m"}); err != nil {
+				t.Fatalf("AddJobEvent(%s, %s) returned error: %v", jobID, kind, err)
+			}
+		}
+		if got := referenceJobNeedsCommentRetry(tc.events); got != tc.wantPending {
+			t.Fatalf("case %q: reference predicate = %v, wantPending %v", tc.name, got, tc.wantPending)
+		}
+		if tc.wantPending {
+			want[jobID] = true
+		}
+	}
+
+	got, err := store.JobIDsWithPendingCommentRetry(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithPendingCommentRetry returned error: %v", err)
+	}
+	assertJobIDSet(t, got, want)
+}
+
+// TestJobIDsWithPendingRetryMutationGuard seeds many jobs with random sequences
+// drawn from the predicate kinds plus benign noise and asserts the two bounded
+// candidate queries return EXACTLY the set the corresponding Go last-one-wins
+// predicate marks pending. This is the divergence guard called for by the #598
+// review: it fails if the SQL kind literals ever drift from the daemon predicates.
+func TestJobIDsWithPendingRetryMutationGuard(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	advKinds := []string{
+		"advance_started", "advance_retry", "advance_completed", "advance_retried",
+		"advance_blocked", "advance_retry_skipped", "retry_queued",
+		"queued", "route_selected", "blocker_deferred", // noise
+	}
+	cmtKinds := []string{
+		"comment_post_failed", "comment_posted", "retry_queued",
+		"queued", "succeeded", "runtime_lock_wait", // noise
+	}
+
+	rng := rand.New(rand.NewSource(598))
+	const jobs = 200
+	wantAdv := map[string]bool{}
+	wantCmt := map[string]bool{}
+	for i := 0; i < jobs; i++ {
+		jobID := "mut-job-" + strings.Repeat("x", i%3) + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "producer", Type: "implement", State: "failed"}); err != nil {
+			t.Fatalf("CreateJob returned error: %v", err)
+		}
+		var seq []string
+		n := rng.Intn(6)
+		for j := 0; j < n; j++ {
+			var kind string
+			// Interleave advancement and comment kinds so both predicates are exercised
+			// on the same job (their tracked sets are disjoint, so they never interfere).
+			if rng.Intn(2) == 0 {
+				kind = advKinds[rng.Intn(len(advKinds))]
+			} else {
+				kind = cmtKinds[rng.Intn(len(cmtKinds))]
+			}
+			seq = append(seq, kind)
+			if err := store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: kind, Message: "m"}); err != nil {
+				t.Fatalf("AddJobEvent returned error: %v", err)
+			}
+		}
+		if referenceJobNeedsAdvanceRetry(seq) {
+			wantAdv[jobID] = true
+		}
+		if referenceJobNeedsCommentRetry(seq) {
+			wantCmt[jobID] = true
+		}
+	}
+
+	gotAdv, err := store.JobIDsWithPendingAdvanceRetry(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithPendingAdvanceRetry returned error: %v", err)
+	}
+	assertJobIDSet(t, gotAdv, wantAdv)
+
+	gotCmt, err := store.JobIDsWithPendingCommentRetry(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithPendingCommentRetry returned error: %v", err)
+	}
+	assertJobIDSet(t, gotCmt, wantCmt)
+}
+
+// TestJobIDsWithPendingAdvanceRetryRaceSafe reads the bounded advancement-candidate
+// query concurrently with writers emitting attempt/reconcile markers, the way the
+// worker tick reads while advanceJob writes. It must never error or deadlock under
+// -race.
+func TestJobIDsWithPendingAdvanceRetryRaceSafe(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	const n = 12
+	for i := 0; i < n; i++ {
+		jobID := "adv-race-" + string(rune('a'+i))
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "producer", Type: "implement", State: "failed"}); err != nil {
+			t.Fatalf("CreateJob returned error: %v", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			jobID := "adv-race-" + string(rune('a'+i))
+			_ = store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: "advance_started", Message: "attempt"})
+			if i%2 == 0 {
+				_ = store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: "advance_completed", Message: "done"})
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			if _, err := store.JobIDsWithPendingAdvanceRetry(ctx); err != nil {
+				t.Errorf("concurrent JobIDsWithPendingAdvanceRetry returned error: %v", err)
+				return
+			}
+			if _, err := store.JobIDsWithPendingCommentRetry(ctx); err != nil {
+				t.Errorf("concurrent JobIDsWithPendingCommentRetry returned error: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	got, err := store.JobIDsWithPendingAdvanceRetry(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithPendingAdvanceRetry returned error: %v", err)
+	}
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	for i := 0; i < n; i++ {
+		jobID := "adv-race-" + string(rune('a'+i))
+		wantPending := i%2 == 1 // odd-indexed kept only advance_started
+		if gotSet[jobID] != wantPending {
+			t.Fatalf("job %s pending=%v, want %v (set=%v)", jobID, gotSet[jobID], wantPending, got)
+		}
+	}
+}
+
+// assertJobIDSet asserts got is exactly want (as a set) with no duplicate ids.
+func assertJobIDSet(t *testing.T, got []string, want map[string]bool) {
+	t.Helper()
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		if gotSet[id] {
+			t.Fatalf("duplicate job id %q in result %v", id, got)
+		}
+		gotSet[id] = true
+	}
+	if len(gotSet) != len(want) {
+		t.Fatalf("candidate set = %v (n=%d), want exactly %v (n=%d)", got, len(gotSet), want, len(want))
+	}
+	for id := range want {
+		if !gotSet[id] {
+			t.Fatalf("expected job %q in candidate set, got %v", id, got)
 		}
 	}
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math/rand"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -4377,6 +4378,184 @@ func assertJobIDSet(t *testing.T, got []string, want map[string]bool) {
 	for id := range want {
 		if !gotSet[id] {
 			t.Fatalf("expected job %q in candidate set, got %v", id, got)
+		}
+	}
+}
+
+// referenceEscalationOpen mirrors Engine.escalationOpen (internal/workflow/engine.go):
+// a coordinator's escalation round is OPEN iff it has strictly more
+// delegation_escalation_requested than delegation_escalation_resolved events, every
+// other kind ignored. It is the source-of-truth JobIDsWithOpenEscalation must
+// reproduce set-at-once (#598). Package db cannot import package workflow, so the
+// constant strings are pinned by the workflow-side test
+// TestJobIDsWithOpenEscalationMatchesEngineConstants.
+func referenceEscalationOpen(kinds []string) bool {
+	requested, resolved := 0, 0
+	for _, kind := range kinds {
+		switch kind {
+		case "delegation_escalation_requested":
+			requested++
+		case "delegation_escalation_resolved":
+			resolved++
+		}
+	}
+	return requested > resolved
+}
+
+func TestJobIDsWithOpenEscalation(t *testing.T) {
+	const (
+		reqKind = "delegation_escalation_requested"
+		resKind = "delegation_escalation_resolved"
+	)
+	cases := []struct {
+		name     string
+		events   []string
+		wantOpen bool
+	}{
+		{name: "no events", events: nil, wantOpen: false},
+		{name: "unrelated only", events: []string{"queued", "succeeded"}, wantOpen: false},
+		{name: "requested only open", events: []string{reqKind}, wantOpen: true},
+		{name: "balanced closed", events: []string{reqKind, resKind}, wantOpen: false},
+		{name: "two requested one resolved open", events: []string{reqKind, resKind, reqKind}, wantOpen: true},
+		{name: "resolved only excluded", events: []string{resKind}, wantOpen: false},
+		{name: "resolved exceeds requested excluded", events: []string{reqKind, resKind, resKind}, wantOpen: false},
+		{name: "reopened round open", events: []string{reqKind, resKind, reqKind, "succeeded"}, wantOpen: true},
+		{name: "mixed noise ignored open", events: []string{"queued", reqKind, "route_selected"}, wantOpen: true},
+	}
+
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	want := map[string]bool{}
+	for i, tc := range cases {
+		jobID := "esc-job-" + string(rune('a'+i))
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "coord", Type: "ask", State: "succeeded"}); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", jobID, err)
+		}
+		for _, kind := range tc.events {
+			if err := store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: kind, Message: "m"}); err != nil {
+				t.Fatalf("AddJobEvent(%s, %s) returned error: %v", jobID, kind, err)
+			}
+		}
+		if got := referenceEscalationOpen(tc.events); got != tc.wantOpen {
+			t.Fatalf("case %q: reference open = %v, wantOpen %v", tc.name, got, tc.wantOpen)
+		}
+		if tc.wantOpen {
+			want[jobID] = true
+		}
+	}
+
+	got, err := store.JobIDsWithOpenEscalation(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithOpenEscalation returned error: %v", err)
+	}
+	assertJobIDSet(t, got, want)
+}
+
+// TestJobIDsWithOpenEscalationMutationGuard seeds random requested/resolved/noise
+// sequences and cross-checks the candidate set against referenceEscalationOpen, so
+// a drift between the store literals and the engine's requested>resolved rule is
+// caught (#598).
+func TestJobIDsWithOpenEscalationMutationGuard(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	kinds := []string{
+		"delegation_escalation_requested", "delegation_escalation_resolved",
+		"queued", "succeeded", "delegation_continuation_enqueued", // noise
+	}
+	rng := rand.New(rand.NewSource(340))
+	const jobs = 200
+	want := map[string]bool{}
+	for i := 0; i < jobs; i++ {
+		jobID := "escmut-" + strconv.Itoa(i)
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "coord", Type: "ask", State: "succeeded"}); err != nil {
+			t.Fatalf("CreateJob returned error: %v", err)
+		}
+		var seq []string
+		n := rng.Intn(6)
+		for j := 0; j < n; j++ {
+			kind := kinds[rng.Intn(len(kinds))]
+			seq = append(seq, kind)
+			if err := store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: kind, Message: "m"}); err != nil {
+				t.Fatalf("AddJobEvent returned error: %v", err)
+			}
+		}
+		if referenceEscalationOpen(seq) {
+			want[jobID] = true
+		}
+	}
+
+	got, err := store.JobIDsWithOpenEscalation(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithOpenEscalation returned error: %v", err)
+	}
+	assertJobIDSet(t, got, want)
+}
+
+// TestJobIDsWithOpenEscalationRaceSafe reads the candidate query concurrently with
+// escalation writers, mirroring the daemon poll reading while the engine
+// requests/resolves escalations. Must not error or deadlock under -race.
+func TestJobIDsWithOpenEscalationRaceSafe(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	const n = 12
+	for i := 0; i < n; i++ {
+		jobID := "esc-race-" + string(rune('a'+i))
+		if err := store.CreateJob(ctx, Job{ID: jobID, Agent: "coord", Type: "ask", State: "succeeded"}); err != nil {
+			t.Fatalf("CreateJob returned error: %v", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			jobID := "esc-race-" + string(rune('a'+i))
+			_ = store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: "delegation_escalation_requested", Message: "req"})
+			if i%2 == 0 {
+				_ = store.AddJobEvent(ctx, JobEvent{JobID: jobID, Kind: "delegation_escalation_resolved", Message: "res"})
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			if _, err := store.JobIDsWithOpenEscalation(ctx); err != nil {
+				t.Errorf("concurrent JobIDsWithOpenEscalation returned error: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	got, err := store.JobIDsWithOpenEscalation(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithOpenEscalation returned error: %v", err)
+	}
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		gotSet[id] = true
+	}
+	for i := 0; i < n; i++ {
+		jobID := "esc-race-" + string(rune('a'+i))
+		wantOpen := i%2 == 1 // odd-indexed kept only a requested event
+		if gotSet[jobID] != wantOpen {
+			t.Fatalf("job %s open=%v, want %v (set=%v)", jobID, gotSet[jobID], wantOpen, got)
 		}
 	}
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -5889,13 +5889,19 @@ func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Dur
 	now := e.now().UTC()
 	finalized := 0
 	for _, jobID := range jobIDs {
-		// A candidate escalation event whose job row was pruned would make
-		// jobPayload (below) return a non-errors.Is-able "job not found" that aborts
-		// the whole scan; skip it here, mirroring the reclaim/retry bounded passes
-		// (#598). Unreachable today (nothing prunes jobs), but keeps the pattern and
-		// the PollOnce caller robust to a future job-pruning feature.
-		if _, err := e.Store.GetJob(ctx, jobID); errors.Is(err, sql.ErrNoRows) {
+		// A candidate escalation event whose job row was pruned would make the
+		// payload load below fail; skip it here on sql.ErrNoRows, mirroring the
+		// reclaim/retry bounded passes (#598). Unreachable today (nothing prunes
+		// jobs), but keeps the pattern and the PollOnce caller robust to a future
+		// job-pruning feature. The fetched job is reused for the payload below, so a
+		// finalized candidate costs a single GetJob rather than the old
+		// GetJob-then-jobPayload double read (#615 review).
+		job, err := e.Store.GetJob(ctx, jobID)
+		if errors.Is(err, sql.ErrNoRows) {
 			continue
+		}
+		if err != nil {
+			return finalized, err
 		}
 		rec, exists, err := e.loadEscalation(ctx, jobID)
 		if err != nil {
@@ -5920,7 +5926,7 @@ func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Dur
 		if now.Sub(pausedAt) < ttl {
 			continue
 		}
-		coordinatorJob, payload, err := e.jobPayload(ctx, jobID)
+		payload, err := unmarshalPayload(job.Payload)
 		if err != nil {
 			return finalized, err
 		}
@@ -5928,7 +5934,7 @@ func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Dur
 			continue
 		}
 		reason := fmt.Sprintf("escalation TTL of %s elapsed with no human response", ttl)
-		if err := e.enqueueFinalizeContinuation(ctx, coordinatorJob, payload, reason); err != nil {
+		if err := e.enqueueFinalizeContinuation(ctx, job, payload, reason); err != nil {
 			return finalized, err
 		}
 		if err := e.setTaskState(ctx, taskRefFromPayload(payload), TaskPlanned); err != nil {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -5874,21 +5874,37 @@ func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Dur
 	if ttl <= 0 {
 		return 0, nil
 	}
-	jobs, err := e.Store.ListJobs(ctx)
+	// BOUNDED (#598): iterate ONLY the coordinators with an open escalation round
+	// (requested > resolved) instead of listing EVERY job and re-reading each one's
+	// full event history twice. Zero candidates => the loop body never runs, so this
+	// is an immediate return with no per-job GetJob/ListJobEvents on the overwhelming
+	// common case (no tree paused awaiting a human). The retained per-candidate
+	// exists/resolved gates below are always-pass for a candidate but kept verbatim,
+	// both to defend against an event added between this query and the walk and to
+	// keep the finalization logic byte-identical.
+	jobIDs, err := e.Store.JobIDsWithOpenEscalation(ctx)
 	if err != nil {
 		return 0, err
 	}
 	now := e.now().UTC()
 	finalized := 0
-	for _, job := range jobs {
-		rec, exists, err := e.loadEscalation(ctx, job.ID)
+	for _, jobID := range jobIDs {
+		// A candidate escalation event whose job row was pruned would make
+		// jobPayload (below) return a non-errors.Is-able "job not found" that aborts
+		// the whole scan; skip it here, mirroring the reclaim/retry bounded passes
+		// (#598). Unreachable today (nothing prunes jobs), but keeps the pattern and
+		// the PollOnce caller robust to a future job-pruning feature.
+		if _, err := e.Store.GetJob(ctx, jobID); errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		rec, exists, err := e.loadEscalation(ctx, jobID)
 		if err != nil {
 			return finalized, err
 		}
 		if !exists {
 			continue
 		}
-		resolved, err := e.escalationResolved(ctx, job.ID)
+		resolved, err := e.escalationResolved(ctx, jobID)
 		if err != nil {
 			return finalized, err
 		}
@@ -5904,7 +5920,7 @@ func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Dur
 		if now.Sub(pausedAt) < ttl {
 			continue
 		}
-		coordinatorJob, payload, err := e.jobPayload(ctx, job.ID)
+		coordinatorJob, payload, err := e.jobPayload(ctx, jobID)
 		if err != nil {
 			return finalized, err
 		}
@@ -5929,7 +5945,7 @@ func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Dur
 			message = string(encoded)
 		}
 		if err := e.Store.AddJobEvent(ctx, db.JobEvent{
-			JobID:   job.ID,
+			JobID:   jobID,
 			Kind:    escalationResolvedEvent,
 			Message: message,
 		}); err != nil {

--- a/internal/workflow/escalate_human_test.go
+++ b/internal/workflow/escalate_human_test.go
@@ -595,3 +595,162 @@ func containsSubstr(haystack, needle string) bool {
 	}
 	return false
 }
+
+// TestJobIDsWithOpenEscalationMatchesEngineConstants pins the store query's literal
+// event-kind strings to the engine constants: seeding events via the constants and
+// asserting the bounded candidate query returns the open coordinator proves a
+// rename of escalationRequestedEvent/escalationResolvedEvent (engine.go) without
+// updating internal/db/store.go would be caught, not silently drop candidates (#598).
+func TestJobIDsWithOpenEscalationMatchesEngineConstants(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+
+	insertCompletedJob(t, store, db.Job{ID: "open-coord", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", TaskID: "task-open", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "x"},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "closed-coord", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", TaskID: "task-closed", Sender: "coord",
+		Result: &AgentResult{Decision: "approved", Summary: "x"},
+	})
+	addEscalationEvent(t, store, "open-coord", escalationRequestedEvent, EscalationRecord{DelegationID: "api"})
+	addEscalationEvent(t, store, "closed-coord", escalationRequestedEvent, EscalationRecord{DelegationID: "api"})
+	addEscalationEvent(t, store, "closed-coord", escalationResolvedEvent, EscalationRecord{DelegationID: "api"})
+
+	ids, err := store.JobIDsWithOpenEscalation(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithOpenEscalation returned error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "open-coord" {
+		t.Fatalf("open-escalation candidates = %v, want exactly [open-coord] (store literals must equal the engine constants)", ids)
+	}
+}
+
+// TestAutoFinalizeExpiredEscalationsBoundedToOpenRounds proves the bounded (#598)
+// finalize scan acts on ONLY coordinators with an open escalation round: a large
+// backlog of closed (resolved) and never-escalated jobs — all past TTL with a
+// stored result — are never finalized (no new resolved event), an orphan candidate
+// event whose job row is absent is skipped instead of aborting the scan, and only
+// the genuinely-open past-TTL coordinator is finalized.
+func TestAutoFinalizeExpiredEscalationsBoundedToOpenRounds(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "api", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "ui", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.EscalationNotifier = &recordingNotifier{}
+
+	base := time.Now().UTC()
+	engine.Now = func() time.Time { return base }
+	// The one genuinely-open coordinator, paused awaiting a human.
+	seedEscalateHumanCoordinator(t, store, engine)
+	if err := engine.AdvanceJob(ctx, "parent-job/delegation/api"); err == nil {
+		t.Fatal("expected AwaitingHumanError")
+	}
+
+	// Backlog: never-escalated + closed-escalation coordinators, all with a stored
+	// result and (once the clock advances) past TTL. None are candidates.
+	oldPause := base.Add(-72 * time.Hour).Format(time.RFC3339)
+	for i := 0; i < 30; i++ {
+		neverID := "never-esc-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		insertCompletedJob(t, store, db.Job{ID: neverID, Agent: "coord", Type: "ask"}, JobPayload{
+			Repo: "jerryfane/gitmoot", TaskID: "task-never-" + neverID, Sender: "coord",
+			Result: &AgentResult{Decision: "approved", Summary: "x"},
+		})
+		closedID := "closed-esc-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		insertCompletedJob(t, store, db.Job{ID: closedID, Agent: "coord", Type: "ask"}, JobPayload{
+			Repo: "jerryfane/gitmoot", TaskID: "task-closed-" + closedID, Sender: "coord",
+			Result: &AgentResult{Decision: "approved", Summary: "x"},
+		})
+		addEscalationEvent(t, store, closedID, escalationRequestedEvent, EscalationRecord{DelegationID: "api", PausedAt: oldPause})
+		addEscalationEvent(t, store, closedID, escalationResolvedEvent, EscalationRecord{DelegationID: "api", PausedAt: oldPause})
+	}
+
+	// An orphan open-escalation event whose job row is absent: a candidate the
+	// query returns but that must be SKIPPED (not abort the scan via jobPayload's
+	// non-errors.Is "job not found"). Sorts after "parent-job" so parent-job would
+	// already be finalized before a would-be abort — the assertion below (nil error,
+	// finalized == 1) fails if the skip is removed.
+	addEscalationEvent(t, store, "zzz-orphan-open", escalationRequestedEvent, EscalationRecord{DelegationID: "api", PausedAt: oldPause})
+
+	// Sanity: the candidate set is exactly the open coordinator + the orphan.
+	ids, err := store.JobIDsWithOpenEscalation(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithOpenEscalation returned error: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("candidate ids = %v, want exactly 2 (parent-job + orphan)", ids)
+	}
+
+	engine.Now = func() time.Time { return base.Add(49 * time.Hour) }
+	finalized, err := engine.AutoFinalizeExpiredEscalations(ctx, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("AutoFinalizeExpiredEscalations returned error: %v", err)
+	}
+	if finalized != 1 {
+		t.Fatalf("finalized = %d, want exactly 1 (only the open past-TTL coordinator)", finalized)
+	}
+	if got := countJobEvents(t, store, "parent-job", escalationResolvedEvent); got != 1 {
+		t.Fatalf("parent-job %s events = %d, want 1", escalationResolvedEvent, got)
+	}
+	// No backlog job was finalized: the closed ones keep their single seeded
+	// resolved event, the never-escalated ones stay at zero.
+	for i := 0; i < 30; i++ {
+		closedID := "closed-esc-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		if got := countJobEvents(t, store, closedID, escalationResolvedEvent); got != 1 {
+			t.Fatalf("closed job %s resolved events = %d, want 1 (never re-finalized)", closedID, got)
+		}
+		neverID := "never-esc-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		if got := countJobEvents(t, store, neverID, escalationResolvedEvent); got != 0 {
+			t.Fatalf("never-escalated job %s resolved events = %d, want 0", neverID, got)
+		}
+	}
+}
+
+// TestAutoFinalizeExpiredEscalationsZeroCandidatesNoWalk proves the immediate-return
+// win: with no open escalation round anywhere, the bounded candidate query returns
+// zero ids so the finalize loop body never runs — no per-job GetJob/ListJobEvents,
+// no finalize (#598).
+func TestAutoFinalizeExpiredEscalationsZeroCandidatesNoWalk(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	base := time.Now().UTC()
+	engine.Now = func() time.Time { return base.Add(49 * time.Hour) }
+	oldPause := base.Add(-72 * time.Hour).Format(time.RFC3339)
+	// A backlog of never-escalated and closed-escalation jobs, all past TTL: zero
+	// open rounds.
+	for i := 0; i < 25; i++ {
+		neverID := "never-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		insertCompletedJob(t, store, db.Job{ID: neverID, Agent: "coord", Type: "ask"}, JobPayload{
+			Repo: "jerryfane/gitmoot", TaskID: "t-never-" + neverID, Sender: "coord",
+			Result: &AgentResult{Decision: "approved", Summary: "x"},
+		})
+		closedID := "closed-" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		insertCompletedJob(t, store, db.Job{ID: closedID, Agent: "coord", Type: "ask"}, JobPayload{
+			Repo: "jerryfane/gitmoot", TaskID: "t-closed-" + closedID, Sender: "coord",
+			Result: &AgentResult{Decision: "approved", Summary: "x"},
+		})
+		addEscalationEvent(t, store, closedID, escalationRequestedEvent, EscalationRecord{DelegationID: "api", PausedAt: oldPause})
+		addEscalationEvent(t, store, closedID, escalationResolvedEvent, EscalationRecord{DelegationID: "api", PausedAt: oldPause})
+	}
+
+	// The candidate query returns nothing, so the loop iterates zero times.
+	ids, err := store.JobIDsWithOpenEscalation(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithOpenEscalation returned error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("candidate ids = %v, want none (no open escalation round)", ids)
+	}
+
+	finalized, err := engine.AutoFinalizeExpiredEscalations(ctx, 48*time.Hour)
+	if err != nil {
+		t.Fatalf("AutoFinalizeExpiredEscalations returned error: %v", err)
+	}
+	if finalized != 0 {
+		t.Fatalf("finalized = %d, want 0 with zero candidates", finalized)
+	}
+}


### PR DESCRIPTION
Fixes #598.

The daemon burned ~88% of a core at steady state (110%+23% during dispatch-spin episodes). Live profiling + code trace (see #598 for full measurements) found three in-daemon hot paths; this PR fixes all three, one commit each, following the exact pattern #549's fix (3598b43) established for the reclaim pass.

## 1. `fix(daemon)`: bound worker-tick retry scans with indexed candidate queries

Every 1s worker tick ran, **per enabled repo** (×18), `retryPendingJobAdvancements` + `retryPendingJobComments`, each doing a full `ListJobs` (38.8 MB), JSON-unmarshaling every payload for the repo filter, then `ListJobEvents` per terminal job (N+1). Per sweep: **36 full scans + ~37k unmarshals (~1.33 GB JSON) + ~2,062 event queries — to find ~3 pending jobs**. The sweep took 15–40s against a 1s interval, saturating the loop permanently.

Now the store answers with indexed candidate ID sets (`JobIDsWithPendingAdvanceRetry`, `JobIDsWithPendingCommentRetry` — last-relevant-event queries over the marker kinds, same shape as `JobIDsWithPendingDelegationWorktreeReclaim`), and the existing Go predicates re-verify each candidate (`GetJob` + `ListJobEvents` per candidate), so behavior is provably identical — the SQL only narrows the candidate set (superset property covered by cross-check tests that seed randomized event histories and assert candidate-set ⊇ predicate-true-set). Pruned-row candidates are skipped instead of aborting the tick.

## 2. `fix(daemon)`: stop pool dispatcher busy-spin on busy runtime session

A queued merge-back job whose runtime session was held got re-dispatched in a tight loop — busy didn't count as "no progress", so the pool re-looped immediately at **~36 attempts/s** with no backoff, writing a `runtime_lock_wait` job_event **per attempt**: 76,289 rows = **56% of the entire job_events table**, which in turn bloated every per-job event scan (compounding with hot path 1).

Now: within one dispatcher invocation, a job that bounces busy — and any sibling queued on the **same runtime session** — is excluded from re-selection (busy ≠ progress), retrying next tick (~1s) like the barrier path. The `runtime_lock_wait` event is written **once per wait episode** (first bounce since the job last acquired its lock / since daemon start), not per attempt. No in-repo consumer counts these rows (checked `job_stuck.go`, `report.go` — they use latest/existence only).

Mutation-proofed: disabling the exclusion makes the regression test spin to its 15s guard (15,093 attempts); dropping same-session holdback yields 2 dispatch attempts where 1 is expected.

## 3. `fix(workflow)`: drive escalation auto-finalize from indexed candidates

`AutoFinalizeExpiredEscalations` ran in **every repo's PollOnce** (TTL defaults on, 24h) doing full `ListJobs` + per-job event walks: measured **103 MB + 1,108 queries per repo-poll** (~2.6 GB reads per sweep). Now it asks the store for jobs with an **open escalation** (`JobIDsWithOpenEscalation`: latest escalation event = requested, not resolved) and walks only those; zero candidates returns immediately. Constants are pinned by a test asserting the SQL literals match the engine's event-kind constants.

## Numbers (before → expected after)

| Per ~20s sweep | before | after |
|---|---|---|
| full jobs-table scans | 36 (1.5 GB reads) | 0 |
| payload JSON unmarshals | ~37,000 (~1.33 GB) | ~candidates only (≈3) |
| ListJobEvents N+1 queries | ~2,062 | ≈ candidates (≈3) |
| escalation scans per repo-poll | 103 MB + 1,108 queries | 1 indexed query (0 candidates → 0 walks) |
| runtime_lock_wait writes during contention | ~36/s | 1 per wait episode |

## Testing

- `go test ./...` — **33/33 packages green** (full non-race suite)
- Targeted `-race` over dispatcher/tick/retry/store/escalation incl. new regression tests + `daemon_worker_loop_escalate_e2e_test.go` — **zero data races, all pass**
- New tests: store candidate-query tests (incl. randomized cross-checks against the Go predicates as divergence guards), dispatcher busy-spin regression tests (attempt-count + event-dedupe + same-session holdback), escalation bounded-scan + orphan-skip + constant-pin tests
- Design + implementation were independently reviewed for correctness (false-negative hunting on the SQL supersets) and conventions before this PR

## Out of scope (follow-ups listed in #598)

GitHub-client efficiency (persistent HTTP client/ETags, per-PR comment `since` reuse), poll-cadence rationalization, one-time data hygiene (pruning the 76k `runtime_lock_wait` backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
