### PR TITLE
fix(runtime): unwrap claude CLI JSON envelope in Start() Raw

### DIFF
--- a/internal/cli/skillopt_synth_test.go
+++ b/internal/cli/skillopt_synth_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
 // TestClassifySynthItem exhaustively covers the pure accept/reject decision and
@@ -172,6 +174,60 @@ func withScriptedSynthDeliver(t *testing.T, challenger, weak, strong, judge stri
 		default:
 			return "", nil
 		}
+	}
+}
+
+// envelopeClaudeRunner is a subprocess.Runner that returns a fixed claude
+// --output-format json envelope for every invocation, mirroring the real claude
+// CLI's Start output so a real ClaudeAdapter runs end-to-end with no LLM.
+type envelopeClaudeRunner struct{ stdout string }
+
+func (r envelopeClaudeRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
+	return subprocess.Result{Stdout: r.stdout}, nil
+}
+
+func (r envelopeClaudeRunner) LookPath(file string) (string, error) { return "/usr/bin/" + file, nil }
+
+// TestRealSkillOptABDeliverUnwrapsClaudeEnvelopeForSynth is the #721 consumer
+// regression. It drives the REAL delivery seam (realSkillOptABDeliver) with a
+// forked-session claude agent (empty RuntimeRef → adapter.Start, the synth
+// challenger path) wired to a real ClaudeAdapter over a fake runner that returns
+// a claude CLI JSON envelope. The delivered answer must be the envelope's inner
+// "result" text — NOT the whole envelope — so parseSynthGeneratedItem finds the
+// context/question/rubric. Before the fix Start leaked the envelope as Raw and
+// this parse returned "synth item missing context, question, or rubric"
+// (bad_rubric, the live failure).
+func TestRealSkillOptABDeliverUnwrapsClaudeEnvelopeForSynth(t *testing.T) {
+	inner := `{"context":"A legacy monolith with no tests.","question":"Outline a safe migration.","rubric":"Rewards incremental strangler-fig steps."}`
+	envelope := `{"type":"result","subtype":"success","is_error":false,` +
+		`"session_id":"550e8400-e29b-41d4-a716-446655440010",` +
+		`"result":` + strconv.Quote(inner) + `,` +
+		`"usage":{"input_tokens":10,"output_tokens":20}}`
+
+	restore := replaceRuntimeFactory(runtime.Factory{Runner: envelopeClaudeRunner{stdout: envelope}})
+	t.Cleanup(restore)
+
+	// Empty RuntimeRef routes realSkillOptABDeliver through adapter.Start (a fresh
+	// throwaway session) — the exact skillopt synth challenger delivery path.
+	answer, err := realSkillOptABDeliver(context.Background(), runtime.Agent{
+		Name:       "challenger-bot",
+		Role:       "reviewer",
+		Runtime:    runtime.ClaudeRuntime,
+		RepoScope:  "acme/widgets",
+		RuntimeRef: "",
+	}, synthChallengerPrompt("", ""))
+	if err != nil {
+		t.Fatalf("realSkillOptABDeliver: %v", err)
+	}
+	if answer != inner {
+		t.Fatalf("delivered answer = %q, want the unwrapped inner result %q", answer, inner)
+	}
+	item, err := parseSynthGeneratedItem(answer)
+	if err != nil {
+		t.Fatalf("parseSynthGeneratedItem on the delivered answer failed (the #721 bad_rubric bug): %v (answer=%q)", err, answer)
+	}
+	if item.Context == "" || item.Question == "" || item.Rubric == "" {
+		t.Fatalf("parsed synth item missing fields: %+v", item)
 	}
 }
 

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -639,7 +639,18 @@ func (a ClaudeAdapter) Start(ctx context.Context, request StartRequest) (StartRe
 	if err != nil {
 		return StartResult{Raw: result.Stdout + result.Stderr}, claudeCommandError(result, err)
 	}
-	return StartResult{RuntimeRef: runtimeRef, Raw: result.Stdout}, nil
+	// Unwrap the --output-format json result envelope so forked-session
+	// consumers (skillopt synth/ab) that parse Raw as the assistant's answer see
+	// the answer text, not the CLI envelope (#721). Reuses the same helper the
+	// Deliver path uses to build Summary. Fail-open: fall back to the raw stdout
+	// when stdout is not the envelope or carries no "result" field (e.g. an older
+	// CLI's plain-text --output-format fallback), so Raw always surfaces the
+	// underlying text and unwrap never errors.
+	raw := result.Stdout
+	if summary, _, _ := parseClaudeJSONResult(result.Stdout); summary != "" {
+		raw = summary
+	}
+	return StartResult{RuntimeRef: runtimeRef, Raw: raw}, nil
 }
 
 func (a ClaudeAdapter) Validate(_ context.Context, agent Agent) error {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -614,6 +615,56 @@ func TestClaudeStartCommandUsesGeneratedSessionID(t *testing.T) {
 		t.Fatalf("runtime ref = %q", result.RuntimeRef)
 	}
 	runner.want(t, 0, "claude", "--session-id", "550e8400-e29b-41d4-a716-446655440010", "-p", "--output-format", "json", "--", "initialize")
+}
+
+// TestClaudeStartUnwrapsJSONEnvelope pins the #721 fix: Start must surface the
+// envelope's inner "result" text as Raw (not the whole CLI JSON envelope) so
+// forked-session consumers that parse Raw as JSON (skillopt synth/ab) see the
+// assistant's actual answer, while corrupt/non-JSON/empty envelopes fail-open to
+// the raw stdout.
+func TestClaudeStartUnwrapsJSONEnvelope(t *testing.T) {
+	// A realistic claude --output-format json envelope whose inner result is
+	// itself a JSON object (the shape skillopt synth's challenger returns).
+	inner := `{"context":"...","question":"2+2?","rubric":"exact match"}`
+	envelope := `{"type":"result","subtype":"success","is_error":false,` +
+		`"session_id":"550e8400-e29b-41d4-a716-446655440010",` +
+		`"result":` + strconv.Quote(inner) + `,` +
+		`"usage":{"input_tokens":12,"output_tokens":34}}`
+
+	for _, tt := range []struct {
+		name    string
+		stdout  string
+		wantRaw string
+	}{
+		{name: "unwraps inner result", stdout: envelope, wantRaw: inner},
+		{name: "plain answer envelope", stdout: `{"type":"result","result":"the answer"}`, wantRaw: "the answer"},
+		{name: "non-json falls back to stdout", stdout: "not json at all", wantRaw: "not json at all"},
+		{name: "empty result field falls back to stdout", stdout: `{"type":"result","result":""}`, wantRaw: `{"type":"result","result":""}`},
+		{name: "envelope without result field falls back", stdout: `{"type":"result","subtype":"error"}`, wantRaw: `{"type":"result","subtype":"error"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: tt.stdout}}}
+			adapter := ClaudeAdapter{
+				Runner: runner,
+				NewRuntimeRef: func() (string, error) {
+					return "550e8400-e29b-41d4-a716-446655440010", nil
+				},
+			}
+			agent := Agent{Name: "challenger", Role: "reviewer", Runtime: ClaudeRuntime, RepoScope: "jerryfane/gitmoot"}
+
+			result, err := adapter.Start(context.Background(), StartRequest{Agent: agent, Prompt: "generate"})
+			if err != nil {
+				t.Fatalf("Start returned error: %v", err)
+			}
+			if result.Raw != tt.wantRaw {
+				t.Fatalf("Raw = %q, want %q", result.Raw, tt.wantRaw)
+			}
+			// RuntimeRef behavior stays identical regardless of unwrap outcome.
+			if result.RuntimeRef != "550e8400-e29b-41d4-a716-446655440010" {
+				t.Fatalf("RuntimeRef = %q, want the generated ref", result.RuntimeRef)
+			}
+		})
+	}
 }
 
 func TestClaudeStartCommandAppliesAutonomyPolicy(t *testing.T) {


### PR DESCRIPTION
## Trace (issue #721)

First live `gitmoot skillopt synth` run (weak=codex, strong/challenger/judge=claude) rejected all 3 items `bad_rubric`, weak/strong scores exactly 0.0 every round, empty stderr — 9/9 silent failures.

Root cause:
- `ClaudeAdapter.Start` runs `claude -p --output-format json` and returned `StartResult{Raw: result.Stdout}` — stdout is claude's **CLI result envelope** (`{"type":"result",...,"result":"<answer>"}`), not the answer text (internal/runtime/adapter.go:637-642).
- `realSkillOptABDeliver` returns `started.Raw` verbatim on the forked-session path (empty RuntimeRef → Start) (internal/cli/skillopt_ab.go:163).
- `extractSynthJSONObject` then grabs the FIRST balanced `{...}` = the **envelope**; `parseSynthGeneratedItem` finds no context/question/rubric → `bad_rubric`, `continue`, no stderr. Judge verdicts fail identically.

Contrast: kimi's Start already unwraps (`StartResult{Raw: content}`, kimi.go:56); codex returns prose stdout. **Claude was the only enveloped Start.**

## Fix

At the adapter (right altitude). `ClaudeAdapter.Start` now **reuses the existing `parseClaudeJSONResult` helper** — the same one the Deliver path uses to build `Summary` — to extract the envelope's `result` field into `Raw`. Fail-open: falls back to raw stdout when stdout is not the envelope, has no `result` field, or `result` is empty (e.g. an older CLI's plain-text `--output-format` fallback), so unwrap **never errors**. No new parser was added. `RuntimeRef` behavior is byte-identical. kimi/codex untouched (kimi already unwraps; codex is prose).

## Consumers audited (Start().Raw)

The **only** reader of `Start().Raw` is `realSkillOptABDeliver`'s forked-session path (skillopt_ab.go:163). Everything downstream routes through it:
- `skillopt synth` — challenger **and** judge (`skillOptSynthDeliver = realSkillOptABDeliver`). **JSON-parsed → was the hard failure.** Fixed.
- `skillopt ab --judge` (`skillOptABJudgeDeliver`, both single + jury paths). **JSON-parsed.** Fixed.
- `skillopt ab` variant deliver + `skillopt binary`. Answer used as prose; envelope leak was cosmetic/quality, now clean.
- live-AB challenger (agent_dispatch_live_ab.go) — presented to the user for a pick as prose (not JSON-parsed); previously showed the raw envelope, now shows the answer.

Non-empty RuntimeRef paths already went through `Deliver` → `result.Summary` (already unwrapped) and are unaffected.

**All other `adapter.Start` call sites** — `agent restart`, `agent_dispatch` instance start, daemon temp/ephemeral workers, `skillopt` agent start — read only `started.RuntimeRef`, never `.Raw`. Unaffected by the unwrap.

## How tested (deterministic, no LLM)

1. **Unit** (`TestClaudeStartUnwrapsJSONEnvelope`, internal/runtime): fake subprocess runner returns a realistic claude JSON envelope → `Start().Raw` == inner `result` text; plain-answer envelope → the answer; non-JSON stdout → falls back to full stdout; empty `result` → fallback; envelope without `result` → fallback. `RuntimeRef` asserted identical in every case.
2. **Consumer regression** (`TestRealSkillOptABDeliverUnwrapsClaudeEnvelopeForSynth`, internal/cli): drives the **REAL** `realSkillOptABDeliver` + a **real** `ClaudeAdapter` wired to a fake runner (via `replaceRuntimeFactory`) on the forked-session path, then asserts the delivered answer is the unwrapped inner JSON **and** that `parseSynthGeneratedItem` succeeds on it — the exact `bad_rubric` parse that failed live.
3. Both tests were verified to **fail on the pre-fix code** (leaked envelope) and pass after.

## Gates (go1.26.4, GOTOOLCHAIN-pinned, pipefail + explicit exit checks)

- `go build ./...` → 0
- `go vet ./internal/runtime/ ./internal/cli/` → 0
- `go test -count=1 ./internal/runtime/` → `ok 0.084s`
- `go test -count=1 ./internal/cli/` → `ok 208.926s`
- `go test -race -count=1 ./internal/runtime/` → `ok 1.114s`
- `gofmt -l` on all changed files → clean

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)