### PR TITLE
feat(pipeline): first-class `skipped` decision — no-op stages advance instead of parking

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -311,7 +311,7 @@ object:
 ```json
 {
   "gitmoot_result": {
-    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "decision": "approved|changes_requested|blocked|implemented|failed|skipped",
     "summary": "Brief outcome.",
     "findings": [],
     "changes_made": [],

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -553,4 +553,5 @@ Agents must return exactly one JSON object containing `gitmoot_result`:
 ```
 
 Valid decisions are `approved`, `changes_requested`, `blocked`, `implemented`,
-and `failed`.
+`failed`, and `skipped`. Use `skipped` only when the task itself had no work to
+do, never as a PR-review synonym for `approved`, and never with delegations.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -37,6 +37,7 @@ schedule:                   # optional; interval schedule (no cron in v1)
 success_decisions:          # optional top-level default (see below)
   - approved
   - implemented
+  - skipped
 stages:                     # the DAG, keyed by unique id and wired by needs
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
@@ -60,7 +61,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
 | `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
 | `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
-| `success_decisions`         | pipeline     | no       | Decisions that mark a stage succeeded. Default `["approved","implemented"]`. Any value must be one of `approved`, `implemented`, `changes_requested` — `blocked`/`failed` are park states and are rejected. |
+| `success_decisions`         | pipeline     | no       | Decisions that mark a stage succeeded. Default `["approved","implemented","skipped"]`. Any value must be one of `approved`, `implemented`, `changes_requested`, `skipped` - `blocked`/`failed` are park states and are rejected. An explicit list is strict: omitting `skipped` requires real work and makes a skipped result fail. |
 | `allow_scheduled_writes`    | pipeline     | no       | Safety flag (#768). A **mutating** `implement` stage on a **scheduled** pipeline (a `schedule:` block) is rejected at add time unless this is `true` — so an unattended nightly pipeline can never write code / open a PR by accident. Manual-run pipelines don't need it. Default `false`. |
 | `stages[].id`               | stage        | yes      | Unique, name-safe stage id. Appears verbatim in the stage job's fingerprint and deterministic id. |
 | `stages[].cmd`              | stage        | cond.    | Shell command run verbatim via `sh -c` (see the stage contract below). A stage is **exactly one** of `cmd`, `agent`, or `gate`. |
@@ -175,8 +176,8 @@ stages:
   dispatch's fail-closed guards). A **retry** lands in the *same* branch/PR — never a
   duplicate — and fails closed if that worktree is dirty or has a live process.
 - **Folds on PR-opened.** A `success` decision folds only once the job carries an
-  opened PR; a legitimate **no-op** implement (nothing to change) folds succeeded too
-  (it can't wedge the run). The opened PR number is appended to the stage summary so a
+  opened PR. The first-class `skipped` decision bypasses that wait because there is
+  no work to turn into a PR. The opened PR number is appended to the stage summary so a
   downstream stage sees it via upstream-context injection.
 - **Never auto-merges.** The pipeline **opens** the PR; a human or your CI does the
   merge. See [Gate stages](#gate-stages) to make a later stage wait for that merge.
@@ -210,6 +211,8 @@ stages:
   **fails open** (keeps waiting while unmerged), and is bounded by the stage `timeout`.
 - A PR that is **closed without merging**, or a **timeout**, parks the run `blocked`
   (a gate is a wait, not a failure — so a retry budget can't re-arm the timer).
+- A source stage that succeeded via `skipped` also parks the gate `blocked`
+  immediately: no PR will exist for that run.
 
 ### Orchestrate stages
 
@@ -251,6 +254,9 @@ the stage by that result's **`decision`**, never by the job's exit state:
 # A stage that succeeds:
 printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
 
+# A stage whose task had no work:
+printf '%s' '{"gitmoot_result":{"decision":"skipped","summary":"no new replies today"}}'
+
 # A stage that parks the run awaiting a human, listing what it needs:
 printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
 ```
@@ -271,6 +277,13 @@ The decision drives advancement:
 job succeeded — because a stage folds on the decision, not the job state, and a
 review that asked for changes is not "this step landed." List it in a stage's (or
 the pipeline's) `success_decisions` to treat it as success instead.
+
+`skipped` is a stage **success by default**. Gitmoot prefixes its persisted summary
+with `[skipped: no work]`, and downstream agent stages receive that honest note in
+their upstream context. An explicit `success_decisions` list is strict: if it omits
+`skipped`, the stage fails because the author required real work. A skipped result
+uses the existing succeeded stage state; the `SKIPPED` funnel state still means a
+downstream stage never ran after the pipeline halted.
 
 ## CLI
 

--- a/internal/cli/agent_prompt.go
+++ b/internal/cli/agent_prompt.go
@@ -97,7 +97,7 @@ func runAgentPrompt(args []string, stdout, stderr io.Writer) int {
 // the importing agent knows the session job id it must close when the here-method
 // work is done (#657). The decision list mirrors workflow.ResultDecisions.
 func sessionCloseHint(jobID string) string {
-	return fmt.Sprintf(`[gitmoot session job %s — when this work is complete, run: gitmoot job close %s --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]`, jobID, jobID)
+	return fmt.Sprintf("[gitmoot session job %s \u2014 when this work is complete, run: gitmoot job close %s --decision <approved|changes_requested|implemented|blocked|failed|skipped> --summary \"...\"]", jobID, jobID)
 }
 
 // runAgentPromptRecord implements `agent prompt <id> --record`: it opens a session

--- a/internal/cli/dashboard_config.go
+++ b/internal/cli/dashboard_config.go
@@ -240,7 +240,7 @@ Describe this agent's role and how it should approach jobs here.
 
 Always end every job with a concise, truthful gitmoot_result JSON object, e.g.:
   {"decision": "implemented", "summary": "what you did"}
-Decisions: approved | changes_requested | blocked | implemented | failed.
+Decisions: approved | changes_requested | blocked | implemented | failed | skipped.
 Use "blocked" when you need human input or external state, and "failed" when an
 attempted action errored.
 `

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -68,7 +68,7 @@ func printJobUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot job cancel --state blocked [--older-than 168h|7d] [--repo owner/repo] [--agent name] [--yes]")
 	fmt.Fprintln(w, "  gitmoot job kill <root-job-id>")
 	fmt.Fprintln(w, "  gitmoot job open --agent name --repo owner/repo --type ask|review|implement [--title ...] [--task id] [--pr n] [--json]")
-	fmt.Fprintln(w, "  gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed [--summary ...] [--pr n] [--branch name] [--json]")
+	fmt.Fprintln(w, "  gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed|skipped [--summary ...] [--pr n] [--branch name] [--json]")
 	fmt.Fprintln(w, "  gitmoot job record --agent name --repo owner/repo --type ask|review|implement --decision ... [--title ...] [--summary ...] [--task id] [--pr n] [--branch name] [--json]")
 }
 

--- a/internal/cli/pipeline_advance_test.go
+++ b/internal/cli/pipeline_advance_test.go
@@ -488,6 +488,96 @@ stages:
 	}
 }
 
+// TestAdvancerSkippedAdvancesByDefault proves an honest no-work result is a
+// first-class successful fold: the existing StageSucceeded row carries the trusted
+// marker and the dependent stage enqueues with zero success_decisions config.
+func TestAdvancerSkippedAdvancesByDefault(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "skip-default", changesRequestedSpec)
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "skipped", "no new replies", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now)
+
+	a := stageRow(t, store, run.ID, "a")
+	if a.State != pipeline.StageSucceeded {
+		t.Fatalf("stage a = %s, want succeeded", a.State)
+	}
+	if a.Summary != "[skipped: no work] no new replies" {
+		t.Fatalf("stage a summary = %q", a.Summary)
+	}
+	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StageQueued || got.JobID == "" {
+		t.Fatalf("stage b = %+v, want queued with a job", got)
+	}
+}
+
+// TestAdvancerSkippedHonorsStrictSuccessDecisions proves an explicit list can
+// require real work: omitting skipped makes the no-work decision fail the stage.
+func TestAdvancerSkippedHonorsStrictSuccessDecisions(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: skip-strict
+repo: owner/repo
+success_decisions: [approved, implemented]
+stages:
+  - id: a
+    cmd: echo a
+  - id: b
+    cmd: echo b
+    needs: [a]
+`
+	rec, parsed := newTestPipeline(t, store, "skip-strict", spec)
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+	settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, "skipped", "no new replies", nil)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+
+	if got := stageRow(t, store, run.ID, "a"); got.State != pipeline.StageFailed {
+		t.Fatalf("stage a = %s, want failed when strict list omits skipped", got.State)
+	}
+	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StageSkipped || got.JobID != "" {
+		t.Fatalf("stage b = %+v, want skipped and never enqueued", got)
+	}
+	if run.State != pipeline.RunFailed {
+		t.Fatalf("run = %s, want failed", run.State)
+	}
+}
+
+// TestAdvancerStripsForgedSkippedMarkerFromNonSkippedOutcomes proves failed and
+// blocked folds cannot persist Gitmoot's reserved no-work provenance marker.
+func TestAdvancerStripsForgedSkippedMarkerFromNonSkippedOutcomes(t *testing.T) {
+	cases := []struct {
+		decision string
+		summary  string
+		want     string
+	}{
+		{"blocked", pipelineSkippedSummaryMarker, "stage blocked"},
+		{"failed", pipelineSkippedSummaryMarker + pipelineSkippedSummaryMarker + " boom", "boom"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.decision, func(t *testing.T) {
+			store := pipelineAdvanceStore(t)
+			enqueue := testStageEnqueuer(store)
+			rec, spec := newTestPipeline(t, store, "forged-"+tc.decision, changesRequestedSpec)
+			now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+			run := startTestRun(t, store, rec, spec, enqueue, now)
+			settleStageJob(t, store, stageRow(t, store, run.ID, "a").JobID, tc.decision, tc.summary, []string{"operator input"})
+
+			run = advance(t, store, rec, spec, enqueue, run, now)
+			got := stageRow(t, store, run.ID, "a")
+			if got.Summary != tc.want {
+				t.Fatalf("persisted summary = %q, want %q", got.Summary, tc.want)
+			}
+			if pipelineSummaryIsSkipped(got.Summary) {
+				t.Fatalf("persisted summary retained forged skipped marker: %q", got.Summary)
+			}
+		})
+	}
+}
+
 // TestAdvancerSkippedPropagation proves a failed stage's transitive dependents are
 // all marked skipped (never enqueued), giving a clean terminal picture.
 func TestAdvancerSkippedPropagation(t *testing.T) {

--- a/internal/cli/pipeline_gate_stage_e2e_test.go
+++ b/internal/cli/pipeline_gate_stage_e2e_test.go
@@ -126,6 +126,60 @@ stages:
 	}
 }
 
+// TestPipelineGateStageRejectsForgedSkippedMarkerE2E proves an implemented source
+// cannot forge Gitmoot's reserved no-work marker. The fold strips repeated leading
+// markers, appends the trusted PR marker, and the gate observes the real merge.
+func TestPipelineGateStageRejectsForgedSkippedMarkerE2E(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: gate-forged-skip
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: wait
+    gate: pr_merged
+    source: impl
+    needs: [impl]
+  - id: deploy
+    cmd: echo deploying
+    needs: [wait]
+`
+	rec, parsed := newTestPipeline(t, store, "gate-forged-skip", spec)
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	forged := pipelineSkippedSummaryMarker + " " + pipelineSkippedSummaryMarker + " landed the fix"
+	settleImplementStageJob(t, store, impl.JobID, "implemented", forged, 42)
+
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	implDone := stageRow(t, store, run.ID, "impl")
+	if implDone.State != pipeline.StageSucceeded {
+		t.Fatalf("impl stage = %s, want succeeded", implDone.State)
+	}
+	if pipelineSummaryIsSkipped(implDone.Summary) {
+		t.Fatalf("impl summary retained forged skipped marker: %q", implDone.Summary)
+	}
+	if implDone.Summary != "landed the fix (opened PR #42)" {
+		t.Fatalf("impl summary = %q", implDone.Summary)
+	}
+	if got := stageRow(t, store, run.ID, "wait"); got.State != pipeline.StageQueued {
+		t.Fatalf("gate stage = %s, want queued", got.State)
+	}
+
+	markPipelinePRMerged(t, store, "owner/repo", 42, "merged")
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "wait"); got.State != pipeline.StageSucceeded {
+		t.Fatalf("gate stage = %s, want succeeded on the real merge", got.State)
+	}
+	if got := stageRow(t, store, run.ID, "deploy"); got.State != pipeline.StageQueued || got.JobID == "" {
+		t.Fatalf("deploy stage = %+v, want queued after the gate passed", got)
+	}
+}
+
 // TestPipelineGateStageTimeoutParksBlockedE2E proves a gate stage whose predicate never
 // holds within its stage timeout PARKS the run BLOCKED (not failed) at the gate, with a
 // needs entry naming the merge it waited on — and never retries (a gate is a wait, not a
