### PR TITLE
Gitmoot: TASK: Implement gitmoot issue #959. Read it first,

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -520,6 +520,9 @@ Fixes:
   worktree path on the task and routes task-tied jobs there.
 - Keep the registered checkout clean. Gitmoot still uses it for base branch
   updates and merge-gate cleanup.
+- If a removed task worktree was previously cached as the registered checkout,
+  run `gitmoot repo doctor owner/repo`. Gitmoot verifies the recorded primary
+  checkout and repairs the registration before the next job resolves its base.
 - Use separate runtime sessions, managed background instances, or forkable temp
   workers for jobs that should truly run concurrently. Worktrees isolate files;
   temp workers isolate busy Codex/Claude runtime sessions when eligible.

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1419,7 +1419,7 @@ func runAgentStart(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2
 	}
-	record, err := repoRecordFromPath(context.Background(), repo, *path)
+	record, err := repoRecordFromStablePath(context.Background(), repo, *path)
 	if err != nil {
 		fmt.Fprintf(stderr, "agent start: %v\n", err)
 		return 1

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -1352,32 +1352,18 @@ func resolveLocalAgentRepo(ctx context.Context, store *db.Store, repoFlag string
 	if err != nil {
 		return github.Repository{}, db.Repo{}, err
 	}
-	if strings.TrimSpace(repoFlag) == "" {
-		record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."})
-		if err != nil {
-			return github.Repository{}, db.Repo{}, err
-		}
-		return repo, record, nil
-	}
-	if existing, err := store.GetRepo(ctx, repo.FullName()); err == nil && strings.TrimSpace(existing.CheckoutPath) != "" {
-		record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: existing.CheckoutPath})
-		if err != nil {
-			return github.Repository{}, db.Repo{}, err
-		}
-		// repoRecordForCheckout reports the checkout's current branch. For a
-		// registered repo, keep the stored default branch so an old feature checkout
-		// cannot redefine the base branch during dispatch.
-		if strings.TrimSpace(existing.DefaultBranch) != "" {
-			record.DefaultBranch = existing.DefaultBranch
-		}
-		record.PollInterval = existing.PollInterval
-		return repo, record, nil
-	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return github.Repository{}, db.Repo{}, err
-	}
-	record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."})
+	record, err := resolveRepoRecord(ctx, store, repo, ".")
 	if err != nil {
 		return github.Repository{}, db.Repo{}, err
+	}
+	// Without --repo, preserve the historical current-checkout branch selection
+	// for the job payload while retaining the registered/stable checkout path.
+	// This prevents an ephemeral cwd from becoming repo.CheckoutPath without
+	// silently rebasing local ask/review behavior onto the stored default branch.
+	if strings.TrimSpace(repoFlag) == "" {
+		if cwdRecord, cwdErr := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."}); cwdErr == nil {
+			record.DefaultBranch = cwdRecord.DefaultBranch
+		}
 	}
 	return repo, record, nil
 }

--- a/internal/cli/agent_implement_base_test.go
+++ b/internal/cli/agent_implement_base_test.go
@@ -292,3 +292,120 @@ func TestResolveLocalAgentRepoPreservesRegisteredDefaultBranch(t *testing.T) {
 		t.Fatalf("checkout branch = %q err=%v, want feature/stale", branch, err)
 	}
 }
