### PR TITLE
feat(session-jobs): agent prompt --record for bare template ids

### DIFF
--- a/internal/cli/agent_prompt.go
+++ b/internal/cli/agent_prompt.go
@@ -100,12 +100,16 @@ func sessionCloseHint(jobID string) string {
 	return fmt.Sprintf(`[gitmoot session job %s — when this work is complete, run: gitmoot job close %s --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]`, jobID, jobID)
 }
 
-// runAgentPromptRecord implements `agent prompt <agent> --record`: it opens a
-// session job (the same OpenExternalJob/Mailbox clock-in `job open` uses) for the
-// agent + repo and returns the prompt with a header that names the job id so the
-// importing session tracks the here-method work by default. Unlike the plain
-// prompt path this needs a writable store, and the id MUST resolve to an agent
-// (a bare template has no repo_scope and cannot own a session job).
+// runAgentPromptRecord implements `agent prompt <id> --record`: it opens a session
+// job (the same OpenExternalJob/Mailbox clock-in `job open` uses) for the resolved
+// identity + repo and returns the prompt with a header that names the job id so the
+// importing session tracks the here-method work by default. Unlike the plain prompt
+// path this needs a writable store. The id may resolve two ways:
+//   - a registered agent: the repo falls back to the agent's repo_scope when --repo
+//     is omitted, and the session job records the agent name as its identity.
+//   - a bare template (no agent registered): --repo owner/repo is REQUIRED (a
+//     template has no repo_scope to fall back on), and the session job records the
+//     template id as its identity (#673).
 func runAgentPromptRecord(home, id, repoFlag, typeName string, jsonOutput bool, stdout, stderr io.Writer) int {
 	action, ok := validateSessionAction(typeName, stderr)
 	if !ok {
@@ -117,34 +121,62 @@ func runAgentPromptRecord(home, id, repoFlag, typeName string, jsonOutput bool, 
 		jobID  string
 	)
 	if err := withStoreAndPaths(home, func(paths config.Paths, store *db.Store) error {
-		agent, err := store.GetAgent(ctx, strings.TrimSpace(id))
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("agent %q not found; --record requires an existing agent (a bare template id has no repo scope to record against)", id)
+		id := strings.TrimSpace(id)
+		agent, err := store.GetAgent(ctx, id)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+
+		var (
+			resolved agentPromptOutput
+			identity string
+			repoName string
+		)
+		if err == nil {
+			// Registered-agent path (unchanged): repo falls back to repo_scope.
+			resolved, err = promptForAgent(ctx, store, agent)
+			if err != nil {
+				return err
 			}
-			return err
+			repoScope := strings.TrimSpace(repoFlag)
+			if repoScope == "" {
+				repoScope = strings.TrimSpace(agent.RepoScope)
+			}
+			if repoScope == "" {
+				return fmt.Errorf("no repo to record against: pass --repo owner/repo or set agent %q's repo_scope", agent.Name)
+			}
+			fullName, verr := validateSessionAgentRepo(ctx, store, agent.Name, repoScope)
+			if verr != nil {
+				return verr
+			}
+			identity = agent.Name
+			repoName = fullName
+		} else {
+			// Bare-template path (#673): no agent to fall back on, so --repo is
+			// required and the template id is the recorded identity.
+			template, terr := loadInstalledTemplate(ctx, store, id)
+			if terr != nil {
+				return terr
+			}
+			repoScope := strings.TrimSpace(repoFlag)
+			if repoScope == "" {
+				return fmt.Errorf("--repo owner/repo is required to record %q: it is a template, not a registered agent, so there is no repo scope to record against", id)
+			}
+			fullName, verr := validateSessionRepo(ctx, store, repoScope)
+			if verr != nil {
+				return verr
+			}
+			resolved = promptOutputForTemplate("template", template.ID, template)
+			identity = template.ID
+			repoName = fullName
 		}
-		resolved, err := promptForAgent(ctx, store, agent)
-		if err != nil {
-			return err
-		}
-		repoScope := strings.TrimSpace(repoFlag)
-		if repoScope == "" {
-			repoScope = strings.TrimSpace(agent.RepoScope)
-		}
-		if repoScope == "" {
-			return fmt.Errorf("no repo to record against: pass --repo owner/repo or set agent %q's repo_scope", agent.Name)
-		}
-		fullName, err := validateSessionAgentRepo(ctx, store, agent.Name, repoScope)
-		if err != nil {
-			return err
-		}
+
 		engine := sessionWorkflowEngine(store, paths.Home)
 		job, err := engine.OpenExternalJob(ctx, workflow.JobRequest{
-			ID:     sessionJobID(action, agent.Name),
-			Agent:  agent.Name,
+			ID:     sessionJobID(action, identity),
+			Agent:  identity,
 			Action: action,
-			Repo:   fullName,
+			Repo:   repoName,
 			Sender: "session",
 		})
 		if err != nil {

--- a/internal/cli/agent_prompt_record_test.go
+++ b/internal/cli/agent_prompt_record_test.go
@@ -161,7 +161,7 @@ func TestAgentPromptWithoutRecordIsByteIdenticalAndOpensNoJob(t *testing.T) {
 }
 
 // TestAgentPromptRecordRepoFlagOverridesScope proves --repo overrides the agent's
-// repo_scope, and that an id resolving to a bare template (no agent) is rejected.
+// repo_scope for the registered-agent path (unchanged behavior).
 func TestAgentPromptRecordRepoFlagOverridesScope(t *testing.T) {
 	home, store := seedPromptRecordFixture(t)
 	seedDaemonWorkerRepo(t, store, "owner/other", t.TempDir())
@@ -184,14 +184,68 @@ func TestAgentPromptRecordRepoFlagOverridesScope(t *testing.T) {
 	if payload.Repo != "owner/other" {
 		t.Fatalf("session job repo = %q, want owner/other (--repo override)", payload.Repo)
 	}
+}
 
-	// A bare template id (no agent record) cannot be recorded against.
-	stdout.Reset()
-	stderr.Reset()
-	if code := runAgentPrompt([]string{"planner", "--record", "--repo", "owner/repo", "--home", home}, io.Discard, &stderr); code == 0 {
-		t.Fatalf("agent prompt --record on a bare template exit code = 0, want non-zero")
+// TestAgentPromptRecordBareTemplateOpensSessionJob proves the #673 extension: an id
+// that resolves to a bare TEMPLATE (no registered agent of that name) plus an
+// explicit --repo opens a running externally_driven session job recorded against
+// the TEMPLATE id as the agent identity + that repo.
+func TestAgentPromptRecordBareTemplateOpensSessionJob(t *testing.T) {
+	home, store := seedPromptRecordFixture(t)
+	// The fixture registers an agent named "lead" carrying the "planner" template;
+	// no agent is named "planner", so `planner` resolves to the bare template.
+
+	var stdout, stderr bytes.Buffer
+	if code := runAgentPrompt([]string{"planner", "--record", "--repo", "owner/repo", "--type", "implement", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent prompt --record on a bare template exit code = %d, want 0; stderr=%q", code, stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "not found") {
-		t.Fatalf("bare-template --record stderr = %q, want an agent-not-found error", stderr.String())
+	var out agentPromptOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode JSON %q: %v", stdout.String(), err)
+	}
+	if strings.TrimSpace(out.JobID) == "" {
+		t.Fatalf("bare-template --record --json carried no job_id: %q", stdout.String())
+	}
+	if !strings.Contains(out.Content, "Plan the work carefully.") {
+		t.Fatalf("bare-template --record content = %q, want the resolved template prompt", out.Content)
+	}
+
+	session := sessionJobsFor(t, store)
+	if len(session) != 1 {
+		t.Fatalf("session jobs = %d, want exactly 1 opened by --record", len(session))
+	}
+	job := session[0]
+	if job.ID != out.JobID {
+		t.Fatalf("session job id = %q, want the JSON job_id %q", job.ID, out.JobID)
+	}
+	if job.State != string(workflow.JobRunning) || !job.ExternallyDriven {
+		t.Fatalf("recorded session job = %+v, want running externally_driven", job)
+	}
+	if job.Agent != "planner" {
+		t.Fatalf("recorded session job agent = %q, want the template id planner (#673)", job.Agent)
+	}
+	if payload, err := workflow.ParseJobPayload(job.Payload); err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	} else if payload.Repo != "owner/repo" {
+		t.Fatalf("recorded session job repo = %q, want owner/repo (the --repo value)", payload.Repo)
+	}
+}
+
+// TestAgentPromptRecordBareTemplateRequiresRepo proves that recording a bare
+// template WITHOUT --repo fails with a clear, actionable error and opens no job —
+// a template has no repo scope to fall back on (#673).
+func TestAgentPromptRecordBareTemplateRequiresRepo(t *testing.T) {
+	home, store := seedPromptRecordFixture(t)
+
+	var stderr bytes.Buffer
+	if code := runAgentPrompt([]string{"planner", "--record", "--home", home}, io.Discard, &stderr); code == 0 {
+		t.Fatalf("agent prompt --record on a bare template without --repo exit code = 0, want non-zero")
+	}
+	msg := stderr.String()
+	if !strings.Contains(msg, "--repo") || !strings.Contains(msg, "template") {
+		t.Fatalf("bare-template --record without --repo stderr = %q, want a clear --repo-required error", msg)
+	}
+	if session := sessionJobsFor(t, store); len(session) != 0 {
+		t.Fatalf("bare-template --record without --repo opened %d session job(s), want 0", len(session))
 	}
 }

--- a/internal/cli/job_session.go
+++ b/internal/cli/job_session.go
@@ -302,6 +302,16 @@ func validateSessionAgentRepo(ctx context.Context, store *db.Store, agentName, r
 		}
 		return "", err
 	}
+	return validateSessionRepo(ctx, store, repoFlag)
+}
+
+// validateSessionRepo confirms the repo is a well-formed owner/repo that gitmoot
+// tracks, returning the canonical full name. It is the repo-only half of
+// validateSessionAgentRepo: the bare-template `--record` path (#673) has no agent
+// to validate (a template id is not a registered agent), so it validates just the
+// explicitly provided repo. Requiring the repo be tracked keeps the recorded
+// session job consistent with the registered-agent path and rejects typos.
+func validateSessionRepo(ctx context.Context, store *db.Store, repoFlag string) (string, error) {
 	repo, err := daemon.ParseRepository(repoFlag)
 	if err != nil {
 		return "", err

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -33,11 +33,11 @@ id. Apply the prompt, do the work, then — this is REQUIRED — clock out with
 `gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."`
 so the work shows in `job list`, the dashboard, and the event stream just like
 an engine-run job (no runtime is spawned; gitmoot is only the record-keeper).
-`--record` needs a **registered agent** with a repo scope — a bare template id is
-rejected. When "here" resolves to a **template that has no registered agent** (e.g.
-the packaged `planner` above, when no `planner` agent exists), import it with plain
-`gitmoot agent prompt <template>` (untracked); to still track it, register the agent
-first or log it explicitly with `gitmoot job record --agent <name> --repo owner/repo`.
+`--record` works for both a **registered agent** (repo defaults to its repo scope)
+and a bare **template** (e.g. the packaged `planner` above, when no `planner` agent
+exists): a template has no repo scope, so pass `--repo owner/repo` and the session
+job records the **template id** as its agent identity (#673). Omitting `--repo` for
+a bare template is a clear error.
 `--record` also defaults the job `--type` to `implement` — pass `--type ask` for
 advisory "here" work (planning, research) so it is not mislabeled.
 For a plain read-only peek — "just show me the prompt" — use

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -627,11 +627,18 @@ gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|
 # followed by the prompt body.
 ```
 
-`--record` requires an **agent** (not a bare template id); the repo comes from
-`--repo`, else the agent's `repo_scope` (error if neither is set). `--type`
-defaults to `implement`. When the imported work is done, close the job with
-`gitmoot job close <id> --decision …`. `--json` includes the opened `job_id`.
-Without `--record`, behavior is unchanged (no job).
+`--record` accepts either a **registered agent** or a bare **template id**:
+
+- Registered agent: the repo comes from `--repo`, else the agent's `repo_scope`
+  (error if neither is set); the session job records the agent name.
+- Bare template (no agent of that name registered, e.g. the packaged `planner`):
+  `--repo owner/repo` is **required** — a template has no `repo_scope` to fall
+  back on — and the session job records the **template id** as its agent identity
+  (#673). The repo must be tracked (`gitmoot repo add owner/repo` first).
+
+`--type` defaults to `implement`. When the imported work is done, close the job
+with `gitmoot job close <id> --decision …`. `--json` includes the opened
+`job_id`. Without `--record`, behavior is unchanged (no job).
 
 Draft and validate a captured template before installing it:
 
@@ -852,9 +859,11 @@ it (retrying would re-queue it for a real runtime with an empty payload) — rec
 one by opening a fresh session job instead. The agent and repo must exist.
 
 **Make in-chat / "here" work show on the dashboard.** The one-step default is
-`gitmoot agent prompt <agent> --record`: it opens the session job *as you import
-the prompt* and prints a header naming the job id (see the `agent prompt`
-section above). Apply the prompt, do the work, then clock out with
+`gitmoot agent prompt <agent-or-template> --record`: it opens the session job *as
+you import the prompt* and prints a header naming the job id (see the `agent
+prompt` section above). It works for a registered agent (repo defaults to its
+scope) and for a bare template id with an explicit `--repo` (the template id is
+recorded as the identity, #673). Apply the prompt, do the work, then clock out with
 `gitmoot job close <id> --decision …`. That is all it takes for otherwise-invisible
 current-chat ("here") work to appear in `job list`, the dashboard, and the event
 stream — no daemon, no runtime, no PR comment. Use plain `agent prompt` (no

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -596,11 +596,18 @@ gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|
 # followed by the prompt body.
 ```
 
-`--record` requires an **agent** (not a bare template id); the repo comes from
-`--repo`, else the agent's `repo_scope` (error if neither is set). `--type`
-defaults to `implement`. When the imported work is done, close the job with
-`gitmoot job close <id> --decision …`. `--json` includes the opened `job_id`.
-Without `--record`, behavior is unchanged (no job).
+`--record` accepts either a **registered agent** or a bare **template id**:
+
+- Registered agent: the repo comes from `--repo`, else the agent's `repo_scope`
+  (error if neither is set); the session job records the agent name.
+- Bare template (no agent of that name registered, e.g. the packaged `planner`):
+  `--repo owner/repo` is **required** — a template has no `repo_scope` to fall
+  back on — and the session job records the **template id** as its agent identity
+  (#673). The repo must be tracked (`gitmoot repo add owner/repo` first).
+
+`--type` defaults to `implement`. When the imported work is done, close the job
+with `gitmoot job close <id> --decision …`. `--json` includes the opened
+`job_id`. Without `--record`, behavior is unchanged (no job).
 
 Draft and validate a captured template before installing it:
 
@@ -824,9 +831,11 @@ it (retrying would re-queue it for a real runtime with an empty payload) — rec
 one by opening a fresh session job instead. The agent and repo must exist.
 
 **Make in-chat / "here" work show on the dashboard.** The one-step default is
-`gitmoot agent prompt <agent> --record`: it opens the session job *as you import
-the prompt* and prints a header naming the job id (see the `agent prompt`
-section above). Apply the prompt, do the work, then clock out with
+`gitmoot agent prompt <agent-or-template> --record`: it opens the session job *as
+you import the prompt* and prints a header naming the job id (see the `agent
+prompt` section above). It works for a registered agent (repo defaults to its
+scope) and for a bare template id with an explicit `--repo` (the template id is
+recorded as the identity, #673). Apply the prompt, do the work, then clock out with
 `gitmoot job close <id> --decision …`. That is all it takes for otherwise-invisible
 current-chat ("here") work to appear in `job list`, the dashboard, and the event
 stream — no daemon, no runtime, no PR comment. Use plain `agent prompt` (no

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -7559,11 +7559,11 @@ id. Apply the prompt, do the work, then — this is REQUIRED — clock out with
 `gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."`
 so the work shows in `job list`, the dashboard, and the event stream just like
 an engine-run job (no runtime is spawned; gitmoot is only the record-keeper).
-`--record` needs a **registered agent** with a repo scope — a bare template id is
-rejected. When "here" resolves to a **template that has no registered agent** (e.g.
-the packaged `planner` above, when no `planner` agent exists), import it with plain
-`gitmoot agent prompt <template>` (untracked); to still track it, register the agent
-first or log it explicitly with `gitmoot job record --agent <name> --repo owner/repo`.
+`--record` works for both a **registered agent** (repo defaults to its repo scope)
+and a bare **template** (e.g. the packaged `planner` above, when no `planner` agent
+exists): a template has no repo scope, so pass `--repo owner/repo` and the session
+job records the **template id** as its agent identity (#673). Omitting `--repo` for
+a bare template is a clear error.
 `--record` also defaults the job `--type` to `implement` — pass `--type ask` for
 advisory "here" work (planning, research) so it is not mislabeled.
 For a plain read-only peek — "just show me the prompt" — use
@@ -8523,11 +8523,18 @@ gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|
 # followed by the prompt body.
 ```
 
-`--record` requires an **agent** (not a bare template id); the repo comes from
-`--repo`, else the agent's `repo_scope` (error if neither is set). `--type`
-defaults to `implement`. When the imported work is done, close the job with
-`gitmoot job close <id> --decision …`. `--json` includes the opened `job_id`.
-Without `--record`, behavior is unchanged (no job).
+`--record` accepts either a **registered agent** or a bare **template id**:
+
+- Registered agent: the repo comes from `--repo`, else the agent's `repo_scope`
+  (error if neither is set); the session job records the agent name.
+- Bare template (no agent of that name registered, e.g. the packaged `planner`):
+  `--repo owner/repo` is **required** — a template has no `repo_scope` to fall
+  back on — and the session job records the **template id** as its agent identity
+  (#673). The repo must be tracked (`gitmoot repo add owner/repo` first).
+
+`--type` defaults to `implement`. When the imported work is done, close the job
+with `gitmoot job close <id> --decision …`. `--json` includes the opened
+`job_id`. Without `--record`, behavior is unchanged (no job).
 
 Draft and validate a captured template before installing it:
 
@@ -8748,9 +8755,11 @@ it (retrying would re-queue it for a real runtime with an empty payload) — rec
 one by opening a fresh session job instead. The agent and repo must exist.
 
 **Make in-chat / "here" work show on the dashboard.** The one-step default is
-`gitmoot agent prompt <agent> --record`: it opens the session job *as you import
-the prompt* and prints a header naming the job id (see the `agent prompt`
-section above). Apply the prompt, do the work, then clock out with
+`gitmoot agent prompt <agent-or-template> --record`: it opens the session job *as
+you import the prompt* and prints a header naming the job id (see the `agent
+prompt` section above). It works for a registered agent (repo defaults to its
+scope) and for a bare template id with an explicit `--repo` (the template id is
+recorded as the identity, #673). Apply the prompt, do the work, then clock out with
 `gitmoot job close <id> --decision …`. That is all it takes for otherwise-invisible
 current-chat ("here") work to appear in `job list`, the dashboard, and the event
 stream — no daemon, no runtime, no PR comment. Use plain `agent prompt` (no


### PR DESCRIPTION
## Summary

Follow-up from #657 / #660. `gitmoot agent prompt <id> --record` today requires a
**registered agent** (it resolves the repo from the agent's scope) and rejects a
bare **template** id — so the common template "here" case cannot auto-record.

This extends `--record` to accept a bare template id plus a required
`--repo owner/repo`, opening a session job recorded against the **template id** as
the agent identity + that repo, without requiring a registered agent.

## Behavior

- **Registered agent (unchanged):** repo falls back to the agent's `repo_scope`
  when `--repo` is omitted; the session job records the agent name.
- **Bare template (new, #673):** `--repo owner/repo` is **required** (a template
  has no repo scope to fall back on — clear error when omitted) and the session
  job records the **template id** as its agent identity. The repo must be tracked,
  reusing the same tracked-repo check as the agent path (the safe, consistent
  option from the #657 open question — validates against typos, keeps recorded
  session jobs uniform).
- **Plain `agent prompt` (no `--record`) stays byte-identical:** no job opened,
  output unchanged.

## Docs-with-code

- `SKILL.md`: drops the "use plain prompt / job record for templates" fallback;
  the "here" default now records template imports too.
- `references/CLI.md` + `website/docs/reference/cli.md`: document both paths.
- `website/static/llms-full.txt` regenerated (`npm run build:llms`).

## Tests

- template + `--record` + `--repo` opens a running externally_driven session job
  with `agent` = template id and the provided repo.
- template + `--record` WITHOUT `--repo` errors clearly and opens no job.
- registered-agent `--record` path unchanged (repo override + repo_scope
  fallback); plain `agent prompt` remains byte-identical (no job).

## Gate

`go build`, `go generate` (clean diff), `go vet`, and the scoped
`go test -race -timeout 20m ./internal/config/ ./internal/runtime/ ./internal/cli/ ./internal/daemon/ ./internal/workflow/ ./internal/db/`
all pass locally.

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)