### PR TITLE
feat(skillopt): offline rubric induction (skillopt rubric induce)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -80,6 +80,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptAB(args[1:], stdout, stderr)
 	case "pairwise":
 		return runSkillOptPairwise(args[1:], stdout, stderr)
+	case "rubric":
+		return runSkillOptRubric(args[1:], stdout, stderr)
 	case "gate":
 		return runSkillOptGate(args[1:], stdout, stderr)
 	default:
@@ -109,6 +111,7 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github sync --run <run-id> [--repo owner/repo] (--issue <number>|--pr <number>)")
 	fmt.Fprintln(w, "  gitmoot skillopt ab <agent> \"<prompt>\" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]")
 	fmt.Fprintln(w, "  gitmoot skillopt pairwise import <packet-dir> [--packet path] [--secret-map path] [--picks path] [--reviewer name] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot skillopt rubric induce --template <id> [--out <dir>] [--holdout 0.2] [--min-events N] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge-report [--template id]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge agreement [--template <id>] [--home <h>] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt judge promote --template <id> --task-kind <kind> --file <pkg.json> [--home <h>] [--yes] [--json]")

--- a/internal/cli/skillopt_rubric.go
+++ b/internal/cli/skillopt_rubric.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// `gitmoot skillopt rubric induce` (#347) — offline, deterministic rubric
+// induction (AutoLibra-style). It reads the human feedback already captured for
+// a template (RankedFeedbackEvent traits), induces a criterion-separated rubric,
+// meta-evaluates it for coverage/redundancy on a held-out split, and writes the
+// frozen rubric + report as files. It is read-only over the store and never
+// injects anywhere — a human reviews the frozen JSON and maps it onto the
+// judge's evaluator_config['rubric'] per the docs recipe.
+
+func runSkillOptRubric(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptRubricUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "induce":
+		return runSkillOptRubricInduce(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt rubric command %q\n\n", args[0])
+		printSkillOptRubricUsage(stderr)
+		return 2
+	}
+}
+
+func printSkillOptRubricUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot skillopt rubric induce --template <id> [--out <dir>] [--holdout 0.2] [--min-events N] [--home path] [--json]")
+}
+
+// skillOptRubricInduceResult is the machine-readable result of one induce run
+// (emitted under --json): the report numbers plus the paths of the written
+// artifacts.
+type skillOptRubricInduceResult struct {
+	Report     skillopt.RubricReport `json:"report"`
+	RubricPath string                `json:"rubric_path"`
+	ReportPath string                `json:"report_path"`
+	TextPath   string                `json:"report_text_path"`
+}
+
+func runSkillOptRubricInduce(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt rubric induce", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	templateID := fs.String("template", "", "template id whose feedback to induce a rubric from (required)")
+	out := fs.String("out", "", "output directory for the frozen rubric + report (default <home>/skillopt/rubrics/<template>)")
+	holdout := fs.Float64("holdout", -1, "fraction of aspects held out to measure coverage (default 0.2; 0 keeps in-sample)")
+	minEvents := fs.Int("min-events", 0, "minimum usable feedback events required (default/floor 3)")
+	jsonOutput := fs.Bool("json", false, "print the result (report + artifact paths) as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt rubric induce does not accept positional arguments")
+		return 2
+	}
+	template := strings.TrimSpace(*templateID)
+	if template == "" {
+		fmt.Fprintln(stderr, "skillopt rubric induce: --template is required")
+		return 2
+	}
+
+	var events []db.RankedFeedbackEventWithTemplate
+	var outDir string
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		var err error
+		events, err = store.ListRankedFeedbackEventsAcrossRuns(context.Background(), template)
+		if err != nil {
+			return err
+		}
+		if trimmed := strings.TrimSpace(*out); trimmed != "" {
+			outDir = trimmed
+		} else {
+			outDir = filepath.Join(paths.Home, "skillopt", "rubrics", template)
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt rubric induce: %v\n", err)
+		return 1
+	}
+
+	rubric, report, err := skillopt.InduceRubric(template, events, skillopt.RubricInduceOptions{
+		HoldoutFraction: *holdout,
+		MinEvents:       *minEvents,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt rubric induce: %v\n", err)
+		return 1
+	}
+
+	rubricPath := filepath.Join(outDir, "rubric.json")
+	reportPath := filepath.Join(outDir, "report.json")
+	textPath := filepath.Join(outDir, "report.txt")
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		fmt.Fprintf(stderr, "skillopt rubric induce: create output dir: %v\n", err)
+		return 1
+	}
+	if err := writeJSONFile(rubricPath, rubric); err != nil {
+		fmt.Fprintf(stderr, "skillopt rubric induce: write rubric: %v\n", err)
+		return 1
+	}
+	if err := writeJSONFile(reportPath, report); err != nil {
+		fmt.Fprintf(stderr, "skillopt rubric induce: write report: %v\n", err)
+		return 1
+	}
+	reportText := skillopt.RenderRubricReport(report)
+	if err := os.WriteFile(textPath, []byte(reportText), 0o644); err != nil {
+		fmt.Fprintf(stderr, "skillopt rubric induce: write report text: %v\n", err)
+		return 1
+	}
+
+	if *jsonOutput {
+		encoded, err := json.MarshalIndent(skillOptRubricInduceResult{
+			Report:     report,
+			RubricPath: rubricPath,
+			ReportPath: reportPath,
+			TextPath:   textPath,
+		}, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "skillopt rubric induce: encode result: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, string(encoded))
+		return 0
+	}
+
+	fmt.Fprint(stdout, reportText)
+	fmt.Fprintf(stdout, "\nwrote frozen rubric -> %s\n", rubricPath)
+	fmt.Fprintf(stdout, "wrote report (json)  -> %s\n", reportPath)
+	fmt.Fprintf(stdout, "wrote report (text)  -> %s\n", textPath)
+	fmt.Fprintln(stdout, "\nHUMAN-GATED: review rubric.json, then map its metrics onto the judge's")
+	fmt.Fprintln(stdout, "evaluator_config['rubric'] (see docs). Nothing was injected automatically.")
+	return 0
+}
+
+// writeJSONFile marshals v as indented JSON to path (with a trailing newline).
+func writeJSONFile(path string, v any) error {
+	encoded, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+	return os.WriteFile(path, encoded, 0o644)
+}

