### PR TITLE
feat(workflow): resumable blocked/needs gates with auto-resume

### DIFF
--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -35,6 +35,8 @@ func runJob(args []string, stdout, stderr io.Writer) int {
 		return runJobRun(args[1:], stdout, stderr)
 	case "retry":
 		return runJobRetry(args[1:], stdout, stderr)
+	case "gates":
+		return runJobGates(args[1:], stdout, stderr)
 	case "cancel":
 		return runJobCancel(args[1:], stdout, stderr)
 	case "kill":
@@ -60,6 +62,8 @@ func printJobUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot job watch <id> [--poll 1s] [--json]")
 	fmt.Fprintln(w, "  gitmoot job run <id>")
 	fmt.Fprintln(w, "  gitmoot job retry <id>")
+	fmt.Fprintln(w, "  gitmoot job gates <id> [--json]")
+	fmt.Fprintln(w, "  gitmoot job gates clear <id> --need \"<text>\"|--all")
 	fmt.Fprintln(w, "  gitmoot job cancel <id>")
 	fmt.Fprintln(w, "  gitmoot job cancel --state blocked [--older-than 168h|7d] [--repo owner/repo] [--agent name] [--yes]")
 	fmt.Fprintln(w, "  gitmoot job kill <root-job-id>")

--- a/internal/cli/job_gates.go
+++ b/internal/cli/job_gates.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// runJobGates dispatches the resumable-gate surface (#682): make a `blocked` +
+// `needs` stage actionable.
+//
+//	gitmoot job gates <id> [--json]                     — list the gates
+//	gitmoot job gates clear <id> --need "<text>"|--all  — mark gate(s) satisfied
+//
+// Clearing a gate is resume-on-clear: when the LAST gate is satisfied the blocked
+// stage auto-re-runs through the existing RetryJob machinery (guarded so session
+// jobs and awaiting-human pauses are never bypassed).
+func runJobGates(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printJobGatesUsage(stdout)
+		return 0
+	}
+	if args[0] == "clear" {
+		return runJobGatesClear(args[1:], stdout, stderr)
+	}
+	return runJobGatesList(args, stdout, stderr)
+}
+
+func printJobGatesUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot job gates <id> [--json]")
+	fmt.Fprintln(w, "  gitmoot job gates clear <id> --need \"<text>\"|--all")
+}
+
+// jobGateEntry is the JSON shape for `job gates <id> --json`.
+type jobGateEntry struct {
+	Need        string `json:"need"`
+	Satisfied   bool   `json:"satisfied"`
+	CreatedAt   string `json:"created_at,omitempty"`
+	SatisfiedAt string `json:"satisfied_at,omitempty"`
+}
+
+func runJobGatesList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job gates", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print gates as JSON")
+	jobID, ok := parseSingleJobID(fs, args, stderr, "job gates")
+	if !ok {
+		return parseSingleJobIDExitCode(args)
+	}
+	var gates []db.JobGate
+	if err := withStore(*home, func(store *db.Store) error {
+		if _, err := store.GetJob(context.Background(), jobID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("job %q not found", jobID)
+			}
+			return err
+		}
+		var err error
+		gates, err = store.ListJobGates(context.Background(), jobID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job gates: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		entries := make([]jobGateEntry, 0, len(gates))
+		for _, g := range gates {
+			entries = append(entries, jobGateEntry{Need: g.Need, Satisfied: g.Satisfied, CreatedAt: g.CreatedAt, SatisfiedAt: g.SatisfiedAt})
+		}
+		if err := writeJSON(stdout, entries); err != nil {
+			fmt.Fprintf(stderr, "job gates: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(gates) == 0 {
+		fmt.Fprintln(stdout, "no gates recorded for this job")
+		return 0
+	}
+	open := 0
+	for _, g := range gates {
+		status := "open"
+		if g.Satisfied {
+			status = "satisfied"
+		} else {
+			open++
+		}
+		fmt.Fprintf(stdout, "%s\t%s\n", status, g.Need)
+	}
+	fmt.Fprintf(stdout, "%d gate(s), %d open\n", len(gates), open)
+	return 0
+}
+
+func runJobGatesClear(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("job gates clear", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { printJobGatesUsage(stderr) }
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	need := fs.String("need", "", "exact need text of the single gate to mark satisfied")
+	all := fs.Bool("all", false, "mark every open gate satisfied")
+
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "job gates clear requires exactly one id")
+			return 2
+		}
+		return 0
+	}
+	jobID := args[0]
+	if err := fs.Parse(args[1:]); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "job gates clear requires exactly one id")
+		return 2
+	}
+	needText := strings.TrimSpace(*need)
+	if (*all && needText != "") || (!*all && needText == "") {
+		fmt.Fprintln(stderr, "job gates clear requires exactly one of --need \"<text>\" or --all")
+		return 2
+	}
+
+	var (
+		outcome workflow.GateResumeOutcome
+		matched int
+		unknown bool
+	)
+	if err := withStore(*home, func(store *db.Store) error {
+		if _, err := store.GetJob(context.Background(), jobID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("job %q not found", jobID)
+			}
+			return err
+		}
+		if *all {
+			cleared, err := store.SatisfyAllJobGates(context.Background(), jobID)
+			if err != nil {
+				return err
+			}
+			matched = cleared
+		} else {
+			ok, err := store.SatisfyJobGate(context.Background(), jobID, needText)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				unknown = true
+				return nil
+			}
+			matched = 1
+		}
+		var err error
+		outcome, err = workflow.MaybeResumeOnGatesCleared(context.Background(), store, jobID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "job gates clear: %v\n", err)
+		return 1
+	}
+	if unknown {
+		fmt.Fprintf(stderr, "job gates clear: no open gate with need %q on job %s\n", needText, jobID)
+		return 1
+	}
+	if *all {
+		fmt.Fprintf(stdout, "cleared %d gate(s) on job %s\n", matched, jobID)
+	} else {
+		fmt.Fprintf(stdout, "cleared gate %q on job %s\n", needText, jobID)
+	}
+	if outcome.Resumed {
+		fmt.Fprintf(stdout, "resumed: %s\n", outcome.Reason)
+	} else {
+		fmt.Fprintf(stdout, "not resumed: %s\n", outcome.Reason)
+	}
+	return 0
+}

