### PR TITLE
fix(dashboard-web): declared DAG carries stage kind + agent runtime (#873 gap)

### DIFF
--- a/internal/cli/dashboard_web_pipelines.go
+++ b/internal/cli/dashboard_web_pipelines.go
@@ -222,13 +222,20 @@ func (d *webDataSource) PipelineDetail(ctx context.Context, name string) (dashbo
 		spec, specParsed := pipeline.Spec{}, false
 		if loaded, lerr := pipeline.Load([]byte(rec.SpecYAML)); lerr == nil {
 			spec, specParsed = loaded, true
+			// Agent runtimes resolve best-effort so the declared preview can label
+			// agent stages even for a pipeline that has never run (#873).
+			agents := pipelineStageAgents(ctx, store, rec)
 			out.Declared = make([]dashboard.PipelineStage, 0, len(spec.Stages))
 			for _, s := range spec.Stages {
 				stage := dashboard.PipelineStage{
 					ID:    s.ID,
 					State: pipeline.StagePending,
+					Kind:  pipelineStageKindName(s),
 					Cmd:   s.Cmd,
 					Retry: s.Retry,
+				}
+				if agent, ok := agents[strings.TrimSpace(s.Agent)]; ok {
+					stage.AgentRuntime = strings.TrimSpace(agent.Runtime)
 				}
 				if len(s.Needs) > 0 {
 					stage.Deps = append([]string(nil), s.Needs...)

--- a/internal/cli/dashboard_web_pipelines_test.go
+++ b/internal/cli/dashboard_web_pipelines_test.go
@@ -546,6 +546,39 @@ func TestWebDataSourcePipelineDetailNeverRun(t *testing.T) {
 	if len(byID["publish"].Deps) != 2 || byID["publish"].Deps[0] != "ascore" || byID["publish"].Deps[1] != "bdedupe" {
 		t.Fatalf("declared publish Deps = %+v, want [ascore bdedupe]", byID["publish"].Deps)
 	}
+	// #873: the declared preview is self-describing with zero runs.
+	if byID["zfetch"].Kind != "shell" {
+		t.Fatalf("declared zfetch Kind = %q, want shell", byID["zfetch"].Kind)
+	}
+}
+
+// TestWebDataSourcePipelineDetailDeclaredAgentKind pins that a never-run AGENT
+// stage carries its kind and (when the agent is registered) runtime, so the
+// dashboard's declared DAG can badge it (#873).
+func TestWebDataSourcePipelineDetailDeclaredAgentKind(t *testing.T) {
+	home := dashboardTestHome(t)
+	store := openPipelineTestStore(t, home)
+	specYAML := "name: mailflow\nrepo: owner/repo\nstages:\n  - {id: triage, agent: helper, action: ask, prompt: read it}\n  - {id: run, cmd: echo, needs: [triage]}\n"
+	seedTestPipeline(t, store, db.Pipeline{Name: "mailflow", Repo: "owner/repo", SpecYAML: specYAML, Enabled: true})
+	if err := store.UpsertAgent(context.Background(), db.Agent{Name: "helper", Runtime: "codex", RepoScope: "owner/repo"}); err != nil {
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	store.Close()
+
+	detail, err := (&webDataSource{home: home}).PipelineDetail(context.Background(), "mailflow")
+	if err != nil {
+		t.Fatalf("PipelineDetail: %v", err)
+	}
+	byID := map[string]dashboard.PipelineStage{}
+	for _, s := range detail.Declared {
+		byID[s.ID] = s
+	}
+	if byID["triage"].Kind != "agent_ask" || byID["triage"].AgentRuntime != "codex" {
+		t.Fatalf("declared triage = %+v, want agent_ask/codex", byID["triage"])
+	}
+	if byID["run"].Kind != "shell" || byID["run"].AgentRuntime != "" {
+		t.Fatalf("declared run = %+v, want shell with no runtime", byID["run"])
+	}
 }
 
 // TestWebDataSourcePipelineDetailHistory pins the run-history projection: runs come


### PR DESCRIPTION
Closes the last #873 gap, user-reported on the live page: the pipeline detail's **declared** stage list (the zero-runs view) had no `kind`/`agentRuntime`, so the badge the UI already renders never appeared there — an agent stage looked like an anonymous box. Server-side only: populate both in the Declared loop, mirroring #877's per-run population. Verified live-API-shape before/after + tests for shell/agent/registered-runtime declared stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)