### PR TITLE
feat(dashboard): Agent detail + daemon version/update datasource + dep bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704002226-35fdadaa94d4
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704122215-8e8c88f3dead
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260703234049-cf7bc058fcd2 h1:pI8
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260703234049-cf7bc058fcd2/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704002226-35fdadaa94d4 h1:l5XQiBqGSejug+QxdtahCrN5/f9a7GqQog3UA8soPig=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704002226-35fdadaa94d4/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704122215-8e8c88f3dead h1:0RpQOKKiUSdTanfMW+HGLOQawDdMWjBT2Lxa6T6SRnY=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704122215-8e8c88f3dead/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -3,22 +3,27 @@ package cli
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"sort"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 	"unicode"
 
 	dashboard "github.com/jerryfane/gitmoot-dashboard"
 
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/update"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -69,6 +74,26 @@ func runDashboardWeb(home, addr string, stdout, stderr io.Writer) int {
 // touches workflow state.
 type webDataSource struct {
 	home string
+
+	// mu guards the Health() caches below (Health can be called concurrently and
+	// its resolvers run in goroutines). Everything else on the source is stateless
+	// per call, so only the caches need protection.
+	mu sync.Mutex
+	// daemonVersionKey/daemonVersion cache the running daemon binary's reported
+	// version, keyed by (executable path, file mtime) so SEQUENTIAL 12s health
+	// polls never re-exec an unchanged binary (there is no singleflight, so
+	// concurrent cold requests may each exec once). An empty daemonVersion is a
+	// valid (negative) cache entry — resolution is fail-open.
+	daemonVersionKey string
+	daemonVersion    string
+	// updateResult/updateFetchedAt/updateOK cache the daemon-binary update check.
+	// updateResult is the last SUCCESSFUL HealthUpdate (nil when the check yielded
+	// no usable data); it is retained across failures so a stale-but-good result is
+	// served while a refresh fails. A success is honored for updateSuccessTTL, a
+	// failure re-tried after updateFailureTTL.
+	updateResult    *dashboard.HealthUpdate
+	updateFetchedAt time.Time
+	updateOK        bool
 }
 
 var _ dashboard.DataSource = (*webDataSource)(nil)
@@ -283,39 +308,13 @@ func (d *webDataSource) Agents(ctx context.Context) ([]dashboard.AgentSummary, e
 			return err
 		}
 
-		// Aggregate per-agent job stats from the single ListJobs pass. Ephemeral
-		// workers (name carries the "-ephemeral-" infix) fold into one rollup.
-		byAgent := map[string]*agentJobStat{}
-		var ephemeral agentJobStat
-		hasEphemeral := false
-		for _, j := range jobs {
-			name := strings.TrimSpace(j.Agent)
-			var s *agentJobStat
-			if strings.Contains(name, "-ephemeral-") {
-				s = &ephemeral
-				hasEphemeral = true
-			} else {
-				s = byAgent[name]
-				if s == nil {
-					s = &agentJobStat{}
-					byAgent[name] = s
-				}
-			}
-			s.observe(j)
-		}
+		// Aggregate per-agent job stats from the single ListJobs pass (shared with
+		// Agent()). Ephemeral workers fold into one rollup.
+		byAgent, ephemeral, hasEphemeral := aggregateAgentJobStats(jobs)
 
 		out = make([]dashboard.AgentSummary, 0, len(agents)+1)
 		for _, a := range agents {
-			summary := dashboard.AgentSummary{
-				Name:           a.Name,
-				Role:           strings.TrimSpace(a.Role),
-				Runtime:        strings.TrimSpace(a.Runtime),
-				RepoScope:      splitRepoScope(a.RepoScope),
-				Model:          strings.TrimSpace(a.Model),
-				Capabilities:   a.Capabilities,
-				AutonomyPolicy: strings.TrimSpace(a.AutonomyPolicy),
-				Health:         strings.TrimSpace(a.HealthStatus),
-			}
+			summary := newAgentSummary(a)
 			if s := byAgent[a.Name]; s != nil {
 				s.applyTo(&summary)
 			}
@@ -338,6 +337,149 @@ func (d *webDataSource) Agents(ctx context.Context) ([]dashboard.AgentSummary, e
 		return nil
 	})
 	return out, err
