### PR TITLE
fix: session isolation + task-run recovery (lands #665 by @plotarmordev + review fixes)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -38,6 +38,7 @@ gitmoot agent show <name>
 gitmoot agent doctor <name>
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
+gitmoot task recover task-001 --owner lead   # finalize a dead implement's dirty worktree
 gitmoot task list --repo owner/repo
 gitmoot job list
 gitmoot job show <job-id>
@@ -57,6 +58,17 @@ gitmoot daemon status
 Goal import turns Markdown headings shaped like `### Task N: Title` into local
 planned tasks. `task run` starts one task branch in a dedicated worktree,
 records its branch lock, and stores the worktree path on the task.
+
+If an implementer dies mid-work — after editing the task worktree but before it
+commits, pushes, and opens a PR — the edits are left uncommitted. `task run`
+(and `agent implement`) refuse to restart over a dirty worktree with no active
+job, rather than silently discard the work, and point at `task recover <id>
+--owner <agent>`. `task recover` commits the full worktree state (`git add -A`,
+including untracked non-ignored files), pushes the branch, and opens or adopts
+the task's PR — the finalize steps the dead implementer never reached. `--repo`
+is optional (it falls back to the task's stored repo). Recovery refuses while a
+live process is still inside the task worktree; wait for it to exit or stop the
+orphaned implementer first.
 
 ## Runtime Plugin Setup
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
@@ -469,10 +471,16 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 	if executionPath == "orchestrate" {
 		errLabel = "orchestrate"
 	}
+	dispatchCtx := context.Background()
+	var stopSignals context.CancelFunc
+	if !options.background {
+		dispatchCtx, stopSignals = signal.NotifyContext(dispatchCtx, os.Interrupt, syscall.SIGTERM)
+		defer stopSignals()
+	}
 	var output localAgentJobOutput
 	if err := withStore(options.home, func(store *db.Store) error {
 		var err error
-		output, err = dispatchLocalAgentJob(context.Background(), store, localAgentDispatchRequest{
+		output, err = dispatchLocalAgentJob(dispatchCtx, store, localAgentDispatchRequest{
 			RepoFlag:               options.repo,
 			Agent:                  options.agent,
 			Action:                 action,

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -572,6 +572,9 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 			} else if ok {
 				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s already has active implement job %s for task %s", branchHint, active.ID, existing.ID)
 			}
+			if strings.TrimSpace(existing.WorktreePath) != "" && taskWorktreeHasLiveProcess(existing.WorktreePath) {
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has a live process still inside task worktree %s; wait for it to exit or stop the orphaned implementer before retrying implement", branchHint, existing.WorktreePath)
+			}
 			if dirty, err := taskWorktreeDirty(ctx, existing); err != nil {
 				return db.Task{}, localAgentDispatchRequest{}, err
 			} else if dirty {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -564,6 +564,20 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 			return db.Task{}, localAgentDispatchRequest{}, err
 		}
 		if err == nil {
+			if !taskBranchReusableForImplement(existing.State) {
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s belongs to task %s in state %s; choose a fresh branch or recover/review the existing task", branchHint, existing.ID, existing.State)
+			}
+			if active, ok, err := findActiveImplementJobForTask(ctx, store, repo.FullName(), branchHint, existing.ID); err != nil {
+				return db.Task{}, localAgentDispatchRequest{}, err
+			} else if ok {
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s already has active implement job %s for task %s", branchHint, active.ID, existing.ID)
+			}
+			if dirty, err := taskWorktreeDirty(ctx, existing); err != nil {
+				return db.Task{}, localAgentDispatchRequest{}, err
+			} else if dirty {
+				skipFanout := taskRecoverSkipFanout(ctx, store, repo.FullName(), branchHint)
+				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has uncommitted changes in task worktree %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying implement", branchHint, existing.WorktreePath, taskRecoverCommand(existing.ID, request.Home, repo.FullName(), request.Agent, skipFanout))
+			}
 			taskID = existing.ID
 			taskTitle = firstNonEmpty(taskTitle, existing.Title)
 			goalID = firstNonEmpty(goalID, existing.GoalID)

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -557,6 +557,21 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 	taskID := strings.TrimSpace(request.TaskID)
 	taskTitle := strings.TrimSpace(request.TaskTitle)
 	goalID := strings.TrimSpace(request.GoalID)
+	branchHint := strings.TrimSpace(request.Branch)
+	if taskID == "" && branchHint != "" {
+		existing, err := store.GetTaskByRepoBranch(ctx, repo.FullName(), branchHint)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return db.Task{}, localAgentDispatchRequest{}, err
+		}
+		if err == nil {
+			taskID = existing.ID
+			taskTitle = firstNonEmpty(taskTitle, existing.Title)
+			goalID = firstNonEmpty(goalID, existing.GoalID)
+			request.TaskID = taskID
+			request.TaskTitle = taskTitle
+			request.GoalID = goalID
+		}
+	}
 	if taskID == "" {
 		taskID = "adhoc-" + shortHash(request.Instructions+"\x00"+time.Now().UTC().Format(time.RFC3339Nano))
 		taskTitle = firstNonEmpty(taskTitle, shortTaskTitle(request.Instructions))

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -205,6 +205,9 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
 		return localAgentJobOutput{}, err
 	}
+	if overrideRuntime == "" {
+		effectiveAgent = scopeRegisteredFreshRefForJob(effectiveAgent, job.ID)
+	}
 	if request.Background {
 		return localAgentJobOutput{
 			JobID:                job.ID,

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -906,6 +906,93 @@ func TestPrepareLocalImplementDispatchRequestReusesExistingBranchTask(t *testing
 	}
 }
 
+func TestPrepareLocalImplementDispatchRequestRejectsDirtyExistingBranchTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	worktree := filepath.Join(home, "dirty-task")
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, repoDir, "worktree", "add", "-b", "feature/retry", worktree, "main")
+	if err := os.WriteFile(filepath.Join(worktree, "feature.txt"), []byte("partial work\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-existing",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-existing",
+		Title:        "Existing branch task",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "feature/retry",
+		WorktreePath: worktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	_, _, err := prepareLocalImplementDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "builder",
+		Action:       "implement",
+		Instructions: "Continue the existing implementation branch.",
+		Branch:       "feature/retry",
+	})
+	if err == nil || !strings.Contains(err.Error(), "uncommitted changes") || !strings.Contains(err.Error(), "gitmoot task recover task-existing") {
+		t.Fatalf("prepareLocalImplementDispatchRequest err = %v, want recover guidance", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "feature/retry"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("dirty dispatch refusal created branch lock, err=%v", err)
+	}
+}
+
+func TestPrepareLocalImplementDispatchRequestRejectsCompletedBranchTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-existing",
+		RepoFullName: "owner/repo",
+		State:        string(workflow.TaskMerged),
+		Branch:       "feature/retry",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	_, _, err := prepareLocalImplementDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "builder",
+		Action:       "implement",
+		Instructions: "Implement a new task on a reused branch.",
+		Branch:       "feature/retry",
+	})
+	if err == nil || !strings.Contains(err.Error(), "state merged") {
+		t.Fatalf("prepareLocalImplementDispatchRequest err = %v, want completed task rejection", err)
+	}
+}
+
 func TestRunAgentAskBackgroundQueuesWithoutRuntimeDelivery(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -955,6 +955,55 @@ func TestPrepareLocalImplementDispatchRequestRejectsDirtyExistingBranchTask(t *t
 	}
 }
 
+func TestPrepareLocalImplementDispatchRequestRejectsLiveExistingBranchTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	worktree := filepath.Join(home, "live-task")
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-existing",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-existing",
+		Title:        "Existing branch task",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "feature/retry",
+		WorktreePath: worktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	prev := taskWorktreeHasLiveProcess
+	taskWorktreeHasLiveProcess = func(path string) bool { return path == worktree }
+	defer func() { taskWorktreeHasLiveProcess = prev }()
+
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	_, _, err := prepareLocalImplementDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "builder",
+		Action:       "implement",
+		Instructions: "Continue the existing implementation branch.",
+		Branch:       "feature/retry",
+	})
+	if err == nil || !strings.Contains(err.Error(), "live process") {
+		t.Fatalf("prepareLocalImplementDispatchRequest err = %v, want live process", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "feature/retry"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("live dispatch refusal created branch lock, err=%v", err)
+	}
+}
+
 func TestPrepareLocalImplementDispatchRequestRejectsCompletedBranchTask(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -847,6 +847,65 @@ func TestPrepareLocalReviewDispatchRequestDoesNotReuseStaleReviewWorktree(t *tes
 	}
 }
 
+func TestPrepareLocalImplementDispatchRequestReusesExistingBranchTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("main\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-existing",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-existing",
+		Title:        "Existing branch task",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "feature/retry",
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
+	task, request, err := prepareLocalImplementDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
+		Home:         home,
+		Agent:        "builder",
+		Action:       "implement",
+		Instructions: "Continue the existing implementation branch.",
+		Branch:       "feature/retry",
+	})
+	if err != nil {
+		t.Fatalf("prepareLocalImplementDispatchRequest returned error: %v", err)
+	}
+	if task.ID != "task-existing" || request.TaskID != "task-existing" {
+		t.Fatalf("task.ID=%q request.TaskID=%q, want task-existing", task.ID, request.TaskID)
+	}
+	if task.Branch != "feature/retry" || request.Branch != "feature/retry" {
+		t.Fatalf("task.Branch=%q request.Branch=%q, want feature/retry", task.Branch, request.Branch)
+	}
+	if task.WorktreePath == "" {
+		t.Fatal("task worktree path was not allocated")
+	}
+	if currentBranch := strings.TrimSpace(runGitOutput(t, task.WorktreePath, "branch", "--show-current")); currentBranch != "feature/retry" {
+		t.Fatalf("task worktree branch = %q, want feature/retry", currentBranch)
+	}
+	stored, err := store.GetTask(ctx, "task-existing")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if stored.WorktreePath != task.WorktreePath || stored.State != string(workflow.TaskImplementing) {
+		t.Fatalf("stored task = %+v, returned task = %+v", stored, task)
+	}
+}
+
 func TestRunAgentAskBackgroundQueuesWithoutRuntimeDelivery(t *testing.T) {
 	home := t.TempDir()
 	repoDir := t.TempDir()

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4634,6 +4634,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			return nil
 		}
 	}
+	if !overridden {
+		agent = scopeRegisteredFreshRefForJob(agent, job.ID)
+	}
 	if readOnlyImplementationBlocked(job.Type, agent) {
 		transitioned, err := markJobPermissionBlocked(ctx, w.Store, job.ID)
 		if err != nil {

--- a/internal/cli/runtime_override.go
+++ b/internal/cli/runtime_override.go
@@ -85,6 +85,18 @@ func applyJobRuntimeOverride(agent runtime.Agent, payload workflow.JobPayload) r
 	return agent
 }
 
+// scopeRegisteredFreshRefForJob rewrites a stored fresh:<seat> ref to a
+// deterministic fresh:<job> ref for the actual execution. This keeps fresh
+// registered agents isolated per job and gives their runtime-session lock a
+// job-scoped key. Runtime overrides already mint a unique fresh ref per job at
+// enqueue time, so callers use this only for non-overridden jobs.
+func scopeRegisteredFreshRefForJob(agent runtime.Agent, jobID string) runtime.Agent {
+	if runtime.IsFreshRef(agent.RuntimeRef) {
+		agent.RuntimeRef = runtime.FreshRefForJob(jobID)
+	}
+	return agent
+}
+
 // overrideRuntimeSessionResourceKey computes the runtime-session lock key for
 // a job running under a runtime override. Resumable runtimes keep the normal
 // "runtime:<rt>:<ref>" key (an explicit session serializes with other users

--- a/internal/cli/runtime_override_test.go
+++ b/internal/cli/runtime_override_test.go
@@ -113,6 +113,35 @@ func TestApplyJobRuntimeOverride(t *testing.T) {
 	}
 }
 
