### PR TITLE
fix(daemon): bound advance_retry events so a stuck job can't pin a CPU core

### DIFF
--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -6836,6 +6836,28 @@ func (w jobWorker) jobNeedsAdvanceRetry(ctx context.Context, jobID string) (bool
 	return needsRetry, nil
 }
 
+// recordAdvanceRetryOnce appends an advance_retry marker UNLESS the job is already
+// sitting on one. A terminal job whose post-delivery advancement keeps failing is
+// re-attempted on every ~1s tick; appending a fresh advance_retry each time grew
+// job_events without bound (a real install reached ~1.8M rows — 96% of the table —
+// and the per-tick JobIDsWithPendingAdvanceRetry GROUP BY plus jobNeedsAdvanceRetry's
+// per-job ListJobEvents pinned a core with zero jobs in flight). Only the latest
+// marker per job is ever consulted (last-one-wins), so a job already on advance_retry
+// stays a candidate and keeps retrying with no new row; any other latest marker
+// (advance_started, or a prior terminal resolution before a re-trigger) still records
+// the transition to advance_retry. jobNeedsAdvanceRetry and JobIDsWithPendingAdvanceRetry
+// see an identical candidate set either way.
+func (w jobWorker) recordAdvanceRetryOnce(ctx context.Context, jobID, message string) error {
+	latest, err := w.Store.LatestAdvancementMarker(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if latest == "advance_retry" {
+		return nil
+	}
+	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: "advance_retry", Message: message})
+}
+
 func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
 	payload, err := daemonJobPayload(job)
 	if err != nil {
@@ -6847,13 +6869,13 @@ func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
 	}
 	agent := runtimeAgent(dbAgent)
 	if refreshed, ok, err := w.refreshImplementedPayloadForRetry(ctx, job, payload); err != nil {
-		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry", Message: "post-delivery workflow retry refresh failed: " + err.Error()})
+		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry refresh failed: "+err.Error())
 	} else if ok {
 		payload = refreshed
 	}
 	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
 	if err != nil {
-		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry", Message: "post-delivery workflow retry preflight failed: " + err.Error()})
+		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry preflight failed: "+err.Error())
 	}
 	engine := w.WorkflowFactory(checkout)
 	if err := engine.AdvanceJob(ctx, job.ID); err != nil {
@@ -6865,7 +6887,7 @@ func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
 		if errors.As(err, &blocked) {
 			return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_blocked", Message: err.Error()})
 		}
-		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry", Message: "post-delivery workflow retry failed: " + err.Error()})
+		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry failed: "+err.Error())
 	}
 	writeLine(w.Stdout, "job %s advancement retried", job.ID)
 	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retried", Message: "post-delivery workflow retry completed"})
@@ -8423,11 +8445,8 @@ func (w jobWorker) delegationParentCheckout(ctx context.Context, job db.Job) str
 }
 
 func (w jobWorker) recordPostDeliveryWorkflowError(ctx context.Context, job db.Job, cause error) error {
-	return w.Store.AddJobEvent(ctx, db.JobEvent{
-		JobID:   job.ID,
-		Kind:    "advance_retry",
-		Message: "post-delivery workflow error; advancement will retry from stored result: " + cause.Error(),
-	})
+	return w.recordAdvanceRetryOnce(ctx, job.ID,
+		"post-delivery workflow error; advancement will retry from stored result: "+cause.Error())
 }
 
 func (w jobWorker) postJobResultComment(ctx context.Context, jobID string, agent runtime.Agent, _ string, cause error) error {

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -4964,6 +4964,72 @@ func TestRunQueuedJobsRecordsPostDeliveryWorkflowErrorForRetry(t *testing.T) {
 	}
 }
 
