### PR TITLE
fix(daemon): reconcile externally merged PRs across all PR-lifecycle task states (#893)

### DIFF
--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -735,6 +735,12 @@ func TestPrepareLocalReviewDispatchRequestCreatesReviewWorktree(t *testing.T) {
 
 	store := openCLIJobStore(t, home)
 	defer store.Close()
+	// An implement task may already own the PR head branch. Review task creation
+	// must keep its branch empty rather than violate tasks(repo,branch)'s partial
+	// unique index or overwrite the canonical implement task.
+	if err := store.UpsertTask(ctx, db.Task{ID: "implement-12", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Implement PR #12", State: string(workflow.TaskImplementing), Branch: "feature/review"}); err != nil {
+		t.Fatalf("UpsertTask(implement): %v", err)
+	}
 	record := db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: repoDir}
 	request, checkout, err := prepareLocalReviewDispatchRequest(ctx, store, record, github.Repository{Owner: "owner", Name: "repo"}, localAgentDispatchRequest{
 		Home:         home,
@@ -771,6 +777,13 @@ func TestPrepareLocalReviewDispatchRequestCreatesReviewWorktree(t *testing.T) {
 	}
 	if task.WorktreePath != checkout || task.State != string(workflow.TaskReviewing) {
 		t.Fatalf("task = %+v, checkout=%q", task, checkout)
+	}
+	if task.ID == "implement-12" || task.Branch != "" {
+		t.Fatalf("review task = %+v, want distinct branchless review-pr task", task)
+	}
+	implementTask, err := store.GetTask(ctx, "implement-12")
+	if err != nil || implementTask.State != string(workflow.TaskImplementing) || implementTask.Branch != "feature/review" {
+		t.Fatalf("implement task changed = %+v, err=%v", implementTask, err)
 	}
 }
 

--- a/internal/daemon/closed_reviewing_pr_test.go
+++ b/internal/daemon/closed_reviewing_pr_test.go
@@ -23,6 +23,7 @@ func TestPollOnceReconcilesClosedReviewingPullRequest(t *testing.T) {
 		// openPulls / closedPulls are what GitHub reports for each list state.
 		openPulls   []github.PullRequest
 		closedPulls []github.PullRequest
+		pinnedPull  *github.PullRequest
 		wantTask    workflow.TaskState
 		wantPRState string
 	}{
@@ -60,6 +61,7 @@ func TestPollOnceReconcilesClosedReviewingPullRequest(t *testing.T) {
 			name:        "non-matching closed PR number is ignored",
 			openPulls:   nil,
 			closedPulls: []github.PullRequest{{Number: 9, State: "closed", HeadRef: branch, BaseRef: "main", HeadSHA: "other"}},
+			pinnedPull:  &github.PullRequest{Number: 6, State: "closed", HeadRef: branch, BaseRef: "main", HeadSHA: headSHA},
 			wantTask:    workflow.TaskReviewing,
 			wantPRState: "open",
 		},
@@ -101,6 +103,9 @@ func TestPollOnceReconcilesClosedReviewingPullRequest(t *testing.T) {
 					"closed": tc.closedPulls,
 				},
 				comments: comments,
+			}
+			if tc.pinnedPull != nil {
+				client.pullsByNumber = map[int64]github.PullRequest{tc.pinnedPull.Number: *tc.pinnedPull}
 			}
 			engine := workflow.Engine{Store: store}
 			daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -17,7 +17,13 @@ import (
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
 
-const defaultPollInterval = 30 * time.Second
+const (
+	defaultPollInterval = 30 * time.Second
+	// externalMergeReconcileLookupLimit bounds targeted GitHub reads per repo poll.
+	// A stale backlog drains over successive ticks without walking paginated closed
+	// PR history or allowing old task rows to dominate the daemon's API budget.
+	externalMergeReconcileLookupLimit = 20
+)
 
 // issueCommentPollOverlap is subtracted from the persisted last-seen cursor when
 // computing the `since` bound for the repo-wide issue-comment fetch (#566). It
@@ -89,6 +95,7 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 		return err
 	}
 	openBranches := map[string]struct{}{}
+	openPullNumbers := map[int64]struct{}{}
 	// Fetch the repo's review-job list AT MOST ONCE for this whole poll and share the
 	// snapshot across every open PR's review-job consumers, instead of re-running
 	// ListJobsByType("review") up to ~2× per PR (#619). Lazy: computed on the first
@@ -96,6 +103,7 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	reviewMemo := newReviewJobsMemo(d.Store)
 	for _, pull := range pulls {
 		openBranches[pull.HeadRef] = struct{}{}
+		openPullNumbers[pull.Number] = struct{}{}
 		changed, err := d.pullRequestChanged(ctx, pull, reviewMemo)
 		if err != nil {
 			return err
@@ -154,6 +162,9 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 			firstErr = err
 		}
 	}
+	if err := d.reconcileExternallyMergedTasks(ctx, openPullNumbers); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	if err := d.retryClosedReadyToMerge(ctx, openBranches); err != nil && firstErr == nil {
 		firstErr = err
 	}
@@ -174,6 +185,152 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 		}
 	}
 	return firstErr
+}
+
+// reconcileExternallyMergedTasks advances PR lifecycle tasks whose PR was
+// merged outside Gitmoot. It uses targeted single-PR reads rather than a closed
+// list, so old wedged tasks are not hidden by GitHub pagination. Empty-branch
+// local review tasks are keyed by their durable review-pr-<number>-<hash> id.
+// Closed-unmerged responses are deliberately ignored here; the existing
+// reviewing/ready-to-merge paths retain their current semantics.
+func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumbers map[int64]struct{}) error {
+	if d.Workflow == nil {
+		return nil
+	}
+	tasks, err := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
+	if err != nil {
+		return err
+	}
+	type candidateGroup struct {
+		number int64
+		tasks  []db.Task
+	}
+	groups := make([]candidateGroup, 0)
+	groupByNumber := make(map[int64]int)
+	for _, task := range tasks {
+		if !externalMergeCandidateState(task.State) {
+			continue
+		}
+		branch := strings.TrimSpace(task.Branch)
+		var number int64
+		if branch == "" {
+			var ok bool
+			number, ok = reviewTaskPullRequestNumber(task.ID)
+			if !ok {
+				continue
+			}
+		} else {
+			stored, err := d.Store.GetPullRequestByRepoBranch(ctx, d.Repo.FullName(), branch)
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					continue
+				}
+				return err
+			}
+			number = stored.Number
+		}
+		if number <= 0 {
+			continue
+		}
+		if _, open := openPullNumbers[number]; open {
+			continue
+		}
+		if index, ok := groupByNumber[number]; ok {
+			groups[index].tasks = append(groups[index].tasks, task)
+			continue
+		}
+		groupByNumber[number] = len(groups)
+		groups = append(groups, candidateGroup{number: number, tasks: []db.Task{task}})
+	}
+
+	var firstErr error
+	if len(groups) > externalMergeReconcileLookupLimit {
+		groups = groups[:externalMergeReconcileLookupLimit]
+	}
+	for _, group := range groups {
+		pull, err := d.GitHub.GetPullRequest(ctx, d.Repo, group.number)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if !pullRequestListedAsMerged(pull) {
+			continue
+		}
+		for _, task := range group.tasks {
+			branch := strings.TrimSpace(pull.HeadRef)
+			if branch == "" {
+				branch = strings.TrimSpace(task.Branch)
+			}
+			if branch == "" {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("reconcile externally merged PR #%d: head branch is empty", pull.Number)
+				}
+				continue
+			}
+			leadAgent := "github"
+			if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), branch); err == nil {
+				if owner := strings.TrimSpace(lock.Owner); owner != "" {
+					leadAgent = owner
+				}
+			} else if !errors.Is(err, sql.ErrNoRows) {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			event := workflow.PullRequestEvent{
+				Repo:        d.Repo.FullName(),
+				Branch:      branch,
+				PullRequest: int(group.number),
+				HeadSHA:     pull.HeadSHA,
+				GoalID:      task.GoalID,
+				TaskID:      task.ID,
+				TaskTitle:   task.Title,
+				LeadAgent:   leadAgent,
+				Sender:      "github",
+			}
+			// Preserve the existing ready-to-merge path's merge-gate cleanup and
+			// outcome side effects. The closure handler below remains the durable
+			// backstop and also updates the local PR mirror for custom test gates.
+			if task.State == string(workflow.TaskReadyToMerge) && strings.TrimSpace(task.Branch) != "" && d.Workflow.MergeGate != nil {
+				if err := d.handleReadyToMergeWorkflow(ctx, pull); err != nil {
+					if firstErr == nil {
+						firstErr = err
+					}
+					continue
+				}
+			}
+			if err := d.Workflow.HandleReviewPullRequestClosed(ctx, event, true); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func externalMergeCandidateState(state string) bool {
+	switch workflow.TaskState(strings.TrimSpace(state)) {
+	case workflow.TaskPullRequestOpen, workflow.TaskReviewing, workflow.TaskChangesRequested, workflow.TaskReadyToMerge:
+		return true
+	default:
+		return false
+	}
+}
+
+func reviewTaskPullRequestNumber(taskID string) (int64, bool) {
+	const prefix = "review-pr-"
+	remainder, ok := strings.CutPrefix(strings.TrimSpace(taskID), prefix)
+	if !ok {
+		return 0, false
+	}
+	numberText, suffix, ok := strings.Cut(remainder, "-")
+	if !ok || strings.TrimSpace(suffix) == "" {
+		return 0, false
+	}
+	number, err := strconv.ParseInt(numberText, 10, 64)
+	return number, err == nil && number > 0
 }
 
 // PollIssuesOnce is the opt-in issue-comment workflow (#389, bounded by #566). It

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -1057,6 +1057,10 @@ func TestPollOnceRetriesClosedReadyToMergePullRequest(t *testing.T) {
 	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 || gate.requests[0].HeadSHA != "abc123" {
 		t.Fatalf("merge gate requests = %+v", gate.requests)
 	}
+	stored, err := store.GetPullRequest(ctx, repo.FullName(), 7)
+	if err != nil || stored.State != "merged" {
+		t.Fatalf("stored pull request = %+v, err=%v; want merged", stored, err)
+	}
 }
 
 func TestPollOnceDoesNotOverwriteNoReviewerAutoMerge(t *testing.T) {
@@ -2549,6 +2553,7 @@ type fakeGitHub struct {
 	listPullRequestsErrs   []error
 	listIssuesCalls        int
 	recentClosedCalls      int
+	getPullRequestCalls    []int64
 }
 
 type postedComment struct {
@@ -2706,8 +2711,22 @@ func (f *fakeGitHub) UpdatePullRequestBranch(context.Context, github.UpdatePullR
 }
 
 func (f *fakeGitHub) GetPullRequest(_ context.Context, _ github.Repository, number int64) (github.PullRequest, error) {
+	f.getPullRequestCalls = append(f.getPullRequestCalls, number)
 	if f.pullsByNumber != nil {
 		if pull, ok := f.pullsByNumber[number]; ok {
+			return pull, nil
+		}
+	}
+	for _, state := range []string{"open", "closed"} {
+		pulls := f.pullsByState[state]
+		for _, pull := range pulls {
+			if pull.Number == number {
+				return pull, nil
+			}
+		}
+	}
+	for _, pull := range f.pulls {
+		if pull.Number == number {
 			return pull, nil
 		}
 	}

--- a/internal/daemon/external_merge_reconcile_test.go
+++ b/internal/daemon/external_merge_reconcile_test.go
@@ -1,0 +1,205 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestPollOnceReconcilesExternallyMergedLifecycleTasks(t *testing.T) {
+	states := []workflow.TaskState{
+		workflow.TaskPullRequestOpen,
+		workflow.TaskReviewing,
+		workflow.TaskChangesRequested,
+		workflow.TaskReadyToMerge,
+	}
+	for _, state := range states {
+		t.Run(string(state), func(t *testing.T) {
+			ctx := context.Background()
+			repo := github.Repository{Owner: "owner", Name: "repo"}
+			store := testStore(t)
+			seedExternalMergeTask(t, store, repo, "task-7", "feature/seven", state, 7)
+			client := &fakeGitHub{
+				pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
+				pullsByNumber: map[int64]github.PullRequest{7: mergedPull(7, "feature/seven")},
+				comments:      map[int64][]github.IssueComment{},
+			}
+			engine := workflow.Engine{Store: store}
+			daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+			if err := daemon.PollOnce(ctx); err != nil {
+				t.Fatalf("PollOnce: %v", err)
+			}
+			assertExternalMergeState(t, store, repo.FullName(), "task-7", 7, workflow.TaskMerged, "merged")
+			if !reflect.DeepEqual(client.getPullRequestCalls, []int64{7}) {
+				t.Fatalf("GetPullRequest calls = %v, want [7]", client.getPullRequestCalls)
+			}
+		})
+	}
+}
+
+func TestPollOnceLeavesClosedUnmergedPullRequestOpenTaskUnchanged(t *testing.T) {
+	ctx := context.Background()
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	store := testStore(t)
+	seedExternalMergeTask(t, store, repo, "task-7", "feature/seven", workflow.TaskPullRequestOpen, 7)
+	client := &fakeGitHub{
+		pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
+		pullsByNumber: map[int64]github.PullRequest{7: {Number: 7, State: "closed", HeadRef: "feature/seven", HeadSHA: "head-7"}},
+		comments:      map[int64][]github.IssueComment{},
+	}
+	engine := workflow.Engine{Store: store}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	assertExternalMergeState(t, store, repo.FullName(), "task-7", 7, workflow.TaskPullRequestOpen, "open")
+}
+
+func TestPollOnceReconcilesEmptyBranchReviewTaskByPullRequestNumber(t *testing.T) {
+	ctx := context.Background()
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	store := testStore(t)
+	// The implement task owns the unique (repo, branch) slot. The legacy review
+	// task is intentionally branchless and can only be associated through its id.
+	if err := store.UpsertTask(ctx, db.Task{ID: "implement-11", RepoFullName: repo.FullName(), Title: "Implement", State: string(workflow.TaskImplementing), Branch: "feature/eleven"}); err != nil {
+		t.Fatalf("Upsert implement task: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "review-pr-11-44cd8322", RepoFullName: repo.FullName(), GoalID: "local-review", Title: "Review PR #11", State: string(workflow.TaskReviewing)}); err != nil {
+		t.Fatalf("Upsert review task: %v", err)
+	}
+	client := &fakeGitHub{
+		pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
+		pullsByNumber: map[int64]github.PullRequest{11: mergedPull(11, "feature/eleven")},
+		comments:      map[int64][]github.IssueComment{},
+	}
+	engine := workflow.Engine{Store: store}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	reviewTask, err := store.GetTask(ctx, "review-pr-11-44cd8322")
+	if err != nil || reviewTask.State != string(workflow.TaskMerged) || reviewTask.Branch != "" {
+		t.Fatalf("review task = %+v, err=%v; want merged with empty branch", reviewTask, err)
+	}
+	implementTask, err := store.GetTask(ctx, "implement-11")
+	if err != nil || implementTask.State != string(workflow.TaskImplementing) || implementTask.Branch != "feature/eleven" {
+		t.Fatalf("implement task changed = %+v, err=%v", implementTask, err)
+	}
+	pr, err := store.GetPullRequest(ctx, repo.FullName(), 11)
+	if err != nil || pr.State != "merged" || pr.HeadBranch != "feature/eleven" {
+		t.Fatalf("PR mirror = %+v, err=%v", pr, err)
+	}
+}
+
+func TestExternalMergeReconcileCapsTargetedLookupsPerTick(t *testing.T) {
+	ctx := context.Background()
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	store := testStore(t)
+	client := &fakeGitHub{
+		pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
+		pullsByNumber: map[int64]github.PullRequest{},
+		comments:      map[int64][]github.IssueComment{},
+	}
+	for i := 1; i <= externalMergeReconcileLookupLimit+5; i++ {
+		id := fmt.Sprintf("task-%02d", i)
+		branch := fmt.Sprintf("feature/%02d", i)
+		seedExternalMergeTask(t, store, repo, id, branch, workflow.TaskPullRequestOpen, int64(i))
+		client.pullsByNumber[int64(i)] = mergedPull(int64(i), branch)
+	}
+	engine := workflow.Engine{Store: store}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	if len(client.getPullRequestCalls) != externalMergeReconcileLookupLimit {
+		t.Fatalf("GetPullRequest calls = %d (%v), want cap %d", len(client.getPullRequestCalls), client.getPullRequestCalls, externalMergeReconcileLookupLimit)
+	}
+	merged := 0
+	for i := 1; i <= externalMergeReconcileLookupLimit+5; i++ {
+		task, err := store.GetTask(ctx, fmt.Sprintf("task-%02d", i))
+		if err != nil {
+			t.Fatalf("GetTask(%d): %v", i, err)
+		}
+		if task.State == string(workflow.TaskMerged) {
+			merged++
+		}
+	}
+	if merged != externalMergeReconcileLookupLimit {
+		t.Fatalf("merged tasks = %d, want %d", merged, externalMergeReconcileLookupLimit)
+	}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("second PollOnce: %v", err)
+	}
+	if len(client.getPullRequestCalls) != externalMergeReconcileLookupLimit+5 {
+		t.Fatalf("GetPullRequest calls after second tick = %d (%v), want %d", len(client.getPullRequestCalls), client.getPullRequestCalls, externalMergeReconcileLookupLimit+5)
+	}
+	for i := 1; i <= externalMergeReconcileLookupLimit+5; i++ {
+		task, err := store.GetTask(ctx, fmt.Sprintf("task-%02d", i))
+		if err != nil || task.State != string(workflow.TaskMerged) {
+			t.Fatalf("task %d after second tick = %+v, err=%v; want merged", i, task, err)
+		}
+	}
+}
+
+func TestReviewTaskPullRequestNumber(t *testing.T) {
+	tests := []struct {
+		id     string
+		number int64
+		ok     bool
+	}{
+		{id: "review-pr-11-44cd8322", number: 11, ok: true},
+		{id: "review-pr-1-a", number: 1, ok: true},
+		{id: "review-pr-0-a"},
+		{id: "review-pr-x-a"},
+		{id: "review-pr-11"},
+		{id: "task-11-a"},
+	}
+	for _, test := range tests {
+		t.Run(test.id, func(t *testing.T) {
+			number, ok := reviewTaskPullRequestNumber(test.id)
+			if number != test.number || ok != test.ok {
+				t.Fatalf("reviewTaskPullRequestNumber(%q) = (%d,%v), want (%d,%v)", test.id, number, ok, test.number, test.ok)
+			}
+		})
+	}
+}
+
+func seedExternalMergeTask(t *testing.T, store *db.Store, repo github.Repository, id, branch string, state workflow.TaskState, number int64) {
+	t.Helper()
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, db.Task{ID: id, RepoFullName: repo.FullName(), GoalID: "goal-1", Title: id, State: string(state), Branch: branch}); err != nil {
+		t.Fatalf("UpsertTask(%s): %v", id, err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(), Number: number, URL: fmt.Sprintf("https://github.com/%s/pull/%d", repo.FullName(), number),
+		HeadBranch: branch, BaseBranch: "main", HeadSHA: fmt.Sprintf("head-%d", number), State: "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest(%d): %v", number, err)
+	}
+}
+
+func mergedPull(number int64, branch string) github.PullRequest {
+	return github.PullRequest{Number: number, State: "closed", Merged: true, MergedAt: "2026-07-13T00:00:00Z", HeadRef: branch, BaseRef: "main", HeadSHA: fmt.Sprintf("head-%d", number)}
+}
+
+func assertExternalMergeState(t *testing.T, store *db.Store, repo, taskID string, number int64, taskState workflow.TaskState, prState string) {
+	t.Helper()
+	task, err := store.GetTask(context.Background(), taskID)
+	if err != nil || task.State != string(taskState) {
+		t.Fatalf("task %s = %+v, err=%v; want state %s", taskID, task, err, taskState)
+	}
+	pr, err := store.GetPullRequest(context.Background(), repo, number)
+	if err != nil || pr.State != prState {
+		t.Fatalf("PR #%d = %+v, err=%v; want state %s", number, pr, err, prState)
+	}
+}

--- a/internal/workflow/closed_reviewing_cleanup_test.go
+++ b/internal/workflow/closed_reviewing_cleanup_test.go
@@ -129,3 +129,150 @@ func TestHandleReviewPullRequestClosedMergedReleasesLockAndWorktree(t *testing.T
 		})
 	}
 }
