### PR TITLE
feat(runtime): codex token usage (fresh sessions) + kimi 0.19.2 usage limitation

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -112,11 +112,12 @@ default_repair_timeout = ""
   with a `delegation_cost_exceeded` event and routed to the graceful finalize
   continuation (synthesize what completed, then stop). Token capture is
   **best-effort per runtime**: Claude reports usage via its `--output-format json`
-  envelope, Kimi reports it when its stream emits a `usage` object, and Codex runs
-  delivery without `--json` so it contributes `0` (the budget under-counts Codex
-  rather than failing). Treat it as a coarse runaway-cost backstop, not a precise
-  spend limit; the budget is in raw tokens. Leaving it at `0` is byte-identical to
-  before the knob existed.
+  envelope, Kimi reports it when its stream emits a `usage` object, and Codex reads
+  usage from its `codex exec --json` JSONL stream for fresh sessions only
+  (resumed sessions contribute `0` — codex reports session-cumulative usage
+  there; older CLIs that predate the flag also fall back to `0`). Treat it as a coarse runaway-cost backstop, not a
+  precise spend limit; the budget is in raw tokens. Leaving it at `0` is
+  byte-identical to before the knob existed.
 - `max_delegation_cost_usd` (default `0` = unlimited/off) is the **dollar-cost**
   analogue of the token budget (#380): it bounds the same tree by its *measured
   spend* rather than raw token count. Cost is derived from the same per-job token

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -62,10 +62,13 @@ type Result struct {
 	// InputTokens and OutputTokens are best-effort runtime token usage captured
 	// from the CLI's structured output where it exposes one (#338 Part B). They
 	// default to 0. Per-runtime status today: claude reports usage via its
-	// --output-format json envelope; kimi reports usage if its stream-json emits a
-	// usage/result event; codex Deliver runs without --json (plain text) so it
-	// contributes 0. A 0 here means "not captured", and the per-root delegation
-	// token budget simply under-counts that job rather than failing.
+	// --output-format json envelope; kimi-code 0.19.2 emits no usage event so it
+	// contributes 0; codex Deliver reads the last turn.completed usage from its
+	// `exec --json` JSONL output (#658) for FRESH sessions only — resumed
+	// sessions contribute 0 because codex reports session-cumulative usage there
+	// (see codexDeliverResult) — falling back to 0 on an older CLI that predates
+	// --json. A 0 here means "not captured", and the per-root delegation token
+	// budget simply under-counts that job rather than failing.
 	InputTokens  int
 	OutputTokens int
 	// RefreshedRuntimeRef is non-empty only when the adapter self-healed a dead
@@ -325,24 +328,40 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 	if err := a.Validate(ctx, agent); err != nil {
 		return Result{}, err
 	}
-	args := append([]string{"exec"}, codexSandboxArgs(agent)...)
 	model := effectiveModel(agent, job)
 	// A fresh ref (per-job --runtime override, #531) starts a brand-new exec
 	// session — never `resume` — so an overridden job cannot read or pollute any
-	// stored session's state.
+	// stored session's state. Every other ref resumes an existing session, which
+	// we first verify still exists.
+	if !IsFreshRef(agent.RuntimeRef) {
+		if err := a.verifySession(ctx, agent); err != nil {
+			return Result{}, err
+		}
+	}
+	result, err := a.runCodex(ctx, agent, job.Prompt, model)
+	if err != nil {
+		return Result{Raw: result.Stdout + result.Stderr}, codexCommandError(result, err)
+	}
+	return codexDeliverResult(result.Stdout, IsFreshRef(agent.RuntimeRef)), nil
+}
+
+// codexDeliverArgs builds the `codex exec` argument vector for a Deliver call.
+// jsonOutput adds --json so codex streams JSONL events (thread/turn/item) on
+// stdout, which is what lets a delivery capture token usage (#658). --json is an
+// `exec` option that codex accepts before the `resume` subcommand, which is where
+// we place it. jsonOutput=false is the older-CLI fallback (see runCodex): it
+// reproduces the pre-#658 plain-text command exactly. A fresh ref (#531) always
+// starts a brand-new exec session and never resumes.
+func codexDeliverArgs(agent Agent, prompt, model string, jsonOutput bool) []string {
+	args := append([]string{"exec"}, codexSandboxArgs(agent)...)
+	if jsonOutput {
+		args = append(args, "--json")
+	}
 	if IsFreshRef(agent.RuntimeRef) {
 		if model != "" {
 			args = append(args, "--model", model)
 		}
-		args = append(args, "--", job.Prompt)
-		result, err := a.runner().Run(ctx, a.Dir, "codex", args...)
-		if err != nil {
-			return Result{Raw: result.Stdout + result.Stderr}, codexCommandError(result, err)
-		}
-		return Result{Raw: result.Stdout}, nil
-	}
-	if err := a.verifySession(ctx, agent); err != nil {
-		return Result{}, err
+		return append(args, "--", prompt)
 	}
 	args = append(args, "resume")
 	if model != "" {
@@ -353,12 +372,50 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 	} else {
 		args = append(args, agent.RuntimeRef)
 	}
-	args = append(args, "--", job.Prompt)
-	result, err := a.runner().Run(ctx, a.Dir, "codex", args...)
-	if err != nil {
-		return Result{Raw: result.Stdout + result.Stderr}, codexCommandError(result, err)
+	return append(args, "--", prompt)
+}
+
+// runCodex performs a single codex Deliver run with --json (for token capture),
+// re-running once WITHOUT --json when an older codex CLI rejects the flag
+// (mirrors runClaude's --output-format fallback). The plain-text re-run keeps the
+// pre-#658 semantics; codexDeliverResult then fails open on the non-JSONL stdout
+// and contributes 0 usage. Only the JSON re-run is retried — a genuine delivery
+// failure surfaces unchanged.
+func (a CodexAdapter) runCodex(ctx context.Context, agent Agent, prompt, model string) (subprocess.Result, error) {
+	result, err := a.runner().Run(ctx, a.Dir, "codex", codexDeliverArgs(agent, prompt, model, true)...)
+	if err != nil && isCodexJSONUnsupported(result) {
+		result, err = a.runner().Run(ctx, a.Dir, "codex", codexDeliverArgs(agent, prompt, model, false)...)
 	}
-	return Result{Raw: result.Stdout}, nil
+	return result, err
+}
+
+// codexDeliverResult turns codex `exec --json` stdout into a Deliver Result: the
+// joined agent_message text becomes Raw — the exact text the engine scans for the
+// gitmoot_result blob, just as the plain-text stdout was before #658 — plus the
+// last turn.completed usage as best-effort token counts. It fails open: stdout
+// carrying no agent_message event (older CLI, the plain-text --json fallback, or
+// an unexpected shape) is returned verbatim as Raw with 0 usage, so a delivery is
+// never lost because usage parsing changed.
+//
+// Usage is reported ONLY for fresh sessions (per-job --runtime overrides and
+// ephemeral delegation workers — the #338 budget's primary target). On RESUMED
+// sessions codex's turn.completed usage is SESSION-CUMULATIVE, not per-turn:
+// probed live on codex-cli 0.142.4, three one-word turns on one thread reported
+// input 16504 -> 85681 -> 103779 and output 20 -> 40 -> 45 (monotonically
+// accumulating), and a single resumed ask on a long-lived agent reported 22.4M
+// input tokens — orders of magnitude beyond any single turn. Attributing the
+// whole session history to each job would corrupt per-root budgets and usage
+// charts, so resumed deliveries contribute 0 until per-session delta tracking
+// exists (follow-up issue).
+func codexDeliverResult(stdout string, freshSession bool) Result {
+	raw, inputTokens, outputTokens, ok := parseCodexJSONResult(stdout)
+	if !ok {
+		return Result{Raw: stdout, Summary: strings.TrimSpace(stdout)}
+	}
+	if !freshSession {
+		inputTokens, outputTokens = 0, 0
+	}
+	return Result{Raw: raw, Summary: strings.TrimSpace(raw), InputTokens: inputTokens, OutputTokens: outputTokens}
 }
 
 func (a CodexAdapter) Health(ctx context.Context, agent Agent) error {
@@ -914,6 +971,79 @@ func parseCodexErrorMessage(output string) string {
 		}
 	}
 	return message
+}
+
+// codexUsage mirrors the usage object on codex's turn.completed --json event.
+// input_tokens already includes cached_input_tokens, so we read only the billed
+// input/output totals and deliberately ignore cached_input_tokens and
+// reasoning_output_tokens — the per-root delegation token budget sums those two.
+type codexUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// parseCodexJSONResult extracts the deliverable text and best-effort token usage
+// from codex `exec --json` JSONL output. It joins the .text of every
+// item.completed agent_message event with a blank line (the agent's full reply,
+// which carries the gitmoot_result blob the engine scans for) and reads the LAST
+// turn.completed usage (the final turn is authoritative if codex emits several).
+//
+// ok reports whether at least one agent_message was seen; ok=false means the
+// stream is not the expected JSONL shape (older CLI, the plain-text --json
+// fallback, or an error-only turn), so the caller fails open on the raw stdout
+// with 0 usage. Usage is best-effort: agent_messages with no turn.completed leave
+// the counts at 0 rather than erroring. It mirrors parseCodexErrorMessage's
+// narrow, unmarshal-per-line style so unrelated schema additions stay harmless.
+func parseCodexJSONResult(output string) (raw string, inputTokens int, outputTokens int, ok bool) {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var messages []string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var event struct {
+			Type string `json:"type"`
+			Item struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"item"`
+			Usage codexUsage `json:"usage"`
+		}
+		if json.Unmarshal([]byte(line), &event) != nil {
+			continue
+		}
+		switch event.Type {
+		case "item.completed":
+			if event.Item.Type == "agent_message" {
+				messages = append(messages, event.Item.Text)
+			}
+		case "turn.completed":
+			inputTokens = event.Usage.InputTokens
+			outputTokens = event.Usage.OutputTokens
+		}
+	}
+	if len(messages) == 0 {
+		return "", 0, 0, false
+	}
+	return strings.Join(messages, "\n\n"), inputTokens, outputTokens, true
+}
+
+// isCodexJSONUnsupported reports whether a failed codex run rejected --json, i.e.
+// an older CLI that predates JSONL event output. codex (clap) prints e.g.
+// "error: unexpected argument '--json' found" to stderr with a nonzero exit;
+// runCodex re-runs plain-text on this signal (mirrors isClaudeJSONUnsupported).
+func isCodexJSONUnsupported(result subprocess.Result) bool {
+	text := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	if !strings.Contains(text, "--json") {
+		return false
+	}
+	return strings.Contains(text, "unexpected argument") ||
+		strings.Contains(text, "unknown") ||
+		strings.Contains(text, "unrecognized") ||
+		strings.Contains(text, "unsupported") ||
+		strings.Contains(text, "invalid")
 }
 
 func claudeCommandError(result subprocess.Result, err error) error {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -127,7 +127,7 @@ func TestCodexDeliverCommand(t *testing.T) {
 	if result.Raw != "done" {
 		t.Fatalf("raw = %q", result.Raw)
 	}
-	runner.want(t, 0, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
 }
 
 func TestCodexDeliverCommandUsesJobModel(t *testing.T) {
@@ -138,7 +138,7 @@ func TestCodexDeliverCommandUsesJobModel(t *testing.T) {
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review this", Model: "opus"}); err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
-	runner.want(t, 0, "codex", "exec", "resume", "--model", "opus", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--model", "opus", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
 }
 
 func TestCodexDeliverCommandFallsBackToAgentModel(t *testing.T) {
@@ -149,7 +149,7 @@ func TestCodexDeliverCommandFallsBackToAgentModel(t *testing.T) {
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review this"}); err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
-	runner.want(t, 0, "codex", "exec", "resume", "--model", "sonnet", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--model", "sonnet", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
 }
 
 func TestCodexStartCommandUsesAgentModel(t *testing.T) {
@@ -221,7 +221,7 @@ func TestCodexDeliverLastSessionCommand(t *testing.T) {
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "continue"}); err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
-	runner.want(t, 0, "codex", "exec", "resume", "--last", "--", "continue")
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--last", "--", "continue")
 }
 
 func TestCodexDeliverCommandAppliesAutonomyPolicy(t *testing.T) {
@@ -242,7 +242,7 @@ func TestCodexDeliverCommandAppliesAutonomyPolicy(t *testing.T) {
 			if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
 				t.Fatalf("Deliver returned error: %v", err)
 			}
-			runner.want(t, 0, "codex", "exec", "--sandbox", tt.sandbox, "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review")
+			runner.want(t, 0, "codex", "exec", "--sandbox", tt.sandbox, "--json", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review")
 		})
 	}
 }
@@ -255,7 +255,7 @@ func TestCodexDeliverVerifiesNamedSession(t *testing.T) {
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
-	runner.want(t, 0, "codex", "exec", "resume", "review-thread", "--", "review")
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "review-thread", "--", "review")
 }
 
 func TestCodexDeliverRejectsMissingNamedSession(t *testing.T) {
@@ -279,7 +279,7 @@ func TestCodexDeliverAllowsMissingUUIDSessionToReachCodex(t *testing.T) {
 	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
-	runner.want(t, 0, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review")
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review")
 }
 
 func TestCodexHealthUsesRegisteredSession(t *testing.T) {
@@ -290,7 +290,7 @@ func TestCodexHealthUsesRegisteredSession(t *testing.T) {
 	if err := adapter.Health(context.Background(), agent); err != nil {
 		t.Fatalf("Health returned error: %v", err)
 	}
-	runner.want(t, 0, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", healthPrompt)
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", healthPrompt)
 }
 
 func TestCodexHealthRejectsBrokenSession(t *testing.T) {
@@ -301,7 +301,7 @@ func TestCodexHealthRejectsBrokenSession(t *testing.T) {
 	if err := adapter.Health(context.Background(), agent); err == nil {
 		t.Fatal("Health accepted broken codex session")
 	}
-	runner.want(t, 0, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", healthPrompt)
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", healthPrompt)
 }
 
 func TestClaudeDeliverCommand(t *testing.T) {

--- a/internal/runtime/fresh_ref_test.go
+++ b/internal/runtime/fresh_ref_test.go
@@ -94,7 +94,7 @@ func TestCodexDeliverFreshRef(t *testing.T) {
 	if result.Raw != "fresh output" {
 		t.Fatalf("Raw = %q", result.Raw)
 	}
-	runner.want(t, 0, "codex", "exec", "--model", "gpt-5.5-codex", "--", "do the thing")
+	runner.want(t, 0, "codex", "exec", "--json", "--model", "gpt-5.5-codex", "--", "do the thing")
 	for _, arg := range runner.calls[0] {
 		if arg == "resume" {
 			t.Fatalf("fresh-ref delivery must not resume any session: %v", runner.calls[0])

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -253,6 +253,14 @@ type kimiUsage struct {
 // that carried a usage object (if any). Usage capture is best-effort: when no
 // event reports usage the returned kimiUsage is zero-valued and the job
 // contributes 0 to the per-root token budget.
+//
+// UPSTREAM LIMITATION (#659): kimi-code 0.19.2 — the CLI Gitmoot targets today —
+// emits NO usage event anywhere in its stream. A prompt-mode run yields only an
+// `assistant` event and a `meta` session.resume_hint event, so every kimi job
+// reports 0/0 by upstream limitation, not a parser bug (confirmed against
+// `kimi --help`: 0.19.2 has no --verbose/--stats/--include-usage flag that would
+// enable usage in the stream). The usage extraction below is retained for
+// older/newer Kimi CLIs that DO emit a usage/result event.
 func parseKimiStreamJSON(output string) (string, string, kimiUsage, error) {
 	scanner := bufio.NewScanner(strings.NewReader(output))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)

--- a/internal/runtime/usage_test.go
+++ b/internal/runtime/usage_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/subprocess"
@@ -108,21 +109,215 @@ func TestKimiDeliverNoUsageStaysZero(t *testing.T) {
 	}
 }
 
-// TestCodexDeliverDoesNotCaptureUsage documents the honest per-runtime status:
-// codex Deliver runs `codex exec resume … -- <prompt>` WITHOUT --json (plain
-// text), so it exposes no machine-readable usage and contributes 0 to the per-root
-// token budget. This is intentional (see Result doc + RESULT_CONTRACT.md); the
-// budget under-counts codex rather than failing.
-func TestCodexDeliverDoesNotCaptureUsage(t *testing.T) {
-	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "codex finished the task. plenty of tokens used but none reported."}}}
+// TestParseKimiStreamJSONVersion0192NoUsage feeds a real kimi-code 0.19.2
+// --output-format stream-json transcript (captured live for #659) through the
+// parser. 0.19.2 emits only an `assistant` event and a `meta` session.resume_hint
+// event — NO usage event anywhere — so the parser must extract the content, honor
+// the resume hint's session id, return zero usage, and report no error. This pins
+// the honest 0/0-by-upstream-limitation behavior; TestKimiDeliverCapturesUsage
+// above keeps the older/newer usage-shape coverage for CLIs that do emit usage.
+func TestParseKimiStreamJSONVersion0192NoUsage(t *testing.T) {
+	stream := `{"role":"assistant","content":"hi"}` + "\n" +
+		`{"role":"meta","type":"session.resume_hint","session_id":"session_3f466a4e-41d2-44ec-a0e5-d162efe3de58","command":"kimi -r session_3f466a4e-41d2-44ec-a0e5-d162efe3de58","content":"To resume this session: kimi -r session_3f466a4e-41d2-44ec-a0e5-d162efe3de58"}` + "\n"
+
+	content, sessionID, usage, err := parseKimiStreamJSON(stream)
+	if err != nil {
+		t.Fatalf("parseKimiStreamJSON returned error: %v", err)
+	}
+	if content != "hi" {
+		t.Fatalf("content = %q, want %q", content, "hi")
+	}
+	if sessionID != "session_3f466a4e-41d2-44ec-a0e5-d162efe3de58" {
+		t.Fatalf("sessionID = %q, want session_3f466a4e-41d2-44ec-a0e5-d162efe3de58", sessionID)
+	}
+	if usage.InputTokens != 0 || usage.OutputTokens != 0 {
+		t.Fatalf("usage = (%d, %d), want (0, 0) — 0.19.2 emits no usage event", usage.InputTokens, usage.OutputTokens)
+	}
+}
+
+// codexUsageTranscript is a real `codex exec --json` transcript captured live
+// (2026-07-05). We read agent_message .text and the turn.completed usage; the
+// thread.started/turn.started lines and cached/reasoning token fields are ignored.
+const codexUsageTranscript = `{"type":"thread.started","thread_id":"019f3041-cfed-7e82-8766-b5ca75cf92da"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}
+{"type":"turn.completed","usage":{"input_tokens":16504,"cached_input_tokens":9600,"output_tokens":20,"reasoning_output_tokens":13}}`
+
+// TestCodexDeliverCapturesUsage pins the #658 token capture for the codex runtime:
+// Deliver now runs `codex exec --json …` and surfaces the last turn.completed
+// usage — but ONLY for fresh sessions (ephemeral delegation workers / per-job
+// overrides, the #338 budget's target). input_tokens already includes cached
+// input, so it is taken verbatim and the cached/reasoning fields are ignored.
+// The agent_message .text becomes both Raw (what the engine scans for the
+// gitmoot_result blob) and the Summary.
+func TestCodexDeliverCapturesUsage(t *testing.T) {
+	ref, err := NewFreshRef()
+	if err != nil {
+		t.Fatalf("NewFreshRef returned error: %v", err)
+	}
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: codexUsageTranscript}}}
 	adapter := CodexAdapter{Runner: runner}
-	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "last", RepoScope: "jerryfane/gitmoot"}
+	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: ref, RepoScope: "jerryfane/gitmoot"}
 
 	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"})
 	if err != nil {
 		t.Fatalf("Deliver returned error: %v", err)
 	}
+	if result.Raw != "hi" || result.Summary != "hi" {
+		t.Fatalf("raw/summary = (%q, %q), want (\"hi\", \"hi\")", result.Raw, result.Summary)
+	}
+	if result.InputTokens != 16504 || result.OutputTokens != 20 {
+		t.Fatalf("codex usage = (%d, %d), want (16504, 20)", result.InputTokens, result.OutputTokens)
+	}
+	runner.want(t, 0, "codex", "exec", "--json", "--", "implement")
+}
+
+// TestCodexDeliverResumeReportsZeroUsage pins the resumed-session exclusion:
+// codex's turn.completed usage on a resumed thread is SESSION-CUMULATIVE, not
+// per-turn (probed live on codex-cli 0.142.4: three one-word turns reported
+// input 16504 -> 85681 -> 103779, and one resumed ask on a long-lived agent
+// reported 22.4M input tokens). Attributing the whole session history to each
+// job would corrupt per-root budgets, so a resumed delivery keeps the parsed
+// text but contributes 0 usage until per-session delta tracking exists.
+func TestCodexDeliverResumeReportsZeroUsage(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: codexUsageTranscript}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Raw != "hi" || result.Summary != "hi" {
+		t.Fatalf("raw/summary = (%q, %q), want (\"hi\", \"hi\")", result.Raw, result.Summary)
+	}
 	if result.InputTokens != 0 || result.OutputTokens != 0 {
-		t.Fatalf("codex usage = (%d, %d), want (0, 0) — codex Deliver reports no usage", result.InputTokens, result.OutputTokens)
+		t.Fatalf("resumed codex usage = (%d, %d), want (0, 0) — session-cumulative upstream", result.InputTokens, result.OutputTokens)
+	}
+	// --json is an `exec` option and sits before the resume subcommand.
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--last", "--", "implement")
+}
+
+// TestCodexDeliverJoinsAgentMessages pins that a turn emitting several
+// agent_message items has their .text joined with a blank line into Raw/Summary,
+// so a multi-message reply reaches the engine intact. Non-agent_message items
+// (e.g. reasoning) are dropped.
+func TestCodexDeliverJoinsAgentMessages(t *testing.T) {
+	stdout := `{"type":"thread.started","thread_id":"t1"}` + "\n" +
+		`{"type":"item.completed","item":{"type":"agent_message","text":"first"}}` + "\n" +
+		`{"type":"item.completed","item":{"type":"reasoning","text":"ignored"}}` + "\n" +
+		`{"type":"item.completed","item":{"type":"agent_message","text":"second"}}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":4}}` + "\n"
+	ref, err := NewFreshRef()
+	if err != nil {
+		t.Fatalf("NewFreshRef returned error: %v", err)
+	}
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: ref, RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Raw != "first\n\nsecond" {
+		t.Fatalf("raw = %q, want %q", result.Raw, "first\n\nsecond")
+	}
+	if result.InputTokens != 10 || result.OutputTokens != 4 {
+		t.Fatalf("codex usage = (%d, %d), want (10, 4)", result.InputTokens, result.OutputTokens)
+	}
+}
+
+// TestCodexDeliverNoUsageEventStaysZero pins the best-effort contract: a stream
+// with an agent_message but no turn.completed still delivers the text (Raw) while
+// contributing 0 to the budget rather than erroring.
+func TestCodexDeliverNoUsageEventStaysZero(t *testing.T) {
+	stdout := `{"type":"thread.started","thread_id":"t1"}` + "\n" +
+		`{"type":"item.completed","item":{"type":"agent_message","text":"answer"}}` + "\n"
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Raw != "answer" {
+		t.Fatalf("raw = %q, want %q", result.Raw, "answer")
+	}
+	if result.InputTokens != 0 || result.OutputTokens != 0 {
+		t.Fatalf("codex usage = (%d, %d), want (0, 0)", result.InputTokens, result.OutputTokens)
+	}
+}
+
+// TestCodexDeliverFailsOpenOnNonJSONL pins the fail-open path: stdout that is not
+// codex --json JSONL (no agent_message event — e.g. an unexpected shape or the
+// plain-text fallback) is returned verbatim as Raw with 0 usage, so a delivery is
+// never lost because usage parsing changed.
+func TestCodexDeliverFailsOpenOnNonJSONL(t *testing.T) {
+	const plain = "codex finished the task. plenty of tokens used but none reported."
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: plain}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Raw != plain {
+		t.Fatalf("raw = %q, want %q", result.Raw, plain)
+	}
+	if result.InputTokens != 0 || result.OutputTokens != 0 {
+		t.Fatalf("codex usage = (%d, %d), want (0, 0)", result.InputTokens, result.OutputTokens)
+	}
+}
+
+// TestCodexDeliverReRunsWithoutJSONWhenRejected pins the older-CLI fallback: when
+// the first --json run fails with clap's "unexpected argument '--json'", Deliver
+// re-runs the exact plain-text command once and uses its stdout (fail-open, 0
+// usage). Mirrors the claude --output-format fallback.
+func TestCodexDeliverReRunsWithoutJSONWhenRejected(t *testing.T) {
+	const legacy = "legacy plain output with no json"
+	runner := &fakeRunner{
+		results: []subprocess.Result{
+			{Stderr: "error: unexpected argument '--json' found"},
+			{Stdout: legacy},
+		},
+		errs: []error{errors.New("exit status 2"), nil},
+	}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "jerryfane/gitmoot"}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Raw != legacy {
+		t.Fatalf("raw = %q, want %q", result.Raw, legacy)
+	}
+	if result.InputTokens != 0 || result.OutputTokens != 0 {
+		t.Fatalf("codex usage = (%d, %d), want (0, 0)", result.InputTokens, result.OutputTokens)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("got %d codex calls, want 2 (json then fallback): %v", len(runner.calls), runner.calls)
+	}
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--last", "--", "implement")
+	runner.want(t, 1, "codex", "exec", "resume", "--last", "--", "implement")
+}
+
+// TestParseCodexJSONResult unit-tests the parser directly, covering the real
+// transcript, the no-agent_message fail-open signal, and non-JSONL noise.
+func TestParseCodexJSONResult(t *testing.T) {
+	raw, in, out, ok := parseCodexJSONResult(codexUsageTranscript)
+	if !ok || raw != "hi" || in != 16504 || out != 20 {
+		t.Fatalf("parseCodexJSONResult(transcript) = (%q, %d, %d, %v), want (\"hi\", 16504, 20, true)", raw, in, out, ok)
+	}
+	// No agent_message event -> ok=false so the caller fails open on raw stdout.
+	if raw, in, out, ok := parseCodexJSONResult(`{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":2}}`); ok || raw != "" || in != 0 || out != 0 {
+		t.Fatalf("parseCodexJSONResult(no message) = (%q, %d, %d, %v), want (\"\", 0, 0, false)", raw, in, out, ok)
+	}
+	// Non-JSONL noise is skipped line-by-line, not fatal.
+	if _, _, _, ok := parseCodexJSONResult("not json at all"); ok {
+		t.Fatal("parseCodexJSONResult(non-json) ok = true, want false")
 	}
 }

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -656,9 +656,9 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 	// Record best-effort runtime token usage so the per-root delegation token
 	// budget (#338 Part B) can sum a tree's cost. Only persist when the runtime
 	// actually reported usage (a positive count) so runtimes that report nothing
