### PR TITLE
fix(runtime): unwrap codex exec transcript in Start() Raw + cap synth judge answers (#724)

### DIFF
--- a/internal/cli/skillopt_synth.go
+++ b/internal/cli/skillopt_synth.go
@@ -550,6 +550,29 @@ func synthAttemptPrompt(item synthGeneratedItem) string {
 	return b.String()
 }
 
+// synthMaxAnswerBytes caps each weak/strong answer embedded in a judge prompt.
+// The judge scores answer quality against the rubric — it does not need a full
+// runtime transcript — so a verbose or un-unwrapped answer (codex banner, kimi
+// blob, etc.) is truncated to keep the judge prompt small regardless of runtime
+// verbosity. This is the second half of #724: even after Start() unwraps the
+// assistant's final message, a genuinely long answer combined with both halves
+// embedded verbatim can blow ARG_MAX on the judge exec, so cap defensively.
+const synthMaxAnswerBytes = 12 * 1024
+
+// capSynthAnswer truncates s to at most synthMaxAnswerBytes bytes, appending a
+// clear "[truncated N bytes]" marker naming how many bytes were dropped. Answers
+// at or under the limit are returned byte-identical (no marker), so short,
+// well-behaved answers reach the judge unchanged. Truncation is on a byte
+// boundary (the marker records the exact dropped-byte count); the judge reads
+// prose, so a split multibyte rune at the boundary is harmless.
+func capSynthAnswer(s string) string {
+	if len(s) <= synthMaxAnswerBytes {
+		return s
+	}
+	dropped := len(s) - synthMaxAnswerBytes
+	return s[:synthMaxAnswerBytes] + fmt.Sprintf("\n[truncated %d bytes]", dropped)
+}
+
 func synthJudgePrompt(item synthGeneratedItem, weakAnswer, strongAnswer string) string {
 	var b strings.Builder
 	b.WriteString("Score two answers against a rubric and judge the item's quality.\n\n")
@@ -560,9 +583,9 @@ func synthJudgePrompt(item synthGeneratedItem, weakAnswer, strongAnswer string) 
 	b.WriteString("\n\nRubric:\n")
 	b.WriteString(item.Rubric)
 	b.WriteString("\n\nAnswer A (weak):\n")
-	b.WriteString(weakAnswer)
+	b.WriteString(capSynthAnswer(weakAnswer))
 	b.WriteString("\n\nAnswer B (strong):\n")
-	b.WriteString(strongAnswer)
+	b.WriteString(capSynthAnswer(strongAnswer))
 	b.WriteString("\n\nScore each answer 0.0-1.0 against the rubric. Set well_formed to false if the ")
 	b.WriteString("item is ill-posed, and diagnostic to \"context_leak\" if the context gives the answer away.\n")
 	b.WriteString("Respond with STRICT JSON only: ")

--- a/internal/cli/skillopt_synth_test.go
+++ b/internal/cli/skillopt_synth_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -229,6 +230,115 @@ func TestRealSkillOptABDeliverUnwrapsClaudeEnvelopeForSynth(t *testing.T) {
 	if item.Context == "" || item.Question == "" || item.Rubric == "" {
 		t.Fatalf("parsed synth item missing fields: %+v", item)
 	}
+}
+
+// transcriptCodexRunner is a subprocess.Runner that returns a fixed `codex exec
+// --json` JSONL transcript for every invocation, mirroring the real codex CLI's
+// Start output (banner + thread.started + turn events + agent_message) so a real
+// CodexAdapter runs end-to-end with no LLM.
+type transcriptCodexRunner struct{ stdout string }
+
+func (r transcriptCodexRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
+	return subprocess.Result{Stdout: r.stdout}, nil
+}
+
+func (r transcriptCodexRunner) LookPath(file string) (string, error) { return "/usr/bin/" + file, nil }
+
+// TestRealSkillOptABDeliverUnwrapsCodexTranscriptForSynth is the #724 consumer
+// regression, the codex flavor of TestRealSkillOptABDeliverUnwrapsClaudeEnvelope-
+// ForSynth. It drives the REAL delivery seam (realSkillOptABDeliver) with a
+// forked-session codex agent (empty RuntimeRef → adapter.Start, the synth
+// challenger path) wired to a real CodexAdapter over a fake runner that returns a
+// codex exec --json transcript. The delivered answer must be the agent_message
+// text — NOT the whole transcript (banner/thread.started/reasoning/turn events) —
+// so parseSynthGeneratedItem finds the context/question/rubric. Before the fix
+// Start leaked the whole transcript as Raw and this parse returned the wrong
+// object (the thread.started event, not the challenger item).
+func TestRealSkillOptABDeliverUnwrapsCodexTranscriptForSynth(t *testing.T) {
+	inner := `{"context":"A legacy monolith with no tests.","question":"Outline a safe migration.","rubric":"Rewards incremental strangler-fig steps."}`
+	transcript := `{"type":"thread.started","thread_id":"019f3041-cfed-7e82-8766-b5ca75cf92da"}` + "\n" +
+		`{"type":"turn.started"}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":"designing a discriminating item"}}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":` + strconv.Quote(inner) + `}}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":16504,"output_tokens":20}}`
+
+	restore := replaceRuntimeFactory(runtime.Factory{Runner: transcriptCodexRunner{stdout: transcript}})
+	t.Cleanup(restore)
+
+	// Empty RuntimeRef routes realSkillOptABDeliver through adapter.Start (a fresh
+	// throwaway session) — the exact skillopt synth challenger delivery path.
+	answer, err := realSkillOptABDeliver(context.Background(), runtime.Agent{
+		Name:       "challenger-bot",
+		Role:       "reviewer",
+		Runtime:    runtime.CodexRuntime,
+		RepoScope:  "acme/widgets",
+		RuntimeRef: "",
+	}, synthChallengerPrompt("", ""))
+	if err != nil {
+		t.Fatalf("realSkillOptABDeliver: %v", err)
+	}
+	if answer != inner {
+		t.Fatalf("delivered answer = %q, want the unwrapped agent_message %q", answer, inner)
+	}
+	item, err := parseSynthGeneratedItem(answer)
+	if err != nil {
+		t.Fatalf("parseSynthGeneratedItem on the delivered answer failed (the #724 codex-bloat bug): %v (answer=%q)", err, answer)
+	}
+	if item.Context == "" || item.Question == "" || item.Rubric == "" {
+		t.Fatalf("parsed synth item missing fields: %+v", item)
+	}
+}
+
+// TestSynthJudgePromptCapsAnswers pins the second half of #724: synthJudgePrompt
+// caps each embedded weak/strong answer so a verbose runtime answer cannot bloat
+// (or, combined, blow ARG_MAX on) the judge exec, while under-limit answers are
+// embedded byte-identical with no marker.
+func TestSynthJudgePromptCapsAnswers(t *testing.T) {
+	item := synthGeneratedItem{Context: "ctx", Question: "q?", Rubric: "rewards X"}
+
+	t.Run("short answers embedded verbatim, no marker", func(t *testing.T) {
+		weak, strong := "a short weak answer", "a short strong answer"
+		got := synthJudgePrompt(item, weak, strong)
+		if !strings.Contains(got, weak) || !strings.Contains(got, strong) {
+			t.Fatalf("short answers must be embedded verbatim; prompt=%q", got)
+		}
+		if strings.Contains(got, "[truncated") {
+			t.Fatalf("short answers must not carry a truncation marker; prompt=%q", got)
+		}
+	})
+
+	t.Run("oversized answers capped with byte-accurate marker", func(t *testing.T) {
+		oversize := 5000
+		weak := strings.Repeat("W", synthMaxAnswerBytes+oversize)
+		strong := strings.Repeat("S", synthMaxAnswerBytes+oversize)
+		got := synthJudgePrompt(item, weak, strong)
+
+		if strings.Contains(got, weak) {
+			t.Fatal("oversized weak answer must not be embedded verbatim")
+		}
+		wantMarker := fmt.Sprintf("[truncated %d bytes]", oversize)
+		if strings.Count(got, wantMarker) != 2 {
+			t.Fatalf("want the byte-accurate marker %q for both answers; prompt tail=%q", wantMarker, got[len(got)-200:])
+		}
+		// The retained prefix is exactly the cap; nothing beyond it survives.
+		if !strings.Contains(got, strings.Repeat("W", synthMaxAnswerBytes)) {
+			t.Fatal("capped weak answer must keep the first synthMaxAnswerBytes bytes")
+		}
+		if strings.Contains(got, strings.Repeat("W", synthMaxAnswerBytes+1)) {
+			t.Fatal("capped weak answer kept more than synthMaxAnswerBytes bytes")
+		}
+	})
+
+	t.Run("answer exactly at the limit is not truncated", func(t *testing.T) {
+		exact := strings.Repeat("E", synthMaxAnswerBytes)
+		got := synthJudgePrompt(item, exact, "short")
+		if strings.Contains(got, "[truncated") {
+			t.Fatalf("answer exactly at the limit must not be truncated; prompt=%q", got[len(got)-120:])
+		}
+		if !strings.Contains(got, exact) {
+			t.Fatal("at-limit answer must be embedded verbatim")
+		}
+	})
 }
 
 // TestRunSkillOptSynthAcceptAndApprove is the deterministic no-LLM E2E: a

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -386,7 +386,19 @@ func (a CodexAdapter) Start(ctx context.Context, request StartRequest) (StartRes
 	if err != nil {
 		return StartResult{Raw: result.Stdout}, err
 	}
-	return StartResult{RuntimeRef: threadID, Raw: result.Stdout}, nil
+	// Unwrap the `codex exec --json` JSONL stream so forked-session consumers
+	// (skillopt synth/ab) that parse Raw as the assistant's answer see the
+	// agent_message text, not the whole transcript (banner, thread.started,
+	// turn events) — the codex flavor of #722. Reuses the same parser the
+	// Deliver path uses to build Summary. Fail-open: fall back to the raw stdout
+	// when the stream carries no agent_message (older CLI, plain-text fallback,
+	// or an unexpected shape), so Raw always surfaces the underlying text and
+	// unwrap never errors. RuntimeRef is untouched.
+	raw := result.Stdout
+	if msg, _, _, ok := parseCodexJSONResult(result.Stdout); ok {
+		raw = msg
+	}
+	return StartResult{RuntimeRef: threadID, Raw: raw}, nil
 }
 
 func (a CodexAdapter) Validate(_ context.Context, agent Agent) error {

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -295,6 +295,63 @@ func TestCodexStartRejectsMissingThreadID(t *testing.T) {
 	runner.want(t, 0, "codex", "exec", "--json", "--", "initialize")
 }
 
+// TestCodexStartUnwrapsJSONTranscript pins the #724 fix: codex Start runs `codex
+// exec --json` (banner + thread.started + turn events + agent_message JSONL) and
+// must surface the agent_message .text as Raw — NOT the whole transcript — so
+// forked-session consumers that parse Raw as JSON (skillopt synth/ab) see the
+// assistant's actual answer. Streams with no agent_message (older CLI, plain-text
+// fallback) fail-open to the full stdout. RuntimeRef stays the parsed thread id
+// in every case.
+func TestCodexStartUnwrapsJSONTranscript(t *testing.T) {
+	const threadID = "019f3041-cfed-7e82-8766-b5ca75cf92da"
+	started := `{"type":"thread.started","thread_id":"` + threadID + `"}`
+	// The assistant's final message is itself a JSON object — the shape skillopt
+	// synth's challenger returns.
+	inner := `{"context":"...","question":"2+2?","rubric":"exact match"}`
+	// A realistic codex exec --json transcript: thread banner, turn start,
+	// reasoning noise, the agent_message, and the turn.completed usage line.
+	transcript := started + "\n" +
+		`{"type":"turn.started"}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":"thinking hard about arithmetic"}}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":` + strconv.Quote(inner) + `}}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":12,"output_tokens":34}}`
+
+	// A transcript that never emits an agent_message (only the thread.started the
+	// thread-id parser needs) must fail-open to the full stdout.
+	noMessage := started + "\n" + `{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}`
+
+	for _, tt := range []struct {
+		name    string
+		stdout  string
+		wantRaw string
+	}{
+		{name: "unwraps agent_message text", stdout: transcript, wantRaw: inner},
+		{name: "joins multiple agent_messages", stdout: started + "\n" +
+			`{"type":"item.completed","item":{"type":"agent_message","text":"first"}}` + "\n" +
+			`{"type":"item.completed","item":{"type":"agent_message","text":"second"}}`,
+			wantRaw: "first\n\nsecond"},
+		{name: "no agent_message falls back to stdout", stdout: noMessage, wantRaw: noMessage},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: tt.stdout}}}
+			adapter := CodexAdapter{Runner: runner}
+			agent := Agent{Name: "challenger", Role: "reviewer", Runtime: CodexRuntime, RepoScope: "jerryfane/gitmoot"}
+
+			result, err := adapter.Start(context.Background(), StartRequest{Agent: agent, Prompt: "generate"})
+			if err != nil {
+				t.Fatalf("Start returned error: %v", err)
+			}
+			if result.Raw != tt.wantRaw {
+				t.Fatalf("Raw = %q, want %q", result.Raw, tt.wantRaw)
+			}
+			// The unwrap never disturbs the parsed thread id.
+			if result.RuntimeRef != threadID {
+				t.Fatalf("RuntimeRef = %q, want %q", result.RuntimeRef, threadID)
+			}
+		})
+	}
+}
+
 func TestCodexDeliverLastSessionCommand(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "done"}}}
 	adapter := CodexAdapter{Runner: runner}


