### PR TITLE
chore(dashboard): bump for agent version diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704145153-7ba30914f6ba
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704172015-caec710e0567
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704135532-d672bab450e9 h1:Egx
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704135532-d672bab450e9/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704145153-7ba30914f6ba h1:RPu9igyYm9q23vGQ3Ytj/z5nYUHAQ2XRBOb776TRTro=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704145153-7ba30914f6ba/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704172015-caec710e0567 h1:eCR4YBL5Fl1bhjcELZZ30zNxAeyeUW5rW8E7viNr1Dk=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704172015-caec710e0567/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to [#27](https://github.com/jerryfane/gitmoot-dashboard/pull/27): inline version diff in the agent detail panel. go.mod/go.sum only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)