### PR TITLE
fix(repo): checkout registration guard + self-heal dangling checkouts (#831)

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -7489,6 +7489,10 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 	if err != nil {
 		return "", err
 	}
+	checkout, err = w.healRegisteredRepoCheckout(ctx, job, repo, repoRecord)
+	if err != nil {
+		return "", err
+	}
 	if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
 		return "", err
 	}
@@ -7503,6 +7507,58 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 		}
 	}
 	return checkout, nil
+}
+
+func (w jobWorker) healRegisteredRepoCheckout(ctx context.Context, job db.Job, repo github.Repository, record db.Repo) (string, error) {
+	checkout := strings.TrimSpace(record.CheckoutPath)
+	if _, err := os.Stat(checkout); err == nil {
+		if strings.TrimSpace(record.PrimaryCheckoutPath) == "" {
+			if primary, primaryErr := (gitutil.Client{Dir: checkout}).PrimaryWorktree(ctx); primaryErr == nil {
+				if _, healErr := w.Store.HealRepoCheckout(ctx, record.FullName(), checkout, checkout, primary); healErr != nil {
+					return "", healErr
+				}
+			}
+		}
+		return checkout, nil
+	} else if !os.IsNotExist(err) {
+		return checkout, nil
+	}
+
+	primary := strings.TrimSpace(record.PrimaryCheckoutPath)
+	if primary == "" || sameCheckoutPath(primary, checkout) {
+		return checkout, nil
+	}
+	if _, err := os.Stat(primary); err != nil {
+		return checkout, nil
+	}
+	verified, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: primary})
+	if err != nil {
+		return "", fmt.Errorf("verify primary checkout for %s: %w", repo.FullName(), err)
+	}
+	healedPath := strings.TrimSpace(verified.CheckoutPath)
+	healed, err := w.Store.HealRepoCheckout(ctx, repo.FullName(), checkout, healedPath, healedPath)
+	if err != nil {
+		return "", err
+	}
+	if !healed {
+		current, err := w.Store.GetRepo(ctx, repo.FullName())
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(current.CheckoutPath), nil
+	}
+	message := fmt.Sprintf("repo %s checkout self-healed from %s to %s", repo.FullName(), checkout, healedPath)
+	if err := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "repo_checkout_self_healed", Message: message}); err != nil {
+		return "", err
+	}
+	if w.Stdout != nil {
+		writeLine(w.Stdout, "WARN: %s", message)
+	}
+	return healedPath, nil
+}
+
+func sameCheckoutPath(a, b string) bool {
+	return filepath.Clean(strings.TrimSpace(a)) == filepath.Clean(strings.TrimSpace(b))
 }
 
 func (w jobWorker) taskWorktreeCheckout(ctx context.Context, payload workflow.JobPayload) (string, bool, error) {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -7014,6 +7014,48 @@ func TestWarnSerializedParallelJobsSilentBelowTwo(t *testing.T) {
 	}
 }
 
+func TestResolveJobCheckoutSelfHealsDanglingLinkedWorktree(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	primary, linked := setupLinkedWorktreeRepo(t)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepoForce(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: linked, PrimaryCheckoutPath: primary}); err != nil {
+		t.Fatalf("UpsertRepoForce returned error: %v", err)
+	}
+	job := db.Job{ID: "job-checkout-heal", Agent: "audit", Type: "ask", State: string(workflow.JobQueued), Payload: `{"repo":"owner/repo"}`}
+	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent returned error: %v", err)
+	}
+	runGit(t, primary, "worktree", "remove", "--force", linked)
+	var output bytes.Buffer
+	worker := jobWorker{Store: store, Stdout: &output}
+	checkout, err := worker.resolveJobCheckout(ctx, job, workflow.JobPayload{Repo: "owner/repo"})
+	if err != nil {
+		t.Fatalf("resolveJobCheckout returned error: %v", err)
+	}
+	if checkout != primary {
+		t.Fatalf("checkout = %q, want healed primary %q", checkout, primary)
+	}
+	record, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil {
+		t.Fatalf("GetRepo returned error: %v", err)
+	}
+	if record.CheckoutPath != primary || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("healed record = %+v", record)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	if !daemonWorkerHasEvent(events, "repo_checkout_self_healed") {
+		t.Fatalf("events = %+v, want repo_checkout_self_healed", events)
+	}
+	if !strings.Contains(output.String(), "WARN:") || !strings.Contains(output.String(), linked) || !strings.Contains(output.String(), primary) {
+		t.Fatalf("warning output = %q", output.String())
+	}
+}
+
 // TestJobStateEligibleForWorktreeReclaim pins the #739-review fix that the
 // worktree reclaim pass also disposes a CANCELLED job's dispatch-allocated
 // read-only worktree, while keeping cancelled OUT of advancement re-run.

