### PR TITLE
Fix session isolation and task-run implement recovery

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
@@ -469,10 +471,16 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 	if executionPath == "orchestrate" {
 		errLabel = "orchestrate"
 	}
+	dispatchCtx := context.Background()
+	var stopSignals context.CancelFunc
+	if !options.background {
+		dispatchCtx, stopSignals = signal.NotifyContext(dispatchCtx, os.Interrupt, syscall.SIGTERM)
+		defer stopSignals()
+	}
 	var output localAgentJobOutput
 	if err := withStore(options.home, func(store *db.Store) error {
 		var err error
-		output, err = dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		output, err = dispatchLocalAgentJob(dispatchCtx, store, localAgentDispatchRequest{
 			RepoFlag:               options.repo,
 			Agent:                  options.agent,
 			Action:                 action,

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -572,6 +572,9 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 			} else if ok {
 				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s already has active implement job %s for task %s", branchHint, active.ID, existing.ID)
 			}
+			if strings.TrimSpace(existing.WorktreePath) != "" && taskWorktreeHasLiveProcess(existing.WorktreePath) {
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has a live process still inside task worktree %s; wait for it to exit or stop the orphaned implementer before retrying implement", branchHint, existing.WorktreePath)
+			}
 			if dirty, err := taskWorktreeDirty(ctx, existing); err != nil {
 				return db.Task{}, localAgentDispatchRequest{}, err
 			} else if dirty {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -564,6 +564,20 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 			return db.Task{}, localAgentDispatchRequest{}, err
 		}
 		if err == nil {
+			if !taskBranchReusableForImplement(existing.State) {
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s belongs to task %s in state %s; choose a fresh branch or recover/review the existing task", branchHint, existing.ID, existing.State)
+			}
+			if active, ok, err := findActiveImplementJobForTask(ctx, store, repo.FullName(), branchHint, existing.ID); err != nil {
+				return db.Task{}, localAgentDispatchRequest{}, err
+			} else if ok {
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s already has active implement job %s for task %s", branchHint, active.ID, existing.ID)
+			}
+			if dirty, err := taskWorktreeDirty(ctx, existing); err != nil {
+				return db.Task{}, localAgentDispatchRequest{}, err
+			} else if dirty {
+				skipFanout := taskRecoverSkipFanout(ctx, store, repo.FullName(), branchHint)
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has uncommitted changes in task worktree %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying implement", branchHint, existing.WorktreePath, taskRecoverCommand(existing.ID, request.Home, repo.FullName(), request.Agent, skipFanout))
+			}
 			taskID = existing.ID
 			taskTitle = firstNonEmpty(taskTitle, existing.Title)
 			goalID = firstNonEmpty(goalID, existing.GoalID)

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -557,6 +557,21 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 	taskID := strings.TrimSpace(request.TaskID)
 	taskTitle := strings.TrimSpace(request.TaskTitle)
 	goalID := strings.TrimSpace(request.GoalID)
+	branchHint := strings.TrimSpace(request.Branch)
+	if taskID == "" && branchHint != "" {
+		existing, err := store.GetTaskByRepoBranch(ctx, repo.FullName(), branchHint)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return db.Task{}, localAgentDispatchRequest{}, err
+		}
+		if err == nil {
+			taskID = existing.ID
+			taskTitle = firstNonEmpty(taskTitle, existing.Title)
+			goalID = firstNonEmpty(goalID, existing.GoalID)
+			request.TaskID = taskID
+			request.TaskTitle = taskTitle
+			request.GoalID = goalID
+		}
+	}
 	if taskID == "" {
 		taskID = "adhoc-" + shortHash(request.Instructions+"\x00"+time.Now().UTC().Format(time.RFC3339Nano))
 		taskTitle = firstNonEmpty(taskTitle, shortTaskTitle(request.Instructions))

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -573,7 +573,7 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s already has active implement job %s for task %s", branchHint, active.ID, existing.ID)
 			}
 			if strings.TrimSpace(existing.WorktreePath) != "" && taskWorktreeHasLiveProcess(existing.WorktreePath) {
-				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has a live process still inside task worktree %s; wait for it to exit or stop the orphaned implementer before retrying implement", branchHint, existing.WorktreePath)
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has a live process still inside task worktree %s; wait for it to exit or stop the orphaned implementer before retrying implement (this can include your own shell if you are inspecting the worktree; retry from outside that directory)", branchHint, existing.WorktreePath)
 			}
 			if dirty, err := taskWorktreeDirty(ctx, existing); err != nil {
 				return db.Task{}, localAgentDispatchRequest{}, err

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -205,6 +205,9 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
 		return localAgentJobOutput{}, err
 	}
+	if overrideRuntime == "" {
+		effectiveAgent = scopeRegisteredFreshRefForJob(effectiveAgent, job.ID)
+	}
 	if request.Background {
 		return localAgentJobOutput{
 			JobID:                job.ID,

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -906,6 +906,93 @@ func TestPrepareLocalImplementDispatchRequestReusesExistingBranchTask(t *testing
 	}
 }
 
+func TestPrepareLocalImplementDispatchRequestRejectsDirtyExistingBranchTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	worktree := filepath.Join(home, "dirty-task")
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, repoDir, "worktree", "add", "-b", "feature/retry", worktree, "main")
+	if err := os.WriteFile(filepath.Join(worktree, "feature.txt"), []byte("partial work\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-existing",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-existing",
+		Title:        "Existing branch task",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "feature/retry",
+		WorktreePath: worktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	_, _, err := prepareLocalImplementDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "builder",
+		Action:       "implement",
+		Instructions: "Continue the existing implementation branch.",
+		Branch:       "feature/retry",
+	})
+	if err == nil || !strings.Contains(err.Error(), "uncommitted changes") || !strings.Contains(err.Error(), "gitmoot task recover task-existing") {
+		t.Fatalf("prepareLocalImplementDispatchRequest err = %v, want recover guidance", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "feature/retry"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("dirty dispatch refusal created branch lock, err=%v", err)
+	}
+}
+
+func TestPrepareLocalImplementDispatchRequestRejectsCompletedBranchTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-existing",
+		RepoFullName: "owner/repo",
+		State:        string(workflow.TaskMerged),
+		Branch:       "feature/retry",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	_, _, err := prepareLocalImplementDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "builder",
+		Action:       "implement",
+		Instructions: "Implement a new task on a reused branch.",
+		Branch:       "feature/retry",
+	})
+	if err == nil || !strings.Contains(err.Error(), "state merged") {
+		t.Fatalf("prepareLocalImplementDispatchRequest err = %v, want completed task rejection", err)
+	}
+}
+
 func TestRunAgentAskBackgroundQueuesWithoutRuntimeDelivery(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -955,6 +955,55 @@ func TestPrepareLocalImplementDispatchRequestRejectsDirtyExistingBranchTask(t *t
 	}
 }
 
+func TestPrepareLocalImplementDispatchRequestRejectsLiveExistingBranchTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	worktree := filepath.Join(home, "live-task")
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-existing",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-existing",
+		Title:        "Existing branch task",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "feature/retry",
+		WorktreePath: worktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	prev := taskWorktreeHasLiveProcess
+	taskWorktreeHasLiveProcess = func(path string) bool { return path == worktree }
+	defer func() { taskWorktreeHasLiveProcess = prev }()
+
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	_, _, err := prepareLocalImplementDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "builder",
+		Action:       "implement",
+		Instructions: "Continue the existing implementation branch.",
+		Branch:       "feature/retry",
+	})
+	if err == nil || !strings.Contains(err.Error(), "live process") {
+		t.Fatalf("prepareLocalImplementDispatchRequest err = %v, want live process", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "feature/retry"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("live dispatch refusal created branch lock, err=%v", err)
+	}
+}
+
 func TestPrepareLocalImplementDispatchRequestRejectsCompletedBranchTask(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -847,6 +847,65 @@ func TestPrepareLocalReviewDispatchRequestDoesNotReuseStaleReviewWorktree(t *tes
 	}
 }
 
