### PR TITLE
feat(daemon): surface build skew — a running daemon silently serving old code (#932)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,6 +3,48 @@
 Use `gitmoot doctor --repo .` first. It checks local prerequisites from the
 repository checkout.
 
+## The Daemon Is Running An Old Build
+
+Symptoms:
+
+- You upgraded gitmoot (or rebuilt it) and the fix did not take effect.
+- Jobs still behave like the previous version; new flags are ignored.
+- `gitmoot version` shows the new build, so everything *looks* current.
+
+Cause: the daemon is a long-lived process. Replacing the binary on disk does not
+change the code an already-running daemon executes — it keeps running the build
+it started from until it is restarted. `gitmoot version` reports the binary
+**you** invoked, not the one the daemon is running, so it cannot tell you this.
+
+Check:
+
+```sh
+gitmoot daemon status   # prints "build: <version>" and warns on skew
+gitmoot doctor          # non-fatal "build" check, same comparison
+```
+
+A skew reads:
+
+```
+WARNING: daemon running dev-cd43a49 (cd43a495); /usr/local/bin/gitmoot is dev-56ba1c7 (56ba1c74) — restart the daemon to pick it up
+```
+
+Fix: restart the daemon (when it is idle — confirm no running jobs first). If it
+runs under systemd, use your service manager rather than `gitmoot daemon restart`.
+
+Notes:
+
+- The comparison is between the daemon **process** and the binary at the
+  **daemon's own path** — the one a restart would load. It is not about the binary
+  you happen to be invoking, which may be a different one entirely.
+- The comparison is only made when both builds are identifiable, and an unknown is
+  never reported as skew *or* as agreement — it reports "comparison skipped". A
+  daemon started by an older gitmoot recorded no build; and two unstamped builds
+  with no VCS commit are both just `dev`, so comparing them would prove nothing.
+- If you run the web dashboard as a **separate service**, it is its own process
+  with its own build. `/api/health` reports the serving process's build separately
+  from the daemon's, so restart both after an upgrade.
+
 ## `gh`
 
 Symptoms:

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,11 +1,22 @@
 package buildinfo
 
-import "runtime"
+import (
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
 
+// Ldflags-injected by release.yml (and by the documented local deploy recipe).
+// A plain `go build` leaves them at these defaults.
 var (
 	Version = "dev"
 	Commit  = "unknown"
 	Date    = "unknown"
+)
+
+const (
+	defaultVersion = "dev"
+	unknownValue   = "unknown"
 )
 
 type Info struct {
@@ -15,11 +26,73 @@ type Info struct {
 	Go      string `json:"go"`
 }
 
+// Identifiable reports whether this build can be told apart from another build.
+// A release (or any ldflags-stamped binary) always can. An unstamped binary can
+// only when Go's VCS stamping supplied a revision: without one, every unstamped
+// build is the same anonymous "dev", and comparing two of them says nothing.
+//
+// Callers that compare builds (the daemon build-skew check) must treat an
+// unidentifiable build as UNKNOWN — never as equal, never as skewed.
+func (i Info) Identifiable() bool {
+	if i.Version == "" || i.Version == unknownValue {
+		return false
+	}
+	if i.Version != defaultVersion {
+		return true
+	}
+	return i.Commit != "" && i.Commit != unknownValue
+}
+
+var (
+	vcsOnce  sync.Once
+	vcsRev   string
+	vcsTime  string
+	vcsDirty bool
+)
+
+// readVCS recovers the revision Go stamps into binaries built from a VCS tree
+// (-buildvcs=auto, the default). It is what lets an unstamped `go build` still
+// be told apart from another unstamped build; without it Commit stays "unknown"
+// and no comparison is possible.
+func readVCS() {
+	vcsOnce.Do(func() {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return
+		}
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				vcsRev = setting.Value
+			case "vcs.time":
+				vcsTime = setting.Value
+			case "vcs.modified":
+				vcsDirty = setting.Value == "true"
+			}
+		}
+	})
+}
+
 func Current() Info {
-	return Info{
+	readVCS()
+	info := Info{
 		Version: Version,
 		Commit:  Commit,
 		Date:    Date,
 		Go:      runtime.Version(),
 	}
+	if unset(info.Commit) && vcsRev != "" {
+		info.Commit = vcsRev
+		if vcsDirty {
+			info.Commit += "-dirty"
+		}
+	}
+	if unset(info.Date) && vcsTime != "" {
+		info.Date = vcsTime
+	}
+	return info
+}
+
+func unset(value string) bool {
+	return value == "" || value == unknownValue
 }

--- a/internal/cli/build_skew.go
+++ b/internal/cli/build_skew.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/doctor"
+)
+
+// daemonBuildStatus answers the only build question an operator can act on: is
+// the running daemon executing the binary that is on disk right now?
+//
+// It compares the build the daemon RECORDED at startup (what the process is
+// actually running) against the build of the binary now at the daemon's
+// executable path (what a restart would load). The build of the binary invoking
+// this command is deliberately not part of the comparison — you may be running
+// `doctor` from a binary that is not the daemon's at all, and warning about that
+// would be noise, not signal.
+func daemonBuildStatus(paths config.Paths) doctor.BuildStatus {
+	var status doctor.BuildStatus
+	// DefaultPaths is best-effort at the call sites (a missing HOME yields zero
+	// Paths). daemonProcessState would then resolve daemon.pid/daemon.json
+	// RELATIVE to the cwd — and currentDaemonPID removes a pidfile it cannot
+	// parse — so refuse rather than touch a stranger's files.
+	if strings.TrimSpace(paths.Home) == "" {
+		return status
+	}
+	state := daemonProcessState(paths)
+	pid, _, err := currentDaemonPID(state)
+	if err != nil || pid <= 0 {
+		return status
+	}
+	status.DaemonRunning = true
+
+	meta, err := readDaemonMeta(state)
+	if err != nil {
+		return status
+	}
+	status.Daemon = doctor.BuildInfoFromValues(meta.Version, meta.Commit)
+	status.OnDiskPath = strings.TrimSpace(meta.Executable)
+	if status.OnDiskPath == "" {
+		return status
+	}
+	version, commit := execBinaryBuildFn(context.Background(), status.OnDiskPath)
+	status.OnDisk = doctor.BuildInfoFromValues(version, commit)
+	return status
+}
+
+func daemonBuildCheck(paths config.Paths) doctor.Check {
+	return doctor.CheckBuild(daemonBuildStatus(paths))
+}
+
+// daemonBuildLabel names the build the daemon PROCESS is running, for `daemon
+// status`. A daemon started by an older gitmoot recorded none.
+func daemonBuildLabel(meta daemonMeta) string {
+	version := strings.TrimSpace(meta.Version)
+	if version == "" {
+		return "unknown"
+	}
+	if commit := strings.TrimSpace(meta.Commit); commit != "" && !strings.EqualFold(commit, "unknown") {
+		if len(commit) > 8 {
+			commit = commit[:8]
+		}
+		return version + " (" + commit + ")"
+	}
+	return version
+}

