### PR TITLE
test(cli): fix codex resume arg expectations for --json

### DIFF
--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -535,7 +535,7 @@ func TestRunAgentAskDispatchesAndStoresResult(t *testing.T) {
 			t.Fatalf("ask output missing %q:\n%s", want, stdout.String())
 		}
 	}
-	runner.want(t, 0, repoDir, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440021", "--")
+	runner.want(t, 0, repoDir, "codex", "exec", "--json", "resume", "550e8400-e29b-41d4-a716-446655440021", "--")
 	if !strings.Contains(runner.calls[0].args[len(runner.calls[0].args)-1], "Write a plan") {
 		t.Fatalf("ask prompt missing message:\n%s", runner.calls[0].args[len(runner.calls[0].args)-1])
 	}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -2690,7 +2690,7 @@ func TestSkillOptTrainContinueGeneratesOptionsWithCurrentSkill(t *testing.T) {
 		t.Fatalf("runtime calls = %+v, want one start and delivery per option", runner.calls)
 	}
 	runner.want(t, 0, repoDir, "codex", "exec", "--json", "--")
-	runner.want(t, 1, repoDir, "codex", "exec", "resume", "550e8400-e29b-41d4-a716-446655440201", "--")
+	runner.want(t, 1, repoDir, "codex", "exec", "--json", "resume", "550e8400-e29b-41d4-a716-446655440201", "--")
 	if !strings.Contains(runner.calls[1].args[len(runner.calls[1].args)-1], "Option label: A") || !strings.Contains(runner.calls[1].args[len(runner.calls[1].args)-1], "Generate one review option") {
 		t.Fatalf("generation prompt = %q", runner.calls[1].args[len(runner.calls[1].args)-1])
 	}


### PR DESCRIPTION
Fix-forward for the red CI on #662 (merged by mistake with the check unread — my batching error): two `internal/cli` tests pinned the pre-#658 codex resume vector and needed `--json` inserted. Behavior is correct; expectations were stale. Full `./...` suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)