### PR TITLE
feat(scheduler): parallelize top-level read-only same-repo jobs via auto-detached worktrees

### DIFF
--- a/docs/parallel-jobs.md
+++ b/docs/parallel-jobs.md
@@ -66,18 +66,19 @@ Parallelism under `pool` is bounded by **two** independent locks:
    plain, top-level same-repo `implement` job with no worktree still shares the
    `repo:<repo>` key and serializes even under `pool`.
 
-   **Read-only fan-out worktrees are the committed tip.** An auto-isolated
+   **Auto-isolated read-only worktrees are the committed tip.** An auto-isolated
    read-only worktree is a detached `git worktree add` at the **committed tip** of
    the base branch, so it does **not** contain gitignored paths (e.g. vendored
-   clones under `repos/**`) or any uncommitted working-tree changes. This only
-   kicks in for **two or more** read-only siblings (the fan-out that would
-   otherwise serialize); a **single** read-only delegation stays in the shared
-   base checkout and sees everything. Each fan-out child's prompt now carries a
+   clones under `repos/**`) or any uncommitted working-tree changes. Isolation only
+   kicks in when a same-repo read-only job is **contended** — a fan-out of **two or
+   more** read-only siblings, or two-plus independently-fired top-level `ask`/`review`
+   jobs on one repo; a **single**, uncontended read-only job stays in the shared
+   base checkout and sees everything. Every auto-isolated job's prompt now carries a
    note with the canonical base-checkout absolute path, so a worker whose sandbox
    can read it (e.g. codex) reaches the real tree instead of reporting a
    working-tree feature as missing. For whole-working-tree analysis that must see
-   gitignored or uncommitted state, either run a **single** read-only delegation
-   (no fan-out → stays in the base checkout) or pass an **absolute** path to the
+   gitignored or uncommitted state, either keep the job uncontended (a lone
+   read-only job stays in the base checkout) or pass an **absolute** path to the
    file/dir under analysis.
 2. **Runtime session lock (`runtime:<runtime>:<ref>`).** Two jobs that use the
    **same** agent/runtime session serialize on the session lock even when their

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4559,6 +4559,17 @@ func (w jobWorker) allocatePoolIsolationWorktree(ctx context.Context, job db.Job
 		return poolIsolatedDispatch{}, false
 	}
 	payload.WorktreePath = path
+	// The detached worktree is the COMMITTED TIP of the base ref, so it omits
+	// gitignored paths (e.g. vendored repos/**) and uncommitted working-tree
+	// changes. Point the isolated read-only job at the canonical repo checkout so an
+	// analysis task does not silently report working-tree state as missing (#654),
+	// exactly as read-only delegation fan-out does (engine.go, #394 part 2). Append
+	// to Instructions so the note is carried in the delivered prompt; the reap path
+	// restores payloadBeforeIsolation on a bounce/defer, reverting this too. A blank
+	// checkout path yields "" ⇒ byte-identical (no note).
+	if note := workflow.ReadOnlyWorktreeContextNote(repoRecord.CheckoutPath); note != "" {
+		payload.Instructions += note
+	}
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		_ = client.RemoveWorktreeForce(context.WithoutCancel(ctx), path)

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4178,6 +4178,72 @@ func TestRunQueuedJobsPoolIsolatesContendedReadJob(t *testing.T) {
 	}
 }
 
