### PR TITLE
fix(dashboard-web): stop synthesizing pipeline/* auto-groups on /workflows (#894)

### DIFF
--- a/internal/cli/dashboard_web_overview_test.go
+++ b/internal/cli/dashboard_web_overview_test.go
@@ -92,6 +92,7 @@ func TestDashboardOverviewTasksAndAutoWorkflows(t *testing.T) {
 	seedJob("finished-cancelled", "beta", "cancelled", "release/cancelled", "acme/app", "Cancelled experiment", 4*time.Hour, 3*time.Hour, 19, 23)
 	seedJob("finished-old", "alpha", "succeeded", "archive/old", "acme/app", "Old completion", 26*time.Hour, 25*time.Hour, 101, 103)
 	seedJob("pipeline-job", "alpha", "succeeded", "", "acme/data", "Nightly ingest", 2*time.Hour, 90*time.Minute, 29, 31)
+	seedJob("explicit-pipeline-label", "alpha", "succeeded", "pipeline/manual", "acme/manual", "Manually labeled campaign", 28*time.Hour, 27*time.Hour, 37, 41)
 
 	blockedPayload := workflow.JobPayload{WorkflowID: "ops/recent", Repo: "acme/ops", TaskTitle: "Provision credentials"}
 	if err := store.CreateJobWithEvent(ctx,
@@ -192,13 +193,23 @@ func TestDashboardOverviewTasksAndAutoWorkflows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dashboardWorkflowEntries: %v", err)
 	}
-	pipelineGroup := workflowIndexEntryByLabel(t, workflows, "pipeline/nightly")
-	if !pipelineGroup.Auto || pipelineGroup.Counts.Jobs != 1 || pipelineGroup.Counts.Succeeded != 1 || !reflect.DeepEqual(pipelineGroup.Repos, []string{"acme/data"}) {
-		t.Fatalf("pipeline auto group = %+v", pipelineGroup)
+	workflowByLabel := make(map[string]dashboard.WorkflowIndexEntry, len(workflows))
+	for _, entry := range workflows {
+		workflowByLabel[entry.Label] = entry
 	}
-	adhocGroup := workflowIndexEntryByLabel(t, workflows, "adhoc/beta")
+	if _, ok := workflowByLabel["pipeline/nightly"]; ok {
+		t.Fatalf("pipeline stage leaked into pipeline auto group: %+v", workflows)
+	}
+	if _, ok := workflowByLabel["adhoc/alpha"]; ok {
+		t.Fatalf("pipeline stage was re-bucketed as adhoc/alpha: %+v", workflows)
+	}
+	adhocGroup := workflowByLabel["adhoc/beta"]
 	if !adhocGroup.Auto || adhocGroup.State != "active" || adhocGroup.Counts.Running != 1 {
 		t.Fatalf("adhoc auto group = %+v", adhocGroup)
+	}
+	explicitPipeline := workflowByLabel["pipeline/manual"]
+	if explicitPipeline.Auto || explicitPipeline.Counts.Jobs != 1 || explicitPipeline.Counts.Succeeded != 1 || !reflect.DeepEqual(explicitPipeline.Repos, []string{"acme/manual"}) {
+		t.Fatalf("explicit pipeline label = %+v", explicitPipeline)
 	}
 
 	second, err := dashboardOverview(ctx, store, now)

--- a/internal/cli/dashboard_web_workflows.go
+++ b/internal/cli/dashboard_web_workflows.go
@@ -47,8 +47,8 @@ func deriveDashboardWorkflowState(now time.Time, activity dashboardWorkflowActiv
 }
 
 // Workflows returns one deterministic index row for every explicit workflow
-// label plus scalar-only pipeline/<name> and adhoc/<agent> groups for unlabeled
-// runs. Auto groups never decode the global job payload corpus.
+// label plus scalar-only adhoc/<agent> groups for unlabeled non-pipeline runs.
+// Auto groups never decode the global job payload corpus.
 func (d *webDataSource) Workflows(ctx context.Context) ([]dashboard.WorkflowIndexEntry, error) {
 	out := []dashboard.WorkflowIndexEntry{}
 	now := time.Now().UTC()

--- a/internal/db/dashboard_store.go
+++ b/internal/db/dashboard_store.go
@@ -50,8 +50,9 @@ type DashboardTerminalBucket struct {
 	OutputTokens int
 }
 
-// DashboardAutoWorkflow is one synthetic workflow group built from scalar job
-// columns. Repos is already sorted and de-duplicated by the SQL projection.
+// DashboardAutoWorkflow is one synthetic adhoc workflow group built from
+// scalar columns on unlabeled, non-pipeline jobs. Repos is already sorted and
+// de-duplicated by the SQL projection.
 type DashboardAutoWorkflow struct {
 	Summary WorkflowSummary
 	Repos   []string
@@ -201,8 +202,8 @@ func (s *Store) ListDashboardFleetCounts(ctx context.Context, since string) ([]D
 	return out, rows.Err()
 }
 
-// ListDashboardAutoWorkflows aggregates unlabeled jobs without reading payloads.
-// Pipeline stage membership wins; all other rows group under the assigned agent.
+// ListDashboardAutoWorkflows groups unlabeled, non-pipeline jobs by assigned
+// agent without reading payloads. Pipeline stage jobs are excluded entirely.
 func (s *Store) ListDashboardAutoWorkflows(ctx context.Context) ([]DashboardAutoWorkflow, error) {
 	rows, err := s.db.QueryContext(ctx, `WITH pipeline_jobs AS (
 		SELECT prs.job_id, MIN(pr.pipeline) AS pipeline
@@ -211,14 +212,11 @@ func (s *Store) ListDashboardAutoWorkflows(ctx context.Context) ([]DashboardAuto
 		WHERE prs.job_id != '' AND pr.pipeline != ''
 		GROUP BY prs.job_id
 	), auto_jobs AS (
-		SELECT CASE
-			WHEN pj.pipeline IS NOT NULL THEN 'pipeline/' || pj.pipeline
-			ELSE 'adhoc/' || j.agent
-		END AS workflow_id,
+		SELECT 'adhoc/' || j.agent AS workflow_id,
 		j.state, j.input_tokens, j.output_tokens, j.created_at, j.updated_at, j.repo
 		FROM jobs j
 		LEFT JOIN pipeline_jobs pj ON pj.job_id = j.id
-		WHERE j.workflow_id = '' AND (pj.pipeline IS NOT NULL OR j.agent != '')
+		WHERE j.workflow_id = '' AND pj.pipeline IS NULL AND j.agent != ''
 	)
 	SELECT workflow_id,
 		COUNT(*),

--- a/internal/db/dashboard_store_test.go
+++ b/internal/db/dashboard_store_test.go
@@ -40,3 +40,47 @@ func TestDashboardChangeCursor(t *testing.T) {
 		t.Fatalf("repeat cursor = %d.%d, err=%v, want %d.%d", events2, notes2, err, events, notes)
 	}
 }
+
+func TestListDashboardAutoWorkflowsExcludesPipelineStages(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	for _, job := range []Job{
+		{ID: "pipeline-job", Agent: "pipeline-worker", Type: "produce", State: "succeeded", Payload: `{"repo":"acme/data"}`},
+		{ID: "adhoc-job", Agent: "adhoc-worker", Type: "ask", State: "running", Payload: `{"repo":"acme/app"}`},
+		{ID: "labeled-pipeline-job", Agent: "pipeline-worker", Type: "produce", State: "succeeded", Payload: `{"repo":"acme/manual","workflow_id":"pipeline/manual"}`},
+	} {
+		if err := store.CreateJob(ctx, job); err != nil {
+			t.Fatalf("CreateJob(%s): %v", job.ID, err)
+		}
+	}
+	if err := store.CreatePipelineRun(ctx, PipelineRun{ID: "run-1", Pipeline: "nightly", State: "succeeded"}); err != nil {
+		t.Fatalf("CreatePipelineRun: %v", err)
+	}
+	for _, stage := range []PipelineRunStage{
+		{RunID: "run-1", StageID: "unlabeled", State: "succeeded", JobID: "pipeline-job"},
+		{RunID: "run-1", StageID: "labeled", State: "succeeded", JobID: "labeled-pipeline-job"},
+	} {
+		if err := store.CreatePipelineRunStage(ctx, stage); err != nil {
+			t.Fatalf("CreatePipelineRunStage(%s): %v", stage.StageID, err)
+		}
+	}
+
+	auto, err := store.ListDashboardAutoWorkflows(ctx)
+	if err != nil {
+		t.Fatalf("ListDashboardAutoWorkflows: %v", err)
+	}
+	if len(auto) != 1 || auto[0].Summary.WorkflowID != "adhoc/adhoc-worker" || auto[0].Summary.JobCount != 1 || auto[0].Summary.Running != 1 {
+		t.Fatalf("auto workflows = %+v, want only adhoc/adhoc-worker", auto)
+	}
+	if len(auto[0].Repos) != 1 || auto[0].Repos[0] != "acme/app" {
+		t.Fatalf("adhoc repos = %v, want [acme/app]", auto[0].Repos)
+	}
+
+	summaries, err := store.ListWorkflowSummaries(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowSummaries: %v", err)
+	}
+	if len(summaries) != 1 || summaries[0].WorkflowID != "pipeline/manual" || summaries[0].JobCount != 1 || summaries[0].Succeeded != 1 {
+		t.Fatalf("labeled workflows = %+v, want pipeline/manual", summaries)
+	}
+}

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -190,9 +190,10 @@ Workflows are labeled campaigns of related work driven by a coordinator: jobs
 dispatched with `--workflow <label>` plus the journal written with
 `gitmoot workflow note`. Labels may carry one namespace slash
 (`fable/dashboard-redesign`) — by convention the coordinator's herdr pane name
-namespaces the campaign. Unlabeled pipeline stages and other runs are also
-summarized without payload scans as synthetic `pipeline/<name>` and
-`adhoc/<agent>` entries; these are marked unattended in the index.
+namespaces the campaign. Unlabeled non-pipeline runs are summarized without
+payload scans as synthetic `adhoc/<agent>` entries and marked unattended in the
+index. Pipeline stage jobs stay on the Pipelines page; an explicitly labeled
+workflow still appears here even when its label begins with `pipeline/`.
 
 The **index** groups every known workflow by derived lifecycle: **stalled**
 pinned on top ("needs a look"), then **active**, then recently **settled**.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6501,9 +6501,10 @@ Workflows are labeled campaigns of related work driven by a coordinator: jobs
 dispatched with `--workflow <label>` plus the journal written with
 `gitmoot workflow note`. Labels may carry one namespace slash
 (`fable/dashboard-redesign`) — by convention the coordinator's herdr pane name
-namespaces the campaign. Unlabeled pipeline stages and other runs are also
-summarized without payload scans as synthetic `pipeline/<name>` and
-`adhoc/<agent>` entries; these are marked unattended in the index.
+namespaces the campaign. Unlabeled non-pipeline runs are summarized without
+payload scans as synthetic `adhoc/<agent>` entries and marked unattended in the
+index. Pipeline stage jobs stay on the Pipelines page; an explicitly labeled
+workflow still appears here even when its label begins with `pipeline/`.
 
 The **index** groups every known workflow by derived lifecycle: **stalled**
 pinned on top ("needs a look"), then **active**, then recently **settled**.


### PR DESCRIPTION
## Summary

Fixes #894 — the /workflows index no longer synthesizes `pipeline/<name>` auto-groups; pipeline runs live on the Pipelines page only.

- `ListDashboardAutoWorkflows` (`internal/db/dashboard_store.go`): auto-group WHERE clause is now `j.workflow_id = '' AND pj.pipeline IS NULL AND j.agent != ''` — pipeline-stage jobs are **excluded entirely** (deliberately not re-bucketed into `adhoc/<agent>`); the pipeline CASE branch is gone, so auto ids are always `'adhoc/' || j.agent`.
- `adhoc/<agent>` groups for genuinely unlabeled non-pipeline jobs are unchanged; explicitly labeled workflows (even a manual `--workflow pipeline/x`) still appear via the labeled path.
- Docs updated in the same PR (`website/docs/dashboard/views.md`, `llms-full.txt` regenerated).

Companion one-line dashboard copy fix (the /workflows empty state promised `pipeline/…` auto-grouping) ships as a separate jerryfane/gitmoot-dashboard PR referencing this issue.

## Tests

New `TestListDashboardAutoWorkflowsExcludesPipelineStages`; `TestDashboardOverviewTasksAndAutoWorkflows` extended for exclusion / no-rebucketing / adhoc grouping / explicit-label survival.

Gates: `go generate` (clean diff), `go build`, `go vet`, `go test ./internal/db/ ./internal/cli/` — all green.

## Deploy notes

Reverses one slice of Wave 3 (#881) after the owner saw it live. Dashboard-web binary change only; no migration, no config.

Part of the `gitmoot4/dashboard-fixes` wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)