### PR TITLE
feat(pipeline): `merge: auto` gate mode — opt-in pipeline self-merge behind a double key

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -64,6 +64,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
 | `success_decisions`         | pipeline     | no       | Decisions that mark a stage succeeded. Default `["approved","implemented","skipped"]`. Any value must be one of `approved`, `implemented`, `changes_requested`, `skipped` - `blocked`/`failed` are park states and are rejected. An explicit list is strict: omitting `skipped` requires real work and makes a skipped result fail. |
 | `allow_scheduled_writes`    | pipeline     | no       | Safety flag. A **mutating** `implement` or `produce` stage on a **scheduled** pipeline is rejected unless this is `true`. Manual runs do not need it. Default `false`. |
+| `allow_auto_merge`          | pipeline     | no       | Pipeline-level half of the auto-merge double key. Required with a gate's `merge: auto`; default `false`. It does not replace `allow_scheduled_writes` on scheduled pipelines. |
 | `stages[].id`               | stage        | yes      | Unique, name-safe stage id. Appears verbatim in the stage job's fingerprint and deterministic id. |
 | `stages[].cmd`              | stage        | cond.    | Shell command run verbatim via `sh -c` (see the stage contract below). A stage is **exactly one** of `cmd`, `agent`, or `gate`. |
 | `stages[].agent`            | stage        | cond.    | Name of a managed gitmoot agent to run this stage (instead of a shell `cmd`). Must be a name-safe token; `pipeline add` warns (does not block) if the agent does not exist yet, but it must exist before the stage runs. Mutually exclusive with `cmd`/`gate`. The stage kind depends on `action`/`write`/`orchestrate` — see [Agent stages](#agent-stages). |
@@ -76,6 +77,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].check_retries`    | stage        | no       | Produce-only count of same-session correction turns after a non-zero `check` (`>= 0`, default `0`). |
 | `stages[].orchestrate`      | stage        | no       | `true` makes an agent stage a **sub-tree coordinator** (#758): its `delegations[]` fan out as owned children and the stage waits for the whole tree, then folds the synthesis. Agent stage only; `action` must be `ask`. |
 | `stages[].gate`             | stage        | cond.    | Makes this a **jobless gate stage** (#768): it runs no worker and folds when an external predicate holds. Only `pr_merged` today. Exclusive with `cmd`/`agent`. Requires `source`. |
+| `stages[].merge`            | stage        | no       | Gate-only merge authority. Omit for the unchanged human-merge default; `auto` lets the pipeline advancer squash-merge after all safety conditions hold. |
 | `stages[].source`           | stage        | cond.    | The upstream `implement` stage whose PR to bind. Required on a `gate`; optional on `action: review`; rejected on shell/ask/implement/orchestrate stages. It must be one of the stage's own `needs`. |
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
@@ -243,8 +245,9 @@ stages:
   terminal no-PR no-op). Other configured success decisions, including `approved` and
   `skipped`, settle immediately without a PR. The stage summary records the opened PR
   number or the terminal no-PR outcome for downstream context.
-- **Never auto-merges.** The pipeline **opens** the PR; a human or your CI does the
-  merge. See [Gate stages](#gate-stages) to make a later stage wait for that merge.
+- **Does not merge by itself.** The implement stage only opens the PR. The default
+  gate still waits for a human merge; a separately double-keyed `merge: auto` gate
+  may merge after review and CI (see [Gate stages](#gate-stages)).
 - **Declared review suppresses native fan-out.** When an implement stage has a
   downstream `action: review` stage with `source` pointing to it, its job carries
   `SkipNativeReviewFanout`. Gitmoot does not also enqueue the ordinary native
@@ -301,6 +304,56 @@ stages:
 - A source stage that succeeds without opening a PR also parks the gate `blocked`
   immediately with `source stage succeeded without opening a PR; nothing to wait for`.
   Only `implemented` promises the PR that this gate can watch.
+
+#### Opt-in auto-merge
+
+The default is and remains **human merge**. To let the pipeline advancer perform
+the squash merge, spell both keys and declare at least one source-bound review:
+
+```yaml
+allow_auto_merge: true
+stages:
+  - id: fix
+    agent: fixer
+    action: implement
+    write: true
+    prompt: "Apply the change."
+  - id: review
+    agent: reviewer
+    action: review
+    source: fix
+    needs: [fix]
+    prompt: "Review the implementation PR."
+    success_decisions: [approved]
+  - id: merge
+    gate: pr_merged
+    merge: auto
+    source: fix
+    needs: [fix, review]
+```
+
+- `merge: auto` is valid only on a gate and requires top-level
+  `allow_auto_merge: true`. A scheduled pipeline still needs
+  `allow_scheduled_writes: true` for its implement stage, so scheduled auto-merge
+  requires **both** top-level keys.
+- Registration rejects an auto-merge gate unless at least one `action: review`
+  stage binds to the same implement `source`. Before merging, the advancer requires
+  **every** such review stage to have folded `succeeded` with decision `approved`.
+  `changes_requested` parks the run and never merges.
+- The source PR and reviewed head come from structured job payloads, never summary
+  prose. The live PR head must still equal that reviewed `HeadSHA`; drift parks the
+  gate `blocked` and names the mismatch.
+- GitHub must report the PR mergeable and at least one external CI status/check.
+  Pending checks keep the jobless gate waiting within its stage timeout. Check-run
+  `skipped`/`neutral` outcomes count as passing, matching the native merge gate;
+  failed checks park it `blocked`. Zero external statuses/checks always park
+  pipeline auto-merge `blocked`, even when `[merge_gate] require_external_ci` is
+  false—the unattended path never synthesizes no-CI success.
+- Unmergeable/conflicting PRs, head drift, and merge API errors park it `blocked`;
+  a merge API failure is tried once and never retry-spammed.
+- The source job timeline atomically records `pipeline_auto_merge_claim` before
+  the write and `pipeline_auto_merge_confirmed` afterward, carrying pipeline/run,
+  stage, PR, and head SHA. Racing scans that lose the claim never call merge.
 
 ### Orchestrate stages
 
@@ -553,8 +606,9 @@ implement` requires an explicit `write: true` double-key (and `write: true` is v
 only on an implement stage), so a typo or prompt injection cannot flip a read-only
 pipeline into a writing one; a mutating stage on a **scheduled** pipeline is rejected
 unless the pipeline sets `allow_scheduled_writes: true`; the bound agent's own
-capability/policy still applies; and the pipeline **never merges its own PR** — it
-opens the PR and leaves the merge to a human or CI.
+capability/policy still applies; and the implement job never merges its own PR. The
+default gate leaves merge to a human or CI; only the separately double-keyed,
+review-required `merge: auto` gate grants merge authority to the advancer.
 
 ## Not yet supported (deferred)
 

