### PR TITLE
fix(scheduler): deterministic per-job worktrees for contended same-repo read-only jobs (#739)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -235,6 +235,15 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		ReadOnlyWorktree:       readOnlyWorktreePath != "",
 	})
 	if err != nil {
+		// #739: the read-only worktree is created on disk BEFORE Enqueue. If Enqueue
+		// fails there is no job row, so neither the terminal AdvanceJob cleanup nor the
+		// daemon reclaim pass will ever dispose it — roll it back here or it leaks a
+		// detached worktree (+ its .git/worktrees admin entry) with no owner. Detached
+		// from the (possibly cancelled) request context so removal still runs; the
+		// reactive pool-isolation path defends its own allocation the same way.
+		if readOnlyWorktreePath != "" {
+			_ = gitutil.Client{Dir: record.CheckoutPath}.RemoveWorktreeForce(context.WithoutCancel(ctx), readOnlyWorktreePath)
+		}
 		return localAgentJobOutput{}, err
 	}
 	if err := releaseReservation(ctx); err != nil {
@@ -1175,7 +1184,7 @@ func maybeAllocateDispatchReadOnlyWorktree(ctx context.Context, store *db.Store,
 	// always resolvable, avoiding the stale current-branch fragility the researchers
 	// flagged. The #654 context note points the job at the canonical checkout for
 	// uncommitted/gitignored paths.
-	return workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, repo, checkout, jobID, "readonly-seat", 0, "", gitutil.Client{Dir: checkout})
+	return workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, repo, checkout, jobID, "readonly-seat", 0, "", workflow.ReadOnlyWorktreeDispatchLockWaitBudget, gitutil.Client{Dir: checkout})
 }
 
 func printLocalAgentJobOutput(stdout io.Writer, output localAgentJobOutput) {

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -183,8 +183,31 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 		recipeTemplate = &tmpl
 	}
+	// #739: give a BACKGROUND read-only (ask) job its own detached committed-tip
+	// worktree BEFORE enqueue — the proven read-only delegation fan-out shape — so
+	// its checkout key is worktree:<path> (queuedJobCheckoutKey) and same-repo
+	// seats (moot, chat-task, autorespond, `agent ask --background`) run
+	// concurrently instead of serializing on the shared repo:<repo> key. Foreground
+	// asks run inline and never serialize, so they are left untouched. Review is
+	// excluded because it already carries a per-PR task worktree (TaskID set) that
+	// keys it off its own worktree. FAIL-OPEN: on any allocation failure the job is
+	// enqueued unchanged (shared checkout, serialized) with a loud skip event —
+	// dispatch never fails for a lost-parallelism optimization.
+	jobID := localAgentJobID(request.Action, agent.Name)
+	readOnlyWorktreePath, readOnlyWorktreeErr := maybeAllocateDispatchReadOnlyWorktree(ctx, store, request, repo.FullName(), record.CheckoutPath, jobID)
+	if readOnlyWorktreePath != "" {
+		// The detached worktree is the committed tip of the checkout HEAD, which may
+		// have advanced past any inherited HeadSHA. Clear it so the job validates
+		// against its own fresh worktree HEAD (matching the delegation path). The
+		// worktree omits gitignored (repos/**) and uncommitted working-tree files, so
+		// point the job at the canonical base checkout for those (#654).
+		request.HeadSHA = ""
+		if note := workflow.ReadOnlyWorktreeContextNote(record.CheckoutPath); note != "" {
+			request.Instructions += note
+		}
+	}
 	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home)}).Enqueue(ctx, workflow.JobRequest{
-		ID:                     localAgentJobID(request.Action, agent.Name),
+		ID:                     jobID,
 		Agent:                  agent.Name,
 		Action:                 request.Action,
 		Repo:                   repo.FullName(),
@@ -208,6 +231,8 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		ThreadID:               request.ThreadID,
 		ChatMessageID:          request.ChatMessageID,
 		MootSeat:               request.MootSeat,
+		WorktreePath:           readOnlyWorktreePath,
+		ReadOnlyWorktree:       readOnlyWorktreePath != "",
 	})
 	if err != nil {
 		return localAgentJobOutput{}, err
@@ -217,6 +242,14 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	}
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
 		return localAgentJobOutput{}, err
