### PR TITLE
feat(memory): recall command - one-shot ranked retrieval for sessions and humans

### DIFF
--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -28,6 +29,8 @@ func runMemory(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "list":
 		return runMemoryList(args[1:], stdout, stderr)
+	case "recall":
+		return runMemoryRecall(args[1:], stdout, stderr)
 	case "replay":
 		return runMemoryReplay(args[1:], stdout, stderr)
 	case "eval":
@@ -62,6 +65,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo R] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory recall \"<query>\" [--repo R] [--agent NAME] [--limit N] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory replay [--agent NAME] [--repo R] [--limit N] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory eval --fixtures FILE [--k N] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory vault export [--out DIR] [--agent NAME] [--json]")
@@ -74,6 +78,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot memory cluster rename <cluster-id> <label>")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  list          show stored memories (confirmed and/or pending observations)")
+	fmt.Fprintln(w, "  recall        retrieve ranked confirmed memories; defaults to all agent pools")
 	fmt.Fprintln(w, "  replay        offline A/B: render recent real jobs' prompts with vs without the")
 	fmt.Fprintln(w, "                learnings block and report the injection delta (tokens, entries)")
 	fmt.Fprintln(w, "  eval          recall/precision@K of retrieval over a labeled fixtures file")
@@ -84,6 +89,150 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  groom         deterministically propose stale-memory retirements, apply on confirmation")
 	fmt.Fprintln(w, "  clusters      list emergent memory clusters; recompute them via a propose/apply plan")
 	fmt.Fprintln(w, "  cluster       rename a cluster (owner label override)")