--- a/internal/cli/merge_gate_policy.go
+++ b/internal/cli/merge_gate_policy.go
@@ -12,16 +12,35 @@ import (
 // required, built-in grace/max windows) rather than erroring the daemon —
 // mirroring how loadEventsPolicy / resolveEscalationTTL degrade to defaults.
 func applyMergeGatePolicy(gate *workflow.PolicyMergeGate, home string, repo string) {
-	cfg := resolveConfigFile(home)
-	if cfg == "" {
+	policy, ok := resolvedMergeGatePolicy(home, repo)
+	if !ok {
 		return
 	}
-	loaded, err := config.LoadMergeGatePolicy(config.Paths{ConfigFile: cfg})
-	if err != nil {
-		return
-	}
-	policy := loaded.For(repo)
 	gate.RequireExternalCI = policy.RequireExternalCI
 	gate.MinCIWait = policy.MinCIWait
 	gate.MaxCIWait = policy.MaxCIWait
+}
+
+func applyPipelineAutoMergePolicy(merger *workflow.PipelineAutoMerger, home string, repo string) {
+	policy, ok := resolvedMergeGatePolicy(home, repo)
+	if !ok {
+		return
+	}
+	merger.RequireExternalCI = policy.RequireExternalCI
+	merger.MinCIWait = policy.MinCIWait
+	merger.MaxCIWait = policy.MaxCIWait
+}
+
+// resolvedMergeGatePolicy is the single config path for the native merge gate
+// and pipeline auto-merge executor, including per-repo overrides.
+func resolvedMergeGatePolicy(home string, repo string) (config.MergeGatePolicy, bool) {
+	cfg := resolveConfigFile(home)
+	if cfg == "" {
+		return config.MergeGatePolicy{}, false
+	}
+	loaded, err := config.LoadMergeGatePolicy(config.Paths{ConfigFile: cfg})
+	if err != nil {
+		return config.MergeGatePolicy{}, false
+	}
+	return loaded.For(repo), true
 }

--- a/internal/cli/merge_gate_policy_test.go
+++ b/internal/cli/merge_gate_policy_test.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
@@ -26,6 +28,38 @@ func TestApplyMergeGatePolicyOffByDefault(t *testing.T) {
 	}
 	if gate.MaxCIWait != config.DefaultMaxCIWait {
 		t.Fatalf("MaxCIWait = %v, want default %v", gate.MaxCIWait, config.DefaultMaxCIWait)
+	}
+}
+
+func TestNewPipelineAutoMergerAppliesPerRepoPolicyOnAndOff(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+`
+[merge_gate]
+min_ci_wait = "45s"
+max_ci_wait = "7m"
+
+[repos."jerryfane/noted".merge_gate]
+require_external_ci = true
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	on := newPipelineAutoMerger(context.Background(), store, "jerryfane/noted")
+	if !on.RequireExternalCI || on.MinCIWait != 45*time.Second || on.MaxCIWait != 7*time.Minute {
+		t.Fatalf("per-repo pipeline policy = %+v", on)
+	}
+	off := newPipelineAutoMerger(context.Background(), store, "jerryfane/gitmoot")
+	if off.RequireExternalCI || off.MinCIWait != 45*time.Second || off.MaxCIWait != 7*time.Minute {
+		t.Fatalf("global pipeline policy = %+v", off)
 	}
 }
 

--- a/internal/cli/pipeline_auto_merge_test.go
+++ b/internal/cli/pipeline_auto_merge_test.go
@@ -1,0 +1,398 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/pipeline"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+const pipelineAutoMergeSpec = `name: auto-merge
+repo: owner/repo
+allow_auto_merge: true
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: review
+    agent: reviewer
+    prompt: Review the implementation PR.
+    action: review
+    source: impl
+    needs: [impl]
+    success_decisions: [approved]
+  - id: merge
+    gate: pr_merged
+    merge: auto
+    source: impl
+    needs: [impl]
+`
+
+type stubPipelineAutoMerger struct {
+	readiness    workflow.PipelineAutoMergeReadiness
+	evaluateErr  error
+	mergeResult  workflow.PipelineAutoMergeResult
+	mergeErr     error
+	evaluateReqs []workflow.PipelineAutoMergeRequest
+	mergeReqs    []workflow.PipelineAutoMergeRequest
+}
+
+type claimRacePipelineAutoMerger struct {
+	evaluations atomic.Int32
+	mergeCalls  atomic.Int32
+	merged      atomic.Bool
+	bothReady   chan struct{}
+}
+
+func (s *claimRacePipelineAutoMerger) Evaluate(_ context.Context, _ workflow.PipelineAutoMergeRequest) (workflow.PipelineAutoMergeReadiness, error) {
+	if s.merged.Load() {
+		return workflow.PipelineAutoMergeReadiness{Merged: true, CurrentHeadSHA: "0123456789abcdef"}, nil
+	}
+	if s.evaluations.Add(1) == 2 {
+		close(s.bothReady)
+	}
+	<-s.bothReady
+	return workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"}, nil
+}
+
+func (s *claimRacePipelineAutoMerger) Merge(_ context.Context, _ workflow.PipelineAutoMergeRequest) (workflow.PipelineAutoMergeResult, error) {
+	s.mergeCalls.Add(1)
+	s.merged.Store(true)
+	return workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "race-merge"}, nil
+}
+
+func (s *stubPipelineAutoMerger) Evaluate(_ context.Context, request workflow.PipelineAutoMergeRequest) (workflow.PipelineAutoMergeReadiness, error) {
+	s.evaluateReqs = append(s.evaluateReqs, request)
+	return s.readiness, s.evaluateErr
+}
+
+func (s *stubPipelineAutoMerger) Merge(_ context.Context, request workflow.PipelineAutoMergeRequest) (workflow.PipelineAutoMergeResult, error) {
+	s.mergeReqs = append(s.mergeReqs, request)
+	return s.mergeResult, s.mergeErr
+}
+
+func advanceWithAutoMerge(t *testing.T, store *db.Store, enqueue pipelineStageEnqueuer, rec db.Pipeline, spec pipeline.Spec, run db.PipelineRun, now time.Time, executor pipelineAutoMergeExecutor) db.PipelineRun {
+	t.Helper()
+	updated, err := advancePipelineRunWithAutoMerge(context.Background(), store, enqueue, rec, spec, run, now, executor)
+	if err != nil {
+		t.Fatalf("advancePipelineRunWithAutoMerge: %v", err)
+	}
+	return updated
+}
+
+func settleBoundReviewJob(t *testing.T, store *db.Store, jobID, decision, head string) {
+	t.Helper()
+	ctx := context.Background()
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob(review): %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(review): %v", err)
+	}
+	payload.HeadSHA = head
+	payload.Result = &workflow.AgentResult{Decision: decision, Summary: "review settled"}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal review payload: %v", err)
+	}
+	to := jobStateForDecision(decision)
+	ok, err := store.TransitionJobStatePayloadWithEvent(ctx, job.ID, job.State, to, string(encoded), db.JobEvent{JobID: job.ID, Kind: to, Message: "review settled by test"})
+	if err != nil || !ok {
+		t.Fatalf("settle review: ok=%v err=%v", ok, err)
+	}
+}
+
+func prepareAutoMergeGate(t *testing.T) (*db.Store, pipelineStageEnqueuer, db.Pipeline, pipeline.Spec, db.PipelineRun, string, time.Time) {
+	t.Helper()
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "auto-merge", pipelineAutoMergeSpec)
+	enqueue := testStageEnqueuer(store)
+	now := time.Date(2026, 7, 11, 8, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	setttle := pipelineStagePRBinding{PullRequest: 813, HeadSHA: "0123456789abcdef", Branch: "feat/813", TaskID: "task-813", LeadAgent: "coder"}
+	settleBoundImplementStageJob(t, store, impl.JobID, "implemented", setttle)
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), &stubPipelineAutoMerger{})
+	return store, enqueue, rec, spec, run, impl.JobID, now
+}
+
+func TestPipelineAutoMergeGateExecutesAfterApprovedReviewAndGreenChecks(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	review := stageRow(t, store, run.ID, "review")
+	settleBoundReviewJob(t, store, review.JobID, "approved", "0123456789abcdef")
+	executor := &stubPipelineAutoMerger{
+		readiness:   workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "0123456789abcdef"},
+		mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merge-sha"},
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	if len(executor.mergeReqs) != 1 {
+		t.Fatalf("merge calls = %d, want 1", len(executor.mergeReqs))
+	}
+	request := executor.mergeReqs[0]
+	if request.Repo != "owner/repo" || request.PullRequest != 813 || request.HeadSHA != "0123456789abcdef" || request.Pipeline != "auto-merge" || request.RunID != run.ID || request.StageID != "merge" {
+		t.Fatalf("merge request = %+v", request)
+	}
+	if run.State != pipeline.RunSucceeded || stageRow(t, store, run.ID, "merge").State != pipeline.StageSucceeded {
+		t.Fatalf("run/gate = %+v / %+v, want succeeded", run, stageRow(t, store, run.ID, "merge"))
+	}
+	events, err := store.ListJobEvents(context.Background(), sourceJobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents(source): %v", err)
+	}
+	intent, confirmed := -1, -1
+	for i, event := range events {
+		switch event.Kind {
+		case "pipeline_auto_merge_claim":
+			intent = i
+			if !strings.Contains(event.Message, `"pull_request":813`) || !strings.Contains(event.Message, `"head_sha":"0123456789abcdef"`) || !strings.Contains(event.Message, `"run_id":"`+run.ID+`"`) {
+				t.Fatalf("intent event = %+v", event)
+			}
+		case "pipeline_auto_merge_confirmed":
+			confirmed = i
+		}
+	}
+	if intent < 0 || confirmed <= intent {
+		t.Fatalf("auto-merge event order intent=%d confirmed=%d events=%+v", intent, confirmed, events)
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(3*time.Second), executor)
+	if len(executor.mergeReqs) != 1 {
+		t.Fatalf("terminal rescan merge calls = %d, want 1", len(executor.mergeReqs))
+	}
+}
+
+func TestPipelineAutoMergeGateRequiresEverySourceBoundReview(t *testing.T) {
+	const secondReview = `  - id: review-two
+    agent: reviewer
+    prompt: Review the implementation PR again.
+    action: review
+    source: impl
+    needs: [impl]
+    success_decisions: [approved]
+`
+	specYAML := strings.Replace(pipelineAutoMergeSpec, "  - id: merge\n", secondReview+"  - id: merge\n", 1)
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "auto-merge", specYAML)
+	enqueue := testStageEnqueuer(store)
+	now := time.Date(2026, 7, 11, 8, 30, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	settleBoundImplementStageJob(t, store, impl.JobID, "implemented", pipelineStagePRBinding{PullRequest: 813, HeadSHA: "all-review-head"})
+	executor := &stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "all-review-head"}, mergeResult: workflow.PipelineAutoMergeResult{Merged: true}}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), executor)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "all-review-head")
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	if len(executor.evaluateReqs) != 0 || len(executor.mergeReqs) != 0 || stageRow(t, store, run.ID, "merge").State != pipeline.StageRunning {
+		t.Fatalf("gate advanced before every review: evaluate=%d merge=%d gate=%+v", len(executor.evaluateReqs), len(executor.mergeReqs), stageRow(t, store, run.ID, "merge"))
+	}
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review-two").JobID, "approved", "all-review-head")
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(3*time.Second), executor)
+	if run.State != pipeline.RunSucceeded || len(executor.mergeReqs) != 1 {
+		t.Fatalf("gate did not merge after every review: run=%+v merge=%d", run, len(executor.mergeReqs))
+	}
+}
+
+func TestPipelineAutoMergeClaimAllowsExactlyOneRacingMerge(t *testing.T) {
+	store, enqueue, rec, spec, run, sourceJobID, now := prepareAutoMergeGate(t)
+	settleBoundReviewJob(t, store, stageRow(t, store, run.ID, "review").JobID, "approved", "0123456789abcdef")
+	waiting := &stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, CurrentHeadSHA: "0123456789abcdef"}}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), waiting)
+	gateRow := stageRow(t, store, run.ID, "merge")
+	var gateStage pipeline.Stage
+	for _, candidate := range spec.Stages {
+		if candidate.ID == "merge" {
+			gateStage = candidate
+			break
+		}
+	}
+	executor := &claimRacePipelineAutoMerger{bothReady: make(chan struct{})}
+	deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now.Add(3 * time.Second), autoMerge: executor}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, _, _, _, _, err := gateStageSettleOutcome(context.Background(), deps, spec, gateStage, gateRow)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("racing settle: %v", err)
+		}
+	}
+	if got := executor.mergeCalls.Load(); got != 1 {
+		t.Fatalf("racing merge calls = %d, want exactly 1", got)
+	}
+	events, err := store.ListJobEvents(context.Background(), sourceJobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	claims := 0
+	for _, event := range events {
+		if event.Kind == "pipeline_auto_merge_claim" {
+			claims++
+		}
+	}
+	if claims != 1 {
+		t.Fatalf("claim events = %d, want 1; events=%+v", claims, events)
+	}
+	settled, state, _, _, _, err := gateStageSettleOutcome(context.Background(), deps, spec, gateStage, gateRow)
+	if err != nil || !settled || state != pipeline.StageSucceeded {
+		t.Fatalf("post-race settle = settled:%v state:%q err:%v", settled, state, err)
+	}
+}
+
+func TestPipelineAutoMergeGateSafetyStops(t *testing.T) {
+	tests := []struct {
+		name          string
+		decision      string
+		reviewHead    string
+		mutateSpec    func(*pipeline.Spec)
+		readiness     workflow.PipelineAutoMergeReadiness
+		mergeErr      error
+		wantRunState  string
+		wantGateState string
+		wantNeed      string
+		wantEvaluate  int
+		wantMerge     int
+	}{
+		{name: "changes requested", decision: "changes_requested", reviewHead: "0123456789abcdef", wantRunState: pipeline.RunFailed, wantGateState: pipeline.StageBlocked, wantNeed: "has not approved"},
+		{name: "reviewed head mismatch", decision: "approved", reviewHead: "different-head", wantRunState: pipeline.RunBlocked, wantGateState: pipeline.StageBlocked, wantNeed: "reviewed head", wantEvaluate: 0},
+		{name: "live head drift", decision: "approved", reviewHead: "0123456789abcdef", readiness: workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: "drifted-head"}, wantRunState: pipeline.RunBlocked, wantGateState: pipeline.StageBlocked, wantNeed: "head drifted", wantEvaluate: 1},
+		{name: "checks pending", decision: "approved", reviewHead: "0123456789abcdef", readiness: workflow.PipelineAutoMergeReadiness{Waiting: true, Reason: "checks pending"}, wantRunState: pipeline.RunRunning, wantGateState: pipeline.StageRunning, wantEvaluate: 1},
+		{name: "allow key missing defensively", decision: "approved", reviewHead: "0123456789abcdef", mutateSpec: func(spec *pipeline.Spec) { spec.AllowAutoMerge = false }, wantRunState: pipeline.RunBlocked, wantGateState: pipeline.StageBlocked, wantNeed: "allow_auto_merge", wantEvaluate: 0},
+		{name: "already merged", decision: "approved", reviewHead: "0123456789abcdef", readiness: workflow.PipelineAutoMergeReadiness{Merged: true, MergeCommitSHA: "merged"}, wantRunState: pipeline.RunSucceeded, wantGateState: pipeline.StageSucceeded, wantEvaluate: 1},
+		{name: "merge API error", decision: "approved", reviewHead: "0123456789abcdef", readiness: workflow.PipelineAutoMergeReadiness{Ready: true}, mergeErr: errors.New("boom"), wantRunState: pipeline.RunBlocked, wantGateState: pipeline.StageBlocked, wantNeed: "retry stopped", wantEvaluate: 1, wantMerge: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, enqueue, rec, spec, run, _, now := prepareAutoMergeGate(t)
+			review := stageRow(t, store, run.ID, "review")
+			settleBoundReviewJob(t, store, review.JobID, tc.decision, tc.reviewHead)
+			if tc.mutateSpec != nil {
+				tc.mutateSpec(&spec)
+			}
+			readiness := tc.readiness
+			if tc.wantEvaluate > 0 && !readiness.Merged && readiness.CurrentHeadSHA == "" {
+				readiness.CurrentHeadSHA = "0123456789abcdef"
+			}
+			executor := &stubPipelineAutoMerger{readiness: readiness, mergeErr: tc.mergeErr}
+			run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+			gate := stageRow(t, store, run.ID, "merge")
+			if run.State != tc.wantRunState || gate.State != tc.wantGateState {
+				t.Fatalf("run/gate states = %s/%s, want %s/%s; run=%+v gate=%+v", run.State, gate.State, tc.wantRunState, tc.wantGateState, run, gate)
+			}
+			if tc.wantNeed != "" && !strings.Contains(gate.NeedsJSON, tc.wantNeed) {
+				t.Fatalf("gate needs = %q, want substring %q", gate.NeedsJSON, tc.wantNeed)
+			}
+			if len(executor.evaluateReqs) != tc.wantEvaluate || len(executor.mergeReqs) != tc.wantMerge {
+				t.Fatalf("evaluate/merge calls = %d/%d, want %d/%d", len(executor.evaluateReqs), len(executor.mergeReqs), tc.wantEvaluate, tc.wantMerge)
+			}
+			if tc.mergeErr != nil {
+				run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(3*time.Second), executor)
+				if len(executor.mergeReqs) != 1 {
+					t.Fatalf("blocked rescan retried merge %d times", len(executor.mergeReqs))
+				}
+			}
+		})
+	}
+}
+
+func TestPipelineHumanMergeGateNeverTouchesAutoMergeExecutor(t *testing.T) {
+	const specYAML = `name: human-merge
+repo: owner/repo
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix it.
+    action: implement
+    write: true
+  - id: wait
+    gate: pr_merged
+    source: impl
+    needs: [impl]
+`
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "human-merge", specYAML)
+	enqueue := testStageEnqueuer(store)
+	now := time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	impl := stageRow(t, store, run.ID, "impl")
+	settleBoundImplementStageJob(t, store, impl.JobID, "implemented", pipelineStagePRBinding{PullRequest: 814, HeadSHA: "human-head"})
+	executor := &stubPipelineAutoMerger{}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), executor)
+	markPipelinePRMerged(t, store, "owner/repo", 814, "merged")
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(2*time.Second), executor)
+	if run.State != pipeline.RunSucceeded || len(executor.evaluateReqs) != 0 || len(executor.mergeReqs) != 0 {
+		t.Fatalf("human gate run=%+v evaluate=%d merge=%d", run, len(executor.evaluateReqs), len(executor.mergeReqs))
+	}
+}
+
+func TestPipelineAutoMergeShellRuntimeE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgentWithPolicy(t, store, "coder", runtime.ShellRuntime, pipelineStageResultCmd("implemented", "fixed", nil), []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
+	seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime, pipelineStageResultCmd("approved", "approved", nil), []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
+
+	rec, spec := newTestPipeline(t, store, "auto-merge", pipelineAutoMergeSpec)
+	enqueue := newPipelineStageEnqueuer(store, home)
+	now := time.Date(2026, 7, 11, 10, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, now)
+	implRow := stageRow(t, store, run.ID, "impl")
+	implJob, err := store.GetJob(ctx, implRow.JobID)
+	if err != nil {
+		t.Fatalf("GetJob(impl): %v", err)
+	}
+	implPayload, err := workflow.ParseJobPayload(implJob.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(impl): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(implPayload.WorktreePath, "auto.txt"), []byte("auto merge\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	runDaemonWorkerGit(t, implPayload.WorktreePath, "add", "auto.txt")
+	runDaemonWorkerGit(t, implPayload.WorktreePath, "commit", "-m", "auto merge fixture")
+	head, err := (gitutil.Client{Dir: implPayload.WorktreePath}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA: %v", err)
+	}
+	settleBoundImplementStageJob(t, store, implJob.ID, "implemented", pipelineStagePRBinding{PullRequest: 815, HeadSHA: head, Branch: implPayload.Branch, TaskID: implPayload.TaskID, LeadAgent: "coder"})
+	executor := &stubPipelineAutoMerger{readiness: workflow.PipelineAutoMergeReadiness{Ready: true, CurrentHeadSHA: head}, mergeResult: workflow.PipelineAutoMergeResult{Merged: true, MergeCommitSHA: "merged-815"}}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(time.Second), executor)
+	if err := runEnabledRepoWorkerTicks(ctx, store, defaultJobWorker(store, io.Discard, home), 1, io.Discard, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("review worker tick: %v", err)
+	}
+	run = advanceWithAutoMerge(t, store, enqueue, rec, spec, run, now.Add(3*time.Second), executor)
+	if run.State != pipeline.RunSucceeded || len(executor.mergeReqs) != 1 {
+		t.Fatalf("shell E2E run=%+v merge calls=%d", run, len(executor.mergeReqs))
+	}
+	if got := executor.mergeReqs[0]; got.PullRequest != 815 || got.HeadSHA != head {
+		t.Fatalf("shell E2E merge request = %+v, want PR 815 head %s", got, head)
+	}
+}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	gitutil "github.com/jerryfane/gitmoot/internal/git"
+	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/pipeline"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/workflow"
@@ -35,6 +37,14 @@ const pipelineSkippedSummaryMarker = "[skipped: no work]"
 // workflow.Mailbox.Enqueue (matching newHeartbeatEnqueuer); tests inject a fake to
 // assert the request shape without a real worker.
 type pipelineStageEnqueuer func(ctx context.Context, request workflow.JobRequest) (db.Job, error)
+
+// pipelineAutoMergeExecutor is the narrow write seam for merge: auto gates.
+// Tests inject a deterministic stub; production adapts the existing workflow
+// merge-gate checks and shared GitHub merge call.
+type pipelineAutoMergeExecutor interface {
+	Evaluate(context.Context, workflow.PipelineAutoMergeRequest) (workflow.PipelineAutoMergeReadiness, error)
+	Merge(context.Context, workflow.PipelineAutoMergeRequest) (workflow.PipelineAutoMergeResult, error)
+}
 
 // newPipelineStageEnqueuer builds the production enqueuer: a Mailbox bound to the
 // store and the daemon's canary-routing policy, so a pipeline stage job is
@@ -497,8 +507,9 @@ func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.Pipel
 	// The writable task-worktree itself is allocated at the enqueue seam
 	// (allocatePipelineStageWritableWorktree), which reuses the existing implement
 	// dispatch's GetTaskByRepoBranch reuse + fail-closed guards. Still a LEAF
-	// (Sender=pipeline strips delegations/human_questions) and the pipeline never merges
-	// its PR. This is an APPEND above the read-only agent branch, which stays byte-identical.
+	// (Sender=pipeline strips delegations/human_questions), and this implement job never
+	// merges its PR; only a separately authorized gate may. This is an APPEND above the
+	// read-only agent branch, which stays byte-identical.
 	if stage.Kind() == pipeline.StageKindAgentImplement {
 		return workflow.JobRequest{
 			ID:           pipelineStageJobID(run.ID, stage.ID, attempt),
@@ -853,6 +864,30 @@ func advancePipelineRuns(ctx context.Context, store *db.Store, enqueue pipelineS
 // no writes and no enqueues. It assumes run.State == running; a parked/terminal run
 // is a no-op. The updated run is returned for callers/tests.
 func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, rec db.Pipeline, spec pipeline.Spec, run db.PipelineRun, now time.Time) (db.PipelineRun, error) {
+	var autoMerge pipelineAutoMergeExecutor
+	for _, stage := range spec.Stages {
+		if strings.TrimSpace(stage.Merge) == pipeline.GateMergeAuto {
+			autoMerge = newPipelineAutoMerger(ctx, store, rec.Repo)
+			break
+		}
+	}
+	return advancePipelineRunWithAutoMerge(ctx, store, enqueue, rec, spec, run, now, autoMerge)
+}
+
+func newPipelineAutoMerger(ctx context.Context, store *db.Store, repo string) workflow.PipelineAutoMerger {
+	checkout := pipelineStageCheckoutPath(ctx, store, repo)
+	merger := workflow.PipelineAutoMerger{Store: store, GitHub: github.NewClient(checkout)}
+	home := ""
+	if databasePath := strings.TrimSpace(store.DatabasePath()); databasePath != "" {
+		home = filepath.Dir(databasePath)
+	}
+	applyPipelineAutoMergePolicy(&merger, home, repo)
+	return merger
+}
+
+// advancePipelineRunWithAutoMerge is the testable advancer core. The executor is
+// threaded only into the per-stage settle deps; human-default gates never call it.
+func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enqueue pipelineStageEnqueuer, rec db.Pipeline, spec pipeline.Spec, run db.PipelineRun, now time.Time, autoMerge pipelineAutoMergeExecutor) (db.PipelineRun, error) {
 	now = now.UTC()
 	if run.State != pipeline.RunRunning {
 		return run, nil
@@ -884,7 +919,7 @@ func advancePipelineRun(ctx context.Context, store *db.Store, enqueue pipelineSt
 		// reflect. That is deliberate — a future JOBLESS kind (gate) is reachable here
 		// without moving a guard out of a shared loop, and an unsettled kind can hand
 		// back a row mutation (nextRow) to persist while it keeps waiting.
-		deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now}
+		deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now, autoMerge: autoMerge}
 		settled, state, summary, needs, nextRow, err := stageSettleOutcome(ctx, deps, spec, stage, row)
 		if err != nil {
 			return run, err
@@ -1101,18 +1136,17 @@ func applyPipelineRunSettlement(ctx context.Context, store *db.Store, rec db.Pip
 
 // pipelineStageSettleDeps carries the ambient capabilities the per-kind settle
 // predicate (stageSettleOutcome) may need. The seam loads the stage's job ITSELF via
-// store (today's shell + read-only agent kinds), so a future JOBLESS kind is not
-// forced to fabricate one. Today's kinds read only store; rec/run/now are threaded
-// now so a future kind is a NEW case in the seam, NOT a widening of the advancer
-// signature or a re-plumb of the FOLD pass. Everything here is already in scope in
-// advancePipelineRun. What the deferred kinds want:
+// store (shell + agent kinds), so a JOBLESS kind is not forced to fabricate one.
+// rec/run/now and the narrow auto-merge executor are threaded here rather than
+// widening the shared fold loop. Everything is already in scope in
+// advancePipelineRun. Current specializations:
 //   - StageKindGate (#768 Phase 2): a gate has no job/worker; it settles when an
 //     external predicate holds (e.g. pr_merged on an upstream implement stage's
 //     PR). Because the seam — not the advancer — owns the "does this stage have a
 //     job" question, a gate case simply never calls store.GetJob; it reads the
 //     managed repo (rec) and upstream stage rows via store, and bounds the wait
-//     against the stage timeout using now. GitHub access would be threaded into this
-//     struct then (a client/poller field), not into the caller. Such a predicate
+//     against the stage timeout using now. The opt-in merge:auto variant alone uses
+//     autoMerge for live readiness and the single audited write. Such a predicate
 //     MUST be non-blocking and ctx-bounded and MUST fail OPEN (return settled=false,
 //     never a hung poll) — the FOLD pass runs it synchronously across every in-flight
 //     run, and a settle error is propagated (err), never swallowed.
@@ -1122,10 +1156,11 @@ func applyPipelineRunSettlement(ctx context.Context, store *db.Store, rec db.Pip
 //     current continuation and stays unsettled by returning that row as nextRow. ctx
 //     bounds those store reads.
 type pipelineStageSettleDeps struct {
-	store *db.Store
-	rec   db.Pipeline
-	run   db.PipelineRun
-	now   time.Time
+	store     *db.Store
+	rec       db.Pipeline
+	run       db.PipelineRun
+	now       time.Time
+	autoMerge pipelineAutoMergeExecutor
 }
 
 // stageSettleOutcome is the per-stage-kind SETTLE PREDICATE seam. Given an in-flight
@@ -1529,6 +1564,9 @@ func pipelineSourceStagePR(ctx context.Context, store *db.Store, source db.Pipel
 // re-arming the timer). A gate with no timeout waits indefinitely (cheaply — no job).
 // While in flight it reflects the one-time queued->running funnel transition via nextRow.
 func gateStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec pipeline.Spec, stage pipeline.Stage, stageRow db.PipelineRunStage) (settled bool, state, summary string, needs []string, nextRow *db.PipelineRunStage, err error) {
+	if strings.TrimSpace(stage.Merge) == pipeline.GateMergeAuto {
+		return autoMergeGateStageSettleOutcome(ctx, deps, spec, stage, stageRow)
+	}
 	// Classify the upstream source from its structured job payload first. Summary text
 	// is only a compatibility fallback when the source job row has been deleted/GC'd.
 	pr := 0
@@ -1593,6 +1631,185 @@ func gateStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, s
 		return false, "", "", nil, &next, nil
 	}
 	return false, "", "", nil, nil, nil
+}
+
+// autoMergeGateStageSettleOutcome is the only pipeline-owned merge authority.
+// It requires the spec double key, a stamped source payload, every source-bound
+// review folded approved at that exact head, and a green live GitHub observation.
+// It records intent before its single squash attempt and blocks terminally on any
+// merge failure, so an unchanged scan can never retry-spam the API.
+func autoMergeGateStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDeps, spec pipeline.Spec, stage pipeline.Stage, stageRow db.PipelineRunStage) (settled bool, state, summary string, needs []string, nextRow *db.PipelineRunStage, err error) {
+	block := func(reason string) (bool, string, string, []string, *db.PipelineRunStage, error) {
+		return true, pipeline.StageBlocked, "gate auto-merge blocked: " + reason, []string{reason}, nil, nil
+	}
+	if !spec.AllowAutoMerge {
+		return block("allow_auto_merge: true is required")
+	}
+	if deps.autoMerge == nil {
+		return block("pipeline auto-merge executor is unavailable")
+	}
+
+	sourceID := strings.TrimSpace(stage.Source)
+	sourceRow, ok, gerr := deps.store.GetPipelineRunStage(ctx, deps.run.ID, sourceID)
+	if gerr != nil {
+		return false, "", "", nil, nil, gerr
+	}
+	if !ok || sourceRow.State != pipeline.StageSucceeded {
+		return autoMergeGateWaiting(stage, stageRow, deps.now, 0)
+	}
+	sourceJobID := strings.TrimSpace(sourceRow.JobID)
+	if sourceJobID == "" {
+		return block(fmt.Sprintf("source stage %q has no stamped job payload", sourceID))
+	}
+	sourceJob, gerr := deps.store.GetJob(ctx, sourceJobID)
+	if gerr != nil {
+		return false, "", "", nil, nil, gerr
+	}
+	payload, gerr := workflow.ParseJobPayload(sourceJob.Payload)
+	if gerr != nil {
+		return block(fmt.Sprintf("source stage %q payload is invalid: %v", sourceID, gerr))
+	}
+	if payload.PullRequest <= 0 {
+		return block(fmt.Sprintf("source stage %q succeeded without a stamped PR", sourceID))
+	}
+	reviewedHead := strings.TrimSpace(payload.HeadSHA)
+	if reviewedHead == "" {
+		return block(fmt.Sprintf("source stage %q PR #%d has no stamped head SHA", sourceID, payload.PullRequest))
+	}
+
+	reviewCount := 0
+	for _, reviewStage := range spec.Stages {
+		if reviewStage.Kind() != pipeline.StageKindAgentReview || strings.TrimSpace(reviewStage.Source) != sourceID {
+			continue
+		}
+		reviewCount++
+		reviewRow, found, rerr := deps.store.GetPipelineRunStage(ctx, deps.run.ID, reviewStage.ID)
+		if rerr != nil {
+			return false, "", "", nil, nil, rerr
+		}
+		if !found || reviewRow.State == pipeline.StagePending || reviewRow.State == pipeline.StageQueued || reviewRow.State == pipeline.StageRunning {
+			return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
+		}
+		if reviewRow.State != pipeline.StageSucceeded {
+			return block(fmt.Sprintf("source-bound review stage %q has not approved", reviewStage.ID))
+		}
+		reviewJobID := strings.TrimSpace(reviewRow.JobID)
+		if reviewJobID == "" {
+			return block(fmt.Sprintf("source-bound review stage %q has no result job", reviewStage.ID))
+		}
+		reviewJob, rerr := deps.store.GetJob(ctx, reviewJobID)
+		if rerr != nil {
+			return false, "", "", nil, nil, rerr
+		}
+		reviewPayload, rerr := workflow.ParseJobPayload(reviewJob.Payload)
+		if rerr != nil || reviewPayload.Result == nil {
+			return block(fmt.Sprintf("source-bound review stage %q produced no valid result", reviewStage.ID))
+		}
+		decision := strings.TrimSpace(reviewPayload.Result.Decision)
+		if decision != "approved" {
+			return block(fmt.Sprintf("source-bound review stage %q returned decision %q, not approved", reviewStage.ID, decision))
+		}
+		if head := strings.TrimSpace(reviewPayload.HeadSHA); head != reviewedHead {
+			return block(fmt.Sprintf("source-bound review stage %q reviewed head %s, expected %s", reviewStage.ID, shortPipelineSHA(head), shortPipelineSHA(reviewedHead)))
+		}
+	}
+	if reviewCount == 0 {
+		return block(fmt.Sprintf("source stage %q has no source-bound review stage", sourceID))
+	}
+
+	request := workflow.PipelineAutoMergeRequest{
+		Repo:        deps.rec.Repo,
+		PullRequest: payload.PullRequest,
+		HeadSHA:     reviewedHead,
+		Pipeline:    deps.rec.Name,
+		RunID:       deps.run.ID,
+		StageID:     stage.ID,
+	}
+	readiness, evalErr := deps.autoMerge.Evaluate(ctx, request)
+	if evalErr != nil {
+		return block("GitHub readiness evaluation failed: " + evalErr.Error())
+	}
+	if readiness.Merged {
+		return true, pipeline.StageSucceeded, fmt.Sprintf("gate %s satisfied: PR #%d already merged", stage.Gate, payload.PullRequest), nil, nil, nil
+	}
+	currentHead := strings.TrimSpace(readiness.CurrentHeadSHA)
+	if currentHead == "" {
+		return block(fmt.Sprintf("GitHub did not report a current head SHA for PR #%d", payload.PullRequest))
+	}
+	if currentHead != reviewedHead {
+		return block(fmt.Sprintf("pull request head drifted after review: reviewed %s, current %s", shortPipelineSHA(reviewedHead), shortPipelineSHA(currentHead)))
+	}
+	if readiness.Blocked {
+		return block(readiness.Reason)
+	}
+	if !readiness.Ready {
+		return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
+	}
+
+	claim, marshalErr := json.Marshal(map[string]any{
+		"phase": "claim", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
+		"stage_id": stage.ID, "pull_request": payload.PullRequest, "head_sha": reviewedHead,
+	})
+	if marshalErr != nil {
+		return false, "", "", nil, nil, marshalErr
+	}
+	claimed, claimErr := deps.store.ClaimJobEvent(ctx, db.JobEvent{JobID: sourceJobID, Kind: "pipeline_auto_merge_claim", Message: string(claim)})
+	if claimErr != nil {
+		return false, "", "", nil, nil, claimErr
+	}
+	if !claimed {
+		// Another scan owns this exact run/stage/PR/head write. Do not call Merge;
+		// the next scan observes either the merged PR or the winner's blocked fold.
+		return autoMergeGateWaiting(stage, stageRow, deps.now, payload.PullRequest)
+	}
+
+	result, mergeErr := deps.autoMerge.Merge(ctx, request)
+	if mergeErr != nil {
+		return block("merge API failed; retry stopped: " + mergeErr.Error())
+	}
+	if !result.Merged {
+		reason := strings.TrimSpace(result.Reason)
+		if reason == "" {
+			reason = "GitHub did not confirm the merge"
+		}
+		return block(reason + "; retry stopped")
+	}
+	confirmation, marshalErr := json.Marshal(map[string]any{
+		"phase": "confirmed", "pipeline": deps.rec.Name, "run_id": deps.run.ID,
+		"stage_id": stage.ID, "pull_request": payload.PullRequest, "head_sha": reviewedHead,
+		"merge_commit_sha": result.MergeCommitSHA,
+	})
+	if marshalErr != nil {
+		return false, "", "", nil, nil, marshalErr
+	}
+	if eventErr := deps.store.AddJobEvent(ctx, db.JobEvent{JobID: sourceJobID, Kind: "pipeline_auto_merge_confirmed", Message: string(confirmation)}); eventErr != nil {
+		return false, "", "", nil, nil, eventErr
+	}
+	return true, pipeline.StageSucceeded, fmt.Sprintf("gate %s auto-merged PR #%d at %s", stage.Gate, payload.PullRequest, shortPipelineSHA(reviewedHead)), nil, nil, nil
+}
+
+func autoMergeGateWaiting(stage pipeline.Stage, stageRow db.PipelineRunStage, now time.Time, pr int) (bool, string, string, []string, *db.PipelineRunStage, error) {
+	if timedOut, waited := pipelineGateTimedOut(stage, stageRow, now); timedOut {
+		want := pipelineGateWaitDescription(stage.Gate, pr)
+		return true, pipeline.StageBlocked, fmt.Sprintf("gate %s timed out after %s waiting for auto-merge readiness for %s", stage.Gate, waited, want), []string{want}, nil, nil
+	}
+	if stageRow.State == pipeline.StageQueued {
+		next := stageRow
+		next.State = pipeline.StageRunning
+		return false, "", "", nil, &next, nil
+	}
+	return false, "", "", nil, nil, nil
+}
+
+func shortPipelineSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	if sha == "" {
+		return "<missing>"
+	}
+	return sha
 }
 
 // pipelineGateTimedOut reports whether a gate stage's wait has exceeded its stage

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -18,7 +18,8 @@ import (
 )
 
 type Store struct {
-	db *sql.DB
+	db   *sql.DB
+	path string
 }
 
 type Repo struct {
@@ -576,7 +577,7 @@ func Open(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, err
 	}
-	store := &Store{db: db}
+	store := &Store{db: db, path: path}
 	if err := store.Migrate(context.Background()); err != nil {
 		_ = db.Close()
 		return nil, err
@@ -600,7 +601,17 @@ func OpenReadOnly(path string) (*Store, error) {
 		_ = db.Close()
 		return nil, err
 	}
-	return &Store{db: db}, nil
+	return &Store{db: db, path: path}, nil
+}
+
+// DatabasePath returns the path used to open the store. It lets home-scoped
+// read-only policy consumers resolve the config beside gitmoot.db without
+// re-resolving an already-resolved Gitmoot home.
+func (s *Store) DatabasePath() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
 }
 
 func configureWritableSQLite(ctx context.Context, db *sql.DB) error {
@@ -3096,6 +3107,26 @@ func (s *Store) AddJobEventIfAbsent(ctx context.Context, event JobEvent) error {
 			SELECT 1 FROM job_events WHERE job_id = ? AND kind = ?
 		)`, event.JobID, event.Kind, event.Message, event.JobID, event.Kind)
 	return err
+}
+
+// ClaimJobEvent atomically inserts an exact job/kind/message event and reports
+// whether this caller won. The NOT EXISTS guard and insert share one SQLite
+// statement, so concurrent pipeline scans cannot both claim the same external
+// write identified by the event content.
+func (s *Store) ClaimJobEvent(ctx context.Context, event JobEvent) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message)
+		SELECT ?, ?, ?
+		WHERE NOT EXISTS (
+			SELECT 1 FROM job_events WHERE job_id = ? AND kind = ? AND message = ?
+		)`, event.JobID, event.Kind, event.Message, event.JobID, event.Kind, event.Message)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
 }
 
 // UpsertLatestJobEvent keeps one mutable latest-only row for a job/event kind.

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -175,6 +175,20 @@ stages:
 	}
 }
 
+func TestHumanMergeGateDefaultsRemainByteIdentical(t *testing.T) {
+	const raw = "name: human-default\nrepo: owner/repo\nstages:\n  - id: impl\n    agent: coder\n    prompt: Fix it.\n    action: implement\n    write: true\n  - id: wait\n    gate: pr_merged\n    source: impl\n    needs: [impl]\n"
+	loaded, err := Load([]byte(raw))
+	if err != nil {
+		t.Fatalf("Load human-default gate: %v", err)
+	}
+	if loaded.AllowAutoMerge || loaded.Stages[1].Merge != "" {
+		t.Fatalf("human-default auto-merge fields = allow:%v merge:%q", loaded.AllowAutoMerge, loaded.Stages[1].Merge)
+	}
+	if got, want := Hash([]byte(raw)), "e7c662207566643a01b2e2dbcf2b7cee11f380409a7decf4de70e670fecc4485"; got != want {
+		t.Fatalf("human-default raw spec hash = %s, want %s", got, want)
+	}
+}
+
 func TestLoadValidSourceBoundReviewSpec(t *testing.T) {
 	const spec = `name: review-flow
 repo: owner/repo
