### PR TITLE
feat(credgw): loopback model gateway — per-job placeholder tokens, claude credential custody (#874 P2)

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -9,6 +9,8 @@ and shell runtime adapters in foreground and daemon-worker delivery paths.
 env_curation = true
 env_passthrough = ["GOCACHE", "NPM_*"]
 github = "deny"
+model_gateway = false
+model_gateway_allow_hosts = ["api.anthropic.com"]
 ```
 
 `env_curation = false` preserves the historical behavior: runtime commands
@@ -35,6 +37,25 @@ missing, Gitmoot imports legacy `daemon-runtime.env` once, or otherwise seeds
 from ambient managed variables once. Existing files are never overwritten.
 For systemd deployments, keep `daemon.env` for operational values such as
 `PATH`; do not duplicate Claude secrets there after bootstrap.
+
+## Claude model gateway
+
+`model_gateway = true` opts Claude deliveries into a daemon-owned loopback
+model gateway. The gateway listens only on an OS-assigned `127.0.0.1` port. For
+each job, Gitmoot snapshots the selected real credential into daemon memory,
+mints a random `gitmoot-kc-...` placeholder, and gives the Claude child only
+that placeholder plus `ANTHROPIC_BASE_URL` pointing at the loopback listener.
+The gateway authenticates the placeholder, replaces it with the real upstream
+credential, streams the response, and revokes the placeholder when delivery
+ends. Unknown and revoked placeholders receive `401`.
+
+The feature is off by default and currently covers Claude only. A populated
+`runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery
+instead of falling back to ambient auth, Claude's credential store, or direct
+upstream egress. `model_gateway_allow_hosts` is an exact hostname allowlist and
+defaults to `api.anthropic.com`. The upstream is fixed by Gitmoot, not selected
+by the child. Credentials are read once when the adapter is built, never once
+per proxied request, so rotation applies to the next adapter/job.
 
 ## Curated environment
 
@@ -83,9 +104,16 @@ disable prompts.
 
 ## Limits
 
-This is ambient credential hygiene and denial, not egress confinement and not a
-network proxy. It creates no placeholder tokens and changes no proxy settings.
-Runtime sandboxes can still read credential files that are visible on disk;
-the current Linux Landlock policy includes read-only `/`. SSH keys, SSH agents,
-Git credential helpers, and direct network access are also untouched. Network
-proxy enforcement is P2, and narrower Landlock read rules are P3.
+The model gateway is credential custody, policy, and attribution, not a hard
+egress boundary. These two limits are deliberate:
+
+1. env-var routing is cooperative, not a hard egress boundary — a malicious
+   agent can unset it; this buys credential custody/policy/attribution, not
+   enforcement.
+2. The strong "agents never hold real credentials" claim also requires
+   Landlock read-rules for `runtime-auth.env` (same-UID read is currently
+   possible) — that is P3.
+
+Codex/Kimi custody, MITM CA support, corporate proxy/`NO_PROXY` interoperability,
+Landlock read restrictions, and hard egress enforcement remain P3. SSH keys,
+SSH agents, Git credential helpers, and direct network access are untouched.

--- a/internal/cli/credential_gateway.go
+++ b/internal/cli/credential_gateway.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/credgw"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+var (
+	modelGatewayRegistry                   = credgw.NewRegistry()
+	modelGatewayUpstreamURL                = credgw.DefaultAnthropicUpstream
+	modelGatewayLogf        credgw.LogFunc = log.Printf
+)
+
+func buildModelGatewayRunner(home string, cfg config.CredentialsConfig, auth runtimeAuthFile, inner subprocess.Runner) (*credgw.Runner, error) {
+	credential, err := modelGatewayCredential(auth)
+	if err != nil {
+		return nil, err
+	}
+	gateway, err := modelGatewayRegistry.Gateway(home, modelGatewayLogf)
+	if err != nil {
+		return nil, fmt.Errorf("start Claude model gateway: %w", err)
+	}
+	return &credgw.Runner{
+		Inner:      inner,
+		Gateway:    gateway,
+		Credential: credential,
+		Policy: credgw.Policy{
+			Upstream:     modelGatewayUpstreamURL,
+			AllowedHosts: append([]string{}, cfg.ModelGatewayAllowHosts...),
+		},
+	}, nil
+}
+
+func modelGatewayCredential(auth runtimeAuthFile) (credgw.Credential, error) {
+	if !auth.Exists || len(auth.Values) == 0 {
+		return credgw.Credential{}, fmt.Errorf("Claude model gateway requires a populated %s", runtimeAuthFileName)
+	}
+	// Preserve Claude's effective preference when more than one managed value is
+	// present: API key first, then Anthropic bearer token, then Claude OAuth.
+	if value := strings.TrimSpace(auth.Values[runtime.AnthropicAPIKeyEnv]); value != "" {
+		return credgw.Credential{Kind: credgw.CredentialAPIKey, Value: value}, nil
+	}
+	if value := strings.TrimSpace(auth.Values[runtime.AnthropicAuthTokenEnv]); value != "" {
+		return credgw.Credential{Kind: credgw.CredentialBearer, Value: value}, nil
+	}
+	if value := strings.TrimSpace(auth.Values[runtime.ClaudeOAuthTokenEnv]); value != "" {
+		return credgw.Credential{Kind: credgw.CredentialBearer, Value: value}, nil
+	}
+	return credgw.Credential{}, fmt.Errorf("Claude model gateway requires a populated %s", runtimeAuthFileName)
+}
+
+type modelGatewayRuntimeAdapter struct {
+	runtime.Adapter
+	runner *credgw.Runner
+}
+
+func (a modelGatewayRuntimeAdapter) Start(ctx context.Context, request runtime.StartRequest) (runtime.StartResult, error) {
+	lease, err := a.runner.NewLease(modelGatewayLeaseID("start-"+request.Agent.Name, ""))
+	if err != nil {
+		return runtime.StartResult{}, err
+	}
+	defer lease.Revoke()
+	return a.Adapter.Start(credgw.WithLease(ctx, lease), request)
+}
+
+func (a modelGatewayRuntimeAdapter) Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	lease, err := a.runner.NewLease(modelGatewayLeaseID(job.ID, agent.Name))
+	if err != nil {
+		return runtime.Result{}, err
+	}
+	defer lease.Revoke()
+	return a.Adapter.Deliver(credgw.WithLease(ctx, lease), agent, job)
+}
+
+func modelGatewayLeaseID(primary, fallback string) string {
+	if value := strings.TrimSpace(primary); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(fallback); value != "" {
+		return "delivery-" + value
+	}
+	return "runtime-delivery"
+}
+
+func wrapModelGatewayAdapter(adapter runtime.Adapter, runner *credgw.Runner) runtime.Adapter {
+	if runner == nil {
+		return adapter
+	}
+	return modelGatewayRuntimeAdapter{Adapter: adapter, runner: runner}
+}
+
+func closeModelGatewayHome(home string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = modelGatewayRegistry.CloseHome(ctx, home)
+}

