### PR TITLE
feat(jobs): dismiss blocked jobs — widen cancel, bulk mode, blocked_ttl sweep, doctor check

### DIFF
--- a/docs/beta-smoke-tests.md
+++ b/docs/beta-smoke-tests.md
@@ -902,9 +902,9 @@ gitmoot lock list --repo owner/project
 gitmoot lock show owner/project <branch>
 ```
 
-Only retry failed, blocked, or cancelled jobs. Only cancel queued or running
-jobs. Use `gitmoot lock release owner/project <branch> --owner <agent>` for an
-exact-owner stale lock; use `--force` only when the stored owner is stale.
+Only retry failed, blocked, or cancelled jobs. Only cancel queued, running, or
+blocked jobs. Use `gitmoot lock release owner/project <branch> --owner <agent>`
+for an exact-owner stale lock; use `--force` only when the stored owner is stale.
 
 ## Known V1 Limits
 

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -43,7 +43,8 @@ gitmoot job list
 gitmoot job show <job-id>
 gitmoot job watch <job-id>
 gitmoot job retry <job-id>
-gitmoot job cancel <job-id>
+gitmoot job cancel <job-id>               # abandon one queued|running|blocked job
+gitmoot job cancel --state blocked --older-than 7d --yes   # bulk-dismiss a blocked backlog (dry-run without --yes)
 gitmoot job kill <root-job-id>            # operator kill switch for a runaway delegation tree
 gitmoot status --repo owner/repo
 gitmoot version --json

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -424,6 +424,30 @@ Fixes:
   `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value
   is 1m — below-1m, malformed, or non-positive values are rejected in favor of
   the 30m default rather than clamped, #560).
+- A backlog of `blocked` jobs (each paused awaiting a human) never clears on its
+  own. Dismiss one with `gitmoot job cancel <job-id>` (cancel now abandons a
+  `blocked` job as well as a `queued`/`running` one; #631), or clear a stale
+  batch with the bulk form:
+
+  ```sh
+  gitmoot job cancel --state blocked --older-than 7d   # dry-run preview
+  gitmoot job cancel --state blocked --older-than 7d --yes
+  ```
+
+  The bulk form is a dry-run by default (it prints id/agent/repo/age and cancels
+  nothing) until you pass `--yes`; narrow it with `--older-than` (a Go duration
+  like `168h`, or a `<N>d` days suffix), `--repo owner/repo`, and `--agent name`.
+  `gitmoot doctor` warns when blocked jobs older than 30d have piled up and prints
+  the exact command. A dismissed job is not lost — `gitmoot job retry` accepts a
+  cancelled job and resurrects it.
+- To sweep the backlog automatically, set `[orchestrate].blocked_ttl` to a
+  positive Go duration (e.g. `blocked_ttl = "168h"`): the daemon then dismisses
+  any blocked job idle longer than the TTL through the same cancel path, recording
+  a `blocked_ttl_expired` job event. It is **off by default** (empty or `0s`
+  disables it; a negative value is rejected), because a blocked job is a
+  human-awaiting decision that is never auto-discarded unless you opt in. This is
+  the single-job counterpart of `[orchestrate].escalation_ttl`, which
+  auto-finalizes a whole paused delegation tree and is on by default (24h).
 
 ## Parallel Implementation And Worktrees
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2504,6 +2504,33 @@ func resolveEscalationTTL(home string) time.Duration {
 	return ttl
 }
 
+// resolveBlockedTTL reads the [orchestrate].blocked_ttl policy (#631) and returns
+// the blocked-job sweep window, or 0 when the sweep is DISABLED. Unlike
+// resolveEscalationTTL it has NO default fallback: an unset/empty (or zero, or
+// unparseable) value resolves to 0 so the sweep stays OFF by default — a blocked
+// job is a human-awaiting decision and is never auto-dismissed unless the operator
+// opted in with a positive duration. It mirrors resolveEscalationTTL's read-only,
+// shape-tolerant config resolution (resolveConfigFile + LoadOrchestratePolicy,
+// never config.Initialize) so it is phantom-free for either a raw --home or an
+// already-resolved <home>/.gitmoot root.
+func resolveBlockedTTL(home string) time.Duration {
+	policy := config.DefaultOrchestratePolicy()
+	if cfg := resolveConfigFile(home); cfg != "" {
+		if loaded, err := config.LoadOrchestratePolicy(config.Paths{ConfigFile: cfg}); err == nil {
+			policy = loaded
+		}
+	}
+	raw := strings.TrimSpace(policy.BlockedTTL)
+	if raw == "" {
+		return 0
+	}
+	ttl, err := time.ParseDuration(raw)
+	if err != nil || ttl <= 0 {
+		return 0
+	}
+	return ttl
+}
+
 func pollRegisteredReposWithPoller(ctx context.Context, poller registeredRepoPoller, schedule registeredRepoSchedule, now time.Time, fallbackPoll time.Duration) (time.Duration, error) {
 	schedule = schedule.ensure()
 	repos, err := poller.Store.ListRepos(ctx)
@@ -2953,6 +2980,72 @@ func recoverExpiredRuntimeSessionLocksSkipping(ctx context.Context, store *db.St
 	return nil
 }
 
+// jobEventBlockedTTLExpired is the job_event kind the blocked_ttl sweep appends
+// after it dismisses a blocked job (#631). It is DISTINCT from the bare
+// "cancelled" event workflow.CancelJob writes so a job's history tells a TTL
+// auto-expiry apart from an operator's explicit `job cancel`.
+const jobEventBlockedTTLExpired = "blocked_ttl_expired"
+
+// sweepExpiredBlockedJobs is the opt-in blocked-job TTL reaper (#631), mirroring
+// recoverExpiredRuntimeSessionLocks's tick cadence. With ttl <= 0 — the DEFAULT,
+// [orchestrate].blocked_ttl unset — it is an immediate no-op: a blocked job is
+// paused awaiting a human, so it is NEVER auto-dismissed unless the operator opted
+// in with a positive duration (so the default path is byte-identical).
+//
+// Otherwise it dismisses every blocked job whose last transition — updated_at,
+// stamped by the blocked transition, falling back to created_at — is older than
+// now-ttl. It routes each dismissal through workflow.CancelJob, the SAME single-row
+// abandon verb an operator's `job cancel` uses, so the job's best-effort lock
+// releases fire; it NEVER raw-writes the cancelled state, which would strand those
+// locks. Each successful dismissal appends a distinct jobEventBlockedTTLExpired
+// event naming the TTL.
+//
+// It is resilient: one job's cancel (or event-append) failure is logged and
+// skipped so it can never abort the rest of the sweep. A job with no parseable
+// timestamp is left alone rather than treated as infinitely old.
+func sweepExpiredBlockedJobs(ctx context.Context, store *db.Store, ttl time.Duration, stdout io.Writer, now time.Time) error {
+	if ttl <= 0 {
+		return nil
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	cutoff := now.Add(-ttl).UnixMilli()
+	swept := 0
+	for _, job := range jobs {
+		if job.State != string(workflow.JobBlocked) {
+			continue
+		}
+		stamped := parseJobTimeMillis(job.UpdatedAt)
+		if stamped == 0 {
+			stamped = parseJobTimeMillis(job.CreatedAt)
+		}
+		if stamped == 0 || stamped >= cutoff {
+			continue
+		}
+		if _, err := workflow.CancelJob(ctx, store, job.ID); err != nil {
+			writeLine(stdout, "blocked_ttl sweep: cancel of blocked job %s failed: %v", job.ID, err)
+			continue
+		}
+		// The cancel already succeeded; the history marker is best-effort (like
+		// CancelJob's own lock-release events) so a failed append is logged but never
+		// undoes the dismissal or aborts the rest of the sweep.
+		if err := store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    jobEventBlockedTTLExpired,
+			Message: fmt.Sprintf("dismissed after blocked_ttl %s elapsed", ttl),
+		}); err != nil {
+			writeLine(stdout, "blocked_ttl sweep: recording expiry event for job %s failed: %v", job.ID, err)
+		}
+		swept++
+	}
+	if swept > 0 {
+		writeLine(stdout, "blocked_ttl sweep: dismissed %d blocked job(s) idle longer than %s", swept, ttl)
+	}
+	return nil
+}
+
 func runDaemonPollWithTimeout(ctx context.Context, timeout time.Duration, poll func(context.Context) error) error {
 	if timeout <= 0 {
 		return poll(ctx)
@@ -3354,6 +3447,16 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	}
 	if err := recoverExpiredRuntimeSessionLocksSkipping(ctx, store, stdout, now, inflightIDs); err != nil {
 		return err
+	}
+	// Opt-in blocked-job TTL reaper (#631): dismiss blocked jobs (paused awaiting a
+	// human) idle longer than [orchestrate].blocked_ttl. Disabled by default (ttl 0
+	// ⇒ immediate no-op), so the default path is byte-identical. A sweep fault is
+	// LOGGED, not returned: this optional housekeeping reaper must never abort the
+	// tick's dispatch or escalate the daemon the way the store-fault recovery scans
+	// above (deliberately) do. Resolved per tick, so the TTL is live-tunable like the
+	// per-repo scheduler override below.
+	if err := sweepExpiredBlockedJobs(ctx, store, resolveBlockedTTL(worker.workflowHome()), stdout, now); err != nil {
+		writeLine(stdout, "blocked_ttl sweep failed: %v", err)
 	}
 	// Checkout-mutating maintenance (advancement/merge retries, delegation
 	// worktree reclaims) is gated on the ACTUAL mutation hazard — each

--- a/internal/cli/daemon_home_shape_test.go
+++ b/internal/cli/daemon_home_shape_test.go
@@ -44,6 +44,24 @@ func initHomeWithEscalationTTL(t *testing.T, ttl string) string {
 	return home
 }
 
+// initHomeWithBlockedTTL writes a real, initialized home with an
+// [orchestrate].blocked_ttl set, returning the raw home root. It writes the
+// config directly (bypassing LoadOrchestratePolicy validation) so a negative or
+// unparseable value can be pinned for the off-by-default resolveBlockedTTL cases.
+func initHomeWithBlockedTTL(t *testing.T, ttl string) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	body := "[orchestrate]\nblocked_ttl = \"" + ttl + "\"\n"
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return home
+}
+
 func assertNoPhantom(t *testing.T, home string) {
 	t.Helper()
 	if _, err := os.Stat(phantomDir(home)); !os.IsNotExist(err) {
@@ -120,6 +138,61 @@ func TestResolveEscalationTTLTable(t *testing.T) {
 	// Zero filesystem side effects: neither home grew a phantom doubled root.
 	assertNoPhantom(t, present)
 	assertNoPhantom(t, absent)
+}
+
+// BLOCKED TTL (#631): resolveBlockedTTL shares resolveEscalationTTL's shape-tolerant,
+// side-effect-free config resolution but has NO default fallback — the sweep is OFF
+// unless the operator opted in with a positive duration. This pins that contract
+// (positive -> duration; unset/zero/negative/unparseable -> 0) AND the home-shape
+// invariant the #446/#459 seam shares: a raw --home and the already-resolved
+// <home>/.gitmoot root resolve identically with no phantom doubled home.
+func TestResolveBlockedTTLShapeTolerantNoPhantom(t *testing.T) {
+	// A positive TTL resolves identically for BOTH the raw --home and the resolved
+	// <home>/.gitmoot root, creating no phantom in either case.
+	positive := initHomeWithBlockedTTL(t, "48h")
+	positiveResolved := config.PathsForHome(positive).Home
+
+	rawTTL := resolveBlockedTTL(positive)
+	if rawTTL != 48*time.Hour {
+		t.Fatalf("resolveBlockedTTL(raw) = %s, want 48h", rawTTL)
+	}
+	assertNoPhantom(t, positive)
+
+	resolvedTTL := resolveBlockedTTL(positiveResolved)
+	if resolvedTTL != 48*time.Hour {
+		t.Fatalf("resolveBlockedTTL(resolved) = %s, want 48h", resolvedTTL)
+	}
+	assertNoPhantom(t, positive)
+	if rawTTL != resolvedTTL {
+		t.Fatalf("blocked_ttl differs across home shapes: raw=%s resolved=%s", rawTTL, resolvedTTL)
+	}
+
+	// Off-by-default: an unset value, an explicit zero, a negative (rejected by
+	// LoadOrchestratePolicy, leaving the empty default), and an unparseable duration
+	// all resolve to 0 so the sweep stays disabled.
+	unset := t.TempDir()
+	if err := config.Initialize(config.PathsForHome(unset)); err != nil {
+		t.Fatalf("Initialize unset: %v", err)
+	}
+	cases := []struct {
+		name string
+		home string
+	}{
+		{"unset-raw", unset},
+		{"unset-resolved", config.PathsForHome(unset).Home},
+		{"zero", initHomeWithBlockedTTL(t, "0s")},
+		{"negative", initHomeWithBlockedTTL(t, "-1h")},
+		{"unparseable", initHomeWithBlockedTTL(t, "soon")},
+		{"empty", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveBlockedTTL(tc.home); got != 0 {
+				t.Fatalf("resolveBlockedTTL(%q) = %s, want 0 (sweep disabled)", tc.home, got)
+			}
+		})
+	}
+	assertNoPhantom(t, unset)
 }
 
 // PHANTOM producer #2 (durable hardening): the read-only policy loaders must

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -5007,6 +5007,188 @@ func TestRecoverExpiredRuntimeSessionLocksRequeuesOwnerBeforeGlobalStaleWindow(t
 	}
 }
 
+// blockedTTLTestStore builds a fresh store on a retained home so the blocked_ttl
+// sweep tests can backdate a blocked job's updated_at through a second raw
+// connection (there is no store setter for updated_at; the blocked transition
+// stamps CURRENT_TIMESTAMP). It mirrors daemonWorkerStore but returns paths.
+func blockedTTLTestStore(t *testing.T) (*db.Store, config.Paths) {
+	t.Helper()
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+	return store, paths
+}
+
+// backdateJobUpdatedAt rewrites a job's updated_at to an explicit SQLite-UTC
+// timestamp through a raw connection, so a blocked job can be aged past the sweep
+// window deterministically without a wall-clock sleep.
+func backdateJobUpdatedAt(t *testing.T, dbPath, jobID string, when time.Time) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open returned error: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(context.Background(), `UPDATE jobs SET updated_at = ? WHERE id = ?`, when.UTC().Format("2006-01-02 15:04:05"), jobID); err != nil {
+		t.Fatalf("backdate updated_at returned error: %v", err)
+	}
+}
+
+// TestSweepExpiredBlockedJobsCancelsOnlyOlderThanTTL pins #631: with a positive
+// TTL the sweep dismisses only the blocked job aged past now-ttl (via CancelJob,
+// so it lands in cancelled with a distinct blocked_ttl_expired history event),
+// leaving a recently-blocked job and its history untouched.
+func TestSweepExpiredBlockedJobsCancelsOnlyOlderThanTTL(t *testing.T) {
+	ctx := context.Background()
+	store, paths := blockedTTLTestStore(t)
+	for _, id := range []string{"job-old", "job-recent"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+		if err := store.UpdateJobState(ctx, id, string(workflow.JobBlocked)); err != nil {
+			t.Fatalf("UpdateJobState(%s) returned error: %v", id, err)
+		}
+	}
+	now := time.Now().UTC()
+	// job-old blocked two hours ago (past the 1h TTL); job-recent stays at ~now.
+	backdateJobUpdatedAt(t, paths.Database, "job-old", now.Add(-2*time.Hour))
+
+	if err := sweepExpiredBlockedJobs(ctx, store, time.Hour, io.Discard, now); err != nil {
+		t.Fatalf("sweepExpiredBlockedJobs returned error: %v", err)
+	}
+
+	old, err := store.GetJob(ctx, "job-old")
+	if err != nil {
+		t.Fatalf("GetJob(job-old) returned error: %v", err)
+	}
+	if old.State != string(workflow.JobCancelled) {
+		t.Fatalf("job-old state = %q, want cancelled", old.State)
+	}
+	oldEvents, err := store.ListJobEvents(ctx, "job-old")
+	if err != nil {
+		t.Fatalf("ListJobEvents(job-old) returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(oldEvents, jobEventBlockedTTLExpired) {
+		t.Fatalf("job-old events = %+v, want a %s event", oldEvents, jobEventBlockedTTLExpired)
+	}
+	if !daemonWorkerHasEvent(oldEvents, string(workflow.JobCancelled)) {
+		t.Fatalf("job-old events = %+v, want the CancelJob cancelled event too", oldEvents)
+	}
+
+	recent, err := store.GetJob(ctx, "job-recent")
+	if err != nil {
+		t.Fatalf("GetJob(job-recent) returned error: %v", err)
+	}
+	if recent.State != string(workflow.JobBlocked) {
+		t.Fatalf("job-recent state = %q, want blocked (untouched)", recent.State)
+	}
+	recentEvents, err := store.ListJobEvents(ctx, "job-recent")
+	if err != nil {
+		t.Fatalf("ListJobEvents(job-recent) returned error: %v", err)
+	}
+	if daemonWorkerHasEvent(recentEvents, jobEventBlockedTTLExpired) {
+		t.Fatalf("job-recent events = %+v, want no %s event", recentEvents, jobEventBlockedTTLExpired)
+	}
+}
+
+// TestSweepExpiredBlockedJobsDisabledSweepsNothing pins the off-by-default
+// contract (#631): with ttl <= 0 the sweep is an immediate no-op even for a
+// long-blocked job, so a human-awaiting decision is never silently discarded.
+func TestSweepExpiredBlockedJobsDisabledSweepsNothing(t *testing.T) {
+	ctx := context.Background()
+	store, paths := blockedTTLTestStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-blocked", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-blocked", string(workflow.JobBlocked)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	now := time.Now().UTC()
+	backdateJobUpdatedAt(t, paths.Database, "job-blocked", now.Add(-30*24*time.Hour))
+
+	if err := sweepExpiredBlockedJobs(ctx, store, 0, io.Discard, now); err != nil {
+		t.Fatalf("sweepExpiredBlockedJobs returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-blocked")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state = %q, want blocked (sweep disabled)", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-blocked")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if daemonWorkerHasEvent(events, jobEventBlockedTTLExpired) {
+		t.Fatalf("events = %+v, want no %s event when disabled", events, jobEventBlockedTTLExpired)
+	}
+}
+
+// TestRunDaemonWorkerTickBlockedTTLSweepsAgedBlockedJob closes the config-path
+// wiring gap for #631: the direct sweep tests above pass the TTL in literally, so
+// they never exercise resolveBlockedTTL(worker.workflowHome()) or the tick call that
+// feeds it. Here a configured [orchestrate].blocked_ttl must reach the tick's sweep
+// end-to-end and cancel a blocked job aged past the window — proving the config ->
+// resolve -> sweep seam (the #446/#459 home-resolution path) is wired, not just that
+// sweepExpiredBlockedJobs works when handed a TTL.
+func TestRunDaemonWorkerTickBlockedTTLSweepsAgedBlockedJob(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	// Opt into the sweep with a 1h window (disabled by default).
+	if err := os.WriteFile(paths.ConfigFile, []byte("[orchestrate]\nblocked_ttl = \"1h\"\n"), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	})
+
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-blocked", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	if err := store.UpdateJobState(ctx, "job-blocked", string(workflow.JobBlocked)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	now := time.Now().UTC()
+	// Aged two hours ago, past the configured 1h window.
+	backdateJobUpdatedAt(t, paths.Database, "job-blocked", now.Add(-2*time.Hour))
+
+	worker := defaultJobWorker(store, io.Discard, home)
+	if err := runDaemonWorkerTick(ctx, store, worker, 0, false, "", "", io.Discard, now); err != nil {
+		t.Fatalf("runDaemonWorkerTick returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-blocked")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled (blocked_ttl sweep driven by tick)", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-blocked")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, jobEventBlockedTTLExpired) {
+		t.Fatalf("events = %+v, want a %s event", events, jobEventBlockedTTLExpired)
+	}
+}
+
 // TestRecoverRunningJobsHonorsLiveRuntimeLease is the #536 regression: a
 // long-running job (e.g. a 4h delegation) holds a runtime-session lock whose LEASE
 // reflects its real job timeout. The coarse `updated_at < before` staleness

