### PR TITLE
feat(daemon): operational-blocker classification slices B–F (#532)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -20,7 +20,7 @@ The pilot emits a tight allowlist of event types over the webhook transport:
 | `job.failed`                    | a job reaches the `failed` terminal state                                          |
 | `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
 | `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
-| `job.deferred`                  | the daemon re-queued a job that just emitted `job.failed` because the failure classified as a retryable operational blocker (runtime auth, rate limit/quota) — it will be re-dispatched automatically |
+| `job.deferred`                  | the daemon re-queued a run whose delivery failed on a retryable operational blocker (runtime auth, rate limit/quota, network/GitHub outage, checkout contention) — it will be re-dispatched automatically. Since #532 slice E this is a **first-class** transition emitted INSTEAD of `job.failed` (no preceding `job.failed` for that run) |
 | `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
 | `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current` (also the canary GRADUATE event) |
 | `candidate.canary_started`      | the off-by-default `[skillopt].auto_promote_canary` policy promoted a candidate to the `canary` state behind the live champion |
@@ -32,16 +32,24 @@ pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
 pass through that path. `job.needs_attention` is emitted once per fresh
 escalation round (a re-advance does not re-emit).
 
-**`job.failed` followed by `job.deferred` is NOT terminal.** When a run fails on
-a classified operational blocker (runtime auth rejected, provider rate
-limit/quota), the engine has already emitted `job.failed` for that run before the
-daemon decides to defer; the daemon then emits `job.deferred` for the same
-`job_id` (detail carries the blocker class, the `attempt N/M` retry budget, and
-the earliest `retry at` timestamp) and silently re-dispatches the job after the
-hold. Consumers acting on `job.failed` (recovery, alerting, cleanup) should
-suppress terminal handling for a job whose `job.failed` is followed by a
-`job.deferred`, and treat only a `job.failed` with no subsequent `job.deferred`
-as final.
+**`job.deferred` is a first-class transition — a deferred run does NOT emit
+`job.failed` first.** When a run's delivery fails on a classified operational
+blocker (runtime auth rejected, provider rate limit/quota, network/GitHub outage,
+or a self-healing checkout contention), the classification now happens
+**pre-terminally** in the mailbox seam (#532 slice E): the run is re-queued
+directly and the daemon emits **only** `job.deferred` for that `job_id` (detail
+carries the blocker class, the `attempt N/M` retry budget, and the earliest
+`retry at` timestamp), then silently re-dispatches after the hold. Product
+failures (the agent answered with a `gitmoot_result`, including
+`decision=failed`) still emit `job.failed` and are never auto-retried.
+
+Migration note: before slice E the daemon emitted `job.failed` **then**
+`job.deferred` for the same run (the accepted first-slice flap); consumers had to
+suppress terminal handling for a `job.failed` followed by a `job.deferred`. That
+flap is gone. A `job.failed` with no following `job.deferred` was already the only
+"final" signal, so the safe consumer rule is unchanged and forward-compatible:
+**treat `job.failed` as final only when it is not immediately followed by a
+`job.deferred` for the same `job_id`.**
 
 The two `candidate.*` events come from the `skillopt import` / `train continue`
 CLI path, NOT the daemon (#471). When a candidate becomes `pending`,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -407,12 +407,18 @@ Fixes:
 - `gitmoot job list` appends a `WHY:` column and `gitmoot job show` prints a
   `why_stuck:` line for queued/blocked jobs (#552) — a runtime-session lock
   wait (naming the holder), `blocked: awaiting human`, `auth failing: …`,
-  `throttled: …`, or `retrying: …` with the attempt schedule.
-- Deferred jobs recover on their own (#532): a delivery failure classified as
-  a retryable operational blocker (runtime auth, provider rate limit/quota) is
-  re-queued with a bounded retry budget instead of failing terminally —
-  `job show --json` carries the `blocker_class` and attempt count. Only act
-  when the retry budget is spent and the job stays failed.
+  `throttled: …`, `retrying: …`, or a `blocked-operational: <class>` deferral
+  with the attempt schedule. A deferral that needs a human (dirty/wrong-head
+  checkout) also prints a `suggested_action` naming the fix.
+- Deferred jobs recover on their own (#532): a delivery failure classified as a
+  retryable operational blocker — `runtime_auth`, `runtime_quota`,
+  `network_outage`, or `checkout_contention` — is re-queued with a bounded
+  retry budget instead of failing terminally. `job show --json` carries the
+  `blocker_class`, attempt count, and `suggested_action`. A `runtime_auth`
+  deferral only re-dispatches once a live doctor-style credential probe passes
+  (a failing probe extends the hold without spending a retry). Over `[events]`
+  the deferral is a first-class `job.deferred` emitted instead of `job.failed`.
+  Only act when the retry budget is spent and the job stays failed.
 - A job stuck in `running` is recovered automatically once it shows no lease
   progress past the staleness window (default 30m; tune with the
   `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value

--- a/internal/cli/blocker_defer_e2e_test.go
+++ b/internal/cli/blocker_defer_e2e_test.go
@@ -189,7 +189,7 @@ printf '%%s' '%s'`, countFile, marker, marker, promptFile, blockerE2EApprovedRes
 	// While inside the hold window, the queue gate must keep the job out of the
 	// pending listing and re-dispatch attempts must not deliver.
 	if time.Now().UTC().Before(retryAt) {
-		pending, err := listPendingQueuedJobs(ctx, worker, "", "")
+		pending, err := listPendingQueuedJobs(ctx, worker, "", "", true)
 		if err != nil {
 			t.Fatalf("listPendingQueuedJobs returned error: %v", err)
 		}

--- a/internal/cli/blocker_defer_e2e_test.go
+++ b/internal/cli/blocker_defer_e2e_test.go
@@ -23,7 +23,7 @@ import (
 // script fails the FIRST delivery with a fabricated 429-with-reset and succeeds
 // on the second, driven through the REAL daemon dispatch entry
 // (runQueuedJobsForRepo → listPendingQueuedJobs → jobWorker.run → engine.RunJob
-// → ShellAdapter → real subprocess → Mailbox.fail → deferOperationalBlocker).
+// → ShellAdapter → real subprocess → Mailbox.Run's pre-terminal BlockerDeferrer).
 //
 // MUTATION PROOF: disable the classification match (make
 // classifyOperationalBlocker return false, or drop the "throttled" case) and

--- a/internal/cli/blocker_slices_e2e_test.go
+++ b/internal/cli/blocker_slices_e2e_test.go
@@ -302,7 +302,7 @@ func TestE2E532SliceBAuthReDispatchGatedOnProbe(t *testing.T) {
 	}
 
 	// Phase 1: probe Invalid -> held, hold extended, attempt NOT burned.
-	pending, err := listPendingQueuedJobs(ctx, worker, "", "")
+	pending, err := listPendingQueuedJobs(ctx, worker, "", "", true)
 	if err != nil {
 		t.Fatalf("listPendingQueuedJobs: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestE2E532SliceBAuthReDispatchGatedOnProbe(t *testing.T) {
 	// Phase 2: probe now Valid AND the hold re-elapsed -> the job is eligible.
 	verdict = authProbeValid
 	seedElapsedAuthHold()
-	pending, err = listPendingQueuedJobs(ctx, worker, "", "")
+	pending, err = listPendingQueuedJobs(ctx, worker, "", "", true)
 	if err != nil {
 		t.Fatalf("listPendingQueuedJobs: %v", err)
 	}
@@ -402,5 +402,192 @@ printf '%%s' '%s'`, marker, marker, promptFile, blockerE2EApprovedResult)
 	// Composed with the at-least-once reconciliation notice.
 	if !strings.Contains(text, "reconcile") {
 		t.Fatalf("retry prompt lost the reconciliation notice:\n%s", text)
+	}
+}
+
+// TestE2E532CheckoutContentionRetrySuppressesReconciliation proves the slice-F
+// reconciliation notice is NOT prepended when the prior deferral was PRE-DELIVERY —
+// a checkout_contention hold trips at the daemon pre-flight, BEFORE the agent is
+// ever delivered a prompt, so the re-dispatch is a FIRST run with no prior side
+// effects to reconcile. Telling the agent otherwise would send it hunting for
+// non-existent artifacts (or mis-reconciling its own PR branch).
+//
+// MUTATION PROOF: drop `&& !payload.BlockerPreDelivery` from the Mailbox.Run gate
+// (or the BlockerPreDelivery=true in deferCheckoutContention) and the "must NOT
+// contain" assertions flip RED.
+func TestE2E532CheckoutContentionRetrySuppressesReconciliation(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	state := t.TempDir()
+	promptFile := filepath.Join(state, "delivered-prompt")
+	// Capture the delivered prompt and succeed on the first (and only) delivery.
+	script := fmt.Sprintf(`printf '%%s' "$1" > %q
+printf '%%s' '%s'`, promptFile, blockerE2EApprovedResult)
+	seedDaemonWorkerAgent(t, store, "checkoutbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-checkout", Agent: "checkoutbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+
+	// Seed a PRE-DELIVERY checkout_contention deferral whose hold has already elapsed
+	// (the daemon pre-flight would have set exactly these fields; the agent never ran).
+	job, payload := blockerE2EJobPayload(t, store, "job-checkout")
+	payload.BlockerClass = string(blockerClassCheckoutContention)
+	payload.BlockerAttempts = 1
+	payload.BlockerRetryAt = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano)
+	payload.BlockerPreDelivery = true
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload: %v", err)
+	}
+
+	worker := blockerE2EWorker(store, home, checkout)
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, p := blockerE2EJobPayload(t, store, "job-checkout"); p.Result == nil || p.Result.Decision != "approved" {
+		t.Fatalf("job did not run to an approved result: %+v", p.Result)
+	}
+	prompt, err := os.ReadFile(promptFile)
+	if err != nil {
+		t.Fatalf("read delivered prompt: %v", err)
+	}
+	text := string(prompt)
+	// The pre-delivery retry must NOT carry any at-least-once reconciliation framing:
+	// there was no prior attempt and no side effects to reconcile.
+	if strings.Contains(text, "did NOT fail on the merits") ||
+		strings.Contains(text, "operational blocker (checkout_contention)") ||
+		strings.Contains(text, "pushed branches") {
+		t.Fatalf("a pre-delivery checkout_contention retry wrongly carried the slice-F reconciliation notice:\n%s", text)
+	}
+}
+
+// TestAuthProbeDedupedAndCadenceMarkedPerPass proves two defects from the slice-B
+// review are fixed at once: (1) the live credential probe is computed AT MOST ONCE
+// per listPendingQueuedJobs pass and shared across every auth-held job of the same
+// effective runtime (the ambient-token verdict is identical for all of them), and
+// (2) a probe-cadence marker is written on EVERY verdict — here a VALID one — so a
+// job that probed this cadence is re-held and NOT re-probed on the next pass.
+//
+// MUTATION PROOF: remove the authProbeCache dedup and probeCalls jumps to 2; drop
+// the extendAuthBlockerHold call on the Valid branch and BlockerRetryAt stays in the
+// past so the "re-held into the future" assertion flips RED.
+func TestAuthProbeDedupedAndCadenceMarkedPerPass(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	// Two DISTINCT agents that share one runtime: the ambient-token probe is identical
+	// for both, so they must collapse to a single live probe.
+	seedDaemonWorkerAgent(t, store, "authbot-a", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "authbot-b", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+	for _, spec := range []struct{ id, agent string }{{"job-auth-a", "authbot-a"}, {"job-auth-b", "authbot-b"}} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+			ID: spec.id, Agent: spec.agent, Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+		})
+		job, payload := blockerE2EJobPayload(t, store, spec.id)
+		payload.BlockerClass = string(blockerClassRuntimeAuth)
+		payload.BlockerAttempts = 1
+		payload.BlockerRetryAt = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano)
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+			t.Fatalf("UpdateJobPayload: %v", err)
+		}
+	}
+
+	worker := blockerE2EWorker(store, home, checkout)
+	probeCalls := 0
+	worker.AuthProbe = func(context.Context, db.Job, workflow.JobPayload) authProbeVerdict {
+		probeCalls++
+		return authProbeValid
+	}
+
+	pending, err := listPendingQueuedJobs(ctx, worker, "", "", true)
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs: %v", err)
+	}
+	if probeCalls != 1 {
+		t.Fatalf("probe ran %d times for two auth-held jobs of one runtime; want 1 (deduped)", probeCalls)
+	}
+	if !blockerSliceContainsJob(pending, "job-auth-a") || !blockerSliceContainsJob(pending, "job-auth-b") {
+		t.Fatalf("both auth jobs should be pending after a Valid probe; got %d", len(pending))
+	}
+	// Cadence marker: both jobs' holds were pushed into the future, so a subsequent
+	// pass finds them held and does NOT re-probe.
+	for _, id := range []string{"job-auth-a", "job-auth-b"} {
+		_, p := blockerE2EJobPayload(t, store, id)
+		at, err := time.Parse(time.RFC3339Nano, p.BlockerRetryAt)
+		if err != nil || !at.After(time.Now().UTC()) {
+			t.Fatalf("%s hold was not re-armed after the probe: %q", id, p.BlockerRetryAt)
+		}
+	}
+	probeCalls = 0
+	pending2, err := listPendingQueuedJobs(ctx, worker, "", "", true)
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs (second pass): %v", err)
+	}
+	if probeCalls != 0 {
+		t.Fatalf("re-probed on the next pass despite an in-window cadence marker (probeCalls=%d)", probeCalls)
+	}
+	if blockerSliceContainsJob(pending2, "job-auth-a") || blockerSliceContainsJob(pending2, "job-auth-b") {
+		t.Fatal("a job whose cadence marker was just re-armed should be held on the next pass")
+	}
+}
+
+// TestAuthProbeSkippedOnWarningCountPath proves finding #2: the live credential
+// probe must NOT run — and the job payload must NOT be mutated — when the queued
+// listing is consumed by the preflight serialization-warning count (forDispatch
+// false), only when a caller is truly about to dispatch. Otherwise a claude-runtime
+// outage would spawn a `claude -p` subprocess and rewrite BlockerRetryAt on every
+// scheduler tick from a pure read path.
+//
+// MUTATION PROOF: make listPendingQueuedJobs always probe (ignore forDispatch) and
+// both the "probe never ran" and "payload untouched" assertions flip RED.
+func TestAuthProbeSkippedOnWarningCountPath(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "warnauthbot", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-warnauth", Agent: "warnauthbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	job, payload := blockerE2EJobPayload(t, store, "job-warnauth")
+	payload.BlockerClass = string(blockerClassRuntimeAuth)
+	payload.BlockerAttempts = 1
+	elapsed := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano)
+	payload.BlockerRetryAt = elapsed
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload: %v", err)
+	}
+
+	worker := blockerE2EWorker(store, home, checkout)
+	probed := false
+	worker.AuthProbe = func(context.Context, db.Job, workflow.JobPayload) authProbeVerdict {
+		probed = true
+		return authProbeInvalid
+	}
+
+	// The warning-count path (forDispatch=false) must never probe or mutate.
+	if _, err := listPendingQueuedJobs(ctx, worker, "", "", false); err != nil {
+		t.Fatalf("listPendingQueuedJobs: %v", err)
+	}
+	if probed {
+		t.Fatal("the live auth probe ran on the warning-count (non-dispatch) path")
+	}
+	if _, p := blockerE2EJobPayload(t, store, "job-warnauth"); p.BlockerRetryAt != elapsed {
+		t.Fatalf("the warning-count path mutated BlockerRetryAt: %q -> %q", elapsed, p.BlockerRetryAt)
 	}
 }

