### PR TITLE
fix(pipeline): decouple advancer cadence from repo-poll backoff

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -1955,6 +1955,18 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 				if err := runPipelineScanOnce(ctx, store, pipelineEnqueue, time.Now().UTC()); err != nil {
 					writeLine(stdout, "pipeline scan error: %s", err)
 				}
+				// Decouple the pipeline-advance cadence from the repo-poll backoff
+				// (#697): `wait` is the poller's cadence, which grows to minutes when
+				// repo polling backs off, and it would otherwise throttle the pipeline
+				// advancer to that same rate. While any run is in flight, cap the sleep
+				// to the configured (non-backed-off) poll interval so settled stages
+				// fold promptly; when idle, leave `wait` untouched so the daemon still
+				// sleeps out the full backoff. Only reduces the sleep, never extends it.
+				if inFlight, err := pipelineRunsInFlight(ctx, store); err != nil {
+					writeLine(stdout, "pipeline in-flight check error: %s", err)
+				} else {
+					wait = pipelineAdvanceWait(wait, live.pollInterval(), inFlight)
+				}
 			}
 			if watchSkillOptReviews {
 				if _, err := pollSkillOptReviewWatches(ctx, paths, store, blobStore, reviewGitHub, stdout, dryRun, home); err != nil {

--- a/internal/cli/pipeline_advance_cadence_test.go
+++ b/internal/cli/pipeline_advance_cadence_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+)
+
+// TestPipelineAdvanceWaitCapsUnderBackoff proves the #697 fix: when a pipeline
+// run is in flight and the repo poller has backed off to a minutes-long wait, the
+// supervisor sleep is capped to the (non-backed-off) poll interval so the pipeline
+// advancer keeps ticking at its own cadence instead of the backoff cadence.
+func TestPipelineAdvanceWaitCapsUnderBackoff(t *testing.T) {
+	const pollFloor = 30 * time.Second
+	backoff := 5 * time.Minute // pollRegisteredReposWithPoller's max backoff wait
+
+	got := pipelineAdvanceWait(backoff, pollFloor, true)
+	if got != pollFloor {
+		t.Fatalf("pipelineAdvanceWait(%s, %s, inFlight) = %s, want the poll floor %s (advancer must not inherit the poll backoff)", backoff, pollFloor, got, pollFloor)
+	}
+}
+
+// TestPipelineAdvanceWaitIdleUnchanged proves the UNCHANGED path: with no run in
+// flight the backed-off poll wait is returned verbatim, so an idle daemon still
+// sleeps out the full backoff exactly as before the fix (byte-identical cadence).
+func TestPipelineAdvanceWaitIdleUnchanged(t *testing.T) {
+	backoff := 5 * time.Minute
+	if got := pipelineAdvanceWait(backoff, 30*time.Second, false); got != backoff {
+		t.Fatalf("pipelineAdvanceWait(idle) = %s, want the poll wait unchanged %s", got, backoff)
+	}
+}
+
+// TestPipelineAdvanceWaitNeverExtends proves the cap only ever SHORTENS the sleep:
+// a normal (non-backed-off) poll wait shorter than the floor is returned as-is,
+// even with a run in flight, so normal-cadence advancement is unaffected. It also
+// covers a non-positive floor (misconfigured poll interval) leaving the wait alone.
+func TestPipelineAdvanceWaitNeverExtends(t *testing.T) {
+	if got := pipelineAdvanceWait(10*time.Second, 30*time.Second, true); got != 10*time.Second {
+		t.Fatalf("pipelineAdvanceWait(shortWait, inFlight) = %s, want the shorter wait 10s (never extend)", got)
+	}
+	if got := pipelineAdvanceWait(2*time.Minute, 0, true); got != 2*time.Minute {
+		t.Fatalf("pipelineAdvanceWait(zeroFloor) = %s, want the wait unchanged 2m", got)
+	}
+}
+
+// TestPipelineRunsInFlight proves the in-flight predicate the supervisor uses to
+// decide whether to cap the sleep: false with no pipelines, true while a run is
+// running, and false again once the run settles.
+func TestPipelineRunsInFlight(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+
+	if inFlight, err := pipelineRunsInFlight(ctx, store); err != nil || inFlight {
+		t.Fatalf("pipelineRunsInFlight(empty) = %v err=%v, want false/nil", inFlight, err)
+	}
+
+	now := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	run := db.PipelineRun{ID: "prun-x", Pipeline: "p", State: pipeline.RunRunning, StartedAt: now}
+	if err := store.CreatePipelineRun(ctx, run); err != nil {
+		t.Fatalf("CreatePipelineRun: %v", err)
+	}
+	if inFlight, err := pipelineRunsInFlight(ctx, store); err != nil || !inFlight {
+		t.Fatalf("pipelineRunsInFlight(running) = %v err=%v, want true/nil", inFlight, err)
+	}
+
+	run.State = pipeline.RunSucceeded
+	run.FinishedAt = now.Add(time.Minute)
+	if err := store.UpdatePipelineRun(ctx, run); err != nil {
+		t.Fatalf("UpdatePipelineRun: %v", err)
+	}
+	if inFlight, err := pipelineRunsInFlight(ctx, store); err != nil || inFlight {
+		t.Fatalf("pipelineRunsInFlight(settled) = %v err=%v, want false/nil", inFlight, err)
+	}
+}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -160,6 +160,43 @@ func runPipelineScanOnce(ctx context.Context, store *db.Store, enqueue pipelineS
 	return firstErr
 }
 
+// pipelineRunsInFlight reports whether any pipeline run is still in flight
+// (state='running'). The registered-repo supervisor calls it once per cycle,
+// AFTER runPipelineScanOnce, to decide whether the pipeline advancer needs a
+// prompt next tick (#697). Off-by-default cheap: with no pipelines / no active
+// runs the active-run query returns an empty slice before any further work, so
+// an idle daemon pays only one indexed SELECT per cycle.
+func pipelineRunsInFlight(ctx context.Context, store *db.Store) (bool, error) {
+	runs, err := store.ListActivePipelineRuns(ctx)
+	if err != nil {
+		return false, err
+	}
+	return len(runs) > 0, nil
+}
+
+// pipelineAdvanceWait decouples the pipeline-advance cadence from the repo-poll
+// backoff (#697). The registered-repo supervisor sleeps for the wait the poller
+// returns, which grows to minutes when repo polling backs off (persistent repo
+// errors / a 404 repo / a GitHub secondary rate-limit; base 1m, max 5m). That
+// backoff must not throttle pipeline-run advancement, or a settled stage folds
+// only once per (now minutes-long) tick. When a run is in flight this caps the
+// sleep to the configured, NON-backed-off poll interval (pollFloor) so the next
+// pipeline scan runs promptly; otherwise (no run in flight, or a non-positive
+// floor, or a poll wait already shorter than the floor) it returns the poll wait
+// unchanged, so an idle daemon still sleeps out the full backoff exactly as
+// before. The repo poller is unaffected: it re-checks each repo's own NextPoll
+// due time and skips repos not yet due, so an early wake never re-polls a
+// backed-off repo.
+func pipelineAdvanceWait(pollWait, pollFloor time.Duration, runsInFlight bool) time.Duration {
+	if !runsInFlight {
+		return pollWait
+	}
+	if pollFloor > 0 && pollFloor < pollWait {
+		return pollFloor
+	}
+	return pollWait
+}
+
 // schedulePipelineRuns is runPipelineScanOnce's SCHEDULE pass (#681): it creates a
 // run for each enabled pipeline whose interval schedule is due and has no active
 // run. A per-pipeline error is collected (first wins) but never stops the rest.


### PR DESCRIPTION
## Problem

`runPipelineScanOnce` runs once per registered-repo supervisor cycle, and the loop then sleeps for `wait` — the cadence returned by `pollRegisteredReposWithPoller` (the **repo-poll** cadence). When repo polling **backs off** (persistent repo errors, a 404 repo, or a GitHub secondary rate-limit; base 1m, max 5m), `wait` grows to minutes and **pipeline run advancement is throttled with it**: a settled stage folds only ~1 stage per (now minutes-long) tick.

Correctness is unaffected (runs always advance eventually), but a human watching a manual run during a GitHub outage/backoff sees stages advance slowly (reproduced live while probing #681).

## Fix

Decouple the pipeline-advance cadence from the repo-poll backoff. While **any pipeline run is in flight**, cap the supervisor sleep to the configured (non-backed-off) poll interval so the pipeline advancer keeps ticking at its own steady cadence:

- `pipelineAdvanceWait(pollWait, pollFloor, runsInFlight)` — pure cap: returns `min(pollWait, pollFloor)` while a run is in flight, else `pollWait` unchanged. It only ever **shortens** the sleep, never extends it.
- `pipelineRunsInFlight(ctx, store)` — cheap post-scan predicate (one indexed `ListActivePipelineRuns` SELECT; empty/false with no pipelines).

The cap is a no-op when idle, so a daemon with no in-flight runs sleeps out the full backoff **exactly as before**. The repo poller is unaffected: it re-checks each repo's own `NextPoll` due time and skips repos not yet due, so an early wake never re-polls a backed-off repo. No new config knob — the fix reuses the operator's configured `--poll` interval as the floor, so normal-cadence behavior is unchanged. The single-repo supervisor already sleeps at the fixed poll interval (no backoff) and needs no change.

Correctness / restart-recovery / resume are unaffected.

## Tests

- `TestPipelineAdvanceWaitCapsUnderBackoff` — a 5m backed-off wait with a run in flight caps to the 30s poll floor (the new behavior).
- `TestPipelineAdvanceWaitIdleUnchanged` — no run in flight → the backed-off wait is returned verbatim (the unchanged path).
- `TestPipelineAdvanceWaitNeverExtends` — a short/normal wait and a zero floor are left untouched (never extend).
- `TestPipelineRunsInFlight` — false with no pipelines, true while running, false once settled.

Gate green: `go build` + `go generate` (no drift) + `go vet` + `go test -race` across `internal/cli internal/daemon internal/workflow internal/db internal/config`.

Closes #697