### PR TITLE
feat(heartbeat): policy-gated implement action + per-heartbeat runtime override

### DIFF
--- a/docs/heartbeats.md
+++ b/docs/heartbeats.md
@@ -33,12 +33,32 @@ max_concurrent = 1
 | `repo`           | yes      | —       | `owner/name` the job runs against. Must be a registered, enabled daemon repo with a checkout (see note below). |
 | `interval`       | yes      | —       | Go duration (e.g. `24h`, `1h30m`). Validated at load.        |
 | `jitter`         | no       | `0s`    | Random `[0, jitter]` added to each `next_due` to de-thunder. |
-| `action`         | no       | `ask`   | `ask` (read-only analysis) or `review` (read-only PR/code review). A `review` heartbeat requires the agent to hold the `review` capability. `implement` is deliberately not supported. |
+| `action`         | no       | `ask`   | `ask` (read-only analysis), `review` (read-only PR/code review), or `implement` (write). A `review` heartbeat requires the agent to hold the `review` capability. `implement` is **policy-gated** — see below. |
+| `runtime`        | no       | —       | Optional per-heartbeat runtime override (`codex`/`claude`/`kimi`). When set, the scheduled job runs on that runtime instead of the agent's registered default, on a fresh session (reuses the per-job override from #531). Empty ⇒ agent default. |
 | `prompt`         | yes      | —       | Instructions passed to the agent.                            |
 | `max_concurrent` | no       | `1`     | Overlap cap; a new run is skipped while this many are active.|
 
-Invalid intervals/jitter or an unsupported action produce a clear validation
-error at config load.
+Invalid intervals/jitter, an unsupported action, or an unsupported runtime
+override produce a clear validation error at config load.
+
+### Policy-gated `implement` action
+
+An `implement` heartbeat enqueues a **write** job (it can change code and open
+PRs), so it is deliberately gated and off by default. It only runs when the
+target agent both:
+
+- holds the `implement` capability, **and**
+- carries a write-granting autonomy policy — `--policy workspace-write` or
+  `--policy danger-full-access`.
+
+This mirrors `agent start` / `agent implement` exactly: under the default `auto`
+policy (or `read-only`) a headless implement job would run and produce no files,
+so gitmoot **fails closed**. The gate is enforced twice: `agent heartbeat add`
+refuses to write an `implement` heartbeat for an agent without a write policy or
+the implement capability, and the daemon scan skips a due `implement` heartbeat
+(advancing `next_due` with `last_status = policy_readonly`) if the agent no longer
+qualifies — it self-recovers once a write policy is granted. Implement heartbeats
+respect branch locks and the merge gate like any other implement job.
 
 ## CLI
 
@@ -55,6 +75,13 @@ gitmoot agent heartbeat add reviewer stale-prs \
   --repo jerryfane/gitmoot --interval 12h --action review \
   --prompt "Review stale open PRs and summarize blockers."
 
+# An implement heartbeat requires the agent to hold the implement capability AND
+# a write-granting policy (workspace-write / danger-full-access). Add --runtime to
+# pin a specific runtime for this schedule.
+gitmoot agent heartbeat add builder nightly-tidy \
+  --repo jerryfane/gitmoot --interval 24h --action implement --runtime codex \
+  --prompt "Fix the top lint/type error and open a small PR."
+
 gitmoot agent heartbeat list [--agent repo-maintainer]
 gitmoot agent heartbeat show repo-maintainer daily-status
 gitmoot agent heartbeat enable repo-maintainer daily-status