--- a/internal/cli/doctor_json_test.go
+++ b/internal/cli/doctor_json_test.go
@@ -11,6 +11,7 @@ import (
 // with name/status/ok/required/detail) instead of erroring with
 // "flag provided but not defined: -json".
 func TestDoctorJSONOutput(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	var stdout, stderr bytes.Buffer
 	// --repo at a temp dir keeps the run local; individual checks may warn/fail (no
 	// git remote, etc.) but the JSON shape is what this test asserts.

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/daemon"
@@ -65,7 +66,7 @@ func parseRepoPositional(fs *flag.FlagSet, command string, args []string, string
 
 func printRepoUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot repo add owner/repo --path <path> [--poll 30s]")
+	fmt.Fprintln(w, "  gitmoot repo add owner/repo --path <path> [--poll 30s] [--force]")
 	fmt.Fprintln(w, "  gitmoot repo list")
 	fmt.Fprintln(w, "  gitmoot repo remove owner/repo")
 	fmt.Fprintln(w, "  gitmoot repo doctor owner/repo")
@@ -79,6 +80,7 @@ func runRepoAdd(args []string, stdout, stderr io.Writer) int {
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	path := fs.String("path", ".", "local checkout path")
 	poll := fs.Duration("poll", 30*time.Second, "poll interval")
+	force := fs.Bool("force", false, "allow a linked worktree to replace the registered checkout")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		fs.Usage()
 		if len(args) == 0 {
@@ -105,8 +107,27 @@ func runRepoAdd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "repo add: %v\n", err)
 		return 1
 	}
+	client := gitutil.Client{Dir: record.CheckoutPath}
+	primary, err := client.PrimaryWorktree(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "repo add: resolve primary worktree: %v\n", err)
+		return 1
+	}
+	record.PrimaryCheckoutPath = primary
+	linked, err := client.IsLinkedWorktree(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "repo add: detect linked worktree: %v\n", err)
+		return 1
+	}
+	if linked && !*force {
+		fmt.Fprintf(stderr, "repo add: %s is a linked worktree; register the primary checkout at %s instead (use --force to override)\n", record.CheckoutPath, primary)
+		return 1
+	}
 	record.PollInterval = poll.String()
 	if err := withStore(*home, func(store *db.Store) error {
+		if *force {
+			return store.UpsertRepoForce(context.Background(), record)
+		}
 		return store.UpsertRepo(context.Background(), record)
 	}); err != nil {
 		fmt.Fprintf(stderr, "repo add: %v\n", err)
@@ -221,18 +242,74 @@ func runRepoDoctor(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "repo doctor: %v\n", err)
 		return 1
 	}
+	primary, linked, checkoutErr := inspectRegisteredRepoCheckout(context.Background(), nil, record)
+	if checkoutErr != nil {
+		writeLine(stdout, "repo: %s warn", repo.FullName())
+		writeLine(stdout, "path: %s", checkoutErr)
+		if strings.TrimSpace(record.PrimaryCheckoutPath) != "" {
+			writeLine(stdout, "primary: %s", record.PrimaryCheckoutPath)
+		}
+		return 1
+	}
+	if strings.TrimSpace(record.PrimaryCheckoutPath) == "" {
+		if err := withStore(*home, func(store *db.Store) error {
+			_, err := store.HealRepoCheckout(context.Background(), record.FullName(), record.CheckoutPath, record.CheckoutPath, primary)
+			return err
+		}); err != nil {
+			fmt.Fprintf(stderr, "repo doctor: backfill primary checkout: %v\n", err)
+			return 1
+		}
+	}
 	validated, err := repoRecordFromPath(context.Background(), repo, record.CheckoutPath)
 	if err != nil {
 		fmt.Fprintf(stderr, "repo doctor: %v\n", err)
 		return 1
 	}
+	if linked {
+		writeLine(stdout, "repo: %s warn", repo.FullName())
+		writeLine(stdout, "path: %s is a linked worktree", validated.CheckoutPath)
+		writeLine(stdout, "primary: %s", primary)
+		return 1
+	}
 	writeLine(stdout, "repo: %s ok", repo.FullName())
 	writeLine(stdout, "path: %s", validated.CheckoutPath)
+	writeLine(stdout, "primary: %s", primary)
 	writeLine(stdout, "remote: %s", validated.RemoteURL)
 	if validated.DefaultBranch != "" {
 		writeLine(stdout, "branch: %s", validated.DefaultBranch)
 	}
 	return 0
+}
+
+func inspectRegisteredRepoCheckout(ctx context.Context, store *db.Store, record db.Repo) (string, bool, error) {
+	checkout := strings.TrimSpace(record.CheckoutPath)
+	if checkout == "" {
+		return "", false, fmt.Errorf("registered checkout is empty")
+	}
+	if _, err := os.Stat(checkout); err != nil {
+		if os.IsNotExist(err) {
+			return "", false, fmt.Errorf("registered checkout %s is missing", checkout)
+		}
+		return "", false, fmt.Errorf("inspect registered checkout %s: %w", checkout, err)
+	}
+	client := gitutil.Client{Dir: checkout}
+	linked, err := client.IsLinkedWorktree(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	primary := strings.TrimSpace(record.PrimaryCheckoutPath)
+	if primary == "" {
+		primary, err = client.PrimaryWorktree(ctx)
+		if err != nil {
+			return "", false, err
+		}
+		if store != nil {
+			if _, err := store.HealRepoCheckout(ctx, record.FullName(), checkout, checkout, primary); err != nil {
+				return "", false, err
+			}
+		}
+	}
+	return primary, linked, nil
 }
 
 func repoRecordFromPath(ctx context.Context, repo github.Repository, path string) (db.Repo, error) {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -2,9 +2,14 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
 )
 
 func TestRunRepoAddListDoctorRemove(t *testing.T) {
@@ -115,5 +120,120 @@ func TestRunRepoAddRejectsWrongOrigin(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "not jerryfane/gitmoot") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunRepoAddRefusesLinkedWorktreeUnlessForced(t *testing.T) {
+	home := t.TempDir()
+	primary, linked := setupLinkedWorktreeRepo(t)
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"repo", "add", "owner/repo", "--home", home, "--path", primary}, &stdout, &stderr); code != 0 {
+		t.Fatalf("primary repo add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"repo", "add", "owner/repo", "--home", home, "--path", linked}, &stdout, &stderr); code != 1 {
+		t.Fatalf("linked repo add exit code = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"linked worktree", primary, "--force"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("linked refusal missing %q: %s", want, stderr.String())
+		}
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"repo", "add", "owner/repo", "--home", home, "--path", linked, "--force"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("forced linked repo add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	record, err := store.GetRepo(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("GetRepo returned error: %v", err)
+	}
+	if record.CheckoutPath != linked || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("forced record = %+v", record)
+	}
+}
+
+func TestRunRepoDoctorReportsLinkedAndDanglingCheckout(t *testing.T) {
+	home := t.TempDir()
+	primary, linked := setupLinkedWorktreeRepo(t)
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"repo", "add", "owner/repo", "--home", home, "--path", linked, "--force"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("forced repo add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"repo", "doctor", "owner/repo", "--home", home}, &stdout, &stderr); code != 1 {
+		t.Fatalf("linked repo doctor exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"repo: owner/repo warn", "linked worktree", "primary: " + primary} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("linked repo doctor missing %q: %s", want, stdout.String())
+		}
+	}
+	runGit(t, primary, "worktree", "remove", "--force", linked)
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"repo", "doctor", "owner/repo", "--home", home}, &stdout, &stderr); code != 1 {
+		t.Fatalf("dangling repo doctor exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "is missing") || !strings.Contains(stdout.String(), "primary: "+primary) {
+		t.Fatalf("dangling repo doctor output = %s", stdout.String())
+	}
+}
+
+func TestRepoCheckoutDoctorChecksWarnAndLazyBackfill(t *testing.T) {
+	home := t.TempDir()
+	primary, linked := setupLinkedWorktreeRepo(t)
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertRepoForce(context.Background(), db.Repo{Owner: "owner", Name: "repo", CheckoutPath: linked}); err != nil {
+		t.Fatalf("UpsertRepoForce returned error: %v", err)
+	}
+	if _, err := store.HealRepoCheckout(context.Background(), "owner/repo", linked, linked, ""); err != nil {
+		t.Fatalf("clear primary checkout returned error: %v", err)
+	}
+	store.Close()
+	checks := repoCheckoutDoctorChecks(config.PathsForHome(home))
+	if len(checks) != 1 || checks[0].OK || !strings.Contains(checks[0].Detail, "linked worktree") {
+		t.Fatalf("checks = %+v", checks)
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	record, err := store.GetRepo(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("GetRepo returned error: %v", err)
+	}
+	if record.PrimaryCheckoutPath != primary {
+		t.Fatalf("lazy primary backfill = %q, want %q", record.PrimaryCheckoutPath, primary)
+	}
+	runGit(t, primary, "worktree", "remove", "--force", linked)
+	checks = repoCheckoutDoctorChecks(config.PathsForHome(home))
+	if len(checks) != 1 || checks[0].OK || !strings.Contains(checks[0].Detail, "is missing") || !strings.Contains(checks[0].Detail, "is available") {
+		t.Fatalf("dangling checks = %+v", checks)
+	}
+}
+
+func setupLinkedWorktreeRepo(t *testing.T) (string, string) {
+	t.Helper()
+	primary := t.TempDir()
+	runGit(t, primary, "init", "-b", "main")
+	runGit(t, primary, "config", "user.email", "gitmoot@example.com")
+	runGit(t, primary, "config", "user.name", "Gitmoot")
+	runGit(t, primary, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	runGit(t, primary, "commit", "--allow-empty", "-m", "init")
+	linked := filepath.Join(t.TempDir(), "linked")
+	runGit(t, primary, "worktree", "add", "-b", "task", linked)
+	return filepath.Clean(primary), filepath.Clean(linked)
+}
+
+func TestRepoCheckoutDoctorChecksSkipMissingDatabase(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if checks := repoCheckoutDoctorChecks(paths); len(checks) != 0 {
+		t.Fatalf("checks = %+v, want none", checks)
+	}
+	if _, err := os.Stat(paths.Database); !os.IsNotExist(err) {
+		t.Fatalf("doctor sweep created database: %v", err)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,6 +7,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -150,6 +152,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	if check, ok := blockedBacklogDoctorCheck(paths); ok {
 		checks = append(checks, check)
 	}
+	checks = append(checks, repoCheckoutDoctorChecks(paths)...)
 	if *jsonOutput {
 		type checkJSON struct {
 			Name     string `json:"name"`
@@ -197,6 +200,49 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+// repoCheckoutDoctorChecks is the store-aware aggregate sweep for `gitmoot
+// doctor`. It stays in the CLI layer so the doctor package remains store-less.
+func repoCheckoutDoctorChecks(paths config.Paths) []doctor.Check {
+	if strings.TrimSpace(paths.Database) == "" {
+		return nil
+	}
+	if _, err := os.Stat(paths.Database); err != nil {
+		return nil
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		return nil
+	}
+	defer store.Close()
+	repos, err := store.ListRepos(context.Background())
+	if err != nil {
+		return nil
+	}
+	checks := make([]doctor.Check, 0, len(repos))
+	for _, repo := range repos {
+		primary, linked, err := inspectRegisteredRepoCheckout(context.Background(), store, repo)
+		check := doctor.Check{Name: "repo checkout", Required: false}
+		switch {
+		case err != nil:
+			check.Detail = fmt.Sprintf("%s: %v", repo.FullName(), err)
+			if recorded := strings.TrimSpace(repo.PrimaryCheckoutPath); recorded != "" {
+				if _, statErr := os.Stat(recorded); statErr == nil {
+					check.Detail += fmt.Sprintf("; primary checkout %s is available", recorded)
+				} else {
+					check.Detail += fmt.Sprintf("; primary checkout %s is unavailable", recorded)
+				}
+			}
+		case linked:
+			check.Detail = fmt.Sprintf("%s: registered checkout %s is a linked worktree; use primary checkout %s", repo.FullName(), repo.CheckoutPath, primary)
+		default:
+			check.OK = true
+			check.Detail = fmt.Sprintf("%s: registered checkout %s is primary", repo.FullName(), repo.CheckoutPath)
+		}
+		checks = append(checks, check)
+	}
+	return checks
 }
 
 func pathsFromFlag(home string) (config.Paths, error) {

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -146,6 +146,22 @@ CREATE TABLE agents (
 CREATE TABLE agent_instances (
 	name TEXT PRIMARY KEY
 );
+-- A minimal repos table (as it existed at the input_tokens migration point) so
+-- the later #831 primary_checkout_path ALTER ADD COLUMN that runs in this pass
+-- has its table; the real table was created by an earlier (here pre-seeded-as-
+-- applied) migration.
+CREATE TABLE repos (
+	owner TEXT NOT NULL,
+	name TEXT NOT NULL,
+	full_name TEXT NOT NULL,
+	default_branch TEXT NOT NULL DEFAULT 'main',
+	remote_url TEXT NOT NULL DEFAULT '',
+	checkout_path TEXT NOT NULL DEFAULT '',
+	enabled INTEGER NOT NULL DEFAULT 1,
+	poll_interval TEXT NOT NULL DEFAULT '',
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (owner, name)
+);
 -- job_events as it existed at an earlier (here pre-seeded-as-applied) migration,
 -- so the #549 job_events index migration that runs in this pass has its table.
 CREATE TABLE job_events (

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -11,8 +11,12 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
+
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
 
 	_ "modernc.org/sqlite"
 )
@@ -27,10 +31,14 @@ type Repo struct {
 	DefaultBranch string
 	RemoteURL     string
 	CheckoutPath  string
-	Enabled       bool
-	PollInterval  string
-	LastPollAt    string
-	LastError     string
+	// PrimaryCheckoutPath is the durable first non-bare checkout reported by
+	// `git worktree list --porcelain`. It lets dispatch recover when a mistakenly
+	// registered linked worktree has been removed.
+	PrimaryCheckoutPath string
+	Enabled             bool
+	PollInterval        string
+	LastPollAt          string
+	LastError           string
 }
 
 type Agent struct {
@@ -737,32 +745,76 @@ func (s *Store) applyMigration(ctx context.Context, version int, migration strin
 }
 
 func (s *Store) UpsertRepo(ctx context.Context, repo Repo) error {
+	return s.upsertRepo(ctx, repo, false)
+}
+
+// UpsertRepoForce deliberately bypasses linked-worktree overwrite protection.
+// It is reserved for the explicit `repo add --force` operator path.
+func (s *Store) UpsertRepoForce(ctx context.Context, repo Repo) error {
+	return s.upsertRepo(ctx, repo, true)
+}
+
+func (s *Store) upsertRepo(ctx context.Context, repo Repo, force bool) error {
 	fullName := repo.Owner + "/" + repo.Name
+	if strings.TrimSpace(repo.CheckoutPath) != "" && strings.TrimSpace(repo.PrimaryCheckoutPath) == "" {
+		if primary, err := (gitutil.Client{Dir: repo.CheckoutPath}).PrimaryWorktree(ctx); err == nil {
+			repo.PrimaryCheckoutPath = primary
+		}
+	}
+	if !force && strings.TrimSpace(repo.CheckoutPath) != "" {
+		if existing, err := s.GetRepo(ctx, fullName); err == nil && shouldProtectRepoCheckout(existing, repo.CheckoutPath) {
+			if linked, linkErr := (gitutil.Client{Dir: repo.CheckoutPath}).IsLinkedWorktree(ctx); linkErr == nil && linked {
+				log.Printf("WARNING: keeping registered checkout for %s at %s; refusing linked worktree %s (use gitmoot repo add --force to override)", fullName, existing.CheckoutPath, repo.CheckoutPath)
+				repo.CheckoutPath = ""
+				repo.PrimaryCheckoutPath = ""
+			}
+		}
+	}
 	updatePollInterval := repo.PollInterval
 	insertPollInterval := repo.PollInterval
 	if strings.TrimSpace(insertPollInterval) == "" {
 		insertPollInterval = "30s"
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO repos(owner, name, full_name, default_branch, remote_url, checkout_path, enabled, poll_interval, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, 1, ?, CURRENT_TIMESTAMP)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO repos(owner, name, full_name, default_branch, remote_url, checkout_path, primary_checkout_path, enabled, poll_interval, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(full_name) DO UPDATE SET
 			default_branch = CASE WHEN excluded.default_branch <> '' THEN excluded.default_branch ELSE repos.default_branch END,
 			remote_url = CASE WHEN excluded.remote_url <> '' THEN excluded.remote_url ELSE repos.remote_url END,
 			checkout_path = CASE WHEN excluded.checkout_path <> '' THEN excluded.checkout_path ELSE repos.checkout_path END,
+			primary_checkout_path = CASE WHEN excluded.primary_checkout_path <> '' THEN excluded.primary_checkout_path ELSE repos.primary_checkout_path END,
 			poll_interval = CASE WHEN ? <> '' THEN excluded.poll_interval ELSE repos.poll_interval END,
 			updated_at = CURRENT_TIMESTAMP`,
-		repo.Owner, repo.Name, fullName, repo.DefaultBranch, repo.RemoteURL, repo.CheckoutPath, insertPollInterval, updatePollInterval)
+		repo.Owner, repo.Name, fullName, repo.DefaultBranch, repo.RemoteURL, repo.CheckoutPath, repo.PrimaryCheckoutPath, insertPollInterval, updatePollInterval)
 	return err
 }
 
+func shouldProtectRepoCheckout(existing Repo, incoming string) bool {
+	if sameRepoCheckoutPath(existing.CheckoutPath, incoming) {
+		return false
+	}
+	if info, err := os.Stat(strings.TrimSpace(existing.CheckoutPath)); err == nil && info.IsDir() {
+		return true
+	}
+	return strings.TrimSpace(existing.PrimaryCheckoutPath) != "" && sameRepoCheckoutPath(existing.CheckoutPath, existing.PrimaryCheckoutPath)
+}
+
+func sameRepoCheckoutPath(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
 func (s *Store) GetRepo(ctx context.Context, fullName string) (Repo, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT owner, name, default_branch, remote_url, checkout_path, enabled, poll_interval, last_poll_at, last_error
+	row := s.db.QueryRowContext(ctx, `SELECT owner, name, default_branch, remote_url, checkout_path, primary_checkout_path, enabled, poll_interval, last_poll_at, last_error
 		FROM repos WHERE full_name = ?`, fullName)
 	return scanRepo(row)
 }
 
 func (s *Store) ListRepos(ctx context.Context) ([]Repo, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT owner, name, default_branch, remote_url, checkout_path, enabled, poll_interval, last_poll_at, last_error
+	rows, err := s.db.QueryContext(ctx, `SELECT owner, name, default_branch, remote_url, checkout_path, primary_checkout_path, enabled, poll_interval, last_poll_at, last_error
 		FROM repos ORDER BY full_name`)
 	if err != nil {
 		return nil, err
@@ -777,6 +829,24 @@ func (s *Store) ListRepos(ctx context.Context) ([]Repo, error) {
 		repos = append(repos, repo)
 	}
 	return repos, rows.Err()
+}
+
+// HealRepoCheckout atomically replaces a repo checkout only when it still has
+// the path the caller observed. The compare guard prevents a concurrent,
+// deliberate re-registration from being overwritten by a stale healer.
+func (s *Store) HealRepoCheckout(ctx context.Context, fullName, expectedCheckoutPath, checkoutPath, primaryCheckoutPath string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `UPDATE repos
+		SET checkout_path = ?, primary_checkout_path = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE full_name = ? AND checkout_path = ?`,
+		strings.TrimSpace(checkoutPath), strings.TrimSpace(primaryCheckoutPath), strings.TrimSpace(fullName), strings.TrimSpace(expectedCheckoutPath))
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
 }
 
 func (s *Store) SetRepoEnabled(ctx context.Context, fullName string, enabled bool) error {
@@ -814,7 +884,7 @@ func (s *Store) RemoveRepo(ctx context.Context, fullName string) (bool, error) {
 func scanRepo(row interface{ Scan(dest ...any) error }) (Repo, error) {
 	var repo Repo
 	var enabled int
-	if err := row.Scan(&repo.Owner, &repo.Name, &repo.DefaultBranch, &repo.RemoteURL, &repo.CheckoutPath, &enabled, &repo.PollInterval, &repo.LastPollAt, &repo.LastError); err != nil {
+	if err := row.Scan(&repo.Owner, &repo.Name, &repo.DefaultBranch, &repo.RemoteURL, &repo.CheckoutPath, &repo.PrimaryCheckoutPath, &enabled, &repo.PollInterval, &repo.LastPollAt, &repo.LastError); err != nil {
 		return Repo{}, err
 	}
 	repo.Enabled = enabled != 0
@@ -8449,5 +8519,10 @@ CREATE UNIQUE INDEX idx_confirmed_general_key ON confirmed_memories(owner_kind, 
 	`
 ALTER TABLE agents ADD COLUMN effort TEXT NOT NULL DEFAULT '';
 ALTER TABLE agent_instances ADD COLUMN effort TEXT NOT NULL DEFAULT '';
+	`,
+	// #831 durable repo checkout recovery. Existing rows lazily backfill this on
+	// their next healthy registration, doctor pass, or dispatch touch.
+	`
+ALTER TABLE repos ADD COLUMN primary_checkout_path TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math/rand"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -2065,14 +2066,14 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	defer store.Close()
 
-	if err := store.UpsertRepo(ctx, Repo{Owner: "jerryfane", Name: "gitmoot", DefaultBranch: "main", RemoteURL: "https://github.com/jerryfane/gitmoot.git", CheckoutPath: "/repo/gitmoot"}); err != nil {
+	if err := store.UpsertRepo(ctx, Repo{Owner: "jerryfane", Name: "gitmoot", DefaultBranch: "main", RemoteURL: "https://github.com/jerryfane/gitmoot.git", CheckoutPath: "/repo/gitmoot", PrimaryCheckoutPath: "/repo/gitmoot"}); err != nil {
 		t.Fatalf("UpsertRepo returned error: %v", err)
 	}
 	repo, err := store.GetRepo(ctx, "jerryfane/gitmoot")
 	if err != nil {
 		t.Fatalf("GetRepo returned error: %v", err)
 	}
-	if repo.FullName() != "jerryfane/gitmoot" || repo.DefaultBranch != "main" || repo.RemoteURL == "" || repo.CheckoutPath != "/repo/gitmoot" || !repo.Enabled || repo.PollInterval != "30s" {
+	if repo.FullName() != "jerryfane/gitmoot" || repo.DefaultBranch != "main" || repo.RemoteURL == "" || repo.CheckoutPath != "/repo/gitmoot" || repo.PrimaryCheckoutPath != "/repo/gitmoot" || !repo.Enabled || repo.PollInterval != "30s" {
 		t.Fatalf("repo = %+v", repo)
 	}
 	if err := store.UpsertRepo(ctx, Repo{Owner: "jerryfane", Name: "gitmoot", PollInterval: "1m"}); err != nil {
@@ -2658,6 +2659,89 @@ func TestRepositoryMethods(t *testing.T) {
 	}
 	if removed {
 		t.Fatal("second RemoveAgent removed missing agent")
+	}
+}
+
+func TestHealRepoCheckoutRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertRepoForce(ctx, Repo{Owner: "owner", Name: "repo", CheckoutPath: "/tmp/deleted-linked", PrimaryCheckoutPath: "/repo/primary"}); err != nil {
+		t.Fatalf("UpsertRepoForce returned error: %v", err)
+	}
+	healed, err := store.HealRepoCheckout(ctx, "owner/repo", "/tmp/deleted-linked", "/repo/primary", "/repo/primary")
+	if err != nil {
+		t.Fatalf("HealRepoCheckout returned error: %v", err)
+	}
+	if !healed {
+		t.Fatal("HealRepoCheckout reported no update")
+	}
+	repo, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil {
+		t.Fatalf("GetRepo returned error: %v", err)
+	}
+	if repo.CheckoutPath != "/repo/primary" || repo.PrimaryCheckoutPath != "/repo/primary" {
+		t.Fatalf("repo after heal = %+v", repo)
+	}
+	healed, err = store.HealRepoCheckout(ctx, "owner/repo", "/tmp/deleted-linked", "/wrong", "/wrong")
+	if err != nil {
+		t.Fatalf("stale HealRepoCheckout returned error: %v", err)
+	}
+	if healed {
+		t.Fatal("stale HealRepoCheckout overwrote a changed checkout")
+	}
+}
+
+func TestUpsertRepoProtectsPrimaryCheckoutFromLinkedWorktree(t *testing.T) {
+	ctx := context.Background()
+	primary := t.TempDir()
+	runStoreGit(t, primary, "init", "-b", "main")
+	runStoreGit(t, primary, "config", "user.email", "gitmoot@example.com")
+	runStoreGit(t, primary, "config", "user.name", "Gitmoot")
+	runStoreGit(t, primary, "commit", "--allow-empty", "-m", "init")
+	linked := filepath.Join(t.TempDir(), "linked")
+	runStoreGit(t, primary, "worktree", "add", "-b", "task", linked)
+
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer store.Close()
+	base := Repo{Owner: "owner", Name: "repo", CheckoutPath: primary, PrimaryCheckoutPath: primary}
+	if err := store.UpsertRepo(ctx, base); err != nil {
+		t.Fatalf("UpsertRepo primary returned error: %v", err)
+	}
+	if err := store.UpsertRepo(ctx, Repo{Owner: "owner", Name: "repo", CheckoutPath: linked, PrimaryCheckoutPath: "/wrong-primary"}); err != nil {
+		t.Fatalf("UpsertRepo linked returned error: %v", err)
+	}
+	repo, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil {
+		t.Fatalf("GetRepo returned error: %v", err)
+	}
+	if repo.CheckoutPath != primary || repo.PrimaryCheckoutPath != primary {
+		t.Fatalf("guarded repo = %+v, want checkout and primary %q", repo, primary)
+	}
+	if err := store.UpsertRepoForce(ctx, Repo{Owner: "owner", Name: "repo", CheckoutPath: linked, PrimaryCheckoutPath: primary}); err != nil {
+		t.Fatalf("UpsertRepoForce linked returned error: %v", err)
+	}
+	repo, err = store.GetRepo(ctx, "owner/repo")
+	if err != nil {
+		t.Fatalf("GetRepo after force returned error: %v", err)
+	}
+	if repo.CheckoutPath != linked {
+		t.Fatalf("forced checkout = %q, want linked %q", repo.CheckoutPath, linked)
+	}
+}
+
+func runStoreGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
 	}
 }
 

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -280,6 +281,81 @@ func (c Client) Root(ctx context.Context) (string, error) {
 		return "", errors.New("git root is empty")
 	}
 	return root, nil
+}
+
+// IsLinkedWorktree reports whether c.Dir is a linked worktree rather than the
+// primary checkout. Git 2.31 added --path-format=absolute; older versions fall
+// back to resolving git-dir/common-dir relative to the client directory.
+func (c Client) IsLinkedWorktree(ctx context.Context) (bool, error) {
+	result, err := c.run(ctx, "rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir")
+	if err != nil {
+		result, err = c.run(ctx, "rev-parse", "--git-dir", "--git-common-dir")
+		if err != nil {
+			return false, err
+		}
+	}
+	paths := strings.Split(strings.TrimSpace(result.Stdout), "\n")
+	if len(paths) != 2 {
+		return false, fmt.Errorf("git rev-parse returned %d paths, want 2", len(paths))
+	}
+	gitDir, err := c.absoluteGitPath(paths[0])
+	if err != nil {
+		return false, err
+	}
+	commonDir, err := c.absoluteGitPath(paths[1])
+	if err != nil {
+		return false, err
+	}
+	return gitDir != commonDir, nil
+}
+
+// PrimaryWorktree returns the first non-bare record from git's porcelain
+// worktree list. Git writes the primary checkout first. A worktree-only repo
+// with no non-bare record falls back to the current checkout.
+func (c Client) PrimaryWorktree(ctx context.Context) (string, error) {
+	result, err := c.run(ctx, "worktree", "list", "--porcelain")
+	if err != nil {
+		return "", err
+	}
+	for _, record := range strings.Split(strings.TrimSpace(result.Stdout), "\n\n") {
+		var worktree string
+		bare := false
+		for _, line := range strings.Split(record, "\n") {
+			switch {
+			case strings.HasPrefix(line, "worktree "):
+				worktree = strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+			case strings.TrimSpace(line) == "bare":
+				bare = true
+			}
+		}
+		if worktree != "" && !bare {
+			absolute, err := c.absoluteGitPath(worktree)
+			if err != nil {
+				return "", err
+			}
+			return absolute, nil
+		}
+	}
+	return c.Root(ctx)
+}
+
+func (c Client) absoluteGitPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("git path is empty")
+	}
+	if !filepath.IsAbs(path) {
+		base := strings.TrimSpace(c.Dir)
+		if base == "" {
+			base = "."
+		}
+		path = filepath.Join(base, path)
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(absolute), nil
 }
 
 func (c Client) OriginRemote(ctx context.Context) (string, error) {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -66,6 +66,82 @@ func TestClientUsesSharedSubprocessRunner(t *testing.T) {
 	runner.wantArgs(t, 8, "git", "pull", "--ff-only", "origin", "main")
 }
 
+func TestClientIsLinkedWorktree(t *testing.T) {
+	tests := []struct {
+		name       string
+		results    []subprocess.Result
+		errs       []error
+		wantLinked bool
+		wantCalls  [][]string
+	}{
+		{
+			name:       "primary absolute paths match",
+			results:    []subprocess.Result{{Stdout: "/repo/.git\n/repo/.git\n"}},
+			wantLinked: false,
+			wantCalls:  [][]string{{"git", "rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"}},
+		},
+		{
+			name:       "linked absolute paths differ",
+			results:    []subprocess.Result{{Stdout: "/repo/.git/worktrees/task\n/repo/.git\n"}},
+			wantLinked: true,
+			wantCalls:  [][]string{{"git", "rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"}},
+		},
+		{
+			name:       "old git fallback resolves relative paths",
+			results:    []subprocess.Result{{}, {Stdout: ".git\n.git\n"}},
+			errs:       []error{errors.New("unknown option"), nil},
+			wantLinked: false,
+			wantCalls: [][]string{
+				{"git", "rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"},
+				{"git", "rev-parse", "--git-dir", "--git-common-dir"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeRunner{results: tc.results, errs: tc.errs}
+			linked, err := (Client{Runner: runner, Dir: "/repo"}).IsLinkedWorktree(context.Background())
+			if err != nil {
+				t.Fatalf("IsLinkedWorktree returned error: %v", err)
+			}
+			if linked != tc.wantLinked {
+				t.Fatalf("linked = %t, want %t", linked, tc.wantLinked)
+			}
+			for i, call := range tc.wantCalls {
+				runner.wantArgs(t, i, call...)
+			}
+		})
+	}
+}
+
+func TestClientPrimaryWorktree(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "worktree /repo\nHEAD abc\nbranch refs/heads/main\n\nworktree /repo-linked\nHEAD def\nbranch refs/heads/task\n"}}}
+	primary, err := (Client{Runner: runner, Dir: "/repo-linked"}).PrimaryWorktree(context.Background())
+	if err != nil {
+		t.Fatalf("PrimaryWorktree returned error: %v", err)
+	}
+	if primary != "/repo" {
+		t.Fatalf("primary = %q, want /repo", primary)
+	}
+	runner.wantArgs(t, 0, "git", "worktree", "list", "--porcelain")
+}
+
+func TestClientPrimaryWorktreeSkipsBareAndFallsBackToSelf(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{
+		{Stdout: "worktree /repo.git\nbare\n"},
+		{Stdout: "/repo-linked\n"},
+	}}
+	primary, err := (Client{Runner: runner, Dir: "/repo-linked"}).PrimaryWorktree(context.Background())
+	if err != nil {
+		t.Fatalf("PrimaryWorktree returned error: %v", err)
+	}
+	if primary != "/repo-linked" {
+		t.Fatalf("primary = %q, want /repo-linked", primary)
+	}
+	runner.wantArgs(t, 0, "git", "worktree", "list", "--porcelain")
+	runner.wantArgs(t, 1, "git", "rev-parse", "--show-toplevel")
+}
+
 func TestClientRejectsUnsafeBranchNames(t *testing.T) {
 	for _, branch := range []string{"", " task", "task ", "-bad", "bad branch", "bad..branch", "bad.lock", "HEAD:main", "bad~branch", "bad^branch", "bad?branch", "bad[branch", "bad\\branch", "bad@{branch", "/bad", "bad/", "bad//branch"} {
 		t.Run(branch, func(t *testing.T) {


### PR DESCRIPTION
Implements #831 per the panel design comment: linked-worktree detection (git-dir vs git-common-dir) + primary derivation (first non-bare worktree-list record); refuse+--force at repo add with the parent suggested; overwrite protection at the SHARED UpsertRepo seam (an incoming linked worktree never replaces an existing checkout from any caller — the actual incident vector); repos.primary_checkout_path (SQL migration, lazy backfill); self-heal in resolveJobCheckout (dangling → recorded primary, origin-verified, atomic HealRepoCheckout + repo_checkout_self_healed event); repo doctor drift lines + cli-layer aggregate in gitmoot doctor. Implemented by gpt-5.6-sol; coordinator-reviewed + empirically probed on a throwaway home (refuse/force/doctor all verified live). Closes #831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)