+}
+
+// ---- memory recall --------------------------------------------------------
+
+type memoryRecallOwner struct {
+	Kind    string `json:"kind"`
+	Ref     string `json:"ref"`
+	Version string `json:"version,omitempty"`
+}
+
+type memoryRecallEntry struct {
+	ID         int64             `json:"id"`
+	Owner      memoryRecallOwner `json:"owner"`
+	Repo       string            `json:"repo"`
+	Scope      string            `json:"scope"`
+	Key        string            `json:"key"`
+	Content    string            `json:"content"`
+	Provenance string            `json:"provenance"`
+	UpdatedAt  string            `json:"updated_at"`
+}
+
+func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory recall", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	agent := fs.String("agent", "", "filter to one agent owner pool; default searches all agent pools")
+	repo := fs.String("repo", "", "filter by repo (owner/repo); omitted searches all repos")
+	limit := fs.Int("limit", 15, "maximum number of matching memories to return")
+	jsonOut := fs.Bool("json", false, "print as JSON")
+	queryText, err := parseMemoryRecallArgs(fs, args)
+	if err != nil {
+		return memoryFlagExit(err)
+	}
+	if strings.TrimSpace(queryText) == "" {
+		fmt.Fprintln(stderr, "usage: gitmoot memory recall \"<query>\" [--repo owner/repo] [--agent NAME] [--limit N] [--json]")
+		return 2
+	}
+	query := workflow.BuildMemoryMatchQuery(queryText)
+
+	var rows []db.ConfirmedMemory
+	err = withReadOnlyStore(*home, func(store *db.Store) error {
+		var err error
+		ctx := context.Background()
+		if strings.TrimSpace(*agent) != "" {
+			owner := db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: strings.TrimSpace(*agent)}
+			if strings.TrimSpace(*repo) != "" {
+				rows, err = store.QueryConfirmedMemories(ctx, owner, strings.TrimSpace(*repo), query, *limit)
+			} else {
+				rows, err = store.QueryConfirmedMemoriesForOwnerAllRepos(ctx, owner, query, *limit)
+			}
+		} else {
+			rows, err = store.QueryConfirmedMemoriesForAllAgents(ctx, strings.TrimSpace(*repo), query, *limit)
+		}
+		return err
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory recall: %v\n", err)
+		return 1
+	}
+
+	if *jsonOut {
+		entries := make([]memoryRecallEntry, 0, len(rows))
+		for _, r := range rows {
+			entries = append(entries, memoryRecallJSONEntry(r))
+		}
+		if err := writeJSON(stdout, entries); err != nil {
+			fmt.Fprintf(stderr, "memory recall: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(rows) == 0 {
+		fmt.Fprintln(stdout, "no matches")
+		return 0
+	}
+	for _, r := range rows {
+		fmt.Fprintf(stdout, "%s repo=%s scope=%s owner=%s:%s\n",
+			r.Key, memoryRecallDisplayRepo(r), r.Scope, r.Owner.Kind, r.Owner.Ref)
+		fmt.Fprintln(stdout, memory.RenderBullet(memory.Entry{
+			Scope:     r.Scope,
+			Key:       r.Key,
+			Content:   r.Content,
+			UpdatedAt: r.UpdatedAt,
+		}))
+	}
+	return 0
+}
+
+func parseMemoryRecallArgs(fs *flag.FlagSet, args []string) (string, error) {
+	var flagArgs []string
+	var queryParts []string
+	flagsWithValues := map[string]bool{
+		"-home": true, "--home": true,
+		"-agent": true, "--agent": true,
+		"-repo": true, "--repo": true,
+		"-limit": true, "--limit": true,
+	}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			queryParts = append(queryParts, args[i+1:]...)
+			break
+		}
+		if strings.HasPrefix(arg, "-") && arg != "-" {
+			flagArgs = append(flagArgs, arg)
+			if strings.Contains(arg, "=") {
+				continue
+			}
+			if flagsWithValues[arg] && i+1 < len(args) {
+				i++
+				flagArgs = append(flagArgs, args[i])
+			}
+			continue
+		}
+		queryParts = append(queryParts, arg)
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(strings.Join(queryParts, " ")), nil
+}
+
+func memoryRecallJSONEntry(r db.ConfirmedMemory) memoryRecallEntry {
+	return memoryRecallEntry{
+		ID: r.ID,
+		Owner: memoryRecallOwner{
+			Kind:    r.Owner.Kind,
+			Ref:     r.Owner.Ref,
+			Version: r.Owner.Version,
+		},
+		Repo:       r.Repo,
+		Scope:      r.Scope,
+		Key:        r.Key,
+		Content:    r.Content,
+		Provenance: r.Provenance,
+		UpdatedAt:  r.UpdatedAt,
+	}
+}
+
+func memoryRecallDisplayRepo(r db.ConfirmedMemory) string {
+	if strings.TrimSpace(r.Repo) != "" {
+		return r.Repo
+	}
+	return "(general)"
 }
 
 // ---- memory list ----------------------------------------------------------

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -77,6 +77,146 @@ func TestMemoryListShowsBothTiers(t *testing.T) {
 	}
 }
 
