### PR TITLE
chore(website): regenerate llms-full.txt for #908 header docs

### DIFF
--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10297,6 +10297,11 @@ their line breaks, tool names are bold with dim argument digests, completed
 machinery and usage render dim, and failed tool results render red. Piped or
 redirected output always uses the plain byte-stable format.
 
+Every transcript opens with an orientation header — job action, agent,
+runtime/model (per-job override first, then the agent default), workflow label,
+and the redacted, length-capped prompt — so a pane or saved transcript is
+self-describing.
+
 `job watch --transcript` follows a cockpit tee log from offset zero and renders
 redacted, bounded human-readable runtime output until the job settles, then
 drains the file to EOF. It is incompatible with `--json`. Without `--log-path`,


### PR DESCRIPTION
Generated-artifact sync (content already deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)