### PR TITLE
fix(runtime): surface claude failure messages; widen failed-event label cap (#895)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -2242,7 +2242,10 @@ func eventLabel(e db.JobEvent) string {
 	if msg == "" {
 		return kind
 	}
-	const maxMsg = 120
+	maxMsg := 120
+	if kind == "failed" {
+		maxMsg = 600
+	}
 	if len(msg) > maxMsg {
 		msg = msg[:maxMsg] + "…"
 	}

--- a/internal/cli/dashboard_web_test.go
+++ b/internal/cli/dashboard_web_test.go
@@ -318,6 +318,34 @@ func TestPinDashboardBlockedDoesNotStampEndedAt(t *testing.T) {
 	}
 }
 
+func TestEventLabelFailureMessageCap(t *testing.T) {
+	message := strings.Repeat("x", 300)
+	tests := []struct {
+		name  string
+		event db.JobEvent
+		want  string
+	}{
+		{
+			name:  "failed event retains 300 byte message",
+			event: db.JobEvent{Kind: "failed", Message: message},
+			want:  "failed: " + message,
+		},
+		{
+			name:  "non failed event keeps 120 byte cap",
+			event: db.JobEvent{Kind: "worker_error", Message: message},
+			want:  "worker_error: " + message[:120] + "…",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := eventLabel(tt.event); got != tt.want {
+				t.Fatalf("eventLabel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestNodeTitleDescriptive covers the descriptive-title preference order beyond
 // the plain task-title case: a humanized delegation id and an instructions line.
 func TestNodeTitleDescriptive(t *testing.T) {

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -1461,8 +1461,21 @@ func isCodexJSONUnsupported(result subprocess.Result) bool {
 		strings.Contains(text, "invalid")
 }
 
+// claudeCommandError prefers the human-readable result from Claude's JSON
+// failure envelope over the raw stdout blob. The original process error stays
+// wrapped, and auth failures retain their existing typed classification.
 func claudeCommandError(result subprocess.Result, err error) error {
-	return ClassifyClaudeCommandError(result, err)
+	base := commandError(result, err)
+	if envelope, parseErr := ExtractClaudeResultEnvelope(result.Stdout); parseErr == nil && envelope.Type == "result" && envelope.IsError {
+		if resultMessage := strings.TrimSpace(envelope.Result); resultMessage != "" {
+			detail := "claude: " + resultMessage
+			if envelope.APIErrorStatus != 0 {
+				detail += fmt.Sprintf(" (api_error_status %d)", envelope.APIErrorStatus)
+			}
+			base = fmt.Errorf("%s: %w", detail, err)
+		}
+	}
+	return classifyClaudeCommandError(result, base)
 }
 
 // classifyClaudeProbeError classifies the error from an ISOLATED doctor live
@@ -1484,7 +1497,10 @@ func classifyClaudeProbeError(result subprocess.Result, err error) error {
 }
 
 func ClassifyClaudeCommandError(result subprocess.Result, err error) error {
-	base := commandError(result, err)
+	return claudeCommandError(result, err)
+}
+
+func classifyClaudeCommandError(result subprocess.Result, base error) error {
 	if !isClaudeAuthFailure(result) {
 		return base
 	}

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -1920,6 +1920,59 @@ func TestCodexCommandError(t *testing.T) {
 	})
 }
 
+func TestClaudeCommandError(t *testing.T) {
+	const rateLimitEnvelope = `{"type":"result","subtype":"success","is_error":true,"api_error_status":429,"duration_ms":755,"duration_api_ms":0,"num_turns":1,"result":"You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.","stop_reason":"stop_sequence","session_id":"fe533d2b-f742-440c-afa6-43608e4e0ba2","total_cost_usd":0,"usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0},"modelUsage":{},"permission_denials":[],"terminal_reason":"api_error","fast_mode_state":"off","uuid":"2af6cf4c-c4cb-44ae-9fa2-db6fdcf705b3"}`
+	runErr := errors.New("exit status 1")
+
+	tests := []struct {
+		name        string
+		result      subprocess.Result
+		want        []string
+		doesNotWant []string
+	}{
+		{
+			name:        "extracts captured 429 failure",
+			result:      subprocess.Result{Stdout: rateLimitEnvelope},
+			want:        []string{"You've reached your Fable 5 limit", "429"},
+			doesNotWant: []string{`{"type":"result"`},
+		},
+		{
+			name:   "successful envelope falls back",
+			result: subprocess.Result{Stdout: `{"type":"result","is_error":false,"result":"done"}`, Stderr: "stderr fallback"},
+			want:   []string{"stderr fallback"},
+		},
+		{
+			name:   "non json stdout falls back",
+			result: subprocess.Result{Stdout: "plain runtime failure"},
+			want:   []string{"plain runtime failure"},
+		},
+		{
+			name: "jsonl uses last result line",
+			result: subprocess.Result{Stdout: `{"type":"result","is_error":true,"api_error_status":500,"result":"first failure"}` + "\n" +
+				`{"type":"system","message":"retrying"}` + "\n" +
+				`{"type":"result","is_error":true,"api_error_status":503,"result":"last failure"}` + "\n"},
+			want:        []string{"last failure", "503"},
+			doesNotWant: []string{"first failure", `{"type":"result"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := claudeCommandError(tt.result, runErr).Error()
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Fatalf("error = %q, want substring %q", got, want)
+				}
+			}
+			for _, unwanted := range tt.doesNotWant {
+				if strings.Contains(got, unwanted) {
+					t.Fatalf("error = %q, must not contain %q", got, unwanted)
+				}
+			}
+		})
+	}
+}
+
 func TestValidateAgentAcceptsKimiRuntimes(t *testing.T) {
 	for _, runtimeName := range []string{KimiRuntime, KimiCLIRuntime} {
 		agent := Agent{Name: "audit", Role: "reviewer", Runtime: runtimeName, RuntimeRef: "session_550e8400-e29b-41d4-a716-446655440000", RepoScope: "jerryfane/gitmoot"}

--- a/internal/runtime/transcript_extract.go
+++ b/internal/runtime/transcript_extract.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bufio"
 	"encoding/json"
 	"strings"
 )
@@ -95,25 +96,47 @@ func ExtractCodexStreamEvent(line string) (CodexStreamEvent, error) {
 	return event, nil
 }
 
-// ClaudeResultEnvelope is the verified subset of Claude Code's single final
+// ClaudeResultEnvelope is the verified subset of Claude Code's final
 // --output-format json envelope.
 type ClaudeResultEnvelope struct {
-	Type   string
-	Result string
-	Usage  StreamUsage
+	Type           string      `json:"type"`
+	Result         string      `json:"result"`
+	Usage          StreamUsage `json:"usage"`
+	IsError        bool        `json:"is_error"`
+	APIErrorStatus int         `json:"api_error_status"`
 }
 
-// ExtractClaudeResultEnvelope owns Claude's final-envelope wire format.
+// ExtractClaudeResultEnvelope owns Claude's final-envelope wire format. Claude
+// normally emits one JSON object, but some versions/modes emit JSONL; in that
+// case the last parseable result envelope is authoritative.
 func ExtractClaudeResultEnvelope(stdout string) (ClaudeResultEnvelope, error) {
-	var wire struct {
-		Type   string      `json:"type"`
-		Result string      `json:"result"`
-		Usage  StreamUsage `json:"usage"`
+	var envelope ClaudeResultEnvelope
+	wholeOutputErr := json.Unmarshal([]byte(stdout), &envelope)
+	if wholeOutputErr == nil {
+		return envelope, nil
 	}
-	if err := json.Unmarshal([]byte(stdout), &wire); err != nil {
-		return ClaudeResultEnvelope{}, err
+
+	scanner := bufio.NewScanner(strings.NewReader(stdout))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	found := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var candidate ClaudeResultEnvelope
+		if json.Unmarshal([]byte(line), &candidate) == nil && candidate.Type == "result" {
+			envelope = candidate
+			found = true
+		}
 	}
-	return ClaudeResultEnvelope{Type: wire.Type, Result: wire.Result, Usage: wire.Usage}, nil
+	if scanErr := scanner.Err(); scanErr != nil {
+		return ClaudeResultEnvelope{}, scanErr
+	}
+	if found {
+		return envelope, nil
+	}
+	return ClaudeResultEnvelope{}, wholeOutputErr
 }
 
 // KimiStreamEvent is the verified subset of one Kimi stream-json line.


### PR DESCRIPTION
## Summary

Fixes #895 — claude-runtime failures now surface their human-readable cause instead of a truncated raw JSON envelope.

- `claudeCommandError` (`internal/runtime/adapter.go`) now parses the claude result envelope and, when `is_error` is set, reports `claude: <result> (api_error_status N)` — symmetrical to the existing `codexCommandError`. The original process error stays wrapped; the existing auth-failure classification is preserved (public `ClassifyClaudeCommandError` kept as a wrapper). Kimi/shell untouched.
- `ClaudeResultEnvelope` (`internal/runtime/transcript_extract.go`) gains `is_error`/`api_error_status` and a JSONL fallback (last parseable `result` line wins; bounded 1 MB scanner) — some claude versions/modes emit JSONL.
- Dashboard `eventLabel` (`internal/cli/dashboard_web.go`): `failed` events keep up to 600 bytes; all other kinds stay at 120.
- Raw output remains fully available via crash diagnostics (#806) — mailbox untouched.

The live failure that motivated this (`local-ask-researcher-…`, a Fable 5 usage-limit 429) previously rendered as `failed: delivery failed: {"type":"result","subtype":"success","is_error":true,…` cut mid-JSON; with this change it reads `failed: delivery failed: claude: You've reached your Fable 5 limit. … (api_error_status 429): exit status 1`.

## Tests

Table-driven `TestClaudeCommandError` (captured 429 fixture; success-envelope fallback; non-JSON fallback; JSONL last-line extraction) and `TestEventLabelFailureMessageCap`.

Gates: `go generate` clean, `go build` / `go vet` green, `go test ./internal/runtime/ ./internal/cli/ ./internal/workflow/` ok.

## Deploy notes

Daemon + dashboard-web binary change; no migration, no config. After deploy, any new failure event shows the extracted message end-to-end (CLI `job show`, /api/job, dashboard events rail).

Part of the `gitmoot4/dashboard-fixes` wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)