### PR TITLE
feat(chat): daemon-relay so sandboxed moot seats can converse (#732)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -59,6 +59,11 @@ type localAgentDispatchRequest struct {
 	// empty for every other dispatch, so the enqueued payload is byte-identical.
 	ThreadID      string
 	ChatMessageID string
+	// MootSeat marks a `gitmoot moot` conversing seat (#732). Set ONLY by the moot
+	// dispatch — never by `chat task` or any other chat-linked dispatch — so only a
+	// real seat is elevated + relay-injected by the daemon. Additive: false leaves
+	// the enqueued payload byte-identical.
+	MootSeat bool
 	// JSONOutput is true when the caller will emit machine-readable JSON (e.g.
 	// `agent ask --json`). The live-A/B interceptor (#482) MUST stay byte-clean for
 	// these consumers: it never presents the A/B block (which would prepend
@@ -202,6 +207,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		TemplateOverride:       recipeTemplate,
 		ThreadID:               request.ThreadID,
 		ChatMessageID:          request.ChatMessageID,
+		MootSeat:               request.MootSeat,
 	})
 	if err != nil {
 		return localAgentJobOutput{}, err

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -341,81 +342,46 @@ func runChatSend(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 
-	authorKind := db.ChatAuthorKindHuman
-	authorName := "human"
-	if a := strings.TrimSpace(*as); a != "" {
-		authorKind = db.ChatAuthorKindAgent
-		authorName = a
+	params := chatSendParams{
+		Ref:  ref,
+		Repo: strings.TrimSpace(*repo),
+		As:   strings.TrimSpace(*as),
+		Body: body,
+		Refs: refs,
 	}
 
-	var out chatMessageOutput
-	if err := withStore(*home, func(store *db.Store) error {
+	var (
+		out      chatMessageOutput
+		warnings []string
+	)
+	// Relay branch (#732): inside a sandboxed agent (moot seat) the gitmoot home is
+	// read-only, so a direct store write fails. When GITMOOT_CHAT_RELAY is set the
+	// daemon injected a socket path + auth token, so route the send over the socket
+	// and let the (unsandboxed) daemon perform the DB write. A human/CLI without the
+	// env set takes the byte-identical direct path below.
+	if sock := os.Getenv(chatRelayEnvSocket); sock != "" {
+		msg, w, err := chatRelaySendClient(sock, os.Getenv(chatRelayEnvToken), params)
+		if err != nil {
+			fmt.Fprintf(stderr, "chat send: %v\n", err)
+			return 1
+		}
+		out = msg
+		warnings = w
+	} else if err := withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
-		thread, err := resolveChatThread(ctx, store, ref, strings.TrimSpace(*repo))
+		msg, w, err := chatSendViaStore(ctx, store, params)
 		if err != nil {
 			return err
 		}
-		if thread.State == db.ChatThreadStateArchived {
-			return fmt.Errorf("thread %q is archived; reopen it before sending", thread.Slug)
-		}
-		if authorKind == db.ChatAuthorKindAgent {
-			if _, err := store.GetAgent(ctx, authorName); err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
-					return fmt.Errorf("agent %q not found (use a registered agent for --as)", authorName)
-				}
-				return err
-			}
-			// Moot cap HARD-STOP (#534 V1.5): once a moot thread has reached its
-			// agent-message cap, refuse further agent-authored turns and post ONE
-			// idempotent visible overrun message. Human sends and the seats' final
-			// job_result conclusions are never blocked by this gate.
-			if err := enforceMootSendCap(ctx, store, thread); err != nil {
-				return err
-			}
-		}
-		mentions := mention.Parse(body)
-		msg, err := store.AddChatMessage(ctx, db.ChatMessage{
-			ThreadID:   thread.ID,
-			AuthorKind: authorKind,
-			AuthorName: authorName,
-			Kind:       db.ChatKindChat,
-			Body:       body,
-			Mentions:   mentions,
-			Refs:       refsToChatRefs(refs, thread.Repo),
-		})
-		if err != nil {
-			return err
-		}
-		// Resolve each mention against the registry: known -> unread inbox row;
-		// unknown -> recorded resolved=0 for audit + a stderr warning. A bad
-		// mention NEVER fails the send.
-		mentionRows := make([]db.ChatMention, 0, len(mentions))
-		for _, name := range mentions {
-			known := true
-			if _, err := store.GetAgent(ctx, name); err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
-					known = false
-					fmt.Fprintf(stderr, "warning: @%s is not a registered agent; mention recorded but not delivered\n", name)
-				} else {
-					return err
-				}
-			}
-			mentionRows = append(mentionRows, db.ChatMention{
-				MessageID: msg.ID,
-				ThreadID:  thread.ID,
-				Agent:     name,
-				Resolved:  known,
-				Unread:    true,
-			})
-		}
-		if err := store.AddChatMentions(ctx, mentionRows); err != nil {
-			return err
-		}
-		out = chatMessageFromDB(msg)
+		out = msg
+		warnings = w
 		return nil
 	}); err != nil {
 		fmt.Fprintf(stderr, "chat send: %v\n", err)
 		return 1
+	}
+	for _, w := range warnings {
+		fmt.Fprintln(stderr, w)
 	}
 	if *jsonOut {
 		_ = writeJSON(stdout, out)
@@ -520,7 +486,29 @@ func runChatWait(args []string, stdout, stderr io.Writer) int {
 		lastSeq    = *sinceSeq
 		capReached bool
 	)
-	if err := withStore(*home, func(store *db.Store) error {
+	// Relay branch (#732): a sandboxed seat's home is read-only, but even READS go
+	// through the daemon here for uniformity — the daemon injected GITMOOT_CHAT_RELAY.
+	// The daemon handler returns ONE snapshot per call; the poll/deadline loop lives
+	// client-side so the visible behavior + output are byte-identical to the direct
+	// path. A human/CLI without the env set takes the direct store path below.
+	if sock := os.Getenv(chatRelayEnvSocket); sock != "" {
+		token := os.Getenv(chatRelayEnvToken)
+		deadline := time.Now().Add(*timeout)
+		for {
+			snap, err := chatRelayWaitClient(sock, token, ref, strings.TrimSpace(*repo), *sinceSeq)
+			if err != nil {
+				fmt.Fprintf(stderr, "chat wait: %v\n", err)
+				return 1
+			}
+			newMsgs = snap.Messages
+			lastSeq = snap.LastSeq
+			capReached = snap.CapReached
+			if len(newMsgs) > 0 || capReached || !time.Now().Before(deadline) {
+				break
+			}
+			time.Sleep(chatWaitPollInterval)
+		}
+	} else if err := withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
 		thread, err := resolveChatThread(ctx, store, ref, strings.TrimSpace(*repo))
 		if err != nil {
@@ -528,34 +516,13 @@ func runChatWait(args []string, stdout, stderr io.Writer) int {
 		}
 		deadline := time.Now().Add(*timeout)
 		for {
-			msgs, err := store.ListChatMessages(ctx, thread.ID, 0)
+			snap, err := chatWaitSnapshot(ctx, store, thread, *sinceSeq)
 			if err != nil {
 				return err
 			}
-			newMsgs = newMsgs[:0]
-			lastSeq = *sinceSeq
-			for _, m := range msgs {
-				if m.Seq > lastSeq {
-					lastSeq = m.Seq
-				}
-				if m.Seq > *sinceSeq {
-					newMsgs = append(newMsgs, chatMessageFromDB(m))
-				}
-			}
-			// Moot cap signalling is independent of new messages: a capped moot with
-			// no fresh turn still tells the seat to wrap up.
-			isMoot, messageCap, err := store.ChatThreadMoot(ctx, thread.ID)
-			if err != nil {
-				return err
-			}
-			capReached = false
-			if isMoot && messageCap > 0 {
-				count, err := store.CountChatMootMessages(ctx, thread.ID)
-				if err != nil {
-					return err
-				}
-				capReached = count >= messageCap
-			}
+			newMsgs = snap.Messages
+			lastSeq = snap.LastSeq
+			capReached = snap.CapReached
 			if len(newMsgs) > 0 || capReached || !time.Now().Before(deadline) {
 				return nil
 			}
@@ -1059,6 +1026,138 @@ func chatMessageFromDB(m db.ChatMessage) chatMessageOutput {
 		AuthorOrigin: m.AuthorOrigin, Kind: m.Kind, Body: m.Body, Mentions: m.Mentions,
 		Refs: m.Refs, ReplyTo: m.ReplyTo, PromotedJobID: m.PromotedJobID,
 	}
+}
+
+// chatSendParams is the resolved input to a `chat send`, shared by the direct CLI
+// path and the #732 daemon relay handler so both run the SAME validated store
+// closure (archived refusal, --as registration, moot cap hard-stop, mentions).
+type chatSendParams struct {
+	Ref  string // thread id or slug
+	Repo string // optional repo scope to disambiguate a slug
+	As   string // author as this registered agent; "" => human
+	Body string
+	Refs chatRefFlags
+}
+
+// chatSendViaStore is the EXACT `chat send` store transaction (#732 extraction):
+// resolve the thread, refuse an archived thread, validate an --as agent + enforce
+// the moot cap, append the message, then resolve mentions (unknown -> a returned
+// warning string, never a failure). It returns the created message plus any
+// non-fatal mention warnings so the caller prints them to stderr. Both the direct
+// CLI path (runChatSend) and the relay handler call it, so the gate is single-sourced.
+func chatSendViaStore(ctx context.Context, store *db.Store, p chatSendParams) (chatMessageOutput, []string, error) {
+	thread, err := resolveChatThread(ctx, store, p.Ref, strings.TrimSpace(p.Repo))
+	if err != nil {
+		return chatMessageOutput{}, nil, err
+	}
+	if thread.State == db.ChatThreadStateArchived {
+		return chatMessageOutput{}, nil, fmt.Errorf("thread %q is archived; reopen it before sending", thread.Slug)
+	}
+	authorKind := db.ChatAuthorKindHuman
+	authorName := "human"
+	if a := strings.TrimSpace(p.As); a != "" {
+		authorKind = db.ChatAuthorKindAgent
+		authorName = a
+	}
+	if authorKind == db.ChatAuthorKindAgent {
+		if _, err := store.GetAgent(ctx, authorName); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return chatMessageOutput{}, nil, fmt.Errorf("agent %q not found (use a registered agent for --as)", authorName)
+			}
+			return chatMessageOutput{}, nil, err
+		}
+		// Moot cap HARD-STOP (#534 V1.5): once a moot thread has reached its
+		// agent-message cap, refuse further agent-authored turns and post ONE
+		// idempotent visible overrun message. Human sends and the seats' final
+		// job_result conclusions are never blocked by this gate.
+		if err := enforceMootSendCap(ctx, store, thread); err != nil {
+			return chatMessageOutput{}, nil, err
+		}
+	}
+	mentions := mention.Parse(p.Body)
+	msg, err := store.AddChatMessage(ctx, db.ChatMessage{
+		ThreadID:   thread.ID,
+		AuthorKind: authorKind,
+		AuthorName: authorName,
+		Kind:       db.ChatKindChat,
+		Body:       p.Body,
+		Mentions:   mentions,
+		Refs:       refsToChatRefs(p.Refs, thread.Repo),
+	})
+	if err != nil {
+		return chatMessageOutput{}, nil, err
+	}
+	// Resolve each mention against the registry: known -> unread inbox row;
+	// unknown -> recorded resolved=0 for audit + a returned warning. A bad
+	// mention NEVER fails the send.
+	var warnings []string
+	mentionRows := make([]db.ChatMention, 0, len(mentions))
+	for _, name := range mentions {
+		known := true
+		if _, err := store.GetAgent(ctx, name); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				known = false
+				warnings = append(warnings, fmt.Sprintf("warning: @%s is not a registered agent; mention recorded but not delivered", name))
+			} else {
+				return chatMessageOutput{}, nil, err
+			}
+		}
+		mentionRows = append(mentionRows, db.ChatMention{
+			MessageID: msg.ID,
+			ThreadID:  thread.ID,
+			Agent:     name,
+			Resolved:  known,
+			Unread:    true,
+		})
+	}
+	if err := store.AddChatMentions(ctx, mentionRows); err != nil {
+		return chatMessageOutput{}, nil, err
+	}
+	return chatMessageFromDB(msg), warnings, nil
+}
+
+// chatWaitResult is one `chat wait` snapshot: the messages with seq > since, the
+// highest seq seen, and whether the moot cap is reached. It is shared by the
+// direct poll loop and the #732 relay (the daemon returns one snapshot per call;
+// the client loops).
+type chatWaitResult struct {
+	Messages   []chatMessageOutput `json:"messages"`
+	LastSeq    int64               `json:"last_seq"`
+	CapReached bool                `json:"cap_reached"`
+}
+
+// chatWaitSnapshot is one non-blocking `chat wait` poll against the store: it
+// returns the new messages (seq > sinceSeq), the max seq, and the moot cap state.
+// The blocking poll loop that repeats it until a new message / cap / deadline
+// lives in the caller (byte-identical for direct + relay).
+func chatWaitSnapshot(ctx context.Context, store *db.Store, thread db.ChatThread, sinceSeq int64) (chatWaitResult, error) {
+	msgs, err := store.ListChatMessages(ctx, thread.ID, 0)
+	if err != nil {
+		return chatWaitResult{}, err
+	}
+	res := chatWaitResult{LastSeq: sinceSeq}
+	for _, m := range msgs {
+		if m.Seq > res.LastSeq {
+			res.LastSeq = m.Seq
+		}
+		if m.Seq > sinceSeq {
+			res.Messages = append(res.Messages, chatMessageFromDB(m))
+		}
+	}
+	// Moot cap signalling is independent of new messages: a capped moot with
+	// no fresh turn still tells the seat to wrap up.
+	isMoot, messageCap, err := store.ChatThreadMoot(ctx, thread.ID)
+	if err != nil {
+		return chatWaitResult{}, err
+	}
+	if isMoot && messageCap > 0 {
+		count, err := store.CountChatMootMessages(ctx, thread.ID)
+		if err != nil {
+			return chatWaitResult{}, err
+		}
+		res.CapReached = count >= messageCap
+	}
+	return res, nil
 }
 
 // resolveChatThread turns a user-supplied <thread> (a thread id OR a slug) into a

