### PR TITLE
ci: dep-only fast lane + 2-way sharded race-cli (#754)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,17 @@ name: CI
 # "the tests pass" is enforced on a clean checkout rather than trusted from a
 # local run. Does NOT run the live multi-runtime (codex/claude/kimi) E2E — that
 # needs runtime auth and stays a manual step.
+#
+# Two speed levers (#754), both rigor-preserving:
+#   - DEP-ONLY FAST LANE: a PR touching only go.mod/go.sum (the dashboard-module
+#     pin bumps — embedded assets, zero Go changes) skips the -race lanes. The
+#     full build + generated-contract check + vet + non-race `go test ./...`
+#     still run, and the bumped module passed its own CI. Pushes to main always
+#     run everything.
+#   - SHARDED race-cli: `go test -race ./internal/cli/` is the wall-time hog
+#     (17-21m, ~6x the plain run) — it is split across a 2-way matrix by an
+#     alternating deterministic partition of `go test -list` output, so the two
+#     shards together always cover the full current suite and wall time halves.
 
 on:
   push:
@@ -18,8 +29,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    # Classifies the diff so the -race lanes can skip dep-only PRs (#754).
+    # code=true means "something beyond go.mod/go.sum changed" (or this is a
+    # push to main, which always runs the full gate).
+    name: classify diff
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.diff.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify
+        id: diff
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "push to main — full gate"
+            exit 0
+          fi
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          echo "changed files:"; echo "$CHANGED"
+          if echo "$CHANGED" | grep -qvE '^(go\.mod|go\.sum)$'; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "dep-only diff — race lanes will be skipped"
+          fi
+
   build-test:
     name: build / vet / test
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,20 +98,23 @@ jobs:
         # reads (JobRuntimeLockLiveness, DeleteExpiredResourceLocks) that the daemon
         # worker pool exercises from multiple goroutines.
         #
-        # internal/cli is race-tested too, but it has outgrown the shared 20m bound
-        # (#733): under -race it alone takes ~17-21m and intermittently timed out
-        # here (a timeout goroutine dump, not a real race). It now runs in its own
-        # parallel `race-cli` job below with a 35m timeout, so a slow runner can no
-        # longer fail green code and total wall-time stays ≈ max(jobs), not the sum.
+        # internal/cli runs in the sharded `race-cli` matrix below (#733/#754).
         #
-        # -timeout 20m: these three suites are comfortably under Go's default
-        # 10m/package deadline even under the ~10x race slowdown; the explicit
-        # bound gives headroom without masking a hang.
+        # Skipped on dep-only PRs (#754): a go.mod/go.sum-only bump changes no
+        # concurrent Go code; the full non-race test above still covers the seam.
+        if: needs.changes.outputs.code == 'true'
         run: go test -race -timeout 20m ./internal/workflow/ ./internal/db/ ./internal/daemon/
 
   race-cli:
-    name: race (internal/cli)
+    name: race (internal/cli, shard ${{ matrix.shard }}/2)
+    needs: changes
+    # Skipped on dep-only PRs (#754); see the fast-lane note at the top.
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,16 +125,20 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Test (race detector, internal/cli)
-        # internal/cli is the mega-package: the #484 canary auto-rollback decorator
-        # (canary_daemon.go) carries a concurrency contract — the daemon runs jobs
-        # in a parallel worker pool, so two same-template harvests can race to roll
-        # back the same canary and `candidate.rolled_back` must still fire exactly
-        # once. TestCanaryLifecycleE2E's concurrent subtest asserts that dedup, so
-        # it belongs under the detector.
-        #
-        # Split into its own job (#733) because every wave adds tests here and the
-        # suite under -race runs ~17-21m — it repeatedly tipped the shared 20m step
-        # over on loaded runners (a timeout, not a data race). -timeout 35m gives
-        # ample headroom while still surfacing a genuine hang.
-        run: go test -race -timeout 35m ./internal/cli/
+      - name: Test (race detector, internal/cli — sharded)
+        # internal/cli is the mega-package (the #484 canary auto-rollback
+        # concurrency contract lives here, so it belongs under the detector),
+        # but under -race the full suite runs 17-21m and grows every wave
+        # (#733). It is sharded 2-way (#754): `go test -list` enumerates the
+        # current test functions and an alternating line split partitions them
+        # deterministically — adjacent names interleave, so alphabetical
+        # clusters of slow E2Es spread across both shards, and the union of
+        # the shards is always the complete suite as it exists on this commit.
+        run: |
+          TESTS=$(go test -list '.*' ./internal/cli/ | grep '^Test' || true)
+          if [ -z "$TESTS" ]; then echo "no tests listed"; exit 1; fi
+          PICK=$(echo "$TESTS" | awk -v s='${{ matrix.shard }}' 'NR % 2 == s')
+          COUNT=$(echo "$PICK" | grep -c . || true)
+          echo "shard ${{ matrix.shard }}: $COUNT of $(echo "$TESTS" | wc -l) tests"
+          RUN="^($(echo "$PICK" | paste -sd'|' -))$"
+          go test -race -timeout 30m -run "$RUN" ./internal/cli/


### PR DESCRIPTION
PR CI wall time ≈ the `race-cli` job (17-21m under -race, ~6× the plain 3-4m run, growing every wave) — and dep-only dashboard pin bumps paid all of it for zero Go changes.

**Lever 1 — dep-only fast lane**: a `changes` job classifies the PR diff; go.mod/go.sum-only PRs skip both `-race` lanes. Full build + generated-contract check + vet + non-race `go test ./...` still run, and the bumped module passed its own CI. Pushes to main always run the full gate.

**Lever 2 — sharded race-cli**: 2-way matrix over a deterministic alternating split of `go test -list` output. Validated locally: 1244 tests → 622/622, disjoint, union complete, regex-selection exact; adjacent-name interleaving spreads the alphabetical E2E clusters across shards.

Expected wall: dep-only PRs **~5-7m**, code PRs **~9-12m** (was ~20m). This PR is itself a code change, so its own run demonstrates the sharded lane; the next pin bump demonstrates the fast lane. Follow-up rigor discussion (PR-targeted race allowlist + nightly full sweep) tracked in #755.

Fixes #754

🤖 Generated with [Claude Code](https://claude.com/claude-code)