### PR TITLE
feat(pipeline): pipeline_success trigger kind — run B when a run of A succeeds (#922)

### DIFF
--- a/internal/cli/dashboard_web_pipelines.go
+++ b/internal/cli/dashboard_web_pipelines.go
@@ -37,12 +37,13 @@ func (d *webDataSource) Pipelines(ctx context.Context) ([]dashboard.PipelineSumm
 			return err
 		}
 		out = make([]dashboard.PipelineSummary, 0, len(rows))
+		knownPipelines := pipelineNameSet(rows)
 		for _, p := range rows {
 			summary := dashboard.PipelineSummary{
 				Name:       p.Name,
 				Repo:       p.Repo,
 				Enabled:    p.Enabled,
-				Mode:       pipelineDisplayMode(p),
+				Mode:       pipelineDisplayMode(p, pipelineUpstreamMissing(p, knownPipelines)),
 				Interval:   p.Interval,
 				Jitter:     p.Jitter,
 				StageCount: pipelineStageCount(p.SpecYAML),

--- a/internal/cli/dashboard_web_pipelines_test.go
+++ b/internal/cli/dashboard_web_pipelines_test.go
@@ -125,6 +125,37 @@ func TestWebDataSourcePipelinesEmpty(t *testing.T) {
 	}
 }
 
+func TestWebDataSourcePipelinesPipelineTriggerMode(t *testing.T) {
+	home := dashboardTestHome(t)
+	store := openPipelineTestStore(t, home)
+	upstreamSpec := "name: upstream\nstages: [{id: run, cmd: echo}]\n"
+	downstreamSpec := "name: downstream\nrepo: owner/downstream\ntrigger: {kind: pipeline, pipeline: upstream}\nstages: [{id: run, cmd: echo}]\n"
+	seedTestPipeline(t, store, db.Pipeline{Name: "upstream", SpecYAML: upstreamSpec})
+	seedTestPipeline(t, store, db.Pipeline{Name: "downstream", Repo: "owner/downstream", SpecYAML: downstreamSpec, Enabled: true})
+	store.Close()
+
+	ds := &webDataSource{home: home}
+	rows, err := ds.Pipelines(context.Background())
+	if err != nil {
+		t.Fatalf("Pipelines: %v", err)
+	}
+	if len(rows) != 2 || rows[0].Name != "downstream" || rows[0].Mode != "after: upstream" {
+		t.Fatalf("pipeline trigger dashboard mode = %+v", rows)
+	}
+	store = openPipelineTestStore(t, home)
+	if removed, err := store.DeletePipeline(context.Background(), "upstream"); err != nil || !removed {
+		t.Fatalf("remove upstream: removed=%v err=%v", removed, err)
+	}
+	store.Close()
+	rows, err = ds.Pipelines(context.Background())
+	if err != nil {
+		t.Fatalf("Pipelines after upstream removal: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Mode != "after: upstream (upstream missing)" {
+		t.Fatalf("missing-upstream dashboard mode = %+v", rows)
+	}
+}
+
 // TestWebDataSourcePipelines pins the list mapping: name order, schedule-state
 // field mapping (including the two time.Time -> epoch-ms conversions), the Recent
 // cap at 10 newest-first, and the Duration = finished-started rule.

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -202,6 +202,20 @@ func runPipelineAdd(args []string, stdout, stderr io.Writer) int {
 		if err := validatePipelineProducePaths(context.Background(), store, *home, spec); err != nil {
 			return err
 		}
+		registered, err := store.ListPipelines(ctx)
+		if err != nil {
+			return err
+		}
+		if err := validatePipelineTriggerCycle(registered, spec); err != nil {
+			return err
+		}
+		if spec.Trigger != nil && spec.Trigger.Kind == "pipeline" {
+			if _, found, err := store.GetPipeline(ctx, spec.Trigger.Pipeline); err != nil {
+				return err
+			} else if !found {
+				fmt.Fprintf(stderr, "warning: pipeline %q references upstream pipeline %q which does not exist yet; it will remain dormant until the upstream is added\n", spec.Name, spec.Trigger.Pipeline)
+			}
+		}
 		// Refuse to clobber a real managed agent that happens to occupy the runner
 		// name: a pre-existing non-shell agent by that name is a naming collision, not
 		// this pipeline's runner. A pre-existing shell agent (this pipeline's own
@@ -237,6 +251,13 @@ func runPipelineAdd(args []string, stdout, stderr io.Writer) int {
 		if err := store.CreateOrUpdatePipeline(ctx, record); err != nil {
 			return err
 		}
+		if spec.Trigger != nil && spec.Trigger.Kind == "pipeline" {
+			if err := store.ArmPipelineTrigger(ctx, spec.Name, spec.Trigger.Pipeline, time.Now().UTC()); err != nil {
+				return err
+			}
+		} else if err := store.DeletePipelineTriggerState(ctx, spec.Name); err != nil {
+			return err
+		}
 		if err := store.UpsertAgent(ctx, pipelineRunnerAgent(runnerName, repo)); err != nil {
 			return err
 		}
@@ -252,7 +273,7 @@ func runPipelineAdd(args []string, stdout, stderr io.Writer) int {
 			return err
 		}
 		finalEnabled = saved.Enabled
-		if finalEnabled && spec.Trigger != nil {
+		if finalEnabled && spec.Trigger != nil && spec.Trigger.Kind == "email" {
 			if _, bindErr := bindPipelineTrigger(ctx, store, saved, activepiecesAuthOptions{Home: *home}, triggerBindingPending); bindErr != nil {
 				fmt.Fprintf(stderr, "warning: pipeline %s was registered but its trigger is pending: %v; retry with `gitmoot pipeline bind-trigger %s`\n", spec.Name, bindErr, spec.Name)
 			}
@@ -285,6 +306,65 @@ func validatePipelineProducePaths(ctx context.Context, store *db.Store, homeFlag
 		if _, err := canonicalizePipelineProducePaths(ctx, store, homeFlag, fmt.Sprintf("stage %q", stage.ID), stage.Writes); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// validatePipelineTriggerCycle overlays candidate on the stored trigger graph
+// and walks downstream->upstream edges from the candidate. Missing upstreams are
+// leaves (the add path warns separately); only a closed chain is rejected.
+func validatePipelineTriggerCycle(records []db.Pipeline, candidate pipeline.Spec) error {
+	edges := make(map[string]string, len(records)+1)
+	for _, rec := range records {
+		spec, err := pipeline.Load([]byte(rec.SpecYAML))
+		if err != nil || spec.Trigger == nil || spec.Trigger.Kind != "pipeline" {
+			continue
+		}
+		edges[spec.Name] = spec.Trigger.Pipeline
+	}
+	delete(edges, candidate.Name)
+	if candidate.Trigger != nil && candidate.Trigger.Kind == "pipeline" {
+		edges[candidate.Name] = candidate.Trigger.Pipeline
+	} else {
+		return nil
+	}
+
+	const (
+		unvisited = iota
+		visiting
+		done
+	)
+	state := make(map[string]int, len(edges))
+	stack := make([]string, 0, len(edges)+1)
+	var visit func(string) []string
+	visit = func(name string) []string {
+		state[name] = visiting
+		stack = append(stack, name)
+		upstream := edges[name]
+		if upstream != "" {
+			switch state[upstream] {
+			case visiting:
+				start := 0
+				for i, item := range stack {
+					if item == upstream {
+						start = i
+						break
+					}
+				}
+				cycle := append([]string(nil), stack[start:]...)
+				return append(cycle, upstream)
+			case unvisited:
+				if cycle := visit(upstream); cycle != nil {
+					return cycle
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[name] = done
+		return nil
+	}
+	if cycle := visit(candidate.Name); cycle != nil {
+		return fmt.Errorf("pipeline trigger cycle: %s", strings.Join(cycle, " -> "))
 	}
 	return nil
 }
@@ -454,15 +534,16 @@ func runPipelineList(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "pipeline list: %v\n", err)
 		return 1
 	}
+	knownPipelines := pipelineNameSet(pipelines)
 	if *jsonOut {
 		out := make([]pipelineJSON, 0, len(pipelines))
 		for _, p := range pipelines {
-			out = append(out, pipelineToJSON(p, false, nil))
+			out = append(out, pipelineToJSON(p, false, nil, pipelineUpstreamMissing(p, knownPipelines)))
 		}
 		return encodePipelineJSON(stdout, stderr, out)
 	}
 	for _, p := range pipelines {
-		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\n", p.Name, enabledLabel(p.Enabled), pipelineListInterval(p), firstNonEmpty(p.Repo, "-"), firstNonEmpty(p.LastStatus, "-"), firstNonEmpty(triggerBindingState(p.TriggerBinding), "-"))
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\n", p.Name, enabledLabel(p.Enabled), pipelineListInterval(p, pipelineUpstreamMissing(p, knownPipelines)), firstNonEmpty(p.Repo, "-"), firstNonEmpty(p.LastStatus, "-"), firstNonEmpty(triggerBindingState(p.TriggerBinding), "-"))
 	}
 	return 0
 }
@@ -492,11 +573,12 @@ func runPipelineShow(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	var (
-		record   db.Pipeline
-		agents   map[string]db.Agent
-		found    bool
-		runView  pipelineRunView
-		runFound bool
+		record          db.Pipeline
+		agents          map[string]db.Agent
+		found           bool
+		runView         pipelineRunView
+		runFound        bool
+		upstreamMissing bool
 	)
 	if err := withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
@@ -510,6 +592,11 @@ func runPipelineShow(args []string, stdout, stderr io.Writer) int {
 		}
 		if found {
 			agents = pipelineStageAgents(ctx, store, record)
+			rows, listErr := store.ListPipelines(ctx)
+			if listErr != nil {
+				return listErr
+			}
+			upstreamMissing = pipelineUpstreamMissing(record, pipelineNameSet(rows))
 			return nil
 		}
 		runView, runFound, err = loadPipelineRunView(ctx, store, name)
@@ -520,9 +607,9 @@ func runPipelineShow(args []string, stdout, stderr io.Writer) int {
 	}
 	if found {
 		if *jsonOut {
-			return encodePipelineJSON(stdout, stderr, pipelineToJSON(record, true, agents))
+			return encodePipelineJSON(stdout, stderr, pipelineToJSON(record, true, agents, upstreamMissing))
 		}
-		printPipeline(stdout, record, agents)
+		printPipeline(stdout, record, agents, upstreamMissing)
 		return 0
 	}
 	if runFound {
@@ -588,7 +675,11 @@ func runPipelineSetEnabled(args []string, enabled bool, stdout, stderr io.Writer
 			if err := store.SetPipelineEnabled(ctx, name, false); err != nil {
 				return err
 			}
-			if strings.TrimSpace(rec.TriggerBinding) != "" {
+			shouldDisableBinding := true
+			if spec, loadErr := pipeline.Load([]byte(rec.SpecYAML)); loadErr == nil && spec.Trigger != nil && spec.Trigger.Kind == "pipeline" {
+				shouldDisableBinding = false
+			}
+			if shouldDisableBinding && strings.TrimSpace(rec.TriggerBinding) != "" {
 				if err := disablePipelineTrigger(ctx, store, rec, auth); err != nil {
 					fmt.Fprintf(stderr, "warning: pipeline %s is disabled locally, but Activepieces flow disable failed: %v\n", name, err)
 				}
@@ -602,7 +693,11 @@ func runPipelineSetEnabled(args []string, enabled bool, stdout, stderr io.Writer
 			}
 			return loadErr
 		}
-		if spec.Trigger != nil {
+		if spec.Trigger != nil && spec.Trigger.Kind == "pipeline" {
+			if err := store.ArmPipelineTrigger(ctx, name, spec.Trigger.Pipeline, time.Now().UTC()); err != nil {
+				return err
+			}
+		} else if spec.Trigger != nil && spec.Trigger.Kind == "email" {
 			if _, err := bindPipelineTrigger(ctx, store, rec, auth, triggerBindingError); err != nil {
 				return err
 			}
@@ -664,7 +759,14 @@ func runPipelineRemove(args []string, stdout, stderr io.Writer) int {
 		// leak it. Ignore the outcome — the pipeline row is what `remove` is about, and
 		// leaving an orphan runner is harmless (run/job cleanup lands in the run step).
 		_, _ = store.RemoveAgent(context.Background(), pipelineRunnerAgentName(name))
-		if removed && strings.TrimSpace(removedRecord.TriggerBinding) != "" {
+		shouldDeleteBinding := true
+		if spec, loadErr := pipeline.Load([]byte(removedRecord.SpecYAML)); loadErr == nil && spec.Trigger != nil && spec.Trigger.Kind == "pipeline" {
+			shouldDeleteBinding = false
+		}
+		if removed {
+			_ = store.DeletePipelineTriggerState(context.Background(), name)
+		}
+		if removed && shouldDeleteBinding && strings.TrimSpace(removedRecord.TriggerBinding) != "" {
 			auth := activepiecesAuthOptions{Home: *home, URL: *apURL, Port: *port, Email: *email, Password: *password}
 			if cleanupErr := deletePipelineTrigger(context.Background(), removedRecord, auth); cleanupErr != nil {
 				binding, _ := decodeTriggerBinding(removedRecord.TriggerBinding)
@@ -688,12 +790,12 @@ func runPipelineRemove(args []string, stdout, stderr io.Writer) int {
 // shape. When withStages is set it parses the stored (already-validated) spec to
 // enumerate the stage DAG; a parse failure degrades to no stages rather than
 // failing the command.
-func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Agent) pipelineJSON {
+func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Agent, upstreamMissing ...bool) pipelineJSON {
 	out := pipelineJSON{
 		Name:                record.Name,
 		Repo:                record.Repo,
 		Enabled:             record.Enabled,
-		Mode:                pipelineDisplayMode(record),
+		Mode:                pipelineDisplayMode(record, upstreamMissing...),
 		Interval:            record.Interval,
 		Jitter:              record.Jitter,
 		SpecHash:            record.SpecHash,
@@ -742,9 +844,16 @@ func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Ag
 	return out
 }
 
-func pipelineDisplayMode(record db.Pipeline) string {
+func pipelineDisplayMode(record db.Pipeline, upstreamMissing ...bool) string {
 	spec, err := pipeline.Load([]byte(record.SpecYAML))
 	if err == nil && spec.Trigger != nil {
+		if spec.Trigger.Kind == "pipeline" {
+			mode := "after: " + spec.Trigger.Pipeline
+			if len(upstreamMissing) > 0 && upstreamMissing[0] {
+				mode += " (upstream missing)"
+			}
+			return mode
+		}
 		state := triggerBindingState(record.TriggerBinding)
 		if state == "" {
 			// No binding record exists yet (never bound, e.g. added disabled):
@@ -768,9 +877,16 @@ func pipelineDisplayMode(record db.Pipeline) string {
 	return "manual"
 }
 
-func pipelineListInterval(record db.Pipeline) string {
+func pipelineListInterval(record db.Pipeline, upstreamMissing ...bool) string {
 	spec, err := pipeline.Load([]byte(record.SpecYAML))
 	if err == nil && spec.Trigger != nil {
+		if spec.Trigger.Kind == "pipeline" {
+			mode := "after: " + spec.Trigger.Pipeline
+			if len(upstreamMissing) > 0 && upstreamMissing[0] {
+				mode += " (upstream missing)"
+			}
+			return mode
+		}
 		// Hybrids keep their live interval visible: the scheduler fires them too.
 		if interval := strings.TrimSpace(record.Interval); interval != "" {
 			return "email+" + interval
@@ -778,6 +894,23 @@ func pipelineListInterval(record db.Pipeline) string {
 		return "email"
 	}
 	return firstNonEmpty(record.Interval, "-")
+}
+
+func pipelineNameSet(records []db.Pipeline) map[string]struct{} {
+	known := make(map[string]struct{}, len(records))
+	for _, rec := range records {
+		known[rec.Name] = struct{}{}
+	}
+	return known
+}
+
+func pipelineUpstreamMissing(record db.Pipeline, known map[string]struct{}) bool {
+	spec, err := pipeline.Load([]byte(record.SpecYAML))
+	if err != nil || spec.Trigger == nil || spec.Trigger.Kind != "pipeline" {
+		return false
+	}
+	_, found := known[spec.Trigger.Pipeline]
+	return !found
 }
 
 func pipelineStageAgents(ctx context.Context, store *db.Store, record db.Pipeline) map[string]db.Agent {
@@ -882,11 +1015,11 @@ func pipelinePromptPreview(prompt string) string {
 	return pipelinePreview(prompt, " ", 100)
 }
 
-func printPipeline(stdout io.Writer, record db.Pipeline, agents map[string]db.Agent) {
+func printPipeline(stdout io.Writer, record db.Pipeline, agents map[string]db.Agent, upstreamMissing ...bool) {
 	writeLine(stdout, "name: %s", record.Name)
 	writeLine(stdout, "repo: %s", firstNonEmpty(record.Repo, "-"))
 	writeLine(stdout, "enabled: %t", record.Enabled)
-	writeLine(stdout, "mode: %s", pipelineDisplayMode(record))
+	writeLine(stdout, "mode: %s", pipelineDisplayMode(record, upstreamMissing...))
 	writeLine(stdout, "interval: %s", firstNonEmpty(record.Interval, "-"))
 	writeLine(stdout, "jitter: %s", firstNonEmpty(record.Jitter, "-"))
 	writeLine(stdout, "spec_hash: %s", record.SpecHash)
@@ -1151,6 +1284,9 @@ func printPipelineRunFunnelAt(stdout io.Writer, view pipelineRunView, now time.T
 	writeLine(stdout, "run: %s", run.ID)
 	writeLine(stdout, "pipeline: %s", run.Pipeline)
 	writeLine(stdout, "trigger: %s", firstNonEmpty(run.Trigger, "-"))
+	if payload := strings.TrimSpace(run.PayloadJSON); payload != "" && payload != "{}" {
+		writeLine(stdout, "payload_json: %s", payload)
+	}
 	writeLine(stdout, "state: %s", run.State)
 	writeLine(stdout, "started: %s", heartbeatTimeForStatus(run.StartedAt))
 	writeLine(stdout, "finished: %s", heartbeatTimeForStatus(run.FinishedAt))
@@ -1298,37 +1434,42 @@ type pipelineRunStageProgressJSON struct {
 }
 
 type pipelineRunJSON struct {
-	ID         string                 `json:"id"`
-	Pipeline   string                 `json:"pipeline"`
-	Trigger    string                 `json:"trigger"`
-	State      string                 `json:"state"`
-	HaltStage  string                 `json:"halt_stage,omitempty"`
-	HaltReason string                 `json:"halt_reason,omitempty"`
-	Needs      []string               `json:"needs,omitempty"`
-	SpecHash   string                 `json:"spec_hash"`
-	StartedAt  string                 `json:"started_at,omitempty"`
-	FinishedAt string                 `json:"finished_at,omitempty"`
-	Funnel     string                 `json:"funnel"`
-	Stages     []pipelineRunStageJSON `json:"stages,omitempty"`
-	Tokens     int                    `json:"tokens"`
+	ID          string                 `json:"id"`
+	Pipeline    string                 `json:"pipeline"`
+	Trigger     string                 `json:"trigger"`
+	PayloadJSON string                 `json:"payload_json,omitempty"`
+	State       string                 `json:"state"`
+	HaltStage   string                 `json:"halt_stage,omitempty"`
+	HaltReason  string                 `json:"halt_reason,omitempty"`
+	Needs       []string               `json:"needs,omitempty"`
+	SpecHash    string                 `json:"spec_hash"`
+	StartedAt   string                 `json:"started_at,omitempty"`
+	FinishedAt  string                 `json:"finished_at,omitempty"`
+	Funnel      string                 `json:"funnel"`
+	Stages      []pipelineRunStageJSON `json:"stages,omitempty"`
+	Tokens      int                    `json:"tokens"`
 }
 
 // pipelineRunToJSON projects a run view into its script-stable JSON shape.
 func pipelineRunToJSON(view pipelineRunView) pipelineRunJSON {
 	run := view.run
 	out := pipelineRunJSON{
-		ID:         run.ID,
-		Pipeline:   run.Pipeline,
-		Trigger:    run.Trigger,
-		State:      run.State,
-		HaltStage:  run.HaltStage,
-		HaltReason: run.HaltReason,
-		Needs:      decodePipelineNeeds(run.NeedsJSON),
-		SpecHash:   run.SpecHash,
-		StartedAt:  pipelineRunTimeJSON(run.StartedAt),
-		FinishedAt: pipelineRunTimeJSON(run.FinishedAt),
-		Funnel:     pipelineFunnelLine(view.stages),
-		Tokens:     view.tokens,
+		ID:          run.ID,
+		Pipeline:    run.Pipeline,
+		Trigger:     run.Trigger,
+		PayloadJSON: strings.TrimSpace(run.PayloadJSON),
+		State:       run.State,
+		HaltStage:   run.HaltStage,
+		HaltReason:  run.HaltReason,
+		Needs:       decodePipelineNeeds(run.NeedsJSON),
+		SpecHash:    run.SpecHash,
+		StartedAt:   pipelineRunTimeJSON(run.StartedAt),
+		FinishedAt:  pipelineRunTimeJSON(run.FinishedAt),
+		Funnel:      pipelineFunnelLine(view.stages),
+		Tokens:      view.tokens,
+	}
+	if out.PayloadJSON == "{}" {
+		out.PayloadJSON = ""
 	}
 	for _, stage := range view.stages {
 		stageJSON := pipelineRunStageJSON{

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -679,17 +679,19 @@ func createPipelineRun(ctx context.Context, store *db.Store, rec db.Pipeline, sp
 }
 
 // runPipelineScanOnce is the pipeline scan wired into BOTH daemon supervisor loops
-// next to runHeartbeatScanOnce (#681). Each tick is two passes, mirroring the
+// next to runHeartbeatScanOnce (#681). Each tick is three passes, mirroring the
 // heartbeat idiom:
 //
 //	SCHEDULE pass — for each enabled pipeline whose interval is due and that has no
 //	  active run, create a fresh scheduled run and advance next_due anchored to now
 //	  (missed ticks coalesce into one run; a durable next_due makes it restart-safe).
+//	TRIGGER pass — create one downstream run for the next unseen succeeded upstream
+//	  run, using a durable cursor and the same active-run guard.
 //	ADVANCE  pass — advance every in-flight (state='running') run once.
 //
-// Ordering matters: the schedule pass creates the run rows, then the advance pass
-// enqueues their ready root stages, so a scheduled run and a manual `pipeline run`
-// reach the worker by the identical code path. Off-by-default and zero-cost when
+// Ordering matters: the schedule and trigger passes create run rows, then the
+// advance pass enqueues their ready root stages, so every run source reaches the
+// worker by the identical code path. Off-by-default and zero-cost when
 // idle: a pipeline with no interval is skipped before any state touch, and a parked
 // or terminal run is never advanced. A per-pipeline / per-run error is collected
 // (first wins) but never stops the rest; the daemon caller logs it and never aborts
@@ -700,10 +702,80 @@ func runPipelineScanOnce(ctx context.Context, store *db.Store, enqueue pipelineS
 	if err := schedulePipelineRuns(ctx, store, now); err != nil && firstErr == nil {
 		firstErr = err
 	}
+	if err := triggerPipelineRuns(ctx, store, now); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	if err := advancePipelineRuns(ctx, store, enqueue, now); err != nil && firstErr == nil {
 		firstErr = err
 	}
 	return firstErr
+}
+
+// triggerPipelineRuns is the once-per-upstream-success scan pass. It creates at
+// most one run per downstream per tick; the downstream active-run guard leaves
+// the cursor untouched so the same upstream success is retried after settlement.
+func triggerPipelineRuns(ctx context.Context, store *db.Store, now time.Time) error {
+	records, err := store.ListPipelines(ctx)
+	if err != nil {
+		return err
+	}
+	var firstErr error
+	for _, rec := range records {
+		if err := triggerOnePipeline(ctx, store, rec, now.UTC()); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func triggerOnePipeline(ctx context.Context, store *db.Store, rec db.Pipeline, now time.Time) error {
+	if !rec.Enabled {
+		return nil
+	}
+	spec, err := pipeline.Load([]byte(rec.SpecYAML))
+	if err != nil || spec.Trigger == nil || spec.Trigger.Kind != "pipeline" {
+		return nil
+	}
+	if _, found, err := store.GetPipeline(ctx, spec.Trigger.Pipeline); err != nil {
+		return err
+	} else if !found {
+		return nil
+	}
+	state, found, err := store.GetPipelineTriggerState(ctx, rec.Name)
+	if err != nil {
+		return err
+	}
+	if !found || state.Upstream != spec.Trigger.Pipeline {
+		// Defensive compatibility for a row created outside `pipeline add`: establish
+		// the no-backfill boundary, then wait for a newer upstream run.
+		return store.ArmPipelineTrigger(ctx, rec.Name, spec.Trigger.Pipeline, now)
+	}
+	upstreamRun, found, err := store.NextSucceededPipelineTriggerRun(ctx, state)
+	if err != nil || !found {
+		return err
+	}
+	payload, err := json.Marshal(map[string]string{
+		"upstream_pipeline": spec.Trigger.Pipeline,
+		"upstream_run_id":   upstreamRun.ID,
+	})
+	if err != nil {
+		return err
+	}
+	run := db.PipelineRun{
+		ID:          pipelineRunID(rec.Name, now) + "-" + pipeline.Hash([]byte(upstreamRun.ID))[:12],
+		Pipeline:    rec.Name,
+		Trigger:     "pipeline",
+		PayloadJSON: string(payload),
+		SpecHash:    rec.SpecHash,
+		State:       pipeline.RunRunning,
+		StartedAt:   now,
+	}
+	stages := make([]db.PipelineRunStage, 0, len(spec.Stages))
+	for _, stage := range spec.Stages {
+		stages = append(stages, db.PipelineRunStage{RunID: run.ID, StageID: stage.ID, State: pipeline.StagePending})
+	}
+	_, err = store.FirePipelineTrigger(ctx, state, upstreamRun, run, stages)
+	return err
 }
 
 // pipelineRunsInFlight reports whether any pipeline run is still in flight

--- a/internal/cli/pipeline_schedule_test.go
+++ b/internal/cli/pipeline_schedule_test.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +37,193 @@ func newScheduledPipeline(t *testing.T, store *db.Store, name, repo, interval, j
 		t.Fatalf("GetPipeline: ok=%v err=%v", ok, err)
 	}
 	return got
+}
+
+func newPipelineTriggeredPipeline(t *testing.T, store *db.Store, name, upstream string, enabled bool, armedAt time.Time) db.Pipeline {
+	t.Helper()
+	specYAML := fmt.Sprintf("name: %s\nrepo: owner/%s\ntrigger: {kind: pipeline, pipeline: %s}\nstages:\n  - {id: run, cmd: echo ok}\n", name, name, upstream)
+	rec := db.Pipeline{Name: name, Repo: "owner/" + name, SpecYAML: specYAML, SpecHash: pipeline.Hash([]byte(specYAML)), Enabled: enabled}
+	if err := store.CreateOrUpdatePipeline(context.Background(), rec); err != nil {
+		t.Fatalf("CreateOrUpdatePipeline: %v", err)
+	}
+	if err := store.ArmPipelineTrigger(context.Background(), name, upstream, armedAt); err != nil {
+		t.Fatalf("ArmPipelineTrigger: %v", err)
+	}
+	got, ok, err := store.GetPipeline(context.Background(), name)
+	if err != nil || !ok {
+		t.Fatalf("GetPipeline: ok=%v err=%v", ok, err)
+	}
+	return got
+}
+
+func seedPipelineRunState(t *testing.T, store *db.Store, id, name, state string, started time.Time) db.PipelineRun {
+	t.Helper()
+	run := db.PipelineRun{ID: id, Pipeline: name, Trigger: "manual", State: state, StartedAt: started}
+	if err := store.CreatePipelineRun(context.Background(), run); err != nil {
+		t.Fatalf("CreatePipelineRun %s: %v", id, err)
+	}
+	return run
+}
+
+func TestPipelineSuccessTriggerFiresOnce(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	upstreamSpec := "name: upstream\nstages: [{id: run, cmd: echo}]\n"
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "upstream", SpecYAML: upstreamSpec, SpecHash: pipeline.Hash([]byte(upstreamSpec))}); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
+	newPipelineTriggeredPipeline(t, store, "downstream", "upstream", true, base)
+	upstream := seedPipelineRunState(t, store, "prun-up-success", "upstream", pipeline.RunSucceeded, base.Add(time.Minute))
+
+	if err := triggerPipelineRuns(ctx, store, base.Add(2*time.Minute)); err != nil {
+		t.Fatalf("triggerPipelineRuns: %v", err)
+	}
+	runs := pipelineRunCount(t, store, "downstream")
+	if len(runs) != 1 || runs[0].Trigger != "pipeline" {
+		t.Fatalf("downstream runs = %+v, want one pipeline-triggered run", runs)
+	}
+	if !strings.Contains(runs[0].PayloadJSON, upstream.ID) || !strings.Contains(runs[0].PayloadJSON, `"upstream_pipeline":"upstream"`) {
+		t.Fatalf("downstream payload_json = %q", runs[0].PayloadJSON)
+	}
+	if err := triggerPipelineRuns(ctx, store, base.Add(3*time.Minute)); err != nil {
+		t.Fatalf("re-tick: %v", err)
+	}
+	if got := len(pipelineRunCount(t, store, "downstream")); got != 1 {
+		t.Fatalf("re-tick created %d downstream runs, want 1", got)
+	}
+	state, _, _ := store.GetPipelineTriggerState(ctx, "downstream")
+	if state.Cursor != upstream.ID {
+		t.Fatalf("cursor = %q, want %q", state.Cursor, upstream.ID)
+	}
+}
+
+func TestPipelineSuccessTriggerIgnoresFailedCancelledAndDisabled(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	upstreamSpec := "name: upstream\nstages: [{id: run, cmd: echo}]\n"
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "upstream", SpecYAML: upstreamSpec, SpecHash: pipeline.Hash([]byte(upstreamSpec))}); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 7, 14, 11, 0, 0, 0, time.UTC)
+	newPipelineTriggeredPipeline(t, store, "downstream", "upstream", true, base)
+	seedPipelineRunState(t, store, "prun-up-failed", "upstream", pipeline.RunFailed, base.Add(time.Minute))
+	seedPipelineRunState(t, store, "prun-up-cancelled", "upstream", pipeline.RunCancelled, base.Add(2*time.Minute))
+	if err := triggerPipelineRuns(ctx, store, base.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(pipelineRunCount(t, store, "downstream")); got != 0 {
+		t.Fatalf("failed/cancelled upstream created %d runs", got)
+	}
+
+	if err := store.SetPipelineEnabled(ctx, "downstream", false); err != nil {
+		t.Fatal(err)
+	}
+	seedPipelineRunState(t, store, "prun-up-success", "upstream", pipeline.RunSucceeded, base.Add(4*time.Minute))
+	if err := triggerPipelineRuns(ctx, store, base.Add(5*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(pipelineRunCount(t, store, "downstream")); got != 0 {
+		t.Fatalf("disabled downstream created %d runs", got)
+	}
+	state, _, _ := store.GetPipelineTriggerState(ctx, "downstream")
+	if state.Cursor != "" {
+		t.Fatalf("disabled downstream advanced cursor to %q", state.Cursor)
+	}
+}
+
+func TestPipelineSuccessTriggerActiveRunDefersWithoutCursorAdvance(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	upstreamSpec := "name: upstream\nstages: [{id: run, cmd: echo}]\n"
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "upstream", SpecYAML: upstreamSpec, SpecHash: pipeline.Hash([]byte(upstreamSpec))}); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	rec := newPipelineTriggeredPipeline(t, store, "downstream", "upstream", true, base)
+	upstream := seedPipelineRunState(t, store, "prun-up-success", "upstream", pipeline.RunSucceeded, base.Add(time.Minute))
+	spec, err := pipeline.Load([]byte(rec.SpecYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := createPipelineRun(ctx, store, rec, spec, "manual", "{}", base.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := triggerPipelineRuns(ctx, store, base.Add(3*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	state, _, _ := store.GetPipelineTriggerState(ctx, "downstream")
+	if state.Cursor != "" || len(pipelineRunCount(t, store, "downstream")) != 1 {
+		t.Fatalf("active guard state=%+v runs=%+v", state, pipelineRunCount(t, store, "downstream"))
+	}
+	active.State = pipeline.RunSucceeded
+	active.FinishedAt = base.Add(4 * time.Minute)
+	if err := store.UpdatePipelineRun(ctx, active); err != nil {
+		t.Fatal(err)
+	}
+	if err := triggerPipelineRuns(ctx, store, base.Add(5*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	state, _, _ = store.GetPipelineTriggerState(ctx, "downstream")
+	if state.Cursor != upstream.ID || len(pipelineRunCount(t, store, "downstream")) != 2 {
+		t.Fatalf("deferred fire state=%+v runs=%+v", state, pipelineRunCount(t, store, "downstream"))
+	}
+}
+
+func TestPipelineSuccessTriggerArmsAtAddAndReenable(t *testing.T) {
+	home := t.TempDir()
+	upstreamFile := writeSpec(t, "name: upstream\nstages: [{id: run, cmd: echo}]\n")
+	if code := Run([]string{"pipeline", "add", upstreamFile, "--home", home}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
+		t.Fatalf("add upstream exit=%d", code)
+	}
+	base := time.Now().UTC().Add(-time.Hour)
+	if err := withStore(home, func(store *db.Store) error {
+		seedPipelineRunState(t, store, "prun-before-add", "upstream", pipeline.RunSucceeded, base)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	downstreamFile := writeSpec(t, "name: downstream\nrepo: owner/downstream\ntrigger: {kind: pipeline, pipeline: upstream}\nstages: [{id: run, cmd: echo}]\n")
+	var stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "add", downstreamFile, "--enable", "--home", home}, &bytes.Buffer{}, &stderr); code != 0 {
+		t.Fatalf("add downstream exit=%d stderr=%s", code, stderr.String())
+	}
+	if err := withStore(home, func(store *db.Store) error {
+		if err := triggerPipelineRuns(context.Background(), store, time.Now().UTC()); err != nil {
+			return err
+		}
+		if runs, err := store.ListPipelineRuns(context.Background(), "downstream"); err != nil || len(runs) != 0 {
+			return fmt.Errorf("add-time arm runs=%v err=%v", runs, err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"pipeline", "disable", "downstream", "--home", home}, &bytes.Buffer{}, &stderr); code != 0 {
+		t.Fatalf("disable exit=%d stderr=%s", code, stderr.String())
+	}
+	if err := withStore(home, func(store *db.Store) error {
+		seedPipelineRunState(t, store, "prun-while-disabled", "upstream", pipeline.RunSucceeded, time.Now().UTC())
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if code := Run([]string{"pipeline", "enable", "downstream", "--home", home}, &bytes.Buffer{}, &stderr); code != 0 {
+		t.Fatalf("enable exit=%d stderr=%s", code, stderr.String())
+	}
+	if err := withStore(home, func(store *db.Store) error {
+		if err := triggerPipelineRuns(context.Background(), store, time.Now().UTC().Add(time.Minute)); err != nil {
+			return err
+		}
+		runs, err := store.ListPipelineRuns(context.Background(), "downstream")
+		if err != nil || len(runs) != 0 {
+			return fmt.Errorf("re-enable arm runs=%v err=%v", runs, err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func pipelineRunCount(t *testing.T, store *db.Store, name string) []db.PipelineRun {

--- a/internal/cli/pipeline_test.go
+++ b/internal/cli/pipeline_test.go
@@ -143,6 +143,7 @@ func TestPipelineAddListShowEnableDisableRemove(t *testing.T) {
 
 func TestPipelineDisplayMode(t *testing.T) {
 	triggerSpec := "name: mail\nrepo: owner/repo\ntrigger: {kind: email}\nstages:\n  - {id: run, cmd: echo}\n"
+	pipelineTriggerSpec := "name: downstream\nrepo: owner/downstream\ntrigger: {kind: pipeline, pipeline: upstream}\nstages:\n  - {id: run, cmd: echo}\n"
 	scheduledSpec := "name: nightly\nschedule: {interval: 24h}\nstages:\n  - {id: run, cmd: echo}\n"
 	manualSpec := "name: manual\nstages:\n  - {id: run, cmd: echo}\n"
 	tests := []struct {
@@ -154,6 +155,7 @@ func TestPipelineDisplayMode(t *testing.T) {
 		{name: "trigger pending", record: db.Pipeline{SpecYAML: triggerSpec, TriggerBinding: `{"state":"pending"}`}, want: "email-triggered (pending)"},
 		{name: "trigger never bound", record: db.Pipeline{SpecYAML: triggerSpec}, want: "email-triggered (unbound)"},
 		{name: "trigger plus schedule hybrid", record: db.Pipeline{SpecYAML: "name: both\nrepo: owner/repo\ntrigger: {kind: email}\nschedule: {interval: 6h}\nstages:\n  - {id: run, cmd: echo}\n", TriggerBinding: `{"state":"bound"}`, Interval: "6h"}, want: "email-triggered (bound), scheduled 6h"},
+		{name: "pipeline trigger", record: db.Pipeline{SpecYAML: pipelineTriggerSpec}, want: "after: upstream"},
 		{name: "schedule", record: db.Pipeline{SpecYAML: scheduledSpec, Interval: "24h"}, want: "scheduled 24h"},
 		{name: "neither", record: db.Pipeline{SpecYAML: manualSpec}, want: "manual"},
 	}
@@ -163,6 +165,9 @@ func TestPipelineDisplayMode(t *testing.T) {
 				t.Fatalf("pipelineDisplayMode() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+	if got := pipelineDisplayMode(db.Pipeline{SpecYAML: pipelineTriggerSpec}, true); got != "after: upstream (upstream missing)" {
+		t.Fatalf("missing-upstream pipelineDisplayMode() = %q", got)
 	}
 }
 
@@ -372,6 +377,45 @@ func TestPipelineValidationExitCodes(t *testing.T) {
 	}
 }
 
+func TestPipelineAddTriggerCycleDetection(t *testing.T) {
+	triggerSpec := func(name, upstream string) string {
+		return fmt.Sprintf("name: %s\nrepo: owner/%s\ntrigger: {kind: pipeline, pipeline: %s}\nstages: [{id: run, cmd: echo}]\n", name, name, upstream)
+	}
+	t.Run("cycle rejected and dropping edge unblocks", func(t *testing.T) {
+		home := t.TempDir()
+		a := writeSpec(t, triggerSpec("A", "B"))
+		if code := Run([]string{"pipeline", "add", a, "--home", home}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
+			t.Fatalf("add A->B exit=%d", code)
+		}
+		b := writeSpec(t, triggerSpec("B", "A"))
+		var stderr bytes.Buffer
+		if code := Run([]string{"pipeline", "add", b, "--home", home}, &bytes.Buffer{}, &stderr); code == 0 {
+			t.Fatalf("add B->A unexpectedly succeeded")
+		}
+		if !strings.Contains(stderr.String(), "B -> A -> B") {
+			t.Fatalf("cycle error does not name chain: %s", stderr.String())
+		}
+		manualA := writeSpec(t, "name: A\nrepo: owner/A\nstages: [{id: run, cmd: echo}]\n")
+		if code := Run([]string{"pipeline", "add", manualA, "--home", home}, &bytes.Buffer{}, &stderr); code != 0 {
+			t.Fatalf("re-add A without edge exit=%d stderr=%s", code, stderr.String())
+		}
+		if code := Run([]string{"pipeline", "add", b, "--home", home}, &bytes.Buffer{}, &stderr); code != 0 {
+			t.Fatalf("B->A remained blocked after A dropped edge: exit=%d stderr=%s", code, stderr.String())
+		}
+	})
+
+	t.Run("chain accepted", func(t *testing.T) {
+		home := t.TempDir()
+		for _, edge := range [][2]string{{"A", "B"}, {"B", "C"}} {
+			spec := writeSpec(t, triggerSpec(edge[0], edge[1]))
+			var stderr bytes.Buffer
+			if code := Run([]string{"pipeline", "add", spec, "--home", home}, &bytes.Buffer{}, &stderr); code != 0 {
+				t.Fatalf("add %s->%s exit=%d stderr=%s", edge[0], edge[1], code, stderr.String())
+			}
+		}
+	})
+}
+
 // TestPipelineRunnerNameCollisionRefused proves `pipeline add` refuses to clobber
 // a pre-existing non-shell agent occupying the runner name.
 func TestPipelineRunnerNameCollisionRefused(t *testing.T) {
@@ -409,6 +453,13 @@ func TestPipelineListIntervalHybridKeepsInterval(t *testing.T) {
 	triggerOnly := db.Pipeline{SpecYAML: "name: mail\nrepo: owner/repo\ntrigger: {kind: email}\nstages:\n  - {id: run, cmd: echo}\n"}
 	if got := pipelineListInterval(triggerOnly); got != "email" {
 		t.Fatalf("trigger-only list interval = %q, want %q", got, "email")
+	}
+	pipelineTrigger := db.Pipeline{SpecYAML: "name: downstream\nrepo: owner/downstream\ntrigger: {kind: pipeline, pipeline: upstream}\nstages:\n  - {id: run, cmd: echo}\n"}
+	if got := pipelineListInterval(pipelineTrigger); got != "after: upstream" {
+		t.Fatalf("pipeline-trigger list interval = %q", got)
+	}
+	if got := pipelineListInterval(pipelineTrigger, true); got != "after: upstream (upstream missing)" {
+		t.Fatalf("missing-upstream list interval = %q", got)
 	}
 }
 

--- a/internal/cli/pipeline_trigger.go
+++ b/internal/cli/pipeline_trigger.go
@@ -156,6 +156,9 @@ func bindPipelineTrigger(ctx context.Context, store *db.Store, rec db.Pipeline, 
 	if spec.Trigger == nil {
 		return pipelineTriggerBinding{}, fmt.Errorf("pipeline %s has no trigger block", rec.Name)
 	}
+	if spec.Trigger.Kind != "email" {
+		return pipelineTriggerBinding{}, fmt.Errorf("pipeline %s uses a %s trigger; Activepieces binding is only for kind: email", rec.Name, spec.Trigger.Kind)
+	}
 	binding, err := decodeTriggerBinding(rec.TriggerBinding)
 	if err != nil {
 		return pipelineTriggerBinding{}, err
@@ -322,6 +325,9 @@ func triggerFlowOwned(flow activepieces.Flow, displayName, bindingID string) boo
 }
 
 func disablePipelineTrigger(ctx context.Context, store *db.Store, rec db.Pipeline, auth activepiecesAuthOptions) error {
+	if spec, err := pipeline.Load([]byte(rec.SpecYAML)); err == nil && spec.Trigger != nil && spec.Trigger.Kind != "email" {
+		return nil
+	}
 	binding, err := decodeTriggerBinding(rec.TriggerBinding)
 	if err != nil || binding.FlowID == "" {
 		return err
@@ -357,6 +363,9 @@ func disablePipelineTrigger(ctx context.Context, store *db.Store, rec db.Pipelin
 }
 
 func deletePipelineTrigger(ctx context.Context, rec db.Pipeline, auth activepiecesAuthOptions) error {
+	if spec, err := pipeline.Load([]byte(rec.SpecYAML)); err == nil && spec.Trigger != nil && spec.Trigger.Kind != "email" {
+		return nil
+	}
 	binding, err := decodeTriggerBinding(rec.TriggerBinding)
 	if err != nil || binding.FlowID == "" {
 		return err
@@ -383,6 +392,9 @@ func deletePipelineTrigger(ctx context.Context, rec db.Pipeline, auth activepiec
 }
 
 func cleanupPipelineTrigger(ctx context.Context, store *db.Store, rec db.Pipeline, auth activepiecesAuthOptions) error {
+	if spec, err := pipeline.Load([]byte(rec.SpecYAML)); err == nil && spec.Trigger != nil && spec.Trigger.Kind != "email" {
+		return nil
+	}
 	if err := deletePipelineTrigger(ctx, rec, auth); err != nil {
 		return err
 	}
@@ -415,6 +427,7 @@ func runPipelineBindTrigger(args []string, stdout, stderr io.Writer) int {
 	name := strings.TrimSpace(fs.Arg(0))
 	var binding pipelineTriggerBinding
 	cleaned := false
+	noBindingNeeded := false
 	if err := withStore(*home, func(store *db.Store) error {
 		rec, ok, err := store.GetPipeline(context.Background(), name)
 		if err != nil {
@@ -438,6 +451,10 @@ func runPipelineBindTrigger(args []string, stdout, stderr io.Writer) int {
 			cleaned = true
 			return nil
 		}
+		if spec.Trigger.Kind == "pipeline" {
+			noBindingNeeded = true
+			return nil
+		}
 		binding, err = bindPipelineTrigger(context.Background(), store, rec, auth, triggerBindingError)
 		return err
 	}); err != nil {
@@ -446,6 +463,10 @@ func runPipelineBindTrigger(args []string, stdout, stderr io.Writer) int {
 	}
 	if cleaned {
 		writeLine(stdout, "cleaned up stale trigger flow for pipeline %s", name)
+		return 0
+	}
+	if noBindingNeeded {
+		writeLine(stdout, "pipeline %s uses a pipeline trigger; no Activepieces binding is needed", name)
 		return 0
 	}
 	writeLine(stdout, "bound trigger for pipeline %s (flow %s, state=%s)", name, binding.FlowID, binding.State)

--- a/internal/cli/pipeline_trigger_test.go
+++ b/internal/cli/pipeline_trigger_test.go
@@ -53,14 +53,18 @@ func writeTriggerTestAdminCredentials(t *testing.T, home, password string) {
 }
 
 func triggerRecord(t *testing.T, home string) db.Pipeline {
+	return triggerRecordNamed(t, home, "mail-flow")
+}
+
+func triggerRecordNamed(t *testing.T, home, name string) db.Pipeline {
 	t.Helper()
 	var rec db.Pipeline
 	if err := withStore(home, func(store *db.Store) error {
 		var ok bool
 		var err error
-		rec, ok, err = store.GetPipeline(context.Background(), "mail-flow")
+		rec, ok, err = store.GetPipeline(context.Background(), name)
 		if err == nil && !ok {
-			t.Fatal("mail-flow not found")
+			t.Fatalf("%s not found", name)
 		}
 		return err
 	}); err != nil {
@@ -590,5 +594,50 @@ func TestPipelineAddAutoBindUsesStackFrontendURL(t *testing.T) {
 	binding, err := decodeTriggerBinding(triggerRecord(t, home).TriggerBinding)
 	if err != nil || binding.State != triggerBindingBound || binding.FlowID != "auto-flow" || binding.BaseURL != server.URL {
 		t.Fatalf("binding=%+v err=%v stderr=%s", binding, err, stderr.String())
+	}
+}
+
+func TestPipelineTriggerKindNeverTouchesActivepieces(t *testing.T) {
+	hits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.Error(w, "pipeline triggers must not call Activepieces", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	home := t.TempDir()
+	writeTriggerTestAdminCredentials(t, home, "admin")
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(paths.Home, "activepieces", ".env"), []byte("AP_FRONTEND_URL="+server.URL+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	specFile := writeSpec(t, "name: downstream\nrepo: owner/downstream\ntrigger: {kind: pipeline, pipeline: upstream}\nstages: [{id: run, cmd: echo}]\n")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--enable", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("add exit=%d stderr=%s", code, stderr.String())
+	}
+	if hits != 0 || strings.Contains(stderr.String(), "Activepieces") || strings.Contains(stderr.String(), "trigger is pending") {
+		t.Fatalf("add touched Activepieces: hits=%d stderr=%s", hits, stderr.String())
+	}
+	if binding := triggerRecordNamed(t, home, "downstream").TriggerBinding; binding != "" {
+		t.Fatalf("pipeline trigger wrote binding %q", binding)
+	}
+	if code := Run([]string{"pipeline", "disable", "downstream", "--home", home, "--url", server.URL, "--password", "admin"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("disable exit=%d stderr=%s", code, stderr.String())
+	}
+	if code := Run([]string{"pipeline", "enable", "downstream", "--home", home, "--url", server.URL, "--password", "admin"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("enable exit=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	if code := Run([]string{"pipeline", "bind-trigger", "downstream", "--home", home, "--url", server.URL, "--password", "admin"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("bind-trigger exit=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no Activepieces binding is needed") {
+		t.Fatalf("bind-trigger message = %q", stdout.String())
+	}
+	if hits != 0 || triggerRecordNamed(t, home, "downstream").TriggerBinding != "" {
+		t.Fatalf("pipeline trigger path touched Activepieces: hits=%d binding=%q", hits, triggerRecordNamed(t, home, "downstream").TriggerBinding)
 	}
 }

--- a/internal/db/pipeline_run.go
+++ b/internal/db/pipeline_run.go
@@ -47,10 +47,18 @@ type PipelineRunStage struct {
 	FinishedAt time.Time
 }
 
+type pipelineRunExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
 // CreatePipelineRun inserts a new run row. The caller supplies the id (a
 // deterministic manual/schedule run id); a duplicate id is an error so a
 // double-create is caught rather than silently overwriting an in-flight run.
 func (s *Store) CreatePipelineRun(ctx context.Context, run PipelineRun) error {
+	return insertPipelineRun(ctx, s.db, run)
+}
+
+func insertPipelineRun(ctx context.Context, execer pipelineRunExecer, run PipelineRun) error {
 	run.ID = strings.TrimSpace(run.ID)
 	run.Pipeline = strings.TrimSpace(run.Pipeline)
 	if run.ID == "" {
@@ -68,7 +76,7 @@ func (s *Store) CreatePipelineRun(ctx context.Context, run PipelineRun) error {
 	if strings.TrimSpace(run.PayloadJSON) == "" {
 		run.PayloadJSON = "{}"
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO pipeline_runs(id, pipeline, trigger, payload_json, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at)
+	_, err := execer.ExecContext(ctx, `INSERT INTO pipeline_runs(id, pipeline, trigger, payload_json, spec_hash, state, halt_stage, halt_reason, needs_json, started_at, finished_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.ID, run.Pipeline, strings.TrimSpace(run.Trigger), run.PayloadJSON, strings.TrimSpace(run.SpecHash),
 		strings.TrimSpace(run.State), strings.TrimSpace(run.HaltStage), run.HaltReason, run.NeedsJSON,
@@ -193,6 +201,10 @@ func (s *Store) UpdatePipelineRun(ctx context.Context, run PipelineRun) error {
 // pair is the primary key, so a duplicate is an error (the run-creation path
 // inserts each stage exactly once).
 func (s *Store) CreatePipelineRunStage(ctx context.Context, stage PipelineRunStage) error {
+	return insertPipelineRunStage(ctx, s.db, stage)
+}
+
+func insertPipelineRunStage(ctx context.Context, execer pipelineRunExecer, stage PipelineRunStage) error {
 	stage.RunID = strings.TrimSpace(stage.RunID)
 	stage.StageID = strings.TrimSpace(stage.StageID)
 	if stage.RunID == "" || stage.StageID == "" {
@@ -201,7 +213,7 @@ func (s *Store) CreatePipelineRunStage(ctx context.Context, stage PipelineRunSta
 	if strings.TrimSpace(stage.State) == "" {
 		stage.State = "pending"
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO pipeline_run_stages(run_id, stage_id, state, job_id, attempt, needs_json, summary, started_at, finished_at)
+	_, err := execer.ExecContext(ctx, `INSERT INTO pipeline_run_stages(run_id, stage_id, state, job_id, attempt, needs_json, summary, started_at, finished_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		stage.RunID, stage.StageID, strings.TrimSpace(stage.State), strings.TrimSpace(stage.JobID), stage.Attempt,
 		stage.NeedsJSON, stage.Summary, formatHeartbeatTime(stage.StartedAt), formatHeartbeatTime(stage.FinishedAt))
@@ -287,17 +299,21 @@ func (s *Store) UpdatePipelineRunStage(ctx context.Context, stage PipelineRunSta
 // run to a terminal state. A missing pipeline row is NOT an error: a run outlives a
 // removed pipeline, and the bookkeeping is best-effort observability.
 func (s *Store) UpdatePipelineLastRun(ctx context.Context, name, runID, status string, at time.Time) error {
+	return updatePipelineLastRun(ctx, s.db, name, runID, status, at)
+}
+
+func updatePipelineLastRun(ctx context.Context, execer pipelineRunExecer, name, runID, status string, at time.Time) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return errors.New("pipeline name is required")
 	}
 	if at.IsZero() {
-		_, err := s.db.ExecContext(ctx,
+		_, err := execer.ExecContext(ctx,
 			`UPDATE pipelines SET last_run_id = ?, last_status = ?, updated_at = CURRENT_TIMESTAMP WHERE name = ?`,
 			strings.TrimSpace(runID), strings.TrimSpace(status), name)
 		return err
 	}
-	_, err := s.db.ExecContext(ctx,
+	_, err := execer.ExecContext(ctx,
 		`UPDATE pipelines SET last_run_at = ?, last_run_id = ?, last_status = ?, updated_at = CURRENT_TIMESTAMP WHERE name = ?`,
 		formatHeartbeatTime(at), strings.TrimSpace(runID), strings.TrimSpace(status), name)
 	return err

--- a/internal/db/pipeline_trigger.go
+++ b/internal/db/pipeline_trigger.go
@@ -1,0 +1,262 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PipelineTriggerState is the durable once-per-upstream-run cursor for one
+// downstream pipeline. Cursor is an upstream pipeline run id; ArmedAt is the
+// no-backfill boundary used while Cursor is empty.
+type PipelineTriggerState struct {
+	Downstream string
+	Upstream   string
+	Cursor     string
+	ArmedAt    time.Time
+}
+
+// ArmPipelineTrigger resets a downstream trigger at add/enable time. The cursor
+// advances to the latest upstream run of any state so historical successes (and
+// runs from a disabled period) can never backfill after arming.
+func (s *Store) ArmPipelineTrigger(ctx context.Context, downstream, upstream string, armedAt time.Time) error {
+	downstream = strings.TrimSpace(downstream)
+	upstream = strings.TrimSpace(upstream)
+	if downstream == "" || upstream == "" {
+		return errors.New("pipeline trigger downstream and upstream names are required")
+	}
+	if armedAt.IsZero() {
+		armedAt = time.Now().UTC()
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	cursor := ""
+	rows, err := tx.QueryContext(ctx, `SELECT id, started_at FROM pipeline_runs WHERE pipeline = ?`, upstream)
+	if err != nil {
+		return err
+	}
+	var latestAt time.Time
+	for rows.Next() {
+		var id, rawStarted string
+		if err := rows.Scan(&id, &rawStarted); err != nil {
+			rows.Close()
+			return err
+		}
+		started := parseHeartbeatTime(rawStarted)
+		if cursor == "" || started.After(latestAt) || (started.Equal(latestAt) && id > cursor) {
+			cursor = id
+			latestAt = started
+		}
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO pipeline_trigger_states(downstream_pipeline, upstream_pipeline, cursor, armed_at)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(downstream_pipeline) DO UPDATE SET
+			upstream_pipeline = excluded.upstream_pipeline,
+			cursor = excluded.cursor,
+			armed_at = excluded.armed_at`,
+		downstream, upstream, cursor, formatHeartbeatTime(armedAt.UTC())); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// GetPipelineTriggerState returns one downstream trigger state. A missing row is
+// not an error.
+func (s *Store) GetPipelineTriggerState(ctx context.Context, downstream string) (PipelineTriggerState, bool, error) {
+	downstream = strings.TrimSpace(downstream)
+	if downstream == "" {
+		return PipelineTriggerState{}, false, errors.New("pipeline trigger downstream name is required")
+	}
+	var state PipelineTriggerState
+	var armedAt string
+	err := s.db.QueryRowContext(ctx, `SELECT downstream_pipeline, upstream_pipeline, cursor, armed_at
+		FROM pipeline_trigger_states WHERE downstream_pipeline = ?`, downstream).
+		Scan(&state.Downstream, &state.Upstream, &state.Cursor, &armedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PipelineTriggerState{}, false, nil
+	}
+	if err != nil {
+		return PipelineTriggerState{}, false, err
+	}
+	state.ArmedAt = parseHeartbeatTime(armedAt)
+	return state, true, nil
+}
+
+// DeletePipelineTriggerState removes the cursor owned by a downstream pipeline.
+// It never removes rows merely because their upstream was removed: that is what
+// keeps downstream pipelines dormant and ready if the upstream is re-added.
+func (s *Store) DeletePipelineTriggerState(ctx context.Context, downstream string) error {
+	downstream = strings.TrimSpace(downstream)
+	if downstream == "" {
+		return errors.New("pipeline trigger downstream name is required")
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM pipeline_trigger_states WHERE downstream_pipeline = ?`, downstream)
+	return err
+}
+
+// NextSucceededPipelineTriggerRun returns the oldest successful upstream run
+// newer than the state cursor (or ArmedAt when no cursor exists). Choosing the
+// oldest lets a downstream drain multiple successes one-by-one without skipping
+// any once it becomes idle.
+func (s *Store) NextSucceededPipelineTriggerRun(ctx context.Context, state PipelineTriggerState) (PipelineRun, bool, error) {
+	state.Downstream = strings.TrimSpace(state.Downstream)
+	state.Upstream = strings.TrimSpace(state.Upstream)
+	state.Cursor = strings.TrimSpace(state.Cursor)
+	if state.Downstream == "" || state.Upstream == "" {
+		return PipelineRun{}, false, errors.New("pipeline trigger downstream and upstream names are required")
+	}
+	boundary := state.ArmedAt.UTC()
+	if state.Cursor != "" {
+		cursorRun, ok, err := s.GetPipelineRun(ctx, state.Cursor)
+		if err != nil {
+			return PipelineRun{}, false, err
+		}
+		if !ok || cursorRun.Pipeline != state.Upstream {
+			return PipelineRun{}, false, fmt.Errorf("pipeline trigger cursor %q for %s does not identify an upstream run", state.Cursor, state.Downstream)
+		}
+		boundary = cursorRun.StartedAt.UTC()
+	}
+	runs, err := s.ListPipelineRuns(ctx, state.Upstream)
+	if err != nil {
+		return PipelineRun{}, false, err
+	}
+	var candidate PipelineRun
+	for _, run := range runs {
+		if run.State != "succeeded" {
+			continue
+		}
+		newer := run.StartedAt.After(boundary)
+		if state.Cursor != "" && run.StartedAt.Equal(boundary) && run.ID > state.Cursor {
+			newer = true
+		}
+		if !newer {
+			continue
+		}
+		if candidate.ID == "" || run.StartedAt.Before(candidate.StartedAt) || (run.StartedAt.Equal(candidate.StartedAt) && run.ID < candidate.ID) {
+			candidate = run
+		}
+	}
+	return candidate, candidate.ID != "", nil
+}
+
+// FirePipelineTrigger atomically creates the downstream run and all of its stage
+// rows, updates last-run bookkeeping, and advances the trigger cursor. If the
+// downstream is disabled, already active, or the cursor changed since selection,
+// it returns fired=false without advancing the cursor.
+func (s *Store) FirePipelineTrigger(ctx context.Context, expected PipelineTriggerState, upstreamRun, downstreamRun PipelineRun, stages []PipelineRunStage) (bool, error) {
+	expected.Downstream = strings.TrimSpace(expected.Downstream)
+	expected.Upstream = strings.TrimSpace(expected.Upstream)
+	expected.Cursor = strings.TrimSpace(expected.Cursor)
+	if expected.Downstream == "" || expected.Upstream == "" {
+		return false, errors.New("pipeline trigger downstream and upstream names are required")
+	}
+	if upstreamRun.ID == "" || upstreamRun.Pipeline != expected.Upstream || upstreamRun.State != "succeeded" {
+		return false, errors.New("pipeline trigger fire requires a succeeded upstream run")
+	}
+	if downstreamRun.Pipeline != expected.Downstream {
+		return false, errors.New("pipeline trigger downstream run does not match trigger state")
+	}
+	if strings.TrimSpace(downstreamRun.State) == "" {
+		downstreamRun.State = "running"
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	var currentUpstream, currentCursor, rawArmedAt string
+	err = tx.QueryRowContext(ctx, `SELECT upstream_pipeline, cursor, armed_at FROM pipeline_trigger_states WHERE downstream_pipeline = ?`, expected.Downstream).
+		Scan(&currentUpstream, &currentCursor, &rawArmedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("pipeline trigger state for %s not found", expected.Downstream)
+	}
+	if err != nil {
+		return false, err
+	}
+	if currentUpstream != expected.Upstream || currentCursor != expected.Cursor {
+		return false, nil
+	}
+	var enabled int
+	if err := tx.QueryRowContext(ctx, `SELECT enabled FROM pipelines WHERE name = ?`, expected.Downstream).Scan(&enabled); err != nil {
+		return false, err
+	}
+	if enabled == 0 {
+		return false, nil
+	}
+	var active int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM pipeline_runs WHERE pipeline = ? AND state = 'running'`, expected.Downstream).Scan(&active); err != nil {
+		return false, err
+	}
+	if active > 0 {
+		return false, nil
+	}
+	var actualPipeline, actualState, rawStartedAt string
+	if err := tx.QueryRowContext(ctx, `SELECT pipeline, state, started_at FROM pipeline_runs WHERE id = ?`, upstreamRun.ID).Scan(&actualPipeline, &actualState, &rawStartedAt); err != nil {
+		return false, err
+	}
+	if actualPipeline != expected.Upstream || actualState != "succeeded" {
+		return false, errors.New("upstream pipeline run is no longer succeeded")
+	}
+	boundary := parseHeartbeatTime(rawArmedAt)
+	if currentCursor != "" {
+		var cursorPipeline, rawCursorStartedAt string
+		if err := tx.QueryRowContext(ctx, `SELECT pipeline, started_at FROM pipeline_runs WHERE id = ?`, currentCursor).Scan(&cursorPipeline, &rawCursorStartedAt); err != nil {
+			return false, err
+		}
+		if cursorPipeline != expected.Upstream {
+			return false, errors.New("pipeline trigger cursor does not belong to upstream pipeline")
+		}
+		boundary = parseHeartbeatTime(rawCursorStartedAt)
+	}
+	startedAt := parseHeartbeatTime(rawStartedAt)
+	if !startedAt.After(boundary) && !(currentCursor != "" && startedAt.Equal(boundary) && upstreamRun.ID > currentCursor) {
+		return false, errors.New("upstream pipeline run is not newer than trigger cursor")
+	}
+	if err := insertPipelineRun(ctx, tx, downstreamRun); err != nil {
+		return false, err
+	}
+	for _, stage := range stages {
+		if strings.TrimSpace(stage.RunID) == "" {
+			stage.RunID = downstreamRun.ID
+		}
+		if stage.RunID != downstreamRun.ID {
+			return false, errors.New("pipeline trigger stage run id does not match downstream run")
+		}
+		if err := insertPipelineRunStage(ctx, tx, stage); err != nil {
+			return false, err
+		}
+	}
+	if err := updatePipelineLastRun(ctx, tx, expected.Downstream, downstreamRun.ID, downstreamRun.State, downstreamRun.StartedAt.UTC()); err != nil {
+		return false, err
+	}
+	result, err := tx.ExecContext(ctx, `UPDATE pipeline_trigger_states SET cursor = ?
+		WHERE downstream_pipeline = ? AND upstream_pipeline = ? AND cursor = ?`,
+		upstreamRun.ID, expected.Downstream, expected.Upstream, expected.Cursor)
+	if err != nil {
+		return false, err
+	}
+	if affected, err := result.RowsAffected(); err != nil {
+		return false, err
+	} else if affected != 1 {
+		return false, errors.New("pipeline trigger cursor changed during fire")
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/db/pipeline_trigger_test.go
+++ b/internal/db/pipeline_trigger_test.go
@@ -1,0 +1,120 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPipelineTriggerStateMigrationAndRoundTrip(t *testing.T) {
+	found := false
+	for _, migration := range migrations {
+		if strings.Contains(migration, "CREATE TABLE pipeline_trigger_states") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("pipeline_trigger_states migration not found")
+	}
+
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	armed := time.Date(2026, 7, 14, 9, 0, 0, 0, time.UTC)
+	if err := store.ArmPipelineTrigger(ctx, "downstream", "upstream", armed); err != nil {
+		t.Fatalf("ArmPipelineTrigger: %v", err)
+	}
+	state, ok, err := store.GetPipelineTriggerState(ctx, "downstream")
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineTriggerState: ok=%v err=%v", ok, err)
+	}
+	if state.Downstream != "downstream" || state.Upstream != "upstream" || state.Cursor != "" || !state.ArmedAt.Equal(armed) {
+		t.Fatalf("state round-trip = %+v", state)
+	}
+	if err := store.DeletePipelineTriggerState(ctx, "downstream"); err != nil {
+		t.Fatalf("DeletePipelineTriggerState: %v", err)
+	}
+	if _, ok, err := store.GetPipelineTriggerState(ctx, "downstream"); err != nil || ok {
+		t.Fatalf("state remained after delete: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestFirePipelineTriggerIsAtomicWithCursor(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	upstreamSpec := "name: upstream\nstages: [{id: run, cmd: echo}]\n"
+	downstreamSpec := "name: downstream\nrepo: owner/downstream\ntrigger: {kind: pipeline, pipeline: upstream}\nstages: [{id: one, cmd: echo}, {id: two, cmd: echo}]\n"
+	for _, rec := range []Pipeline{
+		{Name: "upstream", SpecYAML: upstreamSpec, SpecHash: "up-hash", Enabled: true},
+		{Name: "downstream", Repo: "owner/downstream", SpecYAML: downstreamSpec, SpecHash: "down-hash", Enabled: true},
+	} {
+		if err := store.CreateOrUpdatePipeline(ctx, rec); err != nil {
+			t.Fatalf("CreateOrUpdatePipeline %s: %v", rec.Name, err)
+		}
+	}
+	base := time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC)
+	old := PipelineRun{ID: "prun-up-old", Pipeline: "upstream", State: "succeeded", StartedAt: base}
+	if err := store.CreatePipelineRun(ctx, old); err != nil {
+		t.Fatalf("create old upstream run: %v", err)
+	}
+	if err := store.ArmPipelineTrigger(ctx, "downstream", "upstream", base.Add(time.Minute)); err != nil {
+		t.Fatalf("arm: %v", err)
+	}
+	state, _, _ := store.GetPipelineTriggerState(ctx, "downstream")
+	if state.Cursor != old.ID {
+		t.Fatalf("arm cursor = %q, want %q", state.Cursor, old.ID)
+	}
+	upstream := PipelineRun{ID: "prun-up-new", Pipeline: "upstream", State: "succeeded", StartedAt: base.Add(2 * time.Minute)}
+	if err := store.CreatePipelineRun(ctx, upstream); err != nil {
+		t.Fatalf("create new upstream run: %v", err)
+	}
+	next, ok, err := store.NextSucceededPipelineTriggerRun(ctx, state)
+	if err != nil || !ok || next.ID != upstream.ID {
+		t.Fatalf("NextSucceededPipelineTriggerRun = %+v ok=%v err=%v", next, ok, err)
+	}
+	downstream := PipelineRun{ID: "prun-down-ok", Pipeline: "downstream", Trigger: "pipeline", PayloadJSON: `{"upstream_pipeline":"upstream","upstream_run_id":"prun-up-new"}`, SpecHash: "down-hash", State: "running", StartedAt: base.Add(3 * time.Minute)}
+	fired, err := store.FirePipelineTrigger(ctx, state, upstream, downstream, []PipelineRunStage{{StageID: "one", State: "pending"}, {StageID: "two", State: "pending"}})
+	if err != nil || !fired {
+		t.Fatalf("FirePipelineTrigger: fired=%v err=%v", fired, err)
+	}
+	state, _, _ = store.GetPipelineTriggerState(ctx, "downstream")
+	if state.Cursor != upstream.ID {
+		t.Fatalf("cursor = %q, want %q", state.Cursor, upstream.ID)
+	}
+	created, ok, err := store.GetPipelineRun(ctx, downstream.ID)
+	if err != nil || !ok || created.Trigger != "pipeline" || created.PayloadJSON != downstream.PayloadJSON {
+		t.Fatalf("created downstream run = %+v ok=%v err=%v", created, ok, err)
+	}
+	stages, err := store.ListPipelineRunStages(ctx, downstream.ID)
+	if err != nil || len(stages) != 2 {
+		t.Fatalf("downstream stages = %+v err=%v", stages, err)
+	}
+	rec, _, _ := store.GetPipeline(ctx, "downstream")
+	if rec.LastRunID != downstream.ID || rec.LastStatus != "running" {
+		t.Fatalf("last-run bookkeeping = %+v", rec)
+	}
+
+	// Re-arm past the successful fire, then prove a stage insert failure rolls
+	// back both the run insert and cursor movement (the crash-window invariant).
+	if err := store.UpdatePipelineRun(ctx, PipelineRun{ID: downstream.ID, State: "succeeded", FinishedAt: base.Add(4 * time.Minute)}); err != nil {
+		t.Fatalf("settle downstream: %v", err)
+	}
+	state, _, _ = store.GetPipelineTriggerState(ctx, "downstream")
+	upstream2 := PipelineRun{ID: "prun-up-next", Pipeline: "upstream", State: "succeeded", StartedAt: base.Add(5 * time.Minute)}
+	if err := store.CreatePipelineRun(ctx, upstream2); err != nil {
+		t.Fatalf("create second upstream run: %v", err)
+	}
+	badRun := PipelineRun{ID: "prun-down-rollback", Pipeline: "downstream", Trigger: "pipeline", State: "running", StartedAt: base.Add(6 * time.Minute)}
+	fired, err = store.FirePipelineTrigger(ctx, state, upstream2, badRun, []PipelineRunStage{{StageID: "duplicate"}, {StageID: "duplicate"}})
+	if err == nil || fired {
+		t.Fatalf("duplicate-stage fire = fired=%v err=%v, want rollback error", fired, err)
+	}
+	if _, ok, err := store.GetPipelineRun(ctx, badRun.ID); err != nil || ok {
+		t.Fatalf("rolled-back run exists: ok=%v err=%v", ok, err)
+	}
+	after, _, _ := store.GetPipelineTriggerState(ctx, "downstream")
+	if after.Cursor != state.Cursor {
+		t.Fatalf("cursor advanced on rolled-back fire: before=%q after=%q", state.Cursor, after.Cursor)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -9081,4 +9081,18 @@ CREATE TABLE IF NOT EXISTS task_events (
 );
 CREATE INDEX IF NOT EXISTS idx_task_events_task_id_id ON task_events(task_id, id);
 	`,
+	// #922 once-per-upstream-run pipeline trigger state. The downstream pipeline
+	// name is the durable identity; upstream is deliberately not foreign-keyed so
+	// removing an upstream leaves its dependants dormant and re-creatable. cursor
+	// stores the last observed/fired upstream run id, while armed_at is the no-
+	// backfill boundary used when no upstream run existed at arm time.
+	`
+CREATE TABLE pipeline_trigger_states (
+	downstream_pipeline TEXT PRIMARY KEY,
+	upstream_pipeline TEXT NOT NULL,
+	cursor TEXT NOT NULL DEFAULT '',
+	armed_at TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX idx_pipeline_trigger_states_upstream ON pipeline_trigger_states(upstream_pipeline);
+		`,
 }

--- a/internal/db/task_events_test.go
+++ b/internal/db/task_events_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -13,8 +14,18 @@ func TestTaskEventsMigrationAppliesToExistingDatabase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := legacy.db.Exec(`DROP TABLE task_events; DELETE FROM schema_migrations WHERE version = ?`, len(migrations)); err != nil {
-		t.Fatalf("rewind newest migration: %v", err)
+	taskEventsVersion := 0
+	for i, migration := range migrations {
+		if strings.Contains(migration, "CREATE TABLE IF NOT EXISTS task_events") {
+			taskEventsVersion = i + 1
+			break
+		}
+	}
+	if taskEventsVersion == 0 {
+		t.Fatal("task_events migration not found")
+	}
+	if _, err := legacy.db.Exec(`DROP TABLE task_events; DELETE FROM schema_migrations WHERE version = ?`, taskEventsVersion); err != nil {
+		t.Fatalf("rewind task_events migration: %v", err)
 	}
 	if err := legacy.Close(); err != nil {
 		t.Fatal(err)

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -86,6 +86,38 @@ func TestLoadEmailTriggerDefaultsAndValidation(t *testing.T) {
 	}
 }
 
+func TestLoadPipelineTriggerValidation(t *testing.T) {
+	loaded, err := Load([]byte("name: downstream\nrepo: owner/downstream\ntrigger:\n  kind: pipeline\n  pipeline: upstream\nstages:\n  - {id: run, cmd: echo}\n"))
+	if err != nil {
+		t.Fatalf("Load pipeline trigger: %v", err)
+	}
+	if loaded.Trigger == nil || loaded.Trigger.Pipeline != "upstream" {
+		t.Fatalf("pipeline trigger = %+v", loaded.Trigger)
+	}
+	if loaded.Trigger.Connection != "" || loaded.Trigger.Mailbox != "" {
+		t.Fatalf("pipeline trigger received email defaults: %+v", loaded.Trigger)
+	}
+
+	cases := []struct {
+		name, spec, want string
+	}{
+		{"missing upstream", "name: downstream\nrepo: owner/repo\ntrigger: {kind: pipeline}\nstages: [{id: run, cmd: echo}]\n", "requires an upstream pipeline name"},
+		{"self reference", "name: downstream\nrepo: owner/repo\ntrigger: {kind: pipeline, pipeline: downstream}\nstages: [{id: run, cmd: echo}]\n", "cannot reference itself"},
+		{"connection field", "name: downstream\nrepo: owner/repo\ntrigger: {kind: pipeline, pipeline: upstream, connection: gmail-imap}\nstages: [{id: run, cmd: echo}]\n", "email-only fields"},
+		{"mailbox field", "name: downstream\nrepo: owner/repo\ntrigger: {kind: pipeline, pipeline: upstream, mailbox: INBOX}\nstages: [{id: run, cmd: echo}]\n", "email-only fields"},
+		{"map field", "name: downstream\nrepo: owner/repo\ntrigger: {kind: pipeline, pipeline: upstream, map: {subject: subject}}\nstages: [{id: run, cmd: echo}]\n", "email-only fields"},
+		{"schedule hybrid", "name: downstream\nrepo: owner/repo\nschedule: {interval: 1h}\ntrigger: {kind: pipeline, pipeline: upstream}\nstages: [{id: run, cmd: echo}]\n", "schedule+pipeline hybrid semantics are not supported"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load([]byte(tc.spec))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Load error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 // TestLoadValidAgentSpec exercises the #757 agent-stage schema: an agent stage
 // with no explicit action defaults to "ask", an explicit review action is kept,
 // and shell + agent stages coexist in one DAG.

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -71,8 +71,9 @@ type Spec struct {
 	// Schedule, when present, drives interval-based auto-runs (heartbeat idiom: an
 	// interval plus optional jitter; no cron in v1).
 	Schedule *Schedule `yaml:"schedule,omitempty"`
-	// Trigger, when present, declares an external event source materialized by
-	// Gitmoot. The MVP supports email through an owned Activepieces flow.
+	// Trigger, when present, declares an event source materialized by Gitmoot.
+	// Email uses an owned Activepieces flow; pipeline waits for a successful run
+	// of another named pipeline.
 	Trigger *Trigger `yaml:"trigger,omitempty"`
 	// AllowScheduledWrites, when true, permits MUTATING (implement) stages on a
 	// SCHEDULED pipeline (one carrying a schedule: block) (#768 safety layer 2).
@@ -108,10 +109,12 @@ type Schedule struct {
 	Jitter string `yaml:"jitter,omitempty"`
 }
 
-// Trigger is an external event source for a pipeline. Map names the bounded run
-// payload keys generated from a closed set of kind-specific event selectors.
+// Trigger is an event source for a pipeline. Email triggers use the
+// Activepieces-specific connection/mailbox/map fields; pipeline triggers name an
+// upstream pipeline whose successful runs start this pipeline.
 type Trigger struct {
 	Kind       string            `yaml:"kind"`
+	Pipeline   string            `yaml:"pipeline,omitempty"`
 	Connection string            `yaml:"connection,omitempty"`
 	Mailbox    string            `yaml:"mailbox,omitempty"`
 	Map        map[string]string `yaml:"map,omitempty"`

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -34,13 +34,16 @@ func (s *Spec) normalize() {
 	}
 	if s.Trigger != nil {
 		s.Trigger.Kind = strings.TrimSpace(s.Trigger.Kind)
+		s.Trigger.Pipeline = strings.TrimSpace(s.Trigger.Pipeline)
 		s.Trigger.Connection = strings.TrimSpace(s.Trigger.Connection)
 		s.Trigger.Mailbox = strings.TrimSpace(s.Trigger.Mailbox)
-		if s.Trigger.Connection == "" {
-			s.Trigger.Connection = "gmail-imap"
-		}
-		if s.Trigger.Mailbox == "" {
-			s.Trigger.Mailbox = "INBOX"
+		if s.Trigger.Kind == "email" {
+			if s.Trigger.Connection == "" {
+				s.Trigger.Connection = "gmail-imap"
+			}
+			if s.Trigger.Mailbox == "" {
+				s.Trigger.Mailbox = "INBOX"
+			}
 		}
 	}
 	s.SuccessDecisions = trimAll(s.SuccessDecisions)
@@ -258,15 +261,36 @@ func (s Spec) validateTrigger() error {
 		return nil
 	}
 	if s.Trigger.Kind == "" {
-		return fmt.Errorf("pipeline %q trigger kind is required; supported kinds: email", s.Name)
+		return fmt.Errorf("pipeline %q trigger kind is required; supported kinds: email, pipeline", s.Name)
 	}
-	if s.Trigger.Kind != "email" {
-		return fmt.Errorf("pipeline %q trigger kind %q is not supported; supported kinds: email", s.Name, s.Trigger.Kind)
+	if s.Trigger.Kind != "email" && s.Trigger.Kind != "pipeline" {
+		return fmt.Errorf("pipeline %q trigger kind %q is not supported; supported kinds: email, pipeline", s.Name, s.Trigger.Kind)
 	}
 	// The bridge rejects runs of repo-less pipelines, so a triggered flow would
 	// fire 400s forever; fail at add time instead of silently at every email.
 	if strings.TrimSpace(s.Repo) == "" {
 		return fmt.Errorf("pipeline %q declares a trigger but no repo; triggered runs need a managed repo (add `repo: owner/name`)", s.Name)
+	}
+	if s.Trigger.Kind == "pipeline" {
+		if s.Trigger.Pipeline == "" {
+			return fmt.Errorf("pipeline %q pipeline trigger requires an upstream pipeline name", s.Name)
+		}
+		if !validToken(s.Trigger.Pipeline) {
+			return fmt.Errorf("pipeline %q upstream pipeline %q must be a name-safe token (letters, digits, '-', '_')", s.Name, s.Trigger.Pipeline)
+		}
+		if s.Trigger.Pipeline == s.Name {
+			return fmt.Errorf("pipeline %q pipeline trigger cannot reference itself", s.Name)
+		}
+		if s.Schedule != nil {
+			return fmt.Errorf("pipeline %q combines schedule and pipeline trigger; schedule+pipeline hybrid semantics are not supported", s.Name)
+		}
+		if s.Trigger.Connection != "" || s.Trigger.Mailbox != "" || s.Trigger.Map != nil {
+			return fmt.Errorf("pipeline %q pipeline trigger sets email-only fields; connection, mailbox, and map are only valid for kind: email", s.Name)
+		}
+		return nil
+	}
+	if s.Trigger.Pipeline != "" {
+		return fmt.Errorf("pipeline %q email trigger sets pipeline %q; pipeline is only valid for kind: pipeline", s.Name, s.Trigger.Pipeline)
 	}
 	if !triggerConnectionPattern.MatchString(s.Trigger.Connection) {
 		return fmt.Errorf("pipeline %q trigger connection %q must match [A-Za-z0-9][A-Za-z0-9_-]*", s.Name, s.Trigger.Connection)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2465,7 +2465,8 @@ carry leaf cluster ids, while parent hubs remain an aggregate view only.
 ## Pipelines
 
 A pipeline (#681) runs a **declared DAG of shell and managed-agent stages** — a
-fixed, repeatable multi-step flow — on demand or on an interval schedule. Each
+fixed, repeatable multi-step flow — on demand, on an interval schedule, or after
+another pipeline succeeds. Each
 stage is an ordinary queued job: shell commands use the shell runtime, while agent
 stages use their registered runtime. The normal worker tick claims and runs it,
 and a scan-based advancer folds each stage's `gitmoot_result` **decision**
@@ -2482,8 +2483,8 @@ repo: owner/repo            # optional to register; REQUIRED to run
 schedule:                   # optional interval schedule (no cron in v1)
   interval: 24h             #   positive Go duration (required with a schedule block)
   jitter: 15m               #   optional random [0, jitter] added to next_due
-trigger:                    # optional generated Activepieces event source
-  kind: email               #   only supported kind
+trigger:                    # optional event source (email or pipeline)
+  kind: email
   connection: gmail-imap    #   default gmail-imap
   mailbox: INBOX            #   default INBOX
   map:                      #   optional output name -> closed email selector
@@ -2513,6 +2514,15 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     retry: 2                # optional; re-attempt a FAILED stage up to N times
 ```
 
+To start this pipeline once for every newly-succeeded run of another pipeline,
+use the alternative pipeline trigger shape (do not combine it with `schedule`):
+
+```yaml
+trigger:
+  kind: pipeline
+  pipeline: upstream-name
+```
+
 ```sh
 gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; omit --enable to add disabled
 gitmoot pipeline install-defaults                 # install built-in memory pipelines, skipping existing names
@@ -2530,7 +2540,8 @@ gitmoot pipeline remove nightly-sync
 ### Reading pipeline status
 
 The registry view is self-describing even before the first run. `mode` is
-`email-triggered (bound|pending|error)`, `scheduled <interval>`, or `manual`, and
+`email-triggered (bound|pending|error)`, `after: <upstream>`,
+`scheduled <interval>`, or `manual`, and
 stage lines carry their kind plus bounded command/prompt previews:
 
 ```text
@@ -2545,8 +2556,9 @@ stages:
 ```
 
 An absent agent row renders as `(unregistered)` without failing `show`.
-`pipeline list` retains six columns and uses `email` in the interval column for a
-trigger pipeline. JSON adds pipeline `mode` and stage `kind`, `agent_runtime`,
+`pipeline list` retains six columns and uses `email` or `after: <upstream>` in
+the interval column for a trigger pipeline. A removed or missing upstream is
+shown as `after: <upstream> (upstream missing)`. JSON adds pipeline `mode` and stage `kind`, `agent_runtime`,
 `prompt_preview`, and `cmd_preview`; the existing full fields remain unchanged.
 
 An enabled `trigger.kind: email` pipeline auto-binds. If Activepieces is down,
@@ -2558,8 +2570,32 @@ Provision the default IMAP connection with
 `gitmoot activepieces connect gmail` (`--with-smtp` is optional and unused by the
 generated receive flow).
 
+An enabled `trigger.kind: pipeline` pipeline fires once for each upstream run
+that reaches `succeeded`; failed and cancelled runs never fire it. The durable
+upstream-run cursor makes daemon re-ticks and restarts idempotent. Adding or
+enabling the downstream re-arms the cursor at the latest upstream run, so old
+history and successes from a disabled period never backfill. If the downstream
+already has an active run, the scan leaves the cursor unchanged and fires after
+that run settles. Missing upstreams warn at add time and remain dormant; removing
+an upstream is allowed. Add-time validation rejects self-reference and trigger
+cycles such as `B -> A -> B`. Pipeline triggers never use Activepieces, and
+`pipeline bind-trigger` reports that no binding is needed.
+
+For example, replace a clock-staggered `memory-ingest-sweep` schedule (such as
+24h30m after a 24h groom) with an ordered success chain:
+
+```yaml
+name: memory-ingest-sweep
+repo: owner/repo
+trigger:
+  kind: pipeline
+  pipeline: memory-groom-propose
+stages: [...]
+```
+
 `pipeline add` validates the whole spec at add time (unknown keys, duplicate/self/
-cyclic `needs`, a stage that is not exactly one of `cmd`/`agent`/`gate`, an agent stage
+cyclic `needs`, self/cyclic pipeline triggers, a schedule+pipeline-trigger hybrid,
+a stage that is not exactly one of `cmd`/`agent`/`gate`, an agent stage
 missing a `prompt` / invalid `action` / `implement` without `write: true` / a mutating
 stage on a scheduled pipeline without `allow_scheduled_writes` / a mutating stage on
 a triggered pipeline without `allow_triggered_writes` / a gate or review's
@@ -2579,7 +2615,8 @@ For a non-empty run payload, every agent stage (including roots) receives a
 dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before
 upstream context; each rendered value is capped at 1500 bytes. Shell stages receive
 exact `GITMOOT_TRIGGER_<UPPERCASE_KEY>` exec environment entries, never shell-source
-interpolation. The full canonical payload is retained in the SQLite run row; job
+interpolation. The full canonical payload is retained in the SQLite run row and
+shown by `pipeline show <run-id>` as `payload_json`; job
 env/prompt projections follow normal job-data retention.
 
 Every pipeline shell stage also receives `GITMOOT_PIPELINE_NAME`,

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1071,6 +1071,32 @@ RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
 gitmoot pipeline show "$RUN"                       # watch the text funnel
 ```
 
+### Chain a pipeline after another succeeds
+
+Use `kind: pipeline` when ordering matters more than a clock stagger. This
+example runs ingest exactly once after each newly-succeeded groom run:
+
+```yaml
+name: memory-ingest-sweep
+repo: owner/repo
+trigger:
+  kind: pipeline
+  pipeline: memory-groom-propose
+stages:
+  - id: sweep
+    cmd: gitmoot memory ingest sweep --json
+```
+
+This replaces the old `24h` / `24h30m` imitation of ordering: failed or cancelled
+groom runs do not start ingest, while each successful run fires it once. The
+cursor is durable across daemon restarts. Adding or enabling ingest arms at the
+latest groom run, so no historical or disabled-period runs backfill. If ingest
+is already active, its cursor does not move and it fires after settlement.
+Pipeline-trigger cycles are rejected at add time. A missing or later-removed
+upstream is allowed but leaves the downstream dormant and visibly marked
+`(upstream missing)`. Pipeline triggers are local database state and never use
+Activepieces; `pipeline bind-trigger` is an informational no-op for them.
+
 A stage prints a `gitmoot_result` blob to stdout to signal its decision; the
 advancer folds by that **decision**, never the job's exit state:
 

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -1,8 +1,8 @@
 # Run A Fixed Multi-Step Flow (Pipelines)
 
 Pipelines let the gitmoot daemon run a **declared DAG of shell and agent stages** — a fixed,
-repeatable multi-step flow with explicit dependencies — on demand or on an interval
-schedule. Each stage is an ordinary queued job (shell commands use the shell runtime;
+repeatable multi-step flow with explicit dependencies — on demand, on an interval,
+or after another pipeline succeeds. Each stage is an ordinary queued job (shell commands use the shell runtime;
 agent stages use their registered runtime): the
 existing worker tick claims and runs it, and a scan-based **advancer** folds each
 stage's `gitmoot_result` decision and enqueues the stages whose dependencies have all
@@ -28,8 +28,8 @@ repo: owner/repo            # optional to register; REQUIRED to run
 schedule:                   # optional; auto-runs every interval once enabled
   interval: 24h             #   positive Go duration (required with a schedule block)
   jitter: 15m               #   optional random [0, jitter] added to each next_due
-trigger:                    # optional; generated Activepieces event source (requires repo:)
-  kind: email               #   only email in this release
+trigger:                    # optional event source (requires repo:)
+  kind: email
   connection: gmail-imap    #   optional; default gmail-imap
   mailbox: INBOX            #   optional; default INBOX
   map:                      #   optional outputs from closed email selectors
@@ -67,11 +67,41 @@ name/id, a duplicate stage id, a stage that is not exactly one of `cmd`, `agent`
 `implement` without `write: true`, a mutating stage on a scheduled pipeline without
 `allow_scheduled_writes`, a mutating stage on a triggered pipeline without
 `allow_triggered_writes`, a gate/review's bad `source`, or `source` on another kind), an unknown/self/cyclic
-`needs`, an invalid duration, a negative retry, or a
+`needs`, a self/cyclic pipeline trigger, a schedule+pipeline-trigger hybrid, an invalid duration, a negative retry, or a
 `success_decisions` value outside `approved`/`implemented`/`changes_requested`/`skipped` - so a
 structural mistake is a clear error at registration, not a stuck run later. It stores the raw YAML **verbatim**
 plus a content hash; each run snapshots the hash and executes its snapshot, so
 editing the file later never mutates an in-flight run.
+
+### Chain pipelines on success
+
+Use a pipeline trigger when an upstream must finish successfully before the next
+flow starts:
+
+```yaml
+name: memory-ingest-sweep
+repo: owner/repo
+trigger:
+  kind: pipeline
+  pipeline: memory-groom-propose
+stages:
+  - id: sweep
+    cmd: gitmoot memory ingest sweep --json
+```
+
+This replaces a `24h` groom plus `24h30m` ingest clock stagger with real ordering.
+Each newly-succeeded groom run fires ingest once; failed and cancelled runs do
+nothing. A durable cursor makes re-ticks and daemon restarts idempotent. Add and
+enable re-arm at the latest upstream run, preventing historical or disabled-period
+backfill. If ingest already has an active run, its cursor stays put and the same
+upstream success fires after ingest settles.
+
+Pipeline-trigger cycles (including self-reference) are rejected at `pipeline
+add`. A missing upstream warns but is allowed: the downstream stays dormant and
+renders as `after: <upstream> (upstream missing)` until the upstream exists again.
+Pipeline triggers do not use Activepieces, and `pipeline bind-trigger` is a
+friendly no-op for them. Schedule-plus-pipeline hybrids are deliberately rejected
+in this MVP.
 
 ## Manage pipelines
 
@@ -92,7 +122,7 @@ gitmoot pipeline remove <name>
 ### Reading pipeline status
 
 `pipeline show <name>` labels how the pipeline starts: `email-triggered` plus its
-binding state, `scheduled <interval>`, or `manual`. Its stage block leads with the
+binding state, `after: <upstream>`, `scheduled <interval>`, or `manual`. Its stage block leads with the
 stage kind and resolves registered agent stages to their runtime/model settings:
 
 ```text
@@ -115,7 +145,9 @@ Shell commands are collapsed to a single-line preview (about 80 characters), and
 agent prompts to an escaped preview (about 100 characters); an ellipsis marks
 truncation. Missing agent registrations render as `(unregistered)` instead of
 making inspection fail. `pipeline list` keeps its existing six-column shape but
-uses `email` in the interval column for trigger pipelines (`email+6h` when a schedule is also present, and the mode reads `email-triggered (unbound)` before the first bind). `--json` remains
+uses `email` or `after: <upstream>` in the interval column for trigger pipelines
+(`email+6h` when an email schedule is also present, and the mode reads
+`email-triggered (unbound)` before the first bind). `--json` remains
 additive: pipeline objects include `mode`, while stage objects include `kind` and
 the available `agent_runtime`, `prompt_preview`, and `cmd_preview` fields without
 removing the full `prompt` or `cmd`.
@@ -163,7 +195,8 @@ fenced block labeled `UNTRUSTED external data`; each rendered value is capped at
 1500 bytes and the whole block at 6000 bytes with explicit truncation markers.
 Every shell stage receives exact `GITMOOT_TRIGGER_<UPPERCASE_KEY>` exec environment
 entries. Values are never interpolated into shell source, so newlines and UTF-8
-remain data. The full canonical payload lives in the SQLite run row; shell env and
+remain data. The full canonical payload lives in the SQLite run row, is printed
+as `payload_json` by `pipeline show <run-id>`, and shell env and
 agent prompt projections also live in normal job data.
 
 ### Shell-stage upstream context
@@ -199,7 +232,7 @@ never evaluate them as shell source, and do not put credentials in summaries.
 
 A triggered pipeline containing an `implement` or `produce` stage must set
 `allow_triggered_writes: true`, in addition to each stage's `write: true`. This is
-independent of `allow_scheduled_writes` when a pipeline has both trigger and schedule.
+independent of `allow_scheduled_writes` when an email pipeline has both trigger and schedule.
 
 `pipeline install-defaults` installs Gitmoot's built-in memory pipelines:
 `memory-ingest-sweep` and `memory-groom-propose`. The daemon also runs that

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -655,6 +655,8 @@ gitmoot agent doctor <name>
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task recover task-001 --owner lead   # finalize a dead implement's dirty worktree
+gitmoot task dismiss task-001 --reason "abandoned experiment"
+gitmoot task events task-001 --json
 gitmoot task list --repo owner/repo
 gitmoot job list
 gitmoot job show <job-id>
@@ -683,9 +685,26 @@ job, rather than silently discard the work, and point at `task recover <id>
 --owner <agent>`. `task recover` commits the full worktree state (`git add -A`,
 including untracked non-ignored files), pushes the branch, and opens or adopts
 the task's PR — the finalize steps the dead implementer never reached. `--repo`
-is optional (it falls back to the task's stored repo). Recovery refuses while a
-live process is still inside the task worktree; wait for it to exit or stop the
-orphaned implementer first.
+is optional (it falls back to the task's stored repo). `--owner` is required for
+this artifact-finalization path, while a dismissed task with no branch can be
+restored to `planned` without it. Recovery refuses while a live process is still
+inside the task worktree; wait for it to exit or stop the orphaned implementer
+first.
+
+`task dismiss` is the explicit terminal action for an abandoned
+`implementing` or `blocked` task. It refuses while a matching job or worktree
+process is live, preserves the branch and worktree, releases the branch lock
+best-effort, and records `task_dismissed_manual`. The daemon can record
+`task_dismissed_auto` for stale candidates using `updated_at` as a conservative
+activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
+set it to `"0"` to disable this poll leg. Candidates with a same-repo open PR,
+a remote branch, a live job, or an uncertain remote check are not dismissed.
+
+Dismissed tasks never return to implementation through ordinary task run,
+allocation, or late workflow advancement. `task recover` is the explicit path:
+preserved branch/worktree artifacts move through `implementing` to `pr_open`,
+while a branchless task returns to `planned` with task-run guidance. Inspect the
+full audit trail with `task events`.
 
 ## Runtime Plugin Setup
 
@@ -3917,9 +3936,10 @@ sessions**, with `--parallel N`.
 
 ## Reconfigure without restarting (SIGHUP)
 
-Changing workers/scheduler/poll no longer needs a daemon restart (#577):
+Changing workers/scheduler/poll/idle cadence no longer needs a daemon restart (#577):
 `kill -HUP <daemon-pid>` re-reads the `[daemon]` config section (`poll`,
-`workers`, `scheduler`, parallelism) live — no teardown, no dropped jobs, no
+`workers`, `scheduler`, parallelism, `idle_grace_ticks`, and
+`idle_max_multiplier`) live — no teardown, no dropped jobs, no
 environment re-inheritance (so the daemon's runtime auth is untouched). Values
 pinned by explicit launch flags win over the re-read config. When a full
 restart is genuinely needed, prefer `gitmoot daemon restart`, which recovers
@@ -3987,6 +4007,8 @@ min_interval = "0s"       # min spacing between call starts; 0 = off (Go duratio
 secondary_backoff = true  # pause all GitHub calls on a secondary/abuse limit (default true)
 backoff_base = "60s"      # exponential fallback base when no Retry-After (default 60s)
 backoff_max = "5m"        # exponential fallback cap (default 5m)
+conditional_requests = true # ETag conditional polling (default true)
+calls_per_hour_warn = 0      # daemon-local sliding-hour warning; 0 = off
 ```
 
 **Safe defaults:** the proactive caps (`max_concurrent`, `min_interval`) default
@@ -3999,6 +4021,25 @@ the abuse detector, which only prolongs the block. Calls are never dropped — t
 queue/delay until the window passes. On a busy host, set `max_concurrent` (e.g.
 `6`) and/or a small `min_interval` (e.g. `250ms`) to also smooth bursts
 proactively. `gitmoot daemon status` shows the configured budget.
+
+The four per-tick repository list reads use an in-memory ETag cache. A `304 Not
+Modified` replays the prior raw JSON and does not consume GitHub's REST quota.
+After three consecutive successful all-304 ticks, a quiet repo moves to 2x base
+cadence and then to 4x; configure the thresholds under `[daemon]`:
+
+```toml
+[daemon]
+idle_grace_ticks = 3
+idle_max_multiplier = 4  # 1 disables idle decay
+```
+
+Any response-body miss, poll error, queued repo job, or in-flight repo job resets
+the streak and promotes the repo immediately. A repo with an open PR remains at
+base cadence because its per-PR comment reads are deliberately non-conditional.
+The decayed `NextPoll` gates GitHub calls only: heartbeat, pipeline, and chat
+maintenance still wake at the resolved base interval. The local call count is
+approximate and covers only this daemon process; foreground commands and
+agent-owned `gh` processes are outside it.
 
 ## Not yet automatic (follow-ups)
 
@@ -6346,8 +6387,9 @@ Tasks is a read-only lifecycle board backed by Gitmoot's task registry. Internal
 states are projected into **implementing**, **PR open**, **blocked**, and
 **merged** columns; planned and unknown states are omitted, review,
 changes-requested, and ready-to-merge tasks remain in PR open, and awaiting-human
-tasks appear as blocked. Merged history is limited server-side to the last seven
-days.
+tasks appear as blocked. Dismissed tasks are excluded by the server-side query,
+and task-event cursor invalidation removes a newly dismissed card immediately.
+Merged history is limited server-side to the last seven days.
 
 Cards carry the task title, repository, assigned branch-lock owner when one is
 known, pull-request number, last-update age, and a blocked reason. The CI dot is
@@ -9336,8 +9378,10 @@ only declared data paths, the disposable workdir, and temp roots are writable.
 ```sh
 gitmoot status --repo owner/repo
 gitmoot events --repo owner/repo
-gitmoot repo add owner/repo --path <path> [--poll 30s]
+gitmoot repo add owner/repo --path <path> [--poll <duration>]
 gitmoot repo list
+gitmoot repo set-interval owner/repo (<duration>|default)
+gitmoot repo set-interval --all (<duration>|default)
 gitmoot repo remove owner/repo
 gitmoot repo doctor owner/repo
 gitmoot daemon start --poll 30s --workers 1
@@ -9354,9 +9398,13 @@ For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task show` are not valid commands.
 
 The `gitmoot repo` commands manage the **watched-repo registry**: one daemon
-per Gitmoot home supervises every **enabled** registered repo (each with its
-own `--poll` interval). `repo doctor owner/repo` checks a single repo's
-checkout/config health.
+per Gitmoot home supervises every **enabled** registered repo. An omitted
+`repo add --poll` stores the `inherit` sentinel, so the repo follows the daemon's
+resolved `--poll` / `[daemon].poll` cadence; an explicit `--poll` stores a
+per-repo override. `repo list` renders the sentinel as `inherit`.
+`repo set-interval owner/repo <duration>` changes an override, `default` restores
+inheritance, and `--all` applies either value to every registered repo.
+`repo doctor owner/repo` checks a single repo's checkout/config health.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`
@@ -9410,7 +9458,7 @@ keys are re-read every tick, so edits apply live.
 
 Reconfigure the running daemon without a restart: `kill -HUP <daemon-pid>`
 re-reads the `[daemon]` config section (`poll`, `workers`, `scheduler`,
-parallelism) live (#577) — no teardown, no dropped jobs, no environment
+parallelism, `idle_grace_ticks`, `idle_max_multiplier`) live (#577) — no teardown, no dropped jobs, no environment
 re-inheritance. Values pinned by explicit launch flags win over the re-read
 config. Prefer SIGHUP over a restart when only tuning throughput.
 
@@ -9446,12 +9494,25 @@ else exponential backoff) instead of retry-storming the abuse detector. Knobs:
 `min_interval` spaces successive call starts (0 = off; accepts a Go duration or a
 bare integer of seconds), `secondary_backoff` toggles the reactive pause (default
 `true`), and `backoff_base`/`backoff_max` bound the exponential fallback
-(defaults `60s`/`5m`). **Safe defaults:** the proactive caps are off (single-call
+(defaults `60s`/`5m`). `conditional_requests` defaults to `true` and adds ETag
+validators to the four per-tick polling reads; a `304 Not Modified` replays the
+cached raw response at zero GitHub quota cost. `calls_per_hour_warn` defaults to
+`0` (off) and logs when this daemon process crosses the configured sliding-hour
+count. The count is approximate and daemon-local: foreground commands and
+agent-owned `gh` processes are outside it. **Safe defaults:** the proactive caps are off (single-call
 latency and steady-state throughput unchanged) and only the invisible reactive
 backoff is on. Set `max_concurrent` (e.g. `6`) and/or a small `min_interval`
 (e.g. `250ms`) to also smooth bursts proactively on a busy host. Calls are never
 dropped — they queue/delay. `gitmoot daemon status` shows the configured budget
-(`github limiter: max_concurrent=… min_interval=… secondary_backoff=…`).
+(`github limiter: max_concurrent=… min_interval=… secondary_backoff=… conditional_requests=… calls_per_hour_warn=…`).
+
+After `idle_grace_ticks` consecutive successful polls in which every conditional
+read is a 304, a repo's GitHub poll cadence decays to 2x and then up to
+`idle_max_multiplier` (default `4`; `1` disables decay). Any response-body miss,
+poll error, queued repo job, or in-flight repo job resets/promotes it immediately.
+Repos with open PRs stay at base cadence because their per-PR comment reads are
+deliberately non-conditional. Idle decay gates only GitHub calls; heartbeat,
+pipeline, and chat maintenance still wake at the resolved base interval.
 
 `gitmoot dashboard` shows local state — daemon health, repos, agents and runtime
 sessions, jobs by state, worktrees, branch locks, SkillOpt train phase/candidate,
@@ -10225,11 +10286,26 @@ Start a task in its dedicated branch worktree and inspect task state:
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task list --repo owner/repo
 gitmoot task list --repo owner/repo --state implementing --json
+gitmoot task dismiss task-001 --reason "abandoned experiment"
+gitmoot task events task-001 --json
 ```
 
 `task run` stores the deterministic task worktree path under
 `$GITMOOT_HOME/worktrees/<owner>--<repo>/<task-id>/` and leaves the registered
 checkout on its current branch.
+
+`task dismiss` is an explicit terminal action for stale `implementing` or
+`blocked` tasks. It refuses planned, PR/review/merge, awaiting-human, unknown,
+or otherwise machine-owned states; any live queued/running job, unsettled
+post-delivery advancement, unsettled running cancellation, or live process in
+the task worktree also blocks dismissal. The default reason is `dismissed by
+operator`. Success preserves the branch and worktree, releases the branch lock
+best-effort, and appends `task_dismissed_manual` to `task events`. Repeating the
+command is an exit-0 no-op with `changed:false` in JSON.
+
+`task events <id>` prints the append-only task lifecycle trail. Automatic stale
+dismissals use `task_dismissed_auto`; explicit recovery and retry use
+`task_recovered` and `task_recovered_job_retry`.
 
 ### Recover A Dead Implement
 
@@ -10244,9 +10320,11 @@ gitmoot task recover task-001 --owner lead
 gitmoot task recover task-001 --owner lead --repo owner/repo --skip-native-review-fanout --json
 ```
 
-`--owner <agent>` is required (a registered implement-capable agent, attributed
-as the recovery lead). `--repo owner/repo` is optional — it falls back to the
-task's stored repo and is only required when the task carries none.
+`--owner <agent>` is required when recovering preserved branch/worktree
+artifacts (a registered implement-capable agent, attributed as the recovery
+lead). A dismissed task with no branch returns directly to `planned`, so that
+path does not require `--owner`. `--repo owner/repo` is optional — it falls back
+to the task's stored repo and is only required when the task carries none.
 `--skip-native-review-fanout` persists that flag before the PR is opened;
 `--json` prints the machine-readable recovery result.
 
@@ -10255,6 +10333,14 @@ untracked non-ignored files), pushes the task branch, and opens or adopts the
 task's PR — the exact finalize steps the dead implementer never reached. If the
 worktree is already clean it recovers the commit already ahead of the base
 (and refuses when there is nothing ahead to recover).
+
+Recovery is also the only task-level escape hatch from `dismissed`. A dismissed
+task with a preserved branch and worktree first moves to `implementing`, then to
+`pr_open` after finalization. A branchless auto-dismissed task instead returns to
+`planned` and prints guidance to use `task run`. Ordinary `task run`, branch or
+worktree allocation, review continuation, and task-state advancement never
+resurrect a dismissed task implicitly. Retrying one of its jobs explicitly
+restores the task first and records `task_recovered_job_retry`.
 
 Two refusals guard `task recover` (and the `task run` / `agent implement`
 restart that points to it):
@@ -11550,7 +11636,8 @@ carry leaf cluster ids, while parent hubs remain an aggregate view only.
 ## Pipelines
 
 A pipeline (#681) runs a **declared DAG of shell and managed-agent stages** — a
-fixed, repeatable multi-step flow — on demand or on an interval schedule. Each
+fixed, repeatable multi-step flow — on demand, on an interval schedule, or after
+another pipeline succeeds. Each
 stage is an ordinary queued job: shell commands use the shell runtime, while agent
 stages use their registered runtime. The normal worker tick claims and runs it,
 and a scan-based advancer folds each stage's `gitmoot_result` **decision**
@@ -11567,8 +11654,8 @@ repo: owner/repo            # optional to register; REQUIRED to run
 schedule:                   # optional interval schedule (no cron in v1)
   interval: 24h             #   positive Go duration (required with a schedule block)
   jitter: 15m               #   optional random [0, jitter] added to next_due
-trigger:                    # optional generated Activepieces event source
-  kind: email               #   only supported kind
+trigger:                    # optional event source (email or pipeline)
+  kind: email
   connection: gmail-imap    #   default gmail-imap
   mailbox: INBOX            #   default INBOX
   map:                      #   optional output name -> closed email selector
@@ -11598,6 +11685,15 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     retry: 2                # optional; re-attempt a FAILED stage up to N times
 ```
 
+To start this pipeline once for every newly-succeeded run of another pipeline,
+use the alternative pipeline trigger shape (do not combine it with `schedule`):
+
+```yaml
+trigger:
+  kind: pipeline
+  pipeline: upstream-name
+```
+
 ```sh
 gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; omit --enable to add disabled
 gitmoot pipeline install-defaults                 # install built-in memory pipelines, skipping existing names
@@ -11615,7 +11711,8 @@ gitmoot pipeline remove nightly-sync
 ### Reading pipeline status
 
 The registry view is self-describing even before the first run. `mode` is
-`email-triggered (bound|pending|error)`, `scheduled <interval>`, or `manual`, and
+`email-triggered (bound|pending|error)`, `after: <upstream>`,
+`scheduled <interval>`, or `manual`, and
 stage lines carry their kind plus bounded command/prompt previews:
 
 ```text
@@ -11630,8 +11727,9 @@ stages:
 ```
 
 An absent agent row renders as `(unregistered)` without failing `show`.
-`pipeline list` retains six columns and uses `email` in the interval column for a
-trigger pipeline. JSON adds pipeline `mode` and stage `kind`, `agent_runtime`,
+`pipeline list` retains six columns and uses `email` or `after: <upstream>` in
+the interval column for a trigger pipeline. A removed or missing upstream is
+shown as `after: <upstream> (upstream missing)`. JSON adds pipeline `mode` and stage `kind`, `agent_runtime`,
 `prompt_preview`, and `cmd_preview`; the existing full fields remain unchanged.
 
 An enabled `trigger.kind: email` pipeline auto-binds. If Activepieces is down,
@@ -11643,8 +11741,32 @@ Provision the default IMAP connection with
 `gitmoot activepieces connect gmail` (`--with-smtp` is optional and unused by the
 generated receive flow).
 
+An enabled `trigger.kind: pipeline` pipeline fires once for each upstream run
+that reaches `succeeded`; failed and cancelled runs never fire it. The durable
+upstream-run cursor makes daemon re-ticks and restarts idempotent. Adding or
+enabling the downstream re-arms the cursor at the latest upstream run, so old
+history and successes from a disabled period never backfill. If the downstream
+already has an active run, the scan leaves the cursor unchanged and fires after
+that run settles. Missing upstreams warn at add time and remain dormant; removing
+an upstream is allowed. Add-time validation rejects self-reference and trigger
+cycles such as `B -> A -> B`. Pipeline triggers never use Activepieces, and
+`pipeline bind-trigger` reports that no binding is needed.
+
+For example, replace a clock-staggered `memory-ingest-sweep` schedule (such as
+24h30m after a 24h groom) with an ordered success chain:
+
+```yaml
+name: memory-ingest-sweep
+repo: owner/repo
+trigger:
+  kind: pipeline
+  pipeline: memory-groom-propose
+stages: [...]
+```
+
 `pipeline add` validates the whole spec at add time (unknown keys, duplicate/self/
-cyclic `needs`, a stage that is not exactly one of `cmd`/`agent`/`gate`, an agent stage
+cyclic `needs`, self/cyclic pipeline triggers, a schedule+pipeline-trigger hybrid,
+a stage that is not exactly one of `cmd`/`agent`/`gate`, an agent stage
 missing a `prompt` / invalid `action` / `implement` without `write: true` / a mutating
 stage on a scheduled pipeline without `allow_scheduled_writes` / a mutating stage on
 a triggered pipeline without `allow_triggered_writes` / a gate or review's
@@ -11664,7 +11786,8 @@ For a non-empty run payload, every agent stage (including roots) receives a
 dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before
 upstream context; each rendered value is capped at 1500 bytes. Shell stages receive
 exact `GITMOOT_TRIGGER_<UPPERCASE_KEY>` exec environment entries, never shell-source
-interpolation. The full canonical payload is retained in the SQLite run row; job
+interpolation. The full canonical payload is retained in the SQLite run row and
+shown by `pipeline show <run-id>` as `payload_json`; job
 env/prompt projections follow normal job-data retention.
 
 Every pipeline shell stage also receives `GITMOOT_PIPELINE_NAME`,
@@ -12745,7 +12868,28 @@ over a dirty worktree with no active job (so nothing is discarded) and point at
 `gitmoot task recover <task-id> --owner <agent>`, which commits the full
 worktree state (`git add -A`, incl. untracked non-ignored files), pushes the
 branch, and opens or adopts the PR. `--repo` is optional (falls back to the
-task's repo). Recovery refuses while a live process is still inside the worktree.
+task's repo). `--owner` is required for this artifact-finalization path, but not
+when a dismissed branchless task is simply restored to `planned`. Recovery
+refuses while a live process is still inside the worktree.
+
+**Task dismissal and stale reconciliation:** `dismissed` is a terminal task
+state for implicit workflow transitions. An operator can run `gitmoot task
+dismiss <id> [--reason ...]` only from `implementing` or `blocked`; Gitmoot
+refuses while any matching job is live or a process remains in the task
+worktree. The branch and worktree are preserved, while the branch lock is
+released best-effort. Manual and daemon transitions are audited as
+`task_dismissed_manual` and `task_dismissed_auto` in `gitmoot task events <id>`.
+
+Each repo poll reads a bounded oldest-first stale window and processes up to 20
+qualifying `implementing`/`blocked` tasks whose `updated_at` predates
+`[workflow].stale_task_ttl` (default `168h`; `"0"` disables the leg).
+`updated_at` is deliberately a conservative activity proxy, not proof of
+abandonment. A candidate is skipped for a live job, a same-repo open-PR branch,
+or an exact branch still present on `origin`; remote lookup uncertainty skips
+mutation. A branchless candidate needs no remote lookup. Explicit `task
+recover` restores preserved artifacts through `implementing` to `pr_open`, or
+restores a branchless task to `planned`; job retry records its own recovery
+event. The server-side task board omits dismissed rows immediately.
 
 **PR-bound fix pass:** use `gitmoot agent implement <agent> --repo owner/repo
 --pr <number> "..."` or `gitmoot agent run <agent> --repo owner/repo --action
@@ -13099,6 +13243,32 @@ gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; --enable t
 RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
 gitmoot pipeline show "$RUN"                       # watch the text funnel
 ```
+
+### Chain a pipeline after another succeeds
+
+Use `kind: pipeline` when ordering matters more than a clock stagger. This
+example runs ingest exactly once after each newly-succeeded groom run:
+
+```yaml
+name: memory-ingest-sweep
+repo: owner/repo
+trigger:
+  kind: pipeline
+  pipeline: memory-groom-propose
+stages:
+  - id: sweep
+    cmd: gitmoot memory ingest sweep --json
+```
+
+This replaces the old `24h` / `24h30m` imitation of ordering: failed or cancelled
+groom runs do not start ingest, while each successful run fires it once. The
+cursor is durable across daemon restarts. Adding or enabling ingest arms at the
+latest groom run, so no historical or disabled-period runs backfill. If ingest
+is already active, its cursor does not move and it fires after settlement.
+Pipeline-trigger cycles are rejected at add time. A missing or later-removed
+upstream is allowed but leaves the downstream dormant and visibly marked
+`(upstream missing)`. Pipeline triggers are local database state and never use
+Activepieces; `pipeline bind-trigger` is an informational no-op for them.
 
 A stage prints a `gitmoot_result` blob to stdout to signal its decision; the
 advancer folds by that **decision**, never the job's exit state:
@@ -13727,6 +13897,16 @@ cannot recurse or fan out forever:
   `answer` verb is valid only on an ask round and `retry`/`continue`/`abort` only
   on a failure round — a mismatch is rejected with a clear message. Absence of
   `human_questions[]` is byte-identical to today's behavior.
+
+- Dismissed task terminality (#913): `dismissed` may be entered only from
+  `implementing` or `blocked`. Manual `task dismiss` proves there is no live
+  matching job and no process in the task worktree. Automatic stale-task
+  reconciliation proves there is no live matching job and requires its separate
+  open-PR/remote-branch evidence, but does not inspect worktree processes.
+  Ordinary task run/allocation and late review or continuation advancement fail
+  closed instead of overwriting it. Only `task recover` or retrying a job performs
+  an explicit audited recovery. Dismissal never deletes the task branch or
+  worktree.
 
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, a delegation batch


### PR DESCRIPTION
Closes #922. Owner-approved primitive: `trigger: {kind: pipeline, pipeline: <upstream>}` — the downstream fires exactly once per newly-succeeded upstream run.

**Semantics** (tri-model panel synthesis): durable per-downstream cursor in a new `pipeline_trigger_states` table; the fire creates the run + stage rows + last-run bookkeeping + cursor advance in **one transaction**, with enabled/active-run/upstream-still-succeeded/newer-than-boundary re-verified inside the tx (CAS on the cursor — a concurrent change aborts the fire cleanly). Arm-to-latest at add **and** enable, so history and disabled periods never backfill; oldest-first draining so back-to-back successes each fire once B is free; active downstream defers without cursor advance. Add-time cycle detection (3-color DFS over trigger edges with the candidate overlaid) rejects A→B→A naming the chain; missing upstream warns and leaves the downstream dormant (`after: X (upstream missing)` chip). Cross-repo upstream allowed. AP/email trigger paths untouched — `kind: pipeline` never touches Activepieces; `schedule`+`pipeline` hybrids rejected in MVP.

**Verified**:
- Full `go test ./...` + vet green; focused db/cli/pipeline trigger tests added (fires-once, re-tick no-op, failed-A no-fire, disabled skip without cursor advance, arm-at-enable, cycle tables, display modes, migration round-trip).
- No-LLM shell-runtime E2E on an isolated home, proven **red on the deployed binary (5 failures) → green 13/13 on this branch**: clean add without AP chatter, `after:` chip, cycle rejection by name, exactly-once fire, no double-fire across ticks, failed run never fires, second success fires exactly one more, removed upstream dormant.
- Docs ship with code: skill CLI.md/WORKFLOWS.md + website pipelines page (memory-chain example) + llms-full regenerated.

**Deploy notes**: migration auto-applies. After deploy, re-declare the live memory chain (`memory-ingest-sweep` → `trigger: {kind: pipeline, pipeline: memory-groom-propose}`) via explicit `pipeline add` — install-defaults skips existing rows — retiring the +30m stagger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)