### PR TITLE
perf(dashboard): route /api/learning/knowledge through the response cache (#962)

### DIFF
--- a/internal/cli/dashboard_web_cache.go
+++ b/internal/cli/dashboard_web_cache.go
@@ -41,6 +41,12 @@ var dashboardCachePolicies = []dashboardCachePolicy{
 	{endpoint: "agents", keyKind: "job-event-id", retain: true, minRecompute: 5 * time.Second, maxAge: 30 * time.Second},
 	{endpoint: "tasks", keyKind: "task-event-id", retain: true, minRecompute: 2 * time.Second, maxAge: 15 * time.Second},
 	{endpoint: "workflows", keyKind: "job-event-id+workflow-note-id", retain: true, minRecompute: 5 * time.Second, maxAge: 15 * time.Second},
+	// knowledge (#962): the memory-cluster hierarchy costs ~1s CPU per compute
+	// and its inputs (memory tables) advance NO cursor component, so freshness
+	// is TTL-only. The hierarchy changes on memory writes (minutes-scale); 60s
+	// staleness is honest for a browsing surface and turns the needs-you
+	// radar's per-client polling into one compute per minute.
+	{endpoint: "knowledge", keyKind: "ttl-only", retain: true, minRecompute: 15 * time.Second, maxAge: 60 * time.Second},
 }
 
 var (
@@ -52,6 +58,7 @@ var (
 	dashboardAgentsCachePolicy    = dashboardCachePolicies[5]
 	dashboardTasksCachePolicy     = dashboardCachePolicies[6]
 	dashboardWorkflowsCachePolicy = dashboardCachePolicies[7]
+	dashboardKnowledgeCachePolicy = dashboardCachePolicies[8]
 )
 
 type dashboardCacheEntry struct {

--- a/internal/cli/dashboard_web_cache_test.go
+++ b/internal/cli/dashboard_web_cache_test.go
@@ -36,6 +36,7 @@ func TestDashboardCachePolicyTable(t *testing.T) {
 		{endpoint: "agents", keyKind: "job-event-id", retain: true, minRecompute: 5 * time.Second, maxAge: 30 * time.Second},
 		{endpoint: "tasks", keyKind: "task-event-id", retain: true, minRecompute: 2 * time.Second, maxAge: 15 * time.Second},
 		{endpoint: "workflows", keyKind: "job-event-id+workflow-note-id", retain: true, minRecompute: 5 * time.Second, maxAge: 15 * time.Second},
+		{endpoint: "knowledge", keyKind: "ttl-only", retain: true, minRecompute: 15 * time.Second, maxAge: 60 * time.Second},
 	}
 	if !reflect.DeepEqual(dashboardCachePolicies, want) {
 		t.Fatalf("policies = %#v, want %#v", dashboardCachePolicies, want)
@@ -682,7 +683,7 @@ func TestDashboardCacheMetricsReportUsesPolicyTable(t *testing.T) {
 	cache.mu.Lock()
 	report := cache.recordLocked("overview", "hit", 42, base.Add(dashboardCacheReportInterval))
 	cache.mu.Unlock()
-	want := "dashboard cache: jobs hits=0 misses=0 shared=0 bytes=0; charts hits=0 misses=0 shared=0 bytes=0; health hits=0 misses=0 shared=0 bytes=0; overview hits=1 misses=0 shared=0 bytes=42; attention hits=0 misses=0 shared=0 bytes=0; agents hits=0 misses=0 shared=0 bytes=0; tasks hits=0 misses=0 shared=0 bytes=0; workflows hits=0 misses=0 shared=0 bytes=0\n"
+	want := "dashboard cache: jobs hits=0 misses=0 shared=0 bytes=0; charts hits=0 misses=0 shared=0 bytes=0; health hits=0 misses=0 shared=0 bytes=0; overview hits=1 misses=0 shared=0 bytes=42; attention hits=0 misses=0 shared=0 bytes=0; agents hits=0 misses=0 shared=0 bytes=0; tasks hits=0 misses=0 shared=0 bytes=0; workflows hits=0 misses=0 shared=0 bytes=0; knowledge hits=0 misses=0 shared=0 bytes=0\n"
 	if report != want {
 		t.Fatalf("metrics report:\n%s\nwant:\n%s", report, want)
 	}
@@ -805,5 +806,43 @@ func TestDashboardCacheLeaderDisconnectDoesNotAbortCompute(t *testing.T) {
 	})
 	if err != nil || string(body) != "survived" {
 		t.Fatalf("leader cancellation aborted the shared compute: %q, %v", body, err)
+	}
+}
+
+func TestDashboardKnowledgeCacheTTLAndParity(t *testing.T) {
+	home := dashboardTestHome(t)
+	seedWebDashboardTree(t, home)
+	now := time.Now()
+	ds := &webDataSource{home: home, responseCache: newDashboardJSONCache(nil)}
+	ds.responseCache.now = func() time.Time { return now }
+	h := newDashboardWebHandler(ds)
+	get := func() (string, string) {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest("GET", "/api/learning/knowledge", nil))
+		if rec.Code != 200 {
+			t.Fatalf("knowledge status %d: %s", rec.Code, rec.Body.String())
+		}
+		return rec.Body.String(), rec.Header().Get(dashboardCacheHeader)
+	}
+	first, o1 := get()
+	if o1 != "miss" {
+		t.Fatalf("first outcome %q, want miss", o1)
+	}
+	// Parity: the cached bytes must equal a direct compute.
+	direct, err := ds.knowledgeJSON(context.Background())
+	if err != nil || first != string(direct) {
+		t.Fatalf("cached body diverges from direct compute (err=%v, lens %d vs %d)", err, len(first), len(direct))
+	}
+	// Within maxAge: served from cache regardless of data (ttl-only policy).
+	now = now.Add(30 * time.Second)
+	second, o2 := get()
+	if o2 != "hit" || second != first {
+		t.Fatalf("30s outcome %q (want hit), bytes equal=%v", o2, second == first)
+	}
+	// Past maxAge: recompute.
+	now = now.Add(31 * time.Second)
+	_, o3 := get()
+	if o3 != "miss" {
+		t.Fatalf("61s outcome %q, want miss", o3)
 	}
 }

--- a/internal/cli/dashboard_web_learning.go
+++ b/internal/cli/dashboard_web_learning.go
@@ -378,10 +378,18 @@ type dashboardKnowledgeCluster struct {
 }
 
 func (d *webDataSource) handleLearningKnowledge(w http.ResponseWriter, r *http.Request) {
-	k, sharedByFact, parentByCluster, err := d.knowledgeWithShared(r.Context())
+	// #962: the cluster hierarchy is the dashboard's most expensive compute and
+	// is radar-polled per client; serve it through the response cache. The
+	// cursor is a constant because no cursor component covers memory writes —
+	// the policy's TTLs alone govern freshness.
+	body, outcome, err := d.cacheForDashboard().get(r.Context(), "knowledge", "ttl", dashboardKnowledgeCachePolicy, d.knowledgeJSON)
+	d.writeCachedDashboardJSON(w, outcome, body, err)
+}
+
+func (d *webDataSource) knowledgeJSON(ctx context.Context) ([]byte, error) {
+	k, sharedByFact, parentByCluster, err := d.knowledgeWithShared(ctx)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		return nil, err
 	}
 	resp := dashboardKnowledgeResponse{
 		Agents:   k.Agents,
@@ -403,13 +411,9 @@ func (d *webDataSource) handleLearningKnowledge(w http.ResponseWriter, r *http.R
 	}
 	buf, err := json.MarshalIndent(resp, "", "  ")
 	if err != nil {
-		http.Error(w, "internal error: "+err.Error(), http.StatusInternalServerError)
-		return
+		return nil, err
 	}
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	buf = append(buf, '\n')
-	_, _ = w.Write(buf)
+	return append(buf, '\n'), nil
 }
 
 // factSourceFileMarkers are the Provenance prefixes the file-ingest write paths


### PR DESCRIPTION
The post-#956 measurement (30.6% avg) reconciled the cache counters against actual CPU and proved the cached endpoints cost only ~2.6% — the real driver was `/api/learning/knowledge` (~0.96s CPU per request, the #830 memory-cluster hierarchy), radar-polled per connected client and never routed through the cache. ~23 clients × 60s polling ≈ 30% by itself.

One policy entry (`ttl-only`, 15s/60s — memory writes advance no cursor component; 60s staleness is honest for a browsing surface) + the existing shadow handler routed through `cache.get` with byte parity pinned (cached bytes == direct compute), TTL transitions tested with a fake clock, policy-table and policy-driven metrics tests extended.

Expected after deploy: dashboard-web **<5%** at current viewer load (journey: 200%+ bursts → 38.7% after #948 → 30.6% after #956 → this).

Closes #962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)