### PR TITLE
fix(runtime): per-section resilient default_model resolver + model-resolution docs (#652)

### DIFF
--- a/internal/cli/runtime_registry.go
+++ b/internal/cli/runtime_registry.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -56,6 +57,37 @@ func runtimeMetadataOverrides(overrides []config.RuntimeOverride) []runtime.Meta
 	return out
 }
 
+// resolveRuntimeRegistryResilient builds the effective runtime metadata registry
+// the same way resolveRuntimeRegistry does, but is PER-SECTION resilient: a single
+// malformed [runtimes.<name>] section (an unknown-runtime typo like
+// [runtimes.codxe], or an invalid capability) is SKIPPED with a logged warning
+// naming the offending section instead of failing the whole config. Every VALID
+// [runtimes.<name>] section's overrides still take effect. This is the DELIVERY
+// path: it must never drop otherwise-valid default_model overrides just because one
+// unrelated section has a typo. A missing config file (fresh box), an empty home,
+// or a file-level parse error yields the built-in registry unchanged (fail-safe:
+// nothing is forced). Overrides are applied one section at a time so a rejected
+// section cannot poison the accumulated valid ones.
+func resolveRuntimeRegistryResilient(paths config.Paths) runtime.Registry {
+	registry := runtime.BuiltinRuntimeRegistry()
+	overrides, err := config.LoadRuntimeOverrides(paths)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			log.Printf("runtime registry: ignoring config overrides for delivery model resolution: %v", err)
+		}
+		return registry
+	}
+	for _, o := range overrides {
+		patched, err := registry.ApplyOverrides(runtimeMetadataOverrides([]config.RuntimeOverride{o}))
+		if err != nil {
+			log.Printf("runtime registry: skipping invalid [runtimes.%s] section for delivery model resolution: %v", o.Name, err)
+			continue
+		}
+		registry = patched
+	}
+	return registry
+}
+
 // runtimeDefaultModelResolver returns a HOME-AWARE resolver for a runtime's
 // configured registry default_model (#652), suitable for wiring into
 // workflow.Engine.RuntimeDefaultModel / workflow.Mailbox.RuntimeDefaultModel so a
@@ -63,16 +95,15 @@ func runtimeMetadataOverrides(overrides []config.RuntimeOverride) []runtime.Meta
 // the built-in registry overlaid with any [runtimes.<name>] config overrides for
 // `home` (which may be an already-resolved <home>/.gitmoot root OR a raw --home;
 // resolveConfigFile handles both), then returns the resolved DefaultModel for the
