### PR TITLE
Gitmoot: TASK: Implement the FIRST INCREMENT of the keycard/pipeline-secrets

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -58,6 +58,12 @@ credential and ignore the placeholder — the gateway would then `401` the
 delivery (#936). The mirror never contains a credential; the operator's real
 config is only read, never modified.
 
+Pipeline `env_file` + per-stage `env_keys` are a separate **injected** mode for
+opaque API credentials whose shell script must present the real value. Gitmoot
+scopes those values to selected shell stages and audits names only, but the
+selected process necessarily receives the real credential. Enabling or using
+this feature does not alter the Claude gateway or its placeholder flow.
+
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery
 instead of falling back to ambient auth, Claude's credential store, or direct

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -32,6 +32,9 @@ and does not affect an in-flight run.
 ```yaml
 name: nightly-sync          # required, name-safe token (letters, digits, - _)
 repo: owner/repo            # optional to register; REQUIRED to actually run
+env_file: /root/.config/nightly-sync/env # optional 0600 secret file
+env:                       # optional inline NON-secret defaults
+  OUTPUT_DIR: /srv/nightly-sync
 schedule:                   # optional; interval schedule (no cron in v1)
   interval: 24h             #   required when a schedule block is present (positive Go duration)
   jitter: 15m               #   optional random [0, jitter] added to each next_due (>= 0)
@@ -49,6 +52,7 @@ success_decisions:          # optional top-level default (see below)
 stages:                     # the DAG, keyed by unique id and wired by needs
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
+    env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
     needs: [source]         # runs only after every listed stage SUCCEEDS
@@ -67,6 +71,8 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | --------------------------- | ------------ | -------- | ----- |
 | `name`                      | pipeline     | yes      | Stable identifier and DB primary key; a name-safe token (letters, digits, `-`, `_`). |
 | `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
+| `env_file`                  | pipeline     | no       | Absolute operator-owned secret file. It must exist, be a regular file owned by the current uid with mode exactly `0600`, and live outside the Gitmoot home and every managed checkout. |
+| `env`                       | pipeline     | no       | Inline **non-secret** `KEY: value` defaults. A file value with the same key wins. Values are delivered only when a shell stage selects the key. |
 | `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
 | `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
 | `trigger.kind`              | pipeline     | cond.    | Required with `trigger:`. Only `email` is supported; it generates an owned Activepieces IMAP flow. |
@@ -94,6 +100,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
+| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from `env_file`/`env`. Shell stages only; no entry means no injected values. |
 | `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
 
 `gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
@@ -107,6 +114,41 @@ stage in `needs`, or `source` on another stage kind), an unknown/self/cyclic `ne
 timeout/interval/jitter, a negative retry, or a `success_decisions` value outside the
 allowed set — so a structural mistake surfaces as a clear error at registration
 rather than a stuck run later.
+
+### Stage-scoped environment
+
+Pipeline secrets are deny-by-default. A shell stage receives only the concrete
+names selected by its `env_keys`; a sibling with different or empty `env_keys`
+does not receive them. Agent and gate stages cannot declare `env_keys`.
+
+```yaml
+env_file: /root/.config/trend-scout/env
+env:
+  TREND_SCOUT_DATA: /srv/trend-scout # non-secret fallback
+stages:
+  - id: harvest
+    cmd: scripts/harvest.sh
+    env_keys: [REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, STACKEXCHANGE_*]
+  - id: deliver
+    cmd: scripts/deliver.sh
+    env_keys: [TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID]
+```
+
+`pipeline add` parses the file and refuses missing files/keys, insecure mode,
+wrong ownership, protected locations, malformed selectors, and any inline,
+file, or selector collision with reserved `GITMOOT_*` names. Values are loaded
+again immediately before each stage process starts, so an atomic rewrite of the
+same `0600` file rotates credentials without a daemon restart. The file value
+wins an inline default; selected values win inherited daemon environment;
+Gitmoot's own later `GITMOOT_*` entries always win.
+
+The persisted stage job payload is the audit record: it contains the env-file
+path and expanded key **names**, never secret values. Inline `env` is stored in
+the pipeline spec and is therefore for non-secrets only. An injected/opaque key
+is necessarily visible to its shell process, which can print or transmit it;
+this is scoping and audit, not a vault. The Claude model gateway is independent:
+it continues to proxy the model credential without exposing the real value to
+the child.
 
 On `pipeline add --enable`, Gitmoot publishes the owned flow. An unavailable
 Activepieces instance leaves a pending binding; run

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5387,6 +5387,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		}()
 	}
 	writeLine(w.Stdout, "running job %s for %s in %s", job.ID, agent.Name, payload.Repo)
+	adapter = wrapPipelineEnvDeliveryAdapter(w.Store, w.ConfigHome, payload, adapter)
 	engine := w.WorkflowFactory(checkout)
 	// Wire the PRE-TERMINAL operational-blocker deferrer (#532 slice E) on the LIVE
 	// worker (not the WorkflowFactory-captured copy) so it observes this worker's

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -259,6 +259,9 @@ func addPipelineCore(ctx context.Context, store *db.Store, spec pipeline.Spec, r
 	if err := validatePipelineProducePaths(ctx, store, opts.Home, spec); err != nil {
 		return false, err
 	}
+	if err := validatePipelineEnvironment(ctx, store, opts.Home, spec); err != nil {
+		return false, err
+	}
 	registered, err := store.ListPipelines(ctx)
 	if err != nil {
 		return false, err

--- a/internal/cli/pipeline_env.go
+++ b/internal/cli/pipeline_env.go
@@ -1,0 +1,231 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/pipeline"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const pipelineEnvFileMode os.FileMode = 0o600
+
+type pipelineStageEnvAccess struct {
+	File     string
+	Keys     []string
+	Defaults map[string]string
+}
+
+// validatePipelineEnvironment is the add-time #968 preflight. This first
+// increment resolves only pipeline-owned env_file and inline defaults. The
+// future named-key registry/grants phase can add another source here without
+// changing the names-only payload or delivery adapter.
+func validatePipelineEnvironment(ctx context.Context, store *db.Store, home string, spec pipeline.Spec) error {
+	sources, err := loadPipelineEnvSources(ctx, store, home, spec.EnvFile, spec.Env)
+	if err != nil {
+		return err
+	}
+	for _, stage := range spec.Stages {
+		if len(stage.EnvKeys) == 0 {
+			continue
+		}
+		if _, err := pipeline.ResolveEnvKeys(stage.EnvKeys, sources.available); err != nil {
+			return fmt.Errorf("stage %q: %w", stage.ID, err)
+		}
+	}
+	return nil
+}
+
+func resolvePipelineStageEnvAccess(ctx context.Context, store *db.Store, home string, spec pipeline.Spec, stage pipeline.Stage) (pipelineStageEnvAccess, error) {
+	if len(stage.EnvKeys) == 0 {
+		return pipelineStageEnvAccess{}, nil
+	}
+	sources, err := loadPipelineEnvSources(ctx, store, home, spec.EnvFile, spec.Env)
+	if err != nil {
+		return pipelineStageEnvAccess{}, err
+	}
+	keys, err := pipeline.ResolveEnvKeys(stage.EnvKeys, sources.available)
+	if err != nil {
+		return pipelineStageEnvAccess{}, fmt.Errorf("stage %q: %w", stage.ID, err)
+	}
+	defaults := make(map[string]string)
+	for _, key := range keys {
+		if value, ok := spec.Env[key]; ok {
+			defaults[key] = value
+		}
+	}
+	return pipelineStageEnvAccess{File: spec.EnvFile, Keys: keys, Defaults: defaults}, nil
+}
+
+type pipelineEnvSources struct {
+	available map[string]string
+}
+
+func loadPipelineEnvSources(ctx context.Context, store *db.Store, home, envFile string, inline map[string]string) (pipelineEnvSources, error) {
+	available := make(map[string]string, len(inline))
+	for name, value := range inline {
+		available[name] = value
+	}
+	if strings.TrimSpace(envFile) == "" {
+		return pipelineEnvSources{available: available}, nil
+	}
+	fileValues, err := loadValidatedPipelineEnvFile(ctx, store, home, envFile)
+	if err != nil {
+		return pipelineEnvSources{}, err
+	}
+	// The pipeline-owned file is the most-specific source and wins over inline
+	// non-secret defaults. There is no shared registry in this increment.
+	for name, value := range fileValues {
+		available[name] = value
+	}
+	return pipelineEnvSources{available: available}, nil
+}
+
+func loadValidatedPipelineEnvFile(ctx context.Context, store *db.Store, home, declared string) (map[string]string, error) {
+	declared = strings.TrimSpace(declared)
+	if !filepath.IsAbs(declared) {
+		return nil, fmt.Errorf("env_file %q must be absolute", declared)
+	}
+	file, err := os.Open(declared)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("env_file %s does not exist", declared)
+		}
+		return nil, fmt.Errorf("open env_file %s: %w", declared, err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat env_file %s: %w", declared, err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("env_file %s is not a regular file", declared)
+	}
+	if info.Mode().Perm() != pipelineEnvFileMode {
+		return nil, fmt.Errorf("env_file %s has mode %04o; want 0600", declared, info.Mode().Perm())
+	}
+	owner, err := pipelineEnvOwnerUID(info)
+	if err != nil {
+		return nil, fmt.Errorf("env_file %s: %w", declared, err)
+	}
+	if owner != pipelineEnvCurrentUID() {
+		return nil, fmt.Errorf("env_file %s is owned by uid %d; want operator uid %d", declared, owner, pipelineEnvCurrentUID())
+	}
+	if err := validatePipelineEnvFileLocation(ctx, store, home, declared); err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read env_file %s: %w", declared, err)
+	}
+	values, err := pipeline.ParseEnv(declared, data)
+	if err != nil {
+		return nil, err
+	}
+	for name := range values {
+		if pipeline.ReservedEnvName(name) {
+			return nil, fmt.Errorf("env_file %s key %q uses reserved GITMOOT_* namespace", declared, name)
+		}
+	}
+	return values, nil
+}
+
+func validatePipelineEnvFileLocation(ctx context.Context, store *db.Store, home, declared string) error {
+	if store == nil {
+		return errors.New("pipeline env_file validation requires a store")
+	}
+	resolved, err := resolveProduceSafetyPath(declared)
+	if err != nil {
+		return fmt.Errorf("resolve env_file %s: %w", declared, err)
+	}
+	gitmootHome := ""
+	if databasePath := strings.TrimSpace(store.DatabasePath()); databasePath != "" && databasePath != ":memory:" {
+		gitmootHome = filepath.Dir(databasePath)
+	} else {
+		paths, err := pathsFromFlag(home)
+		if err != nil {
+			return err
+		}
+		gitmootHome = paths.Home
+	}
+	protected := []struct{ label, path string }{{"Gitmoot home", gitmootHome}}
+	repos, err := store.ListRepos(ctx)
+	if err != nil {
+		return err
+	}
+	for _, repo := range repos {
+		label := "managed checkout " + repo.Owner + "/" + repo.Name
+		for _, checkout := range []string{repo.CheckoutPath, repo.PrimaryCheckoutPath} {
+			if strings.TrimSpace(checkout) != "" {
+				protected = append(protected, struct{ label, path string }{label, checkout})
+			}
+		}
+	}
+	for _, item := range protected {
+		protectedPath, err := resolveProduceSafetyPath(item.path)
+		if err != nil {
+			return fmt.Errorf("resolve %s %q: %w", item.label, item.path, err)
+		}
+		if pathWithin(resolved, protectedPath) {
+			return fmt.Errorf("env_file %s resolves inside %s %q", declared, item.label, protectedPath)
+		}
+	}
+	return nil
+}
+
+func pathWithin(path, directory string) bool {
+	rel, err := filepath.Rel(directory, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+type pipelineEnvDeliveryAdapter struct {
+	inner workflow.DeliveryAdapter
+	store *db.Store
+	home  string
+	file  string
+	keys  []string
+	env   map[string]string
+}
+
+func wrapPipelineEnvDeliveryAdapter(store *db.Store, home string, payload workflow.JobPayload, inner workflow.DeliveryAdapter) workflow.DeliveryAdapter {
+	if inner == nil || len(payload.PipelineEnvKeys) == 0 {
+		return inner
+	}
+	return pipelineEnvDeliveryAdapter{
+		inner: inner, store: store, home: home, file: payload.PipelineEnvFile,
+		keys: append([]string(nil), payload.PipelineEnvKeys...), env: payload.PipelineEnv,
+	}
+}
+
+func (a pipelineEnvDeliveryAdapter) Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	sources, err := loadPipelineEnvSources(ctx, a.store, a.home, a.file, a.env)
+	if err != nil {
+		return runtime.Result{}, fmt.Errorf("load pipeline stage environment: %w", err)
+	}
+	entries := make([]string, 0, len(a.keys))
+	for _, key := range a.keys {
+		value, ok := sources.available[key]
+		if !ok {
+			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: key %q is no longer available", key)
+		}
+		entries = append(entries, key+"="+value)
+	}
+	job.ShellEnv = prependPipelineEnvironment(entries, job.ShellEnv)
+	return a.inner.Deliver(ctx, agent, job)
+}
+
+// prependPipelineEnvironment puts selected values before the existing shell
+// environment. exec's last-wins behavior therefore preserves Gitmoot's own
+// GITMOOT_* metadata even for a defense-in-depth, validation-bypassing payload.
+func prependPipelineEnvironment(selected, internal []string) []string {
+	merged := make([]string, 0, len(selected)+len(internal))
+	merged = append(merged, selected...)
+	return append(merged, internal...)
+}

--- a/internal/cli/pipeline_env_owner_unix.go
+++ b/internal/cli/pipeline_env_owner_unix.go
@@ -1,0 +1,21 @@
+//go:build linux || darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+var pipelineEnvCurrentUID = func() uint32 {
+	return uint32(syscall.Geteuid())
+}
+
+func pipelineEnvOwnerUID(info os.FileInfo) (uint32, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("owner information unavailable")
+	}
+	return stat.Uid, nil
+}

--- a/internal/cli/pipeline_env_test.go
+++ b/internal/cli/pipeline_env_test.go
@@ -1,0 +1,335 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/pipeline"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const (
+	pipelineEnvSecretA = "secret-alpha-968"
+	pipelineEnvSecretB = "secret-beta-968"
+)
+
+func writePipelineEnvFile(t *testing.T, dir, body string, mode os.FileMode) string {
+	t.Helper()
+	path := filepath.Join(dir, "pipeline.env")
+	if err := os.WriteFile(path, []byte(body), mode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestPipelineAddEnvFileValidation(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, home string) (envFile, envBody, stage string)
+		want  string
+	}{
+		{
+			name: "missing file",
+			setup: func(t *testing.T, _ string) (string, string, string) {
+				return filepath.Join(t.TempDir(), "missing.env"), "", "{id: run, cmd: echo, env_keys: [TOKEN]}"
+			},
+			want: "does not exist",
+		},
+		{
+			name: "wrong mode",
+			setup: func(t *testing.T, _ string) (string, string, string) {
+				return writePipelineEnvFile(t, t.TempDir(), "TOKEN="+pipelineEnvSecretA+"\n", 0o644), "", "{id: run, cmd: echo, env_keys: [TOKEN]}"
+			},
+			want: "want 0600",
+		},
+		{
+			name: "inside Gitmoot home",
+			setup: func(t *testing.T, home string) (string, string, string) {
+				dir := filepath.Join(home, ".gitmoot", "private")
+				if err := os.MkdirAll(dir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				return writePipelineEnvFile(t, dir, "TOKEN="+pipelineEnvSecretA+"\n", 0o600), "", "{id: run, cmd: echo, env_keys: [TOKEN]}"
+			},
+			want: "inside Gitmoot home",
+		},
+		{
+			name: "inside managed checkout",
+			setup: func(t *testing.T, home string) (string, string, string) {
+				checkout := t.TempDir()
+				if err := withStore(home, func(store *db.Store) error {
+					return store.UpsertRepo(context.Background(), db.Repo{Owner: "owner", Name: "repo", CheckoutPath: checkout})
+				}); err != nil {
+					t.Fatal(err)
+				}
+				return writePipelineEnvFile(t, checkout, "TOKEN="+pipelineEnvSecretA+"\n", 0o600), "", "{id: run, cmd: echo, env_keys: [TOKEN]}"
+			},
+			want: "inside managed checkout",
+		},
+		{
+			name: "reserved file key",
+			setup: func(t *testing.T, _ string) (string, string, string) {
+				return writePipelineEnvFile(t, t.TempDir(), "GITMOOT_PIPELINE_NAME="+pipelineEnvSecretA+"\n", 0o600), "", "{id: run, cmd: echo}"
+			},
+			want: "reserved GITMOOT_*",
+		},
+		{
+			name: "absent key",
+			setup: func(t *testing.T, _ string) (string, string, string) {
+				return writePipelineEnvFile(t, t.TempDir(), "PRESENT="+pipelineEnvSecretA+"\n", 0o600), "", "{id: run, cmd: echo, env_keys: [MISSING]}"
+			},
+			want: `env_keys entry "MISSING" does not resolve`,
+		},
+		{
+			name: "agent stage denied",
+			setup: func(t *testing.T, _ string) (string, string, string) {
+				return writePipelineEnvFile(t, t.TempDir(), "TOKEN="+pipelineEnvSecretA+"\n", 0o600), "", "{id: run, agent: scout, action: ask, prompt: inspect, env_keys: [TOKEN]}"
+			},
+			want: "agent and gate stages receive no injected environment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			envFile, extra, stage := tt.setup(t, home)
+			raw := fmt.Sprintf("name: env-validation\nenv_file: %q\n%s\nstages:\n  - %s\n", envFile, extra, stage)
+			specFile := writeSpec(t, raw)
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"pipeline", "add", specFile, "--home", home}, &stdout, &stderr)
+			if code == 0 || !strings.Contains(stderr.String(), tt.want) {
+				t.Fatalf("code=%d stderr=%q, want %q", code, stderr.String(), tt.want)
+			}
+			if strings.Contains(stdout.String()+stderr.String(), pipelineEnvSecretA) {
+				t.Fatalf("validation leaked secret value: stdout=%q stderr=%q", stdout.String(), stderr.String())
+			}
+			if err := withStore(home, func(store *db.Store) error {
+				_, found, err := store.GetPipeline(context.Background(), "env-validation")
+				if err == nil && found {
+					return fmt.Errorf("invalid pipeline was persisted")
+				}
+				return err
+			}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestPipelineAddEnvFileWrongOwner(t *testing.T) {
+	home := t.TempDir()
+	envFile := writePipelineEnvFile(t, t.TempDir(), "TOKEN="+pipelineEnvSecretA+"\n", 0o600)
+	original := pipelineEnvCurrentUID
+	pipelineEnvCurrentUID = func() uint32 { return original() + 1 }
+	t.Cleanup(func() { pipelineEnvCurrentUID = original })
+	specFile := writeSpec(t, fmt.Sprintf("name: wrong-owner\nenv_file: %q\nstages: [{id: run, cmd: echo, env_keys: [TOKEN]}]\n", envFile))
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "owned by uid") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), pipelineEnvSecretA) {
+		t.Fatalf("owner error leaked secret: %q", stderr.String())
+	}
+}
+
+type pipelineEnvCaptureAdapter struct {
+	jobs []runtime.Job
+}
+
+func (a *pipelineEnvCaptureAdapter) Deliver(_ context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	a.jobs = append(a.jobs, job)
+	return runtime.Result{Raw: `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}, nil
+}
+
+func TestPipelineEnvDeliveryScopePrecedenceAndRotation(t *testing.T) {
+	home, _, store := heartbeatLoopE2EHome(t)
+	envFile := writePipelineEnvFile(t, t.TempDir(), "KEY_A="+pipelineEnvSecretA+"\nKEY_B="+pipelineEnvSecretB+"\n", 0o600)
+	spec := pipeline.Spec{EnvFile: envFile, Env: map[string]string{"DEFAULT": "inline"}}
+	stage := pipeline.Stage{ID: "a", Cmd: "echo", EnvKeys: []string{"KEY_A", "DEFAULT"}}
+	access, err := resolvePipelineStageEnvAccess(context.Background(), store, home, spec, stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(access.Keys, []string{"KEY_A", "DEFAULT"}) {
+		t.Fatalf("resolved keys = %#v", access.Keys)
+	}
+	capture := &pipelineEnvCaptureAdapter{}
+	wrapped := wrapPipelineEnvDeliveryAdapter(store, home, workflow.JobPayload{
+		PipelineEnvFile: access.File, PipelineEnvKeys: access.Keys, PipelineEnv: access.Defaults,
+	}, capture)
+	base := runtime.Job{ShellEnv: []string{"GITMOOT_PIPELINE_NAME=real"}}
+	if _, err := wrapped.Deliver(context.Background(), runtime.Agent{}, base); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.jobs[0].ShellEnv; !reflect.DeepEqual(got, []string{"KEY_A=" + pipelineEnvSecretA, "DEFAULT=inline", "GITMOOT_PIPELINE_NAME=real"}) {
+		t.Fatalf("first delivery env = %#v", got)
+	}
+	if strings.Contains(strings.Join(capture.jobs[0].ShellEnv, "\n"), "KEY_B=") {
+		t.Fatalf("sibling key leaked: %#v", capture.jobs[0].ShellEnv)
+	}
+	emptyCapture := &pipelineEnvCaptureAdapter{}
+	empty := wrapPipelineEnvDeliveryAdapter(store, home, workflow.JobPayload{}, emptyCapture)
+	if _, err := empty.Deliver(context.Background(), runtime.Agent{}, base); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(emptyCapture.jobs[0].ShellEnv, base.ShellEnv) {
+		t.Fatalf("empty env_keys changed delivery env: %#v", emptyCapture.jobs[0].ShellEnv)
+	}
+
+	if err := os.WriteFile(envFile, []byte("KEY_A=rotated-alpha-968\nKEY_B="+pipelineEnvSecretB+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapped.Deliver(context.Background(), runtime.Agent{}, base); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.jobs[1].ShellEnv[0]; got != "KEY_A=rotated-alpha-968" {
+		t.Fatalf("rotated delivery = %q", got)
+	}
+
+	reservedCapture := &pipelineEnvCaptureAdapter{}
+	reserved := wrapPipelineEnvDeliveryAdapter(store, home, workflow.JobPayload{
+		PipelineEnvKeys: []string{"GITMOOT_PIPELINE_NAME"},
+		PipelineEnv:     map[string]string{"GITMOOT_PIPELINE_NAME": "untrusted"},
+	}, reservedCapture)
+	if _, err := reserved.Deliver(context.Background(), runtime.Agent{}, base); err != nil {
+		t.Fatal(err)
+	}
+	if got := reservedCapture.jobs[0].ShellEnv; !reflect.DeepEqual(got, []string{"GITMOOT_PIPELINE_NAME=untrusted", "GITMOOT_PIPELINE_NAME=real"}) {
+		t.Fatalf("Gitmoot internal value did not win at delivery: %#v", got)
+	}
+}
+
+func TestPipelineInjectedEnvShellE2E(t *testing.T) {
+	ctx := context.Background()
+	home, paths, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	const keyA = "PIPELINE_KEY_A_968"
+	const keyB = "PIPELINE_KEY_B_968"
+	for _, key := range []string{keyA, keyB} {
+		old, existed := os.LookupEnv(key)
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if existed {
+				_ = os.Setenv(key, old)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		})
+	}
+	envFile := writePipelineEnvFile(t, t.TempDir(), keyA+"="+pipelineEnvSecretA+"\n"+keyB+"="+pipelineEnvSecretB+"\n", 0o600)
+	outA := filepath.Join(t.TempDir(), "a.txt")
+	outB := filepath.Join(t.TempDir(), "b.txt")
+	resultA := pipelineShellResultCommand(t, "approved", "stage a")
+	resultB := pipelineShellResultCommand(t, "approved", "stage b")
+	cmdA := fmt.Sprintf(`test -n "$%s"; test -z "${%s+x}"; printf 'A:%s-present,%s-absent' > %q; %s`, keyA, keyB, keyA, keyB, outA, resultA)
+	cmdB := fmt.Sprintf(`test -n "$%s"; test -z "${%s+x}"; printf 'B:%s-present,%s-absent' > %q; %s`, keyB, keyA, keyB, keyA, outB, resultB)
+	specYAML := fmt.Sprintf("name: env-e2e\nrepo: owner/repo\nenv_file: %q\nstages:\n  - id: a\n    cmd: |\n      %s\n    env_keys: [%s]\n  - id: b\n    cmd: |\n      %s\n    env_keys: [%s]\n    needs: [a]\n", envFile, cmdA, keyA, cmdB, keyB)
+	specFile := writeSpec(t, specYAML)
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline add exit=%d stderr=%s", code, errBuf.String())
+	}
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "run", "env-e2e", "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline run exit=%d stderr=%s", code, errBuf.String())
+	}
+	runID := strings.TrimSpace(out.String())
+	enqueue := newPipelineStageEnqueuer(store, home)
+	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < 8; i++ {
+		if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+			t.Fatalf("worker tick %d: %v", i, err)
+		}
+		if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+			t.Fatalf("pipeline scan %d: %v", i, err)
+		}
+		run, _, err := store.GetPipelineRun(ctx, runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run.State != pipeline.RunRunning {
+			if run.State != pipeline.RunSucceeded {
+				t.Fatalf("run state=%s halt=%s reason=%s", run.State, run.HaltStage, run.HaltReason)
+			}
+			break
+		}
+	}
+	for path, want := range map[string]string{outA: "A:" + keyA + "-present," + keyB + "-absent", outB: "B:" + keyB + "-present," + keyA + "-absent"} {
+		data, err := os.ReadFile(path)
+		if err != nil || string(data) != want {
+			t.Fatalf("output %s = %q err=%v, want %q", path, data, err, want)
+		}
+	}
+	for _, stageID := range []string{"a", "b"} {
+		stage := stageRow(t, store, runID, stageID)
+		job, err := store.GetJob(ctx, stage.JobID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload, err := workflow.ParseJobPayload(job.Payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantKey := keyA
+		if stageID == "b" {
+			wantKey = keyB
+		}
+		if !reflect.DeepEqual(payload.PipelineEnvKeys, []string{wantKey}) || payload.PipelineEnvFile != envFile {
+			t.Fatalf("stage %s audit payload = keys:%#v file:%q", stageID, payload.PipelineEnvKeys, payload.PipelineEnvFile)
+		}
+		if strings.Contains(job.Payload, pipelineEnvSecretA) || strings.Contains(job.Payload, pipelineEnvSecretB) {
+			t.Fatalf("stage %s persisted a secret value", stageID)
+		}
+		events, err := store.ListJobEvents(ctx, stage.JobID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, event := range events {
+			if strings.Contains(event.Message, pipelineEnvSecretA) || strings.Contains(event.Message, pipelineEnvSecretB) {
+				t.Fatalf("stage %s event %q persisted a secret value", stageID, event.Kind)
+			}
+		}
+	}
+	for _, path := range []string{paths.Database, paths.Database + "-wal"} {
+		data, err := os.ReadFile(path)
+		if err == nil && (bytes.Contains(data, []byte(pipelineEnvSecretA)) || bytes.Contains(data, []byte(pipelineEnvSecretB))) {
+			t.Fatalf("secret value persisted in %s", path)
+		}
+	}
+	if err := filepath.WalkDir(paths.Logs, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if bytes.Contains(data, []byte(pipelineEnvSecretA)) || bytes.Contains(data, []byte(pipelineEnvSecretB)) {
+			return fmt.Errorf("secret value persisted in log %s", path)
+		}
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -1112,6 +1112,15 @@ func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enque
 		}
 		skipNativeReviewFanout := stage.Kind() == pipeline.StageKindAgentImplement && pipelineImplementHasSourceBoundReview(spec, stage.ID)
 		request := pipelineStageJobRequest(rec, stage, run, row.Attempt, upstreamContext, binding, skipNativeReviewFanout)
+		if stage.Kind() == pipeline.StageKindShell {
+			access, envErr := resolvePipelineStageEnvAccess(ctx, store, filepath.Dir(store.DatabasePath()), spec, stage)
+			if envErr != nil {
+				return run, envErr
+			}
+			request.PipelineEnvFile = access.File
+			request.PipelineEnvKeys = access.Keys
+			request.PipelineEnv = access.Defaults
+		}
 		job, err := enqueuePipelineStageJob(ctx, store, enqueue, request, pipelineStageSourceBoundReviewRequest(request))
 		if err != nil {
 			return run, err

--- a/internal/pipeline/env.go
+++ b/internal/pipeline/env.go
@@ -1,0 +1,122 @@
+package pipeline
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var pipelineEnvNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+func ValidateEnvName(name string) error {
+	if !pipelineEnvNamePattern.MatchString(name) {
+		return fmt.Errorf("must match [A-Za-z_][A-Za-z0-9_]*")
+	}
+	return nil
+}
+
+func ReservedEnvName(name string) bool {
+	return strings.HasPrefix(name, "GITMOOT_")
+}
+
+// ValidateEnvSelector accepts an exact name or a path.Match-style glob over
+// names (for example REDDIT_*).
+func ValidateEnvSelector(selector string) error {
+	if selector == "" || strings.ContainsAny(selector, "/\\") {
+		return fmt.Errorf("must be an environment name or glob")
+	}
+	if !strings.ContainsAny(selector, "*?[") {
+		return ValidateEnvName(selector)
+	}
+	if _, err := path.Match(selector, "ENV_NAME"); err != nil {
+		return fmt.Errorf("invalid glob: %w", err)
+	}
+	for _, r := range selector {
+		if r == '*' || r == '?' || r == '[' || r == ']' || r == '-' ||
+			(r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') ||
+			(r >= '0' && r <= '9') || r == '_' {
+			continue
+		}
+		return fmt.Errorf("must be an environment name or glob")
+	}
+	return nil
+}
+
+func ReservedEnvSelector(selector string) bool {
+	if ReservedEnvName(selector) {
+		return true
+	}
+	matched, err := path.Match(selector, "GITMOOT_INTERNAL")
+	return err == nil && matched
+}
+
+// ParseEnv parses blank lines, comments, optional "export ", and one
+// KEY=VALUE assignment per line. Values are never included in errors.
+func ParseEnv(filePath string, data []byte) (map[string]string, error) {
+	values := make(map[string]string)
+	for i, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(strings.TrimSuffix(raw, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		}
+		name, value, ok := strings.Cut(line, "=")
+		name = strings.TrimSpace(name)
+		if !ok {
+			return nil, fmt.Errorf("env file %s line %d: expected KEY=VALUE", filePath, i+1)
+		}
+		if err := ValidateEnvName(name); err != nil {
+			return nil, fmt.Errorf("env file %s line %d key %q: %w", filePath, i+1, name, err)
+		}
+		if _, duplicate := values[name]; duplicate {
+			return nil, fmt.Errorf("env file %s line %d: duplicate key %q", filePath, i+1, name)
+		}
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 && ((value[0] == '\'' && value[len(value)-1] == '\'') || (value[0] == '"' && value[len(value)-1] == '"')) {
+			value = value[1 : len(value)-1]
+		}
+		if strings.ContainsRune(value, '\x00') {
+			return nil, fmt.Errorf("env file %s line %d key %q contains NUL", filePath, i+1, name)
+		}
+		values[name] = value
+	}
+	return values, nil
+}
+
+// ResolveEnvKeys expands selectors against available names. Selector order is
+// preserved, glob matches are lexical, and duplicate concrete names collapse.
+func ResolveEnvKeys(selectors []string, available map[string]string) ([]string, error) {
+	names := make([]string, 0, len(available))
+	for name := range available {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	seen := make(map[string]struct{})
+	resolved := make([]string, 0, len(selectors))
+	for _, selector := range selectors {
+		matched := false
+		for _, name := range names {
+			ok := selector == name
+			if strings.ContainsAny(selector, "*?[") {
+				ok, _ = path.Match(selector, name)
+			}
+			if !ok {
+				continue
+			}
+			matched = true
+			if _, exists := seen[name]; exists {
+				continue
+			}
+			seen[name] = struct{}{}
+			resolved = append(resolved, name)
+		}
+		if !matched {
+			return nil, fmt.Errorf("env_keys entry %q does not resolve to any declared key", selector)
+		}
+	}
+	return resolved, nil
+}

--- a/internal/pipeline/env_test.go
+++ b/internal/pipeline/env_test.go
@@ -1,0 +1,60 @@
+package pipeline
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPipelineEnvParseAndResolve(t *testing.T) {
+	values, err := ParseEnv("/tmp/pipeline.env", []byte("# comment\nexport REDDIT_ID='one'\nREDDIT_SECRET=two\nPLAIN=three\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(values, map[string]string{"REDDIT_ID": "one", "REDDIT_SECRET": "two", "PLAIN": "three"}) {
+		t.Fatalf("values = %#v", values)
+	}
+	keys, err := ResolveEnvKeys([]string{"REDDIT_*", "PLAIN", "REDDIT_ID"}, values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"REDDIT_ID", "REDDIT_SECRET", "PLAIN"}; !reflect.DeepEqual(keys, want) {
+		t.Fatalf("keys = %#v, want %#v", keys, want)
+	}
+
+	const secret = "never-print-this-value"
+	_, err = ParseEnv("/tmp/pipeline.env", []byte("BROKEN "+secret))
+	if err == nil || strings.Contains(err.Error(), secret) {
+		t.Fatalf("parse error = %v, want redacted malformed-line error", err)
+	}
+}
+
+func TestPipelineEnvSpecValidation(t *testing.T) {
+	tests := []struct {
+		name, extra, stage, want string
+	}{
+		{name: "relative file", extra: "env_file: relative.env\n", stage: "{id: run, cmd: echo}", want: "must be absolute"},
+		{name: "reserved inline", extra: "env: {GITMOOT_PIPELINE_NAME: bad}\n", stage: "{id: run, cmd: echo}", want: "reserved GITMOOT_*"},
+		{name: "reserved selector", stage: "{id: run, cmd: echo, env_keys: [GITMOOT_*]}", want: "reserved GITMOOT_*"},
+		{name: "agent denied", stage: "{id: run, agent: scout, action: ask, prompt: inspect, env_keys: [TOKEN]}", want: "agent and gate stages receive no injected environment"},
+		{name: "valid shell", extra: "env_file: /tmp/pipeline.env\nenv: {DATA_DIR: /tmp/data}\n", stage: "{id: run, cmd: echo, env_keys: [API_*, DATA_DIR]}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := "name: env-flow\n" + tt.extra + "stages:\n  - " + tt.stage + "\n"
+			spec, err := Load([]byte(raw))
+			if tt.want != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.want) {
+					t.Fatalf("Load error = %v, want %q", err, tt.want)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if spec.EnvFile != "/tmp/pipeline.env" || spec.Env["DATA_DIR"] != "/tmp/data" || !reflect.DeepEqual(spec.Stages[0].EnvKeys, []string{"API_*", "DATA_DIR"}) {
+				t.Fatalf("parsed spec = %+v", spec)
+			}
+		})
+	}
+}

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -74,6 +74,12 @@ type Spec struct {
 	// Description is optional display metadata explaining a pipeline's purpose.
 	// It is shown verbatim on detail surfaces and has no execution semantics.
 	Description string `yaml:"description,omitempty"`
+	// EnvFile is an optional operator-owned 0600 file containing secret
+	// KEY=VALUE entries. Shell stages opt into individual names through EnvKeys.
+	EnvFile string `yaml:"env_file,omitempty"`
+	// Env contains non-secret defaults. Entries are delivered only when a shell
+	// stage explicitly names them in EnvKeys.
+	Env map[string]string `yaml:"env,omitempty"`
 	// Schedule, when present, drives interval-based auto-runs (heartbeat idiom: an
 	// interval plus optional jitter; no cron in v1).
 	Schedule *Schedule `yaml:"schedule,omitempty"`
@@ -179,6 +185,9 @@ type Stage struct {
 	Timeout string `yaml:"timeout,omitempty"`
 	// Retry is how many times a failed stage may be re-attempted (>= 0).
 	Retry int `yaml:"retry,omitempty"`
+	// EnvKeys is the deny-by-default list of environment names (or glob selectors)
+	// made available to this shell stage. Agent and gate stages may not request it.
+	EnvKeys []string `yaml:"env_keys,omitempty"`
 	// SuccessDecisions optionally overrides the pipeline default for this stage.
 	SuccessDecisions []string `yaml:"success_decisions,omitempty"`
 	// Orchestrate, when true on an agent stage, promotes the stage from a read-only

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -32,6 +32,7 @@ func (s *Spec) normalize() {
 	s.Repo = strings.TrimSpace(s.Repo)
 	s.Group = strings.TrimSpace(s.Group)
 	s.Description = strings.TrimSpace(s.Description)
+	s.EnvFile = strings.TrimSpace(s.EnvFile)
 	if s.Schedule != nil {
 		s.Schedule.Interval = strings.TrimSpace(s.Schedule.Interval)
 		s.Schedule.Jitter = strings.TrimSpace(s.Schedule.Jitter)
@@ -64,6 +65,7 @@ func (s *Spec) normalize() {
 		s.Stages[i].Check = strings.TrimSpace(s.Stages[i].Check)
 		s.Stages[i].Writes = trimAll(s.Stages[i].Writes)
 		s.Stages[i].Needs = trimAll(s.Stages[i].Needs)
+		s.Stages[i].EnvKeys = trimAll(s.Stages[i].EnvKeys)
 		s.Stages[i].SuccessDecisions = trimAll(s.Stages[i].SuccessDecisions)
 		// An agent stage defaults to the read-only "ask" verb when action is unset.
 		// A shell stage never carries an action, so this only touches agent stages.
@@ -106,6 +108,20 @@ func (s Spec) Validate() error {
 			return fmt.Errorf("pipeline %q description must not contain control characters other than newline", s.Name)
 		}
 	}
+	if s.EnvFile != "" && !filepath.IsAbs(s.EnvFile) {
+		return fmt.Errorf("pipeline %q env_file %q must be absolute", s.Name, s.EnvFile)
+	}
+	for name, value := range s.Env {
+		if err := ValidateEnvName(name); err != nil {
+			return fmt.Errorf("pipeline %q env key %q: %w", s.Name, name, err)
+		}
+		if ReservedEnvName(name) {
+			return fmt.Errorf("pipeline %q env key %q uses reserved GITMOOT_* namespace", s.Name, name)
+		}
+		if strings.ContainsRune(value, '\x00') {
+			return fmt.Errorf("pipeline %q env key %q contains NUL", s.Name, name)
+		}
+	}
 	if len(s.Stages) == 0 {
 		return fmt.Errorf("pipeline %q has no stages", s.Name)
 	}
@@ -137,6 +153,17 @@ func (s Spec) Validate() error {
 	for _, stage := range s.Stages {
 		if err := validateStageExecutor(s.Name, stage); err != nil {
 			return err
+		}
+		if len(stage.EnvKeys) > 0 && stage.Kind() != StageKindShell {
+			return fmt.Errorf("pipeline %q stage %q sets env_keys but is not a shell stage; agent and gate stages receive no injected environment", s.Name, stage.ID)
+		}
+		for _, selector := range stage.EnvKeys {
+			if err := ValidateEnvSelector(selector); err != nil {
+				return fmt.Errorf("pipeline %q stage %q env_keys entry %q: %w", s.Name, stage.ID, selector, err)
+			}
+			if ReservedEnvSelector(selector) {
+				return fmt.Errorf("pipeline %q stage %q env_keys entry %q uses reserved GITMOOT_* namespace", s.Name, stage.ID, selector)
+			}
 		}
 		// #768 mutating-implement safety model (spec double-key + scheduled-write gate).
 		// Kept out of validateStageExecutor because it spans stage AND spec context (the

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -189,6 +189,14 @@ type JobRequest struct {
 	// KEY=value entries to a shell runtime job. It is empty for every non-pipeline
 	// and non-shell job.
 	ShellEnv []string
+	// PipelineEnvFile and PipelineEnvKeys are the names-only #968 injected-env
+	// authority for a pipeline shell stage. PipelineEnv contains only selected
+	// inline NON-secret defaults; secret values are loaded at delivery and never
+	// enter the persisted payload. A future keycard registry/grant resolver can
+	// feed this same delivery seam without changing the shell adapter.
+	PipelineEnvFile string
+	PipelineEnvKeys []string
+	PipelineEnv     map[string]string
 	// ShellUpstreamContext carries the persisted JSON CONTENT supplied to a
 	// dependent pipeline shell stage. Delivery writes it to a fresh temporary
 	// file; paths are deliberately never persisted. Additive/omitempty: empty
@@ -271,34 +279,37 @@ type JobPayload struct {
 	// without it serializes byte-identically. The terminal cleanup keys off it to
 	// dispose top-level read-only worktrees that the DelegationID-gated read-only
 	// delegation cleanup would otherwise orphan.
-	ReadOnlyWorktree       bool           `json:"read_only_worktree,omitempty"`
-	TemplateID             string         `json:"template_id,omitempty"`
-	TemplateResolvedCommit string         `json:"template_resolved_commit,omitempty"`
-	TemplateContent        string         `json:"template_content,omitempty"`
-	OriginalAgent          string         `json:"original_agent,omitempty"`
-	DelegatedAgent         string         `json:"delegated_agent,omitempty"`
-	DelegationReason       string         `json:"delegation_reason,omitempty"`
-	RecentDelegationHashes []string       `json:"recent_delegation_hashes,omitempty"`
-	DelegationRepeatCount  int            `json:"delegation_repeat_count,omitempty"`
-	NonProgressStreak      int            `json:"non_progress_streak,omitempty"`
-	LastProgressDigest     string         `json:"last_progress_digest,omitempty"`
-	VerifyAttempt          int            `json:"verify_attempt,omitempty"`
-	DelegationFinalize     bool           `json:"delegation_finalize,omitempty"`
-	Model                  string         `json:"model,omitempty"`
-	Effort                 string         `json:"effort,omitempty"`
-	WorkflowID             string         `json:"workflow_id,omitempty"`
-	RuntimeOverride        string         `json:"runtime_override,omitempty"`
-	RuntimeOverrideRef     string         `json:"runtime_override_ref,omitempty"`
-	ShellEnv               []string       `json:"shell_env,omitempty"`
-	ShellUpstreamContext   string         `json:"shell_upstream_context,omitempty"`
-	Phase                  string         `json:"phase,omitempty"`
-	Cockpit                bool           `json:"cockpit,omitempty"`
-	CockpitSession         string         `json:"cockpit_session,omitempty"`
-	CockpitPaneKey         string         `json:"cockpit_pane_key,omitempty"`
-	SkipNativeReviewFanout bool           `json:"skip_native_review_fanout,omitempty"`
-	ValidatedPullRequest   bool           `json:"validated_pull_request,omitempty"`
-	Ephemeral              *EphemeralSpec `json:"ephemeral,omitempty"`
-	HumanAnswer            string         `json:"human_answer,omitempty"`
+	ReadOnlyWorktree       bool              `json:"read_only_worktree,omitempty"`
+	TemplateID             string            `json:"template_id,omitempty"`
+	TemplateResolvedCommit string            `json:"template_resolved_commit,omitempty"`
+	TemplateContent        string            `json:"template_content,omitempty"`
+	OriginalAgent          string            `json:"original_agent,omitempty"`
+	DelegatedAgent         string            `json:"delegated_agent,omitempty"`
+	DelegationReason       string            `json:"delegation_reason,omitempty"`
+	RecentDelegationHashes []string          `json:"recent_delegation_hashes,omitempty"`
+	DelegationRepeatCount  int               `json:"delegation_repeat_count,omitempty"`
+	NonProgressStreak      int               `json:"non_progress_streak,omitempty"`
+	LastProgressDigest     string            `json:"last_progress_digest,omitempty"`
+	VerifyAttempt          int               `json:"verify_attempt,omitempty"`
+	DelegationFinalize     bool              `json:"delegation_finalize,omitempty"`
+	Model                  string            `json:"model,omitempty"`
+	Effort                 string            `json:"effort,omitempty"`
+	WorkflowID             string            `json:"workflow_id,omitempty"`
+	RuntimeOverride        string            `json:"runtime_override,omitempty"`
+	RuntimeOverrideRef     string            `json:"runtime_override_ref,omitempty"`
+	ShellEnv               []string          `json:"shell_env,omitempty"`
+	PipelineEnvFile        string            `json:"pipeline_env_file,omitempty"`
+	PipelineEnvKeys        []string          `json:"pipeline_env_keys,omitempty"`
+	PipelineEnv            map[string]string `json:"pipeline_env,omitempty"`
+	ShellUpstreamContext   string            `json:"shell_upstream_context,omitempty"`
+	Phase                  string            `json:"phase,omitempty"`
+	Cockpit                bool              `json:"cockpit,omitempty"`
+	CockpitSession         string            `json:"cockpit_session,omitempty"`
+	CockpitPaneKey         string            `json:"cockpit_pane_key,omitempty"`
+	SkipNativeReviewFanout bool              `json:"skip_native_review_fanout,omitempty"`
+	ValidatedPullRequest   bool              `json:"validated_pull_request,omitempty"`
+	Ephemeral              *EphemeralSpec    `json:"ephemeral,omitempty"`
+	HumanAnswer            string            `json:"human_answer,omitempty"`
 	// ThreadID / ChatMessageID back-link a chat-promoted job (#534) to its origin
 	// message. Additive/omitempty: a non-chat job serializes byte-identically.
 	ThreadID      string `json:"thread_id,omitempty"`
@@ -435,6 +446,9 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		RuntimeOverride:        strings.TrimSpace(request.RuntimeOverride),
 		RuntimeOverrideRef:     strings.TrimSpace(request.RuntimeOverrideRef),
 		ShellEnv:               append([]string(nil), request.ShellEnv...),
+		PipelineEnvFile:        strings.TrimSpace(request.PipelineEnvFile),
+		PipelineEnvKeys:        compactStrings(request.PipelineEnvKeys),
+		PipelineEnv:            request.PipelineEnv,
 		ShellUpstreamContext:   request.ShellUpstreamContext,
 		Phase:                  request.Phase,
 		Cockpit:                request.Cockpit,

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2547,6 +2547,9 @@ Define a pipeline in a YAML file and register it:
 ```yaml
 name: nightly-sync          # required, name-safe token (letters, digits, - _)
 repo: owner/repo            # optional to register; REQUIRED to run
+env_file: /root/.config/nightly-sync/env # optional 0600 secret file
+env:                         # optional inline NON-secret defaults
+  OUTPUT_DIR: /srv/nightly-sync
 schedule:                   # optional interval schedule (no cron in v1)
   interval: 24h             #   positive Go duration (required with a schedule block)
   jitter: 15m               #   optional random [0, jitter] added to next_due
@@ -2560,6 +2563,7 @@ trigger:                    # optional event source (email or pipeline)
 stages:                     # the DAG, keyed by unique id and wired by needs
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
+    env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
     needs: [source]         # runs only after every listed stage SUCCEEDS
@@ -2768,6 +2772,20 @@ runs a named managed agent on its own runtime as a read-only leaf (`ask`/`review
 its `needs` stages' result summaries are prepended to the prompt, and a repo-bound
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
+
+Shell stages can opt into pipeline-owned environment values with `env_keys`.
+`env_file` must be an absolute, operator-owned regular file with mode exactly
+`0600`, outside the Gitmoot home and every managed checkout; inline `env` is for
+non-secret defaults. Exact names and globs such as `REDDIT_*` are expanded at
+enqueue, and every selector must resolve. Agent/gate stages cannot set
+`env_keys`; a shell stage with no list gets nothing. The file is read again at
+delivery, so rotation applies without a daemon restart. File values beat inline
+defaults, selected values beat inherited daemon environment, and reserved
+`GITMOOT_*` names are rejected while Gitmoot's internal entries remain final.
+The job payload audits only the env-file path and expanded key names, never file
+values. This injected mode exposes an opaque key to that shell process; it is
+separate from the Claude model gateway, whose proxied credential remains hidden
+from the child.
 
 For a non-empty run payload, every agent stage (including roots) receives a
 dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -172,9 +172,15 @@ The spec is stored **verbatim** (the raw YAML bytes plus a content hash), so a s
 that embeds private hostnames, filesystem paths, tokens-by-reference, or repo names
 is retained in the local store as-is — the same private-repo caveat as a captured
 agent template or a published template. Do not register a spec carrying a secret in
-a stage command; provision the secret out of band and have the stage read it from
-the environment, and let the stage return `blocked` (with its `needs`) until the
-secret is present rather than baking it into the DAG.
+a stage command or inline `env`. Use an operator-owned `0600` `env_file` plus the
+shell stage's `env_keys` allowlist instead.
+
+Pipeline `env_file` injection (#968) is deny-by-default but deliberately
+**opaque**: only a shell stage's selected `env_keys` are injected, yet that
+process receives the real values and can print or transmit them. Gitmoot stores
+only the file path and expanded names in the job audit. This is distinct from
+the Claude keycard/model gateway, where the child receives a placeholder and the
+real model credential stays daemon-side.
 
 ## External Contracts
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1070,12 +1070,16 @@ repo: owner/repo            # required to run (stages need a managed repo)
 group: Release Automation   # optional display section (falls back to repo when unset;
                             #   built-in memory pipelines ship under "Gitmoot System")
 description: Syncs nightly data for deployment. # optional detail-page purpose (multiline, max 500 chars)
+env_file: /root/.config/nightly-sync/env # optional 0600 secret file
+env:                         # optional inline NON-secret defaults
+  OUTPUT_DIR: /srv/nightly-sync
 schedule:                   # optional; auto-runs every interval once enabled
   interval: 24h
   jitter: 15m
 stages:
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
+    env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
     needs: [source]         # runs only after source SUCCEEDS
@@ -1090,6 +1094,14 @@ gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; --enable t
 RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
 gitmoot pipeline show "$RUN"                       # watch the text funnel
 ```
+
+`env_keys` is a shell-stage-only allowlist of exact names or globs resolved from
+the pipeline's `env_file` and inline non-secret `env`. No list means no injected
+values, and agent stages cannot request them. `pipeline add` requires the file
+to be absolute, operator-owned `0600`, and outside Gitmoot state/checkouts; it
+also refuses missing keys and reserved `GITMOOT_*` names. Values are read fresh
+at stage delivery for restart-free rotation. The job audit stores the path and
+expanded names only, not file values.
 
 ### Share a pipeline with another Gitmoot home
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1879,6 +1879,9 @@ Define a pipeline in a YAML file, then register and run it:
 ```yaml
 name: nightly-sync          # required, name-safe token (letters, digits, - _)
 repo: owner/repo            # optional to register; REQUIRED to run
+env_file: /root/.config/nightly-sync/env # optional operator-owned 0600 secret file
+env:                         # optional inline NON-secret defaults
+  OUTPUT_DIR: /srv/nightly-sync
 schedule:                   # optional interval schedule (no cron in v1)
   interval: 24h
   jitter: 15m
@@ -1892,6 +1895,7 @@ trigger:                    # optional generated Activepieces event source
 stages:                     # the DAG, keyed by unique id and wired by needs
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
+    env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
     needs: [source]         # runs only after source SUCCEEDS
@@ -1944,6 +1948,13 @@ coordinator that fans out owned children and folds the synthesis); and **gate** 
 implement stage's PR merges). A read-only stage's `needs` result summaries are prepended
 to its prompt, and a repo-bound read-only agent stage runs in its own detached
 read-only worktree so same-repo stages parallelize without touching the live checkout.
+For shell-stage API credentials, set an absolute pipeline `env_file` and list
+exact names or globs in each stage's `env_keys`. The file must be a regular,
+operator-owned `0600` file outside Gitmoot state and managed checkouts; inline
+`env` is for non-secret defaults. Missing/reserved keys and `env_keys` on an
+agent/gate stage are rejected at add time. A stage with no list receives no
+injected values. Values are read fresh at delivery for restart-free rotation;
+the job payload stores only the path and expanded names, never file values.
 Every agent stage receives a non-empty trigger payload as bounded, dynamically
 fenced `UNTRUSTED external data`; shell stages receive exact
 `GITMOOT_TRIGGER_<UPPERCASE_KEY>` environment entries. The full payload is retained

--- a/website/docs/reference/credentials.md
+++ b/website/docs/reference/credentials.md
@@ -58,6 +58,12 @@ credential and ignore the placeholder — the gateway would then `401` the
 delivery (#936). The mirror never contains a credential; the operator's real
 config is only read, never modified.
 
+Pipeline `env_file` + per-stage `env_keys` are a separate **injected** mode for
+opaque API credentials whose shell script must present the real value. Gitmoot
+scopes those values to selected shell stages and audits names only, but the
+selected process necessarily receives the real credential. Enabling or using
+this feature does not alter the Claude gateway or its placeholder flow.
+
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery
 instead of falling back to ambient auth, Claude's credential store, or direct

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -30,6 +30,9 @@ group: Release Automation   # optional display section on /pipelines and `pipeli
                             #   one repo may split across groups); unset falls back to repo.
                             #   Built-in memory pipelines ship under "Gitmoot System".
 description: Syncs nightly data for deployment. # optional detail-page purpose (multiline, max 500 chars)
+env_file: /root/.config/nightly-sync/env # optional operator-owned 0600 secret file
+env:                         # optional inline NON-secret defaults
+  OUTPUT_DIR: /srv/nightly-sync
 schedule:                   # optional; auto-runs every interval once enabled
   interval: 24h             #   positive Go duration (required with a schedule block)
   jitter: 15m               #   optional random [0, jitter] added to each next_due
@@ -43,6 +46,7 @@ trigger:                    # optional event source (requires repo:)
 stages:                     # the DAG, keyed by unique id and wired by needs
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
+    env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
     needs: [source]         # runs only after source SUCCEEDS
@@ -77,6 +81,38 @@ name/id, a duplicate stage id, a stage that is not exactly one of `cmd`, `agent`
 structural mistake is a clear error at registration, not a stuck run later. It stores the raw YAML **verbatim**
 plus a content hash; each run snapshots the hash and executes its snapshot, so
 editing the file later never mutates an in-flight run.
+
+### Give each shell stage only the keys it needs
+
+Declare secrets in a pipeline-owned file and select them per shell stage:
+
+```yaml
+env_file: /root/.config/trend-scout/env
+env:
+  TREND_SCOUT_DATA: /srv/trend-scout # non-secret fallback
+stages:
+  - id: harvest
+    cmd: scripts/harvest.sh
+    env_keys: [REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, STACKEXCHANGE_*]
+  - id: deliver
+    cmd: scripts/deliver.sh
+    env_keys: [TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID]
+```
+
+No `env_keys` means no injected values. Exact names and globs expand only for
+shell stages; agent and gate stages cannot request them. At registration,
+Gitmoot requires the absolute `env_file` to be operator-owned, mode exactly
+`0600`, and outside its home and managed checkouts. Missing keys, malformed
+files, and reserved `GITMOOT_*` names fail `pipeline add` without printing
+values.
+
+Gitmoot reads the file again immediately before each stage process starts, so
+rotation needs no daemon restart. File values beat inline non-secret defaults,
+selected values beat inherited daemon environment, and Gitmoot's internal
+`GITMOOT_*` entries remain final. The stage job payload audits the file path and
+expanded key names only; file values never enter SQLite. The selected shell can
+still read an injected key. This is separate from the Claude model gateway,
+which keeps its proxied real credential out of the child.
 
 ### Chain pipelines on success
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2745,6 +2745,9 @@ and does not affect an in-flight run.
 ```yaml
 name: nightly-sync          # required, name-safe token (letters, digits, - _)
 repo: owner/repo            # optional to register; REQUIRED to actually run
+env_file: /root/.config/nightly-sync/env # optional 0600 secret file
+env:                       # optional inline NON-secret defaults
+  OUTPUT_DIR: /srv/nightly-sync
 schedule:                   # optional; interval schedule (no cron in v1)
   interval: 24h             #   required when a schedule block is present (positive Go duration)
   jitter: 15m               #   optional random [0, jitter] added to each next_due (>= 0)
@@ -2762,6 +2765,7 @@ success_decisions:          # optional top-level default (see below)
 stages:                     # the DAG, keyed by unique id and wired by needs
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
+    env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
     needs: [source]         # runs only after every listed stage SUCCEEDS
@@ -2780,6 +2784,8 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | --------------------------- | ------------ | -------- | ----- |
 | `name`                      | pipeline     | yes      | Stable identifier and DB primary key; a name-safe token (letters, digits, `-`, `_`). |
 | `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
+| `env_file`                  | pipeline     | no       | Absolute operator-owned secret file. It must exist, be a regular file owned by the current uid with mode exactly `0600`, and live outside the Gitmoot home and every managed checkout. |
+| `env`                       | pipeline     | no       | Inline **non-secret** `KEY: value` defaults. A file value with the same key wins. Values are delivered only when a shell stage selects the key. |
 | `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
 | `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
 | `trigger.kind`              | pipeline     | cond.    | Required with `trigger:`. Only `email` is supported; it generates an owned Activepieces IMAP flow. |
@@ -2807,6 +2813,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
+| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from `env_file`/`env`. Shell stages only; no entry means no injected values. |
 | `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
 
 `gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
@@ -2820,6 +2827,41 @@ stage in `needs`, or `source` on another stage kind), an unknown/self/cyclic `ne
 timeout/interval/jitter, a negative retry, or a `success_decisions` value outside the
 allowed set — so a structural mistake surfaces as a clear error at registration
 rather than a stuck run later.
+
+### Stage-scoped environment
+
+Pipeline secrets are deny-by-default. A shell stage receives only the concrete
+names selected by its `env_keys`; a sibling with different or empty `env_keys`
+does not receive them. Agent and gate stages cannot declare `env_keys`.
+
+```yaml
+env_file: /root/.config/trend-scout/env
+env:
+  TREND_SCOUT_DATA: /srv/trend-scout # non-secret fallback
+stages:
+  - id: harvest
+    cmd: scripts/harvest.sh
+    env_keys: [REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, STACKEXCHANGE_*]
+  - id: deliver
+    cmd: scripts/deliver.sh
+    env_keys: [TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID]
+```
+
+`pipeline add` parses the file and refuses missing files/keys, insecure mode,
+wrong ownership, protected locations, malformed selectors, and any inline,
+file, or selector collision with reserved `GITMOOT_*` names. Values are loaded
+again immediately before each stage process starts, so an atomic rewrite of the
+same `0600` file rotates credentials without a daemon restart. The file value
+wins an inline default; selected values win inherited daemon environment;
+Gitmoot's own later `GITMOOT_*` entries always win.
+
+The persisted stage job payload is the audit record: it contains the env-file
+path and expanded key **names**, never secret values. Inline `env` is stored in
+the pipeline spec and is therefore for non-secrets only. An injected/opaque key
+is necessarily visible to its shell process, which can print or transmit it;
+this is scoping and audit, not a vault. The Claude model gateway is independent:
+it continues to proxy the model credential without exposing the real value to
+the child.
 
 On `pipeline add --enable`, Gitmoot publishes the owned flow. An unavailable
 Activepieces instance leaves a pending binding; run
@@ -11787,6 +11829,9 @@ Define a pipeline in a YAML file and register it:
 ```yaml
 name: nightly-sync          # required, name-safe token (letters, digits, - _)
 repo: owner/repo            # optional to register; REQUIRED to run
+env_file: /root/.config/nightly-sync/env # optional 0600 secret file
+env:                         # optional inline NON-secret defaults
+  OUTPUT_DIR: /srv/nightly-sync
 schedule:                   # optional interval schedule (no cron in v1)
   interval: 24h             #   positive Go duration (required with a schedule block)
   jitter: 15m               #   optional random [0, jitter] added to next_due
@@ -11800,6 +11845,7 @@ trigger:                    # optional event source (email or pipeline)
 stages:                     # the DAG, keyed by unique id and wired by needs
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
+    env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
     needs: [source]         # runs only after every listed stage SUCCEEDS
@@ -12008,6 +12054,20 @@ runs a named managed agent on its own runtime as a read-only leaf (`ask`/`review
 its `needs` stages' result summaries are prepended to the prompt, and a repo-bound
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
+
+Shell stages can opt into pipeline-owned environment values with `env_keys`.
+`env_file` must be an absolute, operator-owned regular file with mode exactly
+`0600`, outside the Gitmoot home and every managed checkout; inline `env` is for
+non-secret defaults. Exact names and globs such as `REDDIT_*` are expanded at
+enqueue, and every selector must resolve. Agent/gate stages cannot set
+`env_keys`; a shell stage with no list gets nothing. The file is read again at
+delivery, so rotation applies without a daemon restart. File values beat inline
+defaults, selected values beat inherited daemon environment, and reserved
+`GITMOOT_*` names are rejected while Gitmoot's internal entries remain final.
+The job payload audits only the env-file path and expanded key names, never file
+values. This injected mode exposes an opaque key to that shell process; it is
+separate from the Claude model gateway, whose proxied credential remains hidden
+from the child.
 
 For a non-empty run payload, every agent stage (including roots) receives a
 dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before
@@ -13470,12 +13530,16 @@ repo: owner/repo            # required to run (stages need a managed repo)
 group: Release Automation   # optional display section (falls back to repo when unset;
                             #   built-in memory pipelines ship under "Gitmoot System")
 description: Syncs nightly data for deployment. # optional detail-page purpose (multiline, max 500 chars)
+env_file: /root/.config/nightly-sync/env # optional 0600 secret file
+env:                         # optional inline NON-secret defaults
+  OUTPUT_DIR: /srv/nightly-sync
 schedule:                   # optional; auto-runs every interval once enabled
   interval: 24h
   jitter: 15m
 stages:
   - id: source
     cmd: "curl -sf https://example.com/data > data.json"
+    env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
     needs: [source]         # runs only after source SUCCEEDS
@@ -13490,6 +13554,14 @@ gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; --enable t
 RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
 gitmoot pipeline show "$RUN"                       # watch the text funnel
 ```
+
+`env_keys` is a shell-stage-only allowlist of exact names or globs resolved from
+the pipeline's `env_file` and inline non-secret `env`. No list means no injected
+values, and agent stages cannot request them. `pipeline add` requires the file
+to be absolute, operator-owned `0600`, and outside Gitmoot state/checkouts; it
+also refuses missing keys and reserved `GITMOOT_*` names. Values are read fresh
+at stage delivery for restart-free rotation. The job audit stores the path and
+expanded names only, not file values.
 
 ### Share a pipeline with another Gitmoot home
 
@@ -14117,9 +14189,15 @@ The spec is stored **verbatim** (the raw YAML bytes plus a content hash), so a s
 that embeds private hostnames, filesystem paths, tokens-by-reference, or repo names
 is retained in the local store as-is — the same private-repo caveat as a captured
 agent template or a published template. Do not register a spec carrying a secret in
-a stage command; provision the secret out of band and have the stage read it from
-the environment, and let the stage return `blocked` (with its `needs`) until the
-secret is present rather than baking it into the DAG.
+a stage command or inline `env`. Use an operator-owned `0600` `env_file` plus the
+shell stage's `env_keys` allowlist instead.
+
+Pipeline `env_file` injection (#968) is deny-by-default but deliberately
+**opaque**: only a shell stage's selected `env_keys` are injected, yet that
+process receives the real values and can print or transmit them. Gitmoot stores
+only the file path and expanded names in the job audit. This is distinct from
+the Claude keycard/model gateway, where the child receives a placeholder and the
+real model credential stays daemon-side.
 
 ## External Contracts
 


### PR DESCRIPTION
WHAT:
Implemented the first #968/#874 increment: pipeline-owned injected environment values with deny-by-default stage grants. No design deviations. Shared registry/grants and generalized proxied delivery remain explicitly deferred; the existing Anthropic credgw behavior is unchanged. No commit or push performed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-c529f05b

RESULTS:
- `go version`: go1.26.4 linux/amd64.
- `TestPipelineEnvParseAndResolve`: env parsing, deterministic glob expansion, missing selectors, and value-safe errors.
- `TestPipelineEnvSpecValidation`: invalid/reserved selectors and non-shell `env_keys` rejection.
- `TestPipelineAddEnvFileValidation` and `TestPipelineAddEnvFileWrongOwner`: all required add-time refusal cases, no persistence, and no value leakage.
- `TestPipelineEnvDeliveryScopePrecedenceAndRotation`: per-stage selection, empty-stage isolation, inline defaults, rotation without restart, and `GITMOOT_*` precedence.
- `TestPipelineInjectedEnvShellE2E`: isolated-home two-stage shell pipeline; each stage received only its granted key, while payloads, events, SQLite/WAL, and logs contained no secret values.
- `go generate ./...`: passed with no unexpected generated changes.
- `go build -buildvcs=false ./...`: passed with no output.
- `go vet ./...`: passed with no output.
- `go test -buildvcs=false ./internal/...`: passed. Tail included internal/cli 356.922s, internal/db 106.408s, internal/credgw 0.023s, internal/pipeline 0.012s, and internal/workflow 106.222s.
- `npm run build:llms`: passed; `git diff --check`: passed.
- Optional full `npm run build` reached the generated-doc step, then stopped because `docusaurus` is not installed in the worktree; the requested llms generation completed successfully.

RISK:
Review the generated diff before merging.

TASK:
adhoc-c529f05b

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented the first #968/#874 increment: pipeline-owned injected environment values with deny-by-default stage grants. No design deviations. Shared registry/grants and generalized proxied delivery remain explicitly deferred; the existing Anthropic credgw behavior is unchanged. No commit or push performed.
````