+
+func TestHandleReviewPullRequestClosedMergedLifecycleStates(t *testing.T) {
+	states := []TaskState{
+		TaskPullRequestOpen,
+		TaskReviewing,
+		TaskChangesRequested,
+		TaskReadyToMerge,
+	}
+	for _, state := range states {
+		t.Run(string(state), func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			if err := store.UpsertTask(ctx, db.Task{
+				ID:           "task-893",
+				RepoFullName: "owner/repo",
+				Title:        "Reconcile external merge",
+				State:        string(state),
+				Branch:       "feature/893",
+			}); err != nil {
+				t.Fatalf("UpsertTask: %v", err)
+			}
+			if err := store.UpsertPullRequest(ctx, db.PullRequest{
+				RepoFullName: "owner/repo",
+				Number:       893,
+				HeadBranch:   "feature/893",
+				State:        "open",
+			}); err != nil {
+				t.Fatalf("UpsertPullRequest: %v", err)
+			}
+
+			engine := Engine{Store: store}
+			if err := engine.HandleReviewPullRequestClosed(ctx, PullRequestEvent{
+				Repo:        "owner/repo",
+				Branch:      "feature/893",
+				PullRequest: 893,
+				TaskID:      "task-893",
+				TaskTitle:   "Reconcile external merge",
+				LeadAgent:   "github",
+				Sender:      "github",
+			}, true); err != nil {
+				t.Fatalf("HandleReviewPullRequestClosed: %v", err)
+			}
+
+			task, err := store.GetTask(ctx, "task-893")
+			if err != nil || task.State != string(TaskMerged) {
+				t.Fatalf("task = %+v, err=%v; want merged", task, err)
+			}
+			pr, err := store.GetPullRequest(ctx, "owner/repo", 893)
+			if err != nil || pr.State != "merged" {
+				t.Fatalf("pull request = %+v, err=%v; want merged", pr, err)
+			}
+		})
+	}
+}
+
+func TestHandleReviewPullRequestClosedUnmergedLeavesNonReviewingStatesUnchanged(t *testing.T) {
+	states := []TaskState{TaskPullRequestOpen, TaskChangesRequested}
+	for _, state := range states {
+		t.Run(string(state), func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			if err := store.UpsertTask(ctx, db.Task{
+				ID:           "task-893",
+				RepoFullName: "owner/repo",
+				Title:        "Conservative close handling",
+				State:        string(state),
+				Branch:       "feature/893",
+			}); err != nil {
+				t.Fatalf("UpsertTask: %v", err)
+			}
+			if err := store.UpsertPullRequest(ctx, db.PullRequest{
+				RepoFullName: "owner/repo",
+				Number:       893,
+				HeadBranch:   "feature/893",
+				State:        "open",
+			}); err != nil {
+				t.Fatalf("UpsertPullRequest: %v", err)
+			}
+
+			engine := Engine{Store: store}
+			if err := engine.HandleReviewPullRequestClosed(ctx, PullRequestEvent{
+				Repo:        "owner/repo",
+				Branch:      "feature/893",
+				PullRequest: 893,
+				TaskID:      "task-893",
+				TaskTitle:   "Conservative close handling",
+				LeadAgent:   "github",
+				Sender:      "github",
+			}, false); err != nil {
+				t.Fatalf("HandleReviewPullRequestClosed: %v", err)
+			}
+
+			task, err := store.GetTask(ctx, "task-893")
+			if err != nil || task.State != string(state) {
+				t.Fatalf("task = %+v, err=%v; want %s", task, err, state)
+			}
+			pr, err := store.GetPullRequest(ctx, "owner/repo", 893)
+			if err != nil || pr.State != "open" {
+				t.Fatalf("pull request = %+v, err=%v; want open", pr, err)
+			}
+		})
+	}
+}
+
+func TestHandleReviewPullRequestClosedEmptyBranchDoesNotAdvanceCanonicalTask(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "implement-11",
+		RepoFullName: "owner/repo",
+		Title:        "Canonical implementation",
+		State:        string(TaskImplementing),
+		Branch:       "feature/eleven",
+	}); err != nil {
+		t.Fatalf("Upsert implement task: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "review-pr-11-44cd8322",
+		RepoFullName: "owner/repo",
+		Title:        "Review PR #11",
+		State:        string(TaskReviewing),
+	}); err != nil {
+		t.Fatalf("Upsert review task: %v", err)
+	}
+
+	engine := Engine{Store: store}
+	if err := engine.HandleReviewPullRequestClosed(ctx, PullRequestEvent{
+		Repo:        "owner/repo",
+		Branch:      "feature/eleven",
+		PullRequest: 11,
+		TaskID:      "review-pr-11-44cd8322",
+		TaskTitle:   "Review PR #11",
+		LeadAgent:   "github",
+		Sender:      "github",
+	}, true); err != nil {
+		t.Fatalf("HandleReviewPullRequestClosed: %v", err)
+	}
+
+	reviewTask, err := store.GetTask(ctx, "review-pr-11-44cd8322")
+	if err != nil || reviewTask.State != string(TaskMerged) || reviewTask.Branch != "" {
+		t.Fatalf("review task = %+v, err=%v; want merged with empty branch", reviewTask, err)
+	}
+	implementTask, err := store.GetTask(ctx, "implement-11")
+	if err != nil || implementTask.State != string(TaskImplementing) || implementTask.Branch != "feature/eleven" {
+		t.Fatalf("implement task changed = %+v, err=%v", implementTask, err)
+	}
+}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1123,22 +1123,16 @@ func (e Engine) HandlePullRequestReadyToMerge(ctx context.Context, event PullReq
 	return err
 }
 