@@ -198,6 +212,41 @@ stages:
 	review := loaded.Stages[1]
 	if review.Kind() != StageKindAgentReview || review.Source != "impl" {
 		t.Fatalf("review stage = %+v, want action: review source: impl", review)
+	}
+}
+
+func TestLoadValidAutoMergeGateSpec(t *testing.T) {
+	const spec = `name: auto-merge-flow
+repo: owner/repo
+schedule:
+  interval: 24h
+allow_scheduled_writes: true
+allow_auto_merge: true
+stages:
+  - id: impl
+    agent: coder
+    prompt: Fix the bug.
+    action: implement
+    write: true
+  - id: review
+    agent: reviewer
+    prompt: Review the implementation PR.
+    action: review
+    source: impl
+    needs: [impl]
+    success_decisions: [approved]
+  - id: merge
+    gate: pr_merged
+    merge: auto
+    source: impl
+    needs: [impl, review]
+`
+	loaded, err := Load([]byte(spec))
+	if err != nil {
+		t.Fatalf("Load valid auto-merge spec: %v", err)
+	}
+	if !loaded.AllowScheduledWrites || !loaded.AllowAutoMerge || loaded.Stages[2].Merge != GateMergeAuto {
+		t.Fatalf("auto-merge keys did not parse: %+v", loaded)
 	}
 }
 
