### PR TITLE
feat(memory): vault import — diff-and-confirm curation (#737 P2)

### DIFF
--- a/internal/cli/memory_vault.go
+++ b/internal/cli/memory_vault.go
@@ -26,10 +26,16 @@ const vaultLinkK = 5
 
 // vaultManifest is the vault's staleness anchor, written as manifest.json at the
 // vault root. snapshot_hash is memory.VaultSnapshotHash over the exported notes;
-// P2's import regenerates a fresh export and aborts if the hashes disagree.
+// P2's import regenerates a fresh export and aborts if the hashes disagree. Agent
+// records the export's --agent scope (empty == all owners) so import can regenerate
+// the fresh export with the SAME scope — otherwise a filtered `export --agent alice`
+// vault would always compare its alice-only hash against an all-owners rebuild and
+// abort as stale whenever any other owner has memories. omitempty keeps the common
+// all-owners manifest byte-identical to prior builds (no "agent" key emitted).
 type vaultManifest struct {
 	SchemaVersion int    `json:"schema_version"`
 	SnapshotHash  string `json:"snapshot_hash"`
+	Agent         string `json:"agent,omitempty"`
 }
 
 // vaultExportResult is the --json summary of an export run.
@@ -124,7 +130,7 @@ func runMemoryVaultExport(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return err
 		}
-		if err := commitVault(outDir, notes, indexes, snapshotHash, *force); err != nil {
+		if err := commitVault(outDir, notes, indexes, snapshotHash, *agent, *force); err != nil {
 			return err
 		}
 		result = vaultExportResult{
@@ -260,7 +266,7 @@ func vaultLinksFor(ctx context.Context, store *db.Store, src db.ConfirmedMemory)
 // replace itself moves any prior vault aside, renames the fresh tree into place,
 // then deletes the displaced tree — so an interruption never leaves --out
 // missing entirely (the old vault is restored on a failed rename).
-func commitVault(outDir string, notes []vaultNote, indexes []vaultIndexFile, snapshotHash string, force bool) error {
+func commitVault(outDir string, notes []vaultNote, indexes []vaultIndexFile, snapshotHash, agent string, force bool) error {
 	if !force {
 		ok, err := vaultTargetOverwritable(outDir)
 		if err != nil {
@@ -297,7 +303,7 @@ func commitVault(outDir string, notes []vaultNote, indexes []vaultIndexFile, sna
 			return fmt.Errorf("write index %s: %w", idx.filename, err)
 		}
 	}
-	manifestBytes, err := json.MarshalIndent(vaultManifest{SchemaVersion: vaultSchemaVersion, SnapshotHash: snapshotHash}, "", "  ")
+	manifestBytes, err := json.MarshalIndent(vaultManifest{SchemaVersion: vaultSchemaVersion, SnapshotHash: snapshotHash, Agent: agent}, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal manifest: %w", err)
 	}

--- a/internal/cli/memory_vault.go
+++ b/internal/cli/memory_vault.go
@@ -52,6 +52,8 @@ func runMemoryVault(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "export":
 		return runMemoryVaultExport(args[1:], stdout, stderr)
+	case "import":
+		return runMemoryVaultImport(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown memory vault command %q\n\n", args[0])
 		printMemoryVaultUsage(stderr)
@@ -64,6 +66,7 @@ func printMemoryVaultUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  export  regenerate a deterministic vault (one note per confirmed memory,")
 	fmt.Fprintln(w, "          per-owner index notes, and a manifest). The vault is a DERIVED VIEW:")
@@ -74,6 +77,13 @@ func printMemoryVaultUsage(w io.Writer) {
 	fmt.Fprintln(w, "          export refuses to overwrite a non-empty --out that is not itself a")
 	fmt.Fprintln(w, "          gitmoot vault, so it can never delete your own notes; pass --force to")
 	fmt.Fprintln(w, "          override.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  import  the human curation gate: diff an edited vault DIR against a FRESH")
+	fmt.Fprintln(w, "          export and apply only on confirmation. Edited notes update the source")
+	fmt.Fprintln(w, "          memory (CAS on updated_at), deleted notes retire their memory, and new")
+	fmt.Fprintln(w, "          .md files stage as pending observations. --dry-run (DEFAULT) prints the")
+	fmt.Fprintln(w, "          diff and writes NOTHING; --yes applies everything in one transaction.")
+	fmt.Fprintln(w, "          Aborts if the store changed since the vault was exported (stale).")
 }
 
 // vaultNote is one rendered memory note held in memory before the atomic commit.

--- a/internal/cli/memory_vault_import.go
+++ b/internal/cli/memory_vault_import.go
@@ -1,0 +1,378 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+)
+
+// memory vault import (#737 P2) — the human curation gate as an explicit
+// round-trip over the P1 export. The flow is strictly: read the vault's manifest →
+// regenerate a FRESH export in memory from the current store → abort if they
+// disagree (the store moved since export, so the diff would be meaningless) →
+// classify every note on disk against the fresh export (unchanged/edited/deleted/
+// new) → print the diff. --dry-run (the DEFAULT) writes nothing; --yes applies the
+// whole plan in one transaction. The markdown is a disposable view: nothing here
+// treats it as a second source of truth — every write still lands through a store
+// op (CAS content update, retire, or a pending observation behind the confirm gate).
+
+// vaultImportItem summarizes one planned mutation for the diff/JSON output.
+type vaultImportItem struct {
+	MemoryID int64  `json:"memory_id,omitempty"`
+	Key      string `json:"key,omitempty"`
+	File     string `json:"file,omitempty"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+// vaultImportResult is the --json summary (and the backing model for the text diff).
+type vaultImportResult struct {
+	Dir             string            `json:"dir"`
+	Applied         bool              `json:"applied"`
+	DryRun          bool              `json:"dry_run"`
+	SnapshotHash    string            `json:"snapshot_hash"`
+	Updates         []vaultImportItem `json:"updates"`
+	Retirements     []vaultImportItem `json:"retirements"`
+	NewObservations []vaultImportItem `json:"new_observations"`
+	Unchanged       int               `json:"unchanged"`
+	Warnings        []string          `json:"warnings"`
+}
+
+func runMemoryVaultImport(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory vault import", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	dryRun := fs.Bool("dry-run", false, "print the diff and write nothing (this is the default)")
+	yes := fs.Bool("yes", false, "apply the diff (edits, retirements, and new observations) in one transaction")
+	jsonOut := fs.Bool("json", false, "print the import summary as JSON")
+	// The directory is a positional and may appear before OR after the flags
+	// (`import <dir> --yes` and `import --yes <dir>` are both natural). Go's flag
+	// parser stops at the first non-flag argument, so parse the leading flags, lift
+	// out the first positional, then parse whatever flags trailed it.
+	if err := parseMemoryFlags(fs, args); err != nil {
+		return memoryFlagExit(err)
+	}
+	dir := strings.TrimSpace(fs.Arg(0))
+	if rest := fs.Args(); len(rest) > 1 {
+		if err := parseMemoryFlags(fs, rest[1:]); err != nil {
+			return memoryFlagExit(err)
+		}
+		if len(fs.Args()) > 0 {
+			fmt.Fprintf(stderr, "memory vault import: unexpected extra argument %q\n", fs.Arg(0))
+			return 2
+		}
+	}
+	if *dryRun && *yes {
+		fmt.Fprintln(stderr, "memory vault import: pass at most one of --dry-run and --yes")
+		return 2
+	}
+	if dir == "" {
+		fmt.Fprintln(stderr, "memory vault import: a vault directory argument is required")
+		printMemoryVaultUsage(stderr)
+		return 2
+	}
+	dir = filepath.Clean(dir)
+	apply := *yes // dry-run is the default whenever --yes is absent
+
+	var result vaultImportResult
+	err := withStore(*home, func(store *db.Store) error {
+		res, err := planAndApplyVaultImport(context.Background(), store, dir, apply)
+		if err != nil {
+			return err
+		}
+		result = res
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory vault import: %v\n", err)
+		return 1
+	}
+
+	if *jsonOut {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "memory vault import: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printVaultImportDiff(stdout, result)
+	return 0
+}
+
+// diskNote is one parsed .md file found in the vault directory.
+type diskNote struct {
+	file   string
+	raw    []byte
+	parsed memory.VaultNoteFile
+}
+
+// planAndApplyVaultImport is the whole import decision, isolated for testing. It
+// never writes unless apply is true.
+func planAndApplyVaultImport(ctx context.Context, store *db.Store, dir string, apply bool) (vaultImportResult, error) {
+	manifest, err := readVaultManifest(dir)
+	if err != nil {
+		return vaultImportResult{}, err
+	}
+	if manifest.SchemaVersion != vaultSchemaVersion {
+		return vaultImportResult{}, fmt.Errorf("vault schema v%d is not supported by this build (expected v%d); re-run `gitmoot memory vault export`", manifest.SchemaVersion, vaultSchemaVersion)
+	}
+
+	// Regenerate a fresh export from the current store and abort if the store moved
+	// since the vault was written — a stale diff could silently clobber newer facts.
+	freshNotes, _, freshHash, _, err := buildVault(ctx, store, "")
+	if err != nil {
+		return vaultImportResult{}, err
+	}
+	if freshHash != manifest.SnapshotHash {
+		return vaultImportResult{}, fmt.Errorf("vault is stale: the memory store changed since it was exported (manifest snapshot %s, current %s); re-run `gitmoot memory vault export` and re-apply your edits", manifest.SnapshotHash, freshHash)
+	}
+
+	disk, warnings, err := readVaultDiskNotes(dir)
+	if err != nil {
+		return vaultImportResult{}, err
+	}
+
+	result := vaultImportResult{Dir: dir, DryRun: !apply, SnapshotHash: freshHash}
+	var plan db.VaultImportPlan
+
+	// Index the disk notes that carry a memory_id so each fresh note can find its
+	// on-disk counterpart by id (robust to the human renaming the file).
+	diskByID := map[int64]diskNote{}
+	var newFiles []diskNote
+	for _, dn := range disk {
+		id, ok := dn.parsed.MemoryID()
+		if !ok {
+			newFiles = append(newFiles, dn)
+			continue
+		}
+		if _, dup := diskByID[id]; dup {
+			warnings = append(warnings, fmt.Sprintf("%s: duplicate memory_id %d (already claimed by another note); skipping", dn.file, id))
+			continue
+		}
+		diskByID[id] = dn
+	}
+
+	// Classify every fresh (current-store) note: edited, unchanged, or deleted.
+	for _, note := range freshNotes {
+		id := note.memRecord.ID
+		dn, ok := diskByID[id]
+		if !ok {
+			plan.Retirements = append(plan.Retirements, db.VaultImportRetire{ID: id, Reason: "vault-import: deleted by owner"})
+			result.Retirements = append(result.Retirements, vaultImportItem{MemoryID: id, Key: note.memRecord.Key, Detail: "note deleted from vault"})
+			continue
+		}
+		delete(diskByID, id)
+		if bytes.Equal(dn.raw, note.bytes) {
+			result.Unchanged++
+			continue
+		}
+		if drift := vaultFrontmatterDrift(dn.parsed, note.memRecord); drift != "" {
+			warnings = append(warnings, fmt.Sprintf("%s (memory %d): %s — out of scope for import; applying the content edit only", dn.file, id, drift))
+		}
+		body := dn.parsed.Body
+		if strings.TrimSpace(body) == "" {
+			warnings = append(warnings, fmt.Sprintf("%s (memory %d): edited note has empty content; skipping (delete the file to retire the memory)", dn.file, id))
+			continue
+		}
+		plan.Updates = append(plan.Updates, db.VaultImportUpdate{
+			ID:                id,
+			ExpectedUpdatedAt: note.memRecord.UpdatedAt,
+			Content:           body,
+			Provenance:        "vault-import",
+		})
+		result.Updates = append(result.Updates, vaultImportItem{MemoryID: id, Key: note.memRecord.Key, File: dn.file, Detail: "content edited"})
+	}
+
+	// Any disk memory_id not present in the fresh export refers to a row that is no
+	// longer injectable (already retired/superseded); leave it alone but flag it.
+	leftover := make([]int64, 0, len(diskByID))
+	for id := range diskByID {
+		leftover = append(leftover, id)
+	}
+	sort.Slice(leftover, func(i, j int) bool { return leftover[i] < leftover[j] })
+	for _, id := range leftover {
+		warnings = append(warnings, fmt.Sprintf("%s: memory_id %d is not in the current export (already retired or superseded); skipping", diskByID[id].file, id))
+	}
+
+	// New, owner-authored .md files (no memory_id) stage as pending observations
+	// behind the existing confirmation gate. They are owner-authored, so trust_mark
+	// is normal (P3's arbitrary-source ingest is the low-trust path).
+	for _, dn := range newFiles {
+		obs, ok, why := vaultObservationFromNewFile(dn)
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("%s: %s; skipping", dn.file, why))
+			continue
+		}
+		plan.Observations = append(plan.Observations, obs)
+		result.NewObservations = append(result.NewObservations, vaultImportItem{Key: obs.Key, File: dn.file, Detail: "new pending observation"})
+	}
+
+	result.Warnings = warnings
+
+	if apply && (len(plan.Updates) > 0 || len(plan.Retirements) > 0 || len(plan.Observations) > 0) {
+		if err := store.ApplyVaultImport(ctx, plan); err != nil {
+			return vaultImportResult{}, err
+		}
+		result.Applied = true
+	}
+	return result, nil
+}
+
+// readVaultManifest reads and validates <dir>/manifest.json.
+func readVaultManifest(dir string) (vaultManifest, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return vaultManifest{}, fmt.Errorf("%s is not a gitmoot vault: no manifest.json (run `gitmoot memory vault export` first)", dir)
+		}
+		return vaultManifest{}, fmt.Errorf("read manifest: %w", err)
+	}
+	var m vaultManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return vaultManifest{}, fmt.Errorf("%s has an invalid manifest.json: %w", dir, err)
+	}
+	if m.SchemaVersion <= 0 {
+		return vaultManifest{}, fmt.Errorf("%s has an invalid manifest.json (no schema_version)", dir)
+	}
+	return m, nil
+}
+
+// readVaultDiskNotes reads every top-level .md memory note from the vault dir,
+// skipping derived/index/manifest/.obsidian artifacts. Parse failures are reported
+// as warnings rather than aborting the whole import.
+func readVaultDiskNotes(dir string) ([]diskNote, []string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read vault dir: %w", err)
+	}
+	var notes []diskNote
+	var warnings []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			continue // flat vault; .obsidian and any nested dirs are ignored
+		}
+		if name == "manifest.json" || !strings.HasSuffix(name, ".md") || strings.HasPrefix(name, "_index-") {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return nil, nil, fmt.Errorf("read note %s: %w", name, err)
+		}
+		parsed, err := memory.ParseVaultNote(string(raw))
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: not a valid vault note (%v); skipping", name, err))
+			continue
+		}
+		notes = append(notes, diskNote{file: name, raw: raw, parsed: parsed})
+	}
+	sort.Slice(notes, func(i, j int) bool { return notes[i].file < notes[j].file })
+	return notes, warnings, nil
+}
+
+// vaultFrontmatterDrift reports whether the owner edited an identity/classification
+// field (out of scope for import — only content edits apply). Empty string == none.
+func vaultFrontmatterDrift(f memory.VaultNoteFile, want memory.VaultMemory) string {
+	var diffs []string
+	check := func(label, got, expected string) {
+		if got != expected {
+			diffs = append(diffs, fmt.Sprintf("%s %q→%q", label, expected, got))
+		}
+	}
+	check("key", f.String("key"), want.Key)
+	check("scope", f.String("scope"), want.Scope)
+	check("owner_kind", f.String("owner_kind"), want.OwnerKind)
+	check("owner_ref", f.String("owner_ref"), want.OwnerRef)
+	check("owner_version", f.String("owner_version"), want.OwnerVersion)
+	check("repo", f.String("repo"), want.Repo)
+	if len(diffs) == 0 {
+		return ""
+	}
+	return "frontmatter changed (" + strings.Join(diffs, ", ") + ")"
+}
+
+// vaultObservationFromNewFile builds a pending observation from an owner-authored
+// note that carries no memory_id. It needs an owner ref and non-empty content; the
+// key falls back to the filename stem. Returns ok=false with a reason when the file
+// lacks the minimum an observation requires.
+func vaultObservationFromNewFile(dn diskNote) (db.MemoryObservation, bool, string) {
+	f := dn.parsed
+	ownerRef := f.String("owner_ref")
+	if ownerRef == "" {
+		ownerRef = f.String("agent")
+	}
+	if strings.TrimSpace(ownerRef) == "" {
+		return db.MemoryObservation{}, false, "new note has no owner_ref/agent in its frontmatter"
+	}
+	ownerKind := f.String("owner_kind")
+	if strings.TrimSpace(ownerKind) == "" {
+		ownerKind = memory.OwnerKindAgent
+	}
+	content := f.Body
+	if strings.TrimSpace(content) == "" {
+		return db.MemoryObservation{}, false, "new note has empty content"
+	}
+	key := f.String("key")
+	if strings.TrimSpace(key) == "" {
+		key = strings.TrimSuffix(dn.file, ".md")
+	}
+	return db.MemoryObservation{
+		Owner:      db.MemoryOwner{Kind: ownerKind, Ref: ownerRef, Version: f.String("owner_version")},
+		Repo:       f.String("repo"),
+		Scope:      f.String("scope"),
+		Key:        key,
+		Content:    content,
+		Provenance: "vault-import:" + dn.file,
+		TrustMark:  memory.TrustNormal,
+	}, true, ""
+}
+
+// printVaultImportDiff renders the human-readable diff/summary.
+func printVaultImportDiff(w io.Writer, r vaultImportResult) {
+	fmt.Fprintf(w, "vault import diff for %s\n", r.Dir)
+	fmt.Fprintf(w, "  %d edit(s), %d retirement(s), %d new observation(s), %d unchanged\n",
+		len(r.Updates), len(r.Retirements), len(r.NewObservations), r.Unchanged)
+	section := func(title string, items []vaultImportItem) {
+		if len(items) == 0 {
+			return
+		}
+		fmt.Fprintf(w, "\n%s:\n", title)
+		for _, it := range items {
+			switch {
+			case it.MemoryID != 0:
+				fmt.Fprintf(w, "  - memory %d [%s] %s\n", it.MemoryID, it.Key, it.Detail)
+			default:
+				fmt.Fprintf(w, "  - %s [%s] %s\n", it.File, it.Key, it.Detail)
+			}
+		}
+	}
+	section("Edits (content updated)", r.Updates)
+	section("Retirements (note deleted)", r.Retirements)
+	section("New notes (staged as pending observations)", r.NewObservations)
+	if len(r.Warnings) > 0 {
+		fmt.Fprintln(w, "\nWarnings:")
+		for _, wn := range r.Warnings {
+			fmt.Fprintf(w, "  ! %s\n", wn)
+		}
+	}
+	fmt.Fprintln(w)
+	if r.Applied {
+		fmt.Fprintln(w, "applied: all changes committed in one transaction.")
+		return
+	}
+	if len(r.Updates) == 0 && len(r.Retirements) == 0 && len(r.NewObservations) == 0 {
+		fmt.Fprintln(w, "no changes to apply.")
+		return
+	}
+	fmt.Fprintln(w, "(dry run — nothing was written; re-run with --yes to apply)")
+}

--- a/internal/cli/memory_vault_import.go
+++ b/internal/cli/memory_vault_import.go
@@ -129,7 +129,10 @@ func planAndApplyVaultImport(ctx context.Context, store *db.Store, dir string, a
 
 	// Regenerate a fresh export from the current store and abort if the store moved
 	// since the vault was written — a stale diff could silently clobber newer facts.
-	freshNotes, _, freshHash, _, err := buildVault(ctx, store, "")
+	// Rebuild with the SAME scope the export used (manifest.Agent, empty == all owners)
+	// so a filtered `export --agent NAME` vault compares like-for-like instead of always
+	// failing stale against an all-owners rebuild when other owners have memories.
+	freshNotes, _, freshHash, _, err := buildVault(ctx, store, manifest.Agent)
 	if err != nil {
 		return vaultImportResult{}, err
 	}
@@ -137,9 +140,18 @@ func planAndApplyVaultImport(ctx context.Context, store *db.Store, dir string, a
 		return vaultImportResult{}, fmt.Errorf("vault is stale: the memory store changed since it was exported (manifest snapshot %s, current %s); re-run `gitmoot memory vault export` and re-apply your edits", manifest.SnapshotHash, freshHash)
 	}
 
-	disk, warnings, err := readVaultDiskNotes(dir)
+	disk, warnings, parseFailed, err := readVaultDiskNotes(dir)
 	if err != nil {
 		return vaultImportResult{}, err
+	}
+	// A note that fails to parse is DROPPED from `disk`, so its memory_id can no longer
+	// be matched to a fresh-export row — the classify loop below would then read the
+	// missing counterpart as a deletion and RETIRE a fact whose file is still sitting on
+	// disk (an owner's YAML typo silently destroying a memory). Refuse to apply while any
+	// note failed to parse; dry-run still previews (writing nothing) so the operator can
+	// see the warning and fix the frontmatter before re-running.
+	if apply && len(parseFailed) > 0 {
+		return vaultImportResult{}, fmt.Errorf("%d vault note(s) failed to parse (%s); refusing to apply because a malformed note would be misread as a deletion — fix the frontmatter (or delete the file to intentionally retire it), then re-export and re-apply", len(parseFailed), strings.Join(parseFailed, ", "))
 	}
 
 	result := vaultImportResult{Dir: dir, DryRun: !apply, SnapshotHash: freshHash}
@@ -167,7 +179,7 @@ func planAndApplyVaultImport(ctx context.Context, store *db.Store, dir string, a
 		id := note.memRecord.ID
 		dn, ok := diskByID[id]
 		if !ok {
-			plan.Retirements = append(plan.Retirements, db.VaultImportRetire{ID: id, Reason: "vault-import: deleted by owner"})
+			plan.Retirements = append(plan.Retirements, db.VaultImportRetire{ID: id, ExpectedUpdatedAt: note.memRecord.UpdatedAt, Reason: "vault-import: deleted by owner"})
 			result.Retirements = append(result.Retirements, vaultImportItem{MemoryID: id, Key: note.memRecord.Key, Detail: "note deleted from vault"})
 			continue
 		}
@@ -249,14 +261,14 @@ func readVaultManifest(dir string) (vaultManifest, error) {
 
 // readVaultDiskNotes reads every top-level .md memory note from the vault dir,
 // skipping derived/index/manifest/.obsidian artifacts. Parse failures are reported
-// as warnings rather than aborting the whole import.
-func readVaultDiskNotes(dir string) ([]diskNote, []string, error) {
+// as warnings AND returned in parseFailed (the filenames) so the caller can refuse
+// to apply — a dropped note whose memory_id can no longer be matched would be
+// misread as a deletion and retire a live fact.
+func readVaultDiskNotes(dir string) (notes []diskNote, warnings []string, parseFailed []string, err error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read vault dir: %w", err)
+		return nil, nil, nil, fmt.Errorf("read vault dir: %w", err)
 	}
-	var notes []diskNote
-	var warnings []string
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() {
@@ -267,17 +279,18 @@ func readVaultDiskNotes(dir string) ([]diskNote, []string, error) {
 		}
 		raw, err := os.ReadFile(filepath.Join(dir, name))
 		if err != nil {
-			return nil, nil, fmt.Errorf("read note %s: %w", name, err)
+			return nil, nil, nil, fmt.Errorf("read note %s: %w", name, err)
 		}
 		parsed, err := memory.ParseVaultNote(string(raw))
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("%s: not a valid vault note (%v); skipping", name, err))
+			parseFailed = append(parseFailed, name)
 			continue
 		}
 		notes = append(notes, diskNote{file: name, raw: raw, parsed: parsed})
 	}
 	sort.Slice(notes, func(i, j int) bool { return notes[i].file < notes[j].file })
-	return notes, warnings, nil
+	return notes, warnings, parseFailed, nil
 }
 
 // vaultFrontmatterDrift reports whether the owner edited an identity/classification

--- a/internal/cli/memory_vault_import_test.go
+++ b/internal/cli/memory_vault_import_test.go
@@ -237,6 +237,97 @@ func TestVaultImportUnknownFileStagesObservation(t *testing.T) {
 	}
 }
 
+// TestVaultImportMalformedNoteNoRetire proves an owner's broken YAML frontmatter is
+// NOT silently reclassified into a retirement: `import --yes` refuses to apply while
+// any note fails to parse, and the underlying confirmed fact survives intact.
+func TestVaultImportMalformedNoteNoRetire(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
+	keepID := seedConfirmed(t, store, owner, "acme/widget", "repo", "keep", "keep content about arm64")
+
+	dir := filepath.Join(t.TempDir(), "vault")
+	exportVault(t, home, dir, "")
+
+	// Corrupt the note's frontmatter with an unclosed quote (a realistic hand-edit
+	// slip) so ParseVaultNote fails and the note drops out of the disk set.
+	notePath := filepath.Join(dir, noteFileFor(keepID, "keep"))
+	raw, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("read note: %v", err)
+	}
+	broken := strings.Replace(string(raw), "---\n", "---\nbroken: \"unclosed value\n", 1)
+	if broken == string(raw) {
+		t.Fatal("failed to inject a frontmatter break")
+	}
+	if err := os.WriteFile(notePath, []byte(broken), 0o644); err != nil {
+		t.Fatalf("write broken note: %v", err)
+	}
+
+	// --yes must refuse rather than retire the memory whose file is still on disk.
+	_, code, stderr := importVault(t, home, dir, true)
+	if code == 0 {
+		t.Fatal("import --yes must fail while a note failed to parse")
+	}
+	if !strings.Contains(stderr, "failed to parse") || !strings.Contains(stderr, "refusing to apply") {
+		t.Fatalf("want a parse-refusal error, got: %s", stderr)
+	}
+
+	// The fact is untouched: still confirmed, not retired.
+	rows, _ := store.ListConfirmedMemories(ctx, "builder", "")
+	if len(rows) != 1 || rows[0].ID != keepID {
+		t.Fatalf("malformed import must not touch the store, got %+v", rows)
+	}
+	if n, _ := store.CountConfirmedMemoriesForOwner(ctx, "agent", "builder"); n != 1 {
+		t.Fatalf("fact must remain injectable (count 1), got %d", n)
+	}
+}
+
+// TestVaultImportAgentScopedRoundTrip proves a vault produced by `export --agent NAME`
+// is importable even when OTHER owners have memories: import rebuilds the fresh export
+// with the manifest's recorded scope, so a filtered vault no longer aborts as stale.
+func TestVaultImportAgentScopedRoundTrip(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	alice := db.MemoryOwner{Kind: "agent", Ref: "alice"}
+	bob := db.MemoryOwner{Kind: "agent", Ref: "bob"}
+	aliceEdit := seedConfirmed(t, store, alice, "acme/widget", "repo", "edit", "alice content about arm64")
+	seedConfirmed(t, store, bob, "acme/widget", "repo", "bobkey", "bob content about arm64")
+
+	dir := filepath.Join(t.TempDir(), "vault")
+	exportVault(t, home, dir, "alice") // filtered export: only alice's note + alice-scoped hash
+
+	// Edit alice's note; bob's memories exist but are outside the export scope.
+	editNote := filepath.Join(dir, noteFileFor(aliceEdit, "edit"))
+	raw, _ := os.ReadFile(editNote)
+	edited := strings.Replace(string(raw), "alice content about arm64", "EDITED alice graviton content", 1)
+	if edited == string(raw) {
+		t.Fatal("edit substitution did not change the note")
+	}
+	if err := os.WriteFile(editNote, []byte(edited), 0o644); err != nil {
+		t.Fatalf("write edit note: %v", err)
+	}
+
+	// Must NOT abort as stale (pre-fix bug: alice-only hash vs all-owners rebuild).
+	res, code, stderr := importVault(t, home, dir, true)
+	if code != 0 {
+		t.Fatalf("agent-scoped import exit %d: %s", code, stderr)
+	}
+	if !res.Applied || len(res.Updates) != 1 || res.Updates[0].MemoryID != aliceEdit {
+		t.Fatalf("want alice edit applied, got %+v", res)
+	}
+
+	rows, _ := store.ListConfirmedMemories(ctx, "alice", "")
+	if len(rows) != 1 || rows[0].Content != "EDITED alice graviton content\n" {
+		t.Fatalf("alice edit not applied: %+v", rows)
+	}
+	// Bob's memory is untouched (never in scope).
+	bobRows, _ := store.ListConfirmedMemories(ctx, "bob", "")
+	if len(bobRows) != 1 || bobRows[0].Content != "bob content about arm64" {
+		t.Fatalf("bob must be untouched, got %+v", bobRows)
+	}
+}
+
 // TestVaultImportNotAVault rejects a directory without a manifest.
 func TestVaultImportNotAVault(t *testing.T) {
 	home, store := memoryTestHome(t)

--- a/internal/cli/memory_vault_import_test.go
+++ b/internal/cli/memory_vault_import_test.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+)
+
+// importVault runs `memory vault import --json` and returns the parsed result plus
+// the exit code and stderr for the failure-path assertions.
+func importVault(t *testing.T, home, dir string, apply bool) (vaultImportResult, int, string) {
+	t.Helper()
+	args := []string{"vault", "import", "--home", home, "--json", dir}
+	if apply {
+		args = append(args, "--yes")
+	}
+	var stdout, stderr bytes.Buffer
+	code := runMemory(args, &stdout, &stderr)
+	var res vaultImportResult
+	if code == 0 {
+		if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+			t.Fatalf("parse import result: %v (%s)", err, stdout.String())
+		}
+	}
+	return res, code, stderr.String()
+}
+
+func noteFileFor(id int64, key string) string { return memory.VaultFilename(id, key) }
+
+// TestVaultImportDryRunNoWrites proves the default (dry-run) diff is correct and
+// writes nothing to the store.
+func TestVaultImportDryRunNoWrites(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
+	keepID := seedConfirmed(t, store, owner, "acme/widget", "repo", "keep", "keep content about arm64")
+	editID := seedConfirmed(t, store, owner, "acme/widget", "repo", "edit", "edit content about arm64")
+	delID := seedConfirmed(t, store, owner, "acme/widget", "repo", "drop", "drop content about arm64")
+	_ = keepID
+
+	dir := filepath.Join(t.TempDir(), "vault")
+	exportVault(t, home, dir, "")
+
+	// Edit one note's body, delete another, add a brand-new owner-authored note.
+	editNote := filepath.Join(dir, noteFileFor(editID, "edit"))
+	raw, err := os.ReadFile(editNote)
+	if err != nil {
+		t.Fatalf("read edit note: %v", err)
+	}
+	edited := strings.Replace(string(raw), "edit content about arm64", "edit content about graviton now", 1)
+	if edited == string(raw) {
+		t.Fatal("edit substitution did not change the note")
+	}
+	if err := os.WriteFile(editNote, []byte(edited), 0o644); err != nil {
+		t.Fatalf("write edit note: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, noteFileFor(delID, "drop"))); err != nil {
+		t.Fatalf("delete note: %v", err)
+	}
+	newNote := "---\nowner_kind: \"agent\"\nowner_ref: \"builder\"\nrepo: \"acme/widget\"\nscope: \"repo\"\nkey: \"brand-new\"\n---\na brand new owner-authored note about deploys\n"
+	if err := os.WriteFile(filepath.Join(dir, "brand-new.md"), []byte(newNote), 0o644); err != nil {
+		t.Fatalf("write new note: %v", err)
+	}
+
+	res, code, stderr := importVault(t, home, dir, false)
+	if code != 0 {
+		t.Fatalf("dry-run import exit %d: %s", code, stderr)
+	}
+	if res.Applied {
+		t.Fatal("dry-run must not apply")
+	}
+	if len(res.Updates) != 1 || res.Updates[0].MemoryID != editID {
+		t.Fatalf("want 1 update for edit id %d, got %+v", editID, res.Updates)
+	}
+	if len(res.Retirements) != 1 || res.Retirements[0].MemoryID != delID {
+		t.Fatalf("want 1 retirement for drop id %d, got %+v", delID, res.Retirements)
+	}
+	if len(res.NewObservations) != 1 {
+		t.Fatalf("want 1 new observation, got %+v", res.NewObservations)
+	}
+	if res.Unchanged != 1 {
+		t.Fatalf("want 1 unchanged (keep), got %d", res.Unchanged)
+	}
+
+	// Nothing was written: still 3 confirmed rows, zero observations.
+	rows, _ := store.ListConfirmedMemories(ctx, "builder", "")
+	if len(rows) != 3 {
+		t.Fatalf("dry-run wrote to the store: %d confirmed rows", len(rows))
+	}
+	obs, _ := store.CountMemoryObservationsForOwner(ctx, "agent", "builder")
+	if obs != 0 {
+		t.Fatalf("dry-run staged observations: %d", obs)
+	}
+}
+
+// TestVaultImportApplyRoundTrip is the full P2 E2E: export → edit + delete + add →
+// import --yes → a fresh re-export reflects all three curations.
+func TestVaultImportApplyRoundTrip(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
+	keepID := seedConfirmed(t, store, owner, "acme/widget", "repo", "keep", "keep content about arm64")
+	editID := seedConfirmed(t, store, owner, "acme/widget", "repo", "edit", "edit content about arm64")
+	delID := seedConfirmed(t, store, owner, "acme/widget", "repo", "drop", "drop content about arm64")
+
+	dir := filepath.Join(t.TempDir(), "vault")
+	exportVault(t, home, dir, "")
+
+	editNote := filepath.Join(dir, noteFileFor(editID, "edit"))
+	raw, _ := os.ReadFile(editNote)
+	edited := strings.Replace(string(raw), "edit content about arm64", "EDITED graviton content", 1)
+	if err := os.WriteFile(editNote, []byte(edited), 0o644); err != nil {
+		t.Fatalf("write edit note: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, noteFileFor(delID, "drop"))); err != nil {
+		t.Fatalf("delete note: %v", err)
+	}
+	newNote := "---\nowner_kind: \"agent\"\nowner_ref: \"builder\"\nrepo: \"acme/widget\"\nscope: \"repo\"\nkey: \"brand-new\"\n---\na brand new owner-authored note about deploys\n"
+	if err := os.WriteFile(filepath.Join(dir, "brand-new.md"), []byte(newNote), 0o644); err != nil {
+		t.Fatalf("write new note: %v", err)
+	}
+
+	res, code, stderr := importVault(t, home, dir, true)
+	if code != 0 {
+		t.Fatalf("apply import exit %d: %s", code, stderr)
+	}
+	if !res.Applied {
+		t.Fatal("--yes must apply")
+	}
+
+	// Confirmed store: edit landed, delete retired, keep intact.
+	rows, _ := store.ListConfirmedMemories(ctx, "builder", "")
+	byID := map[int64]db.ConfirmedMemory{}
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+	if byID[editID].Content != "EDITED graviton content\n" {
+		t.Fatalf("edit not applied, content = %q", byID[editID].Content)
+	}
+	if byID[editID].Provenance != "vault-import" {
+		t.Fatalf("edit provenance = %q, want vault-import", byID[editID].Provenance)
+	}
+	if byID[keepID].Content != "keep content about arm64" {
+		t.Fatalf("keep must be untouched, content = %q", byID[keepID].Content)
+	}
+
+	// Re-export: the retired note is gone, the edit is reflected, keep remains, and
+	// the new observation is staged (pending, not yet in the confirmed vault).
+	dir2 := filepath.Join(t.TempDir(), "vault2")
+	exportVault(t, home, dir2, "")
+	if _, err := os.Stat(filepath.Join(dir2, noteFileFor(delID, "drop"))); !os.IsNotExist(err) {
+		t.Fatalf("retired note must not re-export (stat err = %v)", err)
+	}
+	reRaw, err := os.ReadFile(filepath.Join(dir2, noteFileFor(editID, "edit")))
+	if err != nil {
+		t.Fatalf("read re-exported edit note: %v", err)
+	}
+	if !strings.Contains(string(reRaw), "EDITED graviton content") {
+		t.Fatalf("re-export missing edit:\n%s", reRaw)
+	}
+	if _, err := os.Stat(filepath.Join(dir2, noteFileFor(keepID, "keep"))); err != nil {
+		t.Fatalf("keep note must still export: %v", err)
+	}
+	obs, _ := store.CountMemoryObservationsForOwner(ctx, "agent", "builder")
+	if obs != 1 {
+		t.Fatalf("want 1 staged observation, got %d", obs)
+	}
+	pending, _ := store.ListMemoryObservations(ctx, "builder", "")
+	if len(pending) != 1 || pending[0].Key != "brand-new" || pending[0].Provenance != "vault-import:brand-new.md" {
+		t.Fatalf("staged observation wrong: %+v", pending)
+	}
+}
+
+// TestVaultImportStaleAborts proves import refuses when the store moved since the
+// vault was exported.
+func TestVaultImportStaleAborts(t *testing.T) {
+	home, store := memoryTestHome(t)
+	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
+	seedConfirmed(t, store, owner, "acme/widget", "repo", "keep", "keep content about arm64")
+
+	dir := filepath.Join(t.TempDir(), "vault")
+	exportVault(t, home, dir, "")
+
+	// Mutate the store after export → the fresh snapshot no longer matches manifest.
+	seedConfirmed(t, store, owner, "acme/widget", "repo", "added-after", "a fact added after export")
+
+	_, code, stderr := importVault(t, home, dir, true)
+	if code == 0 {
+		t.Fatal("stale import must fail")
+	}
+	if !strings.Contains(stderr, "stale") {
+		t.Fatalf("stale error must mention staleness, got: %s", stderr)
+	}
+}
+
+// TestVaultImportUnknownFileStagesObservation isolates the new-file path: a bare
+// owner-authored note (no memory_id) becomes a pending observation, nothing else.
+func TestVaultImportUnknownFileStagesObservation(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
+	seedConfirmed(t, store, owner, "acme/widget", "repo", "keep", "keep content about arm64")
+
+	dir := filepath.Join(t.TempDir(), "vault")
+	exportVault(t, home, dir, "")
+
+	newNote := "---\nowner_kind: \"agent\"\nowner_ref: \"builder\"\nrepo: \"acme/widget\"\nscope: \"repo\"\nkey: \"runbook\"\n---\ndeploy runbook the owner dropped in\n"
+	if err := os.WriteFile(filepath.Join(dir, "runbook.md"), []byte(newNote), 0o644); err != nil {
+		t.Fatalf("write new note: %v", err)
+	}
+
+	res, code, stderr := importVault(t, home, dir, true)
+	if code != 0 {
+		t.Fatalf("import exit %d: %s", code, stderr)
+	}
+	if len(res.Updates) != 0 || len(res.Retirements) != 0 || len(res.NewObservations) != 1 {
+		t.Fatalf("want only a new observation, got %+v", res)
+	}
+	if res.Unchanged != 1 {
+		t.Fatalf("want 1 unchanged (keep), got %d", res.Unchanged)
+	}
+	pending, _ := store.ListMemoryObservations(ctx, "builder", "")
+	if len(pending) != 1 || pending[0].TrustMark != memory.TrustNormal {
+		t.Fatalf("owner-authored note must be a normal-trust observation: %+v", pending)
+	}
+	// It stays pending, never auto-confirmed.
+	confirmed, _ := store.ListConfirmedMemories(ctx, "builder", "")
+	if len(confirmed) != 1 {
+		t.Fatalf("new note must NOT confirm; confirmed rows = %d", len(confirmed))
+	}
+}
+
+// TestVaultImportNotAVault rejects a directory without a manifest.
+func TestVaultImportNotAVault(t *testing.T) {
+	home, store := memoryTestHome(t)
+	_ = store
+	dir := t.TempDir()
+	_, code, stderr := importVault(t, home, dir, false)
+	if code == 0 {
+		t.Fatal("import of a non-vault dir must fail")
+	}
+	if !strings.Contains(stderr, "not a gitmoot vault") {
+		t.Fatalf("want not-a-vault error, got: %s", stderr)
+	}
+}

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -73,6 +73,24 @@ func nowRFC3339() string {
 // is append-only by construction: repeated observations of the same key produce
 // distinct rows so witnesses accumulate.
 func (s *Store) InsertMemoryObservation(ctx context.Context, obs MemoryObservation) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	id, err := insertMemoryObservationTx(ctx, tx, obs)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// insertMemoryObservationTx is the transaction body shared by the single-op public
+// method and the atomic ApplyVaultImport batch.
+func insertMemoryObservationTx(ctx context.Context, tx *sql.Tx, obs MemoryObservation) (int64, error) {
 	if strings.TrimSpace(obs.Owner.Kind) == "" || strings.TrimSpace(obs.Owner.Ref) == "" {
 		return 0, fmt.Errorf("memory observation requires an owner kind and ref")
 	}
@@ -87,7 +105,7 @@ func (s *Store) InsertMemoryObservation(ctx context.Context, obs MemoryObservati
 	if strings.TrimSpace(created) == "" {
 		created = nowRFC3339()
 	}
-	res, err := s.db.ExecContext(ctx, `
+	res, err := tx.ExecContext(ctx, `
 INSERT INTO memory_observations
 	(owner_kind, owner_ref, owner_version, repo, scope, key, content, provenance, trust_mark, source_job, created_at)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -118,7 +136,7 @@ WHERE owner_kind = ? AND owner_ref = ? AND owner_version = ?
 
 // CountConfirmedMemoriesForOwner returns how many confirmed_memories rows an
 // owner owns, across ALL owner versions and every repo/scope (owner_version is
-// deliberately not filtered — an agent owner always writes owner_version=''), so
+// deliberately not filtered — an agent owner always writes owner_version=”), so
 // it answers "how many injectable facts does this agent own". It backs the
 // dashboard's per-agent memory count and is a plain read (no FTS). Superseded
 // rows are excluded (superseded_by IS NULL) so the count matches the injectable
@@ -294,6 +312,178 @@ WHERE id = ?`,
 	return id, nil
 }
 
+// UpdateConfirmedMemoryByID applies an owner-curated content edit to ONE confirmed
+// row by primary key, guarded by an optimistic-concurrency CAS on updated_at, and
+// resyncs the FTS index in the same transaction. It backs `memory vault import`
+// (#737 P2): the importer diffs an edited note against a fresh export and, on a
+// difference, writes the human's new content back to the exact row it came from —
+// never key-based (which could clobber a different row), never touching owner/
+// scope/key. expectedUpdatedAt is the updated_at the fresh export observed; if the
+// row changed since (or was retired), the CAS matches nothing and the update is
+// refused with an id-naming error so the caller can abort and re-export. Writes are
+// serialized by the store (MaxOpenConns=1), so this optimistic CAS is sufficient.
+func (s *Store) UpdateConfirmedMemoryByID(ctx context.Context, id int64, expectedUpdatedAt, content, provenance string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := updateConfirmedMemoryByIDTx(ctx, tx, id, expectedUpdatedAt, content, provenance); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// updateConfirmedMemoryByIDTx is the transaction body shared by the single-op
+// public method and the atomic ApplyVaultImport batch.
+func updateConfirmedMemoryByIDTx(ctx context.Context, tx *sql.Tx, id int64, expectedUpdatedAt, content, provenance string) error {
+	if strings.TrimSpace(content) == "" {
+		return fmt.Errorf("confirmed memory %d requires content", id)
+	}
+	now := nowRFC3339()
+	res, err := tx.ExecContext(ctx, `
+UPDATE confirmed_memories
+SET content = ?, provenance = ?, updated_at = ?
+WHERE id = ? AND updated_at = ? AND retired_at = ''`,
+		content, provenance, now, id, expectedUpdatedAt)
+	if err != nil {
+		return fmt.Errorf("update confirmed memory by id: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		// Disambiguate a missing row from a lost CAS race so the operator gets an
+		// actionable message naming the id.
+		var count int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM confirmed_memories WHERE id = ?`, id).Scan(&count); err != nil {
+			return fmt.Errorf("inspect confirmed memory %d: %w", id, err)
+		}
+		if count == 0 {
+			return fmt.Errorf("confirmed memory %d not found", id)
+		}
+		return fmt.Errorf("confirmed memory %d changed since export (expected updated_at %q); re-export and retry", id, expectedUpdatedAt)
+	}
+
+	// Keep the FTS index in sync with the new content inside the same transaction.
+	var key string
+	if err := tx.QueryRowContext(ctx, `SELECT key FROM confirmed_memories WHERE id = ?`, id).Scan(&key); err != nil {
+		return fmt.Errorf("read confirmed memory key %d: %w", id, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM confirmed_memories_fts WHERE rowid = ?`, id); err != nil {
+		return fmt.Errorf("sync confirmed memory fts (delete): %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO confirmed_memories_fts(rowid, content, key) VALUES (?, ?, ?)`, id, content, key); err != nil {
+		return fmt.Errorf("sync confirmed memory fts (insert): %w", err)
+	}
+	return nil
+}
+
+// RetireConfirmedMemory marks ONE confirmed row retired (the owner deleted its note
+// from an exported vault) and removes it from the FTS index in the same transaction
+// so it stops being injected into prompts and stops appearing in future exports. It
+// is additive and NON-destructive: the row is preserved for audit with retired_at/
+// retired_reason set; it deliberately does NOT write superseded_by (which carries
+// distinct replacement semantics and has no writers today — see #737 P2). Backs
+// `memory vault import` deletions ⇒ retirements. A row that does not exist (or is
+// already retired) yields an id-naming error rather than a silent no-op.
+func (s *Store) RetireConfirmedMemory(ctx context.Context, id int64, reason string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := retireConfirmedMemoryTx(ctx, tx, id, reason); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// retireConfirmedMemoryTx is the transaction body shared by the single-op public
+// method and the atomic ApplyVaultImport batch.
+func retireConfirmedMemoryTx(ctx context.Context, tx *sql.Tx, id int64, reason string) error {
+	now := nowRFC3339()
+	res, err := tx.ExecContext(ctx, `
+UPDATE confirmed_memories
+SET retired_at = ?, retired_reason = ?
+WHERE id = ? AND retired_at = ''`,
+		now, reason, id)
+	if err != nil {
+		return fmt.Errorf("retire confirmed memory: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		var count int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM confirmed_memories WHERE id = ?`, id).Scan(&count); err != nil {
+			return fmt.Errorf("inspect confirmed memory %d: %w", id, err)
+		}
+		if count == 0 {
+			return fmt.Errorf("confirmed memory %d not found", id)
+		}
+		return fmt.Errorf("confirmed memory %d already retired", id)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM confirmed_memories_fts WHERE rowid = ?`, id); err != nil {
+		return fmt.Errorf("sync confirmed memory fts (delete): %w", err)
+	}
+	return nil
+}
+
+// VaultImportUpdate is one owner-edited note applied to its source row (CAS on
+// ExpectedUpdatedAt).
+type VaultImportUpdate struct {
+	ID                int64
+	ExpectedUpdatedAt string
+	Content           string
+	Provenance        string
+}
+
+// VaultImportRetire is one confirmed row the owner deleted from the vault.
+type VaultImportRetire struct {
+	ID     int64
+	Reason string
+}
+
+// VaultImportPlan is the full set of mutations `memory vault import --yes` applies
+// ATOMICALLY: content edits (CAS), retirements, and new owner-authored notes staged
+// as pending observations. All-or-nothing — any failure rolls the whole batch back.
+type VaultImportPlan struct {
+	Updates      []VaultImportUpdate
+	Retirements  []VaultImportRetire
+	Observations []MemoryObservation
+}
+
+// ApplyVaultImport applies a whole import plan in ONE transaction so a partial
+// curation can never land: edits, retirements, and new-note observations either all
+// commit or none do. Edits and retirements resync/clear the FTS index in the same
+// transaction (via the shared tx helpers); observations are append-only.
+func (s *Store) ApplyVaultImport(ctx context.Context, plan VaultImportPlan) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	for _, u := range plan.Updates {
+		if err := updateConfirmedMemoryByIDTx(ctx, tx, u.ID, u.ExpectedUpdatedAt, u.Content, u.Provenance); err != nil {
+			return err
+		}
+	}
+	for _, r := range plan.Retirements {
+		if err := retireConfirmedMemoryTx(ctx, tx, r.ID, r.Reason); err != nil {
+			return err
+		}
+	}
+	for _, obs := range plan.Observations {
+		if _, err := insertMemoryObservationTx(ctx, tx, obs); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 // QueryConfirmedMemories is the READ path for job-prompt assembly. It runs one
 // FTS5/BM25 query over confirmed content, filtered by the retrieval default
 // (owner match AND (repo = current OR scope = general)), confirmed tier only,
@@ -317,6 +507,7 @@ WHERE f.confirmed_memories_fts MATCH ?
 	AND c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?
 	AND (c.scope = 'general' OR c.repo = ?)
 	AND c.superseded_by IS NULL
+	AND c.retired_at = ''
 ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC
 LIMIT ?`,
 		matchQuery, owner.Kind, owner.Ref, owner.Version, repo, limit)
@@ -339,7 +530,7 @@ func (s *Store) ListConfirmedMemoriesForVault(ctx context.Context, agentRef stri
 SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
 FROM confirmed_memories
-WHERE superseded_by IS NULL`
+WHERE superseded_by IS NULL AND retired_at = ''`
 	var args []any
 	if strings.TrimSpace(agentRef) != "" {
 		query += "\n\tAND owner_kind = 'agent' AND owner_ref = ?"

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -138,14 +138,15 @@ WHERE owner_kind = ? AND owner_ref = ? AND owner_version = ?
 // owner owns, across ALL owner versions and every repo/scope (owner_version is
 // deliberately not filtered — an agent owner always writes owner_version=”), so
 // it answers "how many injectable facts does this agent own". It backs the
-// dashboard's per-agent memory count and is a plain read (no FTS). Superseded
-// rows are excluded (superseded_by IS NULL) so the count matches the injectable
-// set surfaced by QueryConfirmedMemories.
+// dashboard's per-agent memory count and is a plain read (no FTS). Superseded AND
+// retired rows are excluded (superseded_by IS NULL AND retired_at = '') so the
+// count stays exactly equal to the injectable set surfaced by
+// QueryConfirmedMemories (which applies the same two filters).
 func (s *Store) CountConfirmedMemoriesForOwner(ctx context.Context, ownerKind, ownerRef string) (int, error) {
 	var n int
 	err := s.db.QueryRowContext(ctx, `
 SELECT COUNT(*) FROM confirmed_memories
-WHERE owner_kind = ? AND owner_ref = ? AND superseded_by IS NULL`, ownerKind, ownerRef).Scan(&n)
+WHERE owner_kind = ? AND owner_ref = ? AND superseded_by IS NULL AND retired_at = ''`, ownerKind, ownerRef).Scan(&n)
 	if err != nil {
 		return 0, fmt.Errorf("count confirmed memories for owner: %w", err)
 	}
@@ -174,14 +175,18 @@ WHERE owner_kind = ? AND owner_ref = ?`, ownerKind, ownerRef).Scan(&n)
 // the dashboard brain-graph read path: unlike QueryConfirmedMemories (the
 // injectable set, which drops superseded rows) and CountConfirmedMemoriesForOwner
 // (which counts only injectable rows), the graph deliberately shows superseded
-// "ghost" facts so it can draw supersede edges, so this MUST NOT filter them. Rows
-// come back ordered by id for a stable, deterministic traversal. Plain read, no FTS.
+// "ghost" facts so it can draw supersede edges, so this MUST NOT filter them.
+// Retired rows (retired_at != '') ARE excluded, though: retirement carries no
+// supersede pointer and no edge, so a retired fact drawn as a live node would be a
+// phantom — and excluding it keeps the graph's fact set aligned with the injectable
+// set (QueryConfirmedMemories / CountConfirmedMemoriesForOwner both filter retired).
+// Rows come back ordered by id for a stable, deterministic traversal. Plain read, no FTS.
 func (s *Store) ListConfirmedMemoriesByOwnerKind(ctx context.Context, ownerKind string) ([]ConfirmedMemory, error) {
 	rows, err := s.db.QueryContext(ctx, `
 SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
 FROM confirmed_memories
-WHERE owner_kind = ?
+WHERE owner_kind = ? AND retired_at = ''
 ORDER BY id`, ownerKind)
 	if err != nil {
 		return nil, fmt.Errorf("list confirmed memories by owner kind: %w", err)
@@ -290,9 +295,15 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	case err != nil:
 		return 0, fmt.Errorf("lookup confirmed memory: %w", err)
 	default:
+		// A fresh confirmation of an existing key re-activates it: clear any
+		// retirement so a previously-retired fact that the confirmation gate re-admits
+		// is injectable/exportable again (otherwise the newly confirmed content would
+		// stay permanently hidden behind the stale retired_at, since the lookup above
+		// matches by key regardless of retirement). Re-confirming an active row leaves
+		// the already-empty retirement columns untouched.
 		if _, upErr := tx.ExecContext(ctx, `
 UPDATE confirmed_memories
-SET content = ?, provenance = ?, source_job = ?, updated_at = ?
+SET content = ?, provenance = ?, source_job = ?, updated_at = ?, retired_at = '', retired_reason = ''
 WHERE id = ?`,
 			cm.Content, cm.Provenance, cm.SourceJob, now, id); upErr != nil {
 			return 0, fmt.Errorf("update confirmed memory: %w", upErr)
@@ -394,21 +405,32 @@ func (s *Store) RetireConfirmedMemory(ctx context.Context, id int64, reason stri
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
-	if err := retireConfirmedMemoryTx(ctx, tx, id, reason); err != nil {
+	if err := retireConfirmedMemoryTx(ctx, tx, id, "", reason); err != nil {
 		return err
 	}
 	return tx.Commit()
 }
 
 // retireConfirmedMemoryTx is the transaction body shared by the single-op public
-// method and the atomic ApplyVaultImport batch.
-func retireConfirmedMemoryTx(ctx context.Context, tx *sql.Tx, id int64, reason string) error {
+// method and the atomic ApplyVaultImport batch. expectedUpdatedAt is an optional
+// optimistic-concurrency guard mirroring the edit CAS: when non-empty, the row is
+// retired only if its updated_at still matches what the fresh export observed, so a
+// concurrent write landing in the plan→apply window (e.g. the daemon confirming a
+// newer fact on the same row) makes the retirement match nothing and roll the whole
+// import batch back rather than burying the newer fact. An empty string means "no
+// version guard" (the single-op public path), preserving its prior behavior.
+func retireConfirmedMemoryTx(ctx context.Context, tx *sql.Tx, id int64, expectedUpdatedAt, reason string) error {
 	now := nowRFC3339()
-	res, err := tx.ExecContext(ctx, `
+	query := `
 UPDATE confirmed_memories
 SET retired_at = ?, retired_reason = ?
-WHERE id = ? AND retired_at = ''`,
-		now, reason, id)
+WHERE id = ? AND retired_at = ''`
+	args := []any{now, reason, id}
+	if expectedUpdatedAt != "" {
+		query += ` AND updated_at = ?`
+		args = append(args, expectedUpdatedAt)
+	}
+	res, err := tx.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("retire confirmed memory: %w", err)
 	}
@@ -423,6 +445,17 @@ WHERE id = ? AND retired_at = ''`,
 		}
 		if count == 0 {
 			return fmt.Errorf("confirmed memory %d not found", id)
+		}
+		// Distinguish an already-retired row from a lost CAS race (the row is still
+		// active but changed since export) so the operator gets an actionable message.
+		if expectedUpdatedAt != "" {
+			var retiredAt string
+			if err := tx.QueryRowContext(ctx, `SELECT retired_at FROM confirmed_memories WHERE id = ?`, id).Scan(&retiredAt); err != nil {
+				return fmt.Errorf("inspect confirmed memory %d: %w", id, err)
+			}
+			if retiredAt == "" {
+				return fmt.Errorf("confirmed memory %d changed since export (expected updated_at %q); re-export and retry", id, expectedUpdatedAt)
+			}
 		}
 		return fmt.Errorf("confirmed memory %d already retired", id)
 	}
@@ -442,9 +475,13 @@ type VaultImportUpdate struct {
 }
 
 // VaultImportRetire is one confirmed row the owner deleted from the vault.
+// ExpectedUpdatedAt is the updated_at the fresh export observed; it is an optimistic
+// CAS guard (empty == none) so a retirement never lands on top of a fact that was
+// rewritten in the plan→apply window, mirroring VaultImportUpdate.
 type VaultImportRetire struct {
-	ID     int64
-	Reason string
+	ID                int64
+	ExpectedUpdatedAt string
+	Reason            string
 }
 
 // VaultImportPlan is the full set of mutations `memory vault import --yes` applies
@@ -472,7 +509,7 @@ func (s *Store) ApplyVaultImport(ctx context.Context, plan VaultImportPlan) erro
 		}
 	}
 	for _, r := range plan.Retirements {
-		if err := retireConfirmedMemoryTx(ctx, tx, r.ID, r.Reason); err != nil {
+		if err := retireConfirmedMemoryTx(ctx, tx, r.ID, r.ExpectedUpdatedAt, r.Reason); err != nil {
 			return err
 		}
 	}

--- a/internal/db/memory_store_test.go
+++ b/internal/db/memory_store_test.go
@@ -318,6 +318,122 @@ func TestRetireConfirmedMemory(t *testing.T) {
 	}
 }
 
+// TestRetiredExcludedFromCountAndGraph proves retirement stays consistent across
+// every read path: retiring one of two confirmed rows drops the injectable count to
+// 1 (CountConfirmedMemoriesForOwner) AND removes the row from the brain-graph lister
+// (ListConfirmedMemoriesByOwnerKind), so the documented "count == injectable set"
+// invariant holds and the graph never draws a retired fact as a live node.
+func TestRetiredExcludedFromCountAndGraph(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+	keepID, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "keep", Content: "keep me",
+	})
+	if err != nil {
+		t.Fatalf("upsert keep: %v", err)
+	}
+	dropID, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "drop", Content: "drop me",
+	})
+	if err != nil {
+		t.Fatalf("upsert drop: %v", err)
+	}
+
+	if n, err := store.CountConfirmedMemoriesForOwner(ctx, "agent", "builder"); err != nil || n != 2 {
+		t.Fatalf("pre-retire count = %d (err %v), want 2", n, err)
+	}
+
+	if err := store.RetireConfirmedMemory(ctx, dropID, "vault-import: deleted by owner"); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+
+	if n, err := store.CountConfirmedMemoriesForOwner(ctx, "agent", "builder"); err != nil || n != 1 {
+		t.Fatalf("post-retire count = %d (err %v), want 1 (must equal injectable set)", n, err)
+	}
+	graph, err := store.ListConfirmedMemoriesByOwnerKind(ctx, "agent")
+	if err != nil {
+		t.Fatalf("list by owner kind: %v", err)
+	}
+	if len(graph) != 1 || graph[0].ID != keepID {
+		t.Fatalf("brain-graph lister must exclude the retired row, got %+v", graph)
+	}
+	_ = dropID
+}
+
+// TestReconfirmRetiredKeyReactivates proves a fresh confirmation of a key that was
+// previously retired clears retired_at, so the re-admitted fact is injectable and
+// exportable again instead of staying permanently hidden behind the stale retirement.
+func TestReconfirmRetiredKeyReactivates(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+	id, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "ci-flake", Content: "arm64 CI is flaky",
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := store.RetireConfirmedMemory(ctx, id, "vault-import: deleted by owner"); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+
+	// Re-confirm the same key (the confirmation gate re-admits the fact).
+	reID, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "ci-flake", Content: "arm64 CI flaky, rerun helps",
+	})
+	if err != nil {
+		t.Fatalf("re-confirm: %v", err)
+	}
+	if reID != id {
+		t.Fatalf("re-confirm must reuse the keyed row (%d), got %d", id, reID)
+	}
+
+	// It is injectable again (retired_at cleared) and re-exports.
+	got, err := store.QueryConfirmedMemories(ctx, owner, "acme/widget", `"arm64" OR "flaky"`, 15)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 1 || got[0].Content != "arm64 CI flaky, rerun helps" {
+		t.Fatalf("re-confirmed fact must be injectable with new content, got %+v", got)
+	}
+	vaultRows, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatalf("vault list: %v", err)
+	}
+	if len(vaultRows) != 1 {
+		t.Fatalf("re-confirmed fact must re-export, got %d rows", len(vaultRows))
+	}
+}
+
+// TestRetireCASGuardsConcurrentWrite proves a retirement carrying an ExpectedUpdatedAt
+// aborts (rolling back the whole batch) when the row was rewritten since the fresh
+// export observed it, so a plan→apply-window write can never be buried by a retirement.
+func TestRetireCASGuardsConcurrentWrite(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+	id, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "drop", Content: "original",
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// A retirement whose expected updated_at does not match the current row must fail
+	// wholesale (stale CAS), and the fact must remain live.
+	plan := VaultImportPlan{
+		Retirements: []VaultImportRetire{{ID: id, ExpectedUpdatedAt: "1999-01-01T00:00:00Z", Reason: "vault-import: deleted by owner"}},
+	}
+	if err := store.ApplyVaultImport(ctx, plan); err == nil || !strings.Contains(err.Error(), "changed since export") {
+		t.Fatalf("want changed-since-export CAS failure, got: %v", err)
+	}
+	vaultRows, _ := store.ListConfirmedMemoriesForVault(ctx, "")
+	if len(vaultRows) != 1 {
+		t.Fatalf("stale retirement must not land: want 1 live row, got %d", len(vaultRows))
+	}
+}
+
 // TestApplyVaultImportAtomic proves a whole import plan commits together and that a
 // failing element (a stale CAS) rolls the ENTIRE batch back — no partial curation.
 func TestApplyVaultImportAtomic(t *testing.T) {

--- a/internal/db/memory_store_test.go
+++ b/internal/db/memory_store_test.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -207,4 +209,176 @@ func mustUpsert(t *testing.T, store *Store, cm ConfirmedMemory) int64 {
 		t.Fatalf("upsert: %v", err)
 	}
 	return id
+}
+
+// TestUpdateConfirmedMemoryByIDCAS proves the optimistic CAS: a correct
+// expected updated_at applies the content edit and resyncs FTS, while a stale
+// expected updated_at is refused with an id-naming error and writes nothing.
+func TestUpdateConfirmedMemoryByIDCAS(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+	id, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "ci-flake",
+		Content: "arm64 CI is flaky",
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	rows, err := store.ListConfirmedMemories(ctx, "builder", "")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("list: %v (rows=%d)", err, len(rows))
+	}
+	current := rows[0].UpdatedAt
+
+	// Stale CAS: wrong expected updated_at → refused, names the id, no write.
+	err = store.UpdateConfirmedMemoryByID(ctx, id, "1999-01-01T00:00:00Z", "clobbered", "vault-import")
+	if err == nil {
+		t.Fatal("expected CAS conflict error for a stale expected updated_at")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("%d", id)) {
+		t.Fatalf("CAS error must name the id %d, got: %v", id, err)
+	}
+	rows, _ = store.ListConfirmedMemories(ctx, "builder", "")
+	if rows[0].Content != "arm64 CI is flaky" {
+		t.Fatalf("stale CAS must not write; content = %q", rows[0].Content)
+	}
+
+	// Correct CAS: applies the edit and the new content is FTS-searchable while the
+	// old token is gone.
+	if err := store.UpdateConfirmedMemoryByID(ctx, id, current, "the runner now uses graviton", "vault-import"); err != nil {
+		t.Fatalf("CAS update: %v", err)
+	}
+	got, err := store.QueryConfirmedMemories(ctx, owner, "acme/widget", `"graviton"`, 15)
+	if err != nil {
+		t.Fatalf("query new token: %v", err)
+	}
+	if len(got) != 1 || got[0].Content != "the runner now uses graviton" {
+		t.Fatalf("edited content not FTS-searchable: %+v", got)
+	}
+	stale, err := store.QueryConfirmedMemories(ctx, owner, "acme/widget", `"flaky"`, 15)
+	if err != nil {
+		t.Fatalf("query old token: %v", err)
+	}
+	if len(stale) != 0 {
+		t.Fatalf("old content token must be gone from FTS, got %d rows", len(stale))
+	}
+}
+
+// TestUpdateConfirmedMemoryByIDNotFound reports a missing id distinctly from a CAS
+// conflict.
+func TestUpdateConfirmedMemoryByIDNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	err := store.UpdateConfirmedMemoryByID(ctx, 999, "whenever", "x", "vault-import")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("want not-found error, got: %v", err)
+	}
+}
+
+// TestRetireConfirmedMemory proves retirement removes a fact from BOTH the FTS
+// injection query and the vault-export lister, without deleting the audit row.
+func TestRetireConfirmedMemory(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+	id, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "ci-flake",
+		Content: "arm64 CI is flaky",
+	})
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	if err := store.RetireConfirmedMemory(ctx, id, "vault-import: deleted by owner"); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+
+	// Injection query no longer surfaces it (FTS rowid deleted + retired filter).
+	got, err := store.QueryConfirmedMemories(ctx, owner, "acme/widget", `"arm64" OR "flaky"`, 15)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("retired memory must not be injected, got %d rows", len(got))
+	}
+
+	// Vault-export lister excludes it too.
+	vaultRows, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatalf("vault list: %v", err)
+	}
+	if len(vaultRows) != 0 {
+		t.Fatalf("retired memory must not appear in the vault export, got %d rows", len(vaultRows))
+	}
+
+	// A second retire is a distinct, id-naming error (already retired).
+	if err := store.RetireConfirmedMemory(ctx, id, "again"); err == nil || !strings.Contains(err.Error(), "already retired") {
+		t.Fatalf("want already-retired error, got: %v", err)
+	}
+}
+
+// TestApplyVaultImportAtomic proves a whole import plan commits together and that a
+// failing element (a stale CAS) rolls the ENTIRE batch back — no partial curation.
+func TestApplyVaultImportAtomic(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+	keepID, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "keep", Content: "original keep",
+	})
+	if err != nil {
+		t.Fatalf("upsert keep: %v", err)
+	}
+	dropID, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "drop", Content: "original drop",
+	})
+	if err != nil {
+		t.Fatalf("upsert drop: %v", err)
+	}
+
+	// A plan whose update carries a stale expected updated_at must fail wholesale:
+	// the retirement of dropID must NOT land.
+	badPlan := VaultImportPlan{
+		Updates:     []VaultImportUpdate{{ID: keepID, ExpectedUpdatedAt: "1999-01-01T00:00:00Z", Content: "edited", Provenance: "vault-import"}},
+		Retirements: []VaultImportRetire{{ID: dropID, Reason: "vault-import: deleted by owner"}},
+	}
+	if err := store.ApplyVaultImport(ctx, badPlan); err == nil {
+		t.Fatal("expected the stale-CAS plan to fail")
+	}
+	vaultRows, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatalf("vault list: %v", err)
+	}
+	if len(vaultRows) != 2 {
+		t.Fatalf("rollback failed: want 2 live rows, got %d", len(vaultRows))
+	}
+
+	// A well-formed plan applies edit + retire + observation together.
+	rows, _ := store.ListConfirmedMemories(ctx, "builder", "")
+	var keepUpdatedAt string
+	for _, r := range rows {
+		if r.ID == keepID {
+			keepUpdatedAt = r.UpdatedAt
+		}
+	}
+	goodPlan := VaultImportPlan{
+		Updates:      []VaultImportUpdate{{ID: keepID, ExpectedUpdatedAt: keepUpdatedAt, Content: "edited keep", Provenance: "vault-import"}},
+		Retirements:  []VaultImportRetire{{ID: dropID, Reason: "vault-import: deleted by owner"}},
+		Observations: []MemoryObservation{{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "new", Content: "a new note", Provenance: "vault-import:new.md", TrustMark: "normal"}},
+	}
+	if err := store.ApplyVaultImport(ctx, goodPlan); err != nil {
+		t.Fatalf("apply good plan: %v", err)
+	}
+	vaultRows, _ = store.ListConfirmedMemoriesForVault(ctx, "")
+	if len(vaultRows) != 1 || vaultRows[0].ID != keepID || vaultRows[0].Content != "edited keep" {
+		t.Fatalf("post-apply vault state wrong: %+v", vaultRows)
+	}
+	obsCount, err := store.CountMemoryObservationsForOwner(ctx, "agent", "builder")
+	if err != nil {
+		t.Fatalf("count obs: %v", err)
+	}
+	if obsCount != 1 {
+		t.Fatalf("want 1 staged observation, got %d", obsCount)
+	}
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -8250,4 +8250,16 @@ CREATE TABLE chat_thread_meta (
 	PRIMARY KEY(thread_id, key)
 );
 	`,
+	// #737 P2 `memory vault import` — retirement columns for a confirmed memory
+	// whose note the owner deleted from an exported vault (deletions ⇒ retirements).
+	// Pure additive append: both columns carry a constant '' default, so SQLite
+	// backfills every existing row to non-retired and the read paths that now filter
+	// `retired_at = ''` (vault export lister + the injection query) are byte-identical
+	// on any pre-migration DB. ALTER ADD COLUMN only — no renumber/ALTER of a prior
+	// migration — mirroring the head_sha precedent above. superseded_by stays
+	// RESERVED (still zero writers); retirement is a distinct, additive concept.
+	`
+ALTER TABLE confirmed_memories ADD COLUMN retired_at TEXT NOT NULL DEFAULT '';
+ALTER TABLE confirmed_memories ADD COLUMN retired_reason TEXT NOT NULL DEFAULT '';
+	`,
 }

--- a/internal/memory/frontmatter.go
+++ b/internal/memory/frontmatter.go
@@ -1,0 +1,167 @@
+package memory
+
+// Frontmatter parsing for the vault round-trip (`memory vault import`, RFC #737
+// P2). This is the inverse of RenderVaultNote in vault.go: the exporter renders a
+// confirmed memory to an Obsidian note (sorted YAML frontmatter, the content
+// verbatim, then a "## Links" section); the importer parses an owner-edited note
+// back into its frontmatter map and body so a content edit can be written to the
+// exact source row. It is a small, PURE, DB-free helper so the round-trip
+// determinism can be unit-tested in isolation.
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// vaultLinksMarker is the literal RenderVaultNote emits to open the Links section
+// ("\n## Links\n"). Everything before it (after the frontmatter) is the memory
+// body; the section itself is a pure derivation of FTS co-occurrence and is
+// discarded on import (it is regenerated on the next export).
+const vaultLinksMarker = "\n## Links\n"
+
+// SplitFrontmatter separates a leading YAML frontmatter block delimited by `---`
+// fences from the remaining body. It is the generalized form of agenttemplate's
+// splitFrontmatter, lifted here so the memory vault round-trip can reuse it. CRLF
+// is normalized to LF first. The returned body preserves the content after the
+// closing fence with only leading blank lines trimmed (mirroring the exporter,
+// which writes the content immediately after the closing "---\n").
+func SplitFrontmatter(content string) (frontmatter, body string, err error) {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return "", "", errors.New("note content is empty")
+	}
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) < 3 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", errors.New("note must start with YAML frontmatter")
+	}
+	for index := 1; index < len(lines); index++ {
+		if strings.TrimSpace(lines[index]) != "---" {
+			continue
+		}
+		frontmatter = strings.Join(lines[1:index], "\n")
+		body = strings.TrimLeft(strings.Join(lines[index+1:], "\n"), "\n")
+		return frontmatter, body, nil
+	}
+	return "", "", errors.New("note frontmatter is missing closing ---")
+}
+
+// VaultNoteFile is a parsed vault note: the frontmatter decoded into a generic
+// map (values are the yaml.v3 native types — string, int, etc.) and the memory
+// body with the derived "## Links" section stripped.
+type VaultNoteFile struct {
+	Frontmatter map[string]any
+	Body        string
+}
+
+// ParseVaultNote parses one exported vault note back into its frontmatter map and
+// memory body. The body is the content between the closing frontmatter fence and
+// the "## Links" section (the section is a regenerated derivation, never part of
+// the stored memory). It is the inverse of RenderVaultNote.
+func ParseVaultNote(content string) (VaultNoteFile, error) {
+	fm, body, err := SplitFrontmatter(content)
+	if err != nil {
+		return VaultNoteFile{}, err
+	}
+	values := map[string]any{}
+	if strings.TrimSpace(fm) != "" {
+		if err := yaml.Unmarshal([]byte(fm), &values); err != nil {
+			return VaultNoteFile{}, fmt.Errorf("parse note frontmatter: %w", err)
+		}
+	}
+	// Strip the derived Links section. RenderVaultNote always appends
+	// "\n## Links\n…" after the (newline-terminated) content, so the memory body is
+	// everything before the LAST occurrence of the marker — using the last match so
+	// a body that itself contains the string cannot truncate the content.
+	if idx := strings.LastIndex(body, vaultLinksMarker); idx >= 0 {
+		body = body[:idx] // the marker's leading "\n" is a separator; the content
+		// keeps its own trailing newline, which sits just before it.
+	}
+	return VaultNoteFile{Frontmatter: values, Body: body}, nil
+}
+
+// MemoryID returns the memory_id recorded in the frontmatter and whether it was
+// present and a positive integer. A note with no (or non-positive) memory_id is
+// treated by the importer as an owner-authored NEW note rather than an edit.
+func (f VaultNoteFile) MemoryID() (int64, bool) {
+	raw, ok := f.Frontmatter["memory_id"]
+	if !ok {
+		return 0, false
+	}
+	id, ok := frontmatterInt(raw)
+	if !ok || id <= 0 {
+		return 0, false
+	}
+	return id, true
+}
+
+// String returns a frontmatter value as a string (the exporter renders every
+// scalar field as a quoted YAML string), or "" if absent.
+func (f VaultNoteFile) String(key string) string {
+	raw, ok := f.Frontmatter[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := raw.(string); ok {
+		return s
+	}
+	if n, ok := frontmatterInt(raw); ok {
+		return strconv.FormatInt(n, 10)
+	}
+	return fmt.Sprintf("%v", raw)
+}
+
+// VaultMemory reconstructs the DB-free projection from a parsed note's frontmatter
+// and body. It is used by the round-trip test (render → parse → re-render must be
+// byte-identical) and lets an importer recover the full record shape. Content is
+// taken from the parsed Body (the human-editable region), not the frontmatter.
+func (f VaultNoteFile) VaultMemory() VaultMemory {
+	m := VaultMemory{
+		OwnerKind:    f.String("owner_kind"),
+		OwnerRef:     f.String("owner_ref"),
+		OwnerVersion: f.String("owner_version"),
+		Repo:         f.String("repo"),
+		Scope:        f.String("scope"),
+		Key:          f.String("key"),
+		Content:      f.Body,
+		Provenance:   f.String("provenance"),
+		SourceJob:    f.String("source_job"),
+		CreatedAt:    f.String("created_at"),
+		UpdatedAt:    f.String("updated_at"),
+	}
+	if id, ok := f.MemoryID(); ok {
+		m.ID = id
+	}
+	if raw, ok := f.Frontmatter["superseded_by"]; ok {
+		if n, ok := frontmatterInt(raw); ok {
+			m.SupersededBy = n
+		}
+	}
+	return m
+}
+
+// frontmatterInt coerces a yaml.v3-decoded scalar to an int64. yaml.v3 decodes a
+// bare integer as int; a quoted integer (how the exporter renders string fields)
+// decodes as string.
+func frontmatterInt(raw any) (int64, bool) {
+	switch v := raw.(type) {
+	case int:
+		return int64(v), true
+	case int64:
+		return v, true
+	case float64:
+		return int64(v), true
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/memory/frontmatter_test.go
+++ b/internal/memory/frontmatter_test.go
@@ -1,0 +1,92 @@
+package memory
+
+import "testing"
+
+// TestVaultNoteRoundTrip proves RenderVaultNote → ParseVaultNote → re-render is
+// byte-identical, so `memory vault import` can recover the exact source record from
+// an unedited note (the diff's stable baseline).
+func TestVaultNoteRoundTrip(t *testing.T) {
+	cases := []struct {
+		name  string
+		mem   VaultMemory
+		links []VaultLink
+	}{
+		{
+			name: "repo-scoped with links",
+			mem: VaultMemory{
+				ID: 42, OwnerKind: OwnerKindAgent, OwnerRef: "builder", OwnerVersion: "",
+				Repo: "acme/widget", Scope: ScopeRepo, Key: "ci-flake",
+				Content:    "arm64 CI is flaky under load and often needs a rerun",
+				Provenance: "confirm", SourceJob: "job-ci-flake",
+				CreatedAt: "2026-07-01T00:00:00Z", UpdatedAt: "2026-07-02T00:00:00Z",
+			},
+			links: []VaultLink{
+				{TargetID: 7, Stem: VaultStem(7, "other"), Key: "other"},
+				{TargetID: 3, Stem: VaultStem(3, "another"), Key: "another"},
+			},
+		},
+		{
+			name: "general scope no links",
+			mem: VaultMemory{
+				ID: 9, OwnerKind: OwnerKindAgent, OwnerRef: "reviewer",
+				Repo: "", Scope: ScopeGeneral, Key: "toolchain-trap",
+				Content:   "the default go toolchain is too old\nfor this module",
+				CreatedAt: "2026-06-01T00:00:00Z", UpdatedAt: "2026-06-01T00:00:00Z",
+			},
+			links: nil,
+		},
+		{
+			name: "content without trailing newline",
+			mem: VaultMemory{
+				ID: 100, OwnerKind: OwnerKindAgent, OwnerRef: "builder",
+				Repo: "acme/widget", Scope: ScopeRepo, Key: "no-newline",
+				Content:   "a single line with no trailing newline",
+				CreatedAt: "2026-06-01T00:00:00Z", UpdatedAt: "2026-06-01T00:00:00Z",
+			},
+			links: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := RenderVaultNote(tc.mem, tc.links)
+			parsed, err := ParseVaultNote(original)
+			if err != nil {
+				t.Fatalf("ParseVaultNote: %v", err)
+			}
+			id, ok := parsed.MemoryID()
+			if !ok || id != tc.mem.ID {
+				t.Fatalf("MemoryID = (%d, %v), want %d", id, ok, tc.mem.ID)
+			}
+			reconstructed := parsed.VaultMemory()
+			roundTripped := RenderVaultNote(reconstructed, tc.links)
+			if roundTripped != original {
+				t.Fatalf("round-trip not byte-identical:\n--- original ---\n%q\n--- round-trip ---\n%q", original, roundTripped)
+			}
+		})
+	}
+}
+
+// TestParseVaultNoteStripsLinks confirms the derived "## Links" section never leaks
+// into the recovered body.
+func TestParseVaultNoteStripsLinks(t *testing.T) {
+	m := VaultMemory{
+		ID: 1, OwnerKind: OwnerKindAgent, OwnerRef: "builder",
+		Repo: "acme/widget", Scope: ScopeRepo, Key: "k", Content: "hello world",
+		CreatedAt: "t", UpdatedAt: "t",
+	}
+	note := RenderVaultNote(m, []VaultLink{{TargetID: 2, Stem: "000000002-x", Key: "x"}})
+	parsed, err := ParseVaultNote(note)
+	if err != nil {
+		t.Fatalf("ParseVaultNote: %v", err)
+	}
+	if got := parsed.Body; got != "hello world\n" {
+		t.Fatalf("body = %q, want %q", got, "hello world\n")
+	}
+}
+
+// TestParseVaultNoteRejectsNonNote rejects content with no frontmatter fence.
+func TestParseVaultNoteRejectsNonNote(t *testing.T) {
+	if _, err := ParseVaultNote("just some markdown, no frontmatter\n"); err == nil {
+		t.Fatal("expected error for a note without frontmatter")
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1627,8 +1627,14 @@ trust `normal` — owner-authored) behind the existing confirmation gate. Frontm
 identity edits (key/scope/owner) are **out of scope**: they are detected, warned,
 and skipped (only the content edit applies). `--dry-run` is the **default** — it
 prints the full diff and writes **nothing**; `--yes` applies edits, retirements, and
-new observations in **one transaction** (all-or-nothing). The `<DIR>` positional may
-appear before or after the flags. `memory ingest` (P3) lands in a later phase.
+new observations in **one transaction** (all-or-nothing). If any note fails to parse
+(e.g. broken YAML frontmatter), `--yes` **refuses to apply** — a malformed note could
+otherwise be misread as a deletion and silently retire a live memory; fix the
+frontmatter (or delete the file to intentionally retire it) and re-export. A vault
+produced by `export --agent NAME` stays importable even when other owners have
+memories (import rebuilds the fresh export with the manifest's recorded scope). The
+`<DIR>` positional may appear before or after the flags. `memory ingest` (P3) lands in
+a later phase.
 
 ## Pipelines
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1584,6 +1584,7 @@ gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
+gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
@@ -1608,8 +1609,26 @@ evals area). `--agent NAME` narrows the export to one agent owner. Because the
 export **replaces `--out` wholesale**, it refuses to overwrite a non-empty directory
 that is not itself a prior gitmoot vault (one carrying a `manifest.json`) so an
 accidental `--out ~/my-obsidian-vault` can never delete your own notes; pass
-`--force` to override. This is P1 of the two-way memory bridge; `vault import` /
-`memory ingest` land in later phases.
+`--force` to override. This is P1 of the two-way memory bridge.
+
+`memory vault import <DIR>` (#737 P2) is the **human curation gate** as an explicit
+round-trip over the P1 export: you export a vault, edit/delete/add notes in Obsidian
+(or any editor), then `import` **diffs the directory against a fresh export** and
+applies only what you confirm. It first regenerates a fresh export in memory and
+**aborts as stale** if the store changed since the vault was written (the manifest
+`snapshot_hash` no longer matches), so a stale diff can never clobber newer facts.
+Then, per note: an **edited** note updates its source memory's content (an
+optimistic **CAS on `updated_at`** targets the exact row — never key-based — and
+resyncs the FTS index); a **deleted** note **retires** its memory (additive
+`retired_at`/`retired_reason` columns + FTS removal, so it stops being injected and
+stops exporting — the audit row is preserved, never hard-deleted); a **new** `.md`
+file with no `memory_id` stages a **pending observation** (`provenance=vault-import:<file>`,
+trust `normal` — owner-authored) behind the existing confirmation gate. Frontmatter
+identity edits (key/scope/owner) are **out of scope**: they are detected, warned,
+and skipped (only the content edit applies). `--dry-run` is the **default** — it
+prints the full diff and writes **nothing**; `--yes` applies edits, retirements, and
+new observations in **one transaction** (all-or-nothing). The `<DIR>` positional may
+appear before or after the flags. `memory ingest` (P3) lands in a later phase.
 
 ## Pipelines
 

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -135,7 +135,11 @@ never clobber newer facts. Then:
 Frontmatter identity edits (key/scope/owner) are out of scope — detected, warned,
 and skipped (only the content edit lands). `--dry-run` is the **default**: it prints
 the diff and writes nothing. `--yes` applies edits, retirements, and new
-observations in **one transaction** (all-or-nothing).
+observations in **one transaction** (all-or-nothing). If any note fails to parse
+(e.g. broken YAML frontmatter) `--yes` **refuses to apply** — a malformed note could
+otherwise be misread as a deletion and silently retire a live memory. A vault
+produced by `export --agent NAME` stays importable even when other owners have
+memories, because import rebuilds the fresh export with the manifest's recorded scope.
 
 ## Phases
 

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -92,6 +92,7 @@ recall/precision@K of retrieval over a labeled fixtures file.
 
 ```sh
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
+gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 ```
 
 `memory vault export` renders confirmed memory as an Obsidian-compatible vault:
@@ -104,7 +105,7 @@ so the export never becomes a second store to keep in sync. It is regenerated
 from scratch on every run, is safe to delete, and is fully **deterministic** —
 the same store produces byte-identical files (there is deliberately no
 `exported_at`, and filenames are stable `NNNNNNNNN-<slug>.md` derived from the
-memory id). That determinism is what lets a later `vault import` diff hand-edits
+memory id). That determinism is what lets `vault import` (below) diff hand-edits
 against a fresh export. The export is read-only (zero writes to any table) and
 atomic (it writes a temp directory and renames it over `--out`, which defaults to
 a `vault/` directory under the home's evals area). Since the export **replaces
@@ -112,6 +113,29 @@ a `vault/` directory under the home's evals area). Since the export **replaces
 itself a prior gitmoot vault (one carrying a `manifest.json`), so pointing it at
 an existing Obsidian vault such as `--out ~/my-vault` can never silently delete
 your own notes; pass `--force` to override.
+
+`memory vault import <DIR>` closes the loop as the **human curation gate**: export a
+vault, edit/delete/add notes in any editor, then `import` **diffs the folder against
+a fresh export** and applies only on confirmation. The diff is the audit trail. It
+regenerates a fresh export first and **aborts as stale** if the store moved since the
+vault was written (the manifest `snapshot_hash` mismatches), so a stale edit can
+never clobber newer facts. Then:
+
+- an **edited** note rewrites its source memory's content — an optimistic
+  **compare-and-set on `updated_at`** targets the exact row (never key-based, so it
+  can't clobber a different fact) and resyncs the FTS index;
+- a **deleted** note **retires** its memory: additive `retired_at`/`retired_reason`
+  columns plus FTS removal stop it being injected or exported, while the row is kept
+  for audit (retirement is distinct from `superseded_by` replacement and never
+  hard-deletes);
+- a **new** `.md` file (no `memory_id`) stages a **pending observation**
+  (`provenance=vault-import:<file>`, trust `normal` — it is owner-authored) behind
+  the usual confirmation gate; it is never auto-confirmed.
+
+Frontmatter identity edits (key/scope/owner) are out of scope — detected, warned,
+and skipped (only the content edit lands). `--dry-run` is the **default**: it prints
+the diff and writes nothing. `--yes` applies edits, retirements, and new
+observations in **one transaction** (all-or-nothing).
 
 ## Phases
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1339,6 +1339,7 @@ gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
+gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
@@ -1360,6 +1361,21 @@ single agent owner. Because the export **replaces `--out` wholesale**, it refuse
 overwrite a non-empty directory that is not itself a prior gitmoot vault (one with a
 `manifest.json`), so an accidental `--out ~/my-obsidian-vault` can never delete your
 own notes; pass `--force` to override.
+
+`memory vault import <DIR>` is the **human curation gate**: export a vault, edit it in
+any editor, then `import` **diffs the folder against a fresh export** and applies only
+on confirmation. It regenerates a fresh export first and **aborts as stale** if the
+store moved since the vault was written (manifest `snapshot_hash` mismatch). An
+**edited** note updates its source memory's content via an optimistic **CAS on
+`updated_at`** (exact-row, never key-based; resyncs FTS); a **deleted** note
+**retires** its memory (additive `retired_at`/`retired_reason` + FTS removal — kept
+for audit, never hard-deleted, and excluded from injection and future exports); a
+**new** `.md` file (no `memory_id`) stages a **pending observation**
+(`provenance=vault-import:<file>`, trust `normal`) behind the confirmation gate.
+Frontmatter identity edits (key/scope/owner) are out of scope — detected, warned, and
+skipped. `--dry-run` is the **default** (prints the diff, writes nothing); `--yes`
+applies edits, retirements, and new observations in **one transaction**. The `<DIR>`
+positional may sit before or after the flags.
 
 ## Pipelines
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1374,8 +1374,11 @@ for audit, never hard-deleted, and excluded from injection and future exports); 
 (`provenance=vault-import:<file>`, trust `normal`) behind the confirmation gate.
 Frontmatter identity edits (key/scope/owner) are out of scope — detected, warned, and
 skipped. `--dry-run` is the **default** (prints the diff, writes nothing); `--yes`
-applies edits, retirements, and new observations in **one transaction**. The `<DIR>`
-positional may sit before or after the flags.
+applies edits, retirements, and new observations in **one transaction**. If any note
+fails to parse (e.g. broken YAML frontmatter), `--yes` **refuses to apply** so a
+malformed note is never misread as a deletion. A vault produced by `export --agent
+NAME` stays importable even when other owners have memories. The `<DIR>` positional
+may sit before or after the flags.
 
 ## Pipelines
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9603,8 +9603,14 @@ trust `normal` — owner-authored) behind the existing confirmation gate. Frontm
 identity edits (key/scope/owner) are **out of scope**: they are detected, warned,
 and skipped (only the content edit applies). `--dry-run` is the **default** — it
 prints the full diff and writes **nothing**; `--yes` applies edits, retirements, and
-new observations in **one transaction** (all-or-nothing). The `<DIR>` positional may
-appear before or after the flags. `memory ingest` (P3) lands in a later phase.
+new observations in **one transaction** (all-or-nothing). If any note fails to parse
+(e.g. broken YAML frontmatter), `--yes` **refuses to apply** — a malformed note could
+otherwise be misread as a deletion and silently retire a live memory; fix the
+frontmatter (or delete the file to intentionally retire it) and re-export. A vault
+produced by `export --agent NAME` stays importable even when other owners have
+memories (import rebuilds the fresh export with the manifest's recorded scope). The
+`<DIR>` positional may appear before or after the flags. `memory ingest` (P3) lands in
+a later phase.
 
 ## Pipelines
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9560,6 +9560,7 @@ gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
+gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
@@ -9584,8 +9585,26 @@ evals area). `--agent NAME` narrows the export to one agent owner. Because the
 export **replaces `--out` wholesale**, it refuses to overwrite a non-empty directory
 that is not itself a prior gitmoot vault (one carrying a `manifest.json`) so an
 accidental `--out ~/my-obsidian-vault` can never delete your own notes; pass
-`--force` to override. This is P1 of the two-way memory bridge; `vault import` /
-`memory ingest` land in later phases.
+`--force` to override. This is P1 of the two-way memory bridge.
+
+`memory vault import <DIR>` (#737 P2) is the **human curation gate** as an explicit
+round-trip over the P1 export: you export a vault, edit/delete/add notes in Obsidian
+(or any editor), then `import` **diffs the directory against a fresh export** and
+applies only what you confirm. It first regenerates a fresh export in memory and
+**aborts as stale** if the store changed since the vault was written (the manifest
+`snapshot_hash` no longer matches), so a stale diff can never clobber newer facts.
+Then, per note: an **edited** note updates its source memory's content (an
+optimistic **CAS on `updated_at`** targets the exact row — never key-based — and
+resyncs the FTS index); a **deleted** note **retires** its memory (additive
+`retired_at`/`retired_reason` columns + FTS removal, so it stops being injected and
+stops exporting — the audit row is preserved, never hard-deleted); a **new** `.md`
+file with no `memory_id` stages a **pending observation** (`provenance=vault-import:<file>`,
+trust `normal` — owner-authored) behind the existing confirmation gate. Frontmatter
+identity edits (key/scope/owner) are **out of scope**: they are detected, warned,
+and skipped (only the content edit applies). `--dry-run` is the **default** — it
+prints the full diff and writes **nothing**; `--yes` applies edits, retirements, and
+new observations in **one transaction** (all-or-nothing). The `<DIR>` positional may
+appear before or after the flags. `memory ingest` (P3) lands in a later phase.
 
 ## Pipelines
 


### PR DESCRIPTION
## P2: `gitmoot memory vault import <dir> [--dry-run|--yes]`

The human curation gate as an explicit round-trip over the P1 export (#743). Export a vault, edit/delete/add notes in any editor, then `import` **diffs the folder against a fresh export** and applies only on confirmation. The diff is the audit trail; nothing treats the markdown as a second source of truth.

### Behavior
- **Stale guard first.** Regenerates a fresh export in memory and **aborts as stale** if the store moved since the vault was written (manifest `snapshot_hash` mismatch), so a stale diff can never clobber newer facts.
- **Edited** note → updates its source memory's content via an optimistic **CAS on `updated_at`** (targets the exact row by id — never key-based — and resyncs the FTS index).
- **Deleted** note → **retires** its memory: additive `retired_at`/`retired_reason` columns + FTS removal, so it stops being injected and stops exporting. The audit row is preserved (never hard-deleted); `superseded_by` stays reserved (still zero writers).
- **New** `.md` (no `memory_id`) → stages a **pending observation** (`provenance=vault-import:<file>`, trust `normal` — owner-authored) behind the existing confirmation gate. Never auto-confirmed.
- Frontmatter identity edits (key/scope/owner) are **out of scope** — detected, warned, skipped (only the content edit lands).
- `--dry-run` is the **default** (prints the full diff, writes nothing); `--yes` applies edits + retirements + new observations in **one transaction** (all-or-nothing). The `<DIR>` positional may sit before or after the flags.

### Implementation
- Frontmatter parser lifted into `internal/memory` (`SplitFrontmatter` + `ParseVaultNote`); round-trip with `RenderVaultNote` is byte-identical (tested).
- Store ops `UpdateConfirmedMemoryByID`, `RetireConfirmedMemory`, and the atomic `ApplyVaultImport` (shared tx helpers; `InsertMemoryObservation` refactored onto the same helper).
- **Append-only** migration: `ALTER TABLE confirmed_memories ADD COLUMN retired_at/retired_reason TEXT NOT NULL DEFAULT ''`. The vault lister and the injection query (`QueryConfirmedMemories`) gain `retired_at = ''` — byte-identical on pre-migration DBs.

### Tests
- Parser round-trip + Links-stripping; CAS conflict (error names the id) + FTS resync; retire removes from FTS + injection + export; atomic all-or-nothing rollback; dry-run zero writes; stale-manifest abort; unknown-file → observation; full export→edit+delete+add→import→re-export E2E. Also verified end-to-end through the real binary.

### Gates
`go build ./...`, `go vet`, `go test` (internal/db, internal/memory, internal/cli), scoped `-race` on internal/cli, and `npm ci && npm run build` (website) all pass.

Docs updated in the same PR: `skills/gitmoot/references/CLI.md`, `website/docs/concepts/agent-memory.md`, `website/docs/reference/cli.md`, `website/static/llms-full.txt`.

Part of #737 (P2). P3 (`memory ingest`) and P4 (distill) remain open — intentionally no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)