--- a/internal/cli/credential_gateway_test.go
+++ b/internal/cli/credential_gateway_test.go
@@ -1,0 +1,322 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/credgw"
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+func TestRuntimeJobRunnerModelGatewayInjectsPlaceholderWithCurationOnAndOff(t *testing.T) {
+	for _, curation := range []bool{false, true} {
+		t.Run(fmt.Sprintf("curation-%t", curation), func(t *testing.T) {
+			home := t.TempDir()
+			paths := config.PathsForHome(home)
+			if err := config.Initialize(paths); err != nil {
+				t.Fatal(err)
+			}
+			body := config.DefaultConfig(paths) + fmt.Sprintf(`
+[credentials]
+env_curation = %t
+model_gateway = true
+model_gateway_allow_hosts = ["api.anthropic.com"]
+`, curation)
+			if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := writeRuntimeAuthFile(runtimeAuthFilePath(paths.Home), map[string]string{
+				runtime.ClaudeOAuthTokenEnv: testOAuthToken,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			t.Setenv(runtime.ClaudeOAuthTokenEnv, "ambient-oauth-must-not-reach-child")
+			t.Setenv(runtime.AnthropicAPIKeyEnv, "ambient-api-key-must-not-reach-child")
+			t.Setenv(runtime.AnthropicAuthTokenEnv, "ambient-auth-token-must-not-reach-child")
+
+			registry := credgw.NewRegistry()
+			previousRegistry := modelGatewayRegistry
+			previousGatewayLogf := modelGatewayLogf
+			previousAuthLogf := runtimeAuthLogf
+			modelGatewayRegistry = registry
+			modelGatewayLogf = func(string, ...any) {}
+			runtimeAuthLogf = func(string, ...any) {}
+			t.Cleanup(func() {
+				closeModelGatewayHome(paths.Home)
+				modelGatewayRegistry = previousRegistry
+				modelGatewayLogf = previousGatewayLogf
+				runtimeAuthLogf = previousAuthLogf
+			})
+
+			runner, _, source, err := runtimeJobRunnerWithAuth(home, runtime.ClaudeRuntime, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := runner.(*credgw.Runner); !ok {
+				t.Fatalf("runner = %T", runner)
+			}
+			if source != runtimeAuthFileName+" via model gateway" {
+				t.Fatalf("auth source = %q", source)
+			}
+			result, err := runner.Run(context.Background(), "", "sh", "-c", `printf '%s\n%s\n%s\n%s' "$CLAUDE_CODE_OAUTH_TOKEN" "$ANTHROPIC_API_KEY" "$ANTHROPIC_AUTH_TOKEN" "$ANTHROPIC_BASE_URL"`)
+			if err != nil {
+				t.Fatal(err)
+			}
+			lines := strings.Split(result.Stdout, "\n")
+			if len(lines) != 4 || !strings.HasPrefix(lines[0], "gitmoot-kc-runtime-call-") || lines[1] != "" || lines[2] != "" || !strings.HasPrefix(lines[3], "http://127.0.0.1:") {
+				t.Fatalf("gateway child env = %q", result.Stdout)
+			}
+			for _, secret := range []string{testOAuthToken, "ambient-oauth-must-not-reach-child", "ambient-api-key-must-not-reach-child", "ambient-auth-token-must-not-reach-child"} {
+				if strings.Contains(result.Stdout, secret) {
+					t.Fatalf("child env contains credential %q", secret)
+				}
+			}
+			request, _ := http.NewRequest(http.MethodPost, lines[3]+"/v1/messages", nil)
+			request.Header.Set("Authorization", "Bearer "+lines[0])
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			response.Body.Close()
+			if response.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("revoked placeholder status = %d", response.StatusCode)
+			}
+		})
+	}
+}
+
+func TestRuntimeJobRunnerModelGatewayDisabledKeepsDirectAuthInjection(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	for _, name := range runtimeAuthEnvVars {
+		t.Setenv(name, "")
+	}
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRuntimeAuthFile(runtimeAuthFilePath(paths.Home), map[string]string{
+		runtime.ClaudeOAuthTokenEnv: testOAuthToken,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	runner, err := runtimeJobRunner(home, runtime.ClaudeRuntime, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, enabled := runner.(*credgw.Runner); enabled {
+		t.Fatalf("disabled model gateway returned %T", runner)
+	}
+	result, err := runner.Run(context.Background(), "", "sh", "-c", `printf '%s|%s' "$CLAUDE_CODE_OAUTH_TOKEN" "$ANTHROPIC_BASE_URL"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Stdout != testOAuthToken+"|" {
+		t.Fatalf("disabled gateway child env = %q", result.Stdout)
+	}
+}
+
+func TestRuntimeJobRunnerModelGatewayRequiresAuthoritativeCredential(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	body := config.DefaultConfig(paths) + `
+[credentials]
+model_gateway = true
+`
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRuntimeAuthFile(runtimeAuthFilePath(paths.Home), nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range runtimeAuthEnvVars {
+		t.Setenv(name, "")
+	}
+	_, err := runtimeJobRunner(home, runtime.ClaudeRuntime, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires a populated "+runtimeAuthFileName) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestClaudeModelGatewayCredentialCustodyE2E(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+
+	realToken := "sk-ant-oat01-gateway-real-token-abcdefghijklmnopqrstuvwxyz"
+	seenAuthorization := make(chan string, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuthorization <- r.Header.Get("Authorization")
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = io.WriteString(w, shaFingerprint(realToken))
+	}))
+	defer upstream.Close()
+	parsedUpstream, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configBody := config.DefaultConfig(paths) + fmt.Sprintf(`
+[credentials]
+model_gateway = true
+model_gateway_allow_hosts = [%q]
+`, parsedUpstream.Hostname())
+	if err := os.WriteFile(paths.ConfigFile, []byte(configBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRuntimeAuthFile(runtimeAuthFilePath(paths.Home), map[string]string{
+		runtime.ClaudeOAuthTokenEnv: realToken,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	shim := filepath.Join(binDir, "claude")
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := fmt.Sprintf("#!/bin/sh\nexec %q -test.run '^TestClaudeModelGatewayShimProcess$' -- \"$@\"\n", testBinary)
+	if err := os.WriteFile(shim, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	envDump := filepath.Join(t.TempDir(), "claude-env.txt")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GITMOOT_CLAUDE_GATEWAY_HELPER", "1")
+	t.Setenv("GITMOOT_CLAUDE_GATEWAY_ENV_DUMP", envDump)
+	t.Setenv(runtime.ClaudeOAuthTokenEnv, "ambient-credential-must-not-win")
+	t.Setenv(runtime.AnthropicAPIKeyEnv, "ambient-api-key-must-not-win")
+
+	previousRegistry := modelGatewayRegistry
+	previousUpstream := modelGatewayUpstreamURL
+	previousLogf := modelGatewayLogf
+	previousAuthLogf := runtimeAuthLogf
+	modelGatewayRegistry = credgw.NewRegistry()
+	modelGatewayUpstreamURL = upstream.URL
+	var logs strings.Builder
+	modelGatewayLogf = func(format string, args ...any) { fmt.Fprintf(&logs, format, args...) }
+	runtimeAuthLogf = func(format string, args ...any) { fmt.Fprintf(&logs, format, args...) }
+	t.Cleanup(func() {
+		closeModelGatewayHome(paths.Home)
+		modelGatewayRegistry = previousRegistry
+		modelGatewayUpstreamURL = previousUpstream
+		modelGatewayLogf = previousLogf
+		runtimeAuthLogf = previousAuthLogf
+	})
+
+	adapter, err := buildRuntimeAdapter(home, runtime.Agent{Runtime: runtime.ClaudeRuntime}, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent := runtime.Agent{
+		Name:       "gateway-e2e",
+		Role:       "implementer",
+		Runtime:    runtime.ClaudeRuntime,
+		RuntimeRef: runtime.FreshRefForJob("gateway-e2e"),
+		RepoScope:  "owner/repo",
+	}
+	result, err := adapter.Deliver(context.Background(), agent, runtime.Job{ID: "gateway-e2e-job", Prompt: "exercise model gateway"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Summary != shaFingerprint(realToken) {
+		t.Fatalf("upstream result = %q", result.Summary)
+	}
+	select {
+	case got := <-seenAuthorization:
+		if got != "Bearer "+realToken {
+			t.Fatalf("upstream Authorization = %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("upstream did not receive the gateway request")
+	}
+	dump, err := os.ReadFile(envDump)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dumpText := string(dump)
+	if !strings.Contains(dumpText, "CLAUDE_CODE_OAUTH_TOKEN=gitmoot-kc-gateway-e2e-job-") || !strings.Contains(dumpText, "ANTHROPIC_BASE_URL=http://127.0.0.1:") {
+		t.Fatalf("child env dump = %q", dumpText)
+	}
+	for _, secret := range []string{realToken, "ambient-credential-must-not-win", "ambient-api-key-must-not-win"} {
+		if strings.Contains(dumpText, secret) || strings.Contains(logs.String(), secret) {
+			t.Fatalf("credential leaked through child env/logs")
+		}
+	}
+	placeholder := envDumpValue(dumpText, runtime.ClaudeOAuthTokenEnv)
+	if placeholder == "" || strings.Contains(logs.String(), placeholder) {
+		t.Fatalf("placeholder missing or logged: logs=%q", logs.String())
+	}
+	request, _ := http.NewRequest(http.MethodPost, envDumpValue(dumpText, "ANTHROPIC_BASE_URL")+"/v1/messages", bytes.NewReader(nil))
+	request.Header.Set("Authorization", "Bearer "+placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("settled job placeholder status = %d", response.StatusCode)
+	}
+}
+
+func TestClaudeModelGatewayShimProcess(t *testing.T) {
+	if os.Getenv("GITMOOT_CLAUDE_GATEWAY_HELPER") != "1" {
+		return
+	}
+	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
+	placeholder := os.Getenv(runtime.ClaudeOAuthTokenEnv)
+	dump := fmt.Sprintf("%s=%s\n%s=%s\n%s=%s\nANTHROPIC_BASE_URL=%s\n",
+		runtime.ClaudeOAuthTokenEnv, placeholder,
+		runtime.AnthropicAPIKeyEnv, os.Getenv(runtime.AnthropicAPIKeyEnv),
+		runtime.AnthropicAuthTokenEnv, os.Getenv(runtime.AnthropicAuthTokenEnv),
+		baseURL,
+	)
+	if err := os.WriteFile(os.Getenv("GITMOOT_CLAUDE_GATEWAY_ENV_DUMP"), []byte(dump), 0o600); err != nil {
+		os.Exit(2)
+	}
+	request, err := http.NewRequest(http.MethodPost, baseURL+"/v1/messages", strings.NewReader("test"))
+	if err != nil {
+		os.Exit(2)
+	}
+	request.Header.Set("Authorization", "Bearer "+placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		os.Exit(2)
+	}
+	body, err := io.ReadAll(response.Body)
+	response.Body.Close()
+	if err != nil || response.StatusCode != http.StatusOK {
+		os.Exit(2)
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"type":     "result",
+		"is_error": false,
+		"result":   string(body),
+	})
+	os.Exit(0)
+}
+
+func envDumpValue(dump, name string) string {
+	for _, line := range strings.Split(dump, "\n") {
+		if value, ok := strings.CutPrefix(line, name+"="); ok {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/cli/credential_gateway_test.go
+++ b/internal/cli/credential_gateway_test.go
@@ -40,6 +40,23 @@ func (s *gatewayLogSink) String() string {
 	return s.lines.String()
 }
 
+// waitFor blocks until the logs contain substr and returns everything logged so
+// far, so assertions never race the goroutine that writes the entry.
+func (s *gatewayLogSink) waitFor(t *testing.T, substr string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		logged := s.String()
+		if strings.Contains(logged, substr) {
+			return logged
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("logs never contained %q: %q", substr, logged)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestRuntimeJobRunnerModelGatewayInjectsPlaceholderWithCurationOnAndOff(t *testing.T) {
 	for _, curation := range []bool{false, true} {
 		t.Run(fmt.Sprintf("curation-%t", curation), func(t *testing.T) {
@@ -274,14 +291,18 @@ model_gateway_allow_hosts = [%q]
 	if !strings.Contains(dumpText, "CLAUDE_CODE_OAUTH_TOKEN=gitmoot-kc-gateway-e2e-job-") || !strings.Contains(dumpText, "ANTHROPIC_BASE_URL=http://127.0.0.1:") {
 		t.Fatalf("child env dump = %q", dumpText)
 	}
+	// Wait for the gateway's own request log before asserting on log contents:
+	// it is written by the request goroutine after the response is proxied back,
+	// so reading too early would make these leak checks vacuous.
+	logged := logs.waitFor(t, "job_id=gateway-e2e-job")
 	for _, secret := range []string{realToken, "ambient-credential-must-not-win", "ambient-api-key-must-not-win"} {
-		if strings.Contains(dumpText, secret) || strings.Contains(logs.String(), secret) {
+		if strings.Contains(dumpText, secret) || strings.Contains(logged, secret) {
 			t.Fatalf("credential leaked through child env/logs")
 		}
 	}
 	placeholder := envDumpValue(dumpText, runtime.ClaudeOAuthTokenEnv)
-	if placeholder == "" || strings.Contains(logs.String(), placeholder) {
-		t.Fatalf("placeholder missing or logged: logs=%q", logs.String())
+	if placeholder == "" || strings.Contains(logged, placeholder) {
+		t.Fatalf("placeholder missing or logged: logs=%q", logged)
 	}
 	request, _ := http.NewRequest(http.MethodPost, envDumpValue(dumpText, "ANTHROPIC_BASE_URL")+"/v1/messages", bytes.NewReader(nil))
 	request.Header.Set("Authorization", "Bearer "+placeholder)

--- a/internal/cli/credential_gateway_test.go
+++ b/internal/cli/credential_gateway_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +20,25 @@ import (
 	"github.com/jerryfane/gitmoot/internal/credgw"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 )
+
+// gatewayLogSink collects gateway/auth logs. The gateway logs from its request
+// goroutines, so reads from the test goroutine must be synchronized.
+type gatewayLogSink struct {
+	mu    sync.Mutex
+	lines strings.Builder
+}
+
+func (s *gatewayLogSink) Logf(format string, args ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	fmt.Fprintf(&s.lines, format, args...)
+}
+
+func (s *gatewayLogSink) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lines.String()
+}
 
 func TestRuntimeJobRunnerModelGatewayInjectsPlaceholderWithCurationOnAndOff(t *testing.T) {
 	for _, curation := range []bool{false, true} {
@@ -209,9 +229,9 @@ model_gateway_allow_hosts = [%q]
 	previousAuthLogf := runtimeAuthLogf
 	modelGatewayRegistry = credgw.NewRegistry()
 	modelGatewayUpstreamURL = upstream.URL
-	var logs strings.Builder
-	modelGatewayLogf = func(format string, args ...any) { fmt.Fprintf(&logs, format, args...) }
-	runtimeAuthLogf = func(format string, args ...any) { fmt.Fprintf(&logs, format, args...) }
+	var logs gatewayLogSink
+	modelGatewayLogf = logs.Logf
+	runtimeAuthLogf = logs.Logf
 	t.Cleanup(func() {
 		closeModelGatewayHome(paths.Home)
 		modelGatewayRegistry = previousRegistry

--- a/internal/cli/credentials.go
+++ b/internal/cli/credentials.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/credgw"
 	"github.com/jerryfane/gitmoot/internal/runtime"
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
@@ -140,6 +141,8 @@ func runtimeJobRunner(home string, runtimeName string, outer subprocess.Runner) 
 func runtimeJobRunnerWithAuth(home string, runtimeName string, outer subprocess.Runner) (subprocess.Runner, runtimeAuthFile, string, error) {
 	var authState runtimeAuthFile
 	var authSource string
+	var credentialsCfg config.CredentialsConfig
+	var resolvedHome string
 	if runtimeName == runtime.ClaudeRuntime {
 		authSource = runtimeAuthFileName
 		paths, err := pathsFromFlag(home)
@@ -155,11 +158,30 @@ func runtimeJobRunnerWithAuth(home string, runtimeName string, outer subprocess.
 		}
 		authSource = runtimeAuthSource(authState, runtimeAuthEnvLookup)
 		warnRuntimeAuthConflicts(authState, runtimeAuthEnvLookup, runtimeAuthLogf)
+		credentialsCfg = config.DefaultCredentialsConfig()
+		loadedCredentials, loadErr := config.LoadCredentialsConfig(paths)
+		if loadErr == nil {
+			credentialsCfg = loadedCredentials
+		} else if !errors.Is(loadErr, os.ErrNotExist) {
+			return nil, authState, authSource, fmt.Errorf("load credentials config: %w", loadErr)
+		}
+		resolvedHome = paths.Home
 	}
 
 	curated, err := curatedJobRunner(home, runtimeName)
 	if err != nil {
 		return nil, authState, authSource, err
+	}
+	if runtimeName == runtime.ClaudeRuntime && credentialsCfg.ModelGateway {
+		base := outer
+		if curated != nil {
+			base = graftRuntimeBaseRunner(outer, curated)
+		}
+		gatewayRunner, err := buildModelGatewayRunner(resolvedHome, credentialsCfg, authState, base)
+		if err != nil {
+			return nil, authState, authSource, err
+		}
+		return gatewayRunner, authState, runtimeAuthFileName + " via model gateway", nil
 	}
 	if runtimeName == runtime.ClaudeRuntime {
 		authEnv := runtimeAuthInjectionEnv(authState)
@@ -254,5 +276,10 @@ func runtimeAdapterFor(home string, runtimeName string, checkout string) (runtim
 	if err != nil {
 		return nil, err
 	}
-	return runtimeStartAdapterFor(factory, runtimeName, checkout)
+	adapter, err := runtimeStartAdapterFor(factory, runtimeName, checkout)
+	if err != nil {
+		return nil, err
+	}
+	gatewayRunner, _ := factory.Runner.(*credgw.Runner)
+	return wrapModelGatewayAdapter(adapter, gatewayRunner), nil
 }

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/jerryfane/gitmoot/internal/artifact"
 	"github.com/jerryfane/gitmoot/internal/cockpit"
 	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/credgw"
 	"github.com/jerryfane/gitmoot/internal/daemon"
 	"github.com/jerryfane/gitmoot/internal/db"
 	"github.com/jerryfane/gitmoot/internal/events"
@@ -303,6 +304,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		}); bootstrapErr != nil {
 			fmt.Fprintf(stderr, "daemon run: warning: could not bootstrap runtime auth: %v\n", bootstrapErr)
 		}
+		defer closeModelGatewayHome(paths.Home)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -5527,6 +5529,17 @@ func wrapProduceSandboxAdapter(action string, agent runtime.Agent, adapter workf
 		return nil, err
 	}
 	switch a := adapter.(type) {
+	case modelGatewayRuntimeAdapter:
+		wrapped, err := wrapProduceSandboxAdapter(action, agent, a.Adapter)
+		if err != nil {
+			return nil, err
+		}
+		runtimeAdapter, ok := wrapped.(runtime.Adapter)
+		if !ok {
+			return nil, fmt.Errorf("produce Landlock sandbox returned incompatible %T adapter", wrapped)
+		}
+		a.Adapter = runtimeAdapter
+		return a, nil
 	case runtime.ClaudeAdapter:
 		a.Runner = landlockProduceRunner(a.Runner, paths, env)
 		return a, nil
@@ -6936,6 +6949,7 @@ func buildRuntimeAdapter(home string, agent runtime.Agent, checkout string, runn
 	if err != nil {
 		return nil, err
 	}
+	gatewayRunner, _ := runner.(*credgw.Runner)
 	if len(agent.WritablePaths) > 0 && (agent.Runtime == runtime.ClaudeRuntime || agent.Runtime == runtime.KimiRuntime) {
 		paths, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.WritablePaths)
 		if err != nil {
@@ -6943,20 +6957,22 @@ func buildRuntimeAdapter(home string, agent runtime.Agent, checkout string, runn
 		}
 		runner = landlockProduceRunner(runner, paths, env)
 	}
+	var adapter runtime.Adapter
 	switch agent.Runtime {
 	case runtime.CodexRuntime:
-		return runtime.CodexAdapter{Dir: checkout, Runner: runner}, nil
+		adapter = runtime.CodexAdapter{Dir: checkout, Runner: runner}
 	case runtime.ClaudeRuntime:
-		return runtime.ClaudeAdapter{Dir: checkout, Runner: runner}, nil
+		adapter = runtime.ClaudeAdapter{Dir: checkout, Runner: runner}
 	case runtime.KimiRuntime:
-		return runtime.KimiAdapter{Dir: checkout, Runner: runner}, nil
+		adapter = runtime.KimiAdapter{Dir: checkout, Runner: runner}
 	case runtime.KimiCLIRuntime:
-		return runtime.KimiCLIAdapter{Dir: checkout, Runner: runner}, nil
+		adapter = runtime.KimiCLIAdapter{Dir: checkout, Runner: runner}
 	case runtime.ShellRuntime:
-		return runtime.ShellAdapter{Dir: checkout, Runner: runner}, nil
+		adapter = runtime.ShellAdapter{Dir: checkout, Runner: runner}
 	default:
 		return nil, fmt.Errorf("unsupported runtime: %s", agent.Runtime)
 	}
+	return wrapModelGatewayAdapter(adapter, gatewayRunner), nil
 }
 
 func (w jobWorker) defaultStartAdapter(runtimeName string, checkout string) (runtime.Adapter, error) {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 )
@@ -9,20 +10,26 @@ import (
 const (
 	CredentialsGitHubDeny    = "deny"
 	CredentialsGitHubInherit = "inherit"
+	DefaultModelGatewayHost  = "api.anthropic.com"
 )
 
-// CredentialsConfig controls the off-by-default environment curation applied
-// only to runtime-agent subprocesses. It is loaded when an adapter is built so
+// CredentialsConfig controls runtime-child environment curation and the
+// off-by-default Claude model gateway. It is loaded when an adapter is built so
 // each delivery observes the current file without daemon reload plumbing.
 type CredentialsConfig struct {
-	EnvCuration    bool
-	EnvPassthrough []string
-	GitHub         string
+	EnvCuration            bool
+	EnvPassthrough         []string
+	GitHub                 string
+	ModelGateway           bool
+	ModelGatewayAllowHosts []string
 }
 
-// DefaultCredentialsConfig preserves historical full-environment inheritance.
+// DefaultCredentialsConfig preserves direct auth and full-environment inheritance.
 func DefaultCredentialsConfig() CredentialsConfig {
-	return CredentialsConfig{GitHub: CredentialsGitHubDeny}
+	return CredentialsConfig{
+		GitHub:                 CredentialsGitHubDeny,
+		ModelGatewayAllowHosts: []string{DefaultModelGatewayHost},
+	}
 }
 
 // LoadCredentialsConfig parses the optional [credentials] section.
@@ -71,6 +78,18 @@ func LoadCredentialsConfig(paths Paths) (CredentialsConfig, error) {
 				return CredentialsConfig{}, fmt.Errorf("parse [credentials].github: %w", err)
 			}
 			cfg.GitHub = strings.TrimSpace(parsed)
+		case "model_gateway":
+			parsed, err := parseConfigBool(value)
+			if err != nil {
+				return CredentialsConfig{}, fmt.Errorf("parse [credentials].model_gateway: %w", err)
+			}
+			cfg.ModelGateway = parsed
+		case "model_gateway_allow_hosts":
+			parsed, err := parseConfigStringArray(value)
+			if err != nil {
+				return CredentialsConfig{}, fmt.Errorf("parse [credentials].model_gateway_allow_hosts: %w", err)
+			}
+			cfg.ModelGatewayAllowHosts = parsed
 		default:
 			// Ignore unknown keys so the section remains forward-compatible.
 		}
@@ -90,6 +109,45 @@ func validateCredentialsConfig(cfg CredentialsConfig) error {
 	for _, pattern := range cfg.EnvPassthrough {
 		if err := validateCredentialEnvPattern(pattern); err != nil {
 			return fmt.Errorf("invalid [credentials].env_passthrough entry %q: %w", pattern, err)
+		}
+	}
+	if cfg.ModelGateway && len(cfg.ModelGatewayAllowHosts) == 0 {
+		return fmt.Errorf("[credentials].model_gateway_allow_hosts must not be empty when model_gateway=true")
+	}
+	for _, host := range cfg.ModelGatewayAllowHosts {
+		if err := validateModelGatewayHost(host); err != nil {
+			return fmt.Errorf("invalid [credentials].model_gateway_allow_hosts entry %q: %w", host, err)
+		}
+	}
+	return nil
+}
+
+func validateModelGatewayHost(host string) error {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return fmt.Errorf("host must not be empty")
+	}
+	if strings.ContainsAny(host, "/@?#\x00") || strings.Contains(host, "://") {
+		return fmt.Errorf("use a hostname without scheme, path, or credentials")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return nil
+	}
+	if strings.Contains(host, ":") {
+		return fmt.Errorf("use a hostname without a port")
+	}
+	if len(host) > 253 {
+		return fmt.Errorf("hostname is too long")
+	}
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || len(label) > 63 || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return fmt.Errorf("invalid hostname label")
+		}
+		for _, r := range label {
+			if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' {
+				continue
+			}
+			return fmt.Errorf("hostname contains unsupported character %q", r)
 		}
 	}
 	return nil

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -25,7 +25,7 @@ func TestLoadCredentialsConfigDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadCredentialsConfig: %v", err)
 	}
-	want := CredentialsConfig{GitHub: CredentialsGitHubDeny}
+	want := CredentialsConfig{GitHub: CredentialsGitHubDeny, ModelGatewayAllowHosts: []string{DefaultModelGatewayHost}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("config = %#v, want %#v", got, want)
 	}
@@ -37,12 +37,14 @@ func TestLoadCredentialsConfigParsesSection(t *testing.T) {
 env_curation = true
 env_passthrough = ["GOCACHE", "NPM_*"]
 github = "inherit"
+model_gateway = true
+model_gateway_allow_hosts = ["api.anthropic.com", "localhost"]
 `)
 	got, err := LoadCredentialsConfig(paths)
 	if err != nil {
 		t.Fatalf("LoadCredentialsConfig: %v", err)
 	}
-	if !got.EnvCuration || got.GitHub != CredentialsGitHubInherit || !reflect.DeepEqual(got.EnvPassthrough, []string{"GOCACHE", "NPM_*"}) {
+	if !got.EnvCuration || got.GitHub != CredentialsGitHubInherit || !got.ModelGateway || !reflect.DeepEqual(got.EnvPassthrough, []string{"GOCACHE", "NPM_*"}) || !reflect.DeepEqual(got.ModelGatewayAllowHosts, []string{"api.anthropic.com", "localhost"}) {
 		t.Fatalf("unexpected config: %#v", got)
 	}
 }
@@ -58,6 +60,11 @@ func TestLoadCredentialsConfigRejectsInvalidValues(t *testing.T) {
 		{name: "nul", body: "env_passthrough = [\"A\\u0000B\"]", want: "must not contain"},
 		{name: "middle glob", body: "env_passthrough = [\"N*M\"]", want: "trailing '*'"},
 		{name: "multiple globs", body: "env_passthrough = [\"N**\"]", want: "trailing '*'"},
+		{name: "empty gateway allowlist", body: "model_gateway = true\nmodel_gateway_allow_hosts = []", want: "must not be empty"},
+		{name: "gateway scheme", body: "model_gateway_allow_hosts = [\"https://api.anthropic.com\"]", want: "without scheme"},
+		{name: "gateway port", body: "model_gateway_allow_hosts = [\"api.anthropic.com:443\"]", want: "without a port"},
+		{name: "gateway wildcard", body: "model_gateway_allow_hosts = [\"*.anthropic.com\"]", want: "unsupported character"},
+		{name: "gateway space", body: "model_gateway_allow_hosts = [\"api anthropic.com\"]", want: "unsupported character"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -76,7 +83,7 @@ func TestDefaultConfigCredentialsExampleRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	for _, line := range []string{"# [credentials]", "# env_curation = false", "# env_passthrough = []", "# github = \"deny\""} {
+	for _, line := range []string{"# [credentials]", "# env_curation = false", "# env_passthrough = []", "# github = \"deny\"", "# model_gateway = false", "# model_gateway_allow_hosts = [\"api.anthropic.com\"]"} {
 		if !strings.Contains(string(content), line) {
 			t.Fatalf("DefaultConfig missing %q", line)
 		}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -72,10 +72,14 @@ artifact_blobs = %q
 # subprocesses. env_passthrough accepts exact names or one trailing-* glob.
 # github=deny omits ambient GH_*/GITHUB_* values and gives gh a fresh empty config;
 # github=inherit explicitly restores ambient GitHub environment inheritance.
+# model_gateway is an opt-in daemon-owned loopback gateway for Claude credentials;
+# its allowlist contains exact upstream hostnames and defaults to Anthropic only.
 # [credentials]
 # env_curation = false
 # env_passthrough = [] # e.g. ["GOCACHE", "NPM_*"]
 # github = "deny"
+# model_gateway = false
+# model_gateway_allow_hosts = ["api.anthropic.com"]
 
 [parallel_sessions]
 same_session = "fork_temp_session"

--- a/internal/credgw/gateway.go
+++ b/internal/credgw/gateway.go
@@ -1,0 +1,349 @@
+package credgw
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const DefaultAnthropicUpstream = "https://api.anthropic.com"
+
+type CredentialKind string
+
+const (
+	CredentialBearer CredentialKind = "bearer"
+	CredentialAPIKey CredentialKind = "api_key"
+)
+
+type Credential struct {
+	Kind  CredentialKind
+	Value string
+}
+
+// Policy is snapshotted when a job lease is created. Upstream is fixed by the
+// host; AllowedHosts is an exact hostname allowlist, never child-controlled.
+type Policy struct {
+	Upstream     string
+	AllowedHosts []string
+}
+
+type LogFunc func(format string, args ...any)
+
+type Gateway struct {
+	listener net.Listener
+	server   *http.Server
+	client   *http.Client
+	logf     LogFunc
+
+	mu      sync.RWMutex
+	entries map[string]entry
+	closed  bool
+}
+
+type entry struct {
+	jobID      string
+	credential Credential
+	upstream   *url.URL
+	allowed    map[string]struct{}
+}
+
+func Start(logf LogFunc) (*Gateway, error) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("listen for model gateway: %w", err)
+	}
+	gateway := &Gateway{
+		listener: listener,
+		client: &http.Client{
+			Transport: http.DefaultTransport,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return errors.New("model gateway upstream redirects are disabled")
+			},
+		},
+		logf:    logf,
+		entries: make(map[string]entry),
+	}
+	gateway.server = &http.Server{
+		Handler:           gateway,
+		ErrorLog:          log.New(io.Discard, "", 0),
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       90 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
+	go func() {
+		_ = gateway.server.Serve(listener)
+	}()
+	return gateway, nil
+}
+
+func (g *Gateway) URL() string {
+	if g == nil || g.listener == nil {
+		return ""
+	}
+	return "http://" + g.listener.Addr().String()
+}
+
+func (g *Gateway) Register(jobID string, credential Credential, policy Policy) (string, error) {
+	if g == nil {
+		return "", errors.New("model gateway is not running")
+	}
+	if strings.TrimSpace(jobID) == "" {
+		return "", errors.New("model gateway job id is required")
+	}
+	if strings.TrimSpace(credential.Value) == "" {
+		return "", errors.New("model gateway credential is empty")
+	}
+	if credential.Kind != CredentialBearer && credential.Kind != CredentialAPIKey {
+		return "", fmt.Errorf("unsupported model gateway credential kind %q", credential.Kind)
+	}
+	upstream, allowed, err := validatePolicy(policy)
+	if err != nil {
+		return "", err
+	}
+	placeholder, err := mintPlaceholder(jobID)
+	if err != nil {
+		return "", err
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closed {
+		return "", errors.New("model gateway is not running")
+	}
+	g.entries[placeholder] = entry{
+		jobID:      jobID,
+		credential: credential,
+		upstream:   upstream,
+		allowed:    allowed,
+	}
+	return placeholder, nil
+}
+
+func (g *Gateway) Revoke(placeholder string) {
+	if g == nil || placeholder == "" {
+		return
+	}
+	g.mu.Lock()
+	delete(g.entries, placeholder)
+	g.mu.Unlock()
+}
+
+func (g *Gateway) Close(ctx context.Context) error {
+	if g == nil {
+		return nil
+	}
+	g.mu.Lock()
+	if g.closed {
+		g.mu.Unlock()
+		return nil
+	}
+	g.closed = true
+	clear(g.entries)
+	g.mu.Unlock()
+	return g.server.Shutdown(ctx)
+}
+
+func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	placeholder := requestPlaceholder(r)
+	g.mu.RLock()
+	registered, ok := g.entries[placeholder]
+	g.mu.RUnlock()
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		g.writeLog(r.Method, "", http.StatusUnauthorized, "")
+		return
+	}
+	if _, ok := registered.allowed[strings.ToLower(registered.upstream.Hostname())]; !ok {
+		http.Error(w, "upstream refused", http.StatusBadGateway)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadGateway, registered.jobID)
+		return
+	}
+
+	upstreamURL := *registered.upstream
+	upstreamURL.Path = joinURLPath(registered.upstream.Path, r.URL.Path)
+	upstreamURL.RawPath = ""
+	upstreamURL.RawQuery = r.URL.RawQuery
+	outbound := r.Clone(r.Context())
+	outbound.URL = &upstreamURL
+	outbound.Host = registered.upstream.Host
+	outbound.RequestURI = ""
+	outbound.Header = r.Header.Clone()
+	removeHopHeaders(outbound.Header)
+	outbound.Header.Del("Authorization")
+	outbound.Header.Del("X-Api-Key")
+	outbound.Header.Del("Proxy-Authorization")
+	switch registered.credential.Kind {
+	case CredentialAPIKey:
+		outbound.Header.Set("X-Api-Key", registered.credential.Value)
+	case CredentialBearer:
+		outbound.Header.Set("Authorization", "Bearer "+registered.credential.Value)
+	}
+
+	response, err := g.client.Do(outbound)
+	if err != nil {
+		http.Error(w, "upstream request failed", http.StatusBadGateway)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadGateway, registered.jobID)
+		return
+	}
+	defer response.Body.Close()
+	removeHopHeaders(response.Header)
+	copyHeader(w.Header(), response.Header)
+	w.WriteHeader(response.StatusCode)
+	streamResponse(w, response.Body)
+	g.writeLog(r.Method, registered.upstream.Hostname(), response.StatusCode, registered.jobID)
+}
+
+func validatePolicy(policy Policy) (*url.URL, map[string]struct{}, error) {
+	raw := strings.TrimSpace(policy.Upstream)
+	if raw == "" {
+		raw = DefaultAnthropicUpstream
+	}
+	upstream, err := url.Parse(raw)
+	if err != nil || (upstream.Scheme != "http" && upstream.Scheme != "https") || upstream.Hostname() == "" || upstream.User != nil || upstream.Opaque != "" || upstream.RawQuery != "" || upstream.Fragment != "" {
+		return nil, nil, fmt.Errorf("invalid model gateway upstream %q", raw)
+	}
+	allowed := make(map[string]struct{}, len(policy.AllowedHosts))
+	for _, host := range policy.AllowedHosts {
+		host = strings.ToLower(strings.TrimSpace(host))
+		if host != "" {
+			allowed[host] = struct{}{}
+		}
+	}
+	if _, ok := allowed[strings.ToLower(upstream.Hostname())]; !ok {
+		return nil, nil, fmt.Errorf("model gateway upstream host %q is not allowlisted", upstream.Hostname())
+	}
+	return upstream, allowed, nil
+}
+
+func mintPlaceholder(jobID string) (string, error) {
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("mint model gateway placeholder: %w", err)
+	}
+	cleanID := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, jobID)
+	return "gitmoot-kc-" + cleanID + "-" + hex.EncodeToString(random), nil
+}
+
+func requestPlaceholder(r *http.Request) string {
+	if value := strings.TrimSpace(r.Header.Get("X-Api-Key")); value != "" {
+		return value
+	}
+	authorization := strings.TrimSpace(r.Header.Get("Authorization"))
+	scheme, value, ok := strings.Cut(authorization, " ")
+	if ok && strings.EqualFold(strings.TrimSpace(scheme), "bearer") {
+		return strings.TrimSpace(value)
+	}
+	return ""
+}
+
+func joinURLPath(basePath, requestPath string) string {
+	if basePath == "" || basePath == "/" {
+		return requestPath
+	}
+	return strings.TrimRight(basePath, "/") + "/" + strings.TrimLeft(requestPath, "/")
+}
+
+func removeHopHeaders(header http.Header) {
+	for _, name := range strings.Split(header.Get("Connection"), ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			header.Del(name)
+		}
+	}
+	for _, name := range []string{"Connection", "Proxy-Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization", "Te", "Trailer", "Transfer-Encoding", "Upgrade"} {
+		header.Del(name)
+	}
+}
+
+func copyHeader(dst, src http.Header) {
+	for name, values := range src {
+		for _, value := range values {
+			dst.Add(name, value)
+		}
+	}
+}
+
+func streamResponse(w http.ResponseWriter, body io.Reader) {
+	controller := http.NewResponseController(w)
+	buffer := make([]byte, 32*1024)
+	for {
+		n, err := body.Read(buffer)
+		if n > 0 {
+			if _, writeErr := w.Write(buffer[:n]); writeErr != nil {
+				return
+			}
+			_ = controller.Flush()
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (g *Gateway) writeLog(method, host string, status int, jobID string) {
+	if g.logf != nil {
+		g.logf("model gateway request method=%s upstream_host=%s status=%d job_id=%s", method, host, status, jobID)
+	}
+}
+
+type Registry struct {
+	mu       sync.Mutex
+	gateways map[string]*Gateway
+}
+
+func NewRegistry() *Registry {
+	return &Registry{gateways: make(map[string]*Gateway)}
+}
+
+func (r *Registry) Gateway(home string, logf LogFunc) (*Gateway, error) {
+	if r == nil {
+		return nil, errors.New("model gateway registry is unavailable")
+	}
+	key, err := filepath.Abs(filepath.Clean(home))
+	if err != nil {
+		return nil, fmt.Errorf("resolve model gateway home: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing := r.gateways[key]; existing != nil {
+		return existing, nil
+	}
+	gateway, err := Start(logf)
+	if err != nil {
+		return nil, err
+	}
+	r.gateways[key] = gateway
+	return gateway, nil
+}
+
+func (r *Registry) CloseHome(ctx context.Context, home string) error {
+	if r == nil {
+		return nil
+	}
+	key, err := filepath.Abs(filepath.Clean(home))
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	gateway := r.gateways[key]
+	delete(r.gateways, key)
+	r.mu.Unlock()
+	if gateway == nil {
+		return nil
+	}
+	return gateway.Close(ctx)
+}

--- a/internal/credgw/gateway_test.go
+++ b/internal/credgw/gateway_test.go
@@ -1,0 +1,255 @@
+package credgw
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testRealCredential = "sk-ant-oat01-real-credential-abcdefghijklmnopqrstuvwxyz"
+	testRequestBody    = "request-body-must-not-be-logged"
+)
+
+func TestGatewayPlaceholderLifecycleAndCredentialCustody(t *testing.T) {
+	var upstreamAuthorization string
+	var upstreamAPIKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuthorization = r.Header.Get("Authorization")
+		upstreamAPIKey = r.Header.Get("X-Api-Key")
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	var logs strings.Builder
+	gateway, err := Start(func(format string, args ...any) { fmt.Fprintf(&logs, format, args...) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	if !strings.HasPrefix(gateway.URL(), "http://127.0.0.1:") {
+		t.Fatalf("gateway URL = %q", gateway.URL())
+	}
+
+	placeholder, err := gateway.Register("job-123", Credential{Kind: CredentialBearer, Value: testRealCredential}, testPolicy(t, upstream.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(placeholder, "gitmoot-kc-job-123-") || strings.Contains(placeholder, testRealCredential) {
+		t.Fatalf("placeholder format = %q", placeholder)
+	}
+
+	request, err := http.NewRequest(http.MethodPost, gateway.URL()+"/v1/messages", strings.NewReader(testRequestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+placeholder)
+	request.Header.Set("X-Api-Key", placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusCreated {
+		t.Fatalf("status = %d", response.StatusCode)
+	}
+	if upstreamAuthorization != "Bearer "+testRealCredential {
+		t.Fatalf("upstream Authorization = %q", upstreamAuthorization)
+	}
+	if upstreamAPIKey != "" {
+		t.Fatalf("placeholder reached upstream x-api-key = %q", upstreamAPIKey)
+	}
+
+	for name, token := range map[string]string{
+		"credential":  testRealCredential,
+		"placeholder": placeholder,
+		"header":      "Authorization",
+		"body":        testRequestBody,
+	} {
+		if strings.Contains(logs.String(), token) {
+			t.Fatalf("logs contain %s: %q", name, logs.String())
+		}
+	}
+	if !strings.Contains(logs.String(), "method=POST") || !strings.Contains(logs.String(), "status=201") || !strings.Contains(logs.String(), "job_id=job-123") {
+		t.Fatalf("safe request log = %q", logs.String())
+	}
+
+	gateway.Revoke(placeholder)
+	assertGatewayStatus(t, gateway.URL(), placeholder, http.StatusUnauthorized)
+	assertGatewayStatus(t, gateway.URL(), "gitmoot-kc-unknown", http.StatusUnauthorized)
+}
+
+func TestGatewayAttachesAPIKeyWithoutForwardingPlaceholder(t *testing.T) {
+	var gotAuthorization, gotAPIKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthorization = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("X-Api-Key")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	placeholder, err := gateway.Register("api-key-job", Credential{Kind: CredentialAPIKey, Value: testRealCredential}, testPolicy(t, upstream.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, _ := http.NewRequest(http.MethodPost, gateway.URL()+"/v1/messages", nil)
+	request.Header.Set("Authorization", "Bearer "+placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if gotAuthorization != "" || gotAPIKey != testRealCredential {
+		t.Fatalf("upstream auth = Authorization %q, X-Api-Key %q", gotAuthorization, gotAPIKey)
+	}
+}
+
+func TestGatewayStreamsFlushedChunks(t *testing.T) {
+	firstSent := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	defer func() {
+		select {
+		case <-releaseSecond:
+		default:
+			close(releaseSecond)
+		}
+	}()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: first\n\n")
+		w.(http.Flusher).Flush()
+		close(firstSent)
+		<-releaseSecond
+		_, _ = io.WriteString(w, "data: second\n\n")
+		w.(http.Flusher).Flush()
+	}))
+	defer upstream.Close()
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	placeholder, err := gateway.Register("stream-job", Credential{Kind: CredentialBearer, Value: testRealCredential}, testPolicy(t, upstream.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request, _ := http.NewRequest(http.MethodGet, gateway.URL()+"/v1/messages", nil)
+	request.Header.Set("Authorization", "Bearer "+placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	<-firstSent
+	line := make(chan string, 1)
+	go func() {
+		value, _ := bufio.NewReader(response.Body).ReadString('\n')
+		line <- value
+	}()
+	select {
+	case got := <-line:
+		if got != "data: first\n" {
+			t.Fatalf("first chunk = %q", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first SSE chunk was buffered behind the second")
+	}
+	close(releaseSecond)
+}
+
+func TestGatewayRejectsUnallowlistedUpstream(t *testing.T) {
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	_, err = gateway.Register("blocked-job", Credential{Kind: CredentialBearer, Value: testRealCredential}, Policy{
+		Upstream:     "https://api.anthropic.com",
+		AllowedHosts: []string{"example.com"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not allowlisted") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestGatewayClosedFailsLeaseRegistration(t *testing.T) {
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := gateway.Close(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	_, err = gateway.Register("closed-job", Credential{Kind: CredentialBearer, Value: testRealCredential}, Policy{
+		Upstream:     DefaultAnthropicUpstream,
+		AllowedHosts: []string{"api.anthropic.com"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRegistryUsesOneGatewayPerHome(t *testing.T) {
+	registry := NewRegistry()
+	home := t.TempDir()
+	first, err := registry.Gateway(home, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := registry.Gateway(home, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatal("same home received different model gateways")
+	}
+	other, err := registry.Gateway(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == other {
+		t.Fatal("different homes shared a model gateway")
+	}
+	defer other.Close(context.Background())
+	if err := registry.CloseHome(context.Background(), home); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertGatewayStatus(t *testing.T, gatewayURL, placeholder string, want int) {
+	t.Helper()
+	request, _ := http.NewRequest(http.MethodPost, gatewayURL+"/v1/messages", bytes.NewReader(nil))
+	request.Header.Set("Authorization", "Bearer "+placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != want {
+		t.Fatalf("status = %d, want %d", response.StatusCode, want)
+	}
+}
+
+func testPolicy(t *testing.T, upstream string) Policy {
+	t.Helper()
+	parsed, err := url.Parse(upstream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Policy{Upstream: upstream, AllowedHosts: []string{parsed.Hostname()}}
+}

--- a/internal/credgw/gateway_test.go
+++ b/internal/credgw/gateway_test.go
@@ -39,6 +39,23 @@ func (s *logSink) String() string {
 	return s.lines.String()
 }
 
+// waitFor blocks until the logs contain substr and returns everything logged so
+// far, so assertions never race the goroutine that writes the entry.
+func (s *logSink) waitFor(t *testing.T, substr string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		logged := s.String()
+		if strings.Contains(logged, substr) {
+			return logged
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("logs never contained %q: %q", substr, logged)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestGatewayPlaceholderLifecycleAndCredentialCustody(t *testing.T) {
 	var upstreamAuthorization string
 	var upstreamAPIKey string
@@ -90,18 +107,21 @@ func TestGatewayPlaceholderLifecycleAndCredentialCustody(t *testing.T) {
 		t.Fatalf("placeholder reached upstream x-api-key = %q", upstreamAPIKey)
 	}
 
+	// The gateway logs the request after the response is proxied back, so the
+	// client returning does not mean the log line exists yet.
+	entry := logs.waitFor(t, "job_id=job-123")
+	if !strings.Contains(entry, "method=POST") || !strings.Contains(entry, "status=201") {
+		t.Fatalf("safe request log = %q", entry)
+	}
 	for name, token := range map[string]string{
 		"credential":  testRealCredential,
 		"placeholder": placeholder,
 		"header":      "Authorization",
 		"body":        testRequestBody,
 	} {
-		if strings.Contains(logs.String(), token) {
-			t.Fatalf("logs contain %s: %q", name, logs.String())
+		if strings.Contains(entry, token) {
+			t.Fatalf("logs contain %s: %q", name, entry)
 		}
-	}
-	if !strings.Contains(logs.String(), "method=POST") || !strings.Contains(logs.String(), "status=201") || !strings.Contains(logs.String(), "job_id=job-123") {
-		t.Fatalf("safe request log = %q", logs.String())
 	}
 
 	gateway.Revoke(placeholder)

--- a/internal/credgw/gateway_test.go
+++ b/internal/credgw/gateway_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -18,6 +19,25 @@ const (
 	testRealCredential = "sk-ant-oat01-real-credential-abcdefghijklmnopqrstuvwxyz"
 	testRequestBody    = "request-body-must-not-be-logged"
 )
+
+// logSink collects gateway logs. The gateway logs from its request goroutines,
+// so reads from the test goroutine must be synchronized.
+type logSink struct {
+	mu    sync.Mutex
+	lines strings.Builder
+}
+
+func (s *logSink) Logf(format string, args ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	fmt.Fprintf(&s.lines, format, args...)
+}
+
+func (s *logSink) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lines.String()
+}
 
 func TestGatewayPlaceholderLifecycleAndCredentialCustody(t *testing.T) {
 	var upstreamAuthorization string
@@ -31,8 +51,8 @@ func TestGatewayPlaceholderLifecycleAndCredentialCustody(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	var logs strings.Builder
-	gateway, err := Start(func(format string, args ...any) { fmt.Fprintf(&logs, format, args...) })
+	var logs logSink
+	gateway, err := Start(logs.Logf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/credgw/runner.go
+++ b/internal/credgw/runner.go
@@ -1,0 +1,119 @@
+package credgw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+const anthropicBaseURLEnv = "ANTHROPIC_BASE_URL"
+
+type Lease struct {
+	gateway     *Gateway
+	placeholder string
+}
+
+func (l *Lease) Placeholder() string {
+	if l == nil {
+		return ""
+	}
+	return l.placeholder
+}
+
+func (l *Lease) Revoke() {
+	if l != nil && l.gateway != nil {
+		l.gateway.Revoke(l.placeholder)
+	}
+}
+
+type leaseContextKey struct{}
+
+type leaseContextValue struct {
+	gateway     *Gateway
+	placeholder string
+}
+
+func WithLease(ctx context.Context, lease *Lease) context.Context {
+	if lease == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, leaseContextKey{}, leaseContextValue{
+		gateway:     lease.gateway,
+		placeholder: lease.placeholder,
+	})
+}
+
+// Runner injects only the loopback route and per-job placeholder. The real
+// credential remains in the gateway's in-memory lease entry.
+type Runner struct {
+	Inner      subprocess.Runner
+	Gateway    *Gateway
+	Credential Credential
+	Policy     Policy
+}
+
+func (r *Runner) NewLease(jobID string) (*Lease, error) {
+	if r == nil || r.Gateway == nil {
+		return nil, errors.New("model gateway is not running")
+	}
+	placeholder, err := r.Gateway.Register(jobID, r.Credential, r.Policy)
+	if err != nil {
+		return nil, err
+	}
+	return &Lease{gateway: r.Gateway, placeholder: placeholder}, nil
+}
+
+func (r *Runner) Run(ctx context.Context, dir string, command string, args ...string) (subprocess.Result, error) {
+	return r.runEnv(ctx, dir, nil, command, args...)
+}
+
+func (r *Runner) RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (subprocess.Result, error) {
+	return r.runEnv(ctx, dir, env, command, args...)
+}
+
+func (r *Runner) LookPath(file string) (string, error) {
+	return r.inner().LookPath(file)
+}
+
+func (r *Runner) runEnv(ctx context.Context, dir string, env []string, command string, args ...string) (subprocess.Result, error) {
+	placeholder, cleanup, err := r.placeholderForContext(ctx)
+	if err != nil {
+		return subprocess.Result{}, err
+	}
+	defer cleanup()
+	gatewayEnv := []string{
+		"CLAUDE_CODE_OAUTH_TOKEN=" + placeholder,
+		"ANTHROPIC_API_KEY=",
+		"ANTHROPIC_AUTH_TOKEN=",
+		anthropicBaseURLEnv + "=" + r.Gateway.URL(),
+	}
+	merged := append(append([]string{}, env...), gatewayEnv...)
+	inner, ok := r.inner().(subprocess.EnvRunner)
+	if !ok {
+		return subprocess.Result{}, errors.New("model gateway runner requires environment injection support")
+	}
+	return inner.RunEnv(ctx, dir, merged, command, args...)
+}
+
+func (r *Runner) placeholderForContext(ctx context.Context) (string, func(), error) {
+	if value, ok := ctx.Value(leaseContextKey{}).(leaseContextValue); ok {
+		if value.gateway != r.Gateway || value.placeholder == "" {
+			return "", func() {}, errors.New("model gateway lease does not match runner")
+		}
+		return value.placeholder, func() {}, nil
+	}
+	lease, err := r.NewLease("runtime-call")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("mint model gateway runtime lease: %w", err)
+	}
+	return lease.Placeholder(), lease.Revoke, nil
+}
+
+func (r *Runner) inner() subprocess.Runner {
+	if r.Inner != nil {
+		return r.Inner
+	}
+	return subprocess.GroupRunner{}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -149,7 +149,16 @@ Runtime-child environment curation is off by default. Enable it in
 env_curation = true
 env_passthrough = ["GOCACHE", "NPM_*"]
 github = "deny"
+model_gateway = false
+model_gateway_allow_hosts = ["api.anthropic.com"]
 ```
+
+Set `model_gateway = true` to opt Claude into the daemon-owned loopback model
+gateway. Each delivery receives a random job-scoped placeholder and
+`ANTHROPIC_BASE_URL`; only the gateway holds the snapshotted real credential and
+it forwards only to an exact allowlisted hostname. Gateway startup, credential,
+and allowlist failures are fail-closed. The option is off by default and does
+not change Codex or Kimi.
 
 With `env_curation = false`, runtime subprocesses inherit the full foreground or
 daemon environment exactly as before. With it enabled, the base allowlist is:
@@ -178,11 +187,12 @@ With curation enabled, `github = "deny"` is the default. All ambient `GH_*` and
 cancellation. `github = "inherit"` is the explicit opt-out: ambient `GH_*` and
 `GITHUB_*` variables pass through and Gitmoot adds neither GitHub variable.
 
-This is ambient credential hygiene/denial, not egress confinement or a proxy.
-There are no placeholder tokens or proxy changes. Credential files visible on
-disk remain readable under the current Landlock read-only `/` policy; SSH keys,
-SSH agents, credential helpers, and direct network access are untouched. Proxy
-enforcement is P2 and narrower Landlock read rules are P3.
+Two limits apply: env-var routing is cooperative, not a hard egress boundary —
+a malicious agent can unset it; this buys credential custody/policy/attribution,
+not enforcement. The strong "agents never hold real credentials" claim also
+requires Landlock read-rules for `runtime-auth.env` (same-UID read is currently
+possible) — that is P3. Codex/Kimi custody and hard egress enforcement also
+remain P3.
 
 ## Runtime Launch Sandbox
 

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -124,6 +124,15 @@ cannot resurrect a legacy or ambient token. When one managed variable is
 selected, Gitmoot injects all three Claude auth names and blanks the absent
 ones, preventing ambient API-key precedence from changing the selection.
 
+An opt-in `[credentials] model_gateway = true` routes Claude through a
+daemon-owned `127.0.0.1` reverse model gateway. Each delivery gets a random,
+job-scoped placeholder; the daemon snapshots the real `runtime-auth.env`
+credential, attaches it only on the allowlisted upstream request, and revokes
+the placeholder when delivery returns. Unknown/revoked placeholders fail with
+`401`, and an unavailable gateway or unallowlisted upstream fails the delivery
+without direct-auth fallback. It is off by default and does not cover Codex or
+Kimi.
+
 ### Runtime ambient credential hygiene
 
 The optional `[credentials] env_curation = true` policy curates only runtime
@@ -133,11 +142,17 @@ disables interactive prompts. `github = "inherit"` explicitly restores ambient
 GitHub environment inheritance. See `CLI.md` for the exact base allowlist,
 runtime exceptions, and `env_passthrough` syntax.
 
-This is ambient credential hygiene/denial, not egress confinement or a proxy.
-It does not add placeholder tokens, alter proxy settings, hide credential files
-that remain readable from disk under Landlock's read-only `/`, disable SSH keys
-or agents, bypass Git credential helpers, or block direct network access. Those
-controls belong to the P2 proxy and P3 Landlock read-rule follow-ups.
+The gateway has two explicit limits:
+
+1. env-var routing is cooperative, not a hard egress boundary — a malicious
+   agent can unset it; this buys credential custody/policy/attribution, not
+   enforcement.
+2. The strong "agents never hold real credentials" claim also requires
+   Landlock read-rules for `runtime-auth.env` (same-UID read is currently
+   possible) — that is P3.
+
+Codex/Kimi custody, Landlock read rules, MITM CA support, corporate
+proxy/`NO_PROXY` interoperability, and hard egress enforcement remain P3.
 
 ## Pipeline Stages Run With Daemon Permissions
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -251,6 +251,26 @@ the absent ones so an ambient API key cannot override OAuth. Unset writes an
 explicit-empty file; do not delete it, because a missing file can trigger the
 one-time legacy/environment bootstrap.
 
+Opt Claude into the daemon-owned credential-terminating loopback gateway with:
+
+```toml
+[credentials]
+model_gateway = true
+model_gateway_allow_hosts = ["api.anthropic.com"]
+```
+
+Each delivery receives a job-scoped placeholder and `ANTHROPIC_BASE_URL`; the
+gateway holds the snapshotted real credential, forwards only to an allowlisted
+host, streams the response, and revokes the placeholder when delivery ends.
+Failures are fail-closed. The option is off by default and does not cover Codex
+or Kimi.
+
+env-var routing is cooperative, not a hard egress boundary — a malicious agent
+can unset it; this buys credential custody/policy/attribution, not enforcement.
+The strong "agents never hold real credentials" claim also requires Landlock
+read-rules for `runtime-auth.env` (same-UID read is currently possible) — that
+is P3.
+
 ### GitHub Poll Budget And Idle Cadence
 
 `[github].conditional_requests` defaults to `true`. The daemon sends ETag

--- a/website/docs/reference/credentials.md
+++ b/website/docs/reference/credentials.md
@@ -9,6 +9,8 @@ and shell runtime adapters in foreground and daemon-worker delivery paths.
 env_curation = true
 env_passthrough = ["GOCACHE", "NPM_*"]
 github = "deny"
+model_gateway = false
+model_gateway_allow_hosts = ["api.anthropic.com"]
 ```
 
 `env_curation = false` preserves the historical behavior: runtime commands
@@ -35,6 +37,25 @@ missing, Gitmoot imports legacy `daemon-runtime.env` once, or otherwise seeds
 from ambient managed variables once. Existing files are never overwritten.
 For systemd deployments, keep `daemon.env` for operational values such as
 `PATH`; do not duplicate Claude secrets there after bootstrap.
+
+## Claude model gateway
+
+`model_gateway = true` opts Claude deliveries into a daemon-owned loopback
+model gateway. The gateway listens only on an OS-assigned `127.0.0.1` port. For
+each job, Gitmoot snapshots the selected real credential into daemon memory,
+mints a random `gitmoot-kc-...` placeholder, and gives the Claude child only
+that placeholder plus `ANTHROPIC_BASE_URL` pointing at the loopback listener.
+The gateway authenticates the placeholder, replaces it with the real upstream
+credential, streams the response, and revokes the placeholder when delivery
+ends. Unknown and revoked placeholders receive `401`.
+
+The feature is off by default and currently covers Claude only. A populated
+`runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery
+instead of falling back to ambient auth, Claude's credential store, or direct
+upstream egress. `model_gateway_allow_hosts` is an exact hostname allowlist and
+defaults to `api.anthropic.com`. The upstream is fixed by Gitmoot, not selected
+by the child. Credentials are read once when the adapter is built, never once
+per proxied request, so rotation applies to the next adapter/job.
 
 ## Curated environment
 
@@ -83,9 +104,16 @@ disable prompts.
 
 ## Limits
 
-This is ambient credential hygiene and denial, not egress confinement and not a
-network proxy. It creates no placeholder tokens and changes no proxy settings.
-Runtime sandboxes can still read credential files that are visible on disk;
-the current Linux Landlock policy includes read-only `/`. SSH keys, SSH agents,
-Git credential helpers, and direct network access are also untouched. Network
-proxy enforcement is P2, and narrower Landlock read rules are P3.
+The model gateway is credential custody, policy, and attribution, not a hard
+egress boundary. These two limits are deliberate:
+
+1. env-var routing is cooperative, not a hard egress boundary — a malicious
+   agent can unset it; this buys credential custody/policy/attribution, not
+   enforcement.
+2. The strong "agents never hold real credentials" claim also requires
+   Landlock read-rules for `runtime-auth.env` (same-UID read is currently
+   possible) — that is P3.
+
+Codex/Kimi custody, MITM CA support, corporate proxy/`NO_PROXY` interoperability,
+Landlock read restrictions, and hard egress enforcement remain P3. SSH keys,
+SSH agents, Git credential helpers, and direct network access are untouched.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -9326,7 +9326,16 @@ Runtime-child environment curation is off by default. Enable it in
 env_curation = true
 env_passthrough = ["GOCACHE", "NPM_*"]
 github = "deny"
+model_gateway = false
+model_gateway_allow_hosts = ["api.anthropic.com"]
 ```
+
+Set `model_gateway = true` to opt Claude into the daemon-owned loopback model
+gateway. Each delivery receives a random job-scoped placeholder and
+`ANTHROPIC_BASE_URL`; only the gateway holds the snapshotted real credential and
+it forwards only to an exact allowlisted hostname. Gateway startup, credential,
+and allowlist failures are fail-closed. The option is off by default and does
+not change Codex or Kimi.
 
 With `env_curation = false`, runtime subprocesses inherit the full foreground or
 daemon environment exactly as before. With it enabled, the base allowlist is:
@@ -9355,11 +9364,12 @@ With curation enabled, `github = "deny"` is the default. All ambient `GH_*` and
 cancellation. `github = "inherit"` is the explicit opt-out: ambient `GH_*` and
 `GITHUB_*` variables pass through and Gitmoot adds neither GitHub variable.
 
-This is ambient credential hygiene/denial, not egress confinement or a proxy.
-There are no placeholder tokens or proxy changes. Credential files visible on
-disk remain readable under the current Landlock read-only `/` policy; SSH keys,
-SSH agents, credential helpers, and direct network access are untouched. Proxy
-enforcement is P2 and narrower Landlock read rules are P3.
+Two limits apply: env-var routing is cooperative, not a hard egress boundary —
+a malicious agent can unset it; this buys credential custody/policy/attribution,
+not enforcement. The strong "agents never hold real credentials" claim also
+requires Landlock read-rules for `runtime-auth.env` (same-UID read is currently
+possible) — that is P3. Codex/Kimi custody and hard egress enforcement also
+remain P3.
 
 ## Runtime Launch Sandbox
 
@@ -13776,6 +13786,15 @@ cannot resurrect a legacy or ambient token. When one managed variable is
 selected, Gitmoot injects all three Claude auth names and blanks the absent
 ones, preventing ambient API-key precedence from changing the selection.
 
+An opt-in `[credentials] model_gateway = true` routes Claude through a
+daemon-owned `127.0.0.1` reverse model gateway. Each delivery gets a random,
+job-scoped placeholder; the daemon snapshots the real `runtime-auth.env`
+credential, attaches it only on the allowlisted upstream request, and revokes
+the placeholder when delivery returns. Unknown/revoked placeholders fail with
+`401`, and an unavailable gateway or unallowlisted upstream fails the delivery
+without direct-auth fallback. It is off by default and does not cover Codex or
+Kimi.
+
 ### Runtime ambient credential hygiene
 
 The optional `[credentials] env_curation = true` policy curates only runtime
@@ -13785,11 +13804,17 @@ disables interactive prompts. `github = "inherit"` explicitly restores ambient
 GitHub environment inheritance. See `CLI.md` for the exact base allowlist,
 runtime exceptions, and `env_passthrough` syntax.
 
-This is ambient credential hygiene/denial, not egress confinement or a proxy.
-It does not add placeholder tokens, alter proxy settings, hide credential files
-that remain readable from disk under Landlock's read-only `/`, disable SSH keys
-or agents, bypass Git credential helpers, or block direct network access. Those
-controls belong to the P2 proxy and P3 Landlock read-rule follow-ups.
+The gateway has two explicit limits:
+
+1. env-var routing is cooperative, not a hard egress boundary — a malicious
+   agent can unset it; this buys credential custody/policy/attribution, not
+   enforcement.
+2. The strong "agents never hold real credentials" claim also requires
+   Landlock read-rules for `runtime-auth.env` (same-UID read is currently
+   possible) — that is P3.
+
+Codex/Kimi custody, Landlock read rules, MITM CA support, corporate
+proxy/`NO_PROXY` interoperability, and hard egress enforcement remain P3.
 
 ## Pipeline Stages Run With Daemon Permissions
 


### PR DESCRIPTION
## Summary

**P2 of #874** — agents no longer hold the real Anthropic credential. Design frozen by a tri-model panel (see the synthesis comment on #874): the panel **rejected both RFC options** after probing the live runtimes, and chose a **credential-terminating loopback model gateway** instead — full keycard custody with **no MITM CA**.

- **New `internal/credgw`**: a daemon/foreground-owned loopback gateway (one per home). Per-job **placeholder** leases (`Start`/`Deliver` revoke on return, including after claude's internal retries). The gateway snapshots the real credential per job, strips inbound auth, attaches the real bearer/API key **only** to an allowlisted upstream, blocks redirects, and logs only method/host/status/job-id.
- **Injection** at the #910 seam (`runtimeJobRunnerWithAuth`): an enabled claude child gets `CLAUDE_CODE_OAUTH_TOKEN=<placeholder>`, blanked API/auth vars, and `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`. Disabled → today's behavior, byte-identical.
- **Fail-closed everywhere**: unknown/revoked placeholder → 401; missing credential, stopped gateway, or non-allowlisted upstream → refuse, never fall back to raw egress or to injecting the real token.
- **Streaming preserved**: manual copy loop with `http.ResponseController.Flush` per chunk (claude streams — buffering would break it).
- **Config**: `[credentials] model_gateway = false` (opt-in) + `model_gateway_allow_hosts = ["api.anthropic.com"]`.

### Honest limits (stated verbatim in the docs, per the panel)

1. Proxy/base-URL env routing is **cooperative, not a hard egress boundary** — a malicious agent can unset it. This buys credential **custody, policy, and attribution**, not enforcement.
2. The strong "agents never hold real credentials" claim additionally requires **Landlock read-rules** for `runtime-auth.env` (a same-UID agent can read the 0600 file today) — that is **P3**.

Codex/Kimi custody, Landlock read-rules, MITM fallback, and corporate-proxy interop remain P3.

## Tests

`internal/credgw`: placeholder lifecycle + credential custody, API-key attachment without placeholder forwarding, flushed streaming, unallowlisted-upstream rejection, closed-gateway lease failure, one-gateway-per-home registry.

**E2E (no LLM): `TestClaudeModelGatewayCredentialCustodyE2E`** — a fake `claude` child on PATH makes a real HTTP call through the live loopback gateway to an `httptest` upstream. Asserted: the child sent the **placeholder**, the upstream received the **real** token, the job succeeded, and the real credential appears in **neither** the child env dump **nor** the logs.

Gates: `go generate` clean, build/vet green, `go test ./internal/credgw/ ./internal/cli/ ./internal/config/ ./internal/runtime/ ./internal/daemon/` all ok. Docs + `llms-full.txt` regenerated in-PR.

Part of the `gitmoot4/p1p2-wave` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)