### PR TITLE
feat(pipeline): `source:` PR-binding for review stages — implement → review → gate first-class

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -71,7 +71,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].write`            | stage        | cond.    | Acknowledges that an `implement` stage **mutates** the repo (#768). Required with `action: implement`, and valid **only** there — a double-key so a typo/injection can't turn a read-only pipeline into a writing one. |
 | `stages[].orchestrate`      | stage        | no       | `true` makes an agent stage a **sub-tree coordinator** (#758): its `delegations[]` fan out as owned children and the stage waits for the whole tree, then folds the synthesis. Agent stage only; `action` must be `ask`. |
 | `stages[].gate`             | stage        | cond.    | Makes this a **jobless gate stage** (#768): it runs no worker and folds when an external predicate holds. Only `pr_merged` today. Exclusive with `cmd`/`agent`. Requires `source`. |
-| `stages[].source`           | stage        | cond.    | For a `gate` stage: the id of the upstream `implement` stage whose PR to watch. Must be one of the gate's own `needs`. |
+| `stages[].source`           | stage        | cond.    | The upstream `implement` stage whose PR to bind. Required on a `gate`; optional on `action: review`; rejected on shell/ask/implement/orchestrate stages. It must be one of the stage's own `needs`. |
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
@@ -82,8 +82,8 @@ non-name-safe name/id, a duplicate stage id, a stage that is not **exactly one**
 `cmd`, `agent`, or `gate` (and, per kind: an agent stage's missing `prompt`, an
 invalid `action`, `implement` without `write: true` or `write: true` off an
 implement stage, a mutating stage on a scheduled pipeline without
-`allow_scheduled_writes`, a gate's invalid predicate or a `source` that is not an
-upstream implement stage in `needs`), an unknown/self/cyclic `needs`, an invalid
+`allow_scheduled_writes`, a gate/review `source` that is not an upstream implement
+stage in `needs`, or `source` on another stage kind), an unknown/self/cyclic `needs`, an invalid
 timeout/interval/jitter, a negative retry, or a `success_decisions` value outside the
 allowed set — so a structural mistake surfaces as a clear error at registration
 rather than a stuck run later.
@@ -140,9 +140,12 @@ stages:
   `worktree:<path>` rather than the shared `repo:<repo>` live checkout — same-repo
   agent stages then run **concurrently** and never mutate the live checkout. The
   worktree is disposed when the stage job settles (and reclaimed on daemon restart).
-  Allocation is fail-open: if it cannot be created the stage still runs, serialized on
-  the shared checkout, with a loud skip event. A pure-reasoning agent stage with no
-  `repo` needs no worktree.
+  Allocation is fail-open for ordinary ask/review stages: if it cannot be created the
+  stage still runs, serialized on the shared checkout, with a loud skip event. A
+  source-bound PR review is the safety exception: its detached worktree is pinned to
+  the source payload's `HeadSHA`, validated clean at that exact SHA, and allocation
+  fails closed rather than reviewing the shared default branch. A pure-reasoning
+  agent stage with no `repo` needs no worktree.
 - **Stateless per run.** Because each agent stage runs in a freshly-created worktree
   directory, a runtime that scopes sessions by working directory (e.g. Claude Code)
   starts a **fresh session each run** — a pipeline stage carries no session context
@@ -167,7 +170,13 @@ stages:
   - id: verify
     agent: reviewer
     action: review
+    source: fix                       # bind to fix's PR + exact head SHA
     needs: [fix]
+    success_decisions: [approved]     # changes_requested parks before the merge gate
+  - id: wait
+    gate: pr_merged
+    source: fix
+    needs: [fix, verify]
 ```
 
 - **Writable worktree + deterministic branch reuse.** Unlike a read-only stage, an