--- a/internal/cli/skillopt_rubric_test.go
+++ b/internal/cli/skillopt_rubric_test.go
@@ -1,0 +1,248 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// seedRubricFeedback creates one eval run for templateID and, for each seed,
+// registers a two-option review item and upserts a ranked feedback event
+// carrying the given useful (positive) / rejected (negative) traits on option
+// a. This is the real store-API seeding path the E2E exercises.
+func seedRubricFeedback(t *testing.T, home, templateID string, seeds []struct {
+	item    string
+	useful  []string
+	rejects []string
+}) {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	const runID = "rubric-run-1"
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:           runID,
+		TemplateID:   templateID,
+		TargetRepo:   "owner/repo",
+		State:        "review",
+		Mode:         db.EvalRunModeValidate,
+		OptionsCount: 2,
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun: %v", err)
+	}
+	for _, seed := range seeds {
+		if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{RunID: runID, ItemID: seed.item, Title: seed.item}); err != nil {
+			t.Fatalf("UpsertEvalReviewItem %s: %v", seed.item, err)
+		}
+		for _, label := range []string{"a", "b"} {
+			if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{
+				RunID: runID, ItemID: seed.item, Label: label, Role: "option",
+				ArtifactID: "art-" + seed.item + "-" + label,
+			}); err != nil {
+				t.Fatalf("UpsertEvalReviewOption %s/%s: %v", seed.item, label, err)
+			}
+		}
+		event := db.RankedFeedbackEvent{
+			ID:          "evt-" + seed.item,
+			RunID:       runID,
+			ItemID:      seed.item,
+			RankingJSON: `["a","b"]`,
+			Winner:      "a",
+			Reviewer:    "jerry",
+			Source:      "github",
+			SourceURL:   "https://example.test/" + seed.item,
+			CreatedAt:   "2026-07-01T10:00:00Z",
+		}
+		if len(seed.useful) > 0 {
+			encoded, _ := json.Marshal(map[string][]string{"a": seed.useful})
+			event.UsefulTraitsJSON = string(encoded)
+		}
+		if len(seed.rejects) > 0 {
+			encoded, _ := json.Marshal(map[string][]string{"a": seed.rejects})
+			event.RejectedTraitsJSON = string(encoded)
+		}
+		if err := store.UpsertRankedFeedbackEvent(ctx, event); err != nil {
+			t.Fatalf("UpsertRankedFeedbackEvent %s: %v", seed.item, err)
+		}
+	}
+}
+
+// TestSkillOptRubricInduceE2E drives the real CLI over a temp home seeded with
+// three separable feedback themes and asserts the emitted frozen rubric JSON
+// structure + the report numbers, end to end, with no LLM.
+func TestSkillOptRubricInduceE2E(t *testing.T) {
+	home := t.TempDir()
+	seedRubricFeedback(t, home, "planner", []struct {
+		item    string
+		useful  []string
+		rejects []string
+	}{
+		{"i1", []string{"clarity of the headline copy"}, nil},
+		{"i2", []string{"headline clarity reads strong"}, nil},
+		{"i3", nil, []string{"layout spacing feels cluttered"}},
+		{"i4", nil, []string{"cluttered layout spacing"}},
+		{"i5", []string{"color contrast is accessible"}, nil},
+		{"i6", nil, []string{"poor color contrast accessible"}},
+	})
+
+	outDir := home + "/rubric-out"
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "rubric", "induce", "--home", home, "--template", "planner",
+		"--out", outDir, "--holdout", "0", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("rubric induce exit = %d, stderr: %s", code, stderr.String())
+	}
+
+	var result skillOptRubricInduceResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, stdout.String())
+	}
+	if result.Report.Template != "planner" || result.Report.UsableEvents != 6 {
+		t.Fatalf("report template=%q usableEvents=%d, want planner/6", result.Report.Template, result.Report.UsableEvents)
+	}
+	if result.Report.MetricCount != 3 {
+		t.Fatalf("metric count = %d, want 3\n%s", result.Report.MetricCount, stdout.String())
+	}
+	if !result.Report.InSampleCoverage || result.Report.Coverage != 1.0 {
+		t.Fatalf("coverage = %v (inSample=%v), want in-sample 1.0", result.Report.Coverage, result.Report.InSampleCoverage)
+	}
+	if result.Report.Redundancy >= result.Report.MatchThreshold {
+		t.Fatalf("redundancy %v must be below threshold %v", result.Report.Redundancy, result.Report.MatchThreshold)
+	}
+
+	// The frozen rubric JSON on disk must parse into the induced-rubric shape
+	// with provenance and version stamp.
+	raw, err := os.ReadFile(result.RubricPath)
+	if err != nil {
+		t.Fatalf("read rubric.json: %v", err)
+	}
+	var rubric skillopt.InducedRubric
+	if err := json.Unmarshal(raw, &rubric); err != nil {
+		t.Fatalf("decode rubric.json: %v\n%s", err, raw)
+	}
+	if rubric.Version != skillopt.RubricInductionVersion || rubric.Template != "planner" || len(rubric.Metrics) != 3 {
+		t.Fatalf("rubric = v%d template=%q metrics=%d, want v%d/planner/3", rubric.Version, rubric.Template, len(rubric.Metrics), skillopt.RubricInductionVersion)
+	}
+	sawSource := false
+	for _, metric := range rubric.Metrics {
+		if metric.Name == "" || metric.Definition == "" {
+			t.Fatalf("metric missing name/definition: %+v", metric)
+		}
+		for _, id := range metric.SourceEventIDs {
+			if strings.HasPrefix(id, "evt-i") {
+				sawSource = true
+			}
+		}
+	}
+	if !sawSource {
+		t.Fatalf("expected provenance source_event_ids like evt-i1, got %+v", rubric.Metrics)
+	}
+
+	// The human-readable report.txt exists and carries the headline numbers.
+	text, err := os.ReadFile(result.TextPath)
+	if err != nil {
+		t.Fatalf("read report.txt: %v", err)
+	}
+	for _, want := range []string{"rubric induction report", "metrics induced:   3", "usable events:     6"} {
+		if !strings.Contains(string(text), want) {
+			t.Fatalf("report.txt missing %q\n%s", want, text)
+		}
+	}
+}
+
+// TestSkillOptRubricInduceTooFewEventsErrors proves the actionable error path
+// (and non-zero exit) when there is not enough feedback to induce a rubric.
+func TestSkillOptRubricInduceTooFewEventsErrors(t *testing.T) {
+	home := t.TempDir()
+	seedRubricFeedback(t, home, "planner", []struct {
+		item    string
+		useful  []string
+		rejects []string
+	}{
+		{"i1", []string{"clear headline"}, nil},
+		{"i2", []string{"nice layout"}, nil},
+	})
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "rubric", "induce", "--home", home, "--template", "planner"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit for too few events, stdout: %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "usable feedback events") {
+		t.Fatalf("stderr missing actionable message: %s", stderr.String())
+	}
+}
+
+// TestSkillOptRubricInduceRequiresTemplate proves --template is mandatory.
+func TestSkillOptRubricInduceRequiresTemplate(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "rubric", "induce", "--home", home}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2 for missing --template", code)
+	}
+	if !strings.Contains(stderr.String(), "--template is required") {
+		t.Fatalf("stderr missing required-flag message: %s", stderr.String())
+	}
+}
+
+// TestSkillOptRubricInduceHoldoutSplit exercises the held-out coverage path
+// (default 0.2 holdout) and asserts the split is reported and coverage is not
+// flagged in-sample.
+func TestSkillOptRubricInduceHoldoutSplit(t *testing.T) {
+	home := t.TempDir()
+	var seeds []struct {
+		item    string
+		useful  []string
+		rejects []string
+	}
+	// 12 events across the same three themes so a 0.2 holdout is non-empty.
+	themes := [][]string{
+		{"clarity of the headline copy", "headline clarity reads strong"},
+		{"layout spacing feels cluttered", "cluttered layout spacing here"},
+		{"color contrast is accessible", "strong color contrast accessible"},
+	}
+	for i := 0; i < 12; i++ {
+		theme := themes[i%3]
+		text := theme[i%2]
+		seeds = append(seeds, struct {
+			item    string
+			useful  []string
+			rejects []string
+		}{item: fmt.Sprintf("i%02d", i), useful: []string{text}})
+	}
+	seedRubricFeedback(t, home, "planner", seeds)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "rubric", "induce", "--home", home, "--template", "planner", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("rubric induce exit = %d, stderr: %s", code, stderr.String())
+	}
+	var result skillOptRubricInduceResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode result: %v\n%s", err, stdout.String())
+	}
+	if result.Report.InSampleCoverage {
+		t.Fatalf("expected a held-out split, got in-sample coverage: %+v", result.Report)
+	}
+	if result.Report.HoldoutAspects == 0 || result.Report.TrainAspects == 0 {
+		t.Fatalf("expected non-empty train/holdout split, got %+v", result.Report)
+	}
+	if result.Report.HoldoutFraction != 0.2 {
+		t.Fatalf("holdout fraction = %v, want default 0.2", result.Report.HoldoutFraction)
+	}
+}

