### PR TITLE
refactor(pipeline): stage-kind foundation — Kind() + kind-dispatched validation + pluggable settle-predicate seam

### DIFF
--- a/internal/cli/pipeline_advance_test.go
+++ b/internal/cli/pipeline_advance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -549,6 +550,76 @@ func TestAdvancerIdempotentRescan(t *testing.T) {
 	}
 	if got := stageRow(t, store, run.ID, "b").JobID; got != bJob {
 		t.Fatalf("re-scan changed stage b job id: before=%q after=%q", bJob, got)
+	}
+}
+
+// TestPipelineStageSettleOutcomeDefaultMatchesFold pins the settle-predicate seam
+// (stageSettleOutcome) for today's kinds: (1) a non-terminal stage job is NOT
+// settled, so the FOLD pass leaves it in flight; (2) once the job settles, the seam
+// reports settled AND returns EXACTLY what foldPipelineStageOutcome returns for the
+// same job — for a shell stage AND a read-only agent stage, across a success and a
+// blocked/needs decision. This is the byte-identity contract a future gate/orchestrate
+// kind must not disturb for existing kinds.
+func TestPipelineStageSettleOutcomeDefaultMatchesFold(t *testing.T) {
+	const settleSpec = `name: settle
+repo: owner/repo
+stages:
+  - id: sh
+    cmd: echo hi
+  - id: ag
+    agent: asker
+    prompt: What changed?
+`
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "settle", settleSpec)
+	now := time.Date(2026, 7, 8, 9, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	ctx := context.Background()
+
+	specByID := make(map[string]pipeline.Stage, len(spec.Stages))
+	for _, s := range spec.Stages {
+		specByID[s.ID] = s
+	}
+
+	cases := []struct {
+		stageID, decision, summary string
+		needs                      []string
+	}{
+		{"sh", "approved", "shell landed", nil},
+		{"ag", "blocked", "needs a hint", []string{"which module?"}},
+	}
+	for _, tc := range cases {
+		row := stageRow(t, store, run.ID, tc.stageID)
+		if row.JobID == "" {
+			t.Fatalf("%s: stage not enqueued (job id empty)", tc.stageID)
+		}
+		stage := specByID[tc.stageID]
+
+		// (1) Before settling, the job is queued/running: the seam reports unsettled,
+		// matching the inline IsSettledJobState guard the FOLD pass used to run.
+		pending, err := store.GetJob(ctx, row.JobID)
+		if err != nil {
+			t.Fatalf("GetJob(%s): %v", tc.stageID, err)
+		}
+		if settled, _, _, _ := stageSettleOutcome(ctx, pipelineStageSettleDeps{}, spec, stage, row, pending); settled {
+			t.Fatalf("%s: seam settled a non-terminal job (state=%q)", tc.stageID, pending.State)
+		}
+
+		// (2) After settling, the seam must settle and return the identical fold.
+		settleStageJob(t, store, row.JobID, tc.decision, tc.summary, tc.needs)
+		job, err := store.GetJob(ctx, row.JobID)
+		if err != nil {
+			t.Fatalf("GetJob(%s) after settle: %v", tc.stageID, err)
+		}
+		wantState, wantSummary, wantNeeds := foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
+		settled, gotState, gotSummary, gotNeeds := stageSettleOutcome(ctx, pipelineStageSettleDeps{}, spec, stage, row, job)
+		if !settled {
+			t.Fatalf("%s: seam did not settle a terminal job (state=%q)", tc.stageID, job.State)
+		}
+		if gotState != wantState || gotSummary != wantSummary || !reflect.DeepEqual(gotNeeds, wantNeeds) {
+			t.Fatalf("%s: seam (%q,%q,%v) != fold (%q,%q,%v)", tc.stageID, gotState, gotSummary, gotNeeds, wantState, wantSummary, wantNeeds)
+		}
 	}
 }
 

--- a/internal/cli/pipeline_advance_test.go
+++ b/internal/cli/pipeline_advance_test.go
@@ -596,14 +596,18 @@ stages:
 		}
 		stage := specByID[tc.stageID]
 
+		// The seam loads the job itself via deps.store, so a jobless future kind is
+		// never handed a fabricated job; today's kinds read only the store.
+		deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now}
+
 		// (1) Before settling, the job is queued/running: the seam reports unsettled,
 		// matching the inline IsSettledJobState guard the FOLD pass used to run.
 		pending, err := store.GetJob(ctx, row.JobID)
 		if err != nil {
 			t.Fatalf("GetJob(%s): %v", tc.stageID, err)
 		}