+
+func TestResolveLocalAgentRepoSelfHealsDanglingCheckoutForImplementBase(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	primary, linked := setupLinkedWorktreeRepo(t)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepoForce(ctx, db.Repo{
+		Owner: "owner", Name: "repo", DefaultBranch: "main",
+		CheckoutPath: linked, PrimaryCheckoutPath: primary,
+	}); err != nil {
+		t.Fatalf("UpsertRepoForce: %v", err)
+	}
+	runGit(t, primary, "worktree", "remove", "--force", linked)
+
+	_, record, err := resolveLocalAgentRepo(ctx, store, "owner/repo")
+	if err != nil {
+		t.Fatalf("resolveLocalAgentRepo: %v", err)
+	}
+	if record.CheckoutPath != primary || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("resolved record = %+v, want repaired primary %s", record, primary)
+	}
+	wantSHA := strings.TrimSpace(runGitOutput(t, primary, "rev-parse", "HEAD"))
+	gotSHA, err := resolveLocalImplementBase(ctx, config.PathsForHome(home), record, "HEAD")
+	if err != nil || gotSHA != wantSHA {
+		t.Fatalf("resolveLocalImplementBase = %q, err=%v, want %q", gotSHA, err, wantSHA)
+	}
+	stored, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil || stored.CheckoutPath != primary || stored.PrimaryCheckoutPath != primary {
+		t.Fatalf("stored record = %+v, err=%v", stored, err)
+	}
+}
+
+func TestResolveLocalAgentRepoSelfHealsNonGitCheckout(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	primary, linked := setupLinkedWorktreeRepo(t)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepoForce(ctx, db.Repo{
+		Owner: "owner", Name: "repo", DefaultBranch: "main",
+		CheckoutPath: linked, PrimaryCheckoutPath: primary,
+	}); err != nil {
+		t.Fatalf("UpsertRepoForce: %v", err)
+	}
+	runGit(t, primary, "worktree", "remove", "--force", linked)
+	if err := os.MkdirAll(linked, 0o755); err != nil {
+		t.Fatalf("recreate non-git checkout directory: %v", err)
+	}
+
+	_, record, err := resolveLocalAgentRepo(ctx, store, "owner/repo")
+	if err != nil {
+		t.Fatalf("resolveLocalAgentRepo: %v", err)
+	}
+	if record.CheckoutPath != primary || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("resolved record = %+v, want repaired primary %s", record, primary)
+	}
+	stored, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil || stored.CheckoutPath != primary || stored.PrimaryCheckoutPath != primary {
+		t.Fatalf("stored record = %+v, err=%v", stored, err)
+	}
+}
+
+func TestResolveLocalAgentRepoLeavesValidLinkedCheckoutRegistered(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	primary, linked := setupLinkedWorktreeRepo(t)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepoForce(ctx, db.Repo{
+		Owner: "owner", Name: "repo", DefaultBranch: "main",
+		CheckoutPath: linked, PrimaryCheckoutPath: primary,
+	}); err != nil {
+		t.Fatalf("UpsertRepoForce: %v", err)
+	}
+
+	_, record, err := resolveLocalAgentRepo(ctx, store, "owner/repo")
+	if err != nil {
+		t.Fatalf("resolveLocalAgentRepo: %v", err)
+	}
+	if record.CheckoutPath != linked || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("resolved record = %+v, want valid linked checkout %s", record, linked)
+	}
+	stored, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil || stored.CheckoutPath != linked {
+		t.Fatalf("stored record = %+v, err=%v", stored, err)
+	}
+}
+
+func TestResolveRepoRecordPinsImplicitLinkedCheckoutToPrimary(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	primary, initialLinked := setupLinkedWorktreeRepo(t)
+	runGit(t, primary, "worktree", "remove", "--force", initialLinked)
+	linked := filepath.Join(home, ".gitmoot", "worktrees", "owner--repo", "adhoc-root-prevention")
+	if err := os.MkdirAll(filepath.Dir(linked), 0o755); err != nil {
+		t.Fatalf("mkdir managed worktree parent: %v", err)
+	}
+	runGit(t, primary, "worktree", "add", "-b", "adhoc-root-prevention", linked)
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	record, err := resolveRepoRecord(ctx, store, github.Repository{Owner: "owner", Name: "repo"}, linked)
+	if err != nil {
+		t.Fatalf("resolveRepoRecord: %v", err)
+	}
+	if record.CheckoutPath != primary || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("implicit linked record = %+v, want primary %s", record, primary)
+	}
+	if err := store.UpsertRepo(ctx, record); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+	stored, err := store.GetRepo(ctx, "owner/repo")
+	if err != nil || stored.CheckoutPath != primary {
+		t.Fatalf("stored record = %+v, err=%v", stored, err)
+	}
+}

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -7844,15 +7844,11 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 	if err != nil {
 		return "", err
 	}
-	checkout := strings.TrimSpace(repoRecord.CheckoutPath)
-	if checkout == "" {
-		return "", fmt.Errorf("repo %s has no checkout path", payload.Repo)
-	}
 	repo, err := daemon.ParseRepository(payload.Repo)
 	if err != nil {
 		return "", err
 	}
-	checkout, err = w.healRegisteredRepoCheckout(ctx, job, repo, repoRecord)
+	checkout, err := w.healRegisteredRepoCheckout(ctx, job, repo, repoRecord)
 	if err != nil {
 		return "", err
 	}
@@ -7874,43 +7870,15 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 
 func (w jobWorker) healRegisteredRepoCheckout(ctx context.Context, job db.Job, repo github.Repository, record db.Repo) (string, error) {
 	checkout := strings.TrimSpace(record.CheckoutPath)
-	if _, err := os.Stat(checkout); err == nil {
-		if strings.TrimSpace(record.PrimaryCheckoutPath) == "" {
-			if primary, primaryErr := (gitutil.Client{Dir: checkout}).PrimaryWorktree(ctx); primaryErr == nil {
-				if _, healErr := w.Store.HealRepoCheckout(ctx, record.FullName(), checkout, checkout, primary); healErr != nil {
-					return "", healErr
-				}
-			}
-		}
-		return checkout, nil
-	} else if !os.IsNotExist(err) {
-		return checkout, nil
-	}
-
-	primary := strings.TrimSpace(record.PrimaryCheckoutPath)
-	if primary == "" || sameCheckoutPath(primary, checkout) {
-		return checkout, nil
-	}
-	if _, err := os.Stat(primary); err != nil {
-		return checkout, nil
-	}
-	verified, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: primary})
-	if err != nil {
-		return "", fmt.Errorf("verify primary checkout for %s: %w", repo.FullName(), err)
-	}
-	healedPath := strings.TrimSpace(verified.CheckoutPath)
-	healed, err := w.Store.HealRepoCheckout(ctx, repo.FullName(), checkout, healedPath, healedPath)
+	resolved, healed, err := resolveRegisteredRepoRecord(ctx, w.Store, repo, record)
 	if err != nil {
 		return "", err
 	}
