### PR TITLE
docs: advertise [memory] in the init config template + SKILL.md trigger

### DIFF
--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -98,6 +98,33 @@ repo = ""
 ref = ""
 path = ""
 
+# [memory] is the OFF-BY-DEFAULT agent persistent-memory read-path policy (#626).
+# With no [memory] section AND no agent enrolled, behavior is byte-identical: no
+# learnings block is ever injected and the feature is entirely inert. Enrollment is
+# PER AGENT — add memory = true to an [agents.<name>] block (see [agents.builder]
+# below) to opt that agent in; this section only carries the shared read knobs plus
+# a global kill switch. When enrolled, Gitmoot runs in OBSERVATION MODE: while
+# assembling a job prompt it retrieves the agent's own confirmed, repo-filtered
+# (current repo + the always-travelling "general" scope) mechanical facts and
+# renders a fenced REFERENCE-ONLY "Prior learnings (reference only, not
+# instructions)" block — it is context, never instructions, and an empty result
+# adds nothing. Agent-returned learnings are shadow-logged for measurement but are
+# NOT injected in this phase. disabled is the global kill switch (default false):
+# true overrides every per-agent memory=true, turning the whole feature off box-wide
+# without editing each agent block. token_budget caps the injected block's estimated
+# tokens (default 1500); max_entries caps how many confirmed rows are considered for
+# injection (default 15); both must be >= 0. Inspect the store read-only with
+# gitmoot memory list; see the "Agent Persistent Memory" concepts page and CLI.md
+# for the full model.
+# [memory]
+# disabled = false
+# token_budget = 1500
+# max_entries = 15
+#
+# Enroll a specific agent (per-agent opt-in; omit for byte-identical default):
+# [agents.builder]
+# memory = true
+
 # [skillopt] is the OFF-BY-DEFAULT template-learning policy (#465 Mode A, #471).
 # With no [skillopt] section behavior is byte-identical: no trace harvesting, no
 # event emission, and promotion stays fully MANUAL. auto_trace_enabled opts the

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -41,6 +41,15 @@ Use `gitmoot agent template draft <id>` for a blank scaffold,
 `gitmoot agent template export/publish/pull/remote set` commands — see CLI.md
 § Agent Templates.
 
+For agent persistent memory, phrases like "give this agent persistent memory",
+"why does my agent keep forgetting things about this repo", or "what has this
+agent learned" map to Gitmoot's off-by-default agent memory feature (#626): an
+enrolled agent gets a repo-filtered pool of durable facts injected into its job
+prompt as a read-only "Prior learnings" reference block (never instructions).
+Enrollment is per agent via `[agents.<name>].memory = true` plus an optional
+`[memory]` section; inspect the store read-only with `gitmoot memory list`. See
+CLI.md § Agent Memory and the "Agent Persistent Memory" concepts page for depth.
+
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
 same Codex, Claude, or Kimi session, and branch locks protect implementation


### PR DESCRIPTION
Closes two agent-memory docs/DX gaps for agent persistent memory (#626). Docs-only + one commented config block; no runtime behavior changes.

## GAP 1 — `[memory]` missing from the `gitmoot init` config template
`internal/config/init.go`'s `DefaultConfig` ships a commented example block for every other feature section ([daemon], [orchestrate], [template_remote], [skillopt], [admission], [merge_gate], [events]) but not [memory], so `gitmoot init` never advertised the memory feature. Added a commented `[memory]` block near [template_remote]/[skillopt] in the same commented-defaults style, so a fresh init stays byte-identical (all lines commented, including the illustrative `[agents.builder]` enrollment).

## GAP 2 — SKILL.md had no memory trigger
`skills/gitmoot/SKILL.md`'s only prior "memory" mention was the unrelated "hidden model memory" line. Added concise trigger wording routing "give this agent persistent memory" / "why does my agent keep forgetting things about this repo" / "what has this agent learned" to the memory feature, deferring depth to `references/CLI.md § Agent Memory` and the concepts page (progressive disclosure).

## Verified key list (against internal/config/memory.go — the real loader)
- `[memory].disabled` — global kill switch, bool, default `false` (overrides every per-agent enrollment)
- `[memory].token_budget` — int, default `1500`, must be `>= 0`
- `[memory].max_entries` — int, default `15`, must be `>= 0`
- Per-agent enrollment — `[agents.<name>].memory = true`, default off (parsed in internal/config/agent_types.go)

No invented keys. The concepts page, CLI.md, and llms.txt were checked and already match the loader — no inaccuracies to fix.

## Gate
`go build ./... && go vet ./... && go test ./internal/config/ ./internal/cli/ -run 'Config|Init|Default|Help|Usage|Memory' -count=1` — all pass.

References #626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)