### PR TITLE
fix(workflow): project delegation job budget before enqueuing a batch (#649)

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1928,6 +1928,68 @@ func (e Engine) rootJobCountForPressure(ctx context.Context, rootID string) int 
 	return count
 }
 
+// projectedNewDelegationJobs computes how many NEW child jobs the given
+// delegation batch would add to a coordination tree — the count used by the
+// #649 projected, all-or-nothing job-budget admission in dispatchDelegations.
+// Unlike the reactive token/cost budgets (which cannot know an unspawned child's
+// usage), the job count is exactly projectable before enqueue, so the whole
+// batch is admitted or refused as one unit against the live tree count.
+//
+// A leg contributes 0 when it is already accounted for in that live count, so
+// re-advancing a coordinator (AdvanceJob is idempotent and re-runs
+// dispatchDelegations) never double-counts children already enqueued:
+//
+//   - a leg whose child already exists under this parent is skipped — it is
+//     already inside countRootDelegationJobs;
+//   - a leg whose non-empty fingerprint already appears among an existing
+//     sibling, or earlier in THIS batch, is skipped — it folds into the winning
+//     sibling via the same dedup enqueueDelegation performs (engine.go ~2440),
+//     so it never spawns its own child.
+//
+// Deferred (deps-bearing) legs ARE counted: they escape every later job-budget
+// check (advanceDelegations/enqueueDelegation/allocateAndEnqueueDelegation do
+// not re-check the per-root job count), so the entire batch — ready and
+// deferred — must be pre-authorized here as a single unit.
+func (e Engine) projectedNewDelegationJobs(ctx context.Context, parentJobID string, dels []Delegation) (int, error) {
+	children, err := e.childDelegationJobs(ctx, parentJobID)
+	if err != nil {
+		return 0, err
+	}
+	// One scan of the existing sibling children collects the fingerprints already
+	// present, instead of a per-leg delegationFingerprintSeen query.
+	existingFingerprints := make(map[string]struct{})
+	for _, child := range children {
+		childPayload, err := unmarshalPayload(child.Payload)
+		if err != nil {
+			return 0, err
+		}
+		if fingerprint := strings.TrimSpace(childPayload.Fingerprint); fingerprint != "" {
+			existingFingerprints[fingerprint] = struct{}{}
+		}
+	}
+	batchFingerprints := make(map[string]struct{})
+	projected := 0
+	for _, d := range dels {
+		if _, exists := children[d.ID]; exists {
+			// Already enqueued on an earlier advance; counted in the live total.
+			continue
+		}
+		if fingerprint := strings.TrimSpace(d.Fingerprint); fingerprint != "" {
+			if _, seen := existingFingerprints[fingerprint]; seen {
+				// Folds into an existing same-fingerprint sibling child.
+				continue
+			}
+			if _, seen := batchFingerprints[fingerprint]; seen {
+				// Folds into an earlier same-fingerprint leg in this same batch.
+				continue
+			}
+			batchFingerprints[fingerprint] = struct{}{}
+		}
+		projected++
+	}
+	return projected, nil
+}
+
 // sumRootDelegationTokens sums the runtime token usage (input + output) across an
 // entire coordination tree: the originating coordinator itself (self-rooted to
 // rootID) plus every child or continuation whose root_id points back at it. Used
