### PR TITLE
feat(pipeline): intra-stage progress — elapsed + last-activity for long-running stages

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -325,6 +325,23 @@ needs: R2 token
 source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
+Queued and running stages also get detail lines such as:
+
+```
+  source: RUNNING; enqueued 2m14s ago
+    last activity 8s ago: downloading object 41
+```
+
+`enqueued` is deliberate: the stage `started_at` is written when the job is
+enqueued, not when a worker claims it. After 60 seconds of delivery, pipeline
+workers update one latest-only `progress` job event about every 30 seconds. Its
+age is computed from the stored event timestamp, so a stopped daemon never looks
+fresh. Activity is stripped of terminal controls, redacted, and length-capped
+before storage. Orchestrate stages may have no current per-stage event while their
+sub-tree runs; the view says `(sub-tree running; no per-stage progress)` and does
+not treat that absence as a failure. `--json` stage objects add `started_at`,
+`finished_at`, and optional `{elapsed, activity, updated_at}` progress data.
+
 Funnel labels are `OK` for a succeeded stage, `BLOCKED (needs: …)` for a parked
 stage, and the uppercased state otherwise (`PENDING`, `QUEUED`, `RUNNING`,
 `FAILED`, `SKIPPED`, `CANCELLED`). When a run **failed**, the view also prints the

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -3000,13 +3000,18 @@ type jobWorker struct {
 	// are side-effect-free (no config.Initialize), so even a mistaken resolved-root
 	// ConfigHome can never MkdirAll the phantom — but every construction site must
 	// still pass the raw --home so the config is actually found.
-	ConfigHome          string
-	ConfigHomeExplicit  bool
-	AdapterFactory      func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
-	StartAdapterFactory func(string, string) (runtime.Adapter, error)
-	CheckoutValidator   func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
-	WorkflowFactory     func(string) workflow.Engine
-	CommenterFactory    func(string) github.Client
+	ConfigHome         string
+	ConfigHomeExplicit bool
+	AdapterFactory     func(runtime.Agent, string) (workflow.DeliveryAdapter, error)
+	// OutputAdapterFactory rebuilds a production runtime adapter around the one
+	// shared live-output writer used by pipeline progress and cockpit. Tests that
+	// inject an opaque fake AdapterFactory may leave this nil and still exercise
+	// elapsed-only progress without replacing their fake.
+	OutputAdapterFactory func(runtime.Agent, string, io.Writer) (workflow.DeliveryAdapter, error)
+	StartAdapterFactory  func(string, string) (runtime.Adapter, error)
+	CheckoutValidator    func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
+	WorkflowFactory      func(string) workflow.Engine
+	CommenterFactory     func(string) github.Client
 	// UsePool selects the opt-in continuous worker-pool scheduler (#394,
 	// --scheduler=pool) over the default per-tick wg.Wait() barrier.
 	UsePool bool
@@ -3038,6 +3043,11 @@ type jobWorker struct {
 	// inject a fake verdict; the daemon wires defaultAuthProbe (a bounded
 	// runtime.ClaudeLiveCheck for claude agents, Unknown for other runtimes).
 	AuthProbe func(context.Context, db.Job, workflow.JobPayload) authProbeVerdict
+	// Progress timing seams keep unit/E2E tests deterministic and short. Zero/nil
+	// values select the package defaults and real timer implementation.
+	ProgressThreshold  time.Duration
+	ProgressInterval   time.Duration
+	ProgressTickSource func(context.Context, time.Duration, time.Duration) <-chan time.Time
 }
 
 // eventSink resolves the best-effort outbound event Sink (#446) for the
@@ -3201,6 +3211,7 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	worker := jobWorker{Store: store, Stdout: stdout, ConfigHome: configHome, ConfigHomeExplicit: configHomeExplicit}
 	worker.RelayServer = activeChatRelayServer()
 	worker.AdapterFactory = worker.defaultAdapter
+	worker.OutputAdapterFactory = worker.outputAdapter
 	worker.StartAdapterFactory = worker.defaultStartAdapter
 	worker.CheckoutValidator = worker.defaultCheckout
 	worker.WorkflowFactory = worker.defaultWorkflow
@@ -5110,7 +5121,17 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// MootSeat — not ThreadID — keeps chat-task promotions and ThreadID-carrying
 	// continuations/children byte-identical (unelevated, no relay env). The token is
 	// released on every exit path so it cannot be replayed after the seat ends.
-	adapter, relayToken, err := w.buildSeatAwareAdapter(&agent, checkout, payload)
+	var progressTracker *pipelineProgressLineTracker
+	if payload.Sender == workflow.PipelineJobSender {
+		progressTracker = &pipelineProgressLineTracker{}
+	}
+	var adapter workflow.DeliveryAdapter
+	var relayToken string
+	if progressTracker != nil {
+		adapter, relayToken, err = w.buildSeatAwareAdapter(&agent, checkout, payload, progressTracker)
+	} else {
+		adapter, relayToken, err = w.buildSeatAwareAdapter(&agent, checkout, payload)
+	}
 	if relayToken != "" {
 		defer w.RelayServer.ReleaseSeat(relayToken)
 	}
@@ -5239,7 +5260,14 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		// is opened O_APPEND and is NOT removed per job (it persists for the root's
 		// life and is torn down by FinalizeRoot).
 		if maybeWrapCockpitAvailable(cp, payload.Cockpit, userOptedOff) {
-			teeAdapter, logPath, logFile := w.cockpitLogAdapter(cp, agent, checkout, job.ID, meta.RootJobID, meta.PaneKey, seatMode)
+			var teeAdapter workflow.DeliveryAdapter
+			var logPath string
+			var logFile *os.File
+			if progressTracker != nil {
+				teeAdapter, logPath, logFile = w.cockpitLogAdapter(cp, agent, checkout, job.ID, meta.RootJobID, meta.PaneKey, seatMode, progressTracker)
+			} else {
+				teeAdapter, logPath, logFile = w.cockpitLogAdapter(cp, agent, checkout, job.ID, meta.RootJobID, meta.PaneKey, seatMode)
+			}
 			if logFile != nil {
 				defer func() {
 					if err := logFile.Close(); err != nil {
@@ -5305,7 +5333,34 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		runCtx, cancel = context.WithTimeout(runCtx, jobTimeout)
 		defer cancel()
 	}
+	stopProgress := func() {}
+	if progressTracker != nil {
+		progressCtx, cancelProgress := context.WithCancel(runCtx)
+		done := make(chan struct{})
+		threshold := w.ProgressThreshold
+		if threshold <= 0 {
+			threshold = pipelineProgressThreshold
+		}
+		interval := w.ProgressInterval
+		if interval <= 0 {
+			interval = pipelineProgressInterval
+		}
+		tickSource := w.ProgressTickSource
+		if tickSource == nil {
+			tickSource = pipelineProgressTicks
+		}
+		startedAt := time.Now().UTC()
+		go func() {
+			defer close(done)
+			emitPipelineProgress(progressCtx, w.Store, w.Stdout, job.ID, startedAt, progressTracker, tickSource(progressCtx, threshold, interval))
+		}()
+		stopProgress = func() {
+			cancelProgress()
+			<-done
+		}
+	}
 	_, err = engine.RunJob(runCtx, job.ID, agent, adapter)
+	stopProgress()
 	if err != nil {
 		// Operational-blocker deferral (#532 slice E): a run whose delivery failed on
 		// a classified OPERATIONAL blocker (runtime auth rejected, rate limit/quota,
@@ -5556,7 +5611,7 @@ func cockpitJobMeta(job db.Job, payload workflow.JobPayload, agent runtime.Agent
 // unsupported runtime) returns a nil *os.File so the caller skips teeing and the
 // pane falls back to the P0 `job watch` command. The returned *os.File is the
 // caller's to Close after the job runs; when nil the adapter/path are ignored.
-func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID string) (workflow.DeliveryAdapter, string, *os.File) {
+func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID string, additionalOutput ...io.Writer) (workflow.DeliveryAdapter, string, *os.File) {
 	paths, err := pathsFromFlag(w.ConfigHome)
 	if err != nil {
 		writeLine(w.Stdout, "job %s cockpit log path resolve failed: %v", jobID, err)
@@ -5578,15 +5633,16 @@ func (w jobWorker) cockpitTeeAdapter(agent runtime.Agent, checkout string, jobID
 		writeLine(w.Stdout, "job %s cockpit log create failed: %v", jobID, err)
 		return nil, "", nil
 	}
-	return w.cockpitTeeOnFile(agent, checkout, jobID, logPath, logFile)
+	return w.cockpitTeeOnFile(agent, checkout, jobID, logPath, logFile, additionalOutput...)
 }
 
 // cockpitTeeOnFile rebuilds the runtime adapter to tee the child's live
 // stdout/stderr into an already-open log file, shared by the per-job (truncate)
 // and per-seat (append) log paths. It is fail-open: an unsupported runtime closes
 // the file and returns nils so the caller falls back to the P0 pane.
-func (w jobWorker) cockpitTeeOnFile(agent runtime.Agent, checkout, jobID, logPath string, logFile *os.File) (workflow.DeliveryAdapter, string, *os.File) {
-	adapter, err := buildRuntimeAdapter(agent, checkout, subprocess.TeeRunner{Inner: subprocess.GroupRunner{}, Out: logFile})
+func (w jobWorker) cockpitTeeOnFile(agent runtime.Agent, checkout, jobID, logPath string, logFile *os.File, additionalOutput ...io.Writer) (workflow.DeliveryAdapter, string, *os.File) {
+	outputs := append([]io.Writer{logFile}, additionalOutput...)
+	adapter, err := buildRuntimeAdapter(agent, checkout, subprocess.TeeRunner{Inner: subprocess.GroupRunner{}, Out: runtimeOutputWriter(outputs...)})
 	if err != nil {
 		// Unsupported runtime: this should never happen (AdapterFactory already
 		// built one above), but stay fail-open rather than leak the open file.
@@ -5602,11 +5658,11 @@ func (w jobWorker) cockpitTeeOnFile(agent runtime.Agent, checkout, jobID, logPat
 // file across rounds; job mode keeps the per-job truncate log (byte-identical to
 // P1). It is called only on the wrapping path (herdr available); a nil *os.File
 // means fall back to the P0 pane.
-func (w jobWorker) cockpitLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, checkout, jobID, rootJobID, paneKey string, seatMode bool) (workflow.DeliveryAdapter, string, *os.File) {
+func (w jobWorker) cockpitLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, checkout, jobID, rootJobID, paneKey string, seatMode bool, additionalOutput ...io.Writer) (workflow.DeliveryAdapter, string, *os.File) {
 	if seatMode {
-		return w.cockpitSeatLogAdapter(cp, agent, checkout, jobID, rootJobID, paneKey)
+		return w.cockpitSeatLogAdapter(cp, agent, checkout, jobID, rootJobID, paneKey, additionalOutput...)
 	}
-	return w.cockpitTeeAdapter(agent, checkout, jobID)
+	return w.cockpitTeeAdapter(agent, checkout, jobID, additionalOutput...)
 }
 
 // cockpitSeatLogAdapter opens the stable per-seat append log the seat's one pane
@@ -5617,7 +5673,7 @@ func (w jobWorker) cockpitLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, c
 // root's life and is removed by FinalizeRoot. It is fail-open: any failure
 // (unresolved path, mkdir, create, unsupported runtime) returns nils so the caller
 // falls back to the P0 pane.
-func (w jobWorker) cockpitSeatLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, checkout, jobID, rootJobID, paneKey string) (workflow.DeliveryAdapter, string, *os.File) {
+func (w jobWorker) cockpitSeatLogAdapter(cp *cockpit.Cockpit, agent runtime.Agent, checkout, jobID, rootJobID, paneKey string, additionalOutput ...io.Writer) (workflow.DeliveryAdapter, string, *os.File) {
 	logPath := cp.SeatLogPath(rootJobID, paneKey)
 	if logPath == "" {
 		// Home unset (cockpit could not resolve GITMOOT_HOME): fall back to the P0
@@ -5633,7 +5689,7 @@ func (w jobWorker) cockpitSeatLogAdapter(cp *cockpit.Cockpit, agent runtime.Agen
 		writeLine(w.Stdout, "job %s cockpit seat log open failed: %v", jobID, err)
 		return nil, "", nil
 	}
-	return w.cockpitTeeOnFile(agent, checkout, jobID, logPath, logFile)
+	return w.cockpitTeeOnFile(agent, checkout, jobID, logPath, logFile, additionalOutput...)
 }
 
 // finalizeCockpitRootIfDone tears the root's cockpit down once the coordination
@@ -6546,6 +6602,10 @@ func (w jobWorker) defaultAdapter(agent runtime.Agent, checkout string) (workflo
 	return buildRuntimeAdapter(agent, checkout, nil)
 }
 
+func (w jobWorker) outputAdapter(agent runtime.Agent, checkout string, out io.Writer) (workflow.DeliveryAdapter, error) {
+	return buildRuntimeAdapter(agent, checkout, subprocess.TeeRunner{Inner: subprocess.GroupRunner{}, Out: runtimeOutputWriter(out)})
+}
+
 // buildSeatAwareAdapter builds the job's runtime adapter, injecting the #732 chat
 // relay env for a `gitmoot moot` SEAT (payload.MootSeat) when a relay is running.
 // For a seat that gets a working relay it mints a per-seat token bound to (agent,
@@ -6563,8 +6623,12 @@ func (w jobWorker) defaultAdapter(agent runtime.Agent, checkout string) (workflo
 // so the cockpit adapter-rebuild path in run() — which would replace this adapter
 // and drop the env runner — never fires for a seat. If that ever changes, thread
 // the relay env into the cockpit rebuild too.
-func (w jobWorker) buildSeatAwareAdapter(agent *runtime.Agent, checkout string, payload workflow.JobPayload) (workflow.DeliveryAdapter, string, error) {
+func (w jobWorker) buildSeatAwareAdapter(agent *runtime.Agent, checkout string, payload workflow.JobPayload, output ...io.Writer) (workflow.DeliveryAdapter, string, error) {
 	if w.RelayServer == nil || !payload.MootSeat || strings.TrimSpace(payload.ThreadID) == "" {
+		if len(output) > 0 && output[0] != nil && w.OutputAdapterFactory != nil {
+			adapter, err := w.OutputAdapterFactory(*agent, checkout, output[0])
+			return adapter, "", err
+		}
 		adapter, err := w.AdapterFactory(*agent, checkout)
 		return adapter, "", err
 	}

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -644,8 +644,10 @@ func runPipelineRunCmd(args []string, stdout, stderr io.Writer) int {
 // pipelineRunView is the resolved data behind `pipeline show <run-id>`: the run
 // row plus its stage rows ordered into spec/DAG order for the funnel.
 type pipelineRunView struct {
-	run    db.PipelineRun
-	stages []db.PipelineRunStage
+	run         db.PipelineRun
+	stages      []db.PipelineRunStage
+	progress    map[string]db.JobEvent
+	orchestrate map[string]bool
 }
 
 // loadPipelineRunView loads a run and its stages, ordered for display. A missing
@@ -659,7 +661,26 @@ func loadPipelineRunView(ctx context.Context, store *db.Store, id string) (pipel
 	if err != nil {
 		return pipelineRunView{}, false, err
 	}
-	return pipelineRunView{run: run, stages: orderPipelineRunStages(ctx, store, run, stages)}, true, nil
+	stages = orderPipelineRunStages(ctx, store, run, stages)
+	jobIDs := make([]string, 0, len(stages))
+	for _, stage := range stages {
+		if stage.JobID != "" && (stage.State == pipeline.StageQueued || stage.State == pipeline.StageRunning) {
+			jobIDs = append(jobIDs, stage.JobID)
+		}
+	}
+	progress, err := store.GetLatestJobEventsByKind(ctx, jobIDs, "progress")
+	if err != nil {
+		return pipelineRunView{}, false, err
+	}
+	orchestrate := map[string]bool{}
+	if rec, found, getErr := store.GetPipeline(ctx, run.Pipeline); getErr == nil && found && strings.TrimSpace(rec.SpecHash) == strings.TrimSpace(run.SpecHash) {
+		if spec, loadErr := pipeline.Load([]byte(rec.SpecYAML)); loadErr == nil {
+			for _, stage := range spec.Stages {
+				orchestrate[stage.ID] = stage.Kind() == pipeline.StageKindOrchestrate
+			}
+		}
+	}
+	return pipelineRunView{run: run, stages: stages, progress: progress, orchestrate: orchestrate}, true, nil
 }
 
 // orderPipelineRunStages reorders stage rows into spec (topological) order when the
@@ -700,6 +721,10 @@ func orderPipelineRunStages(ctx context.Context, store *db.Store, run db.Pipelin
 // header. A failed run surfaces the exact `gitmoot report bug --job <stage-job>`
 // command for the halted stage (NO auto-filing).
 func printPipelineRunFunnel(stdout io.Writer, view pipelineRunView) {
+	printPipelineRunFunnelAt(stdout, view, time.Now().UTC())
+}
+
+func printPipelineRunFunnelAt(stdout io.Writer, view pipelineRunView, now time.Time) {
 	run := view.run
 	writeLine(stdout, "run: %s", run.ID)
 	writeLine(stdout, "pipeline: %s", run.Pipeline)
@@ -718,6 +743,25 @@ func printPipelineRunFunnel(stdout io.Writer, view pipelineRunView) {
 	}
 	writeLine(stdout, "")
 	writeLine(stdout, "%s", pipelineFunnelLine(view.stages))
+	for _, stage := range view.stages {
+		if stage.State != pipeline.StageQueued && stage.State != pipeline.StageRunning {
+			continue
+		}
+		writeLine(stdout, "  %s: %s; enqueued %s ago", stage.StageID, strings.ToUpper(stage.State), pipelineElapsed(now, stage.StartedAt))
+		event, hasProgress := view.progress[stage.JobID]
+		progress, validProgress := decodePipelineProgress(event.Message)
+		if stage.State == pipeline.StageRunning && hasProgress && validProgress {
+			age := pipelineEventAge(now, event.CreatedAt)
+			if progress.Activity != "" {
+				writeLine(stdout, "    last activity %s ago: %s", age, progress.Activity)
+			} else {
+				writeLine(stdout, "    last activity %s ago: elapsed %s", age, progress.Elapsed)
+			}
+		}
+		if stage.State == pipeline.StageRunning && view.orchestrate[stage.StageID] && (!hasProgress || !validProgress || !pipelineProgressFresh(now, event.CreatedAt)) {
+			writeLine(stdout, "    (sub-tree running; no per-stage progress)")
+		}
+	}
 	if run.State == pipeline.RunFailed {
 		if jobID := haltStageJobID(view); jobID != "" {
 			writeLine(stdout, "")
@@ -725,6 +769,48 @@ func printPipelineRunFunnel(stdout io.Writer, view pipelineRunView) {
 			writeLine(stdout, "  gitmoot report bug --job %s", jobID)
 		}
 	}
+}
+
+func pipelineElapsed(now, started time.Time) string {
+	if started.IsZero() {
+		return "?"
+	}
+	d := now.Sub(started)
+	if d < 0 {
+		d = 0
+	}
+	return d.Round(time.Second).String()
+}
+
+func pipelineEventTime(value string) time.Time {
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02 15:04:05"} {
+		if parsed, err := time.Parse(layout, strings.TrimSpace(value)); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func pipelineEventAge(now time.Time, createdAt string) string {
+	return pipelineElapsed(now, pipelineEventTime(createdAt))
+}
+
+func pipelineProgressFresh(now time.Time, createdAt string) bool {
+	created := pipelineEventTime(createdAt)
+	if created.IsZero() {
+		return false
+	}
+	age := now.Sub(created)
+	return age >= 0 && age <= 2*pipelineProgressInterval
+}
+
+func decodePipelineProgress(message string) (pipelineProgressEventPayload, bool) {
+	var payload pipelineProgressEventPayload
+	if err := json.Unmarshal([]byte(message), &payload); err != nil {
+		return pipelineProgressEventPayload{}, false
+	}
+	payload.Activity = sanitizePipelineProgressLine(payload.Activity)
+	return payload, strings.TrimSpace(payload.Elapsed) != "" || payload.Activity != ""
 }
 
 // pipelineFunnelLine joins each stage's `<id> <LABEL>` into the funnel line.
@@ -765,12 +851,25 @@ func haltStageJobID(view pipelineRunView) string {
 }
 
 type pipelineRunStageJSON struct {
-	ID      string   `json:"id"`
-	State   string   `json:"state"`
-	JobID   string   `json:"job_id,omitempty"`
-	Attempt int      `json:"attempt,omitempty"`
-	Needs   []string `json:"needs,omitempty"`
-	Summary string   `json:"summary,omitempty"`
+	ID         string                        `json:"id"`
+	State      string                        `json:"state"`
+	JobID      string                        `json:"job_id,omitempty"`
+	Attempt    int                           `json:"attempt,omitempty"`
+	Needs      []string                      `json:"needs,omitempty"`
+	Summary    string                        `json:"summary,omitempty"`
+	StartedAt  string                        `json:"started_at,omitempty"`
+	FinishedAt string                        `json:"finished_at,omitempty"`
+	Progress   *pipelineRunStageProgressJSON `json:"progress,omitempty"`
+}
+
+// The external gitmoot-dashboard repo can already derive elapsed time from
+// started_at. Teaching it the optional progress object is Phase 2 of #816; keep
+// this CLI JSON addition backward-compatible until that separate consumer moves.
+
+type pipelineRunStageProgressJSON struct {
+	Elapsed   string `json:"elapsed"`
+	Activity  string `json:"activity,omitempty"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 type pipelineRunJSON struct {
@@ -805,14 +904,25 @@ func pipelineRunToJSON(view pipelineRunView) pipelineRunJSON {
 		Funnel:     pipelineFunnelLine(view.stages),
 	}
 	for _, stage := range view.stages {
-		out.Stages = append(out.Stages, pipelineRunStageJSON{
-			ID:      stage.StageID,
-			State:   stage.State,
-			JobID:   stage.JobID,
-			Attempt: stage.Attempt,
-			Needs:   decodePipelineNeeds(stage.NeedsJSON),
-			Summary: stage.Summary,
-		})
+		stageJSON := pipelineRunStageJSON{
+			ID:         stage.StageID,
+			State:      stage.State,
+			JobID:      stage.JobID,
+			Attempt:    stage.Attempt,
+			Needs:      decodePipelineNeeds(stage.NeedsJSON),
+			Summary:    stage.Summary,
+			StartedAt:  pipelineRunTimeJSON(stage.StartedAt),
+			FinishedAt: pipelineRunTimeJSON(stage.FinishedAt),
+		}
+		if event, ok := view.progress[stage.JobID]; ok {
+			if progress, valid := decodePipelineProgress(event.Message); valid {
+				stageJSON.Progress = &pipelineRunStageProgressJSON{
+					Elapsed: progress.Elapsed, Activity: progress.Activity,
+					UpdatedAt: pipelineRunTimeJSON(pipelineEventTime(event.CreatedAt)),
+				}
+			}
+		}
+		out.Stages = append(out.Stages, stageJSON)
 	}
 	return out
 }

--- a/internal/cli/pipeline_progress.go
+++ b/internal/cli/pipeline_progress.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+const (
+	pipelineProgressThreshold = 60 * time.Second
+	pipelineProgressInterval  = 30 * time.Second
+	pipelineProgressLineBytes = 400
+)
+
+type pipelineProgressEventPayload struct {
+	Elapsed  string `json:"elapsed"`
+	Activity string `json:"activity,omitempty"`
+}
+
+// pipelineProgressLineTracker is the live-output writer shared with TeeRunner.
+// It retains only the most recent non-empty logical line. Sanitization happens
+// before the line can reach storage or an operator surface.
+type pipelineProgressLineTracker struct {
+	mu      sync.Mutex
+	pending string
+	last    string
+}
+
+func (t *pipelineProgressLineTracker) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.pending += string(p)
+	parts := strings.FieldsFunc(t.pending, func(r rune) bool { return r == '\n' || r == '\r' })
+	ended := len(t.pending) > 0 && (t.pending[len(t.pending)-1] == '\n' || t.pending[len(t.pending)-1] == '\r')
+	complete := len(parts)
+	if !ended && complete > 0 {
+		complete--
+	}
+	for _, line := range parts[:complete] {
+		if clean := sanitizePipelineProgressLine(line); clean != "" {
+			t.last = clean
+		}
+	}
+	if ended {
+		t.pending = ""
+	} else if len(parts) > 0 {
+		t.pending = parts[len(parts)-1]
+	} else if len(t.pending) > 8192 {
+		t.pending = t.pending[len(t.pending)-8192:]
+	}
+	if len(t.pending) > 8192 {
+		t.pending = t.pending[len(t.pending)-8192:]
+	}
+	return len(p), nil
+}
+
+func (t *pipelineProgressLineTracker) LastLine() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if clean := sanitizePipelineProgressLine(t.pending); clean != "" {
+		return clean
+	}
+	return t.last
+}
+
+var pipelineProgressEscapeRE = regexp.MustCompile("\\x1b(?:\\[[0-?]*[ -/]*[@-~]|\\][^\\x07]*(?:\\x07|\\x1b\\\\|$))")
+
+func sanitizePipelineProgressLine(value string) string {
+	value = pipelineProgressEscapeRE.ReplaceAllString(value, "")
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r == '\t':
+			b.WriteByte(' ')
+		case unicode.IsControl(r):
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	value = strings.TrimSpace(workflow.RedactCommentText(b.String()))
+	return truncatePipelineProgressLine(value, pipelineProgressLineBytes)
+}
+
+func truncatePipelineProgressLine(value string, limit int) string {
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	value = value[:limit]
+	for !utf8.ValidString(value) {
+		value = value[:len(value)-1]
+	}
+	return value
+}
+
+// runtimeOutputWriter is the one runtime-output composition point. Cockpit and
+// progress share one MultiWriter beneath one SyncWriter, so concurrent stdout /
+// stderr copies cannot race either destination.
+func runtimeOutputWriter(writers ...io.Writer) io.Writer {
+	nonNil := make([]io.Writer, 0, len(writers))
+	for _, writer := range writers {
+		if writer != nil {
+			nonNil = append(nonNil, writer)
+		}
+	}
+	if len(nonNil) == 0 {
+		return nil
+	}
+	if len(nonNil) == 1 {
+		return subprocess.SyncWriter(nonNil[0])
+	}
+	return subprocess.SyncWriter(io.MultiWriter(nonNil...))
+}
+
+func pipelineProgressTicks(ctx context.Context, threshold, interval time.Duration) <-chan time.Time {
+	out := make(chan time.Time, 1)
+	go func() {
+		defer close(out)
+		timer := time.NewTimer(threshold)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case tick := <-timer.C:
+			select {
+			case out <- tick:
+			case <-ctx.Done():
+				return
+			}
+		}
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case tick := <-ticker.C:
+				select {
+				case out <- tick:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out
+}
+
+func emitPipelineProgress(ctx context.Context, store *db.Store, stdout io.Writer, jobID string, startedAt time.Time, tracker *pipelineProgressLineTracker, ticks <-chan time.Time) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case tick, ok := <-ticks:
+			if !ok {
+				return
+			}
+			elapsed := tick.Sub(startedAt)
+			if elapsed < 0 {
+				elapsed = 0
+			}
+			message, err := json.Marshal(pipelineProgressEventPayload{
+				Elapsed:  elapsed.Round(time.Second).String(),
+				Activity: tracker.LastLine(),
+			})
+			if err != nil {
+				continue
+			}
+			if err := store.UpsertLatestJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "progress", Message: string(message)}); err != nil && ctx.Err() == nil {
+				writeLine(stdout, "job %s progress event failed: %v", jobID, err)
+			}
+		}
+	}
+}

--- a/internal/cli/pipeline_progress_test.go
+++ b/internal/cli/pipeline_progress_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+func TestPipelineProgressLineTrackerSanitizesRedactsCapsAndIgnoresEmpty(t *testing.T) {
+	tracker := &pipelineProgressLineTracker{}
+	_, _ = tracker.Write([]byte("first\n\n\x1b[31mtoken=abcdefghijklmnopqrstuvwxyz1234567890\x1b[0m\x00\n"))
+	got := tracker.LastLine()
+	if strings.Contains(got, "\x1b") || strings.ContainsRune(got, '\x00') || strings.Contains(got, "abcdefghijklmnopqrstuvwxyz") || !strings.Contains(got, "[REDACTED]") {
+		t.Fatalf("sanitized line = %q", got)
+	}
+	_, _ = tracker.Write([]byte(strings.Repeat("\u00e9", 300)))
+	got = tracker.LastLine()
+	if len(got) > pipelineProgressLineBytes || !strings.Contains(got, "\u00e9") {
+		t.Fatalf("capped UTF-8 line bytes=%d valid content=%q", len(got), got)
+	}
+}
+
+func TestEmitPipelineProgressThresholdCadenceAndCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	store := daemonWorkerStore(t)
+	if err := store.CreateJob(ctx, db.Job{ID: "job-progress", Agent: "worker", Type: "ask", State: "running"}); err != nil {
+		t.Fatal(err)
+	}
+	tracker := &pipelineProgressLineTracker{}
+	_, _ = tracker.Write([]byte("working\n"))
+	ticks := make(chan time.Time, 2)
+	done := make(chan struct{})
+	start := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	go func() {
+		emitPipelineProgress(ctx, store, io.Discard, "job-progress", start, tracker, ticks)
+		close(done)
+	}()
+	if _, ok, err := store.GetLatestJobEventByKind(ctx, "job-progress", "progress"); err != nil || ok {
+		t.Fatalf("event existed before threshold tick: ok=%v err=%v", ok, err)
+	}
+	ticks <- start.Add(time.Minute)
+	ticks <- start.Add(90 * time.Second)
+	close(ticks)
+	<-done
+	events, err := store.ListJobEvents(ctx, "job-progress")
+	if err != nil || len(events) != 1 || !strings.Contains(events[0].Message, `"elapsed":"1m30s"`) || !strings.Contains(events[0].Message, `"activity":"working"`) {
+		t.Fatalf("cadenced latest-only events=%+v err=%v", events, err)
+	}
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	stopped := make(chan struct{})
+	blockedTicks := make(chan time.Time)
+	go func() {
+		emitPipelineProgress(ctx2, store, io.Discard, "job-progress", start, tracker, blockedTicks)
+		close(stopped)
+	}()
+	cancel2()
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("emitter did not stop on context cancellation")
+	}
+}
+
+func TestCockpitAndProgressShareRuntimeOutput(t *testing.T) {
+	home := t.TempDir()
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard, home)
+	agent := runtime.Agent{Name: "lead", Role: "builder", Runtime: runtime.ShellRuntime, RuntimeRef: "echo shared-line"}
+	tracker := &pipelineProgressLineTracker{}
+	adapter, logPath, logFile := worker.cockpitTeeAdapter(agent, t.TempDir(), "job-shared", tracker)
+	if logFile == nil {
+		t.Fatal("expected cockpit log")
+	}
+	defer logFile.Close()
+	if _, err := adapter.Deliver(context.Background(), agent, runtime.Job{Prompt: "go"}); err != nil {
+		t.Fatal(err)
+	}
+	logged, err := os.ReadFile(logPath)
+	if err != nil || !strings.Contains(string(logged), "shared-line") || tracker.LastLine() != "shared-line" {
+		t.Fatalf("cockpit=%q tracker=%q err=%v", logged, tracker.LastLine(), err)
+	}
+}
+
+func TestPipelineRunProgressRenderingAndJSON(t *testing.T) {
+	now := time.Date(2026, 7, 10, 10, 2, 0, 0, time.UTC)
+	started := now.Add(-2 * time.Minute)
+	view := pipelineRunView{
+		run: db.PipelineRun{ID: "run", Pipeline: "flow", State: pipeline.RunRunning, StartedAt: started},
+		stages: []db.PipelineRunStage{
+			{StageID: "work", State: pipeline.StageRunning, JobID: "job-work", StartedAt: started},
+			{StageID: "gate", State: pipeline.StageQueued, StartedAt: now.Add(-time.Minute)},
+			{StageID: "tree", State: pipeline.StageRunning, JobID: "job-tree", StartedAt: started},
+			{StageID: "done", State: pipeline.StageSucceeded, JobID: "job-done", StartedAt: started, FinishedAt: now.Add(-time.Minute)},
+		},
+		progress: map[string]db.JobEvent{
+			"job-work": {JobID: "job-work", Kind: "progress", Message: `{"elapsed":"1m55s","activity":"testing"}`, CreatedAt: now.Add(-5 * time.Second).Format(time.RFC3339Nano)},
+			"job-tree": {JobID: "job-tree", Kind: "progress", Message: `{"elapsed":"30s","activity":"delegating"}`, CreatedAt: now.Add(-2 * time.Minute).Format(time.RFC3339Nano)},
+		},
+		orchestrate: map[string]bool{"tree": true},
+	}
+	var out bytes.Buffer
+	printPipelineRunFunnelAt(&out, view, now)
+	for _, want := range []string{"work: RUNNING; enqueued 2m0s ago", "last activity 5s ago: testing", "gate: QUEUED; enqueued 1m0s ago", "last activity 2m0s ago: delegating", "(sub-tree running; no per-stage progress)"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+	jsonView := pipelineRunToJSON(view)
+	if jsonView.Stages[0].StartedAt == "" || jsonView.Stages[0].Progress == nil || jsonView.Stages[0].Progress.Activity != "testing" {
+		t.Fatalf("JSON stage = %+v", jsonView.Stages[0])
+	}
+	if jsonView.Stages[3].FinishedAt == "" {
+		t.Fatalf("finished JSON stage = %+v", jsonView.Stages[3])
+	}
+}
+
+func TestPipelineSlowShellStageProgressE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	cmd := `printf 'phase-one\n'; sleep 0.25; ` + pipelineStageResultCmd("approved", "done", nil)
+	specFile := writeSpec(t, "name: slow-progress\nrepo: owner/repo\nstages:\n"+pipelineE2EStage("slow", cmd, ""))
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline add exit=%d stderr=%s", code, errBuf.String())
+	}
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "run", "slow-progress", "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline run exit=%d stderr=%s", code, errBuf.String())
+	}
+	runID := strings.TrimSpace(out.String())
+	stage := stageRow(t, store, runID, "slow")
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.ProgressThreshold = 5 * time.Millisecond
+	worker.ProgressInterval = 5 * time.Millisecond
+	workerDone := make(chan error, 1)
+	go func() {
+		workerDone <- runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, time.Now().UTC())
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		event, ok, err := store.GetLatestJobEventByKind(ctx, stage.JobID, "progress")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok && strings.Contains(event.Message, "phase-one") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("progress event with last shell line did not arrive; last=%+v", event)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if err := runPipelineScanOnce(ctx, store, newPipelineStageEnqueuer(store, home), time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "show", runID, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline show exit=%d stderr=%s", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "last activity") || !strings.Contains(out.String(), "phase-one") {
+		t.Fatalf("pipeline show missing live progress:\n%s", out.String())
+	}
+	if err := <-workerDone; err != nil {
+		t.Fatalf("worker tick: %v", err)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -3086,6 +3086,91 @@ func (s *Store) AddJobEvent(ctx context.Context, event JobEvent) error {
 	return err
 }
 
+// UpsertLatestJobEvent keeps one mutable latest-only row for a job/event kind.
+// The write is guarded by jobs.state='running' in the same transaction, so a
+// delayed best-effort progress tick that races terminalization becomes a no-op.
+// This intentionally touches only job_events: the stuck-running reaper keys on
+// the jobs row (including runner_boot_id), so progress cannot refresh or mask
+// job liveness and cannot perturb pipeline_run_stages advancement invariants.
+func (s *Store) UpsertLatestJobEvent(ctx context.Context, event JobEvent) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `UPDATE job_events
+		SET message = ?, created_at = CURRENT_TIMESTAMP
+		WHERE job_id = ? AND kind = ?
+		  AND EXISTS (SELECT 1 FROM jobs WHERE id = ? AND state = 'running')`,
+		event.Message, event.JobID, event.Kind, event.JobID)
+	if err != nil {
+		return err
+	}
+	updated, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if updated == 0 {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message)
+			SELECT ?, ?, ? WHERE EXISTS (
+				SELECT 1 FROM jobs WHERE id = ? AND state = 'running'
+			)`, event.JobID, event.Kind, event.Message, event.JobID); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// GetLatestJobEventByKind returns the newest event of kind for jobID. The
+// idx_job_events_kind_job_id covering index serves the lookup.
+func (s *Store) GetLatestJobEventByKind(ctx context.Context, jobID, kind string) (JobEvent, bool, error) {
+	var event JobEvent
+	err := s.db.QueryRowContext(ctx, `SELECT job_id, kind, message, created_at
+		FROM job_events WHERE kind = ? AND job_id = ? ORDER BY id DESC LIMIT 1`,
+		kind, jobID).Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return JobEvent{}, false, nil
+	}
+	return event, err == nil, err
+}
+
+// GetLatestJobEventsByKind returns the newest event of kind for each requested
+// job in one indexed query. Empty input returns an initialized empty map.
+func (s *Store) GetLatestJobEventsByKind(ctx context.Context, jobIDs []string, kind string) (map[string]JobEvent, error) {
+	out := map[string]JobEvent{}
+	if len(jobIDs) == 0 {
+		return out, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(jobIDs)), ",")
+	args := make([]any, 0, 2*(len(jobIDs)+1))
+	args = append(args, kind)
+	for _, jobID := range jobIDs {
+		args = append(args, jobID)
+	}
+	args = append(args, kind)
+	for _, jobID := range jobIDs {
+		args = append(args, jobID)
+	}
+	query := `SELECT job_id, kind, message, created_at FROM job_events
+		WHERE kind = ? AND job_id IN (` + placeholders + `)
+		  AND id IN (SELECT MAX(id) FROM job_events
+			WHERE kind = ? AND job_id IN (` + placeholders + `) GROUP BY job_id)`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var event JobEvent
+		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt); err != nil {
+			return nil, err
+		}
+		out[event.JobID] = event
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) ListJobEvents(ctx context.Context, jobID string) ([]JobEvent, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT job_id, kind, message, created_at FROM job_events WHERE job_id = ? ORDER BY id`, jobID)
 	if err != nil {

--- a/internal/db/store_progress_test.go
+++ b/internal/db/store_progress_test.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestUpsertLatestJobEventReplacesSingleRow(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.CreateJob(ctx, Job{ID: "job-progress", Agent: "worker", Type: "ask", State: "running"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, message := range []string{`{"elapsed":"1m0s","activity":"one"}`, `{"elapsed":"1m30s","activity":"two"}`} {
+		if err := store.UpsertLatestJobEvent(ctx, JobEvent{JobID: "job-progress", Kind: "progress", Message: message}); err != nil {
+			t.Fatalf("UpsertLatestJobEvent: %v", err)
+		}
+	}
+	events, err := store.ListJobEvents(ctx, "job-progress")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Message != `{"elapsed":"1m30s","activity":"two"}` {
+		t.Fatalf("events = %+v, want one replaced progress row", events)
+	}
+}
+
+func TestUpsertLatestJobEventTerminalGuard(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.CreateJob(ctx, Job{ID: "job-terminal", Agent: "worker", Type: "ask", State: "running"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertLatestJobEvent(ctx, JobEvent{JobID: "job-terminal", Kind: "progress", Message: "before"}); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := store.TransitionJobState(ctx, "job-terminal", "running", "succeeded"); err != nil || !ok {
+		t.Fatalf("terminal transition: ok=%v err=%v", ok, err)
+	}
+	if err := store.UpsertLatestJobEvent(ctx, JobEvent{JobID: "job-terminal", Kind: "progress", Message: "late"}); err != nil {
+		t.Fatal(err)
+	}
+	event, ok, err := store.GetLatestJobEventByKind(ctx, "job-terminal", "progress")
+	if err != nil || !ok || event.Message != "before" {
+		t.Fatalf("late terminal upsert changed event: ok=%v event=%+v err=%v", ok, event, err)
+	}
+
+	if err := store.CreateJob(ctx, Job{ID: "job-already-terminal", Agent: "worker", Type: "ask", State: "failed"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertLatestJobEvent(ctx, JobEvent{JobID: "job-already-terminal", Kind: "progress", Message: "late"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := store.GetLatestJobEventByKind(ctx, "job-already-terminal", "progress"); err != nil || ok {
+		t.Fatalf("terminal insert guard: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestGetLatestJobEventByKindAndBulk(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	for _, id := range []string{"job-a", "job-b", "job-c"} {
+		if err := store.CreateJob(ctx, Job{ID: id, Agent: "worker", Type: "ask", State: "running"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.AddJobEvent(ctx, JobEvent{JobID: "job-a", Kind: "queued", Message: "ignore"}); err != nil {
+		t.Fatal(err)
+	}
+	for id, message := range map[string]string{"job-a": "a", "job-b": "b", "job-c": "not-requested"} {
+		if err := store.UpsertLatestJobEvent(ctx, JobEvent{JobID: id, Kind: "progress", Message: message}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	event, ok, err := store.GetLatestJobEventByKind(ctx, "job-a", "progress")
+	if err != nil || !ok || event.Message != "a" || event.CreatedAt == "" {
+		t.Fatalf("by-kind event: ok=%v event=%+v err=%v", ok, event, err)
+	}
+	if _, ok, err := store.GetLatestJobEventByKind(ctx, "job-a", "missing"); err != nil || ok {
+		t.Fatalf("missing by-kind: ok=%v err=%v", ok, err)
+	}
+
+	bulk, err := store.GetLatestJobEventsByKind(ctx, []string{"job-a", "job-b"}, "progress")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(bulk) != 2 || bulk["job-a"].Message != "a" || bulk["job-b"].Message != "b" {
+		t.Fatalf("bulk = %+v", bulk)
+	}
+	empty, err := store.GetLatestJobEventsByKind(ctx, nil, "progress")
+	if err != nil || len(empty) != 0 {
+		t.Fatalf("empty bulk = %+v err=%v", empty, err)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2173,6 +2173,15 @@ funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED`) unde
 run header; a **failed** run also prints the exact `gitmoot report bug --job
 <stage-job>` command (gitmoot never auto-files it).
 
+While a stage is queued or running, the run view adds an honest
+`STATE; enqueued <elapsed> ago` detail (the stage timestamp is enqueue time, not
+claim time). Long-running pipeline jobs publish a latest-only `progress` event
+after one minute and about every 30 seconds thereafter. A running stage shows the
+event's real age and last sanitized activity line; the age continues increasing if
+the daemon dies. Orchestrate stages whose current coordinator has no fresh event
+show `(sub-tree running; no per-stage progress)`. JSON stage objects add
+`started_at`, `finished_at`, and an optional structured `progress` object.
+
 `pipeline resume` re-runs a **parked** (blocked/failed) run from its halted stage
 (or `--from <stage>`) plus its transitive dependents — bumping their attempt — while
 **never re-running a succeeded stage**; it refuses a non-parked run and a run whose

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1049,6 +1049,14 @@ obvious as a funnel:
 source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
+For an active run, `pipeline show` also lists each queued/running stage with the
+time since it was enqueued. After a pipeline job has run for a minute, its worker
+updates one latest-only `progress` event about every 30 seconds; the view prints
+the event age and its last sanitized output line. That age visibly grows when
+updates stop. An orchestrate stage can temporarily point at a settled coordinator
+while its children run, so absent or stale per-stage progress is informational and
+renders as `(sub-tree running; no per-stage progress)`, never as failure.
+
 The operator provisions what the stage needs out of band (here, an R2 token), then
 resumes — which re-runs the halted stage and everything downstream of it, while the
 already-landed upstream stages are left untouched:

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -237,6 +237,16 @@ needs: R2 token
 source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
+Active runs also show queued/running stage details. The duration is labeled
+`enqueued` because the stage timestamp is recorded at enqueue, not worker claim.
+After a pipeline job has been delivering for 60 seconds, its worker updates one
+latest-only `progress` event about every 30 seconds; `pipeline show` renders the
+stored event's age and last sanitized activity line. The age keeps growing when
+updates stop, so stale progress never masquerades as liveness. An orchestrate
+stage can have no fresh per-stage event while its child sub-tree is active; this is
+reported as `(sub-tree running; no per-stage progress)`, not a failure. JSON stage
+objects add `started_at`, `finished_at`, and optional structured `progress` data.
+
 The operator provisions what the stage needs out of band (here, an R2 token), then
 resumes — which re-runs the halted stage and everything downstream of it, while the
 already-landed upstream stages are left untouched:

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2886,6 +2886,23 @@ needs: R2 token
 source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
 
+Queued and running stages also get detail lines such as:
+
+```
+  source: RUNNING; enqueued 2m14s ago
+    last activity 8s ago: downloading object 41
+```
+
+`enqueued` is deliberate: the stage `started_at` is written when the job is
+enqueued, not when a worker claims it. After 60 seconds of delivery, pipeline
+workers update one latest-only `progress` job event about every 30 seconds. Its
+age is computed from the stored event timestamp, so a stopped daemon never looks
+fresh. Activity is stripped of terminal controls, redacted, and length-capped
+before storage. Orchestrate stages may have no current per-stage event while their
+sub-tree runs; the view says `(sub-tree running; no per-stage progress)` and does
+not treat that absence as a failure. `--json` stage objects add `started_at`,
+`finished_at`, and optional `{elapsed, activity, updated_at}` progress data.
+
 Funnel labels are `OK` for a succeeded stage, `BLOCKED (needs: …)` for a parked
 stage, and the uppercased state otherwise (`PENDING`, `QUEUED`, `RUNNING`,
 `FAILED`, `SKIPPED`, `CANCELLED`). When a run **failed**, the view also prints the
@@ -10352,6 +10369,15 @@ funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED`) unde
 run header; a **failed** run also prints the exact `gitmoot report bug --job
 <stage-job>` command (gitmoot never auto-files it).
 
+While a stage is queued or running, the run view adds an honest
+`STATE; enqueued <elapsed> ago` detail (the stage timestamp is enqueue time, not
+claim time). Long-running pipeline jobs publish a latest-only `progress` event
+after one minute and about every 30 seconds thereafter. A running stage shows the
+event's real age and last sanitized activity line; the age continues increasing if
+the daemon dies. Orchestrate stages whose current coordinator has no fresh event
+show `(sub-tree running; no per-stage progress)`. JSON stage objects add
+`started_at`, `finished_at`, and an optional structured `progress` object.
+
 `pipeline resume` re-runs a **parked** (blocked/failed) run from its halted stage
 (or `--from <stage>`) plus its transitive dependents — bumping their attempt — while
 **never re-running a succeeded stage**; it refuses a non-parked run and a run whose
@@ -11641,6 +11667,14 @@ obvious as a funnel:
 ```
 source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
+
+For an active run, `pipeline show` also lists each queued/running stage with the
+time since it was enqueued. After a pipeline job has run for a minute, its worker
+updates one latest-only `progress` event about every 30 seconds; the view prints
+the event age and its last sanitized output line. That age visibly grows when
+updates stop. An orchestrate stage can temporarily point at a settled coordinator
+while its children run, so absent or stale per-stage progress is informational and
+renders as `(sub-tree running; no per-stage progress)`, never as failure.
 
 The operator provisions what the stage needs out of band (here, an R2 token), then
 resumes — which re-runs the halted stage and everything downstream of it, while the


### PR DESCRIPTION
Closes #816.

Long-running pipeline stages now show **signs of life**: an honest elapsed line plus the stage's last output, in `pipeline show` (text + JSON).

### What you see
```
slow RUNNING
  slow: RUNNING; enqueued 2m23s ago
    last activity 9s ago: processing item 12 of 14
```
(That's the actual output of the live E2E — see Verification.)

### Design (per the #816 research-panel synthesis)
- **Phase 0, read-side:** elapsed renders from the already-persisted `started_at` — labeled "enqueued … ago" (it's enqueue time, not claim time; the honest wording the panel asked for). Gate stages (no JobID) render safely; orchestrate stages show a sub-tree note instead of presenting stale continuation progress as liveness.
- **Phase 1, worker-side:** for **pipeline-sender jobs only**, the runtime adapter is wrapped with the existing `subprocess.TeeRunner` (the panel's finding: the streaming seam already existed) feeding a last-line tracker — ANSI/OSC strip + control-char removal + `RedactCommentText` + UTF-8-safe 400-byte cap. After a 60s threshold, every 30s, a **latest-only `progress` job_event** is upserted ("heartbeat" was taken). Best-effort, stops on cancel/timeout; cockpit logging + progress share ONE SyncWriter'd composition point.
- **Storage:** the upsert guards UPDATE **and** fallback INSERT with `jobs.state='running'` inside the mutating statements — a late ticker after terminal is a no-op (verified live). Rides the existing `idx_job_events_kind_job_id`. **No schema migration; `pipeline_run_stages` is never written** (advancer no-writes invariant intact); non-pipeline jobs byte-identical.
- Out of scope (as decided): tokens-so-far; the external gitmoot-dashboard wire field (elapsed already renders there from StartedAt).

### Verification
- **Live E2E on an isolated home** (real binary, real 60s threshold): 140s shell stage → no event before threshold, then exactly ONE progress row updating in place; `pipeline show` rendered elapsed + activity; run succeeded; terminal guard held (no post-terminal writes); clean teardown.
- Adversarial review (gpt-5.6-sol @ xhigh): **NO BLOCKING ISSUES** — all 9 areas cleared (concurrency/joins, terminal race, composition, typed-nil regression, security/injection, rendering, perf/invariants, reaper interaction, scope hygiene).
- My independent runs: build, vet, full db/workflow/subprocess/pipeline suites + uncached cli suite (248s), race gate on the shared-tracker paths.

### Docs (same PR)
`docs/pipelines.md`, skills `CLI.md` + `WORKFLOWS.md`, website `pipelines-workflow.md`, regenerated `llms-full.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
