### PR TITLE
fix(workflow): unify four terminal-state predicates into two documented helpers (#632)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5173,7 +5173,13 @@ func (w jobWorker) rootTreeTerminal(ctx context.Context, rootJobID string) (bool
 		if !inTree {
 			continue
 		}
-		if !cockpitJobStateTerminal(j.State) {
+		// Root-tree finalization uses FINAL (resumability) semantics, NOT settled:
+		// a blocked job is deliberately non-final (it can resume via RetryJob), so
+		// the tree is not terminal while any in-tree job is blocked. Finalizing then
+		// would tear down a pane + seat log the job still needs. The engine's
+		// graceful-finalize continuation provides the real terminal signal for a
+		// stuck tree. See #632 (IsFinalJobState vs IsSettledJobState).
+		if !workflow.IsFinalJobState(j.State) {
 			return false, nil
 		}
 	}
@@ -5206,23 +5212,6 @@ func (w jobWorker) isReconveneContinuation(ctx context.Context, job db.Job, payl
 		return false
 	}
 	return true
-}
-
-// cockpitJobStateTerminal reports whether a job state is terminal for the purpose
-// of root-tree finalization: nothing more will run for it.
-func cockpitJobStateTerminal(state string) bool {
-	switch state {
-	case string(workflow.JobSucceeded), string(workflow.JobFailed),
-		string(workflow.JobCancelled):
-		return true
-	default:
-		// JobBlocked is deliberately NOT terminal: a blocked job (e.g. awaiting a
-		// permission/approval or interactive answer) can resume, and finalizing the
-		// root then would tear down a pane + seat log the job still needs. The
-		// engine's graceful-finalize continuation provides the real terminal signal
-		// for a stuck tree.
-		return false
-	}
 }
 
 // maybeWrapCockpit decides whether a job's delivery is wrapped in a herdr pane.

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -475,6 +475,29 @@ func TestRootTreeTerminal(t *testing.T) {
 	}
 }
 
+// TestPinRootTreeBlockedNotTerminal pins the cockpit's terminal semantics (#632):
+// a `blocked` in-tree job keeps the root tree NON-terminal, so the daemon does
+// not finalize (tear down panes + seat logs) while a blocked job can still
+// resume. This "blocked is live" behavior must hold identically before and after
+// the predicate refactor.
+func TestPinRootTreeBlockedNotTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worker := defaultJobWorker(store, io.Discard)
+
+	mustCreate := func(id, state string, payload workflow.JobPayload) {
+		if err := store.CreateJob(ctx, db.Job{ID: id, Agent: "a", Type: "implement", State: state, Payload: cockpitTestJobPayload(t, payload)}); err != nil {
+			t.Fatalf("CreateJob %s: %v", id, err)
+		}
+	}
+	mustCreate("root-b", string(workflow.JobSucceeded), workflow.JobPayload{})
+	mustCreate("child-blocked", string(workflow.JobBlocked), workflow.JobPayload{RootJobID: "root-b"})
+
+	if done, err := worker.rootTreeTerminal(ctx, "root-b"); err != nil || done {
+		t.Fatalf("rootTreeTerminal with a blocked child = (%v, %v), want (false, nil) — blocked is not terminal for the cockpit", done, err)
+	}
+}
+
 // TestFinalizeCockpitRootIfDoneJobMode is the bug-2 daemon case: in JOB mode the
 // per-Deliver teardown deletes the pane rows, so at root-terminal no pane rows
 // remain — but the per-root workspace (recorded in cockpit_workspaces) must still

--- a/internal/cli/daemon_cockpit_test.go
+++ b/internal/cli/daemon_cockpit_test.go
@@ -539,21 +539,24 @@ func TestFinalizeCockpitRootIfDoneJobMode(t *testing.T) {
 	worker.finalizeCockpitRootIfDone(cp, db.Job{ID: "root-job"}, workflow.JobPayload{}, "root-job")
 }
 
