### PR TITLE
ci: split internal/cli race suite into its own parallel job (#733)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,21 +49,46 @@ jobs:
       - name: Test
         run: go test ./...
 
-      - name: Test (race detector, workflow engine + cli + db + daemon)
-        # internal/cli is race-tested too because the #484 canary auto-rollback
-        # decorator (canary_daemon.go) carries a concurrency contract — the daemon
-        # runs jobs in a parallel worker pool, so two same-template harvests can
-        # race to roll back the same canary and `candidate.rolled_back` must still
-        # fire exactly once. TestCanaryLifecycleE2E's concurrent subtest asserts
-        # that dedup, so it belongs under the detector.
-        #
+      - name: Test (race detector, workflow engine + db + daemon)
         # internal/db and internal/daemon are race-tested because the #536 stale-
         # recovery / worktree-cleanup fix adds concurrency-sensitive resource_locks
         # reads (JobRuntimeLockLiveness, DeleteExpiredResourceLocks) that the daemon
         # worker pool exercises from multiple goroutines.
         #
-        # -timeout 20m: internal/cli is a large suite and the race detector runs
-        # it ~10x slower, so it sits right on Go's default 10m/package deadline —
-        # adding a handful of new tests intermittently tips it over (a timeout, not
-        # a real race). The explicit bound gives headroom without masking a hang.
-        run: go test -race -timeout 20m ./internal/workflow/ ./internal/cli/ ./internal/db/ ./internal/daemon/
+        # internal/cli is race-tested too, but it has outgrown the shared 20m bound
+        # (#733): under -race it alone takes ~17-21m and intermittently timed out
+        # here (a timeout goroutine dump, not a real race). It now runs in its own
+        # parallel `race-cli` job below with a 35m timeout, so a slow runner can no
+        # longer fail green code and total wall-time stays ≈ max(jobs), not the sum.
+        #
+        # -timeout 20m: these three suites are comfortably under Go's default
+        # 10m/package deadline even under the ~10x race slowdown; the explicit
+        # bound gives headroom without masking a hang.
+        run: go test -race -timeout 20m ./internal/workflow/ ./internal/db/ ./internal/daemon/
+
+  race-cli:
+    name: race (internal/cli)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test (race detector, internal/cli)
+        # internal/cli is the mega-package: the #484 canary auto-rollback decorator
+        # (canary_daemon.go) carries a concurrency contract — the daemon runs jobs
+        # in a parallel worker pool, so two same-template harvests can race to roll
+        # back the same canary and `candidate.rolled_back` must still fire exactly
+        # once. TestCanaryLifecycleE2E's concurrent subtest asserts that dedup, so
+        # it belongs under the detector.
+        #
+        # Split into its own job (#733) because every wave adds tests here and the
+        # suite under -race runs ~17-21m — it repeatedly tipped the shared 20m step
+        # over on loaded runners (a timeout, not a data race). -timeout 35m gives
+        # ample headroom while still surfacing a genuine hang.
+        run: go test -race -timeout 35m ./internal/cli/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,10 @@ go build ./...
 go generate ./... && git diff --exit-code   # gitmoot_result contract is single-sourced + regenerated; stale artifact fails CI
 go vet ./...
 go test ./...
-# Race gate is scoped (not ./...) with a 20m timeout — matches CI exactly:
-go test -race -timeout 20m ./internal/workflow/ ./internal/cli/ ./internal/db/ ./internal/daemon/
+# Race gate is scoped (not ./...). CI splits it across two parallel jobs (#733):
+# `build / vet / test` runs workflow+db+daemon at 20m, `race (internal/cli)` runs
+# the mega-package on its own at 35m. Locally you can run all four at once:
+go test -race -timeout 35m ./internal/workflow/ ./internal/cli/ ./internal/db/ ./internal/daemon/
 ```
 
 The CLI entrypoint lives under `cmd/gitmoot/`. The CI gate is Go-only — it does

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,16 @@ build/vet/test gate on every push to `main` and every pull request. The
 go build ./...
 go vet ./...
 go test ./...
-go test -race ./internal/workflow/
+go test -race -timeout 20m ./internal/workflow/ ./internal/db/ ./internal/daemon/
 ```
 
-The race detector covers the workflow engine. CI does not run the live
+A second parallel job, `race (internal/cli)`, runs the `internal/cli` race suite
+on its own with a 35m timeout — it has outgrown the shared 20m bound (#733), so
+splitting it keeps a slow runner from failing green code while total wall-time
+stays roughly the max of the two jobs rather than their sum.
+
+The race detector covers the workflow engine and the concurrency-sensitive
+core packages. CI does not run the live
 multi-runtime (codex/claude/kimi) E2E — that needs runtime auth and stays a
 manual step.
 


### PR DESCRIPTION
## What
Splits the CI race step so `internal/cli` runs under the race detector in its **own parallel job** (`race (internal/cli)`, `-timeout 35m`), while `internal/workflow`, `internal/db`, and `internal/daemon` stay in the existing `build / vet / test` job's race step at `-timeout 20m`.

## Why
The shared step `go test -race -timeout 20m ./internal/workflow/ ./internal/cli/ ./internal/db/ ./internal/daemon/` has started flaking. `internal/cli` is the mega-package — every wave adds tests — and under `-race` it alone takes ~17-21m. PR #730's run hit `panic: test timed out after 20m0s` / `FAIL internal/cli 1200.036s` (a timeout goroutine dump, not a data race; build/vet/full-test were green, scoped race clean). #729 passed at 21m11s, right at the edge. A slow/loaded runner was failing green code.

## How
- New `race-cli` job (`name: race (internal/cli)`) on `ubuntu-latest`, mirroring the existing job's `checkout` + `setup-go` (with `cache: true`) steps exactly, then `go test -race -timeout 35m ./internal/cli/`.
- Existing race step reduced to the other three packages at `-timeout 20m` and re-commented.
- A separate **job** (not step) means total wall-time ≈ max(jobs), not the sum.
- Docs updated in the same PR: `AGENTS.md` and `CONTRIBUTING.md` now describe the two-job split. No Go code changes.

The old required check name `build / vet / test` is **unchanged** (that job still exists), so existing branch protection keeps working. A **new** check `race (internal/cli)` is introduced — if the owner has required-status-checks configured in GitHub branch-protection settings, they may need to add `race (internal/cli)` to the required list after merge (a GitHub-settings click, not a code change).

## How tested
- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml'))"` → **parses; jobs = ['build-test', 'race-cli']**.
- `actionlint` → **not on PATH in this environment (best-effort skip)**.
- No Go source touched, so no package-level Go gate applies.
- **The PR's own CI run is the real validation**: reviewer/owner must confirm **BOTH** the `build / vet / test` job **and** the new `race (internal/cli)` job ran green on this PR before merging.

Closes #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)