@@ -62,17 +89,20 @@ gitmoot agent heartbeat disable repo-maintainer daily-status
 gitmoot agent heartbeat remove repo-maintainer daily-status
 ```
 
-`add` validates the action, repo, interval, jitter, and prompt before writing, and
-(for `action = review`) refuses to write a heartbeat for an agent lacking the
-review capability. `enable`/`disable` flip just the `enabled` flag in place,
-preserving the rest of the block and its comments.
+`add` validates the action, runtime, repo, interval, jitter, and prompt before
+writing; refuses (for `action = review`) a heartbeat for an agent lacking the
+review capability; and refuses (for `action = implement`) a heartbeat for an agent
+lacking the implement capability or a write-granting policy. `enable`/`disable`
+flip just the `enabled` flag in place, preserving the rest of the block and its
+comments.
 
 ## Observability
 
 `gitmoot daemon status` surfaces every configured heartbeat with its enabled
-state, action, interval, repo, and — once it has fired — its `last_run`,
-`next_due`, and `last_status` (from the local `heartbeat_state`). With no
-heartbeats configured the section is omitted entirely (status is unchanged).
+state, action, interval, repo, its `runtime` override (only when one is set), and
+— once it has fired — its `last_run`, `next_due`, and `last_status` (from the
+local `heartbeat_state`). With no heartbeats configured the section is omitted
+entirely (status is unchanged).
 
 ## Behavior
 
@@ -98,14 +128,23 @@ heartbeats configured the section is omitted entirely (status is unchanged).
 
 ## Safety notes
 
-- Both supported actions are **read-only**: `ask` (the conservative default) and
-  `review`. Heartbeats do **not** auto-implement code — recurring unattended
-  code-change PRs are intentionally out of scope.
+- The default action `ask` and `review` are **read-only**. `implement` is a
+  **write** action and is off by default; it is policy-gated (see above) so a
+  recurring unattended code-change PR can only run for an agent an operator has
+  deliberately given a write-granting policy.
 - A `review` heartbeat only enqueues for an agent that holds the `review`
   capability; the check runs both when the heartbeat is written (CLI) and when it
   is due (daemon scan). A review heartbeat for an agent without the capability is
   skipped with `last_status = capability_missing` and self-recovers if the
   capability is later granted.
+- An `implement` heartbeat only enqueues for an agent that holds the `implement`
+  capability AND a write-granting policy; the same two-place check (CLI write +
+  daemon scan) applies. A due implement heartbeat that no longer qualifies is
+  skipped with `last_status = policy_readonly` and self-recovers once a write
+  policy is granted.
+- A per-heartbeat `runtime` override runs the scheduled job on a **fresh** session
+  of the named runtime; it never resumes or writes the agent's default-runtime
+  session, so it cannot collide with the agent's own runtime lock.
 - `repo` must be a repo the daemon **manages** (registered, enabled, with a
   checkout). This keeps heartbeats from enqueuing jobs no worker would run.
 - Heartbeats respect existing agent/runtime capacity limits (`max_background`),
@@ -116,6 +155,4 @@ heartbeats configured the section is omitted entirely (status is unchanged).
 
 ## Not yet supported (deferred)
 
-- `action = "implement"` heartbeats (recurring unattended code-change PRs).
 - Agent-**type** scoping (only named agents today).
-- Per-job runtime override (see #531).

--- a/internal/cli/agent_heartbeat.go
+++ b/internal/cli/agent_heartbeat.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
 // runAgentHeartbeat is the write-side (and read-side) CLI for heartbeat schedules
@@ -45,7 +46,7 @@ func runAgentHeartbeat(args []string, stdout, stderr io.Writer) int {
 
 func printAgentHeartbeatUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot agent heartbeat add <agent> <name> --repo owner/repo --interval 24h --prompt \"...\" [--action ask|review] [--jitter 15m] [--max-concurrent 1] [--enabled]")
+	fmt.Fprintln(w, "  gitmoot agent heartbeat add <agent> <name> --repo owner/repo --interval 24h --prompt \"...\" [--action ask|review|implement] [--runtime codex|claude|kimi] [--jitter 15m] [--max-concurrent 1] [--enabled]")
 	fmt.Fprintln(w, "  gitmoot agent heartbeat list [--agent <agent>]")
 	fmt.Fprintln(w, "  gitmoot agent heartbeat show <agent> <name>")
 	fmt.Fprintln(w, "  gitmoot agent heartbeat enable <agent> <name>")
@@ -60,7 +61,8 @@ func runAgentHeartbeatAdd(args []string, stdout, stderr io.Writer) int {
 	repo := fs.String("repo", "", "managed repo as owner/repo (required)")
 	interval := fs.String("interval", "", "schedule interval, e.g. 24h (required)")
 	prompt := fs.String("prompt", "", "instructions the heartbeat sends the agent (required)")
-	action := fs.String("action", "ask", "heartbeat action: ask or review")
+	action := fs.String("action", "ask", "heartbeat action: ask, review, or implement (implement is policy-gated)")
+	runtimeOverride := fs.String("runtime", "", "run this heartbeat on a specific runtime (codex|claude|kimi) instead of the agent default")
 	jitter := fs.String("jitter", "", "random delay added to each interval, e.g. 15m (default 0s)")
 	maxConcurrent := fs.Int("max-concurrent", 1, "maximum concurrent jobs for this heartbeat")
 	enabled := fs.Bool("enabled", false, "enable the heartbeat immediately (default disabled)")
@@ -96,6 +98,10 @@ func runAgentHeartbeatAdd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "invalid action %q; use one of: %s\n", *action, strings.Join(config.HeartbeatActions(), ", "))
 		return 2
 	}
+	if !config.HeartbeatRuntimeSupported(*runtimeOverride) {
+		fmt.Fprintf(stderr, "invalid runtime %q; use one of: %s\n", strings.TrimSpace(*runtimeOverride), strings.Join(config.HeartbeatRuntimes(), ", "))
+		return 2
+	}
 	entry := config.Heartbeat{
 		Agent:         agent,
 		Name:          name,
@@ -106,6 +112,7 @@ func runAgentHeartbeatAdd(args []string, stdout, stderr io.Writer) int {
 		Action:        strings.TrimSpace(*action),
 		Prompt:        strings.TrimSpace(*prompt),
 		MaxConcurrent: *maxConcurrent,
+		Runtime:       strings.TrimSpace(*runtimeOverride),
 	}
 	paths, err := initializedPaths(*home)
 	if err != nil {
@@ -117,6 +124,17 @@ func runAgentHeartbeatAdd(args []string, stdout, stderr io.Writer) int {
 	// write time, not silently skipped by the daemon scan.
 	if entry.Action == "review" {
 		if exit := requireHeartbeatReviewCapability(*home, agent, stderr); exit != 0 {
+			return exit
+		}
+	}
+	// An implement heartbeat enqueues a WRITE job. Refuse to write one unless the
+	// target agent both holds the implement capability AND carries a write-granting
+	// autonomy policy (workspace-write / danger-full-access). This mirrors the
+	// agent-start gate exactly: under auto/read-only an implement job runs and
+	// produces no files, so it is fail-closed at config-write time rather than
+	// silently no-op'd by the daemon scan (#611).
+	if entry.Action == "implement" {
+		if exit := requireHeartbeatImplementPermission(*home, agent, stderr); exit != 0 {
 			return exit
 		}
 	}
@@ -145,6 +163,38 @@ func requireHeartbeatReviewCapability(home, agent string, stderr io.Writer) int 
 	}
 	if !agentHasCapability(record.Capabilities, "review") {
 		fmt.Fprintf(stderr, "agent heartbeat add: agent %q lacks the review capability required for a review heartbeat\n", agent)
+		return 2
+	}
+	return 0
+}
+
+// requireHeartbeatImplementPermission returns a non-zero exit code (and prints to
+// stderr) when the named agent cannot safely run an implement heartbeat: it must
+// exist, hold the "implement" capability, AND carry a write-granting autonomy
+// policy (workspace-write / danger-full-access). Under auto/read-only an
+// implement job would run and produce nothing, so this is the fail-closed gate
+// that refuses the misconfiguration at write time (#611). It reuses the exact
+// runtime predicate (PolicyGrantsImplementWrite) that agent start / implement
+// dispatch use, so the heartbeat gate can never drift from the direct-job gate.
+func requireHeartbeatImplementPermission(home, agent string, stderr io.Writer) int {
+	var record db.Agent
+	if err := withStore(home, func(store *db.Store) error {
+		got, err := store.GetAgent(context.Background(), agent)
+		if err != nil {
+			return err
+		}
+		record = got
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "agent heartbeat add: agent %q must exist, hold the implement capability, and carry a write-granting policy for an implement heartbeat: %v\n", agent, err)
+		return 1
+	}
+	if !agentHasCapability(record.Capabilities, "implement") {
+		fmt.Fprintf(stderr, "agent heartbeat add: agent %q lacks the implement capability required for an implement heartbeat\n", agent)
+		return 2
+	}
+	if !runtime.PolicyGrantsImplementWrite(record.AutonomyPolicy) {
+		fmt.Fprintf(stderr, "agent heartbeat add: agent %q autonomy policy %q grants no headless write permission; an implement heartbeat needs --policy workspace-write or danger-full-access on the agent\n", agent, runtime.NormalizeStoredAutonomyPolicy(record.AutonomyPolicy))
 		return 2
 	}
 	return 0
@@ -355,6 +405,7 @@ func printHeartbeat(stdout io.Writer, entry config.Heartbeat) {
 	writeLine(stdout, "interval: %s", entry.Interval)
 	writeLine(stdout, "jitter: %s", entry.Jitter)
 	writeLine(stdout, "action: %s", entry.Action)
+	writeLine(stdout, "runtime: %s", firstNonEmpty(entry.Runtime, "(agent default)"))
 	writeLine(stdout, "max_concurrent: %d", entry.MaxConcurrent)
 	writeLine(stdout, "prompt: %s", entry.Prompt)
 }

--- a/internal/cli/agent_heartbeat_test.go
+++ b/internal/cli/agent_heartbeat_test.go
@@ -177,6 +177,127 @@ func TestAgentHeartbeatAddReviewSucceedsWithCapability(t *testing.T) {
 	}
 }
 
+// TestAgentHeartbeatAddImplementRejectsReadOnlyPolicy proves the write path
+// refuses an implement heartbeat for an agent whose autonomy policy grants no
+// headless write (the default auto), even when it holds the implement capability.
+func TestAgentHeartbeatAddImplementRejectsReadOnlyPolicy(t *testing.T) {
+	home := t.TempDir()
+	if err := withStore(home, func(store *db.Store) error {
+		return store.UpsertAgent(context.Background(), db.Agent{
+			Name: "builder", Runtime: "codex", RepoScope: "jerryfane/gitmoot",
+			Capabilities: []string{"ask", "implement"}, AutonomyPolicy: "auto", RuntimeRef: "last",
+		})
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "heartbeat", "add", "builder", "nightly",
+		"--repo", "jerryfane/gitmoot", "--interval", "24h", "--action", "implement",
+		"--prompt", "p", "--home", home}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for implement heartbeat under read-only policy")
+	}
+	if !strings.Contains(stderr.String(), "write") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	heartbeats, err := config.LoadHeartbeats(config.PathsForHome(home))
+	if err != nil {
+		t.Fatalf("LoadHeartbeats: %v", err)
+	}
+	if len(heartbeats) != 0 {
+		t.Fatalf("implement heartbeat was written despite read-only policy: %+v", heartbeats)
+	}
+}
+
+// TestAgentHeartbeatAddImplementRejectsMissingCapability proves an implement
+// heartbeat is refused for a write-policy agent that lacks the implement capability.
+func TestAgentHeartbeatAddImplementRejectsMissingCapability(t *testing.T) {
+	home := t.TempDir()
+	if err := withStore(home, func(store *db.Store) error {
+		return store.UpsertAgent(context.Background(), db.Agent{
+			Name: "builder", Runtime: "codex", RepoScope: "jerryfane/gitmoot",
+			Capabilities: []string{"ask"}, AutonomyPolicy: "danger-full-access", RuntimeRef: "last",
+		})
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "heartbeat", "add", "builder", "nightly",
+		"--repo", "jerryfane/gitmoot", "--interval", "24h", "--action", "implement",
+		"--prompt", "p", "--home", home}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for implement heartbeat without implement capability")
+	}
+	if !strings.Contains(stderr.String(), "implement capability") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+}
+
+// TestAgentHeartbeatAddImplementSucceedsWithWritePolicy is the positive
+// counterpart: an agent with the implement capability AND a write-granting policy
+// may register an implement heartbeat, and a per-heartbeat --runtime override is
+// persisted alongside it.
+func TestAgentHeartbeatAddImplementSucceedsWithWritePolicy(t *testing.T) {
+	home := t.TempDir()
+	if err := withStore(home, func(store *db.Store) error {
+		return store.UpsertAgent(context.Background(), db.Agent{
+			Name: "builder", Runtime: "codex", RepoScope: "jerryfane/gitmoot",
+			Capabilities: []string{"ask", "implement"}, AutonomyPolicy: "danger-full-access", RuntimeRef: "last",
+		})
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "heartbeat", "add", "builder", "nightly",
+		"--repo", "jerryfane/gitmoot", "--interval", "24h", "--action", "implement",
+		"--runtime", "claude", "--prompt", "Fix the top lint error.", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("implement add exit=%d stderr=%s", code, stderr.String())
+	}
+	heartbeats, err := config.LoadHeartbeats(config.PathsForHome(home))
+	if err != nil || len(heartbeats) != 1 {
+		t.Fatalf("implement heartbeat not persisted: %+v err=%v", heartbeats, err)
+	}
+	if heartbeats[0].Action != "implement" || heartbeats[0].Runtime != "claude" {
+		t.Fatalf("implement/runtime not persisted: %+v", heartbeats[0])
+	}
+	// The show surface must report the runtime override.
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"agent", "heartbeat", "show", "builder", "nightly", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("show exit=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "runtime: claude") {
+		t.Fatalf("show did not surface runtime override: %q", stdout.String())
+	}
+}
+
+// TestAgentHeartbeatAddRejectsBadRuntime proves an unsupported --runtime override
+// (e.g. shell) is refused before any config write.
+func TestAgentHeartbeatAddRejectsBadRuntime(t *testing.T) {
+	home := t.TempDir()
+	if _, err := initializedPaths(home); err != nil {
+		t.Fatalf("initializedPaths: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"agent", "heartbeat", "add", "repo-maintainer", "daily",
+		"--repo", "jerryfane/gitmoot", "--interval", "24h", "--runtime", "shell",
+		"--prompt", "p", "--home", home}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for shell runtime override")
+	}
+	if !strings.Contains(stderr.String(), "invalid runtime") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	heartbeats, err := config.LoadHeartbeats(config.PathsForHome(home))
+	if err != nil {
+		t.Fatalf("LoadHeartbeats: %v", err)
+	}
+	if len(heartbeats) != 0 {
+		t.Fatalf("heartbeat written despite bad runtime: %+v", heartbeats)
+	}
+}
+
 // TestDaemonHeartbeatLinesOffByDefault asserts the status observability surface is
 // empty when no heartbeats are configured (off-by-default: status is unchanged).
 func TestDaemonHeartbeatLinesOffByDefault(t *testing.T) {

--- a/internal/cli/agent_heartbeat_test.go
+++ b/internal/cli/agent_heartbeat_test.go
@@ -343,3 +343,50 @@ prompt = "p"
 		t.Fatalf("status lines missing expected detail: %q", joined)
 	}
 }
+
+// TestDaemonHeartbeatLinesSurfacesRuntimeOverride asserts the #611 runtime override
+// (#611) is surfaced as `runtime=<X>` on the status line of the heartbeat that
+// carries one, and is ABSENT from a sibling heartbeat that runs on the agent default
+// (the byte-identical pre-#611 line).
+func TestDaemonHeartbeatLinesSurfacesRuntimeOverride(t *testing.T) {
+	home := t.TempDir()
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+`
+[agents.repo-maintainer.heartbeats.override]
+enabled = true
+repo = "jerryfane/gitmoot"
+interval = "24h"
+runtime = "claude"
+prompt = "p"
+
+[agents.repo-maintainer.heartbeats.plain]
+enabled = true
+repo = "jerryfane/gitmoot"
+interval = "24h"
+prompt = "p"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	lines := daemonHeartbeatLines(paths, home)
+	var overrideLine, plainLine string
+	for _, line := range lines {
+		if strings.Contains(line, "repo-maintainer/override") {
+			overrideLine = line
+		}
+		if strings.Contains(line, "repo-maintainer/plain") {
+			plainLine = line
+		}
+	}
+	if overrideLine == "" || plainLine == "" {
+		t.Fatalf("expected both heartbeat lines, got:\n%s", strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(overrideLine, "runtime=claude") {
+		t.Fatalf("override heartbeat line must surface runtime=claude: %q", overrideLine)
+	}
+	if strings.Contains(plainLine, "runtime=") {
+		t.Fatalf("default heartbeat line must NOT surface a runtime: %q", plainLine)
+	}
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2103,14 +2103,14 @@ func runHeartbeatScanOnce(ctx context.Context, paths config.Paths, store *db.Sto
 	now = now.UTC()
 	var firstErr error
 	for _, heartbeat := range heartbeats {
-		if err := runOneHeartbeat(ctx, store, enqueue, agentTypes, heartbeat, now); err != nil && firstErr == nil {
+		if err := runOneHeartbeat(ctx, store, enqueue, agentTypes, heartbeat, paths.Home, now); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	return firstErr
 }
 
-func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqueuer, agentTypes map[string]config.AgentType, heartbeat config.Heartbeat, now time.Time) error {
+func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqueuer, agentTypes map[string]config.AgentType, heartbeat config.Heartbeat, home string, now time.Time) error {
 	if !heartbeat.Enabled {
 		return nil
 	}
@@ -2237,11 +2237,43 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 		}
 		return overrideErr
 	}
+	// Implement heartbeats need the SAME isolated task/branch/worktree the direct
+	// `agent implement` path allocates (#611). Without it the enqueued job carries
+	// Branch="",TaskID="",WorktreePath="" and the daemon worker fails its checkout
+	// pre-flight ("checkout branch is main, not job branch ") on the shared checkout —
+	// a false-green that never runs the agent, creates a branch, or opens a PR. Do the
+	// allocation here (AFTER the overlap/capacity guards so a skipped tick allocates
+	// nothing) so taskWorktreeCheckout resolves the on-branch worktree and
+	// validateTargetCheckout passes, exactly like a foreground implement. Read-only
+	// actions (ask/review) carry no branch identity and keep their bare-enqueue path.
+	var implementFields heartbeatImplementFields
+	if heartbeat.Action == "implement" {
+		implementFields, err = allocateHeartbeatImplement(ctx, store, home, heartbeat)
+		if err != nil {
+			// Allocation failure (e.g. a dirty checkout or a taken branch) is handled
+			// like an enqueue failure: skip but ADVANCE next_due with a clear status so a
+			// broken implement heartbeat does not hot-loop, and self-recovers next tick.
+			state.Agent = heartbeat.Agent
+			state.Name = heartbeat.Name
+			state.LastRunAt = now
+			state.NextDueAt = now.Add(interval + heartbeatJitter(jitter))
+			state.LastStatus = "implement_alloc_failed"
+			if upsertErr := store.UpsertHeartbeatState(ctx, state); upsertErr != nil {
+				return upsertErr
+			}
+			return err
+		}
+	}
 	job, enqueueErr := enqueue(ctx, workflow.JobRequest{
 		ID:                 heartbeatJobID(heartbeat.Agent, heartbeat.Name, now),
 		Agent:              heartbeat.Agent,
 		Action:             heartbeat.Action,
 		Repo:               heartbeat.Repo,
+		Branch:             implementFields.Branch,
+		TaskID:             implementFields.TaskID,
+		TaskTitle:          implementFields.TaskTitle,
+		GoalID:             implementFields.GoalID,
+		HeadSHA:            implementFields.HeadSHA,
 		Sender:             "heartbeat",
 		Instructions:       heartbeat.Prompt,
 		Fingerprint:        fingerprint,
@@ -2266,6 +2298,56 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 		return err
 	}
 	return enqueueErr
+}
+
+// heartbeatImplementFields is the task/branch/worktree identity an implement
+// heartbeat job must carry so the daemon worker's checkout pre-flight
+// (taskWorktreeCheckout + validateTargetCheckout) resolves the freshly allocated
+// on-branch worktree and passes — the exact set the direct `agent implement` path
+// stamps onto its JobRequest (#611).
+type heartbeatImplementFields struct {
+	Branch    string
+	TaskID    string
+	TaskTitle string
+	GoalID    string
+	HeadSHA   string
+}
+
+// allocateHeartbeatImplement performs the SAME task/branch/worktree allocation the
+// direct `agent implement` dispatch does (prepareLocalImplementDispatchRequest →
+// workflow.Engine.AllocateTaskWorktree): it upserts a fresh adhoc task on a
+// gitmoot/<taskID> branch and adds an isolated git worktree checked out on that
+// branch, returning the identity fields the enqueued job needs. It reuses the
+// direct path verbatim so the scheduled and foreground implement flows can never
+// drift. It uses the STORED repo record (whose DefaultBranch is the allocation
+// base) rather than re-deriving the base from the possibly-off-branch shared
+// checkout (#611).
+func allocateHeartbeatImplement(ctx context.Context, store *db.Store, home string, heartbeat config.Heartbeat) (heartbeatImplementFields, error) {
+	repo, err := daemon.ParseRepository(heartbeat.Repo)
+	if err != nil {
+		return heartbeatImplementFields{}, err
+	}
+	record, err := store.GetRepo(ctx, heartbeat.Repo)
+	if err != nil {
+		return heartbeatImplementFields{}, err
+	}
+	_, prepared, err := prepareLocalImplementDispatchRequest(ctx, store, record, repo, localAgentDispatchRequest{
+		RepoFlag:     heartbeat.Repo,
+		Agent:        heartbeat.Agent,
+		Action:       "implement",
+		Instructions: heartbeat.Prompt,
+		Home:         home,
+	})
+	if err != nil {
+		return heartbeatImplementFields{}, err
+	}
+	return heartbeatImplementFields{
+		Branch:    prepared.Branch,
+		TaskID:    prepared.TaskID,
+		TaskTitle: prepared.TaskTitle,
+		GoalID:    prepared.GoalID,
+		HeadSHA:   prepared.HeadSHA,
+	}, nil
 }
 
 // startSingleRepoWorkerLoop wires the single-repo supervisor's per-tick worker

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -719,6 +719,11 @@ func daemonHeartbeatLines(paths config.Paths, home string) []string {
 		}
 		line := fmt.Sprintf("  %s/%s: %s action=%s interval=%s repo=%s",
 			heartbeat.Agent, heartbeat.Name, enabled, heartbeat.Action, heartbeat.Interval, heartbeat.Repo)
+		// A runtime override (#611) is surfaced only when set, so heartbeats without
+		// one print byte-identically to the pre-#611 status line.
+		if heartbeat.Runtime != "" {
+			line += fmt.Sprintf(" runtime=%s", heartbeat.Runtime)
+		}
 		if state, ok := states[heartbeat.Agent+"/"+heartbeat.Name]; ok {
 			line += fmt.Sprintf(" last_run=%s next_due=%s last_status=%s",
 				heartbeatTimeForStatus(state.LastRunAt), heartbeatTimeForStatus(state.NextDueAt), firstNonEmpty(state.LastStatus, "-"))
@@ -2038,6 +2043,27 @@ func heartbeatAgentHasCapability(ctx context.Context, store *db.Store, agent, ca
 	return agentHasCapability(record.Capabilities, capability), nil
 }
 
+// heartbeatImplementPermitted reports whether the named agent may run an implement
+// heartbeat: it must hold the "implement" capability AND carry a write-granting
+// autonomy policy (workspace-write / danger-full-access). A missing agent is NOT
+// an error — it returns false so an implement heartbeat for an unknown/unstarted
+// agent is skipped (and next_due advanced) rather than aborting the scan. It
+// reuses the exact runtime predicate the direct-implement dispatch gate uses, so
+// the two can never drift. A real store error propagates (#611).
+func heartbeatImplementPermitted(ctx context.Context, store *db.Store, agent string) (bool, error) {
+	record, err := store.GetAgent(ctx, strings.TrimSpace(agent))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !agentHasCapability(record.Capabilities, "implement") {
+		return false, nil
+	}
+	return runtime.PolicyGrantsImplementWrite(record.AutonomyPolicy), nil
+}
+
 func heartbeatJobID(agent, name string, now time.Time) string {
 	return fmt.Sprintf("heartbeat-%s-%s-%x", agent, name, now.UTC().UnixNano())
 }
@@ -2145,6 +2171,29 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 			return store.UpsertHeartbeatState(ctx, state)
 		}
 	}
+	// Policy gate: an implement heartbeat enqueues a WRITE job. The worker only
+	// produces files for an agent that holds the implement capability AND carries a
+	// write-granting autonomy policy (workspace-write / danger-full-access); under
+	// auto/read-only the job runs and produces nothing (and is separately blocked by
+	// readOnlyImplementationBlocked at dispatch). Validate here — the enqueue path
+	// bypasses ensureLocalAgentAccess — so an implement heartbeat for a read-only
+	// agent NO-OPs rather than churning doomed jobs. Skip but ADVANCE next_due with a
+	// clear status so it self-recovers once a write policy is granted. This is the
+	// agent-aware half of the config-level action gate (#611).
+	if heartbeat.Action == "implement" {
+		permitted, err := heartbeatImplementPermitted(ctx, store, heartbeat.Agent)
+		if err != nil {
+			return err
+		}
+		if !permitted {
+			state.Agent = heartbeat.Agent
+			state.Name = heartbeat.Name
+			state.LastRunAt = now
+			state.NextDueAt = now.Add(interval + heartbeatJitter(jitter))
+			state.LastStatus = "policy_readonly"
+			return store.UpsertHeartbeatState(ctx, state)
+		}
+	}
 	// Overlap protection: a still-active heartbeat job (>= max_concurrent) means the
 	// previous run has not finished. Skip WITHOUT advancing so it is retried next
 	// tick (this is also the restart-safe dedup: a restart sees the active job).
@@ -2168,14 +2217,36 @@ func runOneHeartbeat(ctx context.Context, store *db.Store, enqueue heartbeatEnqu
 			return nil
 		}
 	}