--- a/internal/cli/build_skew_test.go
+++ b/internal/cli/build_skew_test.go
@@ -1,0 +1,293 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
+	"github.com/jerryfane/gitmoot/internal/config"
+	"github.com/jerryfane/gitmoot/internal/update"
+)
+
+// stageLiveDaemon makes the home look like it hosts a running daemon whose
+// recorded build is version/commit. Liveness is verified against the real process
+// table (processLooksLikeDaemon matches argv), so the test process impersonates
+// the daemon: its own pid and argv are what we record. That also pins
+// meta.Executable to the test binary, which is why the on-disk build probe goes
+// through the execBinaryBuildFn seam rather than exec'ing it.
+func stageLiveDaemon(t *testing.T, home, version, commit string) config.Paths {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	state := daemonProcessState(paths)
+	meta := daemonMeta{
+		PID:        os.Getpid(),
+		Args:       os.Args[1:],
+		Executable: os.Args[0],
+		LogFile:    state.LogFile,
+		Version:    version,
+		Commit:     commit,
+	}
+	if err := writeDaemonState(state, meta); err != nil {
+		t.Fatal(err)
+	}
+	pid, _, err := currentDaemonPID(state)
+	if err != nil || pid != os.Getpid() {
+		t.Fatalf("staged daemon not seen as live: pid=%d err=%v", pid, err)
+	}
+	return paths
+}
+
+// stubOnDiskBuild makes the binary at the daemon's path report this build.
+func stubOnDiskBuild(t *testing.T, version, commit string) {
+	t.Helper()
+	previous := execBinaryBuildFn
+	execBinaryBuildFn = func(context.Context, string) (string, string) { return version, commit }
+	t.Cleanup(func() { execBinaryBuildFn = previous })
+}
+
+// stubUpdateCheck keeps Health off the network (the package seam; see
+// dashboard_web_test.go).
+func stubUpdateCheck(t *testing.T, latest string) {
+	t.Helper()
+	previous := updateCheckFn
+	updateCheckFn = func(_ context.Context, current buildinfo.Info, _ string) (update.CheckResult, error) {
+		return update.CheckResult{
+			CurrentVersion: current.Version,
+			LatestVersion:  latest,
+			NoRelease:      latest == "",
+		}, nil
+	}
+	t.Cleanup(func() { updateCheckFn = previous })
+}
+
+func TestDaemonStateRoundTripsTheRunningBuild(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	state := daemonProcessState(paths)
+	if err := writeDaemonState(state, daemonMetaWithCurrentBuild(daemonMeta{PID: os.Getpid(), LogFile: state.LogFile})); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := readDaemonMeta(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current := buildinfo.Current()
+	if meta.Version != current.Version || meta.Commit != current.Commit {
+		t.Fatalf("daemon.json build = %q/%q, want this process's %q/%q", meta.Version, meta.Commit, current.Version, current.Commit)
+	}
+}
+
+// A daemon started by an older gitmoot recorded no build. "Unknown" must never
+// be reported as skew, or every upgrade false-alarms until the daemon happens to
+// be restarted.
+func TestLegacyDaemonWithoutRecordedBuildIsUnknownNotSkew(t *testing.T) {
+	home := t.TempDir()
+	paths := stageLiveDaemon(t, home, "", "")
+	stubOnDiskBuild(t, "v0.9.1", "aaaaaaaa")
+
+	meta, err := readDaemonMeta(daemonProcessState(paths))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if daemonBuildLabel(meta) != "unknown" {
+		t.Fatalf("legacy build label = %q, want unknown", daemonBuildLabel(meta))
+	}
+	if check := daemonBuildCheck(paths); !check.OK {
+		t.Fatalf("legacy daemon reported as skewed: %q", check.Detail)
+	}
+}
+
+// daemonBuildStatus must never resolve daemon.pid/daemon.json RELATIVE to the
+// cwd: currentDaemonPID deletes a pidfile it cannot parse, and a zero Paths (a
+// missing HOME, which the call sites tolerate) would point it at a stranger's
+// file in the working directory.
+func TestDaemonBuildStatusRefusesZeroPaths(t *testing.T) {
+	status := daemonBuildStatus(config.Paths{})
+	if status.DaemonRunning {
+		t.Fatal("zero Paths reported a running daemon")
+	}
+	if check := daemonBuildCheck(config.Paths{}); !check.OK {
+		t.Fatalf("zero Paths reported skew: %q", check.Detail)
+	}
+}
+
+// The skew check must compare the daemon PROCESS against the binary at the
+// daemon's own path — not against whatever binary is invoking `doctor`, which
+// may not be the daemon's binary at all.
+func TestBuildCheckComparesDaemonAgainstBinaryAtItsOwnPath(t *testing.T) {
+	home := t.TempDir()
+	paths := stageLiveDaemon(t, home, "dev-old", "0000000000")
+
+	stubOnDiskBuild(t, "dev-new", "1111111111")
+	check := daemonBuildCheck(paths)
+	if check.OK {
+		t.Fatal("a daemon running dev-old with dev-new on disk was reported as current")
+	}
+	for _, want := range []string{"dev-old", "dev-new", "restart the daemon"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("skew detail %q missing %q", check.Detail, want)
+		}
+	}
+
+	// Same build on disk: no warning, regardless of what binary runs this test.
+	stubOnDiskBuild(t, "dev-old", "0000000000")
+	if check := daemonBuildCheck(paths); !check.OK {
+		t.Fatalf("daemon running the on-disk build was reported as skewed: %q", check.Detail)
+	}
+}
+
+// Health must report the build the daemon PROCESS runs (recorded), while the
+// update badge stays relative to the binary ON DISK. Conflating them makes the
+// badge sticky: after `gitmoot update`, it would keep claiming an update is
+// available until someone restarted the daemon.
+func TestHealthReportsRunningBuildWhileUpdateBadgeTracksTheBinaryOnDisk(t *testing.T) {
+	home := t.TempDir()
+	stageLiveDaemon(t, home, "v0.9.0", "old00000")
+	stubOnDiskBuild(t, "v0.9.1", "new11111")
+	stubUpdateCheck(t, "v0.9.1")
+
+	ds := &webDataSource{home: home}
+	health, err := ds.Health(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !health.Daemon.Running || health.Daemon.Version != "v0.9.0" {
+		t.Fatalf("daemon build = %q (running=%t), want the RECORDED v0.9.0", health.Daemon.Version, health.Daemon.Running)
+	}
+	if health.Update == nil {
+		t.Fatal("no update info")
+	}
+	if health.Update.Current != "v0.9.1" {
+		t.Fatalf("update badge current = %q, want the on-disk v0.9.1", health.Update.Current)
+	}
+	if health.Update.UpdateAvailable {
+		t.Fatal("update badge is stuck on: the binary on disk is already the latest release")
+	}
+}
+
+// /api/health reported only the daemon's build, so a dashboard process serving
+// stale code looked perfectly current. It must also report its OWN build — and,
+// shadowing the module's handler, keep every list non-nil as that contract
+// promises.
+func TestHealthEndpointAddsServingBuildAndKeepsListsNonNil(t *testing.T) {
+	home := t.TempDir()
+	stageLiveDaemon(t, home, "dev-stale-daemon", "stale000")
+	stubOnDiskBuild(t, "dev-stale-daemon", "stale000")
+	stubUpdateCheck(t, "")
+
+	ds := &webDataSource{home: home}
+	recorder := httptest.NewRecorder()
+	ds.handleHealth(recorder, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+
+	var payload struct {
+		Daemon struct {
+			Version string `json:"version"`
+		} `json:"daemon"`
+		Server struct {
+			Version string `json:"version"`
+			Commit  string `json:"commit"`
+		} `json:"server"`
+		Locks          *json.RawMessage `json:"locks"`
+		ResourceLocks  *json.RawMessage `json:"resourceLocks"`
+		Stuck          *json.RawMessage `json:"stuck"`
+		RecentFailures *json.RawMessage `json:"recentFailures"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Daemon.Version != "dev-stale-daemon" {
+		t.Fatalf("daemon build = %q", payload.Daemon.Version)
+	}
+	current := buildinfo.Current()
+	if payload.Server.Version != current.Version || payload.Server.Commit != current.Commit {
+		t.Fatalf("server build = %q/%q, want this process's own %q/%q", payload.Server.Version, payload.Server.Commit, current.Version, current.Commit)
+	}
+	if payload.Server.Version == payload.Daemon.Version {
+		t.Fatal("server and daemon builds are indistinguishable; a stale dashboard would stay invisible")
+	}
+	// The module's handler coerces these to []; shadowing it must not regress the
+	// documented shape to null.
+	for name, raw := range map[string]*json.RawMessage{
+		"locks":          payload.Locks,
+		"resourceLocks":  payload.ResourceLocks,
+		"stuck":          payload.Stuck,
+		"recentFailures": payload.RecentFailures,
+	} {
+		if raw == nil || string(*raw) == "null" {
+			t.Fatalf("%s serialized as null; the contract promises an array", name)
+		}
+	}
+}
+
+// E2E on an isolated home (NEVER /root/.gitmoot): a daemon running an older build
+// than the binary at its path must be called out by BOTH `gitmoot daemon status`
+// and `gitmoot doctor` — and, once they agree, by neither.
+func TestBuildSkewSurfacedByDoctorAndDaemonStatusE2E(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home) // runDoctor/runDaemonStatus resolve config.DefaultPaths() from $HOME
+	stageLiveDaemon(t, home, "dev-stale-000", "stale000sha")
+	stubOnDiskBuild(t, "dev-fresh-999", "fresh999sha")
+
+	var status bytes.Buffer
+	if code := runDaemonStatus(nil, &status, &status); code != 0 {
+		t.Fatalf("daemon status exit = %d: %s", code, status.String())
+	}
+	statusOut := status.String()
+	if !strings.Contains(statusOut, "build: dev-stale-000") {
+		t.Fatalf("daemon status did not print the running build:\n%s", statusOut)
+	}
+	for _, want := range []string{"WARNING", "dev-stale-000", "dev-fresh-999", "restart the daemon"} {
+		if !strings.Contains(statusOut, want) {
+			t.Fatalf("daemon status skew warning missing %q:\n%s", want, statusOut)
+		}
+	}
+
+	var doctorOut bytes.Buffer
+	runDoctor(nil, &doctorOut, &doctorOut)
+	buildLine := doctorCheckLine(t, doctorOut.String(), "build")
+	if !strings.Contains(buildLine, "dev-stale-000") || !strings.Contains(buildLine, "dev-fresh-999") {
+		t.Fatalf("doctor build line did not name both builds: %q", buildLine)
+	}
+
+	// The operator restarts: the daemon now runs the binary on disk.
+	stageLiveDaemon(t, home, "dev-fresh-999", "fresh999sha")
+
+	var agreed bytes.Buffer
+	if code := runDaemonStatus(nil, &agreed, &agreed); code != 0 {
+		t.Fatalf("daemon status exit = %d: %s", code, agreed.String())
+	}
+	if strings.Contains(agreed.String(), "WARNING") {
+		t.Fatalf("matching builds still warned:\n%s", agreed.String())
+	}
+	var healthy bytes.Buffer
+	runDoctor(nil, &healthy, &healthy)
+	if line := doctorCheckLine(t, healthy.String(), "build"); !strings.Contains(line, "ok") {
+		t.Fatalf("matching builds did not report ok: %q", line)
+	}
+}
+
+func doctorCheckLine(t *testing.T, out, name string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), name+" ") {
+			return line
+		}
+	}
+	t.Fatalf("doctor printed no %q check:\n%s", name, out)
+	return ""
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/jerryfane/gitmoot/internal/artifact"
+	"github.com/jerryfane/gitmoot/internal/buildinfo"
 	"github.com/jerryfane/gitmoot/internal/cockpit"
 	"github.com/jerryfane/gitmoot/internal/config"
 	"github.com/jerryfane/gitmoot/internal/credgw"
@@ -146,6 +147,7 @@ func runDaemonStartWithWorkDirRestart(args []string, workDir string, _ bool, _ b
 		fmt.Fprintf(stderr, "daemon start: %v\n", err)
 		return 1
 	}
+	started = daemonMetaWithCurrentBuild(started)
 	if err := writeDaemonState(state, started); err != nil {
 		_ = stopDaemonPID(started.PID)
 		fmt.Fprintf(stderr, "daemon start: %v\n", err)
@@ -596,7 +598,13 @@ func runDaemonStatus(args []string, stdout, stderr io.Writer) int {
 	writeLine(stdout, "log: %s", state.LogFile)
 	if pid > 0 {
 		if meta, err := readDaemonMeta(state); err == nil {
+			writeLine(stdout, "build: %s", daemonBuildLabel(meta))
+			if check := daemonBuildCheck(paths); !check.OK {
+				writeLine(stdout, "WARNING: %s", check.Detail)
+			}
 			writeLine(stdout, "%s", daemonSchedulerStatusLine(meta.Args))
+		} else {
+			writeLine(stdout, "build: unknown")
 		}
 		writeLine(stdout, "%s", daemonClaudeAuthLine(paths))
 	}
@@ -914,6 +922,8 @@ type daemonMeta struct {
 	LogFile    string   `json:"log_file"`
 	Executable string   `json:"executable"`
 	WorkingDir string   `json:"working_dir"`
+	Version    string   `json:"version,omitempty"`
+	Commit     string   `json:"commit,omitempty"`
 }
 
 type daemonStartConfig struct {
@@ -1635,6 +1645,13 @@ func writeDaemonState(state daemonState, meta daemonMeta) error {
 	return os.WriteFile(state.MetaFile, append(encoded, '\n'), 0o600)
 }
 
+func daemonMetaWithCurrentBuild(meta daemonMeta) daemonMeta {
+	build := buildinfo.Current()
+	meta.Version = build.Version
+	meta.Commit = build.Commit
+	return meta
+}
+
 // daemonRunStartupReconcile performs the two #505 startup steps for a directly
 // launched `daemon run`: it self-registers THIS process's pid/meta so `daemon
 // status` and the dashboard recognize it (gap 3), and it reconciles phantom
@@ -1688,14 +1705,14 @@ func registerDaemonRunState(state daemonState, argv []string, workDir string) (o
 	if len(argv) > 0 {
 		executable = argv[0]
 	}
-	meta := daemonMeta{
+	meta := daemonMetaWithCurrentBuild(daemonMeta{
 		PID:        os.Getpid(),
 		StartedAt:  time.Now().UTC().Format(time.RFC3339),
 		Args:       argv[1:],
 		LogFile:    state.LogFile,
 		Executable: executable,
 		WorkingDir: workDir,
-	}
+	})
 	if err := writeDaemonState(state, meta); err != nil {
 		return false, err
 	}

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -47,6 +47,7 @@ func runDashboardWeb(home, addr string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/health", ds.handleHealth)
 	mux.HandleFunc("GET /api/learning/knowledge", ds.handleLearningKnowledge)
 	mux.Handle("/", dashboard.Serve(ds))
 	srv := &http.Server{Handler: mux}
@@ -100,6 +101,57 @@ type webDataSource struct {
 	updateResult    *dashboard.HealthUpdate
 	updateFetchedAt time.Time
 	updateOK        bool
+}
+
+type dashboardServerBuild struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+}
+
+type dashboardHealthResponse struct {
+	dashboard.Health
+	Server dashboardServerBuild `json:"server"`
+}
+
+// handleHealth shadows the module's /api/health to add the build of the process
+// actually SERVING this response. Without it, a dashboard left on a stale binary
+// is invisible: the payload reports only the daemon's build, so the page looks
+// current while rendering old code's output (#932).
+//
+// It must otherwise reproduce the module's handler exactly — every list coerced
+// non-nil, so clients that consume the documented shape never see a null where
+// the contract promises an array.
+func (d *webDataSource) handleHealth(w http.ResponseWriter, r *http.Request) {
+	health, err := d.Health(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if health.Locks == nil {
+		health.Locks = []dashboard.HealthLock{}
+	}
+	if health.ResourceLocks == nil {
+		health.ResourceLocks = []dashboard.HealthResourceLock{}
+	}
+	if health.Stuck == nil {
+		health.Stuck = []dashboard.HealthStuckJob{}
+	}
+	if health.RecentFailures == nil {
+		health.RecentFailures = []dashboard.HealthFailure{}
+	}
+	build := buildinfo.Current()
+	response := dashboardHealthResponse{
+		Health: health,
+		Server: dashboardServerBuild{Version: build.Version, Commit: build.Commit},
+	}
+	buf, err := json.MarshalIndent(response, "", "  ")
+	if err != nil {
+		http.Error(w, "internal error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(append(buf, '\n'))
 }
 
 var _ dashboard.DataSource = (*webDataSource)(nil)
@@ -1335,30 +1387,38 @@ func (d *webDataSource) Health(ctx context.Context) (dashboard.Health, error) {
 	// which the version probe execs.
 	state := daemonProcessState(paths)
 	var executable string
+	var recordedDaemonVersion string
 	if pid, _, perr := currentDaemonPID(state); perr == nil && pid > 0 {
 		out.Daemon.Running = true
 		out.Daemon.PID = pid
 		if meta, merr := readDaemonMeta(state); merr == nil {
 			out.Daemon.StartedAt = parseJobTimeMillis(meta.StartedAt)
 			executable = strings.TrimSpace(meta.Executable)
+			recordedDaemonVersion = meta.Version
 		}
 	}
 
-	// The daemon-version probe (execs the binary) and the update check (hits
-	// GitHub) are the only slow parts of Health. Run them CONCURRENTLY — and with
-	// the local store read — so a cold cache never serially stacks their 3s + 4s
-	// timeouts past the health endpoint's latency budget. Both fail-open: a
-	// resolution error leaves the field empty/nil, never an error. The update
-	// check compares buildinfo.Current() (the exact documented shape); its
-	// displayed Current is overridden with the running daemon's version below,
-	// since that is the binary the operator actually runs.
+	// The on-disk probe (execs the binary) and the update check (hits GitHub) are
+	// the only slow parts of Health. Run them CONCURRENTLY — and with the local
+	// store read — so a cold cache never serially stacks their 3s + 4s timeouts
+	// past the health endpoint's latency budget. Both fail-open: a resolution
+	// error leaves the field empty/nil, never an error.
+	//
+	// Two DIFFERENT builds matter here and must not be conflated (#932):
+	//   - the build the daemon PROCESS is running (recorded in daemon.json),
+	//     which is what Daemon.Version reports; and
+	//   - the build of the binary now ON DISK at the daemon's path, which is what
+	//     `gitmoot update` replaces and therefore what the update badge compares.
+	// Pinning the badge to the running daemon instead would make it sticky: after
+	// an update, it would keep claiming an update is available until someone
+	// happened to restart the daemon.
 	var probes sync.WaitGroup
-	var daemonVersion string
+	var onDiskVersion string
 	var updateInfo *dashboard.HealthUpdate
 	probes.Add(2)
 	go func() {
 		defer probes.Done()
-		daemonVersion = d.resolveDaemonVersion(ctx, executable)
+		onDiskVersion = d.resolveOnDiskVersion(ctx, executable)
 	}()
 	go func() {
 		defer probes.Done()
@@ -1503,20 +1563,32 @@ func (d *webDataSource) Health(ctx context.Context) (dashboard.Health, error) {
 		return nil
 	})
 
-	// Join the concurrent probes. Prefer the running daemon's version for the
-	// update check's displayed Current (that is what the operator runs); fall back
-	// to the check's own current (buildinfo.Current().Version) when the daemon
-	// version is unavailable.
 	probes.Wait()
-	out.Daemon.Version = daemonVersion
+
+	// What the daemon PROCESS is running: its recorded build. Only a daemon
+	// started by an older gitmoot recorded none — then, and only then, fall back
+	// to asking the binary at its path (the pre-#932 behavior, which is wrong the
+	// moment the binary has been swapped, but is the best available answer).
+	out.Daemon.Version = recordedDaemonVersion
+	if out.Daemon.Version == "" {
+		out.Daemon.Version = onDiskVersion
+	}
+
+	// What an update would replace: the binary on disk. Keeping the badge
+	// on-disk-relative is what stops it from sticking on after `gitmoot update`
+	// until an unrelated daemon restart happens to clear it.
 	out.Update = updateInfo
-	if out.Update != nil && daemonVersion != "" {
-		// The update check ran against this dashboard-web process's OWN compiled
-		// version, but the operator runs the daemon binary — so make both the
-		// displayed Current AND the availability verdict daemon-relative,
-		// otherwise a divergent-binary deployment reports the wrong badge.
-		out.Update.Current = daemonVersion
-		out.Update.UpdateAvailable = out.Update.Latest != "" && !sameDaemonVersion(daemonVersion, out.Update.Latest)
+	badgeVersion := onDiskVersion
+	if badgeVersion == "" {
+		badgeVersion = out.Daemon.Version
+	}
+	if out.Update != nil && badgeVersion != "" {
+		// The update check ran against this serving process's OWN compiled
+		// version, which need not be the deployed binary at all — so make both the
+		// displayed Current AND the availability verdict relative to the binary on
+		// disk, otherwise a divergent-binary deployment reports the wrong badge.
+		out.Update.Current = badgeVersion
+		out.Update.UpdateAvailable = out.Update.Latest != "" && !sameDaemonVersion(badgeVersion, out.Update.Latest)
 	}
 	return out, err
 }
@@ -1534,14 +1606,15 @@ const (
 	updateFailureTTL = 10 * time.Minute
 )
 
-// resolveDaemonVersion returns the running daemon binary's reported version, or
-// "" when it cannot be determined (fail-open). It execs "<executable> version
-// --json" (preferred) or the plain-text form, under a hard timeout, and caches
-// the result keyed by the executable's path+mtime so SEQUENTIAL 12s health polls
-// never re-exec an unchanged binary (there is no singleflight, so concurrent cold
-// requests may each exec once). Only a regular, executable, existing file is ever
-// run.
-func (d *webDataSource) resolveDaemonVersion(ctx context.Context, executable string) string {
+// resolveOnDiskVersion returns the version of the binary NOW SITTING at the
+// daemon's executable path — what a restart (or an update) would pick up, which
+// is not necessarily what the daemon process is running. It execs
+// "<executable> version --json" (preferred) or the plain-text form under a hard
+// timeout, and caches by executable path+mtime so SEQUENTIAL 12s health polls
+// never re-exec an unchanged binary (there is no singleflight, so concurrent
+// cold requests may each exec once). Only a regular, executable, existing file
+// is ever run. Returns "" when it cannot be determined (fail-open).
+func (d *webDataSource) resolveOnDiskVersion(ctx context.Context, executable string) string {
 	executable = strings.TrimSpace(executable)
 	if executable == "" {
 		return ""
@@ -1560,7 +1633,7 @@ func (d *webDataSource) resolveDaemonVersion(ctx context.Context, executable str
 	}
 	d.mu.Unlock()
 
-	version := execDaemonVersion(ctx, executable)
+	version, _ := execBinaryBuildFn(ctx, executable)
 
 	d.mu.Lock()
 	d.daemonVersionKey = key
@@ -1569,12 +1642,17 @@ func (d *webDataSource) resolveDaemonVersion(ctx context.Context, executable str
 	return version
 }
 
-// execDaemonVersion runs the binary's version subcommand with a hard timeout and
-// returns the reported version. It prefers the JSON form ("version --json" ->
-// {"version": "..."}); on any failure it falls back to the plain-text form
-// ("version" -> "gitmoot <ver>", from which the "gitmoot" prefix is trimmed).
-// Returns "" on any error (fail-open).
-func execDaemonVersion(ctx context.Context, executable string) string {
+// execBinaryBuildFn is the seam the on-disk build probe goes through, so tests
+// can choose what the binary at a path reports without exec'ing anything (the
+// same pattern as updateCheckFn). The real exec path stays covered by
+// TestWebDataSourceDaemonVersionCache / ...TextFallback.
+var execBinaryBuildFn = execBinaryBuild
+
+// execBinaryBuild asks the binary AT THIS PATH what build it is — which is what a
+// daemon restart would load, and therefore the thing worth comparing the running
+// daemon against. The plain-text fallback yields no commit, so callers must treat
+// an empty commit as unknown rather than as "no commit".
+func execBinaryBuild(ctx context.Context, executable string) (version, commit string) {
 	// Both attempts share ONE budget so the whole probe is bounded by
 	// daemonVersionTimeout, never 2× it (a wedged binary must not stack).
 	ctx, cancel := context.WithTimeout(ctx, daemonVersionTimeout)
@@ -1582,19 +1660,20 @@ func execDaemonVersion(ctx context.Context, executable string) string {
 	if out, err := exec.CommandContext(ctx, executable, "version", "--json").Output(); err == nil {
 		var parsed struct {
 			Version string `json:"version"`
+			Commit  string `json:"commit"`
 		}
 		if json.Unmarshal(out, &parsed) == nil {
 			if v := strings.TrimSpace(parsed.Version); v != "" {
-				return v
+				return v, strings.TrimSpace(parsed.Commit)
 			}
 		}
 	}
 	out, err := exec.CommandContext(ctx, executable, "version").Output()
 	if err != nil {
-		return ""
+		return "", ""
 	}
 	line := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
-	return strings.TrimSpace(strings.TrimPrefix(line, "gitmoot"))
+	return strings.TrimSpace(strings.TrimPrefix(line, "gitmoot")), ""
 }
 
 // updateCheckFn is the seam the Health update check goes through so tests can

--- a/internal/cli/dashboard_web_test.go
+++ b/internal/cli/dashboard_web_test.go
@@ -1388,7 +1388,7 @@ func execCount(t *testing.T, counterFile string) int {
 	return len(data)
 }
 
-// TestWebDataSourceDaemonVersionCache asserts resolveDaemonVersion execs the
+// TestWebDataSourceDaemonVersionCache asserts resolveOnDiskVersion execs the
 // binary's "version --json" once, parses the JSON version, serves subsequent
 // calls from the mtime-keyed cache WITHOUT re-execing, and re-execs after the
 // binary's mtime changes. A missing/non-executable path yields "" (fail-open).
@@ -1401,14 +1401,14 @@ func TestWebDataSourceDaemonVersionCache(t *testing.T) {
 	ds := &webDataSource{}
 	ctx := context.Background()
 
-	if v := ds.resolveDaemonVersion(ctx, bin); v != "v1.2.3" {
+	if v := ds.resolveOnDiskVersion(ctx, bin); v != "v1.2.3" {
 		t.Fatalf("version = %q, want v1.2.3", v)
 	}
 	if n := execCount(t, counter); n != 1 {
 		t.Fatalf("exec count = %d after first resolve, want 1", n)
 	}
 	// Cache hit: same binary/mtime -> no re-exec.
-	if v := ds.resolveDaemonVersion(ctx, bin); v != "v1.2.3" {
+	if v := ds.resolveOnDiskVersion(ctx, bin); v != "v1.2.3" {
 		t.Fatalf("cached version = %q, want v1.2.3", v)
 	}
 	if n := execCount(t, counter); n != 1 {
@@ -1421,7 +1421,7 @@ func TestWebDataSourceDaemonVersionCache(t *testing.T) {
 	if err := os.Chtimes(bin, future, future); err != nil {
 		t.Fatalf("Chtimes: %v", err)
 	}
-	if v := ds.resolveDaemonVersion(ctx, bin); v != "v4.5.6" {
+	if v := ds.resolveOnDiskVersion(ctx, bin); v != "v4.5.6" {
 		t.Fatalf("version after mtime change = %q, want v4.5.6", v)
 	}
 	if n := execCount(t, counter); n != 2 {
@@ -1429,12 +1429,12 @@ func TestWebDataSourceDaemonVersionCache(t *testing.T) {
 	}
 
 	// Fail-open on a path that does not exist.
-	if v := ds.resolveDaemonVersion(ctx, filepath.Join(dir, "nope")); v != "" {
+	if v := ds.resolveOnDiskVersion(ctx, filepath.Join(dir, "nope")); v != "" {
 		t.Fatalf("missing binary version = %q, want empty", v)
 	}
 }
 
-// TestWebDataSourceDaemonVersionTextFallback asserts resolveDaemonVersion falls
+// TestWebDataSourceDaemonVersionTextFallback asserts resolveOnDiskVersion falls
 // back to the plain-text "gitmoot <ver>" form (trimming the prefix) when the JSON
 // form does not parse.
 func TestWebDataSourceDaemonVersionTextFallback(t *testing.T) {
@@ -1446,7 +1446,7 @@ func TestWebDataSourceDaemonVersionTextFallback(t *testing.T) {
 	writeFakeVersionBin(t, bin, counter, `gitmoot v7.8.9`)
 
 	ds := &webDataSource{}
-	if v := ds.resolveDaemonVersion(context.Background(), bin); v != "v7.8.9" {
+	if v := ds.resolveOnDiskVersion(context.Background(), bin); v != "v7.8.9" {
 		t.Fatalf("text fallback version = %q, want v7.8.9", v)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -152,6 +152,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	// locate the running daemon. A failure here (no initialized home) just leaves
 	// Paths zero, which skips the daemon check and keeps the shell-local one.
 	paths, _ := config.DefaultPaths()
+	buildStatus := daemonBuildStatus(paths)
 	probeRunner, authState, authSource, authErr := runtimeJobRunnerWithAuth("", runtime.ClaudeRuntime, nil)
 	checker := doctor.Checker{
 		Dir:               *repoDir,
@@ -162,6 +163,7 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 		ClaudeAuthSource:  authSource,
 		ClaudeAuthError:   authErr,
 		SkipDaemonAuth:    true,
+		Build:             &buildStatus,
 	}
 	checks := checker.Run(context.Background())
 	// #631: surface a stale backlog of blocked jobs (each paused awaiting a human)

--- a/internal/doctor/build_check_test.go
+++ b/internal/doctor/build_check_test.go
@@ -1,0 +1,95 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+)
+
+// CheckBuild compares the build the daemon PROCESS is running against the build
+// of the binary at its own path (what a restart would load). It must report skew
+// only when it genuinely knows both, because both kinds of guess are harmful: a
+// false alarm tells the operator to bounce a current daemon, and a false green
+// hides exactly the staleness the check exists to catch.
+func TestCheckBuildReportsSkewOnlyWhenBothBuildsAreIdentifiable(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		status     BuildStatus
+		wantOK     bool
+		wantDetail []string
+	}{
+		{
+			name:       "daemon not running",
+			status:     BuildStatus{OnDisk: BuildInfoFromValues("dev-aaa", "aaa")},
+			wantOK:     true,
+			wantDetail: []string{"daemon not running"},
+		},
+		{
+			name:       "daemon recorded no build (started by an older gitmoot)",
+			status:     BuildStatus{OnDisk: BuildInfoFromValues("dev-aaa", "aaa"), DaemonRunning: true},
+			wantOK:     true,
+			wantDetail: []string{"daemon build unknown", "comparison skipped"},
+		},
+		{
+			name:       "on-disk build could not be resolved",
+			status:     BuildStatus{Daemon: BuildInfoFromValues("dev-aaa", "aaa"), DaemonRunning: true},
+			wantOK:     true,
+			wantDetail: []string{"daemon's binary path is unknown", "comparison skipped"},
+		},
+		{
+			// An unstamped `go build` with no VCS revision is an anonymous "dev".
+			// Comparing two anonymous builds proves nothing: saying "same" would
+			// green-light a daemon running week-old code.
+			name:       "both sides anonymous dev: unknown, not equal",
+			status:     BuildStatus{Daemon: BuildInfoFromValues("dev", "unknown"), OnDisk: BuildInfoFromValues("dev", "unknown"), DaemonRunning: true},
+			wantOK:     true,
+			wantDetail: []string{"unknown", "comparison skipped"},
+		},
+		{
+			// ...and the mirror image: an anonymous "dev" binary on disk must not be
+			// reported as skewed against a stamped daemon, which would tell the
+			// operator to restart a perfectly current daemon.
+			name:       "stamped daemon vs anonymous dev on disk: unknown, not skew",
+			status:     BuildStatus{Daemon: BuildInfoFromValues("dev-56ba1c7", "56ba1c74"), OnDisk: BuildInfoFromValues("dev", "unknown"), DaemonRunning: true},
+			wantOK:     true,
+			wantDetail: []string{"comparison skipped"},
+		},
+		{
+			name:       "same build",
+			status:     BuildStatus{Daemon: BuildInfoFromValues("v0.9.1", "aaa"), OnDisk: BuildInfoFromValues("v0.9.1", "aaa"), DaemonRunning: true},
+			wantOK:     true,
+			wantDetail: []string{"running the binary on disk", "v0.9.1"},
+		},
+		{
+			name:       "versions differ — the daemon is stale",
+			status:     BuildStatus{Daemon: BuildInfoFromValues("v0.9.0", "old"), OnDisk: BuildInfoFromValues("v0.9.1", "new"), DaemonRunning: true, OnDiskPath: "/usr/local/bin/gitmoot"},
+			wantOK:     false,
+			wantDetail: []string{"v0.9.0", "v0.9.1", "/usr/local/bin/gitmoot", "restart the daemon"},
+		},
+		{
+			// Same version string, different code: dev builds keep Version=dev-<sha>
+			// only if stamped; a VCS revision is what distinguishes them otherwise.
+			name:       "same version, different commit",
+			status:     BuildStatus{Daemon: BuildInfoFromValues("dev", "oldsha0000"), OnDisk: BuildInfoFromValues("dev", "newsha1111"), DaemonRunning: true},
+			wantOK:     false,
+			wantDetail: []string{"oldsha00", "newsha11", "restart the daemon"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			check := CheckBuild(tc.status)
+			if check.Name != "build" {
+				t.Fatalf("check name = %q", check.Name)
+			}
+			if check.Required {
+				t.Fatal("build skew must never be a required (fatal) check")
+			}
+			if check.OK != tc.wantOK {
+				t.Fatalf("OK = %t, want %t (detail %q)", check.OK, tc.wantOK, check.Detail)
+			}
+			for _, want := range tc.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("detail = %q, want it to contain %q", check.Detail, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -21,6 +21,30 @@ type Check struct {
 	Detail   string
 }
 
+type BuildInfo struct {
+	Version string
+	Commit  string
+}
+
+func BuildInfoFromValues(version, commit string) BuildInfo {
+	return BuildInfo{Version: strings.TrimSpace(version), Commit: strings.TrimSpace(commit)}
+}
+
+// BuildStatus compares what the daemon PROCESS is running against the binary it
+// would load if restarted. Those are the only two builds the operator can act
+// on; the build of whatever binary happens to be invoking `doctor` is not one of
+// them (it may not even be the daemon's binary), so it is deliberately absent.
+type BuildStatus struct {
+	// Daemon is the build recorded by the running daemon at startup — what it is
+	// actually executing. Zero when the daemon predates build stamping.
+	Daemon BuildInfo
+	// OnDisk is the build of the binary now sitting at the daemon's executable
+	// path — what a restart would pick up. Zero when it cannot be resolved.
+	OnDisk        BuildInfo
+	OnDiskPath    string
+	DaemonRunning bool
+}
+
 type Checker struct {
 	Dir    string
 	Runner subprocess.Runner
@@ -45,6 +69,10 @@ type Checker struct {
 	// background jobs is the daemon's own environment, not the shell that ran
 	// `gitmoot doctor`.
 	Paths config.Paths
+	// Build is supplied by the CLI so this package stays independent of both
+	// buildinfo and daemon-state persistence. Nil omits the check for callers
+	// such as the continuously refreshed terminal dashboard.
+	Build *BuildStatus
 }
 
 // Run returns the global (cwd-independent) checks followed by the per-repo
@@ -77,7 +105,88 @@ func (c Checker) GlobalChecks(ctx context.Context) []Check {
 		}
 	}
 	checks = append(checks, c.claudeAuthEnv(ctx), c.ghAuth(ctx, runner))
+	if c.Build != nil {
+		checks = append(checks, CheckBuild(*c.Build))
+	}
 	return checks
+}
+
+// CheckBuild reports whether the running daemon is executing stale code: the
+// build it started from, versus the build now sitting at its executable path
+// (what a restart would load). Those are the only two builds the operator can
+// act on — the build of whatever binary happens to be invoking `doctor` is not
+// necessarily either of them, so it is deliberately not part of the comparison.
+//
+// Every unknown is neutral. Inferring "skew" from missing information would fire
+// on every daemon started by an older gitmoot; inferring "same" would hide the
+// staleness this check exists to catch. So an unidentifiable build on either
+// side yields a skipped comparison, never a verdict.
+func CheckBuild(status BuildStatus) Check {
+	check := Check{Name: "build", OK: true, Required: false}
+	if !status.DaemonRunning {
+		check.Detail = "daemon not running; build comparison skipped"
+		return check
+	}
+	if !identifiableBuild(status.Daemon) {
+		check.Detail = "running daemon build unknown (older gitmoot, or an unstamped build); comparison skipped"
+		return check
+	}
+	if !identifiableBuild(status.OnDisk) {
+		check.Detail = "build at the daemon's binary path is unknown (unstamped build); comparison skipped"
+		return check
+	}
+
+	versionsDiffer := status.Daemon.Version != status.OnDisk.Version
+	commitsDiffer := knownBuildCommit(status.Daemon.Commit) && knownBuildCommit(status.OnDisk.Commit) && status.Daemon.Commit != status.OnDisk.Commit
+	if !versionsDiffer && !commitsDiffer {
+		check.Detail = "daemon is running the binary on disk (" + buildDisplay(status.OnDisk) + ")"
+		return check
+	}
+
+	check.OK = false
+	target := "the binary on disk"
+	if path := strings.TrimSpace(status.OnDiskPath); path != "" {
+		target = path
+	}
+	check.Detail = fmt.Sprintf("daemon running %s; %s is %s — restart the daemon to pick it up",
+		buildDisplay(status.Daemon), target, buildDisplay(status.OnDisk))
+	return check
+}
+
+// identifiableBuild mirrors buildinfo.Info.Identifiable, without importing it —
+// this package stays free of the build-stamp dependency and the CLI supplies the
+// values. An unstamped build with no VCS revision reports version "dev" and no
+// commit; every such build is the same anonymous "dev", so comparing two of them
+// tells you nothing and must not be treated as a verdict either way.
+func identifiableBuild(build BuildInfo) bool {
+	if !knownBuildVersion(build.Version) {
+		return false
+	}
+	if build.Version != "dev" {
+		return true
+	}
+	return knownBuildCommit(build.Commit)
+}
+
+func knownBuildVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	return version != "" && !strings.EqualFold(version, "unknown")
+}
+
+func knownBuildCommit(commit string) bool {
+	commit = strings.TrimSpace(commit)
+	return commit != "" && !strings.EqualFold(commit, "unknown")
+}
+
+func buildDisplay(build BuildInfo) string {
+	if knownBuildCommit(build.Commit) {
+		commit := build.Commit
+		if len(commit) > 8 {
+			commit = commit[:8]
+		}
+		return fmt.Sprintf("%s (%s)", build.Version, commit)
+	}
+	return build.Version
 }
 
 // RepoChecks returns the per-repo diagnostics (origin remote resolves, base

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -236,6 +236,40 @@ For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task list --repo owner/repo --json`. `gitmoot status --json` and
 `gitmoot task show` are not valid commands.
 
+### Build skew (upgraded but not restarted)
+
+The daemon is a long-lived process: replacing the binary does **not** change the
+code it is executing. It keeps running the old build until you restart it.
+
+The daemon records the build it started from in `<home>/.gitmoot/daemon.json`
+(`version` + `commit`). `gitmoot daemon status` prints that build and compares it
+against the build of the binary **now sitting at the daemon's own path** — the
+one a restart would load:
+
+```
+build: dev-cd43a49 (cd43a495)
+WARNING: daemon running dev-cd43a49 (cd43a495); /root/.local/bin/gitmoot is dev-56ba1c7 (56ba1c74) — restart the daemon to pick it up
+```
+
+`gitmoot doctor` reports the same comparison as a non-fatal `build` check. Note
+it compares the **daemon** against the **daemon's binary** — not against whatever
+binary you happen to be invoking, which may not be the daemon's at all.
+
+Unknown is never reported as skew, and never reported as agreement either. The
+comparison is skipped when the daemon is not running, when it was started by an
+older gitmoot (no recorded build), or when either side is an **unidentifiable**
+build. A build is identifiable if it was stamped (any release, and the documented
+deploy recipe) or if Go's VCS stamping supplied a commit — which a plain
+`go build` in a git tree provides. Two unstamped builds with no commit are both
+just `dev`: indistinguishable, so comparing them would prove nothing.
+
+The web dashboard's `/api/health` reports the daemon's **recorded** build (what
+the process is actually running — not the version of whatever binary now sits at
+its path) plus, separately, the serving dashboard process's own build, so a
+dashboard left on a stale binary is visible rather than silently wrong. The
+update badge stays relative to the binary on disk, since that is what an update
+replaces.
+
 The `gitmoot repo` commands manage the **watched-repo registry**: one daemon
 per Gitmoot home supervises every **enabled** registered repo. An omitted
 `repo add --poll` stores the `inherit` sentinel, so the repo follows the daemon's

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -159,6 +159,42 @@ For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task list --repo owner/repo --json`. `gitmoot status --json` and
 `gitmoot task show` are not valid commands.
 
+### Build Skew (Upgraded But Not Restarted)
+
+The daemon is a long-lived process: replacing the binary does **not** change the
+code it is executing. It keeps running the old build until you restart it, which
+is easy to miss because `gitmoot version` describes the binary you just invoked,
+not the one the daemon is running.
+
+The daemon records the build it started from in `<home>/.gitmoot/daemon.json`
+(`version` + `commit`). `gitmoot daemon status` prints that build and compares it
+against the build of the binary **now sitting at the daemon's own path** — the one
+a restart would load:
+
+```
+build: dev-cd43a49 (cd43a495)
+WARNING: daemon running dev-cd43a49 (cd43a495); /root/.local/bin/gitmoot is dev-56ba1c7 (56ba1c74) — restart the daemon to pick it up
+```
+
+`gitmoot doctor` reports the same comparison as a non-fatal `build` check. It
+compares the **daemon** against the **daemon's own binary** — not against whatever
+binary you happen to be invoking, which need not be the daemon's at all.
+
+Unknown is never reported as skew — and never as agreement either. The comparison
+is skipped when the daemon is not running, when it was started by an older gitmoot
+(which recorded no build), or when either side is an **unidentifiable** build. A
+build is identifiable if it was stamped (any release, and the documented deploy
+recipe) or if Go's VCS stamping supplied a commit, which a plain `go build` in a
+git tree does. Two unstamped builds with no commit are both just `dev`:
+indistinguishable, so comparing them would prove nothing.
+
+The web dashboard's `/api/health` reports the daemon's **recorded** build — what
+the daemon process is actually running, not the version of whatever binary now
+sits at its path — plus, separately, the serving dashboard process's own build,
+so a dashboard left on a stale binary is visible rather than silently wrong. The
+update badge remains relative to the binary on disk, since that is what an update
+replaces.
+
 ### Watched Repos
 
 ```sh

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1715,6 +1715,48 @@ The command must print a valid `gitmoot_result` object for normal jobs.
 Use `gitmoot doctor --repo .` first. It checks local prerequisites from the
 repository checkout.
 
+## The Daemon Is Running An Old Build
+
+Symptoms:
+
+- You upgraded gitmoot (or rebuilt it) and the fix did not take effect.
+- Jobs still behave like the previous version; new flags are ignored.
+- `gitmoot version` shows the new build, so everything *looks* current.
+
+Cause: the daemon is a long-lived process. Replacing the binary on disk does not
+change the code an already-running daemon executes — it keeps running the build
+it started from until it is restarted. `gitmoot version` reports the binary
+**you** invoked, not the one the daemon is running, so it cannot tell you this.
+
+Check:
+
+```sh
+gitmoot daemon status   # prints "build: <version>" and warns on skew
+gitmoot doctor          # non-fatal "build" check, same comparison
+```
+
+A skew reads:
+
+```
+WARNING: daemon running dev-cd43a49 (cd43a495); /usr/local/bin/gitmoot is dev-56ba1c7 (56ba1c74) — restart the daemon to pick it up
+```
+
+Fix: restart the daemon (when it is idle — confirm no running jobs first). If it
+runs under systemd, use your service manager rather than `gitmoot daemon restart`.
+
+Notes:
+
+- The comparison is between the daemon **process** and the binary at the
+  **daemon's own path** — the one a restart would load. It is not about the binary
+  you happen to be invoking, which may be a different one entirely.
+- The comparison is only made when both builds are identifiable, and an unknown is
+  never reported as skew *or* as agreement — it reports "comparison skipped". A
+  daemon started by an older gitmoot recorded no build; and two unstamped builds
+  with no VCS commit are both just `dev`, so comparing them would prove nothing.
+- If you run the web dashboard as a **separate service**, it is its own process
+  with its own build. `/api/health` reports the serving process's build separately
+  from the daemon's, so restart both after an upgrade.
+
 ## `gh`
 
 Symptoms:
@@ -9412,6 +9454,40 @@ gitmoot daemon stop
 For structured local state, use `gitmoot dashboard --json` or
 `gitmoot task list --repo owner/repo --json`. `gitmoot status --json` and
 `gitmoot task show` are not valid commands.
+
+### Build skew (upgraded but not restarted)
+
+The daemon is a long-lived process: replacing the binary does **not** change the
+code it is executing. It keeps running the old build until you restart it.
+
+The daemon records the build it started from in `<home>/.gitmoot/daemon.json`
+(`version` + `commit`). `gitmoot daemon status` prints that build and compares it
+against the build of the binary **now sitting at the daemon's own path** — the
+one a restart would load:
+
+```
+build: dev-cd43a49 (cd43a495)
+WARNING: daemon running dev-cd43a49 (cd43a495); /root/.local/bin/gitmoot is dev-56ba1c7 (56ba1c74) — restart the daemon to pick it up
+```
+
+`gitmoot doctor` reports the same comparison as a non-fatal `build` check. Note
+it compares the **daemon** against the **daemon's binary** — not against whatever
+binary you happen to be invoking, which may not be the daemon's at all.
+
+Unknown is never reported as skew, and never reported as agreement either. The
+comparison is skipped when the daemon is not running, when it was started by an
+older gitmoot (no recorded build), or when either side is an **unidentifiable**
+build. A build is identifiable if it was stamped (any release, and the documented
+deploy recipe) or if Go's VCS stamping supplied a commit — which a plain
+`go build` in a git tree provides. Two unstamped builds with no commit are both
+just `dev`: indistinguishable, so comparing them would prove nothing.
+
+The web dashboard's `/api/health` reports the daemon's **recorded** build (what
+the process is actually running — not the version of whatever binary now sits at
+its path) plus, separately, the serving dashboard process's own build, so a
+dashboard left on a stale binary is visible rather than silently wrong. The
+update badge stays relative to the binary on disk, since that is what an update
+replaces.
 
 The `gitmoot repo` commands manage the **watched-repo registry**: one daemon
 per Gitmoot home supervises every **enabled** registered repo. An omitted


### PR DESCRIPTION
Closes #932.

## The problem

The daemon is a long-lived process: replacing the binary does **not** change the code it is executing. It keeps running the old build until restarted — and nothing surfaced that. `gitmoot version` describes the binary *you* invoked, so it cannot tell you.

`/api/health` made it worse. It resolved "the daemon version" by execing the binary at the path recorded in `daemon.json` — a *file location*, so the instant you `mv` a new binary in, it reported the **new** version while the daemon still ran the **old** code. A false green in precisely the upgraded-but-not-restarted window the check exists for.

Found while deploying the P1/P2 wave: the dashboard served stale code for 20 minutes while every version signal said it was current.

## What this does

- **Stamps the running build** (`version` + `commit`) into `daemon.json` at *both* writers — `daemon start` and `registerDaemonRunState` (the `daemon run` path systemd uses). That is the authoritative record of what the **process** is, versus what is on disk.
- **Compares the right two things**: the daemon process against the binary **at the daemon's own path** (what a restart would load) — *not* against whatever binary invoked the command, which need not be the daemon's at all. Running `doctor` from a `/tmp` build must not tell you to bounce a healthy daemon.
- **`gitmoot doctor`** gains a non-fatal `build` check; **`gitmoot daemon status`** prints the running build and the same warning.
- **`buildinfo` recovers Go's VCS stamping** (`debug.ReadBuildInfo` → `vcs.revision`), so a plain `go build` is identifiable — and `gitmoot version` stops printing `commit: unknown`. Without this the feature is inert for every unstamped build, which is most of them outside a release.
- **`/api/health`** additionally reports the **serving** process's own build, so a dashboard left on a stale binary is self-evident. The update badge stays relative to the **binary on disk**, so it cannot stick on after `gitmoot update` until an unrelated restart clears it.

## Unknown is never a verdict

Neither skew nor agreement is inferred from missing information — both would be harmful (a false alarm tells you to restart a current daemon; a false green hides the staleness). The comparison is *skipped* when the daemon is not running, when it was started by an older gitmoot (no recorded build), or when either side is unidentifiable. Two unstamped builds with no VCS commit are both just `dev` — indistinguishable, so comparing them proves nothing.

## Tests

`internal/doctor/build_check_test.go` — table over `CheckBuild`, including both false-verdict traps: a stamped daemon vs an anonymous `dev` on disk (must **not** be skew) and two anonymous `dev` builds (must **not** be "same").

`internal/cli/build_skew_test.go`:

- `daemon.json` round-trips the running build; a legacy state file without it is *unknown*, not skew.
- the check compares the daemon against the binary at **its own path**, not the invoking binary.
- `daemonBuildStatus` refuses a zero `config.Paths` (it would otherwise resolve `daemon.pid` relative to the cwd — and `currentDaemonPID` deletes a pidfile it cannot parse).
- Health reports the **recorded** build while the update badge tracks the **on-disk** binary (the sticky-badge regression).
- the health endpoint adds the serving build and keeps every list non-nil (shadowing the module handler must not regress `stuck`/`recentFailures` from `[]` to `null`).
- **E2E** `TestBuildSkewSurfacedByDoctorAndDaemonStatusE2E` on an isolated `/tmp` home (never `/root/.gitmoot`): a daemon recorded at an older build than the one at its path is called out by **both** `doctor` and `daemon status`, and by neither once they agree.

Docs ship with the code: `skills/gitmoot/references/CLI.md`, `docs/troubleshooting.md` ("The Daemon Is Running An Old Build"), `website/docs/reference/cli.md`, `llms-full.txt` regenerated.

## Review

Adversarially reviewed before opening; the review caught six real defects in the first cut (the invoking-binary comparison, the unstamped-`dev` false alarm **and** false green, docs asserting behavior the code lacked, the `null` list regression, the sticky update badge, the zero-`Paths` guard). All fixed here.

Gate: `go build` / `go vet` / `go generate` + diff clean / `go test ./internal/cli/ ./internal/doctor/ ./internal/buildinfo/ ./internal/daemon/ ./internal/config/ ./internal/update/` — all green.

## Deploy note

Existing daemons recorded no build, so the check reports "comparison skipped" until the daemon is next restarted — by design, and not a false alarm.
