### PR TITLE
feat(runtime): implement jobs own the commit contract

### DIFF
--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -86,6 +86,15 @@ func RenderJob(prompt JobPrompt) string {
 		builder.WriteByte('\n')
 	}
 
+	if strings.TrimSpace(prompt.Action) == "implement" {
+		// #805: implement jobs must own the commit contract. The engine commits
+		// and delivers the worktree AFTER the job returns, so a worker that
+		// self-commits either races that settle or blocks on linked-worktree git
+		// metadata a sandboxed runtime cannot write. Keyed on the exact canonical
+		// action so ask/review prompts stay byte-identical.
+		builder.WriteString("\nGitmoot commits and delivers your changes after you finish; do not run git commit or git push.\n")
+	}
+
 	builder.WriteString("\nRequired output:\n")
 	builder.WriteString("Return exactly one JSON object containing a top-level gitmoot_result field.\n")
 	builder.WriteString("Use this shape:\n")

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -74,6 +74,33 @@ func TestRenderJobOmitsDelegationArtifactsWhenUnset(t *testing.T) {
 	}
 }
 
+// TestRenderJobCommitContractLine pins the #805 commit contract: an implement
+// prompt carries the one deterministic sentence telling the worker that Gitmoot
+// owns commit+delivery, and ask/review prompts never carry it (they stay
+// byte-identical to before #805 — the sentence is the only conditional write).
+func TestRenderJobCommitContractLine(t *testing.T) {
+	const contract = "Gitmoot commits and delivers your changes after you finish; do not run git commit or git push."
+	base := JobPrompt{
+		Repo:         "jerryfane/gitmoot",
+		Branch:       "task-005",
+		Instructions: "build the api",
+	}
+
+	implement := base
+	implement.Action = "implement"
+	if got := RenderJob(implement); !strings.Contains(got, contract) {
+		t.Fatalf("implement prompt missing commit contract line:\n%s", got)
+	}
+
+	for _, action := range []string{"ask", "review"} {
+		other := base
+		other.Action = action
+		if got := RenderJob(other); strings.Contains(got, contract) {
+			t.Fatalf("%s prompt unexpectedly carries the commit contract line:\n%s", action, got)
+		}
+	}
+}
+
 func TestRenderRepairPromptIncludesErrorAndRawOutput(t *testing.T) {
 	prompt := RenderRepairPrompt("not json", errors.New("missing gitmoot_result"))
 

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -385,7 +385,7 @@ func (a CodexAdapter) Start(ctx context.Context, request StartRequest) (StartRes
 	if err := validateStartRequest(request.Agent, a.Name(), request.Prompt); err != nil {
 		return StartResult{}, err
 	}
-	args := append([]string{"exec"}, codexSandboxArgs(request.Agent)...)
+	args := append([]string{"exec"}, codexSandboxArgs(request.Agent, a.Dir)...)
 	if request.Agent.Model != "" {
 		args = append(args, "--model", request.Agent.Model)
 	}
@@ -447,6 +447,9 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 }
 
 // codexDeliverArgs builds the `codex exec` argument vector for a Deliver call.
+// dir is the adapter's working directory (the job checkout); when it is a linked
+// git worktree and the sandbox is workspace-write, codexSandboxArgs grants the
+// worktree's resolved gitdir as an extra writable root (#805).
 // jsonOutput adds --json so codex streams JSONL events (thread/turn/item) on
 // stdout, which is what lets a delivery capture token usage (#658). --json is an
 // `exec` option that codex accepts before the `resume` subcommand, which is where
@@ -460,8 +463,8 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 // `codex exec` reads the prompt from stdin when the positional is `-` or omitted
 // ("instructions are read from stdin"). Routing oversize prompts through stdin is
 // deferred to a follow-up; #723 fixes kimi, which offers no stdin/file channel.
-func codexDeliverArgs(agent Agent, prompt, model string, jsonOutput bool) []string {
-	args := append([]string{"exec"}, codexSandboxArgs(agent)...)
+func codexDeliverArgs(agent Agent, dir, prompt, model string, jsonOutput bool) []string {
+	args := append([]string{"exec"}, codexSandboxArgs(agent, dir)...)
 	if jsonOutput {
 		args = append(args, "--json")
 	}
@@ -490,9 +493,9 @@ func codexDeliverArgs(agent Agent, prompt, model string, jsonOutput bool) []stri
 // and contributes 0 usage. Only the JSON re-run is retried — a genuine delivery
 // failure surfaces unchanged.
 func (a CodexAdapter) runCodex(ctx context.Context, agent Agent, prompt, model string) (subprocess.Result, error) {
-	result, err := a.runner().Run(ctx, a.Dir, "codex", codexDeliverArgs(agent, prompt, model, true)...)
+	result, err := a.runner().Run(ctx, a.Dir, "codex", codexDeliverArgs(agent, a.Dir, prompt, model, true)...)
 	if err != nil && isCodexJSONUnsupported(result) {
-		result, err = a.runner().Run(ctx, a.Dir, "codex", codexDeliverArgs(agent, prompt, model, false)...)
+		result, err = a.runner().Run(ctx, a.Dir, "codex", codexDeliverArgs(agent, a.Dir, prompt, model, false)...)
 	}
 	return result, err
 }
@@ -611,14 +614,15 @@ func effectiveModel(agent Agent, job Job) string {
 	return strings.TrimSpace(job.RuntimeDefaultModel)
 }
 
-func codexSandboxArgs(agent Agent) []string {
+func codexSandboxArgs(agent Agent, workdir string) []string {
 	// #732: a moot/chat seat must reach the daemon chat-relay unix socket, but a
 	// codex read-only sandbox blocks the connect() syscall itself (empirically
 	// probed on codex-cli 0.142.4 bubblewrap+seccomp). Dispatch the seat with
 	// workspace-write + network so it can connect; the gitmoot home is NOT in
 	// workspace-write's writable roots (workdir + /tmp + $TMPDIR), so the home stays
 	// read-only — the relay, not the seat, does the write. This is self-contained
-	// (does not depend on the operator's global ~/.codex/config.toml).
+	// (does not depend on the operator's global ~/.codex/config.toml). A seat's
+	// whole job is chat, not git, so it takes no #805 gitdir grant.
 	if agent.ChatSeat {
 		return []string{"--sandbox", "workspace-write", "-c", "sandbox_workspace_write.network_access=true"}
 	}
@@ -626,12 +630,59 @@ func codexSandboxArgs(agent Agent) []string {
 	case AutonomyPolicyReadOnly:
 		return []string{"--sandbox", "read-only"}
 	case AutonomyPolicyWorkspaceWrite:
-		return []string{"--sandbox", "workspace-write"}
+		args := []string{"--sandbox", "workspace-write"}
+		// #805: a linked-worktree checkout keeps its real git metadata under the
+		// main repo's .git/worktrees/<name>, OUTSIDE workspace-write's writable
+		// roots, so every metadata-writing git operation (status refresh, add,
+		// commit) fails on the index lock inside the sandbox. Grant exactly that
+		// resolved gitdir via --add-dir — additive, mirroring how `plugin
+		// codex-launch` grants the gitmoot home, and unlike a
+		// `-c sandbox_workspace_write.writable_roots=[...]` override it cannot
+		// clobber roots the operator's config.toml already grants. A primary
+		// checkout (or empty/unknown workdir) resolves to "" and the argv stays
+		// byte-identical.
+		if gitdir := linkedWorktreeGitDir(workdir); gitdir != "" {
+			args = append(args, "--add-dir", gitdir)
+		}
+		return args
 	case AutonomyPolicyDangerFullAccess:
 		return []string{"--sandbox", "danger-full-access"}
 	default:
 		return nil
 	}
+}
+
+// linkedWorktreeGitDir resolves the per-worktree git metadata directory of a
+// linked `git worktree` checkout (#805). In a linked worktree, <dir>/.git is a
+// FILE whose first line is "gitdir: <main-repo>/.git/worktrees/<name>"; that
+// resolved directory holds the worktree's index/HEAD and lives outside the
+// checkout. It returns "" — the fail-open "not applicable" answer — for a
+// primary checkout (.git is a directory), a missing or empty dir, or a
+// malformed .git file. A relative gitdir (git tolerates one) is resolved
+// against dir so the sandbox grant is always an absolute root.
+func linkedWorktreeGitDir(dir string) string {
+	if strings.TrimSpace(dir) == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".git"))
+	if err != nil {
+		// A primary checkout's .git is a directory (EISDIR) and a non-repo has
+		// none (ENOENT); both mean there is no linked gitdir to grant.
+		return ""
+	}
+	line, _, _ := strings.Cut(strings.TrimSpace(string(data)), "\n")
+	rest, ok := strings.CutPrefix(strings.TrimSpace(line), "gitdir:")
+	if !ok {
+		return ""
+	}
+	gitdir := strings.TrimSpace(rest)
+	if gitdir == "" {
+		return ""
+	}
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(dir, gitdir)
+	}
+	return filepath.Clean(gitdir)
 }
 
 // defaultClaudeRetryBackoff is the base pause between Claude delivery attempts

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -317,6 +317,110 @@ func TestCodexDeliverNonSeatSandboxUnchanged(t *testing.T) {
 	runner.want(t, 0, "codex", "exec", "--sandbox", "read-only", "--json", "resume", "--last", "--", "converse")
 }
 
+// TestCodexDeliverWorkspaceWriteGrantsLinkedWorktreeGitDir pins the #805
+// sandbox grant: a workspace-write delivery whose working dir is a linked git
+// worktree passes the worktree's RESOLVED gitdir
+// (<main-repo>/.git/worktrees/<name>) as an extra writable root via --add-dir,
+// so metadata-writing git operations do not fail inside the sandbox. --add-dir
+// is additive, so operator-configured writable_roots are untouched.
+func TestCodexDeliverWorkspaceWriteGrantsLinkedWorktreeGitDir(t *testing.T) {
+	worktree := t.TempDir()
+	gitdir := filepath.Join(t.TempDir(), ".git", "worktrees", "adhoc-1")
+	if err := os.WriteFile(filepath.Join(worktree, ".git"), []byte("gitdir: "+gitdir+"\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "ok"}}}
+	adapter := CodexAdapter{Runner: runner, Dir: worktree}
+	agent := Agent{
+		Name: "worker", Role: "implementer", Runtime: CodexRuntime, RepoScope: "jerryfane/gitmoot",
+		RuntimeRef: "last", AutonomyPolicy: AutonomyPolicyWorkspaceWrite,
+	}
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--sandbox", "workspace-write", "--add-dir", gitdir, "--json", "resume", "--last", "--", "implement")
+}
+
+// TestCodexDeliverPrimaryCheckoutOmitsGitDirGrant proves the #805 grant is a
+// no-op for a primary checkout: .git is a directory, no gitdir resolves, and
+// the workspace-write argv stays byte-identical to before the change.
+func TestCodexDeliverPrimaryCheckoutOmitsGitDirGrant(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "ok"}}}
+	adapter := CodexAdapter{Runner: runner, Dir: repo}
+	agent := Agent{
+		Name: "worker", Role: "implementer", Runtime: CodexRuntime, RepoScope: "jerryfane/gitmoot",
+		RuntimeRef: "last", AutonomyPolicy: AutonomyPolicyWorkspaceWrite,
+	}
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "implement"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--sandbox", "workspace-write", "--json", "resume", "--last", "--", "implement")
+}
+
+// TestCodexDeliverReadOnlyLinkedWorktreeOmitsGitDirGrant proves the #805 grant
+// never widens a read-only sandbox: even in a linked worktree, a read-only
+// policy keeps its exact pre-#805 args.
+func TestCodexDeliverReadOnlyLinkedWorktreeOmitsGitDirGrant(t *testing.T) {
+	worktree := t.TempDir()
+	if err := os.WriteFile(filepath.Join(worktree, ".git"), []byte("gitdir: /main/.git/worktrees/adhoc-1\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "ok"}}}
+	adapter := CodexAdapter{Runner: runner, Dir: worktree}
+	agent := Agent{
+		Name: "worker", Role: "reviewer", Runtime: CodexRuntime, RepoScope: "jerryfane/gitmoot",
+		RuntimeRef: "last", AutonomyPolicy: AutonomyPolicyReadOnly,
+	}
+	if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "review"}); err != nil {
+		t.Fatalf("Deliver returned error: %v", err)
+	}
+	runner.want(t, 0, "codex", "exec", "--sandbox", "read-only", "--json", "resume", "--last", "--", "review")
+}
+
+// TestLinkedWorktreeGitDir covers the resolver's edge shapes directly: absolute
+// and relative gitdir pointers, and every "not applicable" input that must keep
+// the sandbox argv byte-identical.
+func TestLinkedWorktreeGitDir(t *testing.T) {
+	linked := t.TempDir()
+	if err := os.WriteFile(filepath.Join(linked, ".git"), []byte("gitdir: /main/.git/worktrees/wt-1\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	relative := t.TempDir()
+	if err := os.WriteFile(filepath.Join(relative, ".git"), []byte("gitdir: ../main/.git/worktrees/wt-2\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	malformed := t.TempDir()
+	if err := os.WriteFile(filepath.Join(malformed, ".git"), []byte("not a gitdir pointer\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	primary := t.TempDir()
+	if err := os.Mkdir(filepath.Join(primary, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	for _, tt := range []struct {
+		name string
+		dir  string
+		want string
+	}{
+		{name: "linked_absolute", dir: linked, want: "/main/.git/worktrees/wt-1"},
+		{name: "linked_relative", dir: relative, want: filepath.Clean(filepath.Join(relative, "../main/.git/worktrees/wt-2"))},
+		{name: "malformed_pointer", dir: malformed, want: ""},
+		{name: "primary_checkout", dir: primary, want: ""},
+		{name: "no_repo", dir: t.TempDir(), want: ""},
+		{name: "empty_dir", dir: "", want: ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := linkedWorktreeGitDir(tt.dir); got != tt.want {
+				t.Fatalf("linkedWorktreeGitDir(%q) = %q, want %q", tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCodexStartRejectsMissingThreadID(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"type":"turn.completed"}` + "\n"}}}
 	adapter := CodexAdapter{Runner: runner}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -465,6 +465,18 @@ subscribe`, and at implement-job dispatch with an actionable message. Set
 `go`/`git`/`gh`), or `--policy workspace-write` for edits-only (Bash stays
 blocked). See `references/SAFETY.md` for the full mapping and rationale.
 
+Implement jobs own the commit contract: Gitmoot commits and delivers the
+worktree's changes after the job finishes, and every rendered implement prompt
+carries one deterministic sentence telling the worker not to run `git commit`
+or `git push`. Ask and review prompts are unchanged. On the Codex runtime, a
+`workspace-write` job whose checkout is a linked `git worktree` also gets the
+worktree's resolved git directory (`<main-repo>/.git/worktrees/<name>`) added
+to the sandbox writable roots via `--add-dir`, so routine git metadata writes
+(an index refresh from `git status`, or `git add`) work inside the sandbox.
+The grant is additive and leaves operator-configured `writable_roots` intact;
+read-only and danger-full-access sandboxes and primary (non-worktree)
+checkouts are unchanged.
+
 `agent subscribe` accepts `--preset-delivery full|referenced|auto` (default
 `full`) and `agent update <name> --preset-delivery <mode>` flips it in place on
 an already-registered agent. The mode is a sticky per-agent preference:

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -35,6 +35,22 @@ agent template and rendered job prompt before handing work to an adapter.
 - **Shell** invokes a configured shell command and is mainly for smoke tests,
   demos, and adapter contract checks.
 
+## Implement Jobs and the Commit Contract
+
+Gitmoot owns the commit for implement jobs: it commits and delivers the
+worktree's changes after the job finishes. Every rendered implement prompt
+carries one deterministic sentence telling the worker not to run `git commit`
+or `git push`. Ask and review prompts are unchanged.
+
+For Codex, a workspace-write job whose checkout is a linked `git worktree`
+gets one extra sandbox grant: the worktree's resolved git directory
+(`<main-repo>/.git/worktrees/<name>`) is passed to the Codex CLI with
+`--add-dir`, so routine git operations that write metadata (an index refresh
+from `git status`, or `git add`) work inside the sandbox. The grant is
+additive; it does not replace any `writable_roots` configured in the
+operator's `~/.codex/config.toml`. Read-only and danger-full-access sandboxes
+are unchanged, and a primary (non-worktree) checkout gets no extra grant.
+
 ## Metadata Registry
 
 Each built-in runtime carries declarative metadata — advertised capabilities, a


### PR DESCRIPTION
Closes #805.

Implement prompts now carry one deterministic sentence: Gitmoot commits and delivers after the job finishes (ask/review prompts byte-identical, pinned by test). The codex adapter additionally adds the linked worktree's resolved gitdir to the sandbox writable roots, so a worker that commits anyway succeeds harmlessly instead of blocking a finished job.

Implemented by a gitmoot-orchestrated claude (fable) job; reviewed and gated by the lead session (v2 pipeline: review precedes PR; gitmoot's gate merges on green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)