### PR TITLE
feat(skillopt): binary-question disagreement as template prompt-update signal (#527)

### DIFF
--- a/internal/cli/skillopt_binary.go
+++ b/internal/cli/skillopt_binary.go
@@ -31,6 +31,8 @@ func runSkillOptBinary(args []string, stdout, stderr io.Writer) int {
 		return runSkillOptBinaryRun(args[1:], stdout, stderr)
 	case "show":
 		return runSkillOptBinaryShow(args[1:], stdout, stderr)
+	case "lessons":
+		return runSkillOptBinaryLessons(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown skillopt binary command %q\n\n", args[0])
 		printSkillOptBinaryUsage(stderr)
@@ -42,6 +44,7 @@ func printSkillOptBinaryUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot skillopt binary run --set <file> --run <run-id> --source <file> [--deterministic] [--reviewer runtime] [--home path] [--json]")
 	fmt.Fprintln(w, "  gitmoot skillopt binary show --run <run-id> [--home path] [--json]")
+	fmt.Fprintln(w, "  gitmoot skillopt binary lessons --template <id> [--set <file>] [--run <run-id> ...] [--no-passes] [--apply] [--home path] [--json]")
 }
 
 // skillOptBinaryDeliver is the delivery seam for the opt-in LLM-backed binary
@@ -306,6 +309,260 @@ func runSkillOptBinaryShow(args []string, stdout, stderr io.Writer) int {
 		Overall:         overall,
 	})
 	return 0
+}
+
+// binaryLessonsRunID is the deterministic id of the synthetic eval run that
+// --apply writes the derived lessons into. It is namespaced per template so
+// re-applying overwrites the same run's events in place (idempotent).
+func binaryLessonsRunID(templateID string) string {
+	return "binary-lessons:" + strings.TrimSpace(templateID)
+}
+
+// binaryLessonsReviewer / binaryLessonsSource stamp the written RankedFeedbackEvents
+// so they are attributable and filterable as the #527 disagreement channel.
+const (
+	binaryLessonsReviewer = "binary-disagreement"
+	binaryLessonsSource   = "binary-disagreement"
+)
+
+// repeatableStringFlag collects a flag passed multiple times.
+type repeatableStringFlag []string
+
+func (r *repeatableStringFlag) String() string { return strings.Join(*r, ",") }
+func (r *repeatableStringFlag) Set(v string) error {
+	v = strings.TrimSpace(v)
+	if v != "" {
+		*r = append(*r, v)
+	}
+	return nil
+}
+
+// runSkillOptBinaryLessons derives optimizer-consumable lessons from the binary
+// verdicts already recorded for a template (#527): questions whose yes/no
+// verdict flips across runs (candidate-vs-champion or repeated runs of one
+// version) are targeted improvement signals, stable NOs are concrete lessons,
+// and stable YESes are traits to preserve. It PREVIEWS by default and writes
+// NOTHING; only --apply projects the lessons onto RankedFeedbackEvent rows via
+// the existing store API so the existing optimizer + rubric-induce consume them
+// with zero contract change. There is no daemon/automatic path — CLI-explicit
+// only, mirroring the synth approval gate.
+func runSkillOptBinaryLessons(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("skillopt binary lessons", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	template := fs.String("template", "", "template id whose binary verdicts to derive lessons from")
+	setPath := fs.String("set", "", "binary question set file (YAML or JSON) used to recover question wording (optional)")
+	noPasses := fs.Bool("no-passes", false, "omit stable-pass (yes-in-every-run) traits; keep only flips and stable failures")
+	apply := fs.Bool("apply", false, "write the derived lessons as ranked feedback events (default previews only, writes nothing)")
+	asJSON := fs.Bool("json", false, "emit JSON")
+	var runFilter repeatableStringFlag
+	fs.Var(&runFilter, "run", "restrict to these run ids (repeatable); default uses every run of the template")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "skillopt binary lessons does not accept positional arguments")
+		return 2
+	}
+	if strings.TrimSpace(*template) == "" {
+		fmt.Fprintln(stderr, "skillopt binary lessons requires --template")
+		return 2
+	}
+
+	var questionText map[string]string
+	if strings.TrimSpace(*setPath) != "" {
+		set, err := skillopt.LoadBinaryQuestionSet(*setPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "skillopt binary lessons: load question set: %v\n", err)
+			return 1
+		}
+		questionText = skillopt.QuestionTextIndex(set)
+	}
+
+	runAllow := map[string]struct{}{}
+	for _, id := range runFilter {
+		runAllow[id] = struct{}{}
+	}
+
+	ctx := context.Background()
+	var lessons []skillopt.BinaryLesson
+	var appliedRunID string
+	appliedEvents := 0
+
+	err := withStore(*home, func(store *db.Store) error {
+		rows, err := store.ListBinaryVerdictsForTemplate(ctx, strings.TrimSpace(*template))
+		if err != nil {
+			return err
+		}
+		flat := make([]struct {
+			QuestionID  string
+			Dimension   string
+			RunID       string
+			VersionID   string
+			Verdict     string
+			Explanation string
+		}, 0, len(rows))
+		for _, r := range rows {
+			if len(runAllow) > 0 {
+				if _, ok := runAllow[r.RunID]; !ok {
+					continue
+				}
+			}
+			flat = append(flat, struct {
+				QuestionID  string
+				Dimension   string
+				RunID       string
+				VersionID   string
+				Verdict     string
+				Explanation string
+			}{
+				QuestionID:  r.QuestionID,
+				Dimension:   r.Dimension,
+				RunID:       r.RunID,
+				VersionID:   r.TemplateVersionID,
+				Verdict:     r.Verdict,
+				Explanation: r.Explanation,
+			})
+		}
+		groups := skillopt.GroupBinaryObservations(flat)
+		opts := skillopt.BinaryLessonsOptions{}
+		if *noPasses {
+			opts = opts.WithIncludeStableYes(false)
+		}
+		lessons = skillopt.DeriveBinaryLessons(groups, questionText, opts)
+
+		if !*apply || len(lessons) == 0 {
+			return nil
+		}
+		appliedRunID = binaryLessonsRunID(*template)
+		if err := writeBinaryLessonEvents(ctx, store, strings.TrimSpace(*template), appliedRunID, lessons); err != nil {
+			return err
+		}
+		appliedEvents = len(lessons)
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "skillopt binary lessons: %v\n", err)
+		return 1
+	}
+
+	if *asJSON {
+		payload := map[string]any{
+			"template": strings.TrimSpace(*template),
+			"applied":  *apply,
+			"lessons":  lessons,
+		}
+		if *apply {
+			payload["run_id"] = appliedRunID
+			payload["events_written"] = appliedEvents
+		}
+		encoded, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "skillopt binary lessons: %v\n", err)
+			return 1
+		}
+		encoded = append(encoded, '\n')
+		stdout.Write(encoded)
+		return 0
+	}
+
+	writeBinaryLessonsHuman(stdout, strings.TrimSpace(*template), lessons, *apply, appliedRunID, appliedEvents)
+	return 0
+}
+
+// writeBinaryLessonEvents registers a synthetic per-template lessons run (once)
+// and, for each lesson, a two-option review item plus a RankedFeedbackEvent
+// carrying the lesson text. Negative lessons (flips, stable failures) go into
+// required_improvements (a flat list the rubric inducer grounds as negative
+// aspects); stable-pass traits go into useful_traits keyed by a known option
+// label. Everything is upserted with deterministic ids so re-applying is
+// idempotent.
+func writeBinaryLessonEvents(ctx context.Context, store *db.Store, templateID, runID string, lessons []skillopt.BinaryLesson) error {
+	if err := store.UpsertEvalRun(ctx, db.EvalRun{
+		ID:           runID,
+		TemplateID:   templateID,
+		TargetRepo:   "binary-disagreement",
+		State:        "review",
+		Mode:         db.EvalRunModeValidate,
+		OptionsCount: 2,
+	}); err != nil {
+		return err
+	}
+	for _, lesson := range lessons {
+		itemID := "q:" + lesson.QuestionID
+		if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{RunID: runID, ItemID: itemID, Title: lesson.QuestionID}); err != nil {
+			return err
+		}
+		for _, label := range []string{"candidate", "champion"} {
+			if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{
+				RunID:      runID,
+				ItemID:     itemID,
+				Label:      label,
+				Role:       "option",
+				ArtifactID: "binary-lessons/" + itemID + "/" + label,
+			}); err != nil {
+				return err
+			}
+		}
+		event := db.RankedFeedbackEvent{
+			ID:          runID + ":" + itemID,
+			RunID:       runID,
+			ItemID:      itemID,
+			RankingJSON: `["candidate","champion"]`,
+			Winner:      "candidate",
+			Reviewer:    binaryLessonsReviewer,
+			Source:      binaryLessonsSource,
+			Reasoning:   lesson.Text,
+		}
+		if lesson.Sign == skillopt.AspectSignPositive {
+			encoded, err := json.Marshal(map[string][]string{"candidate": {lesson.Trait}})
+			if err != nil {
+				return err
+			}
+			event.UsefulTraitsJSON = string(encoded)
+		} else {
+			encoded, err := json.Marshal([]string{lesson.Trait})
+			if err != nil {
+				return err
+			}
+			event.RequiredImprovementsJSON = string(encoded)
+		}
+		if err := store.UpsertRankedFeedbackEvent(ctx, event); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeBinaryLessonsHuman(w io.Writer, templateID string, lessons []skillopt.BinaryLesson, applied bool, runID string, events int) {
+	writeLine(w, "binary-disagreement lessons for template %s", templateID)
+	if len(lessons) == 0 {
+		writeLine(w, "  (no lessons — no binary verdicts recorded for this template, or nothing to flag)")
+		return
+	}
+	flips, stableNo, stableYes := 0, 0, 0
+	for _, l := range lessons {
+		switch l.Kind {
+		case skillopt.BinaryLessonFlip:
+			flips++
+		case skillopt.BinaryLessonStableNo:
+			stableNo++
+		case skillopt.BinaryLessonStableYes:
+			stableYes++
+		}
+	}
+	writeLine(w, "  %d lesson(s): %d flip, %d stable-fail, %d stable-pass", len(lessons), flips, stableNo, stableYes)
+	for _, l := range lessons {
+		writeLine(w, "  [%s] %s (%s, %d yes / %d no across %d run(s)): %s", l.Kind, l.QuestionID, l.Dimension, l.YesCount, l.NoCount, l.Runs, l.Text)
+	}
+	if applied {
+		writeLine(w, "applied: wrote %d ranked feedback event(s) to run %s", events, runID)
+	} else {
+		writeLine(w, "preview only — nothing written. Re-run with --apply to persist these as ranked feedback events.")
+	}
 }
 
 func writeBinaryHuman(w io.Writer, runID string, result skillopt.BinaryEvaluationResult) {

--- a/internal/cli/skillopt_binary.go
+++ b/internal/cli/skillopt_binary.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -313,7 +315,8 @@ func runSkillOptBinaryShow(args []string, stdout, stderr io.Writer) int {
 
 // binaryLessonsRunID is the deterministic id of the synthetic eval run that
 // --apply writes the derived lessons into. It is namespaced per template so
-// re-applying overwrites the same run's events in place (idempotent).
+// re-applying replaces the same run's events wholesale (idempotent full replace,
+// so a shrinking lesson set removes stale events).
 func binaryLessonsRunID(templateID string) string {
 	return "binary-lessons:" + strings.TrimSpace(templateID)
 }
@@ -434,9 +437,14 @@ func runSkillOptBinaryLessons(args []string, stdout, stderr io.Writer) int {
 		}
 		lessons = skillopt.DeriveBinaryLessons(groups, questionText, opts)
 
-		if !*apply || len(lessons) == 0 {
+		if !*apply {
 			return nil
 		}
+		// --apply is a FULL REPLACE, not an accumulating upsert: writeBinaryLessonEvents
+		// clears the synthetic run's prior events before rewriting the current set, so a
+		// shrinking lesson set (e.g. re-running with --no-passes or a narrower --run
+		// filter) removes stale events. We therefore run it even when the current set is
+		// empty — an early return there would strand previously-written events.
 		appliedRunID = binaryLessonsRunID(*template)
 		if err := writeBinaryLessonEvents(ctx, store, strings.TrimSpace(*template), appliedRunID, lessons); err != nil {
 			return err
@@ -473,13 +481,24 @@ func runSkillOptBinaryLessons(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-// writeBinaryLessonEvents registers a synthetic per-template lessons run (once)
-// and, for each lesson, a two-option review item plus a RankedFeedbackEvent
-// carrying the lesson text. Negative lessons (flips, stable failures) go into
-// required_improvements (a flat list the rubric inducer grounds as negative
-// aspects); stable-pass traits go into useful_traits keyed by a known option
-// label. Everything is upserted with deterministic ids so re-applying is
-// idempotent.
+// writeBinaryLessonEvents rewrites a synthetic per-template lessons run as a
+// FULL REPLACE: it (re)registers the run, clears any events from a prior apply,
+// and then for each lesson writes a two-option review item plus a
+// RankedFeedbackEvent carrying the lesson text. Negative lessons (flips, stable
+// failures) go into required_improvements (a flat list the rubric inducer grounds
+// as negative aspects); stable-pass traits go into useful_traits keyed by a known
+// option label. Clearing first (rather than upserting in place) means a shrinking
+// lesson set removes stale events, so re-applying is genuinely idempotent for the
+// derived set — including the empty-set case, which leaves the run with no events.
+//
+// The `candidate`/`champion` option labels are fixed placeholders, not real
+// versions: the lesson lives entirely in useful_traits/required_improvements.
+// So each event is written as a NEUTRAL single tie group with no winner, which
+// derives ZERO pairwise preference (a fabricated `candidate > champion` win would
+// be meaningless — neither placeholder actually won). Each option is backed by a
+// real (if empty) eval_artifacts row so `skillopt export --run
+// binary-lessons:<template>` resolves every artifact ref instead of erroring on a
+// phantom id (the store requires a non-empty option artifact id).
 func writeBinaryLessonEvents(ctx context.Context, store *db.Store, templateID, runID string, lessons []skillopt.BinaryLesson) error {
 	if err := store.UpsertEvalRun(ctx, db.EvalRun{
 		ID:           runID,
@@ -491,31 +510,50 @@ func writeBinaryLessonEvents(ctx context.Context, store *db.Store, templateID, r
 	}); err != nil {
 		return err
 	}
+	// Full replace: drop the previous apply's items/options/events before rewriting.
+	if err := store.ClearEvalRunFeedback(ctx, runID); err != nil {
+		return err
+	}
 	for _, lesson := range lessons {
 		itemID := "q:" + lesson.QuestionID
 		if err := store.UpsertEvalReviewItem(ctx, db.EvalReviewItem{RunID: runID, ItemID: itemID, Title: lesson.QuestionID}); err != nil {
 			return err
 		}
 		for _, label := range []string{"candidate", "champion"} {
+			artifactID := "binary-lessons/" + itemID + "/" + label
+			// Persist a deterministic, empty synthetic artifact row so export's
+			// GetEvalArtifact resolves the option's artifact id. The row is metadata
+			// only (no blob is fetched during export); the hash is a stable digest of
+			// the id so re-applying is idempotent.
+			digest := sha256.Sum256([]byte(artifactID))
+			if err := store.UpsertEvalArtifact(ctx, db.EvalArtifact{
+				ID:        artifactID,
+				Hash:      hex.EncodeToString(digest[:]),
+				MediaType: "text/plain",
+				SizeBytes: 0,
+				Driver:    "text",
+			}); err != nil {
+				return err
+			}
 			if err := store.UpsertEvalReviewOption(ctx, db.EvalReviewOption{
 				RunID:      runID,
 				ItemID:     itemID,
 				Label:      label,
 				Role:       "option",
-				ArtifactID: "binary-lessons/" + itemID + "/" + label,
+				ArtifactID: artifactID,
 			}); err != nil {
 				return err
 			}
 		}
 		event := db.RankedFeedbackEvent{
-			ID:          runID + ":" + itemID,
-			RunID:       runID,
-			ItemID:      itemID,
-			RankingJSON: `["candidate","champion"]`,
-			Winner:      "candidate",
-			Reviewer:    binaryLessonsReviewer,
-			Source:      binaryLessonsSource,
-			Reasoning:   lesson.Text,
+			ID:            runID + ":" + itemID,
+			RunID:         runID,
+			ItemID:        itemID,
+			RankingJSON:   `["candidate","champion"]`,
+			TieGroupsJSON: `[["candidate","champion"]]`,
+			Reviewer:      binaryLessonsReviewer,
+			Source:        binaryLessonsSource,
+			Reasoning:     lesson.Text,
 		}
 		if lesson.Sign == skillopt.AspectSignPositive {
 			encoded, err := json.Marshal(map[string][]string{"candidate": {lesson.Trait}})

--- a/internal/cli/skillopt_binary_lessons_test.go
+++ b/internal/cli/skillopt_binary_lessons_test.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// binaryLessonsSetYAML gives the seeded question ids their human wording so the
+// lessons command can recover it via --set (the verdicts table stores only ids).
+const binaryLessonsSetYAML = `
+version: 1
+template_or_task_kind: planner
+dimensions:
+  - name: correctness
+    questions:
+      - id: q_tests
+        text: Does the change add unit tests covering new parser branches
+  - name: docs
+    questions:
+      - id: q_docs
+        text: Does the change update the CLI documentation reference
+  - name: safety
+    questions:
+      - id: q_errors
+        text: Does the code check returned filesystem errors before proceeding
+  - name: observability
+    questions:
+      - id: q_logs
+        text: Does the code emit structured logging on failure paths
+  - name: style
+    questions:
+      - id: q_pkg
+        text: Does the output declare a package clause
+`
+
+// seedBinaryLessonsHome writes two eval runs (a candidate v2 and a champion v1)
+// of template "planner" and their per-question binary verdicts so the
+// disagreement view has a flip, three stable failures, and one stable pass.
+func seedBinaryLessonsHome(t *testing.T, home string) {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	for _, run := range []db.EvalRun{
+		{ID: "cand", TemplateID: "planner", TemplateVersionID: "planner@2", TargetRepo: "owner/repo", State: "ready"},
+		{ID: "champ", TemplateID: "planner", TemplateVersionID: "planner@1", TargetRepo: "owner/repo", State: "ready"},
+	} {
+		if err := store.UpsertEvalRun(ctx, run); err != nil {
+			t.Fatalf("UpsertEvalRun %s: %v", run.ID, err)
+		}
+	}
+
+	verdicts := []db.BinaryVerdict{
+		// FLIP: candidate passes, champion fails.
+		{RunID: "cand", QuestionID: "q_tests", Dimension: "correctness", Verdict: "yes"},
+		{RunID: "champ", QuestionID: "q_tests", Dimension: "correctness", Verdict: "no", Explanation: "new parser branch untested"},
+		// STABLE FAILS (both runs no).
+		{RunID: "cand", QuestionID: "q_docs", Dimension: "docs", Verdict: "no", Explanation: "cli reference page stale"},
+		{RunID: "champ", QuestionID: "q_docs", Dimension: "docs", Verdict: "no", Explanation: "cli reference page stale"},
+		{RunID: "cand", QuestionID: "q_errors", Dimension: "safety", Verdict: "no", Explanation: "ignored filesystem write error"},
+		{RunID: "champ", QuestionID: "q_errors", Dimension: "safety", Verdict: "no", Explanation: "ignored filesystem write error"},
+		{RunID: "cand", QuestionID: "q_logs", Dimension: "observability", Verdict: "no", Explanation: "silent failure emits no structured log"},
+		{RunID: "champ", QuestionID: "q_logs", Dimension: "observability", Verdict: "no", Explanation: "silent failure emits no structured log"},
+		// STABLE PASS (both runs yes).
+		{RunID: "cand", QuestionID: "q_pkg", Dimension: "style", Verdict: "yes"},
+		{RunID: "champ", QuestionID: "q_pkg", Dimension: "style", Verdict: "yes"},
+	}
+	for _, v := range verdicts {
+		if err := store.UpsertBinaryVerdict(ctx, v); err != nil {
+			t.Fatalf("UpsertBinaryVerdict %s/%s: %v", v.RunID, v.QuestionID, err)
+		}
+	}
+}
+
+type binaryLessonsResult struct {
+	Template      string                  `json:"template"`
+	Applied       bool                    `json:"applied"`
+	RunID         string                  `json:"run_id"`
+	EventsWritten int                     `json:"events_written"`
+	Lessons       []skillopt.BinaryLesson `json:"lessons"`
+}
+
+// TestSkillOptBinaryLessonsPreviewWritesNothing proves the default (no --apply)
+// derives lessons but persists zero ranked feedback events.
+func TestSkillOptBinaryLessonsPreviewWritesNothing(t *testing.T) {
+	home := t.TempDir()
+	seedBinaryLessonsHome(t, home)
+	setPath := writeBinaryFixture(t, home, "set.yaml", binaryLessonsSetYAML)
+
+	var out, errBuf bytes.Buffer
+	code := Run([]string{"skillopt", "binary", "lessons", "--home", home, "--template", "planner", "--set", setPath, "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("lessons preview exit=%d stderr=%s", code, errBuf.String())
+	}
+	var res binaryLessonsResult
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v (%s)", err, out.String())
+	}
+	if res.Applied {
+		t.Fatal("preview must not report applied")
+	}
+	// 1 flip + 3 stable fails + 1 stable pass = 5 lessons.
+	if len(res.Lessons) != 5 {
+		t.Fatalf("lessons = %d, want 5: %+v", len(res.Lessons), res.Lessons)
+	}
+	kinds := map[string]int{}
+	for _, l := range res.Lessons {
+		kinds[l.Kind]++
+	}
+	if kinds[skillopt.BinaryLessonFlip] != 1 || kinds[skillopt.BinaryLessonStableNo] != 3 || kinds[skillopt.BinaryLessonStableYes] != 1 {
+		t.Fatalf("kind counts = %v, want 1 flip / 3 stable_no / 1 stable_yes", kinds)
+	}
+	// The flip lesson recovered the question wording via --set.
+	for _, l := range res.Lessons {
+		if l.QuestionID == "q_tests" && !strings.Contains(l.Trait, "parser") {
+			t.Fatalf("flip trait missing question wording/explanation: %q", l.Trait)
+		}
+	}
+
+	// Nothing was written: the synthetic lessons run has no ranked feedback yet.
+	assertNoBinaryLessonEvents(t, home, "planner")
+}
+
+// TestSkillOptBinaryLessonsApplyWritesConsumableEvents is the deterministic,
+// no-LLM E2E: seed verdicts -> run the CLI with --apply -> assert the produced
+// ranked feedback events are readable by ListRankedFeedbackEventsAcrossRuns AND
+// that the existing rubric inducer consumes them into a frozen rubric.
+func TestSkillOptBinaryLessonsApplyWritesConsumableEvents(t *testing.T) {
+	home := t.TempDir()
+	seedBinaryLessonsHome(t, home)
+	setPath := writeBinaryFixture(t, home, "set.yaml", binaryLessonsSetYAML)
+
+	var out, errBuf bytes.Buffer
+	code := Run([]string{"skillopt", "binary", "lessons", "--home", home, "--template", "planner", "--set", setPath, "--apply", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("lessons apply exit=%d stderr=%s", code, errBuf.String())
+	}
+	var res binaryLessonsResult
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v (%s)", err, out.String())
+	}
+	if !res.Applied || res.EventsWritten != 5 {
+		t.Fatalf("apply result = applied %v events %d, want true/5", res.Applied, res.EventsWritten)
+	}
+
+	// The events are readable via the cross-run join the optimizer/rubric use.
+	events := readRankedFeedbackAcrossRuns(t, home, "planner")
+	if len(events) != 5 {
+		t.Fatalf("ranked feedback events = %d, want 5", len(events))
+	}
+	for _, e := range events {
+		if e.Source != "binary-disagreement" {
+			t.Fatalf("event source = %q, want binary-disagreement", e.Source)
+		}
+	}
+
+	// The existing rubric inducer consumes the produced events with no contract
+	// change and freezes a multi-metric rubric grounded in them.
+	rubric, report, err := skillopt.InduceRubric("planner", events, skillopt.RubricInduceOptions{HoldoutFraction: 0})
+	if err != nil {
+		t.Fatalf("InduceRubric over binary-disagreement events: %v", err)
+	}
+	if report.UsableEvents != 5 {
+		t.Fatalf("rubric usable events = %d, want 5", report.UsableEvents)
+	}
+	if len(rubric.Metrics) < 2 {
+		t.Fatalf("rubric metrics = %d, want >= 2 (themes must separate)", len(rubric.Metrics))
+	}
+	// Provenance: at least one metric cites a binary-lessons event id.
+	cited := false
+	for _, m := range rubric.Metrics {
+		for _, id := range m.SourceEventIDs {
+			if strings.HasPrefix(id, "binary-lessons:planner:") {
+				cited = true
+			}
+		}
+	}
+	if !cited {
+		t.Fatalf("no metric cited a binary-lessons source event id: %+v", rubric.Metrics)
+	}
+
+	// Idempotent re-apply: event count stays at 5 (upsert in place).
+	out.Reset()
+	errBuf.Reset()
+	code = Run([]string{"skillopt", "binary", "lessons", "--home", home, "--template", "planner", "--set", setPath, "--apply", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("re-apply exit=%d stderr=%s", code, errBuf.String())
+	}
+	if again := readRankedFeedbackAcrossRuns(t, home, "planner"); len(again) != 5 {
+		t.Fatalf("re-apply events = %d, want stable 5 (idempotent)", len(again))
+	}
+}
+
+func assertNoBinaryLessonEvents(t *testing.T, home, template string) {
+	t.Helper()
+	if events := readRankedFeedbackAcrossRuns(t, home, template); len(events) != 0 {
+		t.Fatalf("expected zero ranked feedback events, found %d", len(events))
+	}
+}
+
+func readRankedFeedbackAcrossRuns(t *testing.T, home, template string) []db.RankedFeedbackEventWithTemplate {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	events, err := store.ListRankedFeedbackEventsAcrossRuns(context.Background(), template)
+	if err != nil {
+		t.Fatalf("ListRankedFeedbackEventsAcrossRuns: %v", err)
+	}
+	return events
+}

--- a/internal/cli/skillopt_binary_lessons_test.go
+++ b/internal/cli/skillopt_binary_lessons_test.go
@@ -206,6 +206,135 @@ func TestSkillOptBinaryLessonsApplyWritesConsumableEvents(t *testing.T) {
 	}
 }
 
+// TestSkillOptBinaryLessonsApplyIsFullReplace proves --apply is a full replace,
+// not an accumulating upsert: re-applying with --no-passes drops the stable-pass
+// event, and re-applying when the derived set is empty clears every prior event.
+// Without the fix, stale events would keep feeding the optimizer (findings #1/#4).
+func TestSkillOptBinaryLessonsApplyIsFullReplace(t *testing.T) {
+	home := t.TempDir()
+	seedBinaryLessonsHome(t, home)
+	setPath := writeBinaryFixture(t, home, "set.yaml", binaryLessonsSetYAML)
+
+	// First apply: full set = 5 events (1 flip + 3 stable-fail + 1 stable-pass).
+	var out, errBuf bytes.Buffer
+	code := Run([]string{"skillopt", "binary", "lessons", "--home", home, "--template", "planner", "--set", setPath, "--apply", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("apply exit=%d stderr=%s", code, errBuf.String())
+	}
+	if events := readRankedFeedbackAcrossRuns(t, home, "planner"); len(events) != 5 {
+		t.Fatalf("first apply events = %d, want 5", len(events))
+	}
+
+	// Re-apply with --no-passes: the stable-pass q_pkg trait must be REMOVED, not
+	// left behind. Expect 4 events and no q:q_pkg item id.
+	out.Reset()
+	errBuf.Reset()
+	code = Run([]string{"skillopt", "binary", "lessons", "--home", home, "--template", "planner", "--set", setPath, "--no-passes", "--apply", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("no-passes apply exit=%d stderr=%s", code, errBuf.String())
+	}
+	events := readRankedFeedbackAcrossRuns(t, home, "planner")
+	if len(events) != 4 {
+		t.Fatalf("no-passes apply events = %d, want 4 (stale stable-pass must be removed)", len(events))
+	}
+	for _, e := range events {
+		if e.ItemID == "q:q_pkg" {
+			t.Fatalf("stale stable-pass event q:q_pkg survived a --no-passes re-apply: %+v", e)
+		}
+	}
+
+	// Re-apply restricted to a run set that yields NO lessons: everything clears.
+	out.Reset()
+	errBuf.Reset()
+	code = Run([]string{"skillopt", "binary", "lessons", "--home", home, "--template", "planner", "--set", setPath, "--run", "does-not-exist", "--apply", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("empty apply exit=%d stderr=%s", code, errBuf.String())
+	}
+	if again := readRankedFeedbackAcrossRuns(t, home, "planner"); len(again) != 0 {
+		t.Fatalf("empty-set apply left %d events, want 0 (must clear stale events)", len(again))
+	}
+}
+
+// TestSkillOptBinaryLessonsApplyDerivesNoPairwisePreference proves the synthetic
+// events carry no fabricated candidate>champion pairwise win: candidate/champion
+// are placeholder labels, so a derived preference would be meaningless (finding #3).
+func TestSkillOptBinaryLessonsApplyDerivesNoPairwisePreference(t *testing.T) {
+	home := t.TempDir()
+	seedBinaryLessonsHome(t, home)
+	setPath := writeBinaryFixture(t, home, "set.yaml", binaryLessonsSetYAML)
+
+	var out, errBuf bytes.Buffer
+	code := Run([]string{"skillopt", "binary", "lessons", "--home", home, "--template", "planner", "--set", setPath, "--apply", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("apply exit=%d stderr=%s", code, errBuf.String())
+	}
+
+	paths := config.PathsForHome(home)
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+	prefs, err := store.ListPairwisePreferences(context.Background(), "binary-lessons:planner")
+	if err != nil {
+		t.Fatalf("ListPairwisePreferences: %v", err)
+	}
+	if len(prefs) != 0 {
+		t.Fatalf("synthetic run derived %d pairwise preferences, want 0: %+v", len(prefs), prefs)
+	}
+}
+
+// TestSkillOptBinaryLessonsApplyExportsCleanly proves the documented optimizer
+// path `skillopt export --run binary-lessons:<template>` succeeds: the synthetic
+// options carry no phantom artifact ids that would fail artifact loading (finding #2).
+func TestSkillOptBinaryLessonsApplyExportsCleanly(t *testing.T) {
+	home := t.TempDir()
+	seedBinaryLessonsHome(t, home)
+	setPath := writeBinaryFixture(t, home, "set.yaml", binaryLessonsSetYAML)
+
+	// Export resolves the template by reference, so the planner template must exist.
+	paths := config.PathsForHome(home)
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := store.UpsertAgentTemplate(context.Background(), db.AgentTemplate{
+		ID:             "planner",
+		Name:           "Planner",
+		SourceRepo:     "jerryfane/gitmoot",
+		SourceRef:      "main",
+		SourcePath:     "skills/gitmoot/agent-templates/planner.md",
+		ResolvedCommit: "deadbeef",
+		Content:        "Plan carefully.\n",
+	}); err != nil {
+		store.Close()
+		t.Fatalf("UpsertAgentTemplate: %v", err)
+	}
+	store.Close()
+
+	var out, errBuf bytes.Buffer
+	code := Run([]string{"skillopt", "binary", "lessons", "--home", home, "--template", "planner", "--set", setPath, "--apply", "--json"}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("apply exit=%d stderr=%s", code, errBuf.String())
+	}
+
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open (export): %v", err)
+	}
+	defer store.Close()
+	pkg, err := skillopt.ExportTrainingPackage(context.Background(), store, "binary-lessons:planner")
+	if err != nil {
+		t.Fatalf("ExportTrainingPackage over synthetic run failed (phantom artifacts?): %v", err)
+	}
+	if len(pkg.RankedFeedbackEvents) != 5 {
+		t.Fatalf("exported ranked feedback events = %d, want 5", len(pkg.RankedFeedbackEvents))
+	}
+	if len(pkg.PairwisePreferences) != 0 {
+		t.Fatalf("exported pairwise preferences = %d, want 0", len(pkg.PairwisePreferences))
+	}
+}
+
 func assertNoBinaryLessonEvents(t *testing.T, home, template string) {
 	t.Helper()
 	if events := readRankedFeedbackAcrossRuns(t, home, template); len(events) != 0 {

--- a/internal/db/binary_verdicts_test.go
+++ b/internal/db/binary_verdicts_test.go
@@ -146,3 +146,53 @@ func TestListBinaryVerdictsEmpty(t *testing.T) {
 		t.Fatalf("empty run verdicts = %d, want 0", len(got))
 	}
 }
+
+func TestListBinaryVerdictsForTemplate(t *testing.T) {
+	ctx := context.Background()
+	store := openBinaryTestStore(t)
+
+	// Two runs of template "planner" (a candidate v2 and a champion v1) and one
+	// run of an unrelated template that must NOT bleed in.
+	for _, run := range []EvalRun{
+		{ID: "cand", TemplateID: "planner", TemplateVersionID: "planner@2", TargetRepo: "o/r", State: "ready"},
+		{ID: "champ", TemplateID: "planner", TemplateVersionID: "planner@1", TargetRepo: "o/r", State: "ready"},
+		{ID: "other", TemplateID: "builder", TemplateVersionID: "builder@1", TargetRepo: "o/r", State: "ready"},
+	} {
+		if err := store.UpsertEvalRun(ctx, run); err != nil {
+			t.Fatalf("UpsertEvalRun %s: %v", run.ID, err)
+		}
+	}
+	for _, v := range []BinaryVerdict{
+		{RunID: "cand", QuestionID: "q1", Dimension: "correctness", Verdict: "yes"},
+		{RunID: "champ", QuestionID: "q1", Dimension: "correctness", Verdict: "no"},
+		{RunID: "other", QuestionID: "q1", Dimension: "correctness", Verdict: "no"},
+	} {
+		if err := store.UpsertBinaryVerdict(ctx, v); err != nil {
+			t.Fatalf("UpsertBinaryVerdict: %v", err)
+		}
+	}
+
+	got, err := store.ListBinaryVerdictsForTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("ListBinaryVerdictsForTemplate: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("template verdicts = %d, want 2 (other template excluded): %+v", len(got), got)
+	}
+	// Ordered by run_id (cand < champ), each carries its version id.
+	if got[0].RunID != "cand" || got[0].TemplateVersionID != "planner@2" {
+		t.Fatalf("first row = %+v", got[0])
+	}
+	if got[1].RunID != "champ" || got[1].TemplateVersionID != "planner@1" {
+		t.Fatalf("second row = %+v", got[1])
+	}
+
+	// Empty/whitespace template id returns no rows without a query.
+	empty, err := store.ListBinaryVerdictsForTemplate(ctx, "   ")
+	if err != nil {
+		t.Fatalf("empty template: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("empty template rows = %d, want 0", len(empty))
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2812,7 +2812,7 @@ func (s *Store) ClaimRunningJob(ctx context.Context, id string, from string, to 
 //
 // It is a STRICT no-op when currentBootID is "" (a non-Linux host or a boot id
 // that could not be read): with no boot identity there is nothing to compare
-// against, so behavior is byte-identical to before this feature. The `!= ''`
+// against, so behavior is byte-identical to before this feature. The `!= ”`
 // guard likewise never touches identity-less legacy rows (pre-upgrade running
 // jobs), leaving them to the existing age/lease recovery. It NEVER touches a
 // same-boot job — same-boot liveness stays governed by the age/lease gate, so no
@@ -2885,7 +2885,7 @@ func (s *Store) RequeueRunningJobsFromForeignBoot(ctx context.Context, currentBo
 // foreign boot), so this method only reclaims the lock row. It returns the number
 // of locks released.
 //
-// It is a STRICT no-op when currentBootID is "" and, via the `!= ''` guard, never
+// It is a STRICT no-op when currentBootID is "" and, via the `!= ”` guard, never
 // reclaims an identity-less lock (a non-pid-stamping acquire or a legacy row),
 // which stays governed by its lease/TTL. Because a foreign boot id can only have
 // been written by a process on a prior boot, it can never match an in-flight owner
@@ -4938,6 +4938,50 @@ func (s *Store) ListBinaryVerdicts(ctx context.Context, runID string) ([]BinaryV
 		verdicts = append(verdicts, v)
 	}
 	return verdicts, rows.Err()
+}
+
+// BinaryVerdictWithRun is one persisted binary verdict joined with the template
+// id and version id of the eval run it belongs to. It is the read shape the
+// #527 binary-disagreement lesson derivation consumes: to compare verdicts
+// across candidate-vs-champion runs (different versions) and repeated runs of
+// the same version, the derivation needs every verdict for a template together
+// with which run/version produced it.
+type BinaryVerdictWithRun struct {
+	BinaryVerdict
+	TemplateID        string
+	TemplateVersionID string
+}
+
+// ListBinaryVerdictsForTemplate returns every binary verdict for every eval run
+// of a template, joined with the run's template/version ids, ordered
+// deterministically by (run_id, dimension, question_id). It is read-only and
+// additive — it exists for the #527 disagreement view and touches no existing
+// path. An empty/whitespace templateID returns no rows.
+func (s *Store) ListBinaryVerdictsForTemplate(ctx context.Context, templateID string) ([]BinaryVerdictWithRun, error) {
+	templateID = strings.TrimSpace(templateID)
+	if templateID == "" {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT v.run_id, v.question_id, v.dimension, v.verdict, v.explanation, v.question_weight, v.dimension_weight, v.created_at,
+			r.template_id, r.template_version_id
+		FROM skillopt_binary_verdicts v
+		JOIN eval_runs r ON r.id = v.run_id
+		WHERE r.template_id = ?
+		ORDER BY v.run_id, v.dimension, v.question_id`, templateID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []BinaryVerdictWithRun
+	for rows.Next() {
+		var v BinaryVerdictWithRun
+		if err := rows.Scan(&v.RunID, &v.QuestionID, &v.Dimension, &v.Verdict, &v.Explanation, &v.QuestionWeight, &v.DimensionWeight, &v.CreatedAt,
+			&v.TemplateID, &v.TemplateVersionID); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) ListFeedbackEvents(ctx context.Context, runID string) ([]FeedbackEvent, error) {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -5044,6 +5044,35 @@ func (s *Store) UpsertRankedFeedbackEvent(ctx context.Context, event RankedFeedb
 	return err
 }
 
+// ClearEvalRunFeedback deletes all review items, review options, feedback
+// events, and ranked feedback events attached to a run, leaving the eval_runs
+// row itself intact. It exists so a synthetic/derived run (e.g. the #527
+// binary-lessons run) can be rewritten as an atomic FULL REPLACE rather than an
+// accumulating upsert: without it, shrinking the derived lesson set would leave
+// stale rows behind and break the documented idempotency guarantee.
+func (s *Store) ClearEvalRunFeedback(ctx context.Context, runID string) error {
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return errors.New("run id is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, stmt := range []string{
+		`DELETE FROM ranked_feedback_events WHERE run_id = ?`,
+		`DELETE FROM feedback_events WHERE run_id = ?`,
+		`DELETE FROM eval_review_options WHERE run_id = ?`,
+		`DELETE FROM eval_review_items WHERE run_id = ?`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt, runID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 func (s *Store) validateRankedFeedbackEventOptions(ctx context.Context, event RankedFeedbackEvent) error {
 	run, err := s.GetEvalRun(ctx, event.RunID)
 	if err != nil {

--- a/internal/skillopt/binary_lessons.go
+++ b/internal/skillopt/binary_lessons.go
@@ -1,0 +1,271 @@
+package skillopt
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Binary-disagreement lesson derivation (#527). BINEVAL (arXiv:2606.27226,
+// §3.3/§3.4/§5.4) observes that a per-question yes/no verdict is a far more
+// actionable improvement signal than a scalar score gap: a question whose
+// verdict FLIPS across runs (candidate-vs-champion on the same question set, or
+// repeated runs of one version) is a targeted, unstable check the template
+// prompt can be made to reliably satisfy; a question that is a STABLE NO is a
+// concrete lesson; a STABLE YES is a trait worth preserving.
+//
+// This module is a PURE, deterministic transform: it takes the per-question
+// verdicts already persisted by `skillopt binary run` (#525) and turns them
+// into lessons. It performs NO writes and NO LLM calls. The CLI layer
+// (`skillopt binary lessons`) previews these lessons by default and, only with
+// an explicit --apply, projects them onto RankedFeedbackEvent rows so the
+// EXISTING optimizer + rubric-induce (#347) consume them with zero contract
+// change. Nothing on any daemon/hot path calls into here.
+
+// Binary-disagreement lesson kinds.
+const (
+	// BinaryLessonFlip marks a question whose verdict disagrees across the
+	// compared runs (at least one yes AND at least one no): an unstable check
+	// and a targeted improvement signal.
+	BinaryLessonFlip = "flip"
+	// BinaryLessonStableNo marks a question answered "no" in every compared run:
+	// a concrete, repeatable failure lesson.
+	BinaryLessonStableNo = "stable_no"
+	// BinaryLessonStableYes marks a question answered "yes" in every compared
+	// run: a trait worth preserving (positive signal).
+	BinaryLessonStableYes = "stable_yes"
+)
+
+// BinaryVerdictObservation is one verdict for one question, tagged with the run
+// and template version that produced it.
+type BinaryVerdictObservation struct {
+	RunID       string
+	VersionID   string
+	Verdict     string // canonical yes|no (normalizeVerdict is applied on ingest)
+	Explanation string
+}
+
+// BinaryQuestionObservations groups every observed verdict for a single
+// question across the compared runs.
+type BinaryQuestionObservations struct {
+	QuestionID   string
+	Dimension    string
+	Observations []BinaryVerdictObservation
+}
+
+// BinaryLesson is one derived, optimizer-consumable signal for a question.
+// Sign is AspectSignPositive for a stable-yes trait and AspectSignNegative for
+// a flip/stable-no lesson, matching the rubric-induce grounding convention.
+type BinaryLesson struct {
+	QuestionID   string   `json:"question_id"`
+	Dimension    string   `json:"dimension,omitempty"`
+	QuestionText string   `json:"question_text,omitempty"`
+	Kind         string   `json:"kind"`
+	Sign         string   `json:"sign"`
+	Runs         int      `json:"runs"`
+	YesCount     int      `json:"yes_count"`
+	NoCount      int      `json:"no_count"`
+	Versions     []string `json:"versions,omitempty"`
+	Explanations []string `json:"explanations,omitempty"`
+	// Text is the human-readable, framed lesson shown in the CLI preview
+	// (e.g. "Unstable check ... Update the template ...").
+	Text string `json:"text"`
+	// Trait is the CONTENT-focused string projected into a RankedFeedbackEvent's
+	// required_improvements (negative) or useful_traits (positive) on --apply. It
+	// is deliberately the question's own wording + the failing explanations
+	// (text+explanations) with minimal boilerplate, so the rubric inducer's
+	// token-overlap clustering separates lessons by theme rather than collapsing
+	// them on shared framing words.
+	Trait string `json:"trait"`
+}
+
+// BinaryLessonsOptions tunes derivation. Zero values resolve to documented
+// defaults via normalize().
+type BinaryLessonsOptions struct {
+	// MinRuns is the minimum number of observations a question must have to be
+	// eligible at all (default/floor 1). A flip inherently needs >=2 and is
+	// filtered independently of this floor.
+	MinRuns int
+	// IncludeStableYes controls whether stable-yes traits are emitted. Default
+	// true — a preserved-behavior trait is a useful positive signal for the
+	// rubric inducer.
+	IncludeStableYes bool
+	// includeStableYesSet records whether the caller explicitly set
+	// IncludeStableYes so the default can be true without a tri-state field.
+	includeStableYesSet bool
+}
+
+// WithIncludeStableYes returns a copy with IncludeStableYes set explicitly,
+// distinguishing an intentional false from the zero-value default of true.
+func (o BinaryLessonsOptions) WithIncludeStableYes(v bool) BinaryLessonsOptions {
+	o.IncludeStableYes = v
+	o.includeStableYesSet = true
+	return o
+}
+
+func (o BinaryLessonsOptions) normalize() BinaryLessonsOptions {
+	out := o
+	if out.MinRuns < 1 {
+		out.MinRuns = 1
+	}
+	if !out.includeStableYesSet {
+		out.IncludeStableYes = true
+	}
+	return out
+}
+
+// GroupBinaryObservations collapses a flat list of (question, verdict)
+// observations into per-question groups, preserving a deterministic
+// (dimension, question_id) order. The dimension of a group is the first
+// non-empty dimension seen for that question. Verdicts are normalized to the
+// canonical yes/no here so a raw/garbled stored verdict is fail-safe ("no").
+func GroupBinaryObservations(rows []struct {
+	QuestionID  string
+	Dimension   string
+	RunID       string
+	VersionID   string
+	Verdict     string
+	Explanation string
+}) []BinaryQuestionObservations {
+	byQuestion := map[string]*BinaryQuestionObservations{}
+	var order []string
+	for _, r := range rows {
+		qid := strings.TrimSpace(r.QuestionID)
+		if qid == "" {
+			continue
+		}
+		g, ok := byQuestion[qid]
+		if !ok {
+			g = &BinaryQuestionObservations{QuestionID: qid, Dimension: strings.TrimSpace(r.Dimension)}
+			byQuestion[qid] = g
+			order = append(order, qid)
+		}
+		if g.Dimension == "" {
+			g.Dimension = strings.TrimSpace(r.Dimension)
+		}
+		g.Observations = append(g.Observations, BinaryVerdictObservation{
+			RunID:       strings.TrimSpace(r.RunID),
+			VersionID:   strings.TrimSpace(r.VersionID),
+			Verdict:     normalizeVerdict(r.Verdict),
+			Explanation: strings.TrimSpace(r.Explanation),
+		})
+	}
+	groups := make([]BinaryQuestionObservations, 0, len(order))
+	for _, qid := range order {
+		groups = append(groups, *byQuestion[qid])
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].Dimension != groups[j].Dimension {
+			return groups[i].Dimension < groups[j].Dimension
+		}
+		return groups[i].QuestionID < groups[j].QuestionID
+	})
+	return groups
+}
+
+// DeriveBinaryLessons turns per-question observations into lessons. questionText
+// (optional; keyed by question id) enriches the lesson label with the question's
+// own text when available — the verdicts table stores only ids, so a caller may
+// pass the loaded question set to recover the wording. The result is sorted by
+// (dimension, question_id) for a stable, reproducible ordering.
+func DeriveBinaryLessons(groups []BinaryQuestionObservations, questionText map[string]string, opts BinaryLessonsOptions) []BinaryLesson {
+	opts = opts.normalize()
+	var lessons []BinaryLesson
+	for _, g := range groups {
+		if len(g.Observations) < opts.MinRuns {
+			continue
+		}
+		yes, no := 0, 0
+		versions := newOrderedStringSet()
+		posExpl := newOrderedStringSet()
+		negExpl := newOrderedStringSet()
+		for _, obs := range g.Observations {
+			if obs.Verdict == BinaryVerdictYes {
+				yes++
+				if obs.Explanation != "" {
+					posExpl.add(obs.Explanation)
+				}
+			} else {
+				no++
+				if obs.Explanation != "" {
+					negExpl.add(obs.Explanation)
+				}
+			}
+			if obs.VersionID != "" {
+				versions.add(obs.VersionID)
+			}
+		}
+		runs := len(g.Observations)
+		label := strings.TrimSpace(questionText[g.QuestionID])
+		if label == "" {
+			label = g.QuestionID
+		}
+
+		var kind, sign, text string
+		var explanations []string
+		switch {
+		case yes > 0 && no > 0:
+			kind = BinaryLessonFlip
+			sign = AspectSignNegative
+			text = fmt.Sprintf("Unstable check %q (dimension %q): verdict flips across %d runs (%d yes / %d no). Update the template so this check is reliably satisfied.", label, g.Dimension, runs, yes, no)
+			explanations = negExpl.values()
+		case no > 0:
+			kind = BinaryLessonStableNo
+			sign = AspectSignNegative
+			text = fmt.Sprintf("Consistently fails check %q (dimension %q) across %d run(s). Update the template to satisfy it.", label, g.Dimension, runs)
+			explanations = negExpl.values()
+		default:
+			if !opts.IncludeStableYes {
+				continue
+			}
+			kind = BinaryLessonStableYes
+			sign = AspectSignPositive
+			text = fmt.Sprintf("Reliably satisfies check %q (dimension %q) across %d run(s); preserve this behavior.", label, g.Dimension, runs)
+			explanations = posExpl.values()
+		}
+		if len(explanations) > 0 {
+			text += " Evidence: " + strings.Join(explanations, " | ")
+		}
+
+		// Trait is the content-focused projection: the question's own wording (or
+		// id) plus the failing/passing explanations, without the framing
+		// boilerplate that would otherwise dominate token clustering.
+		trait := label
+		if len(explanations) > 0 {
+			trait += ": " + strings.Join(explanations, "; ")
+		}
+
+		lessons = append(lessons, BinaryLesson{
+			QuestionID:   g.QuestionID,
+			Dimension:    g.Dimension,
+			QuestionText: strings.TrimSpace(questionText[g.QuestionID]),
+			Kind:         kind,
+			Sign:         sign,
+			Runs:         runs,
+			YesCount:     yes,
+			NoCount:      no,
+			Versions:     versions.values(),
+			Explanations: explanations,
+			Text:         text,
+			Trait:        trait,
+		})
+	}
+	return lessons
+}
+
+// QuestionTextIndex flattens a question set into a question_id -> text map so
+// lesson derivation can recover the human wording the verdicts table does not
+// persist.
+func QuestionTextIndex(set BinaryQuestionSet) map[string]string {
+	out := map[string]string{}
+	for _, d := range set.Dimensions {
+		for _, q := range d.Questions {
+			id := strings.TrimSpace(q.ID)
+			if id == "" {
+				continue
+			}
+			out[id] = strings.TrimSpace(q.Text)
+		}
+	}
+	return out
+}

--- a/internal/skillopt/binary_lessons_test.go
+++ b/internal/skillopt/binary_lessons_test.go
@@ -1,0 +1,147 @@
+package skillopt
+
+import (
+	"strings"
+	"testing"
+)
+
+type flatRow = struct {
+	QuestionID  string
+	Dimension   string
+	RunID       string
+	VersionID   string
+	Verdict     string
+	Explanation string
+}
+
+func TestDeriveBinaryLessonsClassifiesFlipStableFailAndPass(t *testing.T) {
+	rows := []flatRow{
+		// q-flip: yes in candidate, no in champion -> flip.
+		{QuestionID: "q-flip", Dimension: "correctness", RunID: "cand", VersionID: "v2", Verdict: "yes", Explanation: "candidate handles it"},
+		{QuestionID: "q-flip", Dimension: "correctness", RunID: "champ", VersionID: "v1", Verdict: "no", Explanation: "champion missed the edge case"},
+		// q-fail: no in every run -> stable failure.
+		{QuestionID: "q-fail", Dimension: "style", RunID: "cand", VersionID: "v2", Verdict: "no", Explanation: "no docstring"},
+		{QuestionID: "q-fail", Dimension: "style", RunID: "champ", VersionID: "v1", Verdict: "no", Explanation: "no docstring"},
+		// q-pass: yes in every run -> stable pass (useful trait).
+		{QuestionID: "q-pass", Dimension: "safety", RunID: "cand", VersionID: "v2", Verdict: "yes"},
+		{QuestionID: "q-pass", Dimension: "safety", RunID: "champ", VersionID: "v1", Verdict: "yes"},
+	}
+	groups := GroupBinaryObservations(rows)
+	lessons := DeriveBinaryLessons(groups, nil, BinaryLessonsOptions{})
+	if len(lessons) != 3 {
+		t.Fatalf("lessons = %d, want 3: %+v", len(lessons), lessons)
+	}
+	byID := map[string]BinaryLesson{}
+	for _, l := range lessons {
+		byID[l.QuestionID] = l
+	}
+
+	flip := byID["q-flip"]
+	if flip.Kind != BinaryLessonFlip || flip.Sign != AspectSignNegative {
+		t.Fatalf("q-flip kind/sign = %s/%s", flip.Kind, flip.Sign)
+	}
+	if flip.YesCount != 1 || flip.NoCount != 1 || flip.Runs != 2 {
+		t.Fatalf("q-flip counts = yes %d no %d runs %d", flip.YesCount, flip.NoCount, flip.Runs)
+	}
+	if !strings.Contains(flip.Text, "flips") || !strings.Contains(flip.Text, "champion missed the edge case") {
+		t.Fatalf("q-flip text missing signal: %q", flip.Text)
+	}
+	if len(flip.Versions) != 2 {
+		t.Fatalf("q-flip versions = %v, want 2 distinct", flip.Versions)
+	}
+
+	fail := byID["q-fail"]
+	if fail.Kind != BinaryLessonStableNo || fail.Sign != AspectSignNegative {
+		t.Fatalf("q-fail kind/sign = %s/%s", fail.Kind, fail.Sign)
+	}
+	if !strings.Contains(fail.Text, "Consistently fails") {
+		t.Fatalf("q-fail text = %q", fail.Text)
+	}
+	// Duplicate explanations dedupe to a single evidence entry.
+	if strings.Count(fail.Text, "no docstring") != 1 {
+		t.Fatalf("q-fail evidence not deduped: %q", fail.Text)
+	}
+
+	pass := byID["q-pass"]
+	if pass.Kind != BinaryLessonStableYes || pass.Sign != AspectSignPositive {
+		t.Fatalf("q-pass kind/sign = %s/%s", pass.Kind, pass.Sign)
+	}
+	if !strings.Contains(pass.Text, "preserve this behavior") {
+		t.Fatalf("q-pass text = %q", pass.Text)
+	}
+}
+
+func TestDeriveBinaryLessonsNoPassesOmitsStableYes(t *testing.T) {
+	rows := []flatRow{
+		{QuestionID: "q-pass", Dimension: "safety", RunID: "cand", Verdict: "yes"},
+		{QuestionID: "q-pass", Dimension: "safety", RunID: "champ", Verdict: "yes"},
+		{QuestionID: "q-fail", Dimension: "style", RunID: "cand", Verdict: "no"},
+	}
+	groups := GroupBinaryObservations(rows)
+	lessons := DeriveBinaryLessons(groups, nil, BinaryLessonsOptions{}.WithIncludeStableYes(false))
+	if len(lessons) != 1 || lessons[0].QuestionID != "q-fail" {
+		t.Fatalf("with --no-passes want only q-fail, got %+v", lessons)
+	}
+}
+
+func TestDeriveBinaryLessonsUsesQuestionText(t *testing.T) {
+	rows := []flatRow{
+		{QuestionID: "q1", Dimension: "d", RunID: "r1", Verdict: "no"},
+	}
+	groups := GroupBinaryObservations(rows)
+	lessons := DeriveBinaryLessons(groups, map[string]string{"q1": "Does the PR include tests?"}, BinaryLessonsOptions{})
+	if len(lessons) != 1 {
+		t.Fatalf("lessons = %d", len(lessons))
+	}
+	if lessons[0].QuestionText != "Does the PR include tests?" {
+		t.Fatalf("question text not carried: %q", lessons[0].QuestionText)
+	}
+	if !strings.Contains(lessons[0].Text, "Does the PR include tests?") {
+		t.Fatalf("lesson text should use question wording: %q", lessons[0].Text)
+	}
+	// The projected Trait is content-focused (question wording), free of the
+	// framing boilerplate present in Text, so token clustering separates themes.
+	if lessons[0].Trait != "Does the PR include tests?" {
+		t.Fatalf("trait = %q, want the bare question wording", lessons[0].Trait)
+	}
+}
+
+func TestDeriveBinaryLessonsAllPassNoLessonsWhenNoPassesAndOnlyYes(t *testing.T) {
+	rows := []flatRow{
+		{QuestionID: "q-pass", Dimension: "safety", RunID: "cand", Verdict: "yes"},
+	}
+	groups := GroupBinaryObservations(rows)
+	lessons := DeriveBinaryLessons(groups, nil, BinaryLessonsOptions{}.WithIncludeStableYes(false))
+	if len(lessons) != 0 {
+		t.Fatalf("all-pass with --no-passes should yield no lessons, got %+v", lessons)
+	}
+}
+
+func TestQuestionTextIndex(t *testing.T) {
+	set := BinaryQuestionSet{
+		Version: 1,
+		Dimensions: []BinaryDimension{
+			{Name: "d", Questions: []BinaryQuestion{{ID: "a", Text: "Text A"}, {ID: "b", Text: "Text B"}}},
+		},
+	}
+	idx := QuestionTextIndex(set)
+	if idx["a"] != "Text A" || idx["b"] != "Text B" {
+		t.Fatalf("index = %v", idx)
+	}
+}
+
+func TestGroupBinaryObservationsDeterministicOrder(t *testing.T) {
+	rows := []flatRow{
+		{QuestionID: "z", Dimension: "b", RunID: "r1", Verdict: "no"},
+		{QuestionID: "a", Dimension: "b", RunID: "r1", Verdict: "yes"},
+		{QuestionID: "m", Dimension: "a", RunID: "r1", Verdict: "no"},
+	}
+	groups := GroupBinaryObservations(rows)
+	// Sorted by (dimension, question_id): a/m, then b/a, then b/z.
+	want := []string{"m", "a", "z"}
+	for i, g := range groups {
+		if g.QuestionID != want[i] {
+			t.Fatalf("group %d = %s, want %s", i, g.QuestionID, want[i])
+		}
+	}
+}

--- a/internal/skillopt/contract.go
+++ b/internal/skillopt/contract.go
@@ -723,7 +723,9 @@ func ExportTrainingPackage(ctx context.Context, store *db.Store, runID string) (
 			artifactIDs[id] = struct{}{}
 		}
 		for _, option := range options {
-			artifactIDs[option.ArtifactID] = struct{}{}
+			if id := strings.TrimSpace(option.ArtifactID); id != "" {
+				artifactIDs[id] = struct{}{}
+			}
 		}
 	}
 	artifacts, err := loadArtifactRefs(ctx, store, artifactIDs)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1178,6 +1178,7 @@ gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-com
 gitmoot skillopt gate history --candidate <version-id> [--json]
 gitmoot skillopt binary run --set <file> --run <run-id> --source <file> [--deterministic] [--reviewer runtime] [--home path] [--json]
 gitmoot skillopt binary show --run <run-id> [--home path] [--json]
+gitmoot skillopt binary lessons --template <id> [--set <file>] [--run <run-id> ...] [--no-passes] [--apply] [--home path] [--json]
 gitmoot skillopt synth --template <id> --repo owner/repo --weak <agent> --strong <agent> [--judge <agent>] [--challenger <agent>] [--max-items N] [--max-rounds-per-item M] [--gap F] [--out dir] [--json]
 gitmoot skillopt synth list [--status pending_human_approval|approved|rejected] [--json]
 gitmoot skillopt synth approve <item-id>
@@ -1341,6 +1342,24 @@ packets are byte-identical). The per-dimension scores map onto the existing
 `EvaluatorScore.DimensionScores` shape with **no contract change**. Nothing here
 runs unless a `skillopt binary` command is invoked — every existing SkillOpt
 review/optimize flow is byte-identical when it is unused.
+
+`skillopt binary lessons --template <id>` turns the per-question verdicts already
+recorded for a template into **optimizer-consumable prompt-update lessons**
+(`#527`, BINEVAL §3.3/§3.4). It compares verdicts across every run of the
+template — candidate-vs-champion (different versions) **and** repeated runs of one
+version (instability) — and classifies each question: a verdict that **flips**
+across runs is an unstable, targeted improvement signal; a **stable NO** is a
+concrete failure lesson; a **stable YES** is a trait to preserve. It **previews by
+default and writes nothing**. With `--apply` it projects the lessons onto
+`RankedFeedbackEvent` rows via the existing store API (`source=binary-disagreement`;
+negative lessons → `required_improvements`, stable-pass traits → `useful_traits`)
+so the **existing** optimizer + `skillopt rubric induce` consume them with **zero
+contract change**. `--set <file>` supplies the question set so lessons recover the
+question wording (the verdicts table stores only ids); `--run <id>` (repeatable)
+restricts to specific runs; `--no-passes` drops the stable-pass traits. There is
+**no daemon or automatic path** — writes are CLI-explicit only, mirroring the
+`skillopt synth` approval gate, and re-applying is idempotent (a deterministic
+per-template synthetic run, upserted in place).
 
 `skillopt pairwise import <packet-dir>` ingests a **blinded paired-review
 packet** produced by the gitmoot-skillopt fork (the `pairwise-review.json`

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1358,8 +1358,13 @@ contract change**. `--set <file>` supplies the question set so lessons recover t
 question wording (the verdicts table stores only ids); `--run <id>` (repeatable)
 restricts to specific runs; `--no-passes` drops the stable-pass traits. There is
 **no daemon or automatic path** — writes are CLI-explicit only, mirroring the
-`skillopt synth` approval gate, and re-applying is idempotent (a deterministic
-per-template synthetic run, upserted in place).
+`skillopt synth` approval gate, and re-applying is idempotent: `--apply` is a
+**full replace** of a deterministic per-template synthetic run (its prior events
+are cleared and rewritten), so a shrinking lesson set — e.g. re-running with
+`--no-passes`, a narrower `--run` filter, or no lessons at all — removes the
+stale events rather than leaving them to feed the optimizer. The synthetic
+events carry no fabricated pairwise preference (neutral tie group, no winner):
+the lesson lives entirely in `required_improvements`/`useful_traits`.
 
 `skillopt pairwise import <packet-dir>` ingests a **blinded paired-review
 packet** produced by the gitmoot-skillopt fork (the `pairwise-review.json`

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -473,6 +473,30 @@ and the verdicts ride the training-package export as the optional
 `skillopt binary` command is invoked — every existing review/optimize flow is
 byte-identical when it is unused.
 
+### Binary-disagreement lessons (#527)
+
+`gitmoot skillopt binary lessons --template <id>` turns those per-question
+verdicts into **optimizer-consumable prompt-update lessons** (BINEVAL §3.3/§3.4).
+It compares verdicts across every run of the template — candidate-vs-champion
+(different versions) **and** repeated runs of one version (instability) — and
+classifies each question:
+
+- a verdict that **flips** across runs → an unstable, targeted improvement signal;
+- a **stable NO** (no in every run) → a concrete failure lesson;
+- a **stable YES** (yes in every run) → a trait worth preserving.
+
+The command **previews by default and writes nothing**. With `--apply` it projects
+the lessons onto `RankedFeedbackEvent` rows via the existing store API
+(`source=binary-disagreement`): negative lessons become `required_improvements`
+and stable-pass traits become `useful_traits`, so the **existing** optimizer and
+`skillopt rubric induce` consume them with **zero contract change**. `--set <file>`
+supplies the question set so a lesson recovers the question's own wording (the
+verdicts table stores only ids); `--run <id>` (repeatable) restricts to specific
+runs; `--no-passes` drops the stable-pass traits. There is **no daemon or
+automatic path** — writes are CLI-explicit only, mirroring the `skillopt synth`
+approval gate, and re-applying is idempotent (a deterministic per-template
+synthetic run, upserted in place).
+
 ### Promotion policy + notifications (off by default)
 
 When a candidate becomes **pending** (after `skillopt import` or `train

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -494,8 +494,13 @@ supplies the question set so a lesson recovers the question's own wording (the
 verdicts table stores only ids); `--run <id>` (repeatable) restricts to specific
 runs; `--no-passes` drops the stable-pass traits. There is **no daemon or
 automatic path** — writes are CLI-explicit only, mirroring the `skillopt synth`
-approval gate, and re-applying is idempotent (a deterministic per-template
-synthetic run, upserted in place).
+approval gate, and re-applying is idempotent: `--apply` is a **full replace** of
+a deterministic per-template synthetic run (its prior events are cleared and
+rewritten), so a shrinking lesson set — re-running with `--no-passes`, a narrower
+`--run` filter, or no lessons at all — removes the stale events rather than
+leaving them to feed the optimizer. The synthetic events carry no fabricated
+pairwise preference (neutral tie group, no winner): the lesson lives entirely in
+`required_improvements`/`useful_traits`.
 
 ### Promotion policy + notifications (off by default)
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9113,6 +9113,7 @@ gitmoot skillopt gate run --candidate <version-id> [--corpus path] [--replay-com
 gitmoot skillopt gate history --candidate <version-id> [--json]
 gitmoot skillopt binary run --set <file> --run <run-id> --source <file> [--deterministic] [--reviewer runtime] [--home path] [--json]
 gitmoot skillopt binary show --run <run-id> [--home path] [--json]
+gitmoot skillopt binary lessons --template <id> [--set <file>] [--run <run-id> ...] [--no-passes] [--apply] [--home path] [--json]
 gitmoot skillopt synth --template <id> --repo owner/repo --weak <agent> --strong <agent> [--judge <agent>] [--challenger <agent>] [--max-items N] [--max-rounds-per-item M] [--gap F] [--out dir] [--json]
 gitmoot skillopt synth list [--status pending_human_approval|approved|rejected] [--json]
 gitmoot skillopt synth approve <item-id>
@@ -9276,6 +9277,24 @@ packets are byte-identical). The per-dimension scores map onto the existing
 `EvaluatorScore.DimensionScores` shape with **no contract change**. Nothing here
 runs unless a `skillopt binary` command is invoked — every existing SkillOpt
 review/optimize flow is byte-identical when it is unused.
+
+`skillopt binary lessons --template <id>` turns the per-question verdicts already
+recorded for a template into **optimizer-consumable prompt-update lessons**
+(`#527`, BINEVAL §3.3/§3.4). It compares verdicts across every run of the
+template — candidate-vs-champion (different versions) **and** repeated runs of one
+version (instability) — and classifies each question: a verdict that **flips**
+across runs is an unstable, targeted improvement signal; a **stable NO** is a
+concrete failure lesson; a **stable YES** is a trait to preserve. It **previews by
+default and writes nothing**. With `--apply` it projects the lessons onto
+`RankedFeedbackEvent` rows via the existing store API (`source=binary-disagreement`;
+negative lessons → `required_improvements`, stable-pass traits → `useful_traits`)
+so the **existing** optimizer + `skillopt rubric induce` consume them with **zero
+contract change**. `--set <file>` supplies the question set so lessons recover the
+question wording (the verdicts table stores only ids); `--run <id>` (repeatable)
+restricts to specific runs; `--no-passes` drops the stable-pass traits. There is
+**no daemon or automatic path** — writes are CLI-explicit only, mirroring the
+`skillopt synth` approval gate, and re-applying is idempotent (a deterministic
+per-template synthetic run, upserted in place).
 
 `skillopt pairwise import <packet-dir>` ingests a **blinded paired-review
 packet** produced by the gitmoot-skillopt fork (the `pairwise-review.json`
@@ -10249,6 +10268,47 @@ family is available), **never** touches the promotion bandit, drops fail-safe on
 unparseable output, and its trust is **deferred to measure-the-judge (#344)**.
 `--judge-only` records only the judge row (skips the human prompt). Off ⇒
 byte-identical.
+
+## Chat
+
+Native chat (#534, V1 local-only) is a durable, repo-aware conversation ledger
+where registered agents and the human converse in threads, `@`-tag one another,
+answer a job that paused for a decision, and explicitly promote a message into
+real work. It lives entirely in gitmoot's local SQLite — zero network, zero
+entmoot dependency. The one rule that shapes everything: **a message is a row
+(free); a job is compute (explicit)**. Tagging `@codex-b` creates an inbox item;
+it does not start work. Work happens only when you explicitly `chat task`
+(promotion) or `chat answer` (the ask-gate resume), which makes runaway agent
+ping-pong structurally impossible.
+
+```sh
+# A durable, repo-scoped thread; leave an @-tagged note (starts nothing).
+gitmoot chat create release-room --repo owner/repo --topic "Release coordination"
+gitmoot chat send release-room "@codex-b can you inspect the runtime adapter?"
+gitmoot chat inbox codex-b --unread          # the mention landed here; no job ran
+
+# Promote a message into a real job — the ONE promotion verb.
+gitmoot chat task release-room "@codex-b implement the adapter" --action implement
+gitmoot chat show release-room               # promotion_request, then later the job_result
+```
+
+`chat task` requires exactly one registered `@agent`, records a
+`promotion_request`, dispatches a background job through the same validate →
+repo-scope → capability → autonomy-policy gate the daemon uses, and back-links the
+job; when the job reaches a terminal state its result is appended back into the
+thread as a `job_result` message (never promotable, never mention-scanned). An
+identical `(thread, body)` promotion that actually produced a job within a 60 s
+window is refused (anti-ping-pong); a promotion whose dispatch failed does not
+block a retry.
+
+The keystone scenario is the **ask-gate answer channel**. When an agent returns
+`human_questions[]`, the engine pauses the tree at `awaiting_human` (#445) and
+auto-links a `job-<hash>` thread carrying the questions as a `system` message.
+`gitmoot chat answer <thread> "<id>: text"` routes the answer onto the existing
+resume path (`ResolveEscalation(answer)`), enqueuing the coordinator continuation
+that carries the answer, inherits the thread link, and posts its result back into
+the same thread. Answering an already-resolved pause is a clear no-op, not a false
+success. See `CLI.md § Native Chat` for every flag.
 
 ## Execution Model
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9293,8 +9293,13 @@ contract change**. `--set <file>` supplies the question set so lessons recover t
 question wording (the verdicts table stores only ids); `--run <id>` (repeatable)
 restricts to specific runs; `--no-passes` drops the stable-pass traits. There is
 **no daemon or automatic path** — writes are CLI-explicit only, mirroring the
-`skillopt synth` approval gate, and re-applying is idempotent (a deterministic
-per-template synthetic run, upserted in place).
+`skillopt synth` approval gate, and re-applying is idempotent: `--apply` is a
+**full replace** of a deterministic per-template synthetic run (its prior events
+are cleared and rewritten), so a shrinking lesson set — e.g. re-running with
+`--no-passes`, a narrower `--run` filter, or no lessons at all — removes the
+stale events rather than leaving them to feed the optimizer. The synthetic
+events carry no fabricated pairwise preference (neutral tie group, no winner):
+the lesson lives entirely in `required_improvements`/`useful_traits`.
 
 `skillopt pairwise import <packet-dir>` ingests a **blinded paired-review
 packet** produced by the gitmoot-skillopt fork (the `pairwise-review.json`


### PR DESCRIPTION
## What

Adds `gitmoot skillopt binary lessons --template <id> [--set <file>] [--run <run-id> ...] [--no-passes] [--apply] [--home path] [--json]` (#527). It turns the per-question binary verdicts recorded by `skillopt binary run` (#525) into **optimizer-consumable prompt-update lessons**.

## Why

BINEVAL (arXiv:2606.27226, §3.3/§3.4) shows a per-question yes/no verdict is a more actionable improvement signal than a scalar score gap. This builds the **disagreement view** over a template's binary verdicts across runs — candidate-vs-champion (different versions) **and** repeated runs of one version (instability) — and classifies each question:

- a verdict that **flips** across runs → an unstable, targeted improvement signal;
- a **stable NO** (no in every run) → a concrete failure lesson;
- a **stable YES** (yes in every run) → a trait worth preserving.

The lessons are emitted as `RankedFeedbackEvent`-shaped rows (`source=binary-disagreement`; negative lessons → `required_improvements`, stable-pass traits → `useful_traits`) via the **existing** store API, so the existing optimizer + `skillopt rubric induce` consume them with **zero contract change**.

## How

- `internal/skillopt/binary_lessons.go` — pure, deterministic derivation (`GroupBinaryObservations` + `DeriveBinaryLessons` + `QuestionTextIndex`). No writes, no LLM. The projected `Trait` is content-focused (question wording + failing explanations) so the rubric inducer's token clustering separates lessons by theme rather than collapsing on shared framing words.
- `internal/db/store.go` — additive, read-only `ListBinaryVerdictsForTemplate` (joins verdicts to `eval_runs` by `template_id`, carrying the version id).
- `internal/cli/skillopt_binary.go` — the `lessons` subcommand. **Previews by default and writes nothing**; only `--apply` persists events, into a deterministic per-template synthetic run (idempotent upsert). **No daemon or automatic path** — CLI-explicit only, mirroring the `skillopt synth` approval gate. `--set` recovers question wording; `--run` (repeatable) restricts to specific runs; `--no-passes` drops stable-pass traits.

Additive + off the hot path: nothing runs unless the command is invoked; no schema change (reuses `skillopt_binary_verdicts`, `eval_runs`, `ranked_feedback_events`).

## How tested (go1.26.4)

- `go build ./...` — ok
- `go vet ./internal/cli/ ./internal/skillopt/ ./internal/db/` — ok
- `go test ./internal/skillopt/ ./internal/db/` — ok
- `go test ./internal/cli/ -timeout 1200s` — ok (232s)
- `go test -race ./internal/skillopt/` — ok; `go test -race ./internal/cli/ -run SkillOptBinary` — ok. (The full `internal/cli` `-race` run exceeds the 10-minute package deadline — a pre-existing property of this large package, not a data race.)
- `cd website && npm ci && npm run build` — ok
- New tests: derivation unit tests (flip / stable-fail / stable-pass, `--no-passes`, question-text enrichment, deterministic ordering); store round-trip test (template scoping + version ids + empty guard); **no-LLM E2E** — seed verdicts via store → run the CLI with `--apply` → assert the produced events are readable by `ListRankedFeedbackEventsAcrossRuns` AND consumed by `skillopt.InduceRubric` into a multi-metric rubric grounded in the `binary-lessons:` source events; preview writes nothing; re-apply is idempotent.

## Docs (same PR)

- `skills/gitmoot/references/CLI.md`
- `website/docs/reference/skillopt-exchange-contract.md` (new "Binary-disagreement lessons" section; `llms-full.txt` regenerated by the docs build)

Closes #527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)