### PR TITLE
fix(daemon,db): eliminate residual tick read-amplification — per-tick candidate hoist, covering index, review-only poll projection (#619)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2212,7 +2212,9 @@ func startSingleRepoWorkerLoop(ctx context.Context, interval time.Duration, stor
 		_, workers, usePool := live.snapshot()
 		w := worker
 		w.UsePool = usePool
-		return runDaemonWorkerTickTracked(ctx, store, w, workers, false, repo, rootFilter, stdout, now, tracker)
+		// nil carrier: this single-repo supervisor tick self-computes the shared
+		// candidate sets once for its own tick (#619).
+		return runDaemonWorkerTickTracked(ctx, store, w, workers, false, repo, rootFilter, stdout, now, tracker, nil)
 	})
 }
 
@@ -3065,6 +3067,79 @@ func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
 	return runQueuedJobsForRepo(ctx, worker, limit, "", "")
 }
 
+// tickCandidates memoizes the three per-tick job-candidate GROUP BY queries
+// (advance-retry / comment-retry / delegation-worktree-reclaim) so they run ONCE
+// per supervisor tick instead of once per enabled repo (#619). Each query takes
+// NO repo argument — they scan the whole job_events table and return the global
+// candidate set — yet the retry passes ran them inside runDaemonWorkerTickTracked,
+// which the multi-repo supervisor invokes once per enabled repo (18×/tick on the
+// affected VPS). The most expensive of the three (JobIDsWithPendingAdvanceRetry)
+// materialized ~23.67 MiB of row fetches per call, so re-running it per repo was
+// the single largest source of the daemon's idle read volume. Hoisting it here
+// keeps per-repo filtering exactly where it was (in Go, in the retry passes) while
+// collapsing the shared query to one execution.
+//
+// No mutex/sync.Once: it is consumed ONLY on the synchronous tick goroutine — the
+// per-repo loop in runEnabledRepoWorkerTicksTracked is sequential, and dispatched
+// jobs run on their own goroutines and never touch it. It is created FRESH each
+// tick (so a candidate that stops qualifying next tick is re-evaluated) and MUST
+// NOT be stored on the long-lived tracker/worker. A query error is memoized like a
+// result: within one tick a transient store fault fails every repo's pass
+// identically, and the next tick's fresh carrier re-queries.
+//
+// The store dependency is the narrow tickCandidateStore interface (satisfied by
+// *db.Store) purely so a counting fake can pin the once-per-tick property in tests;
+// production always threads the real *db.Store, so behavior is byte-identical.
+type tickCandidateStore interface {
+	JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, error)
+	JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, error)
+	JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) ([]string, error)
+}
+
+type tickCandidates struct {
+	store       tickCandidateStore
+	advanceDone bool
+	advanceIDs  []string
+	advanceErr  error
+	commentDone bool
+	commentIDs  []string
+	commentErr  error
+	reclaimDone bool
+	reclaimIDs  []string
+	reclaimErr  error
+}
+
+// newTickCandidates is a package var (not a plain func) only so the once-per-tick
+// regression test can substitute a carrier backed by a counting store; production
+// never reassigns it.
+var newTickCandidates = func(store tickCandidateStore) *tickCandidates {
+	return &tickCandidates{store: store}
+}
+
+func (c *tickCandidates) advanceRetryCandidates(ctx context.Context) ([]string, error) {
+	if !c.advanceDone {
+		c.advanceIDs, c.advanceErr = c.store.JobIDsWithPendingAdvanceRetry(ctx)
+		c.advanceDone = true
+	}
+	return c.advanceIDs, c.advanceErr
+}
+
+func (c *tickCandidates) commentRetryCandidates(ctx context.Context) ([]string, error) {
+	if !c.commentDone {
+		c.commentIDs, c.commentErr = c.store.JobIDsWithPendingCommentRetry(ctx)
+		c.commentDone = true
+	}
+	return c.commentIDs, c.commentErr
+}
+
+func (c *tickCandidates) delegationReclaimCandidates(ctx context.Context) ([]string, error) {
+	if !c.reclaimDone {
+		c.reclaimIDs, c.reclaimErr = c.store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
+		c.reclaimDone = true
+	}
+	return c.reclaimIDs, c.reclaimErr
+}
+
 // retryPendingJobAdvancements re-fires the post-delivery advancement for any
 // terminal job whose latest advancement event is still an unreconciled attempt
 // marker (advance_started/advance_retry). It is BOUNDED, not a full-table scan
@@ -3075,6 +3150,8 @@ func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
 // marker, and GetJob's just those. Each candidate is then re-verified with the Go
 // predicate jobNeedsAdvanceRetry, so behavior is identical to the old per-job walk;
 // the state/repo/session filters and the checkoutHeld gate are preserved verbatim.
+// The candidate set comes from the per-tick tickCandidates carrier (#619) so the
+// underlying GROUP BY query runs once per tick, not once per enabled repo.
 //
 // checkoutHeld (nil ⇒ no gate, the legacy inline-tick behavior) reports whether an
 // in-flight dispatched job currently holds a checkout key: a candidate whose own
@@ -3083,8 +3160,8 @@ func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
 // retried on a later tick once the key frees, instead of gating ALL retries on
 // whole-repo idleness (which a steady backlog can prevent indefinitely, freezing
 // merge retries).
