### PR TITLE
feat(skillopt): add BINEVAL-style binary evaluation schema and runner

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -82,6 +82,8 @@ func runSkillOpt(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptPairwise(args[1:], stdout, stderr)
 	case "gate":
 		return runSkillOptGate(args[1:], stdout, stderr)
+	case "binary":
+		return runSkillOptBinary(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown skillopt command %q\n\n", args[0])
 		printSkillOptUsage(stderr)
@@ -103,6 +105,8 @@ func printSkillOptUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot skillopt candidate reject <version-id> [--reason text]")
 	fmt.Fprintln(w, "  gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-command cmd] [--config path] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt gate history --candidate <version-id> [--json]")
+	fmt.Fprintln(w, "  gitmoot skillopt binary run --set <file> --run <run-id> --source <file> [--deterministic] [--reviewer runtime] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot skillopt binary show --run <run-id> [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback markdown import --packet .gitmoot/evals/<run-id> [--reviewer name]")
 	fmt.Fprintln(w, "  gitmoot skillopt feedback github publish --run <run-id> [--repo owner/repo] [--pr <number>]")

--- a/internal/cli/skillopt_binary.go
+++ b/internal/cli/skillopt_binary.go
@@ -1,0 +1,361 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// runSkillOptBinary dispatches the BINEVAL binary-evaluation subcommands (#525).
+// This whole surface is additive and opt-in: nothing here runs — and no
+// skillopt_binary_verdicts row is ever written — unless a `skillopt binary`
+// command is invoked, so existing review/optimize flows are byte-identical.
+func runSkillOptBinary(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printSkillOptBinaryUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "run":
+		return runSkillOptBinaryRun(args[1:], stdout, stderr)
+	case "show":
+		return runSkillOptBinaryShow(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skillopt binary command %q\n\n", args[0])
+		printSkillOptBinaryUsage(stderr)
+		return 2
+	}
+}
+
+func printSkillOptBinaryUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot skillopt binary run --set <file> --run <run-id> --source <file> [--deterministic] [--reviewer runtime] [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot skillopt binary show --run <run-id> [--home path] [--json]")
+}
+
+// skillOptBinaryDeliver is the delivery seam for the opt-in LLM-backed binary
+// runner. It defaults to the SAME real cross-family adapter path the A/B judge
+// uses (realSkillOptABDeliver) and is a var precisely so tests can inject a fake
+// adapter without any live runtime.
+var skillOptBinaryDeliver skillOptABDeliverFunc = realSkillOptABDeliver
+
+// binaryLLMEvaluator is the opt-in LLM-backed BinaryEvaluator. It answers one
+// question at a time by delivering a small yes/no prompt through the EXISTING
+// cross-family judge plumbing (skillOptABJudgeAgent + the shared deliver seam),
+// so the judgment runs on a DIFFERENT family than any template under test and
+// never becomes a self-preference. Each Answer is a fresh, serialized one-shot
+// ask (read-only) — the same discipline the A/B judge documents.
+type binaryLLMEvaluator struct {
+	agent   runtime.Agent
+	deliver skillOptABDeliverFunc
+}
+
+// Answer implements skillopt.BinaryEvaluator via the LLM plumbing.
+func (e binaryLLMEvaluator) Answer(ctx context.Context, dimension string, question skillopt.BinaryQuestion, source string) (skillopt.BinaryAnswer, error) {
+	prompt := buildBinaryQuestionPrompt(dimension, question, source)
+	raw, err := e.deliver(ctx, e.agent, prompt)
+	if err != nil {
+		return skillopt.BinaryAnswer{}, err
+	}
+	verdict, explanation, ok := parseBinaryVerdict(raw)
+	if !ok {
+		// Fail-safe: an unparseable answer is a "no" so a garbled judge never
+		// fabricates a pass. The raw text is surfaced as the explanation.
+		return skillopt.BinaryAnswer{Verdict: skillopt.BinaryVerdictNo, Explanation: strings.TrimSpace(raw)}, nil
+	}
+	return skillopt.BinaryAnswer{Verdict: verdict, Explanation: explanation}, nil
+}
+
+// buildBinaryQuestionPrompt assembles the single-question prompt. It asks for a
+// strict {"verdict":"yes|no","explanation":"..."} JSON object over ONE atomic
+// check applied to the source output.
+func buildBinaryQuestionPrompt(dimension string, question skillopt.BinaryQuestion, source string) string {
+	var b strings.Builder
+	b.WriteString("You are an impartial evaluator answering ONE yes/no question about the output below. ")
+	b.WriteString("Answer ONLY this question; do not judge anything else. This is a SOFT, advisory signal.\n\n")
+	if strings.TrimSpace(dimension) != "" {
+		b.WriteString("## Dimension\n" + strings.TrimSpace(dimension) + "\n\n")
+	}
+	b.WriteString("## Question\n" + strings.TrimSpace(question.Text) + "\n\n")
+	if strings.TrimSpace(question.ViolationExample) != "" {
+		b.WriteString("## Example of a violation (would be \"no\")\n" + strings.TrimSpace(question.ViolationExample) + "\n\n")
+	}
+	b.WriteString("## Output under evaluation\n" + strings.TrimSpace(source) + "\n\n")
+	b.WriteString(`Return ONLY a JSON object of the form {"verdict":"yes","explanation":"..."} or `)
+	b.WriteString(`{"verdict":"no","explanation":"..."} (no other prose). Do NOT modify any files (read-only).`)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// parseBinaryVerdict extracts a yes/no verdict + explanation from the runner's
+// raw output using the shared brace-balanced jsonCandidates scan, tolerating
+// surrounding prose. ok=false on empty/unparseable/ambiguous output (the
+// fail-safe drop), so a garbled answer never fabricates a verdict.
+func parseBinaryVerdict(raw string) (verdict, explanation string, ok bool) {
+	for _, candidate := range jsonCandidates(raw) {
+		var envelope struct {
+			Verdict       string `json:"verdict"`
+			Explanation   string `json:"explanation"`
+			GitmootResult struct {
+				Verdict     string `json:"verdict"`
+				Explanation string `json:"explanation"`
+			} `json:"gitmoot_result"`
+		}
+		if err := json.Unmarshal([]byte(candidate), &envelope); err != nil {
+			continue
+		}
+		v := firstNonEmpty(
+			strings.ToLower(strings.TrimSpace(envelope.Verdict)),
+			strings.ToLower(strings.TrimSpace(envelope.GitmootResult.Verdict)),
+		)
+		explanation = firstNonEmpty(
+			strings.TrimSpace(envelope.Explanation),
+			strings.TrimSpace(envelope.GitmootResult.Explanation),
+		)
+		if v == skillopt.BinaryVerdictYes || v == skillopt.BinaryVerdictNo {
+			return v, explanation, true
+		}
+	}
+	return "", "", false
+}
+
+func runSkillOptBinaryRun(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt binary run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	setPath := fs.String("set", "", "binary question set file (YAML or JSON)")
+	runID := fs.String("run", "", "eval run id to attach the verdicts to")
+	sourcePath := fs.String("source", "", "file containing the output text to evaluate")
+	deterministic := fs.Bool("deterministic", false, "use the deterministic rule-based runner (no LLM) — required for reproducible/test runs")
+	reviewer := fs.String("reviewer", "", "runtime family for the opt-in LLM-backed runner (ignored with --deterministic)")
+	asJSON := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt binary run does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*setPath) == "" {
+		fmt.Fprintln(stderr, "skillopt binary run requires --set")
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" {
+		fmt.Fprintln(stderr, "skillopt binary run requires --run")
+		return 2
+	}
+	if strings.TrimSpace(*sourcePath) == "" {
+		fmt.Fprintln(stderr, "skillopt binary run requires --source")
+		return 2
+	}
+	set, err := skillopt.LoadBinaryQuestionSet(*setPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt binary run: load question set: %v\n", err)
+		return 1
+	}
+	sourceBytes, err := os.ReadFile(*sourcePath)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt binary run: read source: %v\n", err)
+		return 1
+	}
+	source := string(sourceBytes)
+
+	var evaluator skillopt.BinaryEvaluator
+	if *deterministic {
+		evaluator = skillopt.RuleBasedBinaryEvaluator{}
+	} else {
+		if strings.TrimSpace(*reviewer) == "" {
+			fmt.Fprintln(stderr, "skillopt binary run: the LLM runner requires --reviewer <runtime> (or pass --deterministic)")
+			return 2
+		}
+		evaluator = binaryLLMEvaluator{
+			agent:   skillOptABJudgeAgent(workflow.CrossFamilyReviewer{Runtime: strings.TrimSpace(*reviewer)}),
+			deliver: skillOptBinaryDeliver,
+		}
+	}
+
+	result, err := skillopt.RunBinaryEvaluation(context.Background(), set, source, evaluator)
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt binary run: %v\n", err)
+		return 1
+	}
+
+	if err := withStore(*home, func(store *db.Store) error {
+		for _, v := range result.Verdicts {
+			if err := store.UpsertBinaryVerdict(context.Background(), db.BinaryVerdict{
+				RunID:       strings.TrimSpace(*runID),
+				QuestionID:  v.QuestionID,
+				Dimension:   v.Dimension,
+				Verdict:     v.Verdict,
+				Explanation: v.Explanation,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt binary run: persist verdicts: %v\n", err)
+		return 1
+	}
+
+	if *asJSON {
+		payload := map[string]any{
+			"run_id":           strings.TrimSpace(*runID),
+			"template_or_kind": set.TemplateOrTaskKind,
+			"overall":          result.Overall,
+			"dimension_scores": result.DimensionScores,
+			"verdicts":         result.Verdicts,
+		}
+		encoded, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "skillopt binary run: %v\n", err)
+			return 1
+		}
+		encoded = append(encoded, '\n')
+		stdout.Write(encoded)
+		return 0
+	}
+
+	writeBinaryHuman(stdout, strings.TrimSpace(*runID), result)
+	return 0
+}
+
+func runSkillOptBinaryShow(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt binary show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	runID := fs.String("run", "", "eval run id to show verdicts for")
+	asJSON := fs.Bool("json", false, "emit JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt binary show does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*runID) == "" {
+		fmt.Fprintln(stderr, "skillopt binary show requires --run")
+		return 2
+	}
+	var stored []db.BinaryVerdict
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		stored, err = store.ListBinaryVerdicts(context.Background(), strings.TrimSpace(*runID))
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "skillopt binary show: %v\n", err)
+		return 1
+	}
+
+	verdicts := make([]skillopt.BinaryVerdict, 0, len(stored))
+	for _, v := range stored {
+		verdicts = append(verdicts, skillopt.BinaryVerdict{
+			QuestionID:  v.QuestionID,
+			Dimension:   v.Dimension,
+			Verdict:     v.Verdict,
+			Explanation: v.Explanation,
+			CreatedAt:   v.CreatedAt,
+		})
+	}
+	dimensionScores, overall := aggregateStoredBinaryVerdicts(stored)
+
+	if *asJSON {
+		payload := map[string]any{
+			"run_id":           strings.TrimSpace(*runID),
+			"overall":          overall,
+			"dimension_scores": dimensionScores,
+			"verdicts":         verdicts,
+		}
+		encoded, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "skillopt binary show: %v\n", err)
+			return 1
+		}
+		encoded = append(encoded, '\n')
+		stdout.Write(encoded)
+		return 0
+	}
+
+	writeBinaryHuman(stdout, strings.TrimSpace(*runID), skillopt.BinaryEvaluationResult{
+		Verdicts:        verdicts,
+		DimensionScores: dimensionScores,
+		Overall:         overall,
+	})
+	return 0
+}
+
+// aggregateStoredBinaryVerdicts recomputes per-dimension yes-fractions and an
+// unweighted overall mean from PERSISTED verdicts (the stored rows do not carry
+// question weights, so `show` uses equal weights — `run` reports the weighted
+// scores from the question set directly).
+func aggregateStoredBinaryVerdicts(rows []db.BinaryVerdict) (map[string]float64, float64) {
+	type acc struct{ yes, total int }
+	perDim := map[string]*acc{}
+	order := []string{}
+	for _, r := range rows {
+		a, ok := perDim[r.Dimension]
+		if !ok {
+			a = &acc{}
+			perDim[r.Dimension] = a
+			order = append(order, r.Dimension)
+		}
+		a.total++
+		if strings.EqualFold(strings.TrimSpace(r.Verdict), skillopt.BinaryVerdictYes) {
+			a.yes++
+		}
+	}
+	scores := map[string]float64{}
+	var sum float64
+	for _, dim := range order {
+		a := perDim[dim]
+		s := 0.0
+		if a.total > 0 {
+			s = float64(a.yes) / float64(a.total)
+		}
+		scores[dim] = s
+		sum += s
+	}
+	overall := 0.0
+	if len(order) > 0 {
+		overall = sum / float64(len(order))
+	}
+	return scores, overall
+}
+
+func writeBinaryHuman(w io.Writer, runID string, result skillopt.BinaryEvaluationResult) {
+	writeLine(w, "binary evaluation for run %s", runID)
+	writeLine(w, "overall: %.3f", result.Overall)
+	skillopt.SortBinaryVerdicts(result.Verdicts)
+	dims := make([]string, 0, len(result.DimensionScores))
+	for d := range result.DimensionScores {
+		dims = append(dims, d)
+	}
+	sort.Strings(dims)
+	for _, d := range dims {
+		writeLine(w, "dimension %s: %.3f", d, result.DimensionScores[d])
+	}
+	for _, v := range result.Verdicts {
+		if strings.TrimSpace(v.Explanation) != "" {
+			writeLine(w, "  [%s] %s (%s): %s", v.Dimension, v.QuestionID, v.Verdict, v.Explanation)
+		} else {
+			writeLine(w, "  [%s] %s (%s)", v.Dimension, v.QuestionID, v.Verdict)
+		}
+	}
+}

