### PR TITLE
feat(memory): auto cross-link confirmed memories + links backfill

### DIFF
--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -43,6 +43,8 @@ func runMemory(args []string, stdout, stderr io.Writer) int {
 		return runMemoryObservations(args[1:], stdout, stderr)
 	case "confirm":
 		return runMemoryConfirm(args[1:], stdout, stderr)
+	case "links":
+		return runMemoryLinks(args[1:], stdout, stderr)
 	case "groom":
 		return runMemoryGroom(args[1:], stdout, stderr)
 	case "clusters":
@@ -72,6 +74,8 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot memory ingest <path|dir> --agent NAME [--repo R] [--tier repo|general] [--dry-run] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory links backfill [--dry-run] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory links list <id> [--json]")
 	fmt.Fprintln(w, "  gitmoot memory groom --propose [--out PLAN.json] [--json] | --yes --plan PLAN.json [--json]")
 	fmt.Fprintln(w, "  gitmoot memory clusters [--json]")
 	fmt.Fprintln(w, "  gitmoot memory clusters recompute --propose [--out PLAN.json] [--json] | --apply [--plan PLAN.json] [--json]")
@@ -86,6 +90,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  ingest        stage markdown as trust_mark=low pending observations (PreFilter-gated)")
 	fmt.Fprintln(w, "  observations  list pending observations, flagging which keys are already confirmed")
 	fmt.Fprintln(w, "  confirm       human-gated promotion of pending observations into confirmed memory")
+	fmt.Fprintln(w, "  links         inspect persisted memory links; backfill links for existing facts")
 	fmt.Fprintln(w, "  groom         deterministically propose stale-memory retirements, apply on confirmation")
 	fmt.Fprintln(w, "  clusters      list emergent memory clusters; recompute them via a propose/apply plan")
 	fmt.Fprintln(w, "  cluster       rename a cluster (owner label override)")

--- a/internal/cli/memory_links.go
+++ b/internal/cli/memory_links.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+type memoryLinkEntry struct {
+	SrcID     int64   `json:"src_id"`
+	DstID     int64   `json:"dst_id"`
+	DstKey    string  `json:"dst_key"`
+	Score     float64 `json:"score"`
+	Origin    string  `json:"origin"`
+	CreatedAt string  `json:"created_at,omitempty"`
+}
+
+type memoryLinksBackfillResult struct {
+	DryRun          bool              `json:"dry_run"`
+	Scanned         int               `json:"scanned"`
+	Created         int               `json:"created"`
+	Skipped         int               `json:"skipped"`
+	SkippedExisting int               `json:"skipped_existing"`
+	SkippedWeak     int               `json:"skipped_weak"`
+	Links           []memoryLinkEntry `json:"links,omitempty"`
+}
+
+type memoryLinksListResult struct {
+	ID    int64             `json:"id"`
+	Links []memoryLinkEntry `json:"links"`
+}
+
+func runMemoryLinks(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printMemoryLinksUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "backfill":
+		return runMemoryLinksBackfill(args[1:], stdout, stderr)
+	case "list":
+		return runMemoryLinksList(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown memory links command %q\n\n", args[0])
+		printMemoryLinksUsage(stderr)
+		return 2
+	}
+}
+
+func printMemoryLinksUsage(w io.Writer) {
+	fmt.Fprintln(w, "Inspect and backfill persisted memory links.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot memory links backfill [--dry-run] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory links list <id> [--json]")
+}
+
+func runMemoryLinksBackfill(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory links backfill", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	dryRun := fs.Bool("dry-run", false, "print links that would be created without writing")
+	jsonOut := fs.Bool("json", false, "print as JSON")
+	if err := parseMemoryFlags(fs, args); err != nil {
+		return memoryFlagExit(err)
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "memory links backfill: no positional arguments are accepted")
+		return 2
+	}
+
+	result := memoryLinksBackfillResult{DryRun: *dryRun}
+	err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		rows, err := store.ListConfirmedMemoriesForVault(ctx, "")
+		if err != nil {
+			return err
+		}
+		result.Scanned = len(rows)
+		for _, r := range rows {
+			enriched, err := store.EnrichConfirmedMemoryLinks(ctx, r.ID, *dryRun)
+			if err != nil {
+				return fmt.Errorf("link memory %d: %w", r.ID, err)
+			}
+			result.Created += len(enriched.Created)
+			result.SkippedExisting += enriched.SkippedExisting
+			result.SkippedWeak += enriched.SkippedWeak
+			for _, l := range enriched.Created {
+				result.Links = append(result.Links, memoryLinkEntryFromDB(l))
+			}
+		}
+		result.Skipped = result.SkippedExisting + result.SkippedWeak
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory links backfill: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "memory links backfill: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	action := "created"
+	if *dryRun {
+		action = "would create"
+	}
+	fmt.Fprintf(stdout, "scanned %d confirmed memory(s); %s %d link(s), skipped %d (%d existing, %d weak)\n",
+		result.Scanned, action, result.Created, result.Skipped, result.SkippedExisting, result.SkippedWeak)
+	for _, l := range result.Links {
+		fmt.Fprintf(stdout, "  %d -> %d (%s) score %.6f\n", l.SrcID, l.DstID, l.DstKey, l.Score)
+	}
+	return 0
+}
+
+func runMemoryLinksList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory links list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print as JSON")
+	idArg := ""
+	flagArgs := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		idArg = args[0]
+		flagArgs = args[1:]
+	}
+	if err := parseMemoryFlags(fs, flagArgs); err != nil {
+		return memoryFlagExit(err)
+	}
+	if idArg == "" && fs.NArg() == 1 {
+		idArg = fs.Arg(0)
+	} else if idArg != "" && fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: gitmoot memory links list <id> [--json]")
+		return 2
+	}
+	if idArg == "" {
+		fmt.Fprintln(stderr, "usage: gitmoot memory links list <id> [--json]")
+		return 2
+	}
+	id, err := strconv.ParseInt(strings.TrimSpace(idArg), 10, 64)
+	if err != nil || id <= 0 {
+		fmt.Fprintf(stderr, "memory links list: invalid memory id %q\n", idArg)
+		return 2
+	}
+	result := memoryLinksListResult{ID: id}
+	err = withReadOnlyStore(*home, func(store *db.Store) error {
+		links, err := store.ListMemoryLinks(context.Background(), id)
+		if err != nil {
+			return err
+		}
+		result.Links = make([]memoryLinkEntry, 0, len(links))
+		for _, l := range links {
+			result.Links = append(result.Links, memoryLinkEntryFromDB(l))
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory links list: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "memory links list: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(result.Links) == 0 {
+		fmt.Fprintf(stdout, "memory %d has no persisted links\n", id)
+		return 0
+	}
+	for _, l := range result.Links {
+		fmt.Fprintf(stdout, "%d -> %d %-24s score %.6f origin %s\n", l.SrcID, l.DstID, l.DstKey, l.Score, l.Origin)
+	}
+	return 0
+}
+
+func memoryLinkEntryFromDB(l db.MemoryLink) memoryLinkEntry {
+	return memoryLinkEntry{
+		SrcID:     l.SrcID,
+		DstID:     l.DstID,
+		DstKey:    l.DstKey,
+		Score:     l.Score,
+		Origin:    l.Origin,
+		CreatedAt: l.CreatedAt,
+	}
+}

--- a/internal/cli/memory_links_test.go
+++ b/internal/cli/memory_links_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestMemoryLinksBackfillDryRunAndIdempotent(t *testing.T) {
+	home, store := memoryTestHome(t)
+	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
+	ids := []int64{
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "alpha", "aurora quartz vector hnsw planner spill runbook"),
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "beta", "aurora quartz vector hnsw planner calibration checklist"),
+		seedConfirmed(t, store, owner, "acme/widget", "repo", "gamma", "aurora quartz vector hnsw planner spill calibration"),
+	}
+	clearMemoryLinks(t, home)
+	if got := memoryLinksForIDs(t, store, ids); got != 0 {
+		t.Fatalf("test setup failed: links remain after clear: %d", got)
+	}
+
+	code, out, errOut := runMemoryCapture(t, "links", "backfill", "--home", home, "--dry-run", "--json")
+	if code != 0 {
+		t.Fatalf("dry-run backfill exit %d: %s", code, errOut)
+	}
+	var dry memoryLinksBackfillResult
+	if err := json.Unmarshal([]byte(out), &dry); err != nil {
+		t.Fatalf("parse dry-run: %v (%s)", err, out)
+	}
+	if !dry.DryRun || dry.Created == 0 || len(dry.Links) != dry.Created {
+		t.Fatalf("dry-run summary wrong: %+v", dry)
+	}
+	if got := memoryLinksForIDs(t, store, ids); got != 0 {
+		t.Fatalf("dry-run wrote %d link(s)", got)
+	}
+
+	code, out, errOut = runMemoryCapture(t, "links", "backfill", "--home", home, "--json")
+	if code != 0 {
+		t.Fatalf("backfill exit %d: %s", code, errOut)
+	}
+	var first memoryLinksBackfillResult
+	if err := json.Unmarshal([]byte(out), &first); err != nil {
+		t.Fatalf("parse first backfill: %v (%s)", err, out)
+	}
+	if first.Created == 0 {
+		t.Fatalf("first backfill created no links: %+v", first)
+	}
+	if got := memoryLinksForIDs(t, store, ids); got != first.Created {
+		t.Fatalf("stored links = %d, want created count %d", got, first.Created)
+	}
+
+	code, out, errOut = runMemoryCapture(t, "links", "backfill", "--home", home, "--json")
+	if code != 0 {
+		t.Fatalf("second backfill exit %d: %s", code, errOut)
+	}
+	var second memoryLinksBackfillResult
+	if err := json.Unmarshal([]byte(out), &second); err != nil {
+		t.Fatalf("parse second backfill: %v (%s)", err, out)
+	}
+	if second.Created != 0 || second.SkippedExisting == 0 {
+		t.Fatalf("second backfill should be idempotent, got %+v", second)
+	}
+
+	code, out, errOut = runMemoryCapture(t, "links", "list", strconv.FormatInt(ids[0], 10), "--home", home, "--json")
+	if code != 0 {
+		t.Fatalf("links list exit %d: %s", code, errOut)
+	}
+	var listed memoryLinksListResult
+	if err := json.Unmarshal([]byte(out), &listed); err != nil {
+		t.Fatalf("parse links list: %v (%s)", err, out)
+	}
+	if listed.ID != ids[0] || len(listed.Links) == 0 {
+		t.Fatalf("links list missing persisted links: %+v", listed)
+	}
+	for _, l := range listed.Links {
+		if l.SrcID != ids[0] || l.DstID == ids[0] || l.Score <= 0 {
+			t.Fatalf("bad listed link: %+v", l)
+		}
+	}
+}
+
+func clearMemoryLinks(t *testing.T, home string) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(context.Background(), `DELETE FROM memory_links`); err != nil {
+		t.Fatalf("clear memory links: %v", err)
+	}
+}
+
+func memoryLinksForIDs(t *testing.T, store *db.Store, ids []int64) int {
+	t.Helper()
+	total := 0
+	for _, id := range ids {
+		links, err := store.ListMemoryLinks(context.Background(), id)
+		if err != nil {
+			t.Fatalf("list links %d: %v", id, err)
+		}
+		total += len(links)
+	}
+	return total
+}