--- a/internal/cli/job_gates_test.go
+++ b/internal/cli/job_gates_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestRunJobGatesListAndClearAutoResumes drives the full CLI surface (#682): list
+// the gates, clear one (still blocked), then clear the last (auto-re-queues the
+// blocked stage through RetryJob).
+func TestRunJobGatesListAndClearAutoResumes(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-blocked",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobBlocked),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo"}),
+	}, "blocked")
+	if _, err := store.RecordJobGates(context.Background(), "job-blocked", []string{"API key", "R2 token"}); err != nil {
+		t.Fatalf("RecordJobGates returned error: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"job", "gates", "job-blocked", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job gates exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "open\tAPI key") || !strings.Contains(stdout.String(), "2 gate(s), 2 open") {
+		t.Fatalf("job gates list output = %q", stdout.String())
+	}
+
+	// Clear one -> still blocked, not resumed.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "gates", "clear", "job-blocked", "--need", "API key", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("clear one exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not resumed") {
+		t.Fatalf("clear one output = %q, want not resumed", stdout.String())
+	}
+	if job, _ := store.GetJob(context.Background(), "job-blocked"); job.State != string(workflow.JobBlocked) {
+		t.Fatalf("state after one clear = %q, want blocked", job.State)
+	}
+
+	// Clear the rest -> auto-resume.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "gates", "clear", "job-blocked", "--all", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("clear all exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "resumed:") {
+		t.Fatalf("clear all output = %q, want resumed", stdout.String())
+	}
+	job, err := store.GetJob(context.Background(), "job-blocked")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("state after clearing all = %q, want queued", job.State)
+	}
+}
+
+// TestRunJobGatesClearRequiresNeedOrAll proves the mutually-exclusive flag guard.
+func TestRunJobGatesClearRequiresNeedOrAll(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-blocked",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobBlocked),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo"}),
+	}, "blocked")
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "gates", "clear", "job-blocked", "--home", home}, &stdout, &stderr); code != 2 {
+		t.Fatalf("clear with neither flag exit = %d, want 2; stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "gates", "clear", "job-blocked", "--all", "--need", "x", "--home", home}, &stdout, &stderr); code != 2 {
+		t.Fatalf("clear with both flags exit = %d, want 2; stderr=%s", code, stderr.String())
+	}
+}
+
+// TestRunJobGatesListNoGates prints a friendly line for a job with no gates.
+func TestRunJobGatesListNoGates(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	seedCLIJob(t, store, db.Job{
+		ID:      "job-plain",
+		Agent:   "audit",
+		Type:    "ask",
+		State:   string(workflow.JobFailed),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo"}),
+	}, "failed")
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "gates", "job-plain", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job gates exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no gates recorded") {
+		t.Fatalf("output = %q, want no-gates message", stdout.String())
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -276,6 +276,21 @@ type JobEvent struct {
 	CreatedAt string
 }
 
+// JobGate is one resumable gate row (#682): a single entry from a blocked job's
+// gitmoot_result `needs` list, persisted so the blocker becomes actionable. A
+// blocked stage records one gate per need; when every gate for the job is
+// satisfied the blocked stage auto-re-runs via RetryJob. Satisfied is 0 (open)
+// until an operator clears it; SatisfiedAt is the clear timestamp (empty while
+// open).
+type JobGate struct {
+	ID          int64
+	JobID       string
+	Need        string
+	Satisfied   bool
+	CreatedAt   string
+	SatisfiedAt string
+}
+
 type EvalArtifact struct {
 	ID        string
 	Hash      string
@@ -2787,7 +2802,7 @@ func (s *Store) ClaimRunningJob(ctx context.Context, id string, from string, to 
 //
 // It is a STRICT no-op when currentBootID is "" (a non-Linux host or a boot id
 // that could not be read): with no boot identity there is nothing to compare
-// against, so behavior is byte-identical to before this feature. The `!= ''`
+// against, so behavior is byte-identical to before this feature. The `!= ”`
 // guard likewise never touches identity-less legacy rows (pre-upgrade running
 // jobs), leaving them to the existing age/lease recovery. It NEVER touches a
 // same-boot job — same-boot liveness stays governed by the age/lease gate, so no
@@ -2860,7 +2875,7 @@ func (s *Store) RequeueRunningJobsFromForeignBoot(ctx context.Context, currentBo
 // foreign boot), so this method only reclaims the lock row. It returns the number
 // of locks released.
 //
-// It is a STRICT no-op when currentBootID is "" and, via the `!= ''` guard, never
+// It is a STRICT no-op when currentBootID is "" and, via the `!= ”` guard, never
 // reclaims an identity-less lock (a non-pid-stamping acquire or a legacy row),
 // which stays governed by its lease/TTL. Because a foreign boot id can only have
 // been written by a process on a prior boot, it can never match an in-flight owner
@@ -3294,6 +3309,103 @@ func (s *Store) JobIDsWithOpenEscalation(ctx context.Context) ([]string, error) 
 		HAVING SUM(CASE WHEN kind = 'delegation_escalation_requested' THEN 1 ELSE 0 END)
 		     > SUM(CASE WHEN kind = 'delegation_escalation_resolved' THEN 1 ELSE 0 END)
 		ORDER BY job_id`)
+}
+
+// RecordJobGates persists one resumable gate per non-blank need for a blocked job
+// (#682). It is an UPSERT keyed on (job_id, need): a fresh need inserts an OPEN
+// gate; a re-blocked job that repeats a need REOPENS the existing row (resets
+// satisfied to 0 and clears satisfied_at) so a stage that blocks → clears →
+// re-runs → blocks again does not strand a permanently-satisfied gate. It returns
+// the number of needs written. An empty (or all-blank) list is a no-op that
+// writes nothing, so a blocked job with no `needs` is byte-identical to before
+// this feature (no rows, no behavior change).
+func (s *Store) RecordJobGates(ctx context.Context, jobID string, needs []string) (int, error) {
+	jobID = strings.TrimSpace(jobID)
+	if jobID == "" {
+		return 0, fmt.Errorf("job id is required")
+	}
+	written := 0
+	for _, need := range needs {
+		need = strings.TrimSpace(need)
+		if need == "" {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx, `INSERT INTO job_gates(job_id, need, satisfied, created_at, satisfied_at)
+			VALUES (?, ?, 0, CURRENT_TIMESTAMP, '')
+			ON CONFLICT(job_id, need) DO UPDATE SET satisfied = 0, satisfied_at = ''`,
+			jobID, need); err != nil {
+			return written, err
+		}
+		written++
+	}
+	return written, nil
+}
+
+// ListJobGates returns every gate recorded for a job, oldest-first by insertion
+// id. Zero rows (the common case) yields an empty slice.
+func (s *Store) ListJobGates(ctx context.Context, jobID string) ([]JobGate, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, job_id, need, satisfied, created_at, satisfied_at
+		FROM job_gates WHERE job_id = ? ORDER BY id`, strings.TrimSpace(jobID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var gates []JobGate
+	for rows.Next() {
+		var g JobGate
+		var satisfied int
+		if err := rows.Scan(&g.ID, &g.JobID, &g.Need, &satisfied, &g.CreatedAt, &g.SatisfiedAt); err != nil {
+			return nil, err
+		}
+		g.Satisfied = satisfied != 0
+		gates = append(gates, g)
+	}
+	return gates, rows.Err()
+}
+
+// SatisfyJobGate marks a single open gate satisfied by exact need text. It returns
+// whether an OPEN gate with that need existed and was cleared (false when no such
+// need is recorded or it was already satisfied), so the caller can report an
+// unknown --need rather than silently succeeding.
+func (s *Store) SatisfyJobGate(ctx context.Context, jobID, need string) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `UPDATE job_gates SET satisfied = 1, satisfied_at = CURRENT_TIMESTAMP
+		WHERE job_id = ? AND need = ? AND satisfied = 0`,
+		strings.TrimSpace(jobID), strings.TrimSpace(need))
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// SatisfyAllJobGates marks every still-open gate for a job satisfied and returns
+// how many it cleared.
+func (s *Store) SatisfyAllJobGates(ctx context.Context, jobID string) (int, error) {
+	res, err := s.db.ExecContext(ctx, `UPDATE job_gates SET satisfied = 1, satisfied_at = CURRENT_TIMESTAMP
+		WHERE job_id = ? AND satisfied = 0`, strings.TrimSpace(jobID))
+	if err != nil {
+		return 0, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(affected), nil
+}
+
+// CountJobGates returns (total, open) gate counts for a job in one query. open is
+// the number still unsatisfied; total==0 means the job never recorded any gate.
+func (s *Store) CountJobGates(ctx context.Context, jobID string) (total int, open int, err error) {
+	row := s.db.QueryRowContext(ctx, `SELECT COUNT(*), SUM(CASE WHEN satisfied = 0 THEN 1 ELSE 0 END)
+		FROM job_gates WHERE job_id = ?`, strings.TrimSpace(jobID))
+	var openNull sql.NullInt64
+	if err := row.Scan(&total, &openNull); err != nil {
+		return 0, 0, err
+	}
+	return total, int(openNull.Int64), nil
 }
 
 func (s *Store) UpsertEvalArtifact(ctx context.Context, artifact EvalArtifact) error {
@@ -7626,5 +7738,27 @@ CREATE TABLE runtime_session_usage (
 	output_cum INTEGER NOT NULL DEFAULT 0,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+	`,
+	// #682 resumable blocked/needs gates. When a stage returns `blocked` with a
+	// `needs` list, each need is persisted here as a gate attached to the blocked
+	// job; when every gate is satisfied the blocked stage auto-re-runs via RetryJob.
+	// UNIQUE(job_id, need) makes RecordJobGates' UPSERT idempotent and lets a
+	// re-blocked job REOPEN a repeated need. Pure additive append (CREATE
+	// TABLE/INDEX only, no ALTER/renumber of any prior migration): the table stays
+	// empty until a blocked-with-needs result is recorded, so a blocked job with no
+	// `needs` — and every existing DB — reads byte-identically. Rows are keyed by
+	// job id (not FK-constrained) so a retried/cancelled job's history is retained;
+	// there is no GC in v1 (a satisfied gate is tens of bytes).
+	`
+CREATE TABLE job_gates (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	job_id TEXT NOT NULL,
+	need TEXT NOT NULL,
+	satisfied INTEGER NOT NULL DEFAULT 0,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	satisfied_at TEXT NOT NULL DEFAULT '',
+	UNIQUE(job_id, need)
+);
+CREATE INDEX idx_job_gates_job ON job_gates(job_id);
 	`,
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2802,7 +2802,7 @@ func (s *Store) ClaimRunningJob(ctx context.Context, id string, from string, to 
 //
 // It is a STRICT no-op when currentBootID is "" (a non-Linux host or a boot id
 // that could not be read): with no boot identity there is nothing to compare
-// against, so behavior is byte-identical to before this feature. The `!= ”`
+// against, so behavior is byte-identical to before this feature. The `!= ''`
 // guard likewise never touches identity-less legacy rows (pre-upgrade running
 // jobs), leaving them to the existing age/lease recovery. It NEVER touches a
 // same-boot job — same-boot liveness stays governed by the age/lease gate, so no
@@ -2875,7 +2875,7 @@ func (s *Store) RequeueRunningJobsFromForeignBoot(ctx context.Context, currentBo
 // foreign boot), so this method only reclaims the lock row. It returns the number
 // of locks released.
 //
-// It is a STRICT no-op when currentBootID is "" and, via the `!= ”` guard, never
+// It is a STRICT no-op when currentBootID is "" and, via the `!= ''` guard, never
 // reclaims an identity-less lock (a non-pid-stamping acquire or a legacy row),
 // which stays governed by its lease/TTL. Because a foreign boot id can only have
 // been written by a process on a prior boot, it can never match an in-flight owner

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -52,6 +52,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"skillopt_judge_outcomes",
 		"interactive_prompts",
 		"merge_gate_ci_observations",
+		"job_gates",
 	} {
 		ok, err := store.HasTable(ctx, table)
 		if err != nil {
@@ -4855,5 +4856,86 @@ func TestListRunningJobsUpdatedBeforeOrder(t *testing.T) {
 	plan := explainQueryPlan(t, store, listRunningJobsUpdatedBeforeSQL, "2026-02-01 00:00:00")
 	if !strings.Contains(plan, "idx_jobs_running_updated_at") {
 		t.Fatalf("ListRunningJobsUpdatedBefore plan does not use idx_jobs_running_updated_at:\n%s", plan)
+	}
+}
+
+func TestJobGatesRecordListSatisfyCount(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	// Empty/blank needs write nothing — the byte-identical non-gated path.
+	if n, err := store.RecordJobGates(ctx, "job-1", nil); err != nil || n != 0 {
+		t.Fatalf("RecordJobGates(nil) = (%d, %v), want (0, nil)", n, err)
+	}
+	if n, err := store.RecordJobGates(ctx, "job-1", []string{"  ", ""}); err != nil || n != 0 {
+		t.Fatalf("RecordJobGates(blank) = (%d, %v), want (0, nil)", n, err)
+	}
+	if total, open, err := store.CountJobGates(ctx, "job-1"); err != nil || total != 0 || open != 0 {
+		t.Fatalf("CountJobGates(empty) = (%d,%d,%v), want (0,0,nil)", total, open, err)
+	}
+
+	if n, err := store.RecordJobGates(ctx, "job-1", []string{"API key", "R2 token"}); err != nil || n != 2 {
+		t.Fatalf("RecordJobGates = (%d, %v), want (2, nil)", n, err)
+	}
+	gates, err := store.ListJobGates(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobGates returned error: %v", err)
+	}
+	if len(gates) != 2 || gates[0].Need != "API key" || gates[0].Satisfied || gates[1].Need != "R2 token" {
+		t.Fatalf("ListJobGates = %+v, want two open gates ordered API key, R2 token", gates)
+	}
+
+	// Clearing one leaves the other open.
+	ok, err := store.SatisfyJobGate(ctx, "job-1", "API key")
+	if err != nil || !ok {
+		t.Fatalf("SatisfyJobGate(API key) = (%v, %v), want (true, nil)", ok, err)
+	}
+	if total, open, err := store.CountJobGates(ctx, "job-1"); err != nil || total != 2 || open != 1 {
+		t.Fatalf("CountJobGates after one = (%d,%d,%v), want (2,1,nil)", total, open, err)
+	}
+	// A second clear of the same need reports not-matched (already satisfied).
+	if ok, err := store.SatisfyJobGate(ctx, "job-1", "API key"); err != nil || ok {
+		t.Fatalf("SatisfyJobGate(already satisfied) = (%v, %v), want (false, nil)", ok, err)
+	}
+	// An unknown need reports not-matched.
+	if ok, err := store.SatisfyJobGate(ctx, "job-1", "nope"); err != nil || ok {
+		t.Fatalf("SatisfyJobGate(unknown) = (%v, %v), want (false, nil)", ok, err)
+	}
+
+	// SatisfyAll clears the remainder.
+	if cleared, err := store.SatisfyAllJobGates(ctx, "job-1"); err != nil || cleared != 1 {
+		t.Fatalf("SatisfyAllJobGates = (%d, %v), want (1, nil)", cleared, err)
+	}
+	if total, open, err := store.CountJobGates(ctx, "job-1"); err != nil || total != 2 || open != 0 {
+		t.Fatalf("CountJobGates after all = (%d,%d,%v), want (2,0,nil)", total, open, err)
+	}
+}
+
+func TestRecordJobGatesReopensRepeatedNeedOnReblock(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	if _, err := store.RecordJobGates(ctx, "job-1", []string{"API key"}); err != nil {
+		t.Fatalf("RecordJobGates returned error: %v", err)
+	}
+	if _, err := store.SatisfyAllJobGates(ctx, "job-1"); err != nil {
+		t.Fatalf("SatisfyAllJobGates returned error: %v", err)
+	}
+	// Re-block with the SAME need must REOPEN the gate (not be swallowed by the
+	// UNIQUE constraint), or the stage would strand permanently satisfied.
+	if _, err := store.RecordJobGates(ctx, "job-1", []string{"API key"}); err != nil {
+		t.Fatalf("re-RecordJobGates returned error: %v", err)
+	}
+	total, open, err := store.CountJobGates(ctx, "job-1")
+	if err != nil || total != 1 || open != 1 {
+		t.Fatalf("CountJobGates after reblock = (%d,%d,%v), want (1,1,nil)", total, open, err)
 	}
 }

--- a/internal/workflow/gates_resume_test.go
+++ b/internal/workflow/gates_resume_test.go
@@ -1,0 +1,188 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// TestMailboxRunRecordsGatesFromNeeds proves the recording hook (#682): a blocked
+// decision carrying a `needs` list persists one open gate per need at the single
+// result-bearing terminal chokepoint, and emits the gates_recorded event.
+func TestMailboxRunRecordsGatesFromNeeds(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"blocked","summary":"needs credentials","findings":[],"changes_made":[],"tests_run":[],"needs":["API key","R2 token"],"delegations":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	gates, err := store.ListJobGates(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobGates returned error: %v", err)
+	}
+	if len(gates) != 2 || gates[0].Need != "API key" || gates[1].Need != "R2 token" || gates[0].Satisfied || gates[1].Satisfied {
+		t.Fatalf("gates = %+v, want two open gates from needs", gates)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !hasEvent(events, "gates_recorded") {
+		t.Fatalf("events = %+v, want a gates_recorded event", events)
+	}
+}
+
+// TestMailboxRunBlockedWithoutNeedsRecordsNoGates proves the byte-identical
+// default: a blocked result with no needs records no gates (the non-gated path).
+func TestMailboxRunBlockedWithoutNeedsRecordsNoGates(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"blocked","summary":"blocked","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "audit", Action: "review", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	total, _, err := store.CountJobGates(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("CountJobGates returned error: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("gate total = %d, want 0 for a blocked result with no needs", total)
+	}
+	events, err := store.ListJobEvents(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if hasEvent(events, "gates_recorded") {
+		t.Fatalf("events = %+v, want NO gates_recorded event", events)
+	}
+}
+
+func seedBlockedJobWithGates(t *testing.T, store *db.Store, id string, payload JobPayload, needs []string) {
+	t.Helper()
+	ctx := context.Background()
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: id, Agent: "audit", Type: "ask", State: string(JobBlocked), Payload: encoded}, db.JobEvent{
+		Kind:    string(JobBlocked),
+		Message: "blocked",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	if _, err := store.RecordJobGates(ctx, id, needs); err != nil {
+		t.Fatalf("RecordJobGates returned error: %v", err)
+	}
+}
+
+// TestMaybeResumeOnGatesClearedRequeuesWhenAllCleared proves the resume-on-clear
+// loop closes: once every gate is satisfied the blocked stage re-queues through the
+// real RetryJob machinery.
+func TestMaybeResumeOnGatesClearedRequeuesWhenAllCleared(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedBlockedJobWithGates(t, store, "job-1", JobPayload{Repo: "owner/repo"}, []string{"API key"})
+
+	// One still open -> not resumed, still blocked.
+	out, err := MaybeResumeOnGatesCleared(ctx, store, "job-1")
+	if err != nil {
+		t.Fatalf("MaybeResumeOnGatesCleared returned error: %v", err)
+	}
+	if out.Resumed {
+		t.Fatalf("resumed with an open gate: %+v", out)
+	}
+	if job, _ := store.GetJob(ctx, "job-1"); job.State != string(JobBlocked) {
+		t.Fatalf("state = %q, want blocked while a gate is open", job.State)
+	}
+
+	// Clear it -> resume.
+	if ok, err := store.SatisfyJobGate(ctx, "job-1", "API key"); err != nil || !ok {
+		t.Fatalf("SatisfyJobGate = (%v, %v)", ok, err)
+	}
+	out, err = MaybeResumeOnGatesCleared(ctx, store, "job-1")
+	if err != nil {
+		t.Fatalf("MaybeResumeOnGatesCleared returned error: %v", err)
+	}
+	if !out.Resumed {
+		t.Fatalf("not resumed after clearing all gates: %+v", out)
+	}
+	job, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(JobQueued) {
+		t.Fatalf("state = %q, want queued (RetryJob re-queued the blocked stage)", job.State)
+	}
+}
+
+// TestMaybeResumeOnGatesClearedSkipsSessionJob proves a session job (#657) is never
+// auto-resumed even with all gates cleared.
+func TestMaybeResumeOnGatesClearedSkipsSessionJob(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	encoded, err := marshalPayload(JobPayload{Repo: "owner/repo"})
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	if err := store.CreateExternallyDrivenJobWithEvent(ctx, db.Job{ID: "sess-1", Agent: "lead", Type: "implement", State: string(JobBlocked), Payload: encoded}, db.JobEvent{Kind: string(JobBlocked), Message: "blocked"}); err != nil {
+		t.Fatalf("CreateExternallyDrivenJobWithEvent returned error: %v", err)
+	}
+	if _, err := store.RecordJobGates(ctx, "sess-1", []string{"API key"}); err != nil {
+		t.Fatalf("RecordJobGates returned error: %v", err)
+	}
+	if _, err := store.SatisfyAllJobGates(ctx, "sess-1"); err != nil {
+		t.Fatalf("SatisfyAllJobGates returned error: %v", err)
+	}
+	out, err := MaybeResumeOnGatesCleared(ctx, store, "sess-1")
+	if err != nil {
+		t.Fatalf("MaybeResumeOnGatesCleared returned error: %v", err)
+	}
+	if out.Resumed {
+		t.Fatalf("resumed a session job: %+v", out)
+	}
+	if job, _ := store.GetJob(ctx, "sess-1"); job.State != string(JobBlocked) {
+		t.Fatalf("session job state = %q, want blocked (never re-queued)", job.State)
+	}
+}
+
+// TestMaybeResumeOnGatesClearedSkipsAwaitingHuman proves a cleared resource gate on
+// a stage whose tree is paused awaiting a human (#340) does NOT bypass the human.
+func TestMaybeResumeOnGatesClearedSkipsAwaitingHuman(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", Title: "t", State: string(TaskAwaitingHuman)}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	seedBlockedJobWithGates(t, store, "job-1", JobPayload{Repo: "owner/repo", TaskID: "task-1"}, []string{"human approval"})
+	if _, err := store.SatisfyAllJobGates(ctx, "job-1"); err != nil {
+		t.Fatalf("SatisfyAllJobGates returned error: %v", err)
+	}
+	out, err := MaybeResumeOnGatesCleared(ctx, store, "job-1")
+	if err != nil {
+		t.Fatalf("MaybeResumeOnGatesCleared returned error: %v", err)
+	}
+	if out.Resumed {
+		t.Fatalf("resumed an awaiting-human stage: %+v", out)
+	}
+	if job, _ := store.GetJob(ctx, "job-1"); job.State != string(JobBlocked) {
+		t.Fatalf("state = %q, want blocked (human gate must not be bypassed)", job.State)
+	}
+}

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -82,6 +82,108 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 	return store.GetJob(ctx, job.ID)
 }
 
+// GateResumeOutcome is the result of MaybeResumeOnGatesCleared (#682): whether the
+// blocked stage was auto-re-queued and, if not, why the resume was withheld.
+type GateResumeOutcome struct {
+	// Resumed is true iff the blocked job was re-queued through RetryJob.
+	Resumed bool
+	// Reason is a human-readable explanation of the outcome — the re-queue on
+	// success, or why the resume was skipped (no gates, gates still open, session
+	// job, or an awaiting-human pause that must not be bypassed).
+	Reason string
+}
+
+// MaybeResumeOnGatesCleared auto-re-runs a blocked stage the moment its LAST gate
+// is satisfied (#682), reusing the existing RetryJob machinery (which already
+// resurrects blocked jobs) so the resumed stage — and, via the normal delegation
+// DAG, everything downstream — wakes back up without any polling. It is the
+// resume-on-clear seam the `gitmoot job gates clear` command calls after marking a
+// gate satisfied; it is idempotent and safe to call when nothing should happen.
+//
+// It deliberately does NOT resume in three cases so the gate feature complements,
+// never replaces, the human-escalation path:
+//   - a job that still has an open gate (the blocker is only partially cleared);
+//   - a session job (ExternallyDriven, #657) — RetryJob refuses these outright, and
+//     resurrecting one would let the daemon Deliver an empty session payload;
+//   - a stage whose delegation tree is paused awaiting a human (escalate_human /
+//     ask-gate, #305/#340/#445) — clearing a resource gate must not bypass the
+//     human's retry|continue|abort decision, which is driven from the coordinator
+//     via `gitmoot resume`, not this child.
+//
+// A job that recorded no gates at all is a no-op (Resumed=false), so callers that
+// invoke it unconditionally stay byte-identical for the non-gated path.
+func MaybeResumeOnGatesCleared(ctx context.Context, store *db.Store, jobID string) (GateResumeOutcome, error) {
+	if store == nil {
+		return GateResumeOutcome{}, fmt.Errorf("store is required")
+	}
+	total, open, err := store.CountJobGates(ctx, jobID)
+	if err != nil {
+		return GateResumeOutcome{}, err
+	}
+	if total == 0 {
+		return GateResumeOutcome{Reason: "no gates recorded for this job"}, nil
+	}
+	if open > 0 {
+		return GateResumeOutcome{Reason: fmt.Sprintf("%d of %d gate(s) still open", open, total)}, nil
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		return GateResumeOutcome{}, err
+	}
+	if job.State != string(JobBlocked) {
+		return GateResumeOutcome{Reason: fmt.Sprintf("job is %s, not blocked; not auto-resumed", job.State)}, nil
+	}
+	if job.ExternallyDriven {
+		return GateResumeOutcome{Reason: "session job (externally driven) is not auto-resumed"}, nil
+	}
+	awaiting, err := blockedJobAwaitingHuman(ctx, store, job)
+	if err != nil {
+		return GateResumeOutcome{}, err
+	}
+	if awaiting {
+		return GateResumeOutcome{Reason: "tree is paused awaiting a human; resume via `gitmoot resume`, gates do not bypass the human"}, nil
+	}
+	if _, err := RetryJob(ctx, store, jobID); err != nil {
+		return GateResumeOutcome{}, err
+	}
+	_ = store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   jobID,
+		Kind:    "gates_cleared_resume",
+		Message: "all gates satisfied; re-queued the blocked stage (#682)",
+	})
+	return GateResumeOutcome{Resumed: true, Reason: "all gates satisfied; re-queued the blocked stage"}, nil
+}
+
+// blockedJobAwaitingHuman reports whether a blocked job's delegation tree is paused
+// awaiting a human (#305/#340/#445), so a cleared resource gate does not bypass the
+// human. It checks both the durable signals: the SHARED task state
+// (awaiting_human), and an OPEN escalation round on the job or its coordinator
+// parent (requested > resolved). A normal block_parent/blocked stage sets its task
+// to `blocked` (not awaiting_human) with no escalation, so this returns false and
+// the stage auto-resumes.
+func blockedJobAwaitingHuman(ctx context.Context, store *db.Store, job db.Job) (bool, error) {
+	payload, err := unmarshalPayload(job.Payload)
+	if err == nil {
+		if taskID := strings.TrimSpace(payload.TaskID); taskID != "" {
+			task, terr := store.GetTask(ctx, taskID)
+			if terr == nil && task.State == string(TaskAwaitingHuman) {
+				return true, nil
+			}
+		}
+	}
+	openIDs, err := store.JobIDsWithOpenEscalation(ctx)
+	if err != nil {
+		return false, err
+	}
+	parentID := strings.TrimSpace(payload.ParentJobID)
+	for _, id := range openIDs {
+		if id == job.ID || (parentID != "" && id == parentID) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func manualRetryShouldClearReadOnlyWorktree(job db.Job, payload JobPayload) bool {
 	if strings.TrimSpace(payload.WorktreePath) == "" {
 		return false

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -825,6 +825,20 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 	if m.emitTerminal != nil {
 		m.emitTerminal(ctx, jobID, state, payload)
 	}
+	// Record resumable gates for a blocked stage that carries a `needs` list (#682)
+	// so the blocker becomes actionable: `gitmoot job gates` lists them and clearing
+	// them all auto-re-runs the stage. This is the single result-bearing terminal
+	// chokepoint (an agent-returned blocked decision routes here via
+	// stateForDecision), so the daemon-owned permission/pre-flight blocked paths
+	// (Result nil, no needs) never reach it. Gated on state==JobBlocked and a
+	// non-empty needs list, so every non-blocked terminal — and a blocked result
+	// with no needs — writes nothing and is byte-identical. Best-effort: a gate
+	// write must never turn a successfully-recorded blocked transition into an error.
+	if state == JobBlocked && payload.Result != nil && len(payload.Result.Needs) > 0 {
+		if _, gateErr := m.Store.RecordJobGates(ctx, jobID, payload.Result.Needs); gateErr == nil {
+			_ = m.addEvent(ctx, jobID, "gates_recorded", fmt.Sprintf("recorded %d resumable gate(s) from needs", len(payload.Result.Needs)))
+		}
+	}
 	return nil
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -865,12 +865,36 @@ gitmoot job show <job-id>            # add --json for the full job + why-stuck d
 gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
+gitmoot job gates <job-id>                                         # list resumable gates; add --json
+gitmoot job gates clear <job-id> --need "<text>"|--all             # satisfy gate(s); auto-resume on last
 gitmoot job cancel <job-id>                                        # one queued|running|blocked job
 gitmoot job cancel --state blocked [--older-than 7d] [--repo owner/repo] [--agent name] [--yes]
 gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+### Resumable gates (make `blocked` + `needs` actionable)
+
+When a stage returns `blocked` with a `needs` list (e.g. `needs: ["Maps API key"]`),
+gitmoot persists each need as a **gate** attached to the blocked job. `gitmoot job
+gates <job-id>` lists them (open / satisfied). Clearing a gate marks the blocker
+resolved:
+
+```sh
+gitmoot job gates clear <job-id> --need "Maps API key"   # satisfy one need
+gitmoot job gates clear <job-id> --all                   # satisfy every open gate
+```
+
+When the **last** gate is cleared, the blocked stage **auto-re-runs** via the same
+`RetryJob` machinery `gitmoot job retry` uses (re-queued, then dispatched by the
+daemon; downstream stages follow the normal delegation DAG) — no polling, resume
+happens on clear. Two cases are deliberately **never** auto-resumed even with all
+gates cleared: a **session job** (externally driven, #657) and a stage whose tree is
+**paused awaiting a human** (`escalate_human` / ask-gate, #305/#340/#445) — a
+resource gate must not bypass the human's `gitmoot resume` decision; the command
+reports `not resumed: …` with the reason. A blocked job with **no** `needs` records
+no gates and is byte-identical to before this feature.
 
 ### Session jobs (record "here"-method work)
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -837,12 +837,35 @@ gitmoot job watch <job-id>
 gitmoot job events <job-id>
 gitmoot job run <job-id>
 gitmoot job retry <job-id>
+gitmoot job gates <job-id>                                         # list resumable gates; add --json
+gitmoot job gates clear <job-id> --need "<text>"|--all             # satisfy gate(s); auto-resume on last
 gitmoot job cancel <job-id>                                        # one queued|running|blocked job
 gitmoot job cancel --state blocked [--older-than 7d] [--repo owner/repo] [--agent name] [--yes]
 gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+### Resumable gates (make `blocked` + `needs` actionable)
+
+When a stage returns `blocked` with a `needs` list (e.g. `needs: ["Maps API key"]`),
+gitmoot persists each need as a **gate** attached to the blocked job. `gitmoot job
+gates <job-id>` lists them (open / satisfied); clearing a gate marks the blocker
+resolved:
+
+```sh
+gitmoot job gates clear <job-id> --need "Maps API key"   # satisfy one need
+gitmoot job gates clear <job-id> --all                   # satisfy every open gate
+```
+
+When the **last** gate is cleared, the blocked stage **auto-re-runs** via the same
+`RetryJob` machinery `gitmoot job retry` uses (re-queued, then dispatched by the
+daemon; downstream stages follow the normal delegation DAG) — resume happens on
+clear, no polling. A **session job** (externally driven) and a stage whose tree is
+**paused awaiting a human** (`escalate_human` / ask-gate) are never auto-resumed
+even with all gates cleared — a resource gate must not bypass the human's `gitmoot
+resume` decision; the command reports `not resumed: …` with the reason. A blocked
+job with **no** `needs` records no gates and is byte-identical to before.
 
 ### Session jobs (record "here"-method work)
 


### PR DESCRIPTION
## What

Closes #682. Today a job returning `blocked` with `needs: [...]` is a dead end an operator must babysit. This makes `blocked` + `needs` **actionable**: each need becomes a resumable **gate** attached to the blocked job, and clearing the last gate **auto-re-runs** the blocked stage.

## Design

- **Persist gates** — new `job_gates` table (migration appended as its own slice element at the end of `internal/db/store.go`'s migrations, the known rebase-conflict spot). `RecordJobGates` is an idempotent UPSERT keyed on `(job_id, need)` that **reopens** a repeated need when a stage re-blocks (so a block→clear→re-run→block cycle never strands a permanently-satisfied gate). Companions: `ListJobGates`, `SatisfyJobGate`, `SatisfyAllJobGates`, `CountJobGates`.
- **Record hook** — gates are written at the single result-bearing terminal chokepoint (`Mailbox.finishWithPayload`) only when a `blocked` result carries a non-empty `needs`. The daemon-owned permission/pre-flight blocked paths carry no result, so they never record gates. A blocked result with **no** needs writes nothing → **byte-identical** to before.
- **Auto-resume** — `MaybeResumeOnGatesCleared` re-queues through the existing `RetryJob` machinery once every gate is satisfied (resume-on-clear, no polling; downstream stages follow the normal delegation DAG). It **never** auto-resumes two cases even with all gates cleared:
  - a **session job** (`ExternallyDriven`, #657) — `RetryJob` already refuses these;
  - a stage whose tree is **paused awaiting a human** (`escalate_human` / ask-gate, #305/#340/#445) — detected via the shared task state (`awaiting_human`) and an open escalation round on the job or its coordinator parent. A resource gate must not bypass the human's `gitmoot resume` decision; the command reports `not resumed: <reason>`.
- **CLI** — `gitmoot job gates <id>` (list; `--json`) and `gitmoot job gates clear <id> --need "<text>"|--all` (satisfy + resume-on-clear).
- **Docs** — `skills/gitmoot/references/CLI.md` + `website/docs/reference/cli.md`.

## Tests

- gate recording from `needs` and the no-needs byte-identical path (through `Mailbox.Run`);
- store: record/list/satisfy/count + re-block reopens a repeated need;
- clearing one gate leaves the job blocked; clearing all auto-requeues through **real** `RetryJob` (job → queued);
- session jobs and awaiting-human pauses are **not** auto-resumed;
- full CLI list / clear-one / clear-all / resume surface + flag guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)