### PR TITLE
feat(skillopt): PACE anytime-valid commit gate for candidate promotion (off-by-default)

### DIFF
--- a/docs/skillopt-train-workflow.md
+++ b/docs/skillopt-train-workflow.md
@@ -733,6 +733,32 @@ may be promoted to canary or current; otherwise the promotion seam blocks with a
 `auto_trace_enabled` dependency), and with it off the promote path is
 byte-identical to before. Promotion itself stays manual.
 
+### PACE anytime-valid commit gate (#687)
+
+`pace_enabled` adds an **additional**, off-by-default promotion gate on the
+auto-promote path. When on, a guardrails-pass candidate is auto-promoted only when
+a **model-free** testing-by-betting e-process over its recorded
+candidate-vs-champion pairwise outcomes (the Mode B bandit arm's win/loss tally,
+`#481`/`#482`) crosses the commit threshold `1/pace_alpha`:
+
+```toml
+[skillopt]
+pace_enabled = true
+pace_alpha = 0.05      # target false-commit probability; threshold = 1/alpha = 20
+pace_lambda = 0.5      # bet fraction: win → wealth ×(1+λ), loss → ×(1−λ)
+pace_max_pairs = 200   # discordant-pair budget before a non-decisive stream rejects
+```
+
+Each discordant pair updates wealth `E ← E·(1+λ(2w−1))` (ties discarded). The gate
+**stops early** the moment it is decisive and **rejects** once `pace_max_pairs`
+pairs are spent without crossing, so peeking-until-you-win cannot p-hack a
+promotion — Ville's inequality bounds the false-commit probability by `pace_alpha`
+at any stopping time. PACE is **strictly additional**: every existing guardrail
+(`auto_promote_min_samples`/`_min_score`/`require_external_ci`/`_min_confidence`/
+canary/replay gate) still applies, and a non-decisive or budget-exhausted stream
+**fails safe** to a `pace_blocked` notify (no promotion). Off (the default) it is
+never consulted — byte-identical.
+
 ## Candidate Review And Next Iteration
 
 The candidate review step publishes the candidate summary, preview/PR links