--- a/internal/skillopt/rubric_induce.go
+++ b/internal/skillopt/rubric_induce.go
@@ -1,0 +1,629 @@
+package skillopt
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// Offline rubric induction (#347, AutoLibra-style — 2505.02820).
+//
+// The judge scores against a rubric; if that rubric omits a dimension real
+// reviewers care about, the judge structurally cannot catch it. This module
+// INDUCES a criterion-separated rubric from the human feedback already captured
+// in the store (RankedFeedbackEvent.UsefulTraits / RejectedTraits /
+// RequiredImprovements) and MEASURES it for coverage/redundancy on a held-out
+// split, then emits it as frozen, human-reviewable static JSON.
+//
+// It is deliberately OFFLINE and DETERMINISTIC (no LLM calls) so it stays
+// testable and reproducible: grounding is string extraction, clustering is
+// greedy single-linkage token-overlap (Jaccard). The LLM thematic-clustering
+// upgrade AutoLibra describes is a clearly-marked extension point
+// (see clusterAspects) — it would replace step (2) only, leaving grounding,
+// meta-eval, and the emitted contract unchanged.
+//
+// Nothing here auto-injects anywhere. The tool only produces files; a human
+// reviews the frozen rubric and (per the docs recipe) maps its metrics onto
+// gitmoot-skillopt's evaluator_config['rubric'] with zero judge-code change.
+
+// RubricInductionVersion is the schema version stamped into every emitted
+// frozen rubric so a downstream reader can reject a shape it does not know.
+const RubricInductionVersion = 1
+
+// Aspect is one grounded behavior signal extracted from a single feedback
+// trait string: the text, its sign (positive/negative), and the id of the
+// ranked feedback event it came from (for provenance / audit).
+type Aspect struct {
+	Text          string `json:"text"`
+	Sign          string `json:"sign"` // AspectSignPositive or AspectSignNegative
+	SourceEventID string `json:"source_event_id"`
+
+	// tokens is the normalized token set used for clustering; unexported so it
+	// never leaks into the emitted JSON.
+	tokens []string
+}
+
+const (
+	// AspectSignPositive marks a trait the reviewer valued (useful_traits).
+	AspectSignPositive = "+"
+	// AspectSignNegative marks a trait the reviewer rejected or asked to fix
+	// (rejected_traits, required_improvements).
+	AspectSignNegative = "-"
+)
+
+// RubricMetric is one induced, criterion-separated metric: a named cluster of
+// aspects with a definition, positive/negative examples, and the source event
+// ids that grounded it. This is the shape that maps onto the judge's
+// evaluator_config['rubric'] dimensions.
+type RubricMetric struct {
+	Name             string   `json:"name"`
+	Definition       string   `json:"definition"`
+	PositiveExamples []string `json:"positive_examples"`
+	NegativeExamples []string `json:"negative_examples"`
+	SourceEventIDs   []string `json:"source_event_ids"`
+
+	// members are the aspects assigned to this metric; unexported, kept for the
+	// meta-eval (coverage/redundancy) and never emitted.
+	members []Aspect
+}
+
+// InducedRubric is the frozen artifact written to rubric.json. It carries the
+// schema version, the template it was induced for, and the metrics.
+type InducedRubric struct {
+	Version  int            `json:"version"`
+	Template string         `json:"template"`
+	Metrics  []RubricMetric `json:"metrics"`
+}
+
+// RubricReport is the coverage/redundancy meta-evaluation written to
+// report.json (and rendered to report.txt). All counts are exact so the
+// numbers are reproducible and testable.
+type RubricReport struct {
+	Template        string  `json:"template"`
+	MetricCount     int     `json:"metric_count"`
+	UsableEvents    int     `json:"usable_events"`
+	TotalAspects    int     `json:"total_aspects"`
+	TrainAspects    int     `json:"train_aspects"`
+	HoldoutAspects  int     `json:"holdout_aspects"`
+	HoldoutFraction float64 `json:"holdout_fraction"`
+	MatchThreshold  float64 `json:"match_threshold"`
+	// Coverage is the fraction of held-out aspects that match some induced
+	// metric at or above MatchThreshold. When there is no held-out split
+	// (HoldoutFraction resolves to zero aspects) it is measured in-sample and
+	// InSampleCoverage is set true so the number is not read as generalization.
+	Coverage         float64 `json:"coverage"`
+	InSampleCoverage bool    `json:"in_sample_coverage"`
+	// Redundancy is the maximum inter-metric similarity (single-linkage
+	// Jaccard between any two metrics' member aspects). Lower is better; by
+	// construction it is below the clustering threshold unless a merge-down
+	// pass (too many raw clusters) combined near-duplicates.
+	Redundancy float64 `json:"redundancy"`
+}
+
+// RubricInduceOptions are the tunable knobs for one induction run. Zero values
+// resolve to the documented defaults via normalize().
+type RubricInduceOptions struct {
+	// HoldoutFraction is the fraction of aspects reserved to measure coverage.
+	// A NEGATIVE value means "unset" and resolves to the default 0.2; an
+	// explicit 0 keeps in-sample coverage (no split); values above 0.9 clamp.
+	HoldoutFraction float64
+	// MinEvents is the minimum number of usable (aspect-producing) events
+	// required; below it the run errors (hard floor 3, AutoLibra needs data).
+	MinEvents int
+	// MinMetrics is the minimum number of induced metrics required; below it
+	// the run errors (default/hard floor 2 — a single cluster is not a rubric).
+	MinMetrics int
+	// MaxMetrics caps the metric count; excess raw clusters are merged down by
+	// similarity (default 6, AutoLibra's 3–6 target upper bound).
+	MaxMetrics int
+	// Threshold is the Jaccard token-overlap threshold for both clustering
+	// (single-linkage assignment) and coverage matching (default 0.3).
+	Threshold float64
+}
+
+const (
+	rubricDefaultHoldout   = 0.2
+	rubricMinEventsFloor   = 3
+	rubricMinMetricsFloor  = 2
+	rubricDefaultMaxMetric = 6
+	rubricDefaultThreshold = 0.3
+)
+
+func (o RubricInduceOptions) normalize() RubricInduceOptions {
+	out := o
+	if out.HoldoutFraction < 0 {
+		out.HoldoutFraction = rubricDefaultHoldout
+	}
+	if out.HoldoutFraction > 0.9 {
+		out.HoldoutFraction = 0.9
+	}
+	if out.MinEvents < rubricMinEventsFloor {
+		out.MinEvents = rubricMinEventsFloor
+	}
+	if out.MinMetrics < rubricMinMetricsFloor {
+		out.MinMetrics = rubricMinMetricsFloor
+	}
+	if out.MaxMetrics <= 0 {
+		out.MaxMetrics = rubricDefaultMaxMetric
+	}
+	if out.MaxMetrics < out.MinMetrics {
+		out.MaxMetrics = out.MinMetrics
+	}
+	if out.Threshold <= 0 || out.Threshold > 1 {
+		out.Threshold = rubricDefaultThreshold
+	}
+	return out
+}
+
+// InduceRubric runs the full deterministic pipeline over the ranked feedback
+// events of one template: ground -> split -> cluster (train) -> meta-eval
+// (coverage on holdout, redundancy) -> freeze. The returned InducedRubric is
+// the train-induced metric set (the holdout is spent validating it, the
+// standard train/validation contract); the RubricReport carries the exact
+// coverage/redundancy numbers. It errors on too little data (< MinEvents usable
+// events) or a degenerate rubric (< MinMetrics clusters) with an actionable
+// message.
+func InduceRubric(template string, events []db.RankedFeedbackEventWithTemplate, opts RubricInduceOptions) (InducedRubric, RubricReport, error) {
+	template = strings.TrimSpace(template)
+	opts = opts.normalize()
+
+	aspects := groundAspects(events)
+	usable := usableEventCount(aspects)
+	if usable < opts.MinEvents {
+		return InducedRubric{}, RubricReport{}, fmt.Errorf("rubric induction needs at least %d usable feedback events (events with useful/rejected traits or required improvements), found %d for template %q: capture more human feedback before inducing", opts.MinEvents, usable, template)
+	}
+
+	train, holdout := splitAspects(aspects, opts.HoldoutFraction)
+	// The training split must still carry enough signal to cluster; if the
+	// holdout swallowed everything (pathologically small N) fall back to all
+	// aspects for training so the run is still meaningful.
+	if len(train) == 0 {
+		train = aspects
+		holdout = nil
+	}
+
+	clusters := clusterAspects(train, opts.Threshold, opts.MaxMetrics)
+	if len(clusters) < opts.MinMetrics {
+		return InducedRubric{}, RubricReport{}, fmt.Errorf("rubric induction produced only %d metric cluster(s) for template %q, need at least %d: feedback is too homogeneous or too sparse to separate criteria", len(clusters), template, opts.MinMetrics)
+	}
+
+	metrics := make([]RubricMetric, 0, len(clusters))
+	for _, cl := range clusters {
+		metrics = append(metrics, cl.toMetric())
+	}
+
+	report := RubricReport{
+		Template:        template,
+		MetricCount:     len(metrics),
+		UsableEvents:    usable,
+		TotalAspects:    len(aspects),
+		TrainAspects:    len(train),
+		HoldoutAspects:  len(holdout),
+		HoldoutFraction: opts.HoldoutFraction,
+		MatchThreshold:  opts.Threshold,
+		Redundancy:      maxInterMetricSimilarity(metrics),
+	}
+	if len(holdout) > 0 {
+		report.Coverage = coverageFraction(holdout, metrics, opts.Threshold)
+	} else {
+		report.Coverage = coverageFraction(train, metrics, opts.Threshold)
+		report.InSampleCoverage = true
+	}
+
+	rubric := InducedRubric{
+		Version:  RubricInductionVersion,
+		Template: template,
+		Metrics:  metrics,
+	}
+	return rubric, report, nil
+}
+
+// groundAspects extracts one Aspect per feedback trait string, in a
+// deterministic order: events arrive store-ordered; within each event we emit
+// useful traits (positive) then rejected traits (negative) then required
+// improvements (negative). Empty/whitespace traits and aspects that tokenize to
+// nothing are dropped (they carry no clustering signal).
+func groundAspects(events []db.RankedFeedbackEventWithTemplate) []Aspect {
+	var aspects []Aspect
+	add := func(text, sign, eventID string) {
+		text = strings.TrimSpace(text)
+		if text == "" {
+			return
+		}
+		tokens := tokenize(text)
+		if len(tokens) == 0 {
+			return
+		}
+		aspects = append(aspects, Aspect{Text: text, Sign: sign, SourceEventID: eventID, tokens: tokens})
+	}
+	for _, event := range events {
+		for _, text := range flattenTraitMap(event.UsefulTraitsJSON) {
+			add(text, AspectSignPositive, event.ID)
+		}
+		for _, text := range flattenTraitMap(event.RejectedTraitsJSON) {
+			add(text, AspectSignNegative, event.ID)
+		}
+		for _, text := range flattenStringList(event.RequiredImprovementsJSON) {
+			add(text, AspectSignNegative, event.ID)
+		}
+	}
+	return aspects
+}
+
+// flattenTraitMap decodes a useful/rejected traits JSON blob
+// (map[optionLabel][]trait) into a flat, deterministically ordered slice of
+// trait strings: option labels sorted, traits in their stored order.
+func flattenTraitMap(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	var traits map[string][]string
+	if err := json.Unmarshal([]byte(value), &traits); err != nil {
+		return nil
+	}
+	labels := make([]string, 0, len(traits))
+	for label := range traits {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	var out []string
+	for _, label := range labels {
+		out = append(out, traits[label]...)
+	}
+	return out
+}
+
+// flattenStringList decodes a required_improvements JSON blob (a flat []string)
+// preserving its stored order.
+func flattenStringList(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	var list []string
+	if err := json.Unmarshal([]byte(value), &list); err != nil {
+		return nil
+	}
+	return list
+}
+
+// usableEventCount counts the distinct source events that produced at least one
+// aspect (an event with no gradeable traits is not "usable" for induction).
+func usableEventCount(aspects []Aspect) int {
+	seen := map[string]struct{}{}
+	for _, aspect := range aspects {
+		seen[aspect.SourceEventID] = struct{}{}
+	}
+	return len(seen)
+}
+
+// splitAspects partitions aspects into a training set and a held-out set using
+// an even deterministic stride (never a contiguous tail, which would bias the
+// holdout toward the latest feedback). Aspect i is held out iff
+// floor((i+1)*f) > floor(i*f).
+func splitAspects(aspects []Aspect, fraction float64) (train, holdout []Aspect) {
+	if fraction <= 0 {
+		return append([]Aspect(nil), aspects...), nil
+	}
+	prev := 0
+	for i, aspect := range aspects {
+		cur := int(float64(i+1) * fraction)
+		if cur > prev {
+			holdout = append(holdout, aspect)
+		} else {
+			train = append(train, aspect)
+		}
+		prev = cur
+	}
+	return train, holdout
+}
+
+// cluster is the internal accumulator for one metric before it is frozen.
+type cluster struct {
+	members []Aspect
+}
+
+// clusterAspects greedily groups aspects by single-linkage Jaccard token
+// overlap with stable ordering: each aspect joins the best-matching existing
+// cluster (highest single-linkage member similarity, ties broken to the
+// earliest cluster) when that similarity meets the threshold, else it seeds a
+// new cluster. If more than maxMetrics clusters result, the most-similar pairs
+// are merged down until the cap holds. Order-stable and fully deterministic.
+//
+// EXTENSION POINT (#347): this single-pass token-overlap clusterer is the
+// deterministic v1. AutoLibra's thematic clustering would swap ONLY this
+// function for an LLM pass that groups aspects by meaning; grounding, the
+// held-out meta-eval, and the emitted contract stay identical, so the LLM
+// variant remains offline-reviewable and drop-in.
+func clusterAspects(aspects []Aspect, threshold float64, maxMetrics int) []cluster {
+	var clusters []cluster
+	for _, aspect := range aspects {
+		bestIdx := -1
+		bestSim := threshold
+		for i := range clusters {
+			sim := clusterSingleLinkage(clusters[i].members, aspect)
+			if sim >= bestSim && (bestIdx == -1 || sim > bestSim) {
+				bestSim = sim
+				bestIdx = i
+			}
+		}
+		if bestIdx == -1 {
+			clusters = append(clusters, cluster{members: []Aspect{aspect}})
+		} else {
+			clusters[bestIdx].members = append(clusters[bestIdx].members, aspect)
+		}
+	}
+	return mergeDownClusters(clusters, maxMetrics)
+}
+
+// clusterSingleLinkage returns the maximum Jaccard between an aspect and any
+// member of a cluster (single-linkage similarity).
+func clusterSingleLinkage(members []Aspect, aspect Aspect) float64 {
+	best := 0.0
+	for _, member := range members {
+		if sim := jaccard(member.tokens, aspect.tokens); sim > best {
+			best = sim
+		}
+	}
+	return best
+}
+
+// mergeDownClusters merges the most-similar cluster pair repeatedly until at
+// most maxMetrics remain. The pair is chosen by highest cross single-linkage
+// similarity, tie-broken by lowest (i, j) index for determinism.
+func mergeDownClusters(clusters []cluster, maxMetrics int) []cluster {
+	for len(clusters) > maxMetrics {
+		bestI, bestJ := 0, 1
+		bestSim := -1.0
+		for i := 0; i < len(clusters); i++ {
+			for j := i + 1; j < len(clusters); j++ {
+				sim := clustersSingleLinkage(clusters[i].members, clusters[j].members)
+				if sim > bestSim {
+					bestSim = sim
+					bestI, bestJ = i, j
+				}
+			}
+		}
+		clusters[bestI].members = append(clusters[bestI].members, clusters[bestJ].members...)
+		clusters = append(clusters[:bestJ], clusters[bestJ+1:]...)
+	}
+	return clusters
+}
+
+// clustersSingleLinkage returns the maximum Jaccard between any member of a and
+// any member of b.
+func clustersSingleLinkage(a, b []Aspect) float64 {
+	best := 0.0
+	for _, x := range a {
+		for _, y := range b {
+			if sim := jaccard(x.tokens, y.tokens); sim > best {
+				best = sim
+			}
+		}
+	}
+	return best
+}
+
+// toMetric freezes a cluster into the emitted RubricMetric: a name derived from
+// its dominant tokens, a deterministic definition, deduplicated positive /
+// negative example texts (in member order), and sorted unique source event ids.
+func (c cluster) toMetric() RubricMetric {
+	posCount, negCount := 0, 0
+	positives := newOrderedStringSet()
+	negatives := newOrderedStringSet()
+	sources := map[string]struct{}{}
+	for _, member := range c.members {
+		if member.Sign == AspectSignNegative {
+			negCount++
+			negatives.add(member.Text)
+		} else {
+			posCount++
+			positives.add(member.Text)
+		}
+		if member.SourceEventID != "" {
+			sources[member.SourceEventID] = struct{}{}
+		}
+	}
+	sourceIDs := make([]string, 0, len(sources))
+	for id := range sources {
+		sourceIDs = append(sourceIDs, id)
+	}
+	sort.Strings(sourceIDs)
+	dominant := dominantTokens(c.members, 3)
+	return RubricMetric{
+		Name:             metricName(dominant),
+		Definition:       metricDefinition(dominant, posCount, negCount, len(sourceIDs)),
+		PositiveExamples: positives.values(),
+		NegativeExamples: negatives.values(),
+		SourceEventIDs:   sourceIDs,
+		members:          c.members,
+	}
+}
+
+// dominantTokens returns up to n tokens ranked by document frequency across the
+// cluster's members (each member contributes each of its unique tokens once),
+// tie-broken alphabetically for stability.
+func dominantTokens(members []Aspect, n int) []string {
+	freq := map[string]int{}
+	for _, member := range members {
+		for _, token := range member.tokens {
+			freq[token]++
+		}
+	}
+	tokens := make([]string, 0, len(freq))
+	for token := range freq {
+		tokens = append(tokens, token)
+	}
+	sort.Slice(tokens, func(i, j int) bool {
+		if freq[tokens[i]] != freq[tokens[j]] {
+			return freq[tokens[i]] > freq[tokens[j]]
+		}
+		return tokens[i] < tokens[j]
+	})
+	if len(tokens) > n {
+		tokens = tokens[:n]
+	}
+	return tokens
+}
+
+func metricName(dominant []string) string {
+	if len(dominant) == 0 {
+		return "uncategorized"
+	}
+	return strings.Join(dominant, " / ")
+}
+
+func metricDefinition(dominant []string, positives, negatives, sources int) string {
+	topic := "reviewer feedback"
+	if len(dominant) > 0 {
+		topic = strings.Join(dominant, ", ")
+	}
+	return fmt.Sprintf("Covers feedback about %s (%d positive / %d negative signal(s) across %d source event(s)).", topic, positives, negatives, sources)
+}
+
+// coverageFraction is the fraction of the given aspects that match some metric
+// at or above the threshold (single-linkage Jaccard to any of the metric's
+// member aspects). With no aspects it is 1.0 (vacuously covered).
+func coverageFraction(aspects []Aspect, metrics []RubricMetric, threshold float64) float64 {
+	if len(aspects) == 0 {
+		return 1.0
+	}
+	matched := 0
+	for _, aspect := range aspects {
+		if aspectMatchesAnyMetric(aspect, metrics, threshold) {
+			matched++
+		}
+	}
+	return float64(matched) / float64(len(aspects))
+}
+
+func aspectMatchesAnyMetric(aspect Aspect, metrics []RubricMetric, threshold float64) bool {
+	for _, metric := range metrics {
+		if clusterSingleLinkage(metric.members, aspect) >= threshold {
+			return true
+		}
+	}
+	return false
+}
+
+// maxInterMetricSimilarity returns the largest single-linkage Jaccard between
+// any two distinct metrics' member aspects (0 for fewer than two metrics).
+func maxInterMetricSimilarity(metrics []RubricMetric) float64 {
+	best := 0.0
+	for i := 0; i < len(metrics); i++ {
+		for j := i + 1; j < len(metrics); j++ {
+			if sim := clustersSingleLinkage(metrics[i].members, metrics[j].members); sim > best {
+				best = sim
+			}
+		}
+	}
+	return best
+}
+
+// jaccard is |A∩B| / |A∪B| over two token sets (each already unique+sorted).
+// Two empty sets have similarity 0.
+func jaccard(a, b []string) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, token := range a {
+		set[token] = struct{}{}
+	}
+	intersection := 0
+	for _, token := range b {
+		if _, ok := set[token]; ok {
+			intersection++
+		}
+	}
+	union := len(a) + len(b) - intersection
+	if union == 0 {
+		return 0
+	}
+	return float64(intersection) / float64(union)
+}
+
+// rubricStopwords are common words dropped before clustering so overlap
+// reflects content, not grammar.
+var rubricStopwords = map[string]struct{}{
+	"the": {}, "and": {}, "for": {}, "with": {}, "that": {}, "this": {},
+	"has": {}, "have": {}, "was": {}, "are": {}, "but": {}, "not": {},
+	"you": {}, "your": {}, "its": {}, "too": {}, "very": {}, "more": {},
+	"less": {}, "than": {}, "then": {}, "into": {}, "from": {}, "them": {},
+	"they": {}, "some": {}, "such": {}, "all": {}, "any": {}, "can": {},
+	"could": {}, "would": {}, "should": {}, "will": {}, "does": {},
+	"did": {}, "why": {}, "how": {}, "what": {}, "which": {}, "when": {},
+	"where": {}, "who": {}, "there": {}, "here": {}, "over": {}, "under": {},
+	"about": {}, "also": {}, "just": {}, "only": {}, "much": {}, "many": {},
+}
+
+// tokenize lowercases, splits on any non-alphanumeric rune, drops stopwords and
+// tokens shorter than three characters, and returns a unique, sorted token set.
+func tokenize(text string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+	})
+	seen := map[string]struct{}{}
+	var tokens []string
+	for _, field := range fields {
+		if len(field) < 3 {
+			continue
+		}
+		if _, stop := rubricStopwords[field]; stop {
+			continue
+		}
+		if _, dup := seen[field]; dup {
+			continue
+		}
+		seen[field] = struct{}{}
+		tokens = append(tokens, field)
+	}
+	sort.Strings(tokens)
+	return tokens
+}
+
+// orderedStringSet preserves first-insertion order while deduplicating.
+type orderedStringSet struct {
+	seen  map[string]struct{}
+	order []string
+}
+
+func newOrderedStringSet() *orderedStringSet {
+	return &orderedStringSet{seen: map[string]struct{}{}}
+}
+
+func (s *orderedStringSet) add(value string) {
+	if _, ok := s.seen[value]; ok {
+		return
+	}
+	s.seen[value] = struct{}{}
+	s.order = append(s.order, value)
+}
+
+func (s *orderedStringSet) values() []string {
+	return append([]string(nil), s.order...)
+}
+
+// RenderRubricReport renders the meta-eval report as human-readable text (the
+// report.txt artifact and the default CLI summary).
+func RenderRubricReport(report RubricReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "rubric induction report (#347 offline, deterministic)\n")
+	fmt.Fprintf(&b, "  template:          %s\n", report.Template)
+	fmt.Fprintf(&b, "  metrics induced:   %d\n", report.MetricCount)
+	fmt.Fprintf(&b, "  usable events:     %d\n", report.UsableEvents)
+	fmt.Fprintf(&b, "  aspects (total):   %d (train %d, holdout %d)\n", report.TotalAspects, report.TrainAspects, report.HoldoutAspects)
+	fmt.Fprintf(&b, "  holdout fraction:  %.2f\n", report.HoldoutFraction)
+	fmt.Fprintf(&b, "  match threshold:   %.2f (Jaccard)\n", report.MatchThreshold)
+	if report.InSampleCoverage {
+		fmt.Fprintf(&b, "  coverage:          %.3f (in-sample — no held-out split)\n", report.Coverage)
+	} else {
+		fmt.Fprintf(&b, "  coverage:          %.3f (held-out aspects matched)\n", report.Coverage)
+	}
+	fmt.Fprintf(&b, "  redundancy:        %.3f (max inter-metric similarity; lower is better)\n", report.Redundancy)
+	return b.String()
+}

