### PR TITLE
feat(router): execution-grounded routing telemetry + advisory summary

### DIFF
--- a/cli_test.log
+++ b/cli_test.log
@@ -1,0 +1,4 @@
+ok  	github.com/jerryfane/gitmoot/internal/cli	226.757s
+ok  	github.com/jerryfane/gitmoot/internal/cli/style	0.003s
+ok  	github.com/jerryfane/gitmoot/internal/cli/tui	0.486s
+CLI_EXIT=0

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -6626,6 +6626,13 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// returns before its query, byte-identical) AND no comparator runs, so a
 		// stranded canary row can never keep serving traffic with no auto-rollback.
 		CanaryEnabled: canaryRoutingEnabled(home),
+		// Off-by-default #530 coordinator routing-context injection: when [router]
+		// context_enabled is set, the engine's Mailbox appends a bounded advisory
+		// observed-performance table to a top-level coordinator job's prompt.
+		// routerContextEnabled returns false with no config (or any load error), so
+		// with no config NO telemetry query runs during a job and prompt assembly is
+		// byte-identical. Capture (routing_telemetry rows) is always on and additive.
+		RouterContextEnabled: routerContextEnabled(home),
 	}
 	if strings.TrimSpace(home) != "" {
 		// Root delegation artifacts under GITMOOT_HOME (alongside worktrees)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,6 +45,7 @@ var rootCommands = []command{
 	{name: "skillopt", summary: "export and import SkillOpt packages", run: runSkillOpt},
 	{name: "memory", summary: "inspect and measure agent persistent memory", run: runMemory},
 	{name: "pipeline", summary: "define, run, and manage declarative pipelines", run: runPipeline},
+	{name: "router", summary: "inspect execution-grounded routing telemetry (advisory)", run: runRouter},
 }
 
 func Run(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/router.go
+++ b/internal/cli/router.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"text/tabwriter"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// routerContextEnabled reports whether the off-by-default #530 coordinator
+// routing-context injection is on for this home. It fails safe to disabled: any
+// path/config-load error returns false, so a broken or absent config never turns
+// the feature on. Mirrors canaryRoutingEnabled's off-by-default gate.
+func routerContextEnabled(home string) bool {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return false
+	}
+	settings, err := config.LoadRouterSettings(paths)
+	if err != nil {
+		return false
+	}
+	return settings.ContextEnabled
+}
+
+func runRouter(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printRouterUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "summary":
+		return runRouterSummary(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown router command %q\n\n", args[0])
+		printRouterUsage(stderr)
+		return 2
+	}
+}
+
+func printRouterUsage(w io.Writer) {
+	fmt.Fprintln(w, "Inspect execution-grounded routing telemetry (local observed performance, advisory only).")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot router summary [--repo owner/repo] [--action ask|review|implement] [--since 30d] [--json]")
+}
+
+type routerSummaryJSON struct {
+	Note   string                   `json:"note"`
+	Total  int                      `json:"total_observations"`
+	Groups []db.RoutingSummaryGroup `json:"groups"`
+}
+
+// routerSummaryNote is the mandatory disclaimer: this is local observed
+// performance, never a global benchmark, and v1 routing is advisory only.
+const routerSummaryNote = "local observed performance, not a benchmark (advisory only; routing is not auto-overridden)"
+
+func runRouterSummary(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("router summary", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	repo := fs.String("repo", "", "filter by repo (owner/repo)")
+	action := fs.String("action", "", "filter by action (ask/review/implement/continuation/…)")
+	since := fs.String("since", "", "only include observations newer than this (Go duration or <N>d, e.g. 30d)")
+	jsonOut := fs.Bool("json", false, "print as JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+
+	filter := db.RoutingTelemetryFilter{Repo: *repo, Action: *action}
+	if trimmed := *since; trimmed != "" {
+		d, err := parseOlderThanDuration(trimmed)
+		if err != nil {
+			fmt.Fprintf(stderr, "router summary: parse --since: %v\n", err)
+			return 2
+		}
+		if d > 0 {
+			filter.Since = time.Now().Add(-d)
+		}
+	}
+
+	var rows []db.RoutingTelemetry
+	err := withReadOnlyStore(*home, func(store *db.Store) error {
+		var err error
+		rows, err = store.ListRoutingTelemetry(context.Background(), filter)
+		return err
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "router summary: %v\n", err)
+		return 1
+	}
+
+	groups := db.AggregateRoutingTelemetry(rows)
+
+	if *jsonOut {
+		if err := writeJSON(stdout, routerSummaryJSON{Note: routerSummaryNote, Total: len(rows), Groups: groups}); err != nil {
+			fmt.Fprintf(stderr, "router summary: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	fmt.Fprintf(stdout, "Routing summary — %s\n", routerSummaryNote)
+	fmt.Fprintf(stdout, "%d observation(s)\n\n", len(rows))
+	if len(groups) == 0 {
+		fmt.Fprintln(stdout, "no routing telemetry recorded yet")
+		return 0
+	}
+	tw := tabwriter.NewWriter(stdout, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "ACTION\tRUNTIME\tMODEL\tTEMPLATE\tN\tSUCCESS\tAPPROVAL\tMEDIAN(ms)\tTOKENS(in/out)")
+	for _, g := range groups {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%.0f%%\t%.0f%%\t%d\t%d/%d\n",
+			dashIfEmpty(g.Action), dashIfEmpty(g.Runtime), dashIfEmpty(g.Model), dashIfEmpty(g.TemplateID),
+			g.Count, g.SuccessRate*100, g.ApprovalRate*100, g.MedianDurationMS, g.InputTokens, g.OutputTokens)
+	}
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintf(stderr, "router summary: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/cli/router.go
+++ b/internal/cli/router.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -13,12 +14,31 @@ import (
 	"github.com/jerryfane/gitmoot/internal/db"
 )
 
+// routerPathsForHome resolves the config paths for a home the SAME dual-mode way
+// the other home-scoped daemon seams do (via resolveConfigFile), so it works both
+// when handed the RAW --home and when handed the already-RESOLVED <home>/.gitmoot
+// root. The daemon wiring path (daemonWorkflowEngine at daemon.go passes
+// w.workflowHome(), which is config.Paths.Home — i.e. <home>/.gitmoot — so a naive
+// pathsFromFlag/config.PathsForHome here re-appended ".gitmoot" a SECOND time and
+// read a phantom <home>/.gitmoot/.gitmoot/config.toml with no [router] section,
+// so a user who set [router] context_enabled = true would get the feature
+// silently disabled forever on the daemon path (the same #446/#459 double
+// resolution memoryPathsForHome was created to fix for [memory]). Only
+// LoadRouterSettings reads the returned Paths, and it uses only ConfigFile, so
+// resolving that one field is sufficient.
+func routerPathsForHome(home string) (config.Paths, error) {
+	if strings.TrimSpace(home) == "" {
+		return config.DefaultPaths()
+	}
+	return config.Paths{ConfigFile: resolveConfigFile(home)}, nil
+}
+
 // routerContextEnabled reports whether the off-by-default #530 coordinator
 // routing-context injection is on for this home. It fails safe to disabled: any
 // path/config-load error returns false, so a broken or absent config never turns
 // the feature on. Mirrors canaryRoutingEnabled's off-by-default gate.
 func routerContextEnabled(home string) bool {
-	paths, err := pathsFromFlag(home)
+	paths, err := routerPathsForHome(home)
 	if err != nil {
 		return false
 	}

--- a/internal/cli/router_test.go
+++ b/internal/cli/router_test.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func routerTestHome(t *testing.T) (string, *db.Store) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return home, store
+}
+
+func seedRouterRows(t *testing.T, store *db.Store) {
+	t.Helper()
+	ctx := context.Background()
+	rows := []db.RoutingTelemetry{
+		{JobID: "j1", Repo: "acme/widget", Action: "implement", Runtime: "codex", Model: "gpt-5.5", TemplateID: "impl", JobState: "succeeded", Decision: "implemented", Approved: true, DurationMS: 100, InputTokens: 10, OutputTokens: 2},
+		{JobID: "j2", Repo: "acme/widget", Action: "implement", Runtime: "codex", Model: "gpt-5.5", TemplateID: "impl", JobState: "failed", Decision: "failed", DurationMS: 300},
+		{JobID: "j3", Repo: "acme/widget", Action: "review", Runtime: "claude", Model: "opus", TemplateID: "rev", JobState: "succeeded", Decision: "approved", Approved: true, DurationMS: 200},
+		{JobID: "j4", Repo: "other/repo", Action: "review", Runtime: "kimi", JobState: "blocked", Decision: "blocked", DurationMS: 50},
+	}
+	for _, r := range rows {
+		if err := store.InsertRoutingTelemetry(ctx, r); err != nil {
+			t.Fatalf("seed %s: %v", r.JobID, err)
+		}
+	}
+}
+
+// TestRouterSummaryJSON proves the read-only summary aggregates seeded rows into
+// per-(action,runtime,model,template) groups with the right counts/rates and the
+// mandatory advisory disclaimer.
+func TestRouterSummaryJSON(t *testing.T) {
+	home, store := routerTestHome(t)
+	seedRouterRows(t, store)
+
+	var stdout, stderr bytes.Buffer
+	if code := runRouter([]string{"summary", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("router summary exit %d: %s", code, stderr.String())
+	}
+	var out routerSummaryJSON
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("parse json: %v (%s)", err, stdout.String())
+	}
+	if !strings.Contains(out.Note, "not a benchmark") {
+		t.Fatalf("note missing disclaimer: %q", out.Note)
+	}
+	if out.Total != 4 {
+		t.Fatalf("total = %d, want 4", out.Total)
+	}
+	if len(out.Groups) != 3 {
+		t.Fatalf("groups = %d, want 3: %+v", len(out.Groups), out.Groups)
+	}
+	// Leading group is codex/implement (2 observations): 1 success of 2.
+	g := out.Groups[0]
+	if g.Action != "implement" || g.Runtime != "codex" || g.Count != 2 || g.SuccessCount != 1 || g.FailedCount != 1 {
+		t.Fatalf("leading group mismatch: %+v", g)
+	}
+	if g.SuccessRate != 0.5 {
+		t.Fatalf("success rate = %v, want 0.5", g.SuccessRate)
+	}
+	if g.MedianDurationMS != 200 {
+		t.Fatalf("median = %d, want 200 (avg of 100,300)", g.MedianDurationMS)
+	}
+}
+
+// TestRouterSummaryRepoFilter proves the --repo filter narrows to one repo.
+func TestRouterSummaryRepoFilter(t *testing.T) {
+	home, store := routerTestHome(t)
+	seedRouterRows(t, store)
+
+	var stdout, stderr bytes.Buffer
+	if code := runRouter([]string{"summary", "--home", home, "--repo", "other/repo", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("router summary exit %d: %s", code, stderr.String())
+	}
+	var out routerSummaryJSON
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if out.Total != 1 || len(out.Groups) != 1 || out.Groups[0].Runtime != "kimi" {
+		t.Fatalf("repo filter mismatch: %+v", out)
+	}
+}
+
+// TestRouterSummaryActionFilterText proves the --action filter and that the text
+// output carries the advisory disclaimer.
+func TestRouterSummaryActionFilterText(t *testing.T) {
+	home, store := routerTestHome(t)
+	seedRouterRows(t, store)
+
+	var stdout, stderr bytes.Buffer
+	if code := runRouter([]string{"summary", "--home", home, "--action", "review"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("router summary exit %d: %s", code, stderr.String())
+	}
+	text := stdout.String()
+	if !strings.Contains(text, "not a benchmark") {
+		t.Fatalf("text output missing disclaimer:\n%s", text)
+	}
+	if !strings.Contains(text, "claude") || !strings.Contains(text, "kimi") {
+		t.Fatalf("expected both review runtimes in text:\n%s", text)
+	}
+	if strings.Contains(text, "codex") {
+		t.Fatalf("action=review output should not include implement/codex rows:\n%s", text)
+	}
+}
+
+// TestRouterSummaryEmpty proves a fresh home reports zero observations cleanly.
+func TestRouterSummaryEmpty(t *testing.T) {
+	home, _ := routerTestHome(t)
+	var stdout, stderr bytes.Buffer
+	if code := runRouter([]string{"summary", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("router summary exit %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no routing telemetry recorded yet") {
+		t.Fatalf("expected empty message, got:\n%s", stdout.String())
+	}
+}
+
+// TestRouterContextEnabledResolves proves the [router] context_enabled config knob
+// resolves through routerContextEnabled (off by default, on when set).
+func TestRouterContextEnabledResolves(t *testing.T) {
+	home, _ := routerTestHome(t)
+	if routerContextEnabled(home) {
+		t.Fatalf("expected context injection off by default")
+	}
+	paths := config.PathsForHome(home)
+	existing, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, append(existing, []byte("\n[router]\ncontext_enabled = true\n")...), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if !routerContextEnabled(home) {
+		t.Fatalf("expected context injection on after config set")
+	}
+	settings, err := config.LoadRouterSettings(paths)
+	if err != nil {
+		t.Fatalf("LoadRouterSettings: %v", err)
+	}
+	if !settings.ContextEnabled {
+		t.Fatalf("LoadRouterSettings did not read context_enabled")
+	}
+}

--- a/internal/cli/router_test.go
+++ b/internal/cli/router_test.go
@@ -158,3 +158,30 @@ func TestRouterContextEnabledResolves(t *testing.T) {
 		t.Fatalf("LoadRouterSettings did not read context_enabled")
 	}
 }
+
+// TestRouterContextEnabledResolvesFromDaemonHome pins the daemon wiring path: the
+// daemon calls routerContextEnabled(w.workflowHome()), and workflowHome() returns
+// the ALREADY-RESOLVED <home>/.gitmoot root (config.Paths.Home), NOT the raw
+// --home. A naive pathsFromFlag/PathsForHome resolver would re-append ".gitmoot"
+// a second time, read a phantom <home>/.gitmoot/.gitmoot/config.toml, and return
+// false forever even when [router] context_enabled = true is set — silently
+// disabling the feature on every live daemon. This asserts the resolved-root input
+// (what the daemon actually passes) reads true.
+func TestRouterContextEnabledResolvesFromDaemonHome(t *testing.T) {
+	home, _ := routerTestHome(t)
+	paths := config.PathsForHome(home)
+	// paths.Home is the resolved <home>/.gitmoot root the daemon passes.
+	if routerContextEnabled(paths.Home) {
+		t.Fatalf("expected context injection off by default via resolved home")
+	}
+	existing, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, append(existing, []byte("\n[router]\ncontext_enabled = true\n")...), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if !routerContextEnabled(paths.Home) {
+		t.Fatalf("expected context injection ON via resolved <home>/.gitmoot root (daemon wiring path)")
+	}
+}

--- a/internal/config/router.go
+++ b/internal/config/router.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// RouterSettings is the resolved, off-by-default knob set for execution-grounded
+// routing (#530), parsed from the optional [router] section. v1 is ADVISORY: the
+// only behavioral knob is context_enabled, which decides whether a bounded
+// observed-performance table is injected into a coordinator's prompt. Capture (the
+// routing_telemetry rows) is always on and additive — it does not change any wire
+// output — so it needs no knob. A config with no [router] section resolves to the
+// defaults (context injection off), so behavior is byte-identical.
+type RouterSettings struct {
+	// ContextEnabled turns on the coordinator observed-performance context block.
+	// Default false: with it off, coordinator prompt assembly is byte-identical and
+	// no telemetry query runs during a job.
+	ContextEnabled bool
+}
+
+// DefaultRouterSettings returns the off-by-default resolved settings.
+func DefaultRouterSettings() RouterSettings {
+	return RouterSettings{ContextEnabled: false}
+}
+
+// LoadRouterSettings resolves the [router] section knobs. An absent section (or an
+// absent key) yields the documented default. A malformed value is rejected so
+// `gitmoot config set` surfaces the error.
+func LoadRouterSettings(paths Paths) (RouterSettings, error) {
+	settings := DefaultRouterSettings()
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return settings, nil
+		}
+		return RouterSettings{}, err
+	}
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			continue
+		}
+		if current != "router" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "context_enabled":
+			parsed, err := parseConfigBool(value)
+			if err != nil {
+				return RouterSettings{}, fmt.Errorf("parse [router].context_enabled: %w", err)
+			}
+			settings.ContextEnabled = parsed
+		}
+	}
+	return settings, nil
+}

--- a/internal/config/router_test.go
+++ b/internal/config/router_test.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadRouterSettingsDefaultsWhenAbsent(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	settings, err := LoadRouterSettings(paths)
+	if err != nil {
+		t.Fatalf("LoadRouterSettings: %v", err)
+	}
+	if settings.ContextEnabled {
+		t.Fatalf("expected context_enabled off by default")
+	}
+}
+
+func TestLoadRouterSettingsReadsContextEnabled(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	existing, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, append(existing, []byte("\n[router]\ncontext_enabled = true\n")...), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	settings, err := LoadRouterSettings(paths)
+	if err != nil {
+		t.Fatalf("LoadRouterSettings: %v", err)
+	}
+	if !settings.ContextEnabled {
+		t.Fatalf("expected context_enabled true")
+	}
+}
+
+func TestLoadRouterSettingsRejectsMalformed(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[router]\ncontext_enabled = notabool\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := LoadRouterSettings(paths); err == nil {
+		t.Fatalf("expected error on malformed context_enabled")
+	}
+}

--- a/internal/db/routing_telemetry.go
+++ b/internal/db/routing_telemetry.go
@@ -1,0 +1,240 @@
+package db
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RoutingTelemetry is one execution-grounded routing observation (#530): a single
+// row recorded best-effort at a job's terminal transition so Gitmoot can later
+// compare how a (action, runtime, model, template) combination actually performed
+// on real jobs. It is ADVISORY only — nothing in v1 reads it back to change
+// routing behavior; the CLI summary and the optional coordinator context block are
+// the only consumers. Every field is best-effort: a runtime that does not report
+// tokens contributes 0, a job with no phase leaves Phase empty, and so on.
+type RoutingTelemetry struct {
+	ID    int64
+	JobID string
+	Repo  string
+	// Action is the job type (ask/review/implement/continuation/…).
+	Action string
+	Phase  string
+	// Runtime and Model are the effective runtime + model the job actually ran on.
+	Runtime string
+	Model   string
+	Agent   string
+	// TemplateID and TemplateCommit identify the resolved agent template snapshot.
+	TemplateID     string
+	TemplateCommit string
+	// JobState is the terminal job state: succeeded | failed | blocked.
+	JobState string
+	// Decision is the agent result decision (approved/implemented/changes_requested/
+	// blocked/failed) when the job carried a parseable result; empty otherwise.
+	Decision string
+	// Approved mirrors the engine's approving-outcome test (approved|implemented|
+	// succeeded) so the summary can report an approval rate without re-deriving it.
+	Approved bool
+	// TestsRun is len(result.tests_run) — a coarse "did the agent exercise tests"
+	// signal. It is NOT a pass/fail count (the agent reports the tests it ran, not
+	// their verdicts); the job state/decision carry the real outcome.
+	TestsRun     int
+	DurationMS   int64
+	InputTokens  int
+	OutputTokens int
+	CreatedAt    string
+}
+
+// RoutingTelemetryFilter narrows a ListRoutingTelemetry read. A zero value returns
+// every row. Since, when non-zero, is a lower bound on created_at (inclusive).
+type RoutingTelemetryFilter struct {
+	Repo   string
+	Action string
+	Since  time.Time
+}
+
+// InsertRoutingTelemetry appends one advisory routing observation. It is called
+// best-effort at the job terminal chokepoint; the caller swallows any error so a
+// telemetry write can never fail a job.
+func (s *Store) InsertRoutingTelemetry(ctx context.Context, t RoutingTelemetry) error {
+	approved := 0
+	if t.Approved {
+		approved = 1
+	}
+	_, err := s.db.ExecContext(ctx, `
+INSERT INTO routing_telemetry(
+	job_id, repo, action, phase, runtime, model, agent,
+	template_id, template_commit, job_state, decision, approved,
+	tests_run, duration_ms, input_tokens, output_tokens
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.JobID, t.Repo, t.Action, t.Phase, t.Runtime, t.Model, t.Agent,
+		t.TemplateID, t.TemplateCommit, t.JobState, t.Decision, approved,
+		t.TestsRun, t.DurationMS, t.InputTokens, t.OutputTokens)
+	return err
+}
+
+// ListRoutingTelemetry returns the recorded observations matching filter, newest
+// first. A missing routing_telemetry table (a store that predates the #530
+// migration, e.g. a read-only open) is treated as "no observations" so a summary
+// on an un-migrated DB reports empty rather than erroring.
+func (s *Store) ListRoutingTelemetry(ctx context.Context, filter RoutingTelemetryFilter) ([]RoutingTelemetry, error) {
+	query := `
+SELECT id, job_id, repo, action, phase, runtime, model, agent,
+	template_id, template_commit, job_state, decision, approved,
+	tests_run, duration_ms, input_tokens, output_tokens, created_at
+FROM routing_telemetry`
+	var conds []string
+	var args []any
+	if repo := strings.TrimSpace(filter.Repo); repo != "" {
+		conds = append(conds, "repo = ?")
+		args = append(args, repo)
+	}
+	if action := strings.TrimSpace(filter.Action); action != "" {
+		conds = append(conds, "action = ?")
+		args = append(args, action)
+	}
+	if !filter.Since.IsZero() {
+		conds = append(conds, "created_at >= ?")
+		args = append(args, filter.Since.UTC().Format("2006-01-02 15:04:05"))
+	}
+	if len(conds) > 0 {
+		query += "\nWHERE " + strings.Join(conds, " AND ")
+	}
+	query += "\nORDER BY id DESC"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		if isMissingRelationErr(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []RoutingTelemetry
+	for rows.Next() {
+		var t RoutingTelemetry
+		var approved int
+		if err := rows.Scan(&t.ID, &t.JobID, &t.Repo, &t.Action, &t.Phase, &t.Runtime, &t.Model, &t.Agent,
+			&t.TemplateID, &t.TemplateCommit, &t.JobState, &t.Decision, &approved,
+			&t.TestsRun, &t.DurationMS, &t.InputTokens, &t.OutputTokens, &t.CreatedAt); err != nil {
+			return nil, err
+		}
+		t.Approved = approved != 0
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// isMissingRelationErr reports whether err is a SQLite "no such table"/"no such
+// column" error, which for a read-only telemetry read means the #530 migration has
+// not run on this DB yet (treat as empty, not fatal).
+func isMissingRelationErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no such table") || strings.Contains(msg, "no such column")
+}
+
+// RoutingSummaryGroup is one aggregated (action, runtime, model, template) bucket
+// of observed performance. It is a pure projection of a set of RoutingTelemetry
+// rows — local observed performance, NOT a benchmark.
+type RoutingSummaryGroup struct {
+	Action           string  `json:"action"`
+	Runtime          string  `json:"runtime"`
+	Model            string  `json:"model"`
+	TemplateID       string  `json:"template_id"`
+	Count            int     `json:"count"`
+	SuccessCount     int     `json:"success_count"`
+	ApprovedCount    int     `json:"approved_count"`
+	BlockedCount     int     `json:"blocked_count"`
+	FailedCount      int     `json:"failed_count"`
+	SuccessRate      float64 `json:"success_rate"`
+	ApprovalRate     float64 `json:"approval_rate"`
+	MedianDurationMS int64   `json:"median_duration_ms"`
+	InputTokens      int     `json:"input_tokens"`
+	OutputTokens     int     `json:"output_tokens"`
+}
+
+// AggregateRoutingTelemetry groups rows by (action, runtime, model, template_id)
+// and computes count, success/approval rates, blocked/failed counts, median
+// duration, and summed tokens per group. It is a pure function (no I/O) so both
+// the CLI summary and the coordinator context block share one definition. Groups
+// are returned deterministically: most observations first, ties broken by the key
+// fields, so seeded-row tests and prompt-injection tests are stable.
+func AggregateRoutingTelemetry(rows []RoutingTelemetry) []RoutingSummaryGroup {
+	type acc struct {
+		group     RoutingSummaryGroup
+		durations []int64
+	}
+	buckets := map[string]*acc{}
+	var order []string
+	for _, r := range rows {
+		key := r.Action + "\x00" + r.Runtime + "\x00" + r.Model + "\x00" + r.TemplateID
+		a := buckets[key]
+		if a == nil {
+			a = &acc{group: RoutingSummaryGroup{
+				Action: r.Action, Runtime: r.Runtime, Model: r.Model, TemplateID: r.TemplateID,
+			}}
+			buckets[key] = a
+			order = append(order, key)
+		}
+		a.group.Count++
+		switch strings.ToLower(strings.TrimSpace(r.JobState)) {
+		case "succeeded":
+			a.group.SuccessCount++
+		case "blocked":
+			a.group.BlockedCount++
+		case "failed":
+			a.group.FailedCount++
+		}
+		if r.Approved {
+			a.group.ApprovedCount++
+		}
+		a.group.InputTokens += r.InputTokens
+		a.group.OutputTokens += r.OutputTokens
+		a.durations = append(a.durations, r.DurationMS)
+	}
+
+	groups := make([]RoutingSummaryGroup, 0, len(order))
+	for _, key := range order {
+		a := buckets[key]
+		if a.group.Count > 0 {
+			a.group.SuccessRate = float64(a.group.SuccessCount) / float64(a.group.Count)
+			a.group.ApprovalRate = float64(a.group.ApprovedCount) / float64(a.group.Count)
+		}
+		a.group.MedianDurationMS = medianInt64(a.durations)
+		groups = append(groups, a.group)
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].Count != groups[j].Count {
+			return groups[i].Count > groups[j].Count
+		}
+		if groups[i].Action != groups[j].Action {
+			return groups[i].Action < groups[j].Action
+		}
+		if groups[i].Runtime != groups[j].Runtime {
+			return groups[i].Runtime < groups[j].Runtime
+		}
+		if groups[i].Model != groups[j].Model {
+			return groups[i].Model < groups[j].Model
+		}
+		return groups[i].TemplateID < groups[j].TemplateID
+	})
+	return groups
+}
+
+func medianInt64(values []int64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	n := len(sorted)
+	if n%2 == 1 {
+		return sorted[n/2]
+	}
+	return (sorted[n/2-1] + sorted[n/2]) / 2
+}

--- a/internal/db/routing_telemetry_test.go
+++ b/internal/db/routing_telemetry_test.go
@@ -1,0 +1,151 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestInsertAndListRoutingTelemetry pins the #530 capture round-trip: inserted
+// rows read back with every field intact, newest first, and the repo/action/since
+// filters narrow correctly.
+func TestInsertAndListRoutingTelemetry(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+
+	rows := []RoutingTelemetry{
+		{JobID: "j1", Repo: "o/r", Action: "implement", Phase: "build", Runtime: "codex", Model: "gpt-5.5", Agent: "impl", TemplateID: "t1", TemplateCommit: "abc", JobState: "succeeded", Decision: "implemented", Approved: true, TestsRun: 2, DurationMS: 1000, InputTokens: 100, OutputTokens: 20},
+		{JobID: "j2", Repo: "o/r", Action: "review", Runtime: "claude", Model: "opus", Agent: "rev", JobState: "succeeded", Decision: "approved", Approved: true, DurationMS: 500},
+		{JobID: "j3", Repo: "other/r", Action: "implement", Runtime: "codex", JobState: "failed", Decision: "failed", DurationMS: 2000},
+	}
+	for _, r := range rows {
+		if err := store.InsertRoutingTelemetry(ctx, r); err != nil {
+			t.Fatalf("InsertRoutingTelemetry(%s) error: %v", r.JobID, err)
+		}
+	}
+
+	all, err := store.ListRoutingTelemetry(ctx, RoutingTelemetryFilter{})
+	if err != nil {
+		t.Fatalf("ListRoutingTelemetry error: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("got %d rows, want 3", len(all))
+	}
+	// Newest first (id DESC).
+	if all[0].JobID != "j3" || all[2].JobID != "j1" {
+		t.Fatalf("unexpected order: %s..%s", all[0].JobID, all[2].JobID)
+	}
+	// Field integrity on the richest row.
+	got := all[2]
+	if got.Repo != "o/r" || got.Action != "implement" || got.Phase != "build" || got.Runtime != "codex" ||
+		got.Model != "gpt-5.5" || got.Agent != "impl" || got.TemplateID != "t1" || got.TemplateCommit != "abc" ||
+		got.JobState != "succeeded" || got.Decision != "implemented" || !got.Approved || got.TestsRun != 2 ||
+		got.DurationMS != 1000 || got.InputTokens != 100 || got.OutputTokens != 20 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	if got.CreatedAt == "" {
+		t.Fatalf("expected a created_at default, got empty")
+	}
+
+	// repo filter.
+	byRepo, err := store.ListRoutingTelemetry(ctx, RoutingTelemetryFilter{Repo: "o/r"})
+	if err != nil {
+		t.Fatalf("ListRoutingTelemetry repo error: %v", err)
+	}
+	if len(byRepo) != 2 {
+		t.Fatalf("repo filter got %d, want 2", len(byRepo))
+	}
+
+	// action filter.
+	byAction, err := store.ListRoutingTelemetry(ctx, RoutingTelemetryFilter{Action: "implement"})
+	if err != nil {
+		t.Fatalf("ListRoutingTelemetry action error: %v", err)
+	}
+	if len(byAction) != 2 {
+		t.Fatalf("action filter got %d, want 2", len(byAction))
+	}
+
+	// since filter in the future excludes everything.
+	future, err := store.ListRoutingTelemetry(ctx, RoutingTelemetryFilter{Since: time.Now().Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("ListRoutingTelemetry since error: %v", err)
+	}
+	if len(future) != 0 {
+		t.Fatalf("future since got %d, want 0", len(future))
+	}
+}
+
+// TestAggregateRoutingTelemetry pins the pure aggregation: grouping by
+// (action, runtime, model, template), success/approval rates, blocked/failed
+// counts, median duration, summed tokens, and deterministic ordering.
+func TestAggregateRoutingTelemetry(t *testing.T) {
+	rows := []RoutingTelemetry{
+		// Group A: codex/gpt-5.5/implement/t1 — 3 rows: 2 succeeded (1 approved via
+		// implemented), 1 failed.
+		{Action: "implement", Runtime: "codex", Model: "gpt-5.5", TemplateID: "t1", JobState: "succeeded", Approved: true, DurationMS: 100, InputTokens: 10, OutputTokens: 1},
+		{Action: "implement", Runtime: "codex", Model: "gpt-5.5", TemplateID: "t1", JobState: "succeeded", Approved: true, DurationMS: 300, InputTokens: 10, OutputTokens: 1},
+		{Action: "implement", Runtime: "codex", Model: "gpt-5.5", TemplateID: "t1", JobState: "failed", Approved: false, DurationMS: 200, InputTokens: 10, OutputTokens: 1},
+		// Group B: claude/opus/review/t2 — 1 row, blocked.
+		{Action: "review", Runtime: "claude", Model: "opus", TemplateID: "t2", JobState: "blocked", Approved: false, DurationMS: 999},
+	}
+	groups := AggregateRoutingTelemetry(rows)
+	if len(groups) != 2 {
+		t.Fatalf("got %d groups, want 2", len(groups))
+	}
+	// Most observations first => group A leads.
+	a := groups[0]
+	if a.Action != "implement" || a.Runtime != "codex" || a.Model != "gpt-5.5" || a.TemplateID != "t1" {
+		t.Fatalf("group A key mismatch: %+v", a)
+	}
+	if a.Count != 3 || a.SuccessCount != 2 || a.FailedCount != 1 || a.ApprovedCount != 2 {
+		t.Fatalf("group A counts mismatch: %+v", a)
+	}
+	if a.SuccessRate < 0.66 || a.SuccessRate > 0.67 {
+		t.Fatalf("group A success rate = %v, want ~0.667", a.SuccessRate)
+	}
+	if a.MedianDurationMS != 200 {
+		t.Fatalf("group A median = %d, want 200", a.MedianDurationMS)
+	}
+	if a.InputTokens != 30 || a.OutputTokens != 3 {
+		t.Fatalf("group A tokens = %d/%d, want 30/3", a.InputTokens, a.OutputTokens)
+	}
+	b := groups[1]
+	if b.Count != 1 || b.BlockedCount != 1 || b.SuccessCount != 0 {
+		t.Fatalf("group B counts mismatch: %+v", b)
+	}
+	if b.MedianDurationMS != 999 {
+		t.Fatalf("group B median = %d, want 999", b.MedianDurationMS)
+	}
+
+	// Empty input is safe.
+	if got := AggregateRoutingTelemetry(nil); len(got) != 0 {
+		t.Fatalf("nil input got %d groups, want 0", len(got))
+	}
+}
+
+// TestListRoutingTelemetryMissingTable proves a store that predates the #530
+// migration reports "no observations" rather than erroring, so a read-only
+// summary on an un-migrated DB degrades gracefully.
+func TestListRoutingTelemetryMissingTable(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open error: %v", err)
+	}
+	defer store.Close()
+	if _, err := store.db.ExecContext(ctx, `DROP TABLE routing_telemetry`); err != nil {
+		t.Fatalf("drop table error: %v", err)
+	}
+	rows, err := store.ListRoutingTelemetry(ctx, RoutingTelemetryFilter{})
+	if err != nil {
+		t.Fatalf("expected nil error on missing table, got %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected 0 rows, got %d", len(rows))
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -7829,4 +7829,39 @@ CREATE TABLE pipeline_run_stages (
 
 CREATE INDEX idx_pipeline_run_stages_run_id ON pipeline_run_stages(run_id);
 	`,
+	// #530 execution-grounded routing telemetry: one row per job terminal
+	// transition capturing which (action, runtime, model, template) combination ran
+	// and how it turned out (state/decision/approval + coarse tests-run + duration +
+	// tokens). Pure additive append (CREATE TABLE/INDEX only): the table stays empty
+	// until a job finishes AFTER this migration, so every existing DB reads
+	// identically, and the row write is best-effort/fail-safe (a telemetry error
+	// never fails a job). Consumed read-only by `gitmoot router summary` and the
+	// optional (off-by-default) coordinator context block; NOTHING reads it back to
+	// change routing behavior in v1 — it is advisory only. The two indexes back the
+	// summary's repo/action filters and the --since lower bound.
+	`
+CREATE TABLE routing_telemetry (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	job_id TEXT NOT NULL DEFAULT '',
+	repo TEXT NOT NULL DEFAULT '',
+	action TEXT NOT NULL DEFAULT '',
+	phase TEXT NOT NULL DEFAULT '',
+	runtime TEXT NOT NULL DEFAULT '',
+	model TEXT NOT NULL DEFAULT '',
+	agent TEXT NOT NULL DEFAULT '',
+	template_id TEXT NOT NULL DEFAULT '',
+	template_commit TEXT NOT NULL DEFAULT '',
+	job_state TEXT NOT NULL DEFAULT '',
+	decision TEXT NOT NULL DEFAULT '',
+	approved INTEGER NOT NULL DEFAULT 0,
+	tests_run INTEGER NOT NULL DEFAULT 0,
+	duration_ms INTEGER NOT NULL DEFAULT 0,
+	input_tokens INTEGER NOT NULL DEFAULT 0,
+	output_tokens INTEGER NOT NULL DEFAULT 0,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_routing_telemetry_repo_action ON routing_telemetry(repo, action);
+CREATE INDEX idx_routing_telemetry_created ON routing_telemetry(created_at);
+	`,
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -194,6 +194,13 @@ type Engine struct {
 	// maxInlineArtifactTotalBytes aggregate budget (no new knob). With the flag
 	// off the enqueued prompt is byte-identical to before this field existed.
 	InjectUpstreamDepContext bool
+	// RouterContextEnabled, when true, appends the bounded (<=12 line) advisory
+	// observed-performance table (#530) to a TOP-LEVEL coordinator job's prompt so
+	// the coordinator can weigh which runtime/model/template has done well on this
+	// repo. It is opt-in via [router] context_enabled (default false); with the flag
+	// off no telemetry query runs and prompt assembly is byte-identical. Routing
+	// stays advisory in v1 — the block never forces a route.
+	RouterContextEnabled bool
 	// MaxDelegationTokenBudget is the cumulative per-root token budget (input +
 	// output, summed across a coordination tree) that bounds a delegation tree by
 	// cost in addition to depth/width/total-jobs/wall-clock (#338 Part B). When a
@@ -424,7 +431,7 @@ func (e Engine) now() time.Time {
 // path is byte-identical. The hook maps the terminal JobState to the event_type,
 // resolves root_id from the payload, and ships a redacted event fire-and-forget.
 func (e Engine) mailbox() Mailbox {
-	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer, RuntimeDefaultModel: e.RuntimeDefaultModel}
+	mb := Mailbox{Store: e.Store, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer, RuntimeDefaultModel: e.RuntimeDefaultModel, routerContextEnabled: e.RouterContextEnabled}
 	// Wire the off-by-default memory hooks (#626). When e.Memory is nil (every
 	// non-enrolled path) both hooks stay nil, so Run's prompt assembly and terminal
 	// path are byte-identical. The hooks themselves also no-op when the executor

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/agenttemplate"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -93,6 +94,12 @@ type Mailbox struct {
 	// default, and any error/empty result) forces nothing, so delivery is
 	// byte-identical to before #652.
 	RuntimeDefaultModel func(runtimeName string) string
+	// routerContextEnabled gates the off-by-default #530 coordinator context block.
+	// When true, Run appends a bounded (<=12 line) observed-performance table to a
+	// TOP-LEVEL (coordinator) job's prompt. When false (the default, every
+	// construction site that does not opt in) no telemetry query runs and the prompt
+	// is byte-identical. Wired from Engine.RouterContextEnabled via mailbox().
+	routerContextEnabled bool
 }
 
 type JobRequest struct {
@@ -512,6 +519,9 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	if err := m.claim(ctx, job); err != nil {
 		return AgentResult{}, err
 	}
+	// Execution clock for #530 routing telemetry: measured from the claim (the real
+	// start of this run) to the terminal transition below. Advisory only.
+	runStart := time.Now()
 
 	registeredFreshRef := runtime.IsFreshRef(agent.RuntimeRef)
 	prompt := prompts.RenderJob(payload.prompt(job.Type))
@@ -521,6 +531,17 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	// byte-identical.
 	if m.injectMemory != nil {
 		if block := m.injectMemory(ctx, agent, payload); block != "" {
+			prompt = prompt + "\n\n" + block
+		}
+	}
+	// Append the off-by-default #530 coordinator routing-context block. Gated on the
+	// [router] context_enabled knob (routerContextEnabled) AND on the job being a
+	// top-level coordinator (no parent) — a delegation child inherits its
+	// coordinator's routing decision, so it needs no table. When the knob is off no
+	// telemetry query runs and the prompt is byte-identical; when on-but-empty the
+	// builder returns "" and the prompt is still byte-identical.
+	if m.routerContextEnabled && strings.TrimSpace(payload.ParentJobID) == "" {
+		if block := m.buildRouterContextBlock(ctx, payload); block != "" {
 			prompt = prompt + "\n\n" + block
 		}
 	}
@@ -668,6 +689,10 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	if err := m.finishWithPayload(ctx, job.ID, state, fmt.Sprintf("job %s", state), payload); err != nil {
 		return AgentResult{}, err
 	}
+	// Record advisory routing telemetry (#530) at the settled terminal state.
+	// Best-effort and fail-safe: it swallows every error internally, so a telemetry
+	// write can never turn a successfully-finished job into a failure.
+	m.recordRoutingTelemetry(ctx, job, agent, payload, result, state, time.Since(runStart))
 	return result, nil
 }
 

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -569,6 +569,12 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			return AgentResult{}, deferredError{cause: deliveryErr}
 		}
 		_ = m.fail(ctx, job.ID, fmt.Sprintf("delivery failed: %v", firstErr))
+		// Record an advisory failure observation (#530) so a runtime/model that
+		// repeatedly crashes at the ADAPTER level (never reaching a parsed decision)
+		// still counts against its success rate — otherwise it contributes zero rows
+		// and its recorded SuccessRate stays artificially high. Only reached on the
+		// TERMINAL m.fail path; the tryDeferBlocker re-queue above returns first.
+		m.recordRoutingTelemetry(ctx, job, agent, payload, AgentResult{}, JobFailed, time.Since(runStart))
 		// Typed DeliveryError: this error is FROM the delivery seam (not about the
 		// agent's output), the precondition for #532 operational classification.
 		return AgentResult{}, deliveryErr
@@ -634,6 +640,10 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 					return AgentResult{}, deferredError{cause: deliveryErr}
 				}
 				_ = m.fail(ctx, job.ID, fmt.Sprintf("repair delivery failed: %v", repairErr))
+				// Advisory failure observation (#530): a hard adapter error during repair
+				// is still a runtime-level failure — count it so flaky runtimes are not
+				// over-recommended by the coordinator context block.
+				m.recordRoutingTelemetry(ctx, job, agent, payload, AgentResult{}, JobFailed, time.Since(runStart))
 				return AgentResult{}, deliveryErr
 			}
 			// Same #531 override + #665 ephemeral guard as the first delivery: never
@@ -662,6 +672,10 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 
 		if parseErr != nil {
 			_ = m.fail(ctx, job.ID, fmt.Sprintf("repair output malformed: %v", parseErr))
+			// Advisory failure observation (#530): output that stays malformed after all
+			// repair attempts is a runtime/model failure to honor the contract — count it
+			// so it lowers the recorded success rate instead of being invisible.
+			m.recordRoutingTelemetry(ctx, job, agent, payload, AgentResult{}, JobFailed, time.Since(runStart))
 			return AgentResult{}, parseErr
 		}
 	}

--- a/internal/workflow/routing_telemetry.go
+++ b/internal/workflow/routing_telemetry.go
@@ -1,0 +1,109 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// maxRouterContextRows bounds the observed-performance table injected into a
+// coordinator prompt (#530) so the block never dominates the prompt. With the 2
+// header lines + trailing note this keeps the whole block at or below 12 lines,
+// matching the spec's bound.
+const maxRouterContextRows = 9
+
+// recordRoutingTelemetry writes one advisory routing observation at the job
+// terminal chokepoint (#530). It is best-effort and fail-safe: EVERY error is
+// swallowed so a telemetry write can never fail a job. It is called AFTER the
+// terminal transition so it records the settled job state. Model/runtime are the
+// effective values the delivery used (a #531 per-job runtime override has already
+// been applied to agent.Runtime by the caller); tokens are re-read from the job
+// row where the delivery persisted them (0 for a runtime that reports none).
+func (m Mailbox) recordRoutingTelemetry(ctx context.Context, job db.Job, agent runtime.Agent, payload JobPayload, result AgentResult, state JobState, duration time.Duration) {
+	if m.Store == nil {
+		return
+	}
+	model := strings.TrimSpace(payload.Model)
+	if model == "" {
+		model = strings.TrimSpace(agent.Model)
+	}
+	durationMS := duration.Milliseconds()
+	if durationMS < 0 {
+		durationMS = 0
+	}
+	// Re-read the persisted per-job usage so the telemetry token counts match the
+	// delegation budget's view (deliver() accumulates usage onto the job row). A
+	// read error just leaves tokens at 0 — advisory only.
+	var inTok, outTok int
+	if fresh, err := m.Store.GetJob(ctx, job.ID); err == nil {
+		inTok, outTok = fresh.InputTokens, fresh.OutputTokens
+	}
+	_ = m.Store.InsertRoutingTelemetry(ctx, db.RoutingTelemetry{
+		JobID:          job.ID,
+		Repo:           payload.Repo,
+		Action:         job.Type,
+		Phase:          strings.TrimSpace(payload.Phase),
+		Runtime:        strings.TrimSpace(agent.Runtime),
+		Model:          model,
+		Agent:          job.Agent,
+		TemplateID:     strings.TrimSpace(payload.TemplateID),
+		TemplateCommit: strings.TrimSpace(payload.TemplateResolvedCommit),
+		JobState:       string(state),
+		Decision:       strings.TrimSpace(result.Decision),
+		Approved:       delegationDecisionApproves(result.Decision),
+		TestsRun:       len(result.TestsRun),
+		DurationMS:     durationMS,
+		InputTokens:    inTok,
+		OutputTokens:   outTok,
+	})
+}
+
+// buildRouterContextBlock renders the bounded, off-by-default observed-performance
+// table injected into a coordinator prompt (#530) so a coordinator can weigh which
+// runtime/model/template has historically done well on this repo. It is ADVISORY:
+// the block is explicitly labeled as local observed performance, not a benchmark,
+// and nothing forces a route. It returns "" (append nothing) when there are no
+// observations yet, so an enabled-but-empty install is still byte-identical to the
+// no-context prompt. The caller gates invocation on the [router] context_enabled
+// knob AND on the job being a top-level (coordinator) job, so with the knob off no
+// query runs and the prompt is byte-identical.
+func (m Mailbox) buildRouterContextBlock(ctx context.Context, payload JobPayload) string {
+	if m.Store == nil {
+		return ""
+	}
+	rows, err := m.Store.ListRoutingTelemetry(ctx, db.RoutingTelemetryFilter{Repo: strings.TrimSpace(payload.Repo)})
+	if err != nil || len(rows) == 0 {
+		return ""
+	}
+	groups := db.AggregateRoutingTelemetry(rows)
+	if len(groups) == 0 {
+		return ""
+	}
+	if len(groups) > maxRouterContextRows {
+		groups = groups[:maxRouterContextRows]
+	}
+	var b strings.Builder
+	b.WriteString("Observed routing performance (local observed performance, not a benchmark):\n")
+	b.WriteString("action | runtime | model | n | success | approval\n")
+	for _, g := range groups {
+		model := g.Model
+		if model == "" {
+			model = "default"
+		}
+		b.WriteString(fmt.Sprintf("%s | %s | %s | %d | %.0f%% | %.0f%%\n",
+			nonEmpty(g.Action), nonEmpty(g.Runtime), model, g.Count,
+			g.SuccessRate*100, g.ApprovalRate*100))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func nonEmpty(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/workflow/routing_telemetry.go
+++ b/internal/workflow/routing_telemetry.go
@@ -27,9 +27,18 @@ func (m Mailbox) recordRoutingTelemetry(ctx context.Context, job db.Job, agent r
 	if m.Store == nil {
 		return
 	}
+	// Mirror deliver()'s effective-model precedence (job.Model > agent.Model >
+	// runtime registry default_model, #652) so the recorded model dimension matches
+	// the model the delivery ACTUALLY ran on. Without the final fallback a job with
+	// no --model/agent.Model but a configured [runtimes.<rt>].default_model would
+	// record an empty bucket even though delivery used that default, mislabeling the
+	// observation as "default"/"-" and splitting the telemetry buckets.
 	model := strings.TrimSpace(payload.Model)
 	if model == "" {
 		model = strings.TrimSpace(agent.Model)
+	}
+	if model == "" && m.RuntimeDefaultModel != nil {
+		model = strings.TrimSpace(m.RuntimeDefaultModel(strings.TrimSpace(agent.Runtime)))
 	}
 	durationMS := duration.Milliseconds()
 	if durationMS < 0 {

--- a/internal/workflow/routing_telemetry_test.go
+++ b/internal/workflow/routing_telemetry_test.go
@@ -1,0 +1,179 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// TestRunJobRecordsRoutingTelemetry proves the #530 capture hook: a job that runs
+// to a terminal decision leaves exactly one routing_telemetry row carrying the
+// action, effective runtime, phase, template, terminal state, decision, and
+// approval flag.
+func TestRunJobRecordsRoutingTelemetry(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":["go test"],"needs":[],"delegations":[]}}`,
+	}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID:        "review-job",
+		Agent:     "audit",
+		Action:    "review",
+		Repo:      "jerryfane/gitmoot",
+		Branch:    "task-9",
+		TaskID:    "task-9",
+		TaskTitle: "Review",
+		Phase:     "verify",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+
+	if _, err := engine.RunJob(ctx, "review-job", agent, adapter); err != nil {
+		t.Fatalf("RunJob returned error: %v", err)
+	}
+
+	rows, err := store.ListRoutingTelemetry(ctx, db.RoutingTelemetryFilter{})
+	if err != nil {
+		t.Fatalf("ListRoutingTelemetry error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("routing_telemetry rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.JobID != "review-job" || got.Repo != "jerryfane/gitmoot" || got.Action != "review" ||
+		got.Phase != "verify" || got.Runtime != runtime.ShellRuntime || got.Agent != "audit" ||
+		got.JobState != string(JobSucceeded) || got.Decision != "approved" || !got.Approved || got.TestsRun != 1 {
+		t.Fatalf("telemetry row mismatch: %+v", got)
+	}
+	if got.DurationMS < 0 {
+		t.Fatalf("duration_ms = %d, want >= 0", got.DurationMS)
+	}
+}
+
+// TestRoutingTelemetryFailureIsSwallowed proves the capture is fail-safe: the
+// recorder swallows EVERY store error (here: a closed store makes both the
+// GetJob usage read and the Insert fail) and returns normally without panicking.
+// Because it is called AFTER the terminal transition, a swallowed error can never
+// turn a finished job into a failure.
+func TestRoutingTelemetryFailureIsSwallowed(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	m := Mailbox{Store: store}
+	// Close the underlying DB so every telemetry query errors.
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime}
+	// Must not panic and must return (errors swallowed internally).
+	m.recordRoutingTelemetry(ctx,
+		db.Job{ID: "j1", Agent: "audit", Type: "review"},
+		agent,
+		JobPayload{Repo: "jerryfane/gitmoot"},
+		AgentResult{Decision: "approved"},
+		JobSucceeded,
+		0)
+}
+
+// TestRouterContextOffByDefaultIdenticalPrompt proves the coordinator context
+// injection is off by default: with routerContextEnabled unset the delivered
+// prompt is byte-identical to the base rendered prompt even when telemetry rows
+// exist, and turning it on appends a bounded (<=12 line) observed-performance
+// table that carries the mandatory disclaimer.
+func TestRouterContextOffByDefaultIdenticalPrompt(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"review"}, "jerryfane/gitmoot")
+
+	// Seed observed performance for this repo so an enabled build would inject.
+	for i := 0; i < 3; i++ {
+		if err := store.InsertRoutingTelemetry(ctx, db.RoutingTelemetry{
+			Repo: "jerryfane/gitmoot", Action: "implement", Runtime: "codex", Model: "gpt-5.5",
+			JobState: "succeeded", Approved: true, DurationMS: 100,
+		}); err != nil {
+			t.Fatalf("seed telemetry error: %v", err)
+		}
+	}
+
+	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	req := JobRequest{ID: "coord", Agent: "lead", Action: "review", Repo: "jerryfane/gitmoot", Branch: "task-1", TaskID: "task-1", TaskTitle: "Coordinate"}
+
+	// OFF (default construction): prompt has no router block.
+	offAdapter := &fakeDelivery{outputs: []string{`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, req); err != nil {
+		t.Fatalf("Enqueue off error: %v", err)
+	}
+	if _, err := (Mailbox{Store: store}).Run(ctx, "coord", agent, offAdapter); err != nil {
+		t.Fatalf("Run off error: %v", err)
+	}
+	if len(offAdapter.prompts) != 1 {
+		t.Fatalf("off deliveries = %d, want 1", len(offAdapter.prompts))
+	}
+	offPrompt := offAdapter.prompts[0]
+	if strings.Contains(offPrompt, "Observed routing performance") {
+		t.Fatalf("off-by-default prompt leaked router context:\n%s", offPrompt)
+	}
+
+	// ON: same job, mailbox with routerContextEnabled=true, appends the block.
+	onReq := req
+	onReq.ID = "coord2"
+	onAdapter := &fakeDelivery{outputs: []string{`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, onReq); err != nil {
+		t.Fatalf("Enqueue on error: %v", err)
+	}
+	if _, err := (Mailbox{Store: store, routerContextEnabled: true}).Run(ctx, "coord2", agent, onAdapter); err != nil {
+		t.Fatalf("Run on error: %v", err)
+	}
+	if len(onAdapter.prompts) != 1 {
+		t.Fatalf("on deliveries = %d, want 1", len(onAdapter.prompts))
+	}
+	onPrompt := onAdapter.prompts[0]
+	if !strings.Contains(onPrompt, "Observed routing performance") {
+		t.Fatalf("enabled prompt missing router context:\n%s", onPrompt)
+	}
+	if !strings.Contains(onPrompt, "not a benchmark") {
+		t.Fatalf("router context missing the mandatory disclaimer:\n%s", onPrompt)
+	}
+	// The ON prompt is the OFF prompt plus exactly the appended block.
+	if !strings.HasPrefix(onPrompt, offPrompt) {
+		t.Fatalf("enabled prompt is not off-prompt + appended block:\noff=%q\non=%q", offPrompt, onPrompt)
+	}
+	block := strings.TrimPrefix(onPrompt, offPrompt)
+	if lines := strings.Count(strings.TrimSpace(block), "\n") + 1; lines > 12 {
+		t.Fatalf("router context block = %d lines, want <=12:\n%s", lines, block)
+	}
+}
+
+// TestRouterContextSkippedForDelegationChild proves the context block targets
+// coordinators only: a job WITH a parent (a delegation child) gets no block even
+// when the feature is enabled and telemetry exists.
+func TestRouterContextSkippedForDelegationChild(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "worker", []string{"review"}, "jerryfane/gitmoot")
+	if err := store.InsertRoutingTelemetry(ctx, db.RoutingTelemetry{
+		Repo: "jerryfane/gitmoot", Action: "implement", Runtime: "codex", JobState: "succeeded", Approved: true,
+	}); err != nil {
+		t.Fatalf("seed telemetry error: %v", err)
+	}
+	agent := runtime.Agent{Name: "worker", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID: "child", Agent: "worker", Action: "review", Repo: "jerryfane/gitmoot", Branch: "task-1", TaskID: "task-1", TaskTitle: "Child",
+		ParentJobID: "some-parent", DelegationID: "d1",
+	}); err != nil {
+		t.Fatalf("Enqueue child error: %v", err)
+	}
+	adapter := &fakeDelivery{outputs: []string{`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}}
+	if _, err := (Mailbox{Store: store, routerContextEnabled: true}).Run(ctx, "child", agent, adapter); err != nil {
+		t.Fatalf("Run child error: %v", err)
+	}
+	if strings.Contains(adapter.prompts[0], "Observed routing performance") {
+		t.Fatalf("delegation child prompt should not carry router context:\n%s", adapter.prompts[0])
+	}
+}

--- a/internal/workflow/routing_telemetry_test.go
+++ b/internal/workflow/routing_telemetry_test.go
@@ -2,12 +2,82 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
+
+// TestRoutingTelemetryRecordsRuntimeDefaultModel proves the recorded model matches
+// the model delivery ACTUALLY ran on: a job with no --model and an agent with no
+// Model, but a configured runtime registry default_model (#652), records that
+// default rather than an empty bucket. Mirrors deliver()'s job.Model > agent.Model
+// > RuntimeDefaultModel precedence.
+func TestRoutingTelemetryRecordsRuntimeDefaultModel(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "impl", []string{"implement"}, "jerryfane/gitmoot")
+	agent := runtime.Agent{Name: "impl", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	adapter := &fakeDelivery{outputs: []string{
+		`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}}
+	m := Mailbox{Store: store, RuntimeDefaultModel: func(rt string) string {
+		if rt == runtime.ShellRuntime {
+			return "gpt-5.5"
+		}
+		return ""
+	}}
+	if _, err := m.Enqueue(ctx, JobRequest{ID: "impl-job", Agent: "impl", Action: "implement", Repo: "jerryfane/gitmoot", Branch: "task-1", TaskID: "task-1", TaskTitle: "Impl"}); err != nil {
+		t.Fatalf("Enqueue error: %v", err)
+	}
+	if _, err := m.Run(ctx, "impl-job", agent, adapter); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	rows, err := store.ListRoutingTelemetry(ctx, db.RoutingTelemetryFilter{})
+	if err != nil {
+		t.Fatalf("ListRoutingTelemetry error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].Model != "gpt-5.5" {
+		t.Fatalf("recorded model = %q, want the runtime default_model %q", rows[0].Model, "gpt-5.5")
+	}
+}
+
+// TestRoutingTelemetryRecordsAdapterFailure proves a hard adapter-delivery error
+// (never reaching a parsed decision) still records one advisory observation with
+// JobState failed, so a runtime/model that repeatedly crashes at the adapter level
+// lowers its recorded success rate instead of contributing zero rows.
+func TestRoutingTelemetryRecordsAdapterFailure(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "flaky", []string{"implement"}, "jerryfane/gitmoot")
+	agent := runtime.Agent{Name: "flaky", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "jerryfane/gitmoot", Role: "agent"}
+	adapter := &fakeDelivery{err: errors.New("adapter boom")}
+	m := Mailbox{Store: store}
+	if _, err := m.Enqueue(ctx, JobRequest{ID: "flaky-job", Agent: "flaky", Action: "implement", Repo: "jerryfane/gitmoot", Branch: "task-1", TaskID: "task-1", TaskTitle: "Flaky"}); err != nil {
+		t.Fatalf("Enqueue error: %v", err)
+	}
+	if _, err := m.Run(ctx, "flaky-job", agent, adapter); err == nil {
+		t.Fatalf("Run expected a delivery error, got nil")
+	}
+	rows, err := store.ListRoutingTelemetry(ctx, db.RoutingTelemetryFilter{})
+	if err != nil {
+		t.Fatalf("ListRoutingTelemetry error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1 failure observation", len(rows))
+	}
+	if rows[0].JobState != string(JobFailed) {
+		t.Fatalf("recorded JobState = %q, want %q", rows[0].JobState, JobFailed)
+	}
+	if rows[0].Runtime != runtime.ShellRuntime || rows[0].Action != "implement" || rows[0].Approved {
+		t.Fatalf("failure row mismatch: %+v", rows[0])
+	}
+}
 
 // TestRunJobRecordsRoutingTelemetry proves the #530 capture hook: a job that runs
 // to a terminal decision leaves exactly one routing_telemetry row carrying the

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, pipelines, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, pipelines, routing telemetry, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
@@ -68,6 +68,15 @@ prompt as a read-only "Prior learnings" reference block (never instructions).
 Enrollment is per agent via `[agents.<name>].memory = true` plus an optional
 `[memory]` section; inspect the store read-only with `gitmoot memory list`. See
 CLI.md § Agent Memory and the "Agent Persistent Memory" concepts page for depth.
+
+For routing telemetry, phrases like "which runtime/model works best here",
+"show observed routing performance", or "should I route Go tasks to Codex" map to
+Gitmoot's execution-grounded routing telemetry (#530): every job records an
+additive `routing_telemetry` row at terminal, and `gitmoot router summary` reports
+local observed success/approval rates by `(action, runtime, model, template)`. It
+is **advisory only** — nothing auto-overrides routing — and labeled "local observed
+performance, not a benchmark". An optional `[router] context_enabled = true` feeds a
+bounded table into coordinator prompts. See CLI.md § Routing Telemetry.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1454,3 +1454,46 @@ spawn children — the advancer ignores them and the engine strips them for a pi
 stage job. Use an orchestra for dynamic fan-out, a pipeline for a fixed shell DAG.
 See `docs/pipelines.md` for the full reference and `WORKFLOWS.md → Pipelines` for the
 end-to-end story.
+
+## Routing Telemetry (Advisory)
+
+Gitmoot records lightweight **execution-grounded routing telemetry** (#530): one
+additive row per job at its terminal transition, capturing which combination
+actually ran and how it turned out — `repo`, `action` (ask/review/implement/
+continuation/…), `phase`, `runtime`, `model`, `agent`, resolved `template_id` +
+commit, terminal `job_state` (succeeded/failed/blocked), result `decision` +
+approval flag, a coarse tests-run count, `duration_ms`, and `input`/`output`
+tokens (best-effort; a runtime that reports no usage contributes 0). Capture is
+**always on, additive, and fail-safe**: it writes only to the new
+`routing_telemetry` table and a telemetry error can never fail a job, so wire
+output is unchanged.
+
+**v1 is advisory only.** Nothing reads this back to change routing — no automatic
+model/runtime override happens anywhere. It is a local feedback loop you inspect,
+not a global benchmark. (This capture slice subsumes the phase-aware capability
+telemetry proposed in #522.)
+
+Inspect observed performance (read-only), grouped by `(action, runtime, model,
+template)`:
+
+```sh
+gitmoot router summary [--repo owner/repo] [--action ask|review|implement] [--since 30d] [--json]
+```
+
+It reports per-group count, success rate, approval rate, median duration, and
+summed tokens, always labeled **"local observed performance, not a benchmark"**.
+`--since` accepts a Go duration or an `<N>d` days suffix.
+
+Optionally feed a **bounded** (≤12-line) observed-performance table into a
+**coordinator's** prompt so it can weigh which runtime/model/template has done
+well on the repo. It is **off by default**; with it off, coordinator prompt
+assembly is byte-identical and no telemetry query runs during a job:
+
+```toml
+[router]
+context_enabled = true   # inject the advisory table into top-level coordinator prompts (default false)
+```
+
+The injected block carries the same "not a benchmark" disclaimer and is only added
+to top-level (coordinator) jobs — a delegation child inherits its coordinator's
+routing decision. Routing stays advisory: the block never forces a route.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1320,3 +1320,40 @@ from its halted stage (or `--from`) plus its transitive dependents while **never
 re-running a succeeded stage. A pipeline stage is a **leaf**: a stage result carrying
 `delegations[]` never spawns children. See
 [Pipelines](../workflows/pipelines-workflow.md) for the full workflow.
+
+## Routing Telemetry (Advisory)
+
+Gitmoot records lightweight **execution-grounded routing telemetry**: one additive
+row per job at its terminal transition capturing which combination actually ran and
+how it turned out — `repo`, `action`, `phase`, `runtime`, `model`, `agent`, resolved
+`template_id` + commit, terminal `job_state`, result `decision` + approval flag, a
+coarse tests-run count, `duration_ms`, and input/output tokens (best-effort). Capture
+is **always on, additive, and fail-safe**: it writes only to the new
+`routing_telemetry` table and a telemetry error can never fail a job.
+
+**v1 is advisory only** — nothing reads this back to change routing, and no automatic
+model/runtime override happens anywhere. It is a local feedback loop you inspect, not
+a global benchmark.
+
+Inspect observed performance (read-only), grouped by `(action, runtime, model,
+template)`:
+
+```sh
+gitmoot router summary [--repo owner/repo] [--action ask|review|implement] [--since 30d] [--json]
+```
+
+It reports per-group count, success rate, approval rate, median duration, and summed
+tokens, always labeled **"local observed performance, not a benchmark"**. `--since`
+accepts a Go duration or an `<N>d` days suffix.
+
+Optionally inject a **bounded** (≤12-line) observed-performance table into a
+**coordinator's** prompt. It is **off by default**; with it off, coordinator prompt
+assembly is byte-identical and no telemetry query runs during a job:
+
+```toml
+[router]
+context_enabled = true   # inject the advisory table into top-level coordinator prompts (default false)
+```
+
+The injected block carries the same "not a benchmark" disclaimer, is added only to
+top-level (coordinator) jobs, and never forces a route — routing stays advisory.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -7428,7 +7428,7 @@ his PRs (#555, #560), co-authored.
 
 ---
 name: gitmoot
-description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, pipelines, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
+description: Use Gitmoot for local-first AI agent coordination across repositories, goals, reviews, GitHub PR comments, agent subscriptions, daemon checks, stuck jobs, branch locks, agent-templates, template capture and publish/pull, custom prompt agents, orchestration, heartbeats, pipelines, routing telemetry, event webhooks, the web dashboard, per-job runtime overrides, the config-driven runtime metadata registry, and Codex, Claude Code, or Kimi Code runtime workflows.
 license: Apache-2.0
 compatibility: Requires the gitmoot CLI, git, GitHub CLI authentication, network access to GitHub, and a supported runtime such as Codex, Claude Code, or Kimi Code.
 metadata:
@@ -7496,6 +7496,15 @@ prompt as a read-only "Prior learnings" reference block (never instructions).
 Enrollment is per agent via `[agents.<name>].memory = true` plus an optional
 `[memory]` section; inspect the store read-only with `gitmoot memory list`. See
 CLI.md § Agent Memory and the "Agent Persistent Memory" concepts page for depth.
+
+For routing telemetry, phrases like "which runtime/model works best here",
+"show observed routing performance", or "should I route Go tasks to Codex" map to
+Gitmoot's execution-grounded routing telemetry (#530): every job records an
+additive `routing_telemetry` row at terminal, and `gitmoot router summary` reports
+local observed success/approval rates by `(action, runtime, model, template)`. It
+is **advisory only** — nothing auto-overrides routing — and labeled "local observed
+performance, not a benchmark". An optional `[router] context_enabled = true` feeds a
+bounded table into coordinator prompts. See CLI.md § Routing Telemetry.
 
 For background work, keep Gitmoot's resource model explicit: repo checkout
 locks protect local checkouts, runtime session locks serialize delivery for the
@@ -9278,6 +9287,49 @@ spawn children — the advancer ignores them and the engine strips them for a pi
 stage job. Use an orchestra for dynamic fan-out, a pipeline for a fixed shell DAG.
 See `docs/pipelines.md` for the full reference and `WORKFLOWS.md → Pipelines` for the
 end-to-end story.
+
+## Routing Telemetry (Advisory)
+
+Gitmoot records lightweight **execution-grounded routing telemetry** (#530): one
+additive row per job at its terminal transition, capturing which combination
+actually ran and how it turned out — `repo`, `action` (ask/review/implement/
+continuation/…), `phase`, `runtime`, `model`, `agent`, resolved `template_id` +
+commit, terminal `job_state` (succeeded/failed/blocked), result `decision` +
+approval flag, a coarse tests-run count, `duration_ms`, and `input`/`output`
+tokens (best-effort; a runtime that reports no usage contributes 0). Capture is
+**always on, additive, and fail-safe**: it writes only to the new
+`routing_telemetry` table and a telemetry error can never fail a job, so wire
+output is unchanged.
+
+**v1 is advisory only.** Nothing reads this back to change routing — no automatic
+model/runtime override happens anywhere. It is a local feedback loop you inspect,
+not a global benchmark. (This capture slice subsumes the phase-aware capability
+telemetry proposed in #522.)
+
+Inspect observed performance (read-only), grouped by `(action, runtime, model,
+template)`:
+
+```sh
+gitmoot router summary [--repo owner/repo] [--action ask|review|implement] [--since 30d] [--json]
+```
+
+It reports per-group count, success rate, approval rate, median duration, and
+summed tokens, always labeled **"local observed performance, not a benchmark"**.
+`--since` accepts a Go duration or an `<N>d` days suffix.
+
+Optionally feed a **bounded** (≤12-line) observed-performance table into a
+**coordinator's** prompt so it can weigh which runtime/model/template has done
+well on the repo. It is **off by default**; with it off, coordinator prompt
+assembly is byte-identical and no telemetry query runs during a job:
+
+```toml
+[router]
+context_enabled = true   # inject the advisory table into top-level coordinator prompts (default false)
+```
+
+The injected block carries the same "not a benchmark" disclaimer and is only added
+to top-level (coordinator) jobs — a delegation child inherits its coordinator's
+routing decision. Routing stays advisory: the block never forces a route.
 
 ---
 

--- a/workflow_race.log
+++ b/workflow_race.log
@@ -1,0 +1,2 @@
+ok  	github.com/jerryfane/gitmoot/internal/workflow	521.296s
+RACE_EXIT=0


### PR DESCRIPTION
## What

Implements #530 v1: an execution-grounded routing telemetry layer plus a read-only summary, with an off-by-default coordinator context block. It is **ADVISORY ONLY — zero routing behavior change**. No automatic model/runtime override happens anywhere.

- **Capture** (always on, additive, fail-safe): at the single result-bearing job terminal chokepoint (`Mailbox.Run` after `finishWithPayload`) insert one `routing_telemetry` row — `repo`, `action`, `phase`, effective `runtime`+`model`, `agent`, resolved `template_id`+commit, terminal `job_state`, result `decision`+approval flag, coarse tests-run count, `duration_ms`, and input/output tokens (reusing the existing per-job usage capture; a runtime that reports none contributes 0). A telemetry error is swallowed, so it can **never** fail a job.
- **CLI**: `gitmoot router summary [--repo] [--action] [--since 30d] [--json]` — read-only aggregate of success/approval rates + counts + median duration + tokens grouped by `(action, runtime, model, template)`, always labeled **"local observed performance, not a benchmark"**.
- **Coordinator context (off by default)**: `[router] context_enabled=false`. When `true`, a bounded (≤12-line) observed-performance table is appended to **top-level coordinator** prompts, mirroring the memory/upstream-dep injection seam. When `false`: byte-identical prompts and **no telemetry query runs** during a job.
- **Docs (same PR)**: `skills/gitmoot/references/CLI.md` § Routing Telemetry, `website/docs/reference/cli.md`, and SKILL.md trigger wording; `website/static/llms-full.txt` regenerated.

## Why

Gives Gitmoot a local feedback loop over which runtime/model/template actually works on real jobs (the Agent-as-a-Router direction in the issue). v1 stays advisory — a human inspects it; nothing auto-routes. **The capture slice subsumes #522** (phase-aware capability telemetry): phase is captured per row.

## Additive / off-by-default invariants

- New `routing_telemetry` table via an appended additive migration (CREATE TABLE/INDEX only; empty until a job finishes post-migration) — existing DBs read identically, no ContractVersion bump.
- Capture writes only to the new table; wire output is unchanged.
- Context injection is gated on `[router] context_enabled` AND on the job being top-level; off ⇒ byte-identical prompt, no query. A read-only summary on an un-migrated DB degrades to "no observations" rather than erroring.

## How tested

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -count=1 ./internal/db ./internal/config ./internal/workflow ./internal/cli` — all `ok`
  - db: insert/list round-trip + repo/action/since filters, pure aggregate (rates/median/tokens/order), missing-table degradation
  - workflow: engine capture hook (terminal ⇒ row exists), telemetry failure does not fail the job, prompt off=identical / on=bounded ≤12-line table w/ disclaimer, delegation-child skip
  - cli: summary JSON + text w/ seeded rows, `--repo`/`--action` filters, empty home, `[router]` config resolution
  - config: `[router]` defaults/round-trip/malformed
- `go test -race -count=1 -timeout 20m ./internal/workflow` — `ok`, exit 0
- `cd website && npm ci && npm run build` — success

Closes #530