@@ -2002,12 +2064,28 @@ func (e Engine) dispatchDelegations(ctx context.Context, job db.Job, payload Job
 	if err != nil {
 		return err
 	}
+	// #649: PROJECTED, all-or-nothing job-budget admission. The old guard was
+	// reactive (`total >= maxJobs`) and only tripped once the tree was ALREADY at
+	// the cap, so a wide fan-out launched from just under the limit enqueued its
+	// whole batch and overshot MaxDelegationTotalJobs by up to (batch_width - 1).
+	// The job count is the one backstop that is exactly projectable before
+	// enqueue, so count the NEW jobs this batch would add (ready AND deferred legs
+	// — deferred legs escape every later budget check — minus already-enqueued /
+	// fingerprint-deduped legs) and refuse the WHOLE batch when the tree would
+	// cross the cap. total+projected == maxJobs ADMITS (may reach but not exceed);
+	// > maxJobs refuses. When projected == 0 (an idempotent re-advance whose legs
+	// all already have children) this admits and the enqueue loop below adds
+	// nothing new — the correct idempotent outcome, where the old guard finalized.
+	projected, err := e.projectedNewDelegationJobs(ctx, job.ID, payload.Result.Delegations)
+	if err != nil {
+		return err
+	}
 	maxJobs := effectiveMaxDelegationTotalJobs()
-	if total >= maxJobs {
+	if total+projected > maxJobs {
 		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
 			JobID:   job.ID,
 			Kind:    "delegation_budget_exceeded",
-			Message: fmt.Sprintf("delegation tree for root %s reached the job budget of %d (%d jobs); not dispatching %d delegation(s)", rootID, maxJobs, total, len(payload.Result.Delegations)),
+			Message: fmt.Sprintf("delegation batch of %d new job(s) would exceed the per-root job budget of %d (tree at %d); not dispatching %d delegation(s)", projected, maxJobs, total, len(payload.Result.Delegations)),
 		})
 		return e.enqueueFinalizeContinuation(ctx, job, payload, fmt.Sprintf("per-root job budget of %d reached", maxJobs))
 	}
@@ -2945,6 +3023,12 @@ func (e Engine) advanceDelegations(ctx context.Context, parentJob db.Job, parent
 			if e.InjectUpstreamDepContext {
 				upstreamContext = e.buildUpstreamDepBlock(d, children, dedupWinners)
 			}
+			// No per-root job-budget re-check here: the whole batch (ready +
+			// deferred) was pre-authorized as one unit by the #649 projected
+			// admission in dispatchDelegations (projectedNewDelegationJobs counts
+			// deferred legs), so this deferred enqueue is intentionally uncapped —
+			// a late refusal here would strand a deferred leg whose refused
+			// sibling deps can never satisfy.
 			if err := e.enqueueDelegation(ctx, parentJob, parentPayload, d, artifactDir, upstreamContext, ref); err != nil {
 				return err
 			}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3752,6 +3752,262 @@ func TestEngineDelegationWidthCapStopsDispatch(t *testing.T) {
 	}
 }
 