--- a/internal/cli/blocker_slices_e2e_test.go
+++ b/internal/cli/blocker_slices_e2e_test.go
@@ -1,0 +1,406 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// E2Es for #532 slices B–F, deterministic and LLM-free (the shell runtime), each
+// driving the REAL daemon dispatch entry (runQueuedJobsForRepo /
+// listPendingQueuedJobs → jobWorker.run → engine.RunJob → mailbox seam).
+
+func blockerSliceContainsJob(jobs []db.Job, id string) bool {
+	for _, j := range jobs {
+		if j.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- Slice E: the deferral is PRE-TERMINAL (no job.failed precedes job.deferred).
+
+// TestE2E532SliceEDeferralHasNoPrecedingJobFailed proves the mailbox seam defers a
+// classified blocker BEFORE the terminal transition: the [events] sink sees a
+// job.deferred and NEVER a job.failed for the run.
+//
+// MUTATION PROOF: revert slice E (let Mailbox.Run call m.fail then defer
+// post-terminally, or drop the deferBlocker call) and a job.failed is emitted for
+// this job — the "0 job.failed" assertion below flips RED.
+func TestE2E532SliceEDeferralHasNoPrecedingJobFailed(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	countFile := filepath.Join(t.TempDir(), "count")
+	script := fmt.Sprintf(`printf x >> %q
+echo "HTTP 429 Too Many Requests: rate limit reached; try again in 30 seconds" 1>&2
+exit 1`, countFile)
+	seedDaemonWorkerAgent(t, store, "flapbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-flap", Agent: "flapbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+	sink := &recordingSink{}
+	worker.EventSinkOverride = sink
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-flap")
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want %q (classification/pre-terminal regressed)", job.State, workflow.JobQueued)
+	}
+	if payload.BlockerClass != string(blockerClassRuntimeQuota) {
+		t.Fatalf("blocker_class = %q, want %q", payload.BlockerClass, blockerClassRuntimeQuota)
+	}
+	// The whole point of slice E: NO job.failed for this job, ever.
+	if failed := sink.byType(events.EventJobFailed); blockerSliceHasJob(failed, "job-flap") {
+		t.Fatalf("job.failed was emitted for job-flap before the deferral — the failed→deferred flap is back")
+	}
+	// And the ordered stream for this job carries exactly one first-class deferral.
+	ordered := sink.orderedForJob("job-flap")
+	if len(ordered) != 1 || ordered[0] != events.EventJobDeferred {
+		t.Fatalf("ordered events for job-flap = %v, want exactly [job.deferred]", ordered)
+	}
+}
+
+func blockerSliceHasJob(evs []events.Event, id string) bool {
+	for _, e := range evs {
+		if e.JobID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- Slice C: checkout_contention (lock self-heals with short backoff; dirty
+// surfaces a suggested_action).
+
+// TestE2E532SliceCLockContentionDefersThenSucceeds proves a branch-lock
+// pre-flight failure defers with a SHORT backoff (pre-terminally, no job.failed)
+// and auto-succeeds once the lock clears.
+//
+// MUTATION PROOF: make classifyCheckoutContention return checkoutContentionNone
+// for "is locked by" and the first dispatch terminally FAILS the job — the queued
+// assertion flips RED.
+func TestE2E532SliceCLockContentionDefersThenSucceeds(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	script := fmt.Sprintf("printf '%%s' '%s'", blockerE2EApprovedResult)
+	seedDaemonWorkerAgent(t, store, "lockbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-lock", Agent: "lockbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+	sink := &recordingSink{}
+	worker.EventSinkOverride = sink
+	// The checkout is "locked by another worker" on the first pre-flight, then clears.
+	var checkoutCalls int
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		checkoutCalls++
+		if checkoutCalls == 1 {
+			return "", fmt.Errorf("branch %s is locked by other-worker, not lockbot", "main")
+		}
+		return checkout, nil
+	}
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("first dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-lock")
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("state after lock contention = %q, want %q (terminal fail means slice C is broken)", job.State, workflow.JobQueued)
+	}
+	if payload.BlockerClass != string(blockerClassCheckoutContention) {
+		t.Fatalf("blocker_class = %q, want %q", payload.BlockerClass, blockerClassCheckoutContention)
+	}
+	if payload.BlockerSuggestedAction != "" {
+		t.Fatalf("lock contention set a suggested_action %q, want none (it self-heals)", payload.BlockerSuggestedAction)
+	}
+	retryAt, err := time.Parse(time.RFC3339Nano, payload.BlockerRetryAt)
+	if err != nil {
+		t.Fatalf("parse retry-at: %v", err)
+	}
+	// SHORT exponential backoff: attempt 1 == checkoutLockBaseBackoff (2s), never minutes.
+	if until := time.Until(retryAt); until <= 0 || until > checkoutLockBaseBackoff+time.Second {
+		t.Fatalf("lock backoff %s not short (until=%s)", payload.BlockerRetryAt, until)
+	}
+	// Pre-terminal: no job.failed for this job.
+	if blockerSliceHasJob(sink.byType(events.EventJobFailed), "job-lock") {
+		t.Fatal("job.failed emitted for a lock-contention deferral (flap)")
+	}
+	if !blockerSliceHasJob(sink.byType(events.EventJobDeferred), "job-lock") {
+		t.Fatal("no job.deferred emitted for the lock-contention deferral")
+	}
+
+	// After the short hold elapses, re-dispatch auto-succeeds.
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+			t.Fatalf("re-dispatch returned error: %v", err)
+		}
+		job, payload = blockerE2EJobPayload(t, store, "job-lock")
+		if job.State == string(workflow.JobSucceeded) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job never succeeded after the lock cleared; state=%q", job.State)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if payload.Result == nil || payload.Result.Decision != "approved" {
+		t.Fatalf("stored result = %+v, want approved", payload.Result)
+	}
+}
+
+// TestE2E532SliceCDirtyCheckoutSurfacesSuggestedAction proves a dirty checkout
+// defers with a fixed (non-short) backoff AND a human-facing suggested_action that
+// the #552 stuck surface renders.
+func TestE2E532SliceCDirtyCheckoutSurfacesSuggestedAction(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "dirtybot", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-dirty", Agent: "dirtybot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return "", fmt.Errorf("checkout %s has uncommitted changes", checkout)
+	}
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-dirty")
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("dirty checkout state = %q, want %q", job.State, workflow.JobQueued)
+	}
+	if payload.BlockerClass != string(blockerClassCheckoutContention) {
+		t.Fatalf("blocker_class = %q, want %q", payload.BlockerClass, blockerClassCheckoutContention)
+	}
+	if strings.TrimSpace(payload.BlockerSuggestedAction) == "" {
+		t.Fatal("dirty checkout did not persist a suggested_action")
+	}
+	retryAt, err := time.Parse(time.RFC3339Nano, payload.BlockerRetryAt)
+	if err != nil {
+		t.Fatalf("parse retry-at: %v", err)
+	}
+	// Fixed (human-needing) backoff — minutes, not the short lock backoff.
+	if until := time.Until(retryAt); until <= checkoutLockMaxBackoff {
+		t.Fatalf("dirty backoff %s is too short (until=%s), want ~%s", payload.BlockerRetryAt, until, checkoutDirtyBackoff)
+	}
+	// The #552 stuck surface must carry the suggested_action.
+	reason := loadStuckReason(store, job)
+	if !strings.HasPrefix(reason.Reason, "blocked-operational: "+string(blockerClassCheckoutContention)) {
+		t.Fatalf("stuck reason = %q, want checkout_contention prefix", reason.Reason)
+	}
+	if reason.SuggestedAction != payload.BlockerSuggestedAction {
+		t.Fatalf("stuck suggested_action = %q, want %q", reason.SuggestedAction, payload.BlockerSuggestedAction)
+	}
+}
+
+// ---- Slice D: a typed network / GitHub outage surfaced through the delivery seam
+// defers as network_outage with a short backoff.
+
+// MUTATION PROOF: remove the github.IsTransientMessage arm from
+// classifyOperationalBlocker and the outage terminally FAILS the job.
+func TestE2E532SliceDNetworkOutageDefers(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	countFile := filepath.Join(t.TempDir(), "count")
+	script := fmt.Sprintf(`printf x >> %q
+echo "fatal: unable to access 'https://github.com/owner/repo/': Could not resolve host: github.com" 1>&2
+exit 1`, countFile)
+	seedDaemonWorkerAgent(t, store, "netbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-net", Agent: "netbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch returned error: %v", err)
+	}
+	job, payload := blockerE2EJobPayload(t, store, "job-net")
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("network outage state = %q, want %q (terminal fail means slice D is broken)", job.State, workflow.JobQueued)
+	}
+	if payload.BlockerClass != string(blockerClassNetworkOutage) {
+		t.Fatalf("blocker_class = %q, want %q", payload.BlockerClass, blockerClassNetworkOutage)
+	}
+	retryAt, err := time.Parse(time.RFC3339Nano, payload.BlockerRetryAt)
+	if err != nil {
+		t.Fatalf("parse retry-at: %v", err)
+	}
+	// Short backoff for a self-clearing outage.
+	if until := time.Until(retryAt); until <= 0 || until > networkBlockerRetryDelay+30*time.Second+time.Second {
+		t.Fatalf("network backoff %s not short (until=%s)", payload.BlockerRetryAt, until)
+	}
+}
+
+// ---- Slice B: runtime_auth re-dispatch is gated on a live probe.
+
+// TestE2E532SliceBAuthReDispatchGatedOnProbe seeds a runtime_auth deferral whose
+// coarse hold has already elapsed and drives listPendingQueuedJobs with a fake
+// probe: an Invalid verdict keeps the job held (extending the hold, NOT burning an
+// attempt); a Valid verdict releases it.
+//
+// MUTATION PROOF: drop the authProbeAllowsRedispatch gate from
+// listPendingQueuedJobs and the job is eligible on the FIRST (Invalid) pass — the
+// "not pending" assertion flips RED.
+func TestE2E532SliceBAuthReDispatchGatedOnProbe(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "probebot", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-probe", Agent: "probebot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	// Seed as a runtime_auth deferral whose coarse hold already elapsed.
+	seedElapsedAuthHold := func() {
+		job, payload := blockerE2EJobPayload(t, store, "job-probe")
+		payload.BlockerClass = string(blockerClassRuntimeAuth)
+		payload.BlockerAttempts = 1
+		payload.BlockerRetryAt = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano)
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+			t.Fatalf("UpdateJobPayload: %v", err)
+		}
+	}
+	seedElapsedAuthHold()
+
+	worker := blockerE2EWorker(store, home, checkout)
+	verdict := authProbeInvalid
+	probeCalls := 0
+	worker.AuthProbe = func(context.Context, db.Job, workflow.JobPayload) authProbeVerdict {
+		probeCalls++
+		return verdict
+	}
+
+	// Phase 1: probe Invalid -> held, hold extended, attempt NOT burned.
+	pending, err := listPendingQueuedJobs(ctx, worker, "", "")
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs: %v", err)
+	}
+	if blockerSliceContainsJob(pending, "job-probe") {
+		t.Fatal("auth job was dispatched while the live probe reports the credential Invalid")
+	}
+	if probeCalls == 0 {
+		t.Fatal("the auth probe was never consulted")
+	}
+	_, p2 := blockerE2EJobPayload(t, store, "job-probe")
+	if p2.BlockerAttempts != 1 {
+		t.Fatalf("blocker_attempts = %d after a probe failure, want 1 (probe fail must not burn an attempt)", p2.BlockerAttempts)
+	}
+	if extended, err := time.Parse(time.RFC3339Nano, p2.BlockerRetryAt); err != nil || !extended.After(time.Now().UTC()) {
+		t.Fatalf("hold was not extended after the probe failure: %q", p2.BlockerRetryAt)
+	}
+
+	// Phase 2: probe now Valid AND the hold re-elapsed -> the job is eligible.
+	verdict = authProbeValid
+	seedElapsedAuthHold()
+	pending, err = listPendingQueuedJobs(ctx, worker, "", "")
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs: %v", err)
+	}
+	if !blockerSliceContainsJob(pending, "job-probe") {
+		t.Fatal("auth job was NOT released after the live probe reported the credential Valid")
+	}
+}
+
+// ---- Slice F: the retry prompt carries a WARN-level prior-blocker line.
+
+// TestE2E532SliceFRetryPromptCarriesWarnContext proves a re-dispatched job's
+// prompt tells the agent the previous attempt died OPERATIONALLY (not on its own
+// output). Driven end to end: a 429 defers the first delivery, the second captures
+// the prompt.
+//
+// MUTATION PROOF: stop prepending blockerRetryReconciliationNotice in Mailbox.Run
+// and the "did NOT fail on the merits" assertion flips RED.
+func TestE2E532SliceFRetryPromptCarriesWarnContext(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	state := t.TempDir()
+	marker := filepath.Join(state, "delivered")
+	promptFile := filepath.Join(state, "retry-prompt")
+	script := fmt.Sprintf(`if [ ! -f %q ]; then
+  : > %q
+  echo "HTTP 429 Too Many Requests: rate limit reached; try again in 3 seconds" 1>&2
+  exit 1
+fi
+printf '%%s' "$1" > %q
+printf '%%s' '%s'`, marker, marker, promptFile, blockerE2EApprovedResult)
+	seedDaemonWorkerAgent(t, store, "warnbot", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-warn", Agent: "warnbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	worker := blockerE2EWorker(store, home, checkout)
+
+	// Defer, then wait out the (floored 5s) hold and succeed.
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("first dispatch: %v", err)
+	}
+	_, payload := blockerE2EJobPayload(t, store, "job-warn")
+	retryAt, err := time.Parse(time.RFC3339Nano, payload.BlockerRetryAt)
+	if err != nil {
+		t.Fatalf("parse retry-at: %v", err)
+	}
+	for time.Now().UTC().Before(retryAt) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+			t.Fatalf("re-dispatch: %v", err)
+		}
+		job, _ := blockerE2EJobPayload(t, store, "job-warn")
+		if job.State == string(workflow.JobSucceeded) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job never succeeded; state=%q", job.State)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	prompt, err := os.ReadFile(promptFile)
+	if err != nil {
+		t.Fatalf("read retry prompt: %v", err)
+	}
+	text := string(prompt)
+	// WARN level (slice F): died operationally, not on its own output.
+	if !strings.Contains(text, "did NOT fail on the merits") ||
+		!strings.Contains(text, "operational blocker (runtime_quota)") {
+		t.Fatalf("retry prompt is missing the slice F warn-level prior-blocker context:\n%s", text)
+	}
+	// Composed with the at-least-once reconciliation notice.
+	if !strings.Contains(text, "reconcile") {
+		t.Fatalf("retry prompt lost the reconciliation notice:\n%s", text)
+	}
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2687,6 +2687,16 @@ type jobWorker struct {
 	// a config file / webhook. When nil (production), eventSink() resolves the
 	// shared process-global webhook sink from [events] config instead.
 	EventSinkOverride events.Sink
+	// AuthProbe is the injected doctor-style live credential probe (#532 slice B).
+	// It gates re-dispatch of a runtime_auth deferral: once the coarse hold elapses
+	// the scheduler only releases the job when the probe reports the credential is
+	// VALID again (an Invalid verdict extends the hold WITHOUT burning a retry
+	// attempt; an Unknown/transient verdict falls back to the coarse cadence). When
+	// nil (foreground CLI, and every construction that does not opt in) the gate is
+	// byte-identical to slice A: the coarse cadence alone governs re-dispatch. Tests
+	// inject a fake verdict; the daemon wires defaultAuthProbe (a bounded
+	// runtime.ClaudeLiveCheck for claude agents, Unknown for other runtimes).
+	AuthProbe func(context.Context, db.Job, workflow.JobPayload) authProbeVerdict
 }
 
 // eventSink resolves the best-effort outbound event Sink (#446) for the