-// named runtime. It is FAIL-OPEN: a resolution error, a missing config, an empty
-// home, or an unknown runtime all yield "", so delivery forces nothing and is
-// byte-identical to before #652. It re-reads config on each call, so a warm-reloaded
+// named runtime. It is FAIL-SAFE and PER-SECTION resilient: a missing config, an
+// empty home, or an unknown runtime yields ""; a single malformed [runtimes.<name>]
+// section is skipped with a logged warning while OTHER valid sections'
+// default_model overrides still resolve (so one typo can no longer silently drop
+// every override at delivery). It re-reads config on each call, so a warm-reloaded
 // (SIGHUP) default_model edit takes effect without a full restart.
 func runtimeDefaultModelResolver(home string) func(string) string {
 	return func(runtimeName string) string {
-		registry, err := resolveRuntimeRegistry(config.Paths{ConfigFile: resolveConfigFile(home)})
-		if err != nil {
-			return ""
-		}
+		registry := resolveRuntimeRegistryResilient(config.Paths{ConfigFile: resolveConfigFile(home)})
 		meta, ok := registry.Metadata(strings.TrimSpace(runtimeName))
 		if !ok {
 			return ""

--- a/internal/cli/runtime_registry_test.go
+++ b/internal/cli/runtime_registry_test.go
@@ -168,6 +168,54 @@ func TestRuntimeDefaultModelResolverAbsentConfigByteIdentical(t *testing.T) {
 	}
 }
 
+// TestRuntimeDefaultModelResolverSkipsBadSection proves the DELIVERY path is
+// PER-SECTION resilient (#652 LOW): a config with one VALID [runtimes.codex]
+// default_model plus one bad section (an unknown-runtime typo) still resolves the
+// codex override — a single bad section is skipped, not a whole-config failure that
+// silently drops every valid override at delivery.
+func TestRuntimeDefaultModelResolverSkipsBadSection(t *testing.T) {
+	src := writeCLIConfig(t, `
+[runtimes.codex]
+default_model = "gpt-5.5"
+
+[runtimes.codxe]
+default_model = "typo-runtime"
+`)
+	home := homeFromConfig(t, src)
+	resolve := runtimeDefaultModelResolver(home)
+	// The valid codex override still takes effect despite the bad sibling section.
+	if got := resolve(runtime.CodexRuntime); got != "gpt-5.5" {
+		t.Fatalf("resolve(codex) = %q, want gpt-5.5 (bad sibling section must not drop it)", got)
+	}
+	// The bad section is skipped entirely, not surfaced as a phantom runtime.
+	if got := resolve("codxe"); got != "" {
+		t.Fatalf("resolve(codxe) = %q, want empty (bad section skipped)", got)
+	}
+}
+
+// TestRuntimeDefaultModelResolverSkipsBadCapabilitySection proves the same
+// per-section resilience for an invalid-capability section: the whole-config apply
+// would reject it, but the delivery resolver skips only that section and keeps a
+// valid sibling's default_model.
+func TestRuntimeDefaultModelResolverSkipsBadCapabilitySection(t *testing.T) {
+	src := writeCLIConfig(t, `
+[runtimes.codex]
+default_model = "gpt-5.5"
+
+[runtimes.claude]
+capabilities = ["review", "bogus"]
+`)
+	home := homeFromConfig(t, src)
+	resolve := runtimeDefaultModelResolver(home)
+	if got := resolve(runtime.CodexRuntime); got != "gpt-5.5" {
+		t.Fatalf("resolve(codex) = %q, want gpt-5.5 (bad capability sibling must not drop it)", got)
+	}
+	// The claude section is skipped, so it records no default (byte-identical).
+	if got := resolve(runtime.ClaudeRuntime); got != "" {
+		t.Fatalf("resolve(claude) = %q, want empty (bad capability section skipped)", got)
+	}
+}
+
 // homeFromConfig writes the given config body into a home layout so a --home flag
 // resolves ConfigFile to it. The CLI resolves --home via config.PathsForHome, so
 // place the file at <home>/.gitmoot/config.toml.

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -203,8 +203,11 @@ Delegation fields:
   de-duplicated, so the same delegation is not dispatched twice.
 - `model` (optional): a free-form, runtime-scoped model string for the child
   job (for example a Codex, Claude Code, or Kimi Code model name). When omitted,
-  the delegated agent's configured default model is used. There is no allow-list;
-  Gitmoot passes the value through to the runtime as-is.
+  the model resolves in order: this `model` field (the child's job `--model`),
+  then the delegated agent's `--model`, then the runtime's registry
+  `default_model` (the `[runtimes.<name>].default_model` config), then the
+  runtime CLI's own default. There is no allow-list; Gitmoot passes the value
+  through to the runtime as-is.
 
   **Model-tier routing (recommendation).** Picking a per-delegation `model` is
   the coordinator's call — Gitmoot does not choose or override it. As a costing

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -225,8 +225,11 @@ the same `delegations` field, `coordinator`, and `continuation` mechanics.
   are de-duplicated, so the same delegation is not dispatched twice.
 - `model` (optional): a free-form, runtime-scoped model string for the child job
   (for example a Codex, Claude Code, or Kimi Code model name). When omitted, the
-  delegated agent's configured default model is used. There is no allow-list;
-  Gitmoot passes the value through to the runtime as-is.
+  model resolves in order: this `model` field (the child's job `--model`), then
+  the delegated agent's `--model`, then the runtime's registry `default_model`
+  (the `[runtimes.<name>].default_model` config), then the runtime CLI's own
+  default. There is no allow-list; Gitmoot passes the value through to the
+  runtime as-is.
 
   **Model-tier routing (recommendation).** Picking a per-delegation `model` is
   the coordinator's call — Gitmoot does not choose or override it. As a costing

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10604,8 +10604,11 @@ Delegation fields:
   de-duplicated, so the same delegation is not dispatched twice.
 - `model` (optional): a free-form, runtime-scoped model string for the child
   job (for example a Codex, Claude Code, or Kimi Code model name). When omitted,
-  the delegated agent's configured default model is used. There is no allow-list;
-  Gitmoot passes the value through to the runtime as-is.
+  the model resolves in order: this `model` field (the child's job `--model`),
+  then the delegated agent's `--model`, then the runtime's registry
+  `default_model` (the `[runtimes.<name>].default_model` config), then the
+  runtime CLI's own default. There is no allow-list; Gitmoot passes the value
+  through to the runtime as-is.
 
   **Model-tier routing (recommendation).** Picking a per-delegation `model` is
   the coordinator's call — Gitmoot does not choose or override it. As a costing


### PR DESCRIPTION
Two small follow-ups to the just-merged #652 / #674 (runtime registry `default_model`), addressing the LOW findings from that review.

## (1) Robustness — per-section resilient DELIVERY resolver

Today the delivery-time model resolver is **whole-config fail-open**: if ANY `[runtimes.*]` section errors (an unknown-runtime typo like `[runtimes.codxe]`, or an invalid capability), `resolveRuntimeRegistry` returns an error, so `runtimeDefaultModelResolver` silently returns `""` for **every** runtime — dropping otherwise-valid `default_model` overrides at delivery, with no log.

Fix: new `resolveRuntimeRegistryResilient` applies each `[runtimes.*]` override **one section at a time**. A single bad section is **skipped with a logged warning naming it**, while every VALID section's `default_model` override still takes effect. It stays fail-safe (never forces a wrong/empty model): a missing config, empty home, or file-level parse error yields the built-in registry unchanged.

`gitmoot runtime list` keeps its strict whole-config error (exit 1) via the original `resolveRuntimeRegistry`, so an operator still sees the typo surfaced. The change is scoped to the DELIVERY resolver.

Tests: `TestRuntimeDefaultModelResolverSkipsBadSection` (valid codex `default_model` + unknown-runtime typo → codex still resolves, bad section skipped) and `TestRuntimeDefaultModelResolverSkipsBadCapabilitySection` (invalid-capability sibling skipped, valid override kept).

## (2) Docs cross-update

The delegation `model` field in `RESULT_CONTRACT.md` / `website/docs/reference/result-contract.md` (a model-resolution doc **not** touched by #674) said only "the delegated agent's configured default model is used". Cross-updated to document the full order consistently with `CLI.md` / `runtime-adapters.md`:

> job `--model` > agent `--model` > runtime registry `default_model` (`[runtimes.<name>].default_model`) > the runtime CLI's own default

`llms-full.txt` got the same one-block edit (full regeneration was avoided — main's copy already lags #674/#675, so a regen would sweep in unrelated drift).

## Gate

`go build` / `go generate && git diff --exit-code` / `go vet` / `go test -race` on `./internal/config/ ./internal/cli/ ./internal/runtime/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)