--- a/internal/cli/doctor_blocked_jobs.go
+++ b/internal/cli/doctor_blocked_jobs.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/doctor"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// blockedBacklogDoctorThreshold is the age past which a blocked job (one paused
+// awaiting a human) counts as a stale backlog worth surfacing in `gitmoot
+// doctor`. A blocked job never ends on its own, so a month-old one is almost
+// always abandonable with `job cancel --state blocked` (#631).
+const blockedBacklogDoctorThreshold = 720 * time.Hour // 30 days
+
+// blockedBacklogDoctorCheck counts blocked jobs older than the threshold and, if
+// the home's store can be opened read-only, returns a doctor.Check reporting the
+// backlog. It is best-effort — an unset database path or an unopenable store
+// (no initialized home) yields ok=false so `gitmoot doctor` falls back to its
+// other checks rather than going red on a box that has no Gitmoot home yet. The
+// open is read-only so the diagnostic never creates or migrates a home.
+func blockedBacklogDoctorCheck(paths config.Paths) (doctor.Check, bool) {
+	if strings.TrimSpace(paths.Database) == "" {
+		return doctor.Check{}, false
+	}
+	store, err := db.OpenReadOnly(paths.Database)
+	if err != nil {
+		return doctor.Check{}, false
+	}
+	defer store.Close()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		return doctor.Check{}, false
+	}
+	return buildBlockedBacklogCheck(jobs, time.Now(), blockedBacklogDoctorThreshold), true
+}
+
+// buildBlockedBacklogCheck renders the blocked-jobs doctor line from a job set:
+// no blocked jobs older than the threshold is an ok line; any older ones are a
+// non-required warn carrying the exact bulk-dismiss command (#631). Age uses the
+// same updated_at basis (the blocked-transition timestamp, with a created_at
+// fallback) as the bulk cancel selection, so doctor and `job cancel` agree on
+// which jobs are "older than 30d".
+func buildBlockedBacklogCheck(jobs []db.Job, now time.Time, threshold time.Duration) doctor.Check {
+	cutoff := now.Add(-threshold).UnixMilli()
+	count := 0
+	for _, job := range jobs {
+		if job.State != string(workflow.JobBlocked) {
+			continue
+		}
+		age := blockedJobAgeMillis(job)
+		if age > 0 && age <= cutoff {
+			count++
+		}
+	}
+	if count == 0 {
+		return doctor.Check{Name: "blocked jobs", OK: true, Required: false, Detail: "no blocked jobs older than 30d"}
+	}
+	return doctor.Check{
+		Name:     "blocked jobs",
+		Required: false,
+		Detail:   fmt.Sprintf("%d blocked jobs older than 30d — dismiss with: gitmoot job cancel --state blocked --older-than 30d --yes", count),
+	}
+}

