### PR TITLE
feat(dashboard): Learning datasource + dep bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705130251-1655216f947f
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705184605-03017943bd67
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704210015-df2c3e78c5ae h1:ik2
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260704210015-df2c3e78c5ae/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705130251-1655216f947f h1:RYY2X3CnLjTKx9g1FoLYXWlxmAV7YvLnefozT2w48aA=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705130251-1655216f947f/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705184605-03017943bd67 h1:jnb9Zu4CDp2Rqd1i9L3WOmqb0o/p6NVZ49X3kLuZoEY=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705184605-03017943bd67/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/cli/dashboard_web_learning.go
+++ b/internal/cli/dashboard_web_learning.go
@@ -1,0 +1,394 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	dashboard "github.com/jerryfane/gitmoot-dashboard"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+)
+
+// This file implements the two Learning-page DataSource methods — Skills (the
+// SkillOpt evolution overview) and Knowledge (the memory brain graph) — over the
+// same read-only store paths the rest of dashboard_web.go uses (withStore /
+// withStoreAndPaths, parseJobTimeMillis, loadAgentTypesFailOpen). Both are
+// deterministic: the Learning UI polls them with a change-signature skip, so the
+// sort orders below must be stable across calls.
+
+// Skills returns the SkillOpt evolution overview behind the Learning page's Skills
+// view: one SkillTemplate per registered agent template, each carrying its full
+// version history (the sparkline), the version it currently resolves to, any
+// in-flight canary, and its pending candidates. It is a single read-only pass over
+// ListAgentTemplates plus, per template, ListAgentTemplateVersions; each version's
+// score is read best-effort from its candidate review. It is fail-open per
+// template: a broken review or a version-list error degrades that one template
+// (empty scores / history) rather than failing the endpoint.
+func (d *webDataSource) Skills(ctx context.Context) (dashboard.Skills, error) {
+	out := dashboard.Skills{Templates: []dashboard.SkillTemplate{}}
+	err := withStore(d.home, func(store *db.Store) error {
+		templates, err := store.ListAgentTemplates(ctx)
+		if err != nil {
+			return err
+		}
+		agentsByTemplate := agentsByTemplateID(ctx, store)
+
+		out.Templates = make([]dashboard.SkillTemplate, 0, len(templates))
+		for _, tmpl := range templates {
+			out.Templates = append(out.Templates, buildSkillTemplate(ctx, store, tmpl, agentsByTemplate[tmpl.ID]))
+		}
+
+		// Deterministic order: pending-first, then most-recently-promoted
+		// (LastPromotedAt desc), TemplateID tie-break — mirrors the fake feed's sort.
+		sort.SliceStable(out.Templates, func(i, j int) bool {
+			pi, pj := len(out.Templates[i].Pending) > 0, len(out.Templates[j].Pending) > 0
+			if pi != pj {
+				return pi
+			}
+			if out.Templates[i].LastPromotedAt != out.Templates[j].LastPromotedAt {
+				return out.Templates[i].LastPromotedAt > out.Templates[j].LastPromotedAt
+			}
+			return out.Templates[i].TemplateID < out.Templates[j].TemplateID
+		})
+
+		for i := range out.Templates {
+			if out.Templates[i].CanarySample > 0 {
+				out.ActiveCanaries++
+			}
+			out.PendingTotal += len(out.Templates[i].Pending)
+		}
+		return nil
+	})
+	if err != nil {
+		return dashboard.Skills{}, err
+	}
+	return out, nil
+}
+
+// buildSkillTemplate maps one store template plus its version history into a
+// dashboard SkillTemplate. The current version/state come from ListAgentTemplates'
+// LEFT JOIN on current_version_id (tmpl.VersionNumber/VersionState) — the SAME
+// resolution Agent()'s Current marker uses, so the two views agree on which version
+// a template "runs". Version scores are read best-effort from each version's
+// candidate review; a broken/absent review simply leaves that version unscored.
+func buildSkillTemplate(ctx context.Context, store *db.Store, tmpl db.AgentTemplate, agents []string) dashboard.SkillTemplate {
+	st := dashboard.SkillTemplate{
+		TemplateID:     tmpl.ID,
+		Name:           strings.TrimSpace(tmpl.Name),
+		Agents:         agents,
+		Versions:       []dashboard.SkillVersion{},
+		CurrentVersion: tmpl.VersionNumber,
+		CurrentState:   strings.TrimSpace(tmpl.VersionState),
+		Pending:        []dashboard.SkillCandidate{},
+	}
+
+	versions, err := store.ListAgentTemplateVersions(ctx, tmpl.ID)
+	if err != nil {
+		// Fail-open: a version-list error leaves this one template with no history
+		// (its current version/state still resolved above) rather than failing the
+		// whole endpoint.
+		return st
+	}
+
+	for _, v := range versions {
+		score, hasScore, rawScore := reviewScore(ctx, store, v.ID)
+		state := strings.TrimSpace(v.State)
+
+		st.Versions = append(st.Versions, dashboard.SkillVersion{
+			Number:     v.VersionNumber,
+			State:      state,
+			Score:      score,
+			HasScore:   hasScore,
+			CreatedAt:  parseJobTimeMillis(v.CreatedAt),
+			PromotedAt: parseJobTimeMillis(v.PromotedAt),
+		})
+
+		// LastPromotedAt is the most-recent promotion across the whole history (it
+		// drives the template sort); a never-promoted version contributes 0.
+		if pa := parseJobTimeMillis(v.PromotedAt); pa > st.LastPromotedAt {
+			st.LastPromotedAt = pa
+		}
+
+		// Canary fields come from the single canary-state version (#484), when one is
+		// in flight. At most one canary exists per template, so the last-writer here
+		// is deterministic (there is only one).
+		if state == "canary" && v.CanarySample > 0 {
+			st.CanarySample = v.CanarySample
+			st.CanaryStartedAt = parseJobTimeMillis(v.CanaryStartedAt)
+		}
+
+		// Pending candidates carry the review's raw score string passed through
+		// verbatim (a decimal here, since the store's score column is REAL).
+		if state == "pending" {
+			st.Pending = append(st.Pending, dashboard.SkillCandidate{
+				VersionID: v.ID,
+				Number:    v.VersionNumber,
+				Score:     rawScore,
+				CreatedAt: parseJobTimeMillis(v.CreatedAt),
+			})
+		}
+	}
+
+	// Versions ascending by Number (the sparkline order); ListAgentTemplateVersions
+	// already orders by version, but sort defensively so the contract holds even if
+	// the store's order ever changes.
+	sort.SliceStable(st.Versions, func(i, j int) bool {
+		return st.Versions[i].Number < st.Versions[j].Number
+	})
+	sort.SliceStable(st.Pending, func(i, j int) bool {
+		return st.Pending[i].Number < st.Pending[j].Number
+	})
+	return st
+}
+
+// reviewScore reads a template version's candidate-review score best-effort. The
+// store column (agent_template_candidate_reviews.score) is a nullable REAL, so the
+// review struct carries it as a *float64: a present score is parsed into the float
+// (for SkillVersion.Score/HasScore) and its compact decimal string is passed
+// through on SkillCandidate.Score. A missing review (sql.ErrNoRows) or ANY lookup
+// error is swallowed — a broken review never errors the Skills endpoint (fail-open).
+func reviewScore(ctx context.Context, store *db.Store, versionID string) (score float64, hasScore bool, raw string) {
+	review, err := store.GetAgentTemplateCandidateReview(ctx, versionID)
+	if err != nil || review.Score == nil {
+		return 0, false, ""
+	}
+	return *review.Score, true, strconv.FormatFloat(*review.Score, 'f', -1, 64)
+}
+
+// agentsByTemplateID maps each base template id to the sorted names of the
+// registered agents instantiated from it. An agent's TemplateID can carry an
+// @version ref, so it is split down to the base id (SplitAgentTemplateReference)
+// before grouping. Returns an empty map on a list error (fail-open — the Skills
+// view just shows no agents-per-template).
+func agentsByTemplateID(ctx context.Context, store *db.Store) map[string][]string {
+	out := map[string][]string{}
+	agents, err := store.ListAgents(ctx)
+	if err != nil {
+		return out
+	}
+	for _, a := range agents {
+		tid, _ := db.SplitAgentTemplateReference(a.TemplateID)
+		if tid = strings.TrimSpace(tid); tid == "" {
+			continue
+		}
+		out[tid] = append(out[tid], a.Name)
+	}
+	for tid := range out {
+		sort.Strings(out[tid])
+	}
+	return out
+}
+
+// categoryEdgeCap bounds the number of fact->category-hub edges the brain graph
+// emits. There is one category edge per categorizable fact, so the count grows
+// with the fact pool; it is capped to keep the payload (and the client
+// force-graph) bounded in a large unattended deployment. The truncation is
+// deterministic: facts are walked in their stable sorted order and category edges
+// stop being appended once the cap is reached.
+const categoryEdgeCap = 2000
+
+// witnessKey identifies a fact's observation pool for the witness tally: the
+// owning agent ref, the repo (as stored, "" == general/NULL), and the memory key.
+type witnessKey struct {
+	owner string
+	repo  string
+	key   string
+}
+
+// Knowledge returns the memory brain graph behind the Learning page's Knowledge
+// view: the memory-enrolled agents, their confirmed facts, and the owner/category/
+// supersede edges between them. It is a read-only pass over the enrolled config set
+// (config.LoadAgentTypes) plus the confirmed_memories / memory_observations tables.
+//
+// Deliberate count divergence: a KnowledgeAgent's Facts count is the INJECTABLE set
+// (CountConfirmedMemoriesForOwner, which excludes superseded rows), but the Facts
+// slice INCLUDES superseded rows flagged Superseded==true so the graph can draw the
+// supersede "ghosts". The per-agent count and the on-graph fact-node count for that
+// agent therefore differ by its superseded rows — this is intentional.
+func (d *webDataSource) Knowledge(ctx context.Context) (dashboard.Knowledge, error) {
+	out := dashboard.Knowledge{
+		Agents: []dashboard.KnowledgeAgent{},
+		Facts:  []dashboard.KnowledgeFact{},
+		Edges:  []dashboard.KnowledgeEdge{},
+	}
+	err := withStoreAndPaths(d.home, func(paths config.Paths, store *db.Store) error {
+		// Confirmed facts (INCLUDING superseded ghosts) owned by any agent.
+		rows, err := store.ListConfirmedMemoriesByOwnerKind(ctx, memory.OwnerKindAgent)
+		if err != nil {
+			return err
+		}
+
+		// Per-(owner,repo,key) witness tallies from the append-only observations, in
+		// one grouped pass (no per-fact N+1). Fail-open: a query error leaves every
+		// witness count at 0 rather than failing the endpoint.
+		witnessByKey := map[witnessKey]int{}
+		if ws, werr := store.CountObservationWitnessesByKey(ctx, memory.OwnerKindAgent); werr == nil {
+			for _, w := range ws {
+				witnessByKey[witnessKey{w.OwnerRef, w.Repo, w.Key}] = w.Count
+			}
+		}
+
+		// Facts. rowid -> stable fact id, retained for supersede-edge resolution.
+		idByRow := make(map[int64]string, len(rows))
+		out.Facts = make([]dashboard.KnowledgeFact, 0, len(rows))
+		for _, r := range rows {
+			id := fmt.Sprintf("fact:%d", r.ID)
+			idByRow[r.ID] = id
+			out.Facts = append(out.Facts, dashboard.KnowledgeFact{
+				ID:         id,
+				Content:    r.Content,
+				Repo:       strings.TrimSpace(r.Repo),
+				Key:        strings.TrimSpace(r.Key),
+				Owner:      strings.TrimSpace(r.Owner.Ref),
+				Witnesses:  witnessByKey[witnessKey{r.Owner.Ref, r.Repo, r.Key}],
+				FirstSeen:  parseJobTimeMillis(r.FirstConfirmedAt),
+				LastSeen:   parseJobTimeMillis(r.UpdatedAt),
+				Superseded: r.SupersededBy != 0,
+			})
+		}
+		// Newest-first by FirstSeen, ID tie-break — mirrors the fake feed's stable order.
+		sort.SliceStable(out.Facts, func(i, j int) bool {
+			if out.Facts[i].FirstSeen != out.Facts[j].FirstSeen {
+				return out.Facts[i].FirstSeen > out.Facts[j].FirstSeen
+			}
+			return out.Facts[i].ID < out.Facts[j].ID
+		})
+
+		out.Agents = knowledgeAgents(ctx, store, paths, out.Facts)
+		out.Edges = knowledgeEdges(rows, out.Facts, idByRow)
+		return nil
+	})
+	if err != nil {
+		return dashboard.Knowledge{}, err
+	}
+	return out, nil
+}
+
+// knowledgeAgents returns the brain-graph's agent hubs: the memory-enrolled agents
+// (config.LoadAgentTypes entry.Memory, fail-open to none) UNIONED with any agent
+// that owns a confirmed fact, so every owner edge resolves to a listed node.
+// Enrolled reflects the config flag; Facts/Observations reuse the #670 count
+// helpers (Facts is the injectable count — superseded rows excluded — so it can be
+// smaller than the agent's on-graph fact-node count). Sorted by name.
+func knowledgeAgents(ctx context.Context, store *db.Store, paths config.Paths, facts []dashboard.KnowledgeFact) []dashboard.KnowledgeAgent {
+	enrolled := map[string]bool{}
+	for name, at := range loadAgentTypesFailOpen(paths) {
+		if at.Memory {
+			enrolled[name] = true
+		}
+	}
+	names := map[string]bool{}
+	for name := range enrolled {
+		names[name] = true
+	}
+	for _, f := range facts {
+		if f.Owner != "" {
+			names[f.Owner] = true
+		}
+	}
+
+	out := make([]dashboard.KnowledgeAgent, 0, len(names))
+	for name := range names {
+		ka := dashboard.KnowledgeAgent{Name: name, Enrolled: enrolled[name]}
+		if n, cerr := store.CountConfirmedMemoriesForOwner(ctx, memory.OwnerKindAgent, name); cerr == nil {
+			ka.Facts = n
+		}
+		if n, cerr := store.CountMemoryObservationsForOwner(ctx, memory.OwnerKindAgent, name); cerr == nil {
+			ka.Observations = n
+		}
+		out = append(out, ka)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// knowledgeEdges builds the brain graph's edges from the facts (owner + category)
+// and the raw confirmed rows (supersede). The final set is sorted by (kind,
+// source, target) exactly like the fake feed, so a signature-skip poll is stable.
+func knowledgeEdges(rows []db.ConfirmedMemory, facts []dashboard.KnowledgeFact, idByRow map[int64]string) []dashboard.KnowledgeEdge {
+	edges := make([]dashboard.KnowledgeEdge, 0, len(facts)*2+len(rows))
+
+	// owner: every fact -> its owning agent hub.
+	for _, f := range facts {
+		if f.Owner == "" {
+			continue
+		}
+		edges = append(edges, dashboard.KnowledgeEdge{Source: f.ID, Target: f.Owner, Kind: "owner"})
+	}
+
+	// category: every categorizable fact -> its category hub, derived from the fact
+	// key's LEADING colon-delimited dimension (the mechanical family the memory
+	// writers key on, e.g. `outcome`/`fix-rounds`); facts sharing that dimension
+	// share the hub. NOTE this derives the hub from the KEY per the design, which
+	// differs from the fake feed's use of the fact's repo/scope as the hub — the
+	// real key format carries the category dimension, the fake keys do not. Capped
+	// at categoryEdgeCap with a deterministic truncation: facts are walked in their
+	// already-sorted order and category edges stop once the cap is reached.
+	categoryEdges := 0
+	for _, f := range facts {
+		if categoryEdges >= categoryEdgeCap {
+			break
+		}
+		cat := knowledgeCategory(f.Key)
+		if cat == "" {
+			continue
+		}
+		edges = append(edges, dashboard.KnowledgeEdge{Source: f.ID, Target: cat, Kind: "category"})
+		categoryEdges++
+	}
+
+	// supersede: the newer fact -> the older fact it replaced. confirmed_memories
+	// links them via the OLDER row's superseded_by = <newer row id> (a real, scanned
+	// column — verified linkable). NOTE: no production write path currently sets
+	// superseded_by (UpsertConfirmedMemory updates the keyed row in place), so this
+	// edge set is typically empty until a supersede write-path lands — but the
+	// linkage exists, so the graph renders the ghost edges the moment it does.
+	for _, r := range rows {
+		if r.SupersededBy == 0 {
+			continue
+		}
+		older, olderOK := idByRow[r.ID]
+		newer, newerOK := idByRow[r.SupersededBy]
+		if !olderOK || !newerOK {
+			continue
+		}
+		edges = append(edges, dashboard.KnowledgeEdge{Source: newer, Target: older, Kind: "supersede"})
+	}
+
+	sort.SliceStable(edges, func(i, j int) bool {
+		if edges[i].Kind != edges[j].Kind {
+			return edges[i].Kind < edges[j].Kind
+		}
+		if edges[i].Source != edges[j].Source {
+			return edges[i].Source < edges[j].Source
+		}
+		return edges[i].Target < edges[j].Target
+	})
+	return edges
+}
+
+// knowledgeCategory derives a fact's category-hub id from its memory key. The
+// confirmed-memory writers key facts by a colon-delimited, closed-category form
+// (`fix-rounds:<decision>`, `outcome:<action>:<decision>`), so the LEADING
+// dimension is the category family. The hub id is namespaced `cat:<family>` so it
+// never collides with a fact id ("fact:<n>") or an agent name. An empty/keyless
+// fact yields "" (no category edge).
+func knowledgeCategory(key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return ""
+	}
+	family := key
+	if i := strings.Index(key, ":"); i >= 0 {
+		family = strings.TrimSpace(key[:i])
+	}
+	if family == "" {
+		return ""
+	}
+	return "cat:" + family
+}

--- a/internal/cli/dashboard_web_learning_test.go
+++ b/internal/cli/dashboard_web_learning_test.go
@@ -1,0 +1,413 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	dashboard "github.com/jerryfane/gitmoot-dashboard"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// reviewScoreSeed pins a candidate-review score (the nullable REAL column, carried
+// as *float64) on a template version so Skills() can surface it.
+func reviewScoreSeed(t *testing.T, store *db.Store, templateID, versionID string, score float64) {
+	t.Helper()
+	s := score
+	if err := store.UpsertAgentTemplateCandidateReview(context.Background(), db.AgentTemplateCandidateReview{
+		VersionID: versionID, TemplateID: templateID, Score: &s,
+	}); err != nil {
+		t.Fatalf("UpsertAgentTemplateCandidateReview %s: %v", versionID, err)
+	}
+}
+
+// seedSkillTemplates builds two templates exercising the Skills view: "planner"
+// evolves v1(superseded)->v2(current)->v3(pending)->v4(canary) with scored reviews;
+// "helper" is a single current version with no pending. Two agents point at planner
+// (one via an @latest ref, to prove the reference split) and one at helper.
+func seedSkillTemplates(t *testing.T, home string) (v3ID string) {
+	t.Helper()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	base := db.AgentTemplate{ID: "planner", Name: "Planner", Content: "v1"}
+	if err := store.UpsertAgentTemplate(ctx, base); err != nil {
+		t.Fatalf("UpsertAgentTemplate planner: %v", err)
+	}
+	tmpl, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate planner: %v", err)
+	}
+	reviewScoreSeed(t, store, "planner", tmpl.VersionID, 0.60) // v1
+
+	v2 := base
+	v2.Content = "v2"
+	v2v, err := store.AddPendingAgentTemplateVersion(ctx, v2)
+	if err != nil {
+		t.Fatalf("AddPending v2: %v", err)
+	}
+	reviewScoreSeed(t, store, "planner", v2v.ID, 0.70)
+	if _, err := store.PromoteAgentTemplateVersion(ctx, v2v.ID); err != nil {
+		t.Fatalf("Promote v2: %v", err)
+	}
+
+	v3 := base
+	v3.Content = "v3"
+	v3v, err := store.AddPendingAgentTemplateVersion(ctx, v3)
+	if err != nil {
+		t.Fatalf("AddPending v3: %v", err)
+	}
+	reviewScoreSeed(t, store, "planner", v3v.ID, 0.81)
+	v3ID = v3v.ID
+
+	v4 := base
+	v4.Content = "v4"
+	v4v, err := store.AddPendingAgentTemplateVersion(ctx, v4)
+	if err != nil {
+		t.Fatalf("AddPending v4: %v", err)
+	}
+	if _, err := store.CanaryPromoteAgentTemplateVersion(ctx, v4v.ID, 0.15); err != nil {
+		t.Fatalf("Canary v4: %v", err)
+	}
+
+	if err := store.UpsertAgentTemplate(ctx, db.AgentTemplate{ID: "helper", Name: "Helper", Content: "h1"}); err != nil {
+		t.Fatalf("UpsertAgentTemplate helper: %v", err)
+	}
+
+	for _, a := range []db.Agent{
+		{Name: "planner-two", Runtime: "codex", TemplateID: "planner@latest"},
+		{Name: "planner-agent", Runtime: "codex", TemplateID: "planner"},
+		{Name: "helper-agent", Runtime: "claude", TemplateID: "helper"},
+		{Name: "loose-agent", Runtime: "codex"},
+	} {
+		if err := store.UpsertAgent(ctx, a); err != nil {
+			t.Fatalf("UpsertAgent %s: %v", a.Name, err)
+		}
+	}
+	return v3ID
+}
+
+func approxEq(a, b float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < 1e-9
+}
+
+// TestWebDataSourceSkills asserts Skills() maps the version history + scores,
+// resolves the current/canary state, extracts pending candidates, groups the
+// agents-per-template, and sorts pending-first.
+func TestWebDataSourceSkills(t *testing.T) {
+	home := dashboardTestHome(t)
+	v3ID := seedSkillTemplates(t, home)
+
+	ds := &webDataSource{home: home}
+	skills, err := ds.Skills(context.Background())
+	if err != nil {
+		t.Fatalf("Skills: %v", err)
+	}
+
+	if len(skills.Templates) != 2 {
+		t.Fatalf("templates = %d, want 2: %+v", len(skills.Templates), skills.Templates)
+	}
+	// Pending-first: planner (has a pending candidate) before helper.
+	planner := skills.Templates[0]
+	helper := skills.Templates[1]
+	if planner.TemplateID != "planner" || helper.TemplateID != "helper" {
+		t.Fatalf("template order = %s,%s, want planner,helper (pending-first)", planner.TemplateID, helper.TemplateID)
+	}
+
+	// Current resolution (current_version_id) + canary fields.
+	if planner.CurrentVersion != 2 || planner.CurrentState != "current" {
+		t.Fatalf("planner current = v%d/%q, want v2/current", planner.CurrentVersion, planner.CurrentState)
+	}
+	if !approxEq(planner.CanarySample, 0.15) || planner.CanaryStartedAt <= 0 {
+		t.Fatalf("planner canary = sample %v started %d, want 0.15 / >0", planner.CanarySample, planner.CanaryStartedAt)
+	}
+	if planner.LastPromotedAt <= 0 {
+		t.Fatalf("planner LastPromotedAt = %d, want > 0 (v2 promotion)", planner.LastPromotedAt)
+	}
+
+	// Version history ascending by number, with the store's real states + scores.
+	if len(planner.Versions) != 4 {
+		t.Fatalf("planner versions = %d, want 4: %+v", len(planner.Versions), planner.Versions)
+	}
+	wantState := []string{"superseded", "current", "pending", "canary"}
+	for i, v := range planner.Versions {
+		if v.Number != i+1 {
+			t.Fatalf("versions[%d].Number = %d, want %d (ascending)", i, v.Number, i+1)
+		}
+		if v.State != wantState[i] {
+			t.Fatalf("versions[%d].State = %q, want %q", i, v.State, wantState[i])
+		}
+	}
+	for i, want := range []float64{0.60, 0.70, 0.81} {
+		if !planner.Versions[i].HasScore || !approxEq(planner.Versions[i].Score, want) {
+			t.Fatalf("versions[%d] score = %v (has %v), want %v", i, planner.Versions[i].Score, planner.Versions[i].HasScore, want)
+		}
+	}
+	if planner.Versions[3].HasScore {
+		t.Fatalf("canary v4 must be unscored (mid-canary, no review), got %v", planner.Versions[3].Score)
+	}
+
+	// Pending candidate carries the review's raw score string.
+	if len(planner.Pending) != 1 {
+		t.Fatalf("planner pending = %d, want 1: %+v", len(planner.Pending), planner.Pending)
+	}
+	cand := planner.Pending[0]
+	if cand.VersionID != v3ID || cand.Number != 3 || cand.Score != "0.81" {
+		t.Fatalf("pending candidate = %+v, want {%s, 3, 0.81}", cand, v3ID)
+	}
+
+	// Agents-per-template, sorted, with the @latest ref normalized to the base id.
+	if len(planner.Agents) != 2 || planner.Agents[0] != "planner-agent" || planner.Agents[1] != "planner-two" {
+		t.Fatalf("planner agents = %v, want [planner-agent planner-two]", planner.Agents)
+	}
+	if len(helper.Agents) != 1 || helper.Agents[0] != "helper-agent" {
+		t.Fatalf("helper agents = %v, want [helper-agent]", helper.Agents)
+	}
+
+	// helper: single current version, no pending, no canary.
+	if helper.CurrentVersion != 1 || len(helper.Pending) != 0 || helper.CanarySample != 0 {
+		t.Fatalf("helper = v%d pending%d canary%v, want v1/0/0", helper.CurrentVersion, len(helper.Pending), helper.CanarySample)
+	}
+
+	// Rollups.
+	if skills.ActiveCanaries != 1 || skills.PendingTotal != 1 {
+		t.Fatalf("rollups = canaries%d pending%d, want 1/1", skills.ActiveCanaries, skills.PendingTotal)
+	}
+}
+
+// seedKnowledge seeds confirmed facts across enrolled + unenrolled owners, an
+// observation pool (for witness counts), and one superseded chain (set directly,
+// since no production write path populates superseded_by). It returns the row ids
+// of the older and newer facts of that chain.
+func seedKnowledge(t *testing.T, home string) (oldID, newID int64) {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	ctx := context.Background()
+
+	for _, at := range []config.AgentType{
+		{Name: "researcher", Runtime: "codex", Memory: true},
+		{Name: "reviewer", Runtime: "kimi", Memory: true},
+		{Name: "plain", Runtime: "claude", Memory: false},
+	} {
+		if err := config.SaveAgentType(paths, at); err != nil {
+			t.Fatalf("SaveAgentType %s: %v", at.Name, err)
+		}
+	}
+
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	seed := func(ref, repo, key, content string) int64 {
+		id, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: ref}, Repo: repo, Key: key, Content: content,
+		})
+		if err != nil {
+			t.Fatalf("UpsertConfirmedMemory %s/%s: %v", ref, key, err)
+		}
+		return id
+	}
+	seed("researcher", "jerryfane/noted", "outcome:review:changes_requested", "F1")
+	seed("researcher", "jerryfane/noted", "fix-rounds:approved", "F2")
+	seed("researcher", "", "release-policy", "F3") // general scope, keyless-of-colon
+	seed("reviewer", "jerryfane/noted", "outcome:review:changes_requested", "F4")
+	seed("ghost", "acme/widgets", "outcome:implement:failed", "F5") // unenrolled owner
+	oldID = seed("researcher", "jerryfane/noted", "outcome:review:approved", "F_old")
+	newID = seed("researcher", "jerryfane/noted", "outcome:review:approved-new", "F_new")
+
+	// Observations => witness counts: F1 keyed 3x (researcher), F4 keyed 1x (reviewer).
+	obs := func(ref, repo, key string) {
+		if _, err := store.InsertMemoryObservation(ctx, db.MemoryObservation{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: ref}, Repo: repo, Scope: "repo", Key: key, Content: "obs",
+		}); err != nil {
+			t.Fatalf("InsertMemoryObservation: %v", err)
+		}
+	}
+	obs("researcher", "jerryfane/noted", "outcome:review:changes_requested")
+	obs("researcher", "jerryfane/noted", "outcome:review:changes_requested")
+	obs("researcher", "jerryfane/noted", "outcome:review:changes_requested")
+	obs("reviewer", "jerryfane/noted", "outcome:review:changes_requested")
+	store.Close()
+
+	// Link the supersede chain directly (no production writer sets superseded_by).
+	raw, err := sql.Open("sqlite", paths.Database)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(ctx, `UPDATE confirmed_memories SET superseded_by = ? WHERE id = ?`, newID, oldID); err != nil {
+		t.Fatalf("set superseded_by: %v", err)
+	}
+	return oldID, newID
+}
+
+// TestWebDataSourceKnowledge asserts Knowledge() maps facts (including flagged
+// superseded ghosts), witness counts, enrolled+owner agents, and the owner/
+// category/supersede edges deterministically.
+func TestWebDataSourceKnowledge(t *testing.T) {
+	home := dashboardTestHome(t)
+	oldID, newID := seedKnowledge(t, home)
+
+	ds := &webDataSource{home: home}
+	k, err := ds.Knowledge(context.Background())
+	if err != nil {
+		t.Fatalf("Knowledge: %v", err)
+	}
+
+	// Agents: enrolled (researcher, reviewer) unioned with the unenrolled fact-owner
+	// (ghost). "plain" is enrolled=false AND owns nothing, so it is absent.
+	if len(k.Agents) != 3 {
+		t.Fatalf("agents = %d, want 3: %+v", len(k.Agents), k.Agents)
+	}
+	byAgent := map[string]dashboard.KnowledgeAgent{}
+	for _, a := range k.Agents {
+		byAgent[a.Name] = a
+	}
+	if !byAgent["researcher"].Enrolled || !byAgent["reviewer"].Enrolled {
+		t.Fatalf("researcher/reviewer must be enrolled: %+v", k.Agents)
+	}
+	if _, ok := byAgent["ghost"]; !ok || byAgent["ghost"].Enrolled {
+		t.Fatalf("ghost must be listed with Enrolled=false: %+v", k.Agents)
+	}
+	if _, ok := byAgent["plain"]; ok {
+		t.Fatalf("plain (enrolled=false, no facts) must be absent: %+v", k.Agents)
+	}
+	// Facts count is the INJECTABLE set (excludes the superseded F_old): researcher
+	// owns 5 rows but 4 injectable.
+	if byAgent["researcher"].Facts != 4 {
+		t.Fatalf("researcher injectable Facts = %d, want 4 (F_old superseded is excluded)", byAgent["researcher"].Facts)
+	}
+	if byAgent["researcher"].Observations != 3 {
+		t.Fatalf("researcher Observations = %d, want 3", byAgent["researcher"].Observations)
+	}
+
+	// Facts: all 7 rows present, including the superseded ghost (the graph shows it,
+	// diverging from the per-agent injectable count above).
+	if len(k.Facts) != 7 {
+		t.Fatalf("facts = %d, want 7 (incl the superseded ghost)", len(k.Facts))
+	}
+	byContent := map[string]dashboard.KnowledgeFact{}
+	for _, f := range k.Facts {
+		byContent[f.Content] = f
+	}
+	if !byContent["F_old"].Superseded {
+		t.Fatalf("F_old must be flagged Superseded")
+	}
+	if byContent["F_new"].Superseded || byContent["F1"].Superseded {
+		t.Fatalf("non-superseded facts must not be flagged")
+	}
+	if byContent["F1"].Witnesses != 3 {
+		t.Fatalf("F1 witnesses = %d, want 3", byContent["F1"].Witnesses)
+	}
+	if byContent["F4"].Witnesses != 1 {
+		t.Fatalf("F4 witnesses = %d, want 1", byContent["F4"].Witnesses)
+	}
+	if byContent["F2"].Witnesses != 0 {
+		t.Fatalf("F2 witnesses = %d, want 0 (no matching observations)", byContent["F2"].Witnesses)
+	}
+	if byContent["F3"].Repo != "" {
+		t.Fatalf("F3 must be general-scope (empty repo), got %q", byContent["F3"].Repo)
+	}
+
+	// Edges by kind.
+	var owner, category, supersede int
+	var superEdge dashboard.KnowledgeEdge
+	catTarget := map[string]int{}
+	for _, e := range k.Edges {
+		switch e.Kind {
+		case "owner":
+			owner++
+		case "category":
+			category++
+			if e.Source == byContent["F1"].ID {
+				catTarget["F1"] = 1
+				if e.Target != "cat:outcome" {
+					t.Fatalf("F1 category target = %q, want cat:outcome (leading key dimension)", e.Target)
+				}
+			}
+		case "supersede":
+			supersede++
+			superEdge = e
+		default:
+			t.Fatalf("unexpected edge kind %q", e.Kind)
+		}
+	}
+	if owner != 7 || category != 7 || supersede != 1 {
+		t.Fatalf("edges = owner%d category%d supersede%d, want 7/7/1", owner, category, supersede)
+	}
+	// Supersede direction: newer fact -> older fact.
+	wantNew := fmt.Sprintf("fact:%d", newID)
+	wantOld := fmt.Sprintf("fact:%d", oldID)
+	if superEdge.Source != wantNew || superEdge.Target != wantOld {
+		t.Fatalf("supersede edge = %s->%s, want %s->%s (newer->older)", superEdge.Source, superEdge.Target, wantNew, wantOld)
+	}
+	if catTarget["F1"] != 1 {
+		t.Fatalf("F1 must have a category edge")
+	}
+
+	// Determinism: a second call is byte-identical.
+	k2, err := ds.Knowledge(context.Background())
+	if err != nil {
+		t.Fatalf("Knowledge (2nd): %v", err)
+	}
+	if fmt.Sprintf("%+v", k) != fmt.Sprintf("%+v", k2) {
+		t.Fatalf("Knowledge not deterministic across calls")
+	}
+}
+
+// TestKnowledgeCategory covers the key -> category-hub derivation.
+func TestKnowledgeCategory(t *testing.T) {
+	cases := map[string]string{
+		"outcome:review:changes_requested": "cat:outcome",
+		"fix-rounds:approved":              "cat:fix-rounds",
+		"release-policy":                   "cat:release-policy",
+		"":                                 "",
+		":x":                               "",
+		"   ":                              "",
+	}
+	for key, want := range cases {
+		if got := knowledgeCategory(key); got != want {
+			t.Fatalf("knowledgeCategory(%q) = %q, want %q", key, got, want)
+		}
+	}
+}
+
+// TestKnowledgeEdgesCategoryCap asserts the category-edge cap truncates
+// deterministically while owner edges stay uncapped.
+func TestKnowledgeEdgesCategoryCap(t *testing.T) {
+	const n = categoryEdgeCap + 100
+	facts := make([]dashboard.KnowledgeFact, 0, n)
+	for i := 0; i < n; i++ {
+		facts = append(facts, dashboard.KnowledgeFact{
+			ID: fmt.Sprintf("fact:%d", i), Owner: "researcher", Key: fmt.Sprintf("outcome:%d", i),
+		})
+	}
+	edges := knowledgeEdges(nil, facts, map[int64]string{})
+
+	var owner, category int
+	for _, e := range edges {
+		switch e.Kind {
+		case "owner":
+			owner++
+		case "category":
+			category++
+		}
+	}
+	if owner != n {
+		t.Fatalf("owner edges = %d, want %d (uncapped)", owner, n)
+	}
+	if category != categoryEdgeCap {
+		t.Fatalf("category edges = %d, want %d (capped)", category, categoryEdgeCap)
+	}
+}

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -149,6 +149,78 @@ WHERE owner_kind = ? AND owner_ref = ?`, ownerKind, ownerRef).Scan(&n)
 	return n, nil
 }
 
+// ListConfirmedMemoriesByOwnerKind returns every confirmed_memories row owned by
+// the given owner kind (e.g. memory.OwnerKindAgent), across every repo/scope/owner
+// version, and INCLUDING superseded rows — surfaced with SupersededBy populated
+// (COALESCEd from the nullable superseded_by column, 0 == not superseded). It is
+// the dashboard brain-graph read path: unlike QueryConfirmedMemories (the
+// injectable set, which drops superseded rows) and CountConfirmedMemoriesForOwner
+// (which counts only injectable rows), the graph deliberately shows superseded
+// "ghost" facts so it can draw supersede edges, so this MUST NOT filter them. Rows
+// come back ordered by id for a stable, deterministic traversal. Plain read, no FTS.
+func (s *Store) ListConfirmedMemoriesByOwnerKind(ctx context.Context, ownerKind string) ([]ConfirmedMemory, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
+	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
+FROM confirmed_memories
+WHERE owner_kind = ?
+ORDER BY id`, ownerKind)
+	if err != nil {
+		return nil, fmt.Errorf("list confirmed memories by owner kind: %w", err)
+	}
+	defer rows.Close()
+	var out []ConfirmedMemory
+	for rows.Next() {
+		var c ConfirmedMemory
+		var repoNull sql.NullString
+		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &repoNull,
+			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
+			return nil, err
+		}
+		c.Repo = repoNull.String
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// ObservationKeyWitnesses is a per-(owner_ref, repo, key) tally of how many
+// append-only observation sightings back that triple — the "witness" count a
+// confirmed fact on the same key accumulated. Repo is normalized ("" == general /
+// NULL repo).
+type ObservationKeyWitnesses struct {
+	OwnerRef string
+	Repo     string
+	Key      string
+	Count    int
+}
+
+// CountObservationWitnessesByKey groups memory_observations for the given owner
+// kind by (owner_ref, repo, key) and returns each triple's sighting count in ONE
+// pass, so the brain graph can attach a witness count to every fact without an N+1
+// per-fact query. A NULL repo (general scope) is normalized to "".
+func (s *Store) CountObservationWitnessesByKey(ctx context.Context, ownerKind string) ([]ObservationKeyWitnesses, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT owner_ref, repo, key, COUNT(*)
+FROM memory_observations
+WHERE owner_kind = ?
+GROUP BY owner_ref, repo, key`, ownerKind)
+	if err != nil {
+		return nil, fmt.Errorf("count observation witnesses by key: %w", err)
+	}
+	defer rows.Close()
+	var out []ObservationKeyWitnesses
+	for rows.Next() {
+		var w ObservationKeyWitnesses
+		var repoNull sql.NullString
+		if err := rows.Scan(&w.OwnerRef, &repoNull, &w.Key, &w.Count); err != nil {
+			return nil, err
+		}
+		w.Repo = repoNull.String
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
 // UpsertConfirmedMemory writes or updates the single keyed confirmed row for a
 // fact and keeps the FTS index in sync, all in one transaction. Writes are
 // serialized by the store (MaxOpenConns=1) so a manual select-then-insert/update


### PR DESCRIPTION
Companion to [gitmoot-dashboard#31](https://github.com/jerryfane/gitmoot-dashboard/pull/31) (interface grew → bump + impl together).

- **`Skills()`** — SkillOpt templates with ascending versions + parsed review scores, current/canary state resolution, pending candidates; deterministic ordering for the UI's signature-skip poll.
- **`Knowledge()`** — enrolled agents + injectable counts; graph facts (superseded rows included as flagged ghosts — documented divergence from the count), owner/category/supersede edges with a deterministic cap, witness counts in one grouped pass.

Verified live: 15 templates / 9 pending render on Skills; Knowledge serves the 16-agent empty state. Gates green against the published dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)