### PR TITLE
feat(credentials): keychain registry + per-pipeline grants + override resolution (#874)

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -11,6 +11,7 @@ env_passthrough = ["GOCACHE", "NPM_*"]
 github = "deny"
 model_gateway = false
 model_gateway_allow_hosts = ["api.anthropic.com"]
+# keychain_path = "/absolute/operator/path/keychain.env"
 ```
 
 `env_curation = false` preserves the historical behavior: runtime commands
@@ -38,6 +39,38 @@ from ambient managed variables once. Existing files are never overwritten.
 For systemd deployments, keep `daemon.env` for operational values such as
 `PATH`; do not duplicate Claude secrets there after bootstrap.
 
+## Injected key registry and grants
+
+The shared injected-key source is an operator-owned env file. Its default path
+is `<base-home>/.config/gitmoot/keychain.env`; `gitmoot key path` prints the
+resolved path and validation status. `[credentials] keychain_path` can select a
+different absolute path. The file must be regular, owned by the current uid,
+mode exactly `0600`, and outside the Gitmoot home and managed checkouts. Gitmoot
+revalidates and rereads it at every registration, preflight, and delivery, so an
+atomic rewrite rotates values without a daemon restart.
+
+The `key` commands manage names, modes, and grants only. They never accept or
+print values:
+
+```sh
+gitmoot key path
+gitmoot key add SOURCE_API_TOKEN --mode injected
+gitmoot key grant SOURCE_API_TOKEN --pipeline nightly-sync
+gitmoot key list --json
+gitmoot key show SOURCE_API_TOKEN
+gitmoot key revoke SOURCE_API_TOKEN --pipeline nightly-sync
+gitmoot key rm SOURCE_API_TOKEN       # refuses while grants remain
+gitmoot key rm SOURCE_API_TOKEN --force
+```
+
+`rm` removes registry metadata and grants, not the operator's file entry.
+`proxied` mode is reserved for future gateway composition and cannot be granted
+to a pipeline. Pipeline shell stages may request granted `injected` names with
+`env_keys`; agent and gate stages remain ineligible. Resolution is Gitmoot's
+reserved `GITMOOT_*` namespace, then the pipeline's own `env_file`, then a
+granted shared key, then inline non-secret `env`. Registered but ungranted names
+are not visible to exact or glob selectors.
+
 ## Claude model gateway
 
 `model_gateway = true` opts Claude deliveries into a daemon-owned loopback
@@ -58,11 +91,12 @@ credential and ignore the placeholder — the gateway would then `401` the
 delivery (#936). The mirror never contains a credential; the operator's real
 config is only read, never modified.
 
-Pipeline `env_file` + per-stage `env_keys` are a separate **injected** mode for
-opaque API credentials whose shell script must present the real value. Gitmoot
-scopes those values to selected shell stages and audits names only, but the
-selected process necessarily receives the real credential. Enabling or using
-this feature does not alter the Claude gateway or its placeholder flow.
+Pipeline-owned `env_file` values and granted shared keychain values are a
+separate **injected** mode for opaque API credentials whose shell script must
+present the real value. Gitmoot scopes those values to selected shell stages
+and audits names, sources, and modes only, but the selected process necessarily
+receives the real credential. This does not alter the Claude gateway or its
+placeholder flow.
 
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -72,7 +72,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `name`                      | pipeline     | yes      | Stable identifier and DB primary key; a name-safe token (letters, digits, `-`, `_`). |
 | `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
 | `env_file`                  | pipeline     | no       | Absolute operator-owned secret file. It must exist, be a regular file owned by the current uid with mode exactly `0600`, and live outside the Gitmoot home and every managed checkout. |
-| `env`                       | pipeline     | no       | Inline **non-secret** `KEY: value` defaults. A file value with the same key wins. Values are delivered only when a shell stage selects the key. |
+| `env`                       | pipeline     | no       | Inline **non-secret** `KEY: value` defaults. Pipeline-owned and granted shared values take precedence. Values are delivered only when a shell stage selects the key. |
 | `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
 | `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
 | `trigger.kind`              | pipeline     | cond.    | Required with `trigger:`. Only `email` is supported; it generates an owned Activepieces IMAP flow. |
@@ -100,7 +100,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
-| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from `env_file`/`env`. Shell stages only; no entry means no injected values. |
+| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from the pipeline's `env_file`, granted shared registry keys, or inline `env`. Shell stages only; no entry means no injected values. |
 | `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
 
 `gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
@@ -119,7 +119,14 @@ rather than a stuck run later.
 
 Pipeline secrets are deny-by-default. A shell stage receives only the concrete
 names selected by its `env_keys`; a sibling with different or empty `env_keys`
-does not receive them. Agent and gate stages cannot declare `env_keys`.
+does not receive them. Agent and gate stages cannot declare `env_keys`. Shared
+keys must be registered and granted separately:
+
+```sh
+gitmoot key path # edit this 0600 file; the CLI never accepts values
+gitmoot key add REDDIT_CLIENT_SECRET --mode injected
+gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
+```
 
 ```yaml
 env_file: /root/.config/trend-scout/env
@@ -134,21 +141,27 @@ stages:
     env_keys: [TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID]
 ```
 
-`pipeline add` parses the file and refuses missing files/keys, insecure mode,
-wrong ownership, protected locations, malformed selectors, and any inline,
-file, or selector collision with reserved `GITMOOT_*` names. Values are loaded
-again immediately before each stage process starts, so an atomic rewrite of the
-same `0600` file rotates credentials without a daemon restart. The file value
-wins an inline default; selected values win inherited daemon environment;
-Gitmoot's own later `GITMOOT_*` entries always win.
+`pipeline add` parses the pipeline-owned file and refuses insecure mode, wrong
+ownership, protected locations, malformed selectors, and any inline, file, or
+selector collision with reserved `GITMOOT_*` names. An unresolved selector is a
+names-only warning only while the pipeline remains disabled, which allows the
+pipeline to exist before `key grant`; add-with-enable, enable, manual run, and
+scheduled/triggered preflight fail closed until it resolves. Values are loaded
+again immediately before each stage process starts, so an atomic rewrite of a
+`0600` source rotates credentials without a daemon restart. Resolution is own
+`env_file`, then granted shared key, then inline default; Gitmoot's reserved
+`GITMOOT_*` entries always win. Registered but ungranted names are not glob or
+exact-match candidates.
 
-The persisted stage job payload is the audit record: it contains the env-file
-path and expanded key **names**, never secret values. Inline `env` is stored in
-the pipeline spec and is therefore for non-secrets only. An injected/opaque key
-is necessarily visible to its shell process, which can print or transmit it;
-this is scoping and audit, not a vault. The Claude model gateway is independent:
-it continues to proxy the model credential without exposing the real value to
-the child.
+The persisted stage job payload is the audit record: `PipelineKeyAccess` carries
+only `{stage,name,source,mode}` rows (plus legacy env-file/name fields for
+already-enqueued jobs), never secret values. `pipeline show --json` exposes the
+same rows. Delivery rechecks every shared grant and its registry mode; revoking
+after enqueue fails the stage rather than switching to another source. Inline
+`env` is stored in the pipeline spec and is therefore for non-secrets only. An
+injected key is visible to its shell process; this is scoping and audit, not a
+vault. `proxied` registry mode is stored for future gateway composition but is
+refused for pipeline grants. The Claude model gateway remains independent.
 
 On `pipeline add --enable`, Gitmoot publishes the owned flow. An unavailable
 Activepieces instance leaves a pending binding; run

--- a/internal/cli/bridge.go
+++ b/internal/cli/bridge.go
@@ -370,6 +370,13 @@ func runBridgePipeline(ctx context.Context, store *db.Store, rawHome, name, payl
 	if err != nil {
 		return "", fmt.Errorf("stored spec is invalid: %w", err)
 	}
+	environment, err := resolvePipelineEnvironment(ctx, store, rawHome, spec)
+	if err != nil {
+		return "", err
+	}
+	if err := pipelineEnvironmentResolutionError(spec, environment.Unresolved); err != nil {
+		return "", err
+	}
 	now := time.Now().UTC()
 	run, err := createPipelineRun(ctx, store, rec, spec, "bridge", payloadJSON, now)
 	if err != nil {

--- a/internal/cli/key.go
+++ b/internal/cli/key.go
@@ -1,0 +1,481 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/pipeline"
+)
+
+type keychainPathStatus struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+type keychainKeyOutput struct {
+	db.KeychainKey
+	Grants []db.KeychainGrant `json:"grants"`
+}
+
+type keychainListOutput struct {
+	Keychain keychainPathStatus  `json:"keychain"`
+	Keys     []keychainKeyOutput `json:"keys"`
+}
+
+func runKey(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printKeyUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "path":
+		return runKeyPath(args[1:], stdout, stderr)
+	case "add":
+		return runKeyAdd(args[1:], stdout, stderr)
+	case "list":
+		return runKeyList(args[1:], stdout, stderr)
+	case "show":
+		return runKeyShow(args[1:], stdout, stderr)
+	case "rm":
+		return runKeyRemove(args[1:], stdout, stderr)
+	case "grant":
+		return runKeyGrant(args[1:], stdout, stderr)
+	case "revoke":
+		return runKeyRevoke(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown key command %q\n", args[0])
+		printKeyUsage(stderr)
+		return 2
+	}
+}
+
+func printKeyUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot key path [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key add <NAME> --mode injected|proxied [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key list [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key show <NAME> [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key rm <NAME> [--force] [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key grant <NAME> --pipeline <PIPELINE> [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key revoke <NAME> --pipeline <PIPELINE> [--json] [--home DIR]")
+}
+
+func inspectKeychain(ctx context.Context, store *db.Store, home string) keychainPathStatus {
+	path, err := resolveKeychainPath(store, home)
+	if err != nil {
+		return keychainPathStatus{Status: "invalid", Detail: err.Error()}
+	}
+	status := keychainPathStatus{Path: path, Status: "ready"}
+	if _, _, err := loadValidatedKeychainFile(ctx, store, home); err != nil {
+		status.Status = "invalid"
+		status.Detail = err.Error()
+		if _, statErr := os.Stat(path); errors.Is(statErr, os.ErrNotExist) {
+			status.Status = "missing"
+			status.Detail = ""
+		}
+	}
+	return status
+}
+
+func encodeKeyJSON(stdout, stderr io.Writer, value any) int {
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(value); err != nil {
+		fmt.Fprintf(stderr, "key: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func parseKeyNoPositionals(command string, args []string, stderr io.Writer) (home string, jsonOut bool, code int) {
+	fs := flag.NewFlagSet(command, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&home, "home", "", "home directory to use instead of the current user's home")
+	fs.BoolVar(&jsonOut, "json", false, "print JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return "", false, 0
+		}
+		return "", false, 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "%s does not accept positional arguments\n", command)
+		return "", false, 2
+	}
+	return home, jsonOut, -1
+}
+
+func runKeyPath(args []string, stdout, stderr io.Writer) int {
+	home, jsonOut, code := parseKeyNoPositionals("key path", args, stderr)
+	if code >= 0 {
+		return code
+	}
+	var status keychainPathStatus
+	if err := withStore(home, func(store *db.Store) error {
+		status = inspectKeychain(context.Background(), store, home)
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "key path: %v\n", err)
+		return 1
+	}
+	if jsonOut {
+		return encodeKeyJSON(stdout, stderr, status)
+	}
+	writeLine(stdout, "%s\t%s", status.Path, status.Status)
+	if status.Detail != "" {
+		writeLine(stdout, "  %s", status.Detail)
+	}
+	return 0
+}
+
+func validateKeyName(name string) error {
+	if err := pipeline.ValidateEnvName(name); err != nil {
+		return fmt.Errorf("invalid key name %q: %w", name, err)
+	}
+	if pipeline.ReservedEnvName(name) {
+		return fmt.Errorf("key name %q uses reserved GITMOOT_* namespace", name)
+	}
+	return nil
+}
+
+func runKeyAdd(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printKeyUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "key add requires a name")
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("key add", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	mode := fs.String("mode", "", "delivery mode: injected or proxied")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || *mode == "" {
+		fmt.Fprintln(stderr, "key add requires one name and --mode injected|proxied")
+		return 2
+	}
+	if err := validateKeyName(name); err != nil {
+		fmt.Fprintf(stderr, "key add: %v\n", err)
+		return 2
+	}
+	if *mode != db.KeychainModeInjected && *mode != db.KeychainModeProxied {
+		fmt.Fprintf(stderr, "key add: invalid mode %q; use injected or proxied\n", *mode)
+		return 2
+	}
+	var output keychainKeyOutput
+	var status keychainPathStatus
+	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		if _, found, err := store.GetKeychainKey(ctx, name); err != nil {
+			return err
+		} else if found {
+			return fmt.Errorf("key %s is already registered", name)
+		}
+		path, values, err := loadValidatedKeychainFile(ctx, store, *home)
+		if err != nil {
+			return err
+		}
+		if values[name] == "" {
+			return fmt.Errorf("key %q is absent or empty in %s", name, path)
+		}
+		key, err := store.AddKeychainKey(ctx, name, *mode)
+		output = keychainKeyOutput{KeychainKey: key, Grants: []db.KeychainGrant{}}
+		status = keychainPathStatus{Path: path, Status: "ready"}
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "key add: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		return encodeKeyJSON(stdout, stderr, struct {
+			Keychain keychainPathStatus `json:"keychain"`
+			Key      keychainKeyOutput  `json:"key"`
+		}{status, output})
+	}
+	writeLine(stdout, "added key %s (%s)", output.Name, output.Mode)
+	return 0
+}
+
+func keyOutputs(ctx context.Context, store *db.Store, keys []db.KeychainKey) ([]keychainKeyOutput, error) {
+	out := make([]keychainKeyOutput, 0, len(keys))
+	for _, key := range keys {
+		grants, err := store.ListKeychainGrants(ctx, key.Name)
+		if err != nil {
+			return nil, err
+		}
+		if grants == nil {
+			grants = []db.KeychainGrant{}
+		}
+		out = append(out, keychainKeyOutput{KeychainKey: key, Grants: grants})
+	}
+	return out, nil
+}
+
+func runKeyList(args []string, stdout, stderr io.Writer) int {
+	home, jsonOut, code := parseKeyNoPositionals("key list", args, stderr)
+	if code >= 0 {
+		return code
+	}
+	var output keychainListOutput
+	if err := withStore(home, func(store *db.Store) error {
+		ctx := context.Background()
+		keys, err := store.ListKeychainKeys(ctx)
+		if err != nil {
+			return err
+		}
+		output.Keys, err = keyOutputs(ctx, store, keys)
+		output.Keychain = inspectKeychain(ctx, store, home)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "key list: %v\n", err)
+		return 1
+	}
+	if output.Keys == nil {
+		output.Keys = []keychainKeyOutput{}
+	}
+	if jsonOut {
+		return encodeKeyJSON(stdout, stderr, output)
+	}
+	for _, key := range output.Keys {
+		writeLine(stdout, "%s\t%s\t%s\tgrants=%d", key.Name, key.Mode, key.CreatedAt, len(key.Grants))
+	}
+	return 0
+}
+
+func runKeyShow(args []string, stdout, stderr io.Writer) int {
+	return runKeyNamedRead("show", args, stdout, stderr)
+}
+
+func runKeyNamedRead(verb string, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printKeyUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintf(stderr, "key %s requires a name\n", verb)
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("key "+verb, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "key %s accepts exactly one name\n", verb)
+		return 2
+	}
+	var output keychainKeyOutput
+	var status keychainPathStatus
+	found := false
+	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		key, ok, err := store.GetKeychainKey(ctx, name)
+		if err != nil || !ok {
+			found = ok
+			return err
+		}
+		found = true
+		rows, err := keyOutputs(ctx, store, []db.KeychainKey{key})
+		if err != nil {
+			return err
+		}
+		output = rows[0]
+		status = inspectKeychain(ctx, store, *home)
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "key %s: %v\n", verb, err)
+		return 1
+	}
+	if !found {
+		fmt.Fprintf(stderr, "key %s: key %s not found\n", verb, name)
+		return 1
+	}
+	if *jsonOut {
+		return encodeKeyJSON(stdout, stderr, struct {
+			Keychain keychainPathStatus `json:"keychain"`
+			Key      keychainKeyOutput  `json:"key"`
+		}{status, output})
+	}
+	writeLine(stdout, "name: %s", output.Name)
+	writeLine(stdout, "mode: %s", output.Mode)
+	writeLine(stdout, "created_at: %s", output.CreatedAt)
+	writeLine(stdout, "keychain: %s (%s)", status.Path, status.Status)
+	writeLine(stdout, "grants:")
+	for _, grant := range output.Grants {
+		writeLine(stdout, "  %s:%s", grant.ConsumerKind, grant.ConsumerID)
+	}
+	return 0
+}
+
+func runKeyRemove(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printKeyUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "key rm requires a name")
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("key rm", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	force := fs.Bool("force", false, "remove metadata and grants even when grants exist")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "key rm accepts exactly one name")
+		return 2
+	}
+	var removed bool
+	var grantsRemoved int
+	var status keychainPathStatus
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		removed, grantsRemoved, err = store.RemoveKeychainKey(context.Background(), name, *force)
+		status = inspectKeychain(context.Background(), store, *home)
+		return err
+	}); err != nil {
+		if errors.Is(err, db.ErrKeychainKeyHasGrants) {
+			fmt.Fprintf(stderr, "key rm: key %s has %d grant(s); revoke them or use --force\n", name, grantsRemoved)
+		} else {
+			fmt.Fprintf(stderr, "key rm: %v\n", err)
+		}
+		return 1
+	}
+	if *jsonOut {
+		return encodeKeyJSON(stdout, stderr, struct {
+			Name             string             `json:"name"`
+			Removed          bool               `json:"removed"`
+			GrantsRemoved    int                `json:"grants_removed"`
+			FileEntryRemains bool               `json:"file_entry_remains"`
+			Keychain         keychainPathStatus `json:"keychain"`
+		}{name, removed, grantsRemoved, true, status})
+	}
+	if !removed {
+		writeLine(stdout, "key %s was not registered; keychain file unchanged", name)
+		return 0
+	}
+	writeLine(stdout, "removed key %s metadata and %d grant(s); entry in %s remains unchanged", name, grantsRemoved, status.Path)
+	return 0
+}
+
+func runKeyGrant(args []string, stdout, stderr io.Writer) int {
+	return runKeyGrantMutation(true, args, stdout, stderr)
+}
+
+func runKeyRevoke(args []string, stdout, stderr io.Writer) int {
+	return runKeyGrantMutation(false, args, stdout, stderr)
+}
+
+func runKeyGrantMutation(grant bool, args []string, stdout, stderr io.Writer) int {
+	verb := "grant"
+	if !grant {
+		verb = "revoke"
+	}
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printKeyUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintf(stderr, "key %s requires a name\n", verb)
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("key "+verb, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	pipelineName := fs.String("pipeline", "", "pipeline consumer")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || strings.TrimSpace(*pipelineName) == "" {
+		fmt.Fprintf(stderr, "key %s requires one name and --pipeline <pipeline>\n", verb)
+		return 2
+	}
+	changed := false
+	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		if grant {
+			if _, found, err := store.GetPipeline(ctx, *pipelineName); err != nil {
+				return err
+			} else if !found {
+				return fmt.Errorf("pipeline %s not found", *pipelineName)
+			}
+			key, found, err := store.GetKeychainKey(ctx, name)
+			if err != nil {
+				return err
+			}
+			if !found {
+				return fmt.Errorf("key %s is not registered", name)
+			}
+			if key.Mode != db.KeychainModeInjected {
+				return fmt.Errorf("key %s uses proxied mode; pipeline grants currently accept injected keys only", name)
+			}
+			path, values, err := loadValidatedKeychainFile(ctx, store, *home)
+			if err != nil {
+				return err
+			}
+			if values[name] == "" {
+				return fmt.Errorf("key %q is absent or empty in %s", name, path)
+			}
+			changed, err = store.GrantKeychainKey(ctx, db.KeychainConsumerPipeline, *pipelineName, name)
+			return err
+		}
+		var err error
+		changed, err = store.RevokeKeychainKey(ctx, db.KeychainConsumerPipeline, *pipelineName, name)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "key %s: %v\n", verb, err)
+		return 1
+	}
+	if *jsonOut {
+		return encodeKeyJSON(stdout, stderr, struct {
+			Name     string `json:"name"`
+			Pipeline string `json:"pipeline"`
+			Changed  bool   `json:"changed"`
+		}{name, strings.TrimSpace(*pipelineName), changed})
+	}
+	past := "granted"
+	if !grant {
+		past = "revoked"
+	}
+	if !changed {
+		writeLine(stdout, "key %s already %s for pipeline %s", name, past, *pipelineName)
+		return 0
+	}
+	writeLine(stdout, "%s key %s for pipeline %s", past, name, *pipelineName)
+	return 0
+}