--- a/internal/cli/doctor_blocked_jobs_test.go
+++ b/internal/cli/doctor_blocked_jobs_test.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestDoctorBlockedBacklogCheckClassifies pins the blocked-jobs doctor line
+// (#631): a job set with no blocked jobs older than the threshold is an ok line;
+// any older ones are a non-required warn carrying the exact bulk-dismiss command.
+// Recent blocked jobs and old non-blocked jobs never count.
+func TestDoctorBlockedBacklogCheckClassifies(t *testing.T) {
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	const layout = "2006-01-02 15:04:05"
+	at := func(age time.Duration) string { return now.Add(-age).Format(layout) }
+
+	t.Run("no stale blocked jobs is ok", func(t *testing.T) {
+		jobs := []db.Job{
+			{ID: "blocked-recent", State: string(workflow.JobBlocked), UpdatedAt: at(24 * time.Hour)},
+			{ID: "failed-old", State: string(workflow.JobFailed), UpdatedAt: at(90 * 24 * time.Hour)},
+		}
+		check := buildBlockedBacklogCheck(jobs, now, blockedBacklogDoctorThreshold)
+		if check.Name != "blocked jobs" || !check.OK || check.Required {
+			t.Fatalf("check = %+v, want optional ok 'blocked jobs'", check)
+		}
+		if check.Detail != "no blocked jobs older than 30d" {
+			t.Fatalf("ok detail = %q", check.Detail)
+		}
+	})
+
+	t.Run("stale blocked jobs warn with the dismiss command", func(t *testing.T) {
+		jobs := []db.Job{
+			{ID: "blocked-old-a", State: string(workflow.JobBlocked), UpdatedAt: at(31 * 24 * time.Hour)},
+			{ID: "blocked-old-b", State: string(workflow.JobBlocked), UpdatedAt: at(90 * 24 * time.Hour)},
+			{ID: "blocked-recent", State: string(workflow.JobBlocked), UpdatedAt: at(24 * time.Hour)},
+			{ID: "failed-old", State: string(workflow.JobFailed), UpdatedAt: at(90 * 24 * time.Hour)},
+		}
+		check := buildBlockedBacklogCheck(jobs, now, blockedBacklogDoctorThreshold)
+		if check.OK || check.Required {
+			t.Fatalf("check = %+v, want a non-required warn", check)
+		}
+		if !strings.Contains(check.Detail, "2 blocked jobs older than 30d") {
+			t.Fatalf("warn detail = %q, want the stale count", check.Detail)
+		}
+		if !strings.Contains(check.Detail, "gitmoot job cancel --state blocked --older-than 30d --yes") {
+			t.Fatalf("warn detail = %q, want the bulk-dismiss command", check.Detail)
+		}
+	})
+}
+
+// TestDoctorBlockedBacklogCheckReadsStore exercises the store-backed wrapper end
+// to end: it seeds a home with a stale blocked job and a recent one, opens the
+// store read-only, and asserts doctor warns about exactly the stale one. A missing
+// home is fail-open (ok=false) so doctor never goes red on an uninitialized box.
+func TestDoctorBlockedBacklogCheckReadsStore(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	for _, f := range []struct {
+		id, state string
+		age       time.Duration
+	}{
+		{"blocked-stale", string(workflow.JobBlocked), 45 * 24 * time.Hour},
+		{"blocked-fresh", string(workflow.JobBlocked), 2 * 24 * time.Hour},
+	} {
+		seedCLIJob(t, store, db.Job{
+			ID:      f.id,
+			Agent:   "audit",
+			Type:    "ask",
+			State:   f.state,
+			Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main"}),
+		}, f.state)
+	}
+	store.Close()
+	now := time.Now().UTC()
+	const layout = "2006-01-02 15:04:05"
+	setJobTimes(t, home, "blocked-stale", now.Add(-45*24*time.Hour).Format(layout), now.Add(-45*24*time.Hour).Format(layout))
+	setJobTimes(t, home, "blocked-fresh", now.Add(-2*24*time.Hour).Format(layout), now.Add(-2*24*time.Hour).Format(layout))
+
+	check, ok := blockedBacklogDoctorCheck(config.PathsForHome(home))
+	if !ok {
+		t.Fatal("blockedBacklogDoctorCheck ok=false for an initialized home, want a check")
+	}
+	if check.OK || check.Required {
+		t.Fatalf("check = %+v, want a non-required warn for one stale blocked job", check)
+	}
+	if !strings.Contains(check.Detail, "1 blocked jobs older than 30d") {
+		t.Fatalf("warn detail = %q, want exactly the stale count", check.Detail)
+	}
+
+	if _, ok := blockedBacklogDoctorCheck(config.PathsForHome(t.TempDir())); ok {
+		t.Fatal("blockedBacklogDoctorCheck ok=true for an uninitialized home, want fail-open skip")
+	}
+}

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -54,6 +55,7 @@ func printJobUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot job run <id>")
 	fmt.Fprintln(w, "  gitmoot job retry <id>")
 	fmt.Fprintln(w, "  gitmoot job cancel <id>")
+	fmt.Fprintln(w, "  gitmoot job cancel --state blocked [--older-than 168h|7d] [--repo owner/repo] [--agent name] [--yes]")
 	fmt.Fprintln(w, "  gitmoot job kill <root-job-id>")
 }
 