+	healedPath := strings.TrimSpace(resolved.CheckoutPath)
 	if !healed {
-		current, err := w.Store.GetRepo(ctx, repo.FullName())
-		if err != nil {
-			return "", err
-		}
-		return strings.TrimSpace(current.CheckoutPath), nil
+		return healedPath, nil
 	}
-	message := fmt.Sprintf("repo %s checkout self-healed from %s to %s", repo.FullName(), checkout, healedPath)
+	message := repoCheckoutHealMessage(repo.FullName(), checkout, healedPath)
 	if err := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "repo_checkout_self_healed", Message: message}); err != nil {
 		return "", err
 	}
@@ -8677,24 +8645,12 @@ func resolveDaemonCheckout(ctx context.Context, repo github.Repository, client g
 
 // resolveDaemonStartRepo resolves the repo record that `daemon start/run --repo
 // owner/repo` should run against. When the repo is already registered with a
-// checkout path, it resolves against that REGISTERED checkout so the command
-// works from any working directory (#202) — origin protection is still enforced,
-// just against the registered checkout rather than the cwd. When the repo is not
-// yet registered (or has no checkout path), it bootstraps from workDir (the
-// current checkout), preserving the original behavior for first-time setup.
+// checkout path, it validates that checkout and self-heals through its recorded
+// primary when necessary, so the command works from any working directory
+// (#202/#959). When the repo is not yet registered, it bootstraps from workDir;
+// an implicit linked checkout is pinned to its primary.
 func resolveDaemonStartRepo(ctx context.Context, store *db.Store, repo github.Repository, workDir string) (db.Repo, error) {
-	existing, err := store.GetRepo(ctx, repo.FullName())
-	switch {
-	case err == nil && strings.TrimSpace(existing.CheckoutPath) != "":
-		record, rerr := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: existing.CheckoutPath})
-		if rerr != nil {
-			return db.Repo{}, fmt.Errorf("registered checkout for %s at %s is unusable (re-register with `gitmoot repo add`): %w", repo.FullName(), existing.CheckoutPath, rerr)
-		}
-		return record, nil
-	case err != nil && !errors.Is(err, sql.ErrNoRows):
-		return db.Repo{}, err
-	}
-	return repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: workDir})
+	return resolveRepoRecord(ctx, store, repo, workDir)
 }
 
 func repoRecordForCheckout(ctx context.Context, repo github.Repository, client gitutil.Client) (db.Repo, error) {

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,9 +114,31 @@ func runRepoAdd(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	record, err := repoRecordFromPath(context.Background(), repo, *path)
+	healedFrom := ""
 	if err != nil {
-		fmt.Fprintf(stderr, "repo add: %v\n", err)
-		return 1
+		requestedPath, pathErr := cleanCheckoutPath(*path)
+		if !*force || pathErr != nil {
+			fmt.Fprintf(stderr, "repo add: %v\n", err)
+			return 1
+		}
+		originalErr := err
+		if healErr := withStore(*home, func(store *db.Store) error {
+			existing, getErr := store.GetRepo(context.Background(), repo.FullName())
+			if getErr != nil {
+				return getErr
+			}
+			if !sameCheckoutPath(existing.CheckoutPath, requestedPath) {
+				return originalErr
+			}
+			healedFrom = strings.TrimSpace(existing.CheckoutPath)
+			var resolveErr error
+			record, _, resolveErr = resolveRegisteredRepoRecord(context.Background(), store, repo, existing)
+			return resolveErr
+		}); healErr != nil {
+			fmt.Fprintf(stderr, "repo add: %v\n", originalErr)
+			return 1
+		}
+		writeLine(stderr, "WARN: %s", repoCheckoutHealMessage(repo.FullName(), healedFrom, record.CheckoutPath))
 	}
 	client := gitutil.Client{Dir: record.CheckoutPath}
 	primary, err := client.PrimaryWorktree(context.Background())
@@ -334,9 +357,20 @@ func runRepoDoctor(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	var record db.Repo
+	var linked, healed bool
+	originalCheckout := ""
 	if err := withStore(*home, func(store *db.Store) error {
 		var err error
 		record, err = store.GetRepo(context.Background(), repo.FullName())
+		if err != nil {
+			return err
+		}
+		originalCheckout = strings.TrimSpace(record.CheckoutPath)
+		resolved, isLinked, wasHealed, err := inspectRegisteredRepoCheckout(context.Background(), store, record)
+		if err != nil {
+			return err
+		}
+		record, linked, healed = resolved, isLinked, wasHealed
 		return err
 	}); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -346,74 +380,135 @@ func runRepoDoctor(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "repo doctor: %v\n", err)
 		return 1
 	}
-	primary, linked, checkoutErr := inspectRegisteredRepoCheckout(context.Background(), nil, record)
-	if checkoutErr != nil {
-		writeLine(stdout, "repo: %s warn", repo.FullName())
-		writeLine(stdout, "path: %s", checkoutErr)
-		if strings.TrimSpace(record.PrimaryCheckoutPath) != "" {
-			writeLine(stdout, "primary: %s", record.PrimaryCheckoutPath)
-		}
-		return 1
-	}
-	if strings.TrimSpace(record.PrimaryCheckoutPath) == "" {
-		if err := withStore(*home, func(store *db.Store) error {
-			_, err := store.HealRepoCheckout(context.Background(), record.FullName(), record.CheckoutPath, record.CheckoutPath, primary)
-			return err
-		}); err != nil {
-			fmt.Fprintf(stderr, "repo doctor: backfill primary checkout: %v\n", err)
-			return 1
-		}
-	}
-	validated, err := repoRecordFromPath(context.Background(), repo, record.CheckoutPath)
-	if err != nil {
-		fmt.Fprintf(stderr, "repo doctor: %v\n", err)
-		return 1
+	if healed {
+		writeLine(stdout, "WARN: %s", repoCheckoutHealMessage(repo.FullName(), originalCheckout, record.CheckoutPath))
 	}
 	if linked {
 		writeLine(stdout, "repo: %s warn", repo.FullName())
-		writeLine(stdout, "path: %s is a linked worktree", validated.CheckoutPath)
-		writeLine(stdout, "primary: %s", primary)
+		writeLine(stdout, "path: %s is a linked worktree", record.CheckoutPath)
+		writeLine(stdout, "primary: %s", record.PrimaryCheckoutPath)
 		return 1
 	}
 	writeLine(stdout, "repo: %s ok", repo.FullName())
-	writeLine(stdout, "path: %s", validated.CheckoutPath)
-	writeLine(stdout, "primary: %s", primary)
-	writeLine(stdout, "remote: %s", validated.RemoteURL)
-	if validated.DefaultBranch != "" {
-		writeLine(stdout, "branch: %s", validated.DefaultBranch)
+	writeLine(stdout, "path: %s", record.CheckoutPath)
+	writeLine(stdout, "primary: %s", record.PrimaryCheckoutPath)
+	writeLine(stdout, "remote: %s", record.RemoteURL)
+	if record.DefaultBranch != "" {
+		writeLine(stdout, "branch: %s", record.DefaultBranch)
 	}
 	return 0
 }
 
-func inspectRegisteredRepoCheckout(ctx context.Context, store *db.Store, record db.Repo) (string, bool, error) {
-	checkout := strings.TrimSpace(record.CheckoutPath)
-	if checkout == "" {
-		return "", false, fmt.Errorf("registered checkout is empty")
-	}
-	if _, err := os.Stat(checkout); err != nil {
-		if os.IsNotExist(err) {
-			return "", false, fmt.Errorf("registered checkout %s is missing", checkout)
-		}
-		return "", false, fmt.Errorf("inspect registered checkout %s: %w", checkout, err)
-	}
-	client := gitutil.Client{Dir: checkout}
-	linked, err := client.IsLinkedWorktree(ctx)
+func inspectRegisteredRepoCheckout(ctx context.Context, store *db.Store, record db.Repo) (db.Repo, bool, bool, error) {
+	repo, err := daemon.ParseRepository(record.FullName())
 	if err != nil {
-		return "", false, err
+		return db.Repo{}, false, false, err
 	}
-	primary := strings.TrimSpace(record.PrimaryCheckoutPath)
-	if primary == "" {
-		primary, err = client.PrimaryWorktree(ctx)
-		if err != nil {
-			return "", false, err
-		}
-		if store != nil {
-			if _, err := store.HealRepoCheckout(ctx, record.FullName(), checkout, checkout, primary); err != nil {
-				return "", false, err
+	resolved, healed, err := resolveRegisteredRepoRecord(ctx, store, repo, record)
+	if err != nil {
+		return db.Repo{}, false, false, err
+	}
+	linked, err := (gitutil.Client{Dir: resolved.CheckoutPath}).IsLinkedWorktree(ctx)
+	if err != nil {
+		return db.Repo{}, false, false, err
+	}
+	return resolved, linked, healed, nil
+}
+
+// resolveRepoRecord prefers a registered checkout and self-heals it through the
+// stored primary before considering fallbackDir. A first-time implicit
+// registration from a linked worktree is pinned to its primary so an ephemeral
+// task worktree cannot become the repo-wide base checkout.
+func resolveRepoRecord(ctx context.Context, store *db.Store, repo github.Repository, fallbackDir string) (db.Repo, error) {
+	existing, err := store.GetRepo(ctx, repo.FullName())
+	switch {
+	case err == nil && (strings.TrimSpace(existing.CheckoutPath) != "" || strings.TrimSpace(existing.PrimaryCheckoutPath) != ""):
+		resolved, _, err := resolveRegisteredRepoRecord(ctx, store, repo, existing)
+		return resolved, err
+	case err != nil && !errors.Is(err, sql.ErrNoRows):
+		return db.Repo{}, err
+	}
+	return repoRecordFromStablePath(ctx, repo, fallbackDir)
+}
+
+func resolveRegisteredRepoRecord(ctx context.Context, store *db.Store, repo github.Repository, existing db.Repo) (db.Repo, bool, error) {
+	checkout := strings.TrimSpace(existing.CheckoutPath)
+	var checkoutErr error
+	if checkout != "" {
+		resolved, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: checkout})
+		if err == nil {
+			primary := strings.TrimSpace(existing.PrimaryCheckoutPath)
+			if primary == "" {
+				primary, err = (gitutil.Client{Dir: checkout}).PrimaryWorktree(ctx)
+				if err != nil {
+					return db.Repo{}, false, fmt.Errorf("resolve primary worktree for %s: %w", repo.FullName(), err)
+				}
+				updated, err := store.HealRepoCheckout(ctx, repo.FullName(), checkout, checkout, primary)
+				if err != nil {
+					return db.Repo{}, false, err
+				}
+				if !updated {
+					current, err := store.GetRepo(ctx, repo.FullName())
+					if err != nil {
+						return db.Repo{}, false, err
+					}
+					return resolveRegisteredRepoRecord(ctx, store, repo, current)
+				}
 			}
+			resolved.PrimaryCheckoutPath = primary
+			return preserveRegisteredRepoFields(resolved, existing), false, nil
+		}
+		checkoutErr = err
+	} else {
+		checkoutErr = errors.New("registered checkout is empty")
+	}
+
+	primary := strings.TrimSpace(existing.PrimaryCheckoutPath)
+	if primary == "" || sameCheckoutPath(primary, checkout) {
+		return db.Repo{}, false, fmt.Errorf("registered checkout %s for %s is unusable and no distinct primary checkout is available: %w", checkout, repo.FullName(), checkoutErr)
+	}
+	resolved, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: primary})
+	if err != nil {
+		return db.Repo{}, false, fmt.Errorf("registered checkout %s for %s is unusable (%v); verify primary checkout %s: %w", checkout, repo.FullName(), checkoutErr, primary, err)
+	}
+	primary, err = (gitutil.Client{Dir: resolved.CheckoutPath}).PrimaryWorktree(ctx)
+	if err != nil {
+		return db.Repo{}, false, fmt.Errorf("resolve primary worktree for %s from %s: %w", repo.FullName(), resolved.CheckoutPath, err)
+	}
+	if !sameCheckoutPath(primary, resolved.CheckoutPath) {
+		resolved, err = repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: primary})
+		if err != nil {
+			return db.Repo{}, false, fmt.Errorf("verify resolved primary checkout %s for %s: %w", primary, repo.FullName(), err)
 		}
 	}
-	return primary, linked, nil
+	resolved.PrimaryCheckoutPath = primary
+	resolved = preserveRegisteredRepoFields(resolved, existing)
+	healed, err := store.HealRepoCheckout(ctx, repo.FullName(), checkout, resolved.CheckoutPath, primary)
+	if err != nil {
+		return db.Repo{}, false, err
+	}
+	if !healed {
+		current, err := store.GetRepo(ctx, repo.FullName())
+		if err != nil {
+			return db.Repo{}, false, err
+		}
+		return resolveRegisteredRepoRecord(ctx, store, repo, current)
+	}
+	log.Printf("WARNING: %s", repoCheckoutHealMessage(repo.FullName(), checkout, resolved.CheckoutPath))
+	return resolved, true, nil
+}
+
+func preserveRegisteredRepoFields(resolved, existing db.Repo) db.Repo {
+	if strings.TrimSpace(existing.DefaultBranch) != "" {
+		resolved.DefaultBranch = existing.DefaultBranch
+	}
+	resolved.PollInterval = existing.PollInterval
+	resolved.Enabled = existing.Enabled
+	return resolved
+}
+
+func repoCheckoutHealMessage(fullName, from, to string) string {
+	return fmt.Sprintf("repo %s checkout self-healed from %s to %s", strings.TrimSpace(fullName), strings.TrimSpace(from), strings.TrimSpace(to))
 }
 
 func repoRecordFromPath(ctx context.Context, repo github.Repository, path string) (db.Repo, error) {
@@ -422,6 +517,39 @@ func repoRecordFromPath(ctx context.Context, repo github.Repository, path string
 		return db.Repo{}, err
 	}
 	return repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: checkout})