-		if settled, _, _, _ := stageSettleOutcome(ctx, pipelineStageSettleDeps{}, spec, stage, row, pending); settled {
-			t.Fatalf("%s: seam settled a non-terminal job (state=%q)", tc.stageID, pending.State)
+		if settled, _, _, _, _, err := stageSettleOutcome(ctx, deps, spec, stage, row); err != nil || settled {
+			t.Fatalf("%s: seam settled a non-terminal job (state=%q, err=%v)", tc.stageID, pending.State, err)
 		}
 
 		// (2) After settling, the seam must settle and return the identical fold.
@@ -613,7 +617,10 @@ stages:
 			t.Fatalf("GetJob(%s) after settle: %v", tc.stageID, err)
 		}
 		wantState, wantSummary, wantNeeds := foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
-		settled, gotState, gotSummary, gotNeeds := stageSettleOutcome(ctx, pipelineStageSettleDeps{}, spec, stage, row, job)
+		settled, gotState, gotSummary, gotNeeds, _, err := stageSettleOutcome(ctx, deps, spec, stage, row)
+		if err != nil {
+			t.Fatalf("%s: seam returned err on terminal job: %v", tc.stageID, err)
+		}
 		if !settled {
 			t.Fatalf("%s: seam did not settle a terminal job (state=%q)", tc.stageID, job.State)
 		}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -514,7 +514,9 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 		if err != nil {
 			return run, err
 		}
-		if !workflow.IsSettledJobState(job.State) {
+		deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now}
+		settled, state, summary, needs := stageSettleOutcome(ctx, deps, spec, stage, row, job)
+		if !settled {
 			// Not terminal yet: reflect a queued->running transition so the funnel
 			// tracks the live job, but otherwise leave it in flight.
 			if job.State == string(workflow.JobRunning) && row.State == pipeline.StageQueued {
@@ -526,7 +528,6 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 			}
 			continue
 		}
-		state, summary, needs := foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
 		if state == pipeline.StageFailed && row.Attempt < stage.Retry {
 			// Retry budget remains: bump the attempt and reset to pending so the
 			// enqueue phase re-launches it under a fresh deterministic id/fingerprint.
@@ -660,6 +661,62 @@ func applyPipelineRunSettlement(ctx context.Context, store *db.Store, rec db.Pip
 		return run, err
 	}
 	return updated, nil
+}
+
+// pipelineStageSettleDeps carries the ambient capabilities the per-kind settle
+// predicate (stageSettleOutcome) may need. Today's kinds (shell, agent ask/review)
+// use only the already-loaded job, so every field goes unread — they are threaded
+// now so a future kind is a NEW case in the seam, NOT a widening of the advancer
+// signature or a re-plumb of the FOLD pass. Everything here is already in scope in
+// advancePipelineRun. What the deferred kinds want:
+//   - StageKindGate (#768 Phase 2): a gate has no job/worker; it settles when an
+//     external predicate holds (e.g. pr_merged on an upstream implement stage's
+//     PR). That reads the managed repo (rec) and upstream stage rows via store, and
+//     bounds the wait against the stage timeout using now. GitHub access would be
+//     threaded into this struct then (a client/poller field), not into the caller.
+//   - StageKindOrchestrate (#758): the stage job is a sub-tree root; it settles by
+//     walking the deterministic <jobID>/continuation chain (via store) to its
+//     terminal tail. ctx bounds those store reads.
+type pipelineStageSettleDeps struct {
+	store *db.Store
+	rec   db.Pipeline
+	run   db.PipelineRun
+	now   time.Time
+}
+
+// stageSettleOutcome is the per-stage-kind SETTLE PREDICATE seam. Given a stage
+// whose current job row has been loaded, it reports whether the stage has SETTLED
+// into a foldable outcome and, if so, the folded (state, summary, needs). It is the
+// single dispatch point the FOLD pass consults instead of inlining "is the stage
+// job terminal => foldPipelineStageOutcome"; a new stage kind adds a case here and
+// never edits the shared advancer. This is exactly the generalization #768 Phase 2
+// (gate: pr_merged) and #758 (orchestrate: continuation-chain-terminal) both build
+// on.
+//
+// Today every kind settles identically — a shell or read-only agent (#757) stage
+// settles the instant its job reaches a terminal state, folding by decision via
+// foldPipelineStageOutcome — so the default case reproduces the pre-seam inline
+// behavior BYTE-IDENTICALLY: `settled` is true exactly when the job is terminal,
+// and the folded outcome is identical. The unsettled path (the queued->running
+// funnel reflect) stays in the advancer, unchanged. Future kinds branch here on
+// stage.Kind() using deps (see pipelineStageSettleDeps).
+func stageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec pipeline.Spec, stage pipeline.Stage, stageRow db.PipelineRunStage, job db.Job) (settled bool, state, summary string, needs []string) {
+	switch stage.Kind() {
+	// A future kind adds its case here, e.g.:
+	//   case pipeline.StageKindGate:
+	//       return gateStageSettleOutcome(ctx, deps, spec, stage, stageRow)
+	//   case pipeline.StageKindOrchestrate:
+	//       return orchestrateStageSettleOutcome(ctx, deps, spec, stage, stageRow, job)
+	default:
+		// StageKindShell, StageKindAgentAsk, StageKindAgentReview (and the
+		// never-validated StageKindUnknown): settle on the stage job reaching a
+		// terminal state; fold by decision. Byte-identical to the pre-seam inline.
+		if !workflow.IsSettledJobState(job.State) {
+			return false, "", "", nil
+		}
+		state, summary, needs = foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
+		return true, state, summary, needs
+	}
 }
 
 // foldPipelineStageOutcome maps a settled stage job to a stage outcome BY DECISION

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -191,6 +191,21 @@ func pipelineStageFingerprint(pipelineName, runID, stageID string, attempt int) 
 // ParentJobID would enter delegation advancement, engine.go); RootJobID is the run
 // id so all of a run's stage jobs share a root. The per-stage timeout is plumbed
 // as JobTimeout.
