### PR TITLE
feat(dashboard-web): stop emitting planned tasks from /api/tasks (dashboard#92)

### DIFF
--- a/internal/cli/dashboard_web_overview.go
+++ b/internal/cli/dashboard_web_overview.go
@@ -17,7 +17,7 @@ import (
 const (
 	dashboardTaskMergedWindow = 7 * 24 * time.Hour
 	// Open work older than this is stale backlog, not a board card: the live
-	// store carries months of dormant planned/blocked tasks that would drown
+	// store carries months of dormant nonterminal tasks that would drown
 	// the Tasks board and the needs-you strip.
 	dashboardTaskActiveWindow = 30 * 24 * time.Hour
 	dashboardTodayWindow      = 24 * time.Hour
@@ -44,7 +44,7 @@ func capDashboardNeedsYou(out *dashboard.Overview) {
 
 const ()
 
-// Tasks projects Gitmoot's richer internal task lifecycle onto the five
+// Tasks projects Gitmoot's richer internal task lifecycle onto the four
 // dashboard columns. CI remains empty because no current CI conclusion is
 // persisted locally; dashboard requests never call GitHub.
 func (d *webDataSource) Tasks(ctx context.Context) ([]dashboard.TaskSummary, error) {
@@ -66,7 +66,10 @@ func dashboardTasks(ctx context.Context, store *db.Store, now time.Time) ([]dash
 	out := make([]dashboard.TaskSummary, 0, len(rows))
 	activeCutoff := now.Add(-dashboardTaskActiveWindow)
 	for _, row := range rows {
-		state, blockedReason := dashboardTaskState(row.State)
+		state, blockedReason, ok := dashboardTaskState(row.State)
+		if !ok {
+			continue
+		}
 		updatedAt := parseJobTimeMillis(row.UpdatedAt)
 		if state != "merged" && workflowMillisTime(updatedAt).Before(activeCutoff) {
 			continue
@@ -93,39 +96,37 @@ func dashboardTasks(ctx context.Context, store *db.Store, now time.Time) ([]dash
 	return out, nil
 }
 
-func dashboardTaskState(state string) (string, string) {
+func dashboardTaskState(state string) (stateName, blockedReason string, ok bool) {
 	switch strings.TrimSpace(state) {
 	case "planned":
-		return "planned", ""
+		return "", "", false
 	case "implementing":
-		return "implementing", ""
+		return "implementing", "", true
 	case "pr_open", "reviewing", "changes_requested", "ready_to_merge":
-		return "pr_open", ""
+		return "pr_open", "", true
 	case "blocked":
-		return "blocked", "Task is blocked"
+		return "blocked", "Task is blocked", true
 	case "awaiting_human":
-		return "blocked", "Awaiting human input"
+		return "blocked", "Awaiting human input", true
 	case "merged":
-		return "merged", ""
+		return "merged", "", true
 	default:
-		return "planned", ""
+		return "", "", false
 	}
 }
 
 func dashboardTaskStateRank(state string) int {
 	switch state {
-	case "planned":
-		return 0
 	case "implementing":
-		return 1
+		return 0
 	case "pr_open":
-		return 2
+		return 1
 	case "blocked":
-		return 3
+		return 2
 	case "merged":
-		return 4
+		return 3
 	default:
-		return 5
+		return 4
 	}
 }
 

--- a/internal/cli/dashboard_web_overview_test.go
+++ b/internal/cli/dashboard_web_overview_test.go
@@ -57,6 +57,7 @@ func TestDashboardOverviewTasksAndAutoWorkflows(t *testing.T) {
 	}
 	for _, task := range []db.Task{
 		{ID: "task-plan", RepoFullName: "acme/app", Title: "Plan rollout", State: "planned", Branch: "plan"},
+		{ID: "task-unknown", RepoFullName: "acme/app", Title: "Future lifecycle", State: "future_state", Branch: "future"},
 		{ID: "task-pr", RepoFullName: "acme/app", Title: "Ship dashboard", State: "ready_to_merge", Branch: "ship-dashboard"},
 		{ID: "task-blocked", RepoFullName: "acme/ops", Title: "Rotate key", State: "awaiting_human", Branch: "rotate"},
 		{ID: "task-merged-recent", RepoFullName: "acme/app", Title: "Recent merge", State: "merged", Branch: "recent"},
@@ -129,6 +130,7 @@ func TestDashboardOverviewTasksAndAutoWorkflows(t *testing.T) {
 	defer raw.Close()
 	for id, updated := range map[string]string{
 		"task-plan":          stamp(2 * time.Hour),
+		"task-unknown":       stamp(15 * time.Minute),
 		"task-pr":            stamp(time.Hour),
 		"task-blocked":       stamp(30 * time.Minute),
 		"task-merged-recent": stamp(6 * 24 * time.Hour),
@@ -154,10 +156,10 @@ func TestDashboardOverviewTasksAndAutoWorkflows(t *testing.T) {
 	if err != nil {
 		t.Fatalf("dashboardTasks: %v", err)
 	}
-	if len(tasks) != 4 {
-		t.Fatalf("tasks len=%d want 4 (old merged excluded): %+v", len(tasks), tasks)
+	if len(tasks) != 3 {
+		t.Fatalf("tasks len=%d want 3 (planned, unknown, old merged excluded): %+v", len(tasks), tasks)
 	}
-	if tasks[0].ID != "task-plan" || tasks[1].ID != "task-pr" || tasks[1].State != "pr_open" || tasks[1].Agent != "alpha" || tasks[1].PRNumber != 42 || tasks[2].BlockedReason != "Awaiting human input" || tasks[3].ID != "task-merged-recent" {
+	if tasks[0].ID != "task-pr" || tasks[0].State != "pr_open" || tasks[0].Agent != "alpha" || tasks[0].PRNumber != 42 || tasks[1].ID != "task-blocked" || tasks[1].BlockedReason != "Awaiting human input" || tasks[2].ID != "task-merged-recent" {
 		t.Fatalf("task projection/order = %+v", tasks)
 	}
 
@@ -218,8 +220,14 @@ func TestWebDashboardTasksRoundTripAndMergedWindow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-1", RepoFullName: "acme/app", Title: "Implement", State: "implementing"}); err != nil {
-		t.Fatalf("UpsertTask: %v", err)
+	for _, task := range []db.Task{
+		{ID: "task-1", RepoFullName: "acme/app", Title: "Implement", State: "implementing"},
+		{ID: "task-planned", RepoFullName: "acme/app", Title: "Plan", State: "planned"},
+		{ID: "task-unknown", RepoFullName: "acme/app", Title: "Future", State: "future_state"},
+	} {
+		if err := store.UpsertTask(context.Background(), task); err != nil {
+			t.Fatalf("UpsertTask(%s): %v", task.ID, err)
+		}
 	}
 	store.Close()
 
@@ -234,5 +242,31 @@ func TestWebDashboardTasksRoundTripAndMergedWindow(t *testing.T) {
 	}
 	if len(tasks) != 1 || tasks[0].ID != "task-1" || tasks[0].State != "implementing" || tasks[0].UpdatedAt == 0 {
 		t.Fatalf("tasks round trip = %+v", tasks)
+	}
+}
+
+func TestDashboardTaskStateFiltersUnsupportedStates(t *testing.T) {
+	tests := []struct {
+		internal, state, reason string
+		ok                      bool
+	}{
+		{internal: "planned"},
+		{internal: "future_state"},
+		{internal: "implementing", state: "implementing", ok: true},
+		{internal: "pr_open", state: "pr_open", ok: true},
+		{internal: "reviewing", state: "pr_open", ok: true},
+		{internal: "changes_requested", state: "pr_open", ok: true},
+		{internal: "ready_to_merge", state: "pr_open", ok: true},
+		{internal: "blocked", state: "blocked", reason: "Task is blocked", ok: true},
+		{internal: "awaiting_human", state: "blocked", reason: "Awaiting human input", ok: true},
+		{internal: "merged", state: "merged", ok: true},
+	}
+	for _, test := range tests {
+		t.Run(test.internal, func(t *testing.T) {
+			state, reason, ok := dashboardTaskState(test.internal)
+			if state != test.state || reason != test.reason || ok != test.ok {
+				t.Fatalf("dashboardTaskState(%q) = (%q, %q, %v), want (%q, %q, %v)", test.internal, state, reason, ok, test.state, test.reason, test.ok)
+			}
+		})
 	}
 }

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -34,10 +34,11 @@ artifact directories during a dashboard request.
 Route: `/tasks`
 
 Tasks is a read-only lifecycle board backed by Gitmoot's task registry. Internal
-states are projected into **planned**, **implementing**, **PR open**, **blocked**,
-and **merged** columns; review, changes-requested, and ready-to-merge tasks remain
-in PR open, while awaiting-human tasks appear as blocked. Merged history is
-limited server-side to the last seven days.
+states are projected into **implementing**, **PR open**, **blocked**, and
+**merged** columns; planned and unknown states are omitted, review,
+changes-requested, and ready-to-merge tasks remain in PR open, and awaiting-human
+tasks appear as blocked. Merged history is limited server-side to the last seven
+days.
 
 Cards carry the task title, repository, assigned branch-lock owner when one is
 known, pull-request number, last-update age, and a blocked reason. The CI dot is

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6345,10 +6345,11 @@ artifact directories during a dashboard request.
 Route: `/tasks`
 
 Tasks is a read-only lifecycle board backed by Gitmoot's task registry. Internal
-states are projected into **planned**, **implementing**, **PR open**, **blocked**,
-and **merged** columns; review, changes-requested, and ready-to-merge tasks remain
-in PR open, while awaiting-human tasks appear as blocked. Merged history is
-limited server-side to the last seven days.
+states are projected into **implementing**, **PR open**, **blocked**, and
+**merged** columns; planned and unknown states are omitted, review,
+changes-requested, and ready-to-merge tasks remain in PR open, and awaiting-human
+tasks appear as blocked. Merged history is limited server-side to the last seven
+days.
 
 Cards carry the task title, repository, assigned branch-lock owner when one is
 known, pull-request number, last-update age, and a blocked reason. The CI dot is


### PR DESCRIPTION
## Summary

gitmoot server half of jerryfane/gitmoot-dashboard#92 — `/api/tasks` stops emitting `planned` rows, matching the dashboard's four-column board (dashboard half: jerryfane/gitmoot-dashboard#95).

- `dashboardTaskState` now returns `ok=false` for `planned` and for unrecognized states (previously the default mapped unknowns to `"planned"`); `dashboardTasks` drops those rows before filtering/ranking/serialization.
- `dashboardTaskStateRank` compacted to the four remaining columns.
- The internal task lifecycle is untouched — only the dashboard projection changes.
- Docs updated in-PR (`website/docs/dashboard/views.md`, `llms-full.txt` regenerated).

## Tests

New `TestDashboardTaskStateFiltersUnsupportedStates`; `TestDashboardOverviewTasksAndAutoWorkflows` and `TestWebDashboardTasksRoundTripAndMergedWindow` extended.

Gates: `go generate` clean, `go build` / `go vet` green, `go test ./internal/cli/` ok.

## Deploy notes

Dashboard-web binary change only; no migration, no config.

Part of the `gitmoot4/dashboard-fixes` wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)