@@ -2852,6 +2862,7 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	worker.StartAdapterFactory = worker.defaultStartAdapter
 	worker.CheckoutValidator = worker.defaultCheckout
 	worker.WorkflowFactory = worker.defaultWorkflow
+	worker.AuthProbe = worker.defaultAuthProbe
 	return worker
 }
 
@@ -3750,6 +3761,14 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 		// schedulers (barrier and pool) funnel through this listing, so the hold
 		// is honored everywhere; jobs without the payload field are unaffected.
 		if queuedJobBlockerHeld(job, time.Now().UTC()) {
+			continue
+		}
+		// Auth-probe gate (#532 slice B): once a runtime_auth deferral's coarse hold
+		// elapses, only re-dispatch when a live doctor-style probe says the credential
+		// is VALID again — an Invalid verdict extends the hold (re-probe next cadence,
+		// no attempt burned). Non-auth deferrals and jobs with no probe wired pass
+		// straight through (coarse cadence only, byte-identical to slice A).
+		if !authProbeAllowsRedispatch(ctx, worker, job, time.Now().UTC()) {
 			continue
 		}
 		pending = append(pending, job)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3555,7 +3555,7 @@ func runQueuedJobsForRepo(ctx context.Context, worker jobWorker, limit int, repo
 	if worker.UsePool {
 		return runQueuedJobsForRepoPool(ctx, worker, limit, repoFilter, rootFilter)
 	}
-	pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter)
+	pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter, true)
 	if err != nil {
 		return err
 	}
@@ -3628,7 +3628,11 @@ func serializingConfig(usePool bool, limit int) bool {
 // returned signature uniquely identifies the parallelizable session set so the
 // preflight can de-duplicate an unchanged backlog across ticks.
 func parallelizableSerialJobs(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) (int, string) {
-	pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter)
+	// forDispatch=false: this is a preflight COUNT for the serialization warning, not
+	// a dispatch. It must stay a pure read — no live auth probe (`claude -p`
+	// subprocess) and no payload mutation — so the warning path keeps its documented
+	// off-hot-path contract (#532).
+	pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter, false)
 	if err != nil {
 		return 0, ""
 	}
@@ -3743,10 +3747,22 @@ const daemonRestartEnvCaveat = "note: a restart RE-INHERITS the launching shell'
 // engine can route through the graceful finalize path; in-flight children finish
 // normally. Only children (payload.RootJobID points at another root) are skipped
 // here — the root job itself is never skipped.
-func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string) ([]db.Job, error) {
+//
+// forDispatch (#532 slice B) gates the LIVE runtime_auth credential probe: only a
+// caller that is actually about to dispatch jobs runs it. The preflight
+// serialization-warning path (parallelizableSerialJobs) passes false so counting
+// queued jobs stays a pure read — no `claude -p` subprocess, no job-payload
+// mutation — keeping that path off the DB/subprocess hot path as its contract
+// promises. A within-pass cache dedupes the probe across auth-held jobs of the same
+// runtime so one outage costs at most one live probe per pass.
+func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, forDispatch bool) ([]db.Job, error) {
 	jobs, err := worker.Store.ListQueuedJobs(ctx)
 	if err != nil {
 		return nil, err
+	}
+	var probeCache authProbeCache
+	if forDispatch {
+		probeCache = authProbeCache{}
 	}
 	pending := make([]db.Job, 0, len(jobs))
 	for _, job := range jobs {
@@ -3767,8 +3783,10 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 		// elapses, only re-dispatch when a live doctor-style probe says the credential
 		// is VALID again — an Invalid verdict extends the hold (re-probe next cadence,
 		// no attempt burned). Non-auth deferrals and jobs with no probe wired pass
-		// straight through (coarse cadence only, byte-identical to slice A).
-		if !authProbeAllowsRedispatch(ctx, worker, job, time.Now().UTC()) {
+		// straight through (coarse cadence only, byte-identical to slice A). The live
+		// probe runs ONLY for a dispatching caller (forDispatch); the warning-count
+		// path skips it so it never spawns a subprocess or mutates the payload.
+		if forDispatch && !authProbeAllowsRedispatch(ctx, worker, job, time.Now().UTC(), probeCache) {
 			continue
 		}
 		pending = append(pending, job)
@@ -3937,7 +3955,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 
 		dispatched := 0
 		if firstErr == nil {
-			pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter)
+			pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter, true)
 			if err != nil {
 				firstErr = err
 			} else if slots := poolDispatchSlots(limit, running, hostCap, tracker); slots > 0 {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4522,6 +4522,19 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	}
 	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
 	if err != nil {
+		// Checkout-contention deferral (#532 slice C): a NON-delegation job whose
+		// daemon pre-flight checkout failed on a classified contention string (a
+		// branch-lock conflict that self-heals, or a dirty/wrong-head checkout that
+		// needs a human) is HELD with a backoff instead of terminally failing —
+		// pre-terminal, so no job.failed precedes the additive job.deferred. Every
+		// other checkout error (and every delegation child) falls through to the
+		// existing terminal path byte-identically.
+		if deferred, deferErr := w.deferCheckoutContention(ctx, job, payload, err); deferErr != nil {
+			writeLine(w.Stdout, "job %s checkout-contention deferral failed: %v", job.ID, deferErr)
+		} else if deferred {
+			writeLine(w.Stdout, "job %s deferred on checkout contention: %v", job.ID, err)
+			return nil
+		}
 		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
 		}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4720,6 +4720,12 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	}
 	writeLine(w.Stdout, "running job %s for %s in %s", job.ID, agent.Name, payload.Repo)
 	engine := w.WorkflowFactory(checkout)
+	// Wire the PRE-TERMINAL operational-blocker deferrer (#532 slice E) on the LIVE
+	// worker (not the WorkflowFactory-captured copy) so it observes this worker's
+	// EventSink for the first-class job.deferred emit. When a delivery-seam failure
+	// classifies as a retryable operational blocker the mailbox re-queues the job
+	// BEFORE the terminal transition, so no job.failed reaches the [events] sink.
+	engine.BlockerDeferrer = w.deferOperationalBlockerPreTerminal
 	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
 	defer stopRun()
 	if jobTimeout > 0 {
@@ -4729,25 +4735,20 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	}
 	_, err = engine.RunJob(runCtx, job.ID, agent, adapter)
 	if err != nil {
+		// Operational-blocker deferral (#532 slice E): a run whose delivery failed on
+		// a classified OPERATIONAL blocker (runtime auth rejected, rate limit/quota,
+		// network/GitHub outage) is re-queued PRE-terminally by the mailbox's injected
+		// BlockerDeferrer — running→queued with a hold + a first-class job.deferred,
+		// and NO job.failed. RunJob reports ErrJobDeferred; short-circuit the entire
+		// terminal path (no handleRunJobError, no failure comment) since the run
+		// already resolved to a deferral. Every other failure takes the path below
+		// byte-identically.
+		if errors.Is(err, workflow.ErrJobDeferred) {
+			writeLine(w.Stdout, "job %s deferred on operational blocker (pre-terminal): %v", job.ID, err)
+			return nil
+		}
 		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
 			return markErr
-		}
-		// Operational-blocker deferral (#532): a run that terminally failed on a
-		// classified OPERATIONAL blocker (runtime auth rejected, rate limit/quota)
-		// is re-queued with an earliest-retry-at hold instead of staying failed
-		// indistinguishably from a product failure. Strictly additive and off the
-		// hot path: deferOperationalBlocker only diverts when the error is a typed
-		// delivery-seam failure matching a classified blocker AND the job failed
-		// without a stored result AND no delivery ever completed (no persisted raw
-		// outputs — the duplicate-side-effect gate) AND it is not a delegation
-		// child; every other failure takes the path below byte-identically. A
-		// deferral error is logged and falls through so the job is never left in
-		// limbo.
-		if deferred, deferErr := w.deferOperationalBlocker(ctx, job.ID, err); deferErr != nil {
-			writeLine(w.Stdout, "job %s blocker deferral failed: %v", job.ID, deferErr)
-		} else if deferred {
-			writeLine(w.Stdout, "job %s deferred on operational blocker: %v", job.ID, err)
-			return nil
 		}
 		commentErr := err
 		if job.Type == "implement" && runtimePermissionFailure(err) {

--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -579,7 +579,7 @@ func dispatchQueuedJobsTracked(ctx context.Context, worker jobWorker, limit int,
 		return tracker.takeErr(repoFilter)
 	}
 
-	pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter)
+	pending, err := listPendingQueuedJobs(ctx, worker, repoFilter, rootFilter, true)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -3754,7 +3754,10 @@ func TestRunQueuedJobsFailsReviewOnWrongCheckoutBranchBeforeDelivery(t *testing.
 	}
 }
 
-func TestRunQueuedJobsFailsReviewOnWrongCheckoutHeadBeforeDelivery(t *testing.T) {
+// A wrong-checkout-HEAD review pre-flight is a checkout_contention (#532 slice C):
+// it DEFERS (queued with a suggested_action) instead of failing terminally, since
+// the checkout may just be mid-sync — pre-flight still stops delivery.
+func TestRunQueuedJobsDefersReviewOnWrongCheckoutHeadBeforeDelivery(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	checkout := t.TempDir()
@@ -3790,12 +3793,21 @@ func TestRunQueuedJobsFailsReviewOnWrongCheckoutHeadBeforeDelivery(t *testing.T)
 	if err != nil {
 		t.Fatalf("GetJob returned error: %v", err)
 	}
-	if job.State != string(workflow.JobFailed) {
-		t.Fatalf("job state = %q, want failed", job.State)
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued (checkout_contention deferral)", job.State)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if payload.BlockerClass != string(blockerClassCheckoutContention) || strings.TrimSpace(payload.BlockerSuggestedAction) == "" {
+		t.Fatalf("wrong-head review did not defer as checkout_contention with an action: %+v", payload)
 	}
 }
 
-func TestRunQueuedJobsFailsPRScopedAskOnWrongCheckoutHeadBeforeDelivery(t *testing.T) {
+// A wrong-checkout-HEAD PR-scoped ask pre-flight also DEFERS as
+// checkout_contention (#532 slice C) rather than failing terminally.
+func TestRunQueuedJobsDefersPRScopedAskOnWrongCheckoutHeadBeforeDelivery(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	checkout := t.TempDir()
@@ -3831,8 +3843,15 @@ func TestRunQueuedJobsFailsPRScopedAskOnWrongCheckoutHeadBeforeDelivery(t *testi
 	if err != nil {
 		t.Fatalf("GetJob returned error: %v", err)
 	}
-	if job.State != string(workflow.JobFailed) {
-		t.Fatalf("job state = %q, want failed", job.State)
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued (checkout_contention deferral)", job.State)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if payload.BlockerClass != string(blockerClassCheckoutContention) {
+		t.Fatalf("wrong-head ask did not defer as checkout_contention: %+v", payload)
 	}
 }
 

--- a/internal/cli/event_sink_daemon_test.go
+++ b/internal/cli/event_sink_daemon_test.go
@@ -43,6 +43,21 @@ func (r *recordingSink) count() int {
 	return len(r.events)
 }
 
+// orderedForJob returns, in emission order, the event types recorded for a given
+// job id — used to assert that a deferral never emits job.failed before
+// job.deferred (#532 slice E's pre-terminal property).
+func (r *recordingSink) orderedForJob(jobID string) []events.EventType {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []events.EventType
+	for _, e := range r.events {
+		if e.JobID == jobID {
+			out = append(out, e.Type)
+		}
+	}
+	return out
+}
+
 // TestFinishQueuedJobEmitsJobFailed proves the DAEMON-owned pre-flight terminal
 // path (a queued->failed transition that never reaches the engine's Mailbox
 // chokepoint) fans a job.failed out through the sink, carrying repo/root_id from

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -118,6 +118,7 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 				PreflightFailed: strings.TrimSpace(preflightFailed[job.ID]),
 				WhyStuck:        reason.Reason,
 				NextRetryAt:     reason.NextRetryAt,
+				SuggestedAction: reason.SuggestedAction,
 			})
 		}
 		if err := writeJSON(stdout, entries); err != nil {
@@ -138,6 +139,9 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 			if reason.NextRetryAt != "" {
 				fmt.Fprintf(stdout, " (next retry %s)", reason.NextRetryAt)
 			}
+			if reason.SuggestedAction != "" {
+				fmt.Fprintf(stdout, " [action: %s]", reason.SuggestedAction)
+			}
 		}
 		fmt.Fprintln(stdout)
 	}
