### PR TITLE
feat(dashboard): agent prompt content mapping + dep bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704125843-ca08b12b6332
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704135532-d672bab450e9
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704122215-8e8c88f3dead h1:0Rp
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704122215-8e8c88f3dead/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704125843-ca08b12b6332 h1:O7swCPqEmt9TYXzzDYI389aP7Kh1mxq5K7k6aHXfAfU=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704125843-ca08b12b6332/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704135532-d672bab450e9 h1:Egx/Bb1TJWjgpOW5xYeivD6ssniqOuxC4lxR/EfK/XA=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704135532-d672bab450e9/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -440,6 +440,9 @@ func agentTemplateInfo(tmpl db.AgentTemplate) *dashboard.AgentTemplateInfo {
 		SourceRef:      strings.TrimSpace(tmpl.SourceRef),
 		SourcePath:     strings.TrimSpace(tmpl.SourcePath),
 		ResolvedCommit: strings.TrimSpace(tmpl.ResolvedCommit),
+		// Content is the full resolved prompt body; passed verbatim (no trim) so the
+		// detail view shows the exact template text an agent runs.
+		Content: tmpl.Content,
 	}
 }
 
@@ -471,6 +474,8 @@ func agentTemplateVersions(ctx context.Context, store *db.Store, tmpl db.AgentTe
 			PromotedAt:     parseJobTimeMillis(v.PromotedAt),
 			CanarySample:   v.CanarySample,
 			Current:        currentID != "" && v.ID == currentID,
+			// Content is this version's full prompt body; passed verbatim (no trim).
+			Content: v.Content,
 		})
 	}
 	sort.SliceStable(out, func(i, j int) bool {

--- a/internal/cli/dashboard_web_test.go
+++ b/internal/cli/dashboard_web_test.go
@@ -1226,6 +1226,11 @@ func TestWebDataSourceAgentDetail(t *testing.T) {
 		detail.Template.SourcePath != "agents/planner.md" || detail.Template.ResolvedCommit != "aaaaaaaaaaaa" {
 		t.Fatalf("template source fields = %+v", detail.Template)
 	}
+	// Content is the full body of the version the template currently resolves to
+	// (current_version_id = v1), mapped verbatim from GetAgentTemplate().Content.
+	if detail.Template.Content != "v1 content" {
+		t.Fatalf("template content = %q, want %q (the current v1 body)", detail.Template.Content, "v1 content")
+	}
 
 	// Versions newest-first: v2 (pending) before v1 (current). Current marks v1.
 	if len(detail.Versions) != 2 {
@@ -1241,6 +1246,10 @@ func TestWebDataSourceAgentDetail(t *testing.T) {
 	if newest.Current {
 		t.Fatalf("newest pending v2 must not be marked Current")
 	}
+	// Each version carries its own body, mapped verbatim from the store row's Content.
+	if newest.Content != "v2 content" {
+		t.Fatalf("versions[0].Content = %q, want %q (the v2 body)", newest.Content, "v2 content")
+	}
 	oldest := detail.Versions[1]
 	if oldest.ID != v1ID || oldest.Number != 1 {
 		t.Fatalf("versions[1] = %+v, want v1 (number 1, id %s)", oldest, v1ID)
@@ -1250,6 +1259,9 @@ func TestWebDataSourceAgentDetail(t *testing.T) {
 	}
 	if oldest.State != "current" {
 		t.Fatalf("versions[1].State = %q, want current", oldest.State)
+	}
+	if oldest.Content != "v1 content" {
+		t.Fatalf("versions[1].Content = %q, want %q (the v1 body)", oldest.Content, "v1 content")
 	}
 	if oldest.CreatedAt <= 0 {
 		t.Fatalf("versions[1].CreatedAt = %d, want > 0 (parsed epoch ms)", oldest.CreatedAt)


### PR DESCRIPTION
Companion to [gitmoot-dashboard#25](https://github.com/jerryfane/gitmoot-dashboard/pull/25): maps `Content` from `GetAgentTemplate` + `ListAgentTemplateVersions` into the agent detail (fields grew on the contract → bump + mapping land together). Zero extra queries — the store already selects content. Verified live: researcher's 2.6KB template renders in the panel viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)