### PR TITLE
feat(transcript): styled pane rendering — dim machinery, spaced agent turns, red failures

### DIFF
--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -422,6 +422,9 @@ func runJobTranscriptWatch(jobID, home, requestedLogPath, requestedRuntime strin
 
 	var translator transcript.Translator
 	renderer := transcript.NewRenderer(stdout)
+	if transcriptStyleTerminal(stdout) {
+		renderer = transcript.NewStyledRenderer(stdout)
+	}
 	err := withStore(home, func(store *db.Store) error {
 		job, err := store.GetJob(context.Background(), jobID)
 		if err != nil {
@@ -954,4 +957,23 @@ func printFailureDiagnostics(stdout io.Writer, diag *workflow.FailureDiagnostics
 			fmt.Fprintf(stdout, "    %s\n", line)
 		}
 	}
+}
+
+// transcriptStyleTerminal reports whether transcript output is going straight
+// to an interactive terminal, in which case the styled renderer is safe. Pipes,
+// files, and test buffers stay on the byte-stable plain renderer, and NO_COLOR
+// (https://no-color.org) always wins.
+func transcriptStyleTerminal(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
 }

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -737,3 +737,21 @@ func TestPrintJobOmitsFailureDiagnosticsWhenAbsent(t *testing.T) {
 		t.Fatalf("job show output has a failure diagnostics block for a healthy job:\n%s", buf.String())
 	}
 }
+
+func TestTranscriptStyleTerminalStaysPlainOffTTY(t *testing.T) {
+	if transcriptStyleTerminal(&bytes.Buffer{}) {
+		t.Fatal("buffer writer must not be styled")
+	}
+	f, err := os.CreateTemp(t.TempDir(), "plain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if transcriptStyleTerminal(f) {
+		t.Fatal("regular file must not be styled")
+	}
+	t.Setenv("NO_COLOR", "1")
+	if transcriptStyleTerminal(os.Stdout) {
+		t.Fatal("NO_COLOR must force plain output")
+	}
+}

--- a/internal/transcript/render.go
+++ b/internal/transcript/render.go
@@ -15,12 +15,31 @@ const (
 	renderRawLimit    = 4096
 )
 
+// ANSI SGR fragments for the styled renderer. 16-color codes only, chosen for
+// tmux-pane portability (borrowed from the opencode/pi TUI conventions: dim =
+// finished machinery and metadata, red = failure, everything else stays calm).
+const (
+	sgrReset = "\x1b[0m"
+	sgrBold  = "\x1b[1m"
+	sgrDim   = "\x1b[90m"
+	sgrRed   = "\x1b[31m"
+	sgrCyan  = "\x1b[36m"
+)
+
 // Renderer writes normalized events as redacted, bounded human-readable lines.
+// The plain form is byte-stable for pipes and tests; the styled form adds ANSI
+// color and spacing for live terminal panes.
 type Renderer struct {
-	w io.Writer
+	w        io.Writer
+	styled   bool
+	wroteAny bool
 }
 
 func NewRenderer(w io.Writer) *Renderer { return &Renderer{w: w} }
+
+// NewStyledRenderer renders with ANSI styling and turn spacing. Callers must
+// only pick it for interactive terminals; piped output stays on NewRenderer.
+func NewStyledRenderer(w io.Writer) *Renderer { return &Renderer{w: w, styled: true} }
 
 func (r *Renderer) Render(events ...Event) error {
 	for _, event := range events {
@@ -32,6 +51,9 @@ func (r *Renderer) Render(events ...Event) error {
 }
 
 func (r *Renderer) render(event Event) error {
+	if r.styled {
+		return r.renderStyled(event)
+	}
 	var line string
 	switch event.Kind {
 	case KindAgentText:
@@ -60,6 +82,81 @@ func (r *Renderer) render(event Event) error {
 	}
 	_, err := fmt.Fprintln(r.w, line)
 	return err
+}
+
+// renderStyled applies the pane look: agent text keeps its line breaks and gets
+// a blank line of breathing room, tool calls pack tight with the name in bold,
+// completed machinery and metadata render dim, failures render red.
+func (r *Renderer) renderStyled(event Event) error {
+	var line string
+	switch event.Kind {
+	case KindAgentText:
+		if r.wroteAny {
+			if _, err := fmt.Fprintln(r.w); err != nil {
+				return err
+			}
+		}
+		lines := strings.Split(cleanBlock(event.Text, renderFieldLimit), "\n")
+		line = "\u25cf " + lines[0]
+		for _, cont := range lines[1:] {
+			line += "\n  " + cont
+		}
+	case KindToolCall:
+		line = sgrCyan + "\u25b8 " + sgrReset + sgrBold + cleanField(event.Name, renderDigestLimit) + sgrReset
+		if digest := cleanField(event.InputDigest, renderDigestLimit); digest != "" {
+			line += " " + sgrDim + digest + sgrReset
+		}
+	case KindToolResult:
+		status := cleanField(event.Status, renderDigestLimit)
+		digest := cleanTailField(event.OutputDigest, renderDigestLimit)
+		if strings.Contains(status, "fail") {
+			line = sgrRed + "\u25c2 " + status + sgrReset
+		} else {
+			line = sgrDim + "\u25c2 " + status + sgrReset
+		}
+		if digest != "" {
+			line += "\n" + sgrDim + "  \u21b3 " + digest + sgrReset
+		}
+	case KindUsage:
+		line = sgrDim + fmt.Sprintf("\u2191%s \u2193%s tokens (latest reported)", formatTokens(event.InputTokens), formatTokens(event.OutputTokens)) + sgrReset
+	case KindLifecycle:
+		line = "\u2022 " + cleanField(event.Phase, renderDigestLimit)
+		if detail := cleanField(event.Detail, renderFieldLimit); detail != "" {
+			line += ": " + detail
+		}
+		line = sgrDim + line + sgrReset
+	case KindRaw:
+		line = cleanField(event.RawLine, renderRawLimit)
+	default:
+		line = cleanField(event.RawLine, renderRawLimit)
+	}
+	r.wroteAny = true
+	_, err := fmt.Fprintln(r.w, line)
+	return err
+}
+
+// formatTokens compacts counts the way agent TUIs do: 812, 1.2k, 42k, 1.7M.
+func formatTokens(n int) string {
+	switch {
+	case n < 1000:
+		return fmt.Sprintf("%d", n)
+	case n < 10_000:
+		return fmt.Sprintf("%.1fk", float64(n)/1000)
+	case n < 1_000_000:
+		return fmt.Sprintf("%dk", n/1000)
+	case n < 10_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	default:
+		return fmt.Sprintf("%dM", n/1_000_000)
+	}
+}
+
+// cleanBlock is cleanField except line breaks survive, so styled agent text
+// keeps its paragraph shape. Redaction still happens before truncation.
+func cleanBlock(value string, limit int) string {
+	value = workflow.RedactCommentText(value)
+	value = strings.ReplaceAll(value, "\r", "")
+	return truncateUTF8(value, limit)
 }
 
 func cleanTailField(value string, limit int) string {

--- a/internal/transcript/testdata/codex_tool_run_styled.golden
+++ b/internal/transcript/testdata/codex_tool_run_styled.golden
@@ -1,0 +1,15 @@
+[90m• thread: started[0m
+[90m• turn: started[0m
+
+● Running the requested shell command, then I'll create `fx.txt` with `done` and return the exact completion string.
+[36m▸ [0m[1mbash[0m [90m/bin/bash -lc 'echo transcript-fixture-123'[0m
+[90m◂ completed (exit 0)[0m
+[90m  ↳ transcript-fixture-123[0m
+
+● The command ran. I'm creating `fx.txt` now.
+[36m▸ [0m[1mfile_change[0m [90madd /tmp/example/fx.txt[0m
+[90m◂ completed[0m
+[90m  ↳ add /tmp/example/fx.txt[0m
+
+● FIXTURE COMPLETE
+[90m↑46k ↓343 tokens (latest reported)[0m

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -420,3 +420,63 @@ func waitForLine(t *testing.T, lines <-chan string, want string) {
 		t.Fatalf("timed out waiting for line %q", want)
 	}
 }
+
+func TestStyledRendererGolden(t *testing.T) {
+	translator, err := NewTranslator("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := readTestdata(t, "codex_tool_run.jsonl")
+	var got bytes.Buffer
+	renderer := NewStyledRenderer(&got)
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Buffer(make([]byte, 0, 64*1024), MaxLogicalLineBytes)
+	for scanner.Scan() {
+		if err := renderer.Render(translator.Translate(scanner.Text())...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := renderer.Render(translator.Flush()...); err != nil {
+		t.Fatal(err)
+	}
+	if want := readTestdata(t, "codex_tool_run_styled.golden"); got.String() != want {
+		t.Fatalf("styled transcript:\n%q\nwant:\n%q", got.String(), want)
+	}
+}
+
+func TestStyledRendererFailureIsRedAndTextKeepsLines(t *testing.T) {
+	var got bytes.Buffer
+	renderer := NewStyledRenderer(&got)
+	if err := renderer.Render(
+		Event{Kind: KindAgentText, Text: "first line\nsecond line"},
+		Event{Kind: KindToolResult, Status: "failed (exit 1)", OutputDigest: "boom"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	out := got.String()
+	if !strings.Contains(out, "● first line\n  second line\n") {
+		t.Fatalf("agent text lost its line break: %q", out)
+	}
+	if !strings.Contains(out, "\x1b[31m◂ failed (exit 1)") {
+		t.Fatalf("failed result not red: %q", out)
+	}
+	if !strings.Contains(out, "\x1b[90m  ↳ boom") {
+		t.Fatalf("output digest not dim/indented: %q", out)
+	}
+}
+
+func TestFormatTokens(t *testing.T) {
+	for _, tc := range []struct {
+		in   int
+		want string
+	}{
+		{812, "812"}, {1234, "1.2k"}, {42_500, "42k"}, {1_740_206, "1.7M"}, {12_345_678, "12M"},
+	} {
+		if got := formatTokens(tc.in); got != tc.want {
+			t.Fatalf("formatTokens(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1153,6 +1153,12 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+When standard output is an interactive terminal (and `NO_COLOR` is unset),
+the transcript renders styled: agent turns get blank-line spacing and keep
+their line breaks, tool names are bold with dim argument digests, completed
+machinery and usage render dim, and failed tool results render red. Piped or
+redirected output always uses the plain byte-stable format.
+
 `job watch --transcript` follows a cockpit tee log from offset zero and renders
 redacted, bounded human-readable runtime output until the job settles, then
 drains the file to EOF. It is incompatible with `--json`. Without `--log-path`,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1007,6 +1007,12 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+When standard output is an interactive terminal (and `NO_COLOR` is unset),
+the transcript renders styled: agent turns get blank-line spacing and keep
+their line breaks, tool names are bold with dim argument digests, completed
+machinery and usage render dim, and failed tool results render red. Piped or
+redirected output always uses the plain byte-stable format.
+
 `job watch --transcript` follows a cockpit tee log from offset zero and renders
 redacted, bounded human-readable runtime output until the job settles, then
 drains the file to EOF. It is incompatible with `--json`. Without `--log-path`,


### PR DESCRIPTION
Follow-up polish on #698 after evaluating the opencode and pi TUIs (cloned read-only under /repos). Adopts their converging line-renderer rules:

- **Finished machinery goes dim** (SGR 90) — tool results, lifecycle, usage — so agent narration visually pops.
- **Agent turns get a blank line and keep their line breaks** (previously flattened to one long wrapping line); tool lines pack tight.
- Tool calls: cyan marker + **bold name** + dim argument digest; results put the output tail on its own dim `↳` line; **failures render red**.
- Usage compacts to `↑1.7M ↓343 tokens (latest reported)`.

Styled output only when stdout is an interactive terminal and `NO_COLOR` is unset — pipes/files/tests keep the byte-stable plain format (all existing goldens untouched; new styled golden + red-failure/multi-line/formatTokens/TTY-detection tests). Docs updated in both trees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)