+	}
+	// Emit the #739 read-only isolation outcome now that the job row exists (job
+	// events carry a JobID FK). Allocated → observable worktree:<path> key; a
+	// fail-open skip → loud event so a lost-parallelism serialize is never silent.
+	if readOnlyWorktreePath != "" {
+		_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_worktree_allocated", Message: fmt.Sprintf("read-only worktree %s allocated at dispatch (#739); job keyed worktree:<path> to run beside same-repo seats", readOnlyWorktreePath)})
+	} else if readOnlyWorktreeErr != nil {
+		_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_worktree_skipped", Message: fmt.Sprintf("read-only worktree isolation skipped (#739); job runs serialized in the shared checkout: %v", readOnlyWorktreeErr)})
 	}
 	if overrideRuntime == "" {
 		effectiveAgent = scopeRegisteredFreshRefForJob(effectiveAgent, job.ID)
@@ -1096,6 +1129,53 @@ func ensureLocalAgentAccess(ctx context.Context, store *db.Store, agent db.Agent
 
 func localAgentJobID(action string, agent string) string {
 	return fmt.Sprintf("local-%s-%s-%x", action, agent, time.Now().UTC().UnixNano())
+}
+
+// dispatchReadOnlyWorktreeEligible reports whether a dispatch should allocate a
+// dedicated detached committed-tip worktree for read-only isolation (#739). It is
+// true ONLY for a BACKGROUND read-only (ask/review) job that does not already
+// carry a task worktree: a foreground ask runs inline and never serializes, and a
+// job with a TaskID (every `agent review`, which prepares a per-PR worktree
+// upstream) is already keyed off its own worktree. Mirrors poolIsolationEligible.
+func dispatchReadOnlyWorktreeEligible(request localAgentDispatchRequest) bool {
+	if !request.Background {
+		return false
+	}
+	switch strings.TrimSpace(request.Action) {
+	case "ask", "review":
+	default:
+		return false
+	}
+	return strings.TrimSpace(request.TaskID) == ""
+}
+
+// maybeAllocateDispatchReadOnlyWorktree allocates a throwaway detached
+// committed-tip worktree for an eligible background read-only job so it is born
+// with a distinct worktree:<path> checkout key (#739). It resolves the ref to the
+// checkout HEAD (always resolvable — the researchers' diagnostic showed the
+// stale-branch ref is a red herring; the real trigger was the reactive path being
+// headroom-gated and silent) via the shared workflow.AllocateReadOnlyWorktree
+// primitive, holding the checkout mutation lock. It is FAIL-OPEN: it returns
+// ("", nil) when the job is ineligible or the checkout is unknown, and ("", err)
+// on a genuine allocation failure so the caller enqueues unchanged and emits a
+// loud skip event. The manager is the checkout-bound gitutil.Client, exactly as
+// the reactive pool-isolation path builds it.
+func maybeAllocateDispatchReadOnlyWorktree(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, checkout string, jobID string) (string, error) {
+	if !dispatchReadOnlyWorktreeEligible(request) {
+		return "", nil
+	}
+	if strings.TrimSpace(checkout) == "" {
+		return "", nil
+	}
+	paths, err := pathsFromFlag(request.Home)
+	if err != nil {
+		return "", err
+	}
+	// Ref defaults to HEAD (baseBranch left empty): a committed-tip worktree that is
+	// always resolvable, avoiding the stale current-branch fragility the researchers
+	// flagged. The #654 context note points the job at the canonical checkout for
+	// uncommitted/gitignored paths.
+	return workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, repo, checkout, jobID, "readonly-seat", 0, "", gitutil.Client{Dir: checkout})
 }
 
 func printLocalAgentJobOutput(stdout io.Writer, output localAgentJobOutput) {

--- a/internal/cli/agent_dispatch_readonly_worktree_test.go
+++ b/internal/cli/agent_dispatch_readonly_worktree_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestDispatchReadOnlyWorktreeEligible pins the gate for dispatch-time read-only
+// worktree allocation (#739): only a BACKGROUND read-only (ask/review) job with no
+// existing task worktree qualifies. A foreground ask (runs inline, never
+// serializes), an implement job, and a read-only job that already carries a
+// per-PR/task worktree (TaskID set) are all excluded.
+func TestDispatchReadOnlyWorktreeEligible(t *testing.T) {
+	cases := []struct {
+		name string
+		req  localAgentDispatchRequest
+		want bool
+	}{
+		{"background ask", localAgentDispatchRequest{Background: true, Action: "ask"}, true},
+		{"background review no task", localAgentDispatchRequest{Background: true, Action: "review"}, true},
+		{"foreground ask untouched", localAgentDispatchRequest{Background: false, Action: "ask"}, false},
+		{"background implement untouched", localAgentDispatchRequest{Background: true, Action: "implement"}, false},
+		{"background run untouched", localAgentDispatchRequest{Background: true, Action: "run"}, false},
+		{"background ask with task worktree", localAgentDispatchRequest{Background: true, Action: "ask", TaskID: "t1"}, false},
+		{"background review with task worktree", localAgentDispatchRequest{Background: true, Action: "review", TaskID: "review-pr-1"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dispatchReadOnlyWorktreeEligible(tc.req); got != tc.want {
+				t.Fatalf("dispatchReadOnlyWorktreeEligible = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDispatchBackgroundAskAllocatesReadOnlyWorktree drives the REAL dispatch path
+// for a background ask (a moot seat / chat-task / autorespond / `agent ask
+// --background` shape) and proves the #739 fix: the enqueued job is born with a
+// detached committed-tip worktree, so queuedJobCheckoutKey keys it off
+// worktree:<path> and it runs beside same-repo seats instead of serializing on the
+// shared repo:<repo> key.
+func TestDispatchBackgroundAskAllocatesReadOnlyWorktree(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := readonlyWorktreeGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	// Shell runtime, ask-only: a background dispatch enqueues and returns before any
+	// delivery, so the command body is irrelevant here.
+	seedDaemonWorkerAgent(t, store, "responder", runtime.ShellRuntime, "printf '%s' '{}'", []string{"ask"}, "owner/repo")
+
+	out, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag:     "owner/repo",
+		Agent:        "responder",
+		Action:       "ask",
+		Instructions: "hello",
+		Background:   true,
+		Home:         home,
+	})
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload: %v", err)
+	}
+	if strings.TrimSpace(payload.WorktreePath) == "" {
+		t.Fatal("background ask payload has no WorktreePath; expected a dispatch-time read-only worktree (#739)")
+	}
+	if !payload.ReadOnlyWorktree {
+		t.Fatal("background ask payload ReadOnlyWorktree = false, want true (disposal marker for a top-level read-only worktree)")
+	}
+	if payload.HeadSHA != "" {
+		t.Fatalf("background ask payload HeadSHA = %q, want cleared (validate against the fresh worktree HEAD)", payload.HeadSHA)
+	}
+	if _, statErr := os.Stat(payload.WorktreePath); statErr != nil {
+		t.Fatalf("read-only worktree dir missing on disk: %v", statErr)
+	}
+	// The #654 context note points the isolated committed-tip job at the canonical
+	// checkout for gitignored/uncommitted paths.
+	if !strings.Contains(payload.Instructions, checkout) {
+		t.Fatal("background ask instructions missing the canonical-checkout context note (#654)")
+	}
+	// The job is keyed off its detached worktree, NOT the shared repo checkout — the
+	// whole point of #739.
+	wantPath, err := normalizeTaskWorktreePath(payload.WorktreePath)
+	if err != nil {
+		t.Fatalf("normalizeTaskWorktreePath: %v", err)
+	}
+	if got := queuedJobCheckoutKey(ctx, store, job); got != "worktree:"+wantPath {
+		t.Fatalf("queuedJobCheckoutKey = %q, want worktree:%s (must NOT be repo:owner/repo)", got, wantPath)
+	}
+}
+
+// TestDispatchForegroundAndImplementLeaveCheckoutKeyShared confirms the contrast:
+// neither a foreground ask nor an implement job gets a dispatch-time read-only
+// worktree, so an equivalent payload with no worktree still keys repo:<repo>.
+func TestDispatchImplementUntouchedKeysRepo(t *testing.T) {
+	ctx := context.Background()
+	store, _ := blockerE2EHome(t)
+	// An implement job the dispatch would have prepared carries a task worktree, so
+	// eligibility is false; a bare read-only payload with no worktree keys repo:<repo>.
+	if dispatchReadOnlyWorktreeEligible(localAgentDispatchRequest{Background: true, Action: "implement"}) {
+		t.Fatal("implement dispatch must not be read-only-worktree eligible")
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "responder", runtime.ShellRuntime, "printf '%s' '{}'", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:           "ask-no-worktree",
+		Agent:        "responder",
+		Action:       "ask",
+		Repo:         "owner/repo",
+		Sender:       "local",
+		Instructions: "hi",
+	})
+	jobs, err := store.ListQueuedJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListQueuedJobs: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("queued jobs = %d, want 1", len(jobs))
+	}
+	if got := queuedJobCheckoutKey(ctx, store, jobs[0]); got != "repo:owner/repo" {
+		t.Fatalf("queuedJobCheckoutKey for a no-worktree job = %q, want repo:owner/repo", got)
+	}
+}
+
+func readonlyWorktreeGitCheckout(t *testing.T, fullName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "branch", "-m", "main")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "gitmoot test")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/"+fullName+".git")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+	return dir
+}

--- a/internal/cli/chat_moot.go
+++ b/internal/cli/chat_moot.go
@@ -359,33 +359,40 @@ func chatMootOverrunMessage(messageCap int) string {
 
 // ---- serialization preflight (#534 review #6) ------------------------------
 
-// mootSerializationWarning resolves the EFFECTIVE daemon scheduler/worker config that
-// will actually run these seats for this home + repo, and returns a human warning when
-// that config cannot run >=2 same-repo read-only seats concurrently. It returns "" (say
-// nothing) when the config supports concurrency, when fewer than 2 seats are convening
-// (a solo seat never needs to converse), or on any read error (a best-effort advisory
-// must never break a dispatch).
+// mootSerializationWarning resolves the EFFECTIVE daemon worker config that will
+// actually run these seats for this home + repo, and returns a human warning when
+// that config cannot run >=2 same-repo read-only seats concurrently. It returns ""
+// (say nothing) when the config supports concurrency, when fewer than 2 seats are
+// convening (a solo seat never needs to converse), or on any read error (a
+// best-effort advisory must never break a dispatch).
+//
+// #739: the decision is now the WORKER COUNT alone, NOT the scheduler mode. Since
+// background read-only (ask) seats get a dedicated detached committed-tip worktree
+// at dispatch, they are born keyed worktree:<path> and no longer serialize on the
+// shared repo:<repo> checkout key under EITHER scheduler — the barrier scheduler
+// selects same-repo jobs with distinct checkout keys into one concurrent per-tick
+// batch (selectRunnableQueuedJobs), and the pool scheduler runs them continuously.
+// So the only remaining serializer is a single worker (effective parallelism <2);
+// a pool-vs-barrier verdict would now false-warn a healthy multi-worker barrier
+// daemon.
 //
 // It is a PURE read: no live auth probe and no mutation, mirroring the off-hot-path
-// contract of the daemon's #444 serialization preflight. It reuses the daemon's own
-// parseSchedulerMode + serializingConfig predicates so the moot's verdict is exactly
-// the daemon's.
+// contract of the daemon's #444 serialization preflight. It keeps parseSchedulerMode
+// only as a stay-quiet guard on an invalid scheduler mode (the daemon's error to
+// report at start, not the moot's to guess about).
 func mootSerializationWarning(paths config.Paths, repo string, seats int) string {
 	if seats < 2 {
 		return ""
 	}
 	workers, scheduler := mootEffectiveScheduler(paths, repo)
-	usePool, err := parseSchedulerMode(scheduler)
-	if err != nil {
-		// An invalid scheduler mode is the daemon's error to report at start, not
-		// something the moot should guess about — stay quiet.
+	if _, err := parseSchedulerMode(scheduler); err != nil {
 		return ""
 	}
-	if !serializingConfig(usePool, workers) {
+	if workers >= 2 {
 		return ""
 	}
-	return fmt.Sprintf("warning: this daemon runs seats sequentially (workers=%d, scheduler=%s); a %d-seat moot will exchange turns slowly and each 'chat wait' may time out. Enable the pool scheduler with >=2 workers ([daemon] parallel = %d, or start the daemon with --parallel %d) so seats converse concurrently.",
-		workers, scheduler, seats, seats, seats)
+	return fmt.Sprintf("warning: this daemon runs a single worker (workers=%d); a %d-seat moot will exchange turns slowly and each 'chat wait' may time out. Give the daemon >=2 workers ([daemon] parallel = %d, or start the daemon with --parallel %d) so seats converse concurrently.",
+		workers, seats, seats, seats)
 }
 
 // mootEffectiveScheduler resolves the worker count + scheduler mode the daemon that

--- a/internal/cli/chat_moot_test.go
+++ b/internal/cli/chat_moot_test.go
@@ -481,8 +481,8 @@ func mootSerialWarnRun(t *testing.T, body string) (string, int) {
 // 2-seat moot serializes, yet STILL dispatches both seats (advisory, non-blocking).
 func TestMootSerializationWarningDefaultDaemon(t *testing.T) {
 	stderr, dispatched := mootSerialWarnRun(t, "")
-	if !strings.Contains(stderr, "runs seats sequentially") || !strings.Contains(stderr, "workers=1") || !strings.Contains(stderr, "scheduler=barrier") {
-		t.Fatalf("stderr = %q, want a sequential-serialization warning naming workers=1/scheduler=barrier", stderr)
+	if !strings.Contains(stderr, "runs a single worker") || !strings.Contains(stderr, "workers=1") {
+		t.Fatalf("stderr = %q, want a single-worker serialization warning naming workers=1", stderr)
 	}
 	if dispatched != 2 {
 		t.Fatalf("default-daemon moot dispatched %d seats, want 2 (warning must not block)", dispatched)
@@ -575,16 +575,24 @@ func TestMootSerializationWarningRunningPoolDaemon(t *testing.T) {
 	}
 }
 
-// TestMootSerializationWarningWarmReloadOverridesArgs proves a config.toml [daemon]
-// key warm-reloads OVER the daemon's recorded start args (SIGHUP semantics): a pool/6
-// start with a config.toml `scheduler = "barrier"` serializes (barrier ignores the
-// worker count) and must WARN, naming the effective workers=6/scheduler=barrier.
-func TestMootSerializationWarningWarmReloadOverridesArgs(t *testing.T) {
+// TestMootSerializationWarningBarrierMultiWorkerSuppressed pins the #739 behavior
+// change: the verdict is the WORKER COUNT alone, not the scheduler mode. A barrier
+// scheduler with >=2 workers no longer warns — since background read-only seats get
+// a dedicated detached worktree at dispatch, the barrier scheduler runs same-repo
+// seats with distinct checkout keys concurrently in one per-tick batch. It also
+// proves the warm-reload still resolves the effective worker count: a config.toml
+// [daemon] scheduler=barrier warm-reloads OVER a pool/6 start (SIGHUP semantics),
+// and workers=6 must SUPPRESS. A genuinely single-worker barrier daemon still warns.
+func TestMootSerializationWarningBarrierMultiWorkerSuppressed(t *testing.T) {
 	_, home := mootFixtureHome(t, "\n[daemon]\nscheduler = \"barrier\"\n")
 	writeMootDaemonRunMeta(t, home, []string{"daemon", "run", "--workers", "6", "--scheduler", "pool"})
-	w := mootSerializationWarning(config.PathsForHome(home), "owner/repo", 3)
-	if !strings.Contains(w, "workers=6") || !strings.Contains(w, "scheduler=barrier") {
-		t.Fatalf("warm-reload-override warning = %q, want workers=6/scheduler=barrier", w)
+	if w := mootSerializationWarning(config.PathsForHome(home), "owner/repo", 3); w != "" {
+		t.Fatalf("barrier/6-worker daemon warned: %q, want NO warning under #739 (worktrees parallelize seats under any scheduler)", w)
+	}
+	// A single-worker barrier daemon is the only remaining serializer and still warns.
+	_, serialHome := mootFixtureHome(t, "\n[daemon]\nscheduler = \"barrier\"\nparallel = 1\n")
+	if w := mootSerializationWarning(config.PathsForHome(serialHome), "owner/repo", 3); w == "" {
+		t.Fatal("barrier/1-worker daemon did not warn a 3-seat moot")
 	}
 }
 

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4516,9 +4516,18 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						continue
 					}
 					payloadBeforeIsolation := job.Payload
-					iso, ok := worker.allocatePoolIsolationWorktree(ctx, job, payload)
+					iso, ok, allocErr := worker.allocatePoolIsolationWorktree(ctx, job, payload)
 					if !ok {
 						worker.Admission.Release(job.ID)
+						// #739: the reactive isolation was silent on failure — the exact
+						// reason #739 was hard to diagnose (a seat went queued→running with no
+						// worktree event and serialized on the shared checkout). Emit a loud
+						// skip event so a lost-parallelism serialize is observable. A nil
+						// allocErr means the job was simply not isolable (no home/checkout) —
+						// not a failure — so stay quiet there.
+						if allocErr != nil {
+							_ = worker.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "pool_isolation_skipped", Message: fmt.Sprintf("pool read-only isolation skipped (#739); job stays serialized in the shared checkout: %v", allocErr)})
+						}
 						continue
 					}
 					if !tracker.beginWithin(hostCap, iso.job.ID, repoFilter, iso.checkoutKey, iso.runtimeKey) {
@@ -4535,6 +4544,12 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					if iso.runtimeKey != "" {
 						inflightRuntimes[iso.runtimeKey] = true
 					}
+					// #739: make the reactive isolation observable on SUCCESS too (it was
+					// silent both ways). Emitted only past the host-cap/double-dispatch gate
+					// above, so the event means the job is truly dispatched in its own
+					// worktree:<path> key — running beside the same-repo checkout holder,
+					// not serialized behind it.
+					_ = worker.Store.AddJobEvent(ctx, db.JobEvent{JobID: iso.job.ID, Kind: "pool_isolation_worktree_allocated", Message: fmt.Sprintf("read-only pool-isolation worktree %s allocated (#739); job keyed %s to run beside the same-repo checkout holder", iso.worktreePath, iso.checkoutKey)})
 					running++
 					dispatched++
 					go func() {
@@ -4603,25 +4618,28 @@ type poolIsolatedDispatch struct {
 // means the job is not isolable or the worktree could not be created — the caller
 // then leaves it queued to serialize as before (graceful, no deadlock-for-safety
 // trade). Runs on the dispatcher goroutine under the tick's per-repo lock.
-func (w jobWorker) allocatePoolIsolationWorktree(ctx context.Context, job db.Job, payload workflow.JobPayload) (poolIsolatedDispatch, bool) {
+func (w jobWorker) allocatePoolIsolationWorktree(ctx context.Context, job db.Job, payload workflow.JobPayload) (poolIsolatedDispatch, bool, error) {
 	if strings.TrimSpace(w.ConfigHome) == "" {
-		return poolIsolatedDispatch{}, false
+		return poolIsolatedDispatch{}, false, nil
 	}
 	repoRecord, err := w.Store.GetRepo(ctx, payload.Repo)
 	if err != nil || strings.TrimSpace(repoRecord.CheckoutPath) == "" {
-		return poolIsolatedDispatch{}, false
+		return poolIsolatedDispatch{}, false, err
 	}
-	path, err := workflow.DelegationWorktreePath(w.ConfigHome, payload.Repo, job.ID, "pool-isolation", 0)
-	if err != nil || strings.TrimSpace(path) == "" {
-		return poolIsolatedDispatch{}, false
-	}
-	ref := firstNonEmpty(strings.TrimSpace(payload.HeadSHA), strings.TrimSpace(payload.Branch), "HEAD")
 	client := gitutil.Client{Dir: repoRecord.CheckoutPath}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return poolIsolatedDispatch{}, false
+	// #739: route through the shared read-only allocator so this reactive top-level
+	// isolation path resolves the ref to HEAD (a committed tip that is always
+	// resolvable — NOT the stale current branch the researchers flagged), holds the
+	// checkout mutation lock, and returns errors LOUDLY. This keeps it behaviorally
+	// aligned with the read-only delegation fan-out and the dispatch-time allocation,
+	// and turns the previously-silent worktree-add failure into a returned error the
+	// caller emits as a pool_isolation_skipped event.
+	path, err := workflow.AllocateReadOnlyWorktree(ctx, w.Store, w.ConfigHome, payload.Repo, repoRecord.CheckoutPath, job.ID, "pool-isolation", 0, "", client)
+	if err != nil {
+		return poolIsolatedDispatch{}, false, err
 	}
-	if err := client.AddDetachedWorktree(ctx, path, ref); err != nil {
-		return poolIsolatedDispatch{}, false
+	if strings.TrimSpace(path) == "" {
+		return poolIsolatedDispatch{}, false, nil
 	}
 	payload.WorktreePath = path
 	// The detached worktree is the COMMITTED TIP of the base ref, so it omits
@@ -4638,11 +4656,11 @@ func (w jobWorker) allocatePoolIsolationWorktree(ctx context.Context, job db.Job
 	encoded, err := json.Marshal(payload)
 	if err != nil {
 		_ = client.RemoveWorktreeForce(context.WithoutCancel(ctx), path)
-		return poolIsolatedDispatch{}, false
+		return poolIsolatedDispatch{}, false, err
 	}
 	if err := w.Store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
 		_ = client.RemoveWorktreeForce(context.WithoutCancel(ctx), path)
-		return poolIsolatedDispatch{}, false
+		return poolIsolatedDispatch{}, false, err
 	}
 	job.Payload = string(encoded)
 	return poolIsolatedDispatch{
@@ -4651,7 +4669,7 @@ func (w jobWorker) allocatePoolIsolationWorktree(ctx context.Context, job db.Job
 		runtimeKey:   queuedJobRuntimeResourceKey(ctx, w.Store, job),
 		worktreePath: path,
 		repoCheckout: repoRecord.CheckoutPath,
-	}, true
+	}, true, nil
 }
 
 type queuedJobResourceSelector struct {

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3731,7 +3731,7 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 		if err != nil {
 			return err
 		}
-		if !jobStateCanRetryAdvancement(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
+		if !jobStateEligibleForWorktreeReclaim(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
 			continue
 		}
 		if checkoutHeld != nil {
@@ -3928,6 +3928,18 @@ func jobStateCanRetryAdvancement(state string) bool {
 	default:
 		return false
 	}
+}
+
+// jobStateEligibleForWorktreeReclaim gates the delegation/read-only worktree
+// reclaim pass. It is the advancement-retry set PLUS cancelled: a job aborted
+// (cancel / kill / supersede) before its terminal AdvanceJob leaves a
+// dispatch-allocated read-only worktree (#739) on disk with a
+// delegation_worktree_cleanup_skipped marker but a JobCancelled state, so the
+// reclaim pass must still dispose it. Cancelled is intentionally NOT added to
+// jobStateCanRetryAdvancement (a cancelled job must never RE-ADVANCE) — only its
+// worktree is reclaimed here, via the same idempotent, liveness-gated cleanup.
+func jobStateEligibleForWorktreeReclaim(state string) bool {
+	return jobStateCanRetryAdvancement(state) || state == string(workflow.JobCancelled)
 }
 
 // retryPendingJobComments re-posts the result comment for any terminal job whose
@@ -4633,8 +4645,11 @@ func (w jobWorker) allocatePoolIsolationWorktree(ctx context.Context, job db.Job
 	// checkout mutation lock, and returns errors LOUDLY. This keeps it behaviorally
 	// aligned with the read-only delegation fan-out and the dispatch-time allocation,
 	// and turns the previously-silent worktree-add failure into a returned error the
-	// caller emits as a pool_isolation_skipped event.
-	path, err := workflow.AllocateReadOnlyWorktree(ctx, w.Store, w.ConfigHome, payload.Repo, repoRecord.CheckoutPath, job.ID, "pool-isolation", 0, "", client)
+	// caller emits as a pool_isolation_skipped event. It runs SYNCHRONOUSLY on the
+	// per-repo dispatch loop, so it passes the short ReadOnlyWorktreeDispatchLockWaitBudget
+	// (not the 2-minute default) to fail open fast under merge-gate lock contention
+	// rather than freezing this repo's dispatch+reap loop.
+	path, err := workflow.AllocateReadOnlyWorktree(ctx, w.Store, w.ConfigHome, payload.Repo, repoRecord.CheckoutPath, job.ID, "pool-isolation", 0, "", workflow.ReadOnlyWorktreeDispatchLockWaitBudget, client)
 	if err != nil {
 		return poolIsolatedDispatch{}, false, err
 	}

--- a/internal/cli/daemon_dispatch_tracked_test.go
+++ b/internal/cli/daemon_dispatch_tracked_test.go
@@ -531,6 +531,12 @@ func TestTrackedPoolIsolationHonorsSamePassRuntimeSibling(t *testing.T) {
 	if payload, err = daemonJobPayload(job); err != nil || payload.WorktreePath == "" {
 		t.Fatalf("job-iso final payload worktree = %q err=%v, want an isolation worktree (must have run beside the held shared checkout)", payload.WorktreePath, err)
 	}
+	// #739: the reactive isolation success is now OBSERVABLE — a
+	// pool_isolation_worktree_allocated event was emitted when job-iso was
+	// dispatched into its worktree (it used to be silent both ways).
+	if n := countCLIJobEvents(t, store, "job-iso", "pool_isolation_worktree_allocated"); n != 1 {
+		t.Fatalf("pool_isolation_worktree_allocated event count = %d, want 1 (#739 observability)", n)
+	}
 	select {
 	case err := <-errCh:
 		if err != nil {
@@ -639,4 +645,20 @@ func TestTrackedTickMaintenanceNotStarvedByInFlightJobs(t *testing.T) {
 	if !hasEvent("job-adv-repo", "advance_retried") {
 		t.Fatalf("job-adv-repo still not advanced after the shared checkout freed")
 	}
+}
+
+// countCLIJobEvents returns how many events of the given kind exist for jobID.
+func countCLIJobEvents(t *testing.T, store *db.Store, jobID, kind string) int {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s): %v", jobID, err)
+	}
+	n := 0
+	for _, e := range events {
+		if e.Kind == kind {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -7010,6 +7010,29 @@ func TestWarnSerializedParallelJobsSilentBelowTwo(t *testing.T) {
 	}
 }
 
+// TestJobStateEligibleForWorktreeReclaim pins the #739-review fix that the
+// worktree reclaim pass also disposes a CANCELLED job's dispatch-allocated
+// read-only worktree, while keeping cancelled OUT of advancement re-run.
+func TestJobStateEligibleForWorktreeReclaim(t *testing.T) {
+	for _, s := range []string{
+		string(workflow.JobSucceeded), string(workflow.JobFailed),
+		string(workflow.JobBlocked), string(workflow.JobCancelled),
+	} {
+		if !jobStateEligibleForWorktreeReclaim(s) {
+			t.Fatalf("state %q must be worktree-reclaim eligible", s)
+		}
+	}
+	for _, s := range []string{string(workflow.JobQueued), string(workflow.JobRunning)} {
+		if jobStateEligibleForWorktreeReclaim(s) {
+			t.Fatalf("state %q must not be worktree-reclaim eligible", s)
+		}
+	}
+	// A cancelled job's worktree is reclaimed, but the job must never RE-ADVANCE.
+	if jobStateCanRetryAdvancement(string(workflow.JobCancelled)) {
+		t.Fatal("cancelled must never be advancement-retry eligible")
+	}
+}
+
 func TestSerializingConfig(t *testing.T) {
 	cases := []struct {
 		usePool bool

--- a/internal/cli/readonly_worktree_concurrency_e2e_test.go
+++ b/internal/cli/readonly_worktree_concurrency_e2e_test.go
@@ -1,0 +1,484 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// This file is the no-LLM, no-network end-to-end proof for the #739 fix:
+// background read-only (ask) jobs — moot seats, chat-task promotions, autorespond,
+// `agent ask --background` — are each allocated a dedicated DETACHED committed-tip
+// worktree at DISPATCH time, so their checkout key is worktree:<path> and same-repo
+// seats run CONCURRENTLY instead of serializing on the shared repo:<repo> key.
+//
+// The #739 condition is reproduced faithfully: the repo checkout is parked on a
+// NON-MAIN / stale odd branch (the live symptom was on a repo sitting on
+// feat/delegations-task-3051-schema). The dispatch-time allocator resolves the
+// worktree ref to HEAD (a committed tip that is always resolvable), so the stale
+// branch is a non-issue — matching the researchers' refuted-ref diagnostic.
+//
+// CONCURRENCY PROOF: each seat's shell script blocks on a 2-of-2 filesystem
+// rendezvous — it emits its `approved` result ONLY after BOTH seats' start markers
+// exist. Two seats can therefore both reach `approved` (JobSucceeded) ONLY if they
+// were live SIMULTANEOUSLY. If the fix regresses (both seats share repo:<repo> and
+// serialize), the first-dispatched seat waits out the rendezvous, emits a `failed`
+// decision (→ JobFailed), and the both-succeeded assertions flip RED. A concurrent
+// state sampler independently records both jobs observed in `running` at once.
+
+// staleBranchGitCheckout builds a real git repo for owner/repo with one commit and
+// then parks the working tree on a NON-MAIN stale/odd branch, reproducing the exact
+// #739 condition (the live repo sat on a long-lived feature branch, not main).
+func staleBranchGitCheckout(t *testing.T, fullName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "branch", "-m", "main")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "gitmoot test")
+	runGit(t, dir, "remote", "add", "origin", "https://github.com/"+fullName+".git")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+	// Reproduce #739: leave the checkout on a stale/odd non-main branch.
+	runGit(t, dir, "checkout", "-b", "feat/delegations-stale-odd-branch")
+	return dir
+}
+
+// rendezvousResult builds a valid gitmoot_result envelope with the given terminal
+// decision (approved → JobSucceeded, failed → JobFailed).
+func rendezvousResult(decision, summary string) string {
+	return fmt.Sprintf(`{"gitmoot_result":{"decision":%q,"summary":%q,"findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`, decision, summary)
+}
+
+// rendezvousSeatScript is a shell-runtime agent command that touches its own start
+// marker in stateDir, then waits until `peers` start markers exist before emitting
+// okResult. If the wait times out (the seats serialized rather than running
+// concurrently) it emits a distinctive `failed` result so the both-succeeded
+// assertion flips RED. prefix (may be empty) runs first — used by the moot test to
+// post a real `chat send` conversation turn before the rendezvous.
+func rendezvousSeatScript(stateDir, self string, peers int, okResult, prefix string) string {
+	failResult := rendezvousResult("failed", "rendezvous timeout: seat "+self+" serialized (#739 regression)")
+	// After the barrier clears, hold briefly so BOTH seats are demonstrably in
+	// `running` at the same time for a window the concurrent state sampler can
+	// reliably observe (the barrier alone proves concurrency, but clears in ms).
+	body := fmt.Sprintf(`: > %q/started-%s
+i=0
+while [ "$(ls %q/started-* 2>/dev/null | wc -l)" -lt %d ]; do
+  i=$((i+1))
+  if [ "$i" -gt 200 ]; then printf '%%s' '%s'; exit 0; fi
+  sleep 0.05
+done
+sleep 0.3
+printf '%%s' '%s'`, stateDir, self, stateDir, peers, failResult, okResult)
+	if strings.TrimSpace(prefix) != "" {
+		return prefix + "\n" + body
+	}
+	return body
+}
+
+// readonlyPoolWorker builds a REAL pool-scheduler jobWorker on the isolated home:
+// the default ShellAdapter subprocess runtime and the default checkout resolver
+// (which honors a job's payload worktree path), so a dispatch-time #739 worktree is
+// the actual cwd the seat runs in.
+func readonlyPoolWorker(store *db.Store, home string) jobWorker {
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.UsePool = true
+	return worker
+}
+
+// drivePoolConcurrently runs ONE pool tick (workers=2) that dispatches and drains
+// the queued seats concurrently, guarded by a timeout, while sampling job states.
+// It returns whether both jobIDs were ever observed in `running` simultaneously.
+func drivePoolConcurrently(t *testing.T, ctx context.Context, worker jobWorker, store *db.Store, jobIDs []string) bool {
+	t.Helper()
+	bothRunning := false
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			running := 0
+			for _, id := range jobIDs {
+				if job, err := store.GetJob(ctx, id); err == nil && job.State == string(workflow.JobRunning) {
+					running++
+				}
+			}
+			if running == len(jobIDs) {
+				bothRunning = true
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- runQueuedJobsForRepo(ctx, worker, 2, "", "") }()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("pool tick returned error: %v", err)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("pool tick did not complete within 60s — seats likely serialized (rendezvous never cleared)")
+	}
+	close(stop)
+	<-done
+	return bothRunning
+}
+
+// terminalJobDecision returns a terminal job and its parsed gitmoot_result decision.
+func terminalJobDecision(t *testing.T, ctx context.Context, store *db.Store, jobID string) (db.Job, string) {
+	t.Helper()
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", jobID, err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload(%s): %v", jobID, err)
+	}
+	decision := ""
+	if payload.Result != nil {
+		decision = payload.Result.Decision
+	}
+	return job, decision
+}
+
+// TestReadOnlyWorktreeConcurrentAsksE2E is the primary #739 proof: two BACKGROUND
+// read-only asks dispatched onto the SAME stale-branch repo are each born with a
+// distinct detached committed-tip worktree, run CONCURRENTLY on the pool worker
+// (proven by the 2-of-2 rendezvous + a live state sampler), each carry a
+// readonly_worktree_allocated event, and each worktree is DISPOSED on terminal.
+//
+// MUTATION PROOF: revert the dispatch-time allocation (so both asks key
+// repo:owner/repo) and the first seat serializes behind the second — it waits out
+// the rendezvous, emits `failed`, and the both-succeeded assertion flips RED.
+func TestReadOnlyWorktreeConcurrentAsksE2E(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := staleBranchGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	stateDir := t.TempDir()
+	seedDaemonWorkerAgent(t, store, "alice", runtime.ShellRuntime,
+		rendezvousSeatScript(stateDir, "alice", 2, rendezvousResult("approved", "alice ran beside bob"), ""), []string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "bob", runtime.ShellRuntime,
+		rendezvousSeatScript(stateDir, "bob", 2, rendezvousResult("approved", "bob ran beside alice"), ""), []string{"ask"}, "owner/repo")
+
+	// Dispatch two BACKGROUND read-only asks on the SAME stale-branch repo through
+	// the REAL dispatch entry (the moot-seat / chat-task / autorespond shape).
+	outA, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "alice", Action: "ask", Instructions: "audit module A", Background: true, Home: home})
+	if err != nil {
+		t.Fatalf("dispatch alice: %v", err)
+	}
+	outB, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "bob", Action: "ask", Instructions: "audit module B", Background: true, Home: home})
+	if err != nil {
+		t.Fatalf("dispatch bob: %v", err)
+	}
+
+	jobA, err := store.GetJob(ctx, outA.JobID)
+	if err != nil {
+		t.Fatalf("GetJob alice: %v", err)
+	}
+	jobB, err := store.GetJob(ctx, outB.JobID)
+	if err != nil {
+		t.Fatalf("GetJob bob: %v", err)
+	}
+	payloadA, err := daemonJobPayload(jobA)
+	if err != nil {
+		t.Fatalf("payload alice: %v", err)
+	}
+	payloadB, err := daemonJobPayload(jobB)
+	if err != nil {
+		t.Fatalf("payload bob: %v", err)
+	}
+
+	// Each is born with its OWN detached worktree carrying the disposal marker.
+	for name, p := range map[string]workflow.JobPayload{"alice": payloadA, "bob": payloadB} {
+		if strings.TrimSpace(p.WorktreePath) == "" {
+			t.Fatalf("seat %s has no dispatch-time worktree (#739)", name)
+		}
+		if !p.ReadOnlyWorktree {
+			t.Fatalf("seat %s ReadOnlyWorktree = false, want true (top-level disposal marker)", name)
+		}
+	}
+	// DISTINCT worktree:<path> checkout keys — the whole point of #739.
+	keyA := queuedJobCheckoutKey(ctx, store, jobA)
+	keyB := queuedJobCheckoutKey(ctx, store, jobB)
+	if !strings.HasPrefix(keyA, "worktree:") || !strings.HasPrefix(keyB, "worktree:") {
+		t.Fatalf("checkout keys must both be worktree:<path>, got %q and %q", keyA, keyB)
+	}
+	if keyA == keyB {
+		t.Fatalf("both seats share checkout key %q — they would serialize (want distinct)", keyA)
+	}
+	// Each carries an observable allocation event.
+	for _, id := range []string{outA.JobID, outB.JobID} {
+		if n := countCLIJobEvents(t, store, id, "readonly_worktree_allocated"); n != 1 {
+			t.Fatalf("job %s readonly_worktree_allocated events = %d, want 1", id, n)
+		}
+	}
+
+	// Drive the pool: both must be live simultaneously to clear the 2-of-2 rendezvous.
+	bothRunning := drivePoolConcurrently(t, ctx, readonlyPoolWorker(store, home), store, []string{outA.JobID, outB.JobID})
+	if !bothRunning {
+		t.Fatal("state sampler never observed both seats in `running` at once (serialized)")
+	}
+
+	// Both reached `approved` (JobSucceeded) ⇒ both cleared the 2-of-2 rendezvous ⇒
+	// they ran concurrently. A serialized first seat would be `failed` here.
+	for _, id := range []string{outA.JobID, outB.JobID} {
+		job, decision := terminalJobDecision(t, ctx, store, id)
+		if job.State != string(workflow.JobSucceeded) {
+			t.Fatalf("seat %s state = %q, want succeeded (a serialized seat times out the rendezvous → failed)", id, job.State)
+		}
+		if decision != "approved" {
+			t.Fatalf("seat %s decision = %q, want approved (rendezvous cleared)", id, decision)
+		}
+	}
+
+	// Each detached worktree is DISPOSED on terminal (dir gone + a removal event).
+	for name, id := range map[string]string{"alice": outA.JobID, "bob": outB.JobID} {
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob %s: %v", id, err)
+		}
+		p, err := daemonJobPayload(job)
+		if err != nil {
+			t.Fatalf("payload %s: %v", id, err)
+		}
+		if _, statErr := os.Stat(p.WorktreePath); !os.IsNotExist(statErr) {
+			t.Fatalf("seat %s worktree %s not disposed on terminal (stat err=%v)", name, p.WorktreePath, statErr)
+		}
+		if n := countCLIJobEvents(t, store, id, "delegation_worktree_removed"); n != 1 {
+			t.Fatalf("seat %s delegation_worktree_removed events = %d, want 1", name, n)
+		}
+	}
+}
+
+// TestMootConcurrentSeatsOnStaleBranchE2E convenes a real 2-seat moot on the
+// stale-branch repo and proves both seats run CONCURRENTLY (2-of-2 rendezvous +
+// state sampler) AND converse: each seat posts a real `chat send --as <self>`
+// conversation turn, and both turns plus both back-linked job_result conclusions
+// land in the thread.
+func TestMootConcurrentSeatsOnStaleBranchE2E(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := staleBranchGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	bin := buildGitmootBinaryForTest(t)
+
+	stateDir := t.TempDir()
+	// Each seat posts one real chat turn BEFORE the rendezvous, then clears the
+	// 2-of-2 barrier and returns its conclusions.
+	sendTurn := func(self, msg string) string {
+		return fmt.Sprintf("%q chat send stale-review %q --as %s --repo owner/repo --home %q >/dev/null 2>&1",
+			bin, msg, self, home)
+	}
+	seedDaemonWorkerAgent(t, store, "alice", runtime.ShellRuntime,
+		rendezvousSeatScript(stateDir, "alice", 2, rendezvousResult("approved", "alice: I lean toward A"), sendTurn("alice", "alice: I lean toward option A")),
+		[]string{"ask"}, "owner/repo")
+	seedDaemonWorkerAgent(t, store, "bob", runtime.ShellRuntime,
+		rendezvousSeatScript(stateDir, "bob", 2, rendezvousResult("approved", "bob: A has a cost"), sendTurn("bob", "bob: option A has a runtime cost")),
+		[]string{"ask"}, "owner/repo")
+
+	// Convene the moot through the REAL command (chatMootDispatch is NOT faked).
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"moot", "stale-review", "which option ships?", "--agents", "alice,bob", "--repo", "owner/repo", "--json", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("moot exit != 0: %s", stderr.String())
+	}
+	var out mootOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode moot JSON: %v (%s)", err, stdout.String())
+	}
+	if len(out.Seats) != 2 {
+		t.Fatalf("seats = %d, want 2", len(out.Seats))
+	}
+	seatJobs := make([]string, 0, 2)
+	for _, s := range out.Seats {
+		if s.JobID == "" || s.Error != "" {
+			t.Fatalf("seat %s did not dispatch: %+v", s.Agent, s)
+		}
+		seatJobs = append(seatJobs, s.JobID)
+	}
+
+	// Each seat is born keyed off its own detached worktree (distinct keys).
+	keys := map[string]bool{}
+	for _, id := range seatJobs {
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob %s: %v", id, err)
+		}
+		key := queuedJobCheckoutKey(ctx, store, job)
+		if !strings.HasPrefix(key, "worktree:") {
+			t.Fatalf("moot seat %s checkout key = %q, want worktree:<path> (#739)", id, key)
+		}
+		keys[key] = true
+	}
+	if len(keys) != 2 {
+		t.Fatalf("moot seats collapsed onto %d distinct worktree keys, want 2", len(keys))
+	}
+
+	// Drive both seats concurrently on the pool worker.
+	if !drivePoolConcurrently(t, ctx, readonlyPoolWorker(store, home), store, seatJobs) {
+		t.Fatal("state sampler never observed both moot seats in `running` at once (serialized)")
+	}
+	for _, id := range seatJobs {
+		job, decision := terminalJobDecision(t, ctx, store, id)
+		if job.State != string(workflow.JobSucceeded) {
+			t.Fatalf("moot seat %s state = %q, want succeeded (serialized seat times out the rendezvous)", id, job.State)
+		}
+		if decision != "approved" {
+			t.Fatalf("moot seat %s decision = %q, want approved (ran concurrently)", id, decision)
+		}
+	}
+
+	// Both seats' CONVERSATION turns and back-linked conclusions landed in the thread.
+	msgs, err := store.ListChatMessages(ctx, out.ThreadID, 0)
+	if err != nil {
+		t.Fatalf("ListChatMessages: %v", err)
+	}
+	chatTurns := map[string]bool{}
+	conclusions := map[string]bool{}
+	for _, m := range msgs {
+		if m.AuthorKind != db.ChatAuthorKindAgent {
+			continue
+		}
+		switch m.Kind {
+		case db.ChatKindChat:
+			chatTurns[m.AuthorName] = true
+		case db.ChatKindJobResult:
+			conclusions[m.AuthorName] = true
+		}
+	}
+	if !chatTurns["alice"] || !chatTurns["bob"] {
+		t.Fatalf("agent chat turns = %v, want both alice and bob (the seats' concurrent chat sends)", chatTurns)
+	}
+	if !conclusions["alice"] || !conclusions["bob"] {
+		t.Fatalf("job_result conclusions = %v, want both alice and bob (back-linked)", conclusions)
+	}
+}
+
+// TestLoneUncontendedBackgroundAskE2E proves the fix does not regress the simple
+// case: a single, uncontended background ask on the stale-branch repo still gets a
+// dispatch-time worktree, runs to a terminal decision, and disposes its worktree.
+func TestLoneUncontendedBackgroundAskE2E(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := staleBranchGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "solo", runtime.ShellRuntime,
+		fmt.Sprintf("printf '%%s' '%s'", rendezvousResult("approved", "solo ran")), []string{"ask"}, "owner/repo")
+
+	out, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "solo", Action: "ask", Instructions: "lone audit", Background: true, Home: home})
+	if err != nil {
+		t.Fatalf("dispatch solo: %v", err)
+	}
+	job, err := store.GetJob(ctx, out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if strings.TrimSpace(payload.WorktreePath) == "" || !payload.ReadOnlyWorktree {
+		t.Fatalf("lone ask missing dispatch-time worktree: worktree=%q marker=%v", payload.WorktreePath, payload.ReadOnlyWorktree)
+	}
+
+	worker := readonlyPoolWorker(store, home)
+	terminal := chatE2EDriveUntilTerminal(t, ctx, worker, store, out.JobID)
+	if terminal.State != string(workflow.JobSucceeded) {
+		t.Fatalf("lone ask state = %q, want succeeded", terminal.State)
+	}
+	if _, statErr := os.Stat(payload.WorktreePath); !os.IsNotExist(statErr) {
+		t.Fatalf("lone ask worktree %s not disposed (stat err=%v)", payload.WorktreePath, statErr)
+	}
+	if n := countCLIJobEvents(t, store, out.JobID, "delegation_worktree_removed"); n != 1 {
+		t.Fatalf("lone ask delegation_worktree_removed events = %d, want 1", n)
+	}
+}
+
+// TestReadOnlyWorktreeAllocFailIsFailOpenE2E proves the FAIL-OPEN contract: when
+// the dispatch-time worktree allocation genuinely fails, the ask is still enqueued
+// unchanged (no worktree, shared repo:<repo> checkout key), a loud
+// readonly_worktree_skipped event is recorded, and the job still runs to a terminal
+// decision on the shared checkout. Dispatch NEVER fails for a lost-parallelism
+// optimization. The allocation is forced to fail by planting a FILE where the
+// per-repo worktree directory must be created (git worktree add can never mkdir it).
+func TestReadOnlyWorktreeAllocFailIsFailOpenE2E(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout := staleBranchGitCheckout(t, "owner/repo")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "solo", runtime.ShellRuntime,
+		fmt.Sprintf("printf '%%s' '%s'", rendezvousResult("approved", "ran on the shared checkout")), []string{"ask"}, "owner/repo")
+
+	// Plant a FILE at <home>/.gitmoot/worktrees/owner--repo so os.MkdirAll of the
+	// deterministic worktree parent (…/owner--repo/delegations/<jobID>) fails ENOTDIR.
+	wtDir := filepath.Join(home, ".gitmoot", "worktrees")
+	if err := os.MkdirAll(wtDir, 0o755); err != nil {
+		t.Fatalf("mkdir worktrees: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wtDir, "owner--repo"), []byte("block"), 0o644); err != nil {
+		t.Fatalf("plant blocking file: %v", err)
+	}
+
+	out, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "solo", Action: "ask", Instructions: "audit anyway", Background: true, Home: home})
+	if err != nil {
+		t.Fatalf("dispatch must NOT fail on a worktree alloc error (fail-open): %v", err)
+	}
+	job, err := store.GetJob(ctx, out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if strings.TrimSpace(payload.WorktreePath) != "" {
+		t.Fatalf("fail-open payload has WorktreePath %q, want empty (allocation failed)", payload.WorktreePath)
+	}
+	if payload.ReadOnlyWorktree {
+		t.Fatal("fail-open payload ReadOnlyWorktree = true, want false (no worktree allocated)")
+	}
+	// The job stays on the shared checkout key, and the loud skip event is recorded.
+	if key := queuedJobCheckoutKey(ctx, store, job); key != "repo:owner/repo" {
+		t.Fatalf("fail-open checkout key = %q, want repo:owner/repo (serialized on the shared checkout)", key)
+	}
+	if n := countCLIJobEvents(t, store, out.JobID, "readonly_worktree_skipped"); n != 1 {
+		t.Fatalf("readonly_worktree_skipped events = %d, want 1 (loud fail-open)", n)
+	}
+	if n := countCLIJobEvents(t, store, out.JobID, "readonly_worktree_allocated"); n != 0 {
+		t.Fatalf("readonly_worktree_allocated events = %d, want 0 (allocation failed)", n)
+	}
+
+	// The job still runs to a terminal decision on the shared checkout.
+	worker := readonlyPoolWorker(store, home)
+	terminal := chatE2EDriveUntilTerminal(t, ctx, worker, store, out.JobID)
+	if terminal.State != string(workflow.JobSucceeded) {
+		t.Fatalf("fail-open job state = %q, want succeeded (must run on the shared checkout)", terminal.State)
+	}
+}

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -2,11 +2,48 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 )
+
+// recordReadOnlyWorktreeReclaimOnAbort marks a job's dispatch-allocated read-only
+// worktree (#739) for daemon reclaim when the job is ABORTED (cancel / kill /
+// supersede) instead of running to a terminal AdvanceJob. On main, reactive
+// worktrees were allocated at RUN time, so a queued job carried none; #739 now
+// allocates the worktree at DISPATCH (before enqueue), so a queued read-only ask
+// owns a detached worktree on disk. An abort bypasses the engine's deferred
+// cleanupReadOnlyDelegationWorktree, and neither the advance-retry pass (no advance
+// marker) nor the reclaim pass (no cleanup marker) would otherwise dispose it — it
+// leaks permanently, accumulating one worktree per aborted ask.
+//
+// This is store-only and best-effort, exactly like the sibling branch-lock release
+// on the same abort paths: it writes the delegation_worktree_cleanup_skipped marker
+// the reclaim pass already keys on, so reclaimSkippedDelegationWorktrees disposes
+// the worktree on a later tick (the reclaim state gate accepts cancelled). It is
+// gated on the worktree still existing on disk so an already-cleaned job (e.g. a
+// blocked ask whose run already disposed it) is not turned into a permanent,
+// never-reconciled reclaim candidate.
+func recordReadOnlyWorktreeReclaimOnAbort(ctx context.Context, store *db.Store, job db.Job, payload JobPayload) {
+	if !isReadOnlyDelegationWorktree(job.Type, payload) {
+		return
+	}
+	path := strings.TrimSpace(payload.WorktreePath)
+	if path == "" {
+		return
+	}
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	_ = store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   job.ID,
+		Kind:    "delegation_worktree_cleanup_skipped",
+		Message: fmt.Sprintf("read-only worktree %s preserved for daemon reclaim: job aborted (%s) before its terminal cleanup ran (#739)", path, job.State),
+	})
+}
 
 const JobEventSupersededStaleHead = "superseded_stale_head"
 
@@ -321,6 +358,9 @@ func CancelJob(ctx context.Context, store *db.Store, jobID string) (db.Job, erro
 				Message: fmt.Sprintf("released delegation branch lock %s on cancel (#617)", strings.TrimSpace(payload.Branch)),
 			})
 		}