+	// Per-heartbeat runtime override (#611): when the heartbeat names a runtime,
+	// resolve it through the same seam the per-job --runtime override uses (#531) —
+	// it validates the runtime and mints a FRESH session ref so the scheduled job
+	// neither resumes nor writes the agent's default-runtime session. An empty
+	// heartbeat runtime yields ("", "") and the job runs on the agent default,
+	// byte-identical to a pre-#611 heartbeat.
+	overrideRuntime, overrideRef, overrideErr := resolveJobRuntimeOverride(heartbeat.Runtime, "")
+	if overrideErr != nil {
+		// A bad runtime override is a config error; skip but ADVANCE next_due so a
+		// broken heartbeat does not hot-loop, and self-recovers once corrected.
+		state.Agent = heartbeat.Agent
+		state.Name = heartbeat.Name
+		state.LastRunAt = now
+		state.NextDueAt = now.Add(interval + heartbeatJitter(jitter))
+		state.LastStatus = "runtime_invalid"
+		if err := store.UpsertHeartbeatState(ctx, state); err != nil {
+			return err
+		}
+		return overrideErr
+	}
 	job, enqueueErr := enqueue(ctx, workflow.JobRequest{
-		ID:           heartbeatJobID(heartbeat.Agent, heartbeat.Name, now),
-		Agent:        heartbeat.Agent,
-		Action:       heartbeat.Action,
-		Repo:         heartbeat.Repo,
-		Sender:       "heartbeat",
-		Instructions: heartbeat.Prompt,
-		Fingerprint:  fingerprint,
+		ID:                 heartbeatJobID(heartbeat.Agent, heartbeat.Name, now),
+		Agent:              heartbeat.Agent,
+		Action:             heartbeat.Action,
+		Repo:               heartbeat.Repo,
+		Sender:             "heartbeat",
+		Instructions:       heartbeat.Prompt,
+		Fingerprint:        fingerprint,
+		RuntimeOverride:    overrideRuntime,
+		RuntimeOverrideRef: overrideRef,
 	})
 	// Advance exactly one interval whether or not the enqueue succeeded. Anchoring
 	// next_due to `now` (not the old due time) coalesces missed ticks into a single

