### PR TITLE
chore(dashboard): bump gitmoot-dashboard — safe markdown chat rendering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/creachadair/tomledit v0.0.29
-	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260707091714-b1a07c4feb58
+	github.com/jerryfane/gitmoot-dashboard v0.0.0-20260707132324-54a3d68b158e
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260707091714-b1a07c4feb58 h1:YNN0eAWLRIYy9geoOJohFYNPa35SLaC0QDy2EVoomtc=
 github.com/jerryfane/gitmoot-dashboard v0.0.0-20260707091714-b1a07c4feb58/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260707132324-54a3d68b158e h1:3INZ9OtFvyGq0H2hWgKAaHDhm2D9oCpycLCOQgQG64M=
+github.com/jerryfane/gitmoot-dashboard v0.0.0-20260707132324-54a3d68b158e/go.mod h1:ER6dhQXboKZYEaNaw8TwvHpN1aJdo2bIAeasMnZksHg=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=


### PR DESCRIPTION
Bumps to dashboard `54a3d68` (#42): escape-first whitelist markdown renderer for chat message bodies (bold/code/fences/quotes/bullets; URLs stay plain; 32KB cap; XSS attack pass clean). UI-only embed change, no Go API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)