+// TestCockpitJobStateTerminal pins the cockpit's terminal predicate, now sourced
+// from workflow.IsFinalJobState (#632): root-tree finalization uses FINAL
+// (resumability) semantics, so blocked is NOT terminal.
 func TestCockpitJobStateTerminal(t *testing.T) {
 	terminal := []string{
 		string(workflow.JobSucceeded), string(workflow.JobFailed),
 		string(workflow.JobCancelled),
 	}
 	for _, s := range terminal {
-		if !cockpitJobStateTerminal(s) {
-			t.Errorf("cockpitJobStateTerminal(%q) = false, want true", s)
+		if !workflow.IsFinalJobState(s) {
+			t.Errorf("IsFinalJobState(%q) = false, want true", s)
 		}
 	}
-	// JobBlocked is NOT terminal: a blocked job can resume, so finalizing the root
+	// JobBlocked is NOT final: a blocked job can resume, so finalizing the root
 	// (closing panes + removing seat logs) while blocked would be premature.
 	for _, s := range []string{string(workflow.JobQueued), string(workflow.JobRunning), string(workflow.JobBlocked), "", "weird"} {
-		if cockpitJobStateTerminal(s) {
-			t.Errorf("cockpitJobStateTerminal(%q) = true, want false", s)
+		if workflow.IsFinalJobState(s) {
+			t.Errorf("IsFinalJobState(%q) = true, want false", s)
 		}
 	}
 }

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -470,7 +470,9 @@ func buildDashboardNode(job db.Job, payload workflow.JobPayload, events []db.Job
 	if t := parseJobTimeMillis(job.CreatedAt); t > 0 {
 		node.StartedAt = t
 	}
-	if t := parseJobTimeMillis(job.UpdatedAt); t > 0 && isTerminalJobState(job.State) {
+	// EndedAt uses FINAL (resumability) semantics: a blocked job is deliberately
+	// NOT stamped with an end time because it can resume via RetryJob (#632).
+	if t := parseJobTimeMillis(job.UpdatedAt); t > 0 && workflow.IsFinalJobState(strings.TrimSpace(job.State)) {
 		node.EndedAt = t
 	}
 	// Event.T is epoch millis from the event's created_at when the row carries
@@ -573,7 +575,10 @@ func summarizeRuns(jobs []db.Job) []dashboard.RunSummary {
 		if j.DelegationDepth > a.maxDepth {
 			a.maxDepth = j.DelegationDepth
 		}
-		if isTerminalJobState(j.State) {
+		// A run's "done" count uses FINAL (resumability) semantics: a blocked job is
+		// not counted as done because it can still resume via RetryJob (#632),
+		// keeping the run active — mirroring runStateActive and the cockpit.
+		if workflow.IsFinalJobState(strings.TrimSpace(j.State)) {
 			a.done++
 		}
 		if j.ID == root {
@@ -647,12 +652,10 @@ const maxRunSummaries = 60
 // settled terminal state), so active runs can be surfaced ahead of finished
 // ones in the run list.
 func runStateActive(state dashboard.NodeState) bool {
-	switch string(state) {
-	case "succeeded", "failed", "cancelled":
-		return false
-	default:
-		return true
-	}
+	// Active is the negation of FINAL (resumability) semantics: a blocked run is
+	// still "active" because it can resume via RetryJob (#632). Uses IsFinalJobState
+	// (not IsSettledJobState) so blocked surfaces as live, matching the cockpit.
+	return !workflow.IsFinalJobState(string(state))
 }
 
 // mostRecentRunRoot returns the run root to show when no run is requested: the
@@ -773,16 +776,6 @@ func mapNodeState(state string) dashboard.NodeState {
 		return "queued"
 	default:
 		return dashboard.NodeState(strings.TrimSpace(state))
-	}
-}
-
-// isTerminalJobState reports whether a job has settled (used to stamp EndedAt).
-func isTerminalJobState(state string) bool {
-	switch strings.TrimSpace(state) {
-	case "succeeded", "failed", "cancelled":
-		return true
-	default:
-		return false
 	}
 }
 

--- a/internal/cli/dashboard_web_test.go
+++ b/internal/cli/dashboard_web_test.go
@@ -283,6 +283,35 @@ func TestWebDataSourceNodeTiming(t *testing.T) {
 	}
 }
 
+// TestPinDashboardBlockedDoesNotStampEndedAt pins the web dashboard's terminal
+// semantics (#632): buildDashboardNode stamps EndedAt only for FINAL states
+// (succeeded/failed/cancelled) and NOT for `blocked`, because a blocked job can
+// still resume. This exclusion must hold identically before and after the
+// predicate refactor.
+func TestPinDashboardBlockedDoesNotStampEndedAt(t *testing.T) {
+	const updated = "2026-05-23 07:00:00"
+	wantEnd := parseJobTimeMillis(updated)
+	if wantEnd == 0 {
+		t.Fatalf("test timestamp did not parse")
+	}
+
+	// A blocked job carries an UpdatedAt but must NOT get EndedAt stamped.
+	blocked := buildDashboardNode(
+		db.Job{ID: "j-blocked", Agent: "a", Type: "implement", State: "blocked", UpdatedAt: updated},
+		workflow.JobPayload{}, nil, nil, nil, "implement")
+	if blocked.EndedAt != 0 {
+		t.Fatalf("blocked node EndedAt = %d, want 0 (blocked is not final; can resume)", blocked.EndedAt)
+	}
+
+	// A failed job, by contrast, is final and does get EndedAt stamped.
+	failed := buildDashboardNode(
+		db.Job{ID: "j-failed", Agent: "a", Type: "implement", State: "failed", UpdatedAt: updated},
+		workflow.JobPayload{}, nil, nil, nil, "implement")
+	if failed.EndedAt != wantEnd {
+		t.Fatalf("failed node EndedAt = %d, want %d (failed is final)", failed.EndedAt, wantEnd)
+	}
+}
+
 // TestNodeTitleDescriptive covers the descriptive-title preference order beyond
 // the plain task-title case: a humanized delegation id and an instructions line.
 func TestNodeTitleDescriptive(t *testing.T) {

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -319,7 +319,7 @@ func runJobWatch(args []string, stdout, stderr io.Writer) int {
 					nextEvent++
 				}
 			}
-			if jobStateIsTerminal(job.State) {
+			if workflow.IsSettledJobState(job.State) {
 				output = jobWatchOutput{Job: job, Events: events}
 				return nil
 			}
@@ -464,15 +464,6 @@ func parseSingleJobIDExitCode(args []string) int {
 		return 0
 	}
 	return 2
-}
-
-func jobStateIsTerminal(state string) bool {
-	switch state {
-	case string(workflow.JobSucceeded), string(workflow.JobFailed), string(workflow.JobBlocked), string(workflow.JobCancelled):
-		return true
-	default:
-		return false
-	}
 }
 
 func filterJobs(jobs []db.Job, repoFilter string, stateFilter string) []db.Job {

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -178,6 +178,33 @@ func TestRunJobWatchPrintsEventsUntilTerminal(t *testing.T) {
 	}
 }
 
+// TestPinRunJobWatchStopsOnBlocked pins `job watch`'s terminal semantics (#632):
+// a `blocked` job is treated as SETTLED, so the watch loop stops tailing it and
+// returns exit 0 immediately rather than polling forever. If blocked were not
+// terminal here, this test would hang. This "settled includes blocked" behavior
+// must hold identically before and after the predicate refactor.
+func TestPinRunJobWatchStopsOnBlocked(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-watch-blocked",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobBlocked),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main"}),
+	}, "blocked")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "watch", "job-watch-blocked", "--home", home, "--poll", "1ms"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job watch on blocked job exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "state: blocked") {
+		t.Fatalf("job watch on blocked job did not report terminal state:\n%s", stdout.String())
+	}
+}
+
 func TestRunJobWatchJSON(t *testing.T) {
 	home := t.TempDir()
 	store := openCLIJobStore(t, home)

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -564,13 +564,12 @@ func latestTerminalJobEventIndex(events []db.JobEvent) int {
 	return -1
 }
 
+// isTerminalJobEvent reports whether an event kind names a settled job state.
+// Event kinds mirror job-state strings for terminal transitions, so it uses
+// SETTLED (barrier) semantics — blocked included — to locate the latest
+// terminal event. See workflow.IsSettledJobState (#632).
 func isTerminalJobEvent(kind string) bool {
-	switch strings.TrimSpace(kind) {
-	case string(workflow.JobSucceeded), string(workflow.JobFailed), string(workflow.JobBlocked), string(workflow.JobCancelled):
-		return true
-	default:
-		return false
-	}
+	return workflow.IsSettledJobState(strings.TrimSpace(kind))
 }
 
 func isPriorityDiagnosticEvent(kind string) bool {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -2821,7 +2821,7 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 	retried := false
 	for _, d := range parentResult.Delegations {
 		child, ok := children[d.ID]
-		if !ok || !isTerminalJobState(child.State) || child.State == string(JobSucceeded) {
+		if !ok || !IsSettledJobState(child.State) || child.State == string(JobSucceeded) {
 			continue
 		}
 		// #419: a retried dependent must not run blind to its upstream deps. The
@@ -2870,7 +2870,7 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 	escalate := false
 	for _, d := range parentResult.Delegations {
 		child, ok := children[d.ID]
-		if !ok || !isTerminalJobState(child.State) || child.State == string(JobSucceeded) {
+		if !ok || !IsSettledJobState(child.State) || child.State == string(JobSucceeded) {
 			continue
 		}
 		switch delegationFailurePolicy(d) {
@@ -3495,13 +3495,13 @@ func allDelegationsResolved(delegations []Delegation, children map[string]db.Job
 
 func delegationResolved(d Delegation, children map[string]db.Job, byID map[string]Delegation, dedupWinners map[string]db.Job) bool {
 	if child, ok := children[d.ID]; ok {
-		return isTerminalJobState(child.State)
+		return IsSettledJobState(child.State)
 	}
 	// A fingerprint-deduped delegation never gets its own child; it is resolved
 	// when its winning sibling (the same-fingerprint delegation that did get a
 	// child) reaches a terminal state, so it cannot stall the continuation.
 	if winner, ok := dedupWinners[d.ID]; ok {
-		return isTerminalJobState(winner.State)
+		return IsSettledJobState(winner.State)
 	}
 	// No child job yet: the delegation is resolved only if it can never run
 	// because one of its dependencies is permanently unrunnable.
@@ -3522,13 +3522,13 @@ func delegationPermanentlyBlocked(d Delegation, children map[string]db.Job, byID
 	defer delete(visiting, d.ID)
 	for _, dep := range compactStrings(d.Deps) {
 		if winner, ok := dedupWinners[dep]; ok {
-			if isTerminalJobState(winner.State) && winner.State != string(JobSucceeded) {
+			if IsSettledJobState(winner.State) && winner.State != string(JobSucceeded) {
 				return true
 			}
 			continue
 		}
 		if child, ok := children[dep]; ok {
-			if isTerminalJobState(child.State) && child.State != string(JobSucceeded) {
+			if IsSettledJobState(child.State) && child.State != string(JobSucceeded) {
 				return true
 			}
 			continue
@@ -3551,15 +3551,6 @@ func delegationsByID(delegations []Delegation) map[string]Delegation {
 		byID[d.ID] = d
 	}
 	return byID
-}
-
-func isTerminalJobState(state string) bool {
-	switch state {
-	case string(JobSucceeded), string(JobFailed), string(JobBlocked), string(JobCancelled):
-		return true
-	default:
-		return false
-	}
 }
 
 func delegationFailurePolicy(d Delegation) string {
@@ -3609,7 +3600,7 @@ func (e Engine) delegationRetryPending(ctx context.Context, parentJobID, delegat
 	if !ok {
 		return false, nil
 	}
-	return !isTerminalJobState(child.State), nil
+	return !IsSettledJobState(child.State), nil
 }
 
 func childFailureReason(child db.Job) string {

--- a/internal/workflow/terminal_state_test.go
+++ b/internal/workflow/terminal_state_test.go
@@ -1,0 +1,58 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// TestSettledVsFinalTruthTables pins the canonical two-predicate contract (#632):
+// `blocked` is SETTLED (barrier semantics) but NOT FINAL (resumability
+// semantics); every other end state agrees, and non-end states are neither.
+func TestSettledVsFinalTruthTables(t *testing.T) {
+	cases := []struct {
+		state       string
+		wantSettled bool
+		wantFinal   bool
+	}{
+		{string(JobSucceeded), true, true},
+		{string(JobFailed), true, true},
+		{string(JobCancelled), true, true},
+		// The deliberate split: blocked is settled but resumable (not final).
+		{string(JobBlocked), true, false},
+		{string(JobQueued), false, false},
+		{string(JobRunning), false, false},
+		{"", false, false},
+		{"weird", false, false},
+	}
+	for _, c := range cases {
+		if got := IsSettledJobState(c.state); got != c.wantSettled {
+			t.Errorf("IsSettledJobState(%q) = %v, want %v", c.state, got, c.wantSettled)
+		}
+		if got := IsFinalJobState(c.state); got != c.wantFinal {
+			t.Errorf("IsFinalJobState(%q) = %v, want %v", c.state, got, c.wantFinal)
+		}
+	}
+}
+
+// TestPinDelegationBarrierProceedsPastBlockedChild pins the engine's observable
+// barrier semantics (#632): a delegation whose child is `blocked` counts as
+// resolved, so the coordinator continuation is not stalled by it. This is the
+// "settled includes blocked" behavior encoded via allDelegationsResolved and
+// must hold identically before and after the predicate refactor.
+func TestPinDelegationBarrierProceedsPastBlockedChild(t *testing.T) {
+	delegations := []Delegation{{ID: "a"}, {ID: "b"}}
+	children := map[string]db.Job{
+		"a": {ID: "root/delegation/a", State: string(JobSucceeded)},
+		"b": {ID: "root/delegation/b", State: string(JobBlocked)},
+	}
+	if !allDelegationsResolved(delegations, children, nil) {
+		t.Fatal("allDelegationsResolved with a blocked child = false, want true (barrier must proceed past blocked)")
+	}
+
+	// A still-running child, by contrast, is NOT resolved: the barrier waits.
+	children["b"] = db.Job{ID: "root/delegation/b", State: string(JobRunning)}
+	if allDelegationsResolved(delegations, children, nil) {
+		t.Fatal("allDelegationsResolved with a running child = true, want false (barrier must wait on running)")
+	}
+}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -30,6 +30,55 @@ const (
 	JobCancelled JobState = "cancelled"
 )
 
+// IsSettledJobState and IsFinalJobState are the two canonical "is this job state
+// over?" predicates (#632). They exist because the codebase previously carried
+// four ad-hoc, duplicated predicates that split 2–2 on `blocked` — including two
+// package-level functions that shared the name isTerminalJobState with OPPOSITE
+// handling of `blocked` (a refactor hazard: moving code between packages silently
+// flipped semantics). The two helpers make the `blocked` disagreement a single,
+// documented decision rather than four scattered accidents.
+//
+// The deliberate split is: `blocked` is SETTLED but not FINAL.
+
+// IsSettledJobState reports whether a job state is "settled" under BARRIER
+// semantics: there is no point waiting on the job any longer. The settled set is
+// succeeded, failed, blocked, and cancelled.
+//
+// `blocked` IS settled: a delegation/continuation barrier must not stall waiting
+// on a blocked child, and a `job watch` should stop tailing it — nothing more
+// will happen without external intervention. Use this predicate to answer "will
+// anything more happen on its own?" (delegation barriers, watch loops).
+//
+// It is intentionally DISTINCT from IsFinalJobState, which excludes `blocked`
+// because a blocked job can be resumed via RetryJob. See #632.
+func IsSettledJobState(state string) bool {
+	switch JobState(state) {
+	case JobSucceeded, JobFailed, JobBlocked, JobCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsFinalJobState reports whether a job state is "final" under RESUMABILITY
+// semantics: the job has reached an end state from which it will not resume. The
+// final set is succeeded, failed, and cancelled.
+//
+// `blocked` is deliberately EXCLUDED (#632): a blocked job (awaiting a
+// permission/approval or an interactive answer) can be resumed via RetryJob, so
+// it is settled (see IsSettledJobState) but NOT final. Callers that stamp an end
+// time (dashboard EndedAt) or tear down live resources (cockpit root
+// finalization) must use this predicate, never the settled one, or they would
+// prematurely end a job that can still come back to life.
+func IsFinalJobState(state string) bool {
+	switch JobState(state) {
+	case JobSucceeded, JobFailed, JobCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
 type Task struct {
 	ID     string
 	Title  string

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -746,7 +746,7 @@ func (e Engine) implementLegBranchMayBeMerged(ctx context.Context, payload JobPa
 	}
 	for _, consumerID := range consumerIDs {
 		consumer, ok := children[consumerID]
-		if !ok || !isTerminalJobState(consumer.State) {
+		if !ok || !IsSettledJobState(consumer.State) {
 			return true // consumer not yet dispatched or still running -> preserve
 		}
 	}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -479,6 +479,10 @@ the dollar-cost bullet in [Termination bounds](#termination-bounds) above.
 - `approved`: review found no blocking issues.
 - `changes_requested`: review found issues that should be fixed before merge.
 - `blocked`: work cannot continue without human input or an external state change.
+  A blocked job is *settled* (a delegation barrier will not wait on it and a
+  `job watch` stops tailing it) but not *final*: it can be resumed via retry, so
+  subsystems that stamp an end time or tear down live resources treat it as still
+  live. See `internal/workflow` `IsSettledJobState` vs `IsFinalJobState` (#632).
 - `implemented`: the requested implementation work was completed.
 - `failed`: the attempted action errored or could not complete.
 


### PR DESCRIPTION
## What & why

Closes #632. The codebase carried **four** independent "is this job state terminal?" predicates that split 2–2 on `blocked` — including two package-level functions both named `isTerminalJobState` (in `internal/workflow` and `internal/cli`) with **opposite** `blocked` handling, a refactor hazard where moving code between packages silently flipped semantics.

This PR replaces them with two explicitly-named, documented helpers in `internal/workflow` (single source of truth), each carrying a doc comment that cites #632 and explains the deliberate `blocked` split:

- **`IsSettledJobState`** — barrier semantics: `succeeded/failed/blocked/cancelled` ("no point waiting on it").
- **`IsFinalJobState`** — resumability semantics: `succeeded/failed/cancelled` (`blocked` can be resumed via `RetryJob`).

## Call sites migrated (each to the semantics it actually needs today)

| Site | Was | Now |
|---|---|---|
| `workflow/engine.go` `isTerminalJobState` (+ `worktree.go`) | includes blocked | `IsSettledJobState` (barrier proceeds past blocked) |
| `cli/job.go` `jobStateIsTerminal` (`job watch`) | includes blocked | `IsSettledJobState` (watch stops on blocked) |
| `cli/daemon.go` `cockpitJobStateTerminal` (root finalize) | excludes blocked | `!IsFinalJobState` (blocked stays live) |
| `cli/dashboard_web.go` `isTerminalJobState` (EndedAt stamp + run "done" count) | excludes blocked | `IsFinalJobState` (blocked not final) |

The three ad-hoc functions are **deleted**; the two same-named opposite-semantics `isTerminalJobState` functions are gone.

### Wider sweep (fifth+ occurrences)

Grepped `internal/` for the same inline state-set comparisons over succeeded/failed/blocked/cancelled and migrated the extras found:

- `cli/dashboard_web.go` `runStateActive` → `!IsFinalJobState` (blocked run is "active", matching the cockpit).
- `report/report.go` `isTerminalJobEvent` → `IsSettledJobState` (event kinds mirror job-state strings; blocked-inclusive, behavior-identical).

**Left as-is (with rationale):** `cli/dashboard_tui.go` `buildDashboardActivity` uses a multi-way state *histogram* where `blocked` is its own bucket distinct from `Done` (succeeded/failed/cancelled). That is a categorization, not a boolean terminal predicate; rewriting it into the helper adds risk without consolidation. Noted here rather than silently changed.

## No behavior change (pinning tests)

Before migrating, I added **pinning tests** capturing each subsystem's current observable semantics through stable, higher-level functions; they pass **unchanged** before and after the refactor:

- `TestPinDelegationBarrierProceedsPastBlockedChild` — engine barrier proceeds past a blocked child (`allDelegationsResolved`).
- `TestPinRootTreeBlockedNotTerminal` — cockpit `rootTreeTerminal` treats blocked as live (non-terminal).
- `TestPinDashboardBlockedDoesNotStampEndedAt` — web dashboard does NOT stamp `EndedAt` for blocked (`buildDashboardNode`).
- `TestPinRunJobWatchStopsOnBlocked` — `job watch` stops on blocked (settled).
- `TestSettledVsFinalTruthTables` — the two helpers' truth tables.

## Follow-up questions

- **No genuine bug found.** Once the split is explicit, every one of the four call sites still maps to the semantics it needs (barrier/watch → settled; finalize/EndedAt/run-active → final). Nothing looked like a wrong-set usage that would warrant a behavior fix.
- **Docs surface is thin.** Job-state *terminality* isn't enumerated anywhere in `docs/` or `website/` today (only the `gitmoot_result` *decisions* are). The canonical two-predicate model now lives in the `internal/workflow` doc comments; I added a one-line note to `skills/gitmoot/references/RESULT_CONTRACT.md`'s `blocked` decision (settled-but-resumable). Happy to add a dedicated job-state-lifecycle doc page if reviewers want one.

## Gate

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, and `go test -race -timeout 20m ./internal/workflow/ ./internal/cli/` all green (race: workflow 361s, cli 872s, EXIT=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
