### PR TITLE
fix(workflow): release ephemeral delegation branch locks on every terminal state (#617)

### DIFF
--- a/internal/cli/lock.go
+++ b/internal/cli/lock.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -59,19 +60,36 @@ func runLockList(args []string, stdout, stderr io.Writer) int {
 	if !ok {
 		return 2
 	}
-	var locks []db.BranchLock
+	var locks []db.BranchLockInfo
 	if err := withStore(*home, func(store *db.Store) error {
 		var err error
-		locks, err = store.ListBranchLocks(context.Background(), repoFullName)
+		locks, err = store.ListBranchLocksWithAge(context.Background(), repoFullName)
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "lock list: %v\n", err)
 		return 1
 	}
+	// repo, branch, owner, age — surfacing the owner AND how long each lock has been
+	// held makes a stranded lock (e.g. a crashed/departed ephemeral delegation worker,
+	// #617) diagnosable at a glance instead of a silent mystery.
+	now := time.Now().UTC()
 	for _, lock := range locks {
-		fmt.Fprintf(stdout, "%s\t%s\t%s\n", lock.RepoFullName, lock.Branch, lock.Owner)
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", lock.RepoFullName, lock.Branch, lock.Owner, lockAge(lock.CreatedAt, now))
 	}
 	return 0
+}
+
+// lockAge renders a human-readable age for a branch lock's created_at relative to
+// now. A zero/failed-to-parse timestamp renders "age?" rather than a bogus duration.
+func lockAge(createdAt, now time.Time) string {
+	if createdAt.IsZero() {
+		return "age?"
+	}
+	d := now.Sub(createdAt)
+	if d < 0 {
+		d = 0
+	}
+	return d.Round(time.Second).String() + " old"
 }
 
 func runLockShow(args []string, stdout, stderr io.Writer) int {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -5508,6 +5508,65 @@ func (s *Store) ListBranchLocks(ctx context.Context, repoFullName string) ([]Bra
 	return locks, rows.Err()
 }
 
+// BranchLockInfo is a branch lock plus its acquisition timestamps, surfaced by
+// ListBranchLocksWithAge for observability (#617): a stranded lock is only obvious
+// when its owner AND age are visible, so `gitmoot lock list` can show how long each
+// lock has been held and by whom — turning a silent stale-lock mystery into a
+// diagnosable one. CreatedAt/UpdatedAt are parsed best-effort; an unparseable stored
+// timestamp yields a zero time rather than an error.
+type BranchLockInfo struct {
+	BranchLock
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+// parseStoredTimestamp parses a stored SQLite timestamp. Columns defaulted to
+// CURRENT_TIMESTAMP are UTC in "2006-01-02 15:04:05" form; RFC3339[Nano] is also
+// accepted defensively for columns written explicitly. An unrecognized value yields
+// the zero time (callers treat that as "age unknown") rather than an error.
+func parseStoredTimestamp(s string) time.Time {
+	s = strings.TrimSpace(s)
+	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339Nano, time.RFC3339} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// ListBranchLocksWithAge returns the branch locks for repoFullName (all repos when
+// empty) alongside their created_at/updated_at timestamps, ordered like
+// ListBranchLocks. It exists so callers that need to reason about lock AGE (stale
+// stranded-lock detection, #617) do not have to widen the lean BranchLock struct
+// every read path already scans.
+func (s *Store) ListBranchLocksWithAge(ctx context.Context, repoFullName string) ([]BranchLockInfo, error) {
+	query := `SELECT repo_full_name, branch, owner, skip_native_review_fanout, created_at, updated_at FROM branch_locks`
+	args := []any{}
+	if strings.TrimSpace(repoFullName) != "" {
+		query += ` WHERE repo_full_name = ?`
+		args = append(args, repoFullName)
+	}
+	query += ` ORDER BY repo_full_name, branch`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var infos []BranchLockInfo
+	for rows.Next() {
+		var info BranchLockInfo
+		var createdAt, updatedAt string
+		if err := rows.Scan(&info.RepoFullName, &info.Branch, &info.Owner, &info.SkipNativeReviewFanout, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		info.CreatedAt = parseStoredTimestamp(createdAt)
+		info.UpdatedAt = parseStoredTimestamp(updatedAt)
+		infos = append(infos, info)
+	}
+	return infos, rows.Err()
+}
+
 // SetBranchLockReviewFanout persists the skip_native_review_fanout flag onto the
 // branch lock for (repoFullName, branch). It is a no-op when no lock exists for
 // the pair. The flag is never written at lock creation (CreateLock defaults it to

--- a/internal/workflow/delegation_lock_release_617_e2e_test.go
+++ b/internal/workflow/delegation_lock_release_617_e2e_test.go
@@ -1,0 +1,216 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// This file is the end-to-end proof for #617: an ephemeral implement delegation's
+// per-delegation checkout/branch lock (gitmoot-delegation-<parent-short>-<id>-...)
+// must be released when the leg reaches ANY terminal state — success, failed, AND
+// cancelled — symmetric with the CreateLock AllocateDelegationWorktree takes at
+// dispatch. Before the fix the whole fan-out could SUCCEED and still strand every
+// leg's branch lock (no worker process remained to release it), so the next
+// same-repo orchestration mis-read the stale locks as live workers and was refused
+// until a manual `lock release --force`.
+//
+// It drives the REAL engine fan-out (AdvanceJob on a coordinator dispatches the
+// ephemeral implement legs, acquiring one branch lock each) and the REAL terminal
+// transitions (AdvanceJob on a succeeded/failed leg, CancelJob on a queued leg),
+// then asserts on the store's branch_locks table — deterministic, no LLM, no daemon.
+//
+// FAILS ON UNMODIFIED MAIN: the success sub-test asserts ZERO branch locks remain
+// after every leg succeeds; on main the six locks stay held, so it goes RED (this is
+// the bug reproduction).
+//
+// MUTATION: delete the releaseDelegationBranchLock call in
+// cleanupImplementDelegationWorktree (internal/workflow/worktree.go) and the success
+// sub-test goes RED again — the locks are stranded after success exactly as #617
+// reported.
+
+const burst617Repo = "jerryfane/noted"
+
+// fanOutEphemeralImplementBurst inserts a coordinator whose result declares n
+// ephemeral, workspace-write implement delegations (mirroring the issue's six-way
+// codex burst) and drives its AdvanceJob so the engine dispatches every leg —
+// allocating one gitmoot-delegation-* branch lock per leg. It returns the leg job
+// ids in dispatch order. Each leg is left queued, exactly as the daemon would see it
+// before running the worker.
+func fanOutEphemeralImplementBurst(t *testing.T, engine Engine, store *db.Store, coordinatorID string, n int) []string {
+	t.Helper()
+	ctx := context.Background()
+	seedAgent(t, store, "coord-617", []string{"ask"}, burst617Repo)
+
+	dels := make([]Delegation, 0, n)
+	for i := 0; i < n; i++ {
+		dels = append(dels, Delegation{
+			ID:        fmt.Sprintf("impl-%d-command", i),
+			Action:    "implement",
+			Prompt:    "implement a distinct small subcommand and open a PR",
+			Ephemeral: &EphemeralSpec{Runtime: "codex", AutonomyPolicy: "workspace-write"},
+		})
+	}
+	insertCompletedJob(t, store, db.Job{ID: coordinatorID, Agent: "coord-617", Type: "ask"}, JobPayload{
+		Repo:   burst617Repo,
+		Branch: "main",
+		Sender: "coord-617",
+		Result: &AgentResult{Decision: "approved", Summary: "fan out the burst", Delegations: dels},
+	})
+
+	if err := engine.AdvanceJob(ctx, coordinatorID); err != nil {
+		t.Fatalf("AdvanceJob(%s) fan-out returned error: %v", coordinatorID, err)
+	}
+
+	legIDs := make([]string, 0, n)
+	for _, d := range dels {
+		legID := coordinatorID + "/delegation/" + d.ID
+		if !jobExists(t, store, legID) {
+			t.Fatalf("ephemeral implement leg %s was not dispatched", legID)
+		}
+		legIDs = append(legIDs, legID)
+	}
+	return legIDs
+}
+
+func countBranchLocks(t *testing.T, store *db.Store, repo string) int {
+	t.Helper()
+	locks, err := store.ListBranchLocks(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("ListBranchLocks(%s) returned error: %v", repo, err)
+	}
+	return len(locks)
+}
+
+func newBurst617Engine(t *testing.T) (Engine, *db.Store) {
+	t.Helper()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.Home = t.TempDir()
+	engine.DelegationCheckout = t.TempDir()
+	// A fake worktree manager: AllocateDelegationWorktree still writes the REAL branch
+	// lock to the store (that is the entity #617 leaks); the on-disk worktree/branch
+	// are stubbed. existingBranches stays empty so allocation takes the create path.
+	engine.DelegationWorktrees = &fakeWorktreeManager{existingBranches: map[string]bool{}}
+	return engine, store
+}
+
+// TestDelegationBranchLockReleasedOnSuccess_617_E2E is the primary reproduction and
+// the mutation target: a six-way ephemeral implement burst succeeds in full, and
+// every gitmoot-delegation-* branch lock must be gone afterward. On unmodified main
+// (and if the release is mutated out) the locks remain and this goes RED.
+func TestDelegationBranchLockReleasedOnSuccess_617_E2E(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newBurst617Engine(t)
+
+	legIDs := fanOutEphemeralImplementBurst(t, engine, store, "burst-success", 6)
+	if got := countBranchLocks(t, store, burst617Repo); got != 6 {
+		t.Fatalf("after fan-out: %d branch locks held, want 6 (the burst must acquire one per leg)", got)
+	}
+
+	// Every leg succeeds (decision "implemented"), exactly as the issue's fan-out did.
+	for _, legID := range legIDs {
+		completeDelegationChild(t, store, legID, JobSucceeded, AgentResult{Decision: "implemented", Summary: "opened a PR"})
+		if err := engine.AdvanceJob(ctx, legID); err != nil {
+			t.Fatalf("AdvanceJob(%s) on a succeeded leg returned error: %v", legID, err)
+		}
+	}
+
+	if got := countBranchLocks(t, store, burst617Repo); got != 0 {
+		t.Fatalf("#617: %d delegation branch lock(s) still held after the whole burst SUCCEEDED, want 0 — they are stranded with no worker to release them and block the next same-repo burst", got)
+	}
+
+	// The unblock proof: a SECOND same-repo burst dispatches cleanly (fresh locks),
+	// where before the fix the stale locks would have been mis-read as live workers.
+	secondLegs := fanOutEphemeralImplementBurst(t, engine, store, "burst-success-2", 6)
+	if got := countBranchLocks(t, store, burst617Repo); got != 6 {
+		t.Fatalf("second same-repo burst: %d branch locks held, want 6 (the re-burst must be accepted, not refused)", got)
+	}
+	for _, legID := range secondLegs {
+		completeDelegationChild(t, store, legID, JobSucceeded, AgentResult{Decision: "implemented", Summary: "opened a PR"})
+		if err := engine.AdvanceJob(ctx, legID); err != nil {
+			t.Fatalf("AdvanceJob(%s) on second-burst leg returned error: %v", legID, err)
+		}
+	}
+	if got := countBranchLocks(t, store, burst617Repo); got != 0 {
+		t.Fatalf("after the second burst succeeded: %d branch locks still held, want 0", got)
+	}
+}
+
+// TestDelegationBranchLockReleasedOnFailure_617_E2E: a leg that reaches the FAILED
+// terminal state must also release its branch lock. AdvanceJob on a failed leg
+// blocks its (task-less) ref and returns a BlockedError, but the terminal cleanup —
+// and the branch-lock release — fires from the deferred cleanup on every return
+// path, so the lock is still reclaimed.
+func TestDelegationBranchLockReleasedOnFailure_617_E2E(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newBurst617Engine(t)
+
+	legIDs := fanOutEphemeralImplementBurst(t, engine, store, "burst-failed", 6)
+	if got := countBranchLocks(t, store, burst617Repo); got != 6 {
+		t.Fatalf("after fan-out: %d branch locks held, want 6", got)
+	}
+
+	for _, legID := range legIDs {
+		completeDelegationChild(t, store, legID, JobFailed, AgentResult{Decision: "failed", Summary: "boom"})
+		// A failed leg blocks its ref; AdvanceJob may return a BlockedError. The
+		// deferred cleanup (and its branch-lock release) already fired regardless, so
+		// tolerate the error and assert on the released lock below.
+		_ = engine.AdvanceJob(ctx, legID)
+	}
+
+	if got := countBranchLocks(t, store, burst617Repo); got != 0 {
+		t.Fatalf("#617: %d delegation branch lock(s) still held after the burst FAILED, want 0", got)
+	}
+}
+
+// TestDelegationBranchLockReleasedOnCancel_617_E2E: a queued leg cancelled before it
+// runs must release its branch lock too — a cancel bypasses the engine's terminal
+// cleanup entirely (that fires from AdvanceJob), so CancelJob itself must release the
+// lock (#617), or a cancelled burst strands its locks exactly like the success path
+// once did.
+func TestDelegationBranchLockReleasedOnCancel_617_E2E(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newBurst617Engine(t)
+
+	legIDs := fanOutEphemeralImplementBurst(t, engine, store, "burst-cancel", 6)
+	if got := countBranchLocks(t, store, burst617Repo); got != 6 {
+		t.Fatalf("after fan-out: %d branch locks held, want 6", got)
+	}
+
+	for _, legID := range legIDs {
+		if _, err := CancelJob(ctx, store, legID); err != nil {
+			t.Fatalf("CancelJob(%s) returned error: %v", legID, err)
+		}
+	}
+
+	if got := countBranchLocks(t, store, burst617Repo); got != 0 {
+		t.Fatalf("#617: %d delegation branch lock(s) still held after the burst was CANCELLED, want 0", got)
+	}
+}
+
+// TestDelegationBranchLockReleasedOnKill_617_E2E: `gitmoot job kill` cancels the
+// queued legs of a tree before they start; those legs already acquired their branch
+// locks at dispatch, so KillDelegationTree must release them (#617).
+func TestDelegationBranchLockReleasedOnKill_617_E2E(t *testing.T) {
+	ctx := context.Background()
+	engine, store := newBurst617Engine(t)
+
+	// Kill guards on the leg carrying RootJobID != its own id; the fan-out sets
+	// RootJobID to the coordinator, so kill the coordinator's tree.
+	legIDs := fanOutEphemeralImplementBurst(t, engine, store, "burst-kill", 6)
+	if got := countBranchLocks(t, store, burst617Repo); got != 6 {
+		t.Fatalf("after fan-out: %d branch locks held, want 6", got)
+	}
+	_ = legIDs
+
+	if _, err := KillDelegationTree(ctx, store, "burst-kill"); err != nil {
+		t.Fatalf("KillDelegationTree returned error: %v", err)
+	}
+
+	if got := countBranchLocks(t, store, burst617Repo); got != 0 {
+		t.Fatalf("#617: %d delegation branch lock(s) still held after the tree was KILLED, want 0", got)
+	}
+}

--- a/internal/workflow/job_kill.go
+++ b/internal/workflow/job_kill.go
@@ -81,11 +81,29 @@ func KillDelegationTree(ctx context.Context, store *db.Store, jobID string) (db.
 				if p, perr := unmarshalPayload(j.Payload); perr == nil {
 					rootID := strings.TrimSpace(p.RootJobID)
 					if rootID != "" && rootID != j.ID && strings.TrimSpace(p.DelegationID) != "" {
-						_, _ = store.TransitionJobStateWithEvent(ctx, j.ID, string(JobQueued), string(JobCancelled), db.JobEvent{
+						cancelled, _ := store.TransitionJobStateWithEvent(ctx, j.ID, string(JobQueued), string(JobCancelled), db.JobEvent{
 							JobID:   j.ID,
 							Kind:    string(JobCancelled),
 							Message: fmt.Sprintf("delegation tree rooted at %s killed; queued child leg cancelled before start", root.ID),
 						})
+						// (#617) A queued implement leg already allocated its
+						// per-delegation worktree + branch lock at dispatch (allocation
+						// precedes enqueue), and a cancel-before-start bypasses the engine's
+						// terminal cleanupImplementDelegationWorktree, so release the branch
+						// lock here — symmetric with AllocateDelegationWorktree — or the
+						// killed burst strands gitmoot-delegation-* locks that block the next
+						// same-repo orchestration. Only when the transition actually landed:
+						// a leg that raced to running keeps its lock and releases it via its
+						// own terminal cleanup when it finishes. Best-effort.
+						if cancelled {
+							if released, rerr := releaseDelegationBranchLock(ctx, store, j.Type, p); rerr == nil && released {
+								_ = store.AddJobEvent(ctx, db.JobEvent{
+									JobID:   j.ID,
+									Kind:    "delegation_branch_lock_released",
+									Message: fmt.Sprintf("released delegation branch lock %s on delegation kill of tree %s (#617)", strings.TrimSpace(p.Branch), root.ID),
+								})
+							}
+						}
 					}
 				}
 			}

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -167,6 +167,23 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 	// larger change). We swallow the error on purpose: lock cleanup is incidental
 	// and must never make a successful cancel fail.
 	_, _ = store.DeleteResourceLocksByOwner(ctx, job.ID)
+	// Best-effort: an implement delegation leg cancelled here never runs the engine's
+	// terminal cleanupImplementDelegationWorktree (that fires from AdvanceJob, which a
+	// cancel bypasses), so its per-delegation branch lock would otherwise leak exactly
+	// like the success path did before #617. Release it symmetric with
+	// AllocateDelegationWorktree's CreateLock so a cancelled burst does not strand
+	// gitmoot-delegation-* locks that block the next same-repo orchestration. Gated to
+	// worktree-isolated implement legs and swallowed on error: lock cleanup is
+	// incidental and must never make a successful cancel fail.
+	if payload, perr := unmarshalPayload(job.Payload); perr == nil {
+		if released, rerr := releaseDelegationBranchLock(ctx, store, job.Type, payload); rerr == nil && released {
+			_ = store.AddJobEvent(ctx, db.JobEvent{
+				JobID:   job.ID,
+				Kind:    "delegation_branch_lock_released",
+				Message: fmt.Sprintf("released delegation branch lock %s on cancel (#617)", strings.TrimSpace(payload.Branch)),
+			})
+		}
+	}
 	return store.GetJob(ctx, job.ID)
 }
 

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -467,10 +467,40 @@ func isImplementDelegationWorktree(jobType string, payload JobPayload) bool {
 		!readOnlyDelegationAction(jobType) // i.e. jobType == "implement"
 }
 
+// releaseDelegationBranchLock releases the branch lock a worktree-isolated
+// implement delegation leg acquired in AllocateDelegationWorktree (#617), once
+// the leg has reached a terminal state. It is force-scoped by (repo, branch): a
+// gitmoot-delegation-<parent-short>-<id>[-retry-N] branch is unique to exactly one
+// leg, so a force release cannot clobber another job's lock and is robust to any
+// owner drift, while an owner-scoped release could silently miss a lock whose
+// recorded owner no longer matches. It is gated by isImplementDelegationWorktree so
+// it fires ONLY for worktree-isolated implement legs — whose Branch is a real
+// per-delegation branch — and NEVER for the shared-checkout fallback leg, whose
+// Branch is the PARENT branch the coordinator still owns. Best-effort and
+// idempotent: a no-op (released=false, no branch_locks event) once the lock is gone
+// or when the payload lacks the repo/branch identity. Returns whether a lock was
+// actually released this call.
+func releaseDelegationBranchLock(ctx context.Context, store *db.Store, jobType string, payload JobPayload) (bool, error) {
+	if store == nil || !isImplementDelegationWorktree(jobType, payload) {
+		return false, nil
+	}
+	repo := strings.TrimSpace(payload.Repo)
+	branch := strings.TrimSpace(payload.Branch)
+	if repo == "" || branch == "" {
+		return false, nil
+	}
+	_, released, err := store.ForceReleaseLockWithEvent(ctx, repo, branch, db.BranchLockEvent{
+		Kind:    "released",
+		Message: "released after delegation leg reached a terminal state (#617)",
+	})
+	return released, err
+}
+
 // cleanupImplementDelegationWorktree disposes the per-delegation worktree AND
 // deletes the gitmoot-delegation-* branch allocated for an implement delegation
 // child once the child job is terminal, so they do not accumulate in the shared
-// checkout and mislead a later coordinator (#478). It is best-effort and
+// checkout and mislead a later coordinator (#478). It also releases the child's
+// per-delegation branch lock, symmetric with AllocateDelegationWorktree (#617). It is best-effort and
 // idempotent: an already-gone worktree+branch short-circuit to a no-op. Removal
 // and branch deletion mutate the shared .git, so it holds the checkout mutation
 // lock like allocation does. The worktree is removed FIRST so the branch is no
@@ -514,19 +544,36 @@ func (e Engine) cleanupImplementDelegationWorktree(ctx context.Context, jobID st
 		e.recordCleanupSkippedOnce(ctx, jobID, payload, reason)
 		return
 	}
+	// Detach from the caller's cancellation: this runs on the child's terminal
+	// AdvanceJob, which may carry a job context already cancelled by a run timeout.
+	// The worktree must still be disposed, so keep context values but drop the
+	// deadline/cancel.
+	opCtx := context.WithoutCancel(ctx)
+	branch := strings.TrimSpace(payload.Branch)
+	// #617: release the per-delegation branch lock now that this leg is terminal and
+	// has cleared the preserve-guards above (no integration consumer still needs its
+	// branch, no live runtime owner may still push). Symmetric with the CreateLock
+	// AllocateDelegationWorktree took at dispatch — an ephemeral leg's owner process
+	// is gone by the time it is terminal, so nothing else would ever release it. The
+	// leak stranded a gitmoot-delegation-* lock on EVERY terminal state (success
+	// included), and the next same-repo burst mis-read those stale locks as live
+	// workers and was refused. This is a pure branch_locks DELETE (no checkout
+	// mutation lock needed), placed BEFORE the worktree-manager and on-disk
+	// idempotency checks below so the lock is reclaimed even when no manager is wired
+	// or the worktree/branch are already gone. Idempotent: once released it is a
+	// no-op and emits nothing further.
+	if released, rerr := releaseDelegationBranchLock(opCtx, e.Store, jobType, payload); rerr != nil {
+		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("delegation branch lock %s release failed: %v", branch, rerr)})
+	} else if released {
+		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_branch_lock_released", Message: fmt.Sprintf("released delegation branch lock %s after terminal state (#617)", branch)})
+	}
 	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager) // RemoveWorktreeForce
 	if !ok || manager == nil {
 		return
 	}
 	deleter, _ := e.DelegationWorktrees.(BranchDeleter)
 	checker, _ := e.DelegationWorktrees.(BranchExistenceChecker)
-	// Detach from the caller's cancellation: this runs on the child's terminal
-	// AdvanceJob, which may carry a job context already cancelled by a run timeout.
-	// The worktree must still be disposed, so keep context values but drop the
-	// deadline/cancel.
-	opCtx := context.WithoutCancel(ctx)
 	path := strings.TrimSpace(payload.WorktreePath)
-	branch := strings.TrimSpace(payload.Branch)
 	// Idempotency: short-circuit (no lock, no spurious event) once there is nothing
 	// left to do. The pending work is (a) removing the worktree if it still exists
 	// and (b) deleting the branch if a BranchDeleter is wired and the branch is not


### PR DESCRIPTION
## Problem (P0, #617)

An ephemeral implement delegation acquires a per-delegation branch lock (`gitmoot-delegation-<parent-short>-<id>-...`) in `AllocateDelegationWorktree` at dispatch, but **nothing released it symmetrically** when the leg reached a terminal state — **including success**.

- The engine's terminal `cleanupImplementDelegationWorktree` deleted the worktree + git branch but left the `branch_locks` row.
- `CancelJob` / `KillDelegationTree` released only the job-owned *resource* locks, never the *branch* lock.

So a fan-out that fully **succeeded** stranded one lock per leg (`impl-*-ephemeral-*` owner, long gone). The next same-repo orchestration then mis-read the stale locks as live workers and was refused ("burst already active") until a manual `gitmoot lock release --force`. Both the success and cancel paths leaked.

## Design — release at the terminal transition, symmetric with acquisition

New `releaseDelegationBranchLock(store, jobType, payload)` force-releases the `(repo, branch)` lock. Force-scoped is safe: a `gitmoot-delegation-*` branch is unique to exactly one leg (parent-short + id + retry), so it cannot clobber another job's lock and is robust to owner drift. Gated by `isImplementDelegationWorktree`, so the shared-checkout fallback leg (whose `Branch` is the **parent** branch the coordinator still owns) is never touched.

Invoked from the two terminal machineries:

- **`cleanupImplementDelegationWorktree`** — success / failed / daemon reclaim / integration-fed legs. Placed **after** the preserve-guards (the #332 integration-consumer guard and the #536 live-owner gate both `return` before it, so a lock still needed is preserved) and **before** the on-disk idempotency short-circuit, so the lock is reclaimed even when no worktree manager is wired or the worktree/branch are already gone. Pure `branch_locks` DELETE — no checkout mutation lock needed. Idempotent (a re-advance releases nothing and emits nothing).
- **`CancelJob` / `KillDelegationTree`** — a cancel/kill bypasses the engine's terminal cleanup entirely; a queued leg already allocated its lock at dispatch, so these release it too (only for legs whose transition actually landed; a leg that raced to running keeps its lock and releases it via its own terminal cleanup).

### Observability (no silent stale-lock mystery)
`gitmoot lock list` now prints **owner AND age** per lock (`repo  branch  owner  <age> old`) via a new additive `ListBranchLocksWithAge`. If a stale lock ever survives a crash, which one — and how long it's been held and by whom — is diagnosable at a glance.

## What the E2E proves

`internal/workflow/delegation_lock_release_617_e2e_test.go` — deterministic, no LLM, no daemon. It drives the **real engine fan-out** (AdvanceJob on a coordinator dispatches six ephemeral workspace-write implement legs, acquiring one branch lock each) and the **real terminal transitions**, then asserts on the `branch_locks` table:

- `...OnSuccess_617_E2E` — six legs all succeed → **0 locks**; then a **second same-repo burst dispatches cleanly** (accepted, not refused).
- `...OnFailure_617_E2E` — six legs fail → 0 locks (release fires from the deferred cleanup on the block return path).
- `...OnCancel_617_E2E` — six queued legs cancelled → 0 locks.
- `...OnKill_617_E2E` — `KillDelegationTree` on the coordinator → 0 locks.

**Failed on unmodified main:** all four go RED against `origin/main` (verified by reverting the three workflow source files to main — 6 locks stranded in every case).

**Mutation:** delete the `releaseDelegationBranchLock` call in `cleanupImplementDelegationWorktree` → the success assertion goes red again.

## Docs
Troubleshooting entry on stranded delegation locks updated per docs-with-code policy (both trees).

Closes #617