@@ -296,6 +345,36 @@ func TestLoadValidationErrors(t *testing.T) {
 			name:    "gate with agent rejected",
 			spec:    "name: p\nstages:\n  - {id: a, cmd: echo}\n  - {id: g, gate: pr_merged, source: a, needs: [a], agent: rev, prompt: hi}\n",
 			wantSub: `stage "g" sets both gate and agent`,
+		},
+		{
+			name:    "auto merge without pipeline allow rejected",
+			spec:    "name: p\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: review, agent: rev, prompt: inspect, action: review, source: impl, needs: [impl]}\n  - {id: g, gate: pr_merged, merge: auto, source: impl, needs: [impl, review]}\n",
+			wantSub: "merge: auto without allow_auto_merge: true",
+		},
+		{
+			name:    "merge mode on non-gate rejected",
+			spec:    "name: p\nallow_auto_merge: true\nstages:\n  - {id: shell, cmd: echo, merge: auto}\n",
+			wantSub: "merge is only valid on gate stages",
+		},
+		{
+			name:    "invalid gate merge mode rejected",
+			spec:    "name: p\nallow_auto_merge: true\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: review, agent: rev, prompt: inspect, action: review, source: impl, needs: [impl]}\n  - {id: g, gate: pr_merged, merge: human, source: impl, needs: [impl, review]}\n",
+			wantSub: `merge mode "human" is invalid`,
+		},
+		{
+			name:    "auto merge without source-bound review rejected",
+			spec:    "name: p\nallow_auto_merge: true\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: g, gate: pr_merged, merge: auto, source: impl, needs: [impl]}\n",
+			wantSub: "has no source-bound review stage",
+		},
+		{
+			name:    "scheduled auto merge still needs scheduled writes allow",
+			spec:    "name: p\nschedule: {interval: 24h}\nallow_auto_merge: true\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: review, agent: rev, prompt: inspect, action: review, source: impl, needs: [impl]}\n  - {id: g, gate: pr_merged, merge: auto, source: impl, needs: [impl, review]}\n",
+			wantSub: "set allow_scheduled_writes: true",
+		},
+		{
+			name:    "scheduled auto merge still needs auto merge allow",
+			spec:    "name: p\nschedule: {interval: 24h}\nallow_scheduled_writes: true\nstages:\n  - {id: impl, agent: coder, prompt: fix, action: implement, write: true}\n  - {id: review, agent: rev, prompt: inspect, action: review, source: impl, needs: [impl]}\n  - {id: g, gate: pr_merged, merge: auto, source: impl, needs: [impl, review]}\n",
+			wantSub: "merge: auto without allow_auto_merge: true",
 		},
 		{
 			name:    "review source not in needs",

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -44,10 +44,16 @@ var AgentStageActionCandidates = []string{"ask", "review"}
 
 // GatePredicatePRMerged is the only gate predicate today (#768 Phase 2): a jobless
 // gate stage carrying `gate: pr_merged` folds success once the PR opened by its
-// upstream source (implement) stage has MERGED. The pipeline never merges the PR
-// itself — merge stays with humans/CI — so the gate is the composable wait a
-// pipeline uses to express `[implement] -> [gate: pr_merged] -> [deploy]`.
+// upstream source (implement) stage has MERGED. Human merge is the default; the
+// separately double-keyed merge:auto mode lets the advancer satisfy the same
+// composable wait after bound review approval and green checks.
 const GatePredicatePRMerged = "pr_merged"
+
+// GateMergeAuto is the sole opt-in gate merge mode. When selected on a
+// pr_merged gate, the pipeline advancer may squash-merge the source PR after all
+// source-bound review rungs approve the stamped head and GitHub reports it ready.
+// An absent merge field keeps the historical human-merge wait unchanged.
+const GateMergeAuto = "auto"
 
 // GatePredicateCandidates are the predicate tokens a gate stage's `gate:` MAY set
 // (#768 Phase 2). It starts deliberately small — just pr_merged — so the vocab is a
@@ -72,6 +78,11 @@ type Spec struct {
 	// deliberate, spelled-twice opt-in. Irrelevant to a manual-only pipeline (no
 	// schedule), which a mutating stage enters with only its per-stage write: true.
 	AllowScheduledWrites bool `yaml:"allow_scheduled_writes,omitempty"`
+	// AllowAutoMerge is the pipeline-level half of the auto-merge double key.
+	// A gate that declares merge: auto is rejected unless this is explicitly true.
+	// It does not authorize scheduled writes; a scheduled pipeline still needs
+	// allow_scheduled_writes for its source implement stage.
+	AllowAutoMerge bool `yaml:"allow_auto_merge,omitempty"`
 	// SuccessDecisions overrides DefaultSuccessDecisions for every stage that does
 	// not set its own. Empty means DefaultSuccessDecisions.
 	SuccessDecisions []string `yaml:"success_decisions,omitempty"`
@@ -125,6 +136,11 @@ type Stage struct {
 	// advancer's settle pass evaluates its predicate per scan. Mutually exclusive with
 	// Cmd and Agent (exactly one of the three executors). Pairs with Source.
 	Gate string `yaml:"gate,omitempty"`
+	// Merge optionally selects who satisfies a pr_merged gate. Empty preserves the
+	// default human-merge wait. The only accepted value is "auto", valid only on a
+	// gate and protected by the top-level allow_auto_merge double key plus at least
+	// one source-bound review rung.
+	Merge string `yaml:"merge,omitempty"`
 	// Source is the id of the upstream implement stage whose opened PR this stage
 	// binds to. It is required on a gate stage and optional on an action: review
 	// agent stage; it is rejected on every other stage kind. Source must be one of
@@ -195,7 +211,8 @@ const (
 	// read-only ask/review kinds it takes a WRITABLE task-worktree, commits + pushes +
 	// opens a PR, and folds success only once a PR exists (fold-on-PR-opened). It is
 	// still a LEAF — it may mutate but never fan out (delegations/human_questions are
-	// stripped) — and the pipeline NEVER merges its own PR.
+	// stripped). The implement job never merges its own PR; only an explicitly
+	// authorized downstream auto-merge gate may do so.
 	StageKindAgentImplement
 	// StageKindGate is a JOBLESS GATE stage (#768 Phase 2): Gate set, neither Cmd nor
 	// Agent. It mints NO worker job — the ENQUEUE pass marks it in-flight without a job

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -26,6 +26,7 @@ func (s *Spec) normalize() {
 		s.Stages[i].Prompt = strings.TrimSpace(s.Stages[i].Prompt)
 		s.Stages[i].Action = strings.TrimSpace(s.Stages[i].Action)
 		s.Stages[i].Gate = strings.TrimSpace(s.Stages[i].Gate)
+		s.Stages[i].Merge = strings.TrimSpace(s.Stages[i].Merge)
 		s.Stages[i].Source = strings.TrimSpace(s.Stages[i].Source)
 		s.Stages[i].Timeout = strings.TrimSpace(s.Stages[i].Timeout)
 		s.Stages[i].Check = strings.TrimSpace(s.Stages[i].Check)
@@ -99,6 +100,9 @@ func (s Spec) Validate() error {
 		if err := validateStageSource(s.Name, stage, stageByID); err != nil {
 			return err
 		}
+		if err := s.validateGateMerge(stage); err != nil {
+			return err
+		}
 		if stage.Retry < 0 {
 			return fmt.Errorf("pipeline %q stage %q retry must be >= 0", s.Name, stage.ID)
 		}
@@ -127,6 +131,32 @@ func (s Spec) Validate() error {
 		}
 	}
 	return s.detectCycle()
+}
+
+// validateGateMerge enforces the auto-merge double key and robot-review rung.
+// The stage-level merge: auto opt-in is valid only on gates; the pipeline-level
+// allow_auto_merge key must independently authorize it. At least one review
+// stage must bind to the same implement source so auto-ship is never unreviewed.
+func (s Spec) validateGateMerge(stage Stage) error {
+	merge := strings.TrimSpace(stage.Merge)
+	if merge == "" {
+		return nil
+	}
+	if stage.Kind() != StageKindGate {
+		return fmt.Errorf("pipeline %q stage %q sets merge %q but is not a gate stage; merge is only valid on gate stages", s.Name, stage.ID, merge)
+	}
+	if merge != GateMergeAuto {
+		return fmt.Errorf("pipeline %q stage %q merge mode %q is invalid; use %q or omit merge for the human-merge default", s.Name, stage.ID, merge, GateMergeAuto)
+	}
+	if !s.AllowAutoMerge {
+		return fmt.Errorf("pipeline %q stage %q sets merge: auto without allow_auto_merge: true", s.Name, stage.ID)
+	}
+	for _, candidate := range s.Stages {
+		if candidate.Kind() == StageKindAgentReview && strings.TrimSpace(candidate.Source) == strings.TrimSpace(stage.Source) {
+			return nil
+		}
+	}
+	return fmt.Errorf("pipeline %q stage %q sets merge: auto but source %q has no source-bound review stage; auto-merge requires at least one action: review stage with the same source", s.Name, stage.ID, stage.Source)
 }
 
 // validateStageSource applies the spec-level half of source binding. Gate-local

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -224,7 +224,7 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	}); err != nil {
 		return MergeDecision{}, err
 	}
-	result, err := g.GitHub.MergePullRequest(ctx, github.MergePullRequestInput{
+	result, err := executePullRequestMerge(ctx, g.GitHub, github.MergePullRequestInput{
 		Repo:            repo,
 		Number:          int64(request.PullRequest),
 		Method:          mergeMethod(g.MergeMethod),
@@ -244,6 +244,14 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 		return g.pending(ctx, request, headSHA, reason)
 	}
 	return g.finishMerged(ctx, request, pr, strings.TrimSpace(result.SHA))
+}
+
+// executePullRequestMerge is the single low-level GitHub merge path shared by
+// the native policy merge gate and the opt-in pipeline auto-merge gate.
+func executePullRequestMerge(ctx context.Context, client interface {
+	MergePullRequest(context.Context, github.MergePullRequestInput) (github.MergeResult, error)
+}, input github.MergePullRequestInput) (github.MergeResult, error) {
+	return client.MergePullRequest(ctx, input)
 }
 
 func (g PolicyMergeGate) finishMerged(ctx context.Context, request MergeRequest, pr github.PullRequest, mergeSHA string) (MergeDecision, error) {
@@ -546,9 +554,24 @@ func isIntegrationWorktreeReview(payload JobPayload) bool {
 }
 
 func (g PolicyMergeGate) ensureStatuses(ctx context.Context, repo github.Repository, pullRequest int64, headSHA string) error {
-	status, err := g.GitHub.GetCombinedStatus(ctx, repo, headSHA)
+	externalCount, err := g.evaluateStatuses(ctx, repo, pullRequest, headSHA)
 	if err != nil {
 		return err
+	}
+	if externalCount == 0 {
+		return g.concludeNoExternalCI(ctx, repo, pullRequest, headSHA)
+	}
+	return nil
+}
+
+// evaluateStatuses applies the native merge gate's explicit state semantics and
+// returns the total external status/check count. A caller chooses its zero-signal
+// policy: the native gate uses its bounded no-CI machinery, while unattended
+// pipeline auto-merge fails closed immediately.
+func (g PolicyMergeGate) evaluateStatuses(ctx context.Context, repo github.Repository, pullRequest int64, headSHA string) (int, error) {
+	status, err := g.GitHub.GetCombinedStatus(ctx, repo, headSHA)
+	if err != nil {
+		return 0, err
 	}
 	externalStatusCount := 0
 	for _, item := range status.Statuses {
@@ -557,25 +580,25 @@ func (g PolicyMergeGate) ensureStatuses(ctx context.Context, repo github.Reposit
 				continue
 			}
 			if statusPending(item.State) {
-				return mergePending{reason: fmt.Sprintf("gitmoot status %q is pending", item.Context)}
+				return 0, mergePending{reason: fmt.Sprintf("gitmoot status %q is pending", item.Context)}
 			}
 			if item.State != "success" {
-				return mergeBlocked{reason: fmt.Sprintf("gitmoot status %q is %s", item.Context, item.State)}
+				return 0, mergeBlocked{reason: fmt.Sprintf("gitmoot status %q is %s", item.Context, item.State)}
 			}
 			continue
 		}
 		externalStatusCount++
 		if statusPending(item.State) {
-			return mergePending{reason: "external commit status " + item.Context + " is pending"}
+			return 0, mergePending{reason: "external commit status " + item.Context + " is pending"}
 		}
 		if item.State != "success" {
-			return mergeBlocked{reason: "external commit status " + item.Context + " is not successful"}
+			return 0, mergeBlocked{reason: "external commit status " + item.Context + " is not successful"}
 		}
 	}
 
 	checks, err := g.GitHub.ListPullRequestChecks(ctx, repo, pullRequest)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	externalCheckCount := 0
 	for _, check := range checks {
@@ -588,19 +611,16 @@ func (g PolicyMergeGate) ensureStatuses(ctx context.Context, repo github.Reposit
 			if name == "" {
 				name = "unnamed check"
 			}
-			return mergePending{reason: fmt.Sprintf("external CI check %q is pending", name)}
+			return 0, mergePending{reason: fmt.Sprintf("external CI check %q is pending", name)}
 		}
 		if !checkPassed(check) {
 			if name == "" {
 				name = "unnamed check"
 			}
-			return mergeBlocked{reason: fmt.Sprintf("external CI check %q is not successful", name)}
+			return 0, mergeBlocked{reason: fmt.Sprintf("external CI check %q is not successful", name)}
 		}
 	}
-	if externalCheckCount == 0 && externalStatusCount == 0 {
-		return g.concludeNoExternalCI(ctx, repo, pullRequest, headSHA)
-	}
-	return nil
+	return externalCheckCount + externalStatusCount, nil
 }
 
 // concludeNoExternalCI is the layered defense for the #596 no-CI race. When a

--- a/internal/workflow/pipeline_auto_merge.go
+++ b/internal/workflow/pipeline_auto_merge.go
@@ -1,0 +1,160 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+// PipelineAutoMergeRequest identifies the immutable PR head a pipeline gate is
+// authorized to merge. MatchHeadCommit is enforced again by GitHub at write time.
+type PipelineAutoMergeRequest struct {
+	Repo        string
+	PullRequest int
+	HeadSHA     string
+	Pipeline    string
+	RunID       string
+	StageID     string
+}
+
+// PipelineAutoMergeReadiness is one non-mutating GitHub observation. Ready means
+// mergeability and checks are green; Waiting is a transient not-yet-green state;
+// Blocked is terminal for this pipeline run. Merged is idempotent success.
+type PipelineAutoMergeReadiness struct {
+	Ready          bool
+	Waiting        bool
+	Blocked        bool
+	Merged         bool
+	CurrentHeadSHA string
+	MergeCommitSHA string
+	Reason         string
+}
+
+// PipelineAutoMergeResult is the result of the single audited merge attempt.
+type PipelineAutoMergeResult struct {
+	Merged         bool
+	MergeCommitSHA string
+	Reason         string
+}
+
+// PipelineAutoMerger adapts the existing policy merge-gate checks and the shared
+// low-level merge call for the jobless pipeline gate. Review approval is checked
+// by the pipeline advancer before this type is invoked.
+type PipelineAutoMerger struct {
+	Store             *db.Store
+	GitHub            MergeGateGitHub
+	RequireExternalCI bool
+	MinCIWait         time.Duration
+	MaxCIWait         time.Duration
+	Clock             func() time.Time
+}
+
+// Evaluate performs no merge. It reads the current PR, enforces the stamped head,
+// mergeability, and the same status/check policy used by PolicyMergeGate.
+func (m PipelineAutoMerger) Evaluate(ctx context.Context, request PipelineAutoMergeRequest) (PipelineAutoMergeReadiness, error) {
+	repo, err := parseRepoFullName(request.Repo)
+	if err != nil {
+		return PipelineAutoMergeReadiness{}, err
+	}
+	if request.PullRequest <= 0 {
+		return PipelineAutoMergeReadiness{}, fmt.Errorf("pipeline auto-merge pull request number is required")
+	}
+	if m.Store == nil || m.GitHub == nil {
+		return PipelineAutoMergeReadiness{}, fmt.Errorf("pipeline auto-merge executor is not configured")
+	}
+	pr, err := m.GitHub.GetPullRequest(ctx, repo, int64(request.PullRequest))
+	if err != nil {
+		return PipelineAutoMergeReadiness{}, err
+	}
+	head := strings.TrimSpace(pr.HeadSHA)
+	readiness := PipelineAutoMergeReadiness{CurrentHeadSHA: head}
+	if pullRequestMerged(pr) {
+		readiness.Merged = true
+		readiness.MergeCommitSHA = strings.TrimSpace(pr.MergeSHA)
+		readiness.Reason = "pull request is already merged"
+		return readiness, nil
+	}
+	if strings.EqualFold(strings.TrimSpace(pr.State), "closed") {
+		readiness.Blocked = true
+		readiness.Reason = "pull request is closed without being merged"
+		return readiness, nil
+	}
+	if head == "" {
+		readiness.Blocked = true
+		readiness.Reason = "pull request head SHA is missing"
+		return readiness, nil
+	}
+	if want := strings.TrimSpace(request.HeadSHA); head != want {
+		readiness.Blocked = true
+		readiness.Reason = fmt.Sprintf("pull request head drifted after review: reviewed %s, current %s", shortSHA(want), shortSHA(head))
+		return readiness, nil
+	}
+	if pr.Mergeable == nil {
+		readiness.Waiting = true
+		readiness.Reason = "GitHub has not determined pull request mergeability yet"
+		return readiness, nil
+	}
+	if !*pr.Mergeable {
+		readiness.Blocked = true
+		readiness.Reason = "pull request is not mergeable; rebase or update the branch"
+		return readiness, nil
+	}
+	gate := PolicyMergeGate{
+		Store:             m.Store,
+		GitHub:            m.GitHub,
+		RequireExternalCI: m.RequireExternalCI,
+		MinCIWait:         m.MinCIWait,
+		MaxCIWait:         m.MaxCIWait,
+		Clock:             m.Clock,
+	}
+	externalCount, statusErr := gate.evaluateStatuses(ctx, repo, int64(request.PullRequest), head)
+	if statusErr != nil {
+		var pending mergePending
+		if errors.As(statusErr, &pending) {
+			readiness.Waiting = true
+			readiness.Reason = pending.reason
+			return readiness, nil
+		}
+		var blocked mergeBlocked
+		if errors.As(statusErr, &blocked) {
+			readiness.Blocked = true
+			readiness.Reason = blocked.reason
+			return readiness, nil
+		}
+		return PipelineAutoMergeReadiness{}, statusErr
+	}
+	if externalCount == 0 {
+		readiness.Blocked = true
+		readiness.Reason = fmt.Sprintf("pipeline auto-merge requires at least one external CI status or check at head %s; zero external checks reported", shortSHA(head))
+		return readiness, nil
+	}
+	readiness.Ready = true
+	readiness.Reason = "pull request is mergeable and checks passed"
+	return readiness, nil
+}
+
+// Merge executes exactly one squash attempt against the reviewed head. Callers
+// must record their auditable intent event before entering this method.
+func (m PipelineAutoMerger) Merge(ctx context.Context, request PipelineAutoMergeRequest) (PipelineAutoMergeResult, error) {
+	repo, err := parseRepoFullName(request.Repo)
+	if err != nil {
+		return PipelineAutoMergeResult{}, err
+	}
+	result, err := executePullRequestMerge(ctx, m.GitHub, github.MergePullRequestInput{
+		Repo:            repo,
+		Number:          int64(request.PullRequest),
+		Method:          "squash",
+		Subject:         fmt.Sprintf("Gitmoot pipeline %s run %s", request.Pipeline, request.RunID),
+		Body:            fmt.Sprintf("Merged by Gitmoot pipeline gate %s after source-bound review approval and checks passed.", request.StageID),
+		MatchHeadCommit: strings.TrimSpace(request.HeadSHA),
+	})
+	if err != nil {
+		return PipelineAutoMergeResult{}, err
+	}
+	return PipelineAutoMergeResult{Merged: result.Merged, MergeCommitSHA: strings.TrimSpace(result.SHA), Reason: strings.TrimSpace(result.Message)}, nil
+}

--- a/internal/workflow/pipeline_auto_merge_test.go
+++ b/internal/workflow/pipeline_auto_merge_test.go
@@ -1,0 +1,53 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/github"
+)
+
+func TestPipelineAutoMergerEvaluateCheckStates(t *testing.T) {
+	mergeable := true
+	tests := []struct {
+		name              string
+		checks            []github.PullRequestCheck
+		requireExternalCI bool
+		wantReady         bool
+		wantWaiting       bool
+		wantBlocked       bool
+		wantReason        string
+	}{
+		{name: "pending waits", checks: []github.PullRequestCheck{{Name: "ci", Bucket: "pending", State: "IN_PROGRESS"}}, wantWaiting: true, wantReason: "pending"},
+		{name: "skipped passes", checks: []github.PullRequestCheck{{Name: "ci", Bucket: "skipping", State: "SKIPPED"}}, wantReady: true},
+		{name: "neutral passes", checks: []github.PullRequestCheck{{Name: "ci", State: "neutral"}}, wantReady: true},
+		{name: "failure blocks", checks: []github.PullRequestCheck{{Name: "ci", Bucket: "fail", State: "FAILURE"}}, wantBlocked: true, wantReason: "not successful"},
+		{name: "zero checks blocks policy off", wantBlocked: true, wantReason: "zero external checks"},
+		{name: "zero checks blocks policy on", requireExternalCI: true, wantBlocked: true, wantReason: "zero external checks"},
+		{name: "green passes", checks: []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}}, wantReady: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := openEngineStore(t)
+			gh := &fakeMergeGateGitHub{
+				pr:     github.PullRequest{Number: 813, State: "open", HeadSHA: "reviewed-head", Mergeable: &mergeable},
+				checks: tc.checks,
+			}
+			merger := PipelineAutoMerger{Store: store, GitHub: gh, RequireExternalCI: tc.requireExternalCI}
+			got, err := merger.Evaluate(context.Background(), PipelineAutoMergeRequest{Repo: "owner/repo", PullRequest: 813, HeadSHA: "reviewed-head"})
+			if err != nil {
+				t.Fatalf("Evaluate: %v", err)
+			}
+			if got.Ready != tc.wantReady || got.Waiting != tc.wantWaiting || got.Blocked != tc.wantBlocked {
+				t.Fatalf("readiness = %+v, want ready=%v waiting=%v blocked=%v", got, tc.wantReady, tc.wantWaiting, tc.wantBlocked)
+			}
+			if tc.wantReason != "" && !strings.Contains(got.Reason, tc.wantReason) {
+				t.Fatalf("reason = %q, want substring %q", got.Reason, tc.wantReason)
+			}
+			if len(gh.statuses) != 0 {
+				t.Fatalf("pipeline evaluator synthesized commit statuses: %+v", gh.statuses)
+			}
+		})
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2097,10 +2097,11 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     prompt: "Triage the scored data; block if a human is needed."
     needs: [score]          #   upstream results are prepended to the prompt
   # other agent-stage kinds:
-  #   implement (#768): action: implement + write: true → mutates repo + opens a PR (never auto-merges)
+  #   implement (#768): action: implement + write: true → mutates repo + opens a PR
   #   bound review (#813): action: review + source: <impl stage> -> reviews that PR/head, report-only
   #   orchestrate (#758): orchestrate: true → sub-tree coordinator (fans out owned children, folds synthesis)
-  #   gate (#768): gate: pr_merged + source: <impl stage> (no agent) → jobless, folds when that PR merges
+  #   gate (#768): gate: pr_merged + source: <impl stage> (no agent) → jobless; human merge is default
+  #   auto-merge gate: add merge: auto plus top-level allow_auto_merge: true; requires source-bound review
   - id: deploy
     cmd: "rclone copy out/ r2:bucket"
     needs: [triage]
@@ -2160,6 +2161,20 @@ fix job and never run the native merge gate. Declaring this review also sets
 reviewer jobs. If the source permanently produces no PR (no-op or `skipped`), the
 review folds blocked immediately with `source stage produced no PR; nothing to
 review` and no unbound review is dispatched.
+
+The `pr_merged` gate remains a human-merge waiter by default. Opt-in
+`merge: auto` is gate-only and also requires top-level `allow_auto_merge: true`
+plus at least one review stage bound to the same implement source. The advancer,
+not the report-only review job, performs one squash attempt only after every bound
+review folded `approved`, the live PR head still equals the reviewed payload
+`HeadSHA`, GitHub reports mergeable, and checks pass. Pending checks keep waiting;
+head drift, conflicts/unmergeability, or a merge API error fold the gate blocked.
+Merge errors are not retried. Scheduled pipelines need both `allow_auto_merge` and
+the existing `allow_scheduled_writes` key. Omitting `merge` preserves human merge.
+Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
+external statuses/checks always block regardless of `require_external_ci`. The
+source job atomically records `pipeline_auto_merge_claim` before the write and
+`pipeline_auto_merge_confirmed` after GitHub confirms it.
 
 `pipeline install-defaults` installs the built-in memory pipelines
 `memory-ingest-sweep` and `memory-groom-propose`. The daemon also runs this

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1004,7 +1004,7 @@ runtime (claude / codex). Four kinds:
 - **implement** (#768): `action: implement` + `write: true`. MUTATES the repo on a
   deterministic `gitmoot/pipe-<run>-<stage>` branch (retry reuses it, never duplicates).
   The `implemented` decision folds **on PR-opened**; other configured success decisions
-  settle immediately without promising a PR. It **never auto-merges**. Scheduled
+  settle immediately without promising a PR. The implement job never merges. Scheduled
   pipelines also need pipeline-level `allow_scheduled_writes: true`.
 - **produce** (#814) — `action: produce` + `write: true` + absolute cleaned
   `writes:`. Codex-only data writer; never branch/task/PR state. Optional
@@ -1018,7 +1018,8 @@ runtime (claude / codex). Four kinds:
   continuation chain, folds the tail. `retry: 0`.
 - **gate** (#768) — `gate: pr_merged` + `source: <upstream implement stage>`, no
   `agent`. Jobless waiter: folds succeeded when the source PR merges; parks `blocked`
-  on close-unmerged or timeout. The composable *wait-for-merge*.
+  on close-unmerged or timeout. Human merge is the default. Add gate-level
+  `merge: auto` plus top-level `allow_auto_merge: true` for reviewed auto-merge.
 
 ```yaml
 stages:
@@ -1066,6 +1067,21 @@ also sets `SkipNativeReviewFanout` on `fix`, preventing duplicate reviewer fan-o
 pipelines without the declaration keep native behavior. Any terminal succeeded no-PR
 source (a no-op or a non-`implemented` success decision) blocks the review immediately with `source stage produced no
 PR; nothing to review` instead of dispatching an unbound job or waiting.
+
+For opt-in auto-merge, add `merge: auto` to the `pr_merged` gate and
+`allow_auto_merge: true` at pipeline level. Registration refuses this mode without
+at least one review bound to the same implement source. The advancer requires every
+such review to fold succeeded with decision `approved`, verifies the live PR head
+still equals the reviewed structured `HeadSHA`, then requires GitHub mergeability
+and passing checks before one squash attempt. Pending checks wait within the gate
+timeout; head drift, unmergeability/conflict, and merge API errors fold blocked, and
+merge errors are not retried. The review job remains report-only. Scheduled flows
+also require `allow_scheduled_writes: true`; both top-level safety keys are required.
+Without `merge: auto`, human merge remains unchanged.
+Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
+external statuses/checks always block regardless of `require_external_ci`. The
+source job event timeline atomically records `pipeline_auto_merge_claim` before
+the write and `pipeline_auto_merge_confirmed` after GitHub confirms it.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -166,10 +166,10 @@ is **exactly one** of `cmd`, `agent`, or `gate`. There are five agent-stage kind
 | Kind | Declared by | What it does |
 | ---- | ----------- | ------------ |
 | **ask / review** (#757/#813) | `action: ask\|review` (review may add `source:`) | Read-only leaf; optionally reviews one upstream implement PR at its exact head. |
-| **implement** (#768) | `action: implement` + `write: true` | Mutates the repo; `implemented` folds on PR-opened, while other configured successes settle without promising a PR. Never auto-merges. |
+| **implement** (#768) | `action: implement` + `write: true` | Mutates the repo; `implemented` folds on PR-opened, while other configured successes settle without promising a PR. The implement job never merges. |
 | **produce** (#814) | `action: produce` + `write: true` + `writes:` | Codex-only data writer; never creates repo/branch/task/PR state. |
 | **orchestrate** (#758) | `orchestrate: true` | Sub-tree coordinator — fans out owned children, waits, folds the synthesis. |
-| **gate** (#768) | `gate: pr_merged` + `source:` (no `agent`) | Jobless waiter — folds when an upstream implement stage's PR merges. |
+| **gate** (#768) | `gate: pr_merged` + `source:` (no `agent`) | Jobless waiter — human merge by default; reviewed auto-merge is an explicit double-key opt-in. |
 
 ```yaml
 stages:
@@ -215,11 +215,51 @@ is detached at that exact head and checkout validation confirms it; this binding
 never inferred from summary text. Pipeline reviews are **report-only**: the verdict
 still appears as a PR comment and folds through `success_decisions`, but
 `changes_requested` does not dispatch a native fix and `approved` does not run the
-native merge gate. Human merge remains required. Declaring the binding sets
+native merge gate. Human merge remains required unless a separately double-keyed
+`merge: auto` gate is present. Declaring the binding sets
 `SkipNativeReviewFanout` on the implement request so Gitmoot does not also enqueue
 native reviewers. If the source produced no PR (a no-op or any successful
 non-`implemented` decision), the review
 folds blocked immediately with `source stage produced no PR; nothing to review`.
+
+### Opt-in auto-merge gates
+
+Human merge is the unchanged default. A pipeline may instead let its jobless gate
+perform the squash merge by declaring both keys and a source-bound robot review:
+
+```yaml
+allow_auto_merge: true
+stages:
+  - id: review
+    agent: reviewer
+    action: review
+    prompt: "Review the implementation PR."
+    source: fix
+    needs: [fix]
+    success_decisions: [approved]
+  - id: merge
+    gate: pr_merged
+    merge: auto
+    source: fix
+    needs: [fix, review]
+```
+
+`merge: auto` is valid only on a gate and registration requires top-level
+`allow_auto_merge: true` plus at least one review bound to the same implement
+source. Every bound review in the spec must fold succeeded with decision
+`approved`. The pipeline advancer—not the report-only review job—then verifies the
+live PR head still equals the reviewed structured `HeadSHA`, waits for GitHub
+mergeability and at least one external CI status/check, atomically claims the
+write, and makes one squash attempt. Pending checks keep waiting within the gate
+timeout. Check-run `skipped` and `neutral` count as passing, matching the native
+merge gate; failures block. Zero external statuses/checks always block pipeline
+auto-merge—even when `[merge_gate] require_external_ci` is false—so unattended
+merge never synthesizes a no-CI success. Head drift, unmergeability/conflict, or a
+merge API failure also folds the gate blocked; merge errors are not retried. A
+scheduled auto-merge flow requires both `allow_auto_merge: true` and the existing
+`allow_scheduled_writes: true`. The source job records an atomic
+`pipeline_auto_merge_claim` before the write and `pipeline_auto_merge_confirmed`
+after GitHub confirms it; racing scans that lose the claim do not call merge.
 
 An agent stage runs the named agent on **its own registered runtime** (claude /
 codex — no per-job shell override):

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2625,6 +2625,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
 | `success_decisions`         | pipeline     | no       | Decisions that mark a stage succeeded. Default `["approved","implemented","skipped"]`. Any value must be one of `approved`, `implemented`, `changes_requested`, `skipped` - `blocked`/`failed` are park states and are rejected. An explicit list is strict: omitting `skipped` requires real work and makes a skipped result fail. |
 | `allow_scheduled_writes`    | pipeline     | no       | Safety flag. A **mutating** `implement` or `produce` stage on a **scheduled** pipeline is rejected unless this is `true`. Manual runs do not need it. Default `false`. |
+| `allow_auto_merge`          | pipeline     | no       | Pipeline-level half of the auto-merge double key. Required with a gate's `merge: auto`; default `false`. It does not replace `allow_scheduled_writes` on scheduled pipelines. |
 | `stages[].id`               | stage        | yes      | Unique, name-safe stage id. Appears verbatim in the stage job's fingerprint and deterministic id. |
 | `stages[].cmd`              | stage        | cond.    | Shell command run verbatim via `sh -c` (see the stage contract below). A stage is **exactly one** of `cmd`, `agent`, or `gate`. |
 | `stages[].agent`            | stage        | cond.    | Name of a managed gitmoot agent to run this stage (instead of a shell `cmd`). Must be a name-safe token; `pipeline add` warns (does not block) if the agent does not exist yet, but it must exist before the stage runs. Mutually exclusive with `cmd`/`gate`. The stage kind depends on `action`/`write`/`orchestrate` — see [Agent stages](#agent-stages). |
@@ -2637,6 +2638,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].check_retries`    | stage        | no       | Produce-only count of same-session correction turns after a non-zero `check` (`>= 0`, default `0`). |
 | `stages[].orchestrate`      | stage        | no       | `true` makes an agent stage a **sub-tree coordinator** (#758): its `delegations[]` fan out as owned children and the stage waits for the whole tree, then folds the synthesis. Agent stage only; `action` must be `ask`. |
 | `stages[].gate`             | stage        | cond.    | Makes this a **jobless gate stage** (#768): it runs no worker and folds when an external predicate holds. Only `pr_merged` today. Exclusive with `cmd`/`agent`. Requires `source`. |
+| `stages[].merge`            | stage        | no       | Gate-only merge authority. Omit for the unchanged human-merge default; `auto` lets the pipeline advancer squash-merge after all safety conditions hold. |
 | `stages[].source`           | stage        | cond.    | The upstream `implement` stage whose PR to bind. Required on a `gate`; optional on `action: review`; rejected on shell/ask/implement/orchestrate stages. It must be one of the stage's own `needs`. |
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
@@ -2799,12 +2801,14 @@ stages:
   attempt-independent branch `gitmoot/pipe-<run>-<stage>` (reusing the implement
   dispatch's fail-closed guards). A **retry** lands in the *same* branch/PR — never a
   duplicate — and fails closed if that worktree is dirty or has a live process.
-- **Folds on PR-opened.** A `success` decision folds only once the job carries an
-  opened PR. The first-class `skipped` decision bypasses that wait because there is
-  no work to turn into a PR. The opened PR number is appended to the stage summary so a
-  downstream stage sees it via upstream-context injection.
-- **Never auto-merges.** The pipeline **opens** the PR; a human or your CI does the
-  merge. See [Gate stages](#gate-stages) to make a later stage wait for that merge.
+- **`implemented` folds on PR-opened.** Only `implemented` promises a PR, so that
+  decision waits until the job carries the opened PR stamp (or the engine confirms a
+  terminal no-PR no-op). Other configured success decisions, including `approved` and
+  `skipped`, settle immediately without a PR. The stage summary records the opened PR
+  number or the terminal no-PR outcome for downstream context.
+- **Does not merge by itself.** The implement stage only opens the PR. The default
+  gate still waits for a human merge; a separately double-keyed `merge: auto` gate
+  may merge after review and CI (see [Gate stages](#gate-stages)).
 - **Declared review suppresses native fan-out.** When an implement stage has a
   downstream `action: review` stage with `source` pointing to it, its job carries
   `SkipNativeReviewFanout`. Gitmoot does not also enqueue the ordinary native
@@ -2826,8 +2830,8 @@ the implement stage just opened. `source` must also appear in the review stage's
   still posted as a PR comment and folded by the pipeline's `success_decisions`, but
   `changes_requested` does not dispatch a native fix job and `approved` does not run
   the native merge gate. Human merge remains the default.
-- If the succeeded implement stage produced no PR (a permanent no-op or a first-class
-  `skipped` result), the review stage immediately folds `blocked` with
+- If the succeeded implement stage produced no PR (a permanent no-op or any successful
+  non-`implemented` decision), the review stage immediately folds `blocked` with
   `source stage produced no PR; nothing to review`; no unbound review job is sent.
 
 ### Gate stages
@@ -2858,8 +2862,59 @@ stages:
   **fails open** (keeps waiting while unmerged), and is bounded by the stage `timeout`.
 - A PR that is **closed without merging**, or a **timeout**, parks the run `blocked`
   (a gate is a wait, not a failure — so a retry budget can't re-arm the timer).
-- A source stage that succeeded via `skipped` also parks the gate `blocked`
-  immediately: no PR will exist for that run.
+- A source stage that succeeds without opening a PR also parks the gate `blocked`
+  immediately with `source stage succeeded without opening a PR; nothing to wait for`.
+  Only `implemented` promises the PR that this gate can watch.
+
+#### Opt-in auto-merge
+
+The default is and remains **human merge**. To let the pipeline advancer perform
+the squash merge, spell both keys and declare at least one source-bound review:
+
+```yaml
+allow_auto_merge: true
+stages:
+  - id: fix
+    agent: fixer
+    action: implement
+    write: true
+    prompt: "Apply the change."
+  - id: review
+    agent: reviewer
+    action: review
+    source: fix
+    needs: [fix]
+    prompt: "Review the implementation PR."
+    success_decisions: [approved]
+  - id: merge
+    gate: pr_merged
+    merge: auto
+    source: fix
+    needs: [fix, review]
+```
+
+- `merge: auto` is valid only on a gate and requires top-level
+  `allow_auto_merge: true`. A scheduled pipeline still needs
+  `allow_scheduled_writes: true` for its implement stage, so scheduled auto-merge
+  requires **both** top-level keys.
+- Registration rejects an auto-merge gate unless at least one `action: review`
+  stage binds to the same implement `source`. Before merging, the advancer requires
+  **every** such review stage to have folded `succeeded` with decision `approved`.
+  `changes_requested` parks the run and never merges.
+- The source PR and reviewed head come from structured job payloads, never summary
+  prose. The live PR head must still equal that reviewed `HeadSHA`; drift parks the
+  gate `blocked` and names the mismatch.
+- GitHub must report the PR mergeable and at least one external CI status/check.
+  Pending checks keep the jobless gate waiting within its stage timeout. Check-run
+  `skipped`/`neutral` outcomes count as passing, matching the native merge gate;
+  failed checks park it `blocked`. Zero external statuses/checks always park
+  pipeline auto-merge `blocked`, even when `[merge_gate] require_external_ci` is
+  false—the unattended path never synthesizes no-CI success.
+- Unmergeable/conflicting PRs, head drift, and merge API errors park it `blocked`;
+  a merge API failure is tried once and never retry-spammed.
+- The source job timeline atomically records `pipeline_auto_merge_claim` before
+  the write and `pipeline_auto_merge_confirmed` afterward, carrying pipeline/run,
+  stage, PR, and head SHA. Racing scans that lose the claim never call merge.
 
 ### Orchestrate stages
 
@@ -3112,8 +3167,9 @@ implement` requires an explicit `write: true` double-key (and `write: true` is v
 only on an implement stage), so a typo or prompt injection cannot flip a read-only
 pipeline into a writing one; a mutating stage on a **scheduled** pipeline is rejected
 unless the pipeline sets `allow_scheduled_writes: true`; the bound agent's own
-capability/policy still applies; and the pipeline **never merges its own PR** — it
-opens the PR and leaves the merge to a human or CI.
+capability/policy still applies; and the implement job never merges its own PR. The
+default gate leaves merge to a human or CI; only the separately double-keyed,
+review-required `merge: auto` gate grants merge authority to the advancer.
 
 ## Not yet supported (deferred)
 
@@ -10384,10 +10440,11 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     prompt: "Triage the scored data; block if a human is needed."
     needs: [score]          #   upstream results are prepended to the prompt
   # other agent-stage kinds:
-  #   implement (#768): action: implement + write: true → mutates repo + opens a PR (never auto-merges)
+  #   implement (#768): action: implement + write: true → mutates repo + opens a PR
   #   bound review (#813): action: review + source: <impl stage> -> reviews that PR/head, report-only
   #   orchestrate (#758): orchestrate: true → sub-tree coordinator (fans out owned children, folds synthesis)
-  #   gate (#768): gate: pr_merged + source: <impl stage> (no agent) → jobless, folds when that PR merges
+  #   gate (#768): gate: pr_merged + source: <impl stage> (no agent) → jobless; human merge is default
+  #   auto-merge gate: add merge: auto plus top-level allow_auto_merge: true; requires source-bound review
   - id: deploy
     cmd: "rclone copy out/ r2:bucket"
     needs: [triage]
@@ -10447,6 +10504,20 @@ fix job and never run the native merge gate. Declaring this review also sets
 reviewer jobs. If the source permanently produces no PR (no-op or `skipped`), the
 review folds blocked immediately with `source stage produced no PR; nothing to
 review` and no unbound review is dispatched.
+
+The `pr_merged` gate remains a human-merge waiter by default. Opt-in
+`merge: auto` is gate-only and also requires top-level `allow_auto_merge: true`
+plus at least one review stage bound to the same implement source. The advancer,
+not the report-only review job, performs one squash attempt only after every bound
+review folded `approved`, the live PR head still equals the reviewed payload
+`HeadSHA`, GitHub reports mergeable, and checks pass. Pending checks keep waiting;
+head drift, conflicts/unmergeability, or a merge API error fold the gate blocked.
+Merge errors are not retried. Scheduled pipelines need both `allow_auto_merge` and
+the existing `allow_scheduled_writes` key. Omitting `merge` preserves human merge.
+Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
+external statuses/checks always block regardless of `require_external_ci`. The
+source job atomically records `pipeline_auto_merge_claim` before the write and
+`pipeline_auto_merge_confirmed` after GitHub confirms it.
 
 `pipeline install-defaults` installs the built-in memory pipelines
 `memory-ingest-sweep` and `memory-groom-propose`. The daemon also runs this
@@ -11726,24 +11797,26 @@ printf '%s' '{"gitmoot_result":{"decision":"blocked","summary":"secret missing",
 `skipped` is the default-on success decision for a stage whose task had no work.
 The persisted summary is prefixed with `[skipped: no work]`, so downstream agent
 stages receive the honest outcome. An explicit `success_decisions` list that
-omits `skipped` is strict and folds it failed. If an implement source skips, a
-downstream `pr_merged` gate parks blocked instead of waiting for a PR that cannot
-exist. The result still uses the existing succeeded stage state; the `SKIPPED`
+omits `skipped` is strict and folds it failed. Only `implemented` promises a PR from
+an implement stage; other configured success decisions settle immediately. If an
+implement source succeeds without a PR, a downstream `pr_merged` gate parks blocked
+instead of waiting forever. The result still uses the existing succeeded stage state; the `SKIPPED`
 funnel state remains reserved for downstream stages that never ran.
 
 ### Agent stages (#757 / #768 / #758)
 
-A stage may run a **named managed agent** instead of a shell command — a stage is
+A stage may run a **named managed agent** instead of a shell command; a stage is
 exactly one of `cmd`, `agent`, or `gate`. An agent stage runs on its **own** registered
 runtime (claude / codex). Four kinds:
 
 - **ask / review** (#757) — read-only **leaf** (`action: ask|review`); `delegations[]`
   and `human_questions[]` stripped. A review may add `source: <implement stage>`
   (#813) to bind to that stage's PR and exact head SHA.
-- **implement** (#768) — `action: implement` + `write: true`. MUTATES the repo + opens a
-  PR on a deterministic `gitmoot/pipe-<run>-<stage>` branch (retry reuses it, never
-  duplicates), folds **on PR-opened**, **never auto-merges**. Scheduled pipelines also
-  need pipeline-level `allow_scheduled_writes: true`.
+- **implement** (#768): `action: implement` + `write: true`. MUTATES the repo on a
+  deterministic `gitmoot/pipe-<run>-<stage>` branch (retry reuses it, never duplicates).
+  The `implemented` decision folds **on PR-opened**; other configured success decisions
+  settle immediately without promising a PR. The implement job never merges. Scheduled
+  pipelines also need pipeline-level `allow_scheduled_writes: true`.
 - **produce** (#814) — `action: produce` + `write: true` + absolute cleaned
   `writes:`. Codex-only data writer; never branch/task/PR state. Optional
   `network: true`, `check`, and bounded same-session `check_retries`. Declared paths
@@ -11756,7 +11829,8 @@ runtime (claude / codex). Four kinds:
   continuation chain, folds the tail. `retry: 0`.
 - **gate** (#768) — `gate: pr_merged` + `source: <upstream implement stage>`, no
   `agent`. Jobless waiter: folds succeeded when the source PR merges; parks `blocked`
-  on close-unmerged or timeout. The composable *wait-for-merge*.
+  on close-unmerged or timeout. Human merge is the default. Add gate-level
+  `merge: auto` plus top-level `allow_auto_merge: true` for reviewed auto-merge.
 
 ```yaml
 stages:
@@ -11801,9 +11875,24 @@ succeeded implement job and runs in a detached worktree pinned to that head. It 
 report-only: the verdict is posted to the PR and folded by the pipeline, but it does
 not dispatch a native fix job or run the native merge gate. The declared binding
 also sets `SkipNativeReviewFanout` on `fix`, preventing duplicate reviewer fan-out;
-pipelines without the declaration keep native behavior. A permanent no-PR source
-(no-op or `skipped`) blocks the review immediately with `source stage produced no
+pipelines without the declaration keep native behavior. Any terminal succeeded no-PR
+source (a no-op or a non-`implemented` success decision) blocks the review immediately with `source stage produced no
 PR; nothing to review` instead of dispatching an unbound job or waiting.
+
+For opt-in auto-merge, add `merge: auto` to the `pr_merged` gate and
+`allow_auto_merge: true` at pipeline level. Registration refuses this mode without
+at least one review bound to the same implement source. The advancer requires every
+such review to fold succeeded with decision `approved`, verifies the live PR head
+still equals the reviewed structured `HeadSHA`, then requires GitHub mergeability
+and passing checks before one squash attempt. Pending checks wait within the gate
+timeout; head drift, unmergeability/conflict, and merge API errors fold blocked, and
+merge errors are not retried. The review job remains report-only. Scheduled flows
+also require `allow_scheduled_writes: true`; both top-level safety keys are required.
+Without `merge: auto`, human merge remains unchanged.
+Pending checks wait; skipped/neutral check-runs pass; failures block; and zero
+external statuses/checks always block regardless of `require_external_ci`. The
+source job event timeline atomically records `pipeline_auto_merge_claim` before
+the write and `pipeline_auto_merge_confirmed` after GitHub confirms it.
 
 `pipeline add` warns (does not block) when an agent stage names an agent that does
 not exist yet; create it before the stage runs. The


### PR DESCRIPTION
Implements the owner-approved #813 scope extension (auto-merge as explicit opt-in policy).

**Human merge stays the default.** `merge: auto` + top-level `allow_auto_merge: true` (double key) lets the pipeline advancer merge once: implement succeeded w/ stamped PR · **every** source-bound review approved (validation requires at least one — no unreviewed auto-ship) · head matches the reviewed SHA (drift blocks; MatchHeadCommit pins the merge call) · checks green via the same per-repo merge-gate policy, **zero-check heads fail closed**.

Atomic single-winner merge claim (racing scans concurrency-tested) · merge errors fold blocked, never retry · audited intent+confirmation events · report-only review guard untouched · merge:human gates byte-identical.

Adversarial review (gpt-5.6-sol @ xhigh) found 3 blocking issues (double-merge race, per-repo policy bypass, zero-check semantics) — fixed with production-executor tests across all check states. Full suites green incl. uncached cli (256s) + race test on the claim. Docs both trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)