+// pipelineStageMintsJob reports whether a newly-ready stage of this kind enqueues a
+// worker job in the ENQUEUE pass. Every kind today (shell, agent ask/review) does,
+// so this is always true and the enqueue loop is byte-identical. A future JOBLESS
+// gate (#768 Phase 2) appends `case pipeline.StageKindGate: return false`, at which
+// point the enqueue loop marks the stage in-flight without a job and the settle seam
+// waits on the external predicate — a pure per-kind append, never an edit to the
+// shared enqueue loop or to pipelineStageJobRequest (which stays the per-kind REQUEST
+// builder: an implement kind #768 appends its writable-worktree/branch branch there).
+func pipelineStageMintsJob(stage pipeline.Stage) bool {
+	switch stage.Kind() {
+	default:
+		return true
+	}
+}
+
 func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.PipelineRun, attempt int, upstreamContext string) workflow.JobRequest {
 	// AGENT stage (#757): bind the job to the named managed agent and let IT run on
 	// its OWN registered runtime — no RuntimeOverride, so the agent's real
@@ -507,24 +522,25 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 		if row.State != pipeline.StageQueued && row.State != pipeline.StageRunning {
 			continue
 		}
-		if strings.TrimSpace(row.JobID) == "" {
-			continue
-		}
-		job, err := store.GetJob(ctx, row.JobID)
+		// The per-kind settle predicate owns everything job-shaped: whether the stage
+		// even has a job (the JobID guard), loading it, and the queued->running funnel
+		// reflect. That is deliberate — a future JOBLESS kind (gate) is reachable here
+		// without moving a guard out of a shared loop, and an unsettled kind can hand
+		// back a row mutation (nextRow) to persist while it keeps waiting.
+		deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now}
+		settled, state, summary, needs, nextRow, err := stageSettleOutcome(ctx, deps, spec, stage, row)
 		if err != nil {
 			return run, err
 		}
