### PR TITLE
fix(credgw): give gateway children a credential-free CLAUDE_CONFIG_DIR — model_gateway was unusable (#936)

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -49,6 +49,15 @@ The gateway authenticates the placeholder, replaces it with the real upstream
 credential, streams the response, and revokes the placeholder when delivery
 ends. Unknown and revoked placeholders receive `401`.
 
+Because Claude Code prefers a cached `~/.claude/.credentials.json` over the
+`CLAUDE_CODE_OAUTH_TOKEN` env var, the child is also pointed at a per-home
+`CLAUDE_CONFIG_DIR` under the Gitmoot home that mirrors the operator's real
+Claude config (settings, skills, commands, `CLAUDE.md`) but omits the cached
+credential. Without this the child would authenticate from the cached
+credential and ignore the placeholder — the gateway would then `401` the
+delivery (#936). The mirror never contains a credential; the operator's real
+config is only read, never modified.
+
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery
 instead of falling back to ambient auth, Claude's credential store, or direct
@@ -108,11 +117,13 @@ The model gateway is credential custody, policy, and attribution, not a hard
 egress boundary. These two limits are deliberate:
 
 1. env-var routing is cooperative, not a hard egress boundary — a malicious
-   agent can unset it; this buys credential custody/policy/attribution, not
-   enforcement.
+   agent can unset `ANTHROPIC_BASE_URL`, or point `CLAUDE_CONFIG_DIR` back at
+   the operator's real `~/.claude` to read the cached credential directly. This
+   buys credential custody/policy/attribution against a prompt-injected or
+   misbehaving agent, not enforcement against one that actively evades.
 2. The strong "agents never hold real credentials" claim also requires
-   Landlock read-rules for `runtime-auth.env` (same-UID read is currently
-   possible) — that is P3.
+   Landlock read-rules for `runtime-auth.env` and `~/.claude/.credentials.json`
+   (same-UID read is currently possible) — that is P3.
 
 Codex/Kimi custody, MITM CA support, corporate proxy/`NO_PROXY` interoperability,
 Landlock read restrictions, and hard egress enforcement remain P3. SSH keys,

--- a/internal/cli/claude_gateway_config.go
+++ b/internal/cli/claude_gateway_config.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// claudeCredentialsFile is the cached-credential file inside a Claude config
+// directory. Claude Code prefers it over the CLAUDE_CODE_OAUTH_TOKEN env var, so
+// a child that can see it authenticates from the cached credential and ignores
+// the gateway's placeholder (#936). Excluding exactly this file — and nothing
+// else — is what forces the child onto the placeholder while keeping its
+// settings, skills, and memory.
+const claudeCredentialsFile = ".credentials.json"
+
+// buildClaudeGatewayConfigDir returns a Claude config directory, under the
+// gitmoot home, that mirrors the operator's real Claude config EXCEPT for the
+// cached credential. Every other entry (settings, skills, commands, agents,
+// CLAUDE.md, …) is symlinked through, so a gateway child keeps them but has no
+// credential to prefer over the injected placeholder.
+//
+// It is idempotent: existing correct symlinks are left in place, stale ones are
+// repaired, and real files Claude wrote into the dir on a prior run are never
+// clobbered. The one hard guarantee is that the result never contains a
+// .credentials.json.
+func buildClaudeGatewayConfigDir(gitmootHome string) (string, error) {
+	dest := filepath.Join(gitmootHome, "runtime", "claude-gateway-config")
+	if err := os.MkdirAll(dest, 0o700); err != nil {
+		return "", fmt.Errorf("create claude gateway config dir: %w", err)
+	}
+
+	// Guarantee no credential lives here — a stale symlink to the real one, or a
+	// file Claude wrote itself after a refresh attempt.
+	if err := os.RemoveAll(filepath.Join(dest, claudeCredentialsFile)); err != nil {
+		return "", fmt.Errorf("remove cached credential from claude gateway config dir: %w", err)
+	}
+
+	source := realClaudeConfigDir()
+	if source == "" || source == dest {
+		return dest, nil
+	}
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No real config yet: an empty dir (no credential) is exactly right.
+			return dest, nil
+		}
+		return "", fmt.Errorf("read claude config dir %q: %w", source, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == claudeCredentialsFile {
+			continue // the one thing we deny
+		}
+		link := filepath.Join(dest, name)
+		target := filepath.Join(source, name)
+		switch info, err := os.Lstat(link); {
+		case err == nil && info.Mode()&os.ModeSymlink != 0:
+			// Repair a symlink that points somewhere stale; leave a correct one.
+			if current, _ := os.Readlink(link); current != target {
+				if err := os.Remove(link); err != nil {
+					return "", fmt.Errorf("replace stale claude config link %q: %w", link, err)
+				}
+				if err := os.Symlink(target, link); err != nil {
+					return "", fmt.Errorf("relink claude config entry %q: %w", name, err)
+				}
+			}
+		case err == nil:
+			// A real file/dir Claude wrote here — do not clobber its runtime state.
+		case os.IsNotExist(err):
+			if err := os.Symlink(target, link); err != nil && !os.IsExist(err) {
+				return "", fmt.Errorf("mirror claude config entry %q: %w", name, err)
+			}
+		default:
+			return "", fmt.Errorf("inspect claude config entry %q: %w", link, err)
+		}
+	}
+	return dest, nil
+}
+
+// realClaudeConfigDir is where Claude Code looks by default: $CLAUDE_CONFIG_DIR
+// if set, otherwise ~/.claude. Empty when the home cannot be resolved (the caller
+// then mirrors nothing, which still yields a credential-free dir).
+func realClaudeConfigDir() string {
+	if value := strings.TrimSpace(os.Getenv(runtime.ClaudeConfigDirEnv)); value != "" {
+		return value
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}

--- a/internal/cli/claude_gateway_config_test.go
+++ b/internal/cli/claude_gateway_config_test.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/runtime"
+)
+
+// The child config dir must mirror the real Claude config so the agent keeps its
+// settings and skills, but must never carry the cached credential — otherwise
+// Claude authenticates from it and ignores the gateway placeholder (#936).
+func TestBuildClaudeGatewayConfigDirMirrorsEverythingButTheCredential(t *testing.T) {
+	source := t.TempDir()
+	t.Setenv(runtime.ClaudeConfigDirEnv, source)
+	mustWrite(t, filepath.Join(source, claudeCredentialsFile), "REAL-SECRET-CREDENTIAL")
+	mustWrite(t, filepath.Join(source, "settings.json"), `{"theme":"dark"}`)
+	mustWrite(t, filepath.Join(source, "CLAUDE.md"), "user memory")
+	if err := os.MkdirAll(filepath.Join(source, "skills", "gitmoot"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(source, "skills", "gitmoot", "SKILL.md"), "skill body")
+
+	dest, err := buildClaudeGatewayConfigDir(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The credential must be absent, and reachable through no path.
+	if _, err := os.Lstat(filepath.Join(dest, claudeCredentialsFile)); !os.IsNotExist(err) {
+		t.Fatalf("credential present in child config dir: err=%v", err)
+	}
+	// Settings and skills must be reachable (read THROUGH the mirror).
+	if got := readThrough(t, filepath.Join(dest, "settings.json")); got != `{"theme":"dark"}` {
+		t.Fatalf("settings not mirrored: %q", got)
+	}
+	if got := readThrough(t, filepath.Join(dest, "CLAUDE.md")); got != "user memory" {
+		t.Fatalf("CLAUDE.md not mirrored: %q", got)
+	}
+	if got := readThrough(t, filepath.Join(dest, "skills", "gitmoot", "SKILL.md")); got != "skill body" {
+		t.Fatalf("skills not mirrored: %q", got)
+	}
+	// And the real credential must not be findable anywhere under dest.
+	assertNoCredentialUnder(t, dest, "REAL-SECRET-CREDENTIAL")
+}
+
+// If Claude wrote a .credentials.json into the child dir on a prior run (e.g. a
+// refresh attempt), a rebuild must scrub it — the invariant is "no credential
+// here", regardless of who wrote it.
+func TestBuildClaudeGatewayConfigDirScrubsAWrittenCredential(t *testing.T) {
+	source := t.TempDir()
+	t.Setenv(runtime.ClaudeConfigDirEnv, source)
+	home := t.TempDir()
+
+	dest, err := buildClaudeGatewayConfigDir(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(dest, claudeCredentialsFile), "child-wrote-this")
+
+	dest2, err := buildClaudeGatewayConfigDir(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dest2 != dest {
+		t.Fatalf("config dir path changed across rebuilds: %q vs %q", dest, dest2)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, claudeCredentialsFile)); !os.IsNotExist(err) {
+		t.Fatal("rebuild did not scrub a written credential")
+	}
+}
+
+// A rebuild is idempotent and must not clobber real runtime state the child wrote
+// into the config dir (projects, todos, …).
+func TestBuildClaudeGatewayConfigDirIsIdempotentAndKeepsChildWrites(t *testing.T) {
+	source := t.TempDir()
+	t.Setenv(runtime.ClaudeConfigDirEnv, source)
+	mustWrite(t, filepath.Join(source, "settings.json"), "s1")
+	home := t.TempDir()
+
+	dest, err := buildClaudeGatewayConfigDir(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The child writes real runtime state that the source does not have.
+	mustWrite(t, filepath.Join(dest, "projects", "p1.json"), "child project state")
+
+	if _, err := buildClaudeGatewayConfigDir(home); err != nil {
+		t.Fatal(err)
+	}
+	if got := readThrough(t, filepath.Join(dest, "projects", "p1.json")); got != "child project state" {
+		t.Fatalf("rebuild clobbered child runtime state: %q", got)
+	}
+	if got := readThrough(t, filepath.Join(dest, "settings.json")); got != "s1" {
+		t.Fatalf("settings link lost on rebuild: %q", got)
+	}
+}
+
+// No real config dir at all still yields a usable, credential-free dir.
+func TestBuildClaudeGatewayConfigDirWithNoSource(t *testing.T) {
+	t.Setenv(runtime.ClaudeConfigDirEnv, filepath.Join(t.TempDir(), "does-not-exist"))
+	dest, err := buildClaudeGatewayConfigDir(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info, err := os.Stat(dest); err != nil || !info.IsDir() {
+		t.Fatalf("dest not a directory: err=%v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(dest, claudeCredentialsFile)); !os.IsNotExist(err) {
+		t.Fatal("empty-source dir somehow has a credential")
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readThrough(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %q: %v", path, err)
+	}
+	return string(data)
+}
+
+func assertNoCredentialUnder(t *testing.T, root, secret string) {
+	t.Helper()
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr == nil && string(data) == secret {
+			t.Fatalf("real credential reachable at %q", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/credential_gateway.go
+++ b/internal/cli/credential_gateway.go
@@ -28,6 +28,12 @@ func buildModelGatewayRunner(home string, cfg config.CredentialsConfig, auth run
 	if err != nil {
 		return nil, fmt.Errorf("start Claude model gateway: %w", err)
 	}
+	// Without a credential-free config dir the child reads ~/.claude/.credentials.json
+	// and ignores the placeholder — the gateway would then 401 every job (#936).
+	configDir, err := buildClaudeGatewayConfigDir(home)
+	if err != nil {
+		return nil, fmt.Errorf("prepare Claude gateway config dir: %w", err)
+	}
 	return &credgw.Runner{
 		Inner:      inner,
 		Gateway:    gateway,
@@ -36,6 +42,7 @@ func buildModelGatewayRunner(home string, cfg config.CredentialsConfig, auth run
 			Upstream:     modelGatewayUpstreamURL,
 			AllowedHosts: append([]string{}, cfg.ModelGatewayAllowHosts...),
 		},
+		ChildConfigDir: configDir,
 	}, nil
 }
 

--- a/internal/cli/credential_gateway_test.go
+++ b/internal/cli/credential_gateway_test.go
@@ -82,6 +82,7 @@ model_gateway_allow_hosts = ["api.anthropic.com"]
 			t.Setenv(runtime.ClaudeOAuthTokenEnv, "ambient-oauth-must-not-reach-child")
 			t.Setenv(runtime.AnthropicAPIKeyEnv, "ambient-api-key-must-not-reach-child")
 			t.Setenv(runtime.AnthropicAuthTokenEnv, "ambient-auth-token-must-not-reach-child")
+			t.Setenv(runtime.ClaudeConfigDirEnv, t.TempDir()) // isolate: never mirror the box's real ~/.claude
 
 			registry := credgw.NewRegistry()
 			previousRegistry := modelGatewayRegistry
@@ -240,6 +241,19 @@ model_gateway_allow_hosts = [%q]
 	t.Setenv(runtime.ClaudeOAuthTokenEnv, "ambient-credential-must-not-win")
 	t.Setenv(runtime.AnthropicAPIKeyEnv, "ambient-api-key-must-not-win")
 
+	// The heart of #936: a real Claude config with a CACHED CREDENTIAL. Claude
+	// prefers this file over the env token, so the child must be pointed at a
+	// mirror that excludes it — otherwise the placeholder injection is moot.
+	sourceConfig := t.TempDir()
+	cachedCredential := "sk-ant-oat01-cached-credentials-file-must-not-reach-child"
+	if err := os.WriteFile(filepath.Join(sourceConfig, claudeCredentialsFile), []byte(cachedCredential), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceConfig, "settings.json"), []byte(`{"agent":"keep me"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(runtime.ClaudeConfigDirEnv, sourceConfig)
+
 	previousRegistry := modelGatewayRegistry
 	previousUpstream := modelGatewayUpstreamURL
 	previousLogf := modelGatewayLogf
@@ -291,15 +305,31 @@ model_gateway_allow_hosts = [%q]
 	if !strings.Contains(dumpText, "CLAUDE_CODE_OAUTH_TOKEN=gitmoot-kc-gateway-e2e-job-") || !strings.Contains(dumpText, "ANTHROPIC_BASE_URL=http://127.0.0.1:") {
 		t.Fatalf("child env dump = %q", dumpText)
 	}
+
+	// #936: the child must be pointed at a config dir that is NOT the operator's
+	// real one, and that dir must not contain the cached credential — otherwise
+	// claude would authenticate from the credential and ignore the placeholder.
+	childConfigDir := envDumpValue(dumpText, runtime.ClaudeConfigDirEnv)
+	if childConfigDir == "" || childConfigDir == sourceConfig {
+		t.Fatalf("child CLAUDE_CONFIG_DIR = %q, want a mirror distinct from the real config", childConfigDir)
+	}
+	if _, err := os.Lstat(filepath.Join(childConfigDir, claudeCredentialsFile)); !os.IsNotExist(err) {
+		t.Fatalf("cached credential present in child config dir: err=%v", err)
+	}
+	if got := readThrough(t, filepath.Join(childConfigDir, "settings.json")); got != `{"agent":"keep me"}` {
+		t.Fatalf("child lost its settings through the mirror: %q", got)
+	}
+
 	// Wait for the gateway's own request log before asserting on log contents:
 	// it is written by the request goroutine after the response is proxied back,
 	// so reading too early would make these leak checks vacuous.
 	logged := logs.waitFor(t, "job_id=gateway-e2e-job")
-	for _, secret := range []string{realToken, "ambient-credential-must-not-win", "ambient-api-key-must-not-win"} {
+	for _, secret := range []string{realToken, cachedCredential, "ambient-credential-must-not-win", "ambient-api-key-must-not-win"} {
 		if strings.Contains(dumpText, secret) || strings.Contains(logged, secret) {
 			t.Fatalf("credential leaked through child env/logs")
 		}
 	}
+	assertNoCredentialUnder(t, childConfigDir, cachedCredential)
 	placeholder := envDumpValue(dumpText, runtime.ClaudeOAuthTokenEnv)
 	if placeholder == "" || strings.Contains(logged, placeholder) {
 		t.Fatalf("placeholder missing or logged: logs=%q", logged)
@@ -322,11 +352,12 @@ func TestClaudeModelGatewayShimProcess(t *testing.T) {
 	}
 	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
 	placeholder := os.Getenv(runtime.ClaudeOAuthTokenEnv)
-	dump := fmt.Sprintf("%s=%s\n%s=%s\n%s=%s\nANTHROPIC_BASE_URL=%s\n",
+	dump := fmt.Sprintf("%s=%s\n%s=%s\n%s=%s\nANTHROPIC_BASE_URL=%s\n%s=%s\n",
 		runtime.ClaudeOAuthTokenEnv, placeholder,
 		runtime.AnthropicAPIKeyEnv, os.Getenv(runtime.AnthropicAPIKeyEnv),
 		runtime.AnthropicAuthTokenEnv, os.Getenv(runtime.AnthropicAuthTokenEnv),
 		baseURL,
+		runtime.ClaudeConfigDirEnv, os.Getenv(runtime.ClaudeConfigDirEnv),
 	)
 	if err := os.WriteFile(os.Getenv("GITMOOT_CLAUDE_GATEWAY_ENV_DUMP"), []byte(dump), 0o600); err != nil {
 		os.Exit(2)

--- a/internal/credgw/runner.go
+++ b/internal/credgw/runner.go
@@ -8,7 +8,14 @@ import (
 	"github.com/jerryfane/gitmoot/internal/subprocess"
 )
 
-const anthropicBaseURLEnv = "ANTHROPIC_BASE_URL"
+const (
+	anthropicBaseURLEnv = "ANTHROPIC_BASE_URL"
+	// claudeConfigDirEnv points the Claude CLI at a config directory. The gateway
+	// sets it to a store WITHOUT a cached credential so the child authenticates
+	// from the injected placeholder instead of ~/.claude/.credentials.json, which
+	// Claude otherwise prefers over CLAUDE_CODE_OAUTH_TOKEN (#936).
+	claudeConfigDirEnv = "CLAUDE_CONFIG_DIR"
+)
 
 type Lease struct {
 	gateway     *Gateway
@@ -45,13 +52,20 @@ func WithLease(ctx context.Context, lease *Lease) context.Context {
 	})
 }
 
-// Runner injects only the loopback route and per-job placeholder. The real
-// credential remains in the gateway's in-memory lease entry.
+// Runner injects the loopback route, the per-job placeholder, and — so the child
+// cannot fall back to a cached credential store — a credential-free
+// CLAUDE_CONFIG_DIR. The real credential remains in the gateway's in-memory lease
+// entry.
 type Runner struct {
 	Inner      subprocess.Runner
 	Gateway    *Gateway
 	Credential Credential
 	Policy     Policy
+	// ChildConfigDir, when set, is injected as CLAUDE_CONFIG_DIR. It must be a
+	// Claude config directory that contains no .credentials.json, or the child
+	// will authenticate from the cached credential and ignore the placeholder
+	// (#936). Empty leaves CLAUDE_CONFIG_DIR untouched (pre-#936 behavior).
+	ChildConfigDir string
 }
 
 func (r *Runner) NewLease(jobID string) (*Lease, error) {
@@ -88,6 +102,10 @@ func (r *Runner) runEnv(ctx context.Context, dir string, env []string, command s
 		"ANTHROPIC_API_KEY=",
 		"ANTHROPIC_AUTH_TOKEN=",
 		anthropicBaseURLEnv + "=" + r.Gateway.URL(),
+	}
+	if r.ChildConfigDir != "" {
+		// Last, so it wins over any CLAUDE_CONFIG_DIR the caller passed in env.
+		gatewayEnv = append(gatewayEnv, claudeConfigDirEnv+"="+r.ChildConfigDir)
 	}
 	merged := append(append([]string{}, env...), gatewayEnv...)
 	inner, ok := r.inner().(subprocess.EnvRunner)

--- a/internal/credgw/runner_test.go
+++ b/internal/credgw/runner_test.go
@@ -1,0 +1,98 @@
+package credgw
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jerryfane/gitmoot/internal/subprocess"
+)
+
+// envCapture is an EnvRunner that records the env it was handed and runs nothing.
+type envCapture struct{ env []string }
+
+func (c *envCapture) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
+	return subprocess.Result{}, nil
+}
+func (c *envCapture) LookPath(string) (string, error) { return "", nil }
+func (c *envCapture) RunEnv(_ context.Context, _ string, env []string, _ string, _ ...string) (subprocess.Result, error) {
+	c.env = append([]string{}, env...)
+	return subprocess.Result{}, nil
+}
+
+func envValue(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for i := len(env) - 1; i >= 0; i-- { // last wins, matching real env semantics
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix), true
+		}
+	}
+	return "", false
+}
+
+func newTestGateway(t *testing.T) *Gateway {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { gateway.Close(context.Background()) })
+	t.Cleanup(func() { t.Setenv("_", upstream.URL) }) // keep upstream referenced
+	return gateway
+}
+
+// The runner must inject CLAUDE_CONFIG_DIR when it has one, so the child cannot
+// fall back to its cached credential store (#936). Without it, the placeholder
+// injection is defeated by ~/.claude/.credentials.json.
+func TestRunnerInjectsChildConfigDir(t *testing.T) {
+	gateway := newTestGateway(t)
+	capture := &envCapture{}
+	runner := &Runner{
+		Inner:          capture,
+		Gateway:        gateway,
+		Credential:     Credential{Kind: CredentialBearer, Value: "real-token"},
+		Policy:         Policy{Upstream: DefaultAnthropicUpstream, AllowedHosts: []string{"api.anthropic.com"}},
+		ChildConfigDir: "/gitmoot/home/runtime/claude-gateway-config",
+	}
+	if _, err := runner.Run(context.Background(), "", "claude", "-p", "hi"); err != nil {
+		t.Fatal(err)
+	}
+
+	dir, ok := envValue(capture.env, "CLAUDE_CONFIG_DIR")
+	if !ok || dir != "/gitmoot/home/runtime/claude-gateway-config" {
+		t.Fatalf("CLAUDE_CONFIG_DIR = %q (present=%t), want the child config dir", dir, ok)
+	}
+	// The placeholder — never the real token — must be the injected credential.
+	token, _ := envValue(capture.env, "CLAUDE_CODE_OAUTH_TOKEN")
+	if token == "" || token == "real-token" || !strings.HasPrefix(token, "gitmoot-kc-") {
+		t.Fatalf("CLAUDE_CODE_OAUTH_TOKEN = %q, want a placeholder", token)
+	}
+	if base, ok := envValue(capture.env, "ANTHROPIC_BASE_URL"); !ok || !strings.HasPrefix(base, "http://127.0.0.1:") {
+		t.Fatalf("ANTHROPIC_BASE_URL = %q", base)
+	}
+}
+
+// An empty ChildConfigDir must leave CLAUDE_CONFIG_DIR untouched (pre-#936
+// behavior), so the caller's own value — if any — is not overwritten.
+func TestRunnerWithoutChildConfigDirLeavesItUntouched(t *testing.T) {
+	gateway := newTestGateway(t)
+	capture := &envCapture{}
+	runner := &Runner{
+		Inner:      capture,
+		Gateway:    gateway,
+		Credential: Credential{Kind: CredentialBearer, Value: "real-token"},
+		Policy:     Policy{Upstream: DefaultAnthropicUpstream, AllowedHosts: []string{"api.anthropic.com"}},
+	}
+	if _, err := runner.RunEnv(context.Background(), "", []string{"CLAUDE_CONFIG_DIR=/caller/dir"}, "claude", "-p", "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if dir, _ := envValue(capture.env, "CLAUDE_CONFIG_DIR"); dir != "/caller/dir" {
+		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want the caller's value preserved", dir)
+	}
+}

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -130,8 +130,11 @@ job-scoped placeholder; the daemon snapshots the real `runtime-auth.env`
 credential, attaches it only on the allowlisted upstream request, and revokes
 the placeholder when delivery returns. Unknown/revoked placeholders fail with
 `401`, and an unavailable gateway or unallowlisted upstream fails the delivery
-without direct-auth fallback. It is off by default and does not cover Codex or
-Kimi.
+without direct-auth fallback. The child is also pointed at a credential-free
+`CLAUDE_CONFIG_DIR` (a per-home mirror of the real Claude config minus
+`.credentials.json`), because Claude Code otherwise prefers its cached
+credential over the placeholder and the gateway would `401` every job (#936).
+It is off by default and does not cover Codex or Kimi.
 
 ### Runtime ambient credential hygiene
 
@@ -145,11 +148,13 @@ runtime exceptions, and `env_passthrough` syntax.
 The gateway has two explicit limits:
 
 1. env-var routing is cooperative, not a hard egress boundary — a malicious
-   agent can unset it; this buys credential custody/policy/attribution, not
-   enforcement.
+   agent can unset `ANTHROPIC_BASE_URL`, or point `CLAUDE_CONFIG_DIR` back at
+   the real `~/.claude` to read the cached credential. This buys credential
+   custody/policy/attribution against a prompt-injected or misbehaving agent,
+   not enforcement against one that actively evades.
 2. The strong "agents never hold real credentials" claim also requires
-   Landlock read-rules for `runtime-auth.env` (same-UID read is currently
-   possible) — that is P3.
+   Landlock read-rules for `runtime-auth.env` and `~/.claude/.credentials.json`
+   (same-UID read is currently possible) — that is P3.
 
 Codex/Kimi custody, Landlock read rules, MITM CA support, corporate
 proxy/`NO_PROXY` interoperability, and hard egress enforcement remain P3.

--- a/website/docs/reference/credentials.md
+++ b/website/docs/reference/credentials.md
@@ -49,6 +49,15 @@ The gateway authenticates the placeholder, replaces it with the real upstream
 credential, streams the response, and revokes the placeholder when delivery
 ends. Unknown and revoked placeholders receive `401`.
 
+Because Claude Code prefers a cached `~/.claude/.credentials.json` over the
+`CLAUDE_CODE_OAUTH_TOKEN` env var, the child is also pointed at a per-home
+`CLAUDE_CONFIG_DIR` under the Gitmoot home that mirrors the operator's real
+Claude config (settings, skills, commands, `CLAUDE.md`) but omits the cached
+credential. Without this the child would authenticate from the cached
+credential and ignore the placeholder — the gateway would then `401` the
+delivery (#936). The mirror never contains a credential; the operator's real
+config is only read, never modified.
+
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery
 instead of falling back to ambient auth, Claude's credential store, or direct
@@ -108,11 +117,13 @@ The model gateway is credential custody, policy, and attribution, not a hard
 egress boundary. These two limits are deliberate:
 
 1. env-var routing is cooperative, not a hard egress boundary — a malicious
-   agent can unset it; this buys credential custody/policy/attribution, not
-   enforcement.
+   agent can unset `ANTHROPIC_BASE_URL`, or point `CLAUDE_CONFIG_DIR` back at
+   the operator's real `~/.claude` to read the cached credential directly. This
+   buys credential custody/policy/attribution against a prompt-injected or
+   misbehaving agent, not enforcement against one that actively evades.
 2. The strong "agents never hold real credentials" claim also requires
-   Landlock read-rules for `runtime-auth.env` (same-UID read is currently
-   possible) — that is P3.
+   Landlock read-rules for `runtime-auth.env` and `~/.claude/.credentials.json`
+   (same-UID read is currently possible) — that is P3.
 
 Codex/Kimi custody, MITM CA support, corporate proxy/`NO_PROXY` interoperability,
 Landlock read restrictions, and hard egress enforcement remain P3. SSH keys,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -13870,8 +13870,11 @@ job-scoped placeholder; the daemon snapshots the real `runtime-auth.env`
 credential, attaches it only on the allowlisted upstream request, and revokes
 the placeholder when delivery returns. Unknown/revoked placeholders fail with
 `401`, and an unavailable gateway or unallowlisted upstream fails the delivery
-without direct-auth fallback. It is off by default and does not cover Codex or
-Kimi.
+without direct-auth fallback. The child is also pointed at a credential-free
+`CLAUDE_CONFIG_DIR` (a per-home mirror of the real Claude config minus
+`.credentials.json`), because Claude Code otherwise prefers its cached
+credential over the placeholder and the gateway would `401` every job (#936).
+It is off by default and does not cover Codex or Kimi.
 
 ### Runtime ambient credential hygiene
 
@@ -13885,11 +13888,13 @@ runtime exceptions, and `env_passthrough` syntax.
 The gateway has two explicit limits:
 
 1. env-var routing is cooperative, not a hard egress boundary — a malicious
-   agent can unset it; this buys credential custody/policy/attribution, not
-   enforcement.
+   agent can unset `ANTHROPIC_BASE_URL`, or point `CLAUDE_CONFIG_DIR` back at
+   the real `~/.claude` to read the cached credential. This buys credential
+   custody/policy/attribution against a prompt-injected or misbehaving agent,
+   not enforcement against one that actively evades.
 2. The strong "agents never hold real credentials" claim also requires
-   Landlock read-rules for `runtime-auth.env` (same-UID read is currently
-   possible) — that is P3.
+   Landlock read-rules for `runtime-auth.env` and `~/.claude/.credentials.json`
+   (same-UID read is currently possible) — that is P3.
 
 Codex/Kimi custody, Landlock read rules, MITM CA support, corporate
 proxy/`NO_PROXY` interoperability, and hard egress enforcement remain P3.


### PR DESCRIPTION
Closes #936.

## The bug

`[credentials] model_gateway = true` (#874-P2) was unusable as shipped, and its headline security property did not hold. I found both by running the **real** Claude CLI through the **real** gateway — our E2E used a *fake* `claude` shim, which faithfully reads the token from its env; the real CLI does not.

Claude Code prefers a cached `~/.claude/.credentials.json` over the `CLAUDE_CODE_OAUTH_TOKEN` env var. So the gateway child ignored the injected placeholder and sent **its own cached credential**. The gateway didn't recognise it, fail-closed `401`'d, and the job died — *and* the real key still left the agent process, which is exactly what #874-P2 exists to prevent.

Empirically, before the fix:

```
claude output = "Failed to authenticate. API Error: 401 unauthorized"
gateway log   = model gateway request method=POST status=401 job_id=   # placeholder never presented
# header capture: Authorization: Bearer sk-ant-…  [is_our_placeholder=False]
```

It is not a formatting issue — a correctly-shaped `sk-ant-oat01-…` placeholder is ignored too. Claude prefers the credential file by *presence*.

## The fix

Point the child at a per-home `CLAUDE_CONFIG_DIR`, under the gitmoot home, that mirrors the operator's real Claude config (`settings.json`, `skills/`, `commands/`, `agents/`, `CLAUDE.md`, …) via symlinks but **omits `.credentials.json`**. With no cached credential to prefer, Claude authenticates from the placeholder. The precedent is the doctor's own #486 probe, which already uses an isolated `CLAUDE_CONFIG_DIR` to stop cached creds masking a token — except a *real* job needs its settings and skills, so this mirrors rather than empties.

The mirror is idempotent, repairs stale links, never clobbers runtime state Claude writes into the dir, and is guaranteed credential-free on every rebuild (a `.credentials.json` Claude writes itself is scrubbed). The operator's real config is only read, never modified.

The runner appends `CLAUDE_CONFIG_DIR` last; Go's `os/exec` dedupes `cmd.Env` keeping the last value (verified empirically), so the injected dir wins over any ambient one — the injection can't be silently defeated by inherited env.

## Verified against the live API

With the fix, the real `claude -p` through the gateway returns `pong` (`EXIT=<nil>`), the child presents the placeholder, and the real token reaches only the upstream. Before it, the same probe `401`'d. (The probe is throwaway and not committed; it read the live token read-only and never touched `/root/.gitmoot`.)

## Tests

- `internal/cli/claude_gateway_config_test.go` — the mirror excludes the credential while `settings.json` / `skills/` / `CLAUDE.md` read through; a `.credentials.json` Claude wrote is scrubbed on rebuild; rebuilds are idempotent and keep the child's runtime writes; no-source still yields a credential-free dir; the real secret is unreachable anywhere under the mirror.
- `internal/credgw/runner_test.go` — the runner injects `CLAUDE_CONFIG_DIR` and the placeholder (never the real token); an empty `ChildConfigDir` leaves a caller's value untouched.
- `internal/cli/credential_gateway_test.go` (E2E, no-LLM, isolated /tmp home) — now **seeds a cached credential in the source config** and asserts the child is steered to a mirror that excludes it, keeps its settings, and never sees the cached secret. That is the exact gap the fake-shim E2E missed.

Docs shipped in-PR: `docs/credentials.md`, `skills/gitmoot/references/SAFETY.md`, `website/docs/reference/credentials.md`, `llms-full` regenerated. The two honest limits now state that `CLAUDE_CONFIG_DIR` is cooperative routing (a malicious agent can point it back at `~/.claude`) and that the strong custody claim also needs a Landlock read-rule on the credentials file.

Gate: `go build` / `go vet` / `go generate` + diff clean / `go test ./internal/credgw/ ./internal/cli/ ./internal/config/ ./internal/runtime/` — all green.

`model_gateway` stays **off by default**; this makes it actually work when turned on.