--- a/internal/cli/chat_moot.go
+++ b/internal/cli/chat_moot.go
@@ -255,6 +255,10 @@ func runMoot(args []string, stdout, stderr io.Writer) int {
 				Home:          *home,
 				ThreadID:      thread.ID,
 				ChatMessageID: announce.ID,
+				// The ONLY dispatch that flags a conversing seat (#732): the daemon
+				// relay-injects + elevates strictly on this, never on ThreadID (which
+				// chat-task promotions + continuations also carry).
+				MootSeat: true,
 			})
 			if derr != nil {
 				out.Seats = append(out.Seats, mootSeatOutput{Agent: a, Error: derr.Error()})

--- a/internal/cli/chat_relay.go
+++ b/internal/cli/chat_relay.go
@@ -1,0 +1,411 @@
+package cli
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// #732 daemon chat relay. A `gitmoot moot` seat runs inside the codex/claude
+// runtime sandbox, which makes the gitmoot home (and its SQLite store) read-only,
+// so the seat's `gitmoot chat send` cannot write. This package routes chat
+// send/wait from a sandboxed seat to the DAEMON — which owns the store and runs
+// unsandboxed — over a local unix socket. The daemon performs the actual DB
+// write/read and returns the result. Mirrors entmoot's control-socket relay but
+// trimmed: a length-prefixed JSON frame ([4-byte big-endian length][JSON]), one
+// request → one response → close.
+//
+// The empirical probe (see the #732 design) established that a codex read-only
+// sandbox blocks the connect() syscall itself, so a moot codex seat must be
+// dispatched workspace-write + network_access=true to reach the socket at all;
+// the gitmoot home stays read-only, so the relay is what performs the write.
+
+const (
+	// chatRelayEnvSocket names the env var the daemon injects into a moot seat's
+	// runtime subprocess: the absolute path of the relay unix socket. `chat send`
+	// / `chat wait` relay iff it is set; a human/CLI never has it set, so their
+	// path is byte-identical to pre-#732.
+	chatRelayEnvSocket = "GITMOOT_CHAT_RELAY"
+	// chatRelayEnvToken names the env var carrying the per-seat auth token the
+	// daemon minted for this seat. Named "*_RELAY" (not "*_TOKEN"/"*_SECRET"/
+	// "*_KEY") so a runtime's env-scrubbing policy (codex shell_environment_policy)
+	// does not strip it — the probe showed codex forwards it, but the defensive
+	// name keeps it robust across configs.
+	chatRelayEnvToken = "GITMOOT_CHAT_RELAY_AUTH"
+)
+
+// chatRelayMaxFrame bounds a single frame so a malformed length prefix can never
+// make the daemon allocate unboundedly. Chat bodies are small; 8 MiB is ample.
+const chatRelayMaxFrame = 8 << 20
+
+// chatRelayDialTimeout bounds a single client relay round-trip. `chat wait` loops
+// these snapshots client-side, so each call is a quick, non-blocking op.
+const chatRelayDialTimeout = 30 * time.Second
+
+// chatRelayRequest is one relay operation. `op` is "send" or "wait"; the daemon
+// carries no request `type` byte (unlike entmoot) — op lives in the JSON.
+type chatRelayRequest struct {
+	Op       string       `json:"op"`
+	Token    string       `json:"token"`
+	Thread   string       `json:"thread"`
+	Repo     string       `json:"repo,omitempty"`
+	As       string       `json:"as,omitempty"`
+	Body     string       `json:"body,omitempty"`
+	Refs     chatRefFlags `json:"refs,omitempty"`
+	SinceSeq int64        `json:"since_seq,omitempty"`
+}
+
+// chatRelayResponse is the daemon's reply. OK=false carries a human Error the
+// client surfaces verbatim (so a gate rejection reads the same as a direct one).
+type chatRelayResponse struct {
+	OK         bool                `json:"ok"`
+	Error      string              `json:"error,omitempty"`
+	Message    *chatMessageOutput  `json:"message,omitempty"`
+	Messages   []chatMessageOutput `json:"messages,omitempty"`
+	LastSeq    int64               `json:"last_seq,omitempty"`
+	CapReached bool                `json:"cap_reached,omitempty"`
+	Warnings   []string            `json:"warnings,omitempty"`
+}
+
+// writeChatRelayFrame writes v as [4-byte big-endian length][JSON].
+func writeChatRelayFrame(w io.Writer, v any) error {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if len(payload) > chatRelayMaxFrame {
+		return fmt.Errorf("relay frame too large (%d bytes)", len(payload))
+	}
+	var header [4]byte
+	binary.BigEndian.PutUint32(header[:], uint32(len(payload)))
+	if _, err := w.Write(header[:]); err != nil {
+		return err
+	}
+	_, err = w.Write(payload)
+	return err
+}
+
+// readChatRelayFrame reads one [4-byte length][JSON] frame into v.
+func readChatRelayFrame(r io.Reader, v any) error {
+	var header [4]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return err
+	}
+	n := binary.BigEndian.Uint32(header[:])
+	if n > chatRelayMaxFrame {
+		return fmt.Errorf("relay frame too large (%d bytes)", n)
+	}
+	payload := make([]byte, n)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return err
+	}
+	return json.Unmarshal(payload, v)
+}
+
+// ---- client ----------------------------------------------------------------
+
+// chatRelayRoundTrip dials the socket, sends one request, and returns the reply.
+func chatRelayRoundTrip(sock string, req chatRelayRequest) (chatRelayResponse, error) {
+	conn, err := net.DialTimeout("unix", sock, chatRelayDialTimeout)
+	if err != nil {
+		return chatRelayResponse{}, fmt.Errorf("dial chat relay: %w", err)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(chatRelayDialTimeout))
+	if err := writeChatRelayFrame(conn, req); err != nil {
+		return chatRelayResponse{}, fmt.Errorf("write chat relay request: %w", err)
+	}
+	var resp chatRelayResponse
+	if err := readChatRelayFrame(conn, &resp); err != nil {
+		return chatRelayResponse{}, fmt.Errorf("read chat relay response: %w", err)
+	}
+	return resp, nil
+}
+
+// chatRelaySendClient relays a `chat send` to the daemon and returns the created
+// message plus non-fatal mention warnings. A gate/store error comes back as an
+// error whose text matches the direct path.
+func chatRelaySendClient(sock, token string, p chatSendParams) (chatMessageOutput, []string, error) {
+	resp, err := chatRelayRoundTrip(sock, chatRelayRequest{
+		Op:     "send",
+		Token:  token,
+		Thread: p.Ref,
+		Repo:   p.Repo,
+		As:     p.As,
+		Body:   p.Body,
+		Refs:   p.Refs,
+	})
+	if err != nil {
+		return chatMessageOutput{}, nil, err
+	}
+	if !resp.OK {
+		return chatMessageOutput{}, nil, errors.New(resp.Error)
+	}
+	if resp.Message == nil {
+		return chatMessageOutput{}, nil, errors.New("chat relay returned no message")
+	}
+	return *resp.Message, resp.Warnings, nil
+}
+
+// chatRelayWaitClient relays ONE `chat wait` snapshot to the daemon. The poll /
+// deadline loop stays client-side so behavior + output match the direct path.
+func chatRelayWaitClient(sock, token, ref, repo string, sinceSeq int64) (chatWaitResult, error) {
+	resp, err := chatRelayRoundTrip(sock, chatRelayRequest{
+		Op:       "wait",
+		Token:    token,
+		Thread:   ref,
+		Repo:     repo,
+		SinceSeq: sinceSeq,
+	})
+	if err != nil {
+		return chatWaitResult{}, err
+	}
+	if !resp.OK {
+		return chatWaitResult{}, errors.New(resp.Error)
+	}
+	return chatWaitResult{Messages: resp.Messages, LastSeq: resp.LastSeq, CapReached: resp.CapReached}, nil
+}
+
+// ---- server ----------------------------------------------------------------
+
+// activeChatRelay is the process-global relay server set by runDaemonRun once its
+// listener is up, so every jobWorker built by defaultJobWorker (across per-repo
+// supervisors) shares the one relay for this daemon process. nil until the daemon
+// starts one (and in every non-daemon process), so foreground CLI + tests that
+// build a worker directly get no relay injection unless they set it explicitly.
+var (
+	activeChatRelayMu sync.Mutex
+	activeChatRelay   *chatRelayServer
+)
+
+func setActiveChatRelayServer(s *chatRelayServer) {
+	activeChatRelayMu.Lock()
+	activeChatRelay = s
+	activeChatRelayMu.Unlock()
+}
+
+func activeChatRelayServer() *chatRelayServer {
+	activeChatRelayMu.Lock()
+	defer activeChatRelayMu.Unlock()
+	return activeChatRelay
+}
+
+// chatRelaySeat binds a minted token to the seat that may use it: the seat can
+// only author as its bound agent and only touch its bound thread.
+type chatRelaySeat struct {
+	Agent    string
+	ThreadID string
+}
+
+// chatRelayServer is the daemon-side listener. It reuses the daemon's own
+// *db.Store (unsandboxed) — no second open — and mints/validates per-seat tokens.
+type chatRelayServer struct {
+	store    *db.Store
+	sockPath string
+	stdout   io.Writer
+	ownerUID uint32
+
+	ln net.Listener
+
+	mu     sync.Mutex
+	tokens map[string]chatRelaySeat
+}
+
+// chatRelaySocketPath is the socket path for a home's daemon relay:
+// <TMPDIR>/gitmoot-relay-<uid>/chat.sock. It lives in TMPDIR (not the read-only
+// home) because that is unambiguously inside a codex workspace-write seat's
+// writable roots; the daemon passes the exact path to the seat via env, so
+// nothing is hard-coded on the seat side.
+func chatRelaySocketDir() string {
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gitmoot-relay-%d", os.Getuid()))
+}
+
+// newChatRelayServer constructs a relay server bound to dir/chat.sock. dir is the
+// daemon's relay dir (chatRelaySocketDir in production; a short temp dir in tests
+// — unix socket paths are length-limited).
+func newChatRelayServer(store *db.Store, dir string, stdout io.Writer) *chatRelayServer {
+	return &chatRelayServer{
+		store:    store,
+		sockPath: filepath.Join(dir, "chat.sock"),
+		stdout:   stdout,
+		ownerUID: uint32(os.Getuid()),
+		tokens:   map[string]chatRelaySeat{},
+	}
+}
+
+// SocketPath is the absolute path the daemon injects as GITMOOT_CHAT_RELAY.
+func (s *chatRelayServer) SocketPath() string { return s.sockPath }
+
+// Start creates the socket dir (0700), removes any stale socket, binds the
+// listener (0600), and serves until ctx is cancelled, then closes + unlinks.
+func (s *chatRelayServer) Start(ctx context.Context) error {
+	dir := filepath.Dir(s.sockPath)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create relay dir: %w", err)
+	}
+	// A same-uid dir; tighten perms in case it pre-existed with looser bits.
+	_ = os.Chmod(dir, 0o700)
+	// A stale socket from a crashed daemon would make Listen fail with "address
+	// already in use"; remove it first (best-effort).
+	if err := os.Remove(s.sockPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale relay socket: %w", err)
+	}
+	ln, err := net.Listen("unix", s.sockPath)
+	if err != nil {
+		return fmt.Errorf("listen relay socket: %w", err)
+	}
+	if err := os.Chmod(s.sockPath, 0o600); err != nil {
+		_ = ln.Close()
+		return fmt.Errorf("chmod relay socket: %w", err)
+	}
+	s.ln = ln
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+		_ = os.Remove(s.sockPath)
+	}()
+	go s.acceptLoop(ctx, ln)
+	return nil
+}
+
+func (s *chatRelayServer) acceptLoop(ctx context.Context, ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return // shutdown
+			}
+			// Transient accept error: keep serving.
+			continue
+		}
+		go s.handleConn(ctx, conn)
+	}
+}
+
+// RegisterSeat mints a random token bound to (agent, threadID) and returns it.
+// The daemon injects it as GITMOOT_CHAT_RELAY_AUTH for exactly this seat's job.
+func (s *chatRelayServer) RegisterSeat(agent, threadID string) (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	token := hex.EncodeToString(buf)
+	s.mu.Lock()
+	s.tokens[token] = chatRelaySeat{Agent: agent, ThreadID: threadID}
+	s.mu.Unlock()
+	return token, nil
+}
+
+// ReleaseSeat forgets a token when its seat job ends, so a token cannot be
+// replayed after the seat is gone.
+func (s *chatRelayServer) ReleaseSeat(token string) {
+	if token == "" {
+		return
+	}
+	s.mu.Lock()
+	delete(s.tokens, token)
+	s.mu.Unlock()
+}
+
+func (s *chatRelayServer) lookupSeat(token string) (chatRelaySeat, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seat, ok := s.tokens[token]
+	return seat, ok
+}
+
+func (s *chatRelayServer) handleConn(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(chatRelayDialTimeout))
+	// TRUST BOUNDARY: reject any peer whose uid differs from the daemon's. The
+	// socket is already 0600/dir-0700 same-uid, so this is defense-in-depth and
+	// does NOT widen the boundary (any same-uid process can already open the
+	// SQLite file directly). On platforms without SO_PEERCRED this trusts the fs
+	// perms alone (see peerUID).
+	if uid, err := peerUID(conn); err != nil {
+		s.reply(conn, chatRelayResponse{Error: "peer credential check failed"})
+		return
+	} else if uid != s.ownerUID {
+		s.reply(conn, chatRelayResponse{Error: "relay peer uid not permitted"})
+		return
+	}
+	var req chatRelayRequest
+	if err := readChatRelayFrame(conn, &req); err != nil {
+		s.reply(conn, chatRelayResponse{Error: "malformed relay request"})
+		return
+	}
+	s.reply(conn, s.dispatch(ctx, req))
+}
+
+func (s *chatRelayServer) reply(conn net.Conn, resp chatRelayResponse) {
+	if err := writeChatRelayFrame(conn, resp); err != nil && s.stdout != nil {
+		writeLine(s.stdout, "chat relay: write response failed: %v", err)
+	}
+}
+
+// dispatch validates the token gate, then runs the SAME store closure the direct
+// CLI path uses. Gate (defense-in-depth on top of the 0600 same-uid socket):
+//  1. token must be a live minted seat token;
+//  2. a `send`'s --as MUST equal the token's bound agent (no sibling impersonation);
+//  3. the target thread MUST be the token's bound thread (seat stays in its moot);
+//  4. the bound agent must still have repo access to the thread's repo.
+func (s *chatRelayServer) dispatch(ctx context.Context, req chatRelayRequest) chatRelayResponse {
+	seat, ok := s.lookupSeat(req.Token)
+	if !ok {
+		return chatRelayResponse{Error: "chat relay: invalid or expired token"}
+	}
+	// A send may only be authored as the token's bound agent.
+	if req.Op == "send" && req.As != "" && req.As != seat.Agent {
+		return chatRelayResponse{Error: fmt.Sprintf("chat relay: token bound to %q cannot send as %q", seat.Agent, req.As)}
+	}
+	thread, err := resolveChatThread(ctx, s.store, req.Thread, req.Repo)
+	if err != nil {
+		return chatRelayResponse{Error: fmt.Sprintf("chat relay: %v", err)}
+	}
+	if thread.ID != seat.ThreadID {
+		return chatRelayResponse{Error: "chat relay: token not valid for this thread"}
+	}
+	allowed, err := s.store.AgentCanAccessRepo(ctx, seat.Agent, thread.Repo)
+	if err != nil {
+		return chatRelayResponse{Error: fmt.Sprintf("chat relay: %v", err)}
+	}
+	if !allowed {
+		return chatRelayResponse{Error: fmt.Sprintf("chat relay: agent %q is not allowed on %q", seat.Agent, thread.Repo)}
+	}
+	switch req.Op {
+	case "send":
+		// Force the author to the bound agent: the seat cannot post as human or a
+		// sibling even if it omits --as.
+		msg, warnings, err := chatSendViaStore(ctx, s.store, chatSendParams{
+			Ref:  req.Thread,
+			Repo: req.Repo,
+			As:   seat.Agent,
+			Body: req.Body,
+			Refs: req.Refs,
+		})
+		if err != nil {
+			return chatRelayResponse{Error: err.Error()}
+		}
+		return chatRelayResponse{OK: true, Message: &msg, Warnings: warnings}
+	case "wait":
+		snap, err := chatWaitSnapshot(ctx, s.store, thread, req.SinceSeq)
+		if err != nil {
+			return chatRelayResponse{Error: err.Error()}
+		}
+		return chatRelayResponse{OK: true, Messages: snap.Messages, LastSeq: snap.LastSeq, CapReached: snap.CapReached}
+	default:
+		return chatRelayResponse{Error: fmt.Sprintf("chat relay: unknown op %q", req.Op)}
+	}
+}

