### PR TITLE
feat(skillopt): deterministic hard-verifier tier (#474)

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -336,11 +336,17 @@ grading loop) produces a single **un-gameable `0`/`1`** — the authoritative
 `EvaluatorScore.Hard`. Setting **all three** of `[skillopt].auto_trace_enabled = true`,
 `[skillopt].hard_verifiers_enabled = true`, **and at least one**
 `hard_verifier_commands` line (all default off/empty) runs the operator's configured
-verifier commands in a **fresh, clean sandbox checkout at the merged head** — a
-detached `git worktree` off the daemon checkout, reusing gitmoot's own worktree
-isolation (no E2B / containers / second clone). Each command runs via `sh -c` with its
-**working directory set to the throwaway sandbox**, so it can never touch the real
-checkout; `exit 0 == pass`:
+verifier commands in a **fresh, clean sandbox checkout at the merged head** — an
+**independent local `git clone`** of the daemon checkout (`git clone --local`, so
+objects are hardlinked but the clone gets its **own** git directory: config, refs, gc,
+worktree registry), reusing gitmoot's single-binary git tooling (no E2B / containers /
+network fetch). Because the clone is git-independent, a verifier that shells out to git
+(`git config`, `git update-ref`, `git gc`, `git worktree prune`) is confined to the
+throwaway clone and **cannot mutate the live daemon checkout** — the containment a
+detached `git worktree` off the base could not give (a worktree shares the base's
+object DB, refs, and config). Each command runs via `sh -c` with its **working
+directory set to the throwaway sandbox**, so relative writes and git state alike stay
+inside it; `exit 0 == pass`:
 
 ```toml
 [skillopt]
@@ -359,6 +365,20 @@ authoritative gate-fail, `choice = b`) — a merge whose code actually fails a c
 build/test is caught **even when it merged through an empty gate**, and no LLM judge's
 prose can move it.
 
+> **The sandbox is a BARE checkout — commands must self-provision.** It carries only
+> the merged code: **no installed dependencies, build artifacts, or generated files**,
+> and only the daemon's ambient PATH. Write each command self-contained
+> (`npm ci && npm test`, `pip install -e . && pytest`; `go test ./...` fetches modules
+> itself) — a command that assumes a pre-existing `node_modules`/`venv` will fail every
+> merge and record a **false `hard = 0`** against a genuinely-good implementer, which
+> would poison the optimizer's training signal. Guard rail: a command that cannot be
+> **run at all** (its interpreter/binary is absent — a POSIX exit `127`
+> command-not-found, or a missing `sh`) is treated as an **environment failure and
+> SKIPS the whole run** (no hard row), so a missing toolchain never fabricates a
+> negative. But a command that *runs* and exits non-zero *because* deps were missing is
+> an honest `hard = 0` — the skip only covers un-runnable commands, so keep each command
+> self-provisioning.
+
 The verdict is written as a **fourth** `FeedbackEvent` in the SAME
 `auto-trace:<version>` run under a distinct item id (`hard#<repo>#<pr>`) and the fixed
 `gitmoot-verifier` reviewer sentinel — so it **coexists with** (never overwrites) the
@@ -373,9 +393,10 @@ additive, **no new contract field, `contract_version` stays `1`**.
 The leg runs **off the blocking merge path** (detached, `HardVerifierLegTimeout`-bounded,
 process-group killed so a wedged suite and its grandchildren are reaped) and is
 **fail-safe throughout**: an unprovisionable sandbox (the merged head not present in
-the base checkout) or an empty command list yields **no hard row** and never errors
-the harvest, blocks the merge, or stalls `AdvanceJob`; a dispatch failure records a
-`hard_verifiers_failed` job event and is swallowed. Because it re-runs the tests, it
+the base checkout), an empty command list, or a command that could not be run at all
+(missing toolchain) yields **no hard row** and never errors the harvest, blocks the
+merge, or stalls `AdvanceJob`; a dispatch failure records a `hard_verifiers_failed` job
+event and is swallowed. Because it re-runs the tests, it
 only maps onto **testable** implement legs — subjective review-quality kinds keep the
 soft cross-family signal. Promotion stays manual.
 

