### PR TITLE
feat(memory): 1-hop link expansion in retrieval + mid-job recall affordance

### DIFF
--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -70,7 +70,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo R] [--json]")
-	fmt.Fprintln(w, "  gitmoot memory recall \"<query>\" [--repo R] [--agent NAME|--shared] [--limit N] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory recall \"<query>\" [--repo R] [--agent NAME|--shared] [--limit N] [--expand] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory replay [--agent NAME] [--repo R] [--limit N] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory eval --fixtures FILE [--k N] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory vault export [--out DIR] [--agent NAME] [--json]")
@@ -113,6 +113,7 @@ type memoryRecallEntry struct {
 	ID         int64             `json:"id"`
 	Owner      memoryRecallOwner `json:"owner"`
 	AuthorRef  string            `json:"author_ref,omitempty"`
+	LinkedFrom int64             `json:"linked_from,omitempty"`
 	Repo       string            `json:"repo"`
 	Scope      string            `json:"scope"`
 	Key        string            `json:"key"`
@@ -129,13 +130,14 @@ func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
 	shared := fs.Bool("shared", false, "search only the shared pool")
 	repo := fs.String("repo", "", "filter by repo (owner/repo); omitted searches all repos")
 	limit := fs.Int("limit", 15, "maximum number of matching memories to return")
+	expand := fs.Bool("expand", false, "include 1-hop linked memory neighbors after direct matches")
 	jsonOut := fs.Bool("json", false, "print as JSON")
 	queryText, err := parseMemoryRecallArgs(fs, args)
 	if err != nil {
 		return memoryFlagExit(err)
 	}
 	if strings.TrimSpace(queryText) == "" {
-		fmt.Fprintln(stderr, "usage: gitmoot memory recall \"<query>\" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--json]")
+		fmt.Fprintln(stderr, "usage: gitmoot memory recall \"<query>\" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--expand] [--json]")
 		return 2
 	}
 	if *shared && strings.TrimSpace(*agent) != "" {
@@ -143,23 +145,36 @@ func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	query := workflow.BuildMemoryMatchQuery(queryText)
+	effectiveLimit := *limit
+	if effectiveLimit <= 0 {
+		effectiveLimit = 15
+	}
 
 	var rows []db.ConfirmedMemory
+	linkedFrom := map[int64]int64{}
 	err = withReadOnlyStore(*home, func(store *db.Store) error {
 		var err error
 		ctx := context.Background()
 		if *shared {
-			rows, err = store.QueryConfirmedMemoriesForShared(ctx, strings.TrimSpace(*repo), query, *limit)
+			rows, err = store.QueryConfirmedMemoriesForShared(ctx, strings.TrimSpace(*repo), query, effectiveLimit)
 		} else if strings.TrimSpace(*agent) != "" {
 			owner := db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: strings.TrimSpace(*agent)}
 			if strings.TrimSpace(*repo) != "" {
-				rows, err = store.QueryConfirmedMemories(ctx, owner, strings.TrimSpace(*repo), query, *limit)
+				rows, err = store.QueryConfirmedMemories(ctx, owner, strings.TrimSpace(*repo), query, effectiveLimit)
 			} else {
-				rows, err = store.QueryConfirmedMemoriesForOwnerAllRepos(ctx, owner, query, *limit)
+				rows, err = store.QueryConfirmedMemoriesForOwnerAllRepos(ctx, owner, query, effectiveLimit)
 			}
 		} else {
-			rows, err = store.QueryConfirmedMemoriesForAllAgents(ctx, strings.TrimSpace(*repo), query, *limit)
+			rows, err = store.QueryConfirmedMemoriesForAllAgents(ctx, strings.TrimSpace(*repo), query, effectiveLimit)
 		}
+		if err != nil || !*expand || len(rows) == 0 || len(rows) >= effectiveLimit {
+			return err
+		}
+		linked, linkErr := memoryRecallLinkedRows(ctx, store, *shared, strings.TrimSpace(*agent), strings.TrimSpace(*repo), rows)
+		if linkErr != nil {
+			return linkErr
+		}
+		rows, linkedFrom = appendMemoryRecallExpansion(rows, linked, effectiveLimit)
 		return err
 	})
 	if err != nil {
@@ -170,7 +185,7 @@ func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
 	if *jsonOut {
 		entries := make([]memoryRecallEntry, 0, len(rows))
 		for _, r := range rows {
-			entries = append(entries, memoryRecallJSONEntry(r))
+			entries = append(entries, memoryRecallJSONEntry(r, linkedFrom[r.ID]))
 		}
 		if err := writeJSON(stdout, entries); err != nil {
 			fmt.Fprintf(stderr, "memory recall: %v\n", err)
@@ -190,6 +205,7 @@ func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
 			Key:       r.Key,
 			Content:   r.Content,
 			UpdatedAt: r.UpdatedAt,
+			Linked:    linkedFrom[r.ID] != 0,
 		}))
 	}
 	return 0
@@ -204,6 +220,7 @@ func parseMemoryRecallArgs(fs *flag.FlagSet, args []string) (string, error) {
 		"-repo": true, "--repo": true,
 		"-limit": true, "--limit": true,
 		"-shared": false, "--shared": false,
+		"-expand": false, "--expand": false,
 	}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -230,7 +247,50 @@ func parseMemoryRecallArgs(fs *flag.FlagSet, args []string) (string, error) {
 	return strings.TrimSpace(strings.Join(queryParts, " ")), nil
 }
 