+		// Symmetric with the branch-lock release above: dispose a #739 dispatch-time
+		// read-only worktree that this cancel-before-run would otherwise leak.
+		recordReadOnlyWorktreeReclaimOnAbort(ctx, store, job, payload)
 	}
 	return store.GetJob(ctx, job.ID)
 }
@@ -359,6 +399,12 @@ func SupersedeStaleHeadJob(ctx context.Context, store *db.Store, jobID string, r
 			return db.Job{}, false, getErr
 		}
 		return latest, false, nil
+	}
+	// Defensive symmetry with CancelJob: a superseded job that carried a #739
+	// dispatch-time read-only worktree must not leak it (no-op for the review jobs
+	// this path targets today, which run in a per-PR task worktree, not a #739 seat).
+	if payload, perr := unmarshalPayload(job.Payload); perr == nil {
+		recordReadOnlyWorktreeReclaimOnAbort(ctx, store, job, payload)
 	}
 	updated, err := store.GetJob(ctx, job.ID)
 	return updated, true, err

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -143,6 +143,14 @@ type JobRequest struct {
 	SynthesisRule          string
 	DelegationArtifactDir  string
 	WorktreePath           string
+	// ReadOnlyWorktree marks a job whose WorktreePath is a throwaway detached
+	// committed-tip worktree allocated for read-only (ask) isolation at DISPATCH
+	// time (#739) — as opposed to a delegation child's fan-out worktree (which
+	// carries a DelegationID) or an implement/task worktree (which carries a
+	// Branch). It is the explicit signal the terminal cleanup uses to dispose a
+	// TOP-LEVEL read-only worktree that has no DelegationID. Additive/omitempty:
+	// false leaves the enqueued payload byte-identical.
+	ReadOnlyWorktree       bool
 	OriginalAgent          string
 	DelegatedAgent         string
 	DelegationReason       string
@@ -218,6 +226,13 @@ type JobPayload struct {
 	SynthesisRule          string         `json:"synthesis_rule,omitempty"`
 	DelegationArtifactDir  string         `json:"delegation_artifact_dir,omitempty"`
 	WorktreePath           string         `json:"worktree_path,omitempty"`
+	// ReadOnlyWorktree marks a top-level read-only (ask) worktree allocated at
+	// dispatch time (#739): its WorktreePath is a throwaway detached committed-tip
+	// worktree with no DelegationID and no Branch. Additive/omitempty so a payload
+	// without it serializes byte-identically. The terminal cleanup keys off it to
+	// dispose top-level read-only worktrees that the DelegationID-gated read-only
+	// delegation cleanup would otherwise orphan.
+	ReadOnlyWorktree       bool           `json:"read_only_worktree,omitempty"`
 	TemplateID             string         `json:"template_id,omitempty"`
 	TemplateResolvedCommit string         `json:"template_resolved_commit,omitempty"`
 	TemplateContent        string         `json:"template_content,omitempty"`
@@ -339,6 +354,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		SynthesisRule:          strings.TrimSpace(request.SynthesisRule),
 		DelegationArtifactDir:  request.DelegationArtifactDir,
 		WorktreePath:           request.WorktreePath,
+		ReadOnlyWorktree:       request.ReadOnlyWorktree,
 		TemplateID:             snapshot.ID,
 		TemplateResolvedCommit: snapshot.ResolvedCommit,
 		TemplateContent:        snapshot.Content,

--- a/internal/workflow/readonly_worktree_test.go
+++ b/internal/workflow/readonly_worktree_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -58,10 +59,103 @@ func TestIsReadOnlyDelegationWorktree(t *testing.T) {
 		t.Fatal("implement child must not be treated as a read-only worktree")
 	}
 	if isReadOnlyDelegationWorktree("ask", JobPayload{WorktreePath: "/wt/d1"}) {
-		t.Fatal("non-delegation job (no delegation id) must not match")
+		t.Fatal("non-delegation job with no marker must not match")
 	}
 	if isReadOnlyDelegationWorktree("ask", JobPayload{DelegationID: "d1"}) {
 		t.Fatal("delegation child without a worktree path must not match")
+	}
+
+	// #739: a TOP-LEVEL read-only (ask) worktree carries the explicit
+	// ReadOnlyWorktree marker and NO DelegationID — it must match so the terminal
+	// cleanup disposes it (it would otherwise be orphaned by the DelegationID gate).
+	topLevel := JobPayload{WorktreePath: "/wt/seat", ReadOnlyWorktree: true}
+	if !isReadOnlyDelegationWorktree("ask", topLevel) {
+		t.Fatal("top-level marked read-only worktree (no delegation id) not detected (#739)")
+	}
+	// The marker without a worktree path is still not disposable (nothing to remove).
+	if isReadOnlyDelegationWorktree("ask", JobPayload{ReadOnlyWorktree: true}) {
+		t.Fatal("marker without a worktree path must not match")
+	}
+	// An implement/task worktree (Branch set, marker false) must NEVER match, even
+	// under a DelegationID — it is torn down through the merge gate, not here.
+	if isReadOnlyDelegationWorktree("implement", JobPayload{DelegationID: "d1", WorktreePath: "/wt/d1", Branch: "gitmoot-delegation-d1"}) {
+		t.Fatal("implement delegation worktree must not match the read-only predicate")
+	}
+}
+
+// TestCleanupDisposesTopLevelReadOnlyWorktree proves the #739 terminal disposal: a
+// TOP-LEVEL read-only (ask) worktree — allocated at dispatch, carrying the explicit
+// ReadOnlyWorktree marker and NO DelegationID — is force-removed by the existing
+// cleanupReadOnlyDelegationWorktree once its job is terminal, and an implement
+// worktree in the same call is left untouched.
+func TestCleanupDisposesTopLevelReadOnlyWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	wt := t.TempDir()
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "local-ask-seat", "ask", JobPayload{WorktreePath: wt, ReadOnlyWorktree: true})
+	if len(manager.removedForce) != 1 || manager.removedForce[0] != wt {
+		t.Fatalf("removedForce = %+v, want one force-remove of the top-level worktree %q", manager.removedForce, wt)
+	}
+	if got := countJobEvents(t, store, "local-ask-seat", "delegation_worktree_removed"); got != 1 {
+		t.Fatalf("delegation_worktree_removed count = %d, want 1", got)
+	}
+
+	// An implement worktree (marker false, Branch set) is NOT a read-only worktree.
+	manager.removedForce = nil
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "impl", "implement", JobPayload{DelegationID: "d1", WorktreePath: t.TempDir(), Branch: "b"})
+	if len(manager.removedForce) != 0 {
+		t.Fatalf("implement worktree must not be disposed by the read-only cleanup: %+v", manager.removedForce)
+	}
+}
+
+// TestReclaimReadOnlyWorktree proves ReclaimTerminalDelegationWorktree (the daemon's
+// restart/lock-expiry reclaim path) now also reclaims an orphaned TOP-LEVEL
+// read-only worktree (#739) whose deferred cleanup never ran (crash between terminal
+// advance and the defer), while still reclaiming an implement worktree.
+func TestReclaimReadOnlyWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	manager := &fakeWorktreeManager{}
+	engine.DelegationCheckout = t.TempDir()
+	engine.DelegationWorktrees = manager
+
+	// A terminal top-level read-only ask job whose worktree still exists on disk.
+	roWT := t.TempDir()
+	roPayload, err := json.Marshal(JobPayload{WorktreePath: roWT, ReadOnlyWorktree: true})
+	if err != nil {
+		t.Fatalf("marshal read-only payload: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "local-ask-seat", Agent: "responder", Type: "ask", State: string(JobSucceeded), Payload: string(roPayload)}); err != nil {
+		t.Fatalf("CreateJob read-only: %v", err)
+	}
+	if err := engine.ReclaimTerminalDelegationWorktree(ctx, "local-ask-seat"); err != nil {
+		t.Fatalf("ReclaimTerminalDelegationWorktree (read-only) returned error: %v", err)
+	}
+	if len(manager.removedForce) != 1 || manager.removedForce[0] != roWT {
+		t.Fatalf("removedForce = %+v, want the orphaned read-only worktree %q reclaimed", manager.removedForce, roWT)
+	}
+
+	// An implement delegation worktree is still reclaimed by the same path.
+	manager.removedForce = nil
+	implWT := t.TempDir()
+	implPayload, err := json.Marshal(JobPayload{DelegationID: "d1", WorktreePath: implWT, Branch: "gitmoot-delegation-d1"})
+	if err != nil {
+		t.Fatalf("marshal implement payload: %v", err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "parent/delegation/d1", Agent: "impl", Type: "implement", State: string(JobFailed), Payload: string(implPayload)}); err != nil {
+		t.Fatalf("CreateJob implement: %v", err)
+	}
+	if err := engine.ReclaimTerminalDelegationWorktree(ctx, "parent/delegation/d1"); err != nil {
+		t.Fatalf("ReclaimTerminalDelegationWorktree (implement) returned error: %v", err)
+	}
+	if len(manager.removedForce) != 1 || manager.removedForce[0] != implWT {
+		t.Fatalf("removedForce = %+v, want the implement worktree %q reclaimed", manager.removedForce, implWT)
 	}
 }
 