--- a/internal/skillopt/rubric_induce_test.go
+++ b/internal/skillopt/rubric_induce_test.go
@@ -1,0 +1,291 @@
+package skillopt
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// mustTraitJSON encodes a per-option trait map the way the store persists
+// useful_traits_json / rejected_traits_json.
+func mustTraitJSON(t *testing.T, traits map[string][]string) string {
+	t.Helper()
+	encoded, err := json.Marshal(traits)
+	if err != nil {
+		t.Fatalf("marshal traits: %v", err)
+	}
+	return string(encoded)
+}
+
+func mustListJSON(t *testing.T, list []string) string {
+	t.Helper()
+	encoded, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("marshal list: %v", err)
+	}
+	return string(encoded)
+}
+
+// TestTokenizeDropsNoiseAndDedups pins the normalization the whole pipeline
+// leans on: lowercase, split on non-alphanumerics, drop stopwords and <3-char
+// tokens, dedup, and sort.
+func TestTokenizeDropsNoiseAndDedups(t *testing.T) {
+	got := tokenize("The clear, Clear value-prop is A win!!")
+	want := []string{"clear", "prop", "value", "win"}
+	if len(got) != len(want) {
+		t.Fatalf("tokens = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("tokens = %v, want %v", got, want)
+		}
+	}
+	if len(tokenize("a to of an")) != 0 {
+		t.Fatalf("all-short/stopword text must tokenize to nothing, got %v", tokenize("a to of an"))
+	}
+}
+
+// TestJaccardExact pins the similarity math with hand-computed fixtures.
+func TestJaccardExact(t *testing.T) {
+	cases := []struct {
+		a, b []string
+		want float64
+	}{
+		{[]string{"clarity", "layout"}, []string{"clarity", "layout"}, 1.0},
+		{[]string{"clarity", "layout"}, []string{"clarity", "color"}, 1.0 / 3.0},
+		{[]string{"clarity"}, []string{"color"}, 0.0},
+		{[]string{}, []string{"color"}, 0.0},
+		{[]string{"a"}, []string{}, 0.0},
+	}
+	for _, tc := range cases {
+		if got := jaccard(tc.a, tc.b); math.Abs(got-tc.want) > 1e-12 {
+			t.Fatalf("jaccard(%v,%v) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// TestGroundAspectsOrderAndSigns pins grounding: useful traits are positive,
+// rejected traits and required improvements are negative, option labels are
+// visited in sorted order, and empty / untokenizable traits are dropped.
+func TestGroundAspectsOrderAndSigns(t *testing.T) {
+	events := []db.RankedFeedbackEventWithTemplate{
+		{
+			RankedFeedbackEvent: db.RankedFeedbackEvent{
+				ID:                       "evt-1",
+				UsefulTraitsJSON:         mustTraitJSON(t, map[string][]string{"b": {"clear headline"}, "a": {"strong value prop"}}),
+				RejectedTraitsJSON:       mustTraitJSON(t, map[string][]string{"a": {"cluttered layout"}}),
+				RequiredImprovementsJSON: mustListJSON(t, []string{"tighten the spacing", "  ", "of an"}),
+			},
+		},
+	}
+	aspects := groundAspects(events)
+	// Order: useful (labels sorted a,b) then rejected then improvements;
+	// "  " (empty) and "of an" (only stopwords) are dropped.
+	wantTexts := []string{"strong value prop", "clear headline", "cluttered layout", "tighten the spacing"}
+	wantSigns := []string{AspectSignPositive, AspectSignPositive, AspectSignNegative, AspectSignNegative}
+	if len(aspects) != len(wantTexts) {
+		t.Fatalf("got %d aspects %+v, want %d", len(aspects), aspects, len(wantTexts))
+	}
+	for i := range wantTexts {
+		if aspects[i].Text != wantTexts[i] || aspects[i].Sign != wantSigns[i] {
+			t.Fatalf("aspect %d = {%q,%q}, want {%q,%q}", i, aspects[i].Text, aspects[i].Sign, wantTexts[i], wantSigns[i])
+		}
+		if aspects[i].SourceEventID != "evt-1" {
+			t.Fatalf("aspect %d source = %q, want evt-1", i, aspects[i].SourceEventID)
+		}
+	}
+	if usableEventCount(aspects) != 1 {
+		t.Fatalf("usable events = %d, want 1", usableEventCount(aspects))
+	}
+}
+
+// TestSplitAspectsEvenStride pins the deterministic holdout stride: for f=0.2
+// every 5th aspect is held out, distributed (not a contiguous tail).
+func TestSplitAspectsEvenStride(t *testing.T) {
+	aspects := make([]Aspect, 10)
+	for i := range aspects {
+		aspects[i] = Aspect{Text: string(rune('a' + i))}
+	}
+	train, holdout := splitAspects(aspects, 0.2)
+	if len(holdout) != 2 || len(train) != 8 {
+		t.Fatalf("train=%d holdout=%d, want 8/2", len(train), len(holdout))
+	}
+	// f=0.2: floor((i+1)*.2)>floor(i*.2) is true at i=4 and i=9.
+	if holdout[0].Text != string(rune('a'+4)) || holdout[1].Text != string(rune('a'+9)) {
+		t.Fatalf("holdout picks = %q,%q, want e,j", holdout[0].Text, holdout[1].Text)
+	}
+}
+
+// TestClusterAspectsSeparatesThemes seeds three clearly-separated token themes
+// and asserts greedy single-linkage clustering recovers exactly three metrics,
+// each grouping its own theme, with a deterministic dominant-token name.
+func TestClusterAspectsSeparatesThemes(t *testing.T) {
+	texts := []struct {
+		text string
+		sign string
+	}{
+		{"clarity of the headline copy", AspectSignPositive},
+		{"headline clarity is strong", AspectSignPositive},
+		{"layout spacing feels cluttered", AspectSignNegative},
+		{"cluttered layout spacing", AspectSignNegative},
+		{"color contrast is accessible", AspectSignPositive},
+		{"poor color contrast accessible", AspectSignNegative},
+	}
+	var aspects []Aspect
+	for i, tc := range texts {
+		aspects = append(aspects, Aspect{Text: tc.text, Sign: tc.sign, SourceEventID: "e", tokens: tokenize(tc.text)})
+		_ = i
+	}
+	clusters := clusterAspects(aspects, 0.3, 6)
+	if len(clusters) != 3 {
+		t.Fatalf("clusters = %d, want 3: %+v", len(clusters), clusters)
+	}
+	for _, cl := range clusters {
+		if len(cl.members) != 2 {
+			t.Fatalf("each theme should hold 2 aspects, got %d", len(cl.members))
+		}
+	}
+	// Redundancy between well-separated themes must be below the threshold.
+	metrics := make([]RubricMetric, 0, len(clusters))
+	for _, cl := range clusters {
+		metrics = append(metrics, cl.toMetric())
+	}
+	if red := maxInterMetricSimilarity(metrics); red >= 0.3 {
+		t.Fatalf("redundancy = %v, want < 0.3 for separated themes", red)
+	}
+	// Names derive from dominant tokens.
+	if metrics[0].Name == "" || metrics[0].Definition == "" {
+		t.Fatalf("metric 0 missing name/definition: %+v", metrics[0])
+	}
+}
+
+// TestMergeDownRespectsCap seeds seven singleton themes and asserts the
+// merge-down pass caps the metric count at maxMetrics.
+func TestMergeDownRespectsCap(t *testing.T) {
+	var aspects []Aspect
+	words := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"}
+	for _, w := range words {
+		aspects = append(aspects, Aspect{Text: w + " signal", Sign: AspectSignPositive, tokens: tokenize(w + " signal")})
+	}
+	clusters := clusterAspects(aspects, 0.9, 6)
+	if len(clusters) > 6 {
+		t.Fatalf("clusters = %d, want <= 6 after merge-down", len(clusters))
+	}
+}
+
+// TestCoverageFractionExact pins the coverage math: two held-out aspects, one
+// matching an induced metric above threshold and one not, is coverage 0.5.
+func TestCoverageFractionExact(t *testing.T) {
+	metric := RubricMetric{members: []Aspect{{tokens: tokenize("clarity headline copy")}}}
+	holdout := []Aspect{
+		{tokens: tokenize("clarity of the headline")}, // shares clarity+headline -> matches
+		{tokens: tokenize("unrelated pricing tier")},  // no overlap -> misses
+	}
+	if got := coverageFraction(holdout, []RubricMetric{metric}, 0.3); math.Abs(got-0.5) > 1e-12 {
+		t.Fatalf("coverage = %v, want 0.5", got)
+	}
+	if got := coverageFraction(nil, []RubricMetric{metric}, 0.3); got != 1.0 {
+		t.Fatalf("empty coverage = %v, want 1.0 (vacuous)", got)
+	}
+}
+
+// TestInduceRubricEndToEndDeterministic runs the full pipeline over a seeded
+// three-theme fixture and pins the frozen rubric + report numbers.
+func TestInduceRubricEndToEndDeterministic(t *testing.T) {
+	events := rubricThemeFixture(t)
+	rubric, report, err := InduceRubric("planner", events, RubricInduceOptions{HoldoutFraction: 0})
+	if err != nil {
+		t.Fatalf("InduceRubric returned error: %v", err)
+	}
+	if rubric.Version != RubricInductionVersion || rubric.Template != "planner" {
+		t.Fatalf("rubric header = {v%d,%q}, want {v%d,planner}", rubric.Version, rubric.Template, RubricInductionVersion)
+	}
+	if len(rubric.Metrics) != 3 {
+		t.Fatalf("metrics = %d, want 3: %+v", len(rubric.Metrics), rubric.Metrics)
+	}
+	if report.MetricCount != 3 || report.UsableEvents != 6 {
+		t.Fatalf("report metrics=%d usableEvents=%d, want 3/6", report.MetricCount, report.UsableEvents)
+	}
+	// holdout=0 -> in-sample coverage, which must be perfect for the
+	// self-consistent themes.
+	if !report.InSampleCoverage || report.Coverage != 1.0 {
+		t.Fatalf("coverage = %v (inSample=%v), want 1.0 in-sample", report.Coverage, report.InSampleCoverage)
+	}
+	if report.Redundancy >= report.MatchThreshold {
+		t.Fatalf("redundancy = %v, want < threshold %v", report.Redundancy, report.MatchThreshold)
+	}
+	// Every emitted metric carries provenance.
+	for i, metric := range rubric.Metrics {
+		if len(metric.SourceEventIDs) == 0 {
+			t.Fatalf("metric %d has no source event ids", i)
+		}
+		if len(metric.PositiveExamples)+len(metric.NegativeExamples) == 0 {
+			t.Fatalf("metric %d has no examples", i)
+		}
+	}
+	// Determinism: a second run yields byte-identical frozen JSON.
+	rubric2, _, err := InduceRubric("planner", events, RubricInduceOptions{HoldoutFraction: 0})
+	if err != nil {
+		t.Fatalf("second InduceRubric returned error: %v", err)
+	}
+	a, _ := json.Marshal(rubric)
+	b, _ := json.Marshal(rubric2)
+	if string(a) != string(b) {
+		t.Fatalf("frozen rubric not deterministic:\n%s\n%s", a, b)
+	}
+}
+
+// TestInduceRubricErrors covers the two actionable error paths.
+func TestInduceRubricErrors(t *testing.T) {
+	// Too few usable events (< 3).
+	few := []db.RankedFeedbackEventWithTemplate{
+		{RankedFeedbackEvent: db.RankedFeedbackEvent{ID: "e1", UsefulTraitsJSON: mustTraitJSON(t, map[string][]string{"a": {"clear headline"}})}},
+		{RankedFeedbackEvent: db.RankedFeedbackEvent{ID: "e2", UsefulTraitsJSON: mustTraitJSON(t, map[string][]string{"a": {"nice layout"}})}},
+	}
+	if _, _, err := InduceRubric("planner", few, RubricInduceOptions{}); err == nil {
+		t.Fatal("expected error for < 3 usable events")
+	}
+	// Enough events but homogeneous -> single cluster -> < 2 metrics error.
+	var homo []db.RankedFeedbackEventWithTemplate
+	for i := 0; i < 4; i++ {
+		homo = append(homo, db.RankedFeedbackEventWithTemplate{RankedFeedbackEvent: db.RankedFeedbackEvent{
+			ID:               "h" + string(rune('0'+i)),
+			UsefulTraitsJSON: mustTraitJSON(t, map[string][]string{"a": {"clarity headline clarity headline"}}),
+		}})
+	}
+	if _, _, err := InduceRubric("planner", homo, RubricInduceOptions{HoldoutFraction: 0}); err == nil {
+		t.Fatal("expected error for < 2 metric clusters")
+	}
+}
+
+// rubricThemeFixture builds six events across three separable themes (clarity,
+// layout, color), one theme-pair per event so usableEventCount is 6.
+func rubricThemeFixture(t *testing.T) []db.RankedFeedbackEventWithTemplate {
+	t.Helper()
+	seeds := []struct {
+		id      string
+		useful  []string
+		rejects []string
+	}{
+		{"evt-1", []string{"clarity of the headline copy"}, nil},
+		{"evt-2", []string{"headline clarity reads strong"}, nil},
+		{"evt-3", nil, []string{"layout spacing feels cluttered"}},
+		{"evt-4", nil, []string{"cluttered layout spacing"}},
+		{"evt-5", []string{"color contrast is accessible"}, nil},
+		{"evt-6", nil, []string{"poor color contrast accessible"}},
+	}
+	var events []db.RankedFeedbackEventWithTemplate
+	for _, seed := range seeds {
+		event := db.RankedFeedbackEvent{ID: seed.id}
+		if len(seed.useful) > 0 {
+			event.UsefulTraitsJSON = mustTraitJSON(t, map[string][]string{"a": seed.useful})
+		}
+		if len(seed.rejects) > 0 {
+			event.RejectedTraitsJSON = mustTraitJSON(t, map[string][]string{"a": seed.rejects})
+		}
+		events = append(events, db.RankedFeedbackEventWithTemplate{RankedFeedbackEvent: event, TemplateID: "planner"})
+	}
+	return events
+}

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -207,7 +207,11 @@ continuing. For optimizer-phase recovery, use
 `gitmoot skillopt train recover --session <id> [--out-root path] [--json]`,
 which re-imports or repairs the optimizer candidate package and classifies the
 iteration; it does not release the generation lock or rebuild generation
-options.
+options. To improve the *judge's rubric* (not the model) from accumulated human
+feedback, run `gitmoot skillopt rubric induce --template <id>` — an offline,
+deterministic tool that induces a criterion-separated rubric from captured
+trait feedback, meta-evaluates it for coverage/redundancy, and writes a frozen
+JSON for human review; it never auto-injects.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1090,6 +1090,7 @@ gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-com
 gitmoot skillopt gate history --candidate <version-id> [--json]
 gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 gitmoot skillopt pairwise import <packet-dir> [--packet path] [--secret-map path] [--picks path] [--reviewer name] [--json]
+gitmoot skillopt rubric induce --template <id> [--out <dir>] [--holdout 0.2] [--min-events N] [--home path] [--json]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
@@ -1261,6 +1262,45 @@ fixed `--seed` pinned the champion to one position), and a summary of the
 candidate-level judge outcomes above. Small samples get a loud warning —
 sample size is the limiter. `--json` emits the machine-readable report. It is
 read-only.
+
+`skillopt rubric induce` is the **offline, deterministic rubric-induction**
+tool (#344/#347, AutoLibra-style — 2505.02820). It reads the human feedback
+already captured for a template (the `useful_traits` / `rejected_traits` /
+`required_improvements` on ranked feedback events, across all of that
+template's runs) and **induces a criterion-separated rubric** from it, then
+freezes it as reviewed static JSON. The pipeline is fully offline (no LLM
+calls, so it is reproducible and testable): (1) **ground** each trait string
+into an aspect `{text, sign +/-, source_event_id}`; (2) **cluster** aspects by
+normalized token-overlap (Jaccard, greedy single-linkage, stable ordering)
+into up to six metrics, each `{name, definition, positive_examples,
+negative_examples, source_event_ids}`; (3) **meta-evaluate** on a held-out
+split — `coverage` (fraction of held-out aspects a metric matches) and
+`redundancy` (max inter-metric similarity, lower is better); (4) **write**
+`rubric.json` (the frozen rubric, `{version, template, metrics[...]}`),
+`report.json`, and a human-readable `report.txt` under `--out` (default
+`<home>/skillopt/rubrics/<template>`). Flags: `--template <id>` (required),
+`--holdout 0.2` (fraction reserved for coverage; `0` keeps in-sample),
+`--min-events N` (minimum usable feedback events, hard floor 3),
+`--home <path>`, and `--json` (emits the report plus the artifact paths). It
+errors with an actionable message and a non-zero exit when there are fewer than
+three usable feedback events or fewer than two separable metric clusters. The
+token-overlap clusterer is the deterministic v1; swapping in AutoLibra's LLM
+thematic clustering is a clearly-marked extension point that changes only the
+clustering step, leaving grounding, the held-out meta-eval, and the emitted
+contract identical.
+
+The tool is **read-only over the store and human-gated**: it only writes files
+and never injects anywhere. To adopt an induced rubric, a human reviews
+`rubric.json` and maps its metrics onto gitmoot-skillopt's
+`evaluator_config['rubric']` — one dimension per metric, with the metric
+`name` as the dimension key, its `definition` (and `positive_examples` /
+`negative_examples`) as the description, and a weight the reviewer chooses.
+Because `_compose_evaluator_rubric` already merges arbitrary
+`evaluator_config['rubric']` dimensions and `_normalize_dimension_list`
+accepts arbitrary names, this needs **zero judge-code change and no result
+contract bump**. For example a metric named `clarity / headline / copy` becomes
+`evaluator_config['rubric'] = {"clarity / headline / copy": {"description":
+"<definition + examples>", "weight": 1.0}}`.
 
 `skillopt judge promote` closes the judge-prompt optimization loop: it applies an
 **accepted** judge-prompt variant (from the judge-prompt optimizer's

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1036,6 +1036,7 @@ gitmoot skillopt candidate promote <version-id>
 gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 gitmoot skillopt pairwise import <packet-dir> [--packet path] [--secret-map path] [--picks path] [--reviewer name] [--json]
+gitmoot skillopt rubric induce --template <id> [--out <dir>] [--holdout 0.2] [--min-events N] [--home path] [--json]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
@@ -1191,6 +1192,43 @@ fixed `--seed` pinned the champion to one position), and a summary of the
 candidate-level judge outcomes above. Small samples get a loud warning —
 sample size is the limiter. `--json` emits the machine-readable report. It is
 read-only.
+
+`skillopt rubric induce` is the **offline, deterministic rubric-induction**
+tool (#344/#347, AutoLibra-style — 2505.02820). It reads the human feedback
+already captured for a template (the `useful_traits` / `rejected_traits` /
+`required_improvements` on ranked feedback events, across all of that
+template's runs) and **induces a criterion-separated rubric** from it, then
+freezes it as reviewed static JSON. The pipeline is fully offline — no LLM
+calls, so it is reproducible and testable: (1) **ground** each trait string
+into an aspect `{text, sign +/-, source_event_id}`; (2) **cluster** aspects by
+normalized token-overlap (Jaccard, greedy single-linkage, stable ordering)
+into up to six metrics, each `{name, definition, positive_examples,
+negative_examples, source_event_ids}`; (3) **meta-evaluate** on a held-out
+split — `coverage` (fraction of held-out aspects a metric matches) and
+`redundancy` (max inter-metric similarity, lower is better); (4) **write**
+`rubric.json` (the frozen rubric, `{version, template, metrics[...]}`),
+`report.json`, and a human-readable `report.txt` under `--out` (default
+`<home>/skillopt/rubrics/<template>`). Flags: `--template <id>` (required),
+`--holdout 0.2` (fraction reserved for coverage; `0` keeps in-sample),
+`--min-events N` (minimum usable feedback events, hard floor 3),
+`--home <path>`, and `--json` (emits the report plus the artifact paths). It
+errors with an actionable message and a non-zero exit when there are fewer than
+three usable feedback events or fewer than two separable metric clusters. The
+token-overlap clusterer is the deterministic v1; swapping in AutoLibra's LLM
+thematic clustering is a clearly-marked extension point that changes only the
+clustering step, leaving grounding, the held-out meta-eval, and the emitted
+contract identical.
+
+The tool is **read-only over the store and human-gated**: it only writes files
+and never injects anywhere. To adopt an induced rubric, a human reviews
+`rubric.json` and maps its metrics onto gitmoot-skillopt's
+`evaluator_config['rubric']` — one dimension per metric, using the metric
+`name` as the dimension key and its `definition` (plus the positive/negative
+examples) as the description, with a weight the reviewer chooses. Because the
+judge's `_compose_evaluator_rubric` already merges arbitrary
+`evaluator_config['rubric']` dimensions and `_normalize_dimension_list`
+accepts arbitrary names, adopting an induced rubric needs **zero judge-code
+change and no result-contract bump**.
 
 `skillopt judge promote` closes the judge-prompt optimization loop: it applies an
 **accepted** judge-prompt variant (from the judge-prompt optimizer's

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -7635,7 +7635,11 @@ continuing. For optimizer-phase recovery, use
 `gitmoot skillopt train recover --session <id> [--out-root path] [--json]`,
 which re-imports or repairs the optimizer candidate package and classifies the
 iteration; it does not release the generation lock or rebuild generation
-options.
+options. To improve the *judge's rubric* (not the model) from accumulated human
+feedback, run `gitmoot skillopt rubric induce --template <id>` — an offline,
+deterministic tool that induces a criterion-separated rubric from captured
+trait feedback, meta-evaluates it for coverage/redundancy, and writes a frozen
+JSON for human review; it never auto-injects.
 
 For complete command examples, read [CLI.md](references/CLI.md).
 For end-to-end workflows, read [WORKFLOWS.md](references/WORKFLOWS.md).
@@ -8914,6 +8918,7 @@ gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-com
 gitmoot skillopt gate history --candidate <version-id> [--json]
 gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 gitmoot skillopt pairwise import <packet-dir> [--packet path] [--secret-map path] [--picks path] [--reviewer name] [--json]
+gitmoot skillopt rubric induce --template <id> [--out <dir>] [--holdout 0.2] [--min-events N] [--home path] [--json]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
 gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]
 gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]
@@ -9085,6 +9090,45 @@ fixed `--seed` pinned the champion to one position), and a summary of the
 candidate-level judge outcomes above. Small samples get a loud warning —
 sample size is the limiter. `--json` emits the machine-readable report. It is
 read-only.
+
+`skillopt rubric induce` is the **offline, deterministic rubric-induction**
+tool (#344/#347, AutoLibra-style — 2505.02820). It reads the human feedback
+already captured for a template (the `useful_traits` / `rejected_traits` /
+`required_improvements` on ranked feedback events, across all of that
+template's runs) and **induces a criterion-separated rubric** from it, then
+freezes it as reviewed static JSON. The pipeline is fully offline (no LLM
+calls, so it is reproducible and testable): (1) **ground** each trait string
+into an aspect `{text, sign +/-, source_event_id}`; (2) **cluster** aspects by
+normalized token-overlap (Jaccard, greedy single-linkage, stable ordering)
+into up to six metrics, each `{name, definition, positive_examples,
+negative_examples, source_event_ids}`; (3) **meta-evaluate** on a held-out
+split — `coverage` (fraction of held-out aspects a metric matches) and
+`redundancy` (max inter-metric similarity, lower is better); (4) **write**
+`rubric.json` (the frozen rubric, `{version, template, metrics[...]}`),
+`report.json`, and a human-readable `report.txt` under `--out` (default
+`<home>/skillopt/rubrics/<template>`). Flags: `--template <id>` (required),
+`--holdout 0.2` (fraction reserved for coverage; `0` keeps in-sample),
+`--min-events N` (minimum usable feedback events, hard floor 3),
+`--home <path>`, and `--json` (emits the report plus the artifact paths). It
+errors with an actionable message and a non-zero exit when there are fewer than
+three usable feedback events or fewer than two separable metric clusters. The
+token-overlap clusterer is the deterministic v1; swapping in AutoLibra's LLM
+thematic clustering is a clearly-marked extension point that changes only the
+clustering step, leaving grounding, the held-out meta-eval, and the emitted
+contract identical.
+
+The tool is **read-only over the store and human-gated**: it only writes files
+and never injects anywhere. To adopt an induced rubric, a human reviews
+`rubric.json` and maps its metrics onto gitmoot-skillopt's
+`evaluator_config['rubric']` — one dimension per metric, with the metric
+`name` as the dimension key, its `definition` (and `positive_examples` /
+`negative_examples`) as the description, and a weight the reviewer chooses.
+Because `_compose_evaluator_rubric` already merges arbitrary
+`evaluator_config['rubric']` dimensions and `_normalize_dimension_list`
+accepts arbitrary names, this needs **zero judge-code change and no result
+contract bump**. For example a metric named `clarity / headline / copy` becomes
+`evaluator_config['rubric'] = {"clarity / headline / copy": {"description":
+"<definition + examples>", "weight": 1.0}}`.
 
 `skillopt judge promote` closes the judge-prompt optimization loop: it applies an
 **accepted** judge-prompt variant (from the judge-prompt optimizer's


### PR DESCRIPTION
## What

Adds `gitmoot skillopt rubric induce`, an **offline, deterministic (no-LLM)** AutoLibra-style rubric-induction tool (#347, part of the evaluator-hardening epic #344). It turns accumulated human feedback into a **frozen, criterion-separated rubric** for the judge — improving the *rubric*, not the model.

## Why

The judge scores against a hardcoded rubric. If that rubric omits a dimension reviewers actually care about, the judge structurally cannot catch it. This tool induces a criterion-separated checklist from the human feedback already captured for a template, validates it for coverage/redundancy, and freezes it as reviewed static JSON for human adoption.

## How

New `internal/skillopt/rubric_induce.go` (pure, testable pipeline) + `internal/cli/skillopt_rubric.go` subcommand:

1. **Ground** each `useful_traits` / `rejected_traits` / `required_improvements` string (read via the existing `ListRankedFeedbackEventsAcrossRuns`) into an aspect `{text, sign +/-, source_event_id}`.
2. **Cluster** aspects by normalized token-overlap (Jaccard, greedy single-linkage, stable ordering) into up to 6 metrics `{name, definition, positive_examples, negative_examples, source_event_ids}`, merging down when raw clusters exceed the cap.
3. **Meta-evaluate** on a deterministic held-out split: `coverage` (fraction of held-out aspects a metric matches) + `redundancy` (max inter-metric similarity).
4. **Write** `rubric.json` (frozen `{version, template, metrics}`), `report.json`, `report.txt` under `--out`.

Flags: `--template <id>` (required), `--out <dir>`, `--holdout 0.2` (`0` keeps in-sample), `--min-events N` (floor 3), `--home`, `--json`.

**Additive and off the hot path**: new subcommand + new module, read-only over the store, no contract bump, no schema change. **Human-gated**: emits files only, never auto-injects. The token-overlap clusterer is a clearly-marked extension point for AutoLibra's LLM thematic clustering (swaps step 2 only). Errors with a non-zero exit + actionable message on <3 usable events or <2 separable clusters.

Docs (same PR): `CLI.md` + `website/docs/reference/cli.md` document the command and the **zero-judge-code injection recipe** onto `evaluator_config['rubric']`; `SKILL.md` gets a one-line trigger; `llms-full.txt` regenerated.

## How tested

Ran from the clone root with the repo's Go 1.26.4 toolchain:

- `go build ./...` — pass
- `go vet ./internal/skillopt/ ./internal/cli/` — pass
- `go test -count=1 ./internal/skillopt/` — ok (9.2s)
- `go test -count=1 -timeout 15m ./internal/cli/` — ok (252s)
- `cd website && npm ci && npm run build` — pass (build:llms + docusaurus build)
- `go test -race -count=1 -timeout 20m ./internal/cli/` — started in background; CI runs the authoritative full race matrix.

New tests:
- **Unit** (`internal/skillopt/rubric_induce_test.go`): tokenize, jaccard, grounding order/signs, even-stride split, cluster theme separation, merge-down cap, coverage math, full-pipeline determinism, both error paths.
- **E2E** (`internal/cli/skillopt_rubric_test.go`): temp home + store-API-seeded feedback + real CLI — asserts emitted `rubric.json` structure/provenance + report numbers, the held-out split path, the too-few-events error, and the required `--template`.

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)