### PR TITLE
feat(memory): groom propose/apply + nightly proposal pipeline (#737 P4.2)

### DIFF
--- a/docs/examples/memory-groom-nightly/README.md
+++ b/docs/examples/memory-groom-nightly/README.md
@@ -1,0 +1,65 @@
+# Nightly memory-groom proposal pipeline (#737 P4.2)
+
+A ready-to-register [pipeline](../../pipelines.md) that runs the deterministic
+memory groomer every night and pings the owner when there is something to review.
+It is **proposal-only and human-gated**: it never mutates confirmed memory. The
+detectors write a reviewable plan artifact; a human applies it explicitly.
+
+This mirrors the existing memory-ingest sweep pattern — a nightly job that
+proposes and notifies, with the destructive step held behind an owner `--yes`.
+
+## What it does
+
+Each night the single `propose` stage runs:
+
+```sh
+gitmoot memory groom --propose --out <plans-dir>/groom-<YYYYMMDD>.json
+```
+
+`groom --propose` reads every **active** confirmed memory, computes the current
+vault `snapshot_hash` (the same anchor `vault export`/`import` use), runs the
+deterministic detectors, and writes a plan of:
+
+- **proposed retirements** — status/changelog/ToC snapshot notes, bare to-do
+  lists, and exact-duplicate content (keeping the lowest id of each duplicate set);
+- **rewrite flags** — over-long multi-fact "bricks" are *flagged for owner review*,
+  never retired or rewritten by this track (LLM rewriting is the follow-up P4.3).
+
+When the plan is non-empty the stage pings the owner via `agentgram`. **Nothing is
+retired until the owner reviews the plan and runs:**
+
+```sh
+gitmoot memory groom --yes --plan <plans-dir>/groom-<YYYYMMDD>.json
+```
+
+`--yes` recomputes the `snapshot_hash` and **aborts as stale** if the memory store
+changed since the proposal — so a vault edit between propose and apply can never
+retire the wrong revision.
+
+## Register it
+
+1. Copy `scripts/groom-propose.sh` somewhere the pipeline's stage cwd can reach
+   (the stage runs `sh -c '<cmd>'` from a worktree of the pipeline's `repo`), and
+   adjust the `cmd` in `groom-nightly.yaml` to point at it. Requirements on the
+   host: `gitmoot` on `PATH`, `jq`, and (optionally) `agentgram` for the ping.
+
+2. Set `repo:` in `groom-nightly.yaml` to your gitmoot management repo. A
+   scheduled pipeline needs a managed repo for the worker to claim its stage jobs;
+   groom itself operates on the whole local memory store regardless of which repo
+   the stage runs against.
+
+3. Register and enable it:
+
+   ```sh
+   gitmoot pipeline add groom-nightly.yaml --enable
+   gitmoot pipeline list
+   ```
+
+The spec is stored **verbatim** at `add` time; later edits to the file don't affect
+an in-flight run. Disable with `gitmoot pipeline disable memory-groom-nightly`.
+
+## Files
+
+- `groom-nightly.yaml` — the pipeline spec (24h schedule, one proposal stage).
+- `scripts/groom-propose.sh` — the stage command: propose, notify-on-nonempty,
+  emit the `gitmoot_result` the advancer folds on.

--- a/docs/examples/memory-groom-nightly/groom-nightly.yaml
+++ b/docs/examples/memory-groom-nightly/groom-nightly.yaml
@@ -1,0 +1,35 @@
+# Nightly memory-grooming proposal pipeline (#737 P4.2).
+#
+# A single-stage #681 pipeline that runs `gitmoot memory groom --propose` every
+# night and pings the owner when there are proposals to review. It is
+# PROPOSAL-ONLY: it NEVER mutates confirmed memory. The deterministic detectors
+# write a reviewable plan artifact; the owner applies it by hand after reading it:
+#
+#     gitmoot memory groom --yes --plan <plan.json>
+#
+# This mirrors the memory-ingest sweep pattern (a nightly, notify-on-nonempty,
+# human-gated proposal) — nothing destructive happens without an explicit owner
+# `--yes`.
+#
+# Register it live (the spec is stored verbatim; edits after `add` don't affect
+# in-flight runs):
+#
+#     gitmoot pipeline add groom-nightly.yaml --enable
+#
+# Fill in `repo` with your gitmoot management repo — a scheduled pipeline needs a
+# managed repo for the worker to claim its stage jobs (groom itself operates on the
+# whole local memory store regardless of which repo the stage runs against).
+
+name: memory-groom-nightly
+repo: OWNER/REPO            # REQUIRED to run — set to your gitmoot management repo
+schedule:
+  interval: 24h            # nightly
+  jitter: 30m              # de-thunder against other scheduled sweeps
+stages:
+  - id: propose
+    # Runs the propose script placed alongside this spec (see README). The script
+    # emits the gitmoot_result the advancer folds on; it prints `approved` on a
+    # clean proposal (empty or not) and `failed` only if `groom --propose` errored.
+    # Adjust the path to wherever you install groom-propose.sh.
+    cmd: "sh scripts/groom-propose.sh"
+    timeout: 10m

--- a/docs/examples/memory-groom-nightly/scripts/groom-propose.sh
+++ b/docs/examples/memory-groom-nightly/scripts/groom-propose.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+# Nightly memory-groom proposal stage (#737 P4.2).
+#
+# Runs `gitmoot memory groom --propose` (which NEVER mutates memory), then pings
+# the owner via agentgram when the plan has anything to review. It prints the
+# gitmoot_result the pipeline advancer folds on: `approved` whenever propose
+# succeeds (whether or not there are proposals), `failed` only if propose errored.
+#
+# The owner reviews the written plan and applies it explicitly:
+#     gitmoot memory groom --yes --plan <plan.json>
+#
+# Nothing here is destructive; there is no `--yes` in this script by design.
+#
+# Requires: `gitmoot` on PATH, `jq` for the count, and (optionally) `agentgram`
+# for the notification. Override the plans dir with GROOM_PLANS_DIR.
+set -eu
+
+PLANS_DIR="${GROOM_PLANS_DIR:-${HOME}/evals/groom}"
+mkdir -p "${PLANS_DIR}"
+# A per-day filename keeps nightly runs from piling up while staying deterministic
+# within a day (a re-run overwrites the same plan). `groom --propose`'s own default
+# name is snapshot-derived; an explicit --out just pins the location.
+PLAN="${PLANS_DIR}/groom-$(date -u +%Y%m%d).json"
+
+emit() {
+  # $1 decision, $2 summary
+  printf '%s' "{\"gitmoot_result\":{\"decision\":\"$1\",\"summary\":\"$2\"}}"
+}
+
+if ! gitmoot memory groom --propose --out "${PLAN}" >/dev/null 2>&1; then
+  emit failed "gitmoot memory groom --propose failed"
+  exit 0
+fi
+
+COUNT=$(jq -r '.stats.proposed_retirements // 0' "${PLAN}" 2>/dev/null || echo 0)
+FLAGS=$(jq -r '.stats.rewrite_flags // 0' "${PLAN}" 2>/dev/null || echo 0)
+
+if [ "${COUNT}" -gt 0 ] || [ "${FLAGS}" -gt 0 ]; then
+  # Notify only when there is something to review; best-effort (never fail the stage
+  # on a notification hiccup).
+  if command -v agentgram >/dev/null 2>&1; then
+    agentgram send "gitmoot memory groom: ${COUNT} retirement(s) + ${FLAGS} rewrite flag(s) proposed. Review ${PLAN}, then apply: gitmoot memory groom --yes --plan ${PLAN}" >/dev/null 2>&1 || true
+  fi
+fi
+
+emit approved "proposed ${COUNT} retirement(s), ${FLAGS} rewrite flag(s); plan at ${PLAN}"

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -40,6 +40,8 @@ func runMemory(args []string, stdout, stderr io.Writer) int {
 		return runMemoryObservations(args[1:], stdout, stderr)
 	case "confirm":
 		return runMemoryConfirm(args[1:], stdout, stderr)
+	case "groom":
+		return runMemoryGroom(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown memory command %q\n\n", args[0])
 		printMemoryUsage(stderr)
@@ -58,6 +60,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot memory ingest <path|dir> --agent NAME [--repo R] [--tier repo|general] [--dry-run] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory groom --propose [--out PLAN.json] [--json] | --yes --plan PLAN.json [--json]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  list          show stored memories (confirmed and/or pending observations)")
 	fmt.Fprintln(w, "  replay        offline A/B: render recent real jobs' prompts with vs without the")
@@ -67,6 +70,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  ingest        stage markdown as trust_mark=low pending observations (PreFilter-gated)")
 	fmt.Fprintln(w, "  observations  list pending observations, flagging which keys are already confirmed")
 	fmt.Fprintln(w, "  confirm       human-gated promotion of pending observations into confirmed memory")
+	fmt.Fprintln(w, "  groom         deterministically propose stale-memory retirements, apply on confirmation")
 }
 
 // ---- memory list ----------------------------------------------------------

--- a/internal/cli/memory_groom.go
+++ b/internal/cli/memory_groom.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/memory"
@@ -38,6 +39,9 @@ type groomPlanRetirement struct {
 	Key       string `json:"key"`
 	Reason    string `json:"reason"`
 	FirstLine string `json:"first_line"`
+	Owner     string `json:"owner,omitempty"`
+	Repo      string `json:"repo,omitempty"`
+	Scope     string `json:"scope,omitempty"`
 }
 
 // groomPlanRewriteFlag flags an over-long memory for a later rewrite pass (P4.2
@@ -117,9 +121,14 @@ func runMemoryGroomPropose(home, out string, jsonOut bool, stdout, stderr io.Wri
 		cands := make([]memory.GroomCandidate, 0, len(notes))
 		for _, n := range notes {
 			cands = append(cands, memory.GroomCandidate{
-				ID:      n.memRecord.ID,
-				Key:     n.memRecord.Key,
-				Content: n.memRecord.Content,
+				ID:           n.memRecord.ID,
+				Key:          n.memRecord.Key,
+				Content:      n.memRecord.Content,
+				OwnerKind:    n.memRecord.OwnerKind,
+				OwnerRef:     n.memRecord.OwnerRef,
+				OwnerVersion: n.memRecord.OwnerVersion,
+				Repo:         n.memRecord.Repo,
+				Scope:        n.memRecord.Scope,
 			})
 		}
 		proposal := memory.DetectGroomActions(cands)
@@ -133,6 +142,7 @@ func runMemoryGroomPropose(home, out string, jsonOut bool, stdout, stderr io.Wri
 		for _, r := range proposal.Retirements {
 			plan.ProposedRetirements = append(plan.ProposedRetirements, groomPlanRetirement{
 				ID: r.ID, Key: r.Key, Reason: r.Reason, FirstLine: r.FirstLine,
+				Owner: r.Owner, Repo: r.Repo, Scope: r.Scope,
 			})
 		}
 		for _, f := range proposal.RewriteFlags {
@@ -260,6 +270,27 @@ func readGroomPlan(path string) (groomPlan, error) {
 	return plan, nil
 }
 
+// groomScopeLabel renders a retirement's owner/repo/scope as a compact,
+// trailing-space-terminated prefix (e.g. "agent:lead repo:acme/widget ") so the
+// owner can tell a same-scope duplicate from a cross-scope keeper at a glance.
+// Returns "" when no scope fields are present (older plans), keeping output tidy.
+func groomScopeLabel(r groomPlanRetirement) string {
+	parts := make([]string, 0, 3)
+	if r.Owner != "" {
+		parts = append(parts, r.Owner)
+	}
+	switch {
+	case r.Repo != "":
+		parts = append(parts, "repo:"+r.Repo)
+	case r.Scope != "":
+		parts = append(parts, r.Scope)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " ") + " "
+}
+
 func printGroomProposal(w io.Writer, plan groomPlan, outPath string) {
 	fmt.Fprintf(w, "groom proposal (snapshot %s)\n", plan.SnapshotHash)
 	fmt.Fprintf(w, "  %d of %d memory(ies) proposed for retirement; %d flagged for rewrite\n",
@@ -279,7 +310,7 @@ func printGroomProposal(w io.Writer, plan groomPlan, outPath string) {
 	if len(plan.ProposedRetirements) > 0 {
 		fmt.Fprintln(w, "\nProposed retirements:")
 		for _, r := range plan.ProposedRetirements {
-			fmt.Fprintf(w, "  - memory %d [%s] (%s) %s\n", r.ID, r.Key, r.Reason, r.FirstLine)
+			fmt.Fprintf(w, "  - memory %d [%s] (%s) %s%s\n", r.ID, r.Key, r.Reason, groomScopeLabel(r), r.FirstLine)
 		}
 	}
 	if len(plan.RewriteFlags) > 0 {

--- a/internal/cli/memory_groom.go
+++ b/internal/cli/memory_groom.go
@@ -1,0 +1,297 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+)
+
+// memory groom (#737 P4.2) — the deterministic grooming pass as an explicit,
+// human-gated propose→apply round-trip over confirmed memory.
+//
+// `groom --propose` reads every ACTIVE confirmed memory (the vault lister path,
+// retired rows excluded), computes the CURRENT vault snapshot_hash exactly as
+// `vault export` does, runs the deterministic detectors (internal/memory), and
+// writes a reviewable plan artifact — it touches nothing in the store.
+//
+// `groom --yes --plan <file>` recomputes the snapshot_hash, ABORTS AS STALE if it
+// differs from the plan's (a vault edit between propose and apply invalidates the
+// plan), and applies the plan's retirements in ONE transaction. P4.2 is
+// retire-only: no content is edited or rewritten; over-long "bricks" are only
+// FLAGGED for a later owner/LLM pass (P4.3).
+
+// groomSchemaVersion is the on-disk plan schema version. Bump on a breaking change
+// to the plan shape so a stale `--plan` file is rejected rather than misread.
+const groomSchemaVersion = 1
+
+// groomPlanRetirement is one proposed retirement in the plan artifact.
+type groomPlanRetirement struct {
+	ID        int64  `json:"id"`
+	Key       string `json:"key"`
+	Reason    string `json:"reason"`
+	FirstLine string `json:"first_line"`
+}
+
+// groomPlanRewriteFlag flags an over-long memory for a later rewrite pass (P4.2
+// only lists it; it never rewrites).
+type groomPlanRewriteFlag struct {
+	ID    int64  `json:"id"`
+	Key   string `json:"key"`
+	Chars int    `json:"chars"`
+}
+
+// groomPlan is the reviewable artifact `--propose` writes and `--yes --plan` reads.
+type groomPlan struct {
+	SchemaVersion       int                    `json:"schema_version"`
+	SnapshotHash        string                 `json:"snapshot_hash"`
+	ProposedRetirements []groomPlanRetirement  `json:"proposed_retirements"`
+	RewriteFlags        []groomPlanRewriteFlag `json:"rewrite_flags"`
+	Stats               memory.GroomStats      `json:"stats"`
+}
+
+// groomApplyResult is the --json summary of an apply run.
+type groomApplyResult struct {
+	Plan         string  `json:"plan"`
+	SnapshotHash string  `json:"snapshot_hash"`
+	Applied      bool    `json:"applied"`
+	Retired      []int64 `json:"retired"`
+	Skipped      []int64 `json:"skipped"`
+}
+
+func runMemoryGroom(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory groom", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	propose := fs.Bool("propose", false, "read confirmed memory, run the detectors, and write a reviewable plan (writes nothing to the store)")
+	yes := fs.Bool("yes", false, "apply a plan's retirements (requires --plan)")
+	plan := fs.String("plan", "", "path to a plan artifact produced by --propose (required with --yes)")
+	out := fs.String("out", "", "where --propose writes the plan (default: <home>/evals/groom/groom-<snapshot>.json)")
+	jsonOut := fs.Bool("json", false, "print the summary as JSON")
+	if err := parseMemoryFlags(fs, args); err != nil {
+		return memoryFlagExit(err)
+	}
+	if *propose == *yes {
+		fmt.Fprintln(stderr, "memory groom: pass exactly one of --propose or --yes")
+		printMemoryGroomUsage(stderr)
+		return 2
+	}
+	if *propose {
+		return runMemoryGroomPropose(*home, *out, *jsonOut, stdout, stderr)
+	}
+	return runMemoryGroomApply(*home, *plan, *jsonOut, stdout, stderr)
+}
+
+func printMemoryGroomUsage(w io.Writer) {
+	fmt.Fprintln(w, "Deterministically groom confirmed memory (#737 P4.2): propose retirements, apply on confirmation.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot memory groom --propose [--out PLAN.json] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory groom --yes --plan PLAN.json [--json]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  --propose  read active confirmed memory, run the deterministic detectors")
+	fmt.Fprintln(w, "             (status/changelog/ToC snapshots, bare to-do lists, exact duplicates;")
+	fmt.Fprintln(w, "             over-long bricks are FLAGGED, not retired) and write a reviewable plan.")
+	fmt.Fprintln(w, "             The store is not touched.")
+	fmt.Fprintln(w, "  --yes      apply a plan's retirements in one transaction. Recomputes the vault")
+	fmt.Fprintln(w, "             snapshot and ABORTS AS STALE if the store changed since --propose.")
+	fmt.Fprintln(w, "             Retire-only: no content is edited or rewritten.")
+}
+
+func runMemoryGroomPropose(home, out string, jsonOut bool, stdout, stderr io.Writer) int {
+	var plan groomPlan
+	err := withReadOnlyStore(home, func(store *db.Store) error {
+		// Reuse the exact vault build path: the same active-confirmed lister and the
+		// same snapshot_hash the export/import staleness guard uses.
+		notes, _, snapshotHash, _, err := buildVault(context.Background(), store, "")
+		if err != nil {
+			return err
+		}
+		cands := make([]memory.GroomCandidate, 0, len(notes))
+		for _, n := range notes {
+			cands = append(cands, memory.GroomCandidate{
+				ID:      n.memRecord.ID,
+				Key:     n.memRecord.Key,
+				Content: n.memRecord.Content,
+			})
+		}
+		proposal := memory.DetectGroomActions(cands)
+		plan = groomPlan{
+			SchemaVersion:       groomSchemaVersion,
+			SnapshotHash:        snapshotHash,
+			ProposedRetirements: make([]groomPlanRetirement, 0, len(proposal.Retirements)),
+			RewriteFlags:        make([]groomPlanRewriteFlag, 0, len(proposal.RewriteFlags)),
+			Stats:               proposal.Stats,
+		}
+		for _, r := range proposal.Retirements {
+			plan.ProposedRetirements = append(plan.ProposedRetirements, groomPlanRetirement{
+				ID: r.ID, Key: r.Key, Reason: r.Reason, FirstLine: r.FirstLine,
+			})
+		}
+		for _, f := range proposal.RewriteFlags {
+			plan.RewriteFlags = append(plan.RewriteFlags, groomPlanRewriteFlag{ID: f.ID, Key: f.Key, Chars: f.Chars})
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory groom: %v\n", err)
+		return 1
+	}
+
+	outPath := out
+	if outPath == "" {
+		paths, err := pathsFromFlag(home)
+		if err != nil {
+			fmt.Fprintf(stderr, "memory groom: %v\n", err)
+			return 1
+		}
+		// A snapshot-derived filename is deterministic: the same store state always
+		// writes the same plan path (nightly re-runs of an unchanged store overwrite
+		// in place rather than piling up plans).
+		short := plan.SnapshotHash
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		outPath = filepath.Join(paths.Evals, "groom", "groom-"+short+".json")
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		fmt.Fprintf(stderr, "memory groom: create plan dir: %v\n", err)
+		return 1
+	}
+	if err := writeJSONFile(outPath, plan); err != nil {
+		fmt.Fprintf(stderr, "memory groom: write plan: %v\n", err)
+		return 1
+	}
+
+	if jsonOut {
+		summary := struct {
+			groomPlan
+			Out string `json:"out"`
+		}{groomPlan: plan, Out: outPath}
+		if err := writeJSON(stdout, summary); err != nil {
+			fmt.Fprintf(stderr, "memory groom: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printGroomProposal(stdout, plan, outPath)
+	return 0
+}
+
+func runMemoryGroomApply(home, planPath string, jsonOut bool, stdout, stderr io.Writer) int {
+	if planPath == "" {
+		fmt.Fprintln(stderr, "memory groom: --yes requires --plan <file>")
+		printMemoryGroomUsage(stderr)
+		return 2
+	}
+	plan, err := readGroomPlan(planPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "memory groom: %v\n", err)
+		return 1
+	}
+
+	result := groomApplyResult{Plan: planPath}
+	err = withStore(home, func(store *db.Store) error {
+		ctx := context.Background()
+		// Recompute the CURRENT snapshot_hash and abort if the store moved since the
+		// plan was proposed — a vault edit in the propose→apply window would make the
+		// plan target the wrong revisions (the gpt-5.5 race catch).
+		_, _, freshHash, _, err := buildVault(ctx, store, "")
+		if err != nil {
+			return err
+		}
+		result.SnapshotHash = freshHash
+		if freshHash != plan.SnapshotHash {
+			return fmt.Errorf("plan is stale: the memory store changed since it was proposed (plan snapshot %s, current %s); re-run `gitmoot memory groom --propose` and re-review", plan.SnapshotHash, freshHash)
+		}
+		items := make([]db.GroomRetire, 0, len(plan.ProposedRetirements))
+		for _, r := range plan.ProposedRetirements {
+			items = append(items, db.GroomRetire{ID: r.ID, Reason: "groom:" + r.Reason})
+		}
+		res, err := store.ApplyGroomRetirements(ctx, items)
+		if err != nil {
+			return err
+		}
+		result.Retired = res.Retired
+		result.Skipped = res.Skipped
+		result.Applied = true
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory groom: %v\n", err)
+		return 1
+	}
+
+	if jsonOut {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "memory groom: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "applied groom plan %s (snapshot %s)\n", result.Plan, result.SnapshotHash)
+	fmt.Fprintf(stdout, "  retired %d memory(ies), skipped %d (already retired or missing)\n", len(result.Retired), len(result.Skipped))
+	return 0
+}
+
+// readGroomPlan reads and validates a plan artifact.
+func readGroomPlan(path string) (groomPlan, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return groomPlan{}, fmt.Errorf("read plan %s: %w", path, err)
+	}
+	var plan groomPlan
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return groomPlan{}, fmt.Errorf("%s is not a valid groom plan: %w", path, err)
+	}
+	if plan.SchemaVersion != groomSchemaVersion {
+		return groomPlan{}, fmt.Errorf("groom plan schema v%d is not supported by this build (expected v%d); re-run `gitmoot memory groom --propose`", plan.SchemaVersion, groomSchemaVersion)
+	}
+	if plan.SnapshotHash == "" {
+		return groomPlan{}, fmt.Errorf("%s has no snapshot_hash; re-run `gitmoot memory groom --propose`", path)
+	}
+	return plan, nil
+}
+
+func printGroomProposal(w io.Writer, plan groomPlan, outPath string) {
+	fmt.Fprintf(w, "groom proposal (snapshot %s)\n", plan.SnapshotHash)
+	fmt.Fprintf(w, "  %d of %d memory(ies) proposed for retirement; %d flagged for rewrite\n",
+		plan.Stats.ProposedRetirements, plan.Stats.TotalMemories, plan.Stats.RewriteFlags)
+	if len(plan.Stats.ByReason) > 0 {
+		reasons := make([]string, 0, len(plan.Stats.ByReason))
+		for r := range plan.Stats.ByReason {
+			reasons = append(reasons, r)
+		}
+		sort.Strings(reasons)
+		fmt.Fprint(w, "  by reason:")
+		for _, r := range reasons {
+			fmt.Fprintf(w, " %s=%d", r, plan.Stats.ByReason[r])
+		}
+		fmt.Fprintln(w)
+	}
+	if len(plan.ProposedRetirements) > 0 {
+		fmt.Fprintln(w, "\nProposed retirements:")
+		for _, r := range plan.ProposedRetirements {
+			fmt.Fprintf(w, "  - memory %d [%s] (%s) %s\n", r.ID, r.Key, r.Reason, r.FirstLine)
+		}
+	}
+	if len(plan.RewriteFlags) > 0 {
+		fmt.Fprintln(w, "\nFlagged for rewrite (NOT retired — owner review):")
+		for _, f := range plan.RewriteFlags {
+			fmt.Fprintf(w, "  - memory %d [%s] %d chars\n", f.ID, f.Key, f.Chars)
+		}
+	}
+	fmt.Fprintf(w, "\nplan written to %s\n", outPath)
+	if plan.Stats.ProposedRetirements == 0 {
+		fmt.Fprintln(w, "nothing to retire.")
+		return
+	}
+	fmt.Fprintf(w, "review it, then apply with: gitmoot memory groom --yes --plan %s\n", outPath)
+}

--- a/internal/cli/memory_groom_test.go
+++ b/internal/cli/memory_groom_test.go
@@ -246,6 +246,34 @@ func TestGroomAlreadyRetiredIdsSkipped(t *testing.T) {
 	}
 }
 
+func TestGroomProposeDoesNotRetireCrossScopeDuplicates(t *testing.T) {
+	home, store := memoryTestHome(t)
+	const body = "identical duplicate content body about arm64 retries"
+	alice := db.MemoryOwner{Kind: "agent", Ref: "alice"}
+	bob := db.MemoryOwner{Kind: "agent", Ref: "bob"}
+	// Same content, different owners AND different repos: each copy is the only one
+	// visible in its own retrieval scope, so neither may be proposed for retirement.
+	seedConfirmed(t, store, alice, "acme/widget", "repo", "a", body)
+	seedConfirmed(t, store, bob, "acme/gadget", "repo", "b", body)
+
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	if code, _, stderr := runGroom(t, "--home", home, "--propose", "--out", planPath); code != 0 {
+		t.Fatalf("propose exit %d: %s", code, stderr)
+	}
+	plan, err := readGroomPlan(planPath)
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	for _, r := range plan.ProposedRetirements {
+		if r.Reason == memory.GroomReasonDuplicate {
+			t.Fatalf("cross-scope duplicate wrongly proposed for retirement: %+v", r)
+		}
+	}
+	if plan.Stats.ByReason[memory.GroomReasonDuplicate] != 0 {
+		t.Fatalf("duplicate proposals across scopes: %+v", plan.Stats.ByReason)
+	}
+}
+
 func TestGroomProposeEmptyStore(t *testing.T) {
 	home, _ := memoryTestHome(t)
 	planPath := filepath.Join(t.TempDir(), "plan.json")

--- a/internal/cli/memory_groom_test.go
+++ b/internal/cli/memory_groom_test.go
@@ -1,0 +1,296 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+)
+
+// groomSeed seeds a home with a realistic mix: a ToC/changelog note, a bare to-do
+// list, two exact duplicates, an over-long brick, and a genuine keeper. Returns the
+// seeded ids by label.
+func groomSeed(t *testing.T, store *db.Store) map[string]int64 {
+	t.Helper()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "lead"}
+	ids := map[string]int64{}
+	ids["toc"] = seedConfirmed(t, store, owner, "acme/widget", "repo", "index",
+		"- [ci fast lanes](ci.md) — #754 shipped 2026-07-08\n- [dashboard](dash.md) — LIVE 2026-07-08\n- [feedback](fb.md) — full loop")
+	ids["todo"] = seedConfirmed(t, store, owner, "acme/widget", "repo", "wave-todo",
+		"- [ ] wire the advancer\n- [x] add config keys\n* [ ] write tests")
+	ids["dup-a"] = seedConfirmed(t, store, owner, "acme/widget", "repo", "dup-a", "identical duplicate content body about arm64")
+	ids["dup-b"] = seedConfirmed(t, store, owner, "acme/widget", "repo", "dup-b", "identical duplicate content body about arm64")
+	ids["brick"] = seedConfirmed(t, store, owner, "acme/widget", "repo", "brick", strings.Repeat("a substantive but very long multi-fact brick. ", 40))
+	ids["keep"] = seedConfirmed(t, store, owner, "acme/widget", "repo", "keeper", "killing a foreground agent ask strands a runtime-session lock")
+	return ids
+}
+
+func runGroom(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := runMemory(append([]string{"groom"}, args...), &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+func TestGroomProposeWritesPlanTouchesNothing(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ids := groomSeed(t, store)
+	ctx := context.Background()
+
+	before, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatalf("list before: %v", err)
+	}
+
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	code, stdout, stderr := runGroom(t, "--home", home, "--propose", "--out", planPath, "--json")
+	if code != 0 {
+		t.Fatalf("propose exit %d: %s", code, stderr)
+	}
+
+	// Store is untouched: same active set.
+	after, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatalf("list after: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Fatalf("propose mutated the store: active %d -> %d", len(before), len(after))
+	}
+
+	// Plan on disk equals the --json summary's plan and lists the expected actions.
+	var summary struct {
+		groomPlan
+		Out string `json:"out"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("parse summary: %v (%s)", err, stdout)
+	}
+	if summary.Out != planPath {
+		t.Fatalf("summary out = %q, want %q", summary.Out, planPath)
+	}
+	plan, err := readGroomPlan(planPath)
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	if plan.SnapshotHash == "" || plan.SnapshotHash != summary.SnapshotHash {
+		t.Fatalf("plan/summary snapshot mismatch: %q vs %q", plan.SnapshotHash, summary.SnapshotHash)
+	}
+
+	retired := map[int64]string{}
+	for _, r := range plan.ProposedRetirements {
+		retired[r.ID] = r.Reason
+	}
+	// toc, todo, and one duplicate proposed; brick + keeper + lowest-dup kept.
+	if retired[ids["toc"]] != memory.GroomReasonStatusChangelog {
+		t.Fatalf("toc not proposed status-changelog: %v", retired)
+	}
+	if retired[ids["todo"]] != memory.GroomReasonTaskList {
+		t.Fatalf("todo not proposed task-list: %v", retired)
+	}
+	lowDup, highDup := ids["dup-a"], ids["dup-b"]
+	if lowDup > highDup {
+		lowDup, highDup = highDup, lowDup
+	}
+	if retired[highDup] != memory.GroomReasonDuplicate {
+		t.Fatalf("higher dup not proposed duplicate: %v", retired)
+	}
+	if _, ok := retired[lowDup]; ok {
+		t.Fatalf("lower-id duplicate must be kept")
+	}
+	if _, ok := retired[ids["keep"]]; ok {
+		t.Fatalf("keeper must not be proposed")
+	}
+	if _, ok := retired[ids["brick"]]; ok {
+		t.Fatalf("brick must be flagged, not retired")
+	}
+	if len(plan.RewriteFlags) != 1 || plan.RewriteFlags[0].ID != ids["brick"] {
+		t.Fatalf("rewrite flags = %+v, want brick %d", plan.RewriteFlags, ids["brick"])
+	}
+}
+
+func TestGroomApplyRetiresPlannedIds(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ids := groomSeed(t, store)
+	ctx := context.Background()
+
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	if code, _, stderr := runGroom(t, "--home", home, "--propose", "--out", planPath); code != 0 {
+		t.Fatalf("propose exit %d: %s", code, stderr)
+	}
+	plan, err := readGroomPlan(planPath)
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	wantRetired := map[int64]bool{}
+	for _, r := range plan.ProposedRetirements {
+		wantRetired[r.ID] = true
+	}
+	if len(wantRetired) != 3 {
+		t.Fatalf("expected 3 proposed retirements, got %d", len(wantRetired))
+	}
+
+	code, stdout, stderr := runGroom(t, "--home", home, "--yes", "--plan", planPath, "--json")
+	if code != 0 {
+		t.Fatalf("apply exit %d: %s", code, stderr)
+	}
+	var res groomApplyResult
+	if err := json.Unmarshal([]byte(stdout), &res); err != nil {
+		t.Fatalf("parse apply result: %v (%s)", err, stdout)
+	}
+	if !res.Applied || len(res.Retired) != 3 || len(res.Skipped) != 0 {
+		t.Fatalf("apply result unexpected: %+v", res)
+	}
+
+	// The active vault set no longer contains the retired ids; keeper survives.
+	active, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatalf("list active: %v", err)
+	}
+	activeIDs := map[int64]bool{}
+	for _, m := range active {
+		activeIDs[m.ID] = true
+	}
+	for id := range wantRetired {
+		if activeIDs[id] {
+			t.Fatalf("retired id %d still active after apply", id)
+		}
+	}
+	if !activeIDs[ids["keep"]] || !activeIDs[ids["brick"]] {
+		t.Fatalf("keeper/brick wrongly retired; active=%v", activeIDs)
+	}
+}
+
+func TestGroomStalePlanAborts(t *testing.T) {
+	home, store := memoryTestHome(t)
+	groomSeed(t, store)
+	ctx := context.Background()
+
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	if code, _, stderr := runGroom(t, "--home", home, "--propose", "--out", planPath); code != 0 {
+		t.Fatalf("propose exit %d: %s", code, stderr)
+	}
+
+	// Mutate the store between propose and apply — a new confirmed memory changes the
+	// snapshot_hash.
+	owner := db.MemoryOwner{Kind: "agent", Ref: "lead"}
+	seedConfirmed(t, store, owner, "acme/widget", "repo", "added-after", "a fresh fact added after the proposal")
+
+	before, _ := store.ListConfirmedMemoriesForVault(ctx, "")
+
+	code, _, stderr := runGroom(t, "--home", home, "--yes", "--plan", planPath, "--json")
+	if code == 0 {
+		t.Fatalf("apply should have aborted stale")
+	}
+	if !strings.Contains(stderr, "stale") {
+		t.Fatalf("stderr = %q, want stale abort", stderr)
+	}
+	// Nothing was retired.
+	after, _ := store.ListConfirmedMemoriesForVault(ctx, "")
+	if len(after) != len(before) {
+		t.Fatalf("stale abort still mutated store: %d -> %d", len(before), len(after))
+	}
+}
+
+func TestGroomAlreadyRetiredIdsSkipped(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ids := groomSeed(t, store)
+	ctx := context.Background()
+
+	// Manually retire the to-do note BEFORE proposing, so it drops out of the active
+	// set the snapshot covers.
+	if err := store.RetireConfirmedMemory(ctx, ids["todo"], "manual"); err != nil {
+		t.Fatalf("manual retire: %v", err)
+	}
+
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	if code, _, stderr := runGroom(t, "--home", home, "--propose", "--out", planPath); code != 0 {
+		t.Fatalf("propose exit %d: %s", code, stderr)
+	}
+	plan, err := readGroomPlan(planPath)
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	// Inject the already-retired id into the plan without changing snapshot_hash
+	// (the retired row is not part of the active snapshot, so the hash still matches).
+	plan.ProposedRetirements = append(plan.ProposedRetirements, groomPlanRetirement{
+		ID: ids["todo"], Key: "wave-todo", Reason: memory.GroomReasonTaskList, FirstLine: "- [ ] wire the advancer",
+	})
+	if err := writeJSONFile(planPath, plan); err != nil {
+		t.Fatalf("rewrite plan: %v", err)
+	}
+
+	code, stdout, stderr := runGroom(t, "--home", home, "--yes", "--plan", planPath, "--json")
+	if code != 0 {
+		t.Fatalf("apply exit %d: %s", code, stderr)
+	}
+	var res groomApplyResult
+	if err := json.Unmarshal([]byte(stdout), &res); err != nil {
+		t.Fatalf("parse apply result: %v (%s)", err, stdout)
+	}
+	skipped := map[int64]bool{}
+	for _, id := range res.Skipped {
+		skipped[id] = true
+	}
+	if !skipped[ids["todo"]] {
+		t.Fatalf("already-retired todo id %d not skipped; result=%+v", ids["todo"], res)
+	}
+	// The genuinely active proposed ids (toc + a duplicate) still retired.
+	if len(res.Retired) == 0 {
+		t.Fatalf("expected some ids retired alongside the skip; result=%+v", res)
+	}
+}
+
+func TestGroomProposeEmptyStore(t *testing.T) {
+	home, _ := memoryTestHome(t)
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	code, stdout, stderr := runGroom(t, "--home", home, "--propose", "--out", planPath)
+	if code != 0 {
+		t.Fatalf("propose exit %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "nothing to retire") {
+		t.Fatalf("stdout = %q, want nothing to retire", stdout)
+	}
+	plan, err := readGroomPlan(planPath)
+	if err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+	if len(plan.ProposedRetirements) != 0 || plan.Stats.TotalMemories != 0 {
+		t.Fatalf("empty-store plan not empty: %+v", plan)
+	}
+
+	// Applying an empty plan is a graceful no-op.
+	code, _, stderr = runGroom(t, "--home", home, "--yes", "--plan", planPath)
+	if code != 0 {
+		t.Fatalf("apply empty exit %d: %s", code, stderr)
+	}
+}
+
+func TestGroomRejectsAmbiguousFlags(t *testing.T) {
+	home, _ := memoryTestHome(t)
+	if code, _, _ := runGroom(t, "--home", home); code != 2 {
+		t.Fatalf("no mode should exit 2, got %d", code)
+	}
+	if code, _, _ := runGroom(t, "--home", home, "--propose", "--yes"); code != 2 {
+		t.Fatalf("both modes should exit 2, got %d", code)
+	}
+	if code, _, stderr := runGroom(t, "--home", home, "--yes"); code != 2 || !strings.Contains(stderr, "--plan") {
+		t.Fatalf("--yes without --plan should exit 2 asking for --plan, got %d %q", code, stderr)
+	}
+}
+
+func TestGroomApplyBadPlanFile(t *testing.T) {
+	home, _ := memoryTestHome(t)
+	bad := filepath.Join(t.TempDir(), "bad.json")
+	if err := os.WriteFile(bad, []byte(`{"schema_version": 999}`), 0o644); err != nil {
+		t.Fatalf("write bad plan: %v", err)
+	}
+	if code, _, stderr := runGroom(t, "--home", home, "--yes", "--plan", bad); code != 1 || !strings.Contains(stderr, "schema") {
+		t.Fatalf("bad schema should exit 1 with schema error, got %d %q", code, stderr)
+	}
+}

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -141,7 +141,7 @@ WHERE owner_kind = ? AND owner_ref = ? AND owner_version = ?
 // deliberately not filtered — an agent owner always writes owner_version=”), so
 // it answers "how many injectable facts does this agent own". It backs the
 // dashboard's per-agent memory count and is a plain read (no FTS). Superseded AND
-// retired rows are excluded (superseded_by IS NULL AND retired_at = '') so the
+// retired rows are excluded (superseded_by IS NULL AND retired_at = ”) so the
 // count stays exactly equal to the injectable set surfaced by
 // QueryConfirmedMemories (which applies the same two filters).
 func (s *Store) CountConfirmedMemoriesForOwner(ctx context.Context, ownerKind, ownerRef string) (int, error) {
@@ -178,7 +178,7 @@ WHERE owner_kind = ? AND owner_ref = ?`, ownerKind, ownerRef).Scan(&n)
 // injectable set, which drops superseded rows) and CountConfirmedMemoriesForOwner
 // (which counts only injectable rows), the graph deliberately shows superseded
 // "ghost" facts so it can draw supersede edges, so this MUST NOT filter them.
-// Retired rows (retired_at != '') ARE excluded, though: retirement carries no
+// Retired rows (retired_at != ”) ARE excluded, though: retirement carries no
 // supersede pointer and no edge, so a retired fact drawn as a live node would be a
 // phantom — and excluding it keeps the graph's fact set aligned with the injectable
 // set (QueryConfirmedMemories / CountConfirmedMemoriesForOwner both filter retired).
@@ -521,6 +521,67 @@ func (s *Store) ApplyVaultImport(ctx context.Context, plan VaultImportPlan) erro
 		}
 	}
 	return tx.Commit()
+}
+
+// GroomRetire is one row a groom plan proposes retiring: the memory id and the
+// full store reason ("groom:<detector>").
+type GroomRetire struct {
+	ID     int64
+	Reason string
+}
+
+// GroomRetireResult reports which ids were actually retired and which were skipped
+// (already retired or no longer present) by ApplyGroomRetirements.
+type GroomRetireResult struct {
+	Retired []int64
+	Skipped []int64
+}
+
+// ApplyGroomRetirements retires every planned row in ONE transaction (all-or-
+// nothing on error), removing each from the FTS index in the same transaction so
+// the retired facts stop being injected and stop appearing in future exports.
+// Unlike RetireConfirmedMemory, a planned id that is already retired or missing is
+// SKIPPED gracefully rather than aborting the batch: the groom plan may carry
+// duplicate ids (one memory flagged by two detectors), and re-applying is
+// idempotent. The caller's snapshot-hash staleness guard is what protects against
+// a concurrent vault edit landing between propose and apply; this method just
+// executes the vetted plan. It is additive and NON-destructive (the row is kept
+// for audit with retired_at/retired_reason set) and never writes superseded_by.
+func (s *Store) ApplyGroomRetirements(ctx context.Context, items []GroomRetire) (GroomRetireResult, error) {
+	var result GroomRetireResult
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	now := nowRFC3339()
+	for _, it := range items {
+		res, err := tx.ExecContext(ctx, `
+UPDATE confirmed_memories
+SET retired_at = ?, retired_reason = ?
+WHERE id = ? AND retired_at = ''`, now, it.Reason, it.ID)
+		if err != nil {
+			return GroomRetireResult{}, fmt.Errorf("groom retire %d: %w", it.ID, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return GroomRetireResult{}, err
+		}
+		if affected == 0 {
+			// Already retired within this batch (a duplicate id), already retired by a
+			// prior apply, or the row is gone — skip gracefully.
+			result.Skipped = append(result.Skipped, it.ID)
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM confirmed_memories_fts WHERE rowid = ?`, it.ID); err != nil {
+			return GroomRetireResult{}, fmt.Errorf("groom retire fts %d: %w", it.ID, err)
+		}
+		result.Retired = append(result.Retired, it.ID)
+	}
+	if err := tx.Commit(); err != nil {
+		return GroomRetireResult{}, err
+	}
+	return result, nil
 }
 
 // QueryConfirmedMemories is the READ path for job-prompt assembly. It runs one

--- a/internal/memory/groom.go
+++ b/internal/memory/groom.go
@@ -43,19 +43,32 @@ const groomFirstLineMax = 160
 
 // GroomCandidate is the DB-free projection of one active confirmed memory the
 // detectors consider. It mirrors the fields the vault snapshot already exposes.
+// Owner/Repo/Scope are carried so exact-duplicate detection can be scoped to the
+// SAME retrieval scope: two byte-identical facts held by different owners, repos,
+// or scopes surface in DIFFERENT prompt-assembly scopes, so they are not true
+// duplicates and retiring one would silently drop the fact from that scope.
 type GroomCandidate struct {
-	ID      int64
-	Key     string
-	Content string
+	ID           int64
+	Key          string
+	Content      string
+	OwnerKind    string
+	OwnerRef     string
+	OwnerVersion string
+	Repo         string // "" == general scope
+	Scope        string
 }
 
 // GroomRetirement is one proposed retirement: the memory id, its key, the detector
-// that flagged it, and a first-line preview so the owner can eyeball the plan.
+// that flagged it, a first-line preview, and the owner/repo/scope so the owner can
+// eyeball the plan and tell a same-scope duplicate from a (kept) cross-scope one.
 type GroomRetirement struct {
 	ID        int64
 	Key       string
 	Reason    string
 	FirstLine string
+	Owner     string // "kind:ref@version" label
+	Repo      string
+	Scope     string
 }
 
 // GroomRewriteFlag flags an over-long memory for owner review. P4.2 does not
@@ -103,25 +116,30 @@ func DetectGroomActions(cands []GroomCandidate) GroomProposal {
 			Key:       c.Key,
 			Reason:    reason,
 			FirstLine: groomFirstLine(c.Content),
+			Owner:     groomOwnerLabel(c),
+			Repo:      c.Repo,
+			Scope:     c.Scope,
 		})
 	}
 
-	// (d) Exact-duplicate content: group by sha256(content), keep the lowest id in
-	// each group, propose retiring the rest. sorted is id-ascending so group[0] is
-	// always the lowest id; hashOrder preserves first-seen order for deterministic
-	// output.
-	byHash := make(map[string][]GroomCandidate, len(sorted))
-	var hashOrder []string
+	// (d) Exact-duplicate content: group by (owner tuple, repo, scope, sha256(content)),
+	// keep the lowest id in each group, propose retiring the rest. Scoping the group
+	// key to the retrieval scope (owner/repo/scope) — not content alone — means a fact
+	// duplicated across owners or repos is NOT deduped: each copy is the only one
+	// visible in its own prompt-assembly scope, so retiring it would silently lose the
+	// fact there. sorted is id-ascending so group[0] is always the lowest id; keyOrder
+	// preserves first-seen order for deterministic output.
+	byKey := make(map[string][]GroomCandidate, len(sorted))
+	var keyOrder []string
 	for _, c := range sorted {
-		sum := sha256.Sum256([]byte(c.Content))
-		h := hex.EncodeToString(sum[:])
-		if _, seen := byHash[h]; !seen {
-			hashOrder = append(hashOrder, h)
+		k := groomDedupKey(c)
+		if _, seen := byKey[k]; !seen {
+			keyOrder = append(keyOrder, k)
 		}
-		byHash[h] = append(byHash[h], c)
+		byKey[k] = append(byKey[k], c)
 	}
-	for _, h := range hashOrder {
-		group := byHash[h]
+	for _, k := range keyOrder {
+		group := byKey[k]
 		if len(group) < 2 {
 			continue
 		}
@@ -170,6 +188,29 @@ func DetectGroomActions(cands []GroomCandidate) GroomProposal {
 	}
 }
 
+// groomOwnerLabel renders a candidate's owner as a stable "kind:ref@version" label
+// (version omitted when empty) for the plan's human-readable output.
+func groomOwnerLabel(c GroomCandidate) string {
+	label := c.OwnerKind + ":" + c.OwnerRef
+	if c.OwnerVersion != "" {
+		label += "@" + c.OwnerVersion
+	}
+	return label
+}
+
+// groomDedupKey is the exact-duplicate grouping key: the owner tuple, repo, and
+// scope joined with a NUL delimiter (never present in any component) followed by the
+// content hash. Two candidates share a key only when they are TRUE duplicates —
+// identical content held by the same owner in the same repo and scope — so a fact
+// duplicated across retrieval scopes is never proposed for retirement.
+func groomDedupKey(c GroomCandidate) string {
+	sum := sha256.Sum256([]byte(c.Content))
+	return strings.Join([]string{
+		c.OwnerKind, c.OwnerRef, c.OwnerVersion, c.Repo, c.Scope,
+		hex.EncodeToString(sum[:]),
+	}, "\x00")
+}
+
 // groomFirstLine returns the first non-blank line of content, trimmed and capped,
 // for the plan's human-readable preview.
 func groomFirstLine(content string) string {
@@ -203,6 +244,32 @@ var groomDateLed = regexp.MustCompile(`^[-*]?\s*\[?\d{4}-\d{2}-\d{2}`)
 // isTaskLine reports whether a single line is a Markdown checkbox item.
 func isTaskLine(line string) bool {
 	return groomTaskLine.MatchString(strings.TrimSpace(line))
+}
+
+// isStrongStatusLine reports whether a single line is an UNAMBIGUOUS status-snapshot
+// marker on its own: an explicit "STATUS:" header or a "…& deployed" changelog
+// phrase. These name a status note even as a lone line. The WEAK markers a
+// status/changelog line can also carry — a leading ISO date, a stray "SHIPPED"
+// mention, or a bracketed-ref/ToC list item — are common in substantive one-line
+// keepers, so they only indicate a changelog when they DOMINATE a multi-line note
+// (see detectStatusChangelog's minimum-line guard).
+func isStrongStatusLine(line string) bool {
+	t := strings.TrimSpace(line)
+	if t == "" {
+		return false
+	}
+	upper := strings.ToUpper(t)
+	lower := strings.ToLower(t)
+	switch {
+	case strings.HasPrefix(upper, "STATUS:"):
+		return true
+	case strings.Contains(lower, "merged & deployed"),
+		strings.Contains(lower, "merged and deployed"),
+		strings.Contains(lower, "shipped & deployed"),
+		strings.Contains(lower, "shipped and deployed"):
+		return true
+	}
+	return false
 }
 
 // isStatusChangelogLine reports whether a single line looks like a status,
@@ -272,19 +339,41 @@ func detectTaskListOnly(content string) bool {
 // ARE a changelog/index get flagged.
 const groomStatusDominance = 0.8
 
+// groomStatusMinLines is the minimum non-blank line count at which the WEAK
+// changelog markers (a leading ISO date, a stray "SHIPPED", a bracketed-ref/ToC
+// list item) are trusted to prove a note IS a changelog/index. Below it, only a
+// STRONG marker (an explicit "STATUS:" header or a "…& deployed" phrase) retires,
+// so a lone high-value fact that merely leads with a date or mentions SHIPPED — the
+// RFC's #1 use case: the lead's date-led one-line ingested notes — is kept, not
+// retired. The dominance guard alone is vacuous at n=1 (a single matching line is
+// trivially 100% of the note).
+const groomStatusMinLines = 3
+
 // detectStatusChangelog reports whether content is predominantly a status,
-// changelog, or table-of-contents snapshot: at least one non-blank line and at
-// least groomStatusDominance of them are status/changelog/ToC lines.
+// changelog, or table-of-contents snapshot: at least groomStatusDominance of the
+// non-blank lines are status/changelog/ToC lines. For short notes (fewer than
+// groomStatusMinLines non-blank lines) the weak markers are not enough on their own
+// — at least one line must be a STRONG status marker — so a single substantive
+// keeper is never retired just for leading with a date or containing "SHIPPED".
 func detectStatusChangelog(content string) bool {
 	lines := nonBlankLines(content)
 	if len(lines) == 0 {
 		return false
 	}
-	matching := 0
+	matching, strong := 0, 0
 	for _, line := range lines {
 		if isStatusChangelogLine(line) {
 			matching++
 		}
+		if isStrongStatusLine(line) {
+			strong++
+		}
 	}
-	return float64(matching) >= groomStatusDominance*float64(len(lines))
+	if float64(matching) < groomStatusDominance*float64(len(lines)) {
+		return false
+	}
+	if len(lines) < groomStatusMinLines {
+		return strong >= 1
+	}
+	return true
 }

--- a/internal/memory/groom.go
+++ b/internal/memory/groom.go
@@ -1,0 +1,290 @@
+package memory
+
+// Deterministic grooming detectors for `gitmoot memory groom` (RFC #737, P4.2).
+//
+// Grooming mechanizes the manual curation pass that periodically retires stale,
+// low-signal confirmed memories (status/changelog snapshots, table-of-contents
+// index notes, bare to-do lists, and exact duplicates). Everything here is a
+// PURE, DB-free function of its inputs so the detectors can be unit-tested in
+// isolation against real-shaped fixtures — same inputs ⇒ same proposal, every
+// run. The db-coupled orchestration (reading the vault snapshot, writing the plan
+// artifact, applying retirements in one transaction) lives in the cli package.
+//
+// P4.2 is PROPOSE + retire-only: the detectors emit a reviewable plan the owner
+// applies explicitly. Over-long "brick" memories are only FLAGGED for a later,
+// human/LLM rewrite pass (P4.3) — this track never rewrites content, only
+// proposes retirements the owner confirms.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Groom detector reason tokens. They name WHY a memory was proposed for
+// retirement and become the store retire reason as "groom:<token>" at apply time.
+const (
+	GroomReasonDuplicate       = "duplicate"
+	GroomReasonStatusChangelog = "status-changelog"
+	GroomReasonTaskList        = "task-list"
+)
+
+// GroomRewriteThreshold is the content length (in bytes) above which a memory is
+// flagged as a REWRITE candidate rather than retired. Multi-fact "bricks" carry
+// real signal that a blind retirement would lose, so P4.2 only lists them for the
+// owner; the actual rewrite is deferred to the opt-in LLM pass (P4.3).
+const GroomRewriteThreshold = 1200
+
+// groomFirstLineMax caps the first_line preview carried in the plan so a brick's
+// opening paragraph can't bloat the artifact.
+const groomFirstLineMax = 160
+
+// GroomCandidate is the DB-free projection of one active confirmed memory the
+// detectors consider. It mirrors the fields the vault snapshot already exposes.
+type GroomCandidate struct {
+	ID      int64
+	Key     string
+	Content string
+}
+
+// GroomRetirement is one proposed retirement: the memory id, its key, the detector
+// that flagged it, and a first-line preview so the owner can eyeball the plan.
+type GroomRetirement struct {
+	ID        int64
+	Key       string
+	Reason    string
+	FirstLine string
+}
+
+// GroomRewriteFlag flags an over-long memory for owner review. P4.2 does not
+// rewrite; it only records the id/key/size so the plan can list it.
+type GroomRewriteFlag struct {
+	ID    int64
+	Key   string
+	Chars int
+}
+
+// GroomStats is the roll-up carried in the plan artifact.
+type GroomStats struct {
+	TotalMemories       int            `json:"total_memories"`
+	ProposedRetirements int            `json:"proposed_retirements"`
+	RewriteFlags        int            `json:"rewrite_flags"`
+	ByReason            map[string]int `json:"by_reason"`
+}
+
+// GroomProposal is the detectors' full output over a candidate set.
+type GroomProposal struct {
+	Retirements  []GroomRetirement
+	RewriteFlags []GroomRewriteFlag
+	Stats        GroomStats
+}
+
+// DetectGroomActions runs every deterministic detector over the candidate set and
+// returns a stable proposal. Precedence per memory (a memory is proposed at most
+// once): exact-duplicate content, then a bare to-do list, then a status/changelog/
+// ToC snapshot. Over-long memories that survive retirement are flagged for a later
+// rewrite. Output is fully deterministic and independent of input order (candidates
+// are sorted by id first).
+func DetectGroomActions(cands []GroomCandidate) GroomProposal {
+	sorted := append([]GroomCandidate(nil), cands...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+
+	retired := make(map[int64]bool, len(sorted))
+	var retirements []GroomRetirement
+	addRetire := func(c GroomCandidate, reason string) {
+		if retired[c.ID] {
+			return
+		}
+		retired[c.ID] = true
+		retirements = append(retirements, GroomRetirement{
+			ID:        c.ID,
+			Key:       c.Key,
+			Reason:    reason,
+			FirstLine: groomFirstLine(c.Content),
+		})
+	}
+
+	// (d) Exact-duplicate content: group by sha256(content), keep the lowest id in
+	// each group, propose retiring the rest. sorted is id-ascending so group[0] is
+	// always the lowest id; hashOrder preserves first-seen order for deterministic
+	// output.
+	byHash := make(map[string][]GroomCandidate, len(sorted))
+	var hashOrder []string
+	for _, c := range sorted {
+		sum := sha256.Sum256([]byte(c.Content))
+		h := hex.EncodeToString(sum[:])
+		if _, seen := byHash[h]; !seen {
+			hashOrder = append(hashOrder, h)
+		}
+		byHash[h] = append(byHash[h], c)
+	}
+	for _, h := range hashOrder {
+		group := byHash[h]
+		if len(group) < 2 {
+			continue
+		}
+		for _, dup := range group[1:] {
+			addRetire(dup, GroomReasonDuplicate)
+		}
+	}
+
+	// (a)+(b) Pattern detectors over rows not already claimed as duplicates.
+	for _, c := range sorted {
+		if retired[c.ID] {
+			continue
+		}
+		switch {
+		case detectTaskListOnly(c.Content):
+			addRetire(c, GroomReasonTaskList)
+		case detectStatusChangelog(c.Content):
+			addRetire(c, GroomReasonStatusChangelog)
+		}
+	}
+
+	// (c) Rewrite flags over rows that survived retirement: extreme length.
+	var flags []GroomRewriteFlag
+	for _, c := range sorted {
+		if retired[c.ID] {
+			continue
+		}
+		if len(c.Content) > GroomRewriteThreshold {
+			flags = append(flags, GroomRewriteFlag{ID: c.ID, Key: c.Key, Chars: len(c.Content)})
+		}
+	}
+
+	byReason := map[string]int{}
+	for _, r := range retirements {
+		byReason[r.Reason]++
+	}
+	return GroomProposal{
+		Retirements:  retirements,
+		RewriteFlags: flags,
+		Stats: GroomStats{
+			TotalMemories:       len(sorted),
+			ProposedRetirements: len(retirements),
+			RewriteFlags:        len(flags),
+			ByReason:            byReason,
+		},
+	}
+}
+
+// groomFirstLine returns the first non-blank line of content, trimmed and capped,
+// for the plan's human-readable preview.
+func groomFirstLine(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" {
+			continue
+		}
+		if len(t) > groomFirstLineMax {
+			t = strings.TrimSpace(t[:groomFirstLineMax])
+		}
+		return t
+	}
+	return ""
+}
+
+// groomTaskLine matches a Markdown checkbox item ("- [ ]", "* [x]", "1. [X]").
+var groomTaskLine = regexp.MustCompile(`^([-*]|\d+\.)\s+\[[ xX]\]`)
+
+// groomTocLine matches a Markdown list item whose payload is a link ("- [Title]",
+// "- [[wikilink]]") — the shape of a table-of-contents / changelog index note. The
+// negative lookahead-free form excludes checkboxes (handled by groomTaskLine): the
+// character after '[' must NOT be a checkbox marker (space, x, X immediately
+// followed by ']').
+var groomTocLine = regexp.MustCompile(`^[-*]\s+\[[^\]]`)
+
+// groomDateLed matches a changelog line led by an ISO date, optionally after a
+// list bullet ("2026-07-08 …", "- 2026-07-08 …", "* [2026-07-08] …").
+var groomDateLed = regexp.MustCompile(`^[-*]?\s*\[?\d{4}-\d{2}-\d{2}`)
+
+// isTaskLine reports whether a single line is a Markdown checkbox item.
+func isTaskLine(line string) bool {
+	return groomTaskLine.MatchString(strings.TrimSpace(line))
+}
+
+// isStatusChangelogLine reports whether a single line looks like a status,
+// changelog, or table-of-contents entry: a "STATUS:" marker, a shipped/deployed
+// changelog phrase, an ISO-date-led line, or a Markdown link list item.
+func isStatusChangelogLine(line string) bool {
+	t := strings.TrimSpace(line)
+	if t == "" {
+		return false
+	}
+	if isTaskLine(t) {
+		// A checkbox is a task-list line, not a ToC/changelog line; keep the two
+		// detectors' populations disjoint so a pure checkbox list is reported as
+		// task-list (not status-changelog).
+		return false
+	}
+	upper := strings.ToUpper(t)
+	lower := strings.ToLower(t)
+	switch {
+	case strings.HasPrefix(upper, "STATUS:"):
+		return true
+	case strings.Contains(t, "SHIPPED"):
+		return true
+	case strings.Contains(lower, "merged & deployed"),
+		strings.Contains(lower, "merged and deployed"),
+		strings.Contains(lower, "shipped & deployed"),
+		strings.Contains(lower, "shipped and deployed"):
+		return true
+	case groomTocLine.MatchString(t):
+		return true
+	case groomDateLed.MatchString(t):
+		return true
+	}
+	return false
+}
+
+// nonBlankLines returns the trimmed-nonblank lines of content.
+func nonBlankLines(content string) []string {
+	var out []string
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// detectTaskListOnly reports whether content is nothing but a to-do list: at least
+// one non-blank line and EVERY non-blank line is a checkbox item.
+func detectTaskListOnly(content string) bool {
+	lines := nonBlankLines(content)
+	if len(lines) == 0 {
+		return false
+	}
+	for _, line := range lines {
+		if !isTaskLine(line) {
+			return false
+		}
+	}
+	return true
+}
+
+// groomStatusDominance is the fraction of non-blank lines that must look like
+// status/changelog/ToC entries for the whole note to be proposed for retirement.
+// Requiring dominance (not a single marker) protects substantive memories that
+// merely mention "SHIPPED #754" in one line from being retired — only notes that
+// ARE a changelog/index get flagged.
+const groomStatusDominance = 0.8
+
+// detectStatusChangelog reports whether content is predominantly a status,
+// changelog, or table-of-contents snapshot: at least one non-blank line and at
+// least groomStatusDominance of them are status/changelog/ToC lines.
+func detectStatusChangelog(content string) bool {
+	lines := nonBlankLines(content)
+	if len(lines) == 0 {
+		return false
+	}
+	matching := 0
+	for _, line := range lines {
+		if isStatusChangelogLine(line) {
+			matching++
+		}
+	}
+	return float64(matching) >= groomStatusDominance*float64(len(lines))
+}

--- a/internal/memory/groom_test.go
+++ b/internal/memory/groom_test.go
@@ -24,6 +24,32 @@ func TestDetectStatusChangelog(t *testing.T) {
 			want:    true,
 		},
 		{
+			// A single dense fact that merely LEADS with a date is a keeper: the weak
+			// date marker must not retire the RFC's #1 use case (date-led one-liners).
+			name:    "date-led single-line keeper",
+			content: "2026-07-08 root-caused #487: rare claude-CLI transient 401 under sustained concurrency; fix = retry-on-transient.",
+			want:    false,
+		},
+		{
+			// One substantive prose line that happens to contain SHIPPED is a keeper.
+			name:    "shipped-mention single-line keeper",
+			content: "Validated when #754 SHIPPED, but the arm64 flake predates it and needs retry-on-transient.",
+			want:    false,
+		},
+		{
+			// A single bracketed-ref line (ToC-shaped) is a keeper on its own.
+			name:    "bracketed-ref single-line keeper",
+			content: "- [#487] rare claude-CLI transient under concurrency; retry-on-transient",
+			want:    false,
+		},
+		{
+			// Two date-led lines are still below the min-line dominance floor, so a
+			// short weak-marker note is kept rather than retired.
+			name:    "two date-led lines below min-lines",
+			content: "2026-07-08 shipped X\n2026-07-07 shipped Y",
+			want:    false,
+		},
+		{
 			name: "shipped-and-deployed changelog",
 			content: "SHIPPED #717 squash-merged (main 4953994)\n" +
 				"shipped and deployed live: rubric-induce, binary-eval, synth\n" +
@@ -162,6 +188,64 @@ func TestDetectGroomActionsPrecedenceAndDuplicates(t *testing.T) {
 	if got.Stats.ByReason[GroomReasonDuplicate] != 1 || got.Stats.ByReason[GroomReasonStatusChangelog] != 1 || got.Stats.ByReason[GroomReasonTaskList] != 1 {
 		t.Fatalf("by-reason = %+v", got.Stats.ByReason)
 	}
+}
+
+func TestDetectGroomActionsDuplicateScoping(t *testing.T) {
+	const body = "identical duplicate content body about arm64 retries"
+	t.Run("same scope dedups (lowest id kept)", func(t *testing.T) {
+		cands := []GroomCandidate{
+			{ID: 1, Key: "a", Content: body, OwnerKind: "agent", OwnerRef: "lead", Repo: "acme/widget", Scope: "repo"},
+			{ID: 2, Key: "b", Content: body, OwnerKind: "agent", OwnerRef: "lead", Repo: "acme/widget", Scope: "repo"},
+		}
+		got := DetectGroomActions(cands)
+		if len(got.Retirements) != 1 || got.Retirements[0].ID != 2 || got.Retirements[0].Reason != GroomReasonDuplicate {
+			t.Fatalf("same-scope duplicate not deduped as expected: %+v", got.Retirements)
+		}
+	})
+	t.Run("cross-owner identical content is NOT retired", func(t *testing.T) {
+		cands := []GroomCandidate{
+			{ID: 1, Key: "a", Content: body, OwnerKind: "agent", OwnerRef: "alice", Repo: "acme/widget", Scope: "repo"},
+			{ID: 2, Key: "b", Content: body, OwnerKind: "agent", OwnerRef: "bob", Repo: "acme/widget", Scope: "repo"},
+		}
+		got := DetectGroomActions(cands)
+		if len(got.Retirements) != 0 {
+			t.Fatalf("cross-owner duplicate wrongly retired: %+v", got.Retirements)
+		}
+	})
+	t.Run("cross-repo identical content is NOT retired", func(t *testing.T) {
+		cands := []GroomCandidate{
+			{ID: 1, Key: "a", Content: body, OwnerKind: "agent", OwnerRef: "lead", Repo: "acme/widget", Scope: "repo"},
+			{ID: 2, Key: "b", Content: body, OwnerKind: "agent", OwnerRef: "lead", Repo: "acme/gadget", Scope: "repo"},
+		}
+		got := DetectGroomActions(cands)
+		if len(got.Retirements) != 0 {
+			t.Fatalf("cross-repo duplicate wrongly retired: %+v", got.Retirements)
+		}
+	})
+	t.Run("cross-scope (repo vs general) identical content is NOT retired", func(t *testing.T) {
+		cands := []GroomCandidate{
+			{ID: 1, Key: "a", Content: body, OwnerKind: "agent", OwnerRef: "lead", Repo: "acme/widget", Scope: "repo"},
+			{ID: 2, Key: "b", Content: body, OwnerKind: "agent", OwnerRef: "lead", Repo: "", Scope: "general"},
+		}
+		got := DetectGroomActions(cands)
+		if len(got.Retirements) != 0 {
+			t.Fatalf("cross-scope duplicate wrongly retired: %+v", got.Retirements)
+		}
+	})
+	t.Run("owner/repo/scope surfaced on the retirement", func(t *testing.T) {
+		cands := []GroomCandidate{
+			{ID: 1, Key: "a", Content: body, OwnerKind: "agent", OwnerRef: "lead", OwnerVersion: "v2", Repo: "acme/widget", Scope: "repo"},
+			{ID: 2, Key: "b", Content: body, OwnerKind: "agent", OwnerRef: "lead", OwnerVersion: "v2", Repo: "acme/widget", Scope: "repo"},
+		}
+		got := DetectGroomActions(cands)
+		if len(got.Retirements) != 1 {
+			t.Fatalf("want 1 retirement, got %+v", got.Retirements)
+		}
+		r := got.Retirements[0]
+		if r.Owner != "agent:lead@v2" || r.Repo != "acme/widget" || r.Scope != "repo" {
+			t.Fatalf("owner/repo/scope not surfaced: %+v", r)
+		}
+	})
 }
 
 func TestDetectGroomActionsDeterministicOrder(t *testing.T) {

--- a/internal/memory/groom_test.go
+++ b/internal/memory/groom_test.go
@@ -1,0 +1,204 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectStatusChangelog(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "toc index note",
+			content: "- [ci fast lanes](ci.md) — #754 shipped 2026-07-08\n" +
+				"- [dashboard redesign](dash.md) — LIVE 2026-07-08\n" +
+				"- [feedback machine](fb.md) — full loop validated",
+			want: true,
+		},
+		{
+			name:    "status marker single line",
+			content: "STATUS: shipped 2026-07-08; deployed live; PR #722 merged",
+			want:    true,
+		},
+		{
+			name: "shipped-and-deployed changelog",
+			content: "SHIPPED #717 squash-merged (main 4953994)\n" +
+				"shipped and deployed live: rubric-induce, binary-eval, synth\n" +
+				"SHIPPED the full loop 2026-07-08",
+			want: true,
+		},
+		{
+			name: "date-led changelog",
+			content: "2026-07-08 cut the release\n" +
+				"2026-07-07 chat V1 shipped\n" +
+				"2026-06-25 v0.5.2",
+			want: true,
+		},
+		{
+			name: "substantive memory that merely mentions SHIPPED once",
+			content: "The arm64 CI runner drops flaky failures intermittently under load.\n" +
+				"Root cause is a race in the test harness cache; retry-on-transient fixes it.\n" +
+				"This was validated when #754 SHIPPED but the underlying flake predates it.\n" +
+				"Keep the single-binary invariant sacred; do not add an embeddings service.",
+			want: false,
+		},
+		{
+			name:    "plain prose",
+			content: "Killing a foreground agent ask strands a runtime-session lock; clear it via DB delete.",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectStatusChangelog(tc.content); got != tc.want {
+				t.Fatalf("detectStatusChangelog(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectTaskListOnly(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name:    "pure checkbox list",
+			content: "- [ ] wire the advancer\n- [x] add the config keys\n* [ ] write the tests",
+			want:    true,
+		},
+		{
+			name:    "numbered checkboxes",
+			content: "1. [ ] first\n2. [x] second",
+			want:    true,
+		},
+		{
+			name:    "checkboxes with prose interleaved",
+			content: "Plan for the wave:\n- [ ] wire the advancer\n- [x] add the config keys",
+			want:    false,
+		},
+		{
+			name:    "toc links are not task lists",
+			content: "- [ci fast lanes](ci.md)\n- [dashboard](dash.md)",
+			want:    false,
+		},
+		{
+			name:    "empty",
+			content: "\n\n  \n",
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectTaskListOnly(tc.content); got != tc.want {
+				t.Fatalf("detectTaskListOnly(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectGroomActionsPrecedenceAndDuplicates(t *testing.T) {
+	brick := strings.Repeat("x", GroomRewriteThreshold+50)
+	cands := []GroomCandidate{
+		// Out of id order on purpose — detection must be order-independent.
+		{ID: 5, Key: "dup-b", Content: "identical duplicate body"},
+		{ID: 2, Key: "toc", Content: "- [a](a.md) — one\n- [b](b.md) — two\n- [c](c.md) — three"},
+		{ID: 1, Key: "dup-a", Content: "identical duplicate body"},
+		{ID: 3, Key: "todo", Content: "- [ ] alpha\n- [x] beta"},
+		{ID: 4, Key: "brick", Content: brick},
+		{ID: 6, Key: "keep", Content: "a genuine substantive operational memory worth keeping"},
+	}
+
+	got := DetectGroomActions(cands)
+
+	// Duplicate: keep lowest id (1), retire the higher (5).
+	// ToC (2) and to-do (3) each retire once. Brick (4) is FLAGGED, not retired.
+	retireByID := map[int64]string{}
+	for _, r := range got.Retirements {
+		if _, dup := retireByID[r.ID]; dup {
+			t.Fatalf("id %d proposed for retirement twice", r.ID)
+		}
+		retireByID[r.ID] = r.Reason
+	}
+	if reason := retireByID[5]; reason != GroomReasonDuplicate {
+		t.Fatalf("id 5 reason = %q, want duplicate", reason)
+	}
+	if _, ok := retireByID[1]; ok {
+		t.Fatalf("id 1 (lowest dup) must be kept, not retired")
+	}
+	if reason := retireByID[2]; reason != GroomReasonStatusChangelog {
+		t.Fatalf("id 2 reason = %q, want status-changelog", reason)
+	}
+	if reason := retireByID[3]; reason != GroomReasonTaskList {
+		t.Fatalf("id 3 reason = %q, want task-list", reason)
+	}
+	if _, ok := retireByID[4]; ok {
+		t.Fatalf("id 4 (brick) must be flagged, not retired")
+	}
+	if _, ok := retireByID[6]; ok {
+		t.Fatalf("id 6 (keep) must not be retired")
+	}
+
+	if len(got.RewriteFlags) != 1 || got.RewriteFlags[0].ID != 4 {
+		t.Fatalf("rewrite flags = %+v, want exactly id 4", got.RewriteFlags)
+	}
+	if got.RewriteFlags[0].Chars != len(brick) {
+		t.Fatalf("brick chars = %d, want %d", got.RewriteFlags[0].Chars, len(brick))
+	}
+
+	if got.Stats.TotalMemories != 6 {
+		t.Fatalf("total = %d, want 6", got.Stats.TotalMemories)
+	}
+	if got.Stats.ProposedRetirements != 3 {
+		t.Fatalf("proposed = %d, want 3", got.Stats.ProposedRetirements)
+	}
+	if got.Stats.RewriteFlags != 1 {
+		t.Fatalf("rewrite flags stat = %d, want 1", got.Stats.RewriteFlags)
+	}
+	if got.Stats.ByReason[GroomReasonDuplicate] != 1 || got.Stats.ByReason[GroomReasonStatusChangelog] != 1 || got.Stats.ByReason[GroomReasonTaskList] != 1 {
+		t.Fatalf("by-reason = %+v", got.Stats.ByReason)
+	}
+}
+
+func TestDetectGroomActionsDeterministicOrder(t *testing.T) {
+	cands := []GroomCandidate{
+		{ID: 3, Key: "c", Content: "- [x](x.md)\n- [y](y.md)\nSHIPPED it"},
+		{ID: 1, Key: "a", Content: "STATUS: done and shipped, all green"},
+		{ID: 2, Key: "b", Content: "- [ ] todo\n- [x] done"},
+	}
+	first := DetectGroomActions(cands)
+	// Reverse the input; output must be identical (sorted by id internally).
+	rev := []GroomCandidate{cands[2], cands[1], cands[0]}
+	second := DetectGroomActions(rev)
+	if len(first.Retirements) != len(second.Retirements) {
+		t.Fatalf("retirement counts differ: %d vs %d", len(first.Retirements), len(second.Retirements))
+	}
+	for i := range first.Retirements {
+		if first.Retirements[i] != second.Retirements[i] {
+			t.Fatalf("retirement %d differs: %+v vs %+v", i, first.Retirements[i], second.Retirements[i])
+		}
+	}
+	// Retirements come out id-ascending.
+	for i := 1; i < len(first.Retirements); i++ {
+		if first.Retirements[i-1].ID > first.Retirements[i].ID {
+			t.Fatalf("retirements not id-sorted: %+v", first.Retirements)
+		}
+	}
+}
+
+func TestGroomFirstLine(t *testing.T) {
+	if got := groomFirstLine("\n\n  first real line  \nsecond"); got != "first real line" {
+		t.Fatalf("first line = %q", got)
+	}
+	long := strings.Repeat("z", groomFirstLineMax+40)
+	if got := groomFirstLine(long); len(got) > groomFirstLineMax {
+		t.Fatalf("first line not capped: %d chars", len(got))
+	}
+	if got := groomFirstLine("   \n  "); got != "" {
+		t.Fatalf("blank content first line = %q, want empty", got)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1704,11 +1704,17 @@ use), runs deterministic detectors, and writes a reviewable plan artifact
 
 - **status/changelog/ToC snapshots** — notes dominated (≥80% of non-blank lines) by
   `STATUS:` markers, `SHIPPED`/`merged & deployed` changelog phrases, ISO-date-led
-  lines, or Markdown link-list (`- [ …]`) index entries;
+  lines, or Markdown link-list (`- [ …]`) index entries. Short notes (fewer than 3
+  non-blank lines) additionally require a **strong** marker (`STATUS:`/`… & deployed`),
+  so a single high-value fact that merely leads with a date or mentions `SHIPPED`
+  once is **kept**, not retired;
 - **bare to-do lists** — content whose every non-blank line is a `- [ ]`/`- [x]`
   checkbox;
-- **exact duplicates** — memories sharing identical content; the lowest id is kept
-  and the rest proposed for retirement;
+- **exact duplicates** — memories with identical content **in the same
+  owner/repo/scope**; the lowest id is kept and the rest proposed for retirement. A
+  fact duplicated across owners, repos, or scopes is **not** deduped — each copy is
+  the only one visible in its own retrieval scope (owner/repo/scope is shown on each
+  proposed retirement so you can tell them apart);
 - **over-long "bricks"** (content > ~1200 chars) are **flagged for rewrite**, never
   retired — P4.2 only lists them for the owner (LLM rewriting is the follow-up
   P4.3).

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1685,6 +1685,43 @@ Without `--yes` it prints the plan and writes nothing; with `--yes` it promotes
 > boundary. Trust-aware injection (having the read path weigh `trust_mark`) is
 > future work; nothing reads `trust_mark` for a decision yet.
 
+### Grooming: deterministic propose/apply (#737 P4.2)
+
+`memory groom` mechanizes the periodic curation pass that retires stale,
+low-signal confirmed memories, as an explicit **propose → review → apply**
+round-trip:
+
+```sh
+gitmoot memory groom --propose [--out PLAN.json] [--json]
+gitmoot memory groom --yes --plan PLAN.json [--json]
+```
+
+`--propose` reads every **active** confirmed memory (retired rows excluded),
+computes the current vault `snapshot_hash` (the same anchor `vault export`/`import`
+use), runs deterministic detectors, and writes a reviewable plan artifact
+(`{schema_version, snapshot_hash, proposed_retirements, rewrite_flags, stats}`). It
+**touches nothing** in the store. The detectors are:
+
+- **status/changelog/ToC snapshots** — notes dominated (≥80% of non-blank lines) by
+  `STATUS:` markers, `SHIPPED`/`merged & deployed` changelog phrases, ISO-date-led
+  lines, or Markdown link-list (`- [ …]`) index entries;
+- **bare to-do lists** — content whose every non-blank line is a `- [ ]`/`- [x]`
+  checkbox;
+- **exact duplicates** — memories sharing identical content; the lowest id is kept
+  and the rest proposed for retirement;
+- **over-long "bricks"** (content > ~1200 chars) are **flagged for rewrite**, never
+  retired — P4.2 only lists them for the owner (LLM rewriting is the follow-up
+  P4.3).
+
+`--yes --plan` recomputes the `snapshot_hash` and **aborts as stale** if it differs
+from the plan's (a vault edit between propose and apply invalidates it), then
+retires exactly the planned ids in **one transaction** (reason `groom:<detector>`,
+FTS index cleared in the same tx). It is **retire-only** — no content is edited or
+rewritten — and idempotent: an already-retired or missing id in the plan is skipped
+gracefully rather than aborting the batch. See
+[`docs/examples/memory-groom-nightly`](../../../docs/examples/memory-groom-nightly/README.md)
+for a ready-to-register nightly proposal pipeline.
+
 ## Pipelines
 
 A pipeline (#681) runs a **declared DAG of shell stages** — a fixed, repeatable

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -203,9 +203,12 @@ touches nothing in the store. The detectors flag:
 
 - **status/changelog/ToC snapshots** — notes dominated by `STATUS:` markers,
   `SHIPPED`/`merged & deployed` phrases, ISO-date-led lines, or Markdown link-list
-  index entries;
+  index entries (short notes under 3 lines also need a strong `STATUS:`/`… & deployed`
+  marker, so a lone date-led or `SHIPPED`-mentioning keeper is not retired);
 - **bare to-do lists** — content whose every non-blank line is a checkbox item;
-- **exact duplicates** — the lowest id is kept and the rest proposed for retirement;
+- **exact duplicates** — identical content **within the same owner/repo/scope**; the
+  lowest id is kept and the rest proposed. Copies across owners/repos/scopes are kept
+  (each is the only one its scope can see);
 - **over-long "bricks"** (> ~1200 chars) are **flagged for rewrite, not retired** —
   P4.2 only lists them for the owner (LLM rewriting is the follow-up P4.3).
 

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -184,6 +184,41 @@ boundary. Trust-aware injection — having the read path weigh `trust_mark` — 
 future work; nothing reads `trust_mark` for a decision yet.
 :::
 
+## Grooming stale memory
+
+`memory groom` mechanizes the periodic pass that retires stale, low-signal
+confirmed memories, as an explicit **propose → review → apply** round-trip that
+never mutates memory without an owner `--yes`:
+
+```sh
+gitmoot memory groom --propose [--out PLAN.json] [--json]
+gitmoot memory groom --yes --plan PLAN.json [--json]
+```
+
+`--propose` reads every **active** confirmed memory (retired rows excluded),
+computes the current vault `snapshot_hash` (the same anchor `vault export`/`import`
+use), runs deterministic detectors, and writes a reviewable plan artifact
+(`{schema_version, snapshot_hash, proposed_retirements, rewrite_flags, stats}`). It
+touches nothing in the store. The detectors flag:
+
+- **status/changelog/ToC snapshots** — notes dominated by `STATUS:` markers,
+  `SHIPPED`/`merged & deployed` phrases, ISO-date-led lines, or Markdown link-list
+  index entries;
+- **bare to-do lists** — content whose every non-blank line is a checkbox item;
+- **exact duplicates** — the lowest id is kept and the rest proposed for retirement;
+- **over-long "bricks"** (> ~1200 chars) are **flagged for rewrite, not retired** —
+  P4.2 only lists them for the owner (LLM rewriting is the follow-up P4.3).
+
+`--yes --plan` recomputes the `snapshot_hash` and **aborts as stale** if it differs
+from the plan's (a vault edit between propose and apply invalidates it), then
+retires exactly the planned ids in one transaction (reason `groom:<detector>`,
+clearing each from the FTS index). It is retire-only and idempotent — an
+already-retired or missing id is skipped gracefully.
+
+A ready-to-register nightly proposal pipeline (propose + notify-on-nonempty, apply
+held behind the owner) lives in
+[`docs/examples/memory-groom-nightly`](https://github.com/jerryfane/gitmoot/tree/main/docs/examples/memory-groom-nightly).
+
 ## Phases
 
 - **Phase 0** — typed `learnings` in the result contract; the two-table schema

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1404,8 +1404,9 @@ boundary and nothing reads `trust_mark` for a decision yet.
 `memory groom` retires stale, low-signal confirmed memories as a **propose →
 review → apply** round-trip. `--propose` reads active confirmed memory, computes
 the current vault `snapshot_hash`, runs deterministic detectors
-(status/changelog/ToC snapshots, bare to-do lists, exact duplicates; over-long
-"bricks" are flagged for rewrite, not retired), and writes a reviewable plan
+(status/changelog/ToC snapshots — short notes need a strong `STATUS:`/`… & deployed`
+marker; bare to-do lists; exact duplicates scoped to the same owner/repo/scope;
+over-long "bricks" are flagged for rewrite, not retired), and writes a reviewable plan
 artifact — it touches nothing in the store. `--yes --plan` recomputes the
 `snapshot_hash`, **aborts as stale** if the store changed since the proposal, then
 retires exactly the planned ids in one transaction (reason `groom:<detector>`). It

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1344,6 +1344,8 @@ gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 gitmoot memory ingest <path|dir> --agent NAME [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
 gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
+gitmoot memory groom --propose [--out PLAN.json] [--json]
+gitmoot memory groom --yes --plan PLAN.json [--json]
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
@@ -1398,6 +1400,18 @@ into confirmed memory (idempotently), and without `--yes` only prints the plan.
 Ingested Markdown is an indirect-prompt-injection vector, so it stays inert at
 `trust_mark = low` until a human confirms it; that confirm gate is the trust
 boundary and nothing reads `trust_mark` for a decision yet.
+
+`memory groom` retires stale, low-signal confirmed memories as a **propose →
+review → apply** round-trip. `--propose` reads active confirmed memory, computes
+the current vault `snapshot_hash`, runs deterministic detectors
+(status/changelog/ToC snapshots, bare to-do lists, exact duplicates; over-long
+"bricks" are flagged for rewrite, not retired), and writes a reviewable plan
+artifact — it touches nothing in the store. `--yes --plan` recomputes the
+`snapshot_hash`, **aborts as stale** if the store changed since the proposal, then
+retires exactly the planned ids in one transaction (reason `groom:<detector>`). It
+is retire-only and idempotent (already-retired ids are skipped). A ready-to-register
+nightly proposal pipeline lives under
+[`docs/examples/memory-groom-nightly`](https://github.com/jerryfane/gitmoot/tree/main/docs/examples/memory-groom-nightly).
 
 ## Pipelines
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9680,11 +9680,17 @@ use), runs deterministic detectors, and writes a reviewable plan artifact
 
 - **status/changelog/ToC snapshots** — notes dominated (≥80% of non-blank lines) by
   `STATUS:` markers, `SHIPPED`/`merged & deployed` changelog phrases, ISO-date-led
-  lines, or Markdown link-list (`- [ …]`) index entries;
+  lines, or Markdown link-list (`- [ …]`) index entries. Short notes (fewer than 3
+  non-blank lines) additionally require a **strong** marker (`STATUS:`/`… & deployed`),
+  so a single high-value fact that merely leads with a date or mentions `SHIPPED`
+  once is **kept**, not retired;
 - **bare to-do lists** — content whose every non-blank line is a `- [ ]`/`- [x]`
   checkbox;
-- **exact duplicates** — memories sharing identical content; the lowest id is kept
-  and the rest proposed for retirement;
+- **exact duplicates** — memories with identical content **in the same
+  owner/repo/scope**; the lowest id is kept and the rest proposed for retirement. A
+  fact duplicated across owners, repos, or scopes is **not** deduped — each copy is
+  the only one visible in its own retrieval scope (owner/repo/scope is shown on each
+  proposed retirement so you can tell them apart);
 - **over-long "bricks"** (content > ~1200 chars) are **flagged for rewrite**, never
   retired — P4.2 only lists them for the owner (LLM rewriting is the follow-up
   P4.3).

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9661,6 +9661,43 @@ Without `--yes` it prints the plan and writes nothing; with `--yes` it promotes
 > boundary. Trust-aware injection (having the read path weigh `trust_mark`) is
 > future work; nothing reads `trust_mark` for a decision yet.
 
+### Grooming: deterministic propose/apply (#737 P4.2)
+
+`memory groom` mechanizes the periodic curation pass that retires stale,
+low-signal confirmed memories, as an explicit **propose → review → apply**
+round-trip:
+
+```sh
+gitmoot memory groom --propose [--out PLAN.json] [--json]
+gitmoot memory groom --yes --plan PLAN.json [--json]
+```
+
+`--propose` reads every **active** confirmed memory (retired rows excluded),
+computes the current vault `snapshot_hash` (the same anchor `vault export`/`import`
+use), runs deterministic detectors, and writes a reviewable plan artifact
+(`{schema_version, snapshot_hash, proposed_retirements, rewrite_flags, stats}`). It
+**touches nothing** in the store. The detectors are:
+
+- **status/changelog/ToC snapshots** — notes dominated (≥80% of non-blank lines) by
+  `STATUS:` markers, `SHIPPED`/`merged & deployed` changelog phrases, ISO-date-led
+  lines, or Markdown link-list (`- [ …]`) index entries;
+- **bare to-do lists** — content whose every non-blank line is a `- [ ]`/`- [x]`
+  checkbox;
+- **exact duplicates** — memories sharing identical content; the lowest id is kept
+  and the rest proposed for retirement;
+- **over-long "bricks"** (content > ~1200 chars) are **flagged for rewrite**, never
+  retired — P4.2 only lists them for the owner (LLM rewriting is the follow-up
+  P4.3).
+
+`--yes --plan` recomputes the `snapshot_hash` and **aborts as stale** if it differs
+from the plan's (a vault edit between propose and apply invalidates it), then
+retires exactly the planned ids in **one transaction** (reason `groom:<detector>`,
+FTS index cleared in the same tx). It is **retire-only** — no content is edited or
+rewritten — and idempotent: an already-retired or missing id in the plan is skipped
+gracefully rather than aborting the batch. See
+[`docs/examples/memory-groom-nightly`](../../../docs/examples/memory-groom-nightly/README.md)
+for a ready-to-register nightly proposal pipeline.
+
 ## Pipelines
 
 A pipeline (#681) runs a **declared DAG of shell stages** — a fixed, repeatable


### PR DESCRIPTION
Part of #737 (P4.2).

Implements the deterministic memory grooming pass as an explicit, human-gated **propose → review → apply** round-trip, plus a ready-to-register nightly proposal pipeline. Per the P4 three-runtime panel synthesis on #737.

## CLI

```sh
gitmoot memory groom --propose [--out PLAN.json] [--json]
gitmoot memory groom --yes --plan PLAN.json [--json]
```

**`--propose`** reads every **active** confirmed memory (the vault lister path, retired excluded), computes the current vault `snapshot_hash` by reusing the exact `vault export` build path (`buildVault` → `memory.VaultSnapshotHash`), runs deterministic detectors, and writes a reviewable plan artifact `{schema_version, snapshot_hash, proposed_retirements, rewrite_flags, stats}`. It **touches nothing** in the store. Detectors (pure, in `internal/memory/groom.go`):

- **status/changelog/ToC snapshots** — notes dominated (≥80% of non-blank lines) by `STATUS:` markers, `SHIPPED`/`merged & deployed` phrases, ISO-date-led lines, or Markdown link-list index entries;
- **bare to-do lists** — every non-blank line a `- [ ]`/`- [x]` checkbox;
- **exact duplicates** — identical content; lowest id kept, the rest proposed;
- **over-long "bricks"** (> ~1200 chars) are **flagged for rewrite, never retired** — P4.2 only lists them for the owner (LLM rewriting is the follow-up P4.3).

**`--yes --plan`** recomputes the `snapshot_hash` and **aborts as stale** if it differs from the plan's (the gpt-5.5 race catch — a vault edit between propose and apply invalidates the plan), then retires exactly the planned ids in **one transaction** via the new `Store.ApplyGroomRetirements` (reason `groom:<detector>`, FTS index cleared in the same tx). Retire-only, idempotent — already-retired or missing ids are **skipped gracefully** rather than aborting the batch.

## Additive / off-path

A new subcommand + one new store method. **No schema or config changes** (observations + retired columns already exist). Existing behavior is byte-identical when groom is not invoked.

## Nightly pipeline

`docs/examples/memory-groom-nightly/` ships a documented #681 pipeline template (spec + propose script + README): one nightly stage running `groom --propose` with an agentgram notify when proposals are non-empty; the destructive apply stays behind an explicit owner `--yes`. The spec validates against `pipeline.Load`. It is a template only — the lead registers it live post-merge (this PR does not touch the live home).

## Tests

- Detector unit tests over real-shaped fixtures (ToC/changelog/status lines, checkbox lists, bricks, duplicates), precedence, order-independence, and dominance (a substantive note that merely mentions `SHIPPED` once is **not** retired).
- CLI E2E (temp home): propose writes a valid plan + mutates nothing; apply retires exactly the planned ids in one tx and the injectable/vault set no longer contains them; **stale plan aborts** (mutate a memory between propose and apply); **already-retired ids skipped gracefully**; empty-store no-op; ambiguous-flag and bad-plan-file guards.

## Gates

`go build ./...`, `go vet ./internal/...`, `gofmt` clean; `go test -count=1` green on `internal/memory`, `internal/db`, `internal/cli` (full) + scoped `-race` on `internal/cli`; `cd website && npm ci && npm run build` passes (llms-full regenerated). Manually drove init → ingest → confirm → `groom --propose` → `--yes` on the built binary.