+func TestPrepareLocalImplementDispatchRequestReusesExistingBranchTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-existing",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-existing",
+		Title:        "Existing branch task",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "feature/retry",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	task, request, err := prepareLocalImplementDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "builder",
+		Action:       "implement",
+		Instructions: "Continue the existing implementation branch.",
+		Branch:       "feature/retry",
+	})
+	if err != nil {
+		t.Fatalf("prepareLocalImplementDispatchRequest returned error: %v", err)
+	}
+	if task.ID != "task-existing" || request.TaskID != "task-existing" {
+		t.Fatalf("task.ID=%q request.TaskID=%q, want task-existing", task.ID, request.TaskID)
+	}
+	if task.Branch != "feature/retry" || request.Branch != "feature/retry" {
+		t.Fatalf("task.Branch=%q request.Branch=%q, want feature/retry", task.Branch, request.Branch)
+	}
+	if task.WorktreePath == "" {
+		t.Fatal("task worktree path was not allocated")
+	}
+	if currentBranch := strings.TrimSpace(runGitOutput(t, task.WorktreePath, "branch", "--show-current")); currentBranch != "feature/retry" {
+		t.Fatalf("task worktree branch = %q, want feature/retry", currentBranch)
+	}
+	stored, err := store.GetTask(ctx, "task-existing")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if stored.WorktreePath != task.WorktreePath || stored.State != string(workflow.TaskImplementing) {
+		t.Fatalf("stored task = %+v, returned task = %+v", stored, task)
+	}
+}
+
 func TestRunAgentAskBackgroundQueuesWithoutRuntimeDelivery(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4634,6 +4634,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			return nil
 		}
 	}
+	if !overridden {
+		agent = scopeRegisteredFreshRefForJob(agent, job.ID)
+	}
 	if readOnlyImplementationBlocked(job.Type, agent) {
 		transitioned, err := markJobPermissionBlocked(ctx, w.Store, job.ID)
 		if err != nil {

--- a/internal/cli/runtime_override.go
+++ b/internal/cli/runtime_override.go
@@ -85,6 +85,18 @@ func applyJobRuntimeOverride(agent runtime.Agent, payload workflow.JobPayload) r
 	return agent
 }
 
+// scopeRegisteredFreshRefForJob rewrites a stored fresh:<seat> ref to a
+// deterministic fresh:<job> ref for the actual execution. This keeps fresh
+// registered agents isolated per job and gives their runtime-session lock a
+// job-scoped key. Runtime overrides already mint a unique fresh ref per job at
+// enqueue time, so callers use this only for non-overridden jobs.
+func scopeRegisteredFreshRefForJob(agent runtime.Agent, jobID string) runtime.Agent {
+	if runtime.IsFreshRef(agent.RuntimeRef) {
+		agent.RuntimeRef = runtime.FreshRefForJob(jobID)
+	}
+	return agent
+}
+
 // overrideRuntimeSessionResourceKey computes the runtime-session lock key for
 // a job running under a runtime override. Resumable runtimes keep the normal
 // "runtime:<rt>:<ref>" key (an explicit session serializes with other users

--- a/internal/cli/runtime_override_test.go
+++ b/internal/cli/runtime_override_test.go
@@ -113,6 +113,35 @@ func TestApplyJobRuntimeOverride(t *testing.T) {
 	}
 }
 
+func TestScopeRegisteredFreshRefForJob(t *testing.T) {
+	agent := runtime.Agent{
+		Name:       "council-codex",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: "fresh:council-codex",
+	}
+
+	scoped := scopeRegisteredFreshRefForJob(agent, "local-ask-root/delegation/review-codex")
+	if !runtime.IsFreshRef(scoped.RuntimeRef) {
+		t.Fatalf("scoped ref = %q, want fresh ref", scoped.RuntimeRef)
+	}
+	if scoped.RuntimeRef == agent.RuntimeRef {
+		t.Fatalf("registered fresh ref was not job-scoped: %q", scoped.RuntimeRef)
+	}
+	again := scopeRegisteredFreshRefForJob(agent, "local-ask-root/delegation/review-codex")
+	if again.RuntimeRef != scoped.RuntimeRef {
+		t.Fatalf("job scoping must be deterministic: %q != %q", again.RuntimeRef, scoped.RuntimeRef)
+	}
+	other := scopeRegisteredFreshRefForJob(agent, "local-ask-other/delegation/review-codex")
+	if other.RuntimeRef == scoped.RuntimeRef {
+		t.Fatalf("different jobs must not share fresh lock refs: %q", scoped.RuntimeRef)
+	}
+
+	pinned := runtime.Agent{Name: "reviewer", Runtime: runtime.ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440000"}
+	if got := scopeRegisteredFreshRefForJob(pinned, "job-1"); got.RuntimeRef != pinned.RuntimeRef {
+		t.Fatalf("non-fresh ref changed: %q", got.RuntimeRef)
+	}
+}
+
 // TestOverrideRuntimeSessionResourceKey: the lock key always names the
 // OVERRIDE runtime — resumable runtimes keep the normal runtime:<rt>:<ref>
 // shape, and shell (normally lock-less) gets an override-scoped hashed key —

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -31,6 +31,8 @@ import (
 
 var taskHeadingPattern = regexp.MustCompile(`^### Task ([0-9]+):\s*(.+)$`)
 
+var taskWorktreeHasLiveProcess = workflow.WorktreeHasLiveProcess
+
 type importedGoal struct {
 	Goal  db.Goal
 	Tasks []db.Task
@@ -604,6 +606,9 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		return workflow.JobPayload{}, err
 	} else if ok {
 		return workflow.JobPayload{}, fmt.Errorf("task %s still has active implement job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
+	}
+	if strings.TrimSpace(task.WorktreePath) != "" && taskWorktreeHasLiveProcess(task.WorktreePath) {
+		return workflow.JobPayload{}, fmt.Errorf("task %s worktree %s still has a live process; wait for it to exit or stop the orphaned implementer before recovering", task.ID, task.WorktreePath)
 	}
 	lock, createdLock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
 	if err != nil {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 	"github.com/jerryfane/gitmoot/skills"
 )
@@ -248,6 +249,8 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 		return runTaskRun(args[1:], stdout, stderr)
 	case "list":
 		return runTaskList(args[1:], stdout, stderr)
+	case "recover":
+		return runTaskRecover(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown task command %q\n\n", args[0])
 		printTaskUsage(stderr)
@@ -258,6 +261,7 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>]")
+	fmt.Fprintln(w, "  gitmoot task recover <id> --repo owner/repo [--owner <agent>] [--skip-native-review-fanout] [--json]")
 	fmt.Fprintln(w, "  gitmoot task list [--repo owner/repo] [--state state] [--json]")
 }
 
@@ -425,6 +429,21 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("resolve task worktree head: %w", err)
 		}
+		recoverCmd := taskRecoverCommand(task.ID, *home, requestRepo, strings.TrimSpace(*owner))
+		dirty, err := taskWorktreeDirty(context.Background(), started)
+		if err != nil {
+			return err
+		}
+		request := taskRunImplementJobRequest(taskRunImplementJobID(started.ID, strings.TrimSpace(*owner)), started, strings.TrimSpace(*owner), headSHA)
+		if active, ok, err := findActiveTaskRunJob(context.Background(), store, request); err != nil {
+			return err
+		} else if ok {
+			startedJob = active
+			return nil
+		}
+		if dirty {
+			return fmt.Errorf("task %s worktree has uncommitted changes at %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying task run", started.ID, started.WorktreePath, recoverCmd)
+		}
 		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA, paths.Home)
 		return err
 	}); err != nil {
@@ -444,6 +463,160 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return 0
+}
+
+type taskRecoverOutput struct {
+	TaskID      string `json:"task_id"`
+	Repo        string `json:"repo"`
+	Branch      string `json:"branch"`
+	PullRequest int    `json:"pull_request"`
+	HeadSHA     string `json:"head_sha"`
+	Summary     string `json:"summary"`
+}
+
+func runTaskRecover(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("task recover", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repo := fs.String("repo", "", "repo scope as owner/repo")
+	owner := fs.String("owner", "", "agent/operator attributed as recovery lead")
+	skipFanout := fs.Bool("skip-native-review-fanout", false, "persist skip-native-review-fanout before opening the PR")
+	jsonOutput := fs.Bool("json", false, "print recovery result as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "task recover requires exactly one id")
+			return 2
+		}
+		return 0
+	}
+	taskID := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "task recover requires exactly one id")
+		return 2
+	}
+	var output taskRecoverOutput
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		payload, err := recoverTaskImplementation(context.Background(), store, taskID, strings.TrimSpace(*repo), strings.TrimSpace(*owner), *skipFanout, nil)
+		if err != nil {
+			return err
+		}
+		output = taskRecoverOutput{
+			TaskID:      payload.TaskID,
+			Repo:        payload.Repo,
+			Branch:      payload.Branch,
+			PullRequest: payload.PullRequest,
+			HeadSHA:     payload.HeadSHA,
+			Summary:     "recovered implementation worktree and opened/adopted PR",
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "recover task: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "recover task: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "recovered %s on %s\n", output.TaskID, output.Branch)
+	if output.PullRequest > 0 {
+		fmt.Fprintf(stdout, "pull_request: #%d\n", output.PullRequest)
+	}
+	if output.HeadSHA != "" {
+		fmt.Fprintf(stdout, "head_sha: %s\n", output.HeadSHA)
+	}
+	return 0
+}
+
+func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID string, repoFlag string, owner string, skipFanout bool, gh github.Client) (workflow.JobPayload, error) {
+	task, err := store.GetTask(ctx, strings.TrimSpace(taskID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return workflow.JobPayload{}, fmt.Errorf("task %q not found", taskID)
+		}
+		return workflow.JobPayload{}, err
+	}
+	requestRepo := firstNonEmpty(repoFlag, task.RepoFullName)
+	if strings.TrimSpace(requestRepo) == "" {
+		return workflow.JobPayload{}, errors.New("task recover requires --repo when task has no repo")
+	}
+	if strings.TrimSpace(repoFlag) != "" && strings.TrimSpace(task.RepoFullName) != "" && repoFlag != task.RepoFullName {
+		return workflow.JobPayload{}, fmt.Errorf("task %s belongs to repo %s, not %s", task.ID, task.RepoFullName, repoFlag)
+	}
+	if _, err := daemon.ParseRepository(requestRepo); err != nil {
+		return workflow.JobPayload{}, fmt.Errorf("invalid repo: %w", err)
+	}
+	if _, err := store.GetRepo(ctx, requestRepo); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return workflow.JobPayload{}, err
+		}
+		return workflow.JobPayload{}, fmt.Errorf("repo %s is not registered; run gitmoot repo add from the checkout before task recover", requestRepo)
+	}
+	if strings.TrimSpace(task.WorktreePath) == "" {
+		return workflow.JobPayload{}, errors.New("task has no worktree path; rerun through gitmoot task run or gitmoot agent implement")
+	}
+	headSHA, err := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
+	if err != nil {
+		return workflow.JobPayload{}, fmt.Errorf("resolve task worktree head: %w", err)
+	}
+	if strings.TrimSpace(owner) == "" {
+		owner = "task recover"
+	}
+	job := db.Job{
+		ID:    taskRecoverJobID(task.ID, owner),
+		Agent: owner,
+		Type:  "implement",
+	}
+	payload := workflow.JobPayload{
+		Repo:                   requestRepo,
+		Branch:                 task.Branch,
+		GoalID:                 task.GoalID,
+		TaskID:                 task.ID,
+		TaskTitle:              task.Title,
+		LeadAgent:              owner,
+		HeadSHA:                headSHA,
+		SkipNativeReviewFanout: skipFanout,
+	}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	return finalizer.FinalizeImplementation(ctx, job, payload)
+}
+
+func taskWorktreeDirty(ctx context.Context, task db.Task) (bool, error) {
+	if strings.TrimSpace(task.WorktreePath) == "" {
+		return false, nil
+	}
+	status, err := (gitutil.Client{Dir: task.WorktreePath}).StatusPorcelain(ctx)
+	if err != nil {
+		return false, fmt.Errorf("inspect task worktree %s: %w", task.WorktreePath, err)
+	}
+	return strings.TrimSpace(status) != "", nil
+}
+
+func taskRecoverCommand(taskID string, home string, repo string, owner string) string {
+	args := []string{"gitmoot", "task", "recover", taskID}
+	if strings.TrimSpace(home) != "" {
+		args = append(args, "--home", home)
+	}
+	if strings.TrimSpace(repo) != "" {
+		args = append(args, "--repo", repo)
+	}
+	if strings.TrimSpace(owner) != "" {
+		args = append(args, "--owner", owner)
+	}
+	return shellArgs(args)
+}
+
+func taskRecoverJobID(taskID string, owner string) string {
+	return slug("task-" + taskID + "-recover-" + owner)
 }
 
 func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string, home string) (db.Job, error) {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -383,12 +384,12 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 			}
 			return err
 		}
