### PR TITLE
feat(memory): emergent clusters + repo-tier knowledge bridge (#763 Track A)

### DIFF
--- a/internal/cli/dashboard_web_learning.go
+++ b/internal/cli/dashboard_web_learning.go
@@ -184,13 +184,18 @@ func agentsByTemplateID(ctx context.Context, store *db.Store) map[string][]strin
 	return out
 }
 
-// categoryEdgeCap bounds the number of fact->category-hub edges the brain graph
-// emits. There is one category edge per categorizable fact, so the count grows
-// with the fact pool; it is capped to keep the payload (and the client
-// force-graph) bounded in a large unattended deployment. The truncation is
-// deterministic: facts are walked in their stable sorted order and category edges
-// stop being appended once the cap is reached.
-const categoryEdgeCap = 2000
+// clusterEdgeCap bounds the number of fact->cluster-hub edges the brain graph
+// emits. There is one cluster edge per clustered fact, so the count grows with the
+// fact pool; it is capped to keep the payload (and the client force-graph) bounded
+// in a large unattended deployment. The truncation is deterministic: facts are
+// walked in their stable sorted order and cluster edges stop being appended once
+// the cap is reached.
+const clusterEdgeCap = 2000
+
+// unclusteredHubID is the stable hub node id for facts in the reserved
+// 'unclustered' bucket (cluster 0). Namespaced under "cluster:" so the UI groups
+// them alongside real cluster hubs without colliding with a fact or agent id.
+const unclusteredHubID = "cluster:unclustered"
 
 // witnessKey identifies a fact's observation pool for the witness tally: the
 // owning agent ref, the repo (as stored, "" == general/NULL), and the memory key.
@@ -259,8 +264,19 @@ func (d *webDataSource) Knowledge(ctx context.Context) (dashboard.Knowledge, err
 			return out.Facts[i].ID < out.Facts[j].ID
 		})
 
+		// Persisted emergent-cluster membership (rowid -> cluster id), retiring the
+		// old key-prefix category hack (#763). Fail-open: a query error (or an
+		// un-recomputed store) leaves membership empty and the graph simply emits no
+		// cluster/repo-tier edges rather than failing the endpoint.
+		membByRow := map[int64]int64{}
+		if members, merr := store.ListMemoryClusterMembers(ctx); merr == nil {
+			for _, m := range members {
+				membByRow[m.MemoryID] = m.ClusterID
+			}
+		}
+
 		out.Agents = knowledgeAgents(ctx, store, paths, out.Facts)
