### PR TITLE
chore(dashboard): bump for Knowledge neural layout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705184605-03017943bd67
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705230443-848e465536ca
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705130251-1655216f947f h1:RYY
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705130251-1655216f947f/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705184605-03017943bd67 h1:jnb9Zu4CDp2Rqd1i9L3WOmqb0o/p6NVZ49X3kLuZoEY=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705184605-03017943bd67/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705230443-848e465536ca h1:o/NACenwiTLbz8z/inVn3vcHKaqkgTrmrVYP4IkBd6U=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705230443-848e465536ca/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to [#32](https://github.com/jerryfane/gitmoot-dashboard/pull/32): the Knowledge graph lays out as a left-to-right neural network (evidence → facts → agents, directional packet flow). go.mod/go.sum only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)