--- a/internal/cli/skillopt_binary.go
+++ b/internal/cli/skillopt_binary.go
@@ -197,11 +197,13 @@ func runSkillOptBinaryRun(args []string, stdout, stderr io.Writer) int {
 	if err := withStore(*home, func(store *db.Store) error {
 		for _, v := range result.Verdicts {
 			if err := store.UpsertBinaryVerdict(context.Background(), db.BinaryVerdict{
-				RunID:       strings.TrimSpace(*runID),
-				QuestionID:  v.QuestionID,
-				Dimension:   v.Dimension,
-				Verdict:     v.Verdict,
-				Explanation: v.Explanation,
+				RunID:           strings.TrimSpace(*runID),
+				QuestionID:      v.QuestionID,
+				Dimension:       v.Dimension,
+				Verdict:         v.Verdict,
+				Explanation:     v.Explanation,
+				QuestionWeight:  v.QuestionWeight,
+				DimensionWeight: v.DimensionWeight,
 			}); err != nil {
 				return err
 			}
@@ -267,14 +269,19 @@ func runSkillOptBinaryShow(args []string, stdout, stderr io.Writer) int {
 	verdicts := make([]skillopt.BinaryVerdict, 0, len(stored))
 	for _, v := range stored {
 		verdicts = append(verdicts, skillopt.BinaryVerdict{
-			QuestionID:  v.QuestionID,
-			Dimension:   v.Dimension,
-			Verdict:     v.Verdict,
-			Explanation: v.Explanation,
-			CreatedAt:   v.CreatedAt,
+			QuestionID:      v.QuestionID,
+			Dimension:       v.Dimension,
+			Verdict:         v.Verdict,
+			Explanation:     v.Explanation,
+			QuestionWeight:  v.QuestionWeight,
+			DimensionWeight: v.DimensionWeight,
+			CreatedAt:       v.CreatedAt,
 		})
 	}
-	dimensionScores, overall := aggregateStoredBinaryVerdicts(stored)
+	// Aggregate with the SAME weighted logic (and the persisted weights) that
+	// RunBinaryEvaluation used, so `show` reproduces the score the `run` emitted
+	// for this exact run rather than an unweighted approximation.
+	dimensionScores, overall := skillopt.AggregateBinaryVerdicts(verdicts)
 
 	if *asJSON {
 		payload := map[string]any{
@@ -299,44 +306,6 @@ func runSkillOptBinaryShow(args []string, stdout, stderr io.Writer) int {
 		Overall:         overall,
 	})
 	return 0
-}
-
-// aggregateStoredBinaryVerdicts recomputes per-dimension yes-fractions and an
-// unweighted overall mean from PERSISTED verdicts (the stored rows do not carry
-// question weights, so `show` uses equal weights — `run` reports the weighted
-// scores from the question set directly).
-func aggregateStoredBinaryVerdicts(rows []db.BinaryVerdict) (map[string]float64, float64) {
-	type acc struct{ yes, total int }
-	perDim := map[string]*acc{}
-	order := []string{}
-	for _, r := range rows {
-		a, ok := perDim[r.Dimension]
-		if !ok {
-			a = &acc{}
-			perDim[r.Dimension] = a
-			order = append(order, r.Dimension)
-		}
-		a.total++
-		if strings.EqualFold(strings.TrimSpace(r.Verdict), skillopt.BinaryVerdictYes) {
-			a.yes++
-		}
-	}
-	scores := map[string]float64{}
-	var sum float64
-	for _, dim := range order {
-		a := perDim[dim]
-		s := 0.0
-		if a.total > 0 {
-			s = float64(a.yes) / float64(a.total)
-		}
-		scores[dim] = s
-		sum += s
-	}
-	overall := 0.0
-	if len(order) > 0 {
-		overall = sum / float64(len(order))
-	}
-	return scores, overall
 }
 
 func writeBinaryHuman(w io.Writer, runID string, result skillopt.BinaryEvaluationResult) {

--- a/internal/cli/skillopt_binary_test.go
+++ b/internal/cli/skillopt_binary_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+const binaryTestSetYAML = `
+version: 1
+template_or_task_kind: bugfix
+dimensions:
+  - name: correctness
+    weight: 2
+    questions:
+      - id: has_test
+        text: Does the output add a Go test?
+        contains: "func Test"
+      - id: no_todo
+        text: Is the output free of TODO markers?
+        not_contains: "TODO"
+  - name: style
+    questions:
+      - id: has_pkg
+        text: Does the output declare a package?
+        regex: "^package "
+`
+
+func writeBinaryFixture(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+// TestSkillOptBinaryDeterministicE2E drives the REAL `gitmoot skillopt binary
+// run` + `show` through the top-level Run dispatcher against an isolated temp
+// home with the deterministic (no-LLM) runner, then asserts the aggregated
+// scores and the persisted/re-read verdicts.
+func TestSkillOptBinaryDeterministicE2E(t *testing.T) {
+	home := t.TempDir()
+	setPath := writeBinaryFixture(t, home, "set.yaml", binaryTestSetYAML)
+	// Source hits has_test (func Test) and has_pkg (package ...) but contains a TODO,
+	// so no_todo fails: correctness = 1/2 (weighted equal q-weights), style = 1/1.
+	source := "package main\n\nfunc TestFoo() {} // TODO: finish\n"
+	sourcePath := writeBinaryFixture(t, home, "out.go", source)
+
+	var out, errBuf bytes.Buffer
+	code := Run([]string{"skillopt", "binary", "run", "--home", home, "--set", setPath, "--run", "run-1", "--source", sourcePath, "--deterministic", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("binary run exit=%d stderr=%s", code, errBuf.String())
+	}
+
+	var runResult struct {
+		RunID           string                   `json:"run_id"`
+		Overall         float64                  `json:"overall"`
+		DimensionScores map[string]float64       `json:"dimension_scores"`
+		Verdicts        []skillopt.BinaryVerdict `json:"verdicts"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &runResult); err != nil {
+		t.Fatalf("decode run json: %v (%s)", err, out.String())
+	}
+	if len(runResult.Verdicts) != 3 {
+		t.Fatalf("verdicts = %d, want 3", len(runResult.Verdicts))
+	}
+	if got := runResult.DimensionScores["correctness"]; got != 0.5 {
+		t.Fatalf("correctness = %v, want 0.5", got)
+	}
+	if got := runResult.DimensionScores["style"]; got != 1.0 {
+		t.Fatalf("style = %v, want 1.0", got)
+	}
+	// overall = (2*0.5 + 1*1.0)/3 = 0.6667
+	if runResult.Overall < 0.66 || runResult.Overall > 0.67 {
+		t.Fatalf("overall = %v, want ~0.667", runResult.Overall)
+	}
+
+	// show re-reads the persisted verdicts.
+	out.Reset()
+	errBuf.Reset()
+	code = Run([]string{"skillopt", "binary", "show", "--home", home, "--run", "run-1", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("binary show exit=%d stderr=%s", code, errBuf.String())
+	}
+	var showResult struct {
+		Verdicts        []skillopt.BinaryVerdict `json:"verdicts"`
+		DimensionScores map[string]float64       `json:"dimension_scores"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &showResult); err != nil {
+		t.Fatalf("decode show json: %v (%s)", err, out.String())
+	}
+	if len(showResult.Verdicts) != 3 {
+		t.Fatalf("persisted verdicts = %d, want 3", len(showResult.Verdicts))
+	}
+	// Verify the specific failing verdict persisted with an explanation.
+	var noTodo *skillopt.BinaryVerdict
+	for i := range showResult.Verdicts {
+		if showResult.Verdicts[i].QuestionID == "no_todo" {
+			noTodo = &showResult.Verdicts[i]
+		}
+	}
+	if noTodo == nil || noTodo.Verdict != "no" {
+		t.Fatalf("no_todo verdict = %+v, want no", noTodo)
+	}
+	if !strings.Contains(noTodo.Explanation, "not_contains") {
+		t.Fatalf("no_todo explanation = %q, want deterministic assertion note", noTodo.Explanation)
+	}
+}
+
+// TestSkillOptBinaryRunRequiresSource proves the arg validation.
+func TestSkillOptBinaryRunRequiresFlags(t *testing.T) {
+	home := t.TempDir()
+	setPath := writeBinaryFixture(t, home, "set.yaml", binaryTestSetYAML)
+	var out, errBuf bytes.Buffer
+	code := Run([]string{"skillopt", "binary", "run", "--home", home, "--set", setPath, "--run", "r", "--deterministic"}, &out, &errBuf)
+	if code == 0 {
+		t.Fatal("expected non-zero exit without --source")
+	}
+	if !strings.Contains(errBuf.String(), "--source") {
+		t.Fatalf("stderr = %q, want --source hint", errBuf.String())
+	}
+}
+
+// TestSkillOptBinaryLLMRunnerViaFakeAdapter exercises the OPT-IN LLM-backed
+// runner end to end WITHOUT any live runtime by overriding the shared deliver
+// seam with a fake adapter that returns the yes/no JSON the parser expects.
+func TestSkillOptBinaryLLMRunnerViaFakeAdapter(t *testing.T) {
+	home := t.TempDir()
+	setPath := writeBinaryFixture(t, home, "set.yaml", binaryTestSetYAML)
+	sourcePath := writeBinaryFixture(t, home, "out.txt", "irrelevant to a fake judge")
+
+	orig := skillOptBinaryDeliver
+	t.Cleanup(func() { skillOptBinaryDeliver = orig })
+	var delivered int
+	skillOptBinaryDeliver = func(_ context.Context, agent runtime.Agent, prompt string) (string, error) {
+		delivered++
+		if agent.Runtime != "codex" {
+			t.Errorf("judge runtime = %q, want codex (cross-family)", agent.Runtime)
+		}
+		// Answer "yes" for the has_test question, "no" otherwise.
+		if strings.Contains(prompt, "add a Go test") {
+			return `sure -> {"verdict":"yes","explanation":"fake yes"}`, nil
+		}
+		return `{"verdict":"no","explanation":"fake no"}`, nil
+	}
+
+	var out, errBuf bytes.Buffer
+	code := Run([]string{"skillopt", "binary", "run", "--home", home, "--set", setPath, "--run", "llm-run", "--source", sourcePath, "--reviewer", "codex", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("binary run (llm) exit=%d stderr=%s", code, errBuf.String())
+	}
+	if delivered != 3 {
+		t.Fatalf("deliver calls = %d, want 3 (one per question)", delivered)
+	}
+	var res struct {
+		DimensionScores map[string]float64 `json:"dimension_scores"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Only has_test answered yes: correctness = 1/2, style has_pkg = no -> 0.
+	if res.DimensionScores["correctness"] != 0.5 {
+		t.Fatalf("correctness = %v, want 0.5", res.DimensionScores["correctness"])
+	}
+	if res.DimensionScores["style"] != 0.0 {
+		t.Fatalf("style = %v, want 0.0", res.DimensionScores["style"])
+	}
+}
+
+func TestParseBinaryVerdict(t *testing.T) {
+	cases := []struct {
+		raw     string
+		verdict string
+		ok      bool
+	}{
+		{`{"verdict":"yes","explanation":"x"}`, "yes", true},
+		{`prose {"verdict":"no"} trailing`, "no", true},
+		{`{"gitmoot_result":{"verdict":"yes"}}`, "yes", true},
+		{`no json here`, "", false},
+		{`{"verdict":"maybe"}`, "", false},
+	}
+	for _, c := range cases {
+		v, _, ok := parseBinaryVerdict(c.raw)
+		if ok != c.ok || v != c.verdict {
+			t.Fatalf("parseBinaryVerdict(%q) = (%q,%v), want (%q,%v)", c.raw, v, ok, c.verdict, c.ok)
+		}
+	}
+}

--- a/internal/cli/skillopt_binary_test.go
+++ b/internal/cli/skillopt_binary_test.go
@@ -93,12 +93,35 @@ func TestSkillOptBinaryDeterministicE2E(t *testing.T) {
 	var showResult struct {
 		Verdicts        []skillopt.BinaryVerdict `json:"verdicts"`
 		DimensionScores map[string]float64       `json:"dimension_scores"`
+		Overall         float64                  `json:"overall"`
 	}
 	if err := json.Unmarshal(out.Bytes(), &showResult); err != nil {
 		t.Fatalf("decode show json: %v (%s)", err, out.String())
 	}
 	if len(showResult.Verdicts) != 3 {
 		t.Fatalf("persisted verdicts = %d, want 3", len(showResult.Verdicts))
+	}
+	// Regression guard (#525 review): `show` must reproduce the SAME weighted
+	// scores `run` emitted for this run — not an unweighted mean. The fixture's
+	// correctness dimension carries weight 2, so an unweighted `show` would have
+	// reported overall 0.75 (=(0.5+1.0)/2) instead of 0.667 (=(2*0.5+1*1.0)/3).
+	if showResult.Overall != runResult.Overall {
+		t.Fatalf("show overall = %v, want run overall %v (weighted scores must match)", showResult.Overall, runResult.Overall)
+	}
+	if showResult.DimensionScores["correctness"] != runResult.DimensionScores["correctness"] {
+		t.Fatalf("show correctness = %v, want %v", showResult.DimensionScores["correctness"], runResult.DimensionScores["correctness"])
+	}
+	if showResult.DimensionScores["style"] != runResult.DimensionScores["style"] {
+		t.Fatalf("show style = %v, want %v", showResult.DimensionScores["style"], runResult.DimensionScores["style"])
+	}
+	// Weights round-trip through persistence so the re-read is self-describing.
+	for _, v := range showResult.Verdicts {
+		if v.Dimension == "correctness" && v.DimensionWeight != 2 {
+			t.Fatalf("correctness verdict dimension_weight = %v, want 2 (persisted)", v.DimensionWeight)
+		}
+		if v.QuestionWeight != 1 {
+			t.Fatalf("question %s question_weight = %v, want 1 (persisted default)", v.QuestionID, v.QuestionWeight)
+		}
 	}
 	// Verify the specific failing verdict persisted with an explanation.
 	var noTodo *skillopt.BinaryVerdict

--- a/internal/db/binary_verdicts_test.go
+++ b/internal/db/binary_verdicts_test.go
@@ -1,0 +1,120 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func openBinaryTestStore(t *testing.T) *Store {
+	t.Helper()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func TestBinaryVerdictRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := openBinaryTestStore(t)
+
+	verdicts := []BinaryVerdict{
+		{RunID: "run-1", QuestionID: "q2", Dimension: "style", Verdict: "no", Explanation: "has TODO"},
+		{RunID: "run-1", QuestionID: "q1", Dimension: "correctness", Verdict: "yes", Explanation: "test present"},
+		{RunID: "run-2", QuestionID: "q1", Dimension: "correctness", Verdict: "no"},
+	}
+	for _, v := range verdicts {
+		if err := store.UpsertBinaryVerdict(ctx, v); err != nil {
+			t.Fatalf("upsert %s/%s: %v", v.RunID, v.QuestionID, err)
+		}
+	}
+
+	got, err := store.ListBinaryVerdicts(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("run-1 verdicts = %d, want 2", len(got))
+	}
+	// Ordered by (dimension, question_id): correctness/q1 before style/q2.
+	if got[0].QuestionID != "q1" || got[0].Dimension != "correctness" {
+		t.Fatalf("first row = %+v, want correctness/q1", got[0])
+	}
+	if got[0].Verdict != "yes" || got[0].Explanation != "test present" {
+		t.Fatalf("first row payload = %+v", got[0])
+	}
+	if got[0].CreatedAt == "" {
+		t.Fatal("created_at not defaulted")
+	}
+	if got[1].QuestionID != "q2" {
+		t.Fatalf("second row = %+v, want q2", got[1])
+	}
+
+	// run-2 is isolated.
+	got2, err := store.ListBinaryVerdicts(ctx, "run-2")
+	if err != nil {
+		t.Fatalf("list run-2: %v", err)
+	}
+	if len(got2) != 1 {
+		t.Fatalf("run-2 verdicts = %d, want 1", len(got2))
+	}
+}
+
+func TestBinaryVerdictUpsertOverwrites(t *testing.T) {
+	ctx := context.Background()
+	store := openBinaryTestStore(t)
+
+	if err := store.UpsertBinaryVerdict(ctx, BinaryVerdict{RunID: "r", QuestionID: "q", Dimension: "d", Verdict: "no", Explanation: "first"}); err != nil {
+		t.Fatalf("upsert 1: %v", err)
+	}
+	if err := store.UpsertBinaryVerdict(ctx, BinaryVerdict{RunID: "r", QuestionID: "q", Dimension: "d", Verdict: "yes", Explanation: "second"}); err != nil {
+		t.Fatalf("upsert 2: %v", err)
+	}
+	got, err := store.ListBinaryVerdicts(ctx, "r")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("verdicts = %d, want 1 (upsert in place)", len(got))
+	}
+	if got[0].Verdict != "yes" || got[0].Explanation != "second" {
+		t.Fatalf("row = %+v, want overwrite to yes/second", got[0])
+	}
+}
+
+func TestBinaryVerdictValidation(t *testing.T) {
+	ctx := context.Background()
+	store := openBinaryTestStore(t)
+
+	if err := store.UpsertBinaryVerdict(ctx, BinaryVerdict{QuestionID: "q"}); err == nil {
+		t.Fatal("expected error for missing run id")
+	}
+	if err := store.UpsertBinaryVerdict(ctx, BinaryVerdict{RunID: "r"}); err == nil {
+		t.Fatal("expected error for missing question id")
+	}
+	// Verdict defaults to "no" when blank.
+	if err := store.UpsertBinaryVerdict(ctx, BinaryVerdict{RunID: "r", QuestionID: "q"}); err != nil {
+		t.Fatalf("upsert with default verdict: %v", err)
+	}
+	got, err := store.ListBinaryVerdicts(ctx, "r")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 || got[0].Verdict != "no" {
+		t.Fatalf("default verdict row = %+v, want verdict=no", got)
+	}
+}
+
+func TestListBinaryVerdictsEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := openBinaryTestStore(t)
+	got, err := store.ListBinaryVerdicts(ctx, "nope")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("empty run verdicts = %d, want 0", len(got))
+	}
+}

--- a/internal/db/binary_verdicts_test.go
+++ b/internal/db/binary_verdicts_test.go
@@ -107,6 +107,34 @@ func TestBinaryVerdictValidation(t *testing.T) {
 	}
 }
 
+func TestBinaryVerdictWeightsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := openBinaryTestStore(t)
+
+	// Explicit weights persist; an unweighted (zero) caller defaults to 1 so the
+	// re-read reproduces the run's weighted aggregation.
+	if err := store.UpsertBinaryVerdict(ctx, BinaryVerdict{RunID: "r", QuestionID: "q1", Dimension: "correctness", Verdict: "yes", QuestionWeight: 3, DimensionWeight: 2}); err != nil {
+		t.Fatalf("upsert weighted: %v", err)
+	}
+	if err := store.UpsertBinaryVerdict(ctx, BinaryVerdict{RunID: "r", QuestionID: "q2", Dimension: "style", Verdict: "no"}); err != nil {
+		t.Fatalf("upsert unweighted: %v", err)
+	}
+	got, err := store.ListBinaryVerdicts(ctx, "r")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("verdicts = %d, want 2", len(got))
+	}
+	// Ordered correctness/q1 then style/q2.
+	if got[0].QuestionWeight != 3 || got[0].DimensionWeight != 2 {
+		t.Fatalf("q1 weights = (%v,%v), want (3,2)", got[0].QuestionWeight, got[0].DimensionWeight)
+	}
+	if got[1].QuestionWeight != 1 || got[1].DimensionWeight != 1 {
+		t.Fatalf("q2 weights = (%v,%v), want defaulted (1,1)", got[1].QuestionWeight, got[1].DimensionWeight)
+	}
+}
+
 func TestListBinaryVerdictsEmpty(t *testing.T) {
 	ctx := context.Background()
 	store := openBinaryTestStore(t)

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4860,6 +4860,64 @@ func (s *Store) UpsertFeedbackEvent(ctx context.Context, event FeedbackEvent) er
 	return err
 }
 
+// BinaryVerdict is one persisted BINEVAL binary-evaluation verdict (#525): a
+// yes/no answer + explanation for a single question of an eval run.
+type BinaryVerdict struct {
+	RunID       string
+	QuestionID  string
+	Dimension   string
+	Verdict     string
+	Explanation string
+	CreatedAt   string
+}
+
+// UpsertBinaryVerdict inserts or replaces one binary verdict keyed by
+// (run_id, question_id) so a re-run of the same question set against the same
+// run overwrites verdicts in place (stable row count).
+func (s *Store) UpsertBinaryVerdict(ctx context.Context, v BinaryVerdict) error {
+	if strings.TrimSpace(v.RunID) == "" {
+		return errors.New("binary verdict run id is required")
+	}
+	if strings.TrimSpace(v.QuestionID) == "" {
+		return errors.New("binary verdict question id is required")
+	}
+	if strings.TrimSpace(v.Verdict) == "" {
+		v.Verdict = "no"
+	}
+	if strings.TrimSpace(v.CreatedAt) == "" {
+		v.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO skillopt_binary_verdicts(run_id, question_id, dimension, verdict, explanation, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(run_id, question_id) DO UPDATE SET
+			dimension = excluded.dimension,
+			verdict = excluded.verdict,
+			explanation = excluded.explanation,
+			created_at = excluded.created_at`,
+		v.RunID, v.QuestionID, v.Dimension, v.Verdict, v.Explanation, v.CreatedAt)
+	return err
+}
+
+// ListBinaryVerdicts returns every binary verdict for a run, ordered by
+// (dimension, question_id) for a deterministic read.
+func (s *Store) ListBinaryVerdicts(ctx context.Context, runID string) ([]BinaryVerdict, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT run_id, question_id, dimension, verdict, explanation, created_at
+		FROM skillopt_binary_verdicts WHERE run_id = ? ORDER BY dimension, question_id`, strings.TrimSpace(runID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var verdicts []BinaryVerdict
+	for rows.Next() {
+		var v BinaryVerdict
+		if err := rows.Scan(&v.RunID, &v.QuestionID, &v.Dimension, &v.Verdict, &v.Explanation, &v.CreatedAt); err != nil {
+			return nil, err
+		}
+		verdicts = append(verdicts, v)
+	}
+	return verdicts, rows.Err()
+}
+
 func (s *Store) ListFeedbackEvents(ctx context.Context, runID string) ([]FeedbackEvent, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT id, run_id, item_id, choice, reasoning, reviewer, source, source_url, created_at
 		FROM feedback_events WHERE run_id = ? ORDER BY item_id, reviewer, source, source_url`, runID)
@@ -7828,5 +7886,25 @@ CREATE TABLE pipeline_run_stages (
 );
 
 CREATE INDEX idx_pipeline_run_stages_run_id ON pipeline_run_stages(run_id);
+	`,
+	// #525 BINEVAL binary evaluation: one row per (eval run, binary question)
+	// recording the yes/no verdict + explanation and the dimension the question
+	// belongs to. Keyed by (run_id, question_id) so re-running a question set
+	// against the same run upserts each verdict in place (stable row count,
+	// corrective overwrite). Pure additive append (CREATE TABLE/INDEX only, no
+	// ALTER/renumber of any prior migration): the table stays empty until
+	// `gitmoot skillopt binary run` executes, so every existing DB — and every
+	// existing SkillOpt review/optimize flow — reads byte-identically.
+	`
+CREATE TABLE skillopt_binary_verdicts (
+	run_id TEXT NOT NULL,
+	question_id TEXT NOT NULL,
+	dimension TEXT NOT NULL DEFAULT '',
+	verdict TEXT NOT NULL DEFAULT 'no',
+	explanation TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (run_id, question_id)
+);
+CREATE INDEX idx_skillopt_binary_verdicts_run ON skillopt_binary_verdicts(run_id);
 	`,
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -4863,12 +4863,14 @@ func (s *Store) UpsertFeedbackEvent(ctx context.Context, event FeedbackEvent) er
 // BinaryVerdict is one persisted BINEVAL binary-evaluation verdict (#525): a
 // yes/no answer + explanation for a single question of an eval run.
 type BinaryVerdict struct {
-	RunID       string
-	QuestionID  string
-	Dimension   string
-	Verdict     string
-	Explanation string
-	CreatedAt   string
+	RunID           string
+	QuestionID      string
+	Dimension       string
+	Verdict         string
+	Explanation     string
+	QuestionWeight  float64
+	DimensionWeight float64
+	CreatedAt       string
 }
 
 // UpsertBinaryVerdict inserts or replaces one binary verdict keyed by
@@ -4884,24 +4886,34 @@ func (s *Store) UpsertBinaryVerdict(ctx context.Context, v BinaryVerdict) error 
 	if strings.TrimSpace(v.Verdict) == "" {
 		v.Verdict = "no"
 	}
+	// Weights default to 1 so an unweighted caller (and the DB DEFAULT) agree,
+	// and so aggregation over the persisted rows reproduces the run's scores.
+	if v.QuestionWeight <= 0 {
+		v.QuestionWeight = 1
+	}
+	if v.DimensionWeight <= 0 {
+		v.DimensionWeight = 1
+	}
 	if strings.TrimSpace(v.CreatedAt) == "" {
 		v.CreatedAt = time.Now().UTC().Format(time.RFC3339)
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO skillopt_binary_verdicts(run_id, question_id, dimension, verdict, explanation, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO skillopt_binary_verdicts(run_id, question_id, dimension, verdict, explanation, question_weight, dimension_weight, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(run_id, question_id) DO UPDATE SET
 			dimension = excluded.dimension,
 			verdict = excluded.verdict,
 			explanation = excluded.explanation,
+			question_weight = excluded.question_weight,
+			dimension_weight = excluded.dimension_weight,
 			created_at = excluded.created_at`,
-		v.RunID, v.QuestionID, v.Dimension, v.Verdict, v.Explanation, v.CreatedAt)
+		v.RunID, v.QuestionID, v.Dimension, v.Verdict, v.Explanation, v.QuestionWeight, v.DimensionWeight, v.CreatedAt)
 	return err
 }
 
 // ListBinaryVerdicts returns every binary verdict for a run, ordered by
 // (dimension, question_id) for a deterministic read.
 func (s *Store) ListBinaryVerdicts(ctx context.Context, runID string) ([]BinaryVerdict, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT run_id, question_id, dimension, verdict, explanation, created_at
+	rows, err := s.db.QueryContext(ctx, `SELECT run_id, question_id, dimension, verdict, explanation, question_weight, dimension_weight, created_at
 		FROM skillopt_binary_verdicts WHERE run_id = ? ORDER BY dimension, question_id`, strings.TrimSpace(runID))
 	if err != nil {
 		return nil, err
@@ -4910,7 +4922,7 @@ func (s *Store) ListBinaryVerdicts(ctx context.Context, runID string) ([]BinaryV
 	var verdicts []BinaryVerdict
 	for rows.Next() {
 		var v BinaryVerdict
-		if err := rows.Scan(&v.RunID, &v.QuestionID, &v.Dimension, &v.Verdict, &v.Explanation, &v.CreatedAt); err != nil {
+		if err := rows.Scan(&v.RunID, &v.QuestionID, &v.Dimension, &v.Verdict, &v.Explanation, &v.QuestionWeight, &v.DimensionWeight, &v.CreatedAt); err != nil {
 			return nil, err
 		}
 		verdicts = append(verdicts, v)
@@ -7902,6 +7914,8 @@ CREATE TABLE skillopt_binary_verdicts (
 	dimension TEXT NOT NULL DEFAULT '',
 	verdict TEXT NOT NULL DEFAULT 'no',
 	explanation TEXT NOT NULL DEFAULT '',
+	question_weight REAL NOT NULL DEFAULT 1,
+	dimension_weight REAL NOT NULL DEFAULT 1,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (run_id, question_id)
 );

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -51,6 +51,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"skillopt_review_watches",
 		"skillopt_judge_outcomes",
 		"interactive_prompts",
+		"skillopt_binary_verdicts",
 		"merge_gate_ci_observations",
 		"job_gates",
 	} {

--- a/internal/skillopt/binary_eval.go
+++ b/internal/skillopt/binary_eval.go
@@ -1,0 +1,358 @@
+package skillopt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BINEVAL-style binary evaluation (#525). A rubric dimension is decomposed into
+// small, independent yes/no questions; each question is answered on its own and
+// the per-question verdicts aggregate back into a per-dimension score and an
+// overall score. This is an ADDITIVE, opt-in evaluation mode — it never runs
+// unless `gitmoot skillopt binary run` is invoked, so every existing SkillOpt
+// review/optimize flow is byte-identical when it is unused.
+//
+// Reference: "Ask, Don't Judge: Binary Questions for Interpretable LLM
+// Evaluation and Self-Improvement" (arXiv:2606.27226), §3.1/§3.2.
+
+// BinaryQuestionSetVersion is the only supported question-set schema version.
+const BinaryQuestionSetVersion = 1
+
+// Binary verdict values.
+const (
+	BinaryVerdictYes = "yes"
+	BinaryVerdictNo  = "no"
+)
+
+// BinaryQuestion is one atomic yes/no check. Weight defaults to 1. The optional
+// ViolationExample documents what a "no" looks like (carried through to the LLM
+// prompt). The Contains/NotContains/Regex/NotRegex fields are consulted ONLY by
+// the deterministic rule-based runner (RuleBasedBinaryEvaluator) — they are the
+// test/deterministic mode and are ignored by the LLM-backed runner.
+type BinaryQuestion struct {
+	ID               string  `json:"id" yaml:"id"`
+	Text             string  `json:"text" yaml:"text"`
+	ViolationExample string  `json:"violation_example,omitempty" yaml:"violation_example,omitempty"`
+	Weight           float64 `json:"weight,omitempty" yaml:"weight,omitempty"`
+
+	// Deterministic/test-mode assertions (rule-based runner only). A question is
+	// answered "yes" only when EVERY specified assertion holds against the source.
+	Contains    string `json:"contains,omitempty" yaml:"contains,omitempty"`
+	NotContains string `json:"not_contains,omitempty" yaml:"not_contains,omitempty"`
+	Regex       string `json:"regex,omitempty" yaml:"regex,omitempty"`
+	NotRegex    string `json:"not_regex,omitempty" yaml:"not_regex,omitempty"`
+}
+
+// BinaryDimension groups related questions. Weight defaults to 1 and scales the
+// dimension's contribution to the overall score.
+type BinaryDimension struct {
+	Name      string           `json:"name" yaml:"name"`
+	Weight    float64          `json:"weight,omitempty" yaml:"weight,omitempty"`
+	Questions []BinaryQuestion `json:"questions" yaml:"questions"`
+}
+
+// BinaryQuestionSet is a loadable (YAML or JSON) BINEVAL question set.
+type BinaryQuestionSet struct {
+	Version            int               `json:"version" yaml:"version"`
+	TemplateOrTaskKind string            `json:"template_or_task_kind,omitempty" yaml:"template_or_task_kind,omitempty"`
+	Dimensions         []BinaryDimension `json:"dimensions" yaml:"dimensions"`
+}
+
+// BinaryAnswer is a single question's verdict + explanation returned by a runner.
+type BinaryAnswer struct {
+	Verdict     string `json:"verdict"`
+	Explanation string `json:"explanation,omitempty"`
+}
+
+// BinaryVerdict is a persisted/exported per-question result. It is the row shape
+// of skillopt_binary_verdicts and the element type of the optional export packet
+// section, so its JSON tags are stable wire.
+type BinaryVerdict struct {
+	QuestionID  string `json:"question_id"`
+	Dimension   string `json:"dimension"`
+	Verdict     string `json:"verdict"`
+	Explanation string `json:"explanation,omitempty"`
+	CreatedAt   string `json:"created_at,omitempty"`
+}
+
+// BinaryEvaluationResult is the aggregated outcome of a run: every verdict, the
+// per-dimension weighted yes-fractions, and the weighted-mean overall score.
+type BinaryEvaluationResult struct {
+	Verdicts        []BinaryVerdict    `json:"verdicts"`
+	DimensionScores map[string]float64 `json:"dimension_scores"`
+	Overall         float64            `json:"overall"`
+}
+
+// BinaryEvaluator answers ONE question at a time against a source output. The
+// two provided implementations are RuleBasedBinaryEvaluator (deterministic, for
+// tests) and the LLM-backed runner wired in the CLI layer (opt-in).
+type BinaryEvaluator interface {
+	Answer(ctx context.Context, dimension string, question BinaryQuestion, source string) (BinaryAnswer, error)
+}
+
+// Normalize applies schema defaults in place: version defaults to 1, every
+// missing/zero weight defaults to 1, and text fields are trimmed. It is
+// idempotent and always runs before Validate.
+func (s *BinaryQuestionSet) Normalize() {
+	if s.Version == 0 {
+		s.Version = BinaryQuestionSetVersion
+	}
+	s.TemplateOrTaskKind = strings.TrimSpace(s.TemplateOrTaskKind)
+	for di := range s.Dimensions {
+		d := &s.Dimensions[di]
+		d.Name = strings.TrimSpace(d.Name)
+		if d.Weight <= 0 {
+			d.Weight = 1
+		}
+		for qi := range d.Questions {
+			q := &d.Questions[qi]
+			q.ID = strings.TrimSpace(q.ID)
+			q.Text = strings.TrimSpace(q.Text)
+			if q.Weight <= 0 {
+				q.Weight = 1
+			}
+		}
+	}
+}
+
+// Validate enforces the schema invariants: supported version, at least one
+// dimension, unique non-empty dimension names, and globally-unique non-empty
+// question ids with non-empty text. Call Normalize first (LoadBinaryQuestionSet
+// and RunBinaryEvaluation both do).
+func (s *BinaryQuestionSet) Validate() error {
+	if s.Version != BinaryQuestionSetVersion {
+		return fmt.Errorf("unsupported binary question set version %d (want %d)", s.Version, BinaryQuestionSetVersion)
+	}
+	if len(s.Dimensions) == 0 {
+		return errors.New("binary question set has no dimensions")
+	}
+	seenDim := map[string]struct{}{}
+	seenID := map[string]struct{}{}
+	total := 0
+	for _, d := range s.Dimensions {
+		if d.Name == "" {
+			return errors.New("binary question set has a dimension with an empty name")
+		}
+		if _, dup := seenDim[d.Name]; dup {
+			return fmt.Errorf("binary question set has duplicate dimension %q", d.Name)
+		}
+		seenDim[d.Name] = struct{}{}
+		if len(d.Questions) == 0 {
+			return fmt.Errorf("dimension %q has no questions", d.Name)
+		}
+		for _, q := range d.Questions {
+			if q.ID == "" {
+				return fmt.Errorf("dimension %q has a question with an empty id", d.Name)
+			}
+			if _, dup := seenID[q.ID]; dup {
+				return fmt.Errorf("binary question set has duplicate question id %q", q.ID)
+			}
+			seenID[q.ID] = struct{}{}
+			if q.Text == "" {
+				return fmt.Errorf("question %q has empty text", q.ID)
+			}
+			if q.Regex != "" {
+				if _, err := regexp.Compile(q.Regex); err != nil {
+					return fmt.Errorf("question %q has invalid regex: %w", q.ID, err)
+				}
+			}
+			if q.NotRegex != "" {
+				if _, err := regexp.Compile(q.NotRegex); err != nil {
+					return fmt.Errorf("question %q has invalid not_regex: %w", q.ID, err)
+				}
+			}
+			total++
+		}
+	}
+	if total == 0 {
+		return errors.New("binary question set has no questions")
+	}
+	return nil
+}
+
+// LoadBinaryQuestionSet reads a question set from a .yaml/.yml/.json file (YAML
+// is a JSON superset, so a .json extension is parsed the same way), applies
+// defaults, and validates it.
+func LoadBinaryQuestionSet(path string) (BinaryQuestionSet, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return BinaryQuestionSet{}, err
+	}
+	return ParseBinaryQuestionSet(raw, filepath.Ext(path))
+}
+
+// ParseBinaryQuestionSet decodes a question set from bytes. ext selects the
+// decoder ("" / ".yaml" / ".yml" / ".json"); YAML decoding accepts JSON too.
+func ParseBinaryQuestionSet(raw []byte, ext string) (BinaryQuestionSet, error) {
+	var set BinaryQuestionSet
+	if err := yaml.Unmarshal(raw, &set); err != nil {
+		return BinaryQuestionSet{}, fmt.Errorf("decode binary question set: %w", err)
+	}
+	set.Normalize()
+	if err := set.Validate(); err != nil {
+		return BinaryQuestionSet{}, err
+	}
+	return set, nil
+}
+
+// RunBinaryEvaluation asks every question ONE AT A TIME through the evaluator,
+// records the verdicts, and aggregates them. It normalizes+validates the set
+// first so callers can pass a raw set. A blank/unknown verdict from the
+// evaluator is coerced to "no" (fail-safe) so a garbled answer never fabricates
+// a pass.
+func RunBinaryEvaluation(ctx context.Context, set BinaryQuestionSet, source string, evaluator BinaryEvaluator) (BinaryEvaluationResult, error) {
+	if evaluator == nil {
+		return BinaryEvaluationResult{}, errors.New("binary evaluator is required")
+	}
+	set.Normalize()
+	if err := set.Validate(); err != nil {
+		return BinaryEvaluationResult{}, err
+	}
+	result := BinaryEvaluationResult{DimensionScores: map[string]float64{}}
+	var overallNum, overallDen float64
+	for _, d := range set.Dimensions {
+		var dimNum, dimDen float64
+		for _, q := range d.Questions {
+			answer, err := evaluator.Answer(ctx, d.Name, q, source)
+			if err != nil {
+				return BinaryEvaluationResult{}, fmt.Errorf("answer question %q: %w", q.ID, err)
+			}
+			verdict := normalizeVerdict(answer.Verdict)
+			result.Verdicts = append(result.Verdicts, BinaryVerdict{
+				QuestionID:  q.ID,
+				Dimension:   d.Name,
+				Verdict:     verdict,
+				Explanation: strings.TrimSpace(answer.Explanation),
+			})
+			dimDen += q.Weight
+			if verdict == BinaryVerdictYes {
+				dimNum += q.Weight
+			}
+		}
+		dimScore := 0.0
+		if dimDen > 0 {
+			dimScore = dimNum / dimDen
+		}
+		result.DimensionScores[d.Name] = dimScore
+		overallNum += d.Weight * dimScore
+		overallDen += d.Weight
+	}
+	if overallDen > 0 {
+		result.Overall = overallNum / overallDen
+	}
+	return result, nil
+}
+
+// normalizeVerdict coerces any verdict to the canonical yes/no, defaulting a
+// blank/unknown value to "no" (fail-safe).
+func normalizeVerdict(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case BinaryVerdictYes, "true", "y", "pass":
+		return BinaryVerdictYes
+	default:
+		return BinaryVerdictNo
+	}
+}
+
+// ToEvaluatorScore maps the aggregated result onto the existing EvaluatorScore
+// shape WITHOUT any contract change: the per-dimension weighted yes-fractions
+// populate DimensionScores. TaskKind carries the set's template_or_task_kind so
+// the score is attributable. The overall score is intentionally left off the
+// contract (it is recoverable as the weighted mean of DimensionScores and is
+// surfaced separately in the CLI/result).
+func (r BinaryEvaluationResult) ToEvaluatorScore(taskKind string) *EvaluatorScore {
+	dims := make(map[string]float64, len(r.DimensionScores))
+	for k, v := range r.DimensionScores {
+		dims[k] = v
+	}
+	return &EvaluatorScore{
+		TaskKind:        strings.TrimSpace(taskKind),
+		DimensionScores: dims,
+	}
+}
+
+// RuleBasedBinaryEvaluator is the DETERMINISTIC, no-LLM runner used by tests and
+// by `binary run --deterministic`. It answers each question purely from the
+// question's Contains/NotContains/Regex/NotRegex assertions applied to the
+// source output: "yes" iff every specified assertion holds. A question with NO
+// assertions cannot be judged deterministically and is answered "no" with an
+// explanatory note (fail-safe — it never fabricates a pass).
+type RuleBasedBinaryEvaluator struct{}
+
+// Answer implements BinaryEvaluator deterministically.
+func (RuleBasedBinaryEvaluator) Answer(_ context.Context, _ string, q BinaryQuestion, source string) (BinaryAnswer, error) {
+	var checks []string
+	pass := true
+	has := false
+	if q.Contains != "" {
+		has = true
+		if strings.Contains(source, q.Contains) {
+			checks = append(checks, fmt.Sprintf("contains %q: yes", q.Contains))
+		} else {
+			pass = false
+			checks = append(checks, fmt.Sprintf("contains %q: no", q.Contains))
+		}
+	}
+	if q.NotContains != "" {
+		has = true
+		if !strings.Contains(source, q.NotContains) {
+			checks = append(checks, fmt.Sprintf("not_contains %q: yes", q.NotContains))
+		} else {
+			pass = false
+			checks = append(checks, fmt.Sprintf("not_contains %q: no", q.NotContains))
+		}
+	}
+	if q.Regex != "" {
+		has = true
+		re, err := regexp.Compile(q.Regex)
+		if err != nil {
+			return BinaryAnswer{}, fmt.Errorf("question %q regex: %w", q.ID, err)
+		}
+		if re.MatchString(source) {
+			checks = append(checks, "regex: yes")
+		} else {
+			pass = false
+			checks = append(checks, "regex: no")
+		}
+	}
+	if q.NotRegex != "" {
+		has = true
+		re, err := regexp.Compile(q.NotRegex)
+		if err != nil {
+			return BinaryAnswer{}, fmt.Errorf("question %q not_regex: %w", q.ID, err)
+		}
+		if !re.MatchString(source) {
+			checks = append(checks, "not_regex: yes")
+		} else {
+			pass = false
+			checks = append(checks, "not_regex: no")
+		}
+	}
+	if !has {
+		return BinaryAnswer{Verdict: BinaryVerdictNo, Explanation: "no deterministic assertion on question"}, nil
+	}
+	verdict := BinaryVerdictNo
+	if pass {
+		verdict = BinaryVerdictYes
+	}
+	return BinaryAnswer{Verdict: verdict, Explanation: strings.Join(checks, "; ")}, nil
+}
+
+// SortBinaryVerdicts orders verdicts by (dimension, question_id) so persisted
+// and exported ordering is deterministic.
+func SortBinaryVerdicts(verdicts []BinaryVerdict) {
+	sort.SliceStable(verdicts, func(i, j int) bool {
+		if verdicts[i].Dimension != verdicts[j].Dimension {
+			return verdicts[i].Dimension < verdicts[j].Dimension
+		}
+		return verdicts[i].QuestionID < verdicts[j].QuestionID
+	})
+}

--- a/internal/skillopt/binary_eval.go
+++ b/internal/skillopt/binary_eval.go
@@ -75,12 +75,20 @@ type BinaryAnswer struct {
 // BinaryVerdict is a persisted/exported per-question result. It is the row shape
 // of skillopt_binary_verdicts and the element type of the optional export packet
 // section, so its JSON tags are stable wire.
+//
+// QuestionWeight and DimensionWeight carry the exact weights RunBinaryEvaluation
+// used to aggregate (both default to 1), so a re-read of the persisted rows —
+// via `skillopt binary show` or an exported packet — can reproduce the SAME
+// weighted per-dimension/overall scores the run emitted. They are additive
+// (omitempty) and only populated for BINEVAL rows.
 type BinaryVerdict struct {
-	QuestionID  string `json:"question_id"`
-	Dimension   string `json:"dimension"`
-	Verdict     string `json:"verdict"`
-	Explanation string `json:"explanation,omitempty"`
-	CreatedAt   string `json:"created_at,omitempty"`
+	QuestionID      string  `json:"question_id"`
+	Dimension       string  `json:"dimension"`
+	Verdict         string  `json:"verdict"`
+	Explanation     string  `json:"explanation,omitempty"`
+	QuestionWeight  float64 `json:"question_weight,omitempty"`
+	DimensionWeight float64 `json:"dimension_weight,omitempty"`
+	CreatedAt       string  `json:"created_at,omitempty"`
 }
 
 // BinaryEvaluationResult is the aggregated outcome of a run: every verdict, the
@@ -227,10 +235,12 @@ func RunBinaryEvaluation(ctx context.Context, set BinaryQuestionSet, source stri
 			}
 			verdict := normalizeVerdict(answer.Verdict)
 			result.Verdicts = append(result.Verdicts, BinaryVerdict{
-				QuestionID:  q.ID,
-				Dimension:   d.Name,
-				Verdict:     verdict,
-				Explanation: strings.TrimSpace(answer.Explanation),
+				QuestionID:      q.ID,
+				Dimension:       d.Name,
+				Verdict:         verdict,
+				Explanation:     strings.TrimSpace(answer.Explanation),
+				QuestionWeight:  q.Weight,
+				DimensionWeight: d.Weight,
 			})
 			dimDen += q.Weight
 			if verdict == BinaryVerdictYes {
@@ -344,6 +354,58 @@ func (RuleBasedBinaryEvaluator) Answer(_ context.Context, _ string, q BinaryQues
 		verdict = BinaryVerdictYes
 	}
 	return BinaryAnswer{Verdict: verdict, Explanation: strings.Join(checks, "; ")}, nil
+}
+
+// AggregateBinaryVerdicts recomputes the per-dimension weighted yes-fractions
+// and the weighted-mean overall score from a slice of verdicts, applying each
+// verdict's persisted QuestionWeight/DimensionWeight EXACTLY as
+// RunBinaryEvaluation does. A zero/absent weight is treated as 1 so rows written
+// before weights were persisted still aggregate as equal-weight. This is the
+// canonical re-read aggregation used by `skillopt binary show`, so `show`
+// reproduces the same scores the `run` that produced the rows emitted.
+func AggregateBinaryVerdicts(verdicts []BinaryVerdict) (map[string]float64, float64) {
+	type acc struct {
+		num, den float64
+		dimW     float64
+	}
+	perDim := map[string]*acc{}
+	order := []string{}
+	for _, v := range verdicts {
+		a, ok := perDim[v.Dimension]
+		if !ok {
+			a = &acc{dimW: 1}
+			perDim[v.Dimension] = a
+			order = append(order, v.Dimension)
+		}
+		if v.DimensionWeight > 0 {
+			a.dimW = v.DimensionWeight
+		}
+		qw := v.QuestionWeight
+		if qw <= 0 {
+			qw = 1
+		}
+		a.den += qw
+		if strings.EqualFold(strings.TrimSpace(v.Verdict), BinaryVerdictYes) {
+			a.num += qw
+		}
+	}
+	scores := map[string]float64{}
+	var overallNum, overallDen float64
+	for _, dim := range order {
+		a := perDim[dim]
+		s := 0.0
+		if a.den > 0 {
+			s = a.num / a.den
+		}
+		scores[dim] = s
+		overallNum += a.dimW * s
+		overallDen += a.dimW
+	}
+	overall := 0.0
+	if overallDen > 0 {
+		overall = overallNum / overallDen
+	}
+	return scores, overall
 }
 
 // SortBinaryVerdicts orders verdicts by (dimension, question_id) so persisted

--- a/internal/skillopt/binary_eval_test.go
+++ b/internal/skillopt/binary_eval_test.go
@@ -1,0 +1,246 @@
+package skillopt
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func TestBinaryQuestionSetNormalizeDefaults(t *testing.T) {
+	set := BinaryQuestionSet{
+		Dimensions: []BinaryDimension{
+			{Name: "clarity", Questions: []BinaryQuestion{{ID: "q1", Text: "clear?"}}},
+		},
+	}
+	set.Normalize()
+	if set.Version != BinaryQuestionSetVersion {
+		t.Fatalf("version default = %d, want %d", set.Version, BinaryQuestionSetVersion)
+	}
+	if set.Dimensions[0].Weight != 1 {
+		t.Fatalf("dimension weight default = %v, want 1", set.Dimensions[0].Weight)
+	}
+	if set.Dimensions[0].Questions[0].Weight != 1 {
+		t.Fatalf("question weight default = %v, want 1", set.Dimensions[0].Questions[0].Weight)
+	}
+	if err := set.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestBinaryQuestionSetValidateDuplicateID(t *testing.T) {
+	set := BinaryQuestionSet{
+		Version: 1,
+		Dimensions: []BinaryDimension{
+			{Name: "a", Questions: []BinaryQuestion{{ID: "dup", Text: "x"}}},
+			{Name: "b", Questions: []BinaryQuestion{{ID: "dup", Text: "y"}}},
+		},
+	}
+	set.Normalize()
+	if err := set.Validate(); err == nil {
+		t.Fatal("expected duplicate id error")
+	}
+}
+
+func TestBinaryQuestionSetValidateErrors(t *testing.T) {
+	cases := map[string]BinaryQuestionSet{
+		"bad version":        {Version: 2, Dimensions: []BinaryDimension{{Name: "a", Questions: []BinaryQuestion{{ID: "q", Text: "t"}}}}},
+		"no dimensions":      {Version: 1},
+		"empty dim name":     {Version: 1, Dimensions: []BinaryDimension{{Questions: []BinaryQuestion{{ID: "q", Text: "t"}}}}},
+		"dup dim":            {Version: 1, Dimensions: []BinaryDimension{{Name: "a", Questions: []BinaryQuestion{{ID: "q1", Text: "t"}}}, {Name: "a", Questions: []BinaryQuestion{{ID: "q2", Text: "t"}}}}},
+		"empty question id":  {Version: 1, Dimensions: []BinaryDimension{{Name: "a", Questions: []BinaryQuestion{{Text: "t"}}}}},
+		"empty text":         {Version: 1, Dimensions: []BinaryDimension{{Name: "a", Questions: []BinaryQuestion{{ID: "q"}}}}},
+		"no questions in dim": {Version: 1, Dimensions: []BinaryDimension{{Name: "a"}}},
+		"bad regex":          {Version: 1, Dimensions: []BinaryDimension{{Name: "a", Questions: []BinaryQuestion{{ID: "q", Text: "t", Regex: "("}}}}},
+	}
+	for name, set := range cases {
+		t.Run(name, func(t *testing.T) {
+			if err := set.Validate(); err == nil {
+				t.Fatalf("expected validation error for %q", name)
+			}
+		})
+	}
+}
+
+func TestParseBinaryQuestionSetYAML(t *testing.T) {
+	yaml := `
+version: 1
+template_or_task_kind: bugfix
+dimensions:
+  - name: correctness
+    weight: 2
+    questions:
+      - id: has_test
+        text: Does the change add a test?
+        contains: "func Test"
+      - id: no_todo
+        text: Is the change free of TODOs?
+        not_contains: "TODO"
+`
+	set, err := ParseBinaryQuestionSet([]byte(yaml), ".yaml")
+	if err != nil {
+		t.Fatalf("parse yaml: %v", err)
+	}
+	if set.TemplateOrTaskKind != "bugfix" {
+		t.Fatalf("template_or_task_kind = %q", set.TemplateOrTaskKind)
+	}
+	if len(set.Dimensions) != 1 || len(set.Dimensions[0].Questions) != 2 {
+		t.Fatalf("unexpected shape: %+v", set)
+	}
+	if set.Dimensions[0].Weight != 2 {
+		t.Fatalf("dimension weight = %v", set.Dimensions[0].Weight)
+	}
+}
+
+func TestParseBinaryQuestionSetJSON(t *testing.T) {
+	js := `{"version":1,"dimensions":[{"name":"d","questions":[{"id":"q","text":"t","contains":"x"}]}]}`
+	set, err := ParseBinaryQuestionSet([]byte(js), ".json")
+	if err != nil {
+		t.Fatalf("parse json: %v", err)
+	}
+	if len(set.Dimensions) != 1 {
+		t.Fatalf("unexpected shape: %+v", set)
+	}
+}
+
+func TestRuleBasedEvaluatorVerdicts(t *testing.T) {
+	ev := RuleBasedBinaryEvaluator{}
+	ctx := context.Background()
+
+	yes, err := ev.Answer(ctx, "d", BinaryQuestion{ID: "q", Text: "t", Contains: "hello"}, "hello world")
+	if err != nil {
+		t.Fatalf("answer: %v", err)
+	}
+	if yes.Verdict != BinaryVerdictYes {
+		t.Fatalf("contains hit verdict = %q, want yes", yes.Verdict)
+	}
+
+	no, _ := ev.Answer(ctx, "d", BinaryQuestion{ID: "q", Text: "t", Contains: "missing"}, "hello world")
+	if no.Verdict != BinaryVerdictNo {
+		t.Fatalf("contains miss verdict = %q, want no", no.Verdict)
+	}
+
+	reNo, _ := ev.Answer(ctx, "d", BinaryQuestion{ID: "q", Text: "t", NotContains: "world"}, "hello world")
+	if reNo.Verdict != BinaryVerdictNo {
+		t.Fatalf("not_contains hit verdict = %q, want no", reNo.Verdict)
+	}
+
+	reYes, _ := ev.Answer(ctx, "d", BinaryQuestion{ID: "q", Text: "t", Regex: `^h.*d$`}, "hello world")
+	if reYes.Verdict != BinaryVerdictYes {
+		t.Fatalf("regex verdict = %q, want yes", reYes.Verdict)
+	}
+
+	// A question with no assertions cannot be judged deterministically -> no.
+	none, _ := ev.Answer(ctx, "d", BinaryQuestion{ID: "q", Text: "t"}, "anything")
+	if none.Verdict != BinaryVerdictNo {
+		t.Fatalf("no-assertion verdict = %q, want no", none.Verdict)
+	}
+}
+
+func TestRunBinaryEvaluationAggregation(t *testing.T) {
+	set := BinaryQuestionSet{
+		Version: 1,
+		Dimensions: []BinaryDimension{
+			{
+				Name:   "correctness",
+				Weight: 2,
+				Questions: []BinaryQuestion{
+					{ID: "c1", Text: "t", Contains: "alpha"},   // yes
+					{ID: "c2", Text: "t", Contains: "missing"}, // no
+				},
+			},
+			{
+				Name:   "style",
+				Weight: 1,
+				Questions: []BinaryQuestion{
+					{ID: "s1", Text: "t", Contains: "beta"}, // yes
+				},
+			},
+		},
+	}
+	res, err := RunBinaryEvaluation(context.Background(), set, "alpha beta", RuleBasedBinaryEvaluator{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(res.Verdicts) != 3 {
+		t.Fatalf("verdicts = %d, want 3", len(res.Verdicts))
+	}
+	if got := res.DimensionScores["correctness"]; got != 0.5 {
+		t.Fatalf("correctness score = %v, want 0.5", got)
+	}
+	if got := res.DimensionScores["style"]; got != 1.0 {
+		t.Fatalf("style score = %v, want 1.0", got)
+	}
+	// overall = (2*0.5 + 1*1.0) / 3 = 2/3
+	want := 2.0 / 3.0
+	if math.Abs(res.Overall-want) > 1e-9 {
+		t.Fatalf("overall = %v, want %v", res.Overall, want)
+	}
+}
+
+func TestRunBinaryEvaluationWeightedQuestions(t *testing.T) {
+	set := BinaryQuestionSet{
+		Version: 1,
+		Dimensions: []BinaryDimension{
+			{
+				Name: "d",
+				Questions: []BinaryQuestion{
+					{ID: "q1", Text: "t", Weight: 3, Contains: "yes"}, // yes (weight 3)
+					{ID: "q2", Text: "t", Weight: 1, Contains: "no"},  // no  (weight 1)
+				},
+			},
+		},
+	}
+	res, err := RunBinaryEvaluation(context.Background(), set, "yes only", RuleBasedBinaryEvaluator{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// weighted yes-fraction = 3 / (3+1) = 0.75
+	if got := res.DimensionScores["d"]; math.Abs(got-0.75) > 1e-9 {
+		t.Fatalf("weighted dim score = %v, want 0.75", got)
+	}
+}
+
+func TestToEvaluatorScoreShape(t *testing.T) {
+	res := BinaryEvaluationResult{
+		DimensionScores: map[string]float64{"a": 0.5, "b": 1.0},
+		Overall:         0.75,
+	}
+	score := res.ToEvaluatorScore("bugfix")
+	if score.TaskKind != "bugfix" {
+		t.Fatalf("task kind = %q", score.TaskKind)
+	}
+	if len(score.DimensionScores) != 2 || score.DimensionScores["a"] != 0.5 {
+		t.Fatalf("dimension scores = %+v", score.DimensionScores)
+	}
+	if score.Soft != nil || score.Hard != nil {
+		t.Fatal("expected Soft/Hard unset (contract additive, DimensionScores only)")
+	}
+}
+
+// stubEvaluator lets RunBinaryEvaluation be tested independently of the rule runner.
+type stubEvaluator struct{ answers map[string]BinaryAnswer }
+
+func (s stubEvaluator) Answer(_ context.Context, _ string, q BinaryQuestion, _ string) (BinaryAnswer, error) {
+	return s.answers[q.ID], nil
+}
+
+func TestRunBinaryEvaluationCoercesUnknownVerdict(t *testing.T) {
+	set := BinaryQuestionSet{
+		Version:    1,
+		Dimensions: []BinaryDimension{{Name: "d", Questions: []BinaryQuestion{{ID: "q1", Text: "t"}, {ID: "q2", Text: "t"}}}},
+	}
+	ev := stubEvaluator{answers: map[string]BinaryAnswer{
+		"q1": {Verdict: "YES"},
+		"q2": {Verdict: "garbage"},
+	}}
+	res, err := RunBinaryEvaluation(context.Background(), set, "", ev)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Verdicts[0].Verdict != BinaryVerdictYes {
+		t.Fatalf("q1 verdict = %q, want yes (case-insensitive)", res.Verdicts[0].Verdict)
+	}
+	if res.Verdicts[1].Verdict != BinaryVerdictNo {
+		t.Fatalf("q2 verdict = %q, want no (fail-safe coercion)", res.Verdicts[1].Verdict)
+	}
+}

--- a/internal/skillopt/binary_eval_test.go
+++ b/internal/skillopt/binary_eval_test.go
@@ -200,6 +200,72 @@ func TestRunBinaryEvaluationWeightedQuestions(t *testing.T) {
 	}
 }
 
+// TestAggregateBinaryVerdictsMatchesRun proves the re-read aggregation (used by
+// `skillopt binary show`) reproduces the SAME weighted scores RunBinaryEvaluation
+// emits — for BOTH non-uniform dimension weights and non-uniform question weights
+// — so the two commands never disagree on the same run (#525 review finding).
+func TestAggregateBinaryVerdictsMatchesRun(t *testing.T) {
+	set := BinaryQuestionSet{
+		Version: 1,
+		Dimensions: []BinaryDimension{
+			{
+				Name:   "correctness",
+				Weight: 2,
+				Questions: []BinaryQuestion{
+					{ID: "q1", Text: "t", Weight: 3, Contains: "yes"}, // yes (w3)
+					{ID: "q2", Text: "t", Weight: 1, Contains: "no"},  // no  (w1)
+				},
+			},
+			{
+				Name:   "style",
+				Weight: 1,
+				Questions: []BinaryQuestion{
+					{ID: "q3", Text: "t", Contains: "yes"}, // yes (default w1)
+				},
+			},
+		},
+	}
+	res, err := RunBinaryEvaluation(context.Background(), set, "yes only", RuleBasedBinaryEvaluator{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// The verdicts carry the weights RunBinaryEvaluation used; re-aggregating them
+	// must yield identical per-dimension and overall scores.
+	dims, overall := AggregateBinaryVerdicts(res.Verdicts)
+	for name, want := range res.DimensionScores {
+		if math.Abs(dims[name]-want) > 1e-9 {
+			t.Fatalf("re-read dim %s = %v, want %v", name, dims[name], want)
+		}
+	}
+	if math.Abs(overall-res.Overall) > 1e-9 {
+		t.Fatalf("re-read overall = %v, want %v", overall, res.Overall)
+	}
+	// Sanity: correctness = 3/4 (weighted), style = 1, overall = (2*0.75 + 1*1)/3.
+	if math.Abs(dims["correctness"]-0.75) > 1e-9 {
+		t.Fatalf("correctness = %v, want 0.75", dims["correctness"])
+	}
+	if math.Abs(overall-(2.0*0.75+1.0*1.0)/3.0) > 1e-9 {
+		t.Fatalf("overall = %v, want %v", overall, (2.0*0.75+1.0*1.0)/3.0)
+	}
+}
+
+// TestAggregateBinaryVerdictsDefaultsZeroWeight proves rows written before
+// weights were persisted (zero weight) aggregate as equal-weight rather than
+// collapsing a dimension to a divide-by-zero.
+func TestAggregateBinaryVerdictsDefaultsZeroWeight(t *testing.T) {
+	verdicts := []BinaryVerdict{
+		{QuestionID: "q1", Dimension: "d", Verdict: "yes"}, // zero weights
+		{QuestionID: "q2", Dimension: "d", Verdict: "no"},
+	}
+	dims, overall := AggregateBinaryVerdicts(verdicts)
+	if math.Abs(dims["d"]-0.5) > 1e-9 {
+		t.Fatalf("dim d = %v, want 0.5 (equal-weight fallback)", dims["d"])
+	}
+	if math.Abs(overall-0.5) > 1e-9 {
+		t.Fatalf("overall = %v, want 0.5", overall)
+	}
+}
+
 func TestToEvaluatorScoreShape(t *testing.T) {
 	res := BinaryEvaluationResult{
 		DimensionScores: map[string]float64{"a": 0.5, "b": 1.0},

--- a/internal/skillopt/binary_export_test.go
+++ b/internal/skillopt/binary_export_test.go
@@ -1,0 +1,114 @@
+package skillopt
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestExportTrainingPackageIncludesBinaryVerdicts(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	template := testTemplate("planner", "Plan carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "run-b",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "ready",
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun: %v", err)
+	}
+	if err := store.UpsertBinaryVerdict(ctx, db.BinaryVerdict{RunID: "run-b", QuestionID: "q1", Dimension: "correctness", Verdict: "yes", Explanation: "ok"}); err != nil {
+		t.Fatalf("UpsertBinaryVerdict: %v", err)
+	}
+	if err := store.UpsertBinaryVerdict(ctx, db.BinaryVerdict{RunID: "run-b", QuestionID: "q2", Dimension: "style", Verdict: "no"}); err != nil {
+		t.Fatalf("UpsertBinaryVerdict: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "run-b")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage: %v", err)
+	}
+	if len(pkg.BinaryVerdicts) != 2 {
+		t.Fatalf("binary verdicts = %d, want 2", len(pkg.BinaryVerdicts))
+	}
+	if pkg.BinaryVerdicts[0].QuestionID != "q1" || pkg.BinaryVerdicts[0].Verdict != "yes" {
+		t.Fatalf("first verdict = %+v", pkg.BinaryVerdicts[0])
+	}
+
+	// JSON round-trip preserves the section.
+	raw, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"binary_verdicts"`) {
+		t.Fatalf("marshaled packet missing binary_verdicts section: %s", raw)
+	}
+	var decoded TrainingPackage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(decoded.BinaryVerdicts) != 2 || decoded.BinaryVerdicts[1].Dimension != "style" {
+		t.Fatalf("round-tripped verdicts = %+v", decoded.BinaryVerdicts)
+	}
+}
+
+func TestExportTrainingPackageOmitsBinaryVerdictsWhenAbsent(t *testing.T) {
+	ctx := context.Background()
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	template := testTemplate("planner", "Plan carefully.")
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate: %v", err)
+	}
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:                "run-empty",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/repo",
+		State:             "ready",
+	}); err != nil {
+		t.Fatalf("UpsertEvalRun: %v", err)
+	}
+
+	pkg, err := ExportTrainingPackage(ctx, store, "run-empty")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage: %v", err)
+	}
+	if pkg.BinaryVerdicts != nil {
+		t.Fatalf("binary verdicts = %+v, want nil", pkg.BinaryVerdicts)
+	}
+	// omitempty keeps a verdict-less packet byte-identical to the pre-#525 shape.
+	raw, err := json.Marshal(pkg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "binary_verdicts") {
+		t.Fatalf("verdict-less packet unexpectedly carries binary_verdicts: %s", raw)
+	}
+}

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -432,6 +432,11 @@ type TrainingPackage struct {
 	FeedbackContext      json.RawMessage       `json:"feedback_context,omitempty"`
 	EvaluatorConfig      json.RawMessage       `json:"evaluator_config,omitempty"`
 	EvaluatorProfile     *EvaluatorProfile     `json:"evaluator_profile,omitempty"`
+	// BinaryVerdicts is the OPTIONAL BINEVAL binary-evaluation section (#525):
+	// per-question yes/no verdicts for the run. omitempty keeps old packets (and
+	// runs with no binary verdicts) byte-identical; the field round-trips through
+	// export/import unchanged. No contract-version bump (additive field).
+	BinaryVerdicts []BinaryVerdict `json:"binary_verdicts,omitempty"`
 }
 
 type CandidateTemplate struct {
@@ -737,6 +742,10 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 	if err != nil {
 		return TrainingPackage{}, err
 	}
+	binaryVerdicts, err := loadBinaryVerdicts(ctx, store, run.ID)
+	if err != nil {
+		return TrainingPackage{}, err
+	}
 	feedbackContext, err := buildTrainingFeedbackContext(run, feedbackEvents, rankedFeedbackEvents)
 	if err != nil {
 		return TrainingPackage{}, err
@@ -774,7 +783,32 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 		FeedbackContext:      feedbackContext,
 		EvaluatorConfig:      evaluatorConfig,
 		EvaluatorProfile:     evaluatorProfile,
+		BinaryVerdicts:       binaryVerdicts,
 	}, nil
+}
+
+// loadBinaryVerdicts reads the run's persisted BINEVAL verdicts (#525) into the
+// packet's optional section. A run with none yields a nil slice (omitempty), so
+// the exported packet is byte-identical to the pre-#525 shape.
+func loadBinaryVerdicts(ctx context.Context, store *db.Store, runID string) ([]BinaryVerdict, error) {
+	rows, err := store.ListBinaryVerdicts(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	out := make([]BinaryVerdict, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, BinaryVerdict{
+			QuestionID:  r.QuestionID,
+			Dimension:   r.Dimension,
+			Verdict:     r.Verdict,
+			Explanation: r.Explanation,
+			CreatedAt:   r.CreatedAt,
+		})
+	}
+	return out, nil
 }
 
 func evaluatorConfigFromRunMetadata(metadata json.RawMessage) (json.RawMessage, error) {

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -801,11 +801,13 @@ func loadBinaryVerdicts(ctx context.Context, store *db.Store, runID string) ([]B
 	out := make([]BinaryVerdict, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, BinaryVerdict{
-			QuestionID:  r.QuestionID,
-			Dimension:   r.Dimension,
-			Verdict:     r.Verdict,
-			Explanation: r.Explanation,
-			CreatedAt:   r.CreatedAt,
+			QuestionID:      r.QuestionID,
+			Dimension:       r.Dimension,
+			Verdict:         r.Verdict,
+			Explanation:     r.Explanation,
+			QuestionWeight:  r.QuestionWeight,
+			DimensionWeight: r.DimensionWeight,
+			CreatedAt:       r.CreatedAt,
 		})
 	}
 	return out, nil

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1088,6 +1088,8 @@ gitmoot skillopt candidate promote <version-id>
 gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-command cmd] [--config path] [--json]
 gitmoot skillopt gate history --candidate <version-id> [--json]
+gitmoot skillopt binary run --set <file> --run <run-id> --source <file> [--deterministic] [--reviewer runtime] [--home path] [--json]
+gitmoot skillopt binary show --run <run-id> [--home path] [--json]
 gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 gitmoot skillopt pairwise import <packet-dir> [--packet path] [--secret-map path] [--picks path] [--reviewer name] [--json]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
@@ -1220,6 +1222,29 @@ applies, and a non-decisive or budget-exhausted stream **fails safe** to a
 `pace_blocked` notify (no promotion). Off (the default) it is never consulted —
 byte-identical. Knobs: `pace_alpha` (default `0.05` → threshold 20), `pace_lambda`
 (default `0.5`), `pace_max_pairs` (default `200`).
+
+`skillopt binary run --set <file> --run <run-id> --source <file>` runs the
+off-by-default, additive **BINEVAL-style binary evaluation** (`#525`): instead of
+one opaque scalar judge score, a rubric is decomposed into small, independent
+**yes/no questions**, each answered on its own with a verdict plus explanation,
+and the per-question verdicts aggregate into a per-dimension **weighted
+yes-fraction** and a weighted-mean **overall** score. The **question set** is a
+YAML or JSON file (`{version: 1, template_or_task_kind, dimensions: [{name,
+weight, questions: [{id, text, violation_example, weight}]}]}`); ids must be
+unique and weights default to `1`. `--deterministic` uses a **rule-based runner**
+(no LLM) that answers each question purely from optional
+`contains`/`not_contains`/`regex`/`not_regex` assertions on the question — the
+reproducible/test mode. Without `--deterministic`, `--reviewer <runtime>` selects
+an **opt-in LLM-backed runner** wired through the same cross-family judge plumbing
+as `skillopt ab --judge`, so each question is answered by a *different* family
+(never a self-preference), read-only. Verdicts persist to the additive
+`skillopt_binary_verdicts` table keyed by `(run_id, question_id)` and are re-read
+by `skillopt binary show --run <run-id>`; they also ride the training-package
+export as an **optional** `binary_verdicts` section (omitempty — verdict-less
+packets are byte-identical). The per-dimension scores map onto the existing
+`EvaluatorScore.DimensionScores` shape with **no contract change**. Nothing here
+runs unless a `skillopt binary` command is invoked — every existing SkillOpt
+review/optimize flow is byte-identical when it is unused.
 
 `skillopt pairwise import <packet-dir>` ingests a **blinded paired-review
 packet** produced by the gitmoot-skillopt fork (the `pairwise-review.json`

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1239,7 +1239,10 @@ an **opt-in LLM-backed runner** wired through the same cross-family judge plumbi
 as `skillopt ab --judge`, so each question is answered by a *different* family
 (never a self-preference), read-only. Verdicts persist to the additive
 `skillopt_binary_verdicts` table keyed by `(run_id, question_id)` and are re-read
-by `skillopt binary show --run <run-id>`; they also ride the training-package
+by `skillopt binary show --run <run-id>`. Each row also stores the
+`question_weight`/`dimension_weight` the run used (default `1`), so `show`
+re-aggregates with the same weighting and reports the **identical** per-dimension
+and overall scores `run` emitted (even for non-uniform weights). They also ride the training-package
 export as an **optional** `binary_verdicts` section (omitempty — verdict-less
 packets are byte-identical). The per-dimension scores map onto the existing
 `EvaluatorScore.DimensionScores` shape with **no contract change**. Nothing here

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -44,6 +44,12 @@ The exported package has:
   reasoning
 - `pairwise_preferences`: derived pairwise preferences expanded from ranked
   feedback, for example `C > A > D > B` becomes six ordered preferences
+- `binary_verdicts`: **optional** BINEVAL binary-evaluation verdicts (`#525`),
+  present only when a `gitmoot skillopt binary run` recorded them for the run.
+  Each entry carries `question_id`, `dimension`, `verdict` (`yes`/`no`),
+  `explanation`, and `created_at`. The section is `omitempty` — a run with no
+  binary verdicts exports the pre-existing packet shape byte-for-byte, and no
+  `contract_version` bump is required.
 - `evaluator_config`: evaluator and run metadata used by the external
   optimizer. Top-level workflow mode is exported as `training_mode`, not as
   `evaluator_config.mode`; `evaluator_config.mode` is reserved for evaluator
@@ -415,6 +421,53 @@ records a `hard_verifiers_failed` job event and is swallowed. Because it re-runs
 tests, it only maps onto **testable** implement
 legs — subjective review-quality kinds keep the soft cross-family signal. Promotion
 stays manual.
+
+### Binary evaluation (BINEVAL, off by default)
+
+`gitmoot skillopt binary run --set <file> --run <run-id> --source <file>` runs an
+additive, opt-in **BINEVAL-style binary evaluation** (`#525`, after
+[arXiv:2606.27226](https://arxiv.org/abs/2606.27226)). Instead of one opaque
+scalar judge score, a rubric is decomposed into small, **independent yes/no
+questions**; each is answered on its own with a `verdict` (`yes`/`no`) plus an
+`explanation`, and the per-question verdicts aggregate into a per-dimension
+**weighted yes-fraction** and a weighted-mean **overall** score.
+
+The **question set** is a YAML or JSON file:
+
+```yaml
+version: 1
+template_or_task_kind: bugfix
+dimensions:
+  - name: correctness
+    weight: 2
+    questions:
+      - id: has_test
+        text: Does the output add a test?
+        violation_example: A change with no accompanying test.
+        weight: 1
+        contains: "func Test"     # deterministic-mode assertion only
+```
+
+Question ids must be unique across the whole set; dimension and question weights
+default to `1`. Two runners are provided:
+
+- **Deterministic (`--deterministic`)** — a rule-based runner that answers each
+  question purely from optional `contains` / `not_contains` / `regex` /
+  `not_regex` assertions on the question, applied to the `--source` output. This
+  is the reproducible/test mode (no LLM).
+- **LLM-backed (`--reviewer <runtime>`)** — an opt-in runner wired through the
+  **same cross-family judge plumbing** as `skillopt ab --judge`, so every
+  question is answered by a *different* runtime family (never a self-preference),
+  read-only, one question at a time.
+
+Verdicts persist to the additive `skillopt_binary_verdicts` table keyed by
+`(run_id, question_id)` (a re-run upserts in place) and are re-read by
+`gitmoot skillopt binary show --run <run-id>`. The per-dimension scores map onto
+the existing `EvaluatorScore.DimensionScores` shape with **no contract change**,
+and the verdicts ride the training-package export as the optional
+`binary_verdicts` section described above. The whole surface is inert unless a
+`skillopt binary` command is invoked — every existing review/optimize flow is
+byte-identical when it is unused.
 
 ### Promotion policy + notifications (off by default)
 

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -462,7 +462,11 @@ default to `1`. Two runners are provided:
 
 Verdicts persist to the additive `skillopt_binary_verdicts` table keyed by
 `(run_id, question_id)` (a re-run upserts in place) and are re-read by
-`gitmoot skillopt binary show --run <run-id>`. The per-dimension scores map onto
+`gitmoot skillopt binary show --run <run-id>`. Each persisted row carries the
+`question_weight` and `dimension_weight` the run used (both default to `1`), so
+`show` re-aggregates with the **same weighted logic** and reports the identical
+per-dimension/overall scores the `run` emitted — even when weights are
+non-uniform — and exported packets can reproduce them too. The per-dimension scores map onto
 the existing `EvaluatorScore.DimensionScores` shape with **no contract change**,
 and the verdicts ride the training-package export as the optional
 `binary_verdicts` section described above. The whole surface is inert unless a

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -8973,6 +8973,8 @@ gitmoot skillopt candidate promote <version-id>
 gitmoot skillopt candidate reject <version-id> [--reason text]
 gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-command cmd] [--config path] [--json]
 gitmoot skillopt gate history --candidate <version-id> [--json]
+gitmoot skillopt binary run --set <file> --run <run-id> --source <file> [--deterministic] [--reviewer runtime] [--home path] [--json]
+gitmoot skillopt binary show --run <run-id> [--home path] [--json]
 gitmoot skillopt ab <agent> "<prompt>" [--challenger <versionId>] [--pick a|b] [--seed N] [--judge] [--judge-only] [--home path]
 gitmoot skillopt pairwise import <packet-dir> [--packet path] [--secret-map path] [--picks path] [--reviewer name] [--json]
 gitmoot skillopt feedback markdown export --run <run-id> --output .gitmoot/evals/<run-id>
@@ -9105,6 +9107,29 @@ applies, and a non-decisive or budget-exhausted stream **fails safe** to a
 `pace_blocked` notify (no promotion). Off (the default) it is never consulted —
 byte-identical. Knobs: `pace_alpha` (default `0.05` → threshold 20), `pace_lambda`
 (default `0.5`), `pace_max_pairs` (default `200`).
+
+`skillopt binary run --set <file> --run <run-id> --source <file>` runs the
+off-by-default, additive **BINEVAL-style binary evaluation** (`#525`): instead of
+one opaque scalar judge score, a rubric is decomposed into small, independent
+**yes/no questions**, each answered on its own with a verdict plus explanation,
+and the per-question verdicts aggregate into a per-dimension **weighted
+yes-fraction** and a weighted-mean **overall** score. The **question set** is a
+YAML or JSON file (`{version: 1, template_or_task_kind, dimensions: [{name,
+weight, questions: [{id, text, violation_example, weight}]}]}`); ids must be
+unique and weights default to `1`. `--deterministic` uses a **rule-based runner**
+(no LLM) that answers each question purely from optional
+`contains`/`not_contains`/`regex`/`not_regex` assertions on the question — the
+reproducible/test mode. Without `--deterministic`, `--reviewer <runtime>` selects
+an **opt-in LLM-backed runner** wired through the same cross-family judge plumbing
+as `skillopt ab --judge`, so each question is answered by a *different* family
+(never a self-preference), read-only. Verdicts persist to the additive
+`skillopt_binary_verdicts` table keyed by `(run_id, question_id)` and are re-read
+by `skillopt binary show --run <run-id>`; they also ride the training-package
+export as an **optional** `binary_verdicts` section (omitempty — verdict-less
+packets are byte-identical). The per-dimension scores map onto the existing
+`EvaluatorScore.DimensionScores` shape with **no contract change**. Nothing here
+runs unless a `skillopt binary` command is invoked — every existing SkillOpt
+review/optimize flow is byte-identical when it is unused.
 
 `skillopt pairwise import <packet-dir>` ingests a **blinded paired-review
 packet** produced by the gitmoot-skillopt fork (the `pairwise-review.json`

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9124,7 +9124,10 @@ an **opt-in LLM-backed runner** wired through the same cross-family judge plumbi
 as `skillopt ab --judge`, so each question is answered by a *different* family
 (never a self-preference), read-only. Verdicts persist to the additive
 `skillopt_binary_verdicts` table keyed by `(run_id, question_id)` and are re-read
-by `skillopt binary show --run <run-id>`; they also ride the training-package
+by `skillopt binary show --run <run-id>`. Each row also stores the
+`question_weight`/`dimension_weight` the run used (default `1`), so `show`
+re-aggregates with the same weighting and reports the **identical** per-dimension
+and overall scores `run` emitted (even for non-uniform weights). They also ride the training-package
 export as an **optional** `binary_verdicts` section (omitempty — verdict-less
 packets are byte-identical). The per-dimension scores map onto the existing
 `EvaluatorScore.DimensionScores` shape with **no contract change**. Nothing here


### PR DESCRIPTION
## What

Adds an additive, **opt-in** BINEVAL-style binary-evaluation mode for SkillOpt (#525). Instead of one opaque scalar judge score, a rubric dimension is decomposed into small **independent yes/no questions**; each is answered on its own with a verdict + explanation, and the per-question verdicts aggregate into per-dimension weighted yes-fractions and a weighted-mean overall score.

- **Schema + runner** (`internal/skillopt/binary_eval.go`): `BinaryQuestionSet` `{version:1, template_or_task_kind, dimensions:[{name, weight, questions:[{id, text, violation_example, weight}]}]}` loadable from YAML/JSON with validation (unique ids, weights default 1). A `BinaryEvaluator` interface answers one question at a time. A **deterministic rule-based runner** (`contains`/`not_contains`/`regex`/`not_regex` assertions) is provided for tests/reproducible runs, clearly marked as the deterministic mode. `RunBinaryEvaluation` does the aggregation; `ToEvaluatorScore` maps onto the existing `EvaluatorScore.DimensionScores` shape **without a contract change**.
- **LLM-backed runner** (`internal/cli/skillopt_binary.go`): opt-in, wired through the **existing cross-family judge plumbing** (`skillOptABJudgeAgent` + the shared deliver seam used by `skillopt ab --judge`), so each question is answered by a *different* runtime family (never a self-preference), read-only, one question at a time.
- **Persistence** (`internal/db/store.go`): additive `skillopt_binary_verdicts` table (`run_id, question_id, dimension, verdict, explanation, created_at`) keyed by `(run_id, question_id)` + `UpsertBinaryVerdict`/`ListBinaryVerdicts`. Pure additive migration appended at the end of the slice.
- **Export/import** (`internal/skillopt/contract.go`): optional `binary_verdicts` section on the training package (`omitempty`; verdict-less packets are byte-identical; no `contract_version` bump; round-trip preserved).
- **CLI**: `gitmoot skillopt binary run --set <file> --run <run-id> --source <file> [--deterministic] [--reviewer runtime] [--home] [--json]` and `gitmoot skillopt binary show --run <run-id> [--home] [--json]`.
- **Docs** ship in this PR: `skills/gitmoot/references/CLI.md`, `website/docs/reference/skillopt-exchange-contract.md` (+ regenerated `llms-full.txt`).

## Why

Scalar LLM-judge scores are hard to debug. Turning a broad criterion into small checkable questions makes evaluator feedback inspectable (exact failed criterion is visible) and gives the optimizer per-check lessons. Everything is off by default and additive: with no `skillopt binary` command invoked, every existing SkillOpt review/optimize flow — and every existing DB and export packet — is byte-identical.

## How tested

Gate run from a fresh clone against `origin/main` (Go 1.26.4):

- `go build ./...` — OK
- `go vet ./internal/skillopt/ ./internal/cli/ ./internal/db/` — OK
- `go test -count=1 ./internal/skillopt/` — ok (12.1s)
- `go test -count=1 ./internal/db/` — ok (56.9s)
- `go test -count=1 -timeout 15m ./internal/cli/` — ok (237.1s)
- `go test -race ./internal/db/ -run 'Binary|OpenMigrates|Migrate'` — ok; `go test -race ./internal/cli/ -run 'Binary|SkillOptBinary|ParseBinaryVerdict'` — ok (no data races). The full `-race ./internal/cli/` matrix runs in CI (authoritative); locally it exceeded the 20m wall on this loaded box (GitHub rate-limit pauses + live-A/B tests), with one pre-existing flaky train-init test that passes in isolation and in the non-race full run.
- `cd website && npm ci && npm run build` — SUCCESS

New tests: schema validation + defaults + YAML/JSON parse + duplicate-id/error cases, deterministic rule-based runner, weighted aggregation, verdict coercion, store round-trip/upsert-overwrite/validation, export includes-verdicts + omitempty-when-absent + JSON round-trip, a deterministic no-LLM temp-home E2E through the real `skillopt binary run`/`show` CLI, and a fake-adapter LLM-runner E2E (no live runtime).

Closes #525