### PR TITLE
feat(transcript): orientation header — prompt + model shown before the stream

### DIFF
--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -445,6 +445,9 @@ func runJobTranscriptWatch(jobID, home, requestedLogPath, requestedRuntime strin
 		if err != nil {
 			return err
 		}
+		if err := renderer.RenderHeader(transcriptHeader(context.Background(), store, job, payload, runtimeName)); err != nil {
+			return err
+		}
 		return transcript.Follow(context.Background(), logPath, transcript.FollowOptions{
 			PollInterval: poll,
 			Settled: func(ctx context.Context) (bool, error) {
@@ -976,4 +979,26 @@ func transcriptStyleTerminal(w io.Writer) bool {
 		return false
 	}
 	return info.Mode()&os.ModeCharDevice != 0
+}
+
+// transcriptHeader assembles the orientation block shown before a transcript:
+// job action, agent, runtime/model, workflow label, and the (capped, redacted)
+// prompt. Model resolution mirrors dispatch: per-job override first, then the
+// agent's registered default; empty stays empty rather than guessing a runtime
+// default. Agent-registry lookup is best-effort — ephemeral workers have no row.
+func transcriptHeader(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, runtimeName string) transcript.Header {
+	model := strings.TrimSpace(payload.Model)
+	if model == "" {
+		if agent, err := store.GetAgent(ctx, job.Agent); err == nil {
+			model = strings.TrimSpace(agent.Model)
+		}
+	}
+	return transcript.Header{
+		Action:   job.Type,
+		Agent:    job.Agent,
+		Runtime:  runtimeName,
+		Model:    model,
+		Workflow: job.WorkflowID,
+		Prompt:   payload.Instructions,
+	}
 }

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -286,7 +286,7 @@ func TestRunJobWatchTranscriptRendersExplicitShellLog(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{"job", "watch", "job-transcript", "--home", home, "--transcript", "--log-path", logPath, "--runtime", runtime.ShellRuntime, "--poll", "1ms"}, &stdout, &stderr)
-	if code != 0 || stdout.String() != "working\ndone without newline\n" {
+	if code != 0 || stdout.String() != "\u25b6 ask \u00b7 audit \u00b7 shell\n\nworking\ndone without newline\n" {
 		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
 }
@@ -753,5 +753,28 @@ func TestTranscriptStyleTerminalStaysPlainOffTTY(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 	if transcriptStyleTerminal(os.Stdout) {
 		t.Fatal("NO_COLOR must force plain output")
+	}
+}
+
+func TestTranscriptHeaderModelResolution(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertAgent(context.Background(), db.Agent{Name: "modeled", Runtime: runtime.CodexRuntime, Model: "gpt-5.5"}); err != nil {
+		t.Fatal(err)
+	}
+	job := db.Job{ID: "hdr", Type: "ask", Agent: "modeled", WorkflowID: "wf"}
+	h := transcriptHeader(context.Background(), store, job, workflow.JobPayload{Model: "gpt-5.4", Instructions: "prompt text"}, runtime.CodexRuntime)
+	if h.Model != "gpt-5.4" || h.Action != "ask" || h.Workflow != "wf" || h.Prompt != "prompt text" {
+		t.Fatalf("override header = %+v", h)
+	}
+	h = transcriptHeader(context.Background(), store, job, workflow.JobPayload{}, runtime.CodexRuntime)
+	if h.Model != "gpt-5.5" {
+		t.Fatalf("registry model = %q, want gpt-5.5", h.Model)
+	}
+	eph := db.Job{ID: "hdr2", Type: "ask", Agent: "no-row"}
+	h = transcriptHeader(context.Background(), store, eph, workflow.JobPayload{}, runtime.KimiRuntime)
+	if h.Model != "" {
+		t.Fatalf("ephemeral model = %q, want empty", h.Model)
 	}
 }

--- a/internal/transcript/render.go
+++ b/internal/transcript/render.go
@@ -193,3 +193,59 @@ func truncateUTF8(value string, limit int) string {
 	}
 	return value
 }
+
+// headerPromptLimit caps how much of the job prompt the transcript header
+// shows; the full prompt lives on the job payload, the header is orientation.
+const headerPromptLimit = 400
+
+// Header describes the job a transcript belongs to. It renders once, before
+// the event stream, so a pane (or a saved plain transcript) is self-describing.
+type Header struct {
+	Action   string
+	Agent    string
+	Runtime  string
+	Model    string
+	Workflow string
+	Prompt   string
+}
+
+// RenderHeader writes the job orientation block: one metadata line, then the
+// redacted, capped prompt, then a separating blank line. Styled mode dims the
+// metadata and truncation marker so the prompt reads as the lead.
+func (r *Renderer) RenderHeader(h Header) error {
+	meta := "▶ " + h.Action + " · " + h.Agent + " · " + h.Runtime
+	if h.Model != "" {
+		meta += "/" + h.Model
+	}
+	if h.Workflow != "" {
+		meta += " · workflow " + h.Workflow
+	}
+	prompt := cleanField(h.Prompt, headerPromptLimit)
+	marker := ""
+	if over := len(workflow.RedactCommentText(h.Prompt)) - len(prompt); over > 0 {
+		marker = fmt.Sprintf("… (+%d more chars)", over)
+	}
+	var out string
+	if r.styled {
+		out = sgrDim + meta + sgrReset + "\n"
+		if prompt != "" {
+			out += "  " + prompt
+			if marker != "" {
+				out += " " + sgrDim + marker + sgrReset
+			}
+			out += "\n"
+		}
+	} else {
+		out = meta + "\n"
+		if prompt != "" {
+			out += "  " + prompt
+			if marker != "" {
+				out += " " + marker
+			}
+			out += "\n"
+		}
+	}
+	r.wroteAny = true
+	_, err := fmt.Fprintln(r.w, out)
+	return err
+}

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -480,3 +480,53 @@ func TestFormatTokens(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderHeaderPlainAndStyled(t *testing.T) {
+	full := Header{Action: "ask", Agent: "planner", Runtime: "codex", Model: "gpt-5.5", Workflow: "demo", Prompt: "do the thing"}
+	var plain bytes.Buffer
+	if err := NewRenderer(&plain).RenderHeader(full); err != nil {
+		t.Fatal(err)
+	}
+	want := "▶ ask · planner · codex/gpt-5.5 · workflow demo\n  do the thing\n\n"
+	if plain.String() != want {
+		t.Fatalf("plain header = %q, want %q", plain.String(), want)
+	}
+
+	var bare bytes.Buffer
+	if err := NewRenderer(&bare).RenderHeader(Header{Action: "review", Agent: "a", Runtime: "shell"}); err != nil {
+		t.Fatal(err)
+	}
+	if bare.String() != "▶ review · a · shell\n\n" {
+		t.Fatalf("bare header = %q", bare.String())
+	}
+
+	var styled bytes.Buffer
+	if err := NewStyledRenderer(&styled).RenderHeader(full); err != nil {
+		t.Fatal(err)
+	}
+	out := styled.String()
+	if !strings.Contains(out, "\x1b[90m▶ ask · planner · codex/gpt-5.5 · workflow demo\x1b[0m") {
+		t.Fatalf("styled meta not dim: %q", out)
+	}
+	if !strings.Contains(out, "\n  do the thing\n") {
+		t.Fatalf("styled prompt missing: %q", out)
+	}
+}
+
+func TestRenderHeaderTruncatesAndRedactsPrompt(t *testing.T) {
+	long := "token=ghp_1234567890abcdefghijklmnopqrstuvwxyz " + strings.Repeat("x", 600)
+	var got bytes.Buffer
+	if err := NewRenderer(&got).RenderHeader(Header{Action: "ask", Agent: "a", Runtime: "codex", Prompt: long}); err != nil {
+		t.Fatal(err)
+	}
+	out := got.String()
+	if strings.Contains(out, "ghp_") {
+		t.Fatalf("secret leaked into header: %q", out)
+	}
+	if !strings.Contains(out, "more chars)") {
+		t.Fatalf("missing truncation marker: %q", out)
+	}
+	if len(out) > headerPromptLimit+200 {
+		t.Fatalf("header too long: %d bytes", len(out))
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1167,6 +1167,11 @@ their line breaks, tool names are bold with dim argument digests, completed
 machinery and usage render dim, and failed tool results render red. Piped or
 redirected output always uses the plain byte-stable format.
 
+Every transcript opens with an orientation header — job action, agent,
+runtime/model (per-job override first, then the agent default), workflow label,
+and the redacted, length-capped prompt — so a pane or saved transcript is
+self-describing.
+
 `job watch --transcript` follows a cockpit tee log from offset zero and renders
 redacted, bounded human-readable runtime output until the job settles, then
 drains the file to EOF. It is incompatible with `--json`. Without `--log-path`,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1017,6 +1017,11 @@ their line breaks, tool names are bold with dim argument digests, completed
 machinery and usage render dim, and failed tool results render red. Piped or
 redirected output always uses the plain byte-stable format.
 
+Every transcript opens with an orientation header — job action, agent,
+runtime/model (per-job override first, then the agent default), workflow label,
+and the redacted, length-capped prompt — so a pane or saved transcript is
+self-describing.
+
 `job watch --transcript` follows a cockpit tee log from offset zero and renders
 redacted, bounded human-readable runtime output until the job settles, then
 drains the file to EOF. It is incompatible with `--json`. Without `--log-path`,


### PR DESCRIPTION
Panes (and saved plain transcripts) now open with what was asked and who's answering:

```
▶ ask · gitmoot-readme-planner · codex/gpt-5.5 · workflow demo-transcript
  STYLED PANE SHOWCASE — run these read-only commands ONE AT A TIME… (+612 more chars)

● I'll run the requested commands…
```

- Data comes from the job row/payload `job watch --transcript` already loads — no daemon/log-format/translator changes.
- Model resolution mirrors dispatch: per-job `--model` override → agent registered default → omitted (never guessed).
- Prompt is redacted **before** the 400-char cap, with an honest `… (+N more chars)` marker; metadata line renders dim in styled mode.
- Tests: plain+styled header goldens, redaction/truncation, model-resolution order (override/registry/ephemeral); the existing exact-output shell E2E updated for the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)