### PR TITLE
feat(workflow): auto-detect coordinator identity from herdr (#885)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -253,7 +253,7 @@ func (d *webDataSource) Workflow(ctx context.Context, label string, q dashboard.
 			author = strings.TrimSpace(summary.LastAuthor)
 		}
 		out.Coordinator = dashboard.WorkflowCoordinator{
-			Author: author, Pane: strings.TrimSpace(meta.Pane), SessionID: strings.TrimSpace(meta.SessionID),
+			Author: author, Pane: strings.TrimSpace(meta.Pane), SessionID: dashboardWorkflowResumeSessionID(meta.SessionID),
 		}
 		out.WorkDir = strings.TrimSpace(meta.WorkDir)
 
@@ -288,6 +288,18 @@ func (d *webDataSource) Workflow(ctx context.Context, label string, q dashboard.
 		return nil
 	})
 	return out, err
+}
+
+// The dashboard module has no separate resume-command field. Its workflow
+// detail client builds `claude --resume` whenever SessionID is non-empty, so the
+// detail projection exposes only canonical full UUIDs. The index projection
+// keeps the raw stored value visible as coordinator context.
+func dashboardWorkflowResumeSessionID(value string) string {
+	value = strings.TrimSpace(value)
+	if !isFullWorkflowSessionUUID(value) {
+		return ""
+	}
+	return value
 }
 
 func cappedWorkflowLimit(value, cap int) int {

--- a/internal/cli/dashboard_web_workflow_test.go
+++ b/internal/cli/dashboard_web_workflow_test.go
@@ -328,7 +328,7 @@ func TestWebDataSourceWorkflowsIndexLifecycleCoordinatorAndSlashDetail(t *testin
 
 	activeNote, err := store.InsertWorkflowNoteWithMeta(ctx,
 		db.WorkflowNote{WorkflowID: "fable/dashboard-redesign", Author: "fable", Body: "  live\n coordinator   handoff  "},
-		db.WorkflowMeta{Author: "fable", Pane: "wave-2", SessionID: "session-123", WorkDir: "/work/dashboard", Summary: "Ship the dashboard redesign.", SummarySet: true})
+		db.WorkflowMeta{Author: "fable", Pane: "wave-2", SessionID: workflowCoordinatorTestSession, WorkDir: "/work/dashboard", Summary: "Ship the dashboard redesign.", SummarySet: true})
 	if err != nil {
 		t.Fatalf("Insert active note: %v", err)
 	}
@@ -388,8 +388,18 @@ func TestWebDataSourceWorkflowsIndexLifecycleCoordinatorAndSlashDetail(t *testin
 		t.Fatalf("stalled entry = %+v", stalled)
 	}
 	active := entries[1]
-	if active.Namespace != "fable" || active.Campaign != "dashboard-redesign" || active.Auto || active.Summary != "Ship the dashboard redesign." || active.Counts.Jobs != 1 || active.Counts.Running != 1 || active.TokensIn != 11 || active.TokensOut != 13 || active.LastNote != "live coordinator handoff" || active.Coordinator.Author != "fable" || active.Coordinator.SessionID != "session-123" {
+	if active.Namespace != "fable" || active.Campaign != "dashboard-redesign" || active.Auto || active.Summary != "Ship the dashboard redesign." || active.Counts.Jobs != 1 || active.Counts.Running != 1 || active.TokensIn != 11 || active.TokensOut != 13 || active.LastNote != "live coordinator handoff" || active.Coordinator.Author != "fable" || active.Coordinator.SessionID != workflowCoordinatorTestSession {
 		t.Fatalf("active entry = %+v", active)
+	}
+	if stalled.Coordinator.SessionID != "ops-session" {
+		t.Fatalf("workflow index hid raw legacy session id: %+v", stalled.Coordinator)
+	}
+	stalledDetail, err := ds.Workflow(ctx, "ops/stalled", dashboard.WorkflowQuery{})
+	if err != nil {
+		t.Fatalf("Workflow(ops/stalled): %v", err)
+	}
+	if stalledDetail.Coordinator.SessionID != "" {
+		t.Fatalf("stalled detail exposed invalid resume session: %+v", stalledDetail.Coordinator)
 	}
 	if len(active.Repos) != 1 || active.Repos[0] != "acme/dashboard" {
 		t.Fatalf("active repos = %v", active.Repos)
@@ -422,7 +432,7 @@ func TestWebDataSourceWorkflowsIndexLifecycleCoordinatorAndSlashDetail(t *testin
 	if err := json.Unmarshal(recorder.Body.Bytes(), &detail); err != nil {
 		t.Fatalf("decode detail: %v", err)
 	}
-	if detail.Summary.Label != "fable/dashboard-redesign" || detail.Summary.Summary != "Ship the dashboard redesign." || detail.State != "active" || detail.Coordinator.Pane != "wave-2" || detail.Coordinator.SessionID != "session-123" || detail.WorkDir != "/work/dashboard" || len(detail.Runs) != 1 || detail.Runs[0].Agent != "worker" || detail.Runs[0].Repo != "acme/dashboard" {
+	if detail.Summary.Label != "fable/dashboard-redesign" || detail.Summary.Summary != "Ship the dashboard redesign." || detail.State != "active" || detail.Coordinator.Pane != "wave-2" || detail.Coordinator.SessionID != workflowCoordinatorTestSession || detail.WorkDir != "/work/dashboard" || len(detail.Runs) != 1 || detail.Runs[0].Agent != "worker" || detail.Runs[0].Repo != "acme/dashboard" {
 		t.Fatalf("namespaced detail = %+v", detail)
 	}
 }

--- a/internal/cli/workflow_coordinator.go
+++ b/internal/cli/workflow_coordinator.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+const workflowHerdrLookupTimeout = 2 * time.Second
+
+type workflowCoordinatorIdentity struct {
+	Pane      string
+	SessionID string
+	WorkDir   string
+}
+
+// detectWorkflowCoordinatorIdentity is deliberately fail-open: workflow notes
+// remain useful even when Herdr is absent, unavailable, or returns bad data.
+func detectWorkflowCoordinatorIdentity(ctx context.Context) workflowCoordinatorIdentity {
+	if strings.TrimSpace(os.Getenv("HERDR_SOCKET_PATH")) == "" && os.Getenv("HERDR_ENV") != "1" {
+		return workflowCoordinatorIdentity{}
+	}
+
+	lookupCtx, cancel := context.WithTimeout(ctx, workflowHerdrLookupTimeout)
+	defer cancel()
+	result, err := (subprocess.GroupRunner{}).Run(lookupCtx, "", "herdr", "pane", "current", "--current")
+	if err != nil {
+		return workflowCoordinatorIdentity{}
+	}
+
+	var envelope struct {
+		Result struct {
+			Pane struct {
+				Label         string `json:"label"`
+				PaneID        string `json:"pane_id"`
+				CWD           string `json:"cwd"`
+				ForegroundCWD string `json:"foreground_cwd"`
+				AgentSession  struct {
+					Value string `json:"value"`
+				} `json:"agent_session"`
+			} `json:"pane"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &envelope); err != nil {
+		return workflowCoordinatorIdentity{}
+	}
+	pane := strings.TrimSpace(envelope.Result.Pane.Label)
+	if pane == "" {
+		pane = strings.TrimSpace(envelope.Result.Pane.PaneID)
+	}
+	workDir := strings.TrimSpace(envelope.Result.Pane.CWD)
+	if workDir == "" {
+		workDir = strings.TrimSpace(envelope.Result.Pane.ForegroundCWD)
+	}
+	return workflowCoordinatorIdentity{
+		Pane:      pane,
+		SessionID: strings.TrimSpace(envelope.Result.Pane.AgentSession.Value),
+		WorkDir:   workDir,
+	}
+}
+
+func isFullWorkflowSessionUUID(value string) bool {
+	value = strings.TrimSpace(value)
+	if len(value) != 36 {
+		return false
+	}
+	for i := range value {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if value[i] != '-' {
+				return false
+			}
+			continue
+		}
+		if !isWorkflowUUIDHex(value[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isWorkflowUUIDHex(value byte) bool {
+	return value >= '0' && value <= '9' || value >= 'a' && value <= 'f' || value >= 'A' && value <= 'F'
+}

--- a/internal/cli/workflow_journal.go
+++ b/internal/cli/workflow_journal.go
@@ -48,7 +48,7 @@ func printWorkflowJournalUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
 	fmt.Fprintln(w, "  gitmoot workflow list [--json]")
 	fmt.Fprintln(w, "  gitmoot workflow show <label> [--json] [--limit N]")
-	fmt.Fprintln(w, "  gitmoot workflow note <label> \"<body>\" [--author A] [--pane P] [--session ID] [--workdir PATH] [--summary S] [--remember [--remember-status] [--agent NAME] [--repo R]]")
+	fmt.Fprintln(w, "  gitmoot workflow note <label> \"<body>\" [--author A] [--pane P] [--session ID] [--workdir PATH] [--no-auto] [--summary S] [--remember [--remember-status] [--agent NAME] [--repo R]]")
 }
 
 func runWorkflowList(args []string, stdout, stderr io.Writer) int {
@@ -293,6 +293,7 @@ func runWorkflowNote(args []string, stdout, stderr io.Writer) int {
 	pane := fs.String("pane", "", "coordinator pane name")
 	sessionID := fs.String("session", "", "coordinator runtime session id")
 	workdir := fs.String("workdir", "", "coordinator working directory")
+	noAuto := fs.Bool("no-auto", false, "disable Herdr coordinator identity detection")
 	summary := fs.String("summary", "", "one-line human workflow summary")
 	remember := fs.Bool("remember", false, "also stage the note as persistent memory")
 	rememberStatus := fs.Bool("remember-status", false, "explicitly allow a shipping-status-shaped note into memory")
@@ -326,11 +327,33 @@ func runWorkflowNote(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	summarySet := false
+	paneSet := false
+	sessionSet := false
+	workdirSet := false
 	fs.Visit(func(f *flag.Flag) {
-		if f.Name == "summary" {
+		switch f.Name {
+		case "summary":
 			summarySet = true
+		case "pane":
+			paneSet = true
+		case "session":
+			sessionSet = true
+		case "workdir":
+			workdirSet = true
 		}
 	})
+	if !*noAuto && (!paneSet || !sessionSet || !workdirSet) {
+		detected := detectWorkflowCoordinatorIdentity(context.Background())
+		if !paneSet {
+			*pane = detected.Pane
+		}
+		if !sessionSet {
+			*sessionID = detected.SessionID
+		}
+		if !workdirSet {
+			*workdir = detected.WorkDir
+		}
+	}
 	if len(*summary) > workflowSummaryMax {
 		fmt.Fprintf(stderr, "workflow note summary must be at most %d bytes\n", workflowSummaryMax)
 		return 2

--- a/internal/cli/workflow_journal_test.go
+++ b/internal/cli/workflow_journal_test.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/db"
@@ -210,6 +214,216 @@ func TestWorkflowNotePersistsNamespacedCoordinatorMetadata(t *testing.T) {
 	if code := runWorkflowShow([]string{"fable/dashboard-redesign", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("namespaced workflow show exit=%d stderr=%q", code, stderr.String())
 	}
+}
+
+const workflowCoordinatorTestSession = "66fbda3c-4765-4cdd-9c48-15d495173823"
+
+func TestWorkflowNoteAutoDetectsHerdrCoordinatorIdentity(t *testing.T) {
+	home, store := workflowJournalTestHome(t)
+	ctx := context.Background()
+	if err := store.CreateJob(ctx, db.Job{ID: "auto-job", Agent: "coord", Type: "ask", State: "running", Payload: `{"repo":"acme/widget","workflow_id":"fable/auto"}`}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	logPath := installWorkflowHerdrStub(t, workflowHerdrJSON("Gitmoot2", "pane-id", "/work/gitmoot", "", workflowCoordinatorTestSession), 0, "")
+	t.Setenv("HERDR_ENV", "1")
+	t.Setenv("HERDR_SOCKET_PATH", "")
+
+	var stdout, stderr bytes.Buffer
+	code := runWorkflowJournal([]string{"note", "fable/auto", "Coordinator detected.", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("workflow note exit=%d stderr=%q", code, stderr.String())
+	}
+	meta, err := store.GetWorkflowMeta(ctx, "fable/auto")
+	if err != nil {
+		t.Fatalf("GetWorkflowMeta: %v", err)
+	}
+	if meta.Pane != "Gitmoot2" || meta.SessionID != workflowCoordinatorTestSession || meta.WorkDir != "/work/gitmoot" || meta.Author != "" {
+		t.Fatalf("auto-detected metadata = %+v", meta)
+	}
+	if calls := workflowHerdrStubCalls(t, logPath); calls != 1 {
+		t.Fatalf("herdr calls = %d, want 1", calls)
+	}
+}
+
+func TestWorkflowNoteHerdrFallbackFields(t *testing.T) {
+	installWorkflowHerdrStub(t, workflowHerdrJSON("", "w6536a4e5b44342:p1X", "", "/work/foreground", workflowCoordinatorTestSession), 0, "")
+	t.Setenv("HERDR_SOCKET_PATH", "/tmp/herdr.sock")
+	t.Setenv("HERDR_ENV", "")
+
+	got := detectWorkflowCoordinatorIdentity(context.Background())
+	if got.Pane != "w6536a4e5b44342:p1X" || got.SessionID != workflowCoordinatorTestSession || got.WorkDir != "/work/foreground" {
+		t.Fatalf("fallback identity = %+v", got)
+	}
+}
+
+func TestWorkflowNoteExplicitCoordinatorFlagsWinAndNoAutoSkips(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		extra     []string
+		want      workflowCoordinatorIdentity
+		wantCalls int
+	}{
+		{
+			name:      "all explicit flags avoid lookup",
+			extra:     []string{"--pane", "manual-pane", "--session", "11111111-2222-3333-4444-555555555555", "--workdir", "/manual"},
+			want:      workflowCoordinatorIdentity{Pane: "manual-pane", SessionID: "11111111-2222-3333-4444-555555555555", WorkDir: "/manual"},
+			wantCalls: 0,
+		},
+		{
+			name:      "partial explicit flags win over detected values",
+			extra:     []string{"--pane", "manual-pane"},
+			want:      workflowCoordinatorIdentity{Pane: "manual-pane", SessionID: workflowCoordinatorTestSession, WorkDir: "/auto"},
+			wantCalls: 1,
+		},
+		{name: "no auto", extra: []string{"--no-auto"}, want: workflowCoordinatorIdentity{}, wantCalls: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, store := workflowJournalTestHome(t)
+			ctx := context.Background()
+			if err := store.CreateJob(ctx, db.Job{ID: "override-job", Agent: "coord", Type: "ask", State: "running", Payload: `{"repo":"acme/widget","workflow_id":"fable/override"}`}); err != nil {
+				t.Fatalf("CreateJob: %v", err)
+			}
+			logPath := installWorkflowHerdrStub(t, workflowHerdrJSON("auto-pane", "pane-id", "/auto", "", workflowCoordinatorTestSession), 0, "")
+			t.Setenv("HERDR_SOCKET_PATH", "/tmp/herdr.sock")
+			t.Setenv("HERDR_ENV", "")
+			args := []string{"note", "fable/override", "Explicit metadata.", "--home", home}
+			args = append(args, tc.extra...)
+			var stdout, stderr bytes.Buffer
+			if code := runWorkflowJournal(args, &stdout, &stderr); code != 0 {
+				t.Fatalf("workflow note exit=%d stderr=%q", code, stderr.String())
+			}
+			meta, err := store.GetWorkflowMeta(ctx, "fable/override")
+			if err != nil {
+				t.Fatalf("GetWorkflowMeta: %v", err)
+			}
+			if meta.Pane != tc.want.Pane || meta.SessionID != tc.want.SessionID || meta.WorkDir != tc.want.WorkDir {
+				t.Fatalf("metadata = %+v, want %+v", meta, tc.want)
+			}
+			if calls := workflowHerdrStubCalls(t, logPath); calls != tc.wantCalls {
+				t.Fatalf("herdr calls = %d, want %d", calls, tc.wantCalls)
+			}
+		})
+	}
+}
+
+func TestWorkflowNoteHerdrDetectionFailsOpen(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		enabled    bool
+		stubOutput string
+		stubExit   int
+		stub       bool
+	}{
+		{name: "non-herdr environment", stub: true, stubOutput: workflowHerdrJSON("auto", "pane", "/auto", "", workflowCoordinatorTestSession)},
+		{name: "herdr missing", enabled: true},
+		{name: "herdr exits non-zero", enabled: true, stub: true, stubExit: 7},
+		{name: "herdr emits garbage", enabled: true, stub: true, stubOutput: "not-json"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home, store := workflowJournalTestHome(t)
+			ctx := context.Background()
+			if err := store.CreateJob(ctx, db.Job{ID: "fail-open-job", Agent: "coord", Type: "ask", State: "running", Payload: `{"repo":"acme/widget","workflow_id":"fable/fail-open"}`}); err != nil {
+				t.Fatalf("CreateJob: %v", err)
+			}
+			if tc.stub {
+				installWorkflowHerdrStub(t, tc.stubOutput, tc.stubExit, "")
+			} else {
+				t.Setenv("PATH", t.TempDir())
+			}
+			if tc.enabled {
+				t.Setenv("HERDR_SOCKET_PATH", "/tmp/herdr.sock")
+			} else {
+				t.Setenv("HERDR_SOCKET_PATH", "")
+			}
+			t.Setenv("HERDR_ENV", "")
+			var stdout, stderr bytes.Buffer
+			if code := runWorkflowJournal([]string{"note", "fable/fail-open", "Still succeeds.", "--home", home}, &stdout, &stderr); code != 0 {
+				t.Fatalf("workflow note exit=%d stderr=%q", code, stderr.String())
+			}
+			meta, err := store.GetWorkflowMeta(ctx, "fable/fail-open")
+			if err != nil {
+				t.Fatalf("GetWorkflowMeta: %v", err)
+			}
+			if meta.Pane != "" || meta.SessionID != "" || meta.WorkDir != "" {
+				t.Fatalf("fail-open metadata = %+v", meta)
+			}
+		})
+	}
+}
+
+func TestWorkflowNoteHerdrDetectionTimeoutIsBounded(t *testing.T) {
+	home, store := workflowJournalTestHome(t)
+	ctx := context.Background()
+	if err := store.CreateJob(ctx, db.Job{ID: "timeout-job", Agent: "coord", Type: "ask", State: "running", Payload: `{"repo":"acme/widget","workflow_id":"fable/timeout"}`}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	installWorkflowHerdrStub(t, workflowHerdrJSON("late", "pane", "/late", "", workflowCoordinatorTestSession), 0, "10")
+	t.Setenv("HERDR_SOCKET_PATH", "/tmp/herdr.sock")
+	t.Setenv("HERDR_ENV", "")
+
+	started := time.Now()
+	var stdout, stderr bytes.Buffer
+	if code := runWorkflowJournal([]string{"note", "fable/timeout", "Timeout is fail-open.", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("workflow note exit=%d stderr=%q", code, stderr.String())
+	}
+	if elapsed := time.Since(started); elapsed > workflowHerdrLookupTimeout+1500*time.Millisecond {
+		t.Fatalf("workflow note took %s with %s timeout", elapsed, workflowHerdrLookupTimeout)
+	}
+	meta, err := store.GetWorkflowMeta(ctx, "fable/timeout")
+	if err != nil || meta.Pane != "" || meta.SessionID != "" || meta.WorkDir != "" {
+		t.Fatalf("timeout metadata = %+v, err=%v", meta, err)
+	}
+}
+
+func TestFullWorkflowSessionUUIDValidation(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{value: workflowCoordinatorTestSession, want: true},
+		{value: "550E8400-E29B-41D4-A716-446655440000", want: true},
+		{value: "66fbda3c", want: false},
+		{value: "66fbda3c47654cdd9c4815d495173823", want: false},
+		{value: "66fbda3c-4765-4cdd-9c48-15d49517382z", want: false},
+	} {
+		if got := isFullWorkflowSessionUUID(tc.value); got != tc.want {
+			t.Errorf("isFullWorkflowSessionUUID(%q) = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+func installWorkflowHerdrStub(t *testing.T, output string, exitCode int, sleepSeconds string) string {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "calls.log")
+	t.Setenv("WORKFLOW_HERDR_STUB_LOG", logPath)
+	sleepLine := ""
+	if sleepSeconds != "" {
+		sleepLine = "/bin/sleep " + sleepSeconds + "\n"
+	}
+	script := "#!/bin/sh\nprintf 'call\\n' >> \"$WORKFLOW_HERDR_STUB_LOG\"\n" + sleepLine +
+		"/bin/cat <<'HERDR_EOF'\n" + output + "\nHERDR_EOF\nexit " + fmt.Sprint(exitCode) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "herdr"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write herdr stub: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+"/usr/bin:/bin")
+	return logPath
+}
+
+func workflowHerdrJSON(label, paneID, cwd, foregroundCWD, sessionID string) string {
+	return fmt.Sprintf(`{"id":"cli:pane:current","result":{"pane":{"label":%q,"pane_id":%q,"cwd":%q,"foreground_cwd":%q,"agent_session":{"value":%q}},"type":"pane_current"}}`, label, paneID, cwd, foregroundCWD, sessionID)
+}
+
+func workflowHerdrStubCalls(t *testing.T, path string) int {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return 0
+	}
+	if err != nil {
+		t.Fatalf("read herdr stub log: %v", err)
+	}
+	return len(strings.Fields(string(body)))
 }
 
 func TestWorkflowNoteSummarySetPreserveClearAndLimit(t *testing.T) {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1064,7 +1064,7 @@ gitmoot orchestrate planner "Coordinate the dashboard wave." --repo owner/repo -
 gitmoot job list --workflow fable/dashboard-redesign
 gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
-gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --pane wave-2 --session <session-id> --workdir /work/dashboard --summary "Coordinate and ship the dashboard redesign."
+gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --summary "Coordinate and ship the dashboard redesign."
 ```
 
 `workflow list` reports per-state counts, note count, first/last activity, and
@@ -1074,7 +1074,14 @@ index plus a mission-log detail at `/workflows/<label>`. Workflows are `active`
 while queued/running or touched within 30 minutes, `stalled` when failed/blocked
 and quiet for 30 minutes to 24 hours, and `settled` otherwise. The optional
 `--pane`, `--session`, and `--workdir` note flags persist the latest coordinator
-handoff shown on that page; author defaults to the newest note author.
+handoff shown on that page. When those flags are omitted inside Herdr
+(`HERDR_SOCKET_PATH` or `HERDR_ENV=1`), `workflow note` reads the current pane
+label, full runtime session UUID, and working directory automatically. Explicit
+flags always win; `--no-auto` skips detection for scripted callers. Detection
+is fail-open and never prevents a note, and it does not infer `--author`.
+Dashboard resume commands require a full UUID; legacy short session values stay
+visible in the workflow index as context but are not rendered into a broken
+command. Author defaults to the newest note author.
 Coordinators should set a one-line human summary at kickoff with `--summary`.
 Omitting that flag preserves the stored summary, a non-empty value replaces it,
 and `--summary ""` clears it. Summary input is stored verbatim and limited to

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -39,6 +39,13 @@ workflow index and detail views. Omitting the flag preserves it; a new non-empty
 value replaces it; `--summary ""` clears it. Summaries are stored verbatim with
 a 300-byte limit.
 
+When `workflow note` runs inside Herdr and `--pane`, `--session`, or `--workdir`
+is omitted, it fills each omitted value from `herdr pane current --current`.
+The pane label, full agent session UUID, and pane working directory become the
+latest handoff; explicit flags always win. Use `--no-auto` to disable this for a
+script. Lookup failures are ignored so the note still lands, and author is never
+inferred. The dashboard only builds a resume command from a full UUID.
+
 In `gitmoot dashboard --web`, labeled jobs cluster around workflow hubs in
 Galaxy; a labeled run links to `/workflows/<label>`, which shows the complete
 run forest, state totals, best-effort token totals, and shared journal.

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -215,6 +215,10 @@ pane, session id), and a stalled workflow shows a go-here card with the pane,
 the session id, and a copyable resume command — the dashboard tells you where
 to intervene; it never intervenes itself. Coordinators should set the summary
 at kickoff with `gitmoot workflow note ... --summary "<one sentence>"`.
+Inside Herdr, omitted pane/session/workdir flags are detected from the current
+pane. The resume command is shown only when the stored session id is a full
+UUID; legacy shortened values remain visible in the workflow index but cannot
+produce a broken command.
 
 ## Brain
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -914,7 +914,7 @@ gitmoot orchestrate planner "Coordinate the dashboard wave." --repo owner/repo -
 gitmoot job list --workflow fable/dashboard-redesign
 gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
-gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --pane wave-2 --session <session-id> --workdir /work/dashboard --summary "Coordinate and ship the dashboard redesign."
+gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --summary "Coordinate and ship the dashboard redesign."
 ```
 
 List/show include state counts, notes, first/last activity, and best-effort token
@@ -923,7 +923,12 @@ also renders labels as Galaxy hubs and provides a Workflows index plus mission
 log at `/workflows/<label>`. `active` means queued/running or touched within 30
 minutes; failed/blocked workflows quiet for 30 minutes to 24 hours are
 `stalled`; everything else is `settled`. The optional `--pane`, `--session`, and
-`--workdir` note flags persist the latest coordinator handoff. If coordinator
+`--workdir` note flags persist the latest coordinator handoff. Inside Herdr,
+omitted identity flags are filled from the current pane: its label, full agent
+session UUID, and working directory. Explicit flags always win; `--no-auto`
+disables detection. Missing Herdr state, command failures, timeouts, and invalid
+output are ignored so the note still succeeds, and author is not inferred.
+Only a full UUID is eligible for the dashboard resume command. If coordinator
 author metadata is empty, the newest note author is used.
 Coordinators should set a one-line human summary at kickoff with `--summary`.
 Omitting that flag preserves the stored summary, a non-empty value replaces it,

--- a/website/docs/workflows/coordinator-recipes-workflow.md
+++ b/website/docs/workflows/coordinator-recipes-workflow.md
@@ -8,7 +8,7 @@ several jobs. It works on agent ask/run/review/implement, `orchestrate`, and
 
 ```sh
 gitmoot orchestrate planner "Run release checks." --repo owner/repo --workflow fable/release-42
-gitmoot workflow note fable/release-42 "Canary passed." --author operator --pane release --session <session-id> --workdir /work/release --remember
+gitmoot workflow note fable/release-42 "Canary passed." --author operator --remember
 gitmoot workflow show fable/release-42
 ```
 
@@ -18,7 +18,11 @@ complete run trees, derived active/stalled/settled state, best-effort token
 totals, the shared note journal, and the latest coordinator handoff. Labels may
 use one namespace slash; each side remains a lowercase alphanumeric/single-hyphen
 slug. `--pane`, `--session`, and `--workdir` on `workflow note` update the
-handoff used by the dashboard's resume card.
+handoff used by the dashboard's resume card. Inside Herdr, omitted handoff flags
+default to the current pane label, full agent session UUID, and working
+directory. Explicit flags override detection; `--no-auto` disables it. Detection
+fails open without blocking the note and never invents an author. Resume
+commands are emitted only for full UUID session ids.
 
 Journal text and authors are stored verbatim. JSON keeps them verbatim, while
 terminal text output sanitizes escapes/control bytes and caps each field to one

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -655,6 +655,8 @@ gitmoot agent doctor <name>
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task recover task-001 --owner lead   # finalize a dead implement's dirty worktree
+gitmoot task dismiss task-001 --reason "abandoned experiment"
+gitmoot task events task-001 --json
 gitmoot task list --repo owner/repo
 gitmoot job list
 gitmoot job show <job-id>
@@ -683,9 +685,26 @@ job, rather than silently discard the work, and point at `task recover <id>
 --owner <agent>`. `task recover` commits the full worktree state (`git add -A`,
 including untracked non-ignored files), pushes the branch, and opens or adopts
 the task's PR — the finalize steps the dead implementer never reached. `--repo`
-is optional (it falls back to the task's stored repo). Recovery refuses while a
-live process is still inside the task worktree; wait for it to exit or stop the
-orphaned implementer first.
+is optional (it falls back to the task's stored repo). `--owner` is required for
+this artifact-finalization path, while a dismissed task with no branch can be
+restored to `planned` without it. Recovery refuses while a live process is still
+inside the task worktree; wait for it to exit or stop the orphaned implementer
+first.
+
+`task dismiss` is the explicit terminal action for an abandoned
+`implementing` or `blocked` task. It refuses while a matching job or worktree
+process is live, preserves the branch and worktree, releases the branch lock
+best-effort, and records `task_dismissed_manual`. The daemon can record
+`task_dismissed_auto` for stale candidates using `updated_at` as a conservative
+activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
+set it to `"0"` to disable this poll leg. Candidates with a same-repo open PR,
+a remote branch, a live job, or an uncertain remote check are not dismissed.
+
+Dismissed tasks never return to implementation through ordinary task run,
+allocation, or late workflow advancement. `task recover` is the explicit path:
+preserved branch/worktree artifacts move through `implementing` to `pr_open`,
+while a branchless task returns to `planned` with task-run guidance. Inspect the
+full audit trail with `task events`.
 
 ## Runtime Plugin Setup
 
@@ -3917,9 +3936,10 @@ sessions**, with `--parallel N`.
 
 ## Reconfigure without restarting (SIGHUP)
 
-Changing workers/scheduler/poll no longer needs a daemon restart (#577):
+Changing workers/scheduler/poll/idle cadence no longer needs a daemon restart (#577):
 `kill -HUP <daemon-pid>` re-reads the `[daemon]` config section (`poll`,
-`workers`, `scheduler`, parallelism) live — no teardown, no dropped jobs, no
+`workers`, `scheduler`, parallelism, `idle_grace_ticks`, and
+`idle_max_multiplier`) live — no teardown, no dropped jobs, no
 environment re-inheritance (so the daemon's runtime auth is untouched). Values
 pinned by explicit launch flags win over the re-read config. When a full
 restart is genuinely needed, prefer `gitmoot daemon restart`, which recovers
@@ -3987,6 +4007,8 @@ min_interval = "0s"       # min spacing between call starts; 0 = off (Go duratio
 secondary_backoff = true  # pause all GitHub calls on a secondary/abuse limit (default true)
 backoff_base = "60s"      # exponential fallback base when no Retry-After (default 60s)
 backoff_max = "5m"        # exponential fallback cap (default 5m)
+conditional_requests = true # ETag conditional polling (default true)
+calls_per_hour_warn = 0      # daemon-local sliding-hour warning; 0 = off
 ```
 
 **Safe defaults:** the proactive caps (`max_concurrent`, `min_interval`) default
@@ -3999,6 +4021,25 @@ the abuse detector, which only prolongs the block. Calls are never dropped — t
 queue/delay until the window passes. On a busy host, set `max_concurrent` (e.g.
 `6`) and/or a small `min_interval` (e.g. `250ms`) to also smooth bursts
 proactively. `gitmoot daemon status` shows the configured budget.
+
+The four per-tick repository list reads use an in-memory ETag cache. A `304 Not
+Modified` replays the prior raw JSON and does not consume GitHub's REST quota.
+After three consecutive successful all-304 ticks, a quiet repo moves to 2x base
+cadence and then to 4x; configure the thresholds under `[daemon]`:
+
+```toml
+[daemon]
+idle_grace_ticks = 3
+idle_max_multiplier = 4  # 1 disables idle decay
+```
+
+Any response-body miss, poll error, queued repo job, or in-flight repo job resets
+the streak and promotes the repo immediately. A repo with an open PR remains at
+base cadence because its per-PR comment reads are deliberately non-conditional.
+The decayed `NextPoll` gates GitHub calls only: heartbeat, pipeline, and chat
+maintenance still wake at the resolved base interval. The local call count is
+approximate and covers only this daemon process; foreground commands and
+agent-owned `gh` processes are outside it.
 
 ## Not yet automatic (follow-ups)
 
@@ -6346,8 +6387,9 @@ Tasks is a read-only lifecycle board backed by Gitmoot's task registry. Internal
 states are projected into **implementing**, **PR open**, **blocked**, and
 **merged** columns; planned and unknown states are omitted, review,
 changes-requested, and ready-to-merge tasks remain in PR open, and awaiting-human
-tasks appear as blocked. Merged history is limited server-side to the last seven
-days.
+tasks appear as blocked. Dismissed tasks are excluded by the server-side query,
+and task-event cursor invalidation removes a newly dismissed card immediately.
+Merged history is limited server-side to the last seven days.
 
 Cards carry the task title, repository, assigned branch-lock owner when one is
 known, pull-request number, last-update age, and a blocked reason. The CI dot is
@@ -6523,6 +6565,10 @@ pane, session id), and a stalled workflow shows a go-here card with the pane,
 the session id, and a copyable resume command — the dashboard tells you where
 to intervene; it never intervenes itself. Coordinators should set the summary
 at kickoff with `gitmoot workflow note ... --summary "<one sentence>"`.
+Inside Herdr, omitted pane/session/workdir flags are detected from the current
+pane. The resume command is shown only when the stored session id is a full
+UUID; legacy shortened values remain visible in the workflow index but cannot
+produce a broken command.
 
 ## Brain
 
@@ -9336,8 +9382,10 @@ only declared data paths, the disposable workdir, and temp roots are writable.
 ```sh
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
-gitmoot repo add owner/repo --path <path> [--poll 30s]
+gitmoot repo add owner/repo --path <path> [--poll <duration>]
 gitmoot repo list
+gitmoot repo set-interval owner/repo (<duration>|default)
+gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
 gitmoot daemon start --poll 30s --workers 1
@@ -9354,9 +9402,13 @@ For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task show` are not valid commands.
 
 The `gitmoot repo` commands manage the **watched-repo registry**: one daemon
-per Gitmoot home supervises every **enabled** registered repo (each with its
-own `--poll` interval). `repo doctor owner/repo` checks a single repo's
-checkout/config health.
+per Gitmoot home supervises every **enabled** registered repo. An omitted
+`repo add --poll` stores the `inherit` sentinel, so the repo follows the daemon's
+resolved `--poll` / `[daemon].poll` cadence; an explicit `--poll` stores a
+per-repo override. `repo list` renders the sentinel as `inherit`.
+`repo set-interval owner/repo <duration>` changes an override, `default` restores
+inheritance, and `--all` applies either value to every registered repo.
+`repo doctor owner/repo` checks a single repo's checkout/config health.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`
@@ -9410,7 +9462,7 @@ keys are re-read every tick, so edits apply live.
 
 Reconfigure the running daemon without a restart: `kill -HUP <daemon-pid>`
 re-reads the `[daemon]` config section (`poll`, `workers`, `scheduler`,
-parallelism) live (#577) — no teardown, no dropped jobs, no environment
+parallelism, `idle_grace_ticks`, `idle_max_multiplier`) live (#577) — no teardown, no dropped jobs, no environment
 re-inheritance. Values pinned by explicit launch flags win over the re-read
 config. Prefer SIGHUP over a restart when only tuning throughput.
 
@@ -9446,12 +9498,25 @@ else exponential backoff) instead of retry-storming the abuse detector. Knobs:
 `min_interval` spaces successive call starts (0 = off; accepts a Go duration or a
 bare integer of seconds), `secondary_backoff` toggles the reactive pause (default
 `true`), and `backoff_base`/`backoff_max` bound the exponential fallback
-(defaults `60s`/`5m`). **Safe defaults:** the proactive caps are off (single-call
+(defaults `60s`/`5m`). `conditional_requests` defaults to `true` and adds ETag
+validators to the four per-tick polling reads; a `304 Not Modified` replays the
+cached raw response at zero GitHub quota cost. `calls_per_hour_warn` defaults to
+`0` (off) and logs when this daemon process crosses the configured sliding-hour
+count. The count is approximate and daemon-local: foreground commands and
+agent-owned `gh` processes are outside it. **Safe defaults:** the proactive caps are off (single-call
 latency and steady-state throughput unchanged) and only the invisible reactive
 backoff is on. Set `max_concurrent` (e.g. `6`) and/or a small `min_interval`
 (e.g. `250ms`) to also smooth bursts proactively on a busy host. Calls are never
 dropped — they queue/delay. `gitmoot daemon status` shows the configured budget
-(`github limiter: max_concurrent=… min_interval=… secondary_backoff=…`).
+(`github limiter: max_concurrent=… min_interval=… secondary_backoff=… conditional_requests=… calls_per_hour_warn=…`).
+
+After `idle_grace_ticks` consecutive successful polls in which every conditional
+read is a 304, a repo's GitHub poll cadence decays to 2x and then up to
+`idle_max_multiplier` (default `4`; `1` disables decay). Any response-body miss,
+poll error, queued repo job, or in-flight repo job resets/promotes it immediately.
+Repos with open PRs stay at base cadence because their per-PR comment reads are
+deliberately non-conditional. Idle decay gates only GitHub calls; heartbeat,
+pipeline, and chat maintenance still wake at the resolved base interval.
 
 `gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
 sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,
@@ -10174,7 +10239,7 @@ gitmoot orchestrate planner "Coordinate the dashboard wave." --repo owner/repo -
 gitmoot job list --workflow fable/dashboard-redesign
 gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
-gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --pane wave-2 --session <session-id> --workdir /work/dashboard --summary "Coordinate and ship the dashboard redesign."
+gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --summary "Coordinate and ship the dashboard redesign."
 ```
 
 `workflow list` reports per-state counts, note count, first/last activity, and
@@ -10184,7 +10249,14 @@ index plus a mission-log detail at `/workflows/<label>`. Workflows are `active`
 while queued/running or touched within 30 minutes, `stalled` when failed/blocked
 and quiet for 30 minutes to 24 hours, and `settled` otherwise. The optional
 `--pane`, `--session`, and `--workdir` note flags persist the latest coordinator
-handoff shown on that page; author defaults to the newest note author.
+handoff shown on that page. When those flags are omitted inside Herdr
+(`HERDR_SOCKET_PATH` or `HERDR_ENV=1`), `workflow note` reads the current pane
+label, full runtime session UUID, and working directory automatically. Explicit
+flags always win; `--no-auto` skips detection for scripted callers. Detection
+is fail-open and never prevents a note, and it does not infer `--author`.
+Dashboard resume commands require a full UUID; legacy short session values stay
+visible in the workflow index as context but are not rendered into a broken
+command. Author defaults to the newest note author.
 Coordinators should set a one-line human summary at kickoff with `--summary`.
 Omitting that flag preserves the stored summary, a non-empty value replaces it,
 and `--summary ""` clears it. Summary input is stored verbatim and limited to
@@ -10225,11 +10297,26 @@ Start a task in its dedicated branch worktree and inspect task state:
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task list --repo owner/repo
 gitmoot task list --repo owner/repo --state implementing --json
+gitmoot task dismiss task-001 --reason "abandoned experiment"
+gitmoot task events task-001 --json
 ```
 
 `task run` stores the deterministic task worktree path under
 `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/` and leaves the registered
 checkout on its current branch.
+
+`task dismiss` is an explicit terminal action for stale `implementing` or
+`blocked` tasks. It refuses planned, PR/review/merge, awaiting-human, unknown,
+or otherwise machine-owned states; any live queued/running job, unsettled
+post-delivery advancement, unsettled running cancellation, or live process in
+the task worktree also blocks dismissal. The default reason is `dismissed by
+operator`. Success preserves the branch and worktree, releases the branch lock
+best-effort, and appends `task_dismissed_manual` to `task events`. Repeating the
+command is an exit-0 no-op with `changed:false` in JSON.
+
+`task events <id>` prints the append-only task lifecycle trail. Automatic stale
+dismissals use `task_dismissed_auto`; explicit recovery and retry use
+`task_recovered` and `task_recovered_job_retry`.
 
 ### Recover A Dead Implement
 
@@ -10244,9 +10331,11 @@ gitmoot task recover task-001 --owner lead
 gitmoot task recover task-001 --owner lead --repo owner/repo --skip-native-review-fanout --json
 ```
 
-`--owner <agent>` is required (a registered implement-capable agent, attributed
-as the recovery lead). `--repo owner/repo` is optional — it falls back to the
-task's stored repo and is only required when the task carries none.
+`--owner <agent>` is required when recovering preserved branch/worktree
+artifacts (a registered implement-capable agent, attributed as the recovery
+lead). A dismissed task with no branch returns directly to `planned`, so that
+path does not require `--owner`. `--repo owner/repo` is optional — it falls back
+to the task's stored repo and is only required when the task carries none.
 `--skip-native-review-fanout` persists that flag before the PR is opened;
 `--json` prints the machine-readable recovery result.
 
@@ -10255,6 +10344,14 @@ untracked non-ignored files), pushes the task branch, and opens or adopts the
 task's PR — the exact finalize steps the dead implementer never reached. If the
 worktree is already clean it recovers the commit already ahead of the base
 (and refuses when there is nothing ahead to recover).
+
+Recovery is also the only task-level escape hatch from `dismissed`. A dismissed
+task with a preserved branch and worktree first moves to `implementing`, then to
+`pr_open` after finalization. A branchless auto-dismissed task instead returns to
+`planned` and prints guidance to use `task run`. Ordinary `task run`, branch or
+worktree allocation, review continuation, and task-state advancement never
+resurrect a dismissed task implicitly. Retrying one of its jobs explicitly
+restores the task first and records `task_recovered_job_retry`.
 
 Two refusals guard `task recover` (and the `task run` / `agent implement`
 restart that points to it):
@@ -12089,6 +12186,13 @@ workflow index and detail views. Omitting the flag preserves it; a new non-empty
 value replaces it; `--summary ""` clears it. Summaries are stored verbatim with
 a 300-byte limit.
 
+When `workflow note` runs inside Herdr and `--pane`, `--session`, or `--workdir`
+is omitted, it fills each omitted value from `herdr pane current --current`.
+The pane label, full agent session UUID, and pane working directory become the
+latest handoff; explicit flags always win. Use `--no-auto` to disable this for a
+script. Lookup failures are ignored so the note still lands, and author is never
+inferred. The dashboard only builds a resume command from a full UUID.
+
 In `gitmoot dashboard --web`, labeled jobs cluster around workflow hubs in
 Galaxy; a labeled run links to `/workflows/<label>`, which shows the complete
 run forest, state totals, best-effort token totals, and shared journal.
@@ -12745,7 +12849,28 @@ over a dirty worktree with no active job (so nothing is discarded) and point at
 `gitmoot task recover <task-id> --owner <agent>`, which commits the full
 worktree state (`git add -A`, incl. untracked non-ignored files), pushes the
 branch, and opens or adopts the PR. `--repo` is optional (falls back to the
-task's repo). Recovery refuses while a live process is still inside the worktree.
+task's repo). `--owner` is required for this artifact-finalization path, but not
+when a dismissed branchless task is simply restored to `planned`. Recovery
+refuses while a live process is still inside the worktree.
+
+**Task dismissal and stale reconciliation:** `dismissed` is a terminal task
+state for implicit workflow transitions. An operator can run `gitmoot task
+dismiss <id> [--reason ...]` only from `implementing` or `blocked`; Gitmoot
+refuses while any matching job is live or a process remains in the task
+worktree. The branch and worktree are preserved, while the branch lock is
+released best-effort. Manual and daemon transitions are audited as
+`task_dismissed_manual` and `task_dismissed_auto` in `gitmoot task events <id>`.
+
+Each repo poll reads a bounded oldest-first stale window and processes up to 20
+qualifying `implementing`/`blocked` tasks whose `updated_at` predates
+`[workflow].stale_task_ttl` (default `168h`; `"0"` disables the leg).
+`updated_at` is deliberately a conservative activity proxy, not proof of
+abandonment. A candidate is skipped for a live job, a same-repo open-PR branch,
+or an exact branch still present on `origin`; remote lookup uncertainty skips
+mutation. A branchless candidate needs no remote lookup. Explicit `task
+recover` restores preserved artifacts through `implementing` to `pr_open`, or
+restores a branchless task to `planned`; job retry records its own recovery
+event. The server-side task board omits dismissed rows immediately.
 
 **PR-bound fix pass:** use `gitmoot agent implement <agent> --repo owner/repo
 --pr <number> "..."` or `gitmoot agent run <agent> --repo owner/repo --action
@@ -13727,6 +13852,16 @@ cannot recurse or fan out forever:
   `answer` verb is valid only on an ask round and `retry`/`continue`/`abort` only
   on a failure round — a mismatch is rejected with a clear message. Absence of
   `human_questions[]` is byte-identical to today's behavior.
+
+- Dismissed task terminality (#913): `dismissed` may be entered only from
+  `implementing` or `blocked`. Manual `task dismiss` proves there is no live
+  matching job and no process in the task worktree. Automatic stale-task
+  reconciliation proves there is no live matching job and requires its separate
+  open-PR/remote-branch evidence, but does not inspect worktree processes.
+  Ordinary task run/allocation and late review or continuation advancement fail
+  closed instead of overwriting it. Only `task recover` or retrying a job performs
+  an explicit audited recovery. Dismissal never deletes the task branch or
+  worktree.
 
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, a delegation batch


### PR DESCRIPTION
## Summary

Fixes #885 — `gitmoot workflow note` now auto-detects coordinator identity instead of trusting self-reported values (a shipped workflow once carried pane "fable" when the real herdr pane was "Gitmoot2", with an 8-char session id that breaks `claude --resume`).

- New `internal/cli/workflow_coordinator.go`: when `--pane`/`--session`/`--workdir` are unset and the process is herdr-hosted (`HERDR_SOCKET_PATH` / `HERDR_ENV=1`), query `herdr pane current --current` and default from `result.pane.label` (fallback `pane_id`), `agent_session.value` (the FULL uuid), and `cwd` (fallback `foreground_cwd`).
- **Fail-open by design**: herdr missing, socket absent, non-zero exit, malformed JSON, or non-herdr environment → fields stay empty and the note still succeeds. Lookup is bounded by a 2s process-group timeout.
- **Explicit flags always win**; `--no-auto` disables detection for scripted callers.
- **Full-UUID validation**: a non-canonical session id is suppressed from the workflow detail projection, so the dashboard can never render a broken `--resume` command; raw values remain visible as context.

## Tests

`TestWorkflowNoteAutoDetectsHerdrCoordinatorIdentity`, `TestWorkflowNoteHerdrFallbackFields`, `TestWorkflowNoteExplicitCoordinatorFlagsWinAndNoAutoSkips`, `TestWorkflowNoteHerdrDetectionFailsOpen` (missing binary / non-zero exit / garbage JSON / no herdr env), `TestWorkflowNoteHerdrDetectionTimeoutIsBounded`, `TestFullWorkflowSessionUUIDValidation`; dashboard coordinator-projection test extended.

Gates: `go generate` clean, build/vet green, `go test ./internal/cli/ ./internal/db/ ./internal/workflow/` all ok. Docs + `llms-full.txt` regenerated in-PR.

Part of the `gitmoot4/p1p2-wave` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)