### PR TITLE
fix(review): re-sync instead of fail when the PR branch advances (head-SHA mismatch)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 var newRuntimeFactory = func() runtime.Factory {
@@ -510,6 +511,13 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 	}
 	if options.background {
 		output.WatchCommand = jobWatchCommand(output.JobID, options.home)
+	}
+	// Resolve daemon liveness whenever the job is left QUEUED — for a background job
+	// (always queued) and, per #684, for a FOREGROUND review that was re-queued
+	// because its runtime session was busy. Both need the daemon-hint below;
+	// otherwise a foreground caller would see a bare "state: queued" with no clue the
+	// review has not run and no daemon guidance.
+	if output.State == string(workflow.JobQueued) {
 		running, err := daemonIsRunning(options.home)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s: %v\n", errLabel, err)
@@ -808,9 +816,23 @@ func looksLikeImplementationRequest(message string) bool {
 }
 
 func printQueuedDaemonHint(stdout io.Writer, output localAgentJobOutput, background bool, home string) {
-	if background && !output.DaemonRunning {
+	if output.State != string(workflow.JobQueued) {
+		return
+	}
+	if !output.DaemonRunning {
+		// No daemon to pick the job up: without this, a foreground `agent review`
+		// whose runtime session was busy (#684) would exit 0 showing "state: queued"
+		// and silently never run. Point the caller at the daemon or a manual run.
 		writeLine(stdout, "queued: daemon is not running")
 		writeLine(stdout, "process: %s", daemonStartHint(home, output.Repo))
+		writeLine(stdout, "or: %s", jobRunCommand(output.JobID, home))
+		return
+	}
+	if !background {
+		// A foreground review left queued because its runtime session was busy: the
+		// daemon IS up and will run it when the session frees. Say so explicitly so
+		// the caller does not read "state: queued" as "the review already ran".
+		writeLine(stdout, "queued: runtime session busy; the daemon will run this review when the session frees")
 		writeLine(stdout, "or: %s", jobRunCommand(output.JobID, home))
 	}
 }

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -246,6 +246,20 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		return localAgentJobOutput{}, err
 	}
 	if !acquired {
+		// #684 failure mode B: a review is naturally asynchronous — a busy runtime
+		// session just means "run me a moment later", exactly the daemon's own
+		// runtime-busy handling (it bounces errRuntimeSessionBusy and keeps the job
+		// QUEUED). Rather than cancelling and dropping a foreground review when the
+		// serialized runtime session is busy (the reported "queued job … was not run"
+		// drop), LEAVE it QUEUED so the daemon runs it when the session frees. Ask /
+		// implement stay synchronous (the caller is waiting on the answer / the
+		// mutation) and keep the existing cancel-and-report behavior byte-identically.
+		if request.Action == "review" {
+			waitMessage := fmt.Sprintf("runtime session %s is busy; review job %s left queued for the daemon to run when the session frees", lockKey, job.ID)
+			_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "runtime_lock_wait", Message: waitMessage})
+			_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "requeued_runtime_busy", Message: waitMessage})
+			return buildLocalAgentJobOutput(job, request)
+		}
 		message := fmt.Sprintf("runtime session %s is busy; synchronous ask was not run", lockKey)
 		_, _ = store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobQueued), string(workflow.JobCancelled), db.JobEvent{
 			JobID:   job.ID,

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -7040,6 +7040,18 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 		switch {
 		case payload.PullRequest > 0 && strings.TrimSpace(payload.TaskID) != "":
 			if err := w.validateReviewCheckout(ctx, payload, checkout); err != nil {
+				// #684: the PR branch commonly advances between enqueue and execution
+				// in an active dev loop, leaving the checkout on a NEWER head than the
+				// one the review was pinned to. Re-target the review to the checkout's
+				// current head (reviewing the newest commit is what a human reviewer
+				// does) when the PR is still open, instead of failing on the mismatch.
+				// A closed/merged PR, a dirty tree, or any other checkout error keeps
+				// the existing terminal / deferral path.
+				if resynced, resyncErr := w.resyncReviewHead(ctx, job, payload, checkout, err); resyncErr != nil {
+					return "", resyncErr
+				} else if resynced {
+					return checkout, nil
+				}
 				return "", err
 			}
 		case payload.PullRequest <= 0 && strings.TrimSpace(payload.Branch) == "":
@@ -7265,6 +7277,103 @@ func (w jobWorker) validateReviewCheckout(ctx context.Context, payload workflow.
 		return fmt.Errorf("checkout head is %s, not review job head %s", head, expectedHead)
 	}
 	return nil
+}
+
+// isReviewHeadMismatch reports whether a checkout pre-flight error is specifically
+// the review head-SHA drift emitted by validateReviewCheckout ("checkout head is
+// X, not review job head Y") — NOT a dirty tree, a missing head, or a branch
+// mismatch. Only that one condition is eligible for the #684 re-sync; every other
+// checkout error keeps its existing terminal / deferral path.
+func isReviewHeadMismatch(cause error) bool {
+	if cause == nil {
+		return false
+	}
+	return strings.Contains(cause.Error(), "not review job head")
+}
+
+// reviewPullRequestClosed reports whether the review's PR is known to be closed or
+// merged, using the locally-tracked pull_requests record. A missing record
+// (sql.ErrNoRows) is deliberately treated as NOT closed so the resilient #684
+// re-sync still applies to a PR the local store has not recorded yet; a real DB
+// error is surfaced so the caller declines to re-sync and falls through to the
+// existing behavior.
+func (w jobWorker) reviewPullRequestClosed(ctx context.Context, repo string, number int) (bool, error) {
+	pr, err := w.Store.GetPullRequest(ctx, repo, int64(number))
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	state := strings.ToLower(strings.TrimSpace(pr.State))
+	return state == "closed" || state == "merged", nil
+}
+
+// resyncReviewHead handles #684 head-SHA drift for a PR review job. A review is
+// pinned to the PR head SHA at enqueue; in an active dev loop the branch often
+// advances (a newer commit is pushed) before the queued review runs, so the
+// registered checkout sits on a NEWER head than the one the review was pinned to.
+// validateReviewCheckout then rejects it with "checkout head is <new>, not review
+// job head <old>", and the job ultimately fails — even though reviewing the
+// checkout's current head is strictly more useful (it is exactly what a human
+// reviewer does). resyncReviewHead re-targets the review to the checkout's current
+// head instead of failing, but ONLY when:
+//
+//   - the validation failure was specifically the review head-SHA mismatch (a
+//     dirty tree, a missing head, or a branch mismatch is left untouched), and
+//   - the PR is still OPEN (a closed/merged PR keeps the existing terminal path so
+//     a stale review of a dead PR does not silently pass).
+//
+// On a re-sync it persists the current head onto the job payload (RunJob re-reads
+// the payload from the store, so the delivered review prompt and the posted PR
+// comment carry the new head) and records a review_head_resynced event, then
+// returns true so defaultCheckout proceeds with the review. Every declined case
+// returns false so the caller's existing error path runs byte-identically.
+func (w jobWorker) resyncReviewHead(ctx context.Context, job db.Job, payload workflow.JobPayload, checkout string, cause error) (bool, error) {
+	if !isReviewHeadMismatch(cause) {
+		return false, nil
+	}
+	if payload.PullRequest <= 0 {
+		return false, nil
+	}
+	closed, err := w.reviewPullRequestClosed(ctx, payload.Repo, payload.PullRequest)
+	if err != nil {
+		// Undeterminable PR state (a DB read error) ⇒ do not re-sync; fall through to
+		// the existing deferral/terminal path rather than reviewing a possibly-dead PR.
+		return false, nil
+	}
+	if closed {
+		return false, nil
+	}
+	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		return false, err
+	}
+	head = strings.TrimSpace(head)
+	previous := strings.TrimSpace(payload.HeadSHA)
+	if head == "" || head == previous {
+		// Nothing to re-target to (empty or already-current head); let the caller's
+		// existing path handle it.
+		return false, nil
+	}
+	payload.HeadSHA = head
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return false, err
+	}
+	if err := w.Store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		return false, err
+	}
+	if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{
+		JobID: job.ID,
+		Kind:  "review_head_resynced",
+		Message: fmt.Sprintf("PR #%d branch advanced from %s to %s before the review ran; re-targeting the review to the current head",
+			payload.PullRequest, previous, head),
+	}); eventErr != nil {
+		return false, eventErr
+	}
+	writeLine(w.Stdout, "job %s review head re-synced %s -> %s (PR #%d advanced)", job.ID, previous, head, payload.PullRequest)
+	return true, nil
 }
 
 func implementationLockOwner(agent runtime.Agent, payload workflow.JobPayload) string {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -7291,13 +7291,19 @@ func isReviewHeadMismatch(cause error) bool {
 	return strings.Contains(cause.Error(), "not review job head")
 }
 
-// reviewPullRequestClosed reports whether the review's PR is known to be closed or
-// merged, using the locally-tracked pull_requests record. A missing record
-// (sql.ErrNoRows) is deliberately treated as NOT closed so the resilient #684
-// re-sync still applies to a PR the local store has not recorded yet; a real DB
-// error is surfaced so the caller declines to re-sync and falls through to the
-// existing behavior.
-func (w jobWorker) reviewPullRequestClosed(ctx context.Context, repo string, number int) (bool, error) {
+// reviewPullRequestOpen reports whether the review's PR is KNOWN to be open, using
+// the locally-tracked pull_requests record (the daemon's PR-watcher upserts an
+// open record for every PR it watches before it fans out review jobs, so a genuine
+// #684 review of an active PR has one). Re-sync is gated on a definitively-open PR:
+//
+//   - record found + state open (or any non-closed/-merged state) ⇒ open (re-sync).
+//   - record found + state closed/merged ⇒ NOT open (a stale review of a dead PR
+//     must not silently pass; keep the existing terminal path).
+//   - NO record (sql.ErrNoRows) ⇒ NOT open. The store has no evidence the PR is
+//     live, so it falls through to the existing #532 checkout-contention deferral
+//     rather than re-targeting to a possibly-unrelated checkout head.
+//   - a real DB error ⇒ surfaced; the caller declines to re-sync.
+func (w jobWorker) reviewPullRequestOpen(ctx context.Context, repo string, number int) (bool, error) {
 	pr, err := w.Store.GetPullRequest(ctx, repo, int64(number))
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
@@ -7306,7 +7312,7 @@ func (w jobWorker) reviewPullRequestClosed(ctx context.Context, repo string, num
 		return false, err
 	}
 	state := strings.ToLower(strings.TrimSpace(pr.State))
-	return state == "closed" || state == "merged", nil
+	return state != "closed" && state != "merged", nil
 }
 
 // resyncReviewHead handles #684 head-SHA drift for a PR review job. A review is
@@ -7336,13 +7342,15 @@ func (w jobWorker) resyncReviewHead(ctx context.Context, job db.Job, payload wor
 	if payload.PullRequest <= 0 {
 		return false, nil
 	}
-	closed, err := w.reviewPullRequestClosed(ctx, payload.Repo, payload.PullRequest)
+	open, err := w.reviewPullRequestOpen(ctx, payload.Repo, payload.PullRequest)
 	if err != nil {
 		// Undeterminable PR state (a DB read error) ⇒ do not re-sync; fall through to
 		// the existing deferral/terminal path rather than reviewing a possibly-dead PR.
 		return false, nil
 	}
-	if closed {
+	if !open {
+		// A closed/merged PR, or one the store has no record of, keeps the existing
+		// #532 deferral / terminal path — only a definitively-open PR is re-synced.
 		return false, nil
 	}
 	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -7353,6 +7353,18 @@ func (w jobWorker) resyncReviewHead(ctx context.Context, job db.Job, payload wor
 		// #532 deferral / terminal path — only a definitively-open PR is re-synced.
 		return false, nil
 	}
+	// Confirm the resolved checkout is actually on the PR's head branch before
+	// re-targeting. A review that falls back to the registered shared checkout (which
+	// sits on `main`, not the PR branch) must NOT be re-synced to main's head — that
+	// would review the wrong tree and could post an approval against a SHA that is not
+	// the PR head. We only decline when we can POSITIVELY confirm the branch differs:
+	// a detached-HEAD worktree (CurrentBranch errors) is a legitimate #684 target and
+	// is left to proceed. We deliberately do NOT gate on head == pr.HeadSHA because the
+	// PR-watcher can lag the push, which is exactly the drift #684 exists to tolerate.
+	if b, err := (gitutil.Client{Dir: checkout}).CurrentBranch(ctx); err == nil &&
+		strings.TrimSpace(b) != strings.TrimSpace(payload.Branch) {
+		return false, nil
+	}
 	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
 	if err != nil {
 		return false, err

--- a/internal/cli/review_head_resync_test.go
+++ b/internal/cli/review_head_resync_test.go
@@ -204,6 +204,98 @@ func TestDefaultCheckoutFailsReviewHeadMismatchWhenPRClosed(t *testing.T) {
 	}
 }
 
+// #684 mode A safety guard: when a review falls back to the registered SHARED
+// checkout (which sits on `main`, not the PR branch — e.g. the task worktree was
+// cleaned up while a stale review was still queued), it must NOT be re-synced to
+// main's head. Re-targeting there would review main's tree (none of the PR's
+// changes) and could post an approval against a SHA that is not the PR head. The
+// branch mismatch (checkout on `main`, review pinned to `feat/x`) makes resync
+// decline, so the job keeps the existing head-mismatch failure.
+func TestDefaultCheckoutDeclinesResyncWhenCheckoutOnWrongBranch(t *testing.T) {
+	ctx := context.Background()
+	// The shared checkout sits on `main`, NOT the PR's head branch.
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	worker := defaultJobWorker(store, io.Discard)
+
+	// The head the review was pinned to (the PR branch's tip) — differs from main's
+	// head, so validateReviewCheckout raises the head-SHA mismatch.
+	staleHead := daemonWorkerHeadSHA(t, checkout)
+	if err := os.WriteFile(checkout+"/main.txt", []byte("main advances\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runDaemonWorkerGit(t, checkout, "add", "main.txt")
+	runDaemonWorkerGit(t, checkout, "commit", "-m", "advance main")
+	mainHead := daemonWorkerHeadSHA(t, checkout)
+	if mainHead == staleHead {
+		t.Fatal("test setup: main head did not advance")
+	}
+
+	// The PR is OPEN on branch feat/x — the store would otherwise green-light a resync.
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo",
+		Number:       23,
+		HeadBranch:   "feat/x",
+		HeadSHA:      staleHead,
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+
+	// The queued review is pinned to the feat/x branch + its stale head, but its task
+	// worktree is gone so it resolves the shared checkout (which is on main).
+	if _, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+		ID:          "workflow-review-3",
+		Agent:       "reviewer",
+		Action:      "review",
+		Repo:        "owner/repo",
+		Branch:      "feat/x",
+		PullRequest: 23,
+		HeadSHA:     staleHead,
+		TaskID:      "review-task-3", // no task row → resolves the shared checkout
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "workflow-review-3")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+
+	_, err = worker.defaultCheckout(ctx, job, payload, runtime.Agent{Name: "reviewer"})
+	if err == nil {
+		t.Fatal("defaultCheckout re-synced a review to a checkout on the wrong branch; want a clean head-mismatch failure")
+	}
+	if !strings.Contains(err.Error(), "not review job head") {
+		t.Fatalf("expected the review head-mismatch error, got: %v", err)
+	}
+
+	// The payload head is left unchanged (NOT re-targeted to main's head) and no
+	// re-sync event was recorded.
+	reloaded, err := store.GetJob(ctx, "workflow-review-3")
+	if err != nil {
+		t.Fatalf("GetJob (reload) returned error: %v", err)
+	}
+	reloadedPayload, err := daemonJobPayload(reloaded)
+	if err != nil {
+		t.Fatalf("daemonJobPayload (reload) returned error: %v", err)
+	}
+	if reloadedPayload.HeadSHA != staleHead {
+		t.Fatalf("wrong-branch HeadSHA = %q, want it left unchanged at %q (not main's head %q)", reloadedPayload.HeadSHA, staleHead, mainHead)
+	}
+	events, err := store.ListJobEvents(ctx, "workflow-review-3")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if hasResyncEvent(events, "review_head_resynced") {
+		t.Fatalf("events = %+v, want NO review_head_resynced event for a wrong-branch checkout", events)
+	}
+}
+
 // #684 failure mode B: a foreground review whose serialized runtime session is
 // busy must be LEFT QUEUED for the daemon to run (a review is naturally
 // asynchronous), not cancelled and dropped. Ask/implement keep their existing
@@ -281,6 +373,13 @@ func TestRunAgentReviewRequeuesQueuedJobWhenRuntimeSessionBusy(t *testing.T) {
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("runtime calls = %+v, want none (job left queued, not run)", runner.calls)
+	}
+	// No daemon is running in this test, so the foreground caller MUST be told the
+	// review is only queued and will not run until a daemon picks it up — otherwise a
+	// bare "state: queued" reads as "the review ran" and the review silently never
+	// executes.
+	if out := stdout.String(); !strings.Contains(out, "daemon is not running") || !strings.Contains(out, "job run") {
+		t.Fatalf("foreground busy-review stdout missing daemon guidance; got:\n%s", out)
 	}
 
 	store = openCLIJobStore(t, home)

--- a/internal/cli/review_head_resync_test.go
+++ b/internal/cli/review_head_resync_test.go
@@ -1,0 +1,308 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// daemonWorkerHeadSHA reads the current HEAD sha of a git checkout for the review
+// head-resync tests.
+func daemonWorkerHeadSHA(t *testing.T, dir string) string {
+	t.Helper()
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD failed: %v\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func hasResyncEvent(events []db.JobEvent, kind string) bool {
+	for _, e := range events {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// #684 failure mode A (the reliability fix): a PR review job is pinned to the head
+// SHA the branch had at ENQUEUE time; in an active dev loop the branch advances
+// before the queued review runs, so the registered checkout sits on a NEWER head.
+// The review must re-target the checkout's current head (what a human reviewer
+// does) instead of failing on the mismatch — as long as the PR is still OPEN.
+func TestDefaultCheckoutResyncsReviewHeadWhenPRIsOpen(t *testing.T) {
+	ctx := context.Background()
+	checkout := createDaemonWorkerGitCheckout(t, "feat/x")
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	worker := defaultJobWorker(store, io.Discard)
+
+	// The head the review was pinned to at enqueue (the branch's original tip).
+	staleHead := daemonWorkerHeadSHA(t, checkout)
+
+	// The branch advances: a newer commit is pushed before the review runs.
+	if err := os.WriteFile(checkout+"/feature.txt", []byte("more work\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runDaemonWorkerGit(t, checkout, "add", "feature.txt")
+	runDaemonWorkerGit(t, checkout, "commit", "-m", "advance the branch")
+	newHead := daemonWorkerHeadSHA(t, checkout)
+	if newHead == staleHead {
+		t.Fatal("test setup: branch head did not advance")
+	}
+
+	// The PR is still OPEN.
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo",
+		Number:       23,
+		HeadBranch:   "feat/x",
+		HeadSHA:      staleHead,
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+
+	// A queued review job pinned to the now-stale head.
+	if _, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+		ID:          "workflow-review-1",
+		Agent:       "reviewer",
+		Action:      "review",
+		Repo:        "owner/repo",
+		Branch:      "feat/x",
+		PullRequest: 23,
+		HeadSHA:     staleHead,
+		TaskID:      "review-task-1", // no task row → resolves the shared checkout
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "workflow-review-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+
+	got, err := worker.defaultCheckout(ctx, job, payload, runtime.Agent{Name: "reviewer"})
+	if err != nil {
+		t.Fatalf("defaultCheckout failed the stale-head review instead of re-syncing: %v", err)
+	}
+	if got != checkout {
+		t.Fatalf("defaultCheckout = %q, want shared checkout %q", got, checkout)
+	}
+
+	// The job payload is re-targeted to the checkout's CURRENT head so RunJob (which
+	// re-reads the payload) delivers a review of the newest commit.
+	reloaded, err := store.GetJob(ctx, "workflow-review-1")
+	if err != nil {
+		t.Fatalf("GetJob (reload) returned error: %v", err)
+	}
+	reloadedPayload, err := daemonJobPayload(reloaded)
+	if err != nil {
+		t.Fatalf("daemonJobPayload (reload) returned error: %v", err)
+	}
+	if reloadedPayload.HeadSHA != newHead {
+		t.Fatalf("re-synced HeadSHA = %q, want current head %q (was %q)", reloadedPayload.HeadSHA, newHead, staleHead)
+	}
+	events, err := store.ListJobEvents(ctx, "workflow-review-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasResyncEvent(events, "review_head_resynced") {
+		t.Fatalf("events = %+v, want a review_head_resynced event", events)
+	}
+}
+
+// #684 mode A boundary: a head-SHA mismatch on a CLOSED (or merged) PR must NOT
+// re-sync — a stale review of a dead PR is not useful, so the job keeps the
+// existing terminal path and fails cleanly on the mismatch.
+func TestDefaultCheckoutFailsReviewHeadMismatchWhenPRClosed(t *testing.T) {
+	ctx := context.Background()
+	checkout := createDaemonWorkerGitCheckout(t, "feat/x")
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	worker := defaultJobWorker(store, io.Discard)
+
+	staleHead := daemonWorkerHeadSHA(t, checkout)
+	if err := os.WriteFile(checkout+"/feature.txt", []byte("more work\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runDaemonWorkerGit(t, checkout, "add", "feature.txt")
+	runDaemonWorkerGit(t, checkout, "commit", "-m", "advance the branch")
+
+	// The PR is CLOSED.
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo",
+		Number:       23,
+		HeadBranch:   "feat/x",
+		HeadSHA:      staleHead,
+		State:        "closed",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+
+	if _, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+		ID:          "workflow-review-2",
+		Agent:       "reviewer",
+		Action:      "review",
+		Repo:        "owner/repo",
+		Branch:      "feat/x",
+		PullRequest: 23,
+		HeadSHA:     staleHead,
+		TaskID:      "review-task-2",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "workflow-review-2")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+
+	_, err = worker.defaultCheckout(ctx, job, payload, runtime.Agent{Name: "reviewer"})
+	if err == nil {
+		t.Fatal("defaultCheckout re-synced a review whose PR is closed; want a clean head-mismatch failure")
+	}
+	if !strings.Contains(err.Error(), "not review job head") {
+		t.Fatalf("expected the review head-mismatch error, got: %v", err)
+	}
+
+	// Payload head is unchanged, and no re-sync event was recorded.
+	reloaded, err := store.GetJob(ctx, "workflow-review-2")
+	if err != nil {
+		t.Fatalf("GetJob (reload) returned error: %v", err)
+	}
+	reloadedPayload, err := daemonJobPayload(reloaded)
+	if err != nil {
+		t.Fatalf("daemonJobPayload (reload) returned error: %v", err)
+	}
+	if reloadedPayload.HeadSHA != staleHead {
+		t.Fatalf("closed-PR HeadSHA = %q, want it left unchanged at %q", reloadedPayload.HeadSHA, staleHead)
+	}
+	events, err := store.ListJobEvents(ctx, "workflow-review-2")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if hasResyncEvent(events, "review_head_resynced") {
+		t.Fatalf("events = %+v, want NO review_head_resynced event for a closed PR", events)
+	}
+}
+
+// #684 failure mode B: a foreground review whose serialized runtime session is
+// busy must be LEFT QUEUED for the daemon to run (a review is naturally
+// asynchronous), not cancelled and dropped. Ask/implement keep their existing
+// synchronous cancel behavior (covered by TestRunAgentAskCancelsQueuedJobWhenRuntimeSessionBusy).
+func TestRunAgentReviewRequeuesQueuedJobWhenRuntimeSessionBusy(t *testing.T) {
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	if err := os.WriteFile(repoDir+"/README.md", []byte("test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	t.Chdir(repoDir)
+	head := daemonWorkerHeadSHA(t, repoDir)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{
+		"agent", "subscribe", "reviewer",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440042",
+		"--role", "reviewer",
+		"--repo", "owner/repo",
+		"--capability", "review",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("subscribe reviewer exit code = %d, stderr=%s", code, stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	// A pre-seeded review task whose worktree is at the requested head lets the
+	// review dispatch resolve locally without any GitHub call.
+	if err := store.UpsertTask(context.Background(), db.Task{
+		ID:           "review-task",
+		RepoFullName: "owner/repo",
+		GoalID:       "local-review",
+		Title:        "Review PR #1",
+		State:        string(workflow.TaskReviewing),
+		Branch:       "feat/x",
+		WorktreePath: repoDir,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	// The runtime session is busy (held by another owner).
+	if acquired, err := store.AcquireResourceLock(context.Background(), db.ResourceLock{
+		ResourceKey: "runtime:codex:550e8400-e29b-41d4-a716-446655440042",
+		OwnerJobID:  "other-job",
+		OwnerToken:  "other-token",
+		ExpiresAt:   time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano),
+	}, time.Now().UTC()); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	store.Close()
+
+	runner := &agentStartRunner{}
+	restoreFactory := replaceRuntimeFactory(runtime.Factory{Runner: runner})
+	defer restoreFactory()
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{
+		"agent", "review", "reviewer", "Please review",
+		"--home", home,
+		"--repo", "owner/repo",
+		"--pr", "1",
+		"--head-sha", head,
+		"--branch", "feat/x",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("busy review exit code = %d, want 0 (requeued, not dropped); stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("runtime calls = %+v, want none (job left queued, not run)", runner.calls)
+	}
+
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	jobs, err := store.ListJobs(context.Background())
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %+v, want one queued review job", jobs)
+	}
+	if jobs[0].State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued (left for the daemon)", jobs[0].State)
+	}
+	events, err := store.ListJobEvents(context.Background(), jobs[0].ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasResyncEvent(events, "requeued_runtime_busy") || !hasResyncEvent(events, "runtime_lock_wait") {
+		t.Fatalf("events = %+v, want requeued_runtime_busy and runtime_lock_wait", events)
+	}
+	if hasResyncEvent(events, string(workflow.JobCancelled)) {
+		t.Fatalf("events = %+v, review job must not be cancelled/dropped", events)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -518,6 +518,21 @@ line in human output. Genuine non-terminal failures (the job did not reach
 `succeeded`) still exit non-zero as before. A normal success with no advance error
 is byte-identical to prior behavior — no `advance_error` field is emitted.
 
+**Review resilience under branch churn.** A review job is pinned to the PR head
+SHA it was queued against; in an active dev loop the branch often advances (a new
+commit is pushed) before the queued review runs, leaving the registered checkout
+on a newer head. Rather than failing the review on that head-SHA mismatch, Gitmoot
+**re-syncs** it: when the PR is still **open**, the review is re-targeted to the
+checkout's current head — reviewing the newest commit is exactly what a human
+reviewer does — and a `review_head_resynced` job event records the old→new head.
+The mismatch is only allowed to fail cleanly when the PR is **closed/merged** (a
+stale review of a dead PR is not useful) or when the checkout is dirty. Relatedly,
+when a foreground `agent review` finds the agent's serialized runtime session
+**busy**, the review is now **left queued** for the daemon to run when the session
+frees (a `requeued_runtime_busy` event is recorded) instead of being cancelled and
+dropped; `agent ask`/`implement` stay synchronous and keep their existing
+busy-session cancel behavior.
+
 Start an orchestra of agents with `gitmoot orchestrate`:
 
 ```sh

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -513,6 +513,21 @@ line in human output. Genuine non-terminal failures (the job did not reach
 `succeeded`) still exit non-zero as before. A normal success with no advance error
 is byte-identical to prior behavior — no `advance_error` field is emitted.
 
+**Review resilience under branch churn.** A review job is pinned to the PR head
+SHA it was queued against; in an active dev loop the branch often advances (a new
+commit is pushed) before the queued review runs, leaving the registered checkout
+on a newer head. Rather than failing the review on that head-SHA mismatch, Gitmoot
+**re-syncs** it: when the PR is still **open**, the review is re-targeted to the
+checkout's current head — reviewing the newest commit is exactly what a human
+reviewer does — and a `review_head_resynced` job event records the old→new head.
+The mismatch is only allowed to fail cleanly when the PR is **closed/merged** (a
+stale review of a dead PR is not useful) or when the checkout is dirty. Relatedly,
+when a foreground `agent review` finds the agent's serialized runtime session
+**busy**, the review is now **left queued** for the daemon to run when the session
+frees (a `requeued_runtime_busy` event is recorded) instead of being cancelled and
+dropped; `agent ask`/`implement` stay synchronous and keep their existing
+busy-session cancel behavior.
+
 Start an orchestra of agents with `gitmoot orchestrate`:
 
 ```sh


### PR DESCRIPTION
## Summary

Fixes the ~42% review-job failure rate reported in #684 on `jerryfane/vetrina`, where reviews are brittle to normal repo churn. Two failure modes, both made resilient:

### A. Head-SHA mismatch after the branch advances (the ~42% failures)

A review job is pinned to the PR head SHA at **enqueue**. In an active dev loop the branch advances (a newer commit is pushed) before the queued review runs, so the registered checkout sits on a **newer** head. `validateReviewCheckout` rejected that with `checkout head is <new>, not review job head <old>`, and the job ultimately failed (via the #532 dirty-checkout deferral, which waits for a human to `git reset` — a human who never comes in an active loop, so it burns the retry budget and fails).

**Fix:** on that specific head-SHA mismatch, if the PR is still **open**, re-target the review to the checkout's current head instead of failing — reviewing the newest commit is exactly what a human reviewer does. The new head is persisted onto the job payload (`RunJob` re-reads it, so the delivered review prompt and the posted PR comment carry the new head) and a `review_head_resynced` event is recorded. A **closed/merged** PR, a dirty tree, a missing head, or a branch mismatch all keep the existing terminal/deferral path unchanged.

Implemented in `defaultCheckout`'s PR-review arm via a new `resyncReviewHead` helper (`isReviewHeadMismatch` gate + `reviewPullRequestClosed` open-state check). Non-review paths are byte-identical.

### B. Runtime busy → foreground review dropped

A foreground `agent review` whose serialized runtime session was busy **cancelled and dropped** the job (`runtime session … is busy; queued job … was not run`). Now the review is **left queued** for the daemon to run when the session frees (a `requeued_runtime_busy` event is recorded) — mirroring the daemon's own runtime-busy handling, which already bounces `errRuntimeSessionBusy` and keeps the job queued. `agent ask`/`implement` stay synchronous and keep their existing busy-session cancel behavior byte-identically (existing test `TestRunAgentAskCancelsQueuedJobWhenRuntimeSessionBusy` still green).

## Tests

- `TestDefaultCheckoutResyncsReviewHeadWhenPRIsOpen` — stale HeadSHA + open PR re-syncs to the current head and proceeds; payload head updated + `review_head_resynced` event.
- `TestDefaultCheckoutFailsReviewHeadMismatchWhenPRClosed` — closed-PR mismatch fails cleanly, payload unchanged, no resync event.
- `TestRunAgentReviewRequeuesQueuedJobWhenRuntimeSessionBusy` — busy foreground review is left queued (not cancelled), `requeued_runtime_busy` recorded.

## Docs

Updated `skills/gitmoot/references/CLI.md` and `website/docs/reference/cli.md` with a "Review resilience under branch churn" note.

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
