### PR TITLE
feat(workflow): task dismiss + task_events trail + stale-task auto-reconcile (#913)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -78,9 +78,11 @@ job, rather than silently discard the work, and point at `task recover <id>
 --owner <agent>`. `task recover` commits the full worktree state (`git add -A`,
 including untracked non-ignored files), pushes the branch, and opens or adopts
 the task's PR — the finalize steps the dead implementer never reached. `--repo`
-is optional (it falls back to the task's stored repo). Recovery refuses while a
-live process is still inside the task worktree; wait for it to exit or stop the
-orphaned implementer first.
+is optional (it falls back to the task's stored repo). `--owner` is required for
+this artifact-finalization path, while a dismissed task with no branch can be
+restored to `planned` without it. Recovery refuses while a live process is still
+inside the task worktree; wait for it to exit or stop the orphaned implementer
+first.
 
 `task dismiss` is the explicit terminal action for an abandoned
 `implementing` or `blocked` task. It refuses while a matching job or worktree
@@ -88,8 +90,8 @@ process is live, preserves the branch and worktree, releases the branch lock
 best-effort, and records `task_dismissed_manual`. The daemon can record
 `task_dismissed_auto` for stale candidates using `updated_at` as a conservative
 activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
-set it to `"0"` to disable this poll leg. Candidates with an open PR, a remote
-branch, a live job, or an uncertain remote check are not dismissed.
+set it to `"0"` to disable this poll leg. Candidates with a same-repo open PR,
+a remote branch, a live job, or an uncertain remote check are not dismissed.
 
 Dismissed tasks never return to implementation through ordinary task run,
 allocation, or late workflow advancement. `task recover` is the explicit path:

--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -48,6 +48,8 @@ gitmoot agent doctor <name>
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task recover task-001 --owner lead   # finalize a dead implement's dirty worktree
+gitmoot task dismiss task-001 --reason "abandoned experiment"
+gitmoot task events task-001 --json
 gitmoot task list --repo owner/repo
 gitmoot job list
 gitmoot job show <job-id>
@@ -79,6 +81,21 @@ the task's PR — the finalize steps the dead implementer never reached. `--repo
 is optional (it falls back to the task's stored repo). Recovery refuses while a
 live process is still inside the task worktree; wait for it to exit or stop the
 orphaned implementer first.
+
+`task dismiss` is the explicit terminal action for an abandoned
+`implementing` or `blocked` task. It refuses while a matching job or worktree
+process is live, preserves the branch and worktree, releases the branch lock
+best-effort, and records `task_dismissed_manual`. The daemon can record
+`task_dismissed_auto` for stale candidates using `updated_at` as a conservative
+activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
+set it to `"0"` to disable this poll leg. Candidates with an open PR, a remote
+branch, a live job, or an uncertain remote check are not dismissed.
+
+Dismissed tasks never return to implementation through ordinary task run,
+allocation, or late workflow advancement. `task recover` is the explicit path:
+preserved branch/worktree artifacts move through `implementing` to `pr_open`,
+while a branchless task returns to `planned` with task-run guidance. Inspect the
+full audit trail with `task events`.
 
 ## Runtime Plugin Setup
 

--- a/internal/cli/agent_action_fixpass_793_test.go
+++ b/internal/cli/agent_action_fixpass_793_test.go
@@ -437,10 +437,38 @@ func TestTaskRecoverPredicateStillRejectsPullRequestOpen(t *testing.T) {
 	if taskBranchReusableForImplement(string(workflow.TaskPullRequestOpen)) {
 		t.Fatal("shared task recover/implement predicate was widened to pr_open")
 	}
+	if taskBranchReusableForImplement(string(workflow.TaskDismissed)) {
+		t.Fatal("shared implement branch-reuse predicate was widened to dismissed")
+	}
 	fixture := newFixPassFixture(t, workflow.TaskPullRequestOpen)
 	_, err := recoverTaskImplementation(context.Background(), fixture.store, fixture.task.ID, fixture.repo.FullName(), fixture.owner, false, github.NoopClient{})
 	if err == nil || !strings.Contains(err.Error(), "task recover only supports active implementation states") {
 		t.Fatalf("task recover error = %v, want unchanged pr_open refusal", err)
+	}
+}
+
+func TestTaskRecoverableStateIncludesDismissedWithoutWideningImplementReuse(t *testing.T) {
+	tests := []struct {
+		state string
+		want  bool
+	}{
+		{state: "", want: true},
+		{state: string(workflow.TaskPlanned), want: true},
+		{state: string(workflow.TaskImplementing), want: true},
+		{state: string(workflow.TaskChangesRequested), want: true},
+		{state: string(workflow.TaskBlocked), want: true},
+		{state: string(workflow.TaskAwaitingHuman), want: true},
+		{state: string(workflow.TaskDismissed), want: true},
+		{state: string(workflow.TaskPullRequestOpen)},
+		{state: string(workflow.TaskReviewing)},
+		{state: string(workflow.TaskReadyToMerge)},
+		{state: string(workflow.TaskMerged)},
+		{state: "future"},
+	}
+	for _, test := range tests {
+		if got := taskRecoverableState(test.state); got != test.want {
+			t.Fatalf("taskRecoverableState(%q) = %v, want %v", test.state, got, test.want)
+		}
 	}
 }
 

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -613,16 +613,21 @@ func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.
 		return localAgentDispatchRequest{}, "", errors.New("agent review requires a pull request head SHA")
 	}
 	if strings.TrimSpace(request.Branch) != "" {
-		if task, err := store.GetTaskByRepoBranch(ctx, repo.FullName(), request.Branch); err == nil && strings.TrimSpace(task.WorktreePath) != "" {
-			head, headErr := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
-			if headErr != nil {
-				return localAgentDispatchRequest{}, "", headErr
+		if task, err := store.GetTaskByRepoBranch(ctx, repo.FullName(), request.Branch); err == nil {
+			if task.State == string(workflow.TaskDismissed) {
+				return localAgentDispatchRequest{}, "", dismissedReviewTaskError(task.ID)
 			}
-			if head == request.HeadSHA {
-				request.TaskID = task.ID
-				request.GoalID = firstNonEmpty(request.GoalID, task.GoalID)
-				request.TaskTitle = firstNonEmpty(request.TaskTitle, task.Title)
-				return request, task.WorktreePath, nil
+			if strings.TrimSpace(task.WorktreePath) != "" {
+				head, headErr := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
+				if headErr != nil {
+					return localAgentDispatchRequest{}, "", headErr
+				}
+				if head == request.HeadSHA {
+					request.TaskID = task.ID
+					request.GoalID = firstNonEmpty(request.GoalID, task.GoalID)
+					request.TaskTitle = firstNonEmpty(request.TaskTitle, task.Title)
+					return request, task.WorktreePath, nil
+				}
 			}
 		} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return localAgentDispatchRequest{}, "", err
@@ -635,6 +640,13 @@ func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.
 	taskID := strings.TrimSpace(request.TaskID)
 	if taskID == "" {
 		taskID = fmt.Sprintf("review-pr-%d-%s", request.PullRequest, shortHash(repo.FullName()+"\x00"+request.HeadSHA))
+	}
+	if existing, err := store.GetTask(ctx, taskID); err == nil {
+		if existing.State == string(workflow.TaskDismissed) {
+			return localAgentDispatchRequest{}, "", dismissedReviewTaskError(existing.ID)
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return localAgentDispatchRequest{}, "", err
 	}
 	path, err := workflow.TaskWorktreePath(paths.Home, repo.FullName(), taskID)
 	if err != nil {
@@ -662,13 +674,21 @@ func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.
 		State:        string(workflow.TaskReviewing),
 		WorktreePath: path,
 	}
-	if err := store.UpsertTask(ctx, task); err != nil {
+	updated, err := store.UpsertTaskUnlessState(ctx, task, string(workflow.TaskDismissed))
+	if err != nil {
 		return localAgentDispatchRequest{}, "", err
+	}
+	if !updated {
+		return localAgentDispatchRequest{}, "", dismissedReviewTaskError(task.ID)
 	}
 	request.TaskID = task.ID
 	request.GoalID = task.GoalID
 	request.TaskTitle = task.Title
 	return request, path, nil
+}
+
+func dismissedReviewTaskError(taskID string) error {
+	return fmt.Errorf("task %s is dismissed; run task recover first", taskID)
 }
 
 func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, record db.Repo, repo github.Repository, request localAgentDispatchRequest) (db.Task, localAgentDispatchRequest, error) {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -861,6 +861,101 @@ func TestPrepareLocalReviewDispatchRequestDoesNotReuseStaleReviewWorktree(t *tes
 	}
 }
 
+func TestPrepareLocalReviewWorktreeRejectsDismissedTask(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		task       db.Task
+		setRequest func(*localAgentDispatchRequest)
+	}{
+		{
+			name: "matching head worktree",
+			task: db.Task{ID: "dismissed-by-branch", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed), Branch: "feature/review"},
+			setRequest: func(request *localAgentDispatchRequest) {
+				request.Branch = "feature/review"
+			},
+		},
+		{
+			name: "requested task upsert",
+			task: db.Task{ID: "dismissed-by-id", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed)},
+			setRequest: func(request *localAgentDispatchRequest) {
+				request.TaskID = "dismissed-by-id"
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			home := t.TempDir()
+			repoDir := t.TempDir()
+			runGit(t, repoDir, "init")
+			runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+			runGit(t, repoDir, "config", "user.name", "Gitmoot")
+			writeFile(t, filepath.Join(repoDir, "README.md"), "review\n")
+			runGit(t, repoDir, "add", "README.md")
+			runGit(t, repoDir, "commit", "-m", "review head")
+			head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.task.WorktreePath = repoDir
+			store := openCLIJobStore(t, home)
+			defer store.Close()
+			if err := store.UpsertTask(ctx, test.task); err != nil {
+				t.Fatal(err)
+			}
+			request := localAgentDispatchRequest{Home: home, PullRequest: 12, HeadSHA: head}
+			test.setRequest(&request)
+			_, _, err = prepareLocalReviewWorktree(ctx, store,
+				db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir},
+				github.Repository{Owner: "owner", Name: "repo"}, request)
+			if err == nil || !strings.Contains(err.Error(), "task "+test.task.ID+" is dismissed") || !strings.Contains(err.Error(), "task recover") {
+				t.Fatalf("prepareLocalReviewWorktree error = %v", err)
+			}
+			stored, getErr := store.GetTask(ctx, test.task.ID)
+			if getErr != nil || stored.State != string(workflow.TaskDismissed) {
+				t.Fatalf("stored task=%+v err=%v", stored, getErr)
+			}
+		})
+	}
+}
+
+func TestPrepareLocalReviewWorktreeReusesNonDismissedMatchingHead(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "review\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "review head")
+	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "reviewing-task", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Review",
+		State: string(workflow.TaskReviewing), Branch: "feature/review", WorktreePath: repoDir,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request, checkout, err := prepareLocalReviewWorktree(ctx, store,
+		db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir},
+		github.Repository{Owner: "owner", Name: "repo"},
+		localAgentDispatchRequest{Home: home, PullRequest: 12, Branch: "feature/review", HeadSHA: head})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.TaskID != "reviewing-task" || request.GoalID != "goal-1" || request.TaskTitle != "Review" || checkout != repoDir {
+		t.Fatalf("request=%+v checkout=%q", request, checkout)
+	}
+	task, err := store.GetTask(ctx, "reviewing-task")
+	if err != nil || task.State != string(workflow.TaskReviewing) {
+		t.Fatalf("task=%+v err=%v", task, err)
+	}
+}
+
 func TestPrepareLocalImplementDispatchRequestReusesExistingBranchTask(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -6768,6 +6768,9 @@ func blockTaskForPermissionBlockedJob(ctx context.Context, store *db.Store, job 
 		return err
 	}
 	if err == nil {
+		if existing.State == string(workflow.TaskDismissed) {
+			return fmt.Errorf("task %s is dismissed; permission-blocked job cannot resurrect it", existing.ID)
+		}
 		if task.RepoFullName == "" {
 			task.RepoFullName = existing.RepoFullName
 		}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -6825,6 +6825,26 @@ func TestTaskWorktreeCheckoutPrefersDelegationPayloadWorktree(t *testing.T) {
 	}
 }
 
+func TestPermissionBlockedJobCannotResurrectDismissedTask(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed), Branch: "feature/one"}); err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(workflow.JobPayload{TaskID: "task-1", Repo: "owner/repo", Branch: "feature/one"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = blockTaskForPermissionBlockedJob(ctx, store, db.Job{ID: "job-1", Payload: string(payload)})
+	if err == nil || !strings.Contains(err.Error(), "dismissed") {
+		t.Fatalf("blockTaskForPermissionBlockedJob error = %v", err)
+	}
+	task, _ := store.GetTask(ctx, "task-1")
+	if task.State != string(workflow.TaskDismissed) {
+		t.Fatalf("task resurrected to %s", task.State)
+	}
+}
+
 func TestRunQueuedJobsFansOutDelegationsAndEnqueuesContinuation(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)

--- a/internal/cli/dashboard_web_changes.go
+++ b/internal/cli/dashboard_web_changes.go
@@ -11,13 +11,13 @@ import (
 // uses it only as an invalidation signal; page data still comes from the normal
 // read-only endpoints.
 func (d *webDataSource) ChangeCursor(ctx context.Context) (string, error) {
-	cursor := "0.0"
+	cursor := "0.0.0"
 	err := withStore(d.home, func(store *db.Store) error {
-		jobEventID, workflowNoteID, err := store.DashboardChangeCursor(ctx)
+		jobEventID, workflowNoteID, taskEventID, err := store.DashboardChangeCursor(ctx)
 		if err != nil {
 			return err
 		}
-		cursor = fmt.Sprintf("%d.%d", jobEventID, workflowNoteID)
+		cursor = fmt.Sprintf("%d.%d.%d", jobEventID, workflowNoteID, taskEventID)
 		return nil
 	})
 	return cursor, err

--- a/internal/cli/dashboard_web_changes_test.go
+++ b/internal/cli/dashboard_web_changes_test.go
@@ -23,8 +23,8 @@ func TestWebDataSourceChangeCursor(t *testing.T) {
 			t.Fatalf("ChangeCursor = %q, want %q", got, want)
 		}
 	}
-	assertCursor("0.0")
-	assertCursor("0.0")
+	assertCursor("0.0.0")
+	assertCursor("0.0.0")
 
 	store, err := db.Open(config.PathsForHome(home).Database)
 	if err != nil {
@@ -37,7 +37,7 @@ func TestWebDataSourceChangeCursor(t *testing.T) {
 		t.Fatalf("CreateJobWithEvent: %v", err)
 	}
 	store.Close()
-	assertCursor("1.0")
+	assertCursor("1.0.0")
 
 	store, err = db.Open(config.PathsForHome(home).Database)
 	if err != nil {
@@ -48,6 +48,21 @@ func TestWebDataSourceChangeCursor(t *testing.T) {
 		t.Fatalf("InsertWorkflowNote: %v", err)
 	}
 	store.Close()
-	assertCursor("1.1")
-	assertCursor("1.1")
+	assertCursor("1.1.0")
+
+	store, err = db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("reopen for task event: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", State: "implementing"}); err != nil {
+		store.Close()
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	if err := store.AddTaskEvent(ctx, db.TaskEvent{TaskID: "task-1", Kind: "task_dismissed_manual"}); err != nil {
+		store.Close()
+		t.Fatalf("AddTaskEvent: %v", err)
+	}
+	store.Close()
+	assertCursor("1.1.1")
+	assertCursor("1.1.1")
 }

--- a/internal/cli/dashboard_web_overview.go
+++ b/internal/cli/dashboard_web_overview.go
@@ -98,7 +98,7 @@ func dashboardTasks(ctx context.Context, store *db.Store, now time.Time) ([]dash
 
 func dashboardTaskState(state string) (stateName, blockedReason string, ok bool) {
 	switch strings.TrimSpace(state) {
-	case "planned":
+	case "planned", "dismissed":
 		return "", "", false
 	case "implementing":
 		return "implementing", "", true

--- a/internal/cli/dashboard_web_overview_test.go
+++ b/internal/cli/dashboard_web_overview_test.go
@@ -264,6 +264,7 @@ func TestDashboardTaskStateFiltersUnsupportedStates(t *testing.T) {
 		ok                      bool
 	}{
 		{internal: "planned"},
+		{internal: "dismissed"},
 		{internal: "future_state"},
 		{internal: "implementing", state: "implementing", ok: true},
 		{internal: "pr_open", state: "pr_open", ok: true},

--- a/internal/cli/task_dismiss_shell_e2e_test.go
+++ b/internal/cli/task_dismiss_shell_e2e_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/daemon"
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+type shellDismissE2EGitHub struct{ stubTaskRecoverGitHub }
+
+func (*shellDismissE2EGitHub) ListPullRequests(context.Context, github.Repository, string) ([]github.PullRequest, error) {
+	return nil, nil
+}
+
+func (*shellDismissE2EGitHub) ListIssueComments(context.Context, github.Repository, int64) ([]github.IssueComment, error) {
+	return nil, nil
+}
+
+type shellDismissE2ERemote struct{ calls int }
+
+func (r *shellDismissE2ERemote) RemoteBranches(context.Context, string, []string) (map[string]struct{}, error) {
+	r.calls++
+	return map[string]struct{}{}, nil
+}
+
+func TestNoLLMShellTaskDismissAndRecoverE2E(t *testing.T) {
+	t.Setenv("HERDR_SOCKET_PATH", "/tmp/throwaway.sock")
+	oldHerdr, hadHerdr := os.LookupEnv("HERDR_ENV")
+	if err := os.Unsetenv("HERDR_ENV"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if hadHerdr {
+			_ = os.Setenv("HERDR_ENV", oldHerdr)
+		} else {
+			_ = os.Unsetenv("HERDR_ENV")
+		}
+	})
+
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "origin.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	// task run validates a GitHub-shaped registered remote; switch back to the
+	// local bare origin immediately after allocation so every push stays local.
+	runGit(t, repoDir, "remote", "set-url", "origin", "https://github.com/owner/repo.git")
+	withWorkingDirectory(t, repoDir)
+
+	goal := filepath.Join(home, "GOAL.md")
+	writeFile(t, goal, "# E2E\n\n### Task 1: Bootstrap\n")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"goal", "import", "--home", home, "--file", goal, "--repo", "owner/repo"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("goal import code=%d stderr=%s", code, stderr.String())
+	}
+	subscribeShellImplementAgent(t, home, "lead", "owner/repo")
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"task", "run", "task-001", "--home", home, "--repo", "owner/repo", "--owner", "lead"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("task run code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	runGit(t, repoDir, "remote", "set-url", "origin", remoteDir)
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	task, err := store.GetTask(ctx, "task-001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(task.WorktreePath, "partial.txt"), "recover me\n")
+	jobID := taskRunImplementJobID(task.ID, "lead")
+	if ok, err := store.TransitionJobStateWithEvent(ctx, jobID, string(workflow.JobQueued), string(workflow.JobRunning), db.JobEvent{Kind: string(workflow.JobRunning), Message: "shell stub started"}); err != nil || !ok {
+		t.Fatalf("mark running ok=%v err=%v", ok, err)
+	}
+	if _, err := workflow.CancelJob(ctx, store, jobID); err != nil {
+		t.Fatal(err)
+	}
+	if settled, err := workflow.SettleCancelledRunningJob(ctx, store, jobID, "shell stub settled"); err != nil || !settled {
+		t.Fatalf("settle cancelled settled=%v err=%v", settled, err)
+	}
+
+	configPath := filepath.Join(home, ".gitmoot", "config.toml")
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content = append(content, []byte("\n[workflow]\nstale_task_ttl = \"1ns\"\n")...)
+	if err := os.WriteFile(configPath, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	gh := &shellDismissE2EGitHub{}
+	remote := &shellDismissE2ERemote{}
+	d := daemon.Daemon{
+		Repo:           github.Repository{Owner: "owner", Name: "repo"},
+		Store:          store,
+		GitHub:         gh,
+		RemoteBranches: remote,
+		Now:            func() time.Time { return time.Now().UTC().Add(time.Hour) },
+	}
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	task, _ = store.GetTask(ctx, task.ID)
+	if task.State != string(workflow.TaskDismissed) || remote.calls != 1 {
+		t.Fatalf("after reconcile task=%+v remote calls=%d", task, remote.calls)
+	}
+	events, _ := store.ListTaskEvents(ctx, task.ID)
+	if len(events) != 1 || events[0].Kind != "task_dismissed_auto" {
+		t.Fatalf("auto events=%+v", events)
+	}
+
+	if _, err := recoverTaskImplementation(ctx, store, task.ID, "owner/repo", "lead", false, gh); err != nil {
+		t.Fatalf("task recover: %v", err)
+	}
+	task, _ = store.GetTask(ctx, task.ID)
+	events, _ = store.ListTaskEvents(ctx, task.ID)
+	if task.State != string(workflow.TaskPullRequestOpen) || len(events) != 3 || events[1].ToState != string(workflow.TaskImplementing) || events[2].ToState != string(workflow.TaskPullRequestOpen) {
+		t.Fatalf("recovered task=%+v events=%+v", task, events)
+	}
+}

--- a/internal/cli/task_dismiss_shell_e2e_test.go
+++ b/internal/cli/task_dismiss_shell_e2e_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -125,8 +126,54 @@ func TestNoLLMShellTaskDismissAndRecoverE2E(t *testing.T) {
 		t.Fatalf("auto events=%+v", events)
 	}
 
-	if _, err := recoverTaskImplementation(ctx, store, task.ID, "owner/repo", "lead", false, gh); err != nil {
-		t.Fatalf("task recover: %v", err)
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"task", "events", task.ID, "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("task events code=%d stderr=%s", code, stderr.String())
+	}
+	var autoEvents []db.TaskEvent
+	if err := json.Unmarshal(stdout.Bytes(), &autoEvents); err != nil || len(autoEvents) != 1 || autoEvents[0].Kind != "task_dismissed_auto" {
+		t.Fatalf("task events output=%s events=%+v err=%v", stdout.String(), autoEvents, err)
+	}
+
+	if err := store.UpsertTask(ctx, db.Task{ID: "manual-e2e", RepoFullName: "owner/repo", State: string(workflow.TaskBlocked)}); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"task", "dismiss", "manual-e2e", "--home", home, "--reason", "e2e manual", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("task dismiss code=%d stderr=%s", code, stderr.String())
+	}
+	var dismissed taskDismissOutput
+	if err := json.Unmarshal(stdout.Bytes(), &dismissed); err != nil || !dismissed.Changed || dismissed.State != string(workflow.TaskDismissed) || dismissed.Reason != "e2e manual" {
+		t.Fatalf("task dismiss output=%s decoded=%+v err=%v", stdout.String(), dismissed, err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"task", "events", "manual-e2e", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("manual task events code=%d stderr=%s", code, stderr.String())
+	}
+	var manualEvents []db.TaskEvent
+	if err := json.Unmarshal(stdout.Bytes(), &manualEvents); err != nil || len(manualEvents) != 1 || manualEvents[0].Kind != "task_dismissed_manual" {
+		t.Fatalf("manual task events output=%s decoded=%+v err=%v", stdout.String(), manualEvents, err)
+	}
+
+	// The CLI finalizer adopts an existing local PR record, keeping this E2E
+	// entirely offline while still exercising the real recovery command.
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo", Number: 4, URL: "https://github.com/owner/repo/pull/4",
+		HeadBranch: task.Branch, BaseBranch: "main", State: "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"task", "recover", task.ID, "--home", home, "--repo", "owner/repo", "--owner", "lead", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("task recover code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var recovered taskRecoverOutput
+	if err := json.Unmarshal(stdout.Bytes(), &recovered); err != nil || recovered.TaskID != task.ID || recovered.State != string(workflow.TaskPullRequestOpen) || recovered.PullRequest != 4 || recovered.HeadSHA == "" {
+		t.Fatalf("task recover output=%s decoded=%+v err=%v", stdout.String(), recovered, err)
 	}
 	task, _ = store.GetTask(ctx, task.ID)
 	events, _ = store.ListTaskEvents(ctx, task.ID)

--- a/internal/cli/task_dismiss_test.go
+++ b/internal/cli/task_dismiss_test.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+func TestTaskDismissPredicateFailsClosed(t *testing.T) {
+	tests := []struct {
+		state string
+		want  bool
+	}{
+		{state: ""},
+		{state: string(workflow.TaskPlanned)},
+		{state: string(workflow.TaskImplementing), want: true},
+		{state: string(workflow.TaskPullRequestOpen)},
+		{state: string(workflow.TaskReviewing)},
+		{state: string(workflow.TaskChangesRequested)},
+		{state: string(workflow.TaskReadyToMerge)},
+		{state: string(workflow.TaskMerged)},
+		{state: string(workflow.TaskBlocked), want: true},
+		{state: string(workflow.TaskAwaitingHuman)},
+		{state: string(workflow.TaskDismissed)},
+		{state: "future"},
+	}
+	for _, test := range tests {
+		if got := taskDismissibleState(test.state); got != test.want {
+			t.Fatalf("taskDismissibleState(%q) = %v, want %v", test.state, got, test.want)
+		}
+	}
+}
+
+func TestRunTaskDismissAllowedStatesJSONLockAndEvents(t *testing.T) {
+	for _, state := range []workflow.TaskState{workflow.TaskImplementing, workflow.TaskBlocked} {
+		t.Run(string(state), func(t *testing.T) {
+			home := t.TempDir()
+			store := openCLIJobStore(t, home)
+			defer store.Close()
+			worktree := filepath.Join(home, "preserved-worktree")
+			task := db.Task{ID: "task-1", RepoFullName: "owner/repo", State: string(state), Branch: "feature/one", WorktreePath: worktree}
+			if err := store.UpsertTask(context.Background(), task); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := store.CreateLock(context.Background(), db.BranchLock{RepoFullName: task.RepoFullName, Branch: task.Branch, Owner: "worker"}); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"task", "dismiss", task.ID, "--home", home, "--json"}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("code=%d stderr=%s", code, stderr.String())
+			}
+			var output taskDismissOutput
+			if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+				t.Fatalf("decode %q: %v", stdout.String(), err)
+			}
+			if output.TaskID != task.ID || output.PreviousState != string(state) || output.State != string(workflow.TaskDismissed) || output.Source != "manual" || output.Reason != "dismissed by operator" || !output.Changed {
+				t.Fatalf("output = %+v", output)
+			}
+			stored, _ := store.GetTask(context.Background(), task.ID)
+			if stored.State != string(workflow.TaskDismissed) || stored.Branch != task.Branch || stored.WorktreePath != worktree {
+				t.Fatalf("stored task = %+v", stored)
+			}
+			if _, err := store.GetBranchLock(context.Background(), task.RepoFullName, task.Branch); !errors.Is(err, sql.ErrNoRows) {
+				t.Fatalf("lock still present: %v", err)
+			}
+			events, _ := store.ListTaskEvents(context.Background(), task.ID)
+			if len(events) != 1 || events[0].Kind != "task_dismissed_manual" || events[0].Reason != "dismissed by operator" {
+				t.Fatalf("events = %+v", events)
+			}
+
+			stdout.Reset()
+			stderr.Reset()
+			code = Run([]string{"task", "dismiss", task.ID, "--home", home, "--reason", "ignored", "--json"}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("idempotent code=%d stderr=%s", code, stderr.String())
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &output); err != nil || output.Changed {
+				t.Fatalf("idempotent output=%+v err=%v", output, err)
+			}
+			events, _ = store.ListTaskEvents(context.Background(), task.ID)
+			if len(events) != 1 {
+				t.Fatalf("idempotent events = %+v", events)
+			}
+
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run([]string{"task", "events", task.ID, "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+				t.Fatalf("events code=%d stderr=%s", code, stderr.String())
+			}
+			var listed []db.TaskEvent
+			if err := json.Unmarshal(stdout.Bytes(), &listed); err != nil || len(listed) != 1 || listed[0].Kind != "task_dismissed_manual" {
+				t.Fatalf("listed=%+v err=%v", listed, err)
+			}
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run([]string{"task", "events", task.ID, "--home", home}, &stdout, &stderr); code != 0 {
+				t.Fatalf("plain events code=%d stderr=%s", code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "task_dismissed_manual") || !strings.Contains(stdout.String(), "dismissed by operator") {
+				t.Fatalf("plain events output=%q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestRunTaskDismissRefusesOwnedStates(t *testing.T) {
+	states := []string{
+		"", string(workflow.TaskPlanned), string(workflow.TaskPullRequestOpen),
+		string(workflow.TaskReviewing), string(workflow.TaskChangesRequested),
+		string(workflow.TaskReadyToMerge), string(workflow.TaskMerged),
+		string(workflow.TaskAwaitingHuman), "future",
+	}
+	for _, state := range states {
+		name := state
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			home := t.TempDir()
+			store := openCLIJobStore(t, home)
+			if err := store.UpsertTask(context.Background(), db.Task{ID: "task-1", State: state}); err != nil {
+				t.Fatal(err)
+			}
+			store.Close()
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"task", "dismiss", "task-1", "--home", home}, &stdout, &stderr); code != 1 {
+				t.Fatalf("code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stderr.String(), "only supports implementing or blocked") || !strings.Contains(stderr.String(), "owned by") {
+				t.Fatalf("stderr = %s", stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunTaskDismissRefusesLiveJobAndWorktreeProcess(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		liveJob     bool
+		liveProcess bool
+		want        string
+	}{
+		{name: "live job", liveJob: true, want: "live job job-1"},
+		{name: "live process", liveProcess: true, want: "live process"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			store := openCLIJobStore(t, home)
+			worktree := filepath.Join(home, "worktree")
+			task := db.Task{ID: "task-1", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing), Branch: "feature/one", WorktreePath: worktree}
+			if err := store.UpsertTask(context.Background(), task); err != nil {
+				t.Fatal(err)
+			}
+			if test.liveJob {
+				payload, _ := json.Marshal(workflow.JobPayload{TaskID: task.ID})
+				if err := store.CreateJob(context.Background(), db.Job{ID: "job-1", Type: "ask", State: string(workflow.JobQueued), Payload: string(payload)}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			store.Close()
+			previous := taskWorktreeHasLiveProcess
+			if test.liveProcess {
+				taskWorktreeHasLiveProcess = func(path string) bool { return path == worktree }
+			}
+			defer func() { taskWorktreeHasLiveProcess = previous }()
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"task", "dismiss", task.ID, "--home", home}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), test.want) {
+				t.Fatalf("code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunTaskRunRejectsDismissedTask(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-1", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed), Branch: "feature/one"}); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"task", "run", "task-1", "--home", home, "--repo", "owner/repo", "--owner", "lead"}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "dismissed") || !strings.Contains(stderr.String(), "task recover") {
+		t.Fatalf("code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+}

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -268,7 +268,7 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>]")
-	fmt.Fprintln(w, "  gitmoot task recover <id> --owner <agent> [--repo owner/repo] [--skip-native-review-fanout] [--json]")
+	fmt.Fprintln(w, "  gitmoot task recover <id> [--owner <agent>] [--repo owner/repo] [--skip-native-review-fanout] [--json]")
 	fmt.Fprintln(w, "  gitmoot task dismiss <id> [--reason text] [--json]")
 	fmt.Fprintln(w, "  gitmoot task events <id> [--json]")
 	fmt.Fprintln(w, "  gitmoot task list [--repo owner/repo] [--state state] [--json]")
@@ -557,10 +557,13 @@ func runTaskDismiss(args []string, stdout, stderr io.Writer) int {
 		if strings.TrimSpace(task.WorktreePath) != "" && taskWorktreeHasLiveProcess(task.WorktreePath) {
 			return fmt.Errorf("task %s worktree %s still has a live process; wait for it to exit or stop it before dismissing", task.ID, task.WorktreePath)
 		}
-		changed, current, err := store.TransitionTaskStateWithEvent(context.Background(), task.ID,
+		changed, current, err := store.TransitionTaskStateWithEventIfNoActiveJob(context.Background(), task.ID,
 			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
 			string(workflow.TaskDismissed), "task_dismissed_manual", reason)
 		if err != nil {
+			if errors.Is(err, db.ErrTaskHasActiveJob) {
+				return fmt.Errorf("task %s gained a queued or running job while dismissing; wait for it to settle or cancel it before retrying: %w", task.ID, err)
+			}
 			return err
 		}
 		if !changed {
@@ -572,9 +575,11 @@ func runTaskDismiss(args []string, stdout, stderr io.Writer) int {
 		}
 		output.Changed = true
 		if strings.TrimSpace(task.RepoFullName) != "" && strings.TrimSpace(task.Branch) != "" {
-			_, _, _ = store.ForceReleaseLockWithEvent(context.Background(), task.RepoFullName, task.Branch, db.BranchLockEvent{
+			if _, _, err := store.ForceReleaseLockWithEvent(context.Background(), task.RepoFullName, task.Branch, db.BranchLockEvent{
 				Kind: "force_released", Message: "released after manual task dismissal (#913)",
-			})
+			}); err != nil {
+				fmt.Fprintf(stderr, "warning: dismissed task %s but could not release branch lock %s: %v\n", task.ID, task.Branch, err)
+			}
 		}
 		return nil
 	})
@@ -714,10 +719,6 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "task recover requires exactly one id")
 		return 2
 	}
-	if strings.TrimSpace(*owner) == "" {
-		fmt.Fprintln(stderr, "task recover requires --owner")
-		return 2
-	}
 	var output taskRecoverOutput
 	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
 		payload, err := recoverTaskImplementation(context.Background(), store, taskID, strings.TrimSpace(*repo), strings.TrimSpace(*owner), *skipFanout, nil)
@@ -786,6 +787,9 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		}
 		return workflow.JobPayload{Repo: task.RepoFullName, GoalID: task.GoalID, TaskID: task.ID, TaskTitle: task.Title}, nil
 	}
+	if strings.TrimSpace(owner) == "" {
+		return workflow.JobPayload{}, errors.New("task recover requires --owner")
+	}
 	requestRepo, err := resolveTaskRepoFlag(repoFlag, task.RepoFullName, "task recover")
 	if err != nil {
 		return workflow.JobPayload{}, err
@@ -815,10 +819,10 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 	if err := ensureLocalAgentAccess(ctx, store, agent, requestRepo, "implement"); err != nil {
 		return workflow.JobPayload{}, err
 	}
-	if active, ok, err := findActiveImplementJobForTask(ctx, store, requestRepo, task.Branch, task.ID); err != nil {
+	if active, ok, err := workflow.FindLiveTaskJob(ctx, store, task); err != nil {
 		return workflow.JobPayload{}, err
 	} else if ok {
-		return workflow.JobPayload{}, fmt.Errorf("task %s still has active implement job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
+		return workflow.JobPayload{}, fmt.Errorf("task %s still has live job %s; wait for it, cancel it, or resolve it before recovering", task.ID, active.ID)
 	}
 	if strings.TrimSpace(task.WorktreePath) != "" && taskWorktreeHasLiveProcess(task.WorktreePath) {
 		return workflow.JobPayload{}, fmt.Errorf("task %s worktree %s still has a live process; wait for it to exit or stop the orphaned implementer before recovering", task.ID, task.WorktreePath)

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -254,6 +254,10 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 		return runTaskList(args[1:], stdout, stderr)
 	case "recover":
 		return runTaskRecover(args[1:], stdout, stderr)
+	case "dismiss":
+		return runTaskDismiss(args[1:], stdout, stderr)
+	case "events":
+		return runTaskEvents(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown task command %q\n\n", args[0])
 		printTaskUsage(stderr)
@@ -265,6 +269,8 @@ func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>]")
 	fmt.Fprintln(w, "  gitmoot task recover <id> --owner <agent> [--repo owner/repo] [--skip-native-review-fanout] [--json]")
+	fmt.Fprintln(w, "  gitmoot task dismiss <id> [--reason text] [--json]")
+	fmt.Fprintln(w, "  gitmoot task events <id> [--json]")
 	fmt.Fprintln(w, "  gitmoot task list [--repo owner/repo] [--state state] [--json]")
 }
 
@@ -386,6 +392,9 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 			}
 			return err
 		}
+		if task.State == string(workflow.TaskDismissed) {
+			return fmt.Errorf("task %s is dismissed; use gitmoot task recover before task run", task.ID)
+		}
 		requestRepo, err := resolveTaskRepoFlag(*repo, task.RepoFullName, "task run")
 		if err != nil {
 			return err
@@ -486,10 +495,193 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+type taskDismissOutput struct {
+	TaskID        string `json:"task_id"`
+	PreviousState string `json:"previous_state"`
+	State         string `json:"state"`
+	Source        string `json:"source"`
+	Reason        string `json:"reason"`
+	Changed       bool   `json:"changed"`
+}
+
+func runTaskDismiss(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("task dismiss", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	reasonFlag := fs.String("reason", "", "operator reason recorded in the task event trail")
+	jsonOutput := fs.Bool("json", false, "print dismissal result as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "task dismiss requires exactly one id")
+			return 2
+		}
+		return 0
+	}
+	taskID := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || taskID == "" {
+		fmt.Fprintln(stderr, "task dismiss requires exactly one id")
+		return 2
+	}
+	reason := strings.TrimSpace(*reasonFlag)
+	if reason == "" {
+		reason = "dismissed by operator"
+	}
+	output := taskDismissOutput{TaskID: taskID, State: string(workflow.TaskDismissed), Source: "manual", Reason: reason}
+	err := withStore(*home, func(store *db.Store) error {
+		task, err := store.GetTask(context.Background(), taskID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("task %q not found", taskID)
+			}
+			return err
+		}
+		output.PreviousState = task.State
+		if task.State == string(workflow.TaskDismissed) {
+			return nil
+		}
+		if !taskDismissibleState(task.State) {
+			return taskDismissRefusal(task)
+		}
+		if live, ok, err := workflow.FindLiveTaskJob(context.Background(), store, task); err != nil {
+			return err
+		} else if ok {
+			return fmt.Errorf("task %s still has live job %s (%s); wait for it to settle or cancel it before dismissing", task.ID, live.ID, live.State)
+		}
+		if strings.TrimSpace(task.WorktreePath) != "" && taskWorktreeHasLiveProcess(task.WorktreePath) {
+			return fmt.Errorf("task %s worktree %s still has a live process; wait for it to exit or stop it before dismissing", task.ID, task.WorktreePath)
+		}
+		changed, current, err := store.TransitionTaskStateWithEvent(context.Background(), task.ID,
+			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
+			string(workflow.TaskDismissed), "task_dismissed_manual", reason)
+		if err != nil {
+			return err
+		}
+		if !changed {
+			if current == string(workflow.TaskDismissed) {
+				output.PreviousState = current
+				return nil
+			}
+			return fmt.Errorf("task %s changed from %s to %s while dismissing; retry after inspecting it", task.ID, task.State, current)
+		}
+		output.Changed = true
+		if strings.TrimSpace(task.RepoFullName) != "" && strings.TrimSpace(task.Branch) != "" {
+			_, _, _ = store.ForceReleaseLockWithEvent(context.Background(), task.RepoFullName, task.Branch, db.BranchLockEvent{
+				Kind: "force_released", Message: "released after manual task dismissal (#913)",
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "dismiss task: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, output); err != nil {
+			fmt.Fprintf(stderr, "dismiss task: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if output.Changed {
+		fmt.Fprintf(stdout, "dismissed %s from %s: %s\n", output.TaskID, output.PreviousState, output.Reason)
+	} else {
+		fmt.Fprintf(stdout, "%s is already dismissed\n", output.TaskID)
+	}
+	return 0
+}
+
+func taskDismissibleState(state string) bool {
+	switch workflow.TaskState(strings.TrimSpace(state)) {
+	case workflow.TaskImplementing, workflow.TaskBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+func taskDismissRefusal(task db.Task) error {
+	state := strings.TrimSpace(task.State)
+	if state == "" {
+		state = "unknown"
+	}
+	owner := "other workflow machinery"
+	switch workflow.TaskState(state) {
+	case workflow.TaskPlanned:
+		owner = "task run/implement dispatch"
+	case workflow.TaskPullRequestOpen, workflow.TaskReviewing, workflow.TaskChangesRequested, workflow.TaskReadyToMerge:
+		owner = "pull-request review and merge machinery"
+	case workflow.TaskMerged:
+		owner = "the terminal merge record"
+	case workflow.TaskAwaitingHuman:
+		owner = "the explicit human-resume machinery"
+	}
+	return fmt.Errorf("task %s is in state %s; task dismiss only supports implementing or blocked tasks because this state is owned by %s", task.ID, state, owner)
+}
+
+func runTaskEvents(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("task events", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print task events as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fs.Usage()
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "task events requires exactly one id")
+			return 2
+		}
+		return 0
+	}
+	taskID := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || taskID == "" {
+		fmt.Fprintln(stderr, "task events requires exactly one id")
+		return 2
+	}
+	var events []db.TaskEvent
+	if err := withStore(*home, func(store *db.Store) error {
+		if _, err := store.GetTask(context.Background(), taskID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("task %q not found", taskID)
+			}
+			return err
+		}
+		var err error
+		events, err = store.ListTaskEvents(context.Background(), taskID)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "task events: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, events); err != nil {
+			fmt.Fprintf(stderr, "task events: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	for _, event := range events {
+		fmt.Fprintf(stdout, "%d\t%s\t%s\t%s\t%s\t%s\n", event.ID, event.CreatedAt, event.Kind, event.FromState, event.ToState, event.Reason)
+	}
+	return 0
+}
+
 type taskRecoverOutput struct {
 	TaskID      string `json:"task_id"`
 	Repo        string `json:"repo"`
 	Branch      string `json:"branch"`
+	State       string `json:"state"`
 	PullRequest int    `json:"pull_request"`
 	HeadSHA     string `json:"head_sha"`
 	Summary     string `json:"summary"`
@@ -536,9 +728,14 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 			TaskID:      payload.TaskID,
 			Repo:        payload.Repo,
 			Branch:      payload.Branch,
+			State:       string(workflow.TaskPullRequestOpen),
 			PullRequest: payload.PullRequest,
 			HeadSHA:     payload.HeadSHA,
 			Summary:     "recovered implementation worktree and opened/adopted PR",
+		}
+		if strings.TrimSpace(payload.Branch) == "" {
+			output.State = string(workflow.TaskPlanned)
+			output.Summary = "restored dismissed branchless task to planned; use task run to start it"
 		}
 		return nil
 	}); err != nil {
@@ -550,6 +747,10 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "recover task: %v\n", err)
 			return 1
 		}
+		return 0
+	}
+	if output.State == string(workflow.TaskPlanned) {
+		fmt.Fprintf(stdout, "restored %s to planned; next: gitmoot task run %s --repo owner/repo --owner agent\n", output.TaskID, output.TaskID)
 		return 0
 	}
 	fmt.Fprintf(stdout, "recovered %s on %s\n", output.TaskID, output.Branch)
@@ -570,8 +771,20 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 		}
 		return workflow.JobPayload{}, err
 	}
-	if !taskBranchReusableForImplement(task.State) {
+	if !taskRecoverableState(task.State) {
 		return workflow.JobPayload{}, fmt.Errorf("task %s is in state %s; task recover only supports active implementation states", task.ID, task.State)
+	}
+	if task.State == string(workflow.TaskDismissed) && strings.TrimSpace(task.Branch) == "" {
+		changed, current, err := store.TransitionTaskStateWithEvent(ctx, task.ID,
+			[]string{string(workflow.TaskDismissed)}, string(workflow.TaskPlanned),
+			"task_recovered", "dismissed task without a branch restored to planned for task run")
+		if err != nil {
+			return workflow.JobPayload{}, err
+		}
+		if !changed {
+			return workflow.JobPayload{}, fmt.Errorf("task %s changed to %s while recovering; retry after inspecting it", task.ID, current)
+		}
+		return workflow.JobPayload{Repo: task.RepoFullName, GoalID: task.GoalID, TaskID: task.ID, TaskTitle: task.Title}, nil
 	}
 	requestRepo, err := resolveTaskRepoFlag(repoFlag, task.RepoFullName, "task recover")
 	if err != nil {
@@ -663,6 +876,17 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 	if err != nil {
 		return workflow.JobPayload{}, err
 	}
+	if task.State == string(workflow.TaskDismissed) {
+		changed, current, err := store.TransitionTaskStateWithEvent(ctx, task.ID,
+			[]string{string(workflow.TaskDismissed)}, string(workflow.TaskImplementing),
+			"task_recovered", "dismissed task recovery started from preserved branch and worktree")
+		if err != nil {
+			return workflow.JobPayload{}, err
+		}
+		if !changed {
+			return workflow.JobPayload{}, fmt.Errorf("task %s changed to %s while recovery was starting", task.ID, current)
+		}
+	}
 	if err := store.CreateExternallyDrivenJobWithEvent(ctx, db.Job{
 		ID:      job.ID,
 		Agent:   job.Agent,
@@ -690,6 +914,14 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 	if err := finishTaskRecoverJob(ctx, store, job.ID, string(workflow.JobSucceeded), finalized, "task recovery finalized implementation"); err != nil {
 		return workflow.JobPayload{}, err
 	}
+	changed, current, err := store.TransitionTaskStateWithEvent(ctx, task.ID, taskRecoveryActiveStates(),
+		string(workflow.TaskPullRequestOpen), "task_recovered", "task recovery finalized implementation and opened or adopted a pull request")
+	if err != nil {
+		return workflow.JobPayload{}, err
+	}
+	if !changed && current != string(workflow.TaskPullRequestOpen) {
+		return workflow.JobPayload{}, fmt.Errorf("task %s is %s after recovery finalization; expected pr_open", task.ID, current)
+	}
 	return finalized, nil
 }
 
@@ -710,6 +942,18 @@ func taskBranchReusableForImplement(state string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+func taskRecoverableState(state string) bool {
+	return workflow.TaskState(strings.TrimSpace(state)) == workflow.TaskDismissed || taskBranchReusableForImplement(state)
+}
+
+func taskRecoveryActiveStates() []string {
+	return []string{
+		"", string(workflow.TaskPlanned), string(workflow.TaskImplementing),
+		string(workflow.TaskChangesRequested), string(workflow.TaskBlocked),
+		string(workflow.TaskAwaitingHuman),
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -881,7 +881,7 @@ func TestRecoverDismissedBranchlessTaskRestoresPlanned(t *testing.T) {
 	}
 	store.Close()
 	var stdout, stderr bytes.Buffer
-	code := Run([]string{"task", "recover", "task-empty", "--home", home, "--owner", "lead"}, &stdout, &stderr)
+	code := Run([]string{"task", "recover", "task-empty", "--home", home}, &stdout, &stderr)
 	if code != 0 || !strings.Contains(stdout.String(), "restored task-empty to planned") || !strings.Contains(stdout.String(), "task run task-empty") {
 		t.Fatalf("code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
@@ -891,6 +891,23 @@ func TestRecoverDismissedBranchlessTaskRestoresPlanned(t *testing.T) {
 	events, _ := store.ListTaskEvents(context.Background(), "task-empty")
 	if task.State != string(workflow.TaskPlanned) || len(events) != 1 || events[0].Kind != "task_recovered" || events[0].ToState != string(workflow.TaskPlanned) {
 		t.Fatalf("task=%+v events=%+v", task, events)
+	}
+}
+
+func TestRunTaskRecoverRequiresOwnerForArtifacts(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertTask(context.Background(), db.Task{
+		ID: "task-artifacts", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed),
+		Branch: "feature/artifacts", WorktreePath: filepath.Join(home, "worktree"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"task", "recover", "task-artifacts", "--home", home}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "task recover requires --owner") {
+		t.Fatalf("code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
 }
 
@@ -1068,17 +1085,38 @@ func TestRecoverTaskImplementationBlocksActiveJobAndWrongLockOwner(t *testing.T)
 	if err := store.CreateJob(ctx, db.Job{ID: "active-implement", Agent: "lead", Type: "implement", State: string(workflow.JobRunning), Payload: string(activePayload)}); err != nil {
 		t.Fatalf("CreateJob returned error: %v", err)
 	}
-	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "active implement job") {
-		t.Fatalf("recover with active job err = %v, want active implement job", err)
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "live job active-implement") {
+		t.Fatalf("recover with active job err = %v, want live job", err)
 	}
-	if err := store.UpdateJobState(ctx, "active-implement", string(workflow.JobFailed)); err != nil {
+	if err := store.UpdateJobState(ctx, "active-implement", string(workflow.JobSucceeded)); err != nil {
 		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "active-implement", Kind: "advance_started"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "live job active-implement") {
+		t.Fatalf("recover during pending advancement err = %v, want live job", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "active-implement", Kind: "advance_completed"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateJobState(ctx, "active-implement", string(workflow.JobCancelled)); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "active-implement", Kind: string(workflow.JobCancelled), Message: "cancel requested from running"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "live job active-implement") {
+		t.Fatalf("recover during unsettled cancellation err = %v, want live job", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "active-implement", Kind: "cancel_settled"}); err != nil {
+		t.Fatal(err)
 	}
 	if _, err := store.CreateLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-001-bootstrap", Owner: "other"}); err != nil {
 		t.Fatalf("CreateLock returned error: %v", err)
 	}
 	if _, err := recoverTaskImplementation(ctx, store, "task-001", "owner/repo", "lead", false, &stubTaskRecoverGitHub{}); err == nil || !strings.Contains(err.Error(), "locked by other") {
-		t.Fatalf("recover with wrong lock owner err = %v, want locked by other", err)
+		t.Fatalf("recover after cancellation settled err = %v, want locked by other (liveness cleared)", err)
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -798,6 +798,100 @@ func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
 	if job.State != string(workflow.JobSucceeded) {
 		t.Fatalf("recovery job state = %q, want succeeded", job.State)
 	}
+	recoveredTask, err := store.GetTask(ctx, "task-001")
+	if err != nil || recoveredTask.State != string(workflow.TaskPullRequestOpen) {
+		t.Fatalf("recovered task = %+v err=%v, want pr_open", recoveredTask, err)
+	}
+	taskEvents, err := store.ListTaskEvents(ctx, "task-001")
+	if err != nil || len(taskEvents) != 1 || taskEvents[0].Kind != "task_recovered" || taskEvents[0].ToState != string(workflow.TaskPullRequestOpen) {
+		t.Fatalf("recovery task events = %+v err=%v", taskEvents, err)
+	}
+}
+
+type observingTaskRecoverGitHub struct {
+	stubTaskRecoverGitHub
+	store    *db.Store
+	taskID   string
+	sawState string
+}
+
+func (s *observingTaskRecoverGitHub) EnsurePullRequest(ctx context.Context, input github.CreatePullRequestInput) (github.PullRequest, error) {
+	task, err := s.store.GetTask(ctx, s.taskID)
+	if err != nil {
+		return github.PullRequest{}, err
+	}
+	s.sawState = task.State
+	return s.stubTaskRecoverGitHub.EnsurePullRequest(ctx, input)
+}
+
+func TestRecoverDismissedTaskWithArtifactsTransitionsThroughImplementingToPROpen(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "main\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", RemoteURL: remoteDir, CheckoutPath: repoDir, PollInterval: "30s"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "lead", Runtime: "shell", RuntimeRef: "true", RepoScope: "owner/repo", Capabilities: []string{"implement"}, AutonomyPolicy: "workspace-write", HealthStatus: "ok"}); err != nil {
+		t.Fatal(err)
+	}
+	worktree, err := workflow.TaskWorktreePath(home, "owner/repo", "task-dismissed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repoDir, "worktree", "add", "-b", "feature/dismissed", worktree, "main")
+	writeFile(t, filepath.Join(worktree, "feature.txt"), "recovered work\n")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-dismissed", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed), Branch: "feature/dismissed", WorktreePath: worktree}); err != nil {
+		t.Fatal(err)
+	}
+	gh := &observingTaskRecoverGitHub{store: store, taskID: "task-dismissed"}
+	if _, err := recoverTaskImplementation(ctx, store, "task-dismissed", "owner/repo", "lead", false, gh); err != nil {
+		t.Fatalf("recoverTaskImplementation: %v", err)
+	}
+	if gh.sawState != string(workflow.TaskImplementing) {
+		t.Fatalf("state during finalization = %q, want implementing", gh.sawState)
+	}
+	task, _ := store.GetTask(ctx, "task-dismissed")
+	if task.State != string(workflow.TaskPullRequestOpen) {
+		t.Fatalf("final task state = %s", task.State)
+	}
+	events, _ := store.ListTaskEvents(ctx, task.ID)
+	if len(events) != 2 || events[0].FromState != string(workflow.TaskDismissed) || events[0].ToState != string(workflow.TaskImplementing) || events[1].ToState != string(workflow.TaskPullRequestOpen) {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestRecoverDismissedBranchlessTaskRestoresPlanned(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-empty", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed)}); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"task", "recover", "task-empty", "--home", home, "--owner", "lead"}, &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "restored task-empty to planned") || !strings.Contains(stdout.String(), "task run task-empty") {
+		t.Fatalf("code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	task, _ := store.GetTask(context.Background(), "task-empty")
+	events, _ := store.ListTaskEvents(context.Background(), "task-empty")
+	if task.State != string(workflow.TaskPlanned) || len(events) != 1 || events[0].Kind != "task_recovered" || events[0].ToState != string(workflow.TaskPlanned) {
+		t.Fatalf("task=%+v events=%+v", task, events)
+	}
 }
 
 func TestRecoverTaskImplementationFinalizesCleanCommittedWorktree(t *testing.T) {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -42,10 +42,13 @@ artifact_blobs = %q
 # new-branch worktree from that ref. Use "origin/main" for a remote-tracking
 # default, or "HEAD" to follow the registered checkout. With no value, implement
 # follows checkout HEAD and guards stale non-default checkouts. result_checks is
-# off | warn | block and defaults to warn when omitted.
+# off | warn | block and defaults to warn when omitted. stale_task_ttl is the
+# conservative updated_at age after which abandoned implementing/blocked tasks
+# may be auto-dismissed; it defaults to 168h and "0" disables the reconciler.
 # [workflow]
 # implement_base = "origin/main"
 # result_checks = "warn"
+# stale_task_ttl = "168h"
 
 # [daemon] is the OPTIONAL warm-reloadable runtime config (issue #577). CLI flags to
 # "daemon start" / "daemon run" remain the initial value; a key here is applied only

--- a/internal/config/stale_tasks.go
+++ b/internal/config/stale_tasks.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+const DefaultStaleTaskTTL = 168 * time.Hour
+
+// LoadStaleTaskTTL resolves the hot-read [workflow].stale_task_ttl setting.
+// Omitted or empty uses seven days, exactly "0" disables reconciliation, and
+// every other value must be a non-negative Go duration.
+func LoadStaleTaskTTL(paths Paths) (time.Duration, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultStaleTaskTTL, nil
+		}
+		return 0, err
+	}
+	ttl := DefaultStaleTaskTTL
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			continue
+		}
+		if current != "workflow" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "stale_task_ttl" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "\"") {
+			value, err = parseConfigString(value)
+			if err != nil {
+				return 0, fmt.Errorf("parse [workflow].stale_task_ttl: %w", err)
+			}
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			ttl = DefaultStaleTaskTTL
+			continue
+		}
+		if value == "0" {
+			ttl = 0
+			continue
+		}
+		ttl, err = time.ParseDuration(value)
+		if err != nil || ttl < 0 {
+			if err == nil {
+				err = fmt.Errorf("duration must not be negative")
+			}
+			return 0, fmt.Errorf("invalid [workflow].stale_task_ttl %q: %w", value, err)
+		}
+	}
+	return ttl, nil
+}

--- a/internal/config/stale_tasks_test.go
+++ b/internal/config/stale_tasks_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadStaleTaskTTL(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "missing", want: DefaultStaleTaskTTL},
+		{name: "omitted", content: "[workflow]\nresult_checks = \"warn\"\n", want: DefaultStaleTaskTTL},
+		{name: "empty", content: "[workflow]\nstale_task_ttl = \"\"\n", want: DefaultStaleTaskTTL},
+		{name: "disabled", content: "[workflow]\nstale_task_ttl = \"0\"\n", want: 0},
+		{name: "duration", content: "[workflow]\nstale_task_ttl = \"36h\"\n", want: 36 * time.Hour},
+		{name: "invalid", content: "[workflow]\nstale_task_ttl = \"later\"\n", wantErr: true},
+		{name: "negative", content: "[workflow]\nstale_task_ttl = \"-1h\"\n", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if test.name != "missing" {
+				if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := LoadStaleTaskTTL(Paths{ConfigFile: path})
+			if (err != nil) != test.wantErr {
+				t.Fatalf("LoadStaleTaskTTL error = %v, wantErr %v", err, test.wantErr)
+			}
+			if !test.wantErr && got != test.want {
+				t.Fatalf("LoadStaleTaskTTL = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -7,12 +7,16 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"log"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
+	gitutil "github.com/jerryfane/gitmoot/internal/git"
 	"github.com/jerryfane/gitmoot/internal/github"
 	"github.com/jerryfane/gitmoot/internal/workflow"
 )
@@ -23,6 +27,7 @@ const (
 	// A stale backlog drains over successive ticks without walking paginated closed
 	// PR history or allowing old task rows to dominate the daemon's API budget.
 	externalMergeReconcileLookupLimit = 20
+	staleTaskReconcileLimit           = 20
 )
 
 // issueCommentPollOverlap is subtracted from the persisted last-seen cursor when
@@ -42,6 +47,12 @@ type Daemon struct {
 	// Now is an injectable clock (test seam). It defaults to time.Now and is used
 	// to seed/advance the #566 issue-comment `since` cursor deterministically.
 	Now func() time.Time
+	// RemoteBranches is the fakeable one-call seam used by stale-task
+	// reconciliation. Nil uses git ls-remote against the registered checkout.
+	RemoteBranches RemoteBranchChecker
+	// Logf receives one diagnostic for invalid config or an uncertain remote
+	// check. Nil uses the process logger.
+	Logf func(format string, args ...any)
 	// WatchIssues opts in to the issue-comment workflow (#389): when true,
 	// PollOnce also polls open non-PR issues and routes `@<agent> ask …`
 	// comments to jobs. Default false keeps the PR-only behavior unchanged.
@@ -59,6 +70,18 @@ type Daemon struct {
 	// Default false is a CHEAP SHORT-CIRCUIT: PollOnce parses NO PR body and fires
 	// nothing, so the off path is byte-identical (no new GitHub reads, no new work).
 	RevertDetectionEnabled bool
+}
+
+// RemoteBranchChecker returns the subset of exact branch names present on
+// origin. Implementations must batch the full bounded input into one check.
+type RemoteBranchChecker interface {
+	RemoteBranches(ctx context.Context, checkout string, branches []string) (map[string]struct{}, error)
+}
+
+type gitRemoteBranchChecker struct{}
+
+func (gitRemoteBranchChecker) RemoteBranches(ctx context.Context, checkout string, branches []string) (map[string]struct{}, error) {
+	return (gitutil.Client{Dir: checkout}).RemoteBranches(ctx, branches)
 }
 
 func (d Daemon) Run(ctx context.Context) error {
@@ -171,6 +194,9 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	if err := d.reconcileClosedReviewingTasks(ctx, openBranches); err != nil && firstErr == nil {
 		firstErr = err
 	}
+	if err := d.reconcileStaleTasks(ctx, openBranches); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	if d.WatchIssues {
 		if err := d.PollIssuesOnce(ctx); err != nil && firstErr == nil {
 			firstErr = err
@@ -185,6 +211,109 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 		}
 	}
 	return firstErr
+}
+
+func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string]struct{}) error {
+	paths := config.Paths{ConfigFile: filepath.Join(filepath.Dir(d.Store.DatabasePath()), config.ConfigName)}
+	ttl, err := config.LoadStaleTaskTTL(paths)
+	if err != nil {
+		d.logf("stale task reconciler skipped for %s: %v", d.Repo.FullName(), err)
+		return nil
+	}
+	if ttl == 0 {
+		return nil
+	}
+	candidates, err := d.Store.ListStaleTaskCandidates(ctx, d.Repo.FullName(), []string{
+		string(workflow.TaskImplementing), string(workflow.TaskBlocked),
+	}, d.now().Add(-ttl), staleTaskReconcileLimit)
+	if err != nil {
+		return err
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	type readyCandidate struct {
+		candidate db.StaleTaskCandidate
+		task      db.Task
+	}
+	emptyBranch := []readyCandidate{}
+	remoteCandidates := []readyCandidate{}
+	branches := []string{}
+	for _, candidate := range candidates {
+		task := db.Task{ID: candidate.ID, RepoFullName: candidate.RepoFullName, State: candidate.State, Branch: candidate.Branch}
+		if _, live, err := workflow.FindLiveTaskJob(ctx, d.Store, task); err != nil {
+			return err
+		} else if live {
+			continue
+		}
+		branch := strings.TrimSpace(candidate.Branch)
+		if branch == "" {
+			emptyBranch = append(emptyBranch, readyCandidate{candidate: candidate, task: task})
+			continue
+		}
+		if _, open := openBranches[branch]; open {
+			continue
+		}
+		remoteCandidates = append(remoteCandidates, readyCandidate{candidate: candidate, task: task})
+		branches = append(branches, branch)
+	}
+
+	remotePresent := map[string]struct{}{}
+	remoteCertain := true
+	if len(branches) > 0 {
+		repo, err := d.Store.GetRepo(ctx, d.Repo.FullName())
+		if err != nil {
+			remoteCertain = false
+			d.logf("stale task reconciler remote check skipped for %s: %v", d.Repo.FullName(), err)
+		} else {
+			checker := d.RemoteBranches
+			if checker == nil {
+				checker = gitRemoteBranchChecker{}
+			}
+			remotePresent, err = checker.RemoteBranches(ctx, repo.CheckoutPath, branches)
+			if err != nil {
+				remoteCertain = false
+				d.logf("stale task reconciler remote check skipped for %s: %v", d.Repo.FullName(), err)
+			}
+		}
+	}
+
+	// A failed remote check makes the tick non-authoritative. Avoid even the
+	// otherwise-certain empty-branch writes so one poll never partially applies
+	// its bounded candidate batch.
+	if !remoteCertain {
+		return nil
+	}
+	for _, item := range emptyBranch {
+		reason := fmt.Sprintf("stale task auto-dismissed: empty branch; ttl=%s; updated_at=%s", ttl, item.candidate.UpdatedAt)
+		if _, _, err := d.Store.TransitionTaskStateWithEvent(ctx, item.task.ID,
+			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
+			string(workflow.TaskDismissed), "task_dismissed_auto", reason); err != nil {
+			return err
+		}
+	}
+	for _, item := range remoteCandidates {
+		branch := strings.TrimSpace(item.candidate.Branch)
+		if _, present := remotePresent[branch]; present {
+			continue
+		}
+		reason := fmt.Sprintf("stale task auto-dismissed: remote ref refs/heads/%s absent; ttl=%s; updated_at=%s", branch, ttl, item.candidate.UpdatedAt)
+		if _, _, err := d.Store.TransitionTaskStateWithEvent(ctx, item.task.ID,
+			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
+			string(workflow.TaskDismissed), "task_dismissed_auto", reason); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d Daemon) logf(format string, args ...any) {
+	if d.Logf != nil {
+		d.Logf(format, args...)
+		return
+	}
+	log.Printf(format, args...)
 }
 
 // reconcileExternallyMergedTasks advances PR lifecycle tasks whose PR was

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -28,6 +28,7 @@ const (
 	// PR history or allowing old task rows to dominate the daemon's API budget.
 	externalMergeReconcileLookupLimit = 20
 	staleTaskReconcileLimit           = 20
+	staleTaskReconcileScanLimit       = 200
 )
 
 // issueCommentPollOverlap is subtracted from the persisted last-seen cursor when
@@ -125,7 +126,10 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	// consumer that needs it, never retained beyond this poll.
 	reviewMemo := newReviewJobsMemo(d.Store)
 	for _, pull := range pulls {
-		openBranches[pull.HeadRef] = struct{}{}
+		headRepo := strings.TrimSpace(pull.HeadRepoFullName)
+		if headRepo == "" || headRepo == d.Repo.FullName() {
+			openBranches[pull.HeadRef] = struct{}{}
+		}
 		openPullNumbers[pull.Number] = struct{}{}
 		changed, err := d.pullRequestChanged(ctx, pull, reviewMemo)
 		if err != nil {
@@ -225,7 +229,7 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 	}
 	candidates, err := d.Store.ListStaleTaskCandidates(ctx, d.Repo.FullName(), []string{
 		string(workflow.TaskImplementing), string(workflow.TaskBlocked),
-	}, d.now().Add(-ttl), staleTaskReconcileLimit)
+	}, d.now().Add(-ttl), staleTaskReconcileScanLimit)
 	if err != nil {
 		return err
 	}
@@ -241,6 +245,9 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 	remoteCandidates := []readyCandidate{}
 	branches := []string{}
 	for _, candidate := range candidates {
+		if len(emptyBranch)+len(remoteCandidates) >= staleTaskReconcileLimit {
+			break
+		}
 		task := db.Task{ID: candidate.ID, RepoFullName: candidate.RepoFullName, State: candidate.State, Branch: candidate.Branch}
 		if _, live, err := workflow.FindLiveTaskJob(ctx, d.Store, task); err != nil {
 			return err
@@ -287,9 +294,12 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 	}
 	for _, item := range emptyBranch {
 		reason := fmt.Sprintf("stale task auto-dismissed: empty branch; ttl=%s; updated_at=%s", ttl, item.candidate.UpdatedAt)
-		if _, _, err := d.Store.TransitionTaskStateWithEvent(ctx, item.task.ID,
+		if _, _, err := d.Store.TransitionTaskStateWithEventIfNoActiveJob(ctx, item.task.ID,
 			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
 			string(workflow.TaskDismissed), "task_dismissed_auto", reason); err != nil {
+			if errors.Is(err, db.ErrTaskHasActiveJob) {
+				continue
+			}
 			return err
 		}
 	}
@@ -299,9 +309,12 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 			continue
 		}
 		reason := fmt.Sprintf("stale task auto-dismissed: remote ref refs/heads/%s absent; ttl=%s; updated_at=%s", branch, ttl, item.candidate.UpdatedAt)
-		if _, _, err := d.Store.TransitionTaskStateWithEvent(ctx, item.task.ID,
+		if _, _, err := d.Store.TransitionTaskStateWithEventIfNoActiveJob(ctx, item.task.ID,
 			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
 			string(workflow.TaskDismissed), "task_dismissed_auto", reason); err != nil {
+			if errors.Is(err, db.ErrTaskHasActiveJob) {
+				continue
+			}
 			return err
 		}
 	}

--- a/internal/daemon/stale_task_reconcile_test.go
+++ b/internal/daemon/stale_task_reconcile_test.go
@@ -185,6 +185,39 @@ func TestStaleTaskReconcilerCapDrainAndRepeatIdempotence(t *testing.T) {
 	}
 }
 
+func TestStaleTaskReconcilerFiltersBeforeTickCap(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	writeStaleTaskConfig(t, store, "1h")
+	for i := 0; i < staleTaskReconcileLimit+1; i++ {
+		id := fmt.Sprintf("task-%02d", i)
+		branch := "feature/" + id
+		if err := store.UpsertTask(ctx, db.Task{ID: id, RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing), Branch: branch}); err != nil {
+			t.Fatal(err)
+		}
+		if i < staleTaskReconcileLimit {
+			payload, _ := json.Marshal(workflow.JobPayload{Repo: repo.FullName(), Branch: branch, TaskID: id})
+			if err := store.CreateJob(ctx, db.Job{ID: "job-" + id, Type: "ask", State: string(workflow.JobQueued), Payload: string(payload)}); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	remote := &fakeRemoteBranchChecker{present: map[string]struct{}{}}
+	d := Daemon{Repo: repo, Store: store, RemoteBranches: remote, Now: futureClock}
+	if err := d.reconcileStaleTasks(ctx, map[string]struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	task, err := store.GetTask(ctx, "task-20")
+	if err != nil || task.State != string(workflow.TaskDismissed) {
+		t.Fatalf("task behind live prefix=%+v err=%v", task, err)
+	}
+	if len(remote.calls) != 1 || len(remote.calls[0]) != 1 || remote.calls[0][0] != "feature/task-20" {
+		t.Fatalf("remote calls=%v, want only task behind live prefix", remote.calls)
+	}
+}
+
 func TestStaleTaskReconcilerDisabledAndInvalidConfig(t *testing.T) {
 	for _, test := range []struct {
 		name, value string
@@ -232,6 +265,35 @@ func TestPollOnceRunsStaleTaskReconciler(t *testing.T) {
 	task, _ := store.GetTask(ctx, "task-1")
 	if task.State != string(workflow.TaskDismissed) {
 		t.Fatalf("PollOnce task state = %s", task.State)
+	}
+}
+
+func TestPollOnceForkPRBranchDoesNotProtectStaleTask(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	writeStaleTaskConfig(t, store, "1h")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing), Branch: "feature/shared"}); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeGitHub{
+		pullsByState: map[string][]github.PullRequest{"open": {{
+			Number: 9, State: "open", HeadRef: "feature/shared", HeadRepoFullName: "fork/repo", BaseRef: "main", HeadSHA: "abc123",
+		}}},
+		comments: map[int64][]github.IssueComment{},
+	}
+	remote := &fakeRemoteBranchChecker{present: map[string]struct{}{}}
+	d := Daemon{Repo: repo, Store: store, GitHub: client, Now: futureClock, RemoteBranches: remote}
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	task, err := store.GetTask(ctx, "task-1")
+	if err != nil || task.State != string(workflow.TaskDismissed) {
+		t.Fatalf("fork PR protected base task: task=%+v err=%v", task, err)
+	}
+	if len(remote.calls) != 1 || len(remote.calls[0]) != 1 || remote.calls[0][0] != "feature/shared" {
+		t.Fatalf("remote calls=%v", remote.calls)
 	}
 }
 

--- a/internal/daemon/stale_task_reconcile_test.go
+++ b/internal/daemon/stale_task_reconcile_test.go
@@ -1,0 +1,270 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+type fakeRemoteBranchChecker struct {
+	present map[string]struct{}
+	err     error
+	calls   [][]string
+}
+
+func (f *fakeRemoteBranchChecker) RemoteBranches(_ context.Context, _ string, branches []string) (map[string]struct{}, error) {
+	f.calls = append(f.calls, append([]string(nil), branches...))
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.present, nil
+}
+
+func TestStaleTaskReconcilerDecisions(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       workflow.TaskState
+		branch      string
+		open        bool
+		remote      bool
+		live        bool
+		belowTTL    bool
+		wantDismiss bool
+		wantCalls   int
+		wantReason  string
+	}{
+		{name: "below threshold", state: workflow.TaskImplementing, branch: "feature/one", belowTTL: true},
+		{name: "open PR branch", state: workflow.TaskImplementing, branch: "feature/one", open: true},
+		{name: "remote present", state: workflow.TaskImplementing, branch: "feature/one", remote: true, wantCalls: 1},
+		{name: "remote absent", state: workflow.TaskImplementing, branch: "feature/one", wantDismiss: true, wantCalls: 1, wantReason: "refs/heads/feature/one absent"},
+		{name: "blocked remote absent", state: workflow.TaskBlocked, branch: "feature/blocked", wantDismiss: true, wantCalls: 1, wantReason: "refs/heads/feature/blocked absent"},
+		{name: "empty branch", state: workflow.TaskImplementing, wantDismiss: true, wantReason: "empty branch"},
+		{name: "live job", state: workflow.TaskImplementing, branch: "feature/live", live: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := testStore(t)
+			repo := github.Repository{Owner: "owner", Name: "repo"}
+			seedStaleRepo(t, store, repo)
+			writeStaleTaskConfig(t, store, "168h")
+			task := db.Task{ID: "task-1", RepoFullName: repo.FullName(), State: string(test.state), Branch: test.branch}
+			if err := store.UpsertTask(ctx, task); err != nil {
+				t.Fatal(err)
+			}
+			if test.live {
+				payload, _ := json.Marshal(workflow.JobPayload{Repo: repo.FullName(), Branch: test.branch, TaskID: task.ID})
+				if err := store.CreateJob(ctx, db.Job{ID: "job-live", Type: "review", State: string(workflow.JobQueued), Payload: string(payload)}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			remote := &fakeRemoteBranchChecker{present: map[string]struct{}{}}
+			if test.remote {
+				remote.present[test.branch] = struct{}{}
+			}
+			now := time.Now().UTC().Add(365 * 24 * time.Hour)
+			if test.belowTTL {
+				now = time.Now().UTC()
+			}
+			d := Daemon{Repo: repo, Store: store, RemoteBranches: remote, Now: func() time.Time { return now }}
+			open := map[string]struct{}{}
+			if test.open {
+				open[test.branch] = struct{}{}
+			}
+			if err := d.reconcileStaleTasks(ctx, open); err != nil {
+				t.Fatalf("reconcileStaleTasks: %v", err)
+			}
+			got, err := store.GetTask(ctx, task.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if dismissed := got.State == string(workflow.TaskDismissed); dismissed != test.wantDismiss {
+				t.Fatalf("task state = %s, wantDismiss %v", got.State, test.wantDismiss)
+			}
+			if len(remote.calls) != test.wantCalls {
+				t.Fatalf("remote calls = %v, want %d", remote.calls, test.wantCalls)
+			}
+			events, err := store.ListTaskEvents(ctx, task.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.wantDismiss {
+				if len(events) != 1 || events[0].Kind != "task_dismissed_auto" || !strings.Contains(events[0].Reason, test.wantReason) || !strings.Contains(events[0].Reason, "ttl=168h0m0s") || !strings.Contains(events[0].Reason, "updated_at=") {
+					t.Fatalf("events = %+v", events)
+				}
+			} else if len(events) != 0 {
+				t.Fatalf("unexpected events = %+v", events)
+			}
+		})
+	}
+}
+
+func TestStaleTaskReconcilerRemoteErrorMutatesNothing(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	writeStaleTaskConfig(t, store, "1h")
+	tasks := []db.Task{
+		{ID: "task-a", RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing), Branch: "feature/task-a"},
+		{ID: "task-b", RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing), Branch: "feature/task-b"},
+		{ID: "task-empty", RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing)},
+	}
+	for _, task := range tasks {
+		if err := store.UpsertTask(ctx, task); err != nil {
+			t.Fatal(err)
+		}
+	}
+	remote := &fakeRemoteBranchChecker{err: errors.New("network down")}
+	logs := []string{}
+	d := Daemon{Repo: repo, Store: store, RemoteBranches: remote, Now: futureClock, Logf: func(format string, args ...any) {
+		logs = append(logs, fmt.Sprintf(format, args...))
+	}}
+	if err := d.reconcileStaleTasks(ctx, map[string]struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(remote.calls) != 1 || len(logs) != 1 {
+		t.Fatalf("remote calls=%v logs=%v, want one each", remote.calls, logs)
+	}
+	for _, seeded := range tasks {
+		task, _ := store.GetTask(ctx, seeded.ID)
+		events, _ := store.ListTaskEvents(ctx, seeded.ID)
+		if task.State != string(workflow.TaskImplementing) || len(events) != 0 {
+			t.Fatalf("%s mutated: task=%+v events=%+v", seeded.ID, task, events)
+		}
+	}
+}
+
+func TestStaleTaskReconcilerCapDrainAndRepeatIdempotence(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	writeStaleTaskConfig(t, store, "1h")
+	for i := 0; i < staleTaskReconcileLimit+5; i++ {
+		id := fmt.Sprintf("task-%02d", i)
+		if err := store.UpsertTask(ctx, db.Task{ID: id, RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing), Branch: "feature/" + id}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	remote := &fakeRemoteBranchChecker{present: map[string]struct{}{}}
+	d := Daemon{Repo: repo, Store: store, RemoteBranches: remote, Now: futureClock}
+	if err := d.reconcileStaleTasks(ctx, map[string]struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	assertDismissedCount(t, store, staleTaskReconcileLimit)
+	if len(remote.calls) != 1 || len(remote.calls[0]) != staleTaskReconcileLimit {
+		t.Fatalf("first remote batch = %v", remote.calls)
+	}
+	if err := d.reconcileStaleTasks(ctx, map[string]struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	assertDismissedCount(t, store, staleTaskReconcileLimit+5)
+	if len(remote.calls) != 2 || len(remote.calls[1]) != 5 {
+		t.Fatalf("remote batches = %v", remote.calls)
+	}
+	if err := d.reconcileStaleTasks(ctx, map[string]struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(remote.calls) != 2 {
+		t.Fatalf("repeat remote calls = %v", remote.calls)
+	}
+	events, _ := store.ListTaskEvents(ctx, "task-00")
+	if len(events) != 1 {
+		t.Fatalf("repeat events = %+v", events)
+	}
+}
+
+func TestStaleTaskReconcilerDisabledAndInvalidConfig(t *testing.T) {
+	for _, test := range []struct {
+		name, value string
+		wantLogs    int
+	}{
+		{name: "disabled", value: "0"},
+		{name: "invalid", value: "bad", wantLogs: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			store := testStore(t)
+			repo := github.Repository{Owner: "owner", Name: "repo"}
+			seedStaleRepo(t, store, repo)
+			writeStaleTaskConfig(t, store, test.value)
+			if err := store.UpsertTask(context.Background(), db.Task{ID: "task-1", RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing), Branch: "feature/one"}); err != nil {
+				t.Fatal(err)
+			}
+			remote := &fakeRemoteBranchChecker{present: map[string]struct{}{}}
+			logs := []string{}
+			d := Daemon{Repo: repo, Store: store, RemoteBranches: remote, Now: futureClock, Logf: func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) }}
+			if err := d.reconcileStaleTasks(context.Background(), map[string]struct{}{}); err != nil {
+				t.Fatal(err)
+			}
+			task, _ := store.GetTask(context.Background(), "task-1")
+			if task.State != string(workflow.TaskImplementing) || len(remote.calls) != 0 || len(logs) != test.wantLogs {
+				t.Fatalf("task=%+v calls=%v logs=%v", task, remote.calls, logs)
+			}
+		})
+	}
+}
+
+func TestPollOnceRunsStaleTaskReconciler(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	writeStaleTaskConfig(t, store, "1h")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing)}); err != nil {
+		t.Fatal(err)
+	}
+	client := &fakeGitHub{pullsByState: map[string][]github.PullRequest{"open": nil}, comments: map[int64][]github.IssueComment{}}
+	d := Daemon{Repo: repo, Store: store, GitHub: client, Now: futureClock, RemoteBranches: &fakeRemoteBranchChecker{}}
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatal(err)
+	}
+	task, _ := store.GetTask(ctx, "task-1")
+	if task.State != string(workflow.TaskDismissed) {
+		t.Fatalf("PollOnce task state = %s", task.State)
+	}
+}
+
+func seedStaleRepo(t *testing.T, store *db.Store, repo github.Repository) {
+	t.Helper()
+	if err := store.UpsertRepo(context.Background(), db.Repo{Owner: repo.Owner, Name: repo.Name, CheckoutPath: "/repo", PrimaryCheckoutPath: "/repo"}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeStaleTaskConfig(t *testing.T, store *db.Store, value string) {
+	t.Helper()
+	path := filepath.Join(filepath.Dir(store.DatabasePath()), "config.toml")
+	if err := os.WriteFile(path, []byte("[workflow]\nstale_task_ttl = \""+value+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func futureClock() time.Time { return time.Now().UTC().Add(365 * 24 * time.Hour) }
+
+func assertDismissedCount(t *testing.T, store *db.Store, want int) {
+	t.Helper()
+	tasks, err := store.ListTasks(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := 0
+	for _, task := range tasks {
+		if task.State == string(workflow.TaskDismissed) {
+			got++
+		}
+	}
+	if got != want {
+		t.Fatalf("dismissed count = %d, want %d", got, want)
+	}
+}

--- a/internal/db/dashboard_store.go
+++ b/internal/db/dashboard_store.go
@@ -49,14 +49,15 @@ type DashboardTerminalBucket struct {
 
 const dashboardChangeCursorSQL = `SELECT
 	COALESCE((SELECT MAX(id) FROM job_events), 0),
-	COALESCE((SELECT MAX(id) FROM workflow_notes), 0)`
+	COALESCE((SELECT MAX(id) FROM workflow_notes), 0),
+	COALESCE((SELECT MAX(id) FROM task_events), 0)`
 
-// DashboardChangeCursor returns the two monotonic row ids that invalidate
-// dashboard views. Both maxima are read in one statement so a poll is one cheap
-// SQLite round trip and an empty store has the stable cursor components 0, 0.
-func (s *Store) DashboardChangeCursor(ctx context.Context) (jobEventID, workflowNoteID int64, err error) {
-	err = s.db.QueryRowContext(ctx, dashboardChangeCursorSQL).Scan(&jobEventID, &workflowNoteID)
-	return jobEventID, workflowNoteID, err
+// DashboardChangeCursor returns the three monotonic row ids that invalidate
+// dashboard views. All maxima are read in one statement so a poll is one cheap
+// SQLite round trip and an empty store has the stable cursor 0, 0, 0.
+func (s *Store) DashboardChangeCursor(ctx context.Context) (jobEventID, workflowNoteID, taskEventID int64, err error) {
+	err = s.db.QueryRowContext(ctx, dashboardChangeCursorSQL).Scan(&jobEventID, &workflowNoteID, &taskEventID)
+	return jobEventID, workflowNoteID, taskEventID, err
 }
 
 func (s *Store) ListDashboardTasks(ctx context.Context, mergedSince string) ([]DashboardTaskRow, error) {
@@ -68,7 +69,8 @@ func (s *Store) ListDashboardTasks(ctx context.Context, mergedSince string) ([]D
 			ORDER BY pr.number DESC LIMIT 1), 0),
 		t.updated_at
 	FROM tasks t
-	WHERE t.state != 'merged' OR julianday(t.updated_at) >= julianday(?)
+	WHERE t.state != 'dismissed'
+		AND (t.state != 'merged' OR julianday(t.updated_at) >= julianday(?))
 	ORDER BY t.id`, mergedSince)
 	if err != nil {
 		return nil, err

--- a/internal/db/dashboard_store_test.go
+++ b/internal/db/dashboard_store_test.go
@@ -9,12 +9,12 @@ func TestDashboardChangeCursor(t *testing.T) {
 	store := openWorkflowTestStore(t)
 	ctx := context.Background()
 
-	events, notes, err := store.DashboardChangeCursor(ctx)
+	events, notes, taskEvents, err := store.DashboardChangeCursor(ctx)
 	if err != nil {
 		t.Fatalf("DashboardChangeCursor(empty): %v", err)
 	}
-	if events != 0 || notes != 0 {
-		t.Fatalf("empty cursor = %d.%d, want 0.0", events, notes)
+	if events != 0 || notes != 0 || taskEvents != 0 {
+		t.Fatalf("empty cursor = %d.%d.%d, want 0.0.0", events, notes, taskEvents)
 	}
 
 	if err := store.CreateJobWithEvent(ctx,
@@ -22,21 +22,51 @@ func TestDashboardChangeCursor(t *testing.T) {
 		JobEvent{Kind: "queued", Message: "created"}); err != nil {
 		t.Fatalf("CreateJobWithEvent: %v", err)
 	}
-	events, notes, err = store.DashboardChangeCursor(ctx)
-	if err != nil || events != 1 || notes != 0 {
-		t.Fatalf("event cursor = %d.%d, err=%v, want 1.0", events, notes, err)
+	events, notes, taskEvents, err = store.DashboardChangeCursor(ctx)
+	if err != nil || events != 1 || notes != 0 || taskEvents != 0 {
+		t.Fatalf("event cursor = %d.%d.%d, err=%v, want 1.0.0", events, notes, taskEvents, err)
 	}
 
 	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/one", Body: "checkpoint"}); err != nil {
 		t.Fatalf("InsertWorkflowNote: %v", err)
 	}
-	events, notes, err = store.DashboardChangeCursor(ctx)
-	if err != nil || events != 1 || notes != 1 {
-		t.Fatalf("note cursor = %d.%d, err=%v, want 1.1", events, notes, err)
+	events, notes, taskEvents, err = store.DashboardChangeCursor(ctx)
+	if err != nil || events != 1 || notes != 1 || taskEvents != 0 {
+		t.Fatalf("note cursor = %d.%d.%d, err=%v, want 1.1.0", events, notes, taskEvents, err)
+	}
+	if err := store.UpsertTask(ctx, Task{ID: "task-1", State: "implementing"}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	if err := store.AddTaskEvent(ctx, TaskEvent{TaskID: "task-1", Kind: "task_dismissed_manual", FromState: "implementing", ToState: "dismissed"}); err != nil {
+		t.Fatalf("AddTaskEvent: %v", err)
+	}
+	events, notes, taskEvents, err = store.DashboardChangeCursor(ctx)
+	if err != nil || events != 1 || notes != 1 || taskEvents != 1 {
+		t.Fatalf("task event cursor = %d.%d.%d, err=%v, want 1.1.1", events, notes, taskEvents, err)
 	}
 
-	events2, notes2, err := store.DashboardChangeCursor(ctx)
-	if err != nil || events2 != events || notes2 != notes {
-		t.Fatalf("repeat cursor = %d.%d, err=%v, want %d.%d", events2, notes2, err, events, notes)
+	events2, notes2, taskEvents2, err := store.DashboardChangeCursor(ctx)
+	if err != nil || events2 != events || notes2 != notes || taskEvents2 != taskEvents {
+		t.Fatalf("repeat cursor = %d.%d.%d, err=%v, want %d.%d.%d", events2, notes2, taskEvents2, err, events, notes, taskEvents)
+	}
+}
+
+func TestListDashboardTasksExcludesDismissed(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	for _, task := range []Task{
+		{ID: "visible", State: "implementing"},
+		{ID: "hidden", State: "dismissed"},
+	} {
+		if err := store.UpsertTask(ctx, task); err != nil {
+			t.Fatalf("UpsertTask(%s): %v", task.ID, err)
+		}
+	}
+	tasks, err := store.ListDashboardTasks(ctx, "2000-01-01 00:00:00")
+	if err != nil {
+		t.Fatalf("ListDashboardTasks: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].ID != "visible" {
+		t.Fatalf("dashboard tasks = %+v, want only visible", tasks)
 	}
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -2280,6 +2280,34 @@ func (s *Store) UpsertTask(ctx context.Context, task Task) error {
 	return upsertTask(ctx, s.db, task)
 }
 
+// UpsertTaskUnlessState applies the normal task upsert unless an existing row
+// is currently in forbiddenState. The predicate lives on the conflict UPDATE so
+// callers that must not resurrect a terminal task remain safe if its state
+// changes after their initial read.
+func (s *Store) UpsertTaskUnlessState(ctx context.Context, task Task, forbiddenState string) (bool, error) {
+	result, err := s.db.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, worktree_path, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(id) DO UPDATE SET
+			repo_full_name = excluded.repo_full_name,
+			goal_id = excluded.goal_id,
+			title = excluded.title,
+			state = excluded.state,
+			branch = excluded.branch,
+			worktree_path = CASE
+				WHEN excluded.worktree_path <> '' THEN excluded.worktree_path
+				ELSE tasks.worktree_path
+			END,
+			updated_at = CURRENT_TIMESTAMP
+		WHERE tasks.state <> ?`,
+		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch, task.WorktreePath,
+		strings.TrimSpace(forbiddenState))
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	return affected == 1, err
+}
+
 func (s *Store) ClearTaskWorktreePath(ctx context.Context, id string) error {
 	_, err := s.db.ExecContext(ctx, `UPDATE tasks SET worktree_path = '', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, id)
 	return err
@@ -2472,17 +2500,33 @@ func (s *Store) ListTaskEvents(ctx context.Context, taskID string) ([]TaskEvent,
 	return out, rows.Err()
 }
 
+var ErrTaskHasActiveJob = errors.New("task has a queued or running job")
+
 // TransitionTaskStateWithEvent atomically compares and moves a task state and
 // appends its audit event. A failed comparison writes no event and returns the
 // current state so callers can distinguish idempotence from a conflicting move.
 func (s *Store) TransitionTaskStateWithEvent(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string) (changed bool, currentState string, err error) {
+	return s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, false)
+}
+
+// TransitionTaskStateWithEventIfNoActiveJob adds a queued/running job guard to
+// the same transaction as the task CAS. It is reserved for dismissal: broader
+// liveness (pending advancement and unsettled cancellation) is checked by the
+// caller before entering this transaction, while this guard closes the window
+// in which a newly queued/running job could acquire the task.
+func (s *Store) TransitionTaskStateWithEventIfNoActiveJob(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string) (changed bool, currentState string, err error) {
+	return s.transitionTaskStateWithEvent(ctx, taskID, fromStates, to, kind, reason, true)
+}
+
+func (s *Store) transitionTaskStateWithEvent(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string, rejectActiveJob bool) (changed bool, currentState string, err error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, "", err
 	}
 	defer tx.Rollback()
 
-	if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, strings.TrimSpace(taskID)).Scan(&currentState); err != nil {
+	var repoFullName, branch string
+	if err := tx.QueryRowContext(ctx, `SELECT state, repo_full_name, branch FROM tasks WHERE id = ?`, strings.TrimSpace(taskID)).Scan(&currentState, &repoFullName, &branch); err != nil {
 		return false, "", err
 	}
 	allowed := false
@@ -2494,6 +2538,15 @@ func (s *Store) TransitionTaskStateWithEvent(ctx context.Context, taskID string,
 	}
 	if !allowed {
 		return false, currentState, tx.Commit()
+	}
+	if rejectActiveJob {
+		jobID, active, err := activeJobMatchingTaskTx(ctx, tx, strings.TrimSpace(taskID), repoFullName, branch)
+		if err != nil {
+			return false, currentState, err
+		}
+		if active {
+			return false, currentState, fmt.Errorf("%w: %s", ErrTaskHasActiveJob, jobID)
+		}
 	}
 	result, err := tx.ExecContext(ctx, `UPDATE tasks SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`,
 		strings.TrimSpace(to), strings.TrimSpace(taskID), currentState)
@@ -2518,6 +2571,35 @@ func (s *Store) TransitionTaskStateWithEvent(ctx context.Context, taskID string,
 		return false, "", err
 	}
 	return true, strings.TrimSpace(to), nil
+}
+
+func activeJobMatchingTaskTx(ctx context.Context, tx *sql.Tx, taskID string, repoFullName string, branch string) (string, bool, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT id, payload FROM jobs WHERE state IN ('queued', 'running') ORDER BY id`)
+	if err != nil {
+		return "", false, err
+	}
+	defer rows.Close()
+	branch = strings.TrimSpace(branch)
+	repoFullName = strings.TrimSpace(repoFullName)
+	for rows.Next() {
+		var jobID, rawPayload string
+		if err := rows.Scan(&jobID, &rawPayload); err != nil {
+			return "", false, err
+		}
+		var payload struct {
+			TaskID string `json:"task_id"`
+			Repo   string `json:"repo"`
+			Branch string `json:"branch"`
+		}
+		if err := json.Unmarshal([]byte(rawPayload), &payload); err != nil {
+			continue
+		}
+		if strings.TrimSpace(payload.TaskID) == taskID ||
+			(branch != "" && strings.TrimSpace(payload.Repo) == repoFullName && strings.TrimSpace(payload.Branch) == branch) {
+			return jobID, true, nil
+		}
+	}
+	return "", false, rows.Err()
 }
 
 func scanTask(row interface{ Scan(dest ...any) error }) (Task, error) {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -217,6 +217,28 @@ type Task struct {
 	WorktreePath string
 }
 
+// TaskEvent is one append-only task lifecycle transition. FromState and
+// ToState are empty only for informational events that do not move the task.
+type TaskEvent struct {
+	ID        int64  `json:"id"`
+	TaskID    string `json:"task_id"`
+	Kind      string `json:"kind"`
+	FromState string `json:"from_state"`
+	ToState   string `json:"to_state"`
+	Reason    string `json:"reason"`
+	CreatedAt string `json:"created_at"`
+}
+
+// StaleTaskCandidate is the narrow age-aware task projection used by the
+// daemon reconciler. Keeping UpdatedAt here avoids widening every Task reader.
+type StaleTaskCandidate struct {
+	ID           string
+	RepoFullName string
+	State        string
+	Branch       string
+	UpdatedAt    string
+}
+
 type PullRequest struct {
 	RepoFullName   string
 	Number         int64
@@ -2394,6 +2416,110 @@ func (s *Store) ListTasksByRepoState(ctx context.Context, repoFullName string, s
 	return tasks, rows.Err()
 }
 
+// ListStaleTaskCandidates returns the oldest tasks in one repo whose state is
+// in states and whose conservative updated_at activity proxy predates before.
+func (s *Store) ListStaleTaskCandidates(ctx context.Context, repoFullName string, states []string, before time.Time, limit int) ([]StaleTaskCandidate, error) {
+	if len(states) == 0 || limit <= 0 {
+		return []StaleTaskCandidate{}, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(states)), ",")
+	args := make([]any, 0, len(states)+3)
+	args = append(args, strings.TrimSpace(repoFullName))
+	for _, state := range states {
+		args = append(args, strings.TrimSpace(state))
+	}
+	args = append(args, before.UTC().Format("2006-01-02 15:04:05"), limit)
+	rows, err := s.db.QueryContext(ctx, `SELECT id, repo_full_name, state, branch, updated_at
+		FROM tasks
+		WHERE repo_full_name = ? AND state IN (`+placeholders+`) AND updated_at < ?
+		ORDER BY updated_at, id LIMIT ?`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []StaleTaskCandidate{}
+	for rows.Next() {
+		var candidate StaleTaskCandidate
+		if err := rows.Scan(&candidate.ID, &candidate.RepoFullName, &candidate.State, &candidate.Branch, &candidate.UpdatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, candidate)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) AddTaskEvent(ctx context.Context, event TaskEvent) error {
+	_, err := s.db.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
+		VALUES (?, ?, ?, ?, ?)`, event.TaskID, event.Kind, event.FromState, event.ToState, event.Reason)
+	return err
+}
+
+func (s *Store) ListTaskEvents(ctx context.Context, taskID string) ([]TaskEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, task_id, kind, from_state, to_state, reason, created_at
+		FROM task_events WHERE task_id = ? ORDER BY id`, strings.TrimSpace(taskID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []TaskEvent{}
+	for rows.Next() {
+		var event TaskEvent
+		if err := rows.Scan(&event.ID, &event.TaskID, &event.Kind, &event.FromState, &event.ToState, &event.Reason, &event.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, event)
+	}
+	return out, rows.Err()
+}
+
+// TransitionTaskStateWithEvent atomically compares and moves a task state and
+// appends its audit event. A failed comparison writes no event and returns the
+// current state so callers can distinguish idempotence from a conflicting move.
+func (s *Store) TransitionTaskStateWithEvent(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string) (changed bool, currentState string, err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, "", err
+	}
+	defer tx.Rollback()
+
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, strings.TrimSpace(taskID)).Scan(&currentState); err != nil {
+		return false, "", err
+	}
+	allowed := false
+	for _, state := range fromStates {
+		if currentState == strings.TrimSpace(state) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return false, currentState, tx.Commit()
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE tasks SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`,
+		strings.TrimSpace(to), strings.TrimSpace(taskID), currentState)
+	if err != nil {
+		return false, "", err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, "", err
+	}
+	if affected == 0 {
+		if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, strings.TrimSpace(taskID)).Scan(&currentState); err != nil {
+			return false, "", err
+		}
+		return false, currentState, tx.Commit()
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
+		VALUES (?, ?, ?, ?, ?)`, strings.TrimSpace(taskID), strings.TrimSpace(kind), currentState, strings.TrimSpace(to), strings.TrimSpace(reason)); err != nil {
+		return false, "", err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, "", err
+	}
+	return true, strings.TrimSpace(to), nil
+}
+
 func scanTask(row interface{ Scan(dest ...any) error }) (Task, error) {
 	var task Task
 	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch, &task.WorktreePath); err != nil {
@@ -3112,6 +3238,63 @@ func (s *Store) TransitionJobStatePayloadWithEvent(ctx context.Context, id strin
 		if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, extra.JobID, extra.Kind, extra.Message); err != nil {
 			return false, err
 		}
+	}
+	return true, tx.Commit()
+}
+
+// TransitionJobStatePayloadWithEventAndTaskTransition is the retry path's
+// cross-row transaction: a dismissed task is explicitly recovered before its
+// job is re-queued, and either both lifecycle events commit or neither does.
+func (s *Store) TransitionJobStatePayloadWithEventAndTaskTransition(ctx context.Context, id string, from string, to string, payload string, event JobEvent, taskID string, taskFrom string, taskTo string, taskKind string, taskReason string) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	taskResult, err := tx.ExecContext(ctx, `UPDATE tasks SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`,
+		taskTo, taskID, taskFrom)
+	if err != nil {
+		return false, err
+	}
+	taskAffected, err := taskResult.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if taskAffected != 1 {
+		var current string
+		if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, taskID).Scan(&current); err != nil {
+			return false, err
+		}
+		return false, fmt.Errorf("task %s is %s; retry requires explicit recovery from %s", taskID, current, taskFrom)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
+		VALUES (?, ?, ?, ?, ?)`, taskID, taskKind, taskFrom, taskTo, taskReason); err != nil {
+		return false, err
+	}
+
+	projection := jobProjectionFromPayload(payload)
+	result, err := tx.ExecContext(ctx, `UPDATE jobs SET state = ?, payload = ?, result_hash = ?, repo = ?, pull_request = ?, blocker_retry_at = ?, blocker_suggested_action = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ? AND workflow_id = ?`,
+		to, payload, jobResultHashFromPayload(payload), projection.Repo, projection.PullRequest, projection.BlockerRetryAt,
+		projection.BlockerSuggestedAction, id, from, projection.WorkflowID)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if affected == 0 {
+		if err := rejectWorkflowIDMismatch(ctx, tx, id, projection.WorkflowID); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	if event.JobID == "" {
+		event.JobID = id
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+		return false, err
 	}
 	return true, tx.Commit()
 }
@@ -8800,5 +8983,19 @@ ALTER TABLE workflow_meta ADD COLUMN summary TEXT NOT NULL DEFAULT '';
 	// non-default intervals, including the production 3m0s values, survive.
 	`
 UPDATE repos SET poll_interval = '' WHERE poll_interval = '30s';
+	// #913 task dismissal lifecycle audit. Task state is already unconstrained
+	// TEXT, so the state itself needs no column migration; this append-only table
+	// records every explicit manual, automatic, and recovery transition.
+	`
+CREATE TABLE task_events (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	task_id TEXT NOT NULL,
+	kind TEXT NOT NULL,
+	from_state TEXT NOT NULL DEFAULT '',
+	to_state TEXT NOT NULL DEFAULT '',
+	reason TEXT NOT NULL DEFAULT '',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_task_events_task_id_id ON task_events(task_id, id);
 	`,
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -9065,11 +9065,12 @@ ALTER TABLE workflow_meta ADD COLUMN summary TEXT NOT NULL DEFAULT '';
 	// non-default intervals, including the production 3m0s values, survive.
 	`
 UPDATE repos SET poll_interval = '' WHERE poll_interval = '30s';
+	`,
 	// #913 task dismissal lifecycle audit. Task state is already unconstrained
 	// TEXT, so the state itself needs no column migration; this append-only table
 	// records every explicit manual, automatic, and recovery transition.
 	`
-CREATE TABLE task_events (
+CREATE TABLE IF NOT EXISTS task_events (
 	id INTEGER PRIMARY KEY AUTOINCREMENT,
 	task_id TEXT NOT NULL,
 	kind TEXT NOT NULL,
@@ -9078,6 +9079,6 @@ CREATE TABLE task_events (
 	reason TEXT NOT NULL DEFAULT '',
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-CREATE INDEX idx_task_events_task_id_id ON task_events(task_id, id);
+CREATE INDEX IF NOT EXISTS idx_task_events_task_id_id ON task_events(task_id, id);
 	`,
 }

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -3000,7 +3000,20 @@ func TestPollIntervalInheritanceMigrationPreservesExplicitValues(t *testing.T) {
 	}
 	defer raw.Close()
 	store := &Store{db: raw}
-	for version, migration := range migrations[:len(migrations)-1] {
+	// Locate the poll-interval inheritance migration by content rather than by
+	// slice position so later appended migrations cannot silently retarget this
+	// test at an unrelated entry.
+	pollIdx := -1
+	for i, migration := range migrations {
+		if strings.Contains(migration, "poll_interval = ''") {
+			pollIdx = i
+			break
+		}
+	}
+	if pollIdx < 0 {
+		t.Fatal("poll interval inheritance migration not found")
+	}
+	for version, migration := range migrations[:pollIdx] {
 		if err := store.applyMigration(ctx, version+1, migration); err != nil {
 			t.Fatalf("applyMigration(%d): %v", version+1, err)
 		}
@@ -3011,7 +3024,7 @@ func TestPollIntervalInheritanceMigrationPreservesExplicitValues(t *testing.T) {
 			t.Fatalf("insert %s: %v", value, err)
 		}
 	}
-	if err := store.applyMigration(ctx, len(migrations), migrations[len(migrations)-1]); err != nil {
+	if err := store.applyMigration(ctx, pollIdx+1, migrations[pollIdx]); err != nil {
 		t.Fatalf("apply poll interval migration: %v", err)
 	}
 	for repo, want := range map[string]string{

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -34,6 +34,7 @@ func TestOpenMigratesSchema(t *testing.T) {
 		"seen_comments",
 		"jobs",
 		"job_events",
+		"task_events",
 		"branch_locks",
 		"lock_events",
 		"resource_locks",

--- a/internal/db/task_events_test.go
+++ b/internal/db/task_events_test.go
@@ -1,0 +1,59 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestTaskEventsMigrationAppliesToExistingDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	legacy, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.db.Exec(`DROP TABLE task_events; DELETE FROM schema_migrations WHERE version = ?`, len(migrations)); err != nil {
+		t.Fatalf("rewind newest migration: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open existing db: %v", err)
+	}
+	defer store.Close()
+	if ok, err := store.HasTable(context.Background(), "task_events"); err != nil || !ok {
+		t.Fatalf("task_events table ok=%v err=%v", ok, err)
+	}
+}
+
+func TestTransitionTaskStateWithEventAtomicCASAndOrdering(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	if err := store.UpsertTask(ctx, Task{ID: "task-1", State: "implementing"}); err != nil {
+		t.Fatal(err)
+	}
+	changed, current, err := store.TransitionTaskStateWithEvent(ctx, "task-1", []string{"implementing", "blocked"}, "dismissed", "task_dismissed_manual", "done")
+	if err != nil || !changed || current != "dismissed" {
+		t.Fatalf("first transition = changed %v current %q err %v", changed, current, err)
+	}
+	changed, current, err = store.TransitionTaskStateWithEvent(ctx, "task-1", []string{"implementing", "blocked"}, "dismissed", "task_dismissed_manual", "again")
+	if err != nil || changed || current != "dismissed" {
+		t.Fatalf("idempotent transition = changed %v current %q err %v", changed, current, err)
+	}
+	changed, current, err = store.TransitionTaskStateWithEvent(ctx, "task-1", []string{"blocked"}, "planned", "should_not_exist", "bad cas")
+	if err != nil || changed || current != "dismissed" {
+		t.Fatalf("failed CAS = changed %v current %q err %v", changed, current, err)
+	}
+	if err := store.AddTaskEvent(ctx, TaskEvent{TaskID: "task-1", Kind: "note", Reason: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListTaskEvents(ctx, "task-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 || events[0].Kind != "task_dismissed_manual" || events[0].FromState != "implementing" || events[0].ToState != "dismissed" || events[1].Kind != "note" || events[0].ID >= events[1].ID {
+		t.Fatalf("events = %+v", events)
+	}
+}

--- a/internal/db/task_events_test.go
+++ b/internal/db/task_events_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 )
@@ -55,5 +56,37 @@ func TestTransitionTaskStateWithEventAtomicCASAndOrdering(t *testing.T) {
 	}
 	if len(events) != 2 || events[0].Kind != "task_dismissed_manual" || events[0].FromState != "implementing" || events[0].ToState != "dismissed" || events[1].Kind != "note" || events[0].ID >= events[1].ID {
 		t.Fatalf("events = %+v", events)
+	}
+}
+
+func TestGuardedTaskTransitionRefusesMatchingActiveJob(t *testing.T) {
+	tests := []struct {
+		name    string
+		state   string
+		payload string
+	}{
+		{name: "task id queued", state: "queued", payload: `{"repo":"other/repo","branch":"other","task_id":"task-1"}`},
+		{name: "repo branch running", state: "running", payload: `{"repo":"owner/repo","branch":"feature/one","task_id":"other"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := openWorkflowTestStore(t)
+			ctx := context.Background()
+			if err := store.UpsertTask(ctx, Task{ID: "task-1", RepoFullName: "owner/repo", Branch: "feature/one", State: "implementing"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.CreateJob(ctx, Job{ID: "job-1", Type: "review", State: test.state, Payload: test.payload}); err != nil {
+				t.Fatal(err)
+			}
+			changed, current, err := store.TransitionTaskStateWithEventIfNoActiveJob(ctx, "task-1", []string{"implementing"}, "dismissed", "task_dismissed_manual", "test")
+			if changed || current != "implementing" || !errors.Is(err, ErrTaskHasActiveJob) {
+				t.Fatalf("transition = changed %v current %q err %v", changed, current, err)
+			}
+			task, getErr := store.GetTask(ctx, "task-1")
+			events, listErr := store.ListTaskEvents(ctx, "task-1")
+			if getErr != nil || listErr != nil || task.State != "implementing" || len(events) != 0 {
+				t.Fatalf("task=%+v events=%+v getErr=%v listErr=%v", task, events, getErr, listErr)
+			}
+		})
 	}
 }

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -131,6 +131,41 @@ func (c Client) BranchExists(ctx context.Context, branch string) (bool, error) {
 	return true, nil
 }
 
+// RemoteBranches returns the requested branches that exist on origin using one
+// exact-ref ls-remote call. Callers batch a bounded candidate set so stale-task
+// reconciliation never performs one subprocess/network round trip per task.
+func (c Client) RemoteBranches(ctx context.Context, branches []string) (map[string]struct{}, error) {
+	out := map[string]struct{}{}
+	if len(branches) == 0 {
+		return out, nil
+	}
+	args := []string{"ls-remote", "--heads", "origin"}
+	requested := make(map[string]string, len(branches))
+	for _, branch := range branches {
+		branch = strings.TrimSpace(branch)
+		if err := validateBranch(branch); err != nil {
+			return nil, err
+		}
+		ref := "refs/heads/" + branch
+		args = append(args, ref)
+		requested[ref] = branch
+	}
+	result, err := c.run(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if branch, ok := requested[fields[1]]; ok {
+			out[branch] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
 func (c Client) RemoveWorktree(ctx context.Context, path string) error {
 	path, err := validateWorktreePath(path)
 	if err != nil {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -395,6 +395,21 @@ func TestClientBranchExistsReturnsFalseForMissingBranch(t *testing.T) {
 	runner.wantArgs(t, 0, "git", "show-ref", "--verify", "--quiet", "refs/heads/missing")
 }
 
+func TestClientRemoteBranchesBatchesExactRefs(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "abc\trefs/heads/feature/one\ndef\trefs/heads/unrequested\n"}}}
+	branches, err := (Client{Runner: runner, Dir: "/repo"}).RemoteBranches(context.Background(), []string{"feature/one", "feature/two"})
+	if err != nil {
+		t.Fatalf("RemoteBranches: %v", err)
+	}
+	if _, ok := branches["feature/one"]; !ok || len(branches) != 1 {
+		t.Fatalf("branches = %v", branches)
+	}
+	runner.wantArgs(t, 0, "git", "ls-remote", "--heads", "origin", "refs/heads/feature/one", "refs/heads/feature/two")
+	if _, err := (Client{}).RemoteBranches(context.Background(), []string{"bad branch"}); err == nil {
+		t.Fatal("RemoteBranches accepted unsafe branch")
+	}
+}
+
 func TestClientHeadSHA(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "abc123\n"}}}
 	sha, err := (Client{Runner: runner, Dir: "/repo"}).HeadSHA(context.Background())

--- a/internal/workflow/branch.go
+++ b/internal/workflow/branch.go
@@ -39,6 +39,13 @@ func (e Engine) StartTaskBranch(ctx context.Context, request TaskBranchRequest, 
 	if err := validateTaskBranchRequest(request); err != nil {
 		return db.Task{}, err
 	}
+	if task, err := e.Store.GetTask(ctx, request.TaskID); err == nil {
+		if task.State == string(TaskDismissed) {
+			return db.Task{}, fmt.Errorf("task %s is dismissed; recover it explicitly before starting a branch", request.TaskID)
+		}
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return db.Task{}, err
+	}
 	existing, err := e.Store.GetTaskByRepoBranch(ctx, request.Repo, request.Branch)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return db.Task{}, err

--- a/internal/workflow/branch_test.go
+++ b/internal/workflow/branch_test.go
@@ -45,6 +45,22 @@ func TestEngineStartTaskBranchCreatesBranchAndLock(t *testing.T) {
 	}
 }
 
+func TestEngineStartTaskBranchRejectsDismissedTask(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-dismissed", RepoFullName: "owner/repo", State: string(TaskDismissed), Branch: "feature/dismissed"}); err != nil {
+		t.Fatal(err)
+	}
+	brancher := &fakeBranchCreator{}
+	_, err := testEngine(store).StartTaskBranch(ctx, TaskBranchRequest{Repo: "owner/repo", TaskID: "task-dismissed", Branch: "feature/dismissed", Owner: "lead"}, brancher)
+	if err == nil || !strings.Contains(err.Error(), "dismissed") {
+		t.Fatalf("StartTaskBranch error = %v", err)
+	}
+	if len(brancher.calls) != 0 {
+		t.Fatalf("brancher calls = %+v", brancher.calls)
+	}
+}
+
 func TestEngineStartTaskBranchAcquiresCheckoutMutationLockBeforeBranchSetup(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -6783,6 +6783,9 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 		return err
 	}
 	if err == nil {
+		if existing.State == string(TaskDismissed) && state != TaskDismissed {
+			return fmt.Errorf("task %s is dismissed; workflow advancement cannot move it to %s", existing.ID, state)
+		}
 		if task.GoalID == "" {
 			task.GoalID = existing.GoalID
 		}
@@ -6809,6 +6812,9 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 			return berr
 		}
 		if berr == nil && byBranch.ID != task.ID {
+			if byBranch.State == string(TaskDismissed) && state != TaskDismissed {
+				return fmt.Errorf("task %s is dismissed; workflow advancement cannot move it to %s", byBranch.ID, state)
+			}
 			byBranch.State = string(state)
 			return e.Store.UpsertTask(ctx, byBranch)
 		}

--- a/internal/workflow/job_recovery.go
+++ b/internal/workflow/job_recovery.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -101,11 +102,26 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 	if err != nil {
 		return db.Job{}, err
 	}
-	transitioned, err := store.TransitionJobStatePayloadWithEvent(ctx, job.ID, job.State, string(JobQueued), encoded, db.JobEvent{
+	retryEvent := db.JobEvent{
 		JobID:   job.ID,
 		Kind:    "retry_queued",
 		Message: fmt.Sprintf("retry requested from %s", job.State),
-	})
+	}
+	transitioned := false
+	if task, ok, err := dismissedTaskForJob(ctx, store, payload); err != nil {
+		return db.Job{}, err
+	} else if ok {
+		taskState := string(TaskPlanned)
+		if job.Type == "implement" && strings.TrimSpace(payload.Branch) != "" && strings.TrimSpace(payload.WorktreePath) != "" {
+			taskState = string(TaskImplementing)
+		}
+		transitioned, err = store.TransitionJobStatePayloadWithEventAndTaskTransition(ctx,
+			job.ID, job.State, string(JobQueued), encoded, retryEvent,
+			task.ID, string(TaskDismissed), taskState, "task_recovered_job_retry",
+			fmt.Sprintf("restored dismissed task before retrying job %s", job.ID))
+	} else {
+		transitioned, err = store.TransitionJobStatePayloadWithEvent(ctx, job.ID, job.State, string(JobQueued), encoded, retryEvent)
+	}
 	if err != nil {
 		return db.Job{}, err
 	}
@@ -117,6 +133,29 @@ func RetryJob(ctx context.Context, store *db.Store, jobID string) (db.Job, error
 		return db.Job{}, fmt.Errorf("job %s is %s; retry requires failed, blocked, or cancelled", latest.ID, latest.State)
 	}
 	return store.GetJob(ctx, job.ID)
+}
+
+func dismissedTaskForJob(ctx context.Context, store *db.Store, payload JobPayload) (db.Task, bool, error) {
+	if taskID := strings.TrimSpace(payload.TaskID); taskID != "" {
+		task, err := store.GetTask(ctx, taskID)
+		if err == nil && task.State == string(TaskDismissed) {
+			return task, true, nil
+		}
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return db.Task{}, false, err
+		}
+	}
+	if strings.TrimSpace(payload.Repo) == "" || strings.TrimSpace(payload.Branch) == "" {
+		return db.Task{}, false, nil
+	}
+	task, err := store.GetTaskByRepoBranch(ctx, payload.Repo, payload.Branch)
+	if errors.Is(err, sql.ErrNoRows) {
+		return db.Task{}, false, nil
+	}
+	if err != nil {
+		return db.Task{}, false, err
+	}
+	return task, task.State == string(TaskDismissed), nil
 }
 
 // GateResumeOutcome is the result of MaybeResumeOnGatesCleared (#682): whether the

--- a/internal/workflow/job_recovery_test.go
+++ b/internal/workflow/job_recovery_test.go
@@ -138,6 +138,58 @@ func TestRetryJobPreservesTaskWorktreePath(t *testing.T) {
 	}
 }
 
+func TestRetryJobRecoversDismissedTaskAtomically(t *testing.T) {
+	tests := []struct {
+		name      string
+		jobType   string
+		payload   string
+		wantState TaskState
+	}{
+		{name: "implement artifacts", jobType: "implement", payload: `{"repo":"owner/repo","branch":"feature","task_id":"task-1","worktree_path":"/tmp/task-1"}`, wantState: TaskImplementing},
+		{name: "non implement", jobType: "review", payload: `{"repo":"owner/repo","branch":"feature","task_id":"task-1"}`, wantState: TaskPlanned},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openTestStore(t)
+			if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", State: string(TaskDismissed), Branch: "feature", WorktreePath: "/tmp/task-1"}); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Type: test.jobType, State: string(JobFailed), Payload: test.payload}, db.JobEvent{Kind: string(JobFailed)}); err != nil {
+				t.Fatal(err)
+			}
+			job, err := RetryJob(ctx, store, "job-1")
+			if err != nil || job.State != string(JobQueued) {
+				t.Fatalf("RetryJob job=%+v err=%v", job, err)
+			}
+			task, _ := store.GetTask(ctx, "task-1")
+			events, _ := store.ListTaskEvents(ctx, "task-1")
+			if task.State != string(test.wantState) || len(events) != 1 || events[0].Kind != "task_recovered_job_retry" || events[0].FromState != string(TaskDismissed) || events[0].ToState != string(test.wantState) {
+				t.Fatalf("task=%+v events=%+v", task, events)
+			}
+		})
+	}
+}
+
+func TestRetryJobRefusalLeavesDismissedTaskUntouched(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", State: string(TaskDismissed), Branch: "feature"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "job-1", Type: "implement", State: string(JobCancelled), Payload: `{"repo":"owner/repo","branch":"feature","task_id":"task-1","worktree_path":"/tmp/task-1"}`}, db.JobEvent{Kind: string(JobCancelled), Message: "cancel requested from running"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RetryJob(ctx, store, "job-1"); err == nil {
+		t.Fatal("RetryJob accepted unsettled running cancellation")
+	}
+	task, _ := store.GetTask(ctx, "task-1")
+	events, _ := store.ListTaskEvents(ctx, "task-1")
+	if task.State != string(TaskDismissed) || len(events) != 0 {
+		t.Fatalf("task=%+v events=%+v", task, events)
+	}
+}
+
 func TestRetryJobRejectsNonTerminalJob(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/workflow/set_task_state_branch_test.go
+++ b/internal/workflow/set_task_state_branch_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -57,5 +58,31 @@ func TestSetTaskStateBranchConflict(t *testing.T) {
 	}
 	if got, _ := store.GetTask(ctx, "task-a"); got.State != string(TaskBlocked) {
 		t.Errorf("same-id advance state = %q, want %q", got.State, string(TaskBlocked))
+	}
+}
+
+func TestSetTaskStateCannotResurrectDismissedTask(t *testing.T) {
+	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	const repo, branch = "owner/repo", "feature/dismissed"
+	if err := store.UpsertTask(ctx, db.Task{ID: "canonical", RepoFullName: repo, State: string(TaskDismissed), Branch: branch}); err != nil {
+		t.Fatal(err)
+	}
+	engine := Engine{Store: store}
+	for _, ref := range []taskRef{
+		{ID: "canonical", Repo: repo, Branch: branch},
+		{ID: "late-review", Repo: repo, Branch: branch},
+	} {
+		if err := engine.setTaskState(ctx, ref, TaskReviewing); err == nil || !strings.Contains(err.Error(), "dismissed") {
+			t.Fatalf("setTaskState(%+v) error = %v", ref, err)
+		}
+	}
+	task, _ := store.GetTask(ctx, "canonical")
+	if task.State != string(TaskDismissed) {
+		t.Fatalf("task resurrected to %s", task.State)
 	}
 }

--- a/internal/workflow/task_liveness.go
+++ b/internal/workflow/task_liveness.go
@@ -1,0 +1,84 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+// FindLiveTaskJob returns one job that still owns lifecycle progress for task.
+// Matching is deliberately broader than implement jobs: a redirected canonical
+// branch can be advanced by any job type, so either the payload task id or the
+// exact non-empty repo+branch identity is sufficient.
+func FindLiveTaskJob(ctx context.Context, store *db.Store, task db.Task) (db.Job, bool, error) {
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return db.Job{}, false, err
+	}
+	for _, job := range jobs {
+		payload, err := ParseJobPayload(job.Payload)
+		if err != nil || !jobMatchesTask(payload, task) {
+			continue
+		}
+		if job.State == string(JobQueued) || job.State == string(JobRunning) {
+			return job, true, nil
+		}
+		events, err := store.ListJobEvents(ctx, job.ID)
+		if err != nil {
+			return db.Job{}, false, err
+		}
+		if jobKeepsTaskLive(job, events) {
+			return job, true, nil
+		}
+	}
+	return db.Job{}, false, nil
+}
+
+func jobMatchesTask(payload JobPayload, task db.Task) bool {
+	if taskID := strings.TrimSpace(task.ID); taskID != "" && strings.TrimSpace(payload.TaskID) == taskID {
+		return true
+	}
+	branch := strings.TrimSpace(task.Branch)
+	return branch != "" && strings.TrimSpace(payload.Branch) == branch &&
+		strings.TrimSpace(payload.Repo) == strings.TrimSpace(task.RepoFullName)
+}
+
+func jobKeepsTaskLive(job db.Job, events []db.JobEvent) bool {
+	switch JobState(job.State) {
+	case JobQueued, JobRunning:
+		return true
+	}
+	if IsSettledJobState(job.State) && advancementPending(events) {
+		return true
+	}
+	return job.State == string(JobCancelled) && cancellationFromRunningUnsettled(events)
+}
+
+func advancementPending(events []db.JobEvent) bool {
+	pending := false
+	seen := false
+	for _, event := range events {
+		switch event.Kind {
+		case "advance_started", "advance_retry":
+			pending = true
+			seen = true
+		case "advance_completed", "advance_retried", "advance_blocked", "advance_retry_skipped", "retry_queued":
+			pending = false
+			seen = true
+		}
+	}
+	return seen && pending
+}
+
+func cancellationFromRunningUnsettled(events []db.JobEvent) bool {
+	for i := len(events) - 1; i >= 0; i-- {
+		switch events[i].Kind {
+		case "cancel_settled":
+			return false
+		case string(JobCancelled), JobEventSupersededStaleHead:
+			return strings.HasPrefix(events[i].Message, "cancel requested from running")
+		}
+	}
+	return false
+}

--- a/internal/workflow/task_liveness_test.go
+++ b/internal/workflow/task_liveness_test.go
@@ -1,0 +1,73 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+)
+
+func TestJobKeepsTaskLiveTable(t *testing.T) {
+	completionMarkers := []string{"advance_completed", "advance_retried", "advance_blocked", "advance_retry_skipped", "retry_queued"}
+	type testCase struct {
+		name   string
+		state  JobState
+		type_  string
+		events []db.JobEvent
+		want   bool
+	}
+	tests := []testCase{
+		{name: "succeeded pending advance", state: JobSucceeded, events: kinds("advance_started"), want: true},
+		{name: "failed retry pending", state: JobFailed, events: kinds("advance_retry"), want: true},
+		{name: "cancelled from running unsettled", state: JobCancelled, events: []db.JobEvent{{Kind: "cancelled", Message: "cancel requested from running"}}, want: true},
+		{name: "cancelled from queued", state: JobCancelled, events: []db.JobEvent{{Kind: "cancelled", Message: "cancel requested from queued"}}},
+		{name: "cancelled settled", state: JobCancelled, events: []db.JobEvent{{Kind: "cancelled", Message: "cancel requested from running"}, {Kind: "cancel_settled"}}},
+	}
+	for _, jobType := range []string{"ask", "review", "implement", "produce", "plan", "review-prep", "review-dispatch"} {
+		tests = append(tests,
+			testCase{name: "queued " + jobType, state: JobQueued, type_: jobType, want: true},
+			testCase{name: "running " + jobType, state: JobRunning, type_: jobType, want: true},
+		)
+	}
+	for _, marker := range completionMarkers {
+		tests = append(tests, testCase{name: "settled by " + marker, state: JobSucceeded, events: kinds("advance_started", marker)})
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			job := db.Job{ID: "job", Type: test.type_, State: string(test.state)}
+			if got := jobKeepsTaskLive(job, test.events); got != test.want {
+				t.Fatalf("jobKeepsTaskLive(%s, %v) = %v, want %v", test.state, test.events, got, test.want)
+			}
+		})
+	}
+}
+
+func TestJobMatchesTaskIdentityTable(t *testing.T) {
+	task := db.Task{ID: "task-1", RepoFullName: "owner/repo", Branch: "feature/one"}
+	tests := []struct {
+		name    string
+		payload JobPayload
+		task    db.Task
+		want    bool
+	}{
+		{name: "task id", payload: JobPayload{TaskID: "task-1"}, task: task, want: true},
+		{name: "repo branch", payload: JobPayload{Repo: "owner/repo", Branch: "feature/one"}, task: task, want: true},
+		{name: "wrong repo", payload: JobPayload{Repo: "other/repo", Branch: "feature/one"}, task: task},
+		{name: "wrong branch", payload: JobPayload{Repo: "owner/repo", Branch: "feature/two"}, task: task},
+		{name: "empty task branch never matches", payload: JobPayload{Repo: "owner/repo", Branch: ""}, task: db.Task{ID: "other", RepoFullName: "owner/repo"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := jobMatchesTask(test.payload, test.task); got != test.want {
+				t.Fatalf("jobMatchesTask(%+v, %+v) = %v, want %v", test.payload, test.task, got, test.want)
+			}
+		})
+	}
+}
+
+func kinds(values ...string) []db.JobEvent {
+	events := make([]db.JobEvent, 0, len(values))
+	for _, value := range values {
+		events = append(events, db.JobEvent{Kind: value})
+	}
+	return events
+}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -11,6 +11,7 @@ const (
 	TaskReadyToMerge     TaskState = "ready_to_merge"
 	TaskMerged           TaskState = "merged"
 	TaskBlocked          TaskState = "blocked"
+	TaskDismissed        TaskState = "dismissed"
 	// TaskAwaitingHuman is the resumable pause state a task enters when a
 	// delegation fails under the escalate_human failure_policy (#340). Unlike
 	// TaskBlocked (terminal), it is a durable human-in-the-loop pause: the tree

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -102,6 +102,9 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		}
 		task = db.Task{ID: request.TaskID, RepoFullName: request.Repo, State: string(TaskPlanned)}
 	}
+	if task.State == string(TaskDismissed) {
+		return db.Task{}, fmt.Errorf("task %s is dismissed; recover it explicitly before allocating a worktree", request.TaskID)
+	}
 	if strings.TrimSpace(task.RepoFullName) != "" && task.RepoFullName != request.Repo {
 		return db.Task{}, fmt.Errorf("task %s belongs to repo %s, not %s", request.TaskID, task.RepoFullName, request.Repo)
 	}

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -115,6 +115,22 @@ func TestEngineAllocateTaskWorktreeAddsGitWorktreeAndStoresPath(t *testing.T) {
 	}
 }
 
+func TestEngineAllocateTaskWorktreeRejectsDismissedTask(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-dismissed", RepoFullName: "owner/repo", State: string(TaskDismissed), Branch: "feature/dismissed", WorktreePath: "/tmp/preserved"}); err != nil {
+		t.Fatal(err)
+	}
+	manager := &fakeWorktreeManager{}
+	_, err := testEngine(store).AllocateTaskWorktree(ctx, TaskWorktreeRequest{Home: t.TempDir(), Repo: "owner/repo", TaskID: "task-dismissed", Branch: "feature/dismissed", Owner: "lead"}, manager)
+	if err == nil || !strings.Contains(err.Error(), "dismissed") {
+		t.Fatalf("AllocateTaskWorktree error = %v", err)
+	}
+	if len(manager.calls) != 0 {
+		t.Fatalf("manager calls = %+v", manager.calls)
+	}
+}
+
 func TestEngineAllocateTaskWorktreeWaitsForCheckoutMutationLock(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1149,9 +1149,11 @@ gitmoot task recover task-001 --owner lead
 gitmoot task recover task-001 --owner lead --repo owner/repo --skip-native-review-fanout --json
 ```
 
-`--owner <agent>` is required (a registered implement-capable agent, attributed
-as the recovery lead). `--repo owner/repo` is optional — it falls back to the
-task's stored repo and is only required when the task carries none.
+`--owner <agent>` is required when recovering preserved branch/worktree
+artifacts (a registered implement-capable agent, attributed as the recovery
+lead). A dismissed task with no branch returns directly to `planned`, so that
+path does not require `--owner`. `--repo owner/repo` is optional — it falls back
+to the task's stored repo and is only required when the task carries none.
 `--skip-native-review-fanout` persists that flag before the PR is opened;
 `--json` prints the machine-readable recovery result.
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1115,11 +1115,26 @@ Start a task in its dedicated branch worktree and inspect task state:
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task list --repo owner/repo
 gitmoot task list --repo owner/repo --state implementing --json
+gitmoot task dismiss task-001 --reason "abandoned experiment"
+gitmoot task events task-001 --json
 ```
 
 `task run` stores the deterministic task worktree path under
 `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/` and leaves the registered
 checkout on its current branch.
+
+`task dismiss` is an explicit terminal action for stale `implementing` or
+`blocked` tasks. It refuses planned, PR/review/merge, awaiting-human, unknown,
+or otherwise machine-owned states; any live queued/running job, unsettled
+post-delivery advancement, unsettled running cancellation, or live process in
+the task worktree also blocks dismissal. The default reason is `dismissed by
+operator`. Success preserves the branch and worktree, releases the branch lock
+best-effort, and appends `task_dismissed_manual` to `task events`. Repeating the
+command is an exit-0 no-op with `changed:false` in JSON.
+
+`task events <id>` prints the append-only task lifecycle trail. Automatic stale
+dismissals use `task_dismissed_auto`; explicit recovery and retry use
+`task_recovered` and `task_recovered_job_retry`.
 
 ### Recover A Dead Implement
 
@@ -1145,6 +1160,14 @@ untracked non-ignored files), pushes the task branch, and opens or adopts the
 task's PR — the exact finalize steps the dead implementer never reached. If the
 worktree is already clean it recovers the commit already ahead of the base
 (and refuses when there is nothing ahead to recover).
+
+Recovery is also the only task-level escape hatch from `dismissed`. A dismissed
+task with a preserved branch and worktree first moves to `implementing`, then to
+`pr_open` after finalization. A branchless auto-dismissed task instead returns to
+`planned` and prints guidance to use `task run`. Ordinary `task run`, branch or
+worktree allocation, review continuation, and task-state advancement never
+resurrect a dismissed task implicitly. Retrying one of its jobs explicitly
+restores the task first and records `task_recovered_job_retry`.
 
 Two refusals guard `task recover` (and the `task run` / `agent implement`
 restart that points to it):

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -268,11 +268,14 @@ cannot recurse or fan out forever:
   `human_questions[]` is byte-identical to today's behavior.
 
 - Dismissed task terminality (#913): `dismissed` may be entered only from
-  `implementing` or `blocked` after Gitmoot proves there is no live matching job
-  and no process in the task worktree. Ordinary task run/allocation and late
-  review or continuation advancement fail closed instead of overwriting it.
-  Only `task recover` or retrying a job performs an explicit audited recovery.
-  Dismissal never deletes the task branch or worktree.
+  `implementing` or `blocked`. Manual `task dismiss` proves there is no live
+  matching job and no process in the task worktree. Automatic stale-task
+  reconciliation proves there is no live matching job and requires its separate
+  open-PR/remote-branch evidence, but does not inspect worktree processes.
+  Ordinary task run/allocation and late review or continuation advancement fail
+  closed instead of overwriting it. Only `task recover` or retrying a job performs
+  an explicit audited recovery. Dismissal never deletes the task branch or
+  worktree.
 
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, a delegation batch

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -267,6 +267,13 @@ cannot recurse or fan out forever:
   on a failure round — a mismatch is rejected with a clear message. Absence of
   `human_questions[]` is byte-identical to today's behavior.
 
+- Dismissed task terminality (#913): `dismissed` may be entered only from
+  `implementing` or `blocked` after Gitmoot proves there is no live matching job
+  and no process in the task worktree. Ordinary task run/allocation and late
+  review or continuation advancement fail closed instead of overwriting it.
+  Only `task recover` or retrying a job performs an explicit audited recovery.
+  Dismissal never deletes the task branch or worktree.
+
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, a delegation batch
 of new jobs would exceed the per-root job budget of 64). Rather than stopping

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -697,6 +697,24 @@ worktree state (`git add -A`, incl. untracked non-ignored files), pushes the
 branch, and opens or adopts the PR. `--repo` is optional (falls back to the
 task's repo). Recovery refuses while a live process is still inside the worktree.
 
+**Task dismissal and stale reconciliation:** `dismissed` is a terminal task
+state for implicit workflow transitions. An operator can run `gitmoot task
+dismiss <id> [--reason ...]` only from `implementing` or `blocked`; Gitmoot
+refuses while any matching job is live or a process remains in the task
+worktree. The branch and worktree are preserved, while the branch lock is
+released best-effort. Manual and daemon transitions are audited as
+`task_dismissed_manual` and `task_dismissed_auto` in `gitmoot task events <id>`.
+
+Each repo poll also considers up to 20 oldest `implementing`/`blocked` tasks
+whose `updated_at` predates `[workflow].stale_task_ttl` (default `168h`; `"0"`
+disables the leg). `updated_at` is deliberately a conservative activity proxy,
+not proof of abandonment. A candidate is skipped for a live job, an open-PR
+branch, or an exact branch still present on `origin`; remote lookup uncertainty
+skips mutation. A branchless candidate needs no remote lookup. Explicit `task
+recover` restores preserved artifacts through `implementing` to `pr_open`, or
+restores a branchless task to `planned`; job retry records its own recovery
+event. The server-side task board omits dismissed rows immediately.
+
 **PR-bound fix pass:** use `gitmoot agent implement <agent> --repo owner/repo
 --pr <number> "..."` or `gitmoot agent run <agent> --repo owner/repo --action
 implement --pr <number> "..."` to send an existing open PR back through its

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -695,7 +695,9 @@ over a dirty worktree with no active job (so nothing is discarded) and point at
 `gitmoot task recover <task-id> --owner <agent>`, which commits the full
 worktree state (`git add -A`, incl. untracked non-ignored files), pushes the
 branch, and opens or adopts the PR. `--repo` is optional (falls back to the
-task's repo). Recovery refuses while a live process is still inside the worktree.
+task's repo). `--owner` is required for this artifact-finalization path, but not
+when a dismissed branchless task is simply restored to `planned`. Recovery
+refuses while a live process is still inside the worktree.
 
 **Task dismissal and stale reconciliation:** `dismissed` is a terminal task
 state for implicit workflow transitions. An operator can run `gitmoot task
@@ -705,12 +707,13 @@ worktree. The branch and worktree are preserved, while the branch lock is
 released best-effort. Manual and daemon transitions are audited as
 `task_dismissed_manual` and `task_dismissed_auto` in `gitmoot task events <id>`.
 
-Each repo poll also considers up to 20 oldest `implementing`/`blocked` tasks
-whose `updated_at` predates `[workflow].stale_task_ttl` (default `168h`; `"0"`
-disables the leg). `updated_at` is deliberately a conservative activity proxy,
-not proof of abandonment. A candidate is skipped for a live job, an open-PR
-branch, or an exact branch still present on `origin`; remote lookup uncertainty
-skips mutation. A branchless candidate needs no remote lookup. Explicit `task
+Each repo poll reads a bounded oldest-first stale window and processes up to 20
+qualifying `implementing`/`blocked` tasks whose `updated_at` predates
+`[workflow].stale_task_ttl` (default `168h`; `"0"` disables the leg).
+`updated_at` is deliberately a conservative activity proxy, not proof of
+abandonment. A candidate is skipped for a live job, a same-repo open-PR branch,
+or an exact branch still present on `origin`; remote lookup uncertainty skips
+mutation. A branchless candidate needs no remote lookup. Explicit `task
 recover` restores preserved artifacts through `implementing` to `pr_open`, or
 restores a branchless task to `planned`; job retry records its own recovery
 event. The server-side task board omits dismissed rows immediately.

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -37,8 +37,9 @@ Tasks is a read-only lifecycle board backed by Gitmoot's task registry. Internal
 states are projected into **implementing**, **PR open**, **blocked**, and
 **merged** columns; planned and unknown states are omitted, review,
 changes-requested, and ready-to-merge tasks remain in PR open, and awaiting-human
-tasks appear as blocked. Merged history is limited server-side to the last seven
-days.
+tasks appear as blocked. Dismissed tasks are excluded by the server-side query,
+and task-event cursor invalidation removes a newly dismissed card immediately.
+Merged history is limited server-side to the last seven days.
 
 Cards carry the task title, repository, assigned branch-lock owner when one is
 known, pull-request number, last-update age, and a blocked reason. The CI dot is

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -985,9 +985,11 @@ gitmoot task recover task-001 --owner lead
 gitmoot task recover task-001 --owner lead --repo owner/repo --skip-native-review-fanout --json
 ```
 
-`--owner <agent>` is required and names a registered implement-capable agent,
-attributed as the recovery lead. `--repo owner/repo` is optional and falls back
-to the task's stored repo, so it is only needed when the task carries none.
+`--owner <agent>` is required for preserved branch/worktree recovery and names a
+registered implement-capable agent attributed as the recovery lead. A dismissed
+task with no branch returns directly to `planned`, so that path does not require
+`--owner`. `--repo owner/repo` is optional and falls back to the task's stored
+repo, so it is only needed when the task carries none.
 `--skip-native-review-fanout` persists that flag before the PR is opened, and
 `--json` prints the machine-readable recovery result.
 
@@ -1003,11 +1005,13 @@ task returns to `planned` with guidance to use `task run`. Ordinary allocation
 and workflow advancement cannot resurrect the task. Retrying one of its jobs
 restores it explicitly and records `task_recovered_job_retry`.
 
-The daemon scans up to 20 oldest stale `implementing`/`blocked` tasks per repo
-poll. `[workflow].stale_task_ttl = "168h"` is the default and `"0"` disables the
-leg. `updated_at` is a conservative activity proxy. Live jobs, open-PR branches,
-branches still present on `origin`, and remote-check uncertainty all prevent
-automatic dismissal; successful transitions record `task_dismissed_auto`.
+The daemon reads a bounded oldest-first stale window and processes up to 20
+qualifying `implementing`/`blocked` tasks per repo poll.
+`[workflow].stale_task_ttl = "168h"` is the default and `"0"` disables the leg.
+`updated_at` is a conservative activity proxy. Live jobs, same-repo open-PR
+branches, branches still present on `origin`, and remote-check uncertainty all
+prevent automatic dismissal; successful transitions record
+`task_dismissed_auto`.
 
 Two refusals guard recovery (and the `task run` / `agent implement` restart that
 points to it):

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -956,11 +956,21 @@ Start a task in its dedicated branch worktree and inspect task state:
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task list --repo owner/repo
 gitmoot task list --repo owner/repo --state implementing --json
+gitmoot task dismiss task-001 --reason "abandoned experiment"
+gitmoot task events task-001 --json
 ```
 
 `task run` stores the deterministic task worktree path under
 `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/` and leaves the registered
 checkout on its current branch.
+
+`task dismiss` is an explicit terminal action for stale `implementing` or
+`blocked` tasks. It refuses states owned by planning, PR/review/merge, or human
+resume machinery, and refuses while a matching job or worktree process remains
+live. It preserves branch and worktree, releases the branch lock best-effort,
+and records `task_dismissed_manual`; an already-dismissed task is an exit-0
+no-op (`changed:false` in JSON). `task events <id>` lists the append-only trail,
+including daemon `task_dismissed_auto` and explicit recovery events.
 
 ### Recover a dead implement
 
@@ -986,6 +996,18 @@ untracked non-ignored files), pushes the task branch, and opens or adopts the
 task's PR — the finalize steps the dead implementer never reached. When the
 worktree is already clean it recovers the commit already ahead of the base, and
 refuses when there is nothing ahead to recover.
+
+`task recover` is also the only task-level recovery from `dismissed`. Preserved
+branch/worktree artifacts move through `implementing` to `pr_open`; a branchless
+task returns to `planned` with guidance to use `task run`. Ordinary allocation
+and workflow advancement cannot resurrect the task. Retrying one of its jobs
+restores it explicitly and records `task_recovered_job_retry`.
+
+The daemon scans up to 20 oldest stale `implementing`/`blocked` tasks per repo
+poll. `[workflow].stale_task_ttl = "168h"` is the default and `"0"` disables the
+leg. `updated_at` is a conservative activity proxy. Live jobs, open-PR branches,
+branches still present on `origin`, and remote-check uncertainty all prevent
+automatic dismissal; successful transitions record `task_dismissed_auto`.
 
 Two refusals guard recovery (and the `task run` / `agent implement` restart that
 points to it):


### PR DESCRIPTION
Implements #913 exactly as frozen by the tri-model panel (synthesis on the issue): the board's missing janitor.

## What
- New terminal `dismissed` task state — explicit recovery only; resurrection seams guarded (task run / branch+worktree allocation / **review dispatch** refuse dismissed tasks outside recovery).
- The one migration: `task_events` audit table + atomic CAS transition (`TransitionTaskStateWithEvent[IfNoActiveJob]`) — the guarded variant closes the check-vs-transition race by rejecting queued/running matching jobs inside the same transaction.
- `gitmoot task dismiss <id> [--reason] [--json]` (implementing/blocked only; refuses live jobs via widened liveness incl. the post-terminal finalizer window; idempotent; releases the branch lock, preserves branch+worktree) and `gitmoot task events <id>`.
- Daemon stale-task reconciler after the #899 legs: `[workflow] stale_task_ttl` (default 168h, 0 disables, invalid=log+skip), `updated_at` staleness proxy, fetch-wide-filter-then-cap-20/repo/tick (no starvation), open-PR positive proof (same-repo heads only — fork PRs don't protect), ONE batched `git ls-remote --heads` behind a fakeable seam, ANY remote uncertainty = skip whole batch, `task_dismissed_auto` events with reason detail.
- Recover: dismissed+artifacts → implementing → pr_open on finalization (also fixes the pre-existing gap where recover's success never updated task state); branchless dismissed → planned (no --owner needed); RetryJob restores task state or refuses. The #793-shared predicate is **byte-identical** (verified by revision diff); recover uses a separate predicate.
- Board: server-side hiding (mapper case + SQL exclusion + task-events component in the change cursor). Change cursor is documented-opaque; format widened 2→3 components (no client parses it).

## Verification
- Tri-model panel (fable+sol+kimi, all seats) froze the design incl. two corrections to the original issue text; synthesis on #913.
- Adversarial review (kimi): 3 BLOCKING + 6 MAJOR found and fixed with dedicated regressions (review-dispatch resurrection ×2, dismiss TOCTOU, fork false-protection, cap starvation, recover-vs-finalizer race, CLI-driven E2E).
- Full gate green (db/workflow/daemon/config + 35m cli suite); `TestNoLLMShellTaskDismissAndRecoverE2E` drives the loop through the real CLI.
- Live E2E on a branch binary + isolated home: dismiss/idempotence/events/recover-with-artifacts all correct (branch genuinely pushed on recover); migration 81 rehearsed clean on a copy of the live store.

## Deploy notes
Reconciler defaults ON at 168h TTL (set `stale_task_ttl = "0"` to disable). After deploy the live board's ~15 stale implementing/blocked tasks will auto-dismiss over the following ticks — that is the intended cleanup of the state the owner reported. Migration 81 applies on first daemon start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)