### PR TITLE
feat(memory): shared pool tier with author-preserving union injection

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -45,7 +45,10 @@ func runDashboardWeb(home, addr string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "dashboard: %v\n", err)
 		return 1
 	}
-	srv := &http.Server{Handler: dashboard.Serve(ds)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/learning/knowledge", ds.handleLearningKnowledge)
+	mux.Handle("/", dashboard.Serve(ds))
+	srv := &http.Server{Handler: mux}
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 

--- a/internal/cli/dashboard_web_learning.go
+++ b/internal/cli/dashboard_web_learning.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -221,15 +223,22 @@ type witnessKey struct {
 // supersede "ghosts". The per-agent count and the on-graph fact-node count for that
 // agent therefore differ by its superseded rows — this is intentional.
 func (d *webDataSource) Knowledge(ctx context.Context) (dashboard.Knowledge, error) {
+	out, _, err := d.knowledgeWithShared(ctx)
+	return out, err
+}
+
+func (d *webDataSource) knowledgeWithShared(ctx context.Context) (dashboard.Knowledge, map[string]bool, error) {
 	out := dashboard.Knowledge{
 		Agents:   []dashboard.KnowledgeAgent{},
 		Facts:    []dashboard.KnowledgeFact{},
 		Clusters: []dashboard.KnowledgeCluster{},
 		Edges:    []dashboard.KnowledgeEdge{},
 	}
+	sharedByFact := map[string]bool{}
 	err := withStoreAndPaths(d.home, func(paths config.Paths, store *db.Store) error {
-		// Confirmed facts (INCLUDING superseded ghosts) owned by any agent.
-		rows, err := store.ListConfirmedMemoriesByOwnerKind(ctx, memory.OwnerKindAgent)
+		// Confirmed facts (INCLUDING superseded ghosts) owned by any agent, plus
+		// shared facts attributed to their preserved author.
+		rows, err := store.ListConfirmedMemoriesForKnowledge(ctx)
 		if err != nil {
 			return err
 		}
@@ -276,17 +285,21 @@ func (d *webDataSource) Knowledge(ctx context.Context) (dashboard.Knowledge, err
 		// empty and file-less provenance leaves SourceFile empty.
 		out.Facts = make([]dashboard.KnowledgeFact, 0, len(rows))
 		for _, r := range rows {
+			owner := knowledgeFactOwner(r)
 			fact := dashboard.KnowledgeFact{
 				ID:         idByRow[r.ID],
 				Content:    r.Content,
 				Repo:       strings.TrimSpace(r.Repo),
 				Key:        strings.TrimSpace(r.Key),
-				Owner:      strings.TrimSpace(r.Owner.Ref),
-				Witnesses:  witnessByKey[witnessKey{r.Owner.Ref, r.Repo, r.Key}],
+				Owner:      owner,
+				Witnesses:  witnessByKey[witnessKey{owner, r.Repo, r.Key}],
 				FirstSeen:  parseJobTimeMillis(r.FirstConfirmedAt),
 				LastSeen:   parseJobTimeMillis(r.UpdatedAt),
 				Superseded: r.SupersededBy != 0,
 				Links:      knowledgeFactLinks(ctx, store, r, idByRow),
+			}
+			if r.Owner.Kind == memory.OwnerKindShared && r.Owner.Ref == memory.SharedOwnerRef {
+				sharedByFact[fact.ID] = true
 			}
 			// Cluster: only when the membership resolves to a known cluster row, so a
 			// fact's Cluster never dangles past the emitted Clusters slice.
@@ -319,9 +332,57 @@ func (d *webDataSource) Knowledge(ctx context.Context) (dashboard.Knowledge, err
 		return nil
 	})
 	if err != nil {
-		return dashboard.Knowledge{}, err
+		return dashboard.Knowledge{}, nil, err
 	}
-	return out, nil
+	return out, sharedByFact, nil
+}
+
+func knowledgeFactOwner(r db.ConfirmedMemory) string {
+	if author := strings.TrimSpace(r.AuthorRef); author != "" {
+		return author
+	}
+	return strings.TrimSpace(r.Owner.Ref)
+}
+
+type dashboardKnowledgeResponse struct {
+	Agents   []dashboard.KnowledgeAgent   `json:"agents"`
+	Facts    []dashboardKnowledgeFact     `json:"facts"`
+	Clusters []dashboard.KnowledgeCluster `json:"clusters"`
+	Edges    []dashboard.KnowledgeEdge    `json:"edges"`
+}
+
+type dashboardKnowledgeFact struct {
+	dashboard.KnowledgeFact
+	Shared bool `json:"shared,omitempty"`
+}
+
+func (d *webDataSource) handleLearningKnowledge(w http.ResponseWriter, r *http.Request) {
+	k, sharedByFact, err := d.knowledgeWithShared(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp := dashboardKnowledgeResponse{
+		Agents:   k.Agents,
+		Facts:    make([]dashboardKnowledgeFact, 0, len(k.Facts)),
+		Clusters: k.Clusters,
+		Edges:    k.Edges,
+	}
+	for _, f := range k.Facts {
+		resp.Facts = append(resp.Facts, dashboardKnowledgeFact{
+			KnowledgeFact: f,
+			Shared:        sharedByFact[f.ID],
+		})
+	}
+	buf, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		http.Error(w, "internal error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	buf = append(buf, '\n')
+	_, _ = w.Write(buf)
 }
 
 // factSourceFileMarkers are the Provenance prefixes the file-ingest write paths

--- a/internal/cli/dashboard_web_learning_test.go
+++ b/internal/cli/dashboard_web_learning_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"net/http/httptest"
 	"testing"
 
 	dashboard "github.com/jerryfane/gitmoot-dashboard"
@@ -376,6 +378,72 @@ func TestWebDataSourceKnowledge(t *testing.T) {
 	if fmt.Sprintf("%+v", k) != fmt.Sprintf("%+v", k2) {
 		t.Fatalf("Knowledge not deterministic across calls")
 	}
+}
+
+func TestKnowledgeSharedFactsUseAuthorAndExposeMarker(t *testing.T) {
+	home := dashboardTestHome(t)
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	ctx := context.Background()
+	id, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner:     db.MemoryOwner{Kind: memory.OwnerKindShared, Ref: memory.SharedOwnerRef},
+		AuthorRef: "researcher",
+		Repo:      "jerryfane/noted",
+		Scope:     memory.ScopeRepo,
+		Key:       "shared-runbook",
+		Content:   "Shared deployment facts keep their original author.",
+	})
+	if err != nil {
+		t.Fatalf("Upsert shared memory: %v", err)
+	}
+	store.Close()
+
+	ds := &webDataSource{home: home}
+	k, err := ds.Knowledge(ctx)
+	if err != nil {
+		t.Fatalf("Knowledge: %v", err)
+	}
+	factID := fmt.Sprintf("fact:%d", id)
+	found := false
+	for _, f := range k.Facts {
+		if f.ID == factID {
+			found = true
+			if f.Owner != "researcher" {
+				t.Fatalf("shared fact owner = %q, want author researcher", f.Owner)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("shared fact %s missing from Knowledge facts: %+v", factID, k.Facts)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/learning/knowledge", nil)
+	ds.handleLearningKnowledge(rr, req)
+	if rr.Code != 200 {
+		t.Fatalf("knowledge handler status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	var payload struct {
+		Facts []struct {
+			ID     string `json:"id"`
+			Owner  string `json:"owner"`
+			Shared bool   `json:"shared"`
+		} `json:"facts"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("parse knowledge payload: %v (%s)", err, rr.Body.String())
+	}
+	for _, f := range payload.Facts {
+		if f.ID == factID {
+			if f.Owner != "researcher" || !f.Shared {
+				t.Fatalf("shared payload fact = %+v, want owner researcher shared=true", f)
+			}
+			return
+		}
+	}
+	t.Fatalf("shared fact %s missing from HTTP payload: %+v", factID, payload.Facts)
 }
 
 // TestKnowledgeClusterHierarchy seeds a store, recomputes the emergent clusters,

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/config"
@@ -43,6 +44,8 @@ func runMemory(args []string, stdout, stderr io.Writer) int {
 		return runMemoryObservations(args[1:], stdout, stderr)
 	case "confirm":
 		return runMemoryConfirm(args[1:], stdout, stderr)
+	case "promote":
+		return runMemoryPromote(args[1:], stdout, stderr)
 	case "links":
 		return runMemoryLinks(args[1:], stdout, stderr)
 	case "groom":
@@ -67,13 +70,14 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo R] [--json]")
-	fmt.Fprintln(w, "  gitmoot memory recall \"<query>\" [--repo R] [--agent NAME] [--limit N] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory recall \"<query>\" [--repo R] [--agent NAME|--shared] [--limit N] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory replay [--agent NAME] [--repo R] [--limit N] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory eval --fixtures FILE [--k N] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory vault export [--out DIR] [--agent NAME] [--json]")
-	fmt.Fprintln(w, "  gitmoot memory ingest <path|dir> --agent NAME [--repo R] [--tier repo|general] [--dry-run] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory ingest <path|dir> --agent NAME [--shared] [--repo R] [--tier repo|general] [--dry-run] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]")
-	fmt.Fprintln(w, "  gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--to-shared] [--yes] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory promote --to-shared <id>... [--json]")
 	fmt.Fprintln(w, "  gitmoot memory links backfill [--dry-run] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory links list <id> [--json]")
 	fmt.Fprintln(w, "  gitmoot memory groom --propose [--out PLAN.json] [--json] | --yes --plan PLAN.json [--json]")
@@ -82,7 +86,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot memory cluster rename <cluster-id> <label>")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  list          show stored memories (confirmed and/or pending observations)")
-	fmt.Fprintln(w, "  recall        retrieve ranked confirmed memories; defaults to all agent pools")
+	fmt.Fprintln(w, "  recall        retrieve ranked confirmed memories; defaults to all agent pools plus shared")
 	fmt.Fprintln(w, "  replay        offline A/B: render recent real jobs' prompts with vs without the")
 	fmt.Fprintln(w, "                learnings block and report the injection delta (tokens, entries)")
 	fmt.Fprintln(w, "  eval          recall/precision@K of retrieval over a labeled fixtures file")
@@ -90,6 +94,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  ingest        stage markdown as trust_mark=low pending observations (PreFilter-gated)")
 	fmt.Fprintln(w, "  observations  list pending observations, flagging which keys are already confirmed")
 	fmt.Fprintln(w, "  confirm       human-gated promotion of pending observations into confirmed memory")
+	fmt.Fprintln(w, "  promote       explicitly move active confirmed facts into the shared pool")
 	fmt.Fprintln(w, "  links         inspect persisted memory links; backfill links for existing facts")
 	fmt.Fprintln(w, "  groom         deterministically propose stale-memory retirements, apply on confirmation")
 	fmt.Fprintln(w, "  clusters      list emergent memory clusters; recompute them via a propose/apply plan")
@@ -107,6 +112,7 @@ type memoryRecallOwner struct {
 type memoryRecallEntry struct {
 	ID         int64             `json:"id"`
 	Owner      memoryRecallOwner `json:"owner"`
+	AuthorRef  string            `json:"author_ref,omitempty"`
 	Repo       string            `json:"repo"`
 	Scope      string            `json:"scope"`
 	Key        string            `json:"key"`
@@ -120,6 +126,7 @@ func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	agent := fs.String("agent", "", "filter to one agent owner pool; default searches all agent pools")
+	shared := fs.Bool("shared", false, "search only the shared pool")
 	repo := fs.String("repo", "", "filter by repo (owner/repo); omitted searches all repos")
 	limit := fs.Int("limit", 15, "maximum number of matching memories to return")
 	jsonOut := fs.Bool("json", false, "print as JSON")
@@ -128,7 +135,11 @@ func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
 		return memoryFlagExit(err)
 	}
 	if strings.TrimSpace(queryText) == "" {
-		fmt.Fprintln(stderr, "usage: gitmoot memory recall \"<query>\" [--repo owner/repo] [--agent NAME] [--limit N] [--json]")
+		fmt.Fprintln(stderr, "usage: gitmoot memory recall \"<query>\" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--json]")
+		return 2
+	}
+	if *shared && strings.TrimSpace(*agent) != "" {
+		fmt.Fprintln(stderr, "memory recall: --shared cannot be combined with --agent")
 		return 2
 	}
 	query := workflow.BuildMemoryMatchQuery(queryText)
@@ -137,7 +148,9 @@ func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
 	err = withReadOnlyStore(*home, func(store *db.Store) error {
 		var err error
 		ctx := context.Background()
-		if strings.TrimSpace(*agent) != "" {
+		if *shared {
+			rows, err = store.QueryConfirmedMemoriesForShared(ctx, strings.TrimSpace(*repo), query, *limit)
+		} else if strings.TrimSpace(*agent) != "" {
 			owner := db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: strings.TrimSpace(*agent)}
 			if strings.TrimSpace(*repo) != "" {
 				rows, err = store.QueryConfirmedMemories(ctx, owner, strings.TrimSpace(*repo), query, *limit)
@@ -190,6 +203,7 @@ func parseMemoryRecallArgs(fs *flag.FlagSet, args []string) (string, error) {
 		"-agent": true, "--agent": true,
 		"-repo": true, "--repo": true,
 		"-limit": true, "--limit": true,
+		"-shared": false, "--shared": false,
 	}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -224,6 +238,7 @@ func memoryRecallJSONEntry(r db.ConfirmedMemory) memoryRecallEntry {
 			Ref:     r.Owner.Ref,
 			Version: r.Owner.Version,
 		},
+		AuthorRef:  r.AuthorRef,
 		Repo:       r.Repo,
 		Scope:      r.Scope,
 		Key:        r.Key,
@@ -240,6 +255,76 @@ func memoryRecallDisplayRepo(r db.ConfirmedMemory) string {
 	return "(general)"
 }
 
+// ---- memory promote -------------------------------------------------------
+
+type memoryPromoteResult struct {
+	ToShared bool                `json:"to_shared"`
+	Promoted int                 `json:"promoted"`
+	Rows     []memoryRecallEntry `json:"rows,omitempty"`
+}
+
+func runMemoryPromote(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("memory promote", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	toShared := fs.Bool("to-shared", false, "move confirmed memory rows into the shared pool")
+	jsonOut := fs.Bool("json", false, "print as JSON")
+	if err := parseMemoryFlags(fs, args); err != nil {
+		return memoryFlagExit(err)
+	}
+	if !*toShared {
+		fmt.Fprintln(stderr, "memory promote: --to-shared is required")
+		return 2
+	}
+	if fs.NArg() == 0 {
+		fmt.Fprintln(stderr, "usage: gitmoot memory promote --to-shared <id>... [--json]")
+		return 2
+	}
+	ids := make([]int64, 0, fs.NArg())
+	for _, arg := range fs.Args() {
+		id, err := strconv.ParseInt(strings.TrimSpace(arg), 10, 64)
+		if err != nil || id <= 0 {
+			fmt.Fprintf(stderr, "memory promote: invalid confirmed memory id %q\n", arg)
+			return 2
+		}
+		ids = append(ids, id)
+	}
+
+	result := memoryPromoteResult{ToShared: true}
+	err := withStore(*home, func(store *db.Store) error {
+		rows, err := store.PromoteConfirmedMemoriesToShared(context.Background(), ids)
+		if err != nil {
+			return err
+		}
+		result.Promoted = len(rows)
+		result.Rows = make([]memoryRecallEntry, 0, len(rows))
+		for _, r := range rows {
+			result.Rows = append(result.Rows, memoryRecallJSONEntry(r))
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "memory promote: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "memory promote: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "moved %d confirmed memory row(s) into the shared pool\n", result.Promoted)
+	for _, r := range result.Rows {
+		author := r.AuthorRef
+		if author == "" {
+			author = r.Owner.Ref
+		}
+		fmt.Fprintf(stdout, "  %d %s author=%s\n", r.ID, r.Key, author)
+	}
+	return 0
+}
+
 // ---- memory list ----------------------------------------------------------
 
 type memoryListEntry struct {
@@ -247,6 +332,7 @@ type memoryListEntry struct {
 	ID         int64  `json:"id"`
 	OwnerKind  string `json:"owner_kind"`
 	OwnerRef   string `json:"owner_ref"`
+	AuthorRef  string `json:"author_ref,omitempty"`
 	Repo       string `json:"repo,omitempty"`
 	Scope      string `json:"scope"`
 	Key        string `json:"key"`
@@ -284,7 +370,8 @@ func runMemoryList(args []string, stdout, stderr io.Writer) int {
 			for _, r := range rows {
 				entries = append(entries, memoryListEntry{
 					Tier: "confirmed", ID: r.ID, OwnerKind: r.Owner.Kind, OwnerRef: r.Owner.Ref,
-					Repo: r.Repo, Scope: r.Scope, Key: r.Key, Content: r.Content,
+					AuthorRef: r.AuthorRef,
+					Repo:      r.Repo, Scope: r.Scope, Key: r.Key, Content: r.Content,
 					Provenance: r.Provenance, SourceJob: r.SourceJob, UpdatedAt: r.UpdatedAt,
 				})
 			}
@@ -297,7 +384,8 @@ func runMemoryList(args []string, stdout, stderr io.Writer) int {
 			for _, r := range rows {
 				entries = append(entries, memoryListEntry{
 					Tier: "pending", ID: r.ID, OwnerKind: r.Owner.Kind, OwnerRef: r.Owner.Ref,
-					Repo: r.Repo, Scope: r.Scope, Key: r.Key, Content: r.Content,
+					AuthorRef: r.AuthorRef,
+					Repo:      r.Repo, Scope: r.Scope, Key: r.Key, Content: r.Content,
 					Provenance: r.Provenance, TrustMark: r.TrustMark, SourceJob: r.SourceJob, UpdatedAt: r.CreatedAt,
 				})
 			}

--- a/internal/cli/memory_ingest.go
+++ b/internal/cli/memory_ingest.go
@@ -29,6 +29,7 @@ import (
 // memoryIngestResult is the summary of an ingest run (and the --json shape).
 type memoryIngestResult struct {
 	Agent        string         `json:"agent"`
+	Shared       bool           `json:"shared,omitempty"`
 	Scope        string         `json:"scope"`
 	Repo         string         `json:"repo,omitempty"`
 	DryRun       bool           `json:"dry_run"`
@@ -46,6 +47,7 @@ func runMemoryIngest(args []string, stdout, stderr io.Writer) int {
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	agent := fs.String("agent", "", "owner agent name for the ingested observations (required)")
+	shared := fs.Bool("shared", false, "stage observations in the shared pool with --agent as author")
 	repo := fs.String("repo", "", "repo (owner/repo) for repo-scoped observations")
 	tier := fs.String("tier", "repo", "scope tier: repo|general (general only with this explicit flag)")
 	dryRun := fs.Bool("dry-run", false, "report what would be ingested without writing")
@@ -107,6 +109,7 @@ func runMemoryIngest(args []string, stdout, stderr io.Writer) int {
 
 	result := memoryIngestResult{
 		Agent:      *agent,
+		Shared:     *shared,
 		Scope:      scope,
 		Repo:       strings.TrimSpace(*repo),
 		DryRun:     *dryRun,
@@ -114,10 +117,15 @@ func runMemoryIngest(args []string, stdout, stderr io.Writer) int {
 		RejectedBy: map[string]int{},
 	}
 	owner := db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: *agent}
+	authorRef := ""
+	if *shared {
+		owner = db.MemoryOwner{Kind: memory.OwnerKindShared, Ref: memory.SharedOwnerRef}
+		authorRef = strings.TrimSpace(*agent)
+	}
 
 	err = withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
-		seen, err := store.ObservationDedupKeys(ctx, *agent)
+		seen, err := store.ObservationDedupKeys(ctx, owner.Ref)
 		if err != nil {
 			return err
 		}
@@ -157,6 +165,7 @@ func runMemoryIngest(args []string, stdout, stderr io.Writer) int {
 				}
 				if _, err := store.InsertMemoryObservation(ctx, db.MemoryObservation{
 					Owner:      owner,
+					AuthorRef:  authorRef,
 					Repo:       result.Repo,
 					Scope:      scope,
 					Key:        key,
@@ -250,6 +259,7 @@ func sortedReasonKeys(m map[string]int) []string {
 type memoryObservationEntry struct {
 	ID         int64  `json:"id"`
 	OwnerRef   string `json:"owner_ref"`
+	AuthorRef  string `json:"author_ref,omitempty"`
 	Repo       string `json:"repo,omitempty"`
 	Scope      string `json:"scope"`
 	Key        string `json:"key"`
@@ -280,7 +290,8 @@ func runMemoryObservations(args []string, stdout, stderr io.Writer) int {
 		for _, r := range rows {
 			entries = append(entries, memoryObservationEntry{
 				ID: r.ID, OwnerRef: r.Owner.Ref, Repo: r.Repo, Scope: r.Scope, Key: r.Key,
-				Content: r.Content, Provenance: r.Provenance, TrustMark: r.TrustMark,
+				AuthorRef: r.AuthorRef,
+				Content:   r.Content, Provenance: r.Provenance, TrustMark: r.TrustMark,
 				Confirmed: r.Confirmed, CreatedAt: r.CreatedAt,
 			})
 		}
@@ -319,6 +330,7 @@ func runMemoryObservations(args []string, stdout, stderr io.Writer) int {
 
 type memoryConfirmResult struct {
 	DryRun    bool     `json:"dry_run"`
+	ToShared  bool     `json:"to_shared,omitempty"`
 	Selected  int      `json:"selected"`
 	Confirmed int      `json:"confirmed"`
 	Keys      []string `json:"keys,omitempty"`
@@ -330,6 +342,7 @@ func runMemoryConfirm(args []string, stdout, stderr io.Writer) int {
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	agent := fs.String("agent", "", "owner agent name (scopes --provenance-prefix selection)")
 	prefix := fs.String("provenance-prefix", "", "confirm every pending observation whose provenance starts with this prefix")
+	toShared := fs.Bool("to-shared", false, "confirm selected observations into the shared pool")
 	yes := fs.Bool("yes", false, "actually promote (without it, prints the plan and makes no writes)")
 	jsonOut := fs.Bool("json", false, "print the confirm summary as JSON")
 	if err := parseMemoryFlags(fs, args); err != nil {
@@ -351,7 +364,7 @@ func runMemoryConfirm(args []string, stdout, stderr io.Writer) int {
 		ids = append(ids, id)
 	}
 
-	result := memoryConfirmResult{DryRun: !*yes}
+	result := memoryConfirmResult{DryRun: !*yes, ToShared: *toShared}
 	err := withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
 		selected, err := selectObservationsToConfirm(ctx, store, ids, *agent, *prefix)
@@ -364,8 +377,17 @@ func runMemoryConfirm(args []string, stdout, stderr io.Writer) int {
 			if !*yes {
 				continue
 			}
+			owner := obs.Owner
+			authorRef := observationAuthorRef(obs)
+			if !*toShared && owner.Kind == memory.OwnerKindAgent && owner.Ref == authorRef {
+				authorRef = ""
+			}
+			if *toShared {
+				owner = db.MemoryOwner{Kind: memory.OwnerKindShared, Ref: memory.SharedOwnerRef}
+			}
 			newID, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
-				Owner:      obs.Owner,
+				Owner:      owner,
+				AuthorRef:  authorRef,
 				Repo:       obs.Repo,
 				Scope:      obs.Scope,
 				Key:        obs.Key,
@@ -381,7 +403,7 @@ func runMemoryConfirm(args []string, stdout, stderr io.Writer) int {
 			// the cluster of its nearest similarity neighbor. Best-effort and
 			// fail-safe — a clustering error must never block the confirmation.
 			attachConfirmedFactToCluster(ctx, store, db.ConfirmedMemory{
-				ID: newID, Owner: obs.Owner, Repo: obs.Repo, Scope: obs.Scope,
+				ID: newID, Owner: owner, AuthorRef: authorRef, Repo: obs.Repo, Scope: obs.Scope,
 				Key: obs.Key, Content: obs.Content,
 			})
 		}
@@ -413,6 +435,13 @@ func runMemoryConfirm(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "confirmed %d observation(s) into confirmed memory\n", result.Confirmed)
 	return 0
+}
+
+func observationAuthorRef(obs db.MemoryObservation) string {
+	if author := strings.TrimSpace(obs.AuthorRef); author != "" {
+		return author
+	}
+	return strings.TrimSpace(obs.Owner.Ref)
 }
 
 // selectObservationsToConfirm resolves the explicit id list and/or the

--- a/internal/cli/memory_ingest_test.go
+++ b/internal/cli/memory_ingest_test.go
@@ -226,6 +226,67 @@ func TestMemoryIngestConfirmExportRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMemoryIngestSharedAndConfirmToSharedAuthorStamping(t *testing.T) {
+	home, store := memoryTestHome(t)
+	src := t.TempDir()
+	writeFixture(t, src, "shared.md",
+		"The release checklist lives in the shared memory pool after human review.\n")
+
+	code, out, errOut := runMemoryCapture(t, "ingest", src, "--home", home,
+		"--agent", "lead", "--repo", "acme/widget", "--shared", "--json")
+	if code != 0 {
+		t.Fatalf("shared ingest exit %d: %s", code, errOut)
+	}
+	var ingest memoryIngestResult
+	if err := json.Unmarshal([]byte(out), &ingest); err != nil {
+		t.Fatalf("parse ingest: %v (%s)", err, out)
+	}
+	if !ingest.Shared || ingest.Agent != "lead" || ingest.Inserted != 1 {
+		t.Fatalf("shared ingest result wrong: %+v", ingest)
+	}
+
+	obs := listObservations(t, home)
+	if len(obs) != 1 {
+		t.Fatalf("expected one observation, got %+v", obs)
+	}
+	if obs[0].Owner.Kind != memory.OwnerKindShared || obs[0].Owner.Ref != memory.SharedOwnerRef || obs[0].AuthorRef != "lead" {
+		t.Fatalf("shared observation should preserve author lead, got %+v", obs[0])
+	}
+
+	code, out, errOut = runMemoryCapture(t, "list", "--home", home, "--pending", "--agent", "lead", "--json")
+	if code != 0 {
+		t.Fatalf("list shared pending by author exit %d: %s", code, errOut)
+	}
+	var pending []memoryListEntry
+	if err := json.Unmarshal([]byte(out), &pending); err != nil {
+		t.Fatalf("parse pending list: %v (%s)", err, out)
+	}
+	if len(pending) != 1 || pending[0].OwnerKind != memory.OwnerKindShared || pending[0].AuthorRef != "lead" {
+		t.Fatalf("--agent lead should include shared pending rows authored by lead, got %+v", pending)
+	}
+
+	code, out, errOut = runMemoryCapture(t, "confirm", "--home", home,
+		"--provenance-prefix", "ingest:", "--agent", "lead", "--to-shared", "--yes", "--json")
+	if code != 0 {
+		t.Fatalf("confirm --to-shared exit %d: %s", code, errOut)
+	}
+	var confirm memoryConfirmResult
+	if err := json.Unmarshal([]byte(out), &confirm); err != nil {
+		t.Fatalf("parse confirm: %v (%s)", err, out)
+	}
+	if !confirm.ToShared || confirm.Confirmed != 1 {
+		t.Fatalf("confirm to shared result wrong: %+v", confirm)
+	}
+
+	rows, err := store.QueryConfirmedMemoriesForShared(context.Background(), "acme/widget", `"shared" OR "memory"`, 5)
+	if err != nil {
+		t.Fatalf("query shared: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Owner.Kind != memory.OwnerKindShared || rows[0].AuthorRef != "lead" {
+		t.Fatalf("confirmed shared row should preserve author lead, got %+v", rows)
+	}
+}
+
 func listObservations(t *testing.T, home string) []db.MemoryObservation {
 	t.Helper()
 	var out []db.MemoryObservation

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -215,6 +216,82 @@ func TestMemoryRecallRanksAndFiltersConfirmedMemories(t *testing.T) {
 	if len(none) != 0 {
 		t.Fatalf("empty recall JSON returned rows: %+v", none)
 	}
+}
+
+func TestMemoryRecallSharedParity(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	for _, cm := range []db.ConfirmedMemory{
+		{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: "lead"}, Repo: "acme/widget", Scope: "repo", Key: "lead-private",
+			Content: "atlas runner private lead fact", Provenance: "seed",
+		},
+		{
+			Owner: db.MemoryOwner{Kind: "agent", Ref: "audit"}, Repo: "acme/widget", Scope: "repo", Key: "audit-private",
+			Content: "atlas runner private audit fact", Provenance: "seed",
+		},
+		{
+			Owner: db.MemoryOwner{Kind: memory.OwnerKindShared, Ref: memory.SharedOwnerRef}, AuthorRef: "lead",
+			Repo: "acme/widget", Scope: "repo", Key: "shared-atlas",
+			Content: "atlas runner shared fact", Provenance: "seed",
+		},
+	} {
+		if _, err := store.UpsertConfirmedMemory(ctx, cm); err != nil {
+			t.Fatalf("seed %s: %v", cm.Key, err)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runMemory([]string{"recall", "atlas runner", "--home", home, "--repo", "acme/widget", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("default recall exit %d: %s", code, stderr.String())
+	}
+	var all []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &all); err != nil {
+		t.Fatalf("parse all recall: %v (%s)", err, stdout.String())
+	}
+	if !recallHasKey(all, "lead-private") || !recallHasKey(all, "audit-private") || !recallHasKey(all, "shared-atlas") {
+		t.Fatalf("default recall should include all agent pools plus shared, got %+v", all)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "atlas runner", "--home", home, "--repo", "acme/widget", "--agent", "lead", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("agent recall exit %d: %s", code, stderr.String())
+	}
+	var lead []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &lead); err != nil {
+		t.Fatalf("parse lead recall: %v (%s)", err, stdout.String())
+	}
+	if !recallHasKey(lead, "lead-private") || !recallHasKey(lead, "shared-atlas") || recallHasKey(lead, "audit-private") {
+		t.Fatalf("--agent lead should include lead private plus shared only, got %+v", lead)
+	}
+	for _, e := range lead {
+		if e.Key == "shared-atlas" && e.AuthorRef != "lead" {
+			t.Fatalf("shared recall JSON should expose author_ref lead, got %+v", e)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "atlas runner", "--home", home, "--repo", "acme/widget", "--shared", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("shared recall exit %d: %s", code, stderr.String())
+	}
+	var sharedOnly []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &sharedOnly); err != nil {
+		t.Fatalf("parse shared recall: %v (%s)", err, stdout.String())
+	}
+	if len(sharedOnly) != 1 || sharedOnly[0].Key != "shared-atlas" {
+		t.Fatalf("--shared should return only shared rows, got %+v", sharedOnly)
+	}
+}
+
+func recallHasKey(rows []memoryRecallEntry, key string) bool {
+	for _, r := range rows {
+		if r.Key == key {
+			return true
+		}
+	}
+	return false
 }
 
 func TestMemoryReplayReportsInjectionDelta(t *testing.T) {

--- a/internal/cli/memory_vault.go
+++ b/internal/cli/memory_vault.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/memory"
@@ -270,7 +271,13 @@ func vaultLinksFor(ctx context.Context, store *db.Store, src db.ConfirmedMemory)
 		return nil, nil
 	}
 	// Fetch one extra so excluding self still leaves up to K candidates.
-	related, err := store.QueryConfirmedMemoryVaultLinks(ctx, src.Owner, src.Repo, matchQuery, vaultLinkK+1)
+	owner := src.Owner
+	if src.Owner.Kind == memory.OwnerKindShared && src.Owner.Ref == memory.SharedOwnerRef {
+		if author := strings.TrimSpace(src.AuthorRef); author != "" {
+			owner = db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: author}
+		}
+	}
+	related, err := store.QueryConfirmedMemoryVaultLinks(ctx, owner, src.Repo, matchQuery, vaultLinkK+1)
 	if err != nil {
 		return nil, err
 	}
@@ -431,6 +438,7 @@ func toVaultMemory(c db.ConfirmedMemory) memory.VaultMemory {
 		OwnerKind:    c.Owner.Kind,
 		OwnerRef:     c.Owner.Ref,
 		OwnerVersion: c.Owner.Version,
+		AuthorRef:    c.AuthorRef,
 		Repo:         c.Repo,
 		Scope:        c.Scope,
 		Key:          c.Key,

--- a/internal/cli/memory_vault_import.go
+++ b/internal/cli/memory_vault_import.go
@@ -341,6 +341,7 @@ func vaultObservationFromNewFile(dn diskNote) (db.MemoryObservation, bool, strin
 	}
 	return db.MemoryObservation{
 		Owner:      db.MemoryOwner{Kind: ownerKind, Ref: ownerRef, Version: f.String("owner_version")},
+		AuthorRef:  f.String("author"),
 		Repo:       f.String("repo"),
 		Scope:      f.String("scope"),
 		Key:        key,

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -31,6 +31,7 @@ type MemoryOwner struct {
 type MemoryObservation struct {
 	ID         int64
 	Owner      MemoryOwner
+	AuthorRef  string // "" == author is Owner.Ref; set when a shared row preserves the writer
 	Repo       string // "" == general (scope carries the authoritative meaning)
 	Scope      string
 	Key        string
@@ -47,6 +48,7 @@ type MemoryObservation struct {
 type ConfirmedMemory struct {
 	ID               int64
 	Owner            MemoryOwner
+	AuthorRef        string // "" == author is Owner.Ref; set when owner changes to the shared pool
 	Repo             string // "" == general scope (stored as SQL NULL)
 	Scope            string
 	Key              string
@@ -81,6 +83,10 @@ type MemoryLinkEnrichment struct {
 }
 
 const (
+	memoryOwnerKindAgent  = "agent"
+	memoryOwnerKindShared = "shared"
+	memorySharedOwnerRef  = "shared"
+
 	memoryAutoLinkK = 3
 	// memoryAutoLinkMinScore is a tiny absolute floor guarding degenerate
 	// near-zero bm25 matches. The REAL weak-link guard is relative:
@@ -145,9 +151,9 @@ func insertMemoryObservationTx(ctx context.Context, tx *sql.Tx, obs MemoryObserv
 	}
 	res, err := tx.ExecContext(ctx, `
 INSERT INTO memory_observations
-	(owner_kind, owner_ref, owner_version, repo, scope, key, content, provenance, trust_mark, source_job, created_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		obs.Owner.Kind, obs.Owner.Ref, obs.Owner.Version, nullableRepo(obs.Repo), scope,
+	(owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, provenance, trust_mark, source_job, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		obs.Owner.Kind, obs.Owner.Ref, obs.Owner.Version, strings.TrimSpace(obs.AuthorRef), nullableRepo(obs.Repo), scope,
 		obs.Key, obs.Content, obs.Provenance, obs.TrustMark, obs.SourceJob, created)
 	if err != nil {
 		return 0, fmt.Errorf("insert memory observation: %w", err)
@@ -172,19 +178,29 @@ WHERE owner_kind = ? AND owner_ref = ? AND owner_version = ?
 	return n, nil
 }
 
-// CountConfirmedMemoriesForOwner returns how many confirmed_memories rows an
-// owner owns, across ALL owner versions and every repo/scope (owner_version is
+// CountConfirmedMemoriesForOwner returns how many active confirmed rows an
+// owner owns or, for agent owners, authored after a row moved to the shared pool.
+// It scans across ALL owner versions and every repo/scope (owner_version is
 // deliberately not filtered — an agent owner always writes owner_version=”), so
-// it answers "how many injectable facts does this agent own". It backs the
+// it answers "how many injectable facts belong to this agent". It backs the
 // dashboard's per-agent memory count and is a plain read (no FTS). Superseded AND
 // retired rows are excluded (superseded_by IS NULL AND retired_at = ”) so the
 // count stays exactly equal to the injectable set surfaced by
 // QueryConfirmedMemories (which applies the same two filters).
 func (s *Store) CountConfirmedMemoriesForOwner(ctx context.Context, ownerKind, ownerRef string) (int, error) {
 	var n int
-	err := s.db.QueryRowContext(ctx, `
+	query := `
 SELECT COUNT(*) FROM confirmed_memories
-WHERE owner_kind = ? AND owner_ref = ? AND superseded_by IS NULL AND retired_at = ''`, ownerKind, ownerRef).Scan(&n)
+WHERE owner_kind = ? AND owner_ref = ? AND superseded_by IS NULL AND retired_at = ''`
+	args := []any{ownerKind, ownerRef}
+	if ownerKind == memoryOwnerKindAgent {
+		query = `
+SELECT COUNT(*) FROM confirmed_memories
+WHERE ((owner_kind = ? AND owner_ref = ?) OR (owner_kind = ? AND owner_ref = ? AND author_ref = ?))
+	AND superseded_by IS NULL AND retired_at = ''`
+		args = []any{memoryOwnerKindAgent, ownerRef, memoryOwnerKindShared, memorySharedOwnerRef, ownerRef}
+	}
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(&n)
 	if err != nil {
 		return 0, fmt.Errorf("count confirmed memories for owner: %w", err)
 	}
@@ -192,14 +208,23 @@ WHERE owner_kind = ? AND owner_ref = ? AND superseded_by IS NULL AND retired_at 
 }
 
 // CountMemoryObservationsForOwner returns how many memory_observations rows an
-// owner owns, across ALL owner versions and every repo/scope/key. Observations
+// owner owns or, for agent owners, authored after a row staged directly in the
+// shared pool, across ALL owner versions and every repo/scope/key. Observations
 // are append-only, so this is the raw sighting-report volume for the owner. It
 // backs the dashboard's per-agent observation count.
 func (s *Store) CountMemoryObservationsForOwner(ctx context.Context, ownerKind, ownerRef string) (int, error) {
 	var n int
-	err := s.db.QueryRowContext(ctx, `
+	query := `
 SELECT COUNT(*) FROM memory_observations
-WHERE owner_kind = ? AND owner_ref = ?`, ownerKind, ownerRef).Scan(&n)
+WHERE owner_kind = ? AND owner_ref = ?`
+	args := []any{ownerKind, ownerRef}
+	if ownerKind == memoryOwnerKindAgent {
+		query = `
+SELECT COUNT(*) FROM memory_observations
+WHERE (owner_kind = ? AND owner_ref = ?) OR (owner_kind = ? AND owner_ref = ? AND author_ref = ?)`
+		args = []any{memoryOwnerKindAgent, ownerRef, memoryOwnerKindShared, memorySharedOwnerRef, ownerRef}
+	}
+	err := s.db.QueryRowContext(ctx, query, args...).Scan(&n)
 	if err != nil {
 		return 0, fmt.Errorf("count memory observations for owner: %w", err)
 	}
@@ -221,7 +246,7 @@ WHERE owner_kind = ? AND owner_ref = ?`, ownerKind, ownerRef).Scan(&n)
 // Rows come back ordered by id for a stable, deterministic traversal. Plain read, no FTS.
 func (s *Store) ListConfirmedMemoriesByOwnerKind(ctx context.Context, ownerKind string) ([]ConfirmedMemory, error) {
 	rows, err := s.db.QueryContext(ctx, `
-SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
 FROM confirmed_memories
 WHERE owner_kind = ? AND retired_at = ''
@@ -234,7 +259,37 @@ ORDER BY id`, ownerKind)
 	for rows.Next() {
 		var c ConfirmedMemory
 		var repoNull sql.NullString
-		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &repoNull,
+		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
+			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
+			return nil, err
+		}
+		c.Repo = repoNull.String
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// ListConfirmedMemoriesForKnowledge returns every non-retired fact the dashboard
+// Knowledge graph should render: private agent facts plus the reserved shared
+// pool. Superseded rows stay included as graph ghosts, matching
+// ListConfirmedMemoriesByOwnerKind.
+func (s *Store) ListConfirmedMemoriesForKnowledge(ctx context.Context) ([]ConfirmedMemory, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
+FROM confirmed_memories
+WHERE (owner_kind = 'agent' OR (owner_kind = 'shared' AND owner_ref = 'shared'))
+	AND retired_at = ''
+ORDER BY id`)
+	if err != nil {
+		return nil, fmt.Errorf("list confirmed memories for knowledge: %w", err)
+	}
+	defer rows.Close()
+	var out []ConfirmedMemory
+	for rows.Next() {
+		var c ConfirmedMemory
+		var repoNull sql.NullString
+		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
 			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
 			return nil, err
 		}
@@ -260,11 +315,18 @@ type ObservationKeyWitnesses struct {
 // pass, so the brain graph can attach a witness count to every fact without an N+1
 // per-fact query. A NULL repo (general scope) is normalized to "".
 func (s *Store) CountObservationWitnessesByKey(ctx context.Context, ownerKind string) ([]ObservationKeyWitnesses, error) {
+	where := "owner_kind = ?"
+	args := []any{ownerKind}
+	if ownerKind == memoryOwnerKindAgent {
+		where = "(owner_kind = ? OR owner_kind = ?)"
+		args = []any{memoryOwnerKindAgent, memoryOwnerKindShared}
+	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT owner_ref, repo, key, COUNT(*)
+SELECT CASE WHEN author_ref <> '' THEN author_ref ELSE owner_ref END AS witness_owner_ref,
+	repo, key, COUNT(*)
 FROM memory_observations
-WHERE owner_kind = ?
-GROUP BY owner_ref, repo, key`, ownerKind)
+WHERE `+where+`
+GROUP BY witness_owner_ref, repo, key`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("count observation witnesses by key: %w", err)
 	}
@@ -320,9 +382,9 @@ WHERE owner_kind = ? AND owner_ref = ? AND owner_version = ?
 	case err == sql.ErrNoRows:
 		res, insErr := tx.ExecContext(ctx, `
 INSERT INTO confirmed_memories
-	(owner_kind, owner_ref, owner_version, repo, scope, key, content, provenance, source_job, first_confirmed_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			cm.Owner.Kind, cm.Owner.Ref, cm.Owner.Version, nullableRepo(cm.Repo), scope,
+	(owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, provenance, source_job, first_confirmed_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			cm.Owner.Kind, cm.Owner.Ref, cm.Owner.Version, strings.TrimSpace(cm.AuthorRef), nullableRepo(cm.Repo), scope,
 			cm.Key, cm.Content, cm.Provenance, cm.SourceJob, now, now)
 		if insErr != nil {
 			return 0, fmt.Errorf("insert confirmed memory: %w", insErr)
@@ -341,9 +403,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		// the already-empty retirement columns untouched.
 		if _, upErr := tx.ExecContext(ctx, `
 UPDATE confirmed_memories
-SET content = ?, provenance = ?, source_job = ?, updated_at = ?, retired_at = '', retired_reason = ''
+SET author_ref = ?, content = ?, provenance = ?, source_job = ?, updated_at = ?, retired_at = '', retired_reason = ''
 WHERE id = ?`,
-			cm.Content, cm.Provenance, cm.SourceJob, now, id); upErr != nil {
+			strings.TrimSpace(cm.AuthorRef), cm.Content, cm.Provenance, cm.SourceJob, now, id); upErr != nil {
 			return 0, fmt.Errorf("update confirmed memory: %w", upErr)
 		}
 	}
@@ -362,6 +424,85 @@ WHERE id = ?`,
 		return 0, err
 	}
 	return id, nil
+}
+
+// PromoteConfirmedMemoriesToShared moves active confirmed rows into the reserved
+// shared pool without changing their primary keys, content, keys, or FTS rows.
+// Existing memory_links survive because they key on confirmed_memories.id. When
+// a row has no author_ref, the previous owner_ref is recorded as its author
+// before owner_kind/owner_ref change to shared/shared. Retired or superseded rows
+// are refused so stale facts cannot be widened to every agent.
+func (s *Store) PromoteConfirmedMemoriesToShared(ctx context.Context, ids []int64) ([]ConfirmedMemory, error) {
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("at least one confirmed memory id is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := nowRFC3339()
+	out := make([]ConfirmedMemory, 0, len(ids))
+	seen := map[int64]struct{}{}
+	for _, id := range ids {
+		if id <= 0 {
+			return nil, fmt.Errorf("invalid confirmed memory id %d", id)
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+
+		var c ConfirmedMemory
+		var repoNull sql.NullString
+		var retiredAt string
+		err := tx.QueryRowContext(ctx, `
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0), retired_at
+FROM confirmed_memories
+WHERE id = ?`, id).Scan(
+			&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
+			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt,
+			&c.UpdatedAt, &c.SupersededBy, &retiredAt)
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("confirmed memory %d not found", id)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read confirmed memory %d: %w", id, err)
+		}
+		c.Repo = repoNull.String
+		if c.SupersededBy != 0 {
+			return nil, fmt.Errorf("confirmed memory %d is superseded", id)
+		}
+		if retiredAt != "" {
+			return nil, fmt.Errorf("confirmed memory %d is retired", id)
+		}
+
+		if c.Owner.Kind == memoryOwnerKindShared && c.Owner.Ref == memorySharedOwnerRef {
+			out = append(out, c)
+			continue
+		}
+		author := strings.TrimSpace(c.AuthorRef)
+		if author == "" {
+			author = c.Owner.Ref
+		}
+		if _, err := tx.ExecContext(ctx, `
+UPDATE confirmed_memories
+SET owner_kind = ?, owner_ref = ?, owner_version = '', author_ref = ?, updated_at = ?
+WHERE id = ?`,
+			memoryOwnerKindShared, memorySharedOwnerRef, author, now, id); err != nil {
+			return nil, fmt.Errorf("promote confirmed memory %d to shared: %w", id, err)
+		}
+		c.Owner = MemoryOwner{Kind: memoryOwnerKindShared, Ref: memorySharedOwnerRef}
+		c.AuthorRef = author
+		c.UpdatedAt = now
+		out = append(out, c)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // EnrichConfirmedMemoryLinks computes the deterministic top-K similarity links
@@ -473,11 +614,11 @@ func confirmedMemoryForLinkingTx(ctx context.Context, tx *sql.Tx, id int64) (Con
 	var c ConfirmedMemory
 	var repoNull sql.NullString
 	err := tx.QueryRowContext(ctx, `
-SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
 	provenance, source_job, first_confirmed_at, updated_at
 FROM confirmed_memories
 WHERE id = ? AND superseded_by IS NULL AND retired_at = ''`, id).Scan(
-		&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &repoNull,
+		&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
 		&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return ConfirmedMemory{}, false, nil
@@ -493,20 +634,29 @@ func queryMemoryLinkCandidatesTx(ctx context.Context, tx *sql.Tx, src ConfirmedM
 	if limit <= 0 {
 		limit = memoryAutoLinkK
 	}
+	own := src.Owner
+	if src.Owner.Kind == memoryOwnerKindShared && src.Owner.Ref == memorySharedOwnerRef {
+		if author := strings.TrimSpace(src.AuthorRef); author != "" {
+			own = MemoryOwner{Kind: memoryOwnerKindAgent, Ref: author}
+		}
+	}
 	rows, err := tx.QueryContext(ctx, `
 SELECT c.id, c.key, -bm25(f.confirmed_memories_fts) AS score,
 	EXISTS(SELECT 1 FROM memory_links ml WHERE ml.src_id = ? AND ml.dst_id = c.id) AS already_linked
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
 WHERE f.confirmed_memories_fts MATCH ?
-	AND c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?
+	AND ((c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?) OR (c.owner_kind = ? AND c.owner_ref = ?))
 	AND (c.scope = 'general' OR c.repo = ?)
 	AND c.superseded_by IS NULL
 	AND c.retired_at = ''
 	AND c.id <> ?
-ORDER BY bm25(f.confirmed_memories_fts), c.id
+ORDER BY bm25(f.confirmed_memories_fts),
+	CASE WHEN c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ? THEN 0 ELSE 1 END,
+	c.id
 LIMIT ?`,
-		src.ID, matchQuery, src.Owner.Kind, src.Owner.Ref, src.Owner.Version, src.Repo, src.ID, limit)
+		src.ID, matchQuery, own.Kind, own.Ref, own.Version, memoryOwnerKindShared, memorySharedOwnerRef,
+		src.Repo, src.ID, own.Kind, own.Ref, own.Version, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query memory link candidates: %w", err)
 	}
@@ -825,12 +975,16 @@ WHERE id = ? AND retired_at = ''`, now, it.Reason, it.ID)
 }
 
 // QueryConfirmedMemories is the READ path for job-prompt assembly. It runs one
-// FTS5/BM25 query over confirmed content, filtered by the retrieval default
-// (owner match AND (repo = current OR scope = general)), confirmed tier only,
-// and excludes superseded rows. matchQuery MUST be a sanitized MATCH string
-// (see internal/memory.SanitizeFTSQuery) — never raw job text. Results are
-// ranked by BM25 (ascending; lower is more relevant) then recency, capped by
-// limit. An empty matchQuery returns no rows (no block).
+// FTS5/BM25 query over confirmed content, filtered by the retrieval default:
+// the running agent's private pool UNION the reserved shared pool, then
+// (repo = current OR scope = general), confirmed tier only, and active rows
+// only. matchQuery MUST be a sanitized MATCH string (see
+// internal/memory.SanitizeFTSQuery) — never raw job text. Results are ranked by
+// BM25 (ascending; lower is more relevant), then private facts before shared on
+// an equal BM25 score, then recency, capped by limit. After SQL ranking, a
+// deterministic floor protects private memory: if private matches exist but the
+// limit slice contains only shared rows, the weakest shared row is swapped for
+// the strongest private row.
 func (s *Store) QueryConfirmedMemories(ctx context.Context, owner MemoryOwner, repo, matchQuery string, limit int) ([]ConfirmedMemory, error) {
 	if strings.TrimSpace(matchQuery) == "" {
 		return nil, nil
@@ -839,23 +993,30 @@ func (s *Store) QueryConfirmedMemories(ctx context.Context, owner MemoryOwner, r
 		limit = 15
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
 WHERE f.confirmed_memories_fts MATCH ?
-	AND c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?
+	AND ((c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?) OR (c.owner_kind = ? AND c.owner_ref = ?))
 	AND (c.scope = 'general' OR c.repo = ?)
 	AND c.superseded_by IS NULL
 	AND c.retired_at = ''
-ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC
+ORDER BY bm25(f.confirmed_memories_fts),
+	CASE WHEN c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ? THEN 0 ELSE 1 END,
+	c.updated_at DESC, c.id DESC
 LIMIT ?`,
-		matchQuery, owner.Kind, owner.Ref, owner.Version, repo, limit)
+		matchQuery, owner.Kind, owner.Ref, owner.Version, memoryOwnerKindShared, memorySharedOwnerRef, repo,
+		owner.Kind, owner.Ref, owner.Version, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query confirmed memories: %w", err)
 	}
 	defer rows.Close()
-	return scanConfirmedMemories(rows)
+	out, err := scanConfirmedMemories(rows)
+	if err != nil {
+		return nil, err
+	}
+	return s.ensureOwnMemoryFloor(ctx, owner, repo, matchQuery, limit, true, out)
 }
 
 // QueryConfirmedMemoriesForOwnerAllRepos is the recall variant for a single
@@ -870,28 +1031,97 @@ func (s *Store) QueryConfirmedMemoriesForOwnerAllRepos(ctx context.Context, owne
 		limit = 15
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
+	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
+FROM confirmed_memories_fts f
+JOIN confirmed_memories c ON c.id = f.rowid
+WHERE f.confirmed_memories_fts MATCH ?
+	AND ((c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?) OR (c.owner_kind = ? AND c.owner_ref = ?))
+	AND c.superseded_by IS NULL
+	AND c.retired_at = ''
+ORDER BY bm25(f.confirmed_memories_fts),
+	CASE WHEN c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ? THEN 0 ELSE 1 END,
+	c.updated_at DESC, c.id DESC
+LIMIT ?`,
+		matchQuery, owner.Kind, owner.Ref, owner.Version, memoryOwnerKindShared, memorySharedOwnerRef,
+		owner.Kind, owner.Ref, owner.Version, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query confirmed memories for owner all repos: %w", err)
+	}
+	defer rows.Close()
+	out, err := scanConfirmedMemories(rows)
+	if err != nil {
+		return nil, err
+	}
+	return s.ensureOwnMemoryFloor(ctx, owner, "", matchQuery, limit, false, out)
+}
+
+func (s *Store) ensureOwnMemoryFloor(ctx context.Context, owner MemoryOwner, repo, matchQuery string, limit int, filterRepo bool, rows []ConfirmedMemory) ([]ConfirmedMemory, error) {
+	if len(rows) == 0 || limit <= 0 {
+		return rows, nil
+	}
+	hasOwn := false
+	weakestShared := -1
+	for i, r := range rows {
+		if r.Owner.Kind == owner.Kind && r.Owner.Ref == owner.Ref && r.Owner.Version == owner.Version {
+			hasOwn = true
+			break
+		}
+		if r.Owner.Kind == memoryOwnerKindShared {
+			weakestShared = i
+		}
+	}
+	if hasOwn || weakestShared < 0 {
+		return rows, nil
+	}
+	own, ok, err := s.queryStrongestOwnMemory(ctx, owner, repo, matchQuery, filterRepo)
+	if err != nil || !ok {
+		return rows, err
+	}
+	if len(rows) < limit {
+		return append(rows, own), nil
+	}
+	rows[weakestShared] = own
+	return rows, nil
+}
+
+func (s *Store) queryStrongestOwnMemory(ctx context.Context, owner MemoryOwner, repo, matchQuery string, filterRepo bool) (ConfirmedMemory, bool, error) {
+	query := `
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
 WHERE f.confirmed_memories_fts MATCH ?
 	AND c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?
 	AND c.superseded_by IS NULL
-	AND c.retired_at = ''
-ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC
-LIMIT ?`,
-		matchQuery, owner.Kind, owner.Ref, owner.Version, limit)
+	AND c.retired_at = ''`
+	args := []any{matchQuery, owner.Kind, owner.Ref, owner.Version}
+	if filterRepo {
+		query += "\n\tAND (c.scope = 'general' OR c.repo = ?)"
+		args = append(args, repo)
+	}
+	query += `
+ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC, c.id DESC
+LIMIT 1`
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("query confirmed memories for owner all repos: %w", err)
+		return ConfirmedMemory{}, false, fmt.Errorf("query strongest own memory: %w", err)
 	}
 	defer rows.Close()
-	return scanConfirmedMemories(rows)
+	matches, err := scanConfirmedMemories(rows)
+	if err != nil {
+		return ConfirmedMemory{}, false, err
+	}
+	if len(matches) == 0 {
+		return ConfirmedMemory{}, false, nil
+	}
+	return matches[0], true, nil
 }
 
 // QueryConfirmedMemoriesForAllAgents is the read-only recall path for sessions
 // that are not running as a specific Gitmoot agent. It uses the same FTS5/BM25
-// ranking as QueryConfirmedMemories, but searches every agent owner pool instead
-// of one owner_ref. A non-empty repo applies the same repo/general visibility
+// ranking as QueryConfirmedMemories, but searches every agent owner pool plus
+// the shared pool. A non-empty repo applies the same repo/general visibility
 // filter as injection; an empty repo searches every repo and general facts. Role
 // pools remain excluded.
 func (s *Store) QueryConfirmedMemoriesForAllAgents(ctx context.Context, repo, matchQuery string, limit int) ([]ConfirmedMemory, error) {
@@ -902,15 +1132,15 @@ func (s *Store) QueryConfirmedMemoriesForAllAgents(ctx context.Context, repo, ma
 		limit = 15
 	}
 	query := `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
 WHERE f.confirmed_memories_fts MATCH ?
-	AND c.owner_kind = 'agent'
+	AND (c.owner_kind = 'agent' OR (c.owner_kind = 'shared' AND c.owner_ref = 'shared'))
 	AND c.superseded_by IS NULL
 	AND c.retired_at = ''
-ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC
+ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC, c.id DESC
 LIMIT ?`
 	args := []any{matchQuery}
 	if strings.TrimSpace(repo) != "" {
@@ -921,6 +1151,40 @@ LIMIT ?`
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("query confirmed memories for all agents: %w", err)
+	}
+	defer rows.Close()
+	return scanConfirmedMemories(rows)
+}
+
+// QueryConfirmedMemoriesForShared returns active confirmed rows from only the
+// reserved shared pool. It backs `memory recall --shared`.
+func (s *Store) QueryConfirmedMemoriesForShared(ctx context.Context, repo, matchQuery string, limit int) ([]ConfirmedMemory, error) {
+	if strings.TrimSpace(matchQuery) == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 15
+	}
+	query := `
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
+	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
+FROM confirmed_memories_fts f
+JOIN confirmed_memories c ON c.id = f.rowid
+WHERE f.confirmed_memories_fts MATCH ?
+	AND c.owner_kind = 'shared' AND c.owner_ref = 'shared'
+	AND c.superseded_by IS NULL
+	AND c.retired_at = ''
+ORDER BY bm25(f.confirmed_memories_fts), c.updated_at DESC, c.id DESC
+LIMIT ?`
+	args := []any{matchQuery}
+	if strings.TrimSpace(repo) != "" {
+		query = strings.Replace(query, "\n\tAND c.superseded_by IS NULL", "\n\tAND (c.scope = 'general' OR c.repo = ?)\n\tAND c.superseded_by IS NULL", 1)
+		args = append(args, strings.TrimSpace(repo))
+	}
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query confirmed memories for shared: %w", err)
 	}
 	defer rows.Close()
 	return scanConfirmedMemories(rows)
@@ -949,14 +1213,14 @@ type rowsQuerier interface {
 // (via a *sql.Tx) without duplicating the query.
 func listConfirmedMemoriesForVault(ctx context.Context, q rowsQuerier, agentRef string) ([]ConfirmedMemory, error) {
 	query := `
-SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
 FROM confirmed_memories
 WHERE superseded_by IS NULL AND retired_at = ''`
 	var args []any
 	if strings.TrimSpace(agentRef) != "" {
-		query += "\n\tAND owner_kind = 'agent' AND owner_ref = ?"
-		args = append(args, agentRef)
+		query += "\n\tAND ((owner_kind = 'agent' AND owner_ref = ?) OR (owner_kind = 'shared' AND owner_ref = 'shared' AND author_ref = ?))"
+		args = append(args, agentRef, agentRef)
 	}
 	query += "\nORDER BY id"
 	rows, err := q.QueryContext(ctx, query, args...)
@@ -968,7 +1232,7 @@ WHERE superseded_by IS NULL AND retired_at = ''`
 	for rows.Next() {
 		var c ConfirmedMemory
 		var repoNull sql.NullString
-		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &repoNull,
+		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
 			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
 			return nil, err
 		}
@@ -995,17 +1259,21 @@ func (s *Store) QueryConfirmedMemoryVaultLinks(ctx context.Context, owner Memory
 		limit = 6
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
 WHERE f.confirmed_memories_fts MATCH ?
-	AND c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?
+	AND ((c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ?) OR (c.owner_kind = ? AND c.owner_ref = ?))
 	AND (c.scope = 'general' OR c.repo = ?)
 	AND c.superseded_by IS NULL
-ORDER BY bm25(f.confirmed_memories_fts), c.id
+	AND c.retired_at = ''
+ORDER BY bm25(f.confirmed_memories_fts),
+	CASE WHEN c.owner_kind = ? AND c.owner_ref = ? AND c.owner_version = ? THEN 0 ELSE 1 END,
+	c.id
 LIMIT ?`,
-		matchQuery, owner.Kind, owner.Ref, owner.Version, repo, limit)
+		matchQuery, owner.Kind, owner.Ref, owner.Version, memoryOwnerKindShared, memorySharedOwnerRef, repo,
+		owner.Kind, owner.Ref, owner.Version, limit)
 	if err != nil {
 		return nil, fmt.Errorf("query confirmed memory vault links: %w", err)
 	}
@@ -1020,15 +1288,15 @@ func (s *Store) ListConfirmedMemories(ctx context.Context, ownerRef, repo string
 	var where []string
 	var args []any
 	if strings.TrimSpace(ownerRef) != "" {
-		where = append(where, "owner_ref = ?")
-		args = append(args, ownerRef)
+		where = append(where, "(owner_ref = ? OR author_ref = ?)")
+		args = append(args, ownerRef, ownerRef)
 	}
 	if strings.TrimSpace(repo) != "" {
 		where = append(where, "(repo = ? OR scope = 'general')")
 		args = append(args, repo)
 	}
 	query := `
-SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
 	provenance, source_job, first_confirmed_at, updated_at
 FROM confirmed_memories`
 	if len(where) > 0 {
@@ -1062,15 +1330,15 @@ func (s *Store) ListMemoryObservations(ctx context.Context, ownerRef, repo strin
 	where := []string{"provenance NOT LIKE ? ESCAPE '\\'"}
 	args := []any{likePrefix(MemoryDistillWitnessProvenancePrefix)}
 	if strings.TrimSpace(ownerRef) != "" {
-		where = append(where, "owner_ref = ?")
-		args = append(args, ownerRef)
+		where = append(where, "(owner_ref = ? OR author_ref = ?)")
+		args = append(args, ownerRef, ownerRef)
 	}
 	if strings.TrimSpace(repo) != "" {
 		where = append(where, "(repo = ? OR scope = 'general')")
 		args = append(args, repo)
 	}
 	query := `
-SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
 	provenance, trust_mark, source_job, created_at
 FROM memory_observations`
 	if len(where) > 0 {
@@ -1086,7 +1354,7 @@ FROM memory_observations`
 	for rows.Next() {
 		var o MemoryObservation
 		var repoNull sql.NullString
-		if err := rows.Scan(&o.ID, &o.Owner.Kind, &o.Owner.Ref, &o.Owner.Version, &repoNull,
+		if err := rows.Scan(&o.ID, &o.Owner.Kind, &o.Owner.Ref, &o.Owner.Version, &o.AuthorRef, &repoNull,
 			&o.Scope, &o.Key, &o.Content, &o.Provenance, &o.TrustMark, &o.SourceJob, &o.CreatedAt); err != nil {
 			return nil, err
 		}
@@ -1101,7 +1369,7 @@ func scanConfirmedMemories(rows *sql.Rows) ([]ConfirmedMemory, error) {
 	for rows.Next() {
 		var c ConfirmedMemory
 		var repoNull sql.NullString
-		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &repoNull,
+		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
 			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
@@ -1137,20 +1405,26 @@ func (s *Store) ListMemoryObservationsWithConfirmation(ctx context.Context, owne
 	where := []string{"o.provenance NOT LIKE ? ESCAPE '\\'"}
 	args := []any{likePrefix(MemoryDistillWitnessProvenancePrefix)}
 	if strings.TrimSpace(ownerRef) != "" {
-		where = append(where, "o.owner_ref = ?")
-		args = append(args, ownerRef)
+		where = append(where, "(o.owner_ref = ? OR o.author_ref = ?)")
+		args = append(args, ownerRef, ownerRef)
 	}
 	if strings.TrimSpace(provenancePrefix) != "" {
 		where = append(where, "o.provenance LIKE ? ESCAPE '\\'")
 		args = append(args, likePrefix(provenancePrefix))
 	}
 	query := `
-SELECT o.id, o.owner_kind, o.owner_ref, o.owner_version, o.repo, o.scope, o.key,
+SELECT o.id, o.owner_kind, o.owner_ref, o.owner_version, o.author_ref, o.repo, o.scope, o.key,
 	o.content, o.provenance, o.trust_mark, o.source_job, o.created_at,
 	EXISTS(
 		SELECT 1 FROM confirmed_memories c
-		WHERE c.owner_kind = o.owner_kind AND c.owner_ref = o.owner_ref
-			AND c.owner_version = o.owner_version
+		WHERE ((
+				c.owner_kind = o.owner_kind AND c.owner_ref = o.owner_ref
+					AND c.owner_version = o.owner_version
+			) OR (
+				c.owner_kind = 'shared'
+					AND (CASE WHEN c.author_ref <> '' THEN c.author_ref ELSE c.owner_ref END) =
+						(CASE WHEN o.author_ref <> '' THEN o.author_ref ELSE o.owner_ref END)
+			))
 			AND ((o.repo IS NULL AND c.repo IS NULL) OR c.repo = o.repo)
 			AND c.key = o.key
 	) AS confirmed
@@ -1169,7 +1443,7 @@ FROM memory_observations o`
 		var o ObservationWithConfirmation
 		var repoNull sql.NullString
 		var confirmed int
-		if err := rows.Scan(&o.ID, &o.Owner.Kind, &o.Owner.Ref, &o.Owner.Version, &repoNull,
+		if err := rows.Scan(&o.ID, &o.Owner.Kind, &o.Owner.Ref, &o.Owner.Version, &o.AuthorRef, &repoNull,
 			&o.Scope, &o.Key, &o.Content, &o.Provenance, &o.TrustMark, &o.SourceJob, &o.CreatedAt, &confirmed); err != nil {
 			return nil, err
 		}
@@ -1189,11 +1463,11 @@ func (s *Store) GetMemoryObservationByID(ctx context.Context, id int64) (MemoryO
 	// `memory confirm <witness-id>` resolves to "no observation with id N" rather
 	// than promoting the fixed sentinel string into confirmed memory.
 	err := s.db.QueryRowContext(ctx, `
-SELECT id, owner_kind, owner_ref, owner_version, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
 	provenance, trust_mark, source_job, created_at
 FROM memory_observations WHERE id = ? AND provenance NOT LIKE ? ESCAPE '\'`,
 		id, likePrefix(MemoryDistillWitnessProvenancePrefix)).Scan(
-		&o.ID, &o.Owner.Kind, &o.Owner.Ref, &o.Owner.Version, &repoNull,
+		&o.ID, &o.Owner.Kind, &o.Owner.Ref, &o.Owner.Version, &o.AuthorRef, &repoNull,
 		&o.Scope, &o.Key, &o.Content, &o.Provenance, &o.TrustMark, &o.SourceJob, &o.CreatedAt)
 	if err == sql.ErrNoRows {
 		return MemoryObservation{}, false, nil

--- a/internal/db/memory_store_test.go
+++ b/internal/db/memory_store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -210,6 +211,183 @@ func TestQueryConfirmedTierFilterExcludesOtherRepo(t *testing.T) {
 	if !keys["kg"] {
 		t.Fatalf("want general fact kg to travel into repo-A retrieval, got %v", keys)
 	}
+}
+
+func TestQueryConfirmedIncludesSharedWithOwnTieBreakAndPrivateIsolation(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	lead := agentOwner("lead")
+	audit := agentOwner("audit")
+	shared := MemoryOwner{Kind: memoryOwnerKindShared, Ref: memorySharedOwnerRef}
+
+	mustUpsert(t, store, ConfirmedMemory{
+		Owner: lead, Repo: "acme/widget", Scope: "repo", Key: "lead-private",
+		Content: "aurora tie token", UpdatedAt: "2026-01-01T00:00:00Z",
+	})
+	mustUpsert(t, store, ConfirmedMemory{
+		Owner: shared, AuthorRef: "lead", Repo: "acme/widget", Scope: "repo", Key: "shared-fact",
+		Content: "aurora tie token",
+	})
+	mustUpsert(t, store, ConfirmedMemory{
+		Owner: audit, Repo: "acme/widget", Scope: "repo", Key: "audit-private",
+		Content: "aurora tie token",
+	})
+
+	leadRows, err := store.QueryConfirmedMemories(ctx, lead, "acme/widget", `"aurora" OR "token"`, 10)
+	if err != nil {
+		t.Fatalf("query lead: %v", err)
+	}
+	keys := keysOf(leadRows)
+	if len(leadRows) < 2 || leadRows[0].Key != "lead-private" {
+		t.Fatalf("own row must outrank shared on equal BM25, got keys %v", keys)
+	}
+	if !containsKey(leadRows, "shared-fact") {
+		t.Fatalf("lead should see shared fact, got %v", keys)
+	}
+	if containsKey(leadRows, "audit-private") {
+		t.Fatalf("lead must not see audit private fact, got %v", keys)
+	}
+
+	auditRows, err := store.QueryConfirmedMemories(ctx, audit, "acme/widget", `"aurora" OR "token"`, 10)
+	if err != nil {
+		t.Fatalf("query audit: %v", err)
+	}
+	if !containsKey(auditRows, "audit-private") || !containsKey(auditRows, "shared-fact") {
+		t.Fatalf("audit should see its private fact plus shared, got %v", keysOf(auditRows))
+	}
+	if containsKey(auditRows, "lead-private") {
+		t.Fatalf("audit must not see lead private fact, got %v", keysOf(auditRows))
+	}
+}
+
+func TestQueryConfirmedOwnFloorSwapsWeakestShared(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	lead := agentOwner("lead")
+	shared := MemoryOwner{Kind: memoryOwnerKindShared, Ref: memorySharedOwnerRef}
+
+	for i := 0; i < 3; i++ {
+		mustUpsert(t, store, ConfirmedMemory{
+			Owner: shared, AuthorRef: "lead", Repo: "acme/widget", Scope: "repo",
+			Key:     fmt.Sprintf("shared-%d", i),
+			Content: "quasar quasar quasar quasar vector",
+		})
+	}
+	mustUpsert(t, store, ConfirmedMemory{
+		Owner: lead, Repo: "acme/widget", Scope: "repo", Key: "lead-floor",
+		Content: "quasar vector",
+	})
+
+	got, err := store.QueryConfirmedMemories(ctx, lead, "acme/widget", `"quasar" OR "vector"`, 1)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 1 || got[0].Key != "lead-floor" {
+		t.Fatalf("own-floor should return the strongest private row at limit=1, got %+v", got)
+	}
+}
+
+func TestPromoteConfirmedMemoryToSharedPreservesLinksAndAuthor(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("lead")
+
+	target := mustUpsert(t, store, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "target", Content: "aurora quartz vector hnsw planner calibration checklist",
+	})
+	src := mustUpsert(t, store, ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo",
+		Key: "source", Content: "aurora quartz vector hnsw planner calibration",
+	})
+	before, err := store.ListMemoryLinks(ctx, src)
+	if err != nil {
+		t.Fatalf("links before: %v", err)
+	}
+	if len(before) == 0 || before[0].DstID != target {
+		t.Fatalf("expected source to auto-link to target before promote, got %+v", before)
+	}
+
+	rows, err := store.PromoteConfirmedMemoriesToShared(ctx, []int64{src})
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Owner.Kind != memoryOwnerKindShared || rows[0].Owner.Ref != memorySharedOwnerRef || rows[0].AuthorRef != "lead" {
+		t.Fatalf("promoted row did not preserve author/shared owner: %+v", rows)
+	}
+	after, err := store.ListMemoryLinks(ctx, src)
+	if err != nil {
+		t.Fatalf("links after: %v", err)
+	}
+	if len(after) != len(before) || after[0].DstID != target {
+		t.Fatalf("promote must preserve memory_links rows, before=%+v after=%+v", before, after)
+	}
+}
+
+func TestMemoryAuthorRefMigrationAppliesToPopulatedDB(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "pre777.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql open: %v", err)
+	}
+	raw.SetMaxOpenConns(1)
+	raw.SetMaxIdleConns(1)
+	if err := configureWritableSQLite(ctx, raw); err != nil {
+		t.Fatalf("configure sqlite: %v", err)
+	}
+	store := &Store{db: raw}
+	t.Cleanup(func() { _ = store.Close() })
+
+	for i := 0; i < len(migrations)-1; i++ {
+		if err := store.applyMigration(ctx, i+1, migrations[i]); err != nil {
+			t.Fatalf("apply pre-777 migration %d: %v", i+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `
+INSERT INTO confirmed_memories (owner_kind, owner_ref, owner_version, repo, scope, key, content, provenance, source_job)
+VALUES ('agent', 'lead', '', 'acme/widget', 'repo', 'k', 'legacy populated fact', 'seed', 'job-1');
+INSERT INTO confirmed_memories_fts(rowid, content, key) VALUES (last_insert_rowid(), 'legacy populated fact', 'k');
+INSERT INTO memory_observations (owner_kind, owner_ref, owner_version, repo, scope, key, content, provenance, trust_mark, source_job)
+VALUES ('agent', 'lead', '', 'acme/widget', 'repo', 'o', 'legacy populated observation', 'seed', 'normal', 'job-1');
+`); err != nil {
+		t.Fatalf("seed legacy memory rows: %v", err)
+	}
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("migrate latest: %v", err)
+	}
+	rows, err := store.QueryConfirmedMemories(ctx, agentOwner("lead"), "acme/widget", `"legacy"`, 5)
+	if err != nil {
+		t.Fatalf("query migrated confirmed: %v", err)
+	}
+	if len(rows) != 1 || rows[0].AuthorRef != "" {
+		t.Fatalf("legacy confirmed author_ref should default empty, got %+v", rows)
+	}
+	obs, err := store.ListMemoryObservations(ctx, "lead", "acme/widget")
+	if err != nil {
+		t.Fatalf("list migrated observations: %v", err)
+	}
+	if len(obs) != 1 || obs[0].AuthorRef != "" {
+		t.Fatalf("legacy observation author_ref should default empty, got %+v", obs)
+	}
+}
+
+func keysOf(rows []ConfirmedMemory) []string {
+	keys := make([]string, 0, len(rows))
+	for _, r := range rows {
+		keys = append(keys, r.Key)
+	}
+	return keys
+}
+
+func containsKey(rows []ConfirmedMemory, key string) bool {
+	for _, r := range rows {
+		if r.Key == key {
+			return true
+		}
+	}
+	return false
 }
 
 // TestObservationsAppendNotUpsert proves repeated observations of the same key

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -8305,4 +8305,15 @@ CREATE TABLE memory_links (
 );
 CREATE INDEX idx_memory_links_dst ON memory_links(dst_id);
 	`,
+	// #777 shared memory pool author preservation. Moving a confirmed fact into
+	// the reserved shared pool changes owner_kind/owner_ref, but the dashboard and
+	// vault still need to know who wrote the fact. author_ref is empty for legacy
+	// and private rows, where author == owner_ref, and is populated only when the
+	// author differs from the current pool owner. Observations get the same column
+	// so `memory ingest --shared` can stage shared observations while preserving the
+	// authoring agent. ALTER ADD COLUMN only; existing rows read byte-identically.
+	`
+ALTER TABLE confirmed_memories ADD COLUMN author_ref TEXT NOT NULL DEFAULT '';
+ALTER TABLE memory_observations ADD COLUMN author_ref TEXT NOT NULL DEFAULT '';
+	`,
 }

--- a/internal/memory/frontmatter.go
+++ b/internal/memory/frontmatter.go
@@ -124,6 +124,7 @@ func (f VaultNoteFile) VaultMemory() VaultMemory {
 		OwnerKind:    f.String("owner_kind"),
 		OwnerRef:     f.String("owner_ref"),
 		OwnerVersion: f.String("owner_version"),
+		AuthorRef:    f.String("author"),
 		Repo:         f.String("repo"),
 		Scope:        f.String("scope"),
 		Key:          f.String("key"),

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -24,9 +24,13 @@ const (
 
 // Owner kind values. An agent owner is a registered persistent agent; a role
 // owner is an ephemeral role pool keyed by template identity (Phase 2+ writers).
+// The shared owner is a reserved, explicit human-curated pool that every agent
+// can read alongside its own private pool.
 const (
-	OwnerKindAgent = "agent"
-	OwnerKindRole  = "role"
+	OwnerKindAgent  = "agent"
+	OwnerKindRole   = "role"
+	OwnerKindShared = "shared"
+	SharedOwnerRef  = "shared"
 )
 
 // Trust marks recorded on an observation at birth. A learning derived from

--- a/internal/memory/vault.go
+++ b/internal/memory/vault.go
@@ -30,6 +30,7 @@ type VaultMemory struct {
 	OwnerKind    string
 	OwnerRef     string
 	OwnerVersion string
+	AuthorRef    string
 	Repo         string // "" == general scope
 	Scope        string
 	Key          string
@@ -111,6 +112,9 @@ func RenderVaultNote(m VaultMemory, links []VaultLink) string {
 	fields := make([]field, 0, 13)
 	if m.OwnerKind == OwnerKindAgent {
 		fields = append(fields, field{"agent", yamlScalar(m.OwnerRef)})
+	}
+	if strings.TrimSpace(m.AuthorRef) != "" {
+		fields = append(fields, field{"author", yamlScalar(m.AuthorRef)})
 	}
 	fields = append(fields,
 		field{"created_at", yamlScalar(m.CreatedAt)},

--- a/internal/memory/vault_test.go
+++ b/internal/memory/vault_test.go
@@ -7,14 +7,14 @@ import (
 
 func TestSlugIsLowercaseAndFilesystemSafe(t *testing.T) {
 	cases := map[string]string{
-		"CI Flake":                 "ci-flake",
-		"arm64/CI is flaky!":       "arm64-ci-is-flaky",
-		"   spaced   out   ":       "spaced-out",
-		"":                         "untitled",
-		"!!!":                      "untitled",
-		"Already-Slugged":          "already-slugged",
-		"weird__under..scores":     "weird-under-scores",
-		"CI-FLAKE":                 "ci-flake", // same slug as "CI Flake" — id prefix disambiguates
+		"CI Flake":             "ci-flake",
+		"arm64/CI is flaky!":   "arm64-ci-is-flaky",
+		"   spaced   out   ":   "spaced-out",
+		"":                     "untitled",
+		"!!!":                  "untitled",
+		"Already-Slugged":      "already-slugged",
+		"weird__under..scores": "weird-under-scores",
+		"CI-FLAKE":             "ci-flake", // same slug as "CI Flake" — id prefix disambiguates
 	}
 	for in, want := range cases {
 		if got := Slug(in); got != want {
@@ -82,6 +82,28 @@ func TestRenderVaultNoteRoleOwnerHasNoAgentField(t *testing.T) {
 	got := RenderVaultNote(m, nil)
 	if strings.Contains(got, "agent:") {
 		t.Fatalf("role owner must not emit an agent field:\n%s", got)
+	}
+}
+
+func TestRenderVaultNoteIncludesAuthorWhenPreserved(t *testing.T) {
+	m := VaultMemory{
+		ID: 2, OwnerKind: OwnerKindShared, OwnerRef: SharedOwnerRef, AuthorRef: "lead",
+		Scope: ScopeRepo, Repo: "acme/widget", Key: "shared-fact", Content: "shared content",
+		UpdatedAt: "t",
+	}
+	got := RenderVaultNote(m, nil)
+	if !strings.Contains(got, "author: \"lead\"") {
+		t.Fatalf("shared note must include preserved author frontmatter:\n%s", got)
+	}
+	if strings.Contains(got, "agent:") {
+		t.Fatalf("shared owner must not emit agent frontmatter:\n%s", got)
+	}
+	parsed, err := ParseVaultNote(got)
+	if err != nil {
+		t.Fatalf("parse rendered note: %v", err)
+	}
+	if parsed.VaultMemory().AuthorRef != "lead" {
+		t.Fatalf("parsed author = %q, want lead", parsed.VaultMemory().AuthorRef)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1614,7 +1614,7 @@ Inspect, curate, and measure the store:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
-gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
@@ -1626,16 +1626,27 @@ gitmoot memory links list <id> [--json]
 `memory list` shows confirmed memories and/or pending observations. `memory
 recall` runs the same FTS5/BM25 confirmed-memory retrieval used for prompt
 injection and prints the matching facts in injection bullet format. Without
-`--agent`, recall searches all agent owner pools; pass `--agent NAME` to inspect
-one pool. Without `--repo`, recall searches every repo and general-scope facts.
-`--repo owner/repo` narrows repo-scoped facts to that repo while still including
-general-scope facts. `--json` returns raw rows for scripts. `memory replay` is an offline A/B:
+`--agent`, recall searches all agent owner pools plus the shared pool; pass
+`--agent NAME` to inspect that agent's private pool plus shared, or `--shared`
+to inspect only shared facts. Without `--repo`, recall searches every repo and
+general-scope facts. `--repo owner/repo` narrows repo-scoped facts to that repo
+while still including general-scope facts. `--json` returns raw rows for scripts,
+including `author_ref` when a shared fact preserves a different author. `memory replay` is an offline A/B:
 it re-renders recent real jobs' prompts with and
 without the learnings block and reports the injection delta (added tokens,
 entries injected) — it measures injection *mechanics*, not outcome quality
 (running real agents twice is a later-phase gate). `memory eval` computes
 recall/precision@K of retrieval over a labeled fixtures file whose cases are
 `{agent, repo, instructions, expected_keys}`.
+
+Confirmed-memory injection reads the running agent's private pool unioned with
+the reserved shared pool (`owner_kind=shared`, `owner_ref=shared`). BM25 relevance
+still ranks first. On an equal BM25 score, the agent's private facts outrank
+shared facts, then `updated_at DESC` breaks ties. A small floor guard keeps a
+matching private fact from being completely starved by a tight limit full of
+shared rows. Entry into shared is always explicit and human-driven: use
+`memory promote --to-shared`, `memory ingest --shared`, or
+`memory confirm --to-shared`; daemon producers never auto-share facts.
 
 `memory vault export` renders confirmed memory as a **disposable, Obsidian-compatible
 vault view** (#737): one Markdown note per confirmed memory (sorted-key YAML
@@ -1645,10 +1656,13 @@ staleness anchor.
 It is a **view, not a replica**: the SQLite store stays the only source of truth,
 so the vault is regenerated from scratch on every export, is safe to delete, and
 is **deterministic** — the same store produces byte-identical files (there is no
-`exported_at`; filenames are stable `NNNNNNNNN-<slug>.md` from the memory id). The
+`exported_at`; filenames are stable `NNNNNNNNN-<slug>.md` from the memory id).
+Shared notes include an `author:` frontmatter line when `author_ref` is set, so
+moving a fact into shared does not reattribute it to the shared pool. The
 export is **read-only** (zero writes to any table) and writes to a temp dir then
 atomically renames over `--out` (default: a `vault/` directory under the home's
-evals area). `--agent NAME` narrows the export to one agent owner. Because the
+evals area). `--agent NAME` narrows the export to one agent owner and shared
+facts authored by that agent. Because the
 export **replaces `--out` wholesale**, it refuses to overwrite a non-empty directory
 that is not itself a prior gitmoot vault (one carrying a `manifest.json`) so an
 accidental `--out ~/my-obsidian-vault` can never delete your own notes; pass
@@ -1676,10 +1690,7 @@ otherwise be misread as a deletion and silently retire a live memory; fix the
 frontmatter (or delete the file to intentionally retire it) and re-export. A vault
 produced by `export --agent NAME` stays importable even when other owners have
 memories (import rebuilds the fresh export with the manifest's recorded scope). The
-`<DIR>` positional may appear before or after the flags. `memory ingest` (P3) lands in
-a later phase.
-`--force` to override. This is P1 of the two-way memory bridge; `vault import`
-(P2) lands separately.
+`<DIR>` positional may appear before or after the flags.
 
 ### Markdown ingest and the human confirm gate (#737 P3)
 
@@ -1689,9 +1700,10 @@ observations** behind the existing confirmation gate. It never writes confirmed
 (injectable) memory directly.
 
 ```sh
-gitmoot memory ingest <path|dir> --agent NAME [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
+gitmoot memory ingest <path|dir> --agent NAME [--shared] [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
-gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
+gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--to-shared] [--yes] [--json]
+gitmoot memory promote --to-shared <id>... [--json]
 gitmoot memory links backfill [--dry-run] [--json]
 gitmoot memory links list <id> [--json]
 ```
@@ -1711,8 +1723,9 @@ re-ingesting the same source inserts nothing — but the same note ingested unde
 second repo still stages, since repo-scoped memory injects only for its own repo.
 Surviving chunks land in `memory_observations` with `provenance = ingest:<relpath>`
 and, crucially, **`trust_mark = low`** — see the trust note below. `--tier` defaults
-to `repo`; `general` is only ever chosen with the explicit flag. `--dry-run`
-reports what would be staged without writing.
+to `repo`; `general` is only ever chosen with the explicit flag. `--shared`
+stages the observations in the shared pool while preserving `--agent NAME` as
+their author. `--dry-run` reports what would be staged without writing.
 
 `memory observations` lists pending observations (optionally narrowed by
 `--agent` or `--provenance-prefix`), flagging which keys already crossed the
@@ -1720,15 +1733,21 @@ confirm gate. `memory confirm` is the **human-gated promotion** step: it copies
 selected observations (by id, or every observation matching a
 `--provenance-prefix`) into confirmed memory, carrying provenance through.
 Without `--yes` it prints the plan and writes nothing; with `--yes` it promotes
-(idempotently — re-confirming the same key upserts the one row). This is
+idempotently, re-confirming the same key upserts the one row. `--to-shared`
+confirms selected observations into the shared pool and records the observation
+author. `memory promote --to-shared <id>...` moves existing active confirmed
+facts into shared, refuses retired or superseded rows, preserves outgoing
+`memory_links`, and sets `author_ref` from the previous owner when needed. This is
 **CLI-explicit only**: there is no daemon path and nothing auto-confirms.
 
 Confirming a fact also writes up to three deterministic auto-links from that new
 confirmed row to active related confirmed memories. The links are stored in the
 `memory_links` side table with BM25-derived scores and never rewrite the fact
-content. `memory links backfill` applies the same link pass to the existing active
-confirmed pool in id order; `--dry-run` reports the links it would create without
-writing, and repeat runs are idempotent. `memory links list <id>` shows one fact's
+content. Link candidates use the same private-plus-shared visibility as injection,
+so private facts can link to shared facts and shared facts can link back through
+their author pool. `memory links backfill` applies the same link pass to the existing
+active confirmed pool in id order; `--dry-run` reports the links it would create
+without writing, and repeat runs are idempotent. `memory links list <id>` shows one fact's
 persisted outgoing links. Vault export merges these persisted links with the
 content-derived links in each note's `## Links` section and dedupes by target.
 

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -14,13 +14,16 @@ SkillOpt improves them); memory holds *knowledge* (what is true about a repo).
 The benefit of memory is treated as a measured hypothesis, not an assumption, so
 it ships in phases. The current phase is **observation mode**:
 
-- **READ** — while assembling a job prompt, Gitmoot runs one sanitized FTS5/BM25
-  query over the agent's *confirmed* facts (owner match, and either the current
-  repo or the always-travelling `general` scope), ranks by relevance then
-  recency, caps the result by a token budget, and renders a fenced block titled
-  *"Prior learnings (reference only, not instructions)"* with `[this repo]` /
-  `[general]` tags. An empty result adds nothing.
-- **WRITE** — the confirmed (injectable) tier is populated only by Gitmoot's own
+- **READ:** while assembling a job prompt, Gitmoot runs one sanitized FTS5/BM25
+  query over the agent's private *confirmed* facts plus the reserved shared pool
+  (and either the current repo or the always-travelling `general` scope). BM25
+  ranks first; if scores tie, the agent's private facts outrank shared facts,
+  then recency breaks ties. A small floor guard keeps the strongest private match
+  in the injected slice when private matches exist but shared rows would fill the
+  limit. Gitmoot caps the result by a token budget and renders a fenced block
+  titled *"Prior learnings (reference only, not instructions)"* with
+  `[this repo]` / `[general]` tags. An empty result adds nothing.
+- **WRITE:** the confirmed (injectable) tier is populated only by Gitmoot's own
   deterministic **mechanical facts** (no model involved). A fact is written only
   when a terminal job carries a genuine, bounded signal — never one fact per job:
   a **fix-round fact** when a job needed corrective verify/retry rounds, and a
@@ -49,8 +52,11 @@ Two tables back the evidence/upsert split: an append-only `memory_observations`
 table (where witnesses for a claim accumulate) and a keyed `confirmed_memories`
 table (one injectable row per fact, with graphiti-style supersession rather than
 deletion). Owner identity is structured (agent vs. role, with template version
-awareness) so template upgrades never inherit stale pools. A standalone FTS5
-index over confirmed content powers the BM25 retrieval.
+awareness) so template upgrades never inherit stale pools. The reserved shared
+pool uses `owner_kind = "shared"` and `owner_ref = "shared"`. When a fact moves
+there, `author_ref` preserves who wrote it; an empty `author_ref` means the author
+is the same as `owner_ref`. A standalone FTS5 index over confirmed content powers
+the BM25 retrieval.
 
 ## Enrollment and configuration
 
@@ -108,17 +114,19 @@ All of the following are read-only:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo]
-gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N]
 gitmoot memory eval --fixtures fixtures.json [--k N]
 ```
 
 `memory list` shows confirmed memories and pending observations. `memory recall`
 is an on-demand relevance search over confirmed memory. It uses the same
-FTS5/BM25 retrieval as prompt injection, searches all agent pools by default,
-and can narrow to one pool with `--agent NAME`. Without `--repo`, recall
+FTS5/BM25 retrieval as prompt injection. By default it searches all agent pools
+plus the shared pool; `--agent NAME` searches that agent's private pool plus
+shared, and `--shared` searches only shared facts. Without `--repo`, recall
 searches every repo and general-scope facts. `--repo owner/repo` narrows
-repo-scoped facts to that repo while still including general-scope facts.
+repo-scoped facts to that repo while still including general-scope facts. JSON
+output includes `author_ref` when a shared fact preserves a different author.
 `memory replay` is an offline A/B: it re-renders recent real jobs' prompts with and without the
 learnings block and reports the injection delta (added tokens, entries injected)
 — it measures injection *mechanics*, not outcome quality. `memory eval` computes
@@ -135,6 +143,10 @@ gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
 one Markdown note per confirmed memory (sorted-key YAML frontmatter, the content
 verbatim, and a `## Links` section of FTS co-occurrence plus persisted
 `[[wikilinks]]`), a per-owner index note, and a `manifest.json` staleness anchor.
+Shared notes include an `author:` frontmatter line when `author_ref` is set, so a
+fact moved into shared still points graph tooling at the real author. `--agent NAME`
+narrows the export to that agent's private facts plus shared facts authored by
+that agent.
 
 The vault is a **view, not a replica**: SQLite stays the *only* source of truth,
 so the export never becomes a second store to keep in sync. It is regenerated
@@ -176,6 +188,7 @@ observations in **one transaction** (all-or-nothing). If any note fails to parse
 otherwise be misread as a deletion and silently retire a live memory. A vault
 produced by `export --agent NAME` stays importable even when other owners have
 memories, because import rebuilds the fresh export with the manifest's recorded scope.
+
 ## Markdown ingest and the human confirm gate
 
 The vault export is the bridge's *outlet*; `memory ingest` is its *mouth*. It
@@ -184,9 +197,10 @@ it as **pending observations** behind the existing confirmation gate — it neve
 writes injectable memory directly.
 
 ```sh
-gitmoot memory ingest <path|dir> --agent NAME [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
+gitmoot memory ingest <path|dir> --agent NAME [--shared] [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
-gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
+gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--to-shared] [--yes] [--json]
+gitmoot memory promote --to-shared <id>... [--json]
 gitmoot memory links backfill [--dry-run] [--json]
 gitmoot memory links list <id> [--json]
 ```
@@ -205,23 +219,31 @@ already exists **in the same visibility domain** (same scope and repo) is
 under a second repo still stages, because repo-scoped memory injects only for its
 own repo. Survivors land in `memory_observations` with
 `provenance = ingest:<relpath>` and `trust_mark = low`. `--dry-run` reports the
-plan without writing.
+plan without writing. `--shared` stages observations in the shared pool and
+records `--agent NAME` as the authoring identity.
 
 `memory observations` lists pending observations, flagging which have already
 been confirmed. `memory confirm` is the **human-gated promotion**: it copies
 selected observations (by id, or every one matching a `--provenance-prefix`) into
 confirmed memory, carrying provenance through. Without `--yes` it prints the plan
 and writes nothing; with `--yes` it promotes idempotently. It is **CLI-explicit
-only** — no daemon path, no auto-confirm.
+only**: no daemon path, no auto-confirm. `--to-shared` confirms selected
+observations into the shared pool while preserving the observation author.
+`memory promote --to-shared <id>...` moves active confirmed facts into shared,
+refuses retired or superseded rows, preserves existing links, and stamps
+`author_ref` from the previous owner when needed.
 
 When a fact is confirmed, Gitmoot also records up to three deterministic outgoing
 links from that confirmed row to active related confirmed memories. These links
 live in the `memory_links` side table with BM25-derived scores. They do not rewrite
-the memory's content. `memory links backfill` runs the same pass over all active
-confirmed memories in id order; `--dry-run` reports what would be created, and
-repeat runs create nothing new. `memory links list <id>` inspects a fact's
-persisted outgoing links. Vault export merges persisted links with content-derived
-links in each note's `## Links` section and removes duplicates by target.
+the memory's content. Link candidates use the same private-plus-shared visibility
+as prompt injection, so private facts can link to shared facts and shared facts
+can link back through their author pool. `memory links backfill` runs the same
+pass over all active confirmed memories in id order; `--dry-run` reports what
+would be created, and repeat runs create nothing new. `memory links list <id>`
+inspects a fact's persisted outgoing links. Vault export merges persisted links
+with content-derived links in each note's `## Links` section and removes
+duplicates by target.
 
 :::warning Ingested Markdown is untrusted
 Ingested Markdown is an **indirect-prompt-injection vector**. Ingest stamps
@@ -313,6 +335,6 @@ The dashboard Knowledge view renders this as a **repo → cluster → fact** hie
   facts, shadow writes, and the measurement harness above.
 - **Phase 2** — live agent writes, the confirmation protocol (witness counting +
   a cheap curation judge), curation, general-tier promotion governance, and the
-  full audit CLI (`forget`, `promote`).
+  remaining audit CLI.
 - **Phase 3** — an optional hybrid vector-retrieval leg, added only if the
   Phase-1/2 metrics show BM25 word-matching misses.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1339,14 +1339,15 @@ gate:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
-gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
 gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
-gitmoot memory ingest <path|dir> --agent NAME [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
+gitmoot memory ingest <path|dir> --agent NAME [--shared] [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
-gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
+gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--to-shared] [--yes] [--json]
+gitmoot memory promote --to-shared <id>... [--json]
 gitmoot memory links backfill [--dry-run] [--json]
 gitmoot memory links list <id> [--json]
 gitmoot memory groom --propose [--out PLAN.json] [--json]
@@ -1360,10 +1361,14 @@ gitmoot memory cluster rename <cluster-id> <label>
 `memory list` shows confirmed memories and/or pending observations. `memory
 recall` runs the same FTS5/BM25 confirmed-memory retrieval used for prompt
 injection and prints the matching facts in injection bullet format. Without
-`--agent`, recall searches all agent owner pools; pass `--agent NAME` to inspect
-one pool. Without `--repo`, recall searches every repo and general-scope facts.
-`--repo owner/repo` narrows repo-scoped facts to that repo while still including
-general-scope facts. `--json` returns raw rows for scripts. `memory replay`
+`--agent`, recall searches all agent owner pools plus the shared pool; pass
+`--agent NAME` to inspect that agent's private pool plus shared, or `--shared` to
+inspect only shared facts. Private matches outrank shared matches on equal BM25
+scores, and a floor guard keeps a private match visible when shared rows would
+otherwise fill the limit. Without `--repo`, recall searches every repo and
+general-scope facts. `--repo owner/repo` narrows repo-scoped facts to that repo while still including
+general-scope facts. `--json` returns raw rows for scripts, including
+`author_ref` for shared facts that preserve a different author. `memory replay`
 re-renders recent real jobs' prompts with and without the injected
 learnings block and reports the token/entry delta. `memory eval` computes
 recall/precision@K of retrieval over a labeled `{agent, repo, instructions,
@@ -1378,7 +1383,9 @@ regenerated from scratch on every export, safe to delete, and **deterministic**:
 same store yields byte-identical files (no `exported_at`; stable id-derived
 filenames). The export is read-only and atomic (temp dir then rename over `--out`,
 default a `vault/` directory under the home's evals area); `--agent` narrows it to a
-single agent owner. Because the export **replaces `--out` wholesale**, it refuses to
+single agent owner plus shared facts authored by that agent. Shared notes include
+an `author:` frontmatter line when `author_ref` is set, so graph views still
+attribute moved facts to the real author. Because the export **replaces `--out` wholesale**, it refuses to
 overwrite a non-empty directory that is not itself a prior gitmoot vault (one with a
 `manifest.json`), so an accidental `--out ~/my-obsidian-vault` can never delete your
 own notes; pass `--force` to override.
@@ -1400,6 +1407,7 @@ fails to parse (e.g. broken YAML frontmatter), `--yes` **refuses to apply** so a
 malformed note is never misread as a deletion. A vault produced by `export --agent
 NAME` stays importable even when other owners have memories. The `<DIR>` positional
 may sit before or after the flags.
+
 `memory ingest` stages arbitrary Markdown as **pending observations**: it walks
 `*.md`, strips leading YAML frontmatter, chunks a file only when its body exceeds
 ~512 estimated tokens (on `## ` headings, sub-splitting any still-oversized
@@ -1408,22 +1416,30 @@ every chunk (per-reason rejection counts in the summary), dedups by exact conten
 **within the same scope+repo visibility domain** (identical text under a second
 repo still stages), and inserts survivors with
 `provenance = ingest:<relpath>` and **`trust_mark = low`**. `--tier` defaults to
-`repo`; `general` is only chosen explicitly. `memory observations` lists pending
-observations, flagging which keys are already confirmed. `memory confirm` is the
-**human-gated promotion** — by id or `--provenance-prefix`, it copies observations
+`repo`; `general` is only chosen explicitly. `--shared` stages observations in the
+shared pool while recording `--agent NAME` as the authoring identity.
+`memory observations` lists pending observations, flagging which keys are already
+confirmed. `memory confirm` is the **human-gated promotion**: by id or
+`--provenance-prefix`, it copies observations
 into confirmed memory (idempotently), and without `--yes` only prints the plan.
+`--to-shared` confirms selected observations into the shared pool while preserving
+the observation author. `memory promote --to-shared <id>...` moves active
+confirmed facts into shared, refuses retired or superseded rows, preserves
+existing links, and stamps `author_ref` from the previous owner when needed.
 Ingested Markdown is an indirect-prompt-injection vector, so it stays inert at
 `trust_mark = low` until a human confirms it; that confirm gate is the trust
 boundary and nothing reads `trust_mark` for a decision yet.
 
 Confirming a fact also records up to three deterministic persisted links from that
 confirmed row to active related confirmed memories. Links live in `memory_links`
-with BM25-derived scores and do not rewrite fact content. `memory links backfill`
-runs the same pass over the active confirmed pool in id order; `--dry-run` reports
-what would be created, and repeat runs create nothing new. `memory links list <id>`
-shows one fact's outgoing persisted links. Vault export merges these persisted
-links with content-derived links and dedupes by target in each note's `## Links`
-section.
+with BM25-derived scores and do not rewrite fact content. Link candidates use the
+same private-plus-shared visibility as prompt injection, so private facts can link
+to shared facts and shared facts can link back through their author pool.
+`memory links backfill` runs the same pass over the active confirmed pool in id
+order; `--dry-run` reports what would be created, and repeat runs create nothing
+new. `memory links list <id>` shows one fact's outgoing persisted links. Vault
+export merges these persisted links with content-derived links and dedupes by
+target in each note's `## Links` section.
 
 `memory groom` retires stale, low-signal confirmed memories as a **propose →
 review → apply** round-trip. `--propose` reads active confirmed memory, computes

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9762,24 +9762,28 @@ Most jobs return none. Returned learnings are shadow-logged only (never injected
 in this phase) and pass deterministic pre-filters that reject directive-phrased,
 executable, secret-shaped, or non-repo-agnostic content.
 
-Inspect and measure the store (all read-only):
+Inspect, curate, and measure the store:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
-gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME] [--limit N] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
 gitmoot memory vault import <DIR> [--dry-run|--yes] [--json]
+gitmoot memory links backfill [--dry-run] [--json]
+gitmoot memory links list <id> [--json]
 ```
 
 `memory list` shows confirmed memories and/or pending observations. `memory
 recall` runs the same FTS5/BM25 confirmed-memory retrieval used for prompt
 injection and prints the matching facts in injection bullet format. Without
-`--agent`, recall searches all agent owner pools; pass `--agent NAME` to inspect
-one pool. Without `--repo`, recall searches every repo and general-scope facts.
-`--repo owner/repo` narrows repo-scoped facts to that repo while still including
-general-scope facts. `--json` returns raw rows for scripts. `memory replay` is an offline A/B:
+`--agent`, recall searches all agent owner pools plus the shared pool; pass
+`--agent NAME` to inspect that agent's private pool plus shared, or `--shared`
+to inspect only shared facts. Without `--repo`, recall searches every repo and
+general-scope facts. `--repo owner/repo` narrows repo-scoped facts to that repo
+while still including general-scope facts. `--json` returns raw rows for scripts,
+including `author_ref` when a shared fact preserves a different author. `memory replay` is an offline A/B:
 it re-renders recent real jobs' prompts with and
 without the learnings block and reports the injection delta (added tokens,
 entries injected) — it measures injection *mechanics*, not outcome quality
@@ -9787,17 +9791,30 @@ entries injected) — it measures injection *mechanics*, not outcome quality
 recall/precision@K of retrieval over a labeled fixtures file whose cases are
 `{agent, repo, instructions, expected_keys}`.
 
+Confirmed-memory injection reads the running agent's private pool unioned with
+the reserved shared pool (`owner_kind=shared`, `owner_ref=shared`). BM25 relevance
+still ranks first. On an equal BM25 score, the agent's private facts outrank
+shared facts, then `updated_at DESC` breaks ties. A small floor guard keeps a
+matching private fact from being completely starved by a tight limit full of
+shared rows. Entry into shared is always explicit and human-driven: use
+`memory promote --to-shared`, `memory ingest --shared`, or
+`memory confirm --to-shared`; daemon producers never auto-share facts.
+
 `memory vault export` renders confirmed memory as a **disposable, Obsidian-compatible
 vault view** (#737): one Markdown note per confirmed memory (sorted-key YAML
 frontmatter + the content verbatim + a `## Links` section of FTS co-occurrence
-`[[wikilinks]]`), a per-owner index note, and a `manifest.json` staleness anchor.
+and persisted `[[wikilinks]]`), a per-owner index note, and a `manifest.json`
+staleness anchor.
 It is a **view, not a replica**: the SQLite store stays the only source of truth,
 so the vault is regenerated from scratch on every export, is safe to delete, and
 is **deterministic** — the same store produces byte-identical files (there is no
-`exported_at`; filenames are stable `NNNNNNNNN-<slug>.md` from the memory id). The
+`exported_at`; filenames are stable `NNNNNNNNN-<slug>.md` from the memory id).
+Shared notes include an `author:` frontmatter line when `author_ref` is set, so
+moving a fact into shared does not reattribute it to the shared pool. The
 export is **read-only** (zero writes to any table) and writes to a temp dir then
 atomically renames over `--out` (default: a `vault/` directory under the home's
-evals area). `--agent NAME` narrows the export to one agent owner. Because the
+evals area). `--agent NAME` narrows the export to one agent owner and shared
+facts authored by that agent. Because the
 export **replaces `--out` wholesale**, it refuses to overwrite a non-empty directory
 that is not itself a prior gitmoot vault (one carrying a `manifest.json`) so an
 accidental `--out ~/my-obsidian-vault` can never delete your own notes; pass
@@ -9825,10 +9842,7 @@ otherwise be misread as a deletion and silently retire a live memory; fix the
 frontmatter (or delete the file to intentionally retire it) and re-export. A vault
 produced by `export --agent NAME` stays importable even when other owners have
 memories (import rebuilds the fresh export with the manifest's recorded scope). The
-`<DIR>` positional may appear before or after the flags. `memory ingest` (P3) lands in
-a later phase.
-`--force` to override. This is P1 of the two-way memory bridge; `vault import`
-(P2) lands separately.
+`<DIR>` positional may appear before or after the flags.
 
 ### Markdown ingest and the human confirm gate (#737 P3)
 
@@ -9838,9 +9852,12 @@ observations** behind the existing confirmation gate. It never writes confirmed
 (injectable) memory directly.
 
 ```sh
-gitmoot memory ingest <path|dir> --agent NAME [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
+gitmoot memory ingest <path|dir> --agent NAME [--shared] [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
-gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--yes] [--json]
+gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--to-shared] [--yes] [--json]
+gitmoot memory promote --to-shared <id>... [--json]
+gitmoot memory links backfill [--dry-run] [--json]
+gitmoot memory links list <id> [--json]
 ```
 
 `memory ingest` walks `*.md` (recursively for a directory), strips a leading YAML
@@ -9858,8 +9875,9 @@ re-ingesting the same source inserts nothing — but the same note ingested unde
 second repo still stages, since repo-scoped memory injects only for its own repo.
 Surviving chunks land in `memory_observations` with `provenance = ingest:<relpath>`
 and, crucially, **`trust_mark = low`** — see the trust note below. `--tier` defaults
-to `repo`; `general` is only ever chosen with the explicit flag. `--dry-run`
-reports what would be staged without writing.
+to `repo`; `general` is only ever chosen with the explicit flag. `--shared`
+stages the observations in the shared pool while preserving `--agent NAME` as
+their author. `--dry-run` reports what would be staged without writing.
 
 `memory observations` lists pending observations (optionally narrowed by
 `--agent` or `--provenance-prefix`), flagging which keys already crossed the
@@ -9867,8 +9885,23 @@ confirm gate. `memory confirm` is the **human-gated promotion** step: it copies
 selected observations (by id, or every observation matching a
 `--provenance-prefix`) into confirmed memory, carrying provenance through.
 Without `--yes` it prints the plan and writes nothing; with `--yes` it promotes
-(idempotently — re-confirming the same key upserts the one row). This is
+idempotently, re-confirming the same key upserts the one row. `--to-shared`
+confirms selected observations into the shared pool and records the observation
+author. `memory promote --to-shared <id>...` moves existing active confirmed
+facts into shared, refuses retired or superseded rows, preserves outgoing
+`memory_links`, and sets `author_ref` from the previous owner when needed. This is
 **CLI-explicit only**: there is no daemon path and nothing auto-confirms.
+
+Confirming a fact also writes up to three deterministic auto-links from that new
+confirmed row to active related confirmed memories. The links are stored in the
+`memory_links` side table with BM25-derived scores and never rewrite the fact
+content. Link candidates use the same private-plus-shared visibility as injection,
+so private facts can link to shared facts and shared facts can link back through
+their author pool. `memory links backfill` applies the same link pass to the existing
+active confirmed pool in id order; `--dry-run` reports the links it would create
+without writing, and repeat runs are idempotent. `memory links list <id>` shows one fact's
+persisted outgoing links. Vault export merges these persisted links with the
+content-derived links in each note's `## Links` section and dedupes by target.
 
 > **Trust boundary.** Ingested Markdown is untrusted input — an
 > **indirect-prompt-injection vector**. Ingest records `trust_mark = low` on every

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -32,7 +32,7 @@ full expanded context.
 
 - [Local-First Coordination](https://gitmoot.io/docs/concepts/local-first-coordination): Why state lives in local SQLite and GitHub stays the audit surface.
 - [Agents, Agent Templates, Jobs, And Locks](https://gitmoot.io/docs/concepts/agents-templates-jobs-locks): The core object model — agent identities, template snapshots, job lifecycle, and the three lock kinds.
-- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, auto cross-links for confirmed facts (`memory links backfill|list`), and the memory CLI, including `memory recall "<query>"` for read-only FTS5/BM25 lookup across all agent pools by default.
+- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, the explicit shared pool with author preservation, private-plus-shared prompt injection and auto-links, and the memory CLI, including `memory recall "<query>"` for read-only FTS5/BM25 lookup across all agent pools plus shared by default.
 
 ## Dashboard
 
@@ -41,7 +41,7 @@ full expanded context.
 
 ## References
 
-- [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, pipelines, jobs (incl. resumable `job gates`/`gates clear` for blocked `needs` with auto-resume on last clear, and session jobs `job open/close/record`), review head-SHA re-sync, memory recall, bug reports, locks, goals, interactive prompts, and SkillOpt.
+- [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, pipelines, jobs (incl. resumable `job gates`/`gates clear` for blocked `needs` with auto-resume on last clear, and session jobs `job open/close/record`), review head-SHA re-sync, memory recall and shared-pool curation, bug reports, locks, goals, interactive prompts, and SkillOpt.
 - [Runtime Adapters](https://gitmoot.io/docs/reference/runtime-adapters): Codex, Claude Code, Kimi Code, legacy kimi-cli, shell, and future runtimes; the config-driven metadata registry (`gitmoot runtime list`, `[runtimes.<name>]` overrides).
 - [Result Contract](https://gitmoot.io/docs/reference/result-contract): gitmoot_result shape, the delegations DAG (Orchestration), continuation, and termination bounds.
 - [Event Stream](https://gitmoot.io/docs/reference/event-stream): The `[events]` webhook contract — job.finished/failed/blocked/needs_attention/deferred and candidate.* events, schema_version 1, best-effort delivery.


### PR DESCRIPTION
Closes #777.

Adds the reserved shared/shared owner pool: injection returns the union of the running agent's pool and the shared pool (own facts outrank shared on bm25 ties, with a deterministic floor swap so own facts are never fully displaced). New author_ref column preserves who wrote a fact across pool moves; the dashboard Knowledge bridge reports authors so ownership fans stay truthful. Write paths: memory promote --to-shared, ingest --shared, confirm --to-shared (all explicit and human-driven). Recall gains shared parity and a --shared flag; auto-links see across own+shared pools.

Implemented by a gitmoot-orchestrated codex (gpt-5.5, xhigh) implement job; coordinated and reviewed by the lead session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)