### PR TITLE
fix(daemon): reconcile blocked tasks whose branch merged externally (#953)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -386,12 +386,13 @@ func (d Daemon) reconcilePROpenTasks(ctx context.Context, pulls []github.PullReq
 	return firstErr
 }
 
-// reconcileExternallyMergedTasks advances PR lifecycle tasks whose PR was
-// merged outside Gitmoot. It uses targeted single-PR reads rather than a closed
-// list, so old wedged tasks are not hidden by GitHub pagination. Empty-branch
-// local review tasks are keyed by their durable review-pr-<number>-<hash> id.
-// Closed-unmerged responses are deliberately ignored here; the existing
-// reviewing/ready-to-merge paths retain their current semantics.
+// reconcileExternallyMergedTasks advances PR lifecycle tasks, plus blocked
+// tasks, whose PR was merged outside Gitmoot. It uses targeted single-PR reads
+// rather than a closed list, so old wedged tasks are not hidden by GitHub
+// pagination. Empty-branch local review tasks are keyed by their durable
+// review-pr-<number>-<hash> id. Closed-unmerged responses are deliberately
+// ignored here; the existing reviewing/ready-to-merge paths retain their current
+// semantics.
 func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumbers map[int64]struct{}) error {
 	if d.Workflow == nil {
 		return nil
@@ -511,7 +512,7 @@ func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumb
 
 func externalMergeCandidateState(state string) bool {
 	switch workflow.TaskState(strings.TrimSpace(state)) {
-	case workflow.TaskPullRequestOpen, workflow.TaskReviewing, workflow.TaskChangesRequested, workflow.TaskReadyToMerge:
+	case workflow.TaskPullRequestOpen, workflow.TaskReviewing, workflow.TaskChangesRequested, workflow.TaskReadyToMerge, workflow.TaskBlocked:
 		return true
 	default:
 		return false

--- a/internal/daemon/external_merge_reconcile_test.go
+++ b/internal/daemon/external_merge_reconcile_test.go
@@ -17,6 +17,7 @@ func TestPollOnceReconcilesExternallyMergedLifecycleTasks(t *testing.T) {
 		workflow.TaskReviewing,
 		workflow.TaskChangesRequested,
 		workflow.TaskReadyToMerge,
+		workflow.TaskBlocked,
 	}
 	for _, state := range states {
 		t.Run(string(state), func(t *testing.T) {
@@ -38,6 +39,53 @@ func TestPollOnceReconcilesExternallyMergedLifecycleTasks(t *testing.T) {
 			assertExternalMergeState(t, store, repo.FullName(), "task-7", 7, workflow.TaskMerged, "merged")
 			if !reflect.DeepEqual(client.getPullRequestCalls, []int64{7}) {
 				t.Fatalf("GetPullRequest calls = %v, want [7]", client.getPullRequestCalls)
+			}
+		})
+	}
+}
+
+func TestBlockedTaskExternalMergeReconcileE2E(t *testing.T) {
+	// PollOnce's reconcile path performs no runtime delivery; the fake GitHub
+	// client and t.TempDir-backed store make this a deterministic no-LLM E2E.
+	// Keep the process environment isolated if that path ever grows orchestration.
+	t.Setenv("HERDR_SOCKET_PATH", "/tmp/throwaway")
+	t.Setenv("HERDR_ENV", "")
+
+	ctx := context.Background()
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	store := testStore(t)
+	seedExternalMergeTask(t, store, repo, "blocked-task", "feature/blocked", workflow.TaskBlocked, 953)
+	client := &fakeGitHub{
+		pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
+		pullsByNumber: map[int64]github.PullRequest{953: mergedPull(953, "feature/blocked")},
+		comments:      map[int64][]github.IssueComment{},
+	}
+	engine := workflow.Engine{Store: store}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	if err := daemon.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce: %v", err)
+	}
+	assertExternalMergeState(t, store, repo.FullName(), "blocked-task", 953, workflow.TaskMerged, "merged")
+}
+
+func TestExternalMergeCandidateState(t *testing.T) {
+	tests := []struct {
+		state workflow.TaskState
+		want  bool
+	}{
+		{workflow.TaskPullRequestOpen, true},
+		{workflow.TaskReviewing, true},
+		{workflow.TaskChangesRequested, true},
+		{workflow.TaskReadyToMerge, true},
+		{workflow.TaskBlocked, true},
+		{workflow.TaskAwaitingHuman, false},
+		{workflow.TaskPlanned, false},
+	}
+	for _, test := range tests {
+		t.Run(string(test.state), func(t *testing.T) {
+			if got := externalMergeCandidateState(string(test.state)); got != test.want {
+				t.Fatalf("externalMergeCandidateState(%q) = %v, want %v", test.state, got, test.want)
 			}
 		})
 	}

--- a/internal/workflow/closed_reviewing_cleanup_test.go
+++ b/internal/workflow/closed_reviewing_cleanup_test.go
@@ -16,6 +16,11 @@ import (
 // lock is stranded (held forever) and the worktree leaks on disk. The
 // closed-unmerged (`blocked`) branch must NOT clean up, since a blocked task
 // intentionally keeps its worktree/lock for human resumption.
+//
+// It runs from both `reviewing` and `blocked` start states (#953): a blocked
+// task whose branch merged externally is the exact live incident that motivated
+// #953 (a 21h stranded branch lock), so the merged case must release the lock +
+// worktree from `blocked` too, while blocked+closed-unmerged keeps them.
 func TestHandleReviewPullRequestClosedMergedReleasesLockAndWorktree(t *testing.T) {
 	const (
 		repo    = "jerryfane/gitmoot"
@@ -53,80 +58,90 @@ func TestHandleReviewPullRequestClosedMergedReleasesLockAndWorktree(t *testing.T
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			store := openEngineStore(t)
-			if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo, Branch: branch, Owner: "lead"}); err != nil || !acquired {
-				t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
-			}
-			if err := store.UpsertTask(ctx, db.Task{
-				ID:           "task-7304",
-				RepoFullName: repo,
-				GoalID:       "goal-1",
-				Title:        "CSV Export",
-				State:        string(TaskReviewing),
-				Branch:       branch,
-				WorktreePath: path,
-			}); err != nil {
-				t.Fatalf("UpsertTask returned error: %v", err)
-			}
-			if err := store.UpsertPullRequest(ctx, db.PullRequest{
-				RepoFullName: repo,
-				Number:       6,
-				URL:          "https://github.com/jerryfane/gitmoot/pull/6",
-				HeadBranch:   branch,
-				BaseBranch:   "main",
-				HeadSHA:      headSHA,
-				State:        "open",
-			}); err != nil {
-				t.Fatalf("UpsertPullRequest returned error: %v", err)
-			}
+	for _, startState := range []TaskState{TaskReviewing, TaskBlocked} {
+		for _, tc := range cases {
+			t.Run(string(startState)+"/"+tc.name, func(t *testing.T) {
+				ctx := context.Background()
+				store := openEngineStore(t)
+				if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo, Branch: branch, Owner: "lead"}); err != nil || !acquired {
+					t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+				}
+				if err := store.UpsertTask(ctx, db.Task{
+					ID:           "task-7304",
+					RepoFullName: repo,
+					GoalID:       "goal-1",
+					Title:        "CSV Export",
+					State:        string(startState),
+					Branch:       branch,
+					WorktreePath: path,
+				}); err != nil {
+					t.Fatalf("UpsertTask returned error: %v", err)
+				}
+				if err := store.UpsertPullRequest(ctx, db.PullRequest{
+					RepoFullName: repo,
+					Number:       6,
+					URL:          "https://github.com/jerryfane/gitmoot/pull/6",
+					HeadBranch:   branch,
+					BaseBranch:   "main",
+					HeadSHA:      headSHA,
+					State:        "open",
+				}); err != nil {
+					t.Fatalf("UpsertPullRequest returned error: %v", err)
+				}
 
-			manager := &fakeWorktreeManager{}
-			engine := Engine{Store: store, DelegationWorktrees: manager}
+				manager := &fakeWorktreeManager{}
+				engine := Engine{Store: store, DelegationWorktrees: manager}
 
-			if err := engine.HandleReviewPullRequestClosed(ctx, PullRequestEvent{
-				Repo:        repo,
-				Branch:      branch,
-				PullRequest: 6,
-				HeadSHA:     headSHA,
-				GoalID:      "goal-1",
-				TaskID:      "task-7304",
-				TaskTitle:   "CSV Export",
-				LeadAgent:   "lead",
-				Sender:      "github",
-			}, tc.merged); err != nil {
-				t.Fatalf("HandleReviewPullRequestClosed returned error: %v", err)
-			}
+				if err := engine.HandleReviewPullRequestClosed(ctx, PullRequestEvent{
+					Repo:        repo,
+					Branch:      branch,
+					PullRequest: 6,
+					HeadSHA:     headSHA,
+					GoalID:      "goal-1",
+					TaskID:      "task-7304",
+					TaskTitle:   "CSV Export",
+					LeadAgent:   "lead",
+					Sender:      "github",
+				}, tc.merged); err != nil {
+					t.Fatalf("HandleReviewPullRequestClosed returned error: %v", err)
+				}
 
-			task, err := store.GetTask(ctx, "task-7304")
-			if err != nil {
-				t.Fatalf("GetTask returned error: %v", err)
-			}
-			if task.State != string(tc.wantTask) {
-				t.Fatalf("task state = %q, want %q", task.State, tc.wantTask)
-			}
-			if (task.WorktreePath == "") != tc.wantPathEmpty {
-				t.Fatalf("task worktree path = %q, wantEmpty=%v", task.WorktreePath, tc.wantPathEmpty)
-			}
-			pr, err := store.GetPullRequest(ctx, repo, 6)
-			if err != nil {
-				t.Fatalf("GetPullRequest returned error: %v", err)
-			}
-			if pr.State != tc.wantPRState {
-				t.Fatalf("PR #6 state = %q, want %q", pr.State, tc.wantPRState)
-			}
-			gotRemoved := len(manager.removedForce) == 1 && manager.removedForce[0] == path
-			if gotRemoved != tc.wantRemoved {
-				t.Fatalf("worktree removed = %v (%v), want %v", gotRemoved, manager.removedForce, tc.wantRemoved)
-			}
-			_, lockErr := store.GetBranchLock(ctx, repo, branch)
-			lockGone := errors.Is(lockErr, sql.ErrNoRows)
-			if lockGone != tc.wantLockGone {
-				t.Fatalf("branch lock gone = %v (err=%v), want %v", lockGone, lockErr, tc.wantLockGone)
-			}
-		})
+				task, err := store.GetTask(ctx, "task-7304")
+				if err != nil {
+					t.Fatalf("GetTask returned error: %v", err)
+				}
+				if task.State != string(tc.wantTask) {
+					t.Fatalf("task state = %q, want %q", task.State, tc.wantTask)
+				}
+				if (task.WorktreePath == "") != tc.wantPathEmpty {
+					t.Fatalf("task worktree path = %q, wantEmpty=%v", task.WorktreePath, tc.wantPathEmpty)
+				}
+				pr, err := store.GetPullRequest(ctx, repo, 6)
+				if err != nil {
+					t.Fatalf("GetPullRequest returned error: %v", err)
+				}
+				// blocked + closed-unmerged is a complete no-op: the handler returns
+				// early before touching the PR mirror, so it stays "open". Only the
+				// reviewing start state runs the closed-unmerged transition that also
+				// marks the PR "closed".
+				wantPRState := tc.wantPRState
+				if !tc.merged && startState == TaskBlocked {
+					wantPRState = "open"
+				}
+				if pr.State != wantPRState {
+					t.Fatalf("PR #6 state = %q, want %q", pr.State, wantPRState)
+				}
+				gotRemoved := len(manager.removedForce) == 1 && manager.removedForce[0] == path
+				if gotRemoved != tc.wantRemoved {
+					t.Fatalf("worktree removed = %v (%v), want %v", gotRemoved, manager.removedForce, tc.wantRemoved)
+				}
+				_, lockErr := store.GetBranchLock(ctx, repo, branch)
+				lockGone := errors.Is(lockErr, sql.ErrNoRows)
+				if lockGone != tc.wantLockGone {
+					t.Fatalf("branch lock gone = %v (err=%v), want %v", lockGone, lockErr, tc.wantLockGone)
+				}
+			})
+		}
 	}
 }
 
@@ -136,6 +151,7 @@ func TestHandleReviewPullRequestClosedMergedLifecycleStates(t *testing.T) {
 		TaskReviewing,
 		TaskChangesRequested,
 		TaskReadyToMerge,
+		TaskBlocked,
 	}
 	for _, state := range states {
 		t.Run(string(state), func(t *testing.T) {
@@ -185,7 +201,7 @@ func TestHandleReviewPullRequestClosedMergedLifecycleStates(t *testing.T) {
 }
 
 func TestHandleReviewPullRequestClosedUnmergedLeavesNonReviewingStatesUnchanged(t *testing.T) {
-	states := []TaskState{TaskPullRequestOpen, TaskChangesRequested}
+	states := []TaskState{TaskPullRequestOpen, TaskChangesRequested, TaskReadyToMerge, TaskBlocked}
 	for _, state := range states {
 		t.Run(string(state), func(t *testing.T) {
 			ctx := context.Background()

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1128,11 +1128,12 @@ func (e Engine) HandlePullRequestReadyToMerge(ctx context.Context, event PullReq
 // lists OPEN pull requests, so an externally merged PR otherwise disappears
 // while its task and local PR mirror remain stale.
 //
-// Merged PRs resolve any of pr_open/reviewing/changes_requested/ready_to_merge;
-// an already-merged task is accepted only to repair its stale PR mirror.
-// Closed-unmerged behavior remains deliberately narrower: only reviewing uses
-// the existing transition to blocked; the other lifecycle states are untouched.
-// Existing PR row fields (url/base/merge SHA) are preserved.
+// Merged PRs resolve any of
+// pr_open/reviewing/changes_requested/ready_to_merge/blocked; an already-merged
+// task is accepted only to repair its stale PR mirror. Closed-unmerged behavior
+// remains deliberately narrower: only reviewing uses the existing transition to
+// blocked; the other lifecycle states are untouched. Existing PR row fields
+// (url/base/merge SHA) are preserved.
 func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullRequestEvent, merged bool) error {
 	if err := e.validate(); err != nil {
 		return err
@@ -1152,7 +1153,7 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 	alreadyMerged := false
 	if merged {
 		switch taskState {
-		case TaskPullRequestOpen, TaskReviewing, TaskChangesRequested, TaskReadyToMerge:
+		case TaskPullRequestOpen, TaskReviewing, TaskChangesRequested, TaskReadyToMerge, TaskBlocked:
 		case TaskMerged:
 			// Keep the task terminal while repairing a stale local PR mirror after
 			// another path (notably the ready-to-merge gate) completed first.
@@ -1217,10 +1218,11 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 }
 
 // reconcileMergedCleanup releases the branch lock and removes the task worktree
-// after HandleReviewPullRequestClosed resolves an externally-merged reviewing
-// task to `merged` (#543). It mirrors PolicyMergeGate.finishMerged's post-merge
-// cleanup so the self-heal reconcile path does not leak a held branch lock or an
-// on-disk worktree. Every step is best-effort and nil-safe: failures are
+// after HandleReviewPullRequestClosed resolves an externally-merged lifecycle or
+// blocked task to `merged` (#543, #953). It mirrors
+// PolicyMergeGate.finishMerged's post-merge cleanup so the self-heal reconcile
+// path does not leak a held branch lock or an on-disk worktree. Every step is
+// best-effort and nil-safe: failures are
 // swallowed so the already-durable terminal `merged` transition is never undone,
 // matching finishMerged's treatment of these as non-fatal post-merge warnings.
 func (e Engine) reconcileMergedCleanup(ctx context.Context, repo string, task db.Task) {


### PR DESCRIPTION
Closes #953.

## The bug

A task that enters `blocked` and whose branch is **later merged** stayed wedged in `blocked` forever. The externally-merged reconciler never considered blocked tasks, so a blocked task whose work actually shipped kept showing a phantom "blocked" card and never appeared under "needs a human" (that's `awaiting_human`, a different state). Live repro: task `adhoc-1c637d9a` ("Implement #918") sat blocked while its branch merged as PR #926 — and stranded a 21-hour checkout lock.

## Root cause

- `externalMergeCandidateState` (`internal/daemon/daemon.go:513`) — the reconciler's state gate — returned true only for `pr_open`/`reviewing`/`changes_requested`/`ready_to_merge`, so a `blocked` task was never a reconcile candidate.
- `HandleReviewPullRequestClosed` (`internal/workflow/engine.go:1156`) — the merged-PR resolve path — matched the same four states.

## Fix (two lines + the required asymmetry)

1. `externalMergeCandidateState` (`daemon.go:513`): add `workflow.TaskBlocked` to the candidate set.
2. `HandleReviewPullRequestClosed` (`engine.go:1156`): allow a **merged** PR to resolve a `blocked` task to `merged`, then release its branch lock and remove its worktree via `reconcileMergedCleanup` (the same cleanup the canonical merge gate does — this is what fixes the stranded-lock class).

**The asymmetry (enforced, tested):**
- `blocked` + PR **merged** → `merged` (+ lock released, worktree removed).
- `blocked` + PR **closed-unmerged** → **stays blocked** (a complete no-op — the handler returns early at `engine.go:1165` `else if taskState != TaskReviewing { return nil }` before any state or PR-mirror write). We never silently un-block on an abandoned PR.

No other transition is weakened. The empty-branch (`review-pr-*`) guard and the `idx_tasks_repo_branch_unique` collision protection are unchanged, so the reconciler still advances the correct task.

### Why `awaiting_human` is deliberately left out

`awaiting_human` is a purposeful human-pause state (a human was explicitly asked to act). Auto-advancing it on an external merge would erase a pending human decision, so it stays excluded from both gates — this PR is scoped to `blocked`. `TestExternalMergeCandidateState` asserts `awaiting_human` (and `planned`) stay `false`.

## Tests

- **`TestBlockedTaskExternalMergeReconcileE2E`** (daemon, no-LLM, isolated `t.TempDir` home, `HERDR_SOCKET_PATH=/tmp/throwaway`): seeds a `blocked` task + a merged-PR mirror row, drives `PollOnce`, asserts the task reaches `merged`. This is the acceptance criterion end-to-end.
- **`TestExternalMergeCandidateState`**: `blocked`→true; `awaiting_human`→false; `planned`→false.
- **`TestHandleReviewPullRequestClosedMergedLifecycleStates`** now includes `blocked` (merged→merged).
- **`TestHandleReviewPullRequestClosedUnmergedLeavesNonReviewingStatesUnchanged`** now includes `blocked` (closed-unmerged→unchanged, PR stays open).
- **`TestHandleReviewPullRequestClosedMergedReleasesLockAndWorktree`** now runs from both `reviewing` and `blocked` start states — the `blocked/merged` case proves the lock is released and the worktree removed (the exact 21h-lock incident), and `blocked/closed-unmerged` proves lock + worktree + PR-mirror are all left untouched.
- Existing `pr_open`/`reviewing`/`changes_requested`/`ready_to_merge` behavior is unchanged (regression tests stay green).

**Adversarial-review + test-bite:** an independent reviewer traced every asymmetry hole and found no confirmed defects; reverting the two source lines (leaving the tests) makes exactly the four `blocked` assertions fail, confirming the tests genuinely exercise the change.

## Gate

`go build ./...`, `go vet ./...`, and `go test ./internal/workflow/ ./internal/daemon/ ./internal/db/ ./internal/cli/` all pass on the rebased tree. `go generate` produces no diff.

## Deploy notes

Daemon-only change (no dashboard/web asset touched). Deploy = rebuild the binary + `systemctl --user restart gitmoot-daemon` at idle. No migration. Existing wedged `blocked` rows self-heal on the next poll tick once their branch's merge is observed.