--- a/internal/cli/key_test.go
+++ b/internal/cli/key_test.go
@@ -1,0 +1,215 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+const keychainSentinel = "keychain-sentinel-value-874"
+
+func writeDefaultKeychain(t *testing.T, home, body string) string {
+	t.Helper()
+	path := filepath.Join(home, ".config", "gitmoot", "keychain.env")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func runKeyTestCommand(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := Run(args, &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+func TestKeyCLIRegistryGrantsAndSecretSafety(t *testing.T) {
+	home := t.TempDir()
+	path := writeDefaultKeychain(t, home, "SHARED="+keychainSentinel+"\nPROXY=proxy-"+keychainSentinel+"\n")
+
+	if code, out, errOut := runKeyTestCommand(t, "key", "path", "--home", home, "--json"); code != 0 || !strings.Contains(out, path) || !strings.Contains(out, `"status": "ready"`) {
+		t.Fatalf("key path code=%d out=%q err=%q", code, out, errOut)
+	} else if strings.Contains(out+errOut, keychainSentinel) {
+		t.Fatalf("key path leaked value: %q %q", out, errOut)
+	}
+
+	for _, tc := range []struct {
+		name string
+		mode string
+	}{
+		{"SHARED", db.KeychainModeInjected},
+		{"PROXY", db.KeychainModeProxied},
+	} {
+		code, out, errOut := runKeyTestCommand(t, "key", "add", tc.name, "--mode", tc.mode, "--home", home, "--json")
+		if code != 0 {
+			t.Fatalf("key add %s code=%d out=%q err=%q", tc.name, code, out, errOut)
+		}
+		if strings.Contains(out+errOut, keychainSentinel) {
+			t.Fatalf("key add leaked value: %q %q", out, errOut)
+		}
+	}
+	if err := withStore(home, func(store *db.Store) error {
+		return store.CreateOrUpdatePipeline(context.Background(), db.Pipeline{Name: "pipe", SpecYAML: "name: pipe\nstages: [{id: run, cmd: echo}]\n"})
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "PROXY", "--pipeline", "pipe", "--home", home); code == 0 || !strings.Contains(errOut, "proxied") {
+		t.Fatalf("proxied grant code=%d out=%q err=%q", code, out, errOut)
+	} else if strings.Contains(out+errOut, keychainSentinel) {
+		t.Fatalf("proxied refusal leaked value: %q %q", out, errOut)
+	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "SHARED", "--pipeline", "pipe", "--home", home, "--json"); code != 0 {
+		t.Fatalf("grant code=%d out=%q err=%q", code, out, errOut)
+	} else if strings.Contains(out+errOut, keychainSentinel) {
+		t.Fatalf("grant leaked value: %q %q", out, errOut)
+	}
+
+	for _, args := range [][]string{
+		{"key", "list", "--home", home, "--json"},
+		{"key", "show", "SHARED", "--home", home, "--json"},
+		{"key", "list", "--home", home},
+		{"key", "show", "SHARED", "--home", home},
+	} {
+		code, out, errOut := runKeyTestCommand(t, args...)
+		wantGrantTarget := args[1] == "show" || slices.Contains(args, "--json")
+		if code != 0 || !strings.Contains(out, "SHARED") || (wantGrantTarget && !strings.Contains(out, "pipe")) {
+			t.Fatalf("%v code=%d out=%q err=%q", args, code, out, errOut)
+		}
+		if strings.Contains(out+errOut, keychainSentinel) {
+			t.Fatalf("%v leaked value: %q %q", args, out, errOut)
+		}
+	}
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "rm", "SHARED", "--force", "--home", home, "--json"); code != 0 || !strings.Contains(out, `"file_entry_remains": true`) {
+		t.Fatalf("rm force code=%d out=%q err=%q", code, out, errOut)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("key rm --force modified the keychain file")
+	}
+
+	code, out, errOut := runKeyTestCommand(t, "key", "add", "SHARED", "--value", keychainSentinel, "--mode", "injected", "--home", home)
+	if code == 0 || !strings.Contains(errOut, "flag provided but not defined") {
+		t.Fatalf("value flag unexpectedly accepted: code=%d out=%q err=%q", code, out, errOut)
+	}
+	if strings.Contains(printKeyUsageString(), "value") {
+		t.Fatal("key command usage exposes a value-input option")
+	}
+}
+
+func TestKeychainFileValidationMatchesPipelineEnvFile(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, home string, store *db.Store)
+		want  string
+	}{
+		{
+			name:  "missing",
+			setup: func(_ *testing.T, _ string, _ *db.Store) {},
+			want:  "does not exist",
+		},
+		{
+			name: "wrong mode",
+			setup: func(t *testing.T, home string, _ *db.Store) {
+				path := writeDefaultKeychain(t, home, "TOKEN="+keychainSentinel+"\n")
+				if err := os.Chmod(path, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "want 0600",
+		},
+		{
+			name: "reserved key",
+			setup: func(t *testing.T, home string, _ *db.Store) {
+				writeDefaultKeychain(t, home, "GITMOOT_INTERNAL="+keychainSentinel+"\nTOKEN=x\n")
+			},
+			want: "reserved GITMOOT_*",
+		},
+		{
+			name: "inside Gitmoot home",
+			setup: func(t *testing.T, home string, _ *db.Store) {
+				path := filepath.Join(home, ".gitmoot", "keychain.env")
+				if err := os.WriteFile(path, []byte("TOKEN="+keychainSentinel+"\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				writeKeychainOverride(t, home, path)
+			},
+			want: "inside Gitmoot home",
+		},
+		{
+			name: "inside managed checkout",
+			setup: func(t *testing.T, home string, store *db.Store) {
+				checkout := t.TempDir()
+				if err := store.UpsertRepo(context.Background(), db.Repo{Owner: "owner", Name: "repo", CheckoutPath: checkout}); err != nil {
+					t.Fatal(err)
+				}
+				path := filepath.Join(checkout, "keychain.env")
+				if err := os.WriteFile(path, []byte("TOKEN="+keychainSentinel+"\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				writeKeychainOverride(t, home, path)
+			},
+			want: "inside managed checkout",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home, _, store := heartbeatLoopE2EHome(t)
+			tt.setup(t, home, store)
+			code, out, errOut := runKeyTestCommand(t, "key", "add", "TOKEN", "--mode", "injected", "--home", home)
+			if code == 0 || !strings.Contains(errOut, tt.want) {
+				t.Fatalf("code=%d out=%q err=%q want=%q", code, out, errOut, tt.want)
+			}
+			if strings.Contains(out+errOut, keychainSentinel) {
+				t.Fatalf("validation leaked value: out=%q err=%q", out, errOut)
+			}
+		})
+	}
+}
+
+func TestKeychainFileWrongOwner(t *testing.T) {
+	home, _, store := heartbeatLoopE2EHome(t)
+	writeDefaultKeychain(t, home, "TOKEN="+keychainSentinel+"\n")
+	original := pipelineEnvCurrentUID
+	pipelineEnvCurrentUID = func() uint32 { return original() + 1 }
+	t.Cleanup(func() { pipelineEnvCurrentUID = original })
+	_, _, err := loadValidatedKeychainFile(context.Background(), store, home)
+	if err == nil || !strings.Contains(err.Error(), "owned by uid") || strings.Contains(err.Error(), keychainSentinel) {
+		t.Fatalf("wrong-owner error=%v", err)
+	}
+}
+
+func writeKeychainOverride(t *testing.T, home, path string) {
+	t.Helper()
+	configPath := filepath.Join(home, ".gitmoot", "config.toml")
+	if err := os.WriteFile(configPath, []byte("[credentials]\nkeychain_path = \""+path+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func printKeyUsageString() string {
+	var out bytes.Buffer
+	printKeyUsage(&out)
+	return out.String()
+}

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 // runPipeline is the CLI for the #681 pipeline registry: define, inspect, and
@@ -259,8 +260,27 @@ func addPipelineCore(ctx context.Context, store *db.Store, spec pipeline.Spec, r
 	if err := validatePipelineProducePaths(ctx, store, opts.Home, spec); err != nil {
 		return false, err
 	}
-	if err := validatePipelineEnvironment(ctx, store, opts.Home, spec); err != nil {
+	previous, previousFound, err := store.GetPipeline(ctx, spec.Name)
+	if err != nil {
 		return false, err
+	}
+	finalEnabled := previousFound && previous.Enabled
+	if opts.ForceEnabled {
+		finalEnabled = opts.Enable
+	} else if opts.Enable {
+		finalEnabled = true
+	}
+	environment, err := resolvePipelineEnvironment(ctx, store, opts.Home, spec)
+	if err != nil {
+		return false, err
+	}
+	if err := pipelineEnvironmentResolutionError(spec, environment.Unresolved); err != nil {
+		if finalEnabled {
+			return false, err
+		}
+		for _, unresolved := range environment.Unresolved {
+			fmt.Fprintf(stderr, "warning: pipeline %s is disabled: %v\n", spec.Name, pipelineEnvironmentResolutionError(spec, []pipelineEnvUnresolved{unresolved}))
+		}
 	}
 	registered, err := store.ListPipelines(ctx)
 	if err != nil {
@@ -294,10 +314,6 @@ func addPipelineCore(ctx context.Context, store *db.Store, spec pipeline.Spec, r
 			fmt.Fprintf(stderr, "warning: stage %q references agent %q which does not exist yet; create it before the pipeline runs (gitmoot agent ...)\n", stage.ID, stage.Agent)
 		}
 	}
-	previous, previousFound, err := store.GetPipeline(ctx, spec.Name)
-	if err != nil {
-		return false, err
-	}
 	if err := store.CreateOrUpdatePipeline(ctx, record); err != nil {
 		return false, err
 	}
@@ -320,7 +336,7 @@ func addPipelineCore(ctx context.Context, store *db.Store, spec pipeline.Spec, r
 	if err != nil {
 		return false, err
 	}
-	finalEnabled := saved.Enabled
+	finalEnabled = saved.Enabled
 	if finalEnabled && spec.Trigger != nil && spec.Trigger.Kind == "email" {
 		if _, bindErr := bindPipelineTrigger(ctx, store, saved, activepiecesAuthOptions{Home: opts.Home}, triggerBindingPending); bindErr != nil {
 			fmt.Fprintf(stderr, "warning: pipeline %s was registered but its trigger is pending: %v; retry with `gitmoot pipeline bind-trigger %s`\n", spec.Name, bindErr, spec.Name)
@@ -534,23 +550,26 @@ type pipelineStageJSON struct {
 	Network          bool     `json:"network,omitempty"`
 	Check            string   `json:"check,omitempty"`
 	CheckRetries     *int     `json:"check_retries,omitempty"`
+	EnvKeys          []string `json:"env_keys,omitempty"`
 }
 
 type pipelineJSON struct {
-	Name                string              `json:"name"`
-	Repo                string              `json:"repo,omitempty"`
-	Group               string              `json:"group"`
-	Enabled             bool                `json:"enabled"`
-	Mode                string              `json:"mode"`
-	Interval            string              `json:"interval,omitempty"`
-	Jitter              string              `json:"jitter,omitempty"`
-	SpecHash            string              `json:"spec_hash"`
-	Stages              []pipelineStageJSON `json:"stages,omitempty"`
-	LastRunAt           string              `json:"last_run_at,omitempty"`
-	NextDueAt           string              `json:"next_due_at,omitempty"`
-	LastRunID           string              `json:"last_run_id,omitempty"`
-	LastStatus          string              `json:"last_status,omitempty"`
-	TriggerBindingState string              `json:"trigger_binding_state,omitempty"`
+	Name                string                       `json:"name"`
+	Repo                string                       `json:"repo,omitempty"`
+	Group               string                       `json:"group"`
+	Enabled             bool                         `json:"enabled"`
+	Mode                string                       `json:"mode"`
+	Interval            string                       `json:"interval,omitempty"`
+	Jitter              string                       `json:"jitter,omitempty"`
+	SpecHash            string                       `json:"spec_hash"`
+	EnvFile             string                       `json:"env_file,omitempty"`
+	KeyAccess           []workflow.PipelineKeyAccess `json:"key_access,omitempty"`
+	Stages              []pipelineStageJSON          `json:"stages,omitempty"`
+	LastRunAt           string                       `json:"last_run_at,omitempty"`
+	NextDueAt           string                       `json:"next_due_at,omitempty"`
+	LastRunID           string                       `json:"last_run_id,omitempty"`
+	LastStatus          string                       `json:"last_status,omitempty"`
+	TriggerBindingState string                       `json:"trigger_binding_state,omitempty"`
 }
 
 func runPipelineList(args []string, stdout, stderr io.Writer) int {
@@ -581,7 +600,7 @@ func runPipelineList(args []string, stdout, stderr io.Writer) int {
 	if *jsonOut {
 		out := make([]pipelineJSON, 0, len(pipelines))
 		for _, p := range pipelines {
-			out = append(out, pipelineToJSON(p, false, nil, pipelineUpstreamMissing(p, knownPipelines)))
+			out = append(out, pipelineToJSON(p, false, nil, pipelineEnvironmentResolution{}, pipelineUpstreamMissing(p, knownPipelines)))
 		}
 		return encodePipelineJSON(stdout, stderr, out)
 	}
@@ -623,6 +642,7 @@ func runPipelineShow(args []string, stdout, stderr io.Writer) int {
 		runView         pipelineRunView
 		runFound        bool
 		upstreamMissing bool
+		environment     pipelineEnvironmentResolution
 	)
 	if err := withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
@@ -635,6 +655,15 @@ func runPipelineShow(args []string, stdout, stderr io.Writer) int {
 			return err
 		}
 		if found {
+			if *jsonOut {
+				spec, loadErr := pipeline.Load([]byte(record.SpecYAML))
+				if loadErr == nil {
+					environment, err = resolvePipelineEnvironment(ctx, store, *home, spec)
+					if err != nil {
+						return err
+					}
+				}
+			}
 			agents = pipelineStageAgents(ctx, store, record)
 			rows, listErr := store.ListPipelines(ctx)
 			if listErr != nil {
@@ -651,7 +680,7 @@ func runPipelineShow(args []string, stdout, stderr io.Writer) int {
 	}
 	if found {
 		if *jsonOut {
-			return encodePipelineJSON(stdout, stderr, pipelineToJSON(record, true, agents, upstreamMissing))
+			return encodePipelineJSON(stdout, stderr, pipelineToJSON(record, true, agents, environment, upstreamMissing))
 		}
 		printPipeline(stdout, record, agents, upstreamMissing)
 		return 0
@@ -736,6 +765,13 @@ func runPipelineSetEnabled(args []string, enabled bool, stdout, stderr io.Writer
 				return store.SetPipelineEnabled(ctx, name, true)
 			}
 			return loadErr
+		}
+		environment, envErr := resolvePipelineEnvironment(ctx, store, *home, spec)
+		if envErr != nil {
+			return envErr
+		}
+		if envErr := pipelineEnvironmentResolutionError(spec, environment.Unresolved); envErr != nil {
+			return envErr
 		}
 		if spec.Trigger != nil && spec.Trigger.Kind == "pipeline" {
 			if err := store.ArmPipelineTrigger(ctx, name, spec.Trigger.Pipeline, time.Now().UTC()); err != nil {
@@ -834,7 +870,7 @@ func runPipelineRemove(args []string, stdout, stderr io.Writer) int {
 // shape. When withStages is set it parses the stored (already-validated) spec to
 // enumerate the stage DAG; a parse failure degrades to no stages rather than
 // failing the command.
-func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Agent, upstreamMissing ...bool) pipelineJSON {
+func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Agent, environment pipelineEnvironmentResolution, upstreamMissing ...bool) pipelineJSON {
 	group, _ := resolvedPipelineGroup(record)
 	out := pipelineJSON{
 		Name:                record.Name,
@@ -845,6 +881,7 @@ func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Ag
 		Interval:            record.Interval,
 		Jitter:              record.Jitter,
 		SpecHash:            record.SpecHash,
+		KeyAccess:           append([]workflow.PipelineKeyAccess(nil), environment.Access...),
 		LastRunAt:           heartbeatTimeForStatus(record.LastRunAt),
 		NextDueAt:           heartbeatTimeForStatus(record.NextDueAt),
 		LastRunID:           record.LastRunID,
@@ -859,6 +896,7 @@ func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Ag
 	}
 	if withStages {
 		if spec, err := pipeline.Load([]byte(record.SpecYAML)); err == nil {
+			out.EnvFile = spec.EnvFile
 			for _, stage := range spec.Stages {
 				agentRuntime := ""
 				if agent, ok := agents[stage.Agent]; ok {
@@ -883,6 +921,7 @@ func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Ag
 					Network:          stage.Network,
 					Check:            stage.Check,
 					CheckRetries:     stage.CheckRetries,
+					EnvKeys:          append([]string(nil), stage.EnvKeys...),
 				})
 			}
 		}
@@ -1200,6 +1239,13 @@ func runPipelineRunCmd(args []string, stdout, stderr io.Writer) int {
 		spec, err := pipeline.Load([]byte(rec.SpecYAML))
 		if err != nil {
 			return fmt.Errorf("stored spec is invalid: %w", err)
+		}
+		environment, err := resolvePipelineEnvironment(ctx, store, *home, spec)
+		if err != nil {
+			return err
+		}
+		if err := pipelineEnvironmentResolutionError(spec, environment.Unresolved); err != nil {
+			return err
 		}
 		now := time.Now().UTC()
 		run, err := createPipelineRun(ctx, store, rec, spec, "manual", "{}", now)

--- a/internal/cli/pipeline_env.go
+++ b/internal/cli/pipeline_env.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
@@ -17,113 +19,256 @@ import (
 
 const pipelineEnvFileMode os.FileMode = 0o600
 
+const (
+	pipelineKeySourceOwn     = "own"
+	pipelineKeySourceShared  = "shared"
+	pipelineKeySourceDefault = "default"
+)
+
 type pipelineStageEnvAccess struct {
 	File     string
 	Keys     []string
 	Defaults map[string]string
+	Access   []workflow.PipelineKeyAccess
 }
 
-// validatePipelineEnvironment is the add-time #968 preflight. This first
-// increment resolves only pipeline-owned env_file and inline defaults. The
-// future named-key registry/grants phase can add another source here without
-// changing the names-only payload or delivery adapter.
-func validatePipelineEnvironment(ctx context.Context, store *db.Store, home string, spec pipeline.Spec) error {
-	sources, err := loadPipelineEnvSources(ctx, store, home, spec.EnvFile, spec.Env)
-	if err != nil {
-		return err
+type pipelineEnvUnresolved struct {
+	Stage    string
+	Selector string
+}
+
+type pipelineEnvironmentResolution struct {
+	Access     []workflow.PipelineKeyAccess
+	Unresolved []pipelineEnvUnresolved
+}
+
+// resolvePipelineEnvironment is the single names-only projection used by add
+// validation, run preflight, payload audit, and `pipeline show --json`.
+func resolvePipelineEnvironment(ctx context.Context, store *db.Store, home string, spec pipeline.Spec) (pipelineEnvironmentResolution, error) {
+	available := make(map[string]string, len(spec.Env))
+	source := make(map[string]string, len(spec.Env))
+	for name := range spec.Env {
+		available[name] = ""
+		source[name] = pipelineKeySourceDefault
 	}
-	for _, stage := range spec.Stages {
-		if len(stage.EnvKeys) == 0 {
+	if strings.TrimSpace(spec.EnvFile) != "" {
+		own, err := loadValidatedPipelineEnvFile(ctx, store, home, spec.EnvFile)
+		if err != nil {
+			return pipelineEnvironmentResolution{}, err
+		}
+		for name := range own {
+			available[name] = ""
+			source[name] = pipelineKeySourceOwn
+		}
+	}
+
+	var grants []db.KeychainGrant
+	if strings.TrimSpace(spec.Name) != "" {
+		var err error
+		grants, err = store.ListKeychainGrantsForConsumer(ctx, db.KeychainConsumerPipeline, spec.Name)
+		if err != nil {
+			return pipelineEnvironmentResolution{}, err
+		}
+	}
+	sharedCandidates := make(map[string]db.KeychainKey)
+	for _, grant := range grants {
+		if source[grant.KeyName] == pipelineKeySourceOwn || !pipelineSelectorUsed(spec, grant.KeyName) {
 			continue
 		}
-		if _, err := pipeline.ResolveEnvKeys(stage.EnvKeys, sources.available); err != nil {
-			return fmt.Errorf("stage %q: %w", stage.ID, err)
+		key, found, err := store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, spec.Name, grant.KeyName)
+		if err != nil {
+			return pipelineEnvironmentResolution{}, err
+		}
+		if found && key.Mode == db.KeychainModeInjected {
+			sharedCandidates[key.Name] = key
 		}
 	}
-	return nil
+	if len(sharedCandidates) > 0 {
+		_, shared, err := loadValidatedKeychainFile(ctx, store, home)
+		if err != nil {
+			return pipelineEnvironmentResolution{}, err
+		}
+		for name := range sharedCandidates {
+			if strings.TrimSpace(shared[name]) == "" {
+				continue
+			}
+			available[name] = ""
+			source[name] = pipelineKeySourceShared
+		}
+	}
+
+	resolution := pipelineEnvironmentResolution{}
+	for _, stage := range spec.Stages {
+		seen := make(map[string]struct{})
+		for _, selector := range stage.EnvKeys {
+			keys, err := pipeline.ResolveEnvKeys([]string{selector}, available)
+			if err != nil {
+				resolution.Unresolved = append(resolution.Unresolved, pipelineEnvUnresolved{Stage: stage.ID, Selector: selector})
+				continue
+			}
+			for _, name := range keys {
+				if _, ok := seen[name]; ok {
+					continue
+				}
+				seen[name] = struct{}{}
+				resolution.Access = append(resolution.Access, workflow.PipelineKeyAccess{
+					Stage: stage.ID, Name: name, Source: source[name], Mode: db.KeychainModeInjected,
+				})
+			}
+		}
+	}
+	return resolution, nil
+}
+
+func pipelineSelectorUsed(spec pipeline.Spec, name string) bool {
+	for _, stage := range spec.Stages {
+		for _, selector := range stage.EnvKeys {
+			if selector == name {
+				return true
+			}
+			if strings.ContainsAny(selector, "*?[") {
+				matched, _ := path.Match(selector, name)
+				if matched {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func pipelineEnvironmentResolutionError(spec pipeline.Spec, unresolved []pipelineEnvUnresolved) error {
+	if len(unresolved) == 0 {
+		return nil
+	}
+	item := unresolved[0]
+	name := item.Selector
+	if strings.ContainsAny(name, "*?[") {
+		name = "<name>"
+	}
+	return fmt.Errorf("stage %q env_keys entry %q is unresolved; register a matching key and run gitmoot key grant %s --pipeline %s", item.Stage, item.Selector, name, spec.Name)
 }
 
 func resolvePipelineStageEnvAccess(ctx context.Context, store *db.Store, home string, spec pipeline.Spec, stage pipeline.Stage) (pipelineStageEnvAccess, error) {
 	if len(stage.EnvKeys) == 0 {
 		return pipelineStageEnvAccess{}, nil
 	}
-	sources, err := loadPipelineEnvSources(ctx, store, home, spec.EnvFile, spec.Env)
+	resolutionSpec := spec
+	foundStage := false
+	for _, candidate := range resolutionSpec.Stages {
+		if candidate.ID == stage.ID {
+			foundStage = true
+			break
+		}
+	}
+	if !foundStage {
+		resolutionSpec.Stages = append(append([]pipeline.Stage(nil), resolutionSpec.Stages...), stage)
+	}
+	resolution, err := resolvePipelineEnvironment(ctx, store, home, resolutionSpec)
 	if err != nil {
 		return pipelineStageEnvAccess{}, err
 	}
-	keys, err := pipeline.ResolveEnvKeys(stage.EnvKeys, sources.available)
-	if err != nil {
-		return pipelineStageEnvAccess{}, fmt.Errorf("stage %q: %w", stage.ID, err)
-	}
-	defaults := make(map[string]string)
-	for _, key := range keys {
-		if value, ok := spec.Env[key]; ok {
-			defaults[key] = value
+	for _, unresolved := range resolution.Unresolved {
+		if unresolved.Stage == stage.ID {
+			return pipelineStageEnvAccess{}, pipelineEnvironmentResolutionError(spec, []pipelineEnvUnresolved{unresolved})
 		}
 	}
-	return pipelineStageEnvAccess{File: spec.EnvFile, Keys: keys, Defaults: defaults}, nil
-}
-
-type pipelineEnvSources struct {
-	available map[string]string
-}
-
-func loadPipelineEnvSources(ctx context.Context, store *db.Store, home, envFile string, inline map[string]string) (pipelineEnvSources, error) {
-	available := make(map[string]string, len(inline))
-	for name, value := range inline {
-		available[name] = value
+	access := pipelineStageEnvAccess{File: spec.EnvFile}
+	for _, row := range resolution.Access {
+		if row.Stage != stage.ID {
+			continue
+		}
+		access.Access = append(access.Access, row)
+		access.Keys = append(access.Keys, row.Name)
+		if row.Source == pipelineKeySourceDefault {
+			if access.Defaults == nil {
+				access.Defaults = make(map[string]string)
+			}
+			access.Defaults[row.Name] = spec.Env[row.Name]
+		}
 	}
-	if strings.TrimSpace(envFile) == "" {
-		return pipelineEnvSources{available: available}, nil
-	}
-	fileValues, err := loadValidatedPipelineEnvFile(ctx, store, home, envFile)
-	if err != nil {
-		return pipelineEnvSources{}, err
-	}
-	// The pipeline-owned file is the most-specific source and wins over inline
-	// non-secret defaults. There is no shared registry in this increment.
-	for name, value := range fileValues {
-		available[name] = value
-	}
-	return pipelineEnvSources{available: available}, nil
+	return access, nil
 }
 
 func loadValidatedPipelineEnvFile(ctx context.Context, store *db.Store, home, declared string) (map[string]string, error) {
+	return loadValidatedSecretEnvFile(ctx, store, home, "env_file", declared)
+}
+
+func loadValidatedKeychainFile(ctx context.Context, store *db.Store, home string) (string, map[string]string, error) {
+	path, err := resolveKeychainPath(store, home)
+	if err != nil {
+		return "", nil, err
+	}
+	values, err := loadValidatedSecretEnvFile(ctx, store, home, "keychain", path)
+	return path, values, err
+}
+
+func resolveKeychainPath(store *db.Store, home string) (string, error) {
+	paths, err := configPathsForPipelineStore(store, home)
+	if err != nil {
+		return "", err
+	}
+	cfg, err := config.LoadCredentialsConfig(paths)
+	if err != nil {
+		return "", fmt.Errorf("load credentials config: %w", err)
+	}
+	if cfg.KeychainPath != "" {
+		return cfg.KeychainPath, nil
+	}
+	baseHome := filepath.Dir(paths.Home)
+	return filepath.Join(baseHome, ".config", "gitmoot", "keychain.env"), nil
+}
+
+func configPathsForPipelineStore(store *db.Store, home string) (config.Paths, error) {
+	if strings.TrimSpace(home) != "" {
+		return pathsFromFlag(home)
+	}
+	if store != nil {
+		databasePath := strings.TrimSpace(store.DatabasePath())
+		if databasePath != "" && databasePath != ":memory:" {
+			gitmootHome := filepath.Dir(databasePath)
+			return config.PathsForHome(filepath.Dir(gitmootHome)), nil
+		}
+	}
+	return pathsFromFlag(home)
+}
+
+func loadValidatedSecretEnvFile(ctx context.Context, store *db.Store, home, label, declared string) (map[string]string, error) {
 	declared = strings.TrimSpace(declared)
 	if !filepath.IsAbs(declared) {
-		return nil, fmt.Errorf("env_file %q must be absolute", declared)
+		return nil, fmt.Errorf("%s %q must be absolute", label, declared)
 	}
 	file, err := os.Open(declared)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("env_file %s does not exist", declared)
+			return nil, fmt.Errorf("%s %s does not exist", label, declared)
 		}
-		return nil, fmt.Errorf("open env_file %s: %w", declared, err)
+		return nil, fmt.Errorf("open %s %s: %w", label, declared, err)
 	}
 	defer file.Close()
 	info, err := file.Stat()
 	if err != nil {
-		return nil, fmt.Errorf("stat env_file %s: %w", declared, err)
+		return nil, fmt.Errorf("stat %s %s: %w", label, declared, err)
 	}
 	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("env_file %s is not a regular file", declared)
+		return nil, fmt.Errorf("%s %s is not a regular file", label, declared)
 	}
 	if info.Mode().Perm() != pipelineEnvFileMode {
-		return nil, fmt.Errorf("env_file %s has mode %04o; want 0600", declared, info.Mode().Perm())
+		return nil, fmt.Errorf("%s %s has mode %04o; want 0600", label, declared, info.Mode().Perm())
 	}
 	owner, err := pipelineEnvOwnerUID(info)
 	if err != nil {
-		return nil, fmt.Errorf("env_file %s: %w", declared, err)
+		return nil, fmt.Errorf("%s %s: %w", label, declared, err)
 	}
 	if owner != pipelineEnvCurrentUID() {
-		return nil, fmt.Errorf("env_file %s is owned by uid %d; want operator uid %d", declared, owner, pipelineEnvCurrentUID())
+		return nil, fmt.Errorf("%s %s is owned by uid %d; want operator uid %d", label, declared, owner, pipelineEnvCurrentUID())
 	}
-	if err := validatePipelineEnvFileLocation(ctx, store, home, declared); err != nil {
+	if err := validateSecretEnvFileLocation(ctx, store, home, label, declared); err != nil {
 		return nil, err
 	}
 	data, err := io.ReadAll(file)
 	if err != nil {
-		return nil, fmt.Errorf("read env_file %s: %w", declared, err)
+		return nil, fmt.Errorf("read %s %s: %w", label, declared, err)
 	}
 	values, err := pipeline.ParseEnv(declared, data)
 	if err != nil {
@@ -131,19 +276,23 @@ func loadValidatedPipelineEnvFile(ctx context.Context, store *db.Store, home, de
 	}
 	for name := range values {
 		if pipeline.ReservedEnvName(name) {
-			return nil, fmt.Errorf("env_file %s key %q uses reserved GITMOOT_* namespace", declared, name)
+			return nil, fmt.Errorf("%s %s key %q uses reserved GITMOOT_* namespace", label, declared, name)
 		}
 	}
 	return values, nil
 }
 
 func validatePipelineEnvFileLocation(ctx context.Context, store *db.Store, home, declared string) error {
+	return validateSecretEnvFileLocation(ctx, store, home, "env_file", declared)
+}
+
+func validateSecretEnvFileLocation(ctx context.Context, store *db.Store, home, label, declared string) error {
 	if store == nil {
-		return errors.New("pipeline env_file validation requires a store")
+		return fmt.Errorf("%s validation requires a store", label)
 	}
 	resolved, err := resolveProduceSafetyPath(declared)
 	if err != nil {
-		return fmt.Errorf("resolve env_file %s: %w", declared, err)
+		return fmt.Errorf("resolve %s %s: %w", label, declared, err)
 	}
 	gitmootHome := ""
 	if databasePath := strings.TrimSpace(store.DatabasePath()); databasePath != "" && databasePath != ":memory:" {
@@ -174,7 +323,7 @@ func validatePipelineEnvFileLocation(ctx context.Context, store *db.Store, home,
 			return fmt.Errorf("resolve %s %q: %w", item.label, item.path, err)
 		}
 		if pathWithin(resolved, protectedPath) {
-			return fmt.Errorf("env_file %s resolves inside %s %q", declared, item.label, protectedPath)
+			return fmt.Errorf("%s %s resolves inside %s %q", label, declared, item.label, protectedPath)
 		}
 	}
 	return nil
@@ -186,32 +335,98 @@ func pathWithin(path, directory string) bool {
 }
 
 type pipelineEnvDeliveryAdapter struct {
-	inner workflow.DeliveryAdapter
-	store *db.Store
-	home  string
-	file  string
-	keys  []string
-	env   map[string]string
+	inner        workflow.DeliveryAdapter
+	store        *db.Store
+	home         string
+	pipelineName string
+	access       []workflow.PipelineKeyAccess
+	file         string
+	keys         []string
+	env          map[string]string
 }
 
 func wrapPipelineEnvDeliveryAdapter(store *db.Store, home string, payload workflow.JobPayload, inner workflow.DeliveryAdapter) workflow.DeliveryAdapter {
-	if inner == nil || len(payload.PipelineEnvKeys) == 0 {
+	if inner == nil || (len(payload.PipelineKeyAccess) == 0 && len(payload.PipelineEnvKeys) == 0) {
 		return inner
 	}
 	return pipelineEnvDeliveryAdapter{
-		inner: inner, store: store, home: home, file: payload.PipelineEnvFile,
-		keys: append([]string(nil), payload.PipelineEnvKeys...), env: payload.PipelineEnv,
+		inner: inner, store: store, home: home, pipelineName: payload.PipelineName,
+		access: append([]workflow.PipelineKeyAccess(nil), payload.PipelineKeyAccess...),
+		file:   payload.PipelineEnvFile, keys: append([]string(nil), payload.PipelineEnvKeys...), env: payload.PipelineEnv,
 	}
 }
 
 func (a pipelineEnvDeliveryAdapter) Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
-	sources, err := loadPipelineEnvSources(ctx, a.store, a.home, a.file, a.env)
-	if err != nil {
-		return runtime.Result{}, fmt.Errorf("load pipeline stage environment: %w", err)
+	if len(a.access) == 0 {
+		return a.deliverLegacy(ctx, agent, job)
+	}
+	var own, shared map[string]string
+	entries := make([]string, 0, len(a.access))
+	for _, access := range a.access {
+		if access.Mode != db.KeychainModeInjected {
+			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: key %q has unsupported mode %q", access.Name, access.Mode)
+		}
+		var (
+			value string
+			ok    bool
+		)
+		switch access.Source {
+		case pipelineKeySourceOwn:
+			if own == nil {
+				var err error
+				own, err = loadValidatedPipelineEnvFile(ctx, a.store, a.home, a.file)
+				if err != nil {
+					return runtime.Result{}, fmt.Errorf("load pipeline stage environment: %w", err)
+				}
+			}
+			value, ok = own[access.Name]
+		case pipelineKeySourceShared:
+			key, granted, err := a.store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, a.pipelineName, access.Name)
+			if err != nil {
+				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: re-check grant for key %q: %w", access.Name, err)
+			}
+			if !granted || key.Mode != db.KeychainModeInjected {
+				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: grant for key %q was revoked or changed", access.Name)
+			}
+			if shared == nil {
+				_, shared, err = loadValidatedKeychainFile(ctx, a.store, a.home)
+				if err != nil {
+					return runtime.Result{}, fmt.Errorf("load pipeline stage environment: %w", err)
+				}
+			}
+			value, ok = shared[access.Name]
+			ok = ok && strings.TrimSpace(value) != ""
+		case pipelineKeySourceDefault:
+			value, ok = a.env[access.Name]
+		default:
+			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: key %q has unknown source %q", access.Name, access.Source)
+		}
+		if !ok {
+			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: key %q is no longer available from source %s", access.Name, access.Source)
+		}
+		entries = append(entries, access.Name+"="+value)
+	}
+	job.ShellEnv = prependPipelineEnvironment(entries, job.ShellEnv)
+	return a.inner.Deliver(ctx, agent, job)
+}
+
+func (a pipelineEnvDeliveryAdapter) deliverLegacy(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	available := make(map[string]string, len(a.env))
+	for name, value := range a.env {
+		available[name] = value
+	}
+	if strings.TrimSpace(a.file) != "" {
+		values, err := loadValidatedPipelineEnvFile(ctx, a.store, a.home, a.file)
+		if err != nil {
+			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: %w", err)
+		}
+		for name, value := range values {
+			available[name] = value
+		}
 	}
 	entries := make([]string, 0, len(a.keys))
 	for _, key := range a.keys {
-		value, ok := sources.available[key]
+		value, ok := available[key]
 		if !ok {
 			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: key %q is no longer available", key)
 		}

--- a/internal/cli/pipeline_env_test.go
+++ b/internal/cli/pipeline_env_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -37,9 +38,10 @@ func writePipelineEnvFile(t *testing.T, dir, body string, mode os.FileMode) stri
 
 func TestPipelineAddEnvFileValidation(t *testing.T) {
 	tests := []struct {
-		name  string
-		setup func(t *testing.T, home string) (envFile, envBody, stage string)
-		want  string
+		name   string
+		setup  func(t *testing.T, home string) (envFile, envBody, stage string)
+		want   string
+		enable bool
 	}{
 		{
 			name: "missing file",
@@ -91,7 +93,8 @@ func TestPipelineAddEnvFileValidation(t *testing.T) {
 			setup: func(t *testing.T, _ string) (string, string, string) {
 				return writePipelineEnvFile(t, t.TempDir(), "PRESENT="+pipelineEnvSecretA+"\n", 0o600), "", "{id: run, cmd: echo, env_keys: [MISSING]}"
 			},
-			want: `env_keys entry "MISSING" does not resolve`,
+			want:   `env_keys entry "MISSING" is unresolved`,
+			enable: true,
 		},
 		{
 			name: "agent stage denied",
@@ -109,7 +112,11 @@ func TestPipelineAddEnvFileValidation(t *testing.T) {
 			raw := fmt.Sprintf("name: env-validation\nenv_file: %q\n%s\nstages:\n  - %s\n", envFile, extra, stage)
 			specFile := writeSpec(t, raw)
 			var stdout, stderr bytes.Buffer
-			code := Run([]string{"pipeline", "add", specFile, "--home", home}, &stdout, &stderr)
+			args := []string{"pipeline", "add", specFile, "--home", home}
+			if tt.enable {
+				args = append(args, "--enable")
+			}
+			code := Run(args, &stdout, &stderr)
 			if code == 0 || !strings.Contains(stderr.String(), tt.want) {
 				t.Fatalf("code=%d stderr=%q, want %q", code, stderr.String(), tt.want)
 			}
@@ -209,6 +216,172 @@ func TestPipelineEnvDeliveryScopePrecedenceAndRotation(t *testing.T) {
 	}
 	if got := reservedCapture.jobs[0].ShellEnv; !reflect.DeepEqual(got, []string{"GITMOOT_PIPELINE_NAME=untrusted", "GITMOOT_PIPELINE_NAME=real"}) {
 		t.Fatalf("Gitmoot internal value did not win at delivery: %#v", got)
+	}
+}
+
+func TestPipelineKeyAccessResolutionPrecedenceAndGrantBoundary(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	writeDefaultKeychain(t, home, "OVERLAP=shared-overlap\nSHARED_ONLY="+pipelineEnvSecretA+"\nUNGRANTED="+pipelineEnvSecretB+"\n")
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "sources", SpecYAML: "name: sources\nstages: [{id: run, cmd: echo}]\n"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"OVERLAP", "SHARED_ONLY", "UNGRANTED"} {
+		if _, err := store.AddKeychainKey(ctx, name, db.KeychainModeInjected); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"OVERLAP", "SHARED_ONLY"} {
+		if _, err := store.GrantKeychainKey(ctx, db.KeychainConsumerPipeline, "sources", name); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ownFile := writePipelineEnvFile(t, t.TempDir(), "OVERLAP=own-overlap\nOWN_ONLY=own\n", 0o600)
+	spec := pipeline.Spec{
+		Name:    "sources",
+		EnvFile: ownFile,
+		Env: map[string]string{
+			"OVERLAP":      "default-overlap",
+			"SHARED_ONLY":  "default-shared",
+			"DEFAULT_ONLY": "default-only",
+		},
+		Stages: []pipeline.Stage{{ID: "run", Cmd: "echo", EnvKeys: []string{"OVERLAP", "SHARED_ONLY", "DEFAULT_ONLY"}}},
+	}
+	resolution, err := resolvePipelineEnvironment(ctx, store, home, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []workflow.PipelineKeyAccess{
+		{Stage: "run", Name: "OVERLAP", Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected},
+		{Stage: "run", Name: "SHARED_ONLY", Source: pipelineKeySourceShared, Mode: db.KeychainModeInjected},
+		{Stage: "run", Name: "DEFAULT_ONLY", Source: pipelineKeySourceDefault, Mode: db.KeychainModeInjected},
+	}
+	if !reflect.DeepEqual(resolution.Access, want) || len(resolution.Unresolved) != 0 {
+		t.Fatalf("resolution=%#v unresolved=%#v, want %#v", resolution.Access, resolution.Unresolved, want)
+	}
+
+	for _, selector := range []string{"UNGRANTED", "UNGRANTED*"} {
+		probe := spec
+		probe.Stages = []pipeline.Stage{{ID: "run", Cmd: "echo", EnvKeys: []string{selector}}}
+		got, err := resolvePipelineEnvironment(ctx, store, home, probe)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got.Access) != 0 || !reflect.DeepEqual(got.Unresolved, []pipelineEnvUnresolved{{Stage: "run", Selector: selector}}) {
+			t.Fatalf("selector %q resolved without a grant: access=%#v unresolved=%#v", selector, got.Access, got.Unresolved)
+		}
+	}
+
+	raw := fmt.Sprintf("name: sources\nenv_file: %q\nenv:\n  OVERLAP: default-overlap\n  SHARED_ONLY: default-shared\n  DEFAULT_ONLY: default-only\nstages:\n  - id: run\n    cmd: echo\n    env_keys: [OVERLAP, SHARED_ONLY, DEFAULT_ONLY]\n", ownFile)
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "sources", SpecYAML: raw, SpecHash: pipeline.Hash([]byte(raw))}); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "show", "sources", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("pipeline show code=%d stderr=%q", code, stderr.String())
+	}
+	var shown pipelineJSON
+	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil {
+		t.Fatal(err)
+	}
+	if shown.EnvFile != ownFile || !reflect.DeepEqual(shown.KeyAccess, want) || !reflect.DeepEqual(shown.Stages[0].EnvKeys, spec.Stages[0].EnvKeys) {
+		t.Fatalf("pipeline show projection=%+v", shown)
+	}
+	if err := os.WriteFile(ownFile, []byte("OWN_ONLY=own\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	capture := &pipelineEnvCaptureAdapter{}
+	pinnedOwn := wrapPipelineEnvDeliveryAdapter(store, home, workflow.JobPayload{
+		PipelineName: "sources", PipelineEnvFile: ownFile, PipelineKeyAccess: []workflow.PipelineKeyAccess{want[0]},
+	}, capture)
+	if _, err := pinnedOwn.Deliver(ctx, runtime.Agent{}, runtime.Job{}); err == nil || !strings.Contains(err.Error(), "source own") {
+		t.Fatalf("disappeared own source silently switched to shared: err=%v", err)
+	}
+	if len(capture.jobs) != 0 {
+		t.Fatalf("disappeared own source reached delivery: %#v", capture.jobs)
+	}
+}
+
+func TestPipelineSharedKeyDeliveryRotationAndRevocation(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	path := writeDefaultKeychain(t, home, "SHARED="+pipelineEnvSecretA+"\n")
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "shared-delivery", SpecYAML: "name: shared-delivery\nstages: [{id: run, cmd: echo}]\n"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddKeychainKey(ctx, "SHARED", db.KeychainModeInjected); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantKeychainKey(ctx, db.KeychainConsumerPipeline, "shared-delivery", "SHARED"); err != nil {
+		t.Fatal(err)
+	}
+	spec := pipeline.Spec{Name: "shared-delivery", Stages: []pipeline.Stage{{ID: "run", Cmd: "echo", EnvKeys: []string{"SHARED"}}}}
+	access, err := resolvePipelineStageEnvAccess(ctx, store, home, spec, spec.Stages[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture := &pipelineEnvCaptureAdapter{}
+	wrapped := wrapPipelineEnvDeliveryAdapter(store, home, workflow.JobPayload{
+		PipelineName: "shared-delivery", PipelineKeyAccess: access.Access,
+	}, capture)
+	if _, err := wrapped.Deliver(ctx, runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.jobs[0].ShellEnv; !reflect.DeepEqual(got, []string{"SHARED=" + pipelineEnvSecretA}) {
+		t.Fatalf("first shared delivery=%#v", got)
+	}
+	if err := os.WriteFile(path, []byte("SHARED=rotated-shared-874\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapped.Deliver(ctx, runtime.Agent{}, runtime.Job{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := capture.jobs[1].ShellEnv; !reflect.DeepEqual(got, []string{"SHARED=rotated-shared-874"}) {
+		t.Fatalf("rotated shared delivery=%#v", got)
+	}
+	if _, err := store.RevokeKeychainKey(ctx, db.KeychainConsumerPipeline, "shared-delivery", "SHARED"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapped.Deliver(ctx, runtime.Agent{}, runtime.Job{}); err == nil || !strings.Contains(err.Error(), "revoked") {
+		t.Fatalf("revoked grant delivery error=%v", err)
+	}
+	if len(capture.jobs) != 2 {
+		t.Fatalf("revoked grant reached inner adapter: jobs=%d", len(capture.jobs))
+	}
+}
+
+func TestPipelineEnvironmentValidationTiming(t *testing.T) {
+	home := t.TempDir()
+	specFile := writeSpec(t, "name: unresolved-env\nrepo: owner/repo\nstages: [{id: run, cmd: echo, env_keys: [MISSING]}]\n")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &stdout, &stderr); code != 0 || !strings.Contains(stderr.String(), "warning:") || !strings.Contains(stderr.String(), "gitmoot key grant MISSING --pipeline unresolved-env") {
+		t.Fatalf("disabled add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	for _, args := range [][]string{
+		{"pipeline", "enable", "unresolved-env", "--home", home},
+		{"pipeline", "run", "unresolved-env", "--home", home},
+	} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run(args, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "gitmoot key grant MISSING --pipeline unresolved-env") {
+			t.Fatalf("%v code=%d stdout=%q stderr=%q", args, code, stdout.String(), stderr.String())
+		}
+	}
+
+	enabledSpec := writeSpec(t, "name: unresolved-enabled\nrepo: owner/repo\nstages: [{id: run, cmd: echo, env_keys: [MISSING]}]\n")
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"pipeline", "add", enabledSpec, "--enable", "--home", home}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "gitmoot key grant MISSING --pipeline unresolved-enabled") {
+		t.Fatalf("enabled add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if err := withStore(home, func(store *db.Store) error {
+		_, found, err := store.GetPipeline(context.Background(), "unresolved-enabled")
+		if err == nil && found {
+			return fmt.Errorf("unresolved enabled pipeline was persisted")
+		}
+		return err
+	}); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -327,6 +500,232 @@ func TestPipelineInjectedEnvShellE2E(t *testing.T) {
 		}
 		if bytes.Contains(data, []byte(pipelineEnvSecretA)) || bytes.Contains(data, []byte(pipelineEnvSecretB)) {
 			return fmt.Errorf("secret value persisted in log %s", path)
+		}
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+}
+
+func TestPipelineKeychainRegistryGrantsShellE2E(t *testing.T) {
+	ctx := context.Background()
+	home, paths, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	const (
+		sharedA  = "KEYCARD_SHARED_A"
+		sharedB  = "KEYCARD_SHARED_B"
+		override = "KEYCARD_OVERRIDE"
+		revoked  = "KEYCARD_REVOKED"
+		unused   = "KEYCARD_UNGRANTED"
+		oldA     = "registry-old-a-874"
+		oldB     = "registry-old-b-874"
+		rotatedB = "registry-rotated-b-874"
+		sharedO  = "registry-shared-override-874"
+		ownO     = "pipeline-own-override-874"
+		revokedV = "registry-revoked-874"
+		unusedV  = "registry-ungranted-874"
+	)
+	keychainPath := writeDefaultKeychain(t, home, fmt.Sprintf("%s=%s\n%s=%s\n%s=%s\n%s=%s\n%s=%s\n", sharedA, oldA, sharedB, oldB, override, sharedO, revoked, revokedV, unused, unusedV))
+	ownFile := writePipelineEnvFile(t, t.TempDir(), override+"="+ownO+"\n", 0o600)
+	outA := filepath.Join(t.TempDir(), "shared-a.txt")
+	outB := filepath.Join(t.TempDir(), "shared-b.txt")
+	outRevoked := filepath.Join(t.TempDir(), "revoked.txt")
+	specYAML := fmt.Sprintf(`name: keycard-e2e
+repo: owner/repo
+env_file: %q
+stages:
+  - id: a
+    cmd: |
+      test -n "$%s"; test -n "$%s"; test -z "${%s+x}"; printf '%%s|%%s' "$%s" "$%s" > %q; %s
+    env_keys: [%s, %s]
+  - id: b
+    cmd: |
+      test -n "$%s"; test -z "${%s+x}"; printf '%%s' "$%s" > %q; %s
+    env_keys: [%s]
+    needs: [a]
+  - id: revoked
+    cmd: |
+      printf '%%s' "$%s" > %q; %s
+    env_keys: [%s]
+    needs: [b]
+`, ownFile, sharedA, override, sharedB, sharedA, override, outA, pipelineShellResultCommand(t, "approved", "a"), sharedA, override, sharedB, sharedA, sharedB, outB, pipelineShellResultCommand(t, "approved", "b"), sharedB, revoked, outRevoked, pipelineShellResultCommand(t, "approved", "revoked"), revoked)
+	specFile := writeSpec(t, specYAML)
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("pipeline add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	for _, name := range []string{sharedA, sharedB, override, revoked, unused} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run([]string{"key", "add", name, "--mode", "injected", "--home", home}, &stdout, &stderr); code != 0 {
+			t.Fatalf("key add %s code=%d stdout=%q stderr=%q", name, code, stdout.String(), stderr.String())
+		}
+	}
+	for _, name := range []string{sharedA, sharedB, override, revoked} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run([]string{"key", "grant", name, "--pipeline", "keycard-e2e", "--home", home}, &stdout, &stderr); code != 0 {
+			t.Fatalf("key grant %s code=%d stdout=%q stderr=%q", name, code, stdout.String(), stderr.String())
+		}
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"pipeline", "run", "keycard-e2e", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("pipeline run code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	runID := strings.TrimSpace(stdout.String())
+	enqueue := newPipelineStageEnqueuer(store, home)
+	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Date(2026, 7, 16, 15, 0, 0, 0, time.UTC)
+	rotated := false
+	revokedAfterEnqueue := false
+	for i := 0; i < 12; i++ {
+		if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+			t.Fatalf("worker tick %d: %v", i, err)
+		}
+		if !rotated {
+			row := stageRow(t, store, runID, "a")
+			if row.JobID != "" {
+				job, err := store.GetJob(ctx, row.JobID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if job.State == string(workflow.JobSucceeded) {
+					rotatedBody := fmt.Sprintf("%s=%s\n%s=%s\n%s=%s\n%s=%s\n%s=%s\n", sharedA, oldA, sharedB, rotatedB, override, sharedO, revoked, revokedV, unused, unusedV)
+					if err := os.WriteFile(keychainPath, []byte(rotatedBody), 0o600); err != nil {
+						t.Fatal(err)
+					}
+					rotated = true
+				}
+			}
+		}
+		if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+			t.Fatalf("pipeline scan %d: %v", i, err)
+		}
+		if !revokedAfterEnqueue {
+			row := stageRow(t, store, runID, "revoked")
+			if row.JobID != "" {
+				if _, err := store.RevokeKeychainKey(ctx, db.KeychainConsumerPipeline, "keycard-e2e", revoked); err != nil {
+					t.Fatal(err)
+				}
+				revokedAfterEnqueue = true
+			}
+		}
+		run, _, err := store.GetPipelineRun(ctx, runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run.State != pipeline.RunRunning {
+			if run.State != pipeline.RunFailed {
+				t.Fatalf("run state=%s halt=%s reason=%s", run.State, run.HaltStage, run.HaltReason)
+			}
+			break
+		}
+	}
+	if !rotated || !revokedAfterEnqueue {
+		t.Fatalf("rotation=%v revoke-after-enqueue=%v", rotated, revokedAfterEnqueue)
+	}
+	if data, err := os.ReadFile(outA); err != nil || string(data) != oldA+"|"+ownO {
+		t.Fatalf("stage a output=%q err=%v", data, err)
+	}
+	if data, err := os.ReadFile(outB); err != nil || string(data) != rotatedB {
+		t.Fatalf("stage b output=%q err=%v", data, err)
+	}
+	if _, err := os.Stat(outRevoked); !os.IsNotExist(err) {
+		t.Fatalf("revoked stage executed: err=%v", err)
+	}
+
+	wantSources := map[string]map[string]string{
+		"a":       {sharedA: pipelineKeySourceShared, override: pipelineKeySourceOwn},
+		"b":       {sharedB: pipelineKeySourceShared},
+		"revoked": {revoked: pipelineKeySourceShared},
+	}
+	for stageID, names := range wantSources {
+		row := stageRow(t, store, runID, stageID)
+		job, err := store.GetJob(ctx, row.JobID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload, err := workflow.ParseJobPayload(job.Payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if payload.PipelineName != "keycard-e2e" || len(payload.PipelineKeyAccess) != len(names) {
+			t.Fatalf("stage %s payload=%+v", stageID, payload)
+		}
+		for _, access := range payload.PipelineKeyAccess {
+			if names[access.Name] != access.Source || access.Stage != stageID || access.Mode != db.KeychainModeInjected {
+				t.Fatalf("stage %s access=%+v want=%+v", stageID, payload.PipelineKeyAccess, names)
+			}
+		}
+	}
+
+	ungrantedSpec := writeSpec(t, "name: keycard-ungranted\nrepo: owner/repo\nstages: [{id: run, cmd: echo, env_keys: [KEYCARD_UNGRANTED]}]\n")
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"pipeline", "add", ungrantedSpec, "--home", home}, &stdout, &stderr); code != 0 || !strings.Contains(stderr.String(), "warning:") {
+		t.Fatalf("ungranted add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"pipeline", "run", "keycard-ungranted", "--home", home}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "gitmoot key grant KEYCARD_UNGRANTED --pipeline keycard-ungranted") {
+		t.Fatalf("ungranted run code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if runs, err := store.ListPipelineRuns(ctx, "keycard-ungranted"); err != nil || len(runs) != 0 {
+		t.Fatalf("ungranted runs=%+v err=%v", runs, err)
+	}
+
+	sentinels := []string{oldA, oldB, rotatedB, sharedO, ownO, revokedV, unusedV}
+	for _, stageID := range []string{"a", "b", "revoked"} {
+		row := stageRow(t, store, runID, stageID)
+		job, err := store.GetJob(ctx, row.JobID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, sentinel := range sentinels {
+			if strings.Contains(job.Payload, sentinel) {
+				t.Fatalf("stage %s payload persisted sentinel %q", stageID, sentinel)
+			}
+		}
+		events, err := store.ListJobEvents(ctx, row.JobID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, event := range events {
+			for _, sentinel := range sentinels {
+				if strings.Contains(event.Message, sentinel) {
+					t.Fatalf("stage %s event persisted sentinel %q", stageID, sentinel)
+				}
+			}
+		}
+	}
+	for _, persistedPath := range []string{paths.Database, paths.Database + "-wal"} {
+		data, err := os.ReadFile(persistedPath)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		for _, sentinel := range sentinels {
+			if bytes.Contains(data, []byte(sentinel)) {
+				t.Fatalf("sentinel %q persisted in %s", sentinel, persistedPath)
+			}
+		}
+	}
+	if err := filepath.WalkDir(paths.Logs, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, sentinel := range sentinels {
+			if bytes.Contains(data, []byte(sentinel)) {
+				return fmt.Errorf("sentinel %q persisted in log %s", sentinel, path)
+			}
 		}
 		return nil
 	}); err != nil && !os.IsNotExist(err) {

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -755,6 +755,13 @@ func triggerOnePipeline(ctx context.Context, store *db.Store, rec db.Pipeline, n
 	if err != nil || !found {
 		return err
 	}
+	environment, err := resolvePipelineEnvironment(ctx, store, "", spec)
+	if err != nil {
+		return err
+	}
+	if err := pipelineEnvironmentResolutionError(spec, environment.Unresolved); err != nil {
+		return err
+	}
 	payload, err := json.Marshal(map[string]string{
 		"upstream_pipeline": spec.Trigger.Pipeline,
 		"upstream_run_id":   upstreamRun.ID,
@@ -895,6 +902,16 @@ func scheduleOnePipeline(ctx context.Context, store *db.Store, rec db.Pipeline, 
 		// A stored spec that no longer parses can't be run (`pipeline add` validates,
 		// so this is defensive); advance next_due so a broken spec does not hot-loop.
 		return store.AdvancePipelineNextDue(ctx, rec.Name, nextDue)
+	}
+	environment, envErr := resolvePipelineEnvironment(ctx, store, "", spec)
+	if envErr == nil {
+		envErr = pipelineEnvironmentResolutionError(spec, environment.Unresolved)
+	}
+	if envErr != nil {
+		if advanceErr := store.AdvancePipelineNextDue(ctx, rec.Name, nextDue); advanceErr != nil {
+			return fmt.Errorf("pipeline %s environment preflight: %v (advance next_due: %w)", rec.Name, envErr, advanceErr)
+		}
+		return envErr
 	}
 	if _, err := createPipelineRun(ctx, store, rec, spec, "schedule", "{}", now); err != nil {
 		return err
@@ -1113,13 +1130,17 @@ func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enque
 		skipNativeReviewFanout := stage.Kind() == pipeline.StageKindAgentImplement && pipelineImplementHasSourceBoundReview(spec, stage.ID)
 		request := pipelineStageJobRequest(rec, stage, run, row.Attempt, upstreamContext, binding, skipNativeReviewFanout)
 		if stage.Kind() == pipeline.StageKindShell {
-			access, envErr := resolvePipelineStageEnvAccess(ctx, store, filepath.Dir(store.DatabasePath()), spec, stage)
+			access, envErr := resolvePipelineStageEnvAccess(ctx, store, "", spec, stage)
 			if envErr != nil {
 				return run, envErr
 			}
-			request.PipelineEnvFile = access.File
-			request.PipelineEnvKeys = access.Keys
-			request.PipelineEnv = access.Defaults
+			if len(access.Access) > 0 {
+				request.PipelineName = rec.Name
+				request.PipelineKeyAccess = access.Access
+				request.PipelineEnvFile = access.File
+				request.PipelineEnvKeys = access.Keys
+				request.PipelineEnv = access.Defaults
+			}
 		}
 		job, err := enqueuePipelineStageJob(ctx, store, enqueue, request, pipelineStageSourceBoundReviewRequest(request))
 		if err != nil {

--- a/internal/cli/pipeline_schedule_test.go
+++ b/internal/cli/pipeline_schedule_test.go
@@ -177,6 +177,63 @@ func TestPipelineSuccessTriggerActiveRunDefersWithoutCursorAdvance(t *testing.T)
 	}
 }
 
+func TestPipelineEnvironmentPreflightScheduleAdvancesAndTriggerRetries(t *testing.T) {
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	base := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+
+	scheduledYAML := "name: scheduled-env\nrepo: owner/repo\nstages: [{id: run, cmd: echo, env_keys: [MISSING]}]\n"
+	scheduled := db.Pipeline{
+		Name: "scheduled-env", Repo: "owner/repo", SpecYAML: scheduledYAML,
+		SpecHash: pipeline.Hash([]byte(scheduledYAML)), Interval: "1h", Enabled: true,
+	}
+	if err := store.CreateOrUpdatePipeline(ctx, scheduled); err != nil {
+		t.Fatal(err)
+	}
+	scheduled, _, _ = store.GetPipeline(ctx, scheduled.Name)
+	if err := scheduleOnePipeline(ctx, store, scheduled, base); err == nil || !strings.Contains(err.Error(), "gitmoot key grant MISSING --pipeline scheduled-env") {
+		t.Fatalf("schedule preflight error=%v", err)
+	}
+	updated, _, err := store.GetPipeline(ctx, scheduled.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !updated.NextDueAt.After(base) {
+		t.Fatalf("schedule next_due=%v, want after %v", updated.NextDueAt, base)
+	}
+	if runs := pipelineRunCount(t, store, scheduled.Name); len(runs) != 0 {
+		t.Fatalf("schedule created unusable runs: %+v", runs)
+	}
+
+	upstreamYAML := "name: upstream-env\nstages: [{id: run, cmd: echo}]\n"
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "upstream-env", SpecYAML: upstreamYAML, SpecHash: pipeline.Hash([]byte(upstreamYAML))}); err != nil {
+		t.Fatal(err)
+	}
+	triggeredYAML := "name: triggered-env\nrepo: owner/repo\ntrigger: {kind: pipeline, pipeline: upstream-env}\nstages: [{id: run, cmd: echo, env_keys: [MISSING]}]\n"
+	triggered := db.Pipeline{Name: "triggered-env", Repo: "owner/repo", SpecYAML: triggeredYAML, SpecHash: pipeline.Hash([]byte(triggeredYAML)), Enabled: true}
+	if err := store.CreateOrUpdatePipeline(ctx, triggered); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.ArmPipelineTrigger(ctx, triggered.Name, "upstream-env", base); err != nil {
+		t.Fatal(err)
+	}
+	seedPipelineRunState(t, store, "prun-upstream-env", "upstream-env", pipeline.RunSucceeded, base.Add(time.Minute))
+	triggered, _, _ = store.GetPipeline(ctx, triggered.Name)
+	if err := triggerOnePipeline(ctx, store, triggered, base.Add(2*time.Minute)); err == nil || !strings.Contains(err.Error(), "gitmoot key grant MISSING --pipeline triggered-env") {
+		t.Fatalf("trigger preflight error=%v", err)
+	}
+	state, found, err := store.GetPipelineTriggerState(ctx, triggered.Name)
+	if err != nil || !found {
+		t.Fatalf("trigger state found=%v err=%v", found, err)
+	}
+	if state.Cursor != "" {
+		t.Fatalf("trigger cursor advanced to %q", state.Cursor)
+	}
+	if runs := pipelineRunCount(t, store, triggered.Name); len(runs) != 0 {
+		t.Fatalf("trigger created unusable runs: %+v", runs)
+	}
+}
+
 func TestPipelineSuccessTriggerArmsAtAddAndReenable(t *testing.T) {
 	home := t.TempDir()
 	upstreamFile := writeSpec(t, "name: upstream\nstages: [{id: run, cmd: echo}]\n")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -29,6 +29,7 @@ var rootCommands = []command{
 	{name: "version", summary: "show Gitmoot version and build metadata", run: runVersion},
 	{name: "config", summary: "show local Gitmoot config paths", run: runConfig},
 	{name: "auth", summary: "manage runtime authentication", run: runAuth},
+	{name: "key", summary: "manage keycard registry metadata and grants", run: runKey},
 	{name: "update", summary: "check for and apply Gitmoot releases", run: runUpdate},
 	{name: "setup", summary: "register a repo and initial agent", run: runSetup},
 	{name: "repo", summary: "manage watched repositories", run: runRepo},

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -22,6 +23,9 @@ type CredentialsConfig struct {
 	GitHub                 string
 	ModelGateway           bool
 	ModelGatewayAllowHosts []string
+	// KeychainPath optionally overrides the base-home-derived
+	// ~/.config/gitmoot/keychain.env path. Empty selects that default.
+	KeychainPath string
 }
 
 // DefaultCredentialsConfig preserves direct auth and full-environment inheritance.
@@ -90,6 +94,12 @@ func LoadCredentialsConfig(paths Paths) (CredentialsConfig, error) {
 				return CredentialsConfig{}, fmt.Errorf("parse [credentials].model_gateway_allow_hosts: %w", err)
 			}
 			cfg.ModelGatewayAllowHosts = parsed
+		case "keychain_path":
+			parsed, err := parseConfigString(value)
+			if err != nil {
+				return CredentialsConfig{}, fmt.Errorf("parse [credentials].keychain_path: %w", err)
+			}
+			cfg.KeychainPath = strings.TrimSpace(parsed)
 		default:
 			// Ignore unknown keys so the section remains forward-compatible.
 		}
@@ -118,6 +128,9 @@ func validateCredentialsConfig(cfg CredentialsConfig) error {
 		if err := validateModelGatewayHost(host); err != nil {
 			return fmt.Errorf("invalid [credentials].model_gateway_allow_hosts entry %q: %w", host, err)
 		}
+	}
+	if cfg.KeychainPath != "" && !filepath.IsAbs(cfg.KeychainPath) {
+		return fmt.Errorf("[credentials].keychain_path must be absolute")
 	}
 	return nil
 }

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -39,12 +39,13 @@ env_passthrough = ["GOCACHE", "NPM_*"]
 github = "inherit"
 model_gateway = true
 model_gateway_allow_hosts = ["api.anthropic.com", "localhost"]
+keychain_path = "/tmp/gitmoot-keychain.env"
 `)
 	got, err := LoadCredentialsConfig(paths)
 	if err != nil {
 		t.Fatalf("LoadCredentialsConfig: %v", err)
 	}
-	if !got.EnvCuration || got.GitHub != CredentialsGitHubInherit || !got.ModelGateway || !reflect.DeepEqual(got.EnvPassthrough, []string{"GOCACHE", "NPM_*"}) || !reflect.DeepEqual(got.ModelGatewayAllowHosts, []string{"api.anthropic.com", "localhost"}) {
+	if !got.EnvCuration || got.GitHub != CredentialsGitHubInherit || !got.ModelGateway || !reflect.DeepEqual(got.EnvPassthrough, []string{"GOCACHE", "NPM_*"}) || !reflect.DeepEqual(got.ModelGatewayAllowHosts, []string{"api.anthropic.com", "localhost"}) || got.KeychainPath != "/tmp/gitmoot-keychain.env" {
 		t.Fatalf("unexpected config: %#v", got)
 	}
 }
@@ -65,6 +66,7 @@ func TestLoadCredentialsConfigRejectsInvalidValues(t *testing.T) {
 		{name: "gateway port", body: "model_gateway_allow_hosts = [\"api.anthropic.com:443\"]", want: "without a port"},
 		{name: "gateway wildcard", body: "model_gateway_allow_hosts = [\"*.anthropic.com\"]", want: "unsupported character"},
 		{name: "gateway space", body: "model_gateway_allow_hosts = [\"api anthropic.com\"]", want: "unsupported character"},
+		{name: "relative keychain", body: "keychain_path = \"relative.env\"", want: "must be absolute"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -83,7 +85,7 @@ func TestDefaultConfigCredentialsExampleRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	for _, line := range []string{"# [credentials]", "# env_curation = false", "# env_passthrough = []", "# github = \"deny\"", "# model_gateway = false", "# model_gateway_allow_hosts = [\"api.anthropic.com\"]"} {
+	for _, line := range []string{"# [credentials]", "# env_curation = false", "# env_passthrough = []", "# github = \"deny\"", "# model_gateway = false", "# model_gateway_allow_hosts = [\"api.anthropic.com\"]", "# keychain_path = \"\""} {
 		if !strings.Contains(string(content), line) {
 			t.Fatalf("DefaultConfig missing %q", line)
 		}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -80,6 +80,7 @@ artifact_blobs = %q
 # github = "deny"
 # model_gateway = false
 # model_gateway_allow_hosts = ["api.anthropic.com"]
+# keychain_path = "" # default: <base-home>/.config/gitmoot/keychain.env
 
 [parallel_sessions]
 same_session = "fork_temp_session"

--- a/internal/db/keychain.go
+++ b/internal/db/keychain.go
@@ -1,0 +1,261 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	KeychainModeInjected = "injected"
+	// Proxied is registry metadata only in this phase. Future work may compose it
+	// with credgw's lease model; pipeline grants deliberately refuse it today.
+	KeychainModeProxied      = "proxied"
+	KeychainConsumerPipeline = "pipeline"
+)
+
+var (
+	ErrKeychainKeyNotFound      = errors.New("keychain key not found")
+	ErrKeychainConsumerNotFound = errors.New("keychain consumer not found")
+	ErrKeychainProxiedGrant     = errors.New("proxied keys cannot be granted to pipelines")
+	ErrKeychainKeyHasGrants     = errors.New("keychain key still has grants")
+)
+
+// KeychainKey is value-free registry metadata. Credential bytes never enter
+// SQLite; callers load them from the separately validated keychain file.
+type KeychainKey struct {
+	Name      string `json:"name"`
+	Mode      string `json:"mode"`
+	CreatedAt string `json:"created_at"`
+}
+
+// KeychainGrant authorizes one named consumer to use one registered key.
+// Pipeline is the only accepted consumer kind in this phase.
+type KeychainGrant struct {
+	ConsumerKind string `json:"consumer_kind"`
+	ConsumerID   string `json:"consumer_id"`
+	KeyName      string `json:"key_name"`
+	CreatedAt    string `json:"created_at"`
+}
+
+func validKeychainMode(mode string) bool {
+	return mode == KeychainModeInjected || mode == KeychainModeProxied
+}
+
+func (s *Store) AddKeychainKey(ctx context.Context, name, mode string) (KeychainKey, error) {
+	name = strings.TrimSpace(name)
+	mode = strings.TrimSpace(mode)
+	if name == "" {
+		return KeychainKey{}, errors.New("keychain key name is required")
+	}
+	if !validKeychainMode(mode) {
+		return KeychainKey{}, fmt.Errorf("invalid keychain mode %q; use injected or proxied", mode)
+	}
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO keychain_keys(name, mode) VALUES (?, ?)`, name, mode); err != nil {
+		return KeychainKey{}, err
+	}
+	key, found, err := s.GetKeychainKey(ctx, name)
+	if err != nil {
+		return KeychainKey{}, err
+	}
+	if !found {
+		return KeychainKey{}, errors.New("registered keychain key disappeared")
+	}
+	return key, nil
+}
+
+func (s *Store) GetKeychainKey(ctx context.Context, name string) (KeychainKey, bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return KeychainKey{}, false, errors.New("keychain key name is required")
+	}
+	var key KeychainKey
+	err := s.db.QueryRowContext(ctx, `SELECT name, mode, created_at FROM keychain_keys WHERE name = ?`, name).
+		Scan(&key.Name, &key.Mode, &key.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return KeychainKey{}, false, nil
+	}
+	return key, err == nil, err
+}
+
+func (s *Store) ListKeychainKeys(ctx context.Context) ([]KeychainKey, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT name, mode, created_at FROM keychain_keys ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var keys []KeychainKey
+	for rows.Next() {
+		var key KeychainKey
+		if err := rows.Scan(&key.Name, &key.Mode, &key.CreatedAt); err != nil {
+			return nil, err
+		}
+		keys = append(keys, key)
+	}
+	return keys, rows.Err()
+}
+
+func (s *Store) ListKeychainGrants(ctx context.Context, keyName string) ([]KeychainGrant, error) {
+	query := `SELECT consumer_kind, consumer_id, key_name, created_at FROM keychain_grants`
+	var args []any
+	if keyName = strings.TrimSpace(keyName); keyName != "" {
+		query += ` WHERE key_name = ?`
+		args = append(args, keyName)
+	}
+	query += ` ORDER BY key_name, consumer_kind, consumer_id`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var grants []KeychainGrant
+	for rows.Next() {
+		var grant KeychainGrant
+		if err := rows.Scan(&grant.ConsumerKind, &grant.ConsumerID, &grant.KeyName, &grant.CreatedAt); err != nil {
+			return nil, err
+		}
+		grants = append(grants, grant)
+	}
+	return grants, rows.Err()
+}
+
+func (s *Store) ListKeychainGrantsForConsumer(ctx context.Context, kind, id string) ([]KeychainGrant, error) {
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	if kind != KeychainConsumerPipeline || id == "" {
+		return nil, errors.New("keychain consumer must be a named pipeline")
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT consumer_kind, consumer_id, key_name, created_at
+		FROM keychain_grants WHERE consumer_kind = ? AND consumer_id = ? ORDER BY key_name`, kind, id)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var grants []KeychainGrant
+	for rows.Next() {
+		var grant KeychainGrant
+		if err := rows.Scan(&grant.ConsumerKind, &grant.ConsumerID, &grant.KeyName, &grant.CreatedAt); err != nil {
+			return nil, err
+		}
+		grants = append(grants, grant)
+	}
+	return grants, rows.Err()
+}
+
+// GetGrantedKey checks grant existence and current registry mode in one query.
+// Delivery uses this immediately before loading the value to fail closed after
+// a revoke or metadata change.
+func (s *Store) GetGrantedKey(ctx context.Context, kind, id, name string) (KeychainKey, bool, error) {
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	name = strings.TrimSpace(name)
+	if kind != KeychainConsumerPipeline || id == "" || name == "" {
+		return KeychainKey{}, false, errors.New("keychain grant requires pipeline and key names")
+	}
+	var key KeychainKey
+	err := s.db.QueryRowContext(ctx, `SELECT k.name, k.mode, k.created_at
+		FROM keychain_keys k
+		JOIN keychain_grants g ON g.key_name = k.name
+		WHERE g.consumer_kind = ? AND g.consumer_id = ? AND g.key_name = ?`, kind, id, name).
+		Scan(&key.Name, &key.Mode, &key.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return KeychainKey{}, false, nil
+	}
+	return key, err == nil, err
+}
+
+func (s *Store) GrantKeychainKey(ctx context.Context, kind, id, name string) (bool, error) {
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	name = strings.TrimSpace(name)
+	if kind != KeychainConsumerPipeline || id == "" || name == "" {
+		return false, errors.New("keychain grant requires a named pipeline and key")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	var exists int
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM pipelines WHERE name = ?`, id).Scan(&exists); err != nil {
+		return false, err
+	}
+	if exists == 0 {
+		return false, ErrKeychainConsumerNotFound
+	}
+	var mode string
+	if err := tx.QueryRowContext(ctx, `SELECT mode FROM keychain_keys WHERE name = ?`, name).Scan(&mode); errors.Is(err, sql.ErrNoRows) {
+		return false, ErrKeychainKeyNotFound
+	} else if err != nil {
+		return false, err
+	}
+	if mode != KeychainModeInjected {
+		return false, ErrKeychainProxiedGrant
+	}
+	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO keychain_grants(consumer_kind, consumer_id, key_name) VALUES (?, ?, ?)`, kind, id, name)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return affected == 1, nil
+}
+
+func (s *Store) RevokeKeychainKey(ctx context.Context, kind, id, name string) (bool, error) {
+	kind = strings.TrimSpace(kind)
+	id = strings.TrimSpace(id)
+	name = strings.TrimSpace(name)
+	if kind != KeychainConsumerPipeline || id == "" || name == "" {
+		return false, errors.New("keychain revoke requires a named pipeline and key")
+	}
+	result, err := s.db.ExecContext(ctx, `DELETE FROM keychain_grants WHERE consumer_kind = ? AND consumer_id = ? AND key_name = ?`, kind, id, name)
+	if err != nil {
+		return false, err
+	}
+	affected, err := result.RowsAffected()
+	return affected == 1, err
+}
+
+// RemoveKeychainKey removes metadata only. The operator-owned keychain file is
+// deliberately untouched. Forced removal deletes grants in the same transaction.
+func (s *Store) RemoveKeychainKey(ctx context.Context, name string, force bool) (removed bool, grantsRemoved int, err error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false, 0, errors.New("keychain key name is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, 0, err
+	}
+	defer tx.Rollback()
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM keychain_grants WHERE key_name = ?`, name).Scan(&grantsRemoved); err != nil {
+		return false, 0, err
+	}
+	if grantsRemoved > 0 && !force {
+		return false, grantsRemoved, ErrKeychainKeyHasGrants
+	}
+	if force {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM keychain_grants WHERE key_name = ?`, name); err != nil {
+			return false, 0, err
+		}
+	}
+	result, err := tx.ExecContext(ctx, `DELETE FROM keychain_keys WHERE name = ?`, name)
+	if err != nil {
+		return false, 0, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, 0, err
+	}
+	return affected == 1, grantsRemoved, nil
+}

--- a/internal/db/keychain_test.go
+++ b/internal/db/keychain_test.go
@@ -1,0 +1,122 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestKeychainMigrationAppliesToExistingDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	legacy, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	version := 0
+	for i, migration := range migrations {
+		if strings.Contains(migration, "CREATE TABLE keychain_keys") {
+			version = i + 1
+			break
+		}
+	}
+	if version == 0 {
+		t.Fatal("keychain migration not found")
+	}
+	if _, err := legacy.db.Exec(`DROP TABLE keychain_grants; DROP TABLE keychain_keys; DELETE FROM schema_migrations WHERE version = ?`, version); err != nil {
+		t.Fatalf("rewind keychain migration: %v", err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open existing database: %v", err)
+	}
+	defer store.Close()
+	for _, table := range []string{"keychain_keys", "keychain_grants"} {
+		if ok, err := store.HasTable(context.Background(), table); err != nil || !ok {
+			t.Fatalf("table %s ok=%v err=%v", table, ok, err)
+		}
+	}
+}
+
+func TestKeychainCRUDGrantIdempotenceAndForcedCleanup(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	if err := store.CreateOrUpdatePipeline(ctx, samplePipeline()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddKeychainKey(ctx, "BAD", "other"); err == nil {
+		t.Fatal("invalid mode was accepted")
+	}
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO keychain_keys(name, mode) VALUES ('RAW_BAD', 'other')`); err == nil {
+		t.Fatal("migration CHECK accepted an invalid mode")
+	}
+	injected, err := store.AddKeychainKey(ctx, "API_TOKEN", KeychainModeInjected)
+	if err != nil || injected.Name != "API_TOKEN" || injected.Mode != KeychainModeInjected || injected.CreatedAt == "" {
+		t.Fatalf("AddKeychainKey injected = %+v err=%v", injected, err)
+	}
+	if _, err := store.AddKeychainKey(ctx, "API_TOKEN", KeychainModeInjected); err == nil {
+		t.Fatal("duplicate key name was accepted")
+	}
+	if _, err := store.AddKeychainKey(ctx, "MODEL_TOKEN", KeychainModeProxied); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "MODEL_TOKEN"); changed || !errors.Is(err, ErrKeychainProxiedGrant) {
+		t.Fatalf("proxied grant = changed %v err %v", changed, err)
+	}
+	changed, err := store.GrantKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "API_TOKEN")
+	if err != nil || !changed {
+		t.Fatalf("first grant = changed %v err %v", changed, err)
+	}
+	changed, err = store.GrantKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "API_TOKEN")
+	if err != nil || changed {
+		t.Fatalf("duplicate grant = changed %v err %v", changed, err)
+	}
+	granted, found, err := store.GetGrantedKey(ctx, KeychainConsumerPipeline, "deploy-flow", "API_TOKEN")
+	if err != nil || !found || granted.Mode != KeychainModeInjected {
+		t.Fatalf("GetGrantedKey = %+v found=%v err=%v", granted, found, err)
+	}
+	if removed, count, err := store.RemoveKeychainKey(ctx, "API_TOKEN", false); removed || count != 1 || !errors.Is(err, ErrKeychainKeyHasGrants) {
+		t.Fatalf("guarded remove = removed %v count %d err %v", removed, count, err)
+	}
+	removed, count, err := store.RemoveKeychainKey(ctx, "API_TOKEN", true)
+	if err != nil || !removed || count != 1 {
+		t.Fatalf("forced remove = removed %v count %d err %v", removed, count, err)
+	}
+	if grants, err := store.ListKeychainGrants(ctx, "API_TOKEN"); err != nil || len(grants) != 0 {
+		t.Fatalf("grants after force = %+v err=%v", grants, err)
+	}
+	if changed, err := store.RevokeKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "API_TOKEN"); err != nil || changed {
+		t.Fatalf("idempotent revoke = changed %v err %v", changed, err)
+	}
+	keys, err := store.ListKeychainKeys(ctx)
+	if err != nil || len(keys) != 1 || keys[0].Name != "MODEL_TOKEN" {
+		t.Fatalf("keys = %+v err=%v", keys, err)
+	}
+}
+
+func TestDeletePipelineCleansKeychainGrantsInSameTransaction(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	if err := store.CreateOrUpdatePipeline(ctx, samplePipeline()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddKeychainKey(ctx, "API_TOKEN", KeychainModeInjected); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "API_TOKEN"); err != nil || !changed {
+		t.Fatalf("grant = changed %v err %v", changed, err)
+	}
+	if removed, err := store.DeletePipeline(ctx, "deploy-flow"); err != nil || !removed {
+		t.Fatalf("DeletePipeline = removed %v err %v", removed, err)
+	}
+	if grants, err := store.ListKeychainGrants(ctx, "API_TOKEN"); err != nil || len(grants) != 0 {
+		t.Fatalf("pipeline grants after delete = %+v err=%v", grants, err)
+	}
+	if _, found, err := store.GetKeychainKey(ctx, "API_TOKEN"); err != nil || !found {
+		t.Fatalf("key metadata removed with pipeline: found=%v err=%v", found, err)
+	}
+}

--- a/internal/db/pipeline.go
+++ b/internal/db/pipeline.go
@@ -162,21 +162,32 @@ func (s *Store) SetPipelineTriggerBinding(ctx context.Context, name, binding str
 	return nil
 }
 
-// DeletePipeline removes a pipeline row, returning whether a row was deleted.
-// It does not touch the pipeline's runner agent or any run rows — the CLI removes
-// the runner agent best-effort, and run/stage rows live in separate tables added
-// by the run/advancer step.
+// DeletePipeline removes a pipeline row and its keychain grants atomically,
+// returning whether a pipeline row was deleted. It does not touch the pipeline's
+// runner agent or any run rows — the CLI removes the runner agent best-effort,
+// and run/stage rows live in separate tables added by the run/advancer step.
 func (s *Store) DeletePipeline(ctx context.Context, name string) (bool, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return false, errors.New("pipeline name is required")
 	}
-	result, err := s.db.ExecContext(ctx, `DELETE FROM pipelines WHERE name = ?`, name)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM keychain_grants WHERE consumer_kind = 'pipeline' AND consumer_id = ?`, name); err != nil {
+		return false, err
+	}
+	result, err := tx.ExecContext(ctx, `DELETE FROM pipelines WHERE name = ?`, name)
 	if err != nil {
 		return false, err
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
 		return false, err
 	}
 	return affected > 0, nil

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -9171,4 +9171,25 @@ CREATE UNIQUE INDEX idx_workflow_notes_daemon_auto
 	ON workflow_notes(workflow_id, substr(body, 1, instr(body, ']')))
 	WHERE author = 'daemon' AND substr(body, 1, 9) = '[auto:pr:';
 	`,
+	// #874 named keycard registry metadata. Credential values remain exclusively
+	// in the operator-owned keychain.env file; these tables record only delivery
+	// mode and deny-by-default consumer grants. Foreign-key enforcement is not
+	// enabled globally, so key and pipeline deletion clean grants explicitly in
+	// the same transaction instead of relying on cascading constraints.
+	`
+CREATE TABLE keychain_keys (
+	name TEXT PRIMARY KEY,
+	mode TEXT NOT NULL CHECK(mode IN ('injected', 'proxied')),
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE keychain_grants (
+	consumer_kind TEXT NOT NULL,
+	consumer_id TEXT NOT NULL,
+	key_name TEXT NOT NULL,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (consumer_kind, consumer_id, key_name)
+);
+CREATE INDEX idx_keychain_grants_key_name ON keychain_grants(key_name);
+	`,
 }

--- a/internal/db/workflow_store_test.go
+++ b/internal/db/workflow_store_test.go
@@ -477,7 +477,17 @@ func TestWorkflowDescriptionMigrationSeedsLegacySummary(t *testing.T) {
 	}
 	defer raw.Close()
 	store := &Store{db: raw}
-	for version, migration := range migrations[:len(migrations)-2] {
+	descriptionMigration := -1
+	for i, migration := range migrations {
+		if strings.Contains(migration, "ADD COLUMN description") {
+			descriptionMigration = i
+			break
+		}
+	}
+	if descriptionMigration < 0 {
+		t.Fatal("workflow description migration not found")
+	}
+	for version, migration := range migrations[:descriptionMigration] {
 		if err := store.applyMigration(ctx, version+1, migration); err != nil {
 			t.Fatalf("applyMigration(%d): %v", version+1, err)
 		}
@@ -485,8 +495,8 @@ func TestWorkflowDescriptionMigrationSeedsLegacySummary(t *testing.T) {
 	if _, err := raw.ExecContext(ctx, `INSERT INTO workflow_meta(workflow_id, summary) VALUES ('release/legacy', 'Legacy human intent')`); err != nil {
 		t.Fatalf("insert legacy meta: %v", err)
 	}
-	for offset, migration := range migrations[len(migrations)-2:] {
-		if err := store.applyMigration(ctx, len(migrations)-1+offset, migration); err != nil {
+	for offset, migration := range migrations[descriptionMigration:] {
+		if err := store.applyMigration(ctx, descriptionMigration+1+offset, migration); err != nil {
 			t.Fatalf("apply new workflow migration %d: %v", offset, err)
 		}
 	}

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -74,8 +74,9 @@ type Spec struct {
 	// Description is optional display metadata explaining a pipeline's purpose.
 	// It is shown verbatim on detail surfaces and has no execution semantics.
 	Description string `yaml:"description,omitempty"`
-	// EnvFile is an optional operator-owned 0600 file containing secret
-	// KEY=VALUE entries. Shell stages opt into individual names through EnvKeys.
+	// EnvFile is an optional pipeline-owned 0600 file containing secret KEY=VALUE
+	// entries. Shell stages opt into these or separately granted shared registry
+	// names through EnvKeys.
 	EnvFile string `yaml:"env_file,omitempty"`
 	// Env contains non-secret defaults. Entries are delivered only when a shell
 	// stage explicitly names them in EnvKeys.
@@ -186,7 +187,8 @@ type Stage struct {
 	// Retry is how many times a failed stage may be re-attempted (>= 0).
 	Retry int `yaml:"retry,omitempty"`
 	// EnvKeys is the deny-by-default list of environment names (or glob selectors)
-	// made available to this shell stage. Agent and gate stages may not request it.
+	// made available to this shell stage from own, shared, or default sources.
+	// Agent and gate grants are deliberately deferred to a later keycard phase.
 	EnvKeys []string `yaml:"env_keys,omitempty"`
 	// SuccessDecisions optionally overrides the pipeline default for this stage.
 	SuccessDecisions []string `yaml:"success_decisions,omitempty"`

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -120,6 +120,16 @@ type Mailbox struct {
 	produceCheckTimeout time.Duration
 }
 
+// PipelineKeyAccess is the persisted, names-only authorization for one shell
+// stage environment name. Source is pinned at enqueue so delivery never changes
+// audit meaning by falling through to another source.
+type PipelineKeyAccess struct {
+	Stage  string `json:"stage"`
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Mode   string `json:"mode"`
+}
+
 type JobRequest struct {
 	ID           string
 	Agent        string
@@ -189,14 +199,16 @@ type JobRequest struct {
 	// KEY=value entries to a shell runtime job. It is empty for every non-pipeline
 	// and non-shell job.
 	ShellEnv []string
-	// PipelineEnvFile and PipelineEnvKeys are the names-only #968 injected-env
-	// authority for a pipeline shell stage. PipelineEnv contains only selected
-	// inline NON-secret defaults; secret values are loaded at delivery and never
-	// enter the persisted payload. A future keycard registry/grant resolver can
-	// feed this same delivery seam without changing the shell adapter.
-	PipelineEnvFile string
-	PipelineEnvKeys []string
-	PipelineEnv     map[string]string
+	// PipelineName and PipelineKeyAccess are the names-only keycard authority for
+	// a pipeline shell stage. PipelineEnvFile/PipelineEnvKeys remain for in-flight
+	// jobs enqueued before registry/grant resolution shipped. PipelineEnv contains
+	// only selected inline NON-secret defaults; secret values are loaded at
+	// delivery and never enter the persisted payload.
+	PipelineName      string
+	PipelineKeyAccess []PipelineKeyAccess
+	PipelineEnvFile   string
+	PipelineEnvKeys   []string
+	PipelineEnv       map[string]string
 	// ShellUpstreamContext carries the persisted JSON CONTENT supplied to a
 	// dependent pipeline shell stage. Delivery writes it to a fresh temporary
 	// file; paths are deliberately never persisted. Additive/omitempty: empty
@@ -279,37 +291,39 @@ type JobPayload struct {
 	// without it serializes byte-identically. The terminal cleanup keys off it to
 	// dispose top-level read-only worktrees that the DelegationID-gated read-only
 	// delegation cleanup would otherwise orphan.
-	ReadOnlyWorktree       bool              `json:"read_only_worktree,omitempty"`
-	TemplateID             string            `json:"template_id,omitempty"`
-	TemplateResolvedCommit string            `json:"template_resolved_commit,omitempty"`
-	TemplateContent        string            `json:"template_content,omitempty"`
-	OriginalAgent          string            `json:"original_agent,omitempty"`
-	DelegatedAgent         string            `json:"delegated_agent,omitempty"`
-	DelegationReason       string            `json:"delegation_reason,omitempty"`
-	RecentDelegationHashes []string          `json:"recent_delegation_hashes,omitempty"`
-	DelegationRepeatCount  int               `json:"delegation_repeat_count,omitempty"`
-	NonProgressStreak      int               `json:"non_progress_streak,omitempty"`
-	LastProgressDigest     string            `json:"last_progress_digest,omitempty"`
-	VerifyAttempt          int               `json:"verify_attempt,omitempty"`
-	DelegationFinalize     bool              `json:"delegation_finalize,omitempty"`
-	Model                  string            `json:"model,omitempty"`
-	Effort                 string            `json:"effort,omitempty"`
-	WorkflowID             string            `json:"workflow_id,omitempty"`
-	RuntimeOverride        string            `json:"runtime_override,omitempty"`
-	RuntimeOverrideRef     string            `json:"runtime_override_ref,omitempty"`
-	ShellEnv               []string          `json:"shell_env,omitempty"`
-	PipelineEnvFile        string            `json:"pipeline_env_file,omitempty"`
-	PipelineEnvKeys        []string          `json:"pipeline_env_keys,omitempty"`
-	PipelineEnv            map[string]string `json:"pipeline_env,omitempty"`
-	ShellUpstreamContext   string            `json:"shell_upstream_context,omitempty"`
-	Phase                  string            `json:"phase,omitempty"`
-	Cockpit                bool              `json:"cockpit,omitempty"`
-	CockpitSession         string            `json:"cockpit_session,omitempty"`
-	CockpitPaneKey         string            `json:"cockpit_pane_key,omitempty"`
-	SkipNativeReviewFanout bool              `json:"skip_native_review_fanout,omitempty"`
-	ValidatedPullRequest   bool              `json:"validated_pull_request,omitempty"`
-	Ephemeral              *EphemeralSpec    `json:"ephemeral,omitempty"`
-	HumanAnswer            string            `json:"human_answer,omitempty"`
+	ReadOnlyWorktree       bool                `json:"read_only_worktree,omitempty"`
+	TemplateID             string              `json:"template_id,omitempty"`
+	TemplateResolvedCommit string              `json:"template_resolved_commit,omitempty"`
+	TemplateContent        string              `json:"template_content,omitempty"`
+	OriginalAgent          string              `json:"original_agent,omitempty"`
+	DelegatedAgent         string              `json:"delegated_agent,omitempty"`
+	DelegationReason       string              `json:"delegation_reason,omitempty"`
+	RecentDelegationHashes []string            `json:"recent_delegation_hashes,omitempty"`
+	DelegationRepeatCount  int                 `json:"delegation_repeat_count,omitempty"`
+	NonProgressStreak      int                 `json:"non_progress_streak,omitempty"`
+	LastProgressDigest     string              `json:"last_progress_digest,omitempty"`
+	VerifyAttempt          int                 `json:"verify_attempt,omitempty"`
+	DelegationFinalize     bool                `json:"delegation_finalize,omitempty"`
+	Model                  string              `json:"model,omitempty"`
+	Effort                 string              `json:"effort,omitempty"`
+	WorkflowID             string              `json:"workflow_id,omitempty"`
+	RuntimeOverride        string              `json:"runtime_override,omitempty"`
+	RuntimeOverrideRef     string              `json:"runtime_override_ref,omitempty"`
+	ShellEnv               []string            `json:"shell_env,omitempty"`
+	PipelineName           string              `json:"pipeline_name,omitempty"`
+	PipelineKeyAccess      []PipelineKeyAccess `json:"pipeline_key_access,omitempty"`
+	PipelineEnvFile        string              `json:"pipeline_env_file,omitempty"`
+	PipelineEnvKeys        []string            `json:"pipeline_env_keys,omitempty"`
+	PipelineEnv            map[string]string   `json:"pipeline_env,omitempty"`
+	ShellUpstreamContext   string              `json:"shell_upstream_context,omitempty"`
+	Phase                  string              `json:"phase,omitempty"`
+	Cockpit                bool                `json:"cockpit,omitempty"`
+	CockpitSession         string              `json:"cockpit_session,omitempty"`
+	CockpitPaneKey         string              `json:"cockpit_pane_key,omitempty"`
+	SkipNativeReviewFanout bool                `json:"skip_native_review_fanout,omitempty"`
+	ValidatedPullRequest   bool                `json:"validated_pull_request,omitempty"`
+	Ephemeral              *EphemeralSpec      `json:"ephemeral,omitempty"`
+	HumanAnswer            string              `json:"human_answer,omitempty"`
 	// ThreadID / ChatMessageID back-link a chat-promoted job (#534) to its origin
 	// message. Additive/omitempty: a non-chat job serializes byte-identically.
 	ThreadID      string `json:"thread_id,omitempty"`
@@ -446,6 +460,8 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		RuntimeOverride:        strings.TrimSpace(request.RuntimeOverride),
 		RuntimeOverrideRef:     strings.TrimSpace(request.RuntimeOverrideRef),
 		ShellEnv:               append([]string(nil), request.ShellEnv...),
+		PipelineName:           strings.TrimSpace(request.PipelineName),
+		PipelineKeyAccess:      compactPipelineKeyAccess(request.PipelineKeyAccess),
 		PipelineEnvFile:        strings.TrimSpace(request.PipelineEnvFile),
 		PipelineEnvKeys:        compactStrings(request.PipelineEnvKeys),
 		PipelineEnv:            request.PipelineEnv,
@@ -1484,4 +1500,19 @@ func compactStrings(values []string) []string {
 		}
 	}
 	return compacted
+}
+
+func compactPipelineKeyAccess(values []PipelineKeyAccess) []PipelineKeyAccess {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]PipelineKeyAccess, 0, len(values))
+	for _, value := range values {
+		value.Stage = strings.TrimSpace(value.Stage)
+		value.Name = strings.TrimSpace(value.Name)
+		value.Source = strings.TrimSpace(value.Source)
+		value.Mode = strings.TrimSpace(value.Mode)
+		out = append(out, value)
+	}
+	return out
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -141,6 +141,26 @@ fallback. The first adapter build imports legacy `daemon-runtime.env` when the
 new file is absent, otherwise it seeds from ambient managed variables once;
 existing authoritative files are never overwritten.
 
+Shared injected pipeline keys use a separate operator-owned keychain file,
+defaulting to `<base-home>/.config/gitmoot/keychain.env` (override with
+`[credentials] keychain_path`). The CLI manages names and grants only; edit the
+`0600` file at the path it prints to set or rotate values:
+
+```sh
+gitmoot key path [--json]
+gitmoot key add <NAME> --mode injected|proxied [--json]
+gitmoot key list [--json]
+gitmoot key show <NAME> [--json]
+gitmoot key grant <NAME> --pipeline <pipeline> [--json]
+gitmoot key revoke <NAME> --pipeline <pipeline> [--json]
+gitmoot key rm <NAME> [--force] [--json]
+```
+
+There is deliberately no value flag, stdin value, or value-derived hash.
+`proxied` metadata is reserved for future gateway composition and cannot be
+granted to a pipeline. `rm --force` removes metadata and grants but leaves the
+file entry untouched.
+
 Runtime-child environment curation is off by default. Enable it in
 `config.toml`:
 
@@ -151,6 +171,7 @@ env_passthrough = ["GOCACHE", "NPM_*"]
 github = "deny"
 model_gateway = false
 model_gateway_allow_hosts = ["api.anthropic.com"]
+# keychain_path = "/absolute/operator/path/keychain.env"
 ```
 
 Set `model_gateway = true` to opt Claude into the daemon-owned loopback model
@@ -2773,19 +2794,24 @@ its `needs` stages' result summaries are prepended to the prompt, and a repo-bou
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
 
-Shell stages can opt into pipeline-owned environment values with `env_keys`.
-`env_file` must be an absolute, operator-owned regular file with mode exactly
-`0600`, outside the Gitmoot home and every managed checkout; inline `env` is for
-non-secret defaults. Exact names and globs such as `REDDIT_*` are expanded at
-enqueue, and every selector must resolve. Agent/gate stages cannot set
-`env_keys`; a shell stage with no list gets nothing. The file is read again at
-delivery, so rotation applies without a daemon restart. File values beat inline
-defaults, selected values beat inherited daemon environment, and reserved
-`GITMOOT_*` names are rejected while Gitmoot's internal entries remain final.
-The job payload audits only the env-file path and expanded key names, never file
-values. This injected mode exposes an opaque key to that shell process; it is
-separate from the Claude model gateway, whose proxied credential remains hidden
-from the child.
+Shell stages can opt into pipeline-owned or granted shared environment values
+with `env_keys`. Source files must be absolute, operator-owned regular files
+with mode exactly `0600`, outside the Gitmoot home and every managed checkout;
+inline `env` is for non-secret defaults. Agent/gate stages cannot set
+`env_keys`; a shell stage with no list gets nothing. Resolution is own
+`env_file`, then a shared `injected` key granted with `gitmoot key grant`, then
+inline default. Registered but ungranted names do not match exact or glob
+selectors. Structural errors always fail add; unresolved names warn only while
+the pipeline remains disabled, then hard-fail add-with-enable, enable, manual
+run, and scheduled/triggered preflight.
+
+Sources are revalidated and reread at delivery, so rotation applies without a
+daemon restart. Each payload audits `PipelineName` and names-only
+`PipelineKeyAccess` rows `{stage,name,source,mode}`; `pipeline show --json`
+exposes the same projection. A shared grant is rechecked immediately before
+delivery: revocation fails closed and never switches to another source. Gitmoot
+internal `GITMOOT_*` entries remain final. This injected mode exposes the value
+to that shell process and stays separate from the Claude model gateway.
 
 For a non-empty run payload, every agent stage (including roots) receives a
 dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -171,16 +171,22 @@ treat `pipeline add` from an untrusted source as arbitrary code execution.
 The spec is stored **verbatim** (the raw YAML bytes plus a content hash), so a spec
 that embeds private hostnames, filesystem paths, tokens-by-reference, or repo names
 is retained in the local store as-is — the same private-repo caveat as a captured
-agent template or a published template. Do not register a spec carrying a secret in
-a stage command or inline `env`. Use an operator-owned `0600` `env_file` plus the
-shell stage's `env_keys` allowlist instead.
+agent template or a published template. Do not register a spec carrying a secret
+in a stage command or inline `env`. Use an operator-owned `0600` pipeline
+`env_file`, or register a name from the separate `gitmoot key path` keychain and
+grant it to the pipeline, then select it with the shell stage's `env_keys`
+allowlist.
 
-Pipeline `env_file` injection (#968) is deny-by-default but deliberately
-**opaque**: only a shell stage's selected `env_keys` are injected, yet that
-process receives the real values and can print or transmit them. Gitmoot stores
-only the file path and expanded names in the job audit. This is distinct from
-the Claude keycard/model gateway, where the child receives a placeholder and the
-real model credential stays daemon-side.
+Pipeline injection is deny-by-default but deliberately **opaque**: only a shell
+stage's selected own or granted shared `env_keys` are injected, yet that process
+receives the real values and can print or transmit them. Gitmoot stores only
+`{stage,name,source,mode}` audit rows, never values or hashes. Keychain and
+pipeline files are revalidated as owner-only `0600` files outside Gitmoot state
+and managed checkouts. A shared grant is rechecked at delivery, so revocation
+fails closed without source fallback. `proxied` registry entries cannot be
+granted to pipelines in this phase. This is distinct from the Claude model
+gateway, where the child receives a placeholder and the real model credential
+stays daemon-side.
 
 ## External Contracts
 

--- a/website/docs/reference/credentials.md
+++ b/website/docs/reference/credentials.md
@@ -11,6 +11,7 @@ env_passthrough = ["GOCACHE", "NPM_*"]
 github = "deny"
 model_gateway = false
 model_gateway_allow_hosts = ["api.anthropic.com"]
+# keychain_path = "/absolute/operator/path/keychain.env"
 ```
 
 `env_curation = false` preserves the historical behavior: runtime commands
@@ -38,6 +39,37 @@ from ambient managed variables once. Existing files are never overwritten.
 For systemd deployments, keep `daemon.env` for operational values such as
 `PATH`; do not duplicate Claude secrets there after bootstrap.
 
+## Injected key registry and grants
+
+The shared injected-key source is an operator-owned env file. Its default path
+is `<base-home>/.config/gitmoot/keychain.env`; `gitmoot key path` prints the
+resolved path and validation status. `[credentials] keychain_path` can select a
+different absolute path. The file must be regular, owned by the current uid,
+mode exactly `0600`, and outside the Gitmoot home and managed checkouts. Gitmoot
+revalidates and rereads it at every registration, preflight, and delivery, so an
+atomic rewrite rotates values without a daemon restart.
+
+The `key` commands manage names, modes, and grants only. They never accept or
+print values:
+
+```sh
+gitmoot key path
+gitmoot key add SOURCE_API_TOKEN --mode injected
+gitmoot key grant SOURCE_API_TOKEN --pipeline nightly-sync
+gitmoot key list --json
+gitmoot key show SOURCE_API_TOKEN
+gitmoot key revoke SOURCE_API_TOKEN --pipeline nightly-sync
+gitmoot key rm SOURCE_API_TOKEN --force
+```
+
+`rm` removes registry metadata and grants, not the operator's file entry.
+`proxied` mode is reserved for future gateway composition and cannot be granted
+to a pipeline. Pipeline shell stages may request granted `injected` names with
+`env_keys`; agent and gate stages remain ineligible. Resolution is Gitmoot's
+reserved `GITMOOT_*` namespace, then the pipeline's own `env_file`, then a
+granted shared key, then inline non-secret `env`. Registered but ungranted names
+are not visible to exact or glob selectors.
+
 ## Claude model gateway
 
 `model_gateway = true` opts Claude deliveries into a daemon-owned loopback
@@ -58,11 +90,12 @@ credential and ignore the placeholder — the gateway would then `401` the
 delivery (#936). The mirror never contains a credential; the operator's real
 config is only read, never modified.
 
-Pipeline `env_file` + per-stage `env_keys` are a separate **injected** mode for
-opaque API credentials whose shell script must present the real value. Gitmoot
-scopes those values to selected shell stages and audits names only, but the
-selected process necessarily receives the real credential. Enabling or using
-this feature does not alter the Claude gateway or its placeholder flow.
+Pipeline-owned `env_file` values and granted shared keychain values are a
+separate **injected** mode for opaque API credentials whose shell script must
+present the real value. Gitmoot scopes those values to selected shell stages
+and audits names, sources, and modes only, but the selected process necessarily
+receives the real credential. This does not alter the Claude gateway or its
+placeholder flow.
 
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -84,7 +84,14 @@ editing the file later never mutates an in-flight run.
 
 ### Give each shell stage only the keys it needs
 
-Declare secrets in a pipeline-owned file and select them per shell stage:
+Declare secrets in a pipeline-owned file or the shared keychain and select them
+per shell stage. The key CLI manages names and grants, never values:
+
+```sh
+gitmoot key path
+gitmoot key add REDDIT_CLIENT_SECRET --mode injected
+gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
+```
 
 ```yaml
 env_file: /root/.config/trend-scout/env
@@ -101,18 +108,21 @@ stages:
 
 No `env_keys` means no injected values. Exact names and globs expand only for
 shell stages; agent and gate stages cannot request them. At registration,
-Gitmoot requires the absolute `env_file` to be operator-owned, mode exactly
-`0600`, and outside its home and managed checkouts. Missing keys, malformed
-files, and reserved `GITMOOT_*` names fail `pipeline add` without printing
-values.
+Gitmoot requires each source file to be operator-owned, mode exactly `0600`, and
+outside its home and managed checkouts. Structural errors always fail. An
+unresolved name only warns while the pipeline remains disabled; add-with-enable,
+enable, manual run, and scheduled/triggered preflight fail closed and point to
+`gitmoot key grant`.
 
-Gitmoot reads the file again immediately before each stage process starts, so
-rotation needs no daemon restart. File values beat inline non-secret defaults,
-selected values beat inherited daemon environment, and Gitmoot's internal
-`GITMOOT_*` entries remain final. The stage job payload audits the file path and
-expanded key names only; file values never enter SQLite. The selected shell can
-still read an injected key. This is separate from the Claude model gateway,
-which keeps its proxied real credential out of the child.
+Gitmoot reads the selected source again immediately before each stage process
+starts, so rotation needs no daemon restart. Pipeline-owned values beat granted
+shared keys, which beat inline non-secret defaults; Gitmoot's internal
+`GITMOOT_*` entries remain final. Registered but ungranted names do not match
+exact or glob selectors. The stage job payload and `pipeline show --json` audit
+only `{stage,name,source,mode}` rows. Delivery rechecks shared grants, so a
+post-enqueue revoke fails closed without switching sources. The selected shell
+can still read an injected key. `proxied` mode is reserved for future gateway
+composition and is refused for pipelines; the Claude model gateway is separate.
 
 ### Chain pipelines on success
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2785,7 +2785,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `name`                      | pipeline     | yes      | Stable identifier and DB primary key; a name-safe token (letters, digits, `-`, `_`). |
 | `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
 | `env_file`                  | pipeline     | no       | Absolute operator-owned secret file. It must exist, be a regular file owned by the current uid with mode exactly `0600`, and live outside the Gitmoot home and every managed checkout. |
-| `env`                       | pipeline     | no       | Inline **non-secret** `KEY: value` defaults. A file value with the same key wins. Values are delivered only when a shell stage selects the key. |
+| `env`                       | pipeline     | no       | Inline **non-secret** `KEY: value` defaults. Pipeline-owned and granted shared values take precedence. Values are delivered only when a shell stage selects the key. |
 | `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
 | `schedule.jitter`           | pipeline     | no       | Random `[0, jitter]` added to each `next_due` to de-thunder (`>= 0`). |
 | `trigger.kind`              | pipeline     | cond.    | Required with `trigger:`. Only `email` is supported; it generates an owned Activepieces IMAP flow. |
@@ -2813,7 +2813,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
-| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from `env_file`/`env`. Shell stages only; no entry means no injected values. |
+| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from the pipeline's `env_file`, granted shared registry keys, or inline `env`. Shell stages only; no entry means no injected values. |
 | `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
 
 `gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
@@ -2832,7 +2832,14 @@ rather than a stuck run later.
 
 Pipeline secrets are deny-by-default. A shell stage receives only the concrete
 names selected by its `env_keys`; a sibling with different or empty `env_keys`
-does not receive them. Agent and gate stages cannot declare `env_keys`.
+does not receive them. Agent and gate stages cannot declare `env_keys`. Shared
+keys must be registered and granted separately:
+
+```sh
+gitmoot key path # edit this 0600 file; the CLI never accepts values
+gitmoot key add REDDIT_CLIENT_SECRET --mode injected
+gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
+```
 
 ```yaml
 env_file: /root/.config/trend-scout/env
@@ -2847,21 +2854,27 @@ stages:
     env_keys: [TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID]
 ```
 
-`pipeline add` parses the file and refuses missing files/keys, insecure mode,
-wrong ownership, protected locations, malformed selectors, and any inline,
-file, or selector collision with reserved `GITMOOT_*` names. Values are loaded
-again immediately before each stage process starts, so an atomic rewrite of the
-same `0600` file rotates credentials without a daemon restart. The file value
-wins an inline default; selected values win inherited daemon environment;
-Gitmoot's own later `GITMOOT_*` entries always win.
+`pipeline add` parses the pipeline-owned file and refuses insecure mode, wrong
+ownership, protected locations, malformed selectors, and any inline, file, or
+selector collision with reserved `GITMOOT_*` names. An unresolved selector is a
+names-only warning only while the pipeline remains disabled, which allows the
+pipeline to exist before `key grant`; add-with-enable, enable, manual run, and
+scheduled/triggered preflight fail closed until it resolves. Values are loaded
+again immediately before each stage process starts, so an atomic rewrite of a
+`0600` source rotates credentials without a daemon restart. Resolution is own
+`env_file`, then granted shared key, then inline default; Gitmoot's reserved
+`GITMOOT_*` entries always win. Registered but ungranted names are not glob or
+exact-match candidates.
 
-The persisted stage job payload is the audit record: it contains the env-file
-path and expanded key **names**, never secret values. Inline `env` is stored in
-the pipeline spec and is therefore for non-secrets only. An injected/opaque key
-is necessarily visible to its shell process, which can print or transmit it;
-this is scoping and audit, not a vault. The Claude model gateway is independent:
-it continues to proxy the model credential without exposing the real value to
-the child.
+The persisted stage job payload is the audit record: `PipelineKeyAccess` carries
+only `{stage,name,source,mode}` rows (plus legacy env-file/name fields for
+already-enqueued jobs), never secret values. `pipeline show --json` exposes the
+same rows. Delivery rechecks every shared grant and its registry mode; revoking
+after enqueue fails the stage rather than switching to another source. Inline
+`env` is stored in the pipeline spec and is therefore for non-secrets only. An
+injected key is visible to its shell process; this is scoping and audit, not a
+vault. `proxied` registry mode is stored for future gateway composition but is
+refused for pipeline grants. The Claude model gateway remains independent.
 
 On `pipeline add --enable`, Gitmoot publishes the owned flow. An unavailable
 Activepieces instance leaves a pending binding; run
@@ -9423,6 +9436,26 @@ fallback. The first adapter build imports legacy `daemon-runtime.env` when the
 new file is absent, otherwise it seeds from ambient managed variables once;
 existing authoritative files are never overwritten.
 
+Shared injected pipeline keys use a separate operator-owned keychain file,
+defaulting to `<base-home>/.config/gitmoot/keychain.env` (override with
+`[credentials] keychain_path`). The CLI manages names and grants only; edit the
+`0600` file at the path it prints to set or rotate values:
+
+```sh
+gitmoot key path [--json]
+gitmoot key add <NAME> --mode injected|proxied [--json]
+gitmoot key list [--json]
+gitmoot key show <NAME> [--json]
+gitmoot key grant <NAME> --pipeline <pipeline> [--json]
+gitmoot key revoke <NAME> --pipeline <pipeline> [--json]
+gitmoot key rm <NAME> [--force] [--json]
+```
+
+There is deliberately no value flag, stdin value, or value-derived hash.
+`proxied` metadata is reserved for future gateway composition and cannot be
+granted to a pipeline. `rm --force` removes metadata and grants but leaves the
+file entry untouched.
+
 Runtime-child environment curation is off by default. Enable it in
 `config.toml`:
 
@@ -9433,6 +9466,7 @@ env_passthrough = ["GOCACHE", "NPM_*"]
 github = "deny"
 model_gateway = false
 model_gateway_allow_hosts = ["api.anthropic.com"]
+# keychain_path = "/absolute/operator/path/keychain.env"
 ```
 
 Set `model_gateway = true` to opt Claude into the daemon-owned loopback model
@@ -12055,19 +12089,24 @@ its `needs` stages' result summaries are prepended to the prompt, and a repo-bou
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
 
-Shell stages can opt into pipeline-owned environment values with `env_keys`.
-`env_file` must be an absolute, operator-owned regular file with mode exactly
-`0600`, outside the Gitmoot home and every managed checkout; inline `env` is for
-non-secret defaults. Exact names and globs such as `REDDIT_*` are expanded at
-enqueue, and every selector must resolve. Agent/gate stages cannot set
-`env_keys`; a shell stage with no list gets nothing. The file is read again at
-delivery, so rotation applies without a daemon restart. File values beat inline
-defaults, selected values beat inherited daemon environment, and reserved
-`GITMOOT_*` names are rejected while Gitmoot's internal entries remain final.
-The job payload audits only the env-file path and expanded key names, never file
-values. This injected mode exposes an opaque key to that shell process; it is
-separate from the Claude model gateway, whose proxied credential remains hidden
-from the child.
+Shell stages can opt into pipeline-owned or granted shared environment values
+with `env_keys`. Source files must be absolute, operator-owned regular files
+with mode exactly `0600`, outside the Gitmoot home and every managed checkout;
+inline `env` is for non-secret defaults. Agent/gate stages cannot set
+`env_keys`; a shell stage with no list gets nothing. Resolution is own
+`env_file`, then a shared `injected` key granted with `gitmoot key grant`, then
+inline default. Registered but ungranted names do not match exact or glob
+selectors. Structural errors always fail add; unresolved names warn only while
+the pipeline remains disabled, then hard-fail add-with-enable, enable, manual
+run, and scheduled/triggered preflight.
+
+Sources are revalidated and reread at delivery, so rotation applies without a
+daemon restart. Each payload audits `PipelineName` and names-only
+`PipelineKeyAccess` rows `{stage,name,source,mode}`; `pipeline show --json`
+exposes the same projection. A shared grant is rechecked immediately before
+delivery: revocation fails closed and never switches to another source. Gitmoot
+internal `GITMOOT_*` entries remain final. This injected mode exposes the value
+to that shell process and stays separate from the Claude model gateway.
 
 For a non-empty run payload, every agent stage (including roots) receives a
 dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before
@@ -14188,16 +14227,22 @@ treat `pipeline add` from an untrusted source as arbitrary code execution.
 The spec is stored **verbatim** (the raw YAML bytes plus a content hash), so a spec
 that embeds private hostnames, filesystem paths, tokens-by-reference, or repo names
 is retained in the local store as-is — the same private-repo caveat as a captured
-agent template or a published template. Do not register a spec carrying a secret in
-a stage command or inline `env`. Use an operator-owned `0600` `env_file` plus the
-shell stage's `env_keys` allowlist instead.
+agent template or a published template. Do not register a spec carrying a secret
+in a stage command or inline `env`. Use an operator-owned `0600` pipeline
+`env_file`, or register a name from the separate `gitmoot key path` keychain and
+grant it to the pipeline, then select it with the shell stage's `env_keys`
+allowlist.
 
-Pipeline `env_file` injection (#968) is deny-by-default but deliberately
-**opaque**: only a shell stage's selected `env_keys` are injected, yet that
-process receives the real values and can print or transmit them. Gitmoot stores
-only the file path and expanded names in the job audit. This is distinct from
-the Claude keycard/model gateway, where the child receives a placeholder and the
-real model credential stays daemon-side.
+Pipeline injection is deny-by-default but deliberately **opaque**: only a shell
+stage's selected own or granted shared `env_keys` are injected, yet that process
+receives the real values and can print or transmit them. Gitmoot stores only
+`{stage,name,source,mode}` audit rows, never values or hashes. Keychain and
+pipeline files are revalidated as owner-only `0600` files outside Gitmoot state
+and managed checkouts. A shared grant is rechecked at delivery, so revocation
+fails closed without source fallback. `proxied` registry entries cannot be
+granted to pipelines in this phase. This is distinct from the Claude model
+gateway, where the child receives a placeholder and the real model credential
+stays daemon-side.
 
 ## External Contracts
 


### PR DESCRIPTION
Registry/grants phase of #874, implementing the frozen tri-model panel design (see the design-of-record comment on #874).

- **Keychain**: operator-owned `<base-home>/.config/gitmoot/keychain.env` (0600/euid/location-validated like env_file, `[credentials] keychain_path` override), re-read fresh at every use — rotation without restart.
- **Registry/grants (metadata only)**: `keychain_keys` + `keychain_grants` migration; no value column; same-tx cleanup on `key rm` and pipeline deletion (no FK/PRAGMA changes).
- **CLI**: `gitmoot key path|add|list|show|rm|grant|revoke` — no value flags anywhere; proxied grants refused; grant/revoke idempotent.
- **Resolution**: `GITMOOT_*` > own env_file > granted shared > inline default > fail closed; enqueue = names-only authorization; payload carries `PipelineName` + `PipelineKeyAccess {stage,name,source,mode}` (legacy fields kept for in-flight jobs).
- **Delivery**: source-pinned — grant re-checked at delivery (revocation between enqueue and delivery fails closed); no silent source switching.
- **Validation timing**: structural errors always hard-fail; unresolved names warn only while disabled; enable/run/scheduled/triggered preflights hard-gate.
- **Projection** wired into `pipeline show --json`; docs across both trees + llms-full regenerated.
- Tests: migration/CRUD/cleanup, CLI secret-safety, precedence + grant-boundary tables, rotation+revocation, validation timing, and `TestPipelineKeychainRegistryGrantsShellE2E` (isolated /tmp home, sentinel scans).

Salvaged from implement job `local-implement-wave-impl-18c2a0378bc5c42a` (checkout_contention after completed work); full gate re-run green (generate-clean, build, vet, 36 test packages).

Closes: registry/grants scope of #874 (issue stays open for proxied-mode generalization + agent grants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)