### PR TITLE
ci: Stage 2 — compile-once race binaries + LPT timing-balanced shards (#906)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,20 +5,26 @@ name: CI
 # local run. Does NOT run the live multi-runtime (codex/claude/kimi) E2E — that
 # needs runtime auth and stays a manual step.
 #
-# Stage 1 lane map (#906; expected wall time ~10m), all rigor-preserving:
+# Stage 2 lane map (#906; expected wall time ~8m), all rigor-preserving:
 #   - DEP-ONLY FAST LANE: a PR touching only go.mod/go.sum (the dashboard-module
 #     pin bumps — embedded assets, zero Go changes) skips the -race lanes. The
 #     full build + generated-contract check + vet + non-race `go test ./...`
 #     still run, and the bumped module passed its own CI. Pushes to main always
 #     run everything.
 #   - BUILD / VET / TEST: build, generated-contract check, vet, and plain
-#     `go test ./...` stay together as the non-race gate.
-#   - RACE: internal/cli is split 5 ways, internal/db is split 2 ways, and
-#     internal/workflow is split 3 ways; internal/daemon has its own small leg. Sharded packages use an
-#     alternating deterministic partition of `go test -list` output, so each
-#     matrix covers its full current suite.
-#
-# Stage 2 of #906 will add timing-balanced shards and compile-once race binaries.
+#     `go test ./...` stay together with the partition-script self-test as the
+#     non-race gate.
+#   - RACE BUILD: four package jobs compile one -race test binary each. Every
+#     package's full current test list is partitioned and asserted to appear
+#     exactly once before its binary + shard plan are uploaded.
+#   - RACE RUN: internal/cli is split 5 ways, internal/db 2 ways,
+#     internal/workflow 3 ways, and internal/daemon 1 way. Each runner downloads
+#     the package bundle and executes from the package directory, preserving Go
+#     test-binary working-directory semantics without recompiling.
+#   - TIMINGS: PRs use the newest non-expired main timing artifact (up to 30
+#     days old) for deterministic LPT balancing. Missing, malformed, or stale
+#     timings fall back loudly to Stage 1's deterministic alternation. Successful
+#     pushes to main publish fresh per-test timings for subsequent PRs.
 
 on:
   push:
@@ -27,6 +33,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -41,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.diff.outputs.code }}
+      timings_run_id: ${{ steps.timings.outputs.timings_run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,6 +70,46 @@ jobs:
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
             echo "dep-only diff — race lanes will be skipped"
+          fi
+
+      - name: Find latest main race timings
+        id: timings
+        if: github.event_name == 'pull_request' && steps.diff.outputs.code == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          response="$RUNNER_TEMP/race-timing-artifacts.json"
+          if ! curl --fail --silent --show-error \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts?name=race-test-timings&per_page=100" \
+            --output "$response"; then
+            echo "::warning::could not query main race timings; deterministic fallback will be used"
+            echo "timings_run_id=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cutoff=$(date -u -d '30 days ago' '+%Y-%m-%dT%H:%M:%SZ')
+          if ! run_id=$(jq -r --arg cutoff "$cutoff" '
+            [
+              .artifacts[]
+              | select(.expired == false)
+              | select(.created_at >= $cutoff)
+              | select(.workflow_run.head_branch == "main")
+            ]
+            | sort_by(.created_at)
+            | last
+            | .workflow_run.id // empty
+          ' "$response"); then
+            echo "::warning::could not parse main race timing metadata; deterministic fallback will be used"
+            run_id=""
+          fi
+          echo "timings_run_id=$run_id" >> "$GITHUB_OUTPUT"
+          if [ -n "$run_id" ]; then
+            echo "using race timings from main workflow run $run_id"
+          else
+            echo "no fresh main race timing artifact; deterministic fallback will be used"
           fi
 
   build-test:
@@ -93,11 +141,14 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Race partition script
+        run: scripts/partition-race-tests_test.sh
+
       - name: Test
         run: go test ./...
 
-  race-cli:
-    name: race (internal/cli, shard ${{ matrix.shard }}/5)
+  race-build:
+    name: race build (internal/${{ matrix.package }})
     needs: changes
     # Skipped on dep-only PRs (#754); see the fast-lane note at the top.
     if: needs.changes.outputs.code == 'true'
@@ -105,7 +156,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4]
+        include:
+          - package: cli
+            shards: 5
+          - package: db
+            shards: 2
+          - package: workflow
+            shards: 3
+          - package: daemon
+            shards: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,105 +175,186 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Test (race detector, internal/cli — sharded)
-        # internal/cli is the mega-package (the #484 canary auto-rollback
-        # concurrency contract lives here, so it belongs under the detector),
-        # but under -race the full suite runs 17-21m and grows every wave
-        # (#733). It is sharded 5-way (#906): `go test -list` enumerates the
-        # current test functions and an alternating line split partitions them
-        # deterministically — adjacent names interleave, so alphabetical
-        # clusters of slow E2Es spread across the shards, and the union of
-        # the shards is always the complete suite as it exists on this commit.
-        run: |
-          TESTS=$(go test -list '.*' ./internal/cli/ | grep '^Test' || true)
-          if [ -z "$TESTS" ]; then echo "no tests listed"; exit 1; fi
-          PICK=$(echo "$TESTS" | awk -v s='${{ matrix.shard }}' 'NR % 5 == s')
-          COUNT=$(echo "$PICK" | grep -c . || true)
-          echo "shard ${{ matrix.shard }}: $COUNT of $(echo "$TESTS" | wc -l) tests"
-          RUN="^($(echo "$PICK" | paste -sd'|' -))$"
-          go test -race -timeout 20m -run "$RUN" ./internal/cli/
+      - name: Download latest main race timings
+        id: download-timings
+        if: needs.changes.outputs.timings_run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: race-test-timings
+          path: ${{ runner.temp }}/main-race-timings
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.changes.outputs.timings_run_id }}
 
