### PR TITLE
fix(skillopt): sandbox synth attempt agents in per-item scratch dirs (#725)

### DIFF
--- a/internal/cli/skillopt_synth.go
+++ b/internal/cli/skillopt_synth.go
@@ -366,12 +366,33 @@ func runSkillOptSynthWithStore(ctx context.Context, store *db.Store, opts synthO
 // An accepted item is persisted (file + pending_human_approval DB row). A skipped
 // item logs its final diagnostic. Never returns an error: a per-call runtime
 // failure is logged and treated as a skip so the bounded run continues.
+//
+// Sandbox (#725): every attempt/challenger/judge delivery is forced into a FRESH
+// per-item temp scratch dir (never a registered repo checkout) so an agentic CLI
+// that misreads the exercise as a real job can only ever write into a throwaway
+// directory that is deleted when the item finishes — it can never touch a live
+// checkout. This is the hard guarantee; the answer-only prompt preamble is the
+// soft complement that reduces wasted agent effort.
 func generateSynthItem(ctx context.Context, store *db.Store, opts synthOptions, guidance string, challengerAgent, weakAgent, strongAgent, judgeAgent runtime.Agent, index int, stderr io.Writer) synthItemSummary {
 	result := synthItemSummary{}
+	scratch, err := os.MkdirTemp("", "gitmoot-synth-item-")
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt synth: item %d: create scratch dir: %v\n", index+1, err)
+		result.Diagnostic = synthDiagBadRubric
+		return result
+	}
+	// Clean the scratch dir (and anything a misbehaving agent wrote into it) after
+	// the item, regardless of accept/reject/error.
+	defer os.RemoveAll(scratch)
+	// deliver sandboxes every synth delivery into the per-item scratch dir before
+	// handing it to the (test-overridable) delivery seam.
+	deliver := func(agent runtime.Agent, prompt string) (string, error) {
+		return skillOptSynthDeliver(ctx, sandboxSynthAgent(agent, scratch), prompt)
+	}
 	feedback := ""
 	for round := 1; round <= opts.maxRounds; round++ {
 		result.Rounds = round
-		challengerRaw, err := skillOptSynthDeliver(ctx, challengerAgent, synthChallengerPrompt(guidance, feedback))
+		challengerRaw, err := deliver(challengerAgent, synthChallengerPrompt(guidance, feedback))
 		if err != nil {
 			fmt.Fprintf(stderr, "skillopt synth: item %d round %d: challenger: %v\n", index+1, round, err)
 			result.Diagnostic = synthDiagBadRubric
@@ -383,19 +404,19 @@ func generateSynthItem(ctx context.Context, store *db.Store, opts synthOptions, 
 			feedback = synthFeedbackForDiagnostic(synthDiagBadRubric)
 			continue
 		}
-		weakAns, err := skillOptSynthDeliver(ctx, weakAgent, synthAttemptPrompt(item))
+		weakAns, err := deliver(weakAgent, synthAttemptPrompt(item))
 		if err != nil {
 			fmt.Fprintf(stderr, "skillopt synth: item %d round %d: weak: %v\n", index+1, round, err)
 			result.Diagnostic = synthDiagBadRubric
 			return result
 		}
-		strongAns, err := skillOptSynthDeliver(ctx, strongAgent, synthAttemptPrompt(item))
+		strongAns, err := deliver(strongAgent, synthAttemptPrompt(item))
 		if err != nil {
 			fmt.Fprintf(stderr, "skillopt synth: item %d round %d: strong: %v\n", index+1, round, err)
 			result.Diagnostic = synthDiagBadRubric
 			return result
 		}
-		judgeRaw, err := skillOptSynthDeliver(ctx, judgeAgent, synthJudgePrompt(item, weakAns, strongAns))
+		judgeRaw, err := deliver(judgeAgent, synthJudgePrompt(item, weakAns, strongAns))
 		if err != nil {
 			fmt.Fprintf(stderr, "skillopt synth: item %d round %d: judge: %v\n", index+1, round, err)
 			result.Diagnostic = synthDiagBadRubric
@@ -472,19 +493,28 @@ func resolveSynthAgent(ctx context.Context, store *db.Store, name, repo string) 
 	if strings.TrimSpace(agent.RepoScope) == "" {
 		agent.RepoScope = repo
 	}
-	// Resolve the repo scope to its registered checkout directory so a real
-	// (non-stubbed) delivery chdirs into an existing path instead of the bogus
-	// relative "owner/repo" RepoScope form. RepoScope itself stays in owner/repo
-	// form (it is validated as such by the adapter). When the repo is not
-	// registered or carries no checkout, WorkingDir stays empty and the delivery
-	// seam falls back to RepoScope — unit tests stub the seam, so this lookup is
-	// best-effort and never fails the run.
-	if scope := strings.TrimSpace(agent.RepoScope); scope != "" {
-		if record, repoErr := store.GetRepo(ctx, scope); repoErr == nil {
-			agent.WorkingDir = strings.TrimSpace(record.CheckoutPath)
-		}
-	}
+	// #725: DO NOT resolve the repo scope to its registered checkout directory.
+	// A synth attempt/challenger/judge is delivered to an agentic CLI that runs
+	// with full tool permissions; if its adapter Dir is a live checkout it will
+	// happily write files, start servers, and probe ports IN that checkout (the
+	// incident that motivated this fix). Every synth delivery is instead forced
+	// into a fresh per-item temp scratch dir by sandboxSynthAgent (see
+	// generateSynthItem), so WorkingDir is left empty here on purpose — nothing in
+	// the synth path may carry a real checkout path.
+	agent.WorkingDir = ""
 	return agent, nil
+}
+
+// sandboxSynthAgent returns a copy of agent whose adapter working dir is forced
+// to scratch — a fresh per-item temp directory (#725). Because
+// realSkillOptABDeliver derives the adapter Dir from WorkingDir (falling back to
+// RepoScope only when WorkingDir is empty), setting WorkingDir to the scratch dir
+// guarantees the delivery chdirs into the throwaway scratch and NEVER into a
+// registered repo checkout, no matter what the agent otherwise carries. RepoScope
+// is left intact so the adapter still resolves the correct runtime family.
+func sandboxSynthAgent(agent runtime.Agent, scratch string) runtime.Agent {
+	agent.WorkingDir = scratch
+	return agent
 }
 
 func synthItemID(template string, index int) string {
@@ -520,8 +550,15 @@ func writeSynthItemFile(path string, item db.SynthReviewItem) error {
 
 // --- prompt builders -------------------------------------------------------
 
+// synthEvalOnlyPreamble frames every synth delivery as an answer-only written
+// exercise (#725). The attempts run against agentic CLIs (not chat models); this
+// preamble is the soft complement to the hard scratch-dir sandbox — it tells the
+// agent NOT to treat the item as a real job to implement, cutting wasted effort.
+const synthEvalOnlyPreamble = "This is a written evaluation exercise. Do NOT create files, run commands, start servers, or modify any repository. Respond with text only.\n\n"
+
 func synthChallengerPrompt(guidance, feedback string) string {
 	var b strings.Builder
+	b.WriteString(synthEvalOnlyPreamble)
 	b.WriteString("You are generating a synthetic review item to evaluate an agent skill.\n")
 	if strings.TrimSpace(guidance) != "" {
 		b.WriteString("The skill being exercised:\n")
@@ -542,6 +579,7 @@ func synthChallengerPrompt(guidance, feedback string) string {
 
 func synthAttemptPrompt(item synthGeneratedItem) string {
 	var b strings.Builder
+	b.WriteString(synthEvalOnlyPreamble)
 	b.WriteString("Answer the following question using the given context.\n\n")
 	b.WriteString("Context:\n")
 	b.WriteString(item.Context)
@@ -552,6 +590,7 @@ func synthAttemptPrompt(item synthGeneratedItem) string {
 
 func synthJudgePrompt(item synthGeneratedItem, weakAnswer, strongAnswer string) string {
 	var b strings.Builder
+	b.WriteString(synthEvalOnlyPreamble)
 	b.WriteString("Score two answers against a rubric and judge the item's quality.\n\n")
 	b.WriteString("Context:\n")
 	b.WriteString(item.Context)

--- a/internal/cli/skillopt_synth.go
+++ b/internal/cli/skillopt_synth.go
@@ -512,8 +512,19 @@ func resolveSynthAgent(ctx context.Context, store *db.Store, name, repo string) 
 // guarantees the delivery chdirs into the throwaway scratch and NEVER into a
 // registered repo checkout, no matter what the agent otherwise carries. RepoScope
 // is left intact so the adapter still resolves the correct runtime family.
+//
+// The stored AutonomyPolicy is ALSO forced to read-only. The scratch cwd alone is
+// not a hard guarantee: a synth agent registered with workspace-write or
+// danger-full-access would otherwise launch its adapter (codex --sandbox
+// danger-full-access / claude bypassPermissions) with a permission grant that is
+// not cwd-restricted, letting an agentic CLI that misreads the exercise write
+// files, start servers, and modify a live checkout by ABSOLUTE path — exactly the
+// #725 incident. Downgrading to read-only here (mirroring the hard-verifier
+// sandbox at skillopt_ab.go and cross_family_review.go) removes that escape hatch;
+// a synth delivery is answer-only and never needs write access.
 func sandboxSynthAgent(agent runtime.Agent, scratch string) runtime.Agent {
 	agent.WorkingDir = scratch
+	agent.AutonomyPolicy = runtime.AutonomyPolicyReadOnly
 	return agent
 }
 

--- a/internal/cli/skillopt_synth_test.go
+++ b/internal/cli/skillopt_synth_test.go
@@ -296,6 +296,86 @@ func TestRunSkillOptSynthAcceptAndApprove(t *testing.T) {
 	}
 }
 
+// TestRunSkillOptSynthDeliversInScratchNotCheckout is the #725 deterministic no-LLM
+// E2E: even with the target repo registered to a real filesystem checkout, EVERY
+// delivery (challenger/weak/strong/judge) must be handed a fresh per-item temp
+// scratch dir as its adapter working dir — never the live checkout or the
+// "owner/repo" RepoScope — and those scratch dirs must be cleaned up after the run.
+func TestRunSkillOptSynthDeliversInScratchNotCheckout(t *testing.T) {
+	home, store := synthTestHome(t, "weak-bot", "strong-bot", "judge-bot")
+	ctx := context.Background()
+	// Register the repo with a real checkout — the pre-#725 resolveSynthAgent would
+	// have handed THIS directory to every delivery.
+	checkout := t.TempDir()
+	if err := store.UpsertRepo(ctx, db.Repo{
+		Owner: "acme", Name: "widgets", DefaultBranch: "main",
+		CheckoutPath: checkout, Enabled: true,
+	}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+
+	// Capturing seam: records the working dir of every delivered agent, then returns
+	// scripted answers so the accept path runs to completion with no LLM.
+	prev := skillOptSynthDeliver
+	t.Cleanup(func() { skillOptSynthDeliver = prev })
+	var deliveredDirs []string
+	skillOptSynthDeliver = func(_ context.Context, agent runtime.Agent, prompt string) (string, error) {
+		deliveredDirs = append(deliveredDirs, agent.WorkingDir)
+		switch {
+		case strings.Contains(prompt, "generating a synthetic review item"):
+			return `{"context":"A legacy monolith.","question":"Outline a safe migration.","rubric":"Rewards incremental steps."}`, nil
+		case strings.Contains(prompt, "Score two answers against a rubric"):
+			return `{"weak_score":0.2,"strong_score":0.9,"well_formed":true,"diagnostic":""}`, nil
+		case strings.Contains(prompt, "Answer the following question"):
+			if agent.Name == "weak-bot" {
+				return "rewrite it all at once", nil
+			}
+			return "wrap and migrate incrementally behind a facade", nil
+		default:
+			return "", nil
+		}
+	}
+
+	outDir := filepath.Join(t.TempDir(), "synth-out")
+	var stdout, stderr bytes.Buffer
+	code := runSkillOptSynth([]string{
+		"--template", "planner", "--repo", "acme/widgets",
+		"--weak", "weak-bot", "--strong", "strong-bot", "--judge", "judge-bot",
+		"--max-items", "1", "--out", outDir, "--home", home,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("synth exit = %d, stderr: %s", code, stderr.String())
+	}
+	if len(deliveredDirs) < 4 {
+		t.Fatalf("expected >=4 deliveries (challenger/weak/strong/judge), got %d", len(deliveredDirs))
+	}
+	var scratchDir string
+	for i, dir := range deliveredDirs {
+		if strings.TrimSpace(dir) == "" {
+			t.Fatalf("delivery %d had an empty working dir — the sandbox did not force a scratch dir", i)
+		}
+		if dir == checkout {
+			t.Fatalf("delivery %d ran in the live checkout %q (the #725 bug)", i, checkout)
+		}
+		if dir == "acme/widgets" {
+			t.Fatalf("delivery %d ran in the RepoScope %q, not a scratch dir", i, dir)
+		}
+		if !strings.HasPrefix(filepath.Base(dir), "gitmoot-synth-item-") {
+			t.Fatalf("delivery %d dir %q is not a per-item synth scratch dir", i, dir)
+		}
+		// All deliveries for one item share the same per-item scratch dir.
+		if scratchDir == "" {
+			scratchDir = dir
+		} else if dir != scratchDir {
+			t.Fatalf("delivery %d used a different scratch dir %q, want the shared per-item %q", i, dir, scratchDir)
+		}
+	}
+	// Cleanup: the per-item scratch dir must be gone after the run.
+	if _, err := os.Stat(scratchDir); !os.IsNotExist(err) {
+		t.Fatalf("scratch dir %q was not cleaned up after the item (stat err=%v)", scratchDir, err)
+	}
+}
+
 // TestRunSkillOptSynthRejectsTooEasyAndExhaustsRounds proves a non-discriminating
 // item is skipped with a too_easy diagnostic, no DB row is written, and the round
 // cap is honored.
@@ -369,12 +449,14 @@ func TestRunSkillOptSynthRejectGate(t *testing.T) {
 
 // TestRunSkillOptSynthMissingFlags proves required-flag validation and that an
 // unknown agent errors cleanly.
-// TestResolveSynthAgentResolvesCheckoutPath proves the review fix for #535: a
-// resolved agent carries the registered repo's filesystem CheckoutPath in
-// WorkingDir (so a real, non-stubbed delivery chdirs into an existing directory)
-// while RepoScope stays in "owner/repo" form. When the repo is not registered,
-// WorkingDir stays empty so the delivery seam falls back to RepoScope.
-func TestResolveSynthAgentResolvesCheckoutPath(t *testing.T) {
+// TestResolveSynthAgentNeverCarriesCheckout proves the #725 hard guarantee at the
+// resolve layer: even when the repo IS registered with a real filesystem checkout,
+// a resolved synth agent must NOT carry that checkout in WorkingDir. Every synth
+// delivery runs in a fresh per-item temp scratch dir instead (see
+// sandboxSynthAgent), so nothing in the synth path may hand an agentic CLI a live
+// checkout to write into. RepoScope still stays in "owner/repo" form for adapter
+// family resolution.
+func TestResolveSynthAgentNeverCarriesCheckout(t *testing.T) {
 	home, store := synthTestHome(t, "weak-bot")
 	_ = home
 	ctx := context.Background()
@@ -396,17 +478,52 @@ func TestResolveSynthAgentResolvesCheckoutPath(t *testing.T) {
 	if agent.RepoScope != "acme/widgets" {
 		t.Fatalf("RepoScope = %q, want acme/widgets (must stay owner/repo form)", agent.RepoScope)
 	}
-	if agent.WorkingDir != checkout {
-		t.Fatalf("WorkingDir = %q, want resolved checkout %q", agent.WorkingDir, checkout)
+	if agent.WorkingDir != "" {
+		t.Fatalf("WorkingDir = %q, want empty — synth agents must never carry the live checkout %q (#725)", agent.WorkingDir, checkout)
 	}
+}
 
-	// Unregistered repo: WorkingDir stays empty so the seam falls back to RepoScope.
-	other, err := resolveSynthAgent(ctx, store, "weak-bot", "acme/unregistered")
-	if err != nil {
-		t.Fatalf("resolveSynthAgent (unregistered): %v", err)
+// TestSandboxSynthAgentForcesScratchDir proves sandboxSynthAgent overrides the
+// adapter working dir to the scratch dir regardless of what the agent otherwise
+// carries, and leaves RepoScope intact for family resolution.
+func TestSandboxSynthAgentForcesScratchDir(t *testing.T) {
+	scratch := t.TempDir()
+	agent := runtime.Agent{
+		Name:       "weak-bot",
+		Runtime:    runtime.CodexRuntime,
+		RepoScope:  "acme/widgets",
+		WorkingDir: "/root/gitmoot", // a live checkout — must be overridden
 	}
-	if other.WorkingDir != "" {
-		t.Fatalf("WorkingDir = %q, want empty for unregistered repo", other.WorkingDir)
+	got := sandboxSynthAgent(agent, scratch)
+	if got.WorkingDir != scratch {
+		t.Fatalf("WorkingDir = %q, want scratch %q", got.WorkingDir, scratch)
+	}
+	if got.RepoScope != "acme/widgets" {
+		t.Fatalf("RepoScope = %q, want acme/widgets preserved", got.RepoScope)
+	}
+	// The original agent is not mutated (value copy).
+	if agent.WorkingDir != "/root/gitmoot" {
+		t.Fatalf("original agent mutated: WorkingDir = %q", agent.WorkingDir)
+	}
+}
+
+// TestSynthPromptsCarryEvalOnlyPreamble proves the #725 soft complement: the
+// challenger, attempt, and judge prompts all lead with the answer-only preamble
+// that tells an agentic CLI not to create files or run commands.
+func TestSynthPromptsCarryEvalOnlyPreamble(t *testing.T) {
+	item := synthGeneratedItem{Context: "ctx", Question: "q", Rubric: "r"}
+	prompts := map[string]string{
+		"challenger": synthChallengerPrompt("guidance", ""),
+		"attempt":    synthAttemptPrompt(item),
+		"judge":      synthJudgePrompt(item, "weak", "strong"),
+	}
+	for name, p := range prompts {
+		if !strings.HasPrefix(p, synthEvalOnlyPreamble) {
+			t.Fatalf("%s prompt does not lead with the eval-only preamble:\n%s", name, p)
+		}
+		if !strings.Contains(p, "Do NOT create files, run commands, start servers") {
+			t.Fatalf("%s prompt missing the do-not-execute instruction", name)
+		}
 	}
 }
 

--- a/internal/cli/skillopt_synth_test.go
+++ b/internal/cli/skillopt_synth_test.go
@@ -489,10 +489,11 @@ func TestResolveSynthAgentNeverCarriesCheckout(t *testing.T) {
 func TestSandboxSynthAgentForcesScratchDir(t *testing.T) {
 	scratch := t.TempDir()
 	agent := runtime.Agent{
-		Name:       "weak-bot",
-		Runtime:    runtime.CodexRuntime,
-		RepoScope:  "acme/widgets",
-		WorkingDir: "/root/gitmoot", // a live checkout — must be overridden
+		Name:           "weak-bot",
+		Runtime:        runtime.CodexRuntime,
+		RepoScope:      "acme/widgets",
+		WorkingDir:     "/root/gitmoot",                        // a live checkout — must be overridden
+		AutonomyPolicy: runtime.AutonomyPolicyDangerFullAccess, // a write grant — must be downgraded
 	}
 	got := sandboxSynthAgent(agent, scratch)
 	if got.WorkingDir != scratch {
@@ -501,9 +502,18 @@ func TestSandboxSynthAgentForcesScratchDir(t *testing.T) {
 	if got.RepoScope != "acme/widgets" {
 		t.Fatalf("RepoScope = %q, want acme/widgets preserved", got.RepoScope)
 	}
+	// #725: the scratch cwd is not a hard guarantee unless the permission grant is
+	// also clamped — a write-permissioned agent could otherwise escape by absolute
+	// path. Every synth delivery must be forced to read-only.
+	if got.AutonomyPolicy != runtime.AutonomyPolicyReadOnly {
+		t.Fatalf("AutonomyPolicy = %q, want read-only downgrade", got.AutonomyPolicy)
+	}
 	// The original agent is not mutated (value copy).
 	if agent.WorkingDir != "/root/gitmoot" {
 		t.Fatalf("original agent mutated: WorkingDir = %q", agent.WorkingDir)
+	}
+	if agent.AutonomyPolicy != runtime.AutonomyPolicyDangerFullAccess {
+		t.Fatalf("original agent mutated: AutonomyPolicy = %q", agent.AutonomyPolicy)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1362,7 +1362,12 @@ meaningfully beats the weak agent (score gap ≥ `--gap`, default 0.20) AND the
 judge confirms the item is well-formed; otherwise the round records a
 diagnostic (`too_easy`, `too_hard`, `strong_failed`, `bad_rubric`, or
 `context_leak`) and the Challenger regenerates with targeted feedback until
-accepted or `--max-rounds-per-item` (default 3) is exhausted. Accepted items are
+accepted or `--max-rounds-per-item` (default 3) is exhausted. Every
+challenger/weak/strong/judge delivery is **sandboxed** into a fresh per-item temp
+scratch dir (never a registered repo checkout) and framed with an answer-only
+preamble, so an agentic-CLI attempt can never write files, start servers, or
+modify a live checkout while "answering" the exercise (`#725`); the scratch dir
+is deleted when the item finishes. Accepted items are
 written to `--out` (default `<home>/evals/synth`) and stored in the DB with
 status `pending_human_approval`. They are **structurally isolated**: nothing in
 the promotion/training path reads the synth table, so a pending item can never


### PR DESCRIPTION
## What

`gitmoot skillopt synth` delivers its Challenger/weak/strong/judge attempts to agentic CLIs (codex/claude/kimi), not chat models. `resolveSynthAgent` resolved the adapter working dir to the target repo's **live checkout**, and `synthAttemptPrompt` reads like a real job — so an attempt agent that took the exercise literally **implemented it for real**, writing preview bundles into the maintainer's live `/root/gitmoot` checkout and an unrelated project and probing dev-server ports (the #725 incident).

## Why

The forked-session isolation (`RuntimeRef=""`) protected the agent's live *session* but not the filesystem: the adapter `Dir` still resolved to `agent.WorkingDir` (= the registered `CheckoutPath`), giving a full-tool-permission agent write access to a real checkout.

## How

Two-layer fix, confined to the synth delivery path (`internal/cli/skillopt_synth.go`); the `skillopt ab`/judge dir resolution is byte-identical.

1. **Hard guarantee (sandbox):** `generateSynthItem` now creates a fresh per-item `os.MkdirTemp` scratch dir and forces every delivery into it via the new `sandboxSynthAgent` (sets `agent.WorkingDir = scratch`, which `realSkillOptABDeliver` uses as the adapter `Dir`). The scratch dir — and anything a misbehaving agent wrote into it — is `os.RemoveAll`'d when the item finishes. `resolveSynthAgent` no longer resolves/carries the live checkout at all (`WorkingDir` left empty on purpose), mirroring the #485 hard-verifier write-isolation pattern.
2. **Prompt frame (soft complement):** the challenger, attempt, and judge prompts now lead with an explicit answer-only preamble: *"This is a written evaluation exercise. Do NOT create files, run commands, start servers, or modify any repository. Respond with text only."*

Docs: `skills/gitmoot/references/CLI.md` synth section notes the per-item scratch sandbox + answer-only preamble.

## How tested

Toolchain `go1.26.4`, `HERDR_SOCKET_PATH` throwaway, isolated temp homes.

- `go build ./...` -> pass (exit 0)
- `go vet ./internal/cli/...` -> pass (exit 0)
- `go test -count=1 ./internal/cli/` -> `ok ... 221.496s` (exit 0)
- `go test -race -count=1 -run 'Synth|synth|SandboxSynth|resolveSynth' ./internal/cli/` -> `ok ... 8.368s` (exit 0), **no DATA RACE**
- Full-package `go test -race ./internal/cli/` hit the Go default 10m timeout (pre-existing: the package is too large to race-build+run in 600s; **no data race reported**, `grep -c "DATA RACE"` = 0) — so I ran the race detector scoped to the touched tests instead (green above).

New/updated tests (`internal/cli/skillopt_synth_test.go`):
- `TestRunSkillOptSynthDeliversInScratchNotCheckout` — deterministic no-LLM E2E: with the repo registered to a real checkout, every delivery is handed a `gitmoot-synth-item-*` scratch dir (never the checkout or `owner/repo` RepoScope), all deliveries share the per-item scratch, and it is cleaned up after the run.
- `TestResolveSynthAgentNeverCarriesCheckout` — replaces the old checkout-resolving test; asserts a resolved synth agent never carries the live checkout in `WorkingDir`.
- `TestSandboxSynthAgentForcesScratchDir` — override precedence + no mutation of the source agent.
- `TestSynthPromptsCarryEvalOnlyPreamble` — preamble present on challenger/attempt/judge.
- Existing synth E2E (`TestRunSkillOptSynthAcceptAndApprove` and friends) stay green.

Closes #725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)