--- a/internal/cli/chat_relay.go
+++ b/internal/cli/chat_relay.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
@@ -50,9 +51,21 @@ const (
 // make the daemon allocate unboundedly. Chat bodies are small; 8 MiB is ample.
 const chatRelayMaxFrame = 8 << 20
 
-// chatRelayDialTimeout bounds a single client relay round-trip. `chat wait` loops
-// these snapshots client-side, so each call is a quick, non-blocking op.
+// chatRelayDialTimeout bounds the CONNECT to the relay socket. A live listener
+// accepts immediately and a dead socket fails fast (ECONNREFUSED / ENOENT), so this
+// only needs to catch a wedged daemon; it is intentionally NOT the whole round-trip
+// budget (see chatRelayRoundTripTimeout).
 const chatRelayDialTimeout = 30 * time.Second
+
+// chatRelayRoundTripTimeout is the read/write deadline for one connected relay
+// exchange, on BOTH ends. It is deliberately much larger than dial: the server does
+// the actual AddChatMessage write, which under cross-process WAL contention retries
+// up to maxSeqAssignRetries times and can wait on the 15s SQLite busy_timeout, so a
+// tight wall (the old shared 30s) could fire mid-retry and fail a `chat send` the
+// direct in-process path — which has no transport wall — would have completed. This
+// bound comfortably exceeds any realistic chat-write completion (tiny writes drain
+// in ms even under heavy contention) while still reaping a genuinely hung peer.
+const chatRelayRoundTripTimeout = 120 * time.Second
 
 // chatRelayRequest is one relay operation. `op` is "send" or "wait"; the daemon
 // carries no request `type` byte (unlike entmoot) — op lives in the JSON.
@@ -123,7 +136,7 @@ func chatRelayRoundTrip(sock string, req chatRelayRequest) (chatRelayResponse, e
 		return chatRelayResponse{}, fmt.Errorf("dial chat relay: %w", err)
 	}
 	defer conn.Close()
-	_ = conn.SetDeadline(time.Now().Add(chatRelayDialTimeout))
+	_ = conn.SetDeadline(time.Now().Add(chatRelayRoundTripTimeout))
 	if err := writeChatRelayFrame(conn, req); err != nil {
 		return chatRelayResponse{}, fmt.Errorf("write chat relay request: %w", err)
 	}
@@ -223,13 +236,23 @@ type chatRelayServer struct {
 	tokens map[string]chatRelaySeat
 }
 
-// chatRelaySocketPath is the socket path for a home's daemon relay:
-// <TMPDIR>/gitmoot-relay-<uid>/chat.sock. It lives in TMPDIR (not the read-only
-// home) because that is unambiguously inside a codex workspace-write seat's
-// writable roots; the daemon passes the exact path to the seat via env, so
-// nothing is hard-coded on the seat side.
-func chatRelaySocketDir() string {
-	return filepath.Join(os.TempDir(), fmt.Sprintf("gitmoot-relay-%d", os.Getuid()))
+// chatRelaySocketDir is the socket directory for a home's daemon relay:
+// <TMPDIR>/gitmoot-relay-<uid>-<home-hash>. It is keyed by BOTH the uid AND a hash
+// of the resolved gitmoot home so two same-uid daemons on DIFFERENT homes — e.g.
+// the live /root/.gitmoot daemon and a throwaway /tmp E2E daemon (the documented
+// isolation pattern) — never share and therefore never clobber each other's socket
+// path. Without the home component, the second daemon's Start() would os.Remove the
+// live daemon's socket and bind its own listener at the identical path, hijacking
+// every already-dispatched seat (whose minted tokens it does not hold) and, on its
+// own exit, unlinking the live relay's socket for good. It lives in TMPDIR (not the
+// read-only home) because that is unambiguously inside a codex workspace-write
+// seat's writable roots; the daemon passes the exact path to the seat via env, so
+// nothing is hard-coded on the seat side. homeRoot is the resolved `.gitmoot` root
+// (config.Paths.Home); the short hash keeps the socket path inside the ~108-byte
+// unix-socket limit regardless of how deep the home is.
+func chatRelaySocketDir(homeRoot string) string {
+	sum := sha256.Sum256([]byte(homeRoot))
+	return filepath.Join(os.TempDir(), fmt.Sprintf("gitmoot-relay-%d-%s", os.Getuid(), hex.EncodeToString(sum[:6])))
 }
 
 // newChatRelayServer constructs a relay server bound to dir/chat.sock. dir is the
@@ -328,7 +351,7 @@ func (s *chatRelayServer) lookupSeat(token string) (chatRelaySeat, bool) {
 
 func (s *chatRelayServer) handleConn(ctx context.Context, conn net.Conn) {
 	defer conn.Close()
-	_ = conn.SetDeadline(time.Now().Add(chatRelayDialTimeout))
+	_ = conn.SetDeadline(time.Now().Add(chatRelayRoundTripTimeout))
 	// TRUST BOUNDARY: reject any peer whose uid differs from the daemon's. The
 	// socket is already 0600/dir-0700 same-uid, so this is defense-in-depth and
 	// does NOT widen the boundary (any same-uid process can already open the

--- a/internal/cli/chat_relay_peercred_linux.go
+++ b/internal/cli/chat_relay_peercred_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package cli
+
+import (
+	"errors"
+	"net"
+	"syscall"
+)
+
+// peerUID returns the uid of the process on the other end of a unix-socket
+// connection via SO_PEERCRED (Linux). It is the daemon relay's peer-identity
+// check: the daemon rejects any connection whose uid differs from its own.
+func peerUID(conn net.Conn) (uint32, error) {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0, errors.New("relay peer is not a unix connection")
+	}
+	raw, err := unixConn.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var (
+		ucred   *syscall.Ucred
+		credErr error
+	)
+	if ctrlErr := raw.Control(func(fd uintptr) {
+		ucred, credErr = syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+	}); ctrlErr != nil {
+		return 0, ctrlErr
+	}
+	if credErr != nil {
+		return 0, credErr
+	}
+	return ucred.Uid, nil
+}

--- a/internal/cli/chat_relay_peercred_other.go
+++ b/internal/cli/chat_relay_peercred_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package cli
+
+import (
+	"net"
+	"os"
+)
+
+// peerUID on non-Linux platforms has no portable SO_PEERCRED, so it trusts the
+// socket's filesystem permissions alone (0600, dir 0700, owned by the daemon
+// uid) and reports the daemon's own uid so the caller's uid check passes. The
+// production daemon deployment is Linux, where the real SO_PEERCRED check applies.
+func peerUID(_ net.Conn) (uint32, error) {
+	return uint32(os.Getuid()), nil
+}

--- a/internal/cli/chat_relay_test.go
+++ b/internal/cli/chat_relay_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
 // startTestChatRelay boots a relay server on a short temp socket dir (unix socket
@@ -39,6 +40,74 @@ func seedRelayThread(t *testing.T, store *db.Store, repo, slug string) db.ChatTh
 		t.Fatalf("CreateChatThread: %v", err)
 	}
 	return thread
+}
+
+// TestBuildSeatAwareAdapterElevation pins the #732 seat-classification fix: the
+// daemon elevates a codex agent to ChatSeat (workspace-write+network) — and injects
+// the relay env — ONLY for a real `gitmoot moot` seat (payload.MootSeat) that also
+// gets a working relay, NOT for any ThreadID-carrying job (chat-task promotions /
+// continuations) and NOT when no relay is running. Elevation is coupled to real
+// relay injection so a seat never carries the extra privilege without a relay.
+func TestBuildSeatAwareAdapterElevation(t *testing.T) {
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	thread := seedRelayThread(t, store, "owner/repo", "room")
+	server, _ := startTestChatRelay(t, store)
+
+	// A factory whose adapter is unused here — the point is the agent-elevation +
+	// token side effects, which we assert directly.
+	factory := func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return runtime.ShellAdapter{}, nil
+	}
+
+	cases := []struct {
+		name         string
+		relay        *chatRelayServer
+		payload      workflow.JobPayload
+		wantElevated bool
+		wantToken    bool
+	}{
+		{
+			name:         "moot seat with relay elevates and injects",
+			relay:        server,
+			payload:      workflow.JobPayload{MootSeat: true, ThreadID: thread.ID},
+			wantElevated: true,
+			wantToken:    true,
+		},
+		{
+			name:         "threadid-only job is not a seat",
+			relay:        server,
+			payload:      workflow.JobPayload{ThreadID: thread.ID},
+			wantElevated: false,
+			wantToken:    false,
+		},
+		{
+			name:         "moot seat without relay is not elevated",
+			relay:        nil,
+			payload:      workflow.JobPayload{MootSeat: true, ThreadID: thread.ID},
+			wantElevated: false,
+			wantToken:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := jobWorker{Store: store, RelayServer: tc.relay, AdapterFactory: factory, Stdout: io.Discard}
+			agent := runtime.Agent{Name: "alice", Runtime: runtime.CodexRuntime}
+			_, token, err := w.buildSeatAwareAdapter(&agent, "", tc.payload)
+			if err != nil {
+				t.Fatalf("buildSeatAwareAdapter: %v", err)
+			}
+			if token != "" {
+				t.Cleanup(func() { tc.relay.ReleaseSeat(token) })
+			}
+			if agent.ChatSeat != tc.wantElevated {
+				t.Fatalf("agent.ChatSeat = %v, want %v", agent.ChatSeat, tc.wantElevated)
+			}
+			if (token != "") != tc.wantToken {
+				t.Fatalf("token present = %v (%q), want %v", token != "", token, tc.wantToken)
+			}
+		})
+	}
 }
 
 // TestChatRelayRoundTrip proves a relay send lands in the daemon's store (authored

