### PR TITLE
docs(agents): deploy recipe — update both binaries, stamp the version, probe behavior not version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,10 @@ portable code behavior.
   never re-execs (it preserves inherited runtime auth — the #559 lesson).
 - Public read-only dashboard: <https://gitmoot.themartian.app> (a separate
   `gitmoot-dashboard-web` systemd service behind traefik). Docs site: gitmoot.io.
+  That service runs its **own copy of the binary** at
+  `/root/.local/bin/gitmoot-dashboard-web` (`ExecStart=… dashboard --web --addr
+  172.17.0.1:8790`), so replacing `/root/.local/bin/gitmoot` alone leaves the
+  public dashboard on the old build — see the deploy recipe.
 
 ## Hard rules (footguns)
 
@@ -163,14 +167,33 @@ pattern), bounded by depth, a per-root job budget, and loop detection.
 
 ## Deploy recipe (this host)
 
-1. On `main` after merge, build with the pinned toolchain (above).
+1. On `main` after merge, build with the pinned toolchain (above). Stamp the
+   version the way `release.yml` does, or `gitmoot version` reports
+   `commit: unknown`:
+
+   ```sh
+   PKG=github.com/jerryfane/gitmoot/internal/buildinfo
+   CGO_ENABLED=0 go build -trimpath -ldflags \
+     "-s -w -X $PKG.Version=dev-$(git rev-parse --short HEAD) \
+      -X $PKG.Commit=$(git rev-parse HEAD) -X $PKG.Date=$(date -Iseconds)" \
+     -o /root/.local/bin/gitmoot.new ./cmd/gitmoot
+   ```
+
 2. `mv`-rename the new binary into `/root/.local/bin/gitmoot` (same filesystem;
    the rename avoids `ETXTBSY`).
-3. Restart the daemon at idle: `systemctl --user restart gitmoot-daemon`
-   (confirm 0 running jobs first).
-4. Config-only changes (e.g. `[memory]`/`[skillopt]`) usually need no restart
+3. **Two services run two binaries.** The public dashboard has its own copy, so
+   a deploy that touches only `gitmoot` silently leaves the dashboard stale:
+
+   ```sh
+   cp /root/.local/bin/gitmoot /root/.local/bin/gitmoot-dashboard-web.new
+   mv /root/.local/bin/gitmoot-dashboard-web.new /root/.local/bin/gitmoot-dashboard-web
+   ```
+
+4. Restart at idle (confirm 0 running/queued jobs first):
+   `systemctl --user restart gitmoot-daemon gitmoot-dashboard-web`.
+5. Config-only changes (e.g. `[memory]`/`[skillopt]`) usually need no restart
    (re-read per tick / warm-reloaded on SIGHUP).
-5. **Public releases need explicit OWNER sign-off** —
+6. **Public releases need explicit OWNER sign-off** —
    `gh release create vX.Y.Z --latest` triggers `release.yml`. "Deploy locally"
    is not "cut a release".
 
@@ -179,6 +202,11 @@ pattern), bounded by depth, a per-root job budget, and loop detection.
 Prove a deploy: `gitmoot version` (commit/build), `gitmoot daemon status`,
 `gitmoot doctor`. For engine features, a `shell`-runtime E2E on an isolated
 `/tmp` home is the no-LLM smoke test.
+
+`gitmoot version` only proves the binary **you** invoked, not what the services
+run. Probe the deployed behavior instead: `/root/.local/bin/gitmoot-dashboard-web
+version` for the dashboard service, and hit its API for a field the new build
+changed (e.g. `curl -s http://172.17.0.1:8790/api/workflows`).
 
 ## Work strategy (lead-engineer)
 


### PR DESCRIPTION
Hit while deploying the P1/P2 wave to this box.

## What was wrong

The deploy recipe says "`mv`-rename the new binary into `/root/.local/bin/gitmoot`, restart the daemon". But the public dashboard is a **second systemd service running a second copy of the binary**:

```
ExecStart=/root/.local/bin/gitmoot-dashboard-web dashboard --web --addr 172.17.0.1:8790
```

So the documented recipe deploys half the box. Concretely: after following it, `gitmoot version` reported the new build and `gitmoot daemon status` was healthy, while <https://gitmoot.themartian.app> still served the old build — `/api/workflows` returned workflows in state `active` with `running=0, queued=0`, which the new #918 classifier cannot produce. Refreshing `gitmoot-dashboard-web` and restarting it flipped them to `recent`, as designed.

A plain `go build` also leaves the version unstamped (`gitmoot version` → `commit: unknown`), because the ldflags live only in `release.yml`.

## Changes (AGENTS.md only)

- Runtime map: record that `gitmoot-dashboard-web` runs its own binary copy.
- Deploy recipe: add the ldflags stamping command, add the step that refreshes the dashboard binary, and restart both services in one `systemctl --user restart`.
- Live-probe: state plainly that `gitmoot version` proves only the binary you invoked — probe the deployed *behavior* (the service binary’s own `version`, plus its API) instead.

Docs-only; no code paths touched.