-		deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now}
-		settled, state, summary, needs := stageSettleOutcome(ctx, deps, spec, stage, row, job)
 		if !settled {
-			// Not terminal yet: reflect a queued->running transition so the funnel
-			// tracks the live job, but otherwise leave it in flight.
-			if job.State == string(workflow.JobRunning) && row.State == pipeline.StageQueued {
-				row.State = pipeline.StageRunning
-				if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+			// Not terminal yet. The seam may still return a row mutation to persist:
+			// today the queued->running funnel reflect; a future orchestrate kind
+			// re-points nextRow.JobID at its continuation and stays unsettled.
+			if nextRow != nil {
+				if err := persistPipelineStage(ctx, store, byID[stage.ID], *nextRow); err != nil {
 					return run, err
 				}
-				byID[stage.ID] = row
+				byID[stage.ID] = *nextRow
 			}
 			continue
 		}
@@ -559,6 +575,21 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 	for _, stage := range spec.Stages {
 		row := byID[stage.ID]
 		if row.State != pipeline.StagePending || !pipelineStageDepsSucceeded(stage, byID) {
+			continue
+		}
+		if !pipelineStageMintsJob(stage) {
+			// A JOBLESS kind (future gate #768 Phase 2) becomes in-flight WITHOUT a
+			// worker job; the settle seam (which owns the JobID guard) then drives it
+			// on its external predicate. No kind today is jobless, so this branch is
+			// never taken and the enqueue path below is byte-identical. Kept here so a
+			// gate is a pure append (`case StageKindGate: return false` in
+			// pipelineStageMintsJob), not an edit to this shared enqueue loop.
+			row.State = pipeline.StageQueued
+			row.StartedAt = now
+			if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+				return run, err
+			}
+			byID[stage.ID] = row
 			continue
 		}
 		// For an AGENT stage, inject the results of the stages it needs into its
@@ -664,19 +695,27 @@ func applyPipelineRunSettlement(ctx context.Context, store *db.Store, rec db.Pip
 }
 
 // pipelineStageSettleDeps carries the ambient capabilities the per-kind settle
-// predicate (stageSettleOutcome) may need. Today's kinds (shell, agent ask/review)
-// use only the already-loaded job, so every field goes unread — they are threaded
+// predicate (stageSettleOutcome) may need. The seam loads the stage's job ITSELF via
+// store (today's shell + read-only agent kinds), so a future JOBLESS kind is not
+// forced to fabricate one. Today's kinds read only store; rec/run/now are threaded
 // now so a future kind is a NEW case in the seam, NOT a widening of the advancer
 // signature or a re-plumb of the FOLD pass. Everything here is already in scope in
 // advancePipelineRun. What the deferred kinds want:
 //   - StageKindGate (#768 Phase 2): a gate has no job/worker; it settles when an
 //     external predicate holds (e.g. pr_merged on an upstream implement stage's
-//     PR). That reads the managed repo (rec) and upstream stage rows via store, and
-//     bounds the wait against the stage timeout using now. GitHub access would be
-//     threaded into this struct then (a client/poller field), not into the caller.
+//     PR). Because the seam — not the advancer — owns the "does this stage have a
+//     job" question, a gate case simply never calls store.GetJob; it reads the
+//     managed repo (rec) and upstream stage rows via store, and bounds the wait
+//     against the stage timeout using now. GitHub access would be threaded into this
+//     struct then (a client/poller field), not into the caller. Such a predicate
+//     MUST be non-blocking and ctx-bounded and MUST fail OPEN (return settled=false,
+//     never a hung poll) — the FOLD pass runs it synchronously across every in-flight
+//     run, and a settle error is propagated (err), never swallowed.
 //   - StageKindOrchestrate (#758): the stage job is a sub-tree root; it settles by
 //     walking the deterministic <jobID>/continuation chain (via store) to its
-//     terminal tail. ctx bounds those store reads.
+//     terminal tail. While the tail is still live it re-points the row's JobID at the
+//     current continuation and stays unsettled by returning that row as nextRow. ctx
+//     bounds those store reads.
 type pipelineStageSettleDeps struct {
 	store *db.Store
 	rec   db.Pipeline
@@ -684,38 +723,67 @@ type pipelineStageSettleDeps struct {
 	now   time.Time
 }
 
-// stageSettleOutcome is the per-stage-kind SETTLE PREDICATE seam. Given a stage
-// whose current job row has been loaded, it reports whether the stage has SETTLED
-// into a foldable outcome and, if so, the folded (state, summary, needs). It is the
-// single dispatch point the FOLD pass consults instead of inlining "is the stage
-// job terminal => foldPipelineStageOutcome"; a new stage kind adds a case here and
-// never edits the shared advancer. This is exactly the generalization #768 Phase 2
+// stageSettleOutcome is the per-stage-kind SETTLE PREDICATE seam. Given an in-flight
+// (queued/running) stage row, it reports whether the stage has SETTLED into a
+// foldable outcome and, if so, the folded (state, summary, needs). It is the single
+// dispatch point the FOLD pass consults instead of inlining "load the job; is it
+// terminal => foldPipelineStageOutcome"; a new stage kind adds a case here and never
+// edits the shared advancer. This is exactly the generalization #768 Phase 2
 // (gate: pr_merged) and #758 (orchestrate: continuation-chain-terminal) both build
 // on.
+//
+// The seam owns EVERYTHING job-shaped so the three future kinds are pure appends:
+//   - It loads the stage's job itself (via deps.store), so a JOBLESS kind (gate)
+//     never has to be handed a fabricated job — its case simply never calls GetJob.
+//   - When a kind is NOT settled but wants to persist a row mutation this pass, it
+//     returns it as nextRow (non-nil). Today that carries only the queued->running
+//     funnel reflect; a future orchestrate kind re-points nextRow.JobID at its
+//     deterministic continuation and stays unsettled. nil = leave the row untouched.
+//   - It returns err so a settle predicate that does I/O (a future gate polling
+//     GitHub) can surface a transient failure to the advancer rather than swallow it;
+//     such predicates MUST be non-blocking, ctx-bounded, and fail OPEN (settled=false).
 //
 // Today every kind settles identically — a shell or read-only agent (#757) stage
 // settles the instant its job reaches a terminal state, folding by decision via
 // foldPipelineStageOutcome — so the default case reproduces the pre-seam inline
-// behavior BYTE-IDENTICALLY: `settled` is true exactly when the job is terminal,
-// and the folded outcome is identical. The unsettled path (the queued->running
-// funnel reflect) stays in the advancer, unchanged. Future kinds branch here on
-// stage.Kind() using deps (see pipelineStageSettleDeps).
-func stageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec pipeline.Spec, stage pipeline.Stage, stageRow db.PipelineRunStage, job db.Job) (settled bool, state, summary string, needs []string) {
+// behavior BYTE-IDENTICALLY: the JobID guard, the GetJob, the queued->running funnel
+// reflect (now returned as nextRow), and `settled` true exactly when the job is
+// terminal, all unchanged. Future kinds branch here on stage.Kind() using deps.
+func stageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec pipeline.Spec, stage pipeline.Stage, stageRow db.PipelineRunStage) (settled bool, state, summary string, needs []string, nextRow *db.PipelineRunStage, err error) {
 	switch stage.Kind() {
 	// A future kind adds its case here, e.g.:
-	//   case pipeline.StageKindGate:
+	//   case pipeline.StageKindGate:       // jobless: never calls GetJob
 	//       return gateStageSettleOutcome(ctx, deps, spec, stage, stageRow)
-	//   case pipeline.StageKindOrchestrate:
-	//       return orchestrateStageSettleOutcome(ctx, deps, spec, stage, stageRow, job)
+	//   case pipeline.StageKindOrchestrate: // re-points nextRow.JobID, stays unsettled
+	//       return orchestrateStageSettleOutcome(ctx, deps, spec, stage, stageRow)
 	default:
 		// StageKindShell, StageKindAgentAsk, StageKindAgentReview (and the
-		// never-validated StageKindUnknown): settle on the stage job reaching a
-		// terminal state; fold by decision. Byte-identical to the pre-seam inline.
+		// never-validated StageKindUnknown): a jobful stage that settles on its stage
+		// job reaching a terminal state; fold by decision. The JobID guard and the
+		// queued->running funnel reflect live HERE (not the shared advancer) so a
+		// future JOBLESS kind is reachable without moving them.
+		if strings.TrimSpace(stageRow.JobID) == "" {
+			// A jobful stage with no job yet: leave it in flight untouched —
+			// byte-identical to the pre-seam advancer's `if row.JobID == "" { continue }`.
+			return false, "", "", nil, nil, nil
+		}
+		job, err := deps.store.GetJob(ctx, stageRow.JobID)
+		if err != nil {
+			return false, "", "", nil, nil, err
+		}
 		if !workflow.IsSettledJobState(job.State) {
-			return false, "", "", nil
+			// Not terminal yet: reflect a queued->running transition so the funnel
+			// tracks the live job, but otherwise leave it in flight. Byte-identical to
+			// the advancer's former unsettled branch.
+			if job.State == string(workflow.JobRunning) && stageRow.State == pipeline.StageQueued {
+				next := stageRow
+				next.State = pipeline.StageRunning
+				return false, "", "", nil, &next, nil
+			}
+			return false, "", "", nil, nil, nil
 		}
 		state, summary, needs = foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
-		return true, state, summary, needs
+		return true, state, summary, needs, nil, nil
 	}
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -210,6 +210,66 @@ func TestLoadValidationErrors(t *testing.T) {
 	}
 }
 
+// TestStageKind pins Stage.Kind() over every current stage shape — the SINGLE
+// place a stage kind is decided. It covers the well-formed kinds (shell, agent
+// ask via explicit + defaulted action, agent review) and the malformed shapes that
+// classify as StageKindUnknown (both executors, neither, an unrecognized/implement
+// action). A future kind adds rows here; existing rows must not change.
+func TestPipelineStageKind(t *testing.T) {
+	cases := []struct {
+		name  string
+		stage Stage
+		want  StageKind
+	}{
+		{"shell", Stage{ID: "a", Cmd: "echo hi"}, StageKindShell},
+		{"agent ask explicit", Stage{ID: "a", Agent: "asker", Prompt: "q", Action: "ask"}, StageKindAgentAsk},
+		{"agent ask defaulted", Stage{ID: "a", Agent: "asker", Prompt: "q", Action: DefaultAgentStageAction}, StageKindAgentAsk},
+		{"agent ask empty action", Stage{ID: "a", Agent: "asker", Prompt: "q"}, StageKindAgentAsk},
+		{"agent review", Stage{ID: "a", Agent: "rev", Prompt: "q", Action: "review"}, StageKindAgentReview},
+		{"both executors", Stage{ID: "a", Cmd: "echo", Agent: "rev", Prompt: "q"}, StageKindUnknown},
+		{"neither executor", Stage{ID: "a"}, StageKindUnknown},
+		{"agent implement", Stage{ID: "a", Agent: "impl", Prompt: "q", Action: "implement"}, StageKindUnknown},
+		{"agent bad action", Stage{ID: "a", Agent: "x", Prompt: "q", Action: "deploy"}, StageKindUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.stage.Kind(); got != tc.want {
+				t.Fatalf("Kind() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStageKindMatchesLoadedSpec cross-checks Kind() against real normalized specs
+// loaded through Load (so the defaulted-action path — normalize() setting a blank
+// agent action to "ask" — is exercised end to end, matching what the advancer sees).
+func TestPipelineStageKindMatchesLoadedSpec(t *testing.T) {
+	const spec = `name: kinds
+stages:
+  - id: build
+    cmd: make build
+  - id: ask
+    agent: asker
+    prompt: What changed?
+    needs: [build]
+  - id: review
+    agent: reviewer
+    prompt: Review it.
+    action: review
+    needs: [build]
+`
+	loaded, err := Load([]byte(spec))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []StageKind{StageKindShell, StageKindAgentAsk, StageKindAgentReview}
+	for i, stage := range loaded.Stages {
+		if got := stage.Kind(); got != want[i] {
+			t.Fatalf("stage %q Kind() = %d, want %d", stage.ID, got, want[i])
+		}
+	}
+}
+
 func TestHashDeterministicAndSensitive(t *testing.T) {
 	a := []byte("name: p\nstages:\n  - {id: a, cmd: echo}\n")
 	b := []byte("name: p\nstages:\n  - {id: a, cmd: echo}\n")

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -102,6 +102,58 @@ type Stage struct {
 	SuccessDecisions []string `yaml:"success_decisions,omitempty"`
 }
 
+// StageKind classifies a stage by its declared fields. It is the SINGLE place a
+// stage's kind is decided: validation dispatches its per-kind rules on it
+// (validateStageExecutor) and the advancer's fold/settle pass dispatches the
+// per-kind settle predicate on it (stageSettleOutcome). Adding a future kind —
+// mutating implement (#768), an external gate (#768 Phase 2), or an orchestrate
+// sub-tree (#758) — is an APPEND here plus a new case at each dispatch point,
+// never an edit to an existing case.
+type StageKind int
+
+const (
+	// StageKindUnknown is the zero value: a structurally malformed stage (neither
+	// or both executors set, or an agent stage with an unrecognized action). A
+	// validated spec never yields it — Validate rejects such stages first.
+	StageKindUnknown StageKind = iota
+	// StageKindShell is a shell stage: Cmd set, Agent empty. Runs `sh -c` and folds
+	// by its gitmoot_result decision.
+	StageKindShell
+	// StageKindAgentAsk is a read-only agent stage (#757) running the "ask" verb
+	// (the default when action is unset). A leaf: reads + decides, never mutates or
+	// fans out.
+	StageKindAgentAsk
+	// StageKindAgentReview is a read-only agent stage (#757) running the "review"
+	// verb. Same leaf contract as ask; kept distinct so a future kind is appended as
+	// a sibling case rather than by editing a shared agent branch.
+	StageKindAgentReview
+)
+
+// Kind classifies the stage. A shell stage (Cmd set) is StageKindShell; an agent
+// stage (Agent set) is StageKindAgentAsk / StageKindAgentReview by its action (an
+// empty action defaults to ask, matching normalize()). Anything else — both
+// executors set, neither set, or an unrecognized agent action such as
+// "implement" — is StageKindUnknown, which Validate rejects. This method performs
+// NO validation; it only names the shape. Callers must have validated first, or be
+// validateStageExecutor itself, which classifies AFTER its shared exactly-one-of
+// guard so that here exactly one executor is set.
+func (s Stage) Kind() StageKind {
+	switch {
+	case s.Cmd != "" && s.Agent != "":
+		return StageKindUnknown
+	case s.Cmd != "":
+		return StageKindShell
+	case s.Agent != "":
+		switch s.Action {
+		case "", DefaultAgentStageAction: // "" defaults to ask (see normalize)
+			return StageKindAgentAsk
+		case "review":
+			return StageKindAgentReview
+		}
+	}
+	return StageKindUnknown
+}
+
 // Load parses raw YAML into a Spec, normalizes it, and validates it. Unknown
 // fields are rejected (KnownFields) so a typo'd key surfaces as an error at
 // `pipeline add` time rather than being silently ignored. The returned Spec is

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -108,7 +108,10 @@ type Stage struct {
 // per-kind settle predicate on it (stageSettleOutcome). Adding a future kind —
 // mutating implement (#768), an external gate (#768 Phase 2), or an orchestrate
 // sub-tree (#758) — is an APPEND here plus a new case at each dispatch point,
-// never an edit to an existing case.
+// never an edit to an existing case. Kinds on the existing cmd|agent axes
+// (implement, orchestrate) are a pure classifier append; a jobless gate additionally
+// adds its own executor field and a `case s.Gate != ""` branch below (and widens the
+// exactly-one-of count in validateStageExecutor) — still no existing case is edited.
 type StageKind int
 
 const (

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -198,36 +198,60 @@ func (s Spec) detectCycle() error {
 func validateStageExecutor(pipelineName string, stage Stage) error {
 	hasCmd := stage.Cmd != ""
 	hasAgent := stage.Agent != ""
+	// The exactly-one-of cmd|agent guard is shared across kinds: it must run before
+	// Stage.Kind() (which is only meaningful once exactly one executor is set).
 	switch {
 	case hasCmd && hasAgent:
 		return fmt.Errorf("pipeline %q stage %q sets both cmd and agent; a stage is exactly one of a shell cmd or an agent", pipelineName, stage.ID)
 	case !hasCmd && !hasAgent:
 		return fmt.Errorf("pipeline %q stage %q has neither cmd nor agent; a stage needs exactly one", pipelineName, stage.ID)
-	case hasCmd:
-		// A shell stage carries no agent-only fields; a stray prompt/action is a
-		// mis-declared stage (very likely a forgotten agent: key), so reject it.
-		if stage.Prompt != "" {
-			return fmt.Errorf("pipeline %q stage %q sets prompt but is a shell (cmd) stage; prompt is only for agent stages", pipelineName, stage.ID)
-		}
-		if stage.Action != "" {
-			return fmt.Errorf("pipeline %q stage %q sets action but is a shell (cmd) stage; action is only for agent stages", pipelineName, stage.ID)
-		}
-		return nil
-	default: // hasAgent
-		if !validToken(stage.Agent) {
-			return fmt.Errorf("pipeline %q stage %q agent %q must be a name-safe token (letters, digits, '-', '_')", pipelineName, stage.ID, stage.Agent)
-		}
-		if stage.Prompt == "" {
-			return fmt.Errorf("pipeline %q stage %q agent stage requires a non-empty prompt", pipelineName, stage.ID)
-		}
-		if stage.Action == "implement" {
-			return fmt.Errorf("pipeline %q stage %q agent stage action %q is not allowed; an agent stage is a read-only leaf (use one of: %s)", pipelineName, stage.ID, stage.Action, strings.Join(AgentStageActionCandidates, ", "))
-		}
-		if !containsToken(AgentStageActionCandidates, stage.Action) {
-			return fmt.Errorf("pipeline %q stage %q agent stage action %q is invalid; use one of: %s", pipelineName, stage.ID, stage.Action, strings.Join(AgentStageActionCandidates, ", "))
-		}
-		return nil
 	}
+	// Exactly one executor is set; dispatch the per-kind rules by Stage.Kind(). A
+	// NEW stage kind (implement/gate/orchestrate) adds a case here — it never edits
+	// another kind's validator.
+	switch stage.Kind() {
+	case StageKindShell:
+		return validateShellStage(pipelineName, stage)
+	case StageKindAgentAsk, StageKindAgentReview:
+		return validateAgentStage(pipelineName, stage)
+	default:
+		// StageKindUnknown past the exactly-one-of guard = an agent stage (Agent
+		// set, Cmd empty) with an unrecognized action; validateAgentStage produces
+		// the #757 read-only-leaf rejection (implement) or the invalid-action error.
+		return validateAgentStage(pipelineName, stage)
+	}
+}
+
+// validateShellStage validates a shell (cmd) stage: it carries no agent-only
+// fields, so a stray prompt/action is a mis-declared stage (very likely a
+// forgotten agent: key). Byte-identical to the pre-refactor shell branch.
+func validateShellStage(pipelineName string, stage Stage) error {
+	if stage.Prompt != "" {
+		return fmt.Errorf("pipeline %q stage %q sets prompt but is a shell (cmd) stage; prompt is only for agent stages", pipelineName, stage.ID)
+	}
+	if stage.Action != "" {
+		return fmt.Errorf("pipeline %q stage %q sets action but is a shell (cmd) stage; action is only for agent stages", pipelineName, stage.ID)
+	}
+	return nil
+}
+
+// validateAgentStage validates a read-only agent stage (#757): a name-safe agent
+// token, a non-empty prompt, and an ask/review action ("implement" is rejected as
+// a non-leaf verb). Byte-identical to the pre-refactor agent branch.
+func validateAgentStage(pipelineName string, stage Stage) error {
+	if !validToken(stage.Agent) {
+		return fmt.Errorf("pipeline %q stage %q agent %q must be a name-safe token (letters, digits, '-', '_')", pipelineName, stage.ID, stage.Agent)
+	}
+	if stage.Prompt == "" {
+		return fmt.Errorf("pipeline %q stage %q agent stage requires a non-empty prompt", pipelineName, stage.ID)
+	}
+	if stage.Action == "implement" {
+		return fmt.Errorf("pipeline %q stage %q agent stage action %q is not allowed; an agent stage is a read-only leaf (use one of: %s)", pipelineName, stage.ID, stage.Action, strings.Join(AgentStageActionCandidates, ", "))
+	}
+	if !containsToken(AgentStageActionCandidates, stage.Action) {
+		return fmt.Errorf("pipeline %q stage %q agent stage action %q is invalid; use one of: %s", pipelineName, stage.ID, stage.Action, strings.Join(AgentStageActionCandidates, ", "))
+	}
+	return nil
 }
 
 func containsToken(candidates []string, value string) bool {

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -199,7 +199,13 @@ func validateStageExecutor(pipelineName string, stage Stage) error {
 	hasCmd := stage.Cmd != ""
 	hasAgent := stage.Agent != ""
 	// The exactly-one-of cmd|agent guard is shared across kinds: it must run before
-	// Stage.Kind() (which is only meaningful once exactly one executor is set).
+	// Stage.Kind() (which is only meaningful once exactly one executor is set). A
+	// future kind that lives on the EXISTING axes (e.g. implement = agent + an
+	// implement action) is a pure append below; a future kind that introduces a NEW
+	// executor field (a jobless gate: predicate) additionally widens this count to
+	// exactly-one-of {cmd, agent, gate}. That count widening is inherent to adding an
+	// executor axis, not a per-kind settle-logic edit — the seams the foundation
+	// guarantees (validateStageExecutor's dispatch, stageSettleOutcome) stay append-only.
 	switch {
 	case hasCmd && hasAgent:
 		return fmt.Errorf("pipeline %q stage %q sets both cmd and agent; a stage is exactly one of a shell cmd or an agent", pipelineName, stage.ID)


### PR DESCRIPTION
## What

The shared **stage-kind foundation** that #768 (mutating implement + `gate:pr_merged` stages) and #758 (orchestrate sub-tree stages) both build on. This is a pure **additive refactor** — no new stage kinds, no new spec fields, no user-facing behavior change. Existing shell stages and #757 read-only agent (`ask`/`review`) stages are **byte-identical**.

The research panel on #768/#758 identified the same root: *"do the shared refactor with whichever lands first."* Landing it as its own small PR first lets the two features then proceed truly in parallel, each an **append** at three dispatch points rather than an edit to shared logic.

## The three seams

1. **`Stage.Kind()` classifier** (`internal/pipeline/spec.go`) — a `StageKind` enum + method; the single place a stage's kind is decided. Today: `StageKindShell`, `StageKindAgentAsk`, `StageKindAgentReview` (+ `StageKindUnknown` for malformed, which `Validate` rejects). A future kind is a new constant + a new `Kind()` case, never an edit to an existing case.

2. **Kind-dispatched validation** (`internal/pipeline/validate.go`) — `validateStageExecutor` keeps the shared exactly-one-of `cmd|agent` guard, then dispatches to `validateShellStage`/`validateAgentStage` by `Stage.Kind()`. All error messages/positions unchanged (`TestLoadValidationErrors` passes verbatim). A new kind adds a switch case + its own validator.

3. **Pluggable settle-predicate seam** (`internal/cli/pipeline_run.go`) — the FOLD pass's inline *"load the job; is it terminal ⇒ `foldPipelineStageOutcome`"* is extracted into `stageSettleOutcome(...)`:

```go
func stageSettleOutcome(ctx, deps pipelineStageSettleDeps, spec, stage, stageRow)
    (settled bool, state, summary string, needs []string, nextRow *db.PipelineRunStage, err error)
```

The default case reproduces today's behavior byte-identically. The seam **owns everything job-shaped** so the three future kinds are pure appends:
- It loads the stage's job itself (the `JobID==""` guard + `GetJob` moved *into* the seam) → a future **jobless `gate`** kind is reachable without moving a guard out of shared logic.
- It returns **`nextRow`** (a row mutation to persist while *un*settled) → a future **`orchestrate`** kind re-points `nextRow.JobID` at its continuation and keeps waiting. Today this carries only the queued→running funnel reflect.
- It returns **`err`** with a documented contract (non-blocking, ctx-bounded, **fail-open**) → a future `gate` polling GitHub can surface transients without hanging the FOLD hot loop.

Plus `pipelineStageMintsJob(stage)` seams the **enqueue** pass — a jobless `gate` appends `case StageKindGate: return false` rather than editing the shared enqueue loop.

## Why this shape (review-driven)

The first cut of the seam was executor-axis-only + job-mandatory + had no mutation/error channel. A 3-lens adversarial review (byte-identical regression / **seam sufficiency** / advancer race) caught that this would have forced the `gate` and `orchestrate` kinds to edit shared logic anyway — defeating the point. The seam above is the corrected design that all three future kinds append onto cleanly. (Second commit resolves those findings.)

## Verification

- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅
- `go test -race ./internal/pipeline ./internal/cli ./internal/workflow` ✅
- New `TestPipelineStageKind*` tests for the classifier over every current shape + a seam-default test asserting parity with `foldPipelineStageOutcome`; existing pipeline validation + advancer + leaf tests pass unchanged (byte-identical proof).

Follow-ups that append onto these seams: **#768** (implement + gate stages), **#758** (orchestrate sub-tree stages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
