### PR TITLE
perf(ci): split internal/cli 8 ways, workflow 4 — ~10.8min → ~6.6min race gate (#939)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ name: CI
 #   - RACE BUILD: four package jobs compile one -race test binary each. Every
 #     package's full current test list is partitioned and asserted to appear
 #     exactly once before its binary + shard plan are uploaded.
-#   - RACE RUN: internal/cli is split 5 ways, internal/db 2 ways,
-#     internal/workflow 3 ways, and internal/daemon 1 way. Each runner downloads
+#   - RACE RUN: internal/cli is split 8 ways, internal/db 2 ways,
+#     internal/workflow 4 ways, and internal/daemon 1 way. Each runner downloads
 #     the package bundle and executes from the package directory, preserving Go
 #     test-binary working-directory semantics without recompiling.
 #   - TIMINGS: PRs use the newest non-expired main timing artifact (up to 30
@@ -163,11 +163,11 @@ jobs:
       matrix:
         include:
           - package: cli
-            shards: 5
+            shards: 8
           - package: db
             shards: 2
           - package: workflow
-            shards: 3
+            shards: 4
           - package: daemon
             shards: 1
     steps:
@@ -254,16 +254,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {package: cli, shard: 0, shards: 5}
-          - {package: cli, shard: 1, shards: 5}
-          - {package: cli, shard: 2, shards: 5}
-          - {package: cli, shard: 3, shards: 5}
-          - {package: cli, shard: 4, shards: 5}
+          - {package: cli, shard: 0, shards: 8}
+          - {package: cli, shard: 1, shards: 8}
+          - {package: cli, shard: 2, shards: 8}
+          - {package: cli, shard: 3, shards: 8}
+          - {package: cli, shard: 4, shards: 8}
+          - {package: cli, shard: 5, shards: 8}
+          - {package: cli, shard: 6, shards: 8}
+          - {package: cli, shard: 7, shards: 8}
           - {package: db, shard: 0, shards: 2}
           - {package: db, shard: 1, shards: 2}
-          - {package: workflow, shard: 0, shards: 3}
-          - {package: workflow, shard: 1, shards: 3}
-          - {package: workflow, shard: 2, shards: 3}
+          - {package: workflow, shard: 0, shards: 4}
+          - {package: workflow, shard: 1, shards: 4}
+          - {package: workflow, shard: 2, shards: 4}
+          - {package: workflow, shard: 3, shards: 4}
           - {package: daemon, shard: 0, shards: 1}
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #939.

## Change

`internal/cli`: 5 → 8 race shards. `internal/workflow`: 3 → 4. `db` (2) and `daemon` (1) unchanged. Config-only — both the `race-build` and `race` matrices in `.github/workflows/ci.yml`, plus the Stage-2 comment.

## Why this, and why these numbers

The PR race gate is ~10.8 min end-to-end. Measured on main run `29382202579`, the critical path is entirely the longest `internal/cli` lane:

```
race build (internal/cli) 0.9m  →  cli shards start +1.1m  →  longest cli shard 9.6m  →  ~10.7m
```

Two measured facts drive the fix:

- **Per-lane fixed overhead is ~0.1 min** (Set up + Checkout + Download bundle), not the ~1–1.5 min the issue guessed. The compile is paid once in the `race-build` job; each shard only downloads the binary. So the cli lane is ~**linear** in shard count over its 43.6 race-min total — more shards is nearly free.
- **`internal/cli` is the sole bottleneck** (43.6 race-min). workflow (16.2), db (8.7), daemon (3.0) all finish under the cli lane.

A tri-model design panel (`gitmoot4/ci-sub8-939`: fable + gpt-5.6-sol + kimi) converged on "more cli shards"; options to trim race-work or rebalance packages were unanimously deferred (both add complexity for little gain while peak concurrency is 12 of 20). Shard count **8** over 7: at 7 the lane sits right on the 8-min line, while 8 clears it with margin; past 8, the workflow lane becomes the next bottleneck, so workflow 3→4 removes that tie.

## Predicted result

Verified by running `partition-race-tests.sh` against the **real** main timings artifact at the new counts:

| package | shards | longest lane (LPT, real timings) |
|---|---|---|
| cli | 8 | **5.46 min** ← critical path |
| workflow | 4 | 3.93 min |

End-to-end ≈ 1.1 min (compile + start) + 5.46 ≈ **~6.6 min** (from 10.8), clearing the <8 bar and the stretch <7.

Note on the imbalance factor: the issue and panel cited a +10.8% LPT imbalance, but that was derived from an *alternation* run. Now that #937's timings reconciliation is live, LPT actually engages and packs the real cli timings to **~0.1%** imbalance — so the real prediction is better than the panel's conservative ~7.1 min estimate.

## Safety

- **Coverage assertion green at the new counts** — verified on the real `internal/cli` (1599 tests) and `internal/workflow` (628 tests) lists: `all N current tests assigned exactly once`. The shard-union assertion compares against the compiled binary's own `-test.list`, so it is shard-count-independent by construction.
- **Matrices move together**: the run job consumes the build job's uploaded shard plan (`partitions/shard-$SHARD.regex`), so build and run must agree per package — cli 8/8, workflow 4/4.
- **No script change**: `partition-race-tests.sh` takes `--shards` generically.
- **Concurrency**: 15 race shards + 4 race-builds + build/vet/test + classify → peak ~16, under the 20-job public-repo cap.
- **Dep-only fast lane (#754) untouched** — race/race-build still gate on `needs.changes.outputs.code`.

## Verification after merge

This PR's own run demonstrates it (LPT engaged, longest lane ~5.5 min). Post-merge: one main run + one PR run, quoting the longest-lane delta (expect 9.6 → ~5.5 min) and end-to-end (expect 10.8 → ~6.6 min).
