### PR TITLE
feat(memory): success distillation - skillopt promotions + recovered-failure observations

### DIFF
--- a/internal/cli/canary_daemon.go
+++ b/internal/cli/canary_daemon.go
@@ -35,6 +35,7 @@ func daemonOutcomeHarvesterWithCanary(store *db.Store, gh github.Client, home st
 		inner:      base,
 		store:      store,
 		sink:       daemonEventSink(store, home),
+		home:       home,
 		minSamples: policy.AutoPromoteMinSamples,
 	}
 }
@@ -52,6 +53,7 @@ type canaryRegressionHarvester struct {
 	inner      workflow.OutcomeHarvester
 	store      *db.Store
 	sink       events.Sink
+	home       string
 	minSamples *int
 }
 
@@ -136,6 +138,7 @@ func (h *canaryRegressionHarvester) evaluate(ctx context.Context, payload workfl
 		if err != nil {
 			return
 		}
+		stageSkillOptPromotionObservationForHome(ctx, h.store, h.home, promoted)
 		emitCandidateEvent(ctx, h.sink, events.EventCandidateAutoPromoted, promoted, "auto_promoted", verdict.Reason)
 	default:
 		// CanaryContinue: keep sampling; no state change.

--- a/internal/cli/candidate_notify.go
+++ b/internal/cli/candidate_notify.go
@@ -93,7 +93,15 @@ func notifyAndMaybeAutoPromoteCandidate(ctx context.Context, store *db.Store, ho
 	sink := buildDaemonEventSink(store, home)
 	defer events.FlushSink(ctx, sink)
 	confidence, confidenceSamples, confidenceSummary, pairwiseWins, pairwiseLosses := resolveBanditConfidence(ctx, store, version)
-	return runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents, feedbackUnavailable, confidence, confidenceSamples, confidenceSummary, pairwiseWins, pairwiseLosses)
+	if err := runCandidateNotify(ctx, store, sink, policy, candidate, version, feedbackEvents, feedbackUnavailable, confidence, confidenceSamples, confidenceSummary, pairwiseWins, pairwiseLosses); err != nil {
+		return err
+	}
+	if store != nil {
+		if promoted, err := store.GetAgentTemplateVersionByID(ctx, version.ID); err == nil && promoted.State == "current" && version.State != "current" {
+			stageSkillOptPromotionObservationForHome(ctx, store, home, promoted)
+		}
+	}
+	return nil
 }
 
 // resolveBanditConfidence looks up the #473 Mode B bandit confidence backing a

--- a/internal/cli/memory_daemon.go
+++ b/internal/cli/memory_daemon.go
@@ -43,11 +43,12 @@ func daemonMemoryController(store *db.Store, home string) *workflow.MemoryContro
 		}
 	}
 	// With no enrolled agent there is normally nothing to read or write for, so the