+// TestEngineDelegationBudgetProjectedRefusesBatchJustUnderCap is the #649 core
+// acceptance test: a tree at total = maxJobs-1 that returns a width-2 dep-free
+// batch would cross the cap, so the WHOLE batch is refused BEFORE any child is
+// enqueued (the old reactive `total >= maxJobs` guard let it through and
+// overshot). Fails on unpatched main, where the dep-free legs would enqueue.
+func TestEngineDelegationBudgetProjectedRefusesBatchJustUnderCap(t *testing.T) {
+	t.Setenv("GITMOOT_MAX_DELEGATION_TOTAL_JOBS", "3")
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// Tree at total = maxJobs-1 = 2: the coordinator (self-roots) plus one filler.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", TaskTitle: "Parent", Sender: "coord",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "done",
+			Delegations: []Delegation{
+				{ID: "w1", Agent: "w", Action: "review", Prompt: "do work a"},
+				{ID: "w2", Agent: "w", Action: "review", Prompt: "do work b"},
+			},
+		},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "root-job/filler/1", Agent: "w", Type: "review"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", Sender: "coord", RootJobID: "root-job",
+	})
+	if count, err := engine.countRootDelegationJobs(ctx, "root-job"); err != nil || count != 2 {
+		t.Fatalf("precondition countRootDelegationJobs = %d (err %v), want 2", count, err)
+	}
+
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root): %v", err)
+	}
+
+	// A width-2 batch would push the tree to 4 > 3: nothing in the batch enqueues.
+	if jobExists(t, store, "root-job/delegation/w1") || jobExists(t, store, "root-job/delegation/w2") {
+		t.Fatal("projected admission must refuse the whole batch before any child is enqueued")
+	}
+	// The tree grew only by the finalize continuation (+1), never by a child.
+	if count, err := engine.countRootDelegationJobs(ctx, "root-job"); err != nil || count != 3 {
+		t.Fatalf("countRootDelegationJobs after refusal = %d (err %v), want 3 (2 + finalize continuation)", count, err)
+	}
+	if !jobExists(t, store, delegationContinuationID("root-job")) {
+		t.Fatal("refusal must enqueue the finalize continuation")
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_budget_exceeded"); got != 1 {
+		t.Fatalf("delegation_budget_exceeded event count = %d, want 1", got)
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_finalize_enqueued"); got != 1 {
+		t.Fatalf("delegation_finalize_enqueued event count = %d, want 1", got)
+	}
+}
+
+// TestEngineDelegationBudgetProjectedAdmitsExactFit pins the boundary: a batch
+// whose projected new jobs bring the tree to EXACTLY maxJobs is admitted whole
+// (reach-but-not-exceed), so every leg enqueues.
+func TestEngineDelegationBudgetProjectedAdmitsExactFit(t *testing.T) {
+	t.Setenv("GITMOOT_MAX_DELEGATION_TOTAL_JOBS", "4")
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// Tree at total = maxJobs-2 = 2: coordinator + one filler.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", TaskTitle: "Parent", Sender: "coord",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "done",
+			Delegations: []Delegation{
+				{ID: "w1", Agent: "w", Action: "review", Prompt: "do work a"},
+				{ID: "w2", Agent: "w", Action: "review", Prompt: "do work b"},
+			},
+		},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "root-job/filler/1", Agent: "w", Type: "review"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", Sender: "coord", RootJobID: "root-job",
+	})
+
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root): %v", err)
+	}
+
+	// 2 + 2 == 4 == maxJobs: both legs enqueue; the tree reaches but does not exceed.
+	if !jobExists(t, store, "root-job/delegation/w1") || !jobExists(t, store, "root-job/delegation/w2") {
+		t.Fatal("an exact-fit batch (total+projected == maxJobs) must admit every leg")
+	}
+	if count, err := engine.countRootDelegationJobs(ctx, "root-job"); err != nil || count != 4 {
+		t.Fatalf("countRootDelegationJobs after admit = %d (err %v), want 4 (== maxJobs)", count, err)
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_budget_exceeded"); got != 0 {
+		t.Fatalf("delegation_budget_exceeded event count = %d, want 0 (admitted)", got)
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_finalize_enqueued"); got != 0 {
+		t.Fatalf("delegation_finalize_enqueued event count = %d, want 0 (admitted)", got)
+	}
+}
+
+// TestEngineDelegationBudgetProjectedCountsDeferredLegs covers the critical
+// secondary path: deferred (deps-bearing) legs escape every later budget check,
+// so the projection must count them at admission. A tree at total = maxJobs-1
+// with a batch of 1 ready + 1 deferred leg projects 2 → the whole batch is
+// refused, and NOT EVEN the ready leg enqueues. On unpatched main the ready leg
+// would enqueue (total 2 < 3) and the deferred leg would later escape the cap.
+func TestEngineDelegationBudgetProjectedCountsDeferredLegs(t *testing.T) {
+	t.Setenv("GITMOOT_MAX_DELEGATION_TOTAL_JOBS", "3")
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// Tree at total = maxJobs-1 = 2.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", TaskTitle: "Parent", Sender: "coord",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "done",
+			Delegations: []Delegation{
+				{ID: "ready", Agent: "w", Action: "review", Prompt: "ready leg"},
+				{ID: "deferred", Agent: "w", Action: "review", Prompt: "deferred leg", Deps: []string{"ready"}},
+			},
+		},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "root-job/filler/1", Agent: "w", Type: "review"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", Sender: "coord", RootJobID: "root-job",
+	})
+
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root): %v", err)
+	}
+
+	// projected counts the deferred leg (2 total > 1 slot): whole batch refused,
+	// so even the dep-free ready leg does not enqueue.
+	if jobExists(t, store, "root-job/delegation/ready") {
+		t.Fatal("counting the deferred leg must refuse the whole batch, including the ready leg")
+	}
+	if jobExists(t, store, "root-job/delegation/deferred") {
+		t.Fatal("the deferred leg must not enqueue")
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_budget_exceeded"); got != 1 {
+		t.Fatalf("delegation_budget_exceeded event count = %d, want 1", got)
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_finalize_enqueued"); got != 1 {
+		t.Fatalf("delegation_finalize_enqueued event count = %d, want 1", got)
+	}
+}
+
+// TestEngineDelegationBudgetProjectedDedupNearBoundary pins that the projection
+// dedups shared-fingerprint legs (parity with enqueueDelegation): a width-3
+// batch with two same-fingerprint legs projects 2 unique children, which fits
+// the remaining budget and is admitted. A naive projected = len(dels) would
+// count 3 and wrongly refuse the batch.
+func TestEngineDelegationBudgetProjectedDedupNearBoundary(t *testing.T) {
+	t.Setenv("GITMOOT_MAX_DELEGATION_TOTAL_JOBS", "4")
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	// Tree at total = maxJobs-2 = 2.
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", TaskTitle: "Parent", Sender: "coord",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "done",
+			Delegations: []Delegation{
+				{ID: "d1", Agent: "w", Action: "review", Prompt: "work", Fingerprint: "shared-fp"},
+				{ID: "d2", Agent: "w", Action: "review", Prompt: "work again", Fingerprint: "shared-fp"},
+				{ID: "d3", Agent: "w", Action: "review", Prompt: "distinct", Fingerprint: "other-fp"},
+			},
+		},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "root-job/filler/1", Agent: "w", Type: "review"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", Sender: "coord", RootJobID: "root-job",
+	})
+
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root): %v", err)
+	}
+
+	// projected = 2 (d2 folds into d1's fingerprint); 2 + 2 == 4 == maxJobs: admit.
+	if !jobExists(t, store, "root-job/delegation/d1") {
+		t.Fatal("the first same-fingerprint leg must enqueue")
+	}
+	if jobExists(t, store, "root-job/delegation/d2") {
+		t.Fatal("the second same-fingerprint leg must be deduped, not enqueued")
+	}
+	if !jobExists(t, store, "root-job/delegation/d3") {
+		t.Fatal("the distinct-fingerprint leg must enqueue (dedup must not over-refuse the batch)")
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_deduped"); got != 1 {
+		t.Fatalf("delegation_deduped event count = %d, want 1", got)
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_budget_exceeded"); got != 0 {
+		t.Fatalf("delegation_budget_exceeded event count = %d, want 0 (dedup keeps it under the cap)", got)
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_finalize_enqueued"); got != 0 {
+		t.Fatalf("delegation_finalize_enqueued event count = %d, want 0", got)
+	}
+}
+
+// TestEngineDelegationBudgetProjectedIdempotentReadvance guards the
+// skip-existing-children rule: after a successful admit, re-advancing the
+// coordinator must project 0 new jobs (every leg already has a child) so the
+// tree neither grows nor spuriously finalizes. A projection that forgot to skip
+// already-enqueued children would double-count them and falsely trip the budget.
+func TestEngineDelegationBudgetProjectedIdempotentReadvance(t *testing.T) {
+	t.Setenv("GITMOOT_MAX_DELEGATION_TOTAL_JOBS", "4")
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coord", []string{"ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "w", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+
+	insertCompletedJob(t, store, db.Job{ID: "root-job", Agent: "coord", Type: "ask"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", TaskTitle: "Parent", Sender: "coord",
+		Result: &AgentResult{
+			Decision: "approved", Summary: "done",
+			Delegations: []Delegation{
+				{ID: "w1", Agent: "w", Action: "review", Prompt: "do work a"},
+				{ID: "w2", Agent: "w", Action: "review", Prompt: "do work b"},
+			},
+		},
+	})
+	insertCompletedJob(t, store, db.Job{ID: "root-job/filler/1", Agent: "w", Type: "review"}, JobPayload{
+		Repo: "jerryfane/gitmoot", Branch: "task-005", TaskID: "task-5", Sender: "coord", RootJobID: "root-job",
+	})
+
+	// First advance: admits both legs, tree reaches maxJobs (4).
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) first: %v", err)
+	}
+	if !jobExists(t, store, "root-job/delegation/w1") || !jobExists(t, store, "root-job/delegation/w2") {
+		t.Fatal("first advance must enqueue both legs")
+	}
+	if count, err := engine.countRootDelegationJobs(ctx, "root-job"); err != nil || count != 4 {
+		t.Fatalf("countRootDelegationJobs after first advance = %d (err %v), want 4", count, err)
+	}
+
+	// Re-advance the coordinator: projected == 0 (both legs already have children),
+	// so the tree is at the cap but admits (nothing new) — no spurious finalize.
+	if err := engine.AdvanceJob(ctx, "root-job"); err != nil {
+		t.Fatalf("AdvanceJob(root) re-advance: %v", err)
+	}
+	if count, err := engine.countRootDelegationJobs(ctx, "root-job"); err != nil || count != 4 {
+		t.Fatalf("countRootDelegationJobs after re-advance = %d (err %v), want 4 (unchanged)", count, err)
+	}
+	if got := countJobEvents(t, store, "root-job", "delegation_budget_exceeded"); got != 0 {
+		t.Fatalf("delegation_budget_exceeded event count = %d, want 0 (idempotent re-advance must not trip the budget)", got)
+	}
+	if jobExists(t, store, delegationContinuationID("root-job")) {
+		t.Fatal("an idempotent re-advance at the cap must NOT enqueue a finalize continuation")
+	}
+}
+
 // TestEngineDelegationEscalateThenBlockParentFoldsIntoContinuation pins the
 // contradictory-state fix: once an escalate failure has enqueued the
 // continuation, a later block_parent sibling failure must NOT also block the

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -331,7 +331,10 @@ Delegation trees are bounded so they cannot run forever:
   this depth may not delegate further. Override per host with the
   `GITMOOT_MAX_DELEGATION_DEPTH` env var (positive integer).
 - Per-root job budget: `MaxDelegationTotalJobs = 64`. The whole delegation tree