+func TestPoolIsolationAppendsCommittedTipNote(t *testing.T) {
+	// #696: three same-repo top-level read-only (ask) jobs submitted together under
+	// the pool run concurrently — one in the shared checkout, the other two
+	// auto-isolated into detached committed-tip worktrees (#394 part 2). Each
+	// auto-isolated job must carry the #654 canonical-checkout note in its prompt
+	// (parity with read-only delegation fan-out), while the un-isolated job that
+	// runs in the shared base checkout stays byte-identical (no note). Every
+	// worktree is disposed on completion.
+	ctx := context.Background()
+	home := t.TempDir()
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	const goal = "audit the config loader"
+	for i, id := range []string{"job-1", "job-2", "job-3"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: i + 1, Instructions: goal})
+	}
+	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
+	worker := poolSchedulerWorker(t, store, adapter, true)
+	worker.ConfigHome = home // enable isolation
+
+	if err := runQueuedJobsForRepo(ctx, worker, 3, "", ""); err != nil {
+		t.Fatalf("pool run: %v", err)
+	}
+
+	isolated, shared := 0, 0
+	for _, id := range []string{"job-1", "job-2", "job-3"} {
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob %s: %v", id, err)
+		}
+		if job.State != string(workflow.JobSucceeded) {
+			t.Fatalf("%s state = %q, want succeeded (all three read jobs must run concurrently, not stay queued)", id, job.State)
+		}
+		payload, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("payload %s: %v", id, err)
+		}
+		if payload.WorktreePath != "" {
+			isolated++
+			if _, statErr := os.Stat(payload.WorktreePath); !os.IsNotExist(statErr) {
+				t.Fatalf("%s isolation worktree %s was not cleaned up", id, payload.WorktreePath)
+			}
+			// The auto-isolated job runs in a detached committed-tip worktree, so it
+			// must carry the #654 note pointing at the canonical repo checkout.
+			if !strings.Contains(payload.Instructions, "COMMITTED TIP") || !strings.Contains(payload.Instructions, checkout) {
+				t.Fatalf("%s isolated but Instructions missing committed-tip note pointing at %q: %q", id, checkout, payload.Instructions)
+			}
+			if !strings.HasPrefix(payload.Instructions, goal) {
+				t.Fatalf("%s note must be APPENDED after the original goal, got %q", id, payload.Instructions)
+			}
+		} else {
+			shared++
+			// The un-isolated job stays in the shared base checkout: its prompt must
+			// be byte-identical (no committed-tip note appended).
+			if payload.Instructions != goal {
+				t.Fatalf("%s ran in the shared checkout but its Instructions changed: %q (want byte-identical %q)", id, payload.Instructions, goal)
+			}
+		}
+	}
+	if isolated != 2 || shared != 1 {
+		t.Fatalf("isolated=%d shared=%d, want exactly 2 isolated + 1 shared", isolated, shared)
+	}
+}
+
 func TestRunQueuedJobsPoolRecoversWorkerPanicAndCleansWorktree(t *testing.T) {
 	// A panicking worker must not hang the pool or crash the daemon, and any
 	// isolation worktree allocated for the contended job must still be disposed

--- a/internal/workflow/readonly_worktree_test.go
+++ b/internal/workflow/readonly_worktree_test.go
@@ -404,4 +404,13 @@ func TestReadOnlyWorktreeContextNote(t *testing.T) {
 	if again := readOnlyWorktreeContextNote(base); again != note {
 		t.Fatalf("note is non-deterministic: %q != %q", again, note)
 	}
+	// The exported wrapper the daemon's top-level pool-isolation path uses (#696)
+	// MUST return byte-identical text so top-level auto-isolated read-only jobs and
+	// read-only delegation fan-out share one committed-tip note.
+	if got := ReadOnlyWorktreeContextNote(base); got != note {
+		t.Fatalf("ReadOnlyWorktreeContextNote diverged from readOnlyWorktreeContextNote: %q != %q", got, note)
+	}
+	if got := ReadOnlyWorktreeContextNote(""); got != "" {
+		t.Fatalf("ReadOnlyWorktreeContextNote(\"\") = %q, want empty (byte-identical no-note path)", got)
+	}
 }

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -426,6 +426,19 @@ func readOnlyWorktreeContextNote(baseCheckout string) string {
 	return "\n\nWorktree context (read-only): you are running in a detached git worktree checked out at the COMMITTED TIP of the base branch. It does NOT contain gitignored paths (for example vendored clones under repos/**) or any uncommitted working-tree changes. If a path this task references is absent from your working directory, read it from the canonical base checkout at " + base + " before concluding it is missing — do not report a working-tree feature as absent without checking there. This is a read-only analysis; do not write outside your worktree."
 }
 
+// ReadOnlyWorktreeContextNote is the exported entry point to
+// readOnlyWorktreeContextNote for callers outside the workflow package — namely
+// the daemon's top-level pool-isolation path (#696), which auto-isolates a
+// contended top-level read-only (ask/review) job into a detached committed-tip
+// worktree exactly as read-only delegation fan-out does (#394 part 2) and must
+// append the identical #654 note so an isolated analysis job is pointed at the
+// canonical checkout for gitignored/uncommitted paths. It is a thin pass-through
+// so the delegation and top-level paths share one source of truth for the text;
+// a blank baseCheckout yields "" (byte-identical, no note).
+func ReadOnlyWorktreeContextNote(baseCheckout string) string {
+	return readOnlyWorktreeContextNote(baseCheckout)
+}
+
 // isReadOnlyDelegationWorktree reports whether a job ran in a detached read-only
 // delegation worktree that must be disposed. Only read-only delegation children
 // allocate one; implement children carry a branch and are cleaned through the

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -731,19 +731,21 @@ Each child job carries job-tree linkage fields — `parent_job_id`,
 can be traced back to its parent, its originating delegation, and the root of the
 tree. See `RESULT_CONTRACT.md` for the full delegation field reference.
 
-**Read-only fan-out runs at the committed tip.** When a coordinator emits **two
-or more** read-only (`ask`/`review`) siblings, Gitmoot auto-isolates each into a
-detached `git worktree` at the **committed tip** of the base branch so they run
-in parallel instead of serializing on the shared checkout. That worktree does
-**not** contain gitignored paths (e.g. vendored clones under `repos/**`) or any
-uncommitted working-tree changes, so an analysis/research leg cannot see the
-operator's live working tree there. Each such child's prompt now carries a note
-with the canonical base-checkout absolute path so a worker whose sandbox can read
-it (e.g. codex) reaches the real tree instead of reporting a working-tree feature
-as absent. A **single** read-only delegation stays in the shared base checkout
-and sees everything, so for whole-working-tree analysis (auditing gitignored
-vendored repos, or in-flight uncommitted WIP) either fan out to exactly **one**
-read-only leg or pass an **absolute** path to the file/dir under analysis.
+**Contended read-only jobs run at the committed tip.** When a same-repo read-only
+(`ask`/`review`) job would otherwise serialize on the shared checkout — a
+coordinator emits **two or more** read-only siblings, or two-plus
+independently-fired top-level read-only jobs land on one repo — Gitmoot
+auto-isolates each into a detached `git worktree` at the **committed tip** of the
+base branch so they run in parallel. That worktree does **not** contain gitignored
+paths (e.g. vendored clones under `repos/**`) or any uncommitted working-tree
+changes, so an analysis/research leg cannot see the operator's live working tree
+there. Every auto-isolated job's prompt now carries a note with the canonical
+base-checkout absolute path so a worker whose sandbox can read it (e.g. codex)
+reaches the real tree instead of reporting a working-tree feature as absent. A
+**single**, uncontended read-only job stays in the shared base checkout and sees
+everything, so for whole-working-tree analysis (auditing gitignored vendored
+repos, or in-flight uncommitted WIP) either keep the job uncontended or pass an
+**absolute** path to the file/dir under analysis.
 
 ## Coordinator-Owned Review
 

--- a/website/docs/workflows/parallel-jobs-workflow.md
+++ b/website/docs/workflows/parallel-jobs-workflow.md
@@ -83,19 +83,20 @@ Parallelism under `pool` is bounded by **two** independent locks, not one:
    A plain, top-level same-repo `implement` job with **no** worktree still shares
    the `repo:<repo>` key and serializes even under `pool`.
 
-   **Read-only fan-out worktrees are the committed tip.** An auto-isolated
+   **Auto-isolated read-only worktrees are the committed tip.** An auto-isolated
    read-only worktree is a detached `git worktree add` at the **committed tip** of
    the base branch, so it does **not** contain gitignored paths (e.g. vendored
-   clones under `repos/**`) or any uncommitted working-tree changes. This only
-   applies to **two or more** read-only siblings (the fan-out that would otherwise
-   serialize); a **single** read-only delegation stays in the shared base checkout
-   and sees everything. Each fan-out child's prompt now carries a note with the
-   canonical base-checkout absolute path, so a worker whose sandbox can read it
-   (e.g. codex) reaches the real tree instead of reporting a working-tree feature
-   as missing. For whole-working-tree analysis that must see gitignored or
-   uncommitted state, either run a **single** read-only delegation (no fan-out →
-   stays in the base checkout) or pass an **absolute** path to the file/dir under
-   analysis.
+   clones under `repos/**`) or any uncommitted working-tree changes. Isolation only
+   kicks in when a same-repo read-only job is **contended** — a delegation fan-out
+   of **two or more** read-only siblings, or two-plus independently-fired top-level
+   `ask`/`review` jobs on one repo; a **single**, uncontended read-only job stays in
+   the shared base checkout and sees everything. Every auto-isolated job's prompt
+   carries a note with the canonical base-checkout absolute path, so a worker whose
+   sandbox can read it (e.g. codex) reaches the real tree instead of reporting a
+   working-tree feature as missing. For whole-working-tree analysis that must see
+   gitignored or uncommitted state, either keep the job uncontended (a lone
+   read-only job stays in the base checkout) or pass an **absolute** path to the
+   file/dir under analysis.
 2. **Runtime session lock (`runtime:<runtime>:<ref>`).** Two jobs that use the
    **same agent/runtime session** serialize on the session lock even if their
    checkouts differ. So same-repo parallelism is bounded by **distinct runtime


