### PR TITLE
feat(pipeline): first-class Pipeline primitive — declared DAG of shell-agent stages (#681)

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -143,7 +143,7 @@ halt_stage: score
 halt_reason: secret missing
 needs: R2 token
 
-source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
 Funnel labels are `OK` for a succeeded stage, `BLOCKED (needs: …)` for a parked

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,0 +1,264 @@
+# Pipelines
+
+Pipelines (#681) let the gitmoot daemon run a **declared DAG of shell stages** —
+a small, durable multi-step flow — on demand or on an interval schedule. Each
+stage is an ordinary queued job run through the **shell runtime**: the normal
+worker tick claims and runs it, and a scan-based **advancer** folds each stage's
+`gitmoot_result` decision and enqueues the stages whose dependencies have all
+succeeded. Pipelines reuse the same job queue, result contract, and scheduling
+idiom as heartbeats — there is no separate runner.
+
+Pipelines are **off by default**: with no pipelines defined, the daemon's
+pipeline scan returns an empty list before touching any state, and behavior is
+unchanged.
+
+A pipeline is not an orchestra. Each stage is a **leaf**: it runs a shell command
+and returns a decision. A stage that emits `delegations[]` does **not** spawn
+children — the advancer ignores them and the engine strips them for a pipeline
+stage job, so a pipeline can never fan out into a delegation tree. Reach for an
+orchestra (`gitmoot orchestrate` / a coordinator that returns `delegations[]`)
+when you want dynamic decomposition; reach for a pipeline when you have a fixed,
+repeatable sequence of shell steps with explicit dependencies.
+
+## The spec
+
+A pipeline is declared as a YAML file and registered with `gitmoot pipeline add`.
+The raw bytes are stored **verbatim** in the local store alongside a content hash;
+each run snapshots the hash it was created from, so a run always executes the spec
+it was created against — editing the file later (even whitespace) changes the hash
+and does not affect an in-flight run.
+
+```yaml
+name: nightly-sync          # required, name-safe token (letters, digits, - _)
+repo: owner/repo            # optional to register; REQUIRED to actually run
+schedule:                   # optional; interval schedule (no cron in v1)
+  interval: 24h             #   required when a schedule block is present (positive Go duration)
+  jitter: 15m               #   optional random [0, jitter] added to each next_due (>= 0)
+success_decisions:          # optional top-level default (see below)
+  - approved
+  - implemented
+stages:                     # the DAG, keyed by unique id and wired by needs
+  - id: source
+    cmd: "curl -sf https://example.com/data > data.json"
+  - id: score
+    cmd: "python score.py data.json"
+    needs: [source]         # runs only after every listed stage SUCCEEDS
+  - id: deploy
+    cmd: "rclone copy out/ r2:bucket"
+    needs: [score]
+    timeout: 30m            # optional per-stage job timeout (positive Go duration)
+    retry: 2                # optional; re-attempt a FAILED stage up to N times (>= 0)
+    success_decisions:      # optional per-stage override of the pipeline default
+      - approved
+```
+
+### Fields
+
+| Field                       | Scope        | Required | Notes |
+| --------------------------- | ------------ | -------- | ----- |
+| `name`                      | pipeline     | yes      | Stable identifier and DB primary key; a name-safe token (letters, digits, `-`, `_`). |
+| `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
+| `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
+| `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
+| `success_decisions`         | pipeline     | no       | Decisions that mark a stage succeeded. Default `["approved","implemented"]`. Any value must be one of `approved`, `implemented`, `changes_requested` — `blocked`/`failed` are park states and are rejected. |
+| `stages[].id`               | stage        | yes      | Unique, name-safe stage id. Appears verbatim in the stage job's fingerprint and deterministic id. |
+| `stages[].cmd`              | stage        | yes      | Shell command run verbatim via `sh -c` (see the stage contract below). |
+| `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
+| `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
+| `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
+| `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
+
+`gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
+non-name-safe name/id, a duplicate stage id, a missing `cmd`, an unknown/self/cyclic
+`needs`, an invalid timeout/interval/jitter, a negative retry, or a
+`success_decisions` value outside the allowed set — so a structural mistake surfaces
+as a clear error at registration rather than a stuck run later.
+
+### The stage contract
+
+A stage command runs under the shell runtime as `sh -c '<cmd>' gitmoot '<prompt>'`
+(so `$0` is `gitmoot` and `$1` is the stage's job prompt). The stage signals its
+outcome by printing a `gitmoot_result` JSON blob to **stdout**; the advancer folds
+the stage by that result's **`decision`**, never by the job's exit state:
+
+```sh
+# A stage that succeeds:
+printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+
+# A stage that parks the run awaiting a human, listing what it needs:
+printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
+```
+
+The decision drives advancement:
+
+- **`decision` in the stage's `success_decisions`** → the stage **succeeded**;
+  stages whose `needs` have all now succeeded are enqueued.
+- **`decision: blocked`** → the stage is **blocked**; its `needs` are persisted at
+  the stage and run level and the run **parks blocked**. Downstream stages are
+  never enqueued.
+- **`decision: failed`, any decision outside the stage's `success_decisions`
+  (`changes_requested` by default), a cancelled job, or no `gitmoot_result` at all**
+  → the stage **failed**. If the stage has retry budget left it is re-attempted;
+  otherwise the run **parks failed**.
+
+`changes_requested` is a stage **failure by default** — even though the underlying
+job succeeded — because a stage folds on the decision, not the job state, and a
+review that asked for changes is not "this step landed." List it in a stage's (or
+the pipeline's) `success_decisions` to treat it as success instead.
+
+## CLI
+
+```sh
+# Register (validate + store). Omit --enable to add it disabled (no scheduling).
+gitmoot pipeline add nightly-sync.yaml --enable
+
+gitmoot pipeline list [--json]
+gitmoot pipeline show <name> [--json]        # registry view for a pipeline name
+gitmoot pipeline show <run-id> [--json]      # run funnel for a "prun-…" run id
+
+gitmoot pipeline run <name>                  # start a manual run; prints the run id
+gitmoot pipeline resume <run-id> [--from <stage>]
+gitmoot pipeline cancel <run-id>
+
+gitmoot pipeline enable <name>
+gitmoot pipeline disable <name>
+gitmoot pipeline remove <name>
+```
+
+`pipeline run` prints just the run id (script-stable), so `RUN=$(gitmoot pipeline
+run nightly-sync)` works. A manual run ignores the `enabled` flag — a disabled
+pipeline can still be run by hand — but still requires a `repo` and refuses to
+start while the pipeline already has an active run (one active run per pipeline).
+
+`pipeline show <run-id>` renders the run as a **text funnel**:
+
+```
+run: prun-nightly-sync-18bfa02e9afb86ed
+pipeline: nightly-sync
+trigger: manual
+state: blocked
+started: 2026-07-06T06:41:39Z
+finished: 2026-07-06T06:42:10Z
+halt_stage: score
+halt_reason: secret missing
+needs: R2 token
+
+source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+```
+
+Funnel labels are `OK` for a succeeded stage, `BLOCKED (needs: …)` for a parked
+stage, and the uppercased state otherwise (`PENDING`, `QUEUED`, `RUNNING`,
+`FAILED`, `SKIPPED`, `CANCELLED`). When a run **failed**, the view also prints the
+exact command to file a bug for the halted stage's job — gitmoot never files it for
+you:
+
+```
+stage failed; report it with:
+  gitmoot report bug --job <stage-job-id>
+```
+
+`--json` on `list` and `show` emits a stable machine shape (pipelines as an array;
+a run as `{id, pipeline, trigger, state, halt_stage, halt_reason, needs, spec_hash,
+started_at, finished_at, funnel, stages[]}`).
+
+### Resume
+
+`pipeline resume <run-id>` re-runs a **parked** (blocked or failed) run from its
+halted stage; `--from <stage>` overrides the resume point. Resume resets the halted
+stage (or `--from` stage) and every stage that transitively **depends** on it back
+to pending — bumping each reset stage's attempt so the next scan enqueues a fresh
+stage job — clears the run's park fields, and returns the run to `running`. It
+**never re-runs a stage that already succeeded**, even one downstream of the resume
+point, and it refuses a run that is not parked. Because a run executes its spec
+snapshot, resume is refused if the pipeline's spec changed since the run was
+created.
+
+The intended story: a stage blocks on something the operator must provide (a
+missing secret, an unapproved change), the operator provisions it out of band, then
+`pipeline resume` re-runs the halted stage and everything downstream — while the
+already-landed upstream stages are left untouched. Approval gates that call resume
+automatically are a follow-up (#682); v1 is the manual verb.
+
+### Cancel and remove
+
+`pipeline cancel <run-id>` abandons a running or parked run: it cancels each
+in-flight stage job through the shared `job cancel` path (which also best-effort
+releases the job's locks) and marks the run and its non-terminal stages
+`cancelled`. An already-settled stage keeps its recorded outcome, so a cancelled
+run still shows why it halted. It refuses an already-terminal (succeeded/cancelled)
+run.
+
+`pipeline remove <name>` deletes the pipeline and disposes its hidden shell runner
+agent (below).
+
+## Scheduling
+
+A pipeline with a `schedule.interval` and `enable`d auto-runs on that interval,
+using the same durable-`next_due` idiom as heartbeats. The daemon's pipeline scan
+runs in **both** the registered-repo and single-repo daemon loops and does two
+passes per tick:
+
+1. **Schedule pass** — for each enabled pipeline whose interval is due and that has
+   no active run, create a fresh scheduled run and advance `next_due` **anchored to
+   now**.
+2. **Advance pass** — advance every in-flight run once (fold settled stage jobs,
+   enqueue newly-ready stages, park or finish).
+
+A parked or terminal run is never advanced, so a blocked/failed run consumes **zero
+compute** while it waits. Behavior worth knowing:
+
+- **Interval + jitter only** — there is no cron parser in v1; because `next_due` is
+  durable, a cron front-end is a documented drop-in for a later release.
+- **One active run per pipeline** — a scheduled tick that finds a run in flight is
+  skipped without advancing `next_due`, so the next run fires as soon as the current
+  one settles. A parked run does **not** count as active.
+- **Missed ticks coalesce** — a long-idle scheduler that missed many intervals fires
+  exactly **one** run and schedules the next one interval out; it never replays a
+  backlog.
+- **Restart-safe** — the advancer recovers purely from the persisted run/stage rows,
+  so a daemon restart mid-run picks the run back up and completes it.
+- **Repo required to run** — a scheduled pipeline with no `repo` is skipped and its
+  `next_due` advanced (so a misconfigured schedule does not hot-loop and
+  self-recovers once a repo is set), mirroring the heartbeat repo-unmanaged idiom.
+
+## The hidden runner agent
+
+`pipeline add` auto-creates one hidden shell agent per pipeline, named
+`pipeline-<name>-runner`, that owns the pipeline's stage jobs (the worker loop
+resolves a job's agent record). The stage command travels **per job** (in the stage
+job's runtime-override ref), not on the agent's runtime ref, so one runner serves
+every stage. These runner agents are an implementation detail and are **filtered out
+of `gitmoot agent list`**; `pipeline remove` disposes them.
+
+## Observability
+
+- `gitmoot pipeline list` shows each pipeline's enabled state, interval, repo, and
+  last run status.
+- `gitmoot pipeline show <name>` shows the registry view (spec hash, schedule,
+  last/next run bookkeeping, and the stage DAG).
+- `gitmoot pipeline show <run-id>` shows the run funnel.
+- Stage jobs are ordinary jobs (sender `pipeline`), so they also appear in the usual
+  job/status surfaces.
+
+## Safety
+
+`pipeline add` is an **operator-trust action**: a stage's `cmd` runs verbatim via
+`sh -c` with the daemon's permissions. Only register specs you would run yourself —
+the same trust you extend to a heartbeat prompt or a CI step. The spec is stored
+verbatim (raw bytes), so treat a spec containing private hostnames, paths, or repo
+names the same as any other private-repo data. See `SAFETY.md → Pipeline stages run
+with daemon permissions`.
+
+## Not yet supported (deferred)
+
+These are intentionally out of scope for v1 and tracked as follow-ups:
+
+- A cron schedule front-end (interval + jitter only today).
+- Approval gates / secret stores / an approval UI for a blocked stage (#682) — v1
+  ships the manual `pipeline resume` seam.
+- Auto-filing a bug for a failed stage (`show` prints the command; you run it).
+- LLM stages, upstream stage output flowing into a downstream stage's prompt, and
+  per-stage env/workdir.
+- Matrix / dynamic stages, more than one concurrent run per pipeline, pipelines
+  defined from the dashboard, a web funnel view, and a foreground `--watch`.
+</content>

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1649,6 +1649,9 @@ func runAgentList(args []string, stdout, stderr io.Writer) int {
 		if isEphemeralAgentName(agent.Name) {
 			continue // transient spawn-from-spec workers are not part of the registry
 		}
+		if isPipelineRunnerAgentName(agent.Name) {
+			continue // hidden per-pipeline shell runners (#681) are an executor detail
+		}
 		fmt.Fprintf(stdout, "%-16s %-8s %-12s %-20s %s\n", agent.Name, agent.Runtime, agent.Role, strings.Join(agentRepos[agent.Name], ","), strings.Join(agent.Capabilities, ","))
 	}
 	return 0

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1935,6 +1935,11 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 		// no heartbeat sections the scan returns before any store touch. Skip it under
 		// --dry-run (no worker loop runs there, so an enqueued job would just sit).
 		heartbeatEnqueue := newHeartbeatEnqueuer(store, home)
+		// Pipeline schedules (#681) run the same way: the scan advances in-flight runs
+		// and fires due interval schedules, reusing the normal job queue. Off-by-default
+		// (no pipelines => an empty list before any state touch) and skipped under
+		// --dry-run for the same reason.
+		pipelineEnqueue := newPipelineStageEnqueuer(store, home)
 		for {
 			if err := receiveSupervisorWorkerError(workerErr); err != nil {
 				return err
@@ -1946,6 +1951,9 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 			if !dryRun {
 				if err := runHeartbeatScanOnce(ctx, paths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
 					writeLine(stdout, "heartbeat scan error: %s", err)
+				}
+				if err := runPipelineScanOnce(ctx, store, pipelineEnqueue, time.Now().UTC()); err != nil {
+					writeLine(stdout, "pipeline scan error: %s", err)
 				}
 			}
 			if watchSkillOptReviews {
@@ -2003,6 +2011,12 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 		writeLine(stdout, "heartbeat scan disabled: %s", heartbeatPathsErr)
 	}
 	heartbeatEnqueue := newHeartbeatEnqueuer(store, home)
+	// Pipeline schedules (#681) fire in the single-repo daemon too, or a single-repo
+	// daemon would silently never advance/schedule pipelines. Off-by-default: with no
+	// pipelines the scan returns an empty list before any state touch. Unlike the
+	// heartbeat scan it needs no config paths (it reads the DB), so a paths failure
+	// does not disable it.
+	pipelineEnqueue := newPipelineStageEnqueuer(store, home)
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -2031,6 +2045,9 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 			if err := runHeartbeatScanOnce(ctx, heartbeatPaths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
 				writeLine(stdout, "heartbeat scan error: %s", err)
 			}
+		}
+		if err := runPipelineScanOnce(ctx, store, pipelineEnqueue, time.Now().UTC()); err != nil {
+			writeLine(stdout, "pipeline scan error: %s", err)
 		}
 		// Read the warm-reloadable poll interval each cycle (#577) so a SIGHUP
 		// change takes effect on the next tick. Fall back to the historical 30s

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -30,6 +31,8 @@ func runPipeline(args []string, stdout, stderr io.Writer) int {
 		return runPipelineAdd(args[1:], stdout, stderr)
 	case "list":
 		return runPipelineList(args[1:], stdout, stderr)
+	case "run":
+		return runPipelineRunCmd(args[1:], stdout, stderr)
 	case "show":
 		return runPipelineShow(args[1:], stdout, stderr)
 	case "enable":
@@ -49,7 +52,8 @@ func printPipelineUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot pipeline add <spec.yaml> [--enable]")
 	fmt.Fprintln(w, "  gitmoot pipeline list [--json]")
-	fmt.Fprintln(w, "  gitmoot pipeline show <name> [--json]")
+	fmt.Fprintln(w, "  gitmoot pipeline run <name>")
+	fmt.Fprintln(w, "  gitmoot pipeline show <name|run-id> [--json]")
 	fmt.Fprintln(w, "  gitmoot pipeline enable <name>")
 	fmt.Fprintln(w, "  gitmoot pipeline disable <name>")
 	fmt.Fprintln(w, "  gitmoot pipeline remove <name>")
@@ -269,26 +273,46 @@ func runPipelineShow(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	var (
-		record db.Pipeline
-		found  bool
+		record   db.Pipeline
+		found    bool
+		runView  pipelineRunView
+		runFound bool
 	)
 	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
 		var err error
-		record, found, err = store.GetPipeline(context.Background(), name)
+		// `show <name|run-id>`: a pipeline name resolves to the registry view; a run
+		// id (its distinct "prun-" marker never collides with a name) resolves to the
+		// run funnel. Try the pipeline first — a name is the common case.
+		record, found, err = store.GetPipeline(ctx, name)
+		if err != nil {
+			return err
+		}
+		if found {
+			return nil
+		}
+		runView, runFound, err = loadPipelineRunView(ctx, store, name)
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "pipeline show: %v\n", err)
 		return 1
 	}
-	if !found {
-		fmt.Fprintf(stderr, "pipeline %s not found\n", name)
-		return 1
+	if found {
+		if *jsonOut {
+			return encodePipelineJSON(stdout, stderr, pipelineToJSON(record, true))
+		}
+		printPipeline(stdout, record)
+		return 0
 	}
-	if *jsonOut {
-		return encodePipelineJSON(stdout, stderr, pipelineToJSON(record, true))
+	if runFound {
+		if *jsonOut {
+			return encodePipelineJSON(stdout, stderr, pipelineRunToJSON(runView))
+		}
+		printPipelineRunFunnel(stdout, runView)
+		return 0
 	}
-	printPipeline(stdout, record)
-	return 0
+	fmt.Fprintf(stderr, "pipeline or run %s not found\n", name)
+	return 1
 }
 
 func runPipelineSetEnabled(args []string, enabled bool, stdout, stderr io.Writer) int {
@@ -456,4 +480,258 @@ func enabledLabel(enabled bool) string {
 		return "enabled"
 	}
 	return "disabled"
+}
+
+// runPipelineRunCmd is `gitmoot pipeline run <name>`: it creates a manual run of a
+// registered pipeline, enqueues its ready root stages (via one advance pass), and
+// prints the run id (script-stable, so `RUN=$(gitmoot pipeline run foo)` works).
+// It enforces the two run preconditions: the pipeline must carry a repo (stage
+// jobs need a managed repo for the worker to claim them) and it must have no
+// in-flight run (one active run per pipeline). Manual runs ignore the schedule's
+// enabled flag — a disabled pipeline can still be run by hand.
+func runPipelineRunCmd(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pipeline run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "pipeline run requires a name")
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "pipeline run accepts exactly one name")
+		return 2
+	}
+	var runID string
+	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		rec, ok, err := store.GetPipeline(ctx, name)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("pipeline %s not found", name)
+		}
+		if strings.TrimSpace(rec.Repo) == "" {
+			return fmt.Errorf("pipeline %s has no repo; stages need a managed repo to run", name)
+		}
+		if active, ok, err := store.ActivePipelineRun(ctx, name); err != nil {
+			return err
+		} else if ok {
+			return fmt.Errorf("pipeline %s already has an active run %s", name, active.ID)
+		}
+		spec, err := pipeline.Load([]byte(rec.SpecYAML))
+		if err != nil {
+			return fmt.Errorf("stored spec is invalid: %w", err)
+		}
+		now := time.Now().UTC()
+		run, err := createPipelineRun(ctx, store, rec, spec, "manual", now)
+		if err != nil {
+			return err
+		}
+		enqueue := newPipelineStageEnqueuer(store, *home)
+		if _, err := advancePipelineRun(ctx, store, enqueue, rec, spec, run, now); err != nil {
+			return err
+		}
+		runID = run.ID
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "pipeline run: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "%s", runID)
+	return 0
+}
+
+// pipelineRunView is the resolved data behind `pipeline show <run-id>`: the run
+// row plus its stage rows ordered into spec/DAG order for the funnel.
+type pipelineRunView struct {
+	run    db.PipelineRun
+	stages []db.PipelineRunStage
+}
+
+// loadPipelineRunView loads a run and its stages, ordered for display. A missing
+// run returns ok=false (so `show` falls through to "not found").
+func loadPipelineRunView(ctx context.Context, store *db.Store, id string) (pipelineRunView, bool, error) {
+	run, ok, err := store.GetPipelineRun(ctx, id)
+	if err != nil || !ok {
+		return pipelineRunView{}, ok, err
+	}
+	stages, err := store.ListPipelineRunStages(ctx, run.ID)
+	if err != nil {
+		return pipelineRunView{}, false, err
+	}
+	return pipelineRunView{run: run, stages: orderPipelineRunStages(ctx, store, run, stages)}, true, nil
+}
+
+// orderPipelineRunStages reorders stage rows into spec (topological) order when the
+// run's pipeline + matching spec snapshot are available; otherwise it keeps the
+// store's stable stage_id order. Any stage rows not present in the spec (should not
+// happen) are appended so no data is dropped.
+func orderPipelineRunStages(ctx context.Context, store *db.Store, run db.PipelineRun, stages []db.PipelineRunStage) []db.PipelineRunStage {
+	rec, ok, err := store.GetPipeline(ctx, run.Pipeline)
+	if err != nil || !ok {
+		return stages
+	}
+	spec, err := pipeline.Load([]byte(rec.SpecYAML))
+	if err != nil || strings.TrimSpace(rec.SpecHash) != strings.TrimSpace(run.SpecHash) {
+		return stages
+	}
+	byID := make(map[string]db.PipelineRunStage, len(stages))
+	for _, stage := range stages {
+		byID[stage.StageID] = stage
+	}
+	ordered := make([]db.PipelineRunStage, 0, len(stages))
+	seen := make(map[string]struct{}, len(stages))
+	for _, stage := range spec.Stages {
+		if row, ok := byID[stage.ID]; ok {
+			ordered = append(ordered, row)
+			seen[stage.ID] = struct{}{}
+		}
+	}
+	for _, stage := range stages {
+		if _, ok := seen[stage.StageID]; !ok {
+			ordered = append(ordered, stage)
+		}
+	}
+	return ordered
+}
+
+// printPipelineRunFunnel renders a run as the TEXT FUNNEL (decision 9), e.g.
+// `source OK -> score OK -> deploy BLOCKED (needs: R2 token)`, preceded by the run
+// header. A failed run surfaces the exact `gitmoot report bug --job <stage-job>`
+// command for the halted stage (NO auto-filing).
+func printPipelineRunFunnel(stdout io.Writer, view pipelineRunView) {
+	run := view.run
+	writeLine(stdout, "run: %s", run.ID)
+	writeLine(stdout, "pipeline: %s", run.Pipeline)
+	writeLine(stdout, "trigger: %s", firstNonEmpty(run.Trigger, "-"))
+	writeLine(stdout, "state: %s", run.State)
+	writeLine(stdout, "started: %s", heartbeatTimeForStatus(run.StartedAt))
+	writeLine(stdout, "finished: %s", heartbeatTimeForStatus(run.FinishedAt))
+	if strings.TrimSpace(run.HaltStage) != "" {
+		writeLine(stdout, "halt_stage: %s", run.HaltStage)
+	}
+	if strings.TrimSpace(run.HaltReason) != "" {
+		writeLine(stdout, "halt_reason: %s", run.HaltReason)
+	}
+	if needs := decodePipelineNeeds(run.NeedsJSON); len(needs) > 0 {
+		writeLine(stdout, "needs: %s", strings.Join(needs, ", "))
+	}
+	writeLine(stdout, "")
+	writeLine(stdout, "%s", pipelineFunnelLine(view.stages))
+	if run.State == pipeline.RunFailed {
+		if jobID := haltStageJobID(view); jobID != "" {
+			writeLine(stdout, "")
+			writeLine(stdout, "stage failed; report it with:")
+			writeLine(stdout, "  gitmoot report bug --job %s", jobID)
+		}
+	}
+}
+
+// pipelineFunnelLine joins each stage's `<id> <LABEL>` into the funnel line.
+func pipelineFunnelLine(stages []db.PipelineRunStage) string {
+	parts := make([]string, 0, len(stages))
+	for _, stage := range stages {
+		parts = append(parts, stage.StageID+" "+pipelineStageFunnelLabel(stage))
+	}
+	return strings.Join(parts, " -> ")
+}
+
+// pipelineStageFunnelLabel is the funnel status token for a stage: OK for a
+// succeeded stage, BLOCKED (needs: ...) for a parked stage, else the uppercased
+// state (PENDING/QUEUED/RUNNING/FAILED/SKIPPED/CANCELLED).
+func pipelineStageFunnelLabel(stage db.PipelineRunStage) string {
+	switch stage.State {
+	case pipeline.StageSucceeded:
+		return "OK"
+	case pipeline.StageBlocked:
+		if needs := decodePipelineNeeds(stage.NeedsJSON); len(needs) > 0 {
+			return fmt.Sprintf("BLOCKED (needs: %s)", strings.Join(needs, ", "))
+		}
+		return "BLOCKED"
+	default:
+		return strings.ToUpper(stage.State)
+	}
+}
+
+// haltStageJobID returns the job id of the run's halt stage (for the bug-report
+// command).
+func haltStageJobID(view pipelineRunView) string {
+	for _, stage := range view.stages {
+		if stage.StageID == view.run.HaltStage {
+			return strings.TrimSpace(stage.JobID)
+		}
+	}
+	return ""
+}
+
+type pipelineRunStageJSON struct {
+	ID      string   `json:"id"`
+	State   string   `json:"state"`
+	JobID   string   `json:"job_id,omitempty"`
+	Attempt int      `json:"attempt,omitempty"`
+	Needs   []string `json:"needs,omitempty"`
+	Summary string   `json:"summary,omitempty"`
+}
+
+type pipelineRunJSON struct {
+	ID         string                 `json:"id"`
+	Pipeline   string                 `json:"pipeline"`
+	Trigger    string                 `json:"trigger"`
+	State      string                 `json:"state"`
+	HaltStage  string                 `json:"halt_stage,omitempty"`
+	HaltReason string                 `json:"halt_reason,omitempty"`
+	Needs      []string               `json:"needs,omitempty"`
+	SpecHash   string                 `json:"spec_hash"`
+	StartedAt  string                 `json:"started_at,omitempty"`
+	FinishedAt string                 `json:"finished_at,omitempty"`
+	Funnel     string                 `json:"funnel"`
+	Stages     []pipelineRunStageJSON `json:"stages,omitempty"`
+}
+
+// pipelineRunToJSON projects a run view into its script-stable JSON shape.
+func pipelineRunToJSON(view pipelineRunView) pipelineRunJSON {
+	run := view.run
+	out := pipelineRunJSON{
+		ID:         run.ID,
+		Pipeline:   run.Pipeline,
+		Trigger:    run.Trigger,
+		State:      run.State,
+		HaltStage:  run.HaltStage,
+		HaltReason: run.HaltReason,
+		Needs:      decodePipelineNeeds(run.NeedsJSON),
+		SpecHash:   run.SpecHash,
+		StartedAt:  pipelineRunTimeJSON(run.StartedAt),
+		FinishedAt: pipelineRunTimeJSON(run.FinishedAt),
+		Funnel:     pipelineFunnelLine(view.stages),
+	}
+	for _, stage := range view.stages {
+		out.Stages = append(out.Stages, pipelineRunStageJSON{
+			ID:      stage.StageID,
+			State:   stage.State,
+			JobID:   stage.JobID,
+			Attempt: stage.Attempt,
+			Needs:   decodePipelineNeeds(stage.NeedsJSON),
+			Summary: stage.Summary,
+		})
+	}
+	return out
+}
+
+func pipelineRunTimeJSON(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
 }

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -35,6 +35,10 @@ func runPipeline(args []string, stdout, stderr io.Writer) int {
 		return runPipelineRunCmd(args[1:], stdout, stderr)
 	case "show":
 		return runPipelineShow(args[1:], stdout, stderr)
+	case "resume":
+		return runPipelineResume(args[1:], stdout, stderr)
+	case "cancel":
+		return runPipelineCancel(args[1:], stdout, stderr)
 	case "enable":
 		return runPipelineSetEnabled(args[1:], true, stdout, stderr)
 	case "disable":
@@ -54,6 +58,8 @@ func printPipelineUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot pipeline list [--json]")
 	fmt.Fprintln(w, "  gitmoot pipeline run <name>")
 	fmt.Fprintln(w, "  gitmoot pipeline show <name|run-id> [--json]")
+	fmt.Fprintln(w, "  gitmoot pipeline resume <run-id> [--from <stage>]")
+	fmt.Fprintln(w, "  gitmoot pipeline cancel <run-id>")
 	fmt.Fprintln(w, "  gitmoot pipeline enable <name>")
 	fmt.Fprintln(w, "  gitmoot pipeline disable <name>")
 	fmt.Fprintln(w, "  gitmoot pipeline remove <name>")

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -1,0 +1,459 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// runPipeline is the CLI for the #681 pipeline registry: define, inspect, and
+// toggle declarative pipelines. run/resume/cancel and the per-run funnel view
+// arrive in later steps and are deliberately not registered here (only what
+// already works is exposed). The mux mirrors runAgentHeartbeat's shape.
+func runPipeline(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "add":
+		return runPipelineAdd(args[1:], stdout, stderr)
+	case "list":
+		return runPipelineList(args[1:], stdout, stderr)
+	case "show":
+		return runPipelineShow(args[1:], stdout, stderr)
+	case "enable":
+		return runPipelineSetEnabled(args[1:], true, stdout, stderr)
+	case "disable":
+		return runPipelineSetEnabled(args[1:], false, stdout, stderr)
+	case "remove":
+		return runPipelineRemove(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown pipeline command %q\n\n", args[0])
+		printPipelineUsage(stderr)
+		return 2
+	}
+}
+
+func printPipelineUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot pipeline add <spec.yaml> [--enable]")
+	fmt.Fprintln(w, "  gitmoot pipeline list [--json]")
+	fmt.Fprintln(w, "  gitmoot pipeline show <name> [--json]")
+	fmt.Fprintln(w, "  gitmoot pipeline enable <name>")
+	fmt.Fprintln(w, "  gitmoot pipeline disable <name>")
+	fmt.Fprintln(w, "  gitmoot pipeline remove <name>")
+}
+
+// pipelineRunnerAgentName derives the hidden shell runner agent name for a
+// pipeline. It carries the recognizable "pipeline-...-runner" marker so
+// isPipelineRunnerAgentName can hide it from `agent list`, mirroring the
+// ephemeral-agent naming precedent in workflow/result.go. The pipeline name is a
+// validated name-safe token, so no slugging is needed.
+func pipelineRunnerAgentName(pipelineName string) string {
+	return "pipeline-" + strings.TrimSpace(pipelineName) + "-runner"
+}
+
+// isPipelineRunnerAgentName reports whether an agent name is a pipeline's hidden
+// shell runner (#681). Such agents are an implementation detail of the pipeline
+// executor and are filtered out of the default `agent list` output, mirroring the
+// isEphemeralAgentName filter.
+func isPipelineRunnerAgentName(name string) bool {
+	return strings.HasPrefix(name, "pipeline-") && strings.HasSuffix(name, "-runner") &&
+		len(name) > len("pipeline--runner")
+}
+
+func runPipelineAdd(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "pipeline add requires a spec file")
+			return 2
+		}
+		return 0
+	}
+	specFile := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("pipeline add", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	enable := fs.Bool("enable", false, "enable the pipeline immediately (default disabled)")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "pipeline add accepts exactly one spec file")
+		return 2
+	}
+	raw, err := os.ReadFile(specFile)
+	if err != nil {
+		fmt.Fprintf(stderr, "pipeline add: read spec: %v\n", err)
+		return 1
+	}
+	spec, err := pipeline.Load(raw)
+	if err != nil {
+		fmt.Fprintf(stderr, "pipeline add: %v\n", err)
+		return 2
+	}
+	repo := ""
+	if strings.TrimSpace(spec.Repo) != "" {
+		parsed, err := daemon.ParseRepository(spec.Repo)
+		if err != nil {
+			fmt.Fprintf(stderr, "pipeline add: invalid repo %q: %v\n", spec.Repo, err)
+			return 2
+		}
+		repo = parsed.FullName()
+	}
+	interval, jitter := "", ""
+	if spec.Schedule != nil {
+		interval = spec.Schedule.Interval
+		jitter = spec.Schedule.Jitter
+	}
+	record := db.Pipeline{
+		Name:     spec.Name,
+		Repo:     repo,
+		SpecYAML: string(raw),
+		SpecHash: pipeline.Hash(raw),
+		Interval: interval,
+		Jitter:   jitter,
+	}
+	runnerName := pipelineRunnerAgentName(spec.Name)
+	var finalEnabled bool
+	if err := withStore(*home, func(store *db.Store) error {
+		// Refuse to clobber a real managed agent that happens to occupy the runner
+		// name: a pre-existing non-shell agent by that name is a naming collision, not
+		// this pipeline's runner. A pre-existing shell agent (this pipeline's own
+		// runner from an earlier add) is fine — the upsert below is idempotent.
+		if existing, err := store.GetAgent(context.Background(), runnerName); err == nil && existing.Runtime != runtime.ShellRuntime {
+			return fmt.Errorf("runner agent name %q collides with an existing %s agent", runnerName, existing.Runtime)
+		}
+		if err := store.CreateOrUpdatePipeline(context.Background(), record); err != nil {
+			return err
+		}
+		if err := store.UpsertAgent(context.Background(), pipelineRunnerAgent(runnerName, repo)); err != nil {
+			return err
+		}
+		if *enable {
+			if err := store.SetPipelineEnabled(context.Background(), spec.Name, true); err != nil {
+				return err
+			}
+		}
+		// Report the RESULTING enabled state, not just this invocation's --enable:
+		// re-adding an edited spec preserves an already-enabled pipeline.
+		saved, _, err := store.GetPipeline(context.Background(), spec.Name)
+		if err != nil {
+			return err
+		}
+		finalEnabled = saved.Enabled
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "pipeline add: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "added pipeline %s (%s, %d stages)", spec.Name, enabledLabel(finalEnabled), len(spec.Stages))
+	return 0
+}
+
+// pipelineRunnerAgent builds the hidden shell agent that owns a pipeline's stage
+// jobs. The stage command travels per-job (via the stage job's runtime-override
+// ref), NOT on this agent's runtime_ref, so one runner serves every stage. It is
+// least-privilege read-only (the shell adapter runs the command verbatim; the
+// policy is nominal for shell) and holds only the "ask" capability, matching the
+// stage jobs' Action.
+func pipelineRunnerAgent(name, repo string) db.Agent {
+	return db.Agent{
+		Name:           name,
+		Role:           "pipeline-runner",
+		Runtime:        runtime.ShellRuntime,
+		RepoScope:      repo,
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: runtime.AutonomyPolicyReadOnly,
+		HealthStatus:   "unknown",
+	}
+}
+
+type pipelineStageJSON struct {
+	ID               string   `json:"id"`
+	Cmd              string   `json:"cmd"`
+	Needs            []string `json:"needs,omitempty"`
+	Timeout          string   `json:"timeout,omitempty"`
+	Retry            int      `json:"retry,omitempty"`
+	SuccessDecisions []string `json:"success_decisions,omitempty"`
+}
+
+type pipelineJSON struct {
+	Name       string              `json:"name"`
+	Repo       string              `json:"repo,omitempty"`
+	Enabled    bool                `json:"enabled"`
+	Interval   string              `json:"interval,omitempty"`
+	Jitter     string              `json:"jitter,omitempty"`
+	SpecHash   string              `json:"spec_hash"`
+	Stages     []pipelineStageJSON `json:"stages,omitempty"`
+	LastRunAt  string              `json:"last_run_at,omitempty"`
+	NextDueAt  string              `json:"next_due_at,omitempty"`
+	LastRunID  string              `json:"last_run_id,omitempty"`
+	LastStatus string              `json:"last_status,omitempty"`
+}
+
+func runPipelineList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pipeline list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print the pipelines as a JSON array")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "pipeline list does not accept positional arguments")
+		return 2
+	}
+	var pipelines []db.Pipeline
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		pipelines, err = store.ListPipelines(context.Background())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "pipeline list: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		out := make([]pipelineJSON, 0, len(pipelines))
+		for _, p := range pipelines {
+			out = append(out, pipelineToJSON(p, false))
+		}
+		return encodePipelineJSON(stdout, stderr, out)
+	}
+	for _, p := range pipelines {
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\n", p.Name, enabledLabel(p.Enabled), firstNonEmpty(p.Interval, "-"), firstNonEmpty(p.Repo, "-"), firstNonEmpty(p.LastStatus, "-"))
+	}
+	return 0
+}
+
+func runPipelineShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pipeline show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print the pipeline as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "pipeline show requires a name")
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "pipeline show accepts exactly one name")
+		return 2
+	}
+	var (
+		record db.Pipeline
+		found  bool
+	)
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		record, found, err = store.GetPipeline(context.Background(), name)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "pipeline show: %v\n", err)
+		return 1
+	}
+	if !found {
+		fmt.Fprintf(stderr, "pipeline %s not found\n", name)
+		return 1
+	}
+	if *jsonOut {
+		return encodePipelineJSON(stdout, stderr, pipelineToJSON(record, true))
+	}
+	printPipeline(stdout, record)
+	return 0
+}
+
+func runPipelineSetEnabled(args []string, enabled bool, stdout, stderr io.Writer) int {
+	verb := "enable"
+	if !enabled {
+		verb = "disable"
+	}
+	fs := flag.NewFlagSet("pipeline "+verb, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintf(stderr, "pipeline %s requires a name\n", verb)
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "pipeline %s accepts exactly one name\n", verb)
+		return 2
+	}
+	if err := withStore(*home, func(store *db.Store) error {
+		return store.SetPipelineEnabled(context.Background(), name, enabled)
+	}); err != nil {
+		fmt.Fprintf(stderr, "pipeline %s: %v\n", verb, err)
+		return 1
+	}
+	writeLine(stdout, "%sd pipeline %s", verb, name)
+	return 0
+}
+
+func runPipelineRemove(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pipeline remove", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "pipeline remove requires a name")
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "pipeline remove accepts exactly one name")
+		return 2
+	}
+	var removed bool
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		removed, err = store.DeletePipeline(context.Background(), name)
+		if err != nil {
+			return err
+		}
+		// Best-effort: dispose the hidden runner agent so removing a pipeline does not
+		// leak it. Ignore the outcome — the pipeline row is what `remove` is about, and
+		// leaving an orphan runner is harmless (run/job cleanup lands in the run step).
+		_, _ = store.RemoveAgent(context.Background(), pipelineRunnerAgentName(name))
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "pipeline remove: %v\n", err)
+		return 1
+	}
+	if !removed {
+		fmt.Fprintf(stderr, "pipeline %s not found\n", name)
+		return 1
+	}
+	writeLine(stdout, "removed pipeline %s", name)
+	return 0
+}
+
+// pipelineToJSON projects a stored pipeline row into its script-stable JSON
+// shape. When withStages is set it parses the stored (already-validated) spec to
+// enumerate the stage DAG; a parse failure degrades to no stages rather than
+// failing the command.
+func pipelineToJSON(record db.Pipeline, withStages bool) pipelineJSON {
+	out := pipelineJSON{
+		Name:       record.Name,
+		Repo:       record.Repo,
+		Enabled:    record.Enabled,
+		Interval:   record.Interval,
+		Jitter:     record.Jitter,
+		SpecHash:   record.SpecHash,
+		LastRunAt:  heartbeatTimeForStatus(record.LastRunAt),
+		NextDueAt:  heartbeatTimeForStatus(record.NextDueAt),
+		LastRunID:  record.LastRunID,
+		LastStatus: record.LastStatus,
+	}
+	if out.LastRunAt == "-" {
+		out.LastRunAt = ""
+	}
+	if out.NextDueAt == "-" {
+		out.NextDueAt = ""
+	}
+	if withStages {
+		if spec, err := pipeline.Load([]byte(record.SpecYAML)); err == nil {
+			for _, stage := range spec.Stages {
+				out.Stages = append(out.Stages, pipelineStageJSON{
+					ID:               stage.ID,
+					Cmd:              stage.Cmd,
+					Needs:            stage.Needs,
+					Timeout:          stage.Timeout,
+					Retry:            stage.Retry,
+					SuccessDecisions: stage.SuccessDecisions,
+				})
+			}
+		}
+	}
+	return out
+}
+
+func printPipeline(stdout io.Writer, record db.Pipeline) {
+	writeLine(stdout, "name: %s", record.Name)
+	writeLine(stdout, "repo: %s", firstNonEmpty(record.Repo, "-"))
+	writeLine(stdout, "enabled: %t", record.Enabled)
+	writeLine(stdout, "interval: %s", firstNonEmpty(record.Interval, "-"))
+	writeLine(stdout, "jitter: %s", firstNonEmpty(record.Jitter, "-"))
+	writeLine(stdout, "spec_hash: %s", record.SpecHash)
+	writeLine(stdout, "last_run: %s", heartbeatTimeForStatus(record.LastRunAt))
+	writeLine(stdout, "next_due: %s", heartbeatTimeForStatus(record.NextDueAt))
+	writeLine(stdout, "last_status: %s", firstNonEmpty(record.LastStatus, "-"))
+	writeLine(stdout, "last_run_id: %s", firstNonEmpty(record.LastRunID, "-"))
+	writeLine(stdout, "stages:")
+	spec, err := pipeline.Load([]byte(record.SpecYAML))
+	if err != nil {
+		writeLine(stdout, "  (unparseable stored spec: %v)", err)
+		return
+	}
+	for _, stage := range spec.Stages {
+		needs := "-"
+		if len(stage.Needs) > 0 {
+			needs = strings.Join(stage.Needs, ",")
+		}
+		writeLine(stdout, "  %s\tneeds=%s\tcmd=%s", stage.ID, needs, stage.Cmd)
+	}
+}
+
+func encodePipelineJSON(stdout, stderr io.Writer, value any) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(value); err != nil {
+		fmt.Fprintf(stderr, "pipeline: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func enabledLabel(enabled bool) string {
+	if enabled {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/internal/cli/pipeline_advance_test.go
+++ b/internal/cli/pipeline_advance_test.go
@@ -294,6 +294,72 @@ func TestAdvancerBlockedPark(t *testing.T) {
 	}
 }
 
+const independentBranchSpec = `name: fork
+repo: owner/repo
+stages:
+  - id: a
+    cmd: echo a
+  - id: b
+    cmd: echo b
+  - id: c
+    cmd: echo c
+    needs: [b]
+`
+
+// TestAdvancerIndependentBranchRunsWhenSiblingBlocks proves per-branch (not
+// run-wide) halting: two independent roots a and b, with c depending only on b.
+// When a blocks, c's branch (b -> c) is fully reachable and MUST still run to
+// completion; the run parks blocked only because of a, and only once nothing is in
+// flight. A run-wide fail-fast would wrongly skip c even though its dep b succeeded.
+func TestAdvancerIndependentBranchRunsWhenSiblingBlocks(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "fork", independentBranchSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	// Both roots enqueue immediately; c waits on b.
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	if got := stageRow(t, store, run.ID, "a"); got.State != pipeline.StageQueued {
+		t.Fatalf("stage a = %s, want queued", got.State)
+	}
+	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StageQueued {
+		t.Fatalf("stage b = %s, want queued", got.State)
+	}
+
+	// a blocks, b succeeds: the block must NOT halt b's independent branch.
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "blocked", "a needs a secret", []string{"R2 token"})
+	settleStageJob(t, store, stageRow(t, store, run.ID, "b").JobID, "approved", "b ok", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+
+	// c's dep b succeeded, so c is enqueued and the run stays running (c in flight).
+	c := stageRow(t, store, run.ID, "c")
+	if c.State != pipeline.StageQueued || c.JobID == "" {
+		t.Fatalf("stage c = %+v, want queued after b succeeded (independent of blocked a)", c)
+	}
+	if run.State != pipeline.RunRunning {
+		t.Fatalf("run = %s, want still running while c is in flight", run.State)
+	}
+	if got := stageRow(t, store, run.ID, "a"); got.State != pipeline.StageBlocked {
+		t.Fatalf("stage a = %s, want blocked", got.State)
+	}
+
+	// c completes: only now, with nothing in flight, does the run park blocked on a.
+	settleStageJob(t, store, c.JobID, "approved", "c ok", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "c"); got.State != pipeline.StageSucceeded {
+		t.Fatalf("stage c = %s, want succeeded (reachable branch ran to completion)", got.State)
+	}
+	if run.State != pipeline.RunBlocked {
+		t.Fatalf("run = %s, want blocked (parks on a once nothing is in flight)", run.State)
+	}
+	if run.HaltStage != "a" {
+		t.Fatalf("halt_stage = %q, want a", run.HaltStage)
+	}
+	if got := decodePipelineNeeds(run.NeedsJSON); len(got) != 1 || got[0] != "R2 token" {
+		t.Fatalf("run needs = %v, want [R2 token]", got)
+	}
+}
+
 const retrySpec = `name: retry
 repo: owner/repo
 stages:

--- a/internal/cli/pipeline_advance_test.go
+++ b/internal/cli/pipeline_advance_test.go
@@ -1,0 +1,497 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// pipelineAdvanceStore opens an isolated store for advancer unit tests. The
+// advancer reads/writes real rows (run/stage/job), so a real store — not a mock —
+// is the honest test double; it never touches a user home.
+func pipelineAdvanceStore(t *testing.T) *db.Store {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// newTestPipeline stores a pipeline record built from spec YAML and returns the
+// canonical stored record plus the parsed spec.
+func newTestPipeline(t *testing.T, store *db.Store, name, specYAML string) (db.Pipeline, pipeline.Spec) {
+	t.Helper()
+	spec, err := pipeline.Load([]byte(specYAML))
+	if err != nil {
+		t.Fatalf("pipeline.Load: %v", err)
+	}
+	rec := db.Pipeline{Name: name, Repo: "owner/repo", SpecYAML: specYAML, SpecHash: pipeline.Hash([]byte(specYAML))}
+	if err := store.CreateOrUpdatePipeline(context.Background(), rec); err != nil {
+		t.Fatalf("CreateOrUpdatePipeline: %v", err)
+	}
+	got, ok, err := store.GetPipeline(context.Background(), name)
+	if err != nil || !ok {
+		t.Fatalf("GetPipeline: ok=%v err=%v", ok, err)
+	}
+	return got, spec
+}
+
+// testStageEnqueuer is a real Mailbox-backed enqueuer: it persists a queued job
+// row so the advancer's later GetJob(stage.JobID) fold works. It requires no
+// agent (Mailbox tolerates a missing agent) — the unit tests exercise the
+// advancer's decision logic, not the worker.
+func testStageEnqueuer(store *db.Store) pipelineStageEnqueuer {
+	mailbox := workflow.Mailbox{Store: store}
+	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
+		return mailbox.Enqueue(ctx, request)
+	}
+}
+
+// settleStageJob transitions a stage's enqueued job to the terminal state the real
+// mailbox would produce for a given decision (stateForDecision), attaching the
+// result. It faithfully reproduces the changes_requested TRAP: a changes_requested
+// job settles to jobs.state = SUCCEEDED, so an advancer that folded on jobs.state
+// would wrongly advance it.
+func settleStageJob(t *testing.T, store *db.Store, jobID, decision, summary string, needs []string) {
+	t.Helper()
+	ctx := context.Background()
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", jobID, err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+	payload.Result = &workflow.AgentResult{Decision: decision, Summary: summary, Needs: needs}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	to := jobStateForDecision(decision)
+	ok, err := store.TransitionJobStatePayloadWithEvent(ctx, jobID, job.State, to, string(encoded),
+		db.JobEvent{JobID: jobID, Kind: to, Message: "settled by test"})
+	if err != nil || !ok {
+		t.Fatalf("settle %s -> %s: ok=%v err=%v", jobID, to, ok, err)
+	}
+}
+
+// jobStateForDecision mirrors workflow.stateForDecision (unexported): blocked and
+// failed are their own terminal states; everything else (approved, implemented,
+// AND changes_requested) is a SUCCEEDED job.
+func jobStateForDecision(decision string) string {
+	switch decision {
+	case "blocked":
+		return string(workflow.JobBlocked)
+	case "failed":
+		return string(workflow.JobFailed)
+	default:
+		return string(workflow.JobSucceeded)
+	}
+}
+
+func stageRow(t *testing.T, store *db.Store, runID, stageID string) db.PipelineRunStage {
+	t.Helper()
+	stage, ok, err := store.GetPipelineRunStage(context.Background(), runID, stageID)
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineRunStage(%s/%s): ok=%v err=%v", runID, stageID, ok, err)
+	}
+	return stage
+}
+
+func startTestRun(t *testing.T, store *db.Store, rec db.Pipeline, spec pipeline.Spec, enqueue pipelineStageEnqueuer, now time.Time) db.PipelineRun {
+	t.Helper()
+	run, err := createPipelineRun(context.Background(), store, rec, spec, "manual", now)
+	if err != nil {
+		t.Fatalf("createPipelineRun: %v", err)
+	}
+	run, err = advancePipelineRun(context.Background(), store, enqueue, rec, spec, run, now)
+	if err != nil {
+		t.Fatalf("initial advance: %v", err)
+	}
+	return run
+}
+
+func advance(t *testing.T, store *db.Store, rec db.Pipeline, spec pipeline.Spec, enqueue pipelineStageEnqueuer, run db.PipelineRun, now time.Time) db.PipelineRun {
+	t.Helper()
+	updated, err := advancePipelineRun(context.Background(), store, enqueue, rec, spec, run, now)
+	if err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+	return updated
+}
+
+const linearChainSpec = `name: chain
+repo: owner/repo
+stages:
+  - id: a
+    cmd: echo a
+  - id: b
+    cmd: echo b
+    needs: [a]
+  - id: c
+    cmd: echo c
+    needs: [b]
+`
+
+// TestAdvancerLinearChain proves a linear a->b->c chain advances one layer per
+// scan: each stage is enqueued only after its single dependency succeeds, and the
+// run reaches succeeded exactly when the last stage does.
+func TestAdvancerLinearChain(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	// Only the root is enqueued; b/c wait on their deps.
+	if got := stageRow(t, store, run.ID, "a"); got.State != pipeline.StageQueued || got.JobID == "" {
+		t.Fatalf("stage a = %+v, want queued with job", got)
+	}
+	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StagePending || got.JobID != "" {
+		t.Fatalf("stage b = %+v, want pending with no job", got)
+	}
+
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "approved", "a ok", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "a"); got.State != pipeline.StageSucceeded {
+		t.Fatalf("stage a = %s, want succeeded", got.State)
+	}
+	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StageQueued || got.JobID == "" {
+		t.Fatalf("stage b = %+v, want queued after a succeeded", got)
+	}
+	if run.State != pipeline.RunRunning {
+		t.Fatalf("run = %s, want running", run.State)
+	}
+
+	settleStageJob(t, store, stageRow(t, store, run.ID, "b").JobID, "implemented", "b ok", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "c"); got.State != pipeline.StageQueued {
+		t.Fatalf("stage c = %s, want queued after b succeeded", got.State)
+	}
+
+	settleStageJob(t, store, stageRow(t, store, run.ID, "c").JobID, "approved", "c ok", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if run.State != pipeline.RunSucceeded {
+		t.Fatalf("run = %s, want succeeded", run.State)
+	}
+	if got := stageRow(t, store, run.ID, "c"); got.State != pipeline.StageSucceeded {
+		t.Fatalf("stage c = %s, want succeeded", got.State)
+	}
+	// The pipeline row mirrors the terminal status.
+	if rec2, _, _ := store.GetPipeline(context.Background(), "chain"); rec2.LastStatus != pipeline.RunSucceeded {
+		t.Fatalf("pipeline last_status = %q, want succeeded", rec2.LastStatus)
+	}
+}
+
+const diamondSpec = `name: diamond
+repo: owner/repo
+stages:
+  - id: a
+    cmd: echo a
+  - id: b
+    cmd: echo b
+    needs: [a]
+  - id: c
+    cmd: echo c
+    needs: [a]
+  - id: d
+    cmd: echo d
+    needs: [b, c]
+`
+
+// TestAdvancerDiamond proves fan-out/fan-in: a fans out to b AND c, and d waits
+// for BOTH before it is enqueued.
+func TestAdvancerDiamond(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "diamond", diamondSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "approved", "a", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	// Fan-out: both b and c enqueue off a.
+	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StageQueued {
+		t.Fatalf("stage b = %s, want queued", got.State)
+	}
+	if got := stageRow(t, store, run.ID, "c"); got.State != pipeline.StageQueued {
+		t.Fatalf("stage c = %s, want queued", got.State)
+	}
+	if got := stageRow(t, store, run.ID, "d"); got.State != pipeline.StagePending {
+		t.Fatalf("stage d = %s, want pending", got.State)
+	}
+
+	// Only b succeeds: d must NOT enqueue (c still in flight).
+	settleStageJob(t, store, stageRow(t, store, run.ID, "b").JobID, "approved", "b", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "d"); got.State != pipeline.StagePending {
+		t.Fatalf("stage d = %s, want still pending (c not done)", got.State)
+	}
+	if run.State != pipeline.RunRunning {
+		t.Fatalf("run = %s, want running", run.State)
+	}
+
+	// c succeeds: now d is ready.
+	settleStageJob(t, store, stageRow(t, store, run.ID, "c").JobID, "approved", "c", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "d"); got.State != pipeline.StageQueued {
+		t.Fatalf("stage d = %s, want queued (both deps done)", got.State)
+	}
+
+	settleStageJob(t, store, stageRow(t, store, run.ID, "d").JobID, "approved", "d", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if run.State != pipeline.RunSucceeded {
+		t.Fatalf("run = %s, want succeeded", run.State)
+	}
+}
+
+// TestAdvancerBlockedPark proves a blocked stage parks the run: needs are
+// persisted at stage AND run level, and the downstream stage is never enqueued.
+func TestAdvancerBlockedPark(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "approved", "a ok", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+
+	settleStageJob(t, store, stageRow(t, store, run.ID, "b").JobID, "blocked", "needs a secret", []string{"R2 token"})
+	run = advance(t, store, rec, spec, enqueue, run, now)
+
+	if run.State != pipeline.RunBlocked {
+		t.Fatalf("run = %s, want blocked", run.State)
+	}
+	if run.HaltStage != "b" {
+		t.Fatalf("halt_stage = %q, want b", run.HaltStage)
+	}
+	if got := decodePipelineNeeds(run.NeedsJSON); len(got) != 1 || got[0] != "R2 token" {
+		t.Fatalf("run needs = %v, want [R2 token]", got)
+	}
+	b := stageRow(t, store, run.ID, "b")
+	if b.State != pipeline.StageBlocked {
+		t.Fatalf("stage b = %s, want blocked", b.State)
+	}
+	if got := decodePipelineNeeds(b.NeedsJSON); len(got) != 1 || got[0] != "R2 token" {
+		t.Fatalf("stage b needs = %v, want [R2 token]", got)
+	}
+	c := stageRow(t, store, run.ID, "c")
+	if c.JobID != "" {
+		t.Fatalf("stage c job = %q, want never enqueued", c.JobID)
+	}
+	if c.State != pipeline.StageSkipped {
+		t.Fatalf("stage c = %s, want skipped", c.State)
+	}
+}
+
+const retrySpec = `name: retry
+repo: owner/repo
+stages:
+  - id: a
+    cmd: echo a
+    retry: 1
+  - id: b
+    cmd: echo b
+    needs: [a]
+`
+
+// TestAdvancerFailedRetryBudget proves a failed stage is retried while its budget
+// lasts (a fresh attempt/job id), then parks the run failed once exhausted.
+func TestAdvancerFailedRetryBudget(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "retry", retrySpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	firstJob := stageRow(t, store, run.ID, "a").JobID
+
+	// First failure: budget (retry:1) remains, so a re-attempts under a new id.
+	settleStageJob(t, store, firstJob, "failed", "boom", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	a := stageRow(t, store, run.ID, "a")
+	if a.State != pipeline.StageQueued {
+		t.Fatalf("stage a = %s, want re-queued after retry", a.State)
+	}
+	if a.Attempt != 1 {
+		t.Fatalf("stage a attempt = %d, want 1", a.Attempt)
+	}
+	if a.JobID == firstJob || a.JobID == "" {
+		t.Fatalf("retry job id = %q, want a fresh id (was %q)", a.JobID, firstJob)
+	}
+	if run.State != pipeline.RunRunning {
+		t.Fatalf("run = %s, want still running during retry", run.State)
+	}
+
+	// Second failure: budget exhausted, run parks failed and b is skipped.
+	settleStageJob(t, store, a.JobID, "failed", "boom again", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if run.State != pipeline.RunFailed {
+		t.Fatalf("run = %s, want failed", run.State)
+	}
+	if run.HaltStage != "a" {
+		t.Fatalf("halt_stage = %q, want a", run.HaltStage)
+	}
+	if got := stageRow(t, store, run.ID, "a"); got.State != pipeline.StageFailed || got.Attempt != 1 {
+		t.Fatalf("stage a = %+v, want failed attempt 1", got)
+	}
+	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StageSkipped || got.JobID != "" {
+		t.Fatalf("stage b = %+v, want skipped never-enqueued", got)
+	}
+}
+
+const changesRequestedSpec = `name: cr
+repo: owner/repo
+stages:
+  - id: a
+    cmd: echo a
+  - id: b
+    cmd: echo b
+    needs: [a]
+`
+
+// TestAdvancerChangesRequestedDoesNotAdvance is the stateForDecision TRAP: a
+// changes_requested stage job is jobs.state=SUCCEEDED, but changes_requested is
+// NOT a default success_decision, so the advancer must treat the stage as failed
+// (not advance). Folding on jobs.state would wrongly succeed it and enqueue b.
+func TestAdvancerChangesRequestedDoesNotAdvance(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "cr", changesRequestedSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	aJob := stageRow(t, store, run.ID, "a").JobID
+	settleStageJob(t, store, aJob, "changes_requested", "needs work", nil)
+
+	// Guard the trap premise: the underlying JOB really is succeeded.
+	if job, _ := store.GetJob(context.Background(), aJob); job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("precondition: job state = %s, want succeeded (the trap)", job.State)
+	}
+
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "a"); got.State != pipeline.StageFailed {
+		t.Fatalf("stage a = %s, want failed (changes_requested must NOT advance)", got.State)
+	}
+	if got := stageRow(t, store, run.ID, "b"); got.JobID != "" || got.State == pipeline.StageQueued {
+		t.Fatalf("stage b = %+v, want never enqueued", got)
+	}
+	if run.State != pipeline.RunFailed {
+		t.Fatalf("run = %s, want failed", run.State)
+	}
+}
+
+// TestAdvancerChangesRequestedHonorsSuccessOverride proves the same
+// changes_requested decision DOES advance when the stage opts it into
+// success_decisions — the decision, not jobs.state, is what the advancer keys on.
+func TestAdvancerChangesRequestedHonorsSuccessOverride(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: cr2
+repo: owner/repo
+stages:
+  - id: a
+    cmd: echo a
+    success_decisions: [approved, changes_requested]
+  - id: b
+    cmd: echo b
+    needs: [a]
+`
+	rec, parsed := newTestPipeline(t, store, "cr2", spec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "changes_requested", "ok enough", nil)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "a"); got.State != pipeline.StageSucceeded {
+		t.Fatalf("stage a = %s, want succeeded (override lists changes_requested)", got.State)
+	}
+	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StageQueued {
+		t.Fatalf("stage b = %s, want queued", got.State)
+	}
+}
+
+// TestAdvancerSkippedPropagation proves a failed stage's transitive dependents are
+// all marked skipped (never enqueued), giving a clean terminal picture.
+func TestAdvancerSkippedPropagation(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	// a fails with no retry budget -> b and c can never run.
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "failed", "root broke", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+
+	if run.State != pipeline.RunFailed {
+		t.Fatalf("run = %s, want failed", run.State)
+	}
+	for _, id := range []string{"b", "c"} {
+		got := stageRow(t, store, run.ID, id)
+		if got.State != pipeline.StageSkipped || got.JobID != "" {
+			t.Fatalf("stage %s = %+v, want skipped never-enqueued", id, got)
+		}
+	}
+}
+
+// TestAdvancerIdempotentRescan proves a re-scan with nothing newly settled makes
+// no new enqueues and no state change: the deterministic ids + stage-state gating
+// make advancement safe to run every tick.
+func TestAdvancerIdempotentRescan(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	beforeJobs := countRunJobs(t, store, run.ID)
+	beforeA := stageRow(t, store, run.ID, "a")
+
+	// Re-advance with no settled job: pure no-op.
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if got := countRunJobs(t, store, run.ID); got != beforeJobs {
+		t.Fatalf("re-scan enqueued jobs: before=%d after=%d", beforeJobs, got)
+	}
+	afterA := stageRow(t, store, run.ID, "a")
+	if afterA.State != beforeA.State || afterA.JobID != beforeA.JobID {
+		t.Fatalf("re-scan changed stage a: before=%+v after=%+v", beforeA, afterA)
+	}
+	if run.State != pipeline.RunRunning {
+		t.Fatalf("run = %s, want still running", run.State)
+	}
+
+	// Advance one real layer, then prove the settled layer is also idempotent.
+	settleStageJob(t, store, afterA.JobID, "approved", "a", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	midJobs := countRunJobs(t, store, run.ID)
+	bJob := stageRow(t, store, run.ID, "b").JobID
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if got := countRunJobs(t, store, run.ID); got != midJobs {
+		t.Fatalf("re-scan after a-settled enqueued jobs: before=%d after=%d", midJobs, got)
+	}
+	if got := stageRow(t, store, run.ID, "b").JobID; got != bJob {
+		t.Fatalf("re-scan changed stage b job id: before=%q after=%q", bJob, got)
+	}
+}
+
+// countRunJobs counts persisted jobs belonging to a run (root == run id).
+func countRunJobs(t *testing.T, store *db.Store, runID string) int {
+	t.Helper()
+	jobs, err := store.ListJobsByRoot(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("ListJobsByRoot: %v", err)
+	}
+	return len(jobs)
+}

--- a/internal/cli/pipeline_lifecycle_e2e_test.go
+++ b/internal/cli/pipeline_lifecycle_e2e_test.go
@@ -1,0 +1,219 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+)
+
+// TestPipelineRestartRecoversE2E is the daemon-restart E2E (#681): a run driven
+// PARTWAY by one advancer/worker instance is completed by a FRESH instance that
+// re-opens the same SQLite file, proving the advancer holds NO in-memory run state —
+// it recovers everything from the persisted run/stage/job rows, exactly as a real
+// daemon restart mid-run must. NO LLM, NO network (shell-runtime stages).
+func TestPipelineRestartRecoversE2E(t *testing.T) {
+	ctx := context.Background()
+	home, paths, store := heartbeatLoopE2EHome(t)
+
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	source := pipelineStageResultCmd("approved", "source ok", nil)
+	score := pipelineStageResultCmd("approved", "score ok", nil)
+	deploy := pipelineStageResultCmd("approved", "deploy ok", nil)
+	specYAML := "name: deploy-flow\nrepo: owner/repo\nstages:\n" +
+		pipelineE2EStage("source", source, "") +
+		pipelineE2EStage("score", score, "source") +
+		pipelineE2EStage("deploy", deploy, "score")
+	specFile := writeSpec(t, specYAML)
+
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline add exit=%d stderr=%s", code, errBuf.String())
+	}
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "run", "deploy-flow", "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline run exit=%d stderr=%s", code, errBuf.String())
+	}
+	runID := strings.TrimSpace(out.String())
+	if runID == "" {
+		t.Fatalf("pipeline run printed no run id (stderr=%s)", errBuf.String())
+	}
+
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	// --- Phase 1: drive PARTWAY with the first instance -------------------------
+	// Stop as soon as the root stage has succeeded: the run is genuinely mid-flight
+	// (score enqueued but not run, deploy not started) when we simulate the restart.
+	enqueue1 := newPipelineStageEnqueuer(store, home)
+	worker1 := defaultJobWorker(store, io.Discard, home)
+	for i := 0; i < 8; i++ {
+		if err := runEnabledRepoWorkerTicks(ctx, store, worker1, 1, io.Discard, now); err != nil {
+			t.Fatalf("phase-1 worker tick %d: %v", i, err)
+		}
+		if err := runPipelineScanOnce(ctx, store, enqueue1, now); err != nil {
+			t.Fatalf("phase-1 scan %d: %v", i, err)
+		}
+		if stageRow(t, store, runID, "source").State == pipeline.StageSucceeded {
+			break
+		}
+	}
+	if got := stageRow(t, store, runID, "source"); got.State != pipeline.StageSucceeded {
+		t.Fatalf("phase 1 did not land source: %+v", got)
+	}
+	if mid, _, _ := store.GetPipelineRun(ctx, runID); mid.State != pipeline.RunRunning {
+		t.Fatalf("run settled during phase 1 (state=%s); wanted a mid-run restart", mid.State)
+	}
+	if got := stageRow(t, store, runID, "deploy"); got.State == pipeline.StageSucceeded {
+		t.Fatalf("deploy already succeeded before restart: %+v", got)
+	}
+
+	// --- Phase 2: RESTART — a fresh instance re-opens the same DB ----------------
+	store2, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer store2.Close()
+	enqueue2 := newPipelineStageEnqueuer(store2, home)
+	worker2 := defaultJobWorker(store2, io.Discard, home)
+	for i := 0; i < 8; i++ {
+		if err := runEnabledRepoWorkerTicks(ctx, store2, worker2, 1, io.Discard, now); err != nil {
+			t.Fatalf("phase-2 worker tick %d: %v", i, err)
+		}
+		if err := runPipelineScanOnce(ctx, store2, enqueue2, now); err != nil {
+			t.Fatalf("phase-2 scan %d: %v", i, err)
+		}
+		if run, _, _ := store2.GetPipelineRun(ctx, runID); run.State != pipeline.RunRunning {
+			break
+		}
+	}
+
+	run, ok, err := store2.GetPipelineRun(ctx, runID)
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineRun after restart: ok=%v err=%v", ok, err)
+	}
+	if run.State != pipeline.RunSucceeded {
+		t.Fatalf("run recovered to state %s, want succeeded", run.State)
+	}
+	for _, id := range []string{"source", "score", "deploy"} {
+		if got := stageRow(t, store2, runID, id); got.State != pipeline.StageSucceeded {
+			t.Fatalf("stage %s = %s after restart, want succeeded", id, got.State)
+		}
+	}
+}
+
+// pipelineSecretGatedCmd is a shell stage body that gates its decision on an
+// external file: if the file EXISTS it returns approved, else it returns blocked
+// with the given need. It models the real resume story — a stage blocks on a missing
+// secret, an operator provisions it (creates the file), and the SAME command
+// succeeds on resume because the environment changed. Fully deterministic offline.
+func pipelineSecretGatedCmd(secretPath, need string) string {
+	ok := `printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"secret present","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`
+	blocked := `printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","findings":[],"changes_made":[],"tests_run":[],"needs":["` + need + `"],"delegations":[]}}'`
+	return "if [ -f " + secretPath + " ]; then " + ok + "; else " + blocked + "; fi"
+}
+
+// TestPipelineResumeE2E is the resume E2E (#681): a run parks blocked on a missing
+// secret; the operator provisions the secret and ResumePipelineRun re-runs the
+// halted stage and its dependents, which now succeed, driving the run to succeeded.
+// The already-succeeded upstream stage is NOT re-run. NO LLM, NO network.
+func TestPipelineResumeE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	secretPath := filepath.Join(t.TempDir(), "r2-token")
+	source := pipelineStageResultCmd("approved", "source ok", nil)
+	score := pipelineSecretGatedCmd(secretPath, "R2 token")
+	deploy := pipelineStageResultCmd("approved", "deploy ok", nil)
+	specYAML := "name: deploy-flow\nrepo: owner/repo\nstages:\n" +
+		pipelineE2EStage("source", source, "") +
+		pipelineE2EStage("score", score, "source") +
+		pipelineE2EStage("deploy", deploy, "score")
+	specFile := writeSpec(t, specYAML)
+
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline add exit=%d stderr=%s", code, errBuf.String())
+	}
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "run", "deploy-flow", "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline run exit=%d stderr=%s", code, errBuf.String())
+	}
+	runID := strings.TrimSpace(out.String())
+
+	enqueue := newPipelineStageEnqueuer(store, home)
+	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	drive := func(label string) db.PipelineRun {
+		t.Helper()
+		for i := 0; i < 8; i++ {
+			if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+				t.Fatalf("%s worker tick %d: %v", label, i, err)
+			}
+			if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+				t.Fatalf("%s scan %d: %v", label, i, err)
+			}
+			if run, _, _ := store.GetPipelineRun(ctx, runID); run.State != pipeline.RunRunning {
+				break
+			}
+		}
+		run, _, _ := store.GetPipelineRun(ctx, runID)
+		return run
+	}
+
+	// --- Run 1: parks blocked (secret absent) -----------------------------------
+	run := drive("phase-1")
+	if run.State != pipeline.RunBlocked {
+		t.Fatalf("run state = %s, want blocked (secret absent)", run.State)
+	}
+	if run.HaltStage != "score" {
+		t.Fatalf("halt_stage = %q, want score", run.HaltStage)
+	}
+	sourceJobBefore := stageRow(t, store, runID, "source").JobID
+	if stageRow(t, store, runID, "source").State != pipeline.StageSucceeded {
+		t.Fatalf("source must be succeeded before resume")
+	}
+
+	// --- Operator provisions the secret, then resumes ---------------------------
+	if err := os.WriteFile(secretPath, []byte("present"), 0o644); err != nil {
+		t.Fatalf("provision secret: %v", err)
+	}
+	resumed, err := ResumePipelineRun(ctx, store, runID, "")
+	if err != nil {
+		t.Fatalf("ResumePipelineRun: %v", err)
+	}
+	if resumed.State != pipeline.RunRunning {
+		t.Fatalf("resumed run = %s, want running", resumed.State)
+	}
+	if got := stageRow(t, store, runID, "score"); got.State != pipeline.StagePending || got.Attempt != 1 {
+		t.Fatalf("score after resume = %+v, want pending attempt 1", got)
+	}
+
+	// --- Run 2: now succeeds; source is NOT re-run ------------------------------
+	run = drive("phase-2")
+	if run.State != pipeline.RunSucceeded {
+		t.Fatalf("run after resume = %s, want succeeded", run.State)
+	}
+	for _, id := range []string{"source", "score", "deploy"} {
+		if got := stageRow(t, store, runID, id); got.State != pipeline.StageSucceeded {
+			t.Fatalf("stage %s = %s after resume, want succeeded", id, got.State)
+		}
+	}
+	// The succeeded upstream source stage kept its original job — it was never re-run.
+	if got := stageRow(t, store, runID, "source"); got.JobID != sourceJobBefore || got.Attempt != 0 {
+		t.Fatalf("source re-ran on resume: job %q (was %q) attempt %d", got.JobID, sourceJobBefore, got.Attempt)
+	}
+}

--- a/internal/cli/pipeline_resume.go
+++ b/internal/cli/pipeline_resume.go
@@ -1,0 +1,313 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// The #681 pipeline RESUME and CANCEL verbs. Resume re-runs a parked (blocked or
+// failed) run from its halted stage; cancel abandons a run, cancelling its in-flight
+// stage jobs through the shared workflow.CancelJob path. ResumePipelineRun is the
+// #682 seam — the approval gates that follow-up will call it to restart a run once a
+// block is cleared, so it is exported and side-effect-scoped to the run + stage rows
+// (no gates / secret stores / approval UI here).
+
+// ResumePipelineRun re-runs a PARKED pipeline run (#681, decision 7). It resets the
+// halted stage (or the explicit fromStage) and its transitive DEPENDENTS back to
+// pending — bumping each reset stage's attempt so the next scan re-enqueues a fresh
+// stage job under a new deterministic id/fingerprint — clears the run's park fields,
+// and returns the run to running so the advance pass picks it up. It NEVER touches a
+// stage that already succeeded (an already-landed stage is not re-run, even if it is
+// downstream of the resume point) and it REFUSES a non-parked run (only a
+// blocked/failed run can be resumed).
+//
+// A run executes the spec it was created from, so the spec is resolved from the
+// pipeline row and hash-verified against the run's snapshot: a resume against a spec
+// that drifted since the run was created is refused rather than re-running a changed
+// DAG. The updated run is returned.
+func ResumePipelineRun(ctx context.Context, store *db.Store, runID, fromStage string) (db.PipelineRun, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return db.PipelineRun{}, errors.New("run id is required")
+	}
+	run, ok, err := store.GetPipelineRun(ctx, runID)
+	if err != nil {
+		return db.PipelineRun{}, err
+	}
+	if !ok {
+		return db.PipelineRun{}, fmt.Errorf("run %s not found", runID)
+	}
+	if !isParkedPipelineRun(run.State) {
+		return db.PipelineRun{}, fmt.Errorf("run %s is %s; resume requires a parked (blocked or failed) run", runID, run.State)
+	}
+	rec, ok, err := store.GetPipeline(ctx, run.Pipeline)
+	if err != nil {
+		return db.PipelineRun{}, err
+	}
+	if !ok {
+		return db.PipelineRun{}, fmt.Errorf("pipeline %s not found", run.Pipeline)
+	}
+	if strings.TrimSpace(rec.SpecHash) != strings.TrimSpace(run.SpecHash) {
+		return db.PipelineRun{}, fmt.Errorf("pipeline %s spec changed since run %s was created; cannot resume", run.Pipeline, runID)
+	}
+	spec, err := pipeline.Load([]byte(rec.SpecYAML))
+	if err != nil {
+		return db.PipelineRun{}, fmt.Errorf("stored spec is invalid: %w", err)
+	}
+	// Default the resume point to the halted stage; --from overrides it to re-run from
+	// an explicit stage (and everything downstream of it).
+	from := strings.TrimSpace(fromStage)
+	if from == "" {
+		from = strings.TrimSpace(run.HaltStage)
+	}
+	if from == "" {
+		return db.PipelineRun{}, fmt.Errorf("run %s has no halt stage to resume from; pass --from <stage>", runID)
+	}
+	if _, ok := pipelineStageByID(spec, from); !ok {
+		return db.PipelineRun{}, fmt.Errorf("stage %s is not part of pipeline %s", from, run.Pipeline)
+	}
+	reset := pipelineStageAndDependents(spec, from)
+	rows, err := store.ListPipelineRunStages(ctx, runID)
+	if err != nil {
+		return db.PipelineRun{}, err
+	}
+	for _, row := range rows {
+		if !reset[row.StageID] {
+			continue
+		}
+		// Never re-run a stage that already succeeded — an already-landed stage stays
+		// succeeded even when it is downstream of the resume point.
+		if row.State == pipeline.StageSucceeded {
+			continue
+		}
+		updated := row
+		updated.State = pipeline.StagePending
+		updated.JobID = ""
+		updated.Attempt = row.Attempt + 1
+		updated.NeedsJSON = ""
+		updated.Summary = ""
+		updated.StartedAt = time.Time{}
+		updated.FinishedAt = time.Time{}
+		if err := store.UpdatePipelineRunStage(ctx, updated); err != nil {
+			return db.PipelineRun{}, err
+		}
+	}
+	// Clear the run's park fields and return it to running so the advance pass
+	// re-enqueues the reset stages on the next scan.
+	run.State = pipeline.RunRunning
+	run.HaltStage = ""
+	run.HaltReason = ""
+	run.NeedsJSON = ""
+	run.FinishedAt = time.Time{}
+	if err := store.UpdatePipelineRun(ctx, run); err != nil {
+		return db.PipelineRun{}, err
+	}
+	// Mirror the pipeline's last_status back to running WHEN this run is the
+	// pipeline's most recent one, so `pipeline list` / `show <name>` reflect the
+	// resume without clobbering a newer run's bookkeeping.
+	if strings.TrimSpace(rec.LastRunID) == runID {
+		if err := store.UpdatePipelineLastRun(ctx, rec.Name, runID, pipeline.RunRunning, time.Time{}); err != nil {
+			return db.PipelineRun{}, err
+		}
+	}
+	return run, nil
+}
+
+// cancelPipelineRun abandons a run (#681, decision 9): it cancels every in-flight
+// (queued/running) stage job through the shared workflow.CancelJob path — the same
+// single-job abandon verb `job cancel` uses, which also best-effort releases the
+// job's locks — marks the run cancelled, and moves every not-yet-terminal stage to
+// cancelled for a clean terminal picture. An already-settled stage
+// (succeeded/blocked/failed/skipped) keeps its recorded outcome, so a cancelled
+// run still shows WHY it halted. It refuses an already-terminal run
+// (succeeded/cancelled): there is nothing to abandon. The updated run is returned.
+func cancelPipelineRun(ctx context.Context, store *db.Store, runID string, now time.Time) (db.PipelineRun, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return db.PipelineRun{}, errors.New("run id is required")
+	}
+	now = now.UTC()
+	run, ok, err := store.GetPipelineRun(ctx, runID)
+	if err != nil {
+		return db.PipelineRun{}, err
+	}
+	if !ok {
+		return db.PipelineRun{}, fmt.Errorf("run %s not found", runID)
+	}
+	if run.State == pipeline.RunSucceeded || run.State == pipeline.RunCancelled {
+		return db.PipelineRun{}, fmt.Errorf("run %s is %s; cancel requires a running or parked run", runID, run.State)
+	}
+	rows, err := store.ListPipelineRunStages(ctx, runID)
+	if err != nil {
+		return db.PipelineRun{}, err
+	}
+	for _, row := range rows {
+		// Cancel the in-flight stage job through the shared abandon verb (which also
+		// releases the job's locks best-effort). A stage with no job, or a job that
+		// already settled, is skipped; CancelJob's own state guard makes a lost race a
+		// no-op, and lock cleanup is incidental, so the error is intentionally swallowed.
+		if job := strings.TrimSpace(row.JobID); job != "" && (row.State == pipeline.StageQueued || row.State == pipeline.StageRunning) {
+			_, _ = workflow.CancelJob(ctx, store, job)
+		}
+		if isTerminalPipelineStage(row.State) {
+			continue
+		}
+		updated := row
+		updated.State = pipeline.StageCancelled
+		updated.FinishedAt = now
+		if err := store.UpdatePipelineRunStage(ctx, updated); err != nil {
+			return db.PipelineRun{}, err
+		}
+	}
+	run.State = pipeline.RunCancelled
+	run.FinishedAt = now
+	if err := store.UpdatePipelineRun(ctx, run); err != nil {
+		return db.PipelineRun{}, err
+	}
+	// Mirror the pipeline's last_status to cancelled WHEN this run is its most recent
+	// one (same non-clobber guard as resume).
+	if rec, ok, gerr := store.GetPipeline(ctx, run.Pipeline); gerr == nil && ok && strings.TrimSpace(rec.LastRunID) == runID {
+		if err := store.UpdatePipelineLastRun(ctx, run.Pipeline, runID, pipeline.RunCancelled, time.Time{}); err != nil {
+			return db.PipelineRun{}, err
+		}
+	}
+	return run, nil
+}
+
+// isParkedPipelineRun reports whether a run state is a parked (resumable) one: a
+// blocked or failed run awaits a human, and resume is that human's re-run verb.
+func isParkedPipelineRun(state string) bool {
+	return state == pipeline.RunBlocked || state == pipeline.RunFailed
+}
+
+// isTerminalPipelineStage reports whether a stage row is already in a settled state
+// (so cancel leaves it intact rather than overwriting its recorded outcome).
+func isTerminalPipelineStage(state string) bool {
+	switch state {
+	case pipeline.StageSucceeded, pipeline.StageBlocked, pipeline.StageFailed,
+		pipeline.StageSkipped, pipeline.StageCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// pipelineStageByID looks a stage up in a spec by id.
+func pipelineStageByID(spec pipeline.Spec, id string) (pipeline.Stage, bool) {
+	for _, stage := range spec.Stages {
+		if stage.ID == id {
+			return stage, true
+		}
+	}
+	return pipeline.Stage{}, false
+}
+
+// pipelineStageAndDependents returns the closure of `from` plus every stage that
+// transitively DEPENDS on it (following needs edges forward). Resume resets this set
+// so the resume point AND everything downstream of it re-runs; the spec's validated
+// acyclicity bounds the walk.
+func pipelineStageAndDependents(spec pipeline.Spec, from string) map[string]bool {
+	dependents := make(map[string][]string, len(spec.Stages))
+	for _, stage := range spec.Stages {
+		for _, dep := range stage.Needs {
+			dependents[dep] = append(dependents[dep], stage.ID)
+		}
+	}
+	out := make(map[string]bool)
+	var visit func(id string)
+	visit = func(id string) {
+		if out[id] {
+			return
+		}
+		out[id] = true
+		for _, child := range dependents[id] {
+			visit(child)
+		}
+	}
+	visit(from)
+	return out
+}
+
+// runPipelineResume is `gitmoot pipeline resume <run> [--from <stage>]`: it re-runs a
+// parked run from its halted stage (or the --from stage) via ResumePipelineRun; the
+// next daemon scan re-enqueues the reset stages.
+func runPipelineResume(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pipeline resume", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	from := fs.String("from", "", "stage id to resume from (defaults to the halted stage)")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "pipeline resume requires a run id")
+			return 2
+		}
+		return 0
+	}
+	runID := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "pipeline resume accepts exactly one run id")
+		return 2
+	}
+	if err := withStore(*home, func(store *db.Store) error {
+		_, err := ResumePipelineRun(context.Background(), store, runID, *from)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "pipeline resume: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "resumed run %s", runID)
+	return 0
+}
+
+// runPipelineCancel is `gitmoot pipeline cancel <run>`: it abandons a run, cancelling
+// its in-flight stage jobs through the shared CancelJob path and marking the run and
+// its non-terminal stages cancelled.
+func runPipelineCancel(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pipeline cancel", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "pipeline cancel requires a run id")
+			return 2
+		}
+		return 0
+	}
+	runID := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "pipeline cancel accepts exactly one run id")
+		return 2
+	}
+	if err := withStore(*home, func(store *db.Store) error {
+		_, err := cancelPipelineRun(context.Background(), store, runID, time.Now().UTC())
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "pipeline cancel: %v\n", err)
+		return 1
+	}
+	writeLine(stdout, "cancelled run %s", runID)
+	return 0
+}

--- a/internal/cli/pipeline_resume_test.go
+++ b/internal/cli/pipeline_resume_test.go
@@ -1,0 +1,284 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// parkBlockedChainRun drives the linear a->b->c chain to a parked-blocked run: a
+// succeeds, b returns blocked, c is skipped, run parks blocked. It returns the
+// parked run for the resume/cancel tests to act on.
+func parkBlockedChainRun(t *testing.T, store *db.Store, enqueue pipelineStageEnqueuer, rec db.Pipeline, spec pipeline.Spec, now time.Time) db.PipelineRun {
+	t.Helper()
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "approved", "a ok", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	settleStageJob(t, store, stageRow(t, store, run.ID, "b").JobID, "blocked", "needs secret", []string{"R2 token"})
+	run = advance(t, store, rec, spec, enqueue, run, now)
+	if run.State != pipeline.RunBlocked {
+		t.Fatalf("precondition: run = %s, want blocked", run.State)
+	}
+	return run
+}
+
+// TestResumeResetsHaltedStageAndDependents proves resume of a parked-blocked run
+// resets the halted stage AND its transitive dependents to pending (attempt bumped,
+// job cleared), leaves the already-succeeded upstream stage untouched, clears the
+// run's park fields, and lets the next advance re-enqueue the halted stage.
+func TestResumeResetsHaltedStageAndDependents(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := parkBlockedChainRun(t, store, enqueue, rec, spec, now)
+	bBlockedJob := stageRow(t, store, run.ID, "b").JobID
+	aBefore := stageRow(t, store, run.ID, "a")
+
+	resumed, err := ResumePipelineRun(ctx, store, run.ID, "")
+	if err != nil {
+		t.Fatalf("ResumePipelineRun: %v", err)
+	}
+	if resumed.State != pipeline.RunRunning {
+		t.Fatalf("resumed run = %s, want running", resumed.State)
+	}
+	if resumed.HaltStage != "" || resumed.HaltReason != "" || resumed.NeedsJSON != "" {
+		t.Fatalf("resumed run park fields not cleared: %+v", resumed)
+	}
+
+	// a (succeeded) is untouched: same state, same attempt, same job.
+	a := stageRow(t, store, run.ID, "a")
+	if a.State != pipeline.StageSucceeded || a.Attempt != aBefore.Attempt || a.JobID != aBefore.JobID {
+		t.Fatalf("succeeded stage a changed on resume: before=%+v after=%+v", aBefore, a)
+	}
+	// b (halted) reset to pending, attempt bumped, job cleared, needs cleared.
+	b := stageRow(t, store, run.ID, "b")
+	if b.State != pipeline.StagePending || b.Attempt != 1 || b.JobID != "" || b.NeedsJSON != "" {
+		t.Fatalf("halted stage b not reset: %+v", b)
+	}
+	// c (skipped dependent) reset to pending, attempt bumped.
+	c := stageRow(t, store, run.ID, "c")
+	if c.State != pipeline.StagePending || c.Attempt != 1 {
+		t.Fatalf("dependent stage c not reset: %+v", c)
+	}
+
+	// The next advance re-enqueues b (a is still succeeded) under a FRESH job id.
+	// Advance the RESUMED (running) run — the pre-resume handle is still blocked.
+	advance(t, store, rec, spec, enqueue, resumed, now)
+	b = stageRow(t, store, run.ID, "b")
+	if b.State != pipeline.StageQueued || b.JobID == "" || b.JobID == bBlockedJob {
+		t.Fatalf("b not re-enqueued with a fresh job: %+v (was %q)", b, bBlockedJob)
+	}
+}
+
+// TestResumeFromNeverTouchesSucceeded proves `--from <stage>` naming a SUCCEEDED
+// stage leaves it succeeded (an already-landed stage is never re-run) while still
+// resetting its non-succeeded dependents.
+func TestResumeFromNeverTouchesSucceeded(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := parkBlockedChainRun(t, store, enqueue, rec, spec, now)
+	aBefore := stageRow(t, store, run.ID, "a")
+
+	// Resume FROM a (which succeeded): a stays succeeded, b and c reset.
+	if _, err := ResumePipelineRun(ctx, store, run.ID, "a"); err != nil {
+		t.Fatalf("ResumePipelineRun(from=a): %v", err)
+	}
+	a := stageRow(t, store, run.ID, "a")
+	if a.State != pipeline.StageSucceeded || a.Attempt != aBefore.Attempt {
+		t.Fatalf("succeeded stage a must stay untouched even as resume point: %+v", a)
+	}
+	if b := stageRow(t, store, run.ID, "b"); b.State != pipeline.StagePending {
+		t.Fatalf("stage b = %s, want pending (dependent of resume point a)", b.State)
+	}
+	if c := stageRow(t, store, run.ID, "c"); c.State != pipeline.StagePending {
+		t.Fatalf("stage c = %s, want pending (transitive dependent)", c.State)
+	}
+}
+
+// TestResumeRefusesNonParkedRuns proves resume only applies to a parked
+// (blocked/failed) run: a running run, a succeeded run, and a missing run are all
+// refused.
+func TestResumeRefusesNonParkedRuns(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	// A running run: not parked.
+	running := startTestRun(t, store, rec, spec, enqueue, now)
+	if _, err := ResumePipelineRun(ctx, store, running.ID, ""); err == nil ||
+		!strings.Contains(err.Error(), "requires a parked") {
+		t.Fatalf("resume of running run: err=%v, want a parked-required refusal", err)
+	}
+
+	// A missing run.
+	if _, err := ResumePipelineRun(ctx, store, "prun-nope", ""); err == nil ||
+		!strings.Contains(err.Error(), "not found") {
+		t.Fatalf("resume of missing run: err=%v, want not-found", err)
+	}
+
+	// Drive the running run to succeeded, then prove a succeeded run is refused.
+	settleStageJob(t, store, stageRow(t, store, running.ID, "a").JobID, "approved", "a", nil)
+	running = advance(t, store, rec, spec, enqueue, running, now)
+	settleStageJob(t, store, stageRow(t, store, running.ID, "b").JobID, "approved", "b", nil)
+	running = advance(t, store, rec, spec, enqueue, running, now)
+	settleStageJob(t, store, stageRow(t, store, running.ID, "c").JobID, "approved", "c", nil)
+	running = advance(t, store, rec, spec, enqueue, running, now)
+	if running.State != pipeline.RunSucceeded {
+		t.Fatalf("precondition: run = %s, want succeeded", running.State)
+	}
+	if _, err := ResumePipelineRun(ctx, store, running.ID, ""); err == nil ||
+		!strings.Contains(err.Error(), "requires a parked") {
+		t.Fatalf("resume of succeeded run: err=%v, want a parked-required refusal", err)
+	}
+}
+
+// TestResumeRejectsUnknownFromStage proves a --from naming a stage not in the spec
+// is refused.
+func TestResumeRejectsUnknownFromStage(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := parkBlockedChainRun(t, store, enqueue, rec, spec, now)
+	if _, err := ResumePipelineRun(ctx, store, run.ID, "ghost"); err == nil ||
+		!strings.Contains(err.Error(), "not part of pipeline") {
+		t.Fatalf("resume from unknown stage: err=%v, want not-part-of refusal", err)
+	}
+}
+
+// TestCancelPipelineRunInFlight proves cancel of a running run cancels its in-flight
+// stage job (via the shared CancelJob path) and moves the run + every non-terminal
+// stage to cancelled.
+func TestCancelPipelineRunInFlight(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	aJob := stageRow(t, store, run.ID, "a").JobID
+
+	cancelled, err := cancelPipelineRun(ctx, store, run.ID, now)
+	if err != nil {
+		t.Fatalf("cancelPipelineRun: %v", err)
+	}
+	if cancelled.State != pipeline.RunCancelled {
+		t.Fatalf("run = %s, want cancelled", cancelled.State)
+	}
+	// The in-flight stage job was cancelled through the shared abandon verb.
+	if job, _ := store.GetJob(ctx, aJob); job.State != string(workflow.JobCancelled) {
+		t.Fatalf("stage a job = %s, want cancelled", job.State)
+	}
+	// Every stage moved to cancelled (a was queued; b, c pending).
+	for _, id := range []string{"a", "b", "c"} {
+		if got := stageRow(t, store, run.ID, id); got.State != pipeline.StageCancelled {
+			t.Fatalf("stage %s = %s, want cancelled", id, got.State)
+		}
+	}
+	// The pipeline's last_status mirrors the cancel.
+	if p, _, _ := store.GetPipeline(ctx, "chain"); p.LastStatus != pipeline.RunCancelled {
+		t.Fatalf("pipeline last_status = %q, want cancelled", p.LastStatus)
+	}
+}
+
+// TestCancelPipelineRunPreservesSettledStages proves cancel of a PARKED run leaves
+// the settled stages' recorded outcomes intact (so a cancelled run still shows WHY
+// it halted) while still marking the run cancelled.
+func TestCancelPipelineRunPreservesSettledStages(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := parkBlockedChainRun(t, store, enqueue, rec, spec, now)
+	cancelled, err := cancelPipelineRun(ctx, store, run.ID, now)
+	if err != nil {
+		t.Fatalf("cancelPipelineRun: %v", err)
+	}
+	if cancelled.State != pipeline.RunCancelled {
+		t.Fatalf("run = %s, want cancelled", cancelled.State)
+	}
+	if a := stageRow(t, store, run.ID, "a"); a.State != pipeline.StageSucceeded {
+		t.Fatalf("stage a = %s, want succeeded (preserved)", a.State)
+	}
+	if b := stageRow(t, store, run.ID, "b"); b.State != pipeline.StageBlocked {
+		t.Fatalf("stage b = %s, want blocked (halt record preserved)", b.State)
+	}
+	if c := stageRow(t, store, run.ID, "c"); c.State != pipeline.StageSkipped {
+		t.Fatalf("stage c = %s, want skipped (preserved)", c.State)
+	}
+}
+
+// TestCancelPipelineRunRefusesTerminal proves cancel refuses an already-terminal run.
+func TestCancelPipelineRunRefusesTerminal(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	if _, err := cancelPipelineRun(ctx, store, run.ID, now); err != nil {
+		t.Fatalf("first cancel: %v", err)
+	}
+	// A second cancel of the now-cancelled run is refused.
+	if _, err := cancelPipelineRun(ctx, store, run.ID, now); err == nil ||
+		!strings.Contains(err.Error(), "cancel requires") {
+		t.Fatalf("re-cancel: err=%v, want a refusal", err)
+	}
+	if _, err := cancelPipelineRun(ctx, store, "prun-nope", now); err == nil ||
+		!strings.Contains(err.Error(), "not found") {
+		t.Fatalf("cancel missing run: err=%v, want not-found", err)
+	}
+}
+
+// TestPipelineResumeCancelCLI smoke-tests the resume/cancel CLI wrappers through
+// Run(): argument validation and the error/exit-code contract.
+func TestPipelineResumeCancelCLI(t *testing.T) {
+	home := t.TempDir()
+	run := func(args ...string) (string, string, int) {
+		var stdout, stderr bytes.Buffer
+		code := Run(append(args, "--home", home), &stdout, &stderr)
+		return stdout.String(), stderr.String(), code
+	}
+	// Missing run id: a usage error BEFORE any store touch, so it is safe to invoke
+	// without --home (the arg guard returns before withStore).
+	bare := func(args ...string) (string, int) {
+		var stdout, stderr bytes.Buffer
+		code := Run(args, &stdout, &stderr)
+		return stderr.String(), code
+	}
+
+	if errOut, code := bare("pipeline", "resume"); code != 2 || !strings.Contains(errOut, "requires a run id") {
+		t.Fatalf("resume no-arg: code=%d stderr=%q", code, errOut)
+	}
+	if errOut, code := bare("pipeline", "cancel"); code != 2 || !strings.Contains(errOut, "requires a run id") {
+		t.Fatalf("cancel no-arg: code=%d stderr=%q", code, errOut)
+	}
+	// Unknown run: a friendly not-found with exit 1.
+	if _, errOut, code := run("pipeline", "resume", "prun-nope"); code != 1 || !strings.Contains(errOut, "not found") {
+		t.Fatalf("resume unknown: code=%d stderr=%q", code, errOut)
+	}
+	if _, errOut, code := run("pipeline", "cancel", "prun-nope"); code != 1 || !strings.Contains(errOut, "not found") {
+		t.Fatalf("cancel unknown: code=%d stderr=%q", code, errOut)
+	}
+}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -287,7 +287,8 @@ func advancePipelineRuns(ctx context.Context, store *db.Store, enqueue pipelineS
 
 // advancePipelineRun is the per-run advancer (decision 6). It is a single
 // idempotent pass: FOLD every settled stage job into its stage row by DECISION,
-// ENQUEUE newly-ready stages (unless the run is halting on a block/fail), then, if
+// ENQUEUE every newly-ready stage (deps all succeeded — a blocked/failed branch
+// halts only ITSELF, so independent branches keep running), then, if
 // nothing is in flight, SETTLE the run — succeeded, or parked blocked/failed with
 // the halt stage + reason + (for blocked) the aggregated needs persisted verbatim.
 // It writes only rows that actually change, so a re-scan on an unchanged run makes
@@ -362,27 +363,28 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 	}
 
 	// --- ENQUEUE: launch newly-ready stages ----------------------------------
-	// Once any stage is blocked or failed the run is halting: stop launching new
-	// work and let the in-flight stages drain, then park.
-	halting := anyPipelineStageInState(byID, pipeline.StageBlocked, pipeline.StageFailed)
-	if !halting {
-		for _, stage := range spec.Stages {
-			row := byID[stage.ID]
-			if row.State != pipeline.StagePending || !pipelineStageDepsSucceeded(stage, byID) {
-				continue
-			}
-			job, err := enqueuePipelineStageJob(ctx, store, enqueue, pipelineStageJobRequest(rec, stage, run, row.Attempt))
-			if err != nil {
-				return run, err
-			}
-			row.State = pipeline.StageQueued
-			row.JobID = job.ID
-			row.StartedAt = now
-			if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
-				return run, err
-			}
-			byID[stage.ID] = row
+	// Per-branch reachability, NOT a run-wide fail-fast: a stage whose needs have
+	// ALL succeeded is enqueued even when an INDEPENDENT branch has already blocked
+	// or failed. Only a stage that (transitively) depends on the halted stage never
+	// becomes ready — its dep never reaches succeeded — so a blocked/failed branch
+	// halts itself while its siblings run to completion (decision 6: "dependents
+	// never ready"). The run does not park until nothing is in flight below.
+	for _, stage := range spec.Stages {
+		row := byID[stage.ID]
+		if row.State != pipeline.StagePending || !pipelineStageDepsSucceeded(stage, byID) {
+			continue
 		}
+		job, err := enqueuePipelineStageJob(ctx, store, enqueue, pipelineStageJobRequest(rec, stage, run, row.Attempt))
+		if err != nil {
+			return run, err
+		}
+		row.State = pipeline.StageQueued
+		row.JobID = job.ID
+		row.StartedAt = now
+		if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+			return run, err
+		}
+		byID[stage.ID] = row
 	}
 
 	// --- SETTLE: park or finish once nothing is in flight --------------------
@@ -390,21 +392,22 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 		return run, nil
 	}
 
-	if halting {
-		// Nothing more can run: every still-pending stage is unreachable (a dep chain
-		// is broken by a blocked/failed stage), so mark them skipped for a clean
-		// terminal picture — this is also why a blocked run's downstream stages are
-		// never enqueued.
-		for _, stage := range spec.Stages {
-			row := byID[stage.ID]
-			if row.State == pipeline.StagePending {
-				row.State = pipeline.StageSkipped
-				row.FinishedAt = now
-				if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
-					return run, err
-				}
-				byID[stage.ID] = row
+	// Nothing is in flight, so no stage will ever reach succeeded again. Any stage
+	// still pending here therefore has a dep that can NEVER all-succeed — the ENQUEUE
+	// pass above already launched every pending stage whose deps had all succeeded,
+	// so a leftover pending stage is transitively downstream of a blocked/failed (or
+	// itself-skipped) stage. Mark it skipped for a clean terminal picture; this is
+	// exactly why a blocked/failed branch's downstream stages are never enqueued,
+	// while a reachable independent branch was already run above.
+	for _, stage := range spec.Stages {
+		row := byID[stage.ID]
+		if row.State == pipeline.StagePending {
+			row.State = pipeline.StageSkipped
+			row.FinishedAt = now
+			if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+				return run, err
 			}
+			byID[stage.ID] = row
 		}
 	}
 

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -132,15 +132,124 @@ func createPipelineRun(ctx context.Context, store *db.Store, rec db.Pipeline, sp
 	return run, nil
 }
 
-// runPipelineScanOnce advances every in-flight pipeline run once (#681). It is the
-// scan entry point wired next to runHeartbeatScanOnce; the daemon supervisor-loop
-// wiring lands in a later step. Only state='running' runs are advanced, so parked
-// (blocked/failed) and terminal runs consume zero compute. A per-run error is
-// collected (first wins) but never stops the remaining runs. Runs whose pipeline
-// was removed, whose stored spec no longer parses, or whose spec drifted (hash no
-// longer matches the run's snapshot) are skipped rather than executed against a
-// changed spec.
+// runPipelineScanOnce is the pipeline scan wired into BOTH daemon supervisor loops
+// next to runHeartbeatScanOnce (#681). Each tick is two passes, mirroring the
+// heartbeat idiom:
+//
+//	SCHEDULE pass — for each enabled pipeline whose interval is due and that has no
+//	  active run, create a fresh scheduled run and advance next_due anchored to now
+//	  (missed ticks coalesce into one run; a durable next_due makes it restart-safe).
+//	ADVANCE  pass — advance every in-flight (state='running') run once.
+//
+// Ordering matters: the schedule pass creates the run rows, then the advance pass
+// enqueues their ready root stages, so a scheduled run and a manual `pipeline run`
+// reach the worker by the identical code path. Off-by-default and zero-cost when
+// idle: a pipeline with no interval is skipped before any state touch, and a parked
+// or terminal run is never advanced. A per-pipeline / per-run error is collected
+// (first wins) but never stops the rest; the daemon caller logs it and never aborts
+// the loop.
 func runPipelineScanOnce(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, now time.Time) error {
+	now = now.UTC()
+	var firstErr error
+	if err := schedulePipelineRuns(ctx, store, now); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	if err := advancePipelineRuns(ctx, store, enqueue, now); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+// schedulePipelineRuns is runPipelineScanOnce's SCHEDULE pass (#681): it creates a
+// run for each enabled pipeline whose interval schedule is due and has no active
+// run. A per-pipeline error is collected (first wins) but never stops the rest.
+func schedulePipelineRuns(ctx context.Context, store *db.Store, now time.Time) error {
+	pipelines, err := store.ListPipelines(ctx)
+	if err != nil {
+		return err
+	}
+	now = now.UTC()
+	var firstErr error
+	for _, rec := range pipelines {
+		if err := scheduleOnePipeline(ctx, store, rec, now); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// scheduleOnePipeline fires (or skips) one pipeline's interval schedule, mirroring
+// runOneHeartbeat. Only an ENABLED pipeline with an interval that is DUE and has NO
+// active run creates a run; the guards otherwise skip it. next_due is advanced
+// ANCHORED TO NOW (not the old due time) so a long-idle scheduler that missed many
+// intervals fires exactly ONE run and schedules the next one interval out — never a
+// backlog replay.
+func scheduleOnePipeline(ctx context.Context, store *db.Store, rec db.Pipeline, now time.Time) error {
+	// Only an enabled, scheduled (interval set) pipeline auto-runs; a disabled or
+	// manual-only pipeline is never fired by the scheduler.
+	if !rec.Enabled || strings.TrimSpace(rec.Interval) == "" {
+		return nil
+	}
+	interval, err := time.ParseDuration(strings.TrimSpace(rec.Interval))
+	if err != nil {
+		return fmt.Errorf("pipeline %s interval: %w", rec.Name, err)
+	}
+	if interval <= 0 {
+		return fmt.Errorf("pipeline %s interval must be positive", rec.Name)
+	}
+	jitter := time.Duration(0)
+	if trimmed := strings.TrimSpace(rec.Jitter); trimmed != "" {
+		if jitter, err = time.ParseDuration(trimmed); err != nil {
+			return fmt.Errorf("pipeline %s jitter: %w", rec.Name, err)
+		}
+	}
+	// Not yet due: a zero next_due (the first scan after enable) is in the past, so a
+	// freshly enabled pipeline fires immediately; a future next_due is skipped WITHOUT
+	// advancing (mirrors the heartbeat due check).
+	if !rec.NextDueAt.IsZero() && now.Before(rec.NextDueAt) {
+		return nil
+	}
+	nextDue := now.Add(interval + heartbeatJitter(jitter))
+	// A scheduled pipeline needs a managed repo: its stage jobs need one for the
+	// worker to claim them (the same precondition `pipeline run` enforces). Without a
+	// repo the run would wedge (queued jobs no worker claims keep the overlap guard
+	// tripped forever), so skip the run but ADVANCE next_due so a misconfigured
+	// schedule does not hot-loop and self-recovers once a repo is set (the heartbeat
+	// repo-unmanaged idiom). AdvancePipelineNextDue touches only next_due, so the
+	// last-run display is preserved.
+	if strings.TrimSpace(rec.Repo) == "" {
+		return store.AdvancePipelineNextDue(ctx, rec.Name, nextDue)
+	}
+	// Overlap guard: one active (state='running') run per pipeline. A run in flight
+	// means skip WITHOUT advancing next_due, so the next scheduled run fires as soon
+	// as this one settles. A parked (blocked/failed) run does NOT count as active,
+	// mirroring `pipeline run`'s ActivePipelineRun guard.
+	if _, active, err := store.ActivePipelineRun(ctx, rec.Name); err != nil {
+		return err
+	} else if active {
+		return nil
+	}
+	spec, err := pipeline.Load([]byte(rec.SpecYAML))
+	if err != nil {
+		// A stored spec that no longer parses can't be run (`pipeline add` validates,
+		// so this is defensive); advance next_due so a broken spec does not hot-loop.
+		return store.AdvancePipelineNextDue(ctx, rec.Name, nextDue)
+	}
+	if _, err := createPipelineRun(ctx, store, rec, spec, "schedule", now); err != nil {
+		return err
+	}
+	// createPipelineRun stamped last_run_*; advance ONLY next_due (anchored to now).
+	// The ADVANCE pass that follows enqueues this run's ready root stages.
+	return store.AdvancePipelineNextDue(ctx, rec.Name, nextDue)
+}
+
+// advancePipelineRuns is runPipelineScanOnce's ADVANCE pass (#681): it advances
+// every in-flight (state='running') run once, so parked (blocked/failed) and
+// terminal runs consume zero compute. A per-run error is collected (first wins) but
+// never stops the remaining runs. Runs whose pipeline was removed, whose stored
+// spec no longer parses, or whose spec drifted (hash no longer matches the run's
+// snapshot) are skipped rather than executed against a changed spec.
+func advancePipelineRuns(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, now time.Time) error {
 	runs, err := store.ListActivePipelineRuns(ctx)
 	if err != nil {
 		return err

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -1,0 +1,518 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// The #681 pipeline RUN engine: create a run, enqueue ready stages, and advance it
+// by a scan (mirroring runHeartbeatScanOnce). The advancer is decision-based — it
+// folds each settled stage job by its gitmoot_result DECISION, never jobs.state,
+// because changes_requested is a SUCCEEDED job that must NOT advance (the
+// stateForDecision trap, workflow/result.go). Stage jobs are ordinary queued jobs
+// run through the SHELL runtime via a per-job runtime override; the normal worker
+// tick claims + runs them, and this advancer folds the results. The daemon-loop
+// wiring of runPipelineScanOnce lands in a later step — here it is driven by
+// `pipeline run` and the tests.
+
+// pipelineStageEnqueuer enqueues one pipeline stage job. In production it wraps
+// workflow.Mailbox.Enqueue (matching newHeartbeatEnqueuer); tests inject a fake to
+// assert the request shape without a real worker.
+type pipelineStageEnqueuer func(ctx context.Context, request workflow.JobRequest) (db.Job, error)
+
+// newPipelineStageEnqueuer builds the production enqueuer: a Mailbox bound to the
+// store and the daemon's canary-routing policy, so a pipeline stage job is
+// indistinguishable from a normal background job once enqueued (the runner agent
+// carries no template, so canary never actually samples).
+func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueuer {
+	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home)}
+	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
+		return mailbox.Enqueue(ctx, request)
+	}
+}
+
+// pipelineRunID derives a deterministic-per-invocation run id: a recognizable
+// "prun-" marker, the pipeline name (a validated name-safe token), and the
+// nanosecond clock so distinct runs never collide. The marker also lets
+// `pipeline show` tell a run id from a pipeline name.
+func pipelineRunID(pipelineName string, now time.Time) string {
+	return fmt.Sprintf("prun-%s-%x", strings.TrimSpace(pipelineName), now.UTC().UnixNano())
+}
+
+// pipelineStageJobID is the DETERMINISTIC stage job id: run id + stage id +
+// attempt. It is deterministic so a re-scan re-derives the same id and the
+// idempotent enqueue (enqueuePipelineStageJob) never double-creates a job; the
+// attempt suffix mints a fresh id for each retry.
+func pipelineStageJobID(runID, stageID string, attempt int) string {
+	return fmt.Sprintf("%s-%s-a%d", runID, stageID, attempt)
+}
+
+// pipelineStageFingerprint is the stage job fingerprint `pipeline:<name>:<run>:
+// <stage>:<attempt>` (decision 2), unique per stage attempt.
+func pipelineStageFingerprint(pipelineName, runID, stageID string, attempt int) string {
+	return fmt.Sprintf("pipeline:%s:%s:%s:%d", pipelineName, runID, stageID, attempt)
+}
+
+// pipelineStageJobRequest builds the JobRequest for one stage attempt. The stage
+// command travels in RuntimeOverrideRef (the shell runtime runs it verbatim as
+// `sh -c <cmd> gitmoot <prompt>`), NOT on the runner agent's runtime_ref, so one
+// runner serves every stage. ParentJobID and DelegationID stay EMPTY (any
+// ParentJobID would enter delegation advancement, engine.go); RootJobID is the run
+// id so all of a run's stage jobs share a root. The per-stage timeout is plumbed
+// as JobTimeout.
+func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.PipelineRun, attempt int) workflow.JobRequest {
+	return workflow.JobRequest{
+		ID:                 pipelineStageJobID(run.ID, stage.ID, attempt),
+		Agent:              pipelineRunnerAgentName(rec.Name),
+		Action:             "ask",
+		Repo:               rec.Repo,
+		Sender:             workflow.PipelineJobSender,
+		Instructions:       fmt.Sprintf("pipeline %s run %s stage %s", rec.Name, run.ID, stage.ID),
+		Fingerprint:        pipelineStageFingerprint(rec.Name, run.ID, stage.ID, attempt),
+		RootJobID:          run.ID,
+		JobTimeout:         stage.Timeout,
+		RuntimeOverride:    runtime.ShellRuntime,
+		RuntimeOverrideRef: stage.Cmd,
+	}
+}
+
+// enqueuePipelineStageJob enqueues a stage job idempotently: on an enqueue error
+// (e.g. a duplicate id from a re-scan that raced the stage-row write) it adopts an
+// already-created job with the same deterministic id, mirroring the engine's
+// enqueue idiom (engine.go). A genuinely new error with no matching job propagates.
+func enqueuePipelineStageJob(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, request workflow.JobRequest) (db.Job, error) {
+	job, err := enqueue(ctx, request)
+	if err == nil {
+		return job, nil
+	}
+	if existing, getErr := store.GetJob(ctx, request.ID); getErr == nil {
+		return existing, nil
+	}
+	return db.Job{}, err
+}
+
+// createPipelineRun creates a fresh manual/scheduled run: the pipeline_runs row
+// (snapshotting the pipeline's current spec_hash) plus one pending
+// pipeline_run_stages row per spec stage, and records the run on the pipeline's
+// last-run bookkeeping. It does NOT enqueue anything — the caller advances the run
+// once to enqueue the ready root stages, so creation and the first advance are the
+// same idempotent code path a re-scan uses.
+func createPipelineRun(ctx context.Context, store *db.Store, rec db.Pipeline, spec pipeline.Spec, trigger string, now time.Time) (db.PipelineRun, error) {
+	run := db.PipelineRun{
+		ID:        pipelineRunID(rec.Name, now),
+		Pipeline:  rec.Name,
+		Trigger:   trigger,
+		SpecHash:  rec.SpecHash,
+		State:     pipeline.RunRunning,
+		StartedAt: now.UTC(),
+	}
+	if err := store.CreatePipelineRun(ctx, run); err != nil {
+		return db.PipelineRun{}, err
+	}
+	for _, stage := range spec.Stages {
+		if err := store.CreatePipelineRunStage(ctx, db.PipelineRunStage{
+			RunID:   run.ID,
+			StageID: stage.ID,
+			State:   pipeline.StagePending,
+		}); err != nil {
+			return db.PipelineRun{}, err
+		}
+	}
+	if err := store.UpdatePipelineLastRun(ctx, rec.Name, run.ID, pipeline.RunRunning, now.UTC()); err != nil {
+		return db.PipelineRun{}, err
+	}
+	return run, nil
+}
+
+// runPipelineScanOnce advances every in-flight pipeline run once (#681). It is the
+// scan entry point wired next to runHeartbeatScanOnce; the daemon supervisor-loop
+// wiring lands in a later step. Only state='running' runs are advanced, so parked
+// (blocked/failed) and terminal runs consume zero compute. A per-run error is
+// collected (first wins) but never stops the remaining runs. Runs whose pipeline
+// was removed, whose stored spec no longer parses, or whose spec drifted (hash no
+// longer matches the run's snapshot) are skipped rather than executed against a
+// changed spec.
+func runPipelineScanOnce(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, now time.Time) error {
+	runs, err := store.ListActivePipelineRuns(ctx)
+	if err != nil {
+		return err
+	}
+	now = now.UTC()
+	var firstErr error
+	for _, run := range runs {
+		rec, ok, err := store.GetPipeline(ctx, run.Pipeline)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if !ok {
+			continue
+		}
+		spec, err := pipeline.Load([]byte(rec.SpecYAML))
+		if err != nil {
+			continue
+		}
+		// A run executes its SNAPSHOT: if the pipeline's spec was edited since the run
+		// was created, its hash no longer matches and we do NOT advance against the
+		// changed DAG/commands. Parking/repairing spec drift is a follow-up; skipping
+		// is safe (the run stays running and is left untouched).
+		if strings.TrimSpace(rec.SpecHash) != strings.TrimSpace(run.SpecHash) {
+			continue
+		}
+		if _, err := advancePipelineRun(ctx, store, enqueue, rec, spec, run, now); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// advancePipelineRun is the per-run advancer (decision 6). It is a single
+// idempotent pass: FOLD every settled stage job into its stage row by DECISION,
+// ENQUEUE newly-ready stages (unless the run is halting on a block/fail), then, if
+// nothing is in flight, SETTLE the run — succeeded, or parked blocked/failed with
+// the halt stage + reason + (for blocked) the aggregated needs persisted verbatim.
+// It writes only rows that actually change, so a re-scan on an unchanged run makes
+// no writes and no enqueues. It assumes run.State == running; a parked/terminal run
+// is a no-op. The updated run is returned for callers/tests.
+func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, rec db.Pipeline, spec pipeline.Spec, run db.PipelineRun, now time.Time) (db.PipelineRun, error) {
+	now = now.UTC()
+	if run.State != pipeline.RunRunning {
+		return run, nil
+	}
+	specByID := make(map[string]pipeline.Stage, len(spec.Stages))
+	for _, stage := range spec.Stages {
+		specByID[stage.ID] = stage
+	}
+	rows, err := store.ListPipelineRunStages(ctx, run.ID)
+	if err != nil {
+		return run, err
+	}
+	byID := make(map[string]db.PipelineRunStage, len(rows))
+	for _, row := range rows {
+		byID[row.StageID] = row
+	}
+
+	// --- FOLD: settle stage jobs by decision ---------------------------------
+	for _, stage := range spec.Stages {
+		row, ok := byID[stage.ID]
+		if !ok {
+			continue
+		}
+		if row.State != pipeline.StageQueued && row.State != pipeline.StageRunning {
+			continue
+		}
+		if strings.TrimSpace(row.JobID) == "" {
+			continue
+		}
+		job, err := store.GetJob(ctx, row.JobID)
+		if err != nil {
+			return run, err
+		}
+		if !workflow.IsSettledJobState(job.State) {
+			// Not terminal yet: reflect a queued->running transition so the funnel
+			// tracks the live job, but otherwise leave it in flight.
+			if job.State == string(workflow.JobRunning) && row.State == pipeline.StageQueued {
+				row.State = pipeline.StageRunning
+				if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+					return run, err
+				}
+				byID[stage.ID] = row
+			}
+			continue
+		}
+		state, summary, needs := foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
+		if state == pipeline.StageFailed && row.Attempt < stage.Retry {
+			// Retry budget remains: bump the attempt and reset to pending so the
+			// enqueue phase re-launches it under a fresh deterministic id/fingerprint.
+			row.Attempt++
+			row.State = pipeline.StagePending
+			row.JobID = ""
+			row.Summary = summary
+			row.NeedsJSON = ""
+			row.FinishedAt = time.Time{}
+		} else {
+			row.State = state
+			row.Summary = summary
+			row.NeedsJSON = marshalPipelineNeeds(needs)
+			row.FinishedAt = now
+		}
+		if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+			return run, err
+		}
+		byID[stage.ID] = row
+	}
+
+	// --- ENQUEUE: launch newly-ready stages ----------------------------------
+	// Once any stage is blocked or failed the run is halting: stop launching new
+	// work and let the in-flight stages drain, then park.
+	halting := anyPipelineStageInState(byID, pipeline.StageBlocked, pipeline.StageFailed)
+	if !halting {
+		for _, stage := range spec.Stages {
+			row := byID[stage.ID]
+			if row.State != pipeline.StagePending || !pipelineStageDepsSucceeded(stage, byID) {
+				continue
+			}
+			job, err := enqueuePipelineStageJob(ctx, store, enqueue, pipelineStageJobRequest(rec, stage, run, row.Attempt))
+			if err != nil {
+				return run, err
+			}
+			row.State = pipeline.StageQueued
+			row.JobID = job.ID
+			row.StartedAt = now
+			if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+				return run, err
+			}
+			byID[stage.ID] = row
+		}
+	}
+
+	// --- SETTLE: park or finish once nothing is in flight --------------------
+	if anyPipelineStageInState(byID, pipeline.StageQueued, pipeline.StageRunning) {
+		return run, nil
+	}
+
+	if halting {
+		// Nothing more can run: every still-pending stage is unreachable (a dep chain
+		// is broken by a blocked/failed stage), so mark them skipped for a clean
+		// terminal picture — this is also why a blocked run's downstream stages are
+		// never enqueued.
+		for _, stage := range spec.Stages {
+			row := byID[stage.ID]
+			if row.State == pipeline.StagePending {
+				row.State = pipeline.StageSkipped
+				row.FinishedAt = now
+				if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+					return run, err
+				}
+				byID[stage.ID] = row
+			}
+		}
+	}
+
+	settled := computePipelineRunSettlement(spec, byID, now)
+	return applyPipelineRunSettlement(ctx, store, rec, run, settled)
+}
+
+// pipelineRunSettlement is the computed run-level outcome of an advance pass once
+// nothing is in flight: the terminal state plus the halt stage/reason/needs.
+type pipelineRunSettlement struct {
+	State      string
+	HaltStage  string
+	HaltReason string
+	NeedsJSON  string
+	FinishedAt time.Time
+}
+
+// computePipelineRunSettlement derives the run's terminal state from the settled
+// stage rows (pure). Failed takes precedence over blocked (a hard failure is the
+// more urgent halt); otherwise blocked parks with the aggregated needs; otherwise
+// every stage is succeeded/skipped and the run succeeded. The halt stage is the
+// first blocked/failed stage in spec (topological) order for a stable funnel.
+func computePipelineRunSettlement(spec pipeline.Spec, byID map[string]db.PipelineRunStage, now time.Time) pipelineRunSettlement {
+	if stage, ok := firstPipelineStageInState(spec, byID, pipeline.StageFailed); ok {
+		return pipelineRunSettlement{
+			State:      pipeline.RunFailed,
+			HaltStage:  stage.StageID,
+			HaltReason: stage.Summary,
+			FinishedAt: now,
+		}
+	}
+	if stage, ok := firstPipelineStageInState(spec, byID, pipeline.StageBlocked); ok {
+		return pipelineRunSettlement{
+			State:      pipeline.RunBlocked,
+			HaltStage:  stage.StageID,
+			HaltReason: stage.Summary,
+			NeedsJSON:  marshalPipelineNeeds(aggregatePipelineBlockedNeeds(spec, byID)),
+			FinishedAt: now,
+		}
+	}
+	return pipelineRunSettlement{State: pipeline.RunSucceeded, FinishedAt: now}
+}
+
+// applyPipelineRunSettlement persists the run's terminal state (only when it
+// actually changed) and mirrors it onto the pipeline's last_status.
+func applyPipelineRunSettlement(ctx context.Context, store *db.Store, rec db.Pipeline, run db.PipelineRun, settled pipelineRunSettlement) (db.PipelineRun, error) {
+	updated := run
+	updated.State = settled.State
+	updated.HaltStage = settled.HaltStage
+	updated.HaltReason = settled.HaltReason
+	updated.NeedsJSON = settled.NeedsJSON
+	updated.FinishedAt = settled.FinishedAt
+	if pipelineRunEqual(run, updated) {
+		return run, nil
+	}
+	if err := store.UpdatePipelineRun(ctx, updated); err != nil {
+		return run, err
+	}
+	if err := store.UpdatePipelineLastRun(ctx, rec.Name, run.ID, updated.State, time.Time{}); err != nil {
+		return run, err
+	}
+	return updated, nil
+}
+
+// foldPipelineStageOutcome maps a settled stage job to a stage outcome BY DECISION
+// (decision 6). It reads payload.Result.Decision, never jobs.state: a
+// changes_requested job is SUCCEEDED but must NOT advance, so any decision outside
+// the stage's success_decisions (and not "blocked") is a failure. A cancelled job
+// or a job with no result (errored before parse / unparseable) is a failure too.
+func foldPipelineStageOutcome(successDecisions []string, job db.Job) (state, summary string, needs []string) {
+	if job.State == string(workflow.JobCancelled) {
+		return pipeline.StageFailed, "stage job cancelled", nil
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil || payload.Result == nil {
+		return pipeline.StageFailed, "stage job produced no gitmoot_result", nil
+	}
+	decision := strings.TrimSpace(payload.Result.Decision)
+	summary = strings.TrimSpace(payload.Result.Summary)
+	switch {
+	case containsPipelineDecision(successDecisions, decision):
+		return pipeline.StageSucceeded, summary, nil
+	case decision == "blocked":
+		if summary == "" {
+			summary = "stage blocked"
+		}
+		return pipeline.StageBlocked, summary, append([]string(nil), payload.Result.Needs...)
+	default:
+		if summary == "" {
+			summary = fmt.Sprintf("stage returned decision %q", decision)
+		}
+		return pipeline.StageFailed, summary, nil
+	}
+}
+
+// pipelineStageDepsSucceeded reports whether every stage this one needs has
+// reached StageSucceeded (so it is ready to enqueue). A missing dep row is treated
+// as not-succeeded (defensive; validation already rejects unknown needs).
+func pipelineStageDepsSucceeded(stage pipeline.Stage, byID map[string]db.PipelineRunStage) bool {
+	for _, dep := range stage.Needs {
+		if dep == "" {
+			continue
+		}
+		if byID[dep].State != pipeline.StageSucceeded {
+			return false
+		}
+	}
+	return true
+}
+
+func anyPipelineStageInState(byID map[string]db.PipelineRunStage, states ...string) bool {
+	for _, row := range byID {
+		for _, want := range states {
+			if row.State == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// firstPipelineStageInState returns the first stage row (in spec/topological
+// order) that is in the wanted state, for a stable halt-stage / funnel ordering.
+func firstPipelineStageInState(spec pipeline.Spec, byID map[string]db.PipelineRunStage, want string) (db.PipelineRunStage, bool) {
+	for _, stage := range spec.Stages {
+		if row, ok := byID[stage.ID]; ok && row.State == want {
+			return row, true
+		}
+	}
+	return db.PipelineRunStage{}, false
+}
+
+// aggregatePipelineBlockedNeeds collects the persisted needs of every blocked
+// stage, in spec order, deduped, so the run-level needs_json is the union of what
+// every parked stage is waiting on.
+func aggregatePipelineBlockedNeeds(spec pipeline.Spec, byID map[string]db.PipelineRunStage) []string {
+	seen := make(map[string]struct{})
+	var needs []string
+	for _, stage := range spec.Stages {
+		row, ok := byID[stage.ID]
+		if !ok || row.State != pipeline.StageBlocked {
+			continue
+		}
+		for _, need := range decodePipelineNeeds(row.NeedsJSON) {
+			if _, dup := seen[need]; dup {
+				continue
+			}
+			seen[need] = struct{}{}
+			needs = append(needs, need)
+		}
+	}
+	return needs
+}
+
+// persistPipelineStage writes a stage row only when a field the advancer owns
+// actually changed, keeping a re-scan write-free.
+func persistPipelineStage(ctx context.Context, store *db.Store, old, updated db.PipelineRunStage) error {
+	if pipelineStageEqual(old, updated) {
+		return nil
+	}
+	return store.UpdatePipelineRunStage(ctx, updated)
+}
+
+func pipelineStageEqual(a, b db.PipelineRunStage) bool {
+	return a.State == b.State && a.JobID == b.JobID && a.Attempt == b.Attempt &&
+		a.NeedsJSON == b.NeedsJSON && a.Summary == b.Summary &&
+		a.StartedAt.Equal(b.StartedAt) && a.FinishedAt.Equal(b.FinishedAt)
+}
+
+func pipelineRunEqual(a, b db.PipelineRun) bool {
+	return a.State == b.State && a.HaltStage == b.HaltStage && a.HaltReason == b.HaltReason &&
+		a.NeedsJSON == b.NeedsJSON && a.FinishedAt.Equal(b.FinishedAt)
+}
+
+func containsPipelineDecision(decisions []string, decision string) bool {
+	for _, d := range decisions {
+		if d == decision {
+			return true
+		}
+	}
+	return false
+}
+
+// marshalPipelineNeeds encodes a needs slice as a compact JSON array for
+// needs_json (empty slice => empty string, so no needs stores as "").
+func marshalPipelineNeeds(needs []string) string {
+	needs = compactPipelineNeeds(needs)
+	if len(needs) == 0 {
+		return ""
+	}
+	encoded, err := json.Marshal(needs)
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+// decodePipelineNeeds parses a needs_json array back into a slice; a blank or
+// malformed value decodes to no needs.
+func decodePipelineNeeds(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	var needs []string
+	if err := json.Unmarshal([]byte(value), &needs); err != nil {
+		return nil
+	}
+	return compactPipelineNeeds(needs)
+}
+
+func compactPipelineNeeds(needs []string) []string {
+	out := make([]string, 0, len(needs))
+	for _, need := range needs {
+		if trimmed := strings.TrimSpace(need); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}

--- a/internal/cli/pipeline_run_cli_test.go
+++ b/internal/cli/pipeline_run_cli_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestPipelineRunRequiresRepo proves `pipeline run` refuses a pipeline with no
+// repo: its stage jobs need a managed repo for a worker to claim them.
+func TestPipelineRunRequiresRepo(t *testing.T) {
+	home := t.TempDir()
+	run := func(args ...string) (string, string, int) {
+		var stdout, stderr bytes.Buffer
+		code := Run(append(args, "--home", home), &stdout, &stderr)
+		return stdout.String(), stderr.String(), code
+	}
+	spec := writeSpec(t, "name: norepo\nstages:\n  - id: a\n    cmd: echo a\n")
+	if _, errOut, code := run("pipeline", "add", spec); code != 0 {
+		t.Fatalf("add exit=%d stderr=%s", code, errOut)
+	}
+	_, errOut, code := run("pipeline", "run", "norepo")
+	if code != 1 || !strings.Contains(errOut, "has no repo") {
+		t.Fatalf("run no-repo: code=%d stderr=%q", code, errOut)
+	}
+}
+
+// TestPipelineRunOverlapGuardAndShow proves the manual run path: a run prints its
+// id, a second run while the first is active is refused (one active run per
+// pipeline), and `pipeline show <run-id>` renders the run funnel while
+// `show <name>` still renders the registry view.
+func TestPipelineRunOverlapGuardAndShow(t *testing.T) {
+	home := t.TempDir()
+	run := func(args ...string) (string, string, int) {
+		var stdout, stderr bytes.Buffer
+		code := Run(append(args, "--home", home), &stdout, &stderr)
+		return stdout.String(), stderr.String(), code
+	}
+	spec := writeSpec(t, "name: flow\nrepo: owner/repo\nstages:\n  - id: a\n    cmd: echo a\n")
+	if _, errOut, code := run("pipeline", "add", spec); code != 0 {
+		t.Fatalf("add exit=%d stderr=%s", code, errOut)
+	}
+
+	out, errOut, code := run("pipeline", "run", "flow")
+	if code != 0 {
+		t.Fatalf("run exit=%d stderr=%s", code, errOut)
+	}
+	runID := strings.TrimSpace(out)
+	if !strings.HasPrefix(runID, "prun-flow-") {
+		t.Fatalf("run id = %q, want a prun-flow- id", runID)
+	}
+
+	// Overlap guard: the first run is still running, so a second is refused.
+	if _, errOut, code := run("pipeline", "run", "flow"); code != 1 || !strings.Contains(errOut, "already has an active run") {
+		t.Fatalf("overlap run: code=%d stderr=%q", code, errOut)
+	}
+
+	// show <run-id>: the run funnel.
+	funnel, errOut, code := run("pipeline", "show", runID)
+	if code != 0 {
+		t.Fatalf("show run exit=%d stderr=%s", code, errOut)
+	}
+	if !strings.Contains(funnel, "run: "+runID) || !strings.Contains(funnel, "state: running") || !strings.Contains(funnel, "a QUEUED") {
+		t.Fatalf("run funnel = %q", funnel)
+	}
+
+	// show <name>: the registry view still wins for a pipeline name.
+	regView, _, code := run("pipeline", "show", "flow")
+	if code != 0 || !strings.Contains(regView, "name: flow") {
+		t.Fatalf("show name view = %q code=%d", regView, code)
+	}
+
+	// A totally unknown identifier is a friendly not-found.
+	if _, errOut, code := run("pipeline", "show", "prun-nope-1"); code != 1 || !strings.Contains(errOut, "not found") {
+		t.Fatalf("show unknown: code=%d stderr=%q", code, errOut)
+	}
+}

--- a/internal/cli/pipeline_run_e2e_test.go
+++ b/internal/cli/pipeline_run_e2e_test.go
@@ -1,0 +1,158 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+)
+
+// pipelineStageResultCmd is a shell command that ignores its input and echoes a
+// valid gitmoot_result with the given decision (and, for a block, the given
+// needs). It is the SHELL-runtime session body a stage job runs as
+// `sh -c <cmd> gitmoot <prompt>`, so the whole pipeline chain runs with NO LLM and
+// NO network — fully deterministic offline (the #446/#533 shell-runtime idiom).
+func pipelineStageResultCmd(decision, summary string, needs []string) string {
+	needsJSON := "[]"
+	if len(needs) > 0 {
+		quoted := make([]string, 0, len(needs))
+		for _, n := range needs {
+			quoted = append(quoted, `"`+n+`"`)
+		}
+		needsJSON = "[" + strings.Join(quoted, ",") + "]"
+	}
+	return `printf '%s' '{"gitmoot_result":{"decision":"` + decision + `","summary":"` + summary +
+		`","findings":[],"changes_made":[],"tests_run":[],"needs":` + needsJSON + `,"delegations":[]}}'`
+}
+
+// TestPipelineBlockedParkE2E is the full-chain, NO-LLM, deterministic blocked-park
+// E2E (#681). It drives the REAL chain a daemon iteration runs, end to end:
+//
+//	`pipeline add` (writes the registry row + the hidden shell runner agent)
+//	  -> `pipeline run` (creates the run, enqueues the ready root stage)
+//	    -> the REAL worker tick CLAIMS + RUNS each queued stage job through the
+//	       REAL shell adapter to its terminal decision
+//	      -> runPipelineScanOnce FOLDS each settled stage by DECISION and advances
+//
+// The middle stage returns a blocked result with needs: the run must PARK blocked
+// with the needs persisted at the run level, the blocked stage marked blocked, and
+// the third stage NEVER enqueued (no stage job, marked skipped). It goes red if any
+// link breaks: not-enqueued, worker-didn't-run, decision-misfolded, or the third
+// stage leaking a job.
+func TestPipelineBlockedParkE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+
+	// A real managed (enabled + checked-out) repo so the worker's checkout
+	// validation passes and it will claim the stage jobs.
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	source := pipelineStageResultCmd("approved", "source ok", nil)
+	score := pipelineStageResultCmd("blocked", "score needs a secret", []string{"R2 token"})
+	deploy := pipelineStageResultCmd("approved", "deploy ok", nil)
+	specYAML := "name: deploy-flow\nrepo: owner/repo\nstages:\n" +
+		pipelineE2EStage("source", source, "") +
+		pipelineE2EStage("score", score, "source") +
+		pipelineE2EStage("deploy", deploy, "score")
+	specFile := writeSpec(t, specYAML)
+
+	// `pipeline add` creates the registry row + the hidden pipeline-<name>-runner
+	// shell agent the worker resolves for each stage job.
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline add exit=%d stderr=%s", code, errBuf.String())
+	}
+
+	// `pipeline run` creates the run and enqueues the root stage; it prints the run id.
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "run", "deploy-flow", "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline run exit=%d stderr=%s", code, errBuf.String())
+	}
+	runID := strings.TrimSpace(out.String())
+	if runID == "" {
+		t.Fatalf("pipeline run printed no run id (stderr=%s)", errBuf.String())
+	}
+
+	// Drive the real worker tick + advancer scan until the run leaves running.
+	enqueue := newPipelineStageEnqueuer(store, home)
+	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 8; i++ {
+		if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+			t.Fatalf("worker tick %d: %v", i, err)
+		}
+		if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+			t.Fatalf("pipeline scan %d: %v", i, err)
+		}
+		run, _, err := store.GetPipelineRun(ctx, runID)
+		if err != nil {
+			t.Fatalf("GetPipelineRun: %v", err)
+		}
+		if run.State != pipeline.RunRunning {
+			break
+		}
+	}
+
+	run, ok, err := store.GetPipelineRun(ctx, runID)
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineRun(%s): ok=%v err=%v", runID, ok, err)
+	}
+	if run.State != pipeline.RunBlocked {
+		t.Fatalf("run state = %s, want blocked", run.State)
+	}
+	if run.HaltStage != "score" {
+		t.Fatalf("halt_stage = %q, want score", run.HaltStage)
+	}
+	if got := decodePipelineNeeds(run.NeedsJSON); len(got) != 1 || got[0] != "R2 token" {
+		t.Fatalf("run needs = %v, want [R2 token]", got)
+	}
+
+	src := stageRow(t, store, runID, "source")
+	if src.State != pipeline.StageSucceeded {
+		t.Fatalf("stage source = %s, want succeeded", src.State)
+	}
+	scr := stageRow(t, store, runID, "score")
+	if scr.State != pipeline.StageBlocked {
+		t.Fatalf("stage score = %s, want blocked", scr.State)
+	}
+	if got := decodePipelineNeeds(scr.NeedsJSON); len(got) != 1 || got[0] != "R2 token" {
+		t.Fatalf("stage score needs = %v, want [R2 token]", got)
+	}
+	dep := stageRow(t, store, runID, "deploy")
+	if dep.JobID != "" {
+		t.Fatalf("stage deploy job = %q, want NEVER enqueued", dep.JobID)
+	}
+	if dep.State != pipeline.StageSkipped {
+		t.Fatalf("stage deploy = %s, want skipped", dep.State)
+	}
+
+	// The funnel renders the parked run with the blocking needs inline.
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "show", runID, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline show run exit=%d stderr=%s", code, errBuf.String())
+	}
+	funnel := out.String()
+	if !strings.Contains(funnel, "source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED") {
+		t.Fatalf("funnel missing expected line:\n%s", funnel)
+	}
+	if !strings.Contains(funnel, "state: blocked") {
+		t.Fatalf("funnel missing state: blocked:\n%s", funnel)
+	}
+}
+
+// pipelineE2EStage renders one stage block with the shell cmd as a literal YAML
+// block scalar (so the JSON-bearing single-quoted command survives YAML parsing).
+func pipelineE2EStage(id, cmd, needs string) string {
+	block := "  - id: " + id + "\n    cmd: |\n      " + cmd + "\n"
+	if needs != "" {
+		block += "    needs: [" + needs + "]\n"
+	}
+	return block
+}

--- a/internal/cli/pipeline_schedule_test.go
+++ b/internal/cli/pipeline_schedule_test.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+)
+
+// newScheduledPipeline stores an enabled/disabled pipeline carrying an interval
+// schedule. It writes the interval/jitter/enabled columns DIRECTLY — those DB
+// columns (not the spec YAML) are what the scan-based scheduler reads, exactly as
+// `pipeline add` maps spec.Schedule into them. next_due starts zero (== due), so a
+// freshly scheduled pipeline is due on the first scan.
+func newScheduledPipeline(t *testing.T, store *db.Store, name, repo, interval, jitter string, enabled bool) db.Pipeline {
+	t.Helper()
+	specYAML := "name: " + name + "\nstages:\n  - id: a\n    cmd: echo a\n  - id: b\n    cmd: echo b\n    needs: [a]\n"
+	rec := db.Pipeline{
+		Name:     name,
+		Repo:     repo,
+		SpecYAML: specYAML,
+		SpecHash: pipeline.Hash([]byte(specYAML)),
+		Interval: interval,
+		Jitter:   jitter,
+		Enabled:  enabled,
+	}
+	if err := store.CreateOrUpdatePipeline(context.Background(), rec); err != nil {
+		t.Fatalf("CreateOrUpdatePipeline: %v", err)
+	}
+	got, ok, err := store.GetPipeline(context.Background(), name)
+	if err != nil || !ok {
+		t.Fatalf("GetPipeline: ok=%v err=%v", ok, err)
+	}
+	return got
+}
+
+func pipelineRunCount(t *testing.T, store *db.Store, name string) []db.PipelineRun {
+	t.Helper()
+	runs, err := store.ListPipelineRuns(context.Background(), name)
+	if err != nil {
+		t.Fatalf("ListPipelineRuns: %v", err)
+	}
+	return runs
+}
+
+// TestSchedulePipelineDueFires proves an enabled, due (zero next_due) scheduled
+// pipeline gets exactly one scheduled run and its next_due advances one interval
+// past now (the heartbeat anchor idiom).
+func TestSchedulePipelineDueFires(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	newScheduledPipeline(t, store, "nightly", "owner/repo", "24h", "", true)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	if err := schedulePipelineRuns(ctx, store, now); err != nil {
+		t.Fatalf("schedulePipelineRuns: %v", err)
+	}
+	runs := pipelineRunCount(t, store, "nightly")
+	if len(runs) != 1 {
+		t.Fatalf("due schedule created %d runs, want 1", len(runs))
+	}
+	if runs[0].Trigger != "schedule" {
+		t.Fatalf("run trigger = %q, want schedule", runs[0].Trigger)
+	}
+	if runs[0].State != pipeline.RunRunning {
+		t.Fatalf("run state = %q, want running", runs[0].State)
+	}
+	rec, _, _ := store.GetPipeline(ctx, "nightly")
+	if want := now.Add(24 * time.Hour); !rec.NextDueAt.Equal(want) {
+		t.Fatalf("next_due = %s, want %s (anchored to now + interval)", rec.NextDueAt, want)
+	}
+}
+
+// TestSchedulePipelineNotDue proves a future next_due is skipped without creating a
+// run or advancing.
+func TestSchedulePipelineNotDue(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	newScheduledPipeline(t, store, "nightly", "owner/repo", "24h", "", true)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	// Push next_due into the future: not due yet.
+	future := now.Add(2 * time.Hour)
+	if err := store.AdvancePipelineNextDue(ctx, "nightly", future); err != nil {
+		t.Fatalf("AdvancePipelineNextDue: %v", err)
+	}
+
+	if err := schedulePipelineRuns(ctx, store, now); err != nil {
+		t.Fatalf("schedulePipelineRuns: %v", err)
+	}
+	if runs := pipelineRunCount(t, store, "nightly"); len(runs) != 0 {
+		t.Fatalf("not-due schedule created %d runs, want 0", len(runs))
+	}
+	rec, _, _ := store.GetPipeline(ctx, "nightly")
+	if !rec.NextDueAt.Equal(future) {
+		t.Fatalf("next_due = %s, want unchanged %s", rec.NextDueAt, future)
+	}
+}
+
+// TestSchedulePipelineDisabledOrManual proves a disabled pipeline, and an enabled
+// pipeline with no interval, are both never fired by the scheduler.
+func TestSchedulePipelineDisabledOrManual(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	newScheduledPipeline(t, store, "off", "owner/repo", "24h", "", false) // disabled
+	newScheduledPipeline(t, store, "manual", "owner/repo", "", "", true)  // enabled, no interval
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	if err := schedulePipelineRuns(ctx, store, now); err != nil {
+		t.Fatalf("schedulePipelineRuns: %v", err)
+	}
+	if runs := pipelineRunCount(t, store, "off"); len(runs) != 0 {
+		t.Fatalf("disabled pipeline fired %d runs, want 0", len(runs))
+	}
+	if runs := pipelineRunCount(t, store, "manual"); len(runs) != 0 {
+		t.Fatalf("manual (no interval) pipeline fired %d runs, want 0", len(runs))
+	}
+}
+
+// TestSchedulePipelineOverlapGuard proves a scheduled pipeline with an active
+// (running) run is skipped WITHOUT advancing next_due, so no second run is created
+// and the next one fires as soon as the active one settles.
+func TestSchedulePipelineOverlapGuard(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	rec := newScheduledPipeline(t, store, "nightly", "owner/repo", "24h", "", true)
+	spec, err := pipeline.Load([]byte(rec.SpecYAML))
+	if err != nil {
+		t.Fatalf("pipeline.Load: %v", err)
+	}
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	// An already-running run exists (created earlier).
+	if _, err := createPipelineRun(ctx, store, rec, spec, "schedule", now.Add(-time.Hour)); err != nil {
+		t.Fatalf("createPipelineRun: %v", err)
+	}
+
+	if err := schedulePipelineRuns(ctx, store, now); err != nil {
+		t.Fatalf("schedulePipelineRuns: %v", err)
+	}
+	if runs := pipelineRunCount(t, store, "nightly"); len(runs) != 1 {
+		t.Fatalf("overlap guard created a second run: %d runs, want 1", len(runs))
+	}
+	got, _, _ := store.GetPipeline(ctx, "nightly")
+	if !got.NextDueAt.IsZero() {
+		t.Fatalf("overlap guard advanced next_due to %s, want unchanged (zero)", got.NextDueAt)
+	}
+}
+
+// TestSchedulePipelineCoalescesMissedTicks proves a long-idle scheduler (next_due
+// far in the past) fires exactly ONE run and re-anchors next_due to now+interval —
+// no backlog replay of every missed interval.
+func TestSchedulePipelineCoalescesMissedTicks(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	newScheduledPipeline(t, store, "nightly", "owner/repo", "1h", "", true)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	// 100 intervals overdue (the daemon was down for days).
+	if err := store.AdvancePipelineNextDue(ctx, "nightly", now.Add(-100*time.Hour)); err != nil {
+		t.Fatalf("AdvancePipelineNextDue: %v", err)
+	}
+
+	if err := schedulePipelineRuns(ctx, store, now); err != nil {
+		t.Fatalf("schedulePipelineRuns: %v", err)
+	}
+	if runs := pipelineRunCount(t, store, "nightly"); len(runs) != 1 {
+		t.Fatalf("coalescing created %d runs, want exactly 1", len(runs))
+	}
+	rec, _, _ := store.GetPipeline(ctx, "nightly")
+	if want := now.Add(time.Hour); !rec.NextDueAt.Equal(want) {
+		t.Fatalf("next_due = %s, want %s (re-anchored to now, not replaying backlog)", rec.NextDueAt, want)
+	}
+}
+
+// TestSchedulePipelineNoRepoAdvances proves a scheduled pipeline WITHOUT a repo is
+// skipped (its stage jobs would wedge with no worker to claim them) but its next_due
+// is advanced so a misconfigured schedule does not hot-loop.
+func TestSchedulePipelineNoRepoAdvances(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	newScheduledPipeline(t, store, "norepo", "", "24h", "", true)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	if err := schedulePipelineRuns(ctx, store, now); err != nil {
+		t.Fatalf("schedulePipelineRuns: %v", err)
+	}
+	if runs := pipelineRunCount(t, store, "norepo"); len(runs) != 0 {
+		t.Fatalf("no-repo schedule created %d runs, want 0", len(runs))
+	}
+	rec, _, _ := store.GetPipeline(ctx, "norepo")
+	if want := now.Add(24 * time.Hour); !rec.NextDueAt.Equal(want) {
+		t.Fatalf("next_due = %s, want %s (advanced to avoid hot-loop)", rec.NextDueAt, want)
+	}
+}
+
+// TestSchedulePipelineJitterWithinBounds proves next_due lands in
+// [now+interval, now+interval+jitter] when a jitter is set.
+func TestSchedulePipelineJitterWithinBounds(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	newScheduledPipeline(t, store, "jittered", "owner/repo", "1h", "15m", true)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	if err := schedulePipelineRuns(ctx, store, now); err != nil {
+		t.Fatalf("schedulePipelineRuns: %v", err)
+	}
+	rec, _, _ := store.GetPipeline(ctx, "jittered")
+	lo := now.Add(time.Hour)
+	hi := now.Add(time.Hour + 15*time.Minute)
+	if rec.NextDueAt.Before(lo) || rec.NextDueAt.After(hi) {
+		t.Fatalf("next_due = %s, want within [%s, %s]", rec.NextDueAt, lo, hi)
+	}
+}
+
+// TestRunPipelineScanOnceScheduleThenAdvance proves the full scan wires the two
+// passes in order: the schedule pass creates the due run, and the advance pass that
+// follows in the SAME scan enqueues its ready root stage.
+func TestRunPipelineScanOnceScheduleThenAdvance(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	newScheduledPipeline(t, store, "nightly", "owner/repo", "24h", "", true)
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+
+	if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+		t.Fatalf("runPipelineScanOnce: %v", err)
+	}
+	runs := pipelineRunCount(t, store, "nightly")
+	if len(runs) != 1 {
+		t.Fatalf("scan created %d runs, want 1", len(runs))
+	}
+	// The advance pass in the same scan enqueued the root stage (a), leaving b pending.
+	a := stageRow(t, store, runs[0].ID, "a")
+	if a.State != pipeline.StageQueued || a.JobID == "" {
+		t.Fatalf("root stage a = %+v, want queued with a job (advance pass ran)", a)
+	}
+	if b := stageRow(t, store, runs[0].ID, "b"); b.State != pipeline.StagePending {
+		t.Fatalf("stage b = %s, want pending", b.State)
+	}
+}

--- a/internal/cli/pipeline_test.go
+++ b/internal/cli/pipeline_test.go
@@ -1,0 +1,219 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+const testPipelineSpec = `name: deploy-flow
+repo: jerryfane/gitmoot
+schedule:
+  interval: 24h
+  jitter: 15m
+stages:
+  - id: source
+    cmd: git fetch --all
+  - id: score
+    cmd: ./score.sh
+    needs: [source]
+  - id: deploy
+    cmd: ./deploy.sh
+    needs: [score]
+`
+
+func writeSpec(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "spec.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	return path
+}
+
+// TestPipelineAddListShowEnableDisableRemove exercises the full CLI lifecycle
+// through Run() with an isolated home, asserting the registry round-trip and the
+// hidden-runner-agent behavior.
+func TestPipelineAddListShowEnableDisableRemove(t *testing.T) {
+	home := t.TempDir()
+	run := func(args ...string) (string, string, int) {
+		var stdout, stderr bytes.Buffer
+		code := Run(append(args, "--home", home), &stdout, &stderr)
+		return stdout.String(), stderr.String(), code
+	}
+	spec := writeSpec(t, testPipelineSpec)
+
+	out, errOut, code := run("pipeline", "add", spec, "--enable")
+	if code != 0 {
+		t.Fatalf("add exit=%d stderr=%s", code, errOut)
+	}
+	if !strings.Contains(out, "added pipeline deploy-flow") || !strings.Contains(out, "enabled") || !strings.Contains(out, "3 stages") {
+		t.Fatalf("add stdout=%q", out)
+	}
+
+	out, errOut, code = run("pipeline", "list")
+	if code != 0 {
+		t.Fatalf("list exit=%d stderr=%s", code, errOut)
+	}
+	if !strings.Contains(out, "deploy-flow") || !strings.Contains(out, "enabled") || !strings.Contains(out, "24h") {
+		t.Fatalf("list stdout=%q", out)
+	}
+
+	out, errOut, code = run("pipeline", "show", "deploy-flow")
+	if code != 0 {
+		t.Fatalf("show exit=%d stderr=%s", code, errOut)
+	}
+	if !strings.Contains(out, "enabled: true") || !strings.Contains(out, "interval: 24h") ||
+		!strings.Contains(out, "score\tneeds=source") || !strings.Contains(out, "cmd=./deploy.sh") {
+		t.Fatalf("show stdout=%q", out)
+	}
+
+	// The hidden shell runner agent exists but is filtered out of `agent list`.
+	out, _, _ = run("agent", "list")
+	if strings.Contains(out, "pipeline-deploy-flow-runner") {
+		t.Fatalf("runner agent leaked into agent list: %q", out)
+	}
+	if _, _, code = run("agent", "show", "pipeline-deploy-flow-runner"); code != 0 {
+		t.Fatalf("runner agent should exist (agent show exit=%d)", code)
+	}
+
+	if _, errOut, code = run("pipeline", "disable", "deploy-flow"); code != 0 {
+		t.Fatalf("disable exit=%d stderr=%s", code, errOut)
+	}
+	out, _, _ = run("pipeline", "show", "deploy-flow")
+	if !strings.Contains(out, "enabled: false") {
+		t.Fatalf("expected disabled, show=%q", out)
+	}
+	if _, errOut, code = run("pipeline", "enable", "deploy-flow"); code != 0 {
+		t.Fatalf("enable exit=%d stderr=%s", code, errOut)
+	}
+	out, _, _ = run("pipeline", "show", "deploy-flow")
+	if !strings.Contains(out, "enabled: true") {
+		t.Fatalf("expected enabled, show=%q", out)
+	}
+
+	if _, errOut, code = run("pipeline", "remove", "deploy-flow"); code != 0 {
+		t.Fatalf("remove exit=%d stderr=%s", code, errOut)
+	}
+	// Removing the pipeline also disposes the runner agent (best-effort).
+	if _, _, code = run("agent", "show", "pipeline-deploy-flow-runner"); code == 0 {
+		t.Fatalf("runner agent should be removed with the pipeline")
+	}
+}
+
+func TestPipelineShowJSON(t *testing.T) {
+	home := t.TempDir()
+	spec := writeSpec(t, testPipelineSpec)
+	if code := Run([]string{"pipeline", "add", spec, "--home", home}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("add exit=%d", code)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "show", "deploy-flow", "--json", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("show --json exit=%d stderr=%s", code, stderr.String())
+	}
+	var decoded struct {
+		Name     string `json:"name"`
+		Enabled  bool   `json:"enabled"`
+		SpecHash string `json:"spec_hash"`
+		Stages   []struct {
+			ID    string   `json:"id"`
+			Cmd   string   `json:"cmd"`
+			Needs []string `json:"needs"`
+		} `json:"stages"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode show json: %v (%s)", err, stdout.String())
+	}
+	if decoded.Name != "deploy-flow" || decoded.Enabled || decoded.SpecHash == "" {
+		t.Fatalf("unexpected json header: %+v", decoded)
+	}
+	if len(decoded.Stages) != 3 || decoded.Stages[2].ID != "deploy" || len(decoded.Stages[2].Needs) != 1 {
+		t.Fatalf("unexpected stages: %+v", decoded.Stages)
+	}
+}
+
+func TestPipelineListJSON(t *testing.T) {
+	home := t.TempDir()
+	spec := writeSpec(t, testPipelineSpec)
+	if code := Run([]string{"pipeline", "add", spec, "--enable", "--home", home}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("add exit=%d", code)
+	}
+	var stdout bytes.Buffer
+	if code := Run([]string{"pipeline", "list", "--json", "--home", home}, &stdout, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("list --json exit=%d", code)
+	}
+	var decoded []struct {
+		Name     string `json:"name"`
+		Enabled  bool   `json:"enabled"`
+		Interval string `json:"interval"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode list json: %v (%s)", err, stdout.String())
+	}
+	if len(decoded) != 1 || decoded[0].Name != "deploy-flow" || !decoded[0].Enabled || decoded[0].Interval != "24h" {
+		t.Fatalf("unexpected list json: %+v", decoded)
+	}
+}
+
+func TestPipelineValidationExitCodes(t *testing.T) {
+	home := t.TempDir()
+	run := func(args ...string) int {
+		return Run(append(args, "--home", home), &bytes.Buffer{}, &bytes.Buffer{})
+	}
+	// Invalid spec -> validation error exit 2.
+	dup := writeSpec(t, "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: a, cmd: echo}\n")
+	if code := run("pipeline", "add", dup); code != 2 {
+		t.Fatalf("dup-id add exit=%d, want 2", code)
+	}
+	// Missing file -> runtime error exit 1.
+	if code := run("pipeline", "add", filepath.Join(t.TempDir(), "nope.yaml")); code != 1 {
+		t.Fatalf("missing-file add exit=%d, want 1", code)
+	}
+	// Show/enable/remove of a missing pipeline -> exit 1.
+	if code := run("pipeline", "show", "ghost"); code != 1 {
+		t.Fatalf("show missing exit=%d, want 1", code)
+	}
+	if code := run("pipeline", "enable", "ghost"); code != 1 {
+		t.Fatalf("enable missing exit=%d, want 1", code)
+	}
+	if code := run("pipeline", "remove", "ghost"); code != 1 {
+		t.Fatalf("remove missing exit=%d, want 1", code)
+	}
+	// Unknown subcommand -> usage error exit 2.
+	if code := run("pipeline", "bogus"); code != 2 {
+		t.Fatalf("unknown subcommand exit=%d, want 2", code)
+	}
+}
+
+// TestPipelineRunnerNameCollisionRefused proves `pipeline add` refuses to clobber
+// a pre-existing non-shell agent occupying the runner name.
+func TestPipelineRunnerNameCollisionRefused(t *testing.T) {
+	home := t.TempDir()
+	// Pre-seed a real codex agent named like the runner would be.
+	if err := withStore(home, func(store *db.Store) error {
+		return store.UpsertAgent(context.Background(), db.Agent{
+			Name: "pipeline-clash-runner", Role: "planner", Runtime: "codex",
+			Capabilities: []string{"ask"}, AutonomyPolicy: "auto", HealthStatus: "unknown",
+		})
+	}); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	spec := writeSpec(t, "name: clash\nstages:\n  - {id: a, cmd: echo}\n")
+	var stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "add", spec, "--home", home}, &bytes.Buffer{}, &stderr); code != 1 {
+		t.Fatalf("colliding add exit=%d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "collides with an existing codex agent") {
+		t.Fatalf("stderr=%q", stderr.String())
+	}
+	// The pipeline row must not have been created.
+	if code := Run([]string{"pipeline", "show", "clash", "--home", home}, &bytes.Buffer{}, &bytes.Buffer{}); code == 0 {
+		t.Fatalf("pipeline should not exist after refused add")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -44,6 +44,7 @@ var rootCommands = []command{
 	{name: "dashboard", summary: "show a snapshot of local Gitmoot state", run: runDashboard},
 	{name: "skillopt", summary: "export and import SkillOpt packages", run: runSkillOpt},
 	{name: "memory", summary: "inspect and measure agent persistent memory", run: runMemory},
+	{name: "pipeline", summary: "define and inspect declarative pipelines", run: runPipeline},
 }
 
 func Run(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -44,7 +44,7 @@ var rootCommands = []command{
 	{name: "dashboard", summary: "show a snapshot of local Gitmoot state", run: runDashboard},
 	{name: "skillopt", summary: "export and import SkillOpt packages", run: runSkillOpt},
 	{name: "memory", summary: "inspect and measure agent persistent memory", run: runMemory},
-	{name: "pipeline", summary: "define and inspect declarative pipelines", run: runPipeline},
+	{name: "pipeline", summary: "define, run, and manage declarative pipelines", run: runPipeline},
 }
 
 func Run(args []string, stdout, stderr io.Writer) int {

--- a/internal/db/pipeline.go
+++ b/internal/db/pipeline.go
@@ -1,0 +1,209 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+// Pipeline is one row of the pipelines registry (#681): a named pipeline's
+// verbatim spec (YAML + content hash), its interval/jitter schedule, and the
+// durable schedule state that makes an interval schedule restart-safe. A run
+// snapshots SpecHash so it executes the spec content it was created from, not the
+// row's later state.
+type Pipeline struct {
+	Name       string
+	Repo       string
+	SpecYAML   string
+	SpecHash   string
+	Enabled    bool
+	Interval   string
+	Jitter     string
+	LastRunAt  time.Time
+	NextDueAt  time.Time
+	LastRunID  string
+	LastStatus string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// PipelineScheduleState is the durable schedule state of one pipeline, mirroring
+// HeartbeatState (#533): when it last ran, when it is next due, and the id/status
+// of its most recent run. The next_due + last_status are what make an interval
+// schedule restart-safe (a restart re-reads next_due rather than firing).
+type PipelineScheduleState struct {
+	Name       string
+	LastRunAt  time.Time
+	NextDueAt  time.Time
+	LastRunID  string
+	LastStatus string
+}
+
+// CreateOrUpdatePipeline inserts a pipeline or, on a name conflict, replaces its
+// spec-defining fields (repo, spec_yaml, spec_hash, interval, jitter) in place.
+// It deliberately does NOT touch enabled or the schedule-state columns on
+// conflict: re-adding an edited spec preserves whether the pipeline was enabled
+// and its last-run bookkeeping. enabled is set from the struct only on first
+// insert; toggle it afterwards with SetPipelineEnabled.
+func (s *Store) CreateOrUpdatePipeline(ctx context.Context, pipeline Pipeline) error {
+	pipeline.Name = strings.TrimSpace(pipeline.Name)
+	if pipeline.Name == "" {
+		return errors.New("pipeline name is required")
+	}
+	enabled := 0
+	if pipeline.Enabled {
+		enabled = 1
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO pipelines(name, repo, spec_yaml, spec_hash, enabled, interval, jitter, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(name) DO UPDATE SET
+			repo = excluded.repo,
+			spec_yaml = excluded.spec_yaml,
+			spec_hash = excluded.spec_hash,
+			interval = excluded.interval,
+			jitter = excluded.jitter,
+			updated_at = CURRENT_TIMESTAMP`,
+		pipeline.Name, strings.TrimSpace(pipeline.Repo), pipeline.SpecYAML, strings.TrimSpace(pipeline.SpecHash),
+		enabled, strings.TrimSpace(pipeline.Interval), strings.TrimSpace(pipeline.Jitter))
+	return err
+}
+
+// GetPipeline returns one pipeline by name. A missing row is NOT an error: it
+// returns ok=false with a zero Pipeline so callers can print a friendly
+// "not found" and choose the exit code.
+func (s *Store) GetPipeline(ctx context.Context, name string) (Pipeline, bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return Pipeline{}, false, errors.New("pipeline name is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT name, repo, spec_yaml, spec_hash, enabled, interval, jitter,
+		last_run_at, next_due_at, last_run_id, last_status, created_at, updated_at
+		FROM pipelines WHERE name = ?`, name)
+	pipeline, err := scanPipeline(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Pipeline{}, false, nil
+	}
+	if err != nil {
+		return Pipeline{}, false, err
+	}
+	return pipeline, true, nil
+}
+
+// ListPipelines returns every registered pipeline ordered by name.
+func (s *Store) ListPipelines(ctx context.Context) ([]Pipeline, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT name, repo, spec_yaml, spec_hash, enabled, interval, jitter,
+		last_run_at, next_due_at, last_run_id, last_status, created_at, updated_at
+		FROM pipelines ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var pipelines []Pipeline
+	for rows.Next() {
+		pipeline, err := scanPipeline(rows)
+		if err != nil {
+			return nil, err
+		}
+		pipelines = append(pipelines, pipeline)
+	}
+	return pipelines, rows.Err()
+}
+
+// SetPipelineEnabled flips the enabled flag for a pipeline. It returns an error
+// if no pipeline matched the name so the CLI can report "not found" rather than
+// silently no-op'ing an enable/disable.
+func (s *Store) SetPipelineEnabled(ctx context.Context, name string, enabled bool) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("pipeline name is required")
+	}
+	flag := 0
+	if enabled {
+		flag = 1
+	}
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE pipelines SET enabled = ?, updated_at = CURRENT_TIMESTAMP WHERE name = ?`, flag, name)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return errors.New("pipeline " + name + " not found")
+	}
+	return nil
+}
+
+// DeletePipeline removes a pipeline row, returning whether a row was deleted.
+// It does not touch the pipeline's runner agent or any run rows — the CLI removes
+// the runner agent best-effort, and run/stage rows live in separate tables added
+// by the run/advancer step.
+func (s *Store) DeletePipeline(ctx context.Context, name string) (bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false, errors.New("pipeline name is required")
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM pipelines WHERE name = ?`, name)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected > 0, nil
+}
+
+// UpdatePipelineScheduleState persists a pipeline's durable schedule state — the
+// last-run/next-due bookkeeping the interval scheduler reads on restart. It
+// mirrors UpsertHeartbeatState's role (times stored as RFC3339Nano UTC text; a
+// zero time becomes empty text) but updates the existing pipelines row in place
+// (the row is created by CreateOrUpdatePipeline), so it returns an error if no
+// pipeline matched the name. It leaves the spec and enabled fields untouched.
+func (s *Store) UpdatePipelineScheduleState(ctx context.Context, state PipelineScheduleState) error {
+	state.Name = strings.TrimSpace(state.Name)
+	if state.Name == "" {
+		return errors.New("pipeline name is required")
+	}
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE pipelines SET last_run_at = ?, next_due_at = ?, last_run_id = ?, last_status = ?, updated_at = CURRENT_TIMESTAMP
+			WHERE name = ?`,
+		formatHeartbeatTime(state.LastRunAt), formatHeartbeatTime(state.NextDueAt),
+		strings.TrimSpace(state.LastRunID), strings.TrimSpace(state.LastStatus), state.Name)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return errors.New("pipeline " + state.Name + " not found")
+	}
+	return nil
+}
+
+// scanPipeline reads one pipelines row (from *sql.Row or *sql.Rows) into a
+// Pipeline, decoding the integer enabled flag and the RFC3339 text timestamps.
+func scanPipeline(row interface{ Scan(...any) error }) (Pipeline, error) {
+	var (
+		pipeline                               Pipeline
+		enabled                                int
+		lastRun, nextDue, createdAt, updatedAt string
+	)
+	if err := row.Scan(&pipeline.Name, &pipeline.Repo, &pipeline.SpecYAML, &pipeline.SpecHash, &enabled,
+		&pipeline.Interval, &pipeline.Jitter, &lastRun, &nextDue, &pipeline.LastRunID, &pipeline.LastStatus,
+		&createdAt, &updatedAt); err != nil {
+		return Pipeline{}, err
+	}
+	pipeline.Enabled = enabled != 0
+	pipeline.LastRunAt = parseHeartbeatTime(lastRun)
+	pipeline.NextDueAt = parseHeartbeatTime(nextDue)
+	pipeline.CreatedAt = parseStoredTimestamp(createdAt)
+	pipeline.UpdatedAt = parseStoredTimestamp(updatedAt)
+	return pipeline, nil
+}

--- a/internal/db/pipeline.go
+++ b/internal/db/pipeline.go
@@ -187,6 +187,35 @@ func (s *Store) UpdatePipelineScheduleState(ctx context.Context, state PipelineS
 	return nil
 }
 
+// AdvancePipelineNextDue advances ONLY a pipeline's schedule anchor (next_due_at),
+// leaving the spec, enabled flag, and last-run bookkeeping (last_run_at / id /
+// status) untouched. The scan-based scheduler calls it after creating a scheduled
+// run (createPipelineRun already stamped the last-run columns) and when it skips a
+// due-but-not-runnable pipeline (no repo / unparseable spec), so a misconfigured
+// schedule advances rather than hot-looping and without clobbering the last-run
+// display. It mirrors UpsertHeartbeatState's next_due role (time stored as
+// RFC3339Nano UTC text). A missing pipeline row is an error so a lost row surfaces.
+func (s *Store) AdvancePipelineNextDue(ctx context.Context, name string, nextDue time.Time) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("pipeline name is required")
+	}
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE pipelines SET next_due_at = ?, updated_at = CURRENT_TIMESTAMP WHERE name = ?`,
+		formatHeartbeatTime(nextDue), name)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return errors.New("pipeline " + name + " not found")
+	}
+	return nil
+}
+
 // scanPipeline reads one pipelines row (from *sql.Row or *sql.Rows) into a
 // Pipeline, decoding the integer enabled flag and the RFC3339 text timestamps.
 func scanPipeline(row interface{ Scan(...any) error }) (Pipeline, error) {

--- a/internal/db/pipeline_run.go
+++ b/internal/db/pipeline_run.go
@@ -1,0 +1,328 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+// PipelineRun is one row of pipeline_runs (#681): a single execution of a named
+// pipeline. It snapshots SpecHash so the advancer executes the spec content the
+// run was created from (resolved back through the pipelines row and hash-verified,
+// not stored twice). State is the run-level advancement state; HaltStage/
+// HaltReason name the stage that parked a blocked/failed run and NeedsJSON carries
+// the aggregated blocked needs verbatim. Times are RFC3339Nano UTC (zero == empty
+// text), mirroring the pipelines/heartbeat_state schedule columns.
+type PipelineRun struct {
+	ID         string
+	Pipeline   string
+	Trigger    string
+	SpecHash   string
+	State      string
+	HaltStage  string
+	HaltReason string
+	NeedsJSON  string
+	StartedAt  time.Time
+	FinishedAt time.Time
+}
+
+// PipelineRunStage is one row of pipeline_run_stages (#681): the advancement state
+// of a single stage within a run, keyed by (RunID, StageID). JobID is the stage
+// job the advancer enqueued (empty until enqueued or after a retry reset), Attempt
+// is the current attempt number (the deterministic stage job id embeds it),
+// NeedsJSON persists a blocked stage's needs verbatim, and Summary is the settling
+// result's short summary (or the failure reason).
+type PipelineRunStage struct {
+	RunID      string
+	StageID    string
+	State      string
+	JobID      string
+	Attempt    int
+	NeedsJSON  string
+	Summary    string
+	StartedAt  time.Time
+	FinishedAt time.Time
+}
+
+// CreatePipelineRun inserts a new run row. The caller supplies the id (a
+// deterministic manual/schedule run id); a duplicate id is an error so a
+// double-create is caught rather than silently overwriting an in-flight run.
+func (s *Store) CreatePipelineRun(ctx context.Context, run PipelineRun) error {
+	run.ID = strings.TrimSpace(run.ID)
+	run.Pipeline = strings.TrimSpace(run.Pipeline)
+	if run.ID == "" {
+		return errors.New("pipeline run id is required")
+	}
+	if run.Pipeline == "" {
+		return errors.New("pipeline run pipeline is required")
+	}
+	if strings.TrimSpace(run.State) == "" {
+		run.State = "running"
+	}
+	if strings.TrimSpace(run.Trigger) == "" {
+		run.Trigger = "manual"
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO pipeline_runs(id, pipeline, trigger, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		run.ID, run.Pipeline, strings.TrimSpace(run.Trigger), strings.TrimSpace(run.SpecHash),
+		strings.TrimSpace(run.State), strings.TrimSpace(run.HaltStage), run.HaltReason, run.NeedsJSON,
+		formatHeartbeatTime(run.StartedAt), formatHeartbeatTime(run.FinishedAt))
+	return err
+}
+
+// GetPipelineRun returns one run by id. A missing row is NOT an error: it returns
+// ok=false so callers can print a friendly "not found".
+func (s *Store) GetPipelineRun(ctx context.Context, id string) (PipelineRun, bool, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return PipelineRun{}, false, errors.New("pipeline run id is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT id, pipeline, trigger, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at
+		FROM pipeline_runs WHERE id = ?`, id)
+	run, err := scanPipelineRun(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PipelineRun{}, false, nil
+	}
+	if err != nil {
+		return PipelineRun{}, false, err
+	}
+	return run, true, nil
+}
+
+// ListPipelineRuns returns every run for a pipeline, newest first (by started_at
+// then id). It is used by the run listing / overlap inspection.
+func (s *Store) ListPipelineRuns(ctx context.Context, pipeline string) ([]PipelineRun, error) {
+	pipeline = strings.TrimSpace(pipeline)
+	if pipeline == "" {
+		return nil, errors.New("pipeline name is required")
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT id, pipeline, trigger, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at
+		FROM pipeline_runs WHERE pipeline = ? ORDER BY started_at DESC, id DESC`, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var runs []PipelineRun
+	for rows.Next() {
+		run, err := scanPipelineRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, run)
+	}
+	return runs, rows.Err()
+}
+
+// ActivePipelineRun returns the single in-flight (state='running') run for a
+// pipeline, if any. It backs the "one active run per pipeline" overlap guard (a
+// run parks or finishes before another may start). If more than one ever exists
+// (should not, given the guard), the newest is returned.
+func (s *Store) ActivePipelineRun(ctx context.Context, pipeline string) (PipelineRun, bool, error) {
+	pipeline = strings.TrimSpace(pipeline)
+	if pipeline == "" {
+		return PipelineRun{}, false, errors.New("pipeline name is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT id, pipeline, trigger, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at
+		FROM pipeline_runs WHERE pipeline = ? AND state = 'running' ORDER BY started_at DESC, id DESC LIMIT 1`, pipeline)
+	run, err := scanPipelineRun(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PipelineRun{}, false, nil
+	}
+	if err != nil {
+		return PipelineRun{}, false, err
+	}
+	return run, true, nil
+}
+
+// ListActivePipelineRuns returns every in-flight (state='running') run across all
+// pipelines. It is the scan-based advancer's entry query: only running runs are
+// advanced, so a parked (blocked/failed) or terminal run consumes zero compute
+// until it is resumed.
+func (s *Store) ListActivePipelineRuns(ctx context.Context) ([]PipelineRun, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, pipeline, trigger, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at
+		FROM pipeline_runs WHERE state = 'running' ORDER BY started_at, id`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var runs []PipelineRun
+	for rows.Next() {
+		run, err := scanPipelineRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, run)
+	}
+	return runs, rows.Err()
+}
+
+// UpdatePipelineRun writes a run's mutable advancement fields (state, halt
+// stage/reason, needs, finished_at) in place. The immutable identity — id,
+// pipeline, trigger, spec_hash, started_at — is never changed. It returns an error
+// if no run matched the id so a lost row surfaces rather than silently no-op'ing.
+func (s *Store) UpdatePipelineRun(ctx context.Context, run PipelineRun) error {
+	run.ID = strings.TrimSpace(run.ID)
+	if run.ID == "" {
+		return errors.New("pipeline run id is required")
+	}
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE pipeline_runs SET state = ?, halt_stage = ?, halt_reason = ?, needs_json = ?, finished_at = ?
+			WHERE id = ?`,
+		strings.TrimSpace(run.State), strings.TrimSpace(run.HaltStage), run.HaltReason, run.NeedsJSON,
+		formatHeartbeatTime(run.FinishedAt), run.ID)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return errors.New("pipeline run " + run.ID + " not found")
+	}
+	return nil
+}
+
+// CreatePipelineRunStage inserts one stage row for a run. The (run_id, stage_id)
+// pair is the primary key, so a duplicate is an error (the run-creation path
+// inserts each stage exactly once).
+func (s *Store) CreatePipelineRunStage(ctx context.Context, stage PipelineRunStage) error {
+	stage.RunID = strings.TrimSpace(stage.RunID)
+	stage.StageID = strings.TrimSpace(stage.StageID)
+	if stage.RunID == "" || stage.StageID == "" {
+		return errors.New("pipeline run stage run id and stage id are required")
+	}
+	if strings.TrimSpace(stage.State) == "" {
+		stage.State = "pending"
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO pipeline_run_stages(run_id, stage_id, state, job_id, attempt, needs_json, summary, started_at, finished_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		stage.RunID, stage.StageID, strings.TrimSpace(stage.State), strings.TrimSpace(stage.JobID), stage.Attempt,
+		stage.NeedsJSON, stage.Summary, formatHeartbeatTime(stage.StartedAt), formatHeartbeatTime(stage.FinishedAt))
+	return err
+}
+
+// ListPipelineRunStages returns every stage row for a run, ordered by stage_id
+// (the funnel view reorders them into spec/DAG order). It is the advancer's fold
+// input and the funnel's data source.
+func (s *Store) ListPipelineRunStages(ctx context.Context, runID string) ([]PipelineRunStage, error) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return nil, errors.New("pipeline run id is required")
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT run_id, stage_id, state, job_id, attempt, needs_json, summary, started_at, finished_at
+		FROM pipeline_run_stages WHERE run_id = ? ORDER BY stage_id`, runID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var stages []PipelineRunStage
+	for rows.Next() {
+		stage, err := scanPipelineRunStage(rows)
+		if err != nil {
+			return nil, err
+		}
+		stages = append(stages, stage)
+	}
+	return stages, rows.Err()
+}
+
+// GetPipelineRunStage returns one stage row by (run_id, stage_id). A missing row
+// is NOT an error (ok=false).
+func (s *Store) GetPipelineRunStage(ctx context.Context, runID, stageID string) (PipelineRunStage, bool, error) {
+	runID = strings.TrimSpace(runID)
+	stageID = strings.TrimSpace(stageID)
+	if runID == "" || stageID == "" {
+		return PipelineRunStage{}, false, errors.New("pipeline run id and stage id are required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT run_id, stage_id, state, job_id, attempt, needs_json, summary, started_at, finished_at
+		FROM pipeline_run_stages WHERE run_id = ? AND stage_id = ?`, runID, stageID)
+	stage, err := scanPipelineRunStage(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PipelineRunStage{}, false, nil
+	}
+	if err != nil {
+		return PipelineRunStage{}, false, err
+	}
+	return stage, true, nil
+}
+
+// UpdatePipelineRunStage writes a stage's mutable fields (state, job id, attempt,
+// needs, summary, started/finished) in place, keyed by (run_id, stage_id). It
+// returns an error if no stage row matched so a lost row surfaces.
+func (s *Store) UpdatePipelineRunStage(ctx context.Context, stage PipelineRunStage) error {
+	stage.RunID = strings.TrimSpace(stage.RunID)
+	stage.StageID = strings.TrimSpace(stage.StageID)
+	if stage.RunID == "" || stage.StageID == "" {
+		return errors.New("pipeline run stage run id and stage id are required")
+	}
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE pipeline_run_stages SET state = ?, job_id = ?, attempt = ?, needs_json = ?, summary = ?, started_at = ?, finished_at = ?
+			WHERE run_id = ? AND stage_id = ?`,
+		strings.TrimSpace(stage.State), strings.TrimSpace(stage.JobID), stage.Attempt, stage.NeedsJSON, stage.Summary,
+		formatHeartbeatTime(stage.StartedAt), formatHeartbeatTime(stage.FinishedAt), stage.RunID, stage.StageID)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return errors.New("pipeline run stage " + stage.RunID + "/" + stage.StageID + " not found")
+	}
+	return nil
+}
+
+// UpdatePipelineLastRun records a pipeline's most recent run bookkeeping
+// (last_run_id + last_status), and — when at is non-zero — last_run_at. It leaves
+// the schedule's next_due_at and the spec/enabled fields untouched, so it is safe
+// to call both when a run starts (`pipeline run`) and when the advancer settles a
+// run to a terminal state. A missing pipeline row is NOT an error: a run outlives a
+// removed pipeline, and the bookkeeping is best-effort observability.
+func (s *Store) UpdatePipelineLastRun(ctx context.Context, name, runID, status string, at time.Time) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("pipeline name is required")
+	}
+	if at.IsZero() {
+		_, err := s.db.ExecContext(ctx,
+			`UPDATE pipelines SET last_run_id = ?, last_status = ?, updated_at = CURRENT_TIMESTAMP WHERE name = ?`,
+			strings.TrimSpace(runID), strings.TrimSpace(status), name)
+		return err
+	}
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE pipelines SET last_run_at = ?, last_run_id = ?, last_status = ?, updated_at = CURRENT_TIMESTAMP WHERE name = ?`,
+		formatHeartbeatTime(at), strings.TrimSpace(runID), strings.TrimSpace(status), name)
+	return err
+}
+
+func scanPipelineRun(row interface{ Scan(...any) error }) (PipelineRun, error) {
+	var (
+		run                PipelineRun
+		startedAt, finished string
+	)
+	if err := row.Scan(&run.ID, &run.Pipeline, &run.Trigger, &run.SpecHash, &run.State,
+		&run.HaltStage, &run.HaltReason, &run.NeedsJSON, &startedAt, &finished); err != nil {
+		return PipelineRun{}, err
+	}
+	run.StartedAt = parseHeartbeatTime(startedAt)
+	run.FinishedAt = parseHeartbeatTime(finished)
+	return run, nil
+}
+
+func scanPipelineRunStage(row interface{ Scan(...any) error }) (PipelineRunStage, error) {
+	var (
+		stage               PipelineRunStage
+		startedAt, finished string
+	)
+	if err := row.Scan(&stage.RunID, &stage.StageID, &stage.State, &stage.JobID, &stage.Attempt,
+		&stage.NeedsJSON, &stage.Summary, &startedAt, &finished); err != nil {
+		return PipelineRunStage{}, err
+	}
+	stage.StartedAt = parseHeartbeatTime(startedAt)
+	stage.FinishedAt = parseHeartbeatTime(finished)
+	return stage, nil
+}

--- a/internal/db/pipeline_run_test.go
+++ b/internal/db/pipeline_run_test.go
@@ -1,0 +1,214 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func sampleRun(id string) PipelineRun {
+	return PipelineRun{
+		ID:        id,
+		Pipeline:  "deploy-flow",
+		Trigger:   "manual",
+		SpecHash:  "hash-1",
+		State:     "running",
+		StartedAt: time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestPipelineRunCRUD proves the run row round-trips and its mutable advancement
+// fields update in place while identity stays fixed.
+func TestPipelineRunCRUD(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+
+	if _, ok, err := store.GetPipelineRun(ctx, "prun-x"); err != nil || ok {
+		t.Fatalf("expected no run yet: ok=%v err=%v", ok, err)
+	}
+	run := sampleRun("prun-1")
+	if err := store.CreatePipelineRun(ctx, run); err != nil {
+		t.Fatalf("CreatePipelineRun: %v", err)
+	}
+	// Duplicate id is rejected.
+	if err := store.CreatePipelineRun(ctx, run); err == nil {
+		t.Fatalf("expected duplicate run id to error")
+	}
+
+	got, ok, err := store.GetPipelineRun(ctx, "prun-1")
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineRun: ok=%v err=%v", ok, err)
+	}
+	if got.Pipeline != "deploy-flow" || got.Trigger != "manual" || got.SpecHash != "hash-1" || got.State != "running" {
+		t.Fatalf("run roundtrip mismatch: %+v", got)
+	}
+	if !got.StartedAt.Equal(run.StartedAt) || !got.FinishedAt.IsZero() {
+		t.Fatalf("run times mismatch: %+v", got)
+	}
+
+	// Park it: state + halt + needs + finished update; identity is untouched.
+	finished := time.Date(2026, 7, 6, 9, 5, 0, 0, time.UTC)
+	got.State = "blocked"
+	got.HaltStage = "score"
+	got.HaltReason = "needs a secret"
+	got.NeedsJSON = `["R2 token"]`
+	got.FinishedAt = finished
+	if err := store.UpdatePipelineRun(ctx, got); err != nil {
+		t.Fatalf("UpdatePipelineRun: %v", err)
+	}
+	reloaded, _, _ := store.GetPipelineRun(ctx, "prun-1")
+	if reloaded.State != "blocked" || reloaded.HaltStage != "score" || reloaded.NeedsJSON != `["R2 token"]` {
+		t.Fatalf("park state mismatch: %+v", reloaded)
+	}
+	if !reloaded.FinishedAt.Equal(finished) {
+		t.Fatalf("finished_at mismatch: %+v", reloaded)
+	}
+	if reloaded.Pipeline != "deploy-flow" || reloaded.SpecHash != "hash-1" || !reloaded.StartedAt.Equal(run.StartedAt) {
+		t.Fatalf("update disturbed run identity: %+v", reloaded)
+	}
+
+	if err := store.UpdatePipelineRun(ctx, PipelineRun{ID: "prun-missing", State: "failed"}); err == nil {
+		t.Fatalf("expected UpdatePipelineRun on missing id to error")
+	}
+}
+
+// TestPipelineRunListingAndActive proves the listing / overlap-guard queries: runs
+// list newest-first per pipeline, ActivePipelineRun returns only a running run, and
+// ListActivePipelineRuns is the advancer's cross-pipeline running-run scan.
+func TestPipelineRunListingAndActive(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+
+	older := sampleRun("prun-old")
+	older.StartedAt = time.Date(2026, 7, 6, 8, 0, 0, 0, time.UTC)
+	older.State = "succeeded"
+	newer := sampleRun("prun-new")
+	newer.StartedAt = time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	other := sampleRun("prun-other")
+	other.Pipeline = "other-flow"
+	for _, r := range []PipelineRun{older, newer, other} {
+		if err := store.CreatePipelineRun(ctx, r); err != nil {
+			t.Fatalf("CreatePipelineRun(%s): %v", r.ID, err)
+		}
+	}
+
+	runs, err := store.ListPipelineRuns(ctx, "deploy-flow")
+	if err != nil || len(runs) != 2 {
+		t.Fatalf("ListPipelineRuns = %+v err=%v", runs, err)
+	}
+	if runs[0].ID != "prun-new" {
+		t.Fatalf("ListPipelineRuns not newest-first: %+v", runs)
+	}
+
+	active, ok, err := store.ActivePipelineRun(ctx, "deploy-flow")
+	if err != nil || !ok || active.ID != "prun-new" {
+		t.Fatalf("ActivePipelineRun = %+v ok=%v err=%v (want prun-new)", active, ok, err)
+	}
+
+	all, err := store.ListActivePipelineRuns(ctx)
+	if err != nil || len(all) != 2 {
+		t.Fatalf("ListActivePipelineRuns = %+v err=%v (want the 2 running runs)", all, err)
+	}
+
+	// Once the running run settles, the overlap guard clears.
+	newer.State = "failed"
+	if err := store.UpdatePipelineRun(ctx, newer); err != nil {
+		t.Fatalf("UpdatePipelineRun: %v", err)
+	}
+	if _, ok, _ := store.ActivePipelineRun(ctx, "deploy-flow"); ok {
+		t.Fatalf("ActivePipelineRun should be empty after settle")
+	}
+}
+
+// TestPipelineRunStageCRUD proves stage rows round-trip, update in place by
+// (run_id, stage_id), and list scoped to the run.
+func TestPipelineRunStageCRUD(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	if err := store.CreatePipelineRun(ctx, sampleRun("prun-1")); err != nil {
+		t.Fatalf("CreatePipelineRun: %v", err)
+	}
+
+	for _, id := range []string{"source", "score", "deploy"} {
+		if err := store.CreatePipelineRunStage(ctx, PipelineRunStage{RunID: "prun-1", StageID: id, State: "pending"}); err != nil {
+			t.Fatalf("CreatePipelineRunStage(%s): %v", id, err)
+		}
+	}
+	// A run's stages are scoped to it; a decoy run's stage must not leak.
+	if err := store.CreatePipelineRun(ctx, sampleRun("prun-2")); err != nil {
+		t.Fatalf("CreatePipelineRun 2: %v", err)
+	}
+	if err := store.CreatePipelineRunStage(ctx, PipelineRunStage{RunID: "prun-2", StageID: "source", State: "pending"}); err != nil {
+		t.Fatalf("CreatePipelineRunStage decoy: %v", err)
+	}
+
+	stages, err := store.ListPipelineRunStages(ctx, "prun-1")
+	if err != nil || len(stages) != 3 {
+		t.Fatalf("ListPipelineRunStages = %+v err=%v", stages, err)
+	}
+	// Ordered by stage_id.
+	if stages[0].StageID != "deploy" || stages[1].StageID != "score" || stages[2].StageID != "source" {
+		t.Fatalf("stages not ordered by id: %+v", stages)
+	}
+
+	started := time.Date(2026, 7, 6, 9, 1, 0, 0, time.UTC)
+	update := PipelineRunStage{RunID: "prun-1", StageID: "score", State: "blocked", JobID: "prun-1-score-a0", Attempt: 2, NeedsJSON: `["R2 token"]`, Summary: "blocked on secret", StartedAt: started}
+	if err := store.UpdatePipelineRunStage(ctx, update); err != nil {
+		t.Fatalf("UpdatePipelineRunStage: %v", err)
+	}
+	got, ok, err := store.GetPipelineRunStage(ctx, "prun-1", "score")
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineRunStage: ok=%v err=%v", ok, err)
+	}
+	if got.State != "blocked" || got.JobID != "prun-1-score-a0" || got.Attempt != 2 || got.NeedsJSON != `["R2 token"]` || got.Summary != "blocked on secret" {
+		t.Fatalf("stage update mismatch: %+v", got)
+	}
+	if !got.StartedAt.Equal(started) {
+		t.Fatalf("stage started_at mismatch: %+v", got)
+	}
+
+	if err := store.UpdatePipelineRunStage(ctx, PipelineRunStage{RunID: "prun-1", StageID: "missing", State: "failed"}); err == nil {
+		t.Fatalf("expected UpdatePipelineRunStage on missing stage to error")
+	}
+}
+
+// TestUpdatePipelineLastRun proves the last-run bookkeeping updates without
+// disturbing the schedule's next_due or the spec, and tolerates a missing pipeline.
+func TestUpdatePipelineLastRun(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	if err := store.CreateOrUpdatePipeline(ctx, samplePipeline()); err != nil {
+		t.Fatalf("CreateOrUpdatePipeline: %v", err)
+	}
+	// Seed a next_due so we can prove it is preserved.
+	due := time.Date(2026, 7, 7, 9, 0, 0, 0, time.UTC)
+	if err := store.UpdatePipelineScheduleState(ctx, PipelineScheduleState{Name: "deploy-flow", NextDueAt: due, LastStatus: "old"}); err != nil {
+		t.Fatalf("UpdatePipelineScheduleState: %v", err)
+	}
+
+	started := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	if err := store.UpdatePipelineLastRun(ctx, "deploy-flow", "prun-1", "running", started); err != nil {
+		t.Fatalf("UpdatePipelineLastRun (start): %v", err)
+	}
+	got, _, _ := store.GetPipeline(ctx, "deploy-flow")
+	if got.LastRunID != "prun-1" || got.LastStatus != "running" || !got.LastRunAt.Equal(started) {
+		t.Fatalf("start bookkeeping mismatch: %+v", got)
+	}
+	if !got.NextDueAt.Equal(due) || got.SpecHash != "abc123" {
+		t.Fatalf("last-run update clobbered schedule/spec: %+v", got)
+	}
+
+	// Terminal update (zero at) leaves last_run_at untouched.
+	if err := store.UpdatePipelineLastRun(ctx, "deploy-flow", "prun-1", "blocked", time.Time{}); err != nil {
+		t.Fatalf("UpdatePipelineLastRun (terminal): %v", err)
+	}
+	got, _, _ = store.GetPipeline(ctx, "deploy-flow")
+	if got.LastStatus != "blocked" || !got.LastRunAt.Equal(started) || !got.NextDueAt.Equal(due) {
+		t.Fatalf("terminal bookkeeping mismatch: %+v", got)
+	}
+
+	// A run outlives a removed pipeline: no error on a missing row.
+	if err := store.UpdatePipelineLastRun(ctx, "gone", "prun-1", "failed", time.Time{}); err != nil {
+		t.Fatalf("UpdatePipelineLastRun on missing pipeline should be a no-op nil: %v", err)
+	}
+}

--- a/internal/db/pipeline_test.go
+++ b/internal/db/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -158,8 +159,20 @@ func TestMigrateAddsPipelinesToUpgradedDB(t *testing.T) {
 		t.Fatalf("sql.Open: %v", err)
 	}
 	store := &Store{db: raw}
-	// Apply every migration except the last (the pipelines table).
-	for version, migration := range migrations[:len(migrations)-1] {
+	// Apply every migration BEFORE the pipelines table. Located by content so this
+	// stays correct as later steps append further migrations (the per-run/per-stage
+	// tables) after the pipelines one.
+	pipelinesIdx := -1
+	for i, m := range migrations {
+		if strings.Contains(m, "CREATE TABLE pipelines") {
+			pipelinesIdx = i
+			break
+		}
+	}
+	if pipelinesIdx < 0 {
+		t.Fatalf("pipelines migration not found")
+	}
+	for version, migration := range migrations[:pipelinesIdx] {
 		if err := store.applyMigration(ctx, version+1, migration); err != nil {
 			t.Fatalf("applyMigration(%d): %v", version+1, err)
 		}

--- a/internal/db/pipeline_test.go
+++ b/internal/db/pipeline_test.go
@@ -1,0 +1,197 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func openPipelineStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func samplePipeline() Pipeline {
+	return Pipeline{
+		Name:     "deploy-flow",
+		Repo:     "jerryfane/gitmoot",
+		SpecYAML: "name: deploy-flow\nstages:\n  - {id: a, cmd: echo}\n",
+		SpecHash: "abc123",
+		Interval: "24h",
+		Jitter:   "15m",
+	}
+}
+
+// TestPipelineFreshCRUD proves the full CRUD round-trip on a fresh (fully
+// migrated) DB: create, read back, list, toggle enabled, persist schedule state,
+// and delete.
+func TestPipelineFreshCRUD(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+
+	if _, ok, err := store.GetPipeline(ctx, "deploy-flow"); err != nil || ok {
+		t.Fatalf("expected no pipeline yet, ok=%v err=%v", ok, err)
+	}
+	if err := store.CreateOrUpdatePipeline(ctx, samplePipeline()); err != nil {
+		t.Fatalf("CreateOrUpdatePipeline: %v", err)
+	}
+	got, ok, err := store.GetPipeline(ctx, "deploy-flow")
+	if err != nil || !ok {
+		t.Fatalf("GetPipeline: ok=%v err=%v", ok, err)
+	}
+	if got.Repo != "jerryfane/gitmoot" || got.SpecHash != "abc123" || got.Interval != "24h" || got.Jitter != "15m" {
+		t.Fatalf("roundtrip mismatch: %+v", got)
+	}
+	if got.Enabled {
+		t.Fatalf("new pipeline should default disabled")
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Fatalf("timestamps not populated: %+v", got)
+	}
+
+	list, err := store.ListPipelines(ctx)
+	if err != nil || len(list) != 1 || list[0].Name != "deploy-flow" {
+		t.Fatalf("ListPipelines = %+v err=%v", list, err)
+	}
+
+	if err := store.SetPipelineEnabled(ctx, "deploy-flow", true); err != nil {
+		t.Fatalf("SetPipelineEnabled: %v", err)
+	}
+	if got, _, _ := store.GetPipeline(ctx, "deploy-flow"); !got.Enabled {
+		t.Fatalf("expected enabled after SetPipelineEnabled(true)")
+	}
+
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	due := now.Add(24 * time.Hour)
+	if err := store.UpdatePipelineScheduleState(ctx, PipelineScheduleState{
+		Name: "deploy-flow", LastRunAt: now, NextDueAt: due, LastRunID: "run-1", LastStatus: "succeeded",
+	}); err != nil {
+		t.Fatalf("UpdatePipelineScheduleState: %v", err)
+	}
+	got, _, _ = store.GetPipeline(ctx, "deploy-flow")
+	if !got.LastRunAt.Equal(now) || !got.NextDueAt.Equal(due) || got.LastRunID != "run-1" || got.LastStatus != "succeeded" {
+		t.Fatalf("schedule state mismatch: %+v", got)
+	}
+	// Schedule-state update must not disturb the spec or enabled flag.
+	if !got.Enabled || got.SpecHash != "abc123" {
+		t.Fatalf("schedule update clobbered spec/enabled: %+v", got)
+	}
+
+	deleted, err := store.DeletePipeline(ctx, "deploy-flow")
+	if err != nil || !deleted {
+		t.Fatalf("DeletePipeline: deleted=%v err=%v", deleted, err)
+	}
+	if _, ok, _ := store.GetPipeline(ctx, "deploy-flow"); ok {
+		t.Fatalf("pipeline still present after delete")
+	}
+	if deleted, _ := store.DeletePipeline(ctx, "deploy-flow"); deleted {
+		t.Fatalf("second delete reported a row")
+	}
+}
+
+// TestCreateOrUpdatePipelinePreservesEnabledAndState proves re-adding an edited
+// spec replaces the spec fields but preserves the enabled flag and the durable
+// schedule-state bookkeeping — the "a run executes its snapshot; toggling and
+// last-run state survive an edit" contract.
+func TestCreateOrUpdatePipelinePreservesEnabledAndState(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	if err := store.CreateOrUpdatePipeline(ctx, samplePipeline()); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := store.SetPipelineEnabled(ctx, "deploy-flow", true); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	now := time.Date(2026, 7, 4, 9, 0, 0, 0, time.UTC)
+	if err := store.UpdatePipelineScheduleState(ctx, PipelineScheduleState{
+		Name: "deploy-flow", LastRunAt: now, LastRunID: "run-9", LastStatus: "blocked",
+	}); err != nil {
+		t.Fatalf("schedule state: %v", err)
+	}
+
+	edited := samplePipeline()
+	edited.SpecYAML = "name: deploy-flow\nstages:\n  - {id: a, cmd: echo2}\n"
+	edited.SpecHash = "def456"
+	edited.Interval = "12h"
+	if err := store.CreateOrUpdatePipeline(ctx, edited); err != nil {
+		t.Fatalf("re-add: %v", err)
+	}
+	got, _, _ := store.GetPipeline(ctx, "deploy-flow")
+	if got.SpecHash != "def456" || got.Interval != "12h" {
+		t.Fatalf("spec fields not updated on re-add: %+v", got)
+	}
+	if !got.Enabled {
+		t.Fatalf("re-add clobbered the enabled flag")
+	}
+	if got.LastRunID != "run-9" || got.LastStatus != "blocked" || !got.LastRunAt.Equal(now) {
+		t.Fatalf("re-add clobbered schedule state: %+v", got)
+	}
+}
+
+func TestPipelineNotFoundErrors(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	if err := store.SetPipelineEnabled(ctx, "ghost", true); err == nil {
+		t.Fatalf("SetPipelineEnabled on missing pipeline should error")
+	}
+	if err := store.UpdatePipelineScheduleState(ctx, PipelineScheduleState{Name: "ghost"}); err == nil {
+		t.Fatalf("UpdatePipelineScheduleState on missing pipeline should error")
+	}
+}
+
+// TestMigrateAddsPipelinesToUpgradedDB proves the pipelines table is a clean
+// additive append: an existing DB migrated up to (but not including) the
+// pipelines migration, carrying a legacy row in a prior table, gains a working
+// pipelines table on the next Open while the legacy row still reads back.
+func TestMigrateAddsPipelinesToUpgradedDB(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	store := &Store{db: raw}
+	// Apply every migration except the last (the pipelines table).
+	for version, migration := range migrations[:len(migrations)-1] {
+		if err := store.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("applyMigration(%d): %v", version+1, err)
+		}
+	}
+	// The pipelines table must not exist yet.
+	if _, err := raw.ExecContext(ctx, `SELECT name FROM pipelines`); err == nil {
+		t.Fatalf("pipelines table exists before its migration")
+	}
+	// Seed a legacy row in a long-standing table.
+	if _, err := raw.ExecContext(ctx, `INSERT INTO agents(name, role, runtime, runtime_ref, repo_scope)
+		VALUES ('legacy', 'planner', 'codex', '', '')`); err != nil {
+		t.Fatalf("insert legacy agent: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw: %v", err)
+	}
+
+	upgraded, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open upgraded DB: %v", err)
+	}
+	defer upgraded.Close()
+
+	// The legacy row survives.
+	if _, err := upgraded.GetAgent(ctx, "legacy"); err != nil {
+		t.Fatalf("legacy agent lost after upgrade: %v", err)
+	}
+	// The freshly migrated pipelines table works.
+	if err := upgraded.CreateOrUpdatePipeline(ctx, samplePipeline()); err != nil {
+		t.Fatalf("CreateOrUpdatePipeline on upgraded DB: %v", err)
+	}
+	if _, ok, err := upgraded.GetPipeline(ctx, "deploy-flow"); err != nil || !ok {
+		t.Fatalf("GetPipeline on upgraded DB: ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -7787,4 +7787,46 @@ CREATE TABLE pipelines (
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 	`,
+	// #681 pipeline runs + stages: the per-run execution state the scan-based
+	// advancer folds and drives. A pipeline_runs row is one execution of a
+	// pipeline; it snapshots spec_hash so a run always executes the spec content it
+	// was created from (the pipelines row's spec_yaml is resolved back and its hash
+	// verified against this column). pipeline_run_stages holds one row per stage of
+	// that run, keyed by (run_id, stage_id): the stage's advancement state, the job
+	// id the advancer enqueued for it, the current attempt (deterministic stage job
+	// ids embed it), the blocked needs persisted verbatim, and a short summary.
+	// Pure additive append (CREATE TABLE/INDEX only): both tables stay empty until
+	// `gitmoot pipeline run` creates a run, so every existing DB reads identically.
+	// idx_pipeline_run_stages_run_id backs the per-run stage fold
+	// (ListPipelineRunStages). Times are RFC3339Nano UTC text (empty == zero),
+	// mirroring the pipelines/heartbeat_state schedule columns.
+	`
+CREATE TABLE pipeline_runs (
+	id TEXT PRIMARY KEY,
+	pipeline TEXT NOT NULL DEFAULT '',
+	trigger TEXT NOT NULL DEFAULT 'manual',
+	spec_hash TEXT NOT NULL DEFAULT '',
+	state TEXT NOT NULL DEFAULT 'running',
+	halt_stage TEXT NOT NULL DEFAULT '',
+	halt_reason TEXT NOT NULL DEFAULT '',
+	needs_json TEXT NOT NULL DEFAULT '',
+	started_at TEXT NOT NULL DEFAULT '',
+	finished_at TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE pipeline_run_stages (
+	run_id TEXT NOT NULL,
+	stage_id TEXT NOT NULL,
+	state TEXT NOT NULL DEFAULT 'pending',
+	job_id TEXT NOT NULL DEFAULT '',
+	attempt INTEGER NOT NULL DEFAULT 0,
+	needs_json TEXT NOT NULL DEFAULT '',
+	summary TEXT NOT NULL DEFAULT '',
+	started_at TEXT NOT NULL DEFAULT '',
+	finished_at TEXT NOT NULL DEFAULT '',
+	PRIMARY KEY (run_id, stage_id)
+);
+
+CREATE INDEX idx_pipeline_run_stages_run_id ON pipeline_run_stages(run_id);
+	`,
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -7761,4 +7761,30 @@ CREATE TABLE job_gates (
 );
 CREATE INDEX idx_job_gates_job ON job_gates(job_id);
 	`,
+	// #681 pipeline registry: one row per named pipeline holding the verbatim spec
+	// YAML + its content hash (a run snapshots the hash it was created from), the
+	// interval/jitter schedule fields (heartbeat idiom), and the durable schedule
+	// state (last_run_at/next_due_at/last_run_id/last_status) that makes an
+	// interval schedule restart-safe. name is the primary key and the stem of the
+	// pipeline's hidden shell runner agent. Pure additive append (CREATE TABLE
+	// only): the table stays empty until `gitmoot pipeline add` runs, so every
+	// existing DB reads identically. The per-run and per-stage tables are separate
+	// additive migrations appended by the run/advancer step.
+	`
+CREATE TABLE pipelines (
+	name TEXT PRIMARY KEY,
+	repo TEXT NOT NULL DEFAULT '',
+	spec_yaml TEXT NOT NULL DEFAULT '',
+	spec_hash TEXT NOT NULL DEFAULT '',
+	enabled INTEGER NOT NULL DEFAULT 0,
+	interval TEXT NOT NULL DEFAULT '',
+	jitter TEXT NOT NULL DEFAULT '',
+	last_run_at TEXT NOT NULL DEFAULT '',
+	next_due_at TEXT NOT NULL DEFAULT '',
+	last_run_id TEXT NOT NULL DEFAULT '',
+	last_status TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+	`,
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,184 @@
+package pipeline
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const validSpec = `
+name: deploy-flow
+repo: jerryfane/gitmoot
+schedule:
+  interval: 24h
+  jitter: 15m
+success_decisions: [approved, implemented]
+stages:
+  - id: source
+    cmd: git fetch --all
+  - id: score
+    cmd: ./score.sh
+    needs: [source]
+    timeout: 10m
+    retry: 2
+  - id: deploy
+    cmd: ./deploy.sh
+    needs: [score]
+    success_decisions: [approved]
+`
+
+func TestLoadValidSpec(t *testing.T) {
+	spec, err := Load([]byte(validSpec))
+	if err != nil {
+		t.Fatalf("Load valid spec: %v", err)
+	}
+	if spec.Name != "deploy-flow" || spec.Repo != "jerryfane/gitmoot" {
+		t.Fatalf("unexpected header: %+v", spec)
+	}
+	if spec.Schedule == nil || spec.Schedule.Interval != "24h" || spec.Schedule.Jitter != "15m" {
+		t.Fatalf("unexpected schedule: %+v", spec.Schedule)
+	}
+	if len(spec.Stages) != 3 {
+		t.Fatalf("stages = %d, want 3", len(spec.Stages))
+	}
+	if spec.Stages[1].ID != "score" || spec.Stages[1].Retry != 2 || spec.Stages[1].Timeout != "10m" {
+		t.Fatalf("unexpected score stage: %+v", spec.Stages[1])
+	}
+	if !reflect.DeepEqual(spec.Stages[1].Needs, []string{"source"}) {
+		t.Fatalf("score needs = %v", spec.Stages[1].Needs)
+	}
+}
+
+func TestLoadValidationErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    string
+		wantSub string
+	}{
+		{
+			name:    "missing name",
+			spec:    "stages:\n  - {id: a, cmd: echo}\n",
+			wantSub: "pipeline name is required",
+		},
+		{
+			name:    "bad name",
+			spec:    "name: bad name\nstages:\n  - {id: a, cmd: echo}\n",
+			wantSub: "name-safe token",
+		},
+		{
+			name:    "no stages",
+			spec:    "name: p\n",
+			wantSub: "has no stages",
+		},
+		{
+			name:    "duplicate id",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: a, cmd: echo}\n",
+			wantSub: `stage id "a" is not unique`,
+		},
+		{
+			name:    "missing cmd",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: \"\"}\n",
+			wantSub: `stage "a" has no cmd`,
+		},
+		{
+			name:    "unknown need",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, needs: [zzz]}\n",
+			wantSub: `references unknown need "zzz"`,
+		},
+		{
+			name:    "self dependency",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, needs: [a]}\n",
+			wantSub: `stage "a" depends on itself`,
+		},
+		{
+			name:    "cycle",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, needs: [b]}\n  - {id: b, cmd: echo, needs: [a]}\n",
+			wantSub: "dependency cycle",
+		},
+		{
+			name:    "bad timeout",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, timeout: nope}\n",
+			wantSub: `timeout "nope" is invalid`,
+		},
+		{
+			name:    "non-positive timeout",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, timeout: 0s}\n",
+			wantSub: "must be positive",
+		},
+		{
+			name:    "negative retry",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, retry: -1}\n",
+			wantSub: "retry must be >= 0",
+		},
+		{
+			name:    "bad success decision",
+			spec:    "name: p\nsuccess_decisions: [blocked]\nstages:\n  - {id: a, cmd: echo}\n",
+			wantSub: `success_decisions "blocked" is invalid`,
+		},
+		{
+			name:    "schedule without interval",
+			spec:    "name: p\nschedule:\n  jitter: 5m\nstages:\n  - {id: a, cmd: echo}\n",
+			wantSub: "schedule requires an interval",
+		},
+		{
+			name:    "bad schedule interval",
+			spec:    "name: p\nschedule:\n  interval: soon\nstages:\n  - {id: a, cmd: echo}\n",
+			wantSub: `interval "soon" is invalid`,
+		},
+		{
+			name:    "unknown field",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, need: [b]}\n",
+			wantSub: "field need not found",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load([]byte(tc.spec))
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q does not contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestHashDeterministicAndSensitive(t *testing.T) {
+	a := []byte("name: p\nstages:\n  - {id: a, cmd: echo}\n")
+	b := []byte("name: p\nstages:\n  - {id: a, cmd: echo}\n")
+	c := []byte("name: p\nstages:\n  - {id: a, cmd: echo2}\n")
+	if Hash(a) != Hash(b) {
+		t.Fatalf("identical bytes hashed differently")
+	}
+	if Hash(a) == Hash(c) {
+		t.Fatalf("different bytes hashed identically")
+	}
+	if len(Hash(a)) != 64 {
+		t.Fatalf("hash length = %d, want 64 hex chars", len(Hash(a)))
+	}
+}
+
+func TestEffectiveSuccessDecisions(t *testing.T) {
+	spec := Spec{SuccessDecisions: []string{"approved"}}
+	// Stage override wins.
+	got := spec.EffectiveSuccessDecisions(Stage{SuccessDecisions: []string{"changes_requested"}})
+	if !reflect.DeepEqual(got, []string{"changes_requested"}) {
+		t.Fatalf("stage override = %v", got)
+	}
+	// Top-level override when the stage has none.
+	got = spec.EffectiveSuccessDecisions(Stage{})
+	if !reflect.DeepEqual(got, []string{"approved"}) {
+		t.Fatalf("top-level override = %v", got)
+	}
+	// Package default when neither is set.
+	got = Spec{}.EffectiveSuccessDecisions(Stage{})
+	if !reflect.DeepEqual(got, DefaultSuccessDecisions) {
+		t.Fatalf("default = %v, want %v", got, DefaultSuccessDecisions)
+	}
+	// The returned slice is a copy — mutating it must not corrupt the defaults.
+	got[0] = "mutated"
+	if DefaultSuccessDecisions[0] == "mutated" {
+		t.Fatalf("EffectiveSuccessDecisions leaked the shared default slice")
+	}
+}

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -1,0 +1,119 @@
+// Package pipeline defines the declarative spec for the #681 pipeline primitive:
+// a small DAG of shell stages plus an optional interval schedule. A spec is
+// loaded from a YAML file by `gitmoot pipeline add`, validated structurally, and
+// stored VERBATIM in the DB (the raw bytes + a content hash). Each run snapshots
+// the content hash it was created from, so a run always executes the spec it was
+// created against — not the file's (or the row's) later state. The package is a
+// leaf: it depends only on the standard library and gopkg.in/yaml.v3, so the CLI
+// and the (later) advancer can both parse/validate without importing the engine.
+package pipeline
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// DefaultSuccessDecisions are the gitmoot_result decisions that, absent an
+// explicit override, mark a pipeline stage succeeded. They mirror the
+// gitmoot_result contract's "the work landed" terminal decisions. blocked and
+// failed are deliberately NOT here: the advancer treats them as park states, so
+// they can never mean success (see SuccessDecisionCandidates).
+var DefaultSuccessDecisions = []string{"approved", "implemented"}
+
+// SuccessDecisionCandidates are the gitmoot_result decisions a spec MAY list in
+// success_decisions (top-level or per-stage). It is the subset of the contract's
+// ResultDecisions that can plausibly mean "this stage succeeded": blocked and
+// failed are excluded because the advancer treats them as park states, so listing
+// either as a success would contradict the advance semantics.
+var SuccessDecisionCandidates = []string{"approved", "implemented", "changes_requested"}
+
+// Spec is the parsed, validated declaration of a pipeline.
+type Spec struct {
+	// Name is the pipeline's stable identifier (the DB primary key and the stem of
+	// its hidden shell runner agent name). Must be a name-safe token.
+	Name string `yaml:"name"`
+	// Repo is the optional managed repo (owner/repo) the stages run against. It is
+	// carried onto the run's stage jobs and the runner agent's repo scope.
+	Repo string `yaml:"repo,omitempty"`
+	// Schedule, when present, drives interval-based auto-runs (heartbeat idiom: an
+	// interval plus optional jitter; no cron in v1).
+	Schedule *Schedule `yaml:"schedule,omitempty"`
+	// SuccessDecisions overrides DefaultSuccessDecisions for every stage that does
+	// not set its own. Empty means DefaultSuccessDecisions.
+	SuccessDecisions []string `yaml:"success_decisions,omitempty"`
+	// Stages is the DAG of shell stages, keyed by unique id and wired by needs.
+	Stages []Stage `yaml:"stages"`
+}
+
+// Schedule is the interval-based auto-run cadence for a pipeline.
+type Schedule struct {
+	// Interval is the base cadence (e.g. "24h"); required when a schedule block is
+	// present and must parse as a positive Go duration.
+	Interval string `yaml:"interval,omitempty"`
+	// Jitter is an optional random delay added to each interval (e.g. "15m"); must
+	// parse as a non-negative duration when set.
+	Jitter string `yaml:"jitter,omitempty"`
+}
+
+// Stage is one shell step in the pipeline DAG.
+type Stage struct {
+	// ID is the stage's unique, name-safe identifier. It appears verbatim in the
+	// stage job fingerprint and deterministic job id, so it must be a safe token.
+	ID string `yaml:"id"`
+	// Cmd is the shell command run verbatim via `sh -c` (required).
+	Cmd string `yaml:"cmd"`
+	// Needs lists the ids of stages that must succeed before this stage is enqueued.
+	Needs []string `yaml:"needs,omitempty"`
+	// Timeout optionally bounds the stage job (a positive Go duration when set).
+	Timeout string `yaml:"timeout,omitempty"`
+	// Retry is how many times a failed stage may be re-attempted (>= 0).
+	Retry int `yaml:"retry,omitempty"`
+	// SuccessDecisions optionally overrides the pipeline default for this stage.
+	SuccessDecisions []string `yaml:"success_decisions,omitempty"`
+}
+
+// Load parses raw YAML into a Spec, normalizes it, and validates it. Unknown
+// fields are rejected (KnownFields) so a typo'd key surfaces as an error at
+// `pipeline add` time rather than being silently ignored. The returned Spec is
+// safe to persist; the raw bytes are what get stored verbatim (see Hash).
+func Load(raw []byte) (Spec, error) {
+	var spec Spec
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	if err := dec.Decode(&spec); err != nil {
+		return Spec{}, fmt.Errorf("parse pipeline spec: %w", err)
+	}
+	spec.normalize()
+	if err := spec.Validate(); err != nil {
+		return Spec{}, err
+	}
+	return spec, nil
+}
+
+// Hash returns the hex-encoded SHA-256 of the verbatim spec bytes. It is stored
+// alongside the YAML and snapshotted onto each run so a run can be tied to the
+// exact spec content it was created from (editing the file — even whitespace —
+// changes the hash, which is intentional: a run executes its snapshot).
+func Hash(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// EffectiveSuccessDecisions returns the decisions that mark the given stage
+// succeeded: the stage's own success_decisions if set, else the pipeline
+// top-level override if set, else DefaultSuccessDecisions. The result is always a
+// fresh non-empty slice (a defensive copy), so callers may retain it freely.
+func (s Spec) EffectiveSuccessDecisions(stage Stage) []string {
+	switch {
+	case len(stage.SuccessDecisions) > 0:
+		return append([]string(nil), stage.SuccessDecisions...)
+	case len(s.SuccessDecisions) > 0:
+		return append([]string(nil), s.SuccessDecisions...)
+	default:
+		return append([]string(nil), DefaultSuccessDecisions...)
+	}
+}

--- a/internal/pipeline/state.go
+++ b/internal/pipeline/state.go
@@ -1,0 +1,39 @@
+package pipeline
+
+// The run/stage state vocabulary the #681 advancer drives. They are stored
+// verbatim in pipeline_runs.state and pipeline_run_stages.state (raw strings; the
+// DB does not enum them) and interpreted by the scan-based advancer + the text
+// funnel. Kept in this leaf package so the advancer, the CLI funnel, and tests
+// share one source of truth without importing the engine.
+
+// Run states. A run is RunRunning until nothing is in flight, then settles to
+// exactly one terminal state: RunSucceeded (every stage succeeded or skipped),
+// RunBlocked (a stage returned decision "blocked" — parked, needs persisted),
+// RunFailed (a stage failed past its retry budget — parked, halt_reason set), or
+// RunCancelled (operator cancel; the cancel/resume CLI lands in a later step).
+const (
+	RunRunning   = "running"
+	RunSucceeded = "succeeded"
+	RunBlocked   = "blocked"
+	RunFailed    = "failed"
+	RunCancelled = "cancelled"
+)
+
+// Stage states. A stage starts StagePending, becomes StageQueued when the
+// advancer enqueues its job, StageRunning while that job runs, then settles by
+// the job's gitmoot_result DECISION (never jobs.state — changes_requested is a
+// SUCCEEDED job that must NOT advance): StageSucceeded (decision in the stage's
+// success_decisions), StageBlocked (decision "blocked"), or StageFailed (decision
+// "failed"/changes_requested/other, a job error, or a retry budget exhausted). A
+// pending stage whose deps can never all succeed becomes StageSkipped.
+// StageCancelled mirrors a cancelled stage job (later step).
+const (
+	StagePending   = "pending"
+	StageQueued    = "queued"
+	StageRunning   = "running"
+	StageSucceeded = "succeeded"
+	StageBlocked   = "blocked"
+	StageFailed    = "failed"
+	StageSkipped   = "skipped"
+	StageCancelled = "cancelled"
+)

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -1,0 +1,239 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// normalize trims surrounding whitespace off every free-text field so validation
+// and storage see canonical values. It does NOT lowercase or otherwise rewrite
+// ids/commands — the raw YAML is what gets stored and hashed; normalize only
+// affects the parsed Spec used for validation and downstream advancement.
+func (s *Spec) normalize() {
+	s.Name = strings.TrimSpace(s.Name)
+	s.Repo = strings.TrimSpace(s.Repo)
+	if s.Schedule != nil {
+		s.Schedule.Interval = strings.TrimSpace(s.Schedule.Interval)
+		s.Schedule.Jitter = strings.TrimSpace(s.Schedule.Jitter)
+	}
+	s.SuccessDecisions = trimAll(s.SuccessDecisions)
+	for i := range s.Stages {
+		s.Stages[i].ID = strings.TrimSpace(s.Stages[i].ID)
+		s.Stages[i].Cmd = strings.TrimSpace(s.Stages[i].Cmd)
+		s.Stages[i].Timeout = strings.TrimSpace(s.Stages[i].Timeout)
+		s.Stages[i].Needs = trimAll(s.Stages[i].Needs)
+		s.Stages[i].SuccessDecisions = trimAll(s.Stages[i].SuccessDecisions)
+	}
+}
+
+// Validate enforces the structural invariants of a pipeline spec: a name-safe
+// pipeline name, at least one stage, unique name-safe stage ids, a required cmd
+// per stage, needs that reference known sibling ids (never the stage itself),
+// a needs graph with no cycle, parseable positive timeouts, non-negative retry,
+// a valid schedule, and success_decisions drawn from SuccessDecisionCandidates.
+// It mirrors the shape of the delegation graph validator (workflow/result.go):
+// catching these at parse time turns what would otherwise be a stuck run (unknown
+// deps and cycles are permanently unsatisfiable) into a clean error at add time.
+func (s Spec) Validate() error {
+	if s.Name == "" {
+		return fmt.Errorf("pipeline name is required")
+	}
+	if !validToken(s.Name) {
+		return fmt.Errorf("pipeline name %q must be a name-safe token (letters, digits, '-', '_')", s.Name)
+	}
+	if len(s.Stages) == 0 {
+		return fmt.Errorf("pipeline %q has no stages", s.Name)
+	}
+	if err := validateDecisions("pipeline "+s.Name, s.SuccessDecisions); err != nil {
+		return err
+	}
+	if err := s.validateSchedule(); err != nil {
+		return err
+	}
+
+	known := make(map[string]struct{}, len(s.Stages))
+	for _, stage := range s.Stages {
+		if stage.ID == "" {
+			return fmt.Errorf("pipeline %q has a stage with no id", s.Name)
+		}
+		if !validToken(stage.ID) {
+			return fmt.Errorf("pipeline %q stage id %q must be a name-safe token (letters, digits, '-', '_')", s.Name, stage.ID)
+		}
+		if _, ok := known[stage.ID]; ok {
+			return fmt.Errorf("pipeline %q stage id %q is not unique", s.Name, stage.ID)
+		}
+		known[stage.ID] = struct{}{}
+	}
+	for _, stage := range s.Stages {
+		if stage.Cmd == "" {
+			return fmt.Errorf("pipeline %q stage %q has no cmd", s.Name, stage.ID)
+		}
+		if stage.Retry < 0 {
+			return fmt.Errorf("pipeline %q stage %q retry must be >= 0", s.Name, stage.ID)
+		}
+		if stage.Timeout != "" {
+			parsed, err := time.ParseDuration(stage.Timeout)
+			if err != nil {
+				return fmt.Errorf("pipeline %q stage %q timeout %q is invalid: %w", s.Name, stage.ID, stage.Timeout, err)
+			}
+			if parsed <= 0 {
+				return fmt.Errorf("pipeline %q stage %q timeout %q must be positive", s.Name, stage.ID, stage.Timeout)
+			}
+		}
+		if err := validateDecisions(fmt.Sprintf("pipeline %q stage %q", s.Name, stage.ID), stage.SuccessDecisions); err != nil {
+			return err
+		}
+		for _, dep := range stage.Needs {
+			if dep == "" {
+				continue
+			}
+			if dep == stage.ID {
+				return fmt.Errorf("pipeline %q stage %q depends on itself", s.Name, stage.ID)
+			}
+			if _, ok := known[dep]; !ok {
+				return fmt.Errorf("pipeline %q stage %q references unknown need %q", s.Name, stage.ID, dep)
+			}
+		}
+	}
+	return s.detectCycle()
+}
+
+// validateSchedule checks the optional schedule block: a present block requires a
+// positive interval and, when set, a non-negative jitter (both Go durations).
+func (s Spec) validateSchedule() error {
+	if s.Schedule == nil {
+		return nil
+	}
+	if s.Schedule.Interval == "" {
+		return fmt.Errorf("pipeline %q schedule requires an interval", s.Name)
+	}
+	interval, err := time.ParseDuration(s.Schedule.Interval)
+	if err != nil {
+		return fmt.Errorf("pipeline %q schedule interval %q is invalid: %w", s.Name, s.Schedule.Interval, err)
+	}
+	if interval <= 0 {
+		return fmt.Errorf("pipeline %q schedule interval %q must be positive", s.Name, s.Schedule.Interval)
+	}
+	if s.Schedule.Jitter != "" {
+		jitter, err := time.ParseDuration(s.Schedule.Jitter)
+		if err != nil {
+			return fmt.Errorf("pipeline %q schedule jitter %q is invalid: %w", s.Name, s.Schedule.Jitter, err)
+		}
+		if jitter < 0 {
+			return fmt.Errorf("pipeline %q schedule jitter %q must be >= 0", s.Name, s.Schedule.Jitter)
+		}
+	}
+	return nil
+}
+
+// detectCycle runs a depth-first search over the stage needs graph and reports
+// the first cycle it finds, naming the stages involved. It mirrors
+// workflow.detectDelegationCycle: unknown needs are already rejected by Validate,
+// so the traversal only walks real edges.
+func (s Spec) detectCycle() error {
+	edges := make(map[string][]string, len(s.Stages))
+	for _, stage := range s.Stages {
+		for _, dep := range stage.Needs {
+			if dep != "" {
+				edges[stage.ID] = append(edges[stage.ID], dep)
+			}
+		}
+	}
+
+	const (
+		unvisited = 0
+		visiting  = 1
+		done      = 2
+	)
+	state := make(map[string]int, len(s.Stages))
+	var stack []string
+
+	var visit func(id string) []string
+	visit = func(id string) []string {
+		state[id] = visiting
+		stack = append(stack, id)
+		for _, dep := range edges[id] {
+			switch state[dep] {
+			case visiting:
+				cycle := append([]string{}, stack[indexOf(stack, dep):]...)
+				return append(cycle, dep)
+			case unvisited:
+				if cycle := visit(dep); cycle != nil {
+					return cycle
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[id] = done
+		return nil
+	}
+
+	for _, stage := range s.Stages {
+		if state[stage.ID] == unvisited {
+			if cycle := visit(stage.ID); cycle != nil {
+				return fmt.Errorf("pipeline %q stages form a dependency cycle: %s", s.Name, strings.Join(cycle, " -> "))
+			}
+		}
+	}
+	return nil
+}
+
+// validateDecisions rejects any success_decisions value outside
+// SuccessDecisionCandidates, so blocked/failed/typos are caught at add time.
+func validateDecisions(scope string, decisions []string) error {
+	if len(decisions) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(SuccessDecisionCandidates))
+	for _, d := range SuccessDecisionCandidates {
+		allowed[d] = struct{}{}
+	}
+	for _, d := range decisions {
+		if _, ok := allowed[d]; !ok {
+			return fmt.Errorf("%s success_decisions %q is invalid; use one of: %s", scope, d, strings.Join(SuccessDecisionCandidates, ", "))
+		}
+	}
+	return nil
+}
+
+// validToken reports whether value is a non-empty name-safe token (letters,
+// digits, '-', '_'). Pipeline names and stage ids must satisfy it: the name is a
+// DB primary key and the stem of the runner agent name, and stage ids appear
+// verbatim in job fingerprints and deterministic job ids.
+func validToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func trimAll(values []string) []string {
+	if len(values) == 0 {
+		return values
+	}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		out = append(out, strings.TrimSpace(v))
+	}
+	return out
+}
+
+func indexOf(values []string, target string) int {
+	for i, v := range values {
+		if v == target {
+			return i
+		}
+	}
+	return 0
+}

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -136,6 +136,13 @@ func MaybeResumeOnGatesCleared(ctx context.Context, store *db.Store, jobID strin
 	if job.ExternallyDriven {
 		return GateResumeOutcome{Reason: "session job (externally driven) is not auto-resumed"}, nil
 	}
+	// Pipeline stage jobs (#681) resume at the RUN level (ResumePipelineRun mints
+	// attempt+1 with a new job id); retrying the old stage job here would orphan
+	// its re-execution outside the run's stage rows. Refuse, even for gate rows
+	// recorded before the mailbox-side exclusion existed.
+	if payload, perr := ParseJobPayload(job.Payload); perr == nil && payload.Sender == PipelineJobSender {
+		return GateResumeOutcome{Reason: "pipeline stage job; resume the run via `gitmoot pipeline resume`, job gates do not re-run stages"}, nil
+	}
 	awaiting, err := blockedJobAwaitingHuman(ctx, store, job)
 	if err != nil {
 		return GateResumeOutcome{}, err

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -843,7 +843,13 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 	// non-empty needs list, so every non-blocked terminal — and a blocked result
 	// with no needs — writes nothing and is byte-identical. Best-effort: a gate
 	// write must never turn a successfully-recorded blocked transition into an error.
-	if state == JobBlocked && payload.Result != nil && len(payload.Result.Needs) > 0 {
+	// Pipeline stage jobs (#681) are excluded: their needs are persisted on the
+	// pipeline run/stage rows and resumed at the RUN level via ResumePipelineRun
+	// (attempt+1, new job id). Recording job gates here would let `job gates
+	// clear` RetryJob the OLD stage job id — an orphaned re-execution the
+	// pipeline advancer never folds, and a double execution once the run is
+	// properly resumed.
+	if state == JobBlocked && payload.Result != nil && len(payload.Result.Needs) > 0 && payload.Sender != PipelineJobSender {
 		if _, gateErr := m.Store.RecordJobGates(ctx, jobID, payload.Result.Needs); gateErr == nil {
 			_ = m.addEvent(ctx, jobID, "gates_recorded", fmt.Sprintf("recorded %d resumable gate(s) from needs", len(payload.Result.Needs)))
 		}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -648,6 +648,15 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	if err := m.ensureRunning(ctx, job.ID); err != nil {
 		return AgentResult{}, err
 	}
+	// A #681 pipeline stage is a LEAF: it runs a shell command and returns a
+	// decision. Its ParentJobID is empty, so any delegations[] the stage command
+	// emitted would otherwise dispatch as TOP-LEVEL jobs in AdvanceJob. Strip them
+	// for a pipeline-sender job so a stage can never spawn phantom children; the
+	// advancer already ignores stage delegations, and this makes stages-as-leaves
+	// hold at the engine seam too. Cheap and byte-identical for every other sender.
+	if payload.Sender == PipelineJobSender && len(result.Delegations) > 0 {
+		result.Delegations = nil
+	}
 	payload.Result = &result
 	// Shadow-log returned learnings + write any mechanical fact at job terminal
 	// (#626 WRITE path). No-op when the hook is unset or the agent is not enrolled,

--- a/internal/workflow/pipeline_leaf_test.go
+++ b/internal/workflow/pipeline_leaf_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/runtime"
@@ -69,5 +70,86 @@ func TestMailboxRunKeepsNonPipelineDelegations(t *testing.T) {
 	}
 	if payload.Result == nil || len(payload.Result.Delegations) != 1 {
 		t.Fatalf("non-pipeline delegations = %+v, want preserved (1)", payload.Result)
+	}
+}
+
+const blockedNeedsResult = `{"gitmoot_result":{"decision":"blocked","summary":"missing token","findings":[],"changes_made":[],"tests_run":[],"needs":["R2 token"],"delegations":[]}}`
+
+// TestMailboxRunSkipsJobGatesForPipelineStages proves a blocked #681 pipeline
+// stage records NO job_gates rows (#693): stage needs live on the pipeline
+// run/stage rows and resume happens at the RUN level (ResumePipelineRun mints
+// attempt+1 with a new job id). A job-gate here would let `job gates clear`
+// RetryJob the OLD stage id — an orphaned re-execution the advancer never folds.
+func TestMailboxRunSkipsJobGatesForPipelineStages(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "pipeline-x-runner", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "pipeline-runner"}
+	adapter := &fakeDelivery{outputs: []string{blockedNeedsResult}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "stage-b", Agent: "pipeline-x-runner", Action: "ask", Repo: "jerryfane/gitmoot", Sender: PipelineJobSender}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "stage-b", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "stage-b")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(JobBlocked) {
+		t.Fatalf("job state = %s, want blocked", job.State)
+	}
+	total, _, err := store.CountJobGates(ctx, "stage-b")
+	if err != nil {
+		t.Fatalf("CountJobGates: %v", err)
+	}
+	if total != 0 {
+		t.Fatalf("job_gates rows = %d, want 0 for a pipeline stage", total)
+	}
+}
+
+// TestMaybeResumeOnGatesClearedRefusesPipelineStages is the belt-and-suspenders
+// guard: even if gate rows exist for a pipeline stage (recorded before the
+// mailbox-side exclusion, or written by hand), clearing them must NOT RetryJob
+// the stage — run-level resume is the only sanctioned path.
+func TestMaybeResumeOnGatesClearedRefusesPipelineStages(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "pipeline-x-runner", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "pipeline-runner"}
+	adapter := &fakeDelivery{outputs: []string{blockedNeedsResult}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "stage-g", Agent: "pipeline-x-runner", Action: "ask", Repo: "jerryfane/gitmoot", Sender: PipelineJobSender}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "stage-g", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Simulate legacy/hand-written gate rows on the stage job, then clear them.
+	if _, err := store.RecordJobGates(ctx, "stage-g", []string{"R2 token"}); err != nil {
+		t.Fatalf("RecordJobGates: %v", err)
+	}
+	if _, err := store.SatisfyAllJobGates(ctx, "stage-g"); err != nil {
+		t.Fatalf("SatisfyAllJobGates: %v", err)
+	}
+
+	outcome, err := MaybeResumeOnGatesCleared(ctx, store, "stage-g")
+	if err != nil {
+		t.Fatalf("MaybeResumeOnGatesCleared: %v", err)
+	}
+	if outcome.Resumed {
+		t.Fatalf("outcome = %+v, want refused for a pipeline stage", outcome)
+	}
+	if !strings.Contains(outcome.Reason, "pipeline") {
+		t.Fatalf("reason = %q, want the pipeline-stage refusal", outcome.Reason)
+	}
+	job, err := store.GetJob(ctx, "stage-g")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(JobBlocked) {
+		t.Fatalf("job state = %s, want still blocked (no RetryJob)", job.State)
 	}
 }

--- a/internal/workflow/pipeline_leaf_test.go
+++ b/internal/workflow/pipeline_leaf_test.go
@@ -1,0 +1,73 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+const delegatingResult = `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[{"id":"d","agent":"a","action":"review","prompt":"go"}]}}`
+
+// TestMailboxRunStripsPipelineStageDelegations proves a #681 pipeline stage is a
+// LEAF: a stage-sender job whose shell command emits delegations[] has them
+// stripped before the result is stored, so the engine's dispatchDelegations can
+// never spawn phantom top-level children from a stage (whose ParentJobID is empty).
+func TestMailboxRunStripsPipelineStageDelegations(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "pipeline-x-runner", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "pipeline-runner"}
+	adapter := &fakeDelivery{outputs: []string{delegatingResult}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "stage-1", Agent: "pipeline-x-runner", Action: "ask", Repo: "jerryfane/gitmoot", Sender: PipelineJobSender}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "stage-1", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "stage-1")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+	if payload.Result == nil {
+		t.Fatalf("stage job has no result")
+	}
+	if len(payload.Result.Delegations) != 0 {
+		t.Fatalf("pipeline stage delegations = %+v, want stripped (leaf)", payload.Result.Delegations)
+	}
+}
+
+// TestMailboxRunKeepsNonPipelineDelegations is the control: a normal (non-pipeline)
+// sender's delegations survive, so the strip is scoped strictly to pipeline stages.
+func TestMailboxRunKeepsNonPipelineDelegations(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	agent := runtime.Agent{Name: "coord", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "coordinator"}
+	adapter := &fakeDelivery{outputs: []string{delegatingResult}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-1", Agent: "coord", Action: "ask", Repo: "jerryfane/gitmoot", Sender: "user"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+	if payload.Result == nil || len(payload.Result.Delegations) != 1 {
+		t.Fatalf("non-pipeline delegations = %+v, want preserved (1)", payload.Result)
+	}
+}

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -14,6 +14,15 @@ import (
 
 const resultKey = `"gitmoot_result"`
 
+// PipelineJobSender is the Sender stamped on every #681 pipeline stage job. It is
+// the single source of truth shared by the CLI (which builds the stage
+// JobRequest) and the mailbox (which strips a stage result's delegations[] so a
+// pipeline stage is provably a LEAF — see Mailbox.Run). A pipeline stage carries
+// an EMPTY ParentJobID, so its own result-borne delegations would otherwise
+// dispatch as top-level jobs; stripping them here keeps stages leaves and matches
+// the advancer, which ignores stage delegations entirely.
+const PipelineJobSender = "pipeline"
+
 // The following slices are the single source of truth for the enum-valued
 // fields of the gitmoot_result contract. The validator below checks against
 // them, and the build-time contract generator (internal/prompts/contractgen)

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, pipelines, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
@@ -159,6 +159,15 @@ draft for failed, blocked, or cancelled jobs; use
 `gitmoot report bug --job <job-id> --create --yes` only when the user
 explicitly asks you to file it or the active workflow policy permits automatic
 bug filing.
+
+For a fixed, repeatable multi-step shell flow (not a model-driven decomposition),
+prefer a **pipeline** (#681) over an orchestra: `gitmoot pipeline add <spec.yaml>`
+registers a declared DAG of shell stages that the daemon runs on demand
+(`pipeline run`) or on an interval schedule. Each stage is an ordinary shell-runtime
+job whose `gitmoot_result` decision drives advancement; a `blocked` stage parks the
+run (resume with `pipeline resume <run-id>`), and a stage is a leaf (its
+`delegations[]` never spawn children). Pipelines are off by default. See CLI.md
+§ Pipelines, WORKFLOWS.md § Pipelines, and `docs/pipelines.md`.
 
 The plugin is only the runtime discovery surface for this skill. Local agent
 invocation still goes through the `gitmoot` CLI and the same registered agent,

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1365,3 +1365,92 @@ entries injected) — it measures injection *mechanics*, not outcome quality
 (running real agents twice is a later-phase gate). `memory eval` computes
 recall/precision@K of retrieval over a labeled fixtures file whose cases are
 `{agent, repo, instructions, expected_keys}`.
+
+## Pipelines
+
+A pipeline (#681) runs a **declared DAG of shell stages** — a fixed, repeatable
+multi-step flow — on demand or on an interval schedule. Each stage is an ordinary
+queued job run through the **shell runtime**: the normal worker tick claims and
+runs it, and a scan-based advancer folds each stage's `gitmoot_result` **decision**
+and enqueues the stages whose `needs` have all succeeded. Pipelines reuse the job
+queue, the result contract, and the heartbeat scheduling idiom (durable `next_due`,
+overlap guard, missed-ticks-coalesce). They are **off by default** (no pipelines ⇒
+the daemon's pipeline scan returns before touching state).
+
+Define a pipeline in a YAML file and register it:
+
+```yaml
+name: nightly-sync          # required, name-safe token (letters, digits, - _)
+repo: owner/repo            # optional to register; REQUIRED to run
+schedule:                   # optional interval schedule (no cron in v1)
+  interval: 24h             #   positive Go duration (required with a schedule block)
+  jitter: 15m               #   optional random [0, jitter] added to next_due
+stages:                     # the DAG, keyed by unique id and wired by needs
+  - id: source
+    cmd: "curl -sf https://example.com/data > data.json"
+  - id: score
+    cmd: "python score.py data.json"
+    needs: [source]         # runs only after every listed stage SUCCEEDS
+  - id: deploy
+    cmd: "rclone copy out/ r2:bucket"
+    needs: [score]
+    timeout: 30m            # optional per-stage job timeout
+    retry: 2                # optional; re-attempt a FAILED stage up to N times
+```
+
+```sh
+gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; omit --enable to add disabled
+gitmoot pipeline list [--json]
+gitmoot pipeline show nightly-sync [--json]        # registry view for a name
+gitmoot pipeline run nightly-sync                  # start a manual run; prints the run id
+gitmoot pipeline show <run-id> [--json]            # run funnel for a "prun-…" id
+gitmoot pipeline resume <run-id> [--from <stage>]
+gitmoot pipeline cancel <run-id>
+gitmoot pipeline enable|disable nightly-sync
+gitmoot pipeline remove nightly-sync
+```
+
+`pipeline add` validates the whole spec at add time (unknown keys, duplicate/self/
+cyclic `needs`, missing `cmd`, invalid durations, a `success_decisions` outside
+`approved`/`implemented`/`changes_requested`) so a mistake is a clear error, not a
+stuck run. It stores the raw YAML **verbatim** plus a content hash; each run
+snapshots that hash and executes its snapshot, so editing the file later never
+mutates an in-flight run. `pipeline add` also auto-creates one hidden shell runner
+agent (`pipeline-<name>-runner`) that owns the stage jobs — filtered out of `agent
+list` and disposed by `pipeline remove`.
+
+A stage signals its outcome by printing a `gitmoot_result` blob to stdout; the
+advancer folds by the **decision**, never the job's exit state (`changes_requested`
+is a succeeded job but folds as a stage **failure** by default — a stage folds on the
+decision, not the job state):
+
+```sh
+printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
+```
+
+- a decision in the stage's `success_decisions` (default `approved`/`implemented`) →
+  **succeeded**, dependents enqueue;
+- `blocked` → the stage blocks, its `needs` persist at the stage **and** run level,
+  the run **parks blocked** (downstream never enqueues, zero compute while parked);
+- `failed` / any other decision / a cancelled job / no `gitmoot_result` → the stage
+  **fails** (retried if budget remains), else the run **parks failed**.
+
+`pipeline run` prints only the run id (script-stable: `RUN=$(gitmoot pipeline run
+nightly-sync)`); a manual run ignores `enabled` but still needs a `repo` and refuses
+to start while a run is already active. `pipeline show <run-id>` renders the **text
+funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING`) under a
+run header; a **failed** run also prints the exact `gitmoot report bug --job
+<stage-job>` command (gitmoot never auto-files it).
+
+`pipeline resume` re-runs a **parked** (blocked/failed) run from its halted stage
+(or `--from <stage>`) plus its transitive dependents — bumping their attempt — while
+**never re-running a succeeded stage**; it refuses a non-parked run and a run whose
+spec drifted. `ResumePipelineRun` is the #682 approval-gate seam. `pipeline cancel`
+abandons a run through the shared `job cancel` path.
+
+A pipeline stage is a **leaf**: a stage result carrying `delegations[]` does not
+spawn children — the advancer ignores them and the engine strips them for a pipeline
+stage job. Use an orchestra for dynamic fan-out, a pipeline for a fixed shell DAG.
+See `docs/pipelines.md` for the full reference and `WORKFLOWS.md → Pipelines` for the
+end-to-end story.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1439,7 +1439,7 @@ printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing",
 `pipeline run` prints only the run id (script-stable: `RUN=$(gitmoot pipeline run
 nightly-sync)`); a manual run ignores `enabled` but still needs a `repo` and refuses
 to start while a run is already active. `pipeline show <run-id>` renders the **text
-funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING`) under a
+funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED`) under a
 run header; a **failed** run also prints the exact `gitmoot report bug --job
 <stage-job>` command (gitmoot never auto-files it).
 

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -115,6 +115,23 @@ plan explicitly says they are intended tracked fixtures or release assets.
 Redact secrets from GitHub comments, job summaries, raw examples, and copied
 command output.
 
+## Pipeline Stages Run With Daemon Permissions
+
+`gitmoot pipeline add` (#681) is an **operator-trust action**. A pipeline stage's
+`cmd` is run **verbatim** via `sh -c` with the daemon's own permissions — there is
+no sandbox, allowlist, or policy gate around a stage command the way there is around
+an `implement` job. Registering a spec is exactly as privileged as pasting its stage
+commands into the daemon host's shell, so only add specs you would run yourself, and
+treat `pipeline add` from an untrusted source as arbitrary code execution.
+
+The spec is stored **verbatim** (the raw YAML bytes plus a content hash), so a spec
+that embeds private hostnames, filesystem paths, tokens-by-reference, or repo names
+is retained in the local store as-is — the same private-repo caveat as a captured
+agent template or a published template. Do not register a spec carrying a secret in
+a stage command; provision the secret out of band and have the stage read it from
+the environment, and let the stage return `blocked` (with its `needs`) until the
+secret is present rather than baking it into the DAG.
+
 ## External Contracts
 
 If the work depends on external APIs, CLIs, env vars, generated scripts, service

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -892,3 +892,84 @@ The optional `scripts/cockpit-smoke.sh` confirms the cockpit is opt-in and
 fail-open: it runs against an isolated `--home`, exercises the `--cockpit` wrap
 path when `herdr` is reachable, and skips cleanly when `herdr` or `gitmoot` is
 unavailable. See `../../../docs/cockpit-orchestrate.md` for the full reference.
+
+## Pipelines
+
+When the work is a **fixed, repeatable sequence of shell steps** with explicit
+dependencies — not a decomposition an LLM should reason about — declare a pipeline
+(#681) instead of orchestrating. A pipeline is a declared DAG of shell stages; each
+stage is an ordinary queued job run through the shell runtime, and a scan-based
+advancer folds each stage's `gitmoot_result` decision and enqueues the stages whose
+`needs` have all succeeded. Pipelines are off by default and reuse the same job
+queue and (heartbeat-style) scheduling as everything else.
+
+Write the DAG as YAML, register it, and run it:
+
+```yaml
+# nightly-sync.yaml
+name: nightly-sync
+repo: owner/repo            # required to run (stages need a managed repo)
+schedule:                   # optional; auto-runs every interval once enabled
+  interval: 24h
+  jitter: 15m
+stages:
+  - id: source
+    cmd: "curl -sf https://example.com/data > data.json"
+  - id: score
+    cmd: "python score.py data.json"
+    needs: [source]         # runs only after source SUCCEEDS
+  - id: deploy
+    cmd: "rclone copy out/ r2:bucket"
+    needs: [score]
+    retry: 2
+```
+
+```sh
+gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; --enable turns on the schedule
+RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
+gitmoot pipeline show "$RUN"                       # watch the text funnel
+```
+
+A stage prints a `gitmoot_result` blob to stdout to signal its decision; the
+advancer folds by that **decision**, never the job's exit state:
+
+```sh
+printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
+```
+
+### Park and resume
+
+The core story is **park-then-resume**. When a stage returns `blocked`, the run
+parks: its `needs` are persisted and downstream stages are never enqueued, so the
+run consumes zero compute while it waits. `pipeline show <run-id>` makes the halt
+obvious as a funnel:
+
+```
+source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+```
+
+The operator provisions what the stage needs out of band (here, an R2 token), then
+resumes — which re-runs the halted stage and everything downstream of it, while the
+already-landed upstream stages are left untouched:
+
+```sh
+gitmoot pipeline resume "$RUN"          # re-runs score + deploy; source is NOT re-run
+gitmoot pipeline resume "$RUN" --from source   # re-run from an explicit stage instead
+```
+
+A stage that returns `failed` (or any non-success decision, a cancelled job, or no
+`gitmoot_result`) parks the run **failed** after exhausting its `retry` budget;
+`pipeline show` then prints the exact `gitmoot report bug --job <stage-job>` command
+for the halted stage (it never files the bug for you). Approval gates that resume a
+blocked run automatically are a follow-up (#682) — v1 is the manual `resume` verb.
+
+### Stages are leaves
+
+A pipeline is **not** an orchestra. Each stage is a leaf: it runs a shell command
+and returns a decision, full stop. A stage result that carries `delegations[]` does
+**not** spawn children — the advancer ignores them and the engine strips them for a
+pipeline stage job, so a pipeline can never fan out into a delegation tree. Reach
+for an orchestra (a coordinator returning `delegations[]`) when you want dynamic,
+model-driven decomposition; reach for a pipeline when the steps and their wiring are
+known up front. See `../../../docs/pipelines.md` for the full reference.

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -946,7 +946,7 @@ run consumes zero compute while it waits. `pipeline show <run-id>` makes the hal
 obvious as a funnel:
 
 ```
-source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
 The operator provisions what the stage needs out of band (here, an R2 token), then

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1314,7 +1314,7 @@ is a succeeded job but folds as a stage **failure** by default):
 `pipeline run` prints only the run id (script-stable), ignores the `enabled` flag but
 still needs a `repo` and refuses to start while a run is active. `pipeline show
 <run-id>` renders the **text funnel** (`source OK -> score BLOCKED (needs: R2 token)
--> deploy PENDING`); a **failed** run also prints the exact `gitmoot report bug --job
+-> deploy SKIPPED`); a **failed** run also prints the exact `gitmoot report bug --job
 <stage-job>` command (never auto-filed). `pipeline resume` re-runs a **parked** run
 from its halted stage (or `--from`) plus its transitive dependents while **never**
 re-running a succeeded stage. A pipeline stage is a **leaf**: a stage result carrying

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1250,3 +1250,73 @@ replay` re-renders recent real jobs' prompts with and without the injected
 learnings block and reports the token/entry delta. `memory eval` computes
 recall/precision@K of retrieval over a labeled `{agent, repo, instructions,
 expected_keys}` fixtures file.
+
+## Pipelines
+
+A pipeline (#681) runs a **declared DAG of shell stages** — a fixed, repeatable
+multi-step flow — on demand or on an interval schedule. Each stage is an ordinary
+queued job run through the **shell runtime**; a scan-based advancer folds each
+stage's `gitmoot_result` **decision** and enqueues the stages whose `needs` have all
+succeeded. Pipelines reuse the job queue, the result contract, and the heartbeat
+scheduling idiom (durable `next_due`, overlap guard, missed-ticks-coalesce), and are
+**off by default**.
+
+Define a pipeline in a YAML file, then register and run it:
+
+```yaml
+name: nightly-sync          # required, name-safe token (letters, digits, - _)
+repo: owner/repo            # optional to register; REQUIRED to run
+schedule:                   # optional interval schedule (no cron in v1)
+  interval: 24h
+  jitter: 15m
+stages:                     # the DAG, keyed by unique id and wired by needs
+  - id: source
+    cmd: "curl -sf https://example.com/data > data.json"
+  - id: score
+    cmd: "python score.py data.json"
+    needs: [source]         # runs only after source SUCCEEDS
+  - id: deploy
+    cmd: "rclone copy out/ r2:bucket"
+    needs: [score]
+    timeout: 30m            # optional per-stage job timeout
+    retry: 2                # optional; re-attempt a FAILED stage up to N times
+```
+
+```sh
+gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; omit --enable to add disabled
+gitmoot pipeline list [--json]
+gitmoot pipeline show nightly-sync [--json]        # registry view for a name
+gitmoot pipeline run nightly-sync                  # start a manual run; prints the run id
+gitmoot pipeline show <run-id> [--json]            # run funnel for a "prun-…" id
+gitmoot pipeline resume <run-id> [--from <stage>]
+gitmoot pipeline cancel <run-id>
+gitmoot pipeline enable|disable nightly-sync
+gitmoot pipeline remove nightly-sync
+```
+
+`pipeline add` validates the whole spec at add time and stores the raw YAML
+**verbatim** plus a content hash; each run snapshots the hash and executes its
+snapshot, so editing the file later never mutates an in-flight run. It also
+auto-creates one hidden shell runner agent (`pipeline-<name>-runner`) that owns the
+stage jobs — hidden from `agent list` and disposed by `pipeline remove`.
+
+A stage signals its outcome by printing a `gitmoot_result` blob to stdout; the
+advancer folds by the **decision**, never the job's exit state (`changes_requested`
+is a succeeded job but folds as a stage **failure** by default):
+
+- a decision in the stage's `success_decisions` (default `approved`/`implemented`) →
+  **succeeded**, dependents enqueue;
+- `blocked` → the stage blocks, its `needs` persist, the run **parks blocked**
+  (downstream never enqueues, zero compute while parked);
+- `failed` / any other decision / a cancelled job / no `gitmoot_result` → the stage
+  **fails** (retried if budget remains), else the run **parks failed**.
+
+`pipeline run` prints only the run id (script-stable), ignores the `enabled` flag but
+still needs a `repo` and refuses to start while a run is active. `pipeline show
+<run-id>` renders the **text funnel** (`source OK -> score BLOCKED (needs: R2 token)
+-> deploy PENDING`); a **failed** run also prints the exact `gitmoot report bug --job
+<stage-job>` command (never auto-filed). `pipeline resume` re-runs a **parked** run
+from its halted stage (or `--from`) plus its transitive dependents while **never**
+re-running a succeeded stage. A pipeline stage is a **leaf**: a stage result carrying
+`delegations[]` never spawns children. See
+[Pipelines](../workflows/pipelines-workflow.md) for the full workflow.

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -1,0 +1,195 @@
+# Run A Fixed Multi-Step Flow (Pipelines)
+
+Pipelines let the gitmoot daemon run a **declared DAG of shell stages** — a fixed,
+repeatable multi-step flow with explicit dependencies — on demand or on an interval
+schedule. Each stage is an ordinary queued job run through the **shell runtime**: the
+existing worker tick claims and runs it, and a scan-based **advancer** folds each
+stage's `gitmoot_result` decision and enqueues the stages whose dependencies have all
+succeeded. Pipelines reuse the same job queue, result contract, and scheduling idiom
+as [heartbeats](./heartbeat-schedules-workflow.md) — there is no separate runner.
+
+Pipelines are **off by default**: with no pipelines defined, the daemon's pipeline
+scan returns before touching any state.
+
+Reach for a pipeline when the steps and their wiring are **known up front**. When you
+instead want dynamic, model-driven decomposition, reach for an
+[orchestra](./coordinator-recipes-workflow.md) — a pipeline stage is a leaf and can
+never fan out into a delegation tree (see [Stages are leaves](#stages-are-leaves)).
+
+## The short version
+
+Declare the DAG as YAML:
+
+```yaml
+# nightly-sync.yaml
+name: nightly-sync          # required, name-safe token (letters, digits, - _)
+repo: owner/repo            # optional to register; REQUIRED to run
+schedule:                   # optional; auto-runs every interval once enabled
+  interval: 24h             #   positive Go duration (required with a schedule block)
+  jitter: 15m               #   optional random [0, jitter] added to each next_due
+stages:                     # the DAG, keyed by unique id and wired by needs
+  - id: source
+    cmd: "curl -sf https://example.com/data > data.json"
+  - id: score
+    cmd: "python score.py data.json"
+    needs: [source]         # runs only after source SUCCEEDS
+  - id: deploy
+    cmd: "rclone copy out/ r2:bucket"
+    needs: [score]
+    timeout: 30m            # optional per-stage job timeout
+    retry: 2                # optional; re-attempt a FAILED stage up to N times
+```
+
+Register it and run it:
+
+```sh
+# Validate + store. --enable turns on the interval schedule; omit it to add disabled.
+gitmoot pipeline add nightly-sync.yaml --enable
+
+# Or trigger a manual run right now (script-stable: prints just the run id).
+RUN=$(gitmoot pipeline run nightly-sync)
+
+# Watch the run as a text funnel.
+gitmoot pipeline show "$RUN"
+```
+
+`pipeline add` validates the whole spec at add time — unknown keys, a non-name-safe
+name/id, a duplicate stage id, a missing `cmd`, an unknown/self/cyclic `needs`, an
+invalid duration, a negative retry, or a `success_decisions` value outside
+`approved`/`implemented`/`changes_requested` — so a structural mistake is a clear
+error at registration, not a stuck run later. It stores the raw YAML **verbatim**
+plus a content hash; each run snapshots the hash and executes its snapshot, so
+editing the file later never mutates an in-flight run.
+
+## Manage pipelines
+
+```sh
+gitmoot pipeline list [--json]
+gitmoot pipeline show <name> [--json]        # registry view for a pipeline name
+gitmoot pipeline show <run-id> [--json]      # run funnel for a "prun-…" run id
+gitmoot pipeline run <name>                  # start a manual run; prints the run id
+gitmoot pipeline resume <run-id> [--from <stage>]
+gitmoot pipeline cancel <run-id>
+gitmoot pipeline enable <name>
+gitmoot pipeline disable <name>
+gitmoot pipeline remove <name>
+```
+
+A manual `pipeline run` ignores the `enabled` flag — a disabled pipeline can still be
+run by hand — but still requires a `repo` and refuses to start while the pipeline
+already has an active run (one active run per pipeline). `pipeline add` also
+auto-creates one hidden shell runner agent per pipeline (`pipeline-<name>-runner`)
+that owns the stage jobs; it is filtered out of `gitmoot agent list` and disposed by
+`pipeline remove`.
+
+## The stage contract
+
+A stage command runs as `sh -c '<cmd>' gitmoot '<prompt>'`. It signals its outcome by
+printing a `gitmoot_result` JSON blob to **stdout**; the advancer folds the stage by
+that result's **`decision`**, never by the job's exit state:
+
+```sh
+# succeeds:
+printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+# parks the run awaiting a human, listing what it needs:
+printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
+```
+
+- a decision in the stage's `success_decisions` (default `["approved","implemented"]`)
+  → the stage **succeeded**; stages whose `needs` have all now succeeded are enqueued;
+- `blocked` → the stage **blocks**; its `needs` are persisted at the stage and run
+  level and the run **parks blocked** (downstream stages never enqueue, zero compute
+  while parked);
+- `failed`, any decision outside the stage's `success_decisions` (`changes_requested`
+  by default), a cancelled job, or no `gitmoot_result` at all → the stage **fails**
+  (re-attempted if it has retry budget), else the run **parks failed**.
+
+`changes_requested` is a stage **failure by default** even though the underlying job
+succeeded — a stage folds on the decision, not the job state. List it in
+`success_decisions` (per-stage or top-level) to treat it as success instead.
+
+## Park and resume
+
+The central story is **park-then-resume**. A run that hits a `blocked` stage parks
+until an operator intervenes. `pipeline show <run-id>` renders the halt as a funnel
+under a run header:
+
+```
+run: prun-nightly-sync-18bfa02e9afb86ed
+pipeline: nightly-sync
+trigger: manual
+state: blocked
+halt_stage: score
+halt_reason: secret missing
+needs: R2 token
+
+source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+```
+
+The operator provisions what the stage needs out of band (here, an R2 token), then
+resumes — which re-runs the halted stage and everything downstream of it, while the
+already-landed upstream stages are left untouched:
+
+```sh
+gitmoot pipeline resume "$RUN"                 # re-runs score + deploy; source is NOT re-run
+gitmoot pipeline resume "$RUN" --from source   # re-run from an explicit stage instead
+```
+
+Resume works only on a **parked** (blocked or failed) run, resets the resume point and
+its transitive dependents (bumping each one's attempt), never re-runs a succeeded
+stage, and is refused if the pipeline's spec changed since the run was created.
+Approval gates that resume a blocked run automatically are a follow-up — v1 ships the
+manual `resume` verb.
+
+A run that **fails** (a stage exhausted its retry budget) parks failed, and
+`pipeline show` prints the exact command to file a bug for the halted stage's job —
+gitmoot never files it for you:
+
+```
+stage failed; report it with:
+  gitmoot report bug --job <stage-job-id>
+```
+
+`pipeline cancel <run-id>` abandons a running or parked run, cancelling its in-flight
+stage jobs through the shared `job cancel` path and marking the run and its
+non-terminal stages `cancelled`; an already-settled stage keeps its recorded outcome.
+
+## Scheduling
+
+An enabled pipeline with a `schedule.interval` auto-runs on that interval, using the
+same durable-`next_due` idiom as heartbeats. The daemon's pipeline scan runs in both
+the registered-repo and single-repo daemon loops:
+
+- **Interval + jitter only** — there is no cron parser in v1 (a durable `next_due`
+  makes a cron front-end a later drop-in).
+- **One active run per pipeline** — a scheduled tick that finds a run in flight is
+  skipped without advancing `next_due`, so the next run fires as soon as the current
+  one settles. A parked run does **not** count as active.
+- **Missed ticks coalesce** — a long-idle scheduler fires exactly one run and
+  schedules the next one interval out, never a backlog replay.
+- **Restart-safe** — the advancer recovers purely from the persisted run/stage rows,
+  so a daemon restart mid-run picks the run back up and completes it.
+- **Repo required to run** — a scheduled pipeline with no `repo` is skipped and its
+  `next_due` advanced, so a misconfigured schedule does not hot-loop and self-recovers
+  once a repo is set.
+
+## Stages are leaves
+
+A pipeline is **not** an orchestra. Each stage is a leaf: it runs a shell command and
+returns a decision, full stop. A stage result that carries `delegations[]` does **not**
+spawn children — the advancer ignores them and the engine strips them for a pipeline
+stage job, so a pipeline can never fan out into a delegation tree. Use an orchestra
+when you want dynamic decomposition; use a pipeline when the steps and their
+dependencies are known up front.
+
+## Safety
+
+`gitmoot pipeline add` is an **operator-trust action**: a stage's `cmd` runs verbatim
+via `sh -c` with the daemon's permissions, with no sandbox or policy gate. Only
+register specs you would run yourself, and treat a spec from an untrusted source as
+arbitrary code execution. The spec is stored verbatim, so do not embed secrets in a
+stage command — provision them out of band and have the stage read them from the
+environment, letting it return `blocked` until they are present.
+
+See the in-repo reference at `docs/pipelines.md` for the full field reference.
+</content>

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -123,7 +123,7 @@ halt_stage: score
 halt_reason: secret missing
 needs: R2 token
 
-source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
 The operator provisions what the stage needs out of band (here, an R2 token), then

--- a/website/scripts/build-llms-full.mjs
+++ b/website/scripts/build-llms-full.mjs
@@ -15,6 +15,7 @@ const sources = [
   'docs/troubleshooting.md',
   'docs/events.md',
   'docs/heartbeats.md',
+  'docs/pipelines.md',
   'docs/parallel-jobs.md',
   'docs/cockpit-orchestrate.md',
   'docs/skillopt-train-workflow.md',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
         'workflows/cockpit-orchestrate-workflow',
         'workflows/parallel-jobs-workflow',
         'workflows/heartbeat-schedules-workflow',
+        'workflows/pipelines-workflow',
         'workflows/skillopt-train-workflow',
       ],
     },

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -12,636 +12,168 @@ needs fuller local workflow, CLI, plugin, safety, and result-contract context.
   <img src="docs/assets/gitmoot-hero.png" alt="Gitmoot coordinates local agent runtimes through GitHub pull request workflows" width="900">
 </p>
 
-# Gitmoot
+<div align="center">
 
-Local-first multi-agent coordination for GitHub pull request workflows.
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-black.svg?style=flat-square)](./LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/jerryfane/gitmoot?include_prereleases&color=black&style=flat-square)](https://github.com/jerryfane/gitmoot/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/jerryfane/gitmoot/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/jerryfane/gitmoot/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/Docs-gitmoot.io-blue?style=flat-square)](https://gitmoot.io/docs/intro)
+[![LLM index](https://img.shields.io/badge/llms.txt-agents_start_here-8A2BE2?style=flat-square)](https://gitmoot.io/llms.txt)
+[![Go](https://img.shields.io/badge/go-single_static_binary-00ADD8?style=flat-square&logo=go&logoColor=white)](./go.mod)
 
-[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-black.svg)](./LICENSE)
-[![GitHub release](https://img.shields.io/github/v/release/jerryfane/gitmoot?include_prereleases&color=black)](https://github.com/jerryfane/gitmoot/releases)
-[![Go module](https://img.shields.io/badge/go-module-black.svg)](./go.mod)
-[![CI](https://github.com/jerryfane/gitmoot/actions/workflows/ci.yml/badge.svg)](https://github.com/jerryfane/gitmoot/actions/workflows/ci.yml)
+**Local-first multi-agent coordination for GitHub pull request workflows.**
 
-Gitmoot lets humans and AI agents collaborate through the place software teams
-already audit work: GitHub pull requests. It runs on the user's machine, keeps
-workflow state in local SQLite, routes PR comments to registered agent
-runtimes, and writes the agent's work back into the repo and PR discussion.
+</div>
 
-V1 is intentionally local-only. There is no hosted dashboard, webhook receiver,
-cloud runner, or remote control plane.
+## Our Vision
 
-## Why Gitmoot
+AI agents can already write code, review diffs, and run your tools. What they can't do is coordinate across sessions, runtimes, and days without losing the one thing software teams actually trust: **the pull request audit trail**.
 
-AI agents can already edit code, review diffs, and run local tools. The hard
-part is coordinating that work across sessions without losing the human audit
-trail. Gitmoot makes the repository and its pull requests the shared surface:
+Gitmoot makes the repository and its PRs the shared surface where humans and agents work together. It runs entirely on **your machine**: one static binary, one local SQLite file, zero runtime dependencies, no cloud control plane. PR comments become agent tasks; agent work flows back as branches, commits, reviews, and merges, every step visible where your team already looks.
 
-- PR comments become agent tasks, review requests, retries, and merge signals.
-- Local SQLite records agents, repos, jobs, goals, tasks, PRs, and branch locks.
-- Runtime adapters keep Codex, Claude Code, Kimi Code (plus the legacy
-  `kimi-cli`, a deterministic `shell` adapter), and future runtimes behind the
-  same Gitmoot agent model.
-- **Orchestra** is Gitmoot's name for structured multi-agent delegation: a
-  conductor (coordinator) returns a validated `delegations[]` DAG that Gitmoot
-  dispatches as child jobs (the players), then enqueues one continuation job
-  (the finale) to synthesize their results (replacing the old `next_agents`
-  mechanism). Use `gitmoot orchestrate <agent> "..."` to start one.
-- Delegation trees are bounded by a depth cap, a per-root job budget, a per-root
-  wall-clock budget, a per-coordinator width cap, and loop detection. When a
-  bound trips, the engine enqueues one graceful finalize continuation so the
-  coordinator synthesizes a best-effort result instead of recursing forever or
-  dropping work silently.
-- Agent Templates and job snapshots make agent instructions explicit and
-  reproducible — and can be backed up to / pulled from a GitHub repo.
-- Heartbeat schedules run recurring agent work without an external cron, and an
-  opt-in `[events]` webhook streams job/candidate lifecycle events to your own
-  systems.
-- Humans can follow progress from GitHub while agents keep working locally —
-  in the PR thread, the terminal TUI, or the read-only web dashboard.
+And it is built for the hard part: **unattended operation**. Locks, budgets, crash recovery, and graceful degradation are first-class, because an orchestrator you have to babysit is just a slower way of doing the work yourself.
+
+## Key Features
+
+### Orchestrate sub-agents across different runtimes
+
+A coordinator agent returns a validated `delegations[]` DAG; Gitmoot dispatches the children in parallel or dependency order, then reconvenes one continuation to synthesize the results. The coordinator and its workers do not need to share a runtime: a Claude conductor can fan work out to Codex implementers, a Kimi reviewer, and a deterministic shell checker in the same tree. Ephemeral workers spawn mid-orchestration with no pre-registration, and trees recurse up to depth 8, bounded by per-root job, wall-clock, token, and dollar budgets plus loop detection. When any bound trips, a graceful finalize continuation still delivers a best-effort result instead of dropping work.
+
+```sh
+gitmoot orchestrate lead "Review PR #123 from three independent angles." --repo owner/repo --recipe review-panel
+```
+
+<p align="center">
+  <img src="website/static/img/dashboard/graph.png" alt="Live orchestration graph in the Gitmoot dashboard" width="94%">
+</p>
+
+### Create custom agents in minutes
+
+An agent is a named identity with a role, capabilities, a runtime, and a versioned prompt template. Draft a template, edit it, bind it to an agent; or capture the workflow of your current Codex or Claude chat into a reusable template without retyping anything. Templates are versioned, snapshotted into every job, diffable, pinnable (`--template reviewer@v1`), and shareable through a GitHub repo with `template publish` and `template pull`.
+
+```sh
+gitmoot agent template draft frontend-reviewer --output agents/frontend-reviewer.md
+gitmoot agent template add frontend-reviewer --file agents/frontend-reviewer.md
+gitmoot agent start frontend-reviewer --runtime codex --repo owner/repo --template frontend-reviewer
+```
+
+### Agents that evolve themselves with SkillOpt
+
+The [SkillOpt](https://github.com/jerryfane/gitmoot-skillopt) loop turns real usage into better agents: job traces feed an optimizer, candidate prompt versions run behind a canary with automatic rollback, and promotion stays a human decision. Blind A/B review, ranked exploration, and GitHub-based feedback collection are built in, so your review agent from last month keeps getting sharper without hand-tuning prompts.
+
+### Built for unattended runs
+
+Checkout, branch, and runtime-session locks; per-root token and dollar budgets; boot-id crash recovery that reclaims jobs and locks the moment a reboot proves their owner dead; `task recover` for salvaging a dead implementer's half-finished work; `job kill` for whole delegation trees; paused trees that @-mention you on the PR with the exact resume command. Overnight is the normal case, not the demo case.
+
+### Driven from GitHub, visible everywhere
+
+Route work with `/gitmoot <agent> <action>` or `@agent` mentions on PRs and issues ([comment grammar](https://gitmoot.io/docs/workflows/pr-comment-workflow)). Follow it live in the PR thread, the terminal cockpit (`gitmoot dashboard`), or the [read-only web dashboard](https://gitmoot.io/docs/dashboard/overview): jobs, agents, delegation graphs, token and cost charts.
+
+<p align="center">
+  <img src="website/static/img/dashboard/jobs.png" alt="Gitmoot dashboard jobs view" width="94%">
+</p>
 
 ## How It Works
 
+```mermaid
+flowchart LR
+    A["GitHub PRs & issues<br/>comments · reviews · merges"] --> B["gitmoot daemon<br/>(your machine)"]
+    B --> C["SQLite state machine<br/>jobs · agents · locks · budgets"]
+    C --> D["runtime adapters"]
+    D --> E["Codex"]
+    D --> F["Claude Code"]
+    D --> G["Kimi Code"]
+    D --> H["shell"]
+    E & F & G & H --> I["branches · commits<br/>reviews · PR comments"]
+    I --> A
+```
+
+The core primitive is a runtime-neutral Gitmoot agent. Codex, Claude Code, and Kimi Code are adapters behind one internal contract; local SQLite is the source of truth, and GitHub is the collaboration surface.
+
+Gitmoot is also agent-native from the first minute: you don't have to install it yourself. Paste this into your coding agent and let it do the setup:
+
 ```text
-GitHub PR comments/state
-  -> local gitmoot daemon
-  -> local SQLite state machine and job mailbox
-  -> registered runtime adapter
-  -> Codex, Claude Code, Kimi Code, shell, or another agent runtime
-  -> GitHub PR comments, statuses, branches, PRs, and merges
-```
-
-The core primitive is a runtime-neutral Gitmoot agent, not a Codex-specific
-session. Codex, Claude Code, and Kimi Code are adapters behind the same internal
-runtime contract.
-
-## Install
-
-```sh
-curl -fsSL https://gitmoot.io/install.sh | sh
-gitmoot version
-gh auth status
-```
-
-Later, self-update from GitHub Releases:
-
-```sh
-gitmoot update --check
-gitmoot update --restart-daemon
-```
-
-Install runtime plugin guidance when you want Codex or Claude Code to discover
-Gitmoot's Agent Skill from their plugin systems:
-
-```sh
-gitmoot plugin install codex
-gitmoot plugin install claude
-gitmoot plugin doctor
-```
-
-The plugins are discovery and guidance surfaces. The `gitmoot` CLI and local
-daemon remain the execution path.
-
-For sandboxed Codex sessions, print a launch command that grants access to the
-resolved Gitmoot home:
-
-```sh
-gitmoot plugin codex-launch --repo .
+Install gitmoot on this machine (curl -fsSL https://gitmoot.io/install.sh | sh),
+then set it up for this repo with `gitmoot setup` and verify with `gitmoot doctor`.
+The docs index for agents is https://gitmoot.io/llms.txt
 ```
 
 ## Quick Start
 
-One command registers the repo, subscribes an agent, and launches a
-tagging-ready daemon (`--watch-issues` defaults on):
+Three steps to a working agent:
 
 ```sh
+# 1. Install (single static binary)
+curl -fsSL https://gitmoot.io/install.sh | sh
+
+# 2. Register the repo, subscribe an agent, start the daemon: one command
 gitmoot setup --repo owner/repo --path . --agent helper --runtime claude --session last --start-daemon
+
+# 3. Put it to work from any PR or issue
+#    /gitmoot helper ask What is blocking this PR?
 ```
 
-Or step through the manual path from a project checkout:
+| Runtime | Flag | Notes |
+|---|---|---|
+| Codex | `--runtime codex` | plans, implements, reviews |
+| Claude Code | `--runtime claude` | `--session last` reuses your login |
+| Kimi Code | `--runtime kimi` | `kimi login` first, then restart the daemon |
+| Shell | `--runtime shell` | deterministic command runtime: CI-style jobs, no LLM |
 
-```sh
-gitmoot init
-gitmoot repo add owner/repo --path . --poll 30s
-gitmoot doctor --repo .
-```
+Your agent can also drive Gitmoot on your behalf: `gitmoot plugin install claude` (or `codex`) packages the Gitmoot Agent Skill into the runtime's plugin system, so your agent discovers the commands, registers repos, subscribes other agents, and launches orchestrations for you. Agents start from the [llms.txt index](https://gitmoot.io/llms.txt).
 
-Start a Gitmoot-managed Codex agent and daemon:
+Full setup, daemon operation, PR-comment grammar, and parallelism: **[Install](https://gitmoot.io/docs/getting-started/install)** · **[Quick Start](https://gitmoot.io/docs/getting-started/quick-start)** · **[CLI reference](https://gitmoot.io/docs/reference/cli)**
 
-```sh
-gitmoot agent start project-planner \
-  --runtime codex \
-  --repo owner/repo \
-  --path . \
-  --template planner \
-  --start-daemon
-```
+## Use Cases
 
-`--runtime` accepts `codex`, `claude`, `kimi`, or `kimi-cli` (the opt-in legacy
-Kimi CLI adapter). For Kimi Code, run `kimi login` and restart the Gitmoot
-daemon so it inherits the session, then start the agent with `--runtime kimi`.
+Built-in coordinator recipes turn the Orchestra pattern into one command:
 
-For fast planning in the current Codex or Claude chat, ask the runtime:
+- **Review panel**: a panel of diverse-lens reviewers over a PR, synthesized into one verdict.
+  `gitmoot orchestrate lead "Review PR #123." --repo owner/repo --recipe review-panel`
+- **Decompose and verify**: split a task into parallel file-disjoint legs plus a verify step that depends on all of them.
+  `gitmoot orchestrate lead "Implement the export feature." --repo owner/repo --recipe decompose-and-verify`
+- **Producer vs. checker**: one implementation leg, one independent read-only verification on a different runtime.
+  `gitmoot orchestrate lead "Implement the rate limiter and prove it works." --repo owner/repo --recipe verifier`
 
-```text
-Use the Gitmoot planner here. Write the implementation plan.
-```
+More workflows: **[coordinator recipes](https://gitmoot.io/docs/workflows/coordinator-recipes-workflow)** · [template capture](https://gitmoot.io/docs/workflows/template-capture-workflow) · [heartbeat schedules](https://gitmoot.io/docs/workflows/heartbeat-schedules-workflow) · [SkillOpt training](https://gitmoot.io/docs/workflows/skillopt-train-workflow) · [events webhook](https://gitmoot.io/docs/reference/event-stream).
 
-That uses the same `planner` template as the background agent, but imports the
-prompt into the current chat instead of creating a Gitmoot job.
+## What's Next
 
-Ask the registered background planner when you want a queued analysis or
-planning job:
-
-```sh
-gitmoot agent ask project-planner --repo owner/repo --background "Write the implementation plan and goal file."
-gitmoot job watch <job-id>
-```
-
-Run one job through a different runtime (or model) without re-registering the
-agent — the agent's default runtime and session are untouched:
-
-```sh
-gitmoot agent ask project-planner --repo owner/repo --runtime claude "Compare the approaches."
-gitmoot agent run lead --repo owner/repo --model gpt-5-codex "Implement this task."
-```
-
-For coordinator delegation (the Orchestra pattern) where the request may require
-review or file edits, use `agent run` and let Gitmoot select the safe workflow
-path:
-
-```sh
-gitmoot agent run lead --repo owner/repo --task task-001 --background "Implement this task."
-gitmoot agent run reviewer --repo owner/repo --pr 12 --background "Review this PR."
-```
-
-`gitmoot orchestrate <agent> "..." [--repo R]` is sugar for
-`gitmoot agent run <agent> --background "..."` — it starts an orchestra of agents
-from a conductor that returns a `delegations[]` score.
-
-Background jobs are safe by default. The daemon starts with one worker, repo
-checkout locks protect local checkouts, branch locks protect implementation
-ownership, and busy Codex/Claude runtime sessions can fork bounded temporary
-workers when `[parallel_sessions]` allows it. Temp workers still require
-checkout/worktree safety and write-capable agents for implementation jobs.
-`gitmoot daemon start --parallel N` runs a repo's queued jobs N-wide
-(auto-selecting the pool scheduler); see
-[docs/parallel-jobs.md](docs/parallel-jobs.md).
-
-`daemon start --repo owner/repo` scopes the daemon to a **single** repo: it
-polls only that repo's PRs and claims only that repo's queued jobs. Omit
-`--repo` and one daemon supervises every enabled repo; cap an individual repo's
-parallelism on that shared daemon with the `[repos."owner/repo"] max_parallel`
-config key. Both `daemon run` and `daemon start` accept
-`--session <root-job-id>` (alias `--root`) to pin the worker to a single
-orchestration run — it then runs only jobs whose `root_job_id` matches that
-value plus the root coordinator job itself:
-
-```sh
-gitmoot daemon start --session <root-job-id>
-```
-
-Route work through PR comments:
-
-```text
-/gitmoot project-planner ask Write a task-by-task implementation plan for this PR.
-/gitmoot thermo-review review
-/gitmoot retry <job-id>
-/gitmoot resume <job-id> retry|continue|abort|answer [instructions]
-@project-planner ask What is blocking this PR?
-```
-
-A bare `@<agent> <action>` mention works as the same command; with the daemon's
-`--watch-issues` flag (on by default in `gitmoot setup`) mentions on **issues**
-are routed too. `/gitmoot resume` continues a delegation tree paused for a
-human (`escalate_human` failures or ask-gate questions) — the daemon @-tags you
-with the exact resume command when a tree pauses.
-
-For the full walkthrough, see [docs/local-workflow.md](docs/local-workflow.md).
-
-### Operate the daemon
-
-```sh
-gitmoot daemon status                 # scheduler mode, workers, runtime auth
-gitmoot daemon start --parallel 5     # run queued jobs 5-wide (pool scheduler)
-kill -HUP <daemon-pid>                # live-reload [daemon] poll/workers/scheduler — no restart
-gitmoot daemon restart                # restart WITHOUT losing the persisted Claude token
-gitmoot daemon stop [--forget-runtime-auth]
-```
-
-Reconfigure live with SIGHUP (#577) instead of restarting: the running daemon
-re-reads the `[daemon]` config keys with no teardown, dropped jobs, or env
-re-inheritance. Cap a single repo from config with `[repos."owner/repo"]
-max_parallel = N` (#576) — applied live, no relaunch. Runtime auth survives
-restarts (#578): the daemon persists its Claude token to a 0600
-`daemon-runtime.env` file, `daemon restart` recovers it even from a token-less
-shell (plain `stop`+`start` does not), and `--forget-runtime-auth` deletes it.
-An opt-in `[events]` webhook streams `job.finished/failed/blocked/
-needs_attention/deferred` and `candidate.*` events to one HTTP endpoint
-([docs/events.md](docs/events.md)).
-
-## Core Concepts
-
-- **Repo**: a GitHub repository plus local checkout path that Gitmoot is allowed
-  to monitor and mutate.
-- **Daemon**: the local background process that polls GitHub PRs and routes
-  queued jobs. Passing `--repo owner/repo` scopes it to that single repo
-  (polling + job claims); omit `--repo` and it supervises every enabled repo
-  (cap one repo via `[repos."owner/repo"] max_parallel`).
-  `--session <root-job-id>` scopes it to one orchestration run.
-- **Agent**: a named Gitmoot identity with repo access, role, capabilities, and
-  a runtime adapter.
-- **Runtime adapter**: the bridge from Gitmoot jobs to Codex, Claude Code,
-  Kimi Code, shell commands, or future runtimes.
-- **Template**: cached prompt content attached to an agent and snapshotted into
-  each job.
-- **Job**: a routed unit of work created from a PR comment, local ask, task run,
-  retry, or merge action.
-- **Goal and task**: Markdown implementation plans imported into local Gitmoot
-  state with `gitmoot goal import`.
-- **Branch lock**: local coordination state that prevents multiple agents from
-  racing on the same branch.
-
-## Common Workflows
-
-### Planner Agent
-
-Gitmoot includes `planner` for structured implementation planning
-and standard goal-file writing.
-
-```sh
-gitmoot agent template update planner
-gitmoot agent start project-planner \
-  --runtime codex \
-  --repo owner/repo \
-  --path . \
-  --template planner \
-  --start-daemon
-```
-
-### Review Agent
-
-Gitmoot includes `thermo-nuclear-code-quality-review` for strict review-only
-work.
-
-```sh
-gitmoot agent template update thermo-nuclear-code-quality-review
-gitmoot agent start thermo-review \
-  --runtime codex \
-  --repo owner/repo \
-  --template thermo-nuclear-code-quality-review \
-  --start-daemon
-```
-
-Ask it from a PR comment:
-
-```text
-/gitmoot thermo-review review
-```
-
-### Coordinator Recipes
-
-Coordinator recipes are built-in templates that turn the Orchestra pattern into
-one command. Each runs a coordinator that fans work out to ephemeral workers (no
-pre-registration) and reconvenes them in a single continuation. `review-panel`
-convenes a panel of diverse-lens reviewers over a PR and synthesizes one verdict;
-`decompose-and-verify` splits an implementation task into parallel, file-disjoint
-legs and runs a verify step that depends on all of them; `verifier` is the
-minimal produce-vs-independent-check pair (one producer leg plus one read-only
-verify leg on a different runtime). Route any coordinator agent through a
-recipe with `--recipe`:
-
-```sh
-gitmoot orchestrate project-planner "Review PR #123 in this repo." --repo owner/repo --recipe review-panel
-gitmoot orchestrate project-planner "Implement the export feature described in the task." --repo owner/repo --recipe decompose-and-verify
-gitmoot orchestrate project-planner "Implement the rate limiter and prove it works." --repo owner/repo --recipe verifier
-```
-
-### Custom Prompt Agents
-
-Custom agent templates let you keep a local template file and bind its
-snapshotted instructions to any Gitmoot agent.
-
-```sh
-mkdir -p agents
-gitmoot agent template draft frontend-reviewer --output agents/frontend-reviewer.md
-$EDITOR agents/frontend-reviewer.md
-gitmoot agent template validate agents/frontend-reviewer.md
-gitmoot agent template add frontend-reviewer --file agents/frontend-reviewer.md
-gitmoot agent start frontend-reviewer \
-  --runtime codex \
-  --repo owner/repo \
-  --template frontend-reviewer \
-  --role reviewer \
-  --capability ask \
-  --capability review
-```
-
-After editing the template file, refresh the cached snapshot:
-
-```sh
-gitmoot agent template diff frontend-reviewer
-gitmoot agent template update frontend-reviewer
-```
-
-Template updates are versioned locally. `gitmoot agent template show <id>`
-prints the current version, content hash, source commit, and promotion state.
-Agents use the current promoted version by default, or a pinned version when
-configured with a reference such as `--template frontend-reviewer@v1`.
-Queued jobs keep the exact template content snapshot they were created with.
-
-Discover templates by metadata:
-
-```sh
-gitmoot agent template list --runtime codex --output goal_file
-gitmoot agent template list --tag review --capability ask
-gitmoot agent template show frontend-reviewer
-```
-
-Back up and share templates via a GitHub repo (#476):
-
-```sh
-gitmoot agent template remote set owner/my-templates   # default remote ([template_remote]; ref=main, path=templates/)
-gitmoot agent template publish --all                   # commit custom templates to the remote (built-ins skipped; --create makes a PRIVATE repo)
-gitmoot agent template pull frontend-reviewer          # install/refresh from the remote
-gitmoot agent template add frontend-reviewer --from-repo owner/my-templates
-```
-
-Templates are stored and published **verbatim** (prompt body + metadata) —
-point the remote at a private repo unless the prompts are meant to be public.
-
-Reuse a custom agent prompt in the current Codex or Claude chat without
-starting a background job:
-
-```text
-Use frontend-reviewer here. Review this diff.
-```
-
-The runtime should load the prompt with:
-
-```sh
-gitmoot agent prompt frontend-reviewer
-```
-
-### Template Capture
-
-Template capture turns a useful current Codex or Claude chat workflow into a
-reusable agent template. Capture happens in the current chat from visible
-conversation context and inspected files; Gitmoot does not read hidden model
-state or runtime memory.
-
-Draft a blank structure when starting from scratch:
-
-```sh
-gitmoot agent template draft release-planner
-```
-
-Or ask the current chat to fill the structure from the visible session:
-
-```text
-Use Gitmoot to capture this session as agent template release-planner. Draft only.
-```
-
-Review the draft before installing it:
-
-```sh
-gitmoot agent template validate .gitmoot/templates/release-planner.md
-gitmoot agent template add release-planner --file .gitmoot/templates/release-planner.md
-gitmoot agent prompt release-planner
-```
-
-Installed custom templates are snapshots. After editing the source file, run
-`gitmoot agent template diff <id>` and `gitmoot agent template update <id>`.
-
-### Dashboard Cockpit
-
-On a terminal, `gitmoot dashboard` opens an interactive TUI that can act on
-everything it shows: answer prompts and retry blocked/failed jobs from the
-Attention page (plus `s` to restart a stopped daemon), open/stop/delete train
-sessions (with optional cleanup of GitHub repos gitmoot created for them),
-create/delete agents, revert a template to a previous version, start a training
-run for an agent with a codex/claude backend pick (`o`), and cancel queued or
-running jobs. For failed, blocked, or cancelled jobs, `B` opens a redacted bug
-report preview and `g` creates or reuses a GitHub issue. Press `?` on any page
-for its keys. Piped/`--plain`/`--json` output is unchanged and script-stable.
-
-```sh
-gitmoot dashboard           # interactive cockpit
-gitmoot dashboard --json    # one-shot snapshot for scripts
-gitmoot dashboard --web [--addr 127.0.0.1:8080]   # read-only web dashboard
-```
-
-`gitmoot dashboard --web` serves a read-only browser view — a live
-orchestration/delegation graph with run summaries and prompt/output
-inspection — until interrupted.
-
-Agents should answer directly from the SessionStart snapshot or read-only CLI
-checks first. The dashboard remains the live cockpit for humans.
-
-### Heartbeat Schedules
-
-Heartbeats let the daemon run recurring agent work itself — cron-like
-background jobs without an external cron (off by default):
-
-```sh
-gitmoot agent heartbeat add repo-maintainer daily-status \
-  --repo owner/repo --interval 24h --prompt "Daily status report." --enabled
-gitmoot agent heartbeat list
-```
-
-See [docs/heartbeats.md](docs/heartbeats.md).
-
-### Jobs, Locks, And Recovery
-
-```sh
-gitmoot status --repo owner/repo
-gitmoot events --repo owner/repo
-gitmoot job list --repo owner/repo
-gitmoot job show <job-id>
-gitmoot job events <job-id>
-gitmoot job retry <job-id>
-gitmoot job cancel <job-id>
-gitmoot job kill <root-job-id>
-gitmoot report bug --job <job-id> [--preview]
-gitmoot report bug --job <job-id> --create --yes
-gitmoot daemon logs
-gitmoot lock list --repo owner/repo
-gitmoot lock release owner/repo <branch> --owner <agent>
-```
-
-`gitmoot job kill <root-job-id>` is the operator kill switch for a whole
-delegation tree: in-flight jobs finish, the coordinator's next continuation is
-routed through the graceful finalize path, and the daemon stops starting queued
-children of that root.
-
-`gitmoot report bug` builds a redacted issue draft with job context, selected
-error, recent events, redaction notes, labels, and a duplicate-detection
-fingerprint. Agents should preview first and create only when the user explicitly
-asks or the active workflow policy allows filing the report, then return the
-created or existing issue URL.
-
-### SkillOpt Exchange
-
-```sh
-gitmoot skillopt train init --name <name> --template <id> --review-repo owner/repo --artifact-kind kind --preview kind (--request text|--request-file path)
-gitmoot skillopt train init templates --json
-gitmoot interactive list --state pending --json
-gitmoot interactive show <prompt-id> --json
-gitmoot interactive answer <prompt-id> <value> --source agent
-gitmoot skillopt train start --config .gitmoot/skillopt/<name>/config.toml --workspace-repo <owner/repo> --yes
-gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id>
-gitmoot skillopt review item add --run <run-id> --item <item-id> --baseline baseline.md --candidate candidate.md [--title text]
-gitmoot skillopt review create --template <id> --repo owner/repo --run <run-id> --mode explore --options 4
-gitmoot skillopt review item add --run <run-id> --item <item-id> --option a=option-a.md --option b=option-b.md [...]
-gitmoot skillopt review status --run <run-id>
-gitmoot skillopt export --run <run-id> --output training.json
-gitmoot skillopt import --file candidate.json [--artifact-dir artifacts]
-gitmoot skillopt candidate list [--template id]
-gitmoot skillopt candidate show <version-id>
-gitmoot skillopt candidate promote <version-id>
-gitmoot skillopt candidate reject <version-id> [--reason text]
-gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
-gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id>
-gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
-gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)
-```
-
-Use `skillopt train init` to create a local scaffold under
-`.gitmoot/skillopt/<name>/` without starting model work. The scaffold pins the
-template/version, writes `config.toml`, `task.md`, and starter
-`review-items.yml`, and prints the exact `train start --config` command. Agents
-can list template choices with `train init templates --json`; when an
-interactive setup needs missing values, they can answer the stored prompts with
-`gitmoot interactive list/show/answer`. On a real terminal, missing fields are
-collected through an interactive form (arrow-key template/preview pickers, inline
-validation); each field is still published as a prompt record, so another
-terminal can answer it with `gitmoot interactive answer` and the form advances
-automatically. Set `GITMOOT_NO_TUI=1` (or pipe stdin) to use the line-based
-wizard instead.
-
-On a real terminal, `gitmoot skillopt train run [--config path | --session <id>]`
-opens an interactive view of one train session: a phase bar
-(generate → review → optimize → promote) and a single keypress per step — `enter`
-generates options / publishes the review / syncs feedback / runs the optimizer
-(the long generate and optimizer steps run in a detached background process, so
-quitting the TUI with `q` leaves the run going), `p`/`x` promote or reject a
-candidate, `n` starts the next iteration. At a review-blocked phase it shows the
-GitHub issue link so you can instead comment on the issue and let the
-review-watcher continue. Piped/`--plain`/`GITMOOT_NO_TUI` print a one-shot status
-snapshot. Pass `--create-repos` to `train start` (or accept the in-form prompt
-during `train init`) to create a missing target/workspace/review repo on GitHub.
-
-For lower-level debugging, create a review run, add saved baseline/candidate outputs as review items,
-export a Markdown or GitHub feedback packet, import the completed feedback, then
-export `training.json` for a future external `gitmoot-skillopt` optimizer.
-Use ranked exploration when the template needs broad search: start with
-`--mode explore --options 4` to `6`, rank every option, record useful/rejected
-traits, then narrow into `refine`, `distill`, and finally A/B `validate`.
-`skillopt review status` reports ranking stability and the recommended next
-mode, but the recommendation is advisory only.
-Dry-run optimization validates the contract without model calls:
-
-```sh
-gitmoot-skillopt optimize \
-  --training-package training.json \
-  --artifact-root ~/.gitmoot/evals/blobs \
-  --out-root .gitmoot/skillopt/run-2026-05-31 \
-  --candidate-output candidate.json \
-  --dry-run
-```
-
-Before real model-backed optimization, run `gitmoot-skillopt optimize --help`
-and verify required model/backend environment variables for the installed
-optimizer version. Imported candidates stay pending until a human review
-workflow promotes them.
-When a candidate package includes new artifact manifest entries, pass
-`--artifact-dir` to the directory containing those files; Gitmoot verifies
-relative paths and SHA256 hashes before storing blobs.
-The external optimizer walkthrough lives in
-[`jerryfane/gitmoot-skillopt`](https://github.com/jerryfane/gitmoot-skillopt/blob/main/docs/guide/gitmoot-mvp-workflow.md).
-Use `skillopt candidate show` to inspect the candidate metadata, eval report,
-feedback summary, and content diff before `promote` or `reject` records the
-decision.
-
-Use the Markdown feedback collector for a local blind A/B packet: open
-`index.md`, review `items/*.md`, set `reviewer`, edit `feedback.yml` with `a`,
-`b`, `tie`, `neither`, or `skip`, and import it. Keep `.assignments.json`
-untouched so Gitmoot can validate and de-blind the mapping.
-
-Use the GitHub feedback collector when review should happen in an issue or an
-existing PR thread. Reviewers can reply with either the copy-paste YAML block or
-run-scoped short lines such as `run_id: run-1` followed by
-`item-001: b - More concrete.`. Gitmoot imports matching comments into
-canonical feedback events and ignores unrelated comments. Repo selection uses
-`--repo`, then the eval run target repo, then the template source repo, then
-optional `[feedback].repo = "owner/reviews"` in Gitmoot config.
-
-Detailed ranked exploration examples, including a landing-page visual task and
-a non-visual writing task, live in
-[docs/skillopt-exchange-contract.md](docs/skillopt-exchange-contract.md).
-
-Detailed command coverage lives in
-[skills/gitmoot/references/CLI.md](skills/gitmoot/references/CLI.md).
-
-## Plugins
-
-Gitmoot can package its Agent Skill for Codex and Claude Code so the runtime
-can discover Gitmoot guidance from its plugin system.
-
-```sh
-gitmoot plugin install codex
-gitmoot plugin install claude
-gitmoot plugin doctor
-gitmoot plugin codex-launch --repo .
-```
-
-Plugins do not start a hosted service, replace the daemon, subscribe agents, or
-mutate repository state by themselves. See [docs/plugins.md](docs/plugins.md)
-for install details and troubleshooting.
+The roadmap lives in the open: follow the [open issues](https://github.com/jerryfane/gitmoot/issues) to see what's coming and weigh in on what matters to you.
 
 ## Documentation
 
-- [Hosted docs](https://gitmoot.io/docs/intro)
-- [LLM index](https://gitmoot.io/llms.txt) — machine-readable docs index; agents start here (full context: [llms-full.txt](https://gitmoot.io/llms-full.txt))
-- [Agent Skills package](skills/gitmoot/SKILL.md)
-- [CLI reference](skills/gitmoot/references/CLI.md)
-- [Codex and Claude plugins](docs/plugins.md)
-- [Local workflow walkthrough](docs/local-workflow.md)
-- [Run jobs in parallel](docs/parallel-jobs.md)
-- [Heartbeat schedules](docs/heartbeats.md)
-- [Outbound event stream](docs/events.md)
-- [Cockpit and the [orchestrate] config](docs/cockpit-orchestrate.md)
-- [Beta smoke tests](docs/beta-smoke-tests.md)
-- [Runtime adapter authoring](docs/adapters.md)
-- [Troubleshooting](docs/troubleshooting.md)
+- **[Hosted docs](https://gitmoot.io/docs/intro)**: guides, concepts, reference
+- **[LLM index](https://gitmoot.io/llms.txt)**: machine-readable docs index; agents start here (full context: [llms-full.txt](https://gitmoot.io/llms-full.txt))
+- [Agent Skill package](skills/gitmoot/SKILL.md) · [CLI reference](skills/gitmoot/references/CLI.md): in-repo, versioned with the code
+- [Concepts](https://gitmoot.io/docs/concepts/local-first-coordination) · [Result contract & delegation bounds](https://gitmoot.io/docs/reference/result-contract) · [Dashboard](https://gitmoot.io/docs/dashboard/overview) · [Parallel jobs](https://gitmoot.io/docs/workflows/parallel-jobs-workflow) · [Plugins](https://gitmoot.io/docs/plugins/codex-claude) · [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting)
 
 ## Status And V1 Limits
 
-- Local-only: no hosted dashboard, GitHub App bot identity, cloud runner, or
-  remote control plane.
-- Polling watches GitHub PRs; there is no webhook receiver in V1.
-- GitHub comments are authored by the authenticated `gh` user. Agent identity
-  appears in the comment body.
-- Local SQLite remains the workflow source of truth.
+Local-only by design: no hosted dashboard, GitHub App identity, cloud runner, or webhook receiver (the daemon polls). GitHub comments are authored by your authenticated `gh` user; agent identity appears in the comment body. Local SQLite remains the workflow source of truth.
 
 ## Contributing
 
-Gitmoot is early. Keep changes scoped, preserve local-first behavior, and add
-focused tests for runtime, CLI, daemon, plugin, or workflow changes. Before
-opening a PR, run the relevant checks for the files you touched.
-
-## License
-
-Gitmoot is licensed under the [Apache License 2.0](./LICENSE). See
-[NOTICE](./NOTICE) for copyright and attribution details.
-
-## Development
+Gitmoot is early and moving fast. Keep changes scoped, preserve local-first behavior, add focused tests, and remember: **docs ship with code**. Every user-facing change updates the skill, site, and llms surfaces in the same PR. See [AGENTS.md](AGENTS.md) for the full engineering contract (verify gates, conventions, footguns).
 
 ```sh
 go test ./...
 go vet ./...
 ```
 
-GitHub Actions enforces the same gate on every push to `main` and every pull
-request: build, vet, and test, plus the race detector on `internal/workflow`.
+GitHub Actions enforces build, vet, and tests, plus the race detector on the core packages, on every push to `main` and every pull request.
+
+<a href="https://github.com/jerryfane/gitmoot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=jerryfane/gitmoot" />
+</a>
+
+## Acknowledgements
+
+Gitmoot stands on the runtimes it coordinates: [Codex](https://github.com/openai/codex), [Claude Code](https://claude.com/claude-code), and [Kimi Code](https://github.com/MoonshotAI), and on [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite), which keeps the single-binary, zero-cgo promise honest. Thanks to the downstream builders stress-testing Gitmoot in the wild, including the [council](https://github.com/plotarmordev/council) multi-model quorum system, whose bug reports and PRs make the unattended path real.
+
+## License
+
+Gitmoot is open source under the [Apache License 2.0](./LICENSE). See [NOTICE](./NOTICE) for attribution details.
 
 ---
 
@@ -3017,6 +2549,275 @@ entirely (status is unchanged).
 ## Not yet supported (deferred)
 
 - Agent-**type** scoping (only named agents today).
+
+---
+
+# Source: docs/pipelines.md
+
+# Pipelines
+
+Pipelines (#681) let the gitmoot daemon run a **declared DAG of shell stages** —
+a small, durable multi-step flow — on demand or on an interval schedule. Each
+stage is an ordinary queued job run through the **shell runtime**: the normal
+worker tick claims and runs it, and a scan-based **advancer** folds each stage's
+`gitmoot_result` decision and enqueues the stages whose dependencies have all
+succeeded. Pipelines reuse the same job queue, result contract, and scheduling
+idiom as heartbeats — there is no separate runner.
+
+Pipelines are **off by default**: with no pipelines defined, the daemon's
+pipeline scan returns an empty list before touching any state, and behavior is
+unchanged.
+
+A pipeline is not an orchestra. Each stage is a **leaf**: it runs a shell command
+and returns a decision. A stage that emits `delegations[]` does **not** spawn
+children — the advancer ignores them and the engine strips them for a pipeline
+stage job, so a pipeline can never fan out into a delegation tree. Reach for an
+orchestra (`gitmoot orchestrate` / a coordinator that returns `delegations[]`)
+when you want dynamic decomposition; reach for a pipeline when you have a fixed,
+repeatable sequence of shell steps with explicit dependencies.
+
+## The spec
+
+A pipeline is declared as a YAML file and registered with `gitmoot pipeline add`.
+The raw bytes are stored **verbatim** in the local store alongside a content hash;
+each run snapshots the hash it was created from, so a run always executes the spec
+it was created against — editing the file later (even whitespace) changes the hash
+and does not affect an in-flight run.
+
+```yaml
+name: nightly-sync          # required, name-safe token (letters, digits, - _)
+repo: owner/repo            # optional to register; REQUIRED to actually run
+schedule:                   # optional; interval schedule (no cron in v1)
+  interval: 24h             #   required when a schedule block is present (positive Go duration)
+  jitter: 15m               #   optional random [0, jitter] added to each next_due (>= 0)
+success_decisions:          # optional top-level default (see below)
+  - approved
+  - implemented
+stages:                     # the DAG, keyed by unique id and wired by needs
+  - id: source
+    cmd: "curl -sf https://example.com/data > data.json"
+  - id: score
+    cmd: "python score.py data.json"
+    needs: [source]         # runs only after every listed stage SUCCEEDS
+  - id: deploy
+    cmd: "rclone copy out/ r2:bucket"
+    needs: [score]
+    timeout: 30m            # optional per-stage job timeout (positive Go duration)
+    retry: 2                # optional; re-attempt a FAILED stage up to N times (>= 0)
+    success_decisions:      # optional per-stage override of the pipeline default
+      - approved
+```
+
+### Fields
+
+| Field                       | Scope        | Required | Notes |
+| --------------------------- | ------------ | -------- | ----- |
+| `name`                      | pipeline     | yes      | Stable identifier and DB primary key; a name-safe token (letters, digits, `-`, `_`). |
+| `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
+| `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
+| `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
+| `success_decisions`         | pipeline     | no       | Decisions that mark a stage succeeded. Default `["approved","implemented"]`. Any value must be one of `approved`, `implemented`, `changes_requested` — `blocked`/`failed` are park states and are rejected. |
+| `stages[].id`               | stage        | yes      | Unique, name-safe stage id. Appears verbatim in the stage job's fingerprint and deterministic id. |
+| `stages[].cmd`              | stage        | yes      | Shell command run verbatim via `sh -c` (see the stage contract below). |
+| `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
+| `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
+| `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
+| `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
+
+`gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
+non-name-safe name/id, a duplicate stage id, a missing `cmd`, an unknown/self/cyclic
+`needs`, an invalid timeout/interval/jitter, a negative retry, or a
+`success_decisions` value outside the allowed set — so a structural mistake surfaces
+as a clear error at registration rather than a stuck run later.
+
+### The stage contract
+
+A stage command runs under the shell runtime as `sh -c '<cmd>' gitmoot '<prompt>'`
+(so `$0` is `gitmoot` and `$1` is the stage's job prompt). The stage signals its
+outcome by printing a `gitmoot_result` JSON blob to **stdout**; the advancer folds
+the stage by that result's **`decision`**, never by the job's exit state:
+
+```sh
+# A stage that succeeds:
+printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+
+# A stage that parks the run awaiting a human, listing what it needs:
+printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
+```
+
+The decision drives advancement:
+
+- **`decision` in the stage's `success_decisions`** → the stage **succeeded**;
+  stages whose `needs` have all now succeeded are enqueued.
+- **`decision: blocked`** → the stage is **blocked**; its `needs` are persisted at
+  the stage and run level and the run **parks blocked**. Downstream stages are
+  never enqueued.
+- **`decision: failed`, any decision outside the stage's `success_decisions`
+  (`changes_requested` by default), a cancelled job, or no `gitmoot_result` at all**
+  → the stage **failed**. If the stage has retry budget left it is re-attempted;
+  otherwise the run **parks failed**.
+
+`changes_requested` is a stage **failure by default** — even though the underlying
+job succeeded — because a stage folds on the decision, not the job state, and a
+review that asked for changes is not "this step landed." List it in a stage's (or
+the pipeline's) `success_decisions` to treat it as success instead.
+
+## CLI
+
+```sh
+# Register (validate + store). Omit --enable to add it disabled (no scheduling).
+gitmoot pipeline add nightly-sync.yaml --enable
+
+gitmoot pipeline list [--json]
+gitmoot pipeline show <name> [--json]        # registry view for a pipeline name
+gitmoot pipeline show <run-id> [--json]      # run funnel for a "prun-…" run id
+
+gitmoot pipeline run <name>                  # start a manual run; prints the run id
+gitmoot pipeline resume <run-id> [--from <stage>]
+gitmoot pipeline cancel <run-id>
+
+gitmoot pipeline enable <name>
+gitmoot pipeline disable <name>
+gitmoot pipeline remove <name>
+```
+
+`pipeline run` prints just the run id (script-stable), so `RUN=$(gitmoot pipeline
+run nightly-sync)` works. A manual run ignores the `enabled` flag — a disabled
+pipeline can still be run by hand — but still requires a `repo` and refuses to
+start while the pipeline already has an active run (one active run per pipeline).
+
+`pipeline show <run-id>` renders the run as a **text funnel**:
+
+```
+run: prun-nightly-sync-18bfa02e9afb86ed
+pipeline: nightly-sync
+trigger: manual
+state: blocked
+started: 2026-07-06T06:41:39Z
+finished: 2026-07-06T06:42:10Z
+halt_stage: score
+halt_reason: secret missing
+needs: R2 token
+
+source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+```
+
+Funnel labels are `OK` for a succeeded stage, `BLOCKED (needs: …)` for a parked
+stage, and the uppercased state otherwise (`PENDING`, `QUEUED`, `RUNNING`,
+`FAILED`, `SKIPPED`, `CANCELLED`). When a run **failed**, the view also prints the
+exact command to file a bug for the halted stage's job — gitmoot never files it for
+you:
+
+```
+stage failed; report it with:
+  gitmoot report bug --job <stage-job-id>
+```
+
+`--json` on `list` and `show` emits a stable machine shape (pipelines as an array;
+a run as `{id, pipeline, trigger, state, halt_stage, halt_reason, needs, spec_hash,
+started_at, finished_at, funnel, stages[]}`).
+
+### Resume
+
+`pipeline resume <run-id>` re-runs a **parked** (blocked or failed) run from its
+halted stage; `--from <stage>` overrides the resume point. Resume resets the halted
+stage (or `--from` stage) and every stage that transitively **depends** on it back
+to pending — bumping each reset stage's attempt so the next scan enqueues a fresh
+stage job — clears the run's park fields, and returns the run to `running`. It
+**never re-runs a stage that already succeeded**, even one downstream of the resume
+point, and it refuses a run that is not parked. Because a run executes its spec
+snapshot, resume is refused if the pipeline's spec changed since the run was
+created.
+
+The intended story: a stage blocks on something the operator must provide (a
+missing secret, an unapproved change), the operator provisions it out of band, then
+`pipeline resume` re-runs the halted stage and everything downstream — while the
+already-landed upstream stages are left untouched. Approval gates that call resume
+automatically are a follow-up (#682); v1 is the manual verb.
+
+### Cancel and remove
+
+`pipeline cancel <run-id>` abandons a running or parked run: it cancels each
+in-flight stage job through the shared `job cancel` path (which also best-effort
+releases the job's locks) and marks the run and its non-terminal stages
+`cancelled`. An already-settled stage keeps its recorded outcome, so a cancelled
+run still shows why it halted. It refuses an already-terminal (succeeded/cancelled)
+run.
+
+`pipeline remove <name>` deletes the pipeline and disposes its hidden shell runner
+agent (below).
+
+## Scheduling
+
+A pipeline with a `schedule.interval` and `enable`d auto-runs on that interval,
+using the same durable-`next_due` idiom as heartbeats. The daemon's pipeline scan
+runs in **both** the registered-repo and single-repo daemon loops and does two
+passes per tick:
+
+1. **Schedule pass** — for each enabled pipeline whose interval is due and that has
+   no active run, create a fresh scheduled run and advance `next_due` **anchored to
+   now**.
+2. **Advance pass** — advance every in-flight run once (fold settled stage jobs,
+   enqueue newly-ready stages, park or finish).
+
+A parked or terminal run is never advanced, so a blocked/failed run consumes **zero
+compute** while it waits. Behavior worth knowing:
+
+- **Interval + jitter only** — there is no cron parser in v1; because `next_due` is
+  durable, a cron front-end is a documented drop-in for a later release.
+- **One active run per pipeline** — a scheduled tick that finds a run in flight is
+  skipped without advancing `next_due`, so the next run fires as soon as the current
+  one settles. A parked run does **not** count as active.
+- **Missed ticks coalesce** — a long-idle scheduler that missed many intervals fires
+  exactly **one** run and schedules the next one interval out; it never replays a
+  backlog.
+- **Restart-safe** — the advancer recovers purely from the persisted run/stage rows,
+  so a daemon restart mid-run picks the run back up and completes it.
+- **Repo required to run** — a scheduled pipeline with no `repo` is skipped and its
+  `next_due` advanced (so a misconfigured schedule does not hot-loop and
+  self-recovers once a repo is set), mirroring the heartbeat repo-unmanaged idiom.
+
+## The hidden runner agent
+
+`pipeline add` auto-creates one hidden shell agent per pipeline, named
+`pipeline-<name>-runner`, that owns the pipeline's stage jobs (the worker loop
+resolves a job's agent record). The stage command travels **per job** (in the stage
+job's runtime-override ref), not on the agent's runtime ref, so one runner serves
+every stage. These runner agents are an implementation detail and are **filtered out
+of `gitmoot agent list`**; `pipeline remove` disposes them.
+
+## Observability
+
+- `gitmoot pipeline list` shows each pipeline's enabled state, interval, repo, and
+  last run status.
+- `gitmoot pipeline show <name>` shows the registry view (spec hash, schedule,
+  last/next run bookkeeping, and the stage DAG).
+- `gitmoot pipeline show <run-id>` shows the run funnel.
+- Stage jobs are ordinary jobs (sender `pipeline`), so they also appear in the usual
+  job/status surfaces.
+
+## Safety
+
+`pipeline add` is an **operator-trust action**: a stage's `cmd` runs verbatim via
+`sh -c` with the daemon's permissions. Only register specs you would run yourself —
+the same trust you extend to a heartbeat prompt or a CI step. The spec is stored
+verbatim (raw bytes), so treat a spec containing private hostnames, paths, or repo
+names the same as any other private-repo data. See `SAFETY.md → Pipeline stages run
+with daemon permissions`.
+
+## Not yet supported (deferred)
+
+These are intentionally out of scope for v1 and tracked as follow-ups:
+
+- A cron schedule front-end (interval + jitter only today).
+- Approval gates / secret stores / an approval UI for a blocked stage (#682) — v1
+  ships the manual `pipeline resume` seam.
+- Auto-filing a bug for a failed stage (`show` prints the command; you run it).
+- LLM stages, upstream stage output flowing into a downstream stage's prompt, and
+  per-stage env/workdir.
+- Matrix / dynamic stages, more than one concurrent run per pipeline, pipelines
+  defined from the dashboard, a web funnel view, and a foreground `--watch`.
+</content>
 
 ---
 
@@ -7563,7 +7364,7 @@ his PRs (#555, #560), co-authored.
 
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, pipelines, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
@@ -7722,6 +7523,15 @@ draft for failed, blocked, or cancelled jobs; use
 `gitmoot report bug --job <job-id> --create --yes` only when the user
 explicitly asks you to file it or the active workflow policy permits automatic
 bug filing.
+
+For a fixed, repeatable multi-step shell flow (not a model-driven decomposition),
+prefer a **pipeline** (#681) over an orchestra: `gitmoot pipeline add <spec.yaml>`
+registers a declared DAG of shell stages that the daemon runs on demand
+(`pipeline run`) or on an interval schedule. Each stage is an ordinary shell-runtime
+job whose `gitmoot_result` decision drives advancement; a `blocked` stage parks the
+run (resume with `pipeline resume <run-id>`), and a stage is a leaf (its
+`delegations[]` never spawn children). Pipelines are off by default. See CLI.md
+§ Pipelines, WORKFLOWS.md § Pipelines, and `docs/pipelines.md`.
 
 The plugin is only the runtime discovery surface for this skill. Local agent
 invocation still goes through the `gitmoot` CLI and the same registered agent,
@@ -9228,6 +9038,95 @@ entries injected) — it measures injection *mechanics*, not outcome quality
 recall/precision@K of retrieval over a labeled fixtures file whose cases are
 `{agent, repo, instructions, expected_keys}`.
 
+## Pipelines
+
+A pipeline (#681) runs a **declared DAG of shell stages** — a fixed, repeatable
+multi-step flow — on demand or on an interval schedule. Each stage is an ordinary
+queued job run through the **shell runtime**: the normal worker tick claims and
+runs it, and a scan-based advancer folds each stage's `gitmoot_result` **decision**
+and enqueues the stages whose `needs` have all succeeded. Pipelines reuse the job
+queue, the result contract, and the heartbeat scheduling idiom (durable `next_due`,
+overlap guard, missed-ticks-coalesce). They are **off by default** (no pipelines ⇒
+the daemon's pipeline scan returns before touching state).
+
+Define a pipeline in a YAML file and register it:
+
+```yaml
+name: nightly-sync          # required, name-safe token (letters, digits, - _)
+repo: owner/repo            # optional to register; REQUIRED to run
+schedule:                   # optional interval schedule (no cron in v1)
+  interval: 24h             #   positive Go duration (required with a schedule block)
+  jitter: 15m               #   optional random [0, jitter] added to next_due
+stages:                     # the DAG, keyed by unique id and wired by needs
+  - id: source
+    cmd: "curl -sf https://example.com/data > data.json"
+  - id: score
+    cmd: "python score.py data.json"
+    needs: [source]         # runs only after every listed stage SUCCEEDS
+  - id: deploy
+    cmd: "rclone copy out/ r2:bucket"
+    needs: [score]
+    timeout: 30m            # optional per-stage job timeout
+    retry: 2                # optional; re-attempt a FAILED stage up to N times
+```
+
+```sh
+gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; omit --enable to add disabled
+gitmoot pipeline list [--json]
+gitmoot pipeline show nightly-sync [--json]        # registry view for a name
+gitmoot pipeline run nightly-sync                  # start a manual run; prints the run id
+gitmoot pipeline show <run-id> [--json]            # run funnel for a "prun-…" id
+gitmoot pipeline resume <run-id> [--from <stage>]
+gitmoot pipeline cancel <run-id>
+gitmoot pipeline enable|disable nightly-sync
+gitmoot pipeline remove nightly-sync
+```
+
+`pipeline add` validates the whole spec at add time (unknown keys, duplicate/self/
+cyclic `needs`, missing `cmd`, invalid durations, a `success_decisions` outside
+`approved`/`implemented`/`changes_requested`) so a mistake is a clear error, not a
+stuck run. It stores the raw YAML **verbatim** plus a content hash; each run
+snapshots that hash and executes its snapshot, so editing the file later never
+mutates an in-flight run. `pipeline add` also auto-creates one hidden shell runner
+agent (`pipeline-<name>-runner`) that owns the stage jobs — filtered out of `agent
+list` and disposed by `pipeline remove`.
+
+A stage signals its outcome by printing a `gitmoot_result` blob to stdout; the
+advancer folds by the **decision**, never the job's exit state (`changes_requested`
+is a succeeded job but folds as a stage **failure** by default — a stage folds on the
+decision, not the job state):
+
+```sh
+printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
+```
+
+- a decision in the stage's `success_decisions` (default `approved`/`implemented`) →
+  **succeeded**, dependents enqueue;
+- `blocked` → the stage blocks, its `needs` persist at the stage **and** run level,
+  the run **parks blocked** (downstream never enqueues, zero compute while parked);
+- `failed` / any other decision / a cancelled job / no `gitmoot_result` → the stage
+  **fails** (retried if budget remains), else the run **parks failed**.
+
+`pipeline run` prints only the run id (script-stable: `RUN=$(gitmoot pipeline run
+nightly-sync)`); a manual run ignores `enabled` but still needs a `repo` and refuses
+to start while a run is already active. `pipeline show <run-id>` renders the **text
+funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING`) under a
+run header; a **failed** run also prints the exact `gitmoot report bug --job
+<stage-job>` command (gitmoot never auto-files it).
+
+`pipeline resume` re-runs a **parked** (blocked/failed) run from its halted stage
+(or `--from <stage>`) plus its transitive dependents — bumping their attempt — while
+**never re-running a succeeded stage**; it refuses a non-parked run and a run whose
+spec drifted. `ResumePipelineRun` is the #682 approval-gate seam. `pipeline cancel`
+abandons a run through the shared `job cancel` path.
+
+A pipeline stage is a **leaf**: a stage result carrying `delegations[]` does not
+spawn children — the advancer ignores them and the engine strips them for a pipeline
+stage job. Use an orchestra for dynamic fan-out, a pipeline for a fixed shell DAG.
+See `docs/pipelines.md` for the full reference and `WORKFLOWS.md → Pipelines` for the
+end-to-end story.
+
 ---
 
 # Source: skills/gitmoot/references/WORKFLOWS.md
@@ -10127,6 +10026,87 @@ fail-open: it runs against an isolated `--home`, exercises the `--cockpit` wrap
 path when `herdr` is reachable, and skips cleanly when `herdr` or `gitmoot` is
 unavailable. See `../../../docs/cockpit-orchestrate.md` for the full reference.
 
+## Pipelines
+
+When the work is a **fixed, repeatable sequence of shell steps** with explicit
+dependencies — not a decomposition an LLM should reason about — declare a pipeline
+(#681) instead of orchestrating. A pipeline is a declared DAG of shell stages; each
+stage is an ordinary queued job run through the shell runtime, and a scan-based
+advancer folds each stage's `gitmoot_result` decision and enqueues the stages whose
+`needs` have all succeeded. Pipelines are off by default and reuse the same job
+queue and (heartbeat-style) scheduling as everything else.
+
+Write the DAG as YAML, register it, and run it:
+
+```yaml
+# nightly-sync.yaml
+name: nightly-sync
+repo: owner/repo            # required to run (stages need a managed repo)
+schedule:                   # optional; auto-runs every interval once enabled
+  interval: 24h
+  jitter: 15m
+stages:
+  - id: source
+    cmd: "curl -sf https://example.com/data > data.json"
+  - id: score
+    cmd: "python score.py data.json"
+    needs: [source]         # runs only after source SUCCEEDS
+  - id: deploy
+    cmd: "rclone copy out/ r2:bucket"
+    needs: [score]
+    retry: 2
+```
+
+```sh
+gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; --enable turns on the schedule
+RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
+gitmoot pipeline show "$RUN"                       # watch the text funnel
+```
+
+A stage prints a `gitmoot_result` blob to stdout to signal its decision; the
+advancer folds by that **decision**, never the job's exit state:
+
+```sh
+printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
+```
+
+### Park and resume
+
+The core story is **park-then-resume**. When a stage returns `blocked`, the run
+parks: its `needs` are persisted and downstream stages are never enqueued, so the
+run consumes zero compute while it waits. `pipeline show <run-id>` makes the halt
+obvious as a funnel:
+
+```
+source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+```
+
+The operator provisions what the stage needs out of band (here, an R2 token), then
+resumes — which re-runs the halted stage and everything downstream of it, while the
+already-landed upstream stages are left untouched:
+
+```sh
+gitmoot pipeline resume "$RUN"          # re-runs score + deploy; source is NOT re-run
+gitmoot pipeline resume "$RUN" --from source   # re-run from an explicit stage instead
+```
+
+A stage that returns `failed` (or any non-success decision, a cancelled job, or no
+`gitmoot_result`) parks the run **failed** after exhausting its `retry` budget;
+`pipeline show` then prints the exact `gitmoot report bug --job <stage-job>` command
+for the halted stage (it never files the bug for you). Approval gates that resume a
+blocked run automatically are a follow-up (#682) — v1 is the manual `resume` verb.
+
+### Stages are leaves
+
+A pipeline is **not** an orchestra. Each stage is a leaf: it runs a shell command
+and returns a decision, full stop. A stage result that carries `delegations[]` does
+**not** spawn children — the advancer ignores them and the engine strips them for a
+pipeline stage job, so a pipeline can never fan out into a delegation tree. Reach
+for an orchestra (a coordinator returning `delegations[]`) when you want dynamic,
+model-driven decomposition; reach for a pipeline when the steps and their wiring are
+known up front. See `../../../docs/pipelines.md` for the full reference.
+
 ---
 
 # Source: skills/gitmoot/references/TEMPLATE_CAPTURE.md
@@ -10361,6 +10341,23 @@ plan explicitly says they are intended tracked fixtures or release assets.
 
 Redact secrets from GitHub comments, job summaries, raw examples, and copied
 command output.
+
+## Pipeline Stages Run With Daemon Permissions
+
+`gitmoot pipeline add` (#681) is an **operator-trust action**. A pipeline stage's
+`cmd` is run **verbatim** via `sh -c` with the daemon's own permissions — there is
+no sandbox, allowlist, or policy gate around a stage command the way there is around
+an `implement` job. Registering a spec is exactly as privileged as pasting its stage
+commands into the daemon host's shell, so only add specs you would run yourself, and
+treat `pipeline add` from an untrusted source as arbitrary code execution.
+
+The spec is stored **verbatim** (the raw YAML bytes plus a content hash), so a spec
+that embeds private hostnames, filesystem paths, tokens-by-reference, or repo names
+is retained in the local store as-is — the same private-repo caveat as a captured
+agent template or a published template. Do not register a spec carrying a secret in
+a stage command; provision the secret out of band and have the stage read it from
+the environment, and let the stage return `blocked` (with its `needs`) until the
+secret is present rather than baking it into the DAG.
 
 ## External Contracts
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2699,7 +2699,7 @@ halt_stage: score
 halt_reason: secret missing
 needs: R2 token
 
-source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
 Funnel labels are `OK` for a succeeded stage, `BLOCKED (needs: …)` for a parked
@@ -9111,7 +9111,7 @@ printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing",
 `pipeline run` prints only the run id (script-stable: `RUN=$(gitmoot pipeline run
 nightly-sync)`); a manual run ignores `enabled` but still needs a `repo` and refuses
 to start while a run is already active. `pipeline show <run-id>` renders the **text
-funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING`) under a
+funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED`) under a
 run header; a **failed** run also prints the exact `gitmoot report bug --job
 <stage-job>` command (gitmoot never auto-files it).
 
@@ -10079,7 +10079,7 @@ run consumes zero compute while it waits. `pipeline show <run-id>` makes the hal
 obvious as a funnel:
 
 ```
-source OK -> score BLOCKED (needs: R2 token) -> deploy PENDING
+source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
 The operator provisions what the stage needs out of band (here, an R2 token), then


### PR DESCRIPTION
## What

First-class **Pipeline** primitive (v1): a declared DAG of shell-agent stages that gitmoot runs on demand or on an interval schedule, advancing on each stage's `gitmoot_result` decision, parking on `blocked`/`failed` with the `needs` list persisted, resumable, with a CLI text funnel.

Implements the architecture settled by the cross-runtime research panel on #681 (fable + GPT-5.5 + Kimi, reconciled in the issue comment): a small **declared-DAG advancer** over existing primitives — result contract, shell adapter via per-job runtime override, the normal job queue/worker, the heartbeat scheduler pattern — touching neither the delegation engine nor the heartbeat tables.

## Surface

```sh
gitmoot pipeline add vetrina.yaml --enable   # validate, store spec verbatim + hash, create hidden runner agent
gitmoot pipeline run vetrina-nightly          # manual run; interval schedule runs it from the daemon
gitmoot pipeline show <run-id>                # text funnel: source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
gitmoot pipeline resume <run> [--from stage]  # re-run halted stage + dependents; succeeded stages never re-run
gitmoot pipeline list|enable|disable|cancel|remove
```

Spec: YAML (`name`, `repo`, optional `schedule {interval, jitter}`, `stages[]` with `id`/`cmd`/`needs`/`timeout`/`retry`, configurable `success_decisions` defaulting to approved+implemented). Runs execute their spec **snapshot** (hash pinned at run creation), not the file's later state.

## Design highlights (all five research-flagged traps verified by adversarial review)

- Advancer folds stages **by `Result.Decision`, never job state** — a `changes_requested` stage cannot advance (the `stateForDecision` trap).
- Stage jobs are ordinary queued jobs with **empty `ParentJobID`/`DelegationID`** (no path into delegation advancement), deterministic ids, `RootJobID` = run id.
- `delegations[]` in a stage result are ignored by the advancer AND stripped at delivery for `Sender=pipeline` — stages are leaves.
- Re-scans are idempotent and write-free; the advancer recovers purely from rows (restart E2E kills the loop mid-run).
- `blocked` parks **only its branch** — independent branches finish before the run parks (review round 1 caught the whole-run over-halt; fixed in `7c64d6e`). Needs persisted verbatim at stage and run level — the #682 gates seam.
- Parked runs cost zero compute. Schedule pass uses the heartbeat idiom: durable `next_due_at`, one-active-run overlap guard, anchored-to-now coalescing, wired into both supervisor loops.
- `failed` surfaces the exact `gitmoot report bug --job <stage-job>` command; no auto-filing.
- `pipeline add` auto-creates one hidden shell runner agent per pipeline (`pipeline-<name>-runner`, filtered from `agent list`); the stage cmd travels per-job in `RuntimeOverrideRef`.

## Verification

- 4 staged Conventional Commits, each gated green before the next started; plus one review fix commit.
- Unit tests: spec validation table (dup ids, unknown needs, cycles, missing cmd), migrations on fresh + upgraded DBs, store CRUD, advancer semantics (linear, diamond, blocked-park, failed-retry-budget, changes_requested-must-not-advance, skipped propagation, idempotent double-scan), schedule due/overlap/coalescing, resume (dependents reset, succeeded untouched).
- Three in-process E2Es on isolated homes: **blocked-park** (middle stage blocks with needs → park + needs persisted + downstream never enqueued), **restart recovery** (advancer resumes from rows), **resume** (halted stage + dependents re-run only).
- Adversarial 2-lens review of the whole branch: round 1 found the branch-scope parking bug (fixed); round 2 both lenses approved, zero findings.
- Full gate on the final branch: build, generate-clean, vet, full `go test ./...`, `-race` on workflow/cli/db/daemon — **all green**.

## Docs (ship with code)

`skills/gitmoot/references/CLI.md` (pipeline family) + `WORKFLOWS.md` (pipelines section) + `SAFETY.md` (operator-trust note: stages run `sh -c` verbatim; specs stored verbatim), `website/docs/reference/cli.md`, `docs/` tree, `llms-full.txt` regenerated. All documented behavior verified against a scratch home.

## Cut from v1 (follow-ups, per the research decision table)

Cron expressions (interval+jitter first; durable `next_due_at` makes cron a drop-in) · #682 gates (resume seam ships now) · auto bug-filing · LLM stages · upstream dataflow into stage prompts · per-stage env/workdir · matrix/dynamic stages · concurrent runs per pipeline · web-dashboard funnel UI (needs the external gitmoot-dashboard module bump; CLI text funnel ships now).

## Deploy notes

Three additive migrations (auto-run on first start). New CLI family; no changes to existing behavior — pipelines are inert until `pipeline add`. Standard local deploy.

Fixes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)