+// TestRetryPendingJobAdvancementsDoesNotAccumulateAdvanceRetry guards the fix for
+// the unbounded job_events growth that pinned a daemon core: a job whose
+// post-delivery advancement keeps failing must NOT append a fresh advance_retry
+// on every tick. Across many failed retry passes the job stays a candidate but
+// its advance_retry row count stays at one.
+func TestRetryPendingJobAdvancementsDoesNotAccumulateAdvanceRetry(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "reviewer", runtime.ShellRuntime, "unused", []string{"review"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:          "job-review",
+		Agent:       "reviewer",
+		Action:      "review",
+		Repo:        "owner/repo",
+		Branch:      "task-1",
+		PullRequest: 1,
+		TaskID:      "task-1",
+		HeadSHA:     strings.Repeat("a", 40),
+	})
+	gate := &cliWorkerFakeMergeGate{err: errors.New("github unavailable")}
+	adapter := &cliWorkerFakeAdapter{
+		output: `{"gitmoot_result":{"decision":"approved","summary":"approved","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, MergeGate: gate}
+	}
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	// The gate stays broken: every retry pass fails advancement again.
+	for i := 0; i < 5; i++ {
+		if err := retryPendingJobAdvancements(ctx, worker, "", "", nil, newTickCandidates(worker.Store)); err != nil {
+			t.Fatalf("retryPendingJobAdvancements pass %d returned error: %v", i, err)
+		}
+	}
+	events, err := store.ListJobEvents(ctx, "job-review")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	retries := 0
+	for _, e := range events {
+		if e.Kind == "advance_retry" {
+			retries++
+		}
+	}
+	if retries != 1 {
+		t.Fatalf("advance_retry events = %d after 5 failed retry passes, want 1 (no per-tick accumulation)", retries)
+	}
+	// Still a live candidate — the job is not silently dropped from retry.
+	ids, err := store.JobIDsWithPendingAdvanceRetry(ctx)
+	if err != nil {
+		t.Fatalf("JobIDsWithPendingAdvanceRetry returned error: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "job-review" {
+		t.Fatalf("pending advance-retry candidates = %v, want [job-review]", ids)
+	}
+}
+
 func TestRetryPendingJobAdvancementsRecoversStartedAdvancement(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)

--- a/internal/db/advance_retry_test.go
+++ b/internal/db/advance_retry_test.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLatestAdvancementMarker(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	if err := store.CreateJob(ctx, Job{ID: "j1", Agent: "w", Type: "implement", State: "succeeded", Payload: "{}"}); err != nil {
+		t.Fatal(err)
+	}
+	if k, err := store.LatestAdvancementMarker(ctx, "j1"); err != nil || k != "" {
+		t.Fatalf("no markers yet = %q, %v; want empty", k, err)
+	}
+	// A non-advancement event (queued) must be ignored; advance_retry is the latest
+	// advancement marker.
+	for _, kind := range []string{"advance_started", "queued", "advance_retry"} {
+		if err := store.AddJobEvent(ctx, JobEvent{JobID: "j1", Kind: kind, Message: "m"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if k, err := store.LatestAdvancementMarker(ctx, "j1"); err != nil || k != "advance_retry" {
+		t.Fatalf("latest = %q, %v; want advance_retry", k, err)
+	}
+	// A subsequent terminal resolution wins over the earlier advance_retry.
+	if err := store.AddJobEvent(ctx, JobEvent{JobID: "j1", Kind: "advance_retried", Message: "done"}); err != nil {
+		t.Fatal(err)
+	}
+	if k, err := store.LatestAdvancementMarker(ctx, "j1"); err != nil || k != "advance_retried" {
+		t.Fatalf("latest after resolve = %q, %v; want advance_retried", k, err)
+	}
+}
+
+// TestAdvanceRetryCollapseMigration proves the one-time heal migration collapses a
+// job's runaway advance_retry history (the pre-fix per-tick emission bug) down to a
+// single row while leaving the job a valid pending-advance-retry candidate.
+func TestAdvanceRetryCollapseMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	store, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if err := store.CreateJob(ctx, Job{ID: "stuck", Agent: "w", Type: "implement", State: "succeeded", Payload: "{}"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddJobEvent(ctx, JobEvent{JobID: "stuck", Kind: "advance_started", Message: "s"}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 50; i++ {
+		if err := store.AddJobEvent(ctx, JobEvent{JobID: "stuck", Kind: "advance_retry", Message: "fail"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Rewind the collapse migration by identity and re-open so it re-applies over
+	// the seeded duplicates.
+	collapseVersion := 0
+	for i, m := range migrations {
+		if strings.Contains(m, "DELETE FROM job_events") && strings.Contains(m, "advance_retry") {
+			collapseVersion = i + 1
+		}
+	}
+	if collapseVersion == 0 {
+		t.Fatal("advance_retry collapse migration not found")
+	}
+	if _, err := store.db.Exec(`DELETE FROM schema_migrations WHERE version = ?`, collapseVersion); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store2, err := Open(path)
+	if err != nil {
+		t.Fatalf("re-open (re-apply collapse migration): %v", err)
+	}
+	defer store2.Close()
+
+	events, err := store2.ListJobEvents(ctx, "stuck")
+	if err != nil {
+		t.Fatal(err)
+	}
+	retries := 0
+	for _, e := range events {
+		if e.Kind == "advance_retry" {
+			retries++
+		}
+	}
+	if retries != 1 {
+		t.Fatalf("advance_retry rows after collapse = %d, want 1", retries)
+	}
+	// Candidate semantics unchanged: the job is still surfaced as pending advance
+	// retry (last-one-wins over the surviving markers).
+	ids, err := store2.JobIDsWithPendingAdvanceRetry(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || ids[0] != "stuck" {
+		t.Fatalf("pending advance-retry candidates = %v, want [stuck]", ids)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -3628,6 +3628,29 @@ func (s *Store) GetLatestJobEventByKind(ctx context.Context, jobID, kind string)
 	return event, err == nil, err
 }
 
+// LatestAdvancementMarker returns the most recent post-delivery advancement
+// marker kind for jobID (or "" when the job has none). The kind set is exactly
+// the one jobNeedsAdvanceRetry (daemon.go) evaluates last-one-wins, so this is a
+// cheap way for the emitter to stay idempotent: a job already sitting on
+// advance_retry must not append another advance_retry on every ~1s tick — that
+// unbounded growth is what pinned a core once job_events reached hundreds of
+// thousands of rows (JobIDsWithPendingAdvanceRetry's per-tick GROUP BY and
+// jobNeedsAdvanceRetry's per-job ListJobEvents both scale with those rows). The
+// job stays a retry candidate regardless (last-one-wins is unchanged); only the
+// duplicate row is elided.
+func (s *Store) LatestAdvancementMarker(ctx context.Context, jobID string) (string, error) {
+	var kind string
+	err := s.db.QueryRowContext(ctx, `SELECT kind FROM job_events
+		WHERE job_id = ? AND kind IN (
+			'advance_started', 'advance_retry', 'advance_completed',
+			'advance_retried', 'advance_blocked', 'advance_retry_skipped', 'retry_queued')
+		ORDER BY id DESC LIMIT 1`, jobID).Scan(&kind)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return kind, err
+}
+
 // GetLatestJobEventsByKind returns the newest event of kind for each requested
 // job in one indexed query. Empty input returns an initialized empty map.
 func (s *Store) GetLatestJobEventsByKind(ctx context.Context, jobIDs []string, kind string) (map[string]JobEvent, error) {
@@ -9095,4 +9118,21 @@ CREATE TABLE pipeline_trigger_states (
 );
 CREATE INDEX idx_pipeline_trigger_states_upstream ON pipeline_trigger_states(upstream_pipeline);
 		`,
+	// Collapse unbounded advance_retry history. A terminal job whose post-delivery
+	// advancement kept failing appended a fresh advance_retry event on EVERY ~1s
+	// tick, so job_events grew without limit — a real install reached ~1.8M rows
+	// (96% of the table), and the per-tick JobIDsWithPendingAdvanceRetry GROUP BY
+	// over them (plus jobNeedsAdvanceRetry's per-job ListJobEvents) pinned a whole
+	// core with zero jobs in flight. Only the LATEST advance_retry per job is ever
+	// consulted (last-one-wins), so every earlier duplicate is dead weight: keep
+	// the max-id row per job and drop the rest. The emission path is idempotent
+	// now (recordAdvanceRetryOnce), so this is a one-time heal, not a recurring
+	// clean-up. Candidate/predicate semantics are unchanged: the surviving row is
+	// the newest advance_retry, so MAX(id) and last-one-wins both see the same
+	// result they did before.
+	`
+DELETE FROM job_events
+WHERE kind = 'advance_retry'
+  AND id NOT IN (SELECT MAX(id) FROM job_events WHERE kind = 'advance_retry' GROUP BY job_id);
+	`,
 }


