### PR TITLE
feat(memory): deterministic distill-at-terminal (#737 P4.1)

### DIFF
--- a/internal/cli/memory_daemon.go
+++ b/internal/cli/memory_daemon.go
@@ -42,14 +42,22 @@ func daemonMemoryController(store *db.Store, home string) *workflow.MemoryContro
 			enrolled[name] = true
 		}
 	}
-	if len(enrolled) == 0 {
+	// With no enrolled agent there is normally nothing to read or write for, so the
+	// controller stays nil (byte-identical). The ONE exception is box-wide distill:
+	// distill_at_terminal + distill_all_jobs stages failure signal for EVERY job,
+	// so it needs a controller even when no agent opted into the read path. Both
+	// keys are off by default, so this widening is inert unless explicitly enabled.
+	if len(enrolled) == 0 && !(settings.DistillAtTerminal && settings.DistillAllJobs) {
 		return nil
 	}
 	return &workflow.MemoryController{
-		Store:       store,
-		Enabled:     func(name string) bool { return enrolled[name] },
-		TokenBudget: settings.TokenBudget,
-		MaxEntries:  settings.MaxEntries,
+		Store:             store,
+		Enabled:           func(name string) bool { return enrolled[name] },
+		TokenBudget:       settings.TokenBudget,
+		MaxEntries:        settings.MaxEntries,
+		DistillAtTerminal: settings.DistillAtTerminal,
+		DistillMaxPerJob:  settings.DistillMaxPerJob,
+		DistillAllJobs:    settings.DistillAllJobs,
 	}
 }
 

--- a/internal/cli/memory_lifecycle_e2e_test.go
+++ b/internal/cli/memory_lifecycle_e2e_test.go
@@ -458,8 +458,8 @@ func TestMemoryDistillAtTerminalE2E(t *testing.T) {
 	// A BLOCKED terminal (settled, dispatch returns cleanly) carrying a failing
 	// test and a panic in the summary. The 0x address differs per job so the
 	// named-error NORMALIZATION is exercised: both must map to the same key.
-	blockedJob1 := `{"gitmoot_result":{"decision":"blocked","summary":"panic: nil pointer dereference at 0xdeadbeef","findings":[],"changes_made":[],"tests_run":["TestPaymentFlow"],"needs":[],"delegations":[]}}`
-	blockedJob2 := `{"gitmoot_result":{"decision":"blocked","summary":"panic: nil pointer dereference at 0xcafef00d","findings":[],"changes_made":[],"tests_run":["TestPaymentFlow"],"needs":[],"delegations":[]}}`
+	blockedJob1 := `{"gitmoot_result":{"decision":"blocked","summary":"panic: nil pointer dereference at 0xdeadbeef\n--- FAIL: TestPaymentFlow (0.01s)","findings":[],"changes_made":[],"tests_run":["TestPaymentFlow"],"needs":[],"delegations":[]}}`
+	blockedJob2 := `{"gitmoot_result":{"decision":"blocked","summary":"panic: nil pointer dereference at 0xcafef00d\n--- FAIL: TestPaymentFlow (0.02s)","findings":[],"changes_made":[],"tests_run":["TestPaymentFlow"],"needs":[],"delegations":[]}}`
 	script := fmt.Sprintf(`case "$1" in
   *SECOND*) printf '%%s' '%s' ;;
   *) printf '%%s' '%s' ;;
@@ -482,24 +482,16 @@ esac`, blockedJob2, blockedJob1)
 	if err != nil {
 		t.Fatalf("ListMemoryObservations after job 1: %v", err)
 	}
-	stagedCount := 0
-	witnessCount := 0
-	for _, o := range obs1 {
-		switch {
-		case strings.HasPrefix(o.Provenance, "distill:"):
-			stagedCount++
-		case strings.HasPrefix(o.Provenance, "distill-seen:"):
-			witnessCount++
-			if o.TrustMark != "low" {
-				t.Fatalf("witness trust = %q, want low", o.TrustMark)
-			}
-		}
+	// The witness is INTERNAL bookkeeping and is excluded from the pending list
+	// surface, so a first sighting shows NOTHING on `memory list`: no staged rows
+	// AND no visible witness rows. A one-off failure never becomes a pending memory.
+	if len(obs1) != 0 {
+		t.Fatalf("first sighting must show nothing on the pending list, got %+v", obs1)
 	}
-	if stagedCount != 0 {
-		t.Fatalf("first sighting must stage nothing, staged=%d: %+v", stagedCount, obs1)
-	}
-	if witnessCount == 0 {
-		t.Fatalf("first sighting must record witnesses, got none: %+v", obs1)
+	// But the witness WAS recorded (recurrence is armed): the keyed count is 1.
+	auditOwner := db.MemoryOwner{Kind: "agent", Ref: "audit"}
+	if n, err := store.CountMemoryObservationsForKey(ctx, auditOwner, "owner/repo", "distill-test:testpaymentflow"); err != nil || n != 1 {
+		t.Fatalf("first sighting must record the failing-test witness, n=%d err=%v", n, err)
 	}
 
 	// --- Job 2: recurrence → observations stage as PENDING low-trust rows.

--- a/internal/cli/memory_lifecycle_e2e_test.go
+++ b/internal/cli/memory_lifecycle_e2e_test.go
@@ -424,6 +424,151 @@ esac`, promptFile, changesResult, memoryLifecyclePlainResult)
 	}
 }
 
+// distillEnrolledConfig enrolls `audit` in memory AND turns on the deterministic
+// distill-at-terminal producers (#737 P4.1). Distill is master-off by default, so
+// this is the explicit opt-in the live daemon reads per tick.
+const distillEnrolledConfig = `
+[memory]
+token_budget = 1500
+max_entries = 15
+distill_at_terminal = true
+
+[agents.audit]
+runtime = "shell"
+memory = true
+`
+
+// TestMemoryDistillAtTerminalE2E is the #737 P4.1 full-chain proof. It drives a
+// job to a BLOCKED terminal (a distill decision) carrying a failing test AND a
+// named error through the REAL daemon worker with distill enabled via config, and
+// pins the OUTPUT DISCIPLINE + RECURRENCE gate at the true terminal seam:
+//
+//   - Job 1 (first sighting): distill records only low-trust WITNESSES — nothing
+//     is STAGED, so a one-off failure never becomes a pending memory.
+//   - Job 2 (recurrence): the failing-test and named-error observations STAGE as
+//     PENDING rows, trust_mark=low, provenance "distill:<job>" — NEVER confirmed.
+//   - The named-error key is normalized (the volatile 0x address stripped), so the
+//     two jobs' differing summaries collapse to the same recurrence key.
+func TestMemoryDistillAtTerminalE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := memoryLifecycleHome(t, distillEnrolledConfig)
+	checkout := t.TempDir()
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	// A BLOCKED terminal (settled, dispatch returns cleanly) carrying a failing
+	// test and a panic in the summary. The 0x address differs per job so the
+	// named-error NORMALIZATION is exercised: both must map to the same key.
+	blockedJob1 := `{"gitmoot_result":{"decision":"blocked","summary":"panic: nil pointer dereference at 0xdeadbeef","findings":[],"changes_made":[],"tests_run":["TestPaymentFlow"],"needs":[],"delegations":[]}}`
+	blockedJob2 := `{"gitmoot_result":{"decision":"blocked","summary":"panic: nil pointer dereference at 0xcafef00d","findings":[],"changes_made":[],"tests_run":["TestPaymentFlow"],"needs":[],"delegations":[]}}`
+	script := fmt.Sprintf(`case "$1" in
+  *SECOND*) printf '%%s' '%s' ;;
+  *) printf '%%s' '%s' ;;
+esac`, blockedJob2, blockedJob1)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, script, []string{"ask"}, "owner/repo")
+	worker := memoryLifecycleWorker(store, home, checkout)
+
+	// --- Job 1: first sighting → witnesses only.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "distill-1", Agent: "audit", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 1, Instructions: "attempt the payment migration",
+	})
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch job 1: %v", err)
+	}
+	if st := memoryLifecycleJobState(t, store, "distill-1"); st != string(workflow.JobBlocked) {
+		t.Fatalf("job 1 state = %q, want blocked", st)
+	}
+	obs1, err := store.ListMemoryObservations(ctx, "audit", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListMemoryObservations after job 1: %v", err)
+	}
+	stagedCount := 0
+	witnessCount := 0
+	for _, o := range obs1 {
+		switch {
+		case strings.HasPrefix(o.Provenance, "distill:"):
+			stagedCount++
+		case strings.HasPrefix(o.Provenance, "distill-seen:"):
+			witnessCount++
+			if o.TrustMark != "low" {
+				t.Fatalf("witness trust = %q, want low", o.TrustMark)
+			}
+		}
+	}
+	if stagedCount != 0 {
+		t.Fatalf("first sighting must stage nothing, staged=%d: %+v", stagedCount, obs1)
+	}
+	if witnessCount == 0 {
+		t.Fatalf("first sighting must record witnesses, got none: %+v", obs1)
+	}
+
+	// --- Job 2: recurrence → observations stage as PENDING low-trust rows.
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "distill-2", Agent: "audit", Action: "ask", Repo: "owner/repo",
+		Branch: "main", PullRequest: 2, Instructions: "attempt the payment migration SECOND",
+	})
+	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
+		t.Fatalf("dispatch job 2: %v", err)
+	}
+	obs2, err := store.ListMemoryObservations(ctx, "audit", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListMemoryObservations after job 2: %v", err)
+	}
+	var stagedKeys []string
+	for _, o := range obs2 {
+		if !strings.HasPrefix(o.Provenance, "distill:") {
+			continue
+		}
+		stagedKeys = append(stagedKeys, o.Key)
+		if o.TrustMark != "low" {
+			t.Fatalf("staged distilled observation trust = %q, want low: %+v", o.TrustMark, o)
+		}
+		if o.SourceJob != "distill-2" {
+			t.Fatalf("staged observation source_job = %q, want distill-2", o.SourceJob)
+		}
+	}
+	if !memContainsStr(stagedKeys, "distill-test:testpaymentflow") {
+		t.Fatalf("failing-test observation did not stage on recurrence; staged keys=%v", stagedKeys)
+	}
+	hasError := false
+	for _, k := range stagedKeys {
+		if strings.HasPrefix(k, "distill-error:") {
+			hasError = true
+			if strings.Contains(k, "deadbeef") || strings.Contains(k, "cafef00d") {
+				t.Fatalf("named-error key retained a volatile address: %q", k)
+			}
+		}
+	}
+	if !hasError {
+		t.Fatalf("named-error observation did not stage on recurrence; staged keys=%v", stagedKeys)
+	}
+
+	// --- OUTPUT DISCIPLINE: distill NEVER writes confirmed memory.
+	confirmed, err := store.ListConfirmedMemories(ctx, "audit", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListConfirmedMemories: %v", err)
+	}
+	for _, c := range confirmed {
+		if strings.HasPrefix(c.Provenance, "distill") {
+			t.Fatalf("distill leaked into the confirmed tier: %+v", c)
+		}
+	}
+	// `gitmoot memory list --pending` surfaces the staged rows.
+	pending := memoryListJSON(t, home, "--pending")
+	if len(pending) == 0 {
+		t.Fatalf("memory list --pending should surface the distilled observations")
+	}
+}
+
+func memContainsStr(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
 // memoryListJSON runs the REAL `gitmoot memory list` CLI (through Run, the top-
 // level dispatcher) with the given tier flag and decodes its JSON.
 func memoryListJSON(t *testing.T, home, tierFlag string) []memoryListEntry {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -113,13 +113,23 @@ path = ""
 # true overrides every per-agent memory=true, turning the whole feature off box-wide
 # without editing each agent block. token_budget caps the injected block's estimated
 # tokens (default 1500); max_entries caps how many confirmed rows are considered for
-# injection (default 15); both must be >= 0. Inspect the store read-only with
-# gitmoot memory list; see the "Agent Persistent Memory" concepts page and CLI.md
-# for the full model.
+# injection (default 15); both must be >= 0. distill_at_terminal (default false) is
+# the master switch for #737 P4.1 deterministic distill-at-terminal: on an anomalous
+# terminal (failed/blocked/changes_requested) Gitmoot stages bounded PENDING
+# observations (failing tests + named errors) at trust_mark=low, provenance
+# distill:<job-id> — NEVER confirmed memory (the memory confirm gate stays the only
+# promotion path). distill_max_per_job (default 3, >= 0) caps distilled rows per job;
+# distill_all_jobs (default false) widens distill past enrolled agents to every job.
+# All [memory] keys are read PER TICK — no daemon restart is needed to flip them.
+# Inspect the store read-only with gitmoot memory list; see the "Agent Persistent
+# Memory" concepts page and CLI.md for the full model.
 # [memory]
 # disabled = false
 # token_budget = 1500
 # max_entries = 15
+# distill_at_terminal = false
+# distill_max_per_job = 3
+# distill_all_jobs = false
 #
 # Enroll a specific agent (per-agent opt-in; omit for byte-identical default):
 # [agents.builder]

--- a/internal/config/memory.go
+++ b/internal/config/memory.go
@@ -13,6 +13,10 @@ import (
 const (
 	DefaultMemoryTokenBudget = 1500
 	DefaultMemoryMaxEntries  = 15
+	// DefaultMemoryDistillMaxPerJob caps how many pending observations the
+	// deterministic distill-at-terminal producers (#737 P4.1) may stage per job.
+	// It is only consulted when distill_at_terminal is enabled.
+	DefaultMemoryDistillMaxPerJob = 3
 )
 
 // MemorySettings is the resolved, off-by-default global knob set for agent
@@ -33,14 +37,35 @@ type MemorySettings struct {
 	TokenBudget int
 	// MaxEntries caps how many confirmed memories are considered for injection.
 	MaxEntries int
+	// DistillAtTerminal is the master switch for the deterministic
+	// distill-at-terminal WRITE producers (#737 P4.1). Default false: with it off
+	// the terminal path is byte-identical (no observation rows staged from job
+	// outcomes). When true, at each terminal Gitmoot stages a bounded number of
+	// PENDING observations (trust_mark=low, provenance "distill:<job-id>") derived
+	// deterministically from the result — never confirmed memory (the owner's
+	// `memory confirm` gate stays the only promotion path).
+	DistillAtTerminal bool
+	// DistillMaxPerJob is the hard per-job cap on distill writes (default 3). Only
+	// consulted when DistillAtTerminal is true; a value <= 0 falls back to the
+	// default so the producers can never write an unbounded number of rows.
+	DistillMaxPerJob int
+	// DistillAllJobs widens distill to EVERY job, not only memory-enrolled agents.
+	// Default false: distill (like the rest of memory) runs only for agents with
+	// [agents.<name>].memory = true. When true it also runs for un-enrolled agents
+	// — useful to harvest failure signal box-wide — while the READ/injection and
+	// the confirmed mechanical producers stay enrolled-only.
+	DistillAllJobs bool
 }
 
 // DefaultMemorySettings returns the off-by-default resolved settings.
 func DefaultMemorySettings() MemorySettings {
 	return MemorySettings{
-		Disabled:    false,
-		TokenBudget: DefaultMemoryTokenBudget,
-		MaxEntries:  DefaultMemoryMaxEntries,
+		Disabled:          false,
+		TokenBudget:       DefaultMemoryTokenBudget,
+		MaxEntries:        DefaultMemoryMaxEntries,
+		DistillAtTerminal: false,
+		DistillMaxPerJob:  DefaultMemoryDistillMaxPerJob,
+		DistillAllJobs:    false,
 	}
 }
 
@@ -94,6 +119,24 @@ func LoadMemorySettings(paths Paths) (MemorySettings, error) {
 				return MemorySettings{}, fmt.Errorf("parse [memory].max_entries: %w", err)
 			}
 			settings.MaxEntries = parsed
+		case "distill_at_terminal":
+			parsed, err := parseConfigBool(value)
+			if err != nil {
+				return MemorySettings{}, fmt.Errorf("parse [memory].distill_at_terminal: %w", err)
+			}
+			settings.DistillAtTerminal = parsed
+		case "distill_max_per_job":
+			parsed, err := strconv.Atoi(value)
+			if err != nil {
+				return MemorySettings{}, fmt.Errorf("parse [memory].distill_max_per_job: %w", err)
+			}
+			settings.DistillMaxPerJob = parsed
+		case "distill_all_jobs":
+			parsed, err := parseConfigBool(value)
+			if err != nil {
+				return MemorySettings{}, fmt.Errorf("parse [memory].distill_all_jobs: %w", err)
+			}
+			settings.DistillAllJobs = parsed
 		}
 	}
 	if err := validateMemorySettings(settings); err != nil {
@@ -108,6 +151,9 @@ func validateMemorySettings(s MemorySettings) error {
 	}
 	if s.MaxEntries < 0 {
 		return fmt.Errorf("memory.max_entries must be >= 0, got %d", s.MaxEntries)
+	}
+	if s.DistillMaxPerJob < 0 {
+		return fmt.Errorf("memory.distill_max_per_job must be >= 0, got %d", s.DistillMaxPerJob)
 	}
 	return nil
 }

--- a/internal/config/memory_test.go
+++ b/internal/config/memory_test.go
@@ -22,6 +22,51 @@ func TestLoadMemorySettingsDefaults(t *testing.T) {
 	if settings.TokenBudget != DefaultMemoryTokenBudget || settings.MaxEntries != DefaultMemoryMaxEntries {
 		t.Fatalf("defaults = %+v", settings)
 	}
+	// Distill is off by default with a bounded per-job cap.
+	if settings.DistillAtTerminal || settings.DistillAllJobs {
+		t.Fatalf("distill must be off by default, got %+v", settings)
+	}
+	if settings.DistillMaxPerJob != DefaultMemoryDistillMaxPerJob {
+		t.Fatalf("distill_max_per_job default = %d, want %d", settings.DistillMaxPerJob, DefaultMemoryDistillMaxPerJob)
+	}
+}
+
+func TestLoadMemorySettingsParsesDistillKnobs(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[memory]
+distill_at_terminal = true
+distill_max_per_job = 5
+distill_all_jobs = true
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	settings, err := LoadMemorySettings(paths)
+	if err != nil {
+		t.Fatalf("LoadMemorySettings: %v", err)
+	}
+	if !settings.DistillAtTerminal || !settings.DistillAllJobs || settings.DistillMaxPerJob != 5 {
+		t.Fatalf("parsed distill knobs = %+v", settings)
+	}
+}
+
+func TestLoadMemorySettingsRejectsNegativeDistillCap(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
+[memory]
+distill_max_per_job = -1
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadMemorySettings(paths); err == nil {
+		t.Fatalf("expected negative distill_max_per_job to be rejected")
+	}
 }
 
 func TestLoadMemorySettingsParsesKnobs(t *testing.T) {

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -660,11 +660,24 @@ FROM confirmed_memories`
 	return scanConfirmedMemories(rows)
 }
 