--- a/internal/cli/chat_relay_test.go
+++ b/internal/cli/chat_relay_test.go
@@ -1,0 +1,316 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// startTestChatRelay boots a relay server on a short temp socket dir (unix socket
+// paths are length-limited, so t.TempDir() is too long) bound to a cancelable
+// context, and returns the server + its socket path.
+func startTestChatRelay(t *testing.T, store *db.Store) (*chatRelayServer, string) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "gmrelay")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	server := newChatRelayServer(store, dir, io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("relay Start: %v", err)
+	}
+	return server, server.SocketPath()
+}
+
+func seedRelayThread(t *testing.T, store *db.Store, repo, slug string) db.ChatThread {
+	t.Helper()
+	thread, err := store.CreateChatThread(context.Background(), db.ChatThread{Slug: slug, Name: slug, Repo: repo})
+	if err != nil {
+		t.Fatalf("CreateChatThread: %v", err)
+	}
+	return thread
+}
+
+// TestChatRelayRoundTrip proves a relay send lands in the daemon's store (authored
+// as the token's bound agent) and a relay wait returns it.
+func TestChatRelayRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	seedDaemonWorkerAgent(t, store, "alice", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	thread := seedRelayThread(t, store, "owner/repo", "room")
+
+	// Register the seat token the daemon would mint for alice on this thread.
+	relaySrv, sock := startTestChatRelay(t, store)
+	token, err := relaySrv.RegisterSeat("alice", thread.ID)
+	if err != nil {
+		t.Fatalf("RegisterSeat: %v", err)
+	}
+
+	msg, warnings, err := chatRelaySendClient(sock, token, chatSendParams{
+		Ref: "room", Repo: "owner/repo", As: "alice", Body: "hello @ghost",
+	})
+	if err != nil {
+		t.Fatalf("relay send: %v", err)
+	}
+	if msg.AuthorName != "alice" || msg.AuthorKind != db.ChatAuthorKindAgent {
+		t.Fatalf("message authored wrong: %+v", msg)
+	}
+	if msg.Seq == 0 {
+		t.Fatalf("message seq not assigned: %+v", msg)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "ghost") {
+		t.Fatalf("expected an unknown-mention warning, got %v", warnings)
+	}
+
+	// The write actually landed in the daemon's store.
+	msgs, err := store.ListChatMessages(ctx, thread.ID, 0)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	var found bool
+	for _, m := range msgs {
+		if m.AuthorName == "alice" && m.Body == "hello @ghost" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("relay send did not land in store: %+v", msgs)
+	}
+
+	// A wait snapshot since 0 returns the new message + last seq.
+	snap, err := chatRelayWaitClient(sock, token, "room", "owner/repo", 0)
+	if err != nil {
+		t.Fatalf("relay wait: %v", err)
+	}
+	if len(snap.Messages) == 0 || snap.LastSeq == 0 {
+		t.Fatalf("relay wait returned nothing: %+v", snap)
+	}
+	// A wait since the last seq returns no new messages.
+	snap2, err := chatRelayWaitClient(sock, token, "room", "owner/repo", snap.LastSeq)
+	if err != nil {
+		t.Fatalf("relay wait 2: %v", err)
+	}
+	if len(snap2.Messages) != 0 {
+		t.Fatalf("relay wait since last seq returned messages: %+v", snap2)
+	}
+}
+
+// TestChatRelayTokenRejected proves a bad, empty, or released token is refused.
+func TestChatRelayTokenRejected(t *testing.T) {
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	seedDaemonWorkerAgent(t, store, "alice", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	thread := seedRelayThread(t, store, "owner/repo", "room")
+	server, sock := startTestChatRelay(t, store)
+
+	for _, tok := range []string{"", "bogus-token"} {
+		if _, _, err := chatRelaySendClient(sock, tok, chatSendParams{Ref: "room", Repo: "owner/repo", As: "alice", Body: "x"}); err == nil {
+			t.Fatalf("token %q accepted", tok)
+		} else if !strings.Contains(err.Error(), "token") {
+			t.Fatalf("token %q error = %v, want a token rejection", tok, err)
+		}
+	}
+
+	// A released token can no longer be replayed.
+	token, err := server.RegisterSeat("alice", thread.ID)
+	if err != nil {
+		t.Fatalf("RegisterSeat: %v", err)
+	}
+	server.ReleaseSeat(token)
+	if _, _, err := chatRelaySendClient(sock, token, chatSendParams{Ref: "room", Repo: "owner/repo", As: "alice", Body: "x"}); err == nil {
+		t.Fatal("released token accepted")
+	}
+}
+
+// TestChatRelayGateRejection proves the relay reuses the same access gate: an
+// agent without repo access is refused, and a seat cannot impersonate a sibling.
+func TestChatRelayGateRejection(t *testing.T) {
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	// carol is scoped to a DIFFERENT repo than the thread.
+	seedDaemonWorkerAgent(t, store, "carol", runtime.ShellRuntime, "", []string{"ask"}, "other/repo")
+	seedDaemonWorkerAgent(t, store, "alice", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "bob", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	thread := seedRelayThread(t, store, "owner/repo", "room")
+	server, sock := startTestChatRelay(t, store)
+
+	// Repo-scope rejection: carol's token is bound to an owner/repo thread she
+	// cannot access.
+	carolTok, _ := server.RegisterSeat("carol", thread.ID)
+	if _, _, err := chatRelaySendClient(sock, carolTok, chatSendParams{Ref: "room", Repo: "owner/repo", As: "carol", Body: "x"}); err == nil {
+		t.Fatal("carol allowed on a repo she is not scoped to")
+	} else if !strings.Contains(err.Error(), "not allowed on") {
+		t.Fatalf("carol error = %v, want a repo-scope rejection", err)
+	}
+
+	// Impersonation rejection: alice's token cannot author as bob.
+	aliceTok, _ := server.RegisterSeat("alice", thread.ID)
+	if _, _, err := chatRelaySendClient(sock, aliceTok, chatSendParams{Ref: "room", Repo: "owner/repo", As: "bob", Body: "x"}); err == nil {
+		t.Fatal("alice allowed to send as bob")
+	} else if !strings.Contains(err.Error(), "cannot send as") {
+		t.Fatalf("impersonation error = %v, want an impersonation rejection", err)
+	}
+
+	// Wrong-thread rejection: a token bound to this thread cannot touch another.
+	other := seedRelayThread(t, store, "owner/repo", "other-room")
+	if _, _, err := chatRelaySendClient(sock, aliceTok, chatSendParams{Ref: "other-room", Repo: "owner/repo", As: "alice", Body: "x"}); err == nil {
+		t.Fatal("token accepted for the wrong thread")
+	} else if !strings.Contains(err.Error(), "thread") {
+		t.Fatalf("wrong-thread error = %v", err)
+	}
+	_ = other
+}
+
+// TestChatRelaySocketPermissions proves the socket is 0600, its dir 0700, and it
+// is removed on shutdown.
+func TestChatRelaySocketPermissions(t *testing.T) {
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	dir, err := os.MkdirTemp("", "gmrelayperm")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	server := newChatRelayServer(store, dir, io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := server.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	sock := server.SocketPath()
+	info, err := os.Stat(sock)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("socket perm = %o, want 600", perm)
+	}
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o700 {
+		t.Fatalf("dir perm = %o, want 700", perm)
+	}
+
+	cancel()
+	// The socket is unlinked on ctx.Done (async); poll briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(sock); os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("socket not removed after shutdown")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestChatSendDirectPathUnchanged proves that WITHOUT GITMOOT_CHAT_RELAY the
+// `chat send` command writes directly to the store, byte-identically (no socket).
+func TestChatSendDirectPathUnchanged(t *testing.T) {
+	// Ensure no stray relay env leaks from the harness.
+	t.Setenv(chatRelayEnvSocket, "")
+	t.Setenv(chatRelayEnvToken, "")
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	seedDaemonWorkerAgent(t, store, "alice", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	seedRelayThread(t, store, "owner/repo", "room")
+	store.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"chat", "send", "room", "hi there", "--as", "alice", "--repo", "owner/repo", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("chat send exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "sent #") {
+		t.Fatalf("stdout = %q, want a sent confirmation", stdout.String())
+	}
+	// The message is in the store.
+	store2 := openCLIJobStore(t, home)
+	defer store2.Close()
+	threads, _ := store2.ListChatThreads(context.Background(), "owner/repo", "")
+	if len(threads) == 0 {
+		t.Fatal("no thread")
+	}
+	msgs, _ := store2.ListChatMessages(context.Background(), threads[0].ID, 0)
+	var found bool
+	for _, m := range msgs {
+		if m.AuthorName == "alice" && m.Body == "hi there" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("direct send not in store: %+v", msgs)
+	}
+}
+
+// TestChatSendRelayEnvBranch proves that WITH GITMOOT_CHAT_RELAY set, `chat send`
+// routes over the socket to the daemon (never opening the store itself), and the
+// daemon performs the write — the sandboxed-seat path.
+func TestChatSendRelayEnvBranch(t *testing.T) {
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	seedDaemonWorkerAgent(t, store, "alice", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	thread := seedRelayThread(t, store, "owner/repo", "room")
+	server, sock := startTestChatRelay(t, store)
+	token, _ := server.RegisterSeat("alice", thread.ID)
+
+	t.Setenv(chatRelayEnvSocket, sock)
+	t.Setenv(chatRelayEnvToken, token)
+
+	// Point --home at a NON-EXISTENT dir the seat could not write; the relay path
+	// must not touch it (it dials the socket instead), proving the store open is
+	// bypassed entirely.
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"chat", "send", "room", "relayed body", "--as", "alice", "--repo", "owner/repo", "--home", "/nonexistent/relay-home"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("relayed chat send exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "sent #") {
+		t.Fatalf("stdout = %q, want a sent confirmation", stdout.String())
+	}
+	msgs, _ := store.ListChatMessages(context.Background(), thread.ID, 0)
+	var found bool
+	for _, m := range msgs {
+		if m.AuthorName == "alice" && m.Body == "relayed body" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("relayed send did not land via daemon store: %+v", msgs)
+	}
+}
+
+// TestChatSendRelayDialFailureNoFallback proves that when the relay env is set but
+// the socket is unreachable, `chat send` errors instead of silently falling back
+// to a direct (sandbox-broken) write.
+func TestChatSendRelayDialFailureNoFallback(t *testing.T) {
+	t.Setenv(chatRelayEnvSocket, "/nonexistent/relay.sock")
+	t.Setenv(chatRelayEnvToken, "tok")
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	seedDaemonWorkerAgent(t, store, "alice", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	seedRelayThread(t, store, "owner/repo", "room")
+	store.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"chat", "send", "room", "x", "--as", "alice", "--repo", "owner/repo", "--home", home}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected failure on unreachable relay, got 0; stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "chat send") {
+		t.Fatalf("stderr = %q, want a chat send error", stderr.String())
+	}
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -377,6 +377,33 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	// the leaf helpers (a revert of this wiring would otherwise stay green).
 	defer daemonRunStartupReconcile(ctx, *home, os.Args, stdout)()
 
+	// #732 chat relay: start a daemon-owned unix-socket relay so a sandboxed moot
+	// seat (whose read-only home blocks a direct `gitmoot chat send`) can route
+	// send/wait to THIS daemon, which owns the store unsandboxed. It uses a
+	// dedicated store bound to the daemon ctx (the per-repo supervisors open their
+	// own stores per pass) and is torn down on ctx.Done. Best-effort: a relay start
+	// failure never blocks the daemon — a moot simply degrades to the pre-#732
+	// parallel-conclusions behavior.
+	if relayPaths, perr := initializedPaths(*home); perr != nil {
+		writeLine(stdout, "daemon: chat relay disabled (paths unavailable): %v", perr)
+	} else if relayStore, serr := db.Open(relayPaths.Database); serr != nil {
+		writeLine(stdout, "daemon: chat relay disabled (store unavailable): %v", serr)
+	} else {
+		relay := newChatRelayServer(relayStore, chatRelaySocketDir(), stdout)
+		if rerr := relay.Start(ctx); rerr != nil {
+			writeLine(stdout, "daemon: chat relay disabled: %v", rerr)
+			_ = relayStore.Close()
+		} else {
+			setActiveChatRelayServer(relay)
+			writeLine(stdout, "daemon: chat relay listening at %s", relay.SocketPath())
+			go func() {
+				<-ctx.Done()
+				setActiveChatRelayServer(nil)
+				_ = relayStore.Close()
+			}()
+		}
+	}
+
 	if *repoFlag == "" {
 		err := runRegisteredRepoSupervisor(ctx, *home, live, *dryRun, *watchSkillOptReviews, *watchIssues, session, stdout)
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -2985,6 +3012,13 @@ type jobWorker struct {
 	// a config file / webhook. When nil (production), eventSink() resolves the
 	// shared process-global webhook sink from [events] config instead.
 	EventSinkOverride events.Sink
+	// RelayServer is the daemon's #732 chat relay. When non-nil AND a job payload
+	// carries a ThreadID (a moot/chat seat), run() mints a per-seat token on it and
+	// injects GITMOOT_CHAT_RELAY[_AUTH] into the seat's runtime subprocess so the
+	// sandboxed seat's `gitmoot chat send/wait` routes through the (unsandboxed)
+	// daemon. nil (foreground CLI, and every non-daemon construction) means no relay
+	// injection — the job's adapter is byte-identical to pre-#732.
+	RelayServer *chatRelayServer
 	// AuthProbe is the injected doctor-style live credential probe (#532 slice B).
 	// It gates re-dispatch of a runtime_auth deferral: once the coarse hold elapses
 	// the scheduler only releases the job when the probe reports the credential is
@@ -3156,6 +3190,7 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 		configHomeExplicit = true
 	}
 	worker := jobWorker{Store: store, Stdout: stdout, ConfigHome: configHome, ConfigHomeExplicit: configHomeExplicit}
+	worker.RelayServer = activeChatRelayServer()
 	worker.AdapterFactory = worker.defaultAdapter
 	worker.StartAdapterFactory = worker.defaultStartAdapter
 	worker.CheckoutValidator = worker.defaultCheckout
@@ -5020,7 +5055,23 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, "", err)
 		return nil
 	}
-	adapter, err := w.AdapterFactory(agent, checkout)
+	// #732 moot-seat relay injection: a job whose payload carries a ThreadID is a
+	// moot/chat seat that must converse via `gitmoot chat send/wait`, but its
+	// runtime sandbox makes the home read-only. Flag it a ChatSeat so a codex seat
+	// is dispatched workspace-write + network (the only substrate that can reach the
+	// relay socket; the home stays read-only), mint a per-seat token bound to
+	// (agent, thread), and build the adapter with an env-injecting runner so the
+	// seat's runtime subprocess inherits GITMOOT_CHAT_RELAY[_AUTH] and routes those
+	// writes to this daemon. ONLY seats get this — a normal job builds via the
+	// unmodified AdapterFactory (nil runner) and stays byte-identical. The token is
+	// released on every exit path so it cannot be replayed after the seat ends.
+	if strings.TrimSpace(payload.ThreadID) != "" {
+		agent.ChatSeat = true
+	}
+	adapter, relayToken, err := w.buildSeatAwareAdapter(agent, checkout, payload)
+	if relayToken != "" {
+		defer w.RelayServer.ReleaseSeat(relayToken)
+	}
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
 			return finishErr
@@ -6447,6 +6498,44 @@ func (w jobWorker) refreshImplementedPayloadForRetry(ctx context.Context, job db
 
 func (w jobWorker) defaultAdapter(agent runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
 	return buildRuntimeAdapter(agent, checkout, nil)
+}
+
+// buildSeatAwareAdapter builds the job's runtime adapter, injecting the #732 chat
+// relay env for a moot/chat SEAT (a payload carrying a ThreadID) when a relay is
+// running. For a seat it mints a per-seat token bound to (agent, thread) and
+// returns an adapter whose runner appends GITMOOT_CHAT_RELAY[_AUTH] to the runtime
+// subprocess env, plus the token so the caller can release it on job exit. For
+// every non-seat job (or when no relay is running) it returns the byte-identical
+// AdapterFactory adapter and an empty token.
+//
+// NOTE: moot seats are dispatched WITHOUT cockpit (runMoot sets no Cockpit flag),
+// so the cockpit adapter-rebuild path in run() — which would replace this adapter
+// and drop the env runner — never fires for a seat. If that ever changes, thread
+// the relay env into the cockpit rebuild too.
+func (w jobWorker) buildSeatAwareAdapter(agent runtime.Agent, checkout string, payload workflow.JobPayload) (workflow.DeliveryAdapter, string, error) {
+	if w.RelayServer == nil || strings.TrimSpace(payload.ThreadID) == "" {
+		adapter, err := w.AdapterFactory(agent, checkout)
+		return adapter, "", err
+	}
+	token, err := w.RelayServer.RegisterSeat(agent.Name, payload.ThreadID)
+	if err != nil {
+		// Fail-open: without a token the seat cannot relay, but a normal adapter
+		// still lets the seat run (and degrade to a job_result conclusion). Do not
+		// fail the job over a token mint error.
+		writeLine(w.Stdout, "job seat %s relay token mint failed: %v", agent.Name, err)
+		adapter, aerr := w.AdapterFactory(agent, checkout)
+		return adapter, "", aerr
+	}
+	relayEnv := []string{
+		chatRelayEnvSocket + "=" + w.RelayServer.SocketPath(),
+		chatRelayEnvToken + "=" + token,
+	}
+	adapter, err := buildRuntimeAdapter(agent, checkout, subprocess.EnvInjectingRunner{Env: relayEnv})
+	if err != nil {
+		w.RelayServer.ReleaseSeat(token)
+		return nil, "", err
+	}
+	return adapter, token, nil
 }
 
 // buildRuntimeAdapter constructs the concrete runtime adapter for a job. A nil

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -389,7 +389,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 	} else if relayStore, serr := db.Open(relayPaths.Database); serr != nil {
 		writeLine(stdout, "daemon: chat relay disabled (store unavailable): %v", serr)
 	} else {
-		relay := newChatRelayServer(relayStore, chatRelaySocketDir(), stdout)
+		relay := newChatRelayServer(relayStore, chatRelaySocketDir(relayPaths.Home), stdout)
 		if rerr := relay.Start(ctx); rerr != nil {
 			writeLine(stdout, "daemon: chat relay disabled: %v", rerr)
 			_ = relayStore.Close()
@@ -3012,8 +3012,8 @@ type jobWorker struct {
 	// a config file / webhook. When nil (production), eventSink() resolves the
 	// shared process-global webhook sink from [events] config instead.
 	EventSinkOverride events.Sink
-	// RelayServer is the daemon's #732 chat relay. When non-nil AND a job payload
-	// carries a ThreadID (a moot/chat seat), run() mints a per-seat token on it and
+	// RelayServer is the daemon's #732 chat relay. When non-nil AND a job payload is
+	// a `gitmoot moot` seat (payload.MootSeat), run() mints a per-seat token on it and
 	// injects GITMOOT_CHAT_RELAY[_AUTH] into the seat's runtime subprocess so the
 	// sandboxed seat's `gitmoot chat send/wait` routes through the (unsandboxed)
 	// daemon. nil (foreground CLI, and every non-daemon construction) means no relay
@@ -5055,20 +5055,20 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, "", err)
 		return nil
 	}
-	// #732 moot-seat relay injection: a job whose payload carries a ThreadID is a
-	// moot/chat seat that must converse via `gitmoot chat send/wait`, but its
-	// runtime sandbox makes the home read-only. Flag it a ChatSeat so a codex seat
-	// is dispatched workspace-write + network (the only substrate that can reach the
-	// relay socket; the home stays read-only), mint a per-seat token bound to
-	// (agent, thread), and build the adapter with an env-injecting runner so the
-	// seat's runtime subprocess inherits GITMOOT_CHAT_RELAY[_AUTH] and routes those
-	// writes to this daemon. ONLY seats get this — a normal job builds via the
-	// unmodified AdapterFactory (nil runner) and stays byte-identical. The token is
+	// #732 moot-seat relay injection: a `gitmoot moot` SEAT (payload.MootSeat) must
+	// converse via `gitmoot chat send/wait` mid-run, but its runtime sandbox makes
+	// the home read-only. buildSeatAwareAdapter mints a per-seat token bound to
+	// (agent, thread), builds the adapter with an env-injecting runner so the seat's
+	// runtime subprocess inherits GITMOOT_CHAT_RELAY[_AUTH] and routes those writes
+	// to this daemon, AND — only when it actually injects that relay env — elevates
+	// the agent to ChatSeat (a codex seat then gets workspace-write+network to reach
+	// the socket; the home stays read-only, so the relay does the write). Coupling
+	// the elevation to real injection is deliberate: a seat is NEVER left with the
+	// extra codex privilege but no working relay (the pre-#732-review bug). Gating on
+	// MootSeat — not ThreadID — keeps chat-task promotions and ThreadID-carrying
+	// continuations/children byte-identical (unelevated, no relay env). The token is
 	// released on every exit path so it cannot be replayed after the seat ends.
-	if strings.TrimSpace(payload.ThreadID) != "" {
-		agent.ChatSeat = true
-	}
-	adapter, relayToken, err := w.buildSeatAwareAdapter(agent, checkout, payload)
+	adapter, relayToken, err := w.buildSeatAwareAdapter(&agent, checkout, payload)
 	if relayToken != "" {
 		defer w.RelayServer.ReleaseSeat(relayToken)
 	}
@@ -6501,37 +6501,48 @@ func (w jobWorker) defaultAdapter(agent runtime.Agent, checkout string) (workflo
 }
 
 // buildSeatAwareAdapter builds the job's runtime adapter, injecting the #732 chat
-// relay env for a moot/chat SEAT (a payload carrying a ThreadID) when a relay is
-// running. For a seat it mints a per-seat token bound to (agent, thread) and
-// returns an adapter whose runner appends GITMOOT_CHAT_RELAY[_AUTH] to the runtime
-// subprocess env, plus the token so the caller can release it on job exit. For
-// every non-seat job (or when no relay is running) it returns the byte-identical
-// AdapterFactory adapter and an empty token.
+// relay env for a `gitmoot moot` SEAT (payload.MootSeat) when a relay is running.
+// For a seat that gets a working relay it mints a per-seat token bound to (agent,
+// thread), returns an adapter whose runner appends GITMOOT_CHAT_RELAY[_AUTH] to the
+// runtime subprocess env, and — only then — sets agent.ChatSeat so a codex seat is
+// elevated to workspace-write+network to reach the socket. It takes *agent so this
+// elevation propagates to the agent that RunJob delivers. Elevation is coupled to
+// injection on PURPOSE: a seat is never granted the extra codex privilege without a
+// working relay to use it (a no-relay / mint-failure seat stays unelevated and
+// degrades to a job_result conclusion, exactly like a non-seat). For every non-seat
+// job (or when no relay is running) it returns the byte-identical AdapterFactory
+// adapter, no elevation, and an empty token.
 //
 // NOTE: moot seats are dispatched WITHOUT cockpit (runMoot sets no Cockpit flag),
 // so the cockpit adapter-rebuild path in run() — which would replace this adapter
 // and drop the env runner — never fires for a seat. If that ever changes, thread
 // the relay env into the cockpit rebuild too.
-func (w jobWorker) buildSeatAwareAdapter(agent runtime.Agent, checkout string, payload workflow.JobPayload) (workflow.DeliveryAdapter, string, error) {
-	if w.RelayServer == nil || strings.TrimSpace(payload.ThreadID) == "" {
-		adapter, err := w.AdapterFactory(agent, checkout)
+func (w jobWorker) buildSeatAwareAdapter(agent *runtime.Agent, checkout string, payload workflow.JobPayload) (workflow.DeliveryAdapter, string, error) {
+	if w.RelayServer == nil || !payload.MootSeat || strings.TrimSpace(payload.ThreadID) == "" {
+		adapter, err := w.AdapterFactory(*agent, checkout)
 		return adapter, "", err
 	}
 	token, err := w.RelayServer.RegisterSeat(agent.Name, payload.ThreadID)
 	if err != nil {
 		// Fail-open: without a token the seat cannot relay, but a normal adapter
-		// still lets the seat run (and degrade to a job_result conclusion). Do not
-		// fail the job over a token mint error.
+		// still lets the seat run (and degrade to a job_result conclusion). Leave the
+		// agent UNELEVATED — elevation without a relay buys nothing and would leave a
+		// codex seat with write+network it cannot use. Do not fail the job over a mint
+		// error.
 		writeLine(w.Stdout, "job seat %s relay token mint failed: %v", agent.Name, err)
-		adapter, aerr := w.AdapterFactory(agent, checkout)
+		adapter, aerr := w.AdapterFactory(*agent, checkout)
 		return adapter, "", aerr
 	}
 	relayEnv := []string{
 		chatRelayEnvSocket + "=" + w.RelayServer.SocketPath(),
 		chatRelayEnvToken + "=" + token,
 	}
-	adapter, err := buildRuntimeAdapter(agent, checkout, subprocess.EnvInjectingRunner{Env: relayEnv})
+	// Elevate ONLY now that the seat will get a working relay env (see the coupling
+	// rationale above). Mutates the caller's agent so RunJob delivers with ChatSeat.
+	agent.ChatSeat = true
+	adapter, err := buildRuntimeAdapter(*agent, checkout, subprocess.EnvInjectingRunner{Env: relayEnv})
 	if err != nil {
+		agent.ChatSeat = false
 		w.RelayServer.ReleaseSeat(token)
 		return nil, "", err
 	}

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -59,6 +59,16 @@ type Agent struct {
 	// per-job cost. Never set for long-lived registered agents, whose sessions
 	// span many jobs. In-memory only; not persisted on the agents table.
 	SingleUseSession bool
+	// ChatSeat marks a moot/chat SEAT job (#732): its whole purpose is to converse
+	// via `gitmoot chat send/wait`, which under the default read-only codex sandbox
+	// cannot even reach the daemon relay unix socket (the read-only seccomp filter
+	// blocks the connect() syscall itself, regardless of the socket's path). A seat
+	// is therefore dispatched with codex workspace-write + network_access=true so it
+	// can reach the socket; the gitmoot home stays OUTSIDE workspace-write's
+	// writable roots ([workdir, /tmp, $TMPDIR]), so the read-only-home invariant is
+	// preserved — the relay, not the seat, performs the DB write. The daemon sets
+	// this in-memory for seat jobs (payload carries a ThreadID); never persisted.
+	ChatSeat bool
 	// WorkingDir is the resolved filesystem checkout directory the runtime
 	// adapter should chdir into for a delivery. It is DISTINCT from RepoScope,
 	// which stays in "owner/repo" form (and is validated as such). Callers that
@@ -581,6 +591,16 @@ func effectiveModel(agent Agent, job Job) string {
 }
 
 func codexSandboxArgs(agent Agent) []string {
+	// #732: a moot/chat seat must reach the daemon chat-relay unix socket, but a
+	// codex read-only sandbox blocks the connect() syscall itself (empirically
+	// probed on codex-cli 0.142.4 bubblewrap+seccomp). Dispatch the seat with
+	// workspace-write + network so it can connect; the gitmoot home is NOT in
+	// workspace-write's writable roots (workdir + /tmp + $TMPDIR), so the home stays
+	// read-only — the relay, not the seat, does the write. This is self-contained
+	// (does not depend on the operator's global ~/.codex/config.toml).
+	if agent.ChatSeat {
+		return []string{"--sandbox", "workspace-write", "-c", "sandbox_workspace_write.network_access=true"}
+	}
 	switch NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
 	case AutonomyPolicyReadOnly:
 		return []string{"--sandbox", "read-only"}

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -67,7 +67,9 @@ type Agent struct {
 	// can reach the socket; the gitmoot home stays OUTSIDE workspace-write's
 	// writable roots ([workdir, /tmp, $TMPDIR]), so the read-only-home invariant is
 	// preserved — the relay, not the seat, performs the DB write. The daemon sets
-	// this in-memory for seat jobs (payload carries a ThreadID); never persisted.
+	// this in-memory for a `gitmoot moot` seat (payload.MootSeat) — and ONLY when it
+	// also injects a working relay env, so a seat is never elevated without a relay;
+	// never persisted.
 	ChatSeat bool
 	// WorkingDir is the resolved filesystem checkout directory the runtime
 	// adapter should chdir into for a delivery. It is DISTINCT from RepoScope,

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -284,6 +284,39 @@ func TestCodexStartCommandAppliesAutonomyPolicy(t *testing.T) {
 	}
 }
 
+// TestCodexDeliverChatSeatSandbox pins the #732 sandbox override: a moot/chat
+// seat (ChatSeat=true) is dispatched workspace-write + network_access=true — the
+// only substrate that can reach the daemon chat-relay unix socket — REGARDLESS of
+// the agent's stored read-only policy, so it can connect while its gitmoot home
+// stays read-only (outside workspace-write's writable roots).
+func TestCodexDeliverChatSeatSandbox(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "ok"}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{
+		Name: "planner", Role: "planner", Runtime: CodexRuntime, RepoScope: "jerryfane/gitmoot",
+		RuntimeRef: "last", AutonomyPolicy: AutonomyPolicyReadOnly, ChatSeat: true,
+	}
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "converse"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--sandbox", "workspace-write", "-c", "sandbox_workspace_write.network_access=true", "--json", "resume", "--last", "--", "converse")
+}
+
+// TestCodexDeliverNonSeatSandboxUnchanged proves a NON-seat read-only job keeps
+// the exact pre-#732 read-only sandbox args (byte-identical).
+func TestCodexDeliverNonSeatSandboxUnchanged(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "ok"}}}
+	adapter := CodexAdapter{Runner: runner}
+	agent := Agent{
+		Name: "planner", Role: "planner", Runtime: CodexRuntime, RepoScope: "jerryfane/gitmoot",
+		RuntimeRef: "last", AutonomyPolicy: AutonomyPolicyReadOnly,
+	}
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "converse"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--sandbox", "read-only", "--json", "resume", "--last", "--", "converse")
+}
+
 func TestCodexStartRejectsMissingThreadID(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"type":"turn.completed"}` + "\n"}}}
 	adapter := CodexAdapter{Runner: runner}

--- a/internal/subprocess/group.go
+++ b/internal/subprocess/group.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -25,6 +26,15 @@ func (GroupRunner) Run(ctx context.Context, dir string, command string, args ...
 	return RunGroup(ctx, dir, command, args...)
 }
 
+// RunEnv gives GroupRunner the EnvRunner contract: process-group kill semantics
+// PLUS extra KEY=VALUE env vars appended to the inherited environment. It is what
+// the #732 chat relay uses to inject a moot seat's GITMOOT_CHAT_RELAY[_AUTH] into
+// the runtime subprocess without losing whole-tree cancellation. A nil/empty env
+// is byte-identical to Run.
+func (GroupRunner) RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error) {
+	return RunGroupEnv(ctx, dir, env, command, args...)
+}
+
 // RunStream gives GroupRunner the StreamRunner contract: process-group kill
 // semantics PLUS a live line-tee of the child's stdout/stderr to out. It is what
 // TeeRunner{} defaults to, so teeing a runtime adapter's output into a per-job
@@ -43,7 +53,17 @@ func (GroupRunner) LookPath(file string) (string, error) {
 // group, Go's WaitDelay reaps a stuck main child after the grace period, and a
 // final best-effort SIGKILL sweeps any group members that ignored SIGTERM.
 func RunGroup(ctx context.Context, dir string, command string, args ...string) (Result, error) {
+	return RunGroupEnv(ctx, dir, nil, command, args...)
+}
+
+// RunGroupEnv is RunGroup with extra KEY=VALUE env vars appended to the inherited
+// environment. A nil extraEnv leaves cmd.Env unset (the child inherits os.Environ
+// exactly as RunGroup did), so the env path is byte-identical when unused.
+func RunGroupEnv(ctx context.Context, dir string, extraEnv []string, command string, args ...string) (Result, error) {
 	cmd, sweep := newGroupCmd(ctx, dir, command, args)
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/subprocess/runner.go
+++ b/internal/subprocess/runner.go
@@ -87,6 +87,29 @@ func (t TeeRunner) LookPath(file string) (string, error) {
 	return t.inner().LookPath(file)
 }
 
+// EnvInjectingRunner wraps GroupRunner to always append Env (KEY=VALUE entries)
+// to the runtime subprocess environment while preserving process-group kill. The
+// #732 daemon dispatches a moot seat's runtime adapter with one of these so the
+// seat's GITMOOT_CHAT_RELAY[_AUTH] reaches its `gitmoot chat send/wait` subprocess
+// — ONLY for moot seats; a normal job's adapter keeps a nil runner (plain
+// GroupRunner) and is byte-identical. Env is applied on every Run/RunEnv call.
+type EnvInjectingRunner struct {
+	Env []string
+}
+
+func (r EnvInjectingRunner) Run(ctx context.Context, dir string, command string, args ...string) (Result, error) {
+	return RunGroupEnv(ctx, dir, r.Env, command, args...)
+}
+
+func (r EnvInjectingRunner) RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error) {
+	merged := append(append([]string{}, r.Env...), env...)
+	return RunGroupEnv(ctx, dir, merged, command, args...)
+}
+
+func (r EnvInjectingRunner) LookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}
+
 // SyncWriter serializes writes to w. Stream tees and any sibling writers
 // (e.g. a heartbeat ticker) sharing one destination should share one
 // SyncWriter, since destinations like bytes.Buffer are not safe for

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -181,6 +181,14 @@ type JobRequest struct {
 	// daemon terminal back-link posts the result into ThreadID when it is set.
 	ThreadID      string
 	ChatMessageID string
+	// MootSeat marks the job as a `gitmoot moot` conversing SEAT (#732) — the ONLY
+	// job class whose whole purpose is to run `gitmoot chat send/wait` mid-run and
+	// therefore needs the daemon relay (and, for codex, the sandbox elevation that
+	// reaches it). It is distinct from ThreadID, which every chat-linked job carries
+	// (chat-task promotions, ask-gate coordinator continuations, delegation children
+	// inheriting it for back-linking) but which must NOT trigger seat elevation. Set
+	// only by the moot dispatch; never inherited by continuations/children.
+	MootSeat bool
 }
 
 type JobPayload struct {
@@ -236,6 +244,12 @@ type JobPayload struct {
 	// message. Additive/omitempty: a non-chat job serializes byte-identically.
 	ThreadID      string       `json:"thread_id,omitempty"`
 	ChatMessageID string       `json:"chat_message_id,omitempty"`
+	// MootSeat marks a `gitmoot moot` conversing seat (#732): the daemon elevates
+	// ONLY these jobs (codex workspace-write+network to reach the relay socket) and
+	// injects the relay env into them. Additive/omitempty so every non-seat job —
+	// including chat-task promotions and continuations that carry ThreadID — is
+	// byte-identical. Never inherited by delegation children or continuations.
+	MootSeat bool `json:"moot_seat,omitempty"`
 	RawOutputs    []string     `json:"raw_outputs,omitempty"`
 	Result        *AgentResult `json:"result,omitempty"`
 	// ResultChecks, when non-empty, carries the deterministic binary-checklist
@@ -350,6 +364,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		RiskTier:               strings.TrimSpace(request.RiskTier),
 		ThreadID:               strings.TrimSpace(request.ThreadID),
 		ChatMessageID:          strings.TrimSpace(request.ChatMessageID),
+		MootSeat:               request.MootSeat,
 	})
 	if err != nil {
 		return db.Job{}, err

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1803,16 +1803,13 @@ gitmoot moot <name> "topic" --agents a,b,c --repo owner/repo [--max-messages N] 
   (what it knows / is unsure of / would ask next) as its `gitmoot_result`, which
   arrives via the `job_result` back-link path (the cap never blocks those). Human
   sends and seat conclusions are never gated by the cap.
-- **Daemon relay (sandboxed runtimes)**: a seat runs inside the runtime sandbox, which
-  makes the gitmoot home **read-only**, so a seat's `chat send` cannot write the store
-  directly. The daemon serves a local **unix-socket chat relay** and injects
-  `GITMOOT_CHAT_RELAY` (socket path) + `GITMOOT_CHAT_RELAY_AUTH` (a per-seat token,
-  bound to the seat's agent + thread) into the seat's runtime subprocess; `chat send` /
-  `chat wait` route to the (unsandboxed) daemon, which does the actual store write/read.
-  The home stays read-only — only the daemon writes. A human/CLI without those env vars
-  set takes the byte-identical direct-store path. Codex seats are additionally dispatched
-  `--sandbox workspace-write` with `network_access=true` (the only substrate that can
-  reach the socket; the home is still outside workspace-write's writable roots).
+- **Daemon relay**: seats converse **transparently** even under the runtime sandbox.
+  The daemon serves a local **unix-socket chat relay**, and each moot seat's `chat send`
+  / `chat wait` route through it to the (unsandboxed) daemon, which does the actual store
+  write/read (the daemon injects a scoped, per-seat token bound to that seat's agent +
+  thread). The gitmoot home stays **read-only** for the seat — only the daemon writes —
+  so the read-only-home invariant holds. A human/CLI takes the byte-identical
+  direct-store path.
 - **Concurrency requirement**: seats are top-level read-only same-repo jobs, so they
   converse concurrently **only** under the **pool scheduler with ≥2 workers** (start
   the daemon with `--parallel N`, or set `[daemon] parallel = N`; a per-repo

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1803,6 +1803,16 @@ gitmoot moot <name> "topic" --agents a,b,c --repo owner/repo [--max-messages N] 
   (what it knows / is unsure of / would ask next) as its `gitmoot_result`, which
   arrives via the `job_result` back-link path (the cap never blocks those). Human
   sends and seat conclusions are never gated by the cap.
+- **Daemon relay (sandboxed runtimes)**: a seat runs inside the runtime sandbox, which
+  makes the gitmoot home **read-only**, so a seat's `chat send` cannot write the store
+  directly. The daemon serves a local **unix-socket chat relay** and injects
+  `GITMOOT_CHAT_RELAY` (socket path) + `GITMOOT_CHAT_RELAY_AUTH` (a per-seat token,
+  bound to the seat's agent + thread) into the seat's runtime subprocess; `chat send` /
+  `chat wait` route to the (unsandboxed) daemon, which does the actual store write/read.
+  The home stays read-only — only the daemon writes. A human/CLI without those env vars
+  set takes the byte-identical direct-store path. Codex seats are additionally dispatched
+  `--sandbox workspace-write` with `network_access=true` (the only substrate that can
+  reach the socket; the home is still outside workspace-write's writable roots).
 - **Concurrency requirement**: seats are top-level read-only same-repo jobs, so they
   converse concurrently **only** under the **pool scheduler with ≥2 workers** (start
   the daemon with `--parallel N`, or set `[daemon] parallel = N`; a per-repo

--- a/website/docs/workflows/chat-workflow.md
+++ b/website/docs/workflows/chat-workflow.md
@@ -203,18 +203,14 @@ the thread by running `chat send` / `chat wait` as subprocesses. Because message
 are rows (free), the compute cost is exactly **one job per seat**, no matter how many
 messages they exchange.
 
-:::note Seats write through the daemon relay (sandboxed runtimes)
-A seat runs inside the runtime sandbox, which makes the gitmoot home **read-only**,
-so a seat's `chat send` cannot write the chat store directly. The daemon therefore
-serves a local **unix-socket chat relay**: for a moot seat it injects
-`GITMOOT_CHAT_RELAY` (the socket path) + `GITMOOT_CHAT_RELAY_AUTH` (a per-seat token)
-into the seat's runtime subprocess, and `chat send` / `chat wait` route the operation
-to the (unsandboxed) daemon, which performs the actual store write/read and returns
-the result. The home stays read-only — only the daemon writes. A human or CLI without
-those env vars set takes the byte-identical direct-store path. Codex seats are
-additionally dispatched `--sandbox workspace-write` with `network_access=true` (the
-only substrate that can reach the socket); the gitmoot home is still outside
-workspace-write's writable roots, so the read-only-home invariant holds.
+:::note Seats converse through the daemon relay
+Seats converse **transparently** even under the runtime sandbox: the daemon serves a
+local **unix-socket chat relay**, and each moot seat's `chat send` / `chat wait` route
+through it to the (unsandboxed) daemon, which performs the actual store write/read.
+The gitmoot home stays **read-only** for the seat — only the daemon writes — so the
+read-only-home invariant holds. This is fully automatic (the daemon injects a scoped,
+per-seat token bound to that seat's agent + thread); a human or CLI takes the
+byte-identical direct-store path.
 :::
 
 ```sh

--- a/website/docs/workflows/chat-workflow.md
+++ b/website/docs/workflows/chat-workflow.md
@@ -203,6 +203,20 @@ the thread by running `chat send` / `chat wait` as subprocesses. Because message
 are rows (free), the compute cost is exactly **one job per seat**, no matter how many
 messages they exchange.
 
+:::note Seats write through the daemon relay (sandboxed runtimes)
+A seat runs inside the runtime sandbox, which makes the gitmoot home **read-only**,
+so a seat's `chat send` cannot write the chat store directly. The daemon therefore
+serves a local **unix-socket chat relay**: for a moot seat it injects
+`GITMOOT_CHAT_RELAY` (the socket path) + `GITMOOT_CHAT_RELAY_AUTH` (a per-seat token)
+into the seat's runtime subprocess, and `chat send` / `chat wait` route the operation
+to the (unsandboxed) daemon, which performs the actual store write/read and returns
+the result. The home stays read-only — only the daemon writes. A human or CLI without
+those env vars set takes the byte-identical direct-store path. Codex seats are
+additionally dispatched `--sandbox workspace-write` with `network_access=true` (the
+only substrate that can reach the socket); the gitmoot home is still outside
+workspace-write's writable roots, so the read-only-home invariant holds.
+:::
+
 ```sh
 gitmoot moot paper-review "compare protocol options" \
   --agents alice,bob,researcher --repo owner/repo

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9744,6 +9744,13 @@ gitmoot moot <name> "topic" --agents a,b,c --repo owner/repo [--max-messages N] 
   (what it knows / is unsure of / would ask next) as its `gitmoot_result`, which
   arrives via the `job_result` back-link path (the cap never blocks those). Human
   sends and seat conclusions are never gated by the cap.
+- **Daemon relay**: seats converse **transparently** even under the runtime sandbox.
+  The daemon serves a local **unix-socket chat relay**, and each moot seat's `chat send`
+  / `chat wait` route through it to the (unsandboxed) daemon, which does the actual store
+  write/read (the daemon injects a scoped, per-seat token bound to that seat's agent +
+  thread). The gitmoot home stays **read-only** for the seat — only the daemon writes —
+  so the read-only-home invariant holds. A human/CLI takes the byte-identical
+  direct-store path.
 - **Concurrency requirement**: seats are top-level read-only same-repo jobs, so they
   converse concurrently **only** under the **pool scheduler with ≥2 workers** (start
   the daemon with `--parallel N`, or set `[daemon] parallel = N`; a per-repo


### PR DESCRIPTION
Fixes #732 — the V1.5 live-probe finding that moot seats can't converse because the runtime sandbox makes the gitmoot home read-only.

## The empirical discovery (scout)
Probed the **real codex sandbox** (codex-cli 0.142.4, bubblewrap+seccomp): under `--sandbox read-only` (what a moot ask-seat gets) the seccomp filter blocks the `connect()` syscall itself — **a socket in /tmp is just as blocked as one in the home**, and the `unix_sockets` allowlist knob doesn't help. `connect()` only works under `workspace-write` + `network_access=true`. So the fix must (a) run seats with that sandbox mode and (b) relay their chat writes through the daemon.

## The fix
- **Daemon relay** (`internal/cli/chat_relay.go`): the running daemon serves a unix socket (`<TMPDIR>/gitmoot-relay-<uid>-<home-hash>/chat.sock`, 0600, `SO_PEERCRED` peer-uid check) reusing its own `*db.Store`. Two ops — `send` (validated through the **same** repo-scope + capability + participant gate as `chat task`, then `AddChatMessage` as the requested `--as` author) and `wait` (ListChatMessages since seq). Per-seat token minted at dispatch; bad/absent token rejected.
- **Seat elevation, tightly scoped**: a dedicated `MootSeat` payload marker set **only** by `gitmoot moot` dispatch (never inherited by `chat task` promotions or coordinator continuations — the major review catch). Only a MootSeat with a successfully-minted token + injected relay env is elevated to codex workspace-write+network. **The gitmoot home stays outside workspace-write's writable roots**, so an elevated seat still can't write the home directly — its only path to the store is the validated relay.
- **`chat send`/`chat wait`**: relay iff `GITMOOT_CHAT_RELAY` is set; else byte-identical direct-DB path (human/CLI use unchanged, test-asserted).

## Verify
Scout (empirical real-codex-sandbox probe) → build → adversarial review (security/sandbox/protocol; 4 findings, 0 critical: over-broad elevation, socket-path clobber, elevation/injection decoupling, timeout-vs-retry — all fixed) → fixer. Full gate green; scoped race passed (22.3 min under headroom). Docs: sandbox caveat removed from both trees. **Acceptance test — a real codex moot that actually converses — runs post-deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)