### PR TITLE
feat(dashboard): agent config + memory pool counts + dep bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704210015-df2c3e78c5ae
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705130251-1655216f947f
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704191557-9d53381170c9 h1:dJq
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704191557-9d53381170c9/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704210015-df2c3e78c5ae h1:ik2XgEajqjnT94APbK39+TBmVxe5szAUqGb5e71hEjc=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704210015-df2c3e78c5ae/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705130251-1655216f947f h1:RYY2X3CnLjTKx9g1FoLYXWlxmAV7YvLnefozT2w48aA=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705130251-1655216f947f/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -22,7 +22,9 @@ import (
 	dashboard "github.com/jerryfane/gitmoot-dashboard"
 
 	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
 	"github.com/jerryfane/gitmoot/internal/update"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -298,7 +300,7 @@ func (d *webDataSource) Jobs(ctx context.Context) ([]dashboard.JobSummary, error
 // rollup is always last.
 func (d *webDataSource) Agents(ctx context.Context) ([]dashboard.AgentSummary, error) {
 	out := []dashboard.AgentSummary{}
-	err := withStore(d.home, func(store *db.Store) error {
+	err := withStoreAndPaths(d.home, func(paths config.Paths, store *db.Store) error {
 		agents, err := store.ListAgents(ctx)
 		if err != nil {
 			return err
@@ -308,6 +310,11 @@ func (d *webDataSource) Agents(ctx context.Context) ([]dashboard.AgentSummary, e
 			return err
 		}
 
+		// The [agents.<name>] config sections drive the per-agent memory chip. Load
+		// them ONCE per call, fail-open: a config-load error yields a nil map (no
+		// chips) rather than failing the endpoint (mirrors Health()'s fail-open path).
+		agentTypes := loadAgentTypesFailOpen(paths)
+
 		// Aggregate per-agent job stats from the single ListJobs pass (shared with
 		// Agent()). Ephemeral workers fold into one rollup.
 		byAgent, ephemeral, hasEphemeral := aggregateAgentJobStats(jobs)
@@ -315,6 +322,9 @@ func (d *webDataSource) Agents(ctx context.Context) ([]dashboard.AgentSummary, e
 		out = make([]dashboard.AgentSummary, 0, len(agents)+1)
 		for _, a := range agents {
 			summary := newAgentSummary(a)
+			if at, ok := agentTypes[a.Name]; ok {
+				summary.MemoryEnabled = at.Memory
+			}
 			if s := byAgent[a.Name]; s != nil {
 				s.applyTo(&summary)
 			}
@@ -347,7 +357,7 @@ func (d *webDataSource) Agents(ctx context.Context) ([]dashboard.AgentSummary, e
 // the API layer returns 404 rather than 500.
 func (d *webDataSource) Agent(ctx context.Context, name string) (dashboard.AgentDetail, error) {
 	detail := dashboard.AgentDetail{Versions: []dashboard.TemplateVersionInfo{}}
-	err := withStore(d.home, func(store *db.Store) error {
+	err := withStoreAndPaths(d.home, func(paths config.Paths, store *db.Store) error {
 		agent, err := store.GetAgent(ctx, name)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -367,7 +377,25 @@ func (d *webDataSource) Agent(ctx context.Context, name string) (dashboard.Agent
 		if s := byAgent[agent.Name]; s != nil {
 			s.applyTo(&summary)
 		}
+
+		// Config-section visibility. Load the [agents.<name>] sections ONCE, fail-open
+		// (a config-load error => no section, Config nil, no chip — never an endpoint
+		// error). Config is nil unless this agent has its own section; the memory chip
+		// mirrors that section's memory flag so the summary matches Agents().
+		if at, ok := loadAgentTypesFailOpen(paths)[agent.Name]; ok {
+			summary.MemoryEnabled = at.Memory
+			detail.Config = agentConfigInfo(at)
+		}
 		detail.AgentSummary = summary
+
+		// Owned memory pool sizes (all owner versions). Fail-open: a query error
+		// leaves the count at 0 rather than failing the endpoint.
+		if n, cerr := store.CountConfirmedMemoriesForOwner(ctx, memory.OwnerKindAgent, agent.Name); cerr == nil {
+			detail.MemoryFacts = n
+		}
+		if n, cerr := store.CountMemoryObservationsForOwner(ctx, memory.OwnerKindAgent, agent.Name); cerr == nil {
+			detail.MemoryObservations = n
+		}
 
 		// Template + version history. Fail-open: a missing/broken template leaves the
 		// detail's Template nil and Versions the initialized empty slice rather than
@@ -401,6 +429,37 @@ func newAgentSummary(a db.Agent) dashboard.AgentSummary {
 		Capabilities:   a.Capabilities,
 		AutonomyPolicy: strings.TrimSpace(a.AutonomyPolicy),
 		Health:         strings.TrimSpace(a.HealthStatus),
+	}
+}
+
+// loadAgentTypesFailOpen loads the [agents.<name>] config sections for the memory
+// chip / config panel, returning nil on ANY error (missing/unreadable/malformed
+// config) so both Agents() and Agent() degrade to "no config visibility" rather
+// than failing the endpoint. Indexing the nil result is safe (a missing key
+// yields the zero AgentType, ok=false), so callers gate on the comma-ok.
+func loadAgentTypesFailOpen(paths config.Paths) map[string]config.AgentType {
+	types, err := config.LoadAgentTypes(paths)
+	if err != nil {
+		return nil
+	}
+	return types
+}
+
+// agentConfigInfo maps a resolved config.AgentType onto the dashboard's
+// AgentConfigInfo. The values are the [agents.<name>] section as LoadAgentTypes
+// resolves it — parse-time defaults INCLUDED (capabilities default ["ask"],
+// max_background 1, idle_timeout 20m, job_timeout 10m) — surfaced as-is per the
+// contract. Only ever called for an agent that has a config section (a non-nil
+// return is meaningful presence).
+func agentConfigInfo(at config.AgentType) *dashboard.AgentConfigInfo {
+	return &dashboard.AgentConfigInfo{
+		Memory:        at.Memory,
+		MaxBackground: at.MaxBackground,
+		IdleTimeout:   strings.TrimSpace(at.IdleTimeout),
+		JobTimeout:    strings.TrimSpace(at.JobTimeout),
+		Model:         strings.TrimSpace(at.Model),
+		Template:      strings.TrimSpace(at.Template),
+		Capabilities:  at.Capabilities,
 	}
 }
 

--- a/internal/cli/dashboard_web_test.go
+++ b/internal/cli/dashboard_web_test.go
@@ -1511,3 +1511,152 @@ func TestWebDataSourceUpdateNoRelease(t *testing.T) {
 		t.Fatalf("no-release update = %+v, want nil", u)
 	}
 }
+
+// TestWebDataSourceAgentConfigAndMemory asserts the config-visibility enrichment:
+// Agents() sets MemoryEnabled from each agent's [agents.<name>] section, and
+// Agent() builds AgentDetail.Config (nil when the agent has no section) plus the
+// two owned-memory counts (across all owner versions, scoped to the agent).
+func TestWebDataSourceAgentConfigAndMemory(t *testing.T) {
+	home := dashboardTestHome(t)
+	paths := config.PathsForHome(home)
+	ctx := context.Background()
+
+	// Config sections: mem-agent enrolled (memory on, custom pool knobs); plain-agent
+	// has a section with memory OFF (parse-time defaults fill the rest); nosection-agent
+	// gets NO [agents.<name>] section at all.
+	if err := config.SaveAgentType(paths, config.AgentType{
+		Name: "mem-agent", Runtime: "codex", Memory: true,
+		MaxBackground: 3, IdleTimeout: "15m", JobTimeout: "30m",
+		Model: "gpt-5.5", Template: "coordinator", Capabilities: []string{"orchestrate", "review"},
+	}); err != nil {
+		t.Fatalf("SaveAgentType mem-agent: %v", err)
+	}
+	if err := config.SaveAgentType(paths, config.AgentType{Name: "plain-agent", Runtime: "claude", Memory: false}); err != nil {
+		t.Fatalf("SaveAgentType plain-agent: %v", err)
+	}
+
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	// Store registration is independent of the config section: all three agents are
+	// registered, but only two carry a section and only one has memory rows.
+	for _, a := range []db.Agent{
+		{Name: "mem-agent", Runtime: "codex"},
+		{Name: "plain-agent", Runtime: "claude"},
+		{Name: "nosection-agent", Runtime: "codex"},
+	} {
+		if err := store.UpsertAgent(ctx, a); err != nil {
+			t.Fatalf("UpsertAgent %s: %v", a.Name, err)
+		}
+	}
+
+	// Seed memory rows OWNED by mem-agent: two confirmed facts (distinct keys, one
+	// under a non-empty owner version so the "all owner versions" count is exercised)
+	// and three observations (append-only; a repeated key still counts). Rows owned
+	// by a DIFFERENT agent must be excluded from mem-agent's counts.
+	seedConfirmed := func(ref, version, key string) {
+		if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: ref, Version: version},
+			Repo:  "jerryfane/noted", Scope: "repo", Key: key, Content: "fact " + key,
+		}); err != nil {
+			t.Fatalf("UpsertConfirmedMemory: %v", err)
+		}
+	}
+	seedObs := func(ref, key string) {
+		if _, err := store.InsertMemoryObservation(ctx, db.MemoryObservation{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: ref},
+			Repo:  "jerryfane/noted", Scope: "repo", Key: key, Content: "obs " + key,
+		}); err != nil {
+			t.Fatalf("InsertMemoryObservation: %v", err)
+		}
+	}
+	seedConfirmed("mem-agent", "", "fix-rounds")
+	seedConfirmed("mem-agent", "v2", "outcome") // different owner version, still counted
+	seedObs("mem-agent", "a")
+	seedObs("mem-agent", "a") // append-only: the repeated key is a distinct row
+	seedObs("mem-agent", "b")
+	seedConfirmed("other-agent", "", "x") // foreign owner, must be excluded
+	seedObs("other-agent", "y")
+	store.Close()
+
+	ds := &webDataSource{home: home}
+
+	// Agents(): MemoryEnabled tracks the config section — enrolled vs off vs none.
+	agents, err := ds.Agents(ctx)
+	if err != nil {
+		t.Fatalf("Agents: %v", err)
+	}
+	byName := map[string]dashboard.AgentSummary{}
+	for _, a := range agents {
+		byName[a.Name] = a
+	}
+	if !byName["mem-agent"].MemoryEnabled {
+		t.Fatalf("mem-agent MemoryEnabled = false, want true")
+	}
+	if byName["plain-agent"].MemoryEnabled {
+		t.Fatalf("plain-agent MemoryEnabled = true, want false (config memory off)")
+	}
+	if byName["nosection-agent"].MemoryEnabled {
+		t.Fatalf("nosection-agent MemoryEnabled = true, want false (no config section)")
+	}
+
+	// Agent(mem-agent): full config section + owned memory counts.
+	mem, err := ds.Agent(ctx, "mem-agent")
+	if err != nil {
+		t.Fatalf("Agent(mem-agent): %v", err)
+	}
+	if !mem.MemoryEnabled {
+		t.Fatalf("mem-agent detail MemoryEnabled = false, want true")
+	}
+	if mem.Config == nil {
+		t.Fatalf("mem-agent Config = nil, want a section")
+	}
+	if !mem.Config.Memory || mem.Config.MaxBackground != 3 || mem.Config.IdleTimeout != "15m" ||
+		mem.Config.JobTimeout != "30m" || mem.Config.Model != "gpt-5.5" || mem.Config.Template != "coordinator" {
+		t.Fatalf("mem-agent Config = %+v, want the seeded section values", mem.Config)
+	}
+	if len(mem.Config.Capabilities) != 2 {
+		t.Fatalf("mem-agent Config.Capabilities = %v, want 2", mem.Config.Capabilities)
+	}
+	if mem.MemoryFacts != 2 {
+		t.Fatalf("mem-agent MemoryFacts = %d, want 2 (both owner versions)", mem.MemoryFacts)
+	}
+	if mem.MemoryObservations != 3 {
+		t.Fatalf("mem-agent MemoryObservations = %d, want 3", mem.MemoryObservations)
+	}
+
+	// Agent(plain-agent): a section exists (memory off; parse-time defaults folded in),
+	// no memory rows.
+	plain, err := ds.Agent(ctx, "plain-agent")
+	if err != nil {
+		t.Fatalf("Agent(plain-agent): %v", err)
+	}
+	if plain.MemoryEnabled {
+		t.Fatalf("plain-agent detail MemoryEnabled = true, want false")
+	}
+	if plain.Config == nil || plain.Config.Memory {
+		t.Fatalf("plain-agent Config = %+v, want a non-nil section with memory off", plain.Config)
+	}
+	if plain.Config.MaxBackground != 1 || plain.Config.IdleTimeout != "20m" || plain.Config.JobTimeout != "10m" {
+		t.Fatalf("plain-agent Config defaults = %+v, want max_background 1 / idle 20m / job 10m", plain.Config)
+	}
+	if plain.MemoryFacts != 0 || plain.MemoryObservations != 0 {
+		t.Fatalf("plain-agent memory counts = %d/%d, want 0/0", plain.MemoryFacts, plain.MemoryObservations)
+	}
+
+	// Agent(nosection-agent): no config section => nil Config, no chip, zero counts.
+	none, err := ds.Agent(ctx, "nosection-agent")
+	if err != nil {
+		t.Fatalf("Agent(nosection-agent): %v", err)
+	}
+	if none.Config != nil {
+		t.Fatalf("nosection-agent Config = %+v, want nil (no section)", none.Config)
+	}
+	if none.MemoryEnabled {
+		t.Fatalf("nosection-agent MemoryEnabled = true, want false")
+	}
+	if none.MemoryFacts != 0 || none.MemoryObservations != 0 {
+		t.Fatalf("nosection-agent memory counts = %d/%d, want 0/0", none.MemoryFacts, none.MemoryObservations)
+	}
+}

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -116,6 +116,39 @@ WHERE owner_kind = ? AND owner_ref = ? AND owner_version = ?
 	return n, nil
 }
 
+// CountConfirmedMemoriesForOwner returns how many confirmed_memories rows an
+// owner owns, across ALL owner versions and every repo/scope (owner_version is
+// deliberately not filtered — an agent owner always writes owner_version=''), so
+// it answers "how many injectable facts does this agent own". It backs the
+// dashboard's per-agent memory count and is a plain read (no FTS). Superseded
+// rows are excluded (superseded_by IS NULL) so the count matches the injectable
+// set surfaced by QueryConfirmedMemories.
+func (s *Store) CountConfirmedMemoriesForOwner(ctx context.Context, ownerKind, ownerRef string) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM confirmed_memories
+WHERE owner_kind = ? AND owner_ref = ? AND superseded_by IS NULL`, ownerKind, ownerRef).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count confirmed memories for owner: %w", err)
+	}
+	return n, nil
+}
+
+// CountMemoryObservationsForOwner returns how many memory_observations rows an
+// owner owns, across ALL owner versions and every repo/scope/key. Observations
+// are append-only, so this is the raw sighting-report volume for the owner. It
+// backs the dashboard's per-agent observation count.
+func (s *Store) CountMemoryObservationsForOwner(ctx context.Context, ownerKind, ownerRef string) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM memory_observations
+WHERE owner_kind = ? AND owner_ref = ?`, ownerKind, ownerRef).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count memory observations for owner: %w", err)
+	}
+	return n, nil
+}
+
 // UpsertConfirmedMemory writes or updates the single keyed confirmed row for a
 // fact and keeps the FTS index in sync, all in one transaction. Writes are
 // serialized by the store (MaxOpenConns=1) so a manual select-then-insert/update


### PR DESCRIPTION
Companion to [gitmoot-dashboard#30](https://github.com/jerryfane/gitmoot-dashboard/pull/30) (interface grew → bump + impl together).

- `AgentSummary.MemoryEnabled` + `AgentDetail.Config` from `[agents.<name>]` (via `LoadAgentTypes`, dual-mode home resolution)
- `MemoryFacts`/`MemoryObservations` counts on the canonical `memory.OwnerKindAgent` owner key; the fact count excludes superseded rows so it matches the injectable set (`QueryConfirmedMemories`) exactly
- Fail-open throughout

Verified live: 13 enrolled agents surface chips; planner's panel shows config + an honestly-empty pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)