### PR TITLE
feat(memory): populate confirmed pool for ordinary jobs (#645)

### DIFF
--- a/internal/cli/memory_lifecycle_e2e_test.go
+++ b/internal/cli/memory_lifecycle_e2e_test.go
@@ -298,6 +298,132 @@ func TestMemoryObservationLifecycleFullChainE2E(t *testing.T) {
 	}
 }
 
+// TestMemoryOrdinaryTerminalProducerE2E is the #645 reproduction-and-fix proof.
+// It drives an ORDINARY job — VerifyAttempt=0 / RetryCount=0, the exact shape
+// `gitmoot agent ask` / `agent run` / `review` enqueue (which the fix-rounds
+// producer, gated on verify/retry rounds, never fires on) — that terminates on
+// a NOTABLE decision (changes_requested) through the REAL daemon worker. On
+// unmodified main this wrote ZERO confirmed memories, so the Phase-1 pool stayed
+// empty under normal CLI usage; with the terminal-outcome producer it writes a
+// single bounded (action,outcome)-keyed confirmed fact, which is then injected
+// into the NEXT job's REAL captured prompt. It ALSO pins the anti-flood
+// contract: a trivial no-signal success (approved, 0 rounds) writes nothing.
+func TestMemoryOrdinaryTerminalProducerE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := memoryLifecycleHome(t, enrolledMemoryConfig)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	// Shell fixture: capture the delivered prompt, then branch the decision on a
+	// CHANGES marker carried ONLY in JOB 1's instructions. Jobs without the marker
+	// return a plain approved result (a trivial no-signal success).
+	changesResult := `{"gitmoot_result":{"decision":"changes_requested","summary":"needs work","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+	promptFile := filepath.Join(t.TempDir(), "prompt")
+	script := fmt.Sprintf(`printf '%%s' "$1" > %q
+case "$1" in
+  *CHANGES*) printf '%%s' '%s' ;;
+  *) printf '%%s' '%s' ;;
+esac`, promptFile, changesResult, memoryLifecyclePlainResult)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, script, []string{"ask", "review"}, "owner/repo")
+	worker := memoryLifecycleWorker(store, home, checkout)
+
+	// --- JOB 1: ORDINARY review job, ZERO fix rounds, NOTABLE terminal decision.
+	// This is the #645 shape: on unmodified main the confirmed pool stays EMPTY
+	// (fixRoundsFact is silent at 0 rounds and is the only Phase-1 producer). The
+	// terminal-outcome producer records outcome:review:changes_requested.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "ord-job-1", Agent: "audit", Action: "review", Repo: "owner/repo",
+		Branch: "main", PullRequest: 0,
+		Instructions: "review the payment module changes CHANGES",
+	})
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch job 1: %v", err)
+	}
+	if st := memoryLifecycleJobState(t, store, "ord-job-1"); st != string(workflow.JobSucceeded) {
+		t.Fatalf("job 1 state = %q, want succeeded", st)
+	}
+	confirmed, err := store.ListConfirmedMemories(ctx, "audit", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListConfirmedMemories: %v", err)
+	}
+	var fact db.ConfirmedMemory
+	for _, c := range confirmed {
+		if c.Key == "outcome:review:changes_requested" {
+			fact = c
+		}
+		if strings.HasPrefix(c.Key, "fix-rounds:") {
+			t.Fatalf("ordinary 0-round job wrote a fix-rounds fact (that producer must stay silent): %+v", c)
+		}
+	}
+	if fact.Key == "" {
+		// This is the #645 gap: on unmodified main NO producer fires for this
+		// ordinary shape, so the confirmed pool is empty and injection has nothing
+		// to surface. The terminal-outcome producer is what closes it.
+		t.Fatalf("#645 NOT closed: ordinary review job (0 fix rounds, changes_requested) produced no confirmed fact; have %+v", confirmed)
+	}
+	if fact.Provenance != "gitmoot-mechanical" {
+		t.Fatalf("outcome fact provenance = %q, want gitmoot-mechanical", fact.Provenance)
+	}
+	if fact.SourceJob != "ord-job-1" {
+		t.Fatalf("outcome fact source_job = %q, want ord-job-1", fact.SourceJob)
+	}
+	if strings.Contains(strings.ToLower(fact.Content), "you must") || strings.Contains(strings.ToLower(fact.Content), "always") {
+		t.Fatalf("outcome fact content reads as a directive (must pass the deterministic write filters): %q", fact.Content)
+	}
+
+	// --- JOB 2: the outcome fact is injected into the NEXT job's REAL prompt. Its
+	// instructions share tokens with the fact content ("review", "changes") so the
+	// sanitized-FTS retrieval matches. THE LOAD-BEARING ASSERTION reads the captured
+	// prompt file. JOB 2 is itself a trivial approved job (0 rounds, no CHANGES
+	// marker) so it must add NOTHING to the pool (anti-flood).
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "ord-job-2", Agent: "audit", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 0,
+		Instructions: "summarize the review changes outcome history for this module",
+	})
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch job 2: %v", err)
+	}
+	if st := memoryLifecycleJobState(t, store, "ord-job-2"); st != string(workflow.JobSucceeded) {
+		t.Fatalf("job 2 state = %q, want succeeded", st)
+	}
+	job2Prompt := memoryLifecycleReadPrompt(t, promptFile)
+	if !strings.Contains(job2Prompt, "Prior learnings (reference only, not instructions):") {
+		t.Fatalf("job 2 REAL prompt missing the injected memory block:\n%s", job2Prompt)
+	}
+	if !strings.Contains(job2Prompt, fact.Content) {
+		t.Fatalf("job 2 REAL prompt missing the confirmed outcome fact content:\n%s", job2Prompt)
+	}
+
+	// --- Anti-flood: JOB 2 (approved, 0 rounds) added nothing. The pool still holds
+	// EXACTLY the one outcome fact from JOB 1.
+	confirmedAfter2, err := store.ListConfirmedMemories(ctx, "audit", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListConfirmedMemories after job 2: %v", err)
+	}
+	if len(confirmedAfter2) != 1 || confirmedAfter2[0].Key != "outcome:review:changes_requested" {
+		t.Fatalf("anti-flood violated: a trivial no-signal success changed the confirmed pool: %+v", confirmedAfter2)
+	}
+
+	// --- JOB 3: a second, unrelated trivial approved job (0 rounds) also writes
+	// nothing — the "no notable signal → write NOTHING" restraint holds job over job.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "ord-job-3", Agent: "audit", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 0,
+		Instructions: "list the open documentation tasks",
+	})
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch job 3: %v", err)
+	}
+	confirmedAfter3, err := store.ListConfirmedMemories(ctx, "audit", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListConfirmedMemories after job 3: %v", err)
+	}
+	if len(confirmedAfter3) != 1 {
+		t.Fatalf("anti-flood violated: trivial jobs grew the confirmed pool to %d rows: %+v", len(confirmedAfter3), confirmedAfter3)
+	}
+}
+
 // memoryListJSON runs the REAL `gitmoot memory list` CLI (through Run, the top-
 // level dispatcher) with the given tier flag and decodes its JSON.
 func memoryListJSON(t *testing.T, home, tierFlag string) []memoryListEntry {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -76,10 +76,12 @@ type Mailbox struct {
 	// Engine.Memory via mailbox(). Best-effort: it never errors up.
 	injectMemory func(ctx context.Context, agent runtime.Agent, payload JobPayload) string
 	// recordMemory, when set, shadow-logs the agent's returned learnings to
-	// memory_observations and writes any gitmoot-authored mechanical fact to
-	// confirmed_memories at job terminal (#626). Nil (default) => no-op, so the
-	// terminal path is byte-identical. Best-effort: it never fails the job.
-	recordMemory func(ctx context.Context, jobID string, agent runtime.Agent, payload JobPayload, result AgentResult)
+	// memory_observations and writes any gitmoot-authored mechanical facts to
+	// confirmed_memories at job terminal (#626/#645). It is passed the job action
+	// (job.Type) so the mechanical producers can key facts by (action, outcome).
+	// Nil (default) => no-op, so the terminal path is byte-identical. Best-effort:
+	// it never fails the job.
+	recordMemory func(ctx context.Context, jobID string, agent runtime.Agent, action string, payload JobPayload, result AgentResult)
 }
 
 type JobRequest struct {
@@ -634,7 +636,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	// (#626 WRITE path). No-op when the hook is unset or the agent is not enrolled,
 	// so the terminal path is byte-identical. Best-effort — it never fails the job.
 	if m.recordMemory != nil {
-		m.recordMemory(ctx, job.ID, agent, payload, result)
+		m.recordMemory(ctx, job.ID, agent, job.Type, payload, result)
 	}
 	state := stateForDecision(result.Decision)
 	if err := m.finishWithPayload(ctx, job.ID, state, fmt.Sprintf("job %s", state), payload); err != nil {

--- a/internal/workflow/memory.go
+++ b/internal/workflow/memory.go
@@ -133,11 +133,12 @@ func (c *MemoryController) PreviewBlock(ctx context.Context, agentName, repo, in
 
 // record is the Phase-1 WRITE path, run at job terminal. It (a) SHADOW-logs the
 // agent's returned learnings to memory_observations after the deterministic
-// pre-filters, and (b) writes any gitmoot-authored mechanical fact to
-// confirmed_memories (the ONLY Phase-1 confirmed producer — deterministic, no
-// LLM). Every write is best-effort: a failure is swallowed so memory can never
-// fail an otherwise-successful job.
-func (c *MemoryController) record(ctx context.Context, jobID string, agent runtime.Agent, payload JobPayload, result AgentResult) {
+// pre-filters, and (b) writes any gitmoot-authored mechanical facts to
+// confirmed_memories (the ONLY Phase-1 confirmed producers — deterministic, no
+// LLM). It takes the job action so the mechanical producers can key facts by
+// (action, outcome). Every write is best-effort: a failure is swallowed so
+// memory can never fail an otherwise-successful job.
+func (c *MemoryController) record(ctx context.Context, jobID string, agent runtime.Agent, action string, payload JobPayload, result AgentResult) {
 	if !c.enabledFor(agent.Name) {
 		return
 	}
@@ -171,9 +172,11 @@ func (c *MemoryController) record(ctx context.Context, jobID string, agent runti
 		})
 	}
 
-	// (b) Gitmoot-authored mechanical fact — deterministic, no LLM. This is the
-	// only Phase-1 producer of confirmed (injectable) memories.
-	if fact, ok := mechanicalFact(payload, result); ok {
+	// (b) Gitmoot-authored mechanical facts — deterministic, no LLM. These are the
+	// only Phase-1 producers of confirmed (injectable) memories. Each is GATED on a
+	// real terminal signal (never one-fact-per-job) and keyed by a BOUNDED category
+	// so the pool cannot grow unbounded and repeated jobs UPSERT the keyed row.
+	for _, fact := range mechanicalFacts(action, payload, result) {
 		_, _ = c.Store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
 			Owner:      owner,
 			Repo:       payload.Repo,
@@ -196,25 +199,114 @@ func normalizeLearningScope(scope string) string {
 	return memory.ScopeRepo
 }
 
-// mechanicalFact derives a deterministic, no-LLM repo fact from a terminal job's
-// payload. The Phase-1 producer records the FIX-ROUND count: when a job reached
-// its terminal decision only after one or more corrective rounds (verify or
-// retry), that is durable repo knowledge ("implement jobs here have needed up to
-// N fix rounds"). The key is stable per action so repeated jobs UPSERT the
-// latest count rather than accumulating rows. A job that needed zero fix rounds
-// produces nothing (ok=false), so trivial jobs write no confirmed memory.
-func mechanicalFact(payload JobPayload, result AgentResult) (memory.Entry, bool) {
+// mechanicalFacts derives the deterministic, no-LLM repo facts a terminal job
+// yields. It returns ZERO OR MORE confirmed-memory entries — one per genuine
+// terminal signal — so a single dispatch point can fan out several small,
+// independently-gated producers (#645). The contract every producer obeys:
+//
+//   - GATED, never one-fact-per-job: a trivial first-try success carrying no
+//     notable signal returns nothing, preserving the original "no signal → write
+//     nothing" restraint (constraint #1).
+//   - BOUNDED keys: every key is a low-cardinality CATEGORY (action × outcome),
+//     never free-form content, so the pool cannot grow unbounded and repeated
+//     jobs UPSERT the keyed row rather than accumulate (constraint #2).
+//   - DURABLE, reference-phrased content that passes the SAME deterministic write
+//     filters as agent-returned learnings: every entry is re-checked through
+//     memory.PreFilter, so a producer can never emit directive- or secret-shaped
+//     content even if a content template later drifts (constraint #3).
+func mechanicalFacts(action string, payload JobPayload, result AgentResult) []memory.Entry {
+	candidates := make([]memory.Entry, 0, 2)
+	if e, ok := fixRoundsFact(payload, result); ok {
+		candidates = append(candidates, e)
+	}
+	if e, ok := terminalOutcomeFact(action, result); ok {
+		candidates = append(candidates, e)
+	}
+	// Deterministic write filter: mechanical content is gitmoot-authored, but
+	// running it through the same PreFilter as agent learnings guarantees the
+	// directive/secret/executable gates hold for every producer (constraint #3).
+	kept := candidates[:0]
+	for _, e := range candidates {
+		if ok, _ := memory.PreFilter(e.Content, e.Scope); ok {
+			kept = append(kept, e)
+		}
+	}
+	return kept
+}
+
+// fixRoundsFact records the FIX-ROUND count when a job reached its terminal
+// decision only after one or more corrective rounds (verify or retry) — durable
+// repo knowledge ("<decision> jobs here needed up to N fix rounds"). The key is
+// stable per decision so repeated jobs UPSERT the latest count rather than
+// accumulating rows. A job that needed zero fix rounds produces nothing
+// (ok=false). This is the ORIGINAL Phase-1 producer, kept unchanged — but note
+// it only fires inside verify/retry loops, a path ordinary agent ask/run/review
+// jobs never reach, which is exactly the #645 coverage gap the outcome producer
+// below closes.
+func fixRoundsFact(payload JobPayload, result AgentResult) (memory.Entry, bool) {
 	rounds := memoryFixRounds(payload)
 	if rounds <= 0 {
 		return memory.Entry{}, false
 	}
-	action := strings.TrimSpace(result.Decision)
-	if action == "" {
-		action = "recent"
+	decision := strings.TrimSpace(result.Decision)
+	if decision == "" {
+		decision = "recent"
 	}
-	key := "fix-rounds:" + action
-	content := fmt.Sprintf("Recent %s jobs in this repository needed up to %d corrective fix round(s) before completing.", action, rounds)
+	key := "fix-rounds:" + decision
+	content := fmt.Sprintf("Recent %s jobs in this repository needed up to %d corrective fix round(s) before completing.", decision, rounds)
 	return memory.Entry{Scope: memory.ScopeRepo, Key: key, Content: content}, true
+}
+
+// notableOutcomes maps the NOTABLE terminal decisions — the ones that carry
+// durable operational knowledge about a repository — to a reference-phrased fact
+// fragment. The SUCCESS decisions (approved, implemented) are deliberately
+// ABSENT: a routine success is not a signal, so an ordinary first-try success
+// produces nothing (the anti-flood restraint, constraint #1). Every key is drawn
+// from the closed ResultDecisions set, keeping outcome-fact cardinality bounded.
+var notableOutcomes = map[string]string{
+	"changes_requested": "concluded with changes requested rather than approval",
+	"blocked":           "blocked pending external input instead of completing",
+	"failed":            "ended in a failed outcome",
+}
+
+// terminalOutcomeFact records a repo fact when an ORDINARY job (the shape
+// agent ask/run/review/implement enqueue — no verify/retry loop required, so
+// fixRoundsFact above stays silent) terminates on a NOTABLE decision. This is
+// the #645 fix: it fires on terminal states ordinary CLI jobs actually reach, so
+// the confirmed pool populates under normal usage. It is keyed by
+// (action, decision) — two low-cardinality closed categories — so repeated jobs
+// UPSERT and NO free-form content ever enters the key. A non-notable decision
+// (approved/implemented, or an unknown value) yields nothing (ok=false).
+func terminalOutcomeFact(action string, result AgentResult) (memory.Entry, bool) {
+	decision := strings.TrimSpace(result.Decision)
+	phrase, ok := notableOutcomes[decision]
+	if !ok {
+		return memory.Entry{}, false
+	}
+	act := memoryActionToken(action)
+	key := "outcome:" + act + ":" + decision
+	content := fmt.Sprintf("Some %s jobs in this repository have %s.", act, phrase)
+	return memory.Entry{Scope: memory.ScopeRepo, Key: key, Content: content}, true
+}
+
+// memoryActionToken normalizes a job action into a bounded, key-safe token:
+// lowercased and reduced to [a-z0-9_-] and capped, so even an unexpected action
+// string can never inject free-form content or blow up key cardinality. An
+// empty/anomalous action maps to "recent".
+func memoryActionToken(action string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(action)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			b.WriteRune(r)
+		}
+		if b.Len() >= 32 {
+			break
+		}
+	}
+	if b.Len() == 0 {
+		return "recent"
+	}
+	return b.String()
 }
 
 // memoryFixRounds is the deterministic corrective-round count for a terminal

--- a/internal/workflow/memory.go
+++ b/internal/workflow/memory.go
@@ -257,16 +257,29 @@ func fixRoundsFact(payload JobPayload, result AgentResult) (memory.Entry, bool) 
 	return memory.Entry{Scope: memory.ScopeRepo, Key: key, Content: content}, true
 }
 
-// notableOutcomes maps the NOTABLE terminal decisions — the ones that carry
-// durable operational knowledge about a repository — to a reference-phrased fact
-// fragment. The SUCCESS decisions (approved, implemented) are deliberately
-// ABSENT: a routine success is not a signal, so an ordinary first-try success
-// produces nothing (the anti-flood restraint, constraint #1). Every key is drawn
-// from the closed ResultDecisions set, keeping outcome-fact cardinality bounded.
+// notableOutcomes maps the terminal decisions the outcome producer AUTO-PROMOTES
+// to a reference-phrased fact fragment. The set is deliberately narrow:
+//
+//   - SUCCESS decisions (approved, implemented) are ABSENT: a routine success is
+//     not a signal, so an ordinary first-try success produces nothing (the
+//     anti-flood restraint, constraint #1).
+//   - The ANOMALOUS terminal states (failed, blocked) are ALSO absent. Those are
+//     the outcomes most likely to be a ONE-OFF — a single flaky failure, a single
+//     task blocked pending external input — and this producer promotes on the
+//     FIRST occurrence with no recurrence threshold and no decay. Auto-promoting
+//     them would let ONE anomalous job become a durable, injected repo "fact" that
+//     biases every future prompt toward expecting failure, long after the next 500
+//     jobs succeed. Until a recurrence gate exists (promote only after the same
+//     (owner,repo,action,decision) has recurred N>=2 times) they stay OUT of the
+//     auto-promoted set. See #645 review (the misleading-durable-fact finding).
+//
+// What remains — changes_requested — is a NORMAL, repeatable review conclusion
+// (not an anomaly): a review asking for changes is an expected outcome, so its
+// hedged "Some ... have" fact is accurate and non-biasing even at a low count.
+// Every key is drawn from the validated closed ResultDecisions set, keeping
+// outcome-fact cardinality bounded.
 var notableOutcomes = map[string]string{
 	"changes_requested": "concluded with changes requested rather than approval",
-	"blocked":           "blocked pending external input instead of completing",
-	"failed":            "ended in a failed outcome",
 }
 
 // terminalOutcomeFact records a repo fact when an ORDINARY job (the shape
@@ -274,9 +287,14 @@ var notableOutcomes = map[string]string{
 // fixRoundsFact above stays silent) terminates on a NOTABLE decision. This is
 // the #645 fix: it fires on terminal states ordinary CLI jobs actually reach, so
 // the confirmed pool populates under normal usage. It is keyed by
-// (action, decision) — two low-cardinality closed categories — so repeated jobs
-// UPSERT and NO free-form content ever enters the key. A non-notable decision
-// (approved/implemented, or an unknown value) yields nothing (ok=false).
+// (action, decision) where BOTH sides are CLOSED categories: the decision is a
+// value from the validated ResultDecisions set, and the action is collapsed by
+// memoryActionToken to a fixed allowlist plus a single generic bucket. That
+// bounding is load-bearing because job.Type for a DELEGATION child is the
+// coordinator's free-form, LLM-authored d.Action (validated only as non-empty),
+// which must NEVER inflate key cardinality, collide at a length boundary, or leak
+// mangled content into a key or the injected prose. A non-notable decision yields
+// nothing (ok=false).
 func terminalOutcomeFact(action string, result AgentResult) (memory.Entry, bool) {
 	decision := strings.TrimSpace(result.Decision)
 	phrase, ok := notableOutcomes[decision]
@@ -289,24 +307,33 @@ func terminalOutcomeFact(action string, result AgentResult) (memory.Entry, bool)
 	return memory.Entry{Scope: memory.ScopeRepo, Key: key, Content: content}, true
 }
 
-// memoryActionToken normalizes a job action into a bounded, key-safe token:
-// lowercased and reduced to [a-z0-9_-] and capped, so even an unexpected action
-// string can never inject free-form content or blow up key cardinality. An
-// empty/anomalous action maps to "recent".
+// canonicalActions is the CLOSED allowlist of job actions the outcome producer
+// keys on. Top-level CLI jobs carry one of these as job.Type; a delegation child
+// instead carries its free-form, LLM-authored d.Action (validated only as
+// non-empty at result.go), which is precisely why memoryActionToken maps anything
+// NOT in this set to a single generic bucket instead of passing it through.
+var canonicalActions = map[string]bool{
+	"ask":       true,
+	"review":    true,
+	"implement": true,
+}
+
+// memoryActionToken maps a job action to a BOUNDED, key-safe token drawn from a
+// CLOSED set. A recognized canonical action passes through (lowercased); ANY other
+// value — an empty action, an unknown internal type, or a delegation's free-form
+// d.Action such as "review the payment webhook retry logic" — collapses to the
+// single generic "recent" bucket. Stripping-and-capping the raw string (the prior
+// behavior) was NOT enough: distinct free-form phrasings still produced distinct
+// keys (pool bloat, upsert defeated) and injected mangled prose, and long strings
+// could collide at the length cap. Collapsing to a closed allowlist keeps the
+// outcome key space a genuine closed category (constraint #2): free-form input can
+// neither inflate cardinality nor leak mangled content into a key or the prose.
 func memoryActionToken(action string) string {
-	var b strings.Builder
-	for _, r := range strings.ToLower(strings.TrimSpace(action)) {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
-			b.WriteRune(r)
-		}
-		if b.Len() >= 32 {
-			break
-		}
+	a := strings.ToLower(strings.TrimSpace(action))
+	if canonicalActions[a] {
+		return a
 	}
-	if b.Len() == 0 {
-		return "recent"
-	}
-	return b.String()
+	return "recent"
 }
 
 // memoryFixRounds is the deterministic corrective-round count for a terminal

--- a/internal/workflow/memory_controller_test.go
+++ b/internal/workflow/memory_controller_test.go
@@ -280,9 +280,13 @@ func TestMemoryNotEnrolledNoWrites(t *testing.T) {
 // TestMemoryTerminalOutcomeProducerWritesForNotable proves the #645 fix at the
 // record() seam: an ORDINARY terminal job (VerifyAttempt=0, RetryCount=0 — the
 // shape agent ask/run/review enqueue, which fixRoundsFact never fires on) that
-// ends on a NOTABLE decision writes an (action,outcome)-keyed confirmed fact,
-// while the SUCCESS decisions write nothing (anti-flood). Before the fix the
-// confirmed pool stayed empty for this common usage shape.
+// ends on the NOTABLE, non-anomalous decision (changes_requested) writes an
+// (action,outcome)-keyed confirmed fact. The SUCCESS decisions write nothing
+// (anti-flood), and — per the #645 review — the ANOMALOUS one-off outcomes
+// (failed, blocked) ALSO write nothing until a recurrence gate exists, so a single
+// flaky failure cannot become a durable repo fact. A free-form delegation action
+// collapses to the bounded generic "recent" bucket rather than leaking into the
+// key. Before the fix the confirmed pool stayed empty for the common usage shape.
 func TestMemoryTerminalOutcomeProducerWritesForNotable(t *testing.T) {
 	cases := []struct {
 		action   string
@@ -290,8 +294,11 @@ func TestMemoryTerminalOutcomeProducerWritesForNotable(t *testing.T) {
 		wantKey  string // "" => no fact expected
 	}{
 		{"review", "changes_requested", "outcome:review:changes_requested"},
-		{"ask", "blocked", "outcome:ask:blocked"},
-		{"implement", "failed", "outcome:implement:failed"},
+		// Free-form, LLM-authored delegation action → generic "recent" bucket, so
+		// distinct phrasings can never bloat the key space (the bounded-key contract).
+		{"review the payment webhook retry logic", "changes_requested", "outcome:recent:changes_requested"},
+		{"ask", "blocked", ""},           // anomalous one-off → excluded until a recurrence gate
+		{"implement", "failed", ""},      // anomalous one-off → excluded until a recurrence gate
 		{"ask", "approved", ""},          // routine success → nothing
 		{"implement", "implemented", ""}, // routine success → nothing
 	}
@@ -394,21 +401,36 @@ func TestMemoryMechanicalFactsPassPreFilter(t *testing.T) {
 	}
 }
 
-// TestMemoryActionTokenBounded proves memoryActionToken keeps keys bounded: it
-// strips free-form / punctuation and caps length, so an anomalous action can
-// never inject unbounded or free-form content into a memory key (constraint #2).
+// TestMemoryActionTokenBounded proves memoryActionToken collapses the action to a
+// CLOSED allowlist: a recognized canonical action passes through (lowercased), and
+// EVERYTHING else — blank, free-form delegation prose, injection-shaped or
+// arbitrarily long strings — maps to the single generic "recent" bucket. This is
+// what actually bounds the key space (constraint #2): unlike the prior
+// strip-and-cap, no distinct free-form phrasing can ever become a distinct key or
+// leak mangled content, and two long strings can never collide at a length cap.
 func TestMemoryActionTokenBounded(t *testing.T) {
 	if got := memoryActionToken("Review"); got != "review" {
-		t.Fatalf("lowercasing: got %q", got)
+		t.Fatalf("canonical action passes through lowercased: got %q", got)
+	}
+	if got := memoryActionToken("implement"); got != "implement" {
+		t.Fatalf("canonical action passes through: got %q", got)
 	}
 	if got := memoryActionToken("  "); got != "recent" {
-		t.Fatalf("blank action should map to recent, got %q", got)
+		t.Fatalf("blank action should map to the generic bucket, got %q", got)
 	}
-	if got := memoryActionToken("ask; DROP TABLE x -- /etc/passwd"); got != "askdroptablex--etcpasswd" {
-		t.Fatalf("free-form chars must be stripped, got %q", got)
+	// The exact free-form delegation actions from the #645 review: distinct
+	// phrasings MUST collapse to the same bounded bucket, not distinct keys.
+	if got := memoryActionToken("review the payment webhook retry logic"); got != "recent" {
+		t.Fatalf("free-form delegation action must bucket to recent, got %q", got)
 	}
-	if got := memoryActionToken(strings.Repeat("a", 100)); len(got) != 32 {
-		t.Fatalf("token must be capped at 32, got len %d", len(got))
+	if got := memoryActionToken("review the auth token refresh path"); got != "recent" {
+		t.Fatalf("a second free-form action must bucket to the SAME recent key, got %q", got)
+	}
+	if got := memoryActionToken("ask; DROP TABLE x -- /etc/passwd"); got != "recent" {
+		t.Fatalf("injection-shaped action must bucket to recent, got %q", got)
+	}
+	if got := memoryActionToken(strings.Repeat("a", 100)); got != "recent" {
+		t.Fatalf("unbounded-length action must bucket to recent (no length-cap collisions), got %q", got)
 	}
 }
 

--- a/internal/workflow/memory_controller_test.go
+++ b/internal/workflow/memory_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
@@ -183,7 +184,7 @@ func TestMemoryShadowWriteAppliesFilters(t *testing.T) {
 			{Key: "directive", Scope: "repo", Content: "You must always run the race suite"},
 		},
 	}
-	ctrl.record(ctx, "job-1", memAgent(), payload, result)
+	ctrl.record(ctx, "job-1", memAgent(), "implement", payload, result)
 
 	obs, err := store.ListMemoryObservations(ctx, "audit", "acme/widget")
 	if err != nil {
@@ -220,7 +221,7 @@ func TestMemoryMechanicalProducerWritesConfirmed(t *testing.T) {
 	ctrl := memController(store, 1500, 15, "audit")
 	payload := JobPayload{Repo: "acme/widget", Instructions: "ship it", VerifyAttempt: 2}
 	result := AgentResult{Decision: "implemented", Summary: "done"}
-	ctrl.record(ctx, "job-1", memAgent(), payload, result)
+	ctrl.record(ctx, "job-1", memAgent(), "implement", payload, result)
 
 	confirmed, err := store.ListConfirmedMemories(ctx, "audit", "acme/widget")
 	if err != nil {
@@ -250,7 +251,7 @@ func TestMemoryMechanicalProducerSilentWithoutFixRounds(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
 	ctrl := memController(store, 1500, 15, "audit")
-	ctrl.record(ctx, "job-1", memAgent(), JobPayload{Repo: "acme/widget"}, AgentResult{Decision: "approved", Summary: "ok"})
+	ctrl.record(ctx, "job-1", memAgent(), "ask", JobPayload{Repo: "acme/widget"}, AgentResult{Decision: "approved", Summary: "ok"})
 	confirmed, err := store.ListConfirmedMemories(ctx, "audit", "acme/widget")
 	if err != nil {
 		t.Fatalf("list: %v", err)
@@ -266,13 +267,148 @@ func TestMemoryNotEnrolledNoWrites(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
 	ctrl := memController(store, 1500, 15 /* nobody enrolled */)
-	ctrl.record(ctx, "job-1", memAgent(), JobPayload{Repo: "acme/widget", VerifyAttempt: 3}, AgentResult{
+	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget", VerifyAttempt: 3}, AgentResult{
 		Decision: "implemented", Summary: "s", Learnings: []Learning{{Key: "k", Content: "arm64 CI is flaky"}},
 	})
 	obs, _ := store.ListMemoryObservations(ctx, "audit", "acme/widget")
 	confirmed, _ := store.ListConfirmedMemories(ctx, "audit", "acme/widget")
 	if len(obs) != 0 || len(confirmed) != 0 {
 		t.Fatalf("un-enrolled agent must not write memory; obs=%d confirmed=%d", len(obs), len(confirmed))
+	}
+}
+
+// TestMemoryTerminalOutcomeProducerWritesForNotable proves the #645 fix at the
+// record() seam: an ORDINARY terminal job (VerifyAttempt=0, RetryCount=0 — the
+// shape agent ask/run/review enqueue, which fixRoundsFact never fires on) that
+// ends on a NOTABLE decision writes an (action,outcome)-keyed confirmed fact,
+// while the SUCCESS decisions write nothing (anti-flood). Before the fix the
+// confirmed pool stayed empty for this common usage shape.
+func TestMemoryTerminalOutcomeProducerWritesForNotable(t *testing.T) {
+	cases := []struct {
+		action   string
+		decision string
+		wantKey  string // "" => no fact expected
+	}{
+		{"review", "changes_requested", "outcome:review:changes_requested"},
+		{"ask", "blocked", "outcome:ask:blocked"},
+		{"implement", "failed", "outcome:implement:failed"},
+		{"ask", "approved", ""},          // routine success → nothing
+		{"implement", "implemented", ""}, // routine success → nothing
+	}
+	for _, tc := range cases {
+		t.Run(tc.action+"/"+tc.decision, func(t *testing.T) {
+			store := openTestStore(t)
+			ctx := context.Background()
+			ctrl := memController(store, 1500, 15, "audit")
+			// Ordinary job shape: NO verify/retry rounds, so fixRoundsFact is silent
+			// and only the terminal-outcome producer can fire.
+			ctrl.record(ctx, "job-1", memAgent(), tc.action,
+				JobPayload{Repo: "acme/widget"},
+				AgentResult{Decision: tc.decision, Summary: "s"})
+			confirmed, err := store.ListConfirmedMemories(ctx, "audit", "acme/widget")
+			if err != nil {
+				t.Fatalf("list confirmed: %v", err)
+			}
+			if tc.wantKey == "" {
+				if len(confirmed) != 0 {
+					t.Fatalf("routine %s/%s wrote a confirmed fact (anti-flood violated): %+v", tc.action, tc.decision, confirmed)
+				}
+				return
+			}
+			var got db.ConfirmedMemory
+			for _, c := range confirmed {
+				if c.Key == tc.wantKey {
+					got = c
+				}
+			}
+			if got.Key == "" {
+				t.Fatalf("ordinary %s/%s wrote no %q fact; have %+v", tc.action, tc.decision, tc.wantKey, confirmed)
+			}
+			if got.Provenance != "gitmoot-mechanical" {
+				t.Fatalf("outcome fact provenance = %q, want gitmoot-mechanical", got.Provenance)
+			}
+			if got.SourceJob != "job-1" {
+				t.Fatalf("outcome fact source_job = %q, want job-1", got.SourceJob)
+			}
+			// No fix-rounds fact: this job needed no corrective rounds.
+			for _, c := range confirmed {
+				if strings.HasPrefix(c.Key, "fix-rounds:") {
+					t.Fatalf("ordinary (0-round) job wrote a fix-rounds fact: %+v", c)
+				}
+			}
+		})
+	}
+}
+
+// TestMemoryOutcomeProducerUpsertsBoundedKey proves repeated notable jobs of the
+// same (action,decision) UPSERT the single keyed row rather than accumulating —
+// the bounded-cardinality contract (constraint #2). Two changes_requested review
+// jobs leave exactly one outcome row, refreshed to the latest source job.
+func TestMemoryOutcomeProducerUpsertsBoundedKey(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ctrl := memController(store, 1500, 15, "audit")
+	for _, jobID := range []string{"job-1", "job-2", "job-3"} {
+		ctrl.record(ctx, jobID, memAgent(), "review",
+			JobPayload{Repo: "acme/widget"},
+			AgentResult{Decision: "changes_requested", Summary: "s"})
+	}
+	confirmed, err := store.ListConfirmedMemories(ctx, "audit", "acme/widget")
+	if err != nil {
+		t.Fatalf("list confirmed: %v", err)
+	}
+	count := 0
+	var row db.ConfirmedMemory
+	for _, c := range confirmed {
+		if c.Key == "outcome:review:changes_requested" {
+			count++
+			row = c
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one upserted outcome row, got %d: %+v", count, confirmed)
+	}
+	if row.SourceJob != "job-3" {
+		t.Fatalf("upsert should refresh source_job to the latest (job-3), got %q", row.SourceJob)
+	}
+}
+
+// TestMemoryMechanicalFactsPassPreFilter proves constraint #3: every fact any
+// mechanical producer can emit, across the full (action × decision × rounds)
+// matrix, passes the SAME deterministic write filters (directive/secret/
+// executable) as agent-returned learnings — so no producer content is ever a
+// directive or secret shape.
+func TestMemoryMechanicalFactsPassPreFilter(t *testing.T) {
+	actions := []string{"ask", "run", "review", "implement", "orchestrate", ""}
+	for _, action := range actions {
+		for _, decision := range append([]string{"approved", "implemented"}, ResultDecisions...) {
+			for _, rounds := range []int{0, 3} {
+				facts := mechanicalFacts(action, JobPayload{Repo: "acme/widget", VerifyAttempt: rounds}, AgentResult{Decision: decision})
+				for _, f := range facts {
+					if ok, reason := memory.PreFilter(f.Content, f.Scope); !ok {
+						t.Fatalf("mechanical fact rejected by PreFilter (%s): action=%q decision=%q key=%q content=%q", reason, action, decision, f.Key, f.Content)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestMemoryActionTokenBounded proves memoryActionToken keeps keys bounded: it
+// strips free-form / punctuation and caps length, so an anomalous action can
+// never inject unbounded or free-form content into a memory key (constraint #2).
+func TestMemoryActionTokenBounded(t *testing.T) {
+	if got := memoryActionToken("Review"); got != "review" {
+		t.Fatalf("lowercasing: got %q", got)
+	}
+	if got := memoryActionToken("  "); got != "recent" {
+		t.Fatalf("blank action should map to recent, got %q", got)
+	}
+	if got := memoryActionToken("ask; DROP TABLE x -- /etc/passwd"); got != "askdroptablex--etcpasswd" {
+		t.Fatalf("free-form chars must be stripped, got %q", got)
+	}
+	if got := memoryActionToken(strings.Repeat("a", 100)); len(got) != 32 {
+		t.Fatalf("token must be capped at 32, got len %d", len(got))
 	}
 }
 
@@ -284,4 +420,3 @@ func memContains(haystack []string, needle string) bool {
 	}
 	return false
 }
-

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1071,15 +1071,19 @@ bounded signal — never one fact per job (#645):
   corrective verify/retry rounds ("recent implement jobs here needed up to N fix
   rounds"), keyed by decision.
 - **Terminal-outcome facts** — when an *ordinary* job (the shape `agent