-  under one root is capped at this many jobs. Override per host with the
+  under one root is capped at this many jobs. The check is projected: a batch's
+  new jobs are counted before any child is enqueued and the whole batch is
+  refused if it would cross the cap, so a wide fan-out from just under the limit
+  does not overshoot. Override per host with the
   `GITMOOT_MAX_DELEGATION_TOTAL_JOBS` env var (positive integer).
 - Per-root wall-clock budget: `MaxDelegationWallClock = 2h`. The whole tree under
   one root is bounded in duration (measured from the root job's creation); a

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -404,7 +404,7 @@ Delegation trees are bounded so they cannot run forever:
 
 When a bound trips (a budget cap or confirmed loop), the offending delegations
 are not dispatched and the parent receives a typed lifecycle event explaining why
-(for example, "delegation tree for root <id> reached the job budget of 64").
+(for example, "delegation batch of <n> new job(s) would exceed the per-root job budget of 64").
 Rather than stopping silently, the engine then enqueues one **graceful finalize
 continuation** back to the coordinator (`delegation_finalize_enqueued`): it is
 told it cannot delegate further and asked to synthesize a best-effort final

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -227,9 +227,9 @@ cannot recurse or fan out forever:
   `human_questions[]` is byte-identical to today's behavior.
 
 When a bound trips, the offending delegations are not dispatched and the parent
-receives a typed lifecycle event explaining why (for example, the delegation tree
-for a root reached the job budget of 64). Rather than stopping silently, the
-engine then enqueues one **graceful finalize continuation**
+receives a typed lifecycle event explaining why (for example, a delegation batch
+of new jobs would exceed the per-root job budget of 64). Rather than stopping
+silently, the engine then enqueues one **graceful finalize continuation**
 (`delegation_finalize_enqueued`) back to the coordinator — told it cannot
 delegate further and asked to synthesize a best-effort final result and return
 empty delegations. That continuation is terminal: any delegations it returns are

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -133,7 +133,10 @@ cannot recurse or fan out forever:
   not delegate further.
 - Per-root job budget `MaxDelegationTotalJobs = 64`: the whole delegation tree
   under one root (all children and continuations sharing that root) is capped.
-  When a batch would exceed it, the delegations are not dispatched.
+  The check is projected: the new jobs a batch would add (ready and deferred
+  legs, minus already-enqueued/fingerprint-deduped ones) are counted before any
+  child is enqueued, so a wide fan-out from just under the cap is refused whole
+  rather than overshooting it.
 - Per-root wall-clock budget `MaxDelegationWallClock = 2h`: the whole tree under
   one root is bounded in duration (measured from the root job's creation); a
   coordinator that tries to fan out after the tree has run this long is refused

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -443,11 +443,14 @@ trips, the offending delegations are dropped rather than dispatched.
   `GITMOOT_MAX_DELEGATION_DEPTH` environment variable (positive integer).
 - **Per-root job budget (`MaxDelegationTotalJobs = 64`)**: the whole delegation
   tree under one root — all children and continuations sharing that root — is
-  capped at this many jobs. When a batch of delegations would exceed the budget,
-  it is dropped, and the parent receives a lifecycle event such as "delegation
-  tree for root &lt;id&gt; reached the job budget of 64". Override per host with
-  the `GITMOOT_MAX_DELEGATION_TOTAL_JOBS` environment variable (positive
-  integer).
+  capped at this many jobs. The check is projected: the new jobs a batch would
+  add (ready and deferred legs, minus already-enqueued or fingerprint-deduped
+  ones) are counted before any child is enqueued, so the whole batch is dropped
+  if it would cross the cap — a wide fan-out from just under the limit is refused
+  whole rather than overshooting. The parent receives a lifecycle event such as
+  "delegation batch of &lt;n&gt; new job(s) would exceed the per-root job budget
+  of 64". Override per host with the `GITMOOT_MAX_DELEGATION_TOTAL_JOBS`
+  environment variable (positive integer).
 - **Wall-clock budget (`MaxDelegationWallClock = 2h`)**: the whole delegation
   tree under one root is bounded in duration, measured from the root job's
   creation. When a coordinator tries to fan out after the tree has run longer


### PR DESCRIPTION
## What

`dispatchDelegations` gated the per-root delegation job budget reactively (`if total >= maxJobs`) and then enqueued the **whole batch**, so a wide fan-out from just under `MaxDelegationTotalJobs` overshot the cap by up to `width-1`. Worse, deps-bearing legs enqueued later by `advanceDelegations` never saw a budget check at all.

This PR switches to **projected, all-or-nothing admission**: a new `projectedNewDelegationJobs` helper counts the genuinely-new jobs a batch would create — skipping legs whose child job already exists (idempotent re-advance), deduping by fingerprint (existing siblings + batch-local), and **counting deferred deps-bearing legs** — and the batch is admitted only if `total + projected <= maxJobs`. A refusal still enqueues the terminal finalize continuation (#305 semantics preserved; the root is never stranded).

## Key decisions
- Boundary: `total+projected == maxJobs` **admits** (tree may reach, never exceed); `> maxJobs` refuses the whole batch.
- All-or-nothing (no prefix-admit): partial admission would strand deferred legs whose refused siblings can never satisfy deps and would break `synthesis_rule: quorum`.
- No budget re-check in `advanceDelegations`/`enqueueDelegation`/`allocateAndEnqueueDelegation` — the batch is pre-authorized as one unit (comment added at the deferred enqueue).
- Intentional semantic delta: `total == maxJobs` with `projected == 0` (all legs already enqueued/deduped) now **admits** instead of spuriously finalizing.
- Accepted known limit (commit body): residual TOCTOU overshoot between dispatch and deferred enqueue — same class the token/cost/wall-clock budgets already accept; atomic per-root reservation deferred as follow-up.

## Verification
- 5 new tests (all in the scoped `-race` gate): refused-just-under-cap, exact-fit admit, **deferred-legs-counted**, dedup-near-boundary, idempotent re-advance. 3 of them fail on unpatched main (bug-pinning verified).
- Existing budget/width cap tests pass unchanged.
- Adversarial 2-lens review (correctness + completeness), 2 rounds: round 1 caught a docs/event-message consistency gap (fixed); round 2 both lenses approve, zero findings.
- Full local gate green: build, `go generate` clean, vet, full `go test ./...`, `go test -race` on workflow/cli/db/daemon.
- Integrated-tree verify: this branch merged with #651/#654/#661 + main@3935688 — full gate incl. scoped race green on the union.

## Docs
`skills/gitmoot/references/SAFETY.md` + `RESULT_CONTRACT.md` and `website/docs/reference/result-contract.md` — the docs already described the projected behavior; this aligns code to docs and updates the event-message example.

## Deploy notes
Engine-only change, no schema, no config. Standard local deploy (build, mv-rename, daemon restart at idle).

Fixes #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)
