### PR TITLE
docs: v0.8.7 release notes + SKILL.md/llms.txt catch-up

### DIFF
--- a/docs/release-notes/v0.8.7.md
+++ b/docs/release-notes/v0.8.7.md
@@ -1,0 +1,24 @@
+# Gitmoot v0.8.7
+
+Gitmoot gains a first-class **Pipeline** primitive for fixed, repeatable multi-step flows, and a reliability batch makes long-running work harder to strand: reviews re-sync to a moving PR head, GitHub calls stay under a shared budget, and blocked jobs become resumable through explicit gates. Everything additive; defaults unchanged.
+
+## What's new since v0.8.6
+
+**Pipelines — a declared DAG of shell stages the daemon runs for you (#681, #694, #700, #699)**
+
+- A **pipeline** is a fixed, repeatable multi-step flow: `gitmoot pipeline add <spec.yaml>` registers a declared DAG of stages, and the daemon runs it on demand (`gitmoot pipeline run <name>`) or on an interval schedule. Each stage is an ordinary **shell-runtime** job whose `gitmoot_result` decision drives advancement; a `blocked` stage parks the run so you can resume it with `gitmoot pipeline resume <run-id> [--from <stage>]`. Inspect with `gitmoot pipeline list`/`show`, and gate registration with `enable`/`disable`. Pipelines are **off by default** — unlike an orchestra (a model-driven decomposition), a pipeline is an author-declared flow with explicit dependencies. The advancer cadence is decoupled from repo-poll backoff so stages fold forward promptly (#700), and a read-only top-level run now carries a committed-tip note so isolated stages know their worktree is the committed tip (#699). See the Pipelines Workflow doc and the CLI reference.
+
+**Reliability: reviews, rate limits, and resumable blockers (#684, #691, #683, #692, #682, #693, #695)**
+
+- **Review head-SHA re-sync (#691):** when a PR branch advances mid-review, gitmoot no longer fails the review on a head-SHA mismatch — while the PR is still open it **re-syncs** the review to the newer head instead of dropping the work.
+- **GitHub rate-limit-aware scheduling (#692):** GitHub API calls now draw from a shared, process-wide call budget with adaptive backoff on secondary rate limits, so a busy daemon degrades gracefully instead of tripping GitHub's limiter.
+- **Resumable blocked/needs gates (#693):** a job that returns `blocked` with a `needs` list now records each need as a **gate**. `gitmoot job gates <id>` lists the open gates and `gitmoot job gates clear <id> --need "<text>"|--all` satisfies them; clearing the **last** open gate **auto-resumes** the job through the same machinery as `gitmoot job retry` — no polling. A tree paused **awaiting a human** (`escalate_human` / ask-gate) is never auto-resumed by clearing a resource gate; that still needs the human's `gitmoot resume` decision.
+- Full-chain E2Es cover the review re-sync, rate-limit, and gate paths end to end (#695).
+
+**SkillOpt: PACE anytime-valid commit gate (#687, #690)**
+
+- SkillOpt candidate promotion gains an optional **PACE** anytime-valid commit gate: an additional, **off-by-default** statistical guard (`pace_enabled`) that only lets a candidate promote once the accumulated evidence crosses the commit threshold, so peeking at interim results can't promote a candidate early. Additive and default-off — existing promotion behavior is unchanged unless you opt in.
+
+**Polish (#688, #689)**
+
+- The README is restructured as a product-style overview (#688), and the web dashboard picks up the gitmoot.io moose logo and favicon (#689).

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -79,6 +79,16 @@ To restart the daemon without losing its Claude token, use
 `gitmoot daemon restart` (not stop + start); see CLI.md § Repo And Daemon
 Status for the runtime-auth persistence model.
 
+When a job is **blocked** and the user asks to "resume a blocked job", "clear a
+blocker", or "what does this job need" (#682), route to
+`gitmoot job gates <id>` to list the open resource gates — one per `needs[]` entry
+a blocked job recorded — then `gitmoot job gates clear <id> --need "<text>"` (or
+`--all`) to satisfy them. Clearing the **last** open gate auto-re-runs the blocked
+job via the same machinery as `gitmoot job retry` (resume on clear, no polling). A
+job whose tree is **paused awaiting a human** (`escalate_human` / ask-gate) is
+never auto-resumed by clearing gates — that still needs a `gitmoot resume`
+decision. See CLI.md § Resumable gates.
+
 For Gitmoot health or status questions, first use the injected SessionStart
 snapshot when it is present and sufficient. If more detail is needed, run the
 relevant read-only Gitmoot CLI checks and answer directly from the results.

--- a/website/docs/release-notes/v0.8.7.md
+++ b/website/docs/release-notes/v0.8.7.md
@@ -1,0 +1,24 @@
+# Gitmoot v0.8.7
+
+Gitmoot gains a first-class **Pipeline** primitive for fixed, repeatable multi-step flows, and a reliability batch makes long-running work harder to strand: reviews re-sync to a moving PR head, GitHub calls stay under a shared budget, and blocked jobs become resumable through explicit gates. Everything additive; defaults unchanged.
+
+## What's new since v0.8.6
+
+**Pipelines — a declared DAG of shell stages the daemon runs for you (#681, #694, #700, #699)**
+
+- A **pipeline** is a fixed, repeatable multi-step flow: `gitmoot pipeline add <spec.yaml>` registers a declared DAG of stages, and the daemon runs it on demand (`gitmoot pipeline run <name>`) or on an interval schedule. Each stage is an ordinary **shell-runtime** job whose `gitmoot_result` decision drives advancement; a `blocked` stage parks the run so you can resume it with `gitmoot pipeline resume <run-id> [--from <stage>]`. Inspect with `gitmoot pipeline list`/`show`, and gate registration with `enable`/`disable`. Pipelines are **off by default** — unlike an orchestra (a model-driven decomposition), a pipeline is an author-declared flow with explicit dependencies. The advancer cadence is decoupled from repo-poll backoff so stages fold forward promptly (#700), and a read-only top-level run now carries a committed-tip note so isolated stages know their worktree is the committed tip (#699). See the Pipelines Workflow doc and the CLI reference.
+
+**Reliability: reviews, rate limits, and resumable blockers (#684, #691, #683, #692, #682, #693, #695)**
+
+- **Review head-SHA re-sync (#691):** when a PR branch advances mid-review, gitmoot no longer fails the review on a head-SHA mismatch — while the PR is still open it **re-syncs** the review to the newer head instead of dropping the work.
+- **GitHub rate-limit-aware scheduling (#692):** GitHub API calls now draw from a shared, process-wide call budget with adaptive backoff on secondary rate limits, so a busy daemon degrades gracefully instead of tripping GitHub's limiter.
+- **Resumable blocked/needs gates (#693):** a job that returns `blocked` with a `needs` list now records each need as a **gate**. `gitmoot job gates <id>` lists the open gates and `gitmoot job gates clear <id> --need "<text>"|--all` satisfies them; clearing the **last** open gate **auto-resumes** the job through the same machinery as `gitmoot job retry` — no polling. A tree paused **awaiting a human** (`escalate_human` / ask-gate) is never auto-resumed by clearing a resource gate; that still needs the human's `gitmoot resume` decision.
+- Full-chain E2Es cover the review re-sync, rate-limit, and gate paths end to end (#695).
+
+**SkillOpt: PACE anytime-valid commit gate (#687, #690)**
+
+- SkillOpt candidate promotion gains an optional **PACE** anytime-valid commit gate: an additional, **off-by-default** statistical guard (`pace_enabled`) that only lets a candidate promote once the accumulated evidence crosses the commit threshold, so peeking at interim results can't promote a candidate early. Additive and default-off — existing promotion behavior is unchanged unless you opt in.
+
+**Polish (#688, #689)**
+
+- The README is restructured as a product-style overview (#688), and the web dashboard picks up the gitmoot.io moose logo and favicon (#689).

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -75,6 +75,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Release Notes',
       items: [
+        'release-notes/v0.8.7',
         'release-notes/v0.8.6',
         'release-notes/v0.8.5',
         'release-notes/v0.8.4',

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -4,8 +4,8 @@ Gitmoot is a local-first coordinator for AI agents working across repositories,
 goals, reviews, pull request comments, daemon jobs, branch locks, agent
 templates (including GitHub-backed publish/pull), current-chat prompt import,
 multi-agent orchestration (the Orchestra delegations DAG), heartbeat schedules,
-an outbound event stream, and Codex, Claude Code, Kimi Code, or shell runtime
-workflows.
+declared multi-stage pipelines, an outbound event stream, and Codex, Claude Code,
+Kimi Code, or shell runtime workflows.
 
 This file is the machine-readable index of the Gitmoot docs — agents should
 start here, then open [`llms-full.txt`](https://gitmoot.io/llms-full.txt) for the
@@ -24,7 +24,8 @@ full expanded context.
 - [Cockpit Orchestrate Workflow](https://gitmoot.io/docs/workflows/cockpit-orchestrate-workflow): Watch an orchestra live in Herdr panes (`--cockpit`) plus the `[orchestrate]` config reference (budgets, timeouts, artifact inlining).
 - [Run Jobs In Parallel On A Repo](https://gitmoot.io/docs/workflows/parallel-jobs-workflow): Use `--parallel N` (or `--workers N`, now auto-`pool`) to run a repo's queued jobs N-wide; the two serialization layers (checkout lock + runtime session lock); SIGHUP warm reload, per-repo `max_parallel`, the `[admission]` host budget, and the `[github]` process-wide GitHub call budget + secondary-rate-limit backoff.
 - [Heartbeat Schedules Workflow](https://gitmoot.io/docs/workflows/heartbeat-schedules-workflow): Recurring agent work — `gitmoot agent heartbeat add` enqueues an ask/review (read-only) or policy-gated implement job on an interval, with an optional per-heartbeat `--runtime` override.
-- [SkillOpt Train Workflow](https://gitmoot.io/docs/workflows/skillopt-train-workflow): Run the full feedback, optimizer, candidate-review, and promotion loop, including judge↔human outcome capture, `judge-report`, and judge-prompt optimization.
+- [Pipelines Workflow](https://gitmoot.io/docs/workflows/pipelines-workflow): Run a fixed, repeatable multi-step flow as a declared DAG of shell-runtime stages (`gitmoot pipeline add|run|resume`), advanced by the daemon on demand or on an interval schedule; a `blocked` stage parks the run to resume. Off by default.
+- [SkillOpt Train Workflow](https://gitmoot.io/docs/workflows/skillopt-train-workflow): Run the full feedback, optimizer, candidate-review, and promotion loop, including judge↔human outcome capture, `judge-report`, judge-prompt optimization, and the off-by-default PACE anytime-valid commit gate (`pace_enabled`) for candidate promotion.
 
 ## Concepts
 
@@ -39,7 +40,7 @@ full expanded context.
 
 ## References
 
-- [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, jobs, bug reports, locks, goals, interactive prompts, and SkillOpt.
+- [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, pipelines, jobs (incl. resumable `job gates`/`gates clear` for blocked `needs` with auto-resume on last clear, and session jobs `job open/close/record`), review head-SHA re-sync, bug reports, locks, goals, interactive prompts, and SkillOpt.
 - [Runtime Adapters](https://gitmoot.io/docs/reference/runtime-adapters): Codex, Claude Code, Kimi Code, legacy kimi-cli, shell, and future runtimes; the config-driven metadata registry (`gitmoot runtime list`, `[runtimes.<name>]` overrides).
 - [Result Contract](https://gitmoot.io/docs/reference/result-contract): gitmoot_result shape, the delegations DAG (Orchestration), continuation, and termination bounds.
 - [Event Stream](https://gitmoot.io/docs/reference/event-stream): The `[events]` webhook contract — job.finished/failed/blocked/needs_attention/deferred and candidate.* events, schema_version 1, best-effort delivery.
@@ -48,7 +49,8 @@ full expanded context.
 - [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting): Diagnose GitHub auth, bug reports, runtimes, agent templates, remotes, permissions, daemon lifecycle, stuck/deferred jobs, and locks.
 - [Beta Smoke Tests](https://gitmoot.io/docs/operations/beta-smoke-tests): Deterministic smoke checklists for release validation.
 - [Docs Deployment](https://gitmoot.io/docs/operations/deployment): How the docs site itself is built and published.
-- [Release Notes](https://gitmoot.io/docs/release-notes/v0.8.6): Latest release (v0.8.6) — codex token usage captured correctly for every session shape: fresh sessions run with `--json`, resumed sessions record per-session deltas (not session-cumulative totals), ephemeral/temp workers flagged single-use so their first delivery counts (#658/#661/#662/#664/#669); kimi 0.19.2 emits no usage (documented, #659). Memory confirmed pool now fills from ordinary jobs, not just orchestrate runs (#647), and [memory] is advertised in the init template (#653). Session jobs: `gitmoot job open/close/record` tracks here-method work as first-class jobs (#660/#676). Daemon recovers jobs and reclaims runtime locks across reboots via boot_id (#668). Config-driven runtime metadata registry + resilient per-section default_model resolver (#674/#679). Workflow hardening: delegation budgets projected before enqueue (#666), read-only fan-out warning (#667), session isolation + task-run recovery (#671), policy-gated heartbeat implement action (#675). Dashboard: new Learning section (SkillOpt template evolution + memory brain graph) (#672/#677/#680), agent config + memory pool counts (#670), galaxy ring-collapse fixes (#648/#678), mobile-responsive UI (#644), template version diff (#643).
+- [Release Notes](https://gitmoot.io/docs/release-notes/v0.8.7): Latest release (v0.8.7) — first-class Pipelines: a declared DAG of shell-runtime stages the daemon advances on demand or on a schedule, off by default (`gitmoot pipeline add|run|resume`), with an advancer cadence decoupled from repo-poll backoff and a committed-tip note on read-only top-level isolation (#681/#694/#700/#699). Reliability batch: reviews **re-sync** to a newer PR head instead of failing on a head-SHA mismatch (#691); GitHub API calls share a process-wide budget with adaptive secondary-rate-limit backoff (#692); blocked jobs record their `needs` as **resumable gates** — `gitmoot job gates`/`gates clear` satisfy them and auto-resume on the last clear (#693); full-chain E2Es cover the batch (#695). SkillOpt gains the off-by-default PACE anytime-valid commit gate for candidate promotion (#687/#690). Polish: product-style README (#688); dashboard moose logo + favicon (#689).
+- [v0.8.6 Release Notes](https://gitmoot.io/docs/release-notes/v0.8.6): Codex token usage captured correctly for every session shape (#658/#661/#662/#664/#669); memory confirmed pool fills from ordinary jobs (#647); session jobs `job open/close/record` (#660/#676); daemon boot_id reboot recovery (#668); config-driven runtime metadata registry (#674/#679); dashboard Learning section (#672/#677/#680).
 - [Raw SKILL.md](https://gitmoot.io/SKILL.md): Agent skill entrypoint.
 - [Full LLM Context](https://gitmoot.io/llms-full.txt): Expanded Markdown context for agents.
 - [GitHub Repository](https://github.com/jerryfane/gitmoot): Source code and releases.


### PR DESCRIPTION
Docs-only catch-up for the 10 commits since v0.8.6. Three parts.

## (1) SKILL.md gap fix
- Added a concise trigger routing "resume a blocked job / clear a blocker / what does this job need" (#682) to `gitmoot job gates <id>` and `gitmoot job gates clear <id> --need "..."|--all`, noting the blocked → clear → auto-resume-on-last behavior and the `escalate_human`/ask-gate exception.
- Pipeline (#681) already has an adequate SKILL.md trigger (the "fixed, repeatable multi-step shell flow" paragraph pointing at `pipeline add/run/resume`) — left as-is; the frontmatter `description` already lists pipelines.

## (2) llms.txt refresh
- New **Pipelines Workflow** index entry pointing at `workflows/pipelines-workflow`.
- Enriched the **SkillOpt Train Workflow** entry with the off-by-default **PACE** anytime-valid commit gate (`pace_enabled`, #687/#690).
- Enriched the **CLI Reference** entry with resumable `job gates`/`gates clear`, session jobs, and review head-SHA re-sync.
- Runtime metadata registry and the `[github]` call-budget limiter were already indexed (Runtime Adapters / Parallel Jobs entries).
- Bumped the **Latest** release-notes pointer to v0.8.7 (kept a short v0.8.6 line below it).

## (3) v0.8.7 release notes
- Added `release-notes/v0.8.7.md` to **both** trees (`docs/` + `website/docs/`, byte-identical as v0.8.6 was) and registered `release-notes/v0.8.7` in `website/sidebars.ts`.
- Grouped by theme matching v0.8.6 voice/length: **Pipelines** (#681/#694/#700/#699), **Reliability** (review re-sync #691, GitHub rate-limit #692, resumable gates #693, E2Es #695), **PACE off-by-default** (#687/#690), **Polish** (README #688, dashboard logo/favicon #689). No release date invented.

## Verified against
- `gitmoot job gates --help`, `gitmoot job --help`, `gitmoot pipeline --help` (real CLI subcommands/flags).
- `website/docs/reference/cli.md` § Resumable gates / Session jobs / review re-sync; `website/docs/workflows/skillopt-train-workflow.md` § PACE; `website/docs/workflows/pipelines-workflow.md` (page exists in sidebar).
- `go build ./...` clean; `git diff --stat` shows only .md/.txt/.ts(sidebar).

Release-time (owner-gated, NOT done here): `npm run build` in `website/` (onBrokenLinks: throw), llms-full regen, gitmoot.io rsync, `gh release create v0.8.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)