### PR TITLE
chore(dashboard): bump for Knowledge layered-columns style

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706002022-8f8d983eaabd
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706020102-d63f530abf4f
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705230443-848e465536ca h1:o/N
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260705230443-848e465536ca/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706002022-8f8d983eaabd h1:zh27YYHXMONaQioNxY0JKfnuCr+8RArDFX8emGX5dAE=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706002022-8f8d983eaabd/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706020102-d63f530abf4f h1:SeAdMlmDaGT344lsUrCnyt12dI49A4UBThBMVobHezw=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706020102-d63f530abf4f/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to [#34](https://github.com/jerryfane/gitmoot-dashboard/pull/34): the Knowledge graph restyled to layered columns with curved multi-hue edge bundles. go.mod/go.sum only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)