@@ -393,18 +395,77 @@ func runJobRetry(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+// runJobCancel dismisses jobs (#631). It has two forms sharing the abandon verb
+// workflow.CancelJob (which releases the job's locks — a bulk sweep must never
+// bypass it with a raw store write):
+//
+//	single: gitmoot job cancel <id>
+//	bulk:   gitmoot job cancel --state blocked [--older-than DUR] [--repo R] [--agent A] [--yes]
+//
+// Bulk mode activates when --state is set; a positional <id> is then mutually
+// exclusive with it. The bulk sub-filters (--older-than/--repo/--agent) require
+// --state. Bulk mode is a DRY-RUN by default (prints the selection); --yes commits.
 func runJobCancel(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("job cancel", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	fs.Usage = func() { printJobUsage(stderr) }
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	jobID, ok := parseSingleJobID(fs, args, stderr, "job cancel")
-	if !ok {
-		return parseSingleJobIDExitCode(args)
+	state := fs.String("state", "", "bulk mode: cancel every job in this state (only \"blocked\" is supported)")
+	olderThan := fs.String("older-than", "", "bulk mode: only jobs at least this old (Go duration like 168h, or a <N>d days suffix)")
+	repo := fs.String("repo", "", "bulk mode: only jobs whose payload repo is owner/repo")
+	agent := fs.String("agent", "", "bulk mode: only jobs for this agent")
+	yes := fs.Bool("yes", false, "bulk mode: actually cancel the selection (default is a dry-run preview)")
+
+	if len(args) > 0 && (args[0] == "-h" || args[0] == "--help") {
+		fs.Usage()
+		return 0
+	}
+	// The single form allows flags after the positional id (job cancel <id>
+	// --home X), matching the other single-id job subcommands, so pull a leading
+	// positional out before flag parsing lets those trailing flags bind. A
+	// positional that trails the flags (bulk-flag ordering) is caught by NArg below.
+	positional := ""
+	parseArgs := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		positional = args[0]
+		parseArgs = args[1:]
+	}
+	if err := fs.Parse(parseArgs); err != nil {
+		return 2
+	}
+	extra := fs.Args()
+	if positional == "" && len(extra) > 0 {
+		positional = extra[0]
+		extra = extra[1:]
+	}
+	if len(extra) > 0 {
+		fmt.Fprintf(stderr, "job cancel: unexpected argument %q\n", extra[0])
+		printJobUsage(stderr)
+		return 2
+	}
+
+	if strings.TrimSpace(*state) != "" {
+		if strings.TrimSpace(positional) != "" {
+			fmt.Fprintln(stderr, "job cancel: <id> and --state are mutually exclusive (bulk mode cancels a selection, not one job)")
+			return 2
+		}
+		return runJobCancelBulk(*home, *state, *olderThan, *repo, *agent, *yes, stdout, stderr)
+	}
+
+	// Single form. The bulk sub-filters only make sense alongside --state.
+	if strings.TrimSpace(*olderThan) != "" || strings.TrimSpace(*repo) != "" || strings.TrimSpace(*agent) != "" {
+		fmt.Fprintln(stderr, "job cancel: --older-than, --repo, and --agent require --state")
+		return 2
+	}
+	if strings.TrimSpace(positional) == "" {
+		fmt.Fprintln(stderr, "job cancel requires exactly one id (or --state for bulk mode)")
+		printJobUsage(stderr)
+		return 2
 	}
 	var job db.Job
 	if err := withStore(*home, func(store *db.Store) error {
 		var err error
-		job, err = workflow.CancelJob(context.Background(), store, jobID)
+		job, err = workflow.CancelJob(context.Background(), store, positional)
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "job cancel: %v\n", err)
@@ -412,6 +473,194 @@ func runJobCancel(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "cancelled job %s\n", job.ID)
 	return 0
+}
+
+// runJobCancelBulk selects the blocked jobs matching the filters and either
+// previews them (dry-run default) or cancels each via workflow.CancelJob (#631).
+// Only "blocked" is accepted for --state: a blocked job is paused awaiting a
+// human, so a stale backlog of them is the intended abandon target; other states
+// have their own verbs (queued/running -> single cancel, terminal -> retry).
+func runJobCancelBulk(home, stateFilter, olderThanArg, repoFilter, agentFilter string, apply bool, stdout, stderr io.Writer) int {
+	stateFilter = strings.TrimSpace(stateFilter)
+	if !strings.EqualFold(stateFilter, string(workflow.JobBlocked)) {
+		fmt.Fprintf(stderr, "job cancel: --state %q is not supported; only \"blocked\" jobs can be bulk-cancelled (blocked = paused awaiting a human)\n", stateFilter)
+		return 2
+	}
+	var (
+		filterByAge  bool
+		cutoffMillis int64
+	)
+	now := time.Now()
+	if arg := strings.TrimSpace(olderThanArg); arg != "" {
+		age, err := parseOlderThanDuration(arg)
+		if err != nil {
+			fmt.Fprintf(stderr, "job cancel: invalid --older-than %q: %v\n", arg, err)
+			return 2
+		}
+		if age > 0 {
+			filterByAge = true
+			cutoffMillis = now.Add(-age).UnixMilli()
+		}
+	}
+	repoFilter = strings.TrimSpace(repoFilter)
+	agentFilter = strings.TrimSpace(agentFilter)
+
+	var (
+		selected []db.Job
+		results  []jobCancelResult
+	)
+	if err := withStore(home, func(store *db.Store) error {
+		jobs, err := store.ListJobs(context.Background())
+		if err != nil {
+			return err
+		}
+		selected = selectBlockedJobsForCancel(jobs, repoFilter, agentFilter, filterByAge, cutoffMillis)
+		if apply {
+			for _, job := range selected {
+				_, cerr := workflow.CancelJob(context.Background(), store, job.ID)
+				results = append(results, jobCancelResult{id: job.ID, err: cerr})
+			}
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "job cancel: %v\n", err)
+		return 1
+	}
+
+	if len(selected) == 0 {
+		fmt.Fprintln(stdout, "no blocked jobs match the filter")
+		return 0
+	}
+
+	if !apply {
+		fmt.Fprintln(stdout, "ID\tAGENT\tREPO\tAGE")
+		for _, job := range selected {
+			payload, _ := workflow.ParseJobPayload(job.Payload)
+			fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\n", job.ID, job.Agent, payload.Repo, humanizeJobAge(job, now))
+		}
+		fmt.Fprintf(stdout, "run again with --yes to cancel %d jobs\n", len(selected))
+		return 0
+	}
+
+	failed := 0
+	for _, res := range results {
+		if res.err != nil {
+			fmt.Fprintf(stdout, "%s\tERROR: %v\n", res.id, res.err)
+			failed++
+			continue
+		}
+		fmt.Fprintf(stdout, "%s\tcancelled\n", res.id)
+	}
+	fmt.Fprintf(stdout, "cancelled %d of %d\n", len(results)-failed, len(results))
+	if failed > 0 {
+		return 1
+	}
+	return 0
+}
+
+// jobCancelResult pairs a bulk-cancelled job id with the outcome of its
+// per-job workflow.CancelJob call.
+type jobCancelResult struct {
+	id  string
+	err error
+}
+
+// selectBlockedJobsForCancel filters the job set to blocked jobs matching the
+// optional repo/agent filters and (when filterByAge) an updated_at at or before
+// cutoffMillis, ordered oldest-first with an id tie-break for a deterministic
+// preview and cancel order. Age falls back to created_at when updated_at is
+// absent; a job with no parseable timestamp is excluded once an age filter is set.
+func selectBlockedJobsForCancel(jobs []db.Job, repoFilter, agentFilter string, filterByAge bool, cutoffMillis int64) []db.Job {
+	selected := make([]db.Job, 0, len(jobs))
+	for _, job := range jobs {
+		if job.State != string(workflow.JobBlocked) {
+			continue
+		}
+		if agentFilter != "" && job.Agent != agentFilter {
+			continue
+		}
+		if repoFilter != "" {
+			payload, err := workflow.ParseJobPayload(job.Payload)
+			if err != nil || payload.Repo != repoFilter {
+				continue
+			}
+		}
+		if filterByAge {
+			age := blockedJobAgeMillis(job)
+			if age <= 0 || age > cutoffMillis {
+				continue
+			}
+		}
+		selected = append(selected, job)
+	}
+	sort.Slice(selected, func(i, j int) bool {
+		ai, aj := blockedJobAgeMillis(selected[i]), blockedJobAgeMillis(selected[j])
+		if ai != aj {
+			return ai < aj
+		}
+		return selected[i].ID < selected[j].ID
+	})
+	return selected
+}
+
+// blockedJobAgeMillis is a blocked job's age basis in epoch ms: updated_at
+// (stamped by the blocked transition) with a created_at fallback. Returns 0 when
+// neither timestamp parses.
+func blockedJobAgeMillis(job db.Job) int64 {
+	if ms := parseJobTimeMillis(job.UpdatedAt); ms > 0 {
+		return ms
+	}
+	return parseJobTimeMillis(job.CreatedAt)
+}
+
+// humanizeJobAge renders how long a job has sat as a compact "24d"/"3h"/"5m"/"2s"
+// label relative to now. Unknown (unparseable) ages render "?".
+func humanizeJobAge(job db.Job, now time.Time) string {
+	ms := blockedJobAgeMillis(job)
+	if ms <= 0 {
+		return "?"
+	}
+	d := now.Sub(time.UnixMilli(ms))
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours())/24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	default:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+}
+
+// parseOlderThanDuration parses a --older-than value: a Go duration (e.g. 168h)
+// plus a convenience "<N>d" days suffix (N*24h). A negative value is rejected.
+func parseOlderThanDuration(value string) (time.Duration, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, nil
+	}
+	if days, ok := strings.CutSuffix(value, "d"); ok {
+		n, err := strconv.Atoi(strings.TrimSpace(days))
+		if err != nil {
+			return 0, fmt.Errorf("expected <N>d days, got %q", value)
+		}
+		if n < 0 {
+			return 0, fmt.Errorf("must not be negative")
+		}
+		return time.Duration(n) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, err
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("must not be negative")
+	}
+	return d, nil
 }
 
 // runJobKill is the operator kill switch (#341): it marks a runaway delegation

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -277,6 +278,214 @@ func TestRunJobKill(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "job kill:") {
 		t.Fatalf("job kill missing-root stderr = %q", stderr.String())
+	}
+}
+
+// seedJobCancelBulkFixtures seeds the standard #631 bulk-cancel fixture set: a
+// spread of blocked jobs (assorted ages, repos, agents) plus queued/running/
+// failed decoys that must never be selected. Ages are stamped onto updated_at so
+// the age filter has deterministic values. The seeding store is closed so the
+// later setJobTimes (and the CLI commands) own the file.
+func seedJobCancelBulkFixtures(t *testing.T, home string) {
+	t.Helper()
+	store := openCLIJobStore(t, home)
+	now := time.Now().UTC()
+	const layout = "2006-01-02 15:04:05"
+	fixtures := []struct {
+		id, state, repo, agent string
+		age                    time.Duration
+	}{
+		{"blocked-old-a", string(workflow.JobBlocked), "owner/repo", "audit", 10 * 24 * time.Hour},
+		{"blocked-old-b", string(workflow.JobBlocked), "owner/repo", "builder", 30 * 24 * time.Hour},
+		{"blocked-old-c", string(workflow.JobBlocked), "other/repo", "audit", 12 * 24 * time.Hour},
+		{"blocked-recent", string(workflow.JobBlocked), "owner/repo", "audit", time.Hour},
+		{"queued-old", string(workflow.JobQueued), "owner/repo", "audit", 20 * 24 * time.Hour},
+		{"running-old", string(workflow.JobRunning), "owner/repo", "audit", 20 * 24 * time.Hour},
+		{"failed-old", string(workflow.JobFailed), "owner/repo", "audit", 20 * 24 * time.Hour},
+	}
+	for _, f := range fixtures {
+		seedCLIJob(t, store, db.Job{
+			ID:      f.id,
+			Agent:   f.agent,
+			Type:    "ask",
+			State:   f.state,
+			Payload: mustJobPayload(t, workflow.JobPayload{Repo: f.repo, Branch: "main"}),
+		}, f.state)
+	}
+	store.Close()
+	for _, f := range fixtures {
+		ts := now.Add(-f.age).Format(layout)
+		setJobTimes(t, home, f.id, ts, ts)
+	}
+}
+
+func jobStateForTest(t *testing.T, home, id string) string {
+	t.Helper()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	job, err := store.GetJob(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetJob(%s) returned error: %v", id, err)
+	}
+	return job.State
+}
+
+func TestRunJobCancelBulkDryRunSelectsBlockedAndOlder(t *testing.T) {
+	home := t.TempDir()
+	seedJobCancelBulkFixtures(t, home)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "cancel", "--home", home, "--state", "blocked", "--older-than", "7d"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("bulk dry-run exit code = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"blocked-old-a", "blocked-old-b", "blocked-old-c", "run again with --yes to cancel 3 jobs"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+	for _, absent := range []string{"blocked-recent", "queued-old", "running-old", "failed-old"} {
+		if strings.Contains(out, absent) {
+			t.Fatalf("dry-run selected a job it should not have (%q):\n%s", absent, out)
+		}
+	}
+	// Oldest first with an id tie-break: b (30d) before c (12d) before a (10d).
+	ib, ic, ia := strings.Index(out, "blocked-old-b"), strings.Index(out, "blocked-old-c"), strings.Index(out, "blocked-old-a")
+	if !(ib < ic && ic < ia) {
+		t.Fatalf("dry-run order not oldest-first (b=%d c=%d a=%d):\n%s", ib, ic, ia, out)
+	}
+	// A dry-run must not mutate anything.
+	for _, id := range []string{"blocked-old-a", "blocked-old-b", "blocked-old-c", "blocked-recent"} {
+		if got := jobStateForTest(t, home, id); got != string(workflow.JobBlocked) {
+			t.Fatalf("dry-run mutated %s to %q, want still blocked", id, got)
+		}
+	}
+}
+
+func TestRunJobCancelBulkYesCancelsSelection(t *testing.T) {
+	home := t.TempDir()
+	seedJobCancelBulkFixtures(t, home)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "cancel", "--home", home, "--state", "blocked", "--older-than", "7d", "--yes"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("bulk --yes exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "cancelled 3 of 3") {
+		t.Fatalf("bulk --yes summary missing:\n%s", stdout.String())
+	}
+	for _, id := range []string{"blocked-old-a", "blocked-old-b", "blocked-old-c"} {
+		if got := jobStateForTest(t, home, id); got != string(workflow.JobCancelled) {
+			t.Fatalf("job %s state = %q, want cancelled", id, got)
+		}
+	}
+	// The too-new blocked job and the non-blocked decoys are untouched.
+	if got := jobStateForTest(t, home, "blocked-recent"); got != string(workflow.JobBlocked) {
+		t.Fatalf("blocked-recent state = %q, want still blocked", got)
+	}
+	for id, want := range map[string]string{
+		"queued-old":  string(workflow.JobQueued),
+		"running-old": string(workflow.JobRunning),
+		"failed-old":  string(workflow.JobFailed),
+	} {
+		if got := jobStateForTest(t, home, id); got != want {
+			t.Fatalf("decoy %s state = %q, want %q", id, got, want)
+		}
+	}
+}
+
+func TestRunJobCancelBulkFiltersCompose(t *testing.T) {
+	home := t.TempDir()
+	seedJobCancelBulkFixtures(t, home)
+
+	// --older-than in Go-duration form (168h == 7d) composed with repo + agent:
+	// only blocked-old-a is owner/repo + audit + old enough.
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "cancel", "--home", home, "--state", "blocked", "--older-than", "168h", "--repo", "owner/repo", "--agent", "audit"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("bulk compose exit code = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "blocked-old-a") || !strings.Contains(out, "run again with --yes to cancel 1 jobs") {
+		t.Fatalf("compose selection = %q, want only blocked-old-a", out)
+	}
+	for _, absent := range []string{"blocked-old-b", "blocked-old-c", "blocked-recent"} {
+		if strings.Contains(out, absent) {
+			t.Fatalf("compose selected %q it should have filtered out:\n%s", absent, out)
+		}
+	}
+}
+
+func TestRunJobCancelBulkStateValidation(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "cancel", "--home", home, "--state", "failed"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("bulk --state failed exit code = %d, want 2; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), `only "blocked"`) {
+		t.Fatalf("bulk --state failed stderr = %q, want a blocked-only message", stderr.String())
+	}
+}
+
+func TestRunJobCancelIDStateMutuallyExclusive(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "cancel", "some-id", "--home", home, "--state", "blocked"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("id + --state exit code = %d, want 2; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "mutually exclusive") {
+		t.Fatalf("id + --state stderr = %q, want a mutual-exclusion message", stderr.String())
+	}
+}
+
+func TestRunJobCancelBulkFiltersRequireState(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "cancel", "--home", home, "--older-than", "7d"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("--older-than without --state exit code = %d, want 2; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "require --state") {
+		t.Fatalf("--older-than without --state stderr = %q, want a require-state message", stderr.String())
+	}
+}
+
+func TestParseOlderThanDuration(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"7d", 7 * 24 * time.Hour, false},
+		{"168h", 168 * time.Hour, false},
+		{"0", 0, false},
+		{"90m", 90 * time.Minute, false},
+		{"-3d", 0, true},
+		{"-1h", 0, true},
+		{"bogus", 0, true},
+		{"5x", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := parseOlderThanDuration(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("parseOlderThanDuration(%q) err = nil, want error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("parseOlderThanDuration(%q) returned error: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("parseOlderThanDuration(%q) = %v, want %v", tc.in, got, tc.want)
+		}
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -136,6 +136,13 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	// Paths zero, which skips the daemon check and keeps the shell-local one.
 	paths, _ := config.DefaultPaths()
 	checks := doctor.Checker{Dir: *repoDir, LiveProbe: true, Paths: paths}.Run(context.Background())
+	// #631: surface a stale backlog of blocked jobs (each paused awaiting a human)
+	// so an operator knows they can be bulk-dismissed. Best-effort and appended to
+	// both the text table and the --json array; the dashboard's cheaper
+	// GlobalChecks path deliberately omits it so a refresh never opens the store.
+	if check, ok := blockedBacklogDoctorCheck(paths); ok {
+		checks = append(checks, check)
+	}
 	if *jsonOutput {
 		type checkJSON struct {
 			Name     string `json:"name"`

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -100,7 +100,7 @@ func jobReportable(state string) bool {
 }
 
 func jobCancelable(state string) bool {
-	return state == "queued" || state == "running"
+	return state == "queued" || state == "running" || state == "blocked"
 }
 
 // updateJobOverlay handles keys in the job detail and confirm modes.

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -67,6 +67,16 @@ type OrchestratePolicy struct {
 	// daemon's background scan auto-finalizes it (#340), as a Go duration string.
 	// Empty (the default) uses DefaultEscalationTTL (24h); the daemon parses it.
 	EscalationTTL string
+	// BlockedTTL is the opt-in maximum time a job may sit BLOCKED — paused awaiting a
+	// human (an operator permission gate or an unrecoverable BlockedError) — before
+	// the daemon's housekeeping sweep dismisses it via CancelJob (#631), as a Go
+	// duration string. Empty or zero (the DEFAULT) means the sweep is DISABLED: a
+	// blocked job is a human-awaiting decision and is NEVER auto-discarded unless the
+	// operator opts in with a positive duration; a negative value is rejected. Unlike
+	// EscalationTTL — which auto-finalizes a whole paused delegation TREE and is ON by
+	// default — this dismisses a SINGLE blocked job and is OFF by default. The daemon
+	// resolves it per tick via resolveBlockedTTL.
+	BlockedTTL string
 	// MaxDelegationNonProgressStreak is the per-root threshold for the result-aware
 	// non-progress loop detector (#339): how many consecutive continuation
 	// generations a delegation tree may produce with no new durable side effect
@@ -110,6 +120,7 @@ func DefaultOrchestratePolicy() OrchestratePolicy {
 		MaxDelegationCostUSD:           0,
 		EscalationHandle:               "",
 		EscalationTTL:                  "",
+		BlockedTTL:                     "",
 		MaxDelegationNonProgressStreak: 0,
 		MaxVerifyReplanAttempts:        0,
 		DefaultDelegationTimeout:       "",
@@ -201,6 +212,10 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 		parsed, err := parseConfigString(value)
 		policy.EscalationTTL = strings.TrimSpace(parsed)
 		return err
+	case "blocked_ttl":
+		parsed, err := parseConfigString(value)
+		policy.BlockedTTL = strings.TrimSpace(parsed)
+		return err
 	case "max_delegation_non_progress_streak":
 		parsed, err := strconv.Atoi(value)
 		policy.MaxDelegationNonProgressStreak = parsed
@@ -265,6 +280,18 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 		}
 		if parsed <= 0 {
 			return fmt.Errorf("orchestrate.escalation_ttl must be positive")
+		}
+	}
+	if ttl := strings.TrimSpace(policy.BlockedTTL); ttl != "" {
+		parsed, err := time.ParseDuration(ttl)
+		if err != nil {
+			return fmt.Errorf("orchestrate.blocked_ttl %q is invalid: %w", ttl, err)
+		}
+		// Zero is the explicit "disabled" form (like an empty value); only a
+		// NEGATIVE duration is a misconfiguration to reject, since the blocked_ttl
+		// sweep is off-by-default and a non-positive value simply keeps it off.
+		if parsed < 0 {
+			return fmt.Errorf("orchestrate.blocked_ttl must be zero (disabled) or a positive duration")
 		}
 	}
 	if policy.MaxDelegationNonProgressStreak < 0 {

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -50,6 +50,9 @@ func TestLoadOrchestratePolicyDefaults(t *testing.T) {
 	if policy.MaxVerifyReplanAttempts != 0 {
 		t.Fatalf("MaxVerifyReplanAttempts = %d, want 0 (engine default) by default", policy.MaxVerifyReplanAttempts)
 	}
+	if policy.BlockedTTL != "" {
+		t.Fatalf("BlockedTTL = %q, want empty (disabled) by default", policy.BlockedTTL)
+	}
 	if policy.DefaultDelegationTimeout != "" || policy.DefaultPlanTimeout != "" || policy.DefaultImplementTimeout != "" || policy.DefaultReviewTimeout != "" || policy.DefaultGateTimeout != "" || policy.DefaultRepairTimeout != "" {
 		t.Fatalf("delegation timeout defaults = %+v, want all empty by default", policy)
 	}
@@ -301,6 +304,80 @@ escalation_ttl = "soon"
 	}
 	if _, err := LoadOrchestratePolicy(paths); err == nil {
 		t.Fatal("LoadOrchestratePolicy accepted an invalid escalation_ttl")
+	}
+}
+
+// TestLoadOrchestratePolicyBlockedTTL pins #631: blocked_ttl parses from
+// [orchestrate]; it is DISABLED (empty) by default; a positive duration is
+// accepted; an explicit zero is accepted (still disabled); and a negative or
+// non-duration value is rejected.
+func TestLoadOrchestratePolicyBlockedTTL(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+
+	// Disabled by default: an [orchestrate] section without blocked_ttl keeps it empty.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+cockpit_mode = "auto"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.BlockedTTL != "" {
+		t.Fatalf("BlockedTTL = %q, want empty (disabled) by default", policy.BlockedTTL)
+	}
+
+	// A positive duration parses.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+blocked_ttl = "48h"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err = LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy returned error: %v", err)
+	}
+	if policy.BlockedTTL != "48h" {
+		t.Fatalf("BlockedTTL = %q, want 48h", policy.BlockedTTL)
+	}
+
+	// An explicit zero is accepted (it is another spelling of disabled).
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+blocked_ttl = "0s"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadOrchestratePolicy(paths); err != nil {
+		t.Fatalf("LoadOrchestratePolicy rejected blocked_ttl = 0s: %v", err)
+	}
+
+	// A negative duration is rejected.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+blocked_ttl = "-1h"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadOrchestratePolicy(paths); err == nil {
+		t.Fatal("LoadOrchestratePolicy accepted a negative blocked_ttl")
+	}
+
+	// A non-duration value is rejected.
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[orchestrate]
+blocked_ttl = "soon"
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	if _, err := LoadOrchestratePolicy(paths); err == nil {
+		t.Fatal("LoadOrchestratePolicy accepted an invalid blocked_ttl")
 	}
 }
 

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -130,6 +130,24 @@ func SettleCancelledRunningJob(ctx context.Context, store *db.Store, jobID strin
 	return true, store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "cancel_settled", Message: message})
 }
 
