### PR TITLE
feat(skillopt): deterministic fixed-corpus replay gate for candidates (pre-canary) (#627)

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -636,6 +636,103 @@ and classifies the run as `generation_complete`, `generation_incomplete`, or
 missing items remains `train continue`'s job). `--abort` reclaims the lock and
 leaves the phase at `items_ready`, keeping persisted items.
 
+## Pre-Canary Replay Gate
+
+The replay gate (`#627`, AutoMem A.2) is an **off-by-default**, deterministic
+check that runs **before** a candidate reaches canary. It replays a candidate
+template against a **fixed, versioned job corpus** and accepts the candidate only
+on **strict improvement** over the current champion on the **same** corpus — a
+tie (parity) or any regression fails. It reuses the existing deterministic
+scorers (the `#474` hard-verifier tier and the `#485` deterministic checkers) on
+the corpus outputs, so it invents no new judge and runs **no live LLM in the gate
+itself**: the replay driver is a deterministic `sh -c` command.
+
+### Corpus
+
+A corpus is a plain, versioned JSON file — the same fixed seeds every replay runs
+on:
+
+```json
+{
+  "kind": "gitmoot-skillopt-gate-corpus",
+  "version": 1,
+  "replay_command": "sh .gitmoot/skillopt/gate-replay.sh",
+  "items": [
+    { "id": "widget-a", "prompt": "implement widget A", "expected": "builds" },
+    { "id": "widget-b", "prompt": "implement widget B", "expected": "builds" }
+  ]
+}
+```
+
+Every item needs a unique non-empty `id` and a non-empty `prompt`. `version` is
+`>= 1` so a scoring change is auditable. `replay_command` is optional here and can
+instead come from `--replay-command` or `[skillopt].gate_replay_command`.
+
+### Replay driver contract
+
+For each corpus item the gate runs the replay command via `sh -c` with the
+candidate template staged to a temp file and the item passed in the environment:
+
+- `GITMOOT_GATE_TEMPLATE_FILE` — path to the candidate template content;
+- `GITMOOT_GATE_PROMPT` — the item prompt;
+- `GITMOOT_GATE_EXPECTED` — the item's expected/verifiable outcome;
+- `GITMOOT_GATE_ITEM_ID` — the item id.
+
+The command emits a deterministic per-item result JSON on stdout, in the same
+shape the hard-verifier / deterministic-checker tiers produce, so the existing
+scorers project it into a `[0,1]` score:
+
+```json
+{ "rubric": { "build": 1.0, "test": 0.5 } }
+```
+
+or a binary hard verdict:
+
+```json
+{ "hard_verifier": true, "hard_passed": true }
+```
+
+Because the command is the deterministic map, two replays over the same corpus +
+template yield **identical** scores.
+
+### Running the gate
+
+```sh
+gitmoot skillopt gate run --candidate planner@v2 --corpus .gitmoot/skillopt/gate-corpus.json
+gitmoot skillopt gate run --candidate planner@v2 --json   # machine-readable pass/fail + per-item deltas
+gitmoot skillopt gate history --candidate planner@v2      # persisted audit trail
+```
+
+`gate run` scores the champion and candidate on the corpus, prints pass/fail plus
+per-item deltas, and **persists** the run (additive `skillopt_gate_runs` table)
+for audit. It exits non-zero on a rejected gate so a script can branch on the
+verdict.
+
+### One-retry protocol
+
+On a gate failure the protocol takes **exactly one** retry that feeds the failing
+replay log back to the optimizer step and re-gates the revised candidate; a
+**second** failure is a reject (a clean restart is the operator's choice). The CLI
+`gate run` is a single evaluation (attempt 1); the optimizer-fed retry runs where
+the optimizer is available in the train workflow.
+
+### Config and promotion blocking
+
+The gate is wired as an optional, off-by-default step. Turn it on in `[skillopt]`:
+
+```toml
+[skillopt]
+gate_enabled = true
+gate_corpus = .gitmoot/skillopt/gate-corpus.json
+gate_replay_command = sh .gitmoot/skillopt/gate-replay.sh
+```
+
+When `gate_enabled` is on, a candidate must carry a **passing** gate run before it
+may be promoted to canary or current; otherwise the promotion seam blocks with a
+`gate_blocked` notify and takes no promotion action. The gate is standalone (no
+`auto_trace_enabled` dependency), and with it off the promote path is
+byte-identical to before. Promotion itself stays manual.
+
 ## Candidate Review And Next Iteration
 
 The candidate review step publishes the candidate summary, preview/PR links

--- a/internal/cli/candidate_notify.go
+++ b/internal/cli/candidate_notify.go
@@ -154,6 +154,23 @@ func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, 
 	if store == nil {
 		return nil
 	}
+	// (4z) Pre-canary replay gate (#627): when [skillopt].gate_enabled is on, a
+	// guardrails-pass candidate must ALSO carry a PASSING deterministic replay-gate
+	// run before it may be promoted (to canary OR current). This is additive and off
+	// by default — with the gate off, GatePromotionGuard never blocks and the
+	// promotion path below is byte-identical to pre-#627. When it blocks, the
+	// awaiting_promotion notify above already fired; we emit a gate_blocked detail and
+	// stop short of promotion so the operator runs `gitmoot skillopt gate run` first.
+	if policy.GateEnabled() {
+		hasAccepted, err := store.HasAcceptedSkillOptGateRun(ctx, version.ID)
+		if err != nil {
+			return fmt.Errorf("resolve replay-gate status for candidate %s: %w", version.ID, err)
+		}
+		if blocked, reason := skillopt.GatePromotionGuard(true, hasAccepted); blocked {
+			emitCandidateEvent(ctx, sink, events.EventCandidateAwaitingPromotion, version, "gate_blocked", reason)
+			return nil
+		}
+	}
 	// (4a) Canary path (#484): instead of promoting straight to current, promote the
 	// candidate to the `canary` state behind the live champion (the champion stays
 	// current, so non-sampled resolutions are byte-identical) and emit

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -80,6 +80,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptAB(args[1:], stdout, stderr)
 	case "pairwise":
 		return runSkillOptPairwise(args[1:], stdout, stderr)
+	case "gate":
+		return runSkillOptGate(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown skillopt command %q\n\n", args[0])
 		printSkillOptUsage(stderr)
@@ -99,6 +101,8 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt candidate show <version-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate promote <version-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt candidate reject <version-id> [--reason text]")
+	fmt.Fprintln(w, "  gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-command cmd] [--config path] [--json]")
+	fmt.Fprintln(w, "  gitmoot skillopt gate history --candidate <version-id> [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")

--- a/internal/cli/skillopt_gate.go
+++ b/internal/cli/skillopt_gate.go
@@ -57,19 +57,19 @@ func printSkillOptGateUsage(w io.Writer) {
 
 // skillOptGateRunReport is the machine-readable result of one `gate run` (#627).
 type skillOptGateRunReport struct {
-	CandidateVersionID string                  `json:"candidate_version_id"`
-	ChampionVersionID  string                  `json:"champion_version_id"`
-	TemplateID         string                  `json:"template_id"`
-	CorpusPath         string                  `json:"corpus_path"`
-	CorpusVersion      int                     `json:"corpus_version"`
-	CorpusItems        int                     `json:"corpus_items"`
-	Accepted           bool                    `json:"accepted"`
-	Attempts           int                     `json:"attempts"`
-	ChampionMean       float64                 `json:"champion_mean"`
-	CandidateMean      float64                 `json:"candidate_mean"`
-	Reason             string                  `json:"reason"`
+	CandidateVersionID string                   `json:"candidate_version_id"`
+	ChampionVersionID  string                   `json:"champion_version_id"`
+	TemplateID         string                   `json:"template_id"`
+	CorpusPath         string                   `json:"corpus_path"`
+	CorpusVersion      int                      `json:"corpus_version"`
+	CorpusItems        int                      `json:"corpus_items"`
+	Accepted           bool                     `json:"accepted"`
+	Attempts           int                      `json:"attempts"`
+	ChampionMean       float64                  `json:"champion_mean"`
+	CandidateMean      float64                  `json:"candidate_mean"`
+	Reason             string                   `json:"reason"`
 	Deltas             []skillopt.GateItemDelta `json:"deltas"`
-	GateRunID          string                  `json:"gate_run_id"`
+	GateRunID          string                   `json:"gate_run_id"`
 }
 
 func runSkillOptGateRun(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/skillopt_gate.go
+++ b/internal/cli/skillopt_gate.go
@@ -1,0 +1,393 @@
+package cli
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+// gateReplayEnvRunner is the minimal subprocess capability the deterministic replay
+// driver needs: run a `sh -c` command with extra env. subprocess.ExecRunner
+// satisfies it; a test injects a deterministic fake so the E2E never shells out.
+type gateReplayEnvRunner interface {
+	RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (subprocess.Result, error)
+}
+
+// gateReplayRunner is swappable so tests drive the gate through the real candidate
+// plumbing with a deterministic fake runner (no live subprocess). Production uses
+// subprocess.ExecRunner.
+var gateReplayRunner gateReplayEnvRunner = subprocess.ExecRunner{}
+
+func runSkillOptGate(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptGateUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "run":
+		return runSkillOptGateRun(args[1:], stdout, stderr)
+	case "history":
+		return runSkillOptGateHistory(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt gate command %q\n\n", args[0])
+		printSkillOptGateUsage(stderr)
+		return 2
+	}
+}
+
+func printSkillOptGateUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot skillopt gate run --candidate <version-id> [--corpus <path>] [--replay-command <cmd>] [--config path] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot skillopt gate history --candidate <version-id> [--home path] [--json]")
+}
+
+// skillOptGateRunReport is the machine-readable result of one `gate run` (#627).
+type skillOptGateRunReport struct {
+	CandidateVersionID string                  `json:"candidate_version_id"`
+	ChampionVersionID  string                  `json:"champion_version_id"`
+	TemplateID         string                  `json:"template_id"`
+	CorpusPath         string                  `json:"corpus_path"`
+	CorpusVersion      int                     `json:"corpus_version"`
+	CorpusItems        int                     `json:"corpus_items"`
+	Accepted           bool                    `json:"accepted"`
+	Attempts           int                     `json:"attempts"`
+	ChampionMean       float64                 `json:"champion_mean"`
+	CandidateMean      float64                 `json:"candidate_mean"`
+	Reason             string                  `json:"reason"`
+	Deltas             []skillopt.GateItemDelta `json:"deltas"`
+	GateRunID          string                  `json:"gate_run_id"`
+}
+
+func runSkillOptGateRun(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt gate run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	candidateID := fs.String("candidate", "", "candidate template version id to gate (required)")
+	corpusPath := fs.String("corpus", "", "path to the fixed replay corpus file (overrides [skillopt].gate_corpus)")
+	replayCommand := fs.String("replay-command", "", "deterministic replay driver command (overrides the corpus/config default)")
+	configPath := fs.String("config", "", "config file to load [skillopt] defaults from")
+	jsonOut := fs.Bool("json", false, "emit the gate report as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if strings.TrimSpace(*candidateID) == "" {
+		fmt.Fprintln(stderr, "skillopt gate run: --candidate is required")
+		printSkillOptGateUsage(stderr)
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt gate run does not accept positional arguments")
+		return 2
+	}
+
+	policy := skillOptGatePolicy(*home, *configPath)
+	resolvedCorpus := firstNonEmpty(strings.TrimSpace(*corpusPath), policy.GateCorpusPath)
+	if resolvedCorpus == "" {
+		fmt.Fprintln(stderr, "skillopt gate run: no corpus (pass --corpus or set [skillopt].gate_corpus)")
+		return 2
+	}
+	corpus, err := skillopt.LoadGateCorpus(resolvedCorpus)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt gate run: %v\n", err)
+		return 1
+	}
+	replayCmd := firstNonEmpty(strings.TrimSpace(*replayCommand), strings.TrimSpace(corpus.ReplayCommand), policy.GateReplayCommand)
+	if replayCmd == "" {
+		fmt.Fprintln(stderr, "skillopt gate run: no replay command (pass --replay-command, set the corpus replay_command, or [skillopt].gate_replay_command)")
+		return 2
+	}
+
+	var report skillOptGateRunReport
+	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		candidate, err := store.GetAgentTemplateVersionByID(ctx, strings.TrimSpace(*candidateID))
+		if err != nil {
+			return fmt.Errorf("resolve candidate %q: %w", strings.TrimSpace(*candidateID), err)
+		}
+		champion, hasChampion, err := store.GetCurrentAgentTemplateVersion(ctx, candidate.TemplateID)
+		if err != nil {
+			return fmt.Errorf("resolve champion for template %q: %w", candidate.TemplateID, err)
+		}
+		if !hasChampion {
+			return fmt.Errorf("template %q has no current champion version to compare against; the gate needs a baseline", candidate.TemplateID)
+		}
+
+		replay := gateReplayDriver(corpus, replayCmd)
+		// Score the champion ONCE on the same fixed corpus (it does not change across
+		// gate attempts).
+		championScores, _, err := replay(ctx, champion.Content)
+		if err != nil {
+			return fmt.Errorf("replay champion: %w", err)
+		}
+		// The CLI `gate run` is a SINGLE evaluation (attempt 1, no optimizer wired):
+		// the one-retry-with-optimizer protocol is the train-workflow integration. A
+		// nil optimize func makes RunGateProtocol take exactly attempt 1 and reject on
+		// failure — the same code path, so the CLI and the workflow share the gate.
+		outcome, err := skillopt.RunGateProtocol(ctx, championScores, candidate.Content, replay, nil)
+		if err != nil {
+			return err
+		}
+
+		report = buildGateRunReport(candidate, champion, corpus, resolvedCorpus, outcome)
+		gateRun := gateRunRecord(candidate, champion, corpus, resolvedCorpus, outcome)
+		report.GateRunID = gateRun.ID
+		if err := store.InsertSkillOptGateRun(ctx, gateRun); err != nil {
+			return fmt.Errorf("persist gate run: %w", err)
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt gate run: %v\n", err)
+		return 1
+	}
+
+	if *jsonOut {
+		if err := json.NewEncoder(stdout).Encode(report); err != nil {
+			fmt.Fprintf(stderr, "skillopt gate run: encode json: %v\n", err)
+			return 1
+		}
+	} else {
+		printGateRunReport(stdout, report)
+	}
+	// A rejected gate is NOT a CLI error (the run completed and was persisted), but it
+	// exits non-zero so a script can branch on the verdict.
+	if !report.Accepted {
+		return 1
+	}
+	return 0
+}
+
+// gateReplayDriver builds the deterministic replay function: for each corpus item it
+// writes the template content to a temp file and runs the replay command via
+// `sh -c` with the item's prompt/expected/id in the environment, parsing the
+// command's stdout into a GateReplayResult scored by the EXISTING deterministic
+// metrics (#627). There is NO live LLM in the gate — the command is the
+// deterministic map, so two runs over the same corpus + template yield identical
+// scores.
+func gateReplayDriver(corpus skillopt.GateCorpus, replayCommand string) skillopt.GateReplayFunc {
+	return func(ctx context.Context, templateContent string) ([]skillopt.GateItemScore, skillopt.GateReplayLog, error) {
+		tmpFile, err := os.CreateTemp("", "gitmoot-gate-template-*.md")
+		if err != nil {
+			return nil, skillopt.GateReplayLog{}, fmt.Errorf("stage template: %w", err)
+		}
+		templatePath := tmpFile.Name()
+		defer os.Remove(templatePath)
+		if _, err := tmpFile.WriteString(templateContent); err != nil {
+			tmpFile.Close()
+			return nil, skillopt.GateReplayLog{}, fmt.Errorf("write template: %w", err)
+		}
+		if err := tmpFile.Close(); err != nil {
+			return nil, skillopt.GateReplayLog{}, fmt.Errorf("close template: %w", err)
+		}
+
+		scores := make([]skillopt.GateItemScore, 0, len(corpus.Items))
+		results := make([]skillopt.GateReplayResult, 0, len(corpus.Items))
+		for _, item := range corpus.Items {
+			env := []string{
+				"GITMOOT_GATE_TEMPLATE_FILE=" + templatePath,
+				"GITMOOT_GATE_ITEM_ID=" + item.ID,
+				"GITMOOT_GATE_PROMPT=" + item.Prompt,
+				"GITMOOT_GATE_EXPECTED=" + item.Expected,
+			}
+			res, runErr := gateReplayRunner.RunEnv(ctx, filepath.Dir(templatePath), env, "sh", "-c", replayCommand)
+			if runErr != nil {
+				detail := strings.TrimSpace(res.Stderr)
+				if detail == "" {
+					detail = strings.TrimSpace(res.Stdout)
+				}
+				if detail != "" {
+					return nil, skillopt.GateReplayLog{}, fmt.Errorf("replay corpus item %q: %s: %w", item.ID, detail, runErr)
+				}
+				return nil, skillopt.GateReplayLog{}, fmt.Errorf("replay corpus item %q: %w", item.ID, runErr)
+			}
+			result, parseErr := parseGateReplayResult(item.ID, res.Stdout)
+			if parseErr != nil {
+				return nil, skillopt.GateReplayLog{}, fmt.Errorf("replay corpus item %q: %w", item.ID, parseErr)
+			}
+			results = append(results, result)
+			score, has := result.Score()
+			scores = append(scores, skillopt.GateItemScore{ItemID: item.ID, Score: score, HasScore: has})
+		}
+		return scores, skillopt.GateReplayLog{Results: results}, nil
+	}
+}
+
+// parseGateReplayResult decodes the replay command's stdout into a per-item result,
+// stamping the corpus item id so a driver that omits it still aligns. A blank stdout
+// is a hard error (the command produced no verdict).
+func parseGateReplayResult(itemID string, stdout string) (skillopt.GateReplayResult, error) {
+	trimmed := strings.TrimSpace(stdout)
+	if trimmed == "" {
+		return skillopt.GateReplayResult{}, errors.New("replay command produced no output")
+	}
+	var result skillopt.GateReplayResult
+	if err := json.Unmarshal([]byte(trimmed), &result); err != nil {
+		return skillopt.GateReplayResult{}, fmt.Errorf("decode replay result: %w", err)
+	}
+	if strings.TrimSpace(result.ItemID) == "" {
+		result.ItemID = itemID
+	}
+	return result, nil
+}
+
+func buildGateRunReport(candidate, champion db.AgentTemplateVersion, corpus skillopt.GateCorpus, corpusPath string, outcome skillopt.GateProtocolOutcome) skillOptGateRunReport {
+	report := skillOptGateRunReport{
+		CandidateVersionID: candidate.ID,
+		ChampionVersionID:  champion.ID,
+		TemplateID:         candidate.TemplateID,
+		CorpusPath:         corpusPath,
+		CorpusVersion:      corpus.Version,
+		CorpusItems:        len(corpus.Items),
+		Accepted:           outcome.Accepted,
+		Attempts:           len(outcome.Attempts),
+		Reason:             outcome.Reason,
+	}
+	if len(outcome.Attempts) > 0 {
+		last := outcome.Attempts[len(outcome.Attempts)-1]
+		report.ChampionMean = last.Verdict.ChampionMean
+		report.CandidateMean = last.Verdict.CandidateMean
+		report.Deltas = last.Verdict.Deltas
+	}
+	return report
+}
+
+func gateRunRecord(candidate, champion db.AgentTemplateVersion, corpus skillopt.GateCorpus, corpusPath string, outcome skillopt.GateProtocolOutcome) db.SkillOptGateRun {
+	var championMean, candidateMean float64
+	var deltasJSON string
+	if len(outcome.Attempts) > 0 {
+		last := outcome.Attempts[len(outcome.Attempts)-1]
+		championMean = last.Verdict.ChampionMean
+		candidateMean = last.Verdict.CandidateMean
+		if raw, err := json.Marshal(last.Verdict.Deltas); err == nil {
+			deltasJSON = string(raw)
+		}
+	}
+	return db.SkillOptGateRun{
+		ID:                 newGateRunID(),
+		TemplateID:         candidate.TemplateID,
+		CandidateVersionID: candidate.ID,
+		ChampionVersionID:  champion.ID,
+		CorpusPath:         corpusPath,
+		CorpusVersion:      corpus.Version,
+		CorpusItems:        len(corpus.Items),
+		Attempts:           len(outcome.Attempts),
+		Accepted:           outcome.Accepted,
+		ChampionMean:       championMean,
+		CandidateMean:      candidateMean,
+		Reason:             outcome.Reason,
+		DeltasJSON:         deltasJSON,
+	}
+}
+
+func printGateRunReport(w io.Writer, report skillOptGateRunReport) {
+	verdict := "REJECTED"
+	if report.Accepted {
+		verdict = "ACCEPTED"
+	}
+	fmt.Fprintf(w, "gate %s (attempts: %d)\n", verdict, report.Attempts)
+	fmt.Fprintf(w, "candidate: %s   champion: %s\n", report.CandidateVersionID, report.ChampionVersionID)
+	fmt.Fprintf(w, "corpus: %s (v%d, %d items)\n", report.CorpusPath, report.CorpusVersion, report.CorpusItems)
+	fmt.Fprintf(w, "champion mean: %.4f   candidate mean: %.4f\n", report.ChampionMean, report.CandidateMean)
+	fmt.Fprintf(w, "reason: %s\n", report.Reason)
+	if len(report.Deltas) > 0 {
+		fmt.Fprintf(w, "%-24s %-10s %-10s %-10s\n", "ITEM", "CHAMPION", "CANDIDATE", "DELTA")
+		for _, d := range report.Deltas {
+			marker := ""
+			if d.Regressed {
+				marker = "  (regressed)"
+			}
+			fmt.Fprintf(w, "%-24s %-10.4f %-10.4f %+-10.4f%s\n", d.ItemID, d.ChampionScore, d.CandidateScore, d.Delta, marker)
+		}
+	}
+}
+
+func runSkillOptGateHistory(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt gate history", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	candidateID := fs.String("candidate", "", "candidate template version id (required)")
+	jsonOut := fs.Bool("json", false, "emit the history as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if strings.TrimSpace(*candidateID) == "" {
+		fmt.Fprintln(stderr, "skillopt gate history: --candidate is required")
+		return 2
+	}
+	var runs []db.SkillOptGateRun
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		runs, err = store.ListSkillOptGateRuns(context.Background(), strings.TrimSpace(*candidateID))
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt gate history: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		if err := json.NewEncoder(stdout).Encode(runs); err != nil {
+			fmt.Fprintf(stderr, "skillopt gate history: encode json: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(runs) == 0 {
+		writeLine(stdout, "no gate runs for %s", strings.TrimSpace(*candidateID))
+		return 0
+	}
+	fmt.Fprintf(stdout, "%-20s %-9s %-8s %-9s %-9s %s\n", "GATE-RUN", "VERDICT", "ATTEMPTS", "CHAMP", "CAND", "CREATED")
+	for _, run := range runs {
+		verdict := "reject"
+		if run.Accepted {
+			verdict = "accept"
+		}
+		fmt.Fprintf(stdout, "%-20s %-9s %-8d %-9.4f %-9.4f %s\n", run.ID, verdict, run.Attempts, run.ChampionMean, run.CandidateMean, run.CreatedAt)
+	}
+	return 0
+}
+
+// skillOptGatePolicy loads the [skillopt] policy for gate defaults, preferring an
+// explicit --config path and falling back to the home's config. It is fail-soft: a
+// load error yields the default policy (empty gate defaults), so the CLI still runs
+// when the operator passes every value explicitly.
+func skillOptGatePolicy(home, configPath string) config.SkillOptPolicy {
+	if trimmed := strings.TrimSpace(configPath); trimmed != "" {
+		if policy, err := config.LoadSkillOptPolicy(config.Paths{ConfigFile: trimmed}); err == nil {
+			return policy
+		}
+		return config.DefaultSkillOptPolicy()
+	}
+	if policy, err := loadSkillOptPolicy(home); err == nil {
+		return policy
+	}
+	return config.DefaultSkillOptPolicy()
+}
+
+// newGateRunID mints a fresh, sortable-ish gate-run id (RFC3339Nano timestamp plus
+// a random suffix so concurrent runs never collide). It is a var so tests can make
+// it deterministic.
+var newGateRunID = func() string {
+	suffix := make([]byte, 6)
+	if _, err := rand.Read(suffix); err != nil {
+		return "gate-" + time.Now().UTC().Format("20060102T150405.000000000")
+	}
+	return fmt.Sprintf("gate-%s-%s", time.Now().UTC().Format("20060102T150405"), hex.EncodeToString(suffix))
+}

--- a/internal/cli/skillopt_gate_test.go
+++ b/internal/cli/skillopt_gate_test.go
@@ -1,0 +1,272 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+// markerScoringRunner is a DETERMINISTIC fake replay driver: it reads the template
+// file the gate staged (GITMOOT_GATE_TEMPLATE_FILE), counts a marker token, and
+// emits a deterministic per-item rubric score. No live LLM, no real subprocess — so
+// the E2E drives the REAL candidate plumbing (store, corpus, protocol, persistence)
+// with reproducible scores. A better template (more markers) scores higher; a worse
+// one scores lower, exactly the signal the strict-improvement gate turns on.
+type markerScoringRunner struct {
+	marker string
+	calls  int
+}
+
+func (r *markerScoringRunner) RunEnv(_ context.Context, _ string, env []string, _ string, _ ...string) (subprocess.Result, error) {
+	r.calls++
+	var templatePath string
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "GITMOOT_GATE_TEMPLATE_FILE=") {
+			templatePath = strings.TrimPrefix(kv, "GITMOOT_GATE_TEMPLATE_FILE=")
+		}
+	}
+	content, err := os.ReadFile(templatePath)
+	if err != nil {
+		return subprocess.Result{Stderr: err.Error()}, err
+	}
+	count := strings.Count(string(content), r.marker)
+	score := float64(count) * 0.3
+	if score > 1 {
+		score = 1
+	}
+	out, _ := json.Marshal(skillopt.GateReplayResult{Rubric: map[string]float64{"quality": score}})
+	return subprocess.Result{Stdout: string(out)}, nil
+}
+
+func (r *markerScoringRunner) LookPath(file string) (string, error) { return file, nil }
+
+// seedGateTemplate installs a champion template (its body carries championMarkers
+// copies of "STRONG") and imports a candidate (candidateMarkers copies), returning
+// the store, home, and the pending candidate version.
+func seedGateTemplate(t *testing.T, championMarkers, candidateMarkers int) (*db.Store, string, db.AgentTemplateVersion) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	championBody := strings.TrimSpace(strings.Repeat("STRONG ", championMarkers)) + " guidance."
+	if err := store.UpsertAgentTemplate(context.Background(), cliSkillOptTemplate("planner", championBody)); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	candidateBody := strings.TrimSpace(strings.Repeat("STRONG ", candidateMarkers)) + " guidance."
+	candidate := cliSkillOptCandidatePackage(t, "planner", installed.VersionID, candidateBody)
+	version, err := skillopt.ImportCandidatePackage(context.Background(), store, candidate, "candidate.json")
+	if err != nil {
+		t.Fatalf("ImportCandidatePackage returned error: %v", err)
+	}
+	return store, home, version
+}
+
+// writeGateCorpus writes a minimal valid two-item corpus and returns its path.
+func writeGateCorpus(t *testing.T, dir string) string {
+	t.Helper()
+	corpus := skillopt.GateCorpus{
+		Kind:          skillopt.GateCorpusKind,
+		Version:       1,
+		ReplayCommand: "true",
+		Items: []skillopt.GateCorpusItem{
+			{ID: "item-1", Prompt: "implement widget A", Expected: "builds"},
+			{ID: "item-2", Prompt: "implement widget B", Expected: "builds"},
+		},
+	}
+	raw, err := json.MarshalIndent(corpus, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal corpus: %v", err)
+	}
+	path := filepath.Join(dir, "corpus.json")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write corpus: %v", err)
+	}
+	return path
+}
+
+func withGateReplayRunner(t *testing.T, runner gateReplayEnvRunner) {
+	t.Helper()
+	prev := gateReplayRunner
+	gateReplayRunner = runner
+	t.Cleanup(func() { gateReplayRunner = prev })
+}
+
+// TestSkillOptGateRunRejectsWorseCandidate is the mutation-anchored E2E: a
+// deliberately-worse candidate (fewer markers than the champion) is replayed
+// through the REAL candidate plumbing with a seeded corpus and MUST be rejected.
+// Inverting the strict-improvement comparison in EvaluateGate would let this worse
+// candidate pass — turning this assertion red.
+func TestSkillOptGateRunRejectsWorseCandidate(t *testing.T) {
+	store, home, version := seedGateTemplate(t, 3 /*champion*/, 1 /*candidate is worse*/)
+	corpusPath := writeGateCorpus(t, home)
+	withGateReplayRunner(t, &markerScoringRunner{marker: "STRONG"})
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillOptGateRun([]string{"--home", home, "--candidate", version.ID, "--corpus", corpusPath, "--json"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("worse candidate gate run exit = %d (want 1 reject); stderr=%s", code, stderr.String())
+	}
+	var report skillOptGateRunReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v; stdout=%s", err, stdout.String())
+	}
+	if report.Accepted {
+		t.Fatalf("worse candidate was ACCEPTED; champion mean %.3f candidate mean %.3f", report.ChampionMean, report.CandidateMean)
+	}
+	if report.CandidateMean >= report.ChampionMean {
+		t.Fatalf("expected candidate mean < champion mean, got champ=%.3f cand=%.3f", report.ChampionMean, report.CandidateMean)
+	}
+	// The run is persisted for audit, and the candidate carries NO accepted gate run.
+	accepted, err := store.HasAcceptedSkillOptGateRun(context.Background(), version.ID)
+	if err != nil {
+		t.Fatalf("HasAcceptedSkillOptGateRun returned error: %v", err)
+	}
+	if accepted {
+		t.Fatalf("a rejected gate must not record an accepted run")
+	}
+	runs, err := store.ListSkillOptGateRuns(context.Background(), version.ID)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("expected exactly 1 persisted gate run, got %d (err=%v)", len(runs), err)
+	}
+}
+
+func TestSkillOptGateRunAcceptsBetterCandidate(t *testing.T) {
+	store, home, version := seedGateTemplate(t, 1 /*champion*/, 3 /*candidate is better*/)
+	corpusPath := writeGateCorpus(t, home)
+	withGateReplayRunner(t, &markerScoringRunner{marker: "STRONG"})
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillOptGateRun([]string{"--home", home, "--candidate", version.ID, "--corpus", corpusPath, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("better candidate gate run exit = %d (want 0 accept); stderr=%s", code, stderr.String())
+	}
+	var report skillOptGateRunReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	if !report.Accepted {
+		t.Fatalf("better candidate was rejected: %s", report.Reason)
+	}
+	accepted, err := store.HasAcceptedSkillOptGateRun(context.Background(), version.ID)
+	if err != nil || !accepted {
+		t.Fatalf("expected an accepted gate run on record (accepted=%v err=%v)", accepted, err)
+	}
+}
+
+// TestSkillOptGateReplayDeterminism proves two replays over the same corpus +
+// template yield IDENTICAL per-item scores (the gate has no live-LLM variance).
+func TestSkillOptGateReplayDeterminism(t *testing.T) {
+	home := t.TempDir()
+	corpusPath := writeGateCorpus(t, home)
+	corpus, err := skillopt.LoadGateCorpus(corpusPath)
+	if err != nil {
+		t.Fatalf("LoadGateCorpus returned error: %v", err)
+	}
+	withGateReplayRunner(t, &markerScoringRunner{marker: "STRONG"})
+	driver := gateReplayDriver(corpus, "true")
+
+	content := "# Planner\n\nSTRONG STRONG guidance.\n"
+	first, _, err := driver(context.Background(), content)
+	if err != nil {
+		t.Fatalf("first replay returned error: %v", err)
+	}
+	second, _, err := driver(context.Background(), content)
+	if err != nil {
+		t.Fatalf("second replay returned error: %v", err)
+	}
+	if len(first) != len(second) || len(first) != len(corpus.Items) {
+		t.Fatalf("score counts differ: %d vs %d (corpus %d)", len(first), len(second), len(corpus.Items))
+	}
+	for i := range first {
+		if first[i].ItemID != second[i].ItemID || first[i].Score != second[i].Score || first[i].HasScore != second[i].HasScore {
+			t.Fatalf("non-deterministic score for %s: %+v vs %+v", first[i].ItemID, first[i], second[i])
+		}
+	}
+}
+
+// TestGatePromotionGuardBlocksThenAllows drives the REAL runCandidateNotify
+// promotion seam: with [skillopt].gate_enabled on and guardrails otherwise passing,
+// a candidate with NO passing gate run is blocked (stays pending, gate_blocked
+// event); after an accepted gate run is recorded, the same notify promotes it.
+func TestGatePromotionGuardBlocksThenAllows(t *testing.T) {
+	ctx := context.Background()
+	store, _, version := seedGateTemplate(t, 1, 3)
+
+	minSamples := 1
+	minScore := 0.5
+	score := 0.82
+	policy := config.DefaultSkillOptPolicy()
+	policy.AutoPromote = true
+	policy.AutoPromoteMinSamples = &minSamples
+	policy.AutoPromoteMinScore = &minScore
+	policy.Gate = true
+
+	candidate := skillopt.CandidatePackage{Summary: skillopt.CandidateSummary{Score: &score}}
+	feedback := []db.FeedbackEvent{{Choice: "a"}}
+	sink := &recordingSink{}
+
+	// (1) Gate enabled, no accepted gate run -> blocked, no promotion.
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, feedback, false, nil, 0, ""); err != nil {
+		t.Fatalf("runCandidateNotify (blocked) returned error: %v", err)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "pending" {
+		t.Fatalf("gate-blocked candidate state = %q, want pending (no promotion)", after.State)
+	}
+	if !hasGateBlockedEvent(sink) {
+		t.Fatalf("expected a gate_blocked awaiting event")
+	}
+
+	// (2) Record an accepted gate run, then notify again -> promotes to current.
+	if err := store.InsertSkillOptGateRun(ctx, db.SkillOptGateRun{
+		ID: "gate-accepted", TemplateID: version.TemplateID, CandidateVersionID: version.ID,
+		ChampionVersionID: "planner@v1", Accepted: true, Attempts: 1,
+	}); err != nil {
+		t.Fatalf("InsertSkillOptGateRun returned error: %v", err)
+	}
+	sink2 := &recordingSink{}
+	if err := runCandidateNotify(ctx, store, sink2, policy, candidate, version, feedback, false, nil, 0, ""); err != nil {
+		t.Fatalf("runCandidateNotify (allowed) returned error: %v", err)
+	}
+	promoted, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if promoted.State != "current" {
+		t.Fatalf("gate-passed candidate state = %q, want current (promoted)", promoted.State)
+	}
+}
+
+func hasGateBlockedEvent(sink *recordingSink) bool {
+	for _, e := range sink.byType(events.EventCandidateAwaitingPromotion) {
+		if e.Status == "gate_blocked" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -230,6 +230,23 @@ path = ""
 #     environment failure and SKIPS the run (no row) instead of recording a negative, but
 #     a command that runs and exits non-zero because deps were missing is an honest FAIL
 #     — so keep each command self-contained.
+#   gate_enabled (#627): OFF by default; STANDALONE (no auto_trace dependency). The
+#     deterministic fixed-corpus REPLAY GATE (AutoMem A.2): a pre-canary check that
+#     replays a candidate template against a FIXED job corpus and accepts it only on
+#     STRICT improvement over the champion on the SAME corpus (a tie fails). When on, a
+#     candidate must carry a PASSING gate run ('gitmoot skillopt gate run --candidate
+#     <id>') before it may be promoted to canary/current — otherwise promotion is
+#     blocked with a gate_blocked notify. Off ⇒ byte-identical (the gate is never
+#     consulted). It reuses the #474/#485 deterministic scorers on the corpus outputs
+#     (no new judge, no live LLM in the gate itself); promotion stays MANUAL.
+#   gate_corpus (#627): default fixed-corpus file path used by 'gitmoot skillopt gate
+#     run' when no --corpus is passed. UNSET ⇒ a corpus must be supplied on the CLI.
+#   gate_replay_command (#627): default deterministic replay driver run via 'sh -c' per
+#     corpus item. It receives GITMOOT_GATE_TEMPLATE_FILE (the candidate template),
+#     GITMOOT_GATE_PROMPT, GITMOOT_GATE_EXPECTED, and GITMOOT_GATE_ITEM_ID in the env
+#     and emits a per-item GateReplayResult JSON ({"rubric":{...}} or
+#     {"hard_verifier":true,"hard_passed":bool}) on stdout — the command IS the
+#     deterministic map. A corpus's own replay_command overrides this default.
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false
@@ -239,6 +256,9 @@ path = ""
 # hard_verifiers_enabled = false
 # hard_verifier_commands = go build ./...
 # hard_verifier_commands = go test ./...
+# gate_enabled = false
+# gate_corpus = .gitmoot/skillopt/gate-corpus.json
+# gate_replay_command = sh .gitmoot/skillopt/gate-replay.sh
 # auto_promote = false
 # auto_promote_min_samples = 0
 # auto_promote_min_score = 0.0

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -666,6 +666,34 @@ type SkillOptPolicy struct {
 	// one. Parsed from repeatable `hard_verifier_commands = <one command>` lines so a
 	// command may itself contain commas without ambiguity.
 	HardVerifierCommands []string
+
+	// Gate opts into the OFF-by-default deterministic fixed-corpus replay gate
+	// (#627, AutoMem A.2): a pre-canary gate that replays a candidate template
+	// against a fixed job corpus and accepts it only on STRICT improvement over the
+	// champion on the same corpus. When true, GatePromotionGuard blocks a
+	// candidate->canary promotion until the candidate has a passing gate run on
+	// record. false (the default) is byte-identical to the pre-#627 promote path (the
+	// gate is never consulted). The field is named Gate (not …Enabled) because Go
+	// forbids a field and method sharing a name; GateEnabled() below is the resolved
+	// accessor callers use. The gate is standalone — it does NOT require
+	// AutoTraceEnabled — so it can guard promotions independent of the harvester.
+	Gate bool
+
+	// GateCorpusPath is the default fixed-corpus file path used by
+	// `gitmoot skillopt gate run` when no --corpus flag is supplied (#627). Empty
+	// (the default) means a corpus MUST be supplied on the command line.
+	GateCorpusPath string
+
+	// GateReplayCommand is the default deterministic replay driver command run via
+	// `sh -c` for each corpus item (#627): it receives the candidate template file
+	// (GITMOOT_GATE_TEMPLATE_FILE), the corpus item prompt (GITMOOT_GATE_PROMPT),
+	// expected outcome (GITMOOT_GATE_EXPECTED), and item id (GITMOOT_GATE_ITEM_ID) in
+	// the environment, and emits a deterministic per-item GateReplayResult JSON on
+	// stdout. There is no live LLM in the gate itself — the command is the
+	// deterministic map. A corpus's own replay_command overrides this default. Empty
+	// (the default) means a command MUST be supplied on the command line or in the
+	// corpus.
+	GateReplayCommand string
 }
 
 // DefaultDeterministicCheckers is the safe default checker set used when the
@@ -704,7 +732,18 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		DeterministicCheckerList:        nil,
 		HardVerifiers:                   false,
 		HardVerifierCommands:            nil,
+		Gate:                            false,
+		GateCorpusPath:                  "",
+		GateReplayCommand:               "",
 	}
+}
+
+// GateEnabled reports whether the deterministic fixed-corpus replay gate (#627) is
+// configured on. It is standalone (no AutoTraceEnabled dependency): the gate guards
+// candidate->canary promotion on its own. Default false means byte-identical
+// behavior with no config — the gate is never consulted.
+func (p SkillOptPolicy) GateEnabled() bool {
+	return p.Gate
 }
 
 // Enabled reports whether the automatic trace-harvester is configured on. With
@@ -954,6 +993,16 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		if trimmed := strings.TrimSpace(value); trimmed != "" {
 			policy.HardVerifierCommands = append(policy.HardVerifierCommands, trimmed)
 		}
+		return nil
+	case "gate_enabled":
+		parsed, err := strconv.ParseBool(value)
+		policy.Gate = parsed
+		return err
+	case "gate_corpus":
+		policy.GateCorpusPath = strings.TrimSpace(value)
+		return nil
+	case "gate_replay_command":
+		policy.GateReplayCommand = strings.TrimSpace(value)
 		return nil
 	default:
 		return nil

--- a/internal/config/skillopt_gate_test.go
+++ b/internal/config/skillopt_gate_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLoadSkillOptPolicyGateDefaultsDisabled: the replay gate is OFF by default and
+// carries no corpus/replay defaults (#627).
+func TestLoadSkillOptPolicyGateDefaultsDisabled(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.Gate || policy.GateEnabled() {
+		t.Fatalf("replay gate must default OFF, got %+v", policy)
+	}
+	if policy.GateCorpusPath != "" || policy.GateReplayCommand != "" {
+		t.Fatalf("gate corpus/replay must default empty, got %q / %q", policy.GateCorpusPath, policy.GateReplayCommand)
+	}
+}
+
+// TestLoadSkillOptPolicyGateParsesKnobs: gate_enabled/gate_corpus/gate_replay_command
+// parse; the gate is standalone (no auto_trace dependency) so GateEnabled() is true
+// with gate_enabled alone (#627).
+func TestLoadSkillOptPolicyGateParsesKnobs(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+gate_enabled = true
+gate_corpus = /etc/gitmoot/corpus.json
+gate_replay_command = sh replay.sh
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.Gate || !policy.GateEnabled() {
+		t.Fatalf("gate_enabled = true should turn the gate on standalone, got %+v", policy)
+	}
+	if policy.GateCorpusPath != "/etc/gitmoot/corpus.json" {
+		t.Fatalf("gate_corpus = %q, want /etc/gitmoot/corpus.json", policy.GateCorpusPath)
+	}
+	if policy.GateReplayCommand != "sh replay.sh" {
+		t.Fatalf("gate_replay_command = %q, want sh replay.sh", policy.GateReplayCommand)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -5743,6 +5743,114 @@ func (s *Store) GetNoCIObservation(ctx context.Context, repoFullName string, pul
 	return obs, nil
 }
 
+// SkillOptGateRun is one persisted deterministic replay-gate run for a candidate
+// (#627). It is an additive audit record: the champion the candidate was compared
+// against, the fixed corpus (path + version + item count), the two aggregate corpus
+// means, the accept/reject verdict, the attempt count (1, or 2 after the single
+// retry), the reason, and the per-item deltas serialized as JSON. It NEVER drives
+// promotion by itself — the promotion guard reads Accepted, but a human/operator
+// still promotes.
+type SkillOptGateRun struct {
+	ID                 string
+	TemplateID         string
+	CandidateVersionID string
+	ChampionVersionID  string
+	CorpusPath         string
+	CorpusVersion      int
+	CorpusItems        int
+	Attempts           int
+	Accepted           bool
+	ChampionMean       float64
+	CandidateMean      float64
+	Reason             string
+	DeltasJSON         string
+	CreatedAt          string
+}
+
+// InsertSkillOptGateRun appends a gate-run audit record (#627). It is additive and
+// never mutates a prior run (each gate execution is its own immutable row keyed by a
+// fresh id).
+func (s *Store) InsertSkillOptGateRun(ctx context.Context, run SkillOptGateRun) error {
+	accepted := 0
+	if run.Accepted {
+		accepted = 1
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO skillopt_gate_runs(
+			id, template_id, candidate_version_id, champion_version_id, corpus_path,
+			corpus_version, corpus_items, attempts, accepted, champion_mean,
+			candidate_mean, reason, deltas_json)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		run.ID, run.TemplateID, run.CandidateVersionID, run.ChampionVersionID, run.CorpusPath,
+		run.CorpusVersion, run.CorpusItems, run.Attempts, accepted, run.ChampionMean,
+		run.CandidateMean, run.Reason, run.DeltasJSON)
+	return err
+}
+
+// ListSkillOptGateRuns returns the gate-run audit records for a candidate version,
+// newest first (#627).
+func (s *Store) ListSkillOptGateRuns(ctx context.Context, candidateVersionID string) ([]SkillOptGateRun, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, template_id, candidate_version_id, champion_version_id, corpus_path,
+			corpus_version, corpus_items, attempts, accepted, champion_mean, candidate_mean, reason, deltas_json, created_at
+		FROM skillopt_gate_runs WHERE candidate_version_id = ? ORDER BY created_at DESC, rowid DESC`,
+		strings.TrimSpace(candidateVersionID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	runs := []SkillOptGateRun{}
+	for rows.Next() {
+		run, err := scanSkillOptGateRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, run)
+	}
+	return runs, rows.Err()
+}
+
+// HasAcceptedSkillOptGateRun reports whether a candidate version has at least one
+// ACCEPTED gate run on record (#627) — the fact the promotion guard consults.
+func (s *Store) HasAcceptedSkillOptGateRun(ctx context.Context, candidateVersionID string) (bool, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM skillopt_gate_runs WHERE candidate_version_id = ? AND accepted = 1`,
+		strings.TrimSpace(candidateVersionID)).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func scanSkillOptGateRun(scanner interface{ Scan(...any) error }) (SkillOptGateRun, error) {
+	var run SkillOptGateRun
+	var accepted int
+	if err := scanner.Scan(&run.ID, &run.TemplateID, &run.CandidateVersionID, &run.ChampionVersionID, &run.CorpusPath,
+		&run.CorpusVersion, &run.CorpusItems, &run.Attempts, &accepted, &run.ChampionMean, &run.CandidateMean,
+		&run.Reason, &run.DeltasJSON, &run.CreatedAt); err != nil {
+		return SkillOptGateRun{}, err
+	}
+	run.Accepted = accepted == 1
+	return run, nil
+}
+
+// GetCurrentAgentTemplateVersion returns the current champion version for a template
+// and whether one exists (#627). It is the public, tx-free counterpart of
+// getCurrentAgentTemplateVersion so the replay gate can resolve the champion the
+// candidate is compared against without opening a write transaction.
+func (s *Store) GetCurrentAgentTemplateVersion(ctx context.Context, templateID string) (AgentTemplateVersion, bool, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT v.id, v.template_id, v.version, v.state, v.name, v.description, v.source_repo, v.source_ref, v.source_path, v.resolved_commit, v.content_hash, v.content, v.metadata_json, v.created_at, v.updated_at, v.promoted_at, v.canary_sample, v.canary_started_at
+		FROM agent_templates t
+		JOIN agent_template_versions v ON v.id = t.current_version_id
+		WHERE t.id = ?`, strings.TrimSpace(templateID))
+	version, err := scanAgentTemplateVersion(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AgentTemplateVersion{}, false, nil
+	}
+	if err != nil {
+		return AgentTemplateVersion{}, false, err
+	}
+	return version, true, nil
+}
+
 func (s *Store) HasTable(ctx context.Context, name string) (bool, error) {
 	if strings.ContainsAny(name, "'\"`;") {
 		return false, fmt.Errorf("unsafe table name: %s", name)
@@ -7173,5 +7281,32 @@ CREATE UNIQUE INDEX idx_confirmed_repo_key ON confirmed_memories(owner_kind, own
 CREATE UNIQUE INDEX idx_confirmed_general_key ON confirmed_memories(owner_kind, owner_ref, owner_version, key) WHERE repo IS NULL;
 
 CREATE VIRTUAL TABLE confirmed_memories_fts USING fts5(content, key, tokenize='porter');
+	`,
+	// #627 deterministic fixed-corpus replay-gate audit trail. Each row records one
+	// terminal gate protocol run for a candidate: the champion it was compared
+	// against, the corpus (path + version), the two aggregate corpus means, the
+	// per-item deltas (JSON), the accept/reject verdict, and how many attempts (1 or
+	// the single retry -> 2) it took. Pure additive append (CREATE TABLE only): the
+	// table stays empty until a `gitmoot skillopt gate run` executes, and it is read
+	// only by the gate-run history + the promotion guard, so every existing DB reads
+	// identically. It NEVER promotes — promotion stays a separate, guarded action.
+	`
+CREATE TABLE skillopt_gate_runs (
+	id TEXT PRIMARY KEY,
+	template_id TEXT NOT NULL DEFAULT '',
+	candidate_version_id TEXT NOT NULL DEFAULT '',
+	champion_version_id TEXT NOT NULL DEFAULT '',
+	corpus_path TEXT NOT NULL DEFAULT '',
+	corpus_version INTEGER NOT NULL DEFAULT 0,
+	corpus_items INTEGER NOT NULL DEFAULT 0,
+	attempts INTEGER NOT NULL DEFAULT 0,
+	accepted INTEGER NOT NULL DEFAULT 0,
+	champion_mean REAL NOT NULL DEFAULT 0,
+	candidate_mean REAL NOT NULL DEFAULT 0,
+	reason TEXT NOT NULL DEFAULT '',
+	deltas_json TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_skillopt_gate_runs_candidate ON skillopt_gate_runs(candidate_version_id);
 	`,
 }

--- a/internal/db/store_gate_run_test.go
+++ b/internal/db/store_gate_run_test.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestSkillOptGateRunPersistence covers the additive replay-gate audit trail (#627):
+// insert two runs for a candidate, list them newest-first, and confirm the
+// accepted-run predicate the promotion guard consults.
+func TestSkillOptGateRunPersistence(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	candidate := "planner@v2"
+
+	// No runs yet: the promotion guard sees no accepted run.
+	if ok, err := store.HasAcceptedSkillOptGateRun(ctx, candidate); err != nil || ok {
+		t.Fatalf("HasAcceptedSkillOptGateRun on empty = %v (err=%v), want false", ok, err)
+	}
+
+	// A rejected run does not count as accepted.
+	if err := store.InsertSkillOptGateRun(ctx, SkillOptGateRun{
+		ID: "gate-1", TemplateID: "planner", CandidateVersionID: candidate,
+		ChampionVersionID: "planner@v1", CorpusPath: "corpus.json", CorpusVersion: 1,
+		CorpusItems: 2, Attempts: 2, Accepted: false, ChampionMean: 0.8, CandidateMean: 0.4,
+		Reason: "worse", DeltasJSON: `[{"item_id":"a"}]`,
+	}); err != nil {
+		t.Fatalf("InsertSkillOptGateRun (reject) returned error: %v", err)
+	}
+	if ok, err := store.HasAcceptedSkillOptGateRun(ctx, candidate); err != nil || ok {
+		t.Fatalf("after a rejected run HasAccepted = %v (err=%v), want false", ok, err)
+	}
+
+	// An accepted run flips the predicate.
+	if err := store.InsertSkillOptGateRun(ctx, SkillOptGateRun{
+		ID: "gate-2", TemplateID: "planner", CandidateVersionID: candidate,
+		ChampionVersionID: "planner@v1", CorpusPath: "corpus.json", CorpusVersion: 1,
+		CorpusItems: 2, Attempts: 1, Accepted: true, ChampionMean: 0.4, CandidateMean: 0.9,
+		Reason: "better", DeltasJSON: `[]`,
+	}); err != nil {
+		t.Fatalf("InsertSkillOptGateRun (accept) returned error: %v", err)
+	}
+	if ok, err := store.HasAcceptedSkillOptGateRun(ctx, candidate); err != nil || !ok {
+		t.Fatalf("after an accepted run HasAccepted = %v (err=%v), want true", ok, err)
+	}
+
+	runs, err := store.ListSkillOptGateRuns(ctx, candidate)
+	if err != nil {
+		t.Fatalf("ListSkillOptGateRuns returned error: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("listed %d runs, want 2", len(runs))
+	}
+	// A different candidate has no runs.
+	if other, err := store.ListSkillOptGateRuns(ctx, "planner@v9"); err != nil || len(other) != 0 {
+		t.Fatalf("unrelated candidate runs = %d (err=%v), want 0", len(other), err)
+	}
+	// Round-trip fields survive.
+	got := runs[0]
+	if got.Accepted != true && got.Accepted != false {
+		t.Fatalf("accepted did not round-trip")
+	}
+	found := map[string]SkillOptGateRun{}
+	for _, r := range runs {
+		found[r.ID] = r
+	}
+	if found["gate-1"].CandidateMean != 0.4 || found["gate-2"].CandidateMean != 0.9 {
+		t.Fatalf("means did not round-trip: %+v", found)
+	}
+}

--- a/internal/skillopt/gate.go
+++ b/internal/skillopt/gate.go
@@ -1,0 +1,409 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// GateCorpusKind is the fixed kind tag every replay-gate corpus file carries so a
+// stray JSON document is never mistaken for a corpus (#627). It mirrors the
+// candidate/training package kind discipline.
+const GateCorpusKind = "gitmoot-skillopt-gate-corpus"
+
+// GateCorpusItem is one fixed, deterministic (job fixture -> expected/verifiable
+// outcome) entry in the replay corpus (#627). The Prompt is the job fixture fed to
+// the replay driver; Expected is the verifiable expectation the deterministic
+// replay command scores against (a build/test target, a golden diff, a checker
+// bound). Neither is interpreted by the gate itself — they are handed verbatim to
+// the deterministic replay command, which owns the actual scoring — so the corpus
+// stays a plain, versioned data file with no live-LLM coupling.
+type GateCorpusItem struct {
+	ID       string `json:"id"`
+	Prompt   string `json:"prompt"`
+	Expected string `json:"expected,omitempty"`
+}
+
+// GateCorpus is the versioned, fixed job corpus a candidate template is replayed
+// against before it is allowed to proceed to canary (#627, AutoMem A.2). It is a
+// plain data file (or config-embedded document): the same fixed seeds every replay
+// runs on, so the champion and candidate are compared on identical inputs. The
+// ReplayCommand, when set, is the corpus-scoped deterministic replay driver
+// (`sh -c`); a caller/config default is used when it is empty.
+type GateCorpus struct {
+	Kind          string           `json:"kind"`
+	Version       int              `json:"version"`
+	ReplayCommand string           `json:"replay_command,omitempty"`
+	Items         []GateCorpusItem `json:"items"`
+}
+
+// ParseGateCorpus decodes and validates a corpus document (#627). It is strict: the
+// kind must match, the version must be >= 1 (a corpus is versioned so a scoring
+// change is auditable), there must be at least one item, and every item must carry
+// a unique non-empty id and a non-empty prompt. A malformed corpus is rejected
+// rather than silently scoring an empty/duplicated set.
+func ParseGateCorpus(data []byte) (GateCorpus, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return GateCorpus{}, errors.New("gate corpus is empty")
+	}
+	var corpus GateCorpus
+	if err := json.Unmarshal(data, &corpus); err != nil {
+		return GateCorpus{}, fmt.Errorf("decode gate corpus: %w", err)
+	}
+	if corpus.Kind != GateCorpusKind {
+		return GateCorpus{}, fmt.Errorf("gate corpus kind must be %q, got %q", GateCorpusKind, corpus.Kind)
+	}
+	if corpus.Version < 1 {
+		return GateCorpus{}, fmt.Errorf("gate corpus version must be >= 1, got %d", corpus.Version)
+	}
+	if len(corpus.Items) == 0 {
+		return GateCorpus{}, errors.New("gate corpus has no items")
+	}
+	seen := make(map[string]struct{}, len(corpus.Items))
+	for i, item := range corpus.Items {
+		id := strings.TrimSpace(item.ID)
+		if id == "" {
+			return GateCorpus{}, fmt.Errorf("gate corpus item %d has an empty id", i)
+		}
+		if _, dup := seen[id]; dup {
+			return GateCorpus{}, fmt.Errorf("gate corpus item id %q is duplicated", id)
+		}
+		seen[id] = struct{}{}
+		if strings.TrimSpace(item.Prompt) == "" {
+			return GateCorpus{}, fmt.Errorf("gate corpus item %q has an empty prompt", id)
+		}
+	}
+	return corpus, nil
+}
+
+// LoadGateCorpus reads and validates a corpus file from disk (#627).
+func LoadGateCorpus(path string) (GateCorpus, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return GateCorpus{}, fmt.Errorf("read gate corpus %q: %w", path, err)
+	}
+	return ParseGateCorpus(data)
+}
+
+// GateReplayResult is the deterministic per-item outcome a replay driver emits for
+// one corpus item (#627). It is intentionally the SAME shape the hard-verifier
+// (#474) and deterministic-checker (#485) tiers already produce — a per-command/
+// per-dimension Rubric and/or a binary hard verdict — so the gate reuses the
+// EXISTING deterministic scorers (projectHardVerifier / projectChecker) instead of
+// inventing a new judge. The replay command owns producing this verdict
+// deterministically (no live LLM in the gate itself).
+type GateReplayResult struct {
+	// ItemID is the corpus item this result scores; the driver stamps it so a
+	// misaligned emit is caught.
+	ItemID string `json:"item_id"`
+	// Rubric carries per-dimension [0,1] scores (the deterministic-checker path) or
+	// per-command pass/fail (the hard-verifier audit map).
+	Rubric map[string]float64 `json:"rubric,omitempty"`
+	// HardVerifier marks this as an authoritative binary hard verdict (#474) rather
+	// than a soft objective rubric (#485); the gate scores it via projectHardVerifier.
+	HardVerifier bool `json:"hard_verifier,omitempty"`
+	// HardPassed is the binary verdict, meaningful only when HardVerifier is true.
+	HardPassed bool `json:"hard_passed,omitempty"`
+	// Findings is free-text audit detail carried into the replay log.
+	Findings string `json:"findings,omitempty"`
+}
+
+// outcome maps the replay result onto the internal workflow.Outcome the existing
+// deterministic scorers consume, so the gate never invents a new scoring scale.
+func (r GateReplayResult) outcome() workflow.Outcome {
+	outcome := workflow.Outcome{
+		Kind:     workflow.OutcomeReviewed,
+		Rubric:   r.Rubric,
+		Findings: r.Findings,
+	}
+	if r.HardVerifier {
+		outcome.HardVerifier = true
+		outcome.HardPassed = r.HardPassed
+	} else {
+		outcome.Objective = true
+	}
+	return outcome
+}
+
+// Signal projects the replay result into the SAME NormalizedSignal the auto-trace
+// harvester uses (#627): a hard-verifier result scores via projectHardVerifier (a
+// pass -> 1.0, a fail -> 0.0), any other result via projectChecker (the mean of the
+// deterministic-checker dimensions). An all-empty result yields HasScore=false.
+func (r GateReplayResult) Signal() NormalizedSignal {
+	outcome := r.outcome()
+	if outcome.HardVerifier {
+		return projectHardVerifier(outcome)
+	}
+	return projectChecker(outcome)
+}
+
+// Score returns the projected [0,1] quality score and whether it was scorable at
+// all, reusing the existing deterministic metrics.
+func (r GateReplayResult) Score() (float64, bool) {
+	signal := r.Signal()
+	return signal.Score, signal.HasScore
+}
+
+// GateItemScore is a single corpus item's projected [0,1] deterministic score for
+// one side (champion or candidate) of the comparison (#627).
+type GateItemScore struct {
+	ItemID   string
+	Score    float64
+	HasScore bool
+}
+
+// GateItemDelta is the per-item champion->candidate movement, surfaced in the
+// verdict + persisted for audit so a reviewer sees exactly which fixtures the
+// candidate improved or regressed on.
+type GateItemDelta struct {
+	ItemID         string  `json:"item_id"`
+	ChampionScore  float64 `json:"champion_score"`
+	CandidateScore float64 `json:"candidate_score"`
+	Delta          float64 `json:"delta"`
+	Regressed      bool    `json:"regressed"`
+}
+
+// GateVerdict is the pure result of EvaluateGate: pass/fail on STRICT improvement
+// plus the aggregate means and per-item deltas (#627). It performs no I/O.
+type GateVerdict struct {
+	Pass          bool            `json:"pass"`
+	Reason        string          `json:"reason"`
+	ChampionMean  float64         `json:"champion_mean"`
+	CandidateMean float64         `json:"candidate_mean"`
+	Deltas        []GateItemDelta `json:"deltas"`
+}
+
+// strictlyImproves is the SINGLE comparison the gate turns on (#627, AutoMem A.2):
+// a candidate is accepted ONLY when its corpus mean is STRICTLY greater than the
+// champion's on the same fixed corpus. A tie (equal means) is NOT an improvement
+// and FAILS — parity never earns a promotion. The deliberately-worse-candidate
+// mutation test inverts exactly this comparison (a worse candidate would then
+// pass), so keeping the rule in one named, total function makes the mutation crisp.
+func strictlyImproves(championMean, candidateMean float64) bool {
+	return candidateMean > championMean
+}
+
+// EvaluateGate compares the champion's and candidate's per-item deterministic
+// scores over the SAME corpus and returns a strict-improvement verdict (#627). It
+// is pure and total. The corpus item set is the union of the two sides' ids; every
+// item MUST carry a scorable value on BOTH sides — a missing/unscorable item on
+// either side fails the gate (we can never confirm improvement on a fixture we
+// could not score on both templates). The primary decision is the aggregate strict
+// improvement (strictlyImproves); the per-item deltas are computed for audit.
+func EvaluateGate(champion, candidate []GateItemScore) GateVerdict {
+	champ := indexGateScores(champion)
+	cand := indexGateScores(candidate)
+	ids := sortedGateItemIDs(champ, cand)
+	if len(ids) == 0 {
+		return GateVerdict{Pass: false, Reason: "empty corpus: no items to compare"}
+	}
+
+	deltas := make([]GateItemDelta, 0, len(ids))
+	var champSum, candSum float64
+	for _, id := range ids {
+		c, cOK := champ[id]
+		if !cOK || !c.HasScore {
+			return GateVerdict{
+				Pass:   false,
+				Reason: fmt.Sprintf("champion has no scorable outcome for corpus item %q; cannot confirm improvement", id),
+				Deltas: deltas,
+			}
+		}
+		d, dOK := cand[id]
+		if !dOK || !d.HasScore {
+			return GateVerdict{
+				Pass:   false,
+				Reason: fmt.Sprintf("candidate has no scorable outcome for corpus item %q; cannot confirm improvement", id),
+				Deltas: deltas,
+			}
+		}
+		delta := d.Score - c.Score
+		deltas = append(deltas, GateItemDelta{
+			ItemID:         id,
+			ChampionScore:  c.Score,
+			CandidateScore: d.Score,
+			Delta:          delta,
+			Regressed:      delta < 0,
+		})
+		champSum += c.Score
+		candSum += d.Score
+	}
+
+	n := float64(len(ids))
+	champMean := champSum / n
+	candMean := candSum / n
+	verdict := GateVerdict{ChampionMean: champMean, CandidateMean: candMean, Deltas: deltas}
+
+	if !strictlyImproves(champMean, candMean) {
+		verdict.Pass = false
+		verdict.Reason = fmt.Sprintf("candidate corpus mean %.4f is not a strict improvement over champion %.4f (tie or regression fails)", candMean, champMean)
+		return verdict
+	}
+	verdict.Pass = true
+	verdict.Reason = fmt.Sprintf("candidate corpus mean %.4f strictly improves over champion %.4f (+%.4f)", candMean, champMean, candMean-champMean)
+	return verdict
+}
+
+// indexGateScores keys a score slice by item id. A duplicate id keeps the LAST
+// occurrence (a replay re-run overwrites in place), matching the corpus's unique-id
+// invariant.
+func indexGateScores(scores []GateItemScore) map[string]GateItemScore {
+	byID := make(map[string]GateItemScore, len(scores))
+	for _, score := range scores {
+		byID[strings.TrimSpace(score.ItemID)] = score
+	}
+	return byID
+}
+
+// sortedGateItemIDs returns the sorted union of the two sides' item ids so the
+// comparison and the persisted deltas are deterministic regardless of replay order.
+func sortedGateItemIDs(a, b map[string]GateItemScore) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for id := range a {
+		seen[id] = struct{}{}
+	}
+	for id := range b {
+		seen[id] = struct{}{}
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		if id == "" {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// GateReplayLog is the record of one replay pass over the corpus (#627): the
+// template content that was replayed, the raw per-item deterministic results, and
+// the resulting verdict. On a gate FAILURE it is the "failing eval log" fed back to
+// the optimizer step for the single allowed retry (AutoMem A.2).
+type GateReplayLog struct {
+	TemplateContent string             `json:"template_content,omitempty"`
+	Results         []GateReplayResult `json:"results"`
+	Verdict         GateVerdict        `json:"verdict"`
+}
+
+// GateAttempt records one attempt of the gate protocol (attempt 1, or the single
+// retry as attempt 2) for audit.
+type GateAttempt struct {
+	Attempt          int           `json:"attempt"`
+	CandidateContent string        `json:"-"`
+	Verdict          GateVerdict   `json:"verdict"`
+	Log              GateReplayLog `json:"log"`
+}
+
+// GateProtocolOutcome is the terminal result of RunGateProtocol (#627): accepted or
+// rejected, the accepted template content (empty on reject), the per-attempt
+// history, and a human-facing reason.
+type GateProtocolOutcome struct {
+	Accepted     bool          `json:"accepted"`
+	FinalContent string        `json:"-"`
+	Attempts     []GateAttempt `json:"attempts"`
+	Reason       string        `json:"reason"`
+}
+
+// GateReplayFunc replays a template's content against the fixed corpus and returns
+// its per-item deterministic scores plus the raw replay log. It is injected so the
+// pure protocol is testable with a deterministic fake (no subprocess) and the CLI
+// supplies the real shell-runtime deterministic driver.
+type GateReplayFunc func(ctx context.Context, templateContent string) ([]GateItemScore, GateReplayLog, error)
+
+// GateOptimizeFunc re-runs the optimizer step feeding it the FAILING replay log and
+// returns a revised candidate template content for the single allowed retry (#627).
+type GateOptimizeFunc func(ctx context.Context, failing GateReplayLog) (string, error)
+
+// RunGateProtocol runs the AutoMem A.2 pre-canary gate protocol (#627): replay the
+// candidate against the fixed corpus, accept ONLY on strict improvement over the
+// champion on the SAME corpus; on failure take EXACTLY ONE retry that feeds the
+// failing replay log back to the optimizer step and re-gates the revised candidate;
+// a second failure is a REJECT (a clean restart is the caller's choice, not this
+// function's). The champion is scored ONCE by the caller (championScores) since it
+// does not change between attempts. It is pure orchestration over injected replay/
+// optimize funcs — no I/O of its own — so the one-retry protocol is unit-testable.
+func RunGateProtocol(ctx context.Context, championScores []GateItemScore, candidateContent string, replay GateReplayFunc, optimize GateOptimizeFunc) (GateProtocolOutcome, error) {
+	if replay == nil {
+		return GateProtocolOutcome{}, errors.New("gate protocol requires a replay function")
+	}
+
+	out := GateProtocolOutcome{}
+
+	// Attempt 1: replay the candidate as produced.
+	verdict, log, err := runGateAttempt(ctx, championScores, candidateContent, replay)
+	if err != nil {
+		return out, fmt.Errorf("gate attempt 1 replay: %w", err)
+	}
+	out.Attempts = append(out.Attempts, GateAttempt{Attempt: 1, CandidateContent: candidateContent, Verdict: verdict, Log: log})
+	if verdict.Pass {
+		out.Accepted = true
+		out.FinalContent = candidateContent
+		out.Reason = "gate passed on attempt 1: " + verdict.Reason
+		return out, nil
+	}
+
+	// No optimizer wired: there is no retry to take, so the failure is terminal.
+	if optimize == nil {
+		out.Reason = "gate failed on attempt 1 and no optimizer retry is configured; rejecting: " + verdict.Reason
+		return out, nil
+	}
+
+	// The SINGLE allowed retry: feed the failing replay log to the optimizer step and
+	// re-gate the revised candidate.
+	revised, err := optimize(ctx, log)
+	if err != nil {
+		return out, fmt.Errorf("gate optimizer retry: %w", err)
+	}
+	verdict2, log2, err := runGateAttempt(ctx, championScores, revised, replay)
+	if err != nil {
+		return out, fmt.Errorf("gate attempt 2 replay: %w", err)
+	}
+	out.Attempts = append(out.Attempts, GateAttempt{Attempt: 2, CandidateContent: revised, Verdict: verdict2, Log: log2})
+	if verdict2.Pass {
+		out.Accepted = true
+		out.FinalContent = revised
+		out.Reason = "gate passed on the single retry (attempt 2) after feeding the failing replay log to the optimizer: " + verdict2.Reason
+		return out, nil
+	}
+
+	out.Reason = "gate rejected: candidate failed the fixed corpus twice (a second failure ends the protocol; a clean restart is the caller's choice): " + verdict2.Reason
+	return out, nil
+}
+
+// runGateAttempt replays one candidate content against the corpus and evaluates the
+// verdict, stitching the verdict + content into the returned log for audit.
+func runGateAttempt(ctx context.Context, championScores []GateItemScore, candidateContent string, replay GateReplayFunc) (GateVerdict, GateReplayLog, error) {
+	scores, log, err := replay(ctx, candidateContent)
+	if err != nil {
+		return GateVerdict{}, GateReplayLog{}, err
+	}
+	verdict := EvaluateGate(championScores, scores)
+	log.TemplateContent = candidateContent
+	log.Verdict = verdict
+	return verdict, log, nil
+}
+
+// GatePromotionGuard is the pure guard that blocks candidate->canary promotion when
+// the pre-canary replay gate is enabled but the candidate carries no ACCEPTED gate
+// run (#627). It is additive and off by default: when gateEnabled is false it never
+// blocks (byte-identical to the pre-#627 promote path). When the gate IS enabled, a
+// candidate must have a passing gate run on record before it may be promoted to
+// canary; otherwise promotion is blocked with an actionable reason. It performs no
+// I/O — the caller resolves whether an accepted gate run exists and passes the
+// boolean.
+func GatePromotionGuard(gateEnabled bool, hasAcceptedGateRun bool) (blocked bool, reason string) {
+	if !gateEnabled {
+		return false, ""
+	}
+	if hasAcceptedGateRun {
+		return false, ""
+	}
+	return true, "replay gate is enabled ([skillopt].gate_enabled) but this candidate has no passing gate run; run `gitmoot skillopt gate run --candidate <id>` before promotion"
+}

--- a/internal/skillopt/gate_test.go
+++ b/internal/skillopt/gate_test.go
@@ -1,0 +1,243 @@
+package skillopt
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseGateCorpusValid(t *testing.T) {
+	data := []byte(`{
+		"kind": "gitmoot-skillopt-gate-corpus",
+		"version": 3,
+		"replay_command": "sh replay.sh",
+		"items": [
+			{"id": "a", "prompt": "do a", "expected": "a-ok"},
+			{"id": "b", "prompt": "do b"}
+		]
+	}`)
+	corpus, err := ParseGateCorpus(data)
+	if err != nil {
+		t.Fatalf("ParseGateCorpus returned error: %v", err)
+	}
+	if corpus.Version != 3 || len(corpus.Items) != 2 || corpus.ReplayCommand != "sh replay.sh" {
+		t.Fatalf("unexpected corpus: %+v", corpus)
+	}
+}
+
+func TestParseGateCorpusRejectsMalformed(t *testing.T) {
+	cases := map[string]string{
+		"empty":        ``,
+		"wrong kind":   `{"kind":"other","version":1,"items":[{"id":"a","prompt":"p"}]}`,
+		"zero version": `{"kind":"gitmoot-skillopt-gate-corpus","version":0,"items":[{"id":"a","prompt":"p"}]}`,
+		"no items":     `{"kind":"gitmoot-skillopt-gate-corpus","version":1,"items":[]}`,
+		"empty id":     `{"kind":"gitmoot-skillopt-gate-corpus","version":1,"items":[{"id":"","prompt":"p"}]}`,
+		"dup id":       `{"kind":"gitmoot-skillopt-gate-corpus","version":1,"items":[{"id":"a","prompt":"p"},{"id":"a","prompt":"q"}]}`,
+		"empty prompt": `{"kind":"gitmoot-skillopt-gate-corpus","version":1,"items":[{"id":"a","prompt":"   "}]}`,
+		"invalid json": `{not json`,
+	}
+	for name, body := range cases {
+		if _, err := ParseGateCorpus([]byte(body)); err == nil {
+			t.Errorf("%s: ParseGateCorpus accepted a malformed corpus", name)
+		}
+	}
+}
+
+func TestGateReplayResultScoreReusesDeterministicMetrics(t *testing.T) {
+	// Hard-verifier pass -> 1.0, fail -> 0.0 (projectHardVerifier).
+	pass := GateReplayResult{HardVerifier: true, HardPassed: true}
+	if s, ok := pass.Score(); !ok || s != 1.0 {
+		t.Fatalf("hard pass score = %v (ok=%v), want 1.0", s, ok)
+	}
+	fail := GateReplayResult{HardVerifier: true, HardPassed: false}
+	if s, ok := fail.Score(); !ok || s != 0.0 {
+		t.Fatalf("hard fail score = %v (ok=%v), want 0.0", s, ok)
+	}
+	// Checker rubric -> mean of dimensions (projectChecker).
+	checker := GateReplayResult{Rubric: map[string]float64{"a": 1.0, "b": 0.0}}
+	if s, ok := checker.Score(); !ok || s != 0.5 {
+		t.Fatalf("checker score = %v (ok=%v), want 0.5", s, ok)
+	}
+	// An empty result is not scorable.
+	if _, ok := (GateReplayResult{}).Score(); ok {
+		t.Fatalf("empty result reported HasScore=true")
+	}
+}
+
+func TestEvaluateGateStrictImprovementPasses(t *testing.T) {
+	champion := []GateItemScore{{ItemID: "a", Score: 0.5, HasScore: true}, {ItemID: "b", Score: 0.5, HasScore: true}}
+	candidate := []GateItemScore{{ItemID: "a", Score: 0.9, HasScore: true}, {ItemID: "b", Score: 0.6, HasScore: true}}
+	verdict := EvaluateGate(champion, candidate)
+	if !verdict.Pass {
+		t.Fatalf("strict improvement should pass; reason=%q", verdict.Reason)
+	}
+	if verdict.CandidateMean <= verdict.ChampionMean {
+		t.Fatalf("candidate mean %.3f not > champion mean %.3f", verdict.CandidateMean, verdict.ChampionMean)
+	}
+	if len(verdict.Deltas) != 2 {
+		t.Fatalf("deltas = %d, want 2", len(verdict.Deltas))
+	}
+}
+
+// TestEvaluateGateTieFails is the load-bearing "tie = fail" rule (AutoMem A.2):
+// parity is not improvement. This is the assertion the invert-the-comparison
+// mutation flips.
+func TestEvaluateGateTieFails(t *testing.T) {
+	scores := []GateItemScore{{ItemID: "a", Score: 0.7, HasScore: true}, {ItemID: "b", Score: 0.3, HasScore: true}}
+	verdict := EvaluateGate(scores, scores)
+	if verdict.Pass {
+		t.Fatalf("a tie (identical means) must FAIL the gate, got pass")
+	}
+	if verdict.CandidateMean != verdict.ChampionMean {
+		t.Fatalf("expected equal means, got champ=%.3f cand=%.3f", verdict.ChampionMean, verdict.CandidateMean)
+	}
+}
+
+func TestEvaluateGateWorseCandidateFails(t *testing.T) {
+	champion := []GateItemScore{{ItemID: "a", Score: 0.9, HasScore: true}}
+	candidate := []GateItemScore{{ItemID: "a", Score: 0.4, HasScore: true}}
+	if EvaluateGate(champion, candidate).Pass {
+		t.Fatalf("a worse candidate must fail the gate")
+	}
+}
+
+func TestEvaluateGateMissingScoreFails(t *testing.T) {
+	champion := []GateItemScore{{ItemID: "a", Score: 0.5, HasScore: true}}
+	// Candidate has no scorable outcome for the item.
+	candidate := []GateItemScore{{ItemID: "a", HasScore: false}}
+	verdict := EvaluateGate(champion, candidate)
+	if verdict.Pass {
+		t.Fatalf("an unscorable candidate item must fail the gate")
+	}
+	if !strings.Contains(verdict.Reason, "candidate has no scorable") {
+		t.Fatalf("unexpected reason: %q", verdict.Reason)
+	}
+}
+
+func TestEvaluateGateEmptyCorpusFails(t *testing.T) {
+	if EvaluateGate(nil, nil).Pass {
+		t.Fatalf("an empty corpus must fail the gate")
+	}
+}
+
+// TestStrictlyImprovesIsTheSingleComparison guards the exact predicate the
+// deliberately-worse-candidate mutation targets: strictly-greater, tie excluded.
+func TestStrictlyImprovesIsTheSingleComparison(t *testing.T) {
+	if !strictlyImproves(0.5, 0.6) {
+		t.Fatalf("0.6 should strictly improve over 0.5")
+	}
+	if strictlyImproves(0.5, 0.5) {
+		t.Fatalf("a tie must NOT be a strict improvement")
+	}
+	if strictlyImproves(0.6, 0.5) {
+		t.Fatalf("a regression must NOT be a strict improvement")
+	}
+}
+
+// fixedReplay returns a replay func that maps a template content to a fixed set of
+// per-item scores, and records the failing-log content passed to the optimizer.
+func fixedReplay(scoresByContent map[string][]GateItemScore) GateReplayFunc {
+	return func(_ context.Context, content string) ([]GateItemScore, GateReplayLog, error) {
+		scores, ok := scoresByContent[content]
+		if !ok {
+			return nil, GateReplayLog{}, errors.New("no scripted scores for content")
+		}
+		results := make([]GateReplayResult, 0, len(scores))
+		for _, s := range scores {
+			results = append(results, GateReplayResult{ItemID: s.ItemID, Rubric: map[string]float64{"q": s.Score}})
+		}
+		return scores, GateReplayLog{Results: results}, nil
+	}
+}
+
+func TestRunGateProtocolPassesOnAttemptOne(t *testing.T) {
+	champion := []GateItemScore{{ItemID: "a", Score: 0.5, HasScore: true}}
+	replay := fixedReplay(map[string][]GateItemScore{
+		"cand": {{ItemID: "a", Score: 0.9, HasScore: true}},
+	})
+	out, err := RunGateProtocol(context.Background(), champion, "cand", replay, nil)
+	if err != nil {
+		t.Fatalf("RunGateProtocol returned error: %v", err)
+	}
+	if !out.Accepted || len(out.Attempts) != 1 || out.FinalContent != "cand" {
+		t.Fatalf("expected accept on attempt 1; got %+v", out)
+	}
+}
+
+func TestRunGateProtocolRetrySucceeds(t *testing.T) {
+	champion := []GateItemScore{{ItemID: "a", Score: 0.5, HasScore: true}}
+	replay := fixedReplay(map[string][]GateItemScore{
+		"cand-v1": {{ItemID: "a", Score: 0.4, HasScore: true}}, // fails (worse)
+		"cand-v2": {{ItemID: "a", Score: 0.8, HasScore: true}}, // retry passes
+	})
+	var fedLog GateReplayLog
+	optimize := func(_ context.Context, failing GateReplayLog) (string, error) {
+		fedLog = failing
+		return "cand-v2", nil
+	}
+	out, err := RunGateProtocol(context.Background(), champion, "cand-v1", replay, optimize)
+	if err != nil {
+		t.Fatalf("RunGateProtocol returned error: %v", err)
+	}
+	if !out.Accepted || len(out.Attempts) != 2 || out.FinalContent != "cand-v2" {
+		t.Fatalf("expected accept on retry; got accepted=%v attempts=%d final=%q", out.Accepted, len(out.Attempts), out.FinalContent)
+	}
+	// The optimizer must have received the FAILING attempt-1 replay log (its content
+	// and its failed verdict), which is what AutoMem A.2 feeds back.
+	if fedLog.TemplateContent != "cand-v1" || fedLog.Verdict.Pass {
+		t.Fatalf("optimizer fed the wrong log: content=%q pass=%v", fedLog.TemplateContent, fedLog.Verdict.Pass)
+	}
+}
+
+func TestRunGateProtocolRejectsAfterSecondFailure(t *testing.T) {
+	champion := []GateItemScore{{ItemID: "a", Score: 0.5, HasScore: true}}
+	replay := fixedReplay(map[string][]GateItemScore{
+		"cand-v1": {{ItemID: "a", Score: 0.4, HasScore: true}},
+		"cand-v2": {{ItemID: "a", Score: 0.45, HasScore: true}}, // still worse
+	})
+	optimize := func(_ context.Context, _ GateReplayLog) (string, error) { return "cand-v2", nil }
+	out, err := RunGateProtocol(context.Background(), champion, "cand-v1", replay, optimize)
+	if err != nil {
+		t.Fatalf("RunGateProtocol returned error: %v", err)
+	}
+	if out.Accepted {
+		t.Fatalf("a second failure must REJECT; got accepted")
+	}
+	if len(out.Attempts) != 2 {
+		t.Fatalf("expected exactly 2 attempts (one retry), got %d", len(out.Attempts))
+	}
+	if !strings.Contains(out.Reason, "twice") {
+		t.Fatalf("unexpected reject reason: %q", out.Reason)
+	}
+}
+
+func TestRunGateProtocolNoOptimizerRejectsWithoutRetry(t *testing.T) {
+	champion := []GateItemScore{{ItemID: "a", Score: 0.5, HasScore: true}}
+	replay := fixedReplay(map[string][]GateItemScore{
+		"cand": {{ItemID: "a", Score: 0.4, HasScore: true}},
+	})
+	out, err := RunGateProtocol(context.Background(), champion, "cand", replay, nil)
+	if err != nil {
+		t.Fatalf("RunGateProtocol returned error: %v", err)
+	}
+	if out.Accepted || len(out.Attempts) != 1 {
+		t.Fatalf("no optimizer => single attempt, reject; got accepted=%v attempts=%d", out.Accepted, len(out.Attempts))
+	}
+}
+
+func TestGatePromotionGuard(t *testing.T) {
+	if blocked, _ := GatePromotionGuard(false, false); blocked {
+		t.Fatalf("gate off must never block")
+	}
+	if blocked, _ := GatePromotionGuard(true, true); blocked {
+		t.Fatalf("gate on with an accepted run must not block")
+	}
+	blocked, reason := GatePromotionGuard(true, false)
+	if !blocked {
+		t.Fatalf("gate on without an accepted run must block")
+	}
+	if !strings.Contains(reason, "gate run") {
+		t.Fatalf("unexpected block reason: %q", reason)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -857,6 +857,8 @@ gitmoot skillopt candidate list [--template id]
 gitmoot skillopt candidate show <version-id>
 gitmoot skillopt candidate promote <version-id>
 gitmoot skillopt candidate reject <version-id> [--reason text]
+gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-command cmd] [--config path] [--json]
+gitmoot skillopt gate history --candidate <version-id> [--json]
 gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 gitmoot skillopt pairwise import <packet-dir> [--packet path] [--secret-map path] [--picks path] [--reviewer name] [--json]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
@@ -957,6 +959,21 @@ report JSON, preference summary, and a content diff against the base/current
 version. `skillopt candidate promote` makes a pending candidate current, while
 `skillopt candidate reject` records an auditable rejection and prevents that
 version from being selected by `@latest`.
+
+`skillopt gate run --candidate <version-id>` runs the off-by-default,
+deterministic **pre-canary replay gate** (`#627`, AutoMem A.2): it replays the
+candidate against a **fixed, versioned job corpus** and accepts it only on
+**strict improvement** over the current champion on the same corpus (a tie
+fails). It reuses the `#474`/`#485` deterministic scorers on the corpus outputs —
+no new judge, no live LLM in the gate itself; the replay driver is a deterministic
+`sh -c` command that reads `GITMOOT_GATE_TEMPLATE_FILE`/`GITMOOT_GATE_PROMPT`/
+`GITMOOT_GATE_EXPECTED`/`GITMOOT_GATE_ITEM_ID` and emits a per-item result JSON.
+The command prints pass/fail plus per-item deltas, exits non-zero on a rejected
+gate, and **persists** the run for audit (`skillopt gate history --candidate
+<version-id>`). When `[skillopt].gate_enabled` is on, a candidate must carry a
+passing gate run before it may be promoted to canary or current; otherwise the
+promotion seam blocks. On a gate failure the protocol allows exactly one retry
+feeding the failing replay log back to the optimizer, then rejects.
 
 `skillopt pairwise import <packet-dir>` ingests a **blinded paired-review
 packet** produced by the gitmoot-skillopt fork (the `pairwise-review.json`

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -651,6 +651,103 @@ and classifies the run as `generation_complete`, `generation_incomplete`, or
 missing items remains `train continue`'s job). `--abort` reclaims the lock and
 leaves the phase at `items_ready`, keeping persisted items.
 
+## Pre-Canary Replay Gate
+
+The replay gate (`#627`, AutoMem A.2) is an **off-by-default**, deterministic
+check that runs **before** a candidate reaches canary. It replays a candidate
+template against a **fixed, versioned job corpus** and accepts the candidate only
+on **strict improvement** over the current champion on the **same** corpus — a
+tie (parity) or any regression fails. It reuses the existing deterministic
+scorers (the `#474` hard-verifier tier and the `#485` deterministic checkers) on
+the corpus outputs, so it invents no new judge and runs **no live LLM in the gate
+itself**: the replay driver is a deterministic `sh -c` command.
+
+### Corpus
+
+A corpus is a plain, versioned JSON file — the same fixed seeds every replay runs
+on:
+
+```json
+{
+  "kind": "gitmoot-skillopt-gate-corpus",
+  "version": 1,
+  "replay_command": "sh .gitmoot/skillopt/gate-replay.sh",
+  "items": [
+    { "id": "widget-a", "prompt": "implement widget A", "expected": "builds" },
+    { "id": "widget-b", "prompt": "implement widget B", "expected": "builds" }
+  ]
+}
+```
+
+Every item needs a unique non-empty `id` and a non-empty `prompt`. `version` is
+`>= 1` so a scoring change is auditable. `replay_command` is optional here and can
+instead come from `--replay-command` or `[skillopt].gate_replay_command`.
+
+### Replay driver contract
+
+For each corpus item the gate runs the replay command via `sh -c` with the
+candidate template staged to a temp file and the item passed in the environment:
+
+- `GITMOOT_GATE_TEMPLATE_FILE` — path to the candidate template content;
+- `GITMOOT_GATE_PROMPT` — the item prompt;
+- `GITMOOT_GATE_EXPECTED` — the item's expected/verifiable outcome;
+- `GITMOOT_GATE_ITEM_ID` — the item id.
+
+The command emits a deterministic per-item result JSON on stdout, in the same
+shape the hard-verifier / deterministic-checker tiers produce, so the existing
+scorers project it into a `[0,1]` score:
+
+```json
+{ "rubric": { "build": 1.0, "test": 0.5 } }
+```
+
+or a binary hard verdict:
+
+```json
+{ "hard_verifier": true, "hard_passed": true }
+```
+
+Because the command is the deterministic map, two replays over the same corpus +
+template yield **identical** scores.
+
+### Running the gate
+
+```sh
+gitmoot skillopt gate run --candidate planner@v2 --corpus .gitmoot/skillopt/gate-corpus.json
+gitmoot skillopt gate run --candidate planner@v2 --json   # machine-readable pass/fail + per-item deltas
+gitmoot skillopt gate history --candidate planner@v2      # persisted audit trail
+```
+
+`gate run` scores the champion and candidate on the corpus, prints pass/fail plus
+per-item deltas, and **persists** the run (additive `skillopt_gate_runs` table)
+for audit. It exits non-zero on a rejected gate so a script can branch on the
+verdict.
+
+### One-retry protocol
+
+On a gate failure the protocol takes **exactly one** retry that feeds the failing
+replay log back to the optimizer step and re-gates the revised candidate; a
+**second** failure is a reject (a clean restart is the operator's choice). The CLI
+`gate run` is a single evaluation (attempt 1); the optimizer-fed retry runs where
+the optimizer is available in the train workflow.
+
+### Config and promotion blocking
+
+The gate is wired as an optional, off-by-default step. Turn it on in `[skillopt]`:
+
+```toml
+[skillopt]
+gate_enabled = true
+gate_corpus = .gitmoot/skillopt/gate-corpus.json
+gate_replay_command = sh .gitmoot/skillopt/gate-replay.sh
+```
+
+When `gate_enabled` is on, a candidate must carry a **passing** gate run before it
+may be promoted to canary or current; otherwise the promotion seam blocks with a
+`gate_blocked` notify and takes no promotion action. The gate is standalone (no
+`auto_trace_enabled` dependency), and with it off the promote path is
+byte-identical to before. Promotion itself stays manual.
+
 ## Candidate Review And Next Iteration
 
 The candidate review step publishes the candidate summary, preview/PR links


### PR DESCRIPTION
Implements #627: a deterministic, off-by-default **pre-canary replay gate** for SkillOpt candidates (AutoMem A.2).

## What it does
- Replays a candidate template against a **fixed, versioned job corpus** and accepts it only on **STRICT improvement** vs the champion on the same corpus (tie = fail).
- On gate failure: exactly **ONE** retry that feeds the failing replay log back to the optimizer step; a second failure = **reject** (a clean restart is the caller's choice).
- Reuses the EXISTING deterministic scorers (#474 hard verifiers / #485 deterministic checkers) on the corpus outputs — it does **not** invent a new judge. No live LLM in the gate itself; the replay driver is a deterministic `sh -c` command.
- CLI: `gitmoot skillopt gate run --candidate <id> [--corpus <path>]` returns pass/fail + per-item deltas.
- Wired as an OPTIONAL, off-by-default step (`[skillopt].gate_enabled`) that blocks candidate→canary promotion on gate failure.
- Gate runs persisted (additive) for audit.

## Status
Draft — landing incrementally. Core gate math, corpus, one-retry protocol, and config knobs in first commit; CLI, persistence, promotion-guard wiring, tests, and docs follow.

Closes #627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)