### PR TITLE
chore(dashboard): bump gitmoot-dashboard — site logo + favicon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706023212-5e8ce9d2a709
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706031317-289f7880d1de
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706020102-d63f530abf4f h1:SeA
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706020102-d63f530abf4f/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706023212-5e8ce9d2a709 h1:tInyRxWAOtVCF2tQmsTac4oziVgLv28l1mNy4+DTKHo=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706023212-5e8ce9d2a709/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706031317-289f7880d1de h1:y6de/oHVh7jmtUCxTtiM8LMrvpOpRN+ykl5IGQrz1AM=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260706031317-289f7880d1de/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps `gitmoot-dashboard` to `289f788` (dashboard PR #36): the rail now shows the official gitmoot.io moose logo instead of the placeholder green network icon, and the same asset serves as the tab favicon (the dashboard previously had none). UI-only embed change; no Go API surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)