### PR TITLE
chore(dashboard): bump for Runs-inside-Graph UI change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260703234049-cf7bc058fcd2
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704002226-35fdadaa94d4
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260703212304-f15040865a8a h1:nsa
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260703212304-f15040865a8a/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260703234049-cf7bc058fcd2 h1:pI8ydA/87Z8KK0tVb2UCO5F8fw3XYZrwYnmdT8lsOR8=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260703234049-cf7bc058fcd2/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704002226-35fdadaa94d4 h1:l5XQiBqGSejug+QxdtahCrN5/f9a7GqQog3UA8soPig=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704002226-35fdadaa94d4/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to [#22](https://github.com/jerryfane/gitmoot-dashboard/pull/22): the Runs picker moves out of the nav rail and into the Graph view (floating reopen tab on the canvas). UI-only — `go.mod`/`go.sum` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)