--- a/internal/workflow/readonly_worktree_test.go
+++ b/internal/workflow/readonly_worktree_test.go
@@ -274,6 +274,90 @@ func TestCleanupReadOnlyDelegationWorktreeForceRemoves(t *testing.T) {
 	}
 }
 
+// TestReadOnlyCleanupFailureIsReclaimable pins the #739-review fix: when a
+// read-only worktree's terminal disposal FAILS transiently (force-remove error),
+// cleanup must emit the reclaim-eligible delegation_worktree_cleanup_skipped marker
+// — NOT a dead-end delegation_worktree_cleanup_failed that no pass ever re-selects —
+// so ReclaimTerminalDelegationWorktree re-fires the cleanup on a later daemon tick
+// instead of leaking the worktree permanently.
+func TestReadOnlyCleanupFailureIsReclaimable(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := testEngine(store)
+	engine.DelegationCheckout = t.TempDir()
+	manager := &fakeWorktreeManager{removeErr: errors.New("worktree busy")}
+	engine.DelegationWorktrees = manager
+
+	wt := t.TempDir()
+	payload := JobPayload{WorktreePath: wt, ReadOnlyWorktree: true}
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "local-ask-seat", "ask", payload)
+
+	if got := countJobEvents(t, store, "local-ask-seat", "delegation_worktree_cleanup_failed"); got != 0 {
+		t.Fatalf("a transient read-only cleanup failure must not emit a dead-end cleanup_failed, got %d", got)
+	}
+	if got := countJobEvents(t, store, "local-ask-seat", "delegation_worktree_cleanup_skipped"); got != 1 {
+		t.Fatalf("a transient read-only cleanup failure must emit a reclaimable _skipped marker, got %d", got)
+	}
+	if !engine.lastCleanupOutcomeIsSkip(ctx, "local-ask-seat") {
+		t.Fatal("latest cleanup outcome must be a skip so reclaimSkippedDelegationWorktrees re-fires it")
+	}
+
+	// Deduped: a second failing pass must not grow the event log without bound.
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "local-ask-seat", "ask", payload)
+	if got := countJobEvents(t, store, "local-ask-seat", "delegation_worktree_cleanup_skipped"); got != 1 {
+		t.Fatalf("skip marker must be emitted at most once per preserve window, got %d", got)
+	}
+
+	// Once the removal succeeds, a re-fired cleanup disposes the worktree and closes
+	// the window (delegation_worktree_removed), so it drops out of the reclaim set.
+	manager.removeErr = nil
+	engine.cleanupReadOnlyDelegationWorktree(ctx, "local-ask-seat", "ask", payload)
+	if got := countJobEvents(t, store, "local-ask-seat", "delegation_worktree_removed"); got != 1 {
+		t.Fatalf("a later successful cleanup must emit delegation_worktree_removed, got %d", got)
+	}
+	if engine.lastCleanupOutcomeIsSkip(ctx, "local-ask-seat") {
+		t.Fatal("a successful removal must close the reclaim window")
+	}
+}
+
+// TestRecordReadOnlyWorktreeReclaimOnAbort pins the #739-review leak fix: a
+// read-only ask aborted (cancel/kill/supersede) before it ever runs must mark its
+// dispatch-allocated worktree for daemon reclaim, but only when the worktree is
+// still on disk (so an already-disposed job is not turned into a permanent,
+// never-reconciled reclaim candidate) and only for genuine read-only worktrees.
+func TestRecordReadOnlyWorktreeReclaimOnAbort(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+
+	// A queued read-only ask carrying a live dispatch worktree is marked for reclaim.
+	wt := t.TempDir()
+	recordReadOnlyWorktreeReclaimOnAbort(ctx, store,
+		db.Job{ID: "local-ask-live", Type: "ask", State: string(JobQueued)},
+		JobPayload{Repo: "owner/repo", WorktreePath: wt, ReadOnlyWorktree: true})
+	if got := countJobEvents(t, store, "local-ask-live", "delegation_worktree_cleanup_skipped"); got != 1 {
+		t.Fatalf("aborted read-only ask with a live worktree must be marked for reclaim, got %d", got)
+	}
+
+	// A worktree already gone from disk must NOT be marked (else it becomes a
+	// permanent candidate the reclaim pass can never reconcile).
+	gone := filepath.Join(t.TempDir(), "already-removed")
+	recordReadOnlyWorktreeReclaimOnAbort(ctx, store,
+		db.Job{ID: "local-ask-gone", Type: "ask", State: string(JobCancelled)},
+		JobPayload{Repo: "owner/repo", WorktreePath: gone, ReadOnlyWorktree: true})
+	if got := countJobEvents(t, store, "local-ask-gone", "delegation_worktree_cleanup_skipped"); got != 0 {
+		t.Fatalf("already-disposed worktree must not be marked for reclaim, got %d", got)
+	}
+
+	// An implement leg (Branch set, no read-only marker) is left to its own merge-gate
+	// cleanup and must not be touched by the read-only abort helper.
+	recordReadOnlyWorktreeReclaimOnAbort(ctx, store,
+		db.Job{ID: "impl-leg", Type: "implement", State: string(JobQueued)},
+		JobPayload{DelegationID: "d1", WorktreePath: t.TempDir(), Branch: "gitmoot-delegation-d1"})
+	if got := countJobEvents(t, store, "impl-leg", "delegation_worktree_cleanup_skipped"); got != 0 {
+		t.Fatalf("implement worktree must not be marked by the read-only abort helper, got %d", got)
+	}
+}
+
 func TestDispatchDelegationsTwoReadOnlySiblingsGetSeparateDetachedWorktrees(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -272,6 +272,60 @@ func (e Engine) AllocateDelegationWorktree(ctx context.Context, request Delegati
 	return DelegationWorktreeResult{Path: path, Branch: branch}, nil
 }
 
+// AllocateReadOnlyWorktree is the shared, package-level primitive that creates a
+// detached, branch-lock-free git worktree at the deterministic
+// DelegationWorktreePath(home, repo, pathParent, pathSegment, retryAttempt),
+// holding the checkout mutation lock (a detached `git worktree add` mutates the
+// shared .git) but taking NO branch lock and creating NO branch: a read-only
+// worker owns nothing to merge. The ref defaults to baseBranch, else HEAD (always
+// resolvable), and every failure is returned LOUDLY. It is the single source of
+// truth for both the read-only delegation fan-out
+// (AllocateReadOnlyDelegationWorktree) and the top-level dispatch-time read-only
+// isolation (#739), so the two paths stay behaviorally aligned. It takes an
+// explicit *db.Store rather than an Engine so the cli dispatch layer can call it
+// without an import cycle. The lock key mirrors the delegation path
+// ("worktree:<pathParent>/<pathSegment>") so distinct owners never collide.
+func AllocateReadOnlyWorktree(ctx context.Context, store *db.Store, home string, repo string, checkout string, pathParent string, pathSegment string, retryAttempt int, baseBranch string, manager ReadOnlyWorktreeManager) (string, error) {
+	if store == nil {
+		return "", errors.New("read-only worktree store is required")
+	}
+	if manager == nil {
+		return "", errors.New("read-only worktree manager is required")
+	}
+	if strings.TrimSpace(pathParent) == "" {
+		return "", errors.New("read-only worktree path parent is required")
+	}
+	if strings.TrimSpace(pathSegment) == "" {
+		return "", errors.New("read-only worktree path segment is required")
+	}
+	path, err := DelegationWorktreePath(home, repo, pathParent, pathSegment, retryAttempt)
+	if err != nil {
+		return "", err
+	}
+	ref := strings.TrimSpace(baseBranch)
+	if ref == "" {
+		ref = "HEAD"
+	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, store, checkout, "worktree:"+strings.TrimSpace(pathParent)+"/"+strings.TrimSpace(pathSegment), time.Now().UTC())
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
+	// Ensure the parent chain exists before `git worktree add` (matches the reactive
+	// pool-isolation path); the leaf is created by git itself.
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := manager.AddDetachedWorktree(ctx, path, ref); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
 // AllocateReadOnlyDelegationWorktree creates a detached, branch-lock-free git
 // worktree for a read-only (ask/review) delegation child so it does not
 // serialize with its same-repo siblings on the shared repo checkout key. It
@@ -279,7 +333,9 @@ func (e Engine) AllocateDelegationWorktree(ctx context.Context, request Delegati
 // (a detached `git worktree add` mutates the shared .git) but takes no branch
 // lock and creates no branch: a read-only child owns nothing to merge. The
 // worktree is disposed by cleanupReadOnlyDelegationWorktree once the child job
-// reaches a terminal state.
+// reaches a terminal state. It is a thin Engine wrapper over the shared
+// AllocateReadOnlyWorktree primitive: the delegation-specific validation (a
+// present parent+delegation id) is kept here so its error messages are unchanged.
 func (e Engine) AllocateReadOnlyDelegationWorktree(ctx context.Context, request DelegationWorktreeRequest, manager ReadOnlyWorktreeManager) (string, error) {
 	if err := e.validate(); err != nil {
 		return "", err
@@ -293,27 +349,7 @@ func (e Engine) AllocateReadOnlyDelegationWorktree(ctx context.Context, request 
 	if strings.TrimSpace(request.DelegationID) == "" {
 		return "", errors.New("delegation worktree delegation id is required")
 	}
-	path, err := DelegationWorktreePath(request.Home, request.Repo, request.ParentJobID, request.DelegationID, request.RetryAttempt)
-	if err != nil {
-		return "", err
-	}
-	ref := strings.TrimSpace(request.BaseBranch)
-	if ref == "" {
-		ref = "HEAD"
-	}
-	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, e.Store, request.Checkout, "worktree:"+request.ParentJobID+"/"+request.DelegationID, time.Now().UTC())
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		if releaseCheckoutLock != nil {
-			_ = releaseCheckoutLock(context.Background())
-		}
-	}()
-	if err := manager.AddDetachedWorktree(ctx, path, ref); err != nil {
-		return "", err
-	}
-	return path, nil
+	return AllocateReadOnlyWorktree(ctx, e.Store, request.Home, request.Repo, request.Checkout, request.ParentJobID, request.DelegationID, request.RetryAttempt, request.BaseBranch, manager)
 }
 
 // AllocateIntegrationWorktree creates a detached worktree off the parent base

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -272,6 +272,16 @@ func (e Engine) AllocateDelegationWorktree(ctx context.Context, request Delegati
 	return DelegationWorktreeResult{Path: path, Branch: branch}, nil
 }
 
+// ReadOnlyWorktreeDispatchLockWaitBudget bounds how long the SCHEDULER-LOOP
+// read-only worktree allocators (#739 dispatch-time isolation and the reactive
+// pool-isolation dispatcher) wait for the checkout mutation lock before failing
+// open. They run synchronously on the per-repo dispatch/poll loop, so the full
+// checkoutMutationWaitTimeout (2m) would stall that repo's dispatch AND reap for up
+// to two minutes whenever a same-repo merge gate holds the lock. Isolation is a
+// throughput optimization, not correctness: a miss just serializes the seat (which
+// the next tick retries), so a short, bounded wait is the right trade.
+const ReadOnlyWorktreeDispatchLockWaitBudget = 5 * time.Second
+
 // AllocateReadOnlyWorktree is the shared, package-level primitive that creates a
 // detached, branch-lock-free git worktree at the deterministic
 // DelegationWorktreePath(home, repo, pathParent, pathSegment, retryAttempt),
@@ -285,7 +295,18 @@ func (e Engine) AllocateDelegationWorktree(ctx context.Context, request Delegati
 // explicit *db.Store rather than an Engine so the cli dispatch layer can call it
 // without an import cycle. The lock key mirrors the delegation path
 // ("worktree:<pathParent>/<pathSegment>") so distinct owners never collide.
-func AllocateReadOnlyWorktree(ctx context.Context, store *db.Store, home string, repo string, checkout string, pathParent string, pathSegment string, retryAttempt int, baseBranch string, manager ReadOnlyWorktreeManager) (string, error) {
+//
+// lockWaitBudget bounds how long it waits for the checkout mutation lock before
+// returning a BlockedError. The read-only DELEGATION fan-out passes the full
+// checkoutMutationWaitTimeout (it runs inside an already-dispatched worker, off
+// any scheduler loop). The two HOT-PATH callers — the #739 dispatch-time
+// allocation and the reactive pool-isolation dispatcher — run SYNCHRONOUSLY on the
+// per-repo dispatch/poll loop, so they pass the much shorter
+// ReadOnlyWorktreeDispatchLockWaitBudget: under merge-gate lock contention the full
+// 2-minute wait would freeze that repo's whole dispatch+reap loop, and isolation is
+// a fail-open throughput optimization (a miss just serializes the seat, which the
+// next tick retries) — never worth stalling the scheduler.
+func AllocateReadOnlyWorktree(ctx context.Context, store *db.Store, home string, repo string, checkout string, pathParent string, pathSegment string, retryAttempt int, baseBranch string, lockWaitBudget time.Duration, manager ReadOnlyWorktreeManager) (string, error) {
 	if store == nil {
 		return "", errors.New("read-only worktree store is required")
 	}
@@ -306,7 +327,10 @@ func AllocateReadOnlyWorktree(ctx context.Context, store *db.Store, home string,
 	if ref == "" {
 		ref = "HEAD"
 	}
-	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, store, checkout, "worktree:"+strings.TrimSpace(pathParent)+"/"+strings.TrimSpace(pathSegment), time.Now().UTC())
+	if lockWaitBudget <= 0 {
+		lockWaitBudget = checkoutMutationWaitTimeout
+	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWaitBudget(ctx, store, checkout, "worktree:"+strings.TrimSpace(pathParent)+"/"+strings.TrimSpace(pathSegment), time.Now().UTC(), lockWaitBudget, checkoutMutationWaitBackoff)
 	if err != nil {
 		return "", err
 	}
@@ -349,7 +373,7 @@ func (e Engine) AllocateReadOnlyDelegationWorktree(ctx context.Context, request 
 	if strings.TrimSpace(request.DelegationID) == "" {
 		return "", errors.New("delegation worktree delegation id is required")
 	}
-	return AllocateReadOnlyWorktree(ctx, e.Store, request.Home, request.Repo, request.Checkout, request.ParentJobID, request.DelegationID, request.RetryAttempt, request.BaseBranch, manager)
+	return AllocateReadOnlyWorktree(ctx, e.Store, request.Home, request.Repo, request.Checkout, request.ParentJobID, request.DelegationID, request.RetryAttempt, request.BaseBranch, checkoutMutationWaitTimeout, manager)
 }
 
 // AllocateIntegrationWorktree creates a detached worktree off the parent base
@@ -527,7 +551,13 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 	}
 	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-cleanup:"+jobID, time.Now().UTC())
 	if err != nil {
-		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("read-only worktree %s cleanup could not lock checkout: %v", path, err)})
+		// A transient failure (lock contention) must NOT be terminal: emit the same
+		// reclaim marker the daemon's reclaimSkippedDelegationWorktrees pass keys on,
+		// so ReclaimTerminalDelegationWorktree re-fires this cleanup on a later tick
+		// rather than leaking the worktree. A bare delegation_worktree_cleanup_failed
+		// is never re-selected by any pass (it is not the latest advance marker, and
+		// the reclaim SQL only picks _skipped), so it would leak permanently (#739 review).
+		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, fmt.Sprintf("could not lock checkout: %v", err))
 		return
 	}
 	defer func() {
@@ -536,7 +566,7 @@ func (e Engine) cleanupReadOnlyDelegationWorktree(ctx context.Context, jobID str
 		}
 	}()
 	if err := manager.RemoveWorktreeForce(opCtx, path); err != nil {
-		_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_cleanup_failed", Message: fmt.Sprintf("read-only worktree %s force-remove failed: %v", path, err)})
+		e.recordReadOnlyCleanupSkippedOnce(opCtx, jobID, path, fmt.Sprintf("force-remove failed: %v", err))
 		return
 	}
 	_ = e.Store.AddJobEvent(opCtx, db.JobEvent{JobID: jobID, Kind: "delegation_worktree_removed", Message: fmt.Sprintf("read-only worktree %s removed", path)})
@@ -745,6 +775,26 @@ func (e Engine) recordCleanupSkippedOnce(ctx context.Context, jobID string, payl
 	})
 }
 
+// recordReadOnlyCleanupSkippedOnce emits the reclaim-eligible
+// delegation_worktree_cleanup_skipped marker for a read-only worktree whose
+// terminal disposal FAILED transiently (lock contention / force-remove error). It
+// is the read-only twin of recordCleanupSkippedOnce: without it a bare
+// delegation_worktree_cleanup_failed is never re-selected (the reclaim SQL keys on
+// _skipped, and the advance-retry pass keys on advance markers), so the worktree
+// would leak. Deduped by lastCleanupOutcomeIsSkip so a persistently-failing removal
+// does not grow the event log without bound; a later delegation_worktree_removed
+// closes the window.
+func (e Engine) recordReadOnlyCleanupSkippedOnce(ctx context.Context, jobID string, path string, reason string) {
+	if e.lastCleanupOutcomeIsSkip(ctx, jobID) {
+		return
+	}
+	_ = e.Store.AddJobEvent(context.WithoutCancel(ctx), db.JobEvent{
+		JobID:   jobID,
+		Kind:    "delegation_worktree_cleanup_skipped",
+		Message: fmt.Sprintf("read-only worktree %s cleanup skipped: %s", strings.TrimSpace(path), reason),
+	})
+}
+
 // lastCleanupOutcomeIsSkip reports whether the most recent terminal-cleanup outcome
 // event for jobID is a skip (preserve) not yet followed by a removal — i.e. another
 // skip would be redundant. Order matters (a worktree can be preserved, then later
@@ -766,20 +816,25 @@ func (e Engine) lastCleanupOutcomeIsSkip(ctx context.Context, jobID string) bool
 }
 
 // ReclaimTerminalDelegationWorktree re-attempts the terminal worktree cleanup for
