### PR TITLE
chore(website): regenerate llms-full.txt for #874/#698 doc pages

### DIFF
--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -659,6 +659,7 @@ gitmoot task list --repo owner/repo
 gitmoot job list
 gitmoot job show <job-id>
 gitmoot job watch <job-id>
+gitmoot job watch <job-id> --transcript   # readable cockpit tee log; falls back to events if unavailable
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>               # abandon one queued|running|blocked job
 gitmoot job cancel --state blocked --older-than 7d --yes   # bulk-dismiss a blocked backlog (dry-run without --yes)
@@ -4038,6 +4039,21 @@ the coordinator splits a workspace for the run, each delegation subagent gets a
 pane labeled `<agent> · d<depth> · <branch>`, and that pane streams the child's
 progress while the job runs. Children inherit the cockpit setting from their
 parent, so a single `--cockpit` on the root lights up the whole orchestra.
+
+Each pane renders the cockpit-only tee log through `gitmoot job watch
+--transcript`. Codex JSONL is readable live. Kimi stream-json is turn-buffered,
+and kimi-code 0.19.2 emits no usage. Claude currently emits one final JSON
+envelope, so its pane remains quiet until completion and then shows final text
+and usage. Shell output is redacted raw passthrough. Unknown or malformed lines
+degrade individually to redacted bounded raw output; a fatal renderer exit or
+panic falls back externally to `tail -F`. The tee bytes, runtime result parsing,
+and pipeline progress stream are unchanged.
+
+Verified Codex command/file-change events and Kimi function tool calls/results
+use typed compact lines; other shapes retain the generic/raw path. Render-time
+redaction is per-line best-effort defense in depth: a secret split across
+physical lines may be only partially masked, and the raw log plus external tail
+fallback remain unredacted.
 
 **Auto-detect:** running `gitmoot orchestrate` from inside a Herdr session
 (`HERDR_ENV` set) turns the cockpit on automatically — no `--cockpit` needed. An
@@ -9182,6 +9198,51 @@ A `[runtimes.<name>]` section can only tweak a **built-in** runtime's metadata; 
 cannot add a new first-class runtime (that requires a code change). An unknown
 runtime name is a config error surfaced by `gitmoot runtime list`.
 
