### PR TITLE
fix(workflow): use effective delegation limits in budget pressure

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1506,17 +1506,19 @@ func goalSynthesisClosing(goal string) string {
 // a tree with plenty of headroom prints no line (keeping the prompt clean). A
 // non-positive jobs (the count was unavailable) suppresses the job clause.
 func budgetPressureLine(depth, jobs int) string {
-	nearDepth := depth >= MaxDelegationDepth-budgetPressureSlack
-	nearJobs := jobs > 0 && jobs >= MaxDelegationTotalJobs-budgetPressureSlack
+	maxDepth := effectiveMaxDelegationDepth()
+	maxJobs := effectiveMaxDelegationTotalJobs()
+	nearDepth := depth >= maxDepth-budgetPressureSlack
+	nearJobs := jobs > 0 && jobs >= maxJobs-budgetPressureSlack
 	if !nearDepth && !nearJobs {
 		return ""
 	}
 	if jobs > 0 {
 		return fmt.Sprintf("You are at depth %d/%d and %d/%d jobs — prefer finishing (synthesize now) over re-delegating.\n\n",
-			depth, MaxDelegationDepth, jobs, MaxDelegationTotalJobs)
+			depth, maxDepth, jobs, maxJobs)
 	}
 	return fmt.Sprintf("You are at depth %d/%d — prefer finishing (synthesize now) over re-delegating.\n\n",
-		depth, MaxDelegationDepth)
+		depth, maxDepth)
 }
 
 // budgetPressureSlack is how close to a termination bound (depth or per-root job

--- a/internal/workflow/goal_anchored_finale_test.go
+++ b/internal/workflow/goal_anchored_finale_test.go
@@ -143,6 +143,16 @@ func TestBudgetPressureLine(t *testing.T) {
 	if !strings.Contains(depthOnly, "depth") || strings.Contains(depthOnly, "jobs") {
 		t.Fatalf("expected depth-only nudge with unavailable job count, got %q", depthOnly)
 	}
+
+	t.Setenv("GITMOOT_MAX_DELEGATION_DEPTH", "32")
+	t.Setenv("GITMOOT_MAX_DELEGATION_TOTAL_JOBS", "128")
+	if got := budgetPressureLine(9, 22); got != "" {
+		t.Fatalf("expected no pressure with env-raised limits and headroom, got %q", got)
+	}
+	nearRaised := budgetPressureLine(30, 126)
+	if !strings.Contains(nearRaised, "depth 30/32") || !strings.Contains(nearRaised, "126/128 jobs") {
+		t.Fatalf("expected pressure line to use env-raised limits, got %q", nearRaised)
+	}
 }
 
 // TestNestedContinuationAnchorsGoalFromRoot is the load-bearing depth-stability


### PR DESCRIPTION
## Summary
- make `budgetPressureLine` use the env-aware effective delegation depth and total-job limits
- keep the default behavior unchanged when no env overrides are set
- add a regression for raised limits so the coordinator is not told it is near `8/64` when the effective limits are higher

## Tests
- `go test ./internal/workflow -run 'TestBudgetPressureLine|TestEffectiveDelegationBoundsEnvOverride'`\n- `go test ./internal/workflow`\n