-func memoryRecallJSONEntry(r db.ConfirmedMemory) memoryRecallEntry {
+func memoryRecallLinkedRows(ctx context.Context, store *db.Store, sharedOnly bool, agentName, repo string, direct []db.ConfirmedMemory) ([]db.LinkedConfirmedMemory, error) {
+	srcIDs := make([]int64, 0, len(direct))
+	for _, r := range direct {
+		srcIDs = append(srcIDs, r.ID)
+	}
+	if sharedOnly {
+		return store.ListMemoryLinksForSourcesVisibleToShared(ctx, repo, srcIDs)
+	}
+	if agentName != "" {
+		owner := db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: agentName}
+		if repo != "" {
+			return store.ListMemoryLinksForSourcesVisibleToOwner(ctx, owner, repo, srcIDs)
+		}
+		return store.ListMemoryLinksForSourcesVisibleToOwnerAllRepos(ctx, owner, srcIDs)
+	}
+	return store.ListMemoryLinksForSourcesVisibleToAllAgents(ctx, repo, srcIDs)
+}
+
+func appendMemoryRecallExpansion(direct []db.ConfirmedMemory, linked []db.LinkedConfirmedMemory, limit int) ([]db.ConfirmedMemory, map[int64]int64) {
+	linkedFrom := map[int64]int64{}
+	if len(direct) == 0 || limit <= 0 || len(direct) >= limit {
+		return direct, linkedFrom
+	}
+	out := make([]db.ConfirmedMemory, 0, limit)
+	out = append(out, direct...)
+	seen := make(map[int64]struct{}, len(direct)+len(linked))
+	for _, r := range direct {
+		seen[r.ID] = struct{}{}
+	}
+	for _, l := range linked {
+		if _, ok := seen[l.Memory.ID]; ok {
+			continue
+		}
+		seen[l.Memory.ID] = struct{}{}
+		out = append(out, l.Memory)
+		linkedFrom[l.Memory.ID] = l.SrcID
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, linkedFrom
+}
+
+func memoryRecallJSONEntry(r db.ConfirmedMemory, linkedFrom int64) memoryRecallEntry {
 	return memoryRecallEntry{
 		ID: r.ID,
 		Owner: memoryRecallOwner{
@@ -239,6 +299,7 @@ func memoryRecallJSONEntry(r db.ConfirmedMemory) memoryRecallEntry {
 			Version: r.Owner.Version,
 		},
 		AuthorRef:  r.AuthorRef,
+		LinkedFrom: linkedFrom,
 		Repo:       r.Repo,
 		Scope:      r.Scope,
 		Key:        r.Key,
@@ -299,7 +360,7 @@ func runMemoryPromote(args []string, stdout, stderr io.Writer) int {
 		result.Promoted = len(rows)
 		result.Rows = make([]memoryRecallEntry, 0, len(rows))
 		for _, r := range rows {
-			result.Rows = append(result.Rows, memoryRecallJSONEntry(r))
+			result.Rows = append(result.Rows, memoryRecallJSONEntry(r, 0))
 		}
 		return nil
 	})

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -285,6 +285,62 @@ func TestMemoryRecallSharedParity(t *testing.T) {
 	}
 }
 
+func TestMemoryRecallExpandAddsLinkedFromJSON(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "lead"}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "linked-neighbor",
+		Content: "aurora quartz vector hidden neighbor", Provenance: "seed",
+	}); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	srcID, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "direct-source",
+		Content: "aurora quartz vector source instructions", Provenance: "seed",
+	})
+	if err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runMemory([]string{"recall", "instructions", "--home", home, "--repo", "acme/widget", "--agent", "lead", "--limit", "2", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall without expand exit %d: %s", code, stderr.String())
+	}
+	var directOnly []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &directOnly); err != nil {
+		t.Fatalf("parse direct recall: %v (%s)", err, stdout.String())
+	}
+	if len(directOnly) != 1 || directOnly[0].Key != "direct-source" || directOnly[0].LinkedFrom != 0 {
+		t.Fatalf("without --expand should return only direct source without linked_from, got %+v", directOnly)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "instructions", "--home", home, "--repo", "acme/widget", "--agent", "lead", "--limit", "2", "--expand", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall --expand exit %d: %s", code, stderr.String())
+	}
+	var expanded []memoryRecallEntry
+	if err := json.Unmarshal(stdout.Bytes(), &expanded); err != nil {
+		t.Fatalf("parse expanded recall: %v (%s)", err, stdout.String())
+	}
+	if len(expanded) != 2 || expanded[0].Key != "direct-source" || expanded[1].Key != "linked-neighbor" {
+		t.Fatalf("--expand should append linked neighbor after direct hit, got %+v", expanded)
+	}
+	if expanded[0].LinkedFrom != 0 || expanded[1].LinkedFrom != srcID {
+		t.Fatalf("linked_from JSON mismatch, source=%d rows=%+v", srcID, expanded)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMemory([]string{"recall", "instructions", "--home", home, "--repo", "acme/widget", "--agent", "lead", "--limit", "2", "--expand"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("memory recall --expand text exit %d: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "- [this repo] [linked] aurora quartz vector hidden neighbor") {
+		t.Fatalf("text --expand should mark linked bullet, got:\n%s", stdout.String())
+	}
+}
+
 func recallHasKey(rows []memoryRecallEntry, key string) bool {
 	for _, r := range rows {
 		if r.Key == key {

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -72,6 +72,15 @@ type MemoryLink struct {
 	CreatedAt string
 }
 
+// LinkedConfirmedMemory is one active memory_links edge plus the visible target
+// confirmed memory row. It backs retrieval expansion: direct FTS hits stay first,
+// then callers append these linked target facts in link-rank order.
+type LinkedConfirmedMemory struct {
+	SrcID  int64
+	Score  float64
+	Memory ConfirmedMemory
+}
+
 // MemoryLinkEnrichment reports what the auto-link pass created or skipped for one
 // source memory. Created contains rows that were written, or rows that WOULD be
 // written when the caller requested a dry run.
@@ -552,6 +561,125 @@ ORDER BY ml.dst_id`, srcID)
 		out = append(out, l)
 	}
 	return out, rows.Err()
+}
+
+// ListMemoryLinksForSources returns active linked target facts for a batch of
+// source ids. It applies only the universal active-row filter; callers that need
+// owner/repo visibility should use one of the visibility-specific variants
+// below. Rows are ordered by link score descending, target id ascending, then
+// source id ascending for deterministic expansion and dedupe.
+func (s *Store) ListMemoryLinksForSources(ctx context.Context, srcIDs []int64) ([]LinkedConfirmedMemory, error) {
+	return s.listMemoryLinksForSources(ctx, srcIDs, "", nil)
+}
+
+// ListMemoryLinksForSourcesVisibleToOwner applies the prompt-injection
+// visibility policy for one agent owner: private owner pool plus the reserved
+// shared pool, limited to the current repo plus general-scope facts.
+func (s *Store) ListMemoryLinksForSourcesVisibleToOwner(ctx context.Context, owner MemoryOwner, repo string, srcIDs []int64) ([]LinkedConfirmedMemory, error) {
+	return s.listMemoryLinksForSources(ctx, srcIDs,
+		`((d.owner_kind = ? AND d.owner_ref = ? AND d.owner_version = ?) OR (d.owner_kind = ? AND d.owner_ref = ?))
+	AND (d.scope = 'general' OR d.repo = ?)`,
+		[]any{owner.Kind, owner.Ref, owner.Version, memoryOwnerKindShared, memorySharedOwnerRef, strings.TrimSpace(repo)})
+}
+
+// ListMemoryLinksForSourcesVisibleToOwnerAllRepos is the single-agent recall
+// expansion policy when recall omits --repo: private owner pool plus shared,
+// without a repo/general restriction.
+func (s *Store) ListMemoryLinksForSourcesVisibleToOwnerAllRepos(ctx context.Context, owner MemoryOwner, srcIDs []int64) ([]LinkedConfirmedMemory, error) {
+	return s.listMemoryLinksForSources(ctx, srcIDs,
+		`((d.owner_kind = ? AND d.owner_ref = ? AND d.owner_version = ?) OR (d.owner_kind = ? AND d.owner_ref = ?))`,
+		[]any{owner.Kind, owner.Ref, owner.Version, memoryOwnerKindShared, memorySharedOwnerRef})
+}
+
+// ListMemoryLinksForSourcesVisibleToAllAgents is the default recall expansion
+// policy: every private agent pool plus the reserved shared pool. A non-empty
+// repo applies the same repo/general restriction as the direct recall query.
+func (s *Store) ListMemoryLinksForSourcesVisibleToAllAgents(ctx context.Context, repo string, srcIDs []int64) ([]LinkedConfirmedMemory, error) {
+	where := `(d.owner_kind = 'agent' OR (d.owner_kind = ? AND d.owner_ref = ?))`
+	args := []any{memoryOwnerKindShared, memorySharedOwnerRef}
+	if strings.TrimSpace(repo) != "" {
+		where += "\n\tAND (d.scope = 'general' OR d.repo = ?)"
+		args = append(args, strings.TrimSpace(repo))
+	}
+	return s.listMemoryLinksForSources(ctx, srcIDs, where, args)
+}
+
+// ListMemoryLinksForSourcesVisibleToShared is the shared-only recall expansion
+// policy. A non-empty repo applies the same repo/general restriction as the
+// direct shared recall query.
+func (s *Store) ListMemoryLinksForSourcesVisibleToShared(ctx context.Context, repo string, srcIDs []int64) ([]LinkedConfirmedMemory, error) {
+	where := `d.owner_kind = ? AND d.owner_ref = ?`
+	args := []any{memoryOwnerKindShared, memorySharedOwnerRef}
+	if strings.TrimSpace(repo) != "" {
+		where += "\n\tAND (d.scope = 'general' OR d.repo = ?)"
+		args = append(args, strings.TrimSpace(repo))
+	}
+	return s.listMemoryLinksForSources(ctx, srcIDs, where, args)
+}
+
+func (s *Store) listMemoryLinksForSources(ctx context.Context, srcIDs []int64, visibilityWhere string, visibilityArgs []any) ([]LinkedConfirmedMemory, error) {
+	ids := uniquePositiveInt64s(srcIDs)
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	args := make([]any, 0, len(ids)+len(visibilityArgs))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	query := `
+SELECT ml.src_id, ml.score,
+	d.id, d.owner_kind, d.owner_ref, d.owner_version, d.author_ref, d.repo, d.scope, d.key, d.content,
+	d.provenance, d.source_job, d.first_confirmed_at, d.updated_at
+FROM memory_links ml
+JOIN confirmed_memories d ON d.id = ml.dst_id
+WHERE ml.src_id IN (` + placeholders + `)
+	AND d.superseded_by IS NULL
+	AND d.retired_at = ''`
+	if strings.TrimSpace(visibilityWhere) != "" {
+		query += "\n\tAND " + visibilityWhere
+		args = append(args, visibilityArgs...)
+	}
+	query += `
+ORDER BY ml.score DESC, d.id ASC, ml.src_id ASC`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list memory links for sources: %w", err)
+	}
+	defer rows.Close()
+	var out []LinkedConfirmedMemory
+	for rows.Next() {
+		var l LinkedConfirmedMemory
+		var repoNull sql.NullString
+		if err := rows.Scan(&l.SrcID, &l.Score,
+			&l.Memory.ID, &l.Memory.Owner.Kind, &l.Memory.Owner.Ref, &l.Memory.Owner.Version, &l.Memory.AuthorRef,
+			&repoNull, &l.Memory.Scope, &l.Memory.Key, &l.Memory.Content, &l.Memory.Provenance,
+			&l.Memory.SourceJob, &l.Memory.FirstConfirmedAt, &l.Memory.UpdatedAt); err != nil {
+			return nil, err
+		}
+		l.Memory.Repo = repoNull.String
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}
+
+func uniquePositiveInt64s(ids []int64) []int64 {
+	if len(ids) == 0 {
+		return nil
+	}
+	seen := make(map[int64]struct{}, len(ids))
+	out := make([]int64, 0, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
 }
 
 func enrichConfirmedMemoryLinksTx(ctx context.Context, tx *sql.Tx, srcID int64, dryRun bool) (MemoryLinkEnrichment, error) {

--- a/internal/db/memory_store_test.go
+++ b/internal/db/memory_store_test.go
@@ -124,6 +124,73 @@ func TestConfirmedMemoryAutoLinksSimilarExistingFacts(t *testing.T) {
 	}
 }
 
+func TestListMemoryLinksForSourcesBatchedOrderingAndActiveFilter(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := agentOwner("builder")
+	srcA := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "src-a", Content: "source alpha"})
+	srcB := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "src-b", Content: "source beta"})
+	high := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "target-high", Content: "target high"})
+	tieA := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "target-tie-a", Content: "target tie a"})
+	tieB := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "target-tie-b", Content: "target tie b"})
+	retired := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "target-retired", Content: "target retired"})
+	superseded := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "target-superseded", Content: "target superseded"})
+
+	mustInsertMemoryLink(t, store, srcA, tieB, 0.5)
+	mustInsertMemoryLink(t, store, srcA, tieA, 0.5)
+	mustInsertMemoryLink(t, store, srcB, high, 0.9)
+	mustInsertMemoryLink(t, store, srcA, retired, 1.0)
+	mustInsertMemoryLink(t, store, srcA, superseded, 0.8)
+	if _, err := store.db.ExecContext(ctx, `UPDATE confirmed_memories SET retired_at = '2026-01-01T00:00:00Z' WHERE id = ?`, retired); err != nil {
+		t.Fatalf("retire target: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE confirmed_memories SET superseded_by = ? WHERE id = ?`, high, superseded); err != nil {
+		t.Fatalf("supersede target: %v", err)
+	}
+
+	got, err := store.ListMemoryLinksForSources(ctx, []int64{srcB, srcA, srcA, -1})
+	if err != nil {
+		t.Fatalf("list batched links: %v", err)
+	}
+	if keys := linkedKeys(got); strings.Join(keys, ",") != "target-high,target-tie-a,target-tie-b" {
+		t.Fatalf("links not score/id ordered or inactive-filtered: keys=%v rows=%+v", keys, got)
+	}
+	if got[0].SrcID != srcB || got[0].Score != 0.9 {
+		t.Fatalf("top link metadata mismatch: %+v", got[0])
+	}
+}
+
+func TestListMemoryLinksForSourcesVisibleToOwnerFiltersNeighbors(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	lead := agentOwner("lead")
+	audit := agentOwner("audit")
+	shared := MemoryOwner{Kind: memoryOwnerKindShared, Ref: memorySharedOwnerRef}
+
+	src := mustUpsert(t, store, ConfirmedMemory{Owner: lead, Repo: "acme/widget", Scope: "repo", Key: "source", Content: "source fact"})
+	leadPrivate := mustUpsert(t, store, ConfirmedMemory{Owner: lead, Repo: "acme/widget", Scope: "repo", Key: "lead-private", Content: "lead private neighbor"})
+	auditPrivate := mustUpsert(t, store, ConfirmedMemory{Owner: audit, Repo: "acme/widget", Scope: "repo", Key: "audit-private", Content: "audit private neighbor"})
+	sharedFact := mustUpsert(t, store, ConfirmedMemory{Owner: shared, AuthorRef: "audit", Repo: "acme/widget", Scope: "repo", Key: "shared-neighbor", Content: "shared neighbor"})
+	otherRepo := mustUpsert(t, store, ConfirmedMemory{Owner: lead, Repo: "acme/api", Scope: "repo", Key: "other-repo", Content: "other repo neighbor"})
+	general := mustUpsert(t, store, ConfirmedMemory{Owner: lead, Scope: "general", Key: "general-neighbor", Content: "general neighbor"})
+
+	for i, id := range []int64{leadPrivate, auditPrivate, sharedFact, otherRepo, general} {
+		mustInsertMemoryLink(t, store, src, id, 1.0-float64(i)*0.1)
+	}
+
+	got, err := store.ListMemoryLinksForSourcesVisibleToOwner(ctx, lead, "acme/widget", []int64{src})
+	if err != nil {
+		t.Fatalf("list visible links: %v", err)
+	}
+	keys := linkedKeySet(got)
+	if !keys["lead-private"] || !keys["shared-neighbor"] || !keys["general-neighbor"] {
+		t.Fatalf("visible private/shared/general neighbors missing: keys=%v rows=%+v", keys, got)
+	}
+	if keys["audit-private"] || keys["other-repo"] {
+		t.Fatalf("invisible neighbor leaked: keys=%v rows=%+v", keys, got)
+	}
+}
+
 // TestConfirmedMemoryUpsertKeyed proves the keyed row deduplicates: two upserts
 // on the same (owner, repo, key) leave one row with the latest content.
 func TestConfirmedMemoryUpsertKeyed(t *testing.T) {
@@ -388,6 +455,31 @@ func containsKey(rows []ConfirmedMemory, key string) bool {
 		}
 	}
 	return false
+}
+
+func linkedKeys(rows []LinkedConfirmedMemory) []string {
+	keys := make([]string, 0, len(rows))
+	for _, r := range rows {
+		keys = append(keys, r.Memory.Key)
+	}
+	return keys
+}
+
+func linkedKeySet(rows []LinkedConfirmedMemory) map[string]bool {
+	keys := map[string]bool{}
+	for _, r := range rows {
+		keys[r.Memory.Key] = true
+	}
+	return keys
+}
+
+func mustInsertMemoryLink(t *testing.T, store *Store, srcID, dstID int64, score float64) {
+	t.Helper()
+	if _, err := store.db.ExecContext(context.Background(), `
+INSERT OR REPLACE INTO memory_links (src_id, dst_id, score, origin, created_at)
+VALUES (?, ?, ?, 'test', '2026-01-01T00:00:00Z')`, srcID, dstID, score); err != nil {
+		t.Fatalf("insert memory link %d -> %d: %v", srcID, dstID, err)
+	}
 }
 
 // TestObservationsAppendNotUpsert proves repeated observations of the same key

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -58,6 +58,7 @@ type Entry struct {
 	Key       string
 	Content   string
 	UpdatedAt string
+	Linked    bool // true when included via a 1-hop memory_links expansion
 }
 
 // blockHeader is the first line of the rendered learnings block. It is
@@ -222,7 +223,11 @@ func RenderBlock(entries []Entry, budgetTokens int) (string, int) {
 // RenderBlock. CLI recall uses it so on-demand retrieval matches prompt
 // injection without duplicating the presentation rule.
 func RenderBullet(e Entry) string {
-	return "- " + scopeTag(e.Scope) + " " + strings.TrimSpace(e.Content)
+	tags := []string{scopeTag(e.Scope)}
+	if e.Linked {
+		tags = append(tags, "[linked]")
+	}
+	return "- " + strings.Join(tags, " ") + " " + strings.TrimSpace(e.Content)
 }
 
 // scopeTag renders the per-entry provenance tag used in the block.

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -160,6 +160,9 @@ func TestRenderBlockTagsAndBudget(t *testing.T) {
 	if !strings.Contains(block, "[general] race suites need a long timeout") {
 		t.Errorf("block missing general-tagged entry: %q", block)
 	}
+	if linked := RenderBullet(Entry{Scope: ScopeRepo, Content: "linked neighbor", Linked: true}); !strings.Contains(linked, "[this repo] [linked] linked neighbor") {
+		t.Errorf("linked bullet missing linked tag: %q", linked)
+	}
 }
 
 func TestRenderBlockBudgetCaps(t *testing.T) {

--- a/internal/workflow/memory.go
+++ b/internal/workflow/memory.go
@@ -106,11 +106,31 @@ func (c *MemoryController) injectBlock(ctx context.Context, agent runtime.Agent,
 		return ""
 	}
 	entries := c.retrieve(ctx, ownerForJob(agent, payload), payload.Repo, payload.Instructions, c.MaxEntries)
+	// The mid-job recall affordance renders for EVERY enrolled agent, hits or
+	// not: agents need on-demand recall most when the startup push MISSED
+	// (panel-adjudicated #780 finding). It sits OUTSIDE the learnings block so
+	// the block stays reference-only data.
+	hint := memoryRecallHint(agent.Name)
 	if len(entries) == 0 {
-		return ""
+		return hint
 	}
-	block, _ := renderMemoryInjectionBlock(entries, c.TokenBudget, agent.Name)
-	return block
+	block, _ := memory.RenderBlock(entries, c.TokenBudget)
+	if block == "" {
+		return hint
+	}
+	if !strings.HasSuffix(block, "\n") {
+		block += "\n"
+	}
+	return block + "\n" + hint
+}
+
+// memoryRecallHint is the one-line, deterministic mid-job recall affordance.
+func memoryRecallHint(agentName string) string {
+	name := strings.TrimSpace(agentName)
+	if name == "" {
+		name = "<agent-name>"
+	}
+	return fmt.Sprintf("Project memory is searchable mid-job: run `gitmoot memory recall \"<query>\" --agent %s`.", name)
 }
 
 // retrieve runs the tiered, confirmed-only, sanitized-FTS retrieval and returns
@@ -142,17 +162,26 @@ func (c *MemoryController) retrieve(ctx context.Context, owner db.MemoryOwner, r
 		srcIDs = append(srcIDs, r.ID)
 	}
 	if len(entries) < limit {
+		// Linked expansion fills spare capacity only, and is hard-capped at 3
+		// entries so bm25-derived neighbors can never dominate a sparse direct
+		// result (panel-adjudicated #780 finding).
+		maxExpand := limit - len(entries)
+		if maxExpand > 3 {
+			maxExpand = 3
+		}
+		added := 0
 		linked, err := c.Store.ListMemoryLinksForSourcesVisibleToOwner(ctx, owner, repo, srcIDs)
 		if err == nil {
 			for _, l := range linked {
+				if added >= maxExpand {
+					break
+				}
 				if _, dup := seen[l.Memory.ID]; dup {
 					continue
 				}
 				seen[l.Memory.ID] = struct{}{}
 				entries = append(entries, memoryEntryFromConfirmed(l.Memory, true))
-				if len(entries) >= limit {
-					break
-				}
+				added++
 			}
 		}
 	}
@@ -175,7 +204,9 @@ func (c *MemoryController) PreviewEntries(ctx context.Context, agentName, repo, 
 // ungated, for the harness), returning the block text, the entries injected, and
 // the block's estimated token cost.
 func (c *MemoryController) PreviewBlock(ctx context.Context, agentName, repo, instructions string) (block string, entries int, tokens int) {
-	rendered, n := renderMemoryInjectionBlock(c.PreviewEntries(ctx, agentName, repo, instructions, 0), c.TokenBudget, agentName)
+	// The harness measures the learnings BLOCK alone; the mid-job recall hint is
+	// a constant-cost prompt line, not part of the measured injection delta.
+	rendered, n := memory.RenderBlock(c.PreviewEntries(ctx, agentName, repo, instructions, 0), c.TokenBudget)
 	return rendered, n, memory.EstimateTokens(rendered)
 }
 
@@ -189,21 +220,6 @@ func memoryEntryFromConfirmed(r db.ConfirmedMemory, linked bool) memory.Entry {
 	}
 }
 
-func renderMemoryInjectionBlock(entries []memory.Entry, budget int, agentName string) (string, int) {
-	block, n := memory.RenderBlock(entries, budget)
-	if block == "" {
-		return "", 0
-	}
-	name := strings.TrimSpace(agentName)
-	if name == "" {
-		name = "<agent-name>"
-	}
-	if !strings.HasSuffix(block, "\n") {
-		block += "\n"
-	}
-	block += fmt.Sprintf("More project memory is searchable: run `gitmoot memory recall \"<query>\" --agent %s`.\n", name)
-	return block, n
-}
 
 // record is the WRITE path, run at job terminal. The ENROLLED-ONLY Phase-1 body
 // (recordEnrolled) (a) SHADOW-logs the agent's returned learnings to

--- a/internal/workflow/memory.go
+++ b/internal/workflow/memory.go
@@ -109,7 +109,7 @@ func (c *MemoryController) injectBlock(ctx context.Context, agent runtime.Agent,
 	if len(entries) == 0 {
 		return ""
 	}
-	block, _ := memory.RenderBlock(entries, c.TokenBudget)
+	block, _ := renderMemoryInjectionBlock(entries, c.TokenBudget, agent.Name)
 	return block
 }
 
@@ -133,14 +133,28 @@ func (c *MemoryController) retrieve(ctx context.Context, owner db.MemoryOwner, r
 	if err != nil || len(rows) == 0 {
 		return nil
 	}
-	entries := make([]memory.Entry, 0, len(rows))
+	entries := make([]memory.Entry, 0, limit)
+	seen := make(map[int64]struct{}, len(rows))
+	srcIDs := make([]int64, 0, len(rows))
 	for _, r := range rows {
-		entries = append(entries, memory.Entry{
-			Scope:     r.Scope,
-			Key:       r.Key,
-			Content:   r.Content,
-			UpdatedAt: r.UpdatedAt,
-		})
+		entries = append(entries, memoryEntryFromConfirmed(r, false))
+		seen[r.ID] = struct{}{}
+		srcIDs = append(srcIDs, r.ID)
+	}
+	if len(entries) < limit {
+		linked, err := c.Store.ListMemoryLinksForSourcesVisibleToOwner(ctx, owner, repo, srcIDs)
+		if err == nil {
+			for _, l := range linked {
+				if _, dup := seen[l.Memory.ID]; dup {
+					continue
+				}
+				seen[l.Memory.ID] = struct{}{}
+				entries = append(entries, memoryEntryFromConfirmed(l.Memory, true))
+				if len(entries) >= limit {
+					break
+				}
+			}
+		}
 	}
 	return entries
 }
@@ -161,8 +175,34 @@ func (c *MemoryController) PreviewEntries(ctx context.Context, agentName, repo, 
 // ungated, for the harness), returning the block text, the entries injected, and
 // the block's estimated token cost.
 func (c *MemoryController) PreviewBlock(ctx context.Context, agentName, repo, instructions string) (block string, entries int, tokens int) {
-	rendered, n := memory.RenderBlock(c.PreviewEntries(ctx, agentName, repo, instructions, 0), c.TokenBudget)
+	rendered, n := renderMemoryInjectionBlock(c.PreviewEntries(ctx, agentName, repo, instructions, 0), c.TokenBudget, agentName)
 	return rendered, n, memory.EstimateTokens(rendered)
+}
+
+func memoryEntryFromConfirmed(r db.ConfirmedMemory, linked bool) memory.Entry {
+	return memory.Entry{
+		Scope:     r.Scope,
+		Key:       r.Key,
+		Content:   r.Content,
+		UpdatedAt: r.UpdatedAt,
+		Linked:    linked,
+	}
+}
+
+func renderMemoryInjectionBlock(entries []memory.Entry, budget int, agentName string) (string, int) {
+	block, n := memory.RenderBlock(entries, budget)
+	if block == "" {
+		return "", 0
+	}
+	name := strings.TrimSpace(agentName)
+	if name == "" {
+		name = "<agent-name>"
+	}
+	if !strings.HasSuffix(block, "\n") {
+		block += "\n"
+	}
+	block += fmt.Sprintf("More project memory is searchable: run `gitmoot memory recall \"<query>\" --agent %s`.\n", name)
+	return block, n
 }
 
 // record is the WRITE path, run at job terminal. The ENROLLED-ONLY Phase-1 body

--- a/internal/workflow/memory_controller_test.go
+++ b/internal/workflow/memory_controller_test.go
@@ -291,13 +291,21 @@ func TestMemoryLinkExpansionRespectsRenderBudget(t *testing.T) {
 	}
 }
 
-func TestMemoryInjectionFooterOnlyOnNonEmptyBlock(t *testing.T) {
+func TestMemoryRecallHintRendersForEnrolledAgentsRegardlessOfHits(t *testing.T) {
+	hint := "Project memory is searchable mid-job: run `gitmoot memory recall \"<query>\" --agent audit`."
+
+	// Enrolled agent with ZERO retrieval hits still gets the hint: agents need
+	// on-demand recall most when the startup push missed.
 	store := openTestStore(t)
 	prompt := runMemJob(t, store, memController(store, 1500, 15, "audit"), memTestOutput, "zzznomatch")
-	if strings.Contains(prompt, "More project memory is searchable") {
-		t.Fatalf("footer must not appear without a memory block:\n%s", prompt)
+	if !strings.Contains(prompt, hint) {
+		t.Fatalf("recall hint must render for enrolled agents even with no hits:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "Prior learnings") {
+		t.Fatalf("no learnings block expected on a retrieval miss:\n%s", prompt)
 	}
 
+	// With hits, the hint renders AFTER the learnings block, outside its bullets.
 	store = openTestStore(t)
 	if _, err := store.UpsertConfirmedMemory(context.Background(), db.ConfirmedMemory{
 		Owner: db.MemoryOwner{Kind: "agent", Ref: "audit"}, Repo: "acme/widget", Scope: "repo",
@@ -306,8 +314,17 @@ func TestMemoryInjectionFooterOnlyOnNonEmptyBlock(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 	prompt = runMemJob(t, store, memController(store, 1500, 15, "audit"), memTestOutput, "arm64")
-	if !strings.Contains(prompt, "More project memory is searchable: run `gitmoot memory recall \"<query>\" --agent audit`.") {
-		t.Fatalf("footer missing from non-empty memory block:\n%s", prompt)
+	blockIdx := strings.Index(prompt, "arm64 CI is flaky")
+	hintIdx := strings.Index(prompt, hint)
+	if blockIdx < 0 || hintIdx < 0 || hintIdx < blockIdx {
+		t.Fatalf("hint must render after the learnings block:\n%s", prompt)
+	}
+
+	// Non-enrolled agent: no hint, prompt byte-identical to pre-memory behavior.
+	store = openTestStore(t)
+	prompt = runMemJob(t, store, memController(store, 1500, 15, "someone-else"), memTestOutput, "arm64")
+	if strings.Contains(prompt, "Project memory is searchable mid-job") {
+		t.Fatalf("hint must not render for non-enrolled agents:\n%s", prompt)
 	}
 }
 

--- a/internal/workflow/memory_controller_test.go
+++ b/internal/workflow/memory_controller_test.go
@@ -167,6 +167,150 @@ func TestMemoryTokenBudgetEnforced(t *testing.T) {
 	}
 }
 
+func TestMemoryReadPathExpandsLinkedNeighborsAfterDirectHits(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "audit"}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "linked-neighbor",
+		Content: "aurora quartz vector hidden neighbor",
+	}); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "direct-source",
+		Content: "aurora quartz vector source instructions",
+	}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	ctrl := memController(store, 1500, 2, "audit")
+	entries := ctrl.PreviewEntries(ctx, "audit", "acme/widget", "instructions", 2)
+	if len(entries) != 2 {
+		t.Fatalf("want direct hit plus linked neighbor, got %+v", entries)
+	}
+	if entries[0].Key != "direct-source" || entries[0].Linked {
+		t.Fatalf("first entry must be the direct hit, got %+v", entries[0])
+	}
+	if entries[1].Key != "linked-neighbor" || !entries[1].Linked {
+		t.Fatalf("second entry must be linked neighbor, got %+v", entries[1])
+	}
+	block, injected, _ := ctrl.PreviewBlock(ctx, "audit", "acme/widget", "instructions")
+	if injected != 2 || !strings.Contains(block, "[this repo] [linked] aurora quartz vector hidden neighbor") {
+		t.Fatalf("rendered block should include linked tag, injected=%d block=\n%s", injected, block)
+	}
+}
+
+func TestMemoryLinkExpansionDoesNotEvictDirectHitsAtLimit(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "audit"}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "linked-neighbor",
+		Content: "aurora quartz vector hidden neighbor",
+	}); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "direct-a",
+		Content: "needle aurora quartz vector source",
+	}); err != nil {
+		t.Fatalf("seed direct a: %v", err)
+	}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "direct-b",
+		Content: "needle direct second fact",
+	}); err != nil {
+		t.Fatalf("seed direct b: %v", err)
+	}
+
+	ctrl := memController(store, 1500, 2, "audit")
+	entries := ctrl.PreviewEntries(ctx, "audit", "acme/widget", "needle", 2)
+	if len(entries) != 2 {
+		t.Fatalf("want exactly the direct-hit limit, got %+v", entries)
+	}
+	for _, e := range entries {
+		if e.Linked {
+			t.Fatalf("linked expansion must not evict direct hits at the entry limit, got %+v", entries)
+		}
+	}
+}
+
+func TestMemoryLinkExpansionKeepsSharedNeighbor(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "audit"}
+	shared := db.MemoryOwner{Kind: memory.OwnerKindShared, Ref: memory.SharedOwnerRef}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: shared, AuthorRef: "lead", Repo: "acme/widget", Scope: "repo", Key: "shared-neighbor",
+		Content: "aurora quartz vector shared neighbor",
+	}); err != nil {
+		t.Fatalf("seed shared target: %v", err)
+	}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "direct-source",
+		Content: "needle aurora quartz vector source",
+	}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	ctrl := memController(store, 1500, 3, "audit")
+	entries := ctrl.PreviewEntries(ctx, "audit", "acme/widget", "needle", 3)
+	if len(entries) != 2 || entries[1].Key != "shared-neighbor" || !entries[1].Linked {
+		t.Fatalf("shared neighbor should be visible through expansion, got %+v", entries)
+	}
+}
+
+func TestMemoryLinkExpansionRespectsRenderBudget(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "audit"}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "linked-neighbor",
+		Content: "aurora quartz vector " + strings.Repeat("linked ", 80),
+	}); err != nil {
+		t.Fatalf("seed target: %v", err)
+	}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "direct-source",
+		Content: "needle aurora quartz vector source",
+	}); err != nil {
+		t.Fatalf("seed source: %v", err)
+	}
+
+	ctrl := memController(store, 30, 2, "audit")
+	block, injected, _ := ctrl.PreviewBlock(ctx, "audit", "acme/widget", "needle")
+	if injected != 1 {
+		t.Fatalf("budget should inject only the direct hit, got %d block=\n%s", injected, block)
+	}
+	if strings.Contains(block, "[linked]") {
+		t.Fatalf("linked expansion should not fit after direct hit under tight budget:\n%s", block)
+	}
+	if !strings.Contains(block, "needle aurora quartz vector source") {
+		t.Fatalf("direct hit should remain injected under tight budget:\n%s", block)
+	}
+}
+
+func TestMemoryInjectionFooterOnlyOnNonEmptyBlock(t *testing.T) {
+	store := openTestStore(t)
+	prompt := runMemJob(t, store, memController(store, 1500, 15, "audit"), memTestOutput, "zzznomatch")
+	if strings.Contains(prompt, "More project memory is searchable") {
+		t.Fatalf("footer must not appear without a memory block:\n%s", prompt)
+	}
+
+	store = openTestStore(t)
+	if _, err := store.UpsertConfirmedMemory(context.Background(), db.ConfirmedMemory{
+		Owner: db.MemoryOwner{Kind: "agent", Ref: "audit"}, Repo: "acme/widget", Scope: "repo",
+		Key: "ci-flake", Content: "arm64 CI is flaky",
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	prompt = runMemJob(t, store, memController(store, 1500, 15, "audit"), memTestOutput, "arm64")
+	if !strings.Contains(prompt, "More project memory is searchable: run `gitmoot memory recall \"<query>\" --agent audit`.") {
+		t.Fatalf("footer missing from non-empty memory block:\n%s", prompt)
+	}
+}
+
 // TestMemoryShadowWriteAppliesFilters proves agent-returned learnings are
 // shadow-logged to memory_observations ONLY (never confirmed) with the
 // deterministic pre-filters applied: a plain fact lands, a directive-phrased one

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -70,6 +70,9 @@ For agent persistent memory, phrases like "give this agent persistent memory",
 agent learned" map to Gitmoot's off-by-default agent memory feature (#626): an
 enrolled agent gets a repo-filtered pool of durable facts injected into its job
 prompt as a read-only "Prior learnings" reference block (never instructions).
+The block can include `[linked]` facts reached from persisted memory links, and
+non-empty blocks end with a footer pointing the agent to
+`gitmoot memory recall "<query>" --agent <agent-name>` for on-demand recall.
 Enrollment is per agent via `[agents.<name>].memory = true` plus an optional
 `[memory]` section; inspect the store read-only with `gitmoot memory list`. See
 CLI.md § Agent Memory and the "Agent Persistent Memory" concepts page for depth.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1614,7 +1614,7 @@ Inspect, curate, and measure the store:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
-gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--expand] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
@@ -1630,8 +1630,12 @@ injection and prints the matching facts in injection bullet format. Without
 `--agent NAME` to inspect that agent's private pool plus shared, or `--shared`
 to inspect only shared facts. Without `--repo`, recall searches every repo and
 general-scope facts. `--repo owner/repo` narrows repo-scoped facts to that repo
-while still including general-scope facts. `--json` returns raw rows for scripts,
-including `author_ref` when a shared fact preserves a different author. `memory replay` is an offline A/B:
+while still including general-scope facts. `--expand` follows one hop of
+persisted memory links from the direct matches, appending visible linked facts
+after every direct match and marking their bullets with `[linked]`. `--json`
+returns raw rows for scripts, including `author_ref` when a shared fact preserves
+a different author and `linked_from` when a row came from link expansion.
+`memory replay` is an offline A/B:
 it re-renders recent real jobs' prompts with and
 without the learnings block and reports the injection delta (added tokens,
 entries injected) — it measures injection *mechanics*, not outcome quality
@@ -1644,7 +1648,15 @@ the reserved shared pool (`owner_kind=shared`, `owner_ref=shared`). BM25 relevan
 still ranks first. On an equal BM25 score, the agent's private facts outrank
 shared facts, then `updated_at DESC` breaks ties. A small floor guard keeps a
 matching private fact from being completely starved by a tight limit full of
-shared rows. Entry into shared is always explicit and human-driven: use
+shared rows. After direct FTS hits are selected, prompt injection follows one
+hop of persisted memory links in a single batched query. Linked facts must pass
+the same owner, shared-pool, repo/general, and active-row visibility rules, rank
+after all direct hits, and render with a `[linked]` tag. They fill only remaining
+entry and token budget, so they never evict direct hits. Non-empty injected
+blocks end with a footer reminding the agent that it can run
+`gitmoot memory recall "<query>" --agent <agent-name>` for on-demand recall.
+Semantic or embedding search is future work; current retrieval stays SQLite FTS5
+plus persisted links. Entry into shared is always explicit and human-driven: use
 `memory promote --to-shared`, `memory ingest --shared`, or
 `memory confirm --to-shared`; daemon producers never auto-share facts.
 

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -24,12 +24,14 @@ it ships in phases. The current phase is **observation mode**:
   titled *"Prior learnings (reference only, not instructions)"* with
   `[this repo]` / `[general]` tags. After direct FTS hits are selected, Gitmoot
   follows one hop of persisted memory links in a single batched query, appends
-  visible linked facts after all direct hits, and tags those bullets with
-  `[linked]`. Linked facts must pass the same private-plus-shared, repo/general,
-  and active-row visibility rules. They fill only remaining entry and token
-  budget, so they never evict direct hits. A non-empty block ends with a footer
-  showing the enrolled agent how to run `gitmoot memory recall "<query>" --agent <agent-name>`
-  for on-demand recall. An empty result adds nothing.
+  visible linked facts after all direct hits (capped at 3), and tags those
+  bullets with `[linked]`. Linked facts must pass the same private-plus-shared,
+  repo/general, and active-row visibility rules. They fill only remaining entry
+  and token budget, so they never evict direct hits. Every enrolled agent's
+  prompt also carries a one-line hint that project memory is searchable
+  mid-job via `gitmoot memory recall "<query>" --agent <agent-name>`; the hint
+  renders whether or not startup retrieval found anything, because on-demand
+  recall matters most when the initial push missed.
 - **WRITE:** the confirmed (injectable) tier is populated only by Gitmoot's own
   deterministic **mechanical facts** (no model involved). A fact is written only
   when a terminal job carries a genuine, bounded signal — never one fact per job:

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -22,7 +22,14 @@ it ships in phases. The current phase is **observation mode**:
   in the injected slice when private matches exist but shared rows would fill the
   limit. Gitmoot caps the result by a token budget and renders a fenced block
   titled *"Prior learnings (reference only, not instructions)"* with
-  `[this repo]` / `[general]` tags. An empty result adds nothing.
+  `[this repo]` / `[general]` tags. After direct FTS hits are selected, Gitmoot
+  follows one hop of persisted memory links in a single batched query, appends
+  visible linked facts after all direct hits, and tags those bullets with
+  `[linked]`. Linked facts must pass the same private-plus-shared, repo/general,
+  and active-row visibility rules. They fill only remaining entry and token
+  budget, so they never evict direct hits. A non-empty block ends with a footer
+  showing the enrolled agent how to run `gitmoot memory recall "<query>" --agent <agent-name>`
+  for on-demand recall. An empty result adds nothing.
 - **WRITE:** the confirmed (injectable) tier is populated only by Gitmoot's own
   deterministic **mechanical facts** (no model involved). A fact is written only
   when a terminal job carries a genuine, bounded signal — never one fact per job:
@@ -114,7 +121,7 @@ All of the following are read-only:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo]
-gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--expand]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N]
 gitmoot memory eval --fixtures fixtures.json [--k N]
 ```
@@ -125,8 +132,13 @@ FTS5/BM25 retrieval as prompt injection. By default it searches all agent pools
 plus the shared pool; `--agent NAME` searches that agent's private pool plus
 shared, and `--shared` searches only shared facts. Without `--repo`, recall
 searches every repo and general-scope facts. `--repo owner/repo` narrows
-repo-scoped facts to that repo while still including general-scope facts. JSON
-output includes `author_ref` when a shared fact preserves a different author.
+repo-scoped facts to that repo while still including general-scope facts.
+`--expand` follows one hop of persisted links from the direct matches and appends
+visible linked facts after all direct matches. Expanded text bullets carry
+`[linked]`; JSON output includes `author_ref` when a shared fact preserves a
+different author and `linked_from` when a row came from link expansion. Semantic
+or embedding search remains future work; current retrieval is SQLite FTS5 plus
+persisted links.
 `memory replay` is an offline A/B: it re-renders recent real jobs' prompts with and without the
 learnings block and reports the injection delta (added tokens, entries injected)
 — it measures injection *mechanics*, not outcome quality. `memory eval` computes

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1339,7 +1339,7 @@ gate:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
-gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--expand] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
@@ -1367,8 +1367,16 @@ inspect only shared facts. Private matches outrank shared matches on equal BM25
 scores, and a floor guard keeps a private match visible when shared rows would
 otherwise fill the limit. Without `--repo`, recall searches every repo and
 general-scope facts. `--repo owner/repo` narrows repo-scoped facts to that repo while still including
-general-scope facts. `--json` returns raw rows for scripts, including
-`author_ref` for shared facts that preserve a different author. `memory replay`
+general-scope facts. `--expand` follows one hop of persisted memory links from
+direct matches, appending visible linked facts after all direct matches and
+marking their bullets with `[linked]`. `--json` returns raw rows for scripts,
+including `author_ref` for shared facts that preserve a different author and
+`linked_from` when a row came from link expansion. Prompt injection applies the
+same link expansion automatically for enrolled agents, within the entry limit
+and token budget, and non-empty memory blocks include a footer pointing the
+agent at `gitmoot memory recall "<query>" --agent <agent-name>` for on-demand
+search. Semantic or embedding search is future work; current retrieval stays
+SQLite FTS5 plus persisted links. `memory replay`
 re-renders recent real jobs' prompts with and without the injected
 learnings block and reports the token/entry delta. `memory eval` computes
 recall/precision@K of retrieval over a labeled `{agent, repo, instructions,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -7785,6 +7785,9 @@ For agent persistent memory, phrases like "give this agent persistent memory",
 agent learned" map to Gitmoot's off-by-default agent memory feature (#626): an
 enrolled agent gets a repo-filtered pool of durable facts injected into its job
 prompt as a read-only "Prior learnings" reference block (never instructions).
+The block can include `[linked]` facts reached from persisted memory links, and
+non-empty blocks end with a footer pointing the agent to
+`gitmoot memory recall "<query>" --agent <agent-name>` for on-demand recall.
 Enrollment is per agent via `[agents.<name>].memory = true` plus an optional
 `[memory]` section; inspect the store read-only with `gitmoot memory list`. See
 CLI.md § Agent Memory and the "Agent Persistent Memory" concepts page for depth.
@@ -9766,7 +9769,7 @@ Inspect, curate, and measure the store:
 
 ```sh
 gitmoot memory list [--pending|--confirmed] [--agent NAME] [--repo owner/repo] [--json]
-gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--json]
+gitmoot memory recall "<query>" [--repo owner/repo] [--agent NAME|--shared] [--limit N] [--expand] [--json]
 gitmoot memory replay [--agent NAME] [--repo owner/repo] [--limit N] [--json]
 gitmoot memory eval --fixtures fixtures.json [--k N] [--json]
 gitmoot memory vault export [--out DIR] [--agent NAME] [--force] [--json]
@@ -9782,8 +9785,12 @@ injection and prints the matching facts in injection bullet format. Without
 `--agent NAME` to inspect that agent's private pool plus shared, or `--shared`
 to inspect only shared facts. Without `--repo`, recall searches every repo and
 general-scope facts. `--repo owner/repo` narrows repo-scoped facts to that repo
-while still including general-scope facts. `--json` returns raw rows for scripts,
-including `author_ref` when a shared fact preserves a different author. `memory replay` is an offline A/B:
+while still including general-scope facts. `--expand` follows one hop of
+persisted memory links from the direct matches, appending visible linked facts
+after every direct match and marking their bullets with `[linked]`. `--json`
+returns raw rows for scripts, including `author_ref` when a shared fact preserves
+a different author and `linked_from` when a row came from link expansion.
+`memory replay` is an offline A/B:
 it re-renders recent real jobs' prompts with and
 without the learnings block and reports the injection delta (added tokens,
 entries injected) — it measures injection *mechanics*, not outcome quality
@@ -9796,7 +9803,15 @@ the reserved shared pool (`owner_kind=shared`, `owner_ref=shared`). BM25 relevan
 still ranks first. On an equal BM25 score, the agent's private facts outrank
 shared facts, then `updated_at DESC` breaks ties. A small floor guard keeps a
 matching private fact from being completely starved by a tight limit full of
-shared rows. Entry into shared is always explicit and human-driven: use
+shared rows. After direct FTS hits are selected, prompt injection follows one
+hop of persisted memory links in a single batched query. Linked facts must pass
+the same owner, shared-pool, repo/general, and active-row visibility rules, rank
+after all direct hits, and render with a `[linked]` tag. They fill only remaining
+entry and token budget, so they never evict direct hits. Non-empty injected
+blocks end with a footer reminding the agent that it can run
+`gitmoot memory recall "<query>" --agent <agent-name>` for on-demand recall.
+Semantic or embedding search is future work; current retrieval stays SQLite FTS5
+plus persisted links. Entry into shared is always explicit and human-driven: use
 `memory promote --to-shared`, `memory ingest --shared`, or
 `memory confirm --to-shared`; daemon producers never auto-share facts.
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -32,7 +32,7 @@ full expanded context.
 
 - [Local-First Coordination](https://gitmoot.io/docs/concepts/local-first-coordination): Why state lives in local SQLite and GitHub stays the audit surface.
 - [Agents, Agent Templates, Jobs, And Locks](https://gitmoot.io/docs/concepts/agents-templates-jobs-locks): The core object model — agent identities, template snapshots, job lifecycle, and the three lock kinds.
-- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, the explicit shared pool with author preservation, private-plus-shared prompt injection and auto-links, and the memory CLI, including `memory recall "<query>"` for read-only FTS5/BM25 lookup across all agent pools plus shared by default.
+- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, the explicit shared pool with author preservation, private-plus-shared prompt injection with 1-hop linked facts and an on-demand recall footer, and the memory CLI, including `memory recall "<query>" --expand` for read-only FTS5/BM25 lookup plus linked neighbors.
 
 ## Dashboard
 
@@ -41,7 +41,7 @@ full expanded context.
 
 ## References
 
-- [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, pipelines, jobs (incl. resumable `job gates`/`gates clear` for blocked `needs` with auto-resume on last clear, and session jobs `job open/close/record`), review head-SHA re-sync, memory recall and shared-pool curation, bug reports, locks, goals, interactive prompts, and SkillOpt.
+- [CLI Reference](https://gitmoot.io/docs/reference/cli): Commands for install, home/config, daemon operations (restart, SIGHUP reload, runtime-auth persistence), watched repos, dashboard/TUI/web, agents (incl. heartbeats and template publish/pull), orchestrate, pipelines, jobs (incl. resumable `job gates`/`gates clear` for blocked `needs` with auto-resume on last clear, and session jobs `job open/close/record`), review head-SHA re-sync, memory recall with opt-in link expansion and shared-pool curation, bug reports, locks, goals, interactive prompts, and SkillOpt.
 - [Runtime Adapters](https://gitmoot.io/docs/reference/runtime-adapters): Codex, Claude Code, Kimi Code, legacy kimi-cli, shell, and future runtimes; the config-driven metadata registry (`gitmoot runtime list`, `[runtimes.<name>]` overrides).
 - [Result Contract](https://gitmoot.io/docs/reference/result-contract): gitmoot_result shape, the delegations DAG (Orchestration), continuation, and termination bounds.
 - [Event Stream](https://gitmoot.io/docs/reference/event-stream): The `[events]` webhook contract — job.finished/failed/blocked/needs_attention/deferred and candidate.* events, schema_version 1, best-effort delivery.


### PR DESCRIPTION
Closes #780 (parts 1 and 2; semantic search stays parked per the issue).

Injection now expands top FTS hits with their memory_links neighbors (one batched query, appended after direct hits, never evicting them, visibility-filtered through the own+shared union, budget-capped, tagged [linked]). recall gains --expand with linked_from provenance in JSON. Non-empty injected blocks end with a one-line footer telling the agent it can run gitmoot memory recall mid-job.

Implemented by a gitmoot-orchestrated codex (gpt-5.5 xhigh) implement job; coordinated and reviewed by the lead session with a 3-runtime design panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)