-		requestRepo := firstNonEmpty(*repo, task.RepoFullName)
+		requestRepo, err := resolveTaskRepoFlag(*repo, task.RepoFullName, "task run")
+		if err != nil {
+			return err
+		}
 		if strings.TrimSpace(requestRepo) == "" {
 			return errors.New("task run requires --repo when task has no repo")
-		}
-		if strings.TrimSpace(*repo) != "" && strings.TrimSpace(task.RepoFullName) != "" && *repo != task.RepoFullName {
-			return fmt.Errorf("task %s belongs to repo %s, not %s", task.ID, task.RepoFullName, *repo)
 		}
 		repo, err := daemon.ParseRepository(requestRepo)
 		if err != nil {
@@ -410,6 +411,32 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		}
 		checkout := repoRecord.CheckoutPath
 		requestBranch := firstNonEmpty(*branch, task.Branch, task.ID)
+		if strings.TrimSpace(task.WorktreePath) != "" {
+			candidate := task
+			candidate.RepoFullName = requestRepo
+			candidate.Branch = requestBranch
+			headSHA, err := (gitutil.Client{Dir: candidate.WorktreePath}).HeadSHA(context.Background())
+			if err != nil {
+				return fmt.Errorf("resolve task worktree head: %w", err)
+			}
+			request := taskRunImplementJobRequest(taskRunImplementJobID(candidate.ID, strings.TrimSpace(*owner)), candidate, strings.TrimSpace(*owner), headSHA)
+			if active, ok, err := findActiveTaskRunJob(context.Background(), store, request); err != nil {
+				return err
+			} else if ok {
+				started = candidate
+				startedJob = active
+				return nil
+			}
+			dirty, err := taskWorktreeDirty(context.Background(), candidate)
+			if err != nil {
+				return err
+			}
+			if dirty {
+				skipFanout := taskRecoverSkipFanout(context.Background(), store, requestRepo, requestBranch)
+				recoverCmd := taskRecoverCommand(task.ID, *home, requestRepo, strings.TrimSpace(*owner), skipFanout)
+				return fmt.Errorf("task %s worktree has uncommitted changes at %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying task run", task.ID, candidate.WorktreePath, recoverCmd)
+			}
+		}
 		engine := workflow.Engine{Store: store}
 		started, err = engine.AllocateTaskWorktree(context.Background(), workflow.TaskWorktreeRequest{
 			Home:       paths.Home,
@@ -429,20 +456,12 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("resolve task worktree head: %w", err)
 		}
-		recoverCmd := taskRecoverCommand(task.ID, *home, requestRepo, strings.TrimSpace(*owner))
-		dirty, err := taskWorktreeDirty(context.Background(), started)
-		if err != nil {
-			return err
-		}
 		request := taskRunImplementJobRequest(taskRunImplementJobID(started.ID, strings.TrimSpace(*owner)), started, strings.TrimSpace(*owner), headSHA)
 		if active, ok, err := findActiveTaskRunJob(context.Background(), store, request); err != nil {
 			return err
 		} else if ok {
 			startedJob = active
 			return nil
-		}
-		if dirty {
-			return fmt.Errorf("task %s worktree has uncommitted changes at %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying task run", started.ID, started.WorktreePath, recoverCmd)
 		}
 		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA, paths.Home)
 		return err
@@ -479,7 +498,7 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	repo := fs.String("repo", "", "repo scope as owner/repo")
-	owner := fs.String("owner", "", "agent/operator attributed as recovery lead")
+	owner := fs.String("owner", "", "registered implement-capable agent attributed as recovery lead")
 	skipFanout := fs.Bool("skip-native-review-fanout", false, "persist skip-native-review-fanout before opening the PR")
 	jsonOutput := fs.Bool("json", false, "print recovery result as JSON")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
@@ -499,6 +518,10 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 	}
 	if fs.NArg() != 0 {
 		fmt.Fprintln(stderr, "task recover requires exactly one id")
+		return 2
+	}
+	if strings.TrimSpace(*owner) == "" {
+		fmt.Fprintln(stderr, "task recover requires --owner")
 		return 2
 	}
 	var output taskRecoverOutput
@@ -545,12 +568,12 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		}
 		return workflow.JobPayload{}, err
 	}
