### PR TITLE
feat(workflow): preset prompt delivery modes full|referenced|auto

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1359,6 +1359,17 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
+	// preset-delivery is a sticky per-agent preference. When re-subscribing an
+	// existing agent (e.g. to refresh its session/repo) without passing the flag,
+	// we must preserve the stored mode rather than write empty — which normalizes
+	// to full and would silently disable a previously-chosen auto/referenced mode.
+	presetDeliveryExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "preset-delivery" {
+			presetDeliveryExplicit = true
+		}
+	})
+
 	normalizedRepos, err := normalizeRepoFlags(repos)
 	if err != nil {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
@@ -1419,6 +1430,11 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		if agent.TemplateID != "" {
 			if _, err := loadInstalledTemplate(context.Background(), store, agent.TemplateID); err != nil {
 				return err
+			}
+		}
+		if !presetDeliveryExplicit {
+			if existing, err := store.GetAgent(context.Background(), agent.Name); err == nil {
+				agent.PresetDelivery = existing.PresetDelivery
 			}
 		}
 		return persistAgentSubscription(context.Background(), store, agent, normalizedRepos)

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -64,6 +64,8 @@ func runAgent(args []string, stdout, stderr io.Writer) int {
 		return runAgentGC(args[1:], stdout, stderr)
 	case "subscribe":
 		return runAgentSubscribe(args[1:], stdout, stderr)
+	case "update":
+		return runAgentUpdate(args[1:], stdout, stderr)
 	case "show":
 		return runAgentShow(args[1:], stdout, stderr)
 	case "list":
@@ -100,8 +102,9 @@ func printAgentUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot agent template list|show|add|draft|validate|update|diff ...")
 	fmt.Fprintln(w, "  gitmoot agent prompt <agent-or-template> [--json] [--record [--repo owner/repo] [--type ask|review|implement]]")
 	fmt.Fprintln(w, "  gitmoot agent gc")
-	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|kimi|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] [--model model] --capability <capability>")
+	fmt.Fprintln(w, "  gitmoot agent subscribe <name> --runtime codex|claude|kimi|shell --session <id|name|last|command> --role <role> [--repo owner/repo...] [--model model] [--preset-delivery full|referenced|auto] --capability <capability>")
 	fmt.Fprintln(w, "    Codex sessions may use a UUID, thread name, or last. Claude sessions may use a UUID or last. Kimi sessions may use a Kimi session id. Shell sessions are commands.")
+	fmt.Fprintln(w, "  gitmoot agent update <name> --preset-delivery full|referenced|auto")
 	fmt.Fprintln(w, "  gitmoot agent allow <name> --repo owner/repo")
 	fmt.Fprintln(w, "  gitmoot agent deny <name> --repo owner/repo")
 	fmt.Fprintln(w, "  gitmoot agent repos <name>")
@@ -1331,6 +1334,7 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 	templateID := fs.String("template", "", "agent template")
 	model := fs.String("model", "", "default runtime model for this agent")
 	policy := fs.String("policy", "auto", "autonomy policy")
+	presetDelivery := fs.String("preset-delivery", "", "preset prompt delivery mode: full (default), referenced, or auto")
 	var repos repeatedFlag
 	var capabilities repeatedFlag
 	fs.Var(&repos, "repo", "allowed repo as owner/repo, repeatable")
@@ -1385,6 +1389,11 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "invalid template: %v\n", err)
 		return 2
 	}
+	deliveryMode := strings.TrimSpace(*presetDelivery)
+	if deliveryMode != "" && !db.ValidPresetDeliveryMode(deliveryMode) {
+		fmt.Fprintf(stderr, "invalid --preset-delivery %q: want full, referenced, or auto\n", deliveryMode)
+		return 2
+	}
 	agent := runtime.Agent{
 		Name:           name,
 		Role:           resolvedRole,
@@ -1396,6 +1405,7 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 		Capabilities:   resolvedCapabilities,
 		AutonomyPolicy: strings.TrimSpace(*policy),
 		HealthStatus:   "unknown",
+		PresetDelivery: strings.ToLower(deliveryMode),
 	}
 	if err := runtime.ValidateAgent(agent); err != nil {
 		fmt.Fprintf(stderr, "invalid agent: %v\n", err)
@@ -1425,6 +1435,55 @@ func runAgentSubscribe(args []string, stdout, stderr io.Writer) int {
 	} else {
 		fmt.Fprintf(stdout, "subscribed %s (%s) for %s\n", agent.Name, agent.Runtime, strings.Join(normalizedRepos, ","))
 	}
+	return 0
+}
+
+// runAgentUpdate mutates one flag-updatable field of an already-registered agent
+// in place (#33). Today it exposes --preset-delivery; it mirrors the in-place
+// update path (UpdateAgentRuntimeRef) rather than re-running the full subscribe
+// upsert, so an operator can flip the preset delivery mode without re-declaring
+// runtime/session/role.
+func runAgentUpdate(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("agent update", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	presetDelivery := fs.String("preset-delivery", "", "preset prompt delivery mode: full, referenced, or auto")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		fmt.Fprintln(stderr, "Usage: gitmoot agent update <name> --preset-delivery full|referenced|auto")
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "agent update requires exactly one name")
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || name == "" {
+		fmt.Fprintln(stderr, "agent update requires exactly one name")
+		return 2
+	}
+	mode := strings.TrimSpace(*presetDelivery)
+	if mode == "" {
+		fmt.Fprintln(stderr, "agent update requires at least one field to change (e.g. --preset-delivery)")
+		return 2
+	}
+	if !db.ValidPresetDeliveryMode(mode) {
+		fmt.Fprintf(stderr, "invalid --preset-delivery %q: want full, referenced, or auto\n", mode)
+		return 2
+	}
+	if err := withStore(*home, func(store *db.Store) error {
+		return store.UpdateAgentPresetDelivery(context.Background(), name, mode)
+	}); err != nil {
+		fmt.Fprintf(stderr, "update agent: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "updated %s preset-delivery to %s\n", name, strings.ToLower(mode))
 	return 0
 }
 
@@ -2175,6 +2234,7 @@ func dbAgent(agent runtime.Agent) db.Agent {
 		Capabilities:   agent.Capabilities,
 		AutonomyPolicy: policy,
 		HealthStatus:   agent.HealthStatus,
+		PresetDelivery: agent.PresetDelivery,
 	}
 }
 
@@ -2191,6 +2251,7 @@ func runtimeAgent(agent db.Agent) runtime.Agent {
 		Capabilities:   agent.Capabilities,
 		AutonomyPolicy: policy,
 		HealthStatus:   agent.HealthStatus,
+		PresetDelivery: agent.PresetDelivery,
 	}
 }
 

--- a/internal/cli/agent_preset_delivery_test.go
+++ b/internal/cli/agent_preset_delivery_test.go
@@ -102,3 +102,88 @@ func TestAgentSubscribePresetDeliveryFlag(t *testing.T) {
 		t.Fatalf("subscribe invalid mode exit = %d, want 2 (stderr=%s)", code, stderr.String())
 	}
 }
+
+// TestAgentReSubscribePreservesPresetDelivery guards the review finding: re-running
+// `agent subscribe` on an existing agent WITHOUT --preset-delivery must not silently
+// reset the sticky mode back to full. A brand-new subscribe without the flag still
+// defaults to full.
+func TestAgentReSubscribePreservesPresetDelivery(t *testing.T) {
+	home := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+		"--preset-delivery", "auto",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit = %d, stderr=%s", code, stderr.String())
+	}
+	if got := agentPresetDelivery(t, home, "audit"); got != db.PresetDeliveryAuto {
+		t.Fatalf("subscribed preset delivery = %q, want %q", got, db.PresetDeliveryAuto)
+	}
+
+	// Re-subscribe to refresh the session with NO --preset-delivery flag: the
+	// previously-chosen auto mode must survive.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440099",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("re-subscribe exit = %d, stderr=%s", code, stderr.String())
+	}
+	if got := agentPresetDelivery(t, home, "audit"); got != db.PresetDeliveryAuto {
+		t.Fatalf("re-subscribe preset delivery = %q, want %q (should be preserved)", got, db.PresetDeliveryAuto)
+	}
+
+	// Explicitly passing --preset-delivery on re-subscribe still overrides.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440099",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+		"--preset-delivery", "full",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("re-subscribe override exit = %d, stderr=%s", code, stderr.String())
+	}
+	if got := agentPresetDelivery(t, home, "audit"); got != db.PresetDeliveryFull {
+		t.Fatalf("re-subscribe override preset delivery = %q, want %q", got, db.PresetDeliveryFull)
+	}
+
+	// A brand-new agent without the flag still defaults to full.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440002",
+		"--role", "coordinator",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe planner exit = %d, stderr=%s", code, stderr.String())
+	}
+	if got := agentPresetDelivery(t, home, "planner"); got != db.PresetDeliveryFull {
+		t.Fatalf("new agent default preset delivery = %q, want %q", got, db.PresetDeliveryFull)
+	}
+}