### PR DESCRIPTION
## What & why

Independently-fired **top-level read-only** (`ask`/`review`) jobs on the **same repo**
should run concurrently instead of serializing one-at-a-time on the shared
`repo:<repo>` checkout key. The pool scheduler **already does this** via the
auto-detached-worktree isolation shipped in **#394 part 2 (PR #399)**: a contended
read-only job whose `repo:<repo>` key is held gets an ephemeral detached worktree so
its distinct `worktree:<path>` key dispatches beside the holder
(`allocatePoolIsolationWorktree` / `poolIsolationEligible` in `internal/cli/daemon.go`).
`implement` jobs are excluded — they mutate + hold branch locks, so they keep
serializing on the real checkout.

The one piece of parity that path was **missing** vs read-only delegation fan-out is
the **#654 committed-tip context note**. An auto-isolated worktree is a detached
`git worktree add` at the committed tip of the base ref, so it omits gitignored paths
(vendored `repos/**`) and uncommitted working-tree changes. The delegation fan-out
path appends a note pointing the analysis job at the canonical checkout
(`engine.go`); the top-level pool-isolation path did **not**, so an isolated top-level
`ask`/`review` job could silently report a working-tree feature as missing.

## Change

- Export `workflow.ReadOnlyWorktreeContextNote` (thin wrapper over the existing
  unexported note builder — one source of truth for the text).