--- a/internal/cli/daemon_heartbeat_test.go
+++ b/internal/cli/daemon_heartbeat_test.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"context"
+	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -272,6 +275,15 @@ max_concurrent = 1
 func TestHeartbeatScanEnqueuesImplementJob(t *testing.T) {
 	paths, store := heartbeatScanFixture(t, implementHeartbeatBody)
 	ctx := context.Background()
+	// The implement heartbeat now allocates a real task worktree (#611), so the
+	// target repo needs a real git checkout on its default branch — not the fixture's
+	// bare temp dir. Re-register jerryfane/gitmoot onto one.
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	if err := store.UpsertRepo(ctx, db.Repo{
+		Owner: "jerryfane", Name: "gitmoot", CheckoutPath: checkout, DefaultBranch: "main", PollInterval: "30s",
+	}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
 	if err := store.UpsertAgent(ctx, db.Agent{
 		Name: "builder", Runtime: "codex", RepoScope: "jerryfane/gitmoot",
 		Capabilities: []string{"ask", "implement"}, AutonomyPolicy: "danger-full-access", RuntimeRef: "last",
@@ -286,12 +298,130 @@ func TestHeartbeatScanEnqueuesImplementJob(t *testing.T) {
 	if len(*seen) != 1 {
 		t.Fatalf("expected 1 implement job, got %d", len(*seen))
 	}
-	if req := (*seen)[0]; req.Action != "implement" || req.Agent != "builder" || req.Sender != "heartbeat" {
+	req := (*seen)[0]
+	if req.Action != "implement" || req.Agent != "builder" || req.Sender != "heartbeat" {
 		t.Fatalf("unexpected implement request shape: %+v", req)
+	}
+	// The fix (#611): the implement heartbeat allocates a task/branch/worktree so the
+	// enqueued job carries the identity the daemon worker's checkout pre-flight needs.
+	// A bare enqueue (Branch/TaskID/HeadSHA empty) was the false-green the bug produced.
+	if req.Branch == "" || req.TaskID == "" || req.HeadSHA == "" {
+		t.Fatalf("implement heartbeat job missing allocated identity: branch=%q task=%q head=%q", req.Branch, req.TaskID, req.HeadSHA)
+	}
+	if !strings.HasPrefix(req.Branch, "gitmoot/") {
+		t.Fatalf("implement heartbeat branch = %q, want a gitmoot/<task> branch", req.Branch)
+	}
+	// The task row backs the worktree the worker resolves; it must exist on that branch.
+	task, err := store.GetTask(ctx, req.TaskID)
+	if err != nil {
+		t.Fatalf("GetTask(%s): %v", req.TaskID, err)
+	}
+	if task.Branch != req.Branch || strings.TrimSpace(task.WorktreePath) == "" {
+		t.Fatalf("task not allocated on the job branch with a worktree: %+v", task)
 	}
 	state, found, err := store.GetHeartbeatState(ctx, "builder", "nightly")
 	if err != nil || !found || state.LastStatus != "enqueued" {
 		t.Fatalf("implement heartbeat state not advanced: found=%v err=%v state=%+v", found, err, state)
+	}
+}
+
+// TestHeartbeatImplementJobPassesWorkerCheckout is the WORKER-LEVEL guard for #611:
+// it drives the REAL daemon worker checkout pre-flight (defaultCheckout →
+// taskWorktreeCheckout + validateTargetCheckout + validateImplementationLock) for
+// the job a policy-passing implement heartbeat enqueues, and asserts it RESOLVES the
+// isolated on-branch worktree instead of failing "checkout branch is main, not job
+// branch " on the shared checkout. Against pre-fix code (a bare enqueue with
+// Branch/TaskID empty) defaultCheckout returns that error and the job goes straight
+// to JobFailed — the exact false-green the scan+enqueue tests could never catch
+// because they stop at a fake enqueuer and never reach the worker.
+func TestHeartbeatImplementJobPassesWorkerCheckout(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	paths, err := initializedPaths(home)
+	if err != nil {
+		t.Fatalf("initializedPaths: %v", err)
+	}
+	// A real git checkout whose origin is owner/repo, so the worker's
+	// preflightDaemonRepoCheckout (origin must equal the registered repo) and
+	// validateTargetCheckout both pass against the resolved worktree.
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+`
+[agents.builder]
+runtime = "codex"
+role = "builder"
+capabilities = ["ask", "implement"]
+max_background = 2
+
+[agents.builder.heartbeats.nightly]
+enabled = true
+repo = "owner/repo"
+interval = "24h"
+action = "implement"
+prompt = "Fix the top lint error and open a small PR."
+max_concurrent = 1
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	if err := store.UpsertRepo(ctx, db.Repo{
+		Owner: "owner", Name: "repo", CheckoutPath: checkout, DefaultBranch: "main", PollInterval: "30s",
+	}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "builder", Runtime: "codex", RepoScope: "owner/repo",
+		Capabilities: []string{"ask", "implement"}, AutonomyPolicy: "danger-full-access", RuntimeRef: "last",
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	// Enqueue through the PRODUCTION heartbeat enqueuer so the job lands in the store
+	// exactly as the daemon writes it.
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, newHeartbeatEnqueuer(store, home), now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 enqueued heartbeat job, got %d", len(jobs))
+	}
+	job := jobs[0]
+	if job.Type != "implement" {
+		t.Fatalf("enqueued job type = %q, want implement", job.Type)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload: %v", err)
+	}
+	if payload.Branch == "" || payload.TaskID == "" || payload.HeadSHA == "" {
+		t.Fatalf("enqueued implement payload missing identity: %+v", payload)
+	}
+	// Drive the REAL worker checkout pre-flight. Pre-fix this returned "checkout
+	// branch is main, not job branch "; post-fix it resolves the on-branch worktree.
+	worker := defaultJobWorker(store, io.Discard, home)
+	got, err := worker.defaultCheckout(ctx, job, payload, runtime.Agent{Name: "builder"})
+	if err != nil {
+		t.Fatalf("defaultCheckout rejected the implement heartbeat job (the #611 false-green): %v", err)
+	}
+	if got == checkout {
+		t.Fatalf("defaultCheckout resolved the SHARED checkout %q, not the isolated task worktree", checkout)
+	}
+	task, err := store.GetTask(ctx, payload.TaskID)
+	if err != nil {
+		t.Fatalf("GetTask(%s): %v", payload.TaskID, err)
+	}
+	wantWorktree, err := normalizeTaskWorktreePath(task.WorktreePath)
+	if err != nil {
+		t.Fatalf("normalizeTaskWorktreePath: %v", err)
+	}
+	if got != wantWorktree {
+		t.Fatalf("defaultCheckout = %q, want isolated task worktree %q", got, wantWorktree)
 	}
 }
 

--- a/internal/cli/daemon_heartbeat_test.go
+++ b/internal/cli/daemon_heartbeat_test.go
@@ -250,6 +250,171 @@ func TestHeartbeatScanSkipsUnmanagedRepo(t *testing.T) {
 	}
 }
 
+const implementHeartbeatBody = `
+[agents.builder]
+runtime = "codex"
+role = "builder"
+capabilities = ["ask", "implement"]
+max_background = 2
+
+[agents.builder.heartbeats.nightly]
+enabled = true
+repo = "jerryfane/gitmoot"
+interval = "24h"
+action = "implement"
+prompt = "Fix the top lint error and open a small PR."
+max_concurrent = 1
+`
+
+// TestHeartbeatScanEnqueuesImplementJob proves a policy-gated implement heartbeat
+// enqueues an Action="implement" job when its agent holds the implement capability
+// AND a write-granting autonomy policy (#611).
+func TestHeartbeatScanEnqueuesImplementJob(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, implementHeartbeatBody)
+	ctx := context.Background()
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "builder", Runtime: "codex", RepoScope: "jerryfane/gitmoot",
+		Capabilities: []string{"ask", "implement"}, AutonomyPolicy: "danger-full-access", RuntimeRef: "last",
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("expected 1 implement job, got %d", len(*seen))
+	}
+	if req := (*seen)[0]; req.Action != "implement" || req.Agent != "builder" || req.Sender != "heartbeat" {
+		t.Fatalf("unexpected implement request shape: %+v", req)
+	}
+	state, found, err := store.GetHeartbeatState(ctx, "builder", "nightly")
+	if err != nil || !found || state.LastStatus != "enqueued" {
+		t.Fatalf("implement heartbeat state not advanced: found=%v err=%v state=%+v", found, err, state)
+	}
+}
+
+// TestHeartbeatScanImplementRejectsReadOnlyPolicy proves a due implement heartbeat
+// for an agent that holds the implement capability but carries a read-only-ish
+// policy (the default auto) NO-OPs: it never enqueues, and advances next_due with
+// last_status=policy_readonly so it self-recovers once a write policy is granted.
+func TestHeartbeatScanImplementRejectsReadOnlyPolicy(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, implementHeartbeatBody)
+	ctx := context.Background()
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "builder", Runtime: "codex", RepoScope: "jerryfane/gitmoot",
+		Capabilities: []string{"ask", "implement"}, AutonomyPolicy: "auto", RuntimeRef: "last",
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("implement heartbeat under read-only policy enqueued %d jobs", len(*seen))
+	}
+	state, found, err := store.GetHeartbeatState(ctx, "builder", "nightly")
+	if err != nil || !found {
+		t.Fatalf("expected state row, found=%v err=%v", found, err)
+	}
+	if state.LastStatus != "policy_readonly" {
+		t.Fatalf("last_status = %q, want policy_readonly", state.LastStatus)
+	}
+	if !state.NextDueAt.Equal(now.Add(24 * time.Hour)) {
+		t.Fatalf("policy skip must advance next_due (no wedge): %+v", state)
+	}
+}
+
+// TestHeartbeatScanImplementRejectsMissingCapability proves an implement heartbeat
+// for a write-policy agent that nonetheless LACKS the implement capability also
+// no-ops with last_status=policy_readonly.
+func TestHeartbeatScanImplementRejectsMissingCapability(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, implementHeartbeatBody)
+	ctx := context.Background()
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "builder", Runtime: "codex", RepoScope: "jerryfane/gitmoot",
+		Capabilities: []string{"ask"}, AutonomyPolicy: "danger-full-access", RuntimeRef: "last",
+	}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("implement heartbeat without capability enqueued %d jobs", len(*seen))
+	}
+	state, _, err := store.GetHeartbeatState(ctx, "builder", "nightly")
+	if err != nil {
+		t.Fatalf("GetHeartbeatState: %v", err)
+	}
+	if state.LastStatus != "policy_readonly" {
+		t.Fatalf("last_status = %q, want policy_readonly", state.LastStatus)
+	}
+}
+
+const runtimeOverrideHeartbeatBody = `
+[agents.repo-maintainer]
+runtime = "codex"
+role = "repo-maintainer"
+max_background = 1
+
+[agents.repo-maintainer.heartbeats.daily]
+enabled = true
+repo = "jerryfane/gitmoot"
+interval = "24h"
+action = "ask"
+runtime = "claude"
+prompt = "Review open issues and PRs."
+max_concurrent = 1
+`
+
+// TestHeartbeatScanRuntimeOverride proves a per-heartbeat runtime override (#611)
+// flows onto the enqueued job as a RuntimeOverride plus a freshly-minted override
+// ref, so the scheduled job runs on the named runtime on its own session.
+func TestHeartbeatScanRuntimeOverride(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, runtimeOverrideHeartbeatBody)
+	ctx := context.Background()
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(*seen))
+	}
+	req := (*seen)[0]
+	if req.RuntimeOverride != "claude" {
+		t.Fatalf("expected RuntimeOverride=claude, got %q", req.RuntimeOverride)
+	}
+	if req.RuntimeOverrideRef == "" {
+		t.Fatalf("expected a minted RuntimeOverrideRef for the override, got empty")
+	}
+}
+
+// TestHeartbeatScanNoRuntimeOverrideByDefault is the byte-identical-default guard:
+// a heartbeat WITHOUT a runtime override enqueues a job carrying no override, so
+// it runs on the agent default exactly as before #611.
+func TestHeartbeatScanNoRuntimeOverrideByDefault(t *testing.T) {
+	paths, store := heartbeatScanFixture(t, enabledHeartbeatBody)
+	ctx := context.Background()
+	enq, seen := recordingEnqueuer()
+	now := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	if err := runHeartbeatScanOnce(ctx, paths, store, enq, now); err != nil {
+		t.Fatalf("runHeartbeatScanOnce: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(*seen))
+	}
+	if req := (*seen)[0]; req.RuntimeOverride != "" || req.RuntimeOverrideRef != "" {
+		t.Fatalf("default heartbeat must carry no runtime override: %+v", req)
+	}
+}
+
 const reviewHeartbeatBody = `
 [agents.reviewer]
 runtime = "codex"

--- a/internal/config/heartbeat_edit.go
+++ b/internal/config/heartbeat_edit.go
@@ -84,6 +84,13 @@ func SaveHeartbeat(paths Paths, entry Heartbeat) error {
 				return err
 			}
 		}
+		// A re-save WITHOUT a runtime override (#611) must CLEAR any prior `runtime`
+		// key rather than silently leave it in place: the fields slice omits `runtime`
+		// when empty, so the setSectionScalar loop above never touched it. Without this,
+		// re-adding a heartbeat sans --runtime would keep a stale override.
+		if entry.Runtime == "" {
+			removeSectionScalar(section, "runtime")
+		}
 	}
 	return formatAndValidateConfig(paths, doc, original)
 }
@@ -202,6 +209,22 @@ func setSectionScalar(section *tomledit.Section, key string, value ConfigScalar)
 	}
 	section.Items = append(section.Items, &parser.KeyValue{Name: parser.Key{key}, Value: parsed})
 	return nil
+}
+
+// removeSectionScalar drops the first key mapping from section, reporting whether
+// it removed anything. It is the delete cousin of setSectionScalar, used to clear
+// a heartbeat's optional `runtime` override when the block is re-saved without one
+// (#611) so a stale override cannot silently persist.
+func removeSectionScalar(section *tomledit.Section, key string) bool {
+	for i, item := range section.Items {
+		kv, ok := item.(*parser.KeyValue)
+		if !ok || len(kv.Name) != 1 || kv.Name[0] != key {
+			continue
+		}
+		section.Items = append(section.Items[:i], section.Items[i+1:]...)
+		return true
+	}
+	return false
 }
 
 // formatAndValidateConfig serializes doc, writes it atomically, then re-validates

--- a/internal/config/heartbeat_edit.go
+++ b/internal/config/heartbeat_edit.go
@@ -39,7 +39,9 @@ func SaveHeartbeat(paths Paths, entry Heartbeat) error {
 	tableName := parser.Key{"agents", entry.Agent, "heartbeats", entry.Name}
 	section := findSection(doc, tableName)
 	// Field order mirrors the documented config example so a freshly written block
-	// reads top-to-bottom as enabled→repo→interval→jitter→action→prompt→concurrency.
+	// reads top-to-bottom as enabled→repo→interval→jitter→action→[runtime]→prompt→
+	// concurrency. The optional `runtime` override (#611) is written ONLY when set,
+	// so a heartbeat without an override stays byte-identical to the pre-#611 shape.
 	fields := []struct {
 		key   string
 		value ConfigScalar
@@ -49,9 +51,23 @@ func SaveHeartbeat(paths Paths, entry Heartbeat) error {
 		{"interval", StringScalar(entry.Interval)},
 		{"jitter", StringScalar(entry.Jitter)},
 		{"action", StringScalar(entry.Action)},
-		{"prompt", StringScalar(entry.Prompt)},
-		{"max_concurrent", IntScalar(entry.MaxConcurrent)},
 	}
+	if entry.Runtime != "" {
+		fields = append(fields, struct {
+			key   string
+			value ConfigScalar
+		}{"runtime", StringScalar(entry.Runtime)})
+	}
+	fields = append(fields,
+		struct {
+			key   string
+			value ConfigScalar
+		}{"prompt", StringScalar(entry.Prompt)},
+		struct {
+			key   string
+			value ConfigScalar
+		}{"max_concurrent", IntScalar(entry.MaxConcurrent)},
+	)
 	if section == nil {
 		section = &tomledit.Section{Heading: &parser.Heading{Name: tableName}}
 		for _, field := range fields {

--- a/internal/config/heartbeat_edit_test.go
+++ b/internal/config/heartbeat_edit_test.go
@@ -103,6 +103,42 @@ func TestSaveHeartbeatRuntimeOverride(t *testing.T) {
 	}
 }
 
+// TestSaveHeartbeatClearsRuntimeOnResaveWithoutOverride pins the #611 review LOW:
+// re-saving an existing heartbeat WITHOUT a runtime must CLEAR a prior `runtime`
+// key, not silently keep the stale override (the update path omits `runtime` from
+// its field set when empty, so it is not overwritten — it must be removed).
+func TestSaveHeartbeatClearsRuntimeOnResaveWithoutOverride(t *testing.T) {
+	paths := newHeartbeatEditPaths(t, "")
+	// First save WITH an override.
+	if err := SaveHeartbeat(paths, Heartbeat{
+		Agent: "builder", Name: "nightly", Enabled: true, Repo: "o/r",
+		Interval: "24h", Action: "implement", Runtime: "codex", Prompt: "tidy",
+	}); err != nil {
+		t.Fatalf("SaveHeartbeat with runtime: %v", err)
+	}
+	// Re-save the SAME heartbeat WITHOUT a runtime: the override must be cleared.
+	if err := SaveHeartbeat(paths, Heartbeat{
+		Agent: "builder", Name: "nightly", Enabled: true, Repo: "o/r",
+		Interval: "24h", Action: "implement", Prompt: "tidy",
+	}); err != nil {
+		t.Fatalf("SaveHeartbeat without runtime: %v", err)
+	}
+	raw, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if strings.Contains(string(raw), "runtime =") {
+		t.Fatalf("re-save without --runtime must clear the prior override, got:\n%s", string(raw))
+	}
+	got, err := LoadHeartbeats(paths)
+	if err != nil {
+		t.Fatalf("LoadHeartbeats: %v", err)
+	}
+	if len(got) != 1 || got[0].Runtime != "" {
+		t.Fatalf("runtime override not cleared: %+v", got)
+	}
+}
+
 func TestSaveHeartbeatUpdateExisting(t *testing.T) {
 	paths := newHeartbeatEditPaths(t, `
 [agents.x.heartbeats.h]

--- a/internal/config/heartbeat_edit_test.go
+++ b/internal/config/heartbeat_edit_test.go
@@ -50,6 +50,59 @@ func TestSaveHeartbeatCreateRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSaveHeartbeatRuntimeOverride asserts a runtime override round-trips, and
+// that OMITTING it (the default) writes NO runtime key — keeping a heartbeat
+// without an override byte-identical to the pre-#611 shape.
+func TestSaveHeartbeatRuntimeOverride(t *testing.T) {
+	paths := newHeartbeatEditPaths(t, "")
+	// With a runtime override: the key is written and round-trips.
+	if err := SaveHeartbeat(paths, Heartbeat{
+		Agent: "builder", Name: "nightly", Enabled: true, Repo: "o/r",
+		Interval: "24h", Action: "implement", Runtime: "codex", Prompt: "tidy",
+	}); err != nil {
+		t.Fatalf("SaveHeartbeat with runtime: %v", err)
+	}
+	// Without a runtime override: the section must contain no `runtime =` line.
+	if err := SaveHeartbeat(paths, Heartbeat{
+		Agent: "planner", Name: "daily", Enabled: true, Repo: "o/r",
+		Interval: "24h", Action: "ask", Prompt: "status",
+	}); err != nil {
+		t.Fatalf("SaveHeartbeat without runtime: %v", err)
+	}
+	raw, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	text := string(raw)
+	if !strings.Contains(text, "runtime = \"codex\"") {
+		t.Fatalf("expected runtime override written, got:\n%s", text)
+	}
+	// The planner (no override) section must not carry a runtime key.
+	plannerIdx := strings.Index(text, "[agents.planner.heartbeats.daily]")
+	if plannerIdx < 0 {
+		t.Fatalf("planner heartbeat section missing:\n%s", text)
+	}
+	if strings.Contains(text[plannerIdx:], "runtime =") {
+		t.Fatalf("planner heartbeat (no override) must not write a runtime key:\n%s", text[plannerIdx:])
+	}
+	got, err := LoadHeartbeats(paths)
+	if err != nil {
+		t.Fatalf("LoadHeartbeats: %v", err)
+	}
+	var builder, planner Heartbeat
+	for _, hb := range got {
+		switch hb.Agent {
+		case "builder":
+			builder = hb
+		case "planner":
+			planner = hb
+		}
+	}
+	if builder.Runtime != "codex" || planner.Runtime != "" {
+		t.Fatalf("runtime round-trip mismatch: builder=%q planner=%q", builder.Runtime, planner.Runtime)
+	}
+}
+
 func TestSaveHeartbeatUpdateExisting(t *testing.T) {
 	paths := newHeartbeatEditPaths(t, `
 [agents.x.heartbeats.h]
@@ -258,10 +311,26 @@ prompt = "p"
 func TestSaveHeartbeatRejectsInvalid(t *testing.T) {
 	paths := newHeartbeatEditPaths(t, "")
 	err := SaveHeartbeat(paths, Heartbeat{
-		Agent: "x", Name: "h", Repo: "o/r", Interval: "1h", Action: "implement", Prompt: "p",
+		Agent: "x", Name: "h", Repo: "o/r", Interval: "1h", Action: "deploy", Prompt: "p",
 	})
 	if err == nil {
-		t.Fatalf("expected validation error for implement action")
+		t.Fatalf("expected validation error for unsupported action")
+	}
+	content, _ := os.ReadFile(paths.ConfigFile)
+	if strings.Contains(string(content), "heartbeats.h") {
+		t.Fatalf("invalid heartbeat was written to disk:\n%s", string(content))
+	}
+}
+
+// TestSaveHeartbeatRejectsBadRuntime asserts an unsupported runtime override never
+// reaches disk (#611).
+func TestSaveHeartbeatRejectsBadRuntime(t *testing.T) {
+	paths := newHeartbeatEditPaths(t, "")
+	err := SaveHeartbeat(paths, Heartbeat{
+		Agent: "x", Name: "h", Repo: "o/r", Interval: "1h", Action: "ask", Runtime: "shell", Prompt: "p",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error for shell runtime override")
 	}
 	content, _ := os.ReadFile(paths.ConfigFile)
 	if strings.Contains(string(content), "heartbeats.h") {

--- a/internal/config/heartbeats.go
+++ b/internal/config/heartbeats.go
@@ -116,14 +116,17 @@ func HeartbeatActionSupported(action string) bool {
 }
 
 // HeartbeatRuntimes lists the runtimes a per-heartbeat runtime override may name
-// (#611): every resumable runtime the adapter Factory supports EXCEPT shell (a
+// (#611): the resumable runtimes the adapter Factory supports EXCEPT shell (a
 // heartbeat mints a fresh session, and shell sessions are whole commands, not
-// resumable sessions). It is derived from runtime.SupportedRuntimes so the set
-// stays in lockstep with the actual adapter registry.
+// resumable sessions) and kimi-cli (the legacy Kimi CLI; gitmoot targets kimi-code
+// via the `kimi` runtime). The result — codex|claude|kimi — is the SINGLE source of
+// truth that the CLI usage/flag help and the docs advertise, so accepted ==
+// documented (the rest is derived from runtime.SupportedRuntimes so the set stays
+// in lockstep with the adapter registry).
 func HeartbeatRuntimes() []string {
-	allowed := make([]string, 0, 4)
+	allowed := make([]string, 0, 3)
 	for _, name := range runtime.SupportedRuntimes() {
-		if name == runtime.ShellRuntime {
+		if name == runtime.ShellRuntime || name == runtime.KimiCLIRuntime {
 			continue
 		}
 		allowed = append(allowed, name)

--- a/internal/config/heartbeats.go
+++ b/internal/config/heartbeats.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
 // Heartbeat is one named recurring agent schedule parsed from an
@@ -23,6 +25,13 @@ type Heartbeat struct {
 	Action        string
 	Prompt        string
 	MaxConcurrent int
+	// Runtime, when non-empty, runs this heartbeat's job through the named runtime
+	// instead of the target agent's registered default runtime (#611, reusing the
+	// per-job override machinery from #531). It is OPTIONAL: an empty Runtime leaves
+	// every existing heartbeat byte-identical and runs on the agent default. Only a
+	// resumable runtime (codex/claude/kimi) is allowed — a heartbeat mints a fresh
+	// session, and shell sessions are whole commands, so shell is rejected.
+	Runtime string
 }
 
 // LoadHeartbeats collects every [agents.<agent>.heartbeats.<name>] section from
@@ -86,19 +95,56 @@ func LoadHeartbeats(paths Paths) ([]Heartbeat, error) {
 	return heartbeats, nil
 }
 
-// HeartbeatActions lists the actions a heartbeat may schedule, both read-only:
-// "ask" (the conservative default) and "review". "implement" is deliberately
-// excluded — recurring unattended code-change PRs are a separate safety pass.
-func HeartbeatActions() []string { return []string{"ask", "review"} }
+// HeartbeatActions lists the actions a heartbeat may schedule: the read-only
+// "ask" (the conservative default) and "review", plus the WRITE action
+// "implement". "implement" is structurally valid here but POLICY-GATED (#611):
+// it only runs for a target agent whose autonomy policy grants headless writes
+// (workspace-write / danger-full-access) and that holds the "implement"
+// capability. That gate is agent-aware (it needs the agent registry), so it is
+// enforced at the CLI write path and the daemon scan, mirroring how the "review"
+// capability check lives outside this pure config loader.
+func HeartbeatActions() []string { return []string{"ask", "review", "implement"} }
 
 // HeartbeatActionSupported reports whether action is one a heartbeat may use.
 func HeartbeatActionSupported(action string) bool {
 	switch strings.TrimSpace(action) {
-	case "ask", "review":
+	case "ask", "review", "implement":
 		return true
 	default:
 		return false
 	}
+}
+
+// HeartbeatRuntimes lists the runtimes a per-heartbeat runtime override may name
+// (#611): every resumable runtime the adapter Factory supports EXCEPT shell (a
+// heartbeat mints a fresh session, and shell sessions are whole commands, not
+// resumable sessions). It is derived from runtime.SupportedRuntimes so the set
+// stays in lockstep with the actual adapter registry.
+func HeartbeatRuntimes() []string {
+	allowed := make([]string, 0, 4)
+	for _, name := range runtime.SupportedRuntimes() {
+		if name == runtime.ShellRuntime {
+			continue
+		}
+		allowed = append(allowed, name)
+	}
+	return allowed
+}
+
+// HeartbeatRuntimeSupported reports whether rt is a valid per-heartbeat runtime
+// override (a resumable runtime, never shell). The empty string is valid: it
+// means "no override; run on the agent default".
+func HeartbeatRuntimeSupported(rt string) bool {
+	rt = strings.TrimSpace(rt)
+	if rt == "" {
+		return true
+	}
+	for _, name := range HeartbeatRuntimes() {
+		if name == rt {
+			return true
+		}
+	}
+	return false
 }
 
 // parseHeartbeatSection extracts the agent and the heartbeat name from a section
@@ -155,6 +201,10 @@ func applyHeartbeatField(entry *Heartbeat, key string, value string) error {
 		parsed, err := parseConfigString(value)
 		entry.Prompt = parsed
 		return err
+	case "runtime":
+		parsed, err := parseConfigString(value)
+		entry.Runtime = parsed
+		return err
 	case "max_concurrent":
 		parsed, err := strconv.Atoi(value)
 		entry.MaxConcurrent = parsed
@@ -178,6 +228,7 @@ func applyHeartbeatDefaults(entry *Heartbeat) {
 		entry.Action = "ask"
 	}
 	entry.Prompt = strings.TrimSpace(entry.Prompt)
+	entry.Runtime = strings.TrimSpace(entry.Runtime)
 	if entry.MaxConcurrent <= 0 {
 		entry.MaxConcurrent = 1
 	}
@@ -200,14 +251,21 @@ func validateHeartbeat(entry Heartbeat) error {
 	if _, err := time.ParseDuration(entry.Jitter); err != nil {
 		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: jitter %q: %w", entry.Agent, entry.Name, entry.Jitter, err)
 	}
-	// Supported actions are the conservative read-only ones: "ask" (analyze/answer)
-	// and "review" (read-only PR/code review). A "review" heartbeat additionally
-	// requires the target agent to HOLD the review capability; that check needs the
-	// agent registry, so it lives in the daemon scan (runOneHeartbeat) and the CLI
-	// write path, not here. "implement" heartbeats stay deferred: recurring
-	// unattended code-change PRs are a separate safety pass.
+	// Supported actions are the read-only "ask" (analyze/answer) and "review"
+	// (read-only PR/code review), plus the WRITE action "implement" (#611). A
+	// "review" heartbeat additionally requires the target agent to HOLD the review
+	// capability, and an "implement" heartbeat requires the agent to hold the
+	// implement capability AND carry a write-granting autonomy policy; both checks
+	// need the agent registry, so they live in the daemon scan (runOneHeartbeat) and
+	// the CLI write path, not in this pure config loader.
 	if !HeartbeatActionSupported(entry.Action) {
-		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: unsupported action %q; only %q and %q are supported", entry.Agent, entry.Name, entry.Action, "ask", "review")
+		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: unsupported action %q; supported actions are %s", entry.Agent, entry.Name, entry.Action, strings.Join(HeartbeatActions(), ", "))
+	}
+	// A per-heartbeat runtime override (#611) must name a resumable runtime the
+	// adapter Factory supports (codex/claude/kimi), never shell. An empty runtime is
+	// valid and means "run on the agent default" (the byte-identical default).
+	if !HeartbeatRuntimeSupported(entry.Runtime) {
+		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: unsupported runtime %q; supported runtimes are %s", entry.Agent, entry.Name, entry.Runtime, strings.Join(HeartbeatRuntimes(), ", "))
 	}
 	if entry.Prompt == "" {
 		return fmt.Errorf("heartbeat [agents.%s.heartbeats.%s]: prompt is required", entry.Agent, entry.Name)

--- a/internal/config/heartbeats_test.go
+++ b/internal/config/heartbeats_test.go
@@ -180,18 +180,22 @@ prompt = "Fix the top lint error."
 
 // TestHeartbeatRuntimesExcludesShell asserts the per-heartbeat runtime allow-list
 // is derived from the adapter registry but never offers shell (heartbeats mint a
-// fresh session; shell sessions are whole commands).
+// fresh session; shell sessions are whole commands) nor kimi-cli (the legacy Kimi
+// CLI), so the accepted set equals the documented codex|claude|kimi (#611).
 func TestHeartbeatRuntimesExcludesShell(t *testing.T) {
 	for _, rt := range HeartbeatRuntimes() {
-		if rt == "shell" {
-			t.Fatalf("HeartbeatRuntimes must not include shell: %v", HeartbeatRuntimes())
+		if rt == "shell" || rt == "kimi-cli" {
+			t.Fatalf("HeartbeatRuntimes must not include %q: %v", rt, HeartbeatRuntimes())
 		}
+	}
+	if got, want := strings.Join(HeartbeatRuntimes(), "|"), "codex|claude|kimi"; got != want {
+		t.Fatalf("HeartbeatRuntimes = %q, want %q (accepted must equal the documented set)", got, want)
 	}
 	if !HeartbeatRuntimeSupported("codex") || !HeartbeatRuntimeSupported("") {
 		t.Fatalf("codex and empty must be supported runtimes")
 	}
-	if HeartbeatRuntimeSupported("shell") || HeartbeatRuntimeSupported("bogus") {
-		t.Fatalf("shell and bogus must be rejected runtimes")
+	if HeartbeatRuntimeSupported("shell") || HeartbeatRuntimeSupported("kimi-cli") || HeartbeatRuntimeSupported("bogus") {
+		t.Fatalf("shell, kimi-cli, and bogus must be rejected runtimes")
 	}
 }
 

--- a/internal/config/heartbeats_test.go
+++ b/internal/config/heartbeats_test.go
@@ -98,7 +98,23 @@ interval = "1h"
 enabled = true
 repo = "o/r"
 interval = "1h"
-action = "implement"
+action = "deploy"
+prompt = "p"
+`,
+		"unsupported runtime": `
+[agents.x.heartbeats.h]
+enabled = true
+repo = "o/r"
+interval = "1h"
+runtime = "bogus"
+prompt = "p"
+`,
+		"shell runtime rejected": `
+[agents.x.heartbeats.h]
+enabled = true
+repo = "o/r"
+interval = "1h"
+runtime = "shell"
 prompt = "p"
 `,
 		"bad jitter": `
@@ -120,8 +136,7 @@ prompt = "p"
 	}
 }
 
-// TestLoadHeartbeatsAcceptsReviewAction asserts the review action now loads
-// (the ask/review pair), while implement stays rejected (covered above).
+// TestLoadHeartbeatsAcceptsReviewAction asserts the review action loads.
 func TestLoadHeartbeatsAcceptsReviewAction(t *testing.T) {
 	paths := writeHeartbeatConfig(t, `
 [agents.reviewer.heartbeats.stale-prs]
@@ -137,6 +152,46 @@ prompt = "Review stale PRs."
 	}
 	if len(heartbeats) != 1 || heartbeats[0].Action != "review" {
 		t.Fatalf("expected one review heartbeat, got %+v", heartbeats)
+	}
+}
+
+// TestLoadHeartbeatsAcceptsImplementActionAndRuntime asserts the write action
+// "implement" and a per-heartbeat runtime override now load structurally (#611).
+// The agent-aware policy/capability gate lives in the CLI + daemon scan, not this
+// pure loader, so config-load only checks the action/runtime are valid enums.
+func TestLoadHeartbeatsAcceptsImplementActionAndRuntime(t *testing.T) {
+	paths := writeHeartbeatConfig(t, `
+[agents.builder.heartbeats.nightly]
+enabled = true
+repo = "o/r"
+interval = "24h"
+action = "implement"
+runtime = "codex"
+prompt = "Fix the top lint error."
+`)
+	heartbeats, err := LoadHeartbeats(paths)
+	if err != nil {
+		t.Fatalf("LoadHeartbeats returned error: %v", err)
+	}
+	if len(heartbeats) != 1 || heartbeats[0].Action != "implement" || heartbeats[0].Runtime != "codex" {
+		t.Fatalf("expected one implement/codex heartbeat, got %+v", heartbeats)
+	}
+}
+
+// TestHeartbeatRuntimesExcludesShell asserts the per-heartbeat runtime allow-list
+// is derived from the adapter registry but never offers shell (heartbeats mint a
+// fresh session; shell sessions are whole commands).
+func TestHeartbeatRuntimesExcludesShell(t *testing.T) {
+	for _, rt := range HeartbeatRuntimes() {
+		if rt == "shell" {
+			t.Fatalf("HeartbeatRuntimes must not include shell: %v", HeartbeatRuntimes())
+		}
+	}
+	if !HeartbeatRuntimeSupported("codex") || !HeartbeatRuntimeSupported("") {
+		t.Fatalf("codex and empty must be supported runtimes")
+	}
+	if HeartbeatRuntimeSupported("shell") || HeartbeatRuntimeSupported("bogus") {
+		t.Fatalf("shell and bogus must be rejected runtimes")
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -540,16 +540,26 @@ Schedule recurring agent work (heartbeats, off by default):
 ```sh
 gitmoot agent heartbeat add repo-maintainer daily-status \
   --repo owner/repo --interval 24h --prompt "Daily status report." --enabled
+# implement is policy-gated; --runtime pins a runtime for this schedule.
+gitmoot agent heartbeat add builder nightly-tidy \
+  --repo owner/repo --interval 24h --action implement --runtime codex \
+  --prompt "Fix the top lint error and open a small PR."
 gitmoot agent heartbeat list
 gitmoot agent heartbeat show repo-maintainer daily-status
 gitmoot agent heartbeat enable|disable repo-maintainer daily-status
 gitmoot agent heartbeat remove repo-maintainer daily-status
 ```
 
-A heartbeat enqueues a normal background job on its `interval` (read-only `ask` or
-`review` action; `review` needs the agent's `review` capability). `gitmoot daemon
-status` surfaces each schedule's last-run/next-due/last-status. See
-`docs/heartbeats.md` for the full reference.
+A heartbeat enqueues a normal background job on its `interval`. Actions: read-only
+`ask` (default) or `review` (`review` needs the agent's `review` capability), plus
+the **policy-gated** write action `implement` — it only runs for an agent that
+holds the `implement` capability AND a write-granting policy (`--policy
+workspace-write` or `danger-full-access`); otherwise it is refused at `add` and
+no-op'd (`last_status = policy_readonly`) by the daemon scan. An optional
+`--runtime codex|claude|kimi` runs the scheduled job on that runtime (fresh
+session) instead of the agent default. `gitmoot daemon status` surfaces each
+schedule's last-run/next-due/last-status. See `docs/heartbeats.md` for the full
+reference.
 
 A registered single instance **shadows** a managed type of the same name:
 dispatch resolves `gitmoot agent <name>` to a registered single instance before a

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -520,15 +520,25 @@ Schedule recurring agent work (heartbeats, off by default):
 ```sh
 gitmoot agent heartbeat add repo-maintainer daily-status \
   --repo owner/repo --interval 24h --prompt "Daily status report." --enabled
+# implement is policy-gated; --runtime pins a runtime for this schedule.
+gitmoot agent heartbeat add builder nightly-tidy \
+  --repo owner/repo --interval 24h --action implement --runtime codex \
+  --prompt "Fix the top lint error and open a small PR."
 gitmoot agent heartbeat list [--agent <agent>]
 gitmoot agent heartbeat show repo-maintainer daily-status
 gitmoot agent heartbeat enable|disable repo-maintainer daily-status
 gitmoot agent heartbeat remove repo-maintainer daily-status
 ```
 
-A heartbeat enqueues a normal background job on its `interval` (read-only `ask`
-or `review` action; `review` needs the agent's `review` capability). `gitmoot
-daemon status` surfaces each schedule's last-run/next-due/last-status. See
+A heartbeat enqueues a normal background job on its `interval`. Actions: read-only
+`ask` (default) or `review` (`review` needs the agent's `review` capability), plus
+the **policy-gated** write action `implement` — it only runs for an agent that
+holds the `implement` capability AND a write-granting policy (`--policy
+workspace-write` or `danger-full-access`); otherwise it is refused at `add` and
+no-op'd (`last_status = policy_readonly`) by the daemon scan. An optional
+`--runtime codex|claude|kimi` runs the scheduled job on that runtime (fresh
+session) instead of the agent default. `gitmoot daemon status` surfaces each
+schedule's last-run/next-due/last-status. See
 [Heartbeat Schedules](../workflows/heartbeat-schedules-workflow.md) for the
 full reference.
 

--- a/website/docs/workflows/heartbeat-schedules-workflow.md
+++ b/website/docs/workflows/heartbeat-schedules-workflow.md
@@ -21,6 +21,12 @@ gitmoot agent heartbeat add repo-maintainer daily-status \
 gitmoot agent heartbeat add reviewer stale-prs \
   --repo jerryfane/gitmoot --interval 12h --action review \
   --prompt "Review stale open PRs and summarize blockers."
+
+# A policy-gated implement heartbeat (write action) on a specific runtime. The
+# agent must hold the implement capability AND a write-granting policy.
+gitmoot agent heartbeat add builder nightly-tidy \
+  --repo jerryfane/gitmoot --interval 24h --action implement --runtime codex \
+  --prompt "Fix the top lint/type error and open a small PR."
 ```
 
 The CLI edits the `[agents.<agent>.heartbeats.<name>]` config section through the
@@ -48,15 +54,28 @@ the block and its comments.
 | `repo`           | yes      | —       | `owner/name` the job runs against. Must be a registered, enabled daemon repo with a checkout. |
 | `interval`       | yes      | —       | Go duration (e.g. `24h`, `1h30m`). Validated at load.        |
 | `jitter`         | no       | `0s`    | Random `[0, jitter]` added to each `next_due` to de-thunder. |
-| `action`         | no       | `ask`   | `ask` (read-only analysis) or `review` (read-only PR/code review). `review` needs the `review` capability. `implement` is not supported. |
+| `action`         | no       | `ask`   | `ask` (read-only analysis), `review` (read-only PR/code review; needs the `review` capability), or `implement` (write; **policy-gated** — see below). |
+| `runtime`        | no       | —       | Optional per-heartbeat runtime override (`codex`/`claude`/`kimi`); runs the scheduled job on that runtime (fresh session) instead of the agent default. Empty ⇒ agent default. |
 | `prompt`         | yes      | —       | Instructions passed to the agent.                            |
 | `max_concurrent` | no       | `1`     | Overlap cap; a new run is skipped while this many are active.|
+
+### Policy-gated `implement`
+
+An `implement` heartbeat enqueues a **write** job, so it is off by default and
+gated. It only runs when the target agent holds the `implement` capability **and**
+carries a write-granting autonomy policy (`--policy workspace-write` or
+`danger-full-access`) — mirroring `agent implement`, which fails closed under the
+default `auto`/`read-only` (a headless implement job would otherwise produce no
+files). `agent heartbeat add` refuses an implement heartbeat for an agent that
+does not qualify, and the daemon scan no-ops a due one (`last_status =
+policy_readonly`) until a write policy is granted.
 
 ## Observability
 
 `gitmoot daemon status` lists every configured heartbeat with its enabled state,
-action, interval, and repo, plus its `last_run`, `next_due`, and `last_status`
-once it has fired. With no heartbeats configured the section is omitted.
+action, interval, repo, and `runtime` override (only when set), plus its
+`last_run`, `next_due`, and `last_status` once it has fired. With no heartbeats
+configured the section is omitted.
 
 ## Behavior and safety
 
@@ -67,11 +86,14 @@ once it has fired. With no heartbeats configured the section is omitted.
   does not re-fire an active heartbeat.
 - **Capacity-aware:** skipped this tick when the agent is at its `max_background`.
 - **Missed ticks coalesce:** after an outage the schedule replays only once.
-- **Read-only by design:** both actions (`ask`, `review`) are read-only; heartbeats
-  never auto-implement code.
+- **Read-only by default:** `ask` and `review` are read-only. `implement` is a
+  write action, off by default and policy-gated (see above) so recurring
+  code-change PRs only run for a deliberately write-enabled agent.
 - **Managed repos only:** a heartbeat pointing at an unmanaged/disabled repo is
   skipped (`last_status = repo_unmanaged`) and self-recovers once the repo becomes
   managed. A `review` heartbeat for an agent lacking the review capability is
-  skipped (`last_status = capability_missing`) until the capability is granted.
+  skipped (`last_status = capability_missing`), and an `implement` heartbeat for an
+  agent without a write policy/capability is skipped (`last_status =
+  policy_readonly`), each self-recovering once the requirement is met.
 
 See the in-repo reference at `docs/heartbeats.md` for the full field reference.

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -23,7 +23,7 @@ full expanded context.
 - [Coordinator Recipes Workflow](https://gitmoot.io/docs/workflows/coordinator-recipes-workflow): One-command orchestras via `orchestrate --recipe review-panel|decompose-and-verify|verifier` with ephemeral workers.
 - [Cockpit Orchestrate Workflow](https://gitmoot.io/docs/workflows/cockpit-orchestrate-workflow): Watch an orchestra live in Herdr panes (`--cockpit`) plus the `[orchestrate]` config reference (budgets, timeouts, artifact inlining).
 - [Run Jobs In Parallel On A Repo](https://gitmoot.io/docs/workflows/parallel-jobs-workflow): Use `--parallel N` (or `--workers N`, now auto-`pool`) to run a repo's queued jobs N-wide; the two serialization layers (checkout lock + runtime session lock); SIGHUP warm reload, per-repo `max_parallel`, and the `[admission]` host budget.
-- [Heartbeat Schedules Workflow](https://gitmoot.io/docs/workflows/heartbeat-schedules-workflow): Recurring agent work — `gitmoot agent heartbeat add` enqueues a read-only ask/review job on an interval.
+- [Heartbeat Schedules Workflow](https://gitmoot.io/docs/workflows/heartbeat-schedules-workflow): Recurring agent work — `gitmoot agent heartbeat add` enqueues an ask/review (read-only) or policy-gated implement job on an interval, with an optional per-heartbeat `--runtime` override.
 - [SkillOpt Train Workflow](https://gitmoot.io/docs/workflows/skillopt-train-workflow): Run the full feedback, optimizer, candidate-review, and promotion loop, including judge↔human outcome capture, `judge-report`, and judge-prompt optimization.
 
 ## Concepts


### PR DESCRIPTION
## Summary

Two additive capabilities for agent heartbeats (`[agents.<agent>.heartbeats.<name>]`), completing the residual scope from #533.

### 1. Policy-gated `implement` action
- `implement` is now a structurally-valid heartbeat action, but **off by default and policy-gated**. It only runs for a target agent that holds the `implement` capability **and** carries a write-granting autonomy policy (`workspace-write` / `danger-full-access`).
- Mirrors the `agent start` / `agent implement` gate exactly — fail-closed under the default `auto` (or `read-only`), where a headless implement job would run and produce no files. Reuses the shared `runtime.PolicyGrantsImplementWrite` predicate so the heartbeat gate can never drift from the direct-job gate.
- Enforced in two places: `agent heartbeat add` refuses to write an implement heartbeat for a non-qualifying agent; the daemon scan no-ops a due one (advancing `next_due` with `last_status=policy_readonly`) so it never enqueues doomed jobs and self-recovers once a write policy is granted. Implement heartbeats respect branch locks + the merge gate like any implement job.

### 2. Per-heartbeat `--runtime` override
- Optional `runtime = "codex|claude|kimi"` (config) / `--runtime` (CLI) runs a scheduled job on a specific runtime instead of the agent's registered default. Reuses the #531 per-job override machinery: a **fresh** session ref is minted, so the scheduled job never resumes or writes the agent's default-runtime session. `shell` is rejected (heartbeats mint fresh sessions; shell sessions are whole commands).

## Additive / byte-identical default
A heartbeat with neither an implement action nor a runtime override loads, serializes (`SaveHeartbeat` writes the `runtime` key only when set), and enqueues (no override on the job) exactly as before. Covered by explicit default-unchanged tests.

## Docs (ship-with-code)
`docs/heartbeats.md`, `skills/gitmoot/references/CLI.md`, `website/docs/workflows/heartbeat-schedules-workflow.md`, `website/docs/reference/cli.md`, `website/static/llms.txt`.

## Tests
- config: implement action + runtime override load; unsupported action/runtime and shell rejected; `SaveHeartbeat` runtime round-trip + no-runtime-key default; `HeartbeatRuntimes` excludes shell.
- daemon scan: implement enqueues with write policy; no-ops (`policy_readonly`) under read-only policy or missing capability; runtime override flows onto the job with a minted ref; default carries no override.
- CLI: `add` refuses implement under read-only policy / missing capability, refuses bad runtime; succeeds with write policy and surfaces the runtime in `show`.

## Gate
`go build`, `go vet`, `go generate` (clean), and the non-race tests for the affected packages pass. The full `-race` scoped suite was still running (slow first race compile of `internal/cli`) at PR-open time; CI runs the identical gate.

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)