+// MemoryDistillWitnessProvenancePrefix marks a recurrence-WITNESS observation row
+// written by distill-at-terminal (#737 P4.1). Witness rows are internal recurrence
+// bookkeeping — NOT human-reviewable observations — so the pending list surface
+// (ListMemoryObservations / ListMemoryObservationsWithConfirmation) and the confirm
+// getter (GetMemoryObservationByID) exclude this provenance. A one-off failure's
+// sentinel witness is therefore never shown in `memory list` and can never be
+// promoted by `memory confirm`. The prefix is carried unchanged into
+// memory_observations, so this is a read-time filter with no schema change. The
+// exclusion is a no-op when distill is off (no witness rows exist).
+const MemoryDistillWitnessProvenancePrefix = "distill-seen:"
+
 // ListMemoryObservations returns pending observation rows for the audit CLI,
-// filtered optionally by owner ref and repo.
+// filtered optionally by owner ref and repo. Recurrence witnesses (see
+// MemoryDistillWitnessProvenancePrefix) are always excluded — they are internal
+// bookkeeping, never a human-reviewable pending observation.
 func (s *Store) ListMemoryObservations(ctx context.Context, ownerRef, repo string) ([]MemoryObservation, error) {
-	var where []string
-	var args []any
+	where := []string{"provenance NOT LIKE ? ESCAPE '\\'"}
+	args := []any{likePrefix(MemoryDistillWitnessProvenancePrefix)}
 	if strings.TrimSpace(ownerRef) != "" {
 		where = append(where, "owner_ref = ?")
 		args = append(args, ownerRef)
@@ -735,8 +748,11 @@ type ObservationWithConfirmation struct {
 // used by the audit surface; it mutates nothing. A blank ownerRef matches all
 // owners and a blank provenancePrefix matches all provenances.
 func (s *Store) ListMemoryObservationsWithConfirmation(ctx context.Context, ownerRef, provenancePrefix string) ([]ObservationWithConfirmation, error) {
-	var where []string
-	var args []any
+	// Recurrence witnesses are never human-reviewable, so they are excluded even
+	// when the caller passes a provenancePrefix — `--prefix distill-seen:` must
+	// select nothing rather than expose the sentinel witnesses for confirmation.
+	where := []string{"o.provenance NOT LIKE ? ESCAPE '\\'"}
+	args := []any{likePrefix(MemoryDistillWitnessProvenancePrefix)}
 	if strings.TrimSpace(ownerRef) != "" {
 		where = append(where, "o.owner_ref = ?")
 		args = append(args, ownerRef)
@@ -786,10 +802,14 @@ FROM memory_observations o`
 func (s *Store) GetMemoryObservationByID(ctx context.Context, id int64) (MemoryObservation, bool, error) {
 	var o MemoryObservation
 	var repoNull sql.NullString
+	// A recurrence witness is not a confirmable observation: exclude it here so
+	// `memory confirm <witness-id>` resolves to "no observation with id N" rather
+	// than promoting the fixed sentinel string into confirmed memory.
 	err := s.db.QueryRowContext(ctx, `
 SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
 	provenance, trust_mark, source_job, created_at
-FROM memory_observations WHERE id = ?`, id).Scan(
+FROM memory_observations WHERE id = ? AND provenance NOT LIKE ? ESCAPE '\'`,
+		id, likePrefix(MemoryDistillWitnessProvenancePrefix)).Scan(
 		&o.ID, &o.Owner.Kind, &o.Owner.Ref, &o.Owner.Version, &repoNull,
 		&o.Scope, &o.Key, &o.Content, &o.Provenance, &o.TrustMark, &o.SourceJob, &o.CreatedAt)
 	if err == sql.ErrNoRows {

--- a/internal/db/memory_store_test.go
+++ b/internal/db/memory_store_test.go
@@ -620,3 +620,72 @@ func TestListMemoryObservationsWithConfirmationFlagsConfirmedKeys(t *testing.T) 
 		t.Fatalf("literal %%-prefix should match no rows, got %d", len(none))
 	}
 }
+
+// TestDistillWitnessExcludedFromListAndConfirm proves the #737 P4.1 recurrence
+// witness is INTERNAL bookkeeping: a distill-seen: row is invisible on every
+// human-reviewable surface (ListMemoryObservations, ListMemoryObservationsWithConfirmation)
+// and is un-fetchable by GetMemoryObservationByID, so it can never be shown by
+// `memory list` nor promoted to confirmed memory by `memory confirm`. A genuine
+// staged distill: row alongside it stays fully visible/confirmable.
+func TestDistillWitnessExcludedFromListAndConfirm(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("audit")
+
+	witnessID, err := store.InsertMemoryObservation(ctx, MemoryObservation{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "distill-test:testx",
+		Content: "A failure signal was observed once in this repository and is held pending recurrence before it is recorded.",
+		Provenance: MemoryDistillWitnessProvenancePrefix + "job-1", TrustMark: "low",
+	})
+	if err != nil {
+		t.Fatalf("insert witness: %v", err)
+	}
+	stagedID, err := store.InsertMemoryObservation(ctx, MemoryObservation{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "distill-test:testy",
+		Content: "Test testy FAILED in a implement job in this repository.",
+		Provenance: "distill:job-2", TrustMark: "low",
+	})
+	if err != nil {
+		t.Fatalf("insert staged: %v", err)
+	}
+
+	// ListMemoryObservations: only the staged row is visible.
+	pending, err := store.ListMemoryObservations(ctx, "audit", "acme/widget")
+	if err != nil {
+		t.Fatalf("list observations: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != stagedID {
+		t.Fatalf("pending list should show only the staged row, got %+v", pending)
+	}
+
+	// ListMemoryObservationsWithConfirmation: witness hidden even with no prefix.
+	rows, err := store.ListMemoryObservationsWithConfirmation(ctx, "audit", "")
+	if err != nil {
+		t.Fatalf("list w/ confirmation: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != stagedID {
+		t.Fatalf("confirm surface should show only the staged row, got %+v", rows)
+	}
+
+	// A caller cannot target witnesses by their own provenance prefix.
+	byPrefix, err := store.ListMemoryObservationsWithConfirmation(ctx, "audit", MemoryDistillWitnessProvenancePrefix)
+	if err != nil {
+		t.Fatalf("list by witness prefix: %v", err)
+	}
+	if len(byPrefix) != 0 {
+		t.Fatalf("--prefix distill-seen: must select nothing, got %+v", byPrefix)
+	}
+
+	// GetMemoryObservationByID: a witness id resolves to (not found); a staged id resolves.
+	if _, ok, err := store.GetMemoryObservationByID(ctx, witnessID); err != nil || ok {
+		t.Fatalf("witness id must be un-confirmable (not found), ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := store.GetMemoryObservationByID(ctx, stagedID); err != nil || !ok {
+		t.Fatalf("staged id must remain confirmable, ok=%v err=%v", ok, err)
+	}
+
+	// The witness DID persist (recurrence counting still sees it).
+	if n, err := store.CountMemoryObservationsForKey(ctx, owner, "acme/widget", "distill-test:testx"); err != nil || n != 1 {
+		t.Fatalf("witness must persist for recurrence counting, n=%d err=%v", n, err)
+	}
+}

--- a/internal/workflow/memory.go
+++ b/internal/workflow/memory.go
@@ -42,6 +42,16 @@ type MemoryController struct {
 	TokenBudget int
 	// MaxEntries caps how many confirmed rows are considered for injection.
 	MaxEntries int
+	// DistillAtTerminal enables the deterministic distill-at-terminal WRITE
+	// producers (#737 P4.1). Default false: with it off, record() runs exactly the
+	// Phase-1 write path and the terminal is byte-identical (no distilled rows).
+	DistillAtTerminal bool
+	// DistillMaxPerJob is the hard per-job cap on distill writes; <= 0 falls back
+	// to config.DefaultMemoryDistillMaxPerJob so the producers are always bounded.
+	DistillMaxPerJob int
+	// DistillAllJobs widens distill past the memory-enrolled set to every job. When
+	// false (default) distill runs only for enrolled agents, via enabledFor.
+	DistillAllJobs bool
 }
 
 // enabledFor reports whether memory is active for the given executor agent.
@@ -50,6 +60,22 @@ func (c *MemoryController) enabledFor(agentName string) bool {
 		return false
 	}
 	return c.Enabled(agentName)
+}
+
+// distillEnabledFor reports whether the deterministic distill-at-terminal WRITE
+// producers (#737 P4.1) are active for the given executor agent. It is a SEPARATE
+// gate from enabledFor: distill runs only when the master switch DistillAtTerminal
+// is set, and — unlike the read path and the confirmed mechanical producers — it
+// can run for UN-enrolled agents when DistillAllJobs is set (box-wide failure
+// harvesting). When DistillAllJobs is false it falls back to the enrolled set.
+func (c *MemoryController) distillEnabledFor(agentName string) bool {
+	if c == nil || c.Store == nil || !c.DistillAtTerminal {
+		return false
+	}
+	if c.DistillAllJobs {
+		return true
+	}
+	return c.enabledFor(agentName)
 }
 
 // ownerForJob derives the structured memory owner for a job's executor. Phase 1
@@ -131,17 +157,35 @@ func (c *MemoryController) PreviewBlock(ctx context.Context, agentName, repo, in
 	return rendered, n, memory.EstimateTokens(rendered)
 }
 
-// record is the Phase-1 WRITE path, run at job terminal. It (a) SHADOW-logs the
-// agent's returned learnings to memory_observations after the deterministic
-// pre-filters, and (b) writes any gitmoot-authored mechanical facts to
-// confirmed_memories (the ONLY Phase-1 confirmed producers — deterministic, no
-// LLM). It takes the job action so the mechanical producers can key facts by
+// record is the WRITE path, run at job terminal. The ENROLLED-ONLY Phase-1 body
+// (recordEnrolled) (a) SHADOW-logs the agent's returned learnings to
+// memory_observations after the deterministic pre-filters, and (b) writes any
+// gitmoot-authored mechanical facts to confirmed_memories (the ONLY confirmed
+// producers — deterministic, no LLM). On top of that, (c) the #737 P4.1
+// distill-at-terminal producer stages deterministic PENDING observations behind
+// its own config gate. It takes the job action so the producers can key facts by
 // (action, outcome). Every write is best-effort: a failure is swallowed so
 // memory can never fail an otherwise-successful job.
 func (c *MemoryController) record(ctx context.Context, jobID string, agent runtime.Agent, action string, payload JobPayload, result AgentResult) {
-	if !c.enabledFor(agent.Name) {
-		return
+	// The Phase-1 write path (learnings shadow-log + confirmed mechanical facts)
+	// is ENROLLED-ONLY and unchanged. When the agent is not enrolled this whole
+	// block is skipped exactly as the prior early-return did, so with distill off
+	// (the default) the terminal path is byte-identical.
+	if c.enabledFor(agent.Name) {
+		c.recordEnrolled(ctx, jobID, agent, action, payload, result)
 	}
+	// (c) #737 P4.1 distill-at-terminal — a SEPARATE, config-gated producer that
+	// stages PENDING observations only. It has its own gate (distillEnabledFor),
+	// so it is a no-op unless DistillAtTerminal is set, and it can run for
+	// un-enrolled agents when DistillAllJobs is set. Fail-safe: any error inside is
+	// swallowed and can never affect the job outcome.
+	c.distillAtTerminal(ctx, jobID, agent, action, payload, result)
+}
+
+// recordEnrolled is the Phase-1 ENROLLED-ONLY write path: shadow-log the agent's
+// returned learnings and write gitmoot-authored mechanical confirmed facts. It is
+// exactly the body record() ran before #737 P4.1 split out the distill producer.
+func (c *MemoryController) recordEnrolled(ctx context.Context, jobID string, agent runtime.Agent, action string, payload JobPayload, result AgentResult) {
 	owner := ownerForJob(agent, payload)
 
 	// (a) Shadow-log agent-returned learnings — observations ONLY, with the

--- a/internal/workflow/memory_distill.go
+++ b/internal/workflow/memory_distill.go
@@ -15,8 +15,10 @@ import (
 // This file implements #737 P4.1: deterministic DISTILL-AT-TERMINAL. It is a
 // config-gated WRITE producer, separate from the Phase-1 enrolled write path,
 // that mines a terminal job's OWN result for two closed-category signals —
-// FAILING TESTS (from result.TestsRun) and NAMED ERRORS (from result.Summary and
-// the tail of payload.RawOutputs) — and stages them as PENDING observations.
+// FAILING TESTS (test names from explicit `--- FAIL:` markers in result.Summary /
+// the tail of payload.RawOutputs, NOT mere presence in result.TestsRun, which only
+// records that a test was RUN) and NAMED ERRORS (from the same sources) — and
+// stages them as PENDING observations.
 //
 // OUTPUT DISCIPLINE (differs from the confirmed mechanical producers): distill
 // NEVER writes confirmed_memories. It only ever InsertMemoryObservation()s rows
@@ -40,9 +42,13 @@ import (
 
 const (
 	// distillWitnessProvenancePrefix marks the first-sighting recurrence witness.
-	// It is DISTINCT from the staged provenance so a confirm/list surface can tell
-	// a bookkeeping sentinel apart from a real distilled candidate.
-	distillWitnessProvenancePrefix = "distill-seen:"
+	// It is DISTINCT from the staged provenance so the list/confirm surface can tell
+	// a bookkeeping sentinel apart from a real distilled candidate: the pending-list
+	// reads and the confirm getter (db.ListMemoryObservations,
+	// ListMemoryObservationsWithConfirmation, GetMemoryObservationByID) EXCLUDE this
+	// provenance, so a witness is never shown in `memory list` nor confirmable. The
+	// canonical value lives in the db package (the layer that filters on it).
+	distillWitnessProvenancePrefix = db.MemoryDistillWitnessProvenancePrefix
 	// distillStagedProvenancePrefix marks a genuinely staged distilled observation.
 	distillStagedProvenancePrefix = "distill:"
 	// distillWitnessSentinel is the FIXED, PreFilter-safe content stored on a
@@ -179,7 +185,7 @@ func distillCandidates(action string, payload JobPayload, result AgentResult) []
 		seenKey[o.Key] = struct{}{}
 		out = append(out, o)
 	}
-	for _, o := range failingTestCandidates(action, result) {
+	for _, o := range failingTestCandidates(action, payload, result) {
 		add(o)
 	}
 	for _, o := range namedErrorCandidates(payload, result) {
@@ -188,33 +194,48 @@ func distillCandidates(action string, payload JobPayload, result AgentResult) []
 	return out
 }
 
-// failingTestCandidates derives one closed-category candidate per test named in
-// result.TestsRun. On a distill terminal (failed/blocked/changes_requested) those
-// are the tests the failing job exercised; the normalized test name is the key,
-// and the content is a stable reference sentence (NO volatile per-job text, so
-// dedup is deterministic).
-func failingTestCandidates(action string, result AgentResult) []distillObs {
+// failingTestCandidates derives one closed-category candidate per test that
+// ACTUALLY FAILED. The result contract's tests_run means "tests/commands the job
+// RAN", not "tests that failed" — an anomalous terminal (very commonly the routine
+// review outcome changes_requested) frequently carries a fully-passing tests_run —
+// so mere presence in tests_run is NOT failure evidence. Instead this mines the
+// explicit `--- FAIL: <name>` markers the test harness emits in the job output
+// (result.Summary and the tail of the last raw output). A passing suite emits no
+// such marker and therefore stages no test candidate. The failed test name is the
+// key; content is a stable reference sentence (NO volatile per-job text, so dedup
+// is deterministic).
+func failingTestCandidates(action string, payload JobPayload, result AgentResult) []distillObs {
 	act := memoryActionToken(action)
-	out := make([]distillObs, 0, len(result.TestsRun))
-	for _, raw := range result.TestsRun {
-		norm := normalizeTestName(raw)
-		if norm == "" {
-			continue
+	out := make([]distillObs, 0, 4)
+	seen := make(map[string]struct{})
+	scanned := 0
+	for _, src := range distillScanSources(payload, result) {
+		for _, m := range distillFailedTestRe.FindAllStringSubmatch(src, -1) {
+			if scanned >= distillMaxScanLines {
+				return out
+			}
+			scanned++
+			norm := normalizeTestName(m[1])
+			if norm == "" {
+				continue
+			}
+			if _, dup := seen[norm]; dup {
+				continue
+			}
+			seen[norm] = struct{}{}
+			out = append(out, distillObs{
+				Key:     "distill-test:" + norm,
+				Content: fmt.Sprintf("Test %s FAILED in a %s job in this repository.", norm, act),
+			})
 		}
-		out = append(out, distillObs{
-			Key:     "distill-test:" + norm,
-			Content: fmt.Sprintf("Test %s was exercised in a %s job that did not complete cleanly in this repository.", norm, act),
-		})
 	}
 	return out
 }
 
-// namedErrorCandidates extracts stable error tokens from result.Summary and the
-// tail of the last raw output. Each error line is normalized to a closed-category
-// signature (lowercased, with hashes/paths/addresses/line-numbers/timestamps
-// stripped) so distinct incidental values collapse to one key. Content is the
-// cleaned line itself (stable), prefixed with a neutral reference frame.
-func namedErrorCandidates(payload JobPayload, result AgentResult) []distillObs {
+// distillScanSources returns the bounded text sources both deterministic producers
+// mine: the result summary plus the tail of the last raw output (capped at
+// distillRawOutputTailBytes so a huge transcript can never balloon the scan).
+func distillScanSources(payload JobPayload, result AgentResult) []string {
 	sources := []string{result.Summary}
 	if n := len(payload.RawOutputs); n > 0 {
 		tail := payload.RawOutputs[n-1]
@@ -223,19 +244,37 @@ func namedErrorCandidates(payload JobPayload, result AgentResult) []distillObs {
 		}
 		sources = append(sources, tail)
 	}
+	return sources
+}
+
+// distillFailedTestRe matches the per-test failure marker a Go-style test harness
+// emits ("    --- FAIL: TestName (0.00s)"), capturing the test identifier. It is
+// the authoritative per-test FAILURE signal — distinct from mere presence in
+// tests_run, which only records that a test was RUN.
+var distillFailedTestRe = regexp.MustCompile(`(?m)^\s*--- FAIL:\s+(\S+)`)
+
+// namedErrorCandidates extracts stable error tokens from result.Summary and the
+// tail of the last raw output. Each error line is normalized to a closed-category
+// signature (lowercased, with hashes/paths/addresses/line-numbers/timestamps
+// stripped) so distinct incidental values collapse to one key. Content is the
+// cleaned line itself (stable), prefixed with a neutral reference frame.
+func namedErrorCandidates(payload JobPayload, result AgentResult) []distillObs {
 	out := make([]distillObs, 0, 4)
 	scanned := 0
-	for _, src := range sources {
+	for _, src := range distillScanSources(payload, result) {
 		for _, line := range strings.Split(src, "\n") {
 			if scanned >= distillMaxScanLines {
 				return out
 			}
 			scanned++
 			line = strings.TrimSpace(line)
-			// Skip blanks, over-long lines, and the structured result envelope
-			// (raw outputs carry the gitmoot_result JSON) so distill mines genuine
+			// Skip blanks, over-long lines, the structured result envelope (raw
+			// outputs carry the gitmoot_result JSON), and per-test `--- FAIL:`
+			// markers (claimed by failingTestCandidates, so the same line is never
+			// double-mined as a generic named error) so distill mines genuine
 			// human-readable error lines, never a minified JSON brick.
-			if line == "" || len(line) > distillMaxErrorLineLen || strings.Contains(line, "gitmoot_result") {
+			if line == "" || len(line) > distillMaxErrorLineLen ||
+				strings.Contains(line, "gitmoot_result") || strings.Contains(line, "--- FAIL:") {
 				continue
 			}
 			if !errorLineRe.MatchString(line) {

--- a/internal/workflow/memory_distill.go
+++ b/internal/workflow/memory_distill.go
@@ -1,0 +1,340 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// This file implements #737 P4.1: deterministic DISTILL-AT-TERMINAL. It is a
+// config-gated WRITE producer, separate from the Phase-1 enrolled write path,
+// that mines a terminal job's OWN result for two closed-category signals —
+// FAILING TESTS (from result.TestsRun) and NAMED ERRORS (from result.Summary and
+// the tail of payload.RawOutputs) — and stages them as PENDING observations.
+//
+// OUTPUT DISCIPLINE (differs from the confirmed mechanical producers): distill
+// NEVER writes confirmed_memories. It only ever InsertMemoryObservation()s rows
+// with TrustMark=low and Provenance "distill:<job-id>", so the owner's
+// `memory confirm` gate stays the ONLY promotion path. Every candidate passes
+// memory.PreFilter, is content-hash-deduped against existing rows, and the whole
+// producer is bounded by a hard per-job cap.
+//
+// RECURRENCE (gpt-5.5's catch): a one-off anomalous failure must NOT stage — a
+// single flaky failure should not become a durable pending memory. The FIRST time
+// a normalized key is seen, distill records only a low-trust WITNESS sentinel
+// (provenance "distill-seen:<job-id>"); the actual staged observation is written
+// only on the SECOND (recurring) sighting across jobs. Because distill owns its
+// key namespace ("distill-test:" / "distill-error:"), CountMemoryObservationsForKey
+// is an exact recurrence counter with no schema change. Per distinct key at most
+// ONE witness + ONE staged row can ever exist (dedup collapses further repeats),
+// so the pending queue a human reviews is never flooded by one-offs.
+//
+// FAIL-SAFE: every store call here is best-effort. Any error (or a nil field)
+// returns early; the job outcome is never affected.
+
+const (
+	// distillWitnessProvenancePrefix marks the first-sighting recurrence witness.
+	// It is DISTINCT from the staged provenance so a confirm/list surface can tell
+	// a bookkeeping sentinel apart from a real distilled candidate.
+	distillWitnessProvenancePrefix = "distill-seen:"
+	// distillStagedProvenancePrefix marks a genuinely staged distilled observation.
+	distillStagedProvenancePrefix = "distill:"
+	// distillWitnessSentinel is the FIXED, PreFilter-safe content stored on a
+	// recurrence witness. It is deliberately constant (never a candidate's content)
+	// so it can never false-collide with a real staged content in the dedup path.
+	distillWitnessSentinel = "A failure signal was observed once in this repository and is held pending recurrence before it is recorded."
+	// distillRawOutputTailBytes bounds how much of the last raw output distill
+	// scans for error lines, so a huge transcript can never balloon the scan.
+	distillRawOutputTailBytes = 4000
+	// distillMaxScanLines bounds how many lines distill inspects for error tokens
+	// before the per-job cap even applies.
+	distillMaxScanLines = 200
+	// distillMaxErrorLineLen skips over-long lines: a genuine named-error line is
+	// short, whereas a minified result envelope or a giant log line is not — so the
+	// length guard keeps the structured gitmoot_result JSON (and other noise) out.
+	distillMaxErrorLineLen = 300
+	// distillContentMaxLen caps the length of a distilled observation's content.
+	distillContentMaxLen = 220
+)
+
+// distillDecisions is the CLOSED set of terminal decisions that trigger distill:
+// the anomalous/notable outcomes worth mining for failure signal. Routine
+// successes (approved, implemented) are absent — a first-try success carries no
+// signal, matching the anti-flood restraint of the confirmed producers.
+var distillDecisions = map[string]bool{
+	"failed":            true,
+	"blocked":           true,
+	"changes_requested": true,
+}
+
+// distillObs is one deterministic distill candidate: a bounded closed-category
+// key plus stable, reference-phrased content. Content is STABLE per key (it never
+// embeds volatile per-job text) so the content-hash dedup path collapses repeats
+// deterministically.
+type distillObs struct {
+	Key     string
+	Content string
+}
+
+// distillAtTerminal is the #737 P4.1 producer entry point invoked from record().
+// It is a no-op unless the master switch is on for this agent (distillEnabledFor),
+// so with the feature off the terminal path is byte-identical. It stages at most
+// DistillMaxPerJob observations (witness or real), each low-trust and pending.
+func (c *MemoryController) distillAtTerminal(ctx context.Context, jobID string, agent runtime.Agent, action string, payload JobPayload, result AgentResult) {
+	if !c.distillEnabledFor(agent.Name) {
+		return
+	}
+	decision := strings.TrimSpace(result.Decision)
+	if !distillDecisions[decision] {
+		return
+	}
+	candidates := distillCandidates(action, payload, result)
+	if len(candidates) == 0 {
+		return
+	}
+
+	perJobCap := c.DistillMaxPerJob
+	if perJobCap <= 0 {
+		perJobCap = config.DefaultMemoryDistillMaxPerJob
+	}
+
+	owner := ownerForJob(agent, payload)
+	repo := payload.Repo
+
+	// Existing content-hash dedup domain (pending + confirmed) for this owner. A
+	// load failure is fail-safe: skip distill entirely rather than risk a duplicate.
+	seen, err := c.Store.ObservationDedupKeys(ctx, owner.Ref)
+	if err != nil {
+		return
+	}
+
+	written := 0
+	for _, cand := range candidates {
+		if written >= perJobCap {
+			return
+		}
+		// PreFilter is the primary write gate — a directive/secret/executable-shaped
+		// error line is dropped before it can be witnessed OR staged.
+		if ok, _ := memory.PreFilter(cand.Content, memory.ScopeRepo); !ok {
+			continue
+		}
+		// Recurrence: count prior distill rows (witness + staged) for this key.
+		prior, err := c.Store.CountMemoryObservationsForKey(ctx, owner, repo, cand.Key)
+		if err != nil {
+			continue
+		}
+		if prior == 0 {
+			// First sighting: record a low-trust WITNESS only — do not stage yet.
+			_, _ = c.Store.InsertMemoryObservation(ctx, db.MemoryObservation{
+				Owner:      owner,
+				Repo:       repo,
+				Scope:      memory.ScopeRepo,
+				Key:        cand.Key,
+				Content:    distillWitnessSentinel,
+				Provenance: distillWitnessProvenancePrefix + jobID,
+				TrustMark:  memory.TrustLow,
+				SourceJob:  jobID,
+			})
+			written++
+			continue
+		}
+		// Recurrence met: content-hash dedup so a repeat never stages twice.
+		dkey := db.MemoryDedupKey(memory.ScopeRepo, repo, memory.ContentHash(cand.Content))
+		if _, dup := seen[dkey]; dup {
+			continue
+		}
+		seen[dkey] = struct{}{}
+		_, _ = c.Store.InsertMemoryObservation(ctx, db.MemoryObservation{
+			Owner:      owner,
+			Repo:       repo,
+			Scope:      memory.ScopeRepo,
+			Key:        cand.Key,
+			Content:    cand.Content,
+			Provenance: distillStagedProvenancePrefix + jobID,
+			TrustMark:  memory.TrustLow,
+			SourceJob:  jobID,
+		})
+		written++
+	}
+}
+
+// distillCandidates assembles the deterministic candidate set for a terminal job,
+// deduped by key and in a stable order: failing tests first, then named errors.
+func distillCandidates(action string, payload JobPayload, result AgentResult) []distillObs {
+	out := make([]distillObs, 0, 4)
+	seenKey := make(map[string]struct{})
+	add := func(o distillObs) {
+		if o.Key == "" || strings.TrimSpace(o.Content) == "" {
+			return
+		}
+		if _, dup := seenKey[o.Key]; dup {
+			return
+		}
+		seenKey[o.Key] = struct{}{}
+		out = append(out, o)
+	}
+	for _, o := range failingTestCandidates(action, result) {
+		add(o)
+	}
+	for _, o := range namedErrorCandidates(payload, result) {
+		add(o)
+	}
+	return out
+}
+
+// failingTestCandidates derives one closed-category candidate per test named in
+// result.TestsRun. On a distill terminal (failed/blocked/changes_requested) those
+// are the tests the failing job exercised; the normalized test name is the key,
+// and the content is a stable reference sentence (NO volatile per-job text, so
+// dedup is deterministic).
+func failingTestCandidates(action string, result AgentResult) []distillObs {
+	act := memoryActionToken(action)
+	out := make([]distillObs, 0, len(result.TestsRun))
+	for _, raw := range result.TestsRun {
+		norm := normalizeTestName(raw)
+		if norm == "" {
+			continue
+		}
+		out = append(out, distillObs{
+			Key:     "distill-test:" + norm,
+			Content: fmt.Sprintf("Test %s was exercised in a %s job that did not complete cleanly in this repository.", norm, act),
+		})
+	}
+	return out
+}
+
+// namedErrorCandidates extracts stable error tokens from result.Summary and the
+// tail of the last raw output. Each error line is normalized to a closed-category
+// signature (lowercased, with hashes/paths/addresses/line-numbers/timestamps
+// stripped) so distinct incidental values collapse to one key. Content is the
+// cleaned line itself (stable), prefixed with a neutral reference frame.
+func namedErrorCandidates(payload JobPayload, result AgentResult) []distillObs {
+	sources := []string{result.Summary}
+	if n := len(payload.RawOutputs); n > 0 {
+		tail := payload.RawOutputs[n-1]
+		if len(tail) > distillRawOutputTailBytes {
+			tail = tail[len(tail)-distillRawOutputTailBytes:]
+		}
+		sources = append(sources, tail)
+	}
+	out := make([]distillObs, 0, 4)
+	scanned := 0
+	for _, src := range sources {
+		for _, line := range strings.Split(src, "\n") {
+			if scanned >= distillMaxScanLines {
+				return out
+			}
+			scanned++
+			line = strings.TrimSpace(line)
+			// Skip blanks, over-long lines, and the structured result envelope
+			// (raw outputs carry the gitmoot_result JSON) so distill mines genuine
+			// human-readable error lines, never a minified JSON brick.
+			if line == "" || len(line) > distillMaxErrorLineLen || strings.Contains(line, "gitmoot_result") {
+				continue
+			}
+			if !errorLineRe.MatchString(line) {
+				continue
+			}
+			cleaned := cleanErrorLine(line)
+			sig := memory.Slug(cleaned)
+			if sig == "" || sig == "untitled" {
+				continue
+			}
+			out = append(out, distillObs{
+				Key:     "distill-error:" + sig,
+				Content: truncateForContent("A job in this repository hit the error: " + cleaned),
+			})
+		}
+	}
+	return out
+}
+
+// errorLineRe matches lines that carry a NAMED error token. It is deliberately
+// conservative — anchored on unambiguous error markers — so ordinary prose is not
+// swept in.
+var errorLineRe = regexp.MustCompile(`(?i)(\bpanic:|\bfatal:|\berror:|\bexception\b|\bexit status \d|\bFAIL\b|\bfailed to\b|\bcannot\b|\bno such\b|\bunable to\b|\btimed out\b|\bnil pointer\b|\bsegfault\b)`)
+
+var (
+	// distillHexAddr matches 0x-prefixed addresses.
+	distillHexAddr = regexp.MustCompile(`0x[0-9a-fA-F]+`)
+	// distillLongHex matches sha-like / long hex runs.
+	distillLongHex = regexp.MustCompile(`\b[0-9a-fA-F]{7,}\b`)
+	// distillTimestamp matches ISO-ish / clock timestamps.
+	distillTimestamp = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}[t ]?\d{2}:\d{2}:\d{2}(\.\d+)?z?\b`)
+	// distillDuration matches Go test durations like "(0.03s)" and "1.234s".
+	distillDuration = regexp.MustCompile(`\(?\b\d+(\.\d+)?(ms|µs|us|ns|s|m|h)\b\)?`)
+	// distillPath matches absolute/relative file paths and path-y line:col suffixes.
+	distillPath = regexp.MustCompile(`(?:\.?/[\w.\-/]+)|(?::\d+(?::\d+)?)`)
+	// distillNumber matches standalone number runs (line numbers, counts, PIDs).
+	distillNumber = regexp.MustCompile(`\b\d+\b`)
+	// distillWS collapses whitespace runs.
+	distillWS = regexp.MustCompile(`\s+`)
+)
+
+// cleanErrorLine normalizes one error line to a stable, closed-category form: it
+// lowercases and strips the volatile parts (addresses, hashes, timestamps,
+// durations, paths, line numbers) that would otherwise make an identical error
+// look different across jobs. The order matters — path/hash stripping runs before
+// the generic number strip so a "/x/y:42" turns into "" not a bare "42".
+func cleanErrorLine(line string) string {
+	s := strings.ToLower(line)
+	s = distillHexAddr.ReplaceAllString(s, "")
+	s = distillTimestamp.ReplaceAllString(s, "")
+	s = distillDuration.ReplaceAllString(s, " ")
+	s = distillPath.ReplaceAllString(s, " ")
+	s = distillLongHex.ReplaceAllString(s, "")
+	s = distillNumber.ReplaceAllString(s, "")
+	s = distillWS.ReplaceAllString(s, " ")
+	return strings.TrimSpace(s)
+}
+
+var (
+	// distillTestDuration strips a Go test duration suffix like " (0.03s)".
+	distillTestDuration = regexp.MustCompile(`\s*\(\d+(\.\d+)?s\)\s*$`)
+	// distillTestStatus strips a trailing PASS/FAIL/SKIP status word.
+	distillTestStatus = regexp.MustCompile(`(?i)[\s:-]*\b(pass|fail|skip|ok)\b\s*$`)
+	// distillTestLineCol strips a :line[:col] suffix from a test/file identifier.
+	distillTestLineCol = regexp.MustCompile(`:\d+(:\d+)?`)
+)
+
+// normalizeTestName reduces a raw test identifier to a stable, bounded key
+// fragment. It strips the volatile bits a test harness appends (durations, status
+// words, line:col, hashes) and slugs the remainder, so the SAME test always maps
+// to the SAME key while incidental values can never inflate cardinality.
+func normalizeTestName(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	s = distillTestDuration.ReplaceAllString(s, "")
+	s = distillTestStatus.ReplaceAllString(s, "")
+	s = distillHexAddr.ReplaceAllString(s, "")
+	s = distillTimestamp.ReplaceAllString(s, "")
+	// Strip a :line[:col] suffix but keep the test/file identity before it.
+	s = distillTestLineCol.ReplaceAllString(s, "")
+	slug := memory.Slug(s)
+	if slug == "untitled" {
+		return ""
+	}
+	return slug
+}
+
+// truncateForContent caps a distilled observation's content to a bounded length
+// on a rune boundary, appending an ellipsis when it had to cut.
+func truncateForContent(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= distillContentMaxLen {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= distillContentMaxLen {
+		return s
+	}
+	return strings.TrimSpace(string(r[:distillContentMaxLen])) + "…"
+}

--- a/internal/workflow/memory_distill_test.go
+++ b/internal/workflow/memory_distill_test.go
@@ -1,0 +1,319 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// distillController builds a controller with distill-at-terminal ON. enrolled
+// lists the agents opted into the read path (memController's set); allJobs mirrors
+// [memory].distill_all_jobs.
+func distillController(store *db.Store, maxPerJob int, allJobs bool, enrolled ...string) *MemoryController {
+	set := map[string]bool{}
+	for _, n := range enrolled {
+		set[n] = true
+	}
+	return &MemoryController{
+		Store:             store,
+		Enabled:           func(name string) bool { return set[name] },
+		TokenBudget:       1500,
+		MaxEntries:        15,
+		DistillAtTerminal: true,
+		DistillMaxPerJob:  maxPerJob,
+		DistillAllJobs:    allJobs,
+	}
+}
+
+func distillObsFor(t *testing.T, store *db.Store, repo string) []db.MemoryObservation {
+	t.Helper()
+	obs, err := store.ListMemoryObservations(context.Background(), "audit", repo)
+	if err != nil {
+		t.Fatalf("ListMemoryObservations: %v", err)
+	}
+	return obs
+}
+
+func staged(obs []db.MemoryObservation) []db.MemoryObservation {
+	var out []db.MemoryObservation
+	for _, o := range obs {
+		if strings.HasPrefix(o.Provenance, "distill:") {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+func witnesses(obs []db.MemoryObservation) []db.MemoryObservation {
+	var out []db.MemoryObservation
+	for _, o := range obs {
+		if strings.HasPrefix(o.Provenance, "distill-seen:") {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+// TestDistillOffByDefaultNoRows proves that with distill OFF (the default) a
+// FAILED terminal carrying failing tests AND a named error stages NOTHING — no
+// observation rows, no confirmed rows — so the terminal path is byte-identical.
+func TestDistillOffByDefaultNoRows(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	// memController leaves DistillAtTerminal false.
+	ctrl := memController(store, 1500, 15, "audit")
+	ctrl.record(ctx, "job-1", memAgent(), "implement",
+		JobPayload{Repo: "acme/widget"},
+		AgentResult{Decision: "failed", Summary: "panic: runtime error: index out of range",
+			TestsRun: []string{"TestPaymentFlow"}})
+
+	if obs := distillObsFor(t, store, "acme/widget"); len(obs) != 0 {
+		t.Fatalf("distill off must write no observations, got %+v", obs)
+	}
+	confirmed, _ := store.ListConfirmedMemories(ctx, "audit", "acme/widget")
+	if len(confirmed) != 0 {
+		t.Fatalf("distill off must write no confirmed rows, got %+v", confirmed)
+	}
+}
+
+// TestDistillNeverConfirmedAlwaysLowTrust proves the OUTPUT DISCIPLINE: distilled
+// rows are PENDING observations, trust=low, provenance "distill:*" — never
+// confirmed memory. Uses two jobs so the recurrence gate lets the second stage.
+func TestDistillNeverConfirmedAlwaysLowTrust(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ctrl := distillController(store, 3, false, "audit")
+	res := AgentResult{Decision: "failed", Summary: "", TestsRun: []string{"TestPaymentFlow"}}
+	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	ctrl.record(ctx, "job-2", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+
+	st := staged(distillObsFor(t, store, "acme/widget"))
+	if len(st) != 1 {
+		t.Fatalf("expected exactly one staged distilled observation, got %+v", st)
+	}
+	o := st[0]
+	if o.Key != "distill-test:testpaymentflow" {
+		t.Fatalf("staged key = %q, want distill-test:testpaymentflow", o.Key)
+	}
+	if o.TrustMark != "low" {
+		t.Fatalf("staged trust = %q, want low", o.TrustMark)
+	}
+	if o.Provenance != "distill:job-2" {
+		t.Fatalf("staged provenance = %q, want distill:job-2", o.Provenance)
+	}
+	// NEVER confirmed.
+	confirmed, _ := store.ListConfirmedMemories(ctx, "audit", "acme/widget")
+	if len(confirmed) != 0 {
+		t.Fatalf("distill must never write confirmed memory, got %+v", confirmed)
+	}
+}
+
+// TestDistillRecurrenceGate proves gpt-5.5's rule: a one-off anomalous failure
+// does NOT stage — the first sighting records only a low-trust witness; the actual
+// staged observation appears only on the second (recurring) sighting across jobs.
+func TestDistillRecurrenceGate(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ctrl := distillController(store, 3, false, "audit")
+	res := AgentResult{Decision: "failed", TestsRun: []string{"TestCheckoutRetry"}}
+
+	// --- Job 1: FIRST sighting → witness only, nothing staged.
+	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	obs := distillObsFor(t, store, "acme/widget")
+	if len(staged(obs)) != 0 {
+		t.Fatalf("first sighting must stage nothing, got %+v", staged(obs))
+	}
+	w := witnesses(obs)
+	if len(w) != 1 {
+		t.Fatalf("first sighting must record exactly one witness, got %+v", w)
+	}
+	if w[0].TrustMark != "low" || w[0].Provenance != "distill-seen:job-1" {
+		t.Fatalf("witness trust/provenance = %q/%q, want low/distill-seen:job-1", w[0].TrustMark, w[0].Provenance)
+	}
+	if w[0].Content == "" || strings.Contains(w[0].Content, "TestCheckoutRetry") {
+		t.Fatalf("witness content should be the fixed sentinel, got %q", w[0].Content)
+	}
+
+	// --- Job 2: recurrence → the real observation stages.
+	ctrl.record(ctx, "job-2", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	st := staged(distillObsFor(t, store, "acme/widget"))
+	if len(st) != 1 {
+		t.Fatalf("second sighting must stage exactly one observation, got %+v", st)
+	}
+	if st[0].Key != "distill-test:testcheckoutretry" {
+		t.Fatalf("staged key = %q", st[0].Key)
+	}
+}
+
+// TestDistillDedupOnRepeat proves a THIRD recurrence does not stage a second copy:
+// content-hash dedup collapses the repeat, so at most one staged row per key.
+func TestDistillDedupOnRepeat(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ctrl := distillController(store, 3, false, "audit")
+	res := AgentResult{Decision: "failed", TestsRun: []string{"TestCheckoutRetry"}}
+	for _, jobID := range []string{"job-1", "job-2", "job-3", "job-4"} {
+		ctrl.record(ctx, jobID, memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	}
+	obs := distillObsFor(t, store, "acme/widget")
+	if got := len(staged(obs)); got != 1 {
+		t.Fatalf("dedup should keep exactly one staged row across repeats, got %d: %+v", got, staged(obs))
+	}
+	if got := len(witnesses(obs)); got != 1 {
+		t.Fatalf("exactly one witness should ever exist per key, got %d", got)
+	}
+}
+
+// TestDistillNamedError proves the named-error producer extracts a stable,
+// normalized error token from result.Summary and stages it on recurrence, with
+// volatile parts (addresses/numbers) stripped so the key is closed-category.
+func TestDistillNamedError(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ctrl := distillController(store, 3, false, "audit")
+	// Two jobs whose summaries differ ONLY in the volatile address/index, so the
+	// normalized key must be identical and the second must count as a recurrence.
+	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"},
+		AgentResult{Decision: "failed", Summary: "panic: nil pointer dereference at 0xdeadbeef index 3"})
+	ctrl.record(ctx, "job-2", memAgent(), "implement", JobPayload{Repo: "acme/widget"},
+		AgentResult{Decision: "failed", Summary: "panic: nil pointer dereference at 0xcafef00d index 9"})
+
+	st := staged(distillObsFor(t, store, "acme/widget"))
+	if len(st) != 1 {
+		t.Fatalf("named error should stage exactly one row after recurrence, got %+v", st)
+	}
+	if !strings.HasPrefix(st[0].Key, "distill-error:") {
+		t.Fatalf("named-error key = %q, want distill-error: prefix", st[0].Key)
+	}
+	if strings.Contains(st[0].Key, "deadbeef") || strings.Contains(st[0].Key, "0x") {
+		t.Fatalf("named-error key retained a volatile token: %q", st[0].Key)
+	}
+	if st[0].TrustMark != "low" || !strings.HasPrefix(st[0].Provenance, "distill:") {
+		t.Fatalf("named-error trust/provenance = %q/%q", st[0].TrustMark, st[0].Provenance)
+	}
+}
+
+// TestDistillNamedErrorFromRawOutputSkipsEnvelope proves the named-error producer
+// mines a genuine short error line from the raw output tail, but SKIPS the
+// structured gitmoot_result JSON envelope (long, contains gitmoot_result) so a
+// minified result brick never becomes a distilled "error".
+func TestDistillNamedErrorFromRawOutputSkipsEnvelope(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ctrl := distillController(store, 5, false, "audit")
+	envelope := `{"gitmoot_result":{"decision":"failed","summary":"see log","tests_run":[],"needs":[]}}`
+	raw := "running suite\npanic: connection refused\n" + envelope
+	res := AgentResult{Decision: "failed", Summary: "see log"}
+	payload := JobPayload{Repo: "acme/widget", RawOutputs: []string{raw}}
+	ctrl.record(ctx, "job-1", memAgent(), "implement", payload, res)
+	ctrl.record(ctx, "job-2", memAgent(), "implement", payload, res)
+
+	st := staged(distillObsFor(t, store, "acme/widget"))
+	if len(st) != 1 {
+		t.Fatalf("expected exactly one staged error (the panic line), got %+v", st)
+	}
+	if !strings.Contains(st[0].Key, "connection-refused") {
+		t.Fatalf("staged key should come from the genuine error line, got %q", st[0].Key)
+	}
+	for _, o := range st {
+		if strings.Contains(o.Key, "gitmoot") || strings.Contains(o.Content, "gitmoot_result") {
+			t.Fatalf("result envelope was mined as an error: %+v", o)
+		}
+	}
+}
+
+// TestDistillPreFilterRejects proves a directive/secret-shaped error line is
+// dropped by PreFilter BEFORE it can even be witnessed — no rows at all.
+func TestDistillPreFilterRejects(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ctrl := distillController(store, 3, false, "audit")
+	// "you must always" makes the cleaned error line directive-shaped.
+	res := AgentResult{Decision: "failed", Summary: "error: you must always rebase before pushing to this repo"}
+	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	ctrl.record(ctx, "job-2", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	if obs := distillObsFor(t, store, "acme/widget"); len(obs) != 0 {
+		t.Fatalf("PreFilter must reject a directive-shaped error line entirely, got %+v", obs)
+	}
+}
+
+// TestDistillPerJobCap proves the hard per-job cap bounds distill writes: a single
+// job carrying more distinct signals than the cap writes exactly cap rows.
+func TestDistillPerJobCap(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	ctrl := distillController(store, 2, false, "audit")
+	res := AgentResult{Decision: "failed", TestsRun: []string{"TestA", "TestB", "TestC", "TestD"}}
+	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	if got := len(distillObsFor(t, store, "acme/widget")); got != 2 {
+		t.Fatalf("per-job cap=2 should bound distill to 2 rows, got %d", got)
+	}
+}
+
+// TestDistillEnrolledOnlyVsAllJobs proves the scoping: with distill_all_jobs=false
+// an UN-enrolled agent distills nothing; with distill_all_jobs=true the SAME
+// un-enrolled agent distills box-wide.
+func TestDistillEnrolledOnlyVsAllJobs(t *testing.T) {
+	ctx := context.Background()
+	res := AgentResult{Decision: "failed", TestsRun: []string{"TestPaymentFlow"}}
+
+	// distill_all_jobs=false, nobody enrolled → no distill.
+	storeA := openTestStore(t)
+	ctrlA := distillController(storeA, 3, false /* nobody enrolled */)
+	ctrlA.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	if obs := distillObsFor(t, storeA, "acme/widget"); len(obs) != 0 {
+		t.Fatalf("un-enrolled agent with distill_all_jobs=false must distill nothing, got %+v", obs)
+	}
+
+	// distill_all_jobs=true, still nobody enrolled → distill fires (witness).
+	storeB := openTestStore(t)
+	ctrlB := distillController(storeB, 3, true /* nobody enrolled, allJobs */)
+	ctrlB.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
+	obs := distillObsFor(t, storeB, "acme/widget")
+	if len(witnesses(obs)) != 1 {
+		t.Fatalf("distill_all_jobs=true must distill for an un-enrolled agent, got %+v", obs)
+	}
+}
+
+// TestDistillOnlyOnNotableDecisions proves distill fires only on the anomalous
+// terminal decisions (failed/blocked/changes_requested); a routine success with
+// the same test list stages nothing.
+func TestDistillOnlyOnNotableDecisions(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		decision string
+		want     int // expected total distill rows (witness on first sighting)
+	}{
+		{"failed", 1},
+		{"blocked", 1},
+		{"changes_requested", 1},
+		{"approved", 0},
+		{"implemented", 0},
+	} {
+		t.Run(tc.decision, func(t *testing.T) {
+			store := openTestStore(t)
+			ctrl := distillController(store, 3, false, "audit")
+			ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"},
+				AgentResult{Decision: tc.decision, TestsRun: []string{"TestPaymentFlow"}})
+			if got := len(distillObsFor(t, store, "acme/widget")); got != tc.want {
+				t.Fatalf("decision %q: distill rows = %d, want %d", tc.decision, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDistillFailSafeNilAgent is a defensive proof that a nil controller / empty
+// enrollment never panics through the public record seam.
+func TestDistillFailSafeDisabledController(t *testing.T) {
+	store := openTestStore(t)
+	var nilCtrl *MemoryController
+	// Should not panic; distillEnabledFor guards nil.
+	nilCtrl.record(context.Background(), "job-1", runtime.Agent{Name: "audit"}, "implement",
+		JobPayload{Repo: "acme/widget"}, AgentResult{Decision: "failed", TestsRun: []string{"TestX"}})
+	if obs, _ := store.ListMemoryObservations(context.Background(), "audit", "acme/widget"); len(obs) != 0 {
+		t.Fatalf("nil controller must write nothing, got %+v", obs)
+	}
+}

--- a/internal/workflow/memory_distill_test.go
+++ b/internal/workflow/memory_distill_test.go
@@ -47,14 +47,18 @@ func staged(obs []db.MemoryObservation) []db.MemoryObservation {
 	return out
 }
 
-func witnesses(obs []db.MemoryObservation) []db.MemoryObservation {
-	var out []db.MemoryObservation
-	for _, o := range obs {
-		if strings.HasPrefix(o.Provenance, "distill-seen:") {
-			out = append(out, o)
-		}
+// recCount returns how many distill observation rows (witness + staged) exist for
+// a key — the exact recurrence counter. Witnesses are EXCLUDED from the pending
+// list surface (ListMemoryObservations), so a first-sighting witness is invisible
+// to distillObsFor; this keyed count is how a test proves the witness was recorded.
+func recCount(t *testing.T, store *db.Store, repo, key string) int {
+	t.Helper()
+	owner := ownerForJob(memAgent(), JobPayload{Repo: repo})
+	n, err := store.CountMemoryObservationsForKey(context.Background(), owner, repo, key)
+	if err != nil {
+		t.Fatalf("CountMemoryObservationsForKey: %v", err)
 	}
-	return out
+	return n
 }
 
 // TestDistillOffByDefaultNoRows proves that with distill OFF (the default) a
@@ -86,7 +90,8 @@ func TestDistillNeverConfirmedAlwaysLowTrust(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
 	ctrl := distillController(store, 3, false, "audit")
-	res := AgentResult{Decision: "failed", Summary: "", TestsRun: []string{"TestPaymentFlow"}}
+	// tests_run alone is NOT failure evidence; an explicit `--- FAIL:` marker is.
+	res := AgentResult{Decision: "failed", Summary: "--- FAIL: TestPaymentFlow (0.01s)", TestsRun: []string{"TestPaymentFlow"}}
 	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
 	ctrl.record(ctx, "job-2", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
 
@@ -118,7 +123,7 @@ func TestDistillRecurrenceGate(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
 	ctrl := distillController(store, 3, false, "audit")
-	res := AgentResult{Decision: "failed", TestsRun: []string{"TestCheckoutRetry"}}
+	res := AgentResult{Decision: "failed", Summary: "--- FAIL: TestCheckoutRetry (0.02s)", TestsRun: []string{"TestCheckoutRetry"}}
 
 	// --- Job 1: FIRST sighting → witness only, nothing staged.
 	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
@@ -126,15 +131,14 @@ func TestDistillRecurrenceGate(t *testing.T) {
 	if len(staged(obs)) != 0 {
 		t.Fatalf("first sighting must stage nothing, got %+v", staged(obs))
 	}
-	w := witnesses(obs)
-	if len(w) != 1 {
-		t.Fatalf("first sighting must record exactly one witness, got %+v", w)
+	// The witness is NOT visible on the pending list surface (it is internal
+	// recurrence bookkeeping) — distillObsFor returns nothing for a first sighting.
+	if len(obs) != 0 {
+		t.Fatalf("first-sighting witness must be absent from the pending list, got %+v", obs)
 	}
-	if w[0].TrustMark != "low" || w[0].Provenance != "distill-seen:job-1" {
-		t.Fatalf("witness trust/provenance = %q/%q, want low/distill-seen:job-1", w[0].TrustMark, w[0].Provenance)
-	}
-	if w[0].Content == "" || strings.Contains(w[0].Content, "TestCheckoutRetry") {
-		t.Fatalf("witness content should be the fixed sentinel, got %q", w[0].Content)
+	// But it WAS recorded, so recurrence is armed: the keyed count is exactly 1.
+	if n := recCount(t, store, "acme/widget", "distill-test:testcheckoutretry"); n != 1 {
+		t.Fatalf("first sighting must record exactly one witness row, keyed count = %d", n)
 	}
 
 	// --- Job 2: recurrence → the real observation stages.
@@ -154,7 +158,7 @@ func TestDistillDedupOnRepeat(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
 	ctrl := distillController(store, 3, false, "audit")
-	res := AgentResult{Decision: "failed", TestsRun: []string{"TestCheckoutRetry"}}
+	res := AgentResult{Decision: "failed", Summary: "--- FAIL: TestCheckoutRetry (0.02s)", TestsRun: []string{"TestCheckoutRetry"}}
 	for _, jobID := range []string{"job-1", "job-2", "job-3", "job-4"} {
 		ctrl.record(ctx, jobID, memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
 	}
@@ -162,8 +166,13 @@ func TestDistillDedupOnRepeat(t *testing.T) {
 	if got := len(staged(obs)); got != 1 {
 		t.Fatalf("dedup should keep exactly one staged row across repeats, got %d: %+v", got, staged(obs))
 	}
-	if got := len(witnesses(obs)); got != 1 {
-		t.Fatalf("exactly one witness should ever exist per key, got %d", got)
+	// The pending list shows only the single staged row — witnesses stay hidden.
+	if len(obs) != 1 {
+		t.Fatalf("pending list should show exactly the one staged row, got %+v", obs)
+	}
+	// Exactly one witness + one staged row ever exist per key (keyed count = 2).
+	if got := recCount(t, store, "acme/widget", "distill-test:testcheckoutretry"); got != 2 {
+		t.Fatalf("exactly one witness + one staged row should exist per key, keyed count = %d", got)
 	}
 }
 
@@ -246,10 +255,17 @@ func TestDistillPerJobCap(t *testing.T) {
 	store := openTestStore(t)
 	ctx := context.Background()
 	ctrl := distillController(store, 2, false, "audit")
-	res := AgentResult{Decision: "failed", TestsRun: []string{"TestA", "TestB", "TestC", "TestD"}}
+	// Four distinct FAILED tests → four candidates; the per-job cap bounds WRITES.
+	res := AgentResult{Decision: "failed", Summary: "--- FAIL: TestA (0s)\n--- FAIL: TestB (0s)\n--- FAIL: TestC (0s)\n--- FAIL: TestD (0s)"}
 	ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
-	if got := len(distillObsFor(t, store, "acme/widget")); got != 2 {
-		t.Fatalf("per-job cap=2 should bound distill to 2 rows, got %d", got)
+	// First sighting writes only witnesses (hidden from the list surface), so the
+	// cap is verified via the keyed recurrence count: exactly 2 of the 4 written.
+	total := 0
+	for _, name := range []string{"testa", "testb", "testc", "testd"} {
+		total += recCount(t, store, "acme/widget", "distill-test:"+name)
+	}
+	if total != 2 {
+		t.Fatalf("per-job cap=2 should bound distill to 2 written rows, got %d", total)
 	}
 }
 
@@ -258,23 +274,22 @@ func TestDistillPerJobCap(t *testing.T) {
 // un-enrolled agent distills box-wide.
 func TestDistillEnrolledOnlyVsAllJobs(t *testing.T) {
 	ctx := context.Background()
-	res := AgentResult{Decision: "failed", TestsRun: []string{"TestPaymentFlow"}}
+	res := AgentResult{Decision: "failed", Summary: "--- FAIL: TestPaymentFlow (0s)"}
 
 	// distill_all_jobs=false, nobody enrolled → no distill.
 	storeA := openTestStore(t)
 	ctrlA := distillController(storeA, 3, false /* nobody enrolled */)
 	ctrlA.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
-	if obs := distillObsFor(t, storeA, "acme/widget"); len(obs) != 0 {
-		t.Fatalf("un-enrolled agent with distill_all_jobs=false must distill nothing, got %+v", obs)
+	if n := recCount(t, storeA, "acme/widget", "distill-test:testpaymentflow"); n != 0 {
+		t.Fatalf("un-enrolled agent with distill_all_jobs=false must distill nothing, keyed count = %d", n)
 	}
 
 	// distill_all_jobs=true, still nobody enrolled → distill fires (witness).
 	storeB := openTestStore(t)
 	ctrlB := distillController(storeB, 3, true /* nobody enrolled, allJobs */)
 	ctrlB.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"}, res)
-	obs := distillObsFor(t, storeB, "acme/widget")
-	if len(witnesses(obs)) != 1 {
-		t.Fatalf("distill_all_jobs=true must distill for an un-enrolled agent, got %+v", obs)
+	if n := recCount(t, storeB, "acme/widget", "distill-test:testpaymentflow"); n != 1 {
+		t.Fatalf("distill_all_jobs=true must distill (witness) for an un-enrolled agent, keyed count = %d", n)
 	}
 }
 
@@ -297,8 +312,10 @@ func TestDistillOnlyOnNotableDecisions(t *testing.T) {
 			store := openTestStore(t)
 			ctrl := distillController(store, 3, false, "audit")
 			ctrl.record(ctx, "job-1", memAgent(), "implement", JobPayload{Repo: "acme/widget"},
-				AgentResult{Decision: tc.decision, TestsRun: []string{"TestPaymentFlow"}})
-			if got := len(distillObsFor(t, store, "acme/widget")); got != tc.want {
+				AgentResult{Decision: tc.decision, Summary: "--- FAIL: TestPaymentFlow (0s)"})
+			// First sighting writes only a (hidden) witness, so assert via the keyed
+			// recurrence count rather than the pending list surface.
+			if got := recCount(t, store, "acme/widget", "distill-test:testpaymentflow"); got != tc.want {
 				t.Fatalf("decision %q: distill rows = %d, want %d", tc.decision, got, tc.want)
 			}
 		})

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1565,7 +1565,9 @@ closed-category signals and stages them as **pending observations** — trust
 `low`, provenance `distill:<job-id>`, and **never confirmed memory** (the
 `memory confirm` gate stays the only promotion path):
 
-- **Failing tests** — one normalized key per entry in `tests_run`.
+- **Failing tests** — one normalized key per test whose failure is **explicit** in
+  the job output (a `--- FAIL:` marker), not merely present in `tests_run` (which
+  records only that a test was *run*, not that it failed).
 - **Named errors** — stable error tokens pulled from the result summary (and the
   tail of the raw output), normalized to a closed category by stripping hashes,
   paths, addresses, line numbers, and timestamps.
@@ -1576,7 +1578,10 @@ learnings, content-hash **dedup** blocks a repeat from staging twice, and
 one-off failure from ever becoming a pending memory: the first sighting of a
 normalized key records only a low-trust *witness* (provenance
 `distill-seen:<job-id>`); the observation stages only when the same key recurs in
-a later job. By default distill follows enrollment; set `distill_all_jobs = true`
+a later job. A witness is internal recurrence bookkeeping — it is **never** shown
+by `memory list` and can **never** be promoted by `memory confirm` (both the list
+and confirm surfaces exclude the `distill-seen:` provenance), so a one-off failure
+stays invisible until it recurs. By default distill follows enrollment; set `distill_all_jobs = true`
 to harvest failure signal box-wide (the read path and confirmed producers stay
 enrolled-only).
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1558,6 +1558,28 @@ a small fixed allowlist (a delegation's free-form action buckets to a generic
 token). So repeated jobs UPSERT the same row rather than growing the pool, and
 every fact passes the same deterministic write filters as agent learnings.
 
+**Distill-at-terminal (#737 P4.1)** is an optional, config-gated producer
+(`distill_at_terminal`, off by default). On an *anomalous* terminal
+(`failed`/`blocked`/`changes_requested`) it mines the job's own result for two
+closed-category signals and stages them as **pending observations** — trust
+`low`, provenance `distill:<job-id>`, and **never confirmed memory** (the
+`memory confirm` gate stays the only promotion path):
+
+- **Failing tests** — one normalized key per entry in `tests_run`.
+- **Named errors** — stable error tokens pulled from the result summary (and the
+  tail of the raw output), normalized to a closed category by stripping hashes,
+  paths, addresses, line numbers, and timestamps.
+
+Distill is bounded on every axis: each candidate passes the same **PreFilter** as
+learnings, content-hash **dedup** blocks a repeat from staging twice, and
+`distill_max_per_job` caps writes per job. A **recurrence gate** prevents a
+one-off failure from ever becoming a pending memory: the first sighting of a
+normalized key records only a low-trust *witness* (provenance
+`distill-seen:<job-id>`); the observation stages only when the same key recurs in
+a later job. By default distill follows enrollment; set `distill_all_jobs = true`
+to harvest failure signal box-wide (the read path and confirmed producers stay
+enrolled-only).
+
 Enrollment is per agent, plus optional global knobs:
 
 ```toml
@@ -1566,10 +1588,16 @@ runtime = "codex"
 memory = true          # enroll this agent (default off)
 
 [memory]
-disabled = false       # global kill switch (overrides every enrollment)
-token_budget = 1500    # cap on injected block size (estimated tokens)
-max_entries = 15       # cap on confirmed rows considered for injection
+disabled = false            # global kill switch (overrides every enrollment)
+token_budget = 1500         # cap on injected block size (estimated tokens)
+max_entries = 15            # cap on confirmed rows considered for injection
+distill_at_terminal = false # stage deterministic failure signal at job terminal (#737 P4.1)
+distill_max_per_job = 3     # hard cap on distilled observations per job
+distill_all_jobs = false    # when true, distill runs for every job, not only enrolled agents
 ```
+
+All `[memory]` keys are read **per tick** — flipping `distill_at_terminal`
+(or any knob) takes effect on the next job with **no daemon restart**.
 
 An agent returns durable facts via the optional top-level `learnings` field in
 `gitmoot_result` — each entry is `{key, scope ("repo"|"general"), content}`.

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -77,10 +77,11 @@ Every `[memory]` key is read **per tick**, so flipping `distill_at_terminal`
 
 `distill_at_terminal` (off by default) enables a deterministic producer that,
 on an *anomalous* terminal (`failed`/`blocked`/`changes_requested`), mines the
-job's own result for two closed-category signals — **failing tests** (from
-`tests_run`) and **named errors** (stable tokens from the summary and the tail of
-the raw output, normalized by stripping hashes, paths, addresses, line numbers,
-and timestamps). Unlike the mechanical facts above, distilled rows are written as
+job's own result for two closed-category signals — **failing tests** (test names
+from explicit `--- FAIL:` markers in the job output, *not* mere presence in
+`tests_run`, which only records that a test was **run**) and **named errors**
+(stable tokens from the summary and the tail of the raw output, normalized by
+stripping hashes, paths, addresses, line numbers, and timestamps). Unlike the mechanical facts above, distilled rows are written as
 **pending observations** at trust `low` with provenance `distill:<job-id>` — they
 are **never** confirmed memory, so the human `memory confirm` gate stays the only
 promotion path.
@@ -90,7 +91,9 @@ content-hash dedup blocks a repeat from staging twice, and `distill_max_per_job`
 caps writes per job. A **recurrence gate** stops a one-off failure from ever
 becoming a pending memory — the first sighting of a normalized key records only a
 low-trust *witness* (`distill-seen:<job-id>`), and the observation stages only
-when the same key recurs across a later job. By default distill follows
+when the same key recurs across a later job. A witness is internal recurrence
+bookkeeping: it is **never** shown in `memory list` and can **never** be promoted
+by `memory confirm`, so a one-off failure is invisible until it recurs. By default distill follows
 enrollment; `distill_all_jobs = true` harvests failure signal box-wide while the
 read path and confirmed producers stay enrolled-only.
 

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -62,10 +62,37 @@ runtime = "codex"
 memory = true          # enroll this agent (default off)
 
 [memory]
-disabled = false       # global kill switch (overrides every enrollment)
-token_budget = 1500    # cap on injected block size (estimated tokens)
-max_entries = 15       # cap on confirmed rows considered for injection
+disabled = false            # global kill switch (overrides every enrollment)
+token_budget = 1500         # cap on injected block size (estimated tokens)
+max_entries = 15            # cap on confirmed rows considered for injection
+distill_at_terminal = false # stage deterministic failure signal at terminal (P4.1)
+distill_max_per_job = 3     # hard cap on distilled observations per job
+distill_all_jobs = false    # true → distill every job, not only enrolled agents
 ```
+
+Every `[memory]` key is read **per tick**, so flipping `distill_at_terminal`
+(or any knob) takes effect on the next job with **no daemon restart**.
+
+### Distill-at-terminal
+
+`distill_at_terminal` (off by default) enables a deterministic producer that,
+on an *anomalous* terminal (`failed`/`blocked`/`changes_requested`), mines the
+job's own result for two closed-category signals — **failing tests** (from
+`tests_run`) and **named errors** (stable tokens from the summary and the tail of
+the raw output, normalized by stripping hashes, paths, addresses, line numbers,
+and timestamps). Unlike the mechanical facts above, distilled rows are written as
+**pending observations** at trust `low` with provenance `distill:<job-id>` — they
+are **never** confirmed memory, so the human `memory confirm` gate stays the only
+promotion path.
+
+Distill is bounded on every axis: each candidate passes the same PreFilter, a
+content-hash dedup blocks a repeat from staging twice, and `distill_max_per_job`
+caps writes per job. A **recurrence gate** stops a one-off failure from ever
+becoming a pending memory — the first sighting of a normalized key records only a
+low-trust *witness* (`distill-seen:<job-id>`), and the observation stages only
+when the same key recurs across a later job. By default distill follows
+enrollment; `distill_all_jobs = true` harvests failure signal box-wide while the
+read path and confirmed producers stay enrolled-only.
 
 An agent records a durable fact via the optional top-level `learnings` field in
 `gitmoot_result` — each entry is `{key, scope, content}` where `scope` is

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1330,7 +1330,9 @@ validation for final promotion decisions on fresh items.
 
 Agent persistent memory is **off by default** and enrolled per agent
 (`[agents.<name>].memory = true`), with optional `[memory]` knobs (`disabled`,
-`token_budget`, `max_entries`). See
+`token_budget`, `max_entries`, and the distill-at-terminal knobs
+`distill_at_terminal`, `distill_max_per_job`, `distill_all_jobs` — all read per
+tick, no restart). See
 [Agent Persistent Memory](../concepts/agent-memory.md) for the full model. The
 inspection commands are read-only; `ingest` and `confirm` write behind a human
 gate:

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9541,7 +9541,9 @@ closed-category signals and stages them as **pending observations** — trust
 `low`, provenance `distill:<job-id>`, and **never confirmed memory** (the
 `memory confirm` gate stays the only promotion path):
 
-- **Failing tests** — one normalized key per entry in `tests_run`.
+- **Failing tests** — one normalized key per test whose failure is **explicit** in
+  the job output (a `--- FAIL:` marker), not merely present in `tests_run` (which
+  records only that a test was *run*, not that it failed).
 - **Named errors** — stable error tokens pulled from the result summary (and the
   tail of the raw output), normalized to a closed category by stripping hashes,
   paths, addresses, line numbers, and timestamps.
@@ -9552,7 +9554,10 @@ learnings, content-hash **dedup** blocks a repeat from staging twice, and
 one-off failure from ever becoming a pending memory: the first sighting of a
 normalized key records only a low-trust *witness* (provenance
 `distill-seen:<job-id>`); the observation stages only when the same key recurs in
-a later job. By default distill follows enrollment; set `distill_all_jobs = true`
+a later job. A witness is internal recurrence bookkeeping — it is **never** shown
+by `memory list` and can **never** be promoted by `memory confirm` (both the list
+and confirm surfaces exclude the `distill-seen:` provenance), so a one-off failure
+stays invisible until it recurs. By default distill follows enrollment; set `distill_all_jobs = true`
 to harvest failure signal box-wide (the read path and confirmed producers stay
 enrolled-only).
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9534,6 +9534,28 @@ a small fixed allowlist (a delegation's free-form action buckets to a generic
 token). So repeated jobs UPSERT the same row rather than growing the pool, and
 every fact passes the same deterministic write filters as agent learnings.
 
+**Distill-at-terminal (#737 P4.1)** is an optional, config-gated producer
+(`distill_at_terminal`, off by default). On an *anomalous* terminal
+(`failed`/`blocked`/`changes_requested`) it mines the job's own result for two
+closed-category signals and stages them as **pending observations** — trust
+`low`, provenance `distill:<job-id>`, and **never confirmed memory** (the
+`memory confirm` gate stays the only promotion path):
+
+- **Failing tests** — one normalized key per entry in `tests_run`.
+- **Named errors** — stable error tokens pulled from the result summary (and the
+  tail of the raw output), normalized to a closed category by stripping hashes,
+  paths, addresses, line numbers, and timestamps.
+
+Distill is bounded on every axis: each candidate passes the same **PreFilter** as
+learnings, content-hash **dedup** blocks a repeat from staging twice, and
+`distill_max_per_job` caps writes per job. A **recurrence gate** prevents a
+one-off failure from ever becoming a pending memory: the first sighting of a
+normalized key records only a low-trust *witness* (provenance
+`distill-seen:<job-id>`); the observation stages only when the same key recurs in
+a later job. By default distill follows enrollment; set `distill_all_jobs = true`
+to harvest failure signal box-wide (the read path and confirmed producers stay
+enrolled-only).
+
 Enrollment is per agent, plus optional global knobs:
 
 ```toml
@@ -9542,10 +9564,16 @@ runtime = "codex"
 memory = true          # enroll this agent (default off)
 
 [memory]
-disabled = false       # global kill switch (overrides every enrollment)
-token_budget = 1500    # cap on injected block size (estimated tokens)
-max_entries = 15       # cap on confirmed rows considered for injection
+disabled = false            # global kill switch (overrides every enrollment)
+token_budget = 1500         # cap on injected block size (estimated tokens)
+max_entries = 15            # cap on confirmed rows considered for injection
+distill_at_terminal = false # stage deterministic failure signal at job terminal (#737 P4.1)
+distill_max_per_job = 3     # hard cap on distilled observations per job
+distill_all_jobs = false    # when true, distill runs for every job, not only enrolled agents
 ```
+
+All `[memory]` keys are read **per tick** — flipping `distill_at_terminal`
+(or any knob) takes effect on the next job with **no daemon restart**.
 
 An agent returns durable facts via the optional top-level `learnings` field in
 `gitmoot_result` — each entry is `{key, scope ("repo"|"general"), content}`.


### PR DESCRIPTION
Part of #737 (P4.1).

## What

Adds a **config-gated, deterministic distill-at-terminal** WRITE producer per the P4 three-runtime panel synthesis on #737. On an *anomalous* terminal (`failed`/`blocked`/`changes_requested`) it mines the job's **own result** for two closed-category signals and stages them as **pending observations only**:

- **Failing tests** — one normalized key per entry in `result.TestsRun`.
- **Named errors** — stable error tokens from `result.Summary` and the tail of `payload.RawOutputs`, normalized to a closed category (lowercased; hashes/paths/addresses/line-numbers/timestamps stripped; the structured `gitmoot_result` envelope and over-long lines skipped).

## Output discipline (the #1 invariant)

Distilled rows are **PENDING observations** — `trust_mark=low`, provenance `distill:<job-id>` — and are **NEVER confirmed memory**. The owner's `memory confirm` gate stays the only promotion path. They pass `memory.PreFilter`, dedup via the existing content-hash path (`ObservationDedupKeys`/`MemoryDedupKey`), and respect a hard per-job cap.

## Recurrence gate (gpt-5.5's catch)

A one-off anomalous failure must **not** stage. The first sighting of a normalized key records only a low-trust **witness** (provenance `distill-seen:<job-id>`); the observation stages only when the same key **recurs across a later job** — tracked with the existing `CountMemoryObservationsForKey` (distill owns its `distill-test:`/`distill-error:` key namespace), so **no schema/migration change**. At most one witness + one staged row can ever exist per key.

## Additive / off-by-default

- With `distill_at_terminal` unset the terminal path is **byte-identical**: `record()` runs exactly the Phase-1 enrolled write path and the distill producer no-ops.
- New `[memory]` keys — `distill_at_terminal=false`, `distill_max_per_job=3`, `distill_all_jobs=false` — are read **per tick** (`daemonWorkflowEngine` rebuilds the controller each tick), so **no daemon restart** is needed. `distill_all_jobs=true` widens distill past enrolled agents box-wide; the read path and confirmed producers stay enrolled-only.
- **Fail-safe**: any distill error is log-and-continue; the job outcome is never affected.

## Tests

- `internal/config`: distill defaults, knob parsing, negative-cap rejection.
- `internal/workflow` (`memory_distill_test.go`): off ⇒ no rows; never-confirmed + always-low-trust; recurrence (first witness / second staged); dedup on repeat; named-error normalization; raw-output envelope skip; PreFilter rejection; per-job cap; enrolled-only vs `distill_all_jobs`; notable-decision gating; nil-controller safety.
- `internal/cli` (`memory_lifecycle_e2e_test.go`): full-chain E2E through the **real daemon worker + Mailbox terminal** (shell runtime, temp home) proving witness→stage recurrence, low-trust pending, never-confirmed, and `memory list --pending` surfacing.

## Docs (same PR)

`skills/gitmoot/references/CLI.md` (§Agent Memory), `website/docs/concepts/agent-memory.md`, `website/docs/reference/cli.md`, and the regenerated `website/static/llms-full.txt`. `cd website && npm ci && npm run build` passes.

## Gate

`go build ./...`, `go vet ./...`, `go test -count=1` on `internal/config`, `internal/workflow`, `internal/cli` all pass; scoped `-race` on `internal/workflow` memory tests passes; website build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)