@@ -181,7 +190,30 @@ stages:
   downstream stage sees it via upstream-context injection.
 - **Never auto-merges.** The pipeline **opens** the PR; a human or your CI does the
   merge. See [Gate stages](#gate-stages) to make a later stage wait for that merge.
+- **Declared review suppresses native fan-out.** When an implement stage has a
+  downstream `action: review` stage with `source` pointing to it, its job carries
+  `SkipNativeReviewFanout`. Gitmoot does not also enqueue the ordinary native
+  reviewers; without that declaration, native review behavior is unchanged.
 - Still a **leaf** — it may mutate but never fan out.
+
+### Source-bound review stages
+
+Set `source: <implement-stage>` on an `action: review` stage to review the PR that
+the implement stage just opened. `source` must also appear in the review stage's
+`needs`, and must name an `action: implement` stage.
+
+- At enqueue, Gitmoot reads the succeeded source stage row's `JobID`, parses that
+  job's structured payload stamp, and copies `PullRequest`, `HeadSHA`, `Branch`,
+  `TaskID`, and `LeadAgent` onto the review job. It never scrapes the stage summary.
+- The review runs in a detached read-only worktree at the stamped `HeadSHA` and the
+  existing review checkout preflight verifies that exact clean head.
+- The review is **report-only** for native PR lifecycle purposes. Its verdict is
+  still posted as a PR comment and folded by the pipeline's `success_decisions`, but
+  `changes_requested` does not dispatch a native fix job and `approved` does not run
+  the native merge gate. Human merge remains the default.
+- If the succeeded implement stage produced no PR (a permanent no-op or a first-class
+  `skipped` result), the review stage immediately folds `blocked` with
+  `source stage produced no PR; nothing to review`; no unbound review job is sent.
 
 ### Gate stages
 

--- a/internal/cli/pipeline_orchestrate_request_758_test.go
+++ b/internal/cli/pipeline_orchestrate_request_758_test.go
@@ -20,7 +20,7 @@ func TestPipelineOrchestrateStageJobRequestShape(t *testing.T) {
 	run := db.PipelineRun{ID: "prun-orch-abc", Pipeline: "orch"}
 
 	orch := pipeline.Stage{ID: "decompose", Agent: "coordinator", Prompt: "Fan out.", Action: "ask", Orchestrate: true, Timeout: "30m"}
-	req := pipelineStageJobRequest(rec, orch, run, 0, "UPSTREAM\n")
+	req := pipelineStageJobRequest(rec, orch, run, 0, "UPSTREAM\n", pipelineStagePRBinding{}, false)
 
 	wantID := pipelineStageJobID(run.ID, orch.ID, 0)
 	if req.ID != wantID {
@@ -53,7 +53,7 @@ func TestPipelineOrchestrateStageJobRequestShape(t *testing.T) {
 
 	// Control: a plain #757 agent stage — no OrchestrateStage flag, RootJobID = run.ID.
 	leaf := pipeline.Stage{ID: "review", Agent: "reviewer", Prompt: "Review.", Action: "review"}
-	leafReq := pipelineStageJobRequest(rec, leaf, run, 0, "")
+	leafReq := pipelineStageJobRequest(rec, leaf, run, 0, "", pipelineStagePRBinding{}, false)
 	if leafReq.OrchestrateStage {
 		t.Fatalf("a plain #757 agent stage must NOT set OrchestrateStage")
 	}

--- a/internal/cli/pipeline_review_binding_813_test.go
+++ b/internal/cli/pipeline_review_binding_813_test.go
@@ -1,0 +1,558 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+const pipelineSourceReviewSpec = `name: source-review
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: review
+    agent: reviewer
+    prompt: Review the implementation PR.
+    action: review
+    source: impl
+    needs: [impl]
+    success_decisions: [approved]
+`
+
+func settleBoundImplementStageJob(t *testing.T, store *db.Store, jobID, decision string, binding pipelineStagePRBinding) {
+	t.Helper()
+	ctx := context.Background()
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", jobID, err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload: %v", err)
+	}
+	payload.PullRequest = binding.PullRequest
+	payload.HeadSHA = binding.HeadSHA
+	payload.Branch = binding.Branch
+	payload.TaskID = binding.TaskID
+	payload.LeadAgent = binding.LeadAgent
+	payload.Result = &workflow.AgentResult{Decision: decision, Summary: "implementation settled"}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	to := jobStateForDecision(decision)
+	ok, err := store.TransitionJobStatePayloadWithEvent(ctx, job.ID, job.State, to, string(encoded), db.JobEvent{JobID: job.ID, Kind: to, Message: "settled by test"})
+	if err != nil || !ok {
+		t.Fatalf("settle implement job: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestPipelineSourceReviewBindingAndFanoutSuppression(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "source-review", pipelineSourceReviewSpec)
+	baseEnqueue := testStageEnqueuer(store)
+	requests := make([]workflow.JobRequest, 0, 2)
+	enqueue := func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
+		requests = append(requests, request)
+		return baseEnqueue(ctx, request)
+	}
+	now := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+
+	impl := stageRow(t, store, run.ID, "impl")
+	implJob, err := store.GetJob(ctx, impl.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(impl): %v", err)
+	}
+	implPayload, err := workflow.ParseJobPayload(implJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(impl): %v", err)
+	}
+	if !implPayload.SkipNativeReviewFanout {
+		t.Fatal("implement stage with downstream source-bound review did not suppress native review fan-out")
+	}
+
+	want := pipelineStagePRBinding{PullRequest: 813, HeadSHA: "head-813", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"}
+	settleBoundImplementStageJob(t, store, impl.JobID, "implemented", want)
+	run = advance(t, store, rec, spec, enqueue, run, now.Add(time.Second))
+
+	review := stageRow(t, store, run.ID, "review")
+	if review.State != pipeline.StageQueued || review.JobID == "" {
+		t.Fatalf("review stage = %+v, want queued with bound job", review)
+	}
+	reviewJob, err := store.GetJob(ctx, review.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(review): %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(reviewJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(review): %v", err)
+	}
+	if payload.PullRequest != want.PullRequest || payload.HeadSHA != want.HeadSHA || payload.Branch != want.Branch || payload.TaskID != want.TaskID || payload.LeadAgent != want.LeadAgent {
+		t.Fatalf("review binding = %+v, want %+v", payload, want)
+	}
+	if payload.ReviewRound != "" {
+		t.Fatalf("review round = %q, want empty for pipeline review", payload.ReviewRound)
+	}
+
+	// A second unchanged scan must neither enqueue again nor derive a different
+	// binding: the source job payload and deterministic stage job id are immutable.
+	run = advance(t, store, rec, spec, enqueue, run, now.Add(2*time.Second))
+	if len(requests) != 2 {
+		t.Fatalf("enqueue request count after rescan = %d, want 2 (impl + review)", len(requests))
+	}
+	if got := requests[1]; got.PullRequest != want.PullRequest || got.HeadSHA != want.HeadSHA || got.Branch != want.Branch || got.TaskID != want.TaskID {
+		t.Fatalf("captured review request changed across scan: %+v", got)
+	}
+}
+
+func TestPipelineImplementWithoutSourceReviewKeepsNativeFanout(t *testing.T) {
+	const specYAML = `name: native-review
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix it.
+    action: implement
+    write: true
+  - id: review
+    agent: reviewer
+    prompt: General review.
+    action: review
+    needs: [impl]
+`
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "native-review", specYAML)
+	run := startTestRun(t, store, rec, spec, testStageEnqueuer(store), time.Now().UTC())
+	job, err := store.GetJob(context.Background(), stageRow(t, store, run.ID, "impl").JobID)
+	if err != nil {
+		t.Fatalf("GetJob(impl): %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(impl): %v", err)
+	}
+	if payload.SkipNativeReviewFanout {
+		t.Fatal("unbound downstream review unexpectedly suppressed native review fan-out")
+	}
+}
+
+func TestPipelineSourceReviewUsesSucceededRetryPayload(t *testing.T) {
+	const specYAML = `name: source-review-retry
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+    retry: 1
+  - id: review
+    agent: reviewer
+    prompt: Review it.
+    action: review
+    source: impl
+    needs: [impl]
+`
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "source-review-retry", specYAML)
+	enqueue := testStageEnqueuer(store)
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	first := stageRow(t, store, run.ID, "impl")
+	settleStageJob(t, store, first.JobID, "failed", "first attempt failed", nil)
+	run = advance(t, store, rec, spec, enqueue, run, now.Add(time.Second))
+	second := stageRow(t, store, run.ID, "impl")
+	if second.Attempt != 1 || second.JobID == first.JobID {
+		t.Fatalf("retry row = %+v, first=%+v", second, first)
+	}
+	want := pipelineStagePRBinding{PullRequest: 814, HeadSHA: "retry-head", Branch: "feat/retry", TaskID: "task-retry", LeadAgent: "coder"}
+	settleBoundImplementStageJob(t, store, second.JobID, "implemented", want)
+	run = advance(t, store, rec, spec, enqueue, run, now.Add(2*time.Second))
+	reviewJob, err := store.GetJob(ctx, stageRow(t, store, run.ID, "review").JobID)
+	if err != nil {
+		t.Fatalf("GetJob(review): %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(reviewJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(review): %v", err)
+	}
+	if payload.PullRequest != want.PullRequest || payload.HeadSHA != want.HeadSHA {
+		t.Fatalf("review payload = %+v, want succeeded retry binding %+v", payload, want)
+	}
+}
+
+func TestPipelineSourceReviewNoPRParksBlocked(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		decision string
+		addEvent bool
+	}{
+		{name: "terminal no-op", decision: "implemented", addEvent: true},
+		{name: "skipped no work", decision: "skipped"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := pipelineAdvanceStore(t)
+			rec, spec := newTestPipeline(t, store, "source-review", pipelineSourceReviewSpec)
+			enqueue := testStageEnqueuer(store)
+			now := time.Date(2026, 7, 10, 11, 0, 0, 0, time.UTC)
+			run := startTestRun(t, store, rec, spec, enqueue, now)
+			impl := stageRow(t, store, run.ID, "impl")
+			settleBoundImplementStageJob(t, store, impl.JobID, tc.decision, pipelineStagePRBinding{})
+			if tc.addEvent {
+				if err := store.AddJobEvent(ctx, db.JobEvent{JobID: impl.JobID, Kind: "advance_skipped_no_pr", Message: "no PR"}); err != nil {
+					t.Fatalf("AddJobEvent: %v", err)
+				}
+			}
+			run = advance(t, store, rec, spec, enqueue, run, now.Add(time.Second))
+			review := stageRow(t, store, run.ID, "review")
+			if review.State != pipeline.StageBlocked || review.JobID != "" {
+				t.Fatalf("review stage = %+v, want blocked without a job", review)
+			}
+			if !strings.Contains(review.Summary, "produced no PR") || !strings.Contains(review.NeedsJSON, "source stage produced no PR; nothing to review") {
+				t.Fatalf("review block detail = summary %q needs %q", review.Summary, review.NeedsJSON)
+			}
+			if run.State != pipeline.RunBlocked || run.HaltStage != "review" {
+				t.Fatalf("run = %+v, want blocked at review", run)
+			}
+		})
+	}
+}
+
+func TestPipelineSourceReviewWorktreePinnedToBoundHead(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgentWithPolicy(t, store, "coder", runtime.ShellRuntime, pipelineStageResultCmd("implemented", "fixed", nil), []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, pipelineStageResultCmd("approved", "good", nil), []string{"review"}, "owner/repo")
+
+	// Create a PR-head commit that is resolvable in the shared object database, then
+	// return the registered checkout to main. The review must detach at this SHA,
+	// never at the registered checkout's current main tip.
+	runDaemonWorkerGit(t, checkout, "checkout", "-b", "feat-813")
+	if err := os.WriteFile(filepath.Join(checkout, "feature.txt"), []byte("review me\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile feature: %v", err)
+	}
+	runDaemonWorkerGit(t, checkout, "add", "feature.txt")
+	runDaemonWorkerGit(t, checkout, "commit", "-m", "feature head")
+	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA(feature): %v", err)
+	}
+	runDaemonWorkerGit(t, checkout, "checkout", "main")
+	mainHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA(main): %v", err)
+	}
+	if head == mainHead {
+		t.Fatal("test setup did not create a distinct PR head")
+	}
+
+	rec, spec := newTestPipeline(t, store, "source-review", pipelineSourceReviewSpec)
+	enqueue := newPipelineStageEnqueuer(store, home)
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	settleBoundImplementStageJob(t, store, impl.JobID, "implemented", pipelineStagePRBinding{PullRequest: 813, HeadSHA: head, Branch: "feat-813", TaskID: "task-813", LeadAgent: "coder"})
+	run = advance(t, store, rec, spec, enqueue, run, now.Add(time.Second))
+	reviewJob, err := store.GetJob(ctx, stageRow(t, store, run.ID, "review").JobID)
+	if err != nil {
+		t.Fatalf("GetJob(review): %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(reviewJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(review): %v", err)
+	}
+	if !payload.ReadOnlyWorktree || strings.TrimSpace(payload.WorktreePath) == "" {
+		t.Fatalf("review worktree payload = %+v, want detached read-only worktree", payload)
+	}
+	gotHead, err := (gitutil.Client{Dir: payload.WorktreePath}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA(review worktree): %v", err)
+	}
+	if gotHead != head {
+		t.Fatalf("review checkout HEAD = %s, want bound PR head %s (main=%s)", gotHead, head, mainHead)
+	}
+	worker := jobWorker{Store: store}
+	gotCheckout, err := worker.defaultCheckout(ctx, reviewJob, payload, runtime.Agent{Name: "reviewer"})
+	if err != nil {
+		t.Fatalf("defaultCheckout rejected pinned review worktree: %v", err)
+	}
+	if gotCheckout != payload.WorktreePath {
+		t.Fatalf("defaultCheckout = %q, want %q", gotCheckout, payload.WorktreePath)
+	}
+}
+
+func TestPipelineSourceReviewEnqueueReplayAdoptsExistingJob(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgentWithPolicy(t, store, "coder", runtime.ShellRuntime,
+		pipelineStageResultCmd("implemented", "fixed", nil),
+		[]string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime,
+		pipelineStageResultCmd("approved", "good", nil), []string{"review"}, "owner/repo")
+
+	rec, spec := newTestPipeline(t, store, "source-review", pipelineSourceReviewSpec)
+	productionEnqueue := newPipelineStageEnqueuer(store, home)
+	now := time.Date(2026, 7, 10, 12, 30, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, productionEnqueue, now)
+	implRow := stageRow(t, store, run.ID, "impl")
+	implJob, err := store.GetJob(ctx, implRow.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(impl): %v", err)
+	}
+	implPayload, err := workflow.ParseJobPayload(implJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(impl): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(implPayload.WorktreePath, "replay.txt"), []byte("replay\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile replay: %v", err)
+	}
+	runDaemonWorkerGit(t, implPayload.WorktreePath, "add", "replay.txt")
+	runDaemonWorkerGit(t, implPayload.WorktreePath, "commit", "-m", "replay head")
+	head, err := (gitutil.Client{Dir: implPayload.WorktreePath}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA(impl): %v", err)
+	}
+	settleBoundImplementStageJob(t, store, implJob.ID, "implemented", pipelineStagePRBinding{
+		PullRequest: 813,
+		HeadSHA:     head,
+		Branch:      implPayload.Branch,
+		TaskID:      implPayload.TaskID,
+		LeadAgent:   "coder",
+	})
+
+	// Fault injection: cancel the scan immediately after the real enqueuer has
+	// created the pinned worktree and job. The following stage-row UPDATE observes
+	// context cancellation, reproducing enqueue-success/persist-failure exactly.
+	faultCtx, cancel := context.WithCancel(ctx)
+	enqueueCalls := 0
+	faultEnqueue := func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
+		enqueueCalls++
+		job, err := productionEnqueue(ctx, request)
+		if err == nil {
+			cancel()
+		}
+		return job, err
+	}
+	if _, err := advancePipelineRun(faultCtx, store, faultEnqueue, rec, spec, run, now.Add(time.Second)); err == nil {
+		t.Fatal("fault-injected advance returned nil; want cancelled stage-row persist")
+	}
+	if enqueueCalls != 1 {
+		t.Fatalf("fault enqueue calls = %d, want 1", enqueueCalls)
+	}
+	reviewRow := stageRow(t, store, run.ID, "review")
+	if reviewRow.State != pipeline.StagePending || reviewRow.JobID != "" {
+		t.Fatalf("review row after interrupted enqueue = %+v, want pending without JobID", reviewRow)
+	}
+
+	reviewJobID := pipelineStageJobID(run.ID, "review", 0)
+	created, err := store.GetJob(ctx, reviewJobID)
+	if err != nil {
+		t.Fatalf("GetJob(interrupted review): %v", err)
+	}
+	createdPayload, err := workflow.ParseJobPayload(created.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(interrupted review): %v", err)
+	}
+	if strings.TrimSpace(createdPayload.WorktreePath) == "" {
+		t.Fatal("interrupted review job has no pinned worktree")
+	}
+	createdHead, err := (gitutil.Client{Dir: createdPayload.WorktreePath}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA(interrupted review worktree): %v", err)
+	}
+	if createdHead != head {
+		t.Fatalf("interrupted review worktree HEAD = %s, want %s", createdHead, head)
+	}
+
+	// Replay must adopt before allocation. Make any call to the allocating enqueuer
+	// fail the test: a call would collide with the deterministic existing worktree.
+	replayEnqueueCalls := 0
+	replayEnqueue := func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
+		replayEnqueueCalls++
+		return productionEnqueue(ctx, request)
+	}
+	run, err = advancePipelineRun(ctx, store, replayEnqueue, rec, spec, run, now.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("replay advance: %v", err)
+	}
+	if replayEnqueueCalls != 0 {
+		t.Fatalf("replay called allocating enqueuer %d time(s), want 0", replayEnqueueCalls)
+	}
+	reviewRow = stageRow(t, store, run.ID, "review")
+	if reviewRow.State != pipeline.StageQueued || reviewRow.JobID != reviewJobID {
+		t.Fatalf("adopted review row = %+v, want queued job %s", reviewRow, reviewJobID)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	count := 0
+	for _, job := range jobs {
+		if job.ID == reviewJobID {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("review attempt job count = %d, want exactly 1", count)
+	}
+
+	// Once row and job agree, another scan is a strict no-op for enqueue.
+	before := reviewRow
+	run, err = advancePipelineRun(ctx, store, replayEnqueue, rec, spec, run, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("consistent rescan: %v", err)
+	}
+	after := stageRow(t, store, run.ID, "review")
+	if replayEnqueueCalls != 0 || !pipelineStageEqual(before, after) {
+		t.Fatalf("consistent rescan changed stage or enqueued: before=%+v after=%+v calls=%d", before, after, replayEnqueueCalls)
+	}
+}
+
+func TestPipelineSourceReviewShellRuntimeE2E(t *testing.T) {
+	for _, decision := range []string{"changes_requested", "approved"} {
+		t.Run(decision, func(t *testing.T) {
+			ctx := context.Background()
+			home, _, store := heartbeatLoopE2EHome(t)
+			checkout := createDaemonWorkerGitCheckout(t, "main")
+			seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+			seedDaemonWorkerAgentWithPolicy(t, store, "coder", runtime.ShellRuntime,
+				pipelineStageResultCmd("implemented", "fixed", nil),
+				[]string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+			seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime,
+				pipelineStageResultCmd(decision, "review verdict", nil),
+				[]string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+
+			const specYAML = `name: source-review-e2e
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: review
+    agent: reviewer
+    prompt: Review the implementation PR.
+    action: review
+    source: impl
+    needs: [impl]
+    success_decisions: [approved]
+  - id: wait
+    gate: pr_merged
+    source: impl
+    needs: [impl, review]
+`
+			rec, spec := newTestPipeline(t, store, "source-review-e2e", specYAML)
+			enqueue := newPipelineStageEnqueuer(store, home)
+			now := time.Date(2026, 7, 10, 13, 0, 0, 0, time.UTC)
+			run := startTestRun(t, store, rec, spec, enqueue, now)
+			implRow := stageRow(t, store, run.ID, "impl")
+			implJob, err := store.GetJob(ctx, implRow.JobID)
+			if err != nil {
+				t.Fatalf("GetJob(impl): %v", err)
+			}
+			implPayload, err := workflow.ParseJobPayload(implJob.Payload)
+			if err != nil {
+				t.Fatalf("ParseJobPayload(impl): %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(implPayload.WorktreePath, "change.txt"), []byte("review me\n"), 0o644); err != nil {
+				t.Fatalf("WriteFile change: %v", err)
+			}
+			runDaemonWorkerGit(t, implPayload.WorktreePath, "add", "change.txt")
+			runDaemonWorkerGit(t, implPayload.WorktreePath, "commit", "-m", "pipeline implementation")
+			head, err := (gitutil.Client{Dir: implPayload.WorktreePath}).HeadSHA(ctx)
+			if err != nil {
+				t.Fatalf("HeadSHA(impl): %v", err)
+			}
+			binding := pipelineStagePRBinding{PullRequest: 813, HeadSHA: head, Branch: implPayload.Branch, TaskID: implPayload.TaskID, LeadAgent: "coder"}
+			settleBoundImplementStageJob(t, store, implJob.ID, "implemented", binding)
+			run = advance(t, store, rec, spec, enqueue, run, now.Add(time.Second))
+
+			reviewRow := stageRow(t, store, run.ID, "review")
+			reviewJob, err := store.GetJob(ctx, reviewRow.JobID)
+			if err != nil {
+				t.Fatalf("GetJob(review): %v", err)
+			}
+			reviewPayload, err := workflow.ParseJobPayload(reviewJob.Payload)
+			if err != nil {
+				t.Fatalf("ParseJobPayload(review): %v", err)
+			}
+			if reviewPayload.PullRequest != 813 || reviewPayload.HeadSHA != head {
+				t.Fatalf("review payload = %+v, want PR 813 head %s", reviewPayload, head)
+			}
+
+			worker := defaultJobWorker(store, io.Discard, home)
+			if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now.Add(2*time.Second)); err != nil {
+				t.Fatalf("review worker tick: %v", err)
+			}
+			events, err := store.ListJobEvents(ctx, reviewJob.ID)
+			if err != nil {
+				t.Fatalf("ListJobEvents(review): %v", err)
+			}
+			if !jobEventKindPresent(events, "pipeline_review_report_only") {
+				t.Fatalf("review events = %+v, want pipeline_review_report_only", events)
+			}
+			if _, err := store.GetJob(ctx, "implement-coder-"+implPayload.TaskID); err == nil {
+				t.Fatal("pipeline changes_requested review dispatched a native fix job")
+			}
+			if _, err := store.GetMergeGate(ctx, "owner/repo", 813); !errors.Is(err, sql.ErrNoRows) {
+				t.Fatalf("GetMergeGate = %v, want no native merge-gate evaluation", err)
+			}
+
+			run = advance(t, store, rec, spec, enqueue, run, now.Add(3*time.Second))
+			if decision == "changes_requested" {
+				if run.State != pipeline.RunFailed || run.HaltStage != "review" {
+					t.Fatalf("changes-requested run = %+v, want parked failed at review", run)
+				}
+				if gate := stageRow(t, store, run.ID, "wait"); gate.JobID != "" || gate.State != pipeline.StageSkipped {
+					t.Fatalf("gate = %+v, want never enqueued", gate)
+				}
+				return
+			}
+
+			gate := stageRow(t, store, run.ID, "wait")
+			if gate.JobID != "" || (gate.State != pipeline.StageQueued && gate.State != pipeline.StageRunning) {
+				t.Fatalf("approved review gate = %+v, want jobless in-flight gate", gate)
+			}
+			markPipelinePRMerged(t, store, "owner/repo", 813, "merged")
+			run = advance(t, store, rec, spec, enqueue, run, now.Add(4*time.Second))
+			if run.State != pipeline.RunSucceeded {
+				t.Fatalf("approved+merged run = %+v, want succeeded", run)
+			}
+		})
+	}
+}
+
+func jobEventKindPresent(events []db.JobEvent, kind string) bool {
+	for _, event := range events {
+		if event.Kind == kind {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -57,6 +57,17 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 		// rather than stalling the pipeline scan loop. Shell stages carry a
 		// RuntimeOverride and are excluded, so their request is byte-identical.
 		request, worktreePath, worktreeErr := allocatePipelineStageReadOnlyWorktree(ctx, store, home, request)
+		// A source-bound review is pinned to the implement job's immutable PR head.
+		// Unlike a generic read-only stage, it must never fail open onto the shared
+		// checkout: that checkout may be on the default branch, which would review the
+		// wrong tree. Keep generic #739 allocation fail-open, but fail this one binding
+		// closed unless the pinned detached worktree was allocated successfully.
+		if pipelineStageSourceBoundReviewRequest(request) && strings.TrimSpace(request.WorktreePath) == "" {
+			if worktreeErr != nil {
+				return db.Job{}, fmt.Errorf("allocate PR-bound pipeline review worktree at %s: %w", request.HeadSHA, worktreeErr)
+			}
+			return db.Job{}, fmt.Errorf("allocate PR-bound pipeline review worktree at %s: managed repo checkout is unavailable", request.HeadSHA)
+		}
 		// #768: a MUTATING implement stage takes the WRITABLE task-worktree path
 		// instead of the read-only committed-tip worktree — it must commit + push. Unlike
 		// the read-only allocator (fail-OPEN), this one is fail-CLOSED: on an active
@@ -97,6 +108,12 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 		}
 		return job, nil
 	}
+}
+
+func pipelineStageSourceBoundReviewRequest(request workflow.JobRequest) bool {
+	return request.Sender == workflow.PipelineJobSender &&
+		strings.TrimSpace(request.Action) == "review" &&
+		request.PullRequest > 0
 }
 
 // pipelineStageReadOnlyWorktreeEligible reports whether a stage job request is a
@@ -148,7 +165,11 @@ func allocatePipelineStageReadOnlyWorktree(ctx context.Context, store *db.Store,
 	if err != nil {
 		return request, "", err
 	}
-	path, err := workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, request.Repo, checkout, request.ID, "pipeline-stage", 0, "", workflow.ReadOnlyWorktreeDispatchLockWaitBudget, gitutil.Client{Dir: checkout})
+	// A source-bound review carries HeadSHA; use it as the detached base ref so the
+	// existing review checkout validation proves HEAD == payload.HeadSHA. Other
+	// read-only stages keep the empty-ref behavior (the checkout's committed tip).
+	baseRef := strings.TrimSpace(request.HeadSHA)
+	path, err := workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, request.Repo, checkout, request.ID, "pipeline-stage", 0, baseRef, workflow.ReadOnlyWorktreeDispatchLockWaitBudget, gitutil.Client{Dir: checkout})
 	if err != nil {
 		return request, "", err
 	}
@@ -339,7 +360,19 @@ func pipelineStageMintsJob(stage pipeline.Stage) bool {
 	}
 }
 