-  race-db:
-    name: race (internal/db, shard ${{ matrix.shard }}/2)
-    needs: changes
+      - name: Compile once and partition
+        env:
+          PACKAGE: ${{ matrix.package }}
+          SHARDS: ${{ matrix.shards }}
+        run: |
+          set -o pipefail
+          bundle="$RUNNER_TEMP/race-$PACKAGE"
+          mkdir -p "$bundle/partitions"
+
+          go test -c -race -o "$bundle/$PACKAGE.test" "./internal/$PACKAGE/"
+          # `go tool -n` resolves the matching test2json executable even when
+          # the Go distribution materializes it in the build cache on demand.
+          cp "$(go tool -n test2json)" "$bundle/test2json"
+          (
+            cd "internal/$PACKAGE"
+            "$bundle/$PACKAGE.test" -test.list '.*'
+          ) > "$bundle/tests.list"
+
+          args=(
+            --tests "$bundle/tests.list"
+            --shards "$SHARDS"
+            --out-dir "$bundle/partitions"
+          )
+          timings="$RUNNER_TEMP/main-race-timings/race-test-timings.tsv"
+          if [ -s "$timings" ]; then
+            args+=(--timings "$timings" --package "internal/$PACKAGE")
+          else
+            echo "main timings unavailable; using deterministic alternation"
+          fi
+
+          set +e
+          scripts/partition-race-tests.sh "${args[@]}"
+          status=$?
+          set -e
+          if [ "$status" -eq 2 ]; then
+            echo "::warning::main timings are stale or malformed for internal/$PACKAGE; using deterministic alternation"
+            scripts/partition-race-tests.sh \
+              --tests "$bundle/tests.list" \
+              --shards "$SHARDS" \
+              --out-dir "$bundle/partitions"
+          elif [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
+
+      - name: Upload race binary and shard plan
+        uses: actions/upload-artifact@v4
+        with:
+          name: race-${{ matrix.package }}-bundle
+          path: ${{ runner.temp }}/race-${{ matrix.package }}
+          if-no-files-found: error
+          retention-days: 7
+
+  race:
+    name: race (internal/${{ matrix.package }}, shard ${{ matrix.shard }}/${{ matrix.shards }})
+    needs: [changes, race-build]
     # Skipped on dep-only PRs (#754); see the fast-lane note at the top.
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1]
+        include:
+          - {package: cli, shard: 0, shards: 5}
+          - {package: cli, shard: 1, shards: 5}
+          - {package: cli, shard: 2, shards: 5}
+          - {package: cli, shard: 3, shards: 5}
+          - {package: cli, shard: 4, shards: 5}
+          - {package: db, shard: 0, shards: 2}
+          - {package: db, shard: 1, shards: 2}
+          - {package: workflow, shard: 0, shards: 3}
+          - {package: workflow, shard: 1, shards: 3}
+          - {package: workflow, shard: 2, shards: 3}
+          - {package: daemon, shard: 0, shards: 1}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Download compiled race binary and shard plan
+        uses: actions/download-artifact@v4
         with:
