### PR TITLE
fix(activepieces): polish setup, down, and templates (#857)

### DIFF
--- a/internal/activepieces/client.go
+++ b/internal/activepieces/client.go
@@ -284,6 +284,18 @@ func (c *Client) ImportFlow(ctx context.Context, token, flowID string, flow json
 	return nil
 }
 
+func (c *Client) DeleteFlow(ctx context.Context, token, flowID string) error {
+	path := "/api/v1/flows/" + url.PathEscape(flowID)
+	if err := c.doJSON(ctx, http.MethodDelete, path, token, nil, nil); err != nil {
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("delete Activepieces flow: %w", err)
+	}
+	return nil
+}
+
 func (c *Client) ListFlows(ctx context.Context, token, projectID string) ([]FlowSummary, error) {
 	query := url.Values{"projectId": {projectID}}
 	path := "/api/v1/flows?" + query.Encode()

--- a/internal/activepieces/client_test.go
+++ b/internal/activepieces/client_test.go
@@ -117,6 +117,37 @@ func TestInstallPieceRejectsEmptyVersion(t *testing.T) {
 	}
 }
 
+func TestClientDeletesFlow(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Method != http.MethodDelete {
+			t.Errorf("method = %s, want DELETE", r.Method)
+		}
+		if r.URL.EscapedPath() != "/api/v1/flows/flow%2F1" {
+			t.Errorf("path = %s, want /api/v1/flows/flow%%2F1", r.URL.EscapedPath())
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("Authorization = %q, want bearer token", got)
+		}
+		if requests == 2 {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	client, err := NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := client.DeleteFlow(context.Background(), "test-token", "flow/1"); err != nil {
+			t.Fatalf("DeleteFlow call %d: %v", i+1, err)
+		}
+	}
+}
+
 func TestInstallPieceSendsVersion(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any

--- a/internal/cli/activepieces.go
+++ b/internal/cli/activepieces.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -30,6 +31,7 @@ const (
 	defaultActivepiecesEmail   = "admin@gitmoot.local"
 	defaultActivepiecesProject = "gitmoot-activepieces"
 	activepiecesConnectionID   = "gitmoot-bridge"
+	activepiecesBridgePIDFile  = "bridge.pid"
 )
 
 func runActivepieces(args []string, stdout, stderr io.Writer) int {
@@ -54,7 +56,7 @@ func runActivepieces(args []string, stdout, stderr io.Writer) int {
 func printActivepiecesUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot activepieces setup [flags]")
-	fmt.Fprintln(w, "  gitmoot activepieces down [--volumes] [flags]")
+	fmt.Fprintln(w, "  gitmoot activepieces down [--volumes] [--stop-bridge] [flags]")
 	fmt.Fprintln(w, "  gitmoot activepieces templates list")
 	fmt.Fprintln(w, "  gitmoot activepieces templates import [flags] [id...]")
 }
@@ -143,6 +145,9 @@ func runActivepiecesSetup(args []string, stdout, stderr io.Writer) int {
 	if err := ensureActivepiecesBridge(*home, stackDir, *bridgeAddr, allowRemote, *noBridgeSpawn); err != nil {
 		fmt.Fprintf(stderr, "activepieces setup: %v\n", err)
 		return 1
+	}
+	if allowRemote {
+		fmt.Fprintf(stdout, "Bridge is reachable by local containers on %s (bearer-token protected).\n", *bridgeAddr)
 	}
 
 	targetURL := strings.TrimRight(strings.TrimSpace(*apURL), "/")
@@ -314,7 +319,15 @@ func ensureActivepiecesBridge(home, stackDir, addr string, allowRemote, noSpawn 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start Gitmoot bridge: %w", err)
 	}
+	if err := writeActivepiecesBridgePID(stackDir, cmd.Process.Pid, addr); err != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return fmt.Errorf("write Gitmoot bridge pid file: %w", err)
+	}
 	if err := cmd.Process.Release(); err != nil {
+		_ = os.Remove(filepath.Join(stackDir, activepiecesBridgePIDFile))
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
 		return fmt.Errorf("release Gitmoot bridge process: %w", err)
 	}
 	deadline := time.Now().Add(15 * time.Second)
@@ -325,6 +338,149 @@ func ensureActivepiecesBridge(home, stackDir, addr string, allowRemote, noSpawn 
 		time.Sleep(200 * time.Millisecond)
 	}
 	return fmt.Errorf("Gitmoot bridge did not start on %s; inspect %s", addr, filepath.Join(stackDir, "bridge.log"))
+}
+
+type activepiecesBridgePID struct {
+	PID  int    `json:"pid"`
+	Addr string `json:"addr"`
+}
+
+func writeActivepiecesBridgePID(stackDir string, pid int, addr string) error {
+	if pid <= 0 || strings.TrimSpace(addr) == "" {
+		return errors.New("invalid Gitmoot bridge process metadata")
+	}
+	body, err := json.Marshal(activepiecesBridgePID{PID: pid, Addr: strings.TrimSpace(addr)})
+	if err != nil {
+		return err
+	}
+	body = append(body, '\n')
+	tmp, err := os.CreateTemp(stackDir, ".bridge-pid-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	path := filepath.Join(stackDir, activepiecesBridgePIDFile)
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}
+
+func readActivepiecesBridgePID(stackDir string) (activepiecesBridgePID, error) {
+	raw, err := os.ReadFile(filepath.Join(stackDir, activepiecesBridgePIDFile))
+	if err != nil {
+		return activepiecesBridgePID{}, err
+	}
+	var process activepiecesBridgePID
+	if err := json.Unmarshal(raw, &process); err != nil {
+		return activepiecesBridgePID{}, err
+	}
+	process.Addr = strings.TrimSpace(process.Addr)
+	if process.PID <= 0 || process.Addr == "" {
+		return activepiecesBridgePID{}, errors.New("invalid Gitmoot bridge process metadata")
+	}
+	return process, nil
+}
+
+func inspectActivepiecesBridgePID(pid int) (alive, verified bool) {
+	if pid <= 0 {
+		return false, false
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return false, false
+		}
+		return true, false
+	}
+	raw, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return true, false
+	}
+	return true, isGitmootBridgeCmdline(raw)
+}
+
+func isGitmootBridgeCmdline(raw []byte) bool {
+	cmdline := strings.Join(strings.Fields(strings.ReplaceAll(string(raw), "\x00", " ")), " ")
+	return strings.Contains(cmdline, "bridge serve")
+}
+
+func stopActivepiecesBridgePID(pid int) error {
+	return syscall.Kill(pid, syscall.SIGTERM)
+}
+
+func reconcileActivepiecesBridgePID(
+	stackDir string,
+	stop bool,
+	stdout io.Writer,
+	inspect func(int) (alive, verified bool),
+	terminate func(int) error,
+) error {
+	path := filepath.Join(stackDir, activepiecesBridgePIDFile)
+	process, err := readActivepiecesBridgePID(stackDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			if stop {
+				fmt.Fprintln(stdout, "There was nothing to stop: no verified gitmoot bridge started by setup was found.")
+			}
+			return nil
+		}
+		if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+			return fmt.Errorf("remove stale Gitmoot bridge pid file: %w", removeErr)
+		}
+		if stop {
+			fmt.Fprintln(stdout, "There was nothing to stop: no verified gitmoot bridge started by setup was found.")
+		}
+		return nil
+	}
+	alive, verified := inspect(process.PID)
+	if !alive {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove stale Gitmoot bridge pid file: %w", err)
+		}
+		if stop {
+			fmt.Fprintln(stdout, "There was nothing to stop: no verified gitmoot bridge started by setup was found.")
+		}
+		return nil
+	}
+	if !verified {
+		if !stop {
+			return nil
+		}
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove unverified Gitmoot bridge pid file: %w", err)
+		}
+		fmt.Fprintln(stdout, "There was nothing to stop: no verified gitmoot bridge started by setup was found.")
+		return nil
+	}
+	if !stop {
+		fmt.Fprintf(stdout, "The gitmoot bridge that setup started is still running (pid %d on %s). Stop it with: gitmoot activepieces down --stop-bridge\n", process.PID, process.Addr)
+		return nil
+	}
+	if err := terminate(process.PID); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			_ = os.Remove(path)
+			fmt.Fprintln(stdout, "There was nothing to stop: no verified gitmoot bridge started by setup was found.")
+			return nil
+		}
+		return fmt.Errorf("stop Gitmoot bridge pid %d: %w", process.PID, err)
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove Gitmoot bridge pid file: %w", err)
+	}
+	fmt.Fprintf(stdout, "Stopped the gitmoot bridge that setup started (pid %d on %s).\n", process.PID, process.Addr)
+	return nil
 }
 
 func bridgeTCPReady(addr string, timeout time.Duration) bool {
@@ -392,7 +548,7 @@ func writeAdminCredentialsOnce(path, email, password string) (bool, error) {
 }
 
 func confirmStarterTemplates(stdout io.Writer, yes bool) bool {
-	if yes || !style.IsTerminal(stdout) {
+	if yes || !style.IsTerminal(stdout) || !style.IsTerminal(os.Stdin) {
 		return true
 	}
 	fmt.Fprint(stdout, "Import starter templates? [Y/n] ")
@@ -410,6 +566,7 @@ func runActivepiecesDown(args []string, stdout, stderr io.Writer) int {
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	composeProject := fs.String("compose-project", defaultActivepiecesProject, "Docker Compose project name")
 	volumes := fs.Bool("volumes", false, "also remove Activepieces data volumes")
+	stopBridge := fs.Bool("stop-bridge", false, "also stop the Gitmoot bridge started by setup")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -434,6 +591,10 @@ func runActivepiecesDown(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "Activepieces stopped and its local data volumes were removed.")
 	} else {
 		fmt.Fprintln(stdout, "Activepieces stopped. Local data volumes were preserved.")
+	}
+	if err := reconcileActivepiecesBridgePID(stackDir, *stopBridge, stdout, inspectActivepiecesBridgePID, stopActivepiecesBridgePID); err != nil {
+		fmt.Fprintf(stderr, "activepieces down: %v\n", err)
+		return 1
 	}
 	return 0
 }
@@ -493,7 +654,14 @@ func runActivepiecesTemplatesImport(args []string, stdout, stderr io.Writer) int
 	port := fs.Int("port", defaultActivepiecesPort, "local Activepieces port")
 	email := fs.String("email", defaultActivepiecesEmail, "Activepieces admin email")
 	password := fs.String("password", "", "Activepieces admin password")
-	if err := fs.Parse(args); err != nil {
+	parsedArgs, err := reorderFlagArgs(args, map[string]struct{}{
+		"home": {}, "url": {}, "port": {}, "email": {}, "password": {},
+	}, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "activepieces templates import: %v\n", err)
+		return 2
+	}
+	if err := fs.Parse(parsedArgs); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
@@ -577,6 +745,7 @@ func importActivepiecesTemplates(ctx context.Context, client *activepieces.Clien
 			return imported, fmt.Errorf("import template %s: %w", template.ID, err)
 		}
 		if err := client.ImportFlow(ctx, token, flowID, template.Flow); err != nil {
+			_ = client.DeleteFlow(ctx, token, flowID)
 			return imported, fmt.Errorf("import template %s: %w", template.ID, err)
 		}
 		flowURL := fmt.Sprintf("%s/projects/%s/flows/%s", client.BaseURL(), projectID, flowID)

--- a/internal/cli/activepieces_test.go
+++ b/internal/cli/activepieces_test.go
@@ -2,8 +2,18 @@ package cli
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/activepieces"
 )
 
 func TestResolveBridgeBind(t *testing.T) {
@@ -63,5 +73,186 @@ func TestActivepiecesTemplatesList(t *testing.T) {
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestActivepiecesBridgePIDFileRoundTrip(t *testing.T) {
+	stackDir := t.TempDir()
+	if err := writeActivepiecesBridgePID(stackDir, 1234, "127.0.0.1:8791"); err != nil {
+		t.Fatalf("writeActivepiecesBridgePID: %v", err)
+	}
+	process, err := readActivepiecesBridgePID(stackDir)
+	if err != nil {
+		t.Fatalf("readActivepiecesBridgePID: %v", err)
+	}
+	if process.PID != 1234 || process.Addr != "127.0.0.1:8791" {
+		t.Fatalf("process = %+v", process)
+	}
+	info, err := os.Stat(filepath.Join(stackDir, activepiecesBridgePIDFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("pid file mode = %o, want 600", got)
+	}
+}
+
+func TestActivepiecesBridgeVerifyBeforeStopAndStaleCleanup(t *testing.T) {
+	stackDir := t.TempDir()
+	writePID := func() {
+		t.Helper()
+		if err := writeActivepiecesBridgePID(stackDir, 1234, "127.0.0.1:8791"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writePID()
+	terminated := false
+	var stdout bytes.Buffer
+	err := reconcileActivepiecesBridgePID(
+		stackDir,
+		true,
+		&stdout,
+		func(int) (bool, bool) { return true, false },
+		func(int) error {
+			terminated = true
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if terminated {
+		t.Fatal("unverified process was terminated")
+	}
+	if !strings.Contains(stdout.String(), "nothing to stop") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(stackDir, activepiecesBridgePIDFile)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unverified pid file was not removed: %v", err)
+	}
+
+	writePID()
+	stdout.Reset()
+	err = reconcileActivepiecesBridgePID(
+		stackDir,
+		false,
+		&stdout,
+		func(int) (bool, bool) { return false, false },
+		func(int) error { return syscall.EPERM },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stale cleanup stdout = %q, want empty", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(stackDir, activepiecesBridgePIDFile)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale pid file was not removed: %v", err)
+	}
+}
+
+func TestIsGitmootBridgeCmdline(t *testing.T) {
+	if !isGitmootBridgeCmdline([]byte("/usr/local/bin/gitmoot\x00bridge\x00serve\x00--addr\x00127.0.0.1:8791\x00")) {
+		t.Fatal("expected gitmoot bridge command line to be recognized")
+	}
+	if isGitmootBridgeCmdline([]byte("/usr/local/bin/gitmoot\x00bridge\x00token\x00")) {
+		t.Fatal("non-serve bridge command line was recognized")
+	}
+}
+
+func TestConfirmStarterTemplatesAcceptsNonTerminalStdin(t *testing.T) {
+	stdin, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdout, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		stdin.Close()
+		stdinWriter.Close()
+		t.Fatal(err)
+	}
+	originalStdin := os.Stdin
+	os.Stdin = stdin
+	defer func() {
+		os.Stdin = originalStdin
+		stdin.Close()
+		stdinWriter.Close()
+		stdout.Close()
+	}()
+
+	result := make(chan bool, 1)
+	go func() { result <- confirmStarterTemplates(stdout, false) }()
+	select {
+	case accepted := <-result:
+		if !accepted {
+			t.Fatal("confirmStarterTemplates rejected non-terminal stdin")
+		}
+	case <-time.After(time.Second):
+		stdinWriter.Close()
+		<-result
+		t.Fatal("confirmStarterTemplates blocked on non-terminal stdin")
+	}
+}
+
+func TestRunActivepiecesTemplatesImportReordersFlags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/authentication/sign-up":
+			_, _ = w.Write([]byte(`{"token":"test-token","projectId":"project-1"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/flows":
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/flows":
+			_, _ = w.Write([]byte(`{"id":"flow-1"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/flows/flow-1":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	var stdout, stderr bytes.Buffer
+	code := runActivepiecesTemplatesImport([]string{
+		"gmail-imap-ask-agent",
+		"--url", server.URL,
+		"--password", "test-password",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Imported Gitmoot: Email to Agent Acknowledgement") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestImportActivepiecesTemplatesDeletesFlowAfterImportFailure(t *testing.T) {
+	deleted := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/flows":
+			_, _ = w.Write([]byte(`{"data":[]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/flows":
+			_, _ = w.Write([]byte(`{"id":"flow-1"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/flows/flow-1":
+			http.Error(w, "import failed", http.StatusBadRequest)
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v1/flows/flow-1":
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	client, err := activepieces.NewClient(server.URL, server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = importActivepiecesTemplates(context.Background(), client, "test-token", "project-1", []string{"gmail-imap-ask-agent"}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "import failed") {
+		t.Fatalf("error = %v, want import failure", err)
+	}
+	if !deleted {
+		t.Fatal("created flow was not deleted after import failure")
 	}
 }


### PR DESCRIPTION
Five polish items on the `gitmoot activepieces` command, from the review follow-ups filed as #857.

## What changed

1. **`down --stop-bridge` (opt-in bridge stop).** `setup` now records the bridge it spawned in a `bridge.pid` file (atomic write, 0600, JSON `{pid, addr}`). `down --stop-bridge` stops **only** that process, and only after verifying via `/proc/<pid>/cmdline` that the live pid is a gitmoot `bridge serve`. Plain `down` prints a notice instead of killing anything. A bridge that `setup` merely found already listening is never recorded and never touched, so a user-managed or systemd bridge is safe by default.
2. **Container-reachability notice.** When the bridge is bound for container access, `setup` prints a one-line note (guarded so it only shows when remote binding is actually in effect).
3. **Template re-run recovery.** If `IMPORT_FLOW` fails after the empty flow is created, the empty flow is now deleted (new `client.DeleteFlow`, which treats 404 as already-gone), so a re-run is not permanently wedged by Activepieces' dedup-by-display-name. The original import error is still returned.
4. **`templates import <id> --url X`.** Reuses the existing `reorderFlagArgs` helper so value flags placed after positional ids are honored.
5. **Non-interactive safety.** The starter-templates prompt only appears when **both** stdin and stdout are terminals; otherwise it auto-accepts (use `--no-templates` to skip).

## Verification

- **Adversarial two-lens review: SHIP.** All five items verified correct; only LOW/NIT residuals (documented below).
- **Live E2E (isolated home, port 18080, bridge 172.17.0.1:18791, project `gitmoot-ap-e2e`), 11/11 checks:** setup notice printed; `bridge.pid` written; bridge process alive and cmdline-verified; 2 flows imported (happy-path regression); default `down` warns and leaves the bridge running with pid file intact; `down --stop-bridge` stops the bridge and removes the pid file. Prod Activepieces and the prod systemd bridge were untouched throughout.
- `go build ./...`, `go vet`, and the activepieces client + CLI tests all pass.

## Known limitations (LOW, non-blocking)

- **macOS `--stop-bridge` is a no-op.** Verification reads `/proc`, which does not exist on macOS, so `--stop-bridge` there prints "nothing to stop" rather than stopping the bridge. Safe (never kills the wrong process); a non-`/proc` verification path is a future follow-up. The box and primary deployment are Linux.
- **cmdline check is a substring match** (`bridge serve`). Safe given the pid came from a file `setup` itself wrote; a false match would additionally require the exact pid to have been reused by a coincidental `bridge serve` process. Could be hardened to also match the gitmoot exe path + stored addr.
- **Inherent pid-file TOCTOU** between the liveness check and the SIGTERM, the same window any pid-file-based service manager has.

Closes #857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