+func TestScopeRegisteredFreshRefForJob(t *testing.T) {
+	agent := runtime.Agent{
+		Name:       "council-codex",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: "fresh:council-codex",
+	}
+
+	scoped := scopeRegisteredFreshRefForJob(agent, "local-ask-root/delegation/review-codex")
+	if !runtime.IsFreshRef(scoped.RuntimeRef) {
+		t.Fatalf("scoped ref = %q, want fresh ref", scoped.RuntimeRef)
+	}
+	if scoped.RuntimeRef == agent.RuntimeRef {
+		t.Fatalf("registered fresh ref was not job-scoped: %q", scoped.RuntimeRef)
+	}
+	again := scopeRegisteredFreshRefForJob(agent, "local-ask-root/delegation/review-codex")
+	if again.RuntimeRef != scoped.RuntimeRef {
+		t.Fatalf("job scoping must be deterministic: %q != %q", again.RuntimeRef, scoped.RuntimeRef)
+	}
+	other := scopeRegisteredFreshRefForJob(agent, "local-ask-other/delegation/review-codex")
+	if other.RuntimeRef == scoped.RuntimeRef {
+		t.Fatalf("different jobs must not share fresh lock refs: %q", scoped.RuntimeRef)
+	}
+
+	pinned := runtime.Agent{Name: "reviewer", Runtime: runtime.ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440000"}
+	if got := scopeRegisteredFreshRefForJob(pinned, "job-1"); got.RuntimeRef != pinned.RuntimeRef {
+		t.Fatalf("non-fresh ref changed: %q", got.RuntimeRef)
+	}
+}
+
 // TestOverrideRuntimeSessionResourceKey: the lock key always names the
 // OVERRIDE runtime — resumable runtimes keep the normal runtime:<rt>:<ref>
 // shape, and shell (normally lock-less) gets an override-scoped hashed key —

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -31,6 +31,8 @@ import (
 
 var taskHeadingPattern = regexp.MustCompile(`^### Task ([0-9]+):\s*(.+)$`)
 
+var taskWorktreeHasLiveProcess = workflow.WorktreeHasLiveProcess
+
 type importedGoal struct {
 	Goal  db.Goal
 	Tasks []db.Task
@@ -604,6 +606,9 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		return workflow.JobPayload{}, err
 	} else if ok {
 		return workflow.JobPayload{}, fmt.Errorf("task %s still has active implement job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
+	}
+	if strings.TrimSpace(task.WorktreePath) != "" && taskWorktreeHasLiveProcess(task.WorktreePath) {
+		return workflow.JobPayload{}, fmt.Errorf("task %s worktree %s still has a live process; wait for it to exit or stop the orphaned implementer before recovering", task.ID, task.WorktreePath)
 	}
 	lock, createdLock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
 	if err != nil {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 	"github.com/jerryfane/gitmoot/skills"
 )
@@ -248,6 +249,8 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 		return runTaskRun(args[1:], stdout, stderr)
 	case "list":
 		return runTaskList(args[1:], stdout, stderr)
+	case "recover":
+		return runTaskRecover(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown task command %q\n\n", args[0])
 		printTaskUsage(stderr)
@@ -258,6 +261,7 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>]")
+	fmt.Fprintln(w, "  gitmoot task recover <id> --repo owner/repo [--owner <agent>] [--skip-native-review-fanout] [--json]")
 	fmt.Fprintln(w, "  gitmoot task list [--repo owner/repo] [--state state] [--json]")
 }
 
@@ -425,6 +429,21 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("resolve task worktree head: %w", err)
 		}
+		recoverCmd := taskRecoverCommand(task.ID, *home, requestRepo, strings.TrimSpace(*owner))
+		dirty, err := taskWorktreeDirty(context.Background(), started)
+		if err != nil {
+			return err
+		}
+		request := taskRunImplementJobRequest(taskRunImplementJobID(started.ID, strings.TrimSpace(*owner)), started, strings.TrimSpace(*owner), headSHA)
+		if active, ok, err := findActiveTaskRunJob(context.Background(), store, request); err != nil {
+			return err
+		} else if ok {
+			startedJob = active
+			return nil
+		}
+		if dirty {
+			return fmt.Errorf("task %s worktree has uncommitted changes at %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying task run", started.ID, started.WorktreePath, recoverCmd)
+		}
 		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA, paths.Home)
 		return err
 	}); err != nil {
@@ -444,6 +463,160 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return 0
+}
+
+type taskRecoverOutput struct {
+	TaskID      string `json:"task_id"`
+	Repo        string `json:"repo"`
+	Branch      string `json:"branch"`
+	PullRequest int    `json:"pull_request"`
+	HeadSHA     string `json:"head_sha"`
+	Summary     string `json:"summary"`
+}
+
+func runTaskRecover(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("task recover", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repo := fs.String("repo", "", "repo scope as owner/repo")
+	owner := fs.String("owner", "", "agent/operator attributed as recovery lead")
+	skipFanout := fs.Bool("skip-native-review-fanout", false, "persist skip-native-review-fanout before opening the PR")
+	jsonOutput := fs.Bool("json", false, "print recovery result as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "task recover requires exactly one id")
+			return 2
+		}
+		return 0
+	}
+	taskID := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "task recover requires exactly one id")
+		return 2
+	}
+	var output taskRecoverOutput
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		payload, err := recoverTaskImplementation(context.Background(), store, taskID, strings.TrimSpace(*repo), strings.TrimSpace(*owner), *skipFanout, nil)
+		if err != nil {
+			return err
+		}
+		output = taskRecoverOutput{
+			TaskID:      payload.TaskID,
+			Repo:        payload.Repo,
+			Branch:      payload.Branch,
+			PullRequest: payload.PullRequest,
+			HeadSHA:     payload.HeadSHA,
+			Summary:     "recovered implementation worktree and opened/adopted PR",
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "recover task: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "recover task: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "recovered %s on %s\n", output.TaskID, output.Branch)
+	if output.PullRequest > 0 {
+		fmt.Fprintf(stdout, "pull_request: #%d\n", output.PullRequest)
+	}
+	if output.HeadSHA != "" {
+		fmt.Fprintf(stdout, "head_sha: %s\n", output.HeadSHA)
+	}
+	return 0
+}
+
+func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID string, repoFlag string, owner string, skipFanout bool, gh github.Client) (workflow.JobPayload, error) {
+	task, err := store.GetTask(ctx, strings.TrimSpace(taskID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return workflow.JobPayload{}, fmt.Errorf("task %q not found", taskID)
+		}
+		return workflow.JobPayload{}, err
+	}
+	requestRepo := firstNonEmpty(repoFlag, task.RepoFullName)
+	if strings.TrimSpace(requestRepo) == "" {
+		return workflow.JobPayload{}, errors.New("task recover requires --repo when task has no repo")
+	}
+	if strings.TrimSpace(repoFlag) != "" && strings.TrimSpace(task.RepoFullName) != "" && repoFlag != task.RepoFullName {
+		return workflow.JobPayload{}, fmt.Errorf("task %s belongs to repo %s, not %s", task.ID, task.RepoFullName, repoFlag)
+	}
+	if _, err := daemon.ParseRepository(requestRepo); err != nil {
+		return workflow.JobPayload{}, fmt.Errorf("invalid repo: %w", err)
+	}
+	if _, err := store.GetRepo(ctx, requestRepo); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return workflow.JobPayload{}, err
+		}
+		return workflow.JobPayload{}, fmt.Errorf("repo %s is not registered; run gitmoot repo add from the checkout before task recover", requestRepo)
+	}
+	if strings.TrimSpace(task.WorktreePath) == "" {
+		return workflow.JobPayload{}, errors.New("task has no worktree path; rerun through gitmoot task run or gitmoot agent implement")
+	}
+	headSHA, err := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
+	if err != nil {
+		return workflow.JobPayload{}, fmt.Errorf("resolve task worktree head: %w", err)
+	}
+	if strings.TrimSpace(owner) == "" {
+		owner = "task recover"
+	}
+	job := db.Job{
+		ID:    taskRecoverJobID(task.ID, owner),
+		Agent: owner,
+		Type:  "implement",
+	}
+	payload := workflow.JobPayload{
+		Repo:                   requestRepo,
+		Branch:                 task.Branch,
+		GoalID:                 task.GoalID,
+		TaskID:                 task.ID,
+		TaskTitle:              task.Title,
+		LeadAgent:              owner,
+		HeadSHA:                headSHA,
+		SkipNativeReviewFanout: skipFanout,
+	}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	return finalizer.FinalizeImplementation(ctx, job, payload)
+}
+
+func taskWorktreeDirty(ctx context.Context, task db.Task) (bool, error) {
+	if strings.TrimSpace(task.WorktreePath) == "" {
+		return false, nil
+	}
+	status, err := (gitutil.Client{Dir: task.WorktreePath}).StatusPorcelain(ctx)
+	if err != nil {
+		return false, fmt.Errorf("inspect task worktree %s: %w", task.WorktreePath, err)
+	}
+	return strings.TrimSpace(status) != "", nil
+}
+
+func taskRecoverCommand(taskID string, home string, repo string, owner string) string {
+	args := []string{"gitmoot", "task", "recover", taskID}
+	if strings.TrimSpace(home) != "" {
+		args = append(args, "--home", home)
+	}
+	if strings.TrimSpace(repo) != "" {
+		args = append(args, "--repo", repo)
+	}
+	if strings.TrimSpace(owner) != "" {
+		args = append(args, "--owner", owner)
+	}
+	return shellArgs(args)
+}
+
+func taskRecoverJobID(taskID string, owner string) string {
+	return slug("task-" + taskID + "-recover-" + owner)
 }
 
 func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string, home string) (db.Job, error) {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha1"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -383,12 +384,12 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 			}
 			return err
 		}
-		requestRepo := firstNonEmpty(*repo, task.RepoFullName)
+		requestRepo, err := resolveTaskRepoFlag(*repo, task.RepoFullName, "task run")
+		if err != nil {
+			return err
+		}
 		if strings.TrimSpace(requestRepo) == "" {
 			return errors.New("task run requires --repo when task has no repo")
-		}
-		if strings.TrimSpace(*repo) != "" && strings.TrimSpace(task.RepoFullName) != "" && *repo != task.RepoFullName {
-			return fmt.Errorf("task %s belongs to repo %s, not %s", task.ID, task.RepoFullName, *repo)
 		}
 		repo, err := daemon.ParseRepository(requestRepo)
 		if err != nil {
@@ -410,6 +411,32 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		}
 		checkout := repoRecord.CheckoutPath
 		requestBranch := firstNonEmpty(*branch, task.Branch, task.ID)
+		if strings.TrimSpace(task.WorktreePath) != "" {
+			candidate := task
+			candidate.RepoFullName = requestRepo
+			candidate.Branch = requestBranch
+			headSHA, err := (gitutil.Client{Dir: candidate.WorktreePath}).HeadSHA(context.Background())
+			if err != nil {
+				return fmt.Errorf("resolve task worktree head: %w", err)
+			}
+			request := taskRunImplementJobRequest(taskRunImplementJobID(candidate.ID, strings.TrimSpace(*owner)), candidate, strings.TrimSpace(*owner), headSHA)
+			if active, ok, err := findActiveTaskRunJob(context.Background(), store, request); err != nil {
+				return err
+			} else if ok {
+				started = candidate
+				startedJob = active
+				return nil
+			}
+			dirty, err := taskWorktreeDirty(context.Background(), candidate)
+			if err != nil {
+				return err
+			}
+			if dirty {
+				skipFanout := taskRecoverSkipFanout(context.Background(), store, requestRepo, requestBranch)
+				recoverCmd := taskRecoverCommand(task.ID, *home, requestRepo, strings.TrimSpace(*owner), skipFanout)
+				return fmt.Errorf("task %s worktree has uncommitted changes at %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying task run", task.ID, candidate.WorktreePath, recoverCmd)
+			}
+		}
 		engine := workflow.Engine{Store: store}
 		started, err = engine.AllocateTaskWorktree(context.Background(), workflow.TaskWorktreeRequest{
 			Home:       paths.Home,
@@ -429,20 +456,12 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("resolve task worktree head: %w", err)
 		}
-		recoverCmd := taskRecoverCommand(task.ID, *home, requestRepo, strings.TrimSpace(*owner))
-		dirty, err := taskWorktreeDirty(context.Background(), started)
-		if err != nil {
-			return err
-		}
 		request := taskRunImplementJobRequest(taskRunImplementJobID(started.ID, strings.TrimSpace(*owner)), started, strings.TrimSpace(*owner), headSHA)
 		if active, ok, err := findActiveTaskRunJob(context.Background(), store, request); err != nil {
 			return err
 		} else if ok {
 			startedJob = active
 			return nil
-		}
-		if dirty {
-			return fmt.Errorf("task %s worktree has uncommitted changes at %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying task run", started.ID, started.WorktreePath, recoverCmd)
 		}
 		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA, paths.Home)
 		return err
@@ -479,7 +498,7 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	repo := fs.String("repo", "", "repo scope as owner/repo")
-	owner := fs.String("owner", "", "agent/operator attributed as recovery lead")
+	owner := fs.String("owner", "", "registered implement-capable agent attributed as recovery lead")
 	skipFanout := fs.Bool("skip-native-review-fanout", false, "persist skip-native-review-fanout before opening the PR")
 	jsonOutput := fs.Bool("json", false, "print recovery result as JSON")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
@@ -499,6 +518,10 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 	}
 	if fs.NArg() != 0 {
 		fmt.Fprintln(stderr, "task recover requires exactly one id")
+		return 2
+	}
+	if strings.TrimSpace(*owner) == "" {
+		fmt.Fprintln(stderr, "task recover requires --owner")
 		return 2
 	}
 	var output taskRecoverOutput
@@ -545,12 +568,12 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		}
 		return workflow.JobPayload{}, err
 	}
