### PR TITLE
fix(memory): seam-only brick splitting + split context + groom --split-revert (#842 Phase 1)

### DIFF
--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -84,7 +84,7 @@ func printMemoryUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot memory promote --to-shared <id>... [--json]")
 	fmt.Fprintln(w, "  gitmoot memory links backfill [--dry-run] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory links list <id> [--json]")
-	fmt.Fprintln(w, "  gitmoot memory groom --propose [--out PLAN.json] [--json] | --yes --plan PLAN.json [--json]")
+	fmt.Fprintln(w, "  gitmoot memory groom --propose | --yes --plan PLAN.json | --split | --split-revert [options]")
 	fmt.Fprintln(w, "  gitmoot memory clusters [--json]")
 	fmt.Fprintln(w, "  gitmoot memory clusters recompute --propose [--out PLAN.json] [--json] | --apply [--plan PLAN.json] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory cluster rename <cluster-id> <label>")
@@ -122,6 +122,7 @@ type memoryRecallEntry struct {
 	Repo       string            `json:"repo"`
 	Scope      string            `json:"scope"`
 	Key        string            `json:"key"`
+	Context    string            `json:"context,omitempty"`
 	Content    string            `json:"content"`
 	Provenance string            `json:"provenance"`
 	UpdatedAt  string            `json:"updated_at"`
@@ -208,6 +209,7 @@ func runMemoryRecall(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, memory.RenderBullet(memory.Entry{
 			Scope:     r.Scope,
 			Key:       r.Key,
+			Context:   r.Context,
 			Content:   r.Content,
 			UpdatedAt: r.UpdatedAt,
 			Linked:    linkedFrom[r.ID] != 0,
@@ -308,6 +310,7 @@ func memoryRecallJSONEntry(r db.ConfirmedMemory, linkedFrom int64) memoryRecallE
 		Repo:       r.Repo,
 		Scope:      r.Scope,
 		Key:        r.Key,
+		Context:    r.Context,
 		Content:    r.Content,
 		Provenance: r.Provenance,
 		UpdatedAt:  r.UpdatedAt,

--- a/internal/cli/memory_groom.go
+++ b/internal/cli/memory_groom.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/memory"
@@ -131,6 +133,32 @@ type groomSplitOutput struct {
 	Splits   []groomSplitSummary `json:"splits"`
 }
 
+type groomSplitRevertOutput struct {
+	DryRun   bool                         `json:"dry_run"`
+	Matched  int                          `json:"matched"`
+	Reverted []db.GroomSplitReverted      `json:"reverted"`
+	Skipped  []db.GroomSplitRevertSkipped `json:"skipped"`
+}
+
+type groomParentIDs []int64
+
+func (ids *groomParentIDs) String() string {
+	parts := make([]string, 0, len(*ids))
+	for _, id := range *ids {
+		parts = append(parts, strconv.FormatInt(id, 10))
+	}
+	return strings.Join(parts, ",")
+}
+
+func (ids *groomParentIDs) Set(value string) error {
+	id, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil || id <= 0 {
+		return fmt.Errorf("parent must be a positive memory id: %q", value)
+	}
+	*ids = append(*ids, id)
+	return nil
+}
+
 func runMemoryGroom(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("memory groom", flag.ContinueOnError)
 	fs.SetOutput(stderr)
@@ -138,7 +166,11 @@ func runMemoryGroom(args []string, stdout, stderr io.Writer) int {
 	propose := fs.Bool("propose", false, "read confirmed memory, run the detectors, and write a reviewable plan (writes nothing to the store)")
 	yes := fs.Bool("yes", false, "apply a plan's retirements (requires --plan)")
 	split := fs.Bool("split", false, "automatically split qualifying brick memories into lossless children")
-	dryRun := fs.Bool("dry-run", false, "with --split, print qualifying splits without writing")
+	splitRevert := fs.Bool("split-revert", false, "restore parents from active lossless groom-split children")
+	dryRun := fs.Bool("dry-run", false, "with --split or --split-revert, print changes without writing")
+	var parentIDs groomParentIDs
+	fs.Var(&parentIDs, "parent", "with --split-revert, restore only this parent memory id (repeatable)")
+	since := fs.String("since", "", "with --split-revert, restore splits created at or after this RFC3339 timestamp")
 	plan := fs.String("plan", "", "path to a plan artifact produced by --propose (required with --yes)")
 	out := fs.String("out", "", "where --propose writes the plan (default: <home>/evals/groom/groom-<snapshot>.json)")
 	jsonOut := fs.Bool("json", false, "print the summary as JSON")
@@ -146,26 +178,40 @@ func runMemoryGroom(args []string, stdout, stderr io.Writer) int {
 		return memoryFlagExit(err)
 	}
 	modes := 0
-	for _, enabled := range []bool{*propose, *yes, *split} {
+	for _, enabled := range []bool{*propose, *yes, *split, *splitRevert} {
 		if enabled {
 			modes++
 		}
 	}
 	if modes != 1 {
-		fmt.Fprintln(stderr, "memory groom: pass exactly one of --propose, --yes, or --split")
+		fmt.Fprintln(stderr, "memory groom: pass exactly one of --propose, --yes, --split, or --split-revert")
 		printMemoryGroomUsage(stderr)
 		return 2
 	}
-	if *dryRun && !*split {
-		fmt.Fprintln(stderr, "memory groom: --dry-run requires --split")
+	if *dryRun && !*split && !*splitRevert {
+		fmt.Fprintln(stderr, "memory groom: --dry-run requires --split or --split-revert")
 		printMemoryGroomUsage(stderr)
 		return 2
+	}
+	if (len(parentIDs) > 0 || strings.TrimSpace(*since) != "") && !*splitRevert {
+		fmt.Fprintln(stderr, "memory groom: --parent and --since require --split-revert")
+		printMemoryGroomUsage(stderr)
+		return 2
+	}
+	if value := strings.TrimSpace(*since); value != "" {
+		if _, err := time.Parse(time.RFC3339, value); err != nil {
+			fmt.Fprintf(stderr, "memory groom: --since must be RFC3339: %v\n", err)
+			return 2
+		}
 	}
 	if *propose {
 		return runMemoryGroomPropose(*home, *out, *jsonOut, stdout, stderr)
 	}
 	if *split {
 		return runMemoryGroomSplit(*home, *dryRun, *jsonOut, stdout, stderr)
+	}
+	if *splitRevert {
+		return runMemoryGroomSplitRevert(*home, []int64(parentIDs), strings.TrimSpace(*since), *dryRun, *jsonOut, stdout, stderr)
 	}
 	return runMemoryGroomApply(*home, *plan, *jsonOut, stdout, stderr)
 }
@@ -177,6 +223,7 @@ func printMemoryGroomUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot memory groom --propose [--out PLAN.json] [--json]")
 	fmt.Fprintln(w, "  gitmoot memory groom --yes --plan PLAN.json [--json]")
 	fmt.Fprintln(w, "  gitmoot memory groom --split [--dry-run] [--json]")
+	fmt.Fprintln(w, "  gitmoot memory groom --split-revert [--dry-run] [--parent N]... [--since RFC3339] [--json]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "  --propose  read active confirmed memory, run the deterministic detectors")
 	fmt.Fprintln(w, "             (status/changelog/ToC snapshots, bare to-do lists, exact duplicates,")
@@ -189,7 +236,9 @@ func printMemoryGroomUsage(w io.Writer) {
 	fmt.Fprintln(w, "             Content is never edited or rewritten.")
 	fmt.Fprintln(w, "  --split    automatically split qualifying multi-story bricks at deterministic")
 	fmt.Fprintln(w, "             seams. Children are exact substrings; the parent is superseded.")
-	fmt.Fprintln(w, "  --dry-run  with --split, print what would split without touching the store.")
+	fmt.Fprintln(w, "  --split-revert  retire intact split children and restore their superseded parent.")
+	fmt.Fprintln(w, "                  Defaults to all active groom splits; --parent and --since filter.")
+	fmt.Fprintln(w, "  --dry-run  with --split or --split-revert, print changes without touching the store.")
 }
 
 func runMemoryGroomSplit(home string, dryRun, jsonOut bool, stdout, stderr io.Writer) int {
@@ -281,6 +330,57 @@ func runMemoryGroomSplit(home string, dryRun, jsonOut bool, stdout, stderr io.Wr
 			}
 		}
 		fmt.Fprintln(stdout)
+	}
+	return 0
+}
+
+func runMemoryGroomSplitRevert(home string, parentIDs []int64, since string, dryRun, jsonOut bool, stdout, stderr io.Writer) int {
+	ctx := context.Background()
+	var result db.GroomSplitRevertResult
+	run := func(store *db.Store) error {
+		var err error
+		result, err = store.RevertGroomSplits(ctx, db.GroomSplitRevertOptions{
+			ParentIDs: parentIDs,
+			Since:     since,
+			DryRun:    dryRun,
+		})
+		return err
+	}
+	var err error
+	if dryRun {
+		err = withReadOnlyStore(home, run)
+	} else {
+		err = withStore(home, run)
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "memory groom: split-revert: %v\n", err)
+		return 1
+	}
+	output := groomSplitRevertOutput{
+		DryRun: dryRun, Matched: len(result.Reverted) + len(result.Skipped),
+		Reverted: result.Reverted, Skipped: result.Skipped,
+	}
+	if jsonOut {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "memory groom: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	verb := "reverted"
+	if dryRun {
+		verb = "would revert"
+	}
+	fmt.Fprintf(stdout, "%s %d groom split(s); skipped %d\n", verb, len(result.Reverted), len(result.Skipped))
+	for _, item := range result.Reverted {
+		fmt.Fprintf(stdout, "  parent %d <- children", item.ParentID)
+		for _, childID := range item.ChildIDs {
+			fmt.Fprintf(stdout, " %d", childID)
+		}
+		fmt.Fprintln(stdout)
+	}
+	for _, item := range result.Skipped {
+		fmt.Fprintf(stdout, "  skipped parent %d: %s\n", item.ParentID, item.Reason)
 	}
 	return 0
 }

--- a/internal/cli/memory_groom_test.go
+++ b/internal/cli/memory_groom_test.go
@@ -3,12 +3,15 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/memory"
 )
@@ -302,8 +305,17 @@ func TestGroomProposeEmptyStore(t *testing.T) {
 func TestGroomSplitDryRunApplyAndRerun(t *testing.T) {
 	home, store := memoryTestHome(t)
 	owner := db.MemoryOwner{Kind: "agent", Ref: "lead"}
-	content := "**First shipped story**\nThe first implementation preserved stable daemon sessions.\n\n**Second shipped story**\nThe second implementation preserved explicit owner review."
+	fixture := func(id string) string {
+		t.Helper()
+		body, err := os.ReadFile(filepath.Join("..", "memory", "testdata", "groom", id+".md"))
+		if err != nil {
+			t.Fatalf("read groom fixture %s: %v", id, err)
+		}
+		return strings.TrimSuffix(string(body), "\n")
+	}
+	content := fixture("80")
 	parentID := seedConfirmed(t, store, owner, "acme/widget", "repo", "session-brick", content)
+	structuredID := seedConfirmed(t, store, owner, "acme/widget", "repo", "structured-round", fixture("152"))
 	ctx := context.Background()
 
 	code, stdout, stderr := runGroom(t, "--home", home, "--split", "--dry-run", "--json")
@@ -321,7 +333,7 @@ func TestGroomSplitDryRunApplyAndRerun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read active rows after dry-run: %v", err)
 	}
-	if len(rows) != 1 || rows[0].ID != parentID {
+	if len(rows) != 2 {
 		t.Fatalf("dry-run changed active rows: %+v", rows)
 	}
 
@@ -341,18 +353,80 @@ func TestGroomSplitDryRunApplyAndRerun(t *testing.T) {
 			t.Fatalf("applied child missing id/key: %+v", child)
 		}
 	}
+	firstKeys := []string{applied.Splits[0].Children[0].Key, applied.Splits[0].Children[1].Key}
+	firstIDs := []int64{applied.Splits[0].Children[0].ID, applied.Splits[0].Children[1].ID}
+
+	code, stdout, stderr = runGroom(t, "--home", home, "--split-revert", "--parent", strconv.FormatInt(parentID, 10), "--dry-run", "--json")
+	if code != 0 {
+		t.Fatalf("split-revert dry-run exit %d: %s", code, stderr)
+	}
+	var revertDry groomSplitRevertOutput
+	if err := json.Unmarshal([]byte(stdout), &revertDry); err != nil {
+		t.Fatalf("parse revert dry-run JSON: %v (%s)", err, stdout)
+	}
+	if !revertDry.DryRun || revertDry.Matched != 1 || len(revertDry.Reverted) != 1 || revertDry.Reverted[0].ParentID != parentID {
+		t.Fatalf("revert dry-run output = %+v", revertDry)
+	}
+
+	code, stdout, stderr = runGroom(t, "--home", home, "--split-revert", "--parent", strconv.FormatInt(parentID, 10), "--json")
+	if code != 0 {
+		t.Fatalf("split-revert exit %d: %s", code, stderr)
+	}
+	var reverted groomSplitRevertOutput
+	if err := json.Unmarshal([]byte(stdout), &reverted); err != nil {
+		t.Fatalf("parse revert JSON: %v (%s)", err, stdout)
+	}
+	if reverted.DryRun || len(reverted.Reverted) != 1 || len(reverted.Skipped) != 0 {
+		t.Fatalf("revert output = %+v", reverted)
+	}
+	matches, err := store.QueryConfirmedMemories(ctx, owner, "acme/widget", `"waveform"`, 10)
+	if err != nil {
+		t.Fatalf("query restored parent: %v", err)
+	}
+	if len(matches) == 0 || matches[0].ID != parentID {
+		t.Fatalf("restored parent is not FTS-searchable: %+v", matches)
+	}
+	raw, err := sql.Open("sqlite", config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("open raw store: %v", err)
+	}
+	defer raw.Close()
+	for _, childID := range firstIDs {
+		var retiredAt, reason string
+		if err := raw.QueryRowContext(ctx, `SELECT retired_at, retired_reason FROM confirmed_memories WHERE id = ?`, childID).Scan(&retiredAt, &reason); err != nil {
+			t.Fatalf("read reverted child %d: %v", childID, err)
+		}
+		if retiredAt == "" || reason != "groom-split-revert:"+strconv.FormatInt(parentID, 10) {
+			t.Fatalf("child %d not retired: retired=%q reason=%q", childID, retiredAt, reason)
+		}
+	}
 
 	code, stdout, stderr = runGroom(t, "--home", home, "--split", "--json")
 	if code != 0 {
 		t.Fatalf("split rerun exit %d: %s", code, stderr)
 	}
-	var rerun groomSplitOutput
-	if err := json.Unmarshal([]byte(stdout), &rerun); err != nil {
-		t.Fatalf("parse rerun JSON: %v (%s)", err, stdout)
+	var resplit groomSplitOutput
+	if err := json.Unmarshal([]byte(stdout), &resplit); err != nil {
+		t.Fatalf("parse re-split JSON: %v (%s)", err, stdout)
 	}
-	if rerun.Detected != 0 || rerun.Applied != 0 || len(rerun.Splits) != 0 {
-		t.Fatalf("rerun must be no-op: %+v", rerun)
+	if resplit.Detected != 1 || resplit.Applied != 1 || len(resplit.Splits) != 1 {
+		t.Fatalf("re-split output = %+v", resplit)
 	}
+	for i, child := range resplit.Splits[0].Children {
+		if child.Key != firstKeys[i] || child.ID == firstIDs[i] {
+			t.Fatalf("re-split child %d = %+v, want key %q and new id", i, child, firstKeys[i])
+		}
+	}
+	active, err := store.ListConfirmedMemoriesForVault(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range active {
+		if row.ID == structuredID {
+			return
+		}
+	}
+	t.Fatalf("structured fact %d was incorrectly split or retired", structuredID)
 }
 
 func TestGroomRejectsAmbiguousFlags(t *testing.T) {
@@ -368,6 +442,12 @@ func TestGroomRejectsAmbiguousFlags(t *testing.T) {
 	}
 	if code, _, _ := runGroom(t, "--home", home, "--propose", "--dry-run"); code != 2 {
 		t.Fatalf("--dry-run without --split should exit 2, got %d", code)
+	}
+	if code, _, _ := runGroom(t, "--home", home, "--split", "--parent", "1"); code != 2 {
+		t.Fatalf("--parent without --split-revert should exit 2, got %d", code)
+	}
+	if code, _, _ := runGroom(t, "--home", home, "--split-revert", "--since", "yesterday"); code != 2 {
+		t.Fatalf("invalid --since should exit 2, got %d", code)
 	}
 	if code, _, stderr := runGroom(t, "--home", home, "--yes"); code != 2 || !strings.Contains(stderr, "--plan") {
 		t.Fatalf("--yes without --plan should exit 2 asking for --plan, got %d %q", code, stderr)

--- a/internal/cli/pipeline_defaults_test.go
+++ b/internal/cli/pipeline_defaults_test.go
@@ -203,7 +203,8 @@ repo = "owner/repo"
 	`)
 	groomSeed(t, store)
 	parentID := seedConfirmed(t, store, db.MemoryOwner{Kind: "agent", Ref: "lead"}, "owner/repo", "repo", "pipeline-brick",
-		"**First pipeline story**\nThe first pipeline story has substantive implementation detail.\n\n**Second pipeline story**\nThe second pipeline story has substantive implementation detail.")
+		"**First pipeline story**\n"+strings.Repeat("The first pipeline story has substantive implementation detail. ", 5)+
+			"\n\n**Second pipeline story**\n"+strings.Repeat("The second pipeline story has substantive implementation detail. ", 5))
 	runInstallDefaults(t, home)
 	rec, ok, err := store.GetPipeline(context.Background(), "memory-groom-propose")
 	if err != nil || !ok {

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -171,6 +171,22 @@ CREATE TABLE job_events (
 	message TEXT NOT NULL,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
+-- Minimal memory tables at the pre-#842 shape. The original memory base-table
+-- migration is marked applied below, while later additive migrations still run;
+-- this makes the new confirmed_memories.context ALTER exercise a pre-existing
+-- table instead of relying on a fresh-schema create in this old-schema fixture.
+CREATE TABLE confirmed_memories (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	owner_kind TEXT NOT NULL,
+	owner_ref TEXT NOT NULL,
+	owner_version TEXT NOT NULL DEFAULT '',
+	repo TEXT,
+	key TEXT NOT NULL,
+	superseded_by INTEGER
+);
+CREATE UNIQUE INDEX idx_confirmed_repo_key ON confirmed_memories(owner_kind, owner_ref, owner_version, repo, key) WHERE repo IS NOT NULL;
+CREATE UNIQUE INDEX idx_confirmed_general_key ON confirmed_memories(owner_kind, owner_ref, owner_version, key) WHERE repo IS NULL;
+CREATE TABLE memory_observations (id INTEGER PRIMARY KEY AUTOINCREMENT);
 -- A minimal resource_locks table (created by an earlier, here pre-seeded-as-
 -- applied migration) so the #651 owner_boot_id ALTER ADD COLUMN that runs in this
 -- pass has its table.
@@ -194,18 +210,29 @@ INSERT INTO jobs(id, agent, type, state, payload) VALUES ('old', 'w', 'ask', 'su
 	// We locate the token migration by CONTENT rather than position so appending
 	// new migrations never breaks this pin.
 	tokenMigrationVersion := -1
+	confirmedMemoryBaseVersion := -1
 	for i, m := range migrations {
-		if strings.Contains(m, "input_tokens") {
+		if tokenMigrationVersion < 0 && strings.Contains(m, "input_tokens") {
 			tokenMigrationVersion = i + 1 // migration versions are 1-indexed
-			break
+		}
+		if strings.Contains(m, "CREATE TABLE confirmed_memories") {
+			confirmedMemoryBaseVersion = i + 1
 		}
 	}
 	if tokenMigrationVersion < 1 {
 		t.Fatalf("could not locate the input_tokens migration")
 	}
+	if confirmedMemoryBaseVersion < 1 {
+		t.Fatalf("could not locate the confirmed-memory base migration")
+	}
 	for v := 1; v < tokenMigrationVersion; v++ {
 		if _, err := raw.ExecContext(ctx, `INSERT INTO schema_migrations(version, applied_at) VALUES (?, 'seed')`, v); err != nil {
 			t.Fatalf("seed schema_migrations v%d returned error: %v", v, err)
+		}
+	}
+	if confirmedMemoryBaseVersion >= tokenMigrationVersion {
+		if _, err := raw.ExecContext(ctx, `INSERT INTO schema_migrations(version, applied_at) VALUES (?, 'seed')`, confirmedMemoryBaseVersion); err != nil {
+			t.Fatalf("seed confirmed-memory base migration v%d returned error: %v", confirmedMemoryBaseVersion, err)
 		}
 	}
 	if err := raw.Close(); err != nil {

--- a/internal/db/memory_groom_split_test.go
+++ b/internal/db/memory_groom_split_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 )
@@ -70,15 +71,15 @@ func TestApplyGroomSplitsLosslessInertClusteredAndIdempotent(t *testing.T) {
 
 	var joined string
 	for _, id := range childIDs {
-		var ownerKind, ownerRef, authorRef, repo, scope, provenance, sourceJob, childContent string
+		var ownerKind, ownerRef, authorRef, repo, scope, contextValue, provenance, sourceJob, childContent string
 		if err := store.db.QueryRowContext(ctx, `
-SELECT owner_kind, owner_ref, author_ref, repo, scope, provenance, source_job, content
+SELECT owner_kind, owner_ref, author_ref, repo, scope, context, provenance, source_job, content
 FROM confirmed_memories WHERE id = ?`, id).Scan(
-			&ownerKind, &ownerRef, &authorRef, &repo, &scope, &provenance, &sourceJob, &childContent); err != nil {
+			&ownerKind, &ownerRef, &authorRef, &repo, &scope, &contextValue, &provenance, &sourceJob, &childContent); err != nil {
 			t.Fatalf("read child %d: %v", id, err)
 		}
-		if ownerKind != "agent" || ownerRef != "lead" || authorRef != "author" || repo != "acme/widget" || scope != "repo" || provenance != "groom-split:"+itoa(parentID) || sourceJob != "job-source" {
-			t.Fatalf("child %d did not inherit metadata: owner=%s/%s author=%q repo=%q scope=%q provenance=%q source=%q", id, ownerKind, ownerRef, authorRef, repo, scope, provenance, sourceJob)
+		if ownerKind != "agent" || ownerRef != "lead" || authorRef != "author" || repo != "acme/widget" || scope != "repo" || contextValue != "editor-session" || provenance != "groom-split:"+itoa(parentID) || sourceJob != "job-source" {
+			t.Fatalf("child %d did not inherit metadata: owner=%s/%s author=%q repo=%q scope=%q context=%q provenance=%q source=%q", id, ownerKind, ownerRef, authorRef, repo, scope, contextValue, provenance, sourceJob)
 		}
 		joined += childContent
 	}
@@ -185,6 +186,170 @@ func TestApplyGroomSplitsCoverageViolationRollsBack(t *testing.T) {
 	if rows != 1 || fts != 1 {
 		t.Fatalf("coverage failure must roll back: rows=%d fts=%d", rows, fts)
 	}
+}
+
+func TestRevertGroomSplitsHappyDryRunAndIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	parentID, childIDs, _ := seedAppliedGroomSplit(t, store)
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO memory_clusters(cluster_id, label) VALUES (9, 'current-child-cluster')`); err != nil {
+		t.Fatalf("seed moved cluster: %v", err)
+	}
+	if err := store.AssignMemoryToCluster(ctx, childIDs[0], 9); err != nil {
+		t.Fatalf("move lowest child: %v", err)
+	}
+
+	dry, err := store.RevertGroomSplits(ctx, GroomSplitRevertOptions{ParentIDs: []int64{parentID}, DryRun: true})
+	if err != nil {
+		t.Fatalf("dry-run revert: %v", err)
+	}
+	if len(dry.Reverted) != 1 || len(dry.Skipped) != 0 || len(dry.Reverted[0].ChildIDs) != 2 {
+		t.Fatalf("dry-run result = %+v", dry)
+	}
+	if n := ftsRowCount(t, store, parentID); n != 0 {
+		t.Fatalf("dry run restored parent FTS: %d", n)
+	}
+
+	result, err := store.RevertGroomSplits(ctx, GroomSplitRevertOptions{ParentIDs: []int64{parentID}})
+	if err != nil {
+		t.Fatalf("revert split: %v", err)
+	}
+	if len(result.Reverted) != 1 || result.Reverted[0].ParentID != parentID || len(result.Skipped) != 0 {
+		t.Fatalf("revert result = %+v", result)
+	}
+	var superseded sql.NullInt64
+	if err := store.db.QueryRowContext(ctx, `SELECT superseded_by FROM confirmed_memories WHERE id = ?`, parentID).Scan(&superseded); err != nil {
+		t.Fatalf("read restored parent: %v", err)
+	}
+	if superseded.Valid || ftsRowCount(t, store, parentID) != 1 {
+		t.Fatalf("parent not restored: superseded=%+v fts=%d", superseded, ftsRowCount(t, store, parentID))
+	}
+	var clusterID int64
+	if err := store.db.QueryRowContext(ctx, `SELECT cluster_id FROM memory_cluster_members WHERE memory_id = ?`, parentID).Scan(&clusterID); err != nil {
+		t.Fatalf("read restored parent cluster: %v", err)
+	}
+	if clusterID != 9 {
+		t.Fatalf("restored parent cluster = %d, want lowest child's current cluster 9", clusterID)
+	}
+	for _, childID := range childIDs {
+		var retiredAt, reason string
+		if err := store.db.QueryRowContext(ctx, `SELECT retired_at, retired_reason FROM confirmed_memories WHERE id = ?`, childID).Scan(&retiredAt, &reason); err != nil {
+			t.Fatalf("read retired child %d: %v", childID, err)
+		}
+		if retiredAt == "" || reason != "groom-split-revert:"+itoa(parentID) || ftsRowCount(t, store, childID) != 0 {
+			t.Fatalf("child %d not retired correctly: retired=%q reason=%q fts=%d", childID, retiredAt, reason, ftsRowCount(t, store, childID))
+		}
+		var memberships int
+		if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM memory_cluster_members WHERE memory_id = ?`, childID).Scan(&memberships); err != nil || memberships != 0 {
+			t.Fatalf("child %d cluster memberships = %d, err=%v", childID, memberships, err)
+		}
+	}
+
+	second, err := store.RevertGroomSplits(ctx, GroomSplitRevertOptions{})
+	if err != nil {
+		t.Fatalf("idempotent revert: %v", err)
+	}
+	if len(second.Reverted) != 0 || len(second.Skipped) != 0 {
+		t.Fatalf("second revert = %+v, want no-op", second)
+	}
+}
+
+func TestRevertGroomSplitsEditedChildFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	parentID, childIDs, _ := seedAppliedGroomSplit(t, store)
+	if _, err := store.db.ExecContext(ctx, `UPDATE confirmed_memories SET content = content || ' edited' WHERE id = ?`, childIDs[1]); err != nil {
+		t.Fatalf("edit child: %v", err)
+	}
+
+	result, err := store.RevertGroomSplits(ctx, GroomSplitRevertOptions{})
+	if err != nil {
+		t.Fatalf("revert edited split: %v", err)
+	}
+	if len(result.Reverted) != 0 || len(result.Skipped) != 1 || result.Skipped[0].ParentID != parentID {
+		t.Fatalf("edited-child result = %+v", result)
+	}
+	var supersededBy int64
+	if err := store.db.QueryRowContext(ctx, `SELECT superseded_by FROM confirmed_memories WHERE id = ?`, parentID).Scan(&supersededBy); err != nil {
+		t.Fatal(err)
+	}
+	if supersededBy != childIDs[0] || ftsRowCount(t, store, parentID) != 0 {
+		t.Fatalf("failed-closed parent changed: superseded=%d fts=%d", supersededBy, ftsRowCount(t, store, parentID))
+	}
+	for _, childID := range childIDs {
+		var retiredAt string
+		if err := store.db.QueryRowContext(ctx, `SELECT retired_at FROM confirmed_memories WHERE id = ?`, childID).Scan(&retiredAt); err != nil || retiredAt != "" {
+			t.Fatalf("child %d retired on skipped revert: retired=%q err=%v", childID, retiredAt, err)
+		}
+	}
+}
+
+func TestRevertGroomSplitsAllowsIdenticalKeyResplit(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	parentID, firstChildIDs, item := seedAppliedGroomSplit(t, store)
+	if _, err := store.RevertGroomSplits(ctx, GroomSplitRevertOptions{}); err != nil {
+		t.Fatalf("revert first split: %v", err)
+	}
+	if err := store.db.QueryRowContext(ctx, `SELECT updated_at FROM confirmed_memories WHERE id = ?`, parentID).Scan(&item.ExpectedUpdatedAt); err != nil {
+		t.Fatalf("read restored revision: %v", err)
+	}
+	second, err := store.ApplyGroomSplits(ctx, []GroomSplitItem{item})
+	if err != nil {
+		t.Fatalf("re-split: %v", err)
+	}
+	if len(second.Applied) != 1 {
+		t.Fatalf("re-split result = %+v", second)
+	}
+	for i, childID := range second.Applied[0].ChildIDs {
+		if childID == firstChildIDs[i] {
+			t.Fatalf("re-split reused retired row id %d", childID)
+		}
+		var key string
+		if err := store.db.QueryRowContext(ctx, `SELECT key FROM confirmed_memories WHERE id = ?`, childID).Scan(&key); err != nil {
+			t.Fatal(err)
+		}
+		if key != item.Children[i].Key {
+			t.Fatalf("re-split child key = %q, want %q", key, item.Children[i].Key)
+		}
+	}
+}
+
+func seedAppliedGroomSplit(t *testing.T, store *Store) (int64, []int64, GroomSplitItem) {
+	t.Helper()
+	ctx := context.Background()
+	content := "**First story**\nThe first story has exact durable content.\n\n**Second story**\nThe second story has exact durable content."
+	parentID, err := store.UpsertConfirmedMemory(ctx, ConfirmedMemory{
+		Owner: agentOwner("lead"), Repo: "acme/widget", Scope: "repo", Key: "parent-subject", Content: content, Provenance: "test",
+	})
+	if err != nil {
+		t.Fatalf("seed split parent: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO memory_clusters(cluster_id, label) VALUES (7, 'original')`); err != nil {
+		t.Fatalf("seed original cluster: %v", err)
+	}
+	if err := store.AssignMemoryToCluster(ctx, parentID, 7); err != nil {
+		t.Fatalf("assign original cluster: %v", err)
+	}
+	var updatedAt string
+	if err := store.db.QueryRowContext(ctx, `SELECT updated_at FROM confirmed_memories WHERE id = ?`, parentID).Scan(&updatedAt); err != nil {
+		t.Fatalf("read split parent revision: %v", err)
+	}
+	item := GroomSplitItem{
+		ParentID: parentID, ExpectedUpdatedAt: updatedAt,
+		Children: []GroomSplitChild{
+			{Key: "parent-subject-first-story", Content: "**First story**\nThe first story has exact durable content.\n\n"},
+			{Key: "parent-subject-second-story", Content: "**Second story**\nThe second story has exact durable content."},
+		},
+	}
+	result, err := store.ApplyGroomSplits(ctx, []GroomSplitItem{item})
+	if err != nil {
+		t.Fatalf("apply seeded split: %v", err)
+	}
+	if len(result.Applied) != 1 {
+		t.Fatalf("seed split result = %+v", result)
+	}
+	return parentID, result.Applied[0].ChildIDs, item
 }
 
 func itoa(id int64) string {

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -53,6 +54,7 @@ type ConfirmedMemory struct {
 	Repo             string // "" == general scope (stored as SQL NULL)
 	Scope            string
 	Key              string
+	Context          string // optional subject inherited from a groom-split parent
 	Content          string
 	Provenance       string
 	SourceJob        string
@@ -292,7 +294,7 @@ WHERE (owner_kind = ? AND owner_ref = ?) OR (owner_kind = ? AND owner_ref = ? AN
 // Rows come back ordered by id for a stable, deterministic traversal. Plain read, no FTS.
 func (s *Store) ListConfirmedMemoriesByOwnerKind(ctx context.Context, ownerKind string) ([]ConfirmedMemory, error) {
 	rows, err := s.db.QueryContext(ctx, `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
 FROM confirmed_memories
 WHERE owner_kind = ? AND retired_at = ''
@@ -306,7 +308,7 @@ ORDER BY id`, ownerKind)
 		var c ConfirmedMemory
 		var repoNull sql.NullString
 		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
-			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
+			&c.Scope, &c.Key, &c.Content, &c.Context, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
 			return nil, err
 		}
 		c.Repo = repoNull.String
@@ -321,7 +323,7 @@ ORDER BY id`, ownerKind)
 // ListConfirmedMemoriesByOwnerKind.
 func (s *Store) ListConfirmedMemoriesForKnowledge(ctx context.Context) ([]ConfirmedMemory, error) {
 	rows, err := s.db.QueryContext(ctx, `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
 FROM confirmed_memories
 WHERE (owner_kind = 'agent' OR (owner_kind = 'shared' AND owner_ref = 'shared'))
@@ -336,7 +338,7 @@ ORDER BY id`)
 		var c ConfirmedMemory
 		var repoNull sql.NullString
 		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
-			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
+			&c.Scope, &c.Key, &c.Content, &c.Context, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
 			return nil, err
 		}
 		c.Repo = repoNull.String
@@ -442,10 +444,10 @@ LIMIT 1`,
 	case err == sql.ErrNoRows:
 		res, insErr := tx.ExecContext(ctx, `
 INSERT INTO confirmed_memories
-	(owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, provenance, source_job, first_confirmed_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	(owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context, provenance, source_job, first_confirmed_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			cm.Owner.Kind, cm.Owner.Ref, cm.Owner.Version, strings.TrimSpace(cm.AuthorRef), nullableRepo(cm.Repo), scope,
-			cm.Key, cm.Content, cm.Provenance, cm.SourceJob, now, now)
+			cm.Key, cm.Content, strings.TrimSpace(cm.Context), cm.Provenance, cm.SourceJob, now, now)
 		if insErr != nil {
 			return 0, fmt.Errorf("insert confirmed memory: %w", insErr)
 		}
@@ -469,9 +471,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		// refusal above so re-ingest cannot undo a bulk-retire cleanup.
 		if _, upErr := tx.ExecContext(ctx, `
 UPDATE confirmed_memories
-SET author_ref = ?, content = ?, provenance = ?, source_job = ?, updated_at = ?, retired_at = '', retired_reason = ''
+SET author_ref = ?, content = ?, context = ?, provenance = ?, source_job = ?, updated_at = ?, retired_at = '', retired_reason = ''
 WHERE id = ?`,
-			strings.TrimSpace(cm.AuthorRef), cm.Content, cm.Provenance, cm.SourceJob, now, id); upErr != nil {
+			strings.TrimSpace(cm.AuthorRef), cm.Content, strings.TrimSpace(cm.Context), cm.Provenance, cm.SourceJob, now, id); upErr != nil {
 			return 0, fmt.Errorf("update confirmed memory: %w", upErr)
 		}
 	}
@@ -503,11 +505,11 @@ func archiveSupersededEditionTx(ctx context.Context, tx *sql.Tx, id int64, newCo
 	var prev ConfirmedMemory
 	var repoNull sql.NullString
 	err := tx.QueryRowContext(ctx, `
-SELECT owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at
 FROM confirmed_memories WHERE id = ?`, id).Scan(
 		&prev.Owner.Kind, &prev.Owner.Ref, &prev.Owner.Version, &prev.AuthorRef, &repoNull,
-		&prev.Scope, &prev.Key, &prev.Content, &prev.Provenance, &prev.SourceJob,
+		&prev.Scope, &prev.Key, &prev.Content, &prev.Context, &prev.Provenance, &prev.SourceJob,
 		&prev.FirstConfirmedAt, &prev.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("read confirmed memory %d for supersede archive: %w", id, err)
@@ -518,10 +520,10 @@ FROM confirmed_memories WHERE id = ?`, id).Scan(
 	prev.Repo = repoNull.String
 	if _, err := tx.ExecContext(ctx, `
 INSERT INTO confirmed_memories
-	(owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, provenance, source_job, first_confirmed_at, updated_at, superseded_by)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	(owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context, provenance, source_job, first_confirmed_at, updated_at, superseded_by)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		prev.Owner.Kind, prev.Owner.Ref, prev.Owner.Version, prev.AuthorRef, nullableRepo(prev.Repo), prev.Scope,
-		prev.Key, prev.Content, prev.Provenance, prev.SourceJob, prev.FirstConfirmedAt, prev.UpdatedAt, id); err != nil {
+		prev.Key, prev.Content, prev.Context, prev.Provenance, prev.SourceJob, prev.FirstConfirmedAt, prev.UpdatedAt, id); err != nil {
 		return fmt.Errorf("archive superseded edition of confirmed memory %d: %w", id, err)
 	}
 	return nil
@@ -576,12 +578,12 @@ func promoteConfirmedMemoryToSharedTx(ctx context.Context, tx *sql.Tx, id int64,
 	var repoNull sql.NullString
 	var retiredAt string
 	err := tx.QueryRowContext(ctx, `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0), retired_at
 FROM confirmed_memories
 WHERE id = ?`, id).Scan(
 		&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
-		&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt,
+		&c.Scope, &c.Key, &c.Content, &c.Context, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt,
 		&c.UpdatedAt, &c.SupersededBy, &retiredAt)
 	if err == sql.ErrNoRows {
 		return ConfirmedMemory{}, fmt.Errorf("confirmed memory %d not found", id)
@@ -881,12 +883,12 @@ func confirmedMemoryForLinkingTx(ctx context.Context, tx *sql.Tx, id int64) (Con
 	var c ConfirmedMemory
 	var repoNull sql.NullString
 	err := tx.QueryRowContext(ctx, `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at
 FROM confirmed_memories
 WHERE id = ? AND superseded_by IS NULL AND retired_at = ''`, id).Scan(
 		&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
-		&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt)
+		&c.Scope, &c.Key, &c.Content, &c.Context, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return ConfirmedMemory{}, false, nil
 	}
@@ -1118,7 +1120,7 @@ func listActiveConfirmedMemoriesByProvenancePrefix(ctx context.Context, q rowsQu
 		args = append(args, strings.TrimSpace(agentRef), strings.TrimSpace(agentRef))
 	}
 	query := `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at
 FROM confirmed_memories
 WHERE ` + strings.Join(where, " AND ") + `
@@ -1277,13 +1279,13 @@ func applyGroomSplitTx(ctx context.Context, tx *sql.Tx, item GroomSplitItem) (Gr
 	var parent ConfirmedMemory
 	var repoNull sql.NullString
 	err := tx.QueryRowContext(ctx, `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at
 FROM confirmed_memories
 WHERE id = ? AND updated_at = ? AND superseded_by IS NULL AND retired_at = ''`,
 		item.ParentID, item.ExpectedUpdatedAt).Scan(
 		&parent.ID, &parent.Owner.Kind, &parent.Owner.Ref, &parent.Owner.Version, &parent.AuthorRef, &repoNull,
-		&parent.Scope, &parent.Key, &parent.Content, &parent.Provenance, &parent.SourceJob,
+		&parent.Scope, &parent.Key, &parent.Content, &parent.Context, &parent.Provenance, &parent.SourceJob,
 		&parent.FirstConfirmedAt, &parent.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return GroomSplitApplied{}, false, nil
@@ -1325,10 +1327,10 @@ WHERE id = ? AND updated_at = ? AND superseded_by IS NULL AND retired_at = ''`,
 	for _, child := range item.Children {
 		res, err := tx.ExecContext(ctx, `
 INSERT INTO confirmed_memories
-	(owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, provenance, source_job, first_confirmed_at, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+	(owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context, provenance, source_job, first_confirmed_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			parent.Owner.Kind, parent.Owner.Ref, parent.Owner.Version, parent.AuthorRef, nullableRepo(parent.Repo), parent.Scope,
-			child.Key, child.Content, fmt.Sprintf("groom-split:%d", parent.ID), parent.SourceJob, parent.FirstConfirmedAt, now)
+			child.Key, child.Content, parent.Key, fmt.Sprintf("groom-split:%d", parent.ID), parent.SourceJob, parent.FirstConfirmedAt, now)
 		if err != nil {
 			return GroomSplitApplied{}, false, fmt.Errorf("insert groom split child for parent %d: %w", parent.ID, err)
 		}
@@ -1373,6 +1375,227 @@ WHERE id = ? AND updated_at = ? AND superseded_by IS NULL AND retired_at = ''`,
 		}
 	}
 	return applied, true, nil
+}
+
+// GroomSplitRevertOptions selects active groom splits to restore. Empty
+// ParentIDs and Since select every currently active split.
+type GroomSplitRevertOptions struct {
+	ParentIDs []int64
+	Since     string
+	DryRun    bool
+}
+
+// GroomSplitReverted records one parent and the direct children that were, or
+// in dry-run mode would be, retired to restore it.
+type GroomSplitReverted struct {
+	ParentID int64   `json:"parent_id"`
+	ChildIDs []int64 `json:"child_ids"`
+}
+
+// GroomSplitRevertSkipped is one selected parent that failed a reverse coverage
+// or active-split invariant and was left untouched.
+type GroomSplitRevertSkipped struct {
+	ParentID int64  `json:"parent_id"`
+	Reason   string `json:"reason"`
+}
+
+// GroomSplitRevertResult reports restored and fail-closed parent groups.
+type GroomSplitRevertResult struct {
+	Reverted []GroomSplitReverted      `json:"reverted"`
+	Skipped  []GroomSplitRevertSkipped `json:"skipped"`
+}
+
+// RevertGroomSplits restores active parents superseded by direct groom-split
+// children. Validation is per-parent and happens before any mutation for that
+// group; an edited, retired, or recursively split child therefore skips only its
+// parent. All successful groups commit atomically.
+func (s *Store) RevertGroomSplits(ctx context.Context, options GroomSplitRevertOptions) (GroomSplitRevertResult, error) {
+	var result GroomSplitRevertResult
+	if strings.TrimSpace(options.Since) != "" {
+		if _, err := time.Parse(time.RFC3339, options.Since); err != nil {
+			return result, fmt.Errorf("invalid groom split revert since timestamp %q: %w", options.Since, err)
+		}
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return result, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	parentIDs, err := selectActiveGroomSplitParents(ctx, tx, options)
+	if err != nil {
+		return result, err
+	}
+	for _, parentID := range parentIDs {
+		reverted, ok, reason, err := revertGroomSplitTx(ctx, tx, parentID, options.DryRun)
+		if err != nil {
+			return GroomSplitRevertResult{}, err
+		}
+		if !ok {
+			result.Skipped = append(result.Skipped, GroomSplitRevertSkipped{ParentID: parentID, Reason: reason})
+			continue
+		}
+		result.Reverted = append(result.Reverted, reverted)
+	}
+	if err := tx.Commit(); err != nil {
+		return GroomSplitRevertResult{}, err
+	}
+	return result, nil
+}
+
+func selectActiveGroomSplitParents(ctx context.Context, tx *sql.Tx, options GroomSplitRevertOptions) ([]int64, error) {
+	query := `
+SELECT DISTINCT p.id
+FROM confirmed_memories p
+JOIN confirmed_memories c ON c.provenance = 'groom-split:' || p.id
+WHERE p.superseded_by IS NOT NULL AND p.retired_at = ''
+	AND c.superseded_by IS NULL AND c.retired_at = ''`
+	var args []any
+	if len(options.ParentIDs) > 0 {
+		seen := make(map[int64]struct{}, len(options.ParentIDs))
+		ids := make([]int64, 0, len(options.ParentIDs))
+		for _, id := range options.ParentIDs {
+			if id <= 0 {
+				return nil, fmt.Errorf("invalid groom split parent id %d", id)
+			}
+			if _, duplicate := seen[id]; duplicate {
+				continue
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		placeholders := make([]string, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += "\n\tAND p.id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	if since := strings.TrimSpace(options.Since); since != "" {
+		query += "\n\tAND c.updated_at >= ?"
+		args = append(args, since)
+	}
+	query += "\nORDER BY p.id"
+	rows, err := tx.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("select active groom split parents: %w", err)
+	}
+	defer rows.Close()
+	var out []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+func revertGroomSplitTx(ctx context.Context, tx *sql.Tx, parentID int64, dryRun bool) (GroomSplitReverted, bool, string, error) {
+	var parentKey, parentContent string
+	var expectedChildID int64
+	err := tx.QueryRowContext(ctx, `
+SELECT key, content, COALESCE(superseded_by, 0)
+FROM confirmed_memories
+WHERE id = ? AND retired_at = ''`, parentID).Scan(&parentKey, &parentContent, &expectedChildID)
+	if err == sql.ErrNoRows {
+		return GroomSplitReverted{}, false, "parent is missing or retired", nil
+	}
+	if err != nil {
+		return GroomSplitReverted{}, false, "", fmt.Errorf("read groom split parent %d for revert: %w", parentID, err)
+	}
+
+	type childRow struct {
+		id        int64
+		content   string
+		clusterID sql.NullInt64
+	}
+	rows, err := tx.QueryContext(ctx, `
+SELECT c.id, c.content, m.cluster_id
+FROM confirmed_memories c
+LEFT JOIN memory_cluster_members m ON m.memory_id = c.id
+WHERE c.provenance = ? AND c.superseded_by IS NULL AND c.retired_at = ''
+ORDER BY c.id`, fmt.Sprintf("groom-split:%d", parentID))
+	if err != nil {
+		return GroomSplitReverted{}, false, "", fmt.Errorf("list groom split children for parent %d: %w", parentID, err)
+	}
+	var children []childRow
+	for rows.Next() {
+		var child childRow
+		if err := rows.Scan(&child.id, &child.content, &child.clusterID); err != nil {
+			rows.Close()
+			return GroomSplitReverted{}, false, "", err
+		}
+		children = append(children, child)
+	}
+	if err := rows.Close(); err != nil {
+		return GroomSplitReverted{}, false, "", err
+	}
+	if len(children) < 2 {
+		return GroomSplitReverted{}, false, "fewer than two active split children", nil
+	}
+	if expectedChildID != children[0].id {
+		return GroomSplitReverted{}, false, "parent superseded pointer does not match the lowest active child", nil
+	}
+	var coverage strings.Builder
+	childIDs := make([]int64, 0, len(children))
+	for _, child := range children {
+		coverage.WriteString(child.content)
+		childIDs = append(childIDs, child.id)
+	}
+	if coverage.String() != strings.TrimSpace(parentContent) {
+		return GroomSplitReverted{}, false, "active children no longer reconstruct the parent", nil
+	}
+
+	reverted := GroomSplitReverted{ParentID: parentID, ChildIDs: childIDs}
+	if dryRun {
+		return reverted, true, "", nil
+	}
+	for _, child := range children {
+		if err := retireConfirmedMemoryTx(ctx, tx, child.id, "", fmt.Sprintf("groom-split-revert:%d", parentID)); err != nil {
+			return GroomSplitReverted{}, false, "", fmt.Errorf("retire groom split child %d: %w", child.id, err)
+		}
+	}
+	placeholders := make([]string, len(childIDs))
+	args := make([]any, 0, len(childIDs))
+	for i, id := range childIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memory_cluster_members WHERE memory_id IN (`+strings.Join(placeholders, ",")+`)`, args...); err != nil {
+		return GroomSplitReverted{}, false, "", fmt.Errorf("detach groom split children for parent %d: %w", parentID, err)
+	}
+	now := nowRFC3339()
+	res, err := tx.ExecContext(ctx, `
+UPDATE confirmed_memories SET superseded_by = NULL, updated_at = ?
+WHERE id = ? AND superseded_by = ? AND retired_at = ''`, now, parentID, expectedChildID)
+	if err != nil {
+		return GroomSplitReverted{}, false, "", fmt.Errorf("restore groom split parent %d: %w", parentID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return GroomSplitReverted{}, false, "", err
+	}
+	if affected != 1 {
+		return GroomSplitReverted{}, false, "", fmt.Errorf("groom split parent %d changed during revert", parentID)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM confirmed_memories_fts WHERE rowid = ?`, parentID); err != nil {
+		return GroomSplitReverted{}, false, "", fmt.Errorf("clear restored parent FTS %d: %w", parentID, err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO confirmed_memories_fts(rowid, content, key) VALUES (?, ?, ?)`, parentID, parentContent, parentKey); err != nil {
+		return GroomSplitReverted{}, false, "", fmt.Errorf("restore parent FTS %d: %w", parentID, err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memory_cluster_members WHERE memory_id = ?`, parentID); err != nil {
+		return GroomSplitReverted{}, false, "", fmt.Errorf("clear restored parent cluster %d: %w", parentID, err)
+	}
+	if children[0].clusterID.Valid {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO memory_cluster_members(memory_id, cluster_id) VALUES (?, ?)`, parentID, children[0].clusterID.Int64); err != nil {
+			return GroomSplitReverted{}, false, "", fmt.Errorf("restore parent %d cluster: %w", parentID, err)
+		}
+	}
+	return reverted, true, "", nil
 }
 
 // ApplyVaultImport applies a whole import plan in ONE transaction so a partial
@@ -1786,7 +2009,7 @@ func (s *Store) QueryConfirmedMemories(ctx context.Context, owner MemoryOwner, r
 		limit = 15
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content, c.context,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
@@ -1824,7 +2047,7 @@ func (s *Store) QueryConfirmedMemoriesForOwnerAllRepos(ctx context.Context, owne
 		limit = 15
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content, c.context,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
@@ -1880,7 +2103,7 @@ func (s *Store) ensureOwnMemoryFloor(ctx context.Context, owner MemoryOwner, rep
 
 func (s *Store) queryStrongestOwnMemory(ctx context.Context, owner MemoryOwner, repo, matchQuery string, filterRepo bool) (ConfirmedMemory, bool, error) {
 	query := `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content, c.context,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
@@ -1925,7 +2148,7 @@ func (s *Store) QueryConfirmedMemoriesForAllAgents(ctx context.Context, repo, ma
 		limit = 15
 	}
 	query := `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content, c.context,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
@@ -1959,7 +2182,7 @@ func (s *Store) QueryConfirmedMemoriesForShared(ctx context.Context, repo, match
 		limit = 15
 	}
 	query := `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content, c.context,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
@@ -2006,7 +2229,7 @@ type rowsQuerier interface {
 // (via a *sql.Tx) without duplicating the query.
 func listConfirmedMemoriesForVault(ctx context.Context, q rowsQuerier, agentRef string) ([]ConfirmedMemory, error) {
 	query := `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0)
 FROM confirmed_memories
 WHERE superseded_by IS NULL AND retired_at = ''`
@@ -2026,7 +2249,7 @@ WHERE superseded_by IS NULL AND retired_at = ''`
 		var c ConfirmedMemory
 		var repoNull sql.NullString
 		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
-			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
+			&c.Scope, &c.Key, &c.Content, &c.Context, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt, &c.SupersededBy); err != nil {
 			return nil, err
 		}
 		c.Repo = repoNull.String
@@ -2052,7 +2275,7 @@ func (s *Store) QueryConfirmedMemoryVaultLinks(ctx context.Context, owner Memory
 		limit = 6
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content,
+SELECT c.id, c.owner_kind, c.owner_ref, c.owner_version, c.author_ref, c.repo, c.scope, c.key, c.content, c.context,
 	c.provenance, c.source_job, c.first_confirmed_at, c.updated_at
 FROM confirmed_memories_fts f
 JOIN confirmed_memories c ON c.id = f.rowid
@@ -2089,7 +2312,7 @@ func (s *Store) ListConfirmedMemories(ctx context.Context, ownerRef, repo string
 		args = append(args, repo)
 	}
 	query := `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at
 FROM confirmed_memories`
 	if len(where) > 0 {
@@ -2113,7 +2336,7 @@ func (s *Store) ListActiveConfirmedMemoriesByProvenancePrefix(ctx context.Contex
 		return nil, nil
 	}
 	query := `
-SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content,
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
 	provenance, source_job, first_confirmed_at, updated_at
 FROM confirmed_memories
 WHERE owner_kind = ? AND owner_ref = ? AND owner_version = ?
@@ -2194,7 +2417,7 @@ func scanConfirmedMemories(rows *sql.Rows) ([]ConfirmedMemory, error) {
 		var c ConfirmedMemory
 		var repoNull sql.NullString
 		if err := rows.Scan(&c.ID, &c.Owner.Kind, &c.Owner.Ref, &c.Owner.Version, &c.AuthorRef, &repoNull,
-			&c.Scope, &c.Key, &c.Content, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt); err != nil {
+			&c.Scope, &c.Key, &c.Content, &c.Context, &c.Provenance, &c.SourceJob, &c.FirstConfirmedAt, &c.UpdatedAt); err != nil {
 			return nil, err
 		}
 		c.Repo = repoNull.String

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -8556,4 +8556,9 @@ ALTER TABLE agent_instances ADD COLUMN effort TEXT NOT NULL DEFAULT '';
 	`
 ALTER TABLE repos ADD COLUMN primary_checkout_path TEXT NOT NULL DEFAULT '';
 	`,
+	// #842 split-child subject inheritance. Empty context preserves every legacy
+	// confirmed memory byte-for-byte; groom splits populate it with the parent key.
+	`
+ALTER TABLE confirmed_memories ADD COLUMN context TEXT NOT NULL DEFAULT '';
+	`,
 }

--- a/internal/memory/groom.go
+++ b/internal/memory/groom.go
@@ -50,6 +50,10 @@ const (
 // owner; the actual rewrite is deferred to the opt-in LLM pass (P4.3).
 const GroomRewriteThreshold = 1200
 
+// GroomMinChildBytes is the minimum trimmed size of a split child. Smaller
+// segments are merged into a neighbor before labels and keys are derived.
+const GroomMinChildBytes = 200
+
 // groomFirstLineMax caps the first_line preview carried in the plan so a brick's
 // opening paragraph can't bloat the artifact.
 const groomFirstLineMax = 160
@@ -287,52 +291,43 @@ var groomSeamEvidence = regexp.MustCompile(`(?i)\d{4}-\d{2}-\d{2}|PR\s*#?\d+|#\d
 // shipped-work paragraph. Date-led lines reuse groomDateLed below.
 var groomPRMarker = regexp.MustCompile(`(?i)^\s*(?:[-*]\s*)?(?:PR\s*#?\d+\b|#\d+\b|(?:SHIPPED|MERGED|DEPLOYED)\b[^\r\n]*#\d+\b)`)
 
+// groomListItem rejects every Markdown list item before the broader date and PR
+// seam recognizers run. List entries are details within a story, not new stories.
+var groomListItem = regexp.MustCompile(`^\s*(?:[-*+]|\d+[.)])\s`)
+
 type groomTextUnit struct {
 	start int
 	end   int
 }
 
-// SplitBrick partitions one parent at byte offsets only. Under-threshold bricks
-// require at least two strong story seams. Over-threshold bricks may use the
-// same blank-line paragraph units as atomicUnits. In every case at least two
-// substantive segments are required, and any coverage mismatch fails closed by
-// returning nil so the existing rewrite flag remains the only action.
+// SplitBrick partitions one parent at strong-story-seam byte offsets only. In
+// every case at least two substantive segments are required, and any coverage
+// mismatch fails closed by returning nil so the existing rewrite flag remains
+// the only action.
 func SplitBrick(parentKey, content string) []GroomSplitChild {
 	coverage := strings.TrimSpace(content)
 	if coverage == "" {
 		return nil
 	}
-	units := groomParagraphUnits(coverage)
-	strong := groomStrongSeams(coverage)
-	strongCount := len(strong)
-	if strongCount < 2 && len(content) <= GroomRewriteThreshold {
+	if detectStatusChangelog(coverage) {
 		return nil
 	}
-	if strongCount < 2 && len(units) < 2 {
+	strong := groomStrongSeams(coverage)
+	if len(strong) < 2 {
 		return nil
 	}
 
 	cutStarts := []int{0}
-	if strongCount >= 2 {
-		for _, seam := range strong {
-			if seam.start > 0 {
-				cutStarts = append(cutStarts, seam.start)
-			}
-		}
-	}
-	if len(content) > GroomRewriteThreshold {
-		for _, unit := range units[1:] {
-			cutStarts = append(cutStarts, unit.start)
+	for _, seam := range strong {
+		if seam.start > 0 {
+			cutStarts = append(cutStarts, seam.start)
 		}
 	}
 	cutStarts = uniqueSortedOffsets(cutStarts, len(coverage))
 	if len(cutStarts) < 2 {
 		return nil
 	}
-
-	children := make([]GroomSplitChild, 0, len(cutStarts))
-	usedKeys := make(map[string]struct{}, len(cutStarts))
-	substantive := 0
+	segments := make([]groomTextUnit, 0, len(cutStarts))
 	for i, start := range cutStarts {
 		end := len(coverage)
 		if i+1 < len(cutStarts) {
@@ -341,14 +336,25 @@ func SplitBrick(parentKey, content string) []GroomSplitChild {
 		if start < 0 || start >= end || end > len(coverage) {
 			return nil
 		}
-		text := coverage[start:end]
+		segments = append(segments, groomTextUnit{start: start, end: end})
+	}
+	segments = mergeGroomRunts(segments, coverage)
+	if len(segments) < 2 {
+		return nil
+	}
+
+	children := make([]GroomSplitChild, 0, len(segments))
+	usedKeys := make(map[string]struct{}, len(segments))
+	substantive := 0
+	for _, segment := range segments {
+		text := coverage[segment.start:segment.end]
 		if strings.TrimSpace(text) == "" {
 			return nil
 		}
 		if groomSubstantive(text) {
 			substantive++
 		}
-		label := groomFirstNonBlankLine(groomTextUnit{start: start, end: end}, coverage)
+		label := groomFirstNonBlankLine(segment, coverage)
 		base := parentKey + "-" + Slug(groomSeamLabel(label))
 		key := base
 		for n := 2; ; n++ {
@@ -364,6 +370,31 @@ func SplitBrick(parentKey, content string) []GroomSplitChild {
 		return nil
 	}
 	return children
+}
+
+func mergeGroomRunts(segments []groomTextUnit, content string) []groomTextUnit {
+	segments = append([]groomTextUnit(nil), segments...)
+	for len(segments) > 1 {
+		merged := false
+		for i, segment := range segments {
+			if len(strings.TrimSpace(content[segment.start:segment.end])) >= GroomMinChildBytes {
+				continue
+			}
+			if i == 0 {
+				segments[1].start = segment.start
+				segments = segments[1:]
+			} else {
+				segments[i-1].end = segment.end
+				segments = append(segments[:i], segments[i+1:]...)
+			}
+			merged = true
+			break
+		}
+		if !merged {
+			break
+		}
+	}
+	return segments
 }
 
 func groomStrongSeams(content string) []groomTextUnit {
@@ -420,6 +451,13 @@ func groomFirstNonBlankLine(unit groomTextUnit, content string) string {
 }
 
 func isGroomStrongSeam(line string) bool {
+	if groomListItem.MatchString(line) {
+		return false
+	}
+	label := strings.ToLower(groomSeamLabel(line))
+	if label == "why" || label == "how to apply" {
+		return false
+	}
 	if groomBoldHeader.MatchString(line) || groomDateLed.MatchString(line) || groomPRMarker.MatchString(line) {
 		return true
 	}
@@ -439,7 +477,7 @@ func groomSeamLabel(line string) string {
 		// not the whole line.
 		label = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(m[1]), ":"))
 	}
-	return label
+	return strings.TrimSpace(strings.TrimSuffix(label, ":"))
 }
 
 func groomSubstantive(content string) bool {

--- a/internal/memory/groom_test.go
+++ b/internal/memory/groom_test.go
@@ -1,6 +1,8 @@
 package memory
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -220,7 +222,8 @@ func TestSplitBrickLosslessFact80Shape(t *testing.T) {
 }
 
 func TestSplitBrickStrongSeamsBelowRewriteThreshold(t *testing.T) {
-	content := "**First shipped story**\nThe cache invalidation path now preserves live sessions.\n\n**Second shipped story**\nThe retry path now records its durable terminal reason."
+	content := "**First shipped story**\n" + strings.Repeat("The cache invalidation path now preserves live sessions. ", 5) +
+		"\n\n**Second shipped story**\n" + strings.Repeat("The retry path now records its durable terminal reason. ", 5)
 	if len(content) >= GroomRewriteThreshold {
 		t.Fatal("fixture must exercise seam qualification below the length threshold")
 	}
@@ -235,12 +238,13 @@ func TestSplitBrickStrongSeamsBelowRewriteThreshold(t *testing.T) {
 }
 
 func TestSplitBrickDateAndPRMarkerLines(t *testing.T) {
-	content := "2026-07-10\nThe deployment story includes enough substantive detail.\nPR #832\nThe groom split story includes enough substantive detail."
+	content := "2026-07-10\n" + strings.Repeat("The deployment story includes enough substantive detail. ", 5) +
+		"\nPR #832\n" + strings.Repeat("The groom split story includes enough substantive detail. ", 5)
 	children := SplitBrick("dated-stories", content)
 	if len(children) != 2 || !strings.HasSuffix(children[0].Key, "2026-07-10") || !strings.HasSuffix(children[1].Key, "pr-832") {
 		t.Fatalf("date/PR seams = %+v", children)
 	}
-	if concatGroomSplitChildren(children) != content {
+	if concatGroomSplitChildren(children) != strings.TrimSpace(content) {
 		t.Fatal("date/PR split lost parent bytes")
 	}
 }
@@ -260,8 +264,9 @@ func TestSplitBrickSeamPoorLongProseFallsBackToFlagOnly(t *testing.T) {
 }
 
 func TestDetectGroomSplitsDeterministicAndRejectsNonSubstantiveSegments(t *testing.T) {
-	good := "**Alpha**\nA substantive first implementation story.\n\n**Beta**\nA substantive second implementation story."
-	bad := "**Alpha**\nA substantive implementation story.\n\n**Beta**\nx"
+	good := "**Alpha**\n" + strings.Repeat("A substantive first implementation story remains stable. ", 5) +
+		"\n\n**Beta**\n" + strings.Repeat("A substantive second implementation story remains stable. ", 5)
+	bad := "**Alpha**\n" + strings.Repeat("A substantive implementation story remains stable. ", 5) + "\n\n**Beta**\nx"
 	cands := []GroomCandidate{
 		{ID: 20, Key: "bad", Content: bad, UpdatedAt: "u20"},
 		{ID: 10, Key: "good", Content: good, UpdatedAt: "u10"},
@@ -278,7 +283,8 @@ func TestDetectGroomSplitsDeterministicAndRejectsNonSubstantiveSegments(t *testi
 }
 
 func TestDetectGroomSplitsAllocatesAroundExistingScopeKeys(t *testing.T) {
-	content := "**Alpha story**\nA substantive first implementation story.\n\n**Beta story**\nA substantive second implementation story."
+	content := "**Alpha story**\n" + strings.Repeat("A substantive first implementation story remains stable. ", 5) +
+		"\n\n**Beta story**\n" + strings.Repeat("A substantive second implementation story remains stable. ", 5)
 	cands := []GroomCandidate{
 		{ID: 1, Key: "parent", Content: content, OwnerKind: "agent", OwnerRef: "lead", Repo: "acme/widget", Scope: "repo"},
 		{ID: 2, Key: "parent-alpha-story", Content: "an existing fact", OwnerKind: "agent", OwnerRef: "lead", Repo: "acme/widget", Scope: "repo"},
@@ -392,7 +398,10 @@ func TestGroomFirstLine(t *testing.T) {
 // date/PR evidence so they are story seams; sub-field leads like "**Why:**"
 // must NOT cut.
 func TestSplitBrickBoldLeadInlineSeams(t *testing.T) {
-	content := "**Waveform refinement (2026-06-19, PR #241, main x):** fixed blocky zoom\nmore detail line\n**Per-tile focus bug fixed (2026-06-21, PR #242):** assigning a person\n**Why:** the event was overloaded\ntrailing line"
+	content := "**Waveform refinement (2026-06-19, PR #241, main x):** fixed blocky zoom\n" +
+		strings.Repeat("The waveform path preserves exact source timing and stable redraw behavior. ", 4) +
+		"\n**Per-tile focus bug fixed (2026-06-21, PR #242):** assigning a person\n**Why:** the event was overloaded\n" +
+		strings.Repeat("The tile path preserves the split while updating only the selected track. ", 4)
 	children := SplitBrick("editor-goalset", content)
 	if len(children) != 2 {
 		t.Fatalf("children = %d, want 2 (one per dated bold-lead story; **Why:** must not cut): %+v", len(children), children)
@@ -403,5 +412,113 @@ func TestSplitBrickBoldLeadInlineSeams(t *testing.T) {
 	}
 	if !strings.Contains(children[1].Content, "**Why:**") {
 		t.Fatalf("sub-field lead should stay inside story 2: %q", children[1].Content)
+	}
+}
+
+func TestGroomStrongSeamGuards(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{name: "plain PR marker", line: "PR #842", want: true},
+		{name: "dash list PR", line: "- #147 phrasing perturbation", want: false},
+		{name: "asterisk list PR", line: "* PR #147 phrasing perturbation", want: false},
+		{name: "plus list date", line: "+ 2026-07-11 shipped", want: false},
+		{name: "number-dot list date", line: "1. 2026-07-11 shipped", want: false},
+		{name: "number-paren list PR", line: "2) PR #147 shipped", want: false},
+		{name: "why sub-field", line: "**Why:**", want: false},
+		{name: "how-to-apply sub-field", line: "**How to apply:**", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isGroomStrongSeam(tc.line); got != tc.want {
+				t.Fatalf("isGroomStrongSeam(%q) = %v, want %v", tc.line, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeGroomRunts(t *testing.T) {
+	tests := []struct {
+		name     string
+		lengths  []int
+		wantEnds []int
+	}{
+		{name: "first runt merges forward", lengths: []int{100, 250, 250}, wantEnds: []int{350, 600}},
+		{name: "middle runt merges backward", lengths: []int{250, 100, 250}, wantEnds: []int{350, 600}},
+		{name: "last runt merges backward", lengths: []int{250, 250, 100}, wantEnds: []int{250, 600}},
+		{name: "repeat until one remains", lengths: []int{100, 100, 100}, wantEnds: []int{300}},
+		{name: "exact threshold survives", lengths: []int{200, 200}, wantEnds: []int{200, 400}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var content strings.Builder
+			segments := make([]groomTextUnit, 0, len(tc.lengths))
+			start := 0
+			for i, n := range tc.lengths {
+				content.WriteString(strings.Repeat(string(rune('a'+i)), n))
+				segments = append(segments, groomTextUnit{start: start, end: start + n})
+				start += n
+			}
+			got := mergeGroomRunts(segments, content.String())
+			if len(got) != len(tc.wantEnds) {
+				t.Fatalf("segments = %+v, want ends %v", got, tc.wantEnds)
+			}
+			for i, wantEnd := range tc.wantEnds {
+				if got[i].end != wantEnd {
+					t.Fatalf("segment %d end = %d, want %d (%+v)", i, got[i].end, wantEnd, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSplitBrickRejectsStatusChangelog(t *testing.T) {
+	line := strings.Repeat(" release status detail", 14)
+	content := "2026-07-11" + line + "\n2026-07-10" + line + "\n2026-07-09" + line
+	if !detectStatusChangelog(content) {
+		t.Fatal("fixture must be detected as a status changelog")
+	}
+	if got := SplitBrick("release-status", content); got != nil {
+		t.Fatalf("status changelog split = %+v, want nil", got)
+	}
+}
+
+func TestSplitBrickLiveRegressionFixtures(t *testing.T) {
+	read := func(id string) string {
+		t.Helper()
+		body, err := os.ReadFile(filepath.Join("testdata", "groom", id+".md"))
+		if err != nil {
+			t.Fatalf("read fixture %s: %v", id, err)
+		}
+		return strings.TrimSuffix(string(body), "\n")
+	}
+
+	children := SplitBrick("editor-waveform-speakersplit-goalset", read("80"))
+	if len(children) != 2 {
+		t.Fatalf("fact 80 children = %+v, want exactly 2", children)
+	}
+	if !strings.HasPrefix(children[0].Content, "**Waveform refinement (2026-06-19, PR #241") ||
+		!strings.HasPrefix(children[1].Content, "**Per-tile speaker-focus bug fixed (2026-06-21, PR #242") {
+		t.Fatalf("fact 80 story heads = %q / %q", groomFirstLine(children[0].Content), groomFirstLine(children[1].Content))
+	}
+	wantLabels := []string{
+		"Waveform refinement (2026-06-19, PR #241, main `40b92f0`)",
+		"Per-tile speaker-focus bug fixed (2026-06-21, PR #242, main `f249a12`)",
+	}
+	for i, child := range children {
+		if label := groomSeamLabel(groomFirstNonBlankLine(groomTextUnit{start: 0, end: len(child.Content)}, child.Content)); label != wantLabels[i] {
+			t.Fatalf("fact 80 child %d label = %q, want %q", i, label, wantLabels[i])
+		}
+	}
+	if concatGroomSplitChildren(children) != read("80") {
+		t.Fatal("fact 80 split lost coverage")
+	}
+
+	for _, id := range []string{"152", "204", "264"} {
+		if got := SplitBrick("live-fact-"+id, read(id)); got != nil {
+			t.Fatalf("fact %s split = %+v, want nil", id, got)
+		}
 	}
 }

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -56,6 +56,7 @@ type Owner struct {
 type Entry struct {
 	Scope     string // ScopeRepo | ScopeGeneral
 	Key       string
+	Context   string // optional subject inherited from a split parent
 	Content   string
 	UpdatedAt string
 	Linked    bool // true when included via a 1-hop memory_links expansion
@@ -226,6 +227,9 @@ func RenderBullet(e Entry) string {
 	tags := []string{scopeTag(e.Scope)}
 	if e.Linked {
 		tags = append(tags, "[linked]")
+	}
+	if context := strings.TrimSpace(e.Context); context != "" {
+		tags = append(tags, "(split from: "+context+")")
 	}
 	return "- " + strings.Join(tags, " ") + " " + strings.TrimSpace(e.Content)
 }

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -163,6 +163,9 @@ func TestRenderBlockTagsAndBudget(t *testing.T) {
 	if linked := RenderBullet(Entry{Scope: ScopeRepo, Content: "linked neighbor", Linked: true}); !strings.Contains(linked, "[this repo] [linked] linked neighbor") {
 		t.Errorf("linked bullet missing linked tag: %q", linked)
 	}
+	if split := RenderBullet(Entry{Scope: ScopeRepo, Context: "parent-subject", Content: "child detail"}); split != "- [this repo] (split from: parent-subject) child detail" {
+		t.Errorf("split context bullet = %q", split)
+	}
 }
 
 func TestRenderBlockBudgetCaps(t *testing.T) {

--- a/internal/memory/testdata/groom/152.md
+++ b/internal/memory/testdata/groom/152.md
@@ -1,0 +1,10 @@
+## Round 2 (PRs #144-#148) — best tokens yet, target still unmet
+Round-2 n20 `run-20260610-082812-77c0f0`: 19/20, **5.97M tokens (-17.7% vs 7.24M baseline)**, 190.4s. Merged:
+- #144 unit-parse fix (table_cells `_declared_unit_from_line`): body rows no longer clobber `{In thousands of dollars}` -> uid0127 FIXED (42k, passes).
+- #145 degrade-to-full-baseline: answer-ready routes that can't extract use `_baseline_sparse_search` (not distilled top-3) -> uid0246 2.17M->0.97M.
+- #146 corpus sweep `scripts/sweep_point_formula.py` (anti-overfit): only total_public_debt_outstanding extracts on real corpus; 0 ambiguous across families (can't mis-extract). Decided NOT to build uid0246 summation (overfit).
+- #147 phrasing-perturbation router tests. #148 results doc.
+
+NEW regression: **uid0192 FAILED** (passed before) — step-budget stopped the agent after ~6 steps in the wrong issue (1991_03 vs 1991_06). Step-budget vs accuracy tradeoff.
+
+STRUCTURAL: 62% of tokens = 3 non-extracting hard questions (uid0030 chart 1.48M, uid0111 HP-series 1.23M, uid0246 summation 0.97M); high run-to-run variance. <2.5M needs extracting those = deep + overfit-prone + many paid n20s. Paused for user direction (tg msg 1423): (a) fix uid0192 step-budget, (b) attempt hard extractions, (c) stop at the -17.7% win. #135 OPEN.

--- a/internal/memory/testdata/groom/204.md
+++ b/internal/memory/testdata/groom/204.md
@@ -1,0 +1,12 @@
+Owner feedback (2026-07-07, after the Pipelines v1.6 ship): when I said "only your eyes can check the layout," he replied "why my eyes? u can use playwright to check."
+
+**Why:** UI claims ("the matrix renders", "8 tabs fit at 390px") are verifiable on this box — deferring visual checks to the owner is unnecessary and slows the loop.
+
+**How to apply:** after deploying any dashboard/web UI change, screenshot the LIVE page and Read the PNGs (I can see images):
+1. `/usr/bin/google-chrome` exists + playwright browser caches in `~/.cache/ms-playwright`. Install driver per-scratchpad: `npm i playwright-core` (no browser download needed — point at system Chrome).
+2. Script pattern (kept at a past session's `scratchpad/pw/shoot.js`): `chromium.launch({executablePath:'/usr/bin/google-chrome', args:['--no-sandbox','--disable-dev-shm-usage']})`, per-viewport `newContext({viewport:{width,height}})`, `goto(url,{waitUntil:'domcontentloaded'})`, `waitForSelector` on a page-specific element, small settle delay, `screenshot({fullPage:true})`.
+3. **GOTCHA:** plain `google-chrome --headless --screenshot` HANGS on the gitmoot dashboard — the 12s signature-skip polls keep the page from ever going network-idle, and `--virtual-time-budget` doesn't force the draw under `--headless=new`. Use playwright with `domcontentloaded` + explicit selector waits instead.
+4. Standard shot set: desktop 1440px (list + detail), mobile 390×844 (tab-bar fit + card reflow), plus one adjacent view as a regression check (e.g. Health after touching shared helpers).
+5. This closed the loop that caught nothing new for Pipelines v1.6 (all views verified good) but also caught a side-issue: another session had deployed an UNSTAMPED binary (Health showed "vdev" + a false update chip) — screenshots surface deploy drift too.
+
+See [[pipelines-dashboard-page-shipped]].

--- a/internal/memory/testdata/groom/264.md
+++ b/internal/memory/testdata/groom/264.md
@@ -1,0 +1,9 @@
+Running the noted `gitmoot orchestrate noted-lead ... --recipe decompose-and-verify --home /root/.gitmoot-noted` (per CLAUDE.local.md) has two non-obvious prerequisites:
+
+1. **The `decompose-and-verify` template must be installed in the repo's gitmoot home first**, or orchestrate fails with `agent template ... is not installed`. Install with: `gitmoot agent template update --home /root/.gitmoot-noted decompose-and-verify`.
+
+2. **Flag ordering differs between subcommands.** `gitmoot agent template update` uses Go's flag parser, which stops at the first positional — so `--home` MUST come BEFORE the template id (`update --home <dir> <id>`, not `update <id> --home <dir>`, which errors `requires exactly one template id`). `gitmoot orchestrate` accepts flags AFTER its positionals, so the CLAUDE.local.md ordering works as written for it.
+
+**Why:** Both blocked the one-command workflow on first try. **How to apply:** install the template (flag-first) before orchestrating; keep orchestrate's flags-after-positionals form.
+
+Also: the classifier blocks `gitmoot agent template update` / `gitmoot orchestrate` under auto mode (provisions codex danger-full-access workers). Project `.claude/settings.json` now allowlists `Bash(gitmoot agent template update:*)` and `Bash(gitmoot orchestrate:*)`. Related: [[gitmoot-exec-legs-need-codex]].

--- a/internal/memory/testdata/groom/80.md
+++ b/internal/memory/testdata/groom/80.md
@@ -1,0 +1,21 @@
+**Waveform refinement (2026-06-19, PR #241, main `40b92f0`):** fixed blocky zoom +
+added trim/cutout dimming. Worker peaks `target_pps` 50→100 (`max_length`→500k);
+`EditorTrimRail.vue drawWaveform` now linearly interpolates between buckets (no
+staircase) and dims non-kept columns (tests `keptSegments` = IN/OUT trim + active
+cutouts; α 0.22), redrawing live on drag (watcher deps include trimStart/trimEnd/
+keptSegments/cutoutSegments). Deployed (web+worker) + **re-backfilled all 49 clips at
+100pps** (`/tmp/backfill_peaks.py` with `BACKFILL_ALL=1` → reprocess all ready-source
+jobs, upsert overwrites). The R2 bucket CORS already allows GET/HEAD for the app origin
+(user confirmed) — moot since peaks serve same-origin.
+**Per-tile speaker-focus bug fixed (2026-06-21, PR #242, main `f249a12`):** assigning a
+person to a split tile was collapsing the composition to that person FULL-FRAME (both
+tiles hidden) in preview AND render — the `speaker_focus` event was overloaded ("focus
+full-frame" vs "pin to tile N") and the `slot` was discarded in `editorPreview.ts`,
+`virtual_events.py` (`_podcast_camera_target` flattened to first slot), `clip_edits.py`
+(`_split_focus_event_windows`), and `render_filters.py` (`_apply_focus_overlays` full
+`W,H@0:0`). Fix = preview + render branch identically on `slot`: with a finite slot,
+keep the two-tile split and swap only `tracks[slot]` (render overlays a tile-sized panel
+at the tile origin); slot-less stays full-frame focus. Documented on #234 (issue
+comment). Deployed (web+worker). NOTE: this run did NOT hit the stray-checkout gotcha —
+the review prompt told the reviewer to use `gh pr diff`, not `gh pr checkout`
+([[wave-review-agents-stray-checkout]]).

--- a/internal/workflow/memory.go
+++ b/internal/workflow/memory.go
@@ -230,6 +230,7 @@ func memoryEntryFromConfirmed(r db.ConfirmedMemory, linked bool) memory.Entry {
 	return memory.Entry{
 		Scope:     r.Scope,
 		Key:       r.Key,
+		Context:   r.Context,
 		Content:   r.Content,
 		UpdatedAt: r.UpdatedAt,
 		Linked:    linked,

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1955,21 +1955,34 @@ round-trip:
 gitmoot memory groom --propose [--out PLAN.json] [--json]
 gitmoot memory groom --yes --plan PLAN.json [--json]
 gitmoot memory groom --split [--dry-run] [--json]
+gitmoot memory groom --split-revert [--dry-run] [--parent N]... [--since RFC3339] [--json]
 ```
 
 `--split` is the automatic, approval-free lossless pass. It partitions a brick
 at byte offsets on strong story seams (bold story headers, date-led lines, and
-PR markers) or, for over-threshold content, blank-line paragraph groups. A
-candidate needs at least two substantive segments and either two strong seams
-or content over `GroomRewriteThreshold`. Children are exact parent substrings in
-deterministic order and must concatenate to the parent's trimmed coverage; any
-invariant failure falls back to a rewrite flag without writing. Child keys use
+PR markers). List items, `Why`, and `How to apply` sub-fields are never seams;
+length alone never cuts, and status/changelog content is excluded. A candidate
+needs at least two strong seams and two substantive children after repeatedly
+merging trimmed segments smaller than 200 bytes into a neighbor. Children are
+exact parent substrings in deterministic order and must concatenate to the
+parent's trimmed coverage; any invariant failure falls back to a rewrite flag
+without writing. Child keys use
 `<parent-key>-<seam-slug>` with deterministic ordinals, provenance is
-`groom-split:<parent-id>`, and owner/author/repo/scope are inherited. Apply is one
-CAS-guarded transaction: children and FTS rows are inserted, the parent leaves
-FTS and is set `superseded_by = <first-child-id>`, and children replace the
-parent in its cluster. Links are left for normal enrichment. `--dry-run` prints
-the same split plan without changing the store; a repeat run is a no-op.
+`groom-split:<parent-id>`, owner/author/repo/scope are inherited, and each child
+renders with `(split from: <parent-key>)` subject context. Apply is one CAS-guarded
+transaction: children and FTS rows are inserted, the parent leaves FTS and is set
+`superseded_by = <first-child-id>`, and children replace the parent in its cluster.
+Links are left for normal enrichment. `--dry-run` prints the same split plan
+without changing the store; a repeat run is a no-op.
+
+`--split-revert` restores all currently active groom-split parents by default;
+repeat `--parent N` to select parent ids or pass `--since RFC3339` to select recent
+splits. It first verifies that the active children in id order reconstruct the
+trimmed parent exactly. A mismatched parent is skipped whole. Valid children are
+retired with reason `groom-split-revert:<parent-id>` and removed from clusters,
+the parent is restored to FTS, and its cluster is restored from the lowest-id
+child's current cluster when available. The operation is idempotent, and
+`--dry-run` lists the same groups without writing.
 
 `--propose` reads every **active** confirmed memory (retired rows excluded),
 computes the current vault `snapshot_hash` (the same anchor `vault export`/`import`

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -374,17 +374,29 @@ future work; nothing reads `trust_mark` for a decision yet.
 gitmoot memory groom --propose [--out PLAN.json] [--json]
 gitmoot memory groom --yes --plan PLAN.json [--json]
 gitmoot memory groom --split [--dry-run] [--json]
+gitmoot memory groom --split-revert [--dry-run] [--parent N]... [--since RFC3339] [--json]
 ```
 
 `--split` partitions qualifying multi-story bricks at deterministic byte offsets.
-Strong seams are bold story headers, date-led lines, and PR markers; over-threshold
-content may also split on blank-line paragraph groups. Children are exact parent
-substrings and must concatenate to the parent's trimmed coverage, otherwise the
-operation fails closed to a rewrite flag. The transaction inserts and indexes the
-children, sets the parent `superseded_by` to the first child, removes the parent
-from FTS and cluster membership, and attaches children to the parent's cluster.
-Ownership, author, repo, and scope are inherited; links are enriched later.
-`--dry-run` writes nothing, and subsequent runs are no-ops.
+Strong seams are bold story headers, date-led lines, and PR markers. List items,
+`Why`, and `How to apply` sub-fields are excluded; length alone never creates a
+cut, and status/changelog content is not split. Segments below 200 trimmed bytes
+merge into a neighbor until stable. Children are exact parent substrings and must
+concatenate to the parent's trimmed coverage, otherwise the operation fails closed
+to a rewrite flag. The transaction inserts and indexes the children, sets the
+parent `superseded_by` to the first child, removes the parent from FTS and cluster
+membership, and attaches children to the parent's cluster. Ownership, author,
+repo, and scope are inherited, and rendered children carry `(split from:
+<parent-key>)` context; links are enriched later. `--dry-run` writes nothing, and
+subsequent runs are no-ops.
+
+`--split-revert` defaults to every active groom split; `--parent N` is repeatable
+and `--since RFC3339` filters recent splits. Each parent is restored only when its
+active children in id order still reconstruct the trimmed original exactly.
+Valid children are retired, never deleted, with reason
+`groom-split-revert:<parent-id>`; the parent returns to FTS and inherits the
+lowest-id child's current cluster when one exists. Changed groups are skipped
+whole, repeated runs are no-ops, and `--dry-run` only reports candidates.
 
 `--propose` reads every **active** confirmed memory (retired rows excluded),
 computes the current vault `snapshot_hash` (the same anchor `vault export`/`import`

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1435,6 +1435,7 @@ gitmoot memory links list <id> [--json]
 gitmoot memory groom --propose [--out PLAN.json] [--json]
 gitmoot memory groom --yes --plan PLAN.json [--json]
 gitmoot memory groom --split [--dry-run] [--json]
+gitmoot memory groom --split-revert [--dry-run] [--parent N]... [--since RFC3339] [--json]
 gitmoot memory clusters [--json]
 gitmoot memory clusters recompute --propose [--out PLAN.json] [--json]
 gitmoot memory clusters recompute --apply [--plan PLAN.json] [--json]
@@ -1561,9 +1562,17 @@ export merges these persisted links with content-derived links and dedupes by
 target in each note's `## Links` section.
 
 `memory groom --split [--dry-run]` automatically partitions qualifying bricks at
-deterministic byte-offset seams into exact-substring children, supersedes and
-de-indexes the parent, and carries its cluster membership to the children in one
-CAS-guarded transaction. `memory groom` keeps all other curation as a
+deterministic byte-offset story seams into exact-substring children. List items,
+`Why`, and `How to apply` sub-fields are not seams; length alone never cuts,
+status/changelog content is excluded, and segments below 200 trimmed bytes merge
+into a neighbor. The split supersedes and de-indexes the parent, carries its
+cluster membership to the children, and gives each rendered child `(split from:
+<parent-key>)` context in one CAS-guarded transaction.
+`memory groom --split-revert [--dry-run] [--parent N]... [--since RFC3339]`
+restores all active split parents by default. It retires, never deletes, children
+only when their id-ordered content still reconstructs the original parent, then
+restores parent FTS and the lowest-id child's current cluster. Changed groups skip
+whole and repeat runs are no-ops. `memory groom` keeps all other curation as a
 **propose → review → apply** round-trip. `--propose` reads active confirmed memory, computes the current
 vault `snapshot_hash`, runs deterministic detectors
 (status/changelog/ToC snapshots — short notes need a strong `STATUS:`/`… & deployed`

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10388,21 +10388,34 @@ round-trip:
 gitmoot memory groom --propose [--out PLAN.json] [--json]
 gitmoot memory groom --yes --plan PLAN.json [--json]
 gitmoot memory groom --split [--dry-run] [--json]
+gitmoot memory groom --split-revert [--dry-run] [--parent N]... [--since RFC3339] [--json]
 ```
 
 `--split` is the automatic, approval-free lossless pass. It partitions a brick
 at byte offsets on strong story seams (bold story headers, date-led lines, and
-PR markers) or, for over-threshold content, blank-line paragraph groups. A
-candidate needs at least two substantive segments and either two strong seams
-or content over `GroomRewriteThreshold`. Children are exact parent substrings in
-deterministic order and must concatenate to the parent's trimmed coverage; any
-invariant failure falls back to a rewrite flag without writing. Child keys use
+PR markers). List items, `Why`, and `How to apply` sub-fields are never seams;
+length alone never cuts, and status/changelog content is excluded. A candidate
+needs at least two strong seams and two substantive children after repeatedly
+merging trimmed segments smaller than 200 bytes into a neighbor. Children are
+exact parent substrings in deterministic order and must concatenate to the
+parent's trimmed coverage; any invariant failure falls back to a rewrite flag
+without writing. Child keys use
 `<parent-key>-<seam-slug>` with deterministic ordinals, provenance is
-`groom-split:<parent-id>`, and owner/author/repo/scope are inherited. Apply is one
-CAS-guarded transaction: children and FTS rows are inserted, the parent leaves
-FTS and is set `superseded_by = <first-child-id>`, and children replace the
-parent in its cluster. Links are left for normal enrichment. `--dry-run` prints
-the same split plan without changing the store; a repeat run is a no-op.
+`groom-split:<parent-id>`, owner/author/repo/scope are inherited, and each child
+renders with `(split from: <parent-key>)` subject context. Apply is one CAS-guarded
+transaction: children and FTS rows are inserted, the parent leaves FTS and is set
+`superseded_by = <first-child-id>`, and children replace the parent in its cluster.
+Links are left for normal enrichment. `--dry-run` prints the same split plan
+without changing the store; a repeat run is a no-op.
+
+`--split-revert` restores all currently active groom-split parents by default;
+repeat `--parent N` to select parent ids or pass `--since RFC3339` to select recent
+splits. It first verifies that the active children in id order reconstruct the
+trimmed parent exactly. A mismatched parent is skipped whole. Valid children are
+retired with reason `groom-split-revert:<parent-id>` and removed from clusters,
+the parent is restored to FTS, and its cluster is restored from the lowest-id
+child's current cluster when available. The operation is idempotent, and
+`--dry-run` lists the same groups without writing.
 
 `--propose` reads every **active** confirmed memory (retired rows excluded),
 computes the current vault `snapshot_hash` (the same anchor `vault export`/`import`


### PR DESCRIPTION
Phase 1 of #842 per the panel design comment: seam-only cuts (the >1200-byte cut-at-every-paragraph rule is gone), list items are never seams, Why/How-to-apply sub-fields protected, 200-byte runt-merging, status-changelog guard; split children inherit the parent subject via a new `context` column (rendered as `(split from: …)` by RenderBullet — content stays byte-exact, both coverage guards untouched); and a repeatable `memory groom --split-revert [--dry-run] [--parent] [--since]` that retires children under a reverse coverage invariant and restores the parent (superseded_by cleared, FTS re-inserted, cluster restored from the lowest child).

Acceptance fixtures are the exact live contents of facts 80/152/204/264: 80 must split into exactly its two PR-story children (byte coverage asserted), the other three must return nil. The old-schema migration fixture pre-creates a minimal confirmed_memories table for the new ALTER (the #836 lesson).

Coordinator-verified end-to-end on the live store: revert restored all 22 first-run splits (0 skipped), re-split under the new rules produced exactly the 9 genuine story splits the research simulation predicted (80/96/176/187/222/224/235/240/266), fact 80 = its two stories, 152/204/264 whole again, FTS drift zero. Phase 2 (LLM-guided cuts) follows separately behind groom_split_llm. Implemented by gpt-5.6-sol; coordinator-reviewed. Closes #842 Phase 1 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)