### PR TITLE
perf(dashboard): extend response cache to tier-2 endpoints (#956)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -70,14 +70,19 @@ func runDashboardWeb(home, addr string, stdout, stderr io.Writer) int {
 	}
 }
 
-// newDashboardWebHandler shadows only the three expensive endpoints covered by
-// the frozen #948 policy plus the already-local knowledge handler. Every other
-// route remains owned by the pinned dashboard module.
+// newDashboardWebHandler shadows only the expensive endpoints covered by the
+// frozen #948/#956 policies plus the already-local knowledge handler. Every
+// other route remains owned by the pinned dashboard module.
 func newDashboardWebHandler(ds *webDataSource) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/jobs", ds.handleJobs)
 	mux.HandleFunc("GET /api/charts", ds.handleCharts)
 	mux.HandleFunc("GET /api/health", ds.handleHealth)
+	mux.HandleFunc("GET /api/overview", ds.handleOverview)
+	mux.HandleFunc("GET /api/attention", ds.handleAttention)
+	mux.HandleFunc("GET /api/agents", ds.handleAgents)
+	mux.HandleFunc("GET /api/tasks", ds.handleTasks)
+	mux.HandleFunc("GET /api/workflows", ds.handleWorkflows)
 	mux.HandleFunc("GET /api/learning/knowledge", ds.handleLearningKnowledge)
 	mux.Handle("/", dashboard.Serve(ds))
 	return mux

--- a/internal/cli/dashboard_web_cache.go
+++ b/internal/cli/dashboard_web_cache.go
@@ -94,8 +94,8 @@ func newDashboardJSONCache(stderr io.Writer) *dashboardJSONCache {
 	}
 	now := time.Now
 	return &dashboardJSONCache{
-		entries:    make(map[string]dashboardCacheEntry, 5),
-		flights:    make(map[string]*dashboardCacheFlight, 6),
+		entries: make(map[string]dashboardCacheEntry, len(dashboardCachePolicies)),
+		flights: make(map[string]*dashboardCacheFlight, len(dashboardCachePolicies)+1),
 		stats:      make(map[string]dashboardCacheCounters, 3),
 		now:        now,
 		stderr:     stderr,
@@ -500,7 +500,36 @@ func (d *webDataSource) workflowsJSON(ctx context.Context) ([]byte, error) {
 			entries[i].Repos = []string{}
 		}
 	}
-	sort.SliceStable(entries, func(i, j int) bool { return dashboardWorkflowIndexLess(entries[i], entries[j]) })
+	// Sort with the pinned module's exact semantics (api.go workflowStateRank:
+	// stalled(0) < active(1) < settled(2) < default(3) — 'recent' is a gitmoot
+	// extension the module does not rank, so it must sort LAST for byte parity;
+	// dashboardWorkflowIndexLess ranks it between active and settled and must
+	// not be used here).
+	moduleRank := func(state string) int {
+		switch state {
+		case "stalled":
+			return 0
+		case "active":
+			return 1
+		case "settled":
+			return 2
+		default:
+			return 3
+		}
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		ri, rj := moduleRank(entries[i].State), moduleRank(entries[j].State)
+		if ri != rj {
+			return ri < rj
+		}
+		if entries[i].State == "stalled" && entries[i].StalledForS != entries[j].StalledForS {
+			return entries[i].StalledForS > entries[j].StalledForS
+		}
+		if entries[i].LastAt != entries[j].LastAt {
+			return entries[i].LastAt > entries[j].LastAt
+		}
+		return entries[i].Label < entries[j].Label
+	})
 	return marshalDashboardJSON(entries)
 }
 

--- a/internal/cli/dashboard_web_cache.go
+++ b/internal/cli/dashboard_web_cache.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,7 +20,7 @@ const (
 	dashboardCacheReportInterval = time.Minute
 )
 
