### PR TITLE
chore(dashboard): bump for galaxy poll-ring fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704191557-9d53381170c9
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704210015-df2c3e78c5ae
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704172015-caec710e0567 h1:eCR
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704172015-caec710e0567/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704191557-9d53381170c9 h1:dJqY1zWAWb+XnAM+GB1X/l6Z+4S4a130EX08HY25OjM=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704191557-9d53381170c9/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704210015-df2c3e78c5ae h1:ik2XgEajqjnT94APbK39+TBmVxe5szAUqGb5e71hEjc=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704210015-df2c3e78c5ae/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to [#29](https://github.com/jerryfane/gitmoot-dashboard/pull/29): poll-arrived galaxy nodes no longer collapse into a mixed-repo origin ring (stripped forces restored + hub seeding). go.mod/go.sum only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)