-	// (e.g. codex Deliver, which runs without --json) leave the columns at their 0
-	// default rather than taking a no-op write. Usage accounting must never fail a
-	// delivery, so a write error is swallowed.
+	// (e.g. the shell runtime) leave the columns at their 0 default rather than
+	// taking a no-op write. Usage accounting must never fail a delivery, so a
+	// write error is swallowed.
 	if err == nil && (result.InputTokens > 0 || result.OutputTokens > 0) {
 		_ = m.Store.UpdateJobUsage(ctx, job.ID, result.InputTokens, result.OutputTokens)
 	}

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -420,13 +420,14 @@ a job whose runtime reports no usage contributes `0` to the sum, so the budget
 | --- | --- | --- |
 | **Claude Code** | Yes | Parsed from the `usage.{input,output}_tokens` of the `--output-format json` envelope on delivery. |
 | **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
-| **Codex** | No (contributes `0`) | `codex exec resume … -- <prompt>` runs without `--json` (plain text), so delivery exposes no machine-readable usage. |
+| **Codex** | Fresh sessions only | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658) for fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides). Resumed sessions contribute `0`: codex reports session-cumulative usage there, which would attribute the whole session history to each job. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
 
-Because of this, a tree made up mostly of Codex jobs will accumulate little or no
-counted usage — set the budget with that in mind, and prefer it as a coarse
-runaway-cost backstop rather than a precise spend limit. The same capture also
-feeds the `$`-denominated `[orchestrate].max_delegation_cost_usd` budget — see
-the dollar-cost bullet in [Termination bounds](#termination-bounds) above.
+Capture is best-effort, so treat the budget as a coarse runaway-cost backstop
+rather than a precise spend limit — a runtime that reports nothing (or an older
+codex CLI that predates `--json`) contributes `0` and is silently under-counted.
+The same capture also feeds the `$`-denominated
+`[orchestrate].max_delegation_cost_usd` budget — see the dollar-cost bullet in
+[Termination bounds](#termination-bounds) above.
 
 ### Top-level fields
 

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -147,9 +147,10 @@ cannot recurse or fan out forever:
   every job in the tree). A coordinator that tries to fan out after the tree has
   already used at least the budget is refused with a `delegation_cost_exceeded`
   event. Token capture is **best-effort per runtime** (Claude reports usage; Kimi
-  reports it if its stream emits it; Codex `Deliver` runs without `--json` and so
-  contributes `0`), so the budget can under-count but never over-counts. Leaving
-  the knob at `0` skips the check entirely.
+  reports it if its stream emits it; Codex reads usage from its `codex exec --json`
+  JSONL stream for fresh sessions only — resumed sessions contribute `0` because
+  codex reports session-cumulative usage there — falling back to `0` on an older CLI), so the budget can under-count
+  but never over-counts. Leaving the knob at `0` skips the check entirely.
 - Per-root **dollar-cost** budget `[orchestrate].max_delegation_cost_usd`,
   **off by default** (`0` = unlimited): the cost analogue of the token budget
   (#380). It bounds the same tree by *measured spend* — the same per-job token

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -539,13 +539,13 @@ than failing:
 | --- | --- | --- |
 | **Claude Code** | Yes | Parsed from `usage.{input,output}_tokens` of the `--output-format json` envelope. |
 | **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
-| **Codex** | No (contributes `0`) | Delivery runs `codex exec resume … -- <prompt>` without `--json` (plain text), so no machine-readable usage is exposed. |
+| **Codex** | Fresh sessions only | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658) for fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides). Resumed sessions contribute `0`: codex reports session-cumulative usage there, which would attribute the whole session history to each job. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
 
