### PR TITLE
feat(review): opt-in risk-tiered adaptive review

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -419,6 +419,10 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		// delegation token budget) on this single-repo engine too; fail-safe to the
 		// defaults if the policy cannot load.
 		defaultJobWorker(store, stdout, *home).applyOrchestratePolicy(&engine)
+		// Opt-in risk-tiered adaptive review (#650); off by default so this is a
+		// no-op unless the home config enables it.
+		applyReviewPolicy(&engine, *home)
+		wireReviewRiskSignals(&engine, gh)
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
 		return runSingleRepoSupervisor(ctx, *home, daemon.Daemon{
 			Repo:                   repo,
@@ -6627,6 +6631,11 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// stranded canary row can never keep serving traffic with no auto-rollback.
 		CanaryEnabled: canaryRoutingEnabled(home),
 	}
+	// Opt-in risk-tiered adaptive review (#650): copy the [review] policy onto the
+	// engine. Off by default (RiskTiersEnabled false), so the review fan-out is
+	// byte-identical unless a home config turns it on.
+	applyReviewPolicy(&engine, home)
+	wireReviewRiskSignals(&engine, gh)
 	if strings.TrimSpace(home) != "" {
 		// Root delegation artifacts under GITMOOT_HOME (alongside worktrees)
 		// rather than inside the repo checkout, so generated briefs stay out of

--- a/internal/cli/review_risk.go
+++ b/internal/cli/review_risk.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// loadReviewPolicy reads the [review] section for a `home` that may be either an
+// already-resolved <home>/.gitmoot root or a raw --home (resolveConfigFile
+// handles both). It fails safe to the default (risk tiers OFF) so a missing or
+// malformed config never turns the opt-in path on or breaks the daemon.
+func loadReviewPolicy(home string) config.ReviewPolicy {
+	cfg := resolveConfigFile(home)
+	if cfg == "" {
+		return config.DefaultReviewPolicy()
+	}
+	policy, err := config.LoadReviewPolicy(config.Paths{ConfigFile: cfg})
+	if err != nil {
+		return config.DefaultReviewPolicy()
+	}
+	return policy
+}
+
+// applyReviewPolicy copies the opt-in [review] risk-tiered review policy (#650)
+// onto the engine. With risk tiers off (the default) it sets RiskTiersEnabled
+// false and the engine's review fan-out is byte-identical, so calling it
+// unconditionally at engine construction is safe.
+func applyReviewPolicy(engine *workflow.Engine, home string) {
+	policy := loadReviewPolicy(home)
+	engine.RiskTiersEnabled = policy.RiskTiersEnabled
+	engine.HighRiskPaths = policy.HighRiskPaths
+	engine.RiskLabelHigh = policy.RiskLabelHigh
+	engine.RiskLabelRoutine = policy.RiskLabelRoutine
+}
+
+// wireReviewRiskSignals attaches the best-effort PR-signals resolver (#650) that
+// HandlePullRequestOpened uses on the in-process implement->PR trigger to classify
+// risk (labels + changed paths). It is a GitHub read, so it is wired ONLY when
+// risk tiers are enabled to keep the default path free of any extra API call; when
+// off the engine seam stays nil and behavior is byte-identical.
+func wireReviewRiskSignals(engine *workflow.Engine, gh github.Client) {
+	if engine == nil || !engine.RiskTiersEnabled || gh == nil {
+		return
+	}
+	engine.PullRequestSignals = func(ctx context.Context, repo string, number int) ([]string, []string, error) {
+		owner, name, ok := strings.Cut(strings.TrimSpace(repo), "/")
+		if !ok || owner == "" || name == "" || strings.Contains(name, "/") {
+			return nil, nil, fmt.Errorf("risk signals: invalid repo %q", repo)
+		}
+		r := github.Repository{Owner: owner, Name: name}
+		pr, err := gh.GetPullRequest(ctx, r, int64(number))
+		if err != nil {
+			return nil, nil, err
+		}
+		labels := pr.LabelNames()
+		files, err := gh.ListPullRequestFiles(ctx, r, int64(number))
+		if err != nil {
+			// Labels alone still classify (a label wins over paths); a changed-files
+			// lookup failure must not block the review.
+			return labels, nil, nil
+		}
+		paths := make([]string, 0, len(files))
+		for _, f := range files {
+			if n := strings.TrimSpace(f.Filename); n != "" {
+				paths = append(paths, n)
+			}
+		}
+		return labels, paths, nil
+	}
+}

--- a/internal/cli/review_risk_test.go
+++ b/internal/cli/review_risk_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestApplyReviewPolicyOffByDefault(t *testing.T) {
+	home := t.TempDir()
+	root := config.PathsForHome(home).Home
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A config with no [review] section.
+	if err := os.WriteFile(filepath.Join(root, config.ConfigName), []byte("[orchestrate]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var engine workflow.Engine
+	applyReviewPolicy(&engine, root)
+	if engine.RiskTiersEnabled {
+		t.Fatal("applyReviewPolicy must leave risk tiers OFF when [review] is absent")
+	}
+}
+
+func TestApplyReviewPolicyEnabledFromConfig(t *testing.T) {
+	home := t.TempDir()
+	root := config.PathsForHome(home).Home
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "[review]\nrisk_tiers_enabled = true\nhigh_risk_paths = [\"cmd/**\"]\nrisk_label_high = \"sev:1\"\n"
+	if err := os.WriteFile(filepath.Join(root, config.ConfigName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var engine workflow.Engine
+	applyReviewPolicy(&engine, root)
+	if !engine.RiskTiersEnabled {
+		t.Fatal("applyReviewPolicy must enable risk tiers from [review].risk_tiers_enabled")
+	}
+	if len(engine.HighRiskPaths) != 1 || engine.HighRiskPaths[0] != "cmd/**" {
+		t.Fatalf("HighRiskPaths = %v", engine.HighRiskPaths)
+	}
+	if engine.RiskLabelHigh != "sev:1" {
+		t.Fatalf("RiskLabelHigh = %q", engine.RiskLabelHigh)
+	}
+}
+
+func TestApplyReviewPolicyEmptyHomeIsOff(t *testing.T) {
+	var engine workflow.Engine
+	applyReviewPolicy(&engine, "")
+	if engine.RiskTiersEnabled {
+		t.Fatal("empty home must resolve to risk tiers OFF")
+	}
+}

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -456,6 +456,100 @@ func validateEventsPolicy(policy EventsPolicy) error {
 	return nil
 }
 
+// ReviewPolicy is the host-level review policy read from the [review] section of
+// the gitmoot config (#650). It gates the OPT-IN risk-tiered adaptive review:
+// when RiskTiersEnabled is false (the default) the workflow engine never
+// classifies a PR and the single-review fan-out is byte-identical. HighRiskPaths,
+// RiskLabelHigh, and RiskLabelRoutine are only consulted when risk tiers are on.
+type ReviewPolicy struct {
+	// RiskTiersEnabled opts the engine into risk-tiered review. Default false = OFF.
+	RiskTiersEnabled bool
+	// HighRiskPaths is the changed-path glob list that resolves the `high` tier.
+	// Empty falls back to the engine's built-in defaults.
+	HighRiskPaths []string
+	// RiskLabelHigh / RiskLabelRoutine are the PR label names that force a tier
+	// (winning over path heuristics). Empty falls back to the engine defaults
+	// (risk:high / risk:routine).
+	RiskLabelHigh    string
+	RiskLabelRoutine string
+}
+
+func DefaultReviewPolicy() ReviewPolicy {
+	return ReviewPolicy{RiskTiersEnabled: false}
+}
+
+// LoadReviewPolicy parses the [review] section. A missing config file or section
+// yields the default (risk tiers OFF), so the caller never has to distinguish
+// "no config" from "explicitly off".
+func LoadReviewPolicy(paths Paths) (ReviewPolicy, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultReviewPolicy(), nil
+		}
+		return ReviewPolicy{}, err
+	}
+	policy := DefaultReviewPolicy()
+	current := false
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			current = strings.TrimSpace(section) == "review"
+			continue
+		}
+		if !current {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if err := applyReviewPolicyField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
+			return ReviewPolicy{}, fmt.Errorf("parse [review].%s: %w", strings.TrimSpace(key), err)
+		}
+	}
+	return policy, nil
+}
+
+func applyReviewPolicyField(policy *ReviewPolicy, key string, value string) error {
+	switch key {
+	case "risk_tiers_enabled":
+		parsed, err := parseConfigBool(value)
+		if err != nil {
+			return err
+		}
+		policy.RiskTiersEnabled = parsed
+		return nil
+	case "high_risk_paths":
+		parsed, err := parseConfigStringArray(value)
+		if err != nil {
+			return err
+		}
+		policy.HighRiskPaths = parsed
+		return nil
+	case "risk_label_high":
+		parsed, err := parseConfigString(value)
+		if err != nil {
+			return err
+		}
+		policy.RiskLabelHigh = strings.TrimSpace(parsed)
+		return nil
+	case "risk_label_routine":
+		parsed, err := parseConfigString(value)
+		if err != nil {
+			return err
+		}
+		policy.RiskLabelRoutine = strings.TrimSpace(parsed)
+		return nil
+	default:
+		return nil
+	}
+}
+
 // SkillOptPolicy is the host-level template-learning policy read from the
 // [skillopt] section of the gitmoot config (#465, Mode A). It gates the
 // off-by-default automatic trace-harvester: when AutoTraceEnabled is false (the

--- a/internal/config/review_test.go
+++ b/internal/config/review_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeReviewConfig(t *testing.T, body string) Paths {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(cfg, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return Paths{ConfigFile: cfg}
+}
+
+func TestLoadReviewPolicyDefaultsOff(t *testing.T) {
+	// No file at all -> default (off), no error.
+	policy, err := LoadReviewPolicy(Paths{ConfigFile: filepath.Join(t.TempDir(), "missing.toml")})
+	if err != nil {
+		t.Fatalf("LoadReviewPolicy(missing) error: %v", err)
+	}
+	if policy.RiskTiersEnabled {
+		t.Fatal("missing config must default risk tiers OFF")
+	}
+
+	// A config with no [review] section -> default off.
+	policy, err = LoadReviewPolicy(writeReviewConfig(t, "[orchestrate]\ncockpit_mode = \"off\"\n"))
+	if err != nil {
+		t.Fatalf("LoadReviewPolicy(no section) error: %v", err)
+	}
+	if policy.RiskTiersEnabled {
+		t.Fatal("absent [review] section must default OFF")
+	}
+}
+
+func TestLoadReviewPolicyParsesFields(t *testing.T) {
+	body := `
+[review]
+risk_tiers_enabled = true
+high_risk_paths = ["**/auth/**", "cmd/**", "go.mod"]
+risk_label_high = "sev:1"
+risk_label_routine = "sev:routine"
+`
+	policy, err := LoadReviewPolicy(writeReviewConfig(t, body))
+	if err != nil {
+		t.Fatalf("LoadReviewPolicy error: %v", err)
+	}
+	if !policy.RiskTiersEnabled {
+		t.Fatal("risk_tiers_enabled = true not parsed")
+	}
+	if len(policy.HighRiskPaths) != 3 || policy.HighRiskPaths[1] != "cmd/**" {
+		t.Fatalf("high_risk_paths = %v", policy.HighRiskPaths)
+	}
+	if policy.RiskLabelHigh != "sev:1" || policy.RiskLabelRoutine != "sev:routine" {
+		t.Fatalf("labels = %q / %q", policy.RiskLabelHigh, policy.RiskLabelRoutine)
+	}
+}
+
+func TestLoadReviewPolicyRejectsBadBool(t *testing.T) {
+	_, err := LoadReviewPolicy(writeReviewConfig(t, "[review]\nrisk_tiers_enabled = yes\n"))
+	if err == nil {
+		t.Fatal("expected error for non-bool risk_tiers_enabled")
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -93,6 +93,27 @@ type PullRequest struct {
 	HeadSHA   string
 	MergeSHA  string
 	Mergeable *bool `json:"mergeable"`
+	// Labels carries the PR's GitHub labels (parsed from the list/get JSON, no
+	// extra API call). It is additive (#650): existing callers that ignore it are
+	// byte-identical; the opt-in risk classifier reads label names from it.
+	Labels []PullRequestLabel `json:"labels,omitempty"`
+}
+
+// PullRequestLabel is a single GitHub label on a PR (only the name is used).
+type PullRequestLabel struct {
+	Name string `json:"name"`
+}
+
+// LabelNames returns the PR's label names, dropping blanks. It is the input the
+// risk classifier consumes.
+func (p PullRequest) LabelNames() []string {
+	names := make([]string, 0, len(p.Labels))
+	for _, l := range p.Labels {
+		if name := strings.TrimSpace(l.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 func (p *PullRequest) UnmarshalJSON(data []byte) error {
@@ -114,6 +135,7 @@ func (p *PullRequest) UnmarshalJSON(data []byte) error {
 			Ref string `json:"ref"`
 			SHA string `json:"sha"`
 		} `json:"base"`
+		Labels []PullRequestLabel `json:"labels"`
 	}
 	var decoded wire
 	if err := json.Unmarshal(data, &decoded); err != nil {
@@ -132,6 +154,7 @@ func (p *PullRequest) UnmarshalJSON(data []byte) error {
 	p.MergeSHA = decoded.MergeSHA
 	p.BaseRef = decoded.Base.Ref
 	p.BaseSHA = decoded.Base.SHA
+	p.Labels = decoded.Labels
 	return nil
 }
 

--- a/internal/github/pr_labels_test.go
+++ b/internal/github/pr_labels_test.go
@@ -1,0 +1,28 @@
+package github
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestPullRequestLabelNamesFromJSON(t *testing.T) {
+	// Labels arrive as an array of objects on the GitHub /pulls list+get JSON.
+	raw := `{"number":7,"title":"t","labels":[{"name":"risk:high"},{"name":""},{"name":"enhancement"}]}`
+	var pr PullRequest
+	if err := json.Unmarshal([]byte(raw), &pr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := pr.LabelNames()
+	want := []string{"risk:high", "enhancement"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("LabelNames() = %v, want %v", got, want)
+	}
+}
+
+func TestPullRequestLabelNamesEmpty(t *testing.T) {
+	var pr PullRequest
+	if got := pr.LabelNames(); len(got) != 0 {
+		t.Fatalf("LabelNames() on no labels = %v, want empty", got)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -308,6 +308,35 @@ type Engine struct {
 	// agent/job pin always wins. Nil (the default) forces nothing, so delivery is
 	// byte-identical to before #652.
 	RuntimeDefaultModel func(runtimeName string) string
+	// RiskTiersEnabled gates the opt-in risk-tiered adaptive review (#650). When
+	// false (the default), HandlePullRequestOpened NEVER classifies a PR and runs
+	// the single-review fan-out byte-identically. When true, a PR opened event is
+	// classified (label > path > default); a `high` tier replaces the single
+	// fan-out with a refutation-lens delegation batch synthesized by the EXISTING
+	// quorum synthesis_rule engine, while a `routine` tier stays on the unchanged
+	// single-review path. It is sourced from the host [review].risk_tiers_enabled
+	// config at daemon startup.
+	RiskTiersEnabled bool
+	// HighRiskPaths is the changed-path glob list a PR is matched against to
+	// resolve the `high` tier when RiskTiersEnabled. Empty falls back to
+	// DefaultHighRiskPaths. Sourced from [review].high_risk_paths.
+	HighRiskPaths []string
+	// RiskLabelHigh / RiskLabelRoutine are the PR label names that force a tier,
+	// winning over path heuristics. Empty falls back to DefaultRiskLabelHigh /
+	// DefaultRiskLabelRoutine. Sourced from [review].risk_label_high /
+	// [review].risk_label_routine.
+	RiskLabelHigh    string
+	RiskLabelRoutine string
+	// PullRequestSignals resolves the risk classifier's inputs (PR labels +
+	// changed file paths) for a PR whose event does not already carry them (#650).
+	// It is the seam HandlePullRequestOpened uses on the IN-PROCESS implement->PR
+	// trigger, which has no GitHub file data. It is nil-safe and best-effort: when
+	// nil (every non-daemon construction) or when risk tiers are off, it is never
+	// consulted and classification falls back to the event's own signals; a lookup
+	// error yields no signals (the change classifies routine). The concrete impl is
+	// wired only in cli (a GitHub read), keeping the engine free of the github
+	// client coupling.
+	PullRequestSignals func(ctx context.Context, repo string, number int) (labels []string, changedPaths []string, err error)
 }
 
 // DelegationTimeoutDefaults are optional fallback timeouts for child delegation
@@ -496,6 +525,17 @@ type PullRequestEvent struct {
 	// orchestrators use this to make their own gate the only merge authority.
 	// Defaults false => full native fanout/advancement.
 	SkipReviewFanout bool
+	// Labels carries the PR's GitHub label names, used only by the opt-in risk
+	// classifier (#650) when RiskTiersEnabled. Additive: empty (the default) means
+	// the classifier falls back to path/default signals, and with risk tiers off
+	// it is never read. The daemon PR-watcher populates it best-effort.
+	Labels []string
+	// ChangedPaths carries the PR's changed file paths (repo-relative), used only
+	// by the opt-in risk classifier (#650) when RiskTiersEnabled. Additive: empty
+	// (the default) means the classifier falls back to label/default signals, and
+	// with risk tiers off it is never read. The daemon populates it best-effort
+	// (a lookup failure leaves it empty rather than blocking the review).
+	ChangedPaths []string
 }
 
 // RevertEvent locates the ORIGINAL PR that a (now-merged) revert PR undid (#467).
@@ -874,6 +914,28 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 		}
 		return e.recordPullRequestBaseline(ctx, event)
 	}
+	// Opt-in risk-tiered adaptive review (#650). When RiskTiersEnabled, classify
+	// the PR (label > path > default). A `high` tier replaces the single native
+	// fan-out with a refutation-lens delegation batch synthesized by the EXISTING
+	// quorum synthesis_rule engine. The whole block is gated on the flag, so with
+	// risk tiers off (the default) the classifier is never called and the
+	// single-review path below is byte-identical.
+	if e.RiskTiersEnabled {
+		labels, changedPaths := event.Labels, event.ChangedPaths
+		// The in-process implement->PR trigger carries no GitHub file data. Resolve
+		// the classifier's signals through the best-effort seam when the event has
+		// none and the seam is wired. A lookup error leaves the signals empty, so the
+		// change classifies routine rather than blocking the review.
+		if len(labels) == 0 && len(changedPaths) == 0 && e.PullRequestSignals != nil && event.PullRequest > 0 {
+			if l, p, err := e.PullRequestSignals(ctx, event.Repo, event.PullRequest); err == nil {
+				labels, changedPaths = l, p
+			}
+		}
+		classification := ClassifyRisk(e.HighRiskPaths, e.RiskLabelHigh, e.RiskLabelRoutine, labels, changedPaths)
+		if classification.Tier == RiskTierHigh {
+			return e.dispatchHighRiskReview(ctx, event, reviewers, classification, ref)
+		}
+	}
 	reviewRound, err := e.nextReviewRound(ctx, event)
 	if err != nil {
 		return err
@@ -911,6 +973,93 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 		if err := e.enqueue(ctx, request); err != nil {
 			return err
 		}
+	}
+	if err := e.setTaskState(ctx, ref, TaskReviewing); err != nil {
+		return err
+	}
+	return e.recordPullRequestBaseline(ctx, event)
+}
+
+// dispatchHighRiskReview replaces the single native review fan-out with a
+// refutation-lens delegation batch for a PR classified `high` (#650). It seeds a
+// synthetic, already-completed review COORDINATOR job whose result carries the
+// lens delegations (each tagged synthesis_rule "quorum") and then invokes the
+// EXISTING delegation dispatcher — so the fan-out, the deps machinery, and the
+// cross-lens synthesis are all the same engine the coordinator-returns-delegations
+// path uses, never a bespoke synthesis. When every lens approves, the quorum is
+// satisfied and the coordinator continuation is enqueued; when ANY lens reports a
+// critical refutation (a `blocked` decision, a NON-approving quorum outcome) the
+// quorum fails and the shared task is blocked — the explicit "blocks on a critical
+// refutation or a failed quorum" acceptance behavior.
+//
+// It is idempotent against the daemon's re-poll: the coordinator id is derived
+// from the stable review round for this head SHA, and the lens children are
+// review jobs the daemon's PR-watcher routing already recognizes, so a re-poll at
+// the same head never re-dispatches.
+func (e Engine) dispatchHighRiskReview(ctx context.Context, event PullRequestEvent, reviewers []string, classification RiskClassification, ref taskRef) error {
+	round, err := e.nextReviewRound(ctx, event)
+	if err != nil {
+		return err
+	}
+	coordID := "review-coordinator/" + event.Branch + "/" + round
+	if _, err := e.Store.GetJob(ctx, coordID); err == nil {
+		// Already dispatched for this head SHA/round: idempotent no-op.
+		return nil
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+
+	delegations := highRiskLensDelegations(reviewers, event)
+	if len(delegations) < 2 {
+		// Defensive: no reviewers to fan out to. Fall back to recording the baseline
+		// rather than silently dropping the PR (should not happen — callers guarantee
+		// len(reviewers) >= 1, which yields >= 2 lenses).
+		return e.recordPullRequestBaseline(ctx, event)
+	}
+
+	coordPayload := JobPayload{
+		Repo:        event.Repo,
+		Branch:      event.Branch,
+		PullRequest: event.PullRequest,
+		HeadSHA:     event.HeadSHA,
+		GoalID:      event.GoalID,
+		TaskID:      event.TaskID,
+		TaskTitle:   event.TaskTitle,
+		LeadAgent:   event.LeadAgent,
+		Reviewers:   reviewers,
+		ReviewRound: round,
+		Sender:      event.Sender,
+		Instructions: fmt.Sprintf(
+			"Synthesize the high-risk adversarial review of pull request #%d for task %s from the lens findings below.",
+			event.PullRequest, taskLabel(event.TaskID, event.TaskTitle),
+		),
+		RiskTier: classification.Tier,
+		Result: &AgentResult{
+			Decision:    "approved",
+			Summary:     "high-risk adversarial lens fan-out",
+			Delegations: delegations,
+		},
+	}
+	encoded, err := marshalPayload(coordPayload)
+	if err != nil {
+		return err
+	}
+	coordJob := db.Job{
+		ID:      coordID,
+		Agent:   event.LeadAgent,
+		Type:    "review_coordinator",
+		State:   string(JobSucceeded),
+		Payload: encoded,
+	}
+	if err := e.Store.CreateJobWithEvent(ctx, coordJob, db.JobEvent{
+		JobID:   coordID,
+		Kind:    "risk_tier_resolved",
+		Message: fmt.Sprintf("risk tier %q (%s): %s", classification.Tier, classification.Source, classification.Reason),
+	}); err != nil {
+		return err
+	}
+	if err := e.dispatchDelegations(ctx, coordJob, coordPayload, ref); err != nil {
+		return err
 	}
 	if err := e.setTaskState(ctx, ref, TaskReviewing); err != nil {
 		return err
@@ -1709,6 +1858,9 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		SynthesisRule:   strings.TrimSpace(d.SynthesisRule),
 		Model:           strings.TrimSpace(d.Model),
 		Phase:           strings.TrimSpace(d.Phase),
+		// Inherit the coordinator's resolved risk tier (#650) so a high-risk lens
+		// child carries it for explainable escalation. Empty for every non-risk tree.
+		RiskTier: strings.TrimSpace(payload.RiskTier),
 		// Cockpit settings are inherited from the coordinator so every delegation
 		// subagent in one tree renders a pane under the same workspace/session.
 		Cockpit:        payload.Cockpit,

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -924,12 +924,23 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 		labels, changedPaths := event.Labels, event.ChangedPaths
 		// The in-process implement->PR trigger carries no GitHub file data. Resolve
 		// the classifier's signals through the best-effort seam when the event has
-		// none and the seam is wired. A lookup error leaves the signals empty, so the
-		// change classifies routine rather than blocking the review.
+		// none and the seam is wired.
 		if len(labels) == 0 && len(changedPaths) == 0 && e.PullRequestSignals != nil && event.PullRequest > 0 {
-			if l, p, err := e.PullRequestSignals(ctx, event.Repo, event.PullRequest); err == nil {
-				labels, changedPaths = l, p
+			l, p, err := e.PullRequestSignals(ctx, event.Repo, event.PullRequest)
+			if err != nil {
+				// The signals are UNKNOWN this poll (a transient GitHub error). Do NOT
+				// fall through to the routine single-review fan-out: committing this head
+				// to a routine review job would let a later poll (seam recovered ->
+				// `high`) dispatch the lens quorum onto the SAME review round, so a routine
+				// single review and the high-risk lens quorum would coexist and the routine
+				// reviewer's approval could drive the merge gate without ever satisfying the
+				// adversarial quorum. Defer classification to the next poll instead: the
+				// daemon re-fires HandlePullRequestOpened at the same head, and the routine
+				// path stays reachable if the seam keeps resolving `routine`. Only record
+				// the PR baseline (idempotent) so nothing is dispatched this poll.
+				return e.recordPullRequestBaseline(ctx, event)
 			}
+			labels, changedPaths = l, p
 		}
 		classification := ClassifyRisk(e.HighRiskPaths, e.RiskLabelHigh, e.RiskLabelRoutine, labels, changedPaths)
 		if classification.Tier == RiskTierHigh {
@@ -1335,6 +1346,38 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 	}
 	ref := taskRefFromPayload(payload)
 
+	// High-risk lens normalization (#650). A refutation lens may report a CRITICAL
+	// finding in AgentResult.Findings yet leave its OWN decision at
+	// approved/changes_requested — the documented convention (SynthesizeLensDecision)
+	// is that a critical refutation blocks the merge, but a reviewer that does not
+	// self-normalize would otherwise let the change through. Convert a critical
+	// refutation into a non-approving `blocked` decision (and terminal state) BEFORE
+	// any advance so BOTH the cross-lens quorum synthesis AND the native
+	// required-reviewer merge gate observe the block. Gated on RiskTier == high, so
+	// every routine/non-lens job (empty RiskTier) is byte-identical; a no-op when the
+	// lens reported no critical finding or already decided `blocked`.
+	if job.Type == "review" && payload.RiskTier == RiskTierHigh && payload.Result != nil &&
+		payload.Result.Decision != "blocked" &&
+		SynthesizeLensDecision(ParseLensFindings(payload.Result.Findings)) == "blocked" {
+		payload.Result.Decision = "blocked"
+		encoded, err := marshalPayload(payload)
+		if err != nil {
+			return err
+		}
+		if err := e.Store.UpdateJobPayload(ctx, jobID, encoded); err != nil {
+			return err
+		}
+		if err := e.Store.UpdateJobState(ctx, jobID, string(JobBlocked)); err != nil {
+			return err
+		}
+		job.State = string(JobBlocked)
+		_ = e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   jobID,
+			Kind:    "lens_critical_refutation",
+			Message: "a critical refutation finding normalized the lens decision to blocked",
+		})
+	}
+
 	// A read-only delegation child runs in a throwaway detached worktree; dispose
 	// it once the child is terminal. Deferred so it fires on every return path
 	// below (the delegation DAG early-returns for policy-handled failures and
@@ -1591,6 +1634,24 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			})
 			return nil
 		case "approved":
+			// High-risk review (#650): the native required-reviewer gate approves a PR
+			// as soon as every required reviewer has ONE approving review in the round.
+			// With the lens fan-out that is too weak — a single approving lens (or one
+			// approving lens per reviewer) would drive the merge before the sibling
+			// refutation lenses even finish, defeating the adversarial quorum. Gate the
+			// native merge on the coordinator's quorum being satisfied first, so an
+			// approving lens can only advance toward merge once EVERY lens has approved.
+			// A critical/changes_requested lens leaves the quorum unmet (and its own
+			// terminal advance blocks the task), so this never merges a refuted change.
+			if payload.RiskTier == RiskTierHigh {
+				quorumMet, err := e.highRiskLensQuorumMet(ctx, payload)
+				if err != nil {
+					return err
+				}
+				if !quorumMet {
+					return e.setReviewingIfNotChangesRequested(ctx, ref)
+				}
+			}
 			ready, err := e.allRequiredReviewersApproved(ctx, reviewer, payload)
 			if err != nil {
 				return err
@@ -3362,6 +3423,10 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 			TaskTitle:          parentPayload.TaskTitle,
 			LeadAgent:          parentPayload.LeadAgent,
 			Reviewers:          parentPayload.Reviewers,
+			// Carry the resolved risk tier forward (#650) so a high-risk coordinator's
+			// synthesis-only continuation is recognized as such at dispatch (it need not
+			// grant the synthetic lead `ask` capability). Empty for every non-risk tree.
+			RiskTier:           parentPayload.RiskTier,
 			Sender:             parentJob.Agent,
 			Instructions:       buildCorrectiveContinuationPrompt(goal, parentResult),
 			Constraints:        parentPayload.Constraints,
@@ -3454,6 +3519,10 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 			TaskTitle:          parentPayload.TaskTitle,
 			LeadAgent:          parentPayload.LeadAgent,
 			Reviewers:          parentPayload.Reviewers,
+			// Carry the resolved risk tier forward (#650) so a high-risk coordinator's
+			// synthesis-only continuation is recognized as such at dispatch (it need not
+			// grant the synthetic lead `ask` capability). Empty for every non-risk tree.
+			RiskTier:           parentPayload.RiskTier,
 			Sender:             parentJob.Agent,
 			Instructions:       buildVerifyReplanContinuationPrompt(goal, parentResult, children, childPayloads, attempt, attemptCap),
 			Constraints:        parentPayload.Constraints,
@@ -3516,6 +3585,10 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		TaskTitle:          parentPayload.TaskTitle,
 		LeadAgent:          parentPayload.LeadAgent,
 		Reviewers:          parentPayload.Reviewers,
+		// Carry the resolved risk tier forward (#650) so a high-risk coordinator's
+		// synthesis-only continuation is recognized as such at dispatch (it need not
+		// grant the synthetic lead `ask` capability). Empty for every non-risk tree.
+		RiskTier:           parentPayload.RiskTier,
 		Sender:             parentJob.Agent,
 		// Budget-pressure nudge (#418): when the tree is near a depth/job bound, bias
 		// the coordinator toward synthesizing now over more fan-out. The job count is
@@ -4415,9 +4488,15 @@ func delegationQuorumThreshold(delegations []Delegation) int {
 }
 
 // delegationQuorumSatisfied reports whether at least k children reached an
-// approving outcome: a succeeded job state, or a child result decision of
-// approved/succeeded/implemented (the same approving-outcome test the vote rule
-// uses).
+// approving outcome. It is DECISION-FIRST, mirroring verifyVerdictPassed: whenever
+// a child produced a parsed result its decision is the vote
+// (approved/succeeded/implemented approve; changes_requested/blocked/failed do
+// NOT), and only a child with no parsed result falls back to the succeeded job
+// state. Consulting the decision first is load-bearing for the high-risk review
+// quorum (#650): a review's changes_requested decision maps to a SUCCEEDED job
+// state (stateForDecision), so a succeeded-state short-circuit would count a lens
+// that asked for changes as an approving vote and let a high-risk PR clear the
+// quorum despite reviewers refuting it.
 func delegationQuorumSatisfied(delegations []Delegation, children map[string]db.Job, childPayloads map[string]JobPayload, k int) bool {
 	approving := 0
 	for _, d := range delegations {
@@ -4425,19 +4504,60 @@ func delegationQuorumSatisfied(delegations []Delegation, children map[string]db.
 		if !ok {
 			continue
 		}
+		if payload, ok := childPayloads[d.ID]; ok && payload.Result != nil {
+			if delegationDecisionApproves(payload.Result.Decision) {
+				approving++
+			}
+			continue
+		}
 		if child.State == string(JobSucceeded) {
-			approving++
-			continue
-		}
-		payload, ok := childPayloads[d.ID]
-		if !ok || payload.Result == nil {
-			continue
-		}
-		if delegationDecisionApproves(payload.Result.Decision) {
 			approving++
 		}
 	}
 	return approving >= k
+}
+
+// highRiskLensQuorumMet reports whether the high-risk review coordinator that owns
+// a lens child (childPayload.ParentJobID) has its cross-lens quorum satisfied
+// (#650). It is the gate the native required-reviewer merge path consults for a
+// high-risk lens child so an approving lens cannot drive the merge before every
+// sibling refutation lens has approved. It fails OPEN (returns true) for a child
+// with no coordinator, a missing/pruned coordinator, or a coordinator carrying no
+// quorum rule, so it only ever ADDS a wait for a genuine quorum tree and never
+// strands a non-quorum review.
+func (e Engine) highRiskLensQuorumMet(ctx context.Context, childPayload JobPayload) (bool, error) {
+	coordID := strings.TrimSpace(childPayload.ParentJobID)
+	if coordID == "" {
+		return true, nil
+	}
+	coord, err := e.Store.GetJob(ctx, coordID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return true, nil
+		}
+		return false, err
+	}
+	coordPayload, err := unmarshalPayload(coord.Payload)
+	if err != nil {
+		return false, err
+	}
+	if coordPayload.Result == nil || !delegationSynthesisRequiresQuorum(coordPayload.Result.Delegations) {
+		return true, nil
+	}
+	children, err := e.childDelegationJobs(ctx, coordID)
+	if err != nil {
+		return false, err
+	}
+	childPayloads := make(map[string]JobPayload, len(children))
+	for id, child := range children {
+		payload, err := unmarshalPayload(child.Payload)
+		if err != nil {
+			return false, err
+		}
+		childPayloads[id] = payload
+	}
+	k := delegationQuorumThreshold(coordPayload.Result.Delegations)
+	return delegationQuorumSatisfied(coordPayload.Result.Delegations, children, childPayloads, k), nil
 }
 
 func delegationDecisionApproves(decision string) bool {
@@ -4966,6 +5086,17 @@ func (e Engine) ensureJobExecutorAllowed(ctx context.Context, job db.Job, payloa
 	allowMissingCapability := job.Type == "ask" &&
 		payload.DelegationReason == "temp_worker_merge_back" &&
 		payload.OriginalAgent == job.Agent
+	// Risk-tiered synthesis continuation (#650): the high-risk review coordinator is
+	// a SYNTHETIC job the engine seeds on the LEAD agent, and its continuation
+	// (maybeEnqueueContinuation) is an `ask` job on that same lead. A normal lead
+	// carries implement/review but need not carry `ask`, so requiring `ask` here
+	// would BLOCK the synthesis of an already-approved high-risk review — a
+	// non-additive capability demand the routine review path never imposed. The
+	// continuation is synthesis-only (it summarizes the lens findings; it does not
+	// grant any write/review authority), so allow it to run without the `ask` grant.
+	if job.Type == "ask" && payload.RiskTier == RiskTierHigh {
+		allowMissingCapability = true
+	}
 	return e.ensureAgentAllowedWithBranchOwner(ctx, JobRequest{
 		Agent:        authorizationAgent,
 		Action:       job.Type,

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -157,6 +157,11 @@ type JobRequest struct {
 	// coordinator continuation enqueued by the `answer` resume verb. Empty for
 	// every other job, so the stored payload is byte-identical by default.
 	HumanAnswer string
+	// RiskTier is the resolved risk-tier of the change (#650), stamped on a
+	// high-risk review coordinator and inherited by its lens children so reports
+	// and the dashboard can explain an escalation. Empty (the default) for every
+	// job outside the opt-in risk-tiered path.
+	RiskTier string
 }
 
 type JobPayload struct {
@@ -208,8 +213,13 @@ type JobPayload struct {
 	SkipNativeReviewFanout bool           `json:"skip_native_review_fanout,omitempty"`
 	Ephemeral              *EphemeralSpec `json:"ephemeral,omitempty"`
 	HumanAnswer            string         `json:"human_answer,omitempty"`
-	RawOutputs             []string       `json:"raw_outputs,omitempty"`
-	Result                 *AgentResult   `json:"result,omitempty"`
+	// RiskTier is the resolved risk-tier of the change (#650), additive/omitempty
+	// so a payload outside the opt-in risk-tiered review path serializes
+	// byte-identically. It is stamped on a high-risk review coordinator and
+	// inherited by its lens children for explainable escalation.
+	RiskTier   string       `json:"risk_tier,omitempty"`
+	RawOutputs []string     `json:"raw_outputs,omitempty"`
+	Result     *AgentResult `json:"result,omitempty"`
 	// Operational-blocker deferral context (#532, additive — all omitempty, so a
 	// job that never hit a classified blocker serializes byte-identically).
 	// BlockerClass is the last classified blocker (e.g. "runtime_auth",
@@ -308,6 +318,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		SkipNativeReviewFanout: request.SkipNativeReviewFanout,
 		Ephemeral:              request.Ephemeral,
 		HumanAnswer:            request.HumanAnswer,
+		RiskTier:               strings.TrimSpace(request.RiskTier),
 	})
 	if err != nil {
 		return db.Job{}, err

--- a/internal/workflow/risk.go
+++ b/internal/workflow/risk.go
@@ -1,0 +1,299 @@
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// Risk-tiered adaptive review (#650). This file is the OPT-IN classifier + lens
+// vocabulary that scales review depth to the blast radius of a change. It is
+// fully additive: with [review].risk_tiers_enabled off (the default) the engine
+// never calls ClassifyRisk, so HandlePullRequestOpened's single-review fan-out is
+// byte-identical. When enabled, a PR classified `high` fans out a delegation
+// batch of refutation-framed lens reviewers whose outcomes are synthesized by the
+// EXISTING delegation synthesis_rule engine (quorum) rather than any bespoke
+// synthesis. Competition (two implementations + a judge) is intentionally OUT OF
+// SCOPE here and tracked as a follow-up.
+
+// RiskTier is the resolved risk level of a change. Only two tiers are wired in
+// this slice: `routine` (the default, single-review path) and `high` (the
+// adversarial multi-lens path). The intermediate/competition tiers from the
+// ultraswarm eval are deliberately not modeled yet.
+const (
+	RiskTierRoutine = "routine"
+	RiskTierHigh    = "high"
+)
+
+// DefaultHighRiskPaths is the built-in glob list a change is matched against when
+// [review].high_risk_paths is not configured. These are the blast-radius-heavy
+// areas (auth, security, payments, DB migrations, and the module manifest) that
+// warrant adversarial review. `**` matches any number of path segments; `*`
+// matches within a single segment.
+var DefaultHighRiskPaths = []string{
+	"**/auth/**",
+	"**/security/**",
+	"**/payment/**",
+	"**/migration/**",
+	"go.mod",
+}
+
+// Risk-signal label defaults. An explicit PR label wins over path heuristics so a
+// human can force a tier either way (escalate a subtle change, or de-escalate a
+// noisy path match). These are the label NAMES matched case-insensitively against
+// the PR's labels.
+const (
+	DefaultRiskLabelHigh    = "risk:high"
+	DefaultRiskLabelRoutine = "risk:routine"
+)
+
+// RiskClassification is the resolved tier plus a short, human-readable reason and
+// the signal source that decided it ("label" | "path" | "default"). The reason is
+// recorded as a job event so an escalation is explainable in the report/dashboard.
+type RiskClassification struct {
+	Tier   string
+	Source string
+	Reason string
+}
+
+// ClassifyRisk resolves a change's risk tier from, in priority order: an explicit
+// PR label (high/routine label wins over paths), then a changed-path glob match
+// against highRiskPaths, then the default `routine`. labelHigh/labelRoutine and
+// highRiskPaths fall back to the built-in defaults when empty. It is a pure
+// function of its inputs so it is exhaustively unit-testable.
+func ClassifyRisk(highRiskPaths []string, labelHigh, labelRoutine string, labels, changedPaths []string) RiskClassification {
+	labelHigh = strings.TrimSpace(labelHigh)
+	if labelHigh == "" {
+		labelHigh = DefaultRiskLabelHigh
+	}
+	labelRoutine = strings.TrimSpace(labelRoutine)
+	if labelRoutine == "" {
+		labelRoutine = DefaultRiskLabelRoutine
+	}
+	if len(highRiskPaths) == 0 {
+		highRiskPaths = DefaultHighRiskPaths
+	}
+
+	// 1) Explicit label wins over path heuristics. A high label escalates; a
+	// routine label de-escalates. If (pathologically) both are present, high wins
+	// — a safety-biased tie-break so a mislabeled change is never under-reviewed.
+	hasHigh, hasRoutine := false, false
+	for _, l := range labels {
+		switch strings.ToLower(strings.TrimSpace(l)) {
+		case strings.ToLower(labelHigh):
+			hasHigh = true
+		case strings.ToLower(labelRoutine):
+			hasRoutine = true
+		}
+	}
+	if hasHigh {
+		return RiskClassification{Tier: RiskTierHigh, Source: "label", Reason: fmt.Sprintf("PR carries the %q label", labelHigh)}
+	}
+	if hasRoutine {
+		return RiskClassification{Tier: RiskTierRoutine, Source: "label", Reason: fmt.Sprintf("PR carries the %q label", labelRoutine)}
+	}
+
+	// 2) Changed-path glob match.
+	for _, path := range changedPaths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if pattern, ok := matchAnyGlob(path, highRiskPaths); ok {
+			return RiskClassification{
+				Tier:   RiskTierHigh,
+				Source: "path",
+				Reason: fmt.Sprintf("changed path %q matches high-risk glob %q", path, pattern),
+			}
+		}
+	}
+
+	// 3) Default.
+	return RiskClassification{Tier: RiskTierRoutine, Source: "default", Reason: "no high-risk label or path matched"}
+}
+
+// matchAnyGlob returns the first glob in globs that matches path, if any.
+func matchAnyGlob(path string, globs []string) (string, bool) {
+	for _, g := range globs {
+		g = strings.TrimSpace(g)
+		if g == "" {
+			continue
+		}
+		if globMatch(g, path) {
+			return g, true
+		}
+	}
+	return "", false
+}
+
+// globMatch reports whether the `**`-aware glob pattern matches the /-separated
+// path. `**` matches zero or more whole path segments; within a single segment,
+// `*` and `?` behave as filepath.Match. Paths are normalized to forward slashes.
+func globMatch(pattern, path string) bool {
+	pattern = strings.TrimPrefix(filepath.ToSlash(pattern), "./")
+	path = strings.TrimPrefix(filepath.ToSlash(path), "./")
+	return matchSegments(strings.Split(pattern, "/"), strings.Split(path, "/"))
+}
+
+func matchSegments(pat, name []string) bool {
+	for len(pat) > 0 {
+		if pat[0] == "**" {
+			// `**` matches zero segments (advance the pattern) …
+			if matchSegments(pat[1:], name) {
+				return true
+			}
+			// … or one-or-more segments (consume a name segment, keep `**`).
+			if len(name) > 0 {
+				return matchSegments(pat, name[1:])
+			}
+			return false
+		}
+		if len(name) == 0 {
+			return false
+		}
+		ok, err := filepath.Match(pat[0], name[0])
+		if err != nil || !ok {
+			return false
+		}
+		pat = pat[1:]
+		name = name[1:]
+	}
+	return len(name) == 0
+}
+
+// Lens vocabulary. Each lens is a refutation-framed reviewer that is prompted to
+// actively DISPROVE the change along one axis and report structured findings. The
+// lens names double as the delegation ids of the high-risk fan-out.
+const (
+	LensCorrectness = "correctness"
+	LensSecurity    = "security"
+	LensRegression  = "regression"
+)
+
+// Severity values for a LensFinding. Only `critical` is load-bearing for
+// synthesis: a critical refutation blocks the merge (fails the quorum); the
+// lower severities are advisory and recorded for explainability.
+const (
+	SeverityCritical = "critical"
+	SeverityHigh     = "high"
+	SeverityMedium   = "medium"
+	SeverityLow      = "low"
+)
+
+// LensFinding is the documented convention a lens reviewer returns in
+// AgentResult.Findings ([]json.RawMessage). It is NOT a contract change: findings
+// remains a free-form raw-message list, and this struct is only the agreed shape
+// the synthesizer parses. A reviewer that returns findings in another shape is
+// simply treated as having reported no critical refutation.
+type LensFinding struct {
+	// Lens is which axis produced the finding (correctness/security/regression).
+	Lens string `json:"lens"`
+	// Refuted is true when the reviewer believes it DISPROVED the change on this
+	// axis (found a real defect), false when the change survived the lens.
+	Refuted bool `json:"refuted"`
+	// Severity grades a refutation; `critical` is the only blocking level.
+	Severity string `json:"severity"`
+	// Confidence is the reviewer's [0,1] self-reported confidence in the finding.
+	Confidence float64 `json:"confidence"`
+	// Evidence is a short human-readable justification (file:line, a failing case).
+	Evidence string `json:"evidence"`
+}
+
+// ParseLensFindings best-effort decodes the {lens, refuted, severity, confidence,
+// evidence} convention out of a result's raw findings. Malformed entries are
+// skipped rather than erroring, so a reviewer that mixes shapes still contributes
+// its well-formed findings.
+func ParseLensFindings(raw []json.RawMessage) []LensFinding {
+	out := make([]LensFinding, 0, len(raw))
+	for _, r := range raw {
+		var f LensFinding
+		if err := json.Unmarshal(r, &f); err != nil {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// SynthesizeLensDecision maps a single lens reviewer's findings to the decision it
+// should return so the EXISTING quorum synthesis engine can act on it mechanically:
+// any refuted, critical-severity finding blocks the merge (decision `blocked`,
+// which is a NON-approving quorum outcome); otherwise the lens `approved`. This is
+// the per-reviewer finding→decision convention, NOT a synthesis engine — the
+// cross-lens synthesis is the delegation synthesis_rule quorum gate.
+func SynthesizeLensDecision(findings []LensFinding) string {
+	for _, f := range findings {
+		if f.Refuted && strings.EqualFold(strings.TrimSpace(f.Severity), SeverityCritical) {
+			return "blocked"
+		}
+	}
+	return "approved"
+}
+
+// lensPrompt returns the refutation-framed reviewer prompt for a lens on a given
+// pull request. Each lens is told to actively DISPROVE the change on its axis and
+// to return the structured {lens, refuted, severity, confidence, evidence}
+// findings the synthesizer reads. A critical refutation must be reported as a
+// `blocked` decision so it fails the quorum and blocks the merge.
+func lensPrompt(lens string, event PullRequestEvent) string {
+	var axis string
+	switch lens {
+	case LensCorrectness:
+		axis = "CORRECTNESS: hunt for logic errors, unhandled edge cases, race conditions, " +
+			"broken invariants, and incorrect error handling. Try to construct an input or state that makes the change produce a wrong result."
+	case LensSecurity:
+		axis = "SECURITY: hunt for injection, authn/authz gaps, secret/credential exposure, unsafe deserialization, " +
+			"missing input validation, and privilege escalation. Try to construct an exploit against the change."
+	case LensRegression:
+		axis = "REGRESSION: hunt for behavior the change silently alters — removed/weakened tests, changed public contracts, " +
+			"altered defaults, and side effects on unrelated call sites. Try to name an existing behavior the change breaks."
+	default:
+		axis = strings.ToUpper(lens)
+	}
+	return fmt.Sprintf(
+		"You are the %s LENS on a HIGH-RISK review of pull request #%d for task %s. "+
+			"Adopt a refutation stance: assume the change is WRONG and try to prove it along one axis.\n\n%s\n\n"+
+			"Return gitmoot_result with a refutation-framed decision and structured findings. "+
+			"Each finding is an object {\"lens\":%q,\"refuted\":true|false,\"severity\":\"critical|high|medium|low\",\"confidence\":0..1,\"evidence\":\"file:line — why\"}. "+
+			"If you find a CRITICAL refutation, set decision to \"blocked\" (this blocks the merge); "+
+			"otherwise set decision to \"approved\" and record any lower-severity findings as advisory.",
+		strings.ToUpper(lens), event.PullRequest, taskLabel(event.TaskID, event.TaskTitle), axis, lens,
+	)
+}
+
+// highRiskLensDelegations builds the refutation lens delegation batch for a
+// high-risk PR. It always produces at least 2 lenses (correctness, security) and
+// adds regression when there are >= 3 reviewers to run it (cheap). Each lens is a
+// read-only review delegation tagged synthesis_rule "quorum" with the quorum
+// threshold set to the full lens count, so ANY non-approving lens (a critical
+// refutation, reported as `blocked`) fails the quorum and blocks the merge, while
+// unanimous approval satisfies it. Reviewers are assigned round-robin; with a
+// single configured reviewer every lens runs as a distinct job on that reviewer.
+func highRiskLensDelegations(reviewers []string, event PullRequestEvent) []Delegation {
+	reviewers = compactStrings(reviewers)
+	if len(reviewers) == 0 {
+		return nil
+	}
+	lenses := []string{LensCorrectness, LensSecurity}
+	if len(reviewers) >= 3 {
+		lenses = append(lenses, LensRegression)
+	}
+	quorum := len(lenses)
+	dels := make([]Delegation, 0, len(lenses))
+	for i, lens := range lenses {
+		dels = append(dels, Delegation{
+			ID:            lens,
+			Agent:         reviewers[i%len(reviewers)],
+			Action:        "review",
+			Prompt:        lensPrompt(lens, event),
+			SynthesisRule: "quorum",
+			Quorum:        quorum,
+			// A refuting lens must not fail the whole tree — its `blocked` decision is a
+			// quorum SIGNAL, not an infra failure — so let siblings finish and let the
+			// quorum gate render the verdict.
+			FailurePolicy: "continue",
+		})
+	}
+	return dels
+}

--- a/internal/workflow/risk_review_test.go
+++ b/internal/workflow/risk_review_test.go
@@ -1,0 +1,323 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func highRiskEvent() PullRequestEvent {
+	return PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		GoalID:            "goal-1",
+		TaskID:            "task-7",
+		TaskTitle:         "Auth change",
+		LeadAgent:         "lead",
+		Sender:            "lead",
+		RequiredReviewers: []string{"audit", "sec"},
+		ChangedPaths:      []string{"internal/auth/session.go"},
+	}
+}
+
+// TestHighRiskPRFansOutLensReviewers pins the core acceptance behavior: an
+// enabled + high-risk PR event fans out >= 2 lens review jobs (not the single
+// native fan-out), seeds a review coordinator carrying synthesis_rule quorum, and
+// records the resolved risk as an explainable job event.
+func TestHighRiskPRFansOutLensReviewers(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	if err := engine.HandlePullRequestOpened(ctx, highRiskEvent()); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReviewing)
+
+	coordID := "review-coordinator/task-7/review-1"
+	coord := mustJob(t, store, coordID)
+	if coord.Type != "review_coordinator" {
+		t.Fatalf("coordinator type = %q, want review_coordinator", coord.Type)
+	}
+	if got := countJobEvents(t, store, coordID, "risk_tier_resolved"); got != 1 {
+		t.Fatalf("risk_tier_resolved events = %d, want 1", got)
+	}
+
+	lensIDs := []string{
+		coordID + "/delegation/" + LensCorrectness,
+		coordID + "/delegation/" + LensSecurity,
+	}
+	n := 0
+	for _, id := range lensIDs {
+		if !jobExists(t, store, id) {
+			t.Fatalf("expected lens review job %q to be enqueued", id)
+		}
+		job := mustJob(t, store, id)
+		if job.Type != "review" || job.State != string(JobQueued) {
+			t.Fatalf("lens job %q = type %q state %q, want queued review", id, job.Type, job.State)
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			t.Fatalf("unmarshal lens payload: %v", err)
+		}
+		if payload.SynthesisRule != "quorum" {
+			t.Fatalf("lens %q synthesis_rule = %q, want quorum", id, payload.SynthesisRule)
+		}
+		if payload.RiskTier != RiskTierHigh {
+			t.Fatalf("lens %q risk_tier = %q, want high", id, payload.RiskTier)
+		}
+		n++
+	}
+	if n < 2 {
+		t.Fatalf("fanned out %d lens reviewers, want >= 2", n)
+	}
+	// The single-review job the routine path would have created must NOT exist.
+	if jobExists(t, store, "review-audit-task-7-review-1") {
+		t.Fatal("high-risk path must NOT enqueue the single native review job")
+	}
+}
+
+// TestHighRiskCriticalRefutationBlocks is the deterministic no-LLM E2E: it drives
+// a high-risk PR through fan-out and then lands one lens with a critical
+// refutation (a `blocked` decision, a non-approving quorum outcome). The quorum
+// gate must fail and block the shared task — the "blocks on a critical refutation"
+// acceptance behavior — with no coordinator continuation enqueued.
+func TestHighRiskCriticalRefutationBlocks(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	if err := engine.HandlePullRequestOpened(ctx, highRiskEvent()); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	coordID := "review-coordinator/task-7/review-1"
+	correctnessID := coordID + "/delegation/" + LensCorrectness
+	securityID := coordID + "/delegation/" + LensSecurity
+
+	// Correctness lens approves (survives the lens).
+	completeDelegationChild(t, store, correctnessID, JobSucceeded, AgentResult{
+		Decision: "approved",
+		Summary:  "no correctness defect",
+	})
+	if err := engine.AdvanceJob(ctx, correctnessID); err != nil {
+		t.Fatalf("AdvanceJob(correctness) returned error: %v", err)
+	}
+
+	// Security lens reports a CRITICAL refutation via findings and blocks.
+	critical, _ := json.Marshal(LensFinding{
+		Lens: LensSecurity, Refuted: true, Severity: SeverityCritical, Confidence: 0.95, Evidence: "auth bypass at session.go:41",
+	})
+	blockDecision := SynthesizeLensDecision([]LensFinding{{Refuted: true, Severity: SeverityCritical}})
+	completeDelegationChild(t, store, securityID, stateForDecision(blockDecision), AgentResult{
+		Decision: blockDecision,
+		Summary:  "critical auth bypass",
+		Findings: []json.RawMessage{critical},
+	})
+	err := engine.AdvanceJob(ctx, securityID)
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("AdvanceJob(security) error = %v, want BlockedError (quorum failed)", err)
+	}
+	if !strings.Contains(blocked.Reason, "quorum") {
+		t.Fatalf("block reason = %q, want quorum-failure reason", blocked.Reason)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+	if jobExists(t, store, delegationContinuationID(coordID)) {
+		t.Fatal("a failed quorum must NOT enqueue a coordinator continuation")
+	}
+}
+
+// TestHighRiskAllLensesApproveSatisfiesQuorum pins the other side of the
+// synthesis mapping: when every lens approves, the quorum is satisfied and the
+// coordinator continuation is enqueued (the task is not blocked).
+func TestHighRiskAllLensesApproveSatisfiesQuorum(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement", "ask"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	if err := engine.HandlePullRequestOpened(ctx, highRiskEvent()); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	coordID := "review-coordinator/task-7/review-1"
+	for _, lens := range []string{LensCorrectness, LensSecurity} {
+		id := coordID + "/delegation/" + lens
+		completeDelegationChild(t, store, id, JobSucceeded, AgentResult{Decision: "approved", Summary: "clean"})
+		if err := engine.AdvanceJob(ctx, id); err != nil {
+			t.Fatalf("AdvanceJob(%s) returned error: %v", lens, err)
+		}
+	}
+	if !jobExists(t, store, delegationContinuationID(coordID)) {
+		t.Fatal("a satisfied quorum must enqueue the coordinator continuation")
+	}
+	if task, _ := store.GetTask(ctx, "task-7"); task.State == string(TaskBlocked) {
+		t.Fatal("a satisfied quorum must not block the task")
+	}
+}
+
+// TestPullRequestSignalsSeamClassifiesInProcess pins the in-process trigger path:
+// when an event carries no risk signals, the engine resolves them through the
+// best-effort PullRequestSignals seam and classifies from those.
+func TestPullRequestSignalsSeamClassifiesInProcess(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+	called := 0
+	engine.PullRequestSignals = func(_ context.Context, repo string, number int) ([]string, []string, error) {
+		called++
+		if repo != "jerryfane/gitmoot" || number != 7 {
+			t.Fatalf("seam called with repo=%q number=%d", repo, number)
+		}
+		return nil, []string{"internal/auth/session.go"}, nil
+	}
+
+	event := PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		TaskID:            "task-7",
+		TaskTitle:         "Auth change",
+		LeadAgent:         "lead",
+		Sender:            "lead",
+		RequiredReviewers: []string{"audit", "sec"},
+		// No Labels/ChangedPaths on the event -> the seam supplies them.
+	}
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("PullRequestSignals called %d times, want 1", called)
+	}
+	if !jobExists(t, store, "review-coordinator/task-7/review-1") {
+		t.Fatal("seam-resolved high-risk path must create the coordinator")
+	}
+}
+
+func TestPullRequestSignalsSeamSkippedWhenEventCarriesSignals(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+	engine.PullRequestSignals = func(context.Context, string, int) ([]string, []string, error) {
+		t.Fatal("seam must not be consulted when the event already carries signals")
+		return nil, nil, nil
+	}
+	event := PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		TaskID:            "task-7",
+		TaskTitle:         "Docs",
+		LeadAgent:         "lead",
+		Sender:            "lead",
+		RequiredReviewers: []string{"audit"},
+		ChangedPaths:      []string{"README.md"},
+	}
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	// Event signals are routine -> single review path, no coordinator.
+	if jobExists(t, store, "review-coordinator/task-7/review-1") {
+		t.Fatal("routine event signals must not create a coordinator")
+	}
+}
+
+// TestRiskTiersOffIsByteIdentical is the invariant test: with risk tiers OFF, a
+// PR whose changed paths WOULD classify high still takes the single native
+// review fan-out, byte-for-byte identical to a control with no risk signals. No
+// coordinator is created and the payloads match exactly.
+func TestRiskTiersOffIsByteIdentical(t *testing.T) {
+	run := func(t *testing.T, enabled bool, withSignals bool) string {
+		store := openEngineStore(t)
+		seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+		seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+		engine := testEngine(store)
+		engine.RiskTiersEnabled = enabled
+		event := PullRequestEvent{
+			Repo:              "jerryfane/gitmoot",
+			Branch:            "task-7",
+			PullRequest:       7,
+			GoalID:            "goal-1",
+			TaskID:            "task-7",
+			TaskTitle:         "Workflow Engine",
+			LeadAgent:         "lead",
+			Sender:            "lead",
+			RequiredReviewers: []string{"audit"},
+		}
+		if withSignals {
+			event.ChangedPaths = []string{"internal/auth/session.go"}
+			event.Labels = []string{"risk:high"}
+		}
+		if err := engine.HandlePullRequestOpened(context.Background(), event); err != nil {
+			t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+		}
+		// The single native review job must exist; no coordinator.
+		if jobExists(t, store, "review-coordinator/task-7/review-1") {
+			t.Fatal("risk-tiers-off path must not create a coordinator")
+		}
+		job := mustJob(t, store, "review-audit-task-7-review-1")
+		return job.Payload
+	}
+
+	// Control: risk tiers off, no signals.
+	control := run(t, false, false)
+	// Off but signals present on the event (the daemon never populates them when
+	// off, but assert defensively that the engine ignores them).
+	offWithSignals := run(t, false, true)
+	if control != offWithSignals {
+		t.Fatalf("risk-tiers-off payload changed when signals were present:\n control=%s\n signals=%s", control, offWithSignals)
+	}
+}
+
+// TestRiskTiersEnabledRoutineTakesSingleReviewPath pins that an ENABLED engine on
+// a ROUTINE-classified PR still uses the unchanged single-review fan-out.
+func TestRiskTiersEnabledRoutineTakesSingleReviewPath(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		TaskID:            "task-7",
+		TaskTitle:         "Docs tweak",
+		LeadAgent:         "lead",
+		Sender:            "lead",
+		RequiredReviewers: []string{"audit"},
+		ChangedPaths:      []string{"README.md", "docs/guide.md"},
+	})
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	if jobExists(t, store, "review-coordinator/task-7/review-1") {
+		t.Fatal("routine tier must not create a coordinator")
+	}
+	if !jobExists(t, store, "review-audit-task-7-review-1") {
+		t.Fatal("routine tier must take the single native review path")
+	}
+}

--- a/internal/workflow/risk_review_test.go
+++ b/internal/workflow/risk_review_test.go
@@ -170,6 +170,234 @@ func TestHighRiskAllLensesApproveSatisfiesQuorum(t *testing.T) {
 	}
 }
 
+// TestHighRiskChangesRequestedLensFailsQuorum pins the #650 review fix: a lens
+// that returns `changes_requested` (a valid "real issue, not fatal" reviewer
+// decision that maps to a SUCCEEDED job state) must NOT count as an approving
+// quorum vote. The quorum stays unmet and the shared task blocks — a
+// changes-requested lens can never clear the high-risk gate on a succeeded-state
+// short-circuit.
+func TestHighRiskChangesRequestedLensFailsQuorum(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	if err := engine.HandlePullRequestOpened(ctx, highRiskEvent()); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	coordID := "review-coordinator/task-7/review-1"
+	correctnessID := coordID + "/delegation/" + LensCorrectness
+	securityID := coordID + "/delegation/" + LensSecurity
+
+	// Correctness approves.
+	completeDelegationChild(t, store, correctnessID, JobSucceeded, AgentResult{Decision: "approved", Summary: "ok"})
+	if err := engine.AdvanceJob(ctx, correctnessID); err != nil {
+		t.Fatalf("AdvanceJob(correctness) returned error: %v", err)
+	}
+	// Security asks for changes (a SUCCEEDED job state per stateForDecision).
+	completeDelegationChild(t, store, securityID, stateForDecision("changes_requested"), AgentResult{
+		Decision: "changes_requested",
+		Summary:  "please add input validation",
+	})
+	err := engine.AdvanceJob(ctx, securityID)
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("AdvanceJob(security) error = %v, want BlockedError (quorum unmet)", err)
+	}
+	if !strings.Contains(blocked.Reason, "quorum") {
+		t.Fatalf("block reason = %q, want quorum-failure reason", blocked.Reason)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+	if jobExists(t, store, delegationContinuationID(coordID)) {
+		t.Fatal("an unmet quorum must NOT enqueue a coordinator continuation")
+	}
+}
+
+// TestHighRiskCriticalFindingNotPreNormalizedBlocks pins that a lens which reports
+// a CRITICAL refutation in AgentResult.Findings but leaves its OWN decision at
+// `approved` still fails the quorum: the engine wires SynthesizeLensDecision into
+// the lens completion path and normalizes the approving decision to `blocked`, so
+// a critical finding can never be rubber-stamped by a reviewer that forgot to
+// self-normalize.
+func TestHighRiskCriticalFindingNotPreNormalizedBlocks(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	if err := engine.HandlePullRequestOpened(ctx, highRiskEvent()); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	coordID := "review-coordinator/task-7/review-1"
+	correctnessID := coordID + "/delegation/" + LensCorrectness
+	securityID := coordID + "/delegation/" + LensSecurity
+
+	completeDelegationChild(t, store, correctnessID, JobSucceeded, AgentResult{Decision: "approved", Summary: "ok"})
+	if err := engine.AdvanceJob(ctx, correctnessID); err != nil {
+		t.Fatalf("AdvanceJob(correctness) returned error: %v", err)
+	}
+	// Security leaves its decision at APPROVED but reports a critical refutation.
+	critical, _ := json.Marshal(LensFinding{
+		Lens: LensSecurity, Refuted: true, Severity: SeverityCritical, Confidence: 0.9, Evidence: "auth bypass at session.go:41",
+	})
+	completeDelegationChild(t, store, securityID, JobSucceeded, AgentResult{
+		Decision: "approved",
+		Summary:  "looks fine",
+		Findings: []json.RawMessage{critical},
+	})
+	err := engine.AdvanceJob(ctx, securityID)
+
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("AdvanceJob(security) error = %v, want BlockedError (critical refutation normalized)", err)
+	}
+	assertTaskState(t, store, "task-7", TaskBlocked)
+	// The lens decision was normalized to blocked and recorded as an explainable event.
+	normalized := mustJob(t, store, securityID)
+	np, err := unmarshalPayload(normalized.Payload)
+	if err != nil {
+		t.Fatalf("unmarshal security payload: %v", err)
+	}
+	if np.Result == nil || np.Result.Decision != "blocked" {
+		t.Fatalf("normalized security decision = %v, want blocked", np.Result)
+	}
+	if got := countJobEvents(t, store, securityID, "lens_critical_refutation"); got != 1 {
+		t.Fatalf("lens_critical_refutation events = %d, want 1", got)
+	}
+	if jobExists(t, store, delegationContinuationID(coordID)) {
+		t.Fatal("a critical refutation must NOT enqueue a coordinator continuation")
+	}
+}
+
+// TestHighRiskAllApproveReachesMergeWithoutAskCapability pins the #650 review fix
+// for the synthesis continuation: an all-approved high-risk review must reach
+// TaskReadyToMerge even when the LEAD agent carries NO `ask` capability, and the
+// synthesis-only coordinator continuation must be allowed at dispatch instead of
+// blocking the already-approved task. A high-risk review must not impose a
+// non-additive `ask` grant on a normal lead.
+func TestHighRiskAllApproveReachesMergeWithoutAskCapability(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	// Lead has implement + review but deliberately NOT `ask`.
+	seedAgent(t, store, "lead", []string{"implement", "review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	if err := engine.HandlePullRequestOpened(ctx, highRiskEvent()); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+	coordID := "review-coordinator/task-7/review-1"
+	for _, lens := range []string{LensCorrectness, LensSecurity} {
+		id := coordID + "/delegation/" + lens
+		completeDelegationChild(t, store, id, JobSucceeded, AgentResult{Decision: "approved", Summary: "clean"})
+		if err := engine.AdvanceJob(ctx, id); err != nil {
+			t.Fatalf("AdvanceJob(%s) returned error: %v", lens, err)
+		}
+	}
+	// The native merge gate (MergeGate nil) advances the fully-approved review.
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+
+	// The synthesis continuation was enqueued on the lead; its dispatch preflight
+	// must NOT block despite the lead lacking `ask`.
+	contID := delegationContinuationID(coordID)
+	cont := mustJob(t, store, contID)
+	if cont.Type != "ask" || cont.Agent != "lead" {
+		t.Fatalf("continuation = type %q agent %q, want ask/lead", cont.Type, cont.Agent)
+	}
+	cp, err := unmarshalPayload(cont.Payload)
+	if err != nil {
+		t.Fatalf("unmarshal continuation payload: %v", err)
+	}
+	if cp.RiskTier != RiskTierHigh {
+		t.Fatalf("continuation risk_tier = %q, want high", cp.RiskTier)
+	}
+	if err := engine.ensureJobExecutorAllowed(ctx, cont, cp, taskRefFromPayload(cp)); err != nil {
+		t.Fatalf("risk-tier synthesis continuation must not block on missing ask capability: %v", err)
+	}
+	assertTaskState(t, store, "task-7", TaskReadyToMerge)
+
+	// Control: a plain `ask` job on the same lead (no risk tier) DOES block, proving
+	// the exemption is what unblocks the synthesis continuation.
+	plainPayload := cp
+	plainPayload.RiskTier = ""
+	plainJob := cont
+	plainJob.ID = "plain-ask/task-7"
+	err = engine.ensureJobExecutorAllowed(ctx, plainJob, plainPayload, taskRefFromPayload(plainPayload))
+	var plainBlocked BlockedError
+	if !errors.As(err, &plainBlocked) {
+		t.Fatalf("a non-risk ask on a lead lacking ask must block; got %v", err)
+	}
+}
+
+// TestHighRiskSeamErrorDefersInsteadOfRoutine pins the #650 review fix for a
+// transient classification failure: when risk tiers are enabled and the
+// PullRequestSignals seam ERRORS (signals unknown), the engine must NOT fall
+// through to the routine single-review fan-out (which a later high classification
+// could no longer supersede) — it defers to the next poll. A subsequent poll whose
+// seam resolves `high` then dispatches the lens quorum cleanly, with no stray
+// routine review job coexisting on the round.
+func TestHighRiskSeamErrorDefersInsteadOfRoutine(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "jerryfane/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "jerryfane/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	fail := true
+	engine.PullRequestSignals = func(context.Context, string, int) ([]string, []string, error) {
+		if fail {
+			return nil, nil, errors.New("transient GitHub error")
+		}
+		return nil, []string{"internal/auth/session.go"}, nil
+	}
+	event := PullRequestEvent{
+		Repo:              "jerryfane/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		TaskID:            "task-7",
+		TaskTitle:         "Auth change",
+		LeadAgent:         "lead",
+		Sender:            "lead",
+		RequiredReviewers: []string{"audit", "sec"},
+		// No event signals -> the seam is consulted (and errors on poll #1).
+	}
+
+	// Poll #1: seam errors -> defer. Neither a routine single review job nor a
+	// high-risk coordinator may exist.
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("HandlePullRequestOpened (poll 1) returned error: %v", err)
+	}
+	if jobExists(t, store, "review-audit-task-7-review-1") || jobExists(t, store, "review-sec-task-7-review-1") {
+		t.Fatal("a deferred classification must NOT enqueue the routine single review job")
+	}
+	if jobExists(t, store, "review-coordinator/task-7/review-1") {
+		t.Fatal("a deferred classification must NOT dispatch the high-risk coordinator")
+	}
+
+	// Poll #2: seam recovers and resolves high -> clean lens fan-out on review-1.
+	fail = false
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("HandlePullRequestOpened (poll 2) returned error: %v", err)
+	}
+	if !jobExists(t, store, "review-coordinator/task-7/review-1") {
+		t.Fatal("the recovered high classification must dispatch the coordinator")
+	}
+	if jobExists(t, store, "review-audit-task-7-review-1") || jobExists(t, store, "review-sec-task-7-review-1") {
+		t.Fatal("no routine single review job may coexist with the lens quorum")
+	}
+}
+
 // TestPullRequestSignalsSeamClassifiesInProcess pins the in-process trigger path:
 // when an event carries no risk signals, the engine resolves them through the
 // best-effort PullRequestSignals seam and classifies from those.

--- a/internal/workflow/risk_test.go
+++ b/internal/workflow/risk_test.go
@@ -1,0 +1,189 @@
+package workflow
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestClassifyRiskDefaultRoutine(t *testing.T) {
+	got := ClassifyRisk(nil, "", "", nil, []string{"README.md", "internal/report/report.go"})
+	if got.Tier != RiskTierRoutine {
+		t.Fatalf("tier = %q, want routine", got.Tier)
+	}
+	if got.Source != "default" {
+		t.Fatalf("source = %q, want default", got.Source)
+	}
+}
+
+func TestClassifyRiskHighByPath(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"auth", "internal/auth/session.go"},
+		{"security", "pkg/security/tls.go"},
+		{"payment", "billing/payment/charge.go"},
+		{"migration", "db/migration/0007_add_col.sql"},
+		{"gomod", "go.mod"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyRisk(nil, "", "", nil, []string{"docs/x.md", tc.path})
+			if got.Tier != RiskTierHigh {
+				t.Fatalf("path %q tier = %q, want high", tc.path, got.Tier)
+			}
+			if got.Source != "path" {
+				t.Fatalf("path %q source = %q, want path", tc.path, got.Source)
+			}
+		})
+	}
+}
+
+func TestClassifyRiskLabelWinsOverPath(t *testing.T) {
+	// A routine label de-escalates even when a high-risk path is present.
+	got := ClassifyRisk(nil, "", "", []string{"risk:routine"}, []string{"internal/auth/session.go"})
+	if got.Tier != RiskTierRoutine {
+		t.Fatalf("tier = %q, want routine (label wins over path)", got.Tier)
+	}
+	if got.Source != "label" {
+		t.Fatalf("source = %q, want label", got.Source)
+	}
+}
+
+func TestClassifyRiskHighLabelEscalatesCleanPaths(t *testing.T) {
+	got := ClassifyRisk(nil, "", "", []string{"risk:high"}, []string{"README.md"})
+	if got.Tier != RiskTierHigh || got.Source != "label" {
+		t.Fatalf("classification = %+v, want high/label", got)
+	}
+}
+
+func TestClassifyRiskHighLabelBeatsRoutineLabel(t *testing.T) {
+	// Safety-biased tie-break: both labels present -> high wins.
+	got := ClassifyRisk(nil, "", "", []string{"risk:routine", "risk:high"}, nil)
+	if got.Tier != RiskTierHigh {
+		t.Fatalf("tier = %q, want high on conflicting labels", got.Tier)
+	}
+}
+
+func TestClassifyRiskCustomLabelsAndPaths(t *testing.T) {
+	got := ClassifyRisk([]string{"cmd/**"}, "sev:1", "sev:routine", []string{"sev:1"}, nil)
+	if got.Tier != RiskTierHigh || got.Source != "label" {
+		t.Fatalf("custom high label: %+v", got)
+	}
+	got = ClassifyRisk([]string{"cmd/**"}, "sev:1", "sev:routine", nil, []string{"cmd/root/main.go"})
+	if got.Tier != RiskTierHigh || got.Source != "path" {
+		t.Fatalf("custom path glob: %+v", got)
+	}
+	// The built-in defaults must NOT apply once a custom list is provided.
+	got = ClassifyRisk([]string{"cmd/**"}, "sev:1", "sev:routine", nil, []string{"internal/auth/x.go"})
+	if got.Tier != RiskTierRoutine {
+		t.Fatalf("custom list must not match built-in auth glob: %+v", got)
+	}
+}
+
+func TestClassifyRiskLabelCaseInsensitive(t *testing.T) {
+	got := ClassifyRisk(nil, "", "", []string{"RISK:HIGH"}, nil)
+	if got.Tier != RiskTierHigh {
+		t.Fatalf("label match must be case-insensitive: %+v", got)
+	}
+}
+
+func TestGlobMatch(t *testing.T) {
+	cases := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"**/auth/**", "internal/auth/session.go", true},
+		{"**/auth/**", "a/b/c/auth/d/e.go", true},
+		{"**/auth/**", "internal/authz/x.go", false},
+		{"go.mod", "go.mod", true},
+		{"go.mod", "internal/go.mod", false},
+		{"cmd/**", "cmd/root/main.go", true},
+		{"cmd/**", "internal/cmd/x.go", false},
+		{"*.sql", "0001.sql", true},
+		{"*.sql", "db/0001.sql", false},
+	}
+	for _, tc := range cases {
+		if got := globMatch(tc.pattern, tc.path); got != tc.want {
+			t.Errorf("globMatch(%q, %q) = %v, want %v", tc.pattern, tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestSynthesizeLensDecisionCriticalBlocks(t *testing.T) {
+	findings := []LensFinding{
+		{Lens: "security", Refuted: true, Severity: "critical", Confidence: 0.9, Evidence: "auth bypass"},
+	}
+	if got := SynthesizeLensDecision(findings); got != "blocked" {
+		t.Fatalf("decision = %q, want blocked", got)
+	}
+}
+
+func TestSynthesizeLensDecisionNonCriticalApproves(t *testing.T) {
+	findings := []LensFinding{
+		{Lens: "correctness", Refuted: true, Severity: "medium", Confidence: 0.5},
+		{Lens: "security", Refuted: false, Severity: "critical"}, // not refuted -> ignored
+	}
+	if got := SynthesizeLensDecision(findings); got != "approved" {
+		t.Fatalf("decision = %q, want approved", got)
+	}
+}
+
+func TestSynthesizeLensDecisionEmptyApproves(t *testing.T) {
+	if got := SynthesizeLensDecision(nil); got != "approved" {
+		t.Fatalf("decision = %q, want approved", got)
+	}
+}
+
+func TestParseLensFindingsSkipsMalformed(t *testing.T) {
+	raw := []json.RawMessage{
+		json.RawMessage(`{"lens":"security","refuted":true,"severity":"critical","confidence":0.8,"evidence":"x"}`),
+		json.RawMessage(`"not an object"`),
+		json.RawMessage(`{"lens":"correctness","refuted":false,"severity":"low"}`),
+	}
+	got := ParseLensFindings(raw)
+	if len(got) != 2 {
+		t.Fatalf("parsed %d findings, want 2 (malformed skipped): %+v", len(got), got)
+	}
+	if got[0].Lens != "security" || !got[0].Refuted || got[0].Severity != "critical" {
+		t.Fatalf("first finding = %+v", got[0])
+	}
+}
+
+func TestHighRiskLensDelegations(t *testing.T) {
+	event := PullRequestEvent{PullRequest: 42, TaskID: "task-x", TaskTitle: "T"}
+
+	two := highRiskLensDelegations([]string{"audit"}, event)
+	if len(two) != 2 {
+		t.Fatalf("single reviewer -> %d lenses, want 2", len(two))
+	}
+	for _, d := range two {
+		if d.Agent != "audit" {
+			t.Fatalf("lens %q agent = %q, want audit", d.ID, d.Agent)
+		}
+		if d.Action != "review" {
+			t.Fatalf("lens %q action = %q, want review", d.ID, d.Action)
+		}
+		if d.SynthesisRule != "quorum" || d.Quorum != 2 {
+			t.Fatalf("lens %q synthesis = %q quorum = %d, want quorum/2", d.ID, d.SynthesisRule, d.Quorum)
+		}
+	}
+
+	three := highRiskLensDelegations([]string{"a", "b", "c"}, event)
+	if len(three) != 3 {
+		t.Fatalf("3 reviewers -> %d lenses, want 3 (regression added)", len(three))
+	}
+	if three[0].Agent != "a" || three[1].Agent != "b" || three[2].Agent != "c" {
+		t.Fatalf("round-robin agents = %q/%q/%q", three[0].Agent, three[1].Agent, three[2].Agent)
+	}
+	for _, d := range three {
+		if d.Quorum != 3 {
+			t.Fatalf("3-lens quorum = %d, want 3", d.Quorum)
+		}
+	}
+
+	if got := highRiskLensDelegations(nil, event); got != nil {
+		t.Fatalf("no reviewers -> %+v, want nil", got)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -349,6 +349,36 @@ transition **instead of** `job.failed` (no preceding `job.failed`); the rule
 still holds and is forward-compatible with the older `job.failed`→`job.deferred`
 flap. See `docs/events.md` for the full contract.
 
+## Risk-Tiered Adaptive Review
+
+Scale review depth to a change's blast radius via the off-by-default `[review]`
+config section — it is **not** in the generated default config, so this is its
+discovery surface:
+
+```toml
+[review]
+risk_tiers_enabled = true                     # empty/false (default) = OFF
+# high_risk_paths matched against the PR's changed files (** = any path depth):
+high_risk_paths = ["**/auth/**", "**/security/**", "**/payment/**", "**/migration/**", "go.mod"]
+risk_label_high = "risk:high"                 # PR label that forces the high tier
+risk_label_routine = "risk:routine"           # PR label that forces the routine tier
+```
+
+With `risk_tiers_enabled = true`, each opened PR is classified — **explicit PR
+label > changed-path glob match > default routine** (a `risk:high`/`risk:routine`
+label wins over paths; a high label wins a label tie). A `routine` PR keeps the
+unchanged single-reviewer fan-out. A `high` PR instead fans out a delegation
+batch of **refutation-framed lens reviewers** (correctness, security, and — with
+≥3 configured reviewers — regression), each prompted to *disprove* the change and
+return structured findings `{lens, refuted, severity, confidence, evidence}` in
+`gitmoot_result.findings`. The lenses are synthesized by the existing delegation
+`synthesis_rule = quorum` engine: **any critical-severity refutation (a `blocked`
+lens decision) fails the quorum and blocks the merge**; unanimous approval
+satisfies it. The resolved tier is recorded as a `risk_tier_resolved` job event so
+an escalation is explainable in the report/dashboard. With the section absent or
+`risk_tiers_enabled` off, PR review is byte-identical to the single-reviewer path.
+The competition tier (two implementations + a judge) is a planned follow-up.
+
 ## Bug Reports
 
 Use `gitmoot report bug` to build a redacted GitHub-ready issue from local

--- a/website/docs/workflows/review-agent-workflow.md
+++ b/website/docs/workflows/review-agent-workflow.md
@@ -27,3 +27,39 @@ Ask it from a PR comment:
 The thermo template is review-only. Route implementation work to a separate agent
 with `implement` capability and normal branch-lock protection.
 
+## Risk-Tiered Adaptive Review
+
+Gitmoot can scale review depth to a change's blast radius through the
+off-by-default `[review]` config section (not in the generated default config):
+
+```toml
+[review]
+risk_tiers_enabled = true
+# Changed-path globs that mark a PR high-risk (** matches any path depth):
+high_risk_paths = ["**/auth/**", "**/security/**", "**/payment/**", "**/migration/**", "go.mod"]
+risk_label_high = "risk:high"        # a PR label that forces the high tier
+risk_label_routine = "risk:routine"  # a PR label that forces the routine tier
+```
+
+When enabled, every opened PR is classified — **explicit PR label > changed-path
+glob match > default routine**. A `risk:high` / `risk:routine` label wins over the
+path heuristics, and a high label wins a label tie (safety-biased).
+
+- **routine** PRs keep the existing single-reviewer fan-out, unchanged.
+- **high** PRs fan out a delegation batch of **refutation-framed lens reviewers**
+  (correctness, security, and — with three or more configured reviewers —
+  regression). Each lens is prompted to actively *disprove* the change along one
+  axis and return structured findings `{lens, refuted, severity, confidence,
+  evidence}` in `gitmoot_result.findings`.
+
+The lens outcomes are synthesized by the existing delegation `synthesis_rule =
+quorum` engine (not a bespoke synthesizer): **any critical-severity refutation —
+reported as a `blocked` lens decision — fails the quorum and blocks the merge**;
+unanimous approval satisfies it. The resolved tier is recorded as a
+`risk_tier_resolved` job event so an escalation is explainable in the report and
+dashboard.
+
+With the `[review]` section absent or `risk_tiers_enabled` off, PR review is
+byte-for-byte the single-reviewer path. The competition tier (two independent
+implementations plus a judge) is a planned follow-up.
+

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -8173,6 +8173,36 @@ transition **instead of** `job.failed` (no preceding `job.failed`); the rule
 still holds and is forward-compatible with the older `job.failed`→`job.deferred`
 flap. See `docs/events.md` for the full contract.
 
+## Risk-Tiered Adaptive Review
+
+Scale review depth to a change's blast radius via the off-by-default `[review]`
+config section — it is **not** in the generated default config, so this is its
+discovery surface:
+
+```toml
+[review]
+risk_tiers_enabled = true                     # empty/false (default) = OFF
+# high_risk_paths matched against the PR's changed files (** = any path depth):
+high_risk_paths = ["**/auth/**", "**/security/**", "**/payment/**", "**/migration/**", "go.mod"]
+risk_label_high = "risk:high"                 # PR label that forces the high tier
+risk_label_routine = "risk:routine"           # PR label that forces the routine tier
+```
+
+With `risk_tiers_enabled = true`, each opened PR is classified — **explicit PR
+label > changed-path glob match > default routine** (a `risk:high`/`risk:routine`
+label wins over paths; a high label wins a label tie). A `routine` PR keeps the
+unchanged single-reviewer fan-out. A `high` PR instead fans out a delegation
+batch of **refutation-framed lens reviewers** (correctness, security, and — with
+≥3 configured reviewers — regression), each prompted to *disprove* the change and
+return structured findings `{lens, refuted, severity, confidence, evidence}` in
+`gitmoot_result.findings`. The lenses are synthesized by the existing delegation
+`synthesis_rule = quorum` engine: **any critical-severity refutation (a `blocked`
+lens decision) fails the quorum and blocks the merge**; unanimous approval
+satisfies it. The resolved tier is recorded as a `risk_tier_resolved` job event so
+an escalation is explainable in the report/dashboard. With the section absent or
+`risk_tiers_enabled` off, PR review is byte-identical to the single-reviewer path.
+The competition tier (two implementations + a judge) is a planned follow-up.
+
 ## Bug Reports
 
 Use `gitmoot report bug` to build a redacted GitHub-ready issue from local


### PR DESCRIPTION
## What

Opt-in **risk-tiered adaptive review** (#650): scale review depth to a change's blast radius. Off by default and additive — with the new `[review]` section absent or `risk_tiers_enabled` off, PR review is **byte-for-byte** the existing single-reviewer fan-out.

- **`internal/workflow/risk.go`** — pure risk classifier resolving `routine | high` from **explicit PR label > changed-path glob > default routine** (a `risk:high`/`risk:routine` label wins over paths; high wins a label tie). Includes a `**`-aware glob matcher, the refutation-lens vocabulary (correctness / security / regression) with built-in lens prompt constants, the documented `{lens, refuted, severity, confidence, evidence}` finding convention (reuses `AgentResult.Findings` — no contract change), and a per-reviewer finding→decision mapping (a critical refutation → a `blocked` lens decision).
- **`HandlePullRequestOpened`** — when `risk_tiers_enabled` **and** tier is `high`, the single native fan-out is replaced by a delegation batch of **≥2 refutation-framed lens reviewers** tagged `synthesis_rule = quorum`, seeded onto a synthetic review coordinator and dispatched through the **existing delegation `deps` + `synthesis_rule` engine** — not a bespoke synthesizer (explicit acceptance criterion). Any critical refutation fails the quorum and **blocks** the merge; unanimous approval satisfies it. The resolved tier is recorded as a `risk_tier_resolved` job event and stamped additively (`omitempty`) on `JobPayload` for explainable escalation.
- **`[review]` config section** (`risk_tiers_enabled` / `high_risk_paths` / `risk_label_high` / `risk_label_routine`), loaded off-by-default onto the engine.
- **Nil-by-default `PullRequestSignals` engine seam** so the in-process implement→PR trigger resolves labels + changed paths via a GitHub read (wired only in cli, only when enabled); `github.PullRequest` gains additive `Labels` parsing.
- Docs shipped in the same PR: `skills/gitmoot/references/CLI.md` + `website/docs/workflows/review-agent-workflow.md` (+ regenerated `llms-full.txt`).

## Why

Reserve the expensive adversarial machinery (auth / security / payments / migrations / `go.mod`) for the changes that warrant it and keep routine PRs cheap. Borrowed from the `fubak/ultraswarm` risk-tiered-review eval.

## How tested

All from a fresh clone at branch head (go1.26.4):

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -count=1 ./internal/workflow/ ./internal/config/ ./internal/github/ ./internal/cli/` — all `ok`
- `go test -race -count=1 -timeout 20m ./internal/workflow/` — `ok` (507s; most-touched package)
- `cd website && npm ci && npm run build` — `[SUCCESS] Generated static files`

New tests: classifier (labels/paths/priority/custom + `**` globs), lens synthesis mapping (critical → blocked, else approved), `enabled + high-risk PR → ≥2 lens review jobs + quorum synthesis`, a **deterministic no-LLM E2E** driving a high-risk PR to `blocked` on a critical refutation (and the all-approve quorum-satisfied path), the **off-path byte-identical** invariant, the routine-when-enabled path, the signals seam, config parsing, and PR-label JSON parsing.

## Follow-up

The **competition tier** (two independent implementations + a weighted judge) is intentionally out of scope here. The high-risk **approve** path currently synthesizes via the coordinator continuation; wiring an approved synthesis directly to the merge gate is a follow-up alongside competition.

Closes #650