+}
+
+// repoRecordFromStablePath resolves an operator/cwd-provided checkout but pins
+// linked worktrees to their primary. Explicit linked registration is reserved
+// for repo add --force.
+func repoRecordFromStablePath(ctx context.Context, repo github.Repository, path string) (db.Repo, error) {
+	checkout, err := cleanCheckoutPath(path)
+	if err != nil {
+		return db.Repo{}, err
+	}
+	client := gitutil.Client{Dir: checkout}
+	record, err := repoRecordForCheckout(ctx, repo, client)
+	if err != nil {
+		return db.Repo{}, err
+	}
+	primary, err := client.PrimaryWorktree(ctx)
+	if err != nil {
+		return db.Repo{}, fmt.Errorf("resolve primary worktree: %w", err)
+	}
+	record.PrimaryCheckoutPath = primary
+	linked, err := client.IsLinkedWorktree(ctx)
+	if err != nil {
+		return db.Repo{}, fmt.Errorf("detect linked worktree: %w", err)
+	}
+	if !linked || sameCheckoutPath(record.CheckoutPath, primary) {
+		return record, nil
+	}
+	primaryRecord, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: primary})
+	if err != nil {
+		return db.Repo{}, fmt.Errorf("verify primary checkout: %w", err)
+	}
+	primaryRecord.PrimaryCheckoutPath = primary
+	return primaryRecord, nil
 }
 
 func cleanCheckoutPath(path string) (string, error) {

--- a/internal/cli/repo_test.go
+++ b/internal/cli/repo_test.go
@@ -253,11 +253,46 @@ func TestRunRepoDoctorReportsLinkedAndDanglingCheckout(t *testing.T) {
 	runGit(t, primary, "worktree", "remove", "--force", linked)
 	stdout.Reset()
 	stderr.Reset()
-	if code := Run([]string{"repo", "doctor", "owner/repo", "--home", home}, &stdout, &stderr); code != 1 {
-		t.Fatalf("dangling repo doctor exit code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	if code := Run([]string{"repo", "doctor", "owner/repo", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("dangling repo doctor exit code = %d, want 0; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "is missing") || !strings.Contains(stdout.String(), "primary: "+primary) {
-		t.Fatalf("dangling repo doctor output = %s", stdout.String())
+	for _, want := range []string{"checkout self-healed", "repo: owner/repo ok", "path: " + primary, "primary: " + primary} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("dangling repo doctor missing %q: %s", want, stdout.String())
+		}
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	record, err := store.GetRepo(context.Background(), "owner/repo")
+	if err != nil || record.CheckoutPath != primary || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("repaired repo = %+v, err=%v", record, err)
+	}
+}
+
+func TestRunRepoAddForceSelfHealsDanglingRecordedCheckout(t *testing.T) {
+	home := t.TempDir()
+	primary, linked := setupLinkedWorktreeRepo(t)
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"repo", "add", "owner/repo", "--home", home, "--path", linked, "--force"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial forced repo add exit code = %d, stderr=%s", code, stderr.String())
+	}
+	runGit(t, primary, "worktree", "remove", "--force", linked)
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"repo", "add", "owner/repo", "--home", home, "--path", linked, "--force"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("repairing forced repo add exit code = %d, stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "checkout self-healed") || !strings.Contains(stdout.String(), "registered owner/repo at "+primary) {
+		t.Fatalf("repair output stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	record, err := store.GetRepo(context.Background(), "owner/repo")
+	if err != nil || record.CheckoutPath != primary || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("repaired repo = %+v, err=%v", record, err)
+	}
+	if _, err := os.Stat(linked); !os.IsNotExist(err) {
+		t.Fatalf("removed linked checkout unexpectedly exists: %v", err)
 	}
 }
 
@@ -287,8 +322,12 @@ func TestRepoCheckoutDoctorChecksWarnAndLazyBackfill(t *testing.T) {
 	}
 	runGit(t, primary, "worktree", "remove", "--force", linked)
 	checks = repoCheckoutDoctorChecks(config.PathsForHome(home))
-	if len(checks) != 1 || checks[0].OK || !strings.Contains(checks[0].Detail, "is missing") || !strings.Contains(checks[0].Detail, "is available") {
+	if len(checks) != 1 || !checks[0].OK || !strings.Contains(checks[0].Detail, "checkout self-healed") {
 		t.Fatalf("dangling checks = %+v", checks)
+	}
+	record, err = store.GetRepo(context.Background(), "owner/repo")
+	if err != nil || record.CheckoutPath != primary || record.PrimaryCheckoutPath != primary {
+		t.Fatalf("repaired aggregate-doctor repo = %+v, err=%v", record, err)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -243,7 +243,8 @@ func repoCheckoutDoctorChecks(paths config.Paths) []doctor.Check {
 	}
 	checks := make([]doctor.Check, 0, len(repos))
 	for _, repo := range repos {
-		primary, linked, err := inspectRegisteredRepoCheckout(context.Background(), store, repo)
+		originalCheckout := strings.TrimSpace(repo.CheckoutPath)
+		resolved, linked, healed, err := inspectRegisteredRepoCheckout(context.Background(), store, repo)
 		check := doctor.Check{Name: "repo checkout", Required: false}
 		switch {
 		case err != nil:
@@ -255,11 +256,14 @@ func repoCheckoutDoctorChecks(paths config.Paths) []doctor.Check {
 					check.Detail += fmt.Sprintf("; primary checkout %s is unavailable", recorded)
 				}
 			}
+		case healed:
+			check.OK = true
+			check.Detail = repoCheckoutHealMessage(repo.FullName(), originalCheckout, resolved.CheckoutPath)
 		case linked:
-			check.Detail = fmt.Sprintf("%s: registered checkout %s is a linked worktree; use primary checkout %s", repo.FullName(), repo.CheckoutPath, primary)
+			check.Detail = fmt.Sprintf("%s: registered checkout %s is a linked worktree; use primary checkout %s", repo.FullName(), resolved.CheckoutPath, resolved.PrimaryCheckoutPath)
 		default:
 			check.OK = true
-			check.Detail = fmt.Sprintf("%s: registered checkout %s is primary", repo.FullName(), repo.CheckoutPath)
+			check.Detail = fmt.Sprintf("%s: registered checkout %s is primary", repo.FullName(), resolved.CheckoutPath)
 		}
 		checks = append(checks, check)
 	}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -46,7 +46,7 @@ func runSetup(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "invalid repo: %v\n", err)
 		return 2
 	}
-	record, err := repoRecordFromPath(context.Background(), repo, *path)
+	record, err := repoRecordFromStablePath(context.Background(), repo, *path)
 	if err != nil {
 		fmt.Fprintf(stderr, "setup: %v\n", err)
 		return 1

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/feedback"
-	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/skillopt"
@@ -10435,20 +10434,7 @@ func ensureSkillOptTrainGenerationRepoReady(ctx context.Context, store *db.Store
 	if err != nil {
 		return err
 	}
-	if existing, err := store.GetRepo(ctx, repo.FullName()); err == nil {
-		if strings.TrimSpace(existing.CheckoutPath) == "" {
-			return fmt.Errorf("generation repo %s has no checkout path; run `gitmoot repo add %s --path /path/to/checkout` before train continue", repo.FullName(), repo.FullName())
-		}
-		record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: existing.CheckoutPath})
-		if err != nil {
-			return fmt.Errorf("generation repo %s checkout is not ready: %w", repo.FullName(), err)
-		}
-		record.PollInterval = existing.PollInterval
-		return store.UpsertRepo(ctx, record)
-	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return err
-	}
-	record, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."})
+	record, err := resolveRepoRecord(ctx, store, repo, ".")
 	if err != nil {
 		return fmt.Errorf("generation repo %s is not registered with a checkout path; run `gitmoot repo add %s --path /path/to/checkout` before train continue: %w", repo.FullName(), repo.FullName(), err)
 	}

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -406,7 +406,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("invalid repo: %w", err)
 		}