-Because of this, a tree made up mostly of Codex jobs accumulates little or no
-counted usage — set the budget accordingly and treat it as a coarse runaway-cost
-backstop, not a precise spend limit. The same capture also feeds the
-`$`-denominated `[orchestrate].max_delegation_cost_usd` budget — see the
-dollar-cost bullet under [Termination bounds](#termination-bounds).
+Capture is best-effort, so treat the budget as a coarse runaway-cost backstop,
+not a precise spend limit — a runtime that reports nothing (or an older codex CLI
+that predates `--json`) contributes `0` and is silently under-counted. The same
+capture also feeds the `$`-denominated `[orchestrate].max_delegation_cost_usd`
+budget — see the dollar-cost bullet under [Termination bounds](#termination-bounds).
 
 For the in-repo source of truth, see
 [`skills/gitmoot/references/RESULT_CONTRACT.md`](https://github.com/jerryfane/gitmoot/blob/main/skills/gitmoot/references/RESULT_CONTRACT.md)

--- a/website/docs/workflows/cockpit-orchestrate-workflow.md
+++ b/website/docs/workflows/cockpit-orchestrate-workflow.md
@@ -110,10 +110,12 @@ default_repair_timeout = ""
   `delegation_cost_exceeded` event and routed to the graceful finalize
   continuation. Token capture is **best-effort per runtime** — Claude reports
   usage via `--output-format json`, Kimi reports it when its stream emits a
-  `usage` object, and Codex runs delivery without `--json` so it contributes `0`
-  (the budget under-counts Codex rather than failing). Treat it as a coarse
-  runaway-cost backstop, not a precise spend limit; the budget is in raw tokens.
-  Leaving it at `0` is byte-identical to before the knob existed.
+  `usage` object, and Codex reads usage from its `codex exec --json` JSONL stream
+  for fresh sessions only (resumed sessions contribute `0` — codex reports
+  session-cumulative usage there; older CLIs that predate the flag also fall
+  back to `0`). Treat it as a
+  coarse runaway-cost backstop, not a precise spend limit; the budget is in raw
+  tokens. Leaving it at `0` is byte-identical to before the knob existed.
 - `max_delegation_cost_usd` (default `0` = unlimited/off) is the **dollar-cost**
   analogue of the token budget (#380): it bounds the same tree by its *measured
   spend* rather than raw token count. Cost is derived from the same per-job token

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3220,11 +3220,12 @@ default_repair_timeout = ""
   with a `delegation_cost_exceeded` event and routed to the graceful finalize
   continuation (synthesize what completed, then stop). Token capture is
   **best-effort per runtime**: Claude reports usage via its `--output-format json`
-  envelope, Kimi reports it when its stream emits a `usage` object, and Codex runs
-  delivery without `--json` so it contributes `0` (the budget under-counts Codex
-  rather than failing). Treat it as a coarse runaway-cost backstop, not a precise
-  spend limit; the budget is in raw tokens. Leaving it at `0` is byte-identical to
-  before the knob existed.
+  envelope, Kimi reports it when its stream emits a `usage` object, and Codex reads
+  usage from its `codex exec --json` JSONL stream for fresh sessions only
+  (resumed sessions contribute `0` — codex reports session-cumulative usage
+  there; older CLIs that predate the flag also fall back to `0`). Treat it as a coarse runaway-cost backstop, not a
+  precise spend limit; the budget is in raw tokens. Leaving it at `0` is
+  byte-identical to before the knob existed.
 - `max_delegation_cost_usd` (default `0` = unlimited/off) is the **dollar-cost**
   analogue of the token budget (#380): it bounds the same tree by its *measured
   spend* rather than raw token count. Cost is derived from the same per-job token
@@ -10076,9 +10077,10 @@ cannot recurse or fan out forever:
   every job in the tree). A coordinator that tries to fan out after the tree has
   already used at least the budget is refused with a `delegation_cost_exceeded`
   event. Token capture is **best-effort per runtime** (Claude reports usage; Kimi
-  reports it if its stream emits it; Codex `Deliver` runs without `--json` and so
-  contributes `0`), so the budget can under-count but never over-counts. Leaving
-  the knob at `0` skips the check entirely.
+  reports it if its stream emits it; Codex reads usage from its `codex exec --json`
+  JSONL stream for fresh sessions only — resumed sessions contribute `0` because
+  codex reports session-cumulative usage there — falling back to `0` on an older CLI), so the budget can under-count
+  but never over-counts. Leaving the knob at `0` skips the check entirely.
 - Per-root **dollar-cost** budget `[orchestrate].max_delegation_cost_usd`,
   **off by default** (`0` = unlimited): the cost analogue of the token budget
   (#380). It bounds the same tree by *measured spend* — the same per-job token
@@ -10594,13 +10596,14 @@ a job whose runtime reports no usage contributes `0` to the sum, so the budget
 | --- | --- | --- |
 | **Claude Code** | Yes | Parsed from the `usage.{input,output}_tokens` of the `--output-format json` envelope on delivery. |
 | **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
-| **Codex** | No (contributes `0`) | `codex exec resume … -- <prompt>` runs without `--json` (plain text), so delivery exposes no machine-readable usage. |
+| **Codex** | Fresh sessions only | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658) for fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides). Resumed sessions contribute `0`: codex reports session-cumulative usage there, which would attribute the whole session history to each job. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
 
-Because of this, a tree made up mostly of Codex jobs will accumulate little or no
-counted usage — set the budget with that in mind, and prefer it as a coarse
-runaway-cost backstop rather than a precise spend limit. The same capture also
-feeds the `$`-denominated `[orchestrate].max_delegation_cost_usd` budget — see
-the dollar-cost bullet in [Termination bounds](#termination-bounds) above.
+Capture is best-effort, so treat the budget as a coarse runaway-cost backstop
+rather than a precise spend limit — a runtime that reports nothing (or an older
+codex CLI that predates `--json`) contributes `0` and is silently under-counted.
+The same capture also feeds the `$`-denominated
+`[orchestrate].max_delegation_cost_usd` budget — see the dollar-cost bullet in
+[Termination bounds](#termination-bounds) above.
 
 ### Top-level fields
 


### PR DESCRIPTION
Implements #658 and #659, built by a parallel 4-agent workflow with live-transcript grounding, plus a post-review correction from the live E2E.

## Codex (#658)
- `Deliver` (fresh + resume) now runs `codex exec --json` (flag placement live-verified) and parses the JSONL: `agent_message` texts → `Raw`/`Summary` (the engine's `gitmoot_result` scan is unaffected), last `turn.completed` usage → token fields.
- Fail-open everywhere: shapeless streams fall back to raw stdout with 0; older CLIs rejecting `--json` get one plain-text re-run.
- **Fresh sessions only.** The live E2E caught that resumed-thread usage is **session-cumulative** (probe: `16504 → 85681 → 103779` input across three one-word turns; a resumed ask on `planner` reported **22.4M** input tokens). Counting that would corrupt the #338 budgets and the usage charts, so resumed deliveries contribute 0 pending per-session delta tracking (#661). This exactly covers the budget's primary target: ephemeral delegation workers run fresh sessions.

## Kimi (#659)
- kimi-code 0.19.2 emits **no usage event** (live transcript; `--help` offers no enabling flag) — documented in the parser + `Result` contract with a 0.19.2 fixture test; parser retained for versions that do emit usage.

## Review catches (fixed in-PR)
Stale token-capture contract tables in the skill/site/llms surfaces (#603 policy), a stale load-bearing comment in `mailbox.go`, an overstated resume-flag claim — plus my post-workflow fresh-only correction with tests (`TestCodexDeliverResumeReportsZeroUsage` pins the probe numbers).

## Verification
- `go build/vet ./... && go test ./internal/runtime` green
- Live E2E: fresh-session codex ask persisted **17,777 / 273** tokens end-to-end (adapter → mailbox gate → store); resumed ask persisted 0; the polluted pre-correction row was reset.

Closes #658 · Closes #659 · Follow-up: #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)