### PR TITLE
feat: session jobs — record here-method work as tracked jobs (job open/close/record)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -95,7 +95,7 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent type list|show|set ...")
 	fmt.Fprintln(w, "  gitmoot agent heartbeat add|list|show|enable|disable|remove ...")
 	fmt.Fprintln(w, "  gitmoot agent template list|show|add|draft|validate|update|diff ...")
-	fmt.Fprintln(w, "  gitmoot agent prompt <agent-or-template> [--json]")
+	fmt.Fprintln(w, "  gitmoot agent prompt <agent-or-template> [--json] [--record [--repo owner/repo] [--type ask|review|implement]]")
 	fmt.Fprintln(w, "  gitmoot agent gc")
 	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|kimi|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] [--model model] --capability <capability>")
 	fmt.Fprintln(w, "    Codex sessions may use a UUID, thread name, or last. Claude sessions may use a UUID or last. Kimi sessions may use a Kimi session id. Shell sessions are commands.")

--- a/internal/cli/agent_prompt.go
+++ b/internal/cli/agent_prompt.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 type agentPromptOutput struct {
@@ -23,6 +25,11 @@ type agentPromptOutput struct {
 	Capabilities   []string `json:"capabilities,omitempty"`
 	ResolvedCommit string   `json:"resolved_commit"`
 	Content        string   `json:"content"`
+	// JobID is set only when the prompt is imported with --record: it carries the
+	// session job opened for this import so the JSON consumer can close it later.
+	// Without --record it stays empty and is omitted, keeping the plain-inspection
+	// output byte-identical to the historical behavior.
+	JobID string `json:"job_id,omitempty"`
 }
 
 func runAgentPrompt(args []string, stdout, stderr io.Writer) int {
@@ -30,6 +37,9 @@ func runAgentPrompt(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	jsonOutput := fs.Bool("json", false, "print prompt metadata and content as JSON")
+	record := fs.Bool("record", false, "open a session job for this import so the here-method work is tracked (#657); print the job id in the header and close it with `gitmoot job close`")
+	repo := fs.String("repo", "", "repo scope as owner/repo for the recorded session job (default: the agent's repo_scope); only used with --record")
+	typeName := fs.String("type", "implement", "session job type when recording: ask|review|implement; only used with --record")
 	id, flagArgs := leadingID(args)
 	if len(args) == 0 || containsHelpFlag(args) {
 		fs.Usage()
@@ -56,6 +66,10 @@ func runAgentPrompt(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "agent prompt requires exactly one agent or template id")
 		return 2
 	}
+	if *record {
+		return runAgentPromptRecord(*home, id, *repo, *typeName, *jsonOutput, stdout, stderr)
+	}
+
 	var output agentPromptOutput
 	if err := withReadOnlyStore(*home, func(store *db.Store) error {
 		resolved, err := resolveAgentPrompt(context.Background(), store, id)
@@ -75,6 +89,84 @@ func runAgentPrompt(args []string, stdout, stderr io.Writer) int {
 		}
 		return 0
 	}
+	fmt.Fprintln(stdout, strings.TrimRight(output.Content, "\n"))
+	return 0
+}
+
+// sessionCloseHint is the exact header line printed above a --record'd prompt so
+// the importing agent knows the session job id it must close when the here-method
+// work is done (#657). The decision list mirrors workflow.ResultDecisions.
+func sessionCloseHint(jobID string) string {
+	return fmt.Sprintf(`[gitmoot session job %s — when this work is complete, run: gitmoot job close %s --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]`, jobID, jobID)
+}
+
+// runAgentPromptRecord implements `agent prompt <agent> --record`: it opens a
+// session job (the same OpenExternalJob/Mailbox clock-in `job open` uses) for the
+// agent + repo and returns the prompt with a header that names the job id so the
+// importing session tracks the here-method work by default. Unlike the plain
+// prompt path this needs a writable store, and the id MUST resolve to an agent
+// (a bare template has no repo_scope and cannot own a session job).
+func runAgentPromptRecord(home, id, repoFlag, typeName string, jsonOutput bool, stdout, stderr io.Writer) int {
+	action, ok := validateSessionAction(typeName, stderr)
+	if !ok {
+		return 2
+	}
+	ctx := context.Background()
+	var (
+		output agentPromptOutput
+		jobID  string
+	)
+	if err := withStoreAndPaths(home, func(paths config.Paths, store *db.Store) error {
+		agent, err := store.GetAgent(ctx, strings.TrimSpace(id))
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("agent %q not found; --record requires an existing agent (a bare template id has no repo scope to record against)", id)
+			}
+			return err
+		}
+		resolved, err := promptForAgent(ctx, store, agent)
+		if err != nil {
+			return err
+		}
+		repoScope := strings.TrimSpace(repoFlag)
+		if repoScope == "" {
+			repoScope = strings.TrimSpace(agent.RepoScope)
+		}
+		if repoScope == "" {
+			return fmt.Errorf("no repo to record against: pass --repo owner/repo or set agent %q's repo_scope", agent.Name)
+		}
+		fullName, err := validateSessionAgentRepo(ctx, store, agent.Name, repoScope)
+		if err != nil {
+			return err
+		}
+		engine := sessionWorkflowEngine(store, paths.Home)
+		job, err := engine.OpenExternalJob(ctx, workflow.JobRequest{
+			ID:     sessionJobID(action, agent.Name),
+			Agent:  agent.Name,
+			Action: action,
+			Repo:   fullName,
+			Sender: "session",
+		})
+		if err != nil {
+			return err
+		}
+		jobID = job.ID
+		resolved.JobID = job.ID
+		output = resolved
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent prompt --record: %v\n", promptReadError(err))
+		return 1
+	}
+	if jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "agent prompt --record: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintln(stdout, sessionCloseHint(jobID))
+	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, strings.TrimRight(output.Content, "\n"))
 	return 0
 }

--- a/internal/cli/agent_prompt_record_test.go
+++ b/internal/cli/agent_prompt_record_test.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// seedPromptRecordFixture builds an isolated home with a tracked repo and an agent
+// carrying a real installed template and a repo_scope, returning the home path and
+// a persistent store for assertions.
+func seedPromptRecordFixture(t *testing.T) (string, *db.Store) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("db.Open returned error: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	if err := store.UpsertAgentTemplate(context.Background(), db.AgentTemplate{
+		ID:             "planner",
+		Name:           "Planner",
+		SourceRepo:     "jerryfane/gitmoot",
+		SourceRef:      "main",
+		SourcePath:     "skills/gitmoot/agent-templates/planner.md",
+		ResolvedCommit: "abc123",
+		Content:        "Plan the work carefully.\n",
+	}); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertAgent(context.Background(), db.Agent{
+		Name:         "lead",
+		Role:         "coordinator",
+		Runtime:      runtime.ShellRuntime,
+		RepoScope:    "owner/repo",
+		TemplateID:   "planner",
+		Capabilities: []string{"ask", "implement"},
+		HealthStatus: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	return home, store
+}
+
+func sessionJobsFor(t *testing.T, store *db.Store) []db.Job {
+	t.Helper()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var session []db.Job
+	for _, j := range jobs {
+		if j.ExternallyDriven {
+			session = append(session, j)
+		}
+	}
+	return session
+}
+
+// TestAgentPromptRecordOpensSessionJob proves `agent prompt <agent> --record`
+// opens a running externally_driven session job for the agent's repo_scope and
+// prints the prompt with the exact clock-out header naming the job id, and that
+// --json carries the job id (#657).
+func TestAgentPromptRecordOpensSessionJob(t *testing.T) {
+	home, store := seedPromptRecordFixture(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := runAgentPrompt([]string{"lead", "--record", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent prompt --record --json exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	var out agentPromptOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode JSON %q: %v", stdout.String(), err)
+	}
+	if strings.TrimSpace(out.JobID) == "" {
+		t.Fatalf("agent prompt --record --json carried no job_id: %q", stdout.String())
+	}
+	if !strings.Contains(out.Content, "Plan the work carefully.") {
+		t.Fatalf("--record --json content = %q, want the resolved prompt", out.Content)
+	}
+
+	session := sessionJobsFor(t, store)
+	if len(session) != 1 {
+		t.Fatalf("session jobs = %d, want exactly 1 opened by --record", len(session))
+	}
+	job := session[0]
+	if job.ID != out.JobID {
+		t.Fatalf("session job id = %q, want the JSON job_id %q", job.ID, out.JobID)
+	}
+	if job.State != string(workflow.JobRunning) || !job.ExternallyDriven {
+		t.Fatalf("recorded session job = %+v, want running externally_driven", job)
+	}
+	if job.Type != "implement" {
+		t.Fatalf("recorded session job type = %q, want implement (default)", job.Type)
+	}
+	if payload, err := workflow.ParseJobPayload(job.Payload); err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	} else if payload.Repo != "owner/repo" {
+		t.Fatalf("recorded session job repo = %q, want owner/repo (the agent repo_scope)", payload.Repo)
+	}
+
+	// Text mode prints the exact clock-out header naming the job id.
+	stdout.Reset()
+	stderr.Reset()
+	if code := runAgentPrompt([]string{"lead", "--record", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent prompt --record (text) exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	text := stdout.String()
+	if !strings.Contains(text, "gitmoot session job ") || !strings.Contains(text, "gitmoot job close ") {
+		t.Fatalf("--record text output missing the clock-out header:\n%s", text)
+	}
+	if !strings.Contains(text, "Plan the work carefully.") {
+		t.Fatalf("--record text output missing the prompt body:\n%s", text)
+	}
+}
+
+// TestAgentPromptWithoutRecordIsByteIdenticalAndOpensNoJob is the invariant guard:
+// a plain `agent prompt` (no --record) is a pure read — it opens NO job and its
+// output is byte-identical to before the flag existed (no header, empty job_id).
+func TestAgentPromptWithoutRecordIsByteIdenticalAndOpensNoJob(t *testing.T) {
+	home, store := seedPromptRecordFixture(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := runAgentPrompt([]string{"lead", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent prompt exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "gitmoot session job ") {
+		t.Fatalf("plain agent prompt leaked a session-job header:\n%s", stdout.String())
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "Plan the work carefully." {
+		t.Fatalf("plain agent prompt output = %q, want the bare prompt", got)
+	}
+
+	// JSON form omits job_id entirely (byte-identical to the historical shape).
+	stdout.Reset()
+	stderr.Reset()
+	if code := runAgentPrompt([]string{"lead", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent prompt --json exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "job_id") {
+		t.Fatalf("plain agent prompt --json leaked a job_id field:\n%s", stdout.String())
+	}
+
+	if session := sessionJobsFor(t, store); len(session) != 0 {
+		t.Fatalf("plain agent prompt opened %d session job(s), want 0", len(session))
+	}
+}
+
+// TestAgentPromptRecordRepoFlagOverridesScope proves --repo overrides the agent's
+// repo_scope, and that an id resolving to a bare template (no agent) is rejected.
+func TestAgentPromptRecordRepoFlagOverridesScope(t *testing.T) {
+	home, store := seedPromptRecordFixture(t)
+	seedDaemonWorkerRepo(t, store, "owner/other", t.TempDir())
+
+	var stdout, stderr bytes.Buffer
+	if code := runAgentPrompt([]string{"lead", "--record", "--repo", "owner/other", "--type", "ask", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent prompt --record --repo exit code = %d, want 0; stderr=%q", code, stderr.String())
+	}
+	session := sessionJobsFor(t, store)
+	if len(session) != 1 {
+		t.Fatalf("session jobs = %d, want 1", len(session))
+	}
+	if session[0].Type != "ask" {
+		t.Fatalf("session job type = %q, want ask (--type override)", session[0].Type)
+	}
+	payload, err := workflow.ParseJobPayload(session[0].Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	}
+	if payload.Repo != "owner/other" {
+		t.Fatalf("session job repo = %q, want owner/other (--repo override)", payload.Repo)
+	}
+
+	// A bare template id (no agent record) cannot be recorded against.
+	stdout.Reset()
+	stderr.Reset()
+	if code := runAgentPrompt([]string{"planner", "--record", "--repo", "owner/repo", "--home", home}, io.Discard, &stderr); code == 0 {
+		t.Fatalf("agent prompt --record on a bare template exit code = 0, want non-zero")
+	}
+	if !strings.Contains(stderr.String(), "not found") {
+		t.Fatalf("bare-template --record stderr = %q, want an agent-not-found error", stderr.String())
+	}
+}

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -39,6 +39,12 @@ func runJob(args []string, stdout, stderr io.Writer) int {
 		return runJobCancel(args[1:], stdout, stderr)
 	case "kill":
 		return runJobKill(args[1:], stdout, stderr)
+	case "open":
+		return runJobOpen(args[1:], stdout, stderr)
+	case "close":
+		return runJobClose(args[1:], stdout, stderr)
+	case "record":
+		return runJobRecord(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown job command %q\n\n", args[0])
 		printJobUsage(stderr)
@@ -57,6 +63,9 @@ func printJobUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot job cancel <id>")
 	fmt.Fprintln(w, "  gitmoot job cancel --state blocked [--older-than 168h|7d] [--repo owner/repo] [--agent name] [--yes]")
 	fmt.Fprintln(w, "  gitmoot job kill <root-job-id>")
+	fmt.Fprintln(w, "  gitmoot job open --agent name --repo owner/repo --type ask|review|implement [--title ...] [--task id] [--pr n] [--json]")
+	fmt.Fprintln(w, "  gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed [--summary ...] [--pr n] [--branch name] [--json]")
+	fmt.Fprintln(w, "  gitmoot job record --agent name --repo owner/repo --type ask|review|implement --decision ... [--title ...] [--summary ...] [--task id] [--pr n] [--branch name] [--json]")
 }
 
 func runJobList(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/job_session.go
+++ b/internal/cli/job_session.go
@@ -1,0 +1,344 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// sessionJobActions are the job types a session ("here"/prompt-import) job may be
+// opened as — the same action set an engine-run job uses.
+var sessionJobActions = []string{"ask", "review", "implement"}
+
+// jobSessionOutput is the shared JSON/text shape printed by `job open`, `job
+// close`, and `job record` (#657). Decision/summary/PR fields are omitted when
+// empty so an `open` result (no decision yet) is clean.
+type jobSessionOutput struct {
+	JobID            string `json:"job_id"`
+	State            string `json:"state"`
+	Agent            string `json:"agent"`
+	Type             string `json:"type"`
+	Repo             string `json:"repo"`
+	ExternallyDriven bool   `json:"externally_driven"`
+	Decision         string `json:"decision,omitempty"`
+	Summary          string `json:"summary,omitempty"`
+	PullRequest      int    `json:"pull_request,omitempty"`
+}
+
+func runJobOpen(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job open", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	agent := fs.String("agent", "", "agent that performs the session work (must exist)")
+	repo := fs.String("repo", "", "repo scope as owner/repo (must be tracked)")
+	typeName := fs.String("type", "", "job type: ask|review|implement")
+	title := fs.String("title", "", "optional human title for the job")
+	task := fs.String("task", "", "optional task id to associate")
+	pr := fs.Int("pr", 0, "optional pull request number")
+	jsonOutput := fs.Bool("json", false, "print the created job as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "job open does not accept positional arguments")
+		return 2
+	}
+	action, ok := validateSessionAction(*typeName, stderr)
+	if !ok {
+		return 2
+	}
+	if strings.TrimSpace(*agent) == "" || strings.TrimSpace(*repo) == "" {
+		fmt.Fprintln(stderr, "job open requires --agent and --repo")
+		return 2
+	}
+
+	var out jobSessionOutput
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		fullName, err := validateSessionAgentRepo(context.Background(), store, *agent, *repo)
+		if err != nil {
+			return err
+		}
+		engine := sessionWorkflowEngine(store, paths.Home)
+		job, err := engine.OpenExternalJob(context.Background(), workflow.JobRequest{
+			ID:          sessionJobID(action, *agent),
+			Agent:       *agent,
+			Action:      action,
+			Repo:        fullName,
+			TaskID:      strings.TrimSpace(*task),
+			TaskTitle:   strings.TrimSpace(*title),
+			PullRequest: *pr,
+			Sender:      "session",
+		})
+		if err != nil {
+			return err
+		}
+		out = jobSessionOutput{
+			JobID:            job.ID,
+			State:            job.State,
+			Agent:            job.Agent,
+			Type:             job.Type,
+			Repo:             fullName,
+			ExternallyDriven: true,
+			PullRequest:      *pr,
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "job open: %v\n", err)
+		return 1
+	}
+	printJobSessionOutput(stdout, out, *jsonOutput)
+	return 0
+}
+
+func runJobClose(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job close", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	decision := fs.String("decision", "", "result decision: "+strings.Join(workflow.ResultDecisions, "|"))
+	summary := fs.String("summary", "", "optional result summary")
+	pr := fs.Int("pr", 0, "optional pull request number to record")
+	branch := fs.String("branch", "", "optional branch to record")
+	jsonOutput := fs.Bool("json", false, "print the closed job as JSON")
+	// The job id is positional and precedes the flags (`job close <id> --decision
+	// …`), so pull it off args[0] before flag.Parse (which stops at the first
+	// non-flag token).
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "job close requires a job id")
+			return 2
+		}
+		return 0
+	}
+	jobID := strings.TrimSpace(args[0])
+	if jobID == "" || strings.HasPrefix(jobID, "-") {
+		fmt.Fprintln(stderr, "job close requires a job id as the first argument")
+		return 2
+	}
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "job close accepts exactly one job id")
+		return 2
+	}
+	if !validateSessionDecision(*decision, stderr) {
+		return 2
+	}
+
+	var out jobSessionOutput
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		engine := sessionWorkflowEngine(store, paths.Home)
+		job, err := engine.CloseExternalJob(context.Background(), jobID, workflow.AgentResult{
+			Decision: *decision,
+			Summary:  strings.TrimSpace(*summary),
+		}, *pr, *branch)
+		if err != nil {
+			return err
+		}
+		payload, _ := workflow.ParseJobPayload(job.Payload)
+		out = jobSessionOutput{
+			JobID:            job.ID,
+			State:            job.State,
+			Agent:            job.Agent,
+			Type:             job.Type,
+			Repo:             payload.Repo,
+			ExternallyDriven: job.ExternallyDriven,
+			Decision:         *decision,
+			Summary:          strings.TrimSpace(*summary),
+			PullRequest:      payload.PullRequest,
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "job close: %v\n", err)
+		return 1
+	}
+	printJobSessionOutput(stdout, out, *jsonOutput)
+	return 0
+}
+
+func runJobRecord(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job record", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	agent := fs.String("agent", "", "agent that performed the session work (must exist)")
+	repo := fs.String("repo", "", "repo scope as owner/repo (must be tracked)")
+	typeName := fs.String("type", "", "job type: ask|review|implement")
+	decision := fs.String("decision", "", "result decision: "+strings.Join(workflow.ResultDecisions, "|"))
+	title := fs.String("title", "", "optional human title for the job")
+	summary := fs.String("summary", "", "optional result summary")
+	task := fs.String("task", "", "optional task id to associate")
+	pr := fs.Int("pr", 0, "optional pull request number")
+	branch := fs.String("branch", "", "optional branch to record")
+	jsonOutput := fs.Bool("json", false, "print the recorded job as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "job record does not accept positional arguments")
+		return 2
+	}
+	action, ok := validateSessionAction(*typeName, stderr)
+	if !ok {
+		return 2
+	}
+	if strings.TrimSpace(*agent) == "" || strings.TrimSpace(*repo) == "" {
+		fmt.Fprintln(stderr, "job record requires --agent and --repo")
+		return 2
+	}
+	if !validateSessionDecision(*decision, stderr) {
+		return 2
+	}
+
+	var out jobSessionOutput
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		fullName, err := validateSessionAgentRepo(context.Background(), store, *agent, *repo)
+		if err != nil {
+			return err
+		}
+		engine := sessionWorkflowEngine(store, paths.Home)
+		opened, err := engine.OpenExternalJob(context.Background(), workflow.JobRequest{
+			ID:          sessionJobID(action, *agent),
+			Agent:       *agent,
+			Action:      action,
+			Repo:        fullName,
+			TaskID:      strings.TrimSpace(*task),
+			TaskTitle:   strings.TrimSpace(*title),
+			PullRequest: *pr,
+			Sender:      "session",
+		})
+		if err != nil {
+			return err
+		}
+		job, err := engine.CloseExternalJob(context.Background(), opened.ID, workflow.AgentResult{
+			Decision: *decision,
+			Summary:  strings.TrimSpace(*summary),
+		}, *pr, *branch)
+		if err != nil {
+			return err
+		}
+		payload, _ := workflow.ParseJobPayload(job.Payload)
+		out = jobSessionOutput{
+			JobID:            job.ID,
+			State:            job.State,
+			Agent:            job.Agent,
+			Type:             job.Type,
+			Repo:             fullName,
+			ExternallyDriven: job.ExternallyDriven,
+			Decision:         *decision,
+			Summary:          strings.TrimSpace(*summary),
+			PullRequest:      payload.PullRequest,
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "job record: %v\n", err)
+		return 1
+	}
+	printJobSessionOutput(stdout, out, *jsonOutput)
+	return 0
+}
+
+// sessionWorkflowEngine builds the workflow engine used by the session-job
+// commands. It needs no checkout or GitHub work (a session job never dispatches a
+// runtime), so it passes an empty checkout; the only engine seam it exercises is
+// the wired EventSink, which lets CloseExternalJob emit the outbound
+// job.finished/failed/blocked event exactly as an engine-run job does.
+func sessionWorkflowEngine(store *db.Store, home string) workflow.Engine {
+	return daemonWorkflowEngine(store, github.NewClient(""), "", home)
+}
+
+// validateSessionAction validates a `--type` flag against the allowed job actions.
+func validateSessionAction(value string, stderr io.Writer) (string, bool) {
+	action := strings.TrimSpace(value)
+	for _, a := range sessionJobActions {
+		if action == a {
+			return action, true
+		}
+	}
+	fmt.Fprintf(stderr, "invalid --type %q; want one of %s\n", value, strings.Join(sessionJobActions, ", "))
+	return "", false
+}
+
+// validateSessionDecision validates a `--decision` flag against ResultDecisions.
+func validateSessionDecision(value string, stderr io.Writer) bool {
+	decision := strings.TrimSpace(value)
+	for _, d := range workflow.ResultDecisions {
+		if decision == d {
+			return true
+		}
+	}
+	fmt.Fprintf(stderr, "invalid --decision %q; want one of %s\n", value, strings.Join(workflow.ResultDecisions, ", "))
+	return false
+}
+
+// validateSessionAgentRepo confirms the agent and repo exist, returning the
+// canonical owner/repo full name. The agent must be a registered agent (or a
+// managed instance); the repo must be a well-formed owner/repo that gitmoot
+// tracks. It does NOT run capability/access checks: a session job is a
+// record-keeping surface for work the caller already did, not a dispatch.
+func validateSessionAgentRepo(ctx context.Context, store *db.Store, agentName, repoFlag string) (string, error) {
+	if _, err := store.GetAgent(ctx, strings.TrimSpace(agentName)); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", fmt.Errorf("agent %q not found", agentName)
+		}
+		return "", err
+	}
+	repo, err := daemon.ParseRepository(repoFlag)
+	if err != nil {
+		return "", err
+	}
+	fullName := repo.FullName()
+	if _, err := store.GetRepo(ctx, fullName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", fmt.Errorf("repo %q is not tracked; add it with `gitmoot repo add %s` first", fullName, fullName)
+		}
+		return "", err
+	}
+	return fullName, nil
+}
+
+// sessionJobID mints a stable, unique id for a session job, distinct from the
+// engine's `local-*` foreground ids so a session-recorded job is recognizable.
+func sessionJobID(action, agent string) string {
+	return fmt.Sprintf("session-%s-%s-%x", action, agent, time.Now().UTC().UnixNano())
+}
+
+func printJobSessionOutput(stdout io.Writer, out jobSessionOutput, jsonOutput bool) {
+	if jsonOutput {
+		_ = writeJSON(stdout, out)
+		return
+	}
+	writeLine(stdout, "job: %s", out.JobID)
+	writeLine(stdout, "state: %s", out.State)
+	writeLine(stdout, "agent: %s", out.Agent)
+	writeLine(stdout, "type: %s", out.Type)
+	writeLine(stdout, "repo: %s", out.Repo)
+	if out.Decision != "" {
+		writeLine(stdout, "decision: %s", out.Decision)
+	}
+	if out.Summary != "" {
+		writeLine(stdout, "summary: %s", out.Summary)
+	}
+	if out.PullRequest > 0 {
+		writeLine(stdout, "pull_request: %d", out.PullRequest)
+	}
+}