-		repoRecord, err := repoRecordForCheckout(context.Background(), repo, gitutil.Client{Dir: "."})
+		repoRecord, err := resolveRepoRecord(context.Background(), store, repo, ".")
 		if err != nil {
 			return err
 		}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -277,7 +277,11 @@ resolved `--poll` / `[daemon].poll` cadence; an explicit `--poll` stores a
 per-repo override. `repo list` renders the sentinel as `inherit`.
 `repo set-interval owner/repo <duration>` changes an override, `default` restores
 inheritance, and `--all` applies either value to every registered repo.
-`repo doctor owner/repo` checks a single repo's checkout/config health.
+`repo doctor owner/repo` checks a single repo's checkout/config health. If the
+registered checkout is missing or is no longer a Git worktree, Gitmoot verifies
+the recorded primary checkout, repairs the registration, and reports the
+self-heal. Implicit registration from inside a linked task worktree pins the
+repo to its primary checkout; an existing valid linked checkout remains usable.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -212,7 +212,11 @@ per Gitmoot home supervises every **enabled** registered repo. Omitting
 `--poll` / `[daemon].poll` cadence; an explicit value is a per-repo override.
 `repo list` prints `inherit`. Use `repo set-interval` with a duration to change
 an override, with `default` to restore inheritance, or with `--all` to update all