-		out.Edges = knowledgeEdges(rows, out.Facts, idByRow)
+		out.Edges = knowledgeEdges(rows, out.Facts, idByRow, membByRow)
 		return nil
 	})
 	if err != nil {
@@ -307,11 +323,18 @@ func knowledgeAgents(ctx context.Context, store *db.Store, paths config.Paths, f
 	return out
 }
 
-// knowledgeEdges builds the brain graph's edges from the facts (owner + category)
-// and the raw confirmed rows (supersede). The final set is sorted by (kind,
-// source, target) exactly like the fake feed, so a signature-skip poll is stable.
-func knowledgeEdges(rows []db.ConfirmedMemory, facts []dashboard.KnowledgeFact, idByRow map[int64]string) []dashboard.KnowledgeEdge {
-	edges := make([]dashboard.KnowledgeEdge, 0, len(facts)*2+len(rows))
+// knowledgeEdges builds the brain graph's edges: owner (fact->agent), cluster
+// (fact->emergent-cluster hub), repo (cluster->repo hub, the top tier of the
+// repo->cluster->fact hierarchy), and supersede (newer->older). The final set is
+// sorted by (kind, source, target) exactly like the fake feed, so a
+// signature-skip poll is stable.
+//
+// membByRow is the persisted emergent-cluster membership (confirmed_memories.id
+// -> cluster id) from `memory clusters recompute`. It REPLACES the retired
+// key-prefix category hack: hubs are now the deterministic communities over the
+// fact-similarity graph (#763), not the leading colon-delimited key dimension.
+func knowledgeEdges(rows []db.ConfirmedMemory, facts []dashboard.KnowledgeFact, idByRow map[int64]string, membByRow map[int64]int64) []dashboard.KnowledgeEdge {
+	edges := make([]dashboard.KnowledgeEdge, 0, len(facts)*3+len(rows))
 
 	// owner: every fact -> its owning agent hub.
 	for _, f := range facts {
@@ -321,25 +344,42 @@ func knowledgeEdges(rows []db.ConfirmedMemory, facts []dashboard.KnowledgeFact, 
 		edges = append(edges, dashboard.KnowledgeEdge{Source: f.ID, Target: f.Owner, Kind: "owner"})
 	}
 
-	// category: every categorizable fact -> its category hub, derived from the fact
-	// key's LEADING colon-delimited dimension (the mechanical family the memory
-	// writers key on, e.g. `outcome`/`fix-rounds`); facts sharing that dimension
-	// share the hub. NOTE this derives the hub from the KEY per the design, which
-	// differs from the fake feed's use of the fact's repo/scope as the hub — the
-	// real key format carries the category dimension, the fake keys do not. Capped
-	// at categoryEdgeCap with a deterministic truncation: facts are walked in their
-	// already-sorted order and category edges stop once the cap is reached.
-	categoryEdges := 0
+	// cluster + repo tier: every clustered fact -> its emergent-cluster hub, and
+	// each (cluster, repo) pair among the members -> the repo hub, forming the
+	// repo->cluster->fact hierarchy. Membership is looked up by the fact's stored
+	// rowid (idByRow maps rowid->"fact:<id>"). rowidByFactID inverts idByRow so we
+	// can resolve a KnowledgeFact back to its rowid for the membership lookup.
+	// Capped at clusterEdgeCap with a deterministic truncation (facts walked in
+	// their already-sorted order). repoByCluster dedupes the cluster->repo edges.
+	rowidByFactID := make(map[string]int64, len(idByRow))
+	for rowid, fid := range idByRow {
+		rowidByFactID[fid] = rowid
+	}
+	repoByCluster := map[string]struct{}{}
+	clusterEdges := 0
 	for _, f := range facts {
-		if categoryEdges >= categoryEdgeCap {
+		if clusterEdges >= clusterEdgeCap {
 			break
 		}
-		cat := knowledgeCategory(f.Key)
-		if cat == "" {
+		rowid, ok := rowidByFactID[f.ID]
+		if !ok {
 			continue
 		}
-		edges = append(edges, dashboard.KnowledgeEdge{Source: f.ID, Target: cat, Kind: "category"})
-		categoryEdges++
+		cid, ok := membByRow[rowid]
+		if !ok {
+			continue // fact not yet clustered (no recompute run, or attach pending)
+		}
+		hub := clusterHubID(cid)
+		edges = append(edges, dashboard.KnowledgeEdge{Source: f.ID, Target: hub, Kind: "cluster"})
+		clusterEdges++
+		// repo tier: link this cluster to the repo the fact belongs to (general
+		// scope -> the "general" repo hub) once per (cluster, repo).
+		repoHub := knowledgeRepoHub(f.Repo)
+		key := hub + "\x00" + repoHub
+		if _, seen := repoByCluster[key]; !seen {
+			repoByCluster[key] = struct{}{}
+			edges = append(edges, dashboard.KnowledgeEdge{Source: hub, Target: repoHub, Kind: "repo"})
+		}
 	}
 
 	// supersede: the newer fact -> the older fact it replaced. confirmed_memories
@@ -372,23 +412,24 @@ func knowledgeEdges(rows []db.ConfirmedMemory, facts []dashboard.KnowledgeFact, 
 	return edges
 }
 
-// knowledgeCategory derives a fact's category-hub id from its memory key. The
-// confirmed-memory writers key facts by a colon-delimited, closed-category form
-// (`fix-rounds:<decision>`, `outcome:<action>:<decision>`), so the LEADING
-// dimension is the category family. The hub id is namespaced `cat:<family>` so it
-// never collides with a fact id ("fact:<n>") or an agent name. An empty/keyless
-// fact yields "" (no category edge).
-func knowledgeCategory(key string) string {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return ""
+// clusterHubID is the stable hub node id for an emergent cluster. It is
+// namespaced "cluster:<id>" so it never collides with a fact id ("fact:<n>") or an
+// agent name. The reserved unclustered bucket (id 0) maps to the fixed
+// unclusteredHubID so those facts group together.
+func clusterHubID(clusterID int64) string {
+	if clusterID == memory.UnclusteredID {
+		return unclusteredHubID
 	}
-	family := key
-	if i := strings.Index(key, ":"); i >= 0 {
-		family = strings.TrimSpace(key[:i])
+	return "cluster:" + strconv.FormatInt(clusterID, 10)
+}
+
+// knowledgeRepoHub is the top-tier repo hub node id. A general-scope fact (empty
+// repo) maps to the fixed "repo:general" hub. Namespaced "repo:" so it never
+// collides with a fact, agent, or cluster id.
+func knowledgeRepoHub(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return "repo:general"
 	}
-	if family == "" {
-		return ""
-	}
-	return "cat:" + family
+	return "repo:" + repo
 }

--- a/internal/cli/dashboard_web_learning_test.go
+++ b/internal/cli/dashboard_web_learning_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
 )
 
 // reviewScoreSeed pins a candidate-review score (the nullable REAL column, carried
@@ -320,22 +322,19 @@ func TestWebDataSourceKnowledge(t *testing.T) {
 		t.Fatalf("F3 must be general-scope (empty repo), got %q", byContent["F3"].Repo)
 	}
 
-	// Edges by kind.
-	var owner, category, supersede int
+	// Edges by kind. seedKnowledge does not run a cluster recompute, so with no
+	// persisted membership the graph emits NO cluster/repo edges (fail-open) — the
+	// repo->cluster->fact hierarchy is exercised in TestKnowledgeClusterHierarchy.
+	var owner, cluster, repo, supersede int
 	var superEdge dashboard.KnowledgeEdge
-	catTarget := map[string]int{}
 	for _, e := range k.Edges {
 		switch e.Kind {
 		case "owner":
 			owner++
-		case "category":
-			category++
-			if e.Source == byContent["F1"].ID {
-				catTarget["F1"] = 1
-				if e.Target != "cat:outcome" {
-					t.Fatalf("F1 category target = %q, want cat:outcome (leading key dimension)", e.Target)
-				}
-			}
+		case "cluster":
+			cluster++
+		case "repo":
+			repo++
 		case "supersede":
 			supersede++
 			superEdge = e
@@ -343,17 +342,14 @@ func TestWebDataSourceKnowledge(t *testing.T) {
 			t.Fatalf("unexpected edge kind %q", e.Kind)
 		}
 	}
-	if owner != 7 || category != 7 || supersede != 1 {
-		t.Fatalf("edges = owner%d category%d supersede%d, want 7/7/1", owner, category, supersede)
+	if owner != 7 || cluster != 0 || repo != 0 || supersede != 1 {
+		t.Fatalf("edges = owner%d cluster%d repo%d supersede%d, want 7/0/0/1", owner, cluster, repo, supersede)
 	}
 	// Supersede direction: newer fact -> older fact.
 	wantNew := fmt.Sprintf("fact:%d", newID)
 	wantOld := fmt.Sprintf("fact:%d", oldID)
 	if superEdge.Source != wantNew || superEdge.Target != wantOld {
 		t.Fatalf("supersede edge = %s->%s, want %s->%s (newer->older)", superEdge.Source, superEdge.Target, wantNew, wantOld)
-	}
-	if catTarget["F1"] != 1 {
-		t.Fatalf("F1 must have a category edge")
 	}
 
 	// Determinism: a second call is byte-identical.
@@ -366,48 +362,122 @@ func TestWebDataSourceKnowledge(t *testing.T) {
 	}
 }
 
-// TestKnowledgeCategory covers the key -> category-hub derivation.
-func TestKnowledgeCategory(t *testing.T) {
-	cases := map[string]string{
-		"outcome:review:changes_requested": "cat:outcome",
-		"fix-rounds:approved":              "cat:fix-rounds",
-		"release-policy":                   "cat:release-policy",
-		"":                                 "",
-		":x":                               "",
-		"   ":                              "",
+// TestKnowledgeClusterHierarchy seeds a store, recomputes the emergent clusters,
+// and asserts the Knowledge bridge emits the repo->cluster->fact hierarchy: every
+// clustered fact has a fact->cluster edge, and each cluster links up to its
+// members' repo hub.
+func TestKnowledgeClusterHierarchy(t *testing.T) {
+	home := dashboardTestHome(t)
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open: %v", err)
 	}
-	for key, want := range cases {
-		if got := knowledgeCategory(key); got != want {
-			t.Fatalf("knowledgeCategory(%q) = %q, want %q", key, got, want)
+	dbIDs, netIDs := seedClusterCorpus(t, store)
+	store.Close()
+
+	// Build the clustering via the CLI (first-run apply).
+	var b bytes.Buffer
+	if code := runMemory([]string{"clusters", "recompute", "--apply", "--home", home}, &b, &b); code != 0 {
+		t.Fatalf("recompute apply exit %d: %s", code, b.String())
+	}
+
+	ds := &webDataSource{home: home}
+	k, err := ds.Knowledge(context.Background())
+	if err != nil {
+		t.Fatalf("Knowledge: %v", err)
+	}
+
+	// Index edges.
+	clusterOfFact := map[string]string{} // fact id -> cluster hub
+	repoOfCluster := map[string]string{} // cluster hub -> repo hub
+	var clusterEdges, repoEdges int
+	for _, e := range k.Edges {
+		switch e.Kind {
+		case "cluster":
+			clusterOfFact[e.Source] = e.Target
+			clusterEdges++
+		case "repo":
+			repoOfCluster[e.Source] = e.Target
+			repoEdges++
 		}
+	}
+	if clusterEdges != len(dbIDs)+len(netIDs) {
+		t.Fatalf("cluster edges = %d, want %d (one per fact)", clusterEdges, len(dbIDs)+len(netIDs))
+	}
+	if repoEdges == 0 {
+		t.Fatalf("expected cluster->repo edges for the repo tier, got none")
+	}
+
+	// All db facts share one cluster hub; all net facts share another; the hubs
+	// differ and each links to the acme/widget repo hub.
+	dbHub := clusterOfFact["fact:"+itoaTest(dbIDs[0])]
+	for _, id := range dbIDs {
+		if got := clusterOfFact["fact:"+itoaTest(id)]; got != dbHub {
+			t.Fatalf("db fact %d -> %q, want %q", id, got, dbHub)
+		}
+	}
+	netHub := clusterOfFact["fact:"+itoaTest(netIDs[0])]
+	if dbHub == "" || netHub == "" || dbHub == netHub {
+		t.Fatalf("db/net hubs must be distinct and non-empty: %q %q", dbHub, netHub)
+	}
+	if repoOfCluster[dbHub] != "repo:acme/widget" {
+		t.Fatalf("db cluster repo hub = %q, want repo:acme/widget", repoOfCluster[dbHub])
+	}
+
+	// Determinism: a second bridge call is byte-identical.
+	k2, err := ds.Knowledge(context.Background())
+	if err != nil {
+		t.Fatalf("Knowledge (2nd): %v", err)
+	}
+	if fmt.Sprintf("%+v", k) != fmt.Sprintf("%+v", k2) {
+		t.Fatalf("Knowledge not deterministic across calls")
 	}
 }
 
-// TestKnowledgeEdgesCategoryCap asserts the category-edge cap truncates
-// deterministically while owner edges stay uncapped.
-func TestKnowledgeEdgesCategoryCap(t *testing.T) {
-	const n = categoryEdgeCap + 100
-	facts := make([]dashboard.KnowledgeFact, 0, n)
-	for i := 0; i < n; i++ {
-		facts = append(facts, dashboard.KnowledgeFact{
-			ID: fmt.Sprintf("fact:%d", i), Owner: "researcher", Key: fmt.Sprintf("outcome:%d", i),
-		})
+// TestClusterHubID covers the cluster/repo hub-id derivation.
+func TestClusterHubID(t *testing.T) {
+	if got := clusterHubID(3); got != "cluster:3" {
+		t.Fatalf("clusterHubID(3) = %q, want cluster:3", got)
 	}
-	edges := knowledgeEdges(nil, facts, map[int64]string{})
+	if got := clusterHubID(memory.UnclusteredID); got != unclusteredHubID {
+		t.Fatalf("clusterHubID(0) = %q, want %q", got, unclusteredHubID)
+	}
+	if got := knowledgeRepoHub(""); got != "repo:general" {
+		t.Fatalf("knowledgeRepoHub(\"\") = %q, want repo:general", got)
+	}
+	if got := knowledgeRepoHub("acme/widget"); got != "repo:acme/widget" {
+		t.Fatalf("knowledgeRepoHub = %q, want repo:acme/widget", got)
+	}
+}
 
-	var owner, category int
+// TestKnowledgeEdgesClusterCap asserts the cluster-edge cap truncates
+// deterministically while owner edges stay uncapped.
+func TestKnowledgeEdgesClusterCap(t *testing.T) {
+	const n = clusterEdgeCap + 100
+	facts := make([]dashboard.KnowledgeFact, 0, n)
+	idByRow := make(map[int64]string, n)
+	membByRow := make(map[int64]int64, n)
+	for i := 0; i < n; i++ {
+		fid := fmt.Sprintf("fact:%d", i)
+		facts = append(facts, dashboard.KnowledgeFact{ID: fid, Owner: "researcher"})
+		idByRow[int64(i)] = fid
+		membByRow[int64(i)] = 1 // all in one cluster
+	}
+	edges := knowledgeEdges(nil, facts, idByRow, membByRow)
+
+	var owner, cluster int
 	for _, e := range edges {
 		switch e.Kind {
 		case "owner":
 			owner++
-		case "category":
-			category++
+		case "cluster":
+			cluster++
 		}
 	}
 	if owner != n {
 		t.Fatalf("owner edges = %d, want %d (uncapped)", owner, n)
 	}
-	if category != categoryEdgeCap {
-		t.Fatalf("category edges = %d, want %d (capped)", category, categoryEdgeCap)
+	if cluster != clusterEdgeCap {
+		t.Fatalf("cluster edges = %d, want %d (capped)", cluster, clusterEdgeCap)
 	}
 }

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -42,6 +42,14 @@ func runMemory(args []string, stdout, stderr io.Writer) int {
 		return runMemoryConfirm(args[1:], stdout, stderr)
 	case "groom":
 		return runMemoryGroom(args[1:], stdout, stderr)
+	case "clusters":
+		return runMemoryClusters(args[1:], stdout, stderr)
+	case "cluster":
+		if len(args) >= 2 && args[1] == "rename" {
+			return runMemoryClusterRename(args[2:], stdout, stderr)
+		}
+		fmt.Fprintln(stderr, "usage: gitmoot memory cluster rename <cluster-id> <label>")
+		return 2
 	default:
 		fmt.Fprintf(stderr, "unknown memory command %q\n\n", args[0])
 		printMemoryUsage(stderr)
@@ -61,6 +69,9 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory groom --propose [--out PLAN.json] [--json] | --yes --plan PLAN.json [--json]")
+	fmt.Fprintln(w, "  gitmoot memory clusters [--json]")
+	fmt.Fprintln(w, "  gitmoot memory clusters recompute --propose [--out PLAN.json] [--json] | --apply [--plan PLAN.json] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory cluster rename <cluster-id> <label>")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  list          show stored memories (confirmed and/or pending observations)")
 	fmt.Fprintln(w, "  replay        offline A/B: render recent real jobs' prompts with vs without the")
@@ -71,6 +82,8 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  observations  list pending observations, flagging which keys are already confirmed")
 	fmt.Fprintln(w, "  confirm       human-gated promotion of pending observations into confirmed memory")
 	fmt.Fprintln(w, "  groom         deterministically propose stale-memory retirements, apply on confirmation")
+	fmt.Fprintln(w, "  clusters      list emergent memory clusters; recompute them via a propose/apply plan")
+	fmt.Fprintln(w, "  cluster       rename a cluster (owner label override)")
 }
 
 // ---- memory list ----------------------------------------------------------

--- a/internal/cli/memory_clusters.go
+++ b/internal/cli/memory_clusters.go
@@ -1,0 +1,617 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+)
+
+// memory clusters (#763 Track A) — emergent community detection over the fact
+// similarity graph, surfaced as an explicit list + a human-gated propose→apply
+// recompute round-trip, mirroring the `memory groom` staleness-anchored pattern.
+//
+// The clustering is DETERMINISTIC: the graph is the same bm25+id-tiebreak signal
+// the vault [[links]] use, and the community detection (internal/memory) is a
+// pure function with fixed iteration order and tie-breaks — the same store always
+// yields byte-identical clusters, labels, medoids, and ids.
+
+// clusterPlanSchemaVersion is the on-disk recompute-plan schema version.
+const clusterPlanSchemaVersion = 1
+
+// clusterLinkK is the k-NN degree per fact — the same neighbor count the vault
+// links render (vaultLinkK), so clusters emerge from the exact same signal.
+const clusterLinkK = vaultLinkK
+
+// clusterPlanCluster is one proposed community in the plan (the apply path writes
+// these verbatim). Members are ascending fact ids.
+type clusterPlanCluster struct {
+	ClusterID int64   `json:"cluster_id"`
+	Label     string  `json:"label"`
+	MedoidID  int64   `json:"medoid_id"`
+	Members   []int64 `json:"members"`
+}
+
+// clusterPlanMove is one fact that lands in a different cluster than it currently
+// occupies (a review-only diff; apply writes the whole assignment, not moves).
+type clusterPlanMove struct {
+	MemoryID    int64 `json:"memory_id"`
+	FromCluster int64 `json:"from_cluster"`
+	ToCluster   int64 `json:"to_cluster"`
+}
+
+// clusterPlan is the reviewable artifact `recompute --propose` writes and
+// `recompute --apply --plan` reads. Anchor is the staleness guard over the active
+// facts' (id, updated_at); a mismatch at apply aborts as stale.
+type clusterPlan struct {
+	SchemaVersion int                  `json:"schema_version"`
+	Anchor        string               `json:"anchor"`
+	Clusters      []clusterPlanCluster `json:"clusters"`
+	Moves         []clusterPlanMove    `json:"moves"`
+	NewFacts      []int64              `json:"new_facts,omitempty"`     // facts not previously in any cluster
+	DroppedFacts  []int64              `json:"dropped_facts,omitempty"` // previously-clustered facts now gone/retired
+	Stats         clusterPlanStats     `json:"stats"`
+}
+
+type clusterPlanStats struct {
+	Facts       int `json:"facts"`
+	Clusters    int `json:"clusters"`    // real communities (excludes the unclustered bucket)
+	Unclustered int `json:"unclustered"` // facts in the reserved bucket
+	Moves       int `json:"moves"`
+}
+
+// runMemoryClusters is the `gitmoot memory clusters ...` entry point (list +
+// recompute).
+func runMemoryClusters(args []string, stdout, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "recompute" {
+		return runMemoryClustersRecompute(args[1:], stdout, stderr)
+	}
+	return runMemoryClustersList(args, stdout, stderr)
+}
+
+// ---- memory clusters (list) -----------------------------------------------
+
+type clusterListEntry struct {
+	ClusterID int64  `json:"cluster_id"`
+	Label     string `json:"label"`
+	Override  string `json:"label_override,omitempty"`
+	MedoidID  int64  `json:"medoid_id"`
+	Count     int    `json:"count"`
+}
+
+func runMemoryClustersList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory clusters", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print as JSON")
+	if err := parseMemoryFlags(fs, args); err != nil {
+		return memoryFlagExit(err)
+	}
+
+	var entries []clusterListEntry
+	err := withReadOnlyStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		clusters, err := store.ListMemoryClusters(ctx)
+		if err != nil {
+			return err
+		}
+		counts, err := store.MemoryClusterCounts(ctx)
+		if err != nil {
+			return err
+		}
+		entries = make([]clusterListEntry, 0, len(clusters))
+		for _, c := range clusters {
+			entries = append(entries, clusterListEntry{
+				ClusterID: c.ClusterID, Label: c.DisplayLabel(), Override: c.LabelOverride,
+				MedoidID: c.MedoidID, Count: counts[c.ClusterID],
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory clusters: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		if err := writeJSON(stdout, entries); err != nil {
+			fmt.Fprintf(stderr, "memory clusters: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(stdout, "no clusters (run `gitmoot memory clusters recompute --apply` to build them)")
+		return 0
+	}
+	for _, e := range entries {
+		fmt.Fprintf(stdout, "%-4d %-32s %5d facts (medoid %d)\n", e.ClusterID, e.Label, e.Count, e.MedoidID)
+	}
+	return 0
+}
+
+// ---- memory clusters recompute (propose/apply) ----------------------------
+
+func runMemoryClustersRecompute(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory clusters recompute", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	propose := fs.Bool("propose", false, "compute clusters and write a reviewable plan (writes nothing to the store)")
+	apply := fs.Bool("apply", false, "apply a plan (with --plan), or on first run compute+write directly")
+	plan := fs.String("plan", "", "path to a plan produced by --propose (required with --apply once clusters exist)")
+	out := fs.String("out", "", "where --propose writes the plan (default: <home>/evals/clusters/clusters-<anchor>.json)")
+	jsonOut := fs.Bool("json", false, "print the summary as JSON")
+	if err := parseMemoryFlags(fs, args); err != nil {
+		return memoryFlagExit(err)
+	}
+	if *propose == *apply {
+		fmt.Fprintln(stderr, "memory clusters recompute: pass exactly one of --propose or --apply")
+		return 2
+	}
+	if *propose {
+		return runMemoryClustersPropose(*home, *out, *jsonOut, stdout, stderr)
+	}
+	return runMemoryClustersApply(*home, *plan, *jsonOut, stdout, stderr)
+}
+
+func runMemoryClustersPropose(home, out string, jsonOut bool, stdout, stderr io.Writer) int {
+	var plan clusterPlan
+	err := withReadOnlyStore(home, func(store *db.Store) error {
+		ctx := context.Background()
+		built, anchor, err := buildClusterAssignment(ctx, store)
+		if err != nil {
+			return err
+		}
+		current, err := currentMembership(ctx, store)
+		if err != nil {
+			return err
+		}
+		plan = makeClusterPlan(built, anchor, current)
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory clusters recompute: %v\n", err)
+		return 1
+	}
+
+	outPath := out
+	if outPath == "" {
+		paths, perr := pathsFromFlag(home)
+		if perr != nil {
+			fmt.Fprintf(stderr, "memory clusters recompute: %v\n", perr)
+			return 1
+		}
+		short := plan.Anchor
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		outPath = filepath.Join(paths.Evals, "clusters", "clusters-"+short+".json")
+	}
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		fmt.Fprintf(stderr, "memory clusters recompute: create plan dir: %v\n", err)
+		return 1
+	}
+	if err := writeJSONFile(outPath, plan); err != nil {
+		fmt.Fprintf(stderr, "memory clusters recompute: write plan: %v\n", err)
+		return 1
+	}
+
+	if jsonOut {
+		summary := struct {
+			clusterPlan
+			Out string `json:"out"`
+		}{clusterPlan: plan, Out: outPath}
+		if err := writeJSON(stdout, summary); err != nil {
+			fmt.Fprintf(stderr, "memory clusters recompute: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printClusterProposal(stdout, plan, outPath)
+	return 0
+}
+
+func runMemoryClustersApply(home, planPath string, jsonOut bool, stdout, stderr io.Writer) int {
+	type applyResult struct {
+		Anchor      string `json:"anchor"`
+		Applied     bool   `json:"applied"`
+		FirstRun    bool   `json:"first_run"`
+		Clusters    int    `json:"clusters"`
+		Unclustered int    `json:"unclustered"`
+		Facts       int    `json:"facts"`
+	}
+	var result applyResult
+
+	err := withStore(home, func(store *db.Store) error {
+		ctx := context.Background()
+
+		// First-run shortcut: with no clusters yet there is nothing to protect, so
+		// `--apply` without a plan may compute + write directly.
+		if planPath == "" {
+			n, err := store.CountMemoryClusters(ctx)
+			if err != nil {
+				return err
+			}
+			if n > 0 {
+				return fmt.Errorf("clusters already exist: `--apply` requires a reviewed `--plan` (run `--propose` first); a bare `--apply` is only allowed on first run")
+			}
+			built, anchor, err := buildClusterAssignment(ctx, store)
+			if err != nil {
+				return err
+			}
+			if err := store.RecomputeMemoryClusters(ctx, built.assignment); err != nil {
+				return err
+			}
+			result = applyResult{Anchor: anchor, Applied: true, FirstRun: true,
+				Clusters: built.realClusters, Unclustered: built.unclustered, Facts: built.facts}
+			return nil
+		}
+
+		plan, err := readClusterPlan(planPath)
+		if err != nil {
+			return err
+		}
+		// Recompute the CURRENT anchor and abort if the store moved since the plan was
+		// proposed — a fact added/edited/retired in the window would make the plan
+		// target stale ids.
+		_, freshAnchor, err := buildClusterAssignment(ctx, store)
+		if err != nil {
+			return err
+		}
+		if freshAnchor != plan.Anchor {
+			return fmt.Errorf("plan is stale: the memory store changed since it was proposed (plan anchor %s, current %s); re-run `gitmoot memory clusters recompute --propose` and re-review", plan.Anchor, freshAnchor)
+		}
+		assignment := planAssignment(plan)
+		if err := store.RecomputeMemoryClusters(ctx, assignment); err != nil {
+			return err
+		}
+		real, unc := countPlanBuckets(plan)
+		result = applyResult{Anchor: freshAnchor, Applied: true, Clusters: real,
+			Unclustered: unc, Facts: len(plan.members())}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory clusters recompute: %v\n", err)
+		return 1
+	}
+
+	if jsonOut {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "memory clusters recompute: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	kind := "applied"
+	if result.FirstRun {
+		kind = "applied (first run)"
+	}
+	fmt.Fprintf(stdout, "%s: %d cluster(s), %d unclustered fact(s) across %d fact(s) (anchor %s)\n",
+		kind, result.Clusters, result.Unclustered, result.Facts, result.Anchor)
+	return 0
+}
+
+// ---- memory cluster rename ------------------------------------------------
+
+func runMemoryClusterRename(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory cluster rename", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	// Documented form is `rename <cluster-id> <label> [flags]`, but Go's flag parser
+	// stops at the first positional, so trailing --home would be silently dropped.
+	// Peel the leading positionals (everything before the first flag) off the front,
+	// then flag-parse the remainder — the `memory ingest` pattern, and it handles the
+	// `--home <value>` form correctly.
+	var positionals, flagArgs []string
+	i := 0
+	for i < len(args) && !strings.HasPrefix(args[i], "-") {
+		positionals = append(positionals, args[i])
+		i++
+	}
+	flagArgs = args[i:]
+	if err := parseMemoryFlags(fs, flagArgs); err != nil {
+		return memoryFlagExit(err)
+	}
+	if len(positionals) < 2 {
+		fmt.Fprintln(stderr, "memory cluster rename: usage: gitmoot memory cluster rename <cluster-id> <label>")
+		return 2
+	}
+	clusterID, err := strconv.ParseInt(strings.TrimSpace(positionals[0]), 10, 64)
+	if err != nil {
+		fmt.Fprintf(stderr, "memory cluster rename: invalid cluster id %q\n", positionals[0])
+		return 2
+	}
+	label := strings.TrimSpace(strings.Join(positionals[1:], " "))
+	if label == "" {
+		fmt.Fprintln(stderr, "memory cluster rename: label cannot be empty")
+		return 2
+	}
+	err = withStore(*home, func(store *db.Store) error {
+		return store.RenameMemoryCluster(context.Background(), clusterID, label)
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory cluster rename: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "renamed cluster %d to %q\n", clusterID, label)
+	return 0
+}
+
+// ---- graph construction + plan helpers ------------------------------------
+
+// builtClustering bundles the pure clustering result mapped into a store
+// assignment plus a few counts for reporting.
+type builtClustering struct {
+	assignment   db.MemoryClusterAssignment
+	realClusters int
+	unclustered  int
+	facts        int
+}
+
+// buildClusterAssignment reads every active confirmed fact, builds the undirected
+// k-NN similarity graph from the SAME bm25+id-tiebreak neighbor ranking the vault
+// links use, runs the deterministic community detection, and maps the result into
+// a store assignment. It also returns the staleness anchor over the active facts'
+// (id, updated_at). Read-only.
+func buildClusterAssignment(ctx context.Context, store *db.Store) (builtClustering, string, error) {
+	rows, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		return builtClustering{}, "", err
+	}
+
+	nodes := make([]memory.ClusterNode, 0, len(rows))
+	var edges []memory.ClusterEdge
+	for _, r := range rows {
+		// The similarity GRAPH reuses the exact vault-link signal (key+content, via
+		// vaultLinksFor below); the label is recomputed from CONTENT only, so a fact's
+		// mechanical key slug/hash (e.g. an ingest "untitled-<hash>" stem) never
+		// pollutes a cluster label.
+		nodes = append(nodes, memory.ClusterNode{ID: r.ID, Text: r.Content})
+		links, lerr := vaultLinksFor(ctx, store, r)
+		if lerr != nil {
+			return builtClustering{}, "", lerr
+		}
+		// Rank-based directed weight: the closest neighbor (rank 0) contributes the
+		// most. BuildClusters symmetrizes and sums both directions, so a mutually
+		// top-ranked pair gets the heaviest undirected edge.
+		for rank, l := range links {
+			w := clusterLinkK - rank
+			if w <= 0 {
+				continue
+			}
+			edges = append(edges, memory.ClusterEdge{A: r.ID, B: l.TargetID, Weight: w})
+		}
+	}
+
+	res := memory.BuildClusters(nodes, edges)
+	built := builtClustering{facts: len(rows)}
+	for _, c := range res.Clusters {
+		built.assignment.Clusters = append(built.assignment.Clusters, db.MemoryCluster{
+			ClusterID: c.ID, Label: c.Label, MedoidID: c.MedoidID,
+		})
+		for _, m := range c.Members {
+			built.assignment.Members = append(built.assignment.Members, db.MemoryClusterMember{
+				MemoryID: m, ClusterID: c.ID,
+			})
+		}
+		if c.ID == memory.UnclusteredID {
+			built.unclustered = len(c.Members)
+		} else {
+			built.realClusters++
+		}
+	}
+	return built, clusterAnchor(rows), nil
+}
+
+// clusterAnchor is the deterministic staleness anchor: sha256 over the active
+// facts' (id, updated_at) in id order. A new/edited/retired fact changes it,
+// which aborts a stale apply.
+func clusterAnchor(rows []db.ConfirmedMemory) string {
+	ordered := append([]db.ConfirmedMemory(nil), rows...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].ID < ordered[j].ID })
+	h := sha256.New()
+	for _, r := range ordered {
+		fmt.Fprintf(h, "%d:%s\n", r.ID, r.UpdatedAt)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// currentMembership reads the persisted fact->cluster map for the propose diff.
+func currentMembership(ctx context.Context, store *db.Store) (map[int64]int64, error) {
+	members, err := store.ListMemoryClusterMembers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[int64]int64, len(members))
+	for _, m := range members {
+		out[m.MemoryID] = m.ClusterID
+	}
+	return out, nil
+}
+
+// makeClusterPlan builds the reviewable plan from the freshly built clustering
+// and the current persisted membership (for the moves/new/dropped diff).
+func makeClusterPlan(built builtClustering, anchor string, current map[int64]int64) clusterPlan {
+	plan := clusterPlan{SchemaVersion: clusterPlanSchemaVersion, Anchor: anchor}
+	byCluster := map[int64][]int64{}
+	for _, m := range built.assignment.Members {
+		byCluster[m.ClusterID] = append(byCluster[m.ClusterID], m.MemoryID)
+	}
+	for _, c := range built.assignment.Clusters {
+		members := append([]int64(nil), byCluster[c.ClusterID]...)
+		sort.Slice(members, func(i, j int) bool { return members[i] < members[j] })
+		plan.Clusters = append(plan.Clusters, clusterPlanCluster{
+			ClusterID: c.ClusterID, Label: c.Label, MedoidID: c.MedoidID, Members: members,
+		})
+	}
+	// Diff: moves (fact changed cluster), new facts (not previously clustered),
+	// dropped facts (previously clustered, now absent).
+	proposed := map[int64]int64{}
+	for _, m := range built.assignment.Members {
+		proposed[m.MemoryID] = m.ClusterID
+	}
+	for _, fid := range sortedInt64Keys(proposed) {
+		to := proposed[fid]
+		from, ok := current[fid]
+		if !ok {
+			plan.NewFacts = append(plan.NewFacts, fid)
+			continue
+		}
+		if from != to {
+			plan.Moves = append(plan.Moves, clusterPlanMove{MemoryID: fid, FromCluster: from, ToCluster: to})
+		}
+	}
+	for _, fid := range sortedInt64Keys(current) {
+		if _, ok := proposed[fid]; !ok {
+			plan.DroppedFacts = append(plan.DroppedFacts, fid)
+		}
+	}
+	plan.Stats = clusterPlanStats{
+		Facts: built.facts, Clusters: built.realClusters, Unclustered: built.unclustered,
+		Moves: len(plan.Moves),
+	}
+	return plan
+}
+
+// members returns every fact id referenced by the plan's clusters.
+func (p clusterPlan) members() []int64 {
+	var out []int64
+	for _, c := range p.Clusters {
+		out = append(out, c.Members...)
+	}
+	return out
+}
+
+// planAssignment maps a reviewed plan back into a store assignment for apply.
+func planAssignment(p clusterPlan) db.MemoryClusterAssignment {
+	var a db.MemoryClusterAssignment
+	for _, c := range p.Clusters {
+		a.Clusters = append(a.Clusters, db.MemoryCluster{
+			ClusterID: c.ClusterID, Label: c.Label, MedoidID: c.MedoidID,
+		})
+		for _, m := range c.Members {
+			a.Members = append(a.Members, db.MemoryClusterMember{MemoryID: m, ClusterID: c.ClusterID})
+		}
+	}
+	return a
+}
+
+func countPlanBuckets(p clusterPlan) (real, unclustered int) {
+	for _, c := range p.Clusters {
+		if c.ClusterID == memory.UnclusteredID {
+			unclustered = len(c.Members)
+		} else {
+			real++
+		}
+	}
+	return real, unclustered
+}
+
+func readClusterPlan(path string) (clusterPlan, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return clusterPlan{}, fmt.Errorf("read plan %s: %w", path, err)
+	}
+	var plan clusterPlan
+	if err := json.Unmarshal(data, &plan); err != nil {
+		return clusterPlan{}, fmt.Errorf("%s is not a valid cluster plan: %w", path, err)
+	}
+	if plan.SchemaVersion != clusterPlanSchemaVersion {
+		return clusterPlan{}, fmt.Errorf("cluster plan schema v%d is not supported by this build (expected v%d); re-run `gitmoot memory clusters recompute --propose`", plan.SchemaVersion, clusterPlanSchemaVersion)
+	}
+	if plan.Anchor == "" {
+		return clusterPlan{}, fmt.Errorf("%s has no anchor; re-run `gitmoot memory clusters recompute --propose`", path)
+	}
+	return plan, nil
+}
+
+func printClusterProposal(w io.Writer, plan clusterPlan, outPath string) {
+	fmt.Fprintf(w, "cluster proposal (anchor %s)\n", plan.Anchor)
+	fmt.Fprintf(w, "  %d fact(s) -> %d cluster(s), %d unclustered; %d move(s), %d new, %d dropped\n",
+		plan.Stats.Facts, plan.Stats.Clusters, plan.Stats.Unclustered,
+		len(plan.Moves), len(plan.NewFacts), len(plan.DroppedFacts))
+	for _, c := range plan.Clusters {
+		if c.ClusterID == memory.UnclusteredID {
+			continue
+		}
+		fmt.Fprintf(w, "  cluster %d [%s] %d fact(s) (medoid %d)\n", c.ClusterID, c.Label, len(c.Members), c.MedoidID)
+	}
+	if len(plan.Moves) > 0 {
+		fmt.Fprintln(w, "\nMoves:")
+		for _, m := range plan.Moves {
+			fmt.Fprintf(w, "  - fact %d: cluster %d -> %d\n", m.MemoryID, m.FromCluster, m.ToCluster)
+		}
+	}
+	fmt.Fprintf(w, "\nplan written to %s\n", outPath)
+	fmt.Fprintf(w, "review it, then apply with: gitmoot memory clusters recompute --apply --plan %s\n", outPath)
+}
+
+// attachConfirmedFactToCluster incrementally attaches a freshly confirmed fact to
+// the cluster of its nearest similarity neighbor, using the SAME bm25+id-tiebreak
+// ranking the vault links and the full recompute use. It is best-effort and
+// fail-safe: any error (no clusters yet, no neighbor, a store hiccup) is swallowed
+// so a confirmation is never blocked. A fact already assigned to a cluster is left
+// alone (a content re-confirm never re-shelves it); a fact with no clustered
+// neighbor falls into the reserved 'unclustered' bucket when it exists.
+func attachConfirmedFactToCluster(ctx context.Context, store *db.Store, cm db.ConfirmedMemory) {
+	// Nothing to attach to until a clustering has been built at least once.
+	if n, err := store.CountMemoryClusters(ctx); err != nil || n == 0 {
+		return
+	}
+	// Don't re-shelve a fact that already has an assignment.
+	if _, ok, err := store.ClusterOfMemory(ctx, cm.ID); err != nil || ok {
+		return
+	}
+	links, err := vaultLinksFor(ctx, store, cm)
+	if err != nil {
+		return
+	}
+	for _, l := range links {
+		if l.TargetID == cm.ID {
+			continue
+		}
+		if cid, ok, err := store.ClusterOfMemory(ctx, l.TargetID); err == nil && ok {
+			_ = store.AssignMemoryToCluster(ctx, cm.ID, cid)
+			return
+		}
+	}
+	// No clustered neighbor: fall into the unclustered bucket if it exists.
+	if bucketExists(ctx, store) {
+		_ = store.AssignMemoryToCluster(ctx, cm.ID, memory.UnclusteredID)
+	}
+}
+
+// bucketExists reports whether the reserved unclustered cluster row is present.
+func bucketExists(ctx context.Context, store *db.Store) bool {
+	clusters, err := store.ListMemoryClusters(ctx)
+	if err != nil {
+		return false
+	}
+	for _, c := range clusters {
+		if c.ClusterID == memory.UnclusteredID {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedInt64Keys returns the ascending keys of an int64-keyed map (deterministic
+// iteration for the plan diff).
+func sortedInt64Keys[V any](m map[int64]V) []int64 {
+	out := make([]int64, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}

--- a/internal/cli/memory_clusters.go
+++ b/internal/cli/memory_clusters.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -261,22 +262,22 @@ func runMemoryClustersApply(home, planPath string, jsonOut bool, stdout, stderr 
 		if err != nil {
 			return err
 		}
-		// Recompute the CURRENT anchor and abort if the store moved since the plan was
-		// proposed — a fact added/edited/retired in the window would make the plan
-		// target stale ids.
-		_, freshAnchor, err := buildClusterAssignment(ctx, store)
-		if err != nil {
-			return err
-		}
-		if freshAnchor != plan.Anchor {
-			return fmt.Errorf("plan is stale: the memory store changed since it was proposed (plan anchor %s, current %s); re-run `gitmoot memory clusters recompute --propose` and re-review", plan.Anchor, freshAnchor)
-		}
+		// Verify the CURRENT anchor and perform the destructive rewrite ATOMICALLY:
+		// RecomputeMemoryClustersFresh re-reads the active-fact anchor inside the same
+		// transaction as the delete/insert, so a fact confirmed/edited/retired in the
+		// window between propose and apply cannot slip through — it either changes the
+		// anchor (stale) or invalidates the write snapshot. A prior split (anchor read
+		// then a separate rewrite tx) left a TOCTOU window where a concurrent
+		// attachConfirmedFactToCluster member row was silently dropped by the DELETE.
 		assignment := planAssignment(plan)
-		if err := store.RecomputeMemoryClusters(ctx, assignment); err != nil {
+		if err := store.RecomputeMemoryClustersFresh(ctx, assignment, plan.Anchor, clusterAnchor); err != nil {
+			if errors.Is(err, db.ErrClusterPlanStale) {
+				return fmt.Errorf("plan is stale: the memory store changed since it was proposed (%v); re-run `gitmoot memory clusters recompute --propose` and re-review", err)
+			}
 			return err
 		}
 		real, unc := countPlanBuckets(plan)
-		result = applyResult{Anchor: freshAnchor, Applied: true, Clusters: real,
+		result = applyResult{Anchor: plan.Anchor, Applied: true, Clusters: real,
 			Unclustered: unc, Facts: len(plan.members())}
 		return nil
 	})

--- a/internal/cli/memory_clusters_test.go
+++ b/internal/cli/memory_clusters_test.go
@@ -1,0 +1,308 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+)
+
+// seedClusterCorpus seeds two clearly separable communities (database facts vs
+// network facts) sharing an owner/repo so they are mutually FTS-visible, returning
+// the two id sets.
+func seedClusterCorpus(t *testing.T, store *db.Store) (dbIDs, netIDs []int64) {
+	t.Helper()
+	owner := db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: "researcher"}
+	dbIDs = []int64{
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "db-index", "database index speeds up query lookups on the table"),
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "db-cache", "database query cache reduces index scan latency"),
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "db-vacuum", "database vacuum reclaims index bloat after query churn"),
+	}
+	netIDs = []int64{
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "net-retry", "network retry backoff handles socket timeout gracefully"),
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "net-pool", "network socket pool reuses connections to cut retry cost"),
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "net-tls", "network tls handshake adds socket setup before retry"),
+	}
+	return dbIDs, netIDs
+}
+
+func clustersJSON(t *testing.T, home string) []clusterListEntry {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	if code := runMemory([]string{"clusters", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory clusters exit %d: %s", code, stderr.String())
+	}
+	var entries []clusterListEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("parse clusters json: %v (%s)", err, stdout.String())
+	}
+	return entries
+}
+
+// TestClustersFirstRunApplyAndList: on first run `recompute --apply` (no plan) is
+// allowed; it builds the two communities and the list surfaces them.
+func TestClustersFirstRunApplyAndList(t *testing.T) {
+	home, store := memoryTestHome(t)
+	dbIDs, netIDs := seedClusterCorpus(t, store)
+
+	var stdout, stderr bytes.Buffer
+	if code := runMemory([]string{"clusters", "recompute", "--apply", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("first-run apply exit %d: %s", code, stderr.String())
+	}
+
+	entries := clustersJSON(t, home)
+	real := 0
+	for _, e := range entries {
+		if e.ClusterID != memory.UnclusteredID {
+			real++
+		}
+	}
+	if real != 2 {
+		t.Fatalf("real clusters = %d, want 2: %+v", real, entries)
+	}
+
+	// The three db facts share one cluster; the three net facts share another; the
+	// two clusters differ.
+	ctx := context.Background()
+	dbc := clusterOf(t, store, ctx, dbIDs[0])
+	for _, id := range dbIDs {
+		if got := clusterOf(t, store, ctx, id); got != dbc {
+			t.Fatalf("db fact %d in cluster %d, want %d (same as sibling)", id, got, dbc)
+		}
+	}
+	netc := clusterOf(t, store, ctx, netIDs[0])
+	for _, id := range netIDs {
+		if got := clusterOf(t, store, ctx, id); got != netc {
+			t.Fatalf("net fact %d in cluster %d, want %d", id, got, netc)
+		}
+	}
+	if dbc == netc {
+		t.Fatalf("db and net facts must be in different clusters (both %d)", dbc)
+	}
+}
+
+// TestClustersApplyWithoutPlanRejectedWhenExist: once clusters exist, a bare
+// `--apply` (no plan) must be rejected — recompute has to go through propose.
+func TestClustersApplyWithoutPlanRejectedWhenExist(t *testing.T) {
+	home, store := memoryTestHome(t)
+	seedClusterCorpus(t, store)
+
+	var b bytes.Buffer
+	if code := runMemory([]string{"clusters", "recompute", "--apply", "--home", home}, &b, &b); code != 0 {
+		t.Fatalf("first apply exit %d: %s", code, b.String())
+	}
+	b.Reset()
+	code := runMemory([]string{"clusters", "recompute", "--apply", "--home", home}, &b, &b)
+	if code == 0 {
+		t.Fatalf("bare --apply with existing clusters must fail")
+	}
+	if !bytes.Contains(b.Bytes(), []byte("first run")) {
+		t.Fatalf("error should explain first-run-only; got %s", b.String())
+	}
+}
+
+// TestClustersProposeApplyStalenessAbort: a plan proposed then invalidated by a
+// new fact must abort as stale at apply.
+func TestClustersProposeApplyStalenessAbort(t *testing.T) {
+	home, store := memoryTestHome(t)
+	seedClusterCorpus(t, store)
+	ctx := context.Background()
+
+	// Build an initial clustering so recompute goes through the propose path.
+	var b bytes.Buffer
+	if code := runMemory([]string{"clusters", "recompute", "--apply", "--home", home}, &b, &b); code != 0 {
+		t.Fatalf("seed apply exit %d: %s", code, b.String())
+	}
+
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	b.Reset()
+	if code := runMemory([]string{"clusters", "recompute", "--propose", "--home", home, "--out", planPath}, &b, &b); code != 0 {
+		t.Fatalf("propose exit %d: %s", code, b.String())
+	}
+
+	// Mutate the store AFTER proposing: the anchor over (id, updated_at) changes.
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: "researcher"},
+		Repo:  "acme/widget", Scope: "repo", Key: "db-migrate", Content: "database migration rewrites the index and query plan",
+	}); err != nil {
+		t.Fatalf("mutate store: %v", err)
+	}
+
+	b.Reset()
+	code := runMemory([]string{"clusters", "recompute", "--apply", "--plan", planPath, "--home", home}, &b, &b)
+	if code == 0 {
+		t.Fatalf("stale apply must fail")
+	}
+	if !bytes.Contains(b.Bytes(), []byte("stale")) {
+		t.Fatalf("error should mention staleness; got %s", b.String())
+	}
+}
+
+// TestClusterRenameOverrideWinsAndSurvivesRecompute: rename sets an override that
+// wins in the list AND is carried forward across a recompute (medoid-anchored).
+func TestClusterRenameOverrideWinsAndSurvivesRecompute(t *testing.T) {
+	home, store := memoryTestHome(t)
+	seedClusterCorpus(t, store)
+
+	var b bytes.Buffer
+	if code := runMemory([]string{"clusters", "recompute", "--apply", "--home", home}, &b, &b); code != 0 {
+		t.Fatalf("apply exit %d: %s", code, b.String())
+	}
+
+	// Pick a real cluster to rename.
+	var target int64 = -1
+	for _, e := range clustersJSON(t, home) {
+		if e.ClusterID != memory.UnclusteredID {
+			target = e.ClusterID
+			break
+		}
+	}
+	if target < 0 {
+		t.Fatalf("no real cluster to rename")
+	}
+
+	b.Reset()
+	if code := runMemory([]string{"cluster", "rename", "--home", home}, &b, &b); code == 0 {
+		t.Fatalf("rename with no args must fail usage")
+	}
+	b.Reset()
+	if code := runMemory([]string{"cluster", "rename", itoaTest(target), "storage-layer", "--home", home}, &b, &b); code != 0 {
+		t.Fatalf("rename exit %d: %s", code, b.String())
+	}
+
+	assertOverride := func(where string) {
+		for _, e := range clustersJSON(t, home) {
+			if e.ClusterID == target {
+				if e.Override != "storage-layer" || e.Label != "storage-layer" {
+					t.Fatalf("%s: cluster %d label=%q override=%q, want display+override 'storage-layer'", where, target, e.Label, e.Override)
+				}
+				return
+			}
+		}
+		t.Fatalf("%s: cluster %d missing", where, target)
+	}
+	assertOverride("after rename")
+
+	// Recompute (propose+apply, no store change) must preserve the override.
+	planPath := filepath.Join(t.TempDir(), "plan.json")
+	b.Reset()
+	if code := runMemory([]string{"clusters", "recompute", "--propose", "--home", home, "--out", planPath}, &b, &b); code != 0 {
+		t.Fatalf("propose exit %d: %s", code, b.String())
+	}
+	b.Reset()
+	if code := runMemory([]string{"clusters", "recompute", "--apply", "--plan", planPath, "--home", home}, &b, &b); code != 0 {
+		t.Fatalf("apply exit %d: %s", code, b.String())
+	}
+	assertOverride("after recompute")
+}
+
+// TestClustersProposeDeterministic: two proposes over an unchanged store produce
+// the same anchor and the same cluster assignment.
+func TestClustersProposeDeterministic(t *testing.T) {
+	home, store := memoryTestHome(t)
+	seedClusterCorpus(t, store)
+
+	propose := func() clusterPlan {
+		planPath := filepath.Join(t.TempDir(), "plan.json")
+		var b bytes.Buffer
+		if code := runMemory([]string{"clusters", "recompute", "--propose", "--home", home, "--out", planPath}, &b, &b); code != 0 {
+			t.Fatalf("propose exit %d: %s", code, b.String())
+		}
+		p, err := readClusterPlan(planPath)
+		if err != nil {
+			t.Fatalf("read plan: %v", err)
+		}
+		return p
+	}
+	a := propose()
+	c := propose()
+	if a.Anchor != c.Anchor {
+		t.Fatalf("anchors differ: %s vs %s", a.Anchor, c.Anchor)
+	}
+	if got, want := toJSON(t, a.Clusters), toJSON(t, c.Clusters); got != want {
+		t.Fatalf("cluster assignment not deterministic:\n%s\n%s", got, want)
+	}
+}
+
+// TestClustersIncrementalAttach: a newly confirmed fact attaches to the cluster of
+// its nearest neighbor.
+func TestClustersIncrementalAttach(t *testing.T) {
+	home, store := memoryTestHome(t)
+	dbIDs, _ := seedClusterCorpus(t, store)
+	ctx := context.Background()
+
+	var b bytes.Buffer
+	if code := runMemory([]string{"clusters", "recompute", "--apply", "--home", home}, &b, &b); code != 0 {
+		t.Fatalf("apply exit %d: %s", code, b.String())
+	}
+	dbc := clusterOf(t, store, ctx, dbIDs[0])
+
+	// Stage a new DB-flavored observation and confirm it.
+	obsID, err := store.InsertMemoryObservation(ctx, db.MemoryObservation{
+		Owner: db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: "researcher"},
+		Repo:  "acme/widget", Scope: "repo", Key: "db-shard",
+		Content: "database sharding splits the index across query nodes", TrustMark: "normal",
+	})
+	if err != nil {
+		t.Fatalf("insert obs: %v", err)
+	}
+
+	b.Reset()
+	if code := runMemory([]string{"confirm", "--yes", "--home", home, itoaTest(obsID)}, &b, &b); code != 0 {
+		t.Fatalf("confirm exit %d: %s", code, b.String())
+	}
+
+	// Resolve the confirmed row id for the new key and assert it joined the db cluster.
+	newID := confirmedIDForKey(t, store, ctx, "db-shard")
+	got := clusterOf(t, store, ctx, newID)
+	if got != dbc {
+		t.Fatalf("new fact attached to cluster %d, want %d (nearest-neighbor db cluster)", got, dbc)
+	}
+}
+
+// ---- small test helpers ----
+
+func clusterOf(t *testing.T, store *db.Store, ctx context.Context, id int64) int64 {
+	t.Helper()
+	cid, ok, err := store.ClusterOfMemory(ctx, id)
+	if err != nil {
+		t.Fatalf("cluster of %d: %v", id, err)
+	}
+	if !ok {
+		t.Fatalf("fact %d has no cluster", id)
+	}
+	return cid
+}
+
+func confirmedIDForKey(t *testing.T, store *db.Store, ctx context.Context, key string) int64 {
+	t.Helper()
+	rows, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatalf("list confirmed: %v", err)
+	}
+	for _, r := range rows {
+		if r.Key == key {
+			return r.ID
+		}
+	}
+	t.Fatalf("no confirmed fact with key %q", key)
+	return 0
+}
+
+func itoaTest(n int64) string {
+	return strconv.FormatInt(n, 10)
+}
+
+func toJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}

--- a/internal/cli/memory_ingest.go
+++ b/internal/cli/memory_ingest.go
@@ -364,7 +364,7 @@ func runMemoryConfirm(args []string, stdout, stderr io.Writer) int {
 			if !*yes {
 				continue
 			}
-			if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+			newID, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
 				Owner:      obs.Owner,
 				Repo:       obs.Repo,
 				Scope:      obs.Scope,
@@ -372,10 +372,18 @@ func runMemoryConfirm(args []string, stdout, stderr io.Writer) int {
 				Content:    obs.Content,
 				Provenance: obs.Provenance,
 				SourceJob:  obs.SourceJob,
-			}); err != nil {
+			})
+			if err != nil {
 				return fmt.Errorf("confirm observation %d: %w", obs.ID, err)
 			}
 			result.Confirmed++
+			// Incremental cluster attach (#763 Track A): a newly confirmed fact joins
+			// the cluster of its nearest similarity neighbor. Best-effort and
+			// fail-safe — a clustering error must never block the confirmation.
+			attachConfirmedFactToCluster(ctx, store, db.ConfirmedMemory{
+				ID: newID, Owner: obs.Owner, Repo: obs.Repo, Scope: obs.Scope,
+				Key: obs.Key, Content: obs.Content,
+			})
 		}
 		return nil
 	})

--- a/internal/db/memory_cluster_store.go
+++ b/internal/db/memory_cluster_store.go
@@ -1,0 +1,245 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// This file is the store layer for emergent memory clusters (#763 Track A). It
+// persists the deterministic community detection computed in internal/memory:
+// memory_clusters (one row per community + the reserved cluster 0 'unclustered'
+// bucket) and memory_cluster_members (fact -> cluster). The clustering itself is
+// a pure function elsewhere; this layer is only SQL. Every read orders by id so
+// callers see a stable traversal.
+
+// MemoryCluster is one persisted community. Label is the computed
+// distinctive-term label; LabelOverride is the owner's `memory cluster rename`
+// (it wins when non-empty). MedoidID anchors the label for stability.
+type MemoryCluster struct {
+	ClusterID     int64
+	Label         string
+	LabelOverride string
+	MedoidID      int64
+}
+
+// DisplayLabel is the label the bridge/CLI should show: the override when the
+// owner set one, else the computed label.
+func (c MemoryCluster) DisplayLabel() string {
+	if c.LabelOverride != "" {
+		return c.LabelOverride
+	}
+	return c.Label
+}
+
+// MemoryClusterMember maps one active confirmed fact to its cluster.
+type MemoryClusterMember struct {
+	MemoryID  int64
+	ClusterID int64
+}
+
+// MemoryClusterAssignment is the full input the recompute writes in one tx: the
+// cluster rows and their membership. The caller (CLI) builds these from the pure
+// internal/memory clustering.
+type MemoryClusterAssignment struct {
+	Clusters []MemoryCluster
+	Members  []MemoryClusterMember
+}
+
+// ListMemoryClusters returns every persisted cluster ordered by cluster_id, so
+// the reserved unclustered bucket (id 0) sorts first and real communities follow
+// in their stable numbering.
+func (s *Store) ListMemoryClusters(ctx context.Context) ([]MemoryCluster, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT cluster_id, label, label_override, medoid_id
+FROM memory_clusters
+ORDER BY cluster_id`)
+	if err != nil {
+		return nil, fmt.Errorf("list memory clusters: %w", err)
+	}
+	defer rows.Close()
+	var out []MemoryCluster
+	for rows.Next() {
+		var c MemoryCluster
+		if err := rows.Scan(&c.ClusterID, &c.Label, &c.LabelOverride, &c.MedoidID); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// ListMemoryClusterMembers returns every fact->cluster row ordered by memory_id,
+// for the bridge and the CLI count roll-up.
+func (s *Store) ListMemoryClusterMembers(ctx context.Context) ([]MemoryClusterMember, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT memory_id, cluster_id
+FROM memory_cluster_members
+ORDER BY memory_id`)
+	if err != nil {
+		return nil, fmt.Errorf("list memory cluster members: %w", err)
+	}
+	defer rows.Close()
+	var out []MemoryClusterMember
+	for rows.Next() {
+		var m MemoryClusterMember
+		if err := rows.Scan(&m.MemoryID, &m.ClusterID); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// CountMemoryClusters returns how many cluster rows exist. Used by the CLI to
+// detect the first-run case (no clusters yet ⇒ `recompute --apply` is allowed
+// without a proposal to protect).
+func (s *Store) CountMemoryClusters(ctx context.Context) (int, error) {
+	var n int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM memory_clusters`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count memory clusters: %w", err)
+	}
+	return n, nil
+}
+
+// RecomputeMemoryClusters replaces the ENTIRE clustering in one transaction:
+// every memory_clusters and memory_cluster_members row is deleted and the new
+// assignment inserted. Owner label overrides are carried forward by MEDOID
+// identity — a new cluster whose medoid matches a prior cluster that carried an
+// override keeps that override (the medoid anchors owner intent across a
+// recompute, since cluster_id numbering itself is not stable across membership
+// changes). The whole swap is atomic: a reader never sees a half-written
+// clustering.
+func (s *Store) RecomputeMemoryClusters(ctx context.Context, a MemoryClusterAssignment) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Preserve overrides keyed by medoid id before wiping.
+	overrideByMedoid, err := overridesByMedoidTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memory_cluster_members`); err != nil {
+		return fmt.Errorf("clear cluster members: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memory_clusters`); err != nil {
+		return fmt.Errorf("clear clusters: %w", err)
+	}
+
+	for _, c := range a.Clusters {
+		override := c.LabelOverride
+		if override == "" {
+			if prev, ok := overrideByMedoid[c.MedoidID]; ok && c.MedoidID != 0 {
+				override = prev
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO memory_clusters (cluster_id, label, label_override, medoid_id)
+VALUES (?, ?, ?, ?)`, c.ClusterID, c.Label, override, c.MedoidID); err != nil {
+			return fmt.Errorf("insert cluster %d: %w", c.ClusterID, err)
+		}
+	}
+	for _, m := range a.Members {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO memory_cluster_members (memory_id, cluster_id) VALUES (?, ?)`,
+			m.MemoryID, m.ClusterID); err != nil {
+			return fmt.Errorf("insert cluster member %d: %w", m.MemoryID, err)
+		}
+	}
+	return tx.Commit()
+}
+
+// overridesByMedoidTx reads the current (medoid_id -> non-empty override) map
+// inside a transaction. A zero medoid (the unclustered bucket) is skipped — its
+// label is fixed and never carries an owner override.
+func overridesByMedoidTx(ctx context.Context, tx *sql.Tx) (map[int64]string, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT medoid_id, label_override FROM memory_clusters
+WHERE label_override <> '' AND medoid_id <> 0`)
+	if err != nil {
+		return nil, fmt.Errorf("read prior overrides: %w", err)
+	}
+	defer rows.Close()
+	out := map[int64]string{}
+	for rows.Next() {
+		var medoid int64
+		var override string
+		if err := rows.Scan(&medoid, &override); err != nil {
+			return nil, err
+		}
+		out[medoid] = override
+	}
+	return out, rows.Err()
+}
+
+// AssignMemoryToCluster incrementally attaches a single fact to a cluster
+// (INSERT OR REPLACE on the memory_id PK), used when a newly confirmed fact joins
+// the cluster of its nearest neighbor without a full recompute. Fail-safe by
+// design: the caller wraps it best-effort so a failed attach never blocks a
+// confirm.
+func (s *Store) AssignMemoryToCluster(ctx context.Context, memoryID, clusterID int64) error {
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO memory_cluster_members (memory_id, cluster_id) VALUES (?, ?)
+ON CONFLICT(memory_id) DO UPDATE SET cluster_id = excluded.cluster_id`,
+		memoryID, clusterID); err != nil {
+		return fmt.Errorf("assign memory %d to cluster %d: %w", memoryID, clusterID, err)
+	}
+	return nil
+}
+
+// RenameMemoryCluster sets a cluster's owner label override (the display label
+// then wins over the computed label). A blank label clears the override, falling
+// back to the computed label. Renaming the reserved unclustered bucket (id 0) is
+// rejected — its grouping is structural, not a named community.
+func (s *Store) RenameMemoryCluster(ctx context.Context, clusterID int64, label string) error {
+	if clusterID == 0 {
+		return fmt.Errorf("cannot rename the reserved unclustered bucket")
+	}
+	res, err := s.db.ExecContext(ctx, `
+UPDATE memory_clusters SET label_override = ? WHERE cluster_id = ?`, label, clusterID)
+	if err != nil {
+		return fmt.Errorf("rename cluster %d: %w", clusterID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("no cluster with id %d", clusterID)
+	}
+	return nil
+}
+
+// ClusterOfMemory returns the cluster id a fact currently belongs to, and whether
+// it has an assignment. Used by incremental attach to find a neighbor's cluster.
+func (s *Store) ClusterOfMemory(ctx context.Context, memoryID int64) (int64, bool, error) {
+	var cid int64
+	err := s.db.QueryRowContext(ctx, `
+SELECT cluster_id FROM memory_cluster_members WHERE memory_id = ?`, memoryID).Scan(&cid)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("cluster of memory %d: %w", memoryID, err)
+	}
+	return cid, true, nil
+}
+
+// MemoryClusterCounts returns member counts keyed by cluster id, deterministically
+// (a plain read the caller can pair with ListMemoryClusters). Sorted keys are the
+// caller's job; this returns the map.
+func (s *Store) MemoryClusterCounts(ctx context.Context) (map[int64]int, error) {
+	members, err := s.ListMemoryClusterMembers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := map[int64]int{}
+	for _, m := range members {
+		out[m.ClusterID]++
+	}
+	return out, nil
+}

--- a/internal/db/memory_cluster_store.go
+++ b/internal/db/memory_cluster_store.go
@@ -3,8 +3,15 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 )
+
+// ErrClusterPlanStale is returned by RecomputeMemoryClustersFresh when the
+// active-fact anchor re-read inside the rewrite transaction no longer matches the
+// anchor the reviewed plan was built against — a fact was confirmed/edited/retired
+// in the window. The caller re-proposes rather than applying a stale plan.
+var ErrClusterPlanStale = errors.New("cluster plan is stale")
 
 // This file is the store layer for emergent memory clusters (#763 Track A). It
 // persists the deterministic community detection computed in internal/memory:
@@ -117,6 +124,49 @@ func (s *Store) RecomputeMemoryClusters(ctx context.Context, a MemoryClusterAssi
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := recomputeMemoryClustersTx(ctx, tx, a); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// RecomputeMemoryClustersFresh performs the destructive clustering rewrite ONLY if
+// the active-fact anchor — re-read from the SAME transaction that performs the
+// delete/insert — still equals expected. This closes the TOCTOU window between the
+// CLI's staleness pre-check and the rewrite: a concurrent confirm/attach in that
+// window would otherwise be silently dropped by the DELETE. anchorFn computes the
+// anchor from the tx-scoped active vault rows using the SAME algorithm that
+// produced expected. Because the anchor read and the rewrite share one transaction,
+// a fact confirmed after the snapshot either changes the anchor (→ ErrClusterPlanStale)
+// or invalidates the write snapshot (→ SQLITE_BUSY_SNAPSHOT); the stale row can no
+// longer be dropped unnoticed. Returns ErrClusterPlanStale (wrapped) if the anchor
+// moved; the whole swap is atomic.
+func (s *Store) RecomputeMemoryClustersFresh(ctx context.Context, a MemoryClusterAssignment, expected string, anchorFn func([]ConfirmedMemory) string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := listConfirmedMemoriesForVault(ctx, tx, "")
+	if err != nil {
+		return err
+	}
+	if got := anchorFn(rows); got != expected {
+		return fmt.Errorf("%w (plan anchor %s, current %s)", ErrClusterPlanStale, expected, got)
+	}
+	if err := recomputeMemoryClustersTx(ctx, tx, a); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// recomputeMemoryClustersTx is the delete-all + reinsert core of a full clustering
+// rewrite, run inside the caller's transaction so it can be paired atomically with
+// a same-tx anchor re-read (RecomputeMemoryClustersFresh) or run standalone
+// (RecomputeMemoryClusters). Owner label overrides are carried forward by medoid
+// identity.
+func recomputeMemoryClustersTx(ctx context.Context, tx *sql.Tx, a MemoryClusterAssignment) error {
 	// Preserve overrides keyed by medoid id before wiping.
 	overrideByMedoid, err := overridesByMedoidTx(ctx, tx)
 	if err != nil {
@@ -150,7 +200,7 @@ INSERT INTO memory_cluster_members (memory_id, cluster_id) VALUES (?, ?)`,
 			return fmt.Errorf("insert cluster member %d: %w", m.MemoryID, err)
 		}
 	}
-	return tx.Commit()
+	return nil
 }
 
 // overridesByMedoidTx reads the current (medoid_id -> non-empty override) map

--- a/internal/db/memory_cluster_store_test.go
+++ b/internal/db/memory_cluster_store_test.go
@@ -1,0 +1,106 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// clusterTestAnchor mirrors the CLI's clusterAnchor shape (deterministic over the
+// active facts' (id, updated_at)) closely enough for the store guard test: it only
+// needs to move when a fact is added/edited/retired.
+func clusterTestAnchor(rows []ConfirmedMemory) string {
+	var sb strings.Builder
+	for _, r := range rows {
+		fmt.Fprintf(&sb, "%d:%s;", r.ID, r.UpdatedAt)
+	}
+	return sb.String()
+}
+
+// TestRecomputeMemoryClustersFreshAnchorGuard proves the atomic apply:
+// RecomputeMemoryClustersFresh rewrites the clustering when the in-tx anchor still
+// matches, and — critically for the TOCTOU fix — leaves the membership UNCHANGED
+// (ErrClusterPlanStale, full rollback, no partial write) when a fact confirmed
+// after the plan was built moves the anchor. This is the store-side guarantee the
+// CLI relies on so a concurrent confirm/attach is never silently dropped by the
+// destructive rewrite.
+func TestRecomputeMemoryClustersFreshAnchorGuard(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+
+	idA, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "a", Content: "the storage layer flushes the write-ahead log on commit",
+	})
+	if err != nil {
+		t.Fatalf("upsert A: %v", err)
+	}
+	idB, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "b", Content: "the storage layer checkpoints the write-ahead log periodically",
+	})
+	if err != nil {
+		t.Fatalf("upsert B: %v", err)
+	}
+
+	rows, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatalf("list vault: %v", err)
+	}
+	expected := clusterTestAnchor(rows)
+
+	asg1 := MemoryClusterAssignment{
+		Clusters: []MemoryCluster{
+			{ClusterID: 0, Label: "unclustered"},
+			{ClusterID: 1, Label: "storage", MedoidID: idA},
+		},
+		Members: []MemoryClusterMember{
+			{MemoryID: idA, ClusterID: 1},
+			{MemoryID: idB, ClusterID: 1},
+		},
+	}
+	if err := store.RecomputeMemoryClustersFresh(ctx, asg1, expected, clusterTestAnchor); err != nil {
+		t.Fatalf("fresh apply with matching anchor: %v", err)
+	}
+	members, err := store.ListMemoryClusterMembers(ctx)
+	if err != nil {
+		t.Fatalf("list members: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("want 2 members after apply, got %d", len(members))
+	}
+
+	// A fact confirmed after the plan was built moves the anchor. Attempting the
+	// rewrite with the now-stale expected anchor must abort and roll back entirely.
+	if _, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "c", Content: "a concurrently confirmed fact that must not be dropped",
+	}); err != nil {
+		t.Fatalf("upsert C: %v", err)
+	}
+	asg2 := MemoryClusterAssignment{
+		Clusters: []MemoryCluster{{ClusterID: 0, Label: "unclustered"}},
+		Members:  []MemoryClusterMember{{MemoryID: idA, ClusterID: 0}},
+	}
+	err = store.RecomputeMemoryClustersFresh(ctx, asg2, expected, clusterTestAnchor)
+	if !errors.Is(err, ErrClusterPlanStale) {
+		t.Fatalf("want ErrClusterPlanStale on moved anchor, got %v", err)
+	}
+
+	// Rollback: membership is exactly asg1's — the stale plan wrote nothing.
+	members, err = store.ListMemoryClusterMembers(ctx)
+	if err != nil {
+		t.Fatalf("list members after stale: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("stale apply must not modify membership; got %d members", len(members))
+	}
+	for _, m := range members {
+		if m.ClusterID != 1 {
+			t.Fatalf("stale apply changed membership: memory %d now in cluster %d", m.MemoryID, m.ClusterID)
+		}
+	}
+}

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -626,6 +626,20 @@ LIMIT ?`,
 // non-empty agentRef narrows the export to a single agent owner (owner_kind
 // 'agent', owner_ref = agentRef). Plain read, no FTS, zero writes.
 func (s *Store) ListConfirmedMemoriesForVault(ctx context.Context, agentRef string) ([]ConfirmedMemory, error) {
+	return listConfirmedMemoriesForVault(ctx, s.db, agentRef)
+}
+
+// rowsQuerier is the QueryContext shape shared by *sql.DB and *sql.Tx, so the
+// vault read can run on a plain connection or INSIDE a transaction (the atomic
+// cluster recompute re-reads the anchor rows within its own tx).
+type rowsQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// listConfirmedMemoriesForVault is the shared body of ListConfirmedMemoriesForVault
+// so the exact active-fact projection/ordering can be reused inside a transaction
+// (via a *sql.Tx) without duplicating the query.
+func listConfirmedMemoriesForVault(ctx context.Context, q rowsQuerier, agentRef string) ([]ConfirmedMemory, error) {
 	query := `
 SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
@@ -637,7 +651,7 @@ WHERE superseded_by IS NULL AND retired_at = ''`
 		args = append(args, agentRef)
 	}
 	query += "\nORDER BY id"
-	rows, err := s.db.QueryContext(ctx, query, args...)
+	rows, err := q.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list confirmed memories for vault: %w", err)
 	}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -8262,4 +8262,29 @@ CREATE TABLE chat_thread_meta (
 ALTER TABLE confirmed_memories ADD COLUMN retired_at TEXT NOT NULL DEFAULT '';
 ALTER TABLE confirmed_memories ADD COLUMN retired_reason TEXT NOT NULL DEFAULT '';
 	`,
+	// #763 Track A — emergent memory clusters. Two side-tables persist the
+	// deterministic community detection over the fact-similarity graph so the CLI
+	// and the dashboard bridge read a stable clustering without recomputing it on
+	// every request. memory_clusters holds one row per detected community (plus the
+	// reserved cluster_id 0 'unclustered' bucket): label is the computed
+	// distinctive-term label, label_override is the owner's `memory cluster rename`
+	// (override wins when non-empty), medoid_id anchors the label for stability.
+	// memory_cluster_members maps each active confirmed fact to exactly one cluster
+	// (memory_id PK ⇒ a fact is in at most one cluster). Pure additive append
+	// (CREATE TABLE/INDEX only, no ALTER/renumber of any prior migration): both
+	// tables stay empty until `gitmoot memory clusters recompute` runs, so every
+	// existing DB reads byte-identically and the feature is inert when unused.
+	`
+CREATE TABLE memory_clusters (
+	cluster_id INTEGER PRIMARY KEY,
+	label TEXT NOT NULL DEFAULT '',
+	label_override TEXT NOT NULL DEFAULT '',
+	medoid_id INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE memory_cluster_members (
+	memory_id INTEGER PRIMARY KEY,
+	cluster_id INTEGER NOT NULL
+);
+CREATE INDEX idx_memory_cluster_members_cluster ON memory_cluster_members(cluster_id);
+	`,
 }

--- a/internal/memory/cluster.go
+++ b/internal/memory/cluster.go
@@ -1,0 +1,366 @@
+package memory
+
+import (
+	"sort"
+	"strings"
+)
+
+// This file holds the PURE, deterministic community-detection + labeling logic
+// for emergent memory clusters (#763 Track A). It carries no SQL and no I/O: the
+// caller (internal/db + internal/cli) builds the k-NN similarity graph from the
+// existing FTS/bm25 vault-link signal, hands the nodes + undirected weighted
+// edges here, and this returns a fully-determined clustering. Determinism is a
+// hard requirement — the same graph MUST yield byte-identical clusters, labels,
+// medoids, and cluster ids on every run — so every step below is a pure function
+// of the input with fixed iteration order and fixed tie-breaks (never a map
+// range, never wall-clock, never a random seed).
+
+// UnclusteredID is the reserved cluster id for facts with no similarity
+// neighbors (graph degree 0). They are grouped under a single 'unclustered'
+// bucket rather than each becoming a singleton, so the bridge/UI can show them
+// together. Real communities are numbered from 1.
+const UnclusteredID int64 = 0
+
+// UnclusteredLabel is the fixed label of the reserved degree-0 bucket.
+const UnclusteredLabel = "unclustered"
+
+// clusterMaxLabelTerms is how many distinctive terms a computed label carries.
+const clusterMaxLabelTerms = 3
+
+// clusterLabelRounds caps the label-propagation passes. Determinism does NOT
+// depend on convergence: the algorithm is a pure function of the input for ANY
+// fixed cap (the same fixed sequence of in-order, fixed-tie-break updates runs
+// every time), so a run that hits the cap mid-oscillation still produces
+// byte-identical output. The cap only bounds work; on the small memory graphs
+// this targets (~hundreds of facts) label propagation settles well within it.
+const clusterLabelRounds = 100
+
+// ClusterNode is one fact participating in the similarity graph. Text is the
+// concatenation the labeler tokenizes (key + content); the caller supplies it so
+// this package never re-derives the fact shape.
+type ClusterNode struct {
+	ID   int64
+	Text string
+}
+
+// ClusterEdge is one UNDIRECTED weighted similarity edge. A and B are fact ids
+// (order irrelevant — the builder normalizes A<B); Weight is a positive integer
+// similarity (higher == more mutually similar). The caller derives weight from
+// the same bm25+id-tiebreak neighbor ranking the vault [[links]] use.
+type ClusterEdge struct {
+	A      int64
+	B      int64
+	Weight int
+}
+
+// Cluster is one detected community.
+type Cluster struct {
+	ID       int64   // 1-based; UnclusteredID (0) for the degree-0 bucket
+	Label    string  // computed distinctive-term label (override applied by the store, not here)
+	MedoidID int64   // member with the highest intra-cluster similarity (lowest id tie-break); 0 for unclustered
+	Members  []int64 // member fact ids, ascending
+}
+
+// ClusterResult is the full deterministic clustering.
+type ClusterResult struct {
+	Clusters []Cluster // real communities first (ascending medoid id), then the unclustered bucket if non-empty
+}
+
+// BuildClusters runs deterministic community detection over the similarity graph
+// and returns labeled clusters. It is a PURE function: same nodes + edges ⇒
+// byte-identical result, always.
+//
+// Algorithm (id-ordered label propagation):
+//  1. Every node starts labeled with its own id.
+//  2. Nodes are visited in STRICT ascending-id order, repeatedly. On each visit a
+//     node adopts the label carrying the greatest summed edge weight among its
+//     neighbors; ties are broken by the LOWEST label value.
+//  3. Passes repeat until a full pass makes no change (converged) or the fixed
+//     round cap is hit.
+//
+// Why it is deterministic: the node visit order is fixed (sorted ids), the
+// initial labels are fixed (the ids themselves), the neighbor weighting is a sum
+// (order-independent), and every tie-break resolves to the lowest label — there
+// is no map-iteration order, randomness, or time dependence anywhere. Given the
+// same graph the exact same sequence of updates runs, so the labels, the derived
+// medoids, the cluster-id numbering, and the labels are identical every run.
+//
+// Degree-0 nodes keep their own label and are collected into the single reserved
+// 'unclustered' bucket (UnclusteredID). Real communities are numbered from 1 in
+// ascending medoid-id order so the numbering itself is stable across runs.
+func BuildClusters(nodes []ClusterNode, edges []ClusterEdge) ClusterResult {
+	// Stable, de-duplicated node id list and text lookup.
+	textByID := make(map[int64]string, len(nodes))
+	ids := make([]int64, 0, len(nodes))
+	for _, n := range nodes {
+		if _, seen := textByID[n.ID]; seen {
+			continue
+		}
+		textByID[n.ID] = n.Text
+		ids = append(ids, n.ID)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	// Symmetric adjacency with summed weights. Self-loops and edges touching an
+	// unknown node are ignored so the graph is always well-formed.
+	adj := make(map[int64]map[int64]int, len(ids))
+	for _, id := range ids {
+		adj[id] = map[int64]int{}
+	}
+	for _, e := range edges {
+		if e.A == e.B || e.Weight <= 0 {
+			continue
+		}
+		if _, ok := textByID[e.A]; !ok {
+			continue
+		}
+		if _, ok := textByID[e.B]; !ok {
+			continue
+		}
+		adj[e.A][e.B] += e.Weight
+		adj[e.B][e.A] += e.Weight
+	}
+
+	// Label propagation.
+	label := make(map[int64]int64, len(ids))
+	for _, id := range ids {
+		label[id] = id
+	}
+	for round := 0; round < clusterLabelRounds; round++ {
+		changed := false
+		for _, id := range ids {
+			nbrs := adj[id]
+			if len(nbrs) == 0 {
+				continue // isolated: keep own label (becomes unclustered)
+			}
+			best, ok := dominantLabel(nbrs, label)
+			if ok && best != label[id] {
+				label[id] = best
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	// Group by final label. Degree-0 nodes go to the unclustered bucket.
+	groups := map[int64][]int64{}
+	var unclustered []int64
+	for _, id := range ids {
+		if len(adj[id]) == 0 {
+			unclustered = append(unclustered, id)
+			continue
+		}
+		groups[label[id]] = append(groups[label[id]], id)
+	}
+
+	// Materialize each group: sort members, pick medoid, then order groups by
+	// medoid id so cluster ids are assigned deterministically.
+	type pending struct {
+		members []int64
+		medoid  int64
+	}
+	pend := make([]pending, 0, len(groups))
+	for lbl := range groups {
+		members := append([]int64(nil), groups[lbl]...)
+		sort.Slice(members, func(i, j int) bool { return members[i] < members[j] })
+		pend = append(pend, pending{members: members, medoid: medoidOf(members, adj)})
+	}
+	sort.Slice(pend, func(i, j int) bool { return pend[i].medoid < pend[j].medoid })
+
+	// Per-cluster term sets (over ALL members) drive the corpus document
+	// frequency used for label distinctiveness.
+	termSets := make([]map[string]struct{}, len(pend))
+	for i, p := range pend {
+		set := map[string]struct{}{}
+		for _, id := range p.members {
+			for _, t := range clusterTerms(textByID[id]) {
+				set[t] = struct{}{}
+			}
+		}
+		termSets[i] = set
+	}
+	df := map[string]int{}
+	for _, set := range termSets {
+		for t := range set {
+			df[t]++
+		}
+	}
+
+	result := ClusterResult{Clusters: make([]Cluster, 0, len(pend)+1)}
+	for i, p := range pend {
+		cid := int64(i + 1)
+		result.Clusters = append(result.Clusters, Cluster{
+			ID:       cid,
+			Label:    clusterLabel(p.members, p.medoid, textByID, df),
+			MedoidID: p.medoid,
+			Members:  p.members,
+		})
+	}
+	if len(unclustered) > 0 {
+		sort.Slice(unclustered, func(i, j int) bool { return unclustered[i] < unclustered[j] })
+		result.Clusters = append(result.Clusters, Cluster{
+			ID:       UnclusteredID,
+			Label:    UnclusteredLabel,
+			MedoidID: 0,
+			Members:  unclustered,
+		})
+	}
+	return result
+}
+
+// dominantLabel returns the neighbor label with the greatest summed edge weight,
+// breaking ties by the LOWEST label value. Candidate labels are collected then
+// sorted ascending so the scan is order-independent and the tie-break is exact.
+func dominantLabel(nbrs map[int64]int, label map[int64]int64) (int64, bool) {
+	weightByLabel := map[int64]int{}
+	for nbr, w := range nbrs {
+		weightByLabel[label[nbr]] += w
+	}
+	if len(weightByLabel) == 0 {
+		return 0, false
+	}
+	cands := make([]int64, 0, len(weightByLabel))
+	for l := range weightByLabel {
+		cands = append(cands, l)
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i] < cands[j] })
+	best := cands[0]
+	bestW := weightByLabel[best]
+	for _, l := range cands[1:] {
+		if weightByLabel[l] > bestW { // strict: first (lowest) label wins ties
+			best, bestW = l, weightByLabel[l]
+		}
+	}
+	return best, true
+}
+
+// medoidOf returns the member with the greatest total edge weight to the OTHER
+// members of the same cluster, lowest id breaking ties. members must be sorted
+// ascending so the tie-break naturally resolves to the lowest id.
+func medoidOf(members []int64, adj map[int64]map[int64]int) int64 {
+	if len(members) == 0 {
+		return 0
+	}
+	inCluster := make(map[int64]struct{}, len(members))
+	for _, id := range members {
+		inCluster[id] = struct{}{}
+	}
+	medoid := members[0]
+	bestW := -1
+	for _, id := range members { // ascending: first max wins == lowest id tie-break
+		sum := 0
+		for nbr, w := range adj[id] {
+			if _, ok := inCluster[nbr]; ok {
+				sum += w
+			}
+		}
+		if sum > bestW {
+			medoid, bestW = id, sum
+		}
+	}
+	return medoid
+}
+
+// clusterLabel picks up to clusterMaxLabelTerms distinctive terms and joins them
+// with '-'. Candidate terms are ANCHORED to the medoid fact (for label stability
+// as membership shifts), ranked by (term-frequency-across-the-cluster DESC,
+// corpus document-frequency ASC, term ASC) — a tf-idf-shaped ordering kept in
+// integers so it is byte-deterministic (no float compares). Frequent-inside-yet-
+// rare-in-corpus terms win. A cluster whose medoid yields no usable terms falls
+// back to a stable "cluster-<medoid>" label.
+func clusterLabel(members []int64, medoid int64, textByID map[int64]string, df map[string]int) string {
+	// Term frequency summed across every member of the cluster.
+	tf := map[string]int{}
+	for _, id := range members {
+		for _, t := range clusterTerms(textByID[id]) {
+			tf[t]++
+		}
+	}
+	// Candidate pool = distinct terms of the medoid fact.
+	seen := map[string]struct{}{}
+	var cands []string
+	for _, t := range clusterTerms(textByID[medoid]) {
+		if _, dup := seen[t]; dup {
+			continue
+		}
+		seen[t] = struct{}{}
+		cands = append(cands, t)
+	}
+	sort.Slice(cands, func(i, j int) bool {
+		a, b := cands[i], cands[j]
+		if tf[a] != tf[b] {
+			return tf[a] > tf[b]
+		}
+		if df[a] != df[b] {
+			return df[a] < df[b]
+		}
+		return a < b
+	})
+	if len(cands) > clusterMaxLabelTerms {
+		cands = cands[:clusterMaxLabelTerms]
+	}
+	if len(cands) == 0 {
+		return "cluster-" + itoa(medoid)
+	}
+	return strings.Join(cands, "-")
+}
+
+// clusterTerms tokenizes fact text into normalized label terms using the SAME
+// alphanumeric tokenization + stopword policy as the FTS query builder
+// (SanitizeFTSQuery), plus a light deterministic plural fold so "clusters" and
+// "cluster" collapse to one term. Returns terms in text order WITH repeats (the
+// caller counts them for term frequency); pure and allocation-cheap.
+func clusterTerms(text string) []string {
+	var out []string
+	for _, raw := range wordRun.FindAllString(text, -1) {
+		tok := strings.ToLower(raw)
+		if len(tok) < 3 {
+			continue
+		}
+		if _, ok := ftsKeywords[tok]; ok {
+			continue
+		}
+		if _, ok := tinyStopwords[tok]; ok {
+			continue
+		}
+		out = append(out, foldTerm(tok))
+	}
+	return out
+}
+
+// foldTerm applies a light, deterministic plural fold: a trailing 's' is dropped
+// when the remaining stem is at least 3 chars and the word does not end in 'ss'
+// (so "class" stays "class" but "clusters" -> "cluster"). It is intentionally
+// minimal — a full porter stemmer is unnecessary for label distinctiveness and a
+// hand-rolled one would risk surprising, less-legible labels.
+func foldTerm(tok string) string {
+	if len(tok) >= 4 && strings.HasSuffix(tok, "s") && !strings.HasSuffix(tok, "ss") {
+		return tok[:len(tok)-1]
+	}
+	return tok
+}
+
+// itoa is a tiny dependency-free int64 -> string for the fallback label.
+func itoa(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b [20]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}

--- a/internal/memory/cluster_test.go
+++ b/internal/memory/cluster_test.go
@@ -1,0 +1,153 @@
+package memory
+
+import (
+	"reflect"
+	"testing"
+)
+
+// triangleEdges returns the three undirected edges of a triangle over a,b,c with
+// the given weight.
+func triangleEdges(a, b, c int64, w int) []ClusterEdge {
+	return []ClusterEdge{{A: a, B: b, Weight: w}, {A: b, B: c, Weight: w}, {A: a, B: c, Weight: w}}
+}
+
+// TestBuildClustersDeterministic runs the exact same graph three times and asserts
+// byte-identical output — the hard determinism requirement (#763).
+func TestBuildClustersDeterministic(t *testing.T) {
+	nodes := []ClusterNode{
+		{ID: 1, Text: "database index query"},
+		{ID: 2, Text: "database index query"},
+		{ID: 3, Text: "database index query"},
+		{ID: 4, Text: "network retry socket"},
+		{ID: 5, Text: "network retry socket"},
+		{ID: 6, Text: "network retry socket"},
+		{ID: 7, Text: "isolated orphan fact"},
+	}
+	var edges []ClusterEdge
+	edges = append(edges, triangleEdges(1, 2, 3, 4)...)
+	edges = append(edges, triangleEdges(4, 5, 6, 4)...)
+	// node 7 has no edges -> unclustered.
+
+	first := BuildClusters(nodes, edges)
+	for i := 0; i < 3; i++ {
+		got := BuildClusters(nodes, edges)
+		if !reflect.DeepEqual(first, got) {
+			t.Fatalf("BuildClusters not deterministic on run %d:\n first=%+v\n got  =%+v", i, first, got)
+		}
+	}
+
+	// Two real communities + the unclustered bucket last.
+	if len(first.Clusters) != 3 {
+		t.Fatalf("clusters = %d, want 3 (2 communities + unclustered): %+v", len(first.Clusters), first.Clusters)
+	}
+	// Real communities numbered from 1 in ascending medoid-id order.
+	a := first.Clusters[0]
+	b := first.Clusters[1]
+	unc := first.Clusters[2]
+	if a.ID != 1 || b.ID != 2 || unc.ID != UnclusteredID {
+		t.Fatalf("cluster ids = %d,%d,%d, want 1,2,%d", a.ID, b.ID, unc.ID, UnclusteredID)
+	}
+	if !reflect.DeepEqual(a.Members, []int64{1, 2, 3}) {
+		t.Fatalf("cluster A members = %v, want [1 2 3]", a.Members)
+	}
+	if !reflect.DeepEqual(b.Members, []int64{4, 5, 6}) {
+		t.Fatalf("cluster B members = %v, want [4 5 6]", b.Members)
+	}
+	// Medoid of a symmetric triangle is the lowest id.
+	if a.MedoidID != 1 || b.MedoidID != 4 {
+		t.Fatalf("medoids = %d,%d, want 1,4", a.MedoidID, b.MedoidID)
+	}
+	// The isolated node lands in the unclustered bucket.
+	if unc.Label != UnclusteredLabel || !reflect.DeepEqual(unc.Members, []int64{7}) {
+		t.Fatalf("unclustered = %q %v, want %q [7]", unc.Label, unc.Members, UnclusteredLabel)
+	}
+}
+
+// TestBuildClustersLabelDistinctiveness asserts the tf-idf-shaped label picks the
+// cluster's own distinctive terms (never a term shared across the whole corpus).
+func TestBuildClustersLabelDistinctiveness(t *testing.T) {
+	// Both clusters share the generic word "fact"; each has its own distinctive
+	// vocabulary. The generic term (df=2) must lose to the distinctive terms (df=1).
+	nodes := []ClusterNode{
+		{ID: 1, Text: "fact database index query"},
+		{ID: 2, Text: "fact database index query"},
+		{ID: 3, Text: "fact database index query"},
+		{ID: 4, Text: "fact network retry socket"},
+		{ID: 5, Text: "fact network retry socket"},
+		{ID: 6, Text: "fact network retry socket"},
+	}
+	var edges []ClusterEdge
+	edges = append(edges, triangleEdges(1, 2, 3, 4)...)
+	edges = append(edges, triangleEdges(4, 5, 6, 4)...)
+
+	res := BuildClusters(nodes, edges)
+	if len(res.Clusters) != 2 {
+		t.Fatalf("clusters = %d, want 2: %+v", len(res.Clusters), res.Clusters)
+	}
+	// Ranking is (tf DESC, df ASC, term ASC). Within a cluster every term has the
+	// same tf(3), but "fact" has df=2 (both clusters) so it ranks last; the three
+	// distinctive terms tie on df=1 and fall back to alphabetical order.
+	if got, want := res.Clusters[0].Label, "database-index-query"; got != want {
+		t.Fatalf("cluster A label = %q, want %q", got, want)
+	}
+	if got, want := res.Clusters[1].Label, "network-retry-socket"; got != want {
+		t.Fatalf("cluster B label = %q, want %q", got, want)
+	}
+}
+
+// TestBuildClustersPairAndSingletons covers a two-node community and multiple
+// isolated nodes all sharing the one unclustered bucket.
+func TestBuildClustersPairAndSingletons(t *testing.T) {
+	nodes := []ClusterNode{
+		{ID: 1, Text: "alpha alpha alpha"},
+		{ID: 2, Text: "alpha alpha alpha"},
+		{ID: 3, Text: "lonely"},
+		{ID: 4, Text: "solo"},
+	}
+	edges := []ClusterEdge{{A: 1, B: 2, Weight: 3}}
+
+	res := BuildClusters(nodes, edges)
+	if len(res.Clusters) != 2 {
+		t.Fatalf("clusters = %d, want 2 (one pair + unclustered): %+v", len(res.Clusters), res.Clusters)
+	}
+	pair := res.Clusters[0]
+	unc := res.Clusters[1]
+	if pair.ID != 1 || !reflect.DeepEqual(pair.Members, []int64{1, 2}) {
+		t.Fatalf("pair = id%d %v, want id1 [1 2]", pair.ID, pair.Members)
+	}
+	if unc.ID != UnclusteredID || !reflect.DeepEqual(unc.Members, []int64{3, 4}) {
+		t.Fatalf("unclustered = id%d %v, want id0 [3 4]", unc.ID, unc.Members)
+	}
+}
+
+// TestBuildClustersEmpty asserts an empty graph yields no clusters.
+func TestBuildClustersEmpty(t *testing.T) {
+	res := BuildClusters(nil, nil)
+	if len(res.Clusters) != 0 {
+		t.Fatalf("empty graph clusters = %d, want 0", len(res.Clusters))
+	}
+}
+
+// TestMedoidHighestIntraSimilarity asserts the medoid is the most-connected member
+// (highest total intra-cluster edge weight), lowest id on ties.
+func TestMedoidHighestIntraSimilarity(t *testing.T) {
+	// Star: node 2 is central (connects to 1,3,4); the spokes each touch only 2.
+	nodes := []ClusterNode{
+		{ID: 1, Text: "hub spoke"},
+		{ID: 2, Text: "hub spoke"},
+		{ID: 3, Text: "hub spoke"},
+		{ID: 4, Text: "hub spoke"},
+	}
+	edges := []ClusterEdge{
+		{A: 2, B: 1, Weight: 5},
+		{A: 2, B: 3, Weight: 5},
+		{A: 2, B: 4, Weight: 5},
+	}
+	res := BuildClusters(nodes, edges)
+	if len(res.Clusters) != 1 {
+		t.Fatalf("clusters = %d, want 1: %+v", len(res.Clusters), res.Clusters)
+	}
+	if res.Clusters[0].MedoidID != 2 {
+		t.Fatalf("medoid = %d, want 2 (the hub)", res.Clusters[0].MedoidID)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1761,6 +1761,54 @@ gracefully rather than aborting the batch. See
 [`docs/examples/memory-groom-nightly`](../../../docs/examples/memory-groom-nightly/README.md)
 for a ready-to-register nightly proposal pipeline.
 
+### memory clusters (#763)
+
+`memory clusters` surfaces **emergent memory clusters** — communities detected over
+the fact-similarity graph, the **same** bm25 + id-tiebreak signal the vault
+`[[links]]` use. They replace the old fixed key-prefix "category" hubs on the
+dashboard Knowledge view: clusters are discovered from what the facts actually say,
+not from how their keys happen to be namespaced.
+
+```sh
+gitmoot memory clusters [--json]
+gitmoot memory clusters recompute --propose [--out PLAN.json] [--json]
+gitmoot memory clusters recompute --apply [--plan PLAN.json] [--json]
+gitmoot memory cluster rename <cluster-id> <label>
+```
+
+- `memory clusters` lists each cluster with its display label (the owner override
+  when set, else the computed label), member count, and medoid fact id. The
+  reserved cluster **0 `unclustered`** holds facts with no similarity neighbors.
+- **Determinism is guaranteed.** The community detection is **id-ordered label
+  propagation** with **lowest-label tie-breaks** over a fixed graph: node visit
+  order is the sorted fact ids, initial labels are the ids themselves, neighbor
+  influence is a weight *sum* (order-independent), and every tie resolves to the
+  lowest label. There is no map-iteration order, randomness, or wall-clock input
+  anywhere, so the **same store always yields byte-identical clusters, labels,
+  medoids, and cluster ids** — matching the vault byte-identity house rule.
+- **Labels** are up to three **distinctive terms**, ranked by term frequency inside
+  the cluster weighted against corpus document frequency (frequent-inside-yet-
+  rare-across-clusters wins), joined with `-` and anchored to the **medoid** fact
+  for stability. The **medoid** is the member with the highest total intra-cluster
+  similarity (lowest id breaks ties).
+- **`recompute`** is a human-gated **propose → review → apply** round-trip, mirroring
+  `memory groom`. `--propose` rebuilds the clustering and writes a reviewable plan
+  (`{schema_version, anchor, clusters, moves, new_facts, dropped_facts, stats}`)
+  showing what would move, without touching the store. `--apply --plan` recomputes
+  the **staleness anchor** (a hash over every active fact's `(id, updated_at)`),
+  **aborts as stale** if the store changed since the proposal, then writes the whole
+  clustering in **one transaction**. **First run:** when no clusters exist yet there
+  is nothing to protect, so `recompute --apply` (no `--plan`) is allowed and builds
+  them directly.
+- **Incremental attach:** confirming a **new** fact (`memory confirm`) best-effort
+  attaches it to the cluster of its nearest similarity neighbor (or the `unclustered`
+  bucket) without a full recompute; the attach never blocks a confirmation. Nothing
+  is ever re-shelved silently — wholesale re-clustering is always the explicit
+  `recompute` proposal.
+- `memory cluster rename` sets an **owner label override** that wins over the
+  computed label and is carried across recomputes by medoid identity (a blank label
+  clears it). The reserved `unclustered` bucket cannot be renamed.
+
 ## Pipelines
 
 A pipeline (#681) runs a **declared DAG of shell stages** — a fixed, repeatable

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -252,6 +252,42 @@ A ready-to-register nightly proposal pipeline (propose + notify-on-nonempty, app
 held behind the owner) lives in
 [`docs/examples/memory-groom-nightly`](https://github.com/jerryfane/gitmoot/tree/main/docs/examples/memory-groom-nightly).
 
+## Emergent clusters
+
+`memory clusters` groups confirmed facts into **emergent communities** detected over
+the fact-similarity graph — the **same** bm25 + id-tiebreak signal the vault
+`[[links]]` use. They replace the dashboard's old fixed key-prefix "category" hubs:
+clusters are discovered from what facts actually say, not how their keys are namespaced.
+
+```sh
+gitmoot memory clusters [--json]
+gitmoot memory clusters recompute --propose [--out PLAN.json] [--json]
+gitmoot memory clusters recompute --apply [--plan PLAN.json] [--json]
+gitmoot memory cluster rename <cluster-id> <label>
+```
+
+- **Deterministic by construction.** The community detection is **id-ordered label
+  propagation** with **lowest-label tie-breaks** over a fixed graph (sorted-id visit
+  order, id-valued initial labels, summed neighbor influence). No map order,
+  randomness, or wall clock enters, so the **same store yields byte-identical
+  clusters, labels, medoids, and cluster ids** — matching the vault byte-identity rule.
+- **Labels** are up to three distinctive terms (term frequency inside the cluster
+  weighted against corpus document frequency), joined with `-` and anchored to the
+  cluster **medoid** (the member with the highest total intra-cluster similarity) for
+  stability. Facts with no neighbors fall into the reserved cluster **0 `unclustered`**.
+- **`recompute`** is a human-gated **propose → review → apply** round-trip like
+  `memory groom`: `--propose` writes a reviewable plan of the moves/merges plus a
+  **staleness anchor** over every active fact's `(id, updated_at)`; `--apply --plan`
+  re-checks the anchor, **aborts as stale** if the store moved, then rewrites the
+  whole clustering in one transaction. On **first run** (no clusters yet) a bare
+  `recompute --apply` is allowed since there is nothing to protect.
+- **Incremental attach:** confirming a new fact best-effort joins it to the cluster
+  of its nearest neighbor without a full recompute; nothing is re-shelved silently.
+- `memory cluster rename` sets an **owner label override** that wins over the computed
+  label and survives recomputes (anchored to the medoid).
+
+The dashboard Knowledge view renders this as a **repo → cluster → fact** hierarchy.
+
 ## Phases
 
 - **Phase 0** — typed `learnings` in the result contract; the two-table schema

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1348,6 +1348,10 @@ gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
 gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
 gitmoot memory groom --propose [--out PLAN.json] [--json]
 gitmoot memory groom --yes --plan PLAN.json [--json]
+gitmoot memory clusters [--json]
+gitmoot memory clusters recompute --propose [--out PLAN.json] [--json]
+gitmoot memory clusters recompute --apply [--plan PLAN.json] [--json]
+gitmoot memory cluster rename <cluster-id> <label>
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
@@ -1415,6 +1419,23 @@ retires exactly the planned ids in one transaction (reason `groom:<detector>`). 
 is retire-only and idempotent (already-retired ids are skipped). A ready-to-register
 nightly proposal pipeline lives under
 [`docs/examples/memory-groom-nightly`](https://github.com/jerryfane/gitmoot/tree/main/docs/examples/memory-groom-nightly).
+
+`memory clusters` groups confirmed facts into **emergent communities** over the
+fact-similarity graph (the same bm25 + id-tiebreak signal the vault `[[links]]` use),
+retiring the dashboard's old fixed key-prefix "category" hubs. The community detection
+is **id-ordered label propagation with lowest-label tie-breaks** — a pure function of
+the graph, so the **same store yields byte-identical clusters, labels, medoids, and
+ids**. Labels are up to three distinctive terms (cluster term frequency weighted
+against corpus document frequency), anchored to the cluster **medoid**; facts with no
+neighbors fall into the reserved cluster **0 `unclustered`**. `recompute` is a
+human-gated **propose → apply** round-trip: `--propose` writes a plan with a staleness
+**anchor** over each active fact's `(id, updated_at)`; `--apply --plan` re-checks the
+anchor, **aborts as stale** on drift, then rewrites the whole clustering in one
+transaction (a bare `--apply` is allowed only on first run, when nothing exists to
+protect). Confirming a new fact best-effort attaches it to the nearest neighbor's
+cluster; `memory cluster rename` sets an owner label override that wins over the
+computed label and survives recomputes. The Knowledge view renders a **repo → cluster
+→ fact** hierarchy.
 
 ## Pipelines
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9796,6 +9796,54 @@ gracefully rather than aborting the batch. See
 [`docs/examples/memory-groom-nightly`](../../../docs/examples/memory-groom-nightly/README.md)
 for a ready-to-register nightly proposal pipeline.
 
+### memory clusters (#763)
+
+`memory clusters` surfaces **emergent memory clusters** — communities detected over
+the fact-similarity graph, the **same** bm25 + id-tiebreak signal the vault
+`[[links]]` use. They replace the old fixed key-prefix "category" hubs on the
+dashboard Knowledge view: clusters are discovered from what the facts actually say,
+not from how their keys happen to be namespaced.
+
+```sh
+gitmoot memory clusters [--json]
+gitmoot memory clusters recompute --propose [--out PLAN.json] [--json]
+gitmoot memory clusters recompute --apply [--plan PLAN.json] [--json]
+gitmoot memory cluster rename <cluster-id> <label>
+```
+
+- `memory clusters` lists each cluster with its display label (the owner override
+  when set, else the computed label), member count, and medoid fact id. The
+  reserved cluster **0 `unclustered`** holds facts with no similarity neighbors.
+- **Determinism is guaranteed.** The community detection is **id-ordered label
+  propagation** with **lowest-label tie-breaks** over a fixed graph: node visit
+  order is the sorted fact ids, initial labels are the ids themselves, neighbor
+  influence is a weight *sum* (order-independent), and every tie resolves to the
+  lowest label. There is no map-iteration order, randomness, or wall-clock input
+  anywhere, so the **same store always yields byte-identical clusters, labels,
+  medoids, and cluster ids** — matching the vault byte-identity house rule.
+- **Labels** are up to three **distinctive terms**, ranked by term frequency inside
+  the cluster weighted against corpus document frequency (frequent-inside-yet-
+  rare-across-clusters wins), joined with `-` and anchored to the **medoid** fact
+  for stability. The **medoid** is the member with the highest total intra-cluster
+  similarity (lowest id breaks ties).
+- **`recompute`** is a human-gated **propose → review → apply** round-trip, mirroring
+  `memory groom`. `--propose` rebuilds the clustering and writes a reviewable plan
+  (`{schema_version, anchor, clusters, moves, new_facts, dropped_facts, stats}`)
+  showing what would move, without touching the store. `--apply --plan` recomputes
+  the **staleness anchor** (a hash over every active fact's `(id, updated_at)`),
+  **aborts as stale** if the store changed since the proposal, then writes the whole
+  clustering in **one transaction**. **First run:** when no clusters exist yet there
+  is nothing to protect, so `recompute --apply` (no `--plan`) is allowed and builds
+  them directly.
+- **Incremental attach:** confirming a **new** fact (`memory confirm`) best-effort
+  attaches it to the cluster of its nearest similarity neighbor (or the `unclustered`
+  bucket) without a full recompute; the attach never blocks a confirmation. Nothing
+  is ever re-shelved silently — wholesale re-clustering is always the explicit
+  `recompute` proposal.
+- `memory cluster rename` sets an **owner label override** that wins over the
+  computed label and is carried across recomputes by medoid identity (a blank label
+  clears it). The reserved `unclustered` bucket cannot be renamed.
+
 ## Pipelines
 
 A pipeline (#681) runs a **declared DAG of shell stages** — a fixed, repeatable


### PR DESCRIPTION
Part of #763 (Track A — bridge/store: emergent memory clusters).

## What

Clusters are now **emergent communities** over the fact-similarity graph — the *same* bm25 + id-tiebreak signal the vault `[[links]]` use — replacing the dashboard's retired fixed key-prefix "category" hubs.

### Store + clustering (deterministic)
- `internal/memory/cluster.go` — pure community detection: **id-ordered label propagation** with **lowest-label tie-breaks**, initial label = fact id, summed neighbor influence. No map order, randomness, or wall-clock anywhere, so the **same store yields byte-identical clusters, labels, medoids, and cluster ids** (the vault byte-identity house rule). Labels are up to three distinctive terms (cluster term frequency weighted against corpus document frequency, integer-ranked so no float compares), joined with `-` and anchored to the **medoid** (highest total intra-cluster similarity, lowest id tie-break). Facts with no neighbors → reserved cluster `0 unclustered`.
- `internal/db` — additive `memory_clusters` + `memory_cluster_members` tables (append-only migration tail, `CREATE TABLE` only; empty until used ⇒ byte-identical on any pre-migration DB). Recompute-in-tx (replaces all rows, **carries owner label overrides forward by medoid identity**), incremental attach, rename, list/read.

### CLI
- `gitmoot memory clusters [--json]` — list clusters (display label = override||computed, counts, medoid).
- `gitmoot memory clusters recompute --propose [--out F] / --apply [--plan F]` — human-gated propose→apply mirroring `memory groom`: `--propose` writes a plan (`{schema_version, anchor, clusters, moves, new/dropped facts, stats}`) with a **staleness anchor over every active fact's (id, updated_at)**; `--apply --plan` re-checks the anchor, **aborts as stale** on drift, writes the whole clustering in one tx. **First run** (no clusters) allows a bare `--apply`.
- `gitmoot memory cluster rename <id> <label>` — owner override (wins over computed label, survives recompute).
- **Incremental attach** hooked into `memory confirm`: a newly confirmed fact best-effort joins its nearest neighbor's cluster (or the unclustered bucket); fail-safe, never blocks a confirm; never re-shelves an existing assignment.

### Bridge
- `dashboard_web_learning.go` — retire the `knowledgeCategory` key-prefix hack; the Knowledge DataSource emits **cluster** edges from persisted membership + a **repo → cluster → fact** tier. Kept **additive** to the current `github.com/jerryfane/gitmoot-dashboard` interface (edge `Kind` strings only — builds against the pinned version).

### Docs
Skill `CLI.md`, website `agent-memory.md` + `reference/cli.md`, regenerated `llms-full.txt`.

## Two-repo coordination (#528)
Track B's `feat/763-knowledge-ui` branch on `jerryfane/gitmoot-dashboard` (the new interface: a label-carrying `KnowledgeCluster` hub struct + per-fact detail-panel fields — provenance/source_job/trust/linked ids) is **not pushed yet**, so this PR pins the current dashboard pseudo-version and delivers the bridge groundwork within the existing interface (cluster + repo-tier **edges**). **Post-merge re-pin:** once Track B's interface lands, a follow-up pins its pseudo-version in `go.mod` and fills in the cluster-hub labels/counts + per-fact detail fields.

## Gate
- `go build ./...` ✓ · `go vet ./...` ✓
- `go test ./internal/db/` ✓ (full, validates migration) · `go test ./internal/cli/` ✓ (full)
- `go test -race ./internal/memory/` ✓ · `go test -race ./internal/cli/ -run 'Cluster|Knowledge'` ✓
- `website`: `npm ci && npm run build` ✓
- Real-binary e2e: ingest → confirm → recompute → list → rename verified.

## Tests
Determinism (3× byte-identical), label distinctiveness (seeded corpus), medoid selection, pair+singleton/unclustered handling, propose/apply staleness abort, rename override wins + survives recompute, incremental attach, and the bridge repo→cluster→fact hierarchy shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)