-// HandleReviewPullRequestClosed reconciles a task wedged in `reviewing` whose
-// pull request is no longer open on GitHub (#543). The daemon poll loop only
-// lists OPEN pull requests, so once a reviewing task's PR is closed — most often
-// a duplicate/superseded PR that a cleanup job closed on GitHub — nothing
-// re-routes the task and it stays in `reviewing` pointing at a stale `open`
-// local PR row forever.
+// HandleReviewPullRequestClosed reconciles a PR lifecycle task whose pull
+// request is no longer open on GitHub (#543, #893). The daemon poll loop only
+// lists OPEN pull requests, so an externally merged PR otherwise disappears
+// while its task and local PR mirror remain stale.
 //
-// It is idempotent and narrowly scoped: it acts ONLY when the task is still in
-// `reviewing`, so any already-advanced task (a genuinely-open PR still under
-// review, or one already merged/blocked) is left untouched and the healthy
-// merge/open paths are never regressed. It transitions the task out of
-// `reviewing` and rewrites the stale local PR row to its true state: a merged PR
-// resolves the task to `merged`; a closed-unmerged PR resolves it to the
-// terminal `blocked` state (there is no open PR left to review or merge, so it
-// surfaces to a human). Existing PR row fields (url/base/merge SHA) are
-// preserved — only the state (and, when merged, head SHA) is reconciled.
+// Merged PRs resolve any of pr_open/reviewing/changes_requested/ready_to_merge;
+// an already-merged task is accepted only to repair its stale PR mirror.
+// Closed-unmerged behavior remains deliberately narrower: only reviewing uses
+// the existing transition to blocked; the other lifecycle states are untouched.
+// Existing PR row fields (url/base/merge SHA) are preserved.
 func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullRequestEvent, merged bool) error {
 	if err := e.validate(); err != nil {
 		return err
@@ -1154,17 +1148,39 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 		}
 		return err
 	}