--- a/internal/cli/agent_preset_delivery_test.go
+++ b/internal/cli/agent_preset_delivery_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func agentPresetDelivery(t *testing.T, home, name string) string {
+	t.Helper()
+	var mode string
+	if err := withStore(home, func(store *db.Store) error {
+		agent, err := store.GetAgent(context.Background(), name)
+		if err != nil {
+			return err
+		}
+		mode = agent.PresetDelivery
+		return nil
+	}); err != nil {
+		t.Fatalf("read agent %q: %v", name, err)
+	}
+	return mode
+}
+
+// TestAgentSubscribePresetDeliveryFlag covers the #33 config surface end to end:
+// subscribe --preset-delivery persists the mode, an omitted flag defaults to full,
+// agent update flips it in place, and an invalid value is rejected.
+func TestAgentSubscribePresetDeliveryFlag(t *testing.T) {
+	home := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "subscribe", "audit",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440001",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+		"--preset-delivery", "referenced",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe exit = %d, stderr=%s", code, stderr.String())
+	}
+	if got := agentPresetDelivery(t, home, "audit"); got != db.PresetDeliveryReferenced {
+		t.Fatalf("subscribed preset delivery = %q, want %q", got, db.PresetDeliveryReferenced)
+	}
+
+	// Default (no flag) is full.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "planner",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440002",
+		"--role", "coordinator",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "ask",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("subscribe planner exit = %d, stderr=%s", code, stderr.String())
+	}
+	if got := agentPresetDelivery(t, home, "planner"); got != db.PresetDeliveryFull {
+		t.Fatalf("default preset delivery = %q, want %q", got, db.PresetDeliveryFull)
+	}
+
+	// agent update flips the mode in place.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "update", "audit", "--home", home, "--preset-delivery", "auto"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("update exit = %d, stderr=%s", code, stderr.String())
+	}
+	if got := agentPresetDelivery(t, home, "audit"); got != db.PresetDeliveryAuto {
+		t.Fatalf("updated preset delivery = %q, want %q", got, db.PresetDeliveryAuto)
+	}
+
+	// Invalid mode is rejected on both subscribe and update.
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"agent", "update", "audit", "--home", home, "--preset-delivery", "loose"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("update invalid mode exit = %d, want 2 (stderr=%s)", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{
+		"agent", "subscribe", "bad",
+		"--home", home,
+		"--runtime", "codex",
+		"--session", "550e8400-e29b-41d4-a716-446655440003",
+		"--role", "reviewer",
+		"--repo", "jerryfane/gitmoot",
+		"--capability", "review",
+		"--preset-delivery", "loose",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("subscribe invalid mode exit = %d, want 2 (stderr=%s)", code, stderr.String())
+	}
+}

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -128,6 +128,18 @@ CREATE TABLE agent_template_versions (
 	version INTEGER NOT NULL,
 	state TEXT NOT NULL
 );