+func TestMemoryRecallRanksAndFiltersConfirmedMemories(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	for _, cm := range []db.ConfirmedMemory{
+		{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: "lead"}, Repo: "acme/widget", Scope: "repo", Key: "widget-flake",
+			Content: "arm64 runner flake arm64 runner flake in widget tests", Provenance: "seed",
+		},
+		{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: "audit"}, Repo: "acme/widget", Scope: "repo", Key: "audit-runner",
+			Content: "arm64 runner policy differs for audit", Provenance: "seed",
+		},
+		{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: "lead"}, Repo: "acme/api", Scope: "repo", Key: "api-arm64",
+			Content: "arm64 api migrations need a canary", Provenance: "seed",
+		},
+		{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: "audit"}, Scope: "general", Key: "general-arm64",
+			Content: "arm64 runner facts apply across repositories", Provenance: "seed",
+		},
+		{
+			Owner: db.MemoryOwner{Kind: "role", Ref: "reviewer"}, Repo: "acme/widget", Scope: "repo", Key: "role-hidden",
+			Content: "arm64 runner flake from a role pool", Provenance: "seed",
+		},
+	} {
+		if _, err := store.UpsertConfirmedMemory(ctx, cm); err != nil {
+			t.Fatalf("seed %s: %v", cm.Key, err)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runMemory([]string{"recall", "arm64 runner flake", "--home", home, "--repo", "acme/widget", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall exit %d: %s", code, stderr.String())
+	}
+	var all []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &all); err != nil {
+		t.Fatalf("parse recall json: %v (%s)", err, stdout.String())
+	}
+	if len(all) < 3 {
+		t.Fatalf("expected all-agent recall to include both owners and general memory, got %+v", all)
+	}
+	if all[0].Key != "widget-flake" {
+		t.Fatalf("ranking top key = %q, want widget-flake; rows=%+v", all[0].Key, all)
+	}
+	owners := map[string]bool{}
+	for _, e := range all {
+		owners[e.Owner.Ref] = true
+		if e.Owner.Kind != "agent" {
+			t.Fatalf("recall without --agent must search only agent pools, got %+v", e.Owner)
+		}
+	}
+	if !owners["lead"] || !owners["audit"] {
+		t.Fatalf("expected recall without --agent to search all agent pools, got owners %+v", owners)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "--home", home, "--agent", "lead", "--repo", "acme/widget", "--json", "arm64 runner flake"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall --agent exit %d: %s", code, stderr.String())
+	}
+	var leadOnly []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &leadOnly); err != nil {
+		t.Fatalf("parse lead recall json: %v (%s)", err, stdout.String())
+	}
+	for _, e := range leadOnly {
+		if e.Owner.Ref != "lead" {
+			t.Fatalf("--agent lead returned owner %+v", e.Owner)
+		}
+	}
+	if len(leadOnly) == 0 || leadOnly[0].Owner.Kind != "agent" || leadOnly[0].Owner.Ref != "lead" || leadOnly[0].UpdatedAt == "" {
+		t.Fatalf("json shape missing expected owner/updated_at fields: %+v", leadOnly)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "--home", home, "--agent", "lead", "--json", "api migrations"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall no repo filter exit %d: %s", code, stderr.String())
+	}
+	var unfiltered []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &unfiltered); err != nil {
+		t.Fatalf("parse unfiltered recall json: %v (%s)", err, stdout.String())
+	}
+	if len(unfiltered) == 0 || unfiltered[0].Key != "api-arm64" || unfiltered[0].Repo != "acme/api" {
+		t.Fatalf("omitted --repo should search all repos, got %+v", unfiltered)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "--home", home, "--repo", "acme/api", "--json", "arm64 runner"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall --repo exit %d: %s", code, stderr.String())
+	}
+	var apiRows []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &apiRows); err != nil {
+		t.Fatalf("parse api recall json: %v (%s)", err, stdout.String())
+	}
+	keys := map[string]bool{}
+	for _, e := range apiRows {
+		keys[e.Key] = true
+		if e.Scope == "repo" && e.Repo != "acme/api" {
+			t.Fatalf("--repo acme/api returned repo-scoped row from %q: %+v", e.Repo, apiRows)
+		}
+	}
+	if !keys["api-arm64"] || !keys["general-arm64"] {
+		t.Fatalf("repo filter should include repo row and general row, got keys %+v", keys)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "--home", home, "--repo", "acme/widget", "arm64 runner flake"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall text exit %d: %s", code, stderr.String())
+	}
+	text := stdout.String()
+	if !strings.Contains(text, "widget-flake repo=acme/widget scope=repo owner=agent:lead") ||
+		!strings.Contains(text, "- [this repo] arm64 runner flake arm64 runner flake in widget tests") {
+		t.Fatalf("text recall did not render metadata plus injection bullet format:\n%s", text)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "--home", home, "zzznomatch"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall no-match exit %d: %s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "no matches" {
+		t.Fatalf("no-match stdout = %q, want no matches", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "--home", home, "--json", "zzznomatch"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall no-match json exit %d: %s", code, stderr.String())
+	}
+	var none []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &none); err != nil {
+		t.Fatalf("parse empty recall json: %v (%s)", err, stdout.String())
+	}
+	if len(none) != 0 {
+		t.Fatalf("empty recall JSON returned rows: %+v", none)
+	}
+}
+
 func TestMemoryReplayReportsInjectionDelta(t *testing.T) {
 	home, store := memoryTestHome(t)
 	ctx := context.Background()

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -618,6 +618,74 @@ LIMIT ?`,
 	return scanConfirmedMemories(rows)
 }
 
+// QueryConfirmedMemoriesForOwnerAllRepos is the recall variant for a single
+// agent pool when the caller does not provide a repo filter. It keeps the same
+// confirmed-only, active-row, FTS5/BM25 ranking as QueryConfirmedMemories, but
+// intentionally does not apply the repo/general visibility clause.
+func (s *Store) QueryConfirmedMemoriesForOwnerAllRepos(ctx context.Context, owner MemoryOwner, matchQuery string, limit int) ([]ConfirmedMemory, error) {
+	if strings.TrimSpace(matchQuery) == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 15
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.repo, c.scope, c.key, c.content,
+	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
+FROM confirmed_memories_fts f
+JOIN confirmed_memories c ON c.id = f.rowid
+WHERE f.confirmed_memories_fts MATCH ?
+	AND c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?
+	AND c.superseded_by IS NULL
+	AND c.retired_at = ''
+ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC
+LIMIT ?`,
+		matchQuery, owner.Kind, owner.Ref, owner.Version, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query confirmed memories for owner all repos: %w", err)
+	}
+	defer rows.Close()
+	return scanConfirmedMemories(rows)
+}
+
+// QueryConfirmedMemoriesForAllAgents is the read-only recall path for sessions
+// that are not running as a specific Gitmoot agent. It uses the same FTS5/BM25
+// ranking as QueryConfirmedMemories, but searches every agent owner pool instead
+// of one owner_ref. A non-empty repo applies the same repo/general visibility
+// filter as injection; an empty repo searches every repo and general facts. Role
+// pools remain excluded.
+func (s *Store) QueryConfirmedMemoriesForAllAgents(ctx context.Context, repo, matchQuery string, limit int) ([]ConfirmedMemory, error) {
+	if strings.TrimSpace(matchQuery) == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 15
+	}
+	query := `
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.repo, c.scope, c.key, c.content,
+	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
+FROM confirmed_memories_fts f
+JOIN confirmed_memories c ON c.id = f.rowid
+WHERE f.confirmed_memories_fts MATCH ?
+	AND c.owner_kind = 'agent'
+	AND c.superseded_by IS NULL
+	AND c.retired_at = ''
+ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC
+LIMIT ?`
+	args := []any{matchQuery}
+	if strings.TrimSpace(repo) != "" {
+		query = strings.Replace(query, "\n\tAND c.superseded_by IS NULL", "\n\tAND (c.scope = 'general' OR c.repo = ?)\n\tAND c.superseded_by IS NULL", 1)
+		args = append(args, strings.TrimSpace(repo))
+	}
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query confirmed memories for all agents: %w", err)
+	}
+	defer rows.Close()
+	return scanConfirmedMemories(rows)
+}
+
 // ListConfirmedMemoriesForVault returns every NON-superseded confirmed row for
 // the deterministic `memory vault export` (#737 P1), across all owner kinds,
 // repos, and scopes, ordered by id for a stable traversal. superseded_by is

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -195,7 +195,7 @@ func RenderBlock(entries []Entry, budgetTokens int) (string, int) {
 	used := baseTokens
 	injected := 0
 	for _, e := range entries {
-		line := "- " + scopeTag(e.Scope) + " " + strings.TrimSpace(e.Content)
+		line := RenderBullet(e)
 		cost := EstimateTokens(line)
 		if budgetTokens > 0 && injected > 0 && used+cost > budgetTokens {
 			break
@@ -212,6 +212,13 @@ func RenderBlock(entries []Entry, budgetTokens int) (string, int) {
 		return "", 0
 	}
 	return b.String(), injected
+}
+
+// RenderBullet renders one memory entry in the exact bullet format used inside
+// RenderBlock. CLI recall uses it so on-demand retrieval matches prompt
+// injection without duplicating the presentation rule.
+func RenderBullet(e Entry) string {
+	return "- " + scopeTag(e.Scope) + " " + strings.TrimSpace(e.Content)
 }
 
 // scopeTag renders the per-entry provenance tag used in the block.

--- a/internal/workflow/memory.go
+++ b/internal/workflow/memory.go
@@ -87,6 +87,14 @@ func ownerForJob(agent runtime.Agent, _ JobPayload) db.MemoryOwner {
 	return db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: agent.Name}
 }
 
+// BuildMemoryMatchQuery returns the sanitized FTS5 MATCH query used by the
+// memory read path. Callers outside workflow use this instead of reaching for
+// memory.SanitizeFTSQuery directly so recall surfaces and prompt injection stay
+// byte-for-byte aligned.
+func BuildMemoryMatchQuery(instructions string) string {
+	return memory.SanitizeFTSQuery(instructions)
+}
+
 // injectBlock is the READ path (job-prompt assembly). It builds a SANITIZED FTS
 // query from the job instructions (never raw text into MATCH), runs the tiered
 // confirmed-only retrieval, applies the token budget, and returns the rendered
@@ -114,7 +122,7 @@ func (c *MemoryController) retrieve(ctx context.Context, owner db.MemoryOwner, r
 	if c == nil || c.Store == nil {
 		return nil
 	}
-	query := memory.SanitizeFTSQuery(instructions)
+	query := BuildMemoryMatchQuery(instructions)
 	if query == "" {
 		return nil
 	}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1614,6 +1614,7 @@ Inspect and measure the store (all read-only):
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
@@ -1621,7 +1622,13 @@ gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
-replay` is an offline A/B: it re-renders recent real jobs' prompts with and
+recall` runs the same FTS5/BM25 confirmed-memory retrieval used for prompt
+injection and prints the matching facts in injection bullet format. Without
+`--agent`, recall searches all agent owner pools; pass `--agent NAME` to inspect
+one pool. Without `--repo`, recall searches every repo and general-scope facts.
+`--repo owner/repo` narrows repo-scoped facts to that repo while still including
+general-scope facts. `--json` returns raw rows for scripts. `memory replay` is an offline A/B:
+it re-renders recent real jobs' prompts with and
 without the learnings block and reports the injection delta (added tokens,
 entries injected) — it measures injection *mechanics*, not outcome quality
 (running real agents twice is a later-phase gate). `memory eval` computes

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -108,12 +108,18 @@ All of the following are read-only:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N]
 gitmoot memory eval --fixtures fixtures.json [--k N]
 ```
 
-`memory list` shows confirmed memories and pending observations. `memory replay`
-is an offline A/B: it re-renders recent real jobs' prompts with and without the
+`memory list` shows confirmed memories and pending observations. `memory recall`
+is an on-demand relevance search over confirmed memory. It uses the same
+FTS5/BM25 retrieval as prompt injection, searches all agent pools by default,
+and can narrow to one pool with `--agent NAME`. Without `--repo`, recall
+searches every repo and general-scope facts. `--repo owner/repo` narrows
+repo-scoped facts to that repo while still including general-scope facts.
+`memory replay` is an offline A/B: it re-renders recent real jobs' prompts with and without the
 learnings block and reports the injection delta (added tokens, entries injected)
 — it measures injection *mechanics*, not outcome quality. `memory eval` computes
 recall/precision@K of retrieval over a labeled fixtures file.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1339,6 +1339,7 @@ gate:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
@@ -1355,7 +1356,13 @@ gitmoot memory cluster rename <cluster-id> <label>
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
-replay` re-renders recent real jobs' prompts with and without the injected
+recall` runs the same FTS5/BM25 confirmed-memory retrieval used for prompt
+injection and prints the matching facts in injection bullet format. Without
+`--agent`, recall searches all agent owner pools; pass `--agent NAME` to inspect
+one pool. Without `--repo`, recall searches every repo and general-scope facts.
+`--repo owner/repo` narrows repo-scoped facts to that repo while still including
+general-scope facts. `--json` returns raw rows for scripts. `memory replay`
+re-renders recent real jobs' prompts with and without the injected
 learnings block and reports the token/entry delta. `memory eval` computes
 recall/precision@K of retrieval over a labeled `{agent, repo, instructions,
 expected_keys}` fixtures file.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9766,6 +9766,7 @@ Inspect and measure the store (all read-only):
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
@@ -9773,7 +9774,13 @@ gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
-replay` is an offline A/B: it re-renders recent real jobs' prompts with and
+recall` runs the same FTS5/BM25 confirmed-memory retrieval used for prompt
+injection and prints the matching facts in injection bullet format. Without
+`--agent`, recall searches all agent owner pools; pass `--agent NAME` to inspect
+one pool. Without `--repo`, recall searches every repo and general-scope facts.
+`--repo owner/repo` narrows repo-scoped facts to that repo while still including
+general-scope facts. `--json` returns raw rows for scripts. `memory replay` is an offline A/B:
+it re-renders recent real jobs' prompts with and
 without the learnings block and reports the injection delta (added tokens,
 entries injected) — it measures injection *mechanics*, not outcome quality
 (running real agents twice is a later-phase gate). `memory eval` computes

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -32,7 +32,7 @@ full expanded context.
 
 - [Local-First Coordination](https://gitmoot.io/docs/concepts/local-first-coordination): Why state lives in local SQLite and GitHub stays the audit surface.
 - [Agents, Agent Templates, Jobs, And Locks](https://gitmoot.io/docs/concepts/agents-templates-jobs-locks): The core object model — agent identities, template snapshots, job lifecycle, and the three lock kinds.
-- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, and the memory CLI.
+- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, and the memory CLI, including `memory recall "<query>"` for read-only FTS5/BM25 lookup across all agent pools by default.
 
 ## Dashboard
 
@@ -41,7 +41,7 @@ full expanded context.
 
 ## References
 
-- [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, pipelines, jobs (incl. resumable `job gates`/`gates clear` for blocked `needs` with auto-resume on last clear, and session jobs `job open/close/record`), review head-SHA re-sync, bug reports, locks, goals, interactive prompts, and SkillOpt.
+- [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, pipelines, jobs (incl. resumable `job gates`/`gates clear` for blocked `needs` with auto-resume on last clear, and session jobs `job open/close/record`), review head-SHA re-sync, memory recall, bug reports, locks, goals, interactive prompts, and SkillOpt.
 - [Runtime Adapters](https://gitmoot.io/docs/reference/runtime-adapters): Codex, Claude Code, Kimi Code, legacy kimi-cli, shell, and future runtimes; the config-driven metadata registry (`gitmoot runtime list`, `[runtimes.<name>]` overrides).
 - [Result Contract](https://gitmoot.io/docs/reference/result-contract): gitmoot_result shape, the delegations DAG (Orchestration), continuation, and termination bounds.
 - [Event Stream](https://gitmoot.io/docs/reference/event-stream): The `[events]` webhook contract — job.finished/failed/blocked/needs_attention/deferred and candidate.* events, schema_version 1, best-effort delivery.


### PR DESCRIPTION
Closes #778.

Adds `gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N] [--json]": read-only FTS5+bm25 retrieval using the same machinery as injection, all-pools by default with --agent narrowing, RenderBlock-parity text output or raw JSON. Zero writes, zero locks.

Implemented by a gitmoot-orchestrated codex (gpt-5.5) implement job; coordinated and reviewed by the lead session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)