-	if task.State != string(TaskReviewing) {
+	taskState := TaskState(task.State)
+	alreadyMerged := false
+	if merged {
+		switch taskState {
+		case TaskPullRequestOpen, TaskReviewing, TaskChangesRequested, TaskReadyToMerge:
+		case TaskMerged:
+			// Keep the task terminal while repairing a stale local PR mirror after
+			// another path (notably the ready-to-merge gate) completed first.
+			alreadyMerged = true
+		default:
+			return nil
+		}
+	} else if taskState != TaskReviewing {
 		return nil
 	}
 	prState := "closed"
-	taskState := TaskBlocked
+	nextTaskState := TaskBlocked
 	if merged {
 		prState = "merged"
-		taskState = TaskMerged
+		nextTaskState = TaskMerged
 	}
-	if err := e.setTaskState(ctx, ref, taskState); err != nil {
-		return err
+	if !alreadyMerged {
+		stateRef := ref
+		if strings.TrimSpace(task.Branch) == "" {
+			// Legacy/local review-pr tasks intentionally have no branch because the
+			// canonical implement task may already own (repo, head branch). Keeping the
+			// ref empty advances the review task itself instead of setTaskState's branch
+			// collision fallback advancing the implement task.
+			stateRef.Branch = ""
+		}
+		if err := e.setTaskState(ctx, stateRef, nextTaskState); err != nil {
+			return err
+		}
 	}
 	pr := db.PullRequest{
 		RepoFullName: event.Repo,
@@ -1186,7 +1202,7 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 	if err := e.Store.UpsertPullRequest(ctx, pr); err != nil {
 		return err
 	}
-	if merged {
+	if merged && !alreadyMerged {
 		// An externally-merged PR detected by the reconciler must release the branch
 		// lock and remove the task worktree, exactly as the canonical merge path
 		// (PolicyMergeGate.finishMerged) does. Without this the reconcile method


### PR DESCRIPTION
## Summary

Fixes #893 — tasks no longer wedge in `pr_open`/`reviewing`/`changes_requested`/`ready_to_merge` when their PR is merged outside gitmoot (human squash-merge).

**Daemon** (`internal/daemon/daemon.go`):
- New per-poll pass `reconcileExternallyMergedTasks`: collects candidate tasks in the four PR-lifecycle states, resolves each to a PR number (stored `pull_requests` row by branch; for empty-branch `review-pr-<n>-<hash>` tasks, the number parsed from the task id), skips PRs still open, then does **targeted `GetPullRequest` lookups** — immune to closed-list pagination, deduped by PR number, capped at 20 lookups/repo/tick so a backlog drains over successive ticks.
- `ready_to_merge` tasks route through the existing merge-gate cleanup first, preserving its side effects.

**Engine** (`internal/workflow/engine.go` `HandleReviewPullRequestClosed`):
- Merged PRs now resolve any of the four lifecycle states to `merged` (was: `reviewing` only), releasing the branch lock and removing the task worktree exactly like the canonical merge path; an already-`merged` task is accepted only to repair its stale local PR mirror.
- Closed-unmerged behavior deliberately unchanged: only `reviewing` transitions (to `blocked`); other states are left untouched.
- Empty-branch review tasks advance by task id (the state ref keeps its empty branch), avoiding `setTaskState`'s branch-collision fallback advancing the canonical implement task that owns `(repo, head branch)` — the reason these rows are branchless in the first place (unique index `idx_tasks_repo_branch_unique`).

Existing wedged rows on the live store (~50 tasks across 8 repos, incl. the 638-stale-open `pull_requests` mirror) self-heal through normal daemon ticks; no manual SQL.

**Known bound:** permanently closed-unmerged candidates re-consume lookup slots each tick; with the 20/tick cap this only matters if a single repo accumulates 20+ such rows (not the case today — nearly all wedged PRs are merged and exit the candidate set on first heal).

## Tests

New: `TestPollOnceReconcilesExternallyMergedLifecycleTasks`, `TestPollOnceLeavesClosedUnmergedPullRequestOpenTaskUnchanged`, `TestPollOnceReconcilesEmptyBranchReviewTaskByPullRequestNumber`, `TestExternalMergeReconcileCapsTargetedLookupsPerTick`, `TestReviewTaskPullRequestNumber`, `TestHandleReviewPullRequestClosedMergedLifecycleStates`, `TestHandleReviewPullRequestClosedUnmergedLeavesNonReviewingStatesUnchanged`, `TestHandleReviewPullRequestClosedEmptyBranchDoesNotAdvanceCanonicalTask`; branch-collision coverage added to `TestPrepareLocalReviewDispatchRequestCreatesReviewWorktree`.

Gates: `go build ./... && go vet ./...` green; `go test ./internal/daemon/ ./internal/workflow/ ./internal/cli/ ./internal/db/` all ok.

## Deploy notes

Daemon binary change — deploy at idle and watch one poll tick: the dashboard "PR open" column should start draining within a few ticks (20 PRs/repo/tick). No config or migration.

Part of the `gitmoot4/dashboard-fixes` wave (2026-07-13 deep-dive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)