### PR TITLE
fix(workflow): warn read-only fan-out children their worktree is the committed tip (#654)

### DIFF
--- a/docs/parallel-jobs.md
+++ b/docs/parallel-jobs.md
@@ -65,6 +65,20 @@ Parallelism under `pool` is bounded by **two** independent locks:
    `ask`/`review` jobs can be auto-isolated into an ephemeral detached worktree. A
    plain, top-level same-repo `implement` job with no worktree still shares the
    `repo:<repo>` key and serializes even under `pool`.
+
+   **Read-only fan-out worktrees are the committed tip.** An auto-isolated
+   read-only worktree is a detached `git worktree add` at the **committed tip** of
+   the base branch, so it does **not** contain gitignored paths (e.g. vendored
+   clones under `repos/**`) or any uncommitted working-tree changes. This only
+   kicks in for **two or more** read-only siblings (the fan-out that would
+   otherwise serialize); a **single** read-only delegation stays in the shared
+   base checkout and sees everything. Each fan-out child's prompt now carries a
+   note with the canonical base-checkout absolute path, so a worker whose sandbox
+   can read it (e.g. codex) reaches the real tree instead of reporting a
+   working-tree feature as missing. For whole-working-tree analysis that must see
+   gitignored or uncommitted state, either run a **single** read-only delegation
+   (no fan-out → stays in the base checkout) or pass an **absolute** path to the
+   file/dir under analysis.
 2. **Runtime session lock (`runtime:<runtime>:<ref>`).** Two jobs that use the
    **same** agent/runtime session serialize on the session lock even when their
    checkouts differ. So same-repo parallelism is bounded by **distinct runtime

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -2708,6 +2708,17 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 			// may have advanced past the inherited HeadSHA. Clear it so the child
 			// validates against its own fresh worktree HEAD (see isDelegationWorktreeChild).
 			request.HeadSHA = ""
+			// The worktree is the committed tip: it omits gitignored (repos/**) and
+			// uncommitted working-tree files. Point the child at the canonical base
+			// checkout so an analysis task does not silently report working-tree state
+			// as missing (#654). Appending to Instructions keeps the payload
+			// deterministic for the idempotent-enqueue equality check, matching the
+			// #419 upstream-context pattern. Scoped to this branch only: the
+			// single-read-only, no-manager-fallback, and integration-worktree cases
+			// must NOT be pointed at the base checkout.
+			if note := readOnlyWorktreeContextNote(e.DelegationCheckout); note != "" {
+				request.Instructions += note
+			}
 		}
 	}
 

--- a/internal/workflow/readonly_worktree_test.go
+++ b/internal/workflow/readonly_worktree_test.go
@@ -254,6 +254,28 @@ func TestDispatchDelegationsTwoReadOnlySiblingsGetSeparateDetachedWorktrees(t *t
 			t.Fatalf("detached worktree ref = %q, want parent branch task-005", c.base)
 		}
 	}