+// CancelJob is the single-job abandon verb (#631). It transitions a queued,
+// running, or blocked job to cancelled and best-effort releases the locks the
+// job still owns. A blocked job is one paused awaiting a human (an operator
+// permission gate or an unrecoverable BlockedError), so dismissing it is the
+// same abandon intent as cancelling a queued/running one — cancel is that verb.
+//
+// Scope is deliberately a single row: cancel does NOT propagate to a delegation
+// tree, touch task locks/state, or set the RootKilled flag. Abandoning a whole
+// delegation tree is a different verb (job kill / KillDelegationTree); routing
+// dismissal through the kill machinery would over-reach a lone blocked leg into
+// its siblings and coordinator. isTerminalJobState already treats blocked and
+// cancelled identically, so a blocked->cancelled move changes no delegation
+// barrier disposition.
+//
+// Dismissal is retry-reversible: RetryJob accepts cancelled jobs, so a dismissed
+// blocked job can be resurrected. That is accepted behavior — the settle gate
+// that guards retry after a running-cancel does not apply to a cancel from
+// blocked (a blocked job has no active worker to outrace).
 func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error) {
 	if store == nil {
 		return db.Job{}, fmt.Errorf("store is required")
@@ -139,9 +157,9 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 		return db.Job{}, err
 	}
 	switch job.State {
-	case string(JobQueued), string(JobRunning):
+	case string(JobQueued), string(JobRunning), string(JobBlocked):
 	default:
-		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued or running", job.ID, job.State)
+		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued, running or blocked", job.ID, job.State)
 	}
 	transitioned, err := store.TransitionJobStateWithEvent(ctx, job.ID, job.State, string(JobCancelled), db.JobEvent{
 		JobID:   job.ID,
@@ -156,7 +174,7 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 		if getErr != nil {
 			return db.Job{}, getErr
 		}
-		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued or running", latest.ID, latest.State)
+		return db.Job{}, fmt.Errorf("job %s is %s; cancel requires queued, running or blocked", latest.ID, latest.State)
 	}
 	// Best-effort: release any resource locks the cancelled job still owns (e.g. a
 	// stranded runtime-session lock whose deferred release never ran because the

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -300,5 +301,135 @@ func TestCancelJobRejectsTerminalJob(t *testing.T) {
 	}
 	if _, err := CancelJob(ctx, store, "job-1"); err == nil {
 		t.Fatal("CancelJob accepted succeeded job")
+	}
+}
+
+// TestCancelJobDismissesBlockedJob covers the #631 abandon verb: a blocked job
+// (paused awaiting a human) cancels like a queued/running one — the transition
+// lands, the event records "cancel requested from blocked", and the job's
+// resource locks are released so a stranded gate does not hold them out.
+func TestCancelJobDismissesBlockedJob(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobBlocked)}, db.JobEvent{Kind: string(JobBlocked), Message: "awaiting a human"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	const lockKey = "runtime:codex:session-1"
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: lockKey,
+		OwnerJobID:  "job-1",
+		OwnerToken:  "token-1",
+		ExpiresAt:   now.Add(30 * time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil {
+		t.Fatalf("AcquireResourceLock returned error: %v", err)
+	}
+	if !acquired {
+		t.Fatal("AcquireResourceLock did not acquire the lock")
+	}
+
+	job, err := CancelJob(ctx, store, "job-1")
+	if err != nil {
+		t.Fatalf("CancelJob returned error: %v", err)
+	}
+	if job.State != string(JobCancelled) {
+		t.Fatalf("job state = %q, want cancelled", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(events) != 2 || events[1].Kind != string(JobCancelled) || events[1].Message != "cancel requested from blocked" {
+		t.Fatalf("events = %+v, want a cancellation event recorded from blocked", events)
+	}
+	if _, err := store.GetResourceLock(ctx, lockKey); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("GetResourceLock after cancel error = %v, want sql.ErrNoRows (lock should be released)", err)
+	}
+}
+
+// TestCancelJobRefusesNonCancellableStates proves the widened guard still admits
+// only queued/running/blocked: the three terminal states are refused with the
+// updated message.
+func TestCancelJobRefusesNonCancellableStates(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	for _, state := range []JobState{JobSucceeded, JobFailed, JobCancelled} {
+		id := "job-" + string(state)
+		if err := store.CreateJobWithEvent(ctx, db.Job{ID: id, Agent: "audit", Type: "ask", State: string(state)}, db.JobEvent{Kind: string(state), Message: string(state)}); err != nil {
+			t.Fatalf("CreateJobWithEvent %s returned error: %v", state, err)
+		}
+		_, err := CancelJob(ctx, store, id)
+		if err == nil {
+			t.Fatalf("CancelJob accepted %s job", state)
+		}
+		if !strings.Contains(err.Error(), "cancel requires queued, running or blocked") {
+			t.Fatalf("CancelJob %s error = %q, want the widened refuse message", state, err)
+		}
+	}
+}
+
+// TestCancelJobLostCASRaceRefuses covers the recheck at the CAS seam: several
+// concurrent cancels race one blocked job that lands terminal mid-flight. Exactly
+// one wins (a single cancellation event, no double-cancel); every loser — whether
+// it lost the CAS (recheck path) or read the already-cancelled row (initial
+// guard) — is refused with the widened message.
+func TestCancelJobLostCASRaceRefuses(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "ask", State: string(JobBlocked)}, db.JobEvent{Kind: string(JobBlocked), Message: "awaiting a human"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+
+	const racers = 6
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		start   = make(chan struct{})
+		success int
+		errs    []error
+	)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := CancelJob(ctx, store, "job-1")
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errs = append(errs, err)
+				return
+			}
+			success++
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if success != 1 {
+		t.Fatalf("concurrent cancels succeeded %d times, want exactly 1", success)
+	}
+	if len(errs) != racers-1 {
+		t.Fatalf("got %d refusals, want %d", len(errs), racers-1)
+	}
+	for _, err := range errs {
+		if !strings.Contains(err.Error(), "cancel requires queued, running or blocked") {
+			t.Fatalf("loser error = %q, want the widened refuse message", err)
+		}
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	cancelled := 0
+	for _, ev := range events {
+		if ev.Kind == string(JobCancelled) {
+			cancelled++
+		}
+	}
+	if cancelled != 1 {
+		t.Fatalf("recorded %d cancellation events, want exactly 1 (no double-cancel)", cancelled)
 	}
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -213,7 +213,7 @@ equivalent:
   previous version (same as `gitmoot agent template revert`).
 - **Jobs** lists every job with a state summary: `enter` shows the event
   history, `R` retries failed/blocked/cancelled jobs (same path as
-  `gitmoot job retry`), `c` cancels queued AND running jobs (same as
+  `gitmoot job retry`), `c` cancels queued, running, AND blocked jobs (same as
   `gitmoot job cancel`; running ones show `cancelling…` until the daemon
   settles them), and `B` opens a redacted bug-report preview for
   failed/blocked/cancelled jobs. In the preview, `g` creates or reuses the
@@ -752,7 +752,8 @@ gitmoot job show <job-id>            # add --json for the full job + why-stuck d
 gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
-gitmoot job cancel <job-id>
+gitmoot job cancel <job-id>                                        # one queued|running|blocked job
+gitmoot job cancel --state blocked [--older-than 7d] [--repo owner/repo] [--agent name] [--yes]
 gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
@@ -801,10 +802,41 @@ worker and recovered/re-queued. The window is tunable via the
 below-1m, malformed, or non-positive values are rejected (with a one-time
 warning) in favor of the 30m default rather than clamped (#560).
 
-`gitmoot job cancel <job-id>` also releases any resource locks the cancelled job
-still owned — including a stranded `runtime:<rt>:<session>` lock left behind when
-a foreground `gitmoot agent ask` was killed — so the next ask on that agent does
-not wait out the lock TTL before it can run.
+`gitmoot job cancel <job-id>` is the single-job **abandon** verb. It dismisses a
+`queued`, `running`, **or `blocked`** job (a blocked job is one paused awaiting a
+human — an operator permission gate or an unrecoverable blocker — so dismissing it
+is the same abandon intent as cancelling a queued/running one; #631). Cancel is a
+single-row transition: it does **not** propagate to a delegation tree, touch task
+state, or set the killed flag — abandoning a whole tree is `gitmoot job kill`.
+Cancelling also releases any resource locks the cancelled job still owned —
+including a stranded `runtime:<rt>:<session>` lock left behind when a foreground
+`gitmoot agent ask` was killed — so the next ask on that agent does not wait out
+the lock TTL before it can run. Dismissal is reversible: `gitmoot job retry`
+accepts a cancelled job (its accepted source states are failed/blocked/cancelled),
+so a mistakenly dismissed job can be resurrected.
+
+`gitmoot job cancel --state blocked` is the **bulk** form for clearing a backlog
+of blocked jobs. Only `blocked` is accepted for `--state` (queued/running jobs use
+single-job cancel; terminal jobs use retry). Narrow the selection with
+`--older-than` (a Go duration like `168h`, or a convenience `<N>d` days suffix like
+`7d`; age is measured from when each job became blocked), `--repo owner/repo`
+(matches the job's payload repo), and `--agent name`. The bulk form is a **dry-run
+by default** — it prints the matching jobs (id, agent, repo, age) and exits without
+cancelling anything; pass `--yes` to actually cancel the selection. Each selected
+job is dismissed through the same per-job cancel path, so its locks are released
+too. `<id>` and `--state` are mutually exclusive, and `--older-than`/`--repo`/
+`--agent` require `--state`. `gitmoot doctor` warns when blocked jobs older than
+30d have piled up and prints this exact command as the remediation.
+
+To automate the sweep, set `[orchestrate].blocked_ttl` to a positive Go duration
+(e.g. `blocked_ttl = "168h"`): the daemon's housekeeping tick then dismisses any
+blocked job whose blocked-transition timestamp (updated_at, created_at fallback)
+is older than the TTL, through the same `CancelJob` abandon path, recording a
+distinct `blocked_ttl_expired` job event so a TTL auto-expiry is distinguishable
+from a manual `job cancel`. It is **off by default** — an empty or `0s` value
+disables it (a negative value is rejected). Unlike `[orchestrate].escalation_ttl`
+(which auto-finalizes a whole paused delegation *tree* and is on by default, 24h),
+`blocked_ttl` dismisses a *single* blocked job and is off by default.
 
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -182,7 +182,15 @@ cannot recurse or fan out forever:
   not a hard stop — in-flight jobs finish normally, the coordinator's next
   continuation routes through the same finalize path below (a
   `delegation_killed` event is emitted), and the daemon stops starting queued
-  children of the killed root.
+  children of the killed root. Kill is for a whole **tree**; to abandon a single
+  job (including one blocked awaiting a human) use `gitmoot job cancel <job-id>`
+  instead — or clear a stale backlog of blocked jobs with `gitmoot job cancel
+  --state blocked --older-than 7d --yes` (dry-run without `--yes`). Cancel is a
+  single-row transition that never propagates to siblings or the coordinator, so
+  it must not be routed through the kill machinery (#631). Setting a positive
+  `[orchestrate].blocked_ttl` (off by default) lets the daemon auto-dismiss a
+  blocked job idle longer than the TTL through that same cancel path — the
+  single-job counterpart to the tree-wide `escalation_ttl` below.
 - Human-in-the-loop pause (`escalate_human` failure_policy, #340): when a child
   fails under `escalate_human`, the parent task enters the resumable
   `awaiting_human` state, a one-shot `delegation_escalation_requested` event is

--- a/website/docs/operations/beta-smoke-tests.md
+++ b/website/docs/operations/beta-smoke-tests.md
@@ -962,9 +962,9 @@ gitmoot lock list --repo owner/project
 gitmoot lock show owner/project <branch>
 ```
 
-Only retry failed, blocked, or cancelled jobs. Only cancel queued or running
-jobs. Use `gitmoot lock release owner/project <branch> --owner <agent>` for an
-exact-owner stale lock; use `--force` only when the stored owner is stale.
+Only retry failed, blocked, or cancelled jobs. Only cancel queued, running, or
+blocked jobs. Use `gitmoot lock release owner/project <branch> --owner <agent>`
+for an exact-owner stale lock; use `--force` only when the stored owner is stale.
 
 ## Known V1 Limits
 

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -288,11 +288,37 @@ Fix: resolve the underlying runtime/auth/lock issue, then retry when safe:
 gitmoot job retry <job-id>
 ```
 
-Cancel only when the job should not continue:
+Cancel (abandon) only when the job should not continue. Cancel now dismisses a
+`blocked` job — one paused awaiting a human — as well as a `queued`/`running` one
+(#631); a dismissed job is not lost, since `gitmoot job retry` accepts a cancelled
+job and resurrects it:
 
 ```sh
 gitmoot job cancel <job-id>
 ```
+
+A backlog of `blocked` jobs never clears on its own. Clear a stale batch with the
+bulk form, which is a **dry-run by default** (it prints id/agent/repo/age and
+cancels nothing) until you pass `--yes`:
+
+```sh
+gitmoot job cancel --state blocked --older-than 7d          # preview the selection
+gitmoot job cancel --state blocked --older-than 7d --yes    # cancel it
+```
+
+Only `blocked` is accepted for `--state`; narrow the selection with `--older-than`
+(a Go duration like `168h`, or a `<N>d` days suffix), `--repo owner/repo`, and
+`--agent name`. `gitmoot doctor` warns when blocked jobs older than 30d have piled
+up and prints the exact command to dismiss them.
+
+To sweep the backlog automatically, set `[orchestrate].blocked_ttl` to a positive
+Go duration (e.g. `blocked_ttl = "168h"`): the daemon then dismisses any blocked
+job idle longer than the TTL through the same cancel path, recording a
+`blocked_ttl_expired` job event. It is **off by default** (empty or `0s` disables
+it; a negative value is rejected), because a blocked job is a human-awaiting
+decision that is never auto-discarded unless you opt in. This is the single-job
+counterpart of `[orchestrate].escalation_ttl`, which auto-finalizes a whole paused
+delegation tree and is on by default (24h).
 
 ## Stale Lock
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -217,7 +217,7 @@ equivalent:
   previous version (same as `gitmoot agent template revert`).
 - **Jobs** lists every job with a state summary: `enter` shows the event
   history, `R` retries failed/blocked/cancelled jobs (same path as
-  `gitmoot job retry`), `c` cancels queued AND running jobs (same as
+  `gitmoot job retry`), `c` cancels queued, running, AND blocked jobs (same as
   `gitmoot job cancel`; running ones show `cancelling…` until the daemon
   settles them), and `B` opens a redacted bug-report preview for
   failed/blocked/cancelled jobs. In the preview, `g` creates or reuses the
@@ -721,7 +721,8 @@ gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job run <job-id>
 gitmoot job retry <job-id>
-gitmoot job cancel <job-id>
+gitmoot job cancel <job-id>                                        # one queued|running|blocked job
+gitmoot job cancel --state blocked [--older-than 7d] [--repo owner/repo] [--agent name] [--yes]
 gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
@@ -760,10 +761,41 @@ and the daemon stops starting queued children of that root. See the
 [termination bounds](result-contract.md#termination-bounds) for how it relates
 to the other delegation backstops.
 
-`gitmoot job cancel <job-id>` also releases any resource locks the cancelled job
-still owned — including a stranded `runtime:<rt>:<session>` lock left behind when
-a foreground `gitmoot agent ask` was killed — so the next ask on that agent does
-not wait out the lock TTL before it can run.
+`gitmoot job cancel <job-id>` is the single-job **abandon** verb. It dismisses a
+`queued`, `running`, **or `blocked`** job (a blocked job is one paused awaiting a
+human — an operator permission gate or an unrecoverable blocker — so dismissing it
+is the same abandon intent as cancelling a queued/running one; #631). Cancel is a
+single-row transition: it does **not** propagate to a delegation tree, touch task
+state, or set the killed flag — abandoning a whole tree is `gitmoot job kill`.
+Cancelling also releases any resource locks the cancelled job still owned —
+including a stranded `runtime:<rt>:<session>` lock left behind when a foreground
+`gitmoot agent ask` was killed — so the next ask on that agent does not wait out
+the lock TTL before it can run. Dismissal is reversible: `gitmoot job retry`
+accepts a cancelled job, so a mistakenly dismissed one can be resurrected.
+
+`gitmoot job cancel --state blocked` is the **bulk** form for clearing a backlog
+of blocked jobs. Only `blocked` is accepted for `--state` (queued/running jobs
+have single-job cancel; terminal jobs have retry). Narrow the selection with
+`--older-than` (a Go duration like `168h`, or a convenience `<N>d` days suffix
+like `7d`; age is measured from when each job became blocked), `--repo owner/repo`
+(matches the job's payload repo), and `--agent name`. The bulk form is a
+**dry-run by default** — it prints the matching jobs (id, agent, repo, age) and
+exits without cancelling anything; pass `--yes` to actually cancel the selection.
+Each selected job is dismissed through the same per-job `job cancel` path, so its
+locks are released too. `<id>` and `--state` are mutually exclusive, and
+`--older-than`/`--repo`/`--agent` require `--state`. `gitmoot doctor` warns when
+blocked jobs older than 30d have piled up and prints this exact command.
+
+To automate the sweep, set `[orchestrate].blocked_ttl` to a positive Go duration
+(e.g. `blocked_ttl = "168h"`): the daemon's housekeeping tick then dismisses any
+blocked job whose blocked-transition timestamp is older than the TTL, through the
+same `CancelJob` abandon path (recording a distinct `blocked_ttl_expired` job
+event so a TTL auto-expiry is distinguishable from a manual cancel). It is **off
+by default** — an empty or `0s` value disables it (a negative value is rejected),
+because a blocked job is a human-awaiting decision that is never auto-discarded
+unless you opt in. This is distinct from `[orchestrate].escalation_ttl`, which
+auto-finalizes a whole paused delegation *tree* and is on by default (24h);
+`blocked_ttl` dismisses a *single* blocked job and is off by default.
 
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1045,7 +1045,8 @@ gitmoot job list
 gitmoot job show <job-id>
 gitmoot job watch <job-id>
 gitmoot job retry <job-id>
-gitmoot job cancel <job-id>
+gitmoot job cancel <job-id>               # abandon one queued|running|blocked job
+gitmoot job cancel --state blocked --older-than 7d --yes   # bulk-dismiss a blocked backlog (dry-run without --yes)
 gitmoot job kill <root-job-id>            # operator kill switch for a runaway delegation tree
 gitmoot status --repo owner/repo
 gitmoot version --json
@@ -1442,6 +1443,20 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    base branch because another PR merged first, Gitmoot asks GitHub to update
    the PR branch with the expected head SHA and leaves the merge gate pending so
    the daemon can reload the new head and checks on a later poll tick.
+
+   When a head reports **no** external CI at all (zero commit-statuses and zero
+   check-runs), Gitmoot does not conclude "this repo has no CI" from a single
+   observation — GitHub Actions creates a check-run a few seconds after a push,
+   so the gate stays **pending** and only stamps the synthetic `gitmoot/ci`
+   success after a second consecutive zero-external observation at the same head,
+   at least `[merge_gate] min_ci_wait` (default `60s`) later. When
+   `.github/workflows/` exists at the head tree it instead waits up to
+   `[merge_gate] max_ci_wait` (default `10m`) for a check to appear, then concludes
+   no-CI so a PR whose workflows never trigger for it still merges rather than
+   wedging forever. Set `[merge_gate] require_external_ci = true` (global or
+   per-repo) to hard-block an empty gate once that window elapses instead of ever
+   stamping `gitmoot/ci` (see
+   [`skills/gitmoot/references/SAFETY.md`](../skills/gitmoot/references/SAFETY.md)).
 
 9. Merge and continue.
 
@@ -2457,17 +2472,47 @@ Fixes:
 - `gitmoot job list` appends a `WHY:` column and `gitmoot job show` prints a
   `why_stuck:` line for queued/blocked jobs (#552) — a runtime-session lock
   wait (naming the holder), `blocked: awaiting human`, `auth failing: …`,
-  `throttled: …`, or `retrying: …` with the attempt schedule.
-- Deferred jobs recover on their own (#532): a delivery failure classified as
-  a retryable operational blocker (runtime auth, provider rate limit/quota) is
-  re-queued with a bounded retry budget instead of failing terminally —
-  `job show --json` carries the `blocker_class` and attempt count. Only act
-  when the retry budget is spent and the job stays failed.
+  `throttled: …`, `retrying: …`, or a `blocked-operational: <class>` deferral
+  with the attempt schedule. A deferral that needs a human (dirty/wrong-head
+  checkout) also prints a `suggested_action` naming the fix.
+- Deferred jobs recover on their own (#532): a delivery failure classified as a
+  retryable operational blocker — `runtime_auth`, `runtime_quota`,
+  `network_outage`, or `checkout_contention` — is re-queued with a bounded
+  retry budget instead of failing terminally. `job show --json` carries the
+  `blocker_class`, attempt count, and `suggested_action`. A `runtime_auth`
+  deferral only re-dispatches once a live doctor-style credential probe passes
+  (a failing probe extends the hold without spending a retry). Over `[events]`
+  the deferral is a first-class `job.deferred` emitted instead of `job.failed`.
+  Only act when the retry budget is spent and the job stays failed.
 - A job stuck in `running` is recovered automatically once it shows no lease
   progress past the staleness window (default 30m; tune with the
   `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value
   is 1m — below-1m, malformed, or non-positive values are rejected in favor of
   the 30m default rather than clamped, #560).
+- A backlog of `blocked` jobs (each paused awaiting a human) never clears on its
+  own. Dismiss one with `gitmoot job cancel <job-id>` (cancel now abandons a
+  `blocked` job as well as a `queued`/`running` one; #631), or clear a stale
+  batch with the bulk form:
+
+  ```sh
+  gitmoot job cancel --state blocked --older-than 7d   # dry-run preview
+  gitmoot job cancel --state blocked --older-than 7d --yes
+  ```
+
+  The bulk form is a dry-run by default (it prints id/agent/repo/age and cancels
+  nothing) until you pass `--yes`; narrow it with `--older-than` (a Go duration
+  like `168h`, or a `<N>d` days suffix), `--repo owner/repo`, and `--agent name`.
+  `gitmoot doctor` warns when blocked jobs older than 30d have piled up and prints
+  the exact command. A dismissed job is not lost — `gitmoot job retry` accepts a
+  cancelled job and resurrects it.
+- To sweep the backlog automatically, set `[orchestrate].blocked_ttl` to a
+  positive Go duration (e.g. `blocked_ttl = "168h"`): the daemon then dismisses
+  any blocked job idle longer than the TTL through the same cancel path, recording
+  a `blocked_ttl_expired` job event. It is **off by default** (empty or `0s`
+  disables it; a negative value is rejected), because a blocked job is a
+  human-awaiting decision that is never auto-discarded unless you opt in. This is
+  the single-job counterpart of `[orchestrate].escalation_ttl`, which
+  auto-finalizes a whole paused delegation tree and is on by default (24h).
 
 ## Parallel Implementation And Worktrees
 
@@ -2579,6 +2624,19 @@ Fixes:
   `gitmoot task list` / `gitmoot job events <job-id>`. Resolve the conflict
   manually or run an explicit implement/fix job, then rerun review/merge.
 - Fix failing external CI or Gitmoot statuses.
+- If the reason reads `waiting to confirm no external CI` (or `waiting … for CI
+  to be created`), the gate saw **zero** external commit-statuses and check-runs
+  at the head and is deferring rather than merging before GitHub Actions creates
+  its run (#596). A genuinely CI-less repo merges on the next tick after
+  `[merge_gate] min_ci_wait` (default `60s`) has elapsed with the head unchanged.
+  A CI-configured repo (has `.github/workflows/`) stays pending until the real
+  check appears, but only up to `[merge_gate] max_ci_wait` (default `10m`) — past
+  that bound, with the head unchanged and still no check, the gate concludes no-CI
+  and merges anyway, so a PR whose workflows never trigger for it (docs-only under
+  paths filters, tag-only / `workflow_dispatch`-only workflows, a non-targeted
+  branch) is not wedged forever. Set `[merge_gate] require_external_ci = true`
+  (global or per-repo `[repos."owner/repo".merge_gate]`) to hard-block an empty
+  gate instead of stamping `gitmoot/ci` once that window elapses.
 - Rerun reviews after the PR head SHA changes.
 - If a merged task reports a worktree cleanup warning, inspect the stored task
   worktree path, clean or remove that worktree manually, then clear stale local
@@ -2614,7 +2672,7 @@ The pilot emits a tight allowlist of event types over the webhook transport:
 | `job.failed`                    | a job reaches the `failed` terminal state                                          |
 | `job.blocked`                   | a job reaches the `blocked` terminal state                                         |
 | `job.needs_attention`           | a tree pauses awaiting a human (the `escalate_human` pause today)                  |
-| `job.deferred`                  | the daemon re-queued a job that just emitted `job.failed` because the failure classified as a retryable operational blocker (runtime auth, rate limit/quota) — it will be re-dispatched automatically |
+| `job.deferred`                  | the daemon re-queued a run whose delivery failed on a retryable operational blocker (runtime auth, rate limit/quota, network/GitHub outage, checkout contention) — it will be re-dispatched automatically. Since #532 slice E this is a **first-class** transition emitted INSTEAD of `job.failed` (no preceding `job.failed` for that run) |
 | `candidate.awaiting_promotion`  | a SkillOpt template candidate becomes `pending` after import (always, off the auto-promote policy) |
 | `candidate.auto_promoted`       | the off-by-default `[skillopt].auto_promote` policy auto-promoted a candidate to `current` (also the canary GRADUATE event) |
 | `candidate.canary_started`      | the off-by-default `[skillopt].auto_promote_canary` policy promoted a candidate to the `canary` state behind the live champion |
@@ -2626,16 +2684,24 @@ pre-flight (`queued -> failed|blocked`) and permission-blocked cases that never
 pass through that path. `job.needs_attention` is emitted once per fresh
 escalation round (a re-advance does not re-emit).
 
-**`job.failed` followed by `job.deferred` is NOT terminal.** When a run fails on
-a classified operational blocker (runtime auth rejected, provider rate
-limit/quota), the engine has already emitted `job.failed` for that run before the
-daemon decides to defer; the daemon then emits `job.deferred` for the same
-`job_id` (detail carries the blocker class, the `attempt N/M` retry budget, and
-the earliest `retry at` timestamp) and silently re-dispatches the job after the
-hold. Consumers acting on `job.failed` (recovery, alerting, cleanup) should
-suppress terminal handling for a job whose `job.failed` is followed by a
-`job.deferred`, and treat only a `job.failed` with no subsequent `job.deferred`
-as final.
+**`job.deferred` is a first-class transition — a deferred run does NOT emit
+`job.failed` first.** When a run's delivery fails on a classified operational
+blocker (runtime auth rejected, provider rate limit/quota, network/GitHub outage,
+or a self-healing checkout contention), the classification now happens
+**pre-terminally** in the mailbox seam (#532 slice E): the run is re-queued
+directly and the daemon emits **only** `job.deferred` for that `job_id` (detail
+carries the blocker class, the `attempt N/M` retry budget, and the earliest
+`retry at` timestamp), then silently re-dispatches after the hold. Product
+failures (the agent answered with a `gitmoot_result`, including
+`decision=failed`) still emit `job.failed` and are never auto-retried.
+
+Migration note: before slice E the daemon emitted `job.failed` **then**
+`job.deferred` for the same run (the accepted first-slice flap); consumers had to
+suppress terminal handling for a `job.failed` followed by a `job.deferred`. That
+flap is gone. A `job.failed` with no following `job.deferred` was already the only
+"final" signal, so the safe consumer rule is unchanged and forward-compatible:
+**treat `job.failed` as final only when it is not immediately followed by a
+`job.deferred` for the same `job_id`.**
 
 The two `candidate.*` events come from the `skillopt import` / `train continue`
 CLI path, NOT the daemon (#471). When a candidate becomes `pending`,
@@ -4216,10 +4282,19 @@ mirrors the off-by-default `[events]` stream.
 - **Merged with real CI** (a passing non-`gitmoot/` external status/check at the
   merged head) → strong positive (`soft = 1.0`, `choice = a`).
 - **Merged through an empty gate** (the synthetic `gitmoot/ci` context, or no
-  external CI at head) → **near-neutral** (`soft ≈ 0.5`, `choice = a`), never a
-  strong positive. Rewarding an empty gate would optimize toward "merges that
-  pass no real CI"; the no-CI guard reads the combined status at the merged head
-  SHA and demotes it.
+  external CI at head) → the merge **event** is recorded (`choice = a`) but the
+  quality **score is genuinely absent** (`has_score = false`), **never a
+  fabricated `0.5`** (#474). Rewarding an empty gate would optimize toward "merges
+  that pass no real CI", and inventing a `0.5` midpoint violates the rest of the
+  projection's rule (it returns `has_score = false` when a signal is truly
+  missing). The no-CI guard reads the combined status at the merged head SHA; when
+  the #614/#596 `gitmoot/ci` "no external CI" stamp is present, the reasoning marks
+  it a **confirmed** empty gate (the grace/workflow window elapsed → genuinely no
+  CI, vs. a still-racing zero). To turn a no-CI merge back into a real `0`/`1`
+  quality signal, enable the **hard-verifier tier** below. (On the merge side, an
+  empty gate is itself deferred by a grace window and workflow-awareness before it
+  ever stamps `gitmoot/ci` — see
+  [`SAFETY.md`](../skills/gitmoot/references/SAFETY.md); #596.)
 - **Blocked at the merge gate** → authoritative gate-fail (`hard = 0`,
   `choice = b`).
 - **Review changes_requested** → graded negative (`choice = b`) whose score
@@ -4354,6 +4429,78 @@ swallowed. Promotion stays manual (the leg writes only `eval_runs` /
 > the PR head, so the tool-backed dimensions are effectively produced only when such
 > a checkout happens to be available; `diff_size` always runs. Plumbing a PR-head
 > worktree through to the tool runners is a documented follow-on.
+
+### Deterministic hard-verifier tier (off by default)
+
+Where the `diff_size`/`lint`/`complexity` checkers above produce **soft** quality
+priors, the **hard-verifier tier** (#474, RFC-informed by THUDM/slime's coding-agent
+grading loop) produces a single **un-gameable `0`/`1`** — the authoritative
+`EvaluatorScore.Hard`. Setting **all three** of `[skillopt].auto_trace_enabled = true`,
+`[skillopt].hard_verifiers_enabled = true`, **and at least one**
+`hard_verifier_commands` line (all default off/empty) runs the operator's configured
+verifier commands in a **fresh, clean sandbox checkout at the merged head** — an
+**independent local `git clone`** of the daemon checkout (`git clone --local`, so
+objects are hardlinked but the clone gets its **own** git directory: config, refs, gc,
+worktree registry), reusing gitmoot's single-binary git tooling (no E2B / containers /
+network fetch). Because the clone is git-independent, a verifier that shells out to git
+(`git config`, `git update-ref`, `git gc`, `git worktree prune`) is confined to the
+throwaway clone and **cannot mutate the live daemon checkout** — the containment a
+detached `git worktree` off the base could not give (a worktree shares the base's
+object DB, refs, and config). Each command runs via `sh -c` with its **working
+directory set to the throwaway sandbox**, so relative writes and git state alike stay
+inside it; `exit 0 == pass`:
+
+```toml
+[skillopt]
+auto_trace_enabled = true
+hard_verifiers_enabled = true
+hard_verifier_commands = go build ./...
+hard_verifier_commands = go test ./...
+```
+
+`hard_verifier_commands` is **repeatable** — one command per line — so a command may
+itself contain commas / shell operators. The verdict is **fail-closed**: it PASSES
+only when **every** command exits `0` (slime's `fail_to_pass ∪ pass_to_pass ⊆
+passed`). The binary verdict maps onto `EvaluatorScore.Hard`: **pass → `hard = 1.0`**
+(a strong, evidence-backed positive, `choice = a`), **fail → `hard = 0.0`** (an
+authoritative gate-fail, `choice = b`) — a merge whose code actually fails a clean
+build/test is caught **even when it merged through an empty gate**, and no LLM judge's
+prose can move it.
+
+> **The sandbox is a BARE checkout — commands must self-provision.** It carries only
+> the merged code: **no installed dependencies, build artifacts, or generated files**,
+> and only the daemon's ambient PATH. Write each command self-contained
+> (`npm ci && npm test`, `pip install -e . && pytest`; `go test ./...` fetches modules
+> itself) — a command that assumes a pre-existing `node_modules`/`venv` will fail every
+> merge and record a **false `hard = 0`** against a genuinely-good implementer, which
+> would poison the optimizer's training signal. Guard rail: a command that cannot be
+> **run at all** (its interpreter/binary is absent — a POSIX exit `127`
+> command-not-found, or a missing `sh`) is treated as an **environment failure and
+> SKIPS the whole run** (no hard row), so a missing toolchain never fabricates a
+> negative. But a command that *runs* and exits non-zero *because* deps were missing is
+> an honest `hard = 0` — the skip only covers un-runnable commands, so keep each command
+> self-provisioning.
+
+The verdict is written as a **fourth** `FeedbackEvent` in the SAME
+`auto-trace:<version>` run under a distinct item id (`hard#<repo>#<pr>`) and the fixed
+`gitmoot-verifier` reviewer sentinel — so it **coexists with** (never overwrites) the
+verifiable floor (`gitmoot-auto`), the cross-family review (`gitmoot-review`), and the
+objective checker (`gitmoot-checker`) under the run's UNIQUE
+`(run_id,item_id,reviewer,source,source_url)` key; a re-verification re-upserts the
+SAME hard row in place. The hard eval item carries `hard_verifier = true`,
+`hard_passed`, the projected `hard_score`, and the per-command `command_results`
+(which command failed), while the run keeps `feedback_source = automatic_trace` —
+additive, **no new contract field, `contract_version` stays `1`**.
+
+The leg runs **off the blocking merge path** (detached, `HardVerifierLegTimeout`-bounded,
+process-group killed so a wedged suite and its grandchildren are reaped) and is
+**fail-safe throughout**: an unprovisionable sandbox (the merged head not present in
+the base checkout), an empty command list, or a command that could not be run at all
+(missing toolchain) yields **no hard row** and never errors the harvest, blocks the
+merge, or stalls `AdvanceJob`; a dispatch failure records a `hard_verifiers_failed` job
+event and is swallowed. Because it re-runs the tests, it
+only maps onto **testable** implement legs — subjective review-quality kinds keep the
+soft cross-family signal. Promotion stays manual.
 
 ### Promotion policy + notifications (off by default)
 
@@ -5985,9 +6132,9 @@ gitmoot lock list --repo owner/project
 gitmoot lock show owner/project <branch>
 ```
 
-Only retry failed, blocked, or cancelled jobs. Only cancel queued or running
-jobs. Use `gitmoot lock release owner/project <branch> --owner <agent>` for an
-exact-owner stale lock; use `--force` only when the stored owner is stale.
+Only retry failed, blocked, or cancelled jobs. Only cancel queued, running, or
+blocked jobs. Use `gitmoot lock release owner/project <branch> --owner <agent>`
+for an exact-owner stale lock; use `--force` only when the stored owner is stale.
 
 ## Known V1 Limits
 
@@ -7559,7 +7706,7 @@ equivalent:
   previous version (same as `gitmoot agent template revert`).
 - **Jobs** lists every job with a state summary: `enter` shows the event
   history, `R` retries failed/blocked/cancelled jobs (same path as
-  `gitmoot job retry`), `c` cancels queued AND running jobs (same as
+  `gitmoot job retry`), `c` cancels queued, running, AND blocked jobs (same as
   `gitmoot job cancel`; running ones show `cancelling…` until the daemon
   settles them), and `B` opens a redacted bug-report preview for
   failed/blocked/cancelled jobs. In the preview, `g` creates or reuses the
@@ -7625,11 +7772,12 @@ redacted JSON event to that endpoint for: `job.finished`, `job.failed`,
 (`candidate.awaiting_promotion`, `candidate.auto_promoted`,
 `candidate.canary_started`, `candidate.rolled_back`). Delivery is best-effort
 (bounded buffer + timeout; drops are recorded as a local `event_sink_drop` job
-event, never blocking the job). Consumer rule: **`job.failed` followed by
-`job.deferred` for the same job id is NOT terminal** — the daemon classified the
-failure as a retryable operational blocker and will re-dispatch it; treat only
-a `job.failed` with no subsequent `job.deferred` as final. See `docs/events.md`
-for the full contract.
+event, never blocking the job). Consumer rule: **treat a `job.failed` as final
+only when it is NOT immediately followed by a `job.deferred` for the same job
+id.** Since #532 slice E a deferred run emits `job.deferred` as a first-class
+transition **instead of** `job.failed` (no preceding `job.failed`); the rule
+still holds and is forward-compatible with the older `job.failed`→`job.deferred`
+flap. See `docs/events.md` for the full contract.
 
 ## Bug Reports
 
@@ -8097,7 +8245,8 @@ gitmoot job show <job-id>            # add --json for the full job + why-stuck d
 gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
-gitmoot job cancel <job-id>
+gitmoot job cancel <job-id>                                        # one queued|running|blocked job
+gitmoot job cancel --state blocked [--older-than 7d] [--repo owner/repo] [--agent name] [--yes]
 gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
@@ -8114,20 +8263,30 @@ For a `queued` or `blocked` job, `gitmoot job list` appends a `WHY:` column and
 `gitmoot job show` prints a `why_stuck:` (and, when a lease applies, a
 `next_retry_at:`) line explaining what the job is waiting on — e.g. `waiting on
 runtime session lock runtime:codex:<ref> (held by job <id>)`, `blocked: awaiting
-human`, `auth failing: …`, `throttled: …`, or `retrying: …`. The reason is
-derived from the most authoritative existing signal (the latest reason-bearing
-`job events` entry plus the owning resource lock's lease); a healthy job's output
-is unchanged. `gitmoot doctor` proactively validates `gh auth` (with an
-actionable remediation hint) and the Claude runtime token so a bad credential is
-caught before a job stalls on it.
+human`, `auth failing: …`, `throttled: …`, `retrying: …`, or a
+`blocked-operational: <class>` deferral. The reason is derived from the most
+authoritative existing signal (the latest reason-bearing `job events` entry plus
+the owning resource lock's lease); a healthy job's output is unchanged. When a
+deferral usually needs a human (a dirty or wrong-head checkout), the row/`job
+show` also carries a `suggested_action` naming the concrete fix. `gitmoot doctor`
+proactively validates `gh auth` (with an actionable remediation hint) and the
+Claude runtime token so a bad credential is caught before a job stalls on it.
 
-Operational blockers auto-retry (#532): a delivery failure classified as
-`runtime_auth` or `runtime_quota` does **not** fail the job terminally — the
-daemon re-queues it as **deferred** with a bounded retry budget and a hold
-until the earliest retry time. `gitmoot job show --json` carries the
-`blocker_class` and attempt count, and over the `[events]` stream a
-`job.deferred` follows the `job.failed` (making it non-terminal). So a job that
-"failed then reappeared as queued" is the deferral working, not a bug.
+Operational blockers auto-retry (#532): a delivery failure classified as an
+operational blocker — `runtime_auth`, `runtime_quota`, `network_outage`
+(transient network/GitHub outage), or `checkout_contention` (a self-healing
+branch-lock conflict, or a dirty/wrong-head checkout that carries a
+`suggested_action`) — does **not** fail the job terminally. The daemon re-queues
+it as **deferred** with a bounded retry budget and a hold until the earliest
+retry time, shown as `blocked-operational: <class>: attempt n/3`. `gitmoot job
+show --json` carries the `blocker_class`, attempt count, and `suggested_action`.
+Over the `[events]` stream the deferral is now a **first-class** `job.deferred`
+transition emitted **instead of** `job.failed` (no preceding `job.failed` for
+that run). A `runtime_auth` deferral only re-dispatches once a live doctor-style
+credential probe passes; the probe failing just extends the hold without spending
+a retry. So a job that "failed then reappeared as queued" is the deferral
+working, not a bug. Product failures (the agent answered with a `gitmoot_result`,
+including `decision=failed`) are never auto-retried.
 
 Jobs stuck in `running` are also backstopped: a running job with no lease
 progress past the staleness window (default 30m) is assumed orphaned by a dead
@@ -8136,10 +8295,41 @@ worker and recovered/re-queued. The window is tunable via the
 below-1m, malformed, or non-positive values are rejected (with a one-time
 warning) in favor of the 30m default rather than clamped (#560).
 
-`gitmoot job cancel <job-id>` also releases any resource locks the cancelled job
-still owned — including a stranded `runtime:<rt>:<session>` lock left behind when
-a foreground `gitmoot agent ask` was killed — so the next ask on that agent does
-not wait out the lock TTL before it can run.
+`gitmoot job cancel <job-id>` is the single-job **abandon** verb. It dismisses a
+`queued`, `running`, **or `blocked`** job (a blocked job is one paused awaiting a
+human — an operator permission gate or an unrecoverable blocker — so dismissing it
+is the same abandon intent as cancelling a queued/running one; #631). Cancel is a
+single-row transition: it does **not** propagate to a delegation tree, touch task
+state, or set the killed flag — abandoning a whole tree is `gitmoot job kill`.
+Cancelling also releases any resource locks the cancelled job still owned —
+including a stranded `runtime:<rt>:<session>` lock left behind when a foreground
+`gitmoot agent ask` was killed — so the next ask on that agent does not wait out
+the lock TTL before it can run. Dismissal is reversible: `gitmoot job retry`
+accepts a cancelled job (its accepted source states are failed/blocked/cancelled),
+so a mistakenly dismissed job can be resurrected.
+
+`gitmoot job cancel --state blocked` is the **bulk** form for clearing a backlog
+of blocked jobs. Only `blocked` is accepted for `--state` (queued/running jobs use
+single-job cancel; terminal jobs use retry). Narrow the selection with
+`--older-than` (a Go duration like `168h`, or a convenience `<N>d` days suffix like
+`7d`; age is measured from when each job became blocked), `--repo owner/repo`
+(matches the job's payload repo), and `--agent name`. The bulk form is a **dry-run
+by default** — it prints the matching jobs (id, agent, repo, age) and exits without
+cancelling anything; pass `--yes` to actually cancel the selection. Each selected
+job is dismissed through the same per-job cancel path, so its locks are released
+too. `<id>` and `--state` are mutually exclusive, and `--older-than`/`--repo`/
+`--agent` require `--state`. `gitmoot doctor` warns when blocked jobs older than
+30d have piled up and prints this exact command as the remediation.
+
+To automate the sweep, set `[orchestrate].blocked_ttl` to a positive Go duration
+(e.g. `blocked_ttl = "168h"`): the daemon's housekeeping tick then dismisses any
+blocked job whose blocked-transition timestamp (updated_at, created_at fallback)
+is older than the TTL, through the same `CancelJob` abandon path, recording a
+distinct `blocked_ttl_expired` job event so a TTL auto-expiry is distinguishable
+from a manual `job cancel`. It is **off by default** — an empty or `0s` value
+disables it (a negative value is rejected). Unlike `[orchestrate].escalation_ttl`
+(which auto-finalizes a whole paused delegation *tree* and is on by default, 24h),
+`blocked_ttl` dismisses a *single* blocked job and is off by default.
 
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,
@@ -9361,6 +9551,35 @@ conflict. When an **external** system owns the merge decision instead, set
 then **abstains** from its native merge gate — fail-closed, meaning it never
 merges gatelessly; the external gate makes the call.
 
+### No external CI: grace window, not instant pass (#596)
+
+When a PR head reports **zero** external commit-statuses **and** zero check-runs,
+Gitmoot does **not** immediately treat the repo as CI-less and stamp the
+synthetic `gitmoot/ci` success. GitHub Actions creates a check-run a few seconds
+*after* a head is pushed, so a single zero observation cannot distinguish "no CI
+configured" from "CI not created yet" — and a fast approve path could otherwise
+merge inside that window before CI exists. Instead the gate returns **pending**
+and only concludes "no CI" after a **second consecutive zero-external observation
+at the same head**, at least `min_ci_wait` (default `60s`) later. The gate is
+re-evaluated every daemon poll, so a genuinely CI-less repo merges exactly one
+grace window later. Two extra guards layer on top:
+
+- **Workflow-aware (bounded):** if `.github/workflows/` exists at the head tree,
+  the gate treats a zero observation as an Actions creation lag and stays pending
+  — but only up to `max_ci_wait` (default `10m`) with the head unchanged. Past
+  that bound it concludes no-CI, so a PR whose workflows never produce a check for
+  it (docs-only under paths filters, tag-only / `workflow_dispatch`-only
+  workflows, a non-targeted branch) still merges instead of wedging forever, while
+  the ~seconds creation lag is still covered.
+- **`[merge_gate] require_external_ci`** (global, or per-repo under
+  `[repos."owner/repo".merge_gate]`; default `false`): when `true`, an empty gate
+  **hard-blocks** with an actionable reason — *after* the wait window above, never
+  during the creation-lag race — instead of ever stamping `gitmoot/ci`. Use it for
+  repos you know always have CI. The block is classified transient (it is a
+  repo-config/operator-policy condition, not a template defect), so it is not
+  scored against the implement template. Optionally tune `min_ci_wait` /
+  `max_ci_wait` in the same section.
+
 Useful commands:
 
 ```sh
@@ -9490,7 +9709,15 @@ cannot recurse or fan out forever:
   not a hard stop — in-flight jobs finish normally, the coordinator's next
   continuation routes through the same finalize path below (a
   `delegation_killed` event is emitted), and the daemon stops starting queued
-  children of the killed root.
+  children of the killed root. Kill is for a whole **tree**; to abandon a single
+  job (including one blocked awaiting a human) use `gitmoot job cancel <job-id>`
+  instead — or clear a stale backlog of blocked jobs with `gitmoot job cancel
+  --state blocked --older-than 7d --yes` (dry-run without `--yes`). Cancel is a
+  single-row transition that never propagates to siblings or the coordinator, so
+  it must not be routed through the kill machinery (#631). Setting a positive
+  `[orchestrate].blocked_ttl` (off by default) lets the daemon auto-dismiss a
+  blocked job idle longer than the TTL through that same cancel path — the
+  single-job counterpart to the tree-wide `escalation_ttl` below.
 - Human-in-the-loop pause (`escalate_human` failure_policy, #340): when a child
   fails under `escalate_human`, the parent task enters the resumable
   `awaiting_human` state, a one-shot `delegation_escalation_requested` event is


### PR DESCRIPTION
Implements #631 exactly as designed there (post-adversarial-review design).

## What

- **`job cancel` now admits `blocked`** at both guard sites (initial + CAS-race recheck). Single-row scope by design — the barrier already treats blocked ≡ cancelled, whole-tree abandon remains `job kill`, dismissal is retry-reversible (documented, accepted).
- **Bulk mode**: `job cancel --state blocked [--older-than 7d] [--repo] [--agent]` — dry-run table by default, `--yes` applies via `workflow.CancelJob` per job (lock releases fire), age from `updated_at`, `"<N>d"` suffix supported.
- **Opt-in `blocked_ttl`** (`[orchestrate]`, disabled by default) — daemon sweep on the existing housekeeping tick, distinct `blocked_ttl_expired` event, failure-isolated.
- **`doctor`** check: warns with a copy-paste dismissal command when blocked jobs >30d accumulate.
- **Docs**: all surfaces updated in-PR (CLI reference, config, beta-smoke in both trees, llms-full regenerated) per #603.

## Review (6-agent workflow)

Reviewers caught and the fixer resolved: the TUI's `jobCancelable` not widened (its "mirrors CancelJob" comment had silently become false — dashboard `c` now works on blocked), stale "only queued or running" text in **three** doc surfaces, `resolveBlockedTTL` lacking the home-shape regression tests its `resolveEscalationTTL` template has (the #446/#459 seam), plus an end-to-end tick-wiring test.

## Verification

- Full gates green (build/vet + workflow/cli/config tests).
- **Live E2E**: bulk dry-run against the real home selected exactly the 35 stale blocked jobs (24d sandbox-E2E fossils → 7d demo leftovers), oldest first, zero mutation. The post-merge cleanup of those fossils will be this feature's first production use.

Closes #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)