### PR TITLE
feat(workflow): audit gitmoot_result with deterministic binary checklist checks

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -414,6 +414,8 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			// Registry default_model behavioral fallback (#652), home-aware and
 			// fail-open — see daemonWorkflowEngine. Empty by default => byte-identical.
 			RuntimeDefaultModel: runtimeDefaultModelResolver(*home),
+			// Result-check audit (#526), home-aware and fail-safe to the default warn.
+			ResultCheckMode: resultChecksMode(*home),
 		}
 		// Honor the opt-in [orchestrate] policy (artifact-body inlining + per-root
 		// delegation token budget) on this single-repo engine too; fail-safe to the
@@ -6617,6 +6619,13 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// empty by default, so with no config NO model is forced and delivery is
 		// byte-identical; an agent/job --model always wins.
 		RuntimeDefaultModel: runtimeDefaultModelResolver(home),
+		// Off-restores-byte-identical result-check audit (#526): the deterministic
+		// binary-checklist audit of a job's parsed gitmoot_result. resultChecksMode
+		// resolves the [workflow] result_checks knob (default warn) from the
+		// home-aware config; result_checks = off restores the exact pre-feature
+		// terminal path (no event, no payload field, no feed-forward row). Fail-safe
+		// to the documented default warn on any load error.
+		ResultCheckMode: resultChecksMode(home),
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 		},

--- a/internal/cli/result_checks_daemon.go
+++ b/internal/cli/result_checks_daemon.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// resultChecksMode resolves the [workflow] result_checks policy (#526) for a
+// home the SAME dual-mode way the other home-scoped daemon seams do (via
+// resolveConfigFile), so it works both when handed the RAW --home and when handed
+// the already-RESOLVED <home>/.gitmoot root. It is fail-safe to the documented
+// default (warn) on any config-load error, and maps the config-level mode string
+// onto the workflow-level ResultCheckMode the engine/Mailbox consumes. An
+// operator restores the exact pre-#526 terminal path with result_checks = off.
+func resultChecksMode(home string) workflow.ResultCheckMode {
+	var paths config.Paths
+	if strings.TrimSpace(home) == "" {
+		p, err := config.DefaultPaths()
+		if err != nil {
+			return workflow.ResultChecksWarn
+		}
+		paths = p
+	} else {
+		paths = config.Paths{ConfigFile: resolveConfigFile(home)}
+	}
+	mode, err := config.LoadResultChecksMode(paths)
+	if err != nil {
+		return workflow.ResultChecksWarn
+	}
+	return toWorkflowResultCheckMode(mode)
+}
+
+// toWorkflowResultCheckMode bridges the config-package mode enum to the
+// workflow-package one (the two packages are intentionally decoupled — config
+// owns parsing, workflow owns evaluation).
+func toWorkflowResultCheckMode(mode config.ResultChecksMode) workflow.ResultCheckMode {
+	switch mode {
+	case config.ResultChecksOff:
+		return workflow.ResultChecksOff
+	case config.ResultChecksBlock:
+		return workflow.ResultChecksBlock
+	default:
+		return workflow.ResultChecksWarn
+	}
+}

--- a/internal/config/result_checks.go
+++ b/internal/config/result_checks.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -78,11 +79,21 @@ func LoadResultChecksMode(paths Paths) (ResultChecksMode, error) {
 	return mode, nil
 }
 
-// ParseResultChecksMode validates and normalizes a result_checks value. The empty
+// ParseResultChecksMode validates and normalizes a result_checks value. It
+// accepts both the bare (result_checks = off) and quoted (result_checks = "off")
+// TOML styles — the docs and the default-config writer use the quoted form, which
+// matches the sibling cockpit_mode/daemon-runtime convention (see
+// parseConfigDuration) — so a quoted value is unquoted before matching. The empty
 // string falls back to the default (warn) so an operator can clear the key; any
 // other unrecognized value is an error.
 func ParseResultChecksMode(value string) (ResultChecksMode, error) {
-	switch ResultChecksMode(strings.ToLower(strings.TrimSpace(value))) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "\"") {
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			value = strings.TrimSpace(unquoted)
+		}
+	}
+	switch ResultChecksMode(strings.ToLower(value)) {
 	case "":
 		return DefaultResultChecksMode, nil
 	case ResultChecksOff:

--- a/internal/config/result_checks.go
+++ b/internal/config/result_checks.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ResultChecksMode is the resolved [workflow] result_checks policy (#526): the
+// deterministic binary-checklist audit that runs after a job's gitmoot_result is
+// parsed. It has three values:
+//
+//   - off   — the audit is disabled entirely. No checks run, no event is
+//     recorded, no payload field is set, and no feed-forward row is written, so
+//     behavior and wire output are BYTE-IDENTICAL to before this feature existed.
+//   - warn  — checks run; any failures are recorded as a job event, surfaced in
+//     the job detail, and stored for later SkillOpt consumption, but the job
+//     still succeeds/blocks/fails on its own decision. This is the DEFAULT.
+//   - block — checks run; a failure additionally maps the job onto the same
+//     terminal contract-violation path a malformed result takes (the job fails).
+//     Opt-in, for strict workflows.
+type ResultChecksMode string
+
+const (
+	// ResultChecksOff disables the audit (byte-identical pre-#526 behavior).
+	ResultChecksOff ResultChecksMode = "off"
+	// ResultChecksWarn records failures without failing the job (the default).
+	ResultChecksWarn ResultChecksMode = "warn"
+	// ResultChecksBlock maps a failure onto the terminal contract-violation path.
+	ResultChecksBlock ResultChecksMode = "block"
+)
+
+// DefaultResultChecksMode is the value used when the [workflow] section (or the
+// result_checks key) is absent: warn-only, exactly as issue #526 asks. An
+// operator restores the pre-feature behavior by explicitly setting
+// result_checks = off.
+const DefaultResultChecksMode = ResultChecksWarn
+
+// LoadResultChecksMode resolves the [workflow] result_checks knob. An absent
+// config file, an absent [workflow] section, or an absent result_checks key all
+// yield the documented default (warn). A present-but-invalid value is rejected so
+// a typo surfaces loudly rather than silently disabling the audit.
+func LoadResultChecksMode(paths Paths) (ResultChecksMode, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultResultChecksMode, nil
+		}
+		return "", err
+	}
+	mode := DefaultResultChecksMode
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			continue
+		}
+		if current != "workflow" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) != "result_checks" {
+			continue
+		}
+		parsed, err := ParseResultChecksMode(strings.TrimSpace(value))
+		if err != nil {
+			return "", err
+		}
+		mode = parsed
+	}
+	return mode, nil
+}
+
+// ParseResultChecksMode validates and normalizes a result_checks value. The empty
+// string falls back to the default (warn) so an operator can clear the key; any
+// other unrecognized value is an error.
+func ParseResultChecksMode(value string) (ResultChecksMode, error) {
+	switch ResultChecksMode(strings.ToLower(strings.TrimSpace(value))) {
+	case "":
+		return DefaultResultChecksMode, nil
+	case ResultChecksOff:
+		return ResultChecksOff, nil
+	case ResultChecksWarn:
+		return ResultChecksWarn, nil
+	case ResultChecksBlock:
+		return ResultChecksBlock, nil
+	default:
+		return "", fmt.Errorf("invalid [workflow] result_checks %q; expected one of off, warn, block", value)
+	}
+}