+	// #654: each read-only fan-out child keeps its original prompt AND gains a
+	// worktree-context note pointing at the canonical base checkout, so a codex
+	// (or absolute-path-aware) worker reads gitignored/uncommitted files there
+	// instead of reporting them missing from the committed-tip worktree.
+	for _, tc := range []struct {
+		id      string
+		payload JobPayload
+		prompt  string
+	}{
+		{"d1", payloadOne, "audit one"},
+		{"d2", payloadTwo, "audit two"},
+	} {
+		if !strings.HasPrefix(tc.payload.Instructions, tc.prompt) {
+			t.Fatalf("%s instructions must start with the original prompt %q, got %q", tc.id, tc.prompt, tc.payload.Instructions)
+		}
+		if !strings.Contains(tc.payload.Instructions, engine.DelegationCheckout) {
+			t.Fatalf("%s instructions must carry the base-checkout path %q, got %q", tc.id, engine.DelegationCheckout, tc.payload.Instructions)
+		}
+		if !strings.Contains(tc.payload.Instructions, "COMMITTED TIP") || !strings.Contains(tc.payload.Instructions, "gitignored") {
+			t.Fatalf("%s instructions must warn about the committed-tip / gitignored worktree, got %q", tc.id, tc.payload.Instructions)
+		}
+	}
 }
 
 func TestDispatchDelegationsSingleReadOnlyDelegationStaysInSharedCheckout(t *testing.T) {
@@ -297,6 +319,12 @@ func TestDispatchDelegationsSingleReadOnlyDelegationStaysInSharedCheckout(t *tes
 	if len(manager.detachedCalls) != 0 {
 		t.Fatalf("single read-only delegation must not allocate a worktree: %+v", manager.detachedCalls)
 	}
+	// #654: a single read-only delegation runs in the base checkout and already
+	// sees gitignored/uncommitted files, so it must NOT carry the committed-tip
+	// worktree note; its prompt stays byte-identical to the delegation prompt.
+	if payload.Instructions != "audit one" {
+		t.Fatalf("single read-only delegation instructions = %q, want the bare prompt with no worktree note", payload.Instructions)
+	}
 }
 
 func TestDispatchDelegationsReadOnlyFanoutWithoutManagerEmitsSkippedEvent(t *testing.T) {
@@ -336,8 +364,44 @@ func TestDispatchDelegationsReadOnlyFanoutWithoutManagerEmitsSkippedEvent(t *tes
 		if strings.TrimSpace(payload.WorktreePath) != "" {
 			t.Fatalf("fallback child %s unexpectedly got worktree path %q", id, payload.WorktreePath)
 		}
+		// #654: the fallback children run serialized in the shared base checkout,
+		// so they already see gitignored/uncommitted files and must NOT carry the
+		// committed-tip worktree note (which is scoped to the worktree branch).
+		if strings.Contains(payload.Instructions, "COMMITTED TIP") {
+			t.Fatalf("fallback child %s must not carry the worktree-context note, got %q", id, payload.Instructions)
+		}
 	}
 	if got := countJobEvents(t, store, "parent-job", "delegation_worktree_skipped"); got != 2 {
 		t.Fatalf("delegation_worktree_skipped event count = %d, want 2", got)
+	}
+}
+
+func TestReadOnlyWorktreeContextNote(t *testing.T) {
+	// Blank base checkout → "" so ask-path / test engines that never set
+	// Engine.DelegationCheckout produce byte-identical prompts (#654).
+	if got := readOnlyWorktreeContextNote(""); got != "" {
+		t.Fatalf("readOnlyWorktreeContextNote(\"\") = %q, want empty", got)
+	}
+	if got := readOnlyWorktreeContextNote("   "); got != "" {
+		t.Fatalf("readOnlyWorktreeContextNote(blank) = %q, want empty", got)
+	}
+
+	base := "/root/gitmoot"
+	note := readOnlyWorktreeContextNote(base)
+	if note == "" {
+		t.Fatal("readOnlyWorktreeContextNote with a base checkout returned empty")
+	}
+	if !strings.Contains(note, base) {
+		t.Fatalf("note must contain the base checkout path %q: %q", base, note)
+	}
+	for _, want := range []string{"COMMITTED TIP", "gitignored", "read-only"} {
+		if !strings.Contains(note, want) {
+			t.Fatalf("note must mention %q: %q", want, note)
+		}
+	}
+	// Deterministic: identical input → byte-identical output, so a re-dispatch or
+	// retry recomputes the same payload for the idempotent-enqueue equality check.
+	if again := readOnlyWorktreeContextNote(base); again != note {
+		t.Fatalf("note is non-deterministic: %q != %q", again, note)
 	}
 }

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -406,6 +406,26 @@ func readOnlyFanoutNeedsWorktree(payload JobPayload, d Delegation) bool {
 	return false
 }
 
+// readOnlyWorktreeContextNote returns a deterministic prompt appendix warning a
+// read-only fan-out delegation child that its detached worktree is the COMMITTED
+// TIP of the base branch and therefore omits gitignored paths (e.g. vendored
+// clones under repos/**) and any uncommitted working-tree changes. It points the
+// child at the canonical base checkout so an analysis task reads those files
+// there instead of silently reporting a working-tree feature as absent (#654).
+// It returns "" for a blank baseCheckout so the ask-path and any engine that does
+// not set Engine.DelegationCheckout produce byte-identical prompts. The text is
+// built only from static strings and baseCheckout, so a re-dispatch/retry
+// recomputes it identically — required by the idempotent-enqueue payload-equality
+// check (payloadMatchesRequest compares Instructions); this mirrors the #419
+// upstream-context append.
+func readOnlyWorktreeContextNote(baseCheckout string) string {
+	base := strings.TrimSpace(baseCheckout)
+	if base == "" {
+		return ""
+	}
+	return "\n\nWorktree context (read-only): you are running in a detached git worktree checked out at the COMMITTED TIP of the base branch. It does NOT contain gitignored paths (for example vendored clones under repos/**) or any uncommitted working-tree changes. If a path this task references is absent from your working directory, read it from the canonical base checkout at " + base + " before concluding it is missing — do not report a working-tree feature as absent without checking there. This is a read-only analysis; do not write outside your worktree."
+}
+
 // isReadOnlyDelegationWorktree reports whether a job ran in a detached read-only
 // delegation worktree that must be disposed. Only read-only delegation children
 // allocate one; implement children carry a branch and are cleaned through the

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -722,6 +722,20 @@ Each child job carries job-tree linkage fields — `parent_job_id`,
 can be traced back to its parent, its originating delegation, and the root of the
 tree. See `RESULT_CONTRACT.md` for the full delegation field reference.
 
+**Read-only fan-out runs at the committed tip.** When a coordinator emits **two
+or more** read-only (`ask`/`review`) siblings, Gitmoot auto-isolates each into a
+detached `git worktree` at the **committed tip** of the base branch so they run
+in parallel instead of serializing on the shared checkout. That worktree does
+**not** contain gitignored paths (e.g. vendored clones under `repos/**`) or any
+uncommitted working-tree changes, so an analysis/research leg cannot see the
+operator's live working tree there. Each such child's prompt now carries a note
+with the canonical base-checkout absolute path so a worker whose sandbox can read
+it (e.g. codex) reaches the real tree instead of reporting a working-tree feature
+as absent. A **single** read-only delegation stays in the shared base checkout
+and sees everything, so for whole-working-tree analysis (auditing gitignored
+vendored repos, or in-flight uncommitted WIP) either fan out to exactly **one**
+read-only leg or pass an **absolute** path to the file/dir under analysis.
+
 ## Coordinator-Owned Review
 
 By default an `implement` job that opens a pull request fans the PR out to

--- a/website/docs/workflows/parallel-jobs-workflow.md
+++ b/website/docs/workflows/parallel-jobs-workflow.md
@@ -82,6 +82,20 @@ Parallelism under `pool` is bounded by **two** independent locks, not one:
    `ask`/`review` jobs can be auto-isolated into an ephemeral detached worktree.
    A plain, top-level same-repo `implement` job with **no** worktree still shares
    the `repo:<repo>` key and serializes even under `pool`.
+
+   **Read-only fan-out worktrees are the committed tip.** An auto-isolated
+   read-only worktree is a detached `git worktree add` at the **committed tip** of
+   the base branch, so it does **not** contain gitignored paths (e.g. vendored
+   clones under `repos/**`) or any uncommitted working-tree changes. This only
+   applies to **two or more** read-only siblings (the fan-out that would otherwise
+   serialize); a **single** read-only delegation stays in the shared base checkout
+   and sees everything. Each fan-out child's prompt now carries a note with the
+   canonical base-checkout absolute path, so a worker whose sandbox can read it
+   (e.g. codex) reaches the real tree instead of reporting a working-tree feature
+   as missing. For whole-working-tree analysis that must see gitignored or
+   uncommitted state, either run a **single** read-only delegation (no fan-out →
+   stays in the base checkout) or pass an **absolute** path to the file/dir under
+   analysis.
 2. **Runtime session lock (`runtime:<runtime>:<ref>`).** Two jobs that use the
    **same agent/runtime session** serialize on the session lock even if their
    checkouts differ. So same-repo parallelism is bounded by **distinct runtime


### PR DESCRIPTION
## What

Read-only delegation fan-out children (≥2 siblings) run in detached worktrees checked out at the **committed tip** of the base branch (#328's non-serializing design) — so gitignored paths (`repos/**`) and uncommitted working-tree changes are invisible to them, and they silently report working-tree features as "missing". This has repeatedly produced wrong analysis conclusions (documented in #654).

v1 mitigation, deliberately minimal:
- New pure helper `readOnlyWorktreeContextNote(baseCheckout)` (worktree.go) — a **deterministic** note built only from static strings + the base-checkout path, telling the child its worktree is the committed tip, that gitignored/uncommitted paths are absent by construction, and to read an absent path from the canonical base checkout before concluding it is missing.
- Injected into `request.Instructions` **only** in the `readOnlyFanoutNeedsWorktree` else-branch (the ≥2-read-only-sibling worktree path). Single read-only children (they run in the base checkout), the no-manager fallback, and the integration-worktree branch (must *not* point children at the base checkout) get no note. Determinism + the #419 append pattern keep the idempotent-enqueue payload-equality check intact across retries.
- Engines with unset `DelegationCheckout` (ask-path, tests) are byte-identical.

It is a mitigation, not a guarantee: codex sandboxes can read the absolute base path; a cwd-scoped claude sandbox may not — but the note still stops the child from silently reporting "missing", and docs now steer whole-tree analysis to a single read-only delegation or absolute paths.

## Verification
- 4 tests: two-siblings both carry the note (and still start with their original prompts), single-read-only no note, no-manager fallback no note, pure helper unit test (`''`→`''`, determinism). The two-siblings assertion was verified to **fail on unpatched main** (genuinely pins the behavior).
- Adversarial review: completeness lens approved; correctness lens approved with a full trace of all 5 `allocateAndEnqueueDelegation` paths confirming the note can only inject on the fan-out-worktree branch, no double-append, no #328 serialization change, `-race` clean.
- Full local gate + integrated-tree verify green (with #649/#651/#661 + main@3935688).

## Cut from v1 (follow-ups, in commit body)
Opt-in base-checkout mode (would reintroduce #328 serialization; needs CLI/config/contract plumbing); `delegation_worktree_source_lag` observability event (porcelain probe); extending the note to implement-action children (#521 adjacent).

## Docs
`docs/parallel-jobs.md` + website mirror + `skills/gitmoot/references/WORKFLOWS.md` — committed-tip limitation, the new prompt note, and single-delegation/abs-path guidance.

## Deploy notes
Prompt-text-only engine change; no schema, no config. Standard local deploy.

Fixes #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)
