### PR TITLE
fix(skillopt): local-review publish path + downgrade latch on definitive API rejections (#738)

### DIFF
--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2421,11 +2421,20 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			return skillOptTrainContinueOutput{}, err
 		}
 		updatedSummary := skillopt.BuildTrainStatusSummary(updatedSession, updatedIteration, updatedCounts)
-		lines := []string{
-			fmt.Sprintf("review: %s", result.URL),
-			fmt.Sprintf("review_repo: %s", result.Repo.FullName()),
-			fmt.Sprintf("preview_urls: %d", result.PreviewURLs),
-			"next: wait for feedback, then run train continue after sync",
+		var lines []string
+		if result.LocalSurface {
+			lines = []string{
+				"review_surface: local",
+				"review: local markdown import (feedback already imported)",
+				"next: run train continue to sync the imported feedback",
+			}
+		} else {
+			lines = []string{
+				fmt.Sprintf("review: %s", result.URL),
+				fmt.Sprintf("review_repo: %s", result.Repo.FullName()),
+				fmt.Sprintf("preview_urls: %d", result.PreviewURLs),
+				"next: wait for feedback, then run train continue after sync",
+			}
 		}
 		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
 	case skillopt.TrainStateReviewPublished:
@@ -6065,6 +6074,10 @@ type skillOptTrainReviewPublishResult struct {
 	IssueNumber int64
 	URL         string
 	PreviewURLs int
+	// LocalSurface is set when the review was recorded against the local markdown
+	// surface (#738) — the human already imported feedback (TrainingReady) before
+	// the publish step, so no GitHub issue was created and no watch was registered.
+	LocalSurface bool
 }
 
 type skillOptPreviewPublication struct {
@@ -6126,12 +6139,71 @@ func autoSyncSkillOptTrainReviewFeedback(ctx context.Context, paths config.Paths
 	return lines, result.Count() > 0
 }
 
+// maybePublishSkillOptTrainReviewLocally records the review against the local
+// markdown surface and advances to review_published when the iteration's eval run
+// already reports TrainingReady — i.e. the human imported feedback locally before
+// the publish step (#738). It reports ok=true only when it took the local path.
+//
+// When feedback is not yet ready it returns (_, false, nil) so the caller falls
+// through to the byte-identical GitHub publish path. It also declines the local
+// path (returns false) when a prior GitHub post actually completed but its state
+// update was interrupted (a published_external recovery marker): that real issue
+// must be honored via recover, not shadowed by a local record. Unlike the GitHub
+// path it registers NO review watch (there is no issue to poll) and writes review
+// metadata {status: published, review_surface: local}.
+func maybePublishSkillOptTrainReviewLocally(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (skillOptTrainReviewPublishResult, bool, error) {
+	status, err := loadSkillOptReviewStatus(ctx, store, artifact.NewStore(paths.ArtifactBlobs), iteration.EvalRunID)
+	if err != nil {
+		return skillOptTrainReviewPublishResult{}, false, err
+	}
+	if !status.TrainingReady {
+		return skillOptTrainReviewPublishResult{}, false, nil
+	}
+	if review, ok, rerr := readSkillOptTrainReviewRecovery(paths, session, iteration); rerr == nil && ok {
+		if metadataString(review, "status") == "published_external" {
+			return skillOptTrainReviewPublishResult{}, false, nil
+		}
+	}
+	localMetadata := map[string]any{
+		"status":         "published",
+		"review_surface": "local",
+		"preview_urls":   0,
+		"published_at":   time.Now().UTC().Format(time.RFC3339Nano),
+		"source":         "gitmoot skillopt train continue",
+	}
+	session.State = skillopt.TrainStateReviewPublished
+	iteration.State = skillopt.TrainStateReviewPublished
+	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "review", localMetadata)
+	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "review", localMetadata)
+	if err := store.UpsertSkillOptTrainSessionAndIteration(ctx, session, iteration); err != nil {
+		return skillOptTrainReviewPublishResult{}, false, err
+	}
+	_ = removeSkillOptTrainReviewRecovery(paths, session, iteration)
+	return skillOptTrainReviewPublishResult{LocalSurface: true}, true, nil
+}
+
 func publishSkillOptTrainReview(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration) (skillOptTrainReviewPublishResult, error) {
 	if err := skillopt.CanTransitionTrainIteration(iteration.State, skillopt.TrainStateReviewPublished); err != nil {
 		return skillOptTrainReviewPublishResult{}, err
 	}
 	if strings.TrimSpace(iteration.EvalRunID) == "" {
 		return skillOptTrainReviewPublishResult{}, fmt.Errorf("train iteration %s has no eval run id", iteration.ID)
+	}
+	// Local-review short-circuit (#738): publish is a review SURFACE, and the local
+	// markdown surface is already first-class for feedback import. If the human
+	// already imported feedback locally (the eval run reports TrainingReady) BEFORE
+	// this publish step, there is nothing to post — a GitHub issue would only be a
+	// doomed duplicate (its packet exceeds GitHub's 64KB issue-body limit anyway).
+	// Record the review as published against the local surface and advance to
+	// review_published without any GitHub call or watch registration; the next
+	// continue hop takes the existing TrainingReady -> feedback_synced path. This
+	// runs BEFORE recover, so it also unwedges a session whose prior GitHub attempt
+	// left a stale posting_external marker. When feedback is not yet ready this is a
+	// no-op and GitHub stays the default publish surface (byte-identical).
+	if local, ok, err := maybePublishSkillOptTrainReviewLocally(ctx, paths, store, session, iteration); err != nil {
+		return skillOptTrainReviewPublishResult{}, err
+	} else if ok {
+		return local, nil
 	}
 	if recovered, ok, err := recoverSkillOptTrainReviewPublication(ctx, paths, store, session, iteration); err != nil {
 		return skillOptTrainReviewPublishResult{}, err
@@ -6174,6 +6246,11 @@ func publishSkillOptTrainReview(ctx context.Context, paths config.Paths, store *
 	if err != nil {
 		return skillOptTrainReviewPublishResult{}, err
 	}
+	// TODO(#738 part 3): when body exceeds GitHub's ~64KB issue-body limit, degrade
+	// gracefully instead of letting CreateIssue 422 — post a summary issue plus the
+	// packet as trailing comments (each <=64KB) or a linked artifact. Until then a
+	// 422 is caught below and the marker is downgraded (part 2) so the retry falls
+	// through to the local surface when feedback is already imported (part 1).
 	postingMetadata := make(map[string]any, len(publishingMetadata)+2)
 	for key, value := range publishingMetadata {
 		postingMetadata[key] = value
@@ -6340,25 +6417,56 @@ func isExecLaunchFailure(err error) bool {
 }
 
 // downgradeReviewMarkerOnLaunchFailure clears the conservative posting_external
-// latch when the gh publish call failed to launch (fork/exec / ARG_MAX / missing
-// binary). Because the external GitHub post never started, no duplicate issue can
-// exist, so leaving the posting_external marker — which recover treats as "the
-// post may have happened, a human must inspect before retrying" — would wedge the
-// session behind a phantom duplicate. It rewrites the marker as failed_pre_exec,
-// which recover treats as "no external post occurred", so the next attempt
-// proceeds fresh. For every other error class (a timeout, a kill mid-flight) the
-// request may have reached GitHub, so the latch is deliberately left intact.
+// latch when the gh publish failed in a way that PROVES no GitHub issue was
+// created, so the next attempt can proceed fresh instead of wedging behind a
+// phantom duplicate. recover treats the posting_external marker as "the post may
+// have happened, a human must inspect before retrying"; both downgraded statuses
+// below fall outside {posting_external, published_external}, so recover reports
+// "no external post occurred" and lets the retry through.
+//
+// Two failure classes qualify:
+//   - an exec-launch failure (#734/#735): fork/exec / ARG_MAX / a missing binary —
+//     the gh child never started, so the request never left this machine. Marker
+//     rewritten as failed_pre_exec.
+//   - a definitive 4xx API rejection (#738): HTTP 422 validation (e.g. a body over
+//     GitHub's 64KB issue-body limit), 404, or 403 — gh ran and GitHub declined the
+//     request outright, so nothing was created. Marker rewritten as
+//     failed_external_rejected.
+//
+// Every ambiguous failure (a timeout, a mid-flight kill, a 5xx, a dropped socket)
+// may have reached GitHub and mutated state, so the latch is deliberately left
+// intact and a human must inspect before retrying.
 func downgradeReviewMarkerOnLaunchFailure(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, postingMetadata map[string]any, err error) {
-	if !isExecLaunchFailure(err) {
+	downgraded, ok := reviewMarkerDowngradeStatus(err)
+	if !ok {
 		return
 	}
 	failed := make(map[string]any, len(postingMetadata)+2)
 	for key, value := range postingMetadata {
 		failed[key] = value
 	}
-	failed["status"] = "failed_pre_exec"
-	failed["failed_pre_exec_at"] = time.Now().UTC().Format(time.RFC3339Nano)
+	failed["status"] = downgraded
+	failed["downgraded_at"] = time.Now().UTC().Format(time.RFC3339Nano)
 	_ = writeSkillOptTrainReviewRecovery(paths, session, iteration, failed)
+}
+
+// reviewMarkerDowngradeStatus reports the recovery-marker status a failed gh
+// publish should be downgraded to, and whether it qualifies for a downgrade at
+// all. It maps an exec-launch failure to failed_pre_exec and a definitive 4xx API
+// rejection to failed_external_rejected; every ambiguous failure returns ok=false
+// so the conservative posting_external latch is preserved (see
+// downgradeReviewMarkerOnLaunchFailure).
+func reviewMarkerDowngradeStatus(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	if isExecLaunchFailure(err) {
+		return "failed_pre_exec", true
+	}
+	if github.IsDefinitiveRejectionMessage(err.Error()) {
+		return "failed_external_rejected", true
+	}
+	return "", false
 }
 
 func writeSkillOptTrainReviewRecovery(paths config.Paths, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, metadata map[string]any) error {

--- a/internal/cli/skillopt_local_review_test.go
+++ b/internal/cli/skillopt_local_review_test.go
@@ -1,0 +1,408 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+// seedSkillOptTrainOptionsGeneratedForReview seeds a train session parked at
+// options_generated with an eval run whose review packet is ready. When
+// includeFeedback is true the run also carries an imported human feedback event,
+// so loadSkillOptReviewStatus reports TrainingReady (the local-review surface is
+// already complete, #738); when false the run is packet-ready but training-blocked
+// so GitHub stays the default publish surface. It returns the isolated home.
+func seedSkillOptTrainOptionsGeneratedForReview(t *testing.T, includeFeedback bool) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	if err := store.UpsertAgentTemplate(context.Background(), template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(context.Background(), "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	blobStore := artifact.NewStore(paths.ArtifactBlobs)
+	baselineBlob, err := blobStore.Put([]byte("# Baseline\n\nPlan the edit.\n"))
+	if err != nil {
+		t.Fatalf("Put baseline returned error: %v", err)
+	}
+	candidateBlob, err := blobStore.Put([]byte("# Candidate\n\nPlan the edit and verification.\n"))
+	if err != nil {
+		t.Fatalf("Put candidate returned error: %v", err)
+	}
+	for _, record := range []db.EvalArtifact{
+		{ID: "baseline-artifact", Hash: baselineBlob.Hash, MediaType: "text/markdown", SizeBytes: baselineBlob.Size, Driver: "text"},
+		{ID: "candidate-artifact", Hash: candidateBlob.Hash, MediaType: "text/markdown", SizeBytes: candidateBlob.Size, Driver: "text"},
+	} {
+		if err := store.UpsertEvalArtifact(context.Background(), record); err != nil {
+			t.Fatalf("UpsertEvalArtifact returned error: %v", err)
+		}
+	}
+	previewPolicy, err := skillopt.BuildTrainPreviewPolicy("owner/product", "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("BuildTrainPreviewPolicy returned error: %v", err)
+	}
+	metadata := skillOptTrainStartMetadata("Train planner outputs from human feedback.", db.EvalRunModeValidate, db.ExplorationLevelLow, 2, "hard_then_soft", nil, nil, previewPolicy, skillOptTrainStartConfigDefaults{}, nil)
+	session := db.SkillOptTrainSession{
+		ID:                "optimizer-train",
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/product",
+		RequestSummary:    "Train planner outputs from human feedback.",
+		TaskKind:          "custom",
+		State:             skillopt.TrainStateOptionsGenerated,
+		MetadataJSON:      metadata,
+	}
+	iteration := db.SkillOptTrainIteration{
+		ID:                    "optimizer-train-001",
+		SessionID:             session.ID,
+		EvalRunID:             "optimizer-train-review-001",
+		BaseTemplateVersionID: installed.VersionID,
+		Mode:                  db.EvalRunModeValidate,
+		ExplorationLevel:      db.ExplorationLevelLow,
+		State:                 skillopt.TrainStateOptionsGenerated,
+		MetadataJSON:          metadata,
+	}
+	run := db.EvalRun{
+		ID:                iteration.EvalRunID,
+		TemplateID:        "planner",
+		TemplateVersionID: installed.VersionID,
+		TargetRepo:        "owner/product",
+		State:             "review",
+		Mode:              db.EvalRunModeValidate,
+		ExplorationLevel:  db.ExplorationLevelLow,
+		OptionsCount:      2,
+		MetadataJSON:      metadata,
+	}
+	if err := store.UpsertSkillOptTrainSession(context.Background(), session); err != nil {
+		t.Fatalf("UpsertSkillOptTrainSession returned error: %v", err)
+	}
+	if err := store.UpsertSkillOptTrainIteration(context.Background(), iteration); err != nil {
+		t.Fatalf("UpsertSkillOptTrainIteration returned error: %v", err)
+	}
+	if err := store.UpsertEvalRun(context.Background(), run); err != nil {
+		t.Fatalf("UpsertEvalRun returned error: %v", err)
+	}
+	if err := store.UpsertEvalReviewItem(context.Background(), db.EvalReviewItem{
+		RunID:               run.ID,
+		ItemID:              "item-001",
+		Title:               "README plan",
+		BaselineArtifactID:  "baseline-artifact",
+		CandidateArtifactID: "candidate-artifact",
+	}); err != nil {
+		t.Fatalf("UpsertEvalReviewItem returned error: %v", err)
+	}
+	if includeFeedback {
+		if err := store.UpsertFeedbackEvent(context.Background(), db.FeedbackEvent{
+			RunID:     run.ID,
+			ItemID:    "item-001",
+			Choice:    "b",
+			Reasoning: "Candidate is more complete.",
+			Reviewer:  "markdown:jerry",
+			Source:    "markdown",
+			SourceURL: "local://feedback.md",
+			CreatedAt: "2026-07-08T10:00:00Z",
+		}); err != nil {
+			t.Fatalf("UpsertFeedbackEvent returned error: %v", err)
+		}
+	}
+	return home
+}
+
+// recordingGitHubClientFactory installs a newSkillOptGitHubClient factory that
+// counts constructions and hands back a call-recording fake, restoring the prior
+// factory on cleanup. A local-review continue hop (#738) must never construct a
+// client; *constructed stays 0 and the fake's fields stay empty.
+func recordingGitHubClientFactory(t *testing.T) (constructed *int, fake **skillOptFakeGitHub) {
+	t.Helper()
+	var count int
+	shared := &skillOptFakeGitHub{}
+	prev := newSkillOptGitHubClient
+	newSkillOptGitHubClient = func() github.Client {
+		count++
+		return shared
+	}
+	t.Cleanup(func() { newSkillOptGitHubClient = prev })
+	return &count, &shared
+}
+
+// TestSkillOptTrainContinueLocalReviewSkipsGitHub asserts that when the eval run is
+// already TrainingReady at the publish step, `train continue` records the review
+// against the local surface and advances to review_published without constructing
+// a GitHub client or registering a review watch (#738, scenario a).
+func TestSkillOptTrainContinueLocalReviewSkipsGitHub(t *testing.T) {
+	home := seedSkillOptTrainOptionsGeneratedForReview(t, true)
+	constructed, fake := recordingGitHubClientFactory(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: review_published",
+		"review_surface: local",
+		"continue_ready: true",
+		"next: run train continue to sync the imported feedback",
+	} {
+		if !bytes.Contains(stdout.Bytes(), []byte(want)) {
+			t.Fatalf("train continue stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if *constructed != 0 {
+		t.Fatalf("GitHub client constructed %d times on the local-review path, want 0", *constructed)
+	}
+	if len((*fake).preflightRepos) != 0 || (*fake).createdIssue.Repo.FullName() != "" {
+		t.Fatalf("GitHub was invoked on the local-review path: preflight=%+v issue=%+v", (*fake).preflightRepos, (*fake).createdIssue)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if session.State != skillopt.TrainStateReviewPublished || iteration.State != skillopt.TrainStateReviewPublished {
+		t.Fatalf("states = session %s iteration %s, want review_published", session.State, iteration.State)
+	}
+	for _, want := range []string{`"review_surface":"local"`, `"status":"published"`} {
+		if !bytes.Contains([]byte(iteration.MetadataJSON), []byte(want)) {
+			t.Fatalf("iteration metadata missing %q: %s", want, iteration.MetadataJSON)
+		}
+		if !bytes.Contains([]byte(session.MetadataJSON), []byte(want)) {
+			t.Fatalf("session metadata missing %q: %s", want, session.MetadataJSON)
+		}
+	}
+	// No GitHub issue was recorded and no review watch was registered.
+	if iteration.IssueRepo != "" || iteration.IssueNumber != 0 || iteration.IssueURL != "" {
+		t.Fatalf("local review recorded a GitHub issue: repo=%q number=%d url=%q", iteration.IssueRepo, iteration.IssueNumber, iteration.IssueURL)
+	}
+	watches, err := store.ListSkillOptReviewWatches(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(watches) != 0 {
+		t.Fatalf("local review registered %d watches, want 0: %+v", len(watches), watches)
+	}
+}
+
+// TestSkillOptTrainContinuePublishesToGitHubWhenFeedbackNotReady is the regression
+// guard for #738: when feedback is not yet imported at the publish step, continue
+// must still publish the review packet to GitHub exactly as before — construct the
+// client, create the issue, register a watch, and advance to review_published.
+func TestSkillOptTrainContinuePublishesToGitHubWhenFeedbackNotReady(t *testing.T) {
+	home := seedSkillOptTrainOptionsGeneratedForReview(t, false)
+	constructed, fake := recordingGitHubClientFactory(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("train continue exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: review_published",
+		"review_repo: owner/product",
+		"preview_urls: 0",
+		"next: wait for feedback, then run train continue after sync",
+	} {
+		if !bytes.Contains(stdout.Bytes(), []byte(want)) {
+			t.Fatalf("train continue stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	if bytes.Contains(stdout.Bytes(), []byte("review_surface: local")) {
+		t.Fatalf("GitHub publish path emitted a local-surface line:\n%s", stdout.String())
+	}
+	if *constructed == 0 {
+		t.Fatal("GitHub client was never constructed on the not-ready publish path")
+	}
+	if (*fake).createdIssue.Repo.FullName() != "owner/product" {
+		t.Fatalf("review issue was not created on the not-ready path: %+v", (*fake).createdIssue)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if iteration.State != skillopt.TrainStateReviewPublished {
+		t.Fatalf("iteration state = %s, want review_published", iteration.State)
+	}
+	if iteration.IssueRepo != "owner/product" || iteration.IssueNumber != 8 {
+		t.Fatalf("GitHub issue not recorded: repo=%q number=%d", iteration.IssueRepo, iteration.IssueNumber)
+	}
+	if bytes.Contains([]byte(iteration.MetadataJSON), []byte(`"review_surface":"local"`)) {
+		t.Fatalf("GitHub publish recorded a local surface: %s", iteration.MetadataJSON)
+	}
+	watches, err := store.ListSkillOptReviewWatches(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListSkillOptReviewWatches returned error: %v", err)
+	}
+	if len(watches) != 1 {
+		t.Fatalf("GitHub publish registered %d watches, want 1", len(watches))
+	}
+}
+
+// TestDowngradeReviewMarkerOnDefinitiveRejection asserts #738 part 2: a definitive
+// 4xx API rejection (422/404/403) downgrades the posting_external latch so the next
+// attempt proceeds fresh, while an ambiguous failure (5xx/timeout) preserves it.
+func TestDowngradeReviewMarkerOnDefinitiveRejection(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	session := db.SkillOptTrainSession{ID: "sess-738"}
+	iteration := db.SkillOptTrainIteration{ID: "iter-738"}
+	posting := map[string]any{
+		"status":                   "posting_external",
+		"repo":                     "owner/reviews",
+		"external_post_started_at": "2026-07-08T00:00:00Z",
+	}
+	writePosting := func(t *testing.T) {
+		t.Helper()
+		if err := writeSkillOptTrainReviewRecovery(paths, session, iteration, posting); err != nil {
+			t.Fatalf("write posting_external marker: %v", err)
+		}
+	}
+	markerStatus := func(t *testing.T) string {
+		t.Helper()
+		review, ok, err := readSkillOptTrainReviewRecovery(paths, session, iteration)
+		if err != nil {
+			t.Fatalf("read recovery marker: %v", err)
+		}
+		if !ok {
+			return "<absent>"
+		}
+		return metadataString(review, "status")
+	}
+
+	downgrades := []struct {
+		name string
+		err  error
+	}{
+		{"http 422 validation", errors.New("gh: Validation Failed (HTTP 422): exit status 1")},
+		{"http 404 repo", errors.New("HTTP 404: Not Found (https://api.github.com/...): exit status 1")},
+		{"http 403 forbidden", errors.New("HTTP 403: Resource not accessible by integration: exit status 1")},
+	}
+	for _, tc := range downgrades {
+		t.Run(tc.name+" clears the latch and permits a retry", func(t *testing.T) {
+			writePosting(t)
+			downgradeReviewMarkerOnLaunchFailure(paths, session, iteration, posting, tc.err)
+			if got := markerStatus(t); got != "failed_external_rejected" {
+				t.Fatalf("marker status after definitive rejection = %q, want failed_external_rejected", got)
+			}
+			_, ok, err := recoverSkillOptTrainReviewPublication(context.Background(), paths, (*db.Store)(nil), session, iteration)
+			if err != nil {
+				t.Fatalf("recover after downgrade returned error: %v", err)
+			}
+			if ok {
+				t.Fatal("recover latched a downgraded marker; a retry must be permitted")
+			}
+		})
+	}
+
+	ambiguous := []struct {
+		name string
+		err  error
+	}{
+		{"http 502 gateway", errors.New("HTTP 502 Bad Gateway: exit status 1")},
+		{"http 503 unavailable", errors.New("HTTP 503 Service Unavailable: exit status 1")},
+		{"mid-flight timeout", errors.New("context deadline exceeded")},
+		{"killed mid-flight", errors.New("signal: killed")},
+		{"socket drop", errors.New("unexpected EOF")},
+	}
+	for _, tc := range ambiguous {
+		t.Run(tc.name+" preserves the conservative latch", func(t *testing.T) {
+			writePosting(t)
+			downgradeReviewMarkerOnLaunchFailure(paths, session, iteration, posting, tc.err)
+			if got := markerStatus(t); got != "posting_external" {
+				t.Fatalf("marker status after ambiguous failure = %q, want posting_external", got)
+			}
+			_, ok, err := recoverSkillOptTrainReviewPublication(context.Background(), paths, (*db.Store)(nil), session, iteration)
+			if err == nil {
+				t.Fatal("recover did not latch posting_external; duplicate-issue guard lost")
+			}
+			if !ok {
+				t.Fatal("recover should report ok=true when latched")
+			}
+		})
+	}
+}
+
+// TestSkillOptTrainContinueLocalReviewEndToEnd drives the full local-review path
+// (#738, scenario d): a session parked at options_generated with imported
+// TrainingReady feedback reaches feedback_synced across two continue hops without
+// ever constructing a GitHub client.
+func TestSkillOptTrainContinueLocalReviewEndToEnd(t *testing.T) {
+	home := seedSkillOptTrainOptionsGeneratedForReview(t, true)
+	constructed, fake := recordingGitHubClientFactory(t)
+
+	// Hop 1: options_generated -> review_published (local surface, no GitHub).
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("hop 1 exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("current_phase: review_published")) ||
+		!bytes.Contains(stdout.Bytes(), []byte("review_surface: local")) {
+		t.Fatalf("hop 1 stdout = %s", stdout.String())
+	}
+
+	// Hop 2: review_published -> feedback_synced (feedback already imported).
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"skillopt", "train", "continue", "--home", home, "--session", "optimizer-train"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("hop 2 exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"current_phase: feedback_synced",
+		"feedback_events: 1",
+		"next: export the training package before running the optimizer",
+	} {
+		if !bytes.Contains(stdout.Bytes(), []byte(want)) {
+			t.Fatalf("hop 2 stdout missing %q:\n%s", want, stdout.String())
+		}
+	}
+	// No GitHub feedback sync should have run on the local path.
+	if bytes.Contains(stdout.Bytes(), []byte("github_feedback_sync")) {
+		t.Fatalf("hop 2 attempted a GitHub feedback sync on the local path:\n%s", stdout.String())
+	}
+	if *constructed != 0 {
+		t.Fatalf("GitHub client constructed %d times across the local-review E2E, want 0", *constructed)
+	}
+	if len((*fake).preflightRepos) != 0 || (*fake).createdIssue.Repo.FullName() != "" {
+		t.Fatalf("GitHub was invoked across the local-review E2E: preflight=%+v issue=%+v", (*fake).preflightRepos, (*fake).createdIssue)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	session, err := store.GetSkillOptTrainSession(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetSkillOptTrainSession returned error: %v", err)
+	}
+	iteration, err := store.GetLatestSkillOptTrainIteration(context.Background(), "optimizer-train")
+	if err != nil {
+		t.Fatalf("GetLatestSkillOptTrainIteration returned error: %v", err)
+	}
+	if session.State != skillopt.TrainStateFeedbackSynced || iteration.State != skillopt.TrainStateFeedbackSynced {
+		t.Fatalf("states = session %s iteration %s, want feedback_synced", session.State, iteration.State)
+	}
+}

--- a/internal/github/errors.go
+++ b/internal/github/errors.go
@@ -84,6 +84,44 @@ var transientSignatures = []string{
 	"internal server error", // gh's phrasing for a 5xx api response
 }
 
+// definitiveRejectionSignatures are gh-CLI 4xx client-error signatures that prove
+// the request reached GitHub and was REJECTED before it could create anything: a
+// validation failure (422, e.g. a body over the 64KB issue-body limit — #738), a
+// missing repo/endpoint (404), or a permission denial (403). Unlike a transient
+// failure (a 5xx, a socket drop, a timeout — see transientSignatures) which MAY
+// have mutated state, a definitive rejection is safe to treat as "no resource was
+// created" — so a caller holding a conservative duplicate-guard latch can clear it
+// and retry. gh prints these as "HTTP 422", "Validation Failed", "HTTP 404",
+// "HTTP 403" (the phrasing #738's trace captured: `gh: Validation Failed (HTTP 422)`).
+var definitiveRejectionSignatures = []string{
+	"http 422",
+	"validation failed",
+	"http 404",
+	"http 403",
+}
+
+// IsDefinitiveRejectionMessage reports whether a gh-CLI failure message carries a
+// definitive 4xx client-rejection signature (422 validation / 404 / 403). Such a
+// rejection means GitHub declined the request outright, so no issue/PR/comment was
+// created — the opposite of an ambiguous transient failure (5xx/network/timeout),
+// which may have mutated state before failing. A message that ALSO carries a
+// transient signature is treated as ambiguous (returns false) so a conservative
+// duplicate-guard latch is preserved; the two signature sets are otherwise
+// disjoint (4xx vs 5xx/transport). It is the definitive-rejection counterpart of
+// IsTransientMessage and, like it, keys off exactly one grounded signature set.
+func IsDefinitiveRejectionMessage(text string) bool {
+	if IsTransientMessage(text) {
+		return false
+	}
+	l := strings.ToLower(text)
+	for _, sig := range definitiveRejectionSignatures {
+		if strings.Contains(l, sig) {
+			return true
+		}
+	}
+	return false
+}
+
 // classifyTransientError wraps a gh commandError in a TransientError when the
 // command's output carries a network-outage signature, leaving every other
 // failure (and its exact text) untouched. Called from GhClient.run so any gh call

--- a/internal/github/errors_test.go
+++ b/internal/github/errors_test.go
@@ -38,6 +38,38 @@ func TestIsTransientMessage(t *testing.T) {
 	}
 }
 
+func TestIsDefinitiveRejectionMessage(t *testing.T) {
+	definitive := []string{
+		"gh: Validation Failed (HTTP 422)",
+		"HTTP 422: Validation Failed",
+		"HTTP 404: Not Found",
+		"HTTP 403: Resource not accessible by integration",
+		"body is too long (maximum is 65536 characters) validation failed",
+	}
+	for _, s := range definitive {
+		if !IsDefinitiveRejectionMessage(s) {
+			t.Errorf("IsDefinitiveRejectionMessage(%q) = false, want true", s)
+		}
+	}
+	ambiguous := []string{
+		"dial tcp 140.82.121.3:443: connect: connection refused",
+		"HTTP 502 Bad Gateway",
+		"HTTP 503 Service Unavailable",
+		"HTTP 504 Gateway Timeout",
+		"context deadline exceeded",
+		"signal: killed",
+		"unexpected EOF",
+		"gh: authentication required",
+		"nothing to commit",
+		"",
+	}
+	for _, s := range ambiguous {
+		if IsDefinitiveRejectionMessage(s) {
+			t.Errorf("IsDefinitiveRejectionMessage(%q) = true, want false", s)
+		}
+	}
+}
+
 func TestClassifyTransientError(t *testing.T) {
 	base := errors.New("boom: exit status 1")
 	t.Run("network signature is tagged transient and stays transparent", func(t *testing.T) {


### PR DESCRIPTION
Closes #738

## Problem
A live training session wedged: its human feedback was already `TrainingReady` (ranked + pairwise imported via `feedback markdown import`), but `train continue` could not reach `review_published` without a successful GitHub post — and the post 422'd because the review packet exceeds GitHub's 65,536-char issue-body limit. Two root causes.

## 1. Local-review path in the state machine
`publishSkillOptTrainReview` now checks `loadSkillOptReviewStatus` for the iteration's eval run **before** attempting the GitHub post. If `status.TrainingReady` is already true, it records the review against the local surface (metadata `{status: published, review_surface: local}`), registers **no** GitHub watch, transitions to `review_published`, and returns a `LocalSurface` result. The next `train continue` hop takes the existing `TrainingReady -> feedback_synced` path.

- The check runs before `recoverSkillOptTrainReviewPublication`, so it also unwedges a session left with a stale `posting_external` marker.
- A pending `published_external` recovery marker (a real GitHub post that only needs a state-resume) is still honored via recover, not shadowed by a local record.
- When feedback is **not** yet ready, behavior is byte-identical: GitHub stays the default surface (publish-first / sync-skipped-after preserved).

## 2. Latch downgrade for definitive rejections
Extends #735's `downgradeReviewMarkerOnLaunchFailure`: a definitive 4xx API rejection (HTTP 422 validation / 404 / 403) — which proves no issue was created — now also downgrades the `posting_external` marker (status `failed_external_rejected`) so the retry proceeds. Ambiguous failures (timeouts, kills, 5xx, socket drops) keep the conservative latch. Grounded in a new `github.IsDefinitiveRejectionMessage` classifier that sits alongside `IsTransientMessage` (disjoint 4xx vs 5xx/transport signature sets).

## 3. Size-aware degradation (nice-to-have)
Left as a code `TODO(#738 part 3)` at the publish site — non-trivial (summary issue + trailing comments/artifact). Parts 1+2 already resolve the wedge for the reported scenario.

## Tests (deterministic, no network)
- `TestSkillOptTrainContinueLocalReviewSkipsGitHub` — TrainingReady-before-publish → continue skips GitHub (no client constructed), metadata carries `review_surface: local`, state → `review_published`, no watch registered.
- `TestSkillOptTrainContinuePublishesToGitHubWhenFeedbackNotReady` — not-ready → GitHub publish path invoked exactly as before (regression).
- `TestDowngradeReviewMarkerOnDefinitiveRejection` — 422/404/403 downgrade + retry proceeds; 5xx/timeout/killed/socket preserve the latch.
- `TestSkillOptTrainContinueLocalReviewEndToEnd` — full local path: seeded `options_generated` with imported TrainingReady feedback → two continue hops reach `feedback_synced` with zero GitHub calls.
- `TestIsDefinitiveRejectionMessage` (internal/github) — classifier unit coverage.

## Gate
- `go build ./...` OK
- `go vet ./...` OK
- `go test -count=1 ./internal/cli/` OK (211.99s)
- `go test -count=1 ./internal/github/` OK; `go test -race ./internal/github/` OK
- scoped `-race` on the new cli tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)