### PR TITLE
chore(dashboard): bump for no-cache static shell

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704122215-8e8c88f3dead
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704125843-ca08b12b6332
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704002226-35fdadaa94d4 h1:l5X
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704002226-35fdadaa94d4/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704122215-8e8c88f3dead h1:0RpQOKKiUSdTanfMW+HGLOQawDdMWjBT2Lxa6T6SRnY=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704122215-8e8c88f3dead/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704125843-ca08b12b6332 h1:O7swCPqEmt9TYXzzDYI389aP7Kh1mxq5K7k6aHXfAfU=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704125843-ca08b12b6332/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to [#24](https://github.com/jerryfane/gitmoot-dashboard/pull/24): `Cache-Control: no-cache` on the static shell so open browsers pick up deploys without a hard refresh. go.mod/go.sum only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)