### PR TITLE
chore(dashboard): bump for brighter active galaxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702123637-aaa230cd865a
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702134917-12998175ee7c
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702115600-5ceea0c4fc2d h1:vLi
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702115600-5ceea0c4fc2d/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702123637-aaa230cd865a h1:YHmQ4RI4S6b99D5QRkl92BQ9wM3UnGIrMp5wkXnPB2I=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702123637-aaa230cd865a/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702134917-12998175ee7c h1:mszk5iYyzXlb3PgtIl5ZUd74iBpSBaTzONmQBQ3LUaM=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702134917-12998175ee7c/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to `1299817` ([gitmoot-dashboard#17](https://github.com/jerryfane/gitmoot-dashboard/pull/17)).

Running job nodes now render as pixel-floored **beacons** with a pulsing bloom halo, live delegation links glow bright + pulse, and all links get a minimum screen-px width — so a running codex burst is visible from the zoomed-out whole-galaxy view (it was sub-pixel/invisible at fit zoom before). All the new brightness gates on live activity, so idle perf is preserved (0 idle long-tasks).

Go-only diff is the `go.mod`/`go.sum` bump; the UI change is in the embedded `web/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)