-	requestRepo := firstNonEmpty(repoFlag, task.RepoFullName)
+	requestRepo, err := resolveTaskRepoFlag(repoFlag, task.RepoFullName, "task recover")
+	if err != nil {
+		return workflow.JobPayload{}, err
+	}
 	if strings.TrimSpace(requestRepo) == "" {
 		return workflow.JobPayload{}, errors.New("task recover requires --repo when task has no repo")
-	}
-	if strings.TrimSpace(repoFlag) != "" && strings.TrimSpace(task.RepoFullName) != "" && repoFlag != task.RepoFullName {
-		return workflow.JobPayload{}, fmt.Errorf("task %s belongs to repo %s, not %s", task.ID, task.RepoFullName, repoFlag)
 	}
 	if _, err := daemon.ParseRepository(requestRepo); err != nil {
 		return workflow.JobPayload{}, fmt.Errorf("invalid repo: %w", err)
@@ -564,17 +587,51 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 	if strings.TrimSpace(task.WorktreePath) == "" {
 		return workflow.JobPayload{}, errors.New("task has no worktree path; rerun through gitmoot task run or gitmoot agent implement")
 	}
+	if strings.TrimSpace(task.Branch) == "" {
+		return workflow.JobPayload{}, errors.New("task has no branch; cannot recover implementation")
+	}
+	agent, err := store.GetAgent(ctx, strings.TrimSpace(owner))
+	if err != nil {
+		return workflow.JobPayload{}, fmt.Errorf("load recovery owner agent %q: %w", strings.TrimSpace(owner), err)
+	}
+	if err := ensureLocalAgentAccess(ctx, store, agent, requestRepo, "implement"); err != nil {
+		return workflow.JobPayload{}, err
+	}
+	if active, ok, err := findActiveImplementJobForTask(ctx, store, requestRepo, task.Branch, task.ID); err != nil {
+		return workflow.JobPayload{}, err
+	} else if ok {
+		return workflow.JobPayload{}, fmt.Errorf("task %s still has active implement job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
+	}
+	lock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
+	if err != nil {
+		return workflow.JobPayload{}, err
+	}
 	headSHA, err := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
 	if err != nil {
 		return workflow.JobPayload{}, fmt.Errorf("resolve task worktree head: %w", err)
 	}
-	if strings.TrimSpace(owner) == "" {
-		owner = "task recover"
+	payloadHead := headSHA
+	if dirty, err := taskWorktreeDirty(ctx, task); err != nil {
+		return workflow.JobPayload{}, err
+	} else if !dirty {
+		baseHead := previousTaskImplementHeadSHA(ctx, store, task.ID, requestRepo, task.Branch, headSHA)
+		if strings.TrimSpace(baseHead) == "" {
+			baseHead, err = taskRecoverBaseHead(ctx, store, task, requestRepo)
+			if err != nil {
+				return workflow.JobPayload{}, err
+			}
+		}
+		if strings.TrimSpace(baseHead) == "" || baseHead == headSHA {
+			return workflow.JobPayload{}, workflow.BlockedError{Reason: "task worktree is clean and has no recoverable commit ahead of its base"}
+		}
+		payloadHead = baseHead
 	}
+	skipFanout = skipFanout || lock.SkipNativeReviewFanout
 	job := db.Job{
-		ID:    taskRecoverJobID(task.ID, owner),
+		ID:    uniqueTaskRecoverJobID(ctx, store, task.ID, owner),
 		Agent: owner,
 		Type:  "implement",
+		State: string(workflow.JobRunning),
 	}
 	payload := workflow.JobPayload{
 		Repo:                   requestRepo,
@@ -583,11 +640,42 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		TaskID:                 task.ID,
 		TaskTitle:              task.Title,
 		LeadAgent:              owner,
-		HeadSHA:                headSHA,
+		HeadSHA:                payloadHead,
+		Sender:                 "task recover",
+		Instructions:           "Recover task " + task.ID + " from its existing implementation worktree.",
 		SkipNativeReviewFanout: skipFanout,
 	}
+	encoded, err := encodeWorkflowJobPayload(payload)
+	if err != nil {
+		return workflow.JobPayload{}, err
+	}
+	if err := store.CreateExternallyDrivenJobWithEvent(ctx, db.Job{
+		ID:      job.ID,
+		Agent:   job.Agent,
+		Type:    job.Type,
+		State:   job.State,
+		Payload: encoded,
+	}, db.JobEvent{Kind: string(workflow.JobRunning), Message: "task recovery started"}); err != nil {
+		return workflow.JobPayload{}, err
+	}
 	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
-	return finalizer.FinalizeImplementation(ctx, job, payload)
+	finalized, err := finalizer.FinalizeImplementation(ctx, job, payload)
+	if err != nil {
+		state := string(workflow.JobFailed)
+		var blocked workflow.BlockedError
+		if errors.As(err, &blocked) {
+			state = string(workflow.JobBlocked)
+			finalized = payload
+			finalized.Result = &workflow.AgentResult{Decision: "blocked", Summary: blocked.Reason}
+		}
+		_ = finishTaskRecoverJob(ctx, store, job.ID, state, finalized, err.Error())
+		return workflow.JobPayload{}, err
+	}
+	finalized.Result = &workflow.AgentResult{Decision: "implemented", Summary: "Recovered implementation worktree and opened/adopted PR."}
+	if err := finishTaskRecoverJob(ctx, store, job.ID, string(workflow.JobSucceeded), finalized, "task recovery finalized implementation"); err != nil {
+		return workflow.JobPayload{}, err
+	}
+	return finalized, nil
 }
 
 func taskWorktreeDirty(ctx context.Context, task db.Task) (bool, error) {
@@ -601,7 +689,167 @@ func taskWorktreeDirty(ctx context.Context, task db.Task) (bool, error) {
 	return strings.TrimSpace(status) != "", nil
 }
 
-func taskRecoverCommand(taskID string, home string, repo string, owner string) string {
+func taskBranchReusableForImplement(state string) bool {
+	switch workflow.TaskState(strings.TrimSpace(state)) {
+	case "", workflow.TaskPlanned, workflow.TaskImplementing, workflow.TaskChangesRequested, workflow.TaskBlocked, workflow.TaskAwaitingHuman:
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveTaskRepoFlag(repoFlag string, taskRepo string, command string) (string, error) {
+	repoFlag = strings.TrimSpace(repoFlag)
+	taskRepo = strings.TrimSpace(taskRepo)
+	if repoFlag == "" {
+		if taskRepo == "" {
+			return "", nil
+		}
+		return normalizeRepoFlag(taskRepo)
+	}
+	repo, err := normalizeRepoFlag(repoFlag)
+	if err != nil {
+		return "", fmt.Errorf("invalid repo: %w", err)
+	}
+	if taskRepo != "" {
+		taskRepo, err = normalizeRepoFlag(taskRepo)
+		if err != nil {
+			return "", fmt.Errorf("invalid task repo: %w", err)
+		}
+		if repo != taskRepo {
+			return "", fmt.Errorf("task belongs to repo %s, not %s", taskRepo, repo)
+		}
+	}
+	return repo, nil
+}
+
+func findActiveImplementJobForTask(ctx context.Context, store *db.Store, repo string, branch string, taskID string) (db.Job, bool, error) {
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return db.Job{}, false, err
+	}
+	for _, job := range jobs {
+		if job.State != string(workflow.JobQueued) && job.State != string(workflow.JobRunning) {
+			continue
+		}
+		if job.Type != "implement" {
+			continue
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			continue
+		}
+		if payload.TaskID == taskID && payload.Repo == repo && payload.Branch == branch {
+			return job, true, nil
+		}
+	}
+	return db.Job{}, false, nil
+}
+
+func previousTaskImplementHeadSHA(ctx context.Context, store *db.Store, taskID string, repo string, branch string, currentHead string) string {
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return ""
+	}
+	head := ""
+	for _, job := range jobs {
+		if job.Type != "implement" {
+			continue
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			continue
+		}
+		if payload.TaskID != taskID || payload.Repo != repo || payload.Branch != branch {
+			continue
+		}
+		if strings.TrimSpace(payload.HeadSHA) == "" || payload.HeadSHA == currentHead {
+			continue
+		}
+		head = payload.HeadSHA
+	}
+	return head
+}
+
+func taskRecoverBaseHead(ctx context.Context, store *db.Store, task db.Task, repo string) (string, error) {
+	record, err := store.GetRepo(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	base := strings.TrimSpace(record.DefaultBranch)
+	if base == "" {
+		base = "main"
+	}
+	git := gitutil.Client{Dir: task.WorktreePath}
+	var lastErr error
+	for _, rev := range []string{base, "origin/" + base} {
+		sha, err := git.RevParse(ctx, rev)
+		if err == nil {
+			return sha, nil
+		}
+		lastErr = err
+	}
+	return "", fmt.Errorf("resolve task recovery base %s: %w", base, lastErr)
+}
+
+func ensureTaskRecoverBranchLock(ctx context.Context, store *db.Store, repo string, branch string, owner string) (db.BranchLock, error) {
+	if strings.TrimSpace(branch) == "" {
+		return db.BranchLock{}, errors.New("task recover requires a branch")
+	}
+	lock := db.BranchLock{RepoFullName: repo, Branch: branch, Owner: owner}
+	if _, err := store.CreateLock(ctx, lock); err != nil {
+		return db.BranchLock{}, err
+	}
+	current, err := store.GetBranchLock(ctx, repo, branch)
+	if err != nil {
+		return db.BranchLock{}, err
+	}
+	if current.Owner != owner {
+		return db.BranchLock{}, fmt.Errorf("branch %s is locked by %s, not %s", branch, current.Owner, owner)
+	}
+	return current, nil
+}
+
+func taskRecoverSkipFanout(ctx context.Context, store *db.Store, repo string, branch string) bool {
+	lock, err := store.GetBranchLock(ctx, repo, branch)
+	return err == nil && lock.SkipNativeReviewFanout
+}
+
+func uniqueTaskRecoverJobID(ctx context.Context, store *db.Store, taskID string, owner string) string {
+	base := taskRecoverJobID(taskID, owner)
+	if _, err := store.GetJob(ctx, base); errors.Is(err, sql.ErrNoRows) {
+		return base
+	}
+	return base + "-" + shortHash(time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+func encodeWorkflowJobPayload(payload workflow.JobPayload) (string, error) {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func finishTaskRecoverJob(ctx context.Context, store *db.Store, jobID string, state string, payload workflow.JobPayload, message string) error {
+	encoded, err := encodeWorkflowJobPayload(payload)
+	if err != nil {
+		return err
+	}
+	ok, err := store.TransitionJobStatePayloadWithEvent(ctx, jobID, string(workflow.JobRunning), state, encoded, db.JobEvent{Kind: state, Message: message})
+	if err != nil {
+		return err
+	}
+	if !ok {
+		if err := store.UpdateJobPayload(ctx, jobID, encoded); err != nil {
+			return err
+		}
+		return store.UpdateJobState(ctx, jobID, state)
+	}
+	return nil
+}
+
+func taskRecoverCommand(taskID string, home string, repo string, owner string, skipFanout bool) string {
 	args := []string{"gitmoot", "task", "recover", taskID}
 	if strings.TrimSpace(home) != "" {
 		args = append(args, "--home", home)
@@ -612,11 +860,18 @@ func taskRecoverCommand(taskID string, home string, repo string, owner string) s
 	if strings.TrimSpace(owner) != "" {
 		args = append(args, "--owner", owner)
 	}
+	if skipFanout {
+		args = append(args, "--skip-native-review-fanout")
+	}
 	return shellArgs(args)
 }
 
 func taskRecoverJobID(taskID string, owner string) string {
-	return slug("task-" + taskID + "-recover-" + owner)
+	value := slug("task-" + taskID + "-recover-" + owner)
+	if value == "" {
+		return "task-recover-" + shortHash(taskID+"\x00"+owner)
+	}
+	return value
 }
 
 func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string, home string) (db.Job, error) {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -568,6 +568,9 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		}
 		return workflow.JobPayload{}, err
 	}
+	if !taskBranchReusableForImplement(task.State) {
+		return workflow.JobPayload{}, fmt.Errorf("task %s is in state %s; task recover only supports active implementation states", task.ID, task.State)
+	}
 	requestRepo, err := resolveTaskRepoFlag(repoFlag, task.RepoFullName, "task recover")
 	if err != nil {
 		return workflow.JobPayload{}, err
@@ -602,10 +605,16 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 	} else if ok {
 		return workflow.JobPayload{}, fmt.Errorf("task %s still has active implement job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
 	}
-	lock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
+	lock, createdLock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
 	if err != nil {
 		return workflow.JobPayload{}, err
 	}
+	releaseCreatedLock := createdLock
+	defer func() {
+		if releaseCreatedLock {
+			_, _ = store.ReleaseLockWithEvent(ctx, lock, db.BranchLockEvent{Kind: "released", Message: "released after failed task recover"})
+		}
+	}()
 	headSHA, err := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
 	if err != nil {
 		return workflow.JobPayload{}, fmt.Errorf("resolve task worktree head: %w", err)
@@ -671,6 +680,7 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		_ = finishTaskRecoverJob(ctx, store, job.ID, state, finalized, err.Error())
 		return workflow.JobPayload{}, err
 	}
+	releaseCreatedLock = false
 	finalized.Result = &workflow.AgentResult{Decision: "implemented", Summary: "Recovered implementation worktree and opened/adopted PR."}
 	if err := finishTaskRecoverJob(ctx, store, job.ID, string(workflow.JobSucceeded), finalized, "task recovery finalized implementation"); err != nil {
 		return workflow.JobPayload{}, err
@@ -792,22 +802,23 @@ func taskRecoverBaseHead(ctx context.Context, store *db.Store, task db.Task, rep
 	return "", fmt.Errorf("resolve task recovery base %s: %w", base, lastErr)
 }
 
-func ensureTaskRecoverBranchLock(ctx context.Context, store *db.Store, repo string, branch string, owner string) (db.BranchLock, error) {
+func ensureTaskRecoverBranchLock(ctx context.Context, store *db.Store, repo string, branch string, owner string) (db.BranchLock, bool, error) {
 	if strings.TrimSpace(branch) == "" {
-		return db.BranchLock{}, errors.New("task recover requires a branch")
+		return db.BranchLock{}, false, errors.New("task recover requires a branch")
 	}
 	lock := db.BranchLock{RepoFullName: repo, Branch: branch, Owner: owner}
-	if _, err := store.CreateLock(ctx, lock); err != nil {
-		return db.BranchLock{}, err
+	created, err := store.CreateLock(ctx, lock)
+	if err != nil {
+		return db.BranchLock{}, false, err
 	}
 	current, err := store.GetBranchLock(ctx, repo, branch)
 	if err != nil {
-		return db.BranchLock{}, err
+		return db.BranchLock{}, false, err
 	}
 	if current.Owner != owner {
-		return db.BranchLock{}, fmt.Errorf("branch %s is locked by %s, not %s", branch, current.Owner, owner)
+		return db.BranchLock{}, false, fmt.Errorf("branch %s is locked by %s, not %s", branch, current.Owner, owner)
 	}
-	return current, nil
+	return current, created, nil
 }
 
 func taskRecoverSkipFanout(ctx context.Context, store *db.Store, repo string, branch string) bool {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -608,7 +608,7 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		return workflow.JobPayload{}, fmt.Errorf("task %s still has active implement job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
 	}
 	if strings.TrimSpace(task.WorktreePath) != "" && taskWorktreeHasLiveProcess(task.WorktreePath) {
-		return workflow.JobPayload{}, fmt.Errorf("task %s worktree %s still has a live process; wait for it to exit or stop the orphaned implementer before recovering", task.ID, task.WorktreePath)
+		return workflow.JobPayload{}, fmt.Errorf("task %s worktree %s still has a live process; wait for it to exit or stop the orphaned implementer before recovering (this can include your own shell if you are inspecting the worktree; run recovery from outside that directory)", task.ID, task.WorktreePath)
 	}
 	lock, createdLock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
 	if err != nil {

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -910,6 +910,33 @@ func TestRecoverTaskImplementationReleasesCreatedLockOnBlockedRecovery(t *testin
 	}
 }
 
+func TestRecoverTaskImplementationBlocksLiveWorktreeProcess(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: t.TempDir(), PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	worktree := filepath.Join(home, "live-worktree")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	prev := taskWorktreeHasLiveProcess
+	taskWorktreeHasLiveProcess = func(path string) bool { return path == worktree }
+	defer func() { taskWorktreeHasLiveProcess = prev }()
+
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "live process") {
+		t.Fatalf("recover live worktree err = %v, want live process", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "task-001-bootstrap"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("live worktree recovery created branch lock, err=%v", err)
+	}
+}
+
 func TestRecoverTaskImplementationBlocksActiveJobAndWrongLockOwner(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -652,6 +653,127 @@ func TestTaskRunJobMatchesDelegatedImplementJob(t *testing.T) {
 
 	if !taskRunJobMatchesRequest(job, request) {
 		t.Fatalf("taskRunJobMatchesRequest returned false for delegated task-run job")
+	}
+}
+
+func TestRunTaskRunDirtyTaskWorktreeSuggestsRecover(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	withWorkingDirectory(t, repoDir)
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(context.Background(), db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(context.Background(), db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(paths.Home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "partial work\n")
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"task", "run", "task-001", "--home", home, "--repo", "owner/repo", "--owner", "lead"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("task run exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "worktree has uncommitted changes") || !strings.Contains(stderr.String(), "gitmoot task recover task-001") {
+		t.Fatalf("stderr missing recovery guidance:\n%s", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "UNIQUE constraint") || strings.Contains(stderr.String(), "checkout_contention") {
+		t.Fatalf("stderr contains the old failure mode:\n%s", stderr.String())
+	}
+}
+
+type stubTaskRecoverGitHub struct {
+	github.NoopClient
+	input github.CreatePullRequestInput
+}
+
+func (s *stubTaskRecoverGitHub) EnsurePullRequest(_ context.Context, input github.CreatePullRequestInput) (github.PullRequest, error) {
+	s.input = input
+	return github.PullRequest{
+		Number:  4,
+		URL:     "https://github.com/owner/repo/pull/4",
+		HeadRef: input.Head,
+		BaseRef: input.Base,
+		State:   "open",
+	}, nil
+}
+
+func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", RemoteURL: remoteDir, CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "partial work\n")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	gh := &stubTaskRecoverGitHub{}
+	payload, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, gh)
+	if err != nil {
+		t.Fatalf("recoverTaskImplementation returned error: %v", err)
+	}
+	if payload.PullRequest != 4 || payload.Branch != "task-001-bootstrap" || payload.HeadSHA == "" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if gh.input.Head != "task-001-bootstrap" || gh.input.Base != "main" {
+		t.Fatalf("EnsurePullRequest input = %+v", gh.input)
+	}
+	if status := strings.TrimSpace(runGitOutput(t, worktree, "status", "--porcelain")); status != "" {
+		t.Fatalf("worktree still dirty after recover:\n%s", status)
+	}
+	remoteHead := strings.TrimSpace(runGitOutput(t, repoDir, "ls-remote", "origin", "refs/heads/task-001-bootstrap"))
+	if !strings.Contains(remoteHead, payload.HeadSHA) {
+		t.Fatalf("remote task branch %q does not contain recovered head %q", remoteHead, payload.HeadSHA)
+	}
+	pr, err := store.GetPullRequestByRepoBranch(ctx, "owner/repo", "task-001-bootstrap")
+	if err != nil {
+		t.Fatalf("GetPullRequestByRepoBranch returned error: %v", err)
+	}
+	if pr.Number != 4 || pr.HeadSHA != payload.HeadSHA {
+		t.Fatalf("stored PR = %+v, payload=%+v", pr, payload)
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -687,7 +687,7 @@ func TestRunTaskRunDirtyTaskWorktreeSuggestsRecover(t *testing.T) {
 	}
 	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
 	writeFile(t, filepath.Join(worktree, "feature.txt"), "partial work\n")
-	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskPlanned), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
 
@@ -701,6 +701,16 @@ func TestRunTaskRunDirtyTaskWorktreeSuggestsRecover(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "UNIQUE constraint") || strings.Contains(stderr.String(), "checkout_contention") {
 		t.Fatalf("stderr contains the old failure mode:\n%s", stderr.String())
+	}
+	task, err := store.GetTask(context.Background(), "task-001")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskPlanned) {
+		t.Fatalf("task state mutated to %q, want planned", task.State)
+	}
+	if _, err := store.GetBranchLock(context.Background(), "owner/repo", "task-001-bootstrap"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("dirty refusal created branch lock, err=%v", err)
 	}
 }
 
@@ -740,6 +750,9 @@ func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
 	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", RemoteURL: remoteDir, CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
 		t.Fatalf("UpsertRepo returned error: %v", err)
 	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
 	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
 	if err != nil {
 		t.Fatalf("TaskWorktreePath returned error: %v", err)
@@ -751,7 +764,7 @@ func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
 	}
 
 	gh := &stubTaskRecoverGitHub{}
-	payload, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, gh)
+	payload, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", true, gh)
 	if err != nil {
 		t.Fatalf("recoverTaskImplementation returned error: %v", err)
 	}
@@ -774,6 +787,116 @@ func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
 	}
 	if pr.Number != 4 || pr.HeadSHA != payload.HeadSHA {
 		t.Fatalf("stored PR = %+v, payload=%+v", pr, payload)
+	}
+	if lock, err := store.GetBranchLock(ctx, "owner/repo", "task-001-bootstrap"); err != nil || lock.Owner != "lead" || !lock.SkipNativeReviewFanout {
+		t.Fatalf("branch lock = %+v err=%v, want owner lead with skip native fanout", lock, err)
+	}
+	job, err := store.GetJob(ctx, "task-task-001-recover-lead")
+	if err != nil {
+		t.Fatalf("GetJob recovery audit row returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("recovery job state = %q, want succeeded", job.State)
+	}
+}
+
+func TestRecoverTaskImplementationFinalizesCleanCommittedWorktree(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", RemoteURL: remoteDir, CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "committed work\n")
+	runGit(t, worktree, "add", "feature.txt")
+	runGit(t, worktree, "commit", "-m", "finished work")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	gh := &stubTaskRecoverGitHub{}
+	payload, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, gh)
+	if err != nil {
+		t.Fatalf("recoverTaskImplementation returned error: %v", err)
+	}
+	if payload.PullRequest != 4 || payload.HeadSHA == "" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	remoteHead := strings.TrimSpace(runGitOutput(t, repoDir, "ls-remote", "origin", "refs/heads/task-001-bootstrap"))
+	if !strings.Contains(remoteHead, payload.HeadSHA) {
+		t.Fatalf("remote task branch %q does not contain recovered head %q", remoteHead, payload.HeadSHA)
+	}
+}
+
+func TestRecoverTaskImplementationBlocksActiveJobAndWrongLockOwner(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "partial work\n")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	activePayload, err := json.Marshal(workflow.JobPayload{Repo: "owner/repo", Branch: "task-001-bootstrap", TaskID: "task-001"})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "active-implement", Agent: "lead", Type: "implement", State: string(workflow.JobRunning), Payload: string(activePayload)}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "active implement job") {
+		t.Fatalf("recover with active job err = %v, want active implement job", err)
+	}
+	if err := store.UpdateJobState(ctx, "active-implement", string(workflow.JobFailed)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	if _, err := store.CreateLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-001-bootstrap", Owner: "other"}); err != nil {
+		t.Fatalf("CreateLock returned error: %v", err)
+	}
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "locked by other") {
+		t.Fatalf("recover with wrong lock owner err = %v, want locked by other", err)
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -849,6 +849,67 @@ func TestRecoverTaskImplementationFinalizesCleanCommittedWorktree(t *testing.T) 
 	}
 }
 
+func TestRecoverTaskImplementationRejectsMergedTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-001",
+		RepoFullName: "owner/repo",
+		State:        string(workflow.TaskMerged),
+		Branch:       "task-001-bootstrap",
+		WorktreePath: filepath.Join(home, "worktree"),
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "state merged") {
+		t.Fatalf("recover merged task err = %v, want state merged", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "task-001-bootstrap"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("terminal task recovery created branch lock, err=%v", err)
+	}
+}
+
+func TestRecoverTaskImplementationReleasesCreatedLockOnBlockedRecovery(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "no recoverable commit") {
+		t.Fatalf("recover clean base task err = %v, want no recoverable commit", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "task-001-bootstrap"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("blocked recovery leaked created branch lock, err=%v", err)
+	}
+}
+
 func TestRecoverTaskImplementationBlocksActiveJobAndWrongLockOwner(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -318,6 +318,22 @@ func (c Client) HeadSHA(ctx context.Context) (string, error) {
 	return sha, nil
 }
 
+func (c Client) RevParse(ctx context.Context, rev string) (string, error) {
+	rev = strings.TrimSpace(rev)
+	if rev == "" {
+		return "", errors.New("git revision is required")
+	}
+	result, err := c.run(ctx, "rev-parse", rev)
+	if err != nil {
+		return "", err
+	}
+	sha := strings.TrimSpace(result.Stdout)
+	if sha == "" {
+		return "", errors.New("git revision SHA is empty")
+	}
+	return sha, nil
+}
+
 func (c Client) UpdateBase(ctx context.Context, remote string, branch string) error {
 	if strings.TrimSpace(remote) == "" {
 		remote = "origin"

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -138,12 +139,11 @@ func SupportedRuntimes() []string {
 }
 
 // FreshRefPrefix marks a runtime reference that names no existing session:
-// "fresh:<uuid>". A delivery against a fresh ref must start a brand-new
+// "fresh:<suffix>". A delivery against a fresh ref must start a brand-new
 // session on its runtime and must never resume (or write back to) any stored
-// session. The uuid suffix exists so each fresh ref — and therefore each
-// runtime-session lock key derived from it — is unique per job; adapters do
-// not reuse it as the actual CLI session id. Minted by the per-job --runtime
-// override path (#531) when no explicit session is given.
+// session. The suffix scopes runtime-session lock keys; per-job override refs
+// are unique when minted, and registered fresh refs are rewritten to a job
+// scoped ref before execution.
 const FreshRefPrefix = "fresh:"
 
 // NewFreshRef mints a unique fresh-session runtime reference (see
@@ -161,15 +161,23 @@ func IsFreshRef(ref string) bool {
 	return strings.HasPrefix(ref, FreshRefPrefix)
 }
 
+// FreshRefForJob returns a deterministic fresh-session ref scoped to a job id.
+// This lets a registered "fresh:<seat>" agent get a separate runtime lock and
+// CLI session per job instead of sharing one lock across all jobs.
+func FreshRefForJob(jobID string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(jobID)))
+	return FreshRefPrefix + "job:" + hex.EncodeToString(sum[:8])
+}
+
 func ValidateAgent(agent Agent) error {
 	if err := validateAgentFields(agent, true); err != nil {
 		return err
 	}
 	if agent.Runtime == ClaudeRuntime && agent.RuntimeRef != LastRef && !isUUID(agent.RuntimeRef) && !IsFreshRef(agent.RuntimeRef) {
-		return fmt.Errorf("claude runtime reference %q must be a UUID, last, or fresh:<uuid>", agent.RuntimeRef)
+		return fmt.Errorf("claude runtime reference %q must be a UUID, last, or fresh:<suffix>", agent.RuntimeRef)
 	}
 	if isKimiRuntime(agent.Runtime) && agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) && !IsFreshRef(agent.RuntimeRef) {
-		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<uuid>, or empty", agent.RuntimeRef)
+		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<suffix>, or empty", agent.RuntimeRef)
 	}
 	return nil
 }
@@ -355,7 +363,12 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 	// Usage is attributable to this job when the session belongs to it alone:
 	// a fresh ref (brand-new session, no resume) or a single-use session
 	// (ephemeral/temp workers — started for the job, disposed after it).
-	return codexDeliverResult(result.Stdout, IsFreshRef(agent.RuntimeRef) || agent.SingleUseSession), nil
+	freshSession := IsFreshRef(agent.RuntimeRef) || agent.SingleUseSession
+	parsed := codexDeliverResult(result.Stdout, freshSession)
+	if IsFreshRef(agent.RuntimeRef) {
+		parsed.RefreshedRuntimeRef = parseCodexThreadID(result.Stdout)
+	}
+	return parsed, nil
 }
 
 // codexDeliverArgs builds the `codex exec` argument vector for a Deliver call.
@@ -431,6 +444,28 @@ func codexDeliverResult(stdout string, freshSession bool) Result {
 		inputTokens, outputTokens = 0, 0
 	}
 	return Result{Raw: raw, Summary: strings.TrimSpace(raw), InputTokens: inputTokens, OutputTokens: outputTokens}
+}
+
+func parseCodexThreadID(output string) string {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var event struct {
+			Type     string `json:"type"`
+			ThreadID string `json:"thread_id"`
+		}
+		if json.Unmarshal([]byte(line), &event) != nil {
+			continue
+		}
+		if event.Type == "thread.started" && strings.TrimSpace(event.ThreadID) != "" {
+			return strings.TrimSpace(event.ThreadID)
+		}
+	}
+	return ""
 }
 
 func (a CodexAdapter) Health(ctx context.Context, agent Agent) error {
@@ -660,13 +695,14 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 // fresh-ref path, #531). Each attempt mints a NEW session id, mirroring the
 // #443 self-heal shape (claudeFreshSessionArgs — never --resume/--continue),
 // so a transient-401 retry can never trip over an already-created session id.
-// It intentionally returns no RefreshedRuntimeRef: a fresh-ref delivery is
-// one-shot and must never re-pin the agent's stored session.
+// It returns the successful concrete session id as RefreshedRuntimeRef so
+// malformed-output repair prompts in the same job resume that isolated job
+// session. The mailbox guards registered fresh refs from being re-pinned.
 func (a ClaudeAdapter) deliverFresh(ctx context.Context, agent Agent, job Job, model string) (Result, error) {
 	var result subprocess.Result
 	var err error
+	var sessionID string
 	for attempt := 1; ; attempt++ {
-		var sessionID string
 		sessionID, err = a.newRuntimeRef()
 		if err != nil {
 			return Result{}, err
@@ -682,7 +718,7 @@ func (a ClaudeAdapter) deliverFresh(ctx context.Context, agent Agent, job Job, m
 	if err != nil {
 		return Result{Raw: result.Stdout + result.Stderr}, claudeCommandError(result, err)
 	}
-	parsed := Result{Raw: result.Stdout}
+	parsed := Result{Raw: result.Stdout, RefreshedRuntimeRef: sessionID}
 	summary, inTok, outTok := parseClaudeJSONResult(result.Stdout)
 	if summary != "" {
 		parsed.Summary = summary

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -562,6 +562,13 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 	if IsFreshRef(agent.RuntimeRef) {
 		return a.deliverFresh(ctx, agent, job, model)
 	}
+	// Template-backed Claude agents are coordinator-class jobs: they execute a
+	// long-form prompt recipe and must never resume whichever interactive Claude
+	// session happens to be "last". Treat a legacy --session last registration as
+	// a per-job temp session instead of --continue.
+	if agent.RuntimeRef == LastRef && strings.TrimSpace(agent.TemplateID) != "" {
+		return a.deliverFresh(ctx, agent, job, model)
+	}
 	// The Claude CLI intermittently fails a delivery with a transient
 	// "401 socket connection was closed unexpectedly" under sustained
 	// concurrency; a byte-identical retry typically clears it. Retry on that

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -621,6 +621,40 @@ func TestClaudeDeliverLastSessionCommand(t *testing.T) {
 	runner.want(t, 0, "claude", "--continue", "-p", "--output-format", "json", "--", "review")
 }
 
+func TestClaudeTemplateAgentIgnoresLastSession(t *testing.T) {
+	minted := "550e8400-e29b-41d4-a716-446655440099"
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"coordinated"}`}}}
+	adapter := ClaudeAdapter{
+		Runner: runner,
+		NewRuntimeRef: func() (string, error) {
+			return minted, nil
+		},
+	}
+	agent := Agent{
+		Name:       "lead",
+		Role:       "agent",
+		Runtime:    ClaudeRuntime,
+		RuntimeRef: LastRef,
+		RepoScope:  "jerryfane/gitmoot",
+		TemplateID: "coordinator",
+		Model:      "opus",
+	}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "coordinate"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "coordinated" {
+		t.Fatalf("Summary = %q, want coordinated", result.Summary)
+	}
+	runner.want(t, 0, "claude", "--model", "opus", "--session-id", minted, "-p", "--output-format", "json", "--", "coordinate")
+	for _, arg := range runner.calls[0] {
+		if arg == "--continue" || arg == "--resume" {
+			t.Fatalf("template-backed Claude last agent must use an isolated session, got %v", runner.calls[0])
+		}
+	}
+}
+
 func TestClaudeDeliverCommandAppliesAutonomyPolicy(t *testing.T) {
 	for _, tt := range []struct {
 		name   string

--- a/internal/runtime/fresh_ref_test.go
+++ b/internal/runtime/fresh_ref_test.go
@@ -60,6 +60,22 @@ func TestNewFreshRef(t *testing.T) {
 	}
 }
 
+func TestFreshRefForJob(t *testing.T) {
+	ref := FreshRefForJob("local-ask-a/delegation/review-codex")
+	if !IsFreshRef(ref) {
+		t.Fatalf("FreshRefForJob() = %q, want fresh ref", ref)
+	}
+	if !strings.HasPrefix(ref, FreshRefPrefix+"job:") {
+		t.Fatalf("FreshRefForJob() = %q, want job-scoped suffix", ref)
+	}
+	if other := FreshRefForJob("local-ask-b/delegation/review-codex"); other == ref {
+		t.Fatalf("different jobs must get different fresh refs: %q", ref)
+	}
+	if again := FreshRefForJob("local-ask-a/delegation/review-codex"); again != ref {
+		t.Fatalf("FreshRefForJob must be deterministic: %q != %q", again, ref)
+	}
+}
+
 // TestValidateAgentAcceptsFreshRefs: the session-safety path mints fresh refs
 // for claude/kimi override jobs; agent validation must accept them.
 func TestValidateAgentAcceptsFreshRefs(t *testing.T) {
@@ -83,7 +99,12 @@ func TestCodexDeliverFreshRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFreshRef returned error: %v", err)
 	}
-	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "fresh output"}}}
+	stdout := strings.Join([]string{
+		`{"type":"thread.started","thread_id":"codex-thread-123"}`,
+		`{"type":"item.completed","item":{"type":"agent_message","text":"fresh output"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":7,"output_tokens":5}}`,
+	}, "\n")
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
 	adapter := CodexAdapter{Runner: runner}
 	agent := Agent{Name: "audit", Role: "reviewer", Runtime: CodexRuntime, RuntimeRef: ref, RepoScope: "jerryfane/gitmoot"}
 
@@ -94,6 +115,9 @@ func TestCodexDeliverFreshRef(t *testing.T) {
 	if result.Raw != "fresh output" {
 		t.Fatalf("Raw = %q", result.Raw)
 	}
+	if result.RefreshedRuntimeRef != "codex-thread-123" {
+		t.Fatalf("RefreshedRuntimeRef = %q, want codex thread id", result.RefreshedRuntimeRef)
+	}
 	runner.want(t, 0, "codex", "exec", "--json", "--model", "gpt-5.5-codex", "--", "do the thing")
 	for _, arg := range runner.calls[0] {
 		if arg == "resume" {
@@ -103,8 +127,9 @@ func TestCodexDeliverFreshRef(t *testing.T) {
 }
 
 // TestClaudeDeliverFreshRef: a fresh ref must deliver on a brand-new dedicated
-// --session-id (never --resume/--continue), never return a RefreshedRuntimeRef
-// (nothing may be re-pinned), and pass the per-job model through.
+// --session-id (never --resume/--continue), return that concrete session id so
+// same-job repair prompts resume the isolated job session, and pass the per-job
+// model through.
 func TestClaudeDeliverFreshRef(t *testing.T) {
 	ref, err := NewFreshRef()
 	if err != nil {
@@ -122,8 +147,8 @@ func TestClaudeDeliverFreshRef(t *testing.T) {
 	if result.Summary != "fresh claude output" {
 		t.Fatalf("Summary = %q", result.Summary)
 	}
-	if result.RefreshedRuntimeRef != "" {
-		t.Fatalf("fresh-ref delivery must not re-pin any session, got RefreshedRuntimeRef = %q", result.RefreshedRuntimeRef)
+	if result.RefreshedRuntimeRef != minted {
+		t.Fatalf("RefreshedRuntimeRef = %q, want minted fresh session %q", result.RefreshedRuntimeRef, minted)
 	}
 	runner.want(t, 0, "claude", "--model", "claude-opus-4", "--session-id", minted, "-p", "--output-format", "json", "--", "do the thing")
 	for _, arg := range runner.calls[0] {

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -61,7 +61,7 @@ func (a KimiAdapter) Validate(_ context.Context, agent Agent) error {
 		return err
 	}
 	if agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) && !IsFreshRef(agent.RuntimeRef) {
-		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<uuid>, or empty", agent.RuntimeRef)
+		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<suffix>, or empty", agent.RuntimeRef)
 	}
 	return nil
 }
@@ -159,7 +159,7 @@ func (a KimiCLIAdapter) Validate(_ context.Context, agent Agent) error {
 		return err
 	}
 	if agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) && !IsFreshRef(agent.RuntimeRef) {
-		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<uuid>, or empty", agent.RuntimeRef)
+		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<suffix>, or empty", agent.RuntimeRef)
 	}
 	return nil
 }

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -502,6 +502,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 		return AgentResult{}, err
 	}
 
+	registeredFreshRef := runtime.IsFreshRef(agent.RuntimeRef)
 	prompt := prompts.RenderJob(payload.prompt(job.Type))
 	// Append the off-by-default "Prior learnings" memory block (#626 READ path).
 	// When the memory hook is unset (every non-enrolled path) or returns "" (no
@@ -545,7 +546,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	// belongs to the DEFAULT runtime, and persisting an override-runtime ref
 	// there would corrupt the agent's session identity. The refreshed ref is
 	// still adopted in-memory below so repair retries stay coherent.
-	if payload.RuntimeOverride == "" {
+	if payload.RuntimeOverride == "" && !registeredFreshRef {
 		m.persistRefreshedRuntimeRef(ctx, job.ID, agent, firstRefreshedRef)
 	}
 	// If the first delivery self-healed a dead session (#443), adopt the freshly
@@ -601,7 +602,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			}
 			// Same #531 override guard as the first delivery: never persist an
 			// override-runtime ref onto the agent's default-runtime resume state.
-			if payload.RuntimeOverride == "" {
+			if payload.RuntimeOverride == "" && !registeredFreshRef {
 				m.persistRefreshedRuntimeRef(ctx, job.ID, agent, repairRefreshedRef)
 			}
 			// Adopt a freshly minted session ref so the next repair re-ask resumes the

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -681,6 +681,55 @@ func TestMailboxRunRepairRetryResumesRefreshedRef(t *testing.T) {
 	}
 }
 
+func TestMailboxRunFreshRefRepairUsesConcreteSessionWithoutPersisting(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	freshRef := "fresh:council-codex"
+	concreteRef := "codex-thread-123"
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:       "shipper",
+		Role:       "implementer",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: freshRef,
+		RepoScope:  "jerryfane/gitmoot",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	agent := runtime.Agent{Name: "shipper", Runtime: runtime.CodexRuntime, RuntimeRef: freshRef, RepoScope: "jerryfane/gitmoot", Role: "implementer"}
+	adapter := &fakeDelivery{
+		outputs: []string{
+			"fresh job session but no json",
+			`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["x"],"tests_run":[],"needs":[],"delegations":[]}}`,
+		},
+		refreshedRefs: []string{concreteRef},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "shipper", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(adapter.agentRefs) != 2 {
+		t.Fatalf("deliveries = %d, want 2", len(adapter.agentRefs))
+	}
+	if adapter.agentRefs[0] != freshRef {
+		t.Fatalf("first delivery ref = %q, want registered fresh ref", adapter.agentRefs[0])
+	}
+	if adapter.agentRefs[1] != concreteRef {
+		t.Fatalf("repair delivery ref = %q, want concrete job session", adapter.agentRefs[1])
+	}
+	stored, err := store.GetAgent(ctx, "shipper")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if stored.RuntimeRef != freshRef {
+		t.Fatalf("stored runtime_ref = %q, want registered fresh ref %q", stored.RuntimeRef, freshRef)
+	}
+}
+
 func TestMailboxRunNoRefreshLeavesRefUnchanged(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/workflow/runtime_owner_liveness.go
+++ b/internal/workflow/runtime_owner_liveness.go
@@ -83,6 +83,14 @@ func (e Engine) worktreeHasLiveProcess(path string) bool {
 	return defaultWorktreeHasLiveProcess(path)
 }
 
+// WorktreeHasLiveProcess exposes the same conservative /proc cwd liveness probe
+// used by destructive worktree cleanup to CLI recovery/dispatch paths. It is
+// intentionally best-effort: false means "no same-host cwd owner observed", not a
+// proof that no external process can write.
+func WorktreeHasLiveProcess(path string) bool {
+	return defaultWorktreeHasLiveProcess(path)
+}
+
 // defaultWorktreeHasLiveProcess is a best-effort Linux /proc scan: it returns true
 // when any process's cwd symlink resolves to path or a descendant of it. The codex
 // resume worker in #536 ran with cwd == the delegation worktree, so its presence is


### PR DESCRIPTION
This PR contains reliability fixes found while running external orchestrators/council jobs.

- Treat registered fresh runtime refs as per-job isolated sessions and persist the concrete returned session/thread id for the job, so repair/validation resumes the same job session without using ambient/interactive sessions.
- Reuse an existing task row when local implement dispatch is retried with the same repo+branch and no task id, avoiding a UNIQUE constraint failure on tasks.repo_full_name/tasks.branch after a prior implement died mid-work.
- Add explicit task implement recovery: gitmoot task recover <id> reuses the implementation finalizer to commit dirty task worktree edits, push the branch, and open/adopt the PR. task run now refuses to enqueue a fresh implement against a dirty task worktree when no matching active task-run job exists, and prints the recovery command instead of letting the daemon loop on checkout_contention.

Tests run:
- GOCACHE=/tmp/gitmoot-go-cache GOMODCACHE=/tmp/gitmoot-go-mod /home/smith/.local/go/bin/go test ./internal/cli -run 'TestPrepareLocal(Implement|Review)DispatchRequest' -count=1
- GOCACHE=/tmp/gitmoot-go-cache GOMODCACHE=/tmp/gitmoot-go-mod /home/smith/.local/go/bin/go test ./internal/cli -run 'TestRunTaskRun|TestTaskRunJobMatchesDelegatedImplementJob|TestDaemonImplementationFinalizer|TestRecoverTaskImplementationFinalizesDirtyWorktree' -count=1
- GOCACHE=/tmp/gitmoot-go-cache GOMODCACHE=/tmp/gitmoot-go-mod /home/smith/.local/go/bin/go build -o /tmp/gitmoot-new ./cmd/gitmoot