### PR TITLE
Gitmoot: TASK: Implement gitmoot issue #913 (task dismiss +

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -295,15 +295,20 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 	if !remoteCertain {
 		return nil
 	}
+	dismissed := 0
 	for _, item := range emptyBranch {
 		reason := fmt.Sprintf("stale task auto-dismissed: empty branch; ttl=%s; updated_at=%s", ttl, item.candidate.UpdatedAt)
-		if _, _, err := d.Store.TransitionTaskStateWithEventIfNoActiveJob(ctx, item.task.ID,
+		changed, _, err := d.Store.TransitionTaskStateWithEventIfNoActiveJob(ctx, item.task.ID,
 			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
-			string(workflow.TaskDismissed), "task_dismissed_auto", reason); err != nil {
+			string(workflow.TaskDismissed), "task_dismissed_auto", reason)
+		if err != nil {
 			if errors.Is(err, db.ErrTaskHasActiveJob) {
 				continue
 			}
 			return err
+		}
+		if changed {
+			dismissed++
 		}
 	}
 	for _, item := range remoteCandidates {
@@ -312,15 +317,21 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 			continue
 		}
 		reason := fmt.Sprintf("stale task auto-dismissed: remote ref refs/heads/%s absent; ttl=%s; updated_at=%s", branch, ttl, item.candidate.UpdatedAt)
-		if _, _, err := d.Store.TransitionTaskStateWithEventIfNoActiveJob(ctx, item.task.ID,
+		changed, _, err := d.Store.TransitionTaskStateWithEventIfNoActiveJob(ctx, item.task.ID,
 			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
-			string(workflow.TaskDismissed), "task_dismissed_auto", reason); err != nil {
+			string(workflow.TaskDismissed), "task_dismissed_auto", reason)
+		if err != nil {
 			if errors.Is(err, db.ErrTaskHasActiveJob) {
 				continue
 			}
 			return err
 		}
+		if changed {
+			dismissed++
+		}
 	}
+	d.logf("stale task reconciler for %s: candidates=%d checked=%d dismissed=%d",
+		d.Repo.FullName(), len(candidates), len(emptyBranch)+len(remoteCandidates), dismissed)
 	return nil
 }
 

--- a/internal/daemon/stale_task_reconcile_test.go
+++ b/internal/daemon/stale_task_reconcile_test.go
@@ -145,6 +145,35 @@ func TestStaleTaskReconcilerRemoteErrorMutatesNothing(t *testing.T) {
 	}
 }
 
+func TestStaleTaskReconcilerLogsTickCounts(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	writeStaleTaskConfig(t, store, "1h")
+	for _, task := range []db.Task{
+		{ID: "task-empty", RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing)},
+		{ID: "task-absent", RepoFullName: repo.FullName(), State: string(workflow.TaskBlocked), Branch: "feature/absent"},
+		{ID: "task-present", RepoFullName: repo.FullName(), State: string(workflow.TaskImplementing), Branch: "feature/present"},
+	} {
+		if err := store.UpsertTask(ctx, task); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logs := []string{}
+	d := Daemon{
+		Repo: repo, Store: store, Now: futureClock,
+		RemoteBranches: &fakeRemoteBranchChecker{present: map[string]struct{}{"feature/present": {}}},
+		Logf:           func(format string, args ...any) { logs = append(logs, fmt.Sprintf(format, args...)) },
+	}
+	if err := d.reconcileStaleTasks(ctx, map[string]struct{}{}); err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) != 1 || logs[0] != "stale task reconciler for owner/repo: candidates=3 checked=3 dismissed=2" {
+		t.Fatalf("logs = %v", logs)
+	}
+}
+
 func TestStaleTaskReconcilerCapDrainAndRepeatIdempotence(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)


### PR DESCRIPTION
WHAT:
Issue #913 was already integrated on origin/main. I audited it against the frozen design and completed the one missing requirement: aggregate stale-task reconciliation counts. No design deviations; no commit or push performed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-5af1309c

RESULTS:
- TestTaskEventsMigrationAppliesToExistingDatabase, TestTransitionTaskStateWithEventAtomicCASAndOrdering, and TestGuardedTaskTransitionRefusesMatchingActiveJob cover migration, atomic event/state writes, idempotence, failed CAS, and active-job races.
- TestJobKeepsTaskLiveTable and TestJobMatchesTaskIdentityTable cover shared liveness states, advancement/cancellation markers, and both matching strategies.
- TestLoadStaleTaskTTL and TestClientRemoteBranchesBatchesExactRefs cover hot-read configuration and one exact-ref remote batch.
- TestStaleTaskReconcilerDecisions, TestStaleTaskReconcilerRemoteErrorMutatesNothing, TestStaleTaskReconcilerLogsTickCounts, TestStaleTaskReconcilerCapDrainAndRepeatIdempotence, TestStaleTaskReconcilerFiltersBeforeTickCap, TestStaleTaskReconcilerDisabledAndInvalidConfig, TestPollOnceRunsStaleTaskReconciler, and TestPollOnceForkPRBranchDoesNotProtectStaleTask cover the reconciler decision matrix, cap/drain behavior, uncertainty, ordering, logging, and PollOnce wiring.
- TestTaskDismissPredicateFailsClosed, TestRunTaskDismissAllowedStatesJSONLockAndEvents, TestRunTaskDismissRefusesOwnedStates, TestRunTaskDismissRefusesLiveJobAndWorktreeProcess, and TestRunTaskRunRejectsDismissedTask cover the CLI contract and resurrection guards.
- TestRecoverDismissedTaskWithArtifactsTransitionsThroughImplementingToPROpen, TestRecoverDismissedBranchlessTaskRestoresPlanned, TestTaskRecoverPredicateStillRejectsPullRequestOpen, TestTaskRecoverableStateIncludesDismissedWithoutWideningImplementReuse, TestRetryJobRecoversDismissedTaskAtomically, and TestRetryJobRefusalLeavesDismissedTaskUntouched cover explicit recovery and the #793 predicate boundary.
- TestEngineStartTaskBranchRejectsDismissedTask, TestEngineAllocateTaskWorktreeRejectsDismissedTask, and TestSetTaskStateCannotResurrectDismissedTask cover late implicit transition guards.
- TestDashboardTaskStateFiltersUnsupportedStates, TestListDashboardTasksExcludesDismissed, TestDashboardChangeCursor, and TestWebDataSourceChangeCursor cover board hiding and live invalidation.
- TestNoLLMShellTaskDismissAndRecoverE2E passed, proving cancel_settled through automatic dismissal, task events, explicit recovery, branch push, and pr_open without an LLM.
- Focused six-package #913 suite passed: db 0.984s, config 0.038s, git 0.016s, workflow 4.312s, daemon 2.812s, cli 3.050s.
- go generate ./... passed with unchanged diff hash 408f3a6ea903f8cdbeaf53974d38506339471a7bf0b0eb94b3a4b97f149d72e2; go build -buildvcs=false ./... and go vet ./... passed.
- go test -buildvcs=false ./internal/... -count=1 passed. Tail: cli 349.592s; daemon 20.926s; db 105.965s; workflow 102.603s. git diff --check passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-5af1309c

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Issue #913 was already integrated on origin/main. I audited it against the frozen design and completed the one missing requirement: aggregate stale-task reconciliation counts. No design deviations; no commit or push performed.
````