--- a/internal/config/result_checks_test.go
+++ b/internal/config/result_checks_test.go
@@ -42,6 +42,13 @@ func TestLoadResultChecksModeMatrix(t *testing.T) {
 		{"warn", ResultChecksWarn},
 		{"block", ResultChecksBlock},
 		{"  BLOCK  ", ResultChecksBlock}, // trimmed + case-insensitive
+		// Quoted TOML form — the exact style the docs and DefaultConfig writer
+		// use (result_checks = "off"). Must parse identically to the bare form,
+		// otherwise the feature cannot be disabled/blocked via the docs (#526).
+		{`"off"`, ResultChecksOff},
+		{`"warn"`, ResultChecksWarn},
+		{`"block"`, ResultChecksBlock},
+		{`  "BLOCK"  `, ResultChecksBlock}, // quoted + padded + case-insensitive
 	} {
 		paths := PathsForHome(t.TempDir())
 		if err := Initialize(paths); err != nil {

--- a/internal/config/result_checks_test.go
+++ b/internal/config/result_checks_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadResultChecksModeDefaultsToWarn(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// No [workflow] section -> the documented warn-by-default (issue #526).
+	mode, err := LoadResultChecksMode(paths)
+	if err != nil {
+		t.Fatalf("LoadResultChecksMode: %v", err)
+	}
+	if mode != ResultChecksWarn {
+		t.Fatalf("mode = %q, want warn", mode)
+	}
+}
+
+func TestLoadResultChecksModeMissingFileDefaultsToWarn(t *testing.T) {
+	// A home whose config file was never written must still resolve to warn, not
+	// error, mirroring LoadMemorySettings' missing-file handling.
+	paths := PathsForHome(t.TempDir())
+	mode, err := LoadResultChecksMode(paths)
+	if err != nil {
+		t.Fatalf("LoadResultChecksMode: %v", err)
+	}
+	if mode != ResultChecksWarn {
+		t.Fatalf("mode = %q, want warn", mode)
+	}
+}
+
+func TestLoadResultChecksModeMatrix(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  ResultChecksMode
+	}{
+		{"off", ResultChecksOff},
+		{"warn", ResultChecksWarn},
+		{"block", ResultChecksBlock},
+		{"  BLOCK  ", ResultChecksBlock}, // trimmed + case-insensitive
+	} {
+		paths := PathsForHome(t.TempDir())
+		if err := Initialize(paths); err != nil {
+			t.Fatalf("Initialize: %v", err)
+		}
+		if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+"\n[workflow]\nresult_checks = "+tc.value+"\n"), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		mode, err := LoadResultChecksMode(paths)
+		if err != nil {
+			t.Fatalf("LoadResultChecksMode(%q): %v", tc.value, err)
+		}
+		if mode != tc.want {
+			t.Fatalf("value %q -> mode %q, want %q", tc.value, mode, tc.want)
+		}
+	}
+}
+
+func TestLoadResultChecksModeRejectsInvalid(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+"\n[workflow]\nresult_checks = loud\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadResultChecksMode(paths); err == nil {
+		t.Fatal("expected an error for an invalid result_checks value")
+	}
+}
+
+func TestLoadResultChecksModeIgnoresOtherSections(t *testing.T) {
+	// A result_checks key under a DIFFERENT section must not be picked up.
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+"\n[memory]\nresult_checks = off\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	mode, err := LoadResultChecksMode(paths)
+	if err != nil {
+		t.Fatalf("LoadResultChecksMode: %v", err)
+	}
+	if mode != ResultChecksWarn {
+		t.Fatalf("mode = %q, want warn (result_checks under [memory] must be ignored)", mode)
+	}
+}