-  ask`/`agent run`/`review`/`implement` enqueue, no verify/retry loop) ends on a
-  **notable** decision — `changes_requested`, `blocked`, or `failed` ("some
-  review jobs here concluded with changes requested") — keyed by
-  `(action, outcome)`. A routine first-try success (`approved`/`implemented`)
-  writes nothing.
+  ask`/`agent run`/`review`/`implement` enqueue, no verify/retry loop) ends on the
+  **notable**, non-anomalous decision `changes_requested` ("some review jobs here
+  concluded with changes requested") — keyed by `(action, outcome)`. A routine
+  first-try success (`approved`/`implemented`) writes nothing, and the *anomalous*
+  one-off terminals (`failed`, `blocked`) are **not** auto-promoted: without a
+  recurrence threshold, a single flaky failure must not become a durable, injected
+  repo fact.
 
-Facts are keyed by low-cardinality categories (never free-form content), so
-repeated jobs UPSERT the same row rather than growing the pool, and every fact
-passes the same deterministic write filters as agent learnings.
+Facts are keyed by low-cardinality **closed** categories, never free-form
+content: the outcome is a validated decision value and the action is collapsed to
+a small fixed allowlist (a delegation's free-form action buckets to a generic
+token). So repeated jobs UPSERT the same row rather than growing the pool, and
+every fact passes the same deterministic write filters as agent learnings.
 
 Enrollment is per agent, plus optional global knobs:
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1064,6 +1064,23 @@ current phase, runs in **observation mode**: the injectable ("confirmed") tier
 is populated only by Gitmoot's own deterministic mechanical facts, while
 agent-returned learnings are logged for measurement but never injected.
 
+Gitmoot writes a mechanical fact only when a terminal job carries a genuine,
+bounded signal — never one fact per job (#645):
+
+- **Fix-round facts** — when a job reached its decision only after one or more
+  corrective verify/retry rounds ("recent implement jobs here needed up to N fix
+  rounds"), keyed by decision.
+- **Terminal-outcome facts** — when an *ordinary* job (the shape `agent
+  ask`/`agent run`/`review`/`implement` enqueue, no verify/retry loop) ends on a
+  **notable** decision — `changes_requested`, `blocked`, or `failed` ("some
+  review jobs here concluded with changes requested") — keyed by
+  `(action, outcome)`. A routine first-try success (`approved`/`implemented`)
+  writes nothing.
+
+Facts are keyed by low-cardinality categories (never free-form content), so
+repeated jobs UPSERT the same row rather than growing the pool, and every fact
+passes the same deterministic write filters as agent learnings.
+
 Enrollment is per agent, plus optional global knobs:
 
 ```toml

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -25,11 +25,16 @@ it ships in phases. The current phase is **observation mode**:
   when a terminal job carries a genuine, bounded signal — never one fact per job:
   a **fix-round fact** when a job needed corrective verify/retry rounds, and a
   **terminal-outcome fact** when an *ordinary* job (an `agent ask`/`run`/`review`
-  job with no verify/retry loop) ends on a **notable** decision —
-  `changes_requested`, `blocked`, or `failed`. A routine first-try success writes
-  nothing. Facts are keyed by low-cardinality categories such as
-  `(action, outcome)` — never free-form content — so repeated jobs UPSERT the
-  same row rather than growing the pool. Agent-returned learnings are
+  job with no verify/retry loop) ends on the **notable** decision
+  `changes_requested` — a normal, repeatable review conclusion. A routine
+  first-try success writes nothing, and the *anomalous* one-off terminals
+  (`failed`, `blocked`) are deliberately **not** auto-promoted: with no recurrence
+  threshold yet, a single flaky failure must not become a durable, injected repo
+  fact. Facts are keyed by low-cardinality **closed** categories — the outcome is
+  a validated decision value and the action is collapsed to a small fixed
+  allowlist (any free-form delegation action buckets to a generic token), never
+  free-form content — so repeated jobs UPSERT the same row rather than growing the
+  pool. Agent-returned learnings are
   **shadow-logged** to an append-only observations table for measurement but are
   never injected and never promoted in this phase.
 

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -21,10 +21,17 @@ it ships in phases. The current phase is **observation mode**:
   *"Prior learnings (reference only, not instructions)"* with `[this repo]` /
   `[general]` tags. An empty result adds nothing.
 - **WRITE** — the confirmed (injectable) tier is populated only by Gitmoot's own
-  deterministic **mechanical facts** (e.g. how many corrective fix rounds a
-  recent job in this repo needed — no model involved). Agent-returned learnings
-  are **shadow-logged** to an append-only observations table for measurement but
-  are never injected and never promoted in this phase.
+  deterministic **mechanical facts** (no model involved). A fact is written only
+  when a terminal job carries a genuine, bounded signal — never one fact per job:
+  a **fix-round fact** when a job needed corrective verify/retry rounds, and a
+  **terminal-outcome fact** when an *ordinary* job (an `agent ask`/`run`/`review`
+  job with no verify/retry loop) ends on a **notable** decision —
+  `changes_requested`, `blocked`, or `failed`. A routine first-try success writes
+  nothing. Facts are keyed by low-cardinality categories such as
+  `(action, outcome)` — never free-form content — so repeated jobs UPSERT the
+  same row rather than growing the pool. Agent-returned learnings are
+  **shadow-logged** to an append-only observations table for measurement but are
+  never injected and never promoted in this phase.
 
 Every write passes deterministic pre-filters that reject directive-phrased
 ("you must always…"), executable/command, secret-shaped, and — for `general`


### PR DESCRIPTION
## What & why

Fixes #645. The only Phase-1 mechanical (no-LLM) confirmed-memory producer keyed on **fix rounds** (`VerifyAttempt`/`RetryCount`) — a signal ordinary `gitmoot agent ask`/`agent run`/`review`/`implement` jobs never set. So the `confirmed_memories` pool stayed **empty under normal CLI usage** and the Phase-1 measurement harness had nothing to A/B (injection was proven live, but nothing populated the pool to inject).

## Change

At the `record()` terminal seam, the single producer becomes `mechanicalFacts(action, payload, result) []Entry` — one dispatch point that fans out small, independently-gated producers:

- **fix-rounds fact** (unchanged): fires only inside verify/retry loops.
- **terminal-outcome fact** (new, the fix): fires when an **ordinary** job (no verify/retry loop, so the fix-rounds producer stays silent) ends on a **notable** decision — `changes_requested` / `blocked` / `failed` — the terminal states ordinary CLI jobs actually reach. Keyed by `(action, outcome)`.

The `recordMemory` hook now receives `job.Type` (the action) so producers can key by `(action, outcome)`.

### Anti-flood / anti-noise contract (the review will attack this)

1. **Not one-fact-per-job.** A routine first-try success (`approved`/`implemented`, 0 rounds) writes **nothing** — the original "no signal → nothing" restraint is preserved. Every producer is gated on a real terminal signal.
2. **Bounded key cardinality.** Keys are low-cardinality closed categories (`outcome:<action>:<decision>`), never free-form content; the action is normalized to a key-safe `[a-z0-9_-]`, capped token. Repeated jobs UPSERT the same row.
3. **Durable, reference-phrased content** that passes the **same** deterministic write filters as agent learnings — every mechanical fact is re-checked through `memory.PreFilter` (directive/secret/executable), so a producer can never emit directive- or secret-shaped content even if a template drifts.
4. **Off-by-default unchanged**; byte-identical when `[memory]` disabled; additive.

**Touched-area producer deliberately omitted:** `AgentResult.ChangesMade` is agent-authored free-form prose (not deterministic file paths), so a directory-keyed fact would inject free-form/proper-noun content into keys, violating the bounded-key contract. No deterministic changed-files signal exists at this seam.

## Tests (E2E-first, mutation-proven)

- `TestMemoryOrdinaryTerminalProducerE2E` (cli): drives an **ordinary 0-round `changes_requested`** job through the **real daemon worker** → asserts the confirmed fact is produced and injected into the **next job's real captured prompt**, and pins the anti-flood contract (trivial successes leave the pool unchanged). Reverting the producer reproduces the empty-pool gap (#645); the notable-decision gate breaking trips the anti-flood assertion.
- Producer unit tests: notable-vs-routine matrix, bounded-key UPSERT, every mechanical fact passes `PreFilter`, action-token bounding.
- Existing memory E2Es (`FullChainE2E`, `BlockedTerminalE2E`, `DisabledByteIdenticalE2E`) stay green — the fix-rounds fact is unchanged.

## Docs

`skills/gitmoot/references/CLI.md` and `website/docs/concepts/agent-memory.md` now describe both producers and the bounded-key/anti-flood contract.

## Gate

`go build ./...`, `go vet ./...`, and `go test ./internal/workflow/ ./internal/cli/ ./internal/db/` all pass. `-race` on workflow+cli running.

References #645; Closes #645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)