-	requestRepo := firstNonEmpty(repoFlag, task.RepoFullName)
+	requestRepo, err := resolveTaskRepoFlag(repoFlag, task.RepoFullName, "task recover")
+	if err != nil {
+		return workflow.JobPayload{}, err
+	}
 	if strings.TrimSpace(requestRepo) == "" {
 		return workflow.JobPayload{}, errors.New("task recover requires --repo when task has no repo")
-	}
-	if strings.TrimSpace(repoFlag) != "" && strings.TrimSpace(task.RepoFullName) != "" && repoFlag != task.RepoFullName {
-		return workflow.JobPayload{}, fmt.Errorf("task %s belongs to repo %s, not %s", task.ID, task.RepoFullName, repoFlag)
 	}
 	if _, err := daemon.ParseRepository(requestRepo); err != nil {
 		return workflow.JobPayload{}, fmt.Errorf("invalid repo: %w", err)
@@ -564,17 +587,51 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 	if strings.TrimSpace(task.WorktreePath) == "" {
 		return workflow.JobPayload{}, errors.New("task has no worktree path; rerun through gitmoot task run or gitmoot agent implement")
 	}
+	if strings.TrimSpace(task.Branch) == "" {
+		return workflow.JobPayload{}, errors.New("task has no branch; cannot recover implementation")
+	}
+	agent, err := store.GetAgent(ctx, strings.TrimSpace(owner))
+	if err != nil {
+		return workflow.JobPayload{}, fmt.Errorf("load recovery owner agent %q: %w", strings.TrimSpace(owner), err)
+	}
+	if err := ensureLocalAgentAccess(ctx, store, agent, requestRepo, "implement"); err != nil {
+		return workflow.JobPayload{}, err
+	}
+	if active, ok, err := findActiveImplementJobForTask(ctx, store, requestRepo, task.Branch, task.ID); err != nil {
+		return workflow.JobPayload{}, err
+	} else if ok {
+		return workflow.JobPayload{}, fmt.Errorf("task %s still has active implement job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
+	}
+	lock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
+	if err != nil {
+		return workflow.JobPayload{}, err
+	}
 	headSHA, err := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
 	if err != nil {
 		return workflow.JobPayload{}, fmt.Errorf("resolve task worktree head: %w", err)
 	}
-	if strings.TrimSpace(owner) == "" {
-		owner = "task recover"
+	payloadHead := headSHA
+	if dirty, err := taskWorktreeDirty(ctx, task); err != nil {
+		return workflow.JobPayload{}, err
+	} else if !dirty {
+		baseHead := previousTaskImplementHeadSHA(ctx, store, task.ID, requestRepo, task.Branch, headSHA)
+		if strings.TrimSpace(baseHead) == "" {
+			baseHead, err = taskRecoverBaseHead(ctx, store, task, requestRepo)
+			if err != nil {
+				return workflow.JobPayload{}, err
+			}
+		}
+		if strings.TrimSpace(baseHead) == "" || baseHead == headSHA {
+			return workflow.JobPayload{}, workflow.BlockedError{Reason: "task worktree is clean and has no recoverable commit ahead of its base"}
+		}
+		payloadHead = baseHead
 	}
+	skipFanout = skipFanout || lock.SkipNativeReviewFanout
 	job := db.Job{
-		ID:    taskRecoverJobID(task.ID, owner),
+		ID:    uniqueTaskRecoverJobID(ctx, store, task.ID, owner),
 		Agent: owner,
 		Type:  "implement",
+		State: string(workflow.JobRunning),
 	}
 	payload := workflow.JobPayload{
 		Repo:                   requestRepo,
@@ -583,11 +640,42 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		TaskID:                 task.ID,
 		TaskTitle:              task.Title,
 		LeadAgent:              owner,
-		HeadSHA:                headSHA,
+		HeadSHA:                payloadHead,
+		Sender:                 "task recover",
+		Instructions:           "Recover task " + task.ID + " from its existing implementation worktree.",
 		SkipNativeReviewFanout: skipFanout,
 	}
+	encoded, err := encodeWorkflowJobPayload(payload)
+	if err != nil {
+		return workflow.JobPayload{}, err
+	}
+	if err := store.CreateExternallyDrivenJobWithEvent(ctx, db.Job{
+		ID:      job.ID,
+		Agent:   job.Agent,
+		Type:    job.Type,
+		State:   job.State,
+		Payload: encoded,
+	}, db.JobEvent{Kind: string(workflow.JobRunning), Message: "task recovery started"}); err != nil {
+		return workflow.JobPayload{}, err
+	}
 	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
-	return finalizer.FinalizeImplementation(ctx, job, payload)
+	finalized, err := finalizer.FinalizeImplementation(ctx, job, payload)
+	if err != nil {
+		state := string(workflow.JobFailed)
+		var blocked workflow.BlockedError
+		if errors.As(err, &blocked) {
+			state = string(workflow.JobBlocked)
+			finalized = payload
+			finalized.Result = &workflow.AgentResult{Decision: "blocked", Summary: blocked.Reason}
+		}
+		_ = finishTaskRecoverJob(ctx, store, job.ID, state, finalized, err.Error())
+		return workflow.JobPayload{}, err
+	}
+	finalized.Result = &workflow.AgentResult{Decision: "implemented", Summary: "Recovered implementation worktree and opened/adopted PR."}
+	if err := finishTaskRecoverJob(ctx, store, job.ID, string(workflow.JobSucceeded), finalized, "task recovery finalized implementation"); err != nil {
+		return workflow.JobPayload{}, err
+	}
+	return finalized, nil
 }
 
 func taskWorktreeDirty(ctx context.Context, task db.Task) (bool, error) {
@@ -601,7 +689,167 @@ func taskWorktreeDirty(ctx context.Context, task db.Task) (bool, error) {
 	return strings.TrimSpace(status) != "", nil
 }
 
-func taskRecoverCommand(taskID string, home string, repo string, owner string) string {
+func taskBranchReusableForImplement(state string) bool {
+	switch workflow.TaskState(strings.TrimSpace(state)) {
+	case "", workflow.TaskPlanned, workflow.TaskImplementing, workflow.TaskChangesRequested, workflow.TaskBlocked, workflow.TaskAwaitingHuman:
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveTaskRepoFlag(repoFlag string, taskRepo string, command string) (string, error) {
+	repoFlag = strings.TrimSpace(repoFlag)
+	taskRepo = strings.TrimSpace(taskRepo)
+	if repoFlag == "" {
+		if taskRepo == "" {
+			return "", nil
+		}
+		return normalizeRepoFlag(taskRepo)
+	}
+	repo, err := normalizeRepoFlag(repoFlag)
+	if err != nil {
+		return "", fmt.Errorf("invalid repo: %w", err)
+	}
+	if taskRepo != "" {
+		taskRepo, err = normalizeRepoFlag(taskRepo)
+		if err != nil {
+			return "", fmt.Errorf("invalid task repo: %w", err)
+		}
+		if repo != taskRepo {
+			return "", fmt.Errorf("task belongs to repo %s, not %s", taskRepo, repo)
+		}
+	}
+	return repo, nil
+}
+
+func findActiveImplementJobForTask(ctx context.Context, store *db.Store, repo string, branch string, taskID string) (db.Job, bool, error) {
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return db.Job{}, false, err
+	}
+	for _, job := range jobs {
+		if job.State != string(workflow.JobQueued) && job.State != string(workflow.JobRunning) {
+			continue
+		}
+		if job.Type != "implement" {
+			continue
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			continue
+		}
+		if payload.TaskID == taskID && payload.Repo == repo && payload.Branch == branch {
+			return job, true, nil
+		}
+	}
+	return db.Job{}, false, nil
+}
+
+func previousTaskImplementHeadSHA(ctx context.Context, store *db.Store, taskID string, repo string, branch string, currentHead string) string {
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return ""
+	}
+	head := ""
+	for _, job := range jobs {
+		if job.Type != "implement" {
+			continue
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			continue
+		}
+		if payload.TaskID != taskID || payload.Repo != repo || payload.Branch != branch {
+			continue
+		}
+		if strings.TrimSpace(payload.HeadSHA) == "" || payload.HeadSHA == currentHead {
+			continue
+		}
+		head = payload.HeadSHA
+	}
+	return head
+}
+
+func taskRecoverBaseHead(ctx context.Context, store *db.Store, task db.Task, repo string) (string, error) {
+	record, err := store.GetRepo(ctx, repo)
+	if err != nil {
+		return "", err
+	}
+	base := strings.TrimSpace(record.DefaultBranch)
+	if base == "" {
+		base = "main"
+	}
+	git := gitutil.Client{Dir: task.WorktreePath}
+	var lastErr error
+	for _, rev := range []string{base, "origin/" + base} {
+		sha, err := git.RevParse(ctx, rev)
+		if err == nil {
+			return sha, nil
+		}
+		lastErr = err
+	}
+	return "", fmt.Errorf("resolve task recovery base %s: %w", base, lastErr)
+}
+
+func ensureTaskRecoverBranchLock(ctx context.Context, store *db.Store, repo string, branch string, owner string) (db.BranchLock, error) {
+	if strings.TrimSpace(branch) == "" {
+		return db.BranchLock{}, errors.New("task recover requires a branch")
+	}
+	lock := db.BranchLock{RepoFullName: repo, Branch: branch, Owner: owner}
+	if _, err := store.CreateLock(ctx, lock); err != nil {
+		return db.BranchLock{}, err
+	}
+	current, err := store.GetBranchLock(ctx, repo, branch)
+	if err != nil {
+		return db.BranchLock{}, err
+	}
+	if current.Owner != owner {
+		return db.BranchLock{}, fmt.Errorf("branch %s is locked by %s, not %s", branch, current.Owner, owner)
+	}
+	return current, nil
+}
+
+func taskRecoverSkipFanout(ctx context.Context, store *db.Store, repo string, branch string) bool {
+	lock, err := store.GetBranchLock(ctx, repo, branch)
+	return err == nil && lock.SkipNativeReviewFanout
+}
+
+func uniqueTaskRecoverJobID(ctx context.Context, store *db.Store, taskID string, owner string) string {
+	base := taskRecoverJobID(taskID, owner)
+	if _, err := store.GetJob(ctx, base); errors.Is(err, sql.ErrNoRows) {
+		return base
+	}
+	return base + "-" + shortHash(time.Now().UTC().Format(time.RFC3339Nano))
+}
+
+func encodeWorkflowJobPayload(payload workflow.JobPayload) (string, error) {
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+func finishTaskRecoverJob(ctx context.Context, store *db.Store, jobID string, state string, payload workflow.JobPayload, message string) error {
+	encoded, err := encodeWorkflowJobPayload(payload)
+	if err != nil {
+		return err
+	}
+	ok, err := store.TransitionJobStatePayloadWithEvent(ctx, jobID, string(workflow.JobRunning), state, encoded, db.JobEvent{Kind: state, Message: message})
+	if err != nil {
+		return err
+	}
+	if !ok {
+		if err := store.UpdateJobPayload(ctx, jobID, encoded); err != nil {
+			return err
+		}
+		return store.UpdateJobState(ctx, jobID, state)
+	}
+	return nil
+}
+
+func taskRecoverCommand(taskID string, home string, repo string, owner string, skipFanout bool) string {
 	args := []string{"gitmoot", "task", "recover", taskID}
 	if strings.TrimSpace(home) != "" {
 		args = append(args, "--home", home)
@@ -612,11 +860,18 @@ func taskRecoverCommand(taskID string, home string, repo string, owner string) s
 	if strings.TrimSpace(owner) != "" {
 		args = append(args, "--owner", owner)
 	}
+	if skipFanout {
+		args = append(args, "--skip-native-review-fanout")
+	}
 	return shellArgs(args)
 }
 
 func taskRecoverJobID(taskID string, owner string) string {
-	return slug("task-" + taskID + "-recover-" + owner)
+	value := slug("task-" + taskID + "-recover-" + owner)
+	if value == "" {
+		return "task-recover-" + shortHash(taskID+"\x00"+owner)
+	}
+	return value
 }
 
 func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string, home string) (db.Job, error) {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -568,6 +568,9 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		}
 		return workflow.JobPayload{}, err
 	}
+	if !taskBranchReusableForImplement(task.State) {
+		return workflow.JobPayload{}, fmt.Errorf("task %s is in state %s; task recover only supports active implementation states", task.ID, task.State)
+	}
 	requestRepo, err := resolveTaskRepoFlag(repoFlag, task.RepoFullName, "task recover")
 	if err != nil {
 		return workflow.JobPayload{}, err
@@ -602,10 +605,16 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 	} else if ok {
 		return workflow.JobPayload{}, fmt.Errorf("task %s still has active implement job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
 	}
-	lock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
+	lock, createdLock, err := ensureTaskRecoverBranchLock(ctx, store, requestRepo, task.Branch, strings.TrimSpace(owner))
 	if err != nil {
 		return workflow.JobPayload{}, err
 	}
+	releaseCreatedLock := createdLock
+	defer func() {
+		if releaseCreatedLock {
+			_, _ = store.ReleaseLockWithEvent(ctx, lock, db.BranchLockEvent{Kind: "released", Message: "released after failed task recover"})
+		}
+	}()
 	headSHA, err := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
 	if err != nil {
 		return workflow.JobPayload{}, fmt.Errorf("resolve task worktree head: %w", err)
@@ -671,6 +680,7 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		_ = finishTaskRecoverJob(ctx, store, job.ID, state, finalized, err.Error())
 		return workflow.JobPayload{}, err
 	}
+	releaseCreatedLock = false
 	finalized.Result = &workflow.AgentResult{Decision: "implemented", Summary: "Recovered implementation worktree and opened/adopted PR."}
 	if err := finishTaskRecoverJob(ctx, store, job.ID, string(workflow.JobSucceeded), finalized, "task recovery finalized implementation"); err != nil {
 		return workflow.JobPayload{}, err
@@ -792,22 +802,23 @@ func taskRecoverBaseHead(ctx context.Context, store *db.Store, task db.Task, rep
 	return "", fmt.Errorf("resolve task recovery base %s: %w", base, lastErr)
 }
 
-func ensureTaskRecoverBranchLock(ctx context.Context, store *db.Store, repo string, branch string, owner string) (db.BranchLock, error) {
+func ensureTaskRecoverBranchLock(ctx context.Context, store *db.Store, repo string, branch string, owner string) (db.BranchLock, bool, error) {
 	if strings.TrimSpace(branch) == "" {
-		return db.BranchLock{}, errors.New("task recover requires a branch")
+		return db.BranchLock{}, false, errors.New("task recover requires a branch")
 	}
 	lock := db.BranchLock{RepoFullName: repo, Branch: branch, Owner: owner}
-	if _, err := store.CreateLock(ctx, lock); err != nil {
-		return db.BranchLock{}, err
+	created, err := store.CreateLock(ctx, lock)
+	if err != nil {
+		return db.BranchLock{}, false, err
 	}
 	current, err := store.GetBranchLock(ctx, repo, branch)
 	if err != nil {
-		return db.BranchLock{}, err
+		return db.BranchLock{}, false, err
 	}
 	if current.Owner != owner {
-		return db.BranchLock{}, fmt.Errorf("branch %s is locked by %s, not %s", branch, current.Owner, owner)
+		return db.BranchLock{}, false, fmt.Errorf("branch %s is locked by %s, not %s", branch, current.Owner, owner)
 	}
-	return current, nil
+	return current, created, nil
 }
 
 func taskRecoverSkipFanout(ctx context.Context, store *db.Store, repo string, branch string) bool {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -264,7 +264,7 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>]")
-	fmt.Fprintln(w, "  gitmoot task recover <id> --repo owner/repo [--owner <agent>] [--skip-native-review-fanout] [--json]")
+	fmt.Fprintln(w, "  gitmoot task recover <id> --owner <agent> [--repo owner/repo] [--skip-native-review-fanout] [--json]")
 	fmt.Fprintln(w, "  gitmoot task list [--repo owner/repo] [--state state] [--json]")
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -910,6 +910,33 @@ func TestRecoverTaskImplementationReleasesCreatedLockOnBlockedRecovery(t *testin
 	}
 }
 
+func TestRecoverTaskImplementationBlocksLiveWorktreeProcess(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: t.TempDir(), PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	worktree := filepath.Join(home, "live-worktree")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	prev := taskWorktreeHasLiveProcess
+	taskWorktreeHasLiveProcess = func(path string) bool { return path == worktree }
+	defer func() { taskWorktreeHasLiveProcess = prev }()
+
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "live process") {
+		t.Fatalf("recover live worktree err = %v, want live process", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "task-001-bootstrap"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("live worktree recovery created branch lock, err=%v", err)
+	}
+}
+
 func TestRecoverTaskImplementationBlocksActiveJobAndWrongLockOwner(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -652,6 +653,127 @@ func TestTaskRunJobMatchesDelegatedImplementJob(t *testing.T) {
 
 	if !taskRunJobMatchesRequest(job, request) {
 		t.Fatalf("taskRunJobMatchesRequest returned false for delegated task-run job")
+	}
+}
+
+func TestRunTaskRunDirtyTaskWorktreeSuggestsRecover(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	withWorkingDirectory(t, repoDir)
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(context.Background(), db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(context.Background(), db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(paths.Home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "partial work\n")
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"task", "run", "task-001", "--home", home, "--repo", "owner/repo", "--owner", "lead"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("task run exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "worktree has uncommitted changes") || !strings.Contains(stderr.String(), "gitmoot task recover task-001") {
+		t.Fatalf("stderr missing recovery guidance:\n%s", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "UNIQUE constraint") || strings.Contains(stderr.String(), "checkout_contention") {
+		t.Fatalf("stderr contains the old failure mode:\n%s", stderr.String())
+	}
+}
+
+type stubTaskRecoverGitHub struct {
+	github.NoopClient
+	input github.CreatePullRequestInput
+}
+
+func (s *stubTaskRecoverGitHub) EnsurePullRequest(_ context.Context, input github.CreatePullRequestInput) (github.PullRequest, error) {
+	s.input = input
+	return github.PullRequest{
+		Number:  4,
+		URL:     "https://github.com/owner/repo/pull/4",
+		HeadRef: input.Head,
+		BaseRef: input.Base,
+		State:   "open",
+	}, nil
+}
+
+func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", RemoteURL: remoteDir, CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "partial work\n")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	gh := &stubTaskRecoverGitHub{}
+	payload, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, gh)
+	if err != nil {
+		t.Fatalf("recoverTaskImplementation returned error: %v", err)
+	}
+	if payload.PullRequest != 4 || payload.Branch != "task-001-bootstrap" || payload.HeadSHA == "" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if gh.input.Head != "task-001-bootstrap" || gh.input.Base != "main" {
+		t.Fatalf("EnsurePullRequest input = %+v", gh.input)
+	}
+	if status := strings.TrimSpace(runGitOutput(t, worktree, "status", "--porcelain")); status != "" {
+		t.Fatalf("worktree still dirty after recover:\n%s", status)
+	}
+	remoteHead := strings.TrimSpace(runGitOutput(t, repoDir, "ls-remote", "origin", "refs/heads/task-001-bootstrap"))
+	if !strings.Contains(remoteHead, payload.HeadSHA) {
+		t.Fatalf("remote task branch %q does not contain recovered head %q", remoteHead, payload.HeadSHA)
+	}
+	pr, err := store.GetPullRequestByRepoBranch(ctx, "owner/repo", "task-001-bootstrap")
+	if err != nil {
+		t.Fatalf("GetPullRequestByRepoBranch returned error: %v", err)
+	}
+	if pr.Number != 4 || pr.HeadSHA != payload.HeadSHA {
+		t.Fatalf("stored PR = %+v, payload=%+v", pr, payload)
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -687,7 +687,7 @@ func TestRunTaskRunDirtyTaskWorktreeSuggestsRecover(t *testing.T) {
 	}
 	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
 	writeFile(t, filepath.Join(worktree, "feature.txt"), "partial work\n")
-	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskPlanned), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
 
@@ -701,6 +701,16 @@ func TestRunTaskRunDirtyTaskWorktreeSuggestsRecover(t *testing.T) {
 	}
 	if strings.Contains(stderr.String(), "UNIQUE constraint") || strings.Contains(stderr.String(), "checkout_contention") {
 		t.Fatalf("stderr contains the old failure mode:\n%s", stderr.String())
+	}
+	task, err := store.GetTask(context.Background(), "task-001")
+	if err != nil {
+		t.Fatalf("GetTask returned error: %v", err)
+	}
+	if task.State != string(workflow.TaskPlanned) {
+		t.Fatalf("task state mutated to %q, want planned", task.State)
+	}
+	if _, err := store.GetBranchLock(context.Background(), "owner/repo", "task-001-bootstrap"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("dirty refusal created branch lock, err=%v", err)
 	}
 }
 
@@ -740,6 +750,9 @@ func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
 	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", RemoteURL: remoteDir, CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
 		t.Fatalf("UpsertRepo returned error: %v", err)
 	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
 	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
 	if err != nil {
 		t.Fatalf("TaskWorktreePath returned error: %v", err)
@@ -751,7 +764,7 @@ func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
 	}
 
 	gh := &stubTaskRecoverGitHub{}
-	payload, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, gh)
+	payload, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", true, gh)
 	if err != nil {
 		t.Fatalf("recoverTaskImplementation returned error: %v", err)
 	}
@@ -774,6 +787,116 @@ func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
 	}
 	if pr.Number != 4 || pr.HeadSHA != payload.HeadSHA {
 		t.Fatalf("stored PR = %+v, payload=%+v", pr, payload)
+	}
+	if lock, err := store.GetBranchLock(ctx, "owner/repo", "task-001-bootstrap"); err != nil || lock.Owner != "lead" || !lock.SkipNativeReviewFanout {
+		t.Fatalf("branch lock = %+v err=%v, want owner lead with skip native fanout", lock, err)
+	}
+	job, err := store.GetJob(ctx, "task-task-001-recover-lead")
+	if err != nil {
+		t.Fatalf("GetJob recovery audit row returned error: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("recovery job state = %q, want succeeded", job.State)
+	}
+}
+
+func TestRecoverTaskImplementationFinalizesCleanCommittedWorktree(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", RemoteURL: remoteDir, CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "committed work\n")
+	runGit(t, worktree, "add", "feature.txt")
+	runGit(t, worktree, "commit", "-m", "finished work")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	gh := &stubTaskRecoverGitHub{}
+	payload, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, gh)
+	if err != nil {
+		t.Fatalf("recoverTaskImplementation returned error: %v", err)
+	}
+	if payload.PullRequest != 4 || payload.HeadSHA == "" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	remoteHead := strings.TrimSpace(runGitOutput(t, repoDir, "ls-remote", "origin", "refs/heads/task-001-bootstrap"))
+	if !strings.Contains(remoteHead, payload.HeadSHA) {
+		t.Fatalf("remote task branch %q does not contain recovered head %q", remoteHead, payload.HeadSHA)
+	}
+}
+
+func TestRecoverTaskImplementationBlocksActiveJobAndWrongLockOwner(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "partial work\n")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	activePayload, err := json.Marshal(workflow.JobPayload{Repo: "owner/repo", Branch: "task-001-bootstrap", TaskID: "task-001"})
+	if err != nil {
+		t.Fatalf("Marshal returned error: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "active-implement", Agent: "lead", Type: "implement", State: string(workflow.JobRunning), Payload: string(activePayload)}); err != nil {
+		t.Fatalf("CreateJob returned error: %v", err)
+	}
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "active implement job") {
+		t.Fatalf("recover with active job err = %v, want active implement job", err)
+	}
+	if err := store.UpdateJobState(ctx, "active-implement", string(workflow.JobFailed)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	if _, err := store.CreateLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-001-bootstrap", Owner: "other"}); err != nil {
+		t.Fatalf("CreateLock returned error: %v", err)
+	}
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "locked by other") {
+		t.Fatalf("recover with wrong lock owner err = %v, want locked by other", err)
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -849,6 +849,67 @@ func TestRecoverTaskImplementationFinalizesCleanCommittedWorktree(t *testing.T) 
 	}
 }
 
+func TestRecoverTaskImplementationRejectsMergedTask(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-001",
+		RepoFullName: "owner/repo",
+		State:        string(workflow.TaskMerged),
+		Branch:       "task-001-bootstrap",
+		WorktreePath: filepath.Join(home, "worktree"),
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "state merged") {
+		t.Fatalf("recover merged task err = %v, want state merged", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "task-001-bootstrap"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("terminal task recovery created branch lock, err=%v", err)
+	}
+}
+
+func TestRecoverTaskImplementationReleasesCreatedLockOnBlockedRecovery(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-001")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath returned error: %v", err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "task-001-bootstrap", worktree, "main")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-001", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Bootstrap", State: string(workflow.TaskImplementing), Branch: "task-001-bootstrap", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "no recoverable commit") {
+		t.Fatalf("recover clean base task err = %v, want no recoverable commit", err)
+	}
+	if _, err := store.GetBranchLock(ctx, "owner/repo", "task-001-bootstrap"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("blocked recovery leaked created branch lock, err=%v", err)
+	}
+}
+
 func TestRecoverTaskImplementationBlocksActiveJobAndWrongLockOwner(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -318,6 +318,22 @@ func (c Client) HeadSHA(ctx context.Context) (string, error) {
 	return sha, nil
 }
 
+func (c Client) RevParse(ctx context.Context, rev string) (string, error) {
+	rev = strings.TrimSpace(rev)
+	if rev == "" {
+		return "", errors.New("git revision is required")
+	}
+	result, err := c.run(ctx, "rev-parse", rev)
+	if err != nil {
+		return "", err
+	}
+	sha := strings.TrimSpace(result.Stdout)
+	if sha == "" {
+		return "", errors.New("git revision SHA is empty")
+	}
+	return sha, nil
+}
+
 func (c Client) UpdateBase(ctx context.Context, remote string, branch string) error {
 	if strings.TrimSpace(remote) == "" {
 		remote = "origin"

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -323,6 +323,12 @@ func (c Client) RevParse(ctx context.Context, rev string) (string, error) {
 	if rev == "" {
 		return "", errors.New("git revision is required")
 	}
+	// Defense-in-depth against argument injection: a rev starting with '-' would be
+	// parsed by git as a flag, not a revision. No legitimate revision (SHA, HEAD,
+	// HEAD~1, refs/…, owner/branch) starts with '-'. Mirrors validateBranch.
+	if strings.HasPrefix(rev, "-") {
+		return "", fmt.Errorf("git revision %q must not start with '-'", rev)
+	}
 	result, err := c.run(ctx, "rev-parse", rev)
 	if err != nil {
 		return "", err

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -331,6 +331,31 @@ func TestClientHeadSHA(t *testing.T) {
 	runner.wantArgs(t, 0, "git", "rev-parse", "HEAD")
 }
 
+func TestClientRevParse(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "def456\n"}}}
+	sha, err := (Client{Runner: runner, Dir: "/repo"}).RevParse(context.Background(), "origin/main")
+	if err != nil {
+		t.Fatalf("RevParse returned error: %v", err)
+	}
+	if sha != "def456" {
+		t.Fatalf("sha = %q, want def456", sha)
+	}
+	runner.wantArgs(t, 0, "git", "rev-parse", "origin/main")
+}
+
+// TestClientRevParseRejectsDashRev guards against argument injection: a rev
+// starting with '-' would be parsed by git as a flag, so RevParse must reject it
+// before ever invoking git (no runner call). Mirrors validateBranch's dash guard.
+func TestClientRevParseRejectsDashRev(t *testing.T) {
+	runner := &fakeRunner{}
+	if _, err := (Client{Runner: runner, Dir: "/repo"}).RevParse(context.Background(), "--upload-pack=evil"); err == nil {
+		t.Fatal("RevParse accepted a rev starting with '-', want an error")
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("RevParse invoked git for a rejected rev; calls=%v", runner.calls)
+	}
+}
+
 func TestClientCreateBranchSmoke(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not installed")

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -92,11 +92,25 @@ type Result struct {
 	// session's cumulative == this job's usage — and are recorded verbatim (#664).
 	// Only codex sets this today; other adapters leave it false.
 	CumulativeUsage bool
-	// RefreshedRuntimeRef is non-empty only when the adapter self-healed a dead
-	// pre-execution session and re-pinned the agent to a fresh runtime reference
-	// (#443). The mailbox persists it through the Store so subsequent jobs use the
-	// new ref. Other adapters and the happy path leave it empty.
+	// RefreshedRuntimeRef is non-empty when the adapter delivered on a runtime
+	// reference other than the agent's stored one: either a #443 dead-session
+	// self-heal that re-pinned the agent to a fresh reference, or a by-design
+	// per-job session minted for an isolated delivery (the #531 fresh-ref path and
+	// the last+template coordinator path). The mailbox adopts it in-memory so a
+	// same-job repair delivery resumes the same session; whether it is also
+	// PERSISTED onto the agent's stored ref is gated by SessionEphemeral. Other
+	// adapters and the happy path leave it empty.
 	RefreshedRuntimeRef string
+	// SessionEphemeral reports that RefreshedRuntimeRef names a per-job session the
+	// adapter minted BY DESIGN — the isolated Claude sessions from deliverFresh (the
+	// #531 fresh-ref path and the last+template coordinator path) — and NOT a #443
+	// dead-session self-heal re-pin. The mailbox must adopt an ephemeral ref
+	// in-memory (so same-job repair stays coherent) but must NEVER persist it onto
+	// the agent's stored runtime_ref: persisting it would rewrite a "last"/fresh
+	// registration to the minted UUID and end the per-job isolation after job 1. The
+	// self-heal path (a genuinely dead pinned session, replaced permanently) leaves
+	// this false so its re-pin IS persisted.
+	SessionEphemeral bool
 }
 
 type StartRequest struct {
@@ -730,7 +744,11 @@ func (a ClaudeAdapter) deliverFresh(ctx context.Context, agent Agent, job Job, m
 	if err != nil {
 		return Result{Raw: result.Stdout + result.Stderr}, claudeCommandError(result, err)
 	}
-	parsed := Result{Raw: result.Stdout, RefreshedRuntimeRef: sessionID}
+	// SessionEphemeral marks this session as by-design per-job (fresh-ref #531 or
+	// last+template coordinator): the mailbox adopts sessionID in-memory for
+	// same-job repair but must NOT persist it onto the agent's stored ref, or the
+	// isolation would end after job 1.
+	parsed := Result{Raw: result.Stdout, RefreshedRuntimeRef: sessionID, SessionEphemeral: true}
 	summary, inTok, outTok := parseClaudeJSONResult(result.Stdout)
 	if summary != "" {
 		parsed.Summary = summary

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -138,12 +139,11 @@ func SupportedRuntimes() []string {
 }
 
 // FreshRefPrefix marks a runtime reference that names no existing session:
-// "fresh:<uuid>". A delivery against a fresh ref must start a brand-new
+// "fresh:<suffix>". A delivery against a fresh ref must start a brand-new
 // session on its runtime and must never resume (or write back to) any stored
-// session. The uuid suffix exists so each fresh ref — and therefore each
-// runtime-session lock key derived from it — is unique per job; adapters do
-// not reuse it as the actual CLI session id. Minted by the per-job --runtime
-// override path (#531) when no explicit session is given.
+// session. The suffix scopes runtime-session lock keys; per-job override refs
+// are unique when minted, and registered fresh refs are rewritten to a job
+// scoped ref before execution.
 const FreshRefPrefix = "fresh:"
 
 // NewFreshRef mints a unique fresh-session runtime reference (see
@@ -161,15 +161,23 @@ func IsFreshRef(ref string) bool {
 	return strings.HasPrefix(ref, FreshRefPrefix)
 }
 
+// FreshRefForJob returns a deterministic fresh-session ref scoped to a job id.
+// This lets a registered "fresh:<seat>" agent get a separate runtime lock and
+// CLI session per job instead of sharing one lock across all jobs.
+func FreshRefForJob(jobID string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(jobID)))
+	return FreshRefPrefix + "job:" + hex.EncodeToString(sum[:8])
+}
+
 func ValidateAgent(agent Agent) error {
 	if err := validateAgentFields(agent, true); err != nil {
 		return err
 	}
 	if agent.Runtime == ClaudeRuntime && agent.RuntimeRef != LastRef && !isUUID(agent.RuntimeRef) && !IsFreshRef(agent.RuntimeRef) {
-		return fmt.Errorf("claude runtime reference %q must be a UUID, last, or fresh:<uuid>", agent.RuntimeRef)
+		return fmt.Errorf("claude runtime reference %q must be a UUID, last, or fresh:<suffix>", agent.RuntimeRef)
 	}
 	if isKimiRuntime(agent.Runtime) && agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) && !IsFreshRef(agent.RuntimeRef) {
-		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<uuid>, or empty", agent.RuntimeRef)
+		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<suffix>, or empty", agent.RuntimeRef)
 	}
 	return nil
 }
@@ -355,7 +363,12 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 	// Usage is attributable to this job when the session belongs to it alone:
 	// a fresh ref (brand-new session, no resume) or a single-use session
 	// (ephemeral/temp workers — started for the job, disposed after it).
-	return codexDeliverResult(result.Stdout, IsFreshRef(agent.RuntimeRef) || agent.SingleUseSession), nil
+	freshSession := IsFreshRef(agent.RuntimeRef) || agent.SingleUseSession
+	parsed := codexDeliverResult(result.Stdout, freshSession)
+	if IsFreshRef(agent.RuntimeRef) {
+		parsed.RefreshedRuntimeRef = parseCodexThreadID(result.Stdout)
+	}
+	return parsed, nil
 }
 
 // codexDeliverArgs builds the `codex exec` argument vector for a Deliver call.
@@ -431,6 +444,28 @@ func codexDeliverResult(stdout string, freshSession bool) Result {
 		inputTokens, outputTokens = 0, 0
 	}
 	return Result{Raw: raw, Summary: strings.TrimSpace(raw), InputTokens: inputTokens, OutputTokens: outputTokens}
+}
+
+func parseCodexThreadID(output string) string {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var event struct {
+			Type     string `json:"type"`
+			ThreadID string `json:"thread_id"`
+		}
+		if json.Unmarshal([]byte(line), &event) != nil {
+			continue
+		}
+		if event.Type == "thread.started" && strings.TrimSpace(event.ThreadID) != "" {
+			return strings.TrimSpace(event.ThreadID)
+		}
+	}
+	return ""
 }
 
 func (a CodexAdapter) Health(ctx context.Context, agent Agent) error {
@@ -660,13 +695,14 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 // fresh-ref path, #531). Each attempt mints a NEW session id, mirroring the
 // #443 self-heal shape (claudeFreshSessionArgs — never --resume/--continue),
 // so a transient-401 retry can never trip over an already-created session id.
-// It intentionally returns no RefreshedRuntimeRef: a fresh-ref delivery is
-// one-shot and must never re-pin the agent's stored session.
+// It returns the successful concrete session id as RefreshedRuntimeRef so
+// malformed-output repair prompts in the same job resume that isolated job
+// session. The mailbox guards registered fresh refs from being re-pinned.
 func (a ClaudeAdapter) deliverFresh(ctx context.Context, agent Agent, job Job, model string) (Result, error) {
 	var result subprocess.Result
 	var err error
+	var sessionID string
 	for attempt := 1; ; attempt++ {
-		var sessionID string
 		sessionID, err = a.newRuntimeRef()
 		if err != nil {
 			return Result{}, err
@@ -682,7 +718,7 @@ func (a ClaudeAdapter) deliverFresh(ctx context.Context, agent Agent, job Job, m
 	if err != nil {
 		return Result{Raw: result.Stdout + result.Stderr}, claudeCommandError(result, err)
 	}
-	parsed := Result{Raw: result.Stdout}
+	parsed := Result{Raw: result.Stdout, RefreshedRuntimeRef: sessionID}
 	summary, inTok, outTok := parseClaudeJSONResult(result.Stdout)
 	if summary != "" {
 		parsed.Summary = summary

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -562,6 +562,13 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 	if IsFreshRef(agent.RuntimeRef) {
 		return a.deliverFresh(ctx, agent, job, model)
 	}
+	// Template-backed Claude agents are coordinator-class jobs: they execute a
+	// long-form prompt recipe and must never resume whichever interactive Claude
+	// session happens to be "last". Treat a legacy --session last registration as
+	// a per-job temp session instead of --continue.
+	if agent.RuntimeRef == LastRef && strings.TrimSpace(agent.TemplateID) != "" {
+		return a.deliverFresh(ctx, agent, job, model)
+	}
 	// The Claude CLI intermittently fails a delivery with a transient
 	// "401 socket connection was closed unexpectedly" under sustained
 	// concurrency; a byte-identical retry typically clears it. Retry on that

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -396,6 +396,11 @@ func TestClaudeDeliverSelfHealsDeadSession(t *testing.T) {
 	if result.RefreshedRuntimeRef != "550e8400-e29b-41d4-a716-446655440099" {
 		t.Fatalf("RefreshedRuntimeRef = %q, want the fresh UUID", result.RefreshedRuntimeRef)
 	}
+	// A #443 dead-session self-heal re-pin is NOT ephemeral (#665): the mailbox
+	// MUST persist it — the old pinned session is genuinely gone.
+	if result.SessionEphemeral {
+		t.Fatalf("SessionEphemeral = true, want false for a #443 self-heal re-pin (it must be persisted)")
+	}
 	if len(runner.calls) != 2 {
 		t.Fatalf("expected exactly 2 runner calls (single bounded retry), got %d: %v", len(runner.calls), runner.calls)
 	}
@@ -646,6 +651,14 @@ func TestClaudeTemplateAgentIgnoresLastSession(t *testing.T) {
 	}
 	if result.Summary != "coordinated" {
 		t.Fatalf("Summary = %q, want coordinated", result.Summary)
+	}
+	// The minted session is ephemeral by design (#665): the mailbox adopts it for
+	// same-job repair but must never persist it onto the "last" registration.
+	if !result.SessionEphemeral {
+		t.Fatalf("SessionEphemeral = false, want true for a last+template coordinator session")
+	}
+	if result.RefreshedRuntimeRef != minted {
+		t.Fatalf("RefreshedRuntimeRef = %q, want the minted session %q", result.RefreshedRuntimeRef, minted)
 	}
 	runner.want(t, 0, "claude", "--model", "opus", "--session-id", minted, "-p", "--output-format", "json", "--", "coordinate")
 	for _, arg := range runner.calls[0] {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -621,6 +621,40 @@ func TestClaudeDeliverLastSessionCommand(t *testing.T) {
 	runner.want(t, 0, "claude", "--continue", "-p", "--output-format", "json", "--", "review")
 }
 
+func TestClaudeTemplateAgentIgnoresLastSession(t *testing.T) {
+	minted := "550e8400-e29b-41d4-a716-446655440099"
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"result":"coordinated"}`}}}
+	adapter := ClaudeAdapter{
+		Runner: runner,
+		NewRuntimeRef: func() (string, error) {
+			return minted, nil
+		},
+	}
+	agent := Agent{
+		Name:       "lead",
+		Role:       "agent",
+		Runtime:    ClaudeRuntime,
+		RuntimeRef: LastRef,
+		RepoScope:  "jerryfane/gitmoot",
+		TemplateID: "coordinator",
+		Model:      "opus",
+	}
+
+	result, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "coordinate"})
+	if err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	if result.Summary != "coordinated" {
+		t.Fatalf("Summary = %q, want coordinated", result.Summary)
+	}
+	runner.want(t, 0, "claude", "--model", "opus", "--session-id", minted, "-p", "--output-format", "json", "--", "coordinate")
+	for _, arg := range runner.calls[0] {
+		if arg == "--continue" || arg == "--resume" {
+			t.Fatalf("template-backed Claude last agent must use an isolated session, got %v", runner.calls[0])
+		}
+	}
+}
+
 func TestClaudeDeliverCommandAppliesAutonomyPolicy(t *testing.T) {
 	for _, tt := range []struct {
 		name   string

--- a/internal/runtime/fresh_ref_test.go
+++ b/internal/runtime/fresh_ref_test.go
@@ -150,6 +150,11 @@ func TestClaudeDeliverFreshRef(t *testing.T) {
 	if result.RefreshedRuntimeRef != minted {
 		t.Fatalf("RefreshedRuntimeRef = %q, want minted fresh session %q", result.RefreshedRuntimeRef, minted)
 	}
+	// A fresh-ref session is ephemeral by design (#665): adopted in-memory for
+	// same-job repair, never persisted onto the agent's stored ref.
+	if !result.SessionEphemeral {
+		t.Fatalf("SessionEphemeral = false, want true for a fresh-ref delivery")
+	}
 	runner.want(t, 0, "claude", "--model", "claude-opus-4", "--session-id", minted, "-p", "--output-format", "json", "--", "do the thing")
 	for _, arg := range runner.calls[0] {
 		if arg == "--resume" || arg == "--continue" {

--- a/internal/runtime/fresh_ref_test.go
+++ b/internal/runtime/fresh_ref_test.go
@@ -60,6 +60,22 @@ func TestNewFreshRef(t *testing.T) {
 	}
 }
 
+func TestFreshRefForJob(t *testing.T) {
+	ref := FreshRefForJob("local-ask-a/delegation/review-codex")
+	if !IsFreshRef(ref) {
+		t.Fatalf("FreshRefForJob() = %q, want fresh ref", ref)
+	}
+	if !strings.HasPrefix(ref, FreshRefPrefix+"job:") {
+		t.Fatalf("FreshRefForJob() = %q, want job-scoped suffix", ref)
+	}
+	if other := FreshRefForJob("local-ask-b/delegation/review-codex"); other == ref {
+		t.Fatalf("different jobs must get different fresh refs: %q", ref)
+	}
+	if again := FreshRefForJob("local-ask-a/delegation/review-codex"); again != ref {
+		t.Fatalf("FreshRefForJob must be deterministic: %q != %q", again, ref)
+	}
+}
+
 // TestValidateAgentAcceptsFreshRefs: the session-safety path mints fresh refs
 // for claude/kimi override jobs; agent validation must accept them.
 func TestValidateAgentAcceptsFreshRefs(t *testing.T) {
@@ -83,7 +99,12 @@ func TestCodexDeliverFreshRef(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFreshRef returned error: %v", err)
 	}
-	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "fresh output"}}}
+	stdout := strings.Join([]string{
+		`{"type":"thread.started","thread_id":"codex-thread-123"}`,
+		`{"type":"item.completed","item":{"type":"agent_message","text":"fresh output"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":7,"output_tokens":5}}`,
+	}, "\n")
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: stdout}}}
 	adapter := CodexAdapter{Runner: runner}
 	agent := Agent{Name: "audit", Role: "reviewer", Runtime: CodexRuntime, RuntimeRef: ref, RepoScope: "jerryfane/gitmoot"}
 
@@ -94,6 +115,9 @@ func TestCodexDeliverFreshRef(t *testing.T) {
 	if result.Raw != "fresh output" {
 		t.Fatalf("Raw = %q", result.Raw)
 	}
+	if result.RefreshedRuntimeRef != "codex-thread-123" {
+		t.Fatalf("RefreshedRuntimeRef = %q, want codex thread id", result.RefreshedRuntimeRef)
+	}
 	runner.want(t, 0, "codex", "exec", "--json", "--model", "gpt-5.5-codex", "--", "do the thing")
 	for _, arg := range runner.calls[0] {
 		if arg == "resume" {
@@ -103,8 +127,9 @@ func TestCodexDeliverFreshRef(t *testing.T) {
 }
 
 // TestClaudeDeliverFreshRef: a fresh ref must deliver on a brand-new dedicated
-// --session-id (never --resume/--continue), never return a RefreshedRuntimeRef
-// (nothing may be re-pinned), and pass the per-job model through.
+// --session-id (never --resume/--continue), return that concrete session id so
+// same-job repair prompts resume the isolated job session, and pass the per-job
+// model through.
 func TestClaudeDeliverFreshRef(t *testing.T) {
 	ref, err := NewFreshRef()
 	if err != nil {
@@ -122,8 +147,8 @@ func TestClaudeDeliverFreshRef(t *testing.T) {
 	if result.Summary != "fresh claude output" {
 		t.Fatalf("Summary = %q", result.Summary)
 	}
-	if result.RefreshedRuntimeRef != "" {
-		t.Fatalf("fresh-ref delivery must not re-pin any session, got RefreshedRuntimeRef = %q", result.RefreshedRuntimeRef)
+	if result.RefreshedRuntimeRef != minted {
+		t.Fatalf("RefreshedRuntimeRef = %q, want minted fresh session %q", result.RefreshedRuntimeRef, minted)
 	}
 	runner.want(t, 0, "claude", "--model", "claude-opus-4", "--session-id", minted, "-p", "--output-format", "json", "--", "do the thing")
 	for _, arg := range runner.calls[0] {

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -61,7 +61,7 @@ func (a KimiAdapter) Validate(_ context.Context, agent Agent) error {
 		return err
 	}
 	if agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) && !IsFreshRef(agent.RuntimeRef) {
-		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<uuid>, or empty", agent.RuntimeRef)
+		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<suffix>, or empty", agent.RuntimeRef)
 	}
 	return nil
 }
@@ -159,7 +159,7 @@ func (a KimiCLIAdapter) Validate(_ context.Context, agent Agent) error {
 		return err
 	}
 	if agent.RuntimeRef != "" && !isKimiSessionID(agent.RuntimeRef) && !IsFreshRef(agent.RuntimeRef) {
-		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<uuid>, or empty", agent.RuntimeRef)
+		return fmt.Errorf("kimi runtime reference %q must be a Kimi session id, fresh:<suffix>, or empty", agent.RuntimeRef)
 	}
 	return nil
 }

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -525,7 +525,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 		// there are zero prior artifacts to reconcile — this is its first real run.
 		prompt = blockerRetryReconciliationNotice(payload.BlockerClass, payload.BlockerAttempts) + "\n\n" + prompt
 	}
-	firstRaw, firstRefreshedRef, firstErr := m.deliver(ctx, adapter, agent, job, payload, prompt)
+	firstRaw, firstRefreshedRef, firstEphemeral, firstErr := m.deliver(ctx, adapter, agent, job, payload, prompt)
 	if firstErr != nil {
 		deliveryErr := DeliveryError{Err: firstErr}
 		// PRE-TERMINAL operational-blocker classification (#532 slice E): consult the
@@ -545,9 +545,13 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	// SESSION SAFETY (#531): a job running under a per-job runtime override must
 	// never write back to the agent's stored resume state — the stored ref
 	// belongs to the DEFAULT runtime, and persisting an override-runtime ref
-	// there would corrupt the agent's session identity. The refreshed ref is
-	// still adopted in-memory below so repair retries stay coherent.
-	if payload.RuntimeOverride == "" && !registeredFreshRef {
+	// there would corrupt the agent's session identity. An ephemeral by-design
+	// session (deliverFresh: the #531 fresh-ref path and the last+template
+	// coordinator path, #665) is likewise never persisted — persisting the minted
+	// UUID would rewrite a "last"/fresh registration and end the per-job isolation
+	// after job 1. Both refs are still adopted in-memory below so repair retries
+	// stay coherent. Only a genuine #443 dead-session self-heal re-pin persists.
+	if payload.RuntimeOverride == "" && !registeredFreshRef && !firstEphemeral {
 		m.persistRefreshedRuntimeRef(ctx, job.ID, agent, firstRefreshedRef)
 	}
 	// If the first delivery self-healed a dead session (#443), adopt the freshly
@@ -587,7 +591,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			}
 
 			repairPrompt := prompts.RenderRepairPrompt(lastRaw, parseErr)
-			repairRaw, repairRefreshedRef, repairErr := m.deliver(ctx, adapter, agent, job, payload, repairPrompt)
+			repairRaw, repairRefreshedRef, repairEphemeral, repairErr := m.deliver(ctx, adapter, agent, job, payload, repairPrompt)
 			if repairErr != nil {
 				deliveryErr := DeliveryError{Err: repairErr}
 				// Same pre-terminal seam as the first delivery, but the deferrer's
@@ -601,9 +605,10 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 				_ = m.fail(ctx, job.ID, fmt.Sprintf("repair delivery failed: %v", repairErr))
 				return AgentResult{}, deliveryErr
 			}
-			// Same #531 override guard as the first delivery: never persist an
-			// override-runtime ref onto the agent's default-runtime resume state.
-			if payload.RuntimeOverride == "" && !registeredFreshRef {
+			// Same #531 override + #665 ephemeral guard as the first delivery: never
+			// persist an override-runtime ref or a by-design per-job session onto the
+			// agent's default-runtime resume state.
+			if payload.RuntimeOverride == "" && !registeredFreshRef && !repairEphemeral {
 				m.persistRefreshedRuntimeRef(ctx, job.ID, agent, repairRefreshedRef)
 			}
 			// Adopt a freshly minted session ref so the next repair re-ask resumes the
@@ -647,7 +652,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	return result, nil
 }
 
-func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent runtime.Agent, job db.Job, payload JobPayload, prompt string) (string, string, error) {
+func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent runtime.Agent, job db.Job, payload JobPayload, prompt string) (string, string, bool, error) {
 	result, err := adapter.Deliver(ctx, agent, runtime.Job{
 		ID:          job.ID,
 		AgentName:   agent.Name,
@@ -683,9 +688,9 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		}
 	}
 	if strings.TrimSpace(result.Summary) != "" {
-		return result.Summary, result.RefreshedRuntimeRef, err
+		return result.Summary, result.RefreshedRuntimeRef, result.SessionEphemeral, err
 	}
-	return result.Raw, result.RefreshedRuntimeRef, err
+	return result.Raw, result.RefreshedRuntimeRef, result.SessionEphemeral, err
 }
 
 // persistRefreshedRuntimeRef re-pins an agent that self-healed a dead session

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -679,6 +679,20 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 			inTok, outTok, _ = m.Store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+agent.RuntimeRef, result.InputTokens, result.OutputTokens)
 		} else if result.CumulativeUsage {
 			inTok, outTok = 0, 0
+		} else if agent.Runtime == runtime.CodexRuntime && result.RefreshedRuntimeRef != "" && result.RefreshedRuntimeRef != runtime.LastRef {
+			// A fresh codex delivery reports PER-JOB (non-cumulative) usage and skips the
+			// delta table by design (#664), so the runtime_session_usage baseline for its
+			// thread is never seeded. But a fresh codex delivery ALSO adopts its concrete
+			// thread in-memory for same-job repair (#665): if turn 1 is malformed, the
+			// repair delivery resumes that thread, reports SESSION-CUMULATIVE usage, and
+			// (turn1+turn2) would delta against a ZERO baseline — re-counting turn 1 on
+			// top of the verbatim record below (#669 interaction). SEED the baseline with
+			// turn 1's counts, keyed byte-identically to the key the repair path computes
+			// from the adopted ref (runtime+RefreshedRuntimeRef), so a repair delta =
+			// (turn1+turn2)-turn1 = turn2. The returned delta is discarded; the verbatim
+			// UpdateJobUsage below records this turn. Errors are swallowed like the delta
+			// call — usage accounting never fails a delivery.
+			_, _, _ = m.Store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+result.RefreshedRuntimeRef, result.InputTokens, result.OutputTokens)
 		}
 		// Only persist when a positive count remains so runtimes that report nothing
 		// (e.g. the shell runtime) or a delta that resolved to 0 leave the columns at

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -502,6 +502,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 		return AgentResult{}, err
 	}
 
+	registeredFreshRef := runtime.IsFreshRef(agent.RuntimeRef)
 	prompt := prompts.RenderJob(payload.prompt(job.Type))
 	// Append the off-by-default "Prior learnings" memory block (#626 READ path).
 	// When the memory hook is unset (every non-enrolled path) or returns "" (no
@@ -545,7 +546,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	// belongs to the DEFAULT runtime, and persisting an override-runtime ref
 	// there would corrupt the agent's session identity. The refreshed ref is
 	// still adopted in-memory below so repair retries stay coherent.
-	if payload.RuntimeOverride == "" {
+	if payload.RuntimeOverride == "" && !registeredFreshRef {
 		m.persistRefreshedRuntimeRef(ctx, job.ID, agent, firstRefreshedRef)
 	}
 	// If the first delivery self-healed a dead session (#443), adopt the freshly
@@ -601,7 +602,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			}
 			// Same #531 override guard as the first delivery: never persist an
 			// override-runtime ref onto the agent's default-runtime resume state.
-			if payload.RuntimeOverride == "" {
+			if payload.RuntimeOverride == "" && !registeredFreshRef {
 				m.persistRefreshedRuntimeRef(ctx, job.ID, agent, repairRefreshedRef)
 			}
 			// Adopt a freshly minted session ref so the next repair re-ask resumes the

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -906,6 +906,128 @@ func TestMailboxRunFreshRefRepairUsesConcreteSessionWithoutPersisting(t *testing
 	}
 }
 
+// TestMailboxRunEphemeralRefAdoptedButNotPersisted pins F1 (#665): a delivery
+// that mints a by-design per-job session (SessionEphemeral=true — the
+// last+template coordinator path and the #531 fresh-ref path route through
+// deliverFresh) must ADOPT the concrete session in-memory so a same-job repair
+// resumes it, but must NEVER persist it onto the agent's stored "last"
+// registration, and must NOT emit the dead-session self-heal event. Without the
+// ephemeral guard the "last" agent (registeredFreshRef=false) would be re-pinned
+// to the minted UUID and lose isolation after job 1.
+func TestMailboxRunEphemeralRefAdoptedButNotPersisted(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	concreteRef := "claude-ephemeral-session-1"
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:       "coordinator",
+		Role:       "agent",
+		Runtime:    runtime.ClaudeRuntime,
+		RuntimeRef: runtime.LastRef,
+		RepoScope:  "jerryfane/gitmoot",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	agent := runtime.Agent{Name: "coordinator", Runtime: runtime.ClaudeRuntime, RuntimeRef: runtime.LastRef, RepoScope: "jerryfane/gitmoot", Role: "agent", TemplateID: "coordinator"}
+	adapter := &fakeDelivery{
+		// First delivery mints an ephemeral session but is malformed; the repair
+		// delivery must resume that concrete session, not "last".
+		outputs: []string{
+			"ephemeral session but no json",
+			`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["x"],"tests_run":[],"needs":[],"delegations":[]}}`,
+		},
+		refreshedRefs: []string{concreteRef},
+		ephemeral:     []bool{true},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "coordinator", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(adapter.agentRefs) != 2 {
+		t.Fatalf("deliveries = %d, want 2", len(adapter.agentRefs))
+	}
+	if adapter.agentRefs[0] != runtime.LastRef {
+		t.Fatalf("first delivery ref = %q, want %q", adapter.agentRefs[0], runtime.LastRef)
+	}
+	if adapter.agentRefs[1] != concreteRef {
+		t.Fatalf("repair delivery ref = %q, want in-memory-adopted concrete session %q", adapter.agentRefs[1], concreteRef)
+	}
+	stored, err := store.GetAgent(ctx, "coordinator")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if stored.RuntimeRef != runtime.LastRef {
+		t.Fatalf("stored runtime_ref = %q, want unchanged %q — an ephemeral session must never be persisted", stored.RuntimeRef, runtime.LastRef)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, e := range events {
+		if e.Kind == "session_refresh_retry" {
+			t.Fatalf("unexpected session_refresh_retry event on a healthy ephemeral delivery: %+v", events)
+		}
+	}
+}
+
+// TestMailboxRunEphemeralRefStaysFreshAcrossJobs pins the user-visible F1 (#665)
+// invariant: after a first ephemeral delivery, a SECOND job for the same agent
+// must again take the fresh path. Because job 1 never persisted its minted UUID,
+// the agent's stored ref stays "last", so job 2 (loaded from the store, as the
+// daemon does) delivers on "last" again — never resuming job 1's session.
+func TestMailboxRunEphemeralRefStaysFreshAcrossJobs(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:       "coordinator",
+		Role:       "agent",
+		Runtime:    runtime.ClaudeRuntime,
+		RuntimeRef: runtime.LastRef,
+		RepoScope:  "jerryfane/gitmoot",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	adapter := &fakeDelivery{
+		outputs:       []string{okDeliveryResult, okDeliveryResult},
+		refreshedRefs: []string{"claude-ephemeral-job1", "claude-ephemeral-job2"},
+		ephemeral:     []bool{true, true},
+	}
+
+	for _, jobID := range []string{"job-1", "job-2"} {
+		// Reload the agent from the store before each job, exactly as the daemon
+		// does: if job 1 had persisted its minted UUID, job 2 would load it here and
+		// resume the wrong session.
+		stored, err := store.GetAgent(ctx, "coordinator")
+		if err != nil {
+			t.Fatalf("GetAgent before %s returned error: %v", jobID, err)
+		}
+		if stored.RuntimeRef != runtime.LastRef {
+			t.Fatalf("stored runtime_ref before %s = %q, want %q — an ephemeral session leaked into the stored ref", jobID, stored.RuntimeRef, runtime.LastRef)
+		}
+		agent := runtime.Agent{Name: "coordinator", Runtime: runtime.ClaudeRuntime, RuntimeRef: stored.RuntimeRef, RepoScope: "jerryfane/gitmoot", Role: "agent", TemplateID: "coordinator"}
+		if _, err := mailbox.Enqueue(ctx, JobRequest{ID: jobID, Agent: "coordinator", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+			t.Fatalf("Enqueue %s returned error: %v", jobID, err)
+		}
+		if _, err := mailbox.Run(ctx, jobID, agent, adapter); err != nil {
+			t.Fatalf("Run %s returned error: %v", jobID, err)
+		}
+	}
+
+	if len(adapter.agentRefs) != 2 {
+		t.Fatalf("deliveries = %d, want 2 (one per job)", len(adapter.agentRefs))
+	}
+	for i, ref := range adapter.agentRefs {
+		if ref != runtime.LastRef {
+			t.Fatalf("delivery %d ref = %q, want %q — job 2 must not resume job 1's ephemeral session", i, ref, runtime.LastRef)
+		}
+	}
+}
+
 func TestMailboxRunNoRefreshLeavesRefUnchanged(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
@@ -1209,6 +1331,7 @@ type fakeDelivery struct {
 	outputs       []string
 	summaries     []string
 	refreshedRefs []string
+	ephemeral     []bool
 	inputTokens   []int
 	outputTokens  []int
 	cumulative    []bool
@@ -1240,6 +1363,9 @@ func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runti
 	}
 	if index < len(f.refreshedRefs) {
 		result.RefreshedRuntimeRef = f.refreshedRefs[index]
+	}
+	if index < len(f.ephemeral) {
+		result.SessionEphemeral = f.ephemeral[index]
 	}
 	if index < len(f.inputTokens) {
 		result.InputTokens = f.inputTokens[index]

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -432,6 +432,97 @@ func TestMailboxDeliverCumulativeAmbiguousRefContributesZero(t *testing.T) {
 	}
 }
 
+// TestMailboxDeliverSeedsBaselineForAdoptedThread pins F2 (#665/#669 interaction):
+// a fresh codex delivery reports PER-JOB usage (non-cumulative, recorded verbatim,
+// #664) AND adopts its concrete thread in-memory for same-job repair (#665). If
+// turn 1 is malformed, the repair delivery resumes that thread and reports
+// SESSION-CUMULATIVE usage. The fresh delivery must SEED the runtime_session_usage
+// baseline with turn 1's counts so the repair deltas against turn 1, not a zero
+// baseline — otherwise turn 1 is double-counted. Turn 1 = 100/10 verbatim; the
+// repair reports cumulative 150/15 -> delta 50/5; job total 150/15 (NOT 250/25).
+// This is the double-count pin: it fails without the seed.
+func TestMailboxDeliverSeedsBaselineForAdoptedThread(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: "fresh:codex-solo", RepoScope: "jerryfane/gitmoot", Role: "implementer"}
+	adapter := &fakeDelivery{
+		outputs: []string{
+			"fresh codex turn but no json",
+			okDeliveryResult,
+		},
+		refreshedRefs: []string{"codex-thread-adopted"},
+		inputTokens:   []int{100, 150},
+		outputTokens:  []int{10, 15},
+		cumulative:    []bool{false, true},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "impl", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.InputTokens != 150 || job.OutputTokens != 15 {
+		t.Fatalf("job usage = (%d, %d), want (150, 15) — turn 1 must not be double-counted (a zero baseline would give 250/25)", job.InputTokens, job.OutputTokens)
+	}
+	// The seeded baseline must advance to the repair's cumulative (150/15) — a probe
+	// with the same cumulative deltas to 0, confirming the key matched byte-for-byte.
+	dIn, dOut, err := store.RecordRuntimeSessionUsageDelta(ctx, runtime.CodexRuntime+":codex-thread-adopted", 150, 15)
+	if err != nil {
+		t.Fatalf("probe RecordRuntimeSessionUsageDelta: %v", err)
+	}
+	if dIn != 0 || dOut != 0 {
+		t.Fatalf("post-run baseline probe delta = (%d, %d), want (0, 0) — baseline should equal the repair cumulative", dIn, dOut)
+	}
+}
+
+// TestMailboxDeliverDoesNotSeedBaselineWithoutAdoptedThread pins that the F2 seed
+// fires ONLY when a concrete thread was adopted: a fresh/single-use codex delivery
+// that produced no adoptable thread (RefreshedRuntimeRef empty) records verbatim
+// and writes NO baseline row.
+func TestMailboxDeliverDoesNotSeedBaselineWithoutAdoptedThread(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	freshRef := "fresh:codex-single"
+	agent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: freshRef, RepoScope: "jerryfane/gitmoot", Role: "implementer"}
+	adapter := &fakeDelivery{
+		outputs:      []string{okDeliveryResult},
+		inputTokens:  []int{100},
+		outputTokens: []int{10},
+		cumulative:   []bool{false},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "impl", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.InputTokens != 100 || job.OutputTokens != 10 {
+		t.Fatalf("job usage = (%d, %d), want (100, 10) verbatim", job.InputTokens, job.OutputTokens)
+	}
+	// No thread was adopted, so no baseline may have been seeded. Probe the key the
+	// seed would have used had it (wrongly) keyed on the agent's own ref: a fresh
+	// probe returns the full cumulative, proving the baseline was 0 (no row).
+	dIn, dOut, err := store.RecordRuntimeSessionUsageDelta(ctx, runtime.CodexRuntime+":"+freshRef, 777, 77)
+	if err != nil {
+		t.Fatalf("probe RecordRuntimeSessionUsageDelta: %v", err)
+	}
+	if dIn != 777 || dOut != 77 {
+		t.Fatalf("probe delta = (%d, %d), want (777, 77) — a baseline was unexpectedly seeded", dIn, dOut)
+	}
+}
+
 func TestMailboxEnqueuePersistsRootJobID(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -681,6 +681,55 @@ func TestMailboxRunRepairRetryResumesRefreshedRef(t *testing.T) {
 	}
 }
 
+func TestMailboxRunFreshRefRepairUsesConcreteSessionWithoutPersisting(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	freshRef := "fresh:council-codex"
+	concreteRef := "codex-thread-123"
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:       "shipper",
+		Role:       "implementer",
+		Runtime:    runtime.CodexRuntime,
+		RuntimeRef: freshRef,
+		RepoScope:  "jerryfane/gitmoot",
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	agent := runtime.Agent{Name: "shipper", Runtime: runtime.CodexRuntime, RuntimeRef: freshRef, RepoScope: "jerryfane/gitmoot", Role: "implementer"}
+	adapter := &fakeDelivery{
+		outputs: []string{
+			"fresh job session but no json",
+			`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["x"],"tests_run":[],"needs":[],"delegations":[]}}`,
+		},
+		refreshedRefs: []string{concreteRef},
+	}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "shipper", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(adapter.agentRefs) != 2 {
+		t.Fatalf("deliveries = %d, want 2", len(adapter.agentRefs))
+	}
+	if adapter.agentRefs[0] != freshRef {
+		t.Fatalf("first delivery ref = %q, want registered fresh ref", adapter.agentRefs[0])
+	}
+	if adapter.agentRefs[1] != concreteRef {
+		t.Fatalf("repair delivery ref = %q, want concrete job session", adapter.agentRefs[1])
+	}
+	stored, err := store.GetAgent(ctx, "shipper")
+	if err != nil {
+		t.Fatalf("GetAgent returned error: %v", err)
+	}
+	if stored.RuntimeRef != freshRef {
+		t.Fatalf("stored runtime_ref = %q, want registered fresh ref %q", stored.RuntimeRef, freshRef)
+	}
+}
+
 func TestMailboxRunNoRefreshLeavesRefUnchanged(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/workflow/runtime_owner_liveness.go
+++ b/internal/workflow/runtime_owner_liveness.go
@@ -83,6 +83,14 @@ func (e Engine) worktreeHasLiveProcess(path string) bool {
 	return defaultWorktreeHasLiveProcess(path)
 }
 
+// WorktreeHasLiveProcess exposes the same conservative /proc cwd liveness probe
+// used by destructive worktree cleanup to CLI recovery/dispatch paths. It is
+// intentionally best-effort: false means "no same-host cwd owner observed", not a
+// proof that no external process can write.
+func WorktreeHasLiveProcess(path string) bool {
+	return defaultWorktreeHasLiveProcess(path)
+}
+
 // defaultWorktreeHasLiveProcess is a best-effort Linux /proc scan: it returns true
 // when any process's cwd symlink resolves to path or a descendant of it. The codex
 // resume worker in #536 ran with cwd == the delegation worktree, so its presence is

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -738,6 +738,42 @@ gitmoot task list --repo owner/repo --state implementing --json
 `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/` and leaves the registered
 checkout on its current branch.
 
+### Recover A Dead Implement
+
+When an implementer dies mid-work — its process exits after editing the task
+worktree but before it commits, pushes, and opens a PR — the edits are left
+uncommitted in the worktree. `task run` (and `agent implement`) refuse to
+restart over that state so nothing is silently discarded, and point you at
+`task recover`:
+
+```sh
+gitmoot task recover task-001 --owner lead
+gitmoot task recover task-001 --owner lead --repo owner/repo --skip-native-review-fanout --json
+```
+
+`--owner <agent>` is required (a registered implement-capable agent, attributed
+as the recovery lead). `--repo owner/repo` is optional — it falls back to the
+task's stored repo and is only required when the task carries none.
+`--skip-native-review-fanout` persists that flag before the PR is opened;
+`--json` prints the machine-readable recovery result.
+
+`task recover` commits the full worktree state (`git add -A`, including
+untracked non-ignored files), pushes the task branch, and opens or adopts the
+task's PR — the exact finalize steps the dead implementer never reached. If the
+worktree is already clean it recovers the commit already ahead of the base
+(and refuses when there is nothing ahead to recover).
+
+Two refusals guard `task recover` (and the `task run` / `agent implement`
+restart that points to it):
+
+- **Dirty worktree without an active job** — `task run`/`agent implement` refuse
+  to restart a task whose worktree has uncommitted changes and no in-flight job;
+  inspect it, then `task recover` to commit/push/open the PR, or clean/stash the
+  worktree before retrying.
+- **Live process still in the worktree** — `task recover` refuses while a live
+  process is still inside the task worktree; wait for it to exit or stop the
+  orphaned implementer before recovering.
+
 ## PR Comments
 
 Use GitHub PR comments as the public audit trail:

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -596,6 +596,15 @@ a success is working as designed, not flaky:
   envelope records a `malformed_output` event and is re-asked with a repair
   prompt a bounded number of times before failing terminally.
 
+**Dead implement recovery (manual):** if an implementer's process dies after
+editing the task worktree but before it commits/pushes/opens a PR, the edits sit
+uncommitted. `gitmoot task run` and `gitmoot agent implement` refuse to restart
+over a dirty worktree with no active job (so nothing is discarded) and point at
+`gitmoot task recover <task-id> --owner <agent>`, which commits the full
+worktree state (`git add -A`, incl. untracked non-ignored files), pushes the
+branch, and opens or adopts the PR. `--repo` is optional (falls back to the
+task's repo). Recovery refuses while a live process is still inside the worktree.
+
 The daemon default is `--workers 1`. Users can raise it when jobs target
 different runtime sessions, managed agent types with `max_background` greater
 than one, or forkable temporary workers. By default `[parallel_sessions]` uses

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -709,6 +709,42 @@ gitmoot task list --repo owner/repo --state implementing --json
 `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/` and leaves the registered
 checkout on its current branch.
 
+### Recover a dead implement
+
+If an implementer dies mid-work — its process exits after editing the task
+worktree but before it commits, pushes, and opens a PR — the changes are left
+uncommitted in the worktree. `task run` (and `agent implement`) refuse to
+restart over that state rather than silently discard the work, and point you at
+`task recover`:
+
+```sh
+gitmoot task recover task-001 --owner lead
+gitmoot task recover task-001 --owner lead --repo owner/repo --skip-native-review-fanout --json
+```
+
+`--owner <agent>` is required and names a registered implement-capable agent,
+attributed as the recovery lead. `--repo owner/repo` is optional and falls back
+to the task's stored repo, so it is only needed when the task carries none.
+`--skip-native-review-fanout` persists that flag before the PR is opened, and
+`--json` prints the machine-readable recovery result.
+
+`task recover` commits the full worktree state (`git add -A`, including
+untracked non-ignored files), pushes the task branch, and opens or adopts the
+task's PR — the finalize steps the dead implementer never reached. When the
+worktree is already clean it recovers the commit already ahead of the base, and
+refuses when there is nothing ahead to recover.
+
+Two refusals guard recovery (and the `task run` / `agent implement` restart that
+points to it):
+
+- **Dirty worktree without an active job** — a restart refuses when the task
+  worktree has uncommitted changes and no in-flight job. Inspect it, then run
+  `task recover` to commit/push/open the PR, or clean/stash the worktree before
+  retrying.
+- **Live process still in the worktree** — `task recover` refuses while a live
+  process is still inside the task worktree. Wait for it to exit, or stop the
+  orphaned implementer, before recovering.
+
 ## PR Comments
 
 Use GitHub PR comments as the public audit trail:

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1040,6 +1040,7 @@ gitmoot agent show <name>
 gitmoot agent doctor <name>
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
+gitmoot task recover task-001 --owner lead   # finalize a dead implement's dirty worktree
 gitmoot task list --repo owner/repo
 gitmoot job list
 gitmoot job show <job-id>
@@ -1059,6 +1060,17 @@ gitmoot daemon status
 Goal import turns Markdown headings shaped like `### Task N: Title` into local
 planned tasks. `task run` starts one task branch in a dedicated worktree,
 records its branch lock, and stores the worktree path on the task.
+
+If an implementer dies mid-work — after editing the task worktree but before it
+commits, pushes, and opens a PR — the edits are left uncommitted. `task run`
+(and `agent implement`) refuse to restart over a dirty worktree with no active
+job, rather than silently discard the work, and point at `task recover <id>
+--owner <agent>`. `task recover` commits the full worktree state (`git add -A`,
+including untracked non-ignored files), pushes the branch, and opens or adopts
+the task's PR — the finalize steps the dead implementer never reached. `--repo`
+is optional (it falls back to the task's stored repo). Recovery refuses while a
+live process is still inside the task worktree; wait for it to exit or stop the
+orphaned implementer first.
 
 ## Runtime Plugin Setup
 
@@ -2488,7 +2500,14 @@ Fixes:
   progress past the staleness window (default 30m; tune with the
   `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value
   is 1m — below-1m, malformed, or non-positive values are rejected in favor of
-  the 30m default rather than clamped, #560).
+  the 30m default rather than clamped, #560). This window is a same-boot crash
+  backstop, not a timeout: a job holding a runtime session lock whose lease has
+  not elapsed is left running regardless of the window (its real timeout has not
+  passed). After a **reboot** you do not wait it out at all — the kernel boot id
+  changes, so on its next startup and every tick the daemon immediately requeues
+  every job claimed on the previous boot and reclaims its stranded runtime session
+  lock, regardless of any unexpired lease (#651). Boot-aware recovery is Linux
+  only; elsewhere recovery falls back to the lease/age window above.
 - A backlog of `blocked` jobs (each paused awaiting a human) never clears on its
   own. Dismiss one with `gitmoot job cancel <job-id>` (cancel now abandons a
   `blocked` job as well as a `queued`/`running` one; #631), or clear a stale
@@ -3033,6 +3052,20 @@ Parallelism under `pool` is bounded by **two** independent locks:
    `ask`/`review` jobs can be auto-isolated into an ephemeral detached worktree. A
    plain, top-level same-repo `implement` job with no worktree still shares the
    `repo:<repo>` key and serializes even under `pool`.
+
+   **Read-only fan-out worktrees are the committed tip.** An auto-isolated
+   read-only worktree is a detached `git worktree add` at the **committed tip** of
+   the base branch, so it does **not** contain gitignored paths (e.g. vendored
+   clones under `repos/**`) or any uncommitted working-tree changes. This only
+   kicks in for **two or more** read-only siblings (the fan-out that would
+   otherwise serialize); a **single** read-only delegation stays in the shared
+   base checkout and sees everything. Each fan-out child's prompt now carries a
+   note with the canonical base-checkout absolute path, so a worker whose sandbox
+   can read it (e.g. codex) reaches the real tree instead of reporting a
+   working-tree feature as missing. For whole-working-tree analysis that must see
+   gitignored or uncommitted state, either run a **single** read-only delegation
+   (no fan-out → stays in the base checkout) or pass an **absolute** path to the
+   file/dir under analysis.
 2. **Runtime session lock (`runtime:<runtime>:<ref>`).** Two jobs that use the
    **same** agent/runtime session serialize on the session lock even when their
    checkouts differ. So same-repo parallelism is bounded by **distinct runtime
@@ -7511,14 +7544,33 @@ implementation plans, standard goal files, agent template workflows, custom
 prompt agents, template capture, job status, or branch lock inspection.
 
 For current-chat prompt import, "use <agent> here" or "use Gitmoot agent
-<agent> here" means run `gitmoot agent prompt <agent>` and apply the returned
-prompt content in this current chat. This is prompt import, not true
-system-prompt injection. The natural phrase "use the Gitmoot planner here" maps
-to the same `planner` template used by managed planner agents. If the planner
-template is not cached, read and apply the packaged
-`agent-templates/planner.md` instructions directly. Do not route a "here"
-request through a background `gitmoot agent ask` unless the user explicitly
-asks for background execution, PR-comment routing, or job tracking.
+<agent> here" means import the agent's prompt into this current chat and apply
+it. This is prompt import, not true system-prompt injection. The natural phrase
+"use the Gitmoot planner here" maps to the same `planner` template used by
+managed planner agents. If the planner template is not cached, read and apply
+the packaged `agent-templates/planner.md` instructions directly. Do not route a
+"here" request through a background `gitmoot agent ask` unless the user
+explicitly asks for background execution, PR-comment routing, or job tracking.
+
+By DEFAULT, the "here" flow tracks the work: run
+`gitmoot agent prompt <agent> --record [--repo owner/repo]`, which opens a
+session job on import and returns the prompt with a header line naming its job
+id. Apply the prompt, do the work, then — this is REQUIRED — clock out with
+`gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."`
+so the work shows in `job list`, the dashboard, and the event stream just like
+an engine-run job (no runtime is spawned; gitmoot is only the record-keeper).
+`--record` needs a **registered agent** with a repo scope — a bare template id is
+rejected. When "here" resolves to a **template that has no registered agent** (e.g.
+the packaged `planner` above, when no `planner` agent exists), import it with plain
+`gitmoot agent prompt <template>` (untracked); to still track it, register the agent
+first or log it explicitly with `gitmoot job record --agent <name> --repo owner/repo`.
+`--record` also defaults the job `--type` to `implement` — pass `--type ask` for
+advisory "here" work (planning, research) so it is not mislabeled.
+For a plain read-only peek — "just show me the prompt" — use
+`gitmoot agent prompt <agent>` WITHOUT `--record`, which opens no job. You can
+also clock in/out manually with `gitmoot job open` / `gitmoot job close`, or log
+already-finished work in one shot with `gitmoot job record` (see
+`references/CLI.md` → Session jobs).
 
 For template capture, phrases like "capture this session as a Gitmoot agent
 template", "turn this workflow into a Gitmoot template", or "draft a reusable
@@ -8457,7 +8509,25 @@ gitmoot agent prompt frontend-reviewer --json
 
 This prints the prompt content for the current chat to apply locally. It does
 not create a job, start a daemon, resume a runtime session, or post a PR
-comment.
+comment — a free read-only peek.
+
+To track the here-method work by default, add `--record`: it opens a session
+job on import (see "Session jobs" below) and returns the prompt with a header
+line naming the job id, so the imported work shows in `job list` / the dashboard
+once you clock out:
+
+```sh
+gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|review|implement] [--json]
+# prints:  [gitmoot session job <id> — when this work is complete, run:
+#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]
+# followed by the prompt body.
+```
+
+`--record` requires an **agent** (not a bare template id); the repo comes from
+`--repo`, else the agent's `repo_scope` (error if neither is set). `--type`
+defaults to `implement`. When the imported work is done, close the job with
+`gitmoot job close <id> --decision …`. `--json` includes the opened `job_id`.
+Without `--record`, behavior is unchanged (no job).
 
 Draft and validate a captured template before installing it:
 
@@ -8564,6 +8634,42 @@ gitmoot task list --repo owner/repo --state implementing --json
 `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/` and leaves the registered
 checkout on its current branch.
 
+### Recover A Dead Implement
+
+When an implementer dies mid-work — its process exits after editing the task
+worktree but before it commits, pushes, and opens a PR — the edits are left
+uncommitted in the worktree. `task run` (and `agent implement`) refuse to
+restart over that state so nothing is silently discarded, and point you at
+`task recover`:
+
+```sh
+gitmoot task recover task-001 --owner lead
+gitmoot task recover task-001 --owner lead --repo owner/repo --skip-native-review-fanout --json
+```
+
+`--owner <agent>` is required (a registered implement-capable agent, attributed
+as the recovery lead). `--repo owner/repo` is optional — it falls back to the
+task's stored repo and is only required when the task carries none.
+`--skip-native-review-fanout` persists that flag before the PR is opened;
+`--json` prints the machine-readable recovery result.
+
+`task recover` commits the full worktree state (`git add -A`, including
+untracked non-ignored files), pushes the task branch, and opens or adopts the
+task's PR — the exact finalize steps the dead implementer never reached. If the
+worktree is already clean it recovers the commit already ahead of the base
+(and refuses when there is nothing ahead to recover).
+
+Two refusals guard `task recover` (and the `task run` / `agent implement`
+restart that points to it):
+
+- **Dirty worktree without an active job** — `task run`/`agent implement` refuse
+  to restart a task whose worktree has uncommitted changes and no in-flight job;
+  inspect it, then `task recover` to commit/push/open the PR, or clean/stash the
+  worktree before retrying.
+- **Live process still in the worktree** — `task recover` refuses while a live
+  process is still inside the task worktree; wait for it to exit or stop the
+  orphaned implementer before recovering.
+
 ## PR Comments
 
 Use GitHub PR comments as the public audit trail:
@@ -8603,6 +8709,52 @@ gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+### Session jobs (record "here"-method work)
+
+The "here" method — importing an agent's prompt into your calling session with
+`gitmoot agent prompt <agent>` — does the real work in your session but creates
+**no gitmoot job**, so the dashboard / `job list` / event stream never reflect it.
+Session jobs record that work as a first-class tracked job **without gitmoot
+spawning a runtime** — a clock-in / clock-out pair (plus a one-shot recorder):
+
+```sh
+# Clock in: create a RUNNING, externally-driven job (no dispatch); prints its id.
+gitmoot job open --agent <name> --repo owner/repo --type ask|review|implement \
+                 [--title "..."] [--task <id>] [--pr <n>] [--json]
+
+# Clock out: apply the result and move the job to its terminal state.
+gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed \
+                 [--summary "..."] [--pr <n>] [--branch <name>] [--json]
+
+# One-shot post-hoc: create an already-terminal job (open + close in one).
+gitmoot job record --agent <name> --repo owner/repo --type ask|review|implement \
+                 --decision <decision> [--title "..."] [--summary "..."] \
+                 [--task <id>] [--pr <n>] [--branch <name>] [--json]
+```
+
+An `externally_driven` job is created directly in `running` (it never queues, so
+the daemon never claims or Delivers it — no runtime subprocess, no runtime-session
+or checkout lock) and the stuck-`running` reaper **skips** it, so a session may
+hold it open for as long as the work takes. `close` reuses the exact result path an
+engine-run job uses: `--decision` maps to the same terminal state
+(`approved`/`changes_requested`/`implemented` → succeeded, `blocked` → blocked,
+`failed` → failed) and emits the same finished/failed/blocked event, so a recorded
+job is indistinguishable from an engine-run one in the dashboard and events. A job
+can be closed **once** (it must be a running session job); an orphaned open job
+stays `running` (reaper-exempt) until you `job close --decision failed` or `job
+cancel <id>` it. A session job is never engine-executed, so `job retry` **refuses**
+it (retrying would re-queue it for a real runtime with an empty payload) — recover
+one by opening a fresh session job instead. The agent and repo must exist.
+
+**Make in-chat / "here" work show on the dashboard.** The one-step default is
+`gitmoot agent prompt <agent> --record`: it opens the session job *as you import
+the prompt* and prints a header naming the job id (see the `agent prompt`
+section above). Apply the prompt, do the work, then clock out with
+`gitmoot job close <id> --decision …`. That is all it takes for otherwise-invisible
+current-chat ("here") work to appear in `job list`, the dashboard, and the event
+stream — no daemon, no runtime, no PR comment. Use plain `agent prompt` (no
+`--record`) only when you just want to read a prompt without tracking it.
 
 `gitmoot job kill <root-job-id>` is the operator kill switch for a runaway
 delegation tree: it terminates the tree identified by its **root** job id
@@ -8645,7 +8797,14 @@ progress past the staleness window (default 30m) is assumed orphaned by a dead
 worker and recovered/re-queued. The window is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` env var; the smallest honored value is 1m —
 below-1m, malformed, or non-positive values are rejected (with a one-time
-warning) in favor of the 30m default rather than clamped (#560).
+warning) in favor of the 30m default rather than clamped (#560). That window is a
+same-boot crash backstop, not a timeout: a running job whose runtime-session lease
+has not elapsed is left held regardless of the window. After a **reboot** there is
+no wait at all — the daemon detects the changed kernel boot id and, on its next
+startup and every tick, immediately requeues every job claimed on a previous boot
+and reclaims its stranded `runtime:<rt>:<session>` lock, regardless of any
+unexpired lease (Linux only; elsewhere recovery falls back to the lease/age window;
+#651).
 
 `gitmoot job cancel <job-id>` is the single-job **abandon** verb. It dismisses a
 `queued`, `running`, **or `blocked`** job (a blocked job is one paused awaiting a
@@ -9567,6 +9726,15 @@ a success is working as designed, not flaky:
   envelope records a `malformed_output` event and is re-asked with a repair
   prompt a bounded number of times before failing terminally.
 
+**Dead implement recovery (manual):** if an implementer's process dies after
+editing the task worktree but before it commits/pushes/opens a PR, the edits sit
+uncommitted. `gitmoot task run` and `gitmoot agent implement` refuse to restart
+over a dirty worktree with no active job (so nothing is discarded) and point at
+`gitmoot task recover <task-id> --owner <agent>`, which commits the full
+worktree state (`git add -A`, incl. untracked non-ignored files), pushes the
+branch, and opens or adopts the PR. `--repo` is optional (falls back to the
+task's repo). Recovery refuses while a live process is still inside the worktree.
+
 The daemon default is `--workers 1`. Users can raise it when jobs target
 different runtime sessions, managed agent types with `max_background` greater
 than one, or forkable temporary workers. By default `[parallel_sessions]` uses
@@ -9692,6 +9860,20 @@ Each child job carries job-tree linkage fields — `parent_job_id`,
 `delegation_id`, `root_job_id`, `delegation_depth`, and `task_id` — so a child
 can be traced back to its parent, its originating delegation, and the root of the
 tree. See `RESULT_CONTRACT.md` for the full delegation field reference.
+
+**Read-only fan-out runs at the committed tip.** When a coordinator emits **two
+or more** read-only (`ask`/`review`) siblings, Gitmoot auto-isolates each into a
+detached `git worktree` at the **committed tip** of the base branch so they run
+in parallel instead of serializing on the shared checkout. That worktree does
+**not** contain gitignored paths (e.g. vendored clones under `repos/**`) or any
+uncommitted working-tree changes, so an analysis/research leg cannot see the
+operator's live working tree there. Each such child's prompt now carries a note
+with the canonical base-checkout absolute path so a worker whose sandbox can read
+it (e.g. codex) reaches the real tree instead of reporting a working-tree feature
+as absent. A **single** read-only delegation stays in the shared base checkout
+and sees everything, so for whole-working-tree analysis (auditing gitignored
+vendored repos, or in-flight uncommitted WIP) either fan out to exactly **one**
+read-only leg or pass an **absolute** path to the file/dir under analysis.
 
 ## Coordinator-Owned Review
 
@@ -10094,7 +10276,10 @@ cannot recurse or fan out forever:
   not delegate further.
 - Per-root job budget `MaxDelegationTotalJobs = 64`: the whole delegation tree
   under one root (all children and continuations sharing that root) is capped.
-  When a batch would exceed it, the delegations are not dispatched.
+  The check is projected: the new jobs a batch would add (ready and deferred
+  legs, minus already-enqueued/fingerprint-deduped ones) are counted before any
+  child is enqueued, so a wide fan-out from just under the cap is refused whole
+  rather than overshooting it.
 - Per-root wall-clock budget `MaxDelegationWallClock = 2h`: the whole tree under
   one root is bounded in duration (measured from the root job's creation); a
   coordinator that tries to fan out after the tree has run this long is refused
@@ -10185,9 +10370,9 @@ cannot recurse or fan out forever:
   `human_questions[]` is byte-identical to today's behavior.
 
 When a bound trips, the offending delegations are not dispatched and the parent
-receives a typed lifecycle event explaining why (for example, the delegation tree
-for a root reached the job budget of 64). Rather than stopping silently, the
-engine then enqueues one **graceful finalize continuation**
+receives a typed lifecycle event explaining why (for example, a delegation batch
+of new jobs would exceed the per-root job budget of 64). Rather than stopping
+silently, the engine then enqueues one **graceful finalize continuation**
 (`delegation_finalize_enqueued`) back to the coordinator — told it cannot
 delegate further and asked to synthesize a best-effort final result and return
 empty delegations. That continuation is terminal: any delegations it returns are
@@ -10538,7 +10723,10 @@ Delegation trees are bounded so they cannot run forever:
   this depth may not delegate further. Override per host with the
   `GITMOOT_MAX_DELEGATION_DEPTH` env var (positive integer).
 - Per-root job budget: `MaxDelegationTotalJobs = 64`. The whole delegation tree
-  under one root is capped at this many jobs. Override per host with the
+  under one root is capped at this many jobs. The check is projected: a batch's
+  new jobs are counted before any child is enqueued and the whole batch is
+  refused if it would cross the cap, so a wide fan-out from just under the limit
+  does not overshoot. Override per host with the
   `GITMOOT_MAX_DELEGATION_TOTAL_JOBS` env var (positive integer).
 - Per-root wall-clock budget: `MaxDelegationWallClock = 2h`. The whole tree under
   one root is bounded in duration (measured from the root job's creation); a
@@ -10608,7 +10796,7 @@ Delegation trees are bounded so they cannot run forever:
 
 When a bound trips (a budget cap or confirmed loop), the offending delegations
 are not dispatched and the parent receives a typed lifecycle event explaining why
-(for example, "delegation tree for root <id> reached the job budget of 64").
+(for example, "delegation batch of <n> new job(s) would exceed the per-root job budget of 64").
 Rather than stopping silently, the engine then enqueues one **graceful finalize
 continuation** back to the coordinator (`delegation_finalize_enqueued`): it is
 told it cannot delegate further and asked to synthesize a best-effort final


### PR DESCRIPTION
## What

Lands **#665** (@plotarmordev's session-isolation + task-recovery fixes — thank you!) together with the three maintainer fixes from the review, as one stack. Opened as a maintainer branch because pushing into the contributor's fork isn't appropriate from this side; #665 will be closed as superseded with full credit (plotarmordev's 4 commits are in this branch's history and are credited as co-author on squash).

### From #665 (plotarmordev, unchanged)
1. **Per-job session isolation**: registered fresh runtime refs are job-scoped (`fresh:job:<hash>`); the concrete session/thread id flows back and is adopted in-memory so same-job repair resumes the job's own session.
2. **Task-row reuse**: retried local implement with same repo+branch reuses the existing task row instead of failing the UNIQUE constraint.
3. **`task recover <id>`**: finalizes a dead implement's dirty worktree (commit/push/open-adopt PR); `task run` refuses fresh implement on a dirty worktree and points at recover; plus the live-orphan `/proc` guard (8dc4152).

### Maintainer fixes on top (from the adversarial review of #665)
4. **F1**: `--session last` + template Claude agents stayed isolated only for job 1 — the minted per-job session was persisted onto the agent row, so job 2+ resumed job 1's ever-growing session. New explicit `runtime.Result.SessionEphemeral` signal (set only on by-design fresh paths) gates persistence; the #443 dead-session self-heal re-pin still persists (regression-pinned). The misleading `session_refresh_retry` event no longer fires on healthy fresh deliveries.
5. **F2 (#669 interaction)**: fresh codex deliveries that adopt a concrete thread now **seed the `runtime_session_usage` baseline**, so a malformed-output repair no longer double-counts turn-1 tokens against the #338 delegation token budget (pin test fails `250/25 vs 150/15` without the fix).
6. **F3**: docs-ship-with-code — `task recover` + both refusal behaviors documented in `skills/gitmoot/references/CLI.md`, `WORKFLOWS.md`, `website/docs/reference/cli.md`, `docs/local-workflow.md`; `llms-full.txt` regenerated. Plus: usage-string required/optional brackets corrected, `RevParse` leading-dash guard.

## Verification
- 4-lens adversarial review of #665 (fix-correctness, wave-interaction, completeness/policy, external scrutiny) — findings adversarially verified, 0 refuted; posted on #665.
- Maintainer fixes: 2-lens adversarial review, approved round 1; every new test proven to fail on a surgically-reverted tree (genuine pins).
- Full gate on this exact branch: build, `go generate` clean, vet, full `go test ./...`, `go test -race` on workflow/cli/db/daemon — **all green**.
- Follow-ups deliberately deferred (in commit bodies): scheduler fresh-ref serialization-key scoping; indexed job queries for the dispatch path; `runTaskRecover` CLI-entrypoint tests; push-failure lock-cleanup test.

## Deploy notes
No schema changes beyond what's already on main. Engine/runtime/mailbox changes → standard local deploy (build, mv-rename, daemon restart at idle).

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)