--- a/internal/db/result_checks.go
+++ b/internal/db/result_checks.go
@@ -1,0 +1,76 @@
+package db
+
+import "context"
+
+// ResultCheckFailure is one failed deterministic result check to persist (#526).
+// It is the per-check payload of RecordResultCheckFailures; the job/root/action
+// context is passed alongside so a caller never has to repeat it per row.
+type ResultCheckFailure struct {
+	CheckID     string
+	Question    string
+	Explanation string
+}
+
+// ResultCheckFailureRow is a persisted result-check failure as read back
+// (RecordResultCheckFailures writes one row per failed check). It is the
+// feed-forward record SkillOpt may later consume as structured feedback; nothing
+// consumes it tonight beyond tests and the job-detail cross-check.
+type ResultCheckFailureRow struct {
+	ID          int64
+	JobID       string
+	RootID      string
+	Action      string
+	CheckID     string
+	Question    string
+	Explanation string
+	CreatedAt   string
+}
+
+// RecordResultCheckFailures persists the given failed checks for a job as one row
+// per check (#526, the SkillOpt feed-forward stub). It is a pure additive write:
+// the result_check_failures table is empty until [workflow] result_checks is
+// warn/block AND a result fails a check, so every existing DB and every off-mode
+// job is byte-identical. An empty slice is a no-op. Best-effort by convention at
+// the call site — the audit must never fail a job — but the error is still
+// returned so tests can assert the write.
+func (s *Store) RecordResultCheckFailures(ctx context.Context, jobID, rootID, action string, checks []ResultCheckFailure) error {
+	if len(checks) == 0 {
+		return nil
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, c := range checks {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO result_check_failures(job_id, root_id, action, check_id, question, explanation)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			jobID, rootID, action, c.CheckID, c.Question, c.Explanation); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// ListResultCheckFailures returns the persisted result-check failures for a job
+// in insertion order. It is used by tests and is the read seam a future SkillOpt
+// consumer would build on.
+func (s *Store) ListResultCheckFailures(ctx context.Context, jobID string) ([]ResultCheckFailureRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, job_id, root_id, action, check_id, question, explanation, created_at
+		 FROM result_check_failures WHERE job_id = ? ORDER BY id`, jobID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []ResultCheckFailureRow
+	for rows.Next() {
+		var r ResultCheckFailureRow
+		if err := rows.Scan(&r.ID, &r.JobID, &r.RootID, &r.Action, &r.CheckID, &r.Question, &r.Explanation, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}

--- a/internal/db/result_checks_test.go
+++ b/internal/db/result_checks_test.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func openResultCheckStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+func TestRecordAndListResultCheckFailures(t *testing.T) {
+	ctx := context.Background()
+	store := openResultCheckStore(t)
+
+	checks := []ResultCheckFailure{
+		{CheckID: "implement-changes-listed", Question: "made?", Explanation: "changes_made empty"},
+		{CheckID: "implement-tests-listed", Question: "tested?", Explanation: "tests_run empty"},
+	}
+	if err := store.RecordResultCheckFailures(ctx, "job-1", "root-1", "implement", checks); err != nil {
+		t.Fatalf("RecordResultCheckFailures: %v", err)
+	}
+
+	rows, err := store.ListResultCheckFailures(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListResultCheckFailures: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %+v, want 2", rows)
+	}
+	if rows[0].CheckID != "implement-changes-listed" || rows[1].CheckID != "implement-tests-listed" {
+		t.Fatalf("rows out of insertion order: %+v", rows)
+	}
+	if rows[0].JobID != "job-1" || rows[0].RootID != "root-1" || rows[0].Action != "implement" {
+		t.Fatalf("row context wrong: %+v", rows[0])
+	}
+	if rows[0].CreatedAt == "" {
+		t.Fatalf("row created_at should be populated: %+v", rows[0])
+	}
+
+	// A different job has no rows.
+	other, err := store.ListResultCheckFailures(ctx, "job-2")
+	if err != nil {
+		t.Fatalf("ListResultCheckFailures(job-2): %v", err)
+	}
+	if len(other) != 0 {
+		t.Fatalf("unrelated job rows = %+v, want none", other)
+	}
+}
+
+func TestRecordResultCheckFailuresEmptyIsNoop(t *testing.T) {
+	ctx := context.Background()
+	store := openResultCheckStore(t)
+	if err := store.RecordResultCheckFailures(ctx, "job-1", "root-1", "ask", nil); err != nil {
+		t.Fatalf("RecordResultCheckFailures(empty): %v", err)
+	}
+	rows, err := store.ListResultCheckFailures(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("ListResultCheckFailures: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("empty record must write nothing, got %+v", rows)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -7829,4 +7829,27 @@ CREATE TABLE pipeline_run_stages (
 
 CREATE INDEX idx_pipeline_run_stages_run_id ON pipeline_run_stages(run_id);
 	`,
+	// #526 result-check feed-forward stub: one row per FAILED deterministic
+	// binary-checklist audit of a job's parsed gitmoot_result, stored so SkillOpt
+	// can later consume them as structured feedback. Nothing reads this table
+	// tonight beyond tests and the job-detail cross-check — there is NO SkillOpt
+	// behavior change. Pure additive append (CREATE TABLE/INDEX only, no ALTER or
+	// renumber of any prior migration): the table stays empty until [workflow]
+	// result_checks is warn/block AND a result actually fails a check, so every
+	// existing DB and every off-mode job reads byte-identically. Rows are keyed by
+	// job id (not FK-constrained) so a retried/cancelled job's history is retained;
+	// there is no GC in v1 (a failure row is tens of bytes).
+	`
+CREATE TABLE result_check_failures (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	job_id TEXT NOT NULL,
+	root_id TEXT NOT NULL DEFAULT '',
+	action TEXT NOT NULL DEFAULT '',
+	check_id TEXT NOT NULL DEFAULT '',
+	question TEXT NOT NULL DEFAULT '',
+	explanation TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_result_check_failures_job ON result_check_failures(job_id);
+	`,
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -308,6 +308,16 @@ type Engine struct {
 	// agent/job pin always wins. Nil (the default) forces nothing, so delivery is
 	// byte-identical to before #652.
 	RuntimeDefaultModel func(runtimeName string) string
+	// ResultCheckMode is the resolved [workflow] result_checks policy (#526): the
+	// deterministic binary-checklist audit run on a job's parsed gitmoot_result.
+	// It is copied onto every Mailbox the engine builds (mailbox()). The zero
+	// value ("") and "off" disable the audit entirely, so an Engine built with a
+	// bare struct literal (every test, the ask/foreground path) is byte-identical;
+	// the daemon resolves the real mode (default warn) from config and sets it
+	// here. "warn" records failures as a job event + job-detail field + feed-
+	// forward row; "block" additionally fails the job via the contract-violation
+	// path.
+	ResultCheckMode ResultCheckMode
 }
 
 // DelegationTimeoutDefaults are optional fallback timeouts for child delegation
@@ -424,7 +434,7 @@ func (e Engine) now() time.Time {
 // path is byte-identical. The hook maps the terminal JobState to the event_type,
 // resolves root_id from the payload, and ships a redacted event fire-and-forget.
 func (e Engine) mailbox() Mailbox {
-	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer, RuntimeDefaultModel: e.RuntimeDefaultModel}
+	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer, RuntimeDefaultModel: e.RuntimeDefaultModel, resultCheckMode: normalizeResultCheckMode(e.ResultCheckMode)}
 	// Wire the off-by-default memory hooks (#626). When e.Memory is nil (every
 	// non-enrolled path) both hooks stay nil, so Run's prompt assembly and terminal
 	// path are byte-identical. The hooks themselves also no-op when the executor

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -93,6 +93,12 @@ type Mailbox struct {
 	// default, and any error/empty result) forces nothing, so delivery is
 	// byte-identical to before #652.
 	RuntimeDefaultModel func(runtimeName string) string
+	// resultCheckMode is the resolved [workflow] result_checks policy (#526). The
+	// zero value ("") and "off" both disable the deterministic post-parse audit,
+	// so every Mailbox built without explicitly setting it — every test, the ask/
+	// foreground path — is byte-identical. The daemon resolves the real mode
+	// (default warn) from config and wires it through Engine.ResultCheckMode.
+	resultCheckMode ResultCheckMode
 }
 
 type JobRequest struct {
@@ -210,6 +216,12 @@ type JobPayload struct {
 	HumanAnswer            string         `json:"human_answer,omitempty"`
 	RawOutputs             []string       `json:"raw_outputs,omitempty"`
 	Result                 *AgentResult   `json:"result,omitempty"`
+	// ResultChecks, when non-empty, carries the deterministic binary-checklist
+	// audit FAILURES for this job's parsed result (#526). It is the job-detail
+	// surface the dashboard and `gitmoot job show --json` read. Fully additive
+	// (omitempty): a job whose result passed every applicable check — and every
+	// job when [workflow] result_checks = off — serializes byte-identically.
+	ResultChecks []ResultCheck `json:"result_checks,omitempty"`
 	// Operational-blocker deferral context (#532, additive — all omitempty, so a
 	// job that never hit a classified blocker serializes byte-identically).
 	// BlockerClass is the last classified blocker (e.g. "runtime_auth",
@@ -658,6 +670,45 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 		result.Delegations = nil
 	}
 	payload.Result = &result
+	// #526 deterministic binary-checklist audit of the parsed result. Off (the
+	// zero value and "off") => no checks run, no event, no payload field, no feed-
+	// forward row, so the terminal path is byte-identical. warn => failures are
+	// recorded (job event + job-detail field + feed-forward row) but the job still
+	// finishes on its own decision. block => a failure additionally routes the job
+	// down the same terminal path a malformed result takes (m.fail), reusing the
+	// contract-violation machinery. The audit itself is pure and LLM-free.
+	if mode := normalizeResultCheckMode(m.resultCheckMode); mode != ResultChecksOff {
+		if failed := FailedResultChecks(ResultCheckInput{Action: job.Type, IsFinalize: payload.DelegationFinalize, Result: result}); len(failed) > 0 {
+			payload.ResultChecks = failed
+			summary := SummarizeResultChecks(failed)
+			// Surface in `gitmoot job events`/`job show`. Best-effort in block mode
+			// (the fail path below is authoritative); required in warn mode so the
+			// failure is visible, hence the error is returned there.
+			if err := m.addEvent(ctx, job.ID, ResultChecksFailedEventKind, summary); err != nil && mode != ResultChecksBlock {
+				return AgentResult{}, err
+			}
+			// Feed-forward stub for SkillOpt (#526): persist the failures so the
+			// optimizer can later consume them as structured feedback. Best-effort —
+			// it must never fail the job, and it does nothing tonight beyond storing.
+			rootID := strings.TrimSpace(payload.RootJobID)
+			if rootID == "" {
+				rootID = job.ID
+			}
+			_ = m.Store.RecordResultCheckFailures(ctx, job.ID, rootID, job.Type, toDBResultCheckFailures(failed))
+			if mode == ResultChecksBlock {
+				// Persist the payload (carrying ResultChecks + Result) BEFORE failing so
+				// the job-detail surface shows exactly which checks failed, then map the
+				// audit failure onto the terminal contract-violation path via m.fail.
+				if err := m.savePayload(ctx, job.ID, payload); err != nil {
+					return AgentResult{}, err
+				}
+				if err := m.fail(ctx, job.ID, "result checks failed: "+summary); err != nil {
+					return AgentResult{}, err
+				}
+				return AgentResult{}, &ResultChecksError{Failed: failed}
+			}
+		}
+	}
 	// Shadow-log returned learnings + write any mechanical fact at job terminal
 	// (#626 WRITE path). No-op when the hook is unset or the agent is not enrolled,
 	// so the terminal path is byte-identical. Best-effort — it never fails the job.

--- a/internal/workflow/result_checks.go
+++ b/internal/workflow/result_checks.go
@@ -1,0 +1,274 @@
+package workflow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// ResultChecksError is the typed error returned from Mailbox.Run when the audit
+// is in block mode and one or more checks failed (#526). The job has already been
+// transitioned to failed (via the shared contract-violation path) by the time it
+// is returned; it carries the failed checks so a caller can inspect or log them.
+type ResultChecksError struct {
+	Failed []ResultCheck
+}
+
+func (e *ResultChecksError) Error() string {
+	return SummarizeResultChecks(e.Failed)
+}
+
+// toDBResultCheckFailures maps the workflow-level failed checks onto the db
+// feed-forward rows (#526). Only the per-check fields travel; the job/root/action
+// context is passed alongside at the call site.
+func toDBResultCheckFailures(failed []ResultCheck) []db.ResultCheckFailure {
+	out := make([]db.ResultCheckFailure, 0, len(failed))
+	for _, c := range failed {
+		out = append(out, db.ResultCheckFailure{
+			CheckID:     c.ID,
+			Question:    c.Question,
+			Explanation: c.Explanation,
+		})
+	}
+	return out
+}
+
+// ResultCheckMode is the resolved result-check policy carried on the Engine and
+// its Mailbox (#526). It is a plain string so the workflow package stays
+// decoupled from internal/config (which owns parsing + the warn-by-default
+// resolution). The zero value ("") is treated as OFF: every path that does not
+// explicitly resolve the [workflow] result_checks config — every test, the ask/
+// foreground path, and any Engine built with a bare struct literal — runs the
+// audit disabled, so behavior is byte-identical. The daemon resolves the real
+// mode (default warn) from config and wires it in.
+type ResultCheckMode string
+
+const (
+	// ResultChecksOff disables the audit (byte-identical pre-#526 behavior). It is
+	// also the meaning of the empty zero value.
+	ResultChecksOff ResultCheckMode = "off"
+	// ResultChecksWarn records failures as a job event + job-detail field + feed-
+	// forward row without failing the job.
+	ResultChecksWarn ResultCheckMode = "warn"
+	// ResultChecksBlock additionally maps a failure onto the terminal contract-
+	// violation path (the job fails), for strict workflows.
+	ResultChecksBlock ResultCheckMode = "block"
+)
+
+// ResultChecksFailedEventKind is the job-event kind recorded when one or more
+// deterministic result checks fail. It is visible in `gitmoot job events` and
+// `gitmoot job show`.
+const ResultChecksFailedEventKind = "result_checks_failed"
+
+// normalizeResultCheckMode maps the zero value and any unrecognized string onto a
+// safe mode. Empty ("") and "off" both disable the audit; only the exact "warn"
+// and "block" values enable it, so a malformed injected value fails closed
+// (disabled) rather than surprising an operator with a hard block.
+func normalizeResultCheckMode(mode ResultCheckMode) ResultCheckMode {
+	switch mode {
+	case ResultChecksWarn:
+		return ResultChecksWarn
+	case ResultChecksBlock:
+		return ResultChecksBlock
+	default:
+		return ResultChecksOff
+	}
+}
+
+// ResultCheck is one deterministic yes/no audit of a parsed AgentResult (#526),
+// modeled on BINEVAL's binary-verdict-plus-explanation shape. It is fully
+// additive and serialized (omitempty on the payload slice) so a result that
+// passes every applicable check is byte-identical on the wire.
+type ResultCheck struct {
+	// ID is a stable, machine-readable handle for the check (e.g.
+	// "implement-tests-listed"), suitable for later SkillOpt aggregation.
+	ID string `json:"id"`
+	// Action is the job action the check applies to ("implement", "review",
+	// "ask", "coordinator"), or "any" for a decision-scoped check that applies
+	// regardless of action.
+	Action string `json:"action"`
+	// Question is the human-readable binary question the check answers.
+	Question string `json:"question"`
+	// Pass is the binary verdict.
+	Pass bool `json:"pass"`
+	// Explanation states, in one sentence, why the check failed (empty when it
+	// passed) so the failure is self-describing in job output and the dashboard.
+	Explanation string `json:"explanation"`
+}
+
+// ResultCheckInput carries the minimal job context the deterministic checks need
+// beyond the parsed result: the job action and whether the job is a coordinator
+// finalize continuation (payload.DelegationFinalize). Keeping this a small value
+// type makes the check set trivially unit-testable without a store or a job row.
+type ResultCheckInput struct {
+	Action     string
+	IsFinalize bool
+	Result     AgentResult
+}
+
+// minActionableAnswerChars is the floor below which an ask/finalize answer is
+// treated as non-actionable. It is intentionally tiny: a valid gitmoot_result
+// already requires a non-empty summary, so this only catches degenerate
+// single-token answers ("s", ".") rather than second-guessing terse-but-real
+// answers like "ok" or "done".
+const minActionableAnswerChars = 3
+
+// RunResultChecks evaluates every deterministic check that applies to the given
+// action/result and returns them all (passing and failing), each with its binary
+// verdict and — when failing — an explanation. It performs NO LLM call and reads
+// only fields that exist on AgentResult (see internal/workflow/result.go), so it
+// is pure, fast, and side-effect-free. Callers that only care about failures use
+// FailedResultChecks.
+func RunResultChecks(in ResultCheckInput) []ResultCheck {
+	action := strings.ToLower(strings.TrimSpace(in.Action))
+	r := in.Result
+	var checks []ResultCheck
+
+	// Decision-scoped (action-agnostic): a blocked result must list actionable
+	// blockers. The engine already routes a blocked decision's `needs` into
+	// resumable gates (#682); an empty or blank needs list is a blocked result with
+	// nothing to act on.
+	if r.Decision == "blocked" {
+		pass := hasActionableEntries(r.Needs)
+		checks = append(checks, ResultCheck{
+			ID:          "blocked-blockers-actionable",
+			Action:      "any",
+			Question:    "Does the blocked result list actionable blockers (needs)?",
+			Pass:        pass,
+			Explanation: explain(pass, "the result is blocked but lists no actionable blockers in needs[]"),
+		})
+	}
+
+	switch action {
+	case "implement":
+		// A job that claims it implemented changes must enumerate them, and must
+		// list the tests it ran, so a human/continuation can see what actually
+		// happened rather than trusting the summary prose.
+		if r.Decision == "implemented" {
+			madePass := len(r.ChangesMade) > 0
+			checks = append(checks, ResultCheck{
+				ID:          "implement-changes-listed",
+				Action:      "implement",
+				Question:    "Did the implement job list the concrete changes it made?",
+				Pass:        madePass,
+				Explanation: explain(madePass, "the implement job reports decision \"implemented\" but changes_made[] is empty"),
+			})
+			testsPass := len(r.TestsRun) > 0
+			checks = append(checks, ResultCheck{
+				ID:          "implement-tests-listed",
+				Action:      "implement",
+				Question:    "Did the implement job list the tests it ran?",
+				Pass:        testsPass,
+				Explanation: explain(testsPass, "the implement job reports decision \"implemented\" but tests_run[] is empty"),
+			})
+		}
+	case "review":
+		// A changes-requested review must carry findings — the concrete, evidence-
+		// bearing objections the author is expected to address. A bare
+		// changes_requested with no findings is an un-actionable verdict.
+		if r.Decision == "changes_requested" {
+			pass := len(r.Findings) > 0
+			checks = append(checks, ResultCheck{
+				ID:          "review-evidence-present",
+				Action:      "review",
+				Question:    "Does a changes-requested review include findings/evidence?",
+				Pass:        pass,
+				Explanation: explain(pass, "the review requests changes but findings[] is empty, so there is no evidence to act on"),
+			})
+		}
+	case "ask":
+		// The coordinator finalize continuation is dispatched as an "ask" carrying
+		// DelegationFinalize (#305): it is a reconciliation, not a plain answer, so
+		// it gets the coordinator check below instead of the ask-answer check.
+		if !in.IsFinalize {
+			pass := isActionableAnswer(r)
+			checks = append(checks, ResultCheck{
+				ID:          "ask-answer-actionable",
+				Action:      "ask",
+				Question:    "Did the ask job return a non-empty, actionable answer?",
+				Pass:        pass,
+				Explanation: explain(pass, "the ask job's answer (summary/artifact_body) is empty or too short to be actionable"),
+			})
+		}
+	}
+
+	// Coordinator finalize continuation (#305): a coordinator re-invoked to
+	// reconcile its children's results must produce a substantive synthesis rather
+	// than a terse rubber-stamp. This grounds "reconcile the children" on the
+	// fields available at result-parse time (a substantive answer body); it does
+	// NOT cross-reference each child job — deeper per-child reconciliation is left
+	// as future work once child results are threaded to this seam.
+	if in.IsFinalize {
+		pass := isActionableAnswer(r)
+		checks = append(checks, ResultCheck{
+			ID:          "coordinator-outcome-reconciled",
+			Action:      "coordinator",
+			Question:    "Did the coordinator reconcile and summarize its children's outcomes?",
+			Pass:        pass,
+			Explanation: explain(pass, "the coordinator finalize produced no substantive reconciliation summary"),
+		})
+	}
+
+	return checks
+}
+
+// FailedResultChecks runs the audit and returns only the checks that failed, in
+// check order. An empty slice means the result passed every applicable check.
+func FailedResultChecks(in ResultCheckInput) []ResultCheck {
+	var failed []ResultCheck
+	for _, c := range RunResultChecks(in) {
+		if !c.Pass {
+			failed = append(failed, c)
+		}
+	}
+	return failed
+}
+
+// SummarizeResultChecks renders a one-line, human-readable summary of the failed
+// checks for the job event message, e.g. "2 result check(s) failed:
+// implement-tests-listed (…); blocked-blockers-actionable (…)".
+func SummarizeResultChecks(failed []ResultCheck) string {
+	if len(failed) == 0 {
+		return "all result checks passed"
+	}
+	parts := make([]string, 0, len(failed))
+	for _, c := range failed {
+		parts = append(parts, fmt.Sprintf("%s (%s)", c.ID, c.Explanation))
+	}
+	return fmt.Sprintf("%d result check(s) failed: %s", len(failed), strings.Join(parts, "; "))
+}
+
+// isActionableAnswer reports whether a result carries a non-trivial answer body:
+// a summary at least minActionableAnswerChars long, or a non-empty artifact_body,
+// or any findings. It is the shared deterministic proxy for "actionable" used by
+// the ask and coordinator checks.
+func isActionableAnswer(r AgentResult) bool {
+	if len(strings.TrimSpace(r.Summary)) >= minActionableAnswerChars {
+		return true
+	}
+	if strings.TrimSpace(r.ArtifactBody) != "" {
+		return true
+	}
+	return len(r.Findings) > 0
+}
+
+// hasActionableEntries reports whether a string slice contains at least one
+// non-blank entry, so an all-empty or single-blank list counts as no entries.
+func hasActionableEntries(values []string) bool {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// explain returns the failure explanation for a failed check and "" for a passed
+// one, so the ResultCheck.Explanation field is empty exactly when Pass is true.
+func explain(pass bool, why string) string {
+	if pass {
+		return ""
+	}
+	return why
+}

--- a/internal/workflow/result_checks_mailbox_test.go
+++ b/internal/workflow/result_checks_mailbox_test.go
@@ -1,0 +1,218 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// vagueImplementResult is a deliberately deficient implement result: it claims
+// "implemented" but lists no changes_made and no tests_run, so it fails both
+// implement checks. It parses cleanly (valid contract), so only the #526 audit
+// catches it — the perfect deterministic, no-LLM fixture.
+const vagueImplementResult = `{"gitmoot_result":{"decision":"implemented","summary":"did the work","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+
+func shellAgent() runtime.Agent {
+	return runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "implementer"}
+}
+
+func TestMailboxRunResultChecksOffIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	// Off (the zero value): no audit runs at all.
+	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksOff}
+	adapter := &fakeDelivery{outputs: []string{vagueImplementResult}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-off", Agent: "audit", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "job-off", shellAgent(), adapter)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Decision != "implemented" {
+		t.Fatalf("decision = %q, want implemented", result.Decision)
+	}
+	// No result_checks_failed event.
+	events, err := store.ListJobEvents(ctx, "job-off")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	for _, e := range events {
+		if e.Kind == ResultChecksFailedEventKind {
+			t.Fatalf("off mode must record no %s event; events=%+v", ResultChecksFailedEventKind, events)
+		}
+	}
+	// No payload field and no feed-forward rows.
+	job, err := store.GetJob(ctx, "job-off")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if len(payload.ResultChecks) != 0 {
+		t.Fatalf("off mode must set no payload.ResultChecks, got %+v", payload.ResultChecks)
+	}
+	rows, err := store.ListResultCheckFailures(ctx, "job-off")
+	if err != nil {
+		t.Fatalf("ListResultCheckFailures: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("off mode must write no feed-forward rows, got %+v", rows)
+	}
+}
+
+func TestMailboxRunResultChecksWarnSurfacesButSucceeds(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksWarn}
+	adapter := &fakeDelivery{outputs: []string{vagueImplementResult}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-warn", Agent: "audit", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	result, err := mailbox.Run(ctx, "job-warn", shellAgent(), adapter)
+	if err != nil {
+		t.Fatalf("Run must NOT error in warn mode: %v", err)
+	}
+	if result.Decision != "implemented" {
+		t.Fatalf("decision = %q, want implemented (warn does not change the outcome)", result.Decision)
+	}
+	// Job still succeeded on its own decision.
+	job, err := store.GetJob(ctx, "job-warn")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(JobSucceeded) {
+		t.Fatalf("state = %q, want succeeded (warn does not fail the job)", job.State)
+	}
+	// The failed checks are visible as a job event.
+	events, err := store.ListJobEvents(ctx, "job-warn")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var found bool
+	for _, e := range events {
+		if e.Kind == ResultChecksFailedEventKind {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("warn mode must record a %s event; events=%+v", ResultChecksFailedEventKind, events)
+	}
+	// The failed checks are on the job-detail payload (dashboard / job show).
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if len(payload.ResultChecks) != 2 {
+		t.Fatalf("warn payload.ResultChecks = %+v, want the two failed implement checks", payload.ResultChecks)
+	}
+	for _, c := range payload.ResultChecks {
+		if c.Pass || c.Explanation == "" {
+			t.Fatalf("payload check should be a failure with an explanation: %+v", c)
+		}
+	}
+	// The feed-forward stub persisted the failures for SkillOpt.
+	rows, err := store.ListResultCheckFailures(ctx, "job-warn")
+	if err != nil {
+		t.Fatalf("ListResultCheckFailures: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("warn mode must write 2 feed-forward rows, got %+v", rows)
+	}
+	if rows[0].Action != "implement" || rows[0].CheckID == "" {
+		t.Fatalf("feed-forward row missing context: %+v", rows[0])
+	}
+}
+
+func TestMailboxRunResultChecksBlockFailsLikeContractViolation(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksBlock}
+	adapter := &fakeDelivery{outputs: []string{vagueImplementResult}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-block", Agent: "audit", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	_, err := mailbox.Run(ctx, "job-block", shellAgent(), adapter)
+	if err == nil {
+		t.Fatal("block mode must return an error when checks fail")
+	}
+	var checksErr *ResultChecksError
+	if !errors.As(err, &checksErr) {
+		t.Fatalf("expected a *ResultChecksError, got %T: %v", err, err)
+	}
+	if len(checksErr.Failed) != 2 {
+		t.Fatalf("block error should carry the 2 failed checks, got %+v", checksErr.Failed)
+	}
+	// The job is terminally failed (the contract-violation path), NOT succeeded.
+	job, err := store.GetJob(ctx, "job-block")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(JobFailed) {
+		t.Fatalf("state = %q, want failed (block maps to the contract-violation path)", job.State)
+	}
+	// The failing checks are still surfaced on the payload for the operator.
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if len(payload.ResultChecks) != 2 {
+		t.Fatalf("block payload must carry the failed checks, got %+v", payload.ResultChecks)
+	}
+	events, err := store.ListJobEvents(ctx, "job-block")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	var sawChecks, sawFailed bool
+	for _, e := range events {
+		switch e.Kind {
+		case ResultChecksFailedEventKind:
+			sawChecks = true
+		case string(JobFailed):
+			sawFailed = true
+		}
+	}
+	if !sawChecks || !sawFailed {
+		t.Fatalf("block mode must record both a %s and a failed event; events=%+v", ResultChecksFailedEventKind, events)
+	}
+}
+
+func TestMailboxRunResultChecksWarnCleanResultIsQuiet(t *testing.T) {
+	// A COMPLETE implement result under warn mode records nothing — proving the
+	// audit only fires on genuine failures, not on every job.
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksWarn}
+	clean := `{"gitmoot_result":{"decision":"implemented","summary":"implemented X","findings":[],"changes_made":["added foo.go"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
+	adapter := &fakeDelivery{outputs: []string{clean}}
+
+	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-clean", Agent: "audit", Action: "implement", Repo: "jerryfane/gitmoot"}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "job-clean", shellAgent(), adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, "job-clean")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	for _, e := range events {
+		if e.Kind == ResultChecksFailedEventKind {
+			t.Fatalf("a clean result must record no %s event; events=%+v", ResultChecksFailedEventKind, events)
+		}
+	}
+	rows, err := store.ListResultCheckFailures(ctx, "job-clean")
+	if err != nil {
+		t.Fatalf("ListResultCheckFailures: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("a clean result must write no feed-forward rows, got %+v", rows)
+	}
+}

--- a/internal/workflow/result_checks_test.go
+++ b/internal/workflow/result_checks_test.go
@@ -1,0 +1,189 @@
+package workflow
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// failedIDs runs the audit for the given input and returns the set of failed
+// check ids, for compact assertions.
+func failedIDs(in ResultCheckInput) map[string]ResultCheck {
+	out := map[string]ResultCheck{}
+	for _, c := range FailedResultChecks(in) {
+		out[c.ID] = c
+	}
+	return out
+}
+
+func TestRunResultChecksImplementIncomplete(t *testing.T) {
+	// An implement job claiming "implemented" with no changes and no tests fails
+	// both implement checks.
+	failed := failedIDs(ResultCheckInput{
+		Action: "implement",
+		Result: AgentResult{Decision: "implemented", Summary: "did the thing"},
+	})
+	for _, id := range []string{"implement-changes-listed", "implement-tests-listed"} {
+		if c, ok := failed[id]; !ok {
+			t.Fatalf("expected %s to fail; failed=%v", id, keys(failed))
+		} else if c.Pass || c.Explanation == "" {
+			t.Fatalf("%s should be a failed check with an explanation: %+v", id, c)
+		}
+	}
+}
+
+func TestRunResultChecksImplementClean(t *testing.T) {
+	// A complete implement result passes every check.
+	failed := failedIDs(ResultCheckInput{
+		Action: "implement",
+		Result: AgentResult{
+			Decision:    "implemented",
+			Summary:     "implemented feature X",
+			ChangesMade: []string{"added foo.go"},
+			TestsRun:    []string{"go test ./..."},
+		},
+	})
+	if len(failed) != 0 {
+		t.Fatalf("clean implement result should pass all checks; failed=%v", keys(failed))
+	}
+}
+
+func TestRunResultChecksImplementNonImplementedDecisionSkipsChecks(t *testing.T) {
+	// The implement checks only apply to a decision of "implemented"; a blocked
+	// implement job is audited by the blocked check instead.
+	failed := failedIDs(ResultCheckInput{
+		Action: "implement",
+		Result: AgentResult{Decision: "blocked", Summary: "cannot proceed", Needs: []string{"need creds"}},
+	})
+	if _, ok := failed["implement-changes-listed"]; ok {
+		t.Fatalf("implement checks must not fire on a non-implemented decision; failed=%v", keys(failed))
+	}
+}
+
+func TestRunResultChecksReviewChangesRequestedNeedsEvidence(t *testing.T) {
+	// changes_requested with no findings fails; with findings passes.
+	failed := failedIDs(ResultCheckInput{
+		Action: "review",
+		Result: AgentResult{Decision: "changes_requested", Summary: "please fix"},
+	})
+	if _, ok := failed["review-evidence-present"]; !ok {
+		t.Fatalf("expected review-evidence-present to fail; failed=%v", keys(failed))
+	}
+
+	withFindings := failedIDs(ResultCheckInput{
+		Action: "review",
+		Result: AgentResult{
+			Decision: "changes_requested",
+			Summary:  "please fix",
+			Findings: []json.RawMessage{json.RawMessage(`{"file":"a.go","issue":"bug"}`)},
+		},
+	})
+	if _, ok := withFindings["review-evidence-present"]; ok {
+		t.Fatalf("review with findings must pass; failed=%v", keys(withFindings))
+	}
+
+	// An approved review carries no evidence obligation.
+	approved := failedIDs(ResultCheckInput{
+		Action: "review",
+		Result: AgentResult{Decision: "approved", Summary: "looks good"},
+	})
+	if len(approved) != 0 {
+		t.Fatalf("approved review should pass all checks; failed=%v", keys(approved))
+	}
+}
+
+func TestRunResultChecksAskAnswerActionable(t *testing.T) {
+	// A degenerate single-char answer with no body fails; a real answer passes.
+	failed := failedIDs(ResultCheckInput{
+		Action: "ask",
+		Result: AgentResult{Decision: "approved", Summary: "s"},
+	})
+	if _, ok := failed["ask-answer-actionable"]; !ok {
+		t.Fatalf("expected ask-answer-actionable to fail on a 1-char answer; failed=%v", keys(failed))
+	}
+
+	ok := failedIDs(ResultCheckInput{
+		Action: "ask",
+		Result: AgentResult{Decision: "approved", Summary: "yes, use approach B because it is simpler"},
+	})
+	if _, bad := ok["ask-answer-actionable"]; bad {
+		t.Fatalf("a substantive ask answer must pass; failed=%v", keys(ok))
+	}
+
+	// An answer delivered via artifact_body (short summary) still passes.
+	viaBody := failedIDs(ResultCheckInput{
+		Action: "ask",
+		Result: AgentResult{Decision: "approved", Summary: "s", ArtifactBody: "# Answer\n\nDetailed body here."},
+	})
+	if _, bad := viaBody["ask-answer-actionable"]; bad {
+		t.Fatalf("an ask answer in artifact_body must pass; failed=%v", keys(viaBody))
+	}
+}
+
+func TestRunResultChecksBlockedBlockersActionable(t *testing.T) {
+	// blocked with an empty/blank needs list fails the decision-scoped check
+	// regardless of action.
+	failed := failedIDs(ResultCheckInput{
+		Action: "review",
+		Result: AgentResult{Decision: "blocked", Summary: "stuck", Needs: []string{"   ", ""}},
+	})
+	if _, ok := failed["blocked-blockers-actionable"]; !ok {
+		t.Fatalf("expected blocked-blockers-actionable to fail on blank needs; failed=%v", keys(failed))
+	}
+
+	ok := failedIDs(ResultCheckInput{
+		Action: "review",
+		Result: AgentResult{Decision: "blocked", Summary: "stuck", Needs: []string{"missing GITHUB_TOKEN"}},
+	})
+	if _, bad := ok["blocked-blockers-actionable"]; bad {
+		t.Fatalf("blocked with an actionable need must pass; failed=%v", keys(ok))
+	}
+}
+
+func TestRunResultChecksCoordinatorFinalize(t *testing.T) {
+	// A finalize continuation (action ask + IsFinalize) is audited by the
+	// coordinator check, NOT the ask-answer check.
+	failed := failedIDs(ResultCheckInput{
+		Action:     "ask",
+		IsFinalize: true,
+		Result:     AgentResult{Decision: "failed", Summary: "x"},
+	})
+	if _, ok := failed["coordinator-outcome-reconciled"]; !ok {
+		t.Fatalf("expected coordinator-outcome-reconciled to fail on a terse finalize; failed=%v", keys(failed))
+	}
+	if _, ok := failed["ask-answer-actionable"]; ok {
+		t.Fatalf("a finalize continuation must not run the plain ask-answer check; failed=%v", keys(failed))
+	}
+
+	ok := failedIDs(ResultCheckInput{
+		Action:     "ask",
+		IsFinalize: true,
+		Result:     AgentResult{Decision: "failed", Summary: "reconciled: child A merged, child B failed and was escalated"},
+	})
+	if _, bad := ok["coordinator-outcome-reconciled"]; bad {
+		t.Fatalf("a substantive reconciliation must pass; failed=%v", keys(ok))
+	}
+}
+
+func TestFailedResultChecksCleanIsEmpty(t *testing.T) {
+	if got := FailedResultChecks(ResultCheckInput{Action: "ask", Result: AgentResult{Decision: "approved", Summary: "a real answer"}}); len(got) != 0 {
+		t.Fatalf("clean result should yield no failures, got %+v", got)
+	}
+}
+
+func TestSummarizeResultChecks(t *testing.T) {
+	if got := SummarizeResultChecks(nil); got != "all result checks passed" {
+		t.Fatalf("empty summary = %q", got)
+	}
+	s := SummarizeResultChecks([]ResultCheck{{ID: "a", Explanation: "because"}, {ID: "b", Explanation: "reasons"}})
+	if want := "2 result check(s) failed: a (because); b (reasons)"; s != want {
+		t.Fatalf("summary = %q, want %q", s, want)
+	}
+}
+
+func keys(m map[string]ResultCheck) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1072,6 +1072,43 @@ such as a busy base-branch merge queue or a GitHub branch update in progress,
 are retried on the next daemon poll tick. The default poll interval is `30s`
 unless the daemon was started with a different `--poll`.
 
+## Result Checks
+
+After a daemon-run job's `gitmoot_result` is parsed, Gitmoot runs a set of
+**deterministic, LLM-free binary checks** over the parsed result (#526) — a
+contract-hygiene audit that catches results that are technically valid but vague
+or missing evidence. Each check is a yes/no question with an explanation, e.g.:
+
+- **implement** — a result whose decision is `implemented` must list its
+  `changes_made` and its `tests_run`.
+- **review** — a `changes_requested` review must carry `findings` (evidence).
+- **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
+  actionable.
+- **blocked** (any action) — a `blocked` result must list actionable `needs`.
+- **coordinator finalize** — a finalize continuation must produce a substantive
+  reconciliation summary.
+
+The mode is set in `config.toml` and is **warn by default**:
+
+```toml
+[workflow]
+result_checks = "warn"   # off | warn | block (default: warn)
+```
+
+- `warn` (default) — failing checks are recorded as a `result_checks_failed`
+  job event (visible in `gitmoot job events <id>` and `gitmoot job show <id>`)
+  and attached to the job detail (`job show --json` `payload.result_checks`, and
+  the web dashboard), but the job still finishes on its own decision.
+- `block` — a failing check additionally fails the job through the same terminal
+  path a malformed result takes (opt-in, for strict workflows).
+- `off` — the audit is disabled entirely, restoring byte-identical pre-feature
+  behavior (no event, no payload field, no stored record).
+
+A result that passes every applicable check records nothing, so the audit is
+quiet on healthy jobs. Failed checks are also stored durably so a later SkillOpt
+pass can consume them as structured feedback; there is no SkillOpt behavior
+change today.
+
 ## SkillOpt Exchange
 
 ```sh

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1020,6 +1020,42 @@ gitmoot interactive answer <id> <value> [--source source]
 gitmoot interactive clear <id> [<id>...] | --resolved | --all
 ```
 
+## Result Checks
+
+After a daemon-run job's `gitmoot_result` is parsed, Gitmoot runs a set of
+**deterministic, LLM-free binary checks** over the parsed result — a
+contract-hygiene audit that catches results that are technically valid but vague
+or missing evidence. Each check is a yes/no question with an explanation:
+
+- **implement** — a result whose decision is `implemented` must list its
+  `changes_made` and its `tests_run`.
+- **review** — a `changes_requested` review must carry `findings` (evidence).
+- **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
+  actionable.
+- **blocked** (any action) — a `blocked` result must list actionable `needs`.
+- **coordinator finalize** — a finalize continuation must produce a substantive
+  reconciliation summary.
+
+The mode is set in `config.toml` and is **warn by default**:
+
+```toml
+[workflow]
+result_checks = "warn"   # off | warn | block (default: warn)
+```
+
+- `warn` (default) — failing checks are recorded as a `result_checks_failed`
+  job event (visible in `gitmoot job events <id>` and `gitmoot job show <id>`)
+  and attached to the job detail (`job show --json` `payload.result_checks` and
+  the web dashboard), but the job still finishes on its own decision.
+- `block` — a failing check additionally fails the job through the same terminal
+  path a malformed result takes (opt-in, for strict workflows).
+- `off` — the audit is disabled entirely, restoring byte-identical pre-feature
+  behavior (no event, no payload field, no stored record).
+
+A result that passes every applicable check records nothing, so the audit is
+quiet on healthy jobs. Failed checks are also stored durably for later SkillOpt
+consumption as structured feedback; there is no SkillOpt behavior change today.
+
 ## SkillOpt Exchange
 
 ```sh

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -8896,6 +8896,43 @@ such as a busy base-branch merge queue or a GitHub branch update in progress,
 are retried on the next daemon poll tick. The default poll interval is `30s`
 unless the daemon was started with a different `--poll`.
 
+## Result Checks
+
+After a daemon-run job's `gitmoot_result` is parsed, Gitmoot runs a set of
+**deterministic, LLM-free binary checks** over the parsed result (#526) — a
+contract-hygiene audit that catches results that are technically valid but vague
+or missing evidence. Each check is a yes/no question with an explanation, e.g.:
+
+- **implement** — a result whose decision is `implemented` must list its
+  `changes_made` and its `tests_run`.
+- **review** — a `changes_requested` review must carry `findings` (evidence).
+- **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
+  actionable.
+- **blocked** (any action) — a `blocked` result must list actionable `needs`.
+- **coordinator finalize** — a finalize continuation must produce a substantive
+  reconciliation summary.
+
+The mode is set in `config.toml` and is **warn by default**:
+
+```toml
+[workflow]
+result_checks = "warn"   # off | warn | block (default: warn)
+```
+
+- `warn` (default) — failing checks are recorded as a `result_checks_failed`
+  job event (visible in `gitmoot job events <id>` and `gitmoot job show <id>`)
+  and attached to the job detail (`job show --json` `payload.result_checks`, and
+  the web dashboard), but the job still finishes on its own decision.
+- `block` — a failing check additionally fails the job through the same terminal
+  path a malformed result takes (opt-in, for strict workflows).
+- `off` — the audit is disabled entirely, restoring byte-identical pre-feature
+  behavior (no event, no payload field, no stored record).
+
+A result that passes every applicable check records nothing, so the audit is
+quiet on healthy jobs. Failed checks are also stored durably so a later SkillOpt
+pass can consume them as structured feedback; there is no SkillOpt behavior
+change today.
+
 ## SkillOpt Exchange
 
 ```sh


### PR DESCRIPTION
## What

Add an optional, deterministic binary-checklist audit of a job's parsed
`gitmoot_result` (#526). After a result is extracted (and any repair completes),
Gitmoot runs a set of LLM-free yes/no checks over the parsed `AgentResult`, each
producing `{id, action, question, pass, explanation}` (BINEVAL-style
verdict-plus-explanation).

Per-action checks, grounded on real `AgentResult` fields:

- **implement** — `decision == "implemented"` must list `changes_made` and `tests_run`.
- **review** — a `changes_requested` review must carry `findings` (evidence).
- **ask** — the answer (`summary`/`artifact_body`) must be non-empty and actionable.
- **blocked** (any action) — must list actionable `needs`.
- **coordinator finalize** — a finalize continuation must produce a substantive reconciliation summary.

## Why

Gitmoot relies on structured result contracts. A valid-but-vague or
evidence-free result weakens downstream continuations and human review. These
binary checks make contract-hygiene failures visible without breaking existing
workflows.

## How

- `internal/workflow/result_checks.go` — pure check engine (`RunResultChecks` /
  `FailedResultChecks`), no LLM, reads only existing `AgentResult` fields.
- `Mailbox.Run` runs the audit after a successful parse:
  - **off** (and the zero value) — byte-identical: no event, no payload field, no stored row.
  - **warn** (default) — records a `result_checks_failed` job event (visible in
    `gitmoot job events`/`job show`), attaches failures to the job-detail payload
    (`payload.result_checks`, read by the dashboard and `job show --json`), and
    stores them; the job still finishes on its own decision.
  - **block** — additionally fails the job via the existing terminal
    contract-violation path (`m.fail`), opt-in for strict workflows.
- **Config** — `[workflow] result_checks = off|warn|block`, DEFAULT `warn`,
  resolved home-aware in the daemon engine. The `Engine`/`Mailbox` zero value is
  `off`, so every non-daemon path (tests, ask/foreground) is byte-identical;
  `off` restores the exact pre-feature behavior.
- **Feed-forward stub** — additive `result_check_failures` table + store methods
  so SkillOpt can later consume failures as structured feedback. **No SkillOpt
  behavior change tonight.**
- Additive throughout: `payload.result_checks` is `omitempty`, the migration is a
  pure `CREATE TABLE`/`INDEX` append, no `ContractVersion` bump.

## How tested

- `go build ./...` — 0
- `go vet ./...` — 0
- `go test -count=1 ./internal/config/ ./internal/db/ ./internal/workflow/` — ok
- `go test -count=1 ./internal/cli/` — ok (250s)
- `go test -race -count=1 -timeout 20m ./internal/workflow/` — ok (600s)
- `cd website && npm ci && npm run build` — SUCCESS
- New tests: per-action checks (malformed/incomplete/clean), config matrix
  off/warn/block + default + invalid, db record/list, and a no-LLM mailbox E2E
  (vague result → warn event visible + job still succeeds; block → job fails like
  a contract violation; off → byte-identical).

## Docs

- `skills/gitmoot/references/CLI.md` + `website/docs/reference/cli.md` — new
  Result Checks section (`llms-full.txt` regenerated by the build).

Closes #526