--- a/internal/cli/job_session_test.go
+++ b/internal/cli/job_session_test.go
@@ -1,0 +1,191 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func seedSessionAgentRepo(t *testing.T, store *db.Store) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", Enabled: true}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:         "lead",
+		Role:         "agent",
+		Runtime:      runtime.ShellRuntime,
+		RuntimeRef:   "printf ok",
+		RepoScope:    "owner/repo",
+		Capabilities: []string{"ask", "review", "implement"},
+		HealthStatus: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+}
+
+// TestJobOpenCreatesRunningSessionJob proves `job open` creates a running,
+// externally_driven job with no queued row (no dispatch).
+func TestJobOpenCreatesRunningSessionJob(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedSessionAgentRepo(t, store)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "open", "--home", home, "--agent", "lead", "--repo", "owner/repo", "--type", "ask", "--title", "lead session", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job open exit = %d, stderr=%s", code, stderr.String())
+	}
+	var out jobSessionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode job open JSON: %v (%s)", err, stdout.String())
+	}
+	if out.State != string(workflow.JobRunning) || !out.ExternallyDriven || out.Type != "ask" || out.Repo != "owner/repo" {
+		t.Fatalf("job open output = %+v", out)
+	}
+
+	stored, err := store.GetJob(context.Background(), out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(workflow.JobRunning) || !stored.ExternallyDriven {
+		t.Fatalf("stored job = %+v, want running externally_driven", stored)
+	}
+	queued, err := store.ListQueuedJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	if len(queued) != 0 {
+		t.Fatalf("queued = %d, want 0", len(queued))
+	}
+}
+
+// TestJobCloseAppliesDecision proves open+close moves the job to its terminal state
+// with the session's result.
+func TestJobCloseAppliesDecision(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedSessionAgentRepo(t, store)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "open", "--home", home, "--agent", "lead", "--repo", "owner/repo", "--type", "review", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job open exit = %d, stderr=%s", code, stderr.String())
+	}
+	var opened jobSessionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &opened); err != nil {
+		t.Fatalf("decode open JSON: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "close", opened.JobID, "--home", home, "--decision", "changes_requested", "--summary", "needs work", "--pr", "9", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job close exit = %d, stderr=%s", code, stderr.String())
+	}
+	var closed jobSessionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &closed); err != nil {
+		t.Fatalf("decode close JSON: %v", err)
+	}
+	if closed.State != string(workflow.JobSucceeded) || closed.Decision != "changes_requested" || closed.PullRequest != 9 {
+		t.Fatalf("close output = %+v", closed)
+	}
+	stored, err := store.GetJob(context.Background(), opened.JobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(workflow.JobSucceeded) {
+		t.Fatalf("stored state = %q, want succeeded", stored.State)
+	}
+}
+
+// TestJobRecordOneShotTerminal proves `job record` creates an already-terminal job.
+func TestJobRecordOneShotTerminal(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedSessionAgentRepo(t, store)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "record", "--home", home, "--agent", "lead", "--repo", "owner/repo", "--type", "implement", "--decision", "implemented", "--summary", "done", "--pr", "12", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job record exit = %d, stderr=%s", code, stderr.String())
+	}
+	var out jobSessionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode record JSON: %v", err)
+	}
+	if out.State != string(workflow.JobSucceeded) || out.Decision != "implemented" || !out.ExternallyDriven {
+		t.Fatalf("record output = %+v", out)
+	}
+	stored, err := store.GetJob(context.Background(), out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if stored.State != string(workflow.JobSucceeded) || !stored.ExternallyDriven {
+		t.Fatalf("stored job = %+v", stored)
+	}
+}
+
+// TestJobSessionValidationErrors proves the CLI rejects bad input cleanly.
+func TestJobSessionValidationErrors(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedSessionAgentRepo(t, store)
+
+	cases := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{"invalid type", []string{"job", "open", "--home", home, "--agent", "lead", "--repo", "owner/repo", "--type", "bogus"}, 2},
+		{"invalid decision", []string{"job", "record", "--home", home, "--agent", "lead", "--repo", "owner/repo", "--type", "ask", "--decision", "bogus"}, 2},
+		{"missing agent", []string{"job", "open", "--home", home, "--repo", "owner/repo", "--type", "ask"}, 2},
+		{"unknown agent", []string{"job", "open", "--home", home, "--agent", "ghost", "--repo", "owner/repo", "--type", "ask"}, 1},
+		{"untracked repo", []string{"job", "open", "--home", home, "--agent", "lead", "--repo", "owner/nope", "--type", "ask"}, 1},
+		{"close unknown id", []string{"job", "close", "no-such-job", "--home", home, "--decision", "approved"}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := Run(tc.args, &stdout, &stderr); code != tc.want {
+				t.Fatalf("exit = %d, want %d; stderr=%s", code, tc.want, stderr.String())
+			}
+		})
+	}
+}
+
+// TestJobCloseDoubleCloseFails proves a session job can be closed exactly once.
+func TestJobCloseDoubleCloseFails(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedSessionAgentRepo(t, store)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "open", "--home", home, "--agent", "lead", "--repo", "owner/repo", "--type", "ask", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job open exit = %d, stderr=%s", code, stderr.String())
+	}
+	var opened jobSessionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &opened); err != nil {
+		t.Fatalf("decode open JSON: %v", err)
+	}
+	if code := Run([]string{"job", "close", opened.JobID, "--home", home, "--decision", "approved"}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("first close failed")
+	}
+	stderr.Reset()
+	if code := Run([]string{"job", "close", opened.JobID, "--home", home, "--decision", "approved"}, &bytes.Buffer{}, &stderr); code != 1 {
+		t.Fatalf("second close exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "already been closed") {
+		t.Fatalf("double-close stderr = %q, want already-been-closed", stderr.String())
+	}
+}

