### PR TITLE
docs(workflows): orchestrate vs workflow — who is the manager?

### DIFF
--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1,5 +1,24 @@
 # Gitmoot Workflows
 
+## Orchestrate vs. workflow: who is the manager?
+
+Two ways to run multi-job efforts, answering one question differently: who
+decides the next step? `gitmoot orchestrate` makes GITMOOT the manager — a
+coordinator agent JOB returns `delegations[]` and the engine executes the tree
+with its guardrails (dependency ordering, retries, timeouts, failure policies,
+synthesis, tree token budgets, kill scope). `--workflow <label>` makes an
+EXTERNAL coordinator the manager — a Claude/Codex session, a script, or a human
+drives independent jobs, judging results between steps; the label plus the
+`workflow note` journal make that project visible (workflow list/show, Galaxy
+hubs, `/workflows/<label>`) and `--remember` distills its insight into shared
+memory. Use `orchestrate` when the plan fits a declarable tree run unattended
+(parallel fan-out, bounded autonomous work, pipeline orchestrate stages); use
+an external coordinator with `--workflow` when judgment between steps is the
+point (build-review-fix loops, test-and-decide sequences, git/PR ownership).
+They compose: `orchestrate --workflow x` labels the whole tree, so a workflow
+can contain orchestrations. `--workflow` is visibility-only by design — never
+scheduling, locking, budgets, or lifecycle.
+
 ## External-coordinator workflows
 
 Use `--workflow <label>` when an external coordinator needs one durable group

--- a/website/docs/workflows/orchestrate-vs-workflow.md
+++ b/website/docs/workflows/orchestrate-vs-workflow.md
@@ -1,0 +1,65 @@
+# Orchestrate vs. workflow: who is the manager?
+
+Gitmoot has two ways to run multi-job efforts, and they answer one question
+differently: **who decides the next step?**
+
+- **`gitmoot orchestrate`** — *gitmoot is the manager.* An agent **job inside
+  gitmoot** plans the work by returning `delegations[]`, and gitmoot's engine
+  executes the plan.
+- **`--workflow <label>`** — *someone outside gitmoot is the manager*: a Claude
+  or Codex session, a script, a cron job, or a human at the CLI. Gitmoot runs
+  the individual jobs; the label and its journal make the outside manager's
+  project **visible and remembered**.
+
+## What each gives you
+
+|  | `orchestrate` | `--workflow` + `workflow note` |
+| --- | --- | --- |
+| Who decides the next step | an LLM coordinator **job** returning `delegations[]` | the external coordinator, live, between steps |
+| Execution machinery | **gitmoot's engine**: dependency ordering, retries, timeouts, failure policies, quorum/vote synthesis, tree token budgets, wall-clock limits, kill scope, human-question pauses | **none by design** — grouping and journaling only; the external coordinator owns retries, ordering, and judgment |
+| Job relationships | real parent → child edges (delegation tree) | a shared label on otherwise independent jobs |
+| Where you see it | the run graph (`/?run=<id>`) as a delegation tree | `gitmoot workflow list/show`, Galaxy workflow hubs, and `/workflows/<label>` in the web dashboard |
+| Reasoning trail | the coordinator job's own result | the **journal** (`gitmoot workflow note`), optionally distilled into shared memory with `--remember` |
+| Coordinator cost | the coordinator is itself an LLM job (billed and visible) | free to gitmoot — the brain lives elsewhere |
+
+## When to use `orchestrate`
+
+Reach for `orchestrate` when the plan fits a tree you can **declare up front**
+and you want gitmoot's guardrails while nobody watches:
+
+- parallel fan-out — review a PR from several lenses, research N topics at once;
+- bounded autonomous work, where budgets, timeouts, and failure policies do the
+  babysitting;
+- inside pipelines, as an `orchestrate` stage.
+
+## When to use `--workflow`
+
+Use an external coordinator — and label its jobs — when **judgment between
+steps is the point**. The canonical case is a coordinated build: run the tests
+*between* jobs, read what a reviewer found, decide the scope of a fix round,
+own git and PRs, choose merge timing. No declarative tree can express "run the
+suite, read the failure, decide whether it is a real bug or a timeout, bisect
+against main." The label makes that externally-managed project visible; the
+notes keep the *why*; `--remember` turns cross-job insight into durable shared
+memory that future agents recall.
+
+`--workflow` is deliberately **visibility-only**: it never adds scheduling,
+locking, budgets, or lifecycle behavior to the labeled jobs.
+
+## They compose
+
+`orchestrate --workflow release-42` labels the **whole delegation tree** —
+children and continuations inherit the label — so a workflow can *contain*
+orchestrations. The realistic shape of a large effort is exactly that: an
+external coordinator drives the project as a workflow, and fires an
+`orchestrate` inside it for the sub-tasks that do fit a declarative tree. One
+label, mixed management styles, one story in the dashboard.
+
+## Rule of thumb
+
+If you would trust a written plan executed unattended, use `orchestrate`. If
+the work needs a thinking manager reacting to results, coordinate externally
+and pass `--workflow` so the effort is not invisible. When in doubt on
+quality-critical code changes, prefer the external pattern — an adversarial
+review-and-fix loop with a judging coordinator catches defects a one-shot
+declarative plan does not.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11574,6 +11574,25 @@ requires a non-empty repo and sends only a queued-job acknowledgement because
 
 # Gitmoot Workflows
 
+## Orchestrate vs. workflow: who is the manager?
+
+Two ways to run multi-job efforts, answering one question differently: who
+decides the next step? `gitmoot orchestrate` makes GITMOOT the manager — a
+coordinator agent JOB returns `delegations[]` and the engine executes the tree
+with its guardrails (dependency ordering, retries, timeouts, failure policies,
+synthesis, tree token budgets, kill scope). `--workflow <label>` makes an
+EXTERNAL coordinator the manager — a Claude/Codex session, a script, or a human
+drives independent jobs, judging results between steps; the label plus the
+`workflow note` journal make that project visible (workflow list/show, Galaxy
+hubs, `/workflows/<label>`) and `--remember` distills its insight into shared
+memory. Use `orchestrate` when the plan fits a declarable tree run unattended
+(parallel fan-out, bounded autonomous work, pipeline orchestrate stages); use
+an external coordinator with `--workflow` when judgment between steps is the
+point (build-review-fix loops, test-and-decide sequences, git/PR ownership).
+They compose: `orchestrate --workflow x` labels the whole tree, so a workflow
+can contain orchestrations. `--workflow` is visibility-only by design — never
+scheduling, locking, budgets, or lifecycle.
+
 ## External-coordinator workflows
 
 Use `--workflow <label>` when an external coordinator needs one durable group


### PR DESCRIPTION
Docs-only. New concept page + skill summary section explaining when to use `orchestrate` (gitmoot is the manager: declarable trees, engine guardrails) vs `--workflow` external coordination (judgment between steps, journal, memory), and how they compose. Requested by the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)