-func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool) error {
-	jobIDs, err := worker.Store.JobIDsWithPendingAdvanceRetry(ctx)
+func retryPendingJobAdvancements(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool, cand *tickCandidates) error {
+	jobIDs, err := cand.advanceRetryCandidates(ctx)
 	if err != nil {
 		return err
 	}
@@ -3166,8 +3243,8 @@ func (w jobWorker) delegationWorktreeCleanupPending(ctx context.Context, jobID s
 // marker and are reclaimed on a later tick, so under a steady backlog preserved
 // worktrees are still reclaimed instead of leaking until full idleness (#562
 // review).
-func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool) error {
-	jobIDs, err := worker.Store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
+func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool, cand *tickCandidates) error {
+	jobIDs, err := cand.delegationReclaimCandidates(ctx)
 	if err != nil {
 		return err
 	}
@@ -3201,7 +3278,7 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 }
 
 func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, rootFilter string, stdout io.Writer, now time.Time) error {
-	return runDaemonWorkerTickTracked(ctx, store, worker, workers, dryRun, repoFilter, rootFilter, stdout, now, nil)
+	return runDaemonWorkerTickTracked(ctx, store, worker, workers, dryRun, repoFilter, rootFilter, stdout, now, nil, nil)
 }
 
 // runDaemonWorkerTickTracked is the per-tick worker pass. With a nil tracker it
@@ -3223,9 +3300,17 @@ func runDaemonWorkerTick(ctx context.Context, store *db.Store, worker jobWorker,
 //   - dispatch goes through dispatchQueuedJobsTracked, which returns promptly
 //     and bounds in-flight jobs by both the repo limit and the host-global
 //     --workers cap.
-func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, rootFilter string, stdout io.Writer, now time.Time, tracker *inflightJobTracker) error {
+func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker jobWorker, workers int, dryRun bool, repoFilter string, rootFilter string, stdout io.Writer, now time.Time, tracker *inflightJobTracker, cand *tickCandidates) error {
 	if dryRun {
 		return nil
+	}
+	// A nil carrier means this is a standalone tick (single-repo supervisor or the
+	// runDaemonWorkerTick wrapper): compute the shared candidate sets once for THIS
+	// tick. The multi-repo supervisor passes a carrier it created once per tick, so
+	// the three GROUP BY queries run once per tick rather than once per enabled repo
+	// (#619).
+	if cand == nil {
+		cand = newTickCandidates(worker.Store)
 	}
 	inflightIDs := tracker.inflightIDs()
 	if err := recoverRunningJobsBeforeForRepoSkipping(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter(stdout)), repoFilter, rootFilter, inflightIDs); err != nil {
@@ -3247,10 +3332,10 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	// on its own goroutine, so it still defers the whole block (matching main,
 	// where a live pool pass blocked the tick entirely).
 	if !tracker.poolRunning(repoFilter) {
-		if err := retryPendingJobAdvancements(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld); err != nil {
+		if err := retryPendingJobAdvancements(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand); err != nil {
 			return err
 		}
-		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld); err != nil {
+		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand); err != nil {
 			return err
 		}
 	}
@@ -3260,7 +3345,7 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	// Gating them on an idle repo would let one multi-hour in-flight job delay a
 	// transiently-failed result comment (and any downstream automation waiting
 	// on it) for the job's whole duration.
-	if err := retryPendingJobComments(ctx, worker, repoFilter, rootFilter); err != nil {
+	if err := retryPendingJobComments(ctx, worker, repoFilter, rootFilter, cand); err != nil {
 		return err
 	}
 	// Per-repo concurrency override (#576): a [repos."owner/repo"] section caps
@@ -3291,6 +3376,13 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 	if err != nil {
 		return err
 	}
+	// Compute the shared per-tick job-candidate sets ONCE for this whole sweep and
+	// pass the carrier into every enabled repo's tick (#619). The three GROUP BY
+	// candidate queries take no repo argument — they return the global candidate set
+	// that each repo's retry pass then filters in Go — so running them once here
+	// instead of once inside each runDaemonWorkerTickTracked collapses 18×/tick down
+	// to 1×/tick on a multi-repo daemon. Fresh each sweep; never retained.
+	cand := newTickCandidates(worker.Store)
 	// Scope tick faults per repo (#555 follow-up): the recovering supervisor
 	// treats a returned error as one fleet-wide failure unit and, after a bounded
 	// streak, exits the WHOLE daemon. Returning on the first repo's error would
@@ -3312,7 +3404,7 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 		if lock != nil {
 			lock.Lock()
 		}
-		tickErr := runDaemonWorkerTickTracked(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now, tracker)
+		tickErr := runDaemonWorkerTickTracked(ctx, store, worker, workers, false, repo.FullName(), rootFilter, stdout, now, tracker, cand)
 		if lock != nil {
 			lock.Unlock()
 		}
@@ -3355,8 +3447,8 @@ func jobStateCanRetryAdvancement(state string) bool {
 // with the Go predicate jobNeedsCommentRetry, so behavior is identical. Comment
 // retries never touch a checkout, so (unlike advancements) they take no checkoutHeld
 // gate.
-func retryPendingJobComments(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) error {
-	jobIDs, err := worker.Store.JobIDsWithPendingCommentRetry(ctx)
+func retryPendingJobComments(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, cand *tickCandidates) error {
+	jobIDs, err := cand.commentRetryCandidates(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3079,13 +3079,26 @@ func runQueuedJobs(ctx context.Context, worker jobWorker, limit int) error {
 // keeps per-repo filtering exactly where it was (in Go, in the retry passes) while
 // collapsing the shared query to one execution.
 //
+// Two memoization properties, both implemented once in candidateMemo.get:
+//
+//  1. SUCCESSES are computed once per tick and shared across every repo's pass, so
+//     each query runs once per tick, not once per enabled repo. A job that begins
+//     qualifying mid-sweep is therefore not observed until the next tick's fresh
+//     carrier — a deliberate, bounded one-tick staleness that self-corrects on the
+//     following tick. The carrier is created FRESH each tick (so a candidate that
+//     stops qualifying next tick is re-evaluated) and MUST NOT be stored on the
+//     long-lived tracker/worker.
+//  2. ERRORS are NOT memoized. A failed query leaves the memo unset so the next
+//     repo's pass RE-RUNS it. This preserves the per-repo fault isolation the
+//     pre-#619 per-repo queries had: a transient store fault (e.g. a single
+//     SQLITE_BUSY) fails only the repo that hit it and can self-heal for the rest
+//     of the sweep, instead of being replayed to all 18 repos — which would make
+//     failed==enabled, error the whole sweep, and feed the consecutive-tick daemon
+//     self-exit streak #619 is closing.
+//
 // No mutex/sync.Once: it is consumed ONLY on the synchronous tick goroutine — the
 // per-repo loop in runEnabledRepoWorkerTicksTracked is sequential, and dispatched
-// jobs run on their own goroutines and never touch it. It is created FRESH each
-// tick (so a candidate that stops qualifying next tick is re-evaluated) and MUST
-// NOT be stored on the long-lived tracker/worker. A query error is memoized like a
-// result: within one tick a transient store fault fails every repo's pass
-// identically, and the next tick's fresh carrier re-queries.
+// jobs run on their own goroutines and never touch it.
 //
 // The store dependency is the narrow tickCandidateStore interface (satisfied by
 // *db.Store) purely so a counting fake can pin the once-per-tick property in tests;
@@ -3096,17 +3109,35 @@ type tickCandidateStore interface {
 	JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) ([]string, error)
 }
 
+// candidateMemo lazily runs one per-tick candidate query and shares its RESULT
+// across the tick's repos, memoizing ONLY a success: get caches the ids on the first
+// successful fetch and returns them on every later call, but on a query error it
+// returns the error and leaves the memo unset so the next call RE-RUNS fetch
+// (retry-on-error — see tickCandidates for why per-repo fault isolation matters). It
+// is consumed only on the synchronous tick goroutine, so it needs no synchronization.
+type candidateMemo struct {
+	done bool
+	ids  []string
+}
+
+func (m *candidateMemo) get(fetch func() ([]string, error)) ([]string, error) {
+	if m.done {
+		return m.ids, nil
+	}
+	ids, err := fetch()
+	if err != nil {
+		return nil, err
+	}
+	m.ids = ids
+	m.done = true
+	return m.ids, nil
+}
+
 type tickCandidates struct {
-	store       tickCandidateStore
-	advanceDone bool
-	advanceIDs  []string
-	advanceErr  error
-	commentDone bool
-	commentIDs  []string
-	commentErr  error
-	reclaimDone bool
-	reclaimIDs  []string
-	reclaimErr  error
+	store   tickCandidateStore
+	advance candidateMemo
+	comment candidateMemo
+	reclaim candidateMemo
 }
 
 // newTickCandidates is a package var (not a plain func) only so the once-per-tick
@@ -3117,27 +3148,21 @@ var newTickCandidates = func(store tickCandidateStore) *tickCandidates {
 }
 
 func (c *tickCandidates) advanceRetryCandidates(ctx context.Context) ([]string, error) {
-	if !c.advanceDone {
-		c.advanceIDs, c.advanceErr = c.store.JobIDsWithPendingAdvanceRetry(ctx)
-		c.advanceDone = true
-	}
-	return c.advanceIDs, c.advanceErr
+	return c.advance.get(func() ([]string, error) {
+		return c.store.JobIDsWithPendingAdvanceRetry(ctx)
+	})
 }
 
 func (c *tickCandidates) commentRetryCandidates(ctx context.Context) ([]string, error) {
-	if !c.commentDone {
-		c.commentIDs, c.commentErr = c.store.JobIDsWithPendingCommentRetry(ctx)
-		c.commentDone = true
-	}
-	return c.commentIDs, c.commentErr
+	return c.comment.get(func() ([]string, error) {
+		return c.store.JobIDsWithPendingCommentRetry(ctx)
+	})
 }
 
 func (c *tickCandidates) delegationReclaimCandidates(ctx context.Context) ([]string, error) {
-	if !c.reclaimDone {
-		c.reclaimIDs, c.reclaimErr = c.store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
-		c.reclaimDone = true
-	}
-	return c.reclaimIDs, c.reclaimErr
+	return c.reclaim.get(func() ([]string, error) {
+		return c.store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
+	})
 }
 
 // retryPendingJobAdvancements re-fires the post-delivery advancement for any

--- a/internal/cli/daemon_dispatch_tracked_test.go
+++ b/internal/cli/daemon_dispatch_tracked_test.go
@@ -618,7 +618,7 @@ func TestTrackedTickMaintenanceNotStarvedByInFlightJobs(t *testing.T) {
 		return daemonWorkerHasEvent(events, kind)
 	}
 
-	if err := runDaemonWorkerTickTracked(ctx, store, worker, 2, false, "owner/repo", "", io.Discard, time.Now().UTC(), tracker); err != nil {
+	if err := runDaemonWorkerTickTracked(ctx, store, worker, 2, false, "owner/repo", "", io.Discard, time.Now().UTC(), tracker, nil); err != nil {
 		t.Fatalf("tick (busy repo): %v", err)
 	}
 	if len(comments.posted) != 1 {
@@ -633,7 +633,7 @@ func TestTrackedTickMaintenanceNotStarvedByInFlightJobs(t *testing.T) {
 
 	// Holder finishes -> the shared-checkout advancement is retried next tick.
 	tracker.end("job-live")
-	if err := runDaemonWorkerTickTracked(ctx, store, worker, 2, false, "owner/repo", "", io.Discard, time.Now().UTC(), tracker); err != nil {
+	if err := runDaemonWorkerTickTracked(ctx, store, worker, 2, false, "owner/repo", "", io.Discard, time.Now().UTC(), tracker, nil); err != nil {
 		t.Fatalf("tick (idle repo): %v", err)
 	}
 	if !hasEvent("job-adv-repo", "advance_retried") {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -7294,3 +7294,92 @@ func TestTickCandidatesComputedOncePerTick(t *testing.T) {
 		t.Fatalf("dry-run ran %d candidate queries, want 0", got)
 	}
 }
+
+// flakyCandidateStore returns an error on the first call to each candidate query and
+// the memoized success on every later call, counting total calls per query. It backs
+// TestTickCandidatesRetriesOnError's proof that tickCandidates memoizes SUCCESSES
+// only: a query that errors on one repo's pass must be re-attempted (not replayed as
+// the same error) on the next pass within the same tick.
+type flakyCandidateStore struct {
+	advanceCalls int32
+	commentCalls int32
+	reclaimCalls int32
+}
+
+var errCandidateTransient = errors.New("transient store fault")
+
+func (s *flakyCandidateStore) JobIDsWithPendingAdvanceRetry(context.Context) ([]string, error) {
+	if atomic.AddInt32(&s.advanceCalls, 1) == 1 {
+		return nil, errCandidateTransient
+	}
+	return []string{"advance-job"}, nil
+}
+
+func (s *flakyCandidateStore) JobIDsWithPendingCommentRetry(context.Context) ([]string, error) {
+	if atomic.AddInt32(&s.commentCalls, 1) == 1 {
+		return nil, errCandidateTransient
+	}
+	return []string{"comment-job"}, nil
+}
+
+func (s *flakyCandidateStore) JobIDsWithPendingDelegationWorktreeReclaim(context.Context) ([]string, error) {
+	if atomic.AddInt32(&s.reclaimCalls, 1) == 1 {
+		return nil, errCandidateTransient
+	}
+	return []string{"reclaim-job"}, nil
+}
+
+// TestTickCandidatesRetriesOnError pins FIX-A (#620 review): the per-tick carrier
+// memoizes SUCCESSES only. The first access to each query returns the store's
+// transient error WITHOUT memoizing it; the second access re-runs the query and
+// returns the now-successful result. A regression that memoized the error (the old
+// done=true-on-error behavior) would replay the first error on every later access
+// and never re-query — exactly the failure that turned one SQLITE_BUSY into a
+// whole-sweep error and fed the daemon self-exit streak.
+func TestTickCandidatesRetriesOnError(t *testing.T) {
+	ctx := context.Background()
+	store := &flakyCandidateStore{}
+	cand := newTickCandidates(store)
+
+	// advance-retry: first access errors and is not memoized; second retries and wins.
+	if _, err := cand.advanceRetryCandidates(ctx); !errors.Is(err, errCandidateTransient) {
+		t.Fatalf("first advanceRetryCandidates err = %v, want transient", err)
+	}
+	ids, err := cand.advanceRetryCandidates(ctx)
+	if err != nil {
+		t.Fatalf("second advanceRetryCandidates err = %v, want nil (retry succeeds)", err)
+	}
+	if len(ids) != 1 || ids[0] != "advance-job" {
+		t.Fatalf("second advanceRetryCandidates ids = %v, want [advance-job]", ids)
+	}
+	if got := atomic.LoadInt32(&store.advanceCalls); got != 2 {
+		t.Fatalf("advance query ran %d times, want 2 (error not memoized ⇒ retried)", got)
+	}
+	// A third access reuses the memoized success — no further store call.
+	if _, err := cand.advanceRetryCandidates(ctx); err != nil {
+		t.Fatalf("third advanceRetryCandidates err = %v, want nil", err)
+	}
+	if got := atomic.LoadInt32(&store.advanceCalls); got != 2 {
+		t.Fatalf("advance query ran %d times after a cached success, want still 2", got)
+	}
+
+	// The same retry-on-error / memoize-on-success contract holds for the other two.
+	if _, err := cand.commentRetryCandidates(ctx); !errors.Is(err, errCandidateTransient) {
+		t.Fatalf("first commentRetryCandidates err = %v, want transient", err)
+	}
+	if ids, err := cand.commentRetryCandidates(ctx); err != nil || len(ids) != 1 || ids[0] != "comment-job" {
+		t.Fatalf("second commentRetryCandidates ids=%v err=%v, want [comment-job] nil", ids, err)
+	}
+	if got := atomic.LoadInt32(&store.commentCalls); got != 2 {
+		t.Fatalf("comment query ran %d times, want 2", got)
+	}
+	if _, err := cand.delegationReclaimCandidates(ctx); !errors.Is(err, errCandidateTransient) {
+		t.Fatalf("first delegationReclaimCandidates err = %v, want transient", err)
+	}
+	if ids, err := cand.delegationReclaimCandidates(ctx); err != nil || len(ids) != 1 || ids[0] != "reclaim-job" {
+		t.Fatalf("second delegationReclaimCandidates ids=%v err=%v, want [reclaim-job] nil", ids, err)
+	}
+	if got := atomic.LoadInt32(&store.reclaimCalls); got != 2 {
+		t.Fatalf("reclaim query ran %d times, want 2", got)
+	}
+}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -1203,7 +1203,7 @@ func TestDaemonWorkerTickRetriesFailedResultCommentPost(t *testing.T) {
 	}
 
 	comments.postErr = nil
-	if err := retryPendingJobComments(ctx, worker, "owner/repo", ""); err != nil {
+	if err := retryPendingJobComments(ctx, worker, "owner/repo", "", newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("retryPendingJobComments returned error: %v", err)
 	}
 	if len(comments.posted) != 1 {
@@ -1245,7 +1245,7 @@ func TestRetryPendingJobCommentsPreservesStoredFailureDiagnostic(t *testing.T) {
 		return comments
 	}
 
-	if err := retryPendingJobComments(ctx, worker, "owner/repo", ""); err != nil {
+	if err := retryPendingJobComments(ctx, worker, "owner/repo", "", newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("retryPendingJobComments returned error: %v", err)
 	}
 
@@ -4573,7 +4573,7 @@ func TestRunQueuedJobsRecordsPostDeliveryWorkflowErrorForRetry(t *testing.T) {
 	}
 	gate.err = nil
 	gate.decision = workflow.MergeDecision{Ready: true}
-	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 	if adapter.calls != 1 {
@@ -4630,7 +4630,7 @@ func TestRetryPendingJobAdvancementsRecoversStartedAdvancement(t *testing.T) {
 		return workflow.Engine{Store: store, MergeGate: gate}
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -4684,7 +4684,7 @@ func TestRetryPendingJobAdvancementsAdvancesFailedStoredResult(t *testing.T) {
 		return workflow.Engine{Store: store}
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -4792,7 +4792,7 @@ func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *t
 		return daemonWorkflowEngine(store, github.NoopClient{}, checkout, "")
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -5152,7 +5152,7 @@ func TestReclaimSkippedDelegationWorktrees(t *testing.T) {
 				}
 			}
 
-			if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil); err != nil {
+			if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
 				t.Fatalf("reclaimSkippedDelegationWorktrees returned error: %v", err)
 			}
 
@@ -5250,7 +5250,7 @@ func TestReclaimSkippedDelegationWorktreesBoundedToMarkedJobs(t *testing.T) {
 		}
 	}
 
-	if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil); err != nil {
+	if err := reclaimSkippedDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("reclaimSkippedDelegationWorktrees returned error: %v", err)
 	}
 
@@ -6903,7 +6903,7 @@ func TestRetryPendingJobAdvancementsBoundedToCandidates(t *testing.T) {
 		return "", errors.New("stop after capture")
 	}
 
-	if err := retryPendingJobAdvancements(ctx, worker, "owner/repo", "", nil); err != nil {
+	if err := retryPendingJobAdvancements(ctx, worker, "owner/repo", "", nil, newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("retryPendingJobAdvancements returned error: %v", err)
 	}
 
@@ -6979,7 +6979,7 @@ func TestRetryPendingJobCommentsBoundedToCandidates(t *testing.T) {
 	worker := defaultJobWorker(store, io.Discard)
 	worker.CommenterFactory = func(string) github.Client { return comments }
 
-	if err := retryPendingJobComments(ctx, worker, "owner/repo", ""); err != nil {
+	if err := retryPendingJobComments(ctx, worker, "owner/repo", "", newTickCandidates(worker.Store)); err != nil {
 		t.Fatalf("retryPendingJobComments returned error: %v", err)
 	}
 
@@ -7198,5 +7198,99 @@ func TestSameSessionSiblingsHeldBackOnBusy(t *testing.T) {
 	}
 	if got := atomic.LoadInt64(attempts); got != 1 {
 		t.Fatalf("dispatch attempts = %d, want exactly 1 (same-session sibling must be held back)", got)
+	}
+}
+
+// countingCandidateStore wraps a real *db.Store and counts how many times each of
+// the three per-tick candidate GROUP BY queries executes, delegating to the store
+// so the query still runs (returning the real, empty result on a job-free DB). It
+// backs TestTickCandidatesComputedOncePerTick's proof that the #619 hoist runs each
+// candidate query once per tick, not once per enabled repo.
+type countingCandidateStore struct {
+	inner   *db.Store
+	advance int32
+	comment int32
+	reclaim int32
+}
+
+func (c *countingCandidateStore) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, error) {
+	atomic.AddInt32(&c.advance, 1)
+	return c.inner.JobIDsWithPendingAdvanceRetry(ctx)
+}
+
+func (c *countingCandidateStore) JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, error) {
+	atomic.AddInt32(&c.comment, 1)
+	return c.inner.JobIDsWithPendingCommentRetry(ctx)
+}
+
+func (c *countingCandidateStore) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) ([]string, error) {
+	atomic.AddInt32(&c.reclaim, 1)
+	return c.inner.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
+}
+
+// TestTickCandidatesComputedOncePerTick pins the #619 hoist: the three repo-agnostic
+// candidate GROUP BY queries must run ONCE per supervisor tick, not once per enabled
+// repo. It substitutes a carrier over a shared counter for every newTickCandidates
+// call the tick makes; a regression that rebuilds the carrier per repo fires the
+// constructor (and thus the shared counter) once per repo and trips the asserts.
+func TestTickCandidatesComputedOncePerTick(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	const repoCount = 3
+	for i := 0; i < repoCount; i++ {
+		seedDaemonWorkerRepo(t, store, fmt.Sprintf("owner/repo%d", i), t.TempDir())
+	}
+	worker := defaultJobWorker(store, io.Discard)
+
+	counter := &countingCandidateStore{inner: store}
+	realNewTickCandidates := newTickCandidates
+	newTickCandidates = func(tickCandidateStore) *tickCandidates {
+		return realNewTickCandidates(counter)
+	}
+	defer func() { newTickCandidates = realNewTickCandidates }()
+
+	reset := func() {
+		atomic.StoreInt32(&counter.advance, 0)
+		atomic.StoreInt32(&counter.comment, 0)
+		atomic.StoreInt32(&counter.reclaim, 0)
+	}
+	now := time.Now().UTC()
+
+	// Multi-repo sweep: each candidate query runs exactly once for the whole sweep.
+	if err := runEnabledRepoWorkerTicksTracked(ctx, store, worker, 1, "", io.Discard, now, nil, nil); err != nil {
+		t.Fatalf("runEnabledRepoWorkerTicksTracked returned error: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter.advance); got != 1 {
+		t.Fatalf("advance-retry query ran %d times across %d repos, want 1", got, repoCount)
+	}
+	if got := atomic.LoadInt32(&counter.comment); got != 1 {
+		t.Fatalf("comment-retry query ran %d times across %d repos, want 1", got, repoCount)
+	}
+	if got := atomic.LoadInt32(&counter.reclaim); got != 1 {
+		t.Fatalf("delegation-reclaim query ran %d times across %d repos, want 1", got, repoCount)
+	}
+
+	// Single-repo tick with a nil carrier self-computes each query at most once.
+	reset()
+	if err := runDaemonWorkerTickTracked(ctx, store, worker, 1, false, "owner/repo0", "", io.Discard, now, nil, nil); err != nil {
+		t.Fatalf("runDaemonWorkerTickTracked returned error: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter.advance); got != 1 {
+		t.Fatalf("single-repo advance-retry query ran %d times, want 1", got)
+	}
+	if got := atomic.LoadInt32(&counter.comment); got != 1 {
+		t.Fatalf("single-repo comment-retry query ran %d times, want 1", got)
+	}
+	if got := atomic.LoadInt32(&counter.reclaim); got != 1 {
+		t.Fatalf("single-repo delegation-reclaim query ran %d times, want 1", got)
+	}
+
+	// A dry-run tick returns before computing any candidate set.
+	reset()
+	if err := runDaemonWorkerTickTracked(ctx, store, worker, 1, true, "owner/repo0", "", io.Discard, now, nil, nil); err != nil {
+		t.Fatalf("dry-run runDaemonWorkerTickTracked returned error: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter.advance) + atomic.LoadInt32(&counter.comment) + atomic.LoadInt32(&counter.reclaim); got != 0 {
+		t.Fatalf("dry-run ran %d candidate queries, want 0", got)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -340,7 +340,9 @@ type pullRequestRouting struct {
 }
 
 func (d Daemon) pullRequestWorkflowRouting(ctx context.Context, pull github.PullRequest) (pullRequestRouting, error) {
-	jobs, err := d.Store.ListJobs(ctx)
+	// Only review jobs are inspected below; ListJobsByType filters in SQL so this
+	// poll path stops materializing every non-review job's payload (#619).
+	jobs, err := d.Store.ListJobsByType(ctx, "review")
 	if err != nil {
 		return pullRequestRouting{}, err
 	}
@@ -438,7 +440,9 @@ func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullR
 }
 
 func (d Daemon) supersedeStaleReviewJobs(ctx context.Context, pull github.PullRequest) error {
-	jobs, err := d.Store.ListJobs(ctx)
+	// Only review jobs can be superseded here; ListJobsByType filters in SQL so this
+	// poll path stops materializing every non-review job's payload (#619).
+	jobs, err := d.Store.ListJobsByType(ctx, "review")
 	if err != nil {
 		return err
 	}
@@ -539,7 +543,9 @@ func (d Daemon) reconcileReviewingPullRequest(ctx context.Context, pull github.P
 	if task.State != string(workflow.TaskReviewing) {
 		return nil
 	}
-	jobs, err := d.Store.ListJobs(ctx)
+	// Only review jobs advance the reviewing PR here; ListJobsByType filters in SQL
+	// so this poll path stops materializing every non-review job's payload (#619).
+	jobs, err := d.Store.ListJobsByType(ctx, "review")
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -89,14 +89,19 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 		return err
 	}
 	openBranches := map[string]struct{}{}
+	// Fetch the repo's review-job list AT MOST ONCE for this whole poll and share the
+	// snapshot across every open PR's review-job consumers, instead of re-running
+	// ListJobsByType("review") up to ~2× per PR (#619). Lazy: computed on the first
+	// consumer that needs it, never retained beyond this poll.
+	reviewMemo := newReviewJobsMemo(d.Store)
 	for _, pull := range pulls {
 		openBranches[pull.HeadRef] = struct{}{}
-		changed, err := d.pullRequestChanged(ctx, pull)
+		changed, err := d.pullRequestChanged(ctx, pull, reviewMemo)
 		if err != nil {
 			return err
 		}
 		if changed {
-			if err := d.handlePullRequestWorkflow(ctx, pull); err != nil {
+			if err := d.handlePullRequestWorkflow(ctx, pull, reviewMemo); err != nil {
 				if firstErr == nil {
 					firstErr = err
 				}
@@ -135,7 +140,7 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 				return err
 			}
 		}
-		if err := d.reconcileReviewingPullRequest(ctx, pull); err != nil && firstErr == nil {
+		if err := d.reconcileReviewingPullRequest(ctx, pull, reviewMemo); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -316,14 +321,69 @@ func (d Daemon) validate() error {
 	return nil
 }
 
-func (d Daemon) pullRequestChanged(ctx context.Context, pull github.PullRequest) (bool, error) {
+// reviewJobLister is the narrow store dependency reviewJobsMemo needs (satisfied by
+// *db.Store). It exists purely so a counting fake can pin the once-per-poll fetch
+// property in tests; production always threads the real *db.Store.
+type reviewJobLister interface {
+	ListJobsByType(ctx context.Context, jobType string) ([]db.Job, error)
+}
+
+// reviewJobsMemo fetches the repo's review-job list AT MOST ONCE per PollOnce and
+// shares that snapshot across the poll's review-job consumers
+// (pullRequestWorkflowRouting, supersedeStaleReviewJobs, reconcileReviewingPullRequest).
+// Those consumers previously each ran ListJobsByType("review") per open PR — up to
+// ~2× per PR — re-decoding every review payload each time (#619). The list is a
+// point-in-time snapshot for the duration of ONE poll: the same staleness class as
+// the old per-call fetches, which likewise observed only whatever review rows existed
+// at their moment of call. Like the per-tick candidate memo it caches SUCCESS only — a
+// failed fetch is returned and left unset so a later consumer re-fetches (in practice
+// a fetch error aborts the whole poll). Lazy: a poll that reaches no consumer fetches
+// nothing. Consumed only on the synchronous poll goroutine, so it needs no locking.
+type reviewJobsMemo struct {
+	store reviewJobLister
+	done  bool
+	jobs  []db.Job
+}
+
+func (m *reviewJobsMemo) get(ctx context.Context) ([]db.Job, error) {
+	if m.done {
+		return m.jobs, nil
+	}
+	jobs, err := m.store.ListJobsByType(ctx, "review")
+	if err != nil {
+		return nil, err
+	}
+	m.jobs = jobs
+	m.done = true
+	return m.jobs, nil
+}
+
+// newReviewJobsMemo is a package var (not a plain func) only so the once-per-poll
+// regression test can substitute a memo backed by a counting store; production never
+// reassigns it.
+var newReviewJobsMemo = func(store reviewJobLister) *reviewJobsMemo {
+	return &reviewJobsMemo{store: store}
+}
+
+// reviewJobs returns the poll's shared review-job snapshot via memo when one is
+// threaded (the PollOnce path), and otherwise fetches fresh from the store. The nil
+// case covers standalone/test calls to a single consumer, which fetch exactly as they
+// did before the per-poll memo (#619).
+func (d Daemon) reviewJobs(ctx context.Context, memo *reviewJobsMemo) ([]db.Job, error) {
+	if memo != nil {
+		return memo.get(ctx)
+	}
+	return d.Store.ListJobsByType(ctx, "review")
+}
+
+func (d Daemon) pullRequestChanged(ctx context.Context, pull github.PullRequest, memo *reviewJobsMemo) (bool, error) {
 	previous, err := d.Store.GetPullRequest(ctx, d.Repo.FullName(), pull.Number)
 	switch {
 	case err == nil:
 		if previous.HeadSHA != pull.HeadSHA {
 			return true, nil
 		}
-		routing, err := d.pullRequestWorkflowRouting(ctx, pull)
+		routing, err := d.pullRequestWorkflowRouting(ctx, pull, memo)
 		if err != nil {
 			return false, err
 		}
@@ -339,10 +399,11 @@ type pullRequestRouting struct {
 	stale bool
 }
 
-func (d Daemon) pullRequestWorkflowRouting(ctx context.Context, pull github.PullRequest) (pullRequestRouting, error) {
+func (d Daemon) pullRequestWorkflowRouting(ctx context.Context, pull github.PullRequest, memo *reviewJobsMemo) (pullRequestRouting, error) {
 	// Only review jobs are inspected below; ListJobsByType filters in SQL so this
-	// poll path stops materializing every non-review job's payload (#619).
-	jobs, err := d.Store.ListJobsByType(ctx, "review")
+	// poll path stops materializing every non-review job's payload (#619). The list is
+	// shared across the poll's review-job consumers via memo (fetched once per poll).
+	jobs, err := d.reviewJobs(ctx, memo)
 	if err != nil {
 		return pullRequestRouting{}, err
 	}
@@ -388,11 +449,11 @@ func (d Daemon) pullRequestStoredMerged(ctx context.Context, pull github.PullReq
 	return strings.TrimSpace(stored.State) == "merged", nil
 }
 
-func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullRequest) error {
+func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullRequest, memo *reviewJobsMemo) error {
 	if d.Workflow == nil {
 		return nil
 	}
-	if err := d.supersedeStaleReviewJobs(ctx, pull); err != nil {
+	if err := d.supersedeStaleReviewJobs(ctx, pull, memo); err != nil {
 		return err
 	}
 	lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), pull.HeadRef)
@@ -439,10 +500,11 @@ func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullR
 	})
 }
 
-func (d Daemon) supersedeStaleReviewJobs(ctx context.Context, pull github.PullRequest) error {
+func (d Daemon) supersedeStaleReviewJobs(ctx context.Context, pull github.PullRequest, memo *reviewJobsMemo) error {
 	// Only review jobs can be superseded here; ListJobsByType filters in SQL so this
-	// poll path stops materializing every non-review job's payload (#619).
-	jobs, err := d.Store.ListJobsByType(ctx, "review")
+	// poll path stops materializing every non-review job's payload (#619). The list is
+	// shared across the poll's review-job consumers via memo (fetched once per poll).
+	jobs, err := d.reviewJobs(ctx, memo)
 	if err != nil {
 		return err
 	}
@@ -529,7 +591,7 @@ func (d Daemon) handleReadyToMergeWorkflow(ctx context.Context, pull github.Pull
 	})
 }
 
-func (d Daemon) reconcileReviewingPullRequest(ctx context.Context, pull github.PullRequest) error {
+func (d Daemon) reconcileReviewingPullRequest(ctx context.Context, pull github.PullRequest, memo *reviewJobsMemo) error {
 	if d.Workflow == nil {
 		return nil
 	}
@@ -544,8 +606,9 @@ func (d Daemon) reconcileReviewingPullRequest(ctx context.Context, pull github.P
 		return nil
 	}
 	// Only review jobs advance the reviewing PR here; ListJobsByType filters in SQL
-	// so this poll path stops materializing every non-review job's payload (#619).
-	jobs, err := d.Store.ListJobsByType(ctx, "review")
+	// so this poll path stops materializing every non-review job's payload (#619). The
+	// list is shared across the poll's review-job consumers via memo (once per poll).
+	jobs, err := d.reviewJobs(ctx, memo)
 	if err != nil {
 		return err
 	}
@@ -593,7 +656,7 @@ func (d Daemon) reconcileReviewingPullRequest(ctx context.Context, pull github.P
 	if hasCurrentReview {
 		return nil
 	}
-	return d.handlePullRequestWorkflow(ctx, pull)
+	return d.handlePullRequestWorkflow(ctx, pull, memo)
 }
 
 func (d Daemon) retryClosedReadyToMerge(ctx context.Context, openBranches map[string]struct{}) error {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -286,7 +286,7 @@ func TestHandlePullRequestWorkflowSkipsReviewFanoutWhenLockSet(t *testing.T) {
 		BaseRef: "main",
 		HeadSHA: "abc123",
 	}
-	if err := daemon.handlePullRequestWorkflow(ctx, pull); err != nil {
+	if err := daemon.handlePullRequestWorkflow(ctx, pull, nil); err != nil {
 		t.Fatalf("handlePullRequestWorkflow returned error: %v", err)
 	}
 
@@ -368,7 +368,7 @@ func TestHandlePullRequestWorkflowFansOutWhenLockUnset(t *testing.T) {
 		BaseRef: "main",
 		HeadSHA: "abc123",
 	}
-	if err := daemon.handlePullRequestWorkflow(ctx, pull); err != nil {
+	if err := daemon.handlePullRequestWorkflow(ctx, pull, nil); err != nil {
 		t.Fatalf("handlePullRequestWorkflow returned error: %v", err)
 	}
 	if _, err := store.GetJob(ctx, "review-audit-task-007-review-1"); err != nil {

--- a/internal/daemon/poll_path_projection_test.go
+++ b/internal/daemon/poll_path_projection_test.go
@@ -1,0 +1,212 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// seedLargeNonReviewJob inserts a non-review job carrying a ~1MB payload — a stand
+// in for the real multi-megabyte implement payloads whose per-poll materialization
+// #619's ListJobsByType swap avoids. The poll paths must reach the same decision
+// they did under ListJobs, without this row's type ever qualifying. The payload is
+// a raw JSON blob (never unmarshaled by the poll paths, which skip non-review types
+// before decoding), so it does not depend on any JobPayload field.
+func seedLargeNonReviewJob(t *testing.T, store *db.Store) {
+	t.Helper()
+	blob := `{"blob":"` + strings.Repeat("x", 1<<20) + `"}`
+	if err := store.CreateJob(context.Background(), db.Job{
+		ID:      "implement-huge",
+		Agent:   "coder",
+		Type:    "implement",
+		State:   string(workflow.JobRunning),
+		Payload: blob,
+	}); err != nil {
+		t.Fatalf("CreateJob implement returned error: %v", err)
+	}
+}
+
+func seedReviewJob(t *testing.T, store *db.Store, repo, id, headSHA string, state workflow.JobState, result *workflow.AgentResult) {
+	t.Helper()
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:        repo,
+		Branch:      "task-7",
+		PullRequest: 7,
+		HeadSHA:     headSHA,
+		TaskID:      "task-007",
+		TaskTitle:   "Task 7",
+		LeadAgent:   "lead",
+		Reviewers:   []string{"audit"},
+		ReviewRound: id,
+		Result:      result,
+	})
+	if err != nil {
+		t.Fatalf("Marshal review payload returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(context.Background(), db.Job{
+		ID:      id,
+		Agent:   "audit",
+		Type:    "review",
+		State:   string(state),
+		Payload: string(payload),
+	}, db.JobEvent{JobID: id, Kind: string(state), Message: "seeded review job"}); err != nil {
+		t.Fatalf("CreateJobWithEvent review returned error: %v", err)
+	}
+}
+
+func reviewPull(headSHA string) github.PullRequest {
+	return github.PullRequest{
+		Number:  7,
+		Title:   "Task 7",
+		State:   "open",
+		URL:     "https://github.com/jerryfane/gitmoot/pull/7",
+		HeadRef: "task-7",
+		BaseRef: "main",
+		HeadSHA: headSHA,
+	}
+}
+
+// TestSupersedeStaleReviewJobsSkipsLargeNonReviewPayload proves the #619 projection
+// swap did not change supersession behavior: a stale-head review job is still
+// superseded even with a large non-review payload present that ListJobsByType now
+// skips reading.
+func TestSupersedeStaleReviewJobsSkipsLargeNonReviewPayload(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	seedLargeNonReviewJob(t, store)
+	seedReviewJob(t, store, repo.FullName(), "review-stale", "old-head", workflow.JobQueued, nil)
+
+	d := Daemon{Repo: repo, Store: store, Workflow: &workflow.Engine{Store: store}}
+	if err := d.supersedeStaleReviewJobs(ctx, reviewPull("new-head")); err != nil {
+		t.Fatalf("supersedeStaleReviewJobs returned error: %v", err)
+	}
+
+	review, err := store.GetJob(ctx, "review-stale")
+	if err != nil {
+		t.Fatalf("GetJob review returned error: %v", err)
+	}
+	if review.State != string(workflow.JobCancelled) {
+		t.Fatalf("stale review state = %q, want cancelled (superseded)", review.State)
+	}
+	events, err := store.ListJobEvents(ctx, "review-stale")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	found := false
+	for _, e := range events {
+		if e.Kind == workflow.JobEventSupersededStaleHead {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("stale review missing superseded_stale_head event: %+v", events)
+	}
+	// The large non-review job must be untouched.
+	implement, err := store.GetJob(ctx, "implement-huge")
+	if err != nil {
+		t.Fatalf("GetJob implement returned error: %v", err)
+	}
+	if implement.State != string(workflow.JobRunning) {
+		t.Fatalf("implement job state = %q, want running (untouched)", implement.State)
+	}
+}
+
+// TestPullRequestWorkflowRoutingStaleAmongLargeNonReviewPayload proves routing's
+// stale detection is unchanged by the projection swap.
+func TestPullRequestWorkflowRoutingStaleAmongLargeNonReviewPayload(t *testing.T) {
+	ctx := context.Background()
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+
+	t.Run("stale head routes stale", func(t *testing.T) {
+		store := testStore(t)
+		seedLargeNonReviewJob(t, store)
+		seedReviewJob(t, store, repo.FullName(), "review-stale", "old-head", workflow.JobQueued, nil)
+		d := Daemon{Repo: repo, Store: store, Workflow: &workflow.Engine{Store: store}}
+		routing, err := d.pullRequestWorkflowRouting(ctx, reviewPull("new-head"))
+		if err != nil {
+			t.Fatalf("pullRequestWorkflowRouting returned error: %v", err)
+		}
+		if !routing.stale {
+			t.Fatalf("routing.stale = false, want true for a stale-head review")
+		}
+	})
+
+	t.Run("current head routes not stale", func(t *testing.T) {
+		store := testStore(t)
+		seedLargeNonReviewJob(t, store)
+		seedReviewJob(t, store, repo.FullName(), "review-current", "cur-head", workflow.JobQueued, nil)
+		d := Daemon{Repo: repo, Store: store, Workflow: &workflow.Engine{Store: store}}
+		routing, err := d.pullRequestWorkflowRouting(ctx, reviewPull("cur-head"))
+		if err != nil {
+			t.Fatalf("pullRequestWorkflowRouting returned error: %v", err)
+		}
+		if routing.stale {
+			t.Fatalf("routing.stale = true, want false when the review matches the current head")
+		}
+	})
+}
+
+// TestReconcileReviewingPullRequestAdvancesAmongLargeNonReviewPayload proves the
+// reconcile advance decision is unchanged by the projection swap: an approved
+// current-head review still advances the reviewing task to ready_to_merge with the
+// large non-review payload present.
+func TestReconcileReviewingPullRequestAdvancesAmongLargeNonReviewPayload(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "lead", Role: "lead", Runtime: "codex", RuntimeRef: "last",
+		RepoScope: repo.FullName(), Capabilities: []string{"implement"},
+		AutonomyPolicy: "workspace-write", HealthStatus: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "audit", Role: "reviewer", Runtime: "codex", RuntimeRef: "last",
+		RepoScope: repo.FullName(), Capabilities: []string{"review"},
+		AutonomyPolicy: "auto", HealthStatus: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-007", RepoFullName: repo.FullName(), GoalID: "goal-1",
+		Title: "Task 7", State: string(workflow.TaskReviewing), Branch: "task-7",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	seedLargeNonReviewJob(t, store)
+	seedReviewJob(t, store, repo.FullName(), "review-audit-task-007-review-1", "abc123", workflow.JobSucceeded, &workflow.AgentResult{Decision: "approved", Summary: "approved"})
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(), Number: 7, HeadBranch: "task-7",
+		BaseBranch: "main", HeadSHA: "abc123", State: "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	d := Daemon{Repo: repo, Store: store, Workflow: &engine}
+
+	if err := d.reconcileReviewingPullRequest(ctx, reviewPull("abc123")); err != nil {
+		t.Fatalf("reconcileReviewingPullRequest returned error: %v", err)
+	}
+	task, err := store.GetTask(ctx, "task-007")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskReadyToMerge) {
+		t.Fatalf("task state = %q, want ready_to_merge (review advanced despite large non-review payload)", task.State)
+	}
+	if len(gate.requests) != 1 || gate.requests[0].HeadSHA != "abc123" {
+		t.Fatalf("merge gate requests = %+v, want one for head abc123", gate.requests)
+	}
+}

--- a/internal/daemon/poll_path_projection_test.go
+++ b/internal/daemon/poll_path_projection_test.go
@@ -3,7 +3,9 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -71,6 +73,67 @@ func reviewPull(headSHA string) github.PullRequest {
 	}
 }
 
+// countingReviewLister wraps a real *db.Store and counts ListJobsByType calls,
+// delegating so the query still returns the real rows. It backs
+// TestPollOnceFetchesReviewJobsOncePerPoll's proof that PollOnce's reviewJobsMemo
+// fetches the review-job list once per poll, not once (or ~2×) per open PR.
+type countingReviewLister struct {
+	inner *db.Store
+	calls int32
+}
+
+func (c *countingReviewLister) ListJobsByType(ctx context.Context, jobType string) ([]db.Job, error) {
+	atomic.AddInt32(&c.calls, 1)
+	return c.inner.ListJobsByType(ctx, jobType)
+}
+
+// TestPollOnceFetchesReviewJobsOncePerPoll pins FIX-F (#620 review): PollOnce fetches
+// the review-job list AT MOST ONCE per poll and shares that snapshot across every open
+// PR's review-job consumers, instead of re-running ListJobsByType("review") per PR. A
+// regression that dropped the per-poll memo (fetching per consumer/per PR) fires the
+// counting lister once per PR and trips the assert.
+func TestPollOnceFetchesReviewJobsOncePerPoll(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "jerryfane", Name: "gitmoot"}
+
+	// Three open PRs, each already stored with a matching head, so pullRequestChanged
+	// takes the unchanged-head path that inspects the review-job list for staleness on
+	// EVERY PR — exactly the per-PR fetch the memo collapses to one.
+	var pulls []github.PullRequest
+	for i := int64(1); i <= 3; i++ {
+		pull := github.PullRequest{
+			Number: i, Title: fmt.Sprintf("Task %d", i), State: "open",
+			URL:     fmt.Sprintf("https://github.com/jerryfane/gitmoot/pull/%d", i),
+			HeadRef: fmt.Sprintf("task-%d", i), BaseRef: "main", HeadSHA: fmt.Sprintf("head-%d", i),
+		}
+		pulls = append(pulls, pull)
+		if err := store.UpsertPullRequest(ctx, db.PullRequest{
+			RepoFullName: repo.FullName(), Number: pull.Number, HeadBranch: pull.HeadRef,
+			BaseBranch: pull.BaseRef, HeadSHA: pull.HeadSHA, State: "open",
+		}); err != nil {
+			t.Fatalf("UpsertPullRequest(%d) returned error: %v", i, err)
+		}
+	}
+	// A large non-review job the memo must never materialize, plus one review job that
+	// matches none of the PRs (keeps the list non-empty without changing any routing).
+	seedLargeNonReviewJob(t, store)
+	seedReviewJob(t, store, repo.FullName(), "review-unrelated", "other-head", workflow.JobQueued, nil)
+
+	counter := &countingReviewLister{inner: store}
+	realNewReviewJobsMemo := newReviewJobsMemo
+	newReviewJobsMemo = func(reviewJobLister) *reviewJobsMemo { return realNewReviewJobsMemo(counter) }
+	defer func() { newReviewJobsMemo = realNewReviewJobsMemo }()
+
+	client := &fakeGitHub{pulls: pulls}
+	if err := (Daemon{Repo: repo, Store: store, GitHub: client}).PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if got := atomic.LoadInt32(&counter.calls); got != 1 {
+		t.Fatalf("ListJobsByType(review) ran %d times across %d PRs, want 1 (memoized once per poll)", got, len(pulls))
+	}
+}
+
 // TestSupersedeStaleReviewJobsSkipsLargeNonReviewPayload proves the #619 projection
 // swap did not change supersession behavior: a stale-head review job is still
 // superseded even with a large non-review payload present that ListJobsByType now
@@ -83,7 +146,7 @@ func TestSupersedeStaleReviewJobsSkipsLargeNonReviewPayload(t *testing.T) {
 	seedReviewJob(t, store, repo.FullName(), "review-stale", "old-head", workflow.JobQueued, nil)
 
 	d := Daemon{Repo: repo, Store: store, Workflow: &workflow.Engine{Store: store}}
-	if err := d.supersedeStaleReviewJobs(ctx, reviewPull("new-head")); err != nil {
+	if err := d.supersedeStaleReviewJobs(ctx, reviewPull("new-head"), nil); err != nil {
 		t.Fatalf("supersedeStaleReviewJobs returned error: %v", err)
 	}
 
@@ -128,7 +191,7 @@ func TestPullRequestWorkflowRoutingStaleAmongLargeNonReviewPayload(t *testing.T)
 		seedLargeNonReviewJob(t, store)
 		seedReviewJob(t, store, repo.FullName(), "review-stale", "old-head", workflow.JobQueued, nil)
 		d := Daemon{Repo: repo, Store: store, Workflow: &workflow.Engine{Store: store}}
-		routing, err := d.pullRequestWorkflowRouting(ctx, reviewPull("new-head"))
+		routing, err := d.pullRequestWorkflowRouting(ctx, reviewPull("new-head"), nil)
 		if err != nil {
 			t.Fatalf("pullRequestWorkflowRouting returned error: %v", err)
 		}
@@ -142,7 +205,7 @@ func TestPullRequestWorkflowRoutingStaleAmongLargeNonReviewPayload(t *testing.T)
 		seedLargeNonReviewJob(t, store)
 		seedReviewJob(t, store, repo.FullName(), "review-current", "cur-head", workflow.JobQueued, nil)
 		d := Daemon{Repo: repo, Store: store, Workflow: &workflow.Engine{Store: store}}
-		routing, err := d.pullRequestWorkflowRouting(ctx, reviewPull("cur-head"))
+		routing, err := d.pullRequestWorkflowRouting(ctx, reviewPull("cur-head"), nil)
 		if err != nil {
 			t.Fatalf("pullRequestWorkflowRouting returned error: %v", err)
 		}
@@ -196,7 +259,7 @@ func TestReconcileReviewingPullRequestAdvancesAmongLargeNonReviewPayload(t *test
 	engine := workflow.Engine{Store: store, MergeGate: gate}
 	d := Daemon{Repo: repo, Store: store, Workflow: &engine}
 
-	if err := d.reconcileReviewingPullRequest(ctx, reviewPull("abc123")); err != nil {
+	if err := d.reconcileReviewingPullRequest(ctx, reviewPull("abc123"), nil); err != nil {
 		t.Fatalf("reconcileReviewingPullRequest returned error: %v", err)
 	}
 	task, err := store.GetTask(ctx, "task-007")

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2460,6 +2460,36 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 	return jobs, rows.Err()
 }
 
+// ListJobsByType returns every job of the given type, with the SAME 14-column
+// projection and ORDER BY id as ListJobs, filtered in SQL by `type = ?`. The PR
+// poll path (#619) only ever needs review jobs, but was calling ListJobs and
+// discarding non-review rows in Go — materializing the whole 37.8MB payload column
+// (including one 11MB implement payload) on every open PR every sweep. Because the
+// `type` column precedes `payload` in the row record, SQLite's `type = ?` filter
+// decides to keep a row before it ever touches the payload's overflow pages, so
+// this decodes payload only for matching rows (~237KB of review payloads vs 37.8MB
+// total on the affected DB). Behavior is byte-identical to ListJobs + a Go type
+// filter; only the avoided payload reads differ. EQP: `SCAN jobs USING INDEX
+// sqlite_autoindex_jobs_1` over the same rows — a dedicated jobs(type) index was
+// not worth its per-insert write cost and is deferred.
+func (s *Store) ListJobsByType(ctx context.Context, jobType string) ([]Job, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at, created_at FROM jobs WHERE type = ? ORDER BY id`, jobType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var jobs []Job
+	for rows.Next() {
+		var job Job
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt); err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, rows.Err()
+}
+
 // ListJobsByParent returns the direct children of parentJobID (delegation
 // children and the coordinator continuation job), ordered by delegation_id then
 // id for a stable tree. It selects updated_at like ListJobs so callers can show

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2442,13 +2442,16 @@ func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
 	return job, nil
 }
 
-func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at, created_at FROM jobs ORDER BY id`)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
+// jobColumns is the 14-column projection ListJobs and ListJobsByType both read (the
+// full jobs row except root_id), kept as one const so their SELECT lists — and the
+// scanJobs scan order below — can never drift apart.
+const jobColumns = `id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at, created_at`
 
+// scanJobs reads every row of a *sql.Rows produced by a `SELECT `+jobColumns+`
+// FROM jobs …` query into Jobs, in jobColumns order, and closes rows. Shared by
+// ListJobs and ListJobsByType so their identical scan lives in exactly one place.
+func scanJobs(rows *sql.Rows) ([]Job, error) {
+	defer rows.Close()
 	var jobs []Job
 	for rows.Next() {
 		var job Job
@@ -2458,6 +2461,14 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 		jobs = append(jobs, job)
 	}
 	return jobs, rows.Err()
+}
+
+func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT `+jobColumns+` FROM jobs ORDER BY id`)
+	if err != nil {
+		return nil, err
+	}
+	return scanJobs(rows)
 }
 
 // ListJobsByType returns every job of the given type, with the SAME 14-column
@@ -2473,21 +2484,11 @@ func (s *Store) ListJobs(ctx context.Context) ([]Job, error) {
 // sqlite_autoindex_jobs_1` over the same rows — a dedicated jobs(type) index was
 // not worth its per-insert write cost and is deferred.
 func (s *Store) ListJobsByType(ctx context.Context, jobType string) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at, created_at FROM jobs WHERE type = ? ORDER BY id`, jobType)
+	rows, err := s.db.QueryContext(ctx, `SELECT `+jobColumns+` FROM jobs WHERE type = ? ORDER BY id`, jobType)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-
-	var jobs []Job
-	for rows.Next() {
-		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt); err != nil {
-			return nil, err
-		}
-		jobs = append(jobs, job)
-	}
-	return jobs, rows.Err()
+	return scanJobs(rows)
 }
 
 // ListJobsByParent returns the direct children of parentJobID (delegation
@@ -2560,6 +2561,13 @@ func (s *Store) SumJobTokensByRoot(ctx context.Context, rootID string) (int, err
 	return total, err
 }
 
+// listQueuedJobsSQL is ListQueuedJobs' exact query, exported as a package-level const
+// so the plan test (TestListQueuedJobsUsesQueuedIndex) can EXPLAIN QUERY PLAN the
+// PRODUCTION text rather than a hand-copied duplicate — a change to this query is then
+// what the test actually asserts a plan for.
+const listQueuedJobsSQL = `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
+		FROM jobs WHERE state = 'queued' ORDER BY created_at, rowid`
+
 // ListQueuedJobs returns the queued jobs in created_at (then rowid) order. The
 // state predicate is the SQL literal 'queued' — not a bound parameter — so SQLite
 // can prove it matches the partial index idx_jobs_queued_created (WHERE
@@ -2568,8 +2576,7 @@ func (s *Store) SumJobTokensByRoot(ctx context.Context, rootID string) (int, err
 // and builds a temp b-tree for the ORDER BY every worker tick (#619, verified by
 // EXPLAIN QUERY PLAN). 'queued' is a fixed constant, so inlining it is safe.
 func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
-		FROM jobs WHERE state = 'queued' ORDER BY created_at, rowid`)
+	rows, err := s.db.QueryContext(ctx, listQueuedJobsSQL)
 	if err != nil {
 		return nil, err
 	}
@@ -2586,6 +2593,13 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	return jobs, rows.Err()
 }
 
+// listRunningJobsUpdatedBeforeSQL is ListRunningJobsUpdatedBefore's exact query,
+// exported as a package-level const so the plan test (TestListRunningJobsUpdatedBeforeOrder)
+// EXPLAINs the PRODUCTION text (binding the threshold as its `?` parameter) instead of
+// a hand-copied duplicate.
+const listRunningJobsUpdatedBeforeSQL = `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
+		FROM jobs WHERE state = 'running' AND updated_at < ? ORDER BY updated_at`
+
 // ListRunningJobsUpdatedBefore returns the running jobs whose updated_at predates
 // the crash-backstop threshold. It orders by updated_at (not id) so the partial
 // index idx_jobs_running_updated_at (WHERE state='running') satisfies both the
@@ -2599,8 +2613,7 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 // independently and does not depend on the ordering; updated_at is fixed-width
 // 'YYYY-MM-DD HH:MM:SS' so lexical order equals chronological order.
 func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Time) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
-		FROM jobs WHERE state = 'running' AND updated_at < ? ORDER BY updated_at`, before.UTC().Format("2006-01-02 15:04:05"))
+	rows, err := s.db.QueryContext(ctx, listRunningJobsUpdatedBeforeSQL, before.UTC().Format("2006-01-02 15:04:05"))
 	if err != nil {
 		return nil, err
 	}
@@ -2897,6 +2910,40 @@ func (s *Store) jobIDsByQuery(ctx context.Context, query string) ([]string, erro
 	return jobIDs, rows.Err()
 }
 
+// The three per-tick candidate GROUP BY queries are exported as package-level consts
+// so the covering-index plan test (TestJobEventsKindJobIDCoveringIndexPlan) EXPLAINs
+// the PRODUCTION query text — not a hand-copied duplicate — for each. A change to any
+// of these queries is then exactly what the covering-index test asserts a plan for.
+const (
+	jobIDsWithPendingDelegationWorktreeReclaimSQL = `SELECT job_id FROM job_events
+		WHERE kind = 'delegation_worktree_cleanup_skipped'
+		  AND id IN (
+			SELECT MAX(id) FROM job_events
+			WHERE kind IN ('delegation_worktree_cleanup_skipped', 'delegation_worktree_removed')
+			GROUP BY job_id
+		)
+		ORDER BY job_id`
+
+	jobIDsWithPendingAdvanceRetrySQL = `SELECT job_id FROM job_events
+		WHERE kind IN ('advance_started', 'advance_retry')
+		  AND id IN (
+			SELECT MAX(id) FROM job_events
+			WHERE kind IN ('advance_started', 'advance_retry', 'advance_completed',
+			               'advance_retried', 'advance_blocked', 'advance_retry_skipped', 'retry_queued')
+			GROUP BY job_id
+		)
+		ORDER BY job_id`
+
+	jobIDsWithPendingCommentRetrySQL = `SELECT job_id FROM job_events
+		WHERE kind = 'comment_post_failed'
+		  AND id IN (
+			SELECT MAX(id) FROM job_events
+			WHERE kind IN ('comment_post_failed', 'comment_posted', 'retry_queued')
+			GROUP BY job_id
+		)
+		ORDER BY job_id`
+)
+
 // JobIDsWithPendingDelegationWorktreeReclaim returns the IDs of jobs whose most
 // recent terminal delegation-worktree cleanup outcome was a PRESERVE
 // (delegation_worktree_cleanup_skipped) NOT yet followed by a removal
@@ -2916,14 +2963,7 @@ func (s *Store) jobIDsByQuery(ctx context.Context, query string) ([]string, erro
 // is a skip — exactly mirroring the per-job lastCleanupOutcomeIsSkip walk, but
 // set-at-once.
 func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) ([]string, error) {
-	return s.jobIDsByQuery(ctx, `SELECT job_id FROM job_events
-		WHERE kind = 'delegation_worktree_cleanup_skipped'
-		  AND id IN (
-			SELECT MAX(id) FROM job_events
-			WHERE kind IN ('delegation_worktree_cleanup_skipped', 'delegation_worktree_removed')
-			GROUP BY job_id
-		)
-		ORDER BY job_id`)
+	return s.jobIDsByQuery(ctx, jobIDsWithPendingDelegationWorktreeReclaimSQL)
 }
 
 // JobIDsWithPendingAdvanceRetry returns the IDs of jobs whose LATEST post-delivery
@@ -2943,15 +2983,7 @@ func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) 
 // switch's default: no-op for every other kind) and the outer filter keeps a job
 // iff that latest tracked event is positive. One row per job (its unique MAX id).
 func (s *Store) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, error) {
-	return s.jobIDsByQuery(ctx, `SELECT job_id FROM job_events
-		WHERE kind IN ('advance_started', 'advance_retry')
-		  AND id IN (
-			SELECT MAX(id) FROM job_events
-			WHERE kind IN ('advance_started', 'advance_retry', 'advance_completed',
-			               'advance_retried', 'advance_blocked', 'advance_retry_skipped', 'retry_queued')
-			GROUP BY job_id
-		)
-		ORDER BY job_id`)
+	return s.jobIDsByQuery(ctx, jobIDsWithPendingAdvanceRetrySQL)
 }
 
 // JobIDsWithPendingCommentRetry returns the IDs of jobs whose LATEST comment event
@@ -2962,14 +2994,7 @@ func (s *Store) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, er
 // tick (#598). The pass re-verifies each candidate with the Go predicate, so this
 // only has to be a superset; it is in fact exact.
 func (s *Store) JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, error) {
-	return s.jobIDsByQuery(ctx, `SELECT job_id FROM job_events
-		WHERE kind = 'comment_post_failed'
-		  AND id IN (
-			SELECT MAX(id) FROM job_events
-			WHERE kind IN ('comment_post_failed', 'comment_posted', 'retry_queued')
-			GROUP BY job_id
-		)
-		ORDER BY job_id`)
+	return s.jobIDsByQuery(ctx, jobIDsWithPendingCommentRetrySQL)
 }
 
 // JobIDsWithOpenEscalation returns the IDs of coordinator jobs with an OPEN
@@ -7024,5 +7049,19 @@ CREATE INDEX idx_job_events_kind_job_id ON job_events(kind, job_id, id);
 	// prior migration.
 	`
 CREATE INDEX idx_jobs_queued_created ON jobs(created_at) WHERE state='queued';
+	`,
+	// #619 drop the now-redundant idx_job_events_kind. The prior migration added
+	// idx_job_events_kind_job_id(kind, job_id, id); its leading column is `kind`, so
+	// it is a strict superset of the single-column idx_job_events_kind(kind) for every
+	// query that leads on kind — which is EVERY kind-filtered job_events query in the
+	// codebase (the three per-tick candidate GROUP BYs, JobIDsWithEventKind, and
+	// JobIDsWithOpenEscalation all filter `kind = ?` / `kind IN (...)`). SQLite serves
+	// those from the composite (EQP verified against a copy of the production DB after
+	// this drop), so idx_job_events_kind only cost write amplification on every
+	// job_events insert. DROP INDEX IF EXISTS is idempotent and a pure removal — no
+	// row reads differently — appended at the end so it does not renumber or alter any
+	// prior migration.
+	`
+DROP INDEX IF EXISTS idx_job_events_kind;
 	`,
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -6946,4 +6946,21 @@ CREATE TABLE merge_gate_ci_observations (
 	UNIQUE(repo_full_name, pull_request)
 );
 	`,
+	// #619 covering index for the per-tick job-event candidate GROUP BY queries
+	// (JobIDsWithPendingAdvanceRetry / CommentRetry / DelegationWorktreeReclaim).
+	// Those queries filter `kind IN (...)` and project only job_id + MAX(id), but
+	// idx_job_events_kind covers only `kind`, so each candidate row still required a
+	// table row fetch to read job_id/id (~23.67 MiB/call for the advance query on the
+	// affected DB). Indexing (kind, job_id, id) lets the planner satisfy both the
+	// outer filter and the MAX(id) GROUP BY index-only. EQP flips all three from
+	// `SEARCH ... USING INDEX idx_job_events_kind (kind=? AND rowid=?)` (with row
+	// fetches) to `SEARCH ... USING COVERING INDEX idx_job_events_kind_job_id
+	// (kind=?)`; the GROUP BY temp b-tree remains (groups span kinds) but now runs
+	// over index-only (job_id,id). job_events.id is INTEGER PRIMARY KEY (a rowid
+	// alias) so id is covered. Result sets are byte-identical — pure additive index
+	// (idx_job_events_kind is kept for pure kind= lookups), no renumber/alter of any
+	// prior migration.
+	`
+CREATE INDEX idx_job_events_kind_job_id ON job_events(kind, job_id, id);
+	`,
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2560,9 +2560,16 @@ func (s *Store) SumJobTokensByRoot(ctx context.Context, rootID string) (int, err
 	return total, err
 }
 
+// ListQueuedJobs returns the queued jobs in created_at (then rowid) order. The
+// state predicate is the SQL literal 'queued' — not a bound parameter — so SQLite
+// can prove it matches the partial index idx_jobs_queued_created (WHERE
+// state='queued') and read the queued rows in order directly; a bound `state = ?`
+// leaves the planner unable to prove the partial predicate, so it full-scans jobs
+// and builds a temp b-tree for the ORDER BY every worker tick (#619, verified by
+// EXPLAIN QUERY PLAN). 'queued' is a fixed constant, so inlining it is safe.
 func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
-		FROM jobs WHERE state = ? ORDER BY created_at, rowid`, "queued")
+		FROM jobs WHERE state = 'queued' ORDER BY created_at, rowid`)
 	if err != nil {
 		return nil, err
 	}
@@ -2579,9 +2586,21 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	return jobs, rows.Err()
 }
 
+// ListRunningJobsUpdatedBefore returns the running jobs whose updated_at predates
+// the crash-backstop threshold. It orders by updated_at (not id) so the partial
+// index idx_jobs_running_updated_at (WHERE state='running') satisfies both the
+// filter and the ordering — an `ORDER BY id` defeated that index and forced a full
+// primary-key scan of the whole jobs table each worker tick (#619). The state
+// predicate is the SQL literal 'running' (not a bound parameter) for the same
+// reason ListQueuedJobs inlines 'queued': SQLite only applies a partial index when
+// it can prove the query's WHERE implies the index's predicate, which a bound
+// `state = ?` prevents (EXPLAIN QUERY PLAN falls back to a scan + temp b-tree).
+// The sole caller (recoverRunningJobsBeforeForRepoSkipping) processes each row
+// independently and does not depend on the ordering; updated_at is fixed-width
+// 'YYYY-MM-DD HH:MM:SS' so lexical order equals chronological order.
 func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Time) ([]Job, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
-		FROM jobs WHERE state = ? AND updated_at < ? ORDER BY id`, "running", before.UTC().Format("2006-01-02 15:04:05"))
+		FROM jobs WHERE state = 'running' AND updated_at < ? ORDER BY updated_at`, before.UTC().Format("2006-01-02 15:04:05"))
 	if err != nil {
 		return nil, err
 	}
@@ -6992,5 +7011,18 @@ CREATE TABLE merge_gate_ci_observations (
 	// prior migration.
 	`
 CREATE INDEX idx_job_events_kind_job_id ON job_events(kind, job_id, id);
+	`,
+	// #619 partial index for the per-tick ListQueuedJobs poll. That query
+	// (`WHERE state='queued' ORDER BY created_at, rowid`) had no supporting index,
+	// so it full-scanned jobs and built a temp b-tree for the ORDER BY every worker
+	// tick. A partial index on created_at over only the queued rows lets the planner
+	// read them in created_at order directly (the partial index carries rowid as the
+	// implicit tiebreaker, satisfying `created_at, rowid`) and indexes only the small
+	// queued set, not the terminal-job backlog. ListQueuedJobs' text is unchanged.
+	// EQP flips from `SCAN jobs` + `USE TEMP B-TREE FOR ORDER BY` to `SCAN jobs USING
+	// INDEX idx_jobs_queued_created`. Pure additive index, no renumber/alter of any
+	// prior migration.
+	`
+CREATE INDEX idx_jobs_queued_created ON jobs(created_at) WHERE state='queued';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -4602,10 +4602,12 @@ func TestJobIDsWithOpenEscalationRaceSafe(t *testing.T) {
 
 // explainQueryPlan runs EXPLAIN QUERY PLAN for query and returns the plan's detail
 // lines joined by newline so index-choice assertions read cleanly. store_test is
-// package db (white-box), so it can reach store.db directly.
-func explainQueryPlan(t *testing.T, store *Store, query string) string {
+// package db (white-box), so it can reach store.db directly. args binds any `?`
+// placeholders in query so production SQL consts carrying parameters (e.g.
+// listRunningJobsUpdatedBeforeSQL) can be EXPLAINed verbatim.
+func explainQueryPlan(t *testing.T, store *Store, query string, args ...any) string {
 	t.Helper()
-	rows, err := store.db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+query)
+	rows, err := store.db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+query, args...)
 	if err != nil {
 		t.Fatalf("EXPLAIN QUERY PLAN returned error: %v", err)
 	}
@@ -4627,8 +4629,10 @@ func explainQueryPlan(t *testing.T, store *Store, query string) string {
 
 // TestJobEventsKindJobIDCoveringIndexPlan pins the #619 covering index: each of the
 // three per-tick candidate GROUP BY queries must be served index-only by
-// idx_job_events_kind_job_id, with no fall-through to the non-covering
-// idx_job_events_kind (which forced a table row fetch per candidate row).
+// idx_job_events_kind_job_id. It also pins FIX-E: the redundant single-column
+// idx_job_events_kind is dropped by the migrations, so the composite (whose leading
+// column is `kind`) is now the SOLE kind index — every kind-filtered query still
+// plans through it after the drop.
 func TestJobEventsKindJobIDCoveringIndexPlan(t *testing.T) {
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
 	if err != nil {
@@ -4636,44 +4640,26 @@ func TestJobEventsKindJobIDCoveringIndexPlan(t *testing.T) {
 	}
 	defer store.Close()
 
+	// FIX-E: the migrations dropped idx_job_events_kind; confirm it is gone so the
+	// covering-index assertions below prove the composite carries these queries alone.
+	var kindIndexes int
+	if err := store.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_job_events_kind'`).Scan(&kindIndexes); err != nil {
+		t.Fatalf("query sqlite_master returned error: %v", err)
+	}
+	if kindIndexes != 0 {
+		t.Fatalf("idx_job_events_kind still exists; FIX-E migration should have dropped it")
+	}
+
+	// EXPLAIN the PRODUCTION query text (the exported consts), not hand-copied SQL, so
+	// a change to any candidate query is what this covering-index plan is asserted for.
 	cases := []struct {
 		name  string
 		query string
 	}{
-		{
-			name: "advance",
-			query: `SELECT job_id FROM job_events
-				WHERE kind IN ('advance_started', 'advance_retry')
-				  AND id IN (
-					SELECT MAX(id) FROM job_events
-					WHERE kind IN ('advance_started', 'advance_retry', 'advance_completed',
-					               'advance_retried', 'advance_blocked', 'advance_retry_skipped', 'retry_queued')
-					GROUP BY job_id
-				)
-				ORDER BY job_id`,
-		},
-		{
-			name: "comment",
-			query: `SELECT job_id FROM job_events
-				WHERE kind = 'comment_post_failed'
-				  AND id IN (
-					SELECT MAX(id) FROM job_events
-					WHERE kind IN ('comment_post_failed', 'comment_posted', 'retry_queued')
-					GROUP BY job_id
-				)
-				ORDER BY job_id`,
-		},
-		{
-			name: "reclaim",
-			query: `SELECT job_id FROM job_events
-				WHERE kind = 'delegation_worktree_cleanup_skipped'
-				  AND id IN (
-					SELECT MAX(id) FROM job_events
-					WHERE kind IN ('delegation_worktree_cleanup_skipped', 'delegation_worktree_removed')
-					GROUP BY job_id
-				)
-				ORDER BY job_id`,
-		},
+		{name: "advance", query: jobIDsWithPendingAdvanceRetrySQL},
+		{name: "comment", query: jobIDsWithPendingCommentRetrySQL},
+		{name: "reclaim", query: jobIDsWithPendingDelegationWorktreeReclaimSQL},
 	}
 
 	for _, tc := range cases {
@@ -4682,11 +4668,12 @@ func TestJobEventsKindJobIDCoveringIndexPlan(t *testing.T) {
 			if !strings.Contains(plan, "COVERING INDEX idx_job_events_kind_job_id") {
 				t.Fatalf("plan does not use the covering index:\n%s", plan)
 			}
-			// The non-covering idx_job_events_kind renders "USING INDEX
-			// idx_job_events_kind (kind=? AND rowid=?)" — its trailing "(" plus a
-			// table row fetch is exactly what the covering index removes.
+			// Guard against any fall-through to a non-covering kind index (the dropped
+			// idx_job_events_kind rendered "USING INDEX idx_job_events_kind (kind=? AND
+			// rowid=?)" — its trailing "(" plus a table row fetch is what the covering
+			// index removes).
 			if strings.Contains(plan, "USING INDEX idx_job_events_kind (") {
-				t.Fatalf("plan still row-fetches via the non-covering idx_job_events_kind:\n%s", plan)
+				t.Fatalf("plan still row-fetches via a non-covering idx_job_events_kind:\n%s", plan)
 			}
 		})
 	}
@@ -4789,8 +4776,7 @@ func TestListQueuedJobsUsesQueuedIndex(t *testing.T) {
 		}
 	}
 
-	plan := explainQueryPlan(t, store, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
-		FROM jobs WHERE state = 'queued' ORDER BY created_at, rowid`)
+	plan := explainQueryPlan(t, store, listQueuedJobsSQL)
 	if !strings.Contains(plan, "USING INDEX idx_jobs_queued_created") {
 		t.Fatalf("ListQueuedJobs plan does not use idx_jobs_queued_created:\n%s", plan)
 	}
@@ -4866,8 +4852,7 @@ func TestListRunningJobsUpdatedBeforeOrder(t *testing.T) {
 		}
 	}
 
-	plan := explainQueryPlan(t, store, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
-		FROM jobs WHERE state = 'running' AND updated_at < '2026-02-01 00:00:00' ORDER BY updated_at`)
+	plan := explainQueryPlan(t, store, listRunningJobsUpdatedBeforeSQL, "2026-02-01 00:00:00")
 	if !strings.Contains(plan, "idx_jobs_running_updated_at") {
 		t.Fatalf("ListRunningJobsUpdatedBefore plan does not use idx_jobs_running_updated_at:\n%s", plan)
 	}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math/rand"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -4688,5 +4689,73 @@ func TestJobEventsKindJobIDCoveringIndexPlan(t *testing.T) {
 				t.Fatalf("plan still row-fetches via the non-covering idx_job_events_kind:\n%s", plan)
 			}
 		})
+	}
+}
+
+// TestListJobsByType pins the #619 poll-path projection: ListJobsByType returns
+// exactly the rows of the requested type — with the full ListJobs projection
+// (payload included) — in id order, and nil for a type with no rows.
+func TestListJobsByType(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	seed := []Job{
+		{ID: "job-a-review", Agent: "reviewer", Type: "review", State: "queued", Payload: `{"repo":"owner/repo","kind":"review-a"}`},
+		{ID: "job-b-implement", Agent: "coder", Type: "implement", State: "running", Payload: `{"repo":"owner/repo","kind":"implement-b"}`},
+		{ID: "job-c-review", Agent: "reviewer", Type: "review", State: "succeeded", Payload: `{"repo":"owner/repo","kind":"review-c"}`},
+		{ID: "job-d-ask", Agent: "asker", Type: "ask", State: "queued", Payload: `{"repo":"owner/repo","kind":"ask-d"}`},
+	}
+	for _, job := range seed {
+		if err := store.CreateJob(ctx, job); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", job.ID, err)
+		}
+	}
+
+	got, err := store.ListJobsByType(ctx, "review")
+	if err != nil {
+		t.Fatalf("ListJobsByType returned error: %v", err)
+	}
+	wantIDs := []string{"job-a-review", "job-c-review"}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("ListJobsByType(review) returned %d jobs, want %d: %+v", len(got), len(wantIDs), got)
+	}
+	for i, job := range got {
+		if job.ID != wantIDs[i] {
+			t.Fatalf("job[%d].ID = %q, want %q (order must be by id)", i, job.ID, wantIDs[i])
+		}
+		if job.Type != "review" {
+			t.Fatalf("job[%d].Type = %q, want review", i, job.Type)
+		}
+		if job.Payload == "" {
+			t.Fatalf("job[%d].Payload is empty; the projection must materialize payload", i)
+		}
+		if job.State == "" || job.Agent == "" {
+			t.Fatalf("job[%d] missing fields: %+v", i, job)
+		}
+	}
+
+	// ListJobsByType must equal ListJobs filtered by type in Go (byte-identical rows).
+	all, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var wantReview []Job
+	for _, job := range all {
+		if job.Type == "review" {
+			wantReview = append(wantReview, job)
+		}
+	}
+	if !reflect.DeepEqual(got, wantReview) {
+		t.Fatalf("ListJobsByType(review) = %+v, want ListJobs-filtered %+v", got, wantReview)
+	}
+
+	if unknown, err := store.ListJobsByType(ctx, "nonexistent"); err != nil {
+		t.Fatalf("ListJobsByType(nonexistent) returned error: %v", err)
+	} else if unknown != nil {
+		t.Fatalf("ListJobsByType(nonexistent) = %+v, want nil", unknown)
 	}
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -4598,3 +4598,95 @@ func TestJobIDsWithOpenEscalationRaceSafe(t *testing.T) {
 		}
 	}
 }
+
+// explainQueryPlan runs EXPLAIN QUERY PLAN for query and returns the plan's detail
+// lines joined by newline so index-choice assertions read cleanly. store_test is
+// package db (white-box), so it can reach store.db directly.
+func explainQueryPlan(t *testing.T, store *Store, query string) string {
+	t.Helper()
+	rows, err := store.db.QueryContext(context.Background(), "EXPLAIN QUERY PLAN "+query)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN returned error: %v", err)
+	}
+	defer rows.Close()
+	var lines []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			t.Fatalf("scan EQP row returned error: %v", err)
+		}
+		lines = append(lines, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("EQP rows error: %v", err)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// TestJobEventsKindJobIDCoveringIndexPlan pins the #619 covering index: each of the
+// three per-tick candidate GROUP BY queries must be served index-only by
+// idx_job_events_kind_job_id, with no fall-through to the non-covering
+// idx_job_events_kind (which forced a table row fetch per candidate row).
+func TestJobEventsKindJobIDCoveringIndexPlan(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name: "advance",
+			query: `SELECT job_id FROM job_events
+				WHERE kind IN ('advance_started', 'advance_retry')
+				  AND id IN (
+					SELECT MAX(id) FROM job_events
+					WHERE kind IN ('advance_started', 'advance_retry', 'advance_completed',
+					               'advance_retried', 'advance_blocked', 'advance_retry_skipped', 'retry_queued')
+					GROUP BY job_id
+				)
+				ORDER BY job_id`,
+		},
+		{
+			name: "comment",
+			query: `SELECT job_id FROM job_events
+				WHERE kind = 'comment_post_failed'
+				  AND id IN (
+					SELECT MAX(id) FROM job_events
+					WHERE kind IN ('comment_post_failed', 'comment_posted', 'retry_queued')
+					GROUP BY job_id
+				)
+				ORDER BY job_id`,
+		},
+		{
+			name: "reclaim",
+			query: `SELECT job_id FROM job_events
+				WHERE kind = 'delegation_worktree_cleanup_skipped'
+				  AND id IN (
+					SELECT MAX(id) FROM job_events
+					WHERE kind IN ('delegation_worktree_cleanup_skipped', 'delegation_worktree_removed')
+					GROUP BY job_id
+				)
+				ORDER BY job_id`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := explainQueryPlan(t, store, tc.query)
+			if !strings.Contains(plan, "COVERING INDEX idx_job_events_kind_job_id") {
+				t.Fatalf("plan does not use the covering index:\n%s", plan)
+			}
+			// The non-covering idx_job_events_kind renders "USING INDEX
+			// idx_job_events_kind (kind=? AND rowid=?)" — its trailing "(" plus a
+			// table row fetch is exactly what the covering index removes.
+			if strings.Contains(plan, "USING INDEX idx_job_events_kind (") {
+				t.Fatalf("plan still row-fetches via the non-covering idx_job_events_kind:\n%s", plan)
+			}
+		})
+	}
+}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -4759,3 +4759,116 @@ func TestListJobsByType(t *testing.T) {
 		t.Fatalf("ListJobsByType(nonexistent) = %+v, want nil", unknown)
 	}
 }
+
+// TestListQueuedJobsUsesQueuedIndex pins FIX-4b (#619): ListQueuedJobs is served by
+// the partial index idx_jobs_queued_created with no temp b-tree, and returns only
+// queued rows in created_at then rowid order.
+func TestListQueuedJobsUsesQueuedIndex(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	seed := []struct {
+		id, state, createdAt string
+	}{
+		{"q3", "queued", "2026-01-03 00:00:00"},
+		{"q1", "queued", "2026-01-01 00:00:00"},
+		{"q2", "queued", "2026-01-02 00:00:00"},
+		{"r1", "running", "2026-01-01 00:00:00"},
+		{"done", "succeeded", "2026-01-01 00:00:00"},
+	}
+	for _, s := range seed {
+		if err := store.CreateJob(ctx, Job{ID: s.id, Agent: "a", Type: "implement", State: s.state}); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", s.id, err)
+		}
+		if _, err := store.db.ExecContext(ctx, `UPDATE jobs SET created_at = ? WHERE id = ?`, s.createdAt, s.id); err != nil {
+			t.Fatalf("set created_at(%s) returned error: %v", s.id, err)
+		}
+	}
+
+	plan := explainQueryPlan(t, store, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
+		FROM jobs WHERE state = 'queued' ORDER BY created_at, rowid`)
+	if !strings.Contains(plan, "USING INDEX idx_jobs_queued_created") {
+		t.Fatalf("ListQueuedJobs plan does not use idx_jobs_queued_created:\n%s", plan)
+	}
+	if strings.Contains(plan, "TEMP B-TREE") {
+		t.Fatalf("ListQueuedJobs plan still builds a temp b-tree:\n%s", plan)
+	}
+
+	got, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	wantIDs := []string{"q1", "q2", "q3"}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("ListQueuedJobs returned %d jobs, want %d: %+v", len(got), len(wantIDs), got)
+	}
+	for i, job := range got {
+		if job.ID != wantIDs[i] {
+			t.Fatalf("job[%d].ID = %q, want %q (created_at, rowid order)", i, job.ID, wantIDs[i])
+		}
+		if job.State != "queued" {
+			t.Fatalf("job[%d].State = %q, want queued only", i, job.State)
+		}
+	}
+}
+
+// TestListRunningJobsUpdatedBeforeOrder pins FIX-4a (#619): ListRunningJobsUpdatedBefore
+// orders by updated_at (not id), applies the running/threshold filter, and is served
+// by idx_jobs_running_updated_at.
+func TestListRunningJobsUpdatedBeforeOrder(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	// updated_at order (job-2, job-3, job-1) deliberately differs from id order
+	// (job-1, job-2, job-3) so the result proves ordering by updated_at, not id.
+	seed := []struct {
+		id, state, updatedAt string
+		wantBefore           bool
+	}{
+		{"job-1", "running", "2026-01-30 00:00:00", true},
+		{"job-2", "running", "2026-01-10 00:00:00", true},
+		{"job-3", "running", "2026-01-20 00:00:00", true},
+		{"job-4", "running", "2026-06-01 00:00:00", false}, // after threshold
+		{"job-5", "queued", "2026-01-05 00:00:00", false},  // not running
+	}
+	for _, s := range seed {
+		if err := store.CreateJob(ctx, Job{ID: s.id, Agent: "a", Type: "implement", State: s.state}); err != nil {
+			t.Fatalf("CreateJob(%s) returned error: %v", s.id, err)
+		}
+		if _, err := store.db.ExecContext(ctx, `UPDATE jobs SET updated_at = ? WHERE id = ?`, s.updatedAt, s.id); err != nil {
+			t.Fatalf("set updated_at(%s) returned error: %v", s.id, err)
+		}
+	}
+
+	before := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	got, err := store.ListRunningJobsUpdatedBefore(ctx, before)
+	if err != nil {
+		t.Fatalf("ListRunningJobsUpdatedBefore returned error: %v", err)
+	}
+	wantIDs := []string{"job-2", "job-3", "job-1"}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("returned %d jobs, want %d: %+v", len(got), len(wantIDs), got)
+	}
+	for i, job := range got {
+		if job.ID != wantIDs[i] {
+			t.Fatalf("job[%d].ID = %q, want %q (updated_at order)", i, job.ID, wantIDs[i])
+		}
+		if job.State != "running" {
+			t.Fatalf("job[%d].State = %q, want running only", i, job.State)
+		}
+	}
+
+	plan := explainQueryPlan(t, store, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
+		FROM jobs WHERE state = 'running' AND updated_at < '2026-02-01 00:00:00' ORDER BY updated_at`)
+	if !strings.Contains(plan, "idx_jobs_running_updated_at") {
+		t.Fatalf("ListRunningJobsUpdatedBefore plan does not use idx_jobs_running_updated_at:\n%s", plan)
+	}
+}


### PR DESCRIPTION
Fixes #619.

After #615 the daemon dropped from a pegged core to ~40% — verified profiling (see #619) attributed the residue to two byte sources: the #615 candidate query run **once per repo (18×) per 1s tick** (~71% of reads, 23.7 MiB/call, temp b-tree spill, 0 candidates found), and poll-path `ListJobs` materializing the full 37.8 MB payload column per open PR (~29%). This PR eliminates both, one commit per fix.

## 1. `fix(daemon)`: hoist per-tick job-candidate queries (`13742ec`)

The global candidate sets (`JobIDsWithPendingAdvanceRetry` / `JobIDsWithPendingCommentRetry` / `JobIDsWithPendingDelegationWorktreeReclaim`) take no repo argument, yet each of the 18 per-repo worker ticks re-ran them. A per-tick carrier now computes each **once per tick** and shares the result across repos; per-repo filtering and the #615 per-candidate predicate re-check are unchanged. Covers the multi-repo tracked path, single-repo path, and dry-run. Regression test `TestTickCandidatesComputedOncePerTick` proves once-per-tick with a counting store at the `runEnabledRepoWorkerTicksTracked` integration level. **Removes ~17/18ths of the dominant read source (~66% of all reads).**

## 2. `fix(db)`: covering index for the candidate GROUP BY (`978b7d6`)

`job_events(kind, job_id, id)` covering index (shipped via the standard migration chain) so the `kind IN (...) GROUP BY job_id` candidate queries stop doing 62k random row lookups + a temp b-tree spill per call. `TestJobEventsKindJobIDCoveringIndexPlan` asserts the EXPLAIN QUERY PLAN uses the covering index for all three queries.

## 3. `fix(daemon)`: read only review jobs on the PR poll path (`849f3d1`)

`pullRequestWorkflowRouting` / `reconcileReviewingPullRequest` / `supersedeStaleReviewJobs` only ever act on review jobs, but each called full `ListJobs` (40.7 MB/call — every payload including an 11 MB one) 1–6× per open PR per sweep. New `ListJobsByType("review")` projection filters in SQL; parity tests prove identical routing/reconcile/supersede decisions with large non-review payloads present.

## 4. `fix(db)`: index queued jobs, order running recovery by `updated_at` (`753b2df`)

Partial index for the `ListQueuedJobs` scan and `ORDER BY updated_at` so `ListRunningJobsUpdatedBefore` uses `idx_jobs_running_updated_at`. **EXPLAIN-verified detail:** with a bound `state = ?` parameter SQLite cannot prove a partial-index predicate — the state literals are inlined (constants, not user input), otherwise the ORDER BY change alone would have *regressed* to `SCAN jobs + TEMP B-TREE`. Plan assertions in store tests pin both.

## Expected effect (from #619's verified numbers)

| Per ~1s tick / per sweep | before | after |
|---|---|---|
| Candidate-query reads | 18 × 23.7 MiB ≈ 426 MiB/tick | 1 × ~small (covering index, no spill) |
| Poll-path jobs reads | 40.7 MB × (1–6 × open PRs)/sweep | review-rows only |
| ListQueued/ListRunning scans | ~124 MB/tick combined | indexed point lookups |

Remaining ops step (per #619, not code): one-time prune of the ~117k dead `advance_retry`/`runtime_lock_wait` rows (95% of job_events) after deploy.

## Testing

- Full suite: **33/33 packages green** (`go test ./...`), `go vet` clean
- Race: green over `internal/{db,daemon,workflow,cli}` (cli split into batches for wall-clock; zero `DATA RACE`)
- 49 targeted race tests over the changed areas incl. the full `daemon_worker_loop_escalate_e2e` set
- New regression tests: once-per-tick counting-store proof, EQP covering-index + partial-index plan assertions, poll-path parity trio, mutation guards kept from #615
- Design reviewed by adversarial correctness + conventions judges before implementation (zero blocking findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