--- a/internal/cli/session_job_e2e_test.go
+++ b/internal/cli/session_job_e2e_test.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestSessionJobFullChainE2E is the full-chain, no-LLM, no-network proof for
+// session jobs (#657). It drives the REAL code paths end to end on an isolated
+// t.TempDir home — the actual CLI commands (`job open`/`job retry`/`job close`),
+// the daemon's real dispatch tick, and the real stuck-running reaper — to prove
+// the whole "clock in / clock out" contract holds as an integration, not just in
+// units:
+//
+//	(a) `job open`  -> a RUNNING externally_driven row, a running/"started" event,
+//	                   NO queued row, and NO runtime-session/checkout lock taken;
+//	(b) a real dispatch tick delivers a normal queued job but NEVER the session job;
+//	(c) the real stuck-running reaper, given a stale session row, does NOT reap it;
+//	(d) `job retry` on the session job is refused;
+//	(e) `job close --decision implemented` -> terminal succeeded + a "finished"
+//	    (succeeded) event, reflected in ListJobs/GetJob exactly like an engine job.
+//
+// The fake adapter records every Deliver, so "never dispatched to a runtime" is
+// asserted against the actual delivery seam, not a proxy.
+func TestSessionJobFullChainE2E(t *testing.T) {
+	ctx := context.Background()
+
+	// Isolated home shared by the persistent assertion store and every CLI command
+	// (both resolve config.PathsForHome(home), so they hit the same DB file).
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("db.Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	// lead has both ask + implement so it can own an implement session job and run a
+	// normal ask job; the implement capability also gives it a write policy.
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"ask", "implement"}, "owner/repo")
+
+	homeArgs := []string{"--home", home}
+
+	// --- (a) job open: clock in ---------------------------------------------
+	var openOut bytes.Buffer
+	if code := runJobOpen(append(append([]string{}, homeArgs...),
+		"--agent", "lead", "--repo", "owner/repo", "--type", "implement", "--json"), &openOut, io.Discard); code != 0 {
+		t.Fatalf("job open exit code = %d, want 0; out=%q", code, openOut.String())
+	}
+	sessionID := decodeSessionJobID(t, openOut.Bytes())
+
+	opened, err := store.GetJob(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetJob(session) returned error: %v", err)
+	}
+	if opened.State != string(workflow.JobRunning) {
+		t.Fatalf("opened session job state = %q, want running", opened.State)
+	}
+	if !opened.ExternallyDriven {
+		t.Fatalf("opened session job ExternallyDriven = false, want true")
+	}
+	if evs, err := store.ListJobEvents(ctx, sessionID); err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	} else if !anyEventKind(evs, string(workflow.JobRunning)) {
+		t.Fatalf("session job events = %+v, want a running/started event", evs)
+	}
+	if queued, err := store.ListQueuedJobs(ctx); err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	} else if len(queued) != 0 {
+		t.Fatalf("queued jobs after open = %d, want 0 (a session job never queues)", len(queued))
+	}
+	if locks, err := store.ListResourceLocks(ctx); err != nil {
+		t.Fatalf("ListResourceLocks returned error: %v", err)
+	} else if len(locks) != 0 {
+		t.Fatalf("resource locks after open = %+v, want none (no runtime-session/checkout lock for a session job)", locks)
+	}
+
+	// --- (b) a real dispatch tick never claims/Delivers the session job ------
+	// A NORMAL queued job proves the tick DOES dispatch — the session job's absence
+	// from the delivered set is then a real exemption, not a dead tick.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "engine-ask-1", Agent: "lead", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	worker := poolSchedulerWorker(t, store, adapter, false)
+	if err := runDaemonWorkerTick(ctx, store, worker, 1, false, "owner/repo", "", io.Discard, time.Now().UTC()); err != nil {
+		t.Fatalf("runDaemonWorkerTick(dispatch) returned error: %v", err)
+	}
+	delivered := adapter.deliveredIDs()
+	if !containsString(delivered, "engine-ask-1") {
+		t.Fatalf("delivered = %v, want the normal engine job to be dispatched (tick must be live)", delivered)
+	}
+	if containsString(delivered, sessionID) {
+		t.Fatalf("delivered = %v; the session job %s was dispatched to a runtime (invariant breach)", delivered, sessionID)
+	}
+	if reloaded, err := store.GetJob(ctx, sessionID); err != nil {
+		t.Fatalf("GetJob(session) returned error: %v", err)
+	} else if reloaded.State != string(workflow.JobRunning) {
+		t.Fatalf("session job state after dispatch tick = %q, want still running (never claimed)", reloaded.State)
+	}
+
+	// --- (c) the real stuck-running reaper does NOT reap the session job -----
+	// Treat the session row as stale by giving the REAL reaper a `before` threshold
+	// past its updated_at (the same way the repo's own reaper tests simulate
+	// staleness). A normal running job below the threshold WOULD be requeued; the
+	// session job must be exempt because the calling session holds it open.
+	reapNow := time.Now().UTC()
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, io.Discard, reapNow, reapNow.Add(time.Hour), "owner/repo", ""); err != nil {
+		t.Fatalf("recoverRunningJobsBeforeForRepo returned error: %v", err)
+	}
+	if reaped, err := store.GetJob(ctx, sessionID); err != nil {
+		t.Fatalf("GetJob(session) returned error: %v", err)
+	} else if reaped.State != string(workflow.JobRunning) {
+		t.Fatalf("session job state after reaper = %q, want still running (session job must be exempt)", reaped.State)
+	}
+
+	// --- (d) job retry on the session job is refused -------------------------
+	var retryErr bytes.Buffer
+	if code := runJobRetry(append(append([]string{}, sessionID), homeArgs...), io.Discard, &retryErr); code == 0 {
+		t.Fatalf("job retry on a session job exit code = 0, want non-zero (retry must be refused)")
+	}
+	if !strings.Contains(retryErr.String(), "session job") {
+		t.Fatalf("job retry stderr = %q, want a session-job refusal", retryErr.String())
+	}
+	// The refusal must be pre-transition: the job is untouched (still running, still
+	// never queued).
+	if afterRetry, err := store.GetJob(ctx, sessionID); err != nil {
+		t.Fatalf("GetJob(session) returned error: %v", err)
+	} else if afterRetry.State != string(workflow.JobRunning) {
+		t.Fatalf("session job state after refused retry = %q, want still running", afterRetry.State)
+	}
+	if queued, err := store.ListQueuedJobs(ctx); err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	} else if containsQueued(queued, sessionID) {
+		t.Fatalf("session job appeared in the queue after a refused retry: %+v", queued)
+	}
+
+	// --- (e) job close: clock out, terminal succeeded ------------------------
+	var closeOut bytes.Buffer
+	if code := runJobClose(append(append([]string{sessionID}, homeArgs...),
+		"--decision", "implemented", "--summary", "did the here-work"), &closeOut, io.Discard); code != 0 {
+		t.Fatalf("job close exit code = %d, want 0; out=%q", code, closeOut.String())
+	}
+	closed, err := store.GetJob(ctx, sessionID)
+	if err != nil {
+		t.Fatalf("GetJob(session) returned error: %v", err)
+	}
+	if closed.State != string(workflow.JobSucceeded) {
+		t.Fatalf("closed session job state = %q, want succeeded", closed.State)
+	}
+	if evs, err := store.ListJobEvents(ctx, sessionID); err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	} else if !anyEventKind(evs, string(workflow.JobSucceeded)) {
+		t.Fatalf("session job events after close = %+v, want a succeeded/finished event", evs)
+	}
+
+	// It reflects in ListJobs/GetJob exactly like an engine-run job: succeeded,
+	// externally_driven set, and carrying its recorded implemented decision.
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var listed *db.Job
+	for i := range jobs {
+		if jobs[i].ID == sessionID {
+			listed = &jobs[i]
+			break
+		}
+	}
+	if listed == nil {
+		t.Fatalf("session job %s not present in ListJobs", sessionID)
+	}
+	if listed.State != string(workflow.JobSucceeded) || !listed.ExternallyDriven {
+		t.Fatalf("ListJobs session row = %+v, want succeeded + externally_driven", *listed)
+	}
+	payload, err := workflow.ParseJobPayload(closed.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	}
+	if payload.Result == nil || payload.Result.Decision != "implemented" {
+		t.Fatalf("closed session job payload result = %+v, want decision implemented", payload.Result)
+	}
+}
+
+func decodeSessionJobID(t *testing.T, jsonBytes []byte) string {
+	t.Helper()
+	var out jobSessionOutput
+	if err := json.Unmarshal(jsonBytes, &out); err != nil {
+		t.Fatalf("decode job open JSON %q: %v", string(jsonBytes), err)
+	}
+	if strings.TrimSpace(out.JobID) == "" {
+		t.Fatalf("job open JSON carried no job_id: %q", string(jsonBytes))
+	}
+	return out.JobID
+}
+
+func (f *cliWorkerFakeAdapter) deliveredIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string{}, f.delivered...)
+}
+
+func anyEventKind(events []db.JobEvent, kind string) bool {
+	for _, ev := range events {
+		if ev.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func containsQueued(jobs []db.Job, id string) bool {
+	for _, j := range jobs {
+		if j.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/db/session_job_test.go
+++ b/internal/db/session_job_test.go
@@ -1,0 +1,138 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestExternallyDrivenDefaultsFalse proves the #657 column is additive: a job
+// created via the normal CreateJob path (which never sets externally_driven) reads
+// back false through both GetJob and ListJobs, so every engine-driven job is
+// byte-identical.
+func TestExternallyDrivenDefaultsFalse(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateJob(ctx, Job{ID: "j1", Agent: "a", Type: "ask", State: "queued"}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	got, err := store.GetJob(ctx, "j1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if got.ExternallyDriven {
+		t.Fatalf("GetJob ExternallyDriven = true, want false")
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternallyDriven {
+		t.Fatalf("ListJobs = %+v, want one job with ExternallyDriven=false", jobs)
+	}
+}
+
+// TestCreateExternallyDrivenJobWithEvent proves the session insert path stamps the
+// flag and creates the job directly running with its clock-in event.
+func TestCreateExternallyDrivenJobWithEvent(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateExternallyDrivenJobWithEvent(ctx, Job{
+		ID:    "s1",
+		Agent: "lead",
+		Type:  "ask",
+		State: "running",
+	}, JobEvent{Kind: "running", Message: "job started"}); err != nil {
+		t.Fatalf("CreateExternallyDrivenJobWithEvent returned error: %v", err)
+	}
+	got, err := store.GetJob(ctx, "s1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if !got.ExternallyDriven || got.State != "running" {
+		t.Fatalf("job = %+v, want running externally_driven", got)
+	}
+	evs, err := store.ListJobEvents(ctx, "s1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(evs) != 1 || evs[0].Kind != "running" {
+		t.Fatalf("events = %+v, want a single running event", evs)
+	}
+}
+
+// TestListRunningJobsUpdatedBeforeSkipsExternallyDriven is the highest-risk
+// correctness point (#657): the stuck-running reaper MUST NOT reclaim a session job
+// even when it is stale, because the calling session may hold it open for minutes.
+func TestListRunningJobsUpdatedBeforeSkipsExternallyDriven(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	// A normal running job (engine-driven) and a session running job, both stale.
+	if err := store.CreateJob(ctx, Job{ID: "engine-run", Agent: "a", Type: "implement", State: "running"}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	if err := store.CreateExternallyDrivenJobWithEvent(ctx, Job{ID: "session-run", Agent: "lead", Type: "ask", State: "running"}, JobEvent{Kind: "running", Message: "job started"}); err != nil {
+		t.Fatalf("CreateExternallyDrivenJobWithEvent returned error: %v", err)
+	}
+	// Backdate both so they predate the reaper threshold.
+	if _, err := store.db.ExecContext(ctx, `UPDATE jobs SET updated_at = '2026-01-01 00:00:00'`); err != nil {
+		t.Fatalf("backdate returned error: %v", err)
+	}
+
+	before := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	got, err := store.ListRunningJobsUpdatedBefore(ctx, before)
+	if err != nil {
+		t.Fatalf("ListRunningJobsUpdatedBefore returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "engine-run" {
+		t.Fatalf("reaper candidates = %+v, want only engine-run (session job must be exempt)", got)
+	}
+}
+
+// TestExternallyDrivenColumnMigratesOnPreExistingDB proves the migration is correct
+// on a pre-existing DB: a job written on a first Open reads externally_driven=0 and
+// a re-open (idempotent re-migration) neither errors nor changes it.
+func TestExternallyDrivenColumnMigratesOnPreExistingDB(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, Job{ID: "old", Agent: "a", Type: "ask", State: "queued"}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("re-Open returned error: %v", err)
+	}
+	defer reopened.Close()
+	got, err := reopened.GetJob(ctx, "old")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if got.ExternallyDriven {
+		t.Fatalf("pre-existing row ExternallyDriven = true, want false (default 0)")
+	}
+}

--- a/internal/db/session_job_test.go
+++ b/internal/db/session_job_test.go
@@ -105,6 +105,40 @@ func TestListRunningJobsUpdatedBeforeSkipsExternallyDriven(t *testing.T) {
 	}
 }
 
+// TestListQueuedJobsSkipsExternallyDriven is the belt-and-suspenders dispatch guard
+// (#657): even if some path forces an externally_driven row to state='queued', the
+// daemon's queued selector must never return it, so it can never be claimed and
+// Delivered to a runtime with an empty session payload. A normal queued job on the
+// same DB is still returned.
+func TestListQueuedJobsSkipsExternallyDriven(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateJob(ctx, Job{ID: "engine-queued", Agent: "a", Type: "implement", State: "queued"}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	// A session job is created directly running; force it to 'queued' to simulate a
+	// hypothetical path that put it on the queue, and assert the selector still skips it.
+	if err := store.CreateExternallyDrivenJobWithEvent(ctx, Job{ID: "session-forced-queued", Agent: "lead", Type: "implement", State: "running"}, JobEvent{Kind: "running", Message: "job started"}); err != nil {
+		t.Fatalf("CreateExternallyDrivenJobWithEvent returned error: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE jobs SET state = 'queued' WHERE id = 'session-forced-queued'`); err != nil {
+		t.Fatalf("force queued returned error: %v", err)
+	}
+
+	got, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "engine-queued" {
+		t.Fatalf("queued candidates = %+v, want only engine-queued (session job must be exempt)", got)
+	}
+}
+
 // TestExternallyDrivenColumnMigratesOnPreExistingDB proves the migration is correct
 // on a pre-existing DB: a job written on a first Open reads externally_driven=0 and
 // a re-open (idempotent re-migration) neither errors nor changes it.

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2606,7 +2606,7 @@ func (s *Store) SumJobTokensByRoot(ctx context.Context, rootID string) (int, err
 // PRODUCTION text rather than a hand-copied duplicate — a change to this query is then
 // what the test actually asserts a plan for.
 const listQueuedJobsSQL = `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
-		FROM jobs WHERE state = 'queued' ORDER BY created_at, rowid`
+		FROM jobs WHERE state = 'queued' AND externally_driven = 0 ORDER BY created_at, rowid`
 
 // ListQueuedJobs returns the queued jobs in created_at (then rowid) order. The
 // state predicate is the SQL literal 'queued' — not a bound parameter — so SQLite
@@ -2615,6 +2615,14 @@ const listQueuedJobsSQL = `SELECT id, agent, type, state, payload, parent_job_id
 // leaves the planner unable to prove the partial predicate, so it full-scans jobs
 // and builds a temp b-tree for the ORDER BY every worker tick (#619, verified by
 // EXPLAIN QUERY PLAN). 'queued' is a fixed constant, so inlining it is safe.
+//
+// The `externally_driven = 0` predicate defends the session-job invariant (#657):
+// a "here"/prompt-import job is executed by the calling session, never the engine,
+// so it must never be claimed off the queue and Delivered to a runtime even if some
+// path forced an externally_driven row to state='queued'. Session jobs are created
+// directly running so they normally never reach the queue at all; this is the
+// belt-and-suspenders guard mirroring the reaper's exemption below. It is a residual
+// filter on top of the partial-index scan, so the query plan is unchanged.
 func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	rows, err := s.db.QueryContext(ctx, listQueuedJobsSQL)
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -248,6 +248,15 @@ type Job struct {
 	// report usage contributes 0 — the budget still works, it just under-counts.
 	InputTokens  int
 	OutputTokens int
+	// ExternallyDriven marks a job whose execution happens OUTSIDE the engine —
+	// the "here"/prompt-import calling session does the real work and clocks it in
+	// via `job open`/`record` (#657). It changes exactly three behaviors: the job
+	// is created directly in `running` (never queued, so the daemon never claims or
+	// Delivers it), the stuck-running reaper skips it (a session may hold it open
+	// for minutes), and it is closed via the CLI rather than a runtime result.
+	// Defaults false, so every engine-driven job and the whole normal dispatch/
+	// reaper path is byte-identical. Populated by GetJob/ListJobs.
+	ExternallyDriven bool
 	// UpdatedAt is populated by ListJobs (for age display in the dashboard);
 	// other readers may leave it zero.
 	UpdatedAt string
@@ -2396,6 +2405,37 @@ func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent)
 	return tx.Commit()
 }
 
+// CreateExternallyDrivenJobWithEvent creates a session job (#657) whose execution
+// happens OUTSIDE the engine: it sets externally_driven = 1 so the daemon's
+// queued selector never claims it and the stuck-running reaper skips it. It
+// mirrors CreateJobWithEvent (same root_id denormalization, same in-tx event) but
+// stamps the extra column; the caller supplies job.State = 'running' so the job
+// is created directly running, never queued. This is the ONLY insert site that
+// sets externally_driven — every other job insert leaves it at its DEFAULT 0, so
+// the normal dispatch path is byte-identical.
+func (s *Store) CreateExternallyDrivenJobWithEvent(ctx context.Context, job Job, event JobEvent) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, externally_driven, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), 1, CURRENT_TIMESTAMP)`,
+		job.ID, job.Agent, job.Type, job.State, job.Payload,
+		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy,
+		rootIDFromPayload(job.Payload), job.ID); err != nil {
+		return err
+	}
+	if event.JobID == "" {
+		event.JobID = job.ID
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // JobCreatedAt returns a job's created_at timestamp string (SQLite UTC format,
 // "2006-01-02 15:04:05"). Used by the delegation wall-clock backstop to measure a
 // tree's age from its root job. Returns sql.ErrNoRows if the job is unknown.
@@ -2434,18 +2474,18 @@ func (s *Store) IsRootJobKilled(ctx context.Context, rootID string) (bool, error
 }
 
 func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at, created_at FROM jobs WHERE id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven FROM jobs WHERE id = ?`, id)
 	var job Job
-	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt); err != nil {
+	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven); err != nil {
 		return Job{}, err
 	}
 	return job, nil
 }
 
-// jobColumns is the 14-column projection ListJobs and ListJobsByType both read (the
+// jobColumns is the 15-column projection ListJobs and ListJobsByType both read (the
 // full jobs row except root_id), kept as one const so their SELECT lists — and the
 // scanJobs scan order below — can never drift apart.
-const jobColumns = `id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at, created_at`
+const jobColumns = `id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven`
 
 // scanJobs reads every row of a *sql.Rows produced by a `SELECT `+jobColumns+`
 // FROM jobs …` query into Jobs, in jobColumns order, and closes rows. Shared by
@@ -2455,7 +2495,7 @@ func scanJobs(rows *sql.Rows) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2597,8 +2637,14 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 // exported as a package-level const so the plan test (TestListRunningJobsUpdatedBeforeOrder)
 // EXPLAINs the PRODUCTION text (binding the threshold as its `?` parameter) instead of
 // a hand-copied duplicate.
+// The `externally_driven = 0` predicate exempts session jobs (#657) from the
+// stuck-running reaper: a "here"/prompt-import job is created directly running and
+// held open by the calling session for as long as the work takes, so the daemon
+// must never time it out and requeue it (which would try to Deliver work the
+// engine never owned). Engine-driven jobs default externally_driven = 0, so their
+// reaping is byte-identical.
 const listRunningJobsUpdatedBeforeSQL = `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
-		FROM jobs WHERE state = 'running' AND updated_at < ? ORDER BY updated_at`
+		FROM jobs WHERE state = 'running' AND externally_driven = 0 AND updated_at < ? ORDER BY updated_at`
 
 // ListRunningJobsUpdatedBefore returns the running jobs whose updated_at predates
 // the crash-backstop threshold. It orders by updated_at (not id) so the partial
@@ -7308,5 +7354,16 @@ CREATE TABLE skillopt_gate_runs (
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX idx_skillopt_gate_runs_candidate ON skillopt_gate_runs(candidate_version_id);
+	`,
+	// #657 session jobs: mark a job whose execution happens OUTSIDE the engine (the
+	// "here"/prompt-import calling session drives the real work via `job open`/
+	// `close`/`record`). A session job is created directly `running` and flagged so
+	// (1) the daemon's queued selector never claims it, (2) the stuck-running reaper
+	// skips it, and (3) it is closed via the CLI result path. Pure additive append —
+	// ALTER TABLE ADD COLUMN with a NOT NULL DEFAULT 0, so SQLite backfills every
+	// existing row to 0 and the whole normal dispatch/reaper path is byte-identical
+	// unless the new commands are used.
+	`
+ALTER TABLE jobs ADD COLUMN externally_driven INTEGER NOT NULL DEFAULT 0;
 	`,
 }

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -18,6 +18,15 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 	if err != nil {
 		return db.Job{}, err
 	}
+	// A session job (#657) is executed by the calling session, never the engine, so
+	// it must never be re-queued: retry transitions the job to 'queued', which the
+	// daemon would then claim and Deliver to a real runtime with an empty session
+	// payload (a session *implement* job could push a spurious branch/PR). Refuse
+	// the retry outright, before any state transition. GetJob scans the
+	// externally_driven column into the struct, so this predicate is reliable.
+	if job.ExternallyDriven {
+		return db.Job{}, fmt.Errorf("job %s is a session job (externally driven) and cannot be retried", job.ID)
+	}
 	switch job.State {
 	case string(JobFailed), string(JobBlocked), string(JobCancelled):
 	default:

--- a/internal/workflow/session_job.go
+++ b/internal/workflow/session_job.go
@@ -1,0 +1,155 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// OpenExternalJob records the "clock in" of a session-driven ("here"/prompt-import)
+// unit of work as a first-class tracked job WITHOUT the engine spawning a runtime
+// (#657). The job is created directly in RUNNING state and flagged
+// externally_driven, so the daemon's queued selector never claims it (no Deliver,
+// no runtime subprocess, no runtime-session/checkout lock) and the stuck-running
+// reaper skips it. It emits the same running-state ("job started") event a normal
+// job emits on claim, so the job list, events, and dashboard reflect it. The
+// calling session does the real work and later calls CloseExternalJob to apply the
+// result and move the job to its terminal state.
+func (m Mailbox) OpenExternalJob(ctx context.Context, request JobRequest) (db.Job, error) {
+	if m.Store == nil {
+		return db.Job{}, errors.New("mailbox store is required")
+	}
+	if err := validateJobRequest(request); err != nil {
+		return db.Job{}, err
+	}
+
+	snapshot, err := m.templateSnapshot(ctx, request.Agent)
+	if err != nil {
+		return db.Job{}, err
+	}
+
+	payload, err := marshalPayload(JobPayload{
+		Repo:                   request.Repo,
+		Branch:                 request.Branch,
+		PullRequest:            request.PullRequest,
+		GoalID:                 request.GoalID,
+		TaskID:                 request.TaskID,
+		TaskTitle:              request.TaskTitle,
+		Sender:                 firstNonEmptyString(request.Sender, "session"),
+		Instructions:           request.Instructions,
+		TemplateID:             snapshot.ID,
+		TemplateResolvedCommit: snapshot.ResolvedCommit,
+		TemplateContent:        snapshot.Content,
+	})
+	if err != nil {
+		return db.Job{}, err
+	}
+
+	job := db.Job{
+		ID:               request.ID,
+		Agent:            request.Agent,
+		Type:             request.Action,
+		State:            string(JobRunning),
+		Payload:          payload,
+		ExternallyDriven: true,
+	}
+	if err := m.Store.CreateExternallyDrivenJobWithEvent(ctx, job, db.JobEvent{
+		JobID:   job.ID,
+		Kind:    string(JobRunning),
+		Message: "job started (externally driven session)",
+	}); err != nil {
+		return db.Job{}, err
+	}
+	return job, nil
+}
+
+// CloseExternalJob records the "clock out" of a session job (#657): it applies the
+// session's result through the SAME result path an engine-run job uses —
+// result.Decision maps to a terminal JobState via stateForDecision, the result is
+// stored on the payload, and the terminal-state event + best-effort outbound event
+// (job.finished/failed/blocked via the wired EventSink) fire exactly as they do for
+// a runtime-returned result. Unlike the engine's finishWithPayload it emits NO
+// "advance_started" event, because a session job has no downstream engine
+// advancement to run (the session already did the work); emitting it would make the
+// daemon try to advance a job the engine never owned.
+//
+// A job can be closed exactly once: it must currently be running AND
+// externally_driven, else a clear error is returned (double-close, closing an
+// engine job, or an unknown id all fail cleanly).
+func (m Mailbox) CloseExternalJob(ctx context.Context, jobID string, result AgentResult, prOverride int, branchOverride string) (db.Job, error) {
+	if m.Store == nil {
+		return db.Job{}, errors.New("mailbox store is required")
+	}
+	if _, ok := allowedSet(ResultDecisions)[result.Decision]; !ok {
+		return db.Job{}, fmt.Errorf("unsupported decision %q; want one of %s", result.Decision, strings.Join(ResultDecisions, ", "))
+	}
+
+	job, err := m.Store.GetJob(ctx, jobID)
+	if err != nil {
+		return db.Job{}, err
+	}
+	if !job.ExternallyDriven {
+		return db.Job{}, fmt.Errorf("job %q is not a session job (not externally driven); only a job opened with `job open` can be closed", jobID)
+	}
+	if job.State != string(JobRunning) {
+		return db.Job{}, fmt.Errorf("job %q is %s, not running; it has already been closed", jobID, job.State)
+	}
+
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		return db.Job{}, err
+	}
+	resultCopy := result
+	payload.Result = &resultCopy
+	if prOverride > 0 {
+		payload.PullRequest = prOverride
+	}
+	if strings.TrimSpace(branchOverride) != "" {
+		payload.Branch = strings.TrimSpace(branchOverride)
+	}
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		return db.Job{}, err
+	}
+
+	state := stateForDecision(result.Decision)
+	transitioned, err := m.Store.TransitionJobStatePayloadWithEvent(ctx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
+		JobID:   jobID,
+		Kind:    string(state),
+		Message: fmt.Sprintf("job %s", state),
+	})
+	if err != nil {
+		return db.Job{}, err
+	}
+	if !transitioned {
+		latest, getErr := m.Store.GetJob(ctx, jobID)
+		if getErr != nil {
+			return db.Job{}, getErr
+		}
+		return db.Job{}, fmt.Errorf("job %q is %s, not running; it has already been closed", jobID, latest.State)
+	}
+	// Best-effort outbound emit on the genuine running->terminal transition (#446),
+	// wired the same way the engine wires finishWithPayload's terminal emit. nil-safe:
+	// with no EventSink configured no event is constructed and behavior is unchanged.
+	if m.emitTerminal != nil {
+		m.emitTerminal(ctx, jobID, state, payload)
+	}
+	return m.Store.GetJob(ctx, jobID)
+}
+
+// OpenExternalJob records a session job's clock-in through the engine's Mailbox so
+// the terminal-event emit seam (e.mailbox()) is wired for the matching
+// CloseExternalJob. See Mailbox.OpenExternalJob.
+func (e Engine) OpenExternalJob(ctx context.Context, request JobRequest) (db.Job, error) {
+	return e.mailbox().OpenExternalJob(ctx, request)
+}
+
+// CloseExternalJob applies a session job's result and moves it to its terminal
+// state, emitting the outbound terminal event through the engine's wired EventSink.
+// See Mailbox.CloseExternalJob.
+func (e Engine) CloseExternalJob(ctx context.Context, jobID string, result AgentResult, prOverride int, branchOverride string) (db.Job, error) {
+	return e.mailbox().CloseExternalJob(ctx, jobID, result, prOverride, branchOverride)
+}