- `allocatePoolIsolationWorktree` now appends that note to the isolated job's
  `Instructions`, mirroring the delegation path. A blank checkout path yields `""`
  ⇒ byte-identical (no note). The reap path already restores `payloadBeforeIsolation`
  on a bounce/defer, reverting the appended note too.
- Docs updated (`docs/parallel-jobs.md`, `skills/gitmoot/references/WORKFLOWS.md`,
  `website/docs/workflows/parallel-jobs-workflow.md`) to describe the note now
  covering **contended top-level** read-only jobs, not just delegation fan-out.

## Behavior guarantees

- **Read-only only** — `implement` jobs are untouched (still serialize on the real
  checkout + branch lock; `poolIsolationEligible` already excludes them).
- **Lone read-only job** stays in the shared checkout and gets **no note**
  (byte-identical prompt).
- Worktree lifecycle/disposal is unchanged (reap disposes on every terminal path;
  boot-id reclaim unchanged).

## Tests

- `TestPoolIsolationAppendsCommittedTipNote` — three same-repo top-level `ask` jobs
  submitted together run concurrently (1 shared + 2 isolated), every worktree
  disposed, each isolated job carries the committed-tip note pointing at the canonical
  checkout, and the shared-checkout job's prompt is byte-identical.
- `TestReadOnlyWorktreeContextNote` extended to assert the exported wrapper is
  byte-identical to the internal builder (and `""` for a blank checkout).
- Existing `TestRunQueuedJobsPoolIsolatesContendedReadJob` (the 2-job isolation case)
  still passes unchanged.

## Notes / out of scope

- The core top-level parallelization is not new here — it landed in #394 part 2. This
  PR completes the RFC's remaining committed-tip (#654) parity constraint + tests +
  docs. The "isolation-unavailable observable event" the RFC also mentions is
  intentionally not added: the pool re-evaluates isolation every tick, so a
  once-per-dispatch event (as delegation dispatch emits) has no clean hook here and a
  per-tick event would spam the event table; the safe serialize-in-shared-checkout
  fallback is unchanged.

Closes #696