-	// controller stays nil (byte-identical). The ONE exception is box-wide distill:
-	// distill_at_terminal + distill_all_jobs stages failure signal for EVERY job,
-	// so it needs a controller even when no agent opted into the read path. Both
-	// keys are off by default, so this widening is inert unless explicitly enabled.
-	if len(enrolled) == 0 && !(settings.DistillAtTerminal && settings.DistillAllJobs) {
+	// controller stays nil (byte-identical). The exceptions are box-wide distill
+	// producers: distill_at_terminal + distill_all_jobs stages failure signal for
+	// EVERY job, and distill_successes + distill_all_jobs stages recovered-failure
+	// success observations the same way. All keys are off by default, so this
+	// widening is inert unless explicitly enabled.
+	if len(enrolled) == 0 && !((settings.DistillAtTerminal || settings.DistillSuccesses) && settings.DistillAllJobs) {
 		return nil
 	}
 	return &workflow.MemoryController{
@@ -56,6 +57,7 @@ func daemonMemoryController(store *db.Store, home string) *workflow.MemoryContro
 		TokenBudget:       settings.TokenBudget,
 		MaxEntries:        settings.MaxEntries,
 		DistillAtTerminal: settings.DistillAtTerminal,
+		DistillSuccesses:  settings.DistillSuccesses,
 		DistillMaxPerJob:  settings.DistillMaxPerJob,
 		DistillAllJobs:    settings.DistillAllJobs,
 	}

--- a/internal/cli/memory_success_distill.go
+++ b/internal/cli/memory_success_distill.go
@@ -1,0 +1,253 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+)
+
+const (
+	skillOptPromotionProvenancePrefix = "skillopt-promotion:"
+	skillOptPromotionFallbackOwner    = "lead"
+)
+
+// stageSkillOptPromotionObservation stages the #781 SkillOpt-promotion success
+// observation. It is config-gated, best-effort, pending-only, low-trust, and never
+// writes confirmed memory directly.
+func stageSkillOptPromotionObservation(ctx context.Context, store *db.Store, paths config.Paths, promoted db.AgentTemplateVersion) {
+	if store == nil || strings.TrimSpace(promoted.ID) == "" {
+		return
+	}
+	settings, err := config.LoadMemorySettings(paths)
+	if err != nil || settings.Disabled || !settings.DistillSuccesses {
+		return
+	}
+	ownerRef, repo := resolveSkillOptPromotionOwnerAndRepo(ctx, store, paths, promoted)
+	owner := db.MemoryOwner{Kind: memory.OwnerKindAgent, Ref: ownerRef}
+	scope := memory.ScopeRepo
+	if strings.TrimSpace(repo) == "" {
+		scope = memory.ScopeGeneral
+	}
+	content := skillOptPromotionObservationContent(ctx, store, promoted)
+	if ok, _ := memory.PreFilter(content, scope); !ok {
+		return
+	}
+	key := skillOptPromotionObservationKey(promoted)
+	if n, err := store.CountMemoryObservationsForKey(ctx, owner, repo, key); err != nil || n > 0 {
+		return
+	}
+	seen, err := store.ObservationDedupKeys(ctx, owner.Ref)
+	if err != nil {
+		return
+	}
+	dkey := db.MemoryDedupKey(scope, repo, memory.ContentHash(content))
+	if _, dup := seen[dkey]; dup {
+		return
+	}
+	_, _ = store.InsertMemoryObservation(ctx, db.MemoryObservation{
+		Owner:      owner,
+		Repo:       repo,
+		Scope:      scope,
+		Key:        key,
+		Content:    content,
+		Provenance: skillOptPromotionProvenancePrefix + promoted.ID,
+		TrustMark:  memory.TrustLow,
+	})
+}
+
+func stageSkillOptPromotionObservationForHome(ctx context.Context, store *db.Store, home string, promoted db.AgentTemplateVersion) {
+	paths, err := memoryPathsForHome(home)
+	if err != nil {
+		return
+	}
+	stageSkillOptPromotionObservation(ctx, store, paths, promoted)
+}
+
+func resolveSkillOptPromotionOwnerAndRepo(ctx context.Context, store *db.Store, paths config.Paths, promoted db.AgentTemplateVersion) (string, string) {
+	templateID := strings.TrimSpace(promoted.TemplateID)
+	owner := skillOptPromotionFallbackOwner
+	repo := skillOptPromotionRepo(promoted.SourceRepo)
+	if agents, err := store.ListAgents(ctx); err == nil {
+		for _, agent := range agents {
+			if !skillOptTemplateRefMatches(agent.TemplateID, templateID) {
+				continue
+			}
+			owner = strings.TrimSpace(agent.Name)
+			if repo == "" {
+				repo = skillOptPromotionRepo(agent.RepoScope)
+			}
+			return ownerOrFallback(owner), repo
+		}
+	}
+	if types, err := config.LoadAgentTypes(paths); err == nil {
+		names := make([]string, 0, len(types))
+		for name := range types {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if skillOptTemplateRefMatches(types[name].Template, templateID) {
+				return ownerOrFallback(name), repo
+			}
+		}
+	}
+	return owner, repo
+}
+
+func skillOptTemplateRefMatches(ref, templateID string) bool {
+	id, _ := db.SplitAgentTemplateReference(ref)
+	return strings.TrimSpace(id) != "" && strings.TrimSpace(id) == strings.TrimSpace(templateID)
+}
+
+func ownerOrFallback(owner string) string {
+	if strings.TrimSpace(owner) == "" {
+		return skillOptPromotionFallbackOwner
+	}
+	return strings.TrimSpace(owner)
+}
+
+func skillOptPromotionRepo(repo string) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" || !strings.Contains(repo, "/") || strings.ContainsAny(repo, " \t\n\r") {
+		return ""
+	}
+	return repo
+}
+
+func skillOptPromotionObservationKey(promoted db.AgentTemplateVersion) string {
+	hash := strings.TrimSpace(promoted.ContentHash)
+	if hash == "" {
+		sum := sha256.Sum256([]byte(promoted.Content + promoted.ID))
+		hash = hex.EncodeToString(sum[:])
+	}
+	if len(hash) > 12 {
+		hash = hash[:12]
+	}
+	return fmt.Sprintf("skillopt:%s-promoted:%s", strings.TrimSpace(promoted.ID), hash)
+}
+
+func skillOptPromotionObservationContent(ctx context.Context, store *db.Store, promoted db.AgentTemplateVersion) string {
+	base := "unknown base"
+	var review db.AgentTemplateCandidateReview
+	if r, err := store.GetAgentTemplateCandidateReview(ctx, promoted.ID); err == nil {
+		review = r
+		if strings.TrimSpace(r.BaseVersionID) != "" {
+			base = strings.TrimSpace(r.BaseVersionID)
+		}
+	}
+	parts := []string{
+		fmt.Sprintf("SkillOpt promoted %s over %s for template %s.", promoted.ID, base, promoted.TemplateID),
+	}
+	evidence := skillOptPromotionEvidence(ctx, store, promoted.ID, review)
+	if len(evidence) > 0 {
+		parts = append(parts, "Evidence: "+strings.Join(evidence, "; ")+".")
+	}
+	if weaknesses := skillOptPromotionWeaknesses(review); weaknesses != "" {
+		parts = append(parts, "Trained weaknesses: "+weaknesses+".")
+	}
+	return strings.Join(parts, " ")
+}
+
+func skillOptPromotionEvidence(ctx context.Context, store *db.Store, versionID string, review db.AgentTemplateCandidateReview) []string {
+	var evidence []string
+	if review.Score != nil {
+		evidence = append(evidence, fmt.Sprintf("review score %.4g", *review.Score))
+	}
+	if runs, err := store.ListSkillOptGateRuns(ctx, versionID); err == nil && len(runs) > 0 {
+		run := runs[0]
+		for _, candidate := range runs {
+			if candidate.Accepted {
+				run = candidate
+				break
+			}
+		}
+		verdict := "rejected"
+		if run.Accepted {
+			verdict = "accepted"
+		}
+		evidence = append(evidence, fmt.Sprintf("replay gate %s with candidate mean %.4g over champion mean %.4g", verdict, run.CandidateMean, run.ChampionMean))
+	}
+	return evidence
+}
+
+func skillOptPromotionWeaknesses(review db.AgentTemplateCandidateReview) string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, raw := range []string{review.SummaryMetadataJSON, review.EvalReportJSON} {
+		var decoded any
+		if strings.TrimSpace(raw) == "" || json.Unmarshal([]byte(raw), &decoded) != nil {
+			continue
+		}
+		collectSkillOptWeaknesses(decoded, "", seen, &out)
+		if len(out) >= 3 {
+			break
+		}
+	}
+	if len(out) > 3 {
+		out = out[:3]
+	}
+	return strings.Join(out, "; ")
+}
+
+func collectSkillOptWeaknesses(v any, key string, seen map[string]struct{}, out *[]string) {
+	if len(*out) >= 3 {
+		return
+	}
+	switch x := v.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(x))
+		for k := range x {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			childKey := k
+			if skillOptWeaknessKey(key) {
+				childKey = key
+			}
+			collectSkillOptWeaknesses(x[k], childKey, seen, out)
+			if len(*out) >= 3 {
+				return
+			}
+		}
+	case []any:
+		for _, item := range x {
+			collectSkillOptWeaknesses(item, key, seen, out)
+			if len(*out) >= 3 {
+				return
+			}
+		}
+	case string:
+		if !skillOptWeaknessKey(key) {
+			return
+		}
+		s := strings.Join(strings.Fields(x), " ")
+		if len(s) > 120 {
+			s = strings.TrimSpace(s[:120])
+		}
+		if s == "" {
+			return
+		}
+		if _, dup := seen[s]; dup {
+			return
+		}
+		seen[s] = struct{}{}
+		*out = append(*out, s)
+	}
+}
+
+func skillOptWeaknessKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	return strings.Contains(k, "weak") ||
+		strings.Contains(k, "required_improvements") ||
+		strings.Contains(k, "rejected_traits") ||
+		strings.Contains(k, "optimizer_hint")
+}

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -2667,7 +2667,7 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			return output, nil
 		}
 		if skillOptTrainDecisionRequested(request) && summary.CurrentPhase == skillopt.TrainStateCandidateReviewPublished {
-			return continueSkillOptTrainCandidateDecision(ctx, store, session, *iteration, counts, request)
+			return continueSkillOptTrainCandidateDecision(ctx, paths, store, session, *iteration, counts, request)
 		}
 		if summary.CurrentPhase != skillopt.TrainStateCandidateCreated {
 			output.Lines = []string{fmt.Sprintf("next: %s", summary.NextAction)}
@@ -2702,7 +2702,7 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 			if updatedIteration == nil {
 				return skillOptTrainContinueOutput{}, errors.New("train session has no recovered iteration to decide")
 			}
-			return continueSkillOptTrainCandidateDecision(ctx, store, updatedSession, *updatedIteration, updatedCounts, request)
+			return continueSkillOptTrainCandidateDecision(ctx, paths, store, updatedSession, *updatedIteration, updatedCounts, request)
 		}
 		result, err := publishSkillOptTrainCandidateReview(ctx, paths, store, session, *iteration, request.Home)
 		if err != nil {
@@ -2720,7 +2720,7 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 		}
 		return skillOptTrainContinueOutput{Summary: updatedSummary, Counts: updatedCounts, ContinueReady: true, Lines: lines}, nil
 	case skillopt.TrainStateCandidateReviewPublished:
-		return continueSkillOptTrainCandidateDecision(ctx, store, session, *iteration, counts, request)
+		return continueSkillOptTrainCandidateDecision(ctx, paths, store, session, *iteration, counts, request)
 	case skillopt.TrainStateCandidatePromoted, skillopt.TrainStateCandidateRejected:
 		if err := validateTerminalSkillOptTrainDecisionRequest(*iteration, request); err != nil {
 			return skillOptTrainContinueOutput{}, err
@@ -2754,10 +2754,10 @@ func continueSkillOptTrain(ctx context.Context, paths config.Paths, store *db.St
 	}
 }
 
-func continueSkillOptTrainCandidateDecision(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, counts skillopt.TrainStatusCounts, request skillOptTrainContinueRequest) (skillOptTrainContinueOutput, error) {
+func continueSkillOptTrainCandidateDecision(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, counts skillopt.TrainStatusCounts, request skillOptTrainContinueRequest) (skillOptTrainContinueOutput, error) {
 	summary := skillopt.BuildTrainStatusSummary(session, &iteration, counts)
 	output := skillOptTrainContinueOutput{Summary: summary, Counts: counts}
-	result, err := decideSkillOptTrainCandidate(ctx, store, session, iteration, request)
+	result, err := decideSkillOptTrainCandidate(ctx, paths, store, session, iteration, request)
 	if err != nil {
 		return skillOptTrainContinueOutput{}, err
 	}
@@ -4353,7 +4353,7 @@ func skillOptTrainStatusCommand(usesCustomHome bool, sessionID string) string {
 	return shellArgs(args)
 }
 
-func decideSkillOptTrainCandidate(ctx context.Context, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainContinueRequest) (skillOptTrainCandidateDecisionResult, error) {
+func decideSkillOptTrainCandidate(ctx context.Context, paths config.Paths, store *db.Store, session db.SkillOptTrainSession, iteration db.SkillOptTrainIteration, request skillOptTrainContinueRequest) (skillOptTrainCandidateDecisionResult, error) {
 	promote := strings.TrimSpace(request.PromoteCandidate)
 	reject := strings.TrimSpace(request.RejectCandidate)
 	if promote != "" && reject != "" {
@@ -4412,8 +4412,12 @@ func decideSkillOptTrainCandidate(ctx context.Context, store *db.Store, session 
 	}
 	session.MetadataJSON = mergeSkillOptTrainMetadata(session.MetadataJSON, "candidate_decision", metadata)
 	iteration.MetadataJSON = mergeSkillOptTrainMetadata(iteration.MetadataJSON, "candidate_decision", metadata)
-	if _, err := store.DecideSkillOptTrainCandidate(ctx, session, iteration, candidateID, decision); err != nil {
+	promoted, err := store.DecideSkillOptTrainCandidate(ctx, session, iteration, candidateID, decision)
+	if err != nil {
 		return skillOptTrainCandidateDecisionResult{}, err
+	}
+	if decision == "promoted" {
+		stageSkillOptPromotionObservation(ctx, store, paths, promoted)
 	}
 	return skillOptTrainCandidateDecisionResult{Decided: true, Decision: decision, CandidateVersionID: candidateID}, nil
 }
@@ -12013,9 +12017,12 @@ func runSkillOptCandidatePromote(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	var promoted db.AgentTemplateVersion
-	if err := withStore(*home, func(store *db.Store) error {
+	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
 		var err error
 		promoted, err = store.PromoteAgentTemplateVersion(context.Background(), fs.Arg(0))
+		if err == nil {
+			stageSkillOptPromotionObservation(context.Background(), store, paths, promoted)
+		}
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "skillopt candidate promote: %v\n", err)

--- a/internal/cli/skillopt_success_distill_test.go
+++ b/internal/cli/skillopt_success_distill_test.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/skillopt"
+)
+
+func TestSkillOptCandidatePromoteStagesSuccessObservation(t *testing.T) {
+	home, versionID := seedSkillOptPromotionCandidate(t, true)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "candidate", "promote", "--home", home, versionID}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("candidate promote exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	store := openCLIJobStore(t, home)
+	obs, err := store.ListMemoryObservations(context.Background(), "builder", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListMemoryObservations returned error: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("promote should stage one observation, got %+v", obs)
+	}
+	got := obs[0]
+	if got.Owner.Ref != "builder" || got.Repo != "owner/repo" || got.Scope != memory.ScopeRepo {
+		t.Fatalf("observation owner/repo/scope = %+v", got)
+	}
+	if !strings.HasPrefix(got.Key, "skillopt:planner@v2-promoted:") {
+		t.Fatalf("observation key = %q", got.Key)
+	}
+	if got.TrustMark != memory.TrustLow || got.Provenance != "skillopt-promotion:planner@v2" {
+		t.Fatalf("observation trust/provenance = %q/%q", got.TrustMark, got.Provenance)
+	}
+	for _, want := range []string{
+		"SkillOpt promoted planner@v2 over planner@v1",
+		"review score 0.87",
+		"replay gate accepted with candidate mean 0.91 over champion mean 0.72",
+		"tighten result JSON",
+		"avoid generic output",
+	} {
+		if !strings.Contains(got.Content, want) {
+			t.Fatalf("observation content missing %q:\n%s", want, got.Content)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"skillopt", "candidate", "promote", "--home", home, versionID}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("second promote unexpectedly succeeded; stdout=%s stderr=%s", stdout.String(), stderr.String())
+	}
+	obs, err = store.ListMemoryObservations(context.Background(), "builder", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListMemoryObservations after repeat returned error: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("repeat promote must not duplicate observations, got %+v", obs)
+	}
+}
+
+func TestSkillOptCandidatePromoteDistillSuccessesDefaultOff(t *testing.T) {
+	home, versionID := seedSkillOptPromotionCandidate(t, false)
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"skillopt", "candidate", "promote", "--home", home, versionID}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("candidate promote exit code = %d; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	obs, err := store.ListMemoryObservations(context.Background(), "builder", "owner/repo")
+	if err != nil {
+		t.Fatalf("ListMemoryObservations returned error: %v", err)
+	}
+	if len(obs) != 0 {
+		t.Fatalf("distill_successes default-off should write no observations, got %+v", obs)
+	}
+}
+
+func seedSkillOptPromotionCandidate(t *testing.T, distillSuccesses bool) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if distillSuccesses {
+		if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+`
+[memory]
+distill_successes = true
+`), 0o600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	template := cliSkillOptTemplate("planner", "Plan the work.")
+	template.SourceRepo = "owner/repo"
+	if err := store.UpsertAgentTemplate(ctx, template); err != nil {
+		t.Fatalf("UpsertAgentTemplate returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "builder",
+		Runtime:        runtime.ShellRuntime,
+		RuntimeRef:     "true",
+		RepoScope:      "owner/repo",
+		TemplateID:     "planner",
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: runtime.AutonomyPolicyAuto,
+	}); err != nil {
+		t.Fatalf("UpsertAgent returned error: %v", err)
+	}
+	installed, err := store.GetAgentTemplate(ctx, "planner")
+	if err != nil {
+		t.Fatalf("GetAgentTemplate returned error: %v", err)
+	}
+	candidate := cliSkillOptCandidatePackage(t, "planner", installed.VersionID, "Plan with stronger guidance.")
+	version, err := skillopt.ImportCandidatePackage(ctx, store, candidate, "candidate.json")
+	if err != nil {
+		t.Fatalf("ImportCandidatePackage returned error: %v", err)
+	}
+	review, err := store.GetAgentTemplateCandidateReview(ctx, version.ID)
+	if err != nil {
+		t.Fatalf("GetAgentTemplateCandidateReview returned error: %v", err)
+	}
+	score := 0.87
+	review.Score = &score
+	review.SummaryMetadataJSON = `{"rejected_traits":{"Option A":["avoid generic output"]},"required_improvements":["tighten result JSON"]}`
+	if err := store.UpsertAgentTemplateCandidateReview(ctx, review); err != nil {
+		t.Fatalf("UpsertAgentTemplateCandidateReview returned error: %v", err)
+	}
+	if err := store.InsertSkillOptGateRun(ctx, db.SkillOptGateRun{
+		ID:                 "gate-1",
+		TemplateID:         "planner",
+		CandidateVersionID: version.ID,
+		ChampionVersionID:  installed.VersionID,
+		Accepted:           true,
+		ChampionMean:       0.72,
+		CandidateMean:      0.91,
+		CorpusItems:        2,
+		Attempts:           1,
+	}); err != nil {
+		t.Fatalf("InsertSkillOptGateRun returned error: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	return home, version.ID
+}

--- a/internal/cli/skillopt_test.go
+++ b/internal/cli/skillopt_test.go
@@ -6612,7 +6612,7 @@ func TestSkillOptTrainCandidateReviewBodyMarksNoOpNotPromotable(t *testing.T) {
 	if strings.Contains(body, "--promote "+version.ID) {
 		t.Fatalf("candidate review body exposed promote command for no-op metadata:\n%s", body)
 	}
-	_, err = decideSkillOptTrainCandidate(context.Background(), store, session, db.SkillOptTrainIteration{
+	_, err = decideSkillOptTrainCandidate(context.Background(), config.Paths{}, store, session, db.SkillOptTrainIteration{
 		ID:                 "optimizer-train-001",
 		State:              skillopt.TrainStateCandidateReviewPublished,
 		CandidateVersionID: version.ID,

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -117,10 +117,13 @@ path = ""
 # the master switch for #737 P4.1 deterministic distill-at-terminal: on an anomalous
 # terminal (failed/blocked/changes_requested) Gitmoot stages bounded PENDING
 # observations (failing tests + named errors) at trust_mark=low, provenance
-# distill:<job-id> — NEVER confirmed memory (the memory confirm gate stays the only
-# promotion path). distill_max_per_job (default 3, >= 0) caps distilled rows per job;
-# distill_all_jobs (default false) widens distill past enrolled agents to every job.
-# All [memory] keys are read PER TICK — no daemon restart is needed to flip them.
+# distill:<job-id>, NEVER confirmed memory (the memory confirm gate stays the only
+# promotion path). distill_successes (default false) enables #781 deterministic
+# success producers: SkillOpt promotions and recovered-failure observations. They
+# also stage only trust_mark=low pending observations. distill_max_per_job (default
+# 3, >= 0) caps per-job distilled rows; distill_all_jobs (default false) widens
+# terminal distill past enrolled agents to every job.
+# All [memory] keys are read PER TICK; no daemon restart is needed to flip them.
 # Inspect the store read-only with gitmoot memory list; see the "Agent Persistent
 # Memory" concepts page and CLI.md for the full model.
 # [memory]
@@ -128,6 +131,7 @@ path = ""
 # token_budget = 1500
 # max_entries = 15
 # distill_at_terminal = false
+# distill_successes = false
 # distill_max_per_job = 3
 # distill_all_jobs = false
 #

--- a/internal/config/memory.go
+++ b/internal/config/memory.go
@@ -15,7 +15,7 @@ const (
 	DefaultMemoryMaxEntries  = 15
 	// DefaultMemoryDistillMaxPerJob caps how many pending observations the
 	// deterministic distill-at-terminal producers (#737 P4.1) may stage per job.
-	// It is only consulted when distill_at_terminal is enabled.
+	// It is only consulted when distill_at_terminal or distill_successes is enabled.
 	DefaultMemoryDistillMaxPerJob = 3
 )
 
@@ -45,9 +45,15 @@ type MemorySettings struct {
 	// deterministically from the result — never confirmed memory (the owner's
 	// `memory confirm` gate stays the only promotion path).
 	DistillAtTerminal bool
+	// DistillSuccesses enables deterministic success-side memory producers (#781).
+	// Default false: no SkillOpt promotion observations and no recovered-failure
+	// observations are staged. When true, those producers still write only pending
+	// low-trust observations; they never confirm memory directly.
+	DistillSuccesses bool
 	// DistillMaxPerJob is the hard per-job cap on distill writes (default 3). Only
-	// consulted when DistillAtTerminal is true; a value <= 0 falls back to the
-	// default so the producers can never write an unbounded number of rows.
+	// consulted when DistillAtTerminal or DistillSuccesses is true; a value <= 0
+	// falls back to the default so the producers can never write an unbounded number
+	// of rows.
 	DistillMaxPerJob int
 	// DistillAllJobs widens distill to EVERY job, not only memory-enrolled agents.
 	// Default false: distill (like the rest of memory) runs only for agents with
@@ -64,6 +70,7 @@ func DefaultMemorySettings() MemorySettings {
 		TokenBudget:       DefaultMemoryTokenBudget,
 		MaxEntries:        DefaultMemoryMaxEntries,
 		DistillAtTerminal: false,
+		DistillSuccesses:  false,
 		DistillMaxPerJob:  DefaultMemoryDistillMaxPerJob,
 		DistillAllJobs:    false,
 	}
@@ -125,6 +132,12 @@ func LoadMemorySettings(paths Paths) (MemorySettings, error) {
 				return MemorySettings{}, fmt.Errorf("parse [memory].distill_at_terminal: %w", err)
 			}
 			settings.DistillAtTerminal = parsed
+		case "distill_successes":
+			parsed, err := parseConfigBool(value)
+			if err != nil {
+				return MemorySettings{}, fmt.Errorf("parse [memory].distill_successes: %w", err)
+			}
+			settings.DistillSuccesses = parsed
 		case "distill_max_per_job":
 			parsed, err := strconv.Atoi(value)
 			if err != nil {

--- a/internal/config/memory_test.go
+++ b/internal/config/memory_test.go
@@ -23,7 +23,7 @@ func TestLoadMemorySettingsDefaults(t *testing.T) {
 		t.Fatalf("defaults = %+v", settings)
 	}
 	// Distill is off by default with a bounded per-job cap.
-	if settings.DistillAtTerminal || settings.DistillAllJobs {
+	if settings.DistillAtTerminal || settings.DistillSuccesses || settings.DistillAllJobs {
 		t.Fatalf("distill must be off by default, got %+v", settings)
 	}
 	if settings.DistillMaxPerJob != DefaultMemoryDistillMaxPerJob {
@@ -39,6 +39,7 @@ func TestLoadMemorySettingsParsesDistillKnobs(t *testing.T) {
 	if err := os.WriteFile(paths.ConfigFile, []byte(DefaultConfig(paths)+`
 [memory]
 distill_at_terminal = true
+distill_successes = true
 distill_max_per_job = 5
 distill_all_jobs = true
 `), 0o600); err != nil {
@@ -48,7 +49,7 @@ distill_all_jobs = true
 	if err != nil {
 		t.Fatalf("LoadMemorySettings: %v", err)
 	}
-	if !settings.DistillAtTerminal || !settings.DistillAllJobs || settings.DistillMaxPerJob != 5 {
+	if !settings.DistillAtTerminal || !settings.DistillSuccesses || !settings.DistillAllJobs || settings.DistillMaxPerJob != 5 {
 		t.Fatalf("parsed distill knobs = %+v", settings)
 	}
 }

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -1439,6 +1439,37 @@ FROM confirmed_memories`
 	return scanConfirmedMemories(rows)
 }
 
+// ListActiveConfirmedMemoriesByProvenancePrefix returns active confirmed rows for
+// one owner, repo, and provenance prefix. It is a targeted non-FTS read for
+// deterministic producers that need to reason over confirmed facts without
+// surfacing retired or superseded rows.
+func (s *Store) ListActiveConfirmedMemoriesByProvenancePrefix(ctx context.Context, owner MemoryOwner, repo, provenancePrefix string, limit int) ([]ConfirmedMemory, error) {
+	if strings.TrimSpace(owner.Kind) == "" || strings.TrimSpace(owner.Ref) == "" || strings.TrimSpace(provenancePrefix) == "" {
+		return nil, nil
+	}
+	query := `
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+	provenance, source_job, first_confirmed_at, updated_at
+FROM confirmed_memories
+WHERE owner_kind = ? AND owner_ref = ? AND owner_version = ?
+	AND ((? IS NULL AND repo IS NULL) OR repo = ?)
+	AND provenance LIKE ? ESCAPE '\'
+	AND superseded_by IS NULL
+	AND retired_at = ''
+ORDER BY updated_at DESC, id DESC`
+	args := []any{owner.Kind, owner.Ref, owner.Version, nullableRepo(repo), nullableRepo(repo), likePrefix(provenancePrefix)}
+	if limit > 0 {
+		query += "\nLIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list active confirmed memories by provenance: %w", err)
+	}
+	defer rows.Close()
+	return scanConfirmedMemories(rows)
+}
+
 // MemoryDistillWitnessProvenancePrefix marks a recurrence-WITNESS observation row
 // written by distill-at-terminal (#737 P4.1). Witness rows are internal recurrence
 // bookkeeping — NOT human-reviewable observations — so the pending list surface

--- a/internal/workflow/memory.go
+++ b/internal/workflow/memory.go
@@ -46,6 +46,9 @@ type MemoryController struct {
 	// producers (#737 P4.1). Default false: with it off, record() runs exactly the
 	// Phase-1 write path and the terminal is byte-identical (no distilled rows).
 	DistillAtTerminal bool
+	// DistillSuccesses enables deterministic success-side distill producers (#781).
+	// Default false: no success-side observation rows are staged.
+	DistillSuccesses bool
 	// DistillMaxPerJob is the hard per-job cap on distill writes; <= 0 falls back
 	// to config.DefaultMemoryDistillMaxPerJob so the producers are always bounded.
 	DistillMaxPerJob int
@@ -70,6 +73,19 @@ func (c *MemoryController) enabledFor(agentName string) bool {
 // harvesting). When DistillAllJobs is false it falls back to the enrolled set.
 func (c *MemoryController) distillEnabledFor(agentName string) bool {
 	if c == nil || c.Store == nil || !c.DistillAtTerminal {
+		return false
+	}
+	if c.DistillAllJobs {
+		return true
+	}
+	return c.enabledFor(agentName)
+}
+
+// distillSuccessEnabledFor mirrors distillEnabledFor for the success-side
+// producers (#781). It is separately gated so an operator can keep failure
+// distill enabled while success producers remain off.
+func (c *MemoryController) distillSuccessEnabledFor(agentName string) bool {
+	if c == nil || c.Store == nil || !c.DistillSuccesses {
 		return false
 	}
 	if c.DistillAllJobs {
@@ -220,7 +236,6 @@ func memoryEntryFromConfirmed(r db.ConfirmedMemory, linked bool) memory.Entry {
 	}
 }
 
-
 // record is the WRITE path, run at job terminal. The ENROLLED-ONLY Phase-1 body
 // (recordEnrolled) (a) SHADOW-logs the agent's returned learnings to
 // memory_observations after the deterministic pre-filters, and (b) writes any
@@ -244,6 +259,9 @@ func (c *MemoryController) record(ctx context.Context, jobID string, agent runti
 	// un-enrolled agents when DistillAllJobs is set. Fail-safe: any error inside is
 	// swallowed and can never affect the job outcome.
 	c.distillAtTerminal(ctx, jobID, agent, action, payload, result)
+	// (d) #781 success distill — also PENDING-only and low-trust. It is separately
+	// gated by [memory].distill_successes so the default terminal path stays inert.
+	c.distillRecoveredFailuresAtSuccess(ctx, jobID, agent, payload, result)
 }
 
 // recordEnrolled is the Phase-1 ENROLLED-ONLY write path: shadow-log the agent's

--- a/internal/workflow/memory_distill.go
+++ b/internal/workflow/memory_distill.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -51,6 +52,10 @@ const (
 	distillWitnessProvenancePrefix = db.MemoryDistillWitnessProvenancePrefix
 	// distillStagedProvenancePrefix marks a genuinely staged distilled observation.
 	distillStagedProvenancePrefix = "distill:"
+	// distillSuccessProvenancePrefix marks a success-side recovery observation. It
+	// intentionally does not start with "distill:" so confirmed recovery evidence is
+	// never re-read as a confirmed failure fact by the recovery producer.
+	distillSuccessProvenancePrefix = "distill-success:"
 	// distillWitnessSentinel is the FIXED, PreFilter-safe content stored on a
 	// recurrence witness. It is deliberately constant (never a candidate's content)
 	// so it can never false-collide with a real staged content in the dedup path.
@@ -77,6 +82,12 @@ var distillDecisions = map[string]bool{
 	"failed":            true,
 	"blocked":           true,
 	"changes_requested": true,
+}
+
+var distillSuccessDecisions = map[string]bool{
+	"approved":    true,
+	"implemented": true,
+	"succeeded":   true,
 }
 
 // distillObs is one deterministic distill candidate: a bounded closed-category
@@ -168,6 +179,102 @@ func (c *MemoryController) distillAtTerminal(ctx context.Context, jobID string, 
 		})
 		written++
 	}
+}
+
+// distillRecoveredFailuresAtSuccess is the #781 success-side producer. On an
+// approving terminal result, it finds active confirmed failure facts born from
+// distill ("distill:" provenance) whose source job belongs to the same task
+// lineage as this success, then appends low-trust pending recovery observations
+// on the SAME key. It never mutates or retires the confirmed failure fact.
+func (c *MemoryController) distillRecoveredFailuresAtSuccess(ctx context.Context, jobID string, agent runtime.Agent, payload JobPayload, result AgentResult) {
+	if !c.distillSuccessEnabledFor(agent.Name) {
+		return
+	}
+	if !distillSuccessDecisions[strings.TrimSpace(result.Decision)] {
+		return
+	}
+	repo := strings.TrimSpace(payload.Repo)
+	if repo == "" {
+		return
+	}
+	owner := ownerForJob(agent, payload)
+	perJobCap := c.DistillMaxPerJob
+	if perJobCap <= 0 {
+		perJobCap = config.DefaultMemoryDistillMaxPerJob
+	}
+	facts, err := c.Store.ListActiveConfirmedMemoriesByProvenancePrefix(ctx, owner, repo, distillStagedProvenancePrefix, 0)
+	if err != nil || len(facts) == 0 {
+		return
+	}
+	seen, err := c.Store.ObservationDedupKeys(ctx, owner.Ref)
+	if err != nil {
+		return
+	}
+	written := 0
+	for _, fact := range facts {
+		if written >= perJobCap {
+			return
+		}
+		if strings.TrimSpace(fact.SourceJob) == "" || strings.TrimSpace(fact.Key) == "" {
+			continue
+		}
+		sourceJob, err := c.Store.GetJob(ctx, fact.SourceJob)
+		if err != nil {
+			continue
+		}
+		sourcePayload, err := unmarshalPayload(sourceJob.Payload)
+		if err != nil {
+			continue
+		}
+		if !sameDistillRecoveryLineage(payload, sourcePayload) {
+			continue
+		}
+		content := recoveredFailureObservationContent(jobID, payload.Branch, fact.Key, time.Now().UTC())
+		if ok, _ := memory.PreFilter(content, memory.ScopeRepo); !ok {
+			continue
+		}
+		dkey := db.MemoryDedupKey(memory.ScopeRepo, repo, memory.ContentHash(content))
+		if _, dup := seen[dkey]; dup {
+			continue
+		}
+		seen[dkey] = struct{}{}
+		_, _ = c.Store.InsertMemoryObservation(ctx, db.MemoryObservation{
+			Owner:      owner,
+			Repo:       repo,
+			Scope:      memory.ScopeRepo,
+			Key:        fact.Key,
+			Content:    content,
+			Provenance: distillSuccessProvenancePrefix + jobID,
+			TrustMark:  memory.TrustLow,
+			SourceJob:  jobID,
+		})
+		written++
+	}
+}
+
+func sameDistillRecoveryLineage(success JobPayload, failure JobPayload) bool {
+	successRepo := strings.TrimSpace(success.Repo)
+	failureRepo := strings.TrimSpace(failure.Repo)
+	if successRepo == "" || failureRepo == "" || successRepo != failureRepo {
+		return false
+	}
+	successTask := strings.TrimSpace(success.TaskID)
+	failureTask := strings.TrimSpace(failure.TaskID)
+	if successTask != "" && failureTask != "" {
+		return successTask == failureTask
+	}
+	successBranch := strings.TrimSpace(success.Branch)
+	failureBranch := strings.TrimSpace(failure.Branch)
+	return successBranch != "" && failureBranch != "" && successBranch == failureBranch
+}
+
+func recoveredFailureObservationContent(jobID, branch, key string, now time.Time) string {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		branch = "unrecorded"
+	}
+	return fmt.Sprintf("Job %s succeeded on %s on branch %s, providing recovery evidence for the previously confirmed failure %s.",
+		strings.TrimSpace(jobID), now.UTC().Format("2006-01-02"), branch, strings.TrimSpace(key))
 }
 
 // distillCandidates assembles the deterministic candidate set for a terminal job,

--- a/internal/workflow/memory_distill_test.go
+++ b/internal/workflow/memory_distill_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/memory"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
 
@@ -23,9 +24,16 @@ func distillController(store *db.Store, maxPerJob int, allJobs bool, enrolled ..
 		TokenBudget:       1500,
 		MaxEntries:        15,
 		DistillAtTerminal: true,
+		DistillSuccesses:  true,
 		DistillMaxPerJob:  maxPerJob,
 		DistillAllJobs:    allJobs,
 	}
+}
+
+func distillFailureOnlyController(store *db.Store, maxPerJob int, allJobs bool, enrolled ...string) *MemoryController {
+	ctrl := distillController(store, maxPerJob, allJobs, enrolled...)
+	ctrl.DistillSuccesses = false
+	return ctrl
 }
 
 func distillObsFor(t *testing.T, store *db.Store, repo string) []db.MemoryObservation {
@@ -319,6 +327,118 @@ func TestDistillOnlyOnNotableDecisions(t *testing.T) {
 				t.Fatalf("decision %q: distill rows = %d, want %d", tc.decision, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDistillRecoveredFailureObservationUsesTaskLineage(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	seedDistillSourceJob(t, store, "fail-job", JobPayload{Repo: "acme/widget", TaskID: "task-1", Branch: "feat/fix"})
+	seedConfirmedDistillFact(t, store, "distill-error:nil-pointer", "fail-job")
+
+	ctrl := distillController(store, 3, false, "audit")
+	ctrl.record(ctx, "success-job", memAgent(), "implement",
+		JobPayload{Repo: "acme/widget", TaskID: "task-1", Branch: "feat/fix"},
+		AgentResult{Decision: "implemented", Summary: "fixed"})
+
+	obs := distillObsFor(t, store, "acme/widget")
+	if len(obs) != 1 {
+		t.Fatalf("same task success should stage one recovery observation, got %+v", obs)
+	}
+	got := obs[0]
+	if got.Key != "distill-error:nil-pointer" {
+		t.Fatalf("recovery observation key = %q", got.Key)
+	}
+	if got.TrustMark != memory.TrustLow || got.Provenance != "distill-success:success-job" || got.SourceJob != "success-job" {
+		t.Fatalf("recovery trust/provenance/source = %q/%q/%q", got.TrustMark, got.Provenance, got.SourceJob)
+	}
+	for _, want := range []string{"success-job", "feat/fix", "previously confirmed failure distill-error:nil-pointer"} {
+		if !strings.Contains(got.Content, want) {
+			t.Fatalf("recovery content missing %q:\n%s", want, got.Content)
+		}
+	}
+	confirmed, err := store.ListConfirmedMemories(ctx, "audit", "acme/widget")
+	if err != nil {
+		t.Fatalf("ListConfirmedMemories returned error: %v", err)
+	}
+	if len(confirmed) != 1 || confirmed[0].Content != "A job in this repository hit the error: nil pointer." {
+		t.Fatalf("confirmed failure fact must remain unchanged, got %+v", confirmed)
+	}
+}
+
+func TestDistillRecoveredFailureDifferentTaskStagesNothing(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	seedDistillSourceJob(t, store, "fail-job", JobPayload{Repo: "acme/widget", TaskID: "task-1", Branch: "feat/fix"})
+	seedConfirmedDistillFact(t, store, "distill-error:nil-pointer", "fail-job")
+
+	ctrl := distillController(store, 3, false, "audit")
+	ctrl.record(ctx, "success-job", memAgent(), "implement",
+		JobPayload{Repo: "acme/widget", TaskID: "task-2", Branch: "feat/fix"},
+		AgentResult{Decision: "implemented", Summary: "fixed elsewhere"})
+
+	if obs := distillObsFor(t, store, "acme/widget"); len(obs) != 0 {
+		t.Fatalf("different task must not stage recovery observations, got %+v", obs)
+	}
+}
+
+func TestDistillRecoveredFailureDefaultOffStagesNothing(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	seedDistillSourceJob(t, store, "fail-job", JobPayload{Repo: "acme/widget", TaskID: "task-1", Branch: "feat/fix"})
+	seedConfirmedDistillFact(t, store, "distill-error:nil-pointer", "fail-job")
+
+	ctrl := distillFailureOnlyController(store, 3, false, "audit")
+	ctrl.record(ctx, "success-job", memAgent(), "implement",
+		JobPayload{Repo: "acme/widget", TaskID: "task-1", Branch: "feat/fix"},
+		AgentResult{Decision: "implemented", Summary: "fixed"})
+
+	if obs := distillObsFor(t, store, "acme/widget"); len(obs) != 0 {
+		t.Fatalf("distill_successes=false must not stage recovery observations, got %+v", obs)
+	}
+}
+
+func TestDistillRecoveredFailureCap(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+	seedDistillSourceJob(t, store, "fail-job", JobPayload{Repo: "acme/widget", TaskID: "task-1", Branch: "feat/fix"})
+	for _, key := range []string{"distill-error:a", "distill-error:b", "distill-error:c"} {
+		seedConfirmedDistillFact(t, store, key, "fail-job")
+	}
+
+	ctrl := distillController(store, 1, false, "audit")
+	ctrl.record(ctx, "success-job", memAgent(), "implement",
+		JobPayload{Repo: "acme/widget", TaskID: "task-1", Branch: "feat/fix"},
+		AgentResult{Decision: "implemented", Summary: "fixed"})
+
+	if obs := distillObsFor(t, store, "acme/widget"); len(obs) != 1 {
+		t.Fatalf("distill_max_per_job=1 should cap recovery observations to one, got %+v", obs)
+	}
+}
+
+func seedDistillSourceJob(t *testing.T, store *db.Store, id string, payload JobPayload) {
+	t.Helper()
+	encoded, err := marshalPayload(payload)
+	if err != nil {
+		t.Fatalf("marshalPayload returned error: %v", err)
+	}
+	if err := store.CreateJob(context.Background(), db.Job{ID: id, Agent: "audit", Type: "implement", State: string(JobFailed), Payload: encoded}); err != nil {
+		t.Fatalf("CreateJob(%s) returned error: %v", id, err)
+	}
+}
+
+func seedConfirmedDistillFact(t *testing.T, store *db.Store, key, sourceJob string) {
+	t.Helper()
+	if _, err := store.UpsertConfirmedMemory(context.Background(), db.ConfirmedMemory{
+		Owner:      ownerForJob(memAgent(), JobPayload{Repo: "acme/widget"}),
+		Repo:       "acme/widget",
+		Scope:      memory.ScopeRepo,
+		Key:        key,
+		Content:    "A job in this repository hit the error: nil pointer.",
+		Provenance: "distill:" + sourceJob,
+		SourceJob:  sourceJob,
+	}); err != nil {
+		t.Fatalf("UpsertConfirmedMemory(%s) returned error: %v", key, err)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1585,6 +1585,26 @@ stays invisible until it recurs. By default distill follows enrollment; set `dis
 to harvest failure signal box-wide (the read path and confirmed producers stay
 enrolled-only).
 
+**Success distill (#781)** is separately gated by `distill_successes` (off by
+default). It adds two deterministic, no-LLM producers, both pending-only with
+trust `low`:
+
+- **SkillOpt promotions** stage one observation when a candidate is promoted. The
+  key is bounded by template version and content hash, for example
+  `skillopt:<template>@vN-promoted:<hash>`. The content records which version was
+  promoted over which base, plus cheap local evidence such as review score,
+  replay-gate mean scores, and recorded weaknesses when present.
+- **Recovered failures** run when a later job succeeds. Gitmoot looks for active
+  confirmed failure facts with `distill:` provenance whose `source_job` belongs
+  to the same task lineage as the successful job, using matching `task_id` when
+  both jobs have one, otherwise the same repo plus branch. It appends a low-trust
+  pending observation on the same key that names the successful job, date, and
+  branch. It does not mutate, retire, or auto-upgrade the confirmed failure fact.
+
+Success distill uses the same PreFilter and observation dedup path as other
+memory observations. Recovered-failure writes share `distill_max_per_job`; SkillOpt
+promotion writes are one observation per promotion event.
+
 Enrollment is per agent, plus optional global knobs:
 
 ```toml
@@ -1597,12 +1617,13 @@ disabled = false            # global kill switch (overrides every enrollment)
 token_budget = 1500         # cap on injected block size (estimated tokens)
 max_entries = 15            # cap on confirmed rows considered for injection
 distill_at_terminal = false # stage deterministic failure signal at job terminal (#737 P4.1)
+distill_successes = false   # stage deterministic success observations (#781)
 distill_max_per_job = 3     # hard cap on distilled observations per job
 distill_all_jobs = false    # when true, distill runs for every job, not only enrolled agents
 ```
 
-All `[memory]` keys are read **per tick** — flipping `distill_at_terminal`
-(or any knob) takes effect on the next job with **no daemon restart**.
+All `[memory]` keys are read **per tick**. Flipping `distill_at_terminal`,
+`distill_successes` (or any knob) takes effect on the next job with **no daemon restart**.
 
 An agent returns durable facts via the optional top-level `learnings` field in
 `gitmoot_result` — each entry is `{key, scope ("repo"|"general"), content}`.

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -81,11 +81,12 @@ disabled = false            # global kill switch (overrides every enrollment)
 token_budget = 1500         # cap on injected block size (estimated tokens)
 max_entries = 15            # cap on confirmed rows considered for injection
 distill_at_terminal = false # stage deterministic failure signal at terminal (P4.1)
+distill_successes = false   # stage deterministic success observations
 distill_max_per_job = 3     # hard cap on distilled observations per job
 distill_all_jobs = false    # true → distill every job, not only enrolled agents
 ```
 
-Every `[memory]` key is read **per tick**, so flipping `distill_at_terminal`
+Every `[memory]` key is read **per tick**, so flipping `distill_at_terminal`, `distill_successes`
 (or any knob) takes effect on the next job with **no daemon restart**.
 
 ### Distill-at-terminal
@@ -111,6 +112,28 @@ bookkeeping: it is **never** shown in `memory list` and can **never** be promote
 by `memory confirm`, so a one-off failure is invisible until it recurs. By default distill follows
 enrollment; `distill_all_jobs = true` harvests failure signal box-wide while the
 read path and confirmed producers stay enrolled-only.
+
+### Success Distill
+
+`distill_successes` (off by default) enables two deterministic success producers.
+Both write only pending observations at trust `low`; neither writes confirmed
+memory directly.
+
+- **SkillOpt promotions** stage one observation when a candidate is promoted.
+  The key is bounded by template version and content hash, for example
+  `skillopt:<template>@vN-promoted:<hash>`. The content records which version was
+  promoted over which base, plus local evidence such as review score,
+  replay-gate mean scores, and recorded weaknesses when present.
+- **Recovered failures** run when a later job succeeds. Gitmoot looks for active
+  confirmed failure facts with `distill:` provenance whose `source_job` belongs
+  to the same task lineage as the successful job, using matching `task_id` when
+  both jobs have one, otherwise the same repo plus branch. It appends a low-trust
+  pending observation on the same key that names the successful job, date, and
+  branch. It does not mutate, retire, or auto-upgrade the confirmed failure fact.
+
+Recovered-failure writes share `distill_max_per_job`; SkillOpt promotion writes
+are one observation per promotion event. Both paths use the same PreFilter and
+observation dedup rules as other pending memory.
 
 An agent records a durable fact via the optional top-level `learnings` field in
 `gitmoot_result` — each entry is `{key, scope, content}` where `scope` is

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1331,8 +1331,8 @@ validation for final promotion decisions on fresh items.
 Agent persistent memory is **off by default** and enrolled per agent
 (`[agents.<name>].memory = true`), with optional `[memory]` knobs (`disabled`,
 `token_budget`, `max_entries`, and the distill-at-terminal knobs
-`distill_at_terminal`, `distill_max_per_job`, `distill_all_jobs` — all read per
-tick, no restart). See
+`distill_at_terminal`, `distill_successes`, `distill_max_per_job`,
+`distill_all_jobs`. All are read per tick, with no restart. See
 [Agent Persistent Memory](../concepts/agent-memory.md) for the full model. The
 inspection commands are read-only; `ingest` and `confirm` write behind a human
 gate:

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9740,6 +9740,26 @@ stays invisible until it recurs. By default distill follows enrollment; set `dis
 to harvest failure signal box-wide (the read path and confirmed producers stay
 enrolled-only).
 
+**Success distill (#781)** is separately gated by `distill_successes` (off by
+default). It adds two deterministic, no-LLM producers, both pending-only with
+trust `low`:
+
+- **SkillOpt promotions** stage one observation when a candidate is promoted. The
+  key is bounded by template version and content hash, for example
+  `skillopt:<template>@vN-promoted:<hash>`. The content records which version was
+  promoted over which base, plus cheap local evidence such as review score,
+  replay-gate mean scores, and recorded weaknesses when present.
+- **Recovered failures** run when a later job succeeds. Gitmoot looks for active
+  confirmed failure facts with `distill:` provenance whose `source_job` belongs
+  to the same task lineage as the successful job, using matching `task_id` when
+  both jobs have one, otherwise the same repo plus branch. It appends a low-trust
+  pending observation on the same key that names the successful job, date, and
+  branch. It does not mutate, retire, or auto-upgrade the confirmed failure fact.
+
+Success distill uses the same PreFilter and observation dedup path as other
+memory observations. Recovered-failure writes share `distill_max_per_job`; SkillOpt
+promotion writes are one observation per promotion event.
+
 Enrollment is per agent, plus optional global knobs:
 
 ```toml
@@ -9752,12 +9772,13 @@ disabled = false            # global kill switch (overrides every enrollment)
 token_budget = 1500         # cap on injected block size (estimated tokens)
 max_entries = 15            # cap on confirmed rows considered for injection
 distill_at_terminal = false # stage deterministic failure signal at job terminal (#737 P4.1)
+distill_successes = false   # stage deterministic success observations (#781)
 distill_max_per_job = 3     # hard cap on distilled observations per job
 distill_all_jobs = false    # when true, distill runs for every job, not only enrolled agents
 ```
 
-All `[memory]` keys are read **per tick** — flipping `distill_at_terminal`
-(or any knob) takes effect on the next job with **no daemon restart**.
+All `[memory]` keys are read **per tick**. Flipping `distill_at_terminal`,
+`distill_successes` (or any knob) takes effect on the next job with **no daemon restart**.
 
 An agent returns durable facts via the optional top-level `learnings` field in
 `gitmoot_result` — each entry is `{key, scope ("repo"|"general"), content}`.

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -32,7 +32,7 @@ full expanded context.
 
 - [Local-First Coordination](https://gitmoot.io/docs/concepts/local-first-coordination): Why state lives in local SQLite and GitHub stays the audit surface.
 - [Agents, Agent Templates, Jobs, And Locks](https://gitmoot.io/docs/concepts/agents-templates-jobs-locks): The core object model — agent identities, template snapshots, job lifecycle, and the three lock kinds.
-- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, the explicit shared pool with author preservation, private-plus-shared prompt injection with 1-hop linked facts and an on-demand recall footer, `memory ingest sweep` over configured sources, memory groom, built-in memory pipelines enabled via `[memory.pipelines]`, and the memory CLI, including `memory recall "<query>" --expand` for read-only FTS5/BM25 lookup plus linked neighbors.
+- [Agent Persistent Memory](https://gitmoot.io/docs/concepts/agent-memory): Off-by-default repo-filtered fact memory (SQLite + FTS5); observation-mode read/write model, enrollment, deterministic failure and success distill into low-trust pending observations, the explicit shared pool with author preservation, private-plus-shared prompt injection with 1-hop linked facts and an on-demand recall footer, `memory ingest sweep` over configured sources, memory groom, built-in memory pipelines enabled via `[memory.pipelines]`, and the memory CLI, including `memory recall "<query>" --expand` for read-only FTS5/BM25 lookup plus linked neighbors.
 
 ## Dashboard
 


### PR DESCRIPTION
Closes #781 (panel-revised scope: only the two approved producers; green-streaks and clean-ship dropped per the 3-runtime adjudication on the issue).

SkillOpt promotions stage a pending observation at N=1 (the gate/human is the witness); succeeded jobs sharing a failure fact's task/branch lineage append a low-trust recovery observation on the same key (never mutating the confirmed fact). Both behind [memory] distill_successes, default off.

Implemented by a gitmoot-orchestrated codex (gpt-5.5 xhigh) implement job; panel-informed brief; coordinated and reviewed by the lead session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)