+## Runtime Ambient Credential Hygiene
+
+Runtime-child environment curation is off by default. Enable it in
+`config.toml`:
+
+```toml
+[credentials]
+env_curation = true
+env_passthrough = ["GOCACHE", "NPM_*"]
+github = "deny"
+```
+
+With `env_curation = false`, runtime subprocesses inherit the full foreground or
+daemon environment exactly as before. With it enabled, the base allowlist is:
+`PATH`, `HOME`, `USER`, `LOGNAME`, `SHELL`, `TMPDIR`, `TMP`, `TEMP`, `TZ`,
+`LANG`, `LANGUAGE`, `TERM`, `COLORTERM`, `NO_COLOR`, all `LC_*` names,
+`XDG_CONFIG_HOME`, `XDG_CACHE_HOME`, `XDG_DATA_HOME`, `XDG_STATE_HOME`,
+`GOTOOLCHAIN`, `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`,
+`GIT_COMMITTER_EMAIL`, and `GITMOOT_HOME`.
+
+Codex additionally receives `CODEX_HOME`. Claude receives the transitional P1
+exceptions `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`,
+`ANTHROPIC_AUTH_TOKEN`, and `CLAUDE_CONFIG_DIR`. Kimi, legacy `kimi-cli`, and
+shell add nothing. Gitmoot-owned relay, shell-stage, pipeline, and upstream-file
+variables are appended after the base and remain available.
+
+`env_passthrough` accepts exact names or a single trailing-`*` prefix glob.
+Names containing `=` or NUL and non-trailing `*` forms are invalid. The base
+deliberately excludes `SSH_AUTH_SOCK`, proxy variables, GitHub variables, and
+toolchain caches such as `GOCACHE`; pass through required non-secret operational
+variables explicitly.
+
+With curation enabled, `github = "deny"` is the default. All ambient `GH_*` and
+`GITHUB_*` values are omitted, including the four token variables. Gitmoot sets
+`GH_PROMPT_DISABLED=1` and gives each delivery a fresh empty `0700`
+`GH_CONFIG_DIR`, removed when the runtime exits on success, failure, timeout, or
+cancellation. `github = "inherit"` is the explicit opt-out: ambient `GH_*` and
+`GITHUB_*` variables pass through and Gitmoot adds neither GitHub variable.
+
+This is ambient credential hygiene/denial, not egress confinement or a proxy.
+There are no placeholder tokens or proxy changes. Credential files visible on
+disk remain readable under the current Landlock read-only `/` policy; SSH keys,
+SSH agents, credential helpers, and direct network access are untouched. Proxy
+enforcement is P2 and narrower Landlock read rules are P3.
+
 ## Runtime Launch Sandbox
 
 ```sh
@@ -10155,6 +10216,7 @@ PR-comment-only).
 gitmoot job list --repo owner/repo   # add --json for machine-readable rows
 gitmoot job show <job-id>            # add --json for the full job + why-stuck detail
 gitmoot job watch <job-id>
+gitmoot job watch <job-id> --transcript [--log-path <path>] [--runtime codex|claude|kimi|kimi-cli|shell]
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
 gitmoot job gates <job-id>                                         # list resumable gates; add --json
@@ -10165,6 +10227,29 @@ gitmoot job kill <root-job-id>
 gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
+
+`job watch --transcript` follows a cockpit tee log from offset zero and renders
+redacted, bounded human-readable runtime output until the job settles, then
+drains the file to EOF. It is incompatible with `--json`. Without `--log-path`,
+Gitmoot derives the job-mode path under `<home>/logs/jobs/`; if that file is not
+available, it prints `transcript unavailable; showing job events` and uses the
+normal event watcher. `--log-path` and `--runtime` are primarily cockpit wiring
+flags, but remain usable for diagnosis. When `--runtime` is omitted, the job's
+runtime override wins over the registered agent runtime.
+
+Fidelity follows each runtime's actual output contract: Codex JSONL renders
+live; Kimi stream-json is turn-buffered and kimi-code 0.19.2 reports no usage;
+Claude emits only its final JSON envelope, so its transcript remains quiet until
+completion; shell output passes through as redacted raw lines. Usage is labeled
+`latest reported usage` because resumed Codex counts can be session-cumulative.
+Malformed or unknown lines degrade individually to redacted capped raw output
+without stopping later lines.
+
+Verified Codex command/file-change events and Kimi function tool calls/results
+render as typed compact lines; unrecognized shapes keep the generic/raw
+fail-open path. Render-time redaction is a per-line best-effort defense in depth:
+a secret split across physical lines may be only partially masked, and the raw
+cockpit log plus the external `tail -F` fallback remain unredacted.
 
 ### Resumable gates (make `blocked` + `needs` actionable)
 
@@ -12773,6 +12858,19 @@ its progress; children inherit the cockpit setting from their parent, so one
 `--cockpit` on the root lights up the whole orchestra. The same panes are visible
 in the terminal (open the Herdr workspace) and on Telegram via the herdres bridge.
 
+The pane reads the cockpit-only tee log through `job watch --transcript`; this
+does not alter runtime invocation, result parsing, or the pipeline progress
+stream. Codex JSONL is readable live. Kimi stream-json is turn-buffered (and
+kimi-code 0.19.2 emits no usage). Claude currently emits one final JSON envelope,
+so its pane remains quiet until completion and then shows final text and usage.
+Shell output is redacted raw passthrough. Unknown or malformed lines fail open
+one line at a time; a fatal renderer exit falls back externally to `tail -F`.
+Verified Codex command/file-change events and Kimi function tool calls/results
+use typed compact lines; other shapes retain the generic/raw path. Render-time
+redaction is per-line best-effort defense in depth: a secret split across
+physical lines may be only partially masked, and the raw log plus external tail
+fallback remain unredacted.
+
 A cockpit pane is a **view, not the job**: closing a pane (in the terminal or
 from Telegram) tears down the visible surface but does NOT cancel the underlying
 job — the child keeps running and its result is still synthesized. To stop work,
@@ -13324,6 +13422,21 @@ plan explicitly says they are intended tracked fixtures or release assets.
 
 Redact secrets from GitHub comments, job summaries, raw examples, and copied
 command output.
+
+### Runtime ambient credential hygiene
+
+The optional `[credentials] env_curation = true` policy curates only runtime
+agent subprocess environments. Its default `github = "deny"` omits ambient
+`GH_*`/`GITHUB_*`, points `gh` at a fresh empty `0700` config directory, and
+disables interactive prompts. `github = "inherit"` explicitly restores ambient
+GitHub environment inheritance. See `CLI.md` for the exact base allowlist,
+runtime exceptions, and `env_passthrough` syntax.
+
+This is ambient credential hygiene/denial, not egress confinement or a proxy.
+It does not add placeholder tokens, alter proxy settings, hide credential files
+that remain readable from disk under Landlock's read-only `/`, disable SSH keys
+or agents, bypass Git credential helpers, or block direct network access. Those
+controls belong to the P2 proxy and P3 Landlock read-rule follow-ups.
 
 ## Pipeline Stages Run With Daemon Permissions
 


### PR DESCRIPTION
Generated-artifact sync: PRs #879/#880 added/changed website doc sources; this checks in the matching `npm run build:llms` output (already deployed to gitmoot.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)