### PR TITLE
fix(runtime): capture codex usage for single-use sessions (ephemeral/temp workers)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4610,6 +4610,14 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		return nil
 	}
 	agent := runtimeAgent(dbAgent)
+	// An ephemeral worker's runtime session exists solely for this job — it was
+	// started by startEphemeralWorker above and disposed by the cleanup defer.
+	// Mark it single-use so adapters whose CLIs report session-cumulative usage
+	// (codex, #658) can attribute that usage to the job: the whole session is
+	// this job's cost. In-memory only — GetAgent never returns the flag.
+	if payload.Ephemeral != nil {
+		agent.SingleUseSession = true
+	}
 	// Per-job runtime override (#531): the payload carries the override, so a
 	// background/daemon job honors it identically to a foreground dispatch. The
 	// effective agent swaps in the override runtime + the job's own session ref;
@@ -5669,6 +5677,9 @@ func (w jobWorker) startTempWorker(ctx context.Context, job db.Job, payload work
 	tempAgent := original
 	tempAgent.Name = tempWorkerInstanceName(original.Name, job.ID)
 	tempAgent.RuntimeRef = ""
+	// A temp worker's session is started for this one job and disposed after it
+	// — single-use, so session-cumulative usage (codex, #658) is the job's cost.
+	tempAgent.SingleUseSession = true
 	var cachedTemplate db.AgentTemplate
 	if tempAgent.TemplateID != "" {
 		var err error

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -43,6 +43,15 @@ type Agent struct {
 	AutonomyPolicy string
 	HealthStatus   string
 	Model          string
+	// SingleUseSession marks an agent whose runtime session exists solely for
+	// the current job (ephemeral delegation workers and per-job temp workers:
+	// the session is started for the job and disposed after it). Adapters whose
+	// CLIs report SESSION-CUMULATIVE usage on resumed sessions (codex, see
+	// codexDeliverResult) may attribute that cumulative usage to the job when
+	// this is set — the whole session belongs to the job, so cumulative IS the
+	// per-job cost. Never set for long-lived registered agents, whose sessions
+	// span many jobs. In-memory only; not persisted on the agents table.
+	SingleUseSession bool
 }
 
 type Job struct {
@@ -64,10 +73,11 @@ type Result struct {
 	// default to 0. Per-runtime status today: claude reports usage via its
 	// --output-format json envelope; kimi-code 0.19.2 emits no usage event so it
 	// contributes 0; codex Deliver reads the last turn.completed usage from its
-	// `exec --json` JSONL output (#658) for FRESH sessions only — resumed
-	// sessions contribute 0 because codex reports session-cumulative usage there
-	// (see codexDeliverResult) — falling back to 0 on an older CLI that predates
-	// --json. A 0 here means "not captured", and the per-root delegation token
+	// `exec --json` JSONL output (#658) for single-job sessions only (fresh
+	// refs and SingleUseSession ephemeral/temp workers) — sessions shared
+	// across jobs contribute 0 because codex reports session-cumulative usage
+	// there (see codexDeliverResult) — falling back to 0 on an older CLI that
+	// predates --json. A 0 here means "not captured", and the per-root delegation token
 	// budget simply under-counts that job rather than failing.
 	InputTokens  int
 	OutputTokens int
@@ -342,7 +352,10 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 	if err != nil {
 		return Result{Raw: result.Stdout + result.Stderr}, codexCommandError(result, err)
 	}
-	return codexDeliverResult(result.Stdout, IsFreshRef(agent.RuntimeRef)), nil
+	// Usage is attributable to this job when the session belongs to it alone:
+	// a fresh ref (brand-new session, no resume) or a single-use session
+	// (ephemeral/temp workers — started for the job, disposed after it).
+	return codexDeliverResult(result.Stdout, IsFreshRef(agent.RuntimeRef) || agent.SingleUseSession), nil
 }
 
 // codexDeliverArgs builds the `codex exec` argument vector for a Deliver call.
@@ -397,9 +410,11 @@ func (a CodexAdapter) runCodex(ctx context.Context, agent Agent, prompt, model s
 // an unexpected shape) is returned verbatim as Raw with 0 usage, so a delivery is
 // never lost because usage parsing changed.
 //
-// Usage is reported ONLY for fresh sessions (per-job --runtime overrides and
-// ephemeral delegation workers — the #338 budget's primary target). On RESUMED
-// sessions codex's turn.completed usage is SESSION-CUMULATIVE, not per-turn:
+// Usage is reported ONLY for sessions that belong to a single job: fresh refs
+// (per-job --runtime overrides) and single-use sessions (ephemeral delegation
+// workers and per-job temp workers — the #338 budget's primary target). On
+// sessions SHARED across jobs codex's turn.completed usage is SESSION-CUMULATIVE,
+// not per-turn:
 // probed live on codex-cli 0.142.4, three one-word turns on one thread reported
 // input 16504 -> 85681 -> 103779 and output 20 -> 40 -> 45 (monotonically
 // accumulating), and a single resumed ask on a long-lived agent reported 22.4M

--- a/internal/runtime/usage_test.go
+++ b/internal/runtime/usage_test.go
@@ -172,6 +172,26 @@ func TestCodexDeliverCapturesUsage(t *testing.T) {
 	runner.want(t, 0, "codex", "exec", "--json", "--", "implement")
 }
 
+// TestCodexDeliverSingleUseSessionCapturesUsage pins the ephemeral/temp-worker
+// case (#658): the worker's session is started for one job and disposed after
+// it, so even though delivery RESUMES that session, codex's session-cumulative
+// usage is exactly the job's cost and must be captured. The daemon sets
+// SingleUseSession when materializing ephemeral and temp workers.
+func TestCodexDeliverSingleUseSessionCapturesUsage(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: codexUsageTranscript}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{Name: "impl-x-ephemeral-abc", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "jerryfane/gitmoot", SingleUseSession: true}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.InputTokens != 16504 || result.OutputTokens != 20 {
+		t.Fatalf("single-use codex usage = (%d, %d), want (16504, 20)", result.InputTokens, result.OutputTokens)
+	}
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--last", "--", "implement")
+}
+
 // TestCodexDeliverResumeReportsZeroUsage pins the resumed-session exclusion:
 // codex's turn.completed usage on a resumed thread is SESSION-CUMULATIVE, not
 // per-turn (probed live on codex-cli 0.142.4: three one-word turns reported


### PR DESCRIPTION
Closes the hole in #662's fresh-only gate, found while answering "did you E2E this?": **ephemeral delegation workers resume the session `Start` created**, so `IsFreshRef` excluded exactly the case the #338 budget targets.

A single-use session belongs to one job, so codex's session-cumulative usage **is** that job's honest cost. New `Agent.SingleUseSession` (in-memory), set at both daemon materialization sites (ephemeral spec workers + per-job temp workers); the codex gate becomes `IsFreshRef || SingleUseSession`. Long-lived agents stay excluded (the 22.4M cumulative bug).

**Isolated-home daemon E2E (the full chain):** register repo + codex coordinator on a throwaway home → `daemon run` → `orchestrate` fans out one ephemeral codex ask child → child's store row persisted **34,306 / 361** tokens (two-turn single-session magnitude; was 0 before this fix). Unit tests pin capture-on-single-use and zero-on-shared. Full `./...` suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)