### PR TITLE
feat(daemon): recover jobs & reclaim runtime locks across a reboot via boot_id (#651)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -423,7 +423,14 @@ Fixes:
   progress past the staleness window (default 30m; tune with the
   `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value
   is 1m — below-1m, malformed, or non-positive values are rejected in favor of
-  the 30m default rather than clamped, #560).
+  the 30m default rather than clamped, #560). This window is a same-boot crash
+  backstop, not a timeout: a job holding a runtime session lock whose lease has
+  not elapsed is left running regardless of the window (its real timeout has not
+  passed). After a **reboot** you do not wait it out at all — the kernel boot id
+  changes, so on its next startup and every tick the daemon immediately requeues
+  every job claimed on the previous boot and reclaims its stranded runtime session
+  lock, regardless of any unexpired lease (#651). Boot-aware recovery is Linux
+  only; elsewhere recovery falls back to the lease/age window above.
 - A backlog of `blocked` jobs (each paused awaiting a human) never clears on its
   own. Dismiss one with `gitmoot job cancel <job-id>` (cancel now abandons a
   `blocked` job as well as a `queued`/`running` one; #631), or clear a stale

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1834,6 +1834,9 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 			if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
 				return err
 			}
+			if err := recoverForeignBootRunners(ctx, store, stdout); err != nil {
+				return err
+			}
 			if err := recoverCancelledRunningJobsForEnabledRepos(ctx, store, rootFilter, stdout); err != nil {
 				return err
 			}
@@ -1898,6 +1901,9 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 
 func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, store *db.Store, live *daemonReloadableConfig, rootFilter string, stdout io.Writer) error {
 	if err := recoverExpiredRuntimeSessionLocks(ctx, store, stdout, time.Now().UTC()); err != nil {
+		return err
+	}
+	if err := recoverForeignBootRunners(ctx, store, stdout); err != nil {
 		return err
 	}
 	if err := recoverRunningJobsForRepo(ctx, store, stdout, d.Repo.FullName(), rootFilter); err != nil {
@@ -2933,6 +2939,44 @@ func recoverExpiredRuntimeSessionLocks(ctx context.Context, store *db.Store, std
 	return recoverExpiredRuntimeSessionLocksSkipping(ctx, store, stdout, now, nil)
 }
 
+// recoverForeignBootRunners is the #651 cross-boot recovery pass, run at daemon
+// startup AND every worker tick. When this host's boot id differs from the boot id
+// recorded on a running job / held runtime-session lock, that owner was claimed on
+// a PREVIOUS boot and its in-process worker died when the host rebooted — so it is
+// recovered IMMEDIATELY, regardless of any runtime-session lease (which survives a
+// reboot in the DB and would otherwise keep the job "held" until it expired: the
+// AC2 gap #536's lease gate cannot close by itself).
+//
+// It requeues the foreign-boot running jobs (this covers non-resumable/shell jobs
+// too, which hold no lease at all) and reclaims the foreign-boot runtime-session
+// locks so a requeued resumable owner can re-acquire its session on re-dispatch.
+// It is a STRICT no-op off Linux (BootID()=="") — preserving today's age/lease
+// behavior — and never touches a SAME-boot owner, so a live in-process worker is
+// never double-run (the #536 protection is untouched). Cheap and idempotent: after
+// the first pass reclaims them there are no foreign-boot rows left, so re-running
+// it per repo per tick is a near-empty indexed scan.
+func recoverForeignBootRunners(ctx context.Context, store *db.Store, stdout io.Writer) error {
+	bootID := db.BootID()
+	if bootID == "" {
+		return nil
+	}
+	requeued, err := store.RequeueRunningJobsFromForeignBoot(ctx, bootID)
+	if err != nil {
+		return err
+	}
+	for _, id := range requeued {
+		writeLine(stdout, "requeued running job %s claimed on a previous boot (host rebooted)", id)
+	}
+	released, err := store.ReleaseRuntimeSessionLocksFromForeignBoot(ctx, bootID)
+	if err != nil {
+		return err
+	}
+	if released > 0 {
+		writeLine(stdout, "reclaimed %d runtime session lock(s) held on a previous boot", released)
+	}
+	return nil
+}
+
 // recoverExpiredRuntimeSessionLocksSkipping is recoverExpiredRuntimeSessionLocks
 // with an in-flight owner exclusion (#562): a lock whose owner job is currently
 // being run BY THIS PROCESS is neither requeued nor reaped even if its lease has
@@ -3442,6 +3486,14 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 		cand = newTickCandidates(worker.Store)
 	}
 	inflightIDs := tracker.inflightIDs()
+	// Cross-boot recovery (#651): requeue jobs / reclaim runtime-session locks whose
+	// recorded boot id proves a reboot happened, before the lease-gated recovery
+	// below (which alone would leave a rebooted long-lease job "held"). It is
+	// boot-scoped and repo-agnostic — no in-flight skip is needed because a foreign
+	// boot id can never belong to a job this process is currently running.
+	if err := recoverForeignBootRunners(ctx, store, stdout); err != nil {
+		return err
+	}
 	if err := recoverRunningJobsBeforeForRepoSkipping(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter(stdout)), repoFilter, rootFilter, inflightIDs); err != nil {
 		return err
 	}

--- a/internal/cli/daemon_boot_recovery_test.go
+++ b/internal/cli/daemon_boot_recovery_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestRecoverForeignBootRunnersRequeuesRebootedJobRegardlessOfLease is the AC2
+// fix: after a reboot a running job whose runtime-session lease is still in the
+// future — the case #536's lease gate deliberately leaves "held" — must be
+// requeued immediately, and its stranded runtime lock reclaimed, because the boot
+// id proves the in-process worker died with the old boot.
+func TestRecoverForeignBootRunnersRequeuesRebootedJobRegardlessOfLease(t *testing.T) {
+	if db.BootID() == "" {
+		t.Skip("kernel boot id unavailable on this platform")
+	}
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-reboot", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1, JobTimeout: "4h"})
+
+	priorBoot := "prior-boot-651"
+	if claimed, err := store.ClaimRunningJob(ctx, "job-reboot", string(workflow.JobQueued), string(workflow.JobRunning), db.JobEvent{Kind: string(workflow.JobRunning)}, 4321, priorBoot); err != nil || !claimed {
+		t.Fatalf("ClaimRunningJob claimed=%v err=%v", claimed, err)
+	}
+	now := time.Now().UTC()
+	// Unexpired lease (future) AND a live-looking owner pid: the lease/PID gate
+	// would keep this "held" forever — only the boot signal recovers it.
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey:   "runtime:codex:reboot-session",
+		OwnerJobID:    "job-reboot",
+		OwnerToken:    "tok-reboot",
+		OwnerPID:      int64(os.Getpid()),
+		OwnerHostname: thisHostname(t),
+		OwnerBootID:   priorBoot,
+		ExpiresAt:     now.Add(4 * time.Hour).Format(time.RFC3339Nano),
+	}, now); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock acquired=%v err=%v", acquired, err)
+	}
+
+	if err := recoverForeignBootRunners(ctx, store, io.Discard); err != nil {
+		t.Fatalf("recoverForeignBootRunners returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-reboot")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued (rebooted job must recover regardless of lease)", job.State)
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:reboot-session"); err == nil {
+		t.Fatal("prior-boot runtime lock was not reclaimed")
+	}
+}
+
+// TestRecoverForeignBootRunnersProtectsSameBootJob is the #536 regression guard:
+// a job claimed on the CURRENT boot with an unexpired lease must NOT be touched by
+// the cross-boot pass — nor by the lease-gated coarse recovery — exactly as today.
+func TestRecoverForeignBootRunnersProtectsSameBootJob(t *testing.T) {
+	if db.BootID() == "" {
+		t.Skip("kernel boot id unavailable on this platform")
+	}
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-live", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1, JobTimeout: "4h"})
+
+	if claimed, err := store.ClaimRunningJob(ctx, "job-live", string(workflow.JobQueued), string(workflow.JobRunning), db.JobEvent{Kind: string(workflow.JobRunning)}, os.Getpid(), db.BootID()); err != nil || !claimed {
+		t.Fatalf("ClaimRunningJob claimed=%v err=%v", claimed, err)
+	}
+	now := time.Now().UTC()
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey:   "runtime:codex:live-session",
+		OwnerJobID:    "job-live",
+		OwnerToken:    "tok-live",
+		OwnerPID:      int64(os.Getpid()),
+		OwnerHostname: thisHostname(t),
+		OwnerBootID:   db.BootID(),
+		ExpiresAt:     now.Add(4 * time.Hour).Format(time.RFC3339Nano),
+	}, now); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock acquired=%v err=%v", acquired, err)
+	}
+
+	if err := recoverForeignBootRunners(ctx, store, io.Discard); err != nil {
+		t.Fatalf("recoverForeignBootRunners returned error: %v", err)
+	}
+	// Also drive the coarse lease-gated recovery well past the staleness threshold:
+	// the unexpired lease must still protect the live same-boot job.
+	if err := recoverRunningJobsBefore(ctx, store, io.Discard, now.Add(time.Hour)); err != nil {
+		t.Fatalf("recoverRunningJobsBefore returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-live")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("job state = %q, want running (same-boot unexpired-lease job must stay protected)", job.State)
+	}
+	if _, err := store.GetResourceLock(ctx, "runtime:codex:live-session"); err != nil {
+		t.Fatalf("same-boot runtime lock was wrongly reclaimed: %v", err)
+	}
+}

--- a/internal/cli/runtime_lock.go
+++ b/internal/cli/runtime_lock.go
@@ -67,7 +67,12 @@ func acquireRuntimeSessionLockWithKey(ctx context.Context, store *db.Store, jobI
 		OwnerToken:    ownerToken,
 		OwnerPID:      int64(os.Getpid()),
 		OwnerHostname: strings.TrimSpace(hostname),
-		ExpiresAt:     now.UTC().Add(ttl).Format(time.RFC3339Nano),
+		// Stamp the acquiring host's boot id (#651) so cross-boot recovery can
+		// reclaim this runtime-session lock immediately after a reboot instead of
+		// waiting out its (reboot-surviving) lease. "" off Linux => legacy lease-only
+		// behavior, unchanged.
+		OwnerBootID: db.BootID(),
+		ExpiresAt:   now.UTC().Add(ttl).Format(time.RFC3339Nano),
 	}, now)
 	if err != nil || !acquired {
 		return func(context.Context) error { return nil }, acquired, key, "", err

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5049,8 +5049,11 @@ func acquireSkillOptTrainOptimizerLock(ctx context.Context, store *db.Store, ses
 		OwnerToken:    token,
 		OwnerPID:      int64(os.Getpid()),
 		OwnerHostname: hostname,
-		CommandHash:   skillOptTrainOptimizerRequestHash(request),
-		ExpiresAt:     now.Add(leaseTTL).Format(time.RFC3339Nano),
+		// Boot id (#651) so a same-host owner from a prior boot is provably dead
+		// without trusting a possibly-reused pid.
+		OwnerBootID: db.BootID(),
+		CommandHash: skillOptTrainOptimizerRequestHash(request),
+		ExpiresAt:   now.Add(leaseTTL).Format(time.RFC3339Nano),
 	}
 	lockMetadata.ResourceKey = newKey
 	acquired, err := store.AcquireResourceLock(ctx, lockMetadata, now)
@@ -5316,7 +5319,10 @@ func acquireSkillOptTrainGenerationLock(ctx context.Context, store *db.Store, se
 		OwnerToken:    token,
 		OwnerPID:      int64(os.Getpid()),
 		OwnerHostname: hostname,
-		ExpiresAt:     now.Add(ttl).Format(time.RFC3339Nano),
+		// Boot id (#651): recover --generation treats a same-host owner from a
+		// different boot as definitively dead (PID-reuse-immune, no kill(2)).
+		OwnerBootID: db.BootID(),
+		ExpiresAt:   now.Add(ttl).Format(time.RFC3339Nano),
 	}, now)
 	if err != nil {
 		return noopAgentReservationRelease, skillOptTrainNoopExtend, false, err
@@ -9031,7 +9037,6 @@ func recoverSkillOptTrainGenerationLock(ctx context.Context, paths config.Paths,
 		result.LockOwnerJobID = strings.TrimSpace(lock.OwnerJobID)
 		result.LockOwnerPID = lock.OwnerPID
 		result.LockOwnerHostname = strings.TrimSpace(lock.OwnerHostname)
-		ownerLive := skillOptOwnerPIDLive(lock.OwnerPID)
 		host := strings.TrimSpace(lock.OwnerHostname)
 		// Treat an empty/unrecorded owner_hostname as same-host-eligible: skillopt
 		// train is a local-first workflow (one local SQLite home), and an empty
@@ -9041,6 +9046,20 @@ func recoverSkillOptTrainGenerationLock(ctx context.Context, paths config.Paths,
 		// PID-dead gate still applies: a LIVE owner is always refused (never steal a
 		// live owner); only a DEAD PID with an empty/this-host hostname is reclaimable.
 		sameHost := host == "" || strings.EqualFold(host, strings.TrimSpace(thisHost))
+		// Boot-aware liveness (#651): on the SAME host, an owner boot id that differs
+		// from the current boot proves the host rebooted since the lock was taken, so
+		// the owning process is dead — and its pid may since have been reused, so the
+		// bare kill(2) probe (skillOptOwnerPIDLive) could wrongly report a reused pid
+		// as the still-live owner. Short-circuit to "dead" BEFORE the syscall in that
+		// case. The boot check is scoped to same-host: a different host has an
+		// unrelated boot id, so cross-host still relies on the TTL rule below.
+		ownerBoot, bootErr := store.ResourceLockOwnerBootID(ctx, lockKey)
+		if bootErr != nil {
+			return result, bootErr
+		}
+		currentBoot := db.BootID()
+		bootProvesDead := sameHost && ownerBoot != "" && currentBoot != "" && ownerBoot != currentBoot
+		ownerLive := !bootProvesDead && skillOptOwnerPIDLive(lock.OwnerPID)
 		expired := !skillOptResourceLockActive(lock, now)
 		switch {
 		case ownerLive:

--- a/internal/cli/skillopt_recover_generation_test.go
+++ b/internal/cli/skillopt_recover_generation_test.go
@@ -123,6 +123,49 @@ func seedStrandedGenerationLock(t *testing.T, home string, ownerPID int64, owner
 	}
 }
 
+// seedStrandedGenerationLockBoot is seedStrandedGenerationLock plus an
+// owner_boot_id, used to exercise the #651 cross-boot liveness short-circuit.
+func seedStrandedGenerationLockBoot(t *testing.T, home string, ownerPID int64, ownerHost string, ownerBoot string, expiresAt time.Time) {
+	t.Helper()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey:   skillOptTrainGenerationLockKey("landing-train", "landing-train-001"),
+		OwnerJobID:    "local-skillopt-train-generation-landing-train-deadbeef",
+		OwnerToken:    "stranded-token",
+		OwnerPID:      ownerPID,
+		OwnerHostname: ownerHost,
+		OwnerBootID:   ownerBoot,
+		ExpiresAt:     expiresAt.Format(time.RFC3339Nano),
+	}, time.Now().UTC())
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock stranded returned acquired=%v err=%v", acquired, err)
+	}
+}
+
+// TestSkillOptTrainRecoverGenerationReclaimsForeignBootLiveLock pins the #651
+// short-circuit: a generation lock whose owner PID is LIVE (this very process) on
+// this host with an unexpired lease would normally be refused as an active owner —
+// but a recorded owner_boot_id from a DIFFERENT boot proves the host rebooted, so
+// the (possibly-reused) pid is definitively not the owner and the lock is
+// reclaimed without a kill(2) probe. Without the boot check this refuses (busy).
+func TestSkillOptTrainRecoverGenerationReclaimsForeignBootLiveLock(t *testing.T) {
+	if db.BootID() == "" {
+		t.Skip("kernel boot id unavailable on this platform")
+	}
+	home, _ := seedSkillOptTrainItemsReady(t, 2)
+	seedStrandedGenerationLockBoot(t, home, int64(os.Getpid()), thisHostname(t), "prior-boot-651", time.Now().UTC().Add(time.Hour))
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "recover", "--home", home, "--session", "landing-train", "--generation"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover --generation exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if out := stdout.String(); !strings.Contains(out, "lock_reclaimed: true") {
+		t.Fatalf("stdout = %s, want lock_reclaimed: true (foreign boot proves the live-looking pid is dead)", out)
+	}
+}
+
 // deadPID returns a PID that is (almost certainly) not a running process.
 func deadPID(t *testing.T) int64 {
 	t.Helper()

--- a/internal/db/boot_id.go
+++ b/internal/db/boot_id.go
@@ -1,0 +1,44 @@
+package db
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+// bootIDPath is the Linux kernel's per-boot random identifier. It is regenerated
+// on every boot, so a change in its value is a definitive "the host rebooted"
+// signal — stronger and cheaper than any timeout for proving that a process
+// recorded on a previous boot is dead (its PID may even have been reused since).
+const bootIDPath = "/proc/sys/kernel/random/boot_id"
+
+var (
+	bootIDOnce  sync.Once
+	bootIDValue string
+)
+
+// BootID returns this host's kernel boot identifier, read once and cached for the
+// process lifetime (it cannot change without the process dying with its boot). It
+// is used by the #651 cross-boot liveness recovery to decide that a job/lock whose
+// recorded boot id differs from the current one was owned by a process that died
+// when the host rebooted, so it can be recovered immediately regardless of any
+// unexpired lease.
+//
+// It returns "" when the identifier cannot be read — most importantly on non-Linux
+// hosts (darwin has no such file) and on any read error. "" is the "no boot
+// identity" sentinel every consumer treats as "fall back to today's age/lease
+// behavior", so the whole feature degrades to a strict no-op off Linux.
+func BootID() string {
+	bootIDOnce.Do(func() {
+		bootIDValue = readBootID()
+	})
+	return bootIDValue
+}
+
+func readBootID() string {
+	data, err := os.ReadFile(bootIDPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/db/boot_id_test.go
+++ b/internal/db/boot_id_test.go
@@ -1,0 +1,282 @@
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBootIDStableAndCached(t *testing.T) {
+	first := BootID()
+	second := BootID()
+	if first != second {
+		t.Fatalf("BootID not stable: %q != %q", first, second)
+	}
+	// On a host that exposes the kernel boot id (Linux) it must be non-empty; on any
+	// other platform the file is absent and "" is the documented sentinel.
+	if _, err := os.Stat(bootIDPath); err == nil {
+		if first == "" {
+			t.Fatalf("BootID = %q, want non-empty on a host exposing %s", first, bootIDPath)
+		}
+		if got := readBootID(); got != first {
+			t.Fatalf("readBootID = %q, want %q", got, first)
+		}
+	}
+}
+
+func openBootTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestMigrationAddsRunnerAndOwnerBootColumns(t *testing.T) {
+	ctx := context.Background()
+	store := openBootTestStore(t)
+	// A targeted projection over the new columns errors if the ALTER TABLEs did not
+	// run — a direct assertion the additive migration landed.
+	if _, err := store.db.ExecContext(ctx, `SELECT runner_pid, runner_boot_id FROM jobs LIMIT 0`); err != nil {
+		t.Fatalf("jobs missing runner_pid/runner_boot_id: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `SELECT owner_boot_id FROM resource_locks LIMIT 0`); err != nil {
+		t.Fatalf("resource_locks missing owner_boot_id: %v", err)
+	}
+	// Migrate is idempotent (re-running never re-applies an appended migration).
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("second Migrate returned error: %v", err)
+	}
+}
+
+func seedBootQueuedJob(t *testing.T, store *Store, id string) {
+	t.Helper()
+	if err := store.CreateJobWithEvent(context.Background(), Job{
+		ID:      id,
+		Agent:   "audit",
+		Type:    "ask",
+		State:   "queued",
+		Payload: `{"repo":"owner/repo"}`,
+	}, JobEvent{JobID: id, Kind: "queued", Message: "job queued"}); err != nil {
+		t.Fatalf("CreateJobWithEvent(%s) returned error: %v", id, err)
+	}
+}
+
+func jobRunnerIdentity(t *testing.T, store *Store, id string) (int, string) {
+	t.Helper()
+	var pid int
+	var boot string
+	if err := store.db.QueryRowContext(context.Background(), `SELECT runner_pid, runner_boot_id FROM jobs WHERE id = ?`, id).Scan(&pid, &boot); err != nil {
+		t.Fatalf("read runner identity for %s: %v", id, err)
+	}
+	return pid, boot
+}
+
+func TestClaimRunningJobStampsRunnerIdentity(t *testing.T) {
+	ctx := context.Background()
+	store := openBootTestStore(t)
+	seedBootQueuedJob(t, store, "job-claim")
+
+	claimed, err := store.ClaimRunningJob(ctx, "job-claim", "queued", "running", JobEvent{Kind: "running", Message: "job started"}, 4321, "boot-A")
+	if err != nil {
+		t.Fatalf("ClaimRunningJob returned error: %v", err)
+	}
+	if !claimed {
+		t.Fatal("ClaimRunningJob did not claim a queued job")
+	}
+	job, err := store.GetJob(ctx, "job-claim")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != "running" {
+		t.Fatalf("job state = %q, want running", job.State)
+	}
+	pid, boot := jobRunnerIdentity(t, store, "job-claim")
+	if pid != 4321 || boot != "boot-A" {
+		t.Fatalf("runner identity = (%d, %q), want (4321, boot-A)", pid, boot)
+	}
+	events, err := store.ListJobEvents(ctx, "job-claim")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	var sawRunning bool
+	for _, e := range events {
+		if e.Kind == "running" {
+			sawRunning = true
+		}
+	}
+	if !sawRunning {
+		t.Fatalf("events = %+v, want a running claim event", events)
+	}
+
+	// A second claim on the now-running job transitions nothing and writes no event.
+	claimed, err = store.ClaimRunningJob(ctx, "job-claim", "queued", "running", JobEvent{Kind: "running", Message: "job started"}, 9999, "boot-B")
+	if err != nil {
+		t.Fatalf("second ClaimRunningJob returned error: %v", err)
+	}
+	if claimed {
+		t.Fatal("second ClaimRunningJob claimed an already-running job")
+	}
+	if pid, boot := jobRunnerIdentity(t, store, "job-claim"); pid != 4321 || boot != "boot-A" {
+		t.Fatalf("runner identity after no-op claim = (%d, %q), want (4321, boot-A)", pid, boot)
+	}
+}
+
+func TestRequeueRunningJobsFromForeignBoot(t *testing.T) {
+	ctx := context.Background()
+	store := openBootTestStore(t)
+	// Three running jobs: one claimed on a foreign boot, one on the current boot,
+	// one identity-less (legacy '' boot).
+	for _, tc := range []struct {
+		id   string
+		boot string
+	}{
+		{"job-foreign", "old-boot"},
+		{"job-current", "cur-boot"},
+		{"job-legacy", ""},
+	} {
+		seedBootQueuedJob(t, store, tc.id)
+		if claimed, err := store.ClaimRunningJob(ctx, tc.id, "queued", "running", JobEvent{Kind: "running"}, 1234, tc.boot); err != nil || !claimed {
+			t.Fatalf("ClaimRunningJob(%s) claimed=%v err=%v", tc.id, claimed, err)
+		}
+	}
+
+	requeued, err := store.RequeueRunningJobsFromForeignBoot(ctx, "cur-boot")
+	if err != nil {
+		t.Fatalf("RequeueRunningJobsFromForeignBoot returned error: %v", err)
+	}
+	if len(requeued) != 1 || requeued[0] != "job-foreign" {
+		t.Fatalf("requeued = %v, want [job-foreign]", requeued)
+	}
+	assertState := func(id, want string) {
+		t.Helper()
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob(%s) returned error: %v", id, err)
+		}
+		if job.State != want {
+			t.Fatalf("job %s state = %q, want %q", id, job.State, want)
+		}
+	}
+	assertState("job-foreign", "queued")
+	assertState("job-current", "running")
+	assertState("job-legacy", "running")
+
+	// The foreign-boot requeue must leave an audit event.
+	events, err := store.ListJobEvents(ctx, "job-foreign")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	var sawQueued bool
+	for _, e := range events {
+		if e.Kind == "queued" && e.Message == "recovered running job claimed on a previous boot (host rebooted)" {
+			sawQueued = true
+		}
+	}
+	if !sawQueued {
+		t.Fatalf("events = %+v, want a previous-boot recovery event", events)
+	}
+
+	// An empty current boot id (non-Linux / unavailable) is a STRICT no-op: no job
+	// with a non-empty recorded boot is ever swept just because it differs from "".
+	if requeued, err := store.RequeueRunningJobsFromForeignBoot(ctx, ""); err != nil {
+		t.Fatalf("RequeueRunningJobsFromForeignBoot(\"\") returned error: %v", err)
+	} else if len(requeued) != 0 {
+		t.Fatalf("empty-boot requeue = %v, want none", requeued)
+	}
+	assertState("job-current", "running")
+}
+
+func TestReleaseRuntimeSessionLocksFromForeignBoot(t *testing.T) {
+	ctx := context.Background()
+	store := openBootTestStore(t)
+	now := time.Now().UTC()
+	future := now.Add(4 * time.Hour).Format(time.RFC3339Nano)
+
+	locks := []ResourceLock{
+		// Foreign-boot runtime lock with an UNEXPIRED lease: must be reclaimed
+		// regardless of the lease (the #651 cross-boot gap).
+		{ResourceKey: "runtime:codex:s-old", OwnerJobID: "job-old", OwnerToken: "t1", OwnerBootID: "old-boot", ExpiresAt: future},
+		// Current-boot runtime lock: must be kept.
+		{ResourceKey: "runtime:codex:s-cur", OwnerJobID: "job-cur", OwnerToken: "t2", OwnerBootID: "cur-boot", ExpiresAt: future},
+		// Identity-less runtime lock (legacy / non-Linux acquire): must be kept.
+		{ResourceKey: "runtime:codex:s-legacy", OwnerJobID: "job-leg", OwnerToken: "t3", OwnerBootID: "", ExpiresAt: future},
+		// Foreign-boot but NOT a runtime lock: must be kept (only runtime:% locks
+		// are reclaimed cross-boot by the daemon).
+		{ResourceKey: "skillopt-train-generation:s:i", OwnerJobID: "job-gen", OwnerToken: "t4", OwnerBootID: "old-boot", ExpiresAt: future},
+	}
+	for _, lock := range locks {
+		if acquired, err := store.AcquireResourceLock(ctx, lock, now); err != nil || !acquired {
+			t.Fatalf("AcquireResourceLock(%s) acquired=%v err=%v", lock.ResourceKey, acquired, err)
+		}
+	}
+
+	released, err := store.ReleaseRuntimeSessionLocksFromForeignBoot(ctx, "cur-boot")
+	if err != nil {
+		t.Fatalf("ReleaseRuntimeSessionLocksFromForeignBoot returned error: %v", err)
+	}
+	if released != 1 {
+		t.Fatalf("released = %d, want 1", released)
+	}
+	present := func(key string) bool {
+		t.Helper()
+		if _, err := store.GetResourceLock(ctx, key); err == nil {
+			return true
+		}
+		return false
+	}
+	if present("runtime:codex:s-old") {
+		t.Fatal("foreign-boot runtime lock was not reclaimed")
+	}
+	for _, key := range []string{"runtime:codex:s-cur", "runtime:codex:s-legacy", "skillopt-train-generation:s:i"} {
+		if !present(key) {
+			t.Fatalf("lock %s was wrongly reclaimed", key)
+		}
+	}
+
+	// Empty current boot id is a STRICT no-op.
+	if released, err := store.ReleaseRuntimeSessionLocksFromForeignBoot(ctx, ""); err != nil {
+		t.Fatalf("ReleaseRuntimeSessionLocksFromForeignBoot(\"\") returned error: %v", err)
+	} else if released != 0 {
+		t.Fatalf("empty-boot release = %d, want 0", released)
+	}
+}
+
+func TestAcquireResourceLockPersistsOwnerBootID(t *testing.T) {
+	ctx := context.Background()
+	store := openBootTestStore(t)
+	now := time.Now().UTC()
+	future := now.Add(time.Hour).Format(time.RFC3339Nano)
+
+	if acquired, err := store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey: "runtime:codex:s1", OwnerJobID: "j1", OwnerToken: "tok", OwnerBootID: "boot-x", ExpiresAt: future,
+	}, now); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock acquired=%v err=%v", acquired, err)
+	}
+	boot, err := store.ResourceLockOwnerBootID(ctx, "runtime:codex:s1")
+	if err != nil {
+		t.Fatalf("ResourceLockOwnerBootID returned error: %v", err)
+	}
+	if boot != "boot-x" {
+		t.Fatalf("owner boot id = %q, want boot-x", boot)
+	}
+
+	// A lock with no recorded boot reads "".
+	if acquired, err := store.AcquireResourceLock(ctx, ResourceLock{
+		ResourceKey: "runtime:codex:s2", OwnerJobID: "j2", OwnerToken: "tok2", ExpiresAt: future,
+	}, now); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock(no boot) acquired=%v err=%v", acquired, err)
+	}
+	if boot, err := store.ResourceLockOwnerBootID(ctx, "runtime:codex:s2"); err != nil || boot != "" {
+		t.Fatalf("ResourceLockOwnerBootID(no boot) = (%q, %v), want (\"\", nil)", boot, err)
+	}
+
+	// An absent lock reads "" with no error.
+	if boot, err := store.ResourceLockOwnerBootID(ctx, "runtime:codex:absent"); err != nil || boot != "" {
+		t.Fatalf("ResourceLockOwnerBootID(absent) = (%q, %v), want (\"\", nil)", boot, err)
+	}
+}

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -137,6 +137,16 @@ CREATE TABLE job_events (
 	message TEXT NOT NULL,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+-- A minimal resource_locks table (created by an earlier, here pre-seeded-as-
+-- applied migration) so the #651 owner_boot_id ALTER ADD COLUMN that runs in this
+-- pass has its table.
+CREATE TABLE resource_locks (
+	resource_key TEXT PRIMARY KEY,
+	owner_job_id TEXT NOT NULL,
+	acquired_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	expires_at TEXT NOT NULL
+);
 CREATE TABLE schema_migrations (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL);
 INSERT INTO jobs(id, agent, type, state, payload) VALUES ('old', 'w', 'ask', 'succeeded', '{}');
 `); err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -486,10 +486,19 @@ type ResourceLock struct {
 	OwnerToken    string
 	OwnerPID      int64
 	OwnerHostname string
-	CommandHash   string
-	AcquiredAt    string
-	UpdatedAt     string
-	ExpiresAt     string
+	// OwnerBootID is the acquiring host's kernel boot identifier (db.BootID) at
+	// acquire time (#651). "" means no boot identity was recorded (a non-Linux
+	// host, or a lock acquired before this column existed / by a non-pid-stamping
+	// acquire); such locks fall back to the existing lease/TTL behavior. A recorded
+	// boot id that differs from the current one proves the owning process died with
+	// its boot, so the lock is reclaimable regardless of an unexpired lease. It is
+	// deliberately kept OUT of the shared 9-column lock SELECTs (targeted reads
+	// only) so their scan arity is unchanged.
+	OwnerBootID string
+	CommandHash string
+	AcquiredAt  string
+	UpdatedAt   string
+	ExpiresAt   string
 }
 
 type MergeGate struct {
@@ -2729,6 +2738,163 @@ func (s *Store) TransitionJobStateWithEvent(ctx context.Context, id string, from
 		return false, err
 	}
 	return true, tx.Commit()
+}
+
+// ClaimRunningJob is TransitionJobStateWithEvent specialized for the queued->
+// running CLAIM, additionally stamping the claiming process's identity
+// (runner_pid, runner_boot_id) in the SAME atomic UPDATE (#651). runner_pid is
+// recorded for observability only — cross-boot recovery keys on runner_boot_id,
+// never on the pid, because the daemon runs jobs in-process so the pid is the
+// daemon's own, not the reparented worker's. runnerBootID is db.BootID(): "" off
+// Linux, in which case the row is identity-less and only the existing age/lease
+// recovery applies. It returns false (no event written) when the row was not in
+// `from` state, exactly like TransitionJobStateWithEvent.
+func (s *Store) ClaimRunningJob(ctx context.Context, id string, from string, to string, event JobEvent, runnerPID int, runnerBootID string) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `UPDATE jobs SET state = ?, runner_pid = ?, runner_boot_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`, to, runnerPID, strings.TrimSpace(runnerBootID), id, from)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		return false, tx.Commit()
+	}
+	if event.JobID == "" {
+		event.JobID = id
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+		return false, err
+	}
+	return true, tx.Commit()
+}
+
+// RequeueRunningJobsFromForeignBoot requeues (running->queued) every running job
+// whose recorded runner_boot_id proves it was claimed on a PREVIOUS boot of this
+// host (#651): the host has since rebooted, so its in-process worker is
+// definitively dead and the job must be re-dispatched immediately — regardless of
+// any unexpired runtime-session lease, which survives a reboot in the DB and would
+// otherwise keep the job "held" until it expired (the AC2 gap this closes). Each
+// requeue appends a job_event for the audit trail. It returns the ids actually
+// requeued so the daemon can log them.
+//
+// It is a STRICT no-op when currentBootID is "" (a non-Linux host or a boot id
+// that could not be read): with no boot identity there is nothing to compare
+// against, so behavior is byte-identical to before this feature. The `!= ''`
+// guard likewise never touches identity-less legacy rows (pre-upgrade running
+// jobs), leaving them to the existing age/lease recovery. It NEVER touches a
+// same-boot job — same-boot liveness stays governed by the age/lease gate, so no
+// live in-process worker is ever double-run.
+func (s *Store) RequeueRunningJobsFromForeignBoot(ctx context.Context, currentBootID string) ([]string, error) {
+	currentBootID = strings.TrimSpace(currentBootID)
+	if currentBootID == "" {
+		return nil, nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `SELECT id FROM jobs
+		WHERE state = 'running' AND runner_boot_id != '' AND runner_boot_id != ?
+		ORDER BY id`, currentBootID)
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	rows.Close()
+
+	requeued := make([]string, 0, len(ids))
+	for _, id := range ids {
+		res, err := tx.ExecContext(ctx, `UPDATE jobs SET state = 'queued', updated_at = CURRENT_TIMESTAMP
+			WHERE id = ? AND state = 'running' AND runner_boot_id != '' AND runner_boot_id != ?`, id, currentBootID)
+		if err != nil {
+			return nil, err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return nil, err
+		}
+		if affected == 0 {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`,
+			id, "queued", "recovered running job claimed on a previous boot (host rebooted)"); err != nil {
+			return nil, err
+		}
+		requeued = append(requeued, id)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return requeued, nil
+}
+
+// ReleaseRuntimeSessionLocksFromForeignBoot deletes every runtime-session lock
+// (resource_key LIKE 'runtime:%') whose owner_boot_id proves it was acquired on a
+// PREVIOUS boot of this host (#651). After a reboot such a lock's owning process
+// is dead, but its lease survives in the DB and would otherwise block the requeued
+// owner job from re-acquiring its session lock on re-dispatch — so it is reclaimed
+// regardless of lease. The owner job itself is requeued by
+// RequeueRunningJobsFromForeignBoot (its runner_boot_id matches this lock's
+// foreign boot), so this method only reclaims the lock row. It returns the number
+// of locks released.
+//
+// It is a STRICT no-op when currentBootID is "" and, via the `!= ''` guard, never
+// reclaims an identity-less lock (a non-pid-stamping acquire or a legacy row),
+// which stays governed by its lease/TTL. Because a foreign boot id can only have
+// been written by a process on a prior boot, it can never match an in-flight owner
+// in THIS process, so no live session is ever reclaimed out from under it.
+func (s *Store) ReleaseRuntimeSessionLocksFromForeignBoot(ctx context.Context, currentBootID string) (int64, error) {
+	currentBootID = strings.TrimSpace(currentBootID)
+	if currentBootID == "" {
+		return 0, nil
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM resource_locks
+		WHERE resource_key LIKE ? AND owner_boot_id != '' AND owner_boot_id != ?`,
+		RuntimeSessionLockKeyPrefix+"%", currentBootID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// ResourceLockOwnerBootID returns the recorded owner_boot_id for a held lock, or
+// "" when the lock is absent or its boot id was never stamped (#651). It is a
+// targeted single-column read kept deliberately OUT of the shared 9-column lock
+// SELECTs so their scan arity is unchanged; the skillopt generation-lock recovery
+// path uses it to prove a same-host owner from a different boot is dead without a
+// kill(2) syscall (and PID-reuse-immune).
+func (s *Store) ResourceLockOwnerBootID(ctx context.Context, resourceKey string) (string, error) {
+	var bootID string
+	err := s.db.QueryRowContext(ctx, `SELECT owner_boot_id FROM resource_locks WHERE resource_key = ?`, strings.TrimSpace(resourceKey)).Scan(&bootID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(bootID), nil
 }
 
 func (s *Store) TransitionJobStatePayloadWithEvent(ctx context.Context, id string, from string, to string, payload string, event JobEvent, extraEvents ...JobEvent) (bool, error) {
@@ -5298,8 +5464,8 @@ func (s *Store) AcquireResourceLock(ctx context.Context, lock ResourceLock, now 
 			)`, resourceKey, nowText); err != nil {
 		return false, err
 	}
-	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO resource_locks(resource_key, owner_job_id, owner_token, owner_pid, owner_hostname, command_hash, acquired_at, updated_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, resourceKey, ownerJobID, ownerToken, lock.OwnerPID, strings.TrimSpace(lock.OwnerHostname), strings.TrimSpace(lock.CommandHash), nowText, nowText, expiresAt)
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO resource_locks(resource_key, owner_job_id, owner_token, owner_pid, owner_hostname, owner_boot_id, command_hash, acquired_at, updated_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, resourceKey, ownerJobID, ownerToken, lock.OwnerPID, strings.TrimSpace(lock.OwnerHostname), strings.TrimSpace(lock.OwnerBootID), strings.TrimSpace(lock.CommandHash), nowText, nowText, expiresAt)
 	if err != nil {
 		return false, err
 	}
@@ -7373,5 +7539,19 @@ CREATE INDEX idx_skillopt_gate_runs_candidate ON skillopt_gate_runs(candidate_ve
 	// unless the new commands are used.
 	`
 ALTER TABLE jobs ADD COLUMN externally_driven INTEGER NOT NULL DEFAULT 0;
+	`,
+	// #651 cross-boot process-liveness recovery: stamp the claiming process's
+	// identity onto a running job (runner_pid for observability; runner_boot_id the
+	// load-bearing cross-boot signal) and the acquiring process's boot id onto a
+	// pid-backed resource lock. All three carry DEFAULTs (0 / '') so every existing
+	// row reads identically and this is a pure additive append that does NOT
+	// renumber or alter any prior migration — mirroring the owner_pid/owner_hostname
+	// precedent above. A daemon upgraded mid-flight sees pre-upgrade running jobs as
+	// identity-less ('' boot) and safely leaves them to the existing age/lease
+	// recovery, then stamps identity on every subsequently-claimed job — no backfill.
+	`
+ALTER TABLE jobs ADD COLUMN runner_pid INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE jobs ADD COLUMN runner_boot_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE resource_locks ADD COLUMN owner_boot_id TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
@@ -786,11 +787,16 @@ func (m Mailbox) claim(ctx context.Context, job db.Job) error {
 	if job.State != string(JobQueued) {
 		return fmt.Errorf("job %q is %s, not queued", job.ID, job.State)
 	}
-	claimed, err := m.Store.TransitionJobStateWithEvent(ctx, job.ID, string(JobQueued), string(JobRunning), db.JobEvent{
+	// Stamp the claiming process's identity in the SAME atomic queued->running
+	// UPDATE (#651): runner_boot_id (db.BootID) is the cross-boot liveness signal
+	// that lets the daemon recover this job immediately after a reboot, and
+	// runner_pid is recorded for observability only. Off Linux BootID() is "", so
+	// the row is identity-less and only the existing age/lease recovery applies.
+	claimed, err := m.Store.ClaimRunningJob(ctx, job.ID, string(JobQueued), string(JobRunning), db.JobEvent{
 		JobID:   job.ID,
 		Kind:    string(JobRunning),
 		Message: "job started",
-	})
+	}, os.Getpid(), db.BootID())
 	if err != nil {
 		return err
 	}

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -128,6 +128,55 @@ func TestMailboxEnqueuePersistsEphemeralSpec(t *testing.T) {
 	}
 }
 
+// TestMailboxClaimStampsRunnerBootID pins that the queued->running claim stamps
+// the claiming process's boot id (#651), routing through Store.ClaimRunningJob. It
+// asserts behaviorally via the foreign-boot requeue predicate: a claimed job looks
+// "same-boot" to the current boot (never requeued) but "foreign" to a different
+// boot id (requeued) — which can only hold if claim recorded a concrete, non-empty
+// runner_boot_id. On the unpatched claim (plain TransitionJobStateWithEvent)
+// runner_boot_id stays '' and the foreign-boot requeue matches nothing, so this
+// test fails without the fix.
+func TestMailboxClaimStampsRunnerBootID(t *testing.T) {
+	if db.BootID() == "" {
+		t.Skip("kernel boot id unavailable on this platform")
+	}
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+
+	job, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-claim", Agent: "audit", Action: "ask", Repo: "jerryfane/gitmoot"})
+	if err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if err := mailbox.claim(ctx, job); err != nil {
+		t.Fatalf("claim returned error: %v", err)
+	}
+	running, err := store.GetJob(ctx, "job-claim")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if running.State != string(JobRunning) {
+		t.Fatalf("job state after claim = %q, want running", running.State)
+	}
+
+	// Same boot: the claimed job is NOT foreign, so it is protected.
+	if requeued, err := store.RequeueRunningJobsFromForeignBoot(ctx, db.BootID()); err != nil {
+		t.Fatalf("RequeueRunningJobsFromForeignBoot(current) returned error: %v", err)
+	} else if len(requeued) != 0 {
+		t.Fatalf("same-boot requeue = %v, want none (claim must stamp the CURRENT boot)", requeued)
+	}
+
+	// A different boot proves claim stamped a concrete boot id: the job now looks
+	// foreign and is requeued.
+	requeued, err := store.RequeueRunningJobsFromForeignBoot(ctx, "foreign-"+db.BootID())
+	if err != nil {
+		t.Fatalf("RequeueRunningJobsFromForeignBoot(foreign) returned error: %v", err)
+	}
+	if len(requeued) != 1 || requeued[0] != "job-claim" {
+		t.Fatalf("foreign-boot requeue = %v, want [job-claim] (claim must stamp runner_boot_id)", requeued)
+	}
+}
+
 func TestMailboxEnqueuePersistsModel(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -865,7 +865,14 @@ progress past the staleness window (default 30m) is assumed orphaned by a dead
 worker and recovered/re-queued. The window is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` env var; the smallest honored value is 1m —
 below-1m, malformed, or non-positive values are rejected (with a one-time
-warning) in favor of the 30m default rather than clamped (#560).
+warning) in favor of the 30m default rather than clamped (#560). That window is a
+same-boot crash backstop, not a timeout: a running job whose runtime-session lease
+has not elapsed is left held regardless of the window. After a **reboot** there is
+no wait at all — the daemon detects the changed kernel boot id and, on its next
+startup and every tick, immediately requeues every job claimed on a previous boot
+and reclaims its stranded `runtime:<rt>:<session>` lock, regardless of any
+unexpired lease (Linux only; elsewhere recovery falls back to the lease/age window;
+#651).
 
 `gitmoot job cancel <job-id>` is the single-job **abandon** verb. It dismisses a
 `queued`, `running`, **or `blocked`** job (a blocked job is one paused awaiting a

--- a/website/docs/concepts/agents-templates-jobs-locks.md
+++ b/website/docs/concepts/agents-templates-jobs-locks.md
@@ -149,3 +149,25 @@ mutate branches when Gitmoot assigned the job and the branch lock is held.
 The daemon defaults to `--workers 1`. Raise workers only when jobs use
 independent runtime sessions or managed agent types with `max_background`
 greater than one.
+
+### Recovery after a crash or reboot
+
+When a running job's worker dies, the daemon recovers it so work is never
+stranded. Recovery is **boot-aware**:
+
+- **Same boot** (a daemon restart or crash where the host stayed up): a running
+  job that still holds a runtime session lock whose lease has not elapsed is left
+  running — its real timeout has not passed, and its reparented worker may still
+  be making progress. Only once the lease expires (or the coarse
+  `GITMOOT_STALE_RUNNING_AFTER` backstop trips for a job holding no lease) is it
+  requeued. This is what stops a long job (for example a multi-hour delegation)
+  from being requeued and double-run.
+- **After a reboot**: the machine's kernel boot id changes, which is a definitive
+  "every process from the previous boot is dead" signal. On its next startup and
+  every tick the daemon immediately requeues any job claimed on a previous boot
+  and reclaims its stranded runtime session lock — regardless of how long the
+  lease still had to run — so a rebooted host resumes work at once instead of
+  waiting the lease or the stale-running window out.
+
+On platforms without a kernel boot id (non-Linux), the boot-aware step is a no-op
+and recovery falls back to the lease/age behavior above.

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -280,7 +280,14 @@ A job stuck in `running` is recovered automatically once it shows no lease
 progress past the staleness window (default 30m; tune with the
 `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value
 is 1m — below-1m, malformed, or non-positive values are rejected in favor of the
-30m default rather than clamped, #560).
+30m default rather than clamped, #560). The window is a same-boot crash backstop,
+not a timeout: a job holding a runtime session lock whose lease has not elapsed is
+left running regardless of the window. After a **reboot** there is no wait at
+all — the kernel boot id changes, so on its next startup and every tick the daemon
+immediately requeues every job claimed on the previous boot and reclaims its
+stranded runtime session lock, regardless of any unexpired lease (#651).
+Boot-aware recovery is Linux only; elsewhere recovery falls back to the lease/age
+window above.
 
 Fix: resolve the underlying runtime/auth/lock issue, then retry when safe:
 


### PR DESCRIPTION
## What

After a reboot, running jobs and pid-backed resource locks whose leases hadn't expired were still treated as held — the lease lives in the DB and survives the reboot, so a 4h delegation job or a runtime-session lock stayed wedged until the stale lease ran out (the exact pain that drives operators to crank `GITMOOT_STALE_RUNNING_AFTER`, e.g. council sets it in 17 places).

This PR closes the **boot_id gap**: stamp the claiming process's identity (`runner_pid` for observability, `runner_boot_id` as the load-bearing signal) on running jobs and pid-backed locks, and at daemon startup **and** each tick immediately requeue jobs / reclaim runtime-session locks whose recorded boot id proves they belong to a **previous boot**. Kernel boot_id (`/proc/sys/kernel/random/boot_id`) is PID-reuse-immune across reboots.

**Scope note:** the issue premise was partially stale — #536 already landed lease+PID+host liveness, so recovery was no longer age-only. v1 is deliberately the **cross-boot-only, #536-safe subset**:
- recovery **never** gates on pid (the daemon runs jobs in-process; `runner_pid` is the daemon's pid, not the reparented worker's — same-boot pid reaping would double-run live workers and regress #536)
- same-boot behavior (lease+PID+host from #536) is byte-identical
- `''` boot id (darwin / read error / pre-upgrade rows) → strict no-op, legacy path unchanged
- skillopt generation-lock recovery short-circuits to *dead* on a foreign boot **before** the `kill(pid,0)` probe

## Schema
One additive migration appended at the end (no renumbering): `jobs.runner_pid`, `jobs.runner_boot_id`, `resource_locks.owner_boot_id`, all with backfill-safe defaults, kept out of shared SELECT lists (scan arity unchanged).

## Verification
- Tests (scoped `-race` gate): boot_id stable/cached; migration on fresh + upgraded DBs; atomic claim stamping; foreign-boot requeue (foreign requeued, current + legacy `''` untouched); foreign-boot lock reclaim regardless of lease; skillopt cross-boot reclaim; **#536 regression guard** — a same-boot unexpired-lease job + lock stays protected through both recovery passes.
- Adversarial 2-lens review, 2 rounds: round 1 caught a CLI.md docs gap (docs-only fix); round 2 both lenses approve.
- Full local gate green (build, generate-clean, vet, full tests, scoped race).
- Integrated-tree verify green with #649/#654/#661 + main@3935688; interaction with #660 session jobs checked: externally-driven jobs are created with `runner_boot_id=''` and the sweep guards `!= ''`, so they can never be swept.

## Cut from v1 (follow-ups)
Terminal-task `upsertTask` CAS guard (separate concern); same-boot pid reaping (unsafe by design); `owner_boot_id` on non-pid-stamping acquires; heartbeats/leases/fencing.

## Deploy notes
Additive migration runs automatically on first daemon start with the new binary. Linux gets the feature; darwin degrades to a no-op. Restart the daemon at idle per the standard recipe. Operators can relax `GITMOOT_STALE_RUNNING_AFTER` workarounds after this lands.

Fixes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