--- a/internal/workflow/session_job_test.go
+++ b/internal/workflow/session_job_test.go
@@ -207,6 +207,44 @@ func TestCloseExternalJobErrors(t *testing.T) {
 	}
 }
 
+// TestRetryJobRefusesSessionJob proves the retry invariant hardening (#657): a
+// session job that has reached a retry-eligible terminal state (failed here) must
+// NOT be re-queued by RetryJob — re-queuing it would let the daemon claim it and
+// Deliver an empty session payload to a real runtime (a session implement job could
+// push a spurious branch/PR). Retry must refuse before any state transition, and
+// the job must stay in its terminal state (never queued).
+func TestRetryJobRefusesSessionJob(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+
+	mb := Mailbox{Store: store}
+	if _, err := mb.OpenExternalJob(ctx, JobRequest{ID: "sess-retry", Agent: "lead", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("OpenExternalJob returned error: %v", err)
+	}
+	// Close it into a retry-eligible terminal state (failed).
+	if _, err := mb.CloseExternalJob(ctx, "sess-retry", AgentResult{Decision: "failed"}, 0, ""); err != nil {
+		t.Fatalf("CloseExternalJob returned error: %v", err)
+	}
+
+	_, err := RetryJob(ctx, store, "sess-retry")
+	if err == nil || !strings.Contains(err.Error(), "session job") {
+		t.Fatalf("RetryJob(session job) err = %v, want a session-job refusal", err)
+	}
+
+	after := mustJob(t, store, "sess-retry")
+	if after.State != string(JobFailed) {
+		t.Fatalf("session job state after refused retry = %q, want failed (never re-queued)", after.State)
+	}
+	queued, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	if len(queued) != 0 {
+		t.Fatalf("queued jobs = %d, want 0 (refused retry must not queue the session job)", len(queued))
+	}
+}
+
 func hasEventKind(events []db.JobEvent, kind string) bool {
 	for _, ev := range events {
 		if ev.Kind == kind {

--- a/internal/workflow/session_job_test.go
+++ b/internal/workflow/session_job_test.go
@@ -1,0 +1,217 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+)
+
+// TestOpenExternalJobCreatesRunningNoQueue proves `job open` (clock-in) creates a
+// job directly in running state, flagged externally_driven, with a running-state
+// event and NO queued row — so the daemon's queued selector never claims it and no
+// runtime is ever dispatched.
+func TestOpenExternalJobCreatesRunningNoQueue(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"ask"}, "jerryfane/gitmoot")
+
+	job, err := (Mailbox{Store: store}).OpenExternalJob(ctx, JobRequest{
+		ID:     "session-ask-lead-1",
+		Agent:  "lead",
+		Action: "ask",
+		Repo:   "jerryfane/gitmoot",
+	})
+	if err != nil {
+		t.Fatalf("OpenExternalJob returned error: %v", err)
+	}
+	if job.State != string(JobRunning) {
+		t.Fatalf("job state = %q, want running", job.State)
+	}
+
+	stored := mustJob(t, store, "session-ask-lead-1")
+	if stored.State != string(JobRunning) {
+		t.Fatalf("stored state = %q, want running", stored.State)
+	}
+	if !stored.ExternallyDriven {
+		t.Fatalf("stored ExternallyDriven = false, want true")
+	}
+
+	queued, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs returned error: %v", err)
+	}
+	if len(queued) != 0 {
+		t.Fatalf("queued jobs = %d, want 0 (session jobs never queue)", len(queued))
+	}
+
+	evs, err := store.ListJobEvents(ctx, "session-ask-lead-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if len(evs) != 1 || evs[0].Kind != string(JobRunning) {
+		t.Fatalf("events = %+v, want a single running event", evs)
+	}
+}
+
+// TestCloseExternalJobAppliesDecision proves close applies the decision through the
+// same state mapping an engine result uses, writes the terminal-state event, emits
+// the outbound terminal event through the wired EventSink, and — critically — does
+// NOT write an advance_started event (a session job has no engine advancement).
+func TestCloseExternalJobAppliesDecision(t *testing.T) {
+	cases := []struct {
+		decision  string
+		wantState JobState
+		wantType  events.EventType
+	}{
+		{"approved", JobSucceeded, events.EventJobFinished},
+		{"implemented", JobSucceeded, events.EventJobFinished},
+		{"changes_requested", JobSucceeded, events.EventJobFinished},
+		{"blocked", JobBlocked, events.EventJobBlocked},
+		{"failed", JobFailed, events.EventJobFailed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.decision, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			seedAgent(t, store, "lead", []string{"ask"}, "jerryfane/gitmoot")
+			sink := &recordingSink{}
+			engine := testEngine(store)
+			engine.EventSink = sink
+
+			if _, err := engine.OpenExternalJob(ctx, JobRequest{
+				ID:     "session-job",
+				Agent:  "lead",
+				Action: "ask",
+				Repo:   "jerryfane/gitmoot",
+			}); err != nil {
+				t.Fatalf("OpenExternalJob returned error: %v", err)
+			}
+
+			closed, err := engine.CloseExternalJob(ctx, "session-job", AgentResult{
+				Decision: tc.decision,
+				Summary:  "session done",
+			}, 0, "")
+			if err != nil {
+				t.Fatalf("CloseExternalJob returned error: %v", err)
+			}
+			if closed.State != string(tc.wantState) {
+				t.Fatalf("closed state = %q, want %q", closed.State, tc.wantState)
+			}
+
+			// The stored result must be the session's result.
+			payload, err := unmarshalPayload(closed.Payload)
+			if err != nil {
+				t.Fatalf("unmarshalPayload returned error: %v", err)
+			}
+			if payload.Result == nil || payload.Result.Decision != tc.decision || payload.Result.Summary != "session done" {
+				t.Fatalf("payload result = %+v, want decision %q", payload.Result, tc.decision)
+			}
+
+			// Exactly one outbound terminal event of the right type.
+			got := sink.byType(tc.wantType)
+			if len(got) != 1 {
+				t.Fatalf("%s emissions = %d, want 1; all=%+v", tc.wantType, len(got), sink.snapshot())
+			}
+			if got[0].Status != string(tc.wantState) || got[0].Detail != "session done" {
+				t.Fatalf("terminal event = %+v", got[0])
+			}
+
+			// No advance_started event: a session job must not trigger engine
+			// advancement (which would try to advance work the engine never owned).
+			evs, err := store.ListJobEvents(ctx, "session-job")
+			if err != nil {
+				t.Fatalf("ListJobEvents returned error: %v", err)
+			}
+			for _, ev := range evs {
+				if ev.Kind == "advance_started" {
+					t.Fatalf("close wrote an advance_started event: %+v", evs)
+				}
+			}
+			// The terminal-state event must be present.
+			if !hasEventKind(evs, string(tc.wantState)) {
+				t.Fatalf("events %+v missing terminal %q", evs, tc.wantState)
+			}
+		})
+	}
+}
+
+// TestCloseExternalJobRecordsPRAndBranch proves the optional --pr/--branch
+// overrides land on the stored payload.
+func TestCloseExternalJobRecordsPRAndBranch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+
+	if _, err := (Mailbox{Store: store}).OpenExternalJob(ctx, JobRequest{
+		ID:     "session-impl",
+		Agent:  "lead",
+		Action: "implement",
+		Repo:   "jerryfane/gitmoot",
+	}); err != nil {
+		t.Fatalf("OpenExternalJob returned error: %v", err)
+	}
+	closed, err := (Mailbox{Store: store}).CloseExternalJob(ctx, "session-impl", AgentResult{
+		Decision: "implemented",
+		Summary:  "shipped",
+	}, 42, "feat/x")
+	if err != nil {
+		t.Fatalf("CloseExternalJob returned error: %v", err)
+	}
+	payload, err := unmarshalPayload(closed.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload returned error: %v", err)
+	}
+	if payload.PullRequest != 42 || payload.Branch != "feat/x" {
+		t.Fatalf("payload pr/branch = %d/%q, want 42/feat/x", payload.PullRequest, payload.Branch)
+	}
+}
+
+// TestCloseExternalJobErrors proves the clean-error edges: double-close, closing an
+// unknown id, closing an engine (non-session) job, and an invalid decision.
+func TestCloseExternalJobErrors(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"ask"}, "jerryfane/gitmoot")
+	mb := Mailbox{Store: store}
+
+	// Unknown id.
+	if _, err := mb.CloseExternalJob(ctx, "nope", AgentResult{Decision: "approved"}, 0, ""); err == nil {
+		t.Fatalf("CloseExternalJob(unknown) returned nil error")
+	}
+
+	// Invalid decision.
+	if _, err := mb.CloseExternalJob(ctx, "nope", AgentResult{Decision: "bogus"}, 0, ""); err == nil || !strings.Contains(err.Error(), "unsupported decision") {
+		t.Fatalf("CloseExternalJob(bad decision) err = %v, want unsupported decision", err)
+	}
+
+	// Engine (non-session) job cannot be closed.
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "engine-job", Agent: "lead", Type: "ask", State: string(JobRunning)}, db.JobEvent{Kind: string(JobRunning), Message: "job started"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if _, err := mb.CloseExternalJob(ctx, "engine-job", AgentResult{Decision: "approved"}, 0, ""); err == nil || !strings.Contains(err.Error(), "not a session job") {
+		t.Fatalf("CloseExternalJob(engine job) err = %v, want not-a-session-job", err)
+	}
+
+	// Open then close, then double-close.
+	if _, err := mb.OpenExternalJob(ctx, JobRequest{ID: "sess", Agent: "lead", Action: "ask", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("OpenExternalJob returned error: %v", err)
+	}
+	if _, err := mb.CloseExternalJob(ctx, "sess", AgentResult{Decision: "approved"}, 0, ""); err != nil {
+		t.Fatalf("first CloseExternalJob returned error: %v", err)
+	}
+	if _, err := mb.CloseExternalJob(ctx, "sess", AgentResult{Decision: "approved"}, 0, ""); err == nil || !strings.Contains(err.Error(), "already been closed") {
+		t.Fatalf("double CloseExternalJob err = %v, want already-been-closed", err)
+	}
+}
+
+func hasEventKind(events []db.JobEvent, kind string) bool {
+	for _, ev := range events {
+		if ev.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -25,7 +25,11 @@ to the same `planner` template used by managed planner agents. If the planner
 template is not cached, read and apply the packaged
 `agent-templates/planner.md` instructions directly. Do not route a "here"
 request through a background `gitmoot agent ask` unless the user explicitly
-asks for background execution, PR-comment routing, or job tracking.
+asks for background execution, PR-comment routing, or job tracking. To make
+"here"-method work auditable without gitmoot spawning a runtime, record it as a
+session job: `gitmoot job open` clocks in a tracked running job, `gitmoot job
+close <id> --decision …` clocks out with the result, and `gitmoot job record`
+does both in one shot (see `references/CLI.md` → Session jobs).
 
 For template capture, phrases like "capture this session as a Gitmoot agent
 template", "turn this workflow into a Gitmoot template", or "draft a reusable

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -33,6 +33,13 @@ id. Apply the prompt, do the work, then — this is REQUIRED — clock out with
 `gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."`
 so the work shows in `job list`, the dashboard, and the event stream just like
 an engine-run job (no runtime is spawned; gitmoot is only the record-keeper).
+`--record` needs a **registered agent** with a repo scope — a bare template id is
+rejected. When "here" resolves to a **template that has no registered agent** (e.g.
+the packaged `planner` above, when no `planner` agent exists), import it with plain
+`gitmoot agent prompt <template>` (untracked); to still track it, register the agent
+first or log it explicitly with `gitmoot job record --agent <name> --repo owner/repo`.
+`--record` also defaults the job `--type` to `implement` — pass `--type ask` for
+advisory "here" work (planning, research) so it is not mislabeled.
 For a plain read-only peek — "just show me the prompt" — use
 `gitmoot agent prompt <agent>` WITHOUT `--record`, which opens no job. You can
 also clock in/out manually with `gitmoot job open` / `gitmoot job close`, or log

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -18,18 +18,26 @@ implementation plans, standard goal files, agent template workflows, custom
 prompt agents, template capture, job status, or branch lock inspection.
 
 For current-chat prompt import, "use <agent> here" or "use Gitmoot agent
-<agent> here" means run `gitmoot agent prompt <agent>` and apply the returned
-prompt content in this current chat. This is prompt import, not true
-system-prompt injection. The natural phrase "use the Gitmoot planner here" maps
-to the same `planner` template used by managed planner agents. If the planner
-template is not cached, read and apply the packaged
-`agent-templates/planner.md` instructions directly. Do not route a "here"
-request through a background `gitmoot agent ask` unless the user explicitly
-asks for background execution, PR-comment routing, or job tracking. To make
-"here"-method work auditable without gitmoot spawning a runtime, record it as a
-session job: `gitmoot job open` clocks in a tracked running job, `gitmoot job
-close <id> --decision …` clocks out with the result, and `gitmoot job record`
-does both in one shot (see `references/CLI.md` → Session jobs).
+<agent> here" means import the agent's prompt into this current chat and apply
+it. This is prompt import, not true system-prompt injection. The natural phrase
+"use the Gitmoot planner here" maps to the same `planner` template used by
+managed planner agents. If the planner template is not cached, read and apply
+the packaged `agent-templates/planner.md` instructions directly. Do not route a
+"here" request through a background `gitmoot agent ask` unless the user
+explicitly asks for background execution, PR-comment routing, or job tracking.
+
+By DEFAULT, the "here" flow tracks the work: run
+`gitmoot agent prompt <agent> --record [--repo owner/repo]`, which opens a
+session job on import and returns the prompt with a header line naming its job
+id. Apply the prompt, do the work, then — this is REQUIRED — clock out with
+`gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."`
+so the work shows in `job list`, the dashboard, and the event stream just like
+an engine-run job (no runtime is spawned; gitmoot is only the record-keeper).
+For a plain read-only peek — "just show me the prompt" — use
+`gitmoot agent prompt <agent>` WITHOUT `--record`, which opens no job. You can
+also clock in/out manually with `gitmoot job open` / `gitmoot job close`, or log
+already-finished work in one shot with `gitmoot job record` (see
+`references/CLI.md` → Session jobs).
 
 For template capture, phrases like "capture this session as a Gitmoot agent
 template", "turn this workflow into a Gitmoot template", or "draft a reusable

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -760,6 +760,41 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+### Session jobs (record "here"-method work)
+
+The "here" method — importing an agent's prompt into your calling session with
+`gitmoot agent prompt <agent>` — does the real work in your session but creates
+**no gitmoot job**, so the dashboard / `job list` / event stream never reflect it.
+Session jobs record that work as a first-class tracked job **without gitmoot
+spawning a runtime** — a clock-in / clock-out pair (plus a one-shot recorder):
+
+```sh
+# Clock in: create a RUNNING, externally-driven job (no dispatch); prints its id.
+gitmoot job open --agent <name> --repo owner/repo --type ask|review|implement \
+                 [--title "..."] [--task <id>] [--pr <n>] [--json]
+
+# Clock out: apply the result and move the job to its terminal state.
+gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed \
+                 [--summary "..."] [--pr <n>] [--branch <name>] [--json]
+
+# One-shot post-hoc: create an already-terminal job (open + close in one).
+gitmoot job record --agent <name> --repo owner/repo --type ask|review|implement \
+                 --decision <decision> [--title "..."] [--summary "..."] \
+                 [--task <id>] [--pr <n>] [--branch <name>] [--json]
+```
+
+An `externally_driven` job is created directly in `running` (it never queues, so
+the daemon never claims or Delivers it — no runtime subprocess, no runtime-session
+or checkout lock) and the stuck-`running` reaper **skips** it, so a session may
+hold it open for as long as the work takes. `close` reuses the exact result path an
+engine-run job uses: `--decision` maps to the same terminal state
+(`approved`/`changes_requested`/`implemented` → succeeded, `blocked` → blocked,
+`failed` → failed) and emits the same finished/failed/blocked event, so a recorded
+job is indistinguishable from an engine-run one in the dashboard and events. A job
+can be closed **once** (it must be a running session job); an orphaned open job
+stays `running` (reaper-exempt) until you `job close --decision failed` or `job
+cancel <id>` it. The agent and repo must exist.
+
 `gitmoot job kill <root-job-id>` is the operator kill switch for a runaway
 delegation tree: it terminates the tree identified by its **root** job id
 gracefully. In-flight jobs finish normally; the coordinator's next continuation

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -613,7 +613,25 @@ gitmoot agent prompt frontend-reviewer --json
 
 This prints the prompt content for the current chat to apply locally. It does
 not create a job, start a daemon, resume a runtime session, or post a PR
-comment.
+comment — a free read-only peek.
+
+To track the here-method work by default, add `--record`: it opens a session
+job on import (see "Session jobs" below) and returns the prompt with a header
+line naming the job id, so the imported work shows in `job list` / the dashboard
+once you clock out:
+
+```sh
+gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|review|implement] [--json]
+# prints:  [gitmoot session job <id> — when this work is complete, run:
+#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]
+# followed by the prompt body.
+```
+
+`--record` requires an **agent** (not a bare template id); the repo comes from
+`--repo`, else the agent's `repo_scope` (error if neither is set). `--type`
+defaults to `implement`. When the imported work is done, close the job with
+`gitmoot job close <id> --decision …`. `--json` includes the opened `job_id`.
+Without `--record`, behavior is unchanged (no job).
 
 Draft and validate a captured template before installing it:
 
@@ -793,7 +811,18 @@ engine-run job uses: `--decision` maps to the same terminal state
 job is indistinguishable from an engine-run one in the dashboard and events. A job
 can be closed **once** (it must be a running session job); an orphaned open job
 stays `running` (reaper-exempt) until you `job close --decision failed` or `job
-cancel <id>` it. The agent and repo must exist.
+cancel <id>` it. A session job is never engine-executed, so `job retry` **refuses**
+it (retrying would re-queue it for a real runtime with an empty payload) — recover
+one by opening a fresh session job instead. The agent and repo must exist.
+
+**Make in-chat / "here" work show on the dashboard.** The one-step default is
+`gitmoot agent prompt <agent> --record`: it opens the session job *as you import
+the prompt* and prints a header naming the job id (see the `agent prompt`
+section above). Apply the prompt, do the work, then clock out with
+`gitmoot job close <id> --decision …`. That is all it takes for otherwise-invisible
+current-chat ("here") work to appear in `job list`, the dashboard, and the event
+stream — no daemon, no runtime, no PR comment. Use plain `agent prompt` (no
+`--record`) only when you just want to read a prompt without tracking it.
 
 `gitmoot job kill <root-job-id>` is the operator kill switch for a runaway
 delegation tree: it terminates the tree identified by its **root** job id

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -732,6 +732,41 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+### Session jobs (record "here"-method work)
+
+The "here" method — importing an agent's prompt into your calling session with
+`gitmoot agent prompt <agent>` — does the real work in your session but creates
+**no gitmoot job**, so the dashboard / `job list` / event stream never reflect it.
+Session jobs record that work as a first-class tracked job **without gitmoot
+spawning a runtime** — a clock-in / clock-out pair (plus a one-shot recorder):
+
+```sh
+# Clock in: create a RUNNING, externally-driven job (no dispatch); prints its id.
+gitmoot job open --agent <name> --repo owner/repo --type ask|review|implement \
+                 [--title "..."] [--task <id>] [--pr <n>] [--json]
+
+# Clock out: apply the result and move the job to its terminal state.
+gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed \
+                 [--summary "..."] [--pr <n>] [--branch <name>] [--json]
+
+# One-shot post-hoc: create an already-terminal job (open + close in one).
+gitmoot job record --agent <name> --repo owner/repo --type ask|review|implement \
+                 --decision <decision> [--title "..."] [--summary "..."] \
+                 [--task <id>] [--pr <n>] [--branch <name>] [--json]
+```
+
+An `externally_driven` job is created directly in `running` (it never queues, so
+the daemon never claims or Delivers it — no runtime subprocess, no runtime-session
+or checkout lock) and the stuck-`running` reaper **skips** it, so a session may
+hold it open for as long as the work takes. `close` reuses the exact result path an
+engine-run job uses: `--decision` maps to the same terminal state
+(`approved`/`changes_requested`/`implemented` → succeeded, `blocked` → blocked,
+`failed` → failed) and emits the same finished/failed/blocked event, so a recorded
+job is indistinguishable from an engine-run one in the dashboard and events. A job
+can be closed **once** (it must be a running session job); an orphaned open job
+stays `running` (reaper-exempt) until you `job close --decision failed` or `job
+cancel <id>` it. The agent and repo must exist.
+
 For a `queued` or `blocked` job, `gitmoot job list` appends a `WHY:` column and
 `gitmoot job show` prints a `why_stuck:` (and, when a lease applies, a
 `next_retry_at:`) line explaining what the job is waiting on — e.g. `waiting on

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -582,7 +582,25 @@ gitmoot agent prompt frontend-reviewer --json
 
 This prints the prompt content for the current chat to apply locally. It does
 not create a job, start a daemon, resume a runtime session, or post a PR
-comment.
+comment — a free read-only peek.
+
+To track the here-method work by default, add `--record`: it opens a session
+job on import (see "Session jobs" below) and returns the prompt with a header
+line naming the job id, so the imported work shows in `job list` / the dashboard
+once you clock out:
+
+```sh
+gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|review|implement] [--json]
+# prints:  [gitmoot session job <id> — when this work is complete, run:
+#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]
+# followed by the prompt body.
+```
+
+`--record` requires an **agent** (not a bare template id); the repo comes from
+`--repo`, else the agent's `repo_scope` (error if neither is set). `--type`
+defaults to `implement`. When the imported work is done, close the job with
+`gitmoot job close <id> --decision …`. `--json` includes the opened `job_id`.
+Without `--record`, behavior is unchanged (no job).
 
 Draft and validate a captured template before installing it:
 
@@ -765,7 +783,18 @@ engine-run job uses: `--decision` maps to the same terminal state
 job is indistinguishable from an engine-run one in the dashboard and events. A job
 can be closed **once** (it must be a running session job); an orphaned open job
 stays `running` (reaper-exempt) until you `job close --decision failed` or `job
-cancel <id>` it. The agent and repo must exist.
+cancel <id>` it. A session job is never engine-executed, so `job retry` **refuses**
+it (retrying would re-queue it for a real runtime with an empty payload) — recover
+one by opening a fresh session job instead. The agent and repo must exist.
+
+**Make in-chat / "here" work show on the dashboard.** The one-step default is
+`gitmoot agent prompt <agent> --record`: it opens the session job *as you import
+the prompt* and prints a header naming the job id (see the `agent prompt`
+section above). Apply the prompt, do the work, then clock out with
+`gitmoot job close <id> --decision …`. That is all it takes for otherwise-invisible
+current-chat ("here") work to appear in `job list`, the dashboard, and the event
+stream — no daemon, no runtime, no PR comment. Use plain `agent prompt` (no
+`--record`) only when you just want to read a prompt without tracking it.
 
 For a `queued` or `blocked` job, `gitmoot job list` appends a `WHY:` column and
 `gitmoot job show` prints a `why_stuck:` (and, when a lease applies, a


### PR DESCRIPTION
## Summary

Records **"here"-method** (prompt-import) agent work as a first-class tracked gitmoot job **without the engine spawning a runtime** — a clock-in / clock-out pair plus a one-shot recorder. Today `gitmoot agent prompt <agent>` imports a prompt into the calling session, which does the real work but creates **no job**, so the dashboard / `job list` / event stream never reflect it. This decouples the *worker* (the calling session) from the *record-keeper* (gitmoot).

Closes #657.

## CLI

```
gitmoot job open  --agent <name> --repo owner/repo --type ask|review|implement [--title ...] [--task id] [--pr n] [--json]
gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed [--summary ...] [--pr n] [--branch name] [--json]
gitmoot job record --agent <name> --repo owner/repo --type ... --decision ... [--title ...] [--summary ...] [--task id] [--pr n] [--branch name] [--json]
```

## Design

- **New `externally_driven` column** on `jobs` (migration appended to the slice as its own element; `NOT NULL DEFAULT 0`, so SQLite backfills every existing row and the whole normal path is byte-identical). Added to the `Job` struct + the `GetJob` / `ListJobs`/`ListJobsByType` scan sites.
- **No dispatch.** `open` creates the job directly in `running`, flagged externally_driven, via a dedicated `CreateExternallyDrivenJobWithEvent` insert. It never queues, so the daemon's queued selector never claims it, `Deliver` is never called, and no runtime-session / checkout lock is ever acquired.
- **Reaper exemption (highest-risk point).** The stuck-`running` reaper query gains `AND externally_driven = 0`, so a session held open for minutes is never timed out / requeued. Verified the only other requeue path (expired runtime-session locks) also can't touch it — a session job holds no such lock.
- **Result application on close.** `close` reuses the exact result path an engine-run job uses: `--decision` maps through `stateForDecision` to the terminal state and emits the same `job.finished/failed/blocked` event via the wired `EventSink`. It deliberately omits the `advance_started` event so the daemon never tries to advance work the engine never owned. A job closes **once** (must be a running session job).
- **`record`** = `open` + `close` in one shot for post-hoc logging.

## Tests

`open` creates running/externally_driven with no queued row + no dispatch; the reaper skips a stale session job; `close` applies each decision to the right terminal state + events (and never writes `advance_started`); `record` is terminal in one shot; double-close / unknown-id / non-session / invalid-decision all error cleanly; migration defaults 0 on a pre-existing DB.

## Docs

Skill `references/CLI.md` (new Session jobs section) + `SKILL.md` "here" trigger + website `docs/reference/cli.md`.

## Gate

`go build ./...`, `go generate ./... && git diff --exit-code`, `go vet ./...`, and `go test -race -timeout 20m ./internal/db/ ./internal/cli/ ./internal/workflow/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)