### PR TITLE
feat(runtime): config-driven runtime metadata registry

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -309,7 +309,11 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			}
 		}
 		if !handled {
-			if _, err := (workflow.Mailbox{Store: store}).Run(runCtx, job.ID, effectiveAgent, adapter); err != nil {
+			// #652: wire the home-aware registry default_model fallback so a
+			// foreground ask with no agent/job --model honors [runtimes.<rt>].default_model
+			// too. Fail-open/empty by default => byte-identical; an agent/job pin wins.
+			mailbox := workflow.Mailbox{Store: store, RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home)}
+			if _, err := mailbox.Run(runCtx, job.ID, effectiveAgent, adapter); err != nil {
 				return localAgentJobOutput{}, foregroundAskTimeoutError(runCtx, jobTimeout, err)
 			}
 		}

--- a/internal/cli/agent_dispatch_live_ab.go
+++ b/internal/cli/agent_dispatch_live_ab.go
@@ -133,7 +133,7 @@ func maybeRunLiveAB(ctx context.Context, store *db.Store, request localAgentDisp
 	// === Past this point we ARE intercepting (handled=true regardless of outcome). ===
 	// 1) Champion: the canonical answer the user receives, via the normal
 	//    Mailbox.Run path so the job/result are identical to a plain ask.
-	championResult, runErr := (workflow.Mailbox{Store: store}).Run(ctx, job.ID, runtimeAgent(agent), adapter)
+	championResult, runErr := (workflow.Mailbox{Store: store, RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home)}).Run(ctx, job.ID, runtimeAgent(agent), adapter)
 	if runErr != nil {
 		// The primary ask itself failed — surface it exactly as the non-intercepted
 		// path would (the caller propagates the same error).

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -405,6 +405,9 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		engine := workflow.Engine{
 			Store:     store,
 			MergeGate: mergeGate,
+			// Registry default_model behavioral fallback (#652), home-aware and
+			// fail-open — see daemonWorkflowEngine. Empty by default => byte-identical.
+			RuntimeDefaultModel: runtimeDefaultModelResolver(*home),
 		}
 		// Honor the opt-in [orchestrate] policy (artifact-body inlining + per-root
 		// delegation token budget) on this single-repo engine too; fail-safe to the
@@ -6352,6 +6355,13 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// the terminal path are byte-identical. Non-enrolled agents are never touched
 		// even when the controller is present.
 		Memory: daemonMemoryController(store, home),
+		// Registry default_model behavioral fallback (#652): when a delivered job
+		// pins no agent --model and no job --model, fall back to the runtime's
+		// configured default_model from the HOME-AWARE resolved runtime registry
+		// (built-in defaults overlaid with [runtimes.<name>] config). Fail-open and
+		// empty by default, so with no config NO model is forced and delivery is
+		// byte-identical; an agent/job --model always wins.
+		RuntimeDefaultModel: runtimeDefaultModelResolver(home),
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,7 @@ var rootCommands = []command{
 	{name: "repo", summary: "manage watched repositories", run: runRepo},
 	{name: "daemon", summary: "run the local PR watcher", run: runDaemon},
 	{name: "agent", summary: "manage registered agents", run: runAgent},
+	{name: "runtime", summary: "inspect runtime metadata (models, capabilities, usage)", run: runRuntime},
 	{name: "orchestrate", summary: "Orchestrate work across agents (a coordinator that fans out delegations)", run: runOrchestrate},
 	{name: "plugin", summary: "build and inspect Gitmoot agent plugins", run: runPlugin},
 	{name: "events", summary: "show local repo events", run: runEvents},

--- a/internal/cli/runtime_registry.go
+++ b/internal/cli/runtime_registry.go
@@ -56,6 +56,31 @@ func runtimeMetadataOverrides(overrides []config.RuntimeOverride) []runtime.Meta
 	return out
 }
 
+// runtimeDefaultModelResolver returns a HOME-AWARE resolver for a runtime's
+// configured registry default_model (#652), suitable for wiring into
+// workflow.Engine.RuntimeDefaultModel / workflow.Mailbox.RuntimeDefaultModel so a
+// delivered job with no agent --model and no job --model falls back to it. It reads
+// the built-in registry overlaid with any [runtimes.<name>] config overrides for
+// `home` (which may be an already-resolved <home>/.gitmoot root OR a raw --home;
+// resolveConfigFile handles both), then returns the resolved DefaultModel for the
+// named runtime. It is FAIL-OPEN: a resolution error, a missing config, an empty
+// home, or an unknown runtime all yield "", so delivery forces nothing and is
+// byte-identical to before #652. It re-reads config on each call, so a warm-reloaded
+// (SIGHUP) default_model edit takes effect without a full restart.
+func runtimeDefaultModelResolver(home string) func(string) string {
+	return func(runtimeName string) string {
+		registry, err := resolveRuntimeRegistry(config.Paths{ConfigFile: resolveConfigFile(home)})
+		if err != nil {
+			return ""
+		}
+		meta, ok := registry.Metadata(strings.TrimSpace(runtimeName))
+		if !ok {
+			return ""
+		}
+		return strings.TrimSpace(meta.DefaultModel)
+	}
+}
+
 func runRuntime(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printRuntimeUsage(stdout)

--- a/internal/cli/runtime_registry.go
+++ b/internal/cli/runtime_registry.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// resolveRuntimeRegistry builds the effective runtime metadata registry: the
+// compiled built-in defaults (which reproduce today's behavior exactly) overlaid
+// with any [runtimes.<name>] operator overrides from the config file. A missing
+// config file (fresh box) or an absent [runtimes.*] section yields the built-in
+// registry unchanged, so the default path is byte-identical.
+func resolveRuntimeRegistry(paths config.Paths) (runtime.Registry, error) {
+	registry := runtime.BuiltinRuntimeRegistry()
+	overrides, err := config.LoadRuntimeOverrides(paths)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return registry, nil
+		}
+		return runtime.Registry{}, err
+	}
+	if len(overrides) == 0 {
+		return registry, nil
+	}
+	return registry.ApplyOverrides(runtimeMetadataOverrides(overrides))
+}
+
+// runtimeMetadataOverrides translates the neutral config.RuntimeOverride data
+// into the runtime package's MetadataOverride patches. It exists so config does
+// not import runtime and runtime does not import config — the CLI layer, which
+// imports both, is the single translation seam.
+func runtimeMetadataOverrides(overrides []config.RuntimeOverride) []runtime.MetadataOverride {
+	out := make([]runtime.MetadataOverride, 0, len(overrides))
+	for _, o := range overrides {
+		out = append(out, runtime.MetadataOverride{
+			Name:            o.Name,
+			DefaultModel:    o.DefaultModel,
+			DefaultModelSet: o.DefaultModelSet,
+			Models:          o.Models,
+			ModelsSet:       o.ModelsSet,
+			Capabilities:    o.Capabilities,
+			CapabilitiesSet: o.CapabilitiesSet,
+			UsageSource:     o.UsageSource,
+			UsageSourceSet:  o.UsageSourceSet,
+		})
+	}
+	return out
+}
+
+func runRuntime(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printRuntimeUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "list":
+		return runRuntimeList(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown runtime command %q\n\n", args[0])
+		printRuntimeUsage(stderr)
+		return 2
+	}
+}
+
+func printRuntimeUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot runtime list [--json]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Shows the resolved metadata for each built-in runtime: capabilities, default")
+	fmt.Fprintln(w, "and known models, and where token usage is read from. Values come from the")
+	fmt.Fprintln(w, "compiled built-in defaults, overlaid with any [runtimes.<name>] config overrides.")
+}
+
+// runtimeListEntry is the JSON shape for `gitmoot runtime list --json`.
+type runtimeListEntry struct {
+	Name         string   `json:"name"`
+	Dispatchable bool     `json:"dispatchable"`
+	Capabilities []string `json:"capabilities"`
+	DefaultModel string   `json:"default_model"`
+	Models       []string `json:"models"`
+	UsageSource  string   `json:"usage_source"`
+	Description  string   `json:"description"`
+}
+
+func runRuntimeList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("runtime list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print the runtimes as a JSON array instead of the text table")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "runtime list does not accept positional arguments")
+		return 2
+	}
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "runtime list: %v\n", err)
+		return 1
+	}
+	registry, err := resolveRuntimeRegistry(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "runtime list: %v\n", err)
+		return 1
+	}
+	metas := registry.All()
+	if *jsonOutput {
+		entries := make([]runtimeListEntry, 0, len(metas))
+		for _, m := range metas {
+			entries = append(entries, runtimeListEntry{
+				Name:         m.Name,
+				Dispatchable: m.Dispatchable,
+				Capabilities: m.Capabilities,
+				DefaultModel: m.DefaultModel,
+				Models:       m.Models,
+				UsageSource:  m.UsageSource,
+				Description:  m.Description,
+			})
+		}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(entries); err != nil {
+			fmt.Fprintf(stderr, "runtime list: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	tw := tabwriter.NewWriter(stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "RUNTIME\tCAPABILITIES\tDEFAULT MODEL\tKNOWN MODELS\tUSAGE SOURCE")
+	for _, m := range metas {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			m.Name,
+			strings.Join(m.Capabilities, ","),
+			orDash(m.DefaultModel),
+			orDash(strings.Join(m.Models, ",")),
+			orDash(m.UsageSource),
+		)
+	}
+	_ = tw.Flush()
+	return 0
+}
+
+// orDash renders an empty string as "-" so a table cell is never blank.
+func orDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}

--- a/internal/cli/runtime_registry_test.go
+++ b/internal/cli/runtime_registry_test.go
@@ -135,6 +135,39 @@ func TestRunRuntimeListUnknownRuntimeExits(t *testing.T) {
 	}
 }
 
+// TestRuntimeDefaultModelResolverReadsConfig proves the HOME-AWARE delivery hook
+// (#652) returns the configured [runtimes.<rt>].default_model for a runtime, and
+// resolves NOTHING (byte-identical) for a runtime with no override.
+func TestRuntimeDefaultModelResolverReadsConfig(t *testing.T) {
+	src := writeCLIConfig(t, "[runtimes.codex]\ndefault_model = \"gpt-5.5\"\n")
+	home := homeFromConfig(t, src)
+	resolve := runtimeDefaultModelResolver(home)
+	if got := resolve(runtime.CodexRuntime); got != "gpt-5.5" {
+		t.Fatalf("resolve(codex) = %q, want gpt-5.5", got)
+	}
+	// A runtime with no override records no default: the hook forces nothing.
+	if got := resolve(runtime.ClaudeRuntime); got != "" {
+		t.Fatalf("resolve(claude) = %q, want empty (no override)", got)
+	}
+}
+
+// TestRuntimeDefaultModelResolverAbsentConfigByteIdentical proves the fail-open
+// contract: with no config file (fresh box), an empty home, or an unknown runtime,
+// the hook resolves "" so delivery forces no model — byte-identical to before #652.
+func TestRuntimeDefaultModelResolverAbsentConfigByteIdentical(t *testing.T) {
+	missingHome := t.TempDir() // no config.toml written anywhere under it
+	if got := runtimeDefaultModelResolver(missingHome)(runtime.CodexRuntime); got != "" {
+		t.Fatalf("missing-config resolve(codex) = %q, want empty", got)
+	}
+	if got := runtimeDefaultModelResolver("")(runtime.CodexRuntime); got != "" {
+		t.Fatalf("empty-home resolve(codex) = %q, want empty", got)
+	}
+	src := writeCLIConfig(t, "[runtimes.codex]\ndefault_model = \"gpt-5.5\"\n")
+	if got := runtimeDefaultModelResolver(homeFromConfig(t, src))("nonexistent-runtime"); got != "" {
+		t.Fatalf("unknown-runtime resolve = %q, want empty", got)
+	}
+}
+
 // homeFromConfig writes the given config body into a home layout so a --home flag
 // resolves ConfigFile to it. The CLI resolves --home via config.PathsForHome, so
 // place the file at <home>/.gitmoot/config.toml.

