### PR TITLE
fix(usage): track per-session token delta for resumed codex sessions (#661)

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -113,9 +113,9 @@ default_repair_timeout = ""
   continuation (synthesize what completed, then stop). Token capture is
   **best-effort per runtime**: Claude reports usage via its `--output-format json`
   envelope, Kimi reports it when its stream emits a `usage` object, and Codex reads
-  usage from its `codex exec --json` JSONL stream for fresh sessions only
-  (resumed sessions contribute `0` — codex reports session-cumulative usage
-  there; older CLIs that predate the flag also fall back to `0`). Treat it as a coarse runaway-cost backstop, not a
+  usage from its `codex exec --json` JSONL stream — a resumed session's usage is
+  session-cumulative, so it records only the per-session delta (#661); older CLIs
+  that predate the flag fall back to `0`. Treat it as a coarse runaway-cost backstop, not a
   precise spend limit; the budget is in raw tokens. Leaving it at `0` is
   byte-identical to before the knob existed.
 - `max_delegation_cost_usd` (default `0` = unlimited/off) is the **dollar-cost**

--- a/internal/db/runtime_session_usage_test.go
+++ b/internal/db/runtime_session_usage_test.go
@@ -1,0 +1,196 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// baseline reads the stored cumulative counters for a session key directly, so a
+// test can assert the persisted baseline after each delta call.
+func baseline(t *testing.T, store *Store, key string) (int, int) {
+	t.Helper()
+	var in, out int
+	if err := store.db.QueryRowContext(context.Background(),
+		`SELECT input_cum, output_cum FROM runtime_session_usage WHERE session_key = ?`, key).Scan(&in, &out); err != nil {
+		t.Fatalf("read baseline for %q returned error: %v", key, err)
+	}
+	return in, out
+}
+
+// TestRecordRuntimeSessionUsageDelta pins the #661 per-session delta contract: the
+// first delivery on a fresh session key returns the full cumulative (baseline 0),
+// each subsequent delivery returns only the increase since the last cumulative, and
+// the stored baseline advances to the newest cumulative after every call.
+func TestRecordRuntimeSessionUsageDelta(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	const key = "codex:019f3041-cfed-7e82-8766-b5ca75cf92da"
+
+	// First delivery: no prior row, so the whole cumulative is this job's delta and
+	// becomes the baseline.
+	dIn, dOut, err := store.RecordRuntimeSessionUsageDelta(ctx, key, 16504, 20)
+	if err != nil {
+		t.Fatalf("first delta returned error: %v", err)
+	}
+	if dIn != 16504 || dOut != 20 {
+		t.Fatalf("first delta = (%d, %d), want (16504, 20) — full cumulative on a fresh key", dIn, dOut)
+	}
+	if in, out := baseline(t, store, key); in != 16504 || out != 20 {
+		t.Fatalf("baseline after first = (%d, %d), want (16504, 20)", in, out)
+	}
+
+	// Second delivery on the same session: cumulative advanced, so only the increase
+	// is this job's usage — NOT the whole session history.
+	dIn, dOut, err = store.RecordRuntimeSessionUsageDelta(ctx, key, 85681, 40)
+	if err != nil {
+		t.Fatalf("second delta returned error: %v", err)
+	}
+	if dIn != 85681-16504 || dOut != 40-20 {
+		t.Fatalf("second delta = (%d, %d), want (%d, %d)", dIn, dOut, 85681-16504, 40-20)
+	}
+	if in, out := baseline(t, store, key); in != 85681 || out != 40 {
+		t.Fatalf("baseline after second = (%d, %d), want (85681, 40)", in, out)
+	}
+
+	// Third delivery: same shape, live-probed cumulative.
+	dIn, dOut, err = store.RecordRuntimeSessionUsageDelta(ctx, key, 103779, 45)
+	if err != nil {
+		t.Fatalf("third delta returned error: %v", err)
+	}
+	if dIn != 103779-85681 || dOut != 45-40 {
+		t.Fatalf("third delta = (%d, %d), want (%d, %d)", dIn, dOut, 103779-85681, 45-40)
+	}
+}
+
+// TestRecordRuntimeSessionUsageDeltaBackwardsResync pins the reset/rollover
+// behavior: codex session compaction can make the cumulative counter go backwards.
+// The crossing job's delta clamps to 0 (a safe under-count, never a spurious huge
+// delta) AND the baseline resyncs to the new lower cumulative so subsequent deltas
+// are measured from there.
+func TestRecordRuntimeSessionUsageDeltaBackwardsResync(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	const key = "codex:thread-reset"
+
+	if _, _, err := store.RecordRuntimeSessionUsageDelta(ctx, key, 100000, 500); err != nil {
+		t.Fatalf("seed delta returned error: %v", err)
+	}
+
+	// Counter went backwards (compaction/rollover): delta clamps to 0.
+	dIn, dOut, err := store.RecordRuntimeSessionUsageDelta(ctx, key, 300, 5)
+	if err != nil {
+		t.Fatalf("backwards delta returned error: %v", err)
+	}
+	if dIn != 0 || dOut != 0 {
+		t.Fatalf("backwards delta = (%d, %d), want (0, 0) — clamped", dIn, dOut)
+	}
+	// Baseline resynced to the new lower cumulative.
+	if in, out := baseline(t, store, key); in != 300 || out != 5 {
+		t.Fatalf("baseline after backwards = (%d, %d), want (300, 5) — resynced", in, out)
+	}
+
+	// A subsequent forward step is measured from the resynced baseline.
+	dIn, dOut, err = store.RecordRuntimeSessionUsageDelta(ctx, key, 800, 12)
+	if err != nil {
+		t.Fatalf("post-resync delta returned error: %v", err)
+	}
+	if dIn != 500 || dOut != 7 {
+		t.Fatalf("post-resync delta = (%d, %d), want (500, 7)", dIn, dOut)
+	}
+}
+
+// TestRecordRuntimeSessionUsageDeltaNegativeClamp pins that a malformed negative
+// cumulative report is clamped to 0 before it can corrupt the baseline.
+func TestRecordRuntimeSessionUsageDeltaNegativeClamp(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	dIn, dOut, err := store.RecordRuntimeSessionUsageDelta(ctx, "codex:neg", -5, -7)
+	if err != nil {
+		t.Fatalf("negative delta returned error: %v", err)
+	}
+	if dIn != 0 || dOut != 0 {
+		t.Fatalf("negative delta = (%d, %d), want (0, 0)", dIn, dOut)
+	}
+	if in, out := baseline(t, store, "codex:neg"); in != 0 || out != 0 {
+		t.Fatalf("baseline after negative = (%d, %d), want (0, 0)", in, out)
+	}
+}
+
+// TestRecordRuntimeSessionUsageDeltaConcurrent proves the SELECT+UPSERT pair is
+// atomic under concurrent callers. N goroutines hammer ONE session key with the
+// SAME cumulative C. If each call is atomic, exactly one caller (whichever commits
+// first) sees baseline 0 and returns the full delta C; every later caller reads the
+// committed baseline C and returns 0. So — independent of interleaving order — the
+// deltas sum to exactly C and exactly one is non-zero. A non-atomic implementation
+// (SELECT and UPSERT in separate statements) lets two callers both read baseline 0
+// before either writes, so both return C: the sum exceeds C / more than one delta is
+// non-zero. Runs under `go test -race`, which additionally flags any data race in
+// the method itself. Same-value C makes the assertion order-independent — distinct
+// increasing cumulatives would make the expected sum depend on the nondeterministic
+// arrival order (a backwards arrival clamps to 0 and resyncs the baseline).
+func TestRecordRuntimeSessionUsageDeltaConcurrent(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	const key = "codex:race"
+	const cumIn, cumOut = 123456, 789
+	const n = 64
+
+	var mu sync.Mutex
+	var sumIn, sumOut, nonZero int
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			dIn, dOut, err := store.RecordRuntimeSessionUsageDelta(ctx, key, cumIn, cumOut)
+			if err != nil {
+				t.Errorf("goroutine %d delta returned error: %v", i, err)
+				return
+			}
+			if dIn < 0 || dOut < 0 {
+				t.Errorf("goroutine %d delta = (%d, %d), want both >= 0", i, dIn, dOut)
+			}
+			mu.Lock()
+			sumIn += dIn
+			sumOut += dOut
+			if dIn != 0 || dOut != 0 {
+				nonZero++
+			}
+			mu.Unlock()
+		}(i)
+	}
+	wg.Wait()
+
+	// Atomic: exactly one caller claimed the whole cumulative, the rest saw 0.
+	if sumIn != cumIn || sumOut != cumOut {
+		t.Fatalf("sum of deltas = (%d, %d), want (%d, %d) — read/write interleaved and double-counted", sumIn, sumOut, cumIn, cumOut)
+	}
+	if nonZero != 1 {
+		t.Fatalf("non-zero deltas = %d, want exactly 1 — a stale-baseline read let multiple callers claim the cumulative", nonZero)
+	}
+	if in, out := baseline(t, store, key); in != cumIn || out != cumOut {
+		t.Fatalf("final baseline = (%d, %d), want (%d, %d)", in, out, cumIn, cumOut)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2997,6 +2997,60 @@ func (s *Store) UpdateJobUsage(ctx context.Context, id string, inputTokens int, 
 	return requireAffected(result, "job", id)
 }
 
+// RecordRuntimeSessionUsageDelta converts a runtime session's CUMULATIVE token
+// counters into this delivery's per-job usage. codex reports turn.completed usage
+// as the session's running total on a resumed thread (#661), so a job's real cost
+// is the increase since the last delivery on that session. It reads the prior
+// baseline for sessionKey (0 if none), returns deltaInput/deltaOutput =
+// max(0, cumulative_now - prev), and upserts the new cumulative as the baseline —
+// all inside ONE transaction so two daemon workers racing on the same session
+// cannot interleave the read and the write (the store also caps the pool at a
+// single connection). A counter that went backwards (codex session
+// compaction/rollover resets it) yields a 0 delta for the crossing job AND resyncs
+// the baseline to the new lower cumulative: a safe under-count rather than a
+// spurious huge delta. Negative inputs are clamped to 0 so a malformed usage
+// report can never corrupt the baseline.
+func (s *Store) RecordRuntimeSessionUsageDelta(ctx context.Context, sessionKey string, cumInput, cumOutput int) (deltaInput int, deltaOutput int, err error) {
+	if cumInput < 0 {
+		cumInput = 0
+	}
+	if cumOutput < 0 {
+		cumOutput = 0
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer tx.Rollback()
+
+	var prevInput, prevOutput int
+	err = tx.QueryRowContext(ctx, `SELECT input_cum, output_cum FROM runtime_session_usage WHERE session_key = ?`, sessionKey).Scan(&prevInput, &prevOutput)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, 0, err
+	}
+
+	if deltaInput = cumInput - prevInput; deltaInput < 0 {
+		deltaInput = 0
+	}
+	if deltaOutput = cumOutput - prevOutput; deltaOutput < 0 {
+		deltaOutput = 0
+	}
+
+	if _, err := tx.ExecContext(ctx, `INSERT INTO runtime_session_usage(session_key, input_cum, output_cum, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(session_key) DO UPDATE SET
+			input_cum = excluded.input_cum,
+			output_cum = excluded.output_cum,
+			updated_at = excluded.updated_at`,
+		sessionKey, cumInput, cumOutput); err != nil {
+		return 0, 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, 0, err
+	}
+	return deltaInput, deltaOutput, nil
+}
+
 func (s *Store) AddJobEvent(ctx context.Context, event JobEvent) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message)
 	return err
@@ -7553,5 +7607,24 @@ ALTER TABLE jobs ADD COLUMN externally_driven INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE jobs ADD COLUMN runner_pid INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE jobs ADD COLUMN runner_boot_id TEXT NOT NULL DEFAULT '';
 ALTER TABLE resource_locks ADD COLUMN owner_boot_id TEXT NOT NULL DEFAULT '';
+	`,
+	// #661 per-codex-session token delta tracking. codex reports turn.completed
+	// usage as SESSION-CUMULATIVE on a resumed thread (the session's running
+	// total, not the turn's), so attributing it to a single job needs the last-seen
+	// cumulative counters per runtime session. This table stores them keyed by
+	// runtime+ref; RecordRuntimeSessionUsageDelta reads the prior baseline, returns
+	// max(0, cumulative_now - prev) as the job's usage, and upserts the new
+	// baseline — all in one transaction. Pure additive append (CREATE TABLE only):
+	// the table stays empty until a resumed codex delivery records usage, and every
+	// existing DB reads identically. No cross-runtime use today (only codex sets
+	// Result.CumulativeUsage). No GC/retention in v1 — orphan rows for dead threads
+	// are tens of bytes; a bounded cleanup pass is a follow-up.
+	`
+CREATE TABLE runtime_session_usage (
+	session_key TEXT PRIMARY KEY,
+	input_cum INTEGER NOT NULL DEFAULT 0,
+	output_cum INTEGER NOT NULL DEFAULT 0,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 	`,
 }

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -73,14 +73,24 @@ type Result struct {
 	// default to 0. Per-runtime status today: claude reports usage via its
 	// --output-format json envelope; kimi-code 0.19.2 emits no usage event so it
 	// contributes 0; codex Deliver reads the last turn.completed usage from its
-	// `exec --json` JSONL output (#658) for single-job sessions only (fresh
-	// refs and SingleUseSession ephemeral/temp workers) — sessions shared
-	// across jobs contribute 0 because codex reports session-cumulative usage
-	// there (see codexDeliverResult) — falling back to 0 on an older CLI that
-	// predates --json. A 0 here means "not captured", and the per-root delegation token
-	// budget simply under-counts that job rather than failing.
+	// `exec --json` JSONL output (#658), falling back to 0 on an older CLI that
+	// predates --json. For codex these counts are SESSION-CUMULATIVE on a resumed
+	// thread — the session's whole running total, not this job's usage — so the
+	// caller must delta them (see CumulativeUsage and codexDeliverResult); fresh
+	// and single-use sessions already report a per-job count. A 0 here means "not
+	// captured", and the per-root delegation token budget simply under-counts that
+	// job rather than failing.
 	InputTokens  int
 	OutputTokens int
+	// CumulativeUsage reports that InputTokens/OutputTokens are runtime-session
+	// cumulative — the session's whole running total, not this job's usage (codex
+	// resumed threads report turn.completed usage this way, #661). When true the
+	// caller must subtract the last-seen counters for the runtime session (keyed by
+	// runtime+ref) and record only the delta. False means the counts are already
+	// per-job — fresh sessions and single-use ephemeral/temp workers, where the
+	// session's cumulative == this job's usage — and are recorded verbatim (#664).
+	// Only codex sets this today; other adapters leave it false.
+	CumulativeUsage bool
 	// RefreshedRuntimeRef is non-empty only when the adapter self-healed a dead
 	// pre-execution session and re-pinned the agent to a fresh runtime reference
 	// (#443). The mailbox persists it through the Store so subsequent jobs use the
@@ -410,27 +420,29 @@ func (a CodexAdapter) runCodex(ctx context.Context, agent Agent, prompt, model s
 // an unexpected shape) is returned verbatim as Raw with 0 usage, so a delivery is
 // never lost because usage parsing changed.
 //
-// Usage is reported ONLY for sessions that belong to a single job: fresh refs
-// (per-job --runtime overrides) and single-use sessions (ephemeral delegation
-// workers and per-job temp workers — the #338 budget's primary target). On
-// sessions SHARED across jobs codex's turn.completed usage is SESSION-CUMULATIVE,
-// not per-turn:
-// probed live on codex-cli 0.142.4, three one-word turns on one thread reported
-// input 16504 -> 85681 -> 103779 and output 20 -> 40 -> 45 (monotonically
+// codex's turn.completed usage is SESSION-CUMULATIVE on a resumed thread, not
+// per-turn: probed live on codex-cli 0.142.4, three one-word turns on one thread
+// reported input 16504 -> 85681 -> 103779 and output 20 -> 40 -> 45 (monotonically
 // accumulating), and a single resumed ask on a long-lived agent reported 22.4M
-// input tokens — orders of magnitude beyond any single turn. Attributing the
-// whole session history to each job would corrupt per-root budgets and usage
-// charts, so resumed deliveries contribute 0 until per-session delta tracking
-// exists (follow-up issue).
+// input tokens — orders of magnitude beyond any single turn. So the parsed counts
+// are always returned, with CumulativeUsage set to !freshSession: a resumed
+// (shared) session flags them cumulative so the caller records only the
+// per-session delta (#661), while a fresh ref or single-use session — its
+// cumulative == this job's cost, the #338 budget's primary target — flags them
+// per-job so they are recorded verbatim (#664). The fail-open branch (no
+// agent_message event) returns 0 usage with CumulativeUsage=false, unchanged.
 func codexDeliverResult(stdout string, freshSession bool) Result {
 	raw, inputTokens, outputTokens, ok := parseCodexJSONResult(stdout)
 	if !ok {
 		return Result{Raw: stdout, Summary: strings.TrimSpace(stdout)}
 	}
-	if !freshSession {
-		inputTokens, outputTokens = 0, 0
+	return Result{
+		Raw:             raw,
+		Summary:         strings.TrimSpace(raw),
+		InputTokens:     inputTokens,
+		OutputTokens:    outputTokens,
+		CumulativeUsage: !freshSession,
 	}
-	return Result{Raw: raw, Summary: strings.TrimSpace(raw), InputTokens: inputTokens, OutputTokens: outputTokens}
 }
 
 func (a CodexAdapter) Health(ctx context.Context, agent Agent) error {

--- a/internal/runtime/usage_test.go
+++ b/internal/runtime/usage_test.go
@@ -169,6 +169,11 @@ func TestCodexDeliverCapturesUsage(t *testing.T) {
 	if result.InputTokens != 16504 || result.OutputTokens != 20 {
 		t.Fatalf("codex usage = (%d, %d), want (16504, 20)", result.InputTokens, result.OutputTokens)
 	}
+	// A fresh session's cumulative == this job's usage, so it is per-job, not
+	// cumulative: the mailbox records it verbatim and must NOT delta it (#664).
+	if result.CumulativeUsage {
+		t.Fatal("fresh session CumulativeUsage = true, want false")
+	}
 	runner.want(t, 0, "codex", "exec", "--json", "--", "implement")
 }
 
@@ -189,17 +194,24 @@ func TestCodexDeliverSingleUseSessionCapturesUsage(t *testing.T) {
 	if result.InputTokens != 16504 || result.OutputTokens != 20 {
 		t.Fatalf("single-use codex usage = (%d, %d), want (16504, 20)", result.InputTokens, result.OutputTokens)
 	}
+	// A single-use session is disposed after one job, so its cumulative == this
+	// job's cost: per-job, not cumulative. The mailbox records it verbatim and must
+	// NOT route it through the delta table (#664 non-regression guard).
+	if result.CumulativeUsage {
+		t.Fatal("single-use session CumulativeUsage = true, want false")
+	}
 	runner.want(t, 0, "codex", "exec", "--json", "resume", "--last", "--", "implement")
 }
 
-// TestCodexDeliverResumeReportsZeroUsage pins the resumed-session exclusion:
-// codex's turn.completed usage on a resumed thread is SESSION-CUMULATIVE, not
-// per-turn (probed live on codex-cli 0.142.4: three one-word turns reported
+// TestCodexDeliverResumeReportsCumulativeUsage pins the resumed-session capture
+// (#661): codex's turn.completed usage on a resumed thread is SESSION-CUMULATIVE,
+// not per-turn (probed live on codex-cli 0.142.4: three one-word turns reported
 // input 16504 -> 85681 -> 103779, and one resumed ask on a long-lived agent
-// reported 22.4M input tokens). Attributing the whole session history to each
-// job would corrupt per-root budgets, so a resumed delivery keeps the parsed
-// text but contributes 0 usage until per-session delta tracking exists.
-func TestCodexDeliverResumeReportsZeroUsage(t *testing.T) {
+// reported 22.4M input tokens). Rather than dropping it to 0, a resumed delivery
+// now surfaces the raw cumulative counts AND flags them CumulativeUsage=true, so
+// the mailbox subtracts the last-seen per-session baseline and records only this
+// job's delta. This repurposes the old exclusion test.
+func TestCodexDeliverResumeReportsCumulativeUsage(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: codexUsageTranscript}}}
 	adapter := CodexAdapter{Runner: runner}
 	agent := Agent{Name: "impl", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "jerryfane/gitmoot"}
@@ -211,11 +223,36 @@ func TestCodexDeliverResumeReportsZeroUsage(t *testing.T) {
 	if result.Raw != "hi" || result.Summary != "hi" {
 		t.Fatalf("raw/summary = (%q, %q), want (\"hi\", \"hi\")", result.Raw, result.Summary)
 	}
-	if result.InputTokens != 0 || result.OutputTokens != 0 {
-		t.Fatalf("resumed codex usage = (%d, %d), want (0, 0) — session-cumulative upstream", result.InputTokens, result.OutputTokens)
+	if result.InputTokens != 16504 || result.OutputTokens != 20 {
+		t.Fatalf("resumed codex usage = (%d, %d), want (16504, 20) — raw cumulative surfaced for delta tracking", result.InputTokens, result.OutputTokens)
+	}
+	if !result.CumulativeUsage {
+		t.Fatal("resumed session CumulativeUsage = false, want true — caller must delta the cumulative counts")
 	}
 	// --json is an `exec` option and sits before the resume subcommand.
 	runner.want(t, 0, "codex", "exec", "--json", "resume", "--last", "--", "implement")
+}
+
+// TestCodexDeliverResultFlagMatrix unit-tests the codexDeliverResult seam directly
+// across the flag matrix: a fresh (single-job) session reports its parsed counts
+// per-job (CumulativeUsage=false), a resumed session reports the same parsed counts
+// but flagged cumulative (CumulativeUsage=true), and non-JSONL stdout fails open to
+// 0 usage with CumulativeUsage=false.
+func TestCodexDeliverResultFlagMatrix(t *testing.T) {
+	fresh := codexDeliverResult(codexUsageTranscript, true)
+	if fresh.InputTokens != 16504 || fresh.OutputTokens != 20 || fresh.CumulativeUsage {
+		t.Fatalf("fresh = (%d, %d, cum=%v), want (16504, 20, false)", fresh.InputTokens, fresh.OutputTokens, fresh.CumulativeUsage)
+	}
+	resumed := codexDeliverResult(codexUsageTranscript, false)
+	if resumed.InputTokens != 16504 || resumed.OutputTokens != 20 || !resumed.CumulativeUsage {
+		t.Fatalf("resumed = (%d, %d, cum=%v), want (16504, 20, true)", resumed.InputTokens, resumed.OutputTokens, resumed.CumulativeUsage)
+	}
+	// Fail-open: non-JSONL stdout keeps the verbatim text, 0 usage, never flagged
+	// cumulative (so the mailbox never routes a fail-open delivery to the delta table).
+	failOpen := codexDeliverResult("not json at all", false)
+	if failOpen.Raw != "not json at all" || failOpen.InputTokens != 0 || failOpen.OutputTokens != 0 || failOpen.CumulativeUsage {
+		t.Fatalf("fail-open = (%q, %d, %d, cum=%v), want (\"not json at all\", 0, 0, false)", failOpen.Raw, failOpen.InputTokens, failOpen.OutputTokens, failOpen.CumulativeUsage)
+	}
 }
 
 // TestCodexDeliverJoinsAgentMessages pins that a turn emitting several

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -657,13 +657,29 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		Model:       payload.Model,
 	})
 	// Record best-effort runtime token usage so the per-root delegation token
-	// budget (#338 Part B) can sum a tree's cost. Only persist when the runtime
-	// actually reported usage (a positive count) so runtimes that report nothing
-	// (e.g. the shell runtime) leave the columns at their 0 default rather than
-	// taking a no-op write. Usage accounting must never fail a delivery, so a
-	// write error is swallowed.
-	if err == nil && (result.InputTokens > 0 || result.OutputTokens > 0) {
-		_ = m.Store.UpdateJobUsage(ctx, job.ID, result.InputTokens, result.OutputTokens)
+	// budget (#338 Part B) can sum a tree's cost. Usage accounting must never fail
+	// a delivery, so every write error here is swallowed.
+	if err == nil {
+		inTok, outTok := result.InputTokens, result.OutputTokens
+		// codex reports SESSION-CUMULATIVE counts on a resumed thread (#661): the
+		// session's whole running total, not this job's usage. When the adapter flags
+		// them cumulative, convert to this job's per-session delta keyed by the
+		// runtime session (runtime+ref) before persisting. Only a concrete, stable
+		// ref names a session we can key on; an empty or "last" ref does not, so —
+		// as today — it contributes 0 rather than being mis-attributed. A false flag
+		// (fresh/single-use, and every non-codex runtime) skips the delta table
+		// entirely and records the count verbatim (#664).
+		if result.CumulativeUsage && agent.RuntimeRef != "" && agent.RuntimeRef != runtime.LastRef {
+			inTok, outTok, _ = m.Store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+agent.RuntimeRef, result.InputTokens, result.OutputTokens)
+		} else if result.CumulativeUsage {
+			inTok, outTok = 0, 0
+		}
+		// Only persist when a positive count remains so runtimes that report nothing
+		// (e.g. the shell runtime) or a delta that resolved to 0 leave the columns at
+		// their 0 default rather than taking a no-op write.
+		if inTok > 0 || outTok > 0 {
+			_ = m.Store.UpdateJobUsage(ctx, job.ID, inTok, outTok)
+		}
 	}
 	if strings.TrimSpace(result.Summary) != "" {
 		return result.Summary, result.RefreshedRuntimeRef, err

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -305,6 +305,133 @@ func TestMailboxRunDeliversModelOverride(t *testing.T) {
 	}
 }
 
+// okDeliveryResult is a minimal well-formed gitmoot_result so a fake delivery
+// classifies to a terminal state and the job persists its recorded usage.
+const okDeliveryResult = `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+
+// TestMailboxDeliverDeltasCumulativeUsage pins the #661 wiring: when the adapter
+// flags usage CUMULATIVE (a codex resumed thread reports the session's running
+// total), the mailbox records only this job's per-session delta, not the whole
+// cumulative. Two sequential deliveries on the SAME agent runtime ref report
+// cumulatives 1000/100 then 1500/150; the first job persists the full 1000/100
+// (baseline 0) and the second persists only the 500/50 increase.
+func TestMailboxDeliverDeltasCumulativeUsage(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "planner", Runtime: runtime.CodexRuntime, RuntimeRef: "019f3041-cfed-7e82-8766-b5ca75cf92da", RepoScope: "jerryfane/gitmoot", Role: "implementer"}
+	adapter := &fakeDelivery{
+		outputs:      []string{okDeliveryResult, okDeliveryResult},
+		inputTokens:  []int{1000, 1500},
+		outputTokens: []int{100, 150},
+		cumulative:   []bool{true, true},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-a", Agent: "planner", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue job-a: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-a", agent, adapter); err != nil {
+		t.Fatalf("Run job-a: %v", err)
+	}
+	jobA, err := store.GetJob(ctx, "job-a")
+	if err != nil {
+		t.Fatalf("GetJob job-a: %v", err)
+	}
+	if jobA.InputTokens != 1000 || jobA.OutputTokens != 100 {
+		t.Fatalf("job-a usage = (%d, %d), want (1000, 100) — full cumulative on a fresh session baseline", jobA.InputTokens, jobA.OutputTokens)
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-b", Agent: "planner", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue job-b: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-b", agent, adapter); err != nil {
+		t.Fatalf("Run job-b: %v", err)
+	}
+	jobB, err := store.GetJob(ctx, "job-b")
+	if err != nil {
+		t.Fatalf("GetJob job-b: %v", err)
+	}
+	if jobB.InputTokens != 500 || jobB.OutputTokens != 50 {
+		t.Fatalf("job-b usage = (%d, %d), want (500, 50) — only the per-session delta, not the 1500/150 cumulative", jobB.InputTokens, jobB.OutputTokens)
+	}
+}
+
+// TestMailboxDeliverRecordsNonCumulativeVerbatim guards #664 at the mailbox seam:
+// usage NOT flagged cumulative (fresh sessions, single-use ephemeral/temp workers,
+// and every non-codex runtime) is recorded verbatim and NEVER routed through the
+// per-session delta table. Two deliveries on the same ref report independent per-job
+// counts and each lands in full — a delta would have clamped the second (smaller)
+// count against the first.
+func TestMailboxDeliverRecordsNonCumulativeVerbatim(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: "fresh-thread-xyz", RepoScope: "jerryfane/gitmoot", Role: "implementer"}
+	adapter := &fakeDelivery{
+		outputs:      []string{okDeliveryResult, okDeliveryResult},
+		inputTokens:  []int{3000, 2000},
+		outputTokens: []int{300, 200},
+		cumulative:   []bool{false, false},
+	}
+
+	for _, tc := range []struct {
+		id      string
+		wantIn  int
+		wantOut int
+	}{
+		{"job-c", 3000, 300},
+		{"job-d", 2000, 200},
+	} {
+		if _, err := mailbox.Enqueue(ctx, JobRequest{ID: tc.id, Agent: "impl", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+			t.Fatalf("Enqueue %s: %v", tc.id, err)
+		}
+		if _, err := mailbox.Run(ctx, tc.id, agent, adapter); err != nil {
+			t.Fatalf("Run %s: %v", tc.id, err)
+		}
+		job, err := store.GetJob(ctx, tc.id)
+		if err != nil {
+			t.Fatalf("GetJob %s: %v", tc.id, err)
+		}
+		if job.InputTokens != tc.wantIn || job.OutputTokens != tc.wantOut {
+			t.Fatalf("%s usage = (%d, %d), want (%d, %d) verbatim — a false flag must not be delta'd", tc.id, job.InputTokens, job.OutputTokens, tc.wantIn, tc.wantOut)
+		}
+	}
+}
+
+// TestMailboxDeliverCumulativeAmbiguousRefContributesZero pins the fallback: a
+// cumulative-flagged delivery on an empty or "last" runtime ref names no concrete,
+// stable session to key a delta on, so — as before #661 — it contributes 0 rather
+// than mis-attributing the whole cumulative to the job.
+func TestMailboxDeliverCumulativeAmbiguousRefContributesZero(t *testing.T) {
+	for _, ref := range []string{"", runtime.LastRef} {
+		t.Run("ref="+ref, func(t *testing.T) {
+			ctx := context.Background()
+			store := openTestStore(t)
+			mailbox := Mailbox{Store: store}
+			agent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: ref, RepoScope: "jerryfane/gitmoot", Role: "implementer"}
+			adapter := &fakeDelivery{
+				outputs:      []string{okDeliveryResult},
+				inputTokens:  []int{2000},
+				outputTokens: []int{200},
+				cumulative:   []bool{true},
+			}
+			if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-e", Agent: "impl", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			if _, err := mailbox.Run(ctx, "job-e", agent, adapter); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			job, err := store.GetJob(ctx, "job-e")
+			if err != nil {
+				t.Fatalf("GetJob: %v", err)
+			}
+			if job.InputTokens != 0 || job.OutputTokens != 0 {
+				t.Fatalf("ambiguous-ref usage = (%d, %d), want (0, 0)", job.InputTokens, job.OutputTokens)
+			}
+		})
+	}
+}
+
 func TestMailboxEnqueuePersistsRootJobID(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
@@ -1033,6 +1160,9 @@ type fakeDelivery struct {
 	outputs       []string
 	summaries     []string
 	refreshedRefs []string
+	inputTokens   []int
+	outputTokens  []int
+	cumulative    []bool
 	prompts       []string
 	models        []string
 	agentRefs     []string
@@ -1061,6 +1191,15 @@ func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runti
 	}
 	if index < len(f.refreshedRefs) {
 		result.RefreshedRuntimeRef = f.refreshedRefs[index]
+	}
+	if index < len(f.inputTokens) {
+		result.InputTokens = f.inputTokens[index]
+	}
+	if index < len(f.outputTokens) {
+		result.OutputTokens = f.outputTokens[index]
+	}
+	if index < len(f.cumulative) {
+		result.CumulativeUsage = f.cumulative[index]
 	}
 	return result, nil
 }

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -423,7 +423,7 @@ a job whose runtime reports no usage contributes `0` to the sum, so the budget
 | --- | --- | --- |
 | **Claude Code** | Yes | Parsed from the `usage.{input,output}_tokens` of the `--output-format json` envelope on delivery. |
 | **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