-registered repos. `repo doctor owner/repo` checks checkout/config health.
+registered repos. `repo doctor owner/repo` checks checkout/config health. If the
+registered checkout is missing or is no longer a Git worktree, Gitmoot verifies
+the recorded primary checkout, repairs the registration, and reports the
+self-heal. Implicit registration from inside a linked task worktree pins the
+repo to its primary checkout; an existing valid linked checkout remains usable.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -44,7 +44,7 @@ gitmoot orchestrate lead "Review PR #123 from three independent angles." --repo 
 ```
 
 <p align="center">
-  <img src="website/static/img/dashboard/graph.png" alt="Live orchestration graph in the Gitmoot dashboard" width="94%">
+  <img src="website/static/img/dashboard/galaxy.png" alt="The delegation galaxy — every job, agent, and workflow as a live force-directed graph" width="94%">
 </p>
 
 ### Create custom agents in minutes
@@ -63,7 +63,7 @@ jobs can override it with the same flag. Gitmoot forwards the free-form value as
 
 ### Agents that evolve themselves with SkillOpt
 
-The [SkillOpt](https://github.com/jerryfane/gitmoot-skillopt) loop turns real usage into better agents: job traces feed an optimizer, candidate prompt versions run behind a canary with automatic rollback, and promotion stays a human decision. Blind A/B review, ranked exploration, and GitHub-based feedback collection are built in, so your review agent from last month keeps getting sharper without hand-tuning prompts.
+The [SkillOpt](https://github.com/gitmoot/gitmoot-skillopt) loop turns real usage into better agents: job traces feed an optimizer, candidate prompt versions run behind a canary with automatic rollback, and promotion stays a human decision. Blind A/B review, ranked exploration, and GitHub-based feedback collection are built in, so your review agent from last month keeps getting sharper without hand-tuning prompts.
 
 ### Built for unattended runs
 
@@ -73,9 +73,16 @@ Checkout, branch, and runtime-session locks; per-root token and dollar budgets; 
 
 Route work with `/gitmoot <agent> <action>` or `@agent` mentions on PRs and issues ([comment grammar](https://gitmoot.io/docs/workflows/pr-comment-workflow)). Follow it live in the PR thread, the terminal cockpit (`gitmoot dashboard`), or the [read-only web dashboard](https://gitmoot.io/docs/dashboard/overview): jobs, agents, delegation graphs, token and cost charts.
 
-<p align="center">
-  <img src="website/static/img/dashboard/jobs.png" alt="Gitmoot dashboard jobs view" width="94%">
-</p>
+<table>
+  <tr>
+    <td width="50%"><img src="website/static/img/dashboard/overview.png" alt="Overview — what needs you, live fleet activity, today's outcomes" width="100%"></td>
+    <td width="50%"><img src="website/static/img/dashboard/pipelines.png" alt="Pipelines — collapsible groups with health dots and due hints" width="100%"></td>
+  </tr>
+  <tr>
+    <td width="50%"><img src="website/static/img/dashboard/workflows.png" alt="Workflows — coordinated campaigns with lifecycle, journal notes, and token totals" width="100%"></td>
+    <td width="50%"><img src="website/static/img/dashboard/brain.png" alt="Brain — the agent memory galaxy: clusters, facts, and cross-repo links" width="100%"></td>
+  </tr>
+</table>
 
 ## How It Works
 
@@ -2236,6 +2243,9 @@ Fixes:
   worktree path on the task and routes task-tied jobs there.
 - Keep the registered checkout clean. Gitmoot still uses it for base branch
   updates and merge-gate cleanup.
+- If a removed task worktree was previously cached as the registered checkout,
+  run `gitmoot repo doctor owner/repo`. Gitmoot verifies the recorded primary
+  checkout and repairs the registration before the next job resolves its base.
 - Use separate runtime sessions, managed background instances, or forkable temp
   workers for jobs that should truly run concurrently. Worktrees isolate files;
   temp workers isolate busy Codex/Claude runtime sessions when eligible.
@@ -9507,7 +9517,11 @@ resolved `--poll` / `[daemon].poll` cadence; an explicit `--poll` stores a
 per-repo override. `repo list` renders the sentinel as `inherit`.
 `repo set-interval owner/repo <duration>` changes an override, `default` restores
 inheritance, and `--all` applies either value to every registered repo.
-`repo doctor owner/repo` checks a single repo's checkout/config health.
+`repo doctor owner/repo` checks a single repo's checkout/config health. If the
+registered checkout is missing or is no longer a Git worktree, Gitmoot verifies
+the recorded primary checkout, repairs the registration, and reports the
+self-heal. Implicit registration from inside a linked task worktree pins the
+repo to its primary checkout; an existing valid linked checkout remains usable.
 
 Use `daemon start` for the background daemon. Use `daemon run` only when the
 user explicitly wants a foreground process. Keep the default `--workers 1`


### PR DESCRIPTION
WHAT:
Implemented #959. Dangling or non-Git registered checkouts now fall back to the verified primary, atomically repair storage, and warn. Valid linked worktrees remain unchanged. No commit or push performed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-5e0c6c0e

RESULTS:
- TestRunRepoDoctorReportsLinkedAndDanglingCheckout: isolated temp-home CLI integration removes the registered worktree, runs repo doctor, and verifies primary repair.
- Added repo-add force repair, implement-base repair, non-Git path repair, valid-linked preservation, aggregate-doctor repair, and implicit task-worktree pinning tests.
- go version: go1.26.4 linux/amd64.
- go generate ./...: passed; pre/post diff hash remained 9566c71d819e8123edbc8b6e6d458e305470f1cee85b4b93dba53b4f9c17bf35.
- go build -buildvcs=false ./...: passed.
- go vet ./...: passed.
- go test -buildvcs=false ./internal/... -count=1: passed. Tail: cli 350.560s; daemon 21.433s; db 105.331s; workflow 103.721s.
- npm run build:llms and git diff --check: passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-5e0c6c0e

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented #959. Dangling or non-Git registered checkouts now fall back to the verified primary, atomically repair storage, and warn. Valid linked worktrees remain unchanged. No commit or push performed.
````