+-- A minimal agents table (as it existed at the input_tokens migration point) so
+-- the later #33 preset_delivery ALTER ADD COLUMN that runs in this pass has its
+-- table; the real table was created by an earlier (here pre-seeded-as-applied)
+-- migration.
+CREATE TABLE agents (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL UNIQUE,
+	role TEXT NOT NULL,
+	runtime TEXT NOT NULL,
+	runtime_ref TEXT NOT NULL,
+	repo_scope TEXT NOT NULL
+);
 -- job_events as it existed at an earlier (here pre-seeded-as-applied) migration,
 -- so the #549 job_events index migration that runs in this pass has its table.
 CREATE TABLE job_events (

--- a/internal/db/preset_session_state.go
+++ b/internal/db/preset_session_state.go
@@ -1,0 +1,149 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+)
+
+// Preset prompt delivery modes (#33). They are stored verbatim in
+// agents.preset_delivery (DEFAULT 'full') and consumed by the workflow decision
+// that chooses whether to inline the whole preset or send a short reference.
+const (
+	// PresetDeliveryFull always inlines the full resolved preset content in the
+	// job prompt. It is the default and is byte-identical to pre-#33 behavior.
+	PresetDeliveryFull = "full"
+	// PresetDeliveryReferenced sends only a short "use your installed preset"
+	// reference INSTEAD of the full body, but only when Gitmoot has recorded
+	// evidence (a preset_session_state row) that the exact resumed session already
+	// received the same preset at the same commit. Any doubt falls back to full.
+	PresetDeliveryReferenced = "referenced"
+	// PresetDeliveryAuto behaves like referenced but ADDITIONALLY requires the
+	// runtime to support persisted sessions (codex/claude); shell/kimi/custom
+	// always deliver full under auto.
+	PresetDeliveryAuto = "auto"
+)
+
+// ValidPresetDeliveryMode reports whether mode is one of the recognized preset
+// delivery modes (case-insensitive, trimmed). Empty is NOT valid here; callers
+// that accept an unset value should default it to full themselves.
+func ValidPresetDeliveryMode(mode string) bool {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case PresetDeliveryFull, PresetDeliveryReferenced, PresetDeliveryAuto:
+		return true
+	default:
+		return false
+	}
+}
+
+// normalizePresetDeliveryStored coerces any stored/legacy/empty value to a valid
+// mode, defaulting to full so an unknown or blank value can never turn the
+// optimization on. This is the single normalization chokepoint used on write.
+func normalizePresetDeliveryStored(mode string) string {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if !ValidPresetDeliveryMode(mode) {
+		return PresetDeliveryFull
+	}
+	return mode
+}
+
+// UpdateAgentPresetDelivery re-pins a registered agent's preset delivery mode in
+// place, updating only that column (mirrors UpdateAgentRuntimeRef). The mode is
+// normalized to a valid value (invalid/blank -> full). It returns an error if no
+// agent row matched the name.
+func (s *Store) UpdateAgentPresetDelivery(ctx context.Context, name, mode string) error {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE agents SET preset_delivery = ?, updated_at = CURRENT_TIMESTAMP WHERE name = ?`,
+		normalizePresetDeliveryStored(mode), strings.TrimSpace(name))
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return errors.New("agent " + name + " is not registered")
+	}
+	return nil
+}
+
+// RecordPresetSessionState upserts the marker that a given runtime session has
+// received a preset at a specific resolved commit (#33). It is called after a
+// successful FULL preset delivery so a later referenced/auto delivery on the SAME
+// resumed session can send the short reference instead of the whole body.
+//
+// To enforce the "a preset commit change invalidates state rows for that preset"
+// invariant, it first deletes any prior row for the same (runtime, session_id,
+// preset_id) tuple regardless of commit, then inserts the current commit — so at
+// most one commit is ever recorded per (runtime, session, preset) and a stale
+// commit can never satisfy a match. Empty runtime/session/preset are rejected so
+// a non-resumable session never records a (meaningless) marker.
+func (s *Store) RecordPresetSessionState(ctx context.Context, runtime, sessionID, presetID, presetCommit string) error {
+	runtime = strings.TrimSpace(runtime)
+	sessionID = strings.TrimSpace(sessionID)
+	presetID = strings.TrimSpace(presetID)
+	if runtime == "" || sessionID == "" || presetID == "" {
+		return errors.New("preset session state requires runtime, session, and preset id")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM preset_session_state WHERE runtime = ? AND session_id = ? AND preset_id = ?`,
+		runtime, sessionID, presetID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO preset_session_state(runtime, session_id, preset_id, preset_commit, delivered_at)
+			VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		runtime, sessionID, presetID, strings.TrimSpace(presetCommit)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// HasPresetSessionState reports whether an EXACT (runtime, session_id, preset_id,
+// preset_commit) marker exists — the precondition the referenced/auto delivery
+// decision requires. Any mismatch (different commit, unknown session) returns
+// false so the caller falls back to full.
+func (s *Store) HasPresetSessionState(ctx context.Context, runtime, sessionID, presetID, presetCommit string) (bool, error) {
+	runtime = strings.TrimSpace(runtime)
+	sessionID = strings.TrimSpace(sessionID)
+	presetID = strings.TrimSpace(presetID)
+	if runtime == "" || sessionID == "" || presetID == "" {
+		return false, nil
+	}
+	var exists int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM preset_session_state WHERE runtime = ? AND session_id = ? AND preset_id = ? AND preset_commit = ?`,
+		runtime, sessionID, presetID, strings.TrimSpace(presetCommit)).Scan(&exists)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return exists > 0, nil
+}
+
+// DeletePresetSessionStateForPreset removes every recorded marker for a preset,
+// across all sessions and commits. It exists so a caller that changes a preset's
+// resolved content can eagerly invalidate the loaded-state evidence (the
+// exact-commit match in HasPresetSessionState already prevents a stale commit
+// from matching; this is the eager-cleanup companion). Returns the row count
+// removed.
+func (s *Store) DeletePresetSessionStateForPreset(ctx context.Context, presetID string) (int64, error) {
+	presetID = strings.TrimSpace(presetID)
+	if presetID == "" {
+		return 0, nil
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM preset_session_state WHERE preset_id = ?`, presetID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}

--- a/internal/db/preset_session_state_test.go
+++ b/internal/db/preset_session_state_test.go
@@ -1,0 +1,137 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func openPresetStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+// TestAgentPresetDeliveryDefaultsFull proves the additive column defaults to
+// 'full' for an agent that never sets it, so every existing row and every
+// non-opted-in agent reads back byte-identical behavior.
+func TestAgentPresetDeliveryDefaultsFull(t *testing.T) {
+	store := openPresetStore(t)
+	ctx := context.Background()
+	if err := store.UpsertAgent(ctx, Agent{Name: "audit", Role: "reviewer", Runtime: "codex", RuntimeRef: "last", RepoScope: "o/r"}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	got, err := store.GetAgent(ctx, "audit")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if got.PresetDelivery != PresetDeliveryFull {
+		t.Fatalf("PresetDelivery = %q, want %q", got.PresetDelivery, PresetDeliveryFull)
+	}
+}
+
+// TestUpsertAndUpdateAgentPresetDelivery covers persisting the mode on subscribe
+// (upsert), an in-place update, and the invalid/blank -> full normalization.
+func TestUpsertAndUpdateAgentPresetDelivery(t *testing.T) {
+	store := openPresetStore(t)
+	ctx := context.Background()
+	if err := store.UpsertAgent(ctx, Agent{Name: "audit", Role: "reviewer", Runtime: "codex", RuntimeRef: "last", RepoScope: "o/r", PresetDelivery: "REFERENCED"}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	got, err := store.GetAgent(ctx, "audit")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if got.PresetDelivery != PresetDeliveryReferenced {
+		t.Fatalf("upsert normalized mode = %q, want %q", got.PresetDelivery, PresetDeliveryReferenced)
+	}
+
+	if err := store.UpdateAgentPresetDelivery(ctx, "audit", "auto"); err != nil {
+		t.Fatalf("UpdateAgentPresetDelivery: %v", err)
+	}
+	got, _ = store.GetAgent(ctx, "audit")
+	if got.PresetDelivery != PresetDeliveryAuto {
+		t.Fatalf("after update mode = %q, want %q", got.PresetDelivery, PresetDeliveryAuto)
+	}
+
+	// An invalid mode is coerced to full rather than stored verbatim.
+	if err := store.UpdateAgentPresetDelivery(ctx, "audit", "nonsense"); err != nil {
+		t.Fatalf("UpdateAgentPresetDelivery(nonsense): %v", err)
+	}
+	got, _ = store.GetAgent(ctx, "audit")
+	if got.PresetDelivery != PresetDeliveryFull {
+		t.Fatalf("invalid mode not coerced; mode = %q, want %q", got.PresetDelivery, PresetDeliveryFull)
+	}
+
+	if err := store.UpdateAgentPresetDelivery(ctx, "missing", "auto"); err == nil {
+		t.Fatalf("UpdateAgentPresetDelivery on missing agent should error")
+	}
+}
+
+// TestPresetSessionStateRecordAndMatch covers the exact-match contract and the
+// commit-invalidation invariant: a marker matches only the exact tuple, a commit
+// change overwrites the prior row (so a stale commit never matches), and delete
+// clears the preset.
+func TestPresetSessionStateRecordAndMatch(t *testing.T) {
+	store := openPresetStore(t)
+	ctx := context.Background()
+
+	// No rows until recorded (off by default).
+	if has, err := store.HasPresetSessionState(ctx, "codex", "sess-1", "thermo", "c1"); err != nil || has {
+		t.Fatalf("HasPresetSessionState empty = (%v, %v), want (false, nil)", has, err)
+	}
+
+	if err := store.RecordPresetSessionState(ctx, "codex", "sess-1", "thermo", "c1"); err != nil {
+		t.Fatalf("RecordPresetSessionState: %v", err)
+	}
+	if has, err := store.HasPresetSessionState(ctx, "codex", "sess-1", "thermo", "c1"); err != nil || !has {
+		t.Fatalf("exact match = (%v, %v), want (true, nil)", has, err)
+	}
+	// Any component mismatch must not match.
+	for _, m := range []struct{ rt, s, p, c string }{
+		{"claude", "sess-1", "thermo", "c1"},
+		{"codex", "sess-2", "thermo", "c1"},
+		{"codex", "sess-1", "other", "c1"},
+		{"codex", "sess-1", "thermo", "c2"},
+	} {
+		if has, err := store.HasPresetSessionState(ctx, m.rt, m.s, m.p, m.c); err != nil || has {
+			t.Fatalf("mismatch %+v matched unexpectedly", m)
+		}
+	}
+
+	// A commit change overwrites the prior row for the (runtime, session, preset)
+	// tuple: the old commit no longer matches, only the new one does.
+	if err := store.RecordPresetSessionState(ctx, "codex", "sess-1", "thermo", "c2"); err != nil {
+		t.Fatalf("re-record new commit: %v", err)
+	}
+	if has, _ := store.HasPresetSessionState(ctx, "codex", "sess-1", "thermo", "c1"); has {
+		t.Fatalf("stale commit c1 still matches after commit change")
+	}
+	if has, _ := store.HasPresetSessionState(ctx, "codex", "sess-1", "thermo", "c2"); !has {
+		t.Fatalf("new commit c2 does not match")
+	}
+
+	// Empty components are rejected on write and never match on read.
+	if err := store.RecordPresetSessionState(ctx, "", "sess-1", "thermo", "c2"); err == nil {
+		t.Fatalf("RecordPresetSessionState with empty runtime should error")
+	}
+
+	// DeletePresetSessionStateForPreset clears every session/commit for a preset.
+	if err := store.RecordPresetSessionState(ctx, "codex", "sess-9", "thermo", "c9"); err != nil {
+		t.Fatalf("record another session: %v", err)
+	}
+	n, err := store.DeletePresetSessionStateForPreset(ctx, "thermo")
+	if err != nil {
+		t.Fatalf("DeletePresetSessionStateForPreset: %v", err)
+	}
+	if n < 2 {
+		t.Fatalf("deleted %d rows, want >= 2", n)
+	}
+	if has, _ := store.HasPresetSessionState(ctx, "codex", "sess-1", "thermo", "c2"); has {
+		t.Fatalf("preset state survived delete")
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -44,6 +44,12 @@ type Agent struct {
 	Capabilities   []string
 	AutonomyPolicy string
 	HealthStatus   string
+	// PresetDelivery is the per-agent prompt preset delivery mode (#33): one of
+	// full (the default and pre-#33 behavior — always inline the whole preset),
+	// referenced, or auto. Backed by the additive agents.preset_delivery column
+	// (DEFAULT 'full'), so every existing row and every agent that never sets it
+	// reads 'full' and behaves byte-identically.
+	PresetDelivery string
 }
 
 type AgentTemplate struct {
@@ -830,8 +836,8 @@ func (s *Store) UpsertAgent(ctx context.Context, agent Agent) error {
 		return err
 	}
 	defer tx.Rollback()
-	if _, err := tx.ExecContext(ctx, `INSERT INTO agents(name, role, runtime, runtime_ref, repo_scope, template_id, model, capabilities_json, autonomy_policy, health_status, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+	if _, err := tx.ExecContext(ctx, `INSERT INTO agents(name, role, runtime, runtime_ref, repo_scope, template_id, model, capabilities_json, autonomy_policy, health_status, preset_delivery, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 			ON CONFLICT(name) DO UPDATE SET
 				role = excluded.role,
 				runtime = excluded.runtime,
@@ -842,8 +848,9 @@ func (s *Store) UpsertAgent(ctx context.Context, agent Agent) error {
 				capabilities_json = excluded.capabilities_json,
 				autonomy_policy = excluded.autonomy_policy,
 				health_status = excluded.health_status,
+				preset_delivery = excluded.preset_delivery,
 				updated_at = CURRENT_TIMESTAMP`,
-		agent.Name, agent.Role, agent.Runtime, agent.RuntimeRef, agent.RepoScope, agent.TemplateID, agent.Model, string(capabilities), agent.AutonomyPolicy, agent.HealthStatus); err != nil {
+		agent.Name, agent.Role, agent.Runtime, agent.RuntimeRef, agent.RepoScope, agent.TemplateID, agent.Model, string(capabilities), agent.AutonomyPolicy, agent.HealthStatus, normalizePresetDeliveryStored(agent.PresetDelivery)); err != nil {
 		return err
 	}
 	if strings.TrimSpace(agent.RepoScope) != "" {
@@ -865,7 +872,7 @@ func (s *Store) UpdateAgentRuntime(ctx context.Context, name, runtime string) er
 	if runtime != "codex" && runtime != "claude" && runtime != "kimi" {
 		return fmt.Errorf("unknown runtime %q (want codex, claude, or kimi)", runtime)
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, model, capabilities_json, autonomy_policy, health_status
+	row := s.db.QueryRowContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, model, capabilities_json, autonomy_policy, health_status, preset_delivery
 		FROM agents WHERE name = ?`, name)
 	agent, err := scanAgent(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -902,7 +909,7 @@ func (s *Store) UpdateAgentRuntimeRef(ctx context.Context, name, ref string) err
 }
 
 func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, model, capabilities_json, autonomy_policy, health_status
+	row := s.db.QueryRowContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, model, capabilities_json, autonomy_policy, health_status, preset_delivery
 		FROM agents WHERE name = ?`, name)
 	agent, err := scanAgent(row)
 	if err == nil {
@@ -930,11 +937,14 @@ func (s *Store) GetAgent(ctx context.Context, name string) (Agent, error) {
 		Capabilities:   instance.Capabilities,
 		AutonomyPolicy: policy,
 		HealthStatus:   instance.State,
+		// Ephemeral/temp-worker instances have no preset_delivery column; they
+		// always deliver the full preset (#33), matching the 'full' default.
+		PresetDelivery: PresetDeliveryFull,
 	}, nil
 }
 
 func (s *Store) ListAgents(ctx context.Context) ([]Agent, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, model, capabilities_json, autonomy_policy, health_status
+	rows, err := s.db.QueryContext(ctx, `SELECT name, role, runtime, runtime_ref, repo_scope, template_id, model, capabilities_json, autonomy_policy, health_status, preset_delivery
 		FROM agents ORDER BY name`)
 	if err != nil {
 		return nil, err
@@ -6253,7 +6263,7 @@ type agentScanner interface {
 func scanAgent(scanner agentScanner) (Agent, error) {
 	var agent Agent
 	var capabilities string
-	if err := scanner.Scan(&agent.Name, &agent.Role, &agent.Runtime, &agent.RuntimeRef, &agent.RepoScope, &agent.TemplateID, &agent.Model, &capabilities, &agent.AutonomyPolicy, &agent.HealthStatus); err != nil {
+	if err := scanner.Scan(&agent.Name, &agent.Role, &agent.Runtime, &agent.RuntimeRef, &agent.RepoScope, &agent.TemplateID, &agent.Model, &capabilities, &agent.AutonomyPolicy, &agent.HealthStatus, &agent.PresetDelivery); err != nil {
 		return Agent{}, err
 	}
 	if err := json.Unmarshal([]byte(capabilities), &agent.Capabilities); err != nil {
@@ -7828,5 +7838,26 @@ CREATE TABLE pipeline_run_stages (
 );
 
 CREATE INDEX idx_pipeline_run_stages_run_id ON pipeline_run_stages(run_id);
+	`,
+	// #33 preset prompt delivery modes. Additive-only: the agents column carries a
+	// 'full' DEFAULT so every existing row (and every agent that never opts in)
+	// keeps delivering the whole preset exactly as before. preset_session_state
+	// records, per (runtime, session_id, preset_id, preset_commit), that a resumed
+	// session already received a preset at a specific commit; it stays EMPTY until
+	// an agent set to referenced/auto completes a full delivery, so every existing
+	// DB reads identically. The composite PK is the exact-match key the delivery
+	// decision queries; a preset commit change simply fails to match (and
+	// RecordPresetSessionState overwrites the prior commit row for the tuple).
+	`
+ALTER TABLE agents ADD COLUMN preset_delivery TEXT NOT NULL DEFAULT 'full';
+
+CREATE TABLE preset_session_state (
+	runtime TEXT NOT NULL,
+	session_id TEXT NOT NULL,
+	preset_id TEXT NOT NULL,
+	preset_commit TEXT NOT NULL DEFAULT '',
+	delivered_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (runtime, session_id, preset_id, preset_commit)
+);
 	`,
 }

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -21,13 +21,29 @@ type JobPrompt struct {
 	TemplateID             string
 	TemplateResolvedCommit string
 	TemplateInstructions   string
+	// TemplateReferenceOnly, when true, replaces the full "Template instructions"
+	// block with a short reference line (#33 referenced/auto delivery): the resumed
+	// session is known to already hold this preset, so the whole body is not
+	// re-pasted. It only takes effect when TemplateID is set; otherwise the prompt
+	// is byte-identical to the full path.
+	TemplateReferenceOnly bool
 }
 
 func RenderJob(prompt JobPrompt) string {
 	var builder strings.Builder
 	builder.WriteString("Gitmoot job\n\n")
 
-	if strings.TrimSpace(prompt.TemplateInstructions) != "" {
+	if prompt.TemplateReferenceOnly && strings.TrimSpace(prompt.TemplateID) != "" {
+		// #33 referenced/auto delivery: the resumed session already loaded this
+		// preset, so send a short reference instead of re-pasting the whole body.
+		writeField(&builder, "Template", prompt.TemplateID)
+		writeField(&builder, "Template source commit", prompt.TemplateResolvedCommit)
+		commit := strings.TrimSpace(prompt.TemplateResolvedCommit)
+		if commit == "" {
+			commit = "unknown"
+		}
+		builder.WriteString(fmt.Sprintf("Use your installed %s preset (commit %s) that this resumed session already has loaded. Do not expect the full preset text below.\n\n", strings.TrimSpace(prompt.TemplateID), commit))
+	} else if strings.TrimSpace(prompt.TemplateInstructions) != "" {
 		writeField(&builder, "Template", prompt.TemplateID)
 		writeField(&builder, "Template source commit", prompt.TemplateResolvedCommit)
 		builder.WriteString("Template instructions:\n")

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -44,6 +44,12 @@ type Agent struct {
 	AutonomyPolicy string
 	HealthStatus   string
 	Model          string
+	// PresetDelivery is the agent's prompt preset delivery mode (#33): full
+	// (default), referenced, or auto. Carried in-memory from the stored agents row
+	// so the delivery seam can decide whether to inline the whole preset or send a
+	// short reference. Empty (the default and every construction site that does not
+	// set it) is treated as full, so delivery is byte-identical.
+	PresetDelivery string
 	// SingleUseSession marks an agent whose runtime session exists solely for
 	// the current job (ephemeral delegation workers and per-job temp workers:
 	// the session is started for the job and disposed after it). Adapters whose

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -514,7 +514,16 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	}
 
 	registeredFreshRef := runtime.IsFreshRef(agent.RuntimeRef)
-	prompt := prompts.RenderJob(payload.prompt(job.Type))
+	// #33 preset delivery mode: decide whether the resumed session already holds
+	// this exact preset and may receive the short reference instead of the full
+	// body. For a `full` agent (the default) this returns false without touching
+	// the store, so the assembled prompt is byte-identical. The snapshot in the
+	// payload (id/commit/content) is unchanged regardless — auditability/retry are
+	// preserved.
+	referenceUsed := m.usePresetReference(ctx, agent, payload)
+	jobPrompt := payload.prompt(job.Type)
+	jobPrompt.TemplateReferenceOnly = referenceUsed
+	prompt := prompts.RenderJob(jobPrompt)
 	// Append the off-by-default "Prior learnings" memory block (#626 READ path).
 	// When the memory hook is unset (every non-enrolled path) or returns "" (no
 	// enrolled agent, empty sanitized query, or no confirmed match), the prompt is
@@ -571,6 +580,13 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	if firstRefreshedRef != "" {
 		agent.RuntimeRef = firstRefreshedRef
 	}
+	// #33: after a successful FULL preset delivery, record that the resumed session
+	// now holds this preset so a later referenced/auto delivery can send the short
+	// reference. agent.RuntimeRef here is the effective session the next job will
+	// resume (the refreshed ref was adopted above). No-op for a `full` agent, when
+	// a reference was already used, or for a non-concrete session — so the default
+	// path writes nothing.
+	m.recordPresetSessionState(ctx, agent, payload, agent.RuntimeRef, referenceUsed)
 	payload.RawOutputs = append(payload.RawOutputs, firstRaw)
 
 	result, parseErr := ExtractAgentResult(firstRaw)

--- a/internal/workflow/preset_delivery.go
+++ b/internal/workflow/preset_delivery.go
@@ -1,0 +1,160 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// presetDeliveryInputs are the pure decision inputs for whether a job prompt
+// should send the SHORT preset reference (#33) instead of the full preset body.
+// Keeping the decision pure (no store, no clock) makes every mode x state
+// combination directly testable.
+type presetDeliveryInputs struct {
+	// Mode is the agent's preset_delivery setting (full/referenced/auto; empty ==
+	// full).
+	Mode string
+	// Runtime is the effective runtime the job resumes under.
+	Runtime string
+	// SessionRef is the runtime session reference the job resumes (agent.RuntimeRef
+	// at assembly time).
+	SessionRef string
+	// HasPreset is true when the job actually carries a preset to reference (a
+	// non-empty preset id AND snapshotted content). With no preset there is nothing
+	// to shorten.
+	HasPreset bool
+	// HasState is true when an EXACT (runtime, session, preset id, preset commit)
+	// marker exists proving the resumed session already loaded this exact preset.
+	HasState bool
+}
+
+// decidePresetReference is the correctness-first core: it returns true (send the
+// short reference) ONLY when every guarantee holds, and false (send the full
+// preset) on ANY doubt. Rules:
+//   - full / unknown / empty mode  -> full (the default; byte-identical).
+//   - no preset, or a non-resumable session (empty, "last", or a fresh: ref)
+//     -> full (nothing to reference, or the resumed session is ambiguous).
+//   - referenced -> reference iff an exact state marker exists.
+//   - auto       -> reference iff an exact state marker exists AND the runtime
+//     supports persisted sessions (codex/claude); shell/kimi/custom -> full.
+func decidePresetReference(in presetDeliveryInputs) bool {
+	mode := normalizePresetDeliveryMode(in.Mode)
+	if mode == db.PresetDeliveryFull {
+		return false
+	}
+	if !in.HasPreset {
+		return false
+	}
+	if !isConcreteSessionRef(in.SessionRef) {
+		return false
+	}
+	if !in.HasState {
+		return false
+	}
+	if mode == db.PresetDeliveryAuto && !runtimeSupportsPersistedSessions(in.Runtime) {
+		return false
+	}
+	return true
+}
+
+// normalizePresetDeliveryMode lowercases/trims and defaults any unknown or blank
+// value to full, so an unrecognized mode can never enable the optimization.
+func normalizePresetDeliveryMode(mode string) string {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if !db.ValidPresetDeliveryMode(mode) {
+		return db.PresetDeliveryFull
+	}
+	return mode
+}
+
+// isConcreteSessionRef reports whether ref names a specific, resumable session we
+// can key loaded-preset state on. Empty, "last" (resolves to whichever session is
+// most recent — ambiguous), and a fresh: ref (a brand-new session) are all
+// treated as doubt -> full.
+func isConcreteSessionRef(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if ref == "" || ref == runtime.LastRef || runtime.IsFreshRef(ref) {
+		return false
+	}
+	return true
+}
+
+// runtimeSupportsPersistedSessions reports whether a runtime keeps session
+// context across separate job invocations (the auto-mode gate). Codex and Claude
+// resume a persisted thread; shell sessions are one-shot commands, and the kimi
+// runtimes start a fresh session per job, so none of those carry a preset forward.
+func runtimeSupportsPersistedSessions(runtimeName string) bool {
+	switch strings.TrimSpace(runtimeName) {
+	case runtime.CodexRuntime, runtime.ClaudeRuntime:
+		return true
+	default:
+		return false
+	}
+}
+
+// usePresetReference resolves the pure decision against the store: it looks up
+// the exact loaded-preset marker only when the mode/session/preset preconditions
+// already hold, so a `full` agent (the default) never issues the query and its
+// path is byte-identical. A store error degrades to full (correctness-first).
+func (m Mailbox) usePresetReference(ctx context.Context, agent runtime.Agent, payload JobPayload) bool {
+	presetID := strings.TrimSpace(payload.TemplateID)
+	hasPreset := presetID != "" && strings.TrimSpace(payload.TemplateContent) != ""
+	base := presetDeliveryInputs{
+		Mode:       agent.PresetDelivery,
+		Runtime:    agent.Runtime,
+		SessionRef: agent.RuntimeRef,
+		HasPreset:  hasPreset,
+	}
+	// Cheap gate: if the decision is full even assuming a marker exists, skip the
+	// store query entirely (this is the byte-identical default path).
+	if !decidePresetReference(presetDeliveryInputsWithState(base, true)) {
+		return false
+	}
+	if m.Store == nil {
+		return false
+	}
+	has, err := m.Store.HasPresetSessionState(ctx, agent.Runtime, agent.RuntimeRef, presetID, payload.TemplateResolvedCommit)
+	if err != nil || !has {
+		return false
+	}
+	return decidePresetReference(presetDeliveryInputsWithState(base, true))
+}
+
+func presetDeliveryInputsWithState(in presetDeliveryInputs, hasState bool) presetDeliveryInputs {
+	in.HasState = hasState
+	return in
+}
+
+// recordPresetSessionState marks that THIS delivery loaded the full preset into
+// the resumed session, so a later referenced/auto delivery on the same session
+// can send the short reference (#33). Off by default and best-effort:
+//   - it only fires for a referenced/auto agent (full agents write nothing, so
+//     their behavior is byte-identical);
+//   - only when the full preset was actually sent this delivery (referenceUsed
+//     is false — a referenced delivery already had a marker);
+//   - only when the effective resumed session ref is concrete (so the marker can
+//     match the next resume);
+//   - a write error never fails an otherwise-successful job.
+//
+// effectiveRef is the session the NEXT job will resume: the refreshed ref when a
+// delivery re-pinned the session, else the agent's current ref.
+func (m Mailbox) recordPresetSessionState(ctx context.Context, agent runtime.Agent, payload JobPayload, effectiveRef string, referenceUsed bool) {
+	if m.Store == nil || referenceUsed {
+		return
+	}
+	mode := normalizePresetDeliveryMode(agent.PresetDelivery)
+	if mode == db.PresetDeliveryFull {
+		return
+	}
+	presetID := strings.TrimSpace(payload.TemplateID)
+	if presetID == "" || strings.TrimSpace(payload.TemplateContent) == "" {
+		return
+	}
+	effectiveRef = strings.TrimSpace(effectiveRef)
+	if !isConcreteSessionRef(effectiveRef) {
+		return
+	}
+	_ = m.Store.RecordPresetSessionState(ctx, agent.Runtime, effectiveRef, presetID, payload.TemplateResolvedCommit)
+}

--- a/internal/workflow/preset_delivery_e2e_test.go
+++ b/internal/workflow/preset_delivery_e2e_test.go
@@ -1,0 +1,196 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// presetJobPayload builds a stored job payload that snapshots a preset, mirroring
+// what Enqueue writes. The snapshot (id/commit/content) is what auditability and
+// retry rely on; the delivery mode only changes how it is rendered.
+func presetJobPayload(t *testing.T) string {
+	t.Helper()
+	payload, err := marshalPayload(JobPayload{
+		Repo:                   "jerryfane/gitmoot",
+		TemplateID:             "thermo",
+		TemplateResolvedCommit: "abc123",
+		TemplateContent:        "Review deeply.",
+	})
+	if err != nil {
+		t.Fatalf("marshalPayload: %v", err)
+	}
+	return payload
+}
+
+// TestPresetDeliveryReferencedFiresOnlyWithPriorState is the deterministic no-LLM
+// E2E for #33 using the shell runtime + a captured-prompt fake adapter. It proves:
+//   - the FIRST delivery on a session with no recorded state sends the FULL preset
+//     (byte-identical to today) and records the loaded-state marker;
+//   - the SECOND delivery on the SAME session (referenced mode, state now present)
+//     sends the SHORT reference instead of the whole preset body.
+func TestPresetDeliveryReferencedFiresOnlyWithPriorState(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	// A shell agent with a concrete, resumable session ref (a command) in
+	// referenced mode. referenced trusts the operator and fires on any runtime once
+	// state exists.
+	agent := runtime.Agent{
+		Name:           "audit",
+		Runtime:        runtime.ShellRuntime,
+		RuntimeRef:     "printf ok",
+		RepoScope:      "jerryfane/gitmoot",
+		Role:           "reviewer",
+		PresetDelivery: db.PresetDeliveryReferenced,
+	}
+	adapter := &fakeDelivery{outputs: []string{okDeliveryResult, okDeliveryResult}}
+
+	// First job: no state yet -> full delivery.
+	if err := store.CreateJob(ctx, db.Job{ID: "job-1", Agent: "audit", Type: "review", State: string(JobQueued), Payload: presetJobPayload(t)}); err != nil {
+		t.Fatalf("CreateJob job-1: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-1", agent, adapter); err != nil {
+		t.Fatalf("Run job-1: %v", err)
+	}
+	if len(adapter.prompts) != 1 {
+		t.Fatalf("deliveries = %d, want 1", len(adapter.prompts))
+	}
+	if !strings.Contains(adapter.prompts[0], "Template instructions:\nReview deeply.") {
+		t.Fatalf("first delivery must send the FULL preset:\n%s", adapter.prompts[0])
+	}
+	if strings.Contains(adapter.prompts[0], "Use your installed thermo preset") {
+		t.Fatalf("first delivery unexpectedly sent the reference (no prior state):\n%s", adapter.prompts[0])
+	}
+	// The full delivery must have recorded the loaded-state marker.
+	has, err := store.HasPresetSessionState(ctx, runtime.ShellRuntime, "printf ok", "thermo", "abc123")
+	if err != nil {
+		t.Fatalf("HasPresetSessionState: %v", err)
+	}
+	if !has {
+		t.Fatalf("full delivery did not record preset session state")
+	}
+
+	// Second job: same session, state present -> short reference.
+	if err := store.CreateJob(ctx, db.Job{ID: "job-2", Agent: "audit", Type: "review", State: string(JobQueued), Payload: presetJobPayload(t)}); err != nil {
+		t.Fatalf("CreateJob job-2: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-2", agent, adapter); err != nil {
+		t.Fatalf("Run job-2: %v", err)
+	}
+	if len(adapter.prompts) != 2 {
+		t.Fatalf("deliveries = %d, want 2", len(adapter.prompts))
+	}
+	if !strings.Contains(adapter.prompts[1], "Use your installed thermo preset (commit abc123)") {
+		t.Fatalf("second delivery must send the SHORT reference:\n%s", adapter.prompts[1])
+	}
+	if strings.Contains(adapter.prompts[1], "Template instructions:\nReview deeply.") {
+		t.Fatalf("second delivery unexpectedly re-pasted the full preset:\n%s", adapter.prompts[1])
+	}
+}
+
+// TestPresetDeliveryFullModeAlwaysSendsFullEvenWithState pins the byte-identical
+// default: a `full` agent (and the unset default) always sends the whole preset,
+// and never records or consults state, even when a state row happens to exist.
+func TestPresetDeliveryFullModeAlwaysSendsFullEvenWithState(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	// Pre-seed a matching state row: a full agent must ignore it entirely.
+	if err := store.RecordPresetSessionState(ctx, runtime.ShellRuntime, "printf ok", "thermo", "abc123"); err != nil {
+		t.Fatalf("seed RecordPresetSessionState: %v", err)
+	}
+	for _, mode := range []string{db.PresetDeliveryFull, ""} {
+		agent := runtime.Agent{
+			Name:           "audit",
+			Runtime:        runtime.ShellRuntime,
+			RuntimeRef:     "printf ok",
+			RepoScope:      "jerryfane/gitmoot",
+			Role:           "reviewer",
+			PresetDelivery: mode,
+		}
+		adapter := &fakeDelivery{outputs: []string{okDeliveryResult}}
+		id := "job-full-" + mode
+		if err := store.CreateJob(ctx, db.Job{ID: id, Agent: "audit", Type: "review", State: string(JobQueued), Payload: presetJobPayload(t)}); err != nil {
+			t.Fatalf("CreateJob %s: %v", id, err)
+		}
+		if _, err := mailbox.Run(ctx, id, agent, adapter); err != nil {
+			t.Fatalf("Run %s: %v", id, err)
+		}
+		if !strings.Contains(adapter.prompts[0], "Template instructions:\nReview deeply.") {
+			t.Fatalf("full-mode (%q) delivery must send the full preset:\n%s", mode, adapter.prompts[0])
+		}
+		if strings.Contains(adapter.prompts[0], "Use your installed thermo preset") {
+			t.Fatalf("full-mode (%q) delivery unexpectedly sent the reference:\n%s", mode, adapter.prompts[0])
+		}
+	}
+}
+
+// TestPresetDeliveryAutoRequiresPersistedRuntime pins that auto mode falls back to
+// full on a runtime that does not persist sessions (shell) even with a state row,
+// but shortens on a persisted runtime. The state row is recorded manually so both
+// legs start from an established marker.
+func TestPresetDeliveryAutoRequiresPersistedRuntime(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	// Shell leg: auto must NOT shorten (shell is not a persisted runtime).
+	if err := store.RecordPresetSessionState(ctx, runtime.ShellRuntime, "printf ok", "thermo", "abc123"); err != nil {
+		t.Fatalf("seed shell state: %v", err)
+	}
+	shellAgent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer", PresetDelivery: db.PresetDeliveryAuto}
+	shellAdapter := &fakeDelivery{outputs: []string{okDeliveryResult}}
+	if err := store.CreateJob(ctx, db.Job{ID: "job-auto-shell", Agent: "audit", Type: "review", State: string(JobQueued), Payload: presetJobPayload(t)}); err != nil {
+		t.Fatalf("CreateJob job-auto-shell: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-auto-shell", shellAgent, shellAdapter); err != nil {
+		t.Fatalf("Run job-auto-shell: %v", err)
+	}
+	if !strings.Contains(shellAdapter.prompts[0], "Template instructions:\nReview deeply.") {
+		t.Fatalf("auto on shell must send full (not a persisted runtime):\n%s", shellAdapter.prompts[0])
+	}
+
+	// Codex leg: auto shortens with a matching state row and a concrete session.
+	concrete := "019f3041-cfed-7e82-8766-b5ca75cf92da"
+	if err := store.RecordPresetSessionState(ctx, runtime.CodexRuntime, concrete, "thermo", "abc123"); err != nil {
+		t.Fatalf("seed codex state: %v", err)
+	}
+	codexAgent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: concrete, RepoScope: "jerryfane/gitmoot", Role: "reviewer", PresetDelivery: db.PresetDeliveryAuto}
+	codexAdapter := &fakeDelivery{outputs: []string{okDeliveryResult}}
+	if err := store.CreateJob(ctx, db.Job{ID: "job-auto-codex", Agent: "impl", Type: "review", State: string(JobQueued), Payload: presetJobPayload(t)}); err != nil {
+		t.Fatalf("CreateJob job-auto-codex: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-auto-codex", codexAgent, codexAdapter); err != nil {
+		t.Fatalf("Run job-auto-codex: %v", err)
+	}
+	if !strings.Contains(codexAdapter.prompts[0], "Use your installed thermo preset (commit abc123)") {
+		t.Fatalf("auto on codex with state must send the reference:\n%s", codexAdapter.prompts[0])
+	}
+}
+
+// TestPresetDeliveryReferencedFallsBackOnCommitMismatch pins the auditability
+// invariant that a preset commit change invalidates the loaded-state evidence: a
+// state row at an OLD commit must not satisfy a job snapshotted at a NEW commit.
+func TestPresetDeliveryReferencedFallsBackOnCommitMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	// Marker recorded at an old commit; the job snapshots a newer commit.
+	if err := store.RecordPresetSessionState(ctx, runtime.ShellRuntime, "printf ok", "thermo", "old000"); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "reviewer", PresetDelivery: db.PresetDeliveryReferenced}
+	adapter := &fakeDelivery{outputs: []string{okDeliveryResult}}
+	if err := store.CreateJob(ctx, db.Job{ID: "job-mismatch", Agent: "audit", Type: "review", State: string(JobQueued), Payload: presetJobPayload(t)}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-mismatch", agent, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(adapter.prompts[0], "Template instructions:\nReview deeply.") {
+		t.Fatalf("a commit mismatch must fall back to the full preset:\n%s", adapter.prompts[0])
+	}
+}

--- a/internal/workflow/preset_delivery_test.go
+++ b/internal/workflow/preset_delivery_test.go
@@ -1,0 +1,115 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// TestDecidePresetReferenceEveryModeStateCombination exercises the pure #33
+// decision across every mode x state combination on a concrete, resumable
+// session that carries a preset. Only referenced+state and auto+state+persisted
+// runtime may shorten; everything else falls back to full (send the whole body).
+func TestDecidePresetReferenceEveryModeStateCombination(t *testing.T) {
+	concrete := "codex-thread-123"
+	cases := []struct {
+		name     string
+		mode     string
+		runtime  string
+		hasState bool
+		want     bool
+	}{
+		{"full+state", db.PresetDeliveryFull, runtime.CodexRuntime, true, false},
+		{"full+nostate", db.PresetDeliveryFull, runtime.CodexRuntime, false, false},
+		{"empty-defaults-full+state", "", runtime.CodexRuntime, true, false},
+		{"referenced+state+codex", db.PresetDeliveryReferenced, runtime.CodexRuntime, true, true},
+		{"referenced+nostate+codex", db.PresetDeliveryReferenced, runtime.CodexRuntime, false, false},
+		{"referenced+state+shell", db.PresetDeliveryReferenced, runtime.ShellRuntime, true, true},
+		{"referenced+nostate+shell", db.PresetDeliveryReferenced, runtime.ShellRuntime, false, false},
+		{"auto+state+codex", db.PresetDeliveryAuto, runtime.CodexRuntime, true, true},
+		{"auto+state+claude", db.PresetDeliveryAuto, runtime.ClaudeRuntime, true, true},
+		{"auto+nostate+codex", db.PresetDeliveryAuto, runtime.CodexRuntime, false, false},
+		{"auto+state+shell-unsupported", db.PresetDeliveryAuto, runtime.ShellRuntime, true, false},
+		{"auto+state+kimi-unsupported", db.PresetDeliveryAuto, runtime.KimiRuntime, true, false},
+		{"unknown-mode-defaults-full", "loose", runtime.CodexRuntime, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decidePresetReference(presetDeliveryInputs{
+				Mode:       tc.mode,
+				Runtime:    tc.runtime,
+				SessionRef: concrete,
+				HasPreset:  true,
+				HasState:   tc.hasState,
+			})
+			if got != tc.want {
+				t.Fatalf("decidePresetReference(%+v) = %v, want %v", tc, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDecidePresetReferenceRequiresConcreteSession pins that an ambiguous or
+// brand-new session always falls back to full even in referenced/auto with a
+// state marker present: empty ref, "last", and a fresh: ref are all doubt.
+func TestDecidePresetReferenceRequiresConcreteSession(t *testing.T) {
+	for _, ref := range []string{"", runtime.LastRef, "fresh:codex-solo", runtime.FreshRefPrefix + "abc"} {
+		for _, mode := range []string{db.PresetDeliveryReferenced, db.PresetDeliveryAuto} {
+			if decidePresetReference(presetDeliveryInputs{
+				Mode:       mode,
+				Runtime:    runtime.CodexRuntime,
+				SessionRef: ref,
+				HasPreset:  true,
+				HasState:   true,
+			}) {
+				t.Fatalf("mode=%s ref=%q unexpectedly shortened; a non-concrete session must send full", mode, ref)
+			}
+		}
+	}
+}
+
+// TestDecidePresetReferenceRequiresPreset pins that with no preset to reference
+// (missing id/content) the decision is always full, regardless of mode/state.
+func TestDecidePresetReferenceRequiresPreset(t *testing.T) {
+	if decidePresetReference(presetDeliveryInputs{
+		Mode:       db.PresetDeliveryReferenced,
+		Runtime:    runtime.CodexRuntime,
+		SessionRef: "codex-thread-123",
+		HasPreset:  false,
+		HasState:   true,
+	}) {
+		t.Fatalf("no preset must never shorten")
+	}
+}
+
+func TestRuntimeSupportsPersistedSessions(t *testing.T) {
+	yes := []string{runtime.CodexRuntime, runtime.ClaudeRuntime}
+	no := []string{runtime.ShellRuntime, runtime.KimiRuntime, runtime.KimiCLIRuntime, "custom", ""}
+	for _, rt := range yes {
+		if !runtimeSupportsPersistedSessions(rt) {
+			t.Fatalf("runtime %q should support persisted sessions", rt)
+		}
+	}
+	for _, rt := range no {
+		if runtimeSupportsPersistedSessions(rt) {
+			t.Fatalf("runtime %q should NOT support persisted sessions", rt)
+		}
+	}
+}
+
+func TestNormalizePresetDeliveryMode(t *testing.T) {
+	cases := map[string]string{
+		"":           db.PresetDeliveryFull,
+		"  ":         db.PresetDeliveryFull,
+		"FULL":       db.PresetDeliveryFull,
+		"Referenced": db.PresetDeliveryReferenced,
+		" auto ":     db.PresetDeliveryAuto,
+		"nonsense":   db.PresetDeliveryFull,
+	}
+	for in, want := range cases {
+		if got := normalizePresetDeliveryMode(in); got != want {
+			t.Fatalf("normalizePresetDeliveryMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -433,7 +433,10 @@ blocked). See `references/SAFETY.md` for the full mapping and rationale.
 
 `agent subscribe` accepts `--preset-delivery full|referenced|auto` (default
 `full`) and `agent update <name> --preset-delivery <mode>` flips it in place on
-an already-registered agent. It controls how the agent's installed preset
+an already-registered agent. The mode is a sticky per-agent preference:
+re-running `agent subscribe` on an existing agent WITHOUT `--preset-delivery`
+(e.g. to refresh its session/repo) preserves the stored mode; only brand-new
+agents default to `full`. It controls how the agent's installed preset
 (template) prompt is delivered on each job:
 
 | mode | behavior |

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -431,6 +431,24 @@ subscribe`, and at implement-job dispatch with an actionable message. Set
 `go`/`git`/`gh`), or `--policy workspace-write` for edits-only (Bash stays
 blocked). See `references/SAFETY.md` for the full mapping and rationale.
 
+`agent subscribe` accepts `--preset-delivery full|referenced|auto` (default
+`full`) and `agent update <name> --preset-delivery <mode>` flips it in place on
+an already-registered agent. It controls how the agent's installed preset
+(template) prompt is delivered on each job:
+
+| mode | behavior |
+|---|---|
+| `full` (default) | always inline the full preset prompt every job — the pre-existing behavior, byte-identical |
+| `referenced` | send a short "use your installed `<preset>` preset (commit `<c>`)" reference INSTEAD of the whole body, but only when Gitmoot has recorded that the exact resumed session already loaded the same preset at the same commit; any doubt (new/`last`/fresh session, unknown session, changed commit) falls back to full |
+| `auto` | like `referenced`, and ADDITIONALLY only when the runtime persists sessions (`codex`/`claude`); `shell`/`kimi`/custom always send full |
+
+The optimization is correctness-first and additive: the job payload **always**
+snapshots the exact preset id, resolved commit, and content regardless of mode
+(so auditability and retry determinism are unchanged), and a preset commit change
+invalidates the recorded loaded-state so the next job re-sends the full preset.
+Leave it at `full` unless you are resuming a stable persisted session repeatedly
+and want to save preset tokens.
+
 Subscribe an existing runtime session:
 
 ```sh

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -383,7 +383,10 @@ blocked). `read-only`/`ask`/`review` agents are unaffected.
 
 `agent subscribe` accepts `--preset-delivery full|referenced|auto` (default
 `full`), and `agent update <name> --preset-delivery <mode>` flips it in place on
-an already-registered agent. It controls how the agent's installed preset
+an already-registered agent. The mode is a sticky per-agent preference:
+re-running `agent subscribe` on an existing agent WITHOUT `--preset-delivery`
+(e.g. to refresh its session/repo) preserves the stored mode; only brand-new
+agents default to `full`. It controls how the agent's installed preset
 (template) prompt is delivered on each job:
 
 | mode | behavior |

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -381,6 +381,24 @@ subscribe`, and at implement-job dispatch with an actionable message. Set
 `go`/`git`/`gh`), or `--policy workspace-write` for edits-only (Bash stays
 blocked). `read-only`/`ask`/`review` agents are unaffected.
 
+`agent subscribe` accepts `--preset-delivery full|referenced|auto` (default
+`full`), and `agent update <name> --preset-delivery <mode>` flips it in place on
+an already-registered agent. It controls how the agent's installed preset
+(template) prompt is delivered on each job:
+
+| mode | behavior |
+|---|---|
+| `full` (default) | always inline the full preset prompt every job — the pre-existing behavior, byte-identical |
+| `referenced` | send a short "use your installed `<preset>` preset (commit `<c>`)" reference instead of the whole body, but only when Gitmoot has recorded that the exact resumed session already loaded the same preset at the same commit; any doubt (a new / `last` / fresh session, an unknown session, or a changed commit) falls back to full |
+| `auto` | like `referenced`, and additionally only when the runtime persists sessions (`codex`/`claude`); `shell`/`kimi`/custom always send full |
+
+The optimization is correctness-first and additive: the job payload **always**
+snapshots the exact preset id, resolved commit, and content regardless of mode,
+so auditability and retry determinism are unchanged, and a preset commit change
+invalidates the recorded loaded-state so the next job re-sends the full preset.
+Leave it at `full` unless you repeatedly resume a stable persisted session and
+want to save preset tokens.
+
 `--runtime` accepts `codex`, `claude`, `kimi`, or `kimi-cli`. Kimi Code is a
 first-class runtime adapter alongside Codex and Claude Code; `kimi` targets the
 current Kimi Code CLI (stream-json output) while `kimi-cli` is the opt-in

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -8257,7 +8257,10 @@ blocked). See `references/SAFETY.md` for the full mapping and rationale.
 
 `agent subscribe` accepts `--preset-delivery full|referenced|auto` (default
 `full`) and `agent update <name> --preset-delivery <mode>` flips it in place on
-an already-registered agent. It controls how the agent's installed preset
+an already-registered agent. The mode is a sticky per-agent preference:
+re-running `agent subscribe` on an existing agent WITHOUT `--preset-delivery`
+(e.g. to refresh its session/repo) preserves the stored mode; only brand-new
+agents default to `full`. It controls how the agent's installed preset
 (template) prompt is delivered on each job:
 
 | mode | behavior |

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -8255,6 +8255,24 @@ subscribe`, and at implement-job dispatch with an actionable message. Set
 `go`/`git`/`gh`), or `--policy workspace-write` for edits-only (Bash stays
 blocked). See `references/SAFETY.md` for the full mapping and rationale.
 
+`agent subscribe` accepts `--preset-delivery full|referenced|auto` (default
+`full`) and `agent update <name> --preset-delivery <mode>` flips it in place on
+an already-registered agent. It controls how the agent's installed preset
+(template) prompt is delivered on each job:
+
+| mode | behavior |
+|---|---|
+| `full` (default) | always inline the full preset prompt every job — the pre-existing behavior, byte-identical |
+| `referenced` | send a short "use your installed `<preset>` preset (commit `<c>`)" reference INSTEAD of the whole body, but only when Gitmoot has recorded that the exact resumed session already loaded the same preset at the same commit; any doubt (new/`last`/fresh session, unknown session, changed commit) falls back to full |
+| `auto` | like `referenced`, and ADDITIONALLY only when the runtime persists sessions (`codex`/`claude`); `shell`/`kimi`/custom always send full |
+
+The optimization is correctness-first and additive: the job payload **always**
+snapshots the exact preset id, resolved commit, and content regardless of mode
+(so auditability and retry determinism are unchanged), and a preset commit change
+invalidates the recorded loaded-state so the next job re-sends the full preset.
+Leave it at `full` unless you are resuming a stable persisted session repeatedly
+and want to save preset tokens.
+
 Subscribe an existing runtime session:
 
 ```sh


### PR DESCRIPTION
## What

Adds a per-agent **preset prompt delivery mode** (#33): `full` (default), `referenced`, and `auto`.

- **Config surface**: `gitmoot agent subscribe --preset-delivery full|referenced|auto` and a new in-place `gitmoot agent update <name> --preset-delivery <mode>`. Backed by an additive `agents.preset_delivery` column (DEFAULT `'full'`).
- **State tracking**: a new additive `preset_session_state` table keyed on `(runtime, session_id, preset_id, preset_commit)`, upserted after each successful FULL delivery.
- **Delivery decision** (at prompt assembly, in `Mailbox.Run`): correctness-first.
  - `full` -> today's behavior, byte-identical (the default).
  - `referenced` -> send a short `Use your installed <preset> preset (commit <c>)` reference INSTEAD of the full body, but ONLY when an exact `(runtime, session, preset_id, preset_commit)` state row matches a concrete, resumable session. Any doubt (new/`last`/fresh session, unknown session, changed commit) -> full.
  - `auto` -> like `referenced`, and additionally requires a persisted-session runtime (`codex`/`claude`); `shell`/`kimi`/custom always send full.

## Why

Resending the full preset on every resumed-session invocation is token-heavy for long presets and repeatedly-resumed agents. This makes the optimization explicit, configurable, and correctness-first (prefer full when unsure), exactly as the issue's suggested first step outlines.

## Invariants

- **Additive + off by default**: with `full` (the default) the assembled prompt, wire output, and DB writes are byte-identical. No `ContractVersion` bump. Migrations are additive (`ALTER TABLE ... ADD COLUMN ... DEFAULT 'full'`, `CREATE TABLE`), safe on existing DBs; scan order updated everywhere.
- **Auditability / retry determinism preserved**: the job payload STILL snapshots the exact preset id + resolved commit + content regardless of mode. A preset commit change invalidates the recorded loaded-state (exact-commit match, and `RecordPresetSessionState` overwrites the prior commit row for the tuple), so the next job re-sends the full preset.

## How tested

Gate commands (from a fresh clone off `origin/main`, go1.26.4):

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test -count=1 ./internal/db/... ./internal/workflow/... ./internal/prompts/... ./internal/runtime/... ./internal/cli/...` — pass (cli 250s)
- `go test -race -count=1 -timeout 20m ./internal/workflow/` — pass (622s)
- `cd website && npm ci && npm run build` — pass

New tests:
- **Decision function** unit tests across every mode x state combination (+ concrete-session / preset-present / persisted-runtime gates).
- **Store** tests for the new column (defaults `full`, upsert + in-place update + invalid->full normalization) and table (exact match, per-component mismatch, commit invalidation, delete).
- **CLI** subscribe/update `--preset-delivery` flag test (persist, default, in-place flip, invalid rejected).
- **Deterministic no-LLM E2E** (shell runtime + captured-prompt fake adapter): referenced fires only with prior state, full is the default, auto gates on runtime, and a commit mismatch falls back to full.

## Docs

Updated in this PR: `skills/gitmoot/references/CLI.md`, `website/docs/reference/cli.md`, and the regenerated `website/static/llms-full.txt`.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)