### PR DESCRIPTION
## What

Two composing halves of the same live `skillopt synth` failure (2026-07-08), the codex sibling of #722.

**(1) codex `Start().Raw` unwrap.** `CodexAdapter.Start` runs `codex exec --json` and returned `StartResult{Raw: result.Stdout}` verbatim — the full JSONL transcript (thread.started banner, turn.started, reasoning items, agent_message, turn.completed usage), not the assistant's answer. The sole consumer of `Start().Raw` is `realSkillOptABDeliver`'s forked-session path (empty `RuntimeRef` → Start), which feeds skillopt synth (challenger + judge), ab, and the live-AB challenger. Those consumers parse `Raw` as the assistant's answer, so they saw the whole transcript and could not find the challenger item's `context`/`question`/`rubric`. This is the exact codex flavor of #722's claude envelope leak.

**(2) synth judge-prompt hygiene.** `synthJudgePrompt` embedded both weak/strong answers verbatim with no cap. Even after (1) unwraps the answer, a genuinely long answer combined with both halves embedded blew ARG_MAX on the kimi judge exec (issue evidence: run 2, items 1 & 3 died at the judge exec).

## Why

The judge scores answer quality against a rubric — it does not need a full runtime transcript. And a forked-session consumer that parses `Raw` as the assistant's answer must receive the answer, not the CLI's event stream.