-func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.PipelineRun, attempt int, upstreamContext string) workflow.JobRequest {
+// pipelineStagePRBinding is recovered from a source implement stage's immutable
+// job payload after that stage folds success. It is intentionally not derived from
+// the human-readable stage summary: the finalizer's structured payload stamp is the
+// authoritative and deterministic PR identity across advancer re-scans.
+type pipelineStagePRBinding struct {
+	PullRequest int
+	HeadSHA     string
+	Branch      string
+	TaskID      string
+	LeadAgent   string
+}
+
+func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.PipelineRun, attempt int, upstreamContext string, binding pipelineStagePRBinding, skipNativeReviewFanout bool) workflow.JobRequest {
 	// AGENT stage (#757): bind the job to the named managed agent and let IT run on
 	// its OWN registered runtime — no RuntimeOverride, so the agent's real
 	// claude/codex runtime and session are used. The runtime instruction is the
@@ -414,10 +447,13 @@ func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.Pipel
 			Fingerprint:  pipelineStageFingerprint(rec.Name, run.ID, stage.ID, attempt),
 			RootJobID:    run.ID,
 			JobTimeout:   stage.Timeout,
+			// A declared source-bound review owns this PR's review step. Suppress the
+			// native reviewer fan-out so the same implementation is not reviewed twice.
+			SkipNativeReviewFanout: skipNativeReviewFanout,
 		}
 	}
 	if stage.Agent != "" {
-		return workflow.JobRequest{
+		request := workflow.JobRequest{
 			ID:           pipelineStageJobID(run.ID, stage.ID, attempt),
 			Agent:        stage.Agent,
 			Action:       stage.Action,
@@ -428,6 +464,14 @@ func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.Pipel
 			RootJobID:    run.ID,
 			JobTimeout:   stage.Timeout,
 		}
+		if stage.Kind() == pipeline.StageKindAgentReview && strings.TrimSpace(stage.Source) != "" {
+			request.PullRequest = binding.PullRequest
+			request.HeadSHA = binding.HeadSHA
+			request.Branch = binding.Branch
+			request.TaskID = binding.TaskID
+			request.LeadAgent = binding.LeadAgent
+		}
+		return request
 	}
 	// SHELL stage: byte-identical to before — the runner agent runs stage.Cmd via a
 	// per-job shell runtime override.
@@ -446,11 +490,61 @@ func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.Pipel
 	}
 }
 