-// dashboardCachePolicy is the frozen endpoint policy for #948. Entries are
+// dashboardCachePolicy is the frozen endpoint policy for #948 and #956. Entries are
 // keyed by endpoint/canonical parameter; cursor is stored on the entry rather
 // than included in the flight key, which prevents overlapping generations.
 type dashboardCachePolicy struct {
@@ -35,12 +36,22 @@ var dashboardCachePolicies = []dashboardCachePolicy{
 	{endpoint: "jobs", keyKind: "job-event-id", retain: true, minRecompute: time.Second, maxAge: 15 * time.Second},
 	{endpoint: "charts", keyKind: "canonical-days+job-event-id", retain: true, minRecompute: 12 * time.Second, maxAge: 60 * time.Second, expireAtUTCMidnight: true},
 	{endpoint: "health", keyKind: "singleflight-only", retain: false},
+	{endpoint: "overview", keyKind: "full-cursor", retain: true, minRecompute: 5 * time.Second, maxAge: 15 * time.Second},
+	{endpoint: "attention", keyKind: "full-cursor", retain: true, minRecompute: time.Second, maxAge: 5 * time.Second},
+	{endpoint: "agents", keyKind: "job-event-id", retain: true, minRecompute: 5 * time.Second, maxAge: 30 * time.Second},
+	{endpoint: "tasks", keyKind: "task-event-id", retain: true, minRecompute: 2 * time.Second, maxAge: 15 * time.Second},
+	{endpoint: "workflows", keyKind: "job-event-id+workflow-note-id", retain: true, minRecompute: 5 * time.Second, maxAge: 15 * time.Second},
 }
 
 var (
-	dashboardJobsCachePolicy   = dashboardCachePolicies[0]
-	dashboardChartsCachePolicy = dashboardCachePolicies[1]
-	dashboardHealthCachePolicy = dashboardCachePolicies[2]
+	dashboardJobsCachePolicy      = dashboardCachePolicies[0]
+	dashboardChartsCachePolicy    = dashboardCachePolicies[1]
+	dashboardHealthCachePolicy    = dashboardCachePolicies[2]
+	dashboardOverviewCachePolicy  = dashboardCachePolicies[3]
+	dashboardAttentionCachePolicy = dashboardCachePolicies[4]
+	dashboardAgentsCachePolicy    = dashboardCachePolicies[5]
+	dashboardTasksCachePolicy     = dashboardCachePolicies[6]
+	dashboardWorkflowsCachePolicy = dashboardCachePolicies[7]
 )
 
 type dashboardCacheEntry struct {
@@ -197,11 +208,11 @@ func (c *dashboardJSONCache) recordLocked(endpoint, outcome string, bodyBytes in
 		return ""
 	}
 	line := "dashboard cache:"
-	for _, name := range []string{"jobs", "charts", "health"} {
-		s := c.stats[name]
-		line += fmt.Sprintf(" %s hits=%d misses=%d shared=%d bytes=%d;", name, s.hits, s.misses, s.shared, s.bytes)
+	for _, policy := range dashboardCachePolicies {
+		s := c.stats[policy.endpoint]
+		line += fmt.Sprintf(" %s hits=%d misses=%d shared=%d bytes=%d;", policy.endpoint, s.hits, s.misses, s.shared, s.bytes)
 	}
-	c.stats = make(map[string]dashboardCacheCounters, 3)
+	c.stats = make(map[string]dashboardCacheCounters, len(dashboardCachePolicies))
 	c.lastReport = now
 	return strings.TrimSuffix(line, ";") + "\n"
 }
@@ -251,6 +262,30 @@ func (d *webDataSource) jobEventCursor(ctx context.Context) (string, error) {
 	return jobEventID, nil
 }
 
+func (d *webDataSource) taskEventCursor(ctx context.Context) (string, error) {
+	cursor, err := d.ChangeCursor(ctx)
+	if err != nil {
+		return "", err
+	}
+	_, remainder, _ := strings.Cut(cursor, ".")
+	_, taskEventID, _ := strings.Cut(remainder, ".")
+	return taskEventID, nil
+}
+
+func (d *webDataSource) workflowEventCursor(ctx context.Context) (string, error) {
+	cursor, err := d.ChangeCursor(ctx)
+	if err != nil {
+		return "", err
+	}
+	jobEventID, remainder, _ := strings.Cut(cursor, ".")
+	workflowNoteID, _, _ := strings.Cut(remainder, ".")
+	return jobEventID + "." + workflowNoteID, nil
+}
+
+func (d *webDataSource) fullDashboardCursor(ctx context.Context) (string, error) {
+	return d.ChangeCursor(ctx)
+}
+
 func (d *webDataSource) handleJobs(w http.ResponseWriter, r *http.Request) {
 	cursor, err := d.jobEventCursor(r.Context())
 	if err != nil {
@@ -297,6 +332,176 @@ func (d *webDataSource) handleCharts(w http.ResponseWriter, r *http.Request) {
 		return marshalDashboardJSON(charts)
 	})
 	d.writeCachedDashboardJSON(w, outcome, body, err)
+}
+
+func (d *webDataSource) handleOverview(w http.ResponseWriter, r *http.Request) {
+	cursor, err := d.fullDashboardCursor(r.Context())
+	if err != nil {
+		w.Header().Set(dashboardCacheHeader, "miss")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	body, outcome, err := d.cacheForDashboard().get(r.Context(), "overview", cursor, dashboardOverviewCachePolicy, d.overviewJSON)
+	d.writeCachedDashboardJSON(w, outcome, body, err)
+}
+
+func (d *webDataSource) overviewJSON(ctx context.Context) ([]byte, error) {
+	overview, err := d.Overview(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if overview.NeedsYou == nil {
+		overview.NeedsYou = []dashboard.OverviewNeedsYou{}
+	}
+	if overview.Activity.Workflows == nil {
+		overview.Activity.Workflows = []dashboard.OverviewWorkflowActivity{}
+	}
+	for i := range overview.Activity.Workflows {
+		overview.Activity.Workflows[i].Namespace, overview.Activity.Workflows[i].Campaign = splitDashboardWorkflowLabel(overview.Activity.Workflows[i].Label)
+		if overview.Activity.Workflows[i].Agents == nil {
+			overview.Activity.Workflows[i].Agents = []string{}
+		}
+		sort.Strings(overview.Activity.Workflows[i].Agents)
+	}
+	if overview.Today.Notable == nil {
+		overview.Today.Notable = []dashboard.OverviewNotable{}
+	}
+	if overview.Scheduled == nil {
+		overview.Scheduled = []dashboard.OverviewScheduled{}
+	}
+	if overview.Fleet == nil {
+		overview.Fleet = []dashboard.OverviewFleet{}
+	}
+	sortDashboardOverview(&overview)
+	if len(overview.Today.Notable) > 5 {
+		overview.Today.Notable = overview.Today.Notable[:5]
+	}
+	return marshalDashboardJSON(overview)
+}
+
+func (d *webDataSource) handleAttention(w http.ResponseWriter, r *http.Request) {
+	cursor, err := d.fullDashboardCursor(r.Context())
+	if err != nil {
+		w.Header().Set(dashboardCacheHeader, "miss")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	body, outcome, err := d.cacheForDashboard().get(r.Context(), "attention", cursor, dashboardAttentionCachePolicy, d.attentionJSON)
+	d.writeCachedDashboardJSON(w, outcome, body, err)
+}
+
+func (d *webDataSource) attentionJSON(ctx context.Context) ([]byte, error) {
+	attention, err := d.Attention(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if attention.Gates == nil {
+		attention.Gates = []dashboard.AttentionGate{}
+	}
+	if attention.SynthItems == nil {
+		attention.SynthItems = []dashboard.AttentionSynthItem{}
+	}
+	if attention.Candidates == nil {
+		attention.Candidates = []dashboard.AttentionCandidate{}
+	}
+	return marshalDashboardJSON(attention)
+}
+
+func (d *webDataSource) handleAgents(w http.ResponseWriter, r *http.Request) {
+	cursor, err := d.jobEventCursor(r.Context())
+	if err != nil {
+		w.Header().Set(dashboardCacheHeader, "miss")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	body, outcome, err := d.cacheForDashboard().get(r.Context(), "agents", cursor, dashboardAgentsCachePolicy, func(ctx context.Context) ([]byte, error) {
+		agents, err := d.Agents(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if agents == nil {
+			agents = []dashboard.AgentSummary{}
+		}
+		return marshalDashboardJSON(agents)
+	})
+	d.writeCachedDashboardJSON(w, outcome, body, err)
+}
+
+func (d *webDataSource) handleTasks(w http.ResponseWriter, r *http.Request) {
+	cursor, err := d.taskEventCursor(r.Context())
+	if err != nil {
+		w.Header().Set(dashboardCacheHeader, "miss")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	body, outcome, err := d.cacheForDashboard().get(r.Context(), "tasks", cursor, dashboardTasksCachePolicy, d.tasksJSON)
+	d.writeCachedDashboardJSON(w, outcome, body, err)
+}
+
+func (d *webDataSource) tasksJSON(ctx context.Context) ([]byte, error) {
+	tasks, err := d.Tasks(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if tasks == nil {
+		tasks = []dashboard.TaskSummary{}
+	}
+	sort.SliceStable(tasks, func(i, j int) bool {
+		if ir, jr := dashboardWireTaskStateRank(tasks[i].State), dashboardWireTaskStateRank(tasks[j].State); ir != jr {
+			return ir < jr
+		}
+		if tasks[i].UpdatedAt != tasks[j].UpdatedAt {
+			return tasks[i].UpdatedAt > tasks[j].UpdatedAt
+		}
+		return tasks[i].ID < tasks[j].ID
+	})
+	return marshalDashboardJSON(tasks)
+}
+
+func dashboardWireTaskStateRank(state string) int {
+	switch state {
+	case "planned":
+		return 0
+	case "implementing":
+		return 1
+	case "pr_open":
+		return 2
+	case "blocked":
+		return 3
+	case "merged":
+		return 4
+	default:
+		return 5
+	}
+}
+
+func (d *webDataSource) handleWorkflows(w http.ResponseWriter, r *http.Request) {
+	cursor, err := d.workflowEventCursor(r.Context())
+	if err != nil {
+		w.Header().Set(dashboardCacheHeader, "miss")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	body, outcome, err := d.cacheForDashboard().get(r.Context(), "workflows", cursor, dashboardWorkflowsCachePolicy, d.workflowsJSON)
+	d.writeCachedDashboardJSON(w, outcome, body, err)
+}
+
+func (d *webDataSource) workflowsJSON(ctx context.Context) ([]byte, error) {
+	entries, err := d.Workflows(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if entries == nil {
+		entries = []dashboard.WorkflowIndexEntry{}
+	}
+	for i := range entries {
+		entries[i].Namespace, entries[i].Campaign = splitDashboardWorkflowLabel(entries[i].Label)
+		if entries[i].Repos == nil {
+			entries[i].Repos = []string{}
+		}
+	}
+	sort.SliceStable(entries, func(i, j int) bool { return dashboardWorkflowIndexLess(entries[i], entries[j]) })
+	return marshalDashboardJSON(entries)
 }
 
 func (d *webDataSource) writeCachedDashboardJSON(w http.ResponseWriter, outcome string, body []byte, err error) {

--- a/internal/cli/dashboard_web_cache_test.go
+++ b/internal/cli/dashboard_web_cache_test.go
@@ -323,6 +323,14 @@ func TestDashboardCachedHandlersMatchModuleBytes(t *testing.T) {
 	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{WorkflowID: "cache/tier-two", Author: "lead", Body: "byte parity"}); err != nil {
 		t.Fatal(err)
 	}
+	// A second labeled workflow whose note is backdated below: it derives
+	// 'settled' while cache/tier-two (fresh note) derives 'recent'. The pinned
+	// module does not rank 'recent' (default bucket, AFTER settled) while
+	// gitmoot's index comparator ranks it between active and settled — only a
+	// mixed recent+settled list makes the byte compare guard module parity.
+	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{WorkflowID: "cache/settled-old", Author: "lead", Body: "aged out"}); err != nil {
+		t.Fatal(err)
+	}
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -336,6 +344,13 @@ func TestDashboardCachedHandlersMatchModuleBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := raw.Exec(`UPDATE tasks SET updated_at = ''`); err != nil {
+		t.Fatal(err)
+	}
+	// Backdate ONLY the settled-old note past the active window so exactly one
+	// workflow derives 'settled' alongside tier-two's 'recent' (neither state
+	// carries server-side age fields, so wall-clock boundaries cannot
+	// desynchronize the byte compare).
+	if _, err := raw.Exec(`UPDATE workflow_notes SET created_at = '2026-06-01 00:00:00' WHERE workflow_id = 'cache/settled-old'`); err != nil {
 		t.Fatal(err)
 	}
 	if err := raw.Close(); err != nil {

--- a/internal/cli/dashboard_web_cache_test.go
+++ b/internal/cli/dashboard_web_cache_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -30,10 +31,62 @@ func TestDashboardCachePolicyTable(t *testing.T) {
 		{endpoint: "jobs", keyKind: "job-event-id", retain: true, minRecompute: time.Second, maxAge: 15 * time.Second},
 		{endpoint: "charts", keyKind: "canonical-days+job-event-id", retain: true, minRecompute: 12 * time.Second, maxAge: 60 * time.Second, expireAtUTCMidnight: true},
 		{endpoint: "health", keyKind: "singleflight-only", retain: false},
+		{endpoint: "overview", keyKind: "full-cursor", retain: true, minRecompute: 5 * time.Second, maxAge: 15 * time.Second},
+		{endpoint: "attention", keyKind: "full-cursor", retain: true, minRecompute: time.Second, maxAge: 5 * time.Second},
+		{endpoint: "agents", keyKind: "job-event-id", retain: true, minRecompute: 5 * time.Second, maxAge: 30 * time.Second},
+		{endpoint: "tasks", keyKind: "task-event-id", retain: true, minRecompute: 2 * time.Second, maxAge: 15 * time.Second},
+		{endpoint: "workflows", keyKind: "job-event-id+workflow-note-id", retain: true, minRecompute: 5 * time.Second, maxAge: 15 * time.Second},
 	}
 	if !reflect.DeepEqual(dashboardCachePolicies, want) {
 		t.Fatalf("policies = %#v, want %#v", dashboardCachePolicies, want)
 	}
+}
+
+func TestDashboardCacheCursorSelection(t *testing.T) {
+	home := dashboardTestHome(t)
+	ds := &webDataSource{home: home}
+	ctx := context.Background()
+	assertCursors := func(job, task, workflow, full string) {
+		t.Helper()
+		checks := []struct {
+			name string
+			fn   func(context.Context) (string, error)
+			want string
+		}{
+			{name: "job", fn: ds.jobEventCursor, want: job},
+			{name: "task", fn: ds.taskEventCursor, want: task},
+			{name: "workflow", fn: ds.workflowEventCursor, want: workflow},
+			{name: "full", fn: ds.fullDashboardCursor, want: full},
+		}
+		for _, check := range checks {
+			got, err := check.fn(ctx)
+			if err != nil || got != check.want {
+				t.Errorf("%s cursor = %q, %v, want %q", check.name, got, err, check.want)
+			}
+		}
+	}
+	assertCursors("0", "0", "0.0", "0.0.0")
+
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{ID: "cursor-job", Agent: "worker", Type: "ask", State: "queued"}, db.JobEvent{Kind: "queued"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{WorkflowID: "cache/cursors", Body: "checkpoint"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "cursor-task", State: "implementing"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddTaskEvent(ctx, db.TaskEvent{TaskID: "cursor-task", Kind: "started"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertCursors("1", "1", "1.1", "1.1.1")
 }
 
 func TestDashboardCacheCursorFloorAndHardMax(t *testing.T) {
@@ -258,16 +311,43 @@ func waitForDashboardCacheWaiters(t *testing.T, cache *dashboardJSONCache, key s
 func TestDashboardCachedHandlersMatchModuleBytes(t *testing.T) {
 	home := dashboardTestHome(t)
 	seedWebDashboardTree(t, home)
+	seedAttentionHome(t, home)
 	store, err := db.Open(config.PathsForHome(home).Database)
 	if err != nil {
 		t.Fatal(err)
 	}
 	mustCreateJob(t, store, db.Job{ID: "malformed", Agent: "builder", Type: "ask", State: "failed", Payload: `{"instructions":`}, "failed", "bad payload")
-	_ = store.Close()
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "cache-task", RepoFullName: "acme/cache", Title: "Cache tier two", State: "implementing", Branch: "feat/cache"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{WorkflowID: "cache/tier-two", Author: "lead", Body: "byte parity"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Zero wall-clock-derived ages so the module and shadow calls cannot differ
+	// when the test happens to cross a whole-second boundary.
+	raw, err := sql.Open("sqlite", config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`UPDATE jobs SET created_at = '', updated_at = ''`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`UPDATE tasks SET updated_at = ''`); err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	cached := newDashboardWebHandler(&webDataSource{home: home, responseCache: newDashboardJSONCache(nil)})
 	uncached := dashboard.Serve(&webDataSource{home: home})
-	for _, path := range []string{"/api/jobs", "/api/charts?days=30", "/api/charts?days=0"} {
+	for _, path := range []string{
+		"/api/jobs", "/api/charts?days=30", "/api/charts?days=0",
+		"/api/overview", "/api/attention", "/api/agents", "/api/tasks", "/api/workflows",
+	} {
 		want := httptest.NewRecorder()
 		uncached.ServeHTTP(want, httptest.NewRequest(http.MethodGet, path, nil))
 		for _, wantOutcome := range []string{"miss", "hit"} {
@@ -295,6 +375,301 @@ func TestDashboardCachedHandlersMatchModuleBytes(t *testing.T) {
 	uncached.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/jobs", nil))
 	if !bytes.Equal(rr.Body.Bytes(), wantLegacy) {
 		t.Fatalf("projected jobs differ from the pre-change full-unmarshal path\nwant:\n%s\ngot:\n%s", wantLegacy, rr.Body.Bytes())
+	}
+}
+
+func TestDashboardCachedTierTwoHandlersMatchModuleBytesEmpty(t *testing.T) {
+	home := dashboardTestHome(t)
+	cached := newDashboardWebHandler(&webDataSource{home: home, responseCache: newDashboardJSONCache(nil)})
+	module := dashboard.Serve(&webDataSource{home: home})
+	for _, path := range []string{"/api/overview", "/api/attention", "/api/agents", "/api/tasks", "/api/workflows"} {
+		t.Run(strings.TrimPrefix(path, "/api/"), func(t *testing.T) {
+			want := httptest.NewRecorder()
+			module.ServeHTTP(want, httptest.NewRequest(http.MethodGet, path, nil))
+			for _, wantOutcome := range []string{"miss", "hit"} {
+				got := httptest.NewRecorder()
+				cached.ServeHTTP(got, httptest.NewRequest(http.MethodGet, path+"?ignored=value", nil))
+				if got.Code != want.Code || got.Header().Get("Content-Type") != want.Header().Get("Content-Type") || !bytes.Equal(got.Body.Bytes(), want.Body.Bytes()) {
+					t.Fatalf("%s %s differs: status %d/%d content-type %q/%q\nwant:\n%s\ngot:\n%s", path, wantOutcome,
+						got.Code, want.Code, got.Header().Get("Content-Type"), want.Header().Get("Content-Type"), want.Body.Bytes(), got.Body.Bytes())
+				}
+				if outcome := got.Header().Get(dashboardCacheHeader); outcome != wantOutcome {
+					t.Fatalf("cache outcome = %q, want %q", outcome, wantOutcome)
+				}
+			}
+		})
+	}
+}
+
+func TestDashboardAttentionCacheGateSatisfactionUsesHardMax(t *testing.T) {
+	home := dashboardTestHome(t)
+	ctx := context.Background()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJobWithEvent(ctx,
+		db.Job{ID: "blocked", Agent: "worker", Type: "ask", State: "blocked"},
+		db.JobEvent{Kind: "blocked"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RecordJobGates(ctx, "blocked", []string{"human:approve"}); err != nil {
+		t.Fatal(err)
+	}
+
+	base := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	now := base
+	cache := newDashboardJSONCache(nil)
+	cache.now = func() time.Time { return now }
+	ds := &webDataSource{home: home, responseCache: cache}
+	handler := newDashboardWebHandler(ds)
+	read := func(wantOutcome string) dashboard.Attention {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/attention", nil))
+		if rr.Code != http.StatusOK || rr.Header().Get(dashboardCacheHeader) != wantOutcome {
+			t.Fatalf("attention status=%d outcome=%q body=%s", rr.Code, rr.Header().Get(dashboardCacheHeader), rr.Body.String())
+		}
+		var attention dashboard.Attention
+		if err := json.Unmarshal(rr.Body.Bytes(), &attention); err != nil {
+			t.Fatal(err)
+		}
+		return attention
+	}
+	if got := read("miss"); len(got.Gates) != 1 {
+		t.Fatalf("initial gates = %+v", got.Gates)
+	}
+	before, err := ds.fullDashboardCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := store.SatisfyJobGate(ctx, "blocked", "human:approve"); err != nil || !ok {
+		t.Fatalf("SatisfyJobGate = %v, %v", ok, err)
+	}
+	after, err := ds.fullDashboardCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before != after {
+		t.Fatalf("gate satisfaction moved cursor from %q to %q", before, after)
+	}
+	if got := read("hit"); len(got.Gates) != 1 {
+		t.Fatalf("pre-expiry gates = %+v, want retained gate", got.Gates)
+	}
+	now = base.Add(dashboardAttentionCachePolicy.maxAge)
+	if got := read("miss"); len(got.Gates) != 0 || got.Total != 0 {
+		t.Fatalf("post-expiry attention = %+v", got)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDashboardAgentsCacheRegistryMaxAndJobCursor(t *testing.T) {
+	home := dashboardTestHome(t)
+	ctx := context.Background()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "worker", Runtime: "codex"}); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	now := base
+	cache := newDashboardJSONCache(nil)
+	cache.now = func() time.Time { return now }
+	handler := newDashboardWebHandler(&webDataSource{home: home, responseCache: cache})
+	read := func(wantOutcome string) dashboard.AgentSummary {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/api/agents", nil))
+		if rr.Code != http.StatusOK || rr.Header().Get(dashboardCacheHeader) != wantOutcome {
+			t.Fatalf("agents status=%d outcome=%q body=%s", rr.Code, rr.Header().Get(dashboardCacheHeader), rr.Body.String())
+		}
+		var agents []dashboard.AgentSummary
+		if err := json.Unmarshal(rr.Body.Bytes(), &agents); err != nil {
+			t.Fatal(err)
+		}
+		if len(agents) != 1 {
+			t.Fatalf("agents = %+v", agents)
+		}
+		return agents[0]
+	}
+	if got := read("miss"); got.Runtime != "codex" {
+		t.Fatalf("initial agent = %+v", got)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "worker", Runtime: "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	now = base.Add(dashboardAgentsCachePolicy.maxAge - time.Nanosecond)
+	if got := read("hit"); got.Runtime != "codex" {
+		t.Fatalf("pre-expiry agent = %+v", got)
+	}
+	now = base.Add(dashboardAgentsCachePolicy.maxAge)
+	if got := read("miss"); got.Runtime != "claude" {
+		t.Fatalf("post-expiry agent = %+v", got)
+	}
+	if err := store.CreateJobWithEvent(ctx,
+		db.Job{ID: "agent-job", Agent: "worker", Type: "ask", State: "running"},
+		db.JobEvent{Kind: "running"}); err != nil {
+		t.Fatal(err)
+	}
+	now = base.Add(dashboardAgentsCachePolicy.maxAge + dashboardAgentsCachePolicy.minRecompute - time.Nanosecond)
+	if got := read("hit"); got.JobCount != 0 {
+		t.Fatalf("cursor floor agent = %+v", got)
+	}
+	now = base.Add(dashboardAgentsCachePolicy.maxAge + dashboardAgentsCachePolicy.minRecompute)
+	if got := read("miss"); got.JobCount != 1 || got.RunningCount != 1 {
+		t.Fatalf("cursor refresh agent = %+v", got)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDashboardTierTwoCachesUncoveredWritesUseHardMax(t *testing.T) {
+	base := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		path   string
+		maxAge time.Duration
+		seed   func(*testing.T, *db.Store)
+		mutate func(*testing.T, *db.Store)
+		value  func(*testing.T, []byte) string
+		before string
+		after  string
+	}{
+		{
+			name: "overview pipeline schedule", path: "/api/overview", maxAge: dashboardOverviewCachePolicy.maxAge,
+			seed: func(t *testing.T, store *db.Store) {
+				seedTestPipeline(t, store, db.Pipeline{Name: "nightly", Repo: "acme/app", SpecYAML: diamondSpecYAML, Enabled: true, Interval: "1h"})
+				if err := store.UpdatePipelineScheduleState(context.Background(), db.PipelineScheduleState{Name: "nightly", NextDueAt: time.Now().Add(time.Hour), LastStatus: "queued"}); err != nil {
+					t.Fatal(err)
+				}
+			},
+			mutate: func(t *testing.T, store *db.Store) {
+				if err := store.UpdatePipelineScheduleState(context.Background(), db.PipelineScheduleState{Name: "nightly", NextDueAt: time.Now().Add(time.Hour), LastStatus: "succeeded"}); err != nil {
+					t.Fatal(err)
+				}
+			},
+			value: func(t *testing.T, body []byte) string {
+				var overview dashboard.Overview
+				if err := json.Unmarshal(body, &overview); err != nil {
+					t.Fatal(err)
+				}
+				if len(overview.Scheduled) != 1 {
+					t.Fatalf("scheduled = %+v", overview.Scheduled)
+				}
+				return overview.Scheduled[0].LastStatus
+			},
+			before: "queued", after: "succeeded",
+		},
+		{
+			name: "task upsert", path: "/api/tasks", maxAge: dashboardTasksCachePolicy.maxAge,
+			seed: func(t *testing.T, store *db.Store) {
+				if err := store.UpsertTask(context.Background(), db.Task{ID: "task", RepoFullName: "acme/app", Title: "before", State: "implementing"}); err != nil {
+					t.Fatal(err)
+				}
+			},
+			mutate: func(t *testing.T, store *db.Store) {
+				if err := store.UpsertTask(context.Background(), db.Task{ID: "task", RepoFullName: "acme/app", Title: "after", State: "implementing"}); err != nil {
+					t.Fatal(err)
+				}
+			},
+			value: func(t *testing.T, body []byte) string {
+				var tasks []dashboard.TaskSummary
+				if err := json.Unmarshal(body, &tasks); err != nil {
+					t.Fatal(err)
+				}
+				if len(tasks) != 1 {
+					t.Fatalf("tasks = %+v", tasks)
+				}
+				return tasks[0].Title
+			},
+			before: "before", after: "after",
+		},
+		{
+			name: "workflow direct job transition", path: "/api/workflows", maxAge: dashboardWorkflowsCachePolicy.maxAge,
+			seed: func(t *testing.T, store *db.Store) {
+				payload := mustJSON(t, workflow.JobPayload{WorkflowID: "cache/workflow", Repo: "acme/app"})
+				if err := store.CreateJob(context.Background(), db.Job{ID: "workflow-job", Agent: "worker", Type: "ask", State: "queued", Payload: payload}); err != nil {
+					t.Fatal(err)
+				}
+			},
+			mutate: func(t *testing.T, store *db.Store) {
+				if ok, err := store.TransitionJobState(context.Background(), "workflow-job", "queued", "succeeded"); err != nil || !ok {
+					t.Fatalf("TransitionJobState = %v, %v", ok, err)
+				}
+			},
+			value: func(t *testing.T, body []byte) string {
+				var entries []dashboard.WorkflowIndexEntry
+				if err := json.Unmarshal(body, &entries); err != nil {
+					t.Fatal(err)
+				}
+				if len(entries) != 1 {
+					t.Fatalf("workflows = %+v", entries)
+				}
+				if entries[0].Counts.Queued == 1 {
+					return "queued"
+				}
+				if entries[0].Counts.Succeeded == 1 {
+					return "succeeded"
+				}
+				return "unexpected"
+			},
+			before: "queued", after: "succeeded",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := dashboardTestHome(t)
+			store, err := db.Open(config.PathsForHome(home).Database)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tc.seed(t, store)
+			now := base
+			cache := newDashboardJSONCache(nil)
+			cache.now = func() time.Time { return now }
+			handler := newDashboardWebHandler(&webDataSource{home: home, responseCache: cache})
+			read := func(wantOutcome string) string {
+				t.Helper()
+				rr := httptest.NewRecorder()
+				handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, tc.path, nil))
+				if rr.Code != http.StatusOK || rr.Header().Get(dashboardCacheHeader) != wantOutcome {
+					t.Fatalf("status=%d outcome=%q body=%s", rr.Code, rr.Header().Get(dashboardCacheHeader), rr.Body.String())
+				}
+				return tc.value(t, rr.Body.Bytes())
+			}
+			if got := read("miss"); got != tc.before {
+				t.Fatalf("initial value = %q, want %q", got, tc.before)
+			}
+			tc.mutate(t, store)
+			if got := read("hit"); got != tc.before {
+				t.Fatalf("retained value = %q, want %q", got, tc.before)
+			}
+			now = base.Add(tc.maxAge)
+			if got := read("miss"); got != tc.after {
+				t.Fatalf("post-expiry value = %q, want %q", got, tc.after)
+			}
+			if err := store.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestDashboardCacheMetricsReportUsesPolicyTable(t *testing.T) {
+	base := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	cache := newDashboardJSONCache(nil)
+	cache.lastReport = base
+	cache.mu.Lock()
+	report := cache.recordLocked("overview", "hit", 42, base.Add(dashboardCacheReportInterval))
+	cache.mu.Unlock()
+	want := "dashboard cache: jobs hits=0 misses=0 shared=0 bytes=0; charts hits=0 misses=0 shared=0 bytes=0; health hits=0 misses=0 shared=0 bytes=0; overview hits=1 misses=0 shared=0 bytes=42; attention hits=0 misses=0 shared=0 bytes=0; agents hits=0 misses=0 shared=0 bytes=0; tasks hits=0 misses=0 shared=0 bytes=0; workflows hits=0 misses=0 shared=0 bytes=0\n"
+	if report != want {
+		t.Fatalf("metrics report:\n%s\nwant:\n%s", report, want)
 	}
 }
 


### PR DESCRIPTION
Extends the #948 cache to the second-tier endpoints per the tri-model panel's frozen per-endpoint policy (synthesis on #956): overview (full cursor, 5s/15s), attention (1s/5s — needs-you radar gets the strictest bound; gate/synth/candidate writes are cursor-uncovered), agents (job-event key, 5s/30s), tasks (task-event key, 2s/15s), workflows (job+note keys, 5s/15s). Health stays singleflight-only; jobs/charts unchanged. Two sanctioned mechanism edits: cursor-component helpers + policy-driven metrics report.

## Verification
- Adversarial review (kimi): caught a real HIGH — the workflows shadow sorted the 'recent' lifecycle state by gitmoot's internal rank while the pinned module ranks it in the default bucket (after settled), breaking byte parity on mixed lists. Fixed with a module-parity comparator; the parity fixture now contains a genuine recent+settled mix and the guard is MUTATION-TESTED (old comparator fails it, fix passes). Capacity hints now derive from the policy table.
- Full dashboard suite + race-gated cache tests green; byte parity pinned against the module handler for all five new endpoints (populated + empty stores).
- Post-#948 live baseline: 38.7% avg CPU; expected after deploy: <10% (recompute per data-change instead of per viewer-poll).

Closes #956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)