### PR TITLE
feat(pipeline): run-stage deps persisted + served — detail DAG renders horizontally

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715170422-a81d1dec1d6c
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715222135-ca3e557c5d1c
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715170422-a81d1dec1d6c h1:mTpF6sDmgM3JfuN2twM1G+EybOqsBpfl3zqSUtYV8ms=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715170422-a81d1dec1d6c/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715222135-ca3e557c5d1c h1:yo2amJpqC4O7p5sDXi36xYoFC+YzsOBQbuwAT9YDNzk=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715222135-ca3e557c5d1c/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/cli/dashboard_web_pipelines.go
+++ b/internal/cli/dashboard_web_pipelines.go
@@ -81,10 +81,14 @@ func (d *webDataSource) Pipelines(ctx context.Context) ([]dashboard.PipelineSumm
 // maps to dashboard.ErrPipelineRunNotFound (the API layer serves that as a 404).
 // It replicates orderPipelineRunStages: when the run's pipeline and a matching spec
 // snapshot are available it reorders the stage rows into the spec's declared order
-// and merges each spec stage's cmd + dependency needs onto the row; otherwise it
-// keeps the store's stable stage_id order with no spec-derived fields (the same
-// fall-back the funnel takes on a missing pipeline or a SpecHash mismatch). Stages
-// is always non-nil.
+// and merges each spec stage's metadata onto the row; otherwise it keeps the
+// store's stable stage_id order with no spec-derived metadata (the same fall-back
+// the funnel takes on a missing pipeline or a SpecHash mismatch). Deps prefer the
+// persisted stage needs_json snapshot. Empty snapshots may fall back to the
+// current spec under either the strict hash gate or an exact stage-ID-set gate:
+// dependency edges drive layout, so a metadata-only spec re-add must not flatten
+// run history, while a set mismatch keeps the honest vertical fallback. Stages
+// and every stage's Deps are always non-nil.
 func (d *webDataSource) PipelineRun(ctx context.Context, id string) (dashboard.PipelineRun, error) {
 	out := dashboard.PipelineRun{Stages: []dashboard.PipelineStage{}}
 	err := withStore(d.home, func(store *db.Store) error {
@@ -116,8 +120,11 @@ func (d *webDataSource) PipelineRun(ctx context.Context, id string) (dashboard.P
 			}
 		}
 		ordered, specOK := orderRunStages(spec, specParsed, specHash, run.SpecHash, stageRows)
+		depsSpecOK := specOK || (specParsed && pipelineRunStageIDsMatchSpec(spec, stageRows))
+		stageIDs := make(map[string]struct{}, len(ordered))
 		jobIDs := make([]string, 0, len(ordered))
 		for _, row := range ordered {
+			stageIDs[row.StageID] = struct{}{}
 			if row.JobID != "" {
 				jobIDs = append(jobIDs, row.JobID)
 			}
@@ -131,6 +138,13 @@ func (d *webDataSource) PipelineRun(ctx context.Context, id string) (dashboard.P
 			specByID = make(map[string]pipeline.Stage, len(spec.Stages))
 			for _, s := range spec.Stages {
 				specByID[s.ID] = s
+			}
+		}
+		var depsSpecByID map[string]pipeline.Stage
+		if depsSpecOK {
+			depsSpecByID = make(map[string]pipeline.Stage, len(spec.Stages))
+			for _, s := range spec.Stages {
+				depsSpecByID[s.ID] = s
 			}
 		}
 
@@ -149,9 +163,16 @@ func (d *webDataSource) PipelineRun(ctx context.Context, id string) (dashboard.P
 			Stages:     make([]dashboard.PipelineStage, 0, len(ordered)),
 		}
 		for _, row := range ordered {
+			deps, persisted := decodePipelineRunStageDeps(row.NeedsJSON, stageIDs)
+			if !persisted {
+				if spec, ok := depsSpecByID[row.StageID]; ok {
+					deps = append([]string{}, spec.Needs...)
+				}
+			}
 			stage := dashboard.PipelineStage{
 				ID:         row.StageID,
 				State:      row.State,
+				Deps:       deps,
 				JobID:      row.JobID,
 				Attempt:    row.Attempt,
 				Needs:      decodePipelineNeeds(row.NeedsJSON),
@@ -162,11 +183,9 @@ func (d *webDataSource) PipelineRun(ctx context.Context, id string) (dashboard.P
 			if spec, ok := specByID[row.StageID]; ok {
 				stage.Cmd = spec.Cmd
 				stage.Retry = spec.Retry
-				if len(spec.Needs) > 0 {
-					stage.Deps = append([]string(nil), spec.Needs...)
-				}
-				// #873 display metadata, under the same spec gate as cmd/deps: the
-				// stage kind badge and (when the agent is registered) its runtime.
+				// #873 display metadata stays under the same strict hash gate as
+				// cmd/retry: the structural dependency fallback must never leak the
+				// stage kind or agent runtime from a different spec snapshot.
 				stage.Kind = pipelineStageKindName(spec)
 				if name := strings.TrimSpace(spec.Agent); name != "" {
 					if agent, aerr := store.GetAgent(ctx, name); aerr == nil {
@@ -191,6 +210,56 @@ func (d *webDataSource) PipelineRun(ctx context.Context, id string) (dashboard.P
 		return dashboard.PipelineRun{}, err
 	}
 	return out, nil
+}
+
+// decodePipelineRunStageDeps decodes a persisted stage dependency list without
+// trusting arbitrary needs_json strings as graph edges. The stage row field also
+// carries human-action needs when a stage blocks, so only references to ids in the
+// same run become edges. Any non-empty persisted value is authoritative: malformed
+// JSON and non-stage values deliberately decode to an empty graph rather than
+// falling through to a possibly stale spec. The returned slice is always non-nil
+// and keeps the stored order.
+func decodePipelineRunStageDeps(value string, stageIDs map[string]struct{}) (deps []string, present bool) {
+	deps = []string{}
+	if strings.TrimSpace(value) == "" {
+		return deps, false
+	}
+	if err := json.Unmarshal([]byte(value), &deps); err != nil || deps == nil {
+		return []string{}, true
+	}
+	out := make([]string, 0, len(deps))
+	for _, dep := range deps {
+		dep = strings.TrimSpace(dep)
+		if _, ok := stageIDs[dep]; ok {
+			out = append(out, dep)
+		}
+	}
+	return out, true
+}
+
+// pipelineRunStageIDsMatchSpec is the structural dependency-fallback gate. It
+// compares exact sets (not order) so metadata-only spec re-adds can restore the
+// historical DAG without attaching edges from a genuinely different pipeline.
+func pipelineRunStageIDsMatchSpec(spec pipeline.Spec, rows []db.PipelineRunStage) bool {
+	if len(spec.Stages) != len(rows) {
+		return false
+	}
+	ids := make(map[string]struct{}, len(spec.Stages))
+	for _, stage := range spec.Stages {
+		id := strings.TrimSpace(stage.ID)
+		if _, duplicate := ids[id]; duplicate {
+			return false
+		}
+		ids[id] = struct{}{}
+	}
+	for _, row := range rows {
+		id := strings.TrimSpace(row.StageID)
+		if _, ok := ids[id]; !ok {
+			return false
+		}
+		delete(ids, id)
+	}
+	return len(ids) == 0
 }
 
 // PipelineDetail returns one pipeline's currently declared stage DAG plus its run
@@ -336,6 +405,8 @@ func pipelineStageCount(specYAML string) int {
 // caller may then merge spec-derived cmd/deps/retry). Any weaker condition — no
 // spec, parse failure, or a spec-hash mismatch — keeps the store's stage_id order
 // with specOK false, mirroring orderPipelineRunStages' fallback (the CLI funnel).
+// The caller may independently apply the narrower stage-ID-set fallback to Deps;
+// this strict result remains the only gate for ordering and display metadata.
 func orderRunStages(spec pipeline.Spec, specParsed bool, specHash, runSpecHash string, rows []db.PipelineRunStage) (ordered []db.PipelineRunStage, specOK bool) {
 	if specParsed && strings.TrimSpace(specHash) == strings.TrimSpace(runSpecHash) {
 		return orderPipelineStagesBySpec(spec, rows), true

--- a/internal/cli/dashboard_web_pipelines_test.go
+++ b/internal/cli/dashboard_web_pipelines_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"testing"
@@ -306,11 +307,17 @@ func TestWebDataSourcePipelineRunBlockedDiamond(t *testing.T) {
 	if ascore.Cmd != `./scripts/score.sh --filter "p<95> && q>1"` {
 		t.Fatalf("ascore Cmd = %q, want the verbatim (escapable) filter cmd", ascore.Cmd)
 	}
-	if len(ascore.Deps) != 1 || ascore.Deps[0] != "zfetch" {
-		t.Fatalf("ascore Deps = %+v, want [zfetch]", ascore.Deps)
+	// Persisted needs_json wins over the strict spec gate. This blocked row carries
+	// a human-action need rather than a stage id, so it safely produces no edge.
+	if ascore.Deps == nil || len(ascore.Deps) != 0 {
+		t.Fatalf("ascore Deps = %+v, want non-nil empty persisted override", ascore.Deps)
 	}
 	if len(ascore.Needs) != 1 || ascore.Needs[0] != "set R2 token: gitmoot config set r2.token" {
 		t.Fatalf("ascore Needs = %+v, want the persisted blocked need", ascore.Needs)
+	}
+	bdedupe := byID["bdedupe"]
+	if !slices.Equal(bdedupe.Deps, []string{"zfetch"}) {
+		t.Fatalf("bdedupe Deps = %+v, want strict-hash spec deps [zfetch]", bdedupe.Deps)
 	}
 	publish := byID["publish"]
 	if publish.State != pipeline.StageSkipped || publish.JobID != "" {
@@ -318,6 +325,60 @@ func TestWebDataSourcePipelineRunBlockedDiamond(t *testing.T) {
 	}
 	if len(publish.Deps) != 2 || publish.Deps[0] != "ascore" || publish.Deps[1] != "bdedupe" {
 		t.Fatalf("publish Deps = %+v, want [ascore bdedupe]", publish.Deps)
+	}
+}
+
+// TestWebDataSourcePipelineRunStoredDeps pins persisted-dependency precedence over
+// both spec gates: matching-hash and same-stage-set structural fallback. Stored
+// order is retained; roots and malformed values become non-nil empty slices.
+func TestWebDataSourcePipelineRunStoredDeps(t *testing.T) {
+	home := dashboardTestHome(t)
+	store := openPipelineTestStore(t, home)
+	realHash := pipeline.Hash([]byte(diamondSpecYAML))
+	seedTestPipeline(t, store, db.Pipeline{
+		Name: "listing-refresh", Repo: "jerryfane/noted", SpecYAML: diamondSpecYAML, SpecHash: realHash,
+	})
+	rows := []db.PipelineRunStage{
+		{StageID: "zfetch", State: pipeline.StageSucceeded},
+		{StageID: "ascore", State: pipeline.StagePending, NeedsJSON: `["bdedupe"]`},
+		{StageID: "bdedupe", State: pipeline.StagePending, NeedsJSON: `not-json`},
+		{StageID: "publish", State: pipeline.StagePending, NeedsJSON: `["zfetch","ascore"]`},
+	}
+	seedTestRun(t, store, db.PipelineRun{
+		ID: "prun-stored-deps-strict", Pipeline: "listing-refresh", State: pipeline.RunRunning, SpecHash: realHash,
+	}, rows)
+	seedTestRun(t, store, db.PipelineRun{
+		ID: "prun-stored-deps-structural", Pipeline: "listing-refresh", State: pipeline.RunRunning, SpecHash: "sha256-stale",
+	}, rows)
+	store.Close()
+
+	for _, runID := range []string{"prun-stored-deps-strict", "prun-stored-deps-structural"} {
+		run, err := (&webDataSource{home: home}).PipelineRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("PipelineRun(%s): %v", runID, err)
+		}
+		byID := map[string]dashboard.PipelineStage{}
+		for _, stage := range run.Stages {
+			byID[stage.ID] = stage
+		}
+		if got := byID["ascore"].Deps; !slices.Equal(got, []string{"bdedupe"}) {
+			t.Fatalf("%s ascore Deps = %v, want persisted override [bdedupe]", runID, got)
+		}
+		if got := byID["publish"].Deps; !slices.Equal(got, []string{"zfetch", "ascore"}) {
+			t.Fatalf("%s publish Deps = %v, want persisted order [zfetch ascore]", runID, got)
+		}
+		for _, id := range []string{"zfetch", "bdedupe"} {
+			if got := byID[id].Deps; got == nil || len(got) != 0 {
+				t.Fatalf("%s %s Deps = %#v, want non-nil empty persisted result", runID, id, got)
+			}
+		}
+		encoded, err := json.Marshal(byID["zfetch"].Deps)
+		if err != nil {
+			t.Fatalf("marshal root Deps: %v", err)
+		}
+		if string(encoded) != "[]" {
+			t.Fatalf("%s root Deps JSON = %s, want []", runID, encoded)
+		}
 	}
 }
 
@@ -404,11 +465,10 @@ func TestWebDataSourcePipelineRunNotFound(t *testing.T) {
 	}
 }
 
-// TestWebDataSourcePipelineRunSpecHashMismatchFallback pins the fallback: when the
-// run's SpecHash does not match the stored pipeline's spec, stages keep the store's
-// stage_id order and carry NO spec-derived cmd/deps (the run's snapshot no longer
-// corresponds to the current spec) — mirroring orderPipelineRunStages' fallback.
-func TestWebDataSourcePipelineRunSpecHashMismatchFallback(t *testing.T) {
+// TestWebDataSourcePipelineRunSpecHashMismatchSameStageSetFallback pins the
+// metadata-only re-add case: a hash mismatch keeps store ordering and suppresses
+// metadata, but an exact stage-ID set restores dependency edges for layout.
+func TestWebDataSourcePipelineRunSpecHashMismatchSameStageSetFallback(t *testing.T) {
 	home := dashboardTestHome(t)
 	seedDiamondBlockedRun(t, home, "prun-diamond-stale", "sha256-stale-mismatch")
 
@@ -429,25 +489,71 @@ func TestWebDataSourcePipelineRunSpecHashMismatchFallback(t *testing.T) {
 				[]string{run.Stages[0].ID, run.Stages[1].ID, run.Stages[2].ID, run.Stages[3].ID}, wantOrder)
 		}
 	}
-	// No spec applied => no merged cmd/deps on any stage.
+	// The strict hash gate still suppresses all display metadata.
 	for _, s := range run.Stages {
-		if s.Cmd != "" || len(s.Deps) != 0 {
-			t.Fatalf("stage %s carried spec fields on hash mismatch: %+v", s.ID, s)
+		if s.Cmd != "" || s.Kind != "" || s.AgentRuntime != "" || s.Retry != 0 {
+			t.Fatalf("stage %s carried spec metadata on hash mismatch: %+v", s.ID, s)
 		}
+	}
+	byID := map[string]dashboard.PipelineStage{}
+	for _, stage := range run.Stages {
+		byID[stage.ID] = stage
+	}
+	if !slices.Equal(byID["bdedupe"].Deps, []string{"zfetch"}) {
+		t.Fatalf("bdedupe structural Deps = %v, want [zfetch]", byID["bdedupe"].Deps)
+	}
+	if !slices.Equal(byID["publish"].Deps, []string{"ascore", "bdedupe"}) {
+		t.Fatalf("publish structural Deps = %v, want [ascore bdedupe]", byID["publish"].Deps)
+	}
+	if byID["zfetch"].Deps == nil || len(byID["zfetch"].Deps) != 0 {
+		t.Fatalf("zfetch structural Deps = %#v, want non-nil empty root", byID["zfetch"].Deps)
+	}
+	// The blocked row's present needs_json wins over structural fallback and is
+	// filtered to no edge because its human-action text is not a stage id.
+	if byID["ascore"].Deps == nil || len(byID["ascore"].Deps) != 0 {
+		t.Fatalf("ascore persisted Deps = %#v, want non-nil empty", byID["ascore"].Deps)
 	}
 	// The blocked stage's PERSISTED needs still surface (they live on the row, not the spec).
-	var ascore dashboard.PipelineStage
-	for _, s := range run.Stages {
-		if s.ID == "ascore" {
-			ascore = s
-		}
-	}
+	ascore := byID["ascore"]
 	if len(ascore.Needs) != 1 {
 		t.Fatalf("ascore Needs on fallback = %+v, want the persisted need retained", ascore.Needs)
 	}
 	// Repo is a pipeline-level attribute, so it is still resolved from the current row.
 	if run.Repo != "jerryfane/noted" {
 		t.Fatalf("run Repo on fallback = %q, want jerryfane/noted", run.Repo)
+	}
+}
+
+// TestWebDataSourcePipelineRunSpecHashMismatchDifferentStageSetFallback pins the
+// honest fallback: when stage membership changed, an old run gets neither current
+// metadata nor current dependency edges.
+func TestWebDataSourcePipelineRunSpecHashMismatchDifferentStageSetFallback(t *testing.T) {
+	home := dashboardTestHome(t)
+	store := openPipelineTestStore(t, home)
+	seedTestPipeline(t, store, db.Pipeline{
+		Name: "listing-refresh", Repo: "jerryfane/noted", SpecYAML: diamondSpecYAML,
+	})
+	seedTestRun(t, store, db.PipelineRun{
+		ID: "prun-diamond-different-set", Pipeline: "listing-refresh", State: pipeline.RunRunning,
+		SpecHash: "sha256-stale-mismatch",
+	}, []db.PipelineRunStage{
+		{StageID: "zfetch", State: pipeline.StageSucceeded},
+		{StageID: "ascore", State: pipeline.StagePending},
+		{StageID: "publish", State: pipeline.StagePending},
+	})
+	store.Close()
+
+	run, err := (&webDataSource{home: home}).PipelineRun(context.Background(), "prun-diamond-different-set")
+	if err != nil {
+		t.Fatalf("PipelineRun: %v", err)
+	}
+	for _, stage := range run.Stages {
+		if stage.Deps == nil || len(stage.Deps) != 0 {
+			t.Fatalf("different-set stage %s Deps = %#v, want non-nil empty", stage.ID, stage.Deps)
+		}
+		if stage.Cmd != "" || stage.Kind != "" || stage.AgentRuntime != "" || stage.Retry != 0 {
+			t.Fatalf("different-set stage %s carried spec metadata: %+v", stage.ID, stage)
+		}
 	}
 }
 
@@ -821,8 +927,8 @@ func TestWebDataSourcePipelineDetailRetry(t *testing.T) {
 
 // TestWebDataSourcePipelineRunRetryAbsentOnHashMismatch pins the other half of
 // the retry hash gate: a run whose SpecHash no longer matches the pipeline's
-// stored spec gets NO spec-merged fields — Retry stays 0 alongside the already
-// gated Cmd/Deps, because stale-spec data would be wrong data.
+// stored spec gets no spec-merged metadata — Retry and Cmd stay empty. The exact
+// stage-ID set still permits the structural Deps fallback used for layout.
 func TestWebDataSourcePipelineRunRetryAbsentOnHashMismatch(t *testing.T) {
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
@@ -844,10 +950,18 @@ func TestWebDataSourcePipelineRunRetryAbsentOnHashMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PipelineRun: %v", err)
 	}
+	byID := map[string]dashboard.PipelineStage{}
 	for _, s := range run.Stages {
-		if s.Retry != 0 || s.Cmd != "" || len(s.Deps) != 0 {
-			t.Fatalf("stale-spec stage %s carries spec-merged fields (%+v); retry/cmd/deps must be absent on a hash mismatch", s.ID, s)
+		byID[s.ID] = s
+		if s.Retry != 0 || s.Cmd != "" || s.Kind != "" || s.AgentRuntime != "" {
+			t.Fatalf("stale-spec stage %s carries spec metadata: %+v", s.ID, s)
 		}
+	}
+	if byID["build"].Deps == nil || len(byID["build"].Deps) != 0 {
+		t.Fatalf("stale build Deps = %#v, want non-nil empty root", byID["build"].Deps)
+	}
+	if !slices.Equal(byID["test"].Deps, []string{"build"}) {
+		t.Fatalf("stale test Deps = %v, want structural fallback [build]", byID["test"].Deps)
 	}
 	// The run-level data is untouched by the gate.
 	if run.Stages[0].Attempt+run.Stages[1].Attempt != 2 {

--- a/internal/cli/pipeline_advance_test.go
+++ b/internal/cli/pipeline_advance_test.go
@@ -143,6 +143,29 @@ stages:
     needs: [b]
 `
 
+func TestCreatePipelineRunPersistsStageDeps(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	now := time.Date(2026, 7, 15, 20, 0, 0, 0, time.UTC)
+
+	run, err := createPipelineRun(context.Background(), store, rec, spec, "manual", "{}", now)
+	if err != nil {
+		t.Fatalf("createPipelineRun: %v", err)
+	}
+	for _, tc := range []struct {
+		stageID string
+		want    string
+	}{
+		{stageID: "a", want: ""},
+		{stageID: "b", want: `["a"]`},
+		{stageID: "c", want: `["b"]`},
+	} {
+		if got := stageRow(t, store, run.ID, tc.stageID).NeedsJSON; got != tc.want {
+			t.Fatalf("stage %s needs_json = %q, want %q", tc.stageID, got, tc.want)
+		}
+	}
+}
+
 // TestAdvancerLinearChain proves a linear a->b->c chain advances one layer per
 // scan: each stage is enqueued only after its single dependency succeeds, and the
 // run reaches succeeded exactly when the last stage does.

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -665,9 +665,10 @@ func createPipelineRun(ctx context.Context, store *db.Store, rec db.Pipeline, sp
 	}
 	for _, stage := range spec.Stages {
 		if err := store.CreatePipelineRunStage(ctx, db.PipelineRunStage{
-			RunID:   run.ID,
-			StageID: stage.ID,
-			State:   pipeline.StagePending,
+			RunID:     run.ID,
+			StageID:   stage.ID,
+			State:     pipeline.StagePending,
+			NeedsJSON: marshalPipelineNeeds(stage.Needs),
 		}); err != nil {
 			return db.PipelineRun{}, err
 		}
@@ -772,7 +773,12 @@ func triggerOnePipeline(ctx context.Context, store *db.Store, rec db.Pipeline, n
 	}
 	stages := make([]db.PipelineRunStage, 0, len(spec.Stages))
 	for _, stage := range spec.Stages {
-		stages = append(stages, db.PipelineRunStage{RunID: run.ID, StageID: stage.ID, State: pipeline.StagePending})
+		stages = append(stages, db.PipelineRunStage{
+			RunID:     run.ID,
+			StageID:   stage.ID,
+			State:     pipeline.StagePending,
+			NeedsJSON: marshalPipelineNeeds(stage.Needs),
+		})
 	}
 	_, err = store.FirePipelineTrigger(ctx, state, upstreamRun, run, stages)
 	return err

--- a/internal/cli/pipeline_schedule_test.go
+++ b/internal/cli/pipeline_schedule_test.go
@@ -41,7 +41,7 @@ func newScheduledPipeline(t *testing.T, store *db.Store, name, repo, interval, j
 
 func newPipelineTriggeredPipeline(t *testing.T, store *db.Store, name, upstream string, enabled bool, armedAt time.Time) db.Pipeline {
 	t.Helper()
-	specYAML := fmt.Sprintf("name: %s\nrepo: owner/%s\ntrigger: {kind: pipeline, pipeline: %s}\nstages:\n  - {id: run, cmd: echo ok}\n", name, name, upstream)
+	specYAML := fmt.Sprintf("name: %s\nrepo: owner/%s\ntrigger: {kind: pipeline, pipeline: %s}\nstages:\n  - {id: run, cmd: echo ok}\n  - {id: publish, cmd: echo publish, needs: [run]}\n", name, name, upstream)
 	rec := db.Pipeline{Name: name, Repo: "owner/" + name, SpecYAML: specYAML, SpecHash: pipeline.Hash([]byte(specYAML)), Enabled: enabled}
 	if err := store.CreateOrUpdatePipeline(context.Background(), rec); err != nil {
 		t.Fatalf("CreateOrUpdatePipeline: %v", err)
@@ -85,6 +85,12 @@ func TestPipelineSuccessTriggerFiresOnce(t *testing.T) {
 	}
 	if !strings.Contains(runs[0].PayloadJSON, upstream.ID) || !strings.Contains(runs[0].PayloadJSON, `"upstream_pipeline":"upstream"`) {
 		t.Fatalf("downstream payload_json = %q", runs[0].PayloadJSON)
+	}
+	if got := stageRow(t, store, runs[0].ID, "run").NeedsJSON; got != "" {
+		t.Fatalf("triggered root needs_json = %q, want empty", got)
+	}
+	if got := stageRow(t, store, runs[0].ID, "publish").NeedsJSON; got != `["run"]` {
+		t.Fatalf("triggered publish needs_json = %q, want [run]", got)
 	}
 	if err := triggerPipelineRuns(ctx, store, base.Add(3*time.Minute)); err != nil {
 		t.Fatalf("re-tick: %v", err)

--- a/internal/db/pipeline_run.go
+++ b/internal/db/pipeline_run.go
@@ -33,8 +33,9 @@ type PipelineRun struct {
 // of a single stage within a run, keyed by (RunID, StageID). JobID is the stage
 // job the advancer enqueued (empty until enqueued or after a retry reset), Attempt
 // is the current attempt number (the deterministic stage job id embeds it),
-// NeedsJSON persists a blocked stage's needs verbatim, and Summary is the settling
-// result's short summary (or the failure reason).
+// NeedsJSON snapshots the stage's dependency ids when the row is created; if the
+// stage later parks, it is replaced by that blocked stage's human-action needs.
+// Summary is the settling result's short summary (or the failure reason).
 type PipelineRunStage struct {
 	RunID      string
 	StageID    string


### PR DESCRIPTION
Owner-reported: /pipelines/<name> stage graphs rendered as one vertical alphabetical column, in old gradient cards. Diagnosis: the client's depth-column layout was correct — the run payload just never carried deps (needs_json was never persisted at run creation, and the spec-hash gate blocked the spec fallback after any spec re-add).

- Run creation (schedule/manual + the #922 trigger fire path) now persists each stage's spec `Needs` into `pipeline_run_stages.needs_json`.
- The run payload serves `deps` ([]string, never null) with layered resolution: persisted needs_json → strict spec-hash gate → structural fallback (current spec's stage-ID set exactly equals the run's) — deps drive layout so metadata-only re-adds must not flatten history; kind/cmd/runtime metadata keeps the strict gate untouched.
- Includes the dashboard re-pin: `deps` wire field, .pl-node + all state variants on the flat grammar (zero gradients, computed-style audited), branching split/join fixture so fake mode exercises multi-column layout permanently.

Verified on the live store via replace-build: the reported arxiv-paper-summary page now renders a horizontal DAG in true execution order with flat cards (screenshots in the work log); historical runs recover via the structural gate, new runs carry persisted deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)