--- a/internal/cli/runtime_registry_test.go
+++ b/internal/cli/runtime_registry_test.go
@@ -1,0 +1,156 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+func writeCLIConfig(t *testing.T, body string) config.Paths {
+	t.Helper()
+	dir := t.TempDir()
+	paths := config.Paths{ConfigFile: filepath.Join(dir, "config.toml")}
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return paths
+}
+
+// TestResolveRuntimeRegistryDefaultByteIdentical proves that with no [runtimes.*]
+// section the resolved registry equals the built-in one.
+func TestResolveRuntimeRegistryDefaultByteIdentical(t *testing.T) {
+	paths := writeCLIConfig(t, "[paths]\ndatabase = \"x\"\n")
+	got, err := resolveRuntimeRegistry(paths)
+	if err != nil {
+		t.Fatalf("resolveRuntimeRegistry error: %v", err)
+	}
+	if !reflect.DeepEqual(got.All(), runtime.BuiltinRuntimeRegistry().All()) {
+		t.Fatalf("resolved registry differs from built-in with no overrides")
+	}
+}
+
+// TestResolveRuntimeRegistryMissingFile proves a missing config file resolves to
+// the built-in registry rather than erroring.
+func TestResolveRuntimeRegistryMissingFile(t *testing.T) {
+	paths := config.Paths{ConfigFile: filepath.Join(t.TempDir(), "nope.toml")}
+	got, err := resolveRuntimeRegistry(paths)
+	if err != nil {
+		t.Fatalf("resolveRuntimeRegistry error: %v", err)
+	}
+	if !reflect.DeepEqual(got.All(), runtime.BuiltinRuntimeRegistry().All()) {
+		t.Fatalf("missing file should resolve to built-in registry")
+	}
+}
+
+// TestResolveRuntimeRegistryOverride proves config overrides are applied on top of
+// the built-ins.
+func TestResolveRuntimeRegistryOverride(t *testing.T) {
+	paths := writeCLIConfig(t, `
+[runtimes.codex]
+default_model = "gpt-5.5-codex"
+models = ["gpt-5.5-codex"]
+`)
+	got, err := resolveRuntimeRegistry(paths)
+	if err != nil {
+		t.Fatalf("resolveRuntimeRegistry error: %v", err)
+	}
+	codex, ok := got.Metadata(runtime.CodexRuntime)
+	if !ok {
+		t.Fatal("codex missing")
+	}
+	if codex.DefaultModel != "gpt-5.5-codex" {
+		t.Fatalf("DefaultModel = %q", codex.DefaultModel)
+	}
+	if !reflect.DeepEqual(codex.Models, []string{"gpt-5.5-codex"}) {
+		t.Fatalf("Models = %v", codex.Models)
+	}
+}
+
+// TestResolveRuntimeRegistryUnknownErrors proves an unknown runtime name in config
+// surfaces the moat-preserving error.
+func TestResolveRuntimeRegistryUnknownErrors(t *testing.T) {
+	paths := writeCLIConfig(t, "[runtimes.gpt6]\ndefault_model = \"x\"\n")
+	if _, err := resolveRuntimeRegistry(paths); err == nil {
+		t.Fatal("expected error for unknown runtime")
+	}
+}
+
+// TestRunRuntimeListText covers the human table output on the default registry.
+func TestRunRuntimeListText(t *testing.T) {
+	paths := writeCLIConfig(t, "[paths]\ndatabase = \"x\"\n")
+	var stdout, stderr bytes.Buffer
+	code := runRuntimeList([]string{"--home", homeFromConfig(t, paths)}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, name := range runtime.SupportedRuntimes() {
+		if !strings.Contains(out, name) {
+			t.Fatalf("table missing runtime %q:\n%s", name, out)
+		}
+	}
+	if !strings.Contains(out, "review,implement,ask") {
+		t.Fatalf("table missing capabilities:\n%s", out)
+	}
+}
+
+// TestRunRuntimeListJSON covers the JSON output shape.
+func TestRunRuntimeListJSON(t *testing.T) {
+	paths := writeCLIConfig(t, "[paths]\ndatabase = \"x\"\n")
+	var stdout, stderr bytes.Buffer
+	code := runRuntimeList([]string{"--home", homeFromConfig(t, paths), "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit %d stderr=%s", code, stderr.String())
+	}
+	var entries []runtimeListEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, stdout.String())
+	}
+	if len(entries) != len(runtime.SupportedRuntimes()) {
+		t.Fatalf("expected %d entries, got %d", len(runtime.SupportedRuntimes()), len(entries))
+	}
+	if entries[0].Name != runtime.CodexRuntime || !entries[0].Dispatchable {
+		t.Fatalf("first entry wrong: %+v", entries[0])
+	}
+}
+
+// TestRunRuntimeListUnknownRuntimeExits proves the command exits non-zero on a bad
+// override.
+func TestRunRuntimeListUnknownRuntimeExits(t *testing.T) {
+	paths := writeCLIConfig(t, "[runtimes.gpt6]\ndefault_model = \"x\"\n")
+	var stdout, stderr bytes.Buffer
+	code := runRuntimeList([]string{"--home", homeFromConfig(t, paths)}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit, stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "gpt6") {
+		t.Fatalf("stderr should mention the bad runtime: %s", stderr.String())
+	}
+}
+
+// homeFromConfig writes the given config body into a home layout so a --home flag
+// resolves ConfigFile to it. The CLI resolves --home via config.PathsForHome, so
+// place the file at <home>/.gitmoot/config.toml.
+func homeFromConfig(t *testing.T, src config.Paths) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body, err := os.ReadFile(src.ConfigFile)
+	if err != nil {
+		t.Fatalf("read src: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, body, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return home
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -325,18 +325,22 @@ path = ""
 # (issue #652). Gitmoot ships built-in metadata for each compiled runtime (codex,
 # claude, kimi, kimi-cli, shell) — capabilities, default/known models, and where
 # token usage is read from — that reproduces today's behavior. A [runtimes.<name>]
-# section OVERRIDES that metadata for a BUILT-IN runtime WITHOUT a recompile: point
-# a runtime at a new model id, record its known-valid models, or adjust its
-# advertised capabilities. It is METADATA ONLY — adapter behavior (auth, sandbox,
-# session resume, stream parsing) stays in Go. In particular models is ADVISORY:
-# Gitmoot never REJECTS a --model based on it, so populating it cannot change how a
-# job runs. Inspect the resolved registry with 'gitmoot runtime list'. With no
-# [runtimes.*] section behavior is byte-identical. NOTE: this section can only tweak
-# a BUILT-IN runtime's metadata — it cannot add a new first-class runtime (that is a
-# code change); an unknown runtime name here is an error. default_model overrides the
-# model used when neither the agent nor the job pins one (empty = the CLI's own
-# default); models is the advisory known-valid list; capabilities is a subset of
-# review/implement/ask; usage_source is a human-readable descriptor.
+# section OVERRIDES that recorded metadata for a BUILT-IN runtime WITHOUT a
+# recompile: record which models a runtime accepts, note its declared default, or
+# adjust its advertised capabilities. It is INSPECTION-ONLY METADATA — adapter
+# behavior (auth, sandbox, session resume, stream parsing, AND which model a job
+# actually runs on) stays in Go and is NEVER consulted at job delivery. Every field
+# here is surfaced by 'gitmoot runtime list' but changes nothing at runtime: setting
+# default_model does NOT retarget the model a job uses (a job's model still comes
+# from the agent/job --model or the runtime CLI's own config), models is advisory
+# (Gitmoot never REJECTS a --model based on it), and capabilities gates nothing at
+# dispatch (agent capabilities do). With no [runtimes.*] section behavior is
+# byte-identical. NOTE: this section can only tweak a BUILT-IN runtime's metadata —
+# it cannot add a new first-class runtime (that is a code change); an unknown runtime
+# name here is an error. default_model is the DECLARED default surfaced by 'runtime
+# list' (empty = none recorded); models is the advisory known-valid list;
+# capabilities is a subset of review/implement/ask; usage_source is a human-readable
+# descriptor.
 # [runtimes.codex]
 # default_model = "gpt-5.5-codex"
 # models = ["gpt-5.5-codex", "gpt-5.4-codex"]

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -326,21 +326,23 @@ path = ""
 # claude, kimi, kimi-cli, shell) — capabilities, default/known models, and where
 # token usage is read from — that reproduces today's behavior. A [runtimes.<name>]
 # section OVERRIDES that recorded metadata for a BUILT-IN runtime WITHOUT a
-# recompile: record which models a runtime accepts, note its declared default, or
-# adjust its advertised capabilities. It is INSPECTION-ONLY METADATA — adapter
-# behavior (auth, sandbox, session resume, stream parsing, AND which model a job
-# actually runs on) stays in Go and is NEVER consulted at job delivery. Every field
-# here is surfaced by 'gitmoot runtime list' but changes nothing at runtime: setting
-# default_model does NOT retarget the model a job uses (a job's model still comes
-# from the agent/job --model or the runtime CLI's own config), models is advisory
+# recompile: retarget the default model, record which models a runtime accepts, or
+# adjust its advertised capabilities. Exactly ONE field is BEHAVIORAL: default_model
+# is consulted at job DELIVERY (#652) as the model fallback when NEITHER the agent
+# NOR the job pins a --model — so setting it DOES retarget the model those jobs run
+# on (resolution order: agent/job --model win, then this default_model, then the
+# runtime CLI's own default). Every other field is inspection-only, surfaced by
+# 'gitmoot runtime list' but changing nothing at runtime: models is advisory
 # (Gitmoot never REJECTS a --model based on it), and capabilities gates nothing at
-# dispatch (agent capabilities do). With no [runtimes.*] section behavior is
-# byte-identical. NOTE: this section can only tweak a BUILT-IN runtime's metadata —
-# it cannot add a new first-class runtime (that is a code change); an unknown runtime
-# name here is an error. default_model is the DECLARED default surfaced by 'runtime
-# list' (empty = none recorded); models is the advisory known-valid list;
-# capabilities is a subset of review/implement/ask; usage_source is a human-readable
-# descriptor.
+# dispatch (agent capabilities do). Adapter behavior (auth, sandbox, session resume,
+# stream parsing) always stays in Go. With no [runtimes.*] section — and with
+# default_model unset (empty = none recorded, the built-in default) — behavior is
+# byte-identical: no model is forced. NOTE: this section can only tweak a BUILT-IN
+# runtime's metadata — it cannot add a new first-class runtime (that is a code
+# change); an unknown runtime name here is an error. default_model is the configured
+# default surfaced by 'runtime list' AND the delivery fallback; models is the
+# advisory known-valid list; capabilities is a subset of review/implement/ask;
+# usage_source is a human-readable descriptor.
 # [runtimes.codex]
 # default_model = "gpt-5.5-codex"
 # models = ["gpt-5.5-codex", "gpt-5.4-codex"]

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -321,6 +321,27 @@ path = ""
 # kimi_memory_gb = 0.5
 # default_memory_gb = 0.5
 
+# [runtimes.<name>] is the OPTIONAL config-driven runtime metadata registry
+# (issue #652). Gitmoot ships built-in metadata for each compiled runtime (codex,
+# claude, kimi, kimi-cli, shell) — capabilities, default/known models, and where
+# token usage is read from — that reproduces today's behavior. A [runtimes.<name>]
+# section OVERRIDES that metadata for a BUILT-IN runtime WITHOUT a recompile: point
+# a runtime at a new model id, record its known-valid models, or adjust its
+# advertised capabilities. It is METADATA ONLY — adapter behavior (auth, sandbox,
+# session resume, stream parsing) stays in Go. In particular models is ADVISORY:
+# Gitmoot never REJECTS a --model based on it, so populating it cannot change how a
+# job runs. Inspect the resolved registry with 'gitmoot runtime list'. With no
+# [runtimes.*] section behavior is byte-identical. NOTE: this section can only tweak
+# a BUILT-IN runtime's metadata — it cannot add a new first-class runtime (that is a
+# code change); an unknown runtime name here is an error. default_model overrides the
+# model used when neither the agent nor the job pins one (empty = the CLI's own
+# default); models is the advisory known-valid list; capabilities is a subset of
+# review/implement/ask; usage_source is a human-readable descriptor.
+# [runtimes.codex]
+# default_model = "gpt-5.5-codex"
+# models = ["gpt-5.5-codex", "gpt-5.4-codex"]
+# capabilities = ["review", "implement", "ask"]
+
 # [merge_gate] tunes how the native merge gate handles a PR head that reports NO
 # external CI (issue #596). By default (no section) the gate defers concluding
 # "no CI" until a SECOND consecutive zero-external observation at the same head,

--- a/internal/config/runtime_registry.go
+++ b/internal/config/runtime_registry.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// RuntimeOverride is a parsed [runtimes.<name>] config section: an operator's
+// partial override of a built-in runtime's declarative metadata (issue #652).
+// Each field carries a companion *Set bool reporting whether the key was PRESENT
+// in the file, so an override applies EXACTLY the keys the operator wrote and an
+// absent-or-empty section is a pure no-op (byte-identical default). The values
+// here are neutral data — the runtime package (which owns the metadata registry)
+// consumes them; config deliberately does not import runtime, so a new first-class
+// runtime is a code change, not a config edit.
+type RuntimeOverride struct {
+	// Name is the runtime id from the section header ([runtimes.<name>]).
+	Name string
+	// DefaultModel overrides the runtime's default model (empty = the CLI's own
+	// default). DefaultModelSet reports the key was present.
+	DefaultModel    string
+	DefaultModelSet bool
+	// Models replaces the advisory known-valid model list. ModelsSet reports the
+	// key was present (an empty array is a valid, explicit "clear the list").
+	Models    []string
+	ModelsSet bool
+	// Capabilities replaces the advertised capability set. CapabilitiesSet reports
+	// the key was present.
+	Capabilities    []string
+	CapabilitiesSet bool
+	// UsageSource overrides the human-readable usage descriptor. UsageSourceSet
+	// reports the key was present.
+	UsageSource    string
+	UsageSourceSet bool
+}
+
+// LoadRuntimeOverrides parses every [runtimes.<name>] section from the config
+// file. A file with no such section returns nil (nothing to apply), which the
+// runtime package treats as "use the built-in registry unchanged" — so behavior
+// is byte-identical for configs that never write the section. Sections are
+// returned in first-seen order; a repeated [runtimes.<name>] merges into the same
+// override (last key wins), matching how the other loaders treat duplicate keys.
+func LoadRuntimeOverrides(paths Paths) ([]RuntimeOverride, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	collected := map[string]*RuntimeOverride{}
+	order := make([]string, 0)
+	var current *RuntimeOverride
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = nil
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			name, ok := parseRuntimeRegistrySection(section)
+			if !ok {
+				continue
+			}
+			if collected[name] == nil {
+				collected[name] = &RuntimeOverride{Name: name}
+				order = append(order, name)
+			}
+			current = collected[name]
+			continue
+		}
+		if current == nil {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyRuntimeOverrideField(current, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return nil, fmt.Errorf("parse [runtimes.%s].%s: %w", current.Name, strings.TrimSpace(key), err)
+		}
+	}
+	overrides := make([]RuntimeOverride, 0, len(order))
+	for _, name := range order {
+		overrides = append(overrides, *collected[name])
+	}
+	return overrides, nil
+}
+
+// parseRuntimeRegistrySection extracts the runtime name from a section of the
+// form runtimes.<name>. It returns ok=false for any other section (including a
+// deeper sub-subsection under <name>), so unrelated sections are ignored.
+func parseRuntimeRegistrySection(section string) (string, bool) {
+	section = strings.TrimSpace(section)
+	const prefix = "runtimes."
+	if !strings.HasPrefix(section, prefix) {
+		return "", false
+	}
+	name := strings.TrimSpace(strings.TrimPrefix(section, prefix))
+	if name == "" {
+		return "", false
+	}
+	// The name must be a leaf: a further '.' would be a deeper subsection this
+	// section does not define, so reject it rather than silently truncating.
+	if strings.Contains(name, ".") {
+		return "", false
+	}
+	return name, true
+}
+
+func applyRuntimeOverrideField(override *RuntimeOverride, key string, value string) error {
+	switch key {
+	case "default_model":
+		parsed, err := parseConfigString(value)
+		if err != nil {
+			return err
+		}
+		override.DefaultModel = strings.TrimSpace(parsed)
+		override.DefaultModelSet = true
+		return nil
+	case "models":
+		parsed, err := parseConfigStringArray(value)
+		if err != nil {
+			return err
+		}
+		override.Models = parsed
+		override.ModelsSet = true
+		return nil
+	case "capabilities":
+		parsed, err := parseConfigStringArray(value)
+		if err != nil {
+			return err
+		}
+		override.Capabilities = parsed
+		override.CapabilitiesSet = true
+		return nil
+	case "usage_source":
+		parsed, err := parseConfigString(value)
+		if err != nil {
+			return err
+		}
+		override.UsageSource = strings.TrimSpace(parsed)
+		override.UsageSourceSet = true
+		return nil
+	default:
+		// Unknown keys are ignored so the section can grow without breaking older
+		// binaries, mirroring the other config loaders.
+		return nil
+	}
+}

--- a/internal/config/runtime_registry_test.go
+++ b/internal/config/runtime_registry_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeRuntimeRegistryConfig(t *testing.T, body string) Paths {
+	t.Helper()
+	dir := t.TempDir()
+	paths := Paths{ConfigFile: filepath.Join(dir, "config.toml")}
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return paths
+}
+
+// TestLoadRuntimeOverridesNoSection proves a config with no [runtimes.*] section
+// yields no overrides — the byte-identical default path.
+func TestLoadRuntimeOverridesNoSection(t *testing.T) {
+	paths := writeRuntimeRegistryConfig(t, "[paths]\ndatabase = \"x\"\n")
+	overrides, err := LoadRuntimeOverrides(paths)
+	if err != nil {
+		t.Fatalf("LoadRuntimeOverrides error: %v", err)
+	}
+	if len(overrides) != 0 {
+		t.Fatalf("expected no overrides, got %v", overrides)
+	}
+}
+
+// TestLoadRuntimeOverridesParsesKeys proves each key is parsed and its *Set flag
+// is only true when the key was present.
+func TestLoadRuntimeOverridesParsesKeys(t *testing.T) {
+	paths := writeRuntimeRegistryConfig(t, `
+[runtimes.codex]
+default_model = "gpt-5.5-codex"
+models = ["gpt-5.5-codex", "gpt-5.4-codex"]
+
+[runtimes.claude]
+capabilities = ["review", "ask"]
+usage_source = "custom"
+`)
+	overrides, err := LoadRuntimeOverrides(paths)
+	if err != nil {
+		t.Fatalf("LoadRuntimeOverrides error: %v", err)
+	}
+	if len(overrides) != 2 {
+		t.Fatalf("expected 2 overrides, got %d: %+v", len(overrides), overrides)
+	}
+	codex := overrides[0]
+	if codex.Name != "codex" {
+		t.Fatalf("order/name wrong: %+v", codex)
+	}
+	if !codex.DefaultModelSet || codex.DefaultModel != "gpt-5.5-codex" {
+		t.Fatalf("default_model not parsed: %+v", codex)
+	}
+	if !codex.ModelsSet || !reflect.DeepEqual(codex.Models, []string{"gpt-5.5-codex", "gpt-5.4-codex"}) {
+		t.Fatalf("models not parsed: %+v", codex)
+	}
+	// codex did not set capabilities/usage_source.
+	if codex.CapabilitiesSet || codex.UsageSourceSet {
+		t.Fatalf("unset keys must have *Set false: %+v", codex)
+	}
+	claude := overrides[1]
+	if !claude.CapabilitiesSet || !reflect.DeepEqual(claude.Capabilities, []string{"review", "ask"}) {
+		t.Fatalf("capabilities not parsed: %+v", claude)
+	}
+	if !claude.UsageSourceSet || claude.UsageSource != "custom" {
+		t.Fatalf("usage_source not parsed: %+v", claude)
+	}
+	if claude.DefaultModelSet || claude.ModelsSet {
+		t.Fatalf("unset keys must have *Set false: %+v", claude)
+	}
+}
+
+// TestLoadRuntimeOverridesDuplicateMerges proves a repeated [runtimes.<name>]
+// merges into one override (last key wins) rather than producing two entries.
+func TestLoadRuntimeOverridesDuplicateMerges(t *testing.T) {
+	paths := writeRuntimeRegistryConfig(t, `
+[runtimes.codex]
+default_model = "a"
+
+[runtimes.codex]
+default_model = "b"
+`)
+	overrides, err := LoadRuntimeOverrides(paths)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(overrides) != 1 {
+		t.Fatalf("expected 1 merged override, got %d", len(overrides))
+	}
+	if overrides[0].DefaultModel != "b" {
+		t.Fatalf("last key should win: %q", overrides[0].DefaultModel)
+	}
+}
+
+// TestLoadRuntimeOverridesIgnoresSubSubsection proves a deeper section under a
+// runtime name is ignored rather than mis-parsed as the runtime.
+func TestLoadRuntimeOverridesIgnoresSubSubsection(t *testing.T) {
+	paths := writeRuntimeRegistryConfig(t, `
+[runtimes.codex.extra]
+default_model = "a"
+`)
+	overrides, err := LoadRuntimeOverrides(paths)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(overrides) != 0 {
+		t.Fatalf("sub-subsection must be ignored, got %v", overrides)
+	}
+}
+
+// TestLoadRuntimeOverridesMissingFile surfaces os.ErrNotExist so the caller can
+// treat a fresh box as "no overrides" via errors.Is.
+func TestLoadRuntimeOverridesMissingFile(t *testing.T) {
+	paths := Paths{ConfigFile: filepath.Join(t.TempDir(), "does-not-exist.toml")}
+	if _, err := LoadRuntimeOverrides(paths); !os.IsNotExist(err) {
+		t.Fatalf("expected not-exist error, got %v", err)
+	}
+}

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -63,6 +63,15 @@ type Job struct {
 	Repository  string
 	PullRequest int
 	Model       string
+	// RuntimeDefaultModel is the runtime's configured registry default_model
+	// (#652), threaded in by the dispatch layer from the HOME-AWARE resolved runtime
+	// registry (built-in defaults overlaid with [runtimes.<name>] config). It is the
+	// FINAL model fallback: effectiveModel uses it ONLY when neither the job (Model)
+	// nor the agent (Agent.Model) pins a model, so an agent/job --model always wins.
+	// Empty — the built-in default for every runtime, and the value when no config
+	// sets it — means "no registry default", so delivery defers to the runtime CLI's
+	// own default exactly as before #652 (byte-identical).
+	RuntimeDefaultModel string
 }
 
 type Result struct {
@@ -538,14 +547,21 @@ func (a CodexAdapter) sessionResolver() CodexSessionResolver {
 	return CodexSessionIndex{}
 }
 
-// effectiveModel resolves which model a delivered job runs on: the per-job/
-// per-delegation override (job.Model) wins, falling back to the agent's default
-// (agent.Model). An empty result means "no --model arg" (runtime default).
+// effectiveModel resolves which model a delivered job runs on. Precedence, most
+// specific first: the per-job/per-delegation override (job.Model) wins, then the
+// agent's configured default (agent.Model), then — when NEITHER pins a model — the
+// runtime's configured registry default_model (job.RuntimeDefaultModel, #652). An
+// empty result means "no --model arg" (the runtime CLI's own default). Because the
+// registry default is consulted last and defaults to empty, an agent/job pin
+// always wins and an unset registry default is byte-identical to before #652.
 func effectiveModel(agent Agent, job Job) string {
 	if job.Model != "" {
 		return job.Model
 	}
-	return agent.Model
+	if agent.Model != "" {
+		return agent.Model
+	}
+	return strings.TrimSpace(job.RuntimeDefaultModel)
 }
 
 func codexSandboxArgs(agent Agent) []string {

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -155,11 +155,13 @@ func (f Factory) Adapter(name string) (Adapter, error) {
 
 // SupportedRuntimes enumerates every runtime name the adapter Factory can
 // construct — the single source of truth callers (e.g. the per-job --runtime
-// override validation) use instead of hard-coding runtime names. Keep it in
-// lockstep with Factory.Adapter; TestSupportedRuntimesMatchFactory proves the
-// coupling both ways.
+// override validation) use instead of hard-coding runtime names. It is derived
+// from the built-in runtime metadata registry's dispatchable entries, so the
+// enumeration, the registry, and Factory.Adapter share one source of truth; keep
+// it in lockstep with Factory.Adapter (TestSupportedRuntimesMatchFactory proves
+// the coupling both ways).
 func SupportedRuntimes() []string {
-	return []string{CodexRuntime, ClaudeRuntime, KimiRuntime, KimiCLIRuntime, ShellRuntime}
+	return builtinRegistry.dispatchableNames()
 }
 
 // FreshRefPrefix marks a runtime reference that names no existing session:

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -152,6 +152,87 @@ func TestCodexDeliverCommandFallsBackToAgentModel(t *testing.T) {
 	runner.want(t, 0, "codex", "exec", "--json", "resume", "--model", "sonnet", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
 }
 
+// TestCodexDeliverCommandFallsBackToRuntimeDefaultModel proves the #652 behavioral
+// registry default: with NO agent --model and NO job --model, a delivered job runs
+// on Job.RuntimeDefaultModel (the runtime's configured default_model, threaded in
+// by the dispatch layer). This is the real resolution seam — the --model arg the
+// runtime CLI actually receives.
+func TestCodexDeliverCommandFallsBackToRuntimeDefaultModel(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review this", RuntimeDefaultModel: "gpt-5.5"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--model", "gpt-5.5", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
+}
+
+// TestCodexDeliverCommandJobModelWinsOverRuntimeDefault proves a job --model pin
+// still WINS over the registry default_model (#652 resolution order).
+func TestCodexDeliverCommandJobModelWinsOverRuntimeDefault(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review this", Model: "opus", RuntimeDefaultModel: "gpt-5.5"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--model", "opus", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
+}
+
+// TestCodexDeliverCommandAgentModelWinsOverRuntimeDefault proves an agent --model
+// pin still WINS over the registry default_model when the job pins none (#652).
+func TestCodexDeliverCommandAgentModelWinsOverRuntimeDefault(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot", Model: "sonnet"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review this", RuntimeDefaultModel: "gpt-5.5"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "--model", "sonnet", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
+}
+
+// TestCodexDeliverCommandNoRuntimeDefaultIsByteIdentical proves the byte-identical
+// default: an EMPTY RuntimeDefaultModel (the built-in default for every runtime, and
+// the value when no config sets it) forces NO --model arg — exactly as before #652.
+func TestCodexDeliverCommandNoRuntimeDefaultIsByteIdentical(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
+	adapter := CodexAdapter{Runner: runner, SessionResolver: staticCodexSessions{exists: true}}
+	agent := Agent{Name: "lead", Role: "implementer", Runtime: CodexRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440001", RepoScope: "jerryfane/gitmoot"}
+
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review this", RuntimeDefaultModel: ""}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--json", "resume", "550e8400-e29b-41d4-a716-446655440001", "--", "review this")
+}
+
+// TestEffectiveModelResolutionOrder locks the exact #652 precedence directly at the
+// resolution function: job --model > agent --model > runtime default_model > "".
+func TestEffectiveModelResolutionOrder(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		agentModel string
+		jobModel   string
+		rtDefault  string
+		want       string
+	}{
+		{"job wins over all", "sonnet", "opus", "gpt-5.5", "opus"},
+		{"agent wins over rt default", "sonnet", "", "gpt-5.5", "sonnet"},
+		{"rt default when neither pins", "", "", "gpt-5.5", "gpt-5.5"},
+		{"empty when nothing set (byte-identical)", "", "", "", ""},
+		{"rt default trimmed", "", "", "  gpt-5.5  ", "gpt-5.5"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := effectiveModel(Agent{Model: tc.agentModel}, Job{Model: tc.jobModel, RuntimeDefaultModel: tc.rtDefault})
+			if got != tc.want {
+				t.Fatalf("effectiveModel(agent=%q, job=%q, rtDefault=%q) = %q, want %q", tc.agentModel, tc.jobModel, tc.rtDefault, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCodexStartCommandUsesAgentModel(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"type":"thread.started","thread_id":"550e8400-e29b-41d4-a716-446655440009"}` + "\n"}}}
 	adapter := CodexAdapter{Runner: runner}

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -12,14 +12,16 @@ import (
 // list of known-valid model ids, and a human-readable descriptor of where the
 // adapter reads token usage from the CLI's structured output.
 //
-// It is METADATA ONLY. The adapter *behavior* — auth/token handling, sandbox
-// policy, session resume, stream parsing, transient-retry — stays in Go and is
-// unaffected by this type. The registry is a single source of truth consulted for
-// runtime enumeration (SupportedRuntimes) and surfaced by `gitmoot runtime list`;
-// it is NEVER consulted at delivery time, so seeding it (from the built-in
-// defaults below or from operator config) is byte-identical at runtime. In
-// particular Models is advisory: Gitmoot never REJECTS a --model based on it, so
-// populating it cannot change how a job is delivered.
+// The adapter *behavior* — auth/token handling, sandbox policy, session resume,
+// stream parsing, transient-retry — stays in Go and is unaffected by this type.
+// The registry is a single source of truth consulted for runtime enumeration
+// (SupportedRuntimes) and surfaced by `gitmoot runtime list`. Exactly ONE field is
+// behavioral: DefaultModel is consulted at delivery as the model fallback when
+// neither the agent nor the job pins a --model (#652). Every other field is
+// inspection-only, so seeding it (from the built-in defaults below or from
+// operator config) is byte-identical at runtime. In particular Models is advisory:
+// Gitmoot never REJECTS a --model based on it, so populating it cannot change how a
+// job is delivered.
 type RuntimeMetadata struct {
 	// Name is the runtime id (codex, claude, kimi, kimi-cli, shell).
 	Name string
@@ -32,12 +34,14 @@ type RuntimeMetadata struct {
 	// Capabilities are the job actions the runtime's adapter advertises. Every
 	// built-in advertises review/implement/ask today; the registry mirrors that.
 	Capabilities []string
-	// DefaultModel is the runtime's DECLARED default model, surfaced by
-	// `gitmoot runtime list`. It is inspection-only metadata and is NEVER consulted
-	// at delivery time: setting it does NOT retarget the model a job runs on — a
-	// job's model still comes from the agent/job --model or the runtime CLI's own
-	// configured default. Empty (the default for every built-in) means "none
-	// recorded", exactly as today.
+	// DefaultModel is the runtime's configured default model, surfaced by
+	// `gitmoot runtime list` AND consulted at delivery (#652): when NEITHER the
+	// agent NOR the job pins a --model, a delivered job falls back to this value as
+	// the model passed to the runtime (resolution order: agent/job --model win, then
+	// this registry default, then the runtime CLI's own default). It is the ONLY
+	// metadata field that is behavioral — Models and Capabilities stay advisory.
+	// Empty (the built-in default for every runtime) means "none recorded": nothing
+	// is forced, so delivery is byte-identical to before #652.
 	DefaultModel string
 	// Models is an ADVISORY list of known-valid model ids for the runtime. Empty
 	// (the default for every built-in) means "unrestricted": Gitmoot passes any

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -32,9 +32,12 @@ type RuntimeMetadata struct {
 	// Capabilities are the job actions the runtime's adapter advertises. Every
 	// built-in advertises review/implement/ask today; the registry mirrors that.
 	Capabilities []string
-	// DefaultModel is the model used when neither the agent nor the job pins one.
-	// Empty (the default for every built-in) means "no --model arg" — the runtime
-	// CLI's own configured default, exactly as today.
+	// DefaultModel is the runtime's DECLARED default model, surfaced by
+	// `gitmoot runtime list`. It is inspection-only metadata and is NEVER consulted
+	// at delivery time: setting it does NOT retarget the model a job runs on — a
+	// job's model still comes from the agent/job --model or the runtime CLI's own
+	// configured default. Empty (the default for every built-in) means "none
+	// recorded", exactly as today.
 	DefaultModel string
 	// Models is an ADVISORY list of known-valid model ids for the runtime. Empty
 	// (the default for every built-in) means "unrestricted": Gitmoot passes any

--- a/internal/runtime/registry.go
+++ b/internal/runtime/registry.go
@@ -1,0 +1,256 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RuntimeMetadata is the declarative, per-runtime metadata that Gitmoot has
+// historically hardcoded across the adapter switch and each adapter's methods:
+// which capabilities a runtime advertises, the model it defaults to, an ADVISORY
+// list of known-valid model ids, and a human-readable descriptor of where the
+// adapter reads token usage from the CLI's structured output.
+//
+// It is METADATA ONLY. The adapter *behavior* — auth/token handling, sandbox
+// policy, session resume, stream parsing, transient-retry — stays in Go and is
+// unaffected by this type. The registry is a single source of truth consulted for
+// runtime enumeration (SupportedRuntimes) and surfaced by `gitmoot runtime list`;
+// it is NEVER consulted at delivery time, so seeding it (from the built-in
+// defaults below or from operator config) is byte-identical at runtime. In
+// particular Models is advisory: Gitmoot never REJECTS a --model based on it, so
+// populating it cannot change how a job is delivered.
+type RuntimeMetadata struct {
+	// Name is the runtime id (codex, claude, kimi, kimi-cli, shell).
+	Name string
+	// Dispatchable is true for a runtime backed by a compiled Go adapter (every
+	// built-in). Config can TWEAK a built-in runtime's metadata but cannot add a
+	// new dispatchable runtime — a genuinely new first-class runtime needs a code
+	// change (its behavior is code; only its metadata is data). This field exists
+	// so that invariant is explicit and testable rather than implied.
+	Dispatchable bool
+	// Capabilities are the job actions the runtime's adapter advertises. Every
+	// built-in advertises review/implement/ask today; the registry mirrors that.
+	Capabilities []string
+	// DefaultModel is the model used when neither the agent nor the job pins one.
+	// Empty (the default for every built-in) means "no --model arg" — the runtime
+	// CLI's own configured default, exactly as today.
+	DefaultModel string
+	// Models is an ADVISORY list of known-valid model ids for the runtime. Empty
+	// (the default for every built-in) means "unrestricted": Gitmoot passes any
+	// --model through unchanged, exactly as today. It is informational only —
+	// surfaced by `gitmoot runtime list` so operators have a single place to record
+	// which models a runtime accepts — and is never used to reject a model.
+	Models []string
+	// UsageSource is a human-readable descriptor of where the adapter reads token
+	// usage from the runtime CLI's structured output. It documents (and lets a
+	// `runtime list` view expose) the per-runtime usage-capture story; it is never
+	// consulted to parse anything.
+	UsageSource string
+	// Description is a one-line summary of the runtime for the `runtime list` view.
+	Description string
+}
+
+// clone returns a deep copy so a caller can never mutate the built-in registry
+// through a returned metadata value's slices.
+func (m RuntimeMetadata) clone() RuntimeMetadata {
+	out := m
+	out.Capabilities = append([]string(nil), m.Capabilities...)
+	out.Models = append([]string(nil), m.Models...)
+	return out
+}
+
+// Registry is an ordered, name-keyed set of RuntimeMetadata. The built-in
+// registry (BuiltinRuntimeRegistry) reproduces today's hardcoded behavior; an
+// operator-overridden registry is produced by ApplyOverrides. It is immutable
+// once built — every accessor returns copies.
+type Registry struct {
+	order   []string
+	entries map[string]RuntimeMetadata
+}
+
+// Metadata returns the metadata for a runtime name and whether it is present.
+func (r Registry) Metadata(name string) (RuntimeMetadata, bool) {
+	m, ok := r.entries[strings.TrimSpace(name)]
+	if !ok {
+		return RuntimeMetadata{}, false
+	}
+	return m.clone(), true
+}
+
+// Names returns the runtime names in registration order.
+func (r Registry) Names() []string {
+	return append([]string(nil), r.order...)
+}
+
+// All returns every runtime's metadata in registration order.
+func (r Registry) All() []RuntimeMetadata {
+	out := make([]RuntimeMetadata, 0, len(r.order))
+	for _, name := range r.order {
+		out = append(out, r.entries[name].clone())
+	}
+	return out
+}
+
+// dispatchableNames returns the names of the compiled (dispatchable) runtimes in
+// registration order. SupportedRuntimes is built from this so the enumeration and
+// the adapter Factory share one source of truth.
+func (r Registry) dispatchableNames() []string {
+	out := make([]string, 0, len(r.order))
+	for _, name := range r.order {
+		if r.entries[name].Dispatchable {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// builtinRegistry is the single package-level built-in registry. It is treated as
+// immutable; every accessor returns copies, so callers cannot mutate it.
+var builtinRegistry = newBuiltinRegistry()
+
+// newBuiltinRegistry seeds the registry from the values Gitmoot hardcodes today,
+// so a fresh install with no [runtimes.*] config behaves byte-identically. The
+// registration order matches the historical SupportedRuntimes order.
+func newBuiltinRegistry() Registry {
+	metas := []RuntimeMetadata{
+		{
+			Name:         CodexRuntime,
+			Dispatchable: true,
+			Capabilities: []string{"review", "implement", "ask"},
+			UsageSource:  "codex `exec --json` turn.completed usage (session-cumulative on a resumed thread)",
+			Description:  "OpenAI Codex CLI (exec/resume, sandbox policy, session index)",
+		},
+		{
+			Name:         ClaudeRuntime,
+			Dispatchable: true,
+			Capabilities: []string{"review", "implement", "ask"},
+			UsageSource:  "claude `--output-format json` result envelope usage object",
+			Description:  "Anthropic Claude Code CLI (session-id/resume, permission modes, transient-retry)",
+		},
+		{
+			Name:         KimiRuntime,
+			Dispatchable: true,
+			Capabilities: []string{"review", "implement", "ask"},
+			UsageSource:  "kimi `--output-format stream-json` usage event (kimi-code 0.19.2 emits none -> 0)",
+			Description:  "Kimi Code CLI (prompt mode, stream-json, per-job fresh session)",
+		},
+		{
+			Name:         KimiCLIRuntime,
+			Dispatchable: true,
+			Capabilities: []string{"review", "implement", "ask"},
+			UsageSource:  "kimi `--print` `--output-format stream-json` usage event (legacy kimi-cli)",
+			Description:  "Legacy kimi-cli runtime (--print prompt mode; same model family as kimi)",
+		},
+		{
+			Name:         ShellRuntime,
+			Dispatchable: true,
+			Capabilities: []string{"review", "implement", "ask"},
+			UsageSource:  "none (the shell runtime reports no token usage)",
+			Description:  "Subscribe-only shell command runtime (no LLM; drives no-LLM E2Es)",
+		},
+	}
+	reg := Registry{entries: make(map[string]RuntimeMetadata, len(metas))}
+	for _, m := range metas {
+		reg.order = append(reg.order, m.Name)
+		reg.entries[m.Name] = m
+	}
+	return reg
+}
+
+// BuiltinRuntimeRegistry returns the built-in runtime metadata registry seeded
+// from Gitmoot's compiled defaults. It is a copy — callers cannot mutate the
+// package-level registry through it.
+func BuiltinRuntimeRegistry() Registry {
+	out := Registry{
+		order:   append([]string(nil), builtinRegistry.order...),
+		entries: make(map[string]RuntimeMetadata, len(builtinRegistry.entries)),
+	}
+	for name, m := range builtinRegistry.entries {
+		out.entries[name] = m.clone()
+	}
+	return out
+}
+
+// MetadataOverride is a partial, config-sourced patch to a built-in runtime's
+// metadata. Only the fields whose companion *Set flag is true (or non-nil
+// pointer) are applied; every other key is left at the built-in value. This is
+// what makes an override touch EXACTLY the keys an operator wrote and keeps an
+// absent [runtimes.*] section byte-identical.
+type MetadataOverride struct {
+	Name string
+	// DefaultModel overrides the runtime's default model when DefaultModelSet.
+	DefaultModel    string
+	DefaultModelSet bool
+	// Models replaces the advisory model list when ModelsSet.
+	Models    []string
+	ModelsSet bool
+	// Capabilities replaces the advertised capabilities when CapabilitiesSet.
+	Capabilities    []string
+	CapabilitiesSet bool
+	// UsageSource overrides the usage descriptor when UsageSourceSet.
+	UsageSource    string
+	UsageSourceSet bool
+}
+
+// ApplyOverrides returns a new Registry with the given operator overrides applied
+// on top of the receiver. An override MUST target an existing (built-in) runtime:
+// config can retune a runtime's metadata but cannot introduce a new dispatchable
+// runtime, which preserves the single-static-binary moat (a new first-class
+// runtime needs a code change). An override for an unknown name is a hard error
+// so a typo is caught rather than silently ignored. With no overrides the result
+// equals the receiver, so the default path stays byte-identical.
+func (r Registry) ApplyOverrides(overrides []MetadataOverride) (Registry, error) {
+	out := Registry{
+		order:   append([]string(nil), r.order...),
+		entries: make(map[string]RuntimeMetadata, len(r.entries)),
+	}
+	for name, m := range r.entries {
+		out.entries[name] = m.clone()
+	}
+	for _, override := range overrides {
+		name := strings.TrimSpace(override.Name)
+		meta, ok := out.entries[name]
+		if !ok {
+			return Registry{}, fmt.Errorf("unknown runtime %q in [runtimes.%s]: config can tweak built-in runtime metadata (%s) but cannot add a new runtime; a new first-class runtime requires a code change",
+				name, name, strings.Join(out.dispatchableNames(), ", "))
+		}
+		if override.DefaultModelSet {
+			meta.DefaultModel = strings.TrimSpace(override.DefaultModel)
+		}
+		if override.ModelsSet {
+			meta.Models = append([]string(nil), override.Models...)
+		}
+		if override.CapabilitiesSet {
+			if err := validateRuntimeCapabilities(override.Capabilities); err != nil {
+				return Registry{}, fmt.Errorf("[runtimes.%s].capabilities: %w", name, err)
+			}
+			meta.Capabilities = append([]string(nil), override.Capabilities...)
+		}
+		if override.UsageSourceSet {
+			meta.UsageSource = strings.TrimSpace(override.UsageSource)
+		}
+		out.entries[name] = meta
+	}
+	return out, nil
+}
+
+// runtimeCapabilities is the closed set of job actions a runtime may advertise.
+// It matches the actions the dispatch layer understands; a config override that
+// names anything else is rejected so a typo cannot silently disable a capability.
+func runtimeCapabilities() []string { return []string{"review", "implement", "ask"} }
+
+func validateRuntimeCapabilities(capabilities []string) error {
+	allowed := map[string]bool{}
+	for _, c := range runtimeCapabilities() {
+		allowed[c] = true
+	}
+	for _, c := range capabilities {
+		if !allowed[strings.TrimSpace(c)] {
+			valid := append([]string(nil), runtimeCapabilities()...)
+			sort.Strings(valid)
+			return fmt.Errorf("unsupported capability %q; use %s", strings.TrimSpace(c), strings.Join(valid, ", "))
+		}
+	}
+	return nil
+}

--- a/internal/runtime/registry_test.go
+++ b/internal/runtime/registry_test.go
@@ -1,0 +1,154 @@
+package runtime
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestBuiltinRegistryMatchesSupportedRuntimes proves the built-in metadata
+// registry's dispatchable entries are exactly the runtimes the Factory can
+// construct, in the same order — so the registry, SupportedRuntimes, and the
+// adapter Factory share one source of truth.
+func TestBuiltinRegistryMatchesSupportedRuntimes(t *testing.T) {
+	reg := BuiltinRuntimeRegistry()
+	got := reg.dispatchableNames()
+	want := []string{CodexRuntime, ClaudeRuntime, KimiRuntime, KimiCLIRuntime, ShellRuntime}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dispatchableNames() = %v, want %v", got, want)
+	}
+	if !reflect.DeepEqual(SupportedRuntimes(), want) {
+		t.Fatalf("SupportedRuntimes() = %v, want %v", SupportedRuntimes(), want)
+	}
+	for _, name := range got {
+		adapter, err := (Factory{}).Adapter(name)
+		if err != nil {
+			t.Fatalf("Factory.Adapter(%q) error: %v", name, err)
+		}
+		if adapter.Name() != name {
+			t.Fatalf("adapter for %q reports Name() = %q", name, adapter.Name())
+		}
+	}
+}
+
+// TestBuiltinRegistryCapabilitiesMatchAdapters proves the registry's declared
+// capabilities per runtime equal the adapter's own Capabilities() — the registry
+// is a faithful mirror of the hardcoded values it extracts, so seeding it changes
+// nothing.
+func TestBuiltinRegistryCapabilitiesMatchAdapters(t *testing.T) {
+	reg := BuiltinRuntimeRegistry()
+	for _, name := range reg.dispatchableNames() {
+		adapter, err := (Factory{}).Adapter(name)
+		if err != nil {
+			t.Fatalf("Factory.Adapter(%q) error: %v", name, err)
+		}
+		caps, err := adapter.Capabilities(nil)
+		if err != nil {
+			t.Fatalf("Capabilities(%q) error: %v", name, err)
+		}
+		meta, ok := reg.Metadata(name)
+		if !ok {
+			t.Fatalf("registry missing %q", name)
+		}
+		if !reflect.DeepEqual(meta.Capabilities, caps) {
+			t.Fatalf("%q registry caps %v != adapter caps %v", name, meta.Capabilities, caps)
+		}
+		if !meta.Dispatchable {
+			t.Fatalf("%q should be dispatchable", name)
+		}
+		if strings.TrimSpace(meta.DefaultModel) != "" {
+			t.Fatalf("%q built-in DefaultModel must be empty (CLI default), got %q", name, meta.DefaultModel)
+		}
+		if len(meta.Models) != 0 {
+			t.Fatalf("%q built-in Models must be empty (unrestricted), got %v", name, meta.Models)
+		}
+	}
+}
+
+// TestApplyOverridesNoOp proves an empty override set (the default path) returns a
+// registry equal to the built-in one — byte-identical default behavior.
+func TestApplyOverridesNoOp(t *testing.T) {
+	base := BuiltinRuntimeRegistry()
+	got, err := base.ApplyOverrides(nil)
+	if err != nil {
+		t.Fatalf("ApplyOverrides(nil) error: %v", err)
+	}
+	if !reflect.DeepEqual(got.All(), base.All()) {
+		t.Fatalf("no-op ApplyOverrides changed the registry")
+	}
+}
+
+// TestApplyOverridesPartial proves only the set fields are applied; unset fields
+// keep the built-in value.
+func TestApplyOverridesPartial(t *testing.T) {
+	base := BuiltinRuntimeRegistry()
+	got, err := base.ApplyOverrides([]MetadataOverride{{
+		Name:            CodexRuntime,
+		DefaultModel:    "gpt-5.5-codex",
+		DefaultModelSet: true,
+		Models:          []string{"gpt-5.5-codex", "gpt-5.4-codex"},
+		ModelsSet:       true,
+	}})
+	if err != nil {
+		t.Fatalf("ApplyOverrides error: %v", err)
+	}
+	codex, _ := got.Metadata(CodexRuntime)
+	if codex.DefaultModel != "gpt-5.5-codex" {
+		t.Fatalf("DefaultModel = %q", codex.DefaultModel)
+	}
+	if !reflect.DeepEqual(codex.Models, []string{"gpt-5.5-codex", "gpt-5.4-codex"}) {
+		t.Fatalf("Models = %v", codex.Models)
+	}
+	// Capabilities were NOT overridden — must keep the built-in value.
+	if !reflect.DeepEqual(codex.Capabilities, []string{"review", "implement", "ask"}) {
+		t.Fatalf("Capabilities changed unexpectedly: %v", codex.Capabilities)
+	}
+	// The built-in registry must be untouched (immutability).
+	baseCodex, _ := base.Metadata(CodexRuntime)
+	if baseCodex.DefaultModel != "" {
+		t.Fatalf("ApplyOverrides mutated the source registry: %q", baseCodex.DefaultModel)
+	}
+}
+
+// TestApplyOverridesUnknownRuntime proves config cannot add a new dispatchable
+// runtime: an override for an unknown name is a hard error that lists the built-ins.
+func TestApplyOverridesUnknownRuntime(t *testing.T) {
+	_, err := BuiltinRuntimeRegistry().ApplyOverrides([]MetadataOverride{{Name: "gpt6", DefaultModel: "x", DefaultModelSet: true}})
+	if err == nil {
+		t.Fatal("ApplyOverrides accepted an unknown runtime")
+	}
+	for _, name := range SupportedRuntimes() {
+		if !strings.Contains(err.Error(), name) {
+			t.Fatalf("error %q must enumerate built-in %q", err.Error(), name)
+		}
+	}
+}
+
+// TestApplyOverridesRejectsBadCapability proves a capability override outside the
+// closed set (review/implement/ask) is rejected — a typo cannot silently disable a
+// capability.
+func TestApplyOverridesRejectsBadCapability(t *testing.T) {
+	_, err := BuiltinRuntimeRegistry().ApplyOverrides([]MetadataOverride{{
+		Name:            ClaudeRuntime,
+		Capabilities:    []string{"review", "deploy"},
+		CapabilitiesSet: true,
+	}})
+	if err == nil {
+		t.Fatal("ApplyOverrides accepted an unknown capability")
+	}
+	if !strings.Contains(err.Error(), "deploy") {
+		t.Fatalf("error should name the bad capability: %v", err)
+	}
+}
+
+// TestMetadataAccessorsAreCopies proves callers cannot mutate the registry through
+// a returned metadata value's slices.
+func TestMetadataAccessorsAreCopies(t *testing.T) {
+	reg := BuiltinRuntimeRegistry()
+	meta, _ := reg.Metadata(CodexRuntime)
+	meta.Capabilities[0] = "hacked"
+	again, _ := reg.Metadata(CodexRuntime)
+	if again.Capabilities[0] != "review" {
+		t.Fatalf("Metadata returned a shared slice; registry mutated to %v", again.Capabilities)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -301,6 +301,13 @@ type Engine struct {
 	// path with no enrolled agent), the Mailbox is built with nil memory hooks and
 	// both prompt assembly and the terminal path are byte-identical.
 	Memory *MemoryController
+	// RuntimeDefaultModel, when set, resolves a runtime's configured registry
+	// default_model (HOME-AWARE) for the runtime named by the argument (#652). It is
+	// copied onto the Mailbox in mailbox() and consulted at delivery ONLY as the
+	// final model fallback — after the job --model and the agent --model — so an
+	// agent/job pin always wins. Nil (the default) forces nothing, so delivery is
+	// byte-identical to before #652.
+	RuntimeDefaultModel func(runtimeName string) string
 }
 
 // DelegationTimeoutDefaults are optional fallback timeouts for child delegation
@@ -417,7 +424,7 @@ func (e Engine) now() time.Time {
 // path is byte-identical. The hook maps the terminal JobState to the event_type,
 // resolves root_id from the payload, and ships a redacted event fire-and-forget.
 func (e Engine) mailbox() Mailbox {
-	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer}
+	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer, RuntimeDefaultModel: e.RuntimeDefaultModel}
 	// Wire the off-by-default memory hooks (#626). When e.Memory is nil (every
 	// non-enrolled path) both hooks stay nil, so Run's prompt assembly and terminal
 	// path are byte-identical. The hooks themselves also no-op when the executor

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -83,6 +83,16 @@ type Mailbox struct {
 	// Nil (default) => no-op, so the terminal path is byte-identical. Best-effort:
 	// it never fails the job.
 	recordMemory func(ctx context.Context, jobID string, agent runtime.Agent, action string, payload JobPayload, result AgentResult)
+	// RuntimeDefaultModel, when set, resolves a runtime's configured default model
+	// (the registry default_model, HOME-AWARE: built-in defaults overlaid with any
+	// [runtimes.<name>] config) for the runtime named by the argument (#652). It is
+	// consulted at delivery ONLY as the final model fallback — after the job --model
+	// (payload.Model) and the agent --model (agent.Model) — so an agent/job pin
+	// always wins. Wired from the CLI layer (which owns the home-aware resolver) via
+	// Engine.RuntimeDefaultModel or directly on a CLI-constructed Mailbox. Nil (the
+	// default, and any error/empty result) forces nothing, so delivery is
+	// byte-identical to before #652.
+	RuntimeDefaultModel func(runtimeName string) string
 }
 
 type JobRequest struct {
@@ -653,7 +663,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 }
 
 func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent runtime.Agent, job db.Job, payload JobPayload, prompt string) (string, string, bool, error) {
-	result, err := adapter.Deliver(ctx, agent, runtime.Job{
+	delivery := runtime.Job{
 		ID:          job.ID,
 		AgentName:   agent.Name,
 		Action:      job.Type,
@@ -661,7 +671,17 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		Repository:  payload.Repo,
 		PullRequest: payload.PullRequest,
 		Model:       payload.Model,
-	})
+	}
+	// #652: thread in the runtime's configured registry default_model as the FINAL
+	// model fallback. effectiveModel applies the precedence (job.Model > agent.Model
+	// > this default), so an agent/job --model always wins; a nil hook or empty
+	// default forces nothing and is byte-identical. Resolved for the agent's
+	// EFFECTIVE runtime, so a #531 per-job runtime override picks up the override
+	// runtime's default.
+	if m.RuntimeDefaultModel != nil {
+		delivery.RuntimeDefaultModel = m.RuntimeDefaultModel(agent.Runtime)
+	}
+	result, err := adapter.Deliver(ctx, agent, delivery)
 	// Record best-effort runtime token usage so the per-root delegation token
 	// budget (#338 Part B) can sum a tree's cost. Usage accounting must never fail
 	// a delivery, so every write error here is swallowed.

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -305,6 +305,60 @@ func TestMailboxRunDeliversModelOverride(t *testing.T) {
 	}
 }
 
+// TestMailboxRunThreadsRuntimeDefaultModel proves the #652 wiring: the Mailbox's
+// home-aware RuntimeDefaultModel hook is consulted at delivery and threaded onto the
+// delivered runtime.Job as the FINAL model fallback. With no agent --model and no
+// job --model, the job carries the runtime's configured default (RuntimeDefaultModel
+// set) while its explicit Model pin stays empty — so effectiveModel uses the default,
+// yet an agent/job pin (which would populate job.Model) still wins.
+func TestMailboxRunThreadsRuntimeDefaultModel(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store, RuntimeDefaultModel: func(rt string) string {
+		if rt == runtime.ShellRuntime {
+			return "gpt-5.5"
+		}
+		return ""
+	}}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{okDeliveryResult}}
+
+	// No agent Model, no job Model: the registry default_model must be threaded in.
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(adapter.models) != 1 || adapter.models[0] != "" {
+		t.Fatalf("delivered job.Model = %+v, want no explicit pin []", adapter.models)
+	}
+	if len(adapter.runtimeDefault) != 1 || adapter.runtimeDefault[0] != "gpt-5.5" {
+		t.Fatalf("delivered job.RuntimeDefaultModel = %+v, want [gpt-5.5]", adapter.runtimeDefault)
+	}
+}
+
+// TestMailboxRunNilRuntimeDefaultHookByteIdentical proves the byte-identical
+// default: with NO RuntimeDefaultModel hook (every pre-#652 construction site), the
+// delivered runtime.Job carries an empty RuntimeDefaultModel, so nothing is forced.
+func TestMailboxRunNilRuntimeDefaultHookByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{okDeliveryResult}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(adapter.runtimeDefault) != 1 || adapter.runtimeDefault[0] != "" {
+		t.Fatalf("delivered job.RuntimeDefaultModel = %+v, want empty (byte-identical)", adapter.runtimeDefault)
+	}
+}
+
 // okDeliveryResult is a minimal well-formed gitmoot_result so a fake delivery
 // classifies to a terminal state and the job persists its recorded usage.
 const okDeliveryResult = `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
@@ -1426,16 +1480,18 @@ type fakeDelivery struct {
 	inputTokens   []int
 	outputTokens  []int
 	cumulative    []bool
-	prompts       []string
-	models        []string
-	agentRefs     []string
-	onDeliver     func()
-	err           error
+	prompts        []string
+	models         []string
+	runtimeDefault []string
+	agentRefs      []string
+	onDeliver      func()
+	err            error
 }
 
 func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
 	f.prompts = append(f.prompts, job.Prompt)
 	f.models = append(f.models, job.Model)
+	f.runtimeDefault = append(f.runtimeDefault, job.RuntimeDefaultModel)
 	f.agentRefs = append(f.agentRefs, agent.RuntimeRef)
 	if f.onDeliver != nil {
 		f.onDeliver()

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -140,10 +140,13 @@ self-evaluation; see the `verifier` and `decompose-and-verify` recipes and the
 [RESULT_CONTRACT.md](references/RESULT_CONTRACT.md)). An agent (via `--model` on start/subscribe/type set) and an
 individual job or delegation (via `--model` on run/ask/review/implement or the
 delegation `model` field) can pin a runtime model, with the per-job/delegation
-value overriding the agent default. Use `gitmoot runtime list` to inspect each
-built-in runtime's resolved metadata (capabilities, default/known models, and
+value overriding the agent default. When neither pins one, a job falls back to the
+runtime's configured `[runtimes.<name>].default_model` (the one behavioral registry
+field), then the runtime CLI's own default. Use `gitmoot runtime list` to inspect
+each built-in runtime's resolved metadata (capabilities, default/known models, and
 where token usage is read from); operators can override a built-in runtime's
-metadata without recompiling via a `[runtimes.<name>]` config section (see CLI.md
+metadata without recompiling via a `[runtimes.<name>]` config section — `default_model`
+retargets delivery, `models`/`capabilities` stay advisory (see CLI.md
 § Runtime Metadata Registry). Use
 `gitmoot plugin doctor` when checking whether Codex, Claude Code, or Kimi Code
 can discover Gitmoot through an installed runtime plugin. Use

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, event webhooks, the web dashboard, per-job runtime overrides, and Codex, Claude Code, or Kimi Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
@@ -140,7 +140,11 @@ self-evaluation; see the `verifier` and `decompose-and-verify` recipes and the
 [RESULT_CONTRACT.md](references/RESULT_CONTRACT.md)). An agent (via `--model` on start/subscribe/type set) and an
 individual job or delegation (via `--model` on run/ask/review/implement or the
 delegation `model` field) can pin a runtime model, with the per-job/delegation
-value overriding the agent default. Use
+value overriding the agent default. Use `gitmoot runtime list` to inspect each
+built-in runtime's resolved metadata (capabilities, default/known models, and
+where token usage is read from); operators can override a built-in runtime's
+metadata without recompiling via a `[runtimes.<name>]` config section (see CLI.md
+§ Runtime Metadata Registry). Use
 `gitmoot plugin doctor` when checking whether Codex, Claude Code, or Kimi Code
 can discover Gitmoot through an installed runtime plugin. Use
 `gitmoot plugin codex-launch --repo <path>` to print a Codex launch command that

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -86,8 +86,8 @@ gitmoot runtime list --json
 
 The values come from the compiled built-in defaults, overlaid with any
 `[runtimes.<name>]` overrides in the config file. Override a built-in runtime's
-metadata **without recompiling** — for example to point it at a new model id or
-record its known models:
+recorded **metadata without recompiling** — for example to record its known models
+or note its declared default model:
 
 ```toml
 [runtimes.codex]
@@ -97,10 +97,14 @@ capabilities = ["review", "implement", "ask"]
 usage_source = "codex exec --json turn.completed usage"
 ```
 
-This is **metadata only** — adapter behavior (auth, sandbox policy, session
-resume, stream parsing) stays in Go. In particular `models` is **advisory**:
-Gitmoot never rejects a `--model` based on it, so populating it cannot change how a
-job runs. With no `[runtimes.*]` section behavior is byte-identical.
+This is **inspection-only metadata** — adapter behavior (auth, sandbox policy,
+session resume, stream parsing, **and which model a job actually runs on**) stays in
+Go and is never consulted at delivery. Every field is surfaced by `gitmoot runtime
+list` but changes nothing at runtime: `default_model` does **not** retarget the
+model a job uses (a job's model still comes from the agent/job `--model` or the
+runtime CLI's own config), `models` is **advisory** (Gitmoot never rejects a
+`--model` based on it), and `capabilities` gates nothing at dispatch. With no
+`[runtimes.*]` section behavior is byte-identical.
 
 A `[runtimes.<name>]` section can only tweak a **built-in** runtime's metadata; it
 cannot add a new first-class runtime (that requires a code change). An unknown

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -86,8 +86,8 @@ gitmoot runtime list --json
 
 The values come from the compiled built-in defaults, overlaid with any
 `[runtimes.<name>]` overrides in the config file. Override a built-in runtime's
-recorded **metadata without recompiling** — for example to record its known models
-or note its declared default model:
+recorded metadata **without recompiling** — for example to retarget its default
+model or record its known models:
 
 ```toml
 [runtimes.codex]
@@ -97,14 +97,16 @@ capabilities = ["review", "implement", "ask"]
 usage_source = "codex exec --json turn.completed usage"
 ```
 
-This is **inspection-only metadata** — adapter behavior (auth, sandbox policy,
-session resume, stream parsing, **and which model a job actually runs on**) stays in
-Go and is never consulted at delivery. Every field is surfaced by `gitmoot runtime
-list` but changes nothing at runtime: `default_model` does **not** retarget the
-model a job uses (a job's model still comes from the agent/job `--model` or the
-runtime CLI's own config), `models` is **advisory** (Gitmoot never rejects a
-`--model` based on it), and `capabilities` gates nothing at dispatch. With no
-`[runtimes.*]` section behavior is byte-identical.
+Exactly one field is **behavioral**: `default_model` is consulted at job **delivery**
+as the model fallback when **neither the agent nor the job pins a `--model`** — so
+setting it **does** retarget the model those jobs run on. The resolution order is:
+the agent/job `--model` win, then this `default_model`, then the runtime CLI's own
+default. Every other field is **inspection-only**, surfaced by `gitmoot runtime list`
+but changing nothing at runtime: `models` is **advisory** (Gitmoot never rejects a
+`--model` based on it), and `capabilities` gates nothing at dispatch. Adapter
+behavior (auth, sandbox policy, session resume, stream parsing) always stays in Go.
+With no `[runtimes.*]` section — and with `default_model` unset — behavior is
+byte-identical: no model is forced.
 
 A `[runtimes.<name>]` section can only tweak a **built-in** runtime's metadata; it
 cannot add a new first-class runtime (that requires a code change). An unknown

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -71,6 +71,41 @@ Gitmoot home on Linux, macOS, or Windows. It prints a `codex-face --cd ...
 --add-dir ... -s workspace-write` launch command, or a persistent config
 snippet with `--config-snippet`.
 
+## Runtime Metadata Registry
+
+Gitmoot drives four built-in runtimes (`codex`, `claude`, `kimi`, plus the
+subscribe-only `shell`; the legacy `kimi-cli` is also compiled in). Each carries
+declarative metadata — advertised capabilities, a default model, an advisory list
+of known-valid models, and a descriptor of where token usage is read from. Inspect
+the resolved registry:
+
+```sh
+gitmoot runtime list
+gitmoot runtime list --json
+```
+
+The values come from the compiled built-in defaults, overlaid with any
+`[runtimes.<name>]` overrides in the config file. Override a built-in runtime's
+metadata **without recompiling** — for example to point it at a new model id or
+record its known models:
+
+```toml
+[runtimes.codex]
+default_model = "gpt-5.5-codex"
+models = ["gpt-5.5-codex", "gpt-5.4-codex"]
+capabilities = ["review", "implement", "ask"]
+usage_source = "codex exec --json turn.completed usage"
+```
+
+This is **metadata only** — adapter behavior (auth, sandbox policy, session
+resume, stream parsing) stays in Go. In particular `models` is **advisory**:
+Gitmoot never rejects a `--model` based on it, so populating it cannot change how a
+job runs. With no `[runtimes.*]` section behavior is byte-identical.
+
+A `[runtimes.<name>]` section can only tweak a **built-in** runtime's metadata; it
+cannot add a new first-class runtime (that requires a code change). An unknown
+runtime name is a config error surfaced by `gitmoot runtime list`.
+
 ## Repo And Daemon Status
 
 ```sh

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -94,8 +94,8 @@ gitmoot runtime list --json
 
 The values come from the compiled built-in defaults, overlaid with any
 `[runtimes.<name>]` overrides in `config.toml`. Override a built-in runtime's
-metadata **without recompiling** — for example to point it at a new model id or
-record its known models:
+recorded **metadata without recompiling** — for example to record its known models
+or note its declared default model:
 
 ```toml
 [runtimes.codex]
@@ -105,10 +105,14 @@ capabilities = ["review", "implement", "ask"]
 usage_source = "codex exec --json turn.completed usage"
 ```
 
-This is **metadata only** — adapter behavior (auth, sandbox policy, session
-resume, stream parsing) stays in Go. `models` is **advisory**: Gitmoot never
-rejects a `--model` based on it, so populating it cannot change how a job runs.
-With no `[runtimes.*]` section behavior is byte-identical.
+This is **inspection-only metadata** — adapter behavior (auth, sandbox policy,
+session resume, stream parsing, **and which model a job actually runs on**) stays in
+Go and is never consulted at delivery. Every field is surfaced by `gitmoot runtime
+list` but changes nothing at runtime: `default_model` does **not** retarget the
+model a job uses (a job's model still comes from the agent/job `--model` or the
+runtime CLI's own config), `models` is **advisory** (Gitmoot never rejects a
+`--model` based on it), and `capabilities` gates nothing at dispatch. With no
+`[runtimes.*]` section behavior is byte-identical.
 
 A `[runtimes.<name>]` section can only tweak a **built-in** runtime's metadata; it
 cannot add a new first-class runtime (that requires a code change). An unknown

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -94,8 +94,8 @@ gitmoot runtime list --json
 
 The values come from the compiled built-in defaults, overlaid with any
 `[runtimes.<name>]` overrides in `config.toml`. Override a built-in runtime's
-recorded **metadata without recompiling** — for example to record its known models
-or note its declared default model:
+recorded metadata **without recompiling** — for example to retarget its default
+model or record its known models:
 
 ```toml
 [runtimes.codex]
@@ -105,14 +105,16 @@ capabilities = ["review", "implement", "ask"]
 usage_source = "codex exec --json turn.completed usage"
 ```
 
-This is **inspection-only metadata** — adapter behavior (auth, sandbox policy,
-session resume, stream parsing, **and which model a job actually runs on**) stays in
-Go and is never consulted at delivery. Every field is surfaced by `gitmoot runtime
-list` but changes nothing at runtime: `default_model` does **not** retarget the
-model a job uses (a job's model still comes from the agent/job `--model` or the
-runtime CLI's own config), `models` is **advisory** (Gitmoot never rejects a
-`--model` based on it), and `capabilities` gates nothing at dispatch. With no
-`[runtimes.*]` section behavior is byte-identical.
+Exactly one field is **behavioral**: `default_model` is consulted at job **delivery**
+as the model fallback when **neither the agent nor the job pins a `--model`** — so
+setting it **does** retarget the model those jobs run on. The resolution order is:
+the agent/job `--model` win, then this `default_model`, then the runtime CLI's own
+default. Every other field is **inspection-only**, surfaced by `gitmoot runtime list`
+but changing nothing at runtime: `models` is **advisory** (Gitmoot never rejects a
+`--model` based on it), and `capabilities` gates nothing at dispatch. Adapter
+behavior (auth, sandbox policy, session resume, stream parsing) always stays in Go.
+With no `[runtimes.*]` section — and with `default_model` unset — behavior is
+byte-identical: no model is forced.
 
 A `[runtimes.<name>]` section can only tweak a **built-in** runtime's metadata; it
 cannot add a new first-class runtime (that requires a code change). An unknown

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -79,6 +79,41 @@ Gitmoot home on Linux, macOS, or Windows. It prints a `codex-face --cd ...
 --add-dir ... -s workspace-write` launch command, or a persistent config
 snippet with `--config-snippet`.
 
+## Runtime Metadata Registry
+
+Gitmoot drives four built-in runtimes (`codex`, `claude`, `kimi`, plus the
+subscribe-only `shell`; the legacy `kimi-cli` is also compiled in). Each carries
+declarative metadata — advertised capabilities, a default model, an advisory list
+of known-valid models, and a descriptor of where token usage is read from. Inspect
+the resolved registry:
+
+```sh
+gitmoot runtime list
+gitmoot runtime list --json
+```
+
+The values come from the compiled built-in defaults, overlaid with any
+`[runtimes.<name>]` overrides in `config.toml`. Override a built-in runtime's
+metadata **without recompiling** — for example to point it at a new model id or
+record its known models:
+
+```toml
+[runtimes.codex]
+default_model = "gpt-5.5-codex"
+models = ["gpt-5.5-codex", "gpt-5.4-codex"]
+capabilities = ["review", "implement", "ask"]
+usage_source = "codex exec --json turn.completed usage"
+```
+
+This is **metadata only** — adapter behavior (auth, sandbox policy, session
+resume, stream parsing) stays in Go. `models` is **advisory**: Gitmoot never
+rejects a `--model` based on it, so populating it cannot change how a job runs.
+With no `[runtimes.*]` section behavior is byte-identical.
+
+A `[runtimes.<name>]` section can only tweak a **built-in** runtime's metadata; it
+cannot add a new first-class runtime (that requires a code change). An unknown
+runtime name is a config error surfaced by `gitmoot runtime list`.
+
 ## Repo And Daemon Status
 
 ```sh

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -28,13 +28,14 @@ agent template and rendered job prompt before handing work to an adapter.
 ## Metadata Registry
 
 Each built-in runtime carries declarative metadata — advertised capabilities, a
-default model, an advisory list of known-valid models, and a descriptor of where
-token usage is read from — seeded from compiled defaults that reproduce Gitmoot's
-historical behavior. Inspect the resolved registry with `gitmoot runtime list`
-(add `--json` for machine output).
+declared default model, an advisory list of known-valid models, and a descriptor of
+where token usage is read from — seeded from compiled defaults that reproduce
+Gitmoot's historical behavior. This metadata is **inspection-only**: it is surfaced
+by `gitmoot runtime list` (add `--json` for machine output) and is never consulted
+at job delivery.
 
-Operators can override a built-in runtime's metadata **without recompiling** via a
-`[runtimes.<name>]` section in `config.toml`:
+Operators can override a built-in runtime's recorded metadata **without
+recompiling** via a `[runtimes.<name>]` section in `config.toml`:
 
 ```toml
 [runtimes.codex]
@@ -43,11 +44,15 @@ models = ["gpt-5.5-codex", "gpt-5.4-codex"]
 capabilities = ["review", "implement", "ask"]
 ```
 
-This is metadata only — adapter *behavior* (auth, sandbox, session resume, stream
-parsing) stays in Go. `models` is advisory (Gitmoot never rejects a `--model`
-based on it), and with no `[runtimes.*]` section behavior is byte-identical. The
-section can only tweak a **built-in** runtime; adding a new first-class runtime is
-a code change, and an unknown runtime name is a config error.
+This is inspection-only metadata — adapter *behavior* (auth, sandbox, session
+resume, stream parsing, **and which model a job actually runs on**) stays in Go and
+is never consulted at delivery. Setting `default_model` does **not** retarget the
+model a job uses (a job's model still comes from the agent/job `--model` or the
+runtime CLI's own config); `models` is advisory (Gitmoot never rejects a `--model`
+based on it); and `capabilities` gates nothing at dispatch. With no `[runtimes.*]`
+section behavior is byte-identical. The section can only tweak a **built-in**
+runtime; adding a new first-class runtime is a code change, and an unknown runtime
+name is a config error.
 
 ## Agent Session Values
 

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -28,11 +28,12 @@ agent template and rendered job prompt before handing work to an adapter.
 ## Metadata Registry
 
 Each built-in runtime carries declarative metadata — advertised capabilities, a
-declared default model, an advisory list of known-valid models, and a descriptor of
-where token usage is read from — seeded from compiled defaults that reproduce
-Gitmoot's historical behavior. This metadata is **inspection-only**: it is surfaced
-by `gitmoot runtime list` (add `--json` for machine output) and is never consulted
-at job delivery.
+default model, an advisory list of known-valid models, and a descriptor of where
+token usage is read from — seeded from compiled defaults that reproduce Gitmoot's
+historical behavior. All of it is surfaced by `gitmoot runtime list` (add `--json`
+for machine output). Exactly one field is **behavioral**: `default_model` is
+consulted at job delivery as the model fallback when neither the agent nor the job
+pins a `--model`. Every other field is inspection-only.
 
 Operators can override a built-in runtime's recorded metadata **without
 recompiling** via a `[runtimes.<name>]` section in `config.toml`:
@@ -44,15 +45,16 @@ models = ["gpt-5.5-codex", "gpt-5.4-codex"]
 capabilities = ["review", "implement", "ask"]
 ```
 
-This is inspection-only metadata — adapter *behavior* (auth, sandbox, session
-resume, stream parsing, **and which model a job actually runs on**) stays in Go and
-is never consulted at delivery. Setting `default_model` does **not** retarget the
-model a job uses (a job's model still comes from the agent/job `--model` or the
-runtime CLI's own config); `models` is advisory (Gitmoot never rejects a `--model`
-based on it); and `capabilities` gates nothing at dispatch. With no `[runtimes.*]`
-section behavior is byte-identical. The section can only tweak a **built-in**
-runtime; adding a new first-class runtime is a code change, and an unknown runtime
-name is a config error.
+Setting `default_model` **does** retarget the model a job runs on **when that job
+pins no model itself** — the resolution order is: the agent/job `--model` win, then
+this `default_model`, then the runtime CLI's own default. So an agent/job `--model`
+always wins, and with `default_model` unset (the built-in default) no model is
+forced. Every other field is inspection-only: `models` is advisory (Gitmoot never
+rejects a `--model` based on it); `capabilities` gates nothing at dispatch; and
+adapter *behavior* (auth, sandbox, session resume, stream parsing) always stays in
+Go. With no `[runtimes.*]` section behavior is byte-identical. The section can only
+tweak a **built-in** runtime; adding a new first-class runtime is a code change, and
+an unknown runtime name is a config error.
 
 ## Agent Session Values
 

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -25,6 +25,30 @@ agent template and rendered job prompt before handing work to an adapter.
 - **Shell** invokes a configured shell command and is mainly for smoke tests,
   demos, and adapter contract checks.
 
+## Metadata Registry
+
+Each built-in runtime carries declarative metadata — advertised capabilities, a
+default model, an advisory list of known-valid models, and a descriptor of where
+token usage is read from — seeded from compiled defaults that reproduce Gitmoot's
+historical behavior. Inspect the resolved registry with `gitmoot runtime list`
+(add `--json` for machine output).
+
+Operators can override a built-in runtime's metadata **without recompiling** via a
+`[runtimes.<name>]` section in `config.toml`:
+
+```toml
+[runtimes.codex]
+default_model = "gpt-5.5-codex"
+models = ["gpt-5.5-codex", "gpt-5.4-codex"]
+capabilities = ["review", "implement", "ask"]
+```
+
+This is metadata only — adapter *behavior* (auth, sandbox, session resume, stream
+parsing) stays in Go. `models` is advisory (Gitmoot never rejects a `--model`
+based on it), and with no `[runtimes.*]` section behavior is byte-identical. The
+section can only tweak a **built-in** runtime; adding a new first-class runtime is
+a code change, and an unknown runtime name is a config error.
+
 ## Agent Session Values
 
 `RuntimeRef` is runtime-specific:

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -40,7 +40,7 @@ full expanded context.
 ## References
 
 - [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, jobs, bug reports, locks, goals, interactive prompts, and SkillOpt.
-- [Runtime Adapters](https://gitmoot.io/docs/reference/runtime-adapters): Codex, Claude Code, Kimi Code, legacy kimi-cli, shell, and future runtimes.
+- [Runtime Adapters](https://gitmoot.io/docs/reference/runtime-adapters): Codex, Claude Code, Kimi Code, legacy kimi-cli, shell, and future runtimes; the config-driven metadata registry (`gitmoot runtime list`, `[runtimes.<name>]` overrides).
 - [Result Contract](https://gitmoot.io/docs/reference/result-contract): gitmoot_result shape, the delegations DAG (Orchestration), continuation, and termination bounds.
 - [Event Stream](https://gitmoot.io/docs/reference/event-stream): The `[events]` webhook contract — job.finished/failed/blocked/needs_attention/deferred and candidate.* events, schema_version 1, best-effort delivery.
 - [Codex And Claude Plugins](https://gitmoot.io/docs/plugins/codex-claude): Plugin discovery and runtime skill setup.


### PR DESCRIPTION
## Summary

Implements the tempered scope of #652 in two parts:

1. Pull the *declarative* per-runtime metadata out of the hardcoded adapter
   surface into a **config-driven metadata registry** (`[runtimes.<name>]`),
   keeping every adapter's *behavior* in Go. **Not** a plugin loader — the four
   adapters (codex/claude/kimi + shell, plus legacy kimi-cli) stay compiled in.
2. Make the registry's **`default_model` behavioral at job delivery** — the first
   registry field that changes runtime behavior, not just `runtime list` output.

## Design

- **`internal/runtime/registry.go`** — `RuntimeMetadata` (capabilities, default
  model, advisory known-model list, usage-source descriptor) + an immutable
  `Registry`. `BuiltinRuntimeRegistry()` seeds today's hardcoded values, so a fresh
  box is byte-identical. `SupportedRuntimes()` derives from the registry's
  dispatchable entries (one source of truth with `Factory.Adapter`).
- **`internal/config/runtime_registry.go`** — parses optional `[runtimes.<name>]`
  sections into neutral `RuntimeOverride` data (each key carries a `*Set` flag, so
  an override touches exactly the keys written; an absent section is a no-op).
- **`internal/cli/runtime_registry.go`** — resolves built-in defaults overlaid
  with config overrides and adds **`gitmoot runtime list [--json]`**.

## `default_model` is now behavioral (this update)

At **job delivery**, when NEITHER the agent NOR the job pins a `--model`, a job
falls back to the runtime's configured `default_model` from the **home-aware**
resolved registry (built-in defaults overlaid with `[runtimes.<name>]` config) as
the model passed to the runtime.

**Resolution order (exact):** job `--model` > agent `--model` > runtime
`default_model` (registry) > the runtime CLI's own default. An agent/job pin
**always wins**. (The relative job-over-agent precedence is preserved exactly as
before — a per-job/per-delegation `--model` is the most specific pin — so delivery
stays byte-identical when both are set.)

Wiring:

- `internal/runtime`: `runtime.Job.RuntimeDefaultModel` is threaded into
  `effectiveModel` as the final fallback (`job.Model > agent.Model >
  RuntimeDefaultModel`).
- `internal/workflow`: `Mailbox.RuntimeDefaultModel` / `Engine.RuntimeDefaultModel`
  hooks resolve it for the agent's **effective** runtime, so a #531 per-job runtime
  override picks up the override runtime's default. A nil hook is byte-identical.
- `internal/cli`: a home-aware `runtimeDefaultModelResolver` is wired into every
  delivery seam (daemon engine, foreground `run`/`ask`, live-A/B); it is fail-open
  (a missing config / empty home / unknown runtime resolves `""`).

**Only `default_model` is behavioral.** `models` stays advisory (Gitmoot never
rejects a `--model`) and `capabilities` gates nothing at dispatch.

## Guardrails / moat

- **Additive + byte-identical default**: with no `[runtimes.*]` section and no
  `default_model` set (the built-in default for every runtime is empty), delivery
  forces no model — exactly as before #652.
- Config can only **tweak a built-in runtime's** metadata. An unknown runtime name
  is a hard error pointing at the built-in set — a new first-class runtime is still
  a code change. This preserves the single-static-binary / small-adapter moat.

## Docs (docs-with-code)

- `internal/config/init.go` DefaultConfig comment and
  `internal/runtime/registry.go` `DefaultModel` field comment: reversed the
  inspection-only / "never consulted at delivery" wording **for `default_model`**;
  kept the advisory wording for `models`/`capabilities`.
- `skills/gitmoot/SKILL.md`, `skills/gitmoot/references/CLI.md`,
  `website/docs/reference/cli.md`, `website/docs/reference/runtime-adapters.md`.

## Tests

- runtime: adapter `Deliver` observes `default_model` as the `--model` when nothing
  pins one; an agent `--model` and a job `--model` each still win; an empty default
  is byte-identical; `effectiveModel` precedence table.
- workflow: the Mailbox hook threads `default_model` onto the delivered `Job`; a nil
  hook is byte-identical.
- cli: `runtimeDefaultModelResolver` reads `[runtimes.<rt>].default_model`;
  absent-config / empty-home / unknown-runtime all fail open to `""`.
- registry/config: built-in↔Factory coupling, override no-op byte-identical,
  partial override, unknown-runtime + bad-capability rejection.

## Gate

`export GOTOOLCHAIN=local PATH=… && go build -buildvcs=false ./... && go generate
./... && git diff --exit-code && go vet ./... && go test -buildvcs=false -race
-timeout 20m ./internal/runtime/ ./internal/config/ ./internal/cli/
./internal/workflow/ ./internal/daemon/ ./internal/db/` — all green.

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)