-| **Codex** | Fresh sessions only | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658) for fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides). Resumed sessions contribute `0`: codex reports session-cumulative usage there, which would attribute the whole session history to each job. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
+| **Codex** | Yes | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658). Fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides) and single-use workers report a per-job count directly. On a resumed session codex's usage is session-cumulative, so gitmoot records only the per-session delta — `max(0, cumulative_now − last_seen)`, tracked in the `runtime_session_usage` table (#661); a session reset that rolls the counter backwards clamps the delta to `0` and resyncs. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
 
 Capture is best-effort, so treat the budget as a coarse runaway-cost backstop
 rather than a precise spend limit — a runtime that reports nothing (or an older

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -151,8 +151,8 @@ cannot recurse or fan out forever:
   already used at least the budget is refused with a `delegation_cost_exceeded`
   event. Token capture is **best-effort per runtime** (Claude reports usage; Kimi
   reports it if its stream emits it; Codex reads usage from its `codex exec --json`
-  JSONL stream for fresh sessions only — resumed sessions contribute `0` because
-  codex reports session-cumulative usage there — falling back to `0` on an older CLI), so the budget can under-count
+  JSONL stream — a resumed session's usage is session-cumulative, so it records only
+  the per-session delta (#661) — falling back to `0` on an older CLI), so the budget can under-count
   but never over-counts. Leaving the knob at `0` skips the check entirely.
 - Per-root **dollar-cost** budget `[orchestrate].max_delegation_cost_usd`,
   **off by default** (`0` = unlimited): the cost analogue of the token budget

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -542,7 +542,7 @@ than failing:
 | --- | --- | --- |
 | **Claude Code** | Yes | Parsed from `usage.{input,output}_tokens` of the `--output-format json` envelope. |
 | **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
-| **Codex** | Fresh sessions only | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658) for fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides). Resumed sessions contribute `0`: codex reports session-cumulative usage there, which would attribute the whole session history to each job. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
+| **Codex** | Yes | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658). Fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides) and single-use workers report a per-job count directly. On a resumed session codex's usage is session-cumulative, so gitmoot records only the per-session delta — `max(0, cumulative_now − last_seen)`, tracked in the `runtime_session_usage` table (#661); a session reset that rolls the counter backwards clamps the delta to `0` and resyncs. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
 
 Capture is best-effort, so treat the budget as a coarse runaway-cost backstop,
 not a precise spend limit — a runtime that reports nothing (or an older codex CLI

--- a/website/docs/workflows/cockpit-orchestrate-workflow.md
+++ b/website/docs/workflows/cockpit-orchestrate-workflow.md
@@ -111,9 +111,9 @@ default_repair_timeout = ""
   continuation. Token capture is **best-effort per runtime** — Claude reports
   usage via `--output-format json`, Kimi reports it when its stream emits a
   `usage` object, and Codex reads usage from its `codex exec --json` JSONL stream
-  for fresh sessions only (resumed sessions contribute `0` — codex reports
-  session-cumulative usage there; older CLIs that predate the flag also fall
-  back to `0`). Treat it as a
+  — a resumed session's usage is session-cumulative, so it records only the
+  per-session delta (#661); older CLIs that predate the flag fall
+  back to `0`. Treat it as a
   coarse runaway-cost backstop, not a precise spend limit; the budget is in raw
   tokens. Leaving it at `0` is byte-identical to before the knob existed.
 - `max_delegation_cost_usd` (default `0` = unlimited/off) is the **dollar-cost**

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3221,9 +3221,9 @@ default_repair_timeout = ""
   continuation (synthesize what completed, then stop). Token capture is
   **best-effort per runtime**: Claude reports usage via its `--output-format json`
   envelope, Kimi reports it when its stream emits a `usage` object, and Codex reads
-  usage from its `codex exec --json` JSONL stream for fresh sessions only
-  (resumed sessions contribute `0` — codex reports session-cumulative usage
-  there; older CLIs that predate the flag also fall back to `0`). Treat it as a coarse runaway-cost backstop, not a
+  usage from its `codex exec --json` JSONL stream — a resumed session's usage is
+  session-cumulative, so it records only the per-session delta (#661); older CLIs
+  that predate the flag fall back to `0`. Treat it as a coarse runaway-cost backstop, not a
   precise spend limit; the budget is in raw tokens. Leaving it at `0` is
   byte-identical to before the knob existed.
 - `max_delegation_cost_usd` (default `0` = unlimited/off) is the **dollar-cost**
@@ -7534,6 +7534,15 @@ Use `gitmoot agent template draft <id>` for a blank scaffold,
 `gitmoot agent template export/publish/pull/remote set` commands — see CLI.md
 § Agent Templates.
 
+For agent persistent memory, phrases like "give this agent persistent memory",
+"why does my agent keep forgetting things about this repo", or "what has this
+agent learned" map to Gitmoot's off-by-default agent memory feature (#626): an
+enrolled agent gets a repo-filtered pool of durable facts injected into its job
+prompt as a read-only "Prior learnings" reference block (never instructions).
+Enrollment is per agent via `[agents.<name>].memory = true` plus an optional
+`[memory]` section; inspect the store read-only with `gitmoot memory list`. See
+CLI.md § Agent Memory and the "Agent Persistent Memory" concepts page for depth.
+
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
 same Codex, Claude, or Kimi session, and branch locks protect implementation
@@ -10100,8 +10109,8 @@ cannot recurse or fan out forever:
   already used at least the budget is refused with a `delegation_cost_exceeded`
   event. Token capture is **best-effort per runtime** (Claude reports usage; Kimi
   reports it if its stream emits it; Codex reads usage from its `codex exec --json`
-  JSONL stream for fresh sessions only — resumed sessions contribute `0` because
-  codex reports session-cumulative usage there — falling back to `0` on an older CLI), so the budget can under-count
+  JSONL stream — a resumed session's usage is session-cumulative, so it records only
+  the per-session delta (#661) — falling back to `0` on an older CLI), so the budget can under-count
   but never over-counts. Leaving the knob at `0` skips the check entirely.
 - Per-root **dollar-cost** budget `[orchestrate].max_delegation_cost_usd`,
   **off by default** (`0` = unlimited): the cost analogue of the token budget
@@ -10618,7 +10627,7 @@ a job whose runtime reports no usage contributes `0` to the sum, so the budget
 | --- | --- | --- |
 | **Claude Code** | Yes | Parsed from the `usage.{input,output}_tokens` of the `--output-format json` envelope on delivery. |
 | **Kimi Code** | Best-effort | Captured if the `--output-format stream-json` stream emits a `usage` object; otherwise `0`. |
-| **Codex** | Fresh sessions only | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658) for fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides). Resumed sessions contribute `0`: codex reports session-cumulative usage there, which would attribute the whole session history to each job. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
+| **Codex** | Yes | Read from the last `turn.completed` usage of the `codex exec --json` JSONL stream (#658). Fresh sessions (ephemeral delegation workers, per-job `--runtime` overrides) and single-use workers report a per-job count directly. On a resumed session codex's usage is session-cumulative, so gitmoot records only the per-session delta — `max(0, cumulative_now − last_seen)`, tracked in the `runtime_session_usage` table (#661); a session reset that rolls the counter backwards clamps the delta to `0` and resyncs. Older CLIs that predate `--json` fall back to plain text and contribute `0`. |
 
 Capture is best-effort, so treat the budget as a coarse runaway-cost backstop
 rather than a precise spend limit — a runtime that reports nothing (or an older


### PR DESCRIPTION
## What

Codex reports `turn.completed` usage as **session-cumulative** on resumed threads — the session's running total, not the turn's cost. #658/#664 therefore captured usage only for fresh/single-use sessions and had resumed sessions contribute 0 (explicitly deferring delta tracking to this issue).

This PR adds **per-session delta tracking**:
- `runtime.Result` gains `CumulativeUsage bool`; `codexDeliverResult` now always returns the parsed counts and flags resumed sessions as cumulative. Fresh + single-use paths are **byte-identical** to before (#664 guard — the false path never touches the delta table).
- New `runtime_session_usage` table (additive migration, appended last) stores last-seen cumulative counters keyed `runtime:ref`; `Store.RecordRuntimeSessionUsageDelta` does one transaction: SELECT baseline → `max(0, cum−prev)` → UPSERT. A backwards counter (session compaction/rollover) yields delta 0 and resyncs — a safe under-count, never corruption.
- Mailbox `deliver()` applies the delta only for `CumulativeUsage && concrete stable ref`; empty/`last` refs contribute 0 (today's behavior); delta errors are swallowed (usage accounting never fails delivery); `UpdateJobUsage` accumulate semantics untouched.

## Verification
- Adapter tests: resumed delivery now asserts cumulative counts + flag; fresh and single-use tests assert `CumulativeUsage == false` (#664 non-regression at the adapter seam); flag-matrix table test incl. the fail-open branch.
- DB tests (`-race`): first-call/delta/backwards-resync/negative-clamp + a 64-goroutine concurrency test proving SELECT+UPSERT atomicity (sum of deltas == cumulative, exactly one non-zero).
- Mailbox tests: delta path, verbatim path (fresh/single-use), ambiguous-ref-zero path.
- Adversarial 2-lens review: both lenses approve in round 1.
- Full local gate + integrated-tree verify green (with #649/#651/#654 + main@3935688).

## Docs
Two-tree update (skill refs RESULT_CONTRACT/SAFETY + website result-contract + cockpit-orchestrate pages, both trees). `llms-full.txt` regenerated via `node website/scripts/build-llms-full.mjs` — note this also picked up a pre-existing stale #626 block the generator sources from SKILL.md (bringing the committed artifact back in sync, no unrelated churn).

## Known-and-accepted (v1)
- Repair-retry re-delivery accumulates an incremental delta (approximately correct — the retry did consume tokens).
- No GC for `runtime_session_usage` rows (tens of bytes per dead thread) — bounded cleanup is a follow-up.

## Deploy notes
Additive migration auto-runs on first start. No config. Standard local deploy.

Fixes #661

🤖 Generated with [Claude Code](https://claude.com/claude-code)