--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -180,13 +180,19 @@ mirrors the off-by-default `[events]` stream.
 - **Merged with real CI** (a passing non-`gitmoot/` external status/check at the
   merged head) → strong positive (`soft = 1.0`, `choice = a`).
 - **Merged through an empty gate** (the synthetic `gitmoot/ci` context, or no
-  external CI at head) → **near-neutral** (`soft ≈ 0.5`, `choice = a`), never a
-  strong positive. Rewarding an empty gate would optimize toward "merges that
-  pass no real CI"; the no-CI guard reads the combined status at the merged head
-  SHA and demotes it. (On the merge side, an empty gate is itself deferred by a
-  grace window and workflow-awareness before it ever stamps `gitmoot/ci` — see
-  [`SAFETY.md`](../skills/gitmoot/references/SAFETY.md); #596 — so this
-  near-neutral band applies only to genuinely CI-less heads.)
+  external CI at head) → the merge **event** is recorded (`choice = a`) but the
+  quality **score is genuinely absent** (`has_score = false`), **never a
+  fabricated `0.5`** (#474). Rewarding an empty gate would optimize toward "merges
+  that pass no real CI", and inventing a `0.5` midpoint violates the rest of the
+  projection's rule (it returns `has_score = false` when a signal is truly
+  missing). The no-CI guard reads the combined status at the merged head SHA; when
+  the #614/#596 `gitmoot/ci` "no external CI" stamp is present, the reasoning marks
+  it a **confirmed** empty gate (the grace/workflow window elapsed → genuinely no
+  CI, vs. a still-racing zero). To turn a no-CI merge back into a real `0`/`1`
+  quality signal, enable the **hard-verifier tier** below. (On the merge side, an
+  empty gate is itself deferred by a grace window and workflow-awareness before it
+  ever stamps `gitmoot/ci` — see
+  [`SAFETY.md`](../skills/gitmoot/references/SAFETY.md); #596.)
 - **Blocked at the merge gate** → authoritative gate-fail (`hard = 0`,
   `choice = b`).
 - **Review changes_requested** → graded negative (`choice = b`) whose score
@@ -321,6 +327,57 @@ swallowed. Promotion stays manual (the leg writes only `eval_runs` /
 > the PR head, so the tool-backed dimensions are effectively produced only when such
 > a checkout happens to be available; `diff_size` always runs. Plumbing a PR-head
 > worktree through to the tool runners is a documented follow-on.
+
+### Deterministic hard-verifier tier (off by default)
+
+Where the `diff_size`/`lint`/`complexity` checkers above produce **soft** quality
+priors, the **hard-verifier tier** (#474, RFC-informed by THUDM/slime's coding-agent
+grading loop) produces a single **un-gameable `0`/`1`** — the authoritative
+`EvaluatorScore.Hard`. Setting **all three** of `[skillopt].auto_trace_enabled = true`,
+`[skillopt].hard_verifiers_enabled = true`, **and at least one**
+`hard_verifier_commands` line (all default off/empty) runs the operator's configured
+verifier commands in a **fresh, clean sandbox checkout at the merged head** — a
+detached `git worktree` off the daemon checkout, reusing gitmoot's own worktree
+isolation (no E2B / containers / second clone). Each command runs via `sh -c` with its
+**working directory set to the throwaway sandbox**, so it can never touch the real
+checkout; `exit 0 == pass`:
+
+```toml
+[skillopt]
+auto_trace_enabled = true
+hard_verifiers_enabled = true
+hard_verifier_commands = go build ./...
+hard_verifier_commands = go test ./...
+```
+
+`hard_verifier_commands` is **repeatable** — one command per line — so a command may
+itself contain commas / shell operators. The verdict is **fail-closed**: it PASSES
+only when **every** command exits `0` (slime's `fail_to_pass ∪ pass_to_pass ⊆
+passed`). The binary verdict maps onto `EvaluatorScore.Hard`: **pass → `hard = 1.0`**
+(a strong, evidence-backed positive, `choice = a`), **fail → `hard = 0.0`** (an
+authoritative gate-fail, `choice = b`) — a merge whose code actually fails a clean
+build/test is caught **even when it merged through an empty gate**, and no LLM judge's
+prose can move it.
+
+The verdict is written as a **fourth** `FeedbackEvent` in the SAME
+`auto-trace:<version>` run under a distinct item id (`hard#<repo>#<pr>`) and the fixed
+`gitmoot-verifier` reviewer sentinel — so it **coexists with** (never overwrites) the
+verifiable floor (`gitmoot-auto`), the cross-family review (`gitmoot-review`), and the
+objective checker (`gitmoot-checker`) under the run's UNIQUE
+`(run_id,item_id,reviewer,source,source_url)` key; a re-verification re-upserts the
+SAME hard row in place. The hard eval item carries `hard_verifier = true`,
+`hard_passed`, the projected `hard_score`, and the per-command `command_results`
+(which command failed), while the run keeps `feedback_source = automatic_trace` —
+additive, **no new contract field, `contract_version` stays `1`**.
+
+The leg runs **off the blocking merge path** (detached, `HardVerifierLegTimeout`-bounded,
+process-group killed so a wedged suite and its grandchildren are reaped) and is
+**fail-safe throughout**: an unprovisionable sandbox (the merged head not present in
+the base checkout) or an empty command list yields **no hard row** and never errors
+the harvest, blocks the merge, or stalls `AdvanceJob`; a dispatch failure records a
+`hard_verifiers_failed` job event and is swallowed. Because it re-runs the tests, it
+only maps onto **testable** implement legs — subjective review-quality kinds keep the
+soft cross-family signal. Promotion stays manual.
 
 ### Promotion policy + notifications (off by default)
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -6121,6 +6121,18 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// byte-identical. A missing tool/checkout/timeout SKIPS that dimension and never
 		// blocks or fails the merge; promotion stays manual.
 		DeterministicCheckerDispatcher: daemonDeterministicCheckerDispatcher(store, gh, checkout, home),
+		// Off-by-default deterministic HARD-verifier tier (#474): on a MERGE the engine
+		// additionally runs the operator's configured build/test/lint commands in a
+		// FRESH sandbox checkout at the merged head (exit 0 == pass), best-effort and
+		// DETACHED, and projects the binary pass/fail as the authoritative
+		// EvaluatorScore.Hard into the SAME auto-trace run — an un-gameable gate distinct
+		// from the verifiable floor, the subjective review, and the objective checker.
+		// daemonHardVerifierDispatcher returns nil unless [skillopt].hard_verifiers_enabled
+		// AND auto_trace_enabled are set AND at least one command is configured, so with
+		// no config NO verifier leg runs and NO hard row is written — byte-identical. A
+		// slow suite / unprovisionable sandbox never blocks or fails the merge; promotion
+		// stays manual.
+		HardVerifierDispatcher: daemonHardVerifierDispatcher(store, checkout, home),
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},

--- a/internal/cli/hard_verifier.go
+++ b/internal/cli/hard_verifier.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/git"
@@ -19,7 +22,7 @@ import (
 // carries ONLY the merged code (no scratch state from the daemon's working tree),
 // so the exit-code verdict cannot be tampered with — slime's "no test-cheating"
 // isolation. It is its own narrow seam so the dispatcher is unit-testable with a
-// fake provisioner (no real git) and so the real git-worktree provisioning is
+// fake provisioner (no real git) and so the real git-clone provisioning is
 // swappable.
 type sandboxProvisioner interface {
 	// Provision creates a fresh checkout at ref and returns its directory and a
@@ -35,12 +38,15 @@ type sandboxProvisioner interface {
 // exit 0 == pass), and returns an Outcome{Kind:OutcomeReviewed, HardVerifier:true,
 // HardPassed:<all-passed>} for the engine to harvest into the auto-trace run as the
 // authoritative EvaluatorScore.Hard. The verdict is fail-closed: it PASSES only when
-// EVERY command exits 0. It NEVER mutates the merge and NEVER touches the real
-// checkout — the commands run with their working dir set to the throwaway sandbox, so
-// a verifier that writes relative paths writes INSIDE the sandbox (which is then
-// discarded), never the daemon's repo checkout. An unprovisionable sandbox or an
-// empty command list yields ok=false (no hard row), never an error, so a merge is
-// never blocked.
+// EVERY command exits 0. It NEVER mutates the merge and NEVER mutates the real
+// checkout: the sandbox is an INDEPENDENT local clone (own git dir, config, refs, gc,
+// worktree registry — see cloneSandboxProvisioner), and the commands run with their
+// working dir set to it, so a verifier that writes relative paths OR invokes git
+// writes INSIDE the throwaway clone (which is then discarded), never the daemon's repo
+// checkout. An unprovisionable sandbox, an empty command list, or a command that could
+// not be RUN at all (missing toolchain in the bare sandbox) yields ok=false (no hard
+// row), never an error, so a merge is never blocked and a setup failure never
+// fabricates an authoritative negative.
 type hardVerifierDispatcher struct {
 	store    *db.Store
 	runner   subprocess.Runner
@@ -52,9 +58,10 @@ var _ workflow.HardVerifierDispatcher = (*hardVerifierDispatcher)(nil)
 
 // Verify provisions a fresh sandbox at the merged head and runs the configured hard
 // verifiers there (#474). ok=false means NO verdict was producible (no commands, no
-// runner/provisioner, empty ref, or the sandbox could not be provisioned), so the
-// engine writes no hard row. It NEVER mutates the merge: it runs read-mostly
-// commands in a throwaway checkout and returns a value the engine harvests.
+// runner/provisioner, empty ref, the sandbox could not be provisioned, OR a command
+// could not be RUN at all — an exec-layer/setup failure), so the engine writes no hard
+// row. It NEVER mutates the merge: it runs read-mostly commands in a throwaway
+// checkout and returns a value the engine harvests.
 func (d *hardVerifierDispatcher) Verify(ctx context.Context, implementJob db.Job, implementPayload workflow.JobPayload, mergedHead string) (workflow.Outcome, bool, error) {
 	if d.runner == nil || d.sandbox == nil || len(d.commands) == 0 {
 		return workflow.Outcome{}, false, nil
@@ -68,8 +75,9 @@ func (d *hardVerifierDispatcher) Verify(ctx context.Context, implementJob db.Job
 	dir, cleanup, err := d.sandbox.Provision(ctx, ref)
 	if err != nil {
 		// Could not provision a FRESH sandbox (the merged head is not present in the
-		// base checkout, a worktree add failed, etc.): degrade-skip rather than run the
-		// verifiers against a non-fresh tree or fail the merge. No hard row.
+		// base checkout, the clone failed, the checkout lock could not be taken, etc.):
+		// degrade-skip rather than run the verifiers against a non-fresh tree or fail the
+		// merge. No hard row.
 		return workflow.Outcome{}, false, nil
 	}
 	if cleanup != nil {
@@ -88,14 +96,24 @@ func (d *hardVerifierDispatcher) Verify(ctx context.Context, implementJob db.Job
 		if command == "" {
 			continue
 		}
-		if d.runVerifier(ctx, dir, command) {
+		switch d.runVerifier(ctx, dir, command) {
+		case verifierPass:
 			results[command] = 1.0
 			details = append(details, fmt.Sprintf("%s (pass)", command))
-			continue
+		case verifierFail:
+			results[command] = 0.0
+			allPassed = false
+			details = append(details, fmt.Sprintf("%s (FAIL)", command))
+		case verifierSkip:
+			// The command could not be RUN at all (missing interpreter / command-not-found
+			// in the bare sandbox — the sandbox carries NO installed deps/toolchain). This
+			// is an environmental/setup failure, NOT a verdict on the merged code, so
+			// mapping it to an authoritative Hard=0 would poison the optimizer's training
+			// signal for a genuinely-good merge. Degrade-skip the WHOLE run (ok=false, no
+			// row): a fail-closed AND verdict cannot be trusted once one command was
+			// un-runnable, and skipping is strictly safer than fabricating a negative.
+			return workflow.Outcome{}, false, nil
 		}
-		results[command] = 0.0
-		allPassed = false
-		details = append(details, fmt.Sprintf("%s (FAIL)", command))
 	}
 
 	if len(results) == 0 {
@@ -122,16 +140,77 @@ func (d *hardVerifierDispatcher) Verify(ctx context.Context, implementJob db.Job
 	}, true, nil
 }
 
-// runVerifier runs ONE verifier command in the sandbox dir via `sh -c` and reports
-// whether it exited 0 (pass). It runs with the working directory set to the
-// throwaway SANDBOX, never the real checkout, so a command's relative writes land in
-// the sandbox. Any non-zero exit — a real failure, a context timeout (the leg's
-// bounded context cancels the child), or `sh` itself being unavailable — is a FAIL,
-// never a skip: an un-runnable verifier is a negative signal, not a silent pass (the
-// tier exists precisely to REFUSE to fabricate a positive without proof).
-func (d *hardVerifierDispatcher) runVerifier(ctx context.Context, dir string, command string) bool {
+// verifierVerdict is the tri-state outcome of one verifier command: it PASSED (exit
+// 0), it FAILED (ran and reported a genuine non-zero exit, or was killed by the leg's
+// timeout — a wedged/too-slow suite is a real negative), or it must be SKIPPED because
+// it could not be RUN at all (the interpreter or command is absent in the bare
+// sandbox). Skip is distinct from fail precisely so an environmental/setup problem
+// never masquerades as an authoritative Hard=0.
+type verifierVerdict int
+
+const (
+	verifierPass verifierVerdict = iota
+	verifierFail
+	verifierSkip
+)
+
+// runVerifier runs ONE verifier command in the sandbox dir via `sh -c` and classifies
+// the result. It runs with the working directory set to the throwaway SANDBOX, never
+// the real checkout, so a command's relative writes land in the sandbox. Exit 0 is a
+// PASS. A genuine non-zero exit, or a timeout (the leg's bounded context cancels the
+// child — a suite that could not finish is a negative, never a silent pass), is a
+// FAIL. An exec-layer failure — the interpreter itself missing, or a POSIX
+// command-not-found (exit 127) / not-executable (exit 126) from `sh -c` because the
+// bare sandbox has no installed toolchain — is a SKIP: the command never actually ran,
+// so it is not a verdict on the code and must not fabricate an authoritative Hard=0.
+func (d *hardVerifierDispatcher) runVerifier(ctx context.Context, dir string, command string) verifierVerdict {
 	_, err := d.runner.Run(ctx, dir, "sh", "-c", command)
-	return err == nil
+	if err == nil {
+		return verifierPass
+	}
+	// A context timeout/cancellation is a genuine FAIL (a wedged or too-slow suite is a
+	// negative signal), never a skip — the tier must not silently pass a suite that
+	// could not finish. Check this BEFORE the exec-layer classification because a
+	// context-killed child surfaces as a signal ExitError.
+	if ctx.Err() != nil || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return verifierFail
+	}
+	if isExecLayerFailure(err) {
+		return verifierSkip
+	}
+	// The command ran and reported a non-zero exit: a genuine failure.
+	return verifierFail
+}
+
+// isExecLayerFailure reports whether err means the verifier command could not be RUN
+// at all (as opposed to running and reporting a non-zero exit). The bare hard-verifier
+// sandbox has no installed deps/toolchain, so a missing interpreter or an absent
+// command is an environmental/setup failure to degrade-skip, not a code verdict.
+func isExecLayerFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	// The interpreter itself (sh) could not be located/started, so the process never
+	// ran: os/exec surfaces this as exec.ErrNotFound or an *exec.Error.
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	var execErr *exec.Error
+	if errors.As(err, &execErr) {
+		return true
+	}
+	// The interpreter ran but could not invoke the command: POSIX shells return 127
+	// when the command is not found and 126 when it is found but not executable — both
+	// mean the verifier could not RUN (a bare sandbox missing the toolchain), not that
+	// the code failed. A genuine test failure uses a different code (typically 1).
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		switch exitErr.ExitCode() {
+		case 126, 127:
+			return true
+		}
+	}
+	return false
 }
 
 // shortSandboxRef trims a ref to a short form for the findings text. A short-SHA-ish
@@ -144,15 +223,24 @@ func shortSandboxRef(ref string) string {
 	return ref
 }
 
-// worktreeSandboxProvisioner is the real sandboxProvisioner (#474): it materializes
-// the fresh checkout as a DETACHED git worktree off the daemon's repo checkout at the
-// merged head SHA — reusing gitmoot's existing worktree isolation (internal/git),
-// NOT E2B / containers / a second clone, so the single-binary moat is preserved. The
-// worktree is a clean tree at exactly the merged head; the cleanup force-removes the
-// worktree (so the base repo's worktree registration does not leak) and deletes the
-// temp root.
-type worktreeSandboxProvisioner struct {
-	// base is the daemon's repo checkout the detached worktree is added off of.
+// cloneSandboxProvisioner is the real sandboxProvisioner (#474/#617): it materializes
+// the fresh checkout as an INDEPENDENT local clone of the daemon's repo checkout,
+// detached at the merged head SHA. It is deliberately NOT a `git worktree add` off the
+// daemon checkout: a detached worktree SHARES the base repo's object DB, refs, and
+// config, so a verifier that shells out to git (`git config`, `git update-ref`,
+// `git gc`, `git worktree prune`) would escape into — and could corrupt — the LIVE
+// daemon checkout and its other in-flight worktrees. A `git clone --local` instead
+// gives the sandbox its own git directory (hardlinked objects, but independent
+// config/refs/gc/worktree registry), so a verifier is contained to the throwaway clone
+// while staying single-binary (no E2B / containers / network fetch). The clone READ of
+// the base .git is serialized on the shared checkout-mutation lock every other
+// worktree/checkout op uses (so it never races a concurrent real job mutating the
+// base), and the lock is released BEFORE the long verifier phase runs (the phase
+// operates entirely inside the independent clone and touches the base not at all).
+// Cleanup is a plain directory removal — there is no base worktree registration to
+// unwind, so cleanup never mutates the base .git.
+type cloneSandboxProvisioner struct {
+	// base is the daemon's repo checkout the sandbox is cloned from.
 	base string
 	// home is GITMOOT_HOME; when set, sandboxes are rooted under it (alongside
 	// delegation worktrees) rather than the OS temp dir, keeping scratch checkouts out
@@ -160,41 +248,82 @@ type worktreeSandboxProvisioner struct {
 	home string
 	// runner runs the underlying git commands; ExecRunner in production.
 	runner subprocess.Runner
+	// store backs the checkout-mutation lock that serializes the clone's base read
+	// against concurrent real jobs on the same checkout. When nil (unit/E2E paths with
+	// no concurrency), the clone runs unserialized — correct because it is read-only and
+	// there is no daemon contending for the base.
+	store *db.Store
 }
 
-// Provision adds a detached worktree at ref under a fresh temp root and returns the
-// worktree dir + a cleanup that force-removes the worktree and the temp root. A
-// worktree-add failure (e.g. the merged head is not present in the base checkout)
-// returns an error so the dispatcher degrade-skips.
-func (p worktreeSandboxProvisioner) Provision(ctx context.Context, ref string) (string, func(), error) {
+// Provision clones the base checkout into a fresh temp root, checks out ref as a
+// detached HEAD, and returns the clone dir + a cleanup that removes the temp root. The
+// base READ (the local clone) is serialized on the checkout-mutation lock and the lock
+// is released before returning, so the caller's (long) verifier phase holds no lock. A
+// clone/checkout failure (e.g. the merged head is not present in the base object DB)
+// or a lock-acquisition failure returns an error so the dispatcher degrade-skips.
+func (p cloneSandboxProvisioner) Provision(ctx context.Context, ref string) (string, func(), error) {
 	root, err := os.MkdirTemp(p.tempRoot(), "gitmoot-hardverify-")
 	if err != nil {
 		return "", nil, fmt.Errorf("create hard-verifier sandbox root: %w", err)
 	}
-	// git worktree add refuses a pre-existing target, so point it at a not-yet-created
+	// git clone refuses a pre-existing non-empty target, so point it at a not-yet-created
 	// child of the temp root.
-	worktree := filepath.Join(root, "wt")
-	client := git.Client{Runner: p.runner, Dir: p.base}
+	sandbox := filepath.Join(root, "wt")
 	cleanup := func() {
-		// Force-remove the worktree registration first (best-effort), then the root, so
-		// the base repo does not accumulate stale .git/worktrees entries. Use a
-		// cancellation-decoupled context so cleanup runs even after the leg's context is
-		// cancelled/timed out.
-		_ = client.RemoveWorktreeForce(context.WithoutCancel(ctx), worktree)
+		// The clone is fully independent from the base (its own git dir), so disposal is
+		// just removing the temp root — no `git worktree remove` against the base, hence
+		// no base-.git mutation and no lock needed on cleanup.
 		_ = os.RemoveAll(root)
 	}
-	if err := client.AddDetachedWorktree(ctx, worktree, ref); err != nil {
-		// No worktree was registered; just drop the temp root.
+
+	// Serialize the base READ on the SAME checkout-mutation key every other worktree/
+	// checkout op uses, so the clone never races a concurrent real job mutating the base
+	// .git. The leg waits for the lock (never the real job); the lock is released the
+	// moment the clone completes, before the long verifier phase, since that phase runs
+	// entirely inside the independent clone. When store is nil there is no daemon
+	// contending for the base, so the read-only clone runs unserialized.
+	if p.store != nil {
+		release, lockErr := workflow.AcquireCheckoutMutationLock(ctx, p.store, p.base, "hard-verify:"+shortSandboxRef(ref), time.Now().UTC())
+		if lockErr != nil {
+			_ = os.RemoveAll(root)
+			return "", nil, fmt.Errorf("serialize hard-verifier sandbox clone at %s: %w", shortSandboxRef(ref), lockErr)
+		}
+		if release != nil {
+			// Release with a cancellation-decoupled context so the lock is always dropped,
+			// even if the leg's context was cancelled during the clone.
+			defer func() { _ = release(context.WithoutCancel(ctx)) }()
+		}
+	}
+
+	if err := p.cloneDetached(ctx, sandbox, ref); err != nil {
 		_ = os.RemoveAll(root)
 		return "", nil, fmt.Errorf("provision hard-verifier sandbox at %s: %w", shortSandboxRef(ref), err)
 	}
-	return worktree, cleanup, nil
+	return sandbox, cleanup, nil
+}
+
+// cloneDetached makes the independent local clone at dest and checks out ref detached,
+// then severs the origin remote so a verifier can never fetch/push back against the
+// live daemon checkout. Removing origin is best-effort hardening — the clone already
+// holds every object it needs (hardlinked wholesale) and checks out by raw SHA, so a
+// severed origin never reduces what a verifier can read.
+func (p cloneSandboxProvisioner) cloneDetached(ctx context.Context, dest string, ref string) error {
+	source := git.Client{Runner: p.runner, Dir: p.base}
+	if err := source.CloneLocalNoCheckout(ctx, dest); err != nil {
+		return err
+	}
+	clone := git.Client{Runner: p.runner, Dir: dest}
+	if err := clone.CheckoutDetach(ctx, ref); err != nil {
+		return err
+	}
+	_ = clone.RemoveRemote(ctx, "origin")
+	return nil
 }
 
 // tempRoot returns the parent directory for sandbox temp roots: GITMOOT_HOME when
 // set (co-locating scratch checkouts with worktrees on the repo's filesystem), else
 // "" so os.MkdirTemp uses the OS temp dir.
-func (p worktreeSandboxProvisioner) tempRoot() string {
+func (p cloneSandboxProvisioner) tempRoot() string {
 	if home := strings.TrimSpace(p.home); home != "" {
 		return home
 	}

--- a/internal/cli/hard_verifier.go
+++ b/internal/cli/hard_verifier.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// sandboxProvisioner materializes a FRESH, clean checkout at a given ref for the
+// hard-verifier tier (#474) and returns its directory plus a cleanup func. The
+// freshness is the whole point: the verifier commands run against a checkout that
+// carries ONLY the merged code (no scratch state from the daemon's working tree),
+// so the exit-code verdict cannot be tampered with — slime's "no test-cheating"
+// isolation. It is its own narrow seam so the dispatcher is unit-testable with a
+// fake provisioner (no real git) and so the real git-worktree provisioning is
+// swappable.
+type sandboxProvisioner interface {
+	// Provision creates a fresh checkout at ref and returns its directory and a
+	// cleanup func the caller MUST call (idempotent, best-effort). A non-nil error
+	// means no sandbox was produced (the caller degrade-skips, no hard row); on
+	// error the returned cleanup is nil (nothing to clean).
+	Provision(ctx context.Context, ref string) (dir string, cleanup func(), err error)
+}
+
+// hardVerifierDispatcher is the concrete workflow.HardVerifierDispatcher (#474): on a
+// just-merged implement job it provisions a FRESH sandbox checkout at the merged
+// head, runs the operator's configured verifier COMMANDS there (`sh -c <command>`,
+// exit 0 == pass), and returns an Outcome{Kind:OutcomeReviewed, HardVerifier:true,
+// HardPassed:<all-passed>} for the engine to harvest into the auto-trace run as the
+// authoritative EvaluatorScore.Hard. The verdict is fail-closed: it PASSES only when
+// EVERY command exits 0. It NEVER mutates the merge and NEVER touches the real
+// checkout — the commands run with their working dir set to the throwaway sandbox, so
+// a verifier that writes relative paths writes INSIDE the sandbox (which is then
+// discarded), never the daemon's repo checkout. An unprovisionable sandbox or an
+// empty command list yields ok=false (no hard row), never an error, so a merge is
+// never blocked.
+type hardVerifierDispatcher struct {
+	store    *db.Store
+	runner   subprocess.Runner
+	sandbox  sandboxProvisioner
+	commands []string
+}
+
+var _ workflow.HardVerifierDispatcher = (*hardVerifierDispatcher)(nil)
+
+// Verify provisions a fresh sandbox at the merged head and runs the configured hard
+// verifiers there (#474). ok=false means NO verdict was producible (no commands, no
+// runner/provisioner, empty ref, or the sandbox could not be provisioned), so the
+// engine writes no hard row. It NEVER mutates the merge: it runs read-mostly
+// commands in a throwaway checkout and returns a value the engine harvests.
+func (d *hardVerifierDispatcher) Verify(ctx context.Context, implementJob db.Job, implementPayload workflow.JobPayload, mergedHead string) (workflow.Outcome, bool, error) {
+	if d.runner == nil || d.sandbox == nil || len(d.commands) == 0 {
+		return workflow.Outcome{}, false, nil
+	}
+	ref := strings.TrimSpace(mergedHead)
+	if ref == "" {
+		// No head to check out: nothing to verify. Degrade-skip.
+		return workflow.Outcome{}, false, nil
+	}
+
+	dir, cleanup, err := d.sandbox.Provision(ctx, ref)
+	if err != nil {
+		// Could not provision a FRESH sandbox (the merged head is not present in the
+		// base checkout, a worktree add failed, etc.): degrade-skip rather than run the
+		// verifiers against a non-fresh tree or fail the merge. No hard row.
+		return workflow.Outcome{}, false, nil
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if strings.TrimSpace(dir) == "" {
+		// Defensive: a provisioner that returned no error but no directory is unusable.
+		return workflow.Outcome{}, false, nil
+	}
+
+	results := map[string]float64{}
+	details := make([]string, 0, len(d.commands))
+	allPassed := true
+	for _, raw := range d.commands {
+		command := strings.TrimSpace(raw)
+		if command == "" {
+			continue
+		}
+		if d.runVerifier(ctx, dir, command) {
+			results[command] = 1.0
+			details = append(details, fmt.Sprintf("%s (pass)", command))
+			continue
+		}
+		results[command] = 0.0
+		allPassed = false
+		details = append(details, fmt.Sprintf("%s (FAIL)", command))
+	}
+
+	if len(results) == 0 {
+		// Every command was blank (defensive): nothing verifiable. ok=false, no row.
+		return workflow.Outcome{}, false, nil
+	}
+
+	verdict := "FAIL"
+	if allPassed {
+		verdict = "pass"
+	}
+	findings := fmt.Sprintf("Hard verifiers on PR #%d in a fresh sandbox at %s [%s]: %s.",
+		implementPayload.PullRequest, shortSandboxRef(ref), verdict, strings.Join(details, ", "))
+
+	return workflow.Outcome{
+		Kind:         workflow.OutcomeReviewed,
+		HardVerifier: true,
+		HardPassed:   allPassed,
+		Repo:         implementPayload.Repo,
+		PullRequest:  implementPayload.PullRequest,
+		HeadSHA:      ref,
+		Rubric:       results,
+		Findings:     findings,
+	}, true, nil
+}
+
+// runVerifier runs ONE verifier command in the sandbox dir via `sh -c` and reports
+// whether it exited 0 (pass). It runs with the working directory set to the
+// throwaway SANDBOX, never the real checkout, so a command's relative writes land in
+// the sandbox. Any non-zero exit — a real failure, a context timeout (the leg's
+// bounded context cancels the child), or `sh` itself being unavailable — is a FAIL,
+// never a skip: an un-runnable verifier is a negative signal, not a silent pass (the
+// tier exists precisely to REFUSE to fabricate a positive without proof).
+func (d *hardVerifierDispatcher) runVerifier(ctx context.Context, dir string, command string) bool {
+	_, err := d.runner.Run(ctx, dir, "sh", "-c", command)
+	return err == nil
+}
+
+// shortSandboxRef trims a ref to a short form for the findings text. A short-SHA-ish
+// ref keeps the reasoning compact; a short ref is returned as-is.
+func shortSandboxRef(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if len(ref) > 12 {
+		return ref[:12]
+	}
+	return ref
+}
+
+// worktreeSandboxProvisioner is the real sandboxProvisioner (#474): it materializes
+// the fresh checkout as a DETACHED git worktree off the daemon's repo checkout at the
+// merged head SHA — reusing gitmoot's existing worktree isolation (internal/git),
+// NOT E2B / containers / a second clone, so the single-binary moat is preserved. The
+// worktree is a clean tree at exactly the merged head; the cleanup force-removes the
+// worktree (so the base repo's worktree registration does not leak) and deletes the
+// temp root.
+type worktreeSandboxProvisioner struct {
+	// base is the daemon's repo checkout the detached worktree is added off of.
+	base string
+	// home is GITMOOT_HOME; when set, sandboxes are rooted under it (alongside
+	// delegation worktrees) rather than the OS temp dir, keeping scratch checkouts out
+	// of the tracked tree and on the same filesystem as the repo.
+	home string
+	// runner runs the underlying git commands; ExecRunner in production.
+	runner subprocess.Runner
+}
+
+// Provision adds a detached worktree at ref under a fresh temp root and returns the
+// worktree dir + a cleanup that force-removes the worktree and the temp root. A
+// worktree-add failure (e.g. the merged head is not present in the base checkout)
+// returns an error so the dispatcher degrade-skips.
+func (p worktreeSandboxProvisioner) Provision(ctx context.Context, ref string) (string, func(), error) {
+	root, err := os.MkdirTemp(p.tempRoot(), "gitmoot-hardverify-")
+	if err != nil {
+		return "", nil, fmt.Errorf("create hard-verifier sandbox root: %w", err)
+	}
+	// git worktree add refuses a pre-existing target, so point it at a not-yet-created
+	// child of the temp root.
+	worktree := filepath.Join(root, "wt")
+	client := git.Client{Runner: p.runner, Dir: p.base}
+	cleanup := func() {
+		// Force-remove the worktree registration first (best-effort), then the root, so
+		// the base repo does not accumulate stale .git/worktrees entries. Use a
+		// cancellation-decoupled context so cleanup runs even after the leg's context is
+		// cancelled/timed out.
+		_ = client.RemoveWorktreeForce(context.WithoutCancel(ctx), worktree)
+		_ = os.RemoveAll(root)
+	}
+	if err := client.AddDetachedWorktree(ctx, worktree, ref); err != nil {
+		// No worktree was registered; just drop the temp root.
+		_ = os.RemoveAll(root)
+		return "", nil, fmt.Errorf("provision hard-verifier sandbox at %s: %w", shortSandboxRef(ref), err)
+	}
+	return worktree, cleanup, nil
+}
+
+// tempRoot returns the parent directory for sandbox temp roots: GITMOOT_HOME when
+// set (co-locating scratch checkouts with worktrees on the repo's filesystem), else
+// "" so os.MkdirTemp uses the OS temp dir.
+func (p worktreeSandboxProvisioner) tempRoot() string {
+	if home := strings.TrimSpace(p.home); home != "" {
+		return home
+	}
+	return ""
+}

--- a/internal/cli/hard_verifier_test.go
+++ b/internal/cli/hard_verifier_test.go
@@ -198,6 +198,31 @@ func TestHardVerifierUnprovisionableSandboxSkips(t *testing.T) {
 	}
 }
 
+// TestHardVerifierExecLayerFailureSkips: a command that could not be RUN at all (the
+// runner reports exec.ErrNotFound — the bare sandbox has no installed toolchain) must
+// degrade-skip the WHOLE run (ok=false, no row), NOT fabricate an authoritative Hard=0
+// negative from a setup failure (#474 false-negative hardening). A genuine exit-1 stays
+// a FAIL — see TestHardVerifierAnyFailIsFail.
+func TestHardVerifierExecLayerFailureSkips(t *testing.T) {
+	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
+	runner := &fakeVerifierRunner{errByCommand: map[string]error{
+		// The first command passes; the second cannot be run at all.
+		"npm test": exec.ErrNotFound,
+	}}
+	d := &hardVerifierDispatcher{
+		runner:   runner,
+		sandbox:  prov,
+		commands: []string{"go build ./...", "npm test"},
+	}
+	outcome, ok, err := d.Verify(context.Background(), db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), "head")
+	if err != nil {
+		t.Fatalf("Verify must not error on an un-runnable command, got %v", err)
+	}
+	if ok {
+		t.Fatalf("an un-runnable (exec-layer) command must skip the whole run (ok=false), got outcome %+v", outcome)
+	}
+}
+
 // TestHardVerifierEmptyInputsSkip: no commands, no runner/provisioner, or an empty
 // merged head all skip (ok=false) — byte-identical no-op guards.
 func TestHardVerifierEmptyInputsSkip(t *testing.T) {
@@ -251,7 +276,7 @@ func gitFixtureRepo(t *testing.T, marker string) (string, string) {
 func realHardVerifierDispatcher(repoDir string, commands []string) *hardVerifierDispatcher {
 	return &hardVerifierDispatcher{
 		runner: subprocess.GroupRunner{},
-		sandbox: worktreeSandboxProvisioner{
+		sandbox: cloneSandboxProvisioner{
 			base:   repoDir,
 			runner: subprocess.ExecRunner{},
 		},
@@ -367,6 +392,123 @@ func TestHardVerifierE2ESandboxIsolatesWrites(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(repoDir, "escapee.txt")); !os.IsNotExist(err) {
 		t.Fatalf("a verifier write leaked into the REAL checkout %q (isolation broken): stat err=%v", repoDir, err)
 	}
+}
+
+// TestHardVerifierE2ESandboxIsolatesGitState drives a REAL verifier that shells out to
+// git — writing config, creating a ref, and running gc/worktree-prune — and asserts
+// the base repo's git state (config, refs, and worktree registry) is COMPLETELY
+// untouched. This is the containment guard for finding #474: the sandbox is an
+// independent local clone (its own git dir), so a git-invoking verifier is confined to
+// the throwaway clone and cannot escape into the live daemon checkout. A detached
+// worktree off the base (the pre-fix design) would have leaked all three.
+func TestHardVerifierE2ESandboxIsolatesGitState(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	repoDir, sha := gitFixtureRepo(t, "hello")
+
+	baseRefsBefore := gitShowRef(t, repoDir)
+
+	// The verifier writes git config, creates a branch ref, gc's, and prunes worktrees —
+	// all of which, in the sandbox's OWN git dir, must never reach the base repo.
+	d := realHardVerifierDispatcher(repoDir, []string{
+		"git config hardverify.escaped yes && " +
+			"git update-ref refs/heads/hardverify-escaped HEAD && " +
+			"git gc --prune=now && git worktree prune",
+	})
+
+	outcome, ok, err := d.Verify(ctx, db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), sha)
+	if err != nil || !ok {
+		t.Fatalf("Verify = ok %v err %v, want ok=true", ok, err)
+	}
+	if !outcome.HardPassed {
+		t.Fatal("the git-mutating verifier chain must exit 0 (PASS) so the base-untouched assertions are meaningful")
+	}
+
+	// 1. Config: the escaped key must NOT be in the base repo's config.
+	if got := gitConfigGet(t, repoDir, "hardverify.escaped"); got != "" {
+		t.Fatalf("verifier `git config` escaped into the base repo (hardverify.escaped=%q): git isolation broken", got)
+	}
+	// 2. Refs: the base repo's refs must be exactly what they were, with no new branch.
+	if after := gitShowRef(t, repoDir); after != baseRefsBefore {
+		t.Fatalf("verifier `git update-ref`/`git gc` mutated the base repo's refs:\nbefore:\n%s\nafter:\n%s", baseRefsBefore, after)
+	}
+	// 3. Worktree registry: the base repo must have registered NO worktree (the sandbox
+	// is a clone, not a worktree off the base), so no admin dir leaked.
+	if entries := gitWorktreeRegistryEntries(t, repoDir); len(entries) != 0 {
+		t.Fatalf("verifier leaked worktree registrations into the base repo: %v", entries)
+	}
+}
+
+// TestHardVerifierE2ECommandNotFoundSkips drives a REAL verifier whose command is
+// absent in the bare sandbox (`sh -c` returns exit 127). The tier must degrade-skip
+// (ok=false, no row), never map the missing-toolchain exit onto an authoritative
+// Hard=0 — the false-negative hardening (#474) proven end to end through real `sh`.
+func TestHardVerifierE2ECommandNotFoundSkips(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	repoDir, sha := gitFixtureRepo(t, "hello")
+	d := realHardVerifierDispatcher(repoDir, []string{"gitmoot-hardverify-missing-command-xyz --run"})
+
+	outcome, ok, err := d.Verify(ctx, db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), sha)
+	if err != nil {
+		t.Fatalf("Verify must not error on a command-not-found, got %v", err)
+	}
+	if ok {
+		t.Fatalf("a command-not-found (exit 127) must skip (ok=false, no row), got outcome %+v", outcome)
+	}
+}
+
+// gitShowRef returns the base repo's full ref listing (sorted-by-git `show-ref`
+// output), or "" when the repo has no refs. It is the before/after fingerprint for the
+// git-state isolation assertion.
+func gitShowRef(t *testing.T, repoDir string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repoDir, "show-ref").Output()
+	if err != nil {
+		// `git show-ref` exits 1 with no output when there are no refs; treat as empty.
+		if _, ok := err.(*exec.ExitError); ok {
+			return ""
+		}
+		t.Fatalf("git show-ref: %v", err)
+	}
+	return string(out)
+}
+
+// gitConfigGet returns a local config value from the base repo, or "" when unset.
+func gitConfigGet(t *testing.T, repoDir string, key string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repoDir, "config", "--local", "--get", key).Output()
+	if err != nil {
+		// `git config --get` exits 1 when the key is unset.
+		if _, ok := err.(*exec.ExitError); ok {
+			return ""
+		}
+		t.Fatalf("git config --get %s: %v", key, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitWorktreeRegistryEntries lists the base repo's .git/worktrees admin dirs (the
+// registrations a `git worktree add` off the base would create). An empty slice proves
+// the sandbox never touched the base worktree registry.
+func gitWorktreeRegistryEntries(t *testing.T, repoDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(repoDir, ".git", "worktrees"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read .git/worktrees: %v", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
 }
 
 // TestHardVerifierE2ETimeoutFailsFromRealContext drives a REAL slow command against a

--- a/internal/cli/hard_verifier_test.go
+++ b/internal/cli/hard_verifier_test.go
@@ -1,0 +1,418 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// fakeSandboxProvisioner is a sandboxProvisioner that returns a canned dir (or an
+// error) and records the ref it was asked to provision + whether cleanup ran.
+type fakeSandboxProvisioner struct {
+	dir         string
+	err         error
+	provisioned string
+	cleaned     bool
+}
+
+func (p *fakeSandboxProvisioner) Provision(_ context.Context, ref string) (string, func(), error) {
+	p.provisioned = ref
+	if p.err != nil {
+		return "", nil, p.err
+	}
+	return p.dir, func() { p.cleaned = true }, nil
+}
+
+// fakeVerifierRunner is a subprocess.Runner that returns a canned error per verifier
+// command (the `sh -c <command>` argument) and records the working DIR each command
+// ran in — so a test can assert the commands ran in the SANDBOX, never the real
+// checkout. An optional onRun hook lets a test model a command's side effect.
+type fakeVerifierRunner struct {
+	errByCommand map[string]error
+	onRun        func(dir, command string)
+	calls        []verifierCall
+}
+
+type verifierCall struct {
+	dir     string
+	command string
+}
+
+func (r *fakeVerifierRunner) Run(_ context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	verifier := ""
+	if command == "sh" && len(args) == 2 && args[0] == "-c" {
+		verifier = args[1]
+	}
+	r.calls = append(r.calls, verifierCall{dir: dir, command: verifier})
+	if r.onRun != nil {
+		r.onRun(dir, verifier)
+	}
+	return subprocess.Result{}, r.errByCommand[verifier]
+}
+
+func (r *fakeVerifierRunner) LookPath(file string) (string, error) { return "/bin/" + file, nil }
+
+var _ subprocess.Runner = (*fakeVerifierRunner)(nil)
+
+func hardVerifierImplementPayload() workflow.JobPayload {
+	return workflow.JobPayload{Repo: "owner/repo", PullRequest: 7}
+}
+
+// TestHardVerifierAllPassIsPass: every command exits 0 → HardPassed=true, ok=true, a
+// per-command rubric of all-1.0, tagged HardVerifier, and the sandbox is cleaned up.
+func TestHardVerifierAllPassIsPass(t *testing.T) {
+	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
+	runner := &fakeVerifierRunner{errByCommand: map[string]error{}} // no errors => all pass
+	d := &hardVerifierDispatcher{
+		runner:   runner,
+		sandbox:  prov,
+		commands: []string{"go build ./...", "go test ./..."},
+	}
+	outcome, ok, err := d.Verify(context.Background(), db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), "deadbeefcafe")
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("all-pass verifiers must produce a verdict (ok=true)")
+	}
+	if !outcome.HardVerifier || !outcome.HardPassed {
+		t.Fatalf("outcome = HardVerifier=%v HardPassed=%v, want both true", outcome.HardVerifier, outcome.HardPassed)
+	}
+	if outcome.Kind != workflow.OutcomeReviewed {
+		t.Fatalf("outcome kind = %q, want OutcomeReviewed", outcome.Kind)
+	}
+	if outcome.Rubric["go build ./..."] != 1.0 || outcome.Rubric["go test ./..."] != 1.0 {
+		t.Fatalf("rubric = %v, want all 1.0", outcome.Rubric)
+	}
+	if !prov.cleaned {
+		t.Fatal("the sandbox cleanup must run")
+	}
+	if prov.provisioned != "deadbeefcafe" {
+		t.Fatalf("provisioned ref = %q, want the merged head", prov.provisioned)
+	}
+}
+
+// TestHardVerifierAnyFailIsFail: a SINGLE failing command (fail-closed set membership)
+// makes the whole verdict FAIL, and that command's rubric entry is 0.0.
+func TestHardVerifierAnyFailIsFail(t *testing.T) {
+	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
+	runner := &fakeVerifierRunner{errByCommand: map[string]error{
+		"go test ./...": errors.New("exit status 1"),
+	}}
+	d := &hardVerifierDispatcher{
+		runner:   runner,
+		sandbox:  prov,
+		commands: []string{"go build ./...", "go test ./..."},
+	}
+	outcome, ok, err := d.Verify(context.Background(), db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), "head")
+	if err != nil || !ok {
+		t.Fatalf("Verify = ok %v err %v, want ok=true err=nil", ok, err)
+	}
+	if outcome.HardPassed {
+		t.Fatal("a single failing command must make the verdict FAIL")
+	}
+	if outcome.Rubric["go build ./..."] != 1.0 || outcome.Rubric["go test ./..."] != 0.0 {
+		t.Fatalf("rubric = %v, want go build=1.0 go test=0.0", outcome.Rubric)
+	}
+	if !prov.cleaned {
+		t.Fatal("the sandbox cleanup must run even on a FAIL verdict")
+	}
+}
+
+// TestHardVerifierTimeoutIsFail: a command whose Run returns a context-deadline error
+// (the leg's bounded context cancelled it) is a FAIL, never a silent pass.
+func TestHardVerifierTimeoutIsFail(t *testing.T) {
+	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
+	runner := &fakeVerifierRunner{errByCommand: map[string]error{
+		"slow-suite": context.DeadlineExceeded,
+	}}
+	d := &hardVerifierDispatcher{
+		runner:   runner,
+		sandbox:  prov,
+		commands: []string{"slow-suite"},
+	}
+	outcome, ok, err := d.Verify(context.Background(), db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), "head")
+	if err != nil || !ok {
+		t.Fatalf("Verify = ok %v err %v, want ok=true err=nil", ok, err)
+	}
+	if outcome.HardPassed {
+		t.Fatal("a timed-out (context-cancelled) verifier must FAIL, not pass")
+	}
+}
+
+// TestHardVerifierRunsInSandboxNotRealCheckout: EVERY verifier command runs with its
+// working dir set to the SANDBOX the provisioner returned, never any other checkout.
+// This is the isolation contract the tier depends on for cheat-proofing.
+func TestHardVerifierRunsInSandboxNotRealCheckout(t *testing.T) {
+	const sandboxDir = "/tmp/gitmoot-hardverify-XYZ/wt"
+	prov := &fakeSandboxProvisioner{dir: sandboxDir}
+	runner := &fakeVerifierRunner{errByCommand: map[string]error{}}
+	d := &hardVerifierDispatcher{
+		runner:   runner,
+		sandbox:  prov,
+		commands: []string{"cmd-one", "cmd-two"},
+	}
+	if _, ok, err := d.Verify(context.Background(), db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), "head"); err != nil || !ok {
+		t.Fatalf("Verify = ok %v err %v, want ok=true", ok, err)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("expected two verifier runs, got %d", len(runner.calls))
+	}
+	for _, call := range runner.calls {
+		if call.dir != sandboxDir {
+			t.Fatalf("verifier %q ran in %q, want the sandbox %q", call.command, call.dir, sandboxDir)
+		}
+	}
+}
+
+// TestHardVerifierUnprovisionableSandboxSkips: a provisioner error yields ok=false (no
+// hard row) and runs NO verifier — the leg degrade-skips, never fails the merge.
+func TestHardVerifierUnprovisionableSandboxSkips(t *testing.T) {
+	prov := &fakeSandboxProvisioner{err: errors.New("merged head not present in base checkout")}
+	runner := &fakeVerifierRunner{errByCommand: map[string]error{}}
+	d := &hardVerifierDispatcher{
+		runner:   runner,
+		sandbox:  prov,
+		commands: []string{"go test ./..."},
+	}
+	outcome, ok, err := d.Verify(context.Background(), db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), "head")
+	if err != nil {
+		t.Fatalf("Verify must not error on an unprovisionable sandbox, got %v", err)
+	}
+	if ok {
+		t.Fatalf("an unprovisionable sandbox must skip (ok=false), got outcome %+v", outcome)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("no verifier must run without a sandbox, got %d calls", len(runner.calls))
+	}
+}
+
+// TestHardVerifierEmptyInputsSkip: no commands, no runner/provisioner, or an empty
+// merged head all skip (ok=false) — byte-identical no-op guards.
+func TestHardVerifierEmptyInputsSkip(t *testing.T) {
+	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
+	runner := &fakeVerifierRunner{errByCommand: map[string]error{}}
+	cases := []struct {
+		name string
+		d    *hardVerifierDispatcher
+		head string
+	}{
+		{"no commands", &hardVerifierDispatcher{runner: runner, sandbox: prov}, "head"},
+		{"nil runner", &hardVerifierDispatcher{sandbox: prov, commands: []string{"go test ./..."}}, "head"},
+		{"nil sandbox", &hardVerifierDispatcher{runner: runner, commands: []string{"go test ./..."}}, "head"},
+		{"empty head", &hardVerifierDispatcher{runner: runner, sandbox: prov, commands: []string{"go test ./..."}}, "   "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok, err := tc.d.Verify(context.Background(), db.Job{ID: "j"}, hardVerifierImplementPayload(), tc.head)
+			if err != nil || ok {
+				t.Fatalf("%s: Verify = ok %v err %v, want ok=false err=nil", tc.name, ok, err)
+			}
+		})
+	}
+}
+
+// --- E2E (deterministic, real git worktree sandbox + real sh) ---
+
+// gitFixtureRepo inits a real git repo with one committed fixture file and returns the
+// repo dir + the committed HEAD SHA — the sandbox is provisioned at this SHA.
+func gitFixtureRepo(t *testing.T, marker string) (string, string) {
+	t.Helper()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "marker.txt"), []byte(marker), 0o600); err != nil {
+		t.Fatalf("write fixture marker: %v", err)
+	}
+	runGit(t, repoDir, "add", ".")
+	runGit(t, repoDir, "commit", "-m", "fixture")
+	out, err := exec.Command("git", "-C", repoDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	return repoDir, strings.TrimSpace(string(out))
+}
+
+// realHardVerifierDispatcher wires the REAL worktree provisioner + real ExecRunner
+// against a fixture repo, so the E2E exercises actual git worktree isolation and
+// actual `sh -c` exit codes — no fakes.
+func realHardVerifierDispatcher(repoDir string, commands []string) *hardVerifierDispatcher {
+	return &hardVerifierDispatcher{
+		runner: subprocess.GroupRunner{},
+		sandbox: worktreeSandboxProvisioner{
+			base:   repoDir,
+			runner: subprocess.ExecRunner{},
+		},
+		commands: commands,
+	}
+}
+
+// installHardVerifierTemplate installs a template and returns its version + an
+// implement payload attributed to it, so the real harvester resolves the version.
+func installHardVerifierTemplate(t *testing.T, store *db.Store) (db.AgentTemplateVersion, workflow.JobPayload) {
+	t.Helper()
+	version := installChainTemplate(t, store, "planner")
+	payload := workflow.JobPayload{
+		Repo:                   "owner/repo",
+		PullRequest:            7,
+		TaskID:                 "task-1",
+		TemplateID:             version.TemplateID,
+		TemplateResolvedCommit: version.ResolvedCommit,
+	}
+	return version, payload
+}
+
+// TestHardVerifierE2EPassFlowsIntoHardScore drives a REAL fixture repo + a REAL
+// exit-0 verifier (`test -f marker.txt` — the committed file IS present in the fresh
+// checkout) through the REAL harvester, proving a PASS lands a choice "a" hard row
+// whose persisted hard_score is 1.0 (EvaluatorScore.Hard=1.0).
+func TestHardVerifierE2EPassFlowsIntoHardScore(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	repoDir, sha := gitFixtureRepo(t, "hello")
+	d := realHardVerifierDispatcher(repoDir, []string{"test -f marker.txt"})
+
+	outcome, ok, err := d.Verify(ctx, db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), sha)
+	if err != nil || !ok {
+		t.Fatalf("Verify = ok %v err %v, want ok=true", ok, err)
+	}
+	if !outcome.HardPassed {
+		t.Fatal("exit-0 verifier on the fresh checkout must PASS (the committed marker.txt exists)")
+	}
+
+	store := openTraceChainStore(t)
+	version, payload := installHardVerifierTemplate(t, store)
+	h := skillopt.NewOutcomeHarvester(store, nil)
+	if err := h.Harvest(ctx, db.Job{ID: "implement-job", Type: "implement"}, payload, outcome); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	events := autoTraceFeedback(t, store, version.ID)
+	if len(events) != 1 || events[0].Choice != "a" {
+		t.Fatalf("expected one choice=a hard row, got %+v", events)
+	}
+	assertPersistedHardScore(t, store, version.ID, 1.0, true)
+}
+
+// TestHardVerifierE2EFailFlowsIntoHardScore drives a REAL exit-1 verifier through the
+// REAL harvester, proving a FAIL lands a choice "b" hard row whose persisted
+// hard_score is 0.0 (EvaluatorScore.Hard=0.0). This is the mutation guard for the
+// exit-code mapping: if pass/fail were inverted, this row would be choice "a".
+func TestHardVerifierE2EFailFlowsIntoHardScore(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	repoDir, sha := gitFixtureRepo(t, "hello")
+	// The file does NOT exist in the checkout → `test -f` exits 1 → FAIL.
+	d := realHardVerifierDispatcher(repoDir, []string{"test -f does-not-exist.txt"})
+
+	outcome, ok, err := d.Verify(ctx, db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), sha)
+	if err != nil || !ok {
+		t.Fatalf("Verify = ok %v err %v, want ok=true", ok, err)
+	}
+	if outcome.HardPassed {
+		t.Fatal("exit-1 verifier must FAIL")
+	}
+
+	store := openTraceChainStore(t)
+	version, payload := installHardVerifierTemplate(t, store)
+	h := skillopt.NewOutcomeHarvester(store, nil)
+	if err := h.Harvest(ctx, db.Job{ID: "implement-job", Type: "implement"}, payload, outcome); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	events := autoTraceFeedback(t, store, version.ID)
+	if len(events) != 1 || events[0].Choice != "b" {
+		t.Fatalf("expected one choice=b hard row, got %+v", events)
+	}
+	assertPersistedHardScore(t, store, version.ID, 0.0, false)
+}
+
+// TestHardVerifierE2ESandboxIsolatesWrites drives a REAL verifier that WRITES a file
+// (escapee.txt) via a relative path. The write must land in the throwaway sandbox
+// (which is then cleaned up), NEVER the real base checkout — proving the freshness /
+// isolation guarantee. This is the mutation guard for the sandbox-fresh contract: if
+// the verifier ran in the base checkout, escapee.txt would appear there.
+func TestHardVerifierE2ESandboxIsolatesWrites(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	ctx := context.Background()
+	repoDir, sha := gitFixtureRepo(t, "hello")
+	// The verifier writes a relative file, then exits 0.
+	d := realHardVerifierDispatcher(repoDir, []string{"echo escaped > escapee.txt"})
+
+	outcome, ok, err := d.Verify(ctx, db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), sha)
+	if err != nil || !ok {
+		t.Fatalf("Verify = ok %v err %v, want ok=true", ok, err)
+	}
+	if !outcome.HardPassed {
+		t.Fatal("the write-then-exit-0 verifier must PASS")
+	}
+	// The real base checkout MUST be untouched — the write went to the throwaway
+	// sandbox, which was force-removed on cleanup.
+	if _, err := os.Stat(filepath.Join(repoDir, "escapee.txt")); !os.IsNotExist(err) {
+		t.Fatalf("a verifier write leaked into the REAL checkout %q (isolation broken): stat err=%v", repoDir, err)
+	}
+}
+
+// TestHardVerifierE2ETimeoutFailsFromRealContext drives a REAL slow command against a
+// short leg context, proving a genuine timeout (not a fake) is a FAIL.
+func TestHardVerifierE2ETimeoutFailsFromRealContext(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	repoDir, sha := gitFixtureRepo(t, "hello")
+	d := realHardVerifierDispatcher(repoDir, []string{"sleep 30"})
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	outcome, ok, err := d.Verify(ctx, db.Job{ID: "implement-job"}, hardVerifierImplementPayload(), sha)
+	if err != nil || !ok {
+		t.Fatalf("Verify = ok %v err %v, want ok=true", ok, err)
+	}
+	if outcome.HardPassed {
+		t.Fatal("a real command killed by the leg's context timeout must FAIL")
+	}
+}
+
+// assertPersistedHardScore reads the hard item's metadata and asserts the persisted
+// hard_score + hard_passed — proving the binary verdict flowed into
+// EvaluatorScore.Hard end to end (through the real sandbox and the real harvester).
+func assertPersistedHardScore(t *testing.T, store *db.Store, versionID string, wantScore float64, wantPassed bool) {
+	t.Helper()
+	items, err := store.ListEvalReviewItems(context.Background(), "auto-trace:"+versionID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	for _, item := range items {
+		if !strings.HasPrefix(item.ItemID, "hard#") {
+			continue
+		}
+		var meta map[string]any
+		if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+			t.Fatalf("hard item metadata invalid JSON: %v", err)
+		}
+		if score, _ := meta["hard_score"].(float64); score != wantScore {
+			t.Fatalf("persisted hard_score = %v, want %v", meta["hard_score"], wantScore)
+		}
+		if passed, _ := meta["hard_passed"].(bool); passed != wantPassed {
+			t.Fatalf("persisted hard_passed = %v, want %v", meta["hard_passed"], wantPassed)
+		}
+		return
+	}
+	t.Fatalf("no hard# item found for version %s", versionID)
+}

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -137,8 +137,10 @@ func daemonDeterministicCheckerDispatcher(store *db.Store, gh github.Client, che
 // verifiers to run. When nil, the engine constructs no verifier leg and writes no
 // hard row, so daemon behavior is byte-identical. It mirrors
 // daemonDeterministicCheckerDispatcher's off-by-default gate. The sandbox is a fresh
-// detached worktree off the daemon's checkout at the merged head (reusing gitmoot's
-// worktree isolation, no external sandbox dep).
+// INDEPENDENT local clone of the daemon's checkout, detached at the merged head — its
+// own git dir (config/refs/gc/worktree registry), so a verifier that shells out to git
+// cannot escape into the live checkout (reusing gitmoot's single-binary git tooling, no
+// external sandbox dep).
 func daemonHardVerifierDispatcher(store *db.Store, checkout string, home string) workflow.HardVerifierDispatcher {
 	if store == nil {
 		return nil
@@ -152,12 +154,15 @@ func daemonHardVerifierDispatcher(store *db.Store, checkout string, home string)
 		// GroupRunner (process-group SIGTERM→SIGKILL) reaps a wedged verifier AND its
 		// grandchildren (a `go test` spawns test binaries, `npm test` spawns node), so
 		// the leg's bounded context can never leave an orphaned suite running. The
-		// short-lived git worktree calls keep the plain ExecRunner (no grandchildren).
+		// short-lived git clone/checkout calls keep the plain ExecRunner (no grandchildren).
 		runner: subprocess.GroupRunner{},
-		sandbox: worktreeSandboxProvisioner{
+		sandbox: cloneSandboxProvisioner{
 			base:   checkout,
 			home:   home,
 			runner: subprocess.ExecRunner{},
+			// store backs the checkout-mutation lock that serializes the sandbox clone's
+			// base read against concurrent real jobs on the same daemon checkout (#617).
+			store: store,
 		},
 		commands: policy.ResolvedHardVerifierCommands(),
 	}

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -129,6 +129,36 @@ func daemonDeterministicCheckerDispatcher(store *db.Store, gh github.Client, che
 	}
 }
 
+// daemonHardVerifierDispatcher returns the best-effort deterministic HARD-verifier
+// dispatcher for this home (#474), or nil when the tier is OFF — the default, or any
+// config-load failure (fail-safe to disabled). HardVerifiersEnabled() requires BOTH
+// hard_verifiers_enabled AND auto_trace_enabled AND at least one configured command,
+// so the hard row is only ever written inside an enabled auto-trace run with real
+// verifiers to run. When nil, the engine constructs no verifier leg and writes no
+// hard row, so daemon behavior is byte-identical. It mirrors
+// daemonDeterministicCheckerDispatcher's off-by-default gate. The sandbox is a fresh
+// detached worktree off the daemon's checkout at the merged head (reusing gitmoot's
+// worktree isolation, no external sandbox dep).
+func daemonHardVerifierDispatcher(store *db.Store, checkout string, home string) workflow.HardVerifierDispatcher {
+	if store == nil {
+		return nil
+	}
+	policy, err := loadSkillOptPolicy(home)
+	if err != nil || !policy.HardVerifiersEnabled() {
+		return nil
+	}
+	return &hardVerifierDispatcher{
+		store:  store,
+		runner: subprocess.ExecRunner{},
+		sandbox: worktreeSandboxProvisioner{
+			base:   checkout,
+			home:   home,
+			runner: subprocess.ExecRunner{},
+		},
+		commands: policy.ResolvedHardVerifierCommands(),
+	}
+}
+
 // daemonAuthedRuntimes probes which of the cross-family runtimes (codex/claude/
 // kimi) are authed/available, best-effort, via each adapter's Health check with a
 // synthetic read-only agent. A runtime that errors (not installed / not authed) is

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -148,8 +148,12 @@ func daemonHardVerifierDispatcher(store *db.Store, checkout string, home string)
 		return nil
 	}
 	return &hardVerifierDispatcher{
-		store:  store,
-		runner: subprocess.ExecRunner{},
+		store: store,
+		// GroupRunner (process-group SIGTERM→SIGKILL) reaps a wedged verifier AND its
+		// grandchildren (a `go test` spawns test binaries, `npm test` spawns node), so
+		// the leg's bounded context can never leave an orphaned suite running. The
+		// short-lived git worktree calls keep the plain ExecRunner (no grandchildren).
+		runner: subprocess.GroupRunner{},
 		sandbox: worktreeSandboxProvisioner{
 			base:   checkout,
 			home:   home,

--- a/internal/cli/trace_harvest_integration_test.go
+++ b/internal/cli/trace_harvest_integration_test.go
@@ -343,10 +343,10 @@ func TestTraceHarvestFullChainMergedRealCI(t *testing.T) {
 }
 
 // TestTraceHarvestFullChainMergedNoCI drives case (b): a MERGE whose head carries
-// ONLY the synthetic gitmoot/ci context (no real external CI). The no-CI guard
-// must demote it to the near-neutral band — still choice "a", but NOT the strong
-// positive that case (a) earns. Asserted by comparing the two real runs' rows:
-// both are choice "a", and the no-CI reasoning explicitly marks it near-neutral.
+// ONLY the synthetic gitmoot/ci context (no real external CI). The no-CI guard must
+// record the merge EVENT (still choice "a") but WITHOUT fabricating a quality score,
+// and the persisted reasoning marks it a #614-confirmed empty gate — NOT the strong
+// positive that case (a) earns (#474). Asserted on the real persisted row.
 func TestTraceHarvestFullChainMergedNoCI(t *testing.T) {
 	ctx := context.Background()
 	store := openTraceChainStore(t)
@@ -369,16 +369,17 @@ func TestTraceHarvestFullChainMergedNoCI(t *testing.T) {
 	}
 	event := events[0]
 	if event.Choice != "a" {
-		t.Fatalf("merged+no-CI choice = %q, want a (positive but weak)", event.Choice)
+		t.Fatalf("merged+no-CI choice = %q, want a (the merge event is real)", event.Choice)
 	}
-	// The no-CI guard's near-neutral reasoning is the persisted, observable marker
-	// that this merge was NOT rewarded as a strong positive (the strong-positive
-	// reasoning instead says "merged with passing external CI"). Asserting on the
-	// real persisted reasoning keeps the test reading the store, not a mock, while
-	// still proving the no-CI demotion fired end-to-end.
+	// The honest no-CI reasoning (#474) is the persisted, observable marker that this
+	// merge was recorded WITHOUT a fabricated quality score — the #614 gitmoot/ci stamp
+	// makes it a CONFIRMED empty gate. The strong-positive reasoning instead says
+	// "merged with passing external CI". Asserting on the real persisted reasoning
+	// keeps the test reading the store, not a mock, while still proving the honest no-CI
+	// path fired end-to-end.
 	if got := event.Reasoning; got == "" ||
-		!strings.Contains(got, "no external CI") || !strings.Contains(got, "near-neutral") {
-		t.Fatalf("merged+no-CI reasoning = %q, want the near-neutral no-CI marker", got)
+		!strings.Contains(got, "no external CI") || !strings.Contains(got, "confirmed empty gate") {
+		t.Fatalf("merged+no-CI reasoning = %q, want the honest confirmed-empty-gate marker", got)
 	}
 	if strings.Contains(event.Reasoning, "passing external CI") {
 		t.Fatalf("merged+no-CI must not carry the strong-positive reasoning: %q", event.Reasoning)

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -208,17 +208,28 @@ path = ""
 #     opt heavy tools (jscpd/golangci-lint) in. An unknown name is ignored.
 #   hard_verifiers_enabled (#474): OFF by default; requires auto_trace AND at least one
 #     hard_verifier_commands line. When true, a MERGED implement job runs the configured
-#     build/test/lint COMMANDS in a FRESH clean sandbox checkout at the merged head (a
-#     detached git worktree — no external sandbox dep), exit 0 == pass. The binary
-#     verdict is the authoritative EvaluatorScore.Hard (pass ⇒ hard=1.0/choice a, fail
-#     ⇒ hard=0.0/choice b) — an un-gameable FOURTH coexisting row (reviewer
-#     gitmoot-verifier, item hard#repo#pr) that catches a merge whose code fails a clean
-#     build/test even through an empty (no-CI) gate. DETACHED + best-effort: an
-#     unprovisionable sandbox or empty command list writes no row and never blocks the
-#     merge. Off ⇒ byte-identical. Promotion stays MANUAL.
+#     build/test/lint COMMANDS in a FRESH clean sandbox checkout at the merged head (an
+#     INDEPENDENT local 'git clone' of the daemon checkout — its own git dir, so a
+#     verifier that shells out to git cannot touch the live repo; no external sandbox
+#     dep), exit 0 == pass. The binary verdict is the authoritative EvaluatorScore.Hard
+#     (pass ⇒ hard=1.0/choice a, fail ⇒ hard=0.0/choice b) — an un-gameable FOURTH
+#     coexisting row (reviewer gitmoot-verifier, item hard#repo#pr) that catches a merge
+#     whose code fails a clean build/test even through an empty (no-CI) gate. DETACHED +
+#     best-effort: an unprovisionable sandbox or empty command list writes no row and
+#     never blocks the merge. Off ⇒ byte-identical. Promotion stays MANUAL.
 #   hard_verifier_commands (#474): REPEATABLE — one verifier command per line (so a
 #     command may contain commas / shell operators). The run PASSES only when EVERY
 #     command exits 0. UNSET/empty ⇒ the tier is a no-op (no safe universal default).
+#     IMPORTANT: the sandbox is a BARE checkout of the merged code — it has NO installed
+#     dependencies, build artifacts, or generated files, and inherits only the daemon's
+#     ambient PATH. Each command MUST self-provision what it needs (e.g.
+#     'npm ci && npm test', 'pip install -e . && pytest', or 'go test ./...' which
+#     fetches modules on its own) — a command that assumes a pre-installed
+#     node_modules/venv will FAIL every merge and record a false hard=0. A command that
+#     cannot be RUN at all (its interpreter/binary is absent, exit 127) is treated as an
+#     environment failure and SKIPS the run (no row) instead of recording a negative, but
+#     a command that runs and exits non-zero because deps were missing is an honest FAIL
+#     — so keep each command self-contained.
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -206,12 +206,28 @@ path = ""
 #     default (diff_size only) so a tool-less host runs the always-available metric
 #     and never a heavy tool. Narrow it to run only the cheap dims, or widen it to
 #     opt heavy tools (jscpd/golangci-lint) in. An unknown name is ignored.
+#   hard_verifiers_enabled (#474): OFF by default; requires auto_trace AND at least one
+#     hard_verifier_commands line. When true, a MERGED implement job runs the configured
+#     build/test/lint COMMANDS in a FRESH clean sandbox checkout at the merged head (a
+#     detached git worktree — no external sandbox dep), exit 0 == pass. The binary
+#     verdict is the authoritative EvaluatorScore.Hard (pass ⇒ hard=1.0/choice a, fail
+#     ⇒ hard=0.0/choice b) — an un-gameable FOURTH coexisting row (reviewer
+#     gitmoot-verifier, item hard#repo#pr) that catches a merge whose code fails a clean
+#     build/test even through an empty (no-CI) gate. DETACHED + best-effort: an
+#     unprovisionable sandbox or empty command list writes no row and never blocks the
+#     merge. Off ⇒ byte-identical. Promotion stays MANUAL.
+#   hard_verifier_commands (#474): REPEATABLE — one verifier command per line (so a
+#     command may contain commas / shell operators). The run PASSES only when EVERY
+#     command exits 0. UNSET/empty ⇒ the tier is a no-op (no safe universal default).
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false
 # revert_detection_enabled = true
 # deterministic_checkers_enabled = false
 # deterministic_checkers = diff_size
+# hard_verifiers_enabled = false
+# hard_verifier_commands = go build ./...
+# hard_verifier_commands = go test ./...
 # auto_promote = false
 # auto_promote_min_samples = 0
 # auto_promote_min_score = 0.0

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -611,6 +611,34 @@ type SkillOptPolicy struct {
 	// always-available, tool-less diff_size on a host without dupl/golangci-lint/
 	// gocyclo. An unknown name is ignored (best-effort), never an error.
 	DeterministicCheckerList []string
+
+	// HardVerifiers opts the daemon into the Mode A deterministic HARD-verifier tier
+	// (#474): when true (AND AutoTraceEnabled is also true), a merged implement job
+	// additionally runs the operator's configured verifier COMMANDS (build/test/lint,
+	// e.g. `go build ./...`, `go test ./...`) in a FRESH, clean sandbox checkout at
+	// the merged head — exit 0 == pass. The binary pass/fail verdict is the
+	// authoritative HARD score (EvaluatorScore.Hard) for the run: it CANNOT be gamed
+	// by an LLM judge's prose because it is a plain exit code from an isolated
+	// checkout (slime-style cheat-proofing). Empty/false (the default) means OFF: NO
+	// verifier leg runs and NO hard row is written — byte-identical to the
+	// verifiable-floor-only behavior. It additionally requires AutoTraceEnabled (a
+	// hard row only makes sense inside the auto-trace run); HardVerifiersEnabled()
+	// encodes that dependency, mirroring DeterministicCheckersEnabled(). The field is
+	// named …Verifiers (not …Enabled) because Go forbids a field and method sharing a
+	// name; HardVerifiersEnabled() below is the resolved accessor callers use.
+	HardVerifiers bool
+
+	// HardVerifierCommands is the operator's ordered list of hard-verifier shell
+	// commands (#474): each entry is a full command line (`go build ./...`,
+	// `go test ./...`, `npm test`) run via `sh -c` in the fresh sandbox checkout,
+	// exit 0 == pass. The run PASSES only when EVERY configured command exits 0
+	// (fail-closed set membership, slime's fail_to_pass ∪ pass_to_pass ⊆ passed).
+	// nil/empty (the default) means the leg has NOTHING to run: even with
+	// HardVerifiers on, an empty command list is a no-op (no hard row) — there is no
+	// safe universal default verifier command, so the operator MUST supply at least
+	// one. Parsed from repeatable `hard_verifier_commands = <one command>` lines so a
+	// command may itself contain commas without ambiguity.
+	HardVerifierCommands []string
 }
 
 // DefaultDeterministicCheckers is the safe default checker set used when the
@@ -647,6 +675,8 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		LiveABSampleRate:                nil,
 		DeterministicCheckers:           false,
 		DeterministicCheckerList:        nil,
+		HardVerifiers:                   false,
+		HardVerifierCommands:            nil,
 	}
 }
 
@@ -711,6 +741,31 @@ func (p SkillOptPolicy) ResolvedDeterministicCheckers() []string {
 		return p.DeterministicCheckerList
 	}
 	return DefaultDeterministicCheckers
+}
+
+// HardVerifiersEnabled reports whether the deterministic HARD-verifier tier (#474)
+// is configured on. It requires BOTH hard_verifiers_enabled AND auto_trace_enabled
+// (a hard row only makes sense inside the auto-trace run) AND at least one
+// configured command (an empty command list has nothing to run), so enabling the
+// knob without commands — or without the auto-trace harvester — is OFF, mirroring
+// DeterministicCheckersEnabled()'s AND-dependency. Default false + the AND-gate +
+// the required-command guard guarantee byte-identical behavior with no config.
+func (p SkillOptPolicy) HardVerifiersEnabled() bool {
+	return p.AutoTraceEnabled && p.HardVerifiers && len(p.ResolvedHardVerifierCommands()) > 0
+}
+
+// ResolvedHardVerifierCommands returns the trimmed, non-empty hard-verifier command
+// list (#474). There is NO safe universal default verifier command (unlike the
+// diff_size checker), so an unset list stays empty and HardVerifiersEnabled() gates
+// the leg off — the operator must supply at least one command.
+func (p SkillOptPolicy) ResolvedHardVerifierCommands() []string {
+	out := make([]string, 0, len(p.HardVerifierCommands))
+	for _, cmd := range p.HardVerifierCommands {
+		if trimmed := strings.TrimSpace(cmd); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func LoadSkillOptPolicy(paths Paths) (SkillOptPolicy, error) {
@@ -860,6 +915,18 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		return err
 	case "deterministic_checkers":
 		policy.DeterministicCheckerList = parseDeterministicCheckerList(value)
+		return nil
+	case "hard_verifiers_enabled":
+		parsed, err := strconv.ParseBool(value)
+		policy.HardVerifiers = parsed
+		return err
+	case "hard_verifier_commands":
+		// APPEND one command per occurrence (a repeatable line), so a verifier command
+		// may itself contain commas / shell operators without a delimiter ambiguity.
+		// A blank value is ignored (best-effort); ResolvedHardVerifierCommands trims.
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			policy.HardVerifierCommands = append(policy.HardVerifierCommands, trimmed)
+		}
 		return nil
 	default:
 		return nil

--- a/internal/config/skillopt_hard_verifier_test.go
+++ b/internal/config/skillopt_hard_verifier_test.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLoadSkillOptPolicyHardVerifiersDefaultsDisabled: the hard-verifier tier is OFF
+// by default and has no commands (#474).
+func TestLoadSkillOptPolicyHardVerifiersDefaultsDisabled(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.HardVerifiers || policy.HardVerifiersEnabled() {
+		t.Fatalf("hard verifiers must default OFF, got %+v", policy)
+	}
+	if policy.HardVerifierCommands != nil {
+		t.Fatalf("hard_verifier_commands must default nil, got %+v", policy.HardVerifierCommands)
+	}
+	if got := policy.ResolvedHardVerifierCommands(); len(got) != 0 {
+		t.Fatalf("default resolved hard-verifier commands = %v, want empty", got)
+	}
+}
+
+// TestLoadSkillOptPolicyHardVerifiersRequireAutoTrace: hard_verifiers_enabled +
+// commands WITHOUT auto_trace_enabled is OFF — HardVerifiersEnabled() requires the
+// auto-trace harvester too, mirroring DeterministicCheckersEnabled().
+func TestLoadSkillOptPolicyHardVerifiersRequireAutoTrace(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+hard_verifiers_enabled = true
+hard_verifier_commands = go build ./...
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.HardVerifiers {
+		t.Fatal("hard_verifiers_enabled = true should parse")
+	}
+	if policy.HardVerifiersEnabled() {
+		t.Fatal("HardVerifiersEnabled() must be false without auto_trace_enabled (requires BOTH)")
+	}
+}
+
+// TestLoadSkillOptPolicyHardVerifiersRequireCommands: both knobs on but NO commands
+// is still OFF — an empty command list has nothing to run, so the leg is a no-op.
+func TestLoadSkillOptPolicyHardVerifiersRequireCommands(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+hard_verifiers_enabled = true
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if policy.HardVerifiersEnabled() {
+		t.Fatalf("HardVerifiersEnabled() must be false with no commands configured, got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyHardVerifiersEnabledWithAll: all three prerequisites present
+// (auto_trace + enabled + ≥1 command) => HardVerifiersEnabled().
+func TestLoadSkillOptPolicyHardVerifiersEnabledWithAll(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+hard_verifiers_enabled = true
+hard_verifier_commands = go build ./...
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.HardVerifiersEnabled() {
+		t.Fatalf("HardVerifiersEnabled() must be true with all prerequisites, got %+v", policy)
+	}
+}
+
+// TestLoadSkillOptPolicyHardVerifierCommandsAppendRepeatable: each
+// hard_verifier_commands line appends ONE command (order preserved), so a command may
+// itself contain commas / shell operators without a delimiter ambiguity.
+func TestLoadSkillOptPolicyHardVerifierCommandsAppendRepeatable(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+auto_trace_enabled = true
+hard_verifiers_enabled = true
+hard_verifier_commands = go build ./...
+hard_verifier_commands = go test ./... && echo done, ok
+hard_verifier_commands =
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	// A comma INSIDE a command survives (each line is one command); the blank line is
+	// dropped.
+	want := []string{"go build ./...", "go test ./... && echo done, ok"}
+	got := policy.ResolvedHardVerifierCommands()
+	if len(got) != len(want) {
+		t.Fatalf("resolved hard-verifier commands = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resolved hard-verifier commands[%d] = %q, want %q (got %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestLoadSkillOptPolicyRejectsBadHardVerifiersBool: a non-bool
+// hard_verifiers_enabled surfaces a parse error (fail-safe).
+func TestLoadSkillOptPolicyRejectsBadHardVerifiersBool(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+hard_verifiers_enabled = maybe
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadSkillOptPolicy(paths); err == nil {
+		t.Fatal("expected an error for a non-bool hard_verifiers_enabled")
+	}
+}

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -66,6 +66,58 @@ func (c Client) AddDetachedWorktree(ctx context.Context, path string, ref string
 	return err
 }
 
+// CloneLocalNoCheckout makes an INDEPENDENT local clone of this repo (c.Dir) into
+// dest via `git clone --local --no-checkout`. Because the source is local, git
+// HARDLINKS everything under objects/ (fast, space-cheap) and copies refs, but the
+// clone gets its OWN git directory: its own object DB directory, refs, config, HEAD,
+// and worktree registry. A command later run INSIDE the clone (`git config`,
+// `git update-ref`, `git gc`, `git worktree prune`) therefore mutates only the
+// clone's git state, never the source repo's — the containment property a detached
+// `git worktree` off the source CANNOT provide (a worktree shares the source's
+// object DB, refs, and config). --no-checkout leaves the working tree empty for a
+// subsequent CheckoutDetach at a specific ref. Because objects are copied wholesale
+// (not just reachable ones), any SHA present in the source's object DB stays
+// checkoutable in the clone, so it preserves the availability of a raw
+// `git worktree add --detach <sha>`.
+func (c Client) CloneLocalNoCheckout(ctx context.Context, dest string) error {
+	dest, err := validateWorktreePath(dest)
+	if err != nil {
+		return err
+	}
+	src := strings.TrimSpace(c.Dir)
+	if src == "" {
+		return errors.New("clone source (client dir) is required")
+	}
+	_, err = c.run(ctx, "clone", "--local", "--no-checkout", src, dest)
+	return err
+}
+
+// CheckoutDetach checks out ref as a detached HEAD (`git checkout --detach <ref>`).
+// It accepts a raw SHA even when unreachable from any ref, so it pairs with
+// CloneLocalNoCheckout to materialize an exact merged head in a fresh clone.
+func (c Client) CheckoutDetach(ctx context.Context, ref string) error {
+	if err := validateRef(ref); err != nil {
+		return err
+	}
+	_, err := c.run(ctx, "checkout", "--detach", ref)
+	return err
+}
+
+// RemoveRemote drops a configured remote (`git remote remove <name>`). It is used to
+// sever a throwaway sandbox clone from its origin (the daemon checkout) so a verifier
+// command can never `git fetch`/`git push` back against the live repo.
+func (c Client) RemoveRemote(ctx context.Context, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("remote name is required")
+	}
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("remote name %q must not start with '-'", name)
+	}
+	_, err := c.run(ctx, "remote", "remove", name)
+	return err
+}
+
 func (c Client) BranchExists(ctx context.Context, branch string) (bool, error) {
 	if err := validateBranch(branch); err != nil {
 		return false, err

--- a/internal/skillopt/hard_verifier.go
+++ b/internal/skillopt/hard_verifier.go
@@ -1,0 +1,201 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// hardVerifierReviewerID is the FIXED, tool-derived reviewer id every HARD-verifier
+// row carries (#474). It is a single non-human sentinel (like autoTraceReviewer,
+// reviewReviewerID, and checkerReviewerID) so the hard row is never mistaken for a
+// human ranking, and it is DISTINCT from ALL THREE existing sentinels — the
+// verifiable floor (gitmoot-auto), the subjective LLM rubric (gitmoot-review), and
+// the objective soft checkers (gitmoot-checker) — so the hard row coexists with all
+// of them under the run's UNIQUE (run_id,item_id,reviewer,source,source_url) key
+// instead of overwriting any. A re-verification of the SAME PR re-upserts the SAME
+// hard row in place (the reviewer id is constant), so the row count stays stable.
+//
+// The hard row is the AUTHORITATIVE HARD tier: it carries EvaluatorScore.Hard from a
+// plain exit code in an isolated checkout, so it is un-gameable by the LLM judge's
+// prose. The export/optimizer weights it distinctly via this reviewer sentinel + the
+// hard_verifier item tag.
+const hardVerifierReviewerID = "gitmoot-verifier"
+
+// hardVerifierItemIDPrefix namespaces the hard-verifier eval item so it is a DISTINCT
+// item id from the verifiable-floor item (repo#pr), the subjective review item
+// (review#repo#pr), AND the objective checker item (checker#repo#pr): the hard item
+// is hard#<repo>#<pr>. A distinct item id means the hard row never overwrites any
+// sibling even though all four live in the same auto-trace:<versionID> run.
+const hardVerifierItemIDPrefix = "hard#"
+
+const (
+	// hardVerifierItemMetadataKey marks a hard-verifier row on its eval item so the
+	// export/optimizer can recognize it as the un-gameable HARD tier, WITHOUT a new
+	// contract field. The run-level feedback_source stays automatic_trace (no contract
+	// bump, ContractVersion=1 unchanged).
+	hardVerifierItemMetadataKey = "hard_verifier"
+	// hardVerifierItemMetadataPassedKey carries the binary pass/fail verdict on the
+	// item so the outcome is recoverable by the export/optimizer.
+	hardVerifierItemMetadataPassedKey = "hard_passed"
+	// hardVerifierItemMetadataScoreKey carries the projected Hard score (1.0 pass /
+	// 0.0 fail) so the magnitude reaches the row (the same no-new-field lever the
+	// review/checker rows use).
+	hardVerifierItemMetadataScoreKey = "hard_score"
+	// hardVerifierItemMetadataCommandsKey persists the per-command pass/fail map (each
+	// command → 1.0 pass / 0.0 fail) so which specific verifier failed is auditable,
+	// not just the aggregate verdict.
+	hardVerifierItemMetadataCommandsKey = "command_results"
+)
+
+// projectHardVerifier maps the deterministic hard-verifier verdict to a
+// NormalizedSignal via ProjectSignal over a synthetic EvaluatorScore whose Hard
+// field IS the verdict (#474): HardPassed → Hard=1.0 (a strong, evidence-backed
+// positive), else Hard=0.0 (an authoritative gate-fail 0). ProjectSignal reads
+// Hard==0 as an informative 0 (HasScore=true) and Hard>0 as the quality component,
+// so a pass projects to Score=1.0 and a fail to Score=0.0 — BOTH HasScore=true (a
+// hard verdict is never "absent"). A FAIL additionally rides an
+// EvaluatorFailurePacket so the feedback explains it (like negativeSignal).
+func projectHardVerifier(outcome workflow.Outcome) NormalizedSignal {
+	findings := strings.TrimSpace(outcome.Findings)
+	if findings == "" {
+		findings = fmt.Sprintf("Hard verifiers on PR #%d.", outcome.PullRequest)
+	}
+	if outcome.HardPassed {
+		h := 1.0
+		return ProjectSignal(&EvaluatorScore{Hard: &h}, &RankedFeedbackEvent{Reasoning: findings}, nil)
+	}
+	h := 0.0
+	return ProjectSignal(&EvaluatorScore{Hard: &h}, nil, &EvaluatorFailurePacket{OptimizerHint: findings})
+}
+
+// hardVerifierChoice derives the a/b choice from the hard verdict so a FAIL registers
+// as a non-baseline "b" vote instead of a baseline win, mirroring reviewChoice/
+// checkerChoice. A hard verdict is always scored (HasScore=true), so an unscored
+// signal cannot occur here; the HasScore guard keeps it total.
+func hardVerifierChoice(signal NormalizedSignal) string {
+	if signal.HasScore && signal.Score < hardVerifierChoiceThreshold {
+		return "b"
+	}
+	return "a"
+}
+
+// hardVerifierChoiceThreshold maps the Hard score onto a/b: a FAIL (Hard=0) is below
+// it (=> "b", a non-baseline vote), a PASS (Hard=1.0) is at/above it (=> "a").
+const hardVerifierChoiceThreshold = 0.5
+
+// writeHardVerifierFeedback upserts the AUTHORITATIVE hard-verifier row into the
+// EXISTING auto-trace:<versionID> run (#474): the same run as the verifiable floor,
+// the subjective review, and the objective checker (so the optimizer sees all four),
+// under a DISTINCT item id (hard#repo#pr) and the FIXED tool-derived reviewer
+// sentinel (gitmoot-verifier), so it coexists with all three siblings on the UNIQUE
+// (run_id,item_id,reviewer,source,source_url) key instead of overwriting any — and so
+// a re-verification of the same PR overwrites the hard row in place rather than
+// accumulating a stale duplicate. The run keeps feedback_source=automatic_trace (no
+// contract bump); the hard item carries the hard_verifier tag, the pass/fail verdict,
+// the projected Hard score, and the per-command results so the export/optimizer can
+// weight it as the un-gameable HARD tier. The a/b choice tracks the verdict (fail =>
+// "b").
+//
+// It writes ONLY eval_runs/eval_review_items/feedback_events — no candidate, no
+// promotion path — so promotion stays manual.
+func (h *OutcomeHarvester) writeHardVerifierFeedback(ctx context.Context, version db.AgentTemplateVersion, outcome workflow.Outcome, signal NormalizedSignal) error {
+	// A hard verdict is ALWAYS scored (pass=1.0 / fail=0.0), so HasScore is true here;
+	// the guard is defensive so a malformed projection never lands an unscored row.
+	if !signal.HasScore {
+		return nil
+	}
+	runID := AutoTraceRunID(version.ID)
+	itemID := hardVerifierItemID(outcome)
+	sourceURL := pullRequestURL(outcome.Repo, outcome.PullRequest)
+
+	if err := h.Store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                runID,
+		TemplateID:        strings.TrimSpace(version.TemplateID),
+		TemplateVersionID: strings.TrimSpace(version.ID),
+		TargetRepo:        strings.TrimSpace(outcome.Repo),
+		State:             "ready",
+		Mode:              db.EvalRunModeValidate,
+		MetadataJSON:      autoTraceRunMetadata(),
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace eval_run (hard verifier): %w", err)
+	}
+
+	if err := h.Store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{
+		RunID:        runID,
+		ItemID:       itemID,
+		Title:        hardVerifierItemTitle(outcome),
+		MetadataJSON: hardVerifierItemMetadata(outcome, signal),
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace eval_review_item (hard verifier): %w", err)
+	}
+
+	if err := h.Store.UpsertFeedbackEvent(ctx, db.FeedbackEvent{
+		RunID:     runID,
+		ItemID:    itemID,
+		Choice:    hardVerifierChoice(signal),
+		Reasoning: signal.Feedback,
+		Reviewer:  hardVerifierReviewerID,
+		Source:    autoTraceSource,
+		SourceURL: sourceURL,
+	}); err != nil {
+		return fmt.Errorf("upsert auto-trace feedback_event (hard verifier): %w", err)
+	}
+	return nil
+}
+
+// hardVerifierItemID is the DISTINCT eval item id for the hard-verifier row
+// (hard#repo#pr) so it never overwrites the verifiable-floor row (repo#pr), the
+// review row (review#repo#pr), or the checker row (checker#repo#pr) in the same run,
+// while a re-verification of the SAME PR re-upserts the SAME hard row in place.
+func hardVerifierItemID(outcome workflow.Outcome) string {
+	return hardVerifierItemIDPrefix + autoTraceItemID(outcome)
+}
+
+// hardVerifierItemTitle is the human-readable title of the hard-verifier item.
+func hardVerifierItemTitle(outcome workflow.Outcome) string {
+	repo := strings.TrimSpace(outcome.Repo)
+	verdict := "fail"
+	if outcome.HardPassed {
+		verdict = "pass"
+	}
+	if outcome.PullRequest > 0 {
+		return fmt.Sprintf("Hard verifiers (%s): %s PR #%d", verdict, repo, outcome.PullRequest)
+	}
+	return fmt.Sprintf("Hard verifiers (%s): %s", verdict, repo)
+}
+
+// hardVerifierItemMetadata carries the hard_verifier tag, the binary verdict, the
+// projected Hard score, and the per-command pass/fail map on the hard eval item so
+// the export/optimizer can recognize it as the un-gameable HARD tier and recover
+// exactly which verifier failed, WITHOUT a new contract field. The per-command map
+// is derived from outcome.Rubric (each command → 1.0 pass / 0.0 fail), which the
+// dispatcher populates for audit only — it is NOT used as the score (the score is the
+// binary Hard verdict, not the mean of the commands).
+func hardVerifierItemMetadata(outcome workflow.Outcome, signal NormalizedSignal) string {
+	commands := map[string]float64{}
+	names := make([]string, 0, len(outcome.Rubric))
+	for k, v := range outcome.Rubric {
+		commands[k] = v
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	meta := map[string]any{
+		"repo":                              strings.TrimSpace(outcome.Repo),
+		"pull_request":                      outcome.PullRequest,
+		hardVerifierItemMetadataKey:         true,
+		hardVerifierItemMetadataPassedKey:   outcome.HardPassed,
+		hardVerifierItemMetadataCommandsKey: commands,
+		"commands":                          names,
+	}
+	if signal.HasScore {
+		meta[hardVerifierItemMetadataScoreKey] = signal.Score
+	}
+	raw, _ := json.Marshal(meta)
+	return string(raw)
+}

--- a/internal/skillopt/hard_verifier_test.go
+++ b/internal/skillopt/hard_verifier_test.go
@@ -1,0 +1,212 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// hardOutcome builds a HARD-verifier outcome (Kind=OutcomeReviewed, HardVerifier=true)
+// for the test PR with the given verdict and per-command results.
+func hardOutcome(passed bool, results map[string]float64) workflow.Outcome {
+	verdict := "FAIL"
+	if passed {
+		verdict = "pass"
+	}
+	return workflow.Outcome{
+		Kind:         workflow.OutcomeReviewed,
+		HardVerifier: true,
+		HardPassed:   passed,
+		Repo:         "owner/repo",
+		PullRequest:  7,
+		HeadSHA:      "deadbeef",
+		Rubric:       results,
+		Findings:     "Hard verifiers on PR #7 [" + verdict + "]",
+	}
+}
+
+func hardItemFor(t *testing.T, store *db.Store, versionID, itemID string) (db.EvalReviewItem, bool) {
+	t.Helper()
+	items, err := store.ListEvalReviewItems(context.Background(), autoTraceRunIDPrefix+versionID)
+	if err != nil {
+		t.Fatalf("ListEvalReviewItems returned error: %v", err)
+	}
+	for _, item := range items {
+		if item.ItemID == itemID {
+			return item, true
+		}
+	}
+	return db.EvalReviewItem{}, false
+}
+
+// TestProjectHardVerifierPassIsStrongPositive: a PASS projects to the authoritative
+// Hard=1.0 (Score=1.0, HasScore=true) — an evidence-backed positive.
+func TestProjectHardVerifierPassIsStrongPositive(t *testing.T) {
+	signal := projectHardVerifier(hardOutcome(true, map[string]float64{"go test ./...": 1.0}))
+	if !signal.HasScore || signal.Score != 1.0 {
+		t.Fatalf("hard PASS projection = score=%v has=%v, want score=1.0 has=true", signal.Score, signal.HasScore)
+	}
+	if hardVerifierChoice(signal) != "a" {
+		t.Fatalf("hard PASS choice = %q, want a", hardVerifierChoice(signal))
+	}
+}
+
+// TestProjectHardVerifierFailIsAuthoritativeZero: a FAIL projects to the
+// authoritative gate-fail Hard=0 (Score=0, HasScore=true) — NOT absent — and the
+// choice flips to "b" (a non-baseline vote), with the failure reasoning carried.
+func TestProjectHardVerifierFailIsAuthoritativeZero(t *testing.T) {
+	signal := projectHardVerifier(hardOutcome(false, map[string]float64{"go test ./...": 0.0}))
+	if !signal.HasScore || signal.Score != 0 {
+		t.Fatalf("hard FAIL projection = score=%v has=%v, want score=0 has=true (authoritative gate-fail)", signal.Score, signal.HasScore)
+	}
+	if hardVerifierChoice(signal) != "b" {
+		t.Fatalf("hard FAIL choice = %q, want b (non-baseline vote)", hardVerifierChoice(signal))
+	}
+	if signal.Feedback == "" {
+		t.Fatal("hard FAIL must carry failure reasoning")
+	}
+}
+
+// TestHardVerifierRowCoexistsWithAllSiblings: harvesting the verifiable floor, the
+// subjective review, the objective checker, AND the hard verifier writes FOUR
+// distinct rows in the SAME auto-trace run under distinct item ids + reviewers — the
+// hard row NEVER overwrites any sibling.
+func TestHardVerifierRowCoexistsWithAllSiblings(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, &stubStatusReader{status: realCIStatus()})
+
+	if err := h.Harvest(ctx, implementJob(), payload, workflow.Outcome{
+		Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef",
+	}); err != nil {
+		t.Fatalf("Harvest merge returned error: %v", err)
+	}
+	if err := h.Harvest(ctx, implementJob(), payload, reviewOutcome(map[string]float64{"coverage": 0.5}, "claude", false)); err != nil {
+		t.Fatalf("Harvest review returned error: %v", err)
+	}
+	if err := h.Harvest(ctx, implementJob(), payload, checkerOutcome(map[string]float64{"diff_size": 0.9})); err != nil {
+		t.Fatalf("Harvest checker returned error: %v", err)
+	}
+	if err := h.Harvest(ctx, implementJob(), payload, hardOutcome(true, map[string]float64{"go test ./...": 1.0})); err != nil {
+		t.Fatalf("Harvest hard verifier returned error: %v", err)
+	}
+
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 4 {
+		t.Fatalf("expected floor + review + checker + hard rows (4), got %d: %+v", len(events), events)
+	}
+	var floor, review, checker, hard *db.FeedbackEvent
+	for i := range events {
+		switch events[i].Reviewer {
+		case autoTraceReviewer:
+			floor = &events[i]
+		case reviewReviewerID:
+			review = &events[i]
+		case checkerReviewerID:
+			checker = &events[i]
+		case hardVerifierReviewerID:
+			hard = &events[i]
+		}
+	}
+	if floor == nil || review == nil || checker == nil || hard == nil {
+		t.Fatalf("all four rows must coexist; got %+v", events)
+	}
+	if hard.ItemID != hardVerifierItemIDPrefix+"owner/repo#7" {
+		t.Fatalf("hard item id = %q, want hard#owner/repo#7", hard.ItemID)
+	}
+	if hard.ItemID == floor.ItemID || hard.ItemID == review.ItemID || hard.ItemID == checker.ItemID {
+		t.Fatalf("hard row must use a DISTINCT item id; hard=%q floor=%q review=%q checker=%q", hard.ItemID, floor.ItemID, review.ItemID, checker.ItemID)
+	}
+	if hard.Choice != "a" {
+		t.Fatalf("hard PASS row choice = %q, want a", hard.Choice)
+	}
+}
+
+// TestHardVerifierFailRowIsNegative: a FAILED hard verifier lands a choice "b"
+// (negative) row even though the PR merged — the un-gameable signal that the merged
+// code fails a clean build/test.
+func TestHardVerifierFailRowIsNegative(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	if err := h.Harvest(ctx, implementJob(), payload, hardOutcome(false, map[string]float64{"go test ./...": 0.0})); err != nil {
+		t.Fatalf("Harvest hard verifier returned error: %v", err)
+	}
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one hard row, got %d: %+v", len(events), events)
+	}
+	if events[0].Reviewer != hardVerifierReviewerID || events[0].Choice != "b" {
+		t.Fatalf("hard FAIL row = reviewer %q choice %q, want %q / b", events[0].Reviewer, events[0].Choice, hardVerifierReviewerID)
+	}
+}
+
+// TestHardVerifierItemMetadataRoundTrips: the hard item carries the hard_verifier
+// tag, the binary verdict, the projected Hard score, and the per-command results, all
+// recoverable via a JSON round-trip (contract round-trip, no new contract field).
+func TestHardVerifierItemMetadataRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	outcome := hardOutcome(false, map[string]float64{"go build ./...": 1.0, "go test ./...": 0.0})
+	if err := h.Harvest(ctx, implementJob(), payload, outcome); err != nil {
+		t.Fatalf("Harvest returned error: %v", err)
+	}
+	item, ok := hardItemFor(t, store, version.ID, hardVerifierItemID(outcome))
+	if !ok {
+		t.Fatalf("hard item %q not found", hardVerifierItemID(outcome))
+	}
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(item.MetadataJSON), &meta); err != nil {
+		t.Fatalf("hard item metadata is not valid JSON: %v (%q)", err, item.MetadataJSON)
+	}
+	if meta[hardVerifierItemMetadataKey] != true {
+		t.Fatalf("hard item must be tagged %s=true, got %v", hardVerifierItemMetadataKey, meta[hardVerifierItemMetadataKey])
+	}
+	if meta[hardVerifierItemMetadataPassedKey] != false {
+		t.Fatalf("hard_passed must be false for a FAIL, got %v", meta[hardVerifierItemMetadataPassedKey])
+	}
+	score, ok := meta[hardVerifierItemMetadataScoreKey].(float64)
+	if !ok || score != 0 {
+		t.Fatalf("hard_score = %v, want 0 (fail)", meta[hardVerifierItemMetadataScoreKey])
+	}
+	cmds, ok := meta[hardVerifierItemMetadataCommandsKey].(map[string]any)
+	if !ok {
+		t.Fatalf("command_results must be a map, got %T (%v)", meta[hardVerifierItemMetadataCommandsKey], meta[hardVerifierItemMetadataCommandsKey])
+	}
+	if cmds["go build ./..."] != 1.0 || cmds["go test ./..."] != 0.0 {
+		t.Fatalf("command_results = %v, want go build=1.0 go test=0.0", cmds)
+	}
+}
+
+// TestHardVerifierReEvaluationOverwritesInPlace: a re-verification of the SAME PR
+// (verdict flip pass -> fail) re-upserts the SAME row in place (row count stays 1),
+// mirroring the corrective-overwrite discipline of the other auto-trace rows.
+func TestHardVerifierReEvaluationOverwritesInPlace(t *testing.T) {
+	ctx := context.Background()
+	store := newTraceStore(t)
+	version, payload := installTraceTemplate(t, store, "planner")
+	h := NewOutcomeHarvester(store, nil)
+
+	if err := h.Harvest(ctx, implementJob(), payload, hardOutcome(true, map[string]float64{"go test ./...": 1.0})); err != nil {
+		t.Fatalf("Harvest pass returned error: %v", err)
+	}
+	if err := h.Harvest(ctx, implementJob(), payload, hardOutcome(false, map[string]float64{"go test ./...": 0.0})); err != nil {
+		t.Fatalf("Harvest fail returned error: %v", err)
+	}
+	events := feedbackForVersion(t, store, version.ID)
+	if len(events) != 1 {
+		t.Fatalf("re-verification must overwrite in place (1 row), got %d: %+v", len(events), events)
+	}
+	if events[0].Choice != "b" {
+		t.Fatalf("overwritten hard row choice = %q, want b (the later FAIL)", events[0].Choice)
+	}
+}

--- a/internal/skillopt/trace_harvest.go
+++ b/internal/skillopt/trace_harvest.go
@@ -71,9 +71,12 @@ const (
 	// scoreMergedRealCI is the strong-positive Soft score for a merge that passed a
 	// genuine external CI (a non-gitmoot/ status or check that succeeded).
 	scoreMergedRealCI = 1.0
-	// scoreMergedNoCI is the near-neutral Soft score for a merge through an empty
-	// gate (the synthetic gitmoot/ci context, or no external CI at head): not a
-	// strong positive, but not a negative either — absence of verifiable evidence.
+	// scoreMergedNoCI is the defensive midpoint used ONLY by the unreachable
+	// unknown-outcome-kind branch of project(). It is NO LONGER the merge-through-an-
+	// empty-gate reward: as of #474 an empty-gate merge yields a genuinely-ABSENT
+	// quality score (HasScore=false) instead of this fabricated midpoint — see the
+	// OutcomeMerged branch. The constant survives only so the impossible default arm
+	// keeps a bounded, non-panicking value.
 	scoreMergedNoCI = 0.5
 	// scoreChangesRequestedBase is the first-fix-round Soft score for a
 	// changes_requested negative; each additional fix round subtracts
@@ -189,6 +192,14 @@ func (h *OutcomeHarvester) Harvest(ctx context.Context, job db.Job, payload work
 		return nil
 	}
 	if outcome.Kind == workflow.OutcomeReviewed {
+		if outcome.HardVerifier {
+			// Deterministic HARD-verifier signal (#474): a FOURTH coexisting, un-gameable
+			// FeedbackEvent in the SAME auto-trace run under a DISTINCT item id (hard#repo#pr)
+			// + reviewer (gitmoot-verifier), carrying the authoritative EvaluatorScore.Hard
+			// (1.0 pass / 0.0 fail) so it coexists with the verifiable floor, the objective
+			// checker, AND the subjective review instead of overwriting any of them.
+			return h.writeHardVerifierFeedback(ctx, version, outcome, projectHardVerifier(outcome))
+		}
 		if outcome.Objective {
 			// OBJECTIVE deterministic-checker signal (#485): a THIRD, tool-measured,
 			// non-LLM FeedbackEvent in the SAME auto-trace run under a DISTINCT item id
@@ -293,8 +304,20 @@ func (h *OutcomeHarvester) project(ctx context.Context, payload workflow.JobPayl
 			return positiveSignal(scoreMergedRealCI,
 				fmt.Sprintf("PR #%d merged with %s.", outcome.PullRequest, realExternalCIPhrase)), "a"
 		}
-		return positiveSignal(scoreMergedNoCI,
-			fmt.Sprintf("PR #%d merged through an empty gate (no external CI); near-neutral, not a strong positive.", outcome.PullRequest)), "a"
+		// No external CI at head: the merge EVENT is real (choice "a"), but there is NO
+		// verifiable QUALITY evidence, so we refuse to invent a midpoint reward. The
+		// merge row records the merge with a genuinely-ABSENT quality score
+		// (HasScore=false) — matching how the rest of the read-side projection returns
+		// absence rather than a fabricated 0.5 (#474; obsoletes the old scoreMergedNoCI
+		// punt). The reasoning is grounded in what the harvester can actually observe: a
+		// #614-confirmed empty gate (the grace window elapsed with the gitmoot/ci "no
+		// external CI" stamp at head → genuinely no CI) reads differently from a
+		// still-racing/unread zero.
+		detail := fmt.Sprintf("PR #%d merged through an empty gate (no external CI observed at head); no verifiable quality evidence — recorded as a merge event without a fabricated quality score.", outcome.PullRequest)
+		if h.mergeConfirmedNoCI(ctx, outcome) {
+			detail = fmt.Sprintf("PR #%d merged through a confirmed empty gate (grace window elapsed; genuinely no external CI at head); no verifiable quality evidence — recorded as a merge event without a fabricated quality score.", outcome.PullRequest)
+		}
+		return absentQualitySignal(detail), "a"
 	case workflow.OutcomeBlocked:
 		reason := strings.TrimSpace(outcome.Reason)
 		if reason == "" {
@@ -437,6 +460,52 @@ func gradedSignal(score float64, feedback string) NormalizedSignal {
 func negativeSignal(hard float64, feedback string) NormalizedSignal {
 	h := hard
 	return ProjectSignal(&EvaluatorScore{Hard: &h}, nil, &EvaluatorFailurePacket{OptimizerHint: feedback})
+}
+
+// absentQualitySignal builds a NormalizedSignal that records the textual feedback
+// but carries NO scalar quality score (HasScore=false), via ProjectSignal over a
+// nil EvaluatorScore (#474). It is the honest projection for a merge with no
+// verifiable evidence: the merge EVENT is still recorded by the caller's choice,
+// but the quality score is genuinely absent rather than a fabricated 0.5 — matching
+// how the rest of the read-side projection returns HasScore=false when a signal is
+// truly missing.
+func absentQualitySignal(feedback string) NormalizedSignal {
+	return ProjectSignal(nil, &RankedFeedbackEvent{Reasoning: feedback}, nil)
+}
+
+// mergeConfirmedNoCI reports whether the merged PR head carries the #614/#596
+// synthetic gitmoot/ci "no external CI" success stamp — the merge gate writes it
+// ONLY after the grace/max window elapses with the head unchanged and still zero
+// external CI, so its presence means the empty gate was CONFIRMED (genuinely no CI
+// at this head), NOT a still-racing Actions creation lag. It is best-effort and
+// read-only: a nil reader, a read error, a malformed repo, or an empty head all
+// degrade to false (unconfirmed), so this only ever SHARPENS the no-CI reasoning
+// text and never changes the (absent) score. It is consulted only from the no-CI
+// branch (after mergeHasRealCI already returned false), so a "success" gitmoot/ci
+// context here is exactly the confirmed-empty-gate stamp.
+func (h *OutcomeHarvester) mergeConfirmedNoCI(ctx context.Context, outcome workflow.Outcome) bool {
+	if h.Status == nil {
+		return false
+	}
+	head := strings.TrimSpace(outcome.HeadSHA)
+	if head == "" {
+		return false
+	}
+	repo, ok := parseRepo(outcome.Repo)
+	if !ok {
+		return false
+	}
+	status, err := h.Status.GetCombinedStatus(ctx, repo, head)
+	if err != nil {
+		return false
+	}
+	for _, item := range status.Statuses {
+		if strings.TrimSpace(item.Context) == gitmootNoCIContext &&
+			strings.EqualFold(strings.TrimSpace(item.State), "success") {
+			return true
+		}
+	}
+	return false
 }
 
 // writeFeedback upserts the dedicated per-template-version auto-trace eval_run,

--- a/internal/skillopt/trace_harvest_test.go
+++ b/internal/skillopt/trace_harvest_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -178,10 +179,13 @@ func TestHarvestMergedRealCIWritesStrongPositive(t *testing.T) {
 	}
 }
 
-// TestHarvestMergedNoCINearNeutral asserts a merge through the empty gate (only
-// the synthetic gitmoot/ci context) is scored near-neutral (~0.5), NOT a strong
-// positive — the no-CI guard.
-func TestHarvestMergedNoCINearNeutral(t *testing.T) {
+// TestHarvestMergedNoCIAbsentQuality asserts a merge through the empty gate (only
+// the synthetic gitmoot/ci context) records the merge EVENT (choice "a") but carries
+// a genuinely-ABSENT quality score (HasScore=false), NOT a fabricated 0.5 (#474): the
+// harvester refuses to invent a quality midpoint with no verifiable evidence. Because
+// the #614 gitmoot/ci "no external CI" stamp is present, the reasoning is the
+// CONFIRMED-empty-gate wording.
+func TestHarvestMergedNoCIAbsentQuality(t *testing.T) {
 	ctx := context.Background()
 	store := newTraceStore(t)
 	version, payload := installTraceTemplate(t, store, "planner")
@@ -193,13 +197,14 @@ func TestHarvestMergedNoCINearNeutral(t *testing.T) {
 	}
 	signal, choice := h.project(ctx, payload, outcome)
 	if choice != "a" {
-		t.Fatalf("merged+no-CI choice = %q, want a (positive but weak)", choice)
+		t.Fatalf("merged+no-CI choice = %q, want a (the merge event is real)", choice)
 	}
-	if !signal.HasScore || signal.Score != scoreMergedNoCI {
-		t.Fatalf("merged+no-CI score = %v (has=%v), want %v", signal.Score, signal.HasScore, scoreMergedNoCI)
+	if signal.HasScore {
+		t.Fatalf("merged+no-CI must carry NO fabricated quality score, got score=%v has=%v", signal.Score, signal.HasScore)
 	}
-	if signal.Score >= scoreMergedRealCI {
-		t.Fatalf("no-CI merge must not score a strong positive, got %v", signal.Score)
+	// #614-confirmed empty gate (the gitmoot/ci success stamp is present at head).
+	if !strings.Contains(signal.Feedback, "confirmed empty gate") {
+		t.Fatalf("merged+confirmed-no-CI reasoning = %q, want the confirmed-empty-gate wording", signal.Feedback)
 	}
 	events := feedbackForVersion(t, store, version.ID)
 	if len(events) != 1 || events[0].Choice != "a" {
@@ -245,8 +250,8 @@ func TestHarvestMergedActionsCheckIsStrongPositive(t *testing.T) {
 
 // TestHarvestMergedFailingActionsCheckIsNotRealCI asserts a FAILING (or only
 // gitmoot/) check-run is NOT treated as real CI, so a no-external-success merge
-// stays near-neutral. This guards against rewarding a merge whose only check did
-// not pass.
+// carries no fabricated quality score (HasScore=false), choice "a" (#474). This
+// guards against rewarding a merge whose only check did not pass.
 func TestHarvestMergedFailingActionsCheckIsNotRealCI(t *testing.T) {
 	ctx := context.Background()
 	store := newTraceStore(t)
@@ -262,22 +267,27 @@ func TestHarvestMergedFailingActionsCheckIsNotRealCI(t *testing.T) {
 
 	outcome := workflow.Outcome{Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef"}
 	signal, choice := h.project(ctx, payload, outcome)
-	if choice != "a" || signal.Score != scoreMergedNoCI {
-		t.Fatalf("failing-check merge score = %v choice=%q, want near-neutral %v choice=a", signal.Score, choice, scoreMergedNoCI)
+	if choice != "a" || signal.HasScore {
+		t.Fatalf("failing-check merge = score %v has=%v choice=%q, want absent-quality choice=a", signal.Score, signal.HasScore, choice)
 	}
 }
 
-// TestHarvestMergedNoStatusReaderIsNearNeutral asserts a nil status reader (or a
-// status read failure) conservatively degrades a merge to near-neutral rather
-// than rewarding it as a strong positive.
-func TestHarvestMergedNoStatusReaderIsNearNeutral(t *testing.T) {
+// TestHarvestMergedNoStatusReaderIsAbsentQuality asserts a nil status reader (or a
+// status read failure) conservatively degrades a merge to an ABSENT quality score
+// (HasScore=false) rather than rewarding it as a strong positive OR fabricating a
+// 0.5 (#474). With no reader the empty gate cannot be #614-confirmed, so the
+// reasoning is the unconfirmed wording.
+func TestHarvestMergedNoStatusReaderIsAbsentQuality(t *testing.T) {
 	ctx := context.Background()
 	store := newTraceStore(t)
 	_, payload := installTraceTemplate(t, store, "planner")
 	h := NewOutcomeHarvester(store, nil)
-	signal, _ := h.project(ctx, payload, workflow.Outcome{Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef"})
-	if signal.Score != scoreMergedNoCI {
-		t.Fatalf("nil status reader merge score = %v, want near-neutral %v", signal.Score, scoreMergedNoCI)
+	signal, choice := h.project(ctx, payload, workflow.Outcome{Kind: workflow.OutcomeMerged, Repo: "owner/repo", PullRequest: 7, HeadSHA: "deadbeef"})
+	if choice != "a" || signal.HasScore {
+		t.Fatalf("nil status reader merge = score %v has=%v choice=%q, want absent-quality choice=a", signal.Score, signal.HasScore, choice)
+	}
+	if !strings.Contains(signal.Feedback, "no external CI observed at head") {
+		t.Fatalf("nil-reader no-CI reasoning = %q, want the unconfirmed-empty-gate wording", signal.Feedback)
 	}
 }
 

--- a/internal/workflow/checkout_lock.go
+++ b/internal/workflow/checkout_lock.go
@@ -20,6 +20,20 @@ const (
 	checkoutMutationBusyMessage = "This checkout is already being mutated by another Gitmoot task. Run tasks sequentially or enable per-task worktrees for parallel implementation."
 )
 
+// AcquireCheckoutMutationLock is the EXPORTED seam for out-of-package callers (the
+// CLI hard-verifier sandbox provisioner, #474/#617) to serialize a shared-checkout
+// operation on the SAME resource key every in-package worktree/checkout mutation uses
+// (AllocateTaskWorktree, AllocateReadOnlyDelegationWorktree, the merge gate). It waits
+// up to the standard budget for a concurrent holder, then returns a release the caller
+// MUST call to drop the lock. An empty checkoutPath is a no-op that returns a no-op
+// release (nothing to serialize). Callers hold it only around the short shared-repo
+// op (e.g. a local clone that reads the base .git) and release it before any long,
+// self-contained work, so the leg never stalls a real job for more than that op.
+func AcquireCheckoutMutationLock(ctx context.Context, store *db.Store, checkoutPath string, ownerID string, now time.Time) (func(context.Context) error, error) {
+	release, _, err := acquireCheckoutMutationLockWithWait(ctx, store, checkoutPath, ownerID, now)
+	return release, err
+}
+
 func acquireCheckoutMutationLock(ctx context.Context, store *db.Store, checkoutPath string, ownerID string, now time.Time) (func(context.Context) error, string, error) {
 	key, err := checkoutMutationLockKey(checkoutPath)
 	if err != nil {

--- a/internal/workflow/cross_family_review.go
+++ b/internal/workflow/cross_family_review.go
@@ -48,6 +48,30 @@ type DeterministicCheckerDispatcher interface {
 	Check(ctx context.Context, implementJob db.Job, implementPayload JobPayload, mergedHead string) (Outcome, bool, error)
 }
 
+// HardVerifierDispatcher is the injected, best-effort, nil-by-default seam (#474)
+// the engine calls after a merge to run the deterministic HARD-verifier tier: the
+// operator's configured build/test/lint COMMANDS run in a FRESH, clean sandbox
+// checkout at the merged head — exit 0 == pass. It returns an
+// Outcome{Kind: OutcomeReviewed, HardVerifier: true, HardPassed: <all-passed>} the
+// engine harvests into the SAME auto-trace run, mapping the binary verdict onto the
+// authoritative EvaluatorScore.Hard (1.0 pass / 0.0 fail) — an un-gameable gate the
+// LLM judge's prose can never move.
+//
+// It mirrors DeterministicCheckerDispatcher EXACTLY: nil-safe (when nil — the
+// default, no hard_verifiers_enabled — NO verifier leg runs and NO hard row is
+// written, byte-identical), DETACHED off the blocking AdvanceJob path (a slow test
+// suite can never stall job advancement or the daemon checkoutLock), and
+// best-effort (a dispatch error is swallowed and recorded as a hard_verifiers_failed
+// job event, never returned up). ok=false means NO verdict was producible at all
+// (the sandbox could not be provisioned, or the command list was empty) so the
+// engine writes no hard row; ok=true returns the binary verdict. The concrete impl
+// is wired only in cli (gated by hard_verifiers_enabled AND auto_trace_enabled AND a
+// non-empty command list), keeping the engine free of subprocess/skillopt/git
+// coupling.
+type HardVerifierDispatcher interface {
+	Verify(ctx context.Context, implementJob db.Job, implementPayload JobPayload, mergedHead string) (Outcome, bool, error)
+}
+
 // crossFamilyRotation is the fixed, deterministic family rotation used when no
 // registered different-family reviewer exists and the dispatcher materializes an
 // ephemeral different-family review leg (#469): codex→claude, claude→codex,

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -86,6 +86,21 @@ type Engine struct {
 	// by deterministic_checkers_enabled AND auto_trace_enabled), keeping the engine
 	// free of subprocess/skillopt coupling.
 	DeterministicCheckerDispatcher DeterministicCheckerDispatcher
+	// HardVerifierDispatcher is the injected, best-effort, nil-by-default seam (#474)
+	// the engine calls AFTER a merge harvest to run the deterministic HARD-verifier
+	// tier: the operator's configured build/test/lint COMMANDS run in a FRESH clean
+	// sandbox checkout at the merged head (exit 0 == pass), producing a BINARY
+	// pass/fail verdict the harvester maps onto the authoritative EvaluatorScore.Hard.
+	// It mirrors DeterministicCheckerDispatcher EXACTLY: optional and nil-safe (when
+	// nil — the default, no [skillopt].hard_verifiers_enabled — NO verifier leg runs
+	// and NO hard row is written, byte-identical), DETACHED off the blocking merge
+	// path (a slow test suite can never stall AdvanceJob or the daemon checkoutLock),
+	// and best-effort (a dispatch error is swallowed and recorded as a
+	// hard_verifiers_failed job event, never returned up). The concrete impl is wired
+	// only in cli (gated by hard_verifiers_enabled AND auto_trace_enabled AND a
+	// non-empty command list), keeping the engine free of subprocess/skillopt/git
+	// coupling.
+	HardVerifierDispatcher HardVerifierDispatcher
 	// Home is the resolved GITMOOT_HOME root used to place per-delegation
 	// worktrees. DelegationWorktrees is the checkout-bound git client that
 	// performs the worktree-add. Both are optional: when either is unset, the
@@ -252,6 +267,19 @@ type Engine struct {
 	// spawns a goroutine; tests inject a synchronous runner so the checker leg is
 	// deterministic. It mirrors ReviewSpawner.
 	CheckerSpawner func(func())
+	// HardVerifierLegTimeout bounds the DETACHED hard-verifier leg (#474): the leg
+	// provisions a fresh sandbox and runs the operator's build/test/lint commands,
+	// which can be slow, so it must never run unbounded. The detached goroutine's
+	// context is wrapped in this timeout so a wedged verifier is reaped rather than
+	// leaking forever. <= 0 means defaultHardVerifierLegTimeout. It only matters when
+	// a HardVerifierDispatcher is wired (off by default).
+	HardVerifierLegTimeout time.Duration
+	// HardVerifierSpawner runs the detached hard-verifier leg OFF the AdvanceJob /
+	// daemon-poll path so a slow, possibly-wedged test suite can never block
+	// AdvanceJob, the worker tick, or the daemon's checkoutLock. The default (nil)
+	// spawns a goroutine; tests inject a synchronous runner so the verifier leg is
+	// deterministic. It mirrors CheckerSpawner.
+	HardVerifierSpawner func(func())
 }
 
 // DelegationTimeoutDefaults are optional fallback timeouts for child delegation
@@ -325,6 +353,14 @@ const defaultReviewLegTimeout = 10 * time.Minute
 // take a few minutes — whose only job is to reap a wedged tool so the detached
 // goroutine cannot leak forever.
 const defaultCheckerLegTimeout = 10 * time.Minute
+
+// defaultHardVerifierLegTimeout bounds the detached hard-verifier leg (#474) when
+// the engine's HardVerifierLegTimeout is unset (<= 0). It is a generous ceiling —
+// a real build + full test suite in a fresh checkout can legitimately take many
+// minutes — whose only job is to reap a wedged verifier so the detached goroutine
+// cannot leak forever. A verifier that runs past this is treated as a FAIL (the
+// context-cancelled command returns a non-zero exit), never a hang.
+const defaultHardVerifierLegTimeout = 15 * time.Minute
 
 // nonProgressStreakThreshold returns the configured result-aware non-progress
 // streak threshold, falling back to defaultMaxDelegationNonProgressStreak when
@@ -654,6 +690,27 @@ type Outcome struct {
 	// byte-identical to before this field existed (ADDITIVE: Outcome is an internal
 	// non-wire struct, so this touches no exported contract field or ContractVersion).
 	Objective bool
+
+	// HardVerifier distinguishes a deterministic HARD-verifier outcome (#474) from
+	// BOTH the OBJECTIVE deterministic-checker outcome (#485, Objective:true) and the
+	// SUBJECTIVE cross-family review outcome (#469), again WITHOUT a new OutcomeKind.
+	// It shares Kind == OutcomeReviewed but carries a BINARY pass/fail verdict
+	// (HardPassed) the harvester maps onto EvaluatorScore.Hard (1.0 pass / 0.0 fail) —
+	// an authoritative, un-gameable gate the LLM judge's prose can never move — and
+	// writes under a DISTINCT reviewer sentinel (gitmoot-verifier) + item-id prefix
+	// (hard#) so it coexists with the verifiable floor, the objective checker, and the
+	// subjective review instead of overwriting any of them. It is zero (false) for
+	// every existing path, so those outcomes are byte-identical (ADDITIVE: Outcome is
+	// an internal non-wire struct).
+	HardVerifier bool
+	// HardPassed is the deterministic hard-verifier verdict (#474), meaningful ONLY
+	// when HardVerifier is true: true when EVERY configured verifier command exited 0
+	// in the fresh sandbox (fail-closed set membership), false when ANY command failed
+	// or timed out. The harvester projects true → EvaluatorScore.Hard = 1.0 (strong,
+	// evidence-backed positive) and false → Hard = 0.0 (authoritative gate-fail
+	// negative), so a merge whose code actually fails a clean build/test is caught
+	// even when it merged through an empty (no-CI) gate.
+	HardPassed bool
 }
 
 // OutcomeHarvester is the injected, best-effort, nil-by-default seam (#465, Mode
@@ -4795,6 +4852,15 @@ func (e Engine) runMergeGate(ctx context.Context, reviewer string, payload JobPa
 		// checker-leg failure is swallowed so it can never block or fail the
 		// (already-completed) merge.
 		e.checkDeterministicForMergeGate(ctx, payload, mergedHead)
+		// Deterministic HARD-verifier tier (#474), DETACHED off the blocking AdvanceJob
+		// / daemon-poll path and strictly best-effort, mirroring the review + checker
+		// legs above: a nil dispatcher (the default, no hard_verifiers_enabled) is a
+		// no-op, the operator's build/test commands run in a FRESH sandbox in their own
+		// bounded, cancellation-detached goroutine so a slow suite can never stall
+		// AdvanceJob / the worker tick / the daemon's checkoutLock, and any verifier-leg
+		// failure is swallowed so it can never block or fail the (already-completed)
+		// merge. Its binary pass/fail becomes the authoritative EvaluatorScore.Hard.
+		e.verifyHardForMergeGate(ctx, payload, mergedHead)
 		return decision, nil
 	}
 	return decision, e.setTaskState(ctx, ref, TaskReadyToMerge)
@@ -4951,6 +5017,84 @@ func (e Engine) checkerLegTimeout() time.Duration {
 func (e Engine) spawnCheckerLeg(fn func()) {
 	if e.CheckerSpawner != nil {
 		e.CheckerSpawner(fn)
+		return
+	}
+	go fn()
+}
+
+// verifyHardForMergeGate runs the deterministic HARD-verifier leg for a just-merged
+// PR and harvests its BINARY pass/fail verdict into the SAME auto-trace run as the
+// authoritative EvaluatorScore.Hard (#474). It is nil-safe (no dispatcher => no-op,
+// byte-identical) and best-effort, and mirrors checkDeterministicForMergeGate EXACTLY.
+//
+// CRITICAL: the verifier leg provisions a fresh sandbox and runs the operator's
+// build/test commands, which can take minutes, so it is DETACHED from the caller's
+// path — it runs in its own goroutine (via spawnHardVerifierLeg) under a fresh,
+// cancellation-decoupled context bounded by HardVerifierLegTimeout. This guarantees a
+// slow/wedged verifier can NEVER stall AdvanceJob, the daemon worker tick, or the
+// daemon's checkoutLock, and is reaped by the timeout rather than leaking. A dispatch
+// error is swallowed + recorded as a hard_verifiers_failed job event, NEVER returned
+// up, so a verifier failure can never block or fail a job. The outcome is attributed
+// to the IMPLEMENT job that produced the diff (the same implementJobForTask
+// attribution the merge-gate harvest, review leg, and checker leg use), so the hard
+// row lands on the implementer's template version next to the verifiable floor.
+func (e Engine) verifyHardForMergeGate(ctx context.Context, reviewPayload JobPayload, mergedHead string) {
+	if e.HardVerifierDispatcher == nil || e.OutcomeHarvester == nil {
+		return
+	}
+	// Resolve the owning implement job up front (a cheap store read, no sandbox) so the
+	// detached closure is self-contained. If none resolves, there is nothing to
+	// verify/attribute.
+	job, payload, ok := e.implementJobForTask(ctx, reviewPayload)
+	if !ok {
+		return
+	}
+	e.spawnHardVerifierLeg(func() {
+		// Fresh context decoupled from the caller's ctx (which is cancelled the moment
+		// AdvanceJob returns) yet bounded so a wedged verifier is reaped, not leaked.
+		verifyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), e.hardVerifierLegTimeout())
+		defer cancel()
+		e.runHardVerifierLeg(verifyCtx, job, payload, mergedHead)
+	})
+}
+
+// runHardVerifierLeg performs the actual hard-verifier dispatch + harvest. It is
+// called from the DETACHED goroutine (never on the AdvanceJob path) so its
+// sandbox provision + command runs cannot block job advancement (#474).
+func (e Engine) runHardVerifierLeg(ctx context.Context, job db.Job, payload JobPayload, mergedHead string) {
+	outcome, ok, err := e.HardVerifierDispatcher.Verify(ctx, job, payload, mergedHead)
+	if err != nil {
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "hard_verifiers_failed",
+			Message: err.Error(),
+		})
+		return
+	}
+	if !ok {
+		// No verdict producible (sandbox could not be provisioned, or no commands):
+		// skip silently (no hard row).
+		return
+	}
+	e.harvestOutcome(ctx, job, payload, outcome)
+}
+
+// hardVerifierLegTimeout returns the configured detached-hard-verifier-leg ceiling,
+// defaulting to defaultHardVerifierLegTimeout when unset so a zero-valued Engine
+// keeps a bounded verifier.
+func (e Engine) hardVerifierLegTimeout() time.Duration {
+	if e.HardVerifierLegTimeout > 0 {
+		return e.HardVerifierLegTimeout
+	}
+	return defaultHardVerifierLegTimeout
+}
+
+// spawnHardVerifierLeg runs fn off the caller's path. The default spawns a goroutine
+// (fire-and-forget, like spawnCheckerLeg); tests inject a synchronous runner via the
+// HardVerifierSpawner hook so the detached verifier leg is deterministic.
+func (e Engine) spawnHardVerifierLeg(fn func()) {
+	if e.HardVerifierSpawner != nil {
+		e.HardVerifierSpawner(fn)
 		return
 	}
 	go fn()

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2050,6 +2050,9 @@ func testEngine(store *db.Store) Engine {
 		// Likewise run the detached deterministic-checker leg (#485) synchronously so
 		// its dispatch + harvest are deterministic in tests.
 		CheckerSpawner: func(fn func()) { fn() },
+		// Likewise run the detached hard-verifier leg (#474) synchronously so its
+		// dispatch + harvest are deterministic in tests.
+		HardVerifierSpawner: func(fn func()) { fn() },
 		// Default the #536 physical worktree-process probe to "no live process" so
 		// cleanup tests are not influenced by whatever real processes happen to live
 		// on the host running the suite. Tests exercising the lease-expiry-boundary

--- a/internal/workflow/hard_verifier_test.go
+++ b/internal/workflow/hard_verifier_test.go
@@ -1,0 +1,237 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// recordingHardVerifierDispatcher is a stub HardVerifierDispatcher that records the
+// call and returns a canned hard OutcomeReviewed (or err/skip), so the engine trigger
+// can be tested without a real sandbox.
+type recordingHardVerifierDispatcher struct {
+	called  int
+	jobIDs  []string
+	heads   []string
+	outcome Outcome
+	ok      bool
+	err     error
+}
+
+func (r *recordingHardVerifierDispatcher) Verify(_ context.Context, job db.Job, _ JobPayload, mergedHead string) (Outcome, bool, error) {
+	r.called++
+	r.jobIDs = append(r.jobIDs, job.ID)
+	r.heads = append(r.heads, mergedHead)
+	return r.outcome, r.ok, r.err
+}
+
+// TestEngineDispatchesHardVerifierLegOnMerge proves the hard-verifier leg fires on a
+// merge, attributed to the implement job at the PR head, and its HardVerifier
+// OutcomeReviewed is harvested (#474).
+func TestEngineDispatchesHardVerifierLegOnMerge(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	dispatcher := &recordingHardVerifierDispatcher{
+		ok: true,
+		outcome: Outcome{
+			Kind: OutcomeReviewed, HardVerifier: true, HardPassed: true,
+			Repo: "jerryfane/gitmoot", PullRequest: 7,
+			Rubric: map[string]float64{"go test ./...": 1.0},
+		},
+	}
+	engine.HardVerifierDispatcher = dispatcher
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	if dispatcher.called != 1 {
+		t.Fatalf("hard verifier dispatcher called %d times, want 1", dispatcher.called)
+	}
+	if dispatcher.jobIDs[0] != "implement-job" {
+		t.Fatalf("hard verifier leg attributed to %q, want implement-job", dispatcher.jobIDs[0])
+	}
+	if dispatcher.heads[0] != "head123" {
+		t.Fatalf("hard verifier leg head sha = %q, want the PR head head123", dispatcher.heads[0])
+	}
+	var sawHardReviewed bool
+	kinds := map[OutcomeKind]bool{}
+	for _, o := range harvester.snapshot() {
+		kinds[o.Kind] = true
+		if o.Kind == OutcomeReviewed && o.HardVerifier {
+			sawHardReviewed = true
+		}
+	}
+	if !kinds[OutcomeMerged] {
+		t.Fatalf("harvested kinds = %v, want the merged floor", kinds)
+	}
+	if !sawHardReviewed {
+		t.Fatalf("expected a HardVerifier=true OutcomeReviewed harvest, got %v", harvester.snapshot())
+	}
+}
+
+// TestEngineNilHardVerifierDispatcherIsByteIdentical proves off-by-default: with no
+// HardVerifierDispatcher the merge advances exactly as before and no verifier leg runs.
+func TestEngineNilHardVerifierDispatcherIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine.OutcomeHarvester = &recordingHarvester{}
+	// No HardVerifierDispatcher.
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob with nil hard verifier dispatcher returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+	for _, o := range engine.OutcomeHarvester.(*recordingHarvester).snapshot() {
+		if o.Kind == OutcomeReviewed && o.HardVerifier {
+			t.Fatal("nil hard verifier dispatcher must not produce a hard reviewed outcome")
+		}
+	}
+}
+
+// TestEngineHardVerifierDispatchErrorNeverFailsMerge proves a verifier-leg failure is
+// best-effort: the merge still completes and a hard_verifiers_failed event is recorded
+// on the implement job.
+func TestEngineHardVerifierDispatchErrorNeverFailsMerge(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	engine.OutcomeHarvester = &recordingHarvester{}
+	engine.HardVerifierDispatcher = &recordingHardVerifierDispatcher{err: errors.New("verifier boom")}
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob must not fail on a verifier error, got: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+
+	events, err := store.ListJobEvents(ctx, "implement-job")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	found := false
+	for _, ev := range events {
+		if ev.Kind == "hard_verifiers_failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a hard_verifiers_failed job event, got %+v", events)
+	}
+}
+
+// TestEngineHardVerifierDispatchSkipWritesNothing proves a SKIP (ok=false: no verdict
+// producible) writes no hard row and never errors.
+func TestEngineHardVerifierDispatchSkipWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	engine.HardVerifierDispatcher = &recordingHardVerifierDispatcher{ok: false}
+	seedMergeReviewJobs(t, store)
+
+	if err := engine.AdvanceJob(ctx, "review-job"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+	for _, o := range harvester.snapshot() {
+		if o.Kind == OutcomeReviewed && o.HardVerifier {
+			t.Fatal("a SKIP must not harvest a hard reviewed outcome")
+		}
+	}
+}
+
+// blockingHardVerifierDispatcher blocks inside Verify until released, modeling a
+// wedged test suite.
+type blockingHardVerifierDispatcher struct {
+	started chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingHardVerifierDispatcher) Verify(_ context.Context, _ db.Job, _ JobPayload, _ string) (Outcome, bool, error) {
+	b.once.Do(func() { close(b.started) })
+	<-b.release
+	return Outcome{Kind: OutcomeReviewed, HardVerifier: true, HardPassed: true, Repo: "jerryfane/gitmoot", PullRequest: 7, Rubric: map[string]float64{"go test ./...": 1.0}}, true, nil
+}
+
+// TestEngineHardVerifierLegDoesNotBlockAdvanceJob is the detach regression: even when
+// the verifier blocks indefinitely (a wedged suite), AdvanceJob returns PROMPTLY (the
+// merge completes) because the hard-verifier leg is DETACHED into its own goroutine —
+// it never stalls AdvanceJob, the worker tick, or the daemon's checkoutLock. The
+// detached verifier still runs once unblocked, and the goroutine is race-tested.
+func TestEngineHardVerifierLegDoesNotBlockAdvanceJob(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	// Build an engine with the PRODUCTION default async spawn (no synchronous
+	// HardVerifierSpawner override), so the detached goroutine is exercised for real.
+	engine := Engine{
+		Store: store,
+		JobID: func(request JobRequest) string {
+			return strings.Join([]string{request.Action, request.Agent, request.TaskID}, "-")
+		},
+	}
+	engine.MergeGate = &fakeMergeGate{decision: MergeDecision{Ready: true, Merged: true, MergeCommitSHA: "merge123"}}
+	harvester := &recordingHarvester{}
+	engine.OutcomeHarvester = harvester
+	dispatcher := &blockingHardVerifierDispatcher{started: make(chan struct{}), release: make(chan struct{})}
+	engine.HardVerifierDispatcher = dispatcher
+	seedMergeReviewJobs(t, store)
+
+	done := make(chan error, 1)
+	go func() { done <- engine.AdvanceJob(ctx, "review-job") }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("AdvanceJob returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("AdvanceJob did not return while the verifier was blocked — the hard-verifier leg is NOT detached")
+	}
+	assertTaskState(t, store, "task-7", TaskMerged)
+
+	select {
+	case <-dispatcher.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the detached hard-verifier leg never started")
+	}
+
+	close(dispatcher.release)
+	deadline := time.After(5 * time.Second)
+	for {
+		harvested := false
+		for _, o := range harvester.snapshot() {
+			if o.Kind == OutcomeReviewed && o.HardVerifier {
+				harvested = true
+			}
+		}
+		if harvested {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("the detached verifier never harvested its hard OutcomeReviewed after release")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -353,11 +353,17 @@ grading loop) produces a single **un-gameable `0`/`1`** — the authoritative
 `EvaluatorScore.Hard`. Setting **all three** of `[skillopt].auto_trace_enabled = true`,
 `[skillopt].hard_verifiers_enabled = true`, **and at least one**
 `hard_verifier_commands` line (all default off/empty) runs the operator's configured
-verifier commands in a **fresh, clean sandbox checkout at the merged head** — a
-detached `git worktree` off the daemon checkout, reusing gitmoot's own worktree
-isolation (no E2B / containers / second clone). Each command runs via `sh -c` with its
-**working directory set to the throwaway sandbox**, so it can never touch the real
-checkout; `exit 0 == pass`:
+verifier commands in a **fresh, clean sandbox checkout at the merged head** — an
+**independent local `git clone`** of the daemon checkout (`git clone --local`, so
+objects are hardlinked but the clone gets its **own** git directory: config, refs, gc,
+worktree registry), reusing gitmoot's single-binary git tooling (no E2B / containers /
+network fetch). Because the clone is git-independent, a verifier that shells out to git
+(`git config`, `git update-ref`, `git gc`, `git worktree prune`) is confined to the
+throwaway clone and **cannot mutate the live daemon checkout** — the containment a
+detached `git worktree` off the base could not give (a worktree shares the base's
+object DB, refs, and config). Each command runs via `sh -c` with its **working
+directory set to the throwaway sandbox**, so relative writes and git state alike stay
+inside it; `exit 0 == pass`:
 
 ```toml
 [skillopt]
@@ -376,6 +382,20 @@ authoritative gate-fail, `choice = b`) — a merge whose code actually fails a c
 build/test is caught **even when it merged through an empty gate**, and no LLM judge's
 prose can move it.
 
+:::caution The sandbox is a BARE checkout — commands must self-provision
+It carries only the merged code: **no installed dependencies, build artifacts, or
+generated files**, and only the daemon's ambient PATH. Write each command self-contained
+(`npm ci && npm test`, `pip install -e . && pytest`; `go test ./...` fetches modules
+itself) — a command that assumes a pre-existing `node_modules`/`venv` will fail every
+merge and record a **false `hard = 0`** against a genuinely-good implementer, poisoning
+the optimizer's training signal. Guard rail: a command that cannot be **run at all** (its
+interpreter/binary is absent — a POSIX exit `127` command-not-found, or a missing `sh`)
+is treated as an **environment failure and SKIPS the whole run** (no hard row), so a
+missing toolchain never fabricates a negative. But a command that *runs* and exits
+non-zero *because* deps were missing is an honest `hard = 0` — the skip only covers
+un-runnable commands, so keep each command self-provisioning.
+:::
+
 The verdict is written as a **fourth** `FeedbackEvent` in the SAME
 `auto-trace:<version>` run under a distinct item id (`hard#<repo>#<pr>`) and the fixed
 `gitmoot-verifier` reviewer sentinel — so it **coexists with** (never overwrites) the
@@ -388,10 +408,11 @@ projected `hard_score`, and the per-command `command_results`, while the run kee
 
 The leg runs **off the blocking merge path** (detached, `HardVerifierLegTimeout`-bounded,
 process-group killed so a wedged suite and its grandchildren are reaped) and is
-**fail-safe throughout**: an unprovisionable sandbox or an empty command list yields
-**no hard row** and never errors the harvest, blocks the merge, or stalls
-`AdvanceJob`; a dispatch failure records a `hard_verifiers_failed` job event and is
-swallowed. Because it re-runs the tests, it only maps onto **testable** implement
+**fail-safe throughout**: an unprovisionable sandbox, an empty command list, or a
+command that could not be run at all (missing toolchain) yields **no hard row** and
+never errors the harvest, blocks the merge, or stalls `AdvanceJob`; a dispatch failure
+records a `hard_verifiers_failed` job event and is swallowed. Because it re-runs the
+tests, it only maps onto **testable** implement
 legs — subjective review-quality kinds keep the soft cross-family signal. Promotion
 stays manual.
 

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -195,15 +195,20 @@ mirrors the off-by-default `[events]` stream.
 - **Merged with real CI** (a passing non-`gitmoot/` external status/check at the
   merged head) → strong positive (`soft = 1.0`, `choice = a`).
 - **Merged through an empty gate** (the synthetic `gitmoot/ci` context, or no
-  external CI at head) → **near-neutral** (`soft ≈ 0.5`, `choice = a`), never a
-  strong positive. Rewarding an empty gate would optimize toward "merges that
-  pass no real CI"; the no-CI guard reads the combined status at the merged head
-  SHA and demotes it. (On the merge side, an empty gate is itself deferred by a
-  grace window — a second zero-external observation at the same head at least
-  `[merge_gate] min_ci_wait` later — plus `.github/workflows/` awareness before it
-  ever stamps `gitmoot/ci` (#596), so this near-neutral band applies only to
-  genuinely CI-less heads. Set `[merge_gate] require_external_ci = true` to
-  hard-block an empty gate instead.)
+  external CI at head) → the merge **event** is recorded (`choice = a`) but the
+  quality **score is genuinely absent** (`has_score = false`), **never a
+  fabricated `0.5`** (#474). Rewarding an empty gate would optimize toward "merges
+  that pass no real CI", and inventing a `0.5` midpoint violates the rest of the
+  projection's rule (it returns `has_score = false` when a signal is truly
+  missing). The no-CI guard reads the combined status at the merged head SHA; when
+  the #614/#596 `gitmoot/ci` "no external CI" stamp is present, the reasoning marks
+  it a **confirmed** empty gate (the grace/workflow window elapsed → genuinely no
+  CI, vs. a still-racing zero). To turn a no-CI merge back into a real `0`/`1`
+  quality signal, enable the **hard-verifier tier** below. (On the merge side, an
+  empty gate is itself deferred by a grace window — a second zero-external
+  observation at the same head at least `[merge_gate] min_ci_wait` later — plus
+  `.github/workflows/` awareness before it ever stamps `gitmoot/ci` (#596). Set
+  `[merge_gate] require_external_ci = true` to hard-block an empty gate instead.)
 - **Blocked at the merge gate** → authoritative gate-fail (`hard = 0`,
   `choice = b`).
 - **Review changes_requested** → graded negative (`choice = b`) whose score
@@ -339,6 +344,56 @@ swallowed. Promotion stays manual (the leg writes only `eval_runs` /
 > the PR head, so the tool-backed dimensions are effectively produced only when such
 > a checkout happens to be available; `diff_size` always runs. Plumbing a PR-head
 > worktree through to the tool runners is a documented follow-on.
+
+### Deterministic hard-verifier tier (off by default)
+
+Where the `diff_size`/`lint`/`complexity` checkers above produce **soft** quality
+priors, the **hard-verifier tier** (#474, RFC-informed by THUDM/slime's coding-agent
+grading loop) produces a single **un-gameable `0`/`1`** — the authoritative
+`EvaluatorScore.Hard`. Setting **all three** of `[skillopt].auto_trace_enabled = true`,
+`[skillopt].hard_verifiers_enabled = true`, **and at least one**
+`hard_verifier_commands` line (all default off/empty) runs the operator's configured
+verifier commands in a **fresh, clean sandbox checkout at the merged head** — a
+detached `git worktree` off the daemon checkout, reusing gitmoot's own worktree
+isolation (no E2B / containers / second clone). Each command runs via `sh -c` with its
+**working directory set to the throwaway sandbox**, so it can never touch the real
+checkout; `exit 0 == pass`:
+
+```toml
+[skillopt]
+auto_trace_enabled = true
+hard_verifiers_enabled = true
+hard_verifier_commands = go build ./...
+hard_verifier_commands = go test ./...
+```
+
+`hard_verifier_commands` is **repeatable** — one command per line — so a command may
+itself contain commas / shell operators. The verdict is **fail-closed**: it PASSES
+only when **every** command exits `0` (slime's `fail_to_pass ∪ pass_to_pass ⊆
+passed`). The binary verdict maps onto `EvaluatorScore.Hard`: **pass → `hard = 1.0`**
+(a strong, evidence-backed positive, `choice = a`), **fail → `hard = 0.0`** (an
+authoritative gate-fail, `choice = b`) — a merge whose code actually fails a clean
+build/test is caught **even when it merged through an empty gate**, and no LLM judge's
+prose can move it.
+
+The verdict is written as a **fourth** `FeedbackEvent` in the SAME
+`auto-trace:<version>` run under a distinct item id (`hard#<repo>#<pr>`) and the fixed
+`gitmoot-verifier` reviewer sentinel — so it **coexists with** (never overwrites) the
+verifiable floor (`gitmoot-auto`), the cross-family review (`gitmoot-review`), and the
+objective checker (`gitmoot-checker`); a re-verification re-upserts the SAME hard row
+in place. The hard eval item carries `hard_verifier = true`, `hard_passed`, the
+projected `hard_score`, and the per-command `command_results`, while the run keeps
+`feedback_source = automatic_trace` — additive, **no new contract field,
+`contract_version` stays `1`**.
+
+The leg runs **off the blocking merge path** (detached, `HardVerifierLegTimeout`-bounded,
+process-group killed so a wedged suite and its grandchildren are reaped) and is
+**fail-safe throughout**: an unprovisionable sandbox or an empty command list yields
+**no hard row** and never errors the harvest, blocks the merge, or stalls
+`AdvanceJob`; a dispatch failure records a `hard_verifiers_failed` job event and is
+swallowed. Because it re-runs the tests, it only maps onto **testable** implement
+legs — subjective review-quality kinds keep the soft cross-family signal. Promotion
+stays manual.
 
 ### Promotion policy + notifications (off by default)
 


### PR DESCRIPTION
## Summary

Implements RFC #474: an opt-in, off-by-default deterministic **hard-verifier tier** for the SkillOpt evaluator — the last actionable leg of epic #344's `measure → HARD VERIFIERS → pairwise → jury` reframe.

On a merged implement job, the tier runs the operator's configured build/test/lint **commands** in a **fresh, clean sandbox checkout at the merged head** (a detached `git worktree` — gitmoot's own isolation, no E2B/containers/second clone), where `exit 0 == pass`. The binary pass/fail becomes the authoritative `EvaluatorScore.Hard` — a signal that **cannot be gamed by an LLM judge's prose** (slime-informed cheat-proofing).

## Design

1. **Deterministic hard-verifier tier** (`internal/cli/hard_verifier.go`). A `hardVerifierDispatcher` (new `workflow.HardVerifierDispatcher` seam) provisions a FRESH sandbox via a `sandboxProvisioner` (real impl `worktreeSandboxProvisioner`: detached `git worktree add --detach <tmp> <mergedHead>` off the daemon checkout, force-removed + temp-root-deleted on cleanup), then runs each command via `sh -c` **with the working dir set to the throwaway sandbox** (never the real checkout). Verdict is **fail-closed** — PASS only when *every* command exits 0. The command runner is a `GroupRunner` (process-group SIGTERM→SIGKILL) so a wedged suite **and its grandchildren** (`go test` binaries, `npm`→node) are reaped. The whole leg is DETACHED + best-effort + `HardVerifierLegTimeout`-bounded, mirroring the #485 checker leg exactly, so it can never stall `AdvanceJob` or the daemon `checkoutLock`.

2. **Wired into the evaluator contract as the Hard tier** (`internal/skillopt/hard_verifier.go`). `projectHardVerifier` maps `pass → EvaluatorScore.Hard = 1.0` (choice `a`) and `fail → Hard = 0.0` (choice `b`, an authoritative gate-fail that `ProjectSignal` already treats as an informative 0). The hard row is a **fourth coexisting** auto-trace row (`gitmoot-verifier` reviewer, `hard#<repo>#<pr>` item, carrying `hard_verifier`/`hard_passed`/`hard_score`/`command_results` metadata) alongside the verifiable floor, the subjective review (#469), and the objective checker (#485) — under the same UNIQUE conflict key, so it never overwrites a sibling and a re-verification overwrites itself in place. **Additive to `contract_version = 1`**; off-by-default keeps everything byte-identical.

3. **Fix the trace-harvest fabrication** (`internal/skillopt/trace_harvest.go`). An empty-gate merge no longer fabricates `scoreMergedNoCI = 0.5`. It records the merge EVENT (choice `a`) with a **genuinely-absent quality score** (`HasScore=false`) — matching how the rest of the read-side projection refuses to invent a midpoint. The reasoning is grounded in what the harvester can actually observe: the #614/#596 `gitmoot/ci` "no external CI" stamp distinguishes a **confirmed** empty gate (grace/workflow window elapsed → genuinely no CI) from a still-racing zero. (The merge floor row never persisted the numeric score, so the persisted row is unchanged — choice `a` — this removes the conceptual fabrication and sharpens the honest reasoning.)

## Config (all off by default)

```toml
[skillopt]
auto_trace_enabled = true
hard_verifiers_enabled = true
hard_verifier_commands = go build ./...
hard_verifier_commands = go test ./...
```

`hard_verifier_commands` is **repeatable** (one command per line, so a command may contain commas/shell operators). `HardVerifiersEnabled()` requires `auto_trace_enabled` **AND** `hard_verifiers_enabled` **AND** ≥1 command — so the knob alone, or without commands, is a byte-identical no-op.

## What the tests prove

- **E2E (deterministic, real git worktree sandbox + real `sh`)** — `internal/cli/hard_verifier_test.go`: a fixture repo committed at a known SHA; a real `exit 0` verifier (`test -f marker.txt`, the committed file *is* in the fresh checkout) → PASS → a persisted choice-`a` hard row with `hard_score = 1.0`; a real `exit 1` verifier → FAIL → choice-`b` row with `hard_score = 0.0`. Both flow through the **real** `skillopt.OutcomeHarvester` into `EvaluatorScore.Hard`.
- **Sandbox isolation** — a real verifier that writes `escapee.txt` (relative) leaves the real base checkout untouched (the write landed in the throwaway sandbox, then force-removed).
- **Mutation-red (verified by hand, then reverted):**
  - Inverting the exit-code mapping (`return err == nil` → `return err != nil`) → the pass **and** fail E2E flow tests both go **red**.
  - Breaking the sandbox-fresh guarantee (provisioner returns the real base checkout instead of a fresh worktree) → the isolation test goes **red** (`escapee.txt` leaks into the real checkout).
- **Unit** — dispatcher pass/fail/timeout(real + fake)/empty-inputs/unprovisionable-skip/cleanup-runs/commands-run-in-sandbox-dir; config parse/validate + the three-part gate; projection pass→Hard=1.0 / fail→Hard=0.0, four-row coexistence, metadata round-trip, corrective in-place overwrite; engine leg fires/attributes/detaches/nil-byte-identical/error-fail-safe/skip-writes-nothing; the honest no-CI merge (absent quality + #614-confirmed reasoning) with the three prior 0.5-asserting tests updated.
- **`failed-on-main`**: the trace-harvest fabrication fix is a behavior change (the three no-CI tests asserted the old `0.5`); those assertions are updated to the honest `HasScore=false` + confirmed-empty-gate reasoning.

## Docs

Hard-verifier tier section + the honest no-CI fix added to **both** doc trees (`docs/skillopt-exchange-contract.md`, `website/docs/reference/skillopt-exchange-contract.md`) and the `[skillopt]` config stub (`internal/config/init.go`). No new page added, so `sidebars.ts`/`llms.txt` are unchanged.

## Epic tick

References #344 — this delivers the deep hard-verifier tier (RFC #474). After this merges the epic **cannot close yet**: #347 (rubric induction, blocked on an accumulated human-feedback corpus), #348 Phase 2 (gated on Phase 1 evidence), and the bias/replicate additions surfaced by the "Reliability without Validity" comment (#525/#527) remain open. #474's hard-verifiers box can be struck through.

Closes #474
