### PR TITLE
fix(daemon): promote blocked/implementing tasks with open PRs to pr_open (#920)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -189,6 +189,9 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 			firstErr = err
 		}
 	}
+	if err := d.reconcilePROpenTasks(ctx, pulls); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	if err := d.reconcileExternallyMergedTasks(ctx, openPullNumbers); err != nil && firstErr == nil {
 		firstErr = err
 	}
@@ -327,6 +330,60 @@ func (d Daemon) logf(format string, args ...any) {
 		return
 	}
 	log.Printf(format, args...)
+}
+
+// reconcilePROpenTasks promotes implementing/blocked tasks whose branch carries
+// an open same-repo pull request back to pr_open (#920). It is a catch-up for
+// missed or mis-sequenced PR-open events: without it a wedged task hides its PR
+// from every "needs you" surface, which filters on pr_open. The promotion mirrors
+// what HandlePullRequestOpened would have recorded and cannot trigger a merge —
+// the merge gate acts only on ready_to_merge tasks. Fork heads are skipped:
+// HeadRef text can collide with a local branch name without being that branch.
+func (d Daemon) reconcilePROpenTasks(ctx context.Context, pulls []github.PullRequest) error {
+	if len(pulls) == 0 {
+		return nil
+	}
+	tasks, err := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
+	if err != nil {
+		return err
+	}
+	byBranch := map[string][]db.Task{}
+	for _, task := range tasks {
+		if task.State != string(workflow.TaskImplementing) && task.State != string(workflow.TaskBlocked) {
+			continue
+		}
+		branch := strings.TrimSpace(task.Branch)
+		if branch == "" {
+			continue
+		}
+		byBranch[branch] = append(byBranch[branch], task)
+	}
+	if len(byBranch) == 0 {
+		return nil
+	}
+	var firstErr error
+	for _, pull := range pulls {
+		headRepo := strings.TrimSpace(pull.HeadRepoFullName)
+		if headRepo != "" && headRepo != d.Repo.FullName() {
+			continue
+		}
+		for _, task := range byBranch[strings.TrimSpace(pull.HeadRef)] {
+			changed, _, err := d.Store.TransitionTaskStateWithEvent(ctx, task.ID,
+				[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
+				string(workflow.TaskPullRequestOpen), "task_pr_open_auto",
+				fmt.Sprintf("open PR #%d found for branch %s", pull.Number, pull.HeadRef))
+			if err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			if changed {
+				d.logf("task %s promoted %s -> pr_open: open PR #%d on %s", task.ID, task.State, pull.Number, pull.HeadRef)
+			}
+		}
+	}
+	return firstErr
 }
 
 // reconcileExternallyMergedTasks advances PR lifecycle tasks whose PR was

--- a/internal/daemon/pr_open_promotion_test.go
+++ b/internal/daemon/pr_open_promotion_test.go
@@ -1,0 +1,110 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/db"
+	"github.com/jerryfane/gitmoot/internal/github"
+	"github.com/jerryfane/gitmoot/internal/workflow"
+)
+
+// TestReconcilePROpenTasks proves the #920 catch-up: implementing/blocked tasks
+// whose branch carries an open same-repo PR are promoted to pr_open with an
+// audit event, while fork heads, other states, and unrelated branches stay put.
+func TestReconcilePROpenTasks(t *testing.T) {
+	tests := []struct {
+		name       string
+		state      workflow.TaskState
+		branch     string
+		pull       github.PullRequest
+		wantState  workflow.TaskState
+		wantEvent  bool
+		wantReason string
+	}{
+		{
+			name: "implementing promoted", state: workflow.TaskImplementing, branch: "feat/x",
+			pull:      github.PullRequest{Number: 470, HeadRef: "feat/x"},
+			wantState: workflow.TaskPullRequestOpen, wantEvent: true, wantReason: "open PR #470 found for branch feat/x",
+		},
+		{
+			name: "blocked promoted", state: workflow.TaskBlocked, branch: "feat/x",
+			pull:      github.PullRequest{Number: 470, HeadRef: "feat/x", HeadRepoFullName: "owner/repo"},
+			wantState: workflow.TaskPullRequestOpen, wantEvent: true, wantReason: "open PR #470",
+		},
+		{
+			name: "fork head ignored", state: workflow.TaskBlocked, branch: "feat/x",
+			pull:      github.PullRequest{Number: 470, HeadRef: "feat/x", HeadRepoFullName: "fork/repo"},
+			wantState: workflow.TaskBlocked,
+		},
+		{
+			name: "unrelated branch ignored", state: workflow.TaskBlocked, branch: "feat/other",
+			pull:      github.PullRequest{Number: 470, HeadRef: "feat/x"},
+			wantState: workflow.TaskBlocked,
+		},
+		{
+			name: "planned untouched", state: workflow.TaskPlanned, branch: "feat/x",
+			pull:      github.PullRequest{Number: 470, HeadRef: "feat/x"},
+			wantState: workflow.TaskPlanned,
+		},
+		{
+			name: "pr_open idempotent", state: workflow.TaskPullRequestOpen, branch: "feat/x",
+			pull:      github.PullRequest{Number: 470, HeadRef: "feat/x"},
+			wantState: workflow.TaskPullRequestOpen,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := testStore(t)
+			repo := github.Repository{Owner: "owner", Name: "repo"}
+			seedStaleRepo(t, store, repo)
+			task := db.Task{ID: "task-1", RepoFullName: repo.FullName(), State: string(test.state), Branch: test.branch}
+			if err := store.UpsertTask(ctx, task); err != nil {
+				t.Fatal(err)
+			}
+
+			d := Daemon{Repo: repo, Store: store}
+			if err := d.reconcilePROpenTasks(ctx, []github.PullRequest{test.pull}); err != nil {
+				t.Fatalf("reconcilePROpenTasks: %v", err)
+			}
+
+			got, err := store.GetTask(ctx, task.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.State != string(test.wantState) {
+				t.Fatalf("state = %s, want %s", got.State, test.wantState)
+			}
+			events, err := store.ListTaskEvents(ctx, task.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !test.wantEvent {
+				if len(events) != 0 {
+					t.Fatalf("events = %+v, want none", events)
+				}
+				return
+			}
+			if len(events) != 1 {
+				t.Fatalf("events = %d, want 1: %+v", len(events), events)
+			}
+			event := events[0]
+			if event.Kind != "task_pr_open_auto" || event.FromState != string(test.state) || event.ToState != string(workflow.TaskPullRequestOpen) {
+				t.Fatalf("event = %+v", event)
+			}
+			if !strings.Contains(event.Reason, test.wantReason) {
+				t.Fatalf("event reason = %q, want contains %q", event.Reason, test.wantReason)
+			}
+		})
+	}
+}
+
+// TestReconcilePROpenTasksNoPulls proves the zero-PR fast path never touches the store.
+func TestReconcilePROpenTasksNoPulls(t *testing.T) {
+	d := Daemon{Repo: github.Repository{Owner: "owner", Name: "repo"}}
+	if err := d.reconcilePROpenTasks(context.Background(), nil); err != nil {
+		t.Fatalf("reconcilePROpenTasks(nil pulls): %v", err)
+	}
+}


### PR DESCRIPTION
Closes #920. The "Needs you" panel only lists PRs whose task is in `pr_open` — a task wedged in `blocked`/`implementing` hides its open PR from every waiting-on-you surface (live case: joltra PR #470, invisible while its task sat `blocked`).

Fix at the state level, not the query: a new `reconcilePROpenTasks` pass in the daemon poll promotes implementing/blocked tasks whose branch carries an **open same-repo PR** to `pr_open` via the #916 CAS transition helper, writing a `task_events` audit row (`task_pr_open_auto`, reason names the PR). Needs-you then works unchanged — `ListDashboardTasks` already joins `pull_requests.head_branch` for number + link.

Safety:
- Cannot auto-merge anything: the merge gate acts only on `ready_to_merge` tasks (`daemon.go:439`).
- Fork heads skipped (`HeadRepoFullName` validated — HeadRef text can collide with a local branch).
- CAS: concurrent transitions win cleanly; already-`pr_open` tasks get no duplicate events.
- Zero open PRs → zero store reads.

Tests: table-driven promotion coverage (implementing/blocked promoted with audit event, fork head ignored, unrelated branch ignored, planned untouched, pr_open idempotent) + nil-pulls fast path. Full `internal/daemon` suite green.

Deploy notes: binary-only, no migration; daemon restart picks it up; expect joltra PR #470 to surface under Needs-you within one poll tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)