-// an already-terminal job whose earlier terminal advance did not dispose its
-// worktree — either an implement child PRESERVED because a foreign runtime owner
-// was still active (delegation_worktree_cleanup_skipped), or a read-only worktree
-// (top-level ask #739, or a read-only delegation child) whose terminal advance was
-// interrupted by a daemon crash/restart before the deferred cleanup ran. It is the
-// daemon's lock-expiry-/restart-driven reclamation (#536): once the owner is gone
-// the worktree must be torn down rather than leaked. It re-runs BOTH idempotent,
-// liveness-gated cleanups, so it is a no-op when the owner is still active, when
-// the worktree is already gone, or for a job that allocated no worktree.
+// a job whose earlier disposal was DEFERRED, keyed by a
+// delegation_worktree_cleanup_skipped marker that the daemon's
+// reclaimSkippedDelegationWorktrees pass selects on. Two shapes reach here:
 //
-// Generalizing beyond implement also closes the pre-existing restart gap for
-// read-only DELEGATION worktrees: they were only ever disposed by the deferred
-// AdvanceJob cleanup, so a crash between terminal-advance and that defer leaked
-// them until now.
+//   - an implement child PRESERVED because a foreign runtime owner was still active
+//     (#536): reclaimed once the owner's lock releases or its lease expires;
+//   - a read-only worktree (top-level ask #739, or a read-only delegation child)
+//     whose disposal was deferred — either its terminal cleanup hit transient lock
+//     contention / a force-remove error (cleanupReadOnlyDelegationWorktree now
+//     records a _skipped marker on failure instead of a dead-end _cleanup_failed),
+//     or the job was ABORTED (cancel/kill/supersede) before it ever ran and
+//     recordReadOnlyWorktreeReclaimOnAbort marked its dispatch-allocated worktree.
+//
+// It re-runs BOTH idempotent, liveness-gated cleanups, so it is a no-op when the
+// owner is still active, when the worktree is already gone, or for a job that
+// allocated no worktree. Reachability is via the _skipped marker only: a pure crash
+// in the sub-millisecond window between advance_completed and the deferred cleanup
+// is NOT covered (that residual is shared with the implement path and unchanged by
+// #739).
 func (e Engine) ReclaimTerminalDelegationWorktree(ctx context.Context, jobID string) error {
 	if err := e.validate(); err != nil {
 		return err

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -476,12 +476,27 @@ func ReadOnlyWorktreeContextNote(baseCheckout string) string {
 }
 
 // isReadOnlyDelegationWorktree reports whether a job ran in a detached read-only
-// delegation worktree that must be disposed. Only read-only delegation children
-// allocate one; implement children carry a branch and are cleaned through the
-// merge gate, so they are excluded.
+// worktree that the terminal cleanup must dispose. Two disjoint shapes qualify:
+//
+//  1. A TOP-LEVEL read-only (ask) worktree allocated at DISPATCH time (#739),
+//     flagged by the explicit payload.ReadOnlyWorktree marker. It carries NO
+//     DelegationID, so without the marker the delegation-gated branch below would
+//     orphan it. The marker is set ONLY at the dispatch allocation site and ONLY
+//     for ask/review, so it can never be an implement/task worktree.
+//  2. A read-only DELEGATION child: a read-only action under a DelegationID with a
+//     WorktreePath. implement children carry a Branch and are cleaned through the
+//     merge gate (isImplementDelegationWorktree), so they are excluded here.
+//
+// Preferring the explicit marker over an implicit heuristic keeps implement/task
+// worktrees (marker false, Branch set) from ever matching.
 func isReadOnlyDelegationWorktree(jobType string, payload JobPayload) bool {
+	if strings.TrimSpace(payload.WorktreePath) == "" {
+		return false
+	}
+	if payload.ReadOnlyWorktree {
+		return true
+	}
 	return strings.TrimSpace(payload.DelegationID) != "" &&
-		strings.TrimSpace(payload.WorktreePath) != "" &&
 		readOnlyDelegationAction(jobType)
 }
 
@@ -750,15 +765,21 @@ func (e Engine) lastCleanupOutcomeIsSkip(ctx context.Context, jobID string) bool
 	return false
 }
 
-// ReclaimTerminalDelegationWorktree re-attempts the terminal implement-delegation
-// worktree+branch cleanup for an already-terminal child whose earlier terminal
-// advance PRESERVED it because a foreign runtime owner was still active (it emitted
-// delegation_worktree_cleanup_skipped). It is the daemon's lock-expiry-driven
-// reclamation (#536): once that foreign owner releases its lock or its lease
-// expires, the worktree is no longer owned and must be torn down rather than
-// leaked. It simply re-runs the same idempotent, liveness-gated cleanup, so it is a
-// no-op when the owner is still active, when the worktree is already gone, or for a
-// non-implement / non-delegation job.
+// ReclaimTerminalDelegationWorktree re-attempts the terminal worktree cleanup for
+// an already-terminal job whose earlier terminal advance did not dispose its
+// worktree — either an implement child PRESERVED because a foreign runtime owner
+// was still active (delegation_worktree_cleanup_skipped), or a read-only worktree
+// (top-level ask #739, or a read-only delegation child) whose terminal advance was
+// interrupted by a daemon crash/restart before the deferred cleanup ran. It is the
+// daemon's lock-expiry-/restart-driven reclamation (#536): once the owner is gone
+// the worktree must be torn down rather than leaked. It re-runs BOTH idempotent,
+// liveness-gated cleanups, so it is a no-op when the owner is still active, when
+// the worktree is already gone, or for a job that allocated no worktree.
+//
+// Generalizing beyond implement also closes the pre-existing restart gap for
+// read-only DELEGATION worktrees: they were only ever disposed by the deferred
+// AdvanceJob cleanup, so a crash between terminal-advance and that defer leaked
+// them until now.
 func (e Engine) ReclaimTerminalDelegationWorktree(ctx context.Context, jobID string) error {
 	if err := e.validate(); err != nil {
 		return err
@@ -768,6 +789,7 @@ func (e Engine) ReclaimTerminalDelegationWorktree(ctx context.Context, jobID str
 		return err
 	}
 	e.cleanupImplementDelegationWorktree(ctx, jobID, job.Type, payload)
+	e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload)
 	return nil
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -163,9 +163,13 @@ Both `daemon run` and `daemon start` also accept three opt-in flags (all off by
 default, so leaving them unset is byte-identical to before): `--watch-issues`
 watches open **issues** for `@<agent> ask …` mentions and routes them to jobs,
 mirroring the PR-comment watcher; `--scheduler pool` selects the continuous
-worker-pool scheduler that re-queries the queue as workers free and auto-isolates
-a contended same-repo read job into an ephemeral worktree (fixing a same-repo
-dependent-job deadlock), versus the default `--scheduler barrier`;
+worker-pool scheduler that re-queries the queue as workers free and reactively
+isolates a contended same-repo read job into an ephemeral worktree (fixing a
+same-repo dependent-job deadlock), versus the default `--scheduler barrier`.
+(Independently of the scheduler, background **read-only ask** jobs — moot seats,
+chat-task promotions, autorespond, `agent ask --background` — are each given their
+own detached committed-tip worktree **at dispatch** (#739), so they parallelize
+across same-repo seats under either scheduler with ≥2 workers.)
 `--watch-skillopt-reviews` polls watched SkillOpt review issue comments and
 imports valid feedback automatically (see the SkillOpt Exchange section).
 
@@ -1839,15 +1843,20 @@ gitmoot moot <name> "topic" --agents a,b,c --repo owner/repo [--max-messages N] 
   thread). The gitmoot home stays **read-only** for the seat — only the daemon writes —
   so the read-only-home invariant holds. A human/CLI takes the byte-identical
   direct-store path.
-- **Concurrency requirement**: seats are top-level read-only same-repo jobs, so they
-  converse concurrently **only** under the **pool scheduler with ≥2 workers** (start
-  the daemon with `--parallel N`, or set `[daemon] parallel = N`; a per-repo
-  `[repos."owner/repo"]` `max_parallel`/`scheduler` override also counts). Under the
-  **default** single-worker/barrier daemon the seats **serialize** on the shared
-  `repo:<repo>` checkout key: each seat's `chat wait` times out and the moot degrades
-  to sequential monologues. When it detects a serializing config, `gitmoot moot`
-  prints a **non-blocking** stderr warning naming the effective `workers`/`scheduler`
-  (it still dispatches every seat) — enable the pool scheduler so seats converse.
+- **Concurrency requirement**: seats are top-level read-only same-repo jobs. Each
+  seat gets its own detached committed-tip **worktree at dispatch** (#739), so it is
+  keyed off `worktree:<path>` instead of the shared `repo:<repo>` checkout key and
+  same-repo seats converse concurrently under **either scheduler** as long as the
+  daemon has **≥2 workers** (`--parallel N`, `[daemon] parallel = N`, or a per-repo
+  `[repos."owner/repo"]` `max_parallel` override). Scheduler mode no longer matters
+  (barrier batches the distinct-keyed seats per tick; pool runs them continuously).
+  The only remaining serializer is a genuinely **single-worker** daemon
+  (`parallel = 1`), where each seat's `chat wait` may time out and the moot degrades
+  to sequential monologues. When it detects a single-worker daemon, `gitmoot moot`
+  prints a **non-blocking** stderr warning (it still dispatches every seat) — give
+  the daemon ≥2 workers so seats converse. Because a seat runs in a committed-tip
+  worktree it sees the last committed state, not uncommitted edits (its prompt notes
+  the canonical checkout), the same isolation read-only delegation children use.
 
 Moot bounds (in `[chat]`, warm-reloadable):
 

--- a/website/docs/workflows/chat-workflow.md
+++ b/website/docs/workflows/chat-workflow.md
@@ -233,17 +233,26 @@ gitmoot chat wait paper-review --since-seq 12 --repo owner/repo
 #   prints any messages with seq > 12, then a `last-seq: N` line
 ```
 
-:::caution Seats converse concurrently only under a pool/multi-worker daemon
-Moot seats are top-level **read-only same-repo** jobs. They run at the same time —
-so they can actually hold a conversation — **only** under the **pool scheduler with
-≥2 workers** (start the daemon with `--parallel N`, or set `[daemon] parallel = N`;
-a per-repo `[repos."owner/repo"]` `max_parallel`/`scheduler` override also counts).
-Under the **default** single-worker/barrier daemon the seats **serialize** on the
-shared `repo:<repo>` checkout key: each seat's `chat wait` times out and the moot
-degrades into sequential monologues instead of a conversation. When `gitmoot moot`
-detects a serializing config it prints a **non-blocking** warning to stderr naming
-the effective `workers`/`scheduler` and still dispatches every seat — enable the
-pool scheduler so the seats converse.
+:::caution Seats converse concurrently under any scheduler with ≥2 workers
+Moot seats are top-level **read-only same-repo** jobs. Each seat is allocated its
+own detached committed-tip **worktree at dispatch**, so it is keyed off
+`worktree:<path>` — **not** the shared `repo:<repo>` checkout key — and same-repo
+seats run at the same time (so they can actually hold a conversation) under
+**either scheduler** as long as the daemon has **≥2 workers** (#739). Give the
+daemon parallelism with `--parallel N`, `[daemon] parallel = N`, or a per-repo
+`[repos."owner/repo"]` `max_parallel` override. The scheduler mode no longer
+matters: a barrier daemon selects the distinct-keyed seats into one concurrent
+per-tick batch, and the pool daemon runs them continuously. The **only** remaining
+serializer is a genuinely **single-worker** daemon (`parallel = 1`), where each
+seat's `chat wait` may time out and the moot degrades to sequential monologues.
+When `gitmoot moot` detects a single-worker daemon it prints a **non-blocking**
+warning to stderr and still dispatches every seat — give the daemon ≥2 workers so
+the seats converse.
+
+(Because each seat runs in a detached committed-tip worktree, a seat sees the
+repo's last **committed** state, not uncommitted working-tree edits; its prompt
+carries a note pointing at the canonical checkout for those. This is the same
+isolation model read-only delegation children already use.)
 :::
 
 #### The hard-stop (why moots don't ramble)

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -8137,9 +8137,13 @@ Both `daemon run` and `daemon start` also accept three opt-in flags (all off by
 default, so leaving them unset is byte-identical to before): `--watch-issues`
 watches open **issues** for `@<agent> ask …` mentions and routes them to jobs,
 mirroring the PR-comment watcher; `--scheduler pool` selects the continuous
-worker-pool scheduler that re-queries the queue as workers free and auto-isolates
-a contended same-repo read job into an ephemeral worktree (fixing a same-repo
-dependent-job deadlock), versus the default `--scheduler barrier`;
+worker-pool scheduler that re-queries the queue as workers free and reactively
+isolates a contended same-repo read job into an ephemeral worktree (fixing a
+same-repo dependent-job deadlock), versus the default `--scheduler barrier`.
+(Independently of the scheduler, background **read-only ask** jobs — moot seats,
+chat-task promotions, autorespond, `agent ask --background` — are each given their
+own detached committed-tip worktree **at dispatch** (#739), so they parallelize
+across same-repo seats under either scheduler with ≥2 workers.)
 `--watch-skillopt-reviews` polls watched SkillOpt review issue comments and
 imports valid feedback automatically (see the SkillOpt Exchange section).
 
@@ -9360,7 +9364,12 @@ meaningfully beats the weak agent (score gap ≥ `--gap`, default 0.20) AND the
 judge confirms the item is well-formed; otherwise the round records a
 diagnostic (`too_easy`, `too_hard`, `strong_failed`, `bad_rubric`, or
 `context_leak`) and the Challenger regenerates with targeted feedback until
-accepted or `--max-rounds-per-item` (default 3) is exhausted. Accepted items are
+accepted or `--max-rounds-per-item` (default 3) is exhausted. Every
+challenger/weak/strong/judge delivery is **sandboxed** into a fresh per-item temp
+scratch dir (never a registered repo checkout) and framed with an answer-only
+preamble, so an agentic-CLI attempt can never write files, start servers, or
+modify a live checkout while "answering" the exercise (`#725`); the scratch dir
+is deleted when the item finishes. Accepted items are
 written to `--out` (default `<home>/evals/synth`) and stored in the DB with
 status `pending_human_approval`. They are **structurally isolated**: nothing in
 the promotion/training path reads the synth table, so a pending item can never
@@ -9808,15 +9817,20 @@ gitmoot moot <name> "topic" --agents a,b,c --repo owner/repo [--max-messages N] 
   thread). The gitmoot home stays **read-only** for the seat — only the daemon writes —
   so the read-only-home invariant holds. A human/CLI takes the byte-identical
   direct-store path.
-- **Concurrency requirement**: seats are top-level read-only same-repo jobs, so they
-  converse concurrently **only** under the **pool scheduler with ≥2 workers** (start
-  the daemon with `--parallel N`, or set `[daemon] parallel = N`; a per-repo
-  `[repos."owner/repo"]` `max_parallel`/`scheduler` override also counts). Under the
-  **default** single-worker/barrier daemon the seats **serialize** on the shared
-  `repo:<repo>` checkout key: each seat's `chat wait` times out and the moot degrades
-  to sequential monologues. When it detects a serializing config, `gitmoot moot`
-  prints a **non-blocking** stderr warning naming the effective `workers`/`scheduler`
-  (it still dispatches every seat) — enable the pool scheduler so seats converse.
+- **Concurrency requirement**: seats are top-level read-only same-repo jobs. Each
+  seat gets its own detached committed-tip **worktree at dispatch** (#739), so it is
+  keyed off `worktree:<path>` instead of the shared `repo:<repo>` checkout key and
+  same-repo seats converse concurrently under **either scheduler** as long as the
+  daemon has **≥2 workers** (`--parallel N`, `[daemon] parallel = N`, or a per-repo
+  `[repos."owner/repo"]` `max_parallel` override). Scheduler mode no longer matters
+  (barrier batches the distinct-keyed seats per tick; pool runs them continuously).
+  The only remaining serializer is a genuinely **single-worker** daemon
+  (`parallel = 1`), where each seat's `chat wait` may time out and the moot degrades
+  to sequential monologues. When it detects a single-worker daemon, `gitmoot moot`
+  prints a **non-blocking** stderr warning (it still dispatches every seat) — give
+  the daemon ≥2 workers so seats converse. Because a seat runs in a committed-tip
+  worktree it sees the last committed state, not uncommitted edits (its prompt notes
+  the canonical checkout), the same isolation read-only delegation children use.
 
 Moot bounds (in `[chat]`, warm-reloadable):
 


### PR DESCRIPTION
Fixes #739 — contended same-repo read-only jobs (moot seats + any background `ask`/`review`) serialized on the `repo:<repo>` checkout key instead of running concurrently.

## Root cause (verified)
A job escapes `repo:<repo>` serialization only once its payload carries a `WorktreePath` (`queuedJobCheckoutKey`). Top-level read-only asks were dispatched with none; the only thing to give them one was the **reactive** pool-isolation second pass, which is headroom-gated, **silent** on failure, and **absent under the barrier scheduler entirely**. (The 'stale branch → worktree-add fails' hypothesis was empirically refuted — the add succeeds; the trigger is the reactive path's unreliability.)

## Fix — copy the proven delegation read-only fan-out (allocate *before* enqueue), don't restructure the race-sensitive selection loop
- **Shared allocator** `workflow.AllocateReadOnlyWorktree` extracted from `AllocateReadOnlyDelegationWorktree` (ref=HEAD, checkout-mutation lock, loud errors); the delegation path now calls it too.
- **Dispatch-time allocation** in `dispatchLocalAgentJob` for background read-only jobs (moot seats, chat task, autorespond, `agent ask --background`): the job is born keyed `worktree:<path>` → parallelizes under **any** scheduler with ≥2 workers. Fail-open to the shared checkout on error.
- **Disposal generalized**: a `ReadOnlyWorktree` payload marker broadens the terminal cleanup + restart reclaim to top-level worktrees (also closing the pre-existing read-only-delegation restart gap).
- **Reactive path hardened** (not restructured): routed through the shared allocator + emits `pool_isolation_worktree_allocated`/`_skipped` events (no more silent serialize).
- **Moot preflight** narrowed to warn only on <2 workers (worktrees remove the checkout-key serialization under any scheduler).

## Review-hardened (3-lens adversarial, 12 findings, 0 critical, all majors fixed)
- **Scheduler liveness (major):** hot-path allocators use a **5s** fail-open lock budget (`ReadOnlyWorktreeDispatchLockWaitBudget`), not the 2-min delegation timeout — a held merge-gate lock can't freeze the dispatch/reap loop.
- **Worktree-leak on Enqueue failure (major):** rolled back with `RemoveWorktreeForce`.
- **Worktree-leak on cancel/supersede-while-queued (major):** `CancelJob`/`SupersedeStaleHeadJob` mark the worktree for reclaim; the reclaim pass accepts `cancelled`.
- Read-only cleanup failures now emit the reclaim-eligible marker so the restart backstop is actually reachable.

**Behavior change (intended, precedented by delegation children):** background read-only asks now read a committed-tip worktree (miss uncommitted changes); the `ReadOnlyWorktreeContextNote` points them at the canonical checkout. Foreground `agent ask` (inline, never serializes) is untouched.

**Known scope:** PR/issue-comment `@agent ask` jobs (via `enqueueJob`, not `dispatchLocalAgentJob`) still serialize — they were never isolated on main either; extending them is a follow-up, not a regression.

Full gate incl. scoped `-race` green. Acceptance test post-deploy: a real 2-codex moot on the live gitmoot repo running seats concurrently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)