+}
+
+// Agent returns the click-through detail for a single agent by name: the same
+// AgentSummary Agents() builds for that one row, plus its template (nil when the
+// agent has no template or the template lookup fails — fail-open, never an error)
+// and the template's version history newest-first. An unknown name maps to the
+// dashboard's not-found sentinel (mirroring how Job() maps an unknown job id), so
+// the API layer returns 404 rather than 500.
+func (d *webDataSource) Agent(ctx context.Context, name string) (dashboard.AgentDetail, error) {
+	detail := dashboard.AgentDetail{Versions: []dashboard.TemplateVersionInfo{}}
+	err := withStore(d.home, func(store *db.Store) error {
+		agent, err := store.GetAgent(ctx, name)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return dashboard.ErrAgentNotFound
+			}
+			return err
+		}
+		jobs, err := store.ListJobs(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Build the summary exactly as Agents() does for one row: identity from the
+		// registered agent, tallies from the shared per-agent aggregation.
+		summary := newAgentSummary(agent)
+		byAgent, _, _ := aggregateAgentJobStats(jobs)
+		if s := byAgent[agent.Name]; s != nil {
+			s.applyTo(&summary)
+		}
+		detail.AgentSummary = summary
+
+		// Template + version history. Fail-open: a missing/broken template leaves the
+		// detail's Template nil and Versions the initialized empty slice rather than
+		// erroring the endpoint.
+		if tid := strings.TrimSpace(agent.TemplateID); tid != "" {
+			if tmpl, terr := store.GetAgentTemplate(ctx, tid); terr == nil {
+				detail.Template = agentTemplateInfo(tmpl)
+				if versions := agentTemplateVersions(ctx, store, tmpl); versions != nil {
+					detail.Versions = versions
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return dashboard.AgentDetail{}, err
+	}
+	return detail, nil
+}
+
+// newAgentSummary builds the identity portion of an AgentSummary (everything but
+// the job tallies) from a registered agent row. Shared by Agents() and Agent()
+// so the two views map the same fields identically.
+func newAgentSummary(a db.Agent) dashboard.AgentSummary {
+	return dashboard.AgentSummary{
+		Name:           a.Name,
+		Role:           strings.TrimSpace(a.Role),
+		Runtime:        strings.TrimSpace(a.Runtime),
+		RepoScope:      splitRepoScope(a.RepoScope),
+		Model:          strings.TrimSpace(a.Model),
+		Capabilities:   a.Capabilities,
+		AutonomyPolicy: strings.TrimSpace(a.AutonomyPolicy),
+		Health:         strings.TrimSpace(a.HealthStatus),
+	}
+}
+
+// aggregateAgentJobStats folds a job slice into per-registered-agent tallies plus
+// one rollup for the fleet of ephemeral workers (names carrying the "-ephemeral-"
+// infix). It is the single aggregation both Agents() (which walks byAgent for
+// every registered row and appends the ephemeral rollup) and Agent() (which picks
+// one byAgent entry) share, so their counts can never diverge.
+func aggregateAgentJobStats(jobs []db.Job) (byAgent map[string]*agentJobStat, ephemeral agentJobStat, hasEphemeral bool) {
+	byAgent = map[string]*agentJobStat{}
+	for _, j := range jobs {
+		name := strings.TrimSpace(j.Agent)
+		var s *agentJobStat
+		if strings.Contains(name, "-ephemeral-") {
+			s = &ephemeral
+			hasEphemeral = true
+		} else {
+			s = byAgent[name]
+			if s == nil {
+				s = &agentJobStat{}
+				byAgent[name] = s
+			}
+		}
+		s.observe(j)
+	}
+	return byAgent, ephemeral, hasEphemeral
+}
+
+// agentTemplateInfo maps the store's AgentTemplate onto the dashboard's
+// AgentTemplateInfo (identity + source/resolved provenance).
+func agentTemplateInfo(tmpl db.AgentTemplate) *dashboard.AgentTemplateInfo {
+	return &dashboard.AgentTemplateInfo{
+		ID:             tmpl.ID,
+		Name:           strings.TrimSpace(tmpl.Name),
+		Description:    strings.TrimSpace(tmpl.Description),
+		SourceRepo:     strings.TrimSpace(tmpl.SourceRepo),
+		SourceRef:      strings.TrimSpace(tmpl.SourceRef),
+		SourcePath:     strings.TrimSpace(tmpl.SourcePath),
+		ResolvedCommit: strings.TrimSpace(tmpl.ResolvedCommit),
+	}
+}
+
+// agentTemplateVersions lists a template's version history newest-first (version
+// number descending, id tie-break) and marks the version the template currently
+// resolves to. Current is keyed on the template's current_version_id
+// (tmpl.VersionID from GetAgentTemplate) — the version an agent pinned to the
+// default "current" ref actually runs — NOT the latest_version_id, which only
+// applies to an explicit "@latest" ref and can point at an unpromoted candidate.
+// Timestamps go through parseJobTimeMillis (epoch ms, 0 when unknown). Returns nil
+// on a lookup error so the caller can keep the detail's Versions empty (fail-open).
+func agentTemplateVersions(ctx context.Context, store *db.Store, tmpl db.AgentTemplate) []dashboard.TemplateVersionInfo {
+	rows, err := store.ListAgentTemplateVersions(ctx, tmpl.ID)
+	if err != nil {
+		return nil
+	}
+	currentID := strings.TrimSpace(tmpl.VersionID)
+	out := make([]dashboard.TemplateVersionInfo, 0, len(rows))
+	for _, v := range rows {
+		out = append(out, dashboard.TemplateVersionInfo{
+			ID:             v.ID,
+			Number:         v.VersionNumber,
+			State:          strings.TrimSpace(v.State),
+			Name:           strings.TrimSpace(v.Name),
+			Description:    strings.TrimSpace(v.Description),
+			SourceRef:      strings.TrimSpace(v.SourceRef),
+			ResolvedCommit: strings.TrimSpace(v.ResolvedCommit),
+			CreatedAt:      parseJobTimeMillis(v.CreatedAt),
+			PromotedAt:     parseJobTimeMillis(v.PromotedAt),
+			CanarySample:   v.CanarySample,
+			Current:        currentID != "" && v.ID == currentID,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Number != out[j].Number {
+			return out[i].Number > out[j].Number
+		}
+		return out[i].ID > out[j].ID
+	})
+	return out
 }
 
 // agentJobStat accumulates one agent's job tallies across the ListJobs pass:
@@ -805,15 +947,39 @@ func (d *webDataSource) Health(ctx context.Context) (dashboard.Health, error) {
 
 	// Daemon liveness — same readers buildDashboardSnapshot uses. StartedAt comes
 	// off the running daemon's persisted meta (RFC3339 -> epoch ms); a stopped
-	// daemon reports 0.
+	// daemon reports 0. The persisted meta also carries the daemon binary's path,
+	// which the version probe execs.
 	state := daemonProcessState(paths)
+	var executable string
 	if pid, _, perr := currentDaemonPID(state); perr == nil && pid > 0 {
 		out.Daemon.Running = true
 		out.Daemon.PID = pid
 		if meta, merr := readDaemonMeta(state); merr == nil {
 			out.Daemon.StartedAt = parseJobTimeMillis(meta.StartedAt)
+			executable = strings.TrimSpace(meta.Executable)
 		}
 	}
+
+	// The daemon-version probe (execs the binary) and the update check (hits
+	// GitHub) are the only slow parts of Health. Run them CONCURRENTLY — and with
+	// the local store read — so a cold cache never serially stacks their 3s + 4s
+	// timeouts past the health endpoint's latency budget. Both fail-open: a
+	// resolution error leaves the field empty/nil, never an error. The update
+	// check compares buildinfo.Current() (the exact documented shape); its
+	// displayed Current is overridden with the running daemon's version below,
+	// since that is the binary the operator actually runs.
+	var probes sync.WaitGroup
+	var daemonVersion string
+	var updateInfo *dashboard.HealthUpdate
+	probes.Add(2)
+	go func() {
+		defer probes.Done()
+		daemonVersion = d.resolveDaemonVersion(ctx, executable)
+	}()
+	go func() {
+		defer probes.Done()
+		updateInfo = d.checkUpdate(ctx, executable)
+	}()
 
 	err = withStore(d.home, func(store *db.Store) error {
 		jobs, err := store.ListJobs(ctx)
@@ -952,7 +1118,188 @@ func (d *webDataSource) Health(ctx context.Context) (dashboard.Health, error) {
 		out.ResourceLocks = rlocks
 		return nil
 	})
+
+	// Join the concurrent probes. Prefer the running daemon's version for the
+	// update check's displayed Current (that is what the operator runs); fall back
+	// to the check's own current (buildinfo.Current().Version) when the daemon
+	// version is unavailable.
+	probes.Wait()
+	out.Daemon.Version = daemonVersion
+	out.Update = updateInfo
+	if out.Update != nil && daemonVersion != "" {
+		// The update check ran against this dashboard-web process's OWN compiled
+		// version, but the operator runs the daemon binary — so make both the
+		// displayed Current AND the availability verdict daemon-relative,
+		// otherwise a divergent-binary deployment reports the wrong badge.
+		out.Update.Current = daemonVersion
+		out.Update.UpdateAvailable = out.Update.Latest != "" && !sameDaemonVersion(daemonVersion, out.Update.Latest)
+	}
 	return out, err
+}
+
+// daemonVersionTimeout and updateCheckTimeout bound the two slow Health probes.
+// They run concurrently, so the health endpoint's cold-cache wall-clock is the
+// max of the two (< 5s), never their sum.
+const (
+	daemonVersionTimeout = 3 * time.Second
+	updateCheckTimeout   = 4 * time.Second
+	// updateSuccessTTL/updateFailureTTL age the cached update check: a good result
+	// is trusted for an hour; a failed refresh is retried after ten minutes (the
+	// last good result is served meanwhile).
+	updateSuccessTTL = time.Hour
+	updateFailureTTL = 10 * time.Minute
+)
+
+// resolveDaemonVersion returns the running daemon binary's reported version, or
+// "" when it cannot be determined (fail-open). It execs "<executable> version
+// --json" (preferred) or the plain-text form, under a hard timeout, and caches
+// the result keyed by the executable's path+mtime so SEQUENTIAL 12s health polls
+// never re-exec an unchanged binary (there is no singleflight, so concurrent cold
+// requests may each exec once). Only a regular, executable, existing file is ever
+// run.
+func (d *webDataSource) resolveDaemonVersion(ctx context.Context, executable string) string {
+	executable = strings.TrimSpace(executable)
+	if executable == "" {
+		return ""
+	}
+	info, err := os.Stat(executable)
+	if err != nil || info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+		return ""
+	}
+	key := fmt.Sprintf("%s\x00%d", executable, info.ModTime().UnixNano())
+
+	d.mu.Lock()
+	if d.daemonVersionKey == key {
+		v := d.daemonVersion
+		d.mu.Unlock()
+		return v
+	}
+	d.mu.Unlock()
+
+	version := execDaemonVersion(ctx, executable)
+
+	d.mu.Lock()
+	d.daemonVersionKey = key
+	d.daemonVersion = version
+	d.mu.Unlock()
+	return version
+}
+
+// execDaemonVersion runs the binary's version subcommand with a hard timeout and
+// returns the reported version. It prefers the JSON form ("version --json" ->
+// {"version": "..."}); on any failure it falls back to the plain-text form
+// ("version" -> "gitmoot <ver>", from which the "gitmoot" prefix is trimmed).
+// Returns "" on any error (fail-open).
+func execDaemonVersion(ctx context.Context, executable string) string {
+	// Both attempts share ONE budget so the whole probe is bounded by
+	// daemonVersionTimeout, never 2× it (a wedged binary must not stack).
+	ctx, cancel := context.WithTimeout(ctx, daemonVersionTimeout)
+	defer cancel()
+	if out, err := exec.CommandContext(ctx, executable, "version", "--json").Output(); err == nil {
+		var parsed struct {
+			Version string `json:"version"`
+		}
+		if json.Unmarshal(out, &parsed) == nil {
+			if v := strings.TrimSpace(parsed.Version); v != "" {
+				return v
+			}
+		}
+	}
+	out, err := exec.CommandContext(ctx, executable, "version").Output()
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	return strings.TrimSpace(strings.TrimPrefix(line, "gitmoot"))
+}
+
+// updateCheckFn is the seam the Health update check goes through so tests can
+// stub the GitHub release lookup without a network. It defaults to update.Check
+// against the default repo.
+var updateCheckFn = func(ctx context.Context, current buildinfo.Info, executable string) (update.CheckResult, error) {
+	return update.Check(ctx, update.GhReleaseClient{}, update.DefaultRepo, current, "", "", executable)
+}
+
+// checkUpdate returns the daemon-binary update check for the Health page, served
+// from a TTL cache (updateSuccessTTL on success, updateFailureTTL on failure) so
+// SEQUENTIAL 12s polls never re-hit GitHub (there is no singleflight, so
+// concurrent cold requests may each fetch once) and a fresh success is reused for
+// an hour.
+// It is fail-open and never blocks past updateCheckTimeout: on a failed refresh
+// it serves the last good result (nil if there was none), and a "no release"
+// answer is cached as a definite nil (no data). The returned pointer is always a
+// fresh copy — the internal cached value is never handed out — so callers may
+// mutate it (e.g. to override Current) safely.
+func (d *webDataSource) checkUpdate(ctx context.Context, executable string) *dashboard.HealthUpdate {
+	d.mu.Lock()
+	ttl := updateFailureTTL
+	if d.updateOK {
+		ttl = updateSuccessTTL
+	}
+	if !d.updateFetchedAt.IsZero() && time.Since(d.updateFetchedAt) < ttl {
+		cached := cloneUpdate(d.updateResult)
+		d.mu.Unlock()
+		return cached
+	}
+	d.mu.Unlock()
+
+	checkCtx, cancel := context.WithTimeout(ctx, updateCheckTimeout)
+	defer cancel()
+	res, err := updateCheckFn(checkCtx, buildinfo.Current(), executable)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.updateFetchedAt = time.Now()
+	if err != nil {
+		// Fail-open: keep the last good result and re-try after updateFailureTTL.
+		d.updateOK = false
+		return cloneUpdate(d.updateResult)
+	}
+	d.updateOK = true
+	d.updateResult = buildHealthUpdate(res, d.updateFetchedAt)
+	return cloneUpdate(d.updateResult)
+}
+
+// sameDaemonVersion reports whether two version strings denote the same release,
+// ignoring a leading "v" and surrounding whitespace; both must be non-empty (an
+// unknown version never counts as "same"). It mirrors update.sameVersion (which
+// is unexported) so Health can make the update verdict daemon-relative.
+func sameDaemonVersion(a, b string) bool {
+	a = strings.TrimPrefix(strings.TrimSpace(a), "v")
+	b = strings.TrimPrefix(strings.TrimSpace(b), "v")
+	return a != "" && b != "" && a == b
+}
+
+// buildHealthUpdate maps a settled update-check result onto the HealthUpdate
+// contract, or nil when there is no usable data ("no release" / no latest tag) so
+// the field is omitted entirely. UpdateAvailable is true only when a real newer
+// release exists (!UpToDate, with a latest tag). Current defaults to the check's
+// current version; the caller overrides it with the daemon's version.
+func buildHealthUpdate(res update.CheckResult, at time.Time) *dashboard.HealthUpdate {
+	if res.NoRelease {
+		return nil
+	}
+	latest := strings.TrimSpace(res.LatestVersion)
+	if latest == "" {
+		return nil
+	}
+	return &dashboard.HealthUpdate{
+		Current:         strings.TrimSpace(res.CurrentVersion),
+		Latest:          latest,
+		ReleaseURL:      strings.TrimSpace(res.ReleaseURL),
+		UpdateAvailable: !res.UpToDate,
+		CheckedAt:       at.UnixMilli(),
+	}
+}
+
+// cloneUpdate returns a shallow copy of a HealthUpdate (or nil), so the cached
+// value is never aliased into a response the caller may mutate.
+func cloneUpdate(u *dashboard.HealthUpdate) *dashboard.HealthUpdate {
+	if u == nil {
+		return nil
+	}
+	cp := *u
+	return &cp
 }
 
 // healthStuckSince reports whether a job is wedged for the Health page and its

--- a/internal/cli/dashboard_web_test.go
+++ b/internal/cli/dashboard_web_test.go
@@ -7,14 +7,17 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	dashboard "github.com/jerryfane/gitmoot-dashboard"
 
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/update"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -1133,5 +1136,337 @@ func TestWebDataSourceHealthDaemonRunning(t *testing.T) {
 	}
 	if h.Daemon.StartedAt <= 0 {
 		t.Fatalf("daemon StartedAt = %d, want > 0 (from daemon.json meta)", h.Daemon.StartedAt)
+	}
+}
+
+// seedTemplatedAgent registers an agent bound to a template that has a current
+// v1 plus a newer pending v2 (so version ordering and the Current marker are both
+// exercised), and gives the agent two jobs. It returns the current v1 version id
+// and the pending v2 version id.
+func seedTemplatedAgent(t *testing.T, home string) (v1ID, v2ID string) {
+	t.Helper()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	base := db.AgentTemplate{
+		ID: "planner", Name: "Planner Template", Description: "plans the work",
+		SourceRepo: "jerryfane/noted", SourceRef: "main", SourcePath: "agents/planner.md",
+		ResolvedCommit: "aaaaaaaaaaaa", Content: "v1 content",
+	}
+	if err := store.UpsertAgentTemplate(ctx, base); err != nil {
+		t.Fatalf("UpsertAgentTemplate: %v", err)
+	}
+	// current_version_id (what the template resolves to) is v1 at this point.
+	tmpl, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	v1ID = tmpl.VersionID
+
+	v2 := base
+	v2.Content = "v2 content"
+	v2.ResolvedCommit = "bbbbbbbbbbbb"
+	v2.SourceRef = "candidate"
+	pending, err := store.AddPendingAgentTemplateVersion(ctx, v2)
+	if err != nil {
+		t.Fatalf("AddPendingAgentTemplateVersion: %v", err)
+	}
+	v2ID = pending.ID
+
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "planner-agent", Runtime: "codex", TemplateID: "planner"}); err != nil {
+		t.Fatalf("UpsertAgent planner-agent: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "plain-agent", Runtime: "claude"}); err != nil {
+		t.Fatalf("UpsertAgent plain-agent: %v", err)
+	}
+	// A registered agent pointing at a template that does not exist -> fail-open.
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "ghost-agent", Runtime: "codex", TemplateID: "no-such-template"}); err != nil {
+		t.Fatalf("UpsertAgent ghost-agent: %v", err)
+	}
+
+	mustCreateJob(t, store, db.Job{ID: "pa1", Agent: "planner-agent", Type: "orchestrate", State: "succeeded", Payload: mustJSON(t, workflow.JobPayload{})}, "", "")
+	mustCreateJob(t, store, db.Job{ID: "pa2", Agent: "planner-agent", Type: "orchestrate", State: "running", Payload: mustJSON(t, workflow.JobPayload{})}, "", "")
+	return v1ID, v2ID
+}
+
+// TestWebDataSourceAgentDetail asserts Agent() builds the same summary as Agents()
+// for one row, maps the template, and returns the version history newest-first
+// with Current marking the version the template currently resolves to
+// (current_version_id = v1), not the newer pending candidate (v2).
+func TestWebDataSourceAgentDetail(t *testing.T) {
+	home := dashboardTestHome(t)
+	v1ID, v2ID := seedTemplatedAgent(t, home)
+
+	ds := &webDataSource{home: home}
+	detail, err := ds.Agent(context.Background(), "planner-agent")
+	if err != nil {
+		t.Fatalf("Agent: %v", err)
+	}
+
+	// Summary: identity + job tallies (same as Agents()).
+	if detail.Name != "planner-agent" || detail.Runtime != "codex" {
+		t.Fatalf("summary identity = %+v", detail.AgentSummary)
+	}
+	if detail.JobCount != 2 || detail.RunningCount != 1 || detail.SucceededCount != 1 {
+		t.Fatalf("summary counts = job%d run%d ok%d, want 2/1/1", detail.JobCount, detail.RunningCount, detail.SucceededCount)
+	}
+
+	// Template mapping.
+	if detail.Template == nil {
+		t.Fatalf("template is nil, want the planner template")
+	}
+	if detail.Template.ID != "planner" || detail.Template.Name != "Planner Template" {
+		t.Fatalf("template identity = %+v", detail.Template)
+	}
+	if detail.Template.SourceRepo != "jerryfane/noted" || detail.Template.SourceRef != "main" ||
+		detail.Template.SourcePath != "agents/planner.md" || detail.Template.ResolvedCommit != "aaaaaaaaaaaa" {
+		t.Fatalf("template source fields = %+v", detail.Template)
+	}
+
+	// Versions newest-first: v2 (pending) before v1 (current). Current marks v1.
+	if len(detail.Versions) != 2 {
+		t.Fatalf("versions = %d, want 2: %+v", len(detail.Versions), detail.Versions)
+	}
+	newest := detail.Versions[0]
+	if newest.ID != v2ID || newest.Number != 2 {
+		t.Fatalf("versions[0] = %+v, want v2 (number 2, id %s)", newest, v2ID)
+	}
+	if newest.State != "pending" {
+		t.Fatalf("versions[0].State = %q, want pending", newest.State)
+	}
+	if newest.Current {
+		t.Fatalf("newest pending v2 must not be marked Current")
+	}
+	oldest := detail.Versions[1]
+	if oldest.ID != v1ID || oldest.Number != 1 {
+		t.Fatalf("versions[1] = %+v, want v1 (number 1, id %s)", oldest, v1ID)
+	}
+	if !oldest.Current {
+		t.Fatalf("current v1 must be marked Current (template resolves to current_version_id)")
+	}
+	if oldest.State != "current" {
+		t.Fatalf("versions[1].State = %q, want current", oldest.State)
+	}
+	if oldest.CreatedAt <= 0 {
+		t.Fatalf("versions[1].CreatedAt = %d, want > 0 (parsed epoch ms)", oldest.CreatedAt)
+	}
+}
+
+// TestWebDataSourceAgentNoTemplate asserts an agent with no template (or a
+// dangling template id) returns a nil Template and a non-nil empty Versions slice
+// rather than erroring the endpoint.
+func TestWebDataSourceAgentNoTemplate(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedTemplatedAgent(t, home)
+	ds := &webDataSource{home: home}
+	ctx := context.Background()
+
+	plain, err := ds.Agent(ctx, "plain-agent")
+	if err != nil {
+		t.Fatalf("Agent(plain-agent): %v", err)
+	}
+	if plain.Template != nil {
+		t.Fatalf("plain-agent template = %+v, want nil", plain.Template)
+	}
+	if plain.Versions == nil || len(plain.Versions) != 0 {
+		t.Fatalf("plain-agent versions = %+v, want non-nil empty", plain.Versions)
+	}
+
+	// A dangling template id must fail open (template absent), not 500.
+	ghost, err := ds.Agent(ctx, "ghost-agent")
+	if err != nil {
+		t.Fatalf("Agent(ghost-agent) errored on a missing template, want fail-open: %v", err)
+	}
+	if ghost.Template != nil || len(ghost.Versions) != 0 {
+		t.Fatalf("ghost-agent detail = %+v, want template nil + empty versions", ghost)
+	}
+}
+
+// TestWebDataSourceAgentUnknown asserts an unknown agent name maps to the
+// not-found sentinel (so the API returns 404, mirroring Job()).
+func TestWebDataSourceAgentUnknown(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedTemplatedAgent(t, home)
+	ds := &webDataSource{home: home}
+	if _, err := ds.Agent(context.Background(), "no-such-agent"); !errors.Is(err, dashboard.ErrAgentNotFound) {
+		t.Fatalf("Agent(unknown) err = %v, want ErrAgentNotFound", err)
+	}
+}
+
+// writeFakeVersionBin writes an executable shell script that appends one byte to
+// counterFile on every run (so exec count is observable) and prints stdoutBody.
+func writeFakeVersionBin(t *testing.T, path, counterFile, stdoutBody string) {
+	t.Helper()
+	script := "#!/bin/sh\nprintf 'x' >> " + counterFile + "\nprintf '%s\\n' '" + stdoutBody + "'\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bin: %v", err)
+	}
+}
+
+func execCount(t *testing.T, counterFile string) int {
+	t.Helper()
+	data, err := os.ReadFile(counterFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("read counter: %v", err)
+	}
+	return len(data)
+}
+
+// TestWebDataSourceDaemonVersionCache asserts resolveDaemonVersion execs the
+// binary's "version --json" once, parses the JSON version, serves subsequent
+// calls from the mtime-keyed cache WITHOUT re-execing, and re-execs after the
+// binary's mtime changes. A missing/non-executable path yields "" (fail-open).
+func TestWebDataSourceDaemonVersionCache(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "gitmoot-fake")
+	counter := filepath.Join(dir, "calls")
+	writeFakeVersionBin(t, bin, counter, `{"version":"v1.2.3"}`)
+
+	ds := &webDataSource{}
+	ctx := context.Background()
+
+	if v := ds.resolveDaemonVersion(ctx, bin); v != "v1.2.3" {
+		t.Fatalf("version = %q, want v1.2.3", v)
+	}
+	if n := execCount(t, counter); n != 1 {
+		t.Fatalf("exec count = %d after first resolve, want 1", n)
+	}
+	// Cache hit: same binary/mtime -> no re-exec.
+	if v := ds.resolveDaemonVersion(ctx, bin); v != "v1.2.3" {
+		t.Fatalf("cached version = %q, want v1.2.3", v)
+	}
+	if n := execCount(t, counter); n != 1 {
+		t.Fatalf("exec count = %d after cache hit, want 1 (must not re-exec)", n)
+	}
+
+	// New content + new mtime -> cache miss -> re-exec, new version.
+	writeFakeVersionBin(t, bin, counter, `{"version":"v4.5.6"}`)
+	future := time.Now().Add(2 * time.Hour)
+	if err := os.Chtimes(bin, future, future); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	if v := ds.resolveDaemonVersion(ctx, bin); v != "v4.5.6" {
+		t.Fatalf("version after mtime change = %q, want v4.5.6", v)
+	}
+	if n := execCount(t, counter); n != 2 {
+		t.Fatalf("exec count = %d after mtime change, want 2 (must re-exec)", n)
+	}
+
+	// Fail-open on a path that does not exist.
+	if v := ds.resolveDaemonVersion(ctx, filepath.Join(dir, "nope")); v != "" {
+		t.Fatalf("missing binary version = %q, want empty", v)
+	}
+}
+
+// TestWebDataSourceDaemonVersionTextFallback asserts resolveDaemonVersion falls
+// back to the plain-text "gitmoot <ver>" form (trimming the prefix) when the JSON
+// form does not parse.
+func TestWebDataSourceDaemonVersionTextFallback(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "gitmoot-text")
+	counter := filepath.Join(dir, "calls")
+	// Prints non-JSON for every invocation, so "version --json" fails to parse and
+	// the plain-text fallback is used.
+	writeFakeVersionBin(t, bin, counter, `gitmoot v7.8.9`)
+
+	ds := &webDataSource{}
+	if v := ds.resolveDaemonVersion(context.Background(), bin); v != "v7.8.9" {
+		t.Fatalf("text fallback version = %q, want v7.8.9", v)
+	}
+}
+
+// TestWebDataSourceUpdateCheckCache stubs the GitHub release check and asserts the
+// update result is cached (a second call within TTL does not re-invoke the
+// checker), and that a stale cache whose refresh FAILS still serves the last good
+// result (fail-open).
+func TestWebDataSourceUpdateCheckCache(t *testing.T) {
+	orig := updateCheckFn
+	t.Cleanup(func() { updateCheckFn = orig })
+
+	calls := 0
+	updateCheckFn = func(ctx context.Context, current buildinfo.Info, executable string) (update.CheckResult, error) {
+		calls++
+		return update.CheckResult{
+			CurrentVersion: "v1.0.0", LatestVersion: "v2.0.0",
+			ReleaseURL: "https://github.com/jerryfane/gitmoot/releases/tag/v2.0.0", UpToDate: false,
+		}, nil
+	}
+
+	ds := &webDataSource{}
+	ctx := context.Background()
+
+	u := ds.checkUpdate(ctx, "")
+	if u == nil {
+		t.Fatalf("update = nil, want a HealthUpdate")
+	}
+	if !u.UpdateAvailable || u.Latest != "v2.0.0" || u.Current != "v1.0.0" {
+		t.Fatalf("update = %+v, want UpdateAvailable/latest v2.0.0/current v1.0.0", u)
+	}
+	if u.CheckedAt <= 0 {
+		t.Fatalf("update CheckedAt = %d, want > 0", u.CheckedAt)
+	}
+	if calls != 1 {
+		t.Fatalf("checker calls = %d after first checkUpdate, want 1", calls)
+	}
+	// Cache hit within TTL: no re-invoke.
+	if u2 := ds.checkUpdate(ctx, ""); u2 == nil || u2.Latest != "v2.0.0" {
+		t.Fatalf("cached update = %+v, want the same result", u2)
+	}
+	if calls != 1 {
+		t.Fatalf("checker calls = %d after cache hit, want 1 (must not re-check)", calls)
+	}
+	// Returned pointer must be a copy, not the cached value (caller may mutate).
+	u.Current = "mutated"
+	if u3 := ds.checkUpdate(ctx, ""); u3.Current != "v1.0.0" {
+		t.Fatalf("mutating a returned update leaked into the cache: %q", u3.Current)
+	}
+
+	// Force the cache stale, then fail the refresh: the last good result is served.
+	ds.updateFetchedAt = time.Now().Add(-2 * time.Hour)
+	updateCheckFn = func(ctx context.Context, current buildinfo.Info, executable string) (update.CheckResult, error) {
+		calls++
+		return update.CheckResult{}, errors.New("github unreachable")
+	}
+	u4 := ds.checkUpdate(ctx, "")
+	if calls != 2 {
+		t.Fatalf("checker calls = %d, want 2 (stale cache should attempt a refresh)", calls)
+	}
+	if u4 == nil || u4.Latest != "v2.0.0" {
+		t.Fatalf("failed refresh update = %+v, want the last good result served", u4)
+	}
+}
+
+// TestWebDataSourceUpdateCheckColdFailure asserts a failing check with no prior
+// success is fail-open (nil Update, never an error).
+func TestWebDataSourceUpdateCheckColdFailure(t *testing.T) {
+	orig := updateCheckFn
+	t.Cleanup(func() { updateCheckFn = orig })
+	updateCheckFn = func(ctx context.Context, current buildinfo.Info, executable string) (update.CheckResult, error) {
+		return update.CheckResult{}, errors.New("offline")
+	}
+	ds := &webDataSource{}
+	if u := ds.checkUpdate(context.Background(), ""); u != nil {
+		t.Fatalf("cold failure update = %+v, want nil (fail-open)", u)
+	}
+}
+
+// TestWebDataSourceUpdateNoRelease asserts a "no release" answer is treated as no
+// data (nil Update), so the field is omitted rather than reporting a bogus update.
+func TestWebDataSourceUpdateNoRelease(t *testing.T) {
+	orig := updateCheckFn
+	t.Cleanup(func() { updateCheckFn = orig })
+	updateCheckFn = func(ctx context.Context, current buildinfo.Info, executable string) (update.CheckResult, error) {
+		return update.CheckResult{CurrentVersion: "v1.0.0", LatestVersion: "none", NoRelease: true}, nil
+	}
+	ds := &webDataSource{}
+	if u := ds.checkUpdate(context.Background(), ""); u != nil {
+		t.Fatalf("no-release update = %+v, want nil", u)
 	}
 }


### PR DESCRIPTION
Companion to [gitmoot-dashboard#23](https://github.com/jerryfane/gitmoot-dashboard/pull/23) (interface grew → bump + impl together).

- **`Agent(name)`** — template info + version history (newest-first, current marker from the template's resolved VersionID), stats via aggregation shared with `Agents()`, fail-open template lookups.
- **`Health()`** — daemon `Version` (exec of daemon.json's executable, mtime-cached, shared 3s deadline) + `Update` via `update.Check` (4s deadline, 1h/10m success/failure caches, fail-open). **Availability is daemon-relative** — the review caught that comparing the dashboard binary's own version produced a false negative exactly when the daemon was stale.

Verified live: real templates + SkillOpt version history render; hero shows the dev daemon with the v0.8.4 chip. Race-detector-clean concurrent Health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)