-          go-version-file: go.mod
-          cache: true
+          name: race-${{ matrix.package }}-bundle
+          path: ${{ runner.temp }}/race-${{ matrix.package }}
 
-      - name: Test (race detector, internal/db — sharded)
-        # The database package is large enough to need test-list sharding rather
-        # than package splitting. This is the same deterministic alternation used
-        # by race-cli, with both shards covering the complete current suite.
+      - name: Run compiled race shard
+        env:
+          PACKAGE: ${{ matrix.package }}
+          SHARD: ${{ matrix.shard }}
         run: |
-          TESTS=$(go test -list '.*' ./internal/db/ | grep '^Test' || true)
-          if [ -z "$TESTS" ]; then echo "no tests listed"; exit 1; fi
-          PICK=$(echo "$TESTS" | awk -v s='${{ matrix.shard }}' 'NR % 2 == s')
-          COUNT=$(echo "$PICK" | grep -c . || true)
-          echo "shard ${{ matrix.shard }}: $COUNT of $(echo "$TESTS" | wc -l) tests"
-          RUN="^($(echo "$PICK" | paste -sd'|' -))$"
-          go test -race -timeout 20m -run "$RUN" ./internal/db/
+          set -o pipefail
+          bundle="$RUNNER_TEMP/race-$PACKAGE"
+          binary="$bundle/$PACKAGE.test"
+          test2json="$bundle/test2json"
+          chmod +x "$binary" "$test2json"
 
-  race-workflow:
-    name: race (internal/workflow, shard ${{ matrix.shard }}/3)
-    needs: changes
-    # Skipped on dep-only PRs (#754); see the fast-lane note at the top.
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [0, 1, 2]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+          run_regex=$(cat "$bundle/partitions/shard-$SHARD.regex")
+          count=$(wc -l < "$bundle/partitions/shard-$SHARD.tests" | tr -d ' ')
+          total=$(wc -l < "$bundle/tests.list" | tr -d ' ')
+          echo "running internal/$PACKAGE shard $SHARD: $count of $total tests"
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+          timing="$RUNNER_TEMP/race-timing-$PACKAGE-$SHARD.json"
+          (
+            cd "internal/$PACKAGE"
+            "$binary" \
+              -test.v=test2json \
+              -test.run="$run_regex" \
+              -test.timeout=20m 2>&1 \
+              | "$test2json" -p "internal/$PACKAGE" -t \
+              | tee "$timing"
+          )
+
+      - name: Upload raw per-test timings
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
         with:
-          go-version-file: go.mod
-          cache: true
+          name: race-timing-${{ matrix.package }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/race-timing-${{ matrix.package }}-${{ matrix.shard }}.json
+          if-no-files-found: error
+          retention-days: 7
 
-      - name: Test (race detector, internal/workflow — sharded)
-        # The Stage-1 demonstration run measured this package at ~16m as a
-        # single leg — the true former critical path. Same deterministic
-        # alternating test-list split as race-cli/race-db.
+  race-timings:
+    name: publish race timings
+    needs: race
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download raw timing shards
+        uses: actions/download-artifact@v4
+        with:
+          pattern: race-timing-*
+          path: ${{ runner.temp }}/race-timing-shards
+          merge-multiple: true
+
+      - name: Build per-test timing table
         run: |
-          TESTS=$(go test -list '.*' ./internal/workflow/ | grep '^Test' || true)
-          if [ -z "$TESTS" ]; then echo "no tests listed"; exit 1; fi
-          PICK=$(echo "$TESTS" | awk -v s='${{ matrix.shard }}' 'NR % 3 == s')
-          COUNT=$(echo "$PICK" | grep -c . || true)
-          echo "shard ${{ matrix.shard }}: $COUNT of $(echo "$TESTS" | wc -l) tests"
-          RUN="^($(echo "$PICK" | paste -sd'|' -))$"
-          go test -race -timeout 20m -run "$RUN" ./internal/workflow/
+          shopt -s nullglob
+          files=("$RUNNER_TEMP"/race-timing-shards/*.json)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "no raw timing shards downloaded" >&2
+            exit 1
+          fi
 
-  race-daemon:
-    name: race (internal/daemon)
-    needs: changes
-    # Skipped on dep-only PRs (#754); see the fast-lane note at the top.
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+          jq -sr '
+            [
+              .[]
+              | select(
+                  (.Action == "pass" or .Action == "skip")
+                  and .Test != null
+                  and .Elapsed != null
+                )
+              | select((.Test | contains("/")) | not)
+              | select(.Test | test("^(Test|Fuzz|Example)"))
+              | [.Package, .Test, (.Elapsed | tostring)]
+            ]
+            | sort_by(.[0], .[1])
+            | .[]
+            | @tsv
+          ' "${files[@]}" > "$RUNNER_TEMP/race-test-timings.tsv"
+          if [ ! -s "$RUNNER_TEMP/race-test-timings.tsv" ]; then
+            echo "timing table is empty" >&2
+            exit 1
+          fi
+          awk -F '\t' '{ count[$1]++ } END { for (package in count) print package ": " count[package] " tests" }' \
+            "$RUNNER_TEMP/race-test-timings.tsv" | sort
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - name: Publish main race timings
+        uses: actions/upload-artifact@v4
         with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Test (race detector, internal/daemon)
-        run: go test -race -timeout 20m ./internal/daemon/
+          name: race-test-timings
+          path: ${{ runner.temp }}/race-test-timings.tsv
+          if-no-files-found: error
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,9 @@ go build ./...
 go generate ./... && git diff --exit-code   # gitmoot_result contract is single-sourced + regenerated; stale artifact fails CI
 go vet ./...
 go test ./...
-# Race gate is scoped (not ./...). CI splits it across two parallel jobs (#733):
-# `build / vet / test` runs workflow+db+daemon at 20m, `race (internal/cli)` runs
-# the mega-package on its own at 35m. Locally you can run all four at once:
+# Race gate is scoped (not ./...). CI compiles one -race test binary per package
+# and runs timing-balanced shards from those binaries (#906). Locally you can
+# run the four complete packages at once:
 go test -race -timeout 35m ./internal/workflow/ ./internal/cli/ ./internal/db/ ./internal/daemon/
 ```
 

--- a/scripts/partition-race-tests.sh
+++ b/scripts/partition-race-tests.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export LC_ALL=C
+
+usage() {
+  cat <<'EOF'
+Usage: partition-race-tests.sh --tests FILE --shards N --out-dir DIR [--timings FILE --package NAME]
+
+Partitions the current top-level Go test list into N shards. With timings, it
+uses deterministic longest-processing-time-first balancing. Without timings,
+it uses the Stage 1 alternating split (line number modulo shard count).
+
+Exit status 2 means the optional timings are malformed or do not exactly match
+the current test list. Callers may retry without --timings. Any coverage
+assertion failure uses status 1 and must remain a hard failure.
+EOF
+}
+
+fail() {
+  echo "partition-race-tests: $*" >&2
+  exit 1
+}
+
+timings_invalid() {
+  echo "partition-race-tests: unusable timings: $*" >&2
+  exit 2
+}
+
+tests_file=""
+timings_file=""
+package=""
+shards=""
+out_dir=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tests)
+      [[ $# -ge 2 ]] || fail "--tests requires a value"
+      tests_file="$2"
+      shift 2
+      ;;
+    --timings)
+      [[ $# -ge 2 ]] || fail "--timings requires a value"
+      timings_file="$2"
+      shift 2
+      ;;
+    --package)
+      [[ $# -ge 2 ]] || fail "--package requires a value"
+      package="$2"
+      shift 2
+      ;;
+    --shards)
+      [[ $# -ge 2 ]] || fail "--shards requires a value"
+      shards="$2"
+      shift 2
+      ;;
+    --out-dir)
+      [[ $# -ge 2 ]] || fail "--out-dir requires a value"
+      out_dir="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$tests_file" ]] || fail "--tests is required"
+[[ -f "$tests_file" ]] || fail "test list does not exist: $tests_file"
+[[ "$shards" =~ ^[1-9][0-9]*$ ]] || fail "--shards must be a positive integer"
+[[ -n "$out_dir" ]] || fail "--out-dir is required"
+if [[ -n "$timings_file" && -z "$package" ]]; then
+  fail "--package is required with --timings"
+fi
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/gitmoot-race-partition.XXXXXX")"
+cleanup() { rm -rf "$work_dir"; }
+trap cleanup EXIT
+
+current_tests="$work_dir/current-tests"
+unexpected="$work_dir/unexpected"
+benchmarks="$work_dir/benchmarks"
+: >"$current_tests"
+: >"$unexpected"
+: >"$benchmarks"
+
+# A compiled test binary's -test.list output is just names. go test -list also
+# appends an ok/? package status line, which is accepted for local dry-runs.
+awk -v tests="$current_tests" -v unexpected="$unexpected" -v benchmarks="$benchmarks" '
+  /^(Test|Fuzz|Example)[^[:space:]]*$/ { print > tests; next }
+  /^Benchmark[^[:space:]]*$/ { print > benchmarks; next }
+  /^[[:space:]]*$/ { next }
+  /^(ok|\?)[[:space:]]/ { next }
+  { print > unexpected }
+' "$tests_file"
+
+[[ -s "$current_tests" ]] || fail "no runnable tests found in $tests_file"
+if [[ -s "$unexpected" ]]; then
+  echo "partition-race-tests: unexpected go test -list output:" >&2
+  sed 's/^/  /' "$unexpected" >&2
+  exit 1
+fi
+if [[ -s "$benchmarks" ]]; then
+  echo "partition-race-tests: benchmarks are not selected by -test.run:" >&2
+  sed 's/^/  /' "$benchmarks" >&2
+  exit 1
+fi
+
+sorted_tests="$work_dir/current-tests.sorted"
+sort "$current_tests" >"$sorted_tests"
+duplicates="$work_dir/current-tests.duplicates"
+uniq -d "$sorted_tests" >"$duplicates"
+if [[ -s "$duplicates" ]]; then
+  echo "partition-race-tests: duplicate current tests:" >&2
+  sed 's/^/  /' "$duplicates" >&2
+  exit 1
+fi
+
+mkdir -p "$out_dir"
+rm -f "$out_dir"/shard-*.tests "$out_dir"/shard-*.regex \
+  "$out_dir/manifest.tsv" "$out_dir/mode"
+for ((shard = 0; shard < shards; shard++)); do
+  : >"$out_dir/shard-$shard.tests"
+done
+
+mode="alternation"
+if [[ -n "$timings_file" ]]; then
+  [[ -f "$timings_file" ]] || timings_invalid "file does not exist: $timings_file"
+
+  package_timings="$work_dir/package-timings"
+  if ! awk -F '\t' -v package="$package" '
+    NF != 3 { exit 1 }
+    $1 == "" || $2 == "" || $3 !~ /^[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?$/ { exit 1 }
+    $1 == package { print $2 "\t" $3 }
+  ' "$timings_file" >"$package_timings"; then
+    timings_invalid "expected tab-separated package, test, elapsed rows"
+  fi
+  [[ -s "$package_timings" ]] || timings_invalid "no rows for package $package"
+
+  timing_names="$work_dir/timing-names.sorted"
+  cut -f1 "$package_timings" | sort >"$timing_names"
+  timing_duplicates="$work_dir/timing-names.duplicates"
+  uniq -d "$timing_names" >"$timing_duplicates"
+  missing="$work_dir/timing-names.missing"
+  unknown="$work_dir/timing-names.unknown"
+  comm -23 "$sorted_tests" "$timing_names" >"$missing"
+  comm -13 "$sorted_tests" "$timing_names" >"$unknown"
+
+  if [[ -s "$timing_duplicates" || -s "$missing" || -s "$unknown" ]]; then
+    echo "partition-race-tests: unusable timings: test set does not match current package $package" >&2
+    if [[ -s "$timing_duplicates" ]]; then
+      echo "  duplicate timing rows:" >&2
+      sed 's/^/    /' "$timing_duplicates" >&2
+    fi
+    if [[ -s "$missing" ]]; then
+      echo "  current tests missing from timings:" >&2
+      sed 's/^/    /' "$missing" >&2
+    fi
+    if [[ -s "$unknown" ]]; then
+      echo "  timing rows absent from current tests:" >&2
+      sed 's/^/    /' "$unknown" >&2
+    fi
+    exit 2
+  fi
+
+  # LPT: longest tests first, test name as the stable duration tiebreak, then
+  # assign to the lowest-load shard (lowest shard number breaks load ties).
+  sorted_timings="$work_dir/package-timings.sorted"
+  sort -t $'\t' -k2,2gr -k1,1 "$package_timings" >"$sorted_timings"
+  awk -F '\t' -v shards="$shards" -v out="$out_dir" '
+    BEGIN {
+      for (i = 0; i < shards; i++) load[i] = 0
+    }
+    {
+      selected = 0
+      for (i = 1; i < shards; i++) {
+        if (load[i] < load[selected]) selected = i
+      }
+      print $1 >> (out "/shard-" selected ".tests")
+      load[selected] += $2
+    }
+  ' "$sorted_timings"
+  mode="lpt"
+else
+  # Preserve Stage 1 exactly: awk NR starts at one, so the first test goes to
+  # shard 1 (or shard 0 when there is only one shard).
+  awk -v shards="$shards" -v out="$out_dir" '
+    { print > (out "/shard-" (NR % shards) ".tests") }
+  ' "$current_tests"
+fi
+
+# Coverage is checked from the current package list, never from the timings.
+# A coverage mismatch is status 1 so CI cannot turn it into a timing fallback.
+assigned="$work_dir/assigned"
+for ((shard = 0; shard < shards; shard++)); do
+  cat "$out_dir/shard-$shard.tests" >>"$assigned"
+done
+assigned_sorted="$work_dir/assigned.sorted"
+sort "$assigned" >"$assigned_sorted"
+assigned_duplicates="$work_dir/assigned.duplicates"
+uniq -d "$assigned_sorted" >"$assigned_duplicates"
+missing="$work_dir/assigned.missing"
+extra="$work_dir/assigned.extra"
+comm -23 "$sorted_tests" "$assigned_sorted" >"$missing"
+comm -13 "$sorted_tests" "$assigned_sorted" >"$extra"
+
+if [[ -s "$assigned_duplicates" || -s "$missing" || -s "$extra" ]]; then
+  echo "partition-race-tests: COVERAGE ASSERTION FAILED" >&2
+  [[ ! -s "$assigned_duplicates" ]] || { echo "  tests assigned more than once:" >&2; sed 's/^/    /' "$assigned_duplicates" >&2; }
+  [[ ! -s "$missing" ]] || { echo "  tests not assigned:" >&2; sed 's/^/    /' "$missing" >&2; }
+  [[ ! -s "$extra" ]] || { echo "  assignments absent from current list:" >&2; sed 's/^/    /' "$extra" >&2; }
+  exit 1
+fi
+
+total="$(wc -l <"$current_tests" | tr -d ' ')"
+: >"$out_dir/manifest.tsv"
+for ((shard = 0; shard < shards; shard++)); do
+  tests="$out_dir/shard-$shard.tests"
+  regex="$out_dir/shard-$shard.regex"
+  count="$(wc -l <"$tests" | tr -d ' ')"
+  if [[ "$count" -eq 0 ]]; then
+    echo 'a^' >"$regex"
+  else
+    awk 'BEGIN { printf "^(" } { if (NR > 1) printf "|"; printf "%s", $0 } END { print ")$" }' "$tests" >"$regex"
+  fi
+  awk -v shard="$shard" '{ print shard "\t" $0 }' "$tests" >>"$out_dir/manifest.tsv"
+  echo "partition-race-tests: shard $shard: $count of $total tests"
+done
+echo "$mode" >"$out_dir/mode"
+echo "partition-race-tests: coverage assertion passed: all $total current tests assigned exactly once ($mode)"

--- a/scripts/partition-race-tests_test.sh
+++ b/scripts/partition-race-tests_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PARTITION="$ROOT_DIR/scripts/partition-race-tests.sh"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/gitmoot-race-partition-test.XXXXXX")"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+fail() {
+  echo "partition-race-tests test: $*" >&2
+  exit 1
+}
+
+assert_coverage() {
+  local out_dir="$1"
+  local actual="$WORK/actual"
+  local unique="$WORK/unique"
+  cat "$out_dir"/shard-*.tests | sort >"$actual"
+  uniq "$actual" >"$unique"
+  diff -u "$WORK/expected.sorted" "$actual"
+  diff -u "$actual" "$unique"
+}
+
+cat >"$WORK/tests.list" <<'EOF'
+TestAlpha
+TestBeta
+TestGamma
+TestDelta
+TestEpsilon
+ok  	example/package	0.001s
+EOF
+grep '^Test' "$WORK/tests.list" | sort >"$WORK/expected.sorted"
+
+# Deliberately shuffled; equal durations prove test-name tie-breaking.
+cat >"$WORK/timings.tsv" <<'EOF'
+example/package	TestGamma	4
+example/package	TestEpsilon	1
+example/package	TestBeta	10
+example/package	TestDelta	4
+example/package	TestAlpha	10
+EOF
+
+"$PARTITION" \
+  --tests "$WORK/tests.list" \
+  --timings "$WORK/timings.tsv" \
+  --package example/package \
+  --shards 2 \
+  --out-dir "$WORK/lpt-one"
+assert_coverage "$WORK/lpt-one"
+[[ "$(cat "$WORK/lpt-one/mode")" == "lpt" ]] || fail "timed partition did not select LPT"
+diff -u <(printf 'TestAlpha\nTestDelta\nTestEpsilon\n') "$WORK/lpt-one/shard-0.tests"
+diff -u <(printf 'TestBeta\nTestGamma\n') "$WORK/lpt-one/shard-1.tests"
+
+"$PARTITION" \
+  --tests "$WORK/tests.list" \
+  --timings "$WORK/timings.tsv" \
+  --package example/package \
+  --shards 2 \
+  --out-dir "$WORK/lpt-two" >/dev/null
+diff -ru "$WORK/lpt-one" "$WORK/lpt-two"
+
+"$PARTITION" \
+  --tests "$WORK/tests.list" \
+  --shards 2 \
+  --out-dir "$WORK/fallback" >/dev/null
+assert_coverage "$WORK/fallback"
+[[ "$(cat "$WORK/fallback/mode")" == "alternation" ]] || fail "missing timings did not select alternation"
+diff -u <(printf 'TestBeta\nTestDelta\n') "$WORK/fallback/shard-0.tests"
+diff -u <(printf 'TestAlpha\nTestGamma\nTestEpsilon\n') "$WORK/fallback/shard-1.tests"
+
+cat >"$WORK/stale.tsv" <<'EOF'
+example/package	TestAlpha	10
+example/package	TestBeta	9
+example/package	TestGamma	8
+example/package	TestDelta	7
+example/package	TestRemoved	6
+EOF
+set +e
+"$PARTITION" \
+  --tests "$WORK/tests.list" \
+  --timings "$WORK/stale.tsv" \
+  --package example/package \
+  --shards 2 \
+  --out-dir "$WORK/stale" >"$WORK/stale.stdout" 2>"$WORK/stale.stderr"
+status=$?
+set -e
+[[ "$status" -eq 2 ]] || fail "stale timings returned $status, want 2"
+grep -q 'current tests missing from timings' "$WORK/stale.stderr" || fail "stale timings did not report missing tests"
+grep -q 'timing rows absent from current tests' "$WORK/stale.stderr" || fail "stale timings did not report removed tests"
+
+echo "partition-race-tests test: PASS"


### PR DESCRIPTION
## Summary

**Stage 2** of #906 (Stage 1 — the job split — shipped in #907/e65c88e). Target: ~10 → ~8 min, self-balancing.

- **Compile-once race binaries**: four `race build` jobs each compile one package's `-race` test binary and upload it; the 11 shards (cli×5, db×2, workflow×3, daemon×1) download and run their slice from the package directory. Per-shard compile cost — the measured floor — is now paid once.
- **LPT timing-balanced shards**: main pushes publish a per-test timings artifact (test2json `elapsed`); PR runs partition greedily longest-first, descending, with test name as tie-break and lowest shard number for equal loads → deterministic.
- **Coverage assertion (the critical safety property)**: `scripts/partition-race-tests.sh` verifies the shard union against the **compiled binary's own `-test.list`** — never against the timings — and fails with status 1 on any duplicate, missing, or unknown assignment. A stale/incomplete timings artifact returns status 2 (diagnostics) and CI **retries without timings** via the Stage-1 alternation fallback, so a bad artifact can never silently drop tests.
- Dep-only fast lane (#754) semantics unchanged.

## Tests

`scripts/partition-race-tests_test.sh`: exact-once coverage, deterministic LPT, no-timings alternation fallback, and loud stale-artifact rejection. Fallback dry-runs against all current package lists (cli 1555, db 247, workflow 628, daemon 86). A compiled CLI race binary was executed to confirm relative `testdata` access and numeric test2json output survive the `go test -c` path. YAML parsed; `bash -n` clean; full Go gates green.

## Acceptance

Wall-clock proof comes from **this PR's own CI run** — the shard-union assertion must print green in each shard's log, with all lanes < 10 min.

Part of the `gitmoot4/p1p2-wave` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)