## How

- **`internal/runtime/adapter.go`** `CodexAdapter.Start`: after parsing the thread id, reuse `parseCodexJSONResult` (the same parser the Deliver path uses to build `Summary`) to surface the joined `agent_message` text as `Raw`. Fail-open: fall back to the raw stdout when the stream carries no `agent_message` (older CLI, plain-text fallback, unexpected shape), so `Raw` always surfaces the underlying text and unwrap never errors. `RuntimeRef` is untouched. Same altitude/pattern as #722 (b53269f).
- **`internal/cli/skillopt_synth.go`**: new `capSynthAnswer` caps each embedded answer to `synthMaxAnswerBytes` (12KB) with a byte-accurate `[truncated N bytes]` marker; `synthJudgePrompt` wraps both weak and strong answers. Under-limit answers are embedded byte-identical (no marker).

Additive and fail-open; no CLI surface change (internal adapter/prompt behavior, like #722 which shipped without docs changes).

## How tested

Toolchain pinned: `export PATH=/root/.local/toolchains/go1.26.4/bin:$PATH`, isolated `HERDR_SOCKET_PATH`, `HERDR_ENV` unset.

- `go build ./...` → exit 0
- `go vet ./internal/runtime ./internal/cli` → exit 0
- `go test -count=1 ./internal/runtime` → ok (0.081s)
- `go test -race -count=1 ./internal/runtime` → ok (1.122s)
- `go test -count=1 ./internal/cli` → ok (224.832s)

New tests (all PASS):
- `TestCodexStartUnwrapsJSONTranscript` — adapter unit: unwraps agent_message text, joins multiple messages, falls back to full stdout when no agent_message; `RuntimeRef` preserved in every case. Uses a real `codex exec --json` transcript shape.
- `TestRealSkillOptABDeliverUnwrapsCodexTranscriptForSynth` — consumer regression through the real `realSkillOptABDeliver` seam with a real `CodexAdapter` over a fake runner (codex flavor of #722's `TestRealSkillOptABDeliverUnwrapsClaudeEnvelopeForSynth`); the delivered answer must be the agent_message and `parseSynthGeneratedItem` must succeed.
- `TestSynthJudgePromptCapsAnswers` — cap + byte-accurate marker for oversized answers, verbatim under-limit, exact-at-limit not truncated.

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)