+func pipelineSourceBoundReview(stage pipeline.Stage) bool {
+	return stage.Kind() == pipeline.StageKindAgentReview && strings.TrimSpace(stage.Source) != ""
+}
+
+func pipelineImplementHasSourceBoundReview(spec pipeline.Spec, implementStageID string) bool {
+	for _, candidate := range spec.Stages {
+		if pipelineSourceBoundReview(candidate) && strings.TrimSpace(candidate.Source) == implementStageID {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvePipelineStagePRBinding(ctx context.Context, store *db.Store, sourceRow db.PipelineRunStage) (pipelineStagePRBinding, error) {
+	if strings.TrimSpace(sourceRow.JobID) == "" {
+		return pipelineStagePRBinding{}, fmt.Errorf("source stage %q has no job id", sourceRow.StageID)
+	}
+	job, err := store.GetJob(ctx, sourceRow.JobID)
+	if err != nil {
+		return pipelineStagePRBinding{}, fmt.Errorf("load source stage %q job %q: %w", sourceRow.StageID, sourceRow.JobID, err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		return pipelineStagePRBinding{}, fmt.Errorf("parse source stage %q job %q payload: %w", sourceRow.StageID, sourceRow.JobID, err)
+	}
+	return pipelineStagePRBinding{
+		PullRequest: payload.PullRequest,
+		HeadSHA:     strings.TrimSpace(payload.HeadSHA),
+		Branch:      strings.TrimSpace(payload.Branch),
+		TaskID:      strings.TrimSpace(payload.TaskID),
+		LeadAgent:   strings.TrimSpace(payload.LeadAgent),
+	}, nil
+}
+
 // enqueuePipelineStageJob enqueues a stage job idempotently: on an enqueue error
 // (e.g. a duplicate id from a re-scan that raced the stage-row write) it adopts an
 // already-created job with the same deterministic id, mirroring the engine's
 // enqueue idiom (engine.go). A genuinely new error with no matching job propagates.
-func enqueuePipelineStageJob(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, request workflow.JobRequest) (db.Job, error) {
+func enqueuePipelineStageJob(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, request workflow.JobRequest, adoptBeforeEnqueue bool) (db.Job, error) {
+	// A source-bound review allocates its deterministic pinned worktree before the
+	// mailbox creates the deterministic job. If a scan dies after that enqueue but
+	// before its stage row records JobID, the next scan must adopt the existing job
+	// BEFORE calling the allocating enqueuer again; otherwise worktree allocation
+	// collides with the still-valid worktree and fail-closes forever. Keep this
+	// preflight opt-in so every non-bound stage retains the original enqueue-first
+	// behavior below byte-for-byte.
+	if adoptBeforeEnqueue {
+		existing, err := store.GetJob(ctx, request.ID)
+		if err == nil {
+			return existing, nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return db.Job{}, err
+		}
+	}
 	job, err := enqueue(ctx, request)
 	if err == nil {
 		return job, nil
@@ -796,7 +890,34 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 		// prompt (dataflow), so e.g. a triage stage can act on an upstream extract
 		// stage's output. Deterministic + bounded; "" for shell stages / root stages.
 		upstreamContext := buildPipelineAgentStageContext(stage, byID)
-		job, err := enqueuePipelineStageJob(ctx, store, enqueue, pipelineStageJobRequest(rec, stage, run, row.Attempt, upstreamContext))
+		binding := pipelineStagePRBinding{}
+		if pipelineSourceBoundReview(stage) {
+			sourceRow := byID[strings.TrimSpace(stage.Source)]
+			binding, err = resolvePipelineStagePRBinding(ctx, store, sourceRow)
+			if err != nil {
+				return run, err
+			}
+			if binding.PullRequest <= 0 {
+				// implementStageSettleOutcome only folds success once its payload stamp is
+				// final. A zero PR here is therefore terminal (no-op or skipped), never a
+				// finalizer race: park immediately instead of dispatching an unbound review.
+				row.State = pipeline.StageBlocked
+				row.Summary = fmt.Sprintf("review cannot run: source stage %q produced no PR", stage.Source)
+				row.NeedsJSON = marshalPipelineNeeds([]string{"source stage produced no PR; nothing to review"})
+				row.FinishedAt = now
+				if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
+					return run, err
+				}
+				byID[stage.ID] = row
+				continue
+			}
+			if strings.TrimSpace(binding.HeadSHA) == "" {
+				return run, fmt.Errorf("source stage %q job payload has PR #%d but no head SHA", stage.Source, binding.PullRequest)
+			}
+		}
+		skipNativeReviewFanout := stage.Kind() == pipeline.StageKindAgentImplement && pipelineImplementHasSourceBoundReview(spec, stage.ID)
+		request := pipelineStageJobRequest(rec, stage, run, row.Attempt, upstreamContext, binding, skipNativeReviewFanout)
+		job, err := enqueuePipelineStageJob(ctx, store, enqueue, request, pipelineStageSourceBoundReviewRequest(request))
 		if err != nil {
 			return run, err
 		}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -175,6 +175,32 @@ stages:
 	}
 }
 
+func TestLoadValidSourceBoundReviewSpec(t *testing.T) {
+	const spec = `name: review-flow
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: review
+    agent: reviewer
+    prompt: Review the implementation PR.
+    action: review
+    source: impl
+    needs: [impl]
+`
+	loaded, err := Load([]byte(spec))
+	if err != nil {
+		t.Fatalf("Load valid source-bound review spec: %v", err)
+	}
+	review := loaded.Stages[1]
+	if review.Kind() != StageKindAgentReview || review.Source != "impl" {
+		t.Fatalf("review stage = %+v, want action: review source: impl", review)
+	}
+}
+
 func TestLoadValidationErrors(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -270,6 +296,36 @@ func TestLoadValidationErrors(t *testing.T) {
 			name:    "gate with agent rejected",
 			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: g, gate: pr_merged, source: a, needs: [a], agent: rev, prompt: hi}\n",
 			wantSub: `stage "g" sets both gate and agent`,
+		},
+		{
+			name:    "review source not in needs",
+			spec:    "name: p\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: other, cmd: echo}\n  - {id: review, agent: rev, prompt: inspect, action: review, source: impl, needs: [other]}\n",
+			wantSub: `review source "impl" must be one of the stage's needs`,
+		},
+		{
+			name:    "review source wrong kind",
+			spec:    "name: p\nstages:\n  - {id: prep, cmd: echo}\n  - {id: review, agent: rev, prompt: inspect, action: review, source: prep, needs: [prep]}\n",
+			wantSub: `review source "prep" must be a mutating implement stage`,
+		},
+		{
+			name:    "shell source rejected",
+			spec:    "name: p\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: shell, cmd: echo, source: impl, needs: [impl]}\n",
+			wantSub: `stage "shell" sets source "impl" but is neither a gate nor an action: review agent stage`,
+		},
+		{
+			name:    "ask source rejected",
+			spec:    "name: p\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: ask, agent: helper, prompt: inspect, source: impl, needs: [impl]}\n",
+			wantSub: `stage "ask" sets source "impl" but is neither a gate nor an action: review agent stage`,
+		},
+		{
+			name:    "implement source rejected",
+			spec:    "name: p\nstages:\n  - {id: first, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: second, agent: coder, prompt: more, action: implement, write: true, source: first, needs: [first]}\n",
+			wantSub: `stage "second" sets source "first" but is neither a gate nor an action: review agent stage`,
+		},
+		{
+			name:    "orchestrate source rejected",
+			spec:    "name: p\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: orch, agent: lead, prompt: coordinate, orchestrate: true, source: impl, needs: [impl]}\n",
+			wantSub: `stage "orch" sets source "impl" but is neither a gate nor an action: review agent stage`,
 		},
 		{
 			name:    "shell stage with prompt",

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -125,10 +125,11 @@ type Stage struct {
 	// advancer's settle pass evaluates its predicate per scan. Mutually exclusive with
 	// Cmd and Agent (exactly one of the three executors). Pairs with Source.
 	Gate string `yaml:"gate,omitempty"`
-	// Source is the id of the upstream stage a gate stage watches (required for — and
-	// valid ONLY on — a gate stage): the implement stage whose opened PR the gate's
-	// predicate observes. It must be one of the gate's own Needs, so the gate only
-	// begins watching once that upstream stage has succeeded (and stamped its PR).
+	// Source is the id of the upstream implement stage whose opened PR this stage
+	// binds to. It is required on a gate stage and optional on an action: review
+	// agent stage; it is rejected on every other stage kind. Source must be one of
+	// the stage's own Needs, so binding begins only after the implement stage has
+	// succeeded and its job payload carries the final PR stamp.
 	Source string `yaml:"source,omitempty"`
 	// Needs lists the ids of stages that must succeed before this stage is enqueued.
 	Needs []string `yaml:"needs,omitempty"`

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -89,15 +89,12 @@ func (s Spec) Validate() error {
 		if err := s.validateMutatingStage(stage); err != nil {
 			return err
 		}
-		// A gate's source must be a mutating implement stage: the pr_merged predicate reads
-		// the "(opened PR #<n>)" marker only an implement stage stamps onto its summary, so
-		// a gate pointed at a shell/ask/review source would find no PR and wait/time out
-		// silently instead of failing fast. Checked here (not in validateGateStage) because
-		// it needs the SOURCE stage's kind — spec-level context the per-stage validator lacks.
-		if stage.Kind() == StageKindGate {
-			if src, ok := stageByID[stage.Source]; ok && src.Kind() != StageKindAgentImplement {
-				return fmt.Errorf("pipeline %q stage %q gate source %q must be a mutating implement stage (action: implement) so the gate has a PR to watch", s.Name, stage.ID, stage.Source)
-			}
+		// source is meaningful only for a gate or a review agent. Both bind to the
+		// structured PR produced by an upstream implement stage, so validate the same
+		// dependency and source-kind invariants at add time instead of silently ignoring
+		// a stray source on another kind.
+		if err := validateStageSource(s.Name, stage, stageByID); err != nil {
+			return err
 		}
 		if stage.Retry < 0 {
 			return fmt.Errorf("pipeline %q stage %q retry must be >= 0", s.Name, stage.ID)
@@ -127,6 +124,40 @@ func (s Spec) Validate() error {
 		}
 	}
 	return s.detectCycle()
+}
+
+// validateStageSource applies the spec-level half of source binding. Gate-local
+// requirements (source is mandatory, non-self, and in Needs) remain in
+// validateGateStage; this helper adds the source-stage kind check shared by gates
+// and reviews and rejects source everywhere else.
+func validateStageSource(pipelineName string, stage Stage, stageByID map[string]Stage) error {
+	source := strings.TrimSpace(stage.Source)
+	switch stage.Kind() {
+	case StageKindGate:
+		if src, ok := stageByID[source]; ok && src.Kind() != StageKindAgentImplement {
+			return fmt.Errorf("pipeline %q stage %q gate source %q must be a mutating implement stage (action: implement) so the gate has a PR to watch", pipelineName, stage.ID, source)
+		}
+		return nil
+	case StageKindAgentReview:
+		if source == "" {
+			return nil
+		}
+		if source == stage.ID {
+			return fmt.Errorf("pipeline %q stage %q review source cannot be the stage itself", pipelineName, stage.ID)
+		}
+		if !containsToken(stage.Needs, source) {
+			return fmt.Errorf("pipeline %q stage %q review source %q must be one of the stage's needs (a review binds to an upstream stage it depends on)", pipelineName, stage.ID, source)
+		}
+		if src, ok := stageByID[source]; ok && src.Kind() != StageKindAgentImplement {
+			return fmt.Errorf("pipeline %q stage %q review source %q must be a mutating implement stage (action: implement) so the review has a PR to inspect", pipelineName, stage.ID, source)
+		}
+		return nil
+	default:
+		if source != "" {
+			return fmt.Errorf("pipeline %q stage %q sets source %q but is neither a gate nor an action: review agent stage", pipelineName, stage.ID, source)
+		}
+		return nil
+	}
 }
 
 // validateSchedule checks the optional schedule block: a present block requires a

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1505,6 +1505,28 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 		}
 	}
 
+	if job.Type == "review" && payload.Sender == PipelineJobSender {
+		// Pipeline PR reviews are report-only: delivery and the daemon's PR-comment
+		// posting already happened, while the pipeline advancer owns decision folding.
+		// Do not enter the native review lifecycle here: changes_requested would fan
+		// out a fix job and approved could run the merge gate (and merge the PR), both
+		// violating the human-merge pipeline policy. This is the single policy seam
+		// where a future explicit `merge: auto` mode can branch.
+		events, err := e.Store.ListJobEvents(ctx, job.ID)
+		if err != nil {
+			return err
+		}
+		for _, event := range events {
+			if event.Kind == "pipeline_review_report_only" {
+				return nil
+			}
+		}
+		return e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    "pipeline_review_report_only",
+			Message: "pipeline review recorded as report-only; pipeline advancement owns the verdict and human merge remains required",
+		})
+	}
 	if job.Type == "review" {
 		latest, err := e.latestReviewRound(ctx, payload)
 		if err != nil {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1238,6 +1238,61 @@ func TestEngineAdvanceReviewChangesRequestedDispatchesFix(t *testing.T) {
 	}
 }
 
+func TestEngineAdvancePipelineReviewIsReportOnly(t *testing.T) {
+	for _, decision := range []string{"changes_requested", "approved"} {
+		t.Run(decision, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			seedAgent(t, store, "lead", []string{"implement"}, "jerryfane/gitmoot")
+			engine := testEngine(store)
+			gate := &fakeMergeGate{onEvaluate: func(MergeRequest) {
+				t.Fatalf("merge gate evaluated for report-only pipeline review")
+			}}
+			engine.MergeGate = gate
+			insertCompletedJob(t, store, db.Job{
+				ID:    "pipeline-review-job",
+				Agent: "audit",
+				Type:  "review",
+			}, JobPayload{
+				Repo:        "jerryfane/gitmoot",
+				Branch:      "task-813",
+				PullRequest: 813,
+				HeadSHA:     "head813",
+				TaskID:      "task-813",
+				LeadAgent:   "lead",
+				Sender:      PipelineJobSender,
+				Result:      &AgentResult{Decision: decision, Summary: "pipeline verdict"},
+			})
+
+			if err := engine.AdvanceJob(ctx, "pipeline-review-job"); err != nil {
+				t.Fatalf("AdvanceJob returned error: %v", err)
+			}
+			if err := engine.AdvanceJob(ctx, "pipeline-review-job"); err != nil {
+				t.Fatalf("replayed AdvanceJob returned error: %v", err)
+			}
+			if _, err := store.GetJob(ctx, "implement-lead-task-813"); err == nil {
+				t.Fatal("report-only pipeline review dispatched a native fix job")
+			}
+			if len(gate.requests) != 0 {
+				t.Fatalf("merge gate requests = %+v, want none", gate.requests)
+			}
+			events, err := store.ListJobEvents(ctx, "pipeline-review-job")
+			if err != nil {
+				t.Fatalf("ListJobEvents: %v", err)
+			}
+			count := 0
+			for _, event := range events {
+				if event.Kind == "pipeline_review_report_only" {
+					count++
+				}
+			}
+			if count != 1 {
+				t.Fatalf("pipeline_review_report_only event count = %d, want 1; events=%+v", count, events)
+			}
+		})
+	}
+}
+
 func TestEngineAdvanceReviewSkipsPullRequestFlowWhenNoPullRequest(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2097,6 +2097,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     needs: [score]          #   upstream results are prepended to the prompt
   # other agent-stage kinds:
   #   implement (#768): action: implement + write: true → mutates repo + opens a PR (never auto-merges)
+  #   bound review (#813): action: review + source: <impl stage> -> reviews that PR/head, report-only
   #   orchestrate (#758): orchestrate: true → sub-tree coordinator (fans out owned children, folds synthesis)
   #   gate (#768): gate: pr_merged + source: <impl stage> (no agent) → jobless, folds when that PR merges
   - id: deploy
@@ -2122,8 +2123,8 @@ gitmoot pipeline remove nightly-sync
 `pipeline add` validates the whole spec at add time (unknown keys, duplicate/self/
 cyclic `needs`, a stage that is not exactly one of `cmd`/`agent`/`gate`, an agent stage
 missing a `prompt` / invalid `action` / `implement` without `write: true` / a mutating
-stage on a scheduled pipeline without `allow_scheduled_writes` / a gate's bad
-predicate or `source`, invalid durations, a `success_decisions` outside
+stage on a scheduled pipeline without `allow_scheduled_writes` / a gate or review's
+bad `source` / `source` on another stage kind, invalid durations, a `success_decisions` outside
 `approved`/`implemented`/`changes_requested`/`skipped`) so a mistake is a clear error, not a
 stuck run. It stores the raw YAML **verbatim** plus a content hash; each run
 snapshots that hash and executes its snapshot, so editing the file later never
@@ -2134,6 +2135,17 @@ runs a named managed agent on its own runtime as a read-only leaf (`ask`/`review
 its `needs` stages' result summaries are prepended to the prompt, and a repo-bound
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
+
+An `action: review` stage may set `source: <implement-stage>` (also listed in its
+`needs`) to bind to that implement job's structured PR stamp. The review payload
+inherits the PR number, head SHA, branch, task, and lead agent; its detached worktree
+is pinned to the exact PR head. The verdict still posts as a PR comment and folds by
+`success_decisions`, but pipeline reviews are report-only: they dispatch no native
+fix job and never run the native merge gate. Declaring this review also sets
+`SkipNativeReviewFanout` on the source implement request, avoiding duplicate native
+reviewer jobs. If the source permanently produces no PR (no-op or `skipped`), the
+review folds blocked immediately with `source stage produced no PR; nothing to
+review` and no unbound review is dispatched.
 
 `pipeline install-defaults` installs the built-in memory pipelines
 `memory-ingest-sweep` and `memory-groom-propose`. The daemon also runs this

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -997,7 +997,8 @@ exactly one of `cmd`, `agent`, or `gate`. An agent stage runs on its **own** reg
 runtime (claude / codex). Four kinds:
 
 - **ask / review** (#757) — read-only **leaf** (`action: ask|review`); `delegations[]`
-  and `human_questions[]` stripped. Model judgement inline in a deterministic flow.
+  and `human_questions[]` stripped. A review may add `source: <implement stage>`
+  (#813) to bind to that stage's PR and exact head SHA.
 - **implement** (#768) — `action: implement` + `write: true`. MUTATES the repo + opens a
   PR on a deterministic `gitmoot/pipe-<run>-<stage>` branch (retry reuses it, never
   duplicates), folds **on PR-opened**, **never auto-merges**. Scheduled pipelines also
@@ -1029,6 +1030,32 @@ stages:
     source: fix
     needs: [fix]
 ```
+
+To make review first-class between implementation and the human merge, insert a
+source-bound review before the gate:
+
+```yaml
+  - id: review
+    agent: reviewer
+    action: review
+    prompt: "Review the implementation PR."
+    source: fix
+    needs: [fix]
+    success_decisions: [approved]
+  - id: wait
+    gate: pr_merged
+    source: fix
+    needs: [fix, review]
+```
+
+The review job copies the structured PR/head/branch/task/lead stamp from the
+succeeded implement job and runs in a detached worktree pinned to that head. It is
+report-only: the verdict is posted to the PR and folded by the pipeline, but it does
+not dispatch a native fix job or run the native merge gate. The declared binding
+also sets `SkipNativeReviewFanout` on `fix`, preventing duplicate reviewer fan-out;
+pipelines without the declaration keep native behavior. A permanent no-PR source
+(no-op or `skipped`) blocks the review immediately with `source stage produced no
+PR; nothing to review` instead of dispatching an unbound job or waiting.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -57,7 +57,7 @@ gitmoot pipeline show "$RUN"
 name/id, a duplicate stage id, a stage that is not exactly one of `cmd`, `agent`, or
 `gate` (and, per kind: an agent stage's missing `prompt` or invalid `action`,
 `implement` without `write: true`, a mutating stage on a scheduled pipeline without
-`allow_scheduled_writes`, a gate's bad predicate/`source`), an unknown/self/cyclic
+`allow_scheduled_writes`, a gate/review's bad `source`, or `source` on another kind), an unknown/self/cyclic
 `needs`, an invalid duration, a negative retry, or a
 `success_decisions` value outside `approved`/`implemented`/`changes_requested`/`skipped` - so a
 structural mistake is a clear error at registration, not a stuck run later. It stores the raw YAML **verbatim**
@@ -164,7 +164,7 @@ is **exactly one** of `cmd`, `agent`, or `gate`. There are four agent-stage kind
 
 | Kind | Declared by | What it does |
 | ---- | ----------- | ------------ |
-| **ask / review** (#757) | `action: ask\|review` | Read-only leaf — looks + decides, never mutates. |
+| **ask / review** (#757/#813) | `action: ask\|review` (review may add `source:`) | Read-only leaf; optionally reviews one upstream implement PR at its exact head. |
 | **implement** (#768) | `action: implement` + `write: true` | Mutates the repo + opens a PR (fold-on-PR-opened); never auto-merges. |
 | **orchestrate** (#758) | `orchestrate: true` | Sub-tree coordinator — fans out owned children, waits, folds the synthesis. |
 | **gate** (#768) | `gate: pr_merged` + `source:` (no `agent`) | Jobless waiter — folds when an upstream implement stage's PR merges. |
@@ -190,6 +190,34 @@ stages:
     needs: [fix]
 ```
 
+For the first-class `implement -> review the PR -> wait for human merge` flow, bind
+the review to the implement stage:
+
+```yaml
+  - id: review
+    agent: reviewer
+    action: review
+    prompt: "Review the implementation PR."
+    source: fix              # must also be in needs; must name an implement stage
+    needs: [fix]
+    success_decisions: [approved]
+  - id: wait
+    gate: pr_merged
+    source: fix
+    needs: [fix, review]
+```
+
+At enqueue, Gitmoot copies the source implement job's structured PR number, head
+SHA, branch, task, and lead-agent stamp onto the review job. The read-only worktree
+is detached at that exact head and checkout validation confirms it; this binding is
+never inferred from summary text. Pipeline reviews are **report-only**: the verdict
+still appears as a PR comment and folds through `success_decisions`, but
+`changes_requested` does not dispatch a native fix and `approved` does not run the
+native merge gate. Human merge remains required. Declaring the binding sets
+`SkipNativeReviewFanout` on the implement request so Gitmoot does not also enqueue
+native reviewers. If the source produced no PR (no-op or `skipped`), the review
+folds blocked immediately with `source stage produced no PR; nothing to review`.
+
 An agent stage runs the named agent on **its own registered runtime** (claude /
 codex — no per-job shell override):
 
@@ -213,7 +241,8 @@ codex — no per-job shell override):
 - **isolated read-only worktree** — a repo-bound ask/review agent stage runs in its
   own detached, committed-tip read-only worktree (#739), so same-repo agent stages
   parallelize and never touch the live checkout; the worktree is disposed when the
-  stage job settles.
+  stage job settles. A source-bound review is pinned to its payload `HeadSHA` and
+  fails closed if that detached checkout cannot be allocated.
 
 Agent stages fold by `gitmoot_result` `decision` and park/advance exactly like shell
 stages — an `approved`/`implemented` review advances dependents, a `blocked` result

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2632,7 +2632,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].write`            | stage        | cond.    | Acknowledges that an `implement` stage **mutates** the repo (#768). Required with `action: implement`, and valid **only** there — a double-key so a typo/injection can't turn a read-only pipeline into a writing one. |
 | `stages[].orchestrate`      | stage        | no       | `true` makes an agent stage a **sub-tree coordinator** (#758): its `delegations[]` fan out as owned children and the stage waits for the whole tree, then folds the synthesis. Agent stage only; `action` must be `ask`. |
 | `stages[].gate`             | stage        | cond.    | Makes this a **jobless gate stage** (#768): it runs no worker and folds when an external predicate holds. Only `pr_merged` today. Exclusive with `cmd`/`agent`. Requires `source`. |
-| `stages[].source`           | stage        | cond.    | For a `gate` stage: the id of the upstream `implement` stage whose PR to watch. Must be one of the gate's own `needs`. |
+| `stages[].source`           | stage        | cond.    | The upstream `implement` stage whose PR to bind. Required on a `gate`; optional on `action: review`; rejected on shell/ask/implement/orchestrate stages. It must be one of the stage's own `needs`. |
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
@@ -2643,8 +2643,8 @@ non-name-safe name/id, a duplicate stage id, a stage that is not **exactly one**
 `cmd`, `agent`, or `gate` (and, per kind: an agent stage's missing `prompt`, an
 invalid `action`, `implement` without `write: true` or `write: true` off an
 implement stage, a mutating stage on a scheduled pipeline without
-`allow_scheduled_writes`, a gate's invalid predicate or a `source` that is not an
-upstream implement stage in `needs`), an unknown/self/cyclic `needs`, an invalid
+`allow_scheduled_writes`, a gate/review `source` that is not an upstream implement
+stage in `needs`, or `source` on another stage kind), an unknown/self/cyclic `needs`, an invalid
 timeout/interval/jitter, a negative retry, or a `success_decisions` value outside the
 allowed set — so a structural mistake surfaces as a clear error at registration
 rather than a stuck run later.
@@ -2701,9 +2701,12 @@ stages:
   `worktree:<path>` rather than the shared `repo:<repo>` live checkout — same-repo
   agent stages then run **concurrently** and never mutate the live checkout. The
   worktree is disposed when the stage job settles (and reclaimed on daemon restart).
-  Allocation is fail-open: if it cannot be created the stage still runs, serialized on
-  the shared checkout, with a loud skip event. A pure-reasoning agent stage with no
-  `repo` needs no worktree.
+  Allocation is fail-open for ordinary ask/review stages: if it cannot be created the
+  stage still runs, serialized on the shared checkout, with a loud skip event. A
+  source-bound PR review is the safety exception: its detached worktree is pinned to
+  the source payload's `HeadSHA`, validated clean at that exact SHA, and allocation
+  fails closed rather than reviewing the shared default branch. A pure-reasoning
+  agent stage with no `repo` needs no worktree.
 - **Stateless per run.** Because each agent stage runs in a freshly-created worktree
   directory, a runtime that scopes sessions by working directory (e.g. Claude Code)
   starts a **fresh session each run** — a pipeline stage carries no session context
@@ -2728,7 +2731,13 @@ stages:
   - id: verify
     agent: reviewer
     action: review
+    source: fix                       # bind to fix's PR + exact head SHA
     needs: [fix]
+    success_decisions: [approved]     # changes_requested parks before the merge gate
+  - id: wait
+    gate: pr_merged
+    source: fix
+    needs: [fix, verify]
 ```
 
 - **Writable worktree + deterministic branch reuse.** Unlike a read-only stage, an
@@ -2742,7 +2751,30 @@ stages:
   downstream stage sees it via upstream-context injection.
 - **Never auto-merges.** The pipeline **opens** the PR; a human or your CI does the
   merge. See [Gate stages](#gate-stages) to make a later stage wait for that merge.
+- **Declared review suppresses native fan-out.** When an implement stage has a
+  downstream `action: review` stage with `source` pointing to it, its job carries
+  `SkipNativeReviewFanout`. Gitmoot does not also enqueue the ordinary native
+  reviewers; without that declaration, native review behavior is unchanged.
 - Still a **leaf** — it may mutate but never fan out.
+
+### Source-bound review stages
+
+Set `source: <implement-stage>` on an `action: review` stage to review the PR that
+the implement stage just opened. `source` must also appear in the review stage's
+`needs`, and must name an `action: implement` stage.
+
+- At enqueue, Gitmoot reads the succeeded source stage row's `JobID`, parses that
+  job's structured payload stamp, and copies `PullRequest`, `HeadSHA`, `Branch`,
+  `TaskID`, and `LeadAgent` onto the review job. It never scrapes the stage summary.
+- The review runs in a detached read-only worktree at the stamped `HeadSHA` and the
+  existing review checkout preflight verifies that exact clean head.
+- The review is **report-only** for native PR lifecycle purposes. Its verdict is
+  still posted as a PR comment and folded by the pipeline's `success_decisions`, but
+  `changes_requested` does not dispatch a native fix job and `approved` does not run
+  the native merge gate. Human merge remains the default.
+- If the succeeded implement stage produced no PR (a permanent no-op or a first-class
+  `skipped` result), the review stage immediately folds `blocked` with
+  `source stage produced no PR; nothing to review`; no unbound review job is sent.
 
 ### Gate stages
 
@@ -10293,6 +10325,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     needs: [score]          #   upstream results are prepended to the prompt
   # other agent-stage kinds:
   #   implement (#768): action: implement + write: true → mutates repo + opens a PR (never auto-merges)
+  #   bound review (#813): action: review + source: <impl stage> -> reviews that PR/head, report-only
   #   orchestrate (#758): orchestrate: true → sub-tree coordinator (fans out owned children, folds synthesis)
   #   gate (#768): gate: pr_merged + source: <impl stage> (no agent) → jobless, folds when that PR merges
   - id: deploy
@@ -10318,8 +10351,8 @@ gitmoot pipeline remove nightly-sync
 `pipeline add` validates the whole spec at add time (unknown keys, duplicate/self/
 cyclic `needs`, a stage that is not exactly one of `cmd`/`agent`/`gate`, an agent stage
 missing a `prompt` / invalid `action` / `implement` without `write: true` / a mutating
-stage on a scheduled pipeline without `allow_scheduled_writes` / a gate's bad
-predicate or `source`, invalid durations, a `success_decisions` outside
+stage on a scheduled pipeline without `allow_scheduled_writes` / a gate or review's
+bad `source` / `source` on another stage kind, invalid durations, a `success_decisions` outside
 `approved`/`implemented`/`changes_requested`/`skipped`) so a mistake is a clear error, not a
 stuck run. It stores the raw YAML **verbatim** plus a content hash; each run
 snapshots that hash and executes its snapshot, so editing the file later never
@@ -10330,6 +10363,17 @@ runs a named managed agent on its own runtime as a read-only leaf (`ask`/`review
 its `needs` stages' result summaries are prepended to the prompt, and a repo-bound
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
+
+An `action: review` stage may set `source: <implement-stage>` (also listed in its
+`needs`) to bind to that implement job's structured PR stamp. The review payload
+inherits the PR number, head SHA, branch, task, and lead agent; its detached worktree
+is pinned to the exact PR head. The verdict still posts as a PR comment and folds by
+`success_decisions`, but pipeline reviews are report-only: they dispatch no native
+fix job and never run the native merge gate. Declaring this review also sets
+`SkipNativeReviewFanout` on the source implement request, avoiding duplicate native
+reviewer jobs. If the source permanently produces no PR (no-op or `skipped`), the
+review folds blocked immediately with `source stage produced no PR; nothing to
+review` and no unbound review is dispatched.
 
 `pipeline install-defaults` installs the built-in memory pipelines
 `memory-ingest-sweep` and `memory-groom-propose`. The daemon also runs this
@@ -11616,7 +11660,8 @@ exactly one of `cmd`, `agent`, or `gate`. An agent stage runs on its **own** reg
 runtime (claude / codex). Four kinds:
 
 - **ask / review** (#757) — read-only **leaf** (`action: ask|review`); `delegations[]`
-  and `human_questions[]` stripped. Model judgement inline in a deterministic flow.
+  and `human_questions[]` stripped. A review may add `source: <implement stage>`
+  (#813) to bind to that stage's PR and exact head SHA.
 - **implement** (#768) — `action: implement` + `write: true`. MUTATES the repo + opens a
   PR on a deterministic `gitmoot/pipe-<run>-<stage>` branch (retry reuses it, never
   duplicates), folds **on PR-opened**, **never auto-merges**. Scheduled pipelines also
@@ -11648,6 +11693,32 @@ stages:
     source: fix
     needs: [fix]
 ```
+
+To make review first-class between implementation and the human merge, insert a
+source-bound review before the gate:
+
+```yaml
+  - id: review
+    agent: reviewer
+    action: review
+    prompt: "Review the implementation PR."
+    source: fix
+    needs: [fix]
+    success_decisions: [approved]
+  - id: wait
+    gate: pr_merged
+    source: fix
+    needs: [fix, review]
+```
+
+The review job copies the structured PR/head/branch/task/lead stamp from the
+succeeded implement job and runs in a detached worktree pinned to that head. It is
+report-only: the verdict is posted to the PR and folded by the pipeline, but it does
+not dispatch a native fix job or run the native merge gate. The declared binding
+also sets `SkipNativeReviewFanout` on `fix`, preventing duplicate reviewer fan-out;
+pipelines without the declaration keep native behavior. A permanent no-PR source
+(no-op or `skipped`) blocks the review immediately with `source stage produced no
+PR; nothing to review` instead of dispatching an unbound job or waiting.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The


### PR DESCRIPTION
Closes #813.

Makes the **agent-review-before-human-merge rung first-class**: `[implement] → [review the PR] → [gate: pr_merged] → [deploy]`.

### What's new
- **`source:` on `action: review` stages** — the review job is handed the upstream implement stage's opened PR **natively** (PR number + head SHA + branch from the implement job's structured payload stamp), instead of prose-parsing "(opened PR #n)" and gh-fetching blind.
- **Reviews run at the PR head.** The stage's read-only worktree is allocated detached at the bound HeadSHA and checkout validation pins to that exact clean head — the silent resync-to-main wrong-tree hazard from the research panel cannot fire (regression-tested).
- **Report-only guard** (the panel's critical finding): pipeline review jobs never enter the native review lifecycle — `changes_requested` cannot spawn a fix job, `approved` cannot reach the merge gate (which could **merge the PR** and violate the human-merge invariant). The verdict still folds by decision and still auto-posts as a PR comment. The guard is the single commented seam where the owner-approved `merge: auto` mode (follow-up) will branch.
- **No-PR sources fold blocked** with an actionable need (permanent no-op and #815 `skipped` sources) — never an unbound review, never an indefinite wait.
- **No double review:** `SkipNativeReviewFanout` is set on the implement stage only when the spec declares a downstream source-bound review of that stage.
- **Validation tightening:** a stray `source:` on any non-gate/non-review stage is now an add-time error (was silently ignored).
- **Crash-replay hardening** (found by the adversarial reviewer): bound-review enqueue adopts the deterministic existing job *before* re-allocating its pinned worktree — a scan dying between enqueue and stage-row persist can no longer wedge the run (fault-injection test).

Out of scope by design: `merge: auto` (next PR, on the guard seam) and orchestrate-stage binding (deferred per panel consensus).

### Verification
- 11 new tests incl. a **shell-runtime E2E** (implement stamps PR → review binds + pins worktree → report-only fold) and the fault-injection replay test.
- Adversarial review (gpt-5.6-sol @ xhigh): 7/8 areas cleared with citations; the 1 blocking crash-replay finding fixed + regression-tested before this PR.
- Independent runs: build, vet, pipeline/workflow/db suites, uncached cli suite ×2 (259s, 267s).

### Docs (same PR)
`docs/pipelines.md`, skills `CLI.md` + `WORKFLOWS.md`, website `pipelines-workflow.md`, regenerated `llms-full.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