@@ -157,6 +161,7 @@ type jobListEntry struct {
 	PreflightFailed string `json:"preflight_failed,omitempty"`
 	WhyStuck        string `json:"why_stuck,omitempty"`
 	NextRetryAt     string `json:"next_retry_at,omitempty"`
+	SuggestedAction string `json:"suggested_action,omitempty"`
 }
 
 func runJobShow(args []string, stdout, stderr io.Writer) int {
@@ -191,7 +196,7 @@ func runJobShow(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if *jsonOutput {
-		out := jobShowOutput{Job: job, Payload: payload, WhyStuck: reason.Reason, NextRetryAt: reason.NextRetryAt}
+		out := jobShowOutput{Job: job, Payload: payload, WhyStuck: reason.Reason, NextRetryAt: reason.NextRetryAt, SuggestedAction: reason.SuggestedAction}
 		if err := writeJSON(stdout, out); err != nil {
 			fmt.Fprintf(stderr, "job show: %v\n", err)
 			return 1
@@ -206,10 +211,11 @@ func runJobShow(args []string, stdout, stderr io.Writer) int {
 // payload, and the additive why-stuck detail (#552). The stuck fields are omitted
 // when empty so a healthy job's JSON is unchanged in spirit.
 type jobShowOutput struct {
-	Job         db.Job              `json:"job"`
-	Payload     workflow.JobPayload `json:"payload"`
-	WhyStuck    string              `json:"why_stuck,omitempty"`
-	NextRetryAt string              `json:"next_retry_at,omitempty"`
+	Job             db.Job              `json:"job"`
+	Payload         workflow.JobPayload `json:"payload"`
+	WhyStuck        string              `json:"why_stuck,omitempty"`
+	NextRetryAt     string              `json:"next_retry_at,omitempty"`
+	SuggestedAction string              `json:"suggested_action,omitempty"`
 }
 
 // loadStuckReason derives a queued/blocked job's why-stuck reason from its full
@@ -498,6 +504,9 @@ func printJob(stdout io.Writer, job db.Job, payload workflow.JobPayload, reason 
 		fmt.Fprintf(stdout, "why_stuck: %s\n", reason.Reason)
 		if reason.NextRetryAt != "" {
 			fmt.Fprintf(stdout, "next_retry_at: %s\n", reason.NextRetryAt)
+		}
+		if reason.SuggestedAction != "" {
+			fmt.Fprintf(stdout, "suggested_action: %s\n", reason.SuggestedAction)
 		}
 	}
 	fmt.Fprintf(stdout, "type: %s\n", job.Type)

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -390,6 +390,11 @@ func (w jobWorker) deferOperationalBlockerPreTerminal(ctx context.Context, jobID
 	payload.BlockerAttempts = attempt
 	payload.BlockerRetryAt = retryAt
 	payload.BlockerSuggestedAction = classification.SuggestedAction
+	// MID-DELIVERY (#532): the agent WAS delivered a prompt and may have executed side
+	// effects before the blocker cut it off, so this retry is at-least-once — clear any
+	// pre-delivery marker a prior checkout_contention hold left so Mailbox.Run still
+	// prepends the slice-F reconciliation notice.
+	payload.BlockerPreDelivery = false
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return false, err
@@ -446,6 +451,7 @@ func restorePreIsolationPayloadForDeferredJob(ctx context.Context, store *db.Sto
 	restored.BlockerAttempts = current.BlockerAttempts
 	restored.BlockerRetryAt = current.BlockerRetryAt
 	restored.BlockerSuggestedAction = current.BlockerSuggestedAction
+	restored.BlockerPreDelivery = current.BlockerPreDelivery
 	encoded, err := json.Marshal(restored)
 	if err != nil {
 		return

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -57,6 +58,16 @@ type blockerClass string
 const (
 	blockerClassRuntimeAuth  blockerClass = "runtime_auth"
 	blockerClassRuntimeQuota blockerClass = "runtime_quota"
+	// blockerClassNetworkOutage (#532 slice D) classifies a transient network /
+	// GitHub outage — a gh-CLI transport/DNS/TLS/5xx failure grounded in
+	// internal/github's TransientError / IsTransientMessage signatures — that
+	// reached a terminal job failure. It defers with a short backoff.
+	blockerClassNetworkOutage blockerClass = "network_outage"
+	// blockerClassCheckoutContention (#532 slice C) classifies a daemon-owned
+	// pre-flight checkout failure: a branch-lock conflict (self-heals, short
+	// exponential backoff) or a dirty/wrong-head checkout (usually needs a human;
+	// defers with a suggested_action surfaced through the #552 stuck surface).
+	blockerClassCheckoutContention blockerClass = "checkout_contention"
 )
 
 // blockerDeferredEventKind is the job_event kind recorded when a failed job is
@@ -94,11 +105,22 @@ const quotaBlockerMaxParsedDelay = 24 * time.Hour
 // inside a still-closed window and burn the retry budget in seconds.
 const quotaBlockerMinParsedDelay = 5 * time.Second
 
+// networkBlockerRetryDelay is the short base backoff for a transient network /
+// GitHub outage (#532 slice D). Outages clear on their own quickly, so the hold
+// is short (plus jitter, bounded by the shared 3-attempt budget) rather than the
+// minutes-long auth/quota holds.
+const networkBlockerRetryDelay = 30 * time.Second
+
 // blockerClassification is the classifier verdict for one failed run.
 type blockerClassification struct {
 	Class   blockerClass
 	RetryAt time.Time // earliest safe automatic re-dispatch (UTC)
 	Detail  string    // first line of the causing error, for events/UX
+	// SuggestedAction, when set, is a concrete human-facing remedy surfaced through
+	// the #552 stuck surface (job list/show) and persisted in the payload. Only the
+	// checkout dirty/wrong-head sub-class sets it today (#532 slice C); auth/quota/
+	// network defer on a condition that clears on its own and leave it empty.
+	SuggestedAction string
 }
 
 // classifyOperationalBlocker inspects a RunJob error and reports whether it is a
@@ -134,6 +156,13 @@ func classifyOperationalBlocker(cause error, now time.Time) (blockerClassificati
 		// credential rejection, so it is trustworthy without the delivery gate.
 		return blockerClassification{Class: blockerClassRuntimeAuth, RetryAt: now.Add(authBlockerRetryDelay), Detail: detail}, true
 	}
+	if github.AsTransient(cause) {
+		// A typed github.TransientError can reach a TERMINAL job failure directly
+		// from a daemon-owned github op (not the runtime delivery seam), so it is
+		// trustworthy without the DeliveryError marker — the network signatures live
+		// in internal/github and a 4xx/permission/conflict is never tagged transient.
+		return blockerClassification{Class: blockerClassNetworkOutage, RetryAt: now.Add(networkBlockerRetryDelay + blockerRetryJitter(networkBlockerRetryDelay)), Detail: detail}, true
+	}
 	var delivery workflow.DeliveryError
 	if !errors.As(cause, &delivery) {
 		return blockerClassification{}, false
@@ -144,6 +173,14 @@ func classifyOperationalBlocker(cause error, now time.Time) (blockerClassificati
 		return blockerClassification{Class: blockerClassRuntimeQuota, RetryAt: now.Add(delay + blockerRetryJitter(delay)), Detail: detail}, true
 	case "auth failing":
 		return blockerClassification{Class: blockerClassRuntimeAuth, RetryAt: now.Add(authBlockerRetryDelay), Detail: detail}, true
+	}
+	// Network / GitHub outage that surfaced through the delivery seam: the agent's
+	// own `gh` subprocess printed a transport/DNS/5xx signature to stderr (which
+	// becomes DeliveryError text, never a TransientError value). Reuse the SAME
+	// internal/github signature set so both the typed and the delivery paths agree.
+	// Checked AFTER auth/quota so a 401/429 keeps its more specific class.
+	if github.IsTransientMessage(text) {
+		return blockerClassification{Class: blockerClassNetworkOutage, RetryAt: now.Add(networkBlockerRetryDelay + blockerRetryJitter(networkBlockerRetryDelay)), Detail: detail}, true
 	}
 	return blockerClassification{}, false
 }
@@ -347,6 +384,7 @@ func (w jobWorker) deferOperationalBlocker(ctx context.Context, jobID string, ca
 	payload.BlockerClass = string(classification.Class)
 	payload.BlockerAttempts = attempt
 	payload.BlockerRetryAt = retryAt
+	payload.BlockerSuggestedAction = classification.SuggestedAction
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return false, err
@@ -404,6 +442,7 @@ func restorePreIsolationPayloadForDeferredJob(ctx context.Context, store *db.Sto
 	restored.BlockerClass = current.BlockerClass
 	restored.BlockerAttempts = current.BlockerAttempts
 	restored.BlockerRetryAt = current.BlockerRetryAt
+	restored.BlockerSuggestedAction = current.BlockerSuggestedAction
 	encoded, err := json.Marshal(restored)
 	if err != nil {
 		return

--- a/internal/cli/job_blocker.go
+++ b/internal/cli/job_blocker.go
@@ -47,8 +47,10 @@ import (
 //     budget is exhausted the job stays terminally failed exactly like today.
 //
 // Every job that does not hit a classified blocker takes the existing path
-// byte-identically: the hook in jobWorker.run only diverts when
-// deferOperationalBlocker returns true.
+// byte-identically: the mailbox's injected BlockerDeferrer
+// (deferOperationalBlockerPreTerminal, #532 slice E) only diverts a run when it
+// classifies AND every scope guard passes; otherwise Mailbox.Run fails the job
+// exactly as before.
 
 // blockerClass names a class of operational blocker. Persisted in the job
 // payload (blocker_class) and rendered by the #552 stuck-reason surface, so the
@@ -320,14 +322,17 @@ func blockerRetryJitter(delay time.Duration) time.Duration {
 	return time.Duration(rand.Int64N(int64(max)))
 }
 
-// deferOperationalBlocker re-queues a job that just terminally failed on a
-// classifiable operational blocker, preserving its resumable context. Called by
-// jobWorker.run strictly AFTER RunJob returned an error, i.e. off the hot path:
-// it reads the (already failed) job back, and only when every scope guard passes
-// does it write the blocker fields into the payload and flip failed→queued with
-// a blocker_deferred event. It returns (true, nil) exactly when the job was
-// deferred, so the caller skips the terminal failure comment/log; every other
-// outcome leaves the job exactly as the existing path put it.
+// deferOperationalBlockerPreTerminal re-queues a RUNNING job whose delivery just
+// failed on a classifiable operational blocker, preserving its resumable context.
+// It is the injected workflow.Engine.BlockerDeferrer, called by Mailbox.Run at the
+// delivery-seam failure point BEFORE the terminal transition (#532 slice E): it
+// reads the (still running) job back, and only when every scope guard passes does
+// it write the blocker fields into the payload and flip running→queued with a
+// blocker_deferred event + additive job.deferred emit. It returns (true, nil)
+// exactly when the job was deferred, so Mailbox.Run skips m.fail and NO job.failed
+// is emitted first (slice A deferred failed→queued AFTER the terminal transition —
+// the flap this slice removes). Every other outcome returns false so Run takes its
+// existing terminal path unchanged.
 //
 // SIDE-EFFECT SEMANTICS: the auto-retry is AT-LEAST-ONCE. A run whose FIRST
 // delivery completed (persisted RawOutputs) is never deferred — completed
@@ -338,23 +343,23 @@ func blockerRetryJitter(delay time.Duration) time.Duration {
 // from here, so Mailbox.Run prepends a reconciliation notice to every
 // blocker-retried prompt (payload.BlockerAttempts > 0) telling the agent to
 // verify and reuse prior artifacts instead of duplicating them.
-func (w jobWorker) deferOperationalBlocker(ctx context.Context, jobID string, cause error) (bool, error) {
-	classification, ok := classifyOperationalBlocker(cause, time.Now().UTC())
-	if !ok {
-		return false, nil
-	}
+func (w jobWorker) deferOperationalBlockerPreTerminal(ctx context.Context, jobID string, cause error) (bool, error) {
 	latest, err := w.Store.GetJob(ctx, jobID)
 	if err != nil {
 		return false, err
 	}
-	// Only a run that Mailbox.fail closed as JobFailed is eligible; a blocked/
-	// cancelled/queued job belongs to other machinery (permission block, kill,
-	// pre-flight) that already owns its semantics.
-	if latest.State != string(workflow.JobFailed) {
+	// The pre-terminal seam runs while the job is still RUNNING (Mailbox.Run claimed
+	// it queued→running before delivering); anything else means the run already
+	// resolved and this seam does not apply.
+	if latest.State != string(workflow.JobRunning) {
 		return false, nil
 	}
 	payload, err := daemonJobPayload(latest)
 	if err != nil {
+		return false, nil
+	}
+	classification, ok := classifyOperationalBlocker(cause, time.Now().UTC())
+	if !ok {
 		return false, nil
 	}
 	// A stored result means the agent answered: decision=failed is a PRODUCT
@@ -389,31 +394,29 @@ func (w jobWorker) deferOperationalBlocker(ctx context.Context, jobID string, ca
 	if err != nil {
 		return false, err
 	}
-	// Payload first, transition second: a crash in between leaves the job
-	// terminally failed (today's behavior) with extra context in the payload —
+	// Payload first, transition second: a crash in between leaves the job RUNNING
+	// with extra context in the payload — the stale-running recovery requeues it —
 	// never a queued job missing its hold timestamp.
 	if err := w.Store.UpdateJobPayload(ctx, jobID, string(encoded)); err != nil {
 		return false, err
 	}
-	transitioned, err := w.Store.TransitionJobStateWithEvent(ctx, jobID, string(workflow.JobFailed), string(workflow.JobQueued), db.JobEvent{
-		JobID: jobID,
-		Kind:  blockerDeferredEventKind,
-		Message: fmt.Sprintf("%s: attempt %d/%d, retry at %s: %s",
-			classification.Class, attempt, maxOperationalBlockerRetries, retryAt, classification.Detail),
+	message := fmt.Sprintf("%s: attempt %d/%d, retry at %s: %s",
+		classification.Class, attempt, maxOperationalBlockerRetries, retryAt, classification.Detail)
+	transitioned, err := w.Store.TransitionJobStateWithEvent(ctx, jobID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
+		JobID:   jobID,
+		Kind:    blockerDeferredEventKind,
+		Message: message,
 	})
 	if err != nil {
 		return false, err
 	}
 	if transitioned {
-		// The engine already emitted a terminal job.failed for this run
-		// (Mailbox.fail), so [events] consumers acting on job.failed would race the
-		// hidden retry. Emit an additive job.deferred so stream consumers can
-		// suppress terminal handling: job.failed followed by job.deferred is NOT
-		// terminal (see events.EventJobDeferred). Best-effort and nil-safe when
-		// [events] is OFF, mirroring the daemon's other emits.
-		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, events.EventJobDeferred, string(workflow.JobQueued),
-			fmt.Sprintf("%s: attempt %d/%d, retry at %s: %s",
-				classification.Class, attempt, maxOperationalBlockerRetries, retryAt, classification.Detail))
+		// PRE-TERMINAL (#532 slice E): m.fail was never called, so NO job.failed was
+		// emitted for this run. Emit the additive job.deferred as the FIRST-CLASS
+		// terminal-set transition for this run — the [events] stream sees the deferral
+		// directly, with no preceding failed→deferred flap. Best-effort and nil-safe
+		// when [events] is OFF, mirroring the daemon's other emits.
+		emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, jobID, events.EventJobDeferred, string(workflow.JobQueued), message)
 	}
 	return transitioned, nil
 }

--- a/internal/cli/job_blocker_auth_probe.go
+++ b/internal/cli/job_blocker_auth_probe.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// Issue #532 slice B: gate re-dispatch of a runtime_auth deferral on a
+// doctor-style LIVE credential probe (the ClaudeClassifyProbe SET-vs-VALID
+// pattern from #486/#487) instead of blindly re-dispatching on the coarse 5m
+// cadence. A runtime_auth blocker clears only when a human rotates/re-logs the
+// token — an event with no machine-readable ETA — so re-dispatching purely on a
+// timer either wastes a retry attempt into a still-broken token or holds a
+// now-fixed token longer than necessary. The probe closes that gap: the coarse
+// hold (authBlockerRetryDelay) governs WHEN to probe, and the probe governs
+// whether to actually re-dispatch.
+//
+// Interaction with the 3-attempt budget (maxOperationalBlockerRetries): a probe
+// FAILURE (credential still Invalid) extends the hold WITHOUT burning an attempt,
+// so a long human outage never exhausts the budget on probes alone; an attempt is
+// spent only when the job is actually re-dispatched and the delivery fails again.
+// A probe that cannot run (Unknown — a non-claude runtime with no wired probe, or
+// a transient network blip) falls back to the coarse cadence so a broken probe can
+// never permanently strand a job.
+
+// authProbeVerdict is the tri-state result of a live credential probe, mirroring
+// runtime.ClaudeTokenStatus: Valid (re-dispatch), Invalid (extend the hold), or
+// Unknown (fall back to the coarse cadence).
+type authProbeVerdict int
+
+const (
+	authProbeUnknown authProbeVerdict = iota
+	authProbeValid
+	authProbeInvalid
+)
+
+// authProbeTimeout bounds a single live probe run so it can never block a
+// dispatch tick indefinitely. runtime.ClaudeLiveCheck applies its own internal
+// bound too; this is the belt-and-braces ceiling honored via context.
+const authProbeTimeout = 25 * time.Second
+
+// authProbeAllowsRedispatch reports whether a queued job whose operational-blocker
+// hold has ALREADY elapsed may be re-dispatched now. It only gates runtime_auth
+// deferrals (every other class defers on a time-based reset the hold already
+// encodes); everything else — no probe wired, a non-auth class, an unparseable
+// payload — returns true so the coarse cadence alone governs (slice A behavior).
+func authProbeAllowsRedispatch(ctx context.Context, worker jobWorker, job db.Job, now time.Time) bool {
+	if worker.AuthProbe == nil {
+		return true
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return true
+	}
+	if payload.BlockerClass != string(blockerClassRuntimeAuth) {
+		return true
+	}
+	switch worker.AuthProbe(ctx, job, payload) {
+	case authProbeValid:
+		return true
+	case authProbeInvalid:
+		// Credential still bad: re-arm the coarse hold so the daemon re-probes next
+		// cadence instead of re-dispatching into a broken token — and do NOT increment
+		// BlockerAttempts, so the outage does not eat the retry budget.
+		worker.extendAuthBlockerHold(ctx, job, payload, now)
+		return false
+	default:
+		// Unknown/transient: fall back to the coarse cadence. Releasing now (bounded by
+		// the 3-attempt budget) is safer than stranding a job behind an inconclusive
+		// probe forever.
+		return true
+	}
+}
+
+// extendAuthBlockerHold pushes a runtime_auth deferral's earliest-retry-at forward
+// by the coarse cadence, leaving BlockerAttempts untouched, so a failed probe
+// re-holds the job for another cadence without spending a retry. Best-effort: a
+// write error just means the next tick re-probes, which is safe.
+func (w jobWorker) extendAuthBlockerHold(ctx context.Context, job db.Job, payload workflow.JobPayload, now time.Time) {
+	payload.BlockerRetryAt = now.Add(authBlockerRetryDelay).Format(time.RFC3339Nano)
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+	_ = w.Store.UpdateJobPayload(ctx, job.ID, string(encoded))
+}
+
+// defaultAuthProbe is the daemon's live credential probe. It probes the EFFECTIVE
+// runtime the re-dispatch would use (the agent's runtime, honoring a per-job
+// runtime override): claude gets a bounded live runtime.ClaudeLiveCheck classified
+// SET-vs-VALID; every other runtime has no wired live probe, so it returns Unknown
+// and the coarse cadence stays in charge.
+func (w jobWorker) defaultAuthProbe(ctx context.Context, job db.Job, payload workflow.JobPayload) authProbeVerdict {
+	record, err := w.Store.GetAgent(ctx, job.Agent)
+	if err != nil {
+		return authProbeUnknown
+	}
+	agent := applyJobRuntimeOverride(runtimeAgent(record), payload)
+	if strings.TrimSpace(agent.Runtime) != runtime.ClaudeRuntime {
+		return authProbeUnknown
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, authProbeTimeout)
+	defer cancel()
+	return classifyClaudeAuthProbe(runtime.ClaudeLiveCheck(probeCtx, nil, ""))
+}
+
+// classifyClaudeAuthProbe maps a runtime.ClaudeLiveCheck result to an
+// authProbeVerdict via the shared ClaudeClassifyProbe tri-state, so an INVALID
+// verdict (and only an invalid one) extends the hold, while a missing binary /
+// network blip stays Unknown and never mis-holds a job.
+func classifyClaudeAuthProbe(err error) authProbeVerdict {
+	switch runtime.ClaudeClassifyProbe(err) {
+	case runtime.ClaudeTokenValid:
+		return authProbeValid
+	case runtime.ClaudeTokenInvalid:
+		return authProbeInvalid
+	default:
+		return authProbeUnknown
+	}
+}

--- a/internal/cli/job_blocker_auth_probe.go
+++ b/internal/cli/job_blocker_auth_probe.go
@@ -45,12 +45,27 @@ const (
 // bound too; this is the belt-and-braces ceiling honored via context.
 const authProbeTimeout = 25 * time.Second
 
+// authProbeCache dedupes the live credential probe WITHIN a single
+// listPendingQueuedJobs pass. The production probe (defaultAuthProbe) reads the
+// AMBIENT daemon token, so its verdict is identical for every auth-held job that
+// resolves to the same effective runtime; caching by that runtime key collapses N
+// auth-held jobs to ONE live `claude -p` subprocess per pass instead of N. A nil
+// cache disables dedup (each call probes) so direct/legacy callers are unaffected.
+type authProbeCache map[string]authProbeVerdict
+
 // authProbeAllowsRedispatch reports whether a queued job whose operational-blocker
 // hold has ALREADY elapsed may be re-dispatched now. It only gates runtime_auth
 // deferrals (every other class defers on a time-based reset the hold already
 // encodes); everything else — no probe wired, a non-auth class, an unparseable
 // payload — returns true so the coarse cadence alone governs (slice A behavior).
-func authProbeAllowsRedispatch(ctx context.Context, worker jobWorker, job db.Job, now time.Time) bool {
+//
+// The verdict is deduped across the pass via `cache` (see authProbeCache), and a
+// probe-cadence marker is written on EVERY verdict — not just Invalid — so a job
+// that probed this cadence but was NOT actually dispatched (its runtime session is
+// busy, its checkout key is contended, or the host admission budget is full) is not
+// re-probed on the very next dispatch pass. Without the marker a stuck-but-valid
+// auth-held job would spawn a fresh live probe on every worker reap.
+func authProbeAllowsRedispatch(ctx context.Context, worker jobWorker, job db.Job, now time.Time, cache authProbeCache) bool {
 	if worker.AuthProbe == nil {
 		return true
 	}
@@ -61,14 +76,19 @@ func authProbeAllowsRedispatch(ctx context.Context, worker jobWorker, job db.Job
 	if payload.BlockerClass != string(blockerClassRuntimeAuth) {
 		return true
 	}
-	switch worker.AuthProbe(ctx, job, payload) {
+	verdict := worker.probeAuthVerdict(ctx, job, payload, cache)
+	// Mark the probe cadence on every verdict: re-arm the coarse hold so this job is
+	// not re-probed until authBlockerRetryDelay elapses again. Done AFTER the verdict
+	// so the return value below still governs THIS pass (the queuedJobBlockerHeld gate
+	// already cleared for the in-memory job, so a Valid job is still dispatchable now).
+	// BlockerAttempts is left untouched, so a long outage never eats the retry budget.
+	worker.extendAuthBlockerHold(ctx, job, payload, now)
+	switch verdict {
 	case authProbeValid:
 		return true
 	case authProbeInvalid:
-		// Credential still bad: re-arm the coarse hold so the daemon re-probes next
-		// cadence instead of re-dispatching into a broken token — and do NOT increment
-		// BlockerAttempts, so the outage does not eat the retry budget.
-		worker.extendAuthBlockerHold(ctx, job, payload, now)
+		// Credential still bad: the re-armed hold means the daemon re-probes next
+		// cadence instead of re-dispatching into a broken token.
 		return false
 	default:
 		// Unknown/transient: fall back to the coarse cadence. Releasing now (bounded by
@@ -78,9 +98,42 @@ func authProbeAllowsRedispatch(ctx context.Context, worker jobWorker, job db.Job
 	}
 }
 
+// probeAuthVerdict returns the live probe verdict for a runtime_auth-held job,
+// consulting/populating the per-pass dedup cache when one is supplied. The cache
+// key is the effective runtime the re-dispatch would use (honoring a per-job
+// runtime override): the ambient-token probe result is identical for all jobs of
+// that runtime, so they share one subprocess. A nil cache probes directly.
+func (w jobWorker) probeAuthVerdict(ctx context.Context, job db.Job, payload workflow.JobPayload, cache authProbeCache) authProbeVerdict {
+	if cache == nil {
+		return w.AuthProbe(ctx, job, payload)
+	}
+	key := w.authProbeDedupKey(ctx, job, payload)
+	if verdict, ok := cache[key]; ok {
+		return verdict
+	}
+	verdict := w.AuthProbe(ctx, job, payload)
+	cache[key] = verdict
+	return verdict
+}
+
+// authProbeDedupKey identifies the credential domain a probe result applies to:
+// the effective runtime (agent runtime + any per-job override). All auth-held jobs
+// that share this key share one ambient-token probe. If the agent can't be read,
+// key by agent name so a lookup failure never merges distinct agents' verdicts.
+func (w jobWorker) authProbeDedupKey(ctx context.Context, job db.Job, payload workflow.JobPayload) string {
+	record, err := w.Store.GetAgent(ctx, job.Agent)
+	if err != nil {
+		return "agent:" + job.Agent
+	}
+	agent := applyJobRuntimeOverride(runtimeAgent(record), payload)
+	return "runtime:" + strings.TrimSpace(agent.Runtime)
+}
+
 // extendAuthBlockerHold pushes a runtime_auth deferral's earliest-retry-at forward
-// by the coarse cadence, leaving BlockerAttempts untouched, so a failed probe
-// re-holds the job for another cadence without spending a retry. Best-effort: a
+// by the coarse cadence, leaving BlockerAttempts untouched. It is the probe-cadence
+// marker (#532 slice B): written after every probe verdict so a job is not re-probed
+// until the next cadence, whether the probe held it (Invalid) or released it
+// (Valid/Unknown) but it could not actually be dispatched this pass. Best-effort: a
 // write error just means the next tick re-probes, which is safe.
 func (w jobWorker) extendAuthBlockerHold(ctx context.Context, job db.Job, payload workflow.JobPayload, now time.Time) {
 	payload.BlockerRetryAt = now.Add(authBlockerRetryDelay).Format(time.RFC3339Nano)

--- a/internal/cli/job_blocker_checkout.go
+++ b/internal/cli/job_blocker_checkout.go
@@ -73,13 +73,19 @@ func classifyCheckoutContention(cause error) (checkoutContentionKind, string) {
 		return checkoutContentionNone, ""
 	}
 	text := cause.Error()
+	// Match ONLY the three daemon-owned pre-flight string families the #532 design
+	// names: branch-lock contention, a dirty checkout, and a wrong HEAD. The
+	// branch-identity guard ("checkout branch is X, not job branch Y") is
+	// deliberately NOT matched — it is a routing/config mismatch (a job resolving a
+	// checkout on the wrong branch), not a self-healing or human-clean-the-checkout
+	// condition, so it keeps its existing terminal path.
 	switch {
 	case strings.Contains(text, "is locked by"):
 		return checkoutContentionLock, ""
 	case strings.Contains(text, "has uncommitted changes"):
 		return checkoutContentionDirty, "the registered checkout has uncommitted changes; commit, stash, or discard them (git checkout -- .) so the job's pre-flight can pass, then it auto-retries"
-	case strings.Contains(text, "checkout head is"), strings.Contains(text, "checkout branch is"):
-		return checkoutContentionDirty, "the registered checkout is on the wrong branch/commit; reset it to the branch/head the job expects (git checkout <branch> / git reset --hard <sha>), then it auto-retries"
+	case strings.Contains(text, "checkout head is"):
+		return checkoutContentionDirty, "the registered checkout is on the wrong commit; sync it to the head the job expects (git fetch && git reset --hard <sha>), then it auto-retries"
 	}
 	return checkoutContentionNone, ""
 }

--- a/internal/cli/job_blocker_checkout.go
+++ b/internal/cli/job_blocker_checkout.go
@@ -145,6 +145,12 @@ func (w jobWorker) deferCheckoutContention(ctx context.Context, job db.Job, payl
 	payload.BlockerAttempts = attempt
 	payload.BlockerRetryAt = retryAt
 	payload.BlockerSuggestedAction = action
+	// PRE-DELIVERY (#532): this hold trips at the daemon pre-flight, BEFORE Mailbox.Run
+	// delivers a prompt, so the agent never executed — a re-dispatch is a first run with
+	// no side effects to reconcile. Mark it so Mailbox.Run suppresses the slice-F
+	// reconciliation notice (which would otherwise falsely tell the agent a prior
+	// attempt ran and may have pushed branches / opened PRs).
+	payload.BlockerPreDelivery = true
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return false, err

--- a/internal/cli/job_blocker_checkout.go
+++ b/internal/cli/job_blocker_checkout.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// Issue #532 slice C: classify the daemon-owned pre-flight CHECKOUT strings —
+// which today TERMINALLY fail a job through finishQueuedJob — and defer the job
+// for automatic re-dispatch instead. Two sub-classes of the checkout_contention
+// class, both keyed off strings the daemon itself emits (validateTargetCheckout /
+// validateReviewCheckout / validateImplementationLock):
+//
+//   - branch-LOCK contention ("branch %s is locked by %s"): another worker holds
+//     the branch lock. It self-heals the moment that worker finishes (#328/#329
+//     checkout-key serialization already makes most contention never even reach
+//     here), so it defers with a SHORT EXPONENTIAL backoff and no suggested_action.
+//   - DIRTY / WRONG-HEAD ("checkout %s has uncommitted changes", "checkout head
+//     is %s, not …", "checkout branch is %s, not …"): the registered checkout is
+//     not in the state the job needs. That usually needs a human to clean/reset
+//     the checkout, so it defers with a fixed backoff AND a suggested_action
+//     surfaced through the #552 stuck surface.
+//
+// Scope discipline (mirrors slice A):
+//   - Delegation children (ParentJobID set) are EXCLUDED and keep their existing
+//     DAG routing (finishQueuedJob → finalizePreflightDelegationChild → the
+//     delegation failure_policy, #409). This slice only diverts non-delegation
+//     jobs whose pre-flight checkout failed.
+//   - Auto-retries share the SAME hard budget as the other classes
+//     (maxOperationalBlockerRetries): a contention that outlives the budget stays
+//     terminally failed exactly like today (with the suggested_action preserved in
+//     the payload/stuck surface).
+//   - The job is deferred from the QUEUED state (the pre-flight runs before the
+//     mailbox claims queued→running), so no state transition happens — the hold is
+//     just the payload fields + a blocker_deferred event, and listPendingQueuedJobs'
+//     queuedJobBlockerHeld gate holds it. Because finishQueuedJob is never called,
+//     NO job.failed precedes the additive job.deferred (the pre-terminal property,
+//     same as slice E's mailbox seam).
+
+type checkoutContentionKind int
+
+const (
+	checkoutContentionNone checkoutContentionKind = iota
+	checkoutContentionLock
+	checkoutContentionDirty
+)
+
+// checkoutLockBaseBackoff / checkoutLockMaxBackoff bound the SHORT exponential
+// backoff for self-healing branch-lock contention: 2s, 4s, 8s across the budget,
+// clamped so a bit-shift can never park a job long.
+const (
+	checkoutLockBaseBackoff = 2 * time.Second
+	checkoutLockMaxBackoff  = 30 * time.Second
+	// checkoutDirtyBackoff is the fixed hold for a dirty/wrong-head checkout: it
+	// usually needs a human, so give them a window to clean the checkout before the
+	// next auto-retry (bounded by the shared budget) rather than hammering it.
+	checkoutDirtyBackoff = 2 * time.Minute
+)
+
+// classifyCheckoutContention maps a daemon pre-flight checkout error to its
+// sub-class and, for the human-needing sub-class, a concrete suggested_action.
+// A non-checkout error returns checkoutContentionNone so the caller falls through
+// to today's terminal path byte-identically.
+func classifyCheckoutContention(cause error) (checkoutContentionKind, string) {
+	if cause == nil {
+		return checkoutContentionNone, ""
+	}
+	text := cause.Error()
+	switch {
+	case strings.Contains(text, "is locked by"):
+		return checkoutContentionLock, ""
+	case strings.Contains(text, "has uncommitted changes"):
+		return checkoutContentionDirty, "the registered checkout has uncommitted changes; commit, stash, or discard them (git checkout -- .) so the job's pre-flight can pass, then it auto-retries"
+	case strings.Contains(text, "checkout head is"), strings.Contains(text, "checkout branch is"):
+		return checkoutContentionDirty, "the registered checkout is on the wrong branch/commit; reset it to the branch/head the job expects (git checkout <branch> / git reset --hard <sha>), then it auto-retries"
+	}
+	return checkoutContentionNone, ""
+}
+
+// checkoutLockBackoff returns the SHORT exponential backoff for the attempt-th
+// branch-lock deferral (1-based), clamped to [base, max].
+func checkoutLockBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := checkoutLockBaseBackoff << (attempt - 1)
+	if d <= 0 || d > checkoutLockMaxBackoff {
+		return checkoutLockMaxBackoff
+	}
+	return d
+}
+
+// deferCheckoutContention re-queues (holds) a non-delegation job whose daemon
+// pre-flight checkout validation just failed on a classified contention string,
+// instead of terminally failing it via finishQueuedJob. It operates on the QUEUED
+// job the daemon is dispatching: it writes the blocker hold fields + a
+// blocker_deferred event and emits the additive job.deferred, then returns true so
+// the caller skips finishQueuedJob. Every non-matching / excluded / budget-spent
+// case returns false so the existing terminal path runs unchanged.
+func (w jobWorker) deferCheckoutContention(ctx context.Context, job db.Job, payload workflow.JobPayload, cause error) (bool, error) {
+	kind, action := classifyCheckoutContention(cause)
+	if kind == checkoutContentionNone {
+		return false, nil
+	}
+	// Delegation children keep the DAG's own routing (finishQueuedJob →
+	// finalizePreflightDelegationChild); never divert them here.
+	if strings.TrimSpace(payload.ParentJobID) != "" {
+		return false, nil
+	}
+	// The pre-flight runs before the mailbox claims the job, so only a still-queued
+	// job is eligible; anything else belongs to other machinery.
+	if job.State != string(workflow.JobQueued) {
+		return false, nil
+	}
+	attempt := payload.BlockerAttempts + 1
+	if attempt > maxOperationalBlockerRetries {
+		_ = w.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID: job.ID,
+			Kind:  blockerExhaustedEventKind,
+			Message: fmt.Sprintf("operational blocker %s recurred after %d auto-retries; job stays failed: %s",
+				blockerClassCheckoutContention, maxOperationalBlockerRetries, firstLineTrimmed(cause.Error())),
+		})
+		return false, nil
+	}
+	delay := checkoutDirtyBackoff
+	if kind == checkoutContentionLock {
+		delay = checkoutLockBackoff(attempt)
+	}
+	retryAt := time.Now().UTC().Add(delay).Format(time.RFC3339Nano)
+	detail := firstLineTrimmed(cause.Error())
+	payload.BlockerClass = string(blockerClassCheckoutContention)
+	payload.BlockerAttempts = attempt
+	payload.BlockerRetryAt = retryAt
+	payload.BlockerSuggestedAction = action
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return false, err
+	}
+	if err := w.Store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		return false, err
+	}
+	message := fmt.Sprintf("%s: attempt %d/%d, retry at %s: %s",
+		blockerClassCheckoutContention, attempt, maxOperationalBlockerRetries, retryAt, detail)
+	if err := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: blockerDeferredEventKind, Message: message}); err != nil {
+		return false, err
+	}
+	// Additive job.deferred, best-effort and nil-safe when [events] is OFF. No
+	// job.failed precedes it: finishQueuedJob was never called (pre-terminal).
+	emitDaemonTerminalEvent(ctx, w.eventSink(), w.Store, job.ID, events.EventJobDeferred, string(workflow.JobQueued), message)
+	return true, nil
+}

--- a/internal/cli/job_blocker_slices_test.go
+++ b/internal/cli/job_blocker_slices_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// ---- Slice C: checkout-contention classifier + child exclusion.
+
+func TestClassifyCheckoutContention(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantKind   checkoutContentionKind
+		wantAction bool
+	}{
+		{"branch lock self-heals", errors.New("branch main is locked by other-worker, not me"), checkoutContentionLock, false},
+		{"dirty checkout needs a human", errors.New("checkout /x has uncommitted changes"), checkoutContentionDirty, true},
+		{"wrong head needs a human", errors.New("checkout head is abc, not review job head def"), checkoutContentionDirty, true},
+		{"wrong branch needs a human", errors.New("checkout branch is main, not job branch feat/x"), checkoutContentionDirty, true},
+		{"unrelated error is not contention", errors.New("adapter factory failed"), checkoutContentionNone, false},
+		{"nil error", nil, checkoutContentionNone, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, action := classifyCheckoutContention(tc.err)
+			if kind != tc.wantKind {
+				t.Fatalf("kind = %d, want %d", kind, tc.wantKind)
+			}
+			if (action != "") != tc.wantAction {
+				t.Fatalf("action = %q, wantNonEmpty=%v", action, tc.wantAction)
+			}
+		})
+	}
+}
+
+func TestCheckoutLockBackoffIsShortExponential(t *testing.T) {
+	if got := checkoutLockBackoff(1); got != checkoutLockBaseBackoff {
+		t.Fatalf("attempt 1 backoff = %s, want %s", got, checkoutLockBaseBackoff)
+	}
+	if got := checkoutLockBackoff(2); got != 2*checkoutLockBaseBackoff {
+		t.Fatalf("attempt 2 backoff = %s, want %s", got, 2*checkoutLockBaseBackoff)
+	}
+	if got := checkoutLockBackoff(3); got != 4*checkoutLockBaseBackoff {
+		t.Fatalf("attempt 3 backoff = %s, want %s", got, 4*checkoutLockBaseBackoff)
+	}
+	// Always short — never near the dirty (minutes) backoff.
+	if checkoutLockBackoff(3) >= checkoutDirtyBackoff {
+		t.Fatal("lock backoff grew into the dirty-checkout range")
+	}
+	if got := checkoutLockBackoff(20); got != checkoutLockMaxBackoff {
+		t.Fatalf("large attempt backoff = %s, want clamp %s", got, checkoutLockMaxBackoff)
+	}
+}
+
+// A delegation child must never be diverted by slice C: deferCheckoutContention
+// returns false so the caller's existing DAG routing (finishQueuedJob) runs.
+func TestDeferCheckoutContentionExcludesDelegationChild(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "childbot", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "child-job", Agent: "childbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+		ParentJobID: "parent-1", DelegationID: "deleg-1",
+	})
+	job, err := store.GetJob(ctx, "child-job")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	worker := defaultJobWorker(store, io.Discard, t.TempDir())
+	deferred, err := worker.deferCheckoutContention(ctx, job, payload, errors.New("checkout /x has uncommitted changes"))
+	if err != nil {
+		t.Fatalf("deferCheckoutContention: %v", err)
+	}
+	if deferred {
+		t.Fatal("slice C deferred a delegation child; it must keep DAG routing")
+	}
+	reloaded, _ := store.GetJob(ctx, "child-job")
+	p, _ := daemonJobPayload(reloaded)
+	if p.BlockerClass != "" {
+		t.Fatalf("delegation child acquired a blocker class: %+v", p)
+	}
+}
+
+// The shared 3-attempt budget bounds checkout contention too: a job already at the
+// cap is not deferred again (it records the exhausted event and falls through).
+func TestDeferCheckoutContentionRespectsBudget(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "capbot", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "cap-job", Agent: "capbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	job, _ := store.GetJob(ctx, "cap-job")
+	payload, _ := daemonJobPayload(job)
+	payload.BlockerAttempts = maxOperationalBlockerRetries
+	encoded, _ := json.Marshal(payload)
+	if err := store.UpdateJobPayload(ctx, "cap-job", string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload: %v", err)
+	}
+	job, _ = store.GetJob(ctx, "cap-job")
+	payload, _ = daemonJobPayload(job)
+	worker := defaultJobWorker(store, io.Discard, t.TempDir())
+	deferred, err := worker.deferCheckoutContention(ctx, job, payload, errors.New("branch main is locked by other"))
+	if err != nil {
+		t.Fatalf("deferCheckoutContention: %v", err)
+	}
+	if deferred {
+		t.Fatal("checkout contention deferred past the retry budget")
+	}
+	if !blockerE2EHasEventKind(t, store, "cap-job", blockerExhaustedEventKind) {
+		t.Fatal("budget-exhausted checkout contention did not record the exhausted event")
+	}
+}
+
+// ---- Slice D: network_outage classification (typed marker + delivery signature).
+
+func TestClassifyOperationalBlockerNetworkOutage(t *testing.T) {
+	now := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	t.Run("typed github TransientError classifies without the delivery marker", func(t *testing.T) {
+		cause := github.TransientError{Err: errors.New("connection refused")}
+		got, ok := classifyOperationalBlocker(cause, now)
+		if !ok || got.Class != blockerClassNetworkOutage {
+			t.Fatalf("classify = (%+v, %v), want network_outage", got, ok)
+		}
+	})
+	t.Run("delivery-seam outage signature classifies", func(t *testing.T) {
+		cause := workflow.DeliveryError{Err: errors.New("fatal: unable to access: Could not resolve host: github.com: exit status 128")}
+		got, ok := classifyOperationalBlocker(cause, now)
+		if !ok || got.Class != blockerClassNetworkOutage {
+			t.Fatalf("classify = (%+v, %v), want network_outage", got, ok)
+		}
+	})
+	t.Run("bare outage text WITHOUT the delivery marker never classifies", func(t *testing.T) {
+		// Agent-authored text mentioning a network problem is a product failure.
+		if _, ok := classifyOperationalBlocker(errors.New("summary: the service was unavailable"), now); ok {
+			t.Fatal("agent-authored network text classified without the DeliveryError marker")
+		}
+	})
+	t.Run("auth/quota still win over network on the same text", func(t *testing.T) {
+		cause := workflow.DeliveryError{Err: errors.New("HTTP 503 while checking usage limit; rate limit reached")}
+		got, ok := classifyOperationalBlocker(cause, now)
+		if !ok || got.Class != blockerClassRuntimeQuota {
+			t.Fatalf("classify = (%+v, %v), want runtime_quota (more specific than network)", got, ok)
+		}
+	})
+}
+
+// ---- Slice B: probe verdict mapping.
+
+func TestClassifyClaudeAuthProbe(t *testing.T) {
+	if got := classifyClaudeAuthProbe(nil); got != authProbeValid {
+		t.Fatalf("nil probe err = %d, want valid", got)
+	}
+	if got := classifyClaudeAuthProbe(errors.New("some network blip")); got != authProbeUnknown {
+		t.Fatalf("transient probe err = %d, want unknown", got)
+	}
+	authErr := errors.Join(errors.New("rejected"), runtime.ErrClaudeAuthFailed)
+	if got := classifyClaudeAuthProbe(authErr); got != authProbeInvalid {
+		t.Fatalf("auth-failed probe err = %d, want invalid", got)
+	}
+}
+
+// A non-auth deferral is never probe-gated (the gate is only for runtime_auth).
+func TestAuthProbeAllowsRedispatchOnlyGatesAuth(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "qbot", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "quota-job", Agent: "qbot", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	job, _ := store.GetJob(ctx, "quota-job")
+	payload, _ := daemonJobPayload(job)
+	payload.BlockerClass = string(blockerClassRuntimeQuota)
+	encoded, _ := json.Marshal(payload)
+	_ = store.UpdateJobPayload(ctx, "quota-job", string(encoded))
+	job, _ = store.GetJob(ctx, "quota-job")
+
+	worker := defaultJobWorker(store, io.Discard, t.TempDir())
+	probed := false
+	worker.AuthProbe = func(context.Context, db.Job, workflow.JobPayload) authProbeVerdict {
+		probed = true
+		return authProbeInvalid
+	}
+	if !authProbeAllowsRedispatch(ctx, worker, job, time.Now().UTC()) {
+		t.Fatal("a runtime_quota deferral was probe-gated; only runtime_auth should be")
+	}
+	if probed {
+		t.Fatal("the auth probe ran for a non-auth deferral")
+	}
+}

--- a/internal/cli/job_blocker_slices_test.go
+++ b/internal/cli/job_blocker_slices_test.go
@@ -197,7 +197,7 @@ func TestAuthProbeAllowsRedispatchOnlyGatesAuth(t *testing.T) {
 		probed = true
 		return authProbeInvalid
 	}
-	if !authProbeAllowsRedispatch(ctx, worker, job, time.Now().UTC()) {
+	if !authProbeAllowsRedispatch(ctx, worker, job, time.Now().UTC(), nil) {
 		t.Fatal("a runtime_quota deferral was probe-gated; only runtime_auth should be")
 	}
 	if probed {

--- a/internal/cli/job_blocker_slices_test.go
+++ b/internal/cli/job_blocker_slices_test.go
@@ -25,8 +25,10 @@ func TestClassifyCheckoutContention(t *testing.T) {
 	}{
 		{"branch lock self-heals", errors.New("branch main is locked by other-worker, not me"), checkoutContentionLock, false},
 		{"dirty checkout needs a human", errors.New("checkout /x has uncommitted changes"), checkoutContentionDirty, true},
-		{"wrong head needs a human", errors.New("checkout head is abc, not review job head def"), checkoutContentionDirty, true},
-		{"wrong branch needs a human", errors.New("checkout branch is main, not job branch feat/x"), checkoutContentionDirty, true},
+		{"wrong head (review) needs a human", errors.New("checkout head is abc, not review job head def"), checkoutContentionDirty, true},
+		{"wrong head (job) needs a human", errors.New("checkout head is abc, not job head def"), checkoutContentionDirty, true},
+		// The branch-identity guard is a routing/config mismatch, NOT contention.
+		{"wrong branch is not contention", errors.New("checkout branch is main, not job branch feat/x"), checkoutContentionNone, false},
 		{"unrelated error is not contention", errors.New("adapter factory failed"), checkoutContentionNone, false},
 		{"nil error", nil, checkoutContentionNone, false},
 	}

--- a/internal/cli/job_stuck.go
+++ b/internal/cli/job_stuck.go
@@ -49,6 +49,10 @@ var stuckReasonEventKinds = []string{
 type stuckReason struct {
 	Reason      string // e.g. "waiting on runtime session lock ...", "blocked: awaiting human", "auth failing: ..."
 	NextRetryAt string // an RFC3339 lease expiry when one applies (a runtime-session lock), else ""
+	// SuggestedAction is a concrete human-facing remedy for a deferral that usually
+	// needs manual intervention (a dirty/wrong-head checkout, #532 slice C). Empty
+	// for self-healing holds; callers render it only when non-empty.
+	SuggestedAction string
 }
 
 func (r stuckReason) empty() bool { return strings.TrimSpace(r.Reason) == "" }
@@ -82,10 +86,12 @@ func deriveStuckReason(job db.Job, reasonEvent db.JobEvent, hasReasonEvent bool,
 		// The event message already names the class + attempt budget; the payload
 		// carries the authoritative earliest-retry-at the queue gate honors.
 		next := ""
+		action := ""
 		if payload, err := daemonJobPayload(job); err == nil {
 			next = strings.TrimSpace(payload.BlockerRetryAt)
+			action = strings.TrimSpace(payload.BlockerSuggestedAction)
 		}
-		return stuckReason{Reason: withDetail("blocked-operational", msg), NextRetryAt: next}
+		return stuckReason{Reason: withDetail("blocked-operational", msg), NextRetryAt: next, SuggestedAction: action}
 	case "runtime_lock_wait":
 		reason := "waiting on runtime session lock"
 		next := ""

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1202,7 +1202,12 @@ func (c *GhClient) run(ctx context.Context, mutate bool, args ...string) (subpro
 		}
 	}
 	if err != nil {
-		return result, commandError(result, err)
+		// Tag a network/GitHub-outage failure with the transparent TransientError
+		// marker (#532 slice D) so a caller that propagates it to a TERMINAL job
+		// failure can be classified as network_outage and short-backoff deferred.
+		// Non-outage failures (and every failure's exact text) are untouched, and
+		// best-effort callers that swallow the error are byte-identical.
+		return result, classifyTransientError(result, commandError(result, err))
 	}
 	return result, nil
 }

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+// TransientError marks a gh-CLI failure that a network/GitHub outage caused —
+// connection refused/reset, DNS/TLS failure, a gateway 5xx, a timeout — as
+// opposed to a deterministic failure (bad request, 404, permission, a genuine
+// conflict) that retrying would not fix. It is the minimal typed discriminator
+// #532 slice D calls for: the daemon's operational-blocker classifier maps it (or
+// its signature via IsTransientMessage) to the network_outage class with a short
+// backoff, but ONLY where a github operation currently TERMINALLY fails a job —
+// best-effort github paths swallow the error and stay best-effort.
+//
+// Error() is transparent (it forwards to the wrapped error) so every existing
+// string-based consumer of a gh failure — logs, comments, the #552 stuck-reason
+// matcher — stays byte-identical; the marker is observed only via errors.As /
+// AsTransient. It mirrors the existing UpdatePullRequestBranchError transient
+// discriminator, generalized to any gh call routed through commandError.
+type TransientError struct{ Err error }
+
+func (e TransientError) Error() string {
+	if e.Err == nil {
+		return "transient github error"
+	}
+	return e.Err.Error()
+}
+
+func (e TransientError) Unwrap() error { return e.Err }
+
+// AsTransient reports whether err (anywhere in its chain) is a TransientError.
+func AsTransient(err error) bool {
+	var t TransientError
+	return errors.As(err, &t)
+}
+
+// IsTransientMessage reports whether a gh-CLI failure message carries a
+// network/GitHub-outage signature. It is the single grounded source of the
+// network signatures #532 uses: the classifier reuses it to recognize an outage
+// that surfaced through a DELIVERY error (an agent's own `gh` subprocess stderr,
+// which never becomes a TransientError value), so both the typed github-owned
+// path and the delivery-seam path key off exactly one signature set.
+//
+// The signatures are deliberately outage-specific — transport/DNS/TLS failures
+// and gateway 5xx — so a deterministic 4xx (bad request, 404, 403 permission,
+// 422 conflict) is never misread as retryable. Rate-limit/429 is intentionally
+// NOT here: it is the runtime_quota class's job (classifyAuthQuotaStrict), and
+// gh's own run() already retries a rate limit before returning.
+func IsTransientMessage(text string) bool {
+	l := strings.ToLower(text)
+	for _, sig := range transientSignatures {
+		if strings.Contains(l, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+var transientSignatures = []string{
+	"connection refused",
+	"connection reset",
+	"connection timed out",
+	"could not resolve host",
+	"no such host",
+	"temporary failure in name resolution",
+	"network is unreachable",
+	"tls handshake",
+	"i/o timeout",
+	"timeout awaiting",
+	"client.timeout exceeded",
+	"context deadline exceeded",
+	"unexpected eof", // gh/Go print this when the connection drops mid-response
+	"read: eof",
+	"http 502",
+	"http 503",
+	"http 504",
+	"bad gateway",
+	"service unavailable",
+	"gateway timeout",
+	"internal server error", // gh's phrasing for a 5xx api response
+}
+
+// classifyTransientError wraps a gh commandError in a TransientError when the
+// command's output carries a network-outage signature, leaving every other
+// failure (and its exact text) untouched. Called from GhClient.run so any gh call
+// routed through it — but only the ones a caller propagates to a terminal job
+// failure — carries the marker. err is the already-wrapped commandError so the
+// transparent Error() stays byte-identical.
+func classifyTransientError(result subprocess.Result, err error) error {
+	if err == nil {
+		return nil
+	}
+	if IsTransientMessage(result.Stderr + "\n" + result.Stdout + "\n" + err.Error()) {
+		return TransientError{Err: err}
+	}
+	return err
+}

--- a/internal/github/errors_test.go
+++ b/internal/github/errors_test.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+func TestIsTransientMessage(t *testing.T) {
+	transient := []string{
+		"dial tcp: connection refused",
+		"read: connection reset by peer",
+		"could not resolve host: github.com",
+		"dial tcp: lookup api.github.com: no such host",
+		"net/http: TLS handshake timeout",
+		"Post \"https://api.github.com\": read tcp: i/o timeout",
+		"HTTP 502 Bad Gateway",
+		"HTTP 503 Service Unavailable",
+		"unexpected EOF",
+	}
+	for _, s := range transient {
+		if !IsTransientMessage(s) {
+			t.Errorf("IsTransientMessage(%q) = false, want true", s)
+		}
+	}
+	deterministic := []string{
+		"HTTP 404 Not Found",
+		"HTTP 403 Forbidden: resource not accessible",
+		"HTTP 422 Unprocessable Entity: a pull request already exists",
+		"gh: authentication required",
+		"nothing to commit",
+	}
+	for _, s := range deterministic {
+		if IsTransientMessage(s) {
+			t.Errorf("IsTransientMessage(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestClassifyTransientError(t *testing.T) {
+	base := errors.New("boom: exit status 1")
+	t.Run("network signature is tagged transient and stays transparent", func(t *testing.T) {
+		result := subprocess.Result{Stderr: "dial tcp 140.82.121.3:443: connect: connection refused"}
+		err := classifyTransientError(result, base)
+		if !AsTransient(err) {
+			t.Fatal("network failure was not tagged TransientError")
+		}
+		if err.Error() != base.Error() {
+			t.Fatalf("TransientError changed the message: %q, want %q", err.Error(), base.Error())
+		}
+		if !errors.Is(err, base) {
+			t.Fatal("wrapped base error is no longer reachable via errors.Is")
+		}
+	})
+	t.Run("deterministic failure is left untouched", func(t *testing.T) {
+		result := subprocess.Result{Stderr: "HTTP 404: Not Found"}
+		err := classifyTransientError(result, base)
+		if AsTransient(err) {
+			t.Fatal("a 404 was tagged transient")
+		}
+		if err != base {
+			t.Fatal("deterministic failure was rewrapped")
+		}
+	})
+	t.Run("nil stays nil", func(t *testing.T) {
+		if err := classifyTransientError(subprocess.Result{}, nil); err != nil {
+			t.Fatalf("classifyTransientError(nil) = %v, want nil", err)
+		}
+	})
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -47,6 +47,19 @@ type Engine struct {
 	// terminal cases it owns through the SAME sink so the whole terminal set is
 	// covered. #445 (the ask-gate) rides this seam to emit its job.needs_attention.
 	EventSink events.Sink
+	// BlockerDeferrer is the injected, best-effort, nil-by-default PRE-TERMINAL
+	// operational-blocker deferrer (#532 slice E). When set, the engine's Mailbox
+	// consults it on a delivery-seam failure BEFORE the terminal transition: if it
+	// re-queues the job behind a classified operational blocker (runtime auth/quota/
+	// network), Run reports ErrJobDeferred and never emits job.failed, so the
+	// [events] stream sees the deferral as a first-class transition instead of a
+	// failed→deferred flap. It mirrors EventSink: optional and nil-safe (when nil —
+	// foreground/ask paths and every non-daemon construction — Run is byte-identical),
+	// and best-effort (a deferrer error is treated as "not deferred" so the job takes
+	// its normal terminal path). The concrete impl lives in cli (it classifies with
+	// the #602 matcher and writes the payload hold fields), keeping the engine free of
+	// the classification coupling; it is wired only on the daemon run path.
+	BlockerDeferrer func(ctx context.Context, jobID string, cause error) (bool, error)
 	// OutcomeHarvester is the injected, best-effort, nil-by-default seam (#465,
 	// Mode A) the engine calls after a verifiable implement-job outcome transition
 	// (merge merged/blocked, review changes_requested, revert) to harvest a
@@ -360,7 +373,7 @@ func (e Engine) now() time.Time {
 // path is byte-identical. The hook maps the terminal JobState to the event_type,
 // resolves root_id from the payload, and ships a redacted event fire-and-forget.
 func (e Engine) mailbox() Mailbox {
-	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled}
+	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer}
 	if e.EventSink == nil {
 		return mb
 	}

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -46,6 +46,7 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 	payload.BlockerAttempts = 0
 	payload.BlockerRetryAt = ""
 	payload.BlockerSuggestedAction = ""
+	payload.BlockerPreDelivery = false
 	if manualRetryShouldClearReadOnlyWorktree(job, payload) {
 		payload.WorktreePath = ""
 		payload.HeadSHA = ""

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -45,6 +45,7 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 	payload.BlockerClass = ""
 	payload.BlockerAttempts = 0
 	payload.BlockerRetryAt = ""
+	payload.BlockerSuggestedAction = ""
 	if manualRetryShouldClearReadOnlyWorktree(job, payload) {
 		payload.WorktreePath = ""
 		payload.HeadSHA = ""

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -202,6 +202,16 @@ type JobPayload struct {
 	// sees what condition must change; auth/quota/network deferrals leave it empty
 	// because they clear on their own. Additive/omitempty (byte-identical when unset).
 	BlockerSuggestedAction string `json:"blocker_suggested_action,omitempty"`
+	// BlockerPreDelivery marks a deferral that happened BEFORE the agent was ever
+	// delivered a prompt — currently only the daemon pre-flight checkout_contention
+	// hold (#532 slice C), which trips at checkout validation before Mailbox.Run
+	// claims the job and delivers. A pre-delivery deferral means the agent never
+	// executed, so a re-dispatch is a FIRST run with NO prior side effects to
+	// reconcile: the slice-F reconciliation notice must be suppressed for it. The
+	// mid-delivery seam (deferOperationalBlockerPreTerminal) clears this flag so a
+	// later runtime_auth/quota/network deferral still carries the at-least-once
+	// side-effect warning. Additive/omitempty (byte-identical when unset).
+	BlockerPreDelivery bool `json:"blocker_pre_delivery,omitempty"`
 }
 
 type DeliveryAdapter interface {
@@ -481,12 +491,15 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	}
 
 	prompt := prompts.RenderJob(payload.prompt(job.Type))
-	if payload.BlockerAttempts > 0 && strings.TrimSpace(payload.BlockerClass) != "" {
+	if payload.BlockerAttempts > 0 && strings.TrimSpace(payload.BlockerClass) != "" && !payload.BlockerPreDelivery {
 		// This run is an automatic operational-blocker retry (#532): the previous
 		// attempt died on an environment condition, not on its own output, and may
 		// have executed side effects before the blocker hit — so warn the agent its
 		// prior approach was sound and ask it to reconcile prior artifacts rather than
-		// duplicate them (slice F).
+		// duplicate them (slice F). Suppressed for a PRE-DELIVERY deferral
+		// (BlockerPreDelivery, e.g. a checkout_contention hold): that deferral tripped
+		// at the daemon pre-flight before any delivery, so the agent never executed and
+		// there are zero prior artifacts to reconcile — this is its first real run.
 		prompt = blockerRetryReconciliationNotice(payload.BlockerClass, payload.BlockerAttempts) + "\n\n" + prompt
 	}
 	firstRaw, firstRefreshedRef, firstErr := m.deliver(ctx, adapter, agent, job, payload, prompt)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -47,6 +47,16 @@ type Mailbox struct {
 	// exists for the resolved template, so when the feature is off the rng is never
 	// drawn and resolution is byte-identical.
 	CanaryRand func() float64
+	// deferBlocker, when set, is the injected PRE-TERMINAL operational-blocker
+	// deferrer (#532 slice E). On a DELIVERY-seam failure (adapter.Deliver errored)
+	// Run consults it BEFORE m.fail: if it re-queues the job (running->queued +
+	// job.deferred), Run returns an ErrJobDeferred error and NEVER calls m.fail, so
+	// a deferred job never emits job.failed to the [events] sink first (slice A
+	// deferred AFTER the terminal transition, producing a failed→deferred flap). It
+	// is nil-safe: when unset (the default, foreground/ask paths) Run is
+	// byte-identical. The cause it receives is always a DeliveryError so the
+	// classifier's #602 contract gate still refuses agent-authored text.
+	deferBlocker func(ctx context.Context, jobID string, cause error) (bool, error)
 	// CanaryEnabled gates the #484 canary ROUTING seam on the SAME policy the
 	// daemon's regression comparator uses (config.SkillOptPolicy.CanaryEnabled()),
 	// so the two seams turn on and off together. When false (the default, every
@@ -388,6 +398,35 @@ type DeliveryError struct{ Err error }
 func (e DeliveryError) Error() string { return e.Err.Error() }
 func (e DeliveryError) Unwrap() error { return e.Err }
 
+// ErrJobDeferred is reported by Mailbox.Run (and Engine.RunJob) when a
+// delivery-seam failure was classified as an operational blocker and the injected
+// deferBlocker re-queued the job PRE-terminally (#532 slice E): the job is now
+// JobQueued with a hold and a job.deferred event/emit, and NO job.failed was
+// emitted. The daemon recognizes it via errors.Is to short-circuit the terminal
+// failure path (no handleRunJobError, no failure comment) — the run already
+// resolved to a first-class deferral. The wrapped cause stays inspectable
+// (errors.As DeliveryError) for logging.
+var ErrJobDeferred = errors.New("operational blocker: job deferred pre-terminally")
+
+type deferredError struct{ cause error }
+
+func (e deferredError) Error() string { return e.cause.Error() }
+
+func (e deferredError) Unwrap() []error { return []error{e.cause, ErrJobDeferred} }
+
+// tryDeferBlocker consults the injected pre-terminal deferrer, if any, for a
+// delivery-seam failure. It returns (true, nil) exactly when the job was
+// re-queued behind an operational blocker (so Run must skip m.fail); every other
+// case — no deferrer wired, not classifiable, ineligible, budget spent, or a
+// deferral error — returns false so Run takes its existing terminal path.
+func (m Mailbox) tryDeferBlocker(ctx context.Context, jobID string, cause error) bool {
+	if m.deferBlocker == nil {
+		return false
+	}
+	deferred, err := m.deferBlocker(ctx, jobID, cause)
+	return err == nil && deferred
+}
+
 // blockerRetryReconciliationNotice is prepended to the prompt of a job the
 // daemon re-dispatches after an operational-blocker deferral (#532). It composes
 // two concerns onto the retry prompt (the InjectUpstreamDepContext prompt-prefix
@@ -452,10 +491,20 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	}
 	firstRaw, firstRefreshedRef, firstErr := m.deliver(ctx, adapter, agent, job, payload, prompt)
 	if firstErr != nil {
+		deliveryErr := DeliveryError{Err: firstErr}
+		// PRE-TERMINAL operational-blocker classification (#532 slice E): consult the
+		// injected deferrer BEFORE failing. If it re-queues the job (running->queued +
+		// job.deferred), do NOT call m.fail — no job.failed reaches the [events] sink
+		// first. At the FIRST delivery no RawOutputs are persisted yet, so an eligible
+		// job (no result, not a child, budget left) defers here; the deferrer's own
+		// guards refuse everything else and this falls through to the terminal path.
+		if m.tryDeferBlocker(ctx, job.ID, deliveryErr) {
+			return AgentResult{}, deferredError{cause: deliveryErr}
+		}
 		_ = m.fail(ctx, job.ID, fmt.Sprintf("delivery failed: %v", firstErr))
 		// Typed DeliveryError: this error is FROM the delivery seam (not about the
 		// agent's output), the precondition for #532 operational classification.
-		return AgentResult{}, DeliveryError{Err: firstErr}
+		return AgentResult{}, deliveryErr
 	}
 	// SESSION SAFETY (#531): a job running under a per-job runtime override must
 	// never write back to the agent's stored resume state — the stored ref
@@ -504,11 +553,17 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			repairPrompt := prompts.RenderRepairPrompt(lastRaw, parseErr)
 			repairRaw, repairRefreshedRef, repairErr := m.deliver(ctx, adapter, agent, job, payload, repairPrompt)
 			if repairErr != nil {
+				deliveryErr := DeliveryError{Err: repairErr}
+				// Same pre-terminal seam as the first delivery, but the deferrer's
+				// duplicate-side-effect guard REFUSES this job: the persisted RawOutputs
+				// from the completed first delivery prove side-effectful execution, so it
+				// returns false and this takes the terminal path (no flap to avoid — the
+				// job genuinely fails). Consulting it here keeps a single seam.
+				if m.tryDeferBlocker(ctx, job.ID, deliveryErr) {
+					return AgentResult{}, deferredError{cause: deliveryErr}
+				}
 				_ = m.fail(ctx, job.ID, fmt.Sprintf("repair delivery failed: %v", repairErr))
-				// Typed like the first-delivery failure. Note the #532 deferral still
-				// refuses this job: the persisted RawOutputs from the completed first
-				// delivery prove side-effectful execution (see deferOperationalBlocker).
-				return AgentResult{}, DeliveryError{Err: repairErr}
+				return AgentResult{}, deliveryErr
 			}
 			// Same #531 override guard as the first delivery: never persist an
 			// override-runtime ref onto the agent's default-runtime resume state.

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -186,6 +186,12 @@ type JobPayload struct {
 	BlockerClass    string `json:"blocker_class,omitempty"`
 	BlockerAttempts int    `json:"blocker_attempts,omitempty"`
 	BlockerRetryAt  string `json:"blocker_retry_at,omitempty"`
+	// BlockerSuggestedAction is a concrete human-facing remedy for a deferral that
+	// usually needs manual intervention (a dirty/wrong-head checkout, #532 slice C).
+	// It is surfaced through the #552 stuck surface (job list/show) so an operator
+	// sees what condition must change; auth/quota/network deferrals leave it empty
+	// because they clear on their own. Additive/omitempty (byte-identical when unset).
+	BlockerSuggestedAction string `json:"blocker_suggested_action,omitempty"`
 }
 
 type DeliveryAdapter interface {
@@ -383,15 +389,29 @@ func (e DeliveryError) Error() string { return e.Err.Error() }
 func (e DeliveryError) Unwrap() error { return e.Err }
 
 // blockerRetryReconciliationNotice is prepended to the prompt of a job the
-// daemon re-dispatches after an operational-blocker deferral (#532). The
-// auto-retry is AT-LEAST-ONCE for side effects: a blocker that hit mid-turn may
-// have interrupted an attempt that already pushed branches, opened PRs, or
-// posted comments, and (for ephemeral/fresh-session workers) the retried run
-// has no memory of it — so tell the agent to reconcile instead of duplicating.
-func blockerRetryReconciliationNotice(class string) string {
-	return fmt.Sprintf("IMPORTANT: a previous attempt of this exact job was interrupted by an operational blocker (%s) "+
-		"and may have already performed side effects — pushed branches, opened pull requests, posted comments, or made commits. "+
-		"Before doing any work, check for artifacts from that interrupted attempt and reuse/reconcile them instead of redoing or duplicating the work.", class)
+// daemon re-dispatches after an operational-blocker deferral (#532). It composes
+// two concerns onto the retry prompt (the InjectUpstreamDepContext prompt-prefix
+// pattern):
+//
+//   - WARN level (#532 slice F): tell the agent the previous attempt died
+//     OPERATIONALLY — a runtime auth/quota/network/checkout condition in the
+//     environment — and NOT on the merits of its own output, so it does not
+//     second-guess an approach that was actually sound and get pulled off course.
+//   - AT-LEAST-ONCE side effects (#602's side-effect gate): a blocker that hit
+//     mid-turn may have interrupted an attempt that already pushed branches,
+//     opened PRs, or posted comments, and (for ephemeral/fresh-session workers)
+//     the retried run has no memory of it — so tell the agent to reconcile
+//     instead of duplicating.
+//
+// attempt is the deferral count (payload.BlockerAttempts) so the agent sees this
+// is a bounded operational retry, not an open-ended loop.
+func blockerRetryReconciliationNotice(class string, attempt int) string {
+	return fmt.Sprintf("NOTE (operational retry, attempt %d): the PREVIOUS attempt of this exact job did NOT fail on the merits of your work — "+
+		"it was interrupted by an operational blocker (%s) in the environment (a runtime auth/quota/network/checkout condition), "+
+		"not by anything wrong in your own output. The daemon automatically re-dispatched it now that the condition cleared, so treat "+
+		"your prior approach as still valid rather than a product failure. That interrupted attempt may already have performed side "+
+		"effects — pushed branches, opened pull requests, posted comments, or made commits — so before doing any work, check for those "+
+		"artifacts and reuse/reconcile them instead of redoing or duplicating the work.", attempt, class)
 }
 
 func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, adapter DeliveryAdapter) (AgentResult, error) {
@@ -424,9 +444,11 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	prompt := prompts.RenderJob(payload.prompt(job.Type))
 	if payload.BlockerAttempts > 0 && strings.TrimSpace(payload.BlockerClass) != "" {
 		// This run is an automatic operational-blocker retry (#532): the previous
-		// attempt may have executed side effects before the blocker hit, so ask the
-		// agent to reconcile prior artifacts rather than duplicate them.
-		prompt = blockerRetryReconciliationNotice(payload.BlockerClass) + "\n\n" + prompt
+		// attempt died on an environment condition, not on its own output, and may
+		// have executed side effects before the blocker hit — so warn the agent its
+		// prior approach was sound and ask it to reconcile prior artifacts rather than
+		// duplicate them (slice F).
+		prompt = blockerRetryReconciliationNotice(payload.BlockerClass, payload.BlockerAttempts) + "\n\n" + prompt
 	}
 	firstRaw, firstRefreshedRef, firstErr := m.deliver(ctx, adapter, agent, job, payload, prompt)
 	if firstErr != nil {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -279,11 +279,12 @@ redacted JSON event to that endpoint for: `job.finished`, `job.failed`,
 (`candidate.awaiting_promotion`, `candidate.auto_promoted`,
 `candidate.canary_started`, `candidate.rolled_back`). Delivery is best-effort
 (bounded buffer + timeout; drops are recorded as a local `event_sink_drop` job
-event, never blocking the job). Consumer rule: **`job.failed` followed by
-`job.deferred` for the same job id is NOT terminal** — the daemon classified the
-failure as a retryable operational blocker and will re-dispatch it; treat only
-a `job.failed` with no subsequent `job.deferred` as final. See `docs/events.md`
-for the full contract.
+event, never blocking the job). Consumer rule: **treat a `job.failed` as final
+only when it is NOT immediately followed by a `job.deferred` for the same job
+id.** Since #532 slice E a deferred run emits `job.deferred` as a first-class
+transition **instead of** `job.failed` (no preceding `job.failed`); the rule
+still holds and is forward-compatible with the older `job.failed`→`job.deferred`
+flap. See `docs/events.md` for the full contract.
 
 ## Bug Reports
 
@@ -768,20 +769,30 @@ For a `queued` or `blocked` job, `gitmoot job list` appends a `WHY:` column and
 `gitmoot job show` prints a `why_stuck:` (and, when a lease applies, a
 `next_retry_at:`) line explaining what the job is waiting on — e.g. `waiting on
 runtime session lock runtime:codex:<ref> (held by job <id>)`, `blocked: awaiting
-human`, `auth failing: …`, `throttled: …`, or `retrying: …`. The reason is
-derived from the most authoritative existing signal (the latest reason-bearing
-`job events` entry plus the owning resource lock's lease); a healthy job's output
-is unchanged. `gitmoot doctor` proactively validates `gh auth` (with an
-actionable remediation hint) and the Claude runtime token so a bad credential is
-caught before a job stalls on it.
+human`, `auth failing: …`, `throttled: …`, `retrying: …`, or a
+`blocked-operational: <class>` deferral. The reason is derived from the most
+authoritative existing signal (the latest reason-bearing `job events` entry plus
+the owning resource lock's lease); a healthy job's output is unchanged. When a
+deferral usually needs a human (a dirty or wrong-head checkout), the row/`job
+show` also carries a `suggested_action` naming the concrete fix. `gitmoot doctor`
+proactively validates `gh auth` (with an actionable remediation hint) and the
+Claude runtime token so a bad credential is caught before a job stalls on it.
 
-Operational blockers auto-retry (#532): a delivery failure classified as
-`runtime_auth` or `runtime_quota` does **not** fail the job terminally — the
-daemon re-queues it as **deferred** with a bounded retry budget and a hold
-until the earliest retry time. `gitmoot job show --json` carries the
-`blocker_class` and attempt count, and over the `[events]` stream a
-`job.deferred` follows the `job.failed` (making it non-terminal). So a job that
-"failed then reappeared as queued" is the deferral working, not a bug.
+Operational blockers auto-retry (#532): a delivery failure classified as an
+operational blocker — `runtime_auth`, `runtime_quota`, `network_outage`
+(transient network/GitHub outage), or `checkout_contention` (a self-healing
+branch-lock conflict, or a dirty/wrong-head checkout that carries a
+`suggested_action`) — does **not** fail the job terminally. The daemon re-queues
+it as **deferred** with a bounded retry budget and a hold until the earliest
+retry time, shown as `blocked-operational: <class>: attempt n/3`. `gitmoot job
+show --json` carries the `blocker_class`, attempt count, and `suggested_action`.
+Over the `[events]` stream the deferral is now a **first-class** `job.deferred`
+transition emitted **instead of** `job.failed` (no preceding `job.failed` for
+that run). A `runtime_auth` deferral only re-dispatches once a live doctor-style
+credential probe passes; the probe failing just extends the hold without spending
+a retry. So a job that "failed then reappeared as queued" is the deferral
+working, not a bug. Product failures (the agent answered with a `gitmoot_result`,
+including `decision=failed`) are never auto-retried.
 
 Jobs stuck in `running` are also backstopped: a running job with no lease
 progress past the staleness window (default 30m) is assumed orphaned by a dead

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -261,14 +261,20 @@ gitmoot lock list --repo owner/repo
 `gitmoot job list` appends a `WHY:` column and `gitmoot job show` prints a
 `why_stuck:` line for queued/blocked jobs (#552) — e.g. a runtime-session lock
 wait (naming the holder), `blocked: awaiting human`, `auth failing: …`,
-`throttled: …`, or `retrying: …` with the attempt schedule.
+`throttled: …`, `retrying: …`, or a `blocked-operational: <class>` deferral with
+the attempt schedule. A deferral that needs a human (dirty/wrong-head checkout)
+also prints a `suggested_action` naming the fix.
 
 Deferred jobs recover on their own (#532): a delivery failure classified as a
-retryable operational blocker (runtime auth, provider rate limit/quota) is
-re-queued with a bounded retry budget instead of failing terminally — `job show
---json` carries the `blocker_class` and attempt count. A job that "failed then
-reappeared as queued" is the deferral working; only act when the retry budget
-is spent and the job stays failed.
+retryable operational blocker — `runtime_auth`, `runtime_quota`,
+`network_outage`, or `checkout_contention` — is re-queued with a bounded retry
+budget instead of failing terminally. `job show --json` carries the
+`blocker_class`, attempt count, and `suggested_action`. A `runtime_auth` deferral
+only re-dispatches once a live doctor-style credential probe passes (a failing
+probe extends the hold without spending a retry), and over `[events]` the
+deferral is a first-class `job.deferred` emitted instead of `job.failed`. A job
+that "failed then reappeared as queued" is the deferral working; only act when
+the retry budget is spent and the job stays failed.
 
 A job stuck in `running` is recovered automatically once it shows no lease
 progress past the staleness window (default 30m; tune with the

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -20,7 +20,7 @@ The pilot emits a tight allowlist of event types over the webhook transport:
 | `job.failed`                    | a job reaches the `failed` terminal state                                          |
 | `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
 | `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
-| `job.deferred`                  | the daemon re-queued a job that just emitted `job.failed` because the failure classified as a retryable operational blocker (runtime auth, rate limit/quota) — it will be re-dispatched automatically |
+| `job.deferred`                  | the daemon re-queued a run whose delivery failed on a retryable operational blocker (runtime auth, rate limit/quota, network/GitHub outage, checkout contention) — it will be re-dispatched automatically. Since #532 slice E this is a **first-class** transition emitted INSTEAD of `job.failed` (no preceding `job.failed` for that run) |
 | `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
 | `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current` (also the canary GRADUATE event) |
 | `candidate.canary_started`      | the off-by-default `[skillopt].auto_promote_canary` policy promoted a candidate to the `canary` state behind the live champion |
@@ -32,16 +32,22 @@ pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
 pass through that path. `job.needs_attention` is emitted once per fresh
 escalation round (a re-advance does not re-emit).
 
-**`job.failed` followed by `job.deferred` is NOT terminal.** When a run fails on
-a classified operational blocker (runtime auth rejected, provider rate
-limit/quota), the engine has already emitted `job.failed` for that run before the
-daemon decides to defer; the daemon then emits `job.deferred` for the same
-`job_id` (detail carries the blocker class, the `attempt N/M` retry budget, and
-the earliest `retry at` timestamp) and silently re-dispatches the job after the
-hold. Consumers acting on `job.failed` (recovery, alerting, cleanup) should
-suppress terminal handling for a job whose `job.failed` is followed by a
-`job.deferred`, and treat only a `job.failed` with no subsequent `job.deferred`
-as final.
+**`job.deferred` is a first-class transition — a deferred run does NOT emit
+`job.failed` first.** When a run's delivery fails on a classified operational
+blocker (runtime auth rejected, provider rate limit/quota, network/GitHub outage,
+or a self-healing checkout contention), the classification happens
+**pre-terminally** in the mailbox seam (#532 slice E): the run is re-queued
+directly and the daemon emits **only** `job.deferred` for that `job_id` (detail
+carries the blocker class, the `attempt N/M` retry budget, and the earliest
+`retry at` timestamp), then silently re-dispatches after the hold. Product
+failures (the agent answered with a `gitmoot_result`, including
+`decision=failed`) still emit `job.failed` and are never auto-retried.
+
+Migration note: before slice E the daemon emitted `job.failed` **then**
+`job.deferred` for the same run (the accepted first-slice flap). That flap is
+gone. The safe consumer rule is unchanged and forward-compatible: **treat
+`job.failed` as final only when it is not immediately followed by a `job.deferred`
+for the same `job_id`.**
 
 The two `candidate.*` events come from the `skillopt import` / `train continue`
 CLI path, NOT the daemon. When a candidate becomes `pending`,


### PR DESCRIPTION
## Design

Implements slices B–F of the operational-blocker classification design (the long "Design: operational-blocker classification" comment on #532), composing with slice A (#602) and never duplicating #552 (stuck surface), #570 (worker-loop supervisor), or lease/stale recovery.

- **B — auth re-dispatch gated on a doctor probe**: instead of the fixed 5m cadence for `runtime_auth` deferrals, re-dispatch only after a doctor-style live probe passes (the `ClaudeClassifyProbe` SET-vs-VALID pattern from #486/#487); coarse fallback cadence + the existing 3-attempt budget preserved; probe failures extend the hold WITHOUT burning an attempt.
- **C — `checkout_contention` class**: classify the daemon-owned pre-flight strings. Branch-lock contention self-heals with a SHORT exponential backoff; dirty/wrong-head defers with a `suggested_action` surfaced via #552. Delegation children keep their existing DAG routing (excluded, as in slice A).
- **D — typed github errors**: a minimal `github.TransientError` + `IsTransientMessage` network discriminator wrapping gh CLI failures → `network_outage` class with a short backoff; transparent so best-effort/string consumers stay byte-identical.
- **E — pre-terminal classification**: detection moves into the adapters as TYPED errors carrying `RetryAfter`, classified in the MAILBOX seam BEFORE the terminal transition, so a deferred job never emits `job.failed` first (slice A's accepted flap disappears). The `DeliveryError` gate from #602 is preserved (contract failures still never classify).
- **F — warn level**: a re-dispatched job's retry prompt carries a short prior-blocker context line (composed with the reconciliation notice) so the agent knows the previous attempt died operationally, not on its own output.

Each slice is additive and byte-identical when not triggered.

## What the E2Es prove

Deterministic shell-runtime E2Es (extending `internal/cli/blocker_defer_e2e_test.go`): per-slice — auth held until a fake probe passes; contention defers-then-succeeds with backoff; typed network error defers; E asserts the `[events]` sink sees the deferral WITHOUT a preceding `job.failed`; F asserts the retried prompt carries the blocker context. Mutation-checked on E's pre-terminal seam and C's classifier.

## Docs

Events contract (`docs/events.md` + website), troubleshooting, and skill CLI stuck-reason wording updated per the docs-with-code policy.

## Closes / references

References #532. If all of B–F land green, #532 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)