### PR TITLE
docs: document agent-template publish/pull/remote distribution (#476)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Back up and share templates via a GitHub repo (#476):
 
 ```sh
 gitmoot agent template remote set owner/my-templates   # default remote ([template_remote]; ref=main, path=templates/)
-gitmoot agent template publish --all                   # commit templates to the remote (--create makes the repo)
+gitmoot agent template publish --all                   # commit custom templates to the remote (built-ins skipped; --create makes a PRIVATE repo)
 gitmoot agent template pull frontend-reviewer          # install/refresh from the remote
 gitmoot agent template add frontend-reviewer --from-repo owner/my-templates
 ```

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -684,9 +684,10 @@ gitmoot agent template remote show
 ```
 
 `export` writes template `.md` files to a local directory; `publish` commits
-them to a GitHub repo (`--create` creates a missing repo); `pull` installs or
-refreshes templates from that repo; `add --from-repo` installs a single
-template file directly from a repo. `remote set` stores a default remote in the
+them to a GitHub repo (`--create` creates a missing **private** repo); `pull`
+installs or refreshes templates from that repo; `add --from-repo` installs a
+single template file directly from a repo. `--all` on `export`/`publish` covers
+only your custom templates — built-ins are skipped. `remote set` stores a default remote in the
 `[template_remote]` config section (`repo`; `ref` defaults to `main`; `path`
 defaults to `templates`) so publish/pull/add can omit `--repo`; with no remote
 configured, those commands require an explicit `--repo`. **Caution: templates

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -653,9 +653,10 @@ gitmoot agent template remote show
 ```
 
 `export` writes template `.md` files to a local directory; `publish` commits
-them to a GitHub repo (`--create` creates a missing repo); `pull` installs or
-refreshes templates from that repo; `add --from-repo` installs a single
-template file directly from a repo. `remote set` stores a default remote in the
+them to a GitHub repo (`--create` creates a missing **private** repo); `pull`
+installs or refreshes templates from that repo; `add --from-repo` installs a
+single template file directly from a repo. `--all` on `export`/`publish` covers
+only your custom templates — built-ins are skipped. `remote set` stores a default remote in the
 `[template_remote]` config section (`repo`; `ref` defaults to `main`; `path`
 defaults to `templates`) so publish/pull/add can omit `--repo`; with no remote
 configured, those commands require an explicit `--repo`. **Caution: templates

--- a/website/docs/workflows/template-capture-workflow.md
+++ b/website/docs/workflows/template-capture-workflow.md
@@ -64,8 +64,8 @@ gitmoot agent template remote show
 
 # Back up: export to a local dir, or publish (commit) straight to the remote.
 gitmoot agent template export release-planner --to ./backup
-gitmoot agent template publish release-planner            # or --all
-gitmoot agent template publish --all --repo owner/my-templates --create
+gitmoot agent template publish release-planner            # or --all (custom only; built-ins skipped)
+gitmoot agent template publish --all --repo owner/my-templates --create   # --create makes a PRIVATE repo
 
 # Restore / share: pull from the remote, or install one file from any repo.
 gitmoot agent template pull release-planner               # or --all

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -360,7 +360,7 @@ Back up and share templates via a GitHub repo (#476):
 
 ```sh
 gitmoot agent template remote set owner/my-templates   # default remote ([template_remote]; ref=main, path=templates/)
-gitmoot agent template publish --all                   # commit templates to the remote (--create makes the repo)
+gitmoot agent template publish --all                   # commit custom templates to the remote (built-ins skipped; --create makes a PRIVATE repo)
 gitmoot agent template pull frontend-reviewer          # install/refresh from the remote
 gitmoot agent template add frontend-reviewer --from-repo owner/my-templates
 ```
@@ -8518,9 +8518,10 @@ gitmoot agent template remote show
 ```
 
 `export` writes template `.md` files to a local directory; `publish` commits
-them to a GitHub repo (`--create` creates a missing repo); `pull` installs or
-refreshes templates from that repo; `add --from-repo` installs a single
-template file directly from a repo. `remote set` stores a default remote in the
+them to a GitHub repo (`--create` creates a missing **private** repo); `pull`
+installs or refreshes templates from that repo; `add --from-repo` installs a
+single template file directly from a repo. `--all` on `export`/`publish` covers
+only your custom templates — built-ins are skipped. `remote set` stores a default remote in the
 `[template_remote]` config section (`repo`; `ref` defaults to `main`; `path`
 defaults to `templates`) so publish/pull/add can omit `--repo`; with no remote
 configured, those commands require an explicit `--repo`. **Caution: templates
@@ -8897,6 +8898,27 @@ job prompt as a reference-only block. It is **off by default** and, in the
 current phase, runs in **observation mode**: the injectable ("confirmed") tier
 is populated only by Gitmoot's own deterministic mechanical facts, while
 agent-returned learnings are logged for measurement but never injected.
+
+Gitmoot writes a mechanical fact only when a terminal job carries a genuine,
+bounded signal — never one fact per job (#645):
+
+- **Fix-round facts** — when a job reached its decision only after one or more
+  corrective verify/retry rounds ("recent implement jobs here needed up to N fix
+  rounds"), keyed by decision.
+- **Terminal-outcome facts** — when an *ordinary* job (the shape `agent
+  ask`/`agent run`/`review`/`implement` enqueue, no verify/retry loop) ends on the
+  **notable**, non-anomalous decision `changes_requested` ("some review jobs here
+  concluded with changes requested") — keyed by `(action, outcome)`. A routine
+  first-try success (`approved`/`implemented`) writes nothing, and the *anomalous*
+  one-off terminals (`failed`, `blocked`) are **not** auto-promoted: without a
+  recurrence threshold, a single flaky failure must not become a durable, injected
+  repo fact.
+
+Facts are keyed by low-cardinality **closed** categories, never free-form
+content: the outcome is a validated decision value and the action is collapsed to
+a small fixed allowlist (a delegation's free-form action buckets to a generic
+token). So repeated jobs UPSERT the same row rather than growing the pool, and
+every fact passes the same deterministic write filters as agent learnings.
 
 Enrollment is per agent, plus optional global knobs:
 


### PR DESCRIPTION
## Gap

The agent-template **distribution** commands added in #476 — `gitmoot agent template publish`, `pull`, `export`, `remote set`/`remote show`, and the `[template_remote]` config section — were the target of this docs task.

On investigation, the commands themselves were already documented across the skill CLI reference, the website CLI reference, the template-capture workflow page, README, and llms.txt/llms-full.txt by the #603 completeness audit. However, two **source-verified** facts were missing or imprecise, which the docs-with-code accuracy policy requires fixing:

1. **`--create` makes the repo PRIVATE.** `internal/cli/agent_template_remote.go` calls `client.CreateRepository(ctx, repository, true)` (third arg `private bool`), and `agent template publish --help` states `-create  create the repo (private) if it does not exist`. The docs said only "creates a missing repo".
2. **`--all` skips built-ins.** `agent template publish --help` / `export --help` state `publish/export all custom templates (skips built-ins)`. This was undocumented.

## Commands documented / corrected

- `agent template publish [ids] [--all] [--repo] [--path] [--ref] [--message] [--create] [--dry-run]` — now notes `--create` = private repo, `--all` = custom-only.
- `agent template pull`, `export`, `remote set`/`remote show`, and `[template_remote]` (`repo`; `ref` default `main`; `path` default `templates`) — round-trip already present and verified accurate.

## Files changed (docs-only)

- `skills/gitmoot/references/CLI.md`
- `website/docs/reference/cli.md`
- `website/docs/workflows/template-capture-workflow.md`
- `README.md`
- `website/static/llms-full.txt` — regenerated via `npm run build:llms` (generated file per repo convention; also reconciles pre-existing drift from #645)

`SKILL.md` already routes "publish/back up/pull agent templates" to these commands (`gitmoot agent template export/publish/pull/remote set` → CLI.md § Agent Templates), so no change was needed there.

## Verified against

- Deployed binary help: `gitmoot agent template --help`, `... publish --help`, `... pull --help`, `... export --help`, `... remote set/show --help`
- `internal/cli/agent_template_remote.go` (publish/pull/export/remote behavior; `CreateRepository(..., true)`; verbatim-push warning; conflict→new-version / identical→no-op)
- `internal/config/template_remote.go` (`[template_remote]` repo/ref/path; off-by-default; `DefaultTemplateRemoteRef="main"`, `DefaultTemplateRemotePath="templates"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)