### PR DESCRIPTION
## Problem

On a long-running daemon, a CPU core sits pinned at 50–70% **with zero jobs in flight**. `strace` shows the hot loop is ~12k `pread64`/s against the SQLite file — a per-tick query, not real work.

## Root cause

`advanceJob` re-emits an `advance_retry` `job_event` **on every ~1s supervisor tick** for any terminal job whose post-delivery advancement keeps failing (e.g. a merge/follow-up that can't complete). There is no dedup, backoff, or cap, so the rows grow without bound. On one install `advance_retry` reached **1,788,070 rows — 96% of the entire `job_events` table**.

That bloat then makes the per-tick candidate machinery O(table):

- `JobIDsWithPendingAdvanceRetry`'s `GROUP BY` over every `advance_retry` row measured **5.2 s per pass** (`EXPLAIN QUERY PLAN`: a covering-index SEARCH over all 1.79M `kind='advance_retry'` entries, then a temp-btree GROUP BY).
- `jobNeedsAdvanceRetry` re-reads each candidate's full history via `ListJobEvents`.

Both run every tick, so it is self-reinforcing: more stuck-job ticks → more rows → slower query.

## Fix

Only the **latest** advancement marker per job is ever consulted (last-one-wins), so the duplicate rows are pure dead weight.

1. **`recordAdvanceRetryOnce`** — all four `advance_retry` emission sites now skip the append when the job's latest advancement marker is already `advance_retry`. The job stays a retry candidate and keeps retrying; it just stops appending identical rows, bounding the log to **one `advance_retry` per stuck job**.
2. **`Store.LatestAdvancementMarker`** — an indexed lookup over the exact kind set `jobNeedsAdvanceRetry` evaluates.
3. **One-time migration** — collapses existing `advance_retry` history to the max-id row per job, so already-bloated installs heal on upgrade. Candidate/predicate semantics are unchanged: both `MAX(id)` and last-one-wins still see the surviving row.

## Testing

- `TestLatestAdvancementMarker` and `TestAdvanceRetryCollapseMigration` (collapse **and** candidate preservation).
- `TestRetryPendingJobAdvancementsDoesNotAccumulateAdvanceRetry` — five failed retry passes leave exactly one `advance_retry` row, and the job is still surfaced as a candidate.
- Existing advancement / covering-index-plan tests are unchanged and green; `go build ./...`, `go vet`, and the `internal/db` + `internal/cli` suites pass.

## Real-world result

Deployed to the affected host: the migration collapsed a live DB's `advance_retry` from **207,839 → 8** (one per stuck job), and the daemon dropped from **61% → 0.1% CPU** at idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