--- a/internal/cli/canary_e2e_test.go
+++ b/internal/cli/canary_e2e_test.go
@@ -39,7 +39,7 @@ func canaryE2EFixture(t *testing.T) (store *db.Store, championID, canaryID, cham
 	policy := autoPromotePolicy(1, 0.9)
 	policy.AutoPromoteCanary = true
 	policy.AutoPromoteCanarySample = floatPtrCLI(0.5)
-	if err := runCandidateNotify(ctx, store, &recordingSink{}, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, &recordingSink{}, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify (canary promote): %v", err)
 	}
 

--- a/internal/cli/candidate_autopromote_test.go
+++ b/internal/cli/candidate_autopromote_test.go
@@ -45,7 +45,7 @@ func TestRunCandidateNotifyAutoPromoteOffStaysPending(t *testing.T) {
 	autoPromoteCandidateScore(&candidate, 0.99)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -73,7 +73,7 @@ func TestRunCandidateNotifyAutoPromoteGuardrailsPass(t *testing.T) {
 	autoPromoteCandidateScore(&candidate, 0.96)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -107,7 +107,7 @@ func TestRunCandidateNotifyAutoPromoteGuardrailFailStaysPending(t *testing.T) {
 
 	// A near-neutral (no external CI) feedback event fails require_external_ci.
 	nearNeutral := db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged through an empty gate (no external CI); near-neutral, not a strong positive."}
-	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{nearNeutral}, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{nearNeutral}, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func TestRunCandidateNotifyBanditConfidencePromotes(t *testing.T) {
 
 	confidence := 0.97
 	summary := skillopt.ConfidenceSummary(confidence, 80)
-	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, &confidence, 80, summary); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, &confidence, 80, summary, 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -194,7 +194,7 @@ func TestRunCandidateNotifyModeBNoScoreNoFeedbackPromotes(t *testing.T) {
 	confidence := 0.97
 	summary := skillopt.ConfidenceSummary(confidence, 80)
 	// EMPTY feedback events — the defining property of a Mode B candidate.
-	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, nil, false, &confidence, 80, summary); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, nil, false, &confidence, 80, summary, 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -229,7 +229,7 @@ func TestRunCandidateNotifyBanditConfidenceBelowFloorStaysPending(t *testing.T) 
 	policy.AutoPromoteMinConfidence = floatPtrCLI(0.95)
 
 	confidence := 0.60
-	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, &confidence, 80, skillopt.ConfidenceSummary(confidence, 80)); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, &confidence, 80, skillopt.ConfidenceSummary(confidence, 80), 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
@@ -255,7 +255,7 @@ func TestRunCandidateNotifyNoBanditConfidenceUnchanged(t *testing.T) {
 	sink := &recordingSink{}
 
 	// No min_confidence floor; nil confidence; empty summary.
-	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 	awaiting := sink.byType(events.EventCandidateAwaitingPromotion)

--- a/internal/cli/candidate_canary_test.go
+++ b/internal/cli/candidate_canary_test.go
@@ -163,7 +163,7 @@ func TestRunCandidateNotifyCanaryRoutesToCanary(t *testing.T) {
 	policy.AutoPromoteCanary = true
 	policy.AutoPromoteCanarySample = floatPtrCLI(0.1)
 
-	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -207,7 +207,7 @@ func TestRunCandidateNotifyCanaryOffByDefaultDirectPromote(t *testing.T) {
 	autoPromoteCandidateScore(&candidate, 0.96)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 	if got := len(sink.byType(events.EventCandidateCanaryStarted)); got != 0 {
@@ -237,7 +237,7 @@ func TestRunCandidateNotifyCanaryWithoutSampleStaysPending(t *testing.T) {
 	policy := autoPromotePolicy(1, 0.9)
 	policy.AutoPromoteCanary = true // no AutoPromoteCanarySample => misconfigured
 
-	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 	if got := len(sink.byType(events.EventCandidateCanaryStarted)); got != 0 {

--- a/internal/cli/candidate_notify.go
+++ b/internal/cli/candidate_notify.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"strings"
 	"time"
@@ -91,8 +92,8 @@ func notifyAndMaybeAutoPromoteCandidate(ctx context.Context, store *db.Store, ho
 	// short-lived CLI command exits, or the candidate.* POST never lands.
 	sink := buildDaemonEventSink(store, home)
 	defer events.FlushSink(ctx, sink)
-	confidence, confidenceSamples, confidenceSummary := resolveBanditConfidence(ctx, store, version)
-	return runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents, feedbackUnavailable, confidence, confidenceSamples, confidenceSummary)
+	confidence, confidenceSamples, confidenceSummary, pairwiseWins, pairwiseLosses := resolveBanditConfidence(ctx, store, version)
+	return runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents, feedbackUnavailable, confidence, confidenceSamples, confidenceSummary, pairwiseWins, pairwiseLosses)
 }
 
 // resolveBanditConfidence looks up the #473 Mode B bandit confidence backing a
@@ -100,20 +101,24 @@ func notifyAndMaybeAutoPromoteCandidate(ctx context.Context, store *db.Store, ho
 // champion arm is the template's current promoted version. When the challenger
 // has at least one recorded pull it computes P(challenger>champion) from the two
 // Beta posteriors and returns (confidence, challengerPulls, "NN% likely better
-// over K samples"). When there is no bandit evidence (no challenger arm, or no
-// store) it returns (nil, 0, "") so EvaluateAutoPromote ignores the confidence
-// guardrail and the awaiting detail is unchanged — byte-identical to #471 when
-// Mode B was never exercised. Missing rows degrade to the Beta(1,1) prior; any
-// read error degrades to "no confidence" (fail safe, never block the notify).
-func resolveBanditConfidence(ctx context.Context, store *db.Store, version db.AgentTemplateVersion) (*float64, int, string) {
+// over K samples") plus the challenger arm's raw candidate-vs-champion win/loss
+// counts (the #481/#482 discordant-pair tally: wins = Alpha-1, losses = Beta-1 under
+// the Beta(1,1) prior) — the paired outcome stream the #687 PACE gate consumes. When
+// there is no bandit evidence (no challenger arm, or no store) it returns
+// (nil, 0, "", 0, 0) so EvaluateAutoPromote ignores the confidence guardrail, the
+// awaiting detail is unchanged, and PACE sees zero pairs (never commits) — byte-
+// identical to #471 when Mode B was never exercised. Missing rows degrade to the
+// Beta(1,1) prior; any read error degrades to "no confidence" (fail safe, never
+// block the notify).
+func resolveBanditConfidence(ctx context.Context, store *db.Store, version db.AgentTemplateVersion) (*float64, int, string, int, int) {
 	if store == nil {
-		return nil, 0, ""
+		return nil, 0, "", 0, 0
 	}
 	challengerArm, found, err := store.GetBanditArm(ctx, version.TemplateID, version.ID)
 	if err != nil || !found || challengerArm.Pulls == 0 {
 		// No A/B evidence for this candidate: Mode B contributes nothing, so the
-		// optional confidence guardrail stays a no-op.
-		return nil, 0, ""
+		// optional confidence guardrail stays a no-op and PACE sees no pairs.
+		return nil, 0, "", 0, 0
 	}
 	champion := skillopt.BetaParams{Alpha: 1, Beta: 1}
 	if tmpl, terr := store.GetAgentTemplate(ctx, version.TemplateID); terr == nil && strings.TrimSpace(tmpl.VersionID) != "" {
@@ -124,7 +129,26 @@ func resolveBanditConfidence(ctx context.Context, store *db.Store, version db.Ag
 	challenger := skillopt.BetaParams{Alpha: challengerArm.Alpha, Beta: challengerArm.Beta}
 	prob := skillopt.ProbChallengerBeats(champion, challenger, rand.New(rand.NewSource(banditConfidenceSeed)), skillopt.DefaultProbDraws)
 	summary := skillopt.ConfidenceSummary(prob, challengerArm.Pulls)
-	return &prob, challengerArm.Pulls, summary
+	wins, losses := banditArmWinLoss(challengerArm)
+	return &prob, challengerArm.Pulls, summary, wins, losses
+}
+
+// banditArmWinLoss recovers the candidate-vs-champion discordant-pair tally from a
+// Beta(1+wins, 1+losses) arm: wins = Alpha-1, losses = Beta-1, each clamped at 0 and
+// rounded (Alpha/Beta are integer-valued in practice, seeded at 1 and incremented by
+// 1 per outcome). This is the paired win/loss stream the PACE e-process (#687)
+// consumes — the bandit only ever records discordant win/loss pulls, so ties are
+// already excluded.
+func banditArmWinLoss(arm db.BanditArm) (int, int) {
+	wins := int(math.Round(arm.Alpha - 1))
+	losses := int(math.Round(arm.Beta - 1))
+	if wins < 0 {
+		wins = 0
+	}
+	if losses < 0 {
+		losses = 0
+	}
+	return wins, losses
 }
 
 // runCandidateNotify is the testable core of the post-import notify+auto-promote
@@ -136,7 +160,7 @@ func resolveBanditConfidence(ctx context.Context, store *db.Store, version db.Ag
 // candidate.auto_promoted. Splitting it from the home/sink/feedback resolution lets
 // a recording sink assert the exactly-once emit and the no-double-emit invariant
 // deterministically.
-func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, policy config.SkillOptPolicy, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, feedbackEvents []db.FeedbackEvent, feedbackUnavailable bool, confidence *float64, confidenceSamples int, confidenceSummary string) error {
+func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, policy config.SkillOptPolicy, candidate skillopt.CandidatePackage, version db.AgentTemplateVersion, feedbackEvents []db.FeedbackEvent, feedbackUnavailable bool, confidence *float64, confidenceSamples int, confidenceSummary string, pairwiseWins, pairwiseLosses int) error {
 	decision := skillopt.EvaluateAutoPromote(policy, candidate, feedbackEvents, feedbackUnavailable, confidence, confidenceSamples)
 
 	// (3) Always-on notify (when [events] is configured), independent of the
@@ -153,6 +177,23 @@ func runCandidateNotify(ctx context.Context, store *db.Store, sink events.Sink, 
 	}
 	if store == nil {
 		return nil
+	}
+	// (4p) PACE anytime-valid commit gate (#687): when [skillopt].pace_enabled is on,
+	// a guardrails-pass candidate must ALSO have its recorded candidate-vs-champion
+	// pairwise outcomes (the Mode B bandit arm's win/loss tally, #481/#482) cross the
+	// e-process commit threshold 1/pace_alpha before it may be promoted. This is an
+	// ADDITIONAL gate (never a replacement): every existing guardrail already passed
+	// above (decision.Promote), and PACE is layered on top. It is model-free arithmetic
+	// (no LLM call). A non-commit verdict — budget exhausted (reject) OR not yet
+	// decisive (continue) — FAILS SAFE to a pace_blocked notify and stops short of
+	// promotion, mirroring the #627 gate_blocked behavior. Off by default
+	// (pace_enabled=false) this block never runs and the path below is byte-identical.
+	if policy.PaceEnabled {
+		paceCfg := skillopt.PaceConfig{Alpha: policy.PaceAlpha, Lambda: policy.PaceLambda, MaxPairs: policy.PaceMaxPairs}
+		if verdict, reason := skillopt.PaceGateReason(paceCfg, pairwiseWins, pairwiseLosses); verdict != skillopt.PaceCommit {
+			emitCandidateEvent(ctx, sink, events.EventCandidateAwaitingPromotion, version, "pace_blocked", reason)
+			return nil
+		}
 	}
 	// (4z) Pre-canary replay gate (#627): when [skillopt].gate_enabled is on, a
 	// guardrails-pass candidate must ALSO carry a PASSING deterministic replay-gate

--- a/internal/cli/candidate_notify_test.go
+++ b/internal/cli/candidate_notify_test.go
@@ -61,7 +61,7 @@ func TestRunCandidateNotifyEmitsAwaitingExactlyOnce(t *testing.T) {
 	store, version, candidate, _ := candidateNotifyFixture(t)
 	sink := &recordingSink{}
 
-	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, nil, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, config.DefaultSkillOptPolicy(), candidate, version, nil, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify returned error: %v", err)
 	}
 
@@ -97,7 +97,7 @@ func TestRunCandidateNotifyNilSinkIsNoOp(t *testing.T) {
 	ctx := context.Background()
 	store, version, candidate, _ := candidateNotifyFixture(t)
 
-	if err := runCandidateNotify(ctx, store, nil, config.DefaultSkillOptPolicy(), candidate, version, nil, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, nil, config.DefaultSkillOptPolicy(), candidate, version, nil, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify with nil sink returned error: %v", err)
 	}
 	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
@@ -219,9 +219,9 @@ func TestNotifyAndMaybeAutoPromoteFlushesPerInvocationSink(t *testing.T) {
 func TestResolveBanditConfidenceNoArmIsNil(t *testing.T) {
 	ctx := context.Background()
 	store, version, _, _ := candidateNotifyFixture(t)
-	conf, samples, summary := resolveBanditConfidence(ctx, store, version)
-	if conf != nil || samples != 0 || summary != "" {
-		t.Fatalf("no-arm confidence = (%v, %d, %q), want (nil, 0, \"\")", conf, samples, summary)
+	conf, samples, summary, wins, losses := resolveBanditConfidence(ctx, store, version)
+	if conf != nil || samples != 0 || summary != "" || wins != 0 || losses != 0 {
+		t.Fatalf("no-arm confidence = (%v, %d, %q, %d, %d), want (nil, 0, \"\", 0, 0)", conf, samples, summary, wins, losses)
 	}
 }
 
@@ -245,7 +245,7 @@ func TestResolveBanditConfidenceComputesFromArms(t *testing.T) {
 		t.Fatalf("seed challenger arm: %v", err)
 	}
 
-	conf, samples, summary := resolveBanditConfidence(ctx, store, version)
+	conf, samples, summary, wins, losses := resolveBanditConfidence(ctx, store, version)
 	if conf == nil {
 		t.Fatal("expected a non-nil confidence when the challenger arm has pulls")
 	}
@@ -257,6 +257,11 @@ func TestResolveBanditConfidenceComputesFromArms(t *testing.T) {
 	}
 	if !strings.Contains(summary, "over 40 samples") {
 		t.Fatalf("summary = %q, want it to name 40 samples", summary)
+	}
+	// The challenger arm Alpha=40, Beta=2 decodes to 39 candidate wins / 1 loss
+	// (wins = Alpha-1, losses = Beta-1) — the PACE (#687) discordant-pair stream.
+	if wins != 39 || losses != 1 {
+		t.Fatalf("win/loss = (%d, %d), want (39, 1) from Alpha=40, Beta=2", wins, losses)
 	}
 }
 

--- a/internal/cli/candidate_pace_test.go
+++ b/internal/cli/candidate_pace_test.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/events"
+)
+
+// pacePolicy is autoPromotePolicy with the #687 PACE gate turned on (RFC defaults:
+// alpha 0.05 -> threshold 20, lambda 0.5). All the existing guardrails stay on, so
+// PACE is a strictly ADDITIONAL gate.
+func pacePolicy() config.SkillOptPolicy {
+	policy := autoPromotePolicy(1, 0.9)
+	policy.PaceEnabled = true
+	policy.PaceAlpha = config.DefaultPaceAlpha
+	policy.PaceLambda = config.DefaultPaceLambda
+	policy.PaceMaxPairs = config.DefaultPaceMaxPairs
+	return policy
+}
+
+// TestRunCandidateNotifyPaceOffByteIdentical proves pace_enabled=false is a no-op:
+// with every other guardrail passing, the candidate promotes exactly as before even
+// when the pairwise win/loss counts would NOT cross the PACE threshold (0/0 here).
+// The e-process is never consulted when off.
+func TestRunCandidateNotifyPaceOffByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	// autoPromotePolicy has PaceEnabled=false; pass 0/0 pairwise counts.
+	if err := runCandidateNotify(ctx, store, sink, autoPromotePolicy(1, 0.9), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 0, 0); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 1 {
+		t.Fatalf("auto_promoted emits = %d, want 1 (PACE off must not block)", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "current" {
+		t.Fatalf("version state = %q, want current", after.State)
+	}
+}
+
+// TestRunCandidateNotifyPaceBlocksInsufficientEvidence proves that with PACE on and
+// the recorded candidate-vs-champion pairwise outcomes NOT decisive (a few wins that
+// never cross 1/alpha), a guardrails-pass candidate is NOT promoted: a pace_blocked
+// notify fires and the version stays pending. This is the additional-gate behavior.
+func TestRunCandidateNotifyPaceBlocksInsufficientEvidence(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	// 3 wins, 0 losses: wealth 1.5^3 = 3.375 < 20 -> continue (not decisive).
+	if err := runCandidateNotify(ctx, store, sink, pacePolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 3, 0); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0 (PACE not decisive)", got)
+	}
+	// The awaiting-type stream carries a pace_blocked event with a PACE reason.
+	var blocked bool
+	for _, ev := range sink.byType(events.EventCandidateAwaitingPromotion) {
+		if ev.Status == "pace_blocked" && strings.Contains(ev.Detail, "PACE") {
+			blocked = true
+		}
+	}
+	if !blocked {
+		t.Fatalf("expected a pace_blocked notify with a PACE reason, got %+v", sink.byType(events.EventCandidateAwaitingPromotion))
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "pending" {
+		t.Fatalf("version state = %q, want pending (PACE blocked)", after.State)
+	}
+}
+
+// TestRunCandidateNotifyPaceBudgetExhaustedRejects proves budget exhaustion is a
+// fail-safe notify-only: a coin-flip tally that spends the whole pair budget without
+// crossing rejects (pace_blocked), never promotes.
+func TestRunCandidateNotifyPaceBudgetExhaustedRejects(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	policy := pacePolicy()
+	policy.PaceMaxPairs = 10 // small budget so 6 wins / 6 losses exhausts it
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 6, 6); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0 (budget exhausted)", got)
+	}
+	var rejected bool
+	for _, ev := range sink.byType(events.EventCandidateAwaitingPromotion) {
+		if ev.Status == "pace_blocked" && strings.Contains(ev.Detail, "reject") {
+			rejected = true
+		}
+	}
+	if !rejected {
+		t.Fatalf("expected a pace_blocked reject notify, got %+v", sink.byType(events.EventCandidateAwaitingPromotion))
+	}
+}
+
+// TestRunCandidateNotifyPaceCommitsPromotes proves a clearly-better candidate (a
+// dominant win/loss tally that crosses 1/alpha) passes the PACE gate and promotes,
+// AND that the existing guardrails still had to pass (they do here).
+func TestRunCandidateNotifyPaceCommitsPromotes(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	// 10 wins, 1 loss: 1.5^10 * 0.5 = 28.8 >= 20 -> commit.
+	if err := runCandidateNotify(ctx, store, sink, pacePolicy(), candidate, version, []db.FeedbackEvent{realCIFeedbackEvent()}, false, nil, 0, "", 10, 1); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 1 {
+		t.Fatalf("auto_promoted emits = %d, want 1 (PACE commit)", got)
+	}
+	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateVersionByID returned error: %v", err)
+	}
+	if after.State != "current" {
+		t.Fatalf("version state = %q, want current (PACE committed)", after.State)
+	}
+}
+
+// TestRunCandidateNotifyPaceIsAdditionalNotReplacement proves PACE does NOT rescue a
+// candidate that fails a PRE-EXISTING guardrail: even a decisive PACE tally (10-1)
+// cannot promote when require_external_ci fails, because PACE only runs AFTER the
+// existing guardrails already passed.
+func TestRunCandidateNotifyPaceIsAdditionalNotReplacement(t *testing.T) {
+	ctx := context.Background()
+	store, version, candidate, _ := candidateNotifyFixture(t)
+	autoPromoteCandidateScore(&candidate, 0.96)
+	sink := &recordingSink{}
+
+	nearNeutral := db.FeedbackEvent{Choice: "a", Reasoning: "PR #7 merged through an empty gate (no external CI)."}
+	if err := runCandidateNotify(ctx, store, sink, pacePolicy(), candidate, version, []db.FeedbackEvent{nearNeutral}, false, nil, 0, "", 10, 1); err != nil {
+		t.Fatalf("runCandidateNotify returned error: %v", err)
+	}
+	if got := len(sink.byType(events.EventCandidateAutoPromoted)); got != 0 {
+		t.Fatalf("auto_promoted emits = %d, want 0 (existing guardrail must still block)", got)
+	}
+	// No pace_blocked either — the existing guardrail short-circuits before PACE.
+	for _, ev := range sink.byType(events.EventCandidateAwaitingPromotion) {
+		if ev.Status == "pace_blocked" {
+			t.Fatalf("PACE ran despite a failing prior guardrail; PACE must be downstream of Promote=true")
+		}
+	}
+}

--- a/internal/cli/skillopt_gate_e2e_test.go
+++ b/internal/cli/skillopt_gate_e2e_test.go
@@ -89,7 +89,7 @@ func TestGateRejectedRunViaCLIStillBlocksPromotionE2E(t *testing.T) {
 	policy := gateGuardPolicy()
 	candidate, feedback := gateGuardInputs()
 	sink := &recordingSink{}
-	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, feedback, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, feedback, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify: %v", err)
 	}
 	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
@@ -124,7 +124,7 @@ func TestGateAcceptedRunViaCLIUnblocksPromotionE2E(t *testing.T) {
 	// (1) BEFORE any gate run: guardrails pass + gate enabled → BLOCKED (no accepted
 	// run yet). This mirrors #635's block leg but as the baseline for the unblock.
 	sink1 := &recordingSink{}
-	if err := runCandidateNotify(ctx, store, sink1, policy, candidate, version, feedback, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink1, policy, candidate, version, feedback, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify (pre-gate): %v", err)
 	}
 	if pre, _ := store.GetAgentTemplateVersionByID(ctx, version.ID); pre.State != "pending" {
@@ -147,7 +147,7 @@ func TestGateAcceptedRunViaCLIUnblocksPromotionE2E(t *testing.T) {
 	// (3) The SAME promotion guard now promotes the candidate to current, consuming
 	// the CLI-produced accepted run.
 	sink2 := &recordingSink{}
-	if err := runCandidateNotify(ctx, store, sink2, policy, candidate, version, feedback, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink2, policy, candidate, version, feedback, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify (post-gate): %v", err)
 	}
 	promoted, err := store.GetAgentTemplateVersionByID(ctx, version.ID)

--- a/internal/cli/skillopt_gate_test.go
+++ b/internal/cli/skillopt_gate_test.go
@@ -228,7 +228,7 @@ func TestGatePromotionGuardBlocksThenAllows(t *testing.T) {
 	sink := &recordingSink{}
 
 	// (1) Gate enabled, no accepted gate run -> blocked, no promotion.
-	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, feedback, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, feedback, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify (blocked) returned error: %v", err)
 	}
 	after, err := store.GetAgentTemplateVersionByID(ctx, version.ID)
@@ -250,7 +250,7 @@ func TestGatePromotionGuardBlocksThenAllows(t *testing.T) {
 		t.Fatalf("InsertSkillOptGateRun returned error: %v", err)
 	}
 	sink2 := &recordingSink{}
-	if err := runCandidateNotify(ctx, store, sink2, policy, candidate, version, feedback, false, nil, 0, ""); err != nil {
+	if err := runCandidateNotify(ctx, store, sink2, policy, candidate, version, feedback, false, nil, 0, "", 0, 0); err != nil {
 		t.Fatalf("runCandidateNotify (allowed) returned error: %v", err)
 	}
 	promoted, err := store.GetAgentTemplateVersionByID(ctx, version.ID)

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -274,6 +274,24 @@ path = ""
 #     and emits a per-item GateReplayResult JSON ({"rubric":{...}} or
 #     {"hard_verifier":true,"hard_passed":bool}) on stdout — the command IS the
 #     deterministic map. A corpus's own replay_command overrides this default.
+#   pace_enabled (#687): OFF by default. The PACE anytime-valid commit gate — an
+#     ADDITIONAL auto-promote gate (never a replacement) layered on top of every
+#     existing guardrail. When on, a guardrails-pass candidate is auto-promoted only
+#     when a testing-by-betting e-process over its recorded candidate-vs-champion
+#     pairwise outcomes (the Mode B bandit arm's win/loss tally, #481/#482) crosses the
+#     commit threshold 1/pace_alpha; a budget-exhausted or not-yet-decisive stream
+#     FAILS SAFE to a pace_blocked notify (no promotion). It is model-free arithmetic —
+#     no extra LLM calls — and rides the pairwise comparisons #473 already records.
+#     OFF ⇒ byte-identical (the e-process is never consulted).
+#   pace_alpha (#687): PACE target false-commit probability in (0,1); the commit
+#     threshold is 1/pace_alpha (0.05 -> 20). Default 0.05. Only consulted when
+#     pace_enabled.
+#   pace_lambda (#687): PACE bet fraction in [0,1]; a candidate win scales the wealth
+#     by (1+pace_lambda), a loss by (1-pace_lambda). Default 0.5. Only consulted when
+#     pace_enabled.
+#   pace_max_pairs (#687): PACE discordant-pair budget; after this many win/loss pairs
+#     without crossing the threshold the e-process rejects (notify-only). Default 200.
+#     Only consulted when pace_enabled.
 # [skillopt]
 # auto_trace_enabled = false
 # cross_family_review_enabled = false
@@ -286,6 +304,10 @@ path = ""
 # gate_enabled = false
 # gate_corpus = .gitmoot/skillopt/gate-corpus.json
 # gate_replay_command = sh .gitmoot/skillopt/gate-replay.sh
+# pace_enabled = false
+# pace_alpha = 0.05
+# pace_lambda = 0.5
+# pace_max_pairs = 200
 # auto_promote = false
 # auto_promote_min_samples = 0
 # auto_promote_min_score = 0.0

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -694,6 +694,31 @@ type SkillOptPolicy struct {
 	// (the default) means a command MUST be supplied on the command line or in the
 	// corpus.
 	GateReplayCommand string
+
+	// PaceEnabled opts into the OFF-by-default PACE anytime-valid commit gate (#687):
+	// an ADDITIONAL promotion gate (never a replacement) layered on top of every
+	// existing auto-promote guardrail. When true, a guardrails-pass candidate is
+	// auto-promoted only when a testing-by-betting e-process over its recorded
+	// candidate-vs-champion pairwise outcomes (the Mode B bandit arm's win/loss tally,
+	// #481/#482) crosses the commit threshold 1/PaceAlpha; a budget-exhausted (reject)
+	// or not-yet-decisive (continue) stream FAILS SAFE to notify-only, mirroring the
+	// #627 gate_blocked behavior. false (the default) is byte-identical — the e-process
+	// is never consulted. The field is a plain bool (no accessor method) because it has
+	// no compound dependency: PACE rides the same pairwise stream #473 already reads.
+	PaceEnabled bool
+	// PaceAlpha is the PACE target false-commit probability in (0,1); the commit
+	// threshold is 1/PaceAlpha (#687). DefaultPaceAlpha (0.05 -> threshold 20) when
+	// unset. Only consulted when PaceEnabled.
+	PaceAlpha float64
+	// PaceLambda is the PACE bet fraction in [0,1] (#687): a candidate win scales the
+	// e-process wealth by (1+PaceLambda), a loss by (1-PaceLambda). 0 is a legal no-op
+	// (wealth never moves, never commits). DefaultPaceLambda (0.5) when unset. Only
+	// consulted when PaceEnabled.
+	PaceLambda float64
+	// PaceMaxPairs is the PACE discordant-pair budget (#687): after this many win/loss
+	// pairs without crossing the commit threshold the e-process rejects (notify-only).
+	// DefaultPaceMaxPairs when unset/<=0. Only consulted when PaceEnabled.
+	PaceMaxPairs int
 }
 
 // DefaultDeterministicCheckers is the safe default checker set used when the
@@ -707,6 +732,16 @@ var DefaultDeterministicCheckers = []string{"diff_size"}
 // deferred Mode B auto loop (#473). It is NOT applied when bandit_min_samples is
 // unset (nil stays nil, off); it is the value the config stub comments suggest.
 const DefaultBanditMinSamples = 30
+
+// Default PACE parameters (#687). Duplicated here as plain numbers (config cannot
+// import internal/skillopt without a cycle) but MUST stay in lockstep with
+// skillopt.DefaultPace* — a config test pins the pair. They seed PaceAlpha/PaceLambda/
+// PaceMaxPairs so an enabled PACE gate with no explicit knobs uses the RFC defaults.
+const (
+	DefaultPaceAlpha    = 0.05
+	DefaultPaceLambda   = 0.5
+	DefaultPaceMaxPairs = 200
+)
 
 func DefaultSkillOptPolicy() SkillOptPolicy {
 	return SkillOptPolicy{
@@ -735,6 +770,10 @@ func DefaultSkillOptPolicy() SkillOptPolicy {
 		Gate:                            false,
 		GateCorpusPath:                  "",
 		GateReplayCommand:               "",
+		PaceEnabled:                     false,
+		PaceAlpha:                       DefaultPaceAlpha,
+		PaceLambda:                      DefaultPaceLambda,
+		PaceMaxPairs:                    DefaultPaceMaxPairs,
 	}
 }
 
@@ -1003,6 +1042,46 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		return nil
 	case "gate_replay_command":
 		policy.GateReplayCommand = strings.TrimSpace(value)
+		return nil
+	case "pace_enabled":
+		parsed, err := strconv.ParseBool(value)
+		policy.PaceEnabled = parsed
+		return err
+	case "pace_alpha":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		// alpha is a false-commit probability: it must be in (0,1). 0/negative gives
+		// an infinite commit threshold (never commits) and >=1 makes the threshold
+		// <=1 (commits on the prior), so both are hard errors rather than a clamp.
+		if parsed <= 0 || parsed >= 1 {
+			return fmt.Errorf("pace_alpha %v must be in (0,1)", parsed)
+		}
+		policy.PaceAlpha = parsed
+		return nil
+	case "pace_lambda":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return err
+		}
+		// lambda is the bet fraction in [0,1]: 0 is a legal no-op; >1 would make a
+		// loss multiply wealth by a negative number (nonsensical) and <0 inverts the
+		// bet, so both extremes are hard errors.
+		if parsed < 0 || parsed > 1 {
+			return fmt.Errorf("pace_lambda %v must be in [0,1]", parsed)
+		}
+		policy.PaceLambda = parsed
+		return nil
+	case "pace_max_pairs":
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		if parsed <= 0 {
+			return fmt.Errorf("pace_max_pairs %d must be positive", parsed)
+		}
+		policy.PaceMaxPairs = parsed
 		return nil
 	default:
 		return nil

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -586,3 +586,92 @@ revert_detection_enabled = maybe
 		t.Fatal("expected an error for a non-bool revert_detection_enabled")
 	}
 }
+
+// TestLoadSkillOptPolicyPaceDefaults: with no [skillopt] section (or the section
+// present without pace keys) the PACE gate (#687) is OFF and its parameters carry
+// the RFC defaults, so behavior is byte-identical.
+func TestLoadSkillOptPolicyPaceDefaults(t *testing.T) {
+	policy := DefaultSkillOptPolicy()
+	if policy.PaceEnabled {
+		t.Fatalf("pace must default OFF, got %+v", policy)
+	}
+	if policy.PaceAlpha != DefaultPaceAlpha || policy.PaceLambda != DefaultPaceLambda || policy.PaceMaxPairs != DefaultPaceMaxPairs {
+		t.Fatalf("pace params = (%v, %v, %d), want the Default* constants", policy.PaceAlpha, policy.PaceLambda, policy.PaceMaxPairs)
+	}
+}
+
+// TestLoadSkillOptPolicyParsesPace: the PACE keys parse into the policy.
+func TestLoadSkillOptPolicyParsesPace(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+pace_enabled = true
+pace_alpha = 0.01
+pace_lambda = 0.25
+pace_max_pairs = 64
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if !policy.PaceEnabled {
+		t.Fatalf("expected PaceEnabled true, got %+v", policy)
+	}
+	if policy.PaceAlpha != 0.01 || policy.PaceLambda != 0.25 || policy.PaceMaxPairs != 64 {
+		t.Fatalf("pace params = (%v, %v, %d), want (0.01, 0.25, 64)", policy.PaceAlpha, policy.PaceLambda, policy.PaceMaxPairs)
+	}
+}
+
+// TestLoadSkillOptPolicyPaceLambdaZeroAllowed: lambda=0 is a legal no-op and must
+// parse (not be rejected as out of range).
+func TestLoadSkillOptPolicyPaceLambdaZeroAllowed(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[skillopt]
+pace_lambda = 0
+`), 0o600); err != nil {
+		t.Fatalf("write config returned error: %v", err)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy returned error: %v", err)
+	}
+	if policy.PaceLambda != 0 {
+		t.Fatalf("pace_lambda = %v, want 0 (legal no-op)", policy.PaceLambda)
+	}
+}
+
+// TestLoadSkillOptPolicyRejectsBadPace: out-of-range alpha/lambda and a non-positive
+// max_pairs are hard config errors.
+func TestLoadSkillOptPolicyRejectsBadPace(t *testing.T) {
+	cases := map[string]string{
+		"alpha too high": "pace_alpha = 1.0",
+		"alpha zero":     "pace_alpha = 0",
+		"lambda too high": "pace_lambda = 1.5",
+		"lambda negative": "pace_lambda = -0.1",
+		"max_pairs zero":  "pace_max_pairs = 0",
+		"max_pairs neg":   "pace_max_pairs = -3",
+	}
+	for name, line := range cases {
+		t.Run(name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatalf("Initialize returned error: %v", err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+"\n[skillopt]\n"+line+"\n"), 0o600); err != nil {
+				t.Fatalf("write config returned error: %v", err)
+			}
+			if _, err := LoadSkillOptPolicy(paths); err == nil {
+				t.Fatalf("expected an error for %q", line)
+			}
+		})
+	}
+}

--- a/internal/skillopt/pace.go
+++ b/internal/skillopt/pace.go
@@ -1,0 +1,259 @@
+package skillopt
+
+import "fmt"
+
+// PACE (#687) — a PURE, model-free anytime-valid commit gate for candidate
+// promotion, the accept-side complement of measure-the-judge (#344). It is a
+// testing-by-betting e-process over a stream of PAIRED candidate-vs-champion
+// outcomes evaluated on the SAME instances (McNemar pairing):
+//
+//   - Each pair is a candidate WIN, a candidate LOSS, or a TIE (both right or both
+//     wrong). Ties carry no information under the null and are DISCARDED.
+//   - Wealth E starts at 1. For each DISCORDANT pair with w in {1 (win), 0 (loss)}:
+//         E <- E * (1 + lambda*(2w-1))
+//     i.e. a win multiplies by (1+lambda), a loss by (1-lambda).
+//   - Under H0 "candidate is not better," a discordant pair is a candidate-win with
+//     probability 1/2, so (1+lambda*(2w-1)) has mean 1 and E is a nonnegative
+//     (super)martingale with E[E] <= 1. By Ville's inequality the probability E ever
+//     reaches 1/alpha is <= alpha, so COMMITTING when E >= 1/alpha bounds the
+//     false-commit probability by alpha at ANY stopping time (anytime-valid): you may
+//     peek after every pair, stop early when decisive, and reject when the pair
+//     budget is exhausted without crossing.
+//
+// This file contains NO model calls and NO I/O — it is arithmetic (x(1+lambda) /
+// x(1-lambda)) and is unit-testable in isolation. Wiring it onto the Mode B
+// pairwise/bandit stream as an optional, off-by-default promotion gate lives in the
+// CLI notify seam.
+
+// PaceOutcome is one paired candidate-vs-champion result on a shared instance.
+type PaceOutcome int
+
+const (
+	// PaceTie is a concordant pair (both sides right or both wrong): it carries no
+	// information under the null and is discarded by the accumulator.
+	PaceTie PaceOutcome = iota
+	// PaceWin is a discordant pair the candidate won (candidate right, champion wrong).
+	PaceWin
+	// PaceLoss is a discordant pair the candidate lost (champion right, candidate wrong).
+	PaceLoss
+)
+
+// PaceVerdict is the accumulator's total decision after the pairs seen so far.
+type PaceVerdict int
+
+const (
+	// PaceContinue means the e-process has neither crossed the commit threshold nor
+	// exhausted the pair budget: more discordant pairs are needed to decide.
+	PaceContinue PaceVerdict = iota
+	// PaceCommit means wealth E has reached 1/alpha — promote (false-commit prob <= alpha).
+	PaceCommit
+	// PaceReject means the pair budget (MaxPairs discordant pairs) was exhausted
+	// without E crossing 1/alpha — the evidence never accumulated, so do not promote.
+	PaceReject
+)
+
+// String renders a PaceVerdict for reasons/logs.
+func (v PaceVerdict) String() string {
+	switch v {
+	case PaceCommit:
+		return "commit"
+	case PaceReject:
+		return "reject"
+	default:
+		return "continue"
+	}
+}
+
+// Default PACE parameters (matching the RFC / arXiv:2606.08106):
+//   - alpha = 0.05  -> commit threshold 1/alpha = 20.
+//   - lambda = 0.5  -> a win multiplies wealth by 1.5, a loss by 0.5.
+//   - max_pairs      -> the discordant-pair budget before a non-decisive stream rejects.
+const (
+	DefaultPaceAlpha    = 0.05
+	DefaultPaceLambda   = 0.5
+	DefaultPaceMaxPairs = 200
+)
+
+// PaceConfig is the e-process configuration: the false-commit bound Alpha, the bet
+// fraction Lambda, and the discordant-pair budget MaxPairs. The zero value is not
+// meaningful; use withDefaults (applied by the constructor) to fill clearly-invalid
+// fields from the Default* constants while preserving legal edge values (e.g.
+// Lambda == 0, the no-op bet).
+type PaceConfig struct {
+	// Alpha is the target false-commit probability in (0,1); the commit threshold is
+	// 1/Alpha. Out of range -> DefaultPaceAlpha.
+	Alpha float64
+	// Lambda is the bet fraction in [0,1]: each win scales wealth by (1+Lambda), each
+	// loss by (1-Lambda). Lambda == 0 is a legal no-op (wealth never moves, never
+	// commits). Out of [0,1] -> DefaultPaceLambda.
+	Lambda float64
+	// MaxPairs is the discordant-pair budget: after this many win/loss pairs without
+	// crossing the threshold the accumulator rejects. <= 0 -> DefaultPaceMaxPairs.
+	MaxPairs int
+}
+
+// withDefaults returns the config with only clearly-invalid fields replaced by the
+// Default* constants. Legal edge values are preserved: Lambda == 0 (no-op bet) is
+// kept, and any Alpha in (0,1) / Lambda in [0,1] / MaxPairs > 0 passes through
+// unchanged. This keeps hand-built configs in tests exact while making a zero-value
+// or misconfigured struct safe.
+func (c PaceConfig) withDefaults() PaceConfig {
+	out := c
+	if !(out.Alpha > 0 && out.Alpha < 1) {
+		out.Alpha = DefaultPaceAlpha
+	}
+	if out.Lambda < 0 || out.Lambda > 1 {
+		out.Lambda = DefaultPaceLambda
+	}
+	if out.MaxPairs <= 0 {
+		out.MaxPairs = DefaultPaceMaxPairs
+	}
+	return out
+}
+
+// CommitThreshold is 1/Alpha, the wealth at which the e-process commits.
+func (c PaceConfig) CommitThreshold() float64 {
+	return 1.0 / c.withDefaults().Alpha
+}
+
+// PaceAccumulator is the streaming e-process. It consumes paired outcomes one at a
+// time (ties discarded), updates wealth on each discordant pair, and latches
+// PaceCommit the moment wealth first reaches the commit threshold (the anytime-valid
+// early stop). It is not safe for concurrent use; a promotion decision is a single
+// goroutine feeding a private accumulator.
+type PaceAccumulator struct {
+	cfg       PaceConfig
+	threshold float64
+	wealth    float64
+	pairs     int // discordant pairs consumed (ties excluded)
+	committed bool
+}
+
+// NewPaceAccumulator returns a fresh e-process seeded at wealth 1 for the given
+// config (clearly-invalid fields defaulted). Ties fed later are discarded.
+func NewPaceAccumulator(cfg PaceConfig) *PaceAccumulator {
+	cfg = cfg.withDefaults()
+	return &PaceAccumulator{
+		cfg:       cfg,
+		threshold: 1.0 / cfg.Alpha,
+		wealth:    1.0,
+	}
+}
+
+// Observe feeds one paired outcome and returns the accumulator's verdict AFTER it.
+// A tie is discarded (no state change). A win/loss updates wealth and the discordant
+// pair count. Once committed the accumulator latches: further outcomes are ignored
+// and the verdict stays PaceCommit (an anytime-valid stop is final).
+func (a *PaceAccumulator) Observe(outcome PaceOutcome) PaceVerdict {
+	if a.committed {
+		return PaceCommit
+	}
+	switch outcome {
+	case PaceWin:
+		a.wealth *= 1 + a.cfg.Lambda
+		a.pairs++
+	case PaceLoss:
+		a.wealth *= 1 - a.cfg.Lambda
+		a.pairs++
+	default:
+		// PaceTie (or any unknown value): concordant / no information -> discard.
+		return a.Verdict()
+	}
+	if a.wealth >= a.threshold {
+		a.committed = true
+	}
+	return a.Verdict()
+}
+
+// Verdict returns the current total decision without consuming an outcome: commit if
+// wealth has crossed the threshold, reject if the discordant-pair budget is spent,
+// else continue.
+func (a *PaceAccumulator) Verdict() PaceVerdict {
+	if a.committed {
+		return PaceCommit
+	}
+	if a.pairs >= a.cfg.MaxPairs {
+		return PaceReject
+	}
+	return PaceContinue
+}
+
+// Wealth is the current e-process wealth E (starts at 1).
+func (a *PaceAccumulator) Wealth() float64 { return a.wealth }
+
+// Pairs is the number of DISCORDANT pairs consumed (ties excluded).
+func (a *PaceAccumulator) Pairs() int { return a.pairs }
+
+// Committed reports whether the accumulator has latched PaceCommit.
+func (a *PaceAccumulator) Committed() bool { return a.committed }
+
+// EvaluatePaceStream feeds a whole sequence of paired outcomes through a fresh
+// accumulator (ties discarded, commit latching on first crossing — the early-stop
+// property) and returns the final verdict. The order of the stream matters for WHEN
+// the accumulator commits, exactly as an online anytime-valid test peeks after every
+// pair; it is the faithful streaming evaluation used by the replay harness.
+func EvaluatePaceStream(cfg PaceConfig, outcomes []PaceOutcome) PaceVerdict {
+	acc := NewPaceAccumulator(cfg)
+	for _, o := range outcomes {
+		if acc.Observe(o) == PaceCommit {
+			break
+		}
+	}
+	return acc.Verdict()
+}
+
+// EvaluatePaceCounts decides commit/reject/continue from AGGREGATE discordant-pair
+// counts (candidate wins and losses), which is what the Mode B bandit arm records
+// (skillopt_bandit_arms tallies win/loss; ties are never recorded). The bandit is a
+// COUNT, not an ordered log, so this feeds the accumulator LOSSES-FIRST then wins:
+// with losses first the wealth path descends monotonically to its minimum and then
+// ascends monotonically, so its only threshold crossing is at the terminal pair —
+// making the commit decision equal to the ORDER-INVARIANT terminal-wealth test
+// (E = (1+lambda)^wins * (1-lambda)^losses >= 1/alpha). This is the conservative
+// reading: it never manufactures the false EARLY commit an arbitrary win-first
+// ordering could, so promoting on a count summary stays within the alpha bound. The
+// streaming early-stop lives in EvaluatePaceStream for a true ordered log / the
+// replay harness.
+func EvaluatePaceCounts(cfg PaceConfig, wins, losses int) PaceVerdict {
+	if wins < 0 {
+		wins = 0
+	}
+	if losses < 0 {
+		losses = 0
+	}
+	acc := NewPaceAccumulator(cfg)
+	for i := 0; i < losses; i++ {
+		acc.Observe(PaceLoss)
+	}
+	for i := 0; i < wins; i++ {
+		acc.Observe(PaceWin)
+	}
+	return acc.Verdict()
+}
+
+// PaceGateReason evaluates aggregate candidate-vs-champion counts (via
+// EvaluatePaceCounts) and returns the verdict plus a short, human-facing reason for
+// the candidate.* event Detail. It is the single call the promotion seam makes so
+// the block/commit reason is worded consistently.
+func PaceGateReason(cfg PaceConfig, wins, losses int) (PaceVerdict, string) {
+	cfg = cfg.withDefaults()
+	verdict := EvaluatePaceCounts(cfg, wins, losses)
+	threshold := 1.0 / cfg.Alpha
+	// Terminal wealth for the (wins,losses) tally — the order-invariant e-process
+	// value EvaluatePaceCounts decides on.
+	wealth := 1.0
+	for i := 0; i < wins; i++ {
+		wealth *= 1 + cfg.Lambda
+	}
+	for i := 0; i < losses; i++ {
+		wealth *= 1 - cfg.Lambda
+	}
+	switch verdict {
+	case PaceCommit:
+		return verdict, fmt.Sprintf("PACE commit: e-process wealth %.3g >= 1/alpha=%.3g over %d win / %d loss pair(s) (alpha=%.3g, lambda=%.3g)", wealth, threshold, wins, losses, cfg.Alpha, cfg.Lambda)
+	case PaceReject:
+		return verdict, fmt.Sprintf("PACE reject: pair budget exhausted (%d/%d discordant pairs) with wealth %.3g < 1/alpha=%.3g; notify only", wins+losses, cfg.MaxPairs, wealth, threshold)
+	default:
+		return verdict, fmt.Sprintf("PACE continue: wealth %.3g < 1/alpha=%.3g after %d/%d discordant pair(s); need more paired outcomes; notify only", wealth, threshold, wins+losses, cfg.MaxPairs)
+	}
+}

--- a/internal/skillopt/pace_replay_test.go
+++ b/internal/skillopt/pace_replay_test.go
@@ -1,0 +1,127 @@
+package skillopt
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// replayHistory drives a fresh PACE accumulator through an ordered synthetic
+// candidate-vs-champion history (peeking after every pair, as an online
+// anytime-valid test does) and returns the verdict plus how many DISCORDANT pairs
+// were consumed before it stopped (the "early stop" measurement). Ties advance the
+// history but never consume budget or move wealth.
+func replayHistory(cfg PaceConfig, history []PaceOutcome) (PaceVerdict, int) {
+	acc := NewPaceAccumulator(cfg)
+	for _, o := range history {
+		v := acc.Observe(o)
+		if v == PaceCommit || v == PaceReject {
+			return v, acc.Pairs()
+		}
+	}
+	return acc.Verdict(), acc.Pairs()
+}
+
+// bernoulliHistory builds a length-n history where each discordant pair is a
+// candidate win with probability p (no ties): the synthetic paired signal for a
+// candidate whose true per-pair win rate is p.
+func bernoulliHistory(rng *rand.Rand, n int, p float64) []PaceOutcome {
+	out := make([]PaceOutcome, n)
+	for i := range out {
+		if rng.Float64() < p {
+			out[i] = PaceWin
+		} else {
+			out[i] = PaceLoss
+		}
+	}
+	return out
+}
+
+// TestPaceReplayClearlyBetterCandidateCommitsEarly is the accept-side of the replay
+// harness (#687): a clearly-better candidate (true win rate 0.85) commits, and it
+// commits EARLY — far inside the pair budget — demonstrating the anytime-valid
+// early-stop that makes PACE cheaper than a fixed "run N" gate. Averaged over many
+// independent synthetic histories the mean stopping point is a small number of
+// pairs.
+func TestPaceReplayClearlyBetterCandidateCommitsEarly(t *testing.T) {
+	const (
+		runs    = 2000
+		budget  = 200
+		winRate = 0.85
+	)
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: budget}
+	rng := rand.New(rand.NewSource(7))
+	commits := 0
+	totalPairs := 0
+	maxPairs := 0
+	for r := 0; r < runs; r++ {
+		verdict, pairs := replayHistory(cfg, bernoulliHistory(rng, budget, winRate))
+		if verdict == PaceCommit {
+			commits++
+			totalPairs += pairs
+			if pairs > maxPairs {
+				maxPairs = pairs
+			}
+		}
+	}
+	// A strongly-better candidate should almost always commit.
+	commitRate := float64(commits) / float64(runs)
+	if commitRate < 0.95 {
+		t.Fatalf("clearly-better candidate committed in only %.1f%% of runs, want >= 95%%", commitRate*100)
+	}
+	// And it stops EARLY: the average committing run uses a small fraction of budget.
+	avgPairs := float64(totalPairs) / float64(commits)
+	if avgPairs > 40 {
+		t.Fatalf("mean commit stopping point %.1f pairs is not 'early' (budget %d)", avgPairs, budget)
+	}
+	t.Logf("clearly-better candidate: commit rate %.1f%%, mean stop %.1f pairs, max stop %d (budget %d)", commitRate*100, avgPairs, maxPairs, budget)
+}
+
+// TestPaceReplayFiftyFiftyNoiseRarelyCommits is the false-commit-control side of the
+// replay harness (#687): a candidate that is NO better than the champion (true win
+// rate 0.5, pure noise) must almost never commit within budget — the whole point of
+// the anytime-valid gate is that peeking-until-you-win does NOT p-hack a promotion.
+// The empirical false-commit rate is bounded by alpha (Ville).
+func TestPaceReplayFiftyFiftyNoiseRarelyCommits(t *testing.T) {
+	const (
+		runs   = 20000
+		budget = 200
+		alpha  = 0.05
+	)
+	cfg := PaceConfig{Alpha: alpha, Lambda: DefaultPaceLambda, MaxPairs: budget}
+	rng := rand.New(rand.NewSource(99))
+	commits := 0
+	rejects := 0
+	for r := 0; r < runs; r++ {
+		verdict, _ := replayHistory(cfg, bernoulliHistory(rng, budget, 0.5))
+		switch verdict {
+		case PaceCommit:
+			commits++
+		case PaceReject:
+			rejects++
+		}
+	}
+	falseRate := float64(commits) / float64(runs)
+	if falseRate > alpha+0.01 {
+		t.Fatalf("50/50 noise false-commit rate %.4f exceeds alpha=%.2f (+margin)", falseRate, alpha)
+	}
+	// The overwhelming majority of pure-noise candidates should be correctly rejected
+	// at budget (the safe failure mode).
+	rejectRate := float64(rejects) / float64(runs)
+	if rejectRate < 0.90 {
+		t.Fatalf("50/50 noise reject rate %.4f too low; want the safe reject to dominate", rejectRate)
+	}
+	t.Logf("50/50 noise: false-commit rate %.4f (alpha %.2f), reject rate %.4f", falseRate, alpha, rejectRate)
+}
+
+// TestPaceReplayDeterministic proves the replay harness is deterministic for a fixed
+// seed: identical histories yield identical (verdict, stop) results across runs, so
+// a recorded candidate history is reproducible.
+func TestPaceReplayDeterministic(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: 200}
+	history := bernoulliHistory(rand.New(rand.NewSource(1234)), 200, 0.8)
+	v1, p1 := replayHistory(cfg, history)
+	v2, p2 := replayHistory(cfg, history)
+	if v1 != v2 || p1 != p2 {
+		t.Fatalf("replay not deterministic: (%v,%d) vs (%v,%d)", v1, p1, v2, p2)
+	}
+}

--- a/internal/skillopt/pace_test.go
+++ b/internal/skillopt/pace_test.go
@@ -1,0 +1,280 @@
+package skillopt
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+)
+
+// TestPaceDefaultsInLockstepWithConfig pins the numeric PACE defaults duplicated in
+// internal/config (which cannot import skillopt without a cycle) to the canonical
+// skillopt constants, so the two never drift.
+func TestPaceDefaultsInLockstepWithConfig(t *testing.T) {
+	if config.DefaultPaceAlpha != DefaultPaceAlpha {
+		t.Fatalf("config.DefaultPaceAlpha %v != skillopt %v", config.DefaultPaceAlpha, DefaultPaceAlpha)
+	}
+	if config.DefaultPaceLambda != DefaultPaceLambda {
+		t.Fatalf("config.DefaultPaceLambda %v != skillopt %v", config.DefaultPaceLambda, DefaultPaceLambda)
+	}
+	if config.DefaultPaceMaxPairs != DefaultPaceMaxPairs {
+		t.Fatalf("config.DefaultPaceMaxPairs %v != skillopt %v", config.DefaultPaceMaxPairs, DefaultPaceMaxPairs)
+	}
+}
+
+// TestPaceCommitsOnConsecutiveWins pins the exact crossing point for the default
+// config (alpha=0.05 -> threshold 20, lambda=0.5 -> win x1.5): 1.5^n first reaches
+// 20 at n=8 (1.5^7=17.09 < 20 <= 1.5^8=25.63). Before 8 wins the verdict is
+// continue; at 8 it commits.
+func TestPaceCommitsOnConsecutiveWins(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: DefaultPaceMaxPairs}
+	acc := NewPaceAccumulator(cfg)
+	for i := 1; i <= 7; i++ {
+		if v := acc.Observe(PaceWin); v != PaceContinue {
+			t.Fatalf("after %d wins verdict = %v, want continue", i, v)
+		}
+	}
+	if v := acc.Observe(PaceWin); v != PaceCommit {
+		t.Fatalf("after 8 wins verdict = %v, want commit", v)
+	}
+	if !acc.Committed() {
+		t.Fatal("accumulator should have latched committed after 8 wins")
+	}
+	// Threshold crossed exactly at 8: wealth = 1.5^8.
+	if got, want := acc.Wealth(), math.Pow(1.5, 8); math.Abs(got-want) > 1e-9 {
+		t.Fatalf("wealth = %v, want %v", got, want)
+	}
+}
+
+// TestPaceCommitLatches proves an anytime-valid stop is final: once committed,
+// further losses (which would otherwise drag wealth below the threshold) never
+// un-commit it.
+func TestPaceCommitLatches(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: DefaultPaceMaxPairs}
+	acc := NewPaceAccumulator(cfg)
+	for i := 0; i < 8; i++ {
+		acc.Observe(PaceWin)
+	}
+	if !acc.Committed() {
+		t.Fatal("precondition: expected commit after 8 wins")
+	}
+	for i := 0; i < 100; i++ {
+		if v := acc.Observe(PaceLoss); v != PaceCommit {
+			t.Fatalf("committed accumulator returned %v after a loss, want commit (latched)", v)
+		}
+	}
+	// The wealth is frozen once latched: losses after commit do not move it.
+	if got, want := acc.Wealth(), math.Pow(1.5, 8); math.Abs(got-want) > 1e-9 {
+		t.Fatalf("wealth moved after commit: got %v, want frozen %v", got, want)
+	}
+}
+
+// TestPaceTiesDiscarded proves ties carry no information: an unbounded stream of
+// ties never changes wealth, never increments the discordant-pair count, and never
+// decides (stays continue forever, even past MaxPairs worth of ties).
+func TestPaceTiesDiscarded(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: 5}
+	acc := NewPaceAccumulator(cfg)
+	for i := 0; i < 1000; i++ {
+		if v := acc.Observe(PaceTie); v != PaceContinue {
+			t.Fatalf("tie %d produced verdict %v, want continue", i, v)
+		}
+	}
+	if acc.Pairs() != 0 {
+		t.Fatalf("discordant pairs = %d after 1000 ties, want 0", acc.Pairs())
+	}
+	if acc.Wealth() != 1.0 {
+		t.Fatalf("wealth = %v after 1000 ties, want 1 (unchanged)", acc.Wealth())
+	}
+	// Ties interleaved with a real pair must not consume budget: only the win counts.
+	if v := acc.Observe(PaceWin); v != PaceContinue {
+		t.Fatalf("verdict after 1 win = %v, want continue", v)
+	}
+	if acc.Pairs() != 1 {
+		t.Fatalf("discordant pairs = %d, want 1 (ties excluded)", acc.Pairs())
+	}
+}
+
+// TestPaceLambdaZeroIsNoOp proves lambda=0 is a legal no-op: wealth never moves off
+// 1, so the e-process can never commit no matter how many wins arrive; it rejects
+// only when the pair budget is exhausted.
+func TestPaceLambdaZeroIsNoOp(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: 0, MaxPairs: 10}
+	acc := NewPaceAccumulator(cfg)
+	for i := 0; i < 9; i++ {
+		if v := acc.Observe(PaceWin); v != PaceContinue {
+			t.Fatalf("lambda=0 win %d verdict = %v, want continue", i, v)
+		}
+		if acc.Wealth() != 1.0 {
+			t.Fatalf("lambda=0 wealth = %v, want 1 (no-op)", acc.Wealth())
+		}
+	}
+	// 10th discordant pair exhausts the budget without ever crossing -> reject.
+	if v := acc.Observe(PaceWin); v != PaceReject {
+		t.Fatalf("lambda=0 at budget verdict = %v, want reject", v)
+	}
+}
+
+// TestPaceRejectsOnBudgetExhaustion proves an all-loss (or mixed non-decisive)
+// stream rejects exactly when MaxPairs discordant pairs are consumed without a
+// crossing.
+func TestPaceRejectsOnBudgetExhaustion(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: 6}
+	acc := NewPaceAccumulator(cfg)
+	for i := 1; i <= 5; i++ {
+		if v := acc.Observe(PaceLoss); v != PaceContinue {
+			t.Fatalf("after %d losses verdict = %v, want continue", i, v)
+		}
+	}
+	if v := acc.Observe(PaceLoss); v != PaceReject {
+		t.Fatalf("after 6 losses (budget) verdict = %v, want reject", v)
+	}
+}
+
+// TestPaceDeterministicSequenceOrderIndependentTerminal proves the streaming
+// accumulator's terminal wealth is order-independent (multiplication commutes):
+// wins-first and losses-first give the same final wealth for the same counts. The
+// commit MOMENT differs, but the terminal value does not.
+func TestPaceDeterministicSequenceOrderIndependentTerminal(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: DefaultPaceMaxPairs}
+	winsFirst := NewPaceAccumulator(cfg)
+	for i := 0; i < 3; i++ {
+		winsFirst.Observe(PaceWin)
+	}
+	for i := 0; i < 3; i++ {
+		winsFirst.Observe(PaceLoss)
+	}
+	lossFirst := NewPaceAccumulator(cfg)
+	for i := 0; i < 3; i++ {
+		lossFirst.Observe(PaceLoss)
+	}
+	for i := 0; i < 3; i++ {
+		lossFirst.Observe(PaceWin)
+	}
+	if math.Abs(winsFirst.Wealth()-lossFirst.Wealth()) > 1e-9 {
+		t.Fatalf("terminal wealth differs by order: wins-first %v vs loss-first %v", winsFirst.Wealth(), lossFirst.Wealth())
+	}
+	// 3 wins (x1.5) and 3 losses (x0.5): 1.5^3 * 0.5^3 = 3.375 * 0.125 = 0.421875.
+	if got := lossFirst.Wealth(); math.Abs(got-0.421875) > 1e-9 {
+		t.Fatalf("terminal wealth = %v, want 0.421875", got)
+	}
+}
+
+// TestEvaluatePaceCountsConservativeVsStream proves EvaluatePaceCounts (losses-first,
+// the count-summary reading) never commits when the terminal wealth is below the
+// threshold, even for a count where a WIN-first ordered stream WOULD have committed
+// early and then fallen back. This is the false-early-commit protection.
+func TestEvaluatePaceCountsConservativeVsStream(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: DefaultPaceMaxPairs}
+	// 8 wins then enough losses to drop terminal wealth below 20: 1.5^8 = 25.63,
+	// times 0.5^2 = 0.25 -> 6.4 < 20. Terminal does NOT cross.
+	wins, losses := 8, 2
+	// A win-first ordered stream commits (crosses at the 8th win) then latches.
+	if v := EvaluatePaceStream(cfg, buildStream(wins, losses, true)); v != PaceCommit {
+		t.Fatalf("win-first ordered stream verdict = %v, want commit (early crossing)", v)
+	}
+	// The count summary (losses-first / terminal) must NOT commit: terminal 6.4 < 20.
+	if v := EvaluatePaceCounts(cfg, wins, losses); v == PaceCommit {
+		t.Fatalf("EvaluatePaceCounts committed on terminal wealth below threshold (wins=%d losses=%d)", wins, losses)
+	}
+}
+
+// TestEvaluatePaceCountsCommitsOnDominantCandidate proves a clearly-better candidate
+// (many more wins than losses) commits via the count summary.
+func TestEvaluatePaceCountsCommitsOnDominantCandidate(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: DefaultPaceMaxPairs}
+	// 10 wins, 1 loss: 1.5^10 * 0.5 = 57.67 * 0.5 = 28.8 >= 20 -> commit.
+	if v := EvaluatePaceCounts(cfg, 10, 1); v != PaceCommit {
+		t.Fatalf("dominant candidate verdict = %v, want commit", v)
+	}
+}
+
+// TestEvaluatePaceCountsNegativeClamped proves negative counts are clamped to zero
+// (a defensive guard for a malformed arm) and decide continue with no evidence.
+func TestEvaluatePaceCountsNegativeClamped(t *testing.T) {
+	cfg := PaceConfig{Alpha: DefaultPaceAlpha, Lambda: DefaultPaceLambda, MaxPairs: DefaultPaceMaxPairs}
+	if v := EvaluatePaceCounts(cfg, -5, -3); v != PaceContinue {
+		t.Fatalf("negative counts verdict = %v, want continue (clamped to zero evidence)", v)
+	}
+}
+
+// TestPaceConfigDefaults proves clearly-invalid config fields fall back to the RFC
+// defaults while a legal lambda=0 is preserved.
+func TestPaceConfigDefaults(t *testing.T) {
+	got := PaceConfig{Alpha: 0, Lambda: -1, MaxPairs: 0}.withDefaults()
+	if got.Alpha != DefaultPaceAlpha || got.Lambda != DefaultPaceLambda || got.MaxPairs != DefaultPaceMaxPairs {
+		t.Fatalf("invalid config defaulted to %+v, want the Default* constants", got)
+	}
+	kept := PaceConfig{Alpha: 0.1, Lambda: 0, MaxPairs: 12}.withDefaults()
+	if kept.Alpha != 0.1 || kept.Lambda != 0 || kept.MaxPairs != 12 {
+		t.Fatalf("legal config was altered: %+v (lambda=0 must be preserved)", kept)
+	}
+	if got, want := (PaceConfig{Alpha: 0.05}).CommitThreshold(), 20.0; math.Abs(got-want) > 1e-9 {
+		t.Fatalf("CommitThreshold = %v, want %v", got, want)
+	}
+}
+
+// TestPaceMartingaleFalseCommitRateBounded is the martingale property check: under
+// H0 (each discordant pair is a candidate win with probability 1/2), the average
+// terminal wealth stays ~1 (E[E] <= 1) and the fraction of runs that ever commit is
+// bounded by alpha (Ville's inequality). We run many independent 50/50 histories
+// and assert both.
+func TestPaceMartingaleFalseCommitRateBounded(t *testing.T) {
+	const (
+		alpha = 0.05
+		runs  = 20000
+		pairs = 500
+	)
+	cfg := PaceConfig{Alpha: alpha, Lambda: DefaultPaceLambda, MaxPairs: pairs}
+	rng := rand.New(rand.NewSource(42))
+	commits := 0
+	sumWealth := 0.0
+	for r := 0; r < runs; r++ {
+		acc := NewPaceAccumulator(cfg)
+		for p := 0; p < pairs; p++ {
+			outcome := PaceLoss
+			if rng.Intn(2) == 1 {
+				outcome = PaceWin
+			}
+			if acc.Observe(outcome) == PaceCommit {
+				break
+			}
+		}
+		if acc.Committed() {
+			commits++
+		}
+		sumWealth += acc.Wealth()
+	}
+	falseRate := float64(commits) / float64(runs)
+	// Ville: P(ever commit) <= alpha. Allow a small Monte-Carlo margin.
+	if falseRate > alpha+0.01 {
+		t.Fatalf("false-commit rate %.4f exceeds alpha=%.2f (+margin)", falseRate, alpha)
+	}
+	// A valid e-process has E[terminal wealth] <= 1 (supermartingale). The empirical
+	// mean should sit at or below ~1 (allow a modest upper margin for finite runs and
+	// the heavy right tail; it must not blow up).
+	meanWealth := sumWealth / float64(runs)
+	if meanWealth > 1.5 {
+		t.Fatalf("mean terminal wealth %.4f is implausibly high for a fair martingale", meanWealth)
+	}
+}
+
+// buildStream materializes a win/loss stream in a fixed order for the ordered-stream
+// tests: winsFirst true => all wins then all losses; false => losses then wins.
+func buildStream(wins, losses int, winsFirst bool) []PaceOutcome {
+	out := make([]PaceOutcome, 0, wins+losses)
+	add := func(o PaceOutcome, n int) {
+		for i := 0; i < n; i++ {
+			out = append(out, o)
+		}
+	}
+	if winsFirst {
+		add(PaceWin, wins)
+		add(PaceLoss, losses)
+	} else {
+		add(PaceLoss, losses)
+		add(PaceWin, wins)
+	}
+	return out
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1143,6 +1143,23 @@ passing gate run before it may be promoted to canary or current; otherwise the
 promotion seam blocks. On a gate failure the protocol allows exactly one retry
 feeding the failing replay log back to the optimizer, then rejects.
 
+When `[skillopt].pace_enabled` is on, an **additional** off-by-default
+**PACE anytime-valid commit gate** (`#687`) sits on the auto-promote path: a
+guardrails-pass candidate is auto-promoted only when a model-free
+testing-by-betting e-process over its recorded candidate-vs-champion pairwise
+outcomes (the Mode B bandit arm's win/loss tally, `#481`/`#482`) crosses the
+commit threshold `1/pace_alpha`. Each discordant pair bets `pace_lambda` of the
+wealth (`E ← E·(1+λ(2w−1))`, ties discarded); the gate **stops early** the moment
+it is decisive and **rejects** once `pace_max_pairs` discordant pairs are spent
+without crossing — so peeking-until-you-win cannot p-hack a promotion (Ville's
+inequality bounds the false-commit probability by `pace_alpha`). It is a strictly
+additional gate: **every** existing guardrail (`auto_promote_min_samples`/
+`_min_score`/`require_external_ci`/`_min_confidence`/canary/replay gate) still
+applies, and a non-decisive or budget-exhausted stream **fails safe** to a
+`pace_blocked` notify (no promotion). Off (the default) it is never consulted —
+byte-identical. Knobs: `pace_alpha` (default `0.05` → threshold 20), `pace_lambda`
+(default `0.5`), `pace_max_pairs` (default `200`).
+
 `skillopt pairwise import <packet-dir>` ingests a **blinded paired-review
 packet** produced by the gitmoot-skillopt fork (the `pairwise-review.json`
 packet plus its secret map and the reviewer's picks), de-blinds it, and stores

--- a/website/docs/workflows/skillopt-train-workflow.md
+++ b/website/docs/workflows/skillopt-train-workflow.md
@@ -748,6 +748,32 @@ may be promoted to canary or current; otherwise the promotion seam blocks with a
 `auto_trace_enabled` dependency), and with it off the promote path is
 byte-identical to before. Promotion itself stays manual.
 
+### PACE anytime-valid commit gate (#687)
+
+`pace_enabled` adds an **additional**, off-by-default promotion gate on the
+auto-promote path. When on, a guardrails-pass candidate is auto-promoted only when
+a **model-free** testing-by-betting e-process over its recorded
+candidate-vs-champion pairwise outcomes (the Mode B bandit arm's win/loss tally,
+`#481`/`#482`) crosses the commit threshold `1/pace_alpha`:
+
+```toml
+[skillopt]
+pace_enabled = true
+pace_alpha = 0.05      # target false-commit probability; threshold = 1/alpha = 20
+pace_lambda = 0.5      # bet fraction: win → wealth ×(1+λ), loss → ×(1−λ)
+pace_max_pairs = 200   # discordant-pair budget before a non-decisive stream rejects
+```
+
+Each discordant pair updates wealth `E ← E·(1+λ(2w−1))` (ties discarded). The gate
+**stops early** the moment it is decisive and **rejects** once `pace_max_pairs`
+pairs are spent without crossing, so peeking-until-you-win cannot p-hack a
+promotion — Ville's inequality bounds the false-commit probability by `pace_alpha`
+at any stopping time. PACE is **strictly additional**: every existing guardrail
+(`auto_promote_min_samples`/`_min_score`/`require_external_ci`/`_min_confidence`/
+canary/replay gate) still applies, and a non-decisive or budget-exhausted stream
+**fails safe** to a `pace_blocked` notify (no promotion). Off (the default) it is
+never consulted — byte-identical.
+
 ## Candidate Review And Next Iteration
 
 The candidate review step publishes the candidate summary, preview/PR links


### PR DESCRIPTION
## What

Adds **PACE** — a pure, model-free *anytime-valid commit gate* for SkillOpt
candidate promotion (arXiv:2606.08106), the accept-side complement of
measure-the-judge (#344). It is an **optional, off-by-default, ADDITIONAL** gate:
with `pace_enabled=false` (the default) the e-process is never consulted and the
promotion path is byte-identical.

## Design

**`internal/skillopt/pace.go` — the pure e-process (no model calls, no I/O).**
Feed a stream of paired candidate-vs-champion outcomes `{win, loss, tie}`:

- Ties are **discarded** (concordant pairs carry no information under H0).
- Wealth `E` starts at `1`; each **discordant** pair updates
  `E ← E·(1 + λ(2w−1))` — a win scales by `(1+λ)`, a loss by `(1−λ)`.
- **Commit** when `E ≥ 1/α` (Ville's inequality bounds the false-commit
  probability by `α` at *any* stopping time — you may peek after every pair),
  **reject** when the discordant-pair budget `max_pairs` is spent without
  crossing, else **continue**.
- Streaming `PaceAccumulator` latches commit on the first crossing (early stop).
  `EvaluatePaceCounts` decides from an aggregate win/loss tally by feeding
  losses-first, which makes the commit decision equal the **order-invariant**
  terminal-wealth test `E = (1+λ)^wins·(1−λ)^losses ≥ 1/α` — the conservative
  reading that never manufactures a false early commit from a count summary.

Configurable `α` (default `0.05` → threshold 20), `λ` (default `0.5`),
`max_pairs` (default `200`).

**Wiring (`internal/cli/candidate_notify.go`).** On the existing Mode B
pairwise/bandit promotion seam, `resolveBanditConfidence` now also recovers the
candidate-vs-champion win/loss tally from the challenger bandit arm
(`skillopt_bandit_arms`, #481/#482): `wins = α−1`, `losses = β−1` under the
Beta(1,1) prior (ties are never recorded by the bandit). When `pace_enabled`, a
guardrails-pass candidate is auto-promoted **only** when the e-process over that
tally commits; a non-decisive (`continue`) or budget-exhausted (`reject`) stream
**fails safe** to a `pace_blocked` notify (mirroring the #627 `gate_blocked`
behavior). PACE runs **after** `EvaluateAutoPromote` returns `Promote=true`, so it
is strictly *additional*: `auto_promote_min_samples`/`_min_score`/
`require_external_ci`/`_min_confidence`/canary/replay-gate all still apply and can
still block first.

**Config (`internal/config`).** `[skillopt] pace_enabled` (false),
`pace_alpha`, `pace_lambda`, `pace_max_pairs` — parsed and range-validated in the
existing skillopt loader, documented in `init.go`'s `[skillopt]` block.

## Tests

- `pace_test.go`: exact crossing point, commit latching, ties discarded, `λ=0`
  no-op, budget-exhaustion reject, order-invariant terminal wealth, the
  conservative-vs-ordered-stream false-early-commit guard, config defaults, and a
  **martingale/Ville** Monte-Carlo check (false-commit rate ≤ α, `E[E] ≤ 1`).
- `pace_replay_test.go`: replay harness — a clearly-better candidate (win rate
  0.85) commits **early** (well inside budget); 50/50 noise almost never commits
  (bounded by α) and is safely rejected.
- Config loader tests (defaults off + byte-identical, parsing, `λ=0` allowed,
  out-of-range rejection) and CLI wiring tests (off byte-identical, blocks on thin
  evidence, rejects on exhausted budget, commits on a dominant tally, and
  additional-not-replacement).

## Docs

`skills/gitmoot/references/CLI.md` and `docs/` + `website/docs/` skillopt-train
workflow (both trees). Follow-up per the RFC: wiring the #627 replay corpus as a
paired Mode A source is deferred.

## Scope

Off-by-default and additive; the default promotion path is byte-identical.

Closes #687
