### PR TITLE
chore(dashboard): bump for visible packets + link-web revert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702134917-12998175ee7c
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702142649-f41e24daebae
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702123637-aaa230cd865a h1:YHm
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702123637-aaa230cd865a/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702134917-12998175ee7c h1:mszk5iYyzXlb3PgtIl5ZUd74iBpSBaTzONmQBQ3LUaM=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702134917-12998175ee7c/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702142649-f41e24daebae h1:QMfCXWguO3geo0SVLBS9SfTybn1/0/2nQr6Mjx2Oyfc=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260702142649-f41e24daebae/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to `f41e24d`:
- [#18](https://github.com/jerryfane/gitmoot-dashboard/pull/18) — custom screen-sized **packet** dots flowing between working agents (built-in particles were graph-unit sized → sub-pixel/invisible at fit zoom).
- [#19](https://github.com/jerryfane/gitmoot-dashboard/pull/19) — revert the all-links brightening (it read as a messy hairball); ordinary links recede to a faint web, while beacons, packets, and live delegation links still pop.

Go-only diff is the `go.mod`/`go.sum` bump; UI is in the embedded `web/dist`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)