@@ -235,6 +289,54 @@ stages:
 	}
 	if got := stageRow(t, store, run.ID, "deploy"); got.State != pipeline.StageSkipped {
 		t.Fatalf("deploy stage = %s, want skipped past the parked gate", got.State)
+	}
+}
+
+// TestPipelineGateStageSkippedSourceParksBlockedE2E proves a pr_merged gate does
+// not wait for a PR that a successful no-work implement stage can never create.
+func TestPipelineGateStageSkippedSourceParksBlockedE2E(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: gate-skipped-source
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: wait
+    gate: pr_merged
+    source: impl
+    needs: [impl]
+  - id: deploy
+    cmd: echo deploying
+    needs: [wait]
+`
+	rec, parsed := newTestPipeline(t, store, "gate-skipped-source", spec)
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	settleImplementStageJob(t, store, impl.JobID, "skipped", "nothing changed", 0)
+
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	if got := stageRow(t, store, run.ID, "impl"); got.State != pipeline.StageSucceeded {
+		t.Fatalf("impl stage = %s, want succeeded", got.State)
+	}
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+
+	gate := stageRow(t, store, run.ID, "wait")
+	if gate.State != pipeline.StageBlocked {
+		t.Fatalf("gate stage = %s, want blocked", gate.State)
+	}
+	if got := decodePipelineNeeds(gate.NeedsJSON); len(got) != 1 || got[0] != "source stage skipped: no PR will exist for this run" {
+		t.Fatalf("gate needs = %v", got)
+	}
+	if run.State != pipeline.RunBlocked {
+		t.Fatalf("run = %s, want blocked", run.State)
+	}
+	if got := stageRow(t, store, run.ID, "deploy"); got.State != pipeline.StageSkipped || got.JobID != "" {
+		t.Fatalf("deploy stage = %+v, want skipped and never enqueued", got)
 	}
 }
 

--- a/internal/cli/pipeline_implement_stage_e2e_test.go
+++ b/internal/cli/pipeline_implement_stage_e2e_test.go
@@ -243,6 +243,96 @@ stages:
 	}
 }
 
+// TestPipelineImplementStageSkippedBypassesPRWaitE2E proves a first-class skipped
+// implement result folds immediately without a PR or the legacy no-PR event. Its
+// trusted no-work summary then reaches the dependent agent prompt automatically.
+func TestPipelineImplementStageSkippedBypassesPRWaitE2E(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: skipped-impl
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: notify
+    agent: rev
+    prompt: Announce.
+    needs: [impl]
+`
+	rec, parsed := newTestPipeline(t, store, "skipped-impl", spec)
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+
+	settleImplementStageJob(t, store, impl.JobID, "skipped", "repository already matches", 0)
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+
+	implDone := stageRow(t, store, run.ID, "impl")
+	if implDone.State != pipeline.StageSucceeded {
+		t.Fatalf("impl stage = %s, want succeeded without waiting for a PR", implDone.State)
+	}
+	if implDone.Summary != "[skipped: no work] repository already matches" {
+		t.Fatalf("impl summary = %q", implDone.Summary)
+	}
+	notify := stageRow(t, store, run.ID, "notify")
+	if notify.State != pipeline.StageQueued || notify.JobID == "" {
+		t.Fatalf("notify stage = %+v, want queued with a job", notify)
+	}
+	notifyJob, err := store.GetJob(ctx, notify.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(notify): %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(notifyJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(notify): %v", err)
+	}
+	if !strings.Contains(payload.Instructions, "[skipped: no work] repository already matches") {
+		t.Fatalf("notify prompt missing skipped upstream summary:\n%s", payload.Instructions)
+	}
+}
+
+// TestPipelineImplementStageSkippedHonorsStrictSuccessDecisionsE2E proves a
+// strict implement stage that omits skipped folds failed immediately with no PR,
+// rather than entering the fold-on-PR-opened wait.
+func TestPipelineImplementStageSkippedHonorsStrictSuccessDecisionsE2E(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	const spec = `name: skipped-impl-strict
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+    success_decisions: [approved, implemented]
+  - id: notify
+    cmd: echo notify
+    needs: [impl]
+`
+	rec, parsed := newTestPipeline(t, store, "skipped-impl-strict", spec)
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, parsed, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	settleImplementStageJob(t, store, impl.JobID, "skipped", "nothing to change", 0)
+
+	run = advance(t, store, rec, parsed, enqueue, run, now)
+	implDone := stageRow(t, store, run.ID, "impl")
+	if implDone.State != pipeline.StageFailed {
+		t.Fatalf("impl stage = %s, want failed immediately", implDone.State)
+	}
+	if run.State != pipeline.RunFailed {
+		t.Fatalf("run = %s, want failed", run.State)
+	}
+	if got := stageRow(t, store, run.ID, "notify"); got.State != pipeline.StageSkipped || got.JobID != "" {
+		t.Fatalf("notify stage = %+v, want skipped and never enqueued", got)
+	}
+}
+
 // TestPipelineImplementStageWritableWorktreeReuseE2E proves the WRITABLE-worktree
 // dispatch (#768): a mutating implement stage takes the real task-worktree path (not
 // the read-only committed-tip worktree), is born on its DETERMINISTIC run-scoped branch,

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -29,6 +29,8 @@ import (
 // wiring of runPipelineScanOnce lands in a later step — here it is driven by
 // `pipeline run` and the tests.
 
+const pipelineSkippedSummaryMarker = "[skipped: no work]"
+
 // pipelineStageEnqueuer enqueues one pipeline stage job. In production it wraps
 // workflow.Mailbox.Enqueue (matching newHeartbeatEnqueuer); tests inject a fake to
 // assert the request shape without a real worker.
@@ -1141,9 +1143,9 @@ func orchestrateStageTimeout(stage pipeline.Stage) (time.Duration, error) {
 // job payload carries an opened PullRequest (> 0). That closes the race where the
 // implement job reaches its terminal success state a beat before the
 // ImplementationFinalizer stamps the opened PR onto the payload; without it a downstream
-// stage could advance believing a PR exists when it does not yet. A blocked/failed
-// decision folds IMMEDIATELY (there is no PR to wait on), and a stage whose job times out
-// folds failed via the same decision path — so the PR guard can never wedge a run. On a
+// stage could advance believing a PR exists when it does not yet. A skipped decision
+// folds IMMEDIATELY because no work means no PR can exist; blocked/failed decisions do
+// the same, and a stage whose job times out folds failed via the same decision path. On a
 // successful fold the opened PR number is appended to the stage summary so it flows to
 // downstream stages through the #757 upstream-context injection (which renders the stage
 // summary). It reproduces the default kind's JobID guard + queued->running funnel reflect
@@ -1165,6 +1167,13 @@ func implementStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDe
 		return false, "", "", nil, nil, nil
 	}
 	state, summary, needs = foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
+	if payload, perr := workflow.ParseJobPayload(job.Payload); perr == nil && payload.Result != nil && strings.TrimSpace(payload.Result.Decision) == "skipped" {
+		// A skipped implement job promises that there was no work to turn into a PR.
+		// Fold immediately instead of entering the fold-on-PR-opened wait. This is
+		// intentionally decision-specific; other successful decisions retain the
+		// existing PR gate (including the separately tracked approved case, #817).
+		return true, state, summary, needs, nil, nil
+	}
 	if state == pipeline.StageSucceeded {
 		pr := 0
 		if payload, perr := workflow.ParseJobPayload(job.Payload); perr == nil {
@@ -1263,6 +1272,10 @@ func gateStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, s
 		if srcRow, ok, gerr := deps.store.GetPipelineRunStage(ctx, deps.run.ID, source); gerr != nil {
 			return false, "", "", nil, nil, gerr
 		} else if ok {
+			if srcRow.State == pipeline.StageSucceeded && pipelineSummaryIsSkipped(srcRow.Summary) {
+				need := "source stage skipped: no PR will exist for this run"
+				return true, pipeline.StageBlocked, fmt.Sprintf("gate %s cannot pass: source stage %q skipped", stage.Gate, source), []string{need}, nil, nil
+			}
 			pr = parsePipelineImplementPR(srcRow.Summary)
 		}
 	}
@@ -1386,9 +1399,16 @@ func foldPipelineStageOutcome(successDecisions []string, job db.Job) (state, sum
 		return pipeline.StageFailed, "stage job produced no gitmoot_result", nil
 	}
 	decision := strings.TrimSpace(payload.Result.Decision)
-	summary = strings.TrimSpace(payload.Result.Summary)
+	// The skipped marker is reserved for Gitmoot-authored fold metadata. Strip every
+	// leading agent-authored occurrence before deciding the outcome; only a genuine
+	// successful skipped decision may reapply exactly one marker below. This keeps
+	// downstream context honest and makes the gate's marker-first check trustworthy.
+	summary = stripPipelineSkippedSummaryMarker(payload.Result.Summary)
 	switch {
 	case containsPipelineDecision(successDecisions, decision):
+		if decision == "skipped" {
+			summary = prependPipelineSkippedSummary(summary)
+		}
 		return pipeline.StageSucceeded, summary, nil
 	case decision == "blocked":
 		if summary == "" {
@@ -1401,6 +1421,33 @@ func foldPipelineStageOutcome(successDecisions []string, job db.Job) (state, sum
 		}
 		return pipeline.StageFailed, summary, nil
 	}
+}
+
+// stripPipelineSkippedSummaryMarker removes every leading occurrence of Gitmoot's
+// reserved no-work marker, with or without whitespace or trailing summary text.
+// Agent prose after the markers is preserved and trimmed.
+func stripPipelineSkippedSummaryMarker(summary string) string {
+	summary = strings.TrimSpace(summary)
+	for strings.HasPrefix(summary, pipelineSkippedSummaryMarker) {
+		summary = strings.TrimSpace(strings.TrimPrefix(summary, pipelineSkippedSummaryMarker))
+	}
+	return summary
+}
+
+// prependPipelineSkippedSummary stamps the trusted no-work marker onto a successful
+// skipped fold. The marker lives on the persisted stage row, so downstream context
+// and jobless gates can distinguish a no-work success without a new stage state.
+func prependPipelineSkippedSummary(summary string) string {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return pipelineSkippedSummaryMarker
+	}
+	return pipelineSkippedSummaryMarker + " " + summary
+}
+
+func pipelineSummaryIsSkipped(summary string) bool {
+	summary = strings.TrimSpace(summary)
+	return summary == pipelineSkippedSummaryMarker || strings.HasPrefix(summary, pipelineSkippedSummaryMarker+" ")
 }
 
 // pipelineStageDepsSucceeded reports whether every stage this one needs has

--- a/internal/cli/pipeline_run_e2e_test.go
+++ b/internal/cli/pipeline_run_e2e_test.go
@@ -147,6 +147,67 @@ func TestPipelineBlockedParkE2E(t *testing.T) {
 	}
 }
 
+// TestPipelineSkippedAdvancesE2E drives the real shell worker and pipeline scan
+// through a no-work stage. skipped folds to the existing succeeded stage state,
+// carries the trusted marker, and allows the downstream shell stage to run.
+func TestPipelineSkippedAdvancesE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+
+	scan := pipelineStageResultCmd("skipped", "no new replies today", nil)
+	notify := pipelineStageResultCmd("approved", "downstream ran", nil)
+	specYAML := "name: skipped-flow\nrepo: owner/repo\nstages:\n" +
+		pipelineE2EStage("scan", scan, "") +
+		pipelineE2EStage("notify", notify, "scan")
+	specFile := writeSpec(t, specYAML)
+
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline add exit=%d stderr=%s", code, errBuf.String())
+	}
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "run", "skipped-flow", "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline run exit=%d stderr=%s", code, errBuf.String())
+	}
+	runID := strings.TrimSpace(out.String())
+
+	enqueue := newPipelineStageEnqueuer(store, home)
+	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 8; i++ {
+		if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+			t.Fatalf("worker tick %d: %v", i, err)
+		}
+		if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+			t.Fatalf("pipeline scan %d: %v", i, err)
+		}
+		run, _, err := store.GetPipelineRun(ctx, runID)
+		if err != nil {
+			t.Fatalf("GetPipelineRun: %v", err)
+		}
+		if run.State != pipeline.RunRunning {
+			break
+		}
+	}
+
+	run, ok, err := store.GetPipelineRun(ctx, runID)
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineRun(%s): ok=%v err=%v", runID, ok, err)
+	}
+	if run.State != pipeline.RunSucceeded {
+		t.Fatalf("run = %s, want succeeded", run.State)
+	}
+	if got := stageRow(t, store, runID, "scan"); got.State != pipeline.StageSucceeded || got.Summary != "[skipped: no work] no new replies today" {
+		t.Fatalf("scan stage = %+v", got)
+	}
+	if got := stageRow(t, store, runID, "notify"); got.State != pipeline.StageSucceeded || got.Summary != "downstream ran" {
+		t.Fatalf("notify stage = %+v", got)
+	}
+}
+
 // pipelineE2EStage renders one stage block with the shell cmd as a literal YAML
 // block scalar (so the JSON-bearing single-quoted command survives YAML parsing).
 func pipelineE2EStage(id, cmd, needs string) string {

--- a/internal/cli/tui/jobs.go
+++ b/internal/cli/tui/jobs.go
@@ -258,7 +258,7 @@ func daemonStartCmd(deps Deps) tea.Cmd {
 }
 
 // jobDecisionColor colors a gitmoot_result decision: blocked/failed red,
-// changes_requested neutral, everything else (approved/implemented) green.
+// approved/implemented green, and changes_requested/skipped neutral.
 func jobDecisionColor(decision string) string {
 	switch decision {
 	case "blocked", "failed":

--- a/internal/db/routing_telemetry.go
+++ b/internal/db/routing_telemetry.go
@@ -31,7 +31,7 @@ type RoutingTelemetry struct {
 	// JobState is the terminal job state: succeeded | failed | blocked.
 	JobState string
 	// Decision is the agent result decision (approved/implemented/changes_requested/
-	// blocked/failed) when the job carried a parseable result; empty otherwise.
+	// blocked/failed/skipped) when the job carried a parseable result; empty otherwise.
 	Decision string
 	// Approved mirrors the engine's approving-outcome test (approved|implemented|
 	// succeeded) so the summary can report an approval rate without re-deriving it.

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -18,18 +18,20 @@ import (
 )
 
 // DefaultSuccessDecisions are the gitmoot_result decisions that, absent an
-// explicit override, mark a pipeline stage succeeded. They mirror the
-// gitmoot_result contract's "the work landed" terminal decisions. blocked and
+// explicit override, mark a pipeline stage succeeded. skipped is default-on
+// because an honest no-work result is a successful pipeline stage. blocked and
 // failed are deliberately NOT here: the advancer treats them as park states, so
 // they can never mean success (see SuccessDecisionCandidates).
-var DefaultSuccessDecisions = []string{"approved", "implemented"}
+var DefaultSuccessDecisions = []string{"approved", "implemented", "skipped"}
 
 // SuccessDecisionCandidates are the gitmoot_result decisions a spec MAY list in
 // success_decisions (top-level or per-stage). It is the subset of the contract's
 // ResultDecisions that can plausibly mean "this stage succeeded": blocked and
 // failed are excluded because the advancer treats them as park states, so listing
-// either as a success would contradict the advance semantics.
-var SuccessDecisionCandidates = []string{"approved", "implemented", "changes_requested"}
+// either as a success would contradict the advance semantics. An explicit list is
+// strict: if it omits skipped, a skipped result folds failed because the author
+// required real work.
+var SuccessDecisionCandidates = []string{"approved", "implemented", "changes_requested", "skipped"}
 
 // DefaultAgentStageAction is the read-only agent verb an agent stage runs when
 // action is unset (#757). Agent stages are leaves, so the default is "ask".

--- a/internal/prompts/contract_drift_test.go
+++ b/internal/prompts/contract_drift_test.go
@@ -111,7 +111,7 @@ func TestEnumValuesCoveredInJobPrompt(t *testing.T) {
 // literal. Agents copy this verbatim, so it must never change shape; the
 // generator reproduces it from the struct field set.
 func TestExampleShapeIsByteIdentical(t *testing.T) {
-	const want = `{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+	const want = `{"gitmoot_result":{"decision":"approved|changes_requested|blocked|implemented|failed|skipped","summary":"...","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
 
 	for name, prompt := range map[string]string{
 		"job":    renderedJob(),
@@ -119,6 +119,24 @@ func TestExampleShapeIsByteIdentical(t *testing.T) {
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("%s prompt missing byte-identical example shape\nwant: %s\n--- prompt ---\n%s", name, want, prompt)
+		}
+	}
+}
+
+func TestSkippedDecisionSemanticsAreRendered(t *testing.T) {
+	for name, prompt := range map[string]string{
+		"job":    renderedJob(),
+		"repair": prompts.RenderRepairPrompt("garbage", nil),
+	} {
+		for _, want := range []string{
+			"task itself had no work to do",
+			"Do not use skipped in a PR review",
+			"skipped must not be returned with delegations",
+			"skipped is an abstention for quorum and verify",
+		} {
+			if !strings.Contains(prompt, want) {
+				t.Fatalf("%s prompt missing %q\n--- prompt ---\n%s", name, want, prompt)
+			}
 		}
 	}
 }

--- a/internal/prompts/contract_generated.go
+++ b/internal/prompts/contract_generated.go
@@ -7,7 +7,11 @@ package prompts
 
 // resultContractShape is the byte-identical {"gitmoot_result":{…}} example
 // literal that RenderJob and RenderRepairPrompt both emit. Agents copy it.
-const resultContractShape = "{\"gitmoot_result\":{\"decision\":\"approved|changes_requested|blocked|implemented|failed\",\"summary\":\"...\",\"findings\":[],\"changes_made\":[],\"tests_run\":[],\"needs\":[],\"delegations\":[]}}"
+const resultContractShape = "{\"gitmoot_result\":{\"decision\":\"approved|changes_requested|blocked|implemented|failed|skipped\",\"summary\":\"...\",\"findings\":[],\"changes_made\":[],\"tests_run\":[],\"needs\":[],\"delegations\":[]}}"
+
+// resultDecisionHelp documents semantic constraints that the decision enum alone
+// cannot express. It is emitted beside the shape in job and repair prompts.
+const resultDecisionHelp = "\nDecision semantics:\n- Use decision skipped only when the task itself had no work to do. Do not use skipped in a PR review to mean nothing to flag; use approved. skipped must not be returned with delegations.\n- Outside pipelines, skipped is an abstention for quorum and verify. Vote still counts the skipped child's succeeded job state.\n"
 
 // delegationSchemaHelp documents the full delegations[] object shape inside
 // the rendered prompt. Runtime agents only receive this prompt, not the

--- a/internal/prompts/contractgen/main.go
+++ b/internal/prompts/contractgen/main.go
@@ -96,6 +96,8 @@ var ephemeralFieldAnnotations = map[string]fieldAnnotation{
 	"autonomy_policy": {help: `autonomy_policy (optional)`},
 }
 
+const resultDecisionHelp = "\nDecision semantics:\n- Use decision skipped only when the task itself had no work to do. Do not use skipped in a PR review to mean nothing to flag; use approved. skipped must not be returned with delegations.\n- Outside pipelines, skipped is an abstention for quorum and verify. Vote still counts the skipped child's succeeded job state.\n"
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "contractgen:", err)
@@ -270,6 +272,9 @@ func renderFile(shape, help string) string {
 	b.WriteString("// resultContractShape is the byte-identical {\"gitmoot_result\":{…}} example\n")
 	b.WriteString("// literal that RenderJob and RenderRepairPrompt both emit. Agents copy it.\n")
 	b.WriteString("const resultContractShape = " + goQuote(shape) + "\n\n")
+	b.WriteString("// resultDecisionHelp documents semantic constraints that the decision enum alone\n")
+	b.WriteString("// cannot express. It is emitted beside the shape in job and repair prompts.\n")
+	b.WriteString("const resultDecisionHelp = " + goQuote(resultDecisionHelp) + "\n\n")
 	b.WriteString("// delegationSchemaHelp documents the full delegations[] object shape inside\n")
 	b.WriteString("// the rendered prompt. Runtime agents only receive this prompt, not the\n")
 	b.WriteString("// gitmoot skill docs, so without it they guess field names (e.g. \"to\"\n")

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -100,6 +100,7 @@ func RenderJob(prompt JobPrompt) string {
 	builder.WriteString("Use this shape:\n")
 	builder.WriteString(resultContractShape)
 	builder.WriteByte('\n')
+	builder.WriteString(resultDecisionHelp)
 	builder.WriteString(delegationSchemaHelp)
 	return builder.String()
 }
@@ -122,6 +123,7 @@ func RenderRepairPrompt(rawOutput string, parseError error) string {
 	builder.WriteString("\nReturn only one JSON object in this exact shape:\n")
 	builder.WriteString(resultContractShape)
 	builder.WriteString("\n")
+	builder.WriteString(resultDecisionHelp)
 	builder.WriteString(delegationSchemaHelp)
 	builder.WriteString("\nPrevious raw output:\n")
 	builder.WriteString(trimRawOutput(rawOutput, 12000))

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -34,7 +34,7 @@ func TestRenderJobIncludesContextAndContract(t *testing.T) {
 		"Requested action: review",
 		"- Preserve existing behavior",
 		"gitmoot_result",
-		`"decision":"approved|changes_requested|blocked|implemented|failed"`,
+		`"decision":"approved|changes_requested|blocked|implemented|failed|skipped"`,
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("prompt missing %q:\n%s", want, prompt)

--- a/internal/workflow/result.go
+++ b/internal/workflow/result.go
@@ -31,7 +31,7 @@ const PipelineJobSender = "pipeline"
 // the same order.
 
 // ResultDecisions are the allowed values of AgentResult.Decision.
-var ResultDecisions = []string{"approved", "changes_requested", "blocked", "implemented", "failed"}
+var ResultDecisions = []string{"approved", "changes_requested", "blocked", "implemented", "failed", "skipped"}
 
 // DelegationFailurePolicies are the allowed values of Delegation.FailurePolicy
 // (the empty string falls back to the default and is accepted separately).
@@ -244,6 +244,9 @@ func validateAgentResult(result AgentResult) error {
 	}
 	if strings.TrimSpace(result.Summary) == "" {
 		return errors.New("gitmoot_result summary is required")
+	}
+	if result.Decision == "skipped" && len(result.Delegations) > 0 {
+		return errors.New("gitmoot_result decision skipped cannot be used with delegations")
 	}
 	if err := validateHumanQuestions(result.HumanQuestions); err != nil {
 		return err

--- a/internal/workflow/result_test.go
+++ b/internal/workflow/result_test.go
@@ -64,6 +64,30 @@ func TestExtractAgentResultRejectsUnsupportedDecision(t *testing.T) {
 	}
 }
 
+func TestExtractAgentResultAcceptsSkipped(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"skipped","summary":"no new replies","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+
+	result, err := ExtractAgentResult(output)
+	if err != nil {
+		t.Fatalf("ExtractAgentResult returned error: %v", err)
+	}
+	if result.Decision != "skipped" || result.Summary != "no new replies" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestExtractAgentResultRejectsSkippedWithDelegations(t *testing.T) {
+	output := `{"gitmoot_result":{"decision":"skipped","summary":"nothing to do","delegations":[{"id":"child","agent":"impl","action":"ask","prompt":"check anyway"}]}}`
+
+	_, err := ExtractAgentResult(output)
+	if err == nil {
+		t.Fatal("ExtractAgentResult accepted skipped with delegations")
+	}
+	if !strings.Contains(err.Error(), "decision skipped cannot be used with delegations") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestExtractAgentResultRejectsUnsupportedField(t *testing.T) {
 	output := `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[],"unexpected_field":[]}}`
 

--- a/internal/workflow/session_job_test.go
+++ b/internal/workflow/session_job_test.go
@@ -69,6 +69,7 @@ func TestCloseExternalJobAppliesDecision(t *testing.T) {
 		{"approved", JobSucceeded, events.EventJobFinished},
 		{"implemented", JobSucceeded, events.EventJobFinished},
 		{"changes_requested", JobSucceeded, events.EventJobFinished},
+		{"skipped", JobSucceeded, events.EventJobFinished},
 		{"blocked", JobBlocked, events.EventJobBlocked},
 		{"failed", JobFailed, events.EventJobFailed},
 	}

--- a/skills/gitmoot/SKILL.md
+++ b/skills/gitmoot/SKILL.md
@@ -35,7 +35,7 @@ By DEFAULT, the "here" flow tracks the work: run
 `gitmoot agent prompt <agent> --record [--repo owner/repo]`, which opens a
 session job on import and returns the prompt with a header line naming its job
 id. Apply the prompt, do the work, then — this is REQUIRED — clock out with
-`gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."`
+`gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed|skipped> --summary "..."`
 so the work shows in `job list`, the dashboard, and the event stream just like
 an engine-run job (no runtime is spawned; gitmoot is only the record-keeper).
 `--record` works for both a **registered agent** (repo defaults to its repo scope)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -823,7 +823,7 @@ once you clock out:
 ```sh
 gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|review|implement] [--json]
 # prints:  [gitmoot session job <id> — when this work is complete, run:
-#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]
+#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed|skipped> --summary "..."]
 # followed by the prompt body.
 ```
 
@@ -1059,7 +1059,7 @@ gitmoot job open --agent <name> --repo owner/repo --type ask|review|implement \
                  [--title "..."] [--task <id>] [--pr <n>] [--json]
 
 # Clock out: apply the result and move the job to its terminal state.
-gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed \
+gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed|skipped \
                  [--summary "..."] [--pr <n>] [--branch <name>] [--json]
 
 # One-shot post-hoc: create an already-terminal job (open + close in one).
@@ -1073,8 +1073,8 @@ the daemon never claims or Delivers it — no runtime subprocess, no runtime-ses
 or checkout lock) and the stuck-`running` reaper **skips** it, so a session may
 hold it open for as long as the work takes. `close` reuses the exact result path an
 engine-run job uses: `--decision` maps to the same terminal state
-(`approved`/`changes_requested`/`implemented` → succeeded, `blocked` → blocked,
-`failed` → failed) and emits the same finished/failed/blocked event, so a recorded
+(`approved`/`changes_requested`/`implemented`/`skipped` -> succeeded, `blocked` -> blocked,
+`failed` -> failed) and emits the same finished/failed/blocked event, so a recorded
 job is indistinguishable from an engine-run one in the dashboard and events. A job
 can be closed **once** (it must be a running session job); an orphaned open job
 stays `running` (reaper-exempt) until you `job close --decision failed` or `job
@@ -2124,7 +2124,7 @@ cyclic `needs`, a stage that is not exactly one of `cmd`/`agent`/`gate`, an agen
 missing a `prompt` / invalid `action` / `implement` without `write: true` / a mutating
 stage on a scheduled pipeline without `allow_scheduled_writes` / a gate's bad
 predicate or `source`, invalid durations, a `success_decisions` outside
-`approved`/`implemented`/`changes_requested`) so a mistake is a clear error, not a
+`approved`/`implemented`/`changes_requested`/`skipped`) so a mistake is a clear error, not a
 stuck run. It stores the raw YAML **verbatim** plus a content hash; each run
 snapshots that hash and executes its snapshot, so editing the file later never
 mutates an in-flight run. `pipeline add` also auto-creates one hidden shell runner
@@ -2154,12 +2154,17 @@ printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
 printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
 ```
 
-- a decision in the stage's `success_decisions` (default `approved`/`implemented`) →
+- a decision in the stage's `success_decisions` (default `approved`/`implemented`/`skipped`) ->
   **succeeded**, dependents enqueue;
 - `blocked` → the stage blocks, its `needs` persist at the stage **and** run level,
   the run **parks blocked** (downstream never enqueues, zero compute while parked);
 - `failed` / any other decision / a cancelled job / no `gitmoot_result` → the stage
   **fails** (retried if budget remains), else the run **parks failed**.
+
+`skipped` means the stage itself had no work and advances by default with a
+`[skipped: no work]` summary marker. An explicit `success_decisions` list is
+strict: omitting `skipped` makes it fail. A `pr_merged` gate whose source skipped
+parks blocked because no PR can exist for that run.
 
 `pipeline run` prints only the run id (script-stable: `RUN=$(gitmoot pipeline run
 nightly-sync)`); a manual run ignores `enabled` but still needs a `repo` and refuses
@@ -2402,4 +2407,3 @@ POST /v1/agents/{name}/ask. Every request needs
 rate-limited (30/min) and body-capped (1MB). Containers reach the host
 bridge at http://host.docker.internal:8791 (or the docker bridge IP on
 Linux). Built for the Activepieces piece seam (issue #785).
-

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -6,7 +6,7 @@ truthful, and tied to work that actually happened.
 ```json
 {
   "gitmoot_result": {
-    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "decision": "approved|changes_requested|blocked|implemented|failed|skipped",
     "summary": "Brief outcome.",
     "findings": [],
     "changes_made": [],
@@ -516,6 +516,13 @@ The same capture also feeds the `$`-denominated
   live. See `internal/workflow` `IsSettledJobState` vs `IsFinalJobState` (#632).
 - `implemented`: the requested implementation work was completed.
 - `failed`: the attempted action errored or could not complete.
+- `skipped`: the task itself had no work to do. Do not use `skipped` in a PR
+  review to mean "nothing to flag"; reviewers use `approved`. A skipped result
+  cannot carry delegations. Outside pipelines it maps to a succeeded job state;
+  it is an abstention for quorum/verify, while vote counts that succeeded state.
+  Pipelines accept it as success by default and persist the existing succeeded
+  stage state, not the separate skipped state used for downstream stages that
+  never ran.
 
 ## Reporting Rules
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -978,8 +978,17 @@ advancer folds by that **decision**, never the job's exit state:
 
 ```sh
 printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+printf '%s' '{"gitmoot_result":{"decision":"skipped","summary":"no new replies today"}}'
 printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
 ```
+
+`skipped` is the default-on success decision for a stage whose task had no work.
+The persisted summary is prefixed with `[skipped: no work]`, so downstream agent
+stages receive the honest outcome. An explicit `success_decisions` list that
+omits `skipped` is strict and folds it failed. If an implement source skips, a
+downstream `pr_merged` gate parks blocked instead of waiting for a PR that cannot
+exist. The result still uses the existing succeeded stage state; the `SKIPPED`
+funnel state remains reserved for downstream stages that never ran.
 
 ### Agent stages (#757 / #768 / #758)
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -727,7 +727,7 @@ once you clock out:
 ```sh
 gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|review|implement] [--json]
 # prints:  [gitmoot session job <id> — when this work is complete, run:
-#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]
+#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed|skipped> --summary "..."]
 # followed by the prompt body.
 ```
 
@@ -965,7 +965,7 @@ gitmoot job open --agent <name> --repo owner/repo --type ask|review|implement \
                  [--title "..."] [--task <id>] [--pr <n>] [--json]
 
 # Clock out: apply the result and move the job to its terminal state.
-gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed \
+gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed|skipped \
                  [--summary "..."] [--pr <n>] [--branch <name>] [--json]
 
 # One-shot post-hoc: create an already-terminal job (open + close in one).
@@ -979,8 +979,8 @@ the daemon never claims or Delivers it — no runtime subprocess, no runtime-ses
 or checkout lock) and the stuck-`running` reaper **skips** it, so a session may
 hold it open for as long as the work takes. `close` reuses the exact result path an
 engine-run job uses: `--decision` maps to the same terminal state
-(`approved`/`changes_requested`/`implemented` → succeeded, `blocked` → blocked,
-`failed` → failed) and emits the same finished/failed/blocked event, so a recorded
+(`approved`/`changes_requested`/`implemented`/`skipped` -> succeeded, `blocked` -> blocked,
+`failed` -> failed) and emits the same finished/failed/blocked event, so a recorded
 job is indistinguishable from an engine-run one in the dashboard and events. A job
 can be closed **once** (it must be a running session job); an orphaned open job
 stays `running` (reaper-exempt) until you `job close --decision failed` or `job
@@ -1666,12 +1666,17 @@ A stage signals its outcome by printing a `gitmoot_result` blob to stdout; the
 advancer folds by the **decision**, never the job's exit state (`changes_requested`
 is a succeeded job but folds as a stage **failure** by default):
 
-- a decision in the stage's `success_decisions` (default `approved`/`implemented`) →
+- a decision in the stage's `success_decisions` (default `approved`/`implemented`/`skipped`) ->
   **succeeded**, dependents enqueue;
 - `blocked` → the stage blocks, its `needs` persist, the run **parks blocked**
   (downstream never enqueues, zero compute while parked);
 - `failed` / any other decision / a cancelled job / no `gitmoot_result` → the stage
   **fails** (retried if budget remains), else the run **parks failed**.
+
+`skipped` means the stage itself had no work and advances by default with a
+`[skipped: no work]` summary marker. An explicit `success_decisions` list is
+strict: omitting `skipped` makes it fail. A `pr_merged` gate whose source skipped
+parks blocked because no PR can exist for that run.
 
 `pipeline run` prints only the run id (script-stable), ignores the `enabled` flag but
 still needs a `repo` and refuses to start while a run is active. `pipeline show

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -15,7 +15,7 @@ arrays that describe the work:
 ```json
 {
   "gitmoot_result": {
-    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "decision": "approved|changes_requested|blocked|implemented|failed|skipped",
     "summary": "Brief outcome.",
     "findings": [],
     "changes_made": [],
@@ -34,6 +34,13 @@ The `decision` field reports the outcome of the job:
   change.
 - `implemented`: the requested implementation work was completed.
 - `failed`: the attempted action errored or could not complete.
+- `skipped`: the task itself had no work to do. Do not use `skipped` in a PR
+  review to mean "nothing to flag"; reviewers use `approved`. A skipped result
+  cannot carry delegations. Outside pipelines it maps to a succeeded job state;
+  it is an abstention for quorum/verify, while vote counts that succeeded state.
+  Pipelines accept it as success by default and persist the existing succeeded
+  stage state, not the separate skipped state used for downstream stages that
+  never ran.
 
 The narrative and evidence fields are reporting-only. Do not claim tests were run
 in `tests_run` unless they were actually run, and do not list files in

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -59,7 +59,7 @@ name/id, a duplicate stage id, a stage that is not exactly one of `cmd`, `agent`
 `implement` without `write: true`, a mutating stage on a scheduled pipeline without
 `allow_scheduled_writes`, a gate's bad predicate/`source`), an unknown/self/cyclic
 `needs`, an invalid duration, a negative retry, or a
-`success_decisions` value outside `approved`/`implemented`/`changes_requested` — so a
+`success_decisions` value outside `approved`/`implemented`/`changes_requested`/`skipped` - so a
 structural mistake is a clear error at registration, not a stuck run later. It stores the raw YAML **verbatim**
 plus a content hash; each run snapshots the hash and executes its snapshot, so
 editing the file later never mutates an in-flight run.
@@ -132,11 +132,12 @@ that result's **`decision`**, never by the job's exit state:
 ```sh
 # succeeds:
 printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+printf '%s' '{"gitmoot_result":{"decision":"skipped","summary":"no new replies today"}}'
 # parks the run awaiting a human, listing what it needs:
 printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
 ```
 
-- a decision in the stage's `success_decisions` (default `["approved","implemented"]`)
+- a decision in the stage's `success_decisions` (default `["approved","implemented","skipped"]`)
   → the stage **succeeded**; stages whose `needs` have all now succeeded are enqueued;
 - `blocked` → the stage **blocks**; its `needs` are persisted at the stage and run
   level and the run **parks blocked** (downstream stages never enqueue, zero compute
@@ -148,6 +149,13 @@ printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing",
 `changes_requested` is a stage **failure by default** even though the underlying job
 succeeded — a stage folds on the decision, not the job state. List it in
 `success_decisions` (per-stage or top-level) to treat it as success instead.
+
+`skipped` is a stage **success by default** for a task that had no work. Gitmoot
+prefixes the persisted summary with `[skipped: no work]`, which downstream agent
+stages receive as upstream context. An explicit `success_decisions` list is strict:
+if it omits `skipped`, the stage fails because the author required real work. A
+skipped result uses the existing succeeded stage state; the `SKIPPED` funnel state
+still means a downstream stage never ran after the pipeline halted.
 
 ## Agent stages
 
@@ -191,7 +199,8 @@ codex — no per-job shell override):
   reuses it), requires `write: true`, and never auto-merges. `orchestrate` is a
   coordinator (the one non-leaf): it fans out owned children, waits for the sub-tree
   via the continuation chain, then folds the tail. `gate` runs no job and folds when
-  `pr_merged` holds on its `source` PR (parks `blocked` on close-unmerged / timeout).
+  `pr_merged` holds on its `source` PR (parks `blocked` on close-unmerged, timeout,
+  or a source that succeeded via `skipped` because no PR can exist).
 - **agent existence is warned, not blocked** — `pipeline add` warns for any referenced
   agent that does not exist yet but still adds the pipeline (so a spec can be bundled
   ahead of provisioning its agents); create the agent (`gitmoot agent …`) before the

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -54,8 +54,12 @@ An agent is a named identity with a role, capabilities, a runtime, and a version
 ```sh
 gitmoot agent template draft frontend-reviewer --output agents/frontend-reviewer.md
 gitmoot agent template add frontend-reviewer --file agents/frontend-reviewer.md
-gitmoot agent start frontend-reviewer --runtime codex --repo owner/repo --template frontend-reviewer
+gitmoot agent start frontend-reviewer --runtime codex --repo owner/repo --template frontend-reviewer --effort high
 ```
+
+Codex agents can set a default reasoning effort with `--effort`, and individual
+jobs can override it with the same flag. Gitmoot forwards the free-form value as
+`-c model_reasoning_effort=<value>`; Claude and Kimi ignore it.
 
 ### Agents that evolve themselves with SkillOpt
 
@@ -492,7 +496,7 @@ object:
 ```json
 {
   "gitmoot_result": {
-    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "decision": "approved|changes_requested|blocked|implemented|failed|skipped",
     "summary": "Brief outcome.",
     "findings": [],
     "changes_made": [],
@@ -1087,7 +1091,8 @@ Agents must return exactly one JSON object containing `gitmoot_result`:
 ```
 
 Valid decisions are `approved`, `changes_requested`, `blocked`, `implemented`,
-and `failed`.
+`failed`, and `skipped`. Use `skipped` only when the task itself had no work to
+do, never as a PR-review synonym for `approved`, and never with delegations.
 
 ---
 
@@ -2593,6 +2598,7 @@ schedule:                   # optional; interval schedule (no cron in v1)
 success_decisions:          # optional top-level default (see below)
   - approved
   - implemented
+  - skipped
 stages:                     # the DAG, keyed by unique id and wired by needs
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
@@ -2616,7 +2622,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
 | `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
 | `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
-| `success_decisions`         | pipeline     | no       | Decisions that mark a stage succeeded. Default `["approved","implemented"]`. Any value must be one of `approved`, `implemented`, `changes_requested` — `blocked`/`failed` are park states and are rejected. |
+| `success_decisions`         | pipeline     | no       | Decisions that mark a stage succeeded. Default `["approved","implemented","skipped"]`. Any value must be one of `approved`, `implemented`, `changes_requested`, `skipped` - `blocked`/`failed` are park states and are rejected. An explicit list is strict: omitting `skipped` requires real work and makes a skipped result fail. |
 | `allow_scheduled_writes`    | pipeline     | no       | Safety flag (#768). A **mutating** `implement` stage on a **scheduled** pipeline (a `schedule:` block) is rejected at add time unless this is `true` — so an unattended nightly pipeline can never write code / open a PR by accident. Manual-run pipelines don't need it. Default `false`. |
 | `stages[].id`               | stage        | yes      | Unique, name-safe stage id. Appears verbatim in the stage job's fingerprint and deterministic id. |
 | `stages[].cmd`              | stage        | cond.    | Shell command run verbatim via `sh -c` (see the stage contract below). A stage is **exactly one** of `cmd`, `agent`, or `gate`. |
@@ -2731,8 +2737,8 @@ stages:
   dispatch's fail-closed guards). A **retry** lands in the *same* branch/PR — never a
   duplicate — and fails closed if that worktree is dirty or has a live process.
 - **Folds on PR-opened.** A `success` decision folds only once the job carries an
-  opened PR; a legitimate **no-op** implement (nothing to change) folds succeeded too
-  (it can't wedge the run). The opened PR number is appended to the stage summary so a
+  opened PR. The first-class `skipped` decision bypasses that wait because there is
+  no work to turn into a PR. The opened PR number is appended to the stage summary so a
   downstream stage sees it via upstream-context injection.
 - **Never auto-merges.** The pipeline **opens** the PR; a human or your CI does the
   merge. See [Gate stages](#gate-stages) to make a later stage wait for that merge.
@@ -2766,6 +2772,8 @@ stages:
   **fails open** (keeps waiting while unmerged), and is bounded by the stage `timeout`.
 - A PR that is **closed without merging**, or a **timeout**, parks the run `blocked`
   (a gate is a wait, not a failure — so a retry budget can't re-arm the timer).
+- A source stage that succeeded via `skipped` also parks the gate `blocked`
+  immediately: no PR will exist for that run.
 
 ### Orchestrate stages
 
@@ -2807,6 +2815,9 @@ the stage by that result's **`decision`**, never by the job's exit state:
 # A stage that succeeds:
 printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
 
+# A stage whose task had no work:
+printf '%s' '{"gitmoot_result":{"decision":"skipped","summary":"no new replies today"}}'
+
 # A stage that parks the run awaiting a human, listing what it needs:
 printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
 ```
@@ -2827,6 +2838,13 @@ The decision drives advancement:
 job succeeded — because a stage folds on the decision, not the job state, and a
 review that asked for changes is not "this step landed." List it in a stage's (or
 the pipeline's) `success_decisions` to treat it as success instead.
+
+`skipped` is a stage **success by default**. Gitmoot prefixes its persisted summary
+with `[skipped: no work]`, and downstream agent stages receive that honest note in
+their upstream context. An explicit `success_decisions` list is strict: if it omits
+`skipped`, the stage fails because the author required real work. A skipped result
+uses the existing succeeded stage state; the `SKIPPED` funnel state still means a
+downstream stage never ran after the pipeline halted.
 
 ## CLI
 
@@ -7750,7 +7768,7 @@ By DEFAULT, the "here" flow tracks the work: run
 `gitmoot agent prompt <agent> --record [--repo owner/repo]`, which opens a
 session job on import and returns the prompt with a header line naming its job
 id. Apply the prompt, do the work, then — this is REQUIRED — clock out with
-`gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."`
+`gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed|skipped> --summary "..."`
 so the work shows in `job list`, the dashboard, and the event stream just like
 an engine-run job (no runtime is spawned; gitmoot is only the record-keeper).
 `--record` works for both a **registered agent** (repo defaults to its repo scope)
@@ -7883,12 +7901,18 @@ self-evaluation; see the `verifier` and `decompose-and-verify` recipes and the
 individual job or delegation (via `--model` on run/ask/review/implement or the
 delegation `model` field) can pin a runtime model, with the per-job/delegation
 value overriding the agent default. When neither pins one, a job falls back to the
-runtime's configured `[runtimes.<name>].default_model` (the one behavioral registry
-field), then the runtime CLI's own default. Use `gitmoot runtime list` to inspect
-each built-in runtime's resolved metadata (capabilities, default/known models, and
-where token usage is read from); operators can override a built-in runtime's
+runtime's configured `[runtimes.<name>].default_model`, then the runtime CLI's own
+default. Codex agents, jobs, delegations, and ephemeral worker specs can likewise
+set reasoning effort with `--effort` or the `effort` field. Job/delegation effort
+overrides agent/worker effort, then `[runtimes.codex].default_effort`, and Gitmoot
+forwards the free-form value as `-c model_reasoning_effort=<value>`. Claude and
+Kimi ignore effort. Use
+`gitmoot runtime list` to inspect each built-in runtime's resolved metadata:
+capabilities, default model/effort, known models, and the token-usage source.
+Operators can override a built-in runtime's
 metadata without recompiling via a `[runtimes.<name>]` config section — `default_model`
-retargets delivery, `models`/`capabilities` stay advisory (see CLI.md
+retargets delivery and `default_effort` selects Codex effort, while
+`models`/`capabilities` stay advisory (see CLI.md
 § Runtime Metadata Registry). Use
 `gitmoot plugin doctor` when checking whether Codex, Claude Code, or Kimi Code
 can discover Gitmoot through an installed runtime plugin. Use
@@ -8242,26 +8266,29 @@ gitmoot runtime list --json
 The values come from the compiled built-in defaults, overlaid with any
 `[runtimes.<name>]` overrides in the config file. Override a built-in runtime's
 recorded metadata **without recompiling** — for example to retarget its default
-model or record its known models:
+model/effort or record its known models:
 
 ```toml
 [runtimes.codex]
 default_model = "gpt-5.5-codex"
+default_effort = "high"
 models = ["gpt-5.5-codex", "gpt-5.4-codex"]
 capabilities = ["review", "implement", "ask"]
 usage_source = "codex exec --json turn.completed usage"
 ```
 
-Exactly one field is **behavioral**: `default_model` is consulted at job **delivery**
-as the model fallback when **neither the agent nor the job pins a `--model`** — so
-setting it **does** retarget the model those jobs run on. The resolution order is:
-the agent/job `--model` win, then this `default_model`, then the runtime CLI's own
-default. Every other field is **inspection-only**, surfaced by `gitmoot runtime list`
+Two fields are **behavioral**. `default_model` is the model fallback when neither
+the agent nor the job pins `--model`: agent/job `--model`, then `default_model`,
+then the runtime CLI's own default. `default_effort` follows the same precedence
+after job/agent `--effort`; for Codex, Gitmoot emits
+`-c model_reasoning_effort=<value>`. Claude and Kimi do not expose a reasoning
+effort argument, so the resolved value is a no-op for those adapters. Every other
+field is **inspection-only**, surfaced by `gitmoot runtime list`
 but changing nothing at runtime: `models` is **advisory** (Gitmoot never rejects a
 `--model` based on it), and `capabilities` gates nothing at dispatch. Adapter
 behavior (auth, sandbox policy, session resume, stream parsing) always stays in Go.
-With no `[runtimes.*]` section — and with `default_model` unset — behavior is
-byte-identical: no model is forced.
+With no `[runtimes.*]` section, and with both defaults unset, no model or effort is
+forced.
 
 A `[runtimes.<name>]` section can only tweak a **built-in** runtime's metadata; it
 cannot add a new first-class runtime (that requires a code change). An unknown
@@ -8582,6 +8609,7 @@ gitmoot agent start reviewer \
   --capability ask \
   --capability review \
   --model gpt-5-codex \
+  --effort high \
   --start-daemon
 ```
 
@@ -8602,6 +8630,13 @@ with no allow-list; both `--model X` and `--model=X` are accepted. A per-job
 omitted model preserves the runtime's own default. The same default can be set
 in config under `[agents.<type>].model`.
 
+The same commands accept `--effort <value>` as the agent's default reasoning
+effort, and `agent run`, `ask`, `implement`, `review`, and `orchestrate` accept it
+as a per-job override. The resolution order mirrors model selection: job effort,
+agent effort, `[runtimes.<runtime>].default_effort`, then no explicit override.
+Values are free-form pass-through strings. Codex receives
+`-c model_reasoning_effort=<value>`; Claude and Kimi ignore the setting.
+
 `agent start` and `agent subscribe` accept `--policy` (default `auto`). The policy
 maps to the runtime permission mode and decides what a headless job may do:
 
@@ -8619,6 +8654,18 @@ subscribe`, and at implement-job dispatch with an actionable message. Set
 `--policy danger-full-access` for full headless implementation (file writes plus
 `go`/`git`/`gh`), or `--policy workspace-write` for edits-only (Bash stays
 blocked). See `references/SAFETY.md` for the full mapping and rationale.
+
+Implement jobs own the commit contract: Gitmoot commits and delivers the
+worktree's changes after the job finishes, and every rendered implement prompt
+carries one deterministic sentence telling the worker not to run `git commit`
+or `git push`. Ask and review prompts are unchanged. On the Codex runtime, a
+`workspace-write` job whose checkout is a linked `git worktree` also gets the
+worktree's resolved git directory (`<main-repo>/.git/worktrees/<name>`) added
+to the sandbox writable roots via `--add-dir`, so routine git metadata writes
+(an index refresh from `git status`, or `git add`) work inside the sandbox.
+The grant is additive and leaves operator-configured `writable_roots` intact;
+read-only and danger-full-access sandboxes and primary (non-worktree)
+checkouts are unchanged.
 
 `agent subscribe` accepts `--preset-delivery full|referenced|auto` (default
 `full`) and `agent update <name> --preset-delivery <mode>` flips it in place on
@@ -8651,7 +8698,8 @@ gitmoot agent subscribe reviewer \
   --role reviewer \
   --capability ask \
   --capability review \
-  --model gpt-5-codex
+  --model gpt-5-codex \
+  --effort high
 
 # Deterministic shell runtime: the session is a command, not a session id.
 gitmoot agent subscribe stub-agent \
@@ -8688,11 +8736,34 @@ gitmoot agent run lead --repo owner/repo --task task-001 --background "Implement
 gitmoot agent run reviewer --repo owner/repo --pr 12 --background "Review this PR."
 gitmoot agent review reviewer --repo owner/repo --pr 12 "Review this PR."
 gitmoot agent implement lead --repo owner/repo --task task-001 "Implement this task."
+gitmoot agent implement lead --repo owner/repo --task task-002 --base origin/main "Implement from current origin/main."
 gitmoot agent ask project-planner --repo owner/repo "Return the plan status."
 gitmoot agent ask project-planner --repo owner/repo --background "Write the implementation plan and goal file."
 gitmoot agent run lead --repo owner/repo --model gpt-5-codex "Implement this task."
+gitmoot agent run lead --repo owner/repo --effort xhigh "Implement this task."
 gitmoot job watch <job-id>
 ```
+
+For `agent implement`, `--base <ref>` selects the commit used to create a new
+branch worktree. `agent run` accepts the same flag when it routes to implement.
+An `origin/*` ref is fetched before it is resolved, and an unknown ref fails
+before a job is enqueued. `--base HEAD` explicitly follows the registered
+checkout's current commit. On implement, `--head-sha <sha>` is a compatibility
+alias for `--base <sha>`; passing both with different values is an error.
+
+Set a default for implement dispatches in `config.toml`:
+
+```toml
+[workflow]
+implement_base = "origin/main"
+```
+
+The flag wins over the config value. The config value `"HEAD"` keeps
+checkout-following behavior. With no flag and no config value, Gitmoot still
+uses checkout HEAD, but refuses when the checkout is on a non-default branch
+that is behind `origin/<default>`. The error reports the branch and behind
+count and offers both explicit choices: `--base origin/<default>` or
+`--base HEAD`.
 
 `gitmoot agent run`, `ask`, `implement`, and `review` (and `orchestrate`) accept
 an optional `--model <name>` flag that pins the runtime model for that one job,
@@ -8700,6 +8771,10 @@ overriding the agent's configured default. It is a free-form, runtime-scoped
 string (a Codex, Claude Code, or Kimi Code model name) with no allow-list; an
 omitted `--model` leaves the agent's default model in effect. Both `--model X`
 and `--model=X` are accepted.
+
+`--effort <value>` and `--effort=<value>` select reasoning effort for one job
+with the same job-over-agent-over-registry precedence. Gitmoot does not validate
+an allow-list; Codex validates the forwarded value.
 
 The same commands accept an optional per-job `--runtime
 codex|claude|kimi|kimi-cli|shell` override: that ONE job runs through the named
@@ -8714,8 +8789,9 @@ override runtime so it cannot collide with the default session's lock. Model
 rule: `--model` combined with `--runtime` is interpreted for the OVERRIDE
 runtime; an override without `--model` uses the override runtime's default
 model — the agent's configured default model is never applied to a different
-runtime. An unknown
-`--runtime` fails before any job is enqueued, background (daemon) jobs honor
+runtime. The same rule applies to `--effort`: an explicit job value belongs to
+the override runtime, while the agent's default effort does not cross runtimes.
+An unknown `--runtime` fails before any job is enqueued, background (daemon) jobs honor
 the override identically to foreground, and a coordinator's delegation-tree
 continuations (synthesis, corrective, replan, finalize) inherit the override,
 so an `orchestrate --runtime` tree stays on the override runtime across
@@ -8770,6 +8846,7 @@ Start an orchestra of agents with `gitmoot orchestrate`:
 ```sh
 gitmoot orchestrate project-planner "Plan and split this work across agents." --repo owner/repo
 gitmoot orchestrate project-planner "Plan and split this work." --repo owner/repo --model gpt-5-codex
+gitmoot orchestrate project-planner "Plan and split this work." --repo owner/repo --effort high
 ```
 
 The built-in coordinator recipes `review-panel`, `decompose-and-verify`, and
@@ -8817,11 +8894,15 @@ gitmoot agent type list
 gitmoot agent type show planner
 gitmoot agent type set planner --runtime codex --template planner --max-background 2 --idle-timeout 20m
 gitmoot agent type set planner --model gpt-5-codex
+gitmoot agent type set planner --effort high
 gitmoot agent gc
 ```
 
 `agent type set --model <name>` (or `[agents.<type>].model` in config) sets the
 default runtime model for that managed agent type.
+
+`agent type set --effort <value>` (or `[agents.<type>].effort`) sets its default
+reasoning effort.
 
 Schedule recurring agent work (heartbeats, off by default):
 
@@ -8921,7 +9002,7 @@ once you clock out:
 ```sh
 gitmoot agent prompt frontend-reviewer --record [--repo owner/repo] [--type ask|review|implement] [--json]
 # prints:  [gitmoot session job <id> — when this work is complete, run:
-#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed> --summary "..."]
+#           gitmoot job close <id> --decision <approved|changes_requested|implemented|blocked|failed|skipped> --summary "..."]
 # followed by the prompt body.
 ```
 
@@ -9157,7 +9238,7 @@ gitmoot job open --agent <name> --repo owner/repo --type ask|review|implement \
                  [--title "..."] [--task <id>] [--pr <n>] [--json]
 
 # Clock out: apply the result and move the job to its terminal state.
-gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed \
+gitmoot job close <id> --decision approved|changes_requested|blocked|implemented|failed|skipped \
                  [--summary "..."] [--pr <n>] [--branch <name>] [--json]
 
 # One-shot post-hoc: create an already-terminal job (open + close in one).
@@ -9171,8 +9252,8 @@ the daemon never claims or Delivers it — no runtime subprocess, no runtime-ses
 or checkout lock) and the stuck-`running` reaper **skips** it, so a session may
 hold it open for as long as the work takes. `close` reuses the exact result path an
 engine-run job uses: `--decision` maps to the same terminal state
-(`approved`/`changes_requested`/`implemented` → succeeded, `blocked` → blocked,
-`failed` → failed) and emits the same finished/failed/blocked event, so a recorded
+(`approved`/`changes_requested`/`implemented`/`skipped` -> succeeded, `blocked` -> blocked,
+`failed` -> failed) and emits the same finished/failed/blocked event, so a recorded
 job is indistinguishable from an engine-run one in the dashboard and events. A job
 can be closed **once** (it must be a running session job); an orphaned open job
 stays `running` (reaper-exempt) until you `job close --decision failed` or `job
@@ -9226,6 +9307,20 @@ credential probe passes; the probe failing just extends the hold without spendin
 a retry. So a job that "failed then reappeared as queued" is the deferral
 working, not a bug. Product failures (the agent answered with a `gitmoot_result`,
 including `decision=failed`) are never auto-retried.
+
+When a runtime session ends **without** producing a `gitmoot_result` envelope —
+the CLI process crashed, exited non-zero, was signal-killed, or completed but
+never emitted a valid envelope even after repair attempts — the job records
+**failure diagnostics** (#806): a `phase` marker (`launched` = died before any
+stdout, `streaming` = died mid-output, `result-parse` = every delivery completed
+but no valid envelope was found), the process `exit_code` **or** terminating
+`signal`, a **redacted** stderr tail (hard-capped at 2 KB; redaction runs over
+the full text with the same token-redaction rules as job comments *before* the
+tail is cut, so a secret can never leak partially), and the runtime session id
+when one is known. `gitmoot job show` prints a `failure_diagnostics:` block,
+`job show --json` carries `payload.failure_diagnostics`, and `gitmoot report
+bug` includes a "Failure diagnostics" section. Successful jobs never store one,
+and a retried job clears the previous run's crash report.
 
 Jobs stuck in `running` are also backstopped: a running job with no lease
 progress past the staleness window (default 30m) is assumed orphaned by a dead
@@ -9775,6 +9870,7 @@ distill_at_terminal = false # stage deterministic failure signal at job terminal
 distill_successes = false   # stage deterministic success observations (#781)
 distill_max_per_job = 3     # hard cap on distilled observations per job
 distill_all_jobs = false    # when true, distill runs for every job, not only enrolled agents
+ingest_auto_confirm = false # when true, ingest/chat remember confirm to the authoring agent private pool only
 ```
 
 All `[memory]` keys are read **per tick**. Flipping `distill_at_terminal`,
@@ -9880,18 +9976,23 @@ produced by `export --agent NAME` stays importable even when other owners have
 memories (import rebuilds the fresh export with the manifest's recorded scope). The
 `<DIR>` positional may appear before or after the flags.
 
-### Markdown ingest and the human confirm gate (#737 P3)
+### Markdown ingest, private auto-confirm, and provenance retirement (#737 P3, #782 V1)
 
 `memory ingest` is the **mouth** of the bridge: it reads arbitrary Markdown
-(session notes, runbooks, incident writeups) and stages it as **pending
-observations** behind the existing confirmation gate. It never writes confirmed
-(injectable) memory directly.
+(session notes, runbooks, incident writeups) and stages it as observations behind
+the existing confirmation gate. By default those observations stay pending. If
+`[memory].ingest_auto_confirm = true`, `memory ingest`, `memory ingest sweep`,
+and `chat remember` immediately confirm the staged observation into the
+authoring agent's **private** pool only. They never auto-confirm into the shared
+pool. Shared memory stays explicit through `memory confirm --to-shared` or
+`memory promote --to-shared`.
 
 ```sh
 gitmoot memory ingest <path|dir> --agent NAME [--shared] [--repo owner/repo] [--tier repo|general] [--dry-run] [--json]
 gitmoot memory ingest sweep [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
 gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--to-shared] [--yes] [--json]
+gitmoot memory retire --provenance-prefix P [--agent NAME] [--dry-run] [--yes] [--json]
 gitmoot memory promote --to-shared <id>... [--json]
 gitmoot memory links backfill [--dry-run] [--json]
 gitmoot memory links list <id> [--json]
@@ -9914,15 +10015,30 @@ Surviving chunks land in `memory_observations` with `provenance = ingest:<relpat
 and, crucially, **`trust_mark = low`** — see the trust note below. `--tier` defaults
 to `repo`; `general` is only ever chosen with the explicit flag. `--shared`
 stages the observations in the shared pool while preserving `--agent NAME` as
-their author. `--dry-run` reports what would be staged without writing.
+their author. With auto-confirm enabled, the confirmed write still goes to
+`--agent NAME`'s private pool, not shared. `--dry-run` reports what would be
+staged without writing.
+
+Chunk keys are **stable**: `slug(file)-slug(heading)`, with an ordinal suffix
+(`-2`, `-3`) only when a file/heading pair repeats within one sweep. The content
+hash participates only in dedup, never in the key, so a re-swept **edited** note
+lands on the same key as its earlier edition and, under auto-confirm, updates
+the existing confirmed fact **in place**. Auto-confirmed key-matched updates
+(ingest auto-confirm and `chat remember`) are **supersede-preserving**: the
+prior edition is archived first as a `superseded_by` row (out of FTS, out of the
+vault; `memory_links` stay on the unchanged live row id) so a bad edit never
+destroys the last reviewed edition. Manual paths (vault import CAS edits,
+`memory confirm --yes`) keep plain overwrite semantics. Keys minted before this
+scheme end in an 8-hex content-hash suffix; the groom **rekey** detector
+migrates them (below).
 
 `memory ingest sweep` reads every configured `[[memory.ingest]]` source from the
 current config at run time and runs the same ingest logic in-process for each one.
 `--json` emits per-source entries with `path`, `agent`, `repo`, `tier`,
-`inserted`, `deduped`, `rejected`, and `error`, plus aggregate totals. One bad
-source does not stop the rest; the command exits non-zero only when the config is
-invalid or every configured source fails. With no sources it exits zero with a
-skipped note.
+`inserted`, `confirmed`, `skipped_retired`, `deduped`, `rejected`, and `error`,
+plus aggregate totals. One bad source does not stop the rest; the command exits
+non-zero only when the config is invalid or every configured source fails. With
+no sources it exits zero with a skipped note.
 
 `memory observations` lists pending observations (optionally narrowed by
 `--agent` or `--provenance-prefix`), flagging which keys already crossed the
@@ -9935,7 +10051,16 @@ confirms selected observations into the shared pool and records the observation
 author. `memory promote --to-shared <id>...` moves existing active confirmed
 facts into shared, refuses retired or superseded rows, preserves outgoing
 `memory_links`, and sets `author_ref` from the previous owner when needed. This is
-**CLI-explicit only**: there is no daemon path and nothing auto-confirms.
+**CLI-explicit only**.
+
+`memory retire --provenance-prefix P` is the blast-radius undo for any collector
+batch. It selects active confirmed rows whose provenance starts with `P`, scoped
+optionally by `--agent NAME`, and is a dry run unless `--yes` is passed. Applying
+the plan sets `retired_at` and `retired_reason` and removes the rows from FTS in
+the same transaction, so they stop being injected and exported while the audit
+rows remain. Retired keys are not resurrected by ingest or collectors on
+re-ingest; only explicit human-controlled confirmation paths may revive a retired
+key.
 
 The built-in `memory-ingest-sweep` pipeline calls
 `gitmoot memory ingest sweep --json` and then summarizes the run totals. Configure
@@ -9995,8 +10120,8 @@ gitmoot memory groom --yes --plan PLAN.json [--json]
 `--propose` reads every **active** confirmed memory (retired rows excluded),
 computes the current vault `snapshot_hash` (the same anchor `vault export`/`import`
 use), runs deterministic detectors, and writes a reviewable plan artifact
-(`{schema_version, snapshot_hash, proposed_retirements, rewrite_flags, stats}`). It
-**touches nothing** in the store. The detectors are:
+(`{schema_version, snapshot_hash, proposed_retirements, rewrite_flags, rekeys,
+cross_pool, stats}`). It **touches nothing** in the store. The detectors are:
 
 - **status/changelog/ToC snapshots** — notes dominated (≥80% of non-blank lines) by
   `STATUS:` markers, `SHIPPED`/`merged & deployed` changelog phrases, ISO-date-led
@@ -10013,14 +10138,31 @@ use), runs deterministic detectors, and writes a reviewable plan artifact
   proposed retirement so you can tell them apart);
 - **over-long "bricks"** (content > ~1200 chars) are **flagged for rewrite**, never
   retired — P4.2 only lists them for the owner (LLM rewriting is the follow-up
-  P4.3).
+  P4.3);
+- **legacy-key rekeys** (#804): active rows whose key still ends in the
+  pre-stable-key 8-hex content-hash suffix (`…-a1b2c3d4`) are grouped per
+  owner/repo/scope by their stripped stable key. Organic sweeps can never fix
+  them (content dedup skips unchanged notes; the first edit would spawn a
+  stable-keyed third sibling), so the plan keeps the current edition (the row
+  already holding the stable key when one exists, otherwise the newest by
+  `updated_at`), rewrites its key to the stable form, and retires the older
+  siblings with reason `rekey: superseded edition`;
+- **cross-pool stale shared editions** (#804): a shared-pool fact gets a
+  **promote-and-retire pair** when a strictly newer private fact matches it in
+  the same repo and scope, by stable-key equality (primary, deterministic) or
+  by a strong BM25 top-match that also shares a `memory_links` edge (composite
+  secondary evidence; BM25 alone never proposes). Applying promotes the newer
+  private edition to the shared pool (author preserved) and retires the stale
+  shared edition with reason `cross-pool: superseded by promoted edition`.
 
 `--yes --plan` recomputes the `snapshot_hash` and **aborts as stale** if it differs
 from the plan's (a vault edit between propose and apply invalidates it), then
-retires exactly the planned ids in **one transaction** (reason `groom:<detector>`,
-FTS index cleared in the same tx). It is **retire-only** — no content is edited or
-rewritten — and idempotent: an already-retired or missing id in the plan is skipped
-gracefully rather than aborting the batch.
+applies the whole plan in **one transaction**: retirements (reason
+`groom:<detector>`, FTS index cleared in the same tx), rekey groups (FTS key
+column re-synced in the same tx), and cross-pool pairs. **No content is edited or
+rewritten**, and applying is idempotent: an already-retired or missing id is
+skipped gracefully, and a rekey group or cross-pool pair whose rows changed state
+since the proposal is skipped whole rather than half-applied.
 
 The built-in `memory-groom-propose` pipeline runs only the proposal half:
 `gitmoot memory groom --propose --out <run-scoped-plan> --json`, then summarizes
@@ -10161,7 +10303,7 @@ cyclic `needs`, a stage that is not exactly one of `cmd`/`agent`/`gate`, an agen
 missing a `prompt` / invalid `action` / `implement` without `write: true` / a mutating
 stage on a scheduled pipeline without `allow_scheduled_writes` / a gate's bad
 predicate or `source`, invalid durations, a `success_decisions` outside
-`approved`/`implemented`/`changes_requested`) so a mistake is a clear error, not a
+`approved`/`implemented`/`changes_requested`/`skipped`) so a mistake is a clear error, not a
 stuck run. It stores the raw YAML **verbatim** plus a content hash; each run
 snapshots that hash and executes its snapshot, so editing the file later never
 mutates an in-flight run. `pipeline add` also auto-creates one hidden shell runner
@@ -10191,12 +10333,17 @@ printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
 printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
 ```
 
-- a decision in the stage's `success_decisions` (default `approved`/`implemented`) →
+- a decision in the stage's `success_decisions` (default `approved`/`implemented`/`skipped`) ->
   **succeeded**, dependents enqueue;
 - `blocked` → the stage blocks, its `needs` persist at the stage **and** run level,
   the run **parks blocked** (downstream never enqueues, zero compute while parked);
 - `failed` / any other decision / a cancelled job / no `gitmoot_result` → the stage
   **fails** (retried if budget remains), else the run **parks failed**.
+
+`skipped` means the stage itself had no work and advances by default with a
+`[skipped: no work]` summary marker. An explicit `success_decisions` list is
+strict: omitting `skipped` makes it fail. A `pr_merged` gate whose source skipped
+parks blocked because no PR can exist for that run.
 
 `pipeline run` prints only the run id (script-stable: `RUN=$(gitmoot pipeline run
 nightly-sync)`); a manual run ignores `enabled` but still needs a `repo` and refuses
@@ -10232,6 +10379,7 @@ gitmoot chat create <name> --repo owner/repo [--topic "title"] [--json]
 gitmoot chat list [--repo owner/repo] [--all] [--json]      # open threads; --all includes archived
 gitmoot chat show <thread> [--repo owner/repo] [--limit N] [--json]
 gitmoot chat send <thread> "message" [--as agent] [--repo owner/repo] [--ref kind:value ...] [--json]
+gitmoot chat remember <thread> <message-seq> [--repo owner/repo] [--tier repo|general] [--agent NAME] [--json]
 gitmoot chat inbox <agent> [--unread] [--json]
 gitmoot chat task <thread> "@agent message" [--action ask|review|implement] [--repo owner/repo] [--json]
 gitmoot chat answer <thread> "<question-id>: answer text" [--repo owner/repo] [--json]
@@ -10249,6 +10397,15 @@ gitmoot chat rename <thread> "new name" [--repo owner/repo] [--json]
   `--as <agent>` authors the message as a registered agent (default: the human);
   `--ref kind:value` attaches structured refs (e.g. `--ref pr:42`). Sending to an
   archived thread is refused until you `reopen` it.
+- **`remember`**: captures exactly one existing message by sequence as a memory
+  observation. It stores the message body verbatim with deterministic provenance
+  `chat:<thread-id>#<seq>`, applies the memory PreFilter, and dedups by content
+  hash within the target scope/repo. It does not scan for natural-language
+  prefixes, does not bulk-mine a thread, and does not self-trigger from agent
+  messages. `--agent` is the capturing agent identity (default `lead`); `--tier`
+  defaults to `repo`. If `[memory].ingest_auto_confirm = true`, the observation is
+  immediately confirmed into that agent's private pool only. Shared memory remains
+  explicit through `memory confirm --to-shared` or `memory promote --to-shared`.
 - **`inbox`** — an agent's mentions, newest first; `--unread` restricts to unread.
 - **`task`** — the one promotion verb. The body must name **exactly one**
   registered `@agent`; it records a `promotion_request` message, then dispatches a
@@ -10413,6 +10570,22 @@ Moot bounds (in `[chat]`, warm-reloadable):
 
 `[chat]` is entirely optional: with no `[chat]` section every knob resolves to its
 default, `auto_respond` stays off, and the daemon tick is byte-identical.
+
+## Bridge (localhost HTTP for external automation)
+
+```bash
+gitmoot bridge serve [--addr 127.0.0.1:8791]   # localhost-only unless --allow-remote (dangerous)
+gitmoot bridge token [--rotate]                 # prints the token FILE PATH, never the token
+```
+
+The bridge exposes a small authenticated HTTP surface over the same internal
+seams the CLI uses (no new authority): POST /v1/pipelines/{name}/run,
+GET /v1/runs/{id}, POST /v1/memory/recall, GET /v1/jobs/{id},
+POST /v1/agents/{name}/ask. Every request needs
+`Authorization: Bearer $(cat ~/.gitmoot/bridge.token)`. Requests are
+rate-limited (30/min) and body-capped (1MB). Containers reach the host
+bridge at http://host.docker.internal:8791 (or the docker bridge IP on
+Linux). Built for the Activepieces piece seam (issue #785).
 
 ---
 
@@ -11398,8 +11571,17 @@ advancer folds by that **decision**, never the job's exit state:
 
 ```sh
 printf '%s' '{"gitmoot_result":{"decision":"approved","summary":"synced"}}'
+printf '%s' '{"gitmoot_result":{"decision":"skipped","summary":"no new replies today"}}'
 printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing","needs":["R2 token"]}}'
 ```
+
+`skipped` is the default-on success decision for a stage whose task had no work.
+The persisted summary is prefixed with `[skipped: no work]`, so downstream agent
+stages receive the honest outcome. An explicit `success_decisions` list that
+omits `skipped` is strict and folds it failed. If an implement source skips, a
+downstream `pr_merged` gate parks blocked instead of waiting for a PR that cannot
+exist. The result still uses the existing succeeded stage state; the `SKIPPED`
+funnel state remains reserved for downstream stages that never ran.
 
 ### Agent stages (#757 / #768 / #758)
 
@@ -11877,7 +12059,7 @@ truthful, and tied to work that actually happened.
 ```json
 {
   "gitmoot_result": {
-    "decision": "approved|changes_requested|blocked|implemented|failed",
+    "decision": "approved|changes_requested|blocked|implemented|failed|skipped",
     "summary": "Brief outcome.",
     "findings": [],
     "changes_made": [],
@@ -12117,6 +12299,12 @@ Delegation fields:
   **Rule of thumb:** downshift `model` for cheap/mechanical legs; leave `model`
   empty for standard legs (so they take the runtime default); and reserve a deep
   model for genuinely hard or quorum-critical legs.
+- `effort` (optional): a free-form, runtime-scoped reasoning effort for the
+  child job. This job-level value overrides the delegated agent's default or
+  the ephemeral worker's `effort`; when omitted, effort falls back to that
+  agent/worker default and then `[runtimes.<name>].default_effort`. Gitmoot does
+  not apply an allow-list. Codex receives
+  `-c model_reasoning_effort=<value>`; Claude and Kimi ignore the setting.
 - `phase` (optional): a free-form per-delegation string. It is pass-through
   metadata — Gitmoot carries it through to the child job untouched and echoes it
   back in the coordinator continuation for each delegation that set a non-empty
@@ -12139,6 +12327,9 @@ Delegation fields:
     `claude`, or `kimi`. It is never `shell`.
   - `model` (optional): a runtime-scoped model string, as for the delegation
     `model` field above.
+  - `effort` (optional): the worker's default reasoning effort. A top-level
+    delegation `effort` overrides it; omit both to use the runtime registry
+    default (if configured).
   - `template` (optional): an agent-template id to seed the worker's prompt.
   - `role` (optional): a human-readable role label for the worker.
   - `capabilities` (optional): an array of capability strings advertised by the
@@ -12378,6 +12569,13 @@ The same capture also feeds the `$`-denominated
   live. See `internal/workflow` `IsSettledJobState` vs `IsFinalJobState` (#632).
 - `implemented`: the requested implementation work was completed.
 - `failed`: the attempted action errored or could not complete.
+- `skipped`: the task itself had no work to do. Do not use `skipped` in a PR
+  review to mean "nothing to flag"; reviewers use `approved`. A skipped result
+  cannot carry delegations. Outside pipelines it maps to a succeeded job state;
+  it is an abstention for quorum/verify, while vote counts that succeeded state.
+  Pipelines accept it as success by default and persist the existing succeeded
+  stage state, not the separate skipped state used for downstream stages that
+  never ran.
 
 ## Reporting Rules
 


### PR DESCRIPTION
Closes #815.

Adds a **first-class "nothing to do" outcome**: a `skipped` result decision that pipeline stages fold as success-with-note instead of forcing an honest no-op stage to lie (`implemented`) or park the whole run.

### Semantics
- **Token only, no new stage state.** A skipped stage folds to the existing `StageSucceeded` row with a Gitmoot-stamped `[skipped: no work]` summary marker (downstream needs-context carries it automatically). The existing `StageSkipped` state keeps meaning "never ran" — the panel's collision warning is honored.
- **Default-on, strict-mode preserved.** `skipped` joins `DefaultSuccessDecisions` (zero-config advance; zero-regression since nothing could emit it before). An explicit `success_decisions` omitting it folds skipped → failed: the author demanded real work.
- **Implement stages can't wedge.** A skipped implement folds immediately — never enters the fold-on-PR-opened wait. (The adjacent *pre-existing* `approved` wedge is tracked separately: #817.)
- **Gates fail honestly.** A `gate: pr_merged` whose source stage skipped folds **blocked** with an actionable need instead of waiting forever for a PR that cannot exist.
- **Forgery-hardened** (from the adversarial review round): the reserved marker is stripped from every non-skipped fold before persistence, so an agent-forged `[skipped: no work]` can neither mislead downstream context nor falsely block a gate that has a real PR. Regression tests cover the forged-marker + real-PR case.
- **Contract guards:** `skipped` + delegations rejected at validation; contract prose scopes it to "the task itself had no work", forbids PR reviewers using it for "nothing to flag" (that's `approved`), and documents it as an **abstention** for quorum/verify (vote's succeeded-state behavior unchanged, per the documented asymmetry).

### Process
Implemented by a gpt-5.6-sol codex subagent from the #815 research-panel synthesis (Fable 5 · GPT-5.6-sol · Kimi), coordinated + reviewed by the Gitmoot 3 session, adversarially reviewed by a second gpt-5.6-sol agent (running at `--effort xhigh` — dogfooding #800), which confirmed one blocking forgery hazard that was fixed and regression-tested before this PR.

### Verification
- Unit + E2E: contract parse/reject, fold default + strict override, dependents enqueue, implement-skip bypass (incl. strict-mode no-wait), gate-blocked-on-skipped-source, downstream-context marker, forged-marker sanitization, shell-runtime E2Es for advance/park.
- `go generate` contract regeneration byte-stable; drift test extended.
- Full local suites green (workflow/pipeline/prompts/db/config/cli, cli uncached rerun 254s).

### Docs (same PR)
`RESULT_CONTRACT.md`, `CLI.md`, `WORKFLOWS.md`, `SKILL.md` (skills tree), `docs/pipelines.md`, `docs/local-workflow.md`, and the website tree (`result-contract.md`, `pipelines-workflow.md`, regenerated `llms-full.txt` — note: the llms regeneration also refreshes text for already-merged features (#800/#806 etc.) that had gone stale in the checked-in artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
