### PR TITLE
ci: reconcile race-shard timings instead of discarding them — LPT never actually ran (#930)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,14 @@ name: CI
 #     the package bundle and executes from the package directory, preserving Go
 #     test-binary working-directory semantics without recompiling.
 #   - TIMINGS: PRs use the newest non-expired main timing artifact (up to 30
-#     days old) for deterministic LPT balancing. Missing, malformed, or stale
-#     timings fall back loudly to Stage 1's deterministic alternation. Successful
-#     pushes to main publish fresh per-test timings for subsequent PRs.
+#     days old) for deterministic LPT balancing. A PR's test set almost never
+#     matches main's exactly, so the timings are RECONCILED against the current
+#     test list (new tests weighted at the median, vanished rows dropped) rather
+#     than discarded — demanding an exact match meant LPT never ran (#930). Only a
+#     missing or corrupt artifact falls back loudly to Stage 1's deterministic
+#     alternation. Coverage never depends on the timings: the shard union is
+#     asserted against the compiled binary's own -test.list. Successful pushes to
+#     main publish fresh per-test timings for subsequent PRs.
 
 on:
   push:
@@ -222,7 +227,7 @@ jobs:
           status=$?
           set -e
           if [ "$status" -eq 2 ]; then
-            echo "::warning::main timings are stale or malformed for internal/$PACKAGE; using deterministic alternation"
+            echo "::warning::main timings are missing or corrupt for internal/$PACKAGE; using deterministic alternation"
             scripts/partition-race-tests.sh \
               --tests "$bundle/tests.list" \
               --shards "$SHARDS" \

--- a/scripts/partition-race-tests.sh
+++ b/scripts/partition-race-tests.sh
@@ -146,26 +146,67 @@ if [[ -n "$timings_file" ]]; then
   cut -f1 "$package_timings" | sort >"$timing_names"
   timing_duplicates="$work_dir/timing-names.duplicates"
   uniq -d "$timing_names" >"$timing_duplicates"
+
+  # A duplicate row makes a test's weight ambiguous — that is a corrupt artifact,
+  # not a stale one, so it stays fatal.
+  if [[ -s "$timing_duplicates" ]]; then
+    echo "partition-race-tests: unusable timings: duplicate rows for package $package" >&2
+    sed 's/^/    /' "$timing_duplicates" >&2
+    exit 2
+  fi
+
+  # RECONCILE the timings against the CURRENT test list rather than demanding they
+  # match it (#930). Requiring an exact match meant any PR that added, renamed, or
+  # deleted a single test fell back to alternation — which is nearly every PR, so
+  # LPT balancing effectively never ran. Instead:
+  #   - a test with a recorded time keeps it;
+  #   - a test that is NEW here (no recorded time) gets the median of the known
+  #     times, so it is scheduled as a typical test rather than a free one;
+  #   - a recorded time for a test that no longer exists is dropped.
+  # Coverage is guaranteed downstream regardless: the shard-union assertion below
+  # compares the partition against the compiled binary's own -test.list, so a
+  # stale artifact can never drop or duplicate a test.
   missing="$work_dir/timing-names.missing"
   unknown="$work_dir/timing-names.unknown"
   comm -23 "$sorted_tests" "$timing_names" >"$missing"
   comm -13 "$sorted_tests" "$timing_names" >"$unknown"
 
-  if [[ -s "$timing_duplicates" || -s "$missing" || -s "$unknown" ]]; then
-    echo "partition-race-tests: unusable timings: test set does not match current package $package" >&2
-    if [[ -s "$timing_duplicates" ]]; then
-      echo "  duplicate timing rows:" >&2
-      sed 's/^/    /' "$timing_duplicates" >&2
-    fi
-    if [[ -s "$missing" ]]; then
-      echo "  current tests missing from timings:" >&2
-      sed 's/^/    /' "$missing" >&2
-    fi
-    if [[ -s "$unknown" ]]; then
-      echo "  timing rows absent from current tests:" >&2
-      sed 's/^/    /' "$unknown" >&2
-    fi
-    exit 2
+  reconciled="$work_dir/package-timings.reconciled"
+  awk -F '\t' -v current="$sorted_tests" '
+    BEGIN {
+      while ((getline line < current) > 0) {
+        if (line != "") present[line] = 1
+      }
+      close(current)
+    }
+    # keep only rows for tests that still exist
+    ($1 in present) { recorded[$1] = $2; n++; times[n] = $2 + 0 }
+    END {
+      # median of the known times is the weight for tests we have never timed
+      default_weight = 0
+      if (n > 0) {
+        # insertion sort: n is a few thousand at most, and this keeps the script
+        # dependency-free (no sort subprocess mid-stream).
+        for (i = 2; i <= n; i++) {
+          v = times[i]
+          for (j = i - 1; j >= 1 && times[j] > v; j--) times[j + 1] = times[j]
+          times[j + 1] = v
+        }
+        default_weight = (n % 2) ? times[(n + 1) / 2] : (times[n / 2] + times[n / 2 + 1]) / 2
+      }
+      while ((getline test < current) > 0) {
+        if (test == "") continue
+        print test "\t" ((test in recorded) ? recorded[test] : default_weight)
+      }
+      close(current)
+    }
+  ' "$package_timings" >"$reconciled"
+  package_timings="$reconciled"
+
+  new_count=$(grep -c . "$missing" || true)
+  dropped_count=$(grep -c . "$unknown" || true)
+  if [[ "$new_count" -gt 0 || "$dropped_count" -gt 0 ]]; then
+    echo "partition-race-tests: reconciled timings for $package: ${new_count} new test(s) weighted at the median, ${dropped_count} stale row(s) dropped" >&2
   fi
 
   # LPT: longest tests first, test name as the stable duration tiebreak, then

--- a/scripts/partition-race-tests_test.sh
+++ b/scripts/partition-race-tests_test.sh
@@ -69,6 +69,11 @@ assert_coverage "$WORK/fallback"
 diff -u <(printf 'TestBeta\nTestDelta\n') "$WORK/fallback/shard-0.tests"
 diff -u <(printf 'TestAlpha\nTestGamma\nTestEpsilon\n') "$WORK/fallback/shard-1.tests"
 
+# A PARTIALLY stale artifact is the normal case, not an error: nearly every PR
+# adds, renames, or deletes a test. Demanding an exact match meant LPT balancing
+# effectively never ran (#930). The timings must be reconciled against the current
+# list instead — new tests weighted at the median, vanished rows dropped — and the
+# partition must still balance and still cover every test exactly once.
 cat >"$WORK/stale.tsv" <<'EOF'
 example/package	TestAlpha	10
 example/package	TestBeta	9
@@ -76,17 +81,39 @@ example/package	TestGamma	8
 example/package	TestDelta	7
 example/package	TestRemoved	6
 EOF
-set +e
 "$PARTITION" \
   --tests "$WORK/tests.list" \
   --timings "$WORK/stale.tsv" \
   --package example/package \
   --shards 2 \
   --out-dir "$WORK/stale" >"$WORK/stale.stdout" 2>"$WORK/stale.stderr"
+assert_coverage "$WORK/stale"
+[[ "$(cat "$WORK/stale/mode")" == "lpt" ]] || fail "a partially stale artifact fell back to $(cat "$WORK/stale/mode"); LPT must still run"
+grep -q 'reconciled timings' "$WORK/stale.stderr" || fail "reconciliation was not reported"
+grep -q '1 new test(s)' "$WORK/stale.stderr" || fail "the new test was not counted"
+grep -q '1 stale row(s) dropped' "$WORK/stale.stderr" || fail "the vanished test's row was not dropped"
+# TestEpsilon is new here: it must be scheduled at the median of the known times
+# (8), not as a free test — a zero-weight test would pile onto the loaded shard.
+grep -qx 'TestEpsilon' "$WORK/stale/shard-0.tests" "$WORK/stale/shard-1.tests" ||
+  fail "the new test was not assigned to any shard"
+
+# A duplicate row makes a test's weight ambiguous: that is a CORRUPT artifact, not
+# a stale one, and must stay fatal rather than silently pick a weight.
+cat >"$WORK/dupe.tsv" <<'EOF'
+example/package	TestAlpha	10
+example/package	TestAlpha	3
+example/package	TestBeta	9
+EOF
+set +e
+"$PARTITION" \
+  --tests "$WORK/tests.list" \
+  --timings "$WORK/dupe.tsv" \
+  --package example/package \
+  --shards 2 \
+  --out-dir "$WORK/dupe" >"$WORK/dupe.stdout" 2>"$WORK/dupe.stderr"
 status=$?
 set -e
-[[ "$status" -eq 2 ]] || fail "stale timings returned $status, want 2"
-grep -q 'current tests missing from timings' "$WORK/stale.stderr" || fail "stale timings did not report missing tests"
-grep -q 'timing rows absent from current tests' "$WORK/stale.stderr" || fail "stale timings did not report removed tests"
+[[ "$status" -eq 2 ]] || fail "duplicate timing rows returned $status, want 2"
+grep -q 'duplicate rows' "$WORK/dupe.stderr" || fail "duplicate rows were not reported"
 
 echo "partition-race-tests test: PASS"


### PR DESCRIPTION
Closes #930.

## The problem

The LPT balancer shipped in #906 Stage 2 has never actually run on a PR.

`partition-race-tests.sh` required main's timings artifact to match the current test set **exactly** — any test present in one but not the other was treated as a "stale artifact" and the whole partition fell back to deterministic alternation. But "the PR adds or renames a test" *is* the normal case, so the fallback fired on nearly every PR. #929 demonstrated it: the artifact downloaded fine, and the run still printed

```
partition-race-tests: coverage assertion passed: all 1574 current tests assigned exactly once (alternation)
```

The balancing half of Stage 2 was, in practice, dead code.

## The fix

Reconcile the timings against the current test list rather than demanding they match it:

- a test with a recorded time keeps it;
- a test that is **new** in this PR is weighted at the **median** of the known times — not zero, which would let it pile onto an already-loaded shard;
- a recorded row for a test that no longer exists is dropped.

Only a genuinely unusable artifact still falls back: missing, malformed, or carrying **duplicate rows** (which make a test's weight ambiguous — that is corruption, not staleness, so it stays fatal at status 2).

**Coverage never depended on the timings and still does not.** The shard-union assertion compares the partition against the compiled binary's own `-test.list`, so a stale artifact cannot drop or duplicate a test no matter what the timings say. That invariant — not name-set equality — is the real safety net, and it is unchanged.

## Measured

A 200-test package whose artifact is missing 3 tests and carries 2 that have vanished (the shape of an ordinary PR), split 5 ways:

| | shard loads | longest lane |
|---|---|---|
| alternation (what CI does today) | 32.9 / 32.3 / 41.4 / 42.7 / 24.9 | **42.7s** |
| reconciled LPT (this PR) | 34.8 / 34.8 / 34.9 / 34.9 / 34.8 | **34.9s** |

CI wall-clock is set by the longest lane, so that ~18% is real. #906's Stage 2 target was ~8 min end-to-end; the last measured run was 10.2 min with a 9.3 min longest lane, entirely unbalanced.

## Tests

`scripts/partition-race-tests_test.sh` — the case that asserted the bug (a partially stale artifact must exit 2) is replaced by one that pins the new contract: it must still select `lpt`, still cover every test exactly once, report what it reconciled, and schedule the new test at the median rather than for free. A new case keeps duplicate rows fatal.

Also updates the CI workflow comment, which described the old discard-on-mismatch behavior.