--- a/internal/cli/memory_vault.go
+++ b/internal/cli/memory_vault.go
@@ -182,7 +182,7 @@ func buildVault(ctx context.Context, store *db.Store, agent string) ([]vaultNote
 
 	for _, r := range rows {
 		m := toVaultMemory(r)
-		links, err := vaultLinksFor(ctx, store, r)
+		links, err := vaultLinksForExport(ctx, store, r)
 		if err != nil {
 			return nil, nil, "", nil, err
 		}
@@ -221,6 +221,43 @@ func buildVault(ctx context.Context, store *db.Store, agent string) ([]vaultNote
 	}
 
 	return notes, indexes, snapshotHash, owners, nil
+}
+
+// vaultLinksForExport merges the existing derived bm25 links with persisted
+// memory_links rows. The table links are a side-table view of confirmed memory,
+// so they appear in the derived vault without changing the source note content.
+// Duplicates collapse by target id; RenderVaultNote applies the final id sort.
+func vaultLinksForExport(ctx context.Context, store *db.Store, src db.ConfirmedMemory) ([]memory.VaultLink, error) {
+	derived, err := vaultLinksFor(ctx, store, src)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[int64]memory.VaultLink, len(derived))
+	for _, l := range derived {
+		byID[l.TargetID] = l
+	}
+	persisted, err := store.ListMemoryLinks(ctx, src.ID)
+	if err != nil {
+		return nil, err
+	}
+	for _, l := range persisted {
+		if l.DstID == src.ID {
+			continue
+		}
+		if _, seen := byID[l.DstID]; seen {
+			continue
+		}
+		byID[l.DstID] = memory.VaultLink{
+			TargetID: l.DstID,
+			Stem:     memory.VaultStem(l.DstID, l.DstKey),
+			Key:      l.DstKey,
+		}
+	}
+	out := make([]memory.VaultLink, 0, len(byID))
+	for _, l := range byID {
+		out = append(out, l)
+	}
+	return out, nil
 }
 
 // vaultLinksFor computes the deterministic top-K co-occurrence links for one

--- a/internal/cli/memory_vault_test.go
+++ b/internal/cli/memory_vault_test.go
@@ -206,6 +206,42 @@ func TestVaultExportDeterministicLinksUnderBM25Ties(t *testing.T) {
 	}
 }
 
+func TestVaultExportIncludesPersistedMemoryLinks(t *testing.T) {
+	home, store := memoryTestHome(t)
+	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
+	srcID := seedConfirmed(t, store, owner, "acme/widget", "repo", "source", "alpha-only operational note")
+	dstID := seedConfirmed(t, store, owner, "acme/widget", "repo", "target", "zulu-only release note")
+	clearMemoryLinks(t, home)
+
+	raw, err := sql.Open("sqlite", config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open raw: %v", err)
+	}
+	if _, err := raw.ExecContext(context.Background(), `
+INSERT INTO memory_links (src_id, dst_id, score, origin, created_at)
+VALUES (?, ?, 0.42, 'auto', '2026-07-09T00:00:00Z')`, srcID, dstID); err != nil {
+		t.Fatalf("insert persisted link: %v", err)
+	}
+	raw.Close()
+
+	out := filepath.Join(t.TempDir(), "v")
+	exportVault(t, home, out, "")
+	tree := readVaultTree(t, out)
+	var source string
+	for name, body := range tree {
+		if strings.HasSuffix(name, "-source.md") {
+			source = string(body)
+		}
+	}
+	if source == "" {
+		t.Fatal("source note not found")
+	}
+	want := "[[" + memory.VaultStem(dstID, "target") + "|target]]"
+	if !strings.Contains(source, want) {
+		t.Fatalf("vault note missing persisted link %s:\n%s", want, source)
+	}
+}
+
 func TestVaultExportEmptyDB(t *testing.T) {
 	home, _ := memoryTestHome(t)
 	out := filepath.Join(t.TempDir(), "v")

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -81,8 +81,16 @@ type MemoryLinkEnrichment struct {
 }
 
 const (
-	memoryAutoLinkK        = 3
-	memoryAutoLinkMinScore = 0.000002
+	memoryAutoLinkK = 3
+	// memoryAutoLinkMinScore is a tiny absolute floor guarding degenerate
+	// near-zero bm25 matches. The REAL weak-link guard is relative:
+	// memoryAutoLinkMinRelative drops any candidate scoring below that
+	// fraction of the best candidate for the same source fact, which stays
+	// meaningful as the corpus grows (absolute bm25 magnitudes are
+	// corpus-dependent; a live probe on 95 facts showed scores 1.25-45.6,
+	// so any fixed absolute cutoff is either dead code or brittle).
+	memoryAutoLinkMinScore    = 0.000002
+	memoryAutoLinkMinRelative = 0.30
 )
 
 // nullableRepo maps an empty repo string to SQL NULL (a general-scope fact) and
@@ -420,10 +428,16 @@ func enrichConfirmedMemoryLinksTx(ctx context.Context, tx *sql.Tx, srcID int64, 
 		return MemoryLinkEnrichment{}, err
 	}
 	now := nowRFC3339()
+	// Candidates arrive best-first; the top score anchors the relative
+	// weak-link cutoff for this source fact.
+	var topScore float64
+	if len(candidates) > 0 {
+		topScore = candidates[0].Score
+	}
 	for _, c := range candidates {
 		c.SrcID = srcID
 		c.CreatedAt = now
-		if c.Score < memoryAutoLinkMinScore {
+		if c.Score < memoryAutoLinkMinScore || c.Score < topScore*memoryAutoLinkMinRelative {
 			result.SkippedWeak++
 			continue
 		}

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -56,6 +57,33 @@ type ConfirmedMemory struct {
 	UpdatedAt        string
 	SupersededBy     int64 // 0 == not superseded
 }
+
+// MemoryLink is one persisted, derived edge from a source confirmed memory to a
+// related target confirmed memory. It never mutates fact content; vault export and
+// inspection commands opt into this side table explicitly.
+type MemoryLink struct {
+	SrcID     int64
+	DstID     int64
+	DstKey    string
+	Score     float64
+	Origin    string
+	CreatedAt string
+}
+
+// MemoryLinkEnrichment reports what the auto-link pass created or skipped for one
+// source memory. Created contains rows that were written, or rows that WOULD be
+// written when the caller requested a dry run.
+type MemoryLinkEnrichment struct {
+	SrcID           int64
+	Created         []MemoryLink
+	SkippedExisting int
+	SkippedWeak     int
+}
+
+const (
+	memoryAutoLinkK        = 3
+	memoryAutoLinkMinScore = 0.000002
+)
 
 // nullableRepo maps an empty repo string to SQL NULL (a general-scope fact) and
 // a non-empty repo to itself, matching the NULLABLE repo column semantics the
@@ -319,10 +347,208 @@ WHERE id = ?`,
 	if _, err := tx.ExecContext(ctx, `INSERT INTO confirmed_memories_fts(rowid, content, key) VALUES (?, ?, ?)`, id, cm.Content, cm.Key); err != nil {
 		return 0, fmt.Errorf("sync confirmed memory fts (insert): %w", err)
 	}
+	if _, err := enrichConfirmedMemoryLinksTx(ctx, tx, id, false); err != nil {
+		return 0, fmt.Errorf("auto-link confirmed memory: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return 0, err
 	}
 	return id, nil
+}
+
+// EnrichConfirmedMemoryLinks computes the deterministic top-K similarity links
+// for one active confirmed memory and inserts any missing edges. When dryRun is
+// true it returns the rows that would be inserted without writing anything.
+func (s *Store) EnrichConfirmedMemoryLinks(ctx context.Context, srcID int64, dryRun bool) (MemoryLinkEnrichment, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return MemoryLinkEnrichment{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := enrichConfirmedMemoryLinksTx(ctx, tx, srcID, dryRun)
+	if err != nil {
+		return MemoryLinkEnrichment{}, err
+	}
+	if dryRun {
+		return result, nil
+	}
+	if err := tx.Commit(); err != nil {
+		return MemoryLinkEnrichment{}, err
+	}
+	return result, nil
+}
+
+// ListMemoryLinks returns active target links for one source memory, ordered by
+// target id for deterministic CLI and vault rendering. Retired/superseded targets
+// are hidden so stale side-table rows never reappear in derived views.
+func (s *Store) ListMemoryLinks(ctx context.Context, srcID int64) ([]MemoryLink, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT ml.src_id, ml.dst_id, d.key, ml.score, ml.origin, ml.created_at
+FROM memory_links ml
+JOIN confirmed_memories d ON d.id = ml.dst_id
+WHERE ml.src_id = ?
+	AND d.superseded_by IS NULL
+	AND d.retired_at = ''
+ORDER BY ml.dst_id`, srcID)
+	if err != nil {
+		return nil, fmt.Errorf("list memory links: %w", err)
+	}
+	defer rows.Close()
+	var out []MemoryLink
+	for rows.Next() {
+		var l MemoryLink
+		if err := rows.Scan(&l.SrcID, &l.DstID, &l.DstKey, &l.Score, &l.Origin, &l.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+func enrichConfirmedMemoryLinksTx(ctx context.Context, tx *sql.Tx, srcID int64, dryRun bool) (MemoryLinkEnrichment, error) {
+	result := MemoryLinkEnrichment{SrcID: srcID}
+	src, ok, err := confirmedMemoryForLinkingTx(ctx, tx, srcID)
+	if err != nil || !ok {
+		return result, err
+	}
+	matchQuery := memoryLinkMatchQuery(src.Content)
+	if strings.TrimSpace(matchQuery) == "" {
+		return result, nil
+	}
+	candidates, err := queryMemoryLinkCandidatesTx(ctx, tx, src, matchQuery, memoryAutoLinkK)
+	if err != nil {
+		return MemoryLinkEnrichment{}, err
+	}
+	now := nowRFC3339()
+	for _, c := range candidates {
+		c.SrcID = srcID
+		c.CreatedAt = now
+		if c.Score < memoryAutoLinkMinScore {
+			result.SkippedWeak++
+			continue
+		}
+		if c.Origin == "existing" {
+			result.SkippedExisting++
+			continue
+		}
+		c.Origin = "auto"
+		if dryRun {
+			result.Created = append(result.Created, c)
+			continue
+		}
+		res, err := tx.ExecContext(ctx, `
+INSERT OR IGNORE INTO memory_links (src_id, dst_id, score, origin, created_at)
+VALUES (?, ?, ?, 'auto', ?)`, srcID, c.DstID, c.Score, now)
+		if err != nil {
+			return MemoryLinkEnrichment{}, fmt.Errorf("insert memory link %d -> %d: %w", srcID, c.DstID, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return MemoryLinkEnrichment{}, err
+		}
+		if affected == 0 {
+			result.SkippedExisting++
+			continue
+		}
+		result.Created = append(result.Created, c)
+	}
+	return result, nil
+}
+
+func confirmedMemoryForLinkingTx(ctx context.Context, tx *sql.Tx, id int64) (ConfirmedMemory, bool, error) {
+	var c ConfirmedMemory
+	var repoNull sql.NullString
+	err := tx.QueryRowContext(ctx, `
+SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
+	provenance, source_job, first_confirmed_at, updated_at
+FROM confirmed_memories
+WHERE id = ? AND superseded_by IS NULL AND retired_at = ''`, id).Scan(
+		&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &repoNull,
+		&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return ConfirmedMemory{}, false, nil
+	}
+	if err != nil {
+		return ConfirmedMemory{}, false, fmt.Errorf("read confirmed memory %d for linking: %w", id, err)
+	}
+	c.Repo = repoNull.String
+	return c, true, nil
+}
+
+func queryMemoryLinkCandidatesTx(ctx context.Context, tx *sql.Tx, src ConfirmedMemory, matchQuery string, limit int) ([]MemoryLink, error) {
+	if limit <= 0 {
+		limit = memoryAutoLinkK
+	}
+	rows, err := tx.QueryContext(ctx, `
+SELECT c.id, c.key, -bm25(f.confirmed_memories_fts) AS score,
+	EXISTS(SELECT 1 FROM memory_links ml WHERE ml.src_id = ? AND ml.dst_id = c.id) AS already_linked
+FROM confirmed_memories_fts f
+JOIN confirmed_memories c ON c.id = f.rowid
+WHERE f.confirmed_memories_fts MATCH ?
+	AND c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?
+	AND (c.scope = 'general' OR c.repo = ?)
+	AND c.superseded_by IS NULL
+	AND c.retired_at = ''
+	AND c.id <> ?
+ORDER BY bm25(f.confirmed_memories_fts), c.id
+LIMIT ?`,
+		src.ID, matchQuery, src.Owner.Kind, src.Owner.Ref, src.Owner.Version, src.Repo, src.ID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query memory link candidates: %w", err)
+	}
+	defer rows.Close()
+	var out []MemoryLink
+	for rows.Next() {
+		var l MemoryLink
+		var already int
+		if err := rows.Scan(&l.DstID, &l.DstKey, &l.Score, &already); err != nil {
+			return nil, err
+		}
+		if already != 0 {
+			l.Origin = "existing"
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+var memoryLinkWordRun = regexp.MustCompile(`[A-Za-z0-9]+`)
+
+var memoryLinkFTSKeywords = map[string]struct{}{
+	"and": {}, "or": {}, "not": {}, "near": {},
+}
+
+var memoryLinkStopwords = map[string]struct{}{
+	"the": {}, "and": {}, "for": {}, "with": {}, "that": {}, "this": {},
+	"you": {}, "your": {}, "are": {}, "was": {}, "will": {}, "have": {},
+	"from": {}, "into": {}, "should": {}, "would": {}, "could": {},
+}
+
+func memoryLinkMatchQuery(content string) string {
+	const maxTokens = 24
+	seen := make(map[string]struct{}, maxTokens)
+	tokens := make([]string, 0, maxTokens)
+	for _, raw := range memoryLinkWordRun.FindAllString(content, -1) {
+		tok := strings.ToLower(raw)
+		if len(tok) < 3 {
+			continue
+		}
+		if _, ok := memoryLinkFTSKeywords[tok]; ok {
+			continue
+		}
+		if _, ok := memoryLinkStopwords[tok]; ok {
+			continue
+		}
+		if _, dup := seen[tok]; dup {
+			continue
+		}
+		seen[tok] = struct{}{}
+		tokens = append(tokens, `"`+tok+`"`)
+		if len(tokens) >= maxTokens {
+			break
+		}
+	}
+	return strings.Join(tokens, " OR ")
 }
 
 // UpdateConfirmedMemoryByID applies an owner-curated content edit to ONE confirmed

--- a/internal/db/memory_store_test.go
+++ b/internal/db/memory_store_test.go
@@ -27,7 +27,7 @@ func agentOwner(ref string) MemoryOwner {
 func TestMemoryMigrationCreatesTables(t *testing.T) {
 	ctx := context.Background()
 	store := openMemTestStore(t)
-	for _, name := range []string{"memory_observations", "confirmed_memories", "confirmed_memories_fts"} {
+	for _, name := range []string{"memory_observations", "confirmed_memories", "confirmed_memories_fts", "memory_links"} {
 		exists, err := store.tableExists(ctx, name)
 		if err != nil {
 			t.Fatalf("tableExists(%q): %v", name, err)
@@ -68,6 +68,58 @@ func TestConfirmedMemoryFTSRoundTrip(t *testing.T) {
 	}
 	if got[0].Key != "ci-flake" {
 		t.Fatalf("want key ci-flake, got %q", got[0].Key)
+	}
+}
+
+func TestConfirmedMemoryAutoLinksSimilarExistingFacts(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+
+	nearOne := mustUpsert(t, store, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "near-one", Content: "aurora quartz vector hnsw planner spill runbook",
+	})
+	nearTwo := mustUpsert(t, store, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "near-two", Content: "aurora quartz vector hnsw planner calibration checklist",
+	})
+	weak := mustUpsert(t, store, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "weak", Content: "aurora deployment handbook unrelated release notes",
+	})
+	src := mustUpsert(t, store, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "source", Content: "aurora quartz vector hnsw planner spill calibration",
+	})
+
+	links, err := store.ListMemoryLinks(ctx, src)
+	if err != nil {
+		t.Fatalf("list links: %v", err)
+	}
+	if len(links) != 2 {
+		t.Fatalf("want exactly two strong links, got %+v", links)
+	}
+	want := map[int64]bool{nearOne: true, nearTwo: true}
+	for _, l := range links {
+		if l.SrcID != src {
+			t.Fatalf("link source = %d, want %d", l.SrcID, src)
+		}
+		if l.DstID == src {
+			t.Fatalf("self-link created: %+v", l)
+		}
+		if l.DstID == weak {
+			t.Fatalf("weak one-token match crossed threshold: %+v", l)
+		}
+		if !want[l.DstID] {
+			t.Fatalf("unexpected target link: %+v", l)
+		}
+		if l.Score < memoryAutoLinkMinScore {
+			t.Fatalf("score %.12f below threshold %.12f", l.Score, memoryAutoLinkMinScore)
+		}
+		if l.Origin != "auto" {
+			t.Fatalf("origin = %q, want auto", l.Origin)
+		}
 	}
 }
 
@@ -634,7 +686,7 @@ func TestDistillWitnessExcludedFromListAndConfirm(t *testing.T) {
 
 	witnessID, err := store.InsertMemoryObservation(ctx, MemoryObservation{
 		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "distill-test:testx",
-		Content: "A failure signal was observed once in this repository and is held pending recurrence before it is recorded.",
+		Content:    "A failure signal was observed once in this repository and is held pending recurrence before it is recorded.",
 		Provenance: MemoryDistillWitnessProvenancePrefix + "job-1", TrustMark: "low",
 	})
 	if err != nil {
@@ -642,7 +694,7 @@ func TestDistillWitnessExcludedFromListAndConfirm(t *testing.T) {
 	}
 	stagedID, err := store.InsertMemoryObservation(ctx, MemoryObservation{
 		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "distill-test:testy",
-		Content: "Test testy FAILED in a implement job in this repository.",
+		Content:    "Test testy FAILED in a implement job in this repository.",
 		Provenance: "distill:job-2", TrustMark: "low",
 	})
 	if err != nil {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -8285,7 +8285,7 @@ CREATE TABLE memory_cluster_members (
 	memory_id INTEGER PRIMARY KEY,
 	cluster_id INTEGER NOT NULL
 );
-	CREATE INDEX idx_memory_cluster_members_cluster ON memory_cluster_members(cluster_id);
+CREATE INDEX idx_memory_cluster_members_cluster ON memory_cluster_members(cluster_id);
 	`,
 	// #784 auto cross-link confirmed memories. Links are stored in a dedicated side
 	// table rather than mutating owner-authored fact content: the confirmed memory

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -8285,6 +8285,24 @@ CREATE TABLE memory_cluster_members (
 	memory_id INTEGER PRIMARY KEY,
 	cluster_id INTEGER NOT NULL
 );
-CREATE INDEX idx_memory_cluster_members_cluster ON memory_cluster_members(cluster_id);
+	CREATE INDEX idx_memory_cluster_members_cluster ON memory_cluster_members(cluster_id);
+	`,
+	// #784 auto cross-link confirmed memories. Links are stored in a dedicated side
+	// table rather than mutating owner-authored fact content: the confirmed memory
+	// row remains the source of truth for the fact, while this table records a
+	// deterministic, capped similarity edge from one active fact to another. Pure
+	// additive append (CREATE TABLE/INDEX only): the table stays empty until a
+	// memory is confirmed or `gitmoot memory links backfill` runs, so every
+	// existing read path is byte-identical unless it explicitly opts into links.
+	`
+CREATE TABLE memory_links (
+	src_id INTEGER NOT NULL,
+	dst_id INTEGER NOT NULL,
+	score REAL NOT NULL,
+	origin TEXT NOT NULL DEFAULT 'auto',
+	created_at TEXT NOT NULL,
+	UNIQUE(src_id, dst_id)
+);
+CREATE INDEX idx_memory_links_dst ON memory_links(dst_id);
 	`,
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1610,7 +1610,7 @@ Most jobs return none. Returned learnings are shadow-logged only (never injected
 in this phase) and pass deterministic pre-filters that reject directive-phrased,
 executable, secret-shaped, or non-repo-agnostic content.
 
-Inspect and measure the store (all read-only):
+Inspect, curate, and measure the store:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
@@ -1619,6 +1619,8 @@ gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
 gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
+gitmoot memory links backfill [--dry-run] [--json]
+gitmoot memory links list <id> [--json]
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
@@ -1638,7 +1640,8 @@ recall/precision@K of retrieval over a labeled fixtures file whose cases are
 `memory vault export` renders confirmed memory as a **disposable, Obsidian-compatible
 vault view** (#737): one Markdown note per confirmed memory (sorted-key YAML
 frontmatter + the content verbatim + a `## Links` section of FTS co-occurrence
-`[[wikilinks]]`), a per-owner index note, and a `manifest.json` staleness anchor.
+and persisted `[[wikilinks]]`), a per-owner index note, and a `manifest.json`
+staleness anchor.
 It is a **view, not a replica**: the SQLite store stays the only source of truth,
 so the vault is regenerated from scratch on every export, is safe to delete, and
 is **deterministic** — the same store produces byte-identical files (there is no
@@ -1689,6 +1692,8 @@ observations** behind the existing confirmation gate. It never writes confirmed
 gitmoot memory ingest <path|dir> --agent NAME [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
 gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
+gitmoot memory links backfill [--dry-run] [--json]
+gitmoot memory links list <id> [--json]
 ```
 
 `memory ingest` walks `*.md` (recursively for a directory), strips a leading YAML
@@ -1717,6 +1722,15 @@ selected observations (by id, or every observation matching a
 Without `--yes` it prints the plan and writes nothing; with `--yes` it promotes
 (idempotently — re-confirming the same key upserts the one row). This is
 **CLI-explicit only**: there is no daemon path and nothing auto-confirms.
+
+Confirming a fact also writes up to three deterministic auto-links from that new
+confirmed row to active related confirmed memories. The links are stored in the
+`memory_links` side table with BM25-derived scores and never rewrite the fact
+content. `memory links backfill` applies the same link pass to the existing active
+confirmed pool in id order; `--dry-run` reports the links it would create without
+writing, and repeat runs are idempotent. `memory links list <id>` shows one fact's
+persisted outgoing links. Vault export merges these persisted links with the
+content-derived links in each note's `## Links` section and dedupes by target.
 
 > **Trust boundary.** Ingested Markdown is untrusted input — an
 > **indirect-prompt-injection vector**. Ingest records `trust_mark = low` on every

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -133,8 +133,8 @@ gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 
 `memory vault export` renders confirmed memory as an Obsidian-compatible vault:
 one Markdown note per confirmed memory (sorted-key YAML frontmatter, the content
-verbatim, and a `## Links` section of FTS co-occurrence `[[wikilinks]]`), a
-per-owner index note, and a `manifest.json` staleness anchor.
+verbatim, and a `## Links` section of FTS co-occurrence plus persisted
+`[[wikilinks]]`), a per-owner index note, and a `manifest.json` staleness anchor.
 
 The vault is a **view, not a replica**: SQLite stays the *only* source of truth,
 so the export never becomes a second store to keep in sync. It is regenerated
@@ -187,6 +187,8 @@ writes injectable memory directly.
 gitmoot memory ingest <path|dir> --agent NAME [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
 gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
+gitmoot memory links backfill [--dry-run] [--json]
+gitmoot memory links list <id> [--json]
 ```
 
 `memory ingest` walks `*.md`, strips a leading YAML frontmatter block when
@@ -211,6 +213,15 @@ selected observations (by id, or every one matching a `--provenance-prefix`) int
 confirmed memory, carrying provenance through. Without `--yes` it prints the plan
 and writes nothing; with `--yes` it promotes idempotently. It is **CLI-explicit
 only** — no daemon path, no auto-confirm.
+
+When a fact is confirmed, Gitmoot also records up to three deterministic outgoing
+links from that confirmed row to active related confirmed memories. These links
+live in the `memory_links` side table with BM25-derived scores. They do not rewrite
+the memory's content. `memory links backfill` runs the same pass over all active
+confirmed memories in id order; `--dry-run` reports what would be created, and
+repeat runs create nothing new. `memory links list <id>` inspects a fact's
+persisted outgoing links. Vault export merges persisted links with content-derived
+links in each note's `## Links` section and removes duplicates by target.
 
 :::warning Ingested Markdown is untrusted
 Ingested Markdown is an **indirect-prompt-injection vector**. Ingest stamps

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1347,6 +1347,8 @@ gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 gitmoot memory ingest <path|dir> --agent NAME [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
 gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
+gitmoot memory links backfill [--dry-run] [--json]
+gitmoot memory links list <id> [--json]
 gitmoot memory groom --propose [--out PLAN.json] [--json]
 gitmoot memory groom --yes --plan PLAN.json [--json]
 gitmoot memory clusters [--json]
@@ -1369,9 +1371,9 @@ expected_keys}` fixtures file.
 
 `memory vault export` renders confirmed memory as a **disposable, Obsidian-compatible
 vault view**: one Markdown note per confirmed memory (sorted-key YAML frontmatter,
-the content verbatim, and a `## Links` section of FTS co-occurrence `[[wikilinks]]`),
-a per-owner index note, and a `manifest.json` staleness anchor. The vault is a **view,
-not a replica** — the SQLite store stays the only source of truth, so it is
+the content verbatim, and a `## Links` section of FTS co-occurrence plus persisted
+`[[wikilinks]]`), a per-owner index note, and a `manifest.json` staleness anchor.
+The vault is a **view, not a replica**: the SQLite store stays the only source of truth, so it is
 regenerated from scratch on every export, safe to delete, and **deterministic**: the
 same store yields byte-identical files (no `exported_at`; stable id-derived
 filenames). The export is read-only and atomic (temp dir then rename over `--out`,
@@ -1413,6 +1415,15 @@ into confirmed memory (idempotently), and without `--yes` only prints the plan.
 Ingested Markdown is an indirect-prompt-injection vector, so it stays inert at
 `trust_mark = low` until a human confirms it; that confirm gate is the trust
 boundary and nothing reads `trust_mark` for a decision yet.
+
+Confirming a fact also records up to three deterministic persisted links from that
+confirmed row to active related confirmed memories. Links live in `memory_links`
+with BM25-derived scores and do not rewrite fact content. `memory links backfill`
+runs the same pass over the active confirmed pool in id order; `--dry-run` reports
+what would be created, and repeat runs create nothing new. `memory links list <id>`
+shows one fact's outgoing persisted links. Vault export merges these persisted
+links with content-derived links and dedupes by target in each note's `## Links`
+section.
 
 `memory groom` retires stale, low-signal confirmed memories as a **propose →
 review → apply** round-trip. `--propose` reads active confirmed memory, computes

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -32,7 +32,7 @@ full expanded context.
 
 - [Local-First Coordination](https://gitmoot.io/docs/concepts/local-first-coordination): Why state lives in local SQLite and GitHub stays the audit surface.
 - [Agents, Agent Templates, Jobs, And Locks](https://gitmoot.io/docs/concepts/agents-templates-jobs-locks): The core object model — agent identities, template snapshots, job lifecycle, and the three lock kinds.
-- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, and the memory CLI, including `memory recall "<query>"` for read-only FTS5/BM25 lookup across all agent pools by default.
+- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, auto cross-links for confirmed facts (`memory links backfill|list`), and the memory CLI, including `memory recall "<query>"` for read-only FTS5/BM25 lookup across all agent pools by default.
 
 ## Dashboard
 


### PR DESCRIPTION
Closes #784.

New `memory_links` table (append-only migration; no content mutation): on confirm, each new memory links to its top-K bm25-similar existing memories above a score threshold. Adds `gitmoot memory links backfill [--dry-run]` and `memory links list <id>`, and renders table links in the vault export Links section. Injection behavior unchanged.

Implemented by a gitmoot-orchestrated codex (gpt-5.5) implement job; coordinated and reviewed by the lead session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)