### PR TITLE
fix(github): pass large gh bodies via temp file to survive ARG_MAX (#734)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	neturl "net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -6188,6 +6189,7 @@ func publishSkillOptTrainReview(ctx context.Context, paths config.Paths, store *
 		Body:  body,
 	})
 	if err != nil {
+		downgradeReviewMarkerOnLaunchFailure(paths, session, iteration, postingMetadata, err)
 		return skillOptTrainReviewPublishResult{}, err
 	}
 	published := feedback.GitHubPublishResult{Repo: repo, IssueNumber: issue.Number, URL: issue.URL, Mode: "issue"}
@@ -6319,6 +6321,44 @@ func skillOptTrainReviewWatch(ctx context.Context, store *db.Store, iteration db
 		StaleThresholdSeconds: int64(skillOptReviewWatchDefaultStaleThreshold.Seconds()),
 		MetadataJSON:          string(metadataJSON),
 	}, nil
+}
+
+// isExecLaunchFailure reports whether err is a failure to even launch the gh
+// subprocess — a missing binary (exec.ErrNotFound) or a failed fork/exec such as
+// ARG_MAX "argument list too long" (#734). In every such case the child process
+// never started, so no GitHub request left this machine.
+func isExecLaunchFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "fork/exec") ||
+		strings.Contains(msg, "argument list too long")
+}
+
+// downgradeReviewMarkerOnLaunchFailure clears the conservative posting_external
+// latch when the gh publish call failed to launch (fork/exec / ARG_MAX / missing
+// binary). Because the external GitHub post never started, no duplicate issue can
+// exist, so leaving the posting_external marker — which recover treats as "the
+// post may have happened, a human must inspect before retrying" — would wedge the
+// session behind a phantom duplicate. It rewrites the marker as failed_pre_exec,
+// which recover treats as "no external post occurred", so the next attempt
+// proceeds fresh. For every other error class (a timeout, a kill mid-flight) the
+// request may have reached GitHub, so the latch is deliberately left intact.
+func downgradeReviewMarkerOnLaunchFailure(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, postingMetadata map[string]any, err error) {
+	if !isExecLaunchFailure(err) {
+		return
+	}
+	failed := make(map[string]any, len(postingMetadata)+2)
+	for key, value := range postingMetadata {
+		failed[key] = value
+	}
+	failed["status"] = "failed_pre_exec"
+	failed["failed_pre_exec_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	_ = writeSkillOptTrainReviewRecovery(paths, session, iteration, failed)
 }
 
 func writeSkillOptTrainReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, metadata map[string]any) error {

--- a/internal/cli/skillopt_review_launchfailure_test.go
+++ b/internal/cli/skillopt_review_launchfailure_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestIsExecLaunchFailure(t *testing.T) {
+	// A real missing-binary exec surfaces exec.ErrNotFound in its chain.
+	_, realNotFound := exec.Command("gitmoot-nonexistent-binary-xyz-734").Output()
+	if realNotFound == nil {
+		t.Fatal("expected a launch failure exec'ing a missing binary")
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"real exec not found", realNotFound, true},
+		{"fork/exec ARG_MAX", errors.New("fork/exec /usr/bin/gh: argument list too long"), true},
+		{"argument list too long only", errors.New("argument list too long"), true},
+		{"wrapped ErrNotFound", errors.Join(errors.New("gh call failed"), exec.ErrNotFound), true},
+		{"http 422 validation", errors.New("HTTP 422: Validation Failed"), false},
+		{"mid-flight timeout", errors.New("context deadline exceeded"), false},
+		{"killed mid-flight", errors.New("signal: killed"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isExecLaunchFailure(tc.err); got != tc.want {
+				t.Fatalf("isExecLaunchFailure(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDowngradeReviewMarkerOnLaunchFailure asserts the posting_external latch is
+// cleared only when the gh publish never launched, and preserved for every
+// genuinely ambiguous failure.
+func TestDowngradeReviewMarkerOnLaunchFailure(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	session := db.SkillOptTrainSession{ID: "sess-734"}
+	iteration := db.SkillOptTrainIteration{ID: "iter-734"}
+	posting := map[string]any{
+		"status":                   "posting_external",
+		"repo":                     "owner/reviews",
+		"external_post_started_at": "2026-07-08T00:00:00Z",
+	}
+
+	writePosting := func(t *testing.T) {
+		t.Helper()
+		if err := writeSkillOptTrainReviewRecovery(paths, session, iteration, posting); err != nil {
+			t.Fatalf("write posting_external marker: %v", err)
+		}
+	}
+	markerStatus := func(t *testing.T) string {
+		t.Helper()
+		review, ok, err := readSkillOptTrainReviewRecovery(paths, session, iteration)
+		if err != nil {
+			t.Fatalf("read recovery marker: %v", err)
+		}
+		if !ok {
+			return "<absent>"
+		}
+		return metadataString(review, "status")
+	}
+
+	t.Run("exec-launch failure clears the latch and permits a retry", func(t *testing.T) {
+		writePosting(t)
+		launchErr := errors.New("fork/exec /usr/bin/gh: argument list too long")
+		downgradeReviewMarkerOnLaunchFailure(paths, session, iteration, posting, launchErr)
+
+		if got := markerStatus(t); got != "failed_pre_exec" {
+			t.Fatalf("marker status after launch failure = %q, want failed_pre_exec", got)
+		}
+		// recover must now let the next attempt proceed fresh (no false latch).
+		_, ok, err := recoverSkillOptTrainReviewPublication(context.Background(), paths, (*db.Store)(nil), session, iteration)
+		if err != nil {
+			t.Fatalf("recover after downgrade returned error: %v", err)
+		}
+		if ok {
+			t.Fatal("recover latched a failed_pre_exec marker; a retry must be permitted")
+		}
+	})
+
+	t.Run("mid-flight failure preserves the conservative latch", func(t *testing.T) {
+		writePosting(t)
+		midFlightErr := errors.New("context deadline exceeded")
+		downgradeReviewMarkerOnLaunchFailure(paths, session, iteration, posting, midFlightErr)
+
+		if got := markerStatus(t); got != "posting_external" {
+			t.Fatalf("marker status after mid-flight failure = %q, want posting_external", got)
+		}
+		// recover must still latch: the post may have reached GitHub.
+		_, ok, err := recoverSkillOptTrainReviewPublication(context.Background(), paths, (*db.Store)(nil), session, iteration)
+		if err == nil {
+			t.Fatal("recover did not latch posting_external; duplicate-issue guard lost")
+		}
+		if !ok {
+			t.Fatal("recover should report ok=true when latched")
+		}
+	})
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -603,7 +604,14 @@ func (c *GhClient) GetPullRequest(ctx context.Context, repo Repository, number i
 }
 
 func (c *GhClient) CreatePullRequest(ctx context.Context, input CreatePullRequestInput) (PullRequest, error) {
-	args := []string{"pr", "create", "--repo", input.Repo.FullName(), "--title", input.Title, "--body", input.Body, "--head", input.Head, "--base", input.Base}
+	bodyArgs, cleanup, err := bodyFlagArgs(input.Body)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	defer cleanup()
+	args := []string{"pr", "create", "--repo", input.Repo.FullName(), "--title", input.Title}
+	args = append(args, bodyArgs...)
+	args = append(args, "--head", input.Head, "--base", input.Base)
 	if input.Draft {
 		args = append(args, "--draft")
 	}
@@ -756,7 +764,13 @@ func (c *GhClient) ListRepoIssueComments(ctx context.Context, repo Repository, s
 
 func (c *GhClient) PostIssueComment(ctx context.Context, repo Repository, issueNumber int64, body string) (IssueComment, error) {
 	var comment IssueComment
-	err := c.apiJSON(ctx, true, &comment, endpoint(repo, "issues", issueNumber, "comments"), "-f", "body="+body)
+	bodyArgs, cleanup, err := apiBodyFieldArgs(body)
+	if err != nil {
+		return IssueComment{}, err
+	}
+	defer cleanup()
+	args := append([]string{endpoint(repo, "issues", issueNumber, "comments")}, bodyArgs...)
+	err = c.apiJSON(ctx, true, &comment, args...)
 	return comment, err
 }
 
@@ -778,10 +792,14 @@ func (c *GhClient) SearchOpenIssues(ctx context.Context, repo Repository, text s
 
 func (c *GhClient) CreateIssue(ctx context.Context, input CreateIssueInput) (Issue, error) {
 	var issue Issue
-	err := c.apiJSON(ctx, true, &issue,
-		endpoint(input.Repo, "issues"),
-		"-f", "title="+input.Title,
-		"-f", "body="+input.Body)
+	bodyArgs, cleanup, err := apiBodyFieldArgs(input.Body)
+	if err != nil {
+		return Issue{}, err
+	}
+	defer cleanup()
+	args := []string{endpoint(input.Repo, "issues"), "-f", "title=" + input.Title}
+	args = append(args, bodyArgs...)
+	err = c.apiJSON(ctx, true, &issue, args...)
 	if err != nil {
 		return Issue{}, err
 	}
@@ -880,7 +898,12 @@ func (c *GhClient) MergePullRequest(ctx context.Context, input MergePullRequestI
 		args = append(args, "--subject", input.Subject)
 	}
 	if input.Body != "" {
-		args = append(args, "--body", input.Body)
+		bodyArgs, cleanup, err := bodyFlagArgs(input.Body)
+		if err != nil {
+			return MergeResult{}, err
+		}
+		defer cleanup()
+		args = append(args, bodyArgs...)
 	}
 	if input.MatchHeadCommit != "" {
 		args = append(args, "--match-head-commit", input.MatchHeadCommit)
@@ -1290,6 +1313,74 @@ func commandError(result subprocess.Result, err error) error {
 		return err
 	}
 	return fmt.Errorf("%s: %w", detail, err)
+}
+
+// bodyFileThreshold is the byte size above which a GitHub body (issue/PR/comment)
+// is handed to gh via a temp file instead of a single argv argument. The OS caps
+// a single argv element (and the whole argv+env block) at roughly 128KB
+// (MAX_ARG_STRLEN); passing a larger body inline makes fork/exec fail with
+// "argument list too long" before gh ever runs (#734). 100KB leaves headroom for
+// the surrounding flags while staying byte-identical to the old inline behavior
+// for every ordinary body.
+const bodyFileThreshold = 100 * 1024
+
+// writeGhBodyTempFile writes body to a fresh temp file and returns its path plus
+// a cleanup func that removes it. The caller MUST defer cleanup so the file is
+// removed after the gh invocation (including all internal retries) completes.
+func writeGhBodyTempFile(body string) (string, func(), error) {
+	f, err := os.CreateTemp("", "gitmoot-gh-body-*.md")
+	if err != nil {
+		return "", func() {}, err
+	}
+	name := f.Name()
+	cleanup := func() { _ = os.Remove(name) }
+	if _, err := f.WriteString(body); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", func() {}, err
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return name, cleanup, nil
+}
+
+// bodyFlagArgs returns the gh arguments that supply body to a gh verb that
+// accepts `--body`/`--body-file` (e.g. `gh pr create`, `gh pr merge`). A body at
+// or below bodyFileThreshold is passed inline as `--body <body>` — byte-identical
+// to the historical behavior — while a larger one is written to a temp file and
+// passed as `--body-file <path>` to stay under ARG_MAX (#734). The returned
+// cleanup removes any temp file and must be deferred by the caller.
+func bodyFlagArgs(body string) (args []string, cleanup func(), err error) {
+	if len(body) <= bodyFileThreshold {
+		return []string{"--body", body}, func() {}, nil
+	}
+	path, cleanup, err := writeGhBodyTempFile(body)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return []string{"--body-file", path}, cleanup, nil
+}
+
+// apiBodyFieldArgs returns the `gh api` field arguments that supply the "body"
+// parameter. A body at or below bodyFileThreshold is passed inline as
+// `-f body=<body>` — byte-identical to the historical behavior — while a larger
+// one is written to a temp file and passed as `-F body=@<path>`, which tells
+// `gh api` to read the field value from that file instead of taking it as a
+// single argv argument that would blow ARG_MAX (#734). gh's `-F/--field` `@file`
+// magic reads the file content verbatim as the string value; the file-read path
+// bypasses the true/false/number type coercion, so a body is never re-typed. The
+// returned cleanup removes any temp file and must be deferred by the caller.
+func apiBodyFieldArgs(body string) (args []string, cleanup func(), err error) {
+	if len(body) <= bodyFileThreshold {
+		return []string{"-f", "body=" + body}, func() {}, nil
+	}
+	path, cleanup, err := writeGhBodyTempFile(body)
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return []string{"-F", "body=@" + path}, cleanup, nil
 }
 
 func isRateLimit(result subprocess.Result) bool {

--- a/internal/github/client_bodyfile_test.go
+++ b/internal/github/client_bodyfile_test.go
@@ -1,0 +1,332 @@
+package github
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+// bodyCapturingRunner records every gh argv and, for a call that references a
+// body temp file (`--body-file <path>` or a `body=@<path>` field), reads the
+// file's content DURING the run — before the caller's deferred cleanup removes
+// it — so a test can assert the content is byte-identical to the intended body.
+type bodyCapturingRunner struct {
+	results  []subprocess.Result
+	calls    [][]string
+	bodyPath []string // temp-file path referenced by each call, or "" for inline
+	bodyRead []string // file content read during each call, or "" for inline
+}
+
+func (r *bodyCapturingRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	r.calls = append(r.calls, append([]string{command}, args...))
+	idx := len(r.calls) - 1
+
+	path := bodyFilePathFromArgs(args)
+	r.bodyPath = append(r.bodyPath, path)
+	content := ""
+	if path != "" {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return subprocess.Result{}, err
+		}
+		content = string(b)
+	}
+	r.bodyRead = append(r.bodyRead, content)
+
+	var result subprocess.Result
+	if idx < len(r.results) {
+		result = r.results[idx]
+	}
+	result.Command = command
+	result.Args = args
+	return result, nil
+}
+
+func (r *bodyCapturingRunner) LookPath(string) (string, error) { return "/usr/bin/gh", nil }
+
+// bodyFilePathFromArgs extracts the temp-file path a call routed the body
+// through, whether via the gh-verb `--body-file <path>` flag or the `gh api`
+// `-F body=@<path>` field.
+func bodyFilePathFromArgs(args []string) string {
+	for i, a := range args {
+		if a == "--body-file" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "body=@") {
+			return strings.TrimPrefix(a, "body=@")
+		}
+	}
+	return ""
+}
+
+func hasArgPair(args []string, flag, val string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == val {
+			return true
+		}
+	}
+	return false
+}
+
+func hasArg(args []string, val string) bool {
+	for _, a := range args {
+		if a == val {
+			return true
+		}
+	}
+	return false
+}
+
+func largeBody() string {
+	return strings.Repeat("A", bodyFileThreshold) + "\n-tail-marker-\n"
+}
+
+// TestBodyFlagArgsBoundary pins the `--body`/`--body-file` verb helper: inline at
+// the threshold, temp-file above it, content byte-identical, file removed on
+// cleanup.
+func TestBodyFlagArgsBoundary(t *testing.T) {
+	t.Run("at threshold stays inline", func(t *testing.T) {
+		body := strings.Repeat("x", bodyFileThreshold)
+		args, cleanup, err := bodyFlagArgs(body)
+		if err != nil {
+			t.Fatalf("bodyFlagArgs: %v", err)
+		}
+		defer cleanup()
+		want := []string{"--body", body}
+		if len(args) != 2 || args[0] != want[0] || args[1] != want[1] {
+			t.Fatalf("args[0]=%q len=%d; want inline --body", args[0], len(args))
+		}
+	})
+
+	t.Run("above threshold routes through a temp file", func(t *testing.T) {
+		body := strings.Repeat("x", bodyFileThreshold+1)
+		args, cleanup, err := bodyFlagArgs(body)
+		if err != nil {
+			t.Fatalf("bodyFlagArgs: %v", err)
+		}
+		if len(args) != 2 || args[0] != "--body-file" {
+			t.Fatalf("args=%v; want --body-file <path>", args)
+		}
+		path := args[1]
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read temp body file: %v", err)
+		}
+		if string(got) != body {
+			t.Fatalf("temp file content mismatch: got %d bytes, want %d bytes", len(got), len(body))
+		}
+		cleanup()
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("temp file not cleaned up: stat err=%v", err)
+		}
+	})
+}
+
+// TestAPIBodyFieldArgsBoundary pins the `gh api` field helper: inline `-f body=`
+// at the threshold, `-F body=@<file>` above it, content byte-identical, cleanup.
+func TestAPIBodyFieldArgsBoundary(t *testing.T) {
+	t.Run("at threshold stays inline -f", func(t *testing.T) {
+		body := strings.Repeat("y", bodyFileThreshold)
+		args, cleanup, err := apiBodyFieldArgs(body)
+		if err != nil {
+			t.Fatalf("apiBodyFieldArgs: %v", err)
+		}
+		defer cleanup()
+		if len(args) != 2 || args[0] != "-f" || args[1] != "body="+body {
+			t.Fatalf("args[0]=%q len=%d; want inline -f body=", args[0], len(args))
+		}
+	})
+
+	t.Run("above threshold routes through -F @file", func(t *testing.T) {
+		body := strings.Repeat("y", bodyFileThreshold+1)
+		args, cleanup, err := apiBodyFieldArgs(body)
+		if err != nil {
+			t.Fatalf("apiBodyFieldArgs: %v", err)
+		}
+		if len(args) != 2 || args[0] != "-F" || !strings.HasPrefix(args[1], "body=@") {
+			t.Fatalf("args=%v; want -F body=@<path>", args)
+		}
+		path := strings.TrimPrefix(args[1], "body=@")
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read temp body file: %v", err)
+		}
+		if string(got) != body {
+			t.Fatalf("temp file content mismatch: got %d bytes, want %d bytes", len(got), len(body))
+		}
+		cleanup()
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("temp file not cleaned up: stat err=%v", err)
+		}
+	})
+}
+
+func TestCreateIssueBodyRouting(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+	ctx := context.Background()
+
+	t.Run("small body stays inline -f", func(t *testing.T) {
+		runner := &bodyCapturingRunner{results: []subprocess.Result{{Stdout: `{"number":7}`}}}
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.CreateIssue(ctx, CreateIssueInput{Repo: repo, Title: "t", Body: "small"}); err != nil {
+			t.Fatalf("CreateIssue: %v", err)
+		}
+		call := runner.calls[0]
+		if !hasArgPair(call, "-f", "body=small") {
+			t.Fatalf("want inline -f body=small; got %v", call)
+		}
+		if hasArg(call, "--body-file") || hasArg(call, "-F") {
+			t.Fatalf("small body should not use a file; got %v", call)
+		}
+	})
+
+	t.Run("large body routes through -F @file and cleans up", func(t *testing.T) {
+		body := largeBody()
+		runner := &bodyCapturingRunner{results: []subprocess.Result{{Stdout: `{"number":7}`}}}
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.CreateIssue(ctx, CreateIssueInput{Repo: repo, Title: "t", Body: body}); err != nil {
+			t.Fatalf("CreateIssue: %v", err)
+		}
+		call := runner.calls[0]
+		path := runner.bodyPath[0]
+		if path == "" || !hasArgPair(call, "-F", "body=@"+path) {
+			t.Fatalf("want -F body=@<path>; got %v", call)
+		}
+		if hasArg(call, "-f") && strings.Contains(strings.Join(call, " "), "body=A") {
+			t.Fatalf("large body must not be an inline -f arg; got %v", call)
+		}
+		if runner.bodyRead[0] != body {
+			t.Fatalf("temp file content not byte-identical to body")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("temp file not cleaned up after CreateIssue: %v", err)
+		}
+	})
+}
+
+func TestPostIssueCommentBodyRouting(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+	ctx := context.Background()
+
+	t.Run("small body stays inline -f", func(t *testing.T) {
+		runner := &bodyCapturingRunner{results: []subprocess.Result{{Stdout: `{"id":3}`}}}
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.PostIssueComment(ctx, repo, 5, "small"); err != nil {
+			t.Fatalf("PostIssueComment: %v", err)
+		}
+		if !hasArgPair(runner.calls[0], "-f", "body=small") {
+			t.Fatalf("want inline -f body=small; got %v", runner.calls[0])
+		}
+	})
+
+	t.Run("large body routes through -F @file and cleans up", func(t *testing.T) {
+		body := largeBody()
+		runner := &bodyCapturingRunner{results: []subprocess.Result{{Stdout: `{"id":3}`}}}
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.PostIssueComment(ctx, repo, 5, body); err != nil {
+			t.Fatalf("PostIssueComment: %v", err)
+		}
+		path := runner.bodyPath[0]
+		if path == "" || !hasArgPair(runner.calls[0], "-F", "body=@"+path) {
+			t.Fatalf("want -F body=@<path>; got %v", runner.calls[0])
+		}
+		if runner.bodyRead[0] != body {
+			t.Fatalf("temp file content not byte-identical to body")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("temp file not cleaned up after PostIssueComment: %v", err)
+		}
+	})
+}
+
+func TestCreatePullRequestBodyRouting(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+	ctx := context.Background()
+	// call 0: pr create -> URL on stdout; call 1: getPullRequest -> PR JSON.
+	makeRunner := func() *bodyCapturingRunner {
+		return &bodyCapturingRunner{results: []subprocess.Result{
+			{Stdout: "https://github.com/o/r/pull/12\n"},
+			{Stdout: `{"number":12,"html_url":"https://github.com/o/r/pull/12"}`},
+		}}
+	}
+
+	t.Run("small body stays inline --body", func(t *testing.T) {
+		runner := makeRunner()
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.CreatePullRequest(ctx, CreatePullRequestInput{Repo: repo, Title: "t", Body: "small", Head: "h", Base: "main"}); err != nil {
+			t.Fatalf("CreatePullRequest: %v", err)
+		}
+		if !hasArgPair(runner.calls[0], "--body", "small") {
+			t.Fatalf("want inline --body small; got %v", runner.calls[0])
+		}
+		if hasArg(runner.calls[0], "--body-file") {
+			t.Fatalf("small body should not use --body-file; got %v", runner.calls[0])
+		}
+	})
+
+	t.Run("large body routes through --body-file and cleans up", func(t *testing.T) {
+		body := largeBody()
+		runner := makeRunner()
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.CreatePullRequest(ctx, CreatePullRequestInput{Repo: repo, Title: "t", Body: body, Head: "h", Base: "main"}); err != nil {
+			t.Fatalf("CreatePullRequest: %v", err)
+		}
+		path := runner.bodyPath[0]
+		if path == "" || !hasArgPair(runner.calls[0], "--body-file", path) {
+			t.Fatalf("want --body-file <path>; got %v", runner.calls[0])
+		}
+		if hasArg(runner.calls[0], "--body") {
+			t.Fatalf("large body must not also pass inline --body; got %v", runner.calls[0])
+		}
+		if runner.bodyRead[0] != body {
+			t.Fatalf("temp file content not byte-identical to body")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("temp file not cleaned up after CreatePullRequest: %v", err)
+		}
+	})
+}
+
+func TestMergePullRequestBodyRouting(t *testing.T) {
+	repo := Repository{Owner: "o", Name: "r"}
+	ctx := context.Background()
+	makeRunner := func() *bodyCapturingRunner {
+		return &bodyCapturingRunner{results: []subprocess.Result{
+			{},
+			{Stdout: `{"number":5,"merged":true,"state":"merged"}`},
+		}}
+	}
+
+	t.Run("small body stays inline --body", func(t *testing.T) {
+		runner := makeRunner()
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.MergePullRequest(ctx, MergePullRequestInput{Repo: repo, Number: 5, Method: "squash", Body: "small"}); err != nil {
+			t.Fatalf("MergePullRequest: %v", err)
+		}
+		if !hasArgPair(runner.calls[0], "--body", "small") {
+			t.Fatalf("want inline --body small; got %v", runner.calls[0])
+		}
+	})
+
+	t.Run("large body routes through --body-file and cleans up", func(t *testing.T) {
+		body := largeBody()
+		runner := makeRunner()
+		client := GhClient{Runner: runner, MaxRetries: 0}
+		if _, err := client.MergePullRequest(ctx, MergePullRequestInput{Repo: repo, Number: 5, Method: "squash", Body: body}); err != nil {
+			t.Fatalf("MergePullRequest: %v", err)
+		}
+		path := runner.bodyPath[0]
+		if path == "" || !hasArgPair(runner.calls[0], "--body-file", path) {
+			t.Fatalf("want --body-file <path>; got %v", runner.calls[0])
+		}
+		if runner.bodyRead[0] != body {
+			t.Fatalf("temp file content not byte-identical to body")
+		}
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("temp file not cleaned up after MergePullRequest: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Trace

`skillopt train continue` at the publish-review-packet step failed with `fork/exec /usr/bin/gh: argument list too long` (#734, third of the ARG_MAX family after #723/#724). The session's synth-generated review items carry full context + rubric each, so the composed GitHub issue body exceeds the per-argument / total argv+env limit (`MAX_ARG_STRLEN` ≈ 128KB). Every body-passing `GhClient` method handed the body to gh as a **single argv argument**, so the kernel rejected the exec before gh ran:

- `CreatePullRequest` → `gh pr create --body <body>`
- `MergePullRequest` → `gh pr merge --body <body>`
- `CreateIssue` → `gh api … -f body=<body>`  ← the #734 failing call
- `PostIssueComment` → `gh api … -f body=<body>`

Note the two publish-critical paths use `gh api -f body=` (not `--body`); the `-f body=<huge>` field is still one argv element, so it blows ARG_MAX identically. Fixing only the `--body` verbs would have left #734 open, so all four sites are converted.

## Fix (at the client, so every consumer is covered)

A size-aware helper in `GhClient` chooses inline vs temp-file per call:

- **≤ 100KB**: byte-identical to before — `--body <body>` for verbs, `-f body=<body>` for `gh api`.
- **> 100KB**: body written to `os.CreateTemp` and passed as:
  - `--body-file <path>` for `gh pr create` / `gh pr merge`, or
  - `-F body=@<path>` for `gh api` (issue create / issue comment) — gh's `-F/--field` `@file` magic reads the field value from the file verbatim (bypassing true/false/number coercion), so the huge body never becomes an argv arg.
  - The temp file is removed via `defer cleanup()` after the run (including gh's internal retries) completes.

100KB leaves headroom under the ~128KB limit for the surrounding flags.

Audited: no gh body is constructed outside `internal/github/client.go`; all consumers (skillopt publish, feedback, daemon) route through these four methods. No other `gh api -F/--field body=` huge-value site exists to note.

## Secondary (same PR)

`publishSkillOptTrainReview` writes the `posting_external` recovery marker **before** the gh exec, and `recoverSkillOptTrainReviewPublication` reads it as "the external post may have happened; inspect the repo before retrying" — latching the session. But a `fork/exec` failure means the process never started, so nothing was posted. When `CreateIssue` returns an exec-launch failure (`errors.Is(err, exec.ErrNotFound)`, or the error string contains `fork/exec` / `argument list too long`), the marker is downgraded to `failed_pre_exec` so a retry proceeds fresh. Every other error class (timeouts, killed mid-flight — genuinely ambiguous) keeps the conservative latch.

## Tests (deterministic, no network)

`internal/github/client_bodyfile_test.go`:
- Fake runner captures argv and reads the referenced temp file **during** the run.
- Small body → `--body` / `-f body=` unchanged; > 100KB → `--body-file` / `-F body=@file`, temp-file content byte-identical to the body, file cleaned up after the call.
- Threshold boundary (exactly 100KB inline; +1 → file) on both helpers.
- Issue + PR create + PR merge + issue comment sites all covered.

`internal/cli/skillopt_review_launchfailure_test.go`:
- `isExecLaunchFailure`: real missing-binary exec, `fork/exec` / `argument list too long`, wrapped `ErrNotFound` → true; HTTP 422 / timeout / killed / nil → false.
- Exec-launch error → marker becomes `failed_pre_exec` and `recoverSkillOptTrainReviewPublication` permits a retry (`ok=false`).
- Mid-flight error → marker stays `posting_external` and recover still latches (`ok=true`, err).

## Gate

`go build ./...`, `go vet ./...` clean. `go test -count=1 ./internal/github/ ./internal/cli/` pass (cli ran fully, 221.9s). `go test -race -count=1 ./internal/github/` passes.

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)