### PR TITLE
feat(pipeline): mutating implement stages (Model A) + composable gate:pr_merged stage (#768)

### DIFF
--- a/internal/cli/pipeline_gate_stage_e2e_test.go
+++ b/internal/cli/pipeline_gate_stage_e2e_test.go
@@ -188,6 +188,56 @@ stages:
 	}
 }
 
+// TestPipelineGateStageClosedUnmergedParksBlockedE2E proves a gate whose upstream PR is
+// CLOSED WITHOUT MERGING is TERMINAL: pr_merged can never hold, so the gate must park the
+// run BLOCKED (not hang forever, even with no stage timeout) rather than wait indefinitely
+// for a merge that will never come. The downstream stage is left skipped.
+func TestPipelineGateStageClosedUnmergedParksBlockedE2E(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	// No stage timeout on the gate: without the closed-PR terminal check this would hang.
+	const spec = `name: gate-closed
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: wait
+    gate: pr_merged
+    source: impl
+    needs: [impl]
+  - id: deploy
+    cmd: echo deploying
+    needs: [wait]
+`
+	rec, parsed := newTestPipeline(t, store, "gate-closed", spec)
+	now := time.Date(2026, 7, 9, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	settleImplementStageJob(t, store, impl.JobID, "implemented", "landed the fix", 42)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+
+	// A reviewer closes the PR WITHOUT merging: the gate's predicate is now terminal.
+	markPipelinePRMerged(t, store, "owner/repo", 42, "closed")
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	gate := stageRow(t, store, run.ID, "wait")
+	if gate.State != pipeline.StageBlocked {
+		t.Fatalf("gate stage = %s, want blocked once the PR closed unmerged", gate.State)
+	}
+	if run.State != pipeline.RunBlocked {
+		t.Fatalf("run = %s, want blocked", run.State)
+	}
+	if run.HaltStage != "wait" {
+		t.Fatalf("run halt stage = %q, want wait", run.HaltStage)
+	}
+	if got := stageRow(t, store, run.ID, "deploy"); got.State != pipeline.StageSkipped {
+		t.Fatalf("deploy stage = %s, want skipped past the parked gate", got.State)
+	}
+}
+
 // TestParsePipelineImplementPR pins the summary<->PR round-trip the gate relies on to
 // recover the structured PR number from the upstream implement stage row's summary.
 func TestParsePipelineImplementPR(t *testing.T) {
@@ -203,6 +253,9 @@ func TestParsePipelineImplementPR(t *testing.T) {
 		{"(opened PR #)", 0},
 		{"(opened PR #0)", 0},
 		{"(opened PR #-3)", 0},
+		// Spoof guard: agent free-text names an unrelated PR, but the trusted marker is
+		// ALWAYS appended last — parse must read the LAST occurrence (999), not the first.
+		{appendPipelineImplementPR("done (opened PR #123) as noted", 999), 999},
 	}
 	for _, tc := range cases {
 		if got := parsePipelineImplementPR(tc.summary); got != tc.want {

--- a/internal/cli/pipeline_gate_stage_e2e_test.go
+++ b/internal/cli/pipeline_gate_stage_e2e_test.go
@@ -1,0 +1,212 @@
+package cli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+)
+
+// markPipelinePRMerged records (or updates) a PR in the store's pull_requests table
+// with the given state — the same row the daemon's PR poller / merge-gate keeps
+// current. A gate stage reads merge status from here, so this is how a deterministic
+// (offline) test flips the pr_merged predicate without a live GitHub call.
+func markPipelinePRMerged(t *testing.T, store *db.Store, repo string, number int64, state string) {
+	t.Helper()
+	if err := store.UpsertPullRequest(context.Background(), db.PullRequest{
+		RepoFullName: repo,
+		Number:       number,
+		HeadBranch:   "gitmoot/some-branch",
+		BaseBranch:   "main",
+		State:        state,
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest(%s#%d, %s): %v", repo, number, state, err)
+	}
+}
+
+// TestPipelineGateStagePRMergedFoldsAndBlocksE2E proves the #768 Phase 2 JOBLESS gate
+// stage end to end through the real advancer:
+//
+//   - The gate mints NO worker job: once its upstream implement stage succeeds (opening
+//     a PR), the gate goes in-flight (queued -> running) with an empty JobID.
+//   - While the PR is NOT merged the gate stays in flight, the downstream deploy stage
+//     never enqueues, and the run stays running (fail-open: waiting, not a hung poll).
+//   - When the PR merges (a merged pull_requests row appears), the SAME gate folds
+//     succeeded and the downstream stage enqueues.
+//
+// It is fully deterministic and offline — the implement job's terminal state + opened
+// PR and the PR's merged state are set directly in the store, exactly what the
+// finalizer and the PR poller would persist.
+func TestPipelineGateStagePRMergedFoldsAndBlocksE2E(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: gate-flow
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: wait
+    gate: pr_merged
+    source: impl
+    needs: [impl]
+    timeout: 1h
+  - id: deploy
+    cmd: echo deploying
+    needs: [wait]
+`
+	rec, parsed := newTestPipeline(t, store, "gate-flow", spec)
+	now := time.Date(2026, 7, 9, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+
+	// The implement stage settles success WITH an opened PR (#42), so it folds succeeded
+	// and its summary carries "(opened PR #42)".
+	impl := stageRow(t, store, run.ID, "impl")
+	if impl.State != pipeline.StageQueued || impl.JobID == "" {
+		t.Fatalf("impl stage = %+v, want queued with a job", impl)
+	}
+	settleImplementStageJob(t, store, impl.JobID, "implemented", "landed the fix", 42)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "impl"); got.State != pipeline.StageSucceeded {
+		t.Fatalf("impl stage = %s, want succeeded", got.State)
+	}
+
+	// The JOBLESS gate is now in-flight (marked queued in the ENQUEUE pass, with NO job).
+	gate := stageRow(t, store, run.ID, "wait")
+	if gate.State != pipeline.StageQueued {
+		t.Fatalf("gate stage = %s, want queued (in-flight, jobless)", gate.State)
+	}
+	if gate.JobID != "" {
+		t.Fatalf("gate stage minted a job %q; a gate must be jobless", gate.JobID)
+	}
+	if got := stageRow(t, store, run.ID, "deploy"); got.State != pipeline.StagePending {
+		t.Fatalf("deploy stage = %s, want pending (gate not satisfied)", got.State)
+	}
+
+	// The PR is NOT merged yet: the gate stays in flight (reflecting queued -> running),
+	// deploy does not enqueue, and the run stays running.
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	gate = stageRow(t, store, run.ID, "wait")
+	if gate.State != pipeline.StageRunning {
+		t.Fatalf("gate stage = %s, want running while the PR is unmerged", gate.State)
+	}
+	if gate.JobID != "" {
+		t.Fatalf("gate stage acquired a job %q while watching; a gate is jobless", gate.JobID)
+	}
+	if run.State != pipeline.RunRunning {
+		t.Fatalf("run = %s, want running while the gate waits on the merge", run.State)
+	}
+	if got := stageRow(t, store, run.ID, "deploy"); got.State != pipeline.StagePending {
+		t.Fatalf("deploy stage = %s, want still pending while the gate waits", got.State)
+	}
+
+	// The PR merges: the gate predicate now holds, so the SAME gate folds succeeded and
+	// the downstream deploy stage enqueues.
+	markPipelinePRMerged(t, store, "owner/repo", 42, "merged")
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	gate = stageRow(t, store, run.ID, "wait")
+	if gate.State != pipeline.StageSucceeded {
+		t.Fatalf("gate stage = %s, want succeeded once the PR merged", gate.State)
+	}
+	deploy := stageRow(t, store, run.ID, "deploy")
+	if deploy.State != pipeline.StageQueued || deploy.JobID == "" {
+		t.Fatalf("deploy stage = %+v, want queued with a job after the gate folded", deploy)
+	}
+
+	// The run completes once the downstream deploy stage succeeds.
+	settleStageJob(t, store, deploy.JobID, "approved", "deployed", nil)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	if run.State != pipeline.RunSucceeded {
+		t.Fatalf("run = %s, want succeeded", run.State)
+	}
+}
+
+// TestPipelineGateStageTimeoutParksBlockedE2E proves a gate stage whose predicate never
+// holds within its stage timeout PARKS the run BLOCKED (not failed) at the gate, with a
+// needs entry naming the merge it waited on — and never retries (a gate is a wait, not a
+// mutation). The downstream stage is left skipped.
+func TestPipelineGateStageTimeoutParksBlockedE2E(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: gate-timeout
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: wait
+    gate: pr_merged
+    source: impl
+    needs: [impl]
+    timeout: 1h
+  - id: deploy
+    cmd: echo deploying
+    needs: [wait]
+`
+	rec, parsed := newTestPipeline(t, store, "gate-timeout", spec)
+	start := time.Date(2026, 7, 9, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, parsed, enqueue, start)
+
+	impl := stageRow(t, store, run.ID, "impl")
+	settleImplementStageJob(t, store, impl.JobID, "implemented", "landed the fix", 42)
+	run = advance(t, store, rec, parsed, enqueue, run, start)
+
+	// The gate is in-flight and StartedAt is anchored at `start`.
+	gate := stageRow(t, store, run.ID, "wait")
+	if gate.State != pipeline.StageQueued || !gate.StartedAt.Equal(start.UTC()) {
+		t.Fatalf("gate stage = %+v, want queued with StartedAt %s", gate, start.UTC())
+	}
+
+	// The PR never merges. Advance well past the 1h timeout: the gate parks BLOCKED and
+	// the run parks blocked at the gate with the merge it waited on surfaced as a need.
+	late := start.Add(2 * time.Hour)
+	run = advance(t, store, rec, parsed, enqueue, run, late)
+	gate = stageRow(t, store, run.ID, "wait")
+	if gate.State != pipeline.StageBlocked {
+		t.Fatalf("gate stage = %s, want blocked after the timeout", gate.State)
+	}
+	if run.State != pipeline.RunBlocked {
+		t.Fatalf("run = %s, want blocked", run.State)
+	}
+	if run.HaltStage != "wait" {
+		t.Fatalf("run halt stage = %q, want wait", run.HaltStage)
+	}
+	if got := decodePipelineNeeds(run.NeedsJSON); len(got) != 1 || got[0] != "PR #42 merged" {
+		t.Fatalf("run needs = %v, want [\"PR #42 merged\"]", got)
+	}
+	// The downstream deploy stage is skipped (never reachable past a parked gate).
+	if got := stageRow(t, store, run.ID, "deploy"); got.State != pipeline.StageSkipped {
+		t.Fatalf("deploy stage = %s, want skipped", got.State)
+	}
+}
+
+// TestParsePipelineImplementPR pins the summary<->PR round-trip the gate relies on to
+// recover the structured PR number from the upstream implement stage row's summary.
+func TestParsePipelineImplementPR(t *testing.T) {
+	cases := []struct {
+		summary string
+		want    int
+	}{
+		{appendPipelineImplementPR("landed the fix", 42), 42},
+		{"landed the fix (opened PR #7)", 7},
+		{"(opened PR #123)", 123},
+		{"landed the fix", 0},
+		{"no marker here", 0},
+		{"(opened PR #)", 0},
+		{"(opened PR #0)", 0},
+		{"(opened PR #-3)", 0},
+	}
+	for _, tc := range cases {
+		if got := parsePipelineImplementPR(tc.summary); got != tc.want {
+			t.Fatalf("parsePipelineImplementPR(%q) = %d, want %d", tc.summary, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/pipeline_implement_stage_e2e_test.go
+++ b/internal/cli/pipeline_implement_stage_e2e_test.go
@@ -1,0 +1,285 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// settleImplementStageJob transitions a stage's enqueued job to a terminal state with
+// the given decision AND an opened PR number, faithfully reproducing what the real
+// implement flow persists once the ImplementationFinalizer stamps the PR onto the
+// payload. A pr of 0 models the RACE the #768 settle guard closes: the job is terminal
+// SUCCESS but the PR is not stamped yet.
+func settleImplementStageJob(t *testing.T, store *db.Store, jobID, decision, summary string, pr int) {
+	t.Helper()
+	ctx := context.Background()
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", jobID, err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+	payload.Result = &workflow.AgentResult{Decision: decision, Summary: summary}
+	payload.PullRequest = pr
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	to := jobStateForDecision(decision)
+	ok, err := store.TransitionJobStatePayloadWithEvent(ctx, jobID, job.State, to, string(encoded),
+		db.JobEvent{JobID: jobID, Kind: to, Message: "settled by test"})
+	if err != nil || !ok {
+		t.Fatalf("settle %s -> %s: ok=%v err=%v", jobID, to, ok, err)
+	}
+}
+
+// stampImplementStageJobPR sets an already-terminal implement stage job's PullRequest
+// on the payload WITHOUT re-transitioning it — simulating the finalizer stamping the
+// opened PR a beat after the job settled (the race the settle guard waits out).
+func stampImplementStageJobPR(t *testing.T, store *db.Store, jobID string, pr int) {
+	t.Helper()
+	ctx := context.Background()
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", jobID, err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+	payload.PullRequest = pr
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if err := store.UpdateJobPayload(ctx, jobID, string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload: %v", err)
+	}
+}
+
+// TestPipelineImplementStagePRGateAndDownstreamE2E proves the #768 Model A settle
+// semantics for a MUTATING implement stage, end to end through the real advancer:
+//
+//  1. FOLD-ON-PR-OPENED gate: the implement job settles SUCCESS with decision
+//     "implemented" but NO PR stamped yet — the stage must stay in flight (NOT
+//     succeeded), closing the race where a downstream stage would advance believing a
+//     PR exists. Once the PR is stamped, the same stage folds succeeded.
+//  2. The implement stage job binds to the NAMED agent with the DETERMINISTIC,
+//     attempt-independent branch/task derived from run+stage.
+//  3. DOWNSTREAM CONSUMPTION: a stage that needs the implement stage receives the
+//     opened PR number in its prompt via the #757 upstream-context injection.
+//
+// It uses the real store-backed advancer (no worker/finalizer, so it is deterministic
+// and offline) — the implement job's terminal state + payload are set directly, exactly
+// what the finalizer would persist.
+func TestPipelineImplementStagePRGateAndDownstreamE2E(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: impl-gate
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: notify
+    agent: notifier
+    prompt: Announce the change.
+    needs: [impl]
+`
+	rec, parsed := newTestPipeline(t, store, "impl-gate", spec)
+	now := time.Date(2026, 7, 9, 9, 0, 0, 0, time.UTC)
+	ctx := context.Background()
+
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+
+	// The implement stage enqueued with the deterministic branch/task (attempt 0).
+	impl := stageRow(t, store, run.ID, "impl")
+	if impl.State != pipeline.StageQueued || impl.JobID == "" {
+		t.Fatalf("impl stage = %+v, want queued with a job", impl)
+	}
+	implJob, err := store.GetJob(ctx, impl.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(impl): %v", err)
+	}
+	if implJob.Type != "implement" {
+		t.Fatalf("impl job action = %q, want implement", implJob.Type)
+	}
+	implPayload, err := workflow.ParseJobPayload(implJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(impl): %v", err)
+	}
+	wantBranch := "gitmoot/pipe-" + run.ID + "-impl"
+	wantTask := "pipe-" + run.ID + "-impl"
+	if implPayload.Branch != wantBranch {
+		t.Fatalf("impl branch = %q, want %q", implPayload.Branch, wantBranch)
+	}
+	if implPayload.TaskID != wantTask {
+		t.Fatalf("impl task = %q, want %q", implPayload.TaskID, wantTask)
+	}
+
+	// (1) The job settles SUCCESS but with NO PR stamped: the gate holds the stage in
+	// flight (still queued), NOT succeeded, and the run stays running.
+	settleImplementStageJob(t, store, impl.JobID, "implemented", "landed the fix", 0)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "impl"); got.State != pipeline.StageQueued {
+		t.Fatalf("impl stage = %s, want still queued (PR-gate holds an unstamped success)", got.State)
+	}
+	if run.State != pipeline.RunRunning {
+		t.Fatalf("run = %s, want running while impl waits on its PR", run.State)
+	}
+	if got := stageRow(t, store, run.ID, "notify"); got.JobID != "" {
+		t.Fatalf("notify enqueued before impl succeeded: %+v", got)
+	}
+
+	// The PR is stamped a beat later: NOW the stage folds succeeded and notify enqueues.
+	stampImplementStageJobPR(t, store, impl.JobID, 42)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	implDone := stageRow(t, store, run.ID, "impl")
+	if implDone.State != pipeline.StageSucceeded {
+		t.Fatalf("impl stage = %s, want succeeded once PR stamped", implDone.State)
+	}
+	if !strings.Contains(implDone.Summary, "opened PR #42") {
+		t.Fatalf("impl summary = %q, want it to carry the opened PR", implDone.Summary)
+	}
+
+	// (3) The downstream notify stage's enqueued prompt carries the implement stage's
+	// summary INCLUDING the opened PR, via the #757 upstream-context injection.
+	notify := stageRow(t, store, run.ID, "notify")
+	if notify.State != pipeline.StageQueued || notify.JobID == "" {
+		t.Fatalf("notify stage = %+v, want queued with a job after impl succeeded", notify)
+	}
+	notifyJob, err := store.GetJob(ctx, notify.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(notify): %v", err)
+	}
+	notifyPayload, err := workflow.ParseJobPayload(notifyJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(notify): %v", err)
+	}
+	if !strings.Contains(notifyPayload.Instructions, "Upstream stage results") {
+		t.Fatalf("notify prompt missing upstream-context block:\n%s", notifyPayload.Instructions)
+	}
+	if !strings.Contains(notifyPayload.Instructions, "opened PR #42") {
+		t.Fatalf("notify prompt missing the upstream PR reference:\n%s", notifyPayload.Instructions)
+	}
+	if !strings.Contains(notifyPayload.Instructions, "Announce the change.") {
+		t.Fatalf("notify prompt lost its own task text:\n%s", notifyPayload.Instructions)
+	}
+
+	// The run completes once notify approves.
+	settleStageJob(t, store, notify.JobID, "approved", "announced", nil)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	if run.State != pipeline.RunSucceeded {
+		t.Fatalf("run = %s, want succeeded", run.State)
+	}
+}
+
+// TestPipelineImplementStageWritableWorktreeReuseE2E proves the WRITABLE-worktree
+// dispatch (#768): a mutating implement stage takes the real task-worktree path (not
+// the read-only committed-tip worktree), is born on its DETERMINISTIC run-scoped branch,
+// keys worktree:<path> (so mutating same-repo stages parallelize), and a RETRY reuses
+// the SAME branch/worktree and FAILS CLOSED when that worktree has uncommitted changes.
+//
+// It drives the production enqueuer (newPipelineStageEnqueuer) against a real local git
+// checkout so the writable allocation genuinely runs, but never runs the worker (the
+// implement finalizer needs GitHub) — the retry is driven by settling the job failed.
+func TestPipelineImplementStageWritableWorktreeReuseE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	// A named implement-capable agent on the shell runtime with a WRITE policy (a
+	// read-only policy would fail-closed the implement preflight). The shell body is
+	// irrelevant here — the worker never runs; the allocation + retry are what matter.
+	seedDaemonWorkerAgentWithPolicy(t, store, "coder", runtime.ShellRuntime,
+		pipelineStageResultCmd("implemented", "fixed", nil),
+		[]string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+
+	const spec = `name: impl-worktree
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+    retry: 1
+`
+	rec, parsed := newTestPipeline(t, store, "impl-worktree", spec)
+	enqueue := newPipelineStageEnqueuer(store, home)
+	now := time.Date(2026, 7, 9, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+
+	impl := stageRow(t, store, run.ID, "impl")
+	if impl.State != pipeline.StageQueued || impl.JobID == "" {
+		t.Fatalf("impl stage = %+v, want queued with a job", impl)
+	}
+	job, err := store.GetJob(ctx, impl.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(impl): %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(impl): %v", err)
+	}
+	// It took the WRITABLE task-worktree, not the read-only committed-tip worktree.
+	if strings.TrimSpace(payload.WorktreePath) == "" {
+		t.Fatalf("impl stage has no writable task worktree")
+	}
+	if payload.ReadOnlyWorktree {
+		t.Fatalf("impl stage ReadOnlyWorktree = true, want false (a mutating worktree is durable)")
+	}
+	wantBranch := "gitmoot/pipe-" + run.ID + "-impl"
+	if payload.Branch != wantBranch {
+		t.Fatalf("impl branch = %q, want %q", payload.Branch, wantBranch)
+	}
+	if _, statErr := os.Stat(payload.WorktreePath); statErr != nil {
+		t.Fatalf("impl worktree %s not created on disk: %v", payload.WorktreePath, statErr)
+	}
+	// A worktree-keyed job parallelizes with same-repo siblings (never repo:<repo>).
+	if key := queuedJobCheckoutKey(ctx, store, job); !strings.HasPrefix(key, "worktree:") {
+		t.Fatalf("impl stage checkout key = %q, want worktree:<path> (parallelizes)", key)
+	}
+
+	worktreePath := payload.WorktreePath
+
+	// RETRY REUSE + FAIL-CLOSED: dirty the worktree, then fail the job so the stage
+	// retries (retry:1). The retry re-derives the SAME deterministic branch/task and
+	// reuses the worktree — but the uncommitted change trips the fail-closed guard, so
+	// the advance errors rather than duplicating or clobbering the branch/PR.
+	if err := os.WriteFile(filepath.Join(worktreePath, "dirty.txt"), []byte("uncommitted\n"), 0o644); err != nil {
+		t.Fatalf("dirty the worktree: %v", err)
+	}
+	settleStageJob(t, store, impl.JobID, "failed", "boom", nil)
+	_, err = advancePipelineRun(ctx, store, enqueue, rec, parsed, run, now)
+	if err == nil {
+		t.Fatalf("retry into a dirty worktree should FAIL CLOSED, got nil error")
+	}
+	if !strings.Contains(err.Error(), "uncommitted changes") {
+		t.Fatalf("fail-closed error = %q, want it to mention uncommitted changes", err.Error())
+	}
+	// The retry stayed on the SAME branch (never minted a fresh one).
+	if !strings.Contains(err.Error(), wantBranch) {
+		t.Fatalf("fail-closed error = %q, want it to reference the reused branch %q", err.Error(), wantBranch)
+	}
+	retried := stageRow(t, store, run.ID, "impl")
+	if retried.Attempt != 1 {
+		t.Fatalf("impl attempt = %d, want 1 (retry budget consumed)", retried.Attempt)
+	}
+}

--- a/internal/cli/pipeline_implement_stage_e2e_test.go
+++ b/internal/cli/pipeline_implement_stage_e2e_test.go
@@ -188,6 +188,61 @@ stages:
 	}
 }
 
+// TestPipelineImplementStageNoOpTerminalFoldsE2E proves the settle guard does NOT wedge
+// forever on the ROUTINE no-op path: an implement agent that produces no diff settles
+// with decision "implemented" but PullRequest=0, and the engine records the terminal
+// "advance_skipped_no_pr" job event (engine.go). That event is the definitive signal that
+// no PR will ever land, so the stage must fold SUCCEEDED (no PR marker) rather than hold
+// in flight indefinitely, letting the downstream stage advance.
+func TestPipelineImplementStageNoOpTerminalFoldsE2E(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: noop-flow
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: notify
+    agent: rev
+    prompt: Announce.
+    needs: [impl]
+`
+	rec, parsed := newTestPipeline(t, store, "noop-flow", spec)
+	now := time.Date(2026, 7, 9, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+
+	// The job settles SUCCESS with NO PR (a no-op change) — but BEFORE the engine's
+	// terminal marker exists, the stage still holds in flight (the finalizer-race path).
+	settleImplementStageJob(t, store, impl.JobID, "implemented", "no changes needed", 0)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "impl"); got.State != pipeline.StageQueued {
+		t.Fatalf("impl stage = %s, want still queued before the no-pr marker exists", got.State)
+	}
+
+	// The engine records the terminal "advance_skipped_no_pr" event: NOW the stage folds
+	// succeeded (no PR marker) and the downstream notify stage enqueues.
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: impl.JobID, Kind: "advance_skipped_no_pr", Message: "no pull request is attached"}); err != nil {
+		t.Fatalf("AddJobEvent: %v", err)
+	}
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	implDone := stageRow(t, store, run.ID, "impl")
+	if implDone.State != pipeline.StageSucceeded {
+		t.Fatalf("impl stage = %s, want succeeded once the no-pr marker exists", implDone.State)
+	}
+	if strings.Contains(implDone.Summary, "opened PR") {
+		t.Fatalf("impl summary = %q, want no opened-PR marker for a no-op change", implDone.Summary)
+	}
+	if got := stageRow(t, store, run.ID, "notify"); got.State != pipeline.StageQueued || got.JobID == "" {
+		t.Fatalf("notify stage = %+v, want queued with a job after impl succeeded", got)
+	}
+}
+
 // TestPipelineImplementStageWritableWorktreeReuseE2E proves the WRITABLE-worktree
 // dispatch (#768): a mutating implement stage takes the real task-worktree path (not
 // the read-only committed-tip worktree), is born on its DETERMINISTIC run-scoped branch,

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -732,12 +732,14 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 			continue
 		}
 		if !pipelineStageMintsJob(stage) {
-			// A JOBLESS kind (future gate #768 Phase 2) becomes in-flight WITHOUT a
-			// worker job; the settle seam (which owns the JobID guard) then drives it
-			// on its external predicate. No kind today is jobless, so this branch is
-			// never taken and the enqueue path below is byte-identical. Kept here so a
-			// gate is a pure append (`case StageKindGate: return false` in
-			// pipelineStageMintsJob), not an edit to this shared enqueue loop.
+			// A JOBLESS kind becomes in-flight WITHOUT a worker job; the settle seam
+			// (which owns the JobID guard) then drives it on its external predicate. The
+			// #768 Phase 2 gate stage is jobless (pipelineStageMintsJob returns false for
+			// StageKindGate), so it TAKES this branch: the row goes queued with StartedAt
+			// set here but no JobID — and that StartedAt is exactly what pipelineGateTimedOut
+			// measures the gate's wait from. This stays a pure append (`case StageKindGate:
+			// return false` in pipelineStageMintsJob), not an edit to the shared enqueue loop
+			// below, which remains byte-identical for job-minting kinds.
 			row.State = pipeline.StageQueued
 			row.StartedAt = now
 			if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
@@ -990,13 +992,49 @@ func implementStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDe
 			pr = payload.PullRequest
 		}
 		if pr <= 0 {
-			// The job settled successfully but the PR is not stamped on the payload yet:
-			// WAIT (fold-on-PR-opened). Stay in flight untouched; a later scan re-checks.
-			return false, "", "", nil, nil, nil
+			// The job settled successfully but no PR is stamped on the payload. Two cases,
+			// disambiguated by the engine's terminal "advance_skipped_no_pr" job event:
+			//   1. FINALIZER RACE (event absent): the implement job reached its terminal
+			//      success state a beat before the ImplementationFinalizer stamped the
+			//      opened PR — WAIT (fold-on-PR-opened); a later scan re-checks once it lands.
+			//   2. TERMINAL NO-OP (event present): the agent produced no diff
+			//      (idempotent/no-op change), so the engine finalized, found nothing pushed,
+			//      recorded "advance_skipped_no_pr" and settled the job for good
+			//      (engine.go). No PR will EVER land, so waiting would wedge the run
+			//      forever ([implement] -> [gate] -> [deploy] never advances). This is a
+			//      legitimate SUCCESS of the implement stage — fold it succeeded with no PR
+			//      marker (a downstream pr_merged gate then bounds its own wait via timeout).
+			skipped, eerr := implementJobSettledNoPR(ctx, deps.store, job.ID)
+			if eerr != nil {
+				return false, "", "", nil, nil, eerr
+			}
+			if !skipped {
+				return false, "", "", nil, nil, nil
+			}
+			return true, state, summary, needs, nil, nil
 		}
 		summary = appendPipelineImplementPR(summary, pr)
 	}
 	return true, state, summary, needs, nil, nil
+}
+
+// implementJobSettledNoPR reports whether the engine has recorded the terminal
+// "advance_skipped_no_pr" marker for an implement job — its definitive signal that the
+// job settled successfully, the finalizer ran (or was not needed), and NO pull request
+// was produced (a no-op/idempotent change with nothing pushed, engine.go). Its presence
+// distinguishes a permanent no-PR success (fold succeeded, never wedge the run) from the
+// transient finalizer race where a PR is a beat away from being stamped (keep waiting).
+func implementJobSettledNoPR(ctx context.Context, store *db.Store, jobID string) (bool, error) {
+	events, err := store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		return false, err
+	}
+	for _, ev := range events {
+		if ev.Kind == "advance_skipped_no_pr" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // appendPipelineImplementPR annotates a mutating implement stage's SUCCESS summary with
@@ -1051,6 +1089,7 @@ func gateStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, s
 	}
 
 	merged := false
+	closedUnmerged := false
 	if pr > 0 {
 		prRow, gerr := deps.store.GetPullRequest(ctx, deps.rec.Repo, int64(pr))
 		if gerr != nil {
@@ -1059,11 +1098,24 @@ func gateStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, s
 			}
 			// The PR is not recorded in the store yet — not merged; keep waiting (fail-open).
 		} else {
-			merged = strings.EqualFold(strings.TrimSpace(prRow.State), "merged")
+			switch strings.ToLower(strings.TrimSpace(prRow.State)) {
+			case "merged":
+				merged = true
+			case "closed":
+				closedUnmerged = true
+			}
 		}
 	}
 	if merged {
 		return true, pipeline.StageSucceeded, fmt.Sprintf("gate %s satisfied: PR #%d merged", stage.Gate, pr), nil, nil, nil
+	}
+	// The upstream PR was CLOSED without merging: pr_merged can NEVER hold now, so the
+	// gate is terminal — waiting would hang the run forever (esp. with no stage timeout).
+	// Park the run BLOCKED (a gate is a wait, not a mutation, so blocked — never failed —
+	// keeps the retry budget from re-arming the timer), naming the terminal reason.
+	if closedUnmerged {
+		want := fmt.Sprintf("PR #%d merged (it was closed without merging)", pr)
+		return true, pipeline.StageBlocked, fmt.Sprintf("gate %s cannot pass: PR #%d was closed without merging", stage.Gate, pr), []string{want}, nil, nil
 	}
 
 	// Not merged yet. Bound the wait against the stage timeout (measured from StartedAt),
@@ -1116,9 +1168,16 @@ func pipelineGateWaitDescription(predicate string, pr int) string {
 // marker is present or the number is not a positive int — the inverse of the stamping so
 // a gate can read the structured PR back out of the upstream stage row's summary (Phase 1
 // deliberately added no schema column). Deterministic and allocation-light.
+//
+// It matches the LAST occurrence of the marker, not the first: appendPipelineImplementPR
+// always APPENDS the trusted "(opened PR #<n>)" at the very END of the summary, while the
+// leading text is the agent's untrusted free-text decision summary — which could itself
+// contain a literal "(opened PR #<k>)" naming an unrelated PR. Reading the last match
+// binds the gate to the marker gitmoot stamped, never to a number the agent spoofed into
+// its prose.
 func parsePipelineImplementPR(summary string) int {
 	const prefix = "(opened PR #"
-	idx := strings.Index(summary, prefix)
+	idx := strings.LastIndex(summary, prefix)
 	if idx < 0 {
 		return 0
 	}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -326,6 +327,11 @@ func pipelineStageFingerprint(pipelineName, runID, stageID string, attempt int) 
 // builder: an implement kind #768 appends its writable-worktree/branch branch there).
 func pipelineStageMintsJob(stage pipeline.Stage) bool {
 	switch stage.Kind() {
+	case pipeline.StageKindGate:
+		// A JOBLESS gate (#768 Phase 2) has no worker/runtime session: the ENQUEUE pass
+		// marks it in-flight (queued) WITHOUT minting a job, and the settle seam folds it
+		// on its external predicate (pr_merged) instead of on a job's terminal state.
+		return false
 	default:
 		return true
 	}
@@ -905,9 +911,15 @@ func stageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec 
 		// payload carries an opened PR — closing the race where the implement job reaches
 		// terminal success a beat before the finalizer stamps the PR.
 		return implementStageSettleOutcome(ctx, deps, spec, stage, stageRow)
+	case pipeline.StageKindGate:
+		// #768 Phase 2 JOBLESS gate: it has no worker job, so it NEVER calls GetJob. It
+		// folds success once its external predicate (pr_merged on the upstream source
+		// stage's PR) holds, or parks the run on the stage timeout. The predicate reads
+		// only the store (upstream stage row + the polled PR state), is non-blocking and
+		// ctx-bounded, and fails OPEN (settled=false while the merge has not landed / the
+		// PR is not yet recorded); a genuine store error surfaces via err.
+		return gateStageSettleOutcome(ctx, deps, spec, stage, stageRow)
 	// A future kind adds its case here, e.g.:
-	//   case pipeline.StageKindGate:       // jobless: never calls GetJob
-	//       return gateStageSettleOutcome(ctx, deps, spec, stage, stageRow)
 	//   case pipeline.StageKindOrchestrate: // re-points nextRow.JobID, stays unsettled
 	//       return orchestrateStageSettleOutcome(ctx, deps, spec, stage, stageRow)
 	default:
@@ -1001,6 +1013,125 @@ func appendPipelineImplementPR(summary string, pr int) string {
 		return marker
 	}
 	return summary + " " + marker
+}
+
+// gateStageSettleOutcome is the #768 Phase 2 JOBLESS gate stage's per-kind settle
+// predicate. A gate mints no worker job (pipelineStageMintsJob is false), so it enters
+// the settle pass in the StageQueued state with no JobID and NEVER calls GetJob. It
+// evaluates its external predicate once per advance scan and folds when the predicate
+// holds:
+//
+//   - pr_merged: the PR opened by the upstream SOURCE (implement) stage has MERGED.
+//     The PR number is recovered from the source stage row's summary (where
+//     implementStageSettleOutcome stamped "(opened PR #<n>)"), and merge is read from
+//     the polled pull_requests state (deps.store) — the same store row the daemon's PR
+//     poller / merge-gate keeps current, so this needs no live GitHub call. On merged:
+//     settled=true, state=success. This is the STORE/state path the design prefers; a
+//     bounded GitHub poll would be threaded into pipelineStageSettleDeps as the fallback.
+//
+// It is non-blocking + ctx-bounded and FAILS OPEN: while the PR is not yet recorded or
+// not yet merged it stays in flight (settled=false), never a hung poll. A genuine store
+// error (not sql.ErrNoRows) surfaces via err so the advancer can retry the scan. The
+// wait is bounded by the stage timeout measured from the gate's StartedAt (set when the
+// ENQUEUE pass marked it in-flight): on expiry it parks the run BLOCKED (a gate is a
+// wait, not a mutation — parking blocked, never failed, keeps the retry budget from
+// re-arming the timer). A gate with no timeout waits indefinitely (cheaply — no job).
+// While in flight it reflects the one-time queued->running funnel transition via nextRow.
+func gateStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec pipeline.Spec, stage pipeline.Stage, stageRow db.PipelineRunStage) (settled bool, state, summary string, needs []string, nextRow *db.PipelineRunStage, err error) {
+	// Recover the PR the upstream source stage opened (parsed from its folded summary,
+	// where the implement stage stamped "(opened PR #<n>)"). A missing source row or an
+	// unparseable PR keeps the gate waiting (fail-open) until the timeout parks it.
+	pr := 0
+	if source := strings.TrimSpace(stage.Source); source != "" {
+		if srcRow, ok, gerr := deps.store.GetPipelineRunStage(ctx, deps.run.ID, source); gerr != nil {
+			return false, "", "", nil, nil, gerr
+		} else if ok {
+			pr = parsePipelineImplementPR(srcRow.Summary)
+		}
+	}
+
+	merged := false
+	if pr > 0 {
+		prRow, gerr := deps.store.GetPullRequest(ctx, deps.rec.Repo, int64(pr))
+		if gerr != nil {
+			if !errors.Is(gerr, sql.ErrNoRows) {
+				return false, "", "", nil, nil, gerr
+			}
+			// The PR is not recorded in the store yet — not merged; keep waiting (fail-open).
+		} else {
+			merged = strings.EqualFold(strings.TrimSpace(prRow.State), "merged")
+		}
+	}
+	if merged {
+		return true, pipeline.StageSucceeded, fmt.Sprintf("gate %s satisfied: PR #%d merged", stage.Gate, pr), nil, nil, nil
+	}
+
+	// Not merged yet. Bound the wait against the stage timeout (measured from StartedAt),
+	// parking the run BLOCKED on expiry with a needs entry naming what it waited on.
+	if timedOut, waited := pipelineGateTimedOut(stage, stageRow, deps.now); timedOut {
+		want := pipelineGateWaitDescription(stage.Gate, pr)
+		return true, pipeline.StageBlocked, fmt.Sprintf("gate %s timed out after %s waiting for %s", stage.Gate, waited, want), []string{want}, nil, nil
+	}
+
+	// Still waiting: reflect the one-time queued->running funnel transition so the gate
+	// shows as actively watching, then stay in flight (settled=false).
+	if stageRow.State == pipeline.StageQueued {
+		next := stageRow
+		next.State = pipeline.StageRunning
+		return false, "", "", nil, &next, nil
+	}
+	return false, "", "", nil, nil, nil
+}
+
+// pipelineGateTimedOut reports whether a gate stage's wait has exceeded its stage
+// timeout, measured from the row's StartedAt (set when the ENQUEUE pass marked the
+// jobless gate in-flight) to now. A gate with no timeout (or a not-yet-started row)
+// never times out — it waits indefinitely, cheaply. The elapsed duration is returned
+// for the park summary. Validation already guarantees a set timeout parses positive.
+func pipelineGateTimedOut(stage pipeline.Stage, stageRow db.PipelineRunStage, now time.Time) (bool, time.Duration) {
+	to := strings.TrimSpace(stage.Timeout)
+	if to == "" || stageRow.StartedAt.IsZero() {
+		return false, 0
+	}
+	limit, err := time.ParseDuration(to)
+	if err != nil || limit <= 0 {
+		return false, 0
+	}
+	elapsed := now.Sub(stageRow.StartedAt)
+	return elapsed >= limit, elapsed
+}
+
+// pipelineGateWaitDescription names, for a park summary / needs entry, the external
+// thing a gate is waiting on — the merge of a specific PR when one is known, else the
+// upstream PR generically (it has not been recorded yet).
+func pipelineGateWaitDescription(predicate string, pr int) string {
+	if pr > 0 {
+		return fmt.Sprintf("PR #%d merged", pr)
+	}
+	return fmt.Sprintf("the upstream %s predicate to hold", predicate)
+}
+
+// parsePipelineImplementPR recovers the PR number an implement stage stamped onto its
+// summary via appendPipelineImplementPR ("(opened PR #<n>)"). It returns 0 when no such
+// marker is present or the number is not a positive int — the inverse of the stamping so
+// a gate can read the structured PR back out of the upstream stage row's summary (Phase 1
+// deliberately added no schema column). Deterministic and allocation-light.
+func parsePipelineImplementPR(summary string) int {
+	const prefix = "(opened PR #"
+	idx := strings.Index(summary, prefix)
+	if idx < 0 {
+		return 0
+	}
+	rest := summary[idx+len(prefix):]
+	end := strings.IndexByte(rest, ')')
+	if end < 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(rest[:end]))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
 }
 
 // foldPipelineStageOutcome maps a settled stage job to a stage outcome BY DECISION

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 	"unicode/utf8"
 
+	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/pipeline"
@@ -51,6 +54,18 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 		// rather than stalling the pipeline scan loop. Shell stages carry a
 		// RuntimeOverride and are excluded, so their request is byte-identical.
 		request, worktreePath, worktreeErr := allocatePipelineStageReadOnlyWorktree(ctx, store, home, request)
+		// #768: a MUTATING implement stage takes the WRITABLE task-worktree path
+		// instead of the read-only committed-tip worktree — it must commit + push. Unlike
+		// the read-only allocator (fail-OPEN), this one is fail-CLOSED: on an active
+		// implement job / live process / uncommitted changes it errors and the stage is
+		// NOT enqueued, so a retry can never duplicate or clobber a branch/PR (`gitmoot
+		// task recover` is the operator escape hatch). The two allocators are mutually
+		// exclusive — read-only eligibility excludes the implement action.
+		var writableErr error
+		request, writableErr = allocatePipelineStageWritableWorktree(ctx, store, home, request)
+		if writableErr != nil {
+			return db.Job{}, writableErr
+		}
 		job, err := mailbox.Enqueue(ctx, request)
 		if err != nil {
 			// The worktree is created on disk BEFORE Enqueue; a failed Enqueue leaves
@@ -162,6 +177,116 @@ func pipelineStageCheckoutPath(ctx context.Context, store *db.Store, repo string
 	return strings.TrimSpace(record.CheckoutPath)
 }
 
+// pipelineStageImplementWorktreeEligible reports whether a stage job request is a
+// repo-bound MUTATING implement stage (#768) that needs a WRITABLE task-worktree.
+// True only for a pipeline-sender implement job bound to a named agent, running
+// against a repo, that carries NO runtime override (the shell runner sets one) and NO
+// worktree yet. Every read-only agent stage (ask/review) and every shell stage is
+// excluded — the read-only allocator (which itself excludes non-ask/review) owns those.
+func pipelineStageImplementWorktreeEligible(request workflow.JobRequest) bool {
+	if request.Sender != workflow.PipelineJobSender {
+		return false
+	}
+	if strings.TrimSpace(request.RuntimeOverride) != "" {
+		return false
+	}
+	if strings.TrimSpace(request.Agent) == "" {
+		return false
+	}
+	if strings.TrimSpace(request.Action) != "implement" {
+		return false
+	}
+	if strings.TrimSpace(request.Repo) == "" {
+		return false
+	}
+	return strings.TrimSpace(request.WorktreePath) == ""
+}
+
+// allocatePipelineStageWritableWorktree gives a MUTATING implement stage (#768) a real
+// WRITABLE task-worktree on its DETERMINISTIC branch by REUSING the existing implement
+// dispatch preparation (prepareLocalImplementDispatchRequest): its GetTaskByRepoBranch
+// reuse lands a retry in the SAME branch/worktree (never a duplicate PR), and its
+// fail-closed guards (an active implement job, a live process still inside the
+// worktree, or uncommitted changes) reject a retry that would clobber or duplicate
+// work. Unlike the read-only allocator it is FAIL-CLOSED: any error propagates so the
+// stage is NOT enqueued. An ineligible request (every non-implement stage) returns
+// unchanged with a nil error. On success the request carries the task worktree path +
+// the resolved deterministic branch/task/head, so the enqueued job keys worktree:<path>
+// (mutating same-repo stages parallelize; the only serialization is the brief
+// checkout-mutation lock during allocation). ReadOnlyWorktree is deliberately left
+// false — the task worktree is durable (disposed by the task lifecycle, not the #739
+// read-only cleanup).
+func allocatePipelineStageWritableWorktree(ctx context.Context, store *db.Store, home string, request workflow.JobRequest) (workflow.JobRequest, error) {
+	if !pipelineStageImplementWorktreeEligible(request) {
+		return request, nil
+	}
+	record, err := store.GetRepo(ctx, request.Repo)
+	if err != nil {
+		return request, fmt.Errorf("resolve repo %q for implement stage: %w", request.Repo, err)
+	}
+	repo, err := daemon.ParseRepository(request.Repo)
+	if err != nil {
+		return request, err
+	}
+	// Ensure the DETERMINISTIC task row exists so prepareLocalImplementDispatchRequest's
+	// BRANCH-reuse path adopts THIS run+stage's task id — and, crucially, so its
+	// fail-closed guards (active job / live process / uncommitted changes) run on EVERY
+	// attempt. We therefore hand it an EMPTY TaskID (which routes through that guarded
+	// branch-reuse block) plus the deterministic Branch; passing a non-empty TaskID would
+	// skip the guards entirely. Idempotent: created once (Planned), reused thereafter.
+	if _, gerr := store.GetTask(ctx, request.TaskID); gerr != nil {
+		if !errors.Is(gerr, sql.ErrNoRows) {
+			return request, gerr
+		}
+		if uerr := store.UpsertTask(ctx, db.Task{
+			ID:           request.TaskID,
+			RepoFullName: request.Repo,
+			GoalID:       firstNonEmpty(request.GoalID, "pipeline"),
+			Title:        firstNonEmpty(request.TaskTitle, request.TaskID),
+			State:        string(workflow.TaskPlanned),
+			Branch:       request.Branch,
+		}); uerr != nil {
+			return request, uerr
+		}
+	}
+	dispatch := localAgentDispatchRequest{
+		Home:         home,
+		Agent:        request.Agent,
+		Action:       "implement",
+		Instructions: request.Instructions,
+		Branch:       request.Branch,
+		GoalID:       request.GoalID,
+		TaskTitle:    request.TaskTitle,
+		RepoFlag:     request.Repo,
+	}
+	task, dispatch, err := prepareLocalImplementDispatchRequest(ctx, store, record, repo, dispatch)
+	if err != nil {
+		return request, err
+	}
+	request.WorktreePath = task.WorktreePath
+	request.Branch = dispatch.Branch
+	request.TaskID = dispatch.TaskID
+	request.HeadSHA = dispatch.HeadSHA
+	request.GoalID = firstNonEmpty(request.GoalID, dispatch.GoalID)
+	request.TaskTitle = firstNonEmpty(request.TaskTitle, dispatch.TaskTitle)
+	request.LeadAgent = firstNonEmpty(request.LeadAgent, dispatch.LeadAgent)
+	return request, nil
+}
+
+// pipelineStageImplementTaskID / pipelineStageImplementBranch derive the DETERMINISTIC,
+// attempt-INDEPENDENT task id and branch a mutating implement stage (#768) reuses across
+// retries: `pipe-<runID>-<stageID>` and `gitmoot/pipe-<runID>-<stageID>`. Excluding the
+// attempt is what makes attempt N+1 land in the SAME branch/worktree (via
+// GetTaskByRepoBranch reuse) rather than opening a duplicate PR; branches are RUN-scoped,
+// so distinct runs of a scheduled pipeline are distinct logical changes.
+func pipelineStageImplementTaskID(runID, stageID string) string {
+	return fmt.Sprintf("pipe-%s-%s", runID, stageID)
+}
+
+func pipelineStageImplementBranch(runID, stageID string) string {
+	return "gitmoot/" + pipelineStageImplementTaskID(runID, stageID)
+}
+
 // pipelineRunID derives a deterministic-per-invocation run id: a recognizable
 // "prun-" marker, the pipeline name (a validated name-safe token), and the
 // nanosecond clock so distinct runs never collide. The marker also lets
@@ -218,6 +343,29 @@ func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.Pipel
 	// advancement), RootJobID=run.ID. The action is the validated read-only
 	// ask/review. Everything else (fingerprint, timeout, root) matches the shell path
 	// so the advancer folds it identically.
+	// #768 MUTATING implement stage: bind to the named agent running its OWN runtime,
+	// but — unlike a read-only agent stage — carry a DETERMINISTIC, attempt-INDEPENDENT
+	// Branch/TaskID so a retry lands in the SAME branch/worktree (never a duplicate PR).
+	// The writable task-worktree itself is allocated at the enqueue seam
+	// (allocatePipelineStageWritableWorktree), which reuses the existing implement
+	// dispatch's GetTaskByRepoBranch reuse + fail-closed guards. Still a LEAF
+	// (Sender=pipeline strips delegations/human_questions) and the pipeline never merges
+	// its PR. This is an APPEND above the read-only agent branch, which stays byte-identical.
+	if stage.Kind() == pipeline.StageKindAgentImplement {
+		return workflow.JobRequest{
+			ID:           pipelineStageJobID(run.ID, stage.ID, attempt),
+			Agent:        stage.Agent,
+			Action:       "implement",
+			Repo:         rec.Repo,
+			Branch:       pipelineStageImplementBranch(run.ID, stage.ID),
+			TaskID:       pipelineStageImplementTaskID(run.ID, stage.ID),
+			Sender:       workflow.PipelineJobSender,
+			Instructions: upstreamContext + stage.Prompt,
+			Fingerprint:  pipelineStageFingerprint(rec.Name, run.ID, stage.ID, attempt),
+			RootJobID:    run.ID,
+			JobTimeout:   stage.Timeout,
+		}
+	}
 	if stage.Agent != "" {
 		return workflow.JobRequest{
 			ID:           pipelineStageJobID(run.ID, stage.ID, attempt),
@@ -751,6 +899,12 @@ type pipelineStageSettleDeps struct {
 // terminal, all unchanged. Future kinds branch here on stage.Kind() using deps.
 func stageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec pipeline.Spec, stage pipeline.Stage, stageRow db.PipelineRunStage) (settled bool, state, summary string, needs []string, nextRow *db.PipelineRunStage, err error) {
 	switch stage.Kind() {
+	case pipeline.StageKindAgentImplement:
+		// #768 MUTATING implement stage (Model A: fold-on-PR-opened). It settles like
+		// the default job-decision path but holds a SUCCESS fold back until the job
+		// payload carries an opened PR — closing the race where the implement job reaches
+		// terminal success a beat before the finalizer stamps the PR.
+		return implementStageSettleOutcome(ctx, deps, spec, stage, stageRow)
 	// A future kind adds its case here, e.g.:
 	//   case pipeline.StageKindGate:       // jobless: never calls GetJob
 	//       return gateStageSettleOutcome(ctx, deps, spec, stage, stageRow)
@@ -785,6 +939,68 @@ func stageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec 
 		state, summary, needs = foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
 		return true, state, summary, needs, nil, nil
 	}
+}
+
+// implementStageSettleOutcome is the #768 MUTATING implement stage's per-kind settle
+// predicate (Model A: fold-on-PR-opened). Like the default job-decision path it settles
+// only once the stage job is TERMINAL and folds by decision (implemented is already a
+// DefaultSuccessDecision) — with ONE added guard: a SUCCESS fold is held back until the
+// job payload carries an opened PullRequest (> 0). That closes the race where the
+// implement job reaches its terminal success state a beat before the
+// ImplementationFinalizer stamps the opened PR onto the payload; without it a downstream
+// stage could advance believing a PR exists when it does not yet. A blocked/failed
+// decision folds IMMEDIATELY (there is no PR to wait on), and a stage whose job times out
+// folds failed via the same decision path — so the PR guard can never wedge a run. On a
+// successful fold the opened PR number is appended to the stage summary so it flows to
+// downstream stages through the #757 upstream-context injection (which renders the stage
+// summary). It reproduces the default kind's JobID guard + queued->running funnel reflect
+// byte-for-byte for the not-terminal path.
+func implementStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec pipeline.Spec, stage pipeline.Stage, stageRow db.PipelineRunStage) (settled bool, state, summary string, needs []string, nextRow *db.PipelineRunStage, err error) {
+	if strings.TrimSpace(stageRow.JobID) == "" {
+		return false, "", "", nil, nil, nil
+	}
+	job, err := deps.store.GetJob(ctx, stageRow.JobID)
+	if err != nil {
+		return false, "", "", nil, nil, err
+	}
+	if !workflow.IsSettledJobState(job.State) {
+		if job.State == string(workflow.JobRunning) && stageRow.State == pipeline.StageQueued {
+			next := stageRow
+			next.State = pipeline.StageRunning
+			return false, "", "", nil, &next, nil
+		}
+		return false, "", "", nil, nil, nil
+	}
+	state, summary, needs = foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
+	if state == pipeline.StageSucceeded {
+		pr := 0
+		if payload, perr := workflow.ParseJobPayload(job.Payload); perr == nil {
+			pr = payload.PullRequest
+		}
+		if pr <= 0 {
+			// The job settled successfully but the PR is not stamped on the payload yet:
+			// WAIT (fold-on-PR-opened). Stay in flight untouched; a later scan re-checks.
+			return false, "", "", nil, nil, nil
+		}
+		summary = appendPipelineImplementPR(summary, pr)
+	}
+	return true, state, summary, needs, nil, nil
+}
+
+// appendPipelineImplementPR annotates a mutating implement stage's SUCCESS summary with
+// the opened PR number so downstream stages see it via the #757 upstream-context
+// injection. Deterministic + idempotent: it appends the marker only when a positive PR
+// is present and not already referenced, so a re-derivation is byte-identical.
+func appendPipelineImplementPR(summary string, pr int) string {
+	summary = strings.TrimSpace(summary)
+	marker := fmt.Sprintf("(opened PR #%d)", pr)
+	if strings.Contains(summary, marker) {
+		return summary
+	}
+	if summary == "" {
+		return marker
+	}
+	return summary + " " + marker
 }
 
 // foldPipelineStageOutcome maps a settled stage job to a stage outcome BY DECISION

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -90,6 +90,57 @@ stages:
 	}
 }
 
+// TestLoadValidImplementSpec exercises the #768 mutating implement schema: an
+// `action: implement` stage with `write: true` on a SCHEDULED pipeline that opts in
+// via `allow_scheduled_writes: true` loads, parses both new fields, and classifies as
+// StageKindAgentImplement.
+func TestLoadValidImplementSpec(t *testing.T) {
+	const spec = `name: build-flow
+repo: owner/repo
+schedule:
+  interval: 24h
+allow_scheduled_writes: true
+stages:
+  - id: fix
+    agent: coder
+    prompt: Fix the reported bug.
+    action: implement
+    write: true
+    retry: 1
+`
+	loaded, err := Load([]byte(spec))
+	if err != nil {
+		t.Fatalf("Load valid implement spec: %v", err)
+	}
+	if !loaded.AllowScheduledWrites {
+		t.Fatalf("allow_scheduled_writes did not parse: %+v", loaded)
+	}
+	st := loaded.Stages[0]
+	if st.Action != "implement" || !st.Write {
+		t.Fatalf("implement stage = %+v, want action=implement write=true", st)
+	}
+	if st.Kind() != StageKindAgentImplement {
+		t.Fatalf("Kind() = %d, want StageKindAgentImplement", st.Kind())
+	}
+}
+
+// TestLoadValidManualImplementSpec proves a MANUAL (no schedule) implement pipeline
+// needs only the per-stage write: true — the scheduled-write gate does not apply.
+func TestLoadValidManualImplementSpec(t *testing.T) {
+	const spec = `name: manual-flow
+repo: owner/repo
+stages:
+  - id: fix
+    agent: coder
+    prompt: Fix it.
+    action: implement
+    write: true
+`
+	if _, err := Load([]byte(spec)); err != nil {
+		t.Fatalf("manual implement spec should validate: %v", err)
+	}
+}
+
 func TestLoadValidationErrors(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -132,9 +183,19 @@ func TestLoadValidationErrors(t *testing.T) {
 			wantSub: `stage "a" agent stage requires a non-empty prompt`,
 		},
 		{
-			name:    "agent implement rejected",
+			name:    "implement without write rejected",
 			spec:    "name: p\nstages:\n  - {id: a, agent: rev, prompt: hi, action: implement}\n",
-			wantSub: `action "implement" is not allowed`,
+			wantSub: `sets action "implement" without write: true`,
+		},
+		{
+			name:    "write without implement rejected",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, write: true}\n",
+			wantSub: "write: true is only valid with action: implement",
+		},
+		{
+			name:    "scheduled implement without allow rejected",
+			spec:    "name: p\nschedule:\n  interval: 24h\nstages:\n  - {id: a, agent: rev, prompt: hi, action: implement, write: true}\n",
+			wantSub: "set allow_scheduled_writes: true",
 		},
 		{
 			name:    "agent bad action",
@@ -228,7 +289,8 @@ func TestPipelineStageKind(t *testing.T) {
 		{"agent review", Stage{ID: "a", Agent: "rev", Prompt: "q", Action: "review"}, StageKindAgentReview},
 		{"both executors", Stage{ID: "a", Cmd: "echo", Agent: "rev", Prompt: "q"}, StageKindUnknown},
 		{"neither executor", Stage{ID: "a"}, StageKindUnknown},
-		{"agent implement", Stage{ID: "a", Agent: "impl", Prompt: "q", Action: "implement"}, StageKindUnknown},
+		{"agent implement", Stage{ID: "a", Agent: "impl", Prompt: "q", Action: "implement", Write: true}, StageKindAgentImplement},
+		{"agent implement no write still a kind", Stage{ID: "a", Agent: "impl", Prompt: "q", Action: "implement"}, StageKindAgentImplement},
 		{"agent bad action", Stage{ID: "a", Agent: "x", Prompt: "q", Action: "deploy"}, StageKindUnknown},
 	}
 	for _, tc := range cases {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -141,6 +141,40 @@ stages:
 	}
 }
 
+// TestLoadValidGateSpec proves a JOBLESS gate stage (#768 Phase 2) loads: a
+// pr_merged predicate watching an upstream implement stage it needs, classifying as
+// StageKindGate and expressing [implement] -> [gate] -> [deploy].
+func TestLoadValidGateSpec(t *testing.T) {
+	const spec = `name: gate-flow
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: wait
+    gate: pr_merged
+    source: impl
+    needs: [impl]
+    timeout: 24h
+  - id: deploy
+    cmd: echo deploying
+    needs: [wait]
+`
+	loaded, err := Load([]byte(spec))
+	if err != nil {
+		t.Fatalf("Load valid gate spec: %v", err)
+	}
+	gate := loaded.Stages[1]
+	if gate.Gate != "pr_merged" || gate.Source != "impl" {
+		t.Fatalf("gate stage = %+v, want gate=pr_merged source=impl", gate)
+	}
+	if gate.Kind() != StageKindGate {
+		t.Fatalf("gate Kind() = %d, want StageKindGate", gate.Kind())
+	}
+}
+
 func TestLoadValidationErrors(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -201,6 +235,36 @@ func TestLoadValidationErrors(t *testing.T) {
 			name:    "agent bad action",
 			spec:    "name: p\nstages:\n  - {id: a, agent: rev, prompt: hi, action: deploy}\n",
 			wantSub: `action "deploy" is invalid`,
+		},
+		{
+			name:    "gate bad predicate",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: g, gate: pr_reviewed, source: a, needs: [a]}\n",
+			wantSub: `gate predicate "pr_reviewed" is invalid`,
+		},
+		{
+			name:    "gate without source",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: g, gate: pr_merged, needs: [a]}\n",
+			wantSub: "gate stage requires a source",
+		},
+		{
+			name:    "gate source not in needs",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: b, cmd: echo}\n  - {id: g, gate: pr_merged, source: a, needs: [b]}\n",
+			wantSub: `gate source "a" must be one of the stage's needs`,
+		},
+		{
+			name:    "gate source is self",
+			spec:    "name: p\nstages:\n  - {id: g, gate: pr_merged, source: g, needs: [g]}\n",
+			wantSub: "gate source cannot be the stage itself",
+		},
+		{
+			name:    "gate with cmd rejected",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: g, gate: pr_merged, source: a, needs: [a], cmd: echo}\n",
+			wantSub: `stage "g" sets both gate and cmd`,
+		},
+		{
+			name:    "gate with agent rejected",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: g, gate: pr_merged, source: a, needs: [a], agent: rev, prompt: hi}\n",
+			wantSub: `stage "g" sets both gate and agent`,
 		},
 		{
 			name:    "shell stage with prompt",
@@ -292,6 +356,7 @@ func TestPipelineStageKind(t *testing.T) {
 		{"agent implement", Stage{ID: "a", Agent: "impl", Prompt: "q", Action: "implement", Write: true}, StageKindAgentImplement},
 		{"agent implement no write still a kind", Stage{ID: "a", Agent: "impl", Prompt: "q", Action: "implement"}, StageKindAgentImplement},
 		{"agent bad action", Stage{ID: "a", Agent: "x", Prompt: "q", Action: "deploy"}, StageKindUnknown},
+		{"gate pr_merged", Stage{ID: "g", Gate: "pr_merged", Source: "impl", Needs: []string{"impl"}}, StageKindGate},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -257,6 +257,11 @@ func TestLoadValidationErrors(t *testing.T) {
 			wantSub: "gate source cannot be the stage itself",
 		},
 		{
+			name:    "gate source is not an implement stage",
+			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: g, gate: pr_merged, source: a, needs: [a]}\n",
+			wantSub: `gate source "a" must be a mutating implement stage`,
+		},
+		{
 			name:    "gate with cmd rejected",
 			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: g, gate: pr_merged, source: a, needs: [a], cmd: echo}\n",
 			wantSub: `stage "g" sets both gate and cmd`,

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -51,6 +51,13 @@ type Spec struct {
 	// Schedule, when present, drives interval-based auto-runs (heartbeat idiom: an
 	// interval plus optional jitter; no cron in v1).
 	Schedule *Schedule `yaml:"schedule,omitempty"`
+	// AllowScheduledWrites, when true, permits MUTATING (implement) stages on a
+	// SCHEDULED pipeline (one carrying a schedule: block) (#768 safety layer 2).
+	// Absent (the default), a scheduled pipeline REJECTS any mutating stage at
+	// validation, so an unattended nightly can never write code + open a PR without a
+	// deliberate, spelled-twice opt-in. Irrelevant to a manual-only pipeline (no
+	// schedule), which a mutating stage enters with only its per-stage write: true.
+	AllowScheduledWrites bool `yaml:"allow_scheduled_writes,omitempty"`
 	// SuccessDecisions overrides DefaultSuccessDecisions for every stage that does
 	// not set its own. Empty means DefaultSuccessDecisions.
 	SuccessDecisions []string `yaml:"success_decisions,omitempty"`
@@ -88,10 +95,15 @@ type Stage struct {
 	// Agent is set; ignored for a shell stage). Builder 2 prepends upstream
 	// needs-context; for now the runtime prompt is Prompt verbatim.
 	Prompt string `yaml:"prompt,omitempty"`
-	// Action is the read-only agent verb for an agent stage: "ask" (default) or
-	// "review". "implement" is rejected — an agent stage must stay a read-only
-	// leaf. Ignored for a shell stage.
+	// Action is the agent verb for an agent stage: "ask" (default) or "review"
+	// (read-only leaves), or "implement" (a MUTATING stage, #768) which additionally
+	// requires Write. Ignored for a shell stage.
 	Action string `yaml:"action,omitempty"`
+	// Write, when true, ACKNOWLEDGES that this stage MUTATES the repo (#768). It is
+	// REQUIRED for — and valid ONLY on — an `action: implement` stage: the spec
+	// double-key that stops a prompt injection or a template typo from silently
+	// flipping a read-only pipeline into a writing one. Rejected on any other stage.
+	Write bool `yaml:"write,omitempty"`
 	// Needs lists the ids of stages that must succeed before this stage is enqueued.
 	Needs []string `yaml:"needs,omitempty"`
 	// Timeout optionally bounds the stage job (a positive Go duration when set).
@@ -130,6 +142,13 @@ const (
 	// verb. Same leaf contract as ask; kept distinct so a future kind is appended as
 	// a sibling case rather than by editing a shared agent branch.
 	StageKindAgentReview
+	// StageKindAgentImplement is a MUTATING agent stage (#768 Model A): Agent set,
+	// action "implement", plus the required Write acknowledgement. Unlike the
+	// read-only ask/review kinds it takes a WRITABLE task-worktree, commits + pushes +
+	// opens a PR, and folds success only once a PR exists (fold-on-PR-opened). It is
+	// still a LEAF — it may mutate but never fan out (delegations/human_questions are
+	// stripped) — and the pipeline NEVER merges its own PR.
+	StageKindAgentImplement
 )
 
 // Kind classifies the stage. A shell stage (Cmd set) is StageKindShell; an agent
@@ -152,6 +171,8 @@ func (s Stage) Kind() StageKind {
 			return StageKindAgentAsk
 		case "review":
 			return StageKindAgentReview
+		case "implement":
+			return StageKindAgentImplement
 		}
 	}
 	return StageKindUnknown

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -40,6 +40,18 @@ const DefaultAgentStageAction = "ask"
 // agent stage must never write, fan out, or leave the read-only leaf contract.
 var AgentStageActionCandidates = []string{"ask", "review"}
 
+// GatePredicatePRMerged is the only gate predicate today (#768 Phase 2): a jobless
+// gate stage carrying `gate: pr_merged` folds success once the PR opened by its
+// upstream source (implement) stage has MERGED. The pipeline never merges the PR
+// itself — merge stays with humans/CI — so the gate is the composable wait a
+// pipeline uses to express `[implement] -> [gate: pr_merged] -> [deploy]`.
+const GatePredicatePRMerged = "pr_merged"
+
+// GatePredicateCandidates are the predicate tokens a gate stage's `gate:` MAY set
+// (#768 Phase 2). It starts deliberately small — just pr_merged — so the vocab is a
+// pure append when a future external-gate predicate (e.g. #758 subtree_settled) lands.
+var GatePredicateCandidates = []string{GatePredicatePRMerged}
+
 // Spec is the parsed, validated declaration of a pipeline.
 type Spec struct {
 	// Name is the pipeline's stable identifier (the DB primary key and the stem of
@@ -104,6 +116,18 @@ type Stage struct {
 	// double-key that stops a prompt injection or a template typo from silently
 	// flipping a read-only pipeline into a writing one. Rejected on any other stage.
 	Write bool `yaml:"write,omitempty"`
+	// Gate, when set, declares a JOBLESS GATE stage (#768 Phase 2): it runs NEITHER a
+	// shell cmd NOR an agent — it WAITS on an external predicate and folds only once
+	// the predicate holds. The value is the predicate token (today only "pr_merged";
+	// see GatePredicateCandidates). A gate mints no worker job, no runtime session; the
+	// advancer's settle pass evaluates its predicate per scan. Mutually exclusive with
+	// Cmd and Agent (exactly one of the three executors). Pairs with Source.
+	Gate string `yaml:"gate,omitempty"`
+	// Source is the id of the upstream stage a gate stage watches (required for — and
+	// valid ONLY on — a gate stage): the implement stage whose opened PR the gate's
+	// predicate observes. It must be one of the gate's own Needs, so the gate only
+	// begins watching once that upstream stage has succeeded (and stamped its PR).
+	Source string `yaml:"source,omitempty"`
 	// Needs lists the ids of stages that must succeed before this stage is enqueued.
 	Needs []string `yaml:"needs,omitempty"`
 	// Timeout optionally bounds the stage job (a positive Go duration when set).
@@ -149,6 +173,14 @@ const (
 	// still a LEAF — it may mutate but never fan out (delegations/human_questions are
 	// stripped) — and the pipeline NEVER merges its own PR.
 	StageKindAgentImplement
+	// StageKindGate is a JOBLESS GATE stage (#768 Phase 2): Gate set, neither Cmd nor
+	// Agent. It mints NO worker job — the ENQUEUE pass marks it in-flight without a job
+	// and the advancer's SETTLE pass folds it when its external predicate holds
+	// (pr_merged: the PR opened by the upstream Source implement stage has merged),
+	// parking the run on the stage timeout if it never does. Its executor is a NEW axis
+	// (Gate) alongside cmd|agent, which is why validateStageExecutor's exactly-one-of
+	// guard widens to {cmd, agent, gate}.
+	StageKindGate
 )
 
 // Kind classifies the stage. A shell stage (Cmd set) is StageKindShell; an agent
@@ -174,6 +206,11 @@ func (s Stage) Kind() StageKind {
 		case "implement":
 			return StageKindAgentImplement
 		}
+	case s.Gate != "":
+		// A jobless gate (#768 Phase 2): no cmd, no agent, a gate predicate instead.
+		// Reached only after validateStageExecutor's widened exactly-one-of guard has
+		// confirmed gate is the SOLE executor set.
+		return StageKindGate
 	}
 	return StageKindUnknown
 }

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -79,6 +79,12 @@ func (s Spec) Validate() error {
 		if err := validateStageExecutor(s.Name, stage); err != nil {
 			return err
 		}
+		// #768 mutating-implement safety model (spec double-key + scheduled-write gate).
+		// Kept out of validateStageExecutor because it spans stage AND spec context (the
+		// schedule block); an APPEND that leaves every read-only kind's validator intact.
+		if err := s.validateMutatingStage(stage); err != nil {
+			return err
+		}
 		if stage.Retry < 0 {
 			return fmt.Errorf("pipeline %q stage %q retry must be >= 0", s.Name, stage.ID)
 		}
@@ -220,6 +226,8 @@ func validateStageExecutor(pipelineName string, stage Stage) error {
 		return validateShellStage(pipelineName, stage)
 	case StageKindAgentAsk, StageKindAgentReview:
 		return validateAgentStage(pipelineName, stage)
+	case StageKindAgentImplement:
+		return validateImplementStage(pipelineName, stage)
 	default:
 		// StageKindUnknown past the exactly-one-of guard = an agent stage (Agent
 		// set, Cmd empty) with an unrecognized action; validateAgentStage produces
@@ -256,6 +264,50 @@ func validateAgentStage(pipelineName string, stage Stage) error {
 	}
 	if !containsToken(AgentStageActionCandidates, stage.Action) {
 		return fmt.Errorf("pipeline %q stage %q agent stage action %q is invalid; use one of: %s", pipelineName, stage.ID, stage.Action, strings.Join(AgentStageActionCandidates, ", "))
+	}
+	return nil
+}
+
+// validateImplementStage validates a MUTATING implement agent stage (#768): a
+// name-safe agent token and a non-empty prompt — exactly like a read-only agent
+// stage, but WITHOUT validateAgentStage's read-only-leaf rejection, since a validated
+// implement stage is allowed. The write: true acknowledgement and the scheduled-write
+// gate live in Spec.validateMutatingStage (they need spec-level context). The token /
+// prompt messages are byte-identical to validateAgentStage so a mis-typed implement
+// stage fails with the same wording an ask stage would.
+func validateImplementStage(pipelineName string, stage Stage) error {
+	if !validToken(stage.Agent) {
+		return fmt.Errorf("pipeline %q stage %q agent %q must be a name-safe token (letters, digits, '-', '_')", pipelineName, stage.ID, stage.Agent)
+	}
+	if stage.Prompt == "" {
+		return fmt.Errorf("pipeline %q stage %q agent stage requires a non-empty prompt", pipelineName, stage.ID)
+	}
+	return nil
+}
+
+// validateMutatingStage enforces the #768 mutating-implement SAFETY MODEL, which
+// spans stage-level AND spec-level context (so it is a Spec method, not part of the
+// per-kind executor dispatch):
+//   - Spec double-key: `action: implement` REQUIRES `write: true` and, conversely,
+//     `write: true` is valid ONLY on an implement stage — so neither a prompt injection
+//     nor a template typo can flip a read-only pipeline into a writing one.
+//   - Schedule gate: a MUTATING stage on a SCHEDULED pipeline (a schedule: block) is
+//     rejected unless the pipeline sets `allow_scheduled_writes: true`, so an unattended
+//     nightly writing code is always a deliberate, spelled-twice choice. A manual-only
+//     pipeline (no schedule) needs only the per-stage write: true.
+//
+// It reads stage.Action / stage.Write directly (not Stage.Kind()) so it also catches
+// write: true on a NON-implement stage, which Kind() classifies as its base kind.
+func (s Spec) validateMutatingStage(stage Stage) error {
+	isImplement := stage.Agent != "" && stage.Action == "implement"
+	if stage.Write && !isImplement {
+		return fmt.Errorf("pipeline %q stage %q sets write: true but is not a mutating implement stage; write: true is only valid with action: implement", s.Name, stage.ID)
+	}
+	if isImplement && !stage.Write {
+		return fmt.Errorf("pipeline %q stage %q sets action \"implement\" without write: true; a mutating implement stage must acknowledge writes with write: true", s.Name, stage.ID)
+	}
+	if isImplement && s.Schedule != nil && !s.AllowScheduledWrites {
+		return fmt.Errorf("pipeline %q stage %q is a mutating implement stage on a scheduled pipeline; set allow_scheduled_writes: true to permit unattended writes", s.Name, stage.ID)
 	}
 	return nil
 }

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -65,6 +65,7 @@ func (s Spec) Validate() error {
 	}
 
 	known := make(map[string]struct{}, len(s.Stages))
+	stageByID := make(map[string]Stage, len(s.Stages))
 	for _, stage := range s.Stages {
 		if stage.ID == "" {
 			return fmt.Errorf("pipeline %q has a stage with no id", s.Name)
@@ -76,6 +77,7 @@ func (s Spec) Validate() error {
 			return fmt.Errorf("pipeline %q stage id %q is not unique", s.Name, stage.ID)
 		}
 		known[stage.ID] = struct{}{}
+		stageByID[stage.ID] = stage
 	}
 	for _, stage := range s.Stages {
 		if err := validateStageExecutor(s.Name, stage); err != nil {
@@ -86,6 +88,16 @@ func (s Spec) Validate() error {
 		// schedule block); an APPEND that leaves every read-only kind's validator intact.
 		if err := s.validateMutatingStage(stage); err != nil {
 			return err
+		}
+		// A gate's source must be a mutating implement stage: the pr_merged predicate reads
+		// the "(opened PR #<n>)" marker only an implement stage stamps onto its summary, so
+		// a gate pointed at a shell/ask/review source would find no PR and wait/time out
+		// silently instead of failing fast. Checked here (not in validateGateStage) because
+		// it needs the SOURCE stage's kind — spec-level context the per-stage validator lacks.
+		if stage.Kind() == StageKindGate {
+			if src, ok := stageByID[stage.Source]; ok && src.Kind() != StageKindAgentImplement {
+				return fmt.Errorf("pipeline %q stage %q gate source %q must be a mutating implement stage (action: implement) so the gate has a PR to watch", s.Name, stage.ID, stage.Source)
+			}
 		}
 		if stage.Retry < 0 {
 			return fmt.Errorf("pipeline %q stage %q retry must be >= 0", s.Name, stage.ID)

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -24,6 +24,8 @@ func (s *Spec) normalize() {
 		s.Stages[i].Agent = strings.TrimSpace(s.Stages[i].Agent)
 		s.Stages[i].Prompt = strings.TrimSpace(s.Stages[i].Prompt)
 		s.Stages[i].Action = strings.TrimSpace(s.Stages[i].Action)
+		s.Stages[i].Gate = strings.TrimSpace(s.Stages[i].Gate)
+		s.Stages[i].Source = strings.TrimSpace(s.Stages[i].Source)
 		s.Stages[i].Timeout = strings.TrimSpace(s.Stages[i].Timeout)
 		s.Stages[i].Needs = trimAll(s.Stages[i].Needs)
 		s.Stages[i].SuccessDecisions = trimAll(s.Stages[i].SuccessDecisions)
@@ -204,18 +206,25 @@ func (s Spec) detectCycle() error {
 func validateStageExecutor(pipelineName string, stage Stage) error {
 	hasCmd := stage.Cmd != ""
 	hasAgent := stage.Agent != ""
-	// The exactly-one-of cmd|agent guard is shared across kinds: it must run before
+	hasGate := stage.Gate != ""
+	// The exactly-one-of executor guard is shared across kinds: it must run before
 	// Stage.Kind() (which is only meaningful once exactly one executor is set). A
 	// future kind that lives on the EXISTING axes (e.g. implement = agent + an
-	// implement action) is a pure append below; a future kind that introduces a NEW
-	// executor field (a jobless gate: predicate) additionally widens this count to
-	// exactly-one-of {cmd, agent, gate}. That count widening is inherent to adding an
+	// implement action) is a pure append below; the jobless gate (#768 Phase 2)
+	// introduces a NEW executor field (gate: predicate), which is why this count widens
+	// to exactly-one-of {cmd, agent, gate}. That count widening is inherent to adding an
 	// executor axis, not a per-kind settle-logic edit — the seams the foundation
 	// guarantees (validateStageExecutor's dispatch, stageSettleOutcome) stay append-only.
+	// The cmd+agent and neither messages stay BYTE-IDENTICAL (the neither case only
+	// gains the && !hasGate term so a pure gate stage is not mis-rejected as "neither").
 	switch {
 	case hasCmd && hasAgent:
 		return fmt.Errorf("pipeline %q stage %q sets both cmd and agent; a stage is exactly one of a shell cmd or an agent", pipelineName, stage.ID)
-	case !hasCmd && !hasAgent:
+	case hasGate && hasCmd:
+		return fmt.Errorf("pipeline %q stage %q sets both gate and cmd; a stage is exactly one of a shell cmd, an agent, or a gate", pipelineName, stage.ID)
+	case hasGate && hasAgent:
+		return fmt.Errorf("pipeline %q stage %q sets both gate and agent; a stage is exactly one of a shell cmd, an agent, or a gate", pipelineName, stage.ID)
+	case !hasCmd && !hasAgent && !hasGate:
 		return fmt.Errorf("pipeline %q stage %q has neither cmd nor agent; a stage needs exactly one", pipelineName, stage.ID)
 	}
 	// Exactly one executor is set; dispatch the per-kind rules by Stage.Kind(). A
@@ -228,6 +237,8 @@ func validateStageExecutor(pipelineName string, stage Stage) error {
 		return validateAgentStage(pipelineName, stage)
 	case StageKindAgentImplement:
 		return validateImplementStage(pipelineName, stage)
+	case StageKindGate:
+		return validateGateStage(pipelineName, stage)
 	default:
 		// StageKindUnknown past the exactly-one-of guard = an agent stage (Agent
 		// set, Cmd empty) with an unrecognized action; validateAgentStage produces
@@ -281,6 +292,35 @@ func validateImplementStage(pipelineName string, stage Stage) error {
 	}
 	if stage.Prompt == "" {
 		return fmt.Errorf("pipeline %q stage %q agent stage requires a non-empty prompt", pipelineName, stage.ID)
+	}
+	return nil
+}
+
+// validateGateStage validates a JOBLESS GATE stage (#768 Phase 2): a recognized
+// predicate token (only pr_merged today) plus a Source that names an upstream stage
+// this gate depends on. Requiring Source to be one of the gate's own Needs is what
+// makes "an existing upstream needs stage" fall out for free — Validate separately
+// rejects any need that does not reference a known stage, so a source-in-needs also
+// references a known stage. A gate carries no prompt/action (those are agent-only), so
+// a stray one is a mis-declared stage (very likely a forgotten agent: key).
+func validateGateStage(pipelineName string, stage Stage) error {
+	if !containsToken(GatePredicateCandidates, stage.Gate) {
+		return fmt.Errorf("pipeline %q stage %q gate predicate %q is invalid; use one of: %s", pipelineName, stage.ID, stage.Gate, strings.Join(GatePredicateCandidates, ", "))
+	}
+	if stage.Prompt != "" {
+		return fmt.Errorf("pipeline %q stage %q sets prompt but is a gate stage; prompt is only for agent stages", pipelineName, stage.ID)
+	}
+	if stage.Action != "" {
+		return fmt.Errorf("pipeline %q stage %q sets action but is a gate stage; action is only for agent stages", pipelineName, stage.ID)
+	}
+	if stage.Source == "" {
+		return fmt.Errorf("pipeline %q stage %q gate stage requires a source (the upstream stage whose PR to watch)", pipelineName, stage.ID)
+	}
+	if stage.Source == stage.ID {
+		return fmt.Errorf("pipeline %q stage %q gate source cannot be the stage itself", pipelineName, stage.ID)
+	}
+	if !containsToken(stage.Needs, stage.Source) {
+		return fmt.Errorf("pipeline %q stage %q gate source %q must be one of the stage's needs (a gate watches an upstream stage it depends on)", pipelineName, stage.ID, stage.Source)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #768.

Builds on the stage-kind foundation (#770) — every change is an **append** at the three seams (`StageKind` case, `validateStageExecutor` dispatch, `stageSettleOutcome` case), so existing shell + #757 read-only agent stages are byte-identical.

## Phase 1 — mutating `implement` stage (Model A: fold on PR-opened)

A stage can run a named agent with `action: implement` to mutate the repo + open a PR, and the pipeline advances the moment the PR is opened.

```yaml
stages:
  - id: fix
    agent: fixer
    action: implement
    write: true              # required double-key (see safety)
    prompt: "Apply the change described in the ticket."
  - id: verify
    agent: reviewer
    action: review
    needs: [fix]
```

- **Writable worktree + deterministic branch reuse** — an implement stage takes the writable task-worktree path (not the #739 read-only path), keyed on an attempt-**independent** `TaskID`/`Branch = gitmoot/pipe-<run>-<stage>`, reusing `prepareLocalImplementDispatchRequest`'s fail-closed guards (active-job / live-process / dirty). A stage **retry** lands in the *same* branch/PR — never a duplicate.
- **Folds on PR-opened** — `implemented` success only when `payload.PullRequest > 0`, closing the race where the job settles before the PR is stamped. A legitimate **no-op** implement (no changes needed) folds succeeded once the engine's terminal `advance_skipped_no_pr` event exists (so it can't wedge).
- **Hard ceiling** — the pipeline **never merges** the PR; merge stays with humans/CI. Still a leaf (delegations/human_questions stripped).

## Phase 2 — composable `gate` stage (fold on PR-merged)

A **jobless** gate stage (no worker, no runtime session) that folds when an external predicate holds — the composable way to express wait-on-merge without making the implement stage itself block:

```yaml
  - id: wait
    gate: pr_merged
    source: fix              # the upstream implement stage whose PR to watch
    needs: [fix]
  - id: deploy
    cmd: "./deploy.sh"
    needs: [wait]
```

- Settles via the foundation seam (never calls `GetJob`); reads the `source` stage's PR, checks merged. **Non-blocking, ctx-bounded, fail-open** per the seam contract (a transient/unreachable GitHub → keep waiting, never hang the FOLD loop). A **closed-unmerged** PR parks the run `blocked` (not failed → retry can't re-arm); a timeout parks on the stage deadline.
- The PR identity is bound to the **trusted appended `(opened PR #n)` marker** (`strings.LastIndex`), so agent free-text can't spoof it. Spec-level validation rejects a gate whose `source` isn't a mutating implement stage.

## Safety model (three layers + ceiling)

1. **Spec double-key** — `action: implement` requires `write: true` (and vice-versa); no prompt-injection/typo can flip a read-only pipeline into a writing one.
2. **Schedule gate** — a `schedule:`d pipeline rejects mutating stages unless `allow_scheduled_writes: true` — an unattended nightly writing code is spelled twice.
3. **Agent policy backstop** — the bound agent's own capability/policy still applies.
4. **Ceiling** — never auto-merge.

## Review (3-lens adversarial, 6 findings)

5 applied, 1 skipped (a doc-only non-defect — the schedule-gate keying on the spec's own `schedule:` is the intended trust boundary). The majors: the no-op-implement wedge (→ `advance_skipped_no_pr` fold) and PR-identity spoofing (→ trusted marker + `LastIndex`).

## Verification

- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅ · `-race` on pipeline/cli/workflow ✅
- New E2Es (shell-runtime, deterministic): implement dispatch → writable worktree → fold-on-PR-opened + retry-reuses-branch; no-op-terminal fold; gate stays-in-flight → folds-on-merge; gate closed-unmerged parks blocked; PR-marker spoof rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
