### PR TITLE
Gitmoot: TASK: Implement the gitmoot SERVER half of the

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715222135-ca3e557c5d1c
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716012516-ba81b5ad8e51
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715222135-ca3e557c5d1c h1:yo2amJpqC4O7p5sDXi36xYoFC+YzsOBQbuwAT9YDNzk=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260715222135-ca3e557c5d1c/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716012516-ba81b5ad8e51 h1:bBVBn74Xv9yt4/AHtSsSY45I5CE5wfrQf19pDkKFQJM=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716012516-ba81b5ad8e51/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/cli/dashboard_web_pipelines.go
+++ b/internal/cli/dashboard_web_pipelines.go
@@ -262,6 +262,52 @@ func pipelineRunStageIDsMatchSpec(spec pipeline.Spec, rows []db.PipelineRunStage
 	return len(ids) == 0
 }
 
+func dashboardPipelineKeys(ctx context.Context, store *db.Store, home string, spec pipeline.Spec) (dashboard.PipelineKeys, error) {
+	inspection := classifyPipelineEnvFile(ctx, store, home, spec.EnvFile)
+	out := dashboard.PipelineKeys{
+		EnvFile: dashboard.PipelineEnvFileStatus{Path: inspection.Path, Status: inspection.Status},
+		Stages:  make([]dashboard.PipelineStageKeys, 0, len(spec.Stages)),
+	}
+
+	sharedCandidates, err := pipelineSharedKeyCandidates(ctx, store, spec, inspection.Names)
+	if err != nil {
+		return dashboard.PipelineKeys{}, err
+	}
+	sharedNames := make(map[string]struct{})
+	if len(sharedCandidates) > 0 {
+		// Keychain drift is advisory on this read-only endpoint. A missing or invalid
+		// file makes shared selectors unresolved; delivery remains fail-closed.
+		if names, loadErr := loadValidatedKeychainNames(ctx, store, home); loadErr == nil {
+			for name := range sharedCandidates {
+				if _, present := names[name]; present {
+					sharedNames[name] = struct{}{}
+				}
+			}
+		}
+	}
+	resolution := projectPipelineEnvironment(spec, inspection.Names, sharedNames)
+	for _, stage := range spec.Stages {
+		row := dashboard.PipelineStageKeys{
+			ID:                  stage.ID,
+			Kind:                pipelineStageKindName(stage),
+			Keys:                []dashboard.PipelineKeyEntry{},
+			UnresolvedSelectors: []string{},
+		}
+		for _, access := range resolution.Access {
+			if access.Stage == stage.ID {
+				row.Keys = append(row.Keys, dashboard.PipelineKeyEntry{Name: access.Name, Source: access.Source, Mode: access.Mode})
+			}
+		}
+		for _, unresolved := range resolution.Unresolved {
+			if unresolved.Stage == stage.ID {
+				row.UnresolvedSelectors = append(row.UnresolvedSelectors, unresolved.Selector)
+			}
+		}
+		out.Stages = append(out.Stages, row)
+	}
+	return out, nil
+}
+
 // PipelineDetail returns one pipeline's currently declared stage DAG plus its run
 // history (newest-first, capped at 100), each history row carrying its per-stage
 // marks. An unknown name maps to dashboard.ErrPipelineNotFound (the API layer
@@ -277,6 +323,10 @@ func (d *webDataSource) PipelineDetail(ctx context.Context, name string) (dashbo
 		Name:     name,
 		Declared: []dashboard.PipelineStage{},
 		Runs:     []dashboard.PipelineRunHistoryEntry{},
+		Keys: dashboard.PipelineKeys{
+			EnvFile: dashboard.PipelineEnvFileStatus{Status: pipelineEnvFileStatusNone},
+			Stages:  []dashboard.PipelineStageKeys{},
+		},
 	}
 	err := withStore(d.home, func(store *db.Store) error {
 		rec, ok, err := store.GetPipeline(ctx, name)
@@ -295,6 +345,11 @@ func (d *webDataSource) PipelineDetail(ctx context.Context, name string) (dashbo
 		if loaded, lerr := pipeline.Load([]byte(rec.SpecYAML)); lerr == nil {
 			spec, specParsed = loaded, true
 			out.Description = spec.Description
+			keys, keyErr := dashboardPipelineKeys(ctx, store, d.home, spec)
+			if keyErr != nil {
+				return keyErr
+			}
+			out.Keys = keys
 			// Agent runtimes resolve best-effort so the declared preview can label
 			// agent stages even for a pipeline that has never run (#873).
 			agents := pipelineStageAgents(ctx, store, rec)

--- a/internal/cli/dashboard_web_pipelines_test.go
+++ b/internal/cli/dashboard_web_pipelines_test.go
@@ -4,7 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -690,6 +696,145 @@ func TestWebDataSourcePipelineDetailNeverRun(t *testing.T) {
 	// #873: the declared preview is self-describing with zero runs.
 	if byID["zfetch"].Kind != "shell" {
 		t.Fatalf("declared zfetch Kind = %q, want shell", byID["zfetch"].Kind)
+	}
+}
+
+func TestWebDataSourcePipelineDetailKeysNamesOnlyAndLiveDrift(t *testing.T) {
+	const (
+		ownSentinel     = "own-secret-value-974"
+		sharedSentinel  = "shared-secret-value-974"
+		defaultSentinel = "inline-default-value-974"
+	)
+	home := dashboardTestHome(t)
+	envFile := writePipelineEnvFile(t, t.TempDir(), "OWN_TWO="+ownSentinel+"\nOWN_ONE="+ownSentinel+"\n", 0o600)
+	writeDefaultKeychain(t, home, "SHARED_TOKEN="+sharedSentinel+"\n")
+	raw := fmt.Sprintf(`name: keys-view
+env_file: %q
+env:
+  DEFAULT_TOKEN: %q
+stages:
+  - id: deliver
+    cmd: echo deliver
+    env_keys: [OWN_*, SHARED_TOKEN, DEFAULT_TOKEN]
+  - id: harvest
+    cmd: echo harvest
+  - id: inspect
+    agent: scout
+    action: ask
+    prompt: inspect
+`, envFile, defaultSentinel)
+	store := openPipelineTestStore(t, home)
+	seedTestPipeline(t, store, db.Pipeline{Name: "keys-view", SpecYAML: raw})
+	if _, err := store.AddKeychainKey(context.Background(), "SHARED_TOKEN", db.KeychainModeInjected); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantKeychainKey(context.Background(), db.KeychainConsumerPipeline, "keys-view", "SHARED_TOKEN"); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+
+	ds := &webDataSource{home: home}
+	detail, err := ds.PipelineDetail(context.Background(), "keys-view")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Keys.EnvFile != (dashboard.PipelineEnvFileStatus{Path: envFile, Status: pipelineEnvFileStatusOK}) {
+		t.Fatalf("envFile = %+v", detail.Keys.EnvFile)
+	}
+	if len(detail.Keys.Stages) != 3 {
+		t.Fatalf("stages = %+v", detail.Keys.Stages)
+	}
+	wantKeys := []dashboard.PipelineKeyEntry{
+		{Name: "OWN_ONE", Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected},
+		{Name: "OWN_TWO", Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected},
+		{Name: "SHARED_TOKEN", Source: pipelineKeySourceShared, Mode: db.KeychainModeInjected},
+		{Name: "DEFAULT_TOKEN", Source: pipelineKeySourceDefault, Mode: db.KeychainModeInjected},
+	}
+	if got := detail.Keys.Stages[0]; got.ID != "deliver" || got.Kind != "shell" || !reflect.DeepEqual(got.Keys, wantKeys) || len(got.UnresolvedSelectors) != 0 {
+		t.Fatalf("deliver keys = %+v", got)
+	}
+	for _, stage := range detail.Keys.Stages[1:] {
+		if stage.Keys == nil || stage.UnresolvedSelectors == nil || len(stage.Keys) != 0 || len(stage.UnresolvedSelectors) != 0 {
+			t.Fatalf("empty stage arrays = %+v", stage)
+		}
+	}
+	encoded, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sentinel := range []string{ownSentinel, sharedSentinel, defaultSentinel} {
+		if strings.Contains(string(encoded), sentinel) {
+			t.Fatalf("PipelineDetail leaked secret/default value %q: %s", sentinel, encoded)
+		}
+	}
+
+	if err := os.Remove(envFile); err != nil {
+		t.Fatal(err)
+	}
+	drifted, err := ds.PipelineDetail(context.Background(), "keys-view")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if drifted.Keys.EnvFile.Status != pipelineEnvFileStatusMissing {
+		t.Fatalf("drifted envFile = %+v", drifted.Keys.EnvFile)
+	}
+	if got, want := drifted.Keys.Stages[0].Keys, wantKeys[2:]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("drifted keys = %#v, want %#v", got, want)
+	}
+	if got, want := drifted.Keys.Stages[0].UnresolvedSelectors, []string{"OWN_*"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("drifted unresolved = %#v, want %#v", got, want)
+	}
+}
+
+func TestDashboardPipelineDetailKeysHTTPShape(t *testing.T) {
+	home := dashboardTestHome(t)
+	envFile := writePipelineEnvFile(t, t.TempDir(), "TOKEN=http-secret-value-974\n", 0o600)
+	raw := fmt.Sprintf("name: http-keys\nenv_file: %q\nstages:\n  - {id: deliver, cmd: echo, env_keys: [TOKEN]}\n  - {id: idle, cmd: echo}\n", envFile)
+	store := openPipelineTestStore(t, home)
+	seedTestPipeline(t, store, db.Pipeline{Name: "http-keys", SpecYAML: raw})
+	store.Close()
+
+	server := httptest.NewServer(dashboard.Serve(&webDataSource{home: home}))
+	defer server.Close()
+	resp, err := http.Get(server.URL + "/api/pipelines/http-keys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), `"envFile"`) || !strings.Contains(string(body), `"unresolvedSelectors"`) || strings.Contains(string(body), "http-secret-value-974") {
+		t.Fatalf("unexpected wire shape or value leak: %s", body)
+	}
+	var detail dashboard.PipelineDetail
+	if err := json.Unmarshal(body, &detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail.Keys.Stages == nil || len(detail.Keys.Stages) != 2 || detail.Keys.Stages[0].Keys == nil || detail.Keys.Stages[1].Keys == nil || detail.Keys.Stages[1].UnresolvedSelectors == nil {
+		t.Fatalf("non-null array contract failed: %+v", detail.Keys)
+	}
+}
+
+func TestWebDataSourcePipelineDetailKeysFailOpenSpec(t *testing.T) {
+	home := dashboardTestHome(t)
+	store := openPipelineTestStore(t, home)
+	seedTestPipeline(t, store, db.Pipeline{Name: "broken-keys", SpecYAML: "name: [unterminated"})
+	store.Close()
+
+	detail, err := (&webDataSource{home: home}).PipelineDetail(context.Background(), "broken-keys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Declared == nil || detail.Runs == nil || detail.Keys.Stages == nil {
+		t.Fatalf("fail-open slices must be non-nil: %+v", detail)
+	}
+	if detail.Keys.EnvFile.Status != pipelineEnvFileStatusNone || len(detail.Keys.Stages) != 0 {
+		t.Fatalf("fail-open keys = %+v", detail.Keys)
 	}
 }
 

--- a/internal/cli/pipeline_env.go
+++ b/internal/cli/pipeline_env.go
@@ -25,6 +25,16 @@ const (
 	pipelineKeySourceDefault = "default"
 )
 
+const (
+	pipelineEnvFileStatusNone        = "none"
+	pipelineEnvFileStatusOK          = "ok"
+	pipelineEnvFileStatusMissing     = "missing"
+	pipelineEnvFileStatusBadMode     = "bad_mode"
+	pipelineEnvFileStatusBadOwner    = "bad_owner"
+	pipelineEnvFileStatusBadLocation = "bad_location"
+	pipelineEnvFileStatusInvalid     = "invalid"
+)
+
 type pipelineStageEnvAccess struct {
 	File     string
 	Keys     []string
@@ -42,82 +52,95 @@ type pipelineEnvironmentResolution struct {
 	Unresolved []pipelineEnvUnresolved
 }
 
+type pipelineEnvFileInspection struct {
+	Path   string
+	Status string
+	Names  map[string]struct{}
+}
+
 // resolvePipelineEnvironment is the single names-only projection used by add
 // validation, run preflight, payload audit, and `pipeline show --json`.
 func resolvePipelineEnvironment(ctx context.Context, store *db.Store, home string, spec pipeline.Spec) (pipelineEnvironmentResolution, error) {
-	available := make(map[string]string, len(spec.Env))
-	source := make(map[string]string, len(spec.Env))
-	for name := range spec.Env {
-		available[name] = ""
-		source[name] = pipelineKeySourceDefault
-	}
+	ownNames := make(map[string]struct{})
 	if strings.TrimSpace(spec.EnvFile) != "" {
-		own, err := loadValidatedPipelineEnvFile(ctx, store, home, spec.EnvFile)
+		own, err := loadValidatedSecretEnvNames(ctx, store, home, "env_file", spec.EnvFile)
 		if err != nil {
 			return pipelineEnvironmentResolution{}, err
 		}
 		for name := range own {
-			available[name] = ""
-			source[name] = pipelineKeySourceOwn
+			ownNames[name] = struct{}{}
 		}
 	}
 
-	var grants []db.KeychainGrant
-	if strings.TrimSpace(spec.Name) != "" {
-		var err error
-		grants, err = store.ListKeychainGrantsForConsumer(ctx, db.KeychainConsumerPipeline, spec.Name)
-		if err != nil {
-			return pipelineEnvironmentResolution{}, err
-		}
+	sharedCandidates, err := pipelineSharedKeyCandidates(ctx, store, spec, ownNames)
+	if err != nil {
+		return pipelineEnvironmentResolution{}, err
 	}
-	sharedCandidates := make(map[string]db.KeychainKey)
-	for _, grant := range grants {
-		if source[grant.KeyName] == pipelineKeySourceOwn || !pipelineSelectorUsed(spec, grant.KeyName) {
-			continue
-		}
-		key, found, err := store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, spec.Name, grant.KeyName)
-		if err != nil {
-			return pipelineEnvironmentResolution{}, err
-		}
-		if found && key.Mode == db.KeychainModeInjected {
-			sharedCandidates[key.Name] = key
-		}
-	}
+	sharedNames := make(map[string]struct{})
 	if len(sharedCandidates) > 0 {
-		_, shared, err := loadValidatedKeychainFile(ctx, store, home)
+		shared, err := loadValidatedKeychainNames(ctx, store, home)
 		if err != nil {
 			return pipelineEnvironmentResolution{}, err
 		}
 		for name := range sharedCandidates {
-			if strings.TrimSpace(shared[name]) == "" {
-				continue
+			if _, present := shared[name]; present {
+				sharedNames[name] = struct{}{}
 			}
-			available[name] = ""
-			source[name] = pipelineKeySourceShared
 		}
 	}
+	return projectPipelineEnvironment(spec, ownNames, sharedNames), nil
+}
 
+func projectPipelineEnvironment(spec pipeline.Spec, ownNames, sharedNames map[string]struct{}) pipelineEnvironmentResolution {
+	defaultNames := make(map[string]struct{}, len(spec.Env))
+	for name := range spec.Env {
+		defaultNames[name] = struct{}{}
+	}
+	sources := []pipeline.EnvKeySource{
+		{Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected, Names: ownNames},
+		{Source: pipelineKeySourceShared, Mode: db.KeychainModeInjected, Names: sharedNames},
+		{Source: pipelineKeySourceDefault, Mode: db.KeychainModeInjected, Names: defaultNames},
+	}
 	resolution := pipelineEnvironmentResolution{}
 	for _, stage := range spec.Stages {
-		seen := make(map[string]struct{})
-		for _, selector := range stage.EnvKeys {
-			keys, err := pipeline.ResolveEnvKeys([]string{selector}, available)
-			if err != nil {
-				resolution.Unresolved = append(resolution.Unresolved, pipelineEnvUnresolved{Stage: stage.ID, Selector: selector})
-				continue
-			}
-			for _, name := range keys {
-				if _, ok := seen[name]; ok {
-					continue
-				}
-				seen[name] = struct{}{}
-				resolution.Access = append(resolution.Access, workflow.PipelineKeyAccess{
-					Stage: stage.ID, Name: name, Source: source[name], Mode: db.KeychainModeInjected,
-				})
-			}
+		projected, unresolved := pipeline.ProjectEnvKeys(stage.EnvKeys, sources)
+		for _, key := range projected {
+			resolution.Access = append(resolution.Access, workflow.PipelineKeyAccess{
+				Stage: stage.ID, Name: key.Name, Source: key.Source, Mode: key.Mode,
+			})
+		}
+		for _, selector := range unresolved {
+			resolution.Unresolved = append(resolution.Unresolved, pipelineEnvUnresolved{Stage: stage.ID, Selector: selector})
 		}
 	}
-	return resolution, nil
+	return resolution
+}
+
+func pipelineSharedKeyCandidates(ctx context.Context, store *db.Store, spec pipeline.Spec, ownNames map[string]struct{}) (map[string]db.KeychainKey, error) {
+	candidates := make(map[string]db.KeychainKey)
+	if strings.TrimSpace(spec.Name) == "" {
+		return candidates, nil
+	}
+	grants, err := store.ListKeychainGrantsForConsumer(ctx, db.KeychainConsumerPipeline, spec.Name)
+	if err != nil {
+		return nil, err
+	}
+	for _, grant := range grants {
+		if _, owned := ownNames[grant.KeyName]; owned {
+			continue
+		}
+		if !pipelineSelectorUsed(spec, grant.KeyName) {
+			continue
+		}
+		key, found, err := store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, spec.Name, grant.KeyName)
+		if err != nil {
+			return nil, err
+		}
+		if found && key.Mode == db.KeychainModeInjected {
+			candidates[key.Name] = key
+		}
+	}
+	return candidates, nil
 }
 
 func pipelineSelectorUsed(spec pipeline.Spec, name string) bool {
@@ -203,6 +226,14 @@ func loadValidatedKeychainFile(ctx context.Context, store *db.Store, home string
 	return path, values, err
 }
 
+func loadValidatedKeychainNames(ctx context.Context, store *db.Store, home string) (map[string]struct{}, error) {
+	path, err := resolveKeychainPath(store, home)
+	if err != nil {
+		return nil, err
+	}
+	return loadValidatedSecretEnvNames(ctx, store, home, "keychain", path)
+}
+
 func resolveKeychainPath(store *db.Store, home string) (string, error) {
 	paths, err := configPathsForPipelineStore(store, home)
 	if err != nil {
@@ -234,52 +265,124 @@ func configPathsForPipelineStore(store *db.Store, home string) (config.Paths, er
 }
 
 func loadValidatedSecretEnvFile(ctx context.Context, store *db.Store, home, label, declared string) (map[string]string, error) {
-	declared = strings.TrimSpace(declared)
-	if !filepath.IsAbs(declared) {
-		return nil, fmt.Errorf("%s %q must be absolute", label, declared)
-	}
-	file, err := os.Open(declared)
+	file, _, err := openValidatedSecretEnvFile(ctx, store, home, label, declared)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("%s %s does not exist", label, declared)
-		}
-		return nil, fmt.Errorf("open %s %s: %w", label, declared, err)
-	}
-	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
-		return nil, fmt.Errorf("stat %s %s: %w", label, declared, err)
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("%s %s is not a regular file", label, declared)
-	}
-	if info.Mode().Perm() != pipelineEnvFileMode {
-		return nil, fmt.Errorf("%s %s has mode %04o; want 0600", label, declared, info.Mode().Perm())
-	}
-	owner, err := pipelineEnvOwnerUID(info)
-	if err != nil {
-		return nil, fmt.Errorf("%s %s: %w", label, declared, err)
-	}
-	if owner != pipelineEnvCurrentUID() {
-		return nil, fmt.Errorf("%s %s is owned by uid %d; want operator uid %d", label, declared, owner, pipelineEnvCurrentUID())
-	}
-	if err := validateSecretEnvFileLocation(ctx, store, home, label, declared); err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	data, err := io.ReadAll(file)
 	if err != nil {
-		return nil, fmt.Errorf("read %s %s: %w", label, declared, err)
+		return nil, fmt.Errorf("read %s %s: %w", label, strings.TrimSpace(declared), err)
 	}
-	values, err := pipeline.ParseEnv(declared, data)
+	values, err := pipeline.ParseEnv(strings.TrimSpace(declared), data)
 	if err != nil {
 		return nil, err
 	}
 	for name := range values {
 		if pipeline.ReservedEnvName(name) {
-			return nil, fmt.Errorf("%s %s key %q uses reserved GITMOOT_* namespace", label, declared, name)
+			return nil, fmt.Errorf("%s %s key %q uses reserved GITMOOT_* namespace", label, strings.TrimSpace(declared), name)
 		}
 	}
 	return values, nil
+}
+
+func loadValidatedSecretEnvNames(ctx context.Context, store *db.Store, home, label, declared string) (map[string]struct{}, error) {
+	file, _, err := openValidatedSecretEnvFile(ctx, store, home, label, declared)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("read %s %s: %w", label, strings.TrimSpace(declared), err)
+	}
+	names, err := pipeline.ParseEnvNames(strings.TrimSpace(declared), data)
+	if err != nil {
+		return nil, err
+	}
+	for name := range names {
+		if pipeline.ReservedEnvName(name) {
+			return nil, fmt.Errorf("%s %s key %q uses reserved GITMOOT_* namespace", label, strings.TrimSpace(declared), name)
+		}
+	}
+	return names, nil
+}
+
+// classifyPipelineEnvFile returns the live advisory status and names needed by
+// the dashboard. It never returns file contents or an error string.
+func classifyPipelineEnvFile(ctx context.Context, store *db.Store, home, declared string) pipelineEnvFileInspection {
+	declared = strings.TrimSpace(declared)
+	inspection := pipelineEnvFileInspection{Path: declared, Status: pipelineEnvFileStatusNone, Names: map[string]struct{}{}}
+	if declared == "" {
+		return inspection
+	}
+	file, status, err := openValidatedSecretEnvFile(ctx, store, home, "env_file", declared)
+	if err != nil {
+		inspection.Status = status
+		return inspection
+	}
+	defer file.Close()
+	data, err := io.ReadAll(file)
+	if err != nil {
+		inspection.Status = pipelineEnvFileStatusInvalid
+		return inspection
+	}
+	names, err := pipeline.ParseEnvNames(declared, data)
+	if err != nil {
+		inspection.Status = pipelineEnvFileStatusInvalid
+		return inspection
+	}
+	for name := range names {
+		if pipeline.ReservedEnvName(name) {
+			inspection.Status = pipelineEnvFileStatusInvalid
+			return inspection
+		}
+	}
+	inspection.Status = pipelineEnvFileStatusOK
+	inspection.Names = names
+	return inspection
+}
+
+// openValidatedSecretEnvFile is the shared safety gate for value-loading
+// delivery and value-free status inspection. Its check order is fixed so unsafe
+// files are never read or parsed after an earlier failure.
+func openValidatedSecretEnvFile(ctx context.Context, store *db.Store, home, label, declared string) (*os.File, string, error) {
+	declared = strings.TrimSpace(declared)
+	if !filepath.IsAbs(declared) {
+		return nil, pipelineEnvFileStatusInvalid, fmt.Errorf("%s %q must be absolute", label, declared)
+	}
+	file, err := os.Open(declared)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, pipelineEnvFileStatusMissing, fmt.Errorf("%s %s does not exist", label, declared)
+		}
+		return nil, pipelineEnvFileStatusInvalid, fmt.Errorf("open %s %s: %w", label, declared, err)
+	}
+	closeWith := func(status string, err error) (*os.File, string, error) {
+		file.Close()
+		return nil, status, err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return closeWith(pipelineEnvFileStatusInvalid, fmt.Errorf("stat %s %s: %w", label, declared, err))
+	}
+	if !info.Mode().IsRegular() {
+		return closeWith(pipelineEnvFileStatusInvalid, fmt.Errorf("%s %s is not a regular file", label, declared))
+	}
+	if info.Mode().Perm() != pipelineEnvFileMode {
+		return closeWith(pipelineEnvFileStatusBadMode, fmt.Errorf("%s %s has mode %04o; want 0600", label, declared, info.Mode().Perm()))
+	}
+	owner, err := pipelineEnvOwnerUID(info)
+	if err != nil {
+		return closeWith(pipelineEnvFileStatusInvalid, fmt.Errorf("%s %s: %w", label, declared, err))
+	}
+	if owner != pipelineEnvCurrentUID() {
+		return closeWith(pipelineEnvFileStatusBadOwner, fmt.Errorf("%s %s is owned by uid %d; want operator uid %d", label, declared, owner, pipelineEnvCurrentUID()))
+	}
+	if err := validateSecretEnvFileLocation(ctx, store, home, label, declared); err != nil {
+		return closeWith(pipelineEnvFileStatusBadLocation, err)
+	}
+	return file, pipelineEnvFileStatusOK, nil
 }
 
 func validatePipelineEnvFileLocation(ctx context.Context, store *db.Store, home, declared string) error {

--- a/internal/cli/pipeline_env_test.go
+++ b/internal/cli/pipeline_env_test.go
@@ -152,6 +152,62 @@ func TestPipelineAddEnvFileWrongOwner(t *testing.T) {
 	}
 }
 
+func TestClassifyPipelineEnvFileStatuses(t *testing.T) {
+	home := dashboardTestHome(t)
+	store := openPipelineTestStore(t, home)
+	defer store.Close()
+
+	insideHome := filepath.Join(home, ".gitmoot", "inside.env")
+	if err := os.WriteFile(insideHome, []byte("BROKEN"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name          string
+		path          func(t *testing.T) string
+		want          string
+		wrongOwnerUID bool
+	}{
+		{name: "none", path: func(*testing.T) string { return "" }, want: pipelineEnvFileStatusNone},
+		{name: "ok", path: func(t *testing.T) string {
+			return writePipelineEnvFile(t, t.TempDir(), "ALPHA=secret\nBETA=secret\n", 0o600)
+		}, want: pipelineEnvFileStatusOK},
+		{name: "missing", path: func(t *testing.T) string { return filepath.Join(t.TempDir(), "missing.env") }, want: pipelineEnvFileStatusMissing},
+		{name: "bad mode before parse", path: func(t *testing.T) string {
+			return writePipelineEnvFile(t, t.TempDir(), "BROKEN", 0o644)
+		}, want: pipelineEnvFileStatusBadMode},
+		{name: "bad owner before parse", path: func(t *testing.T) string {
+			return writePipelineEnvFile(t, t.TempDir(), "BROKEN", 0o600)
+		}, want: pipelineEnvFileStatusBadOwner, wrongOwnerUID: true},
+		{name: "bad location before parse", path: func(*testing.T) string { return insideHome }, want: pipelineEnvFileStatusBadLocation},
+		{name: "invalid parse", path: func(t *testing.T) string {
+			return writePipelineEnvFile(t, t.TempDir(), "BROKEN", 0o600)
+		}, want: pipelineEnvFileStatusInvalid},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalUID := pipelineEnvCurrentUID
+			if tt.wrongOwnerUID {
+				pipelineEnvCurrentUID = func() uint32 { return originalUID() + 1 }
+			}
+			defer func() { pipelineEnvCurrentUID = originalUID }()
+
+			got := classifyPipelineEnvFile(context.Background(), store, home, tt.path(t))
+			if got.Status != tt.want {
+				t.Fatalf("status = %q, want %q (inspection=%+v)", got.Status, tt.want, got)
+			}
+			if got.Names == nil {
+				t.Fatal("Names is nil")
+			}
+			if tt.want == pipelineEnvFileStatusOK && !reflect.DeepEqual(got.Names, map[string]struct{}{"ALPHA": {}, "BETA": {}}) {
+				t.Fatalf("ok names = %#v", got.Names)
+			}
+			if tt.want != pipelineEnvFileStatusOK && len(got.Names) != 0 {
+				t.Fatalf("unsafe file exposed names: %#v", got.Names)
+			}
+		})
+	}
+}
+
 type pipelineEnvCaptureAdapter struct {
 	jobs []runtime.Job
 }
@@ -299,6 +355,33 @@ func TestPipelineKeyAccessResolutionPrecedenceAndGrantBoundary(t *testing.T) {
 	}
 	if len(capture.jobs) != 0 {
 		t.Fatalf("disappeared own source reached delivery: %#v", capture.jobs)
+	}
+}
+
+func TestPipelineOwnKeyDoesNotRequireLowerPriorityKeychain(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "own-only", SpecYAML: "name: own-only\nstages: [{id: run, cmd: echo}]\n"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddKeychainKey(ctx, "OVERLAP", db.KeychainModeInjected); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantKeychainKey(ctx, db.KeychainConsumerPipeline, "own-only", "OVERLAP"); err != nil {
+		t.Fatal(err)
+	}
+	envFile := writePipelineEnvFile(t, t.TempDir(), "OVERLAP=own\n", 0o600)
+	spec := pipeline.Spec{
+		Name: "own-only", EnvFile: envFile,
+		Stages: []pipeline.Stage{{ID: "run", Cmd: "echo", EnvKeys: []string{"OVERLAP"}}},
+	}
+	resolution, err := resolvePipelineEnvironment(ctx, store, home, spec)
+	if err != nil {
+		t.Fatalf("own source consulted missing lower-priority keychain: %v", err)
+	}
+	want := []workflow.PipelineKeyAccess{{Stage: "run", Name: "OVERLAP", Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected}}
+	if !reflect.DeepEqual(resolution.Access, want) || len(resolution.Unresolved) != 0 {
+		t.Fatalf("resolution=%#v unresolved=%#v", resolution.Access, resolution.Unresolved)
 	}
 }
 

--- a/internal/pipeline/env.go
+++ b/internal/pipeline/env.go
@@ -87,6 +87,103 @@ func ParseEnv(filePath string, data []byte) (map[string]string, error) {
 	return values, nil
 }
 
+// ParseEnvNames validates an env file and returns only its names. The right-hand
+// side of each assignment is inspected only for structural validity and is never
+// retained in the result.
+func ParseEnvNames(filePath string, data []byte) (map[string]struct{}, error) {
+	names := make(map[string]struct{})
+	for i, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(strings.TrimSuffix(raw, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		}
+		equals := strings.IndexByte(line, '=')
+		if equals < 0 {
+			return nil, fmt.Errorf("env file %s line %d: expected KEY=VALUE", filePath, i+1)
+		}
+		name := strings.TrimSpace(line[:equals])
+		if err := ValidateEnvName(name); err != nil {
+			return nil, fmt.Errorf("env file %s line %d key %q: %w", filePath, i+1, name, err)
+		}
+		if _, duplicate := names[name]; duplicate {
+			return nil, fmt.Errorf("env file %s line %d: duplicate key %q", filePath, i+1, name)
+		}
+		if strings.ContainsRune(line[equals+1:], '\x00') {
+			return nil, fmt.Errorf("env file %s line %d key %q contains NUL", filePath, i+1, name)
+		}
+		names[name] = struct{}{}
+	}
+	return names, nil
+}
+
+// EnvKeySource is one value-free namespace available to env_keys selectors.
+// Sources are supplied in precedence order, highest first.
+type EnvKeySource struct {
+	Source string
+	Mode   string
+	Names  map[string]struct{}
+}
+
+// EnvKeyProjection is one concrete name selected from an EnvKeySource.
+type EnvKeyProjection struct {
+	Name   string
+	Source string
+	Mode   string
+}
+
+// ProjectEnvKeys expands selectors over name sets without accepting or
+// returning credential values. Selector order is preserved, glob matches are
+// lexical, duplicate concrete names collapse, and unresolved selectors are
+// returned in their original order.
+func ProjectEnvKeys(selectors []string, sources []EnvKeySource) (resolved []EnvKeyProjection, unresolved []string) {
+	type sourceMeta struct {
+		source string
+		mode   string
+	}
+	winners := make(map[string]sourceMeta)
+	for _, candidate := range sources {
+		for name := range candidate.Names {
+			if _, exists := winners[name]; exists {
+				continue
+			}
+			winners[name] = sourceMeta{source: candidate.Source, mode: candidate.Mode}
+		}
+	}
+	names := make([]string, 0, len(winners))
+	for name := range winners {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	seen := make(map[string]struct{})
+	for _, selector := range selectors {
+		matched := false
+		for _, name := range names {
+			ok := selector == name
+			if strings.ContainsAny(selector, "*?[") {
+				ok, _ = path.Match(selector, name)
+			}
+			if !ok {
+				continue
+			}
+			matched = true
+			if _, exists := seen[name]; exists {
+				continue
+			}
+			seen[name] = struct{}{}
+			meta := winners[name]
+			resolved = append(resolved, EnvKeyProjection{Name: name, Source: meta.source, Mode: meta.mode})
+		}
+		if !matched {
+			unresolved = append(unresolved, selector)
+		}
+	}
+	return resolved, unresolved
+}
+
 // ResolveEnvKeys expands selectors against available names. Selector order is
 // preserved, glob matches are lexical, and duplicate concrete names collapse.
 func ResolveEnvKeys(selectors []string, available map[string]string) ([]string, error) {

--- a/internal/pipeline/env_test.go
+++ b/internal/pipeline/env_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -26,6 +27,43 @@ func TestPipelineEnvParseAndResolve(t *testing.T) {
 	_, err = ParseEnv("/tmp/pipeline.env", []byte("BROKEN "+secret))
 	if err == nil || strings.Contains(err.Error(), secret) {
 		t.Fatalf("parse error = %v, want redacted malformed-line error", err)
+	}
+}
+
+func TestParseEnvNamesDiscardsValues(t *testing.T) {
+	const secret = "dashboard-must-never-see-this"
+	names, err := ParseEnvNames("/tmp/pipeline.env", []byte("# comment\nexport ALPHA="+secret+"\nBETA='another-secret'\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := map[string]struct{}{"ALPHA": {}, "BETA": {}}; !reflect.DeepEqual(names, want) {
+		t.Fatalf("names = %#v, want %#v", names, want)
+	}
+	if strings.Contains(fmt.Sprint(names), secret) {
+		t.Fatalf("names retained secret value: %#v", names)
+	}
+	if _, err := ParseEnvNames("/tmp/pipeline.env", []byte("BROKEN "+secret)); err == nil || strings.Contains(err.Error(), secret) {
+		t.Fatalf("malformed error = %v, want value-free error", err)
+	}
+}
+
+func TestProjectEnvKeysPrecedenceAndOrdering(t *testing.T) {
+	sources := []EnvKeySource{
+		{Source: "own", Mode: "injected", Names: map[string]struct{}{"ALPHA_ONE": {}, "OVERLAP": {}}},
+		{Source: "shared", Mode: "injected", Names: map[string]struct{}{"ALPHA_TWO": {}, "OVERLAP": {}}},
+		{Source: "default", Mode: "injected", Names: map[string]struct{}{"DEFAULT": {}, "OVERLAP": {}}},
+	}
+	got, unresolved := ProjectEnvKeys([]string{"ALPHA_*", "OVERLAP", "ALPHA_ONE", "MISSING", "NO_*"}, sources)
+	want := []EnvKeyProjection{
+		{Name: "ALPHA_ONE", Source: "own", Mode: "injected"},
+		{Name: "ALPHA_TWO", Source: "shared", Mode: "injected"},
+		{Name: "OVERLAP", Source: "own", Mode: "injected"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("projection = %#v, want %#v", got, want)
+	}
+	if wantUnresolved := []string{"MISSING", "NO_*"}; !reflect.DeepEqual(unresolved, wantUnresolved) {
+		t.Fatalf("unresolved = %#v, want %#v", unresolved, wantUnresolved)
 	}
 }
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1103,6 +1103,14 @@ also refuses missing keys and reserved `GITMOOT_*` names. Values are read fresh
 at stage delivery for restart-free rotation. The job audit stores the path and
 expanded names only, not file values.
 
+The pipeline detail **Keys** tab exposes this authorization as names only: every
+stage appears in spec order with each resolved key's `own`, `shared`, or
+`default` source and delivery mode. It live-checks the declared `env_file` and
+reports `none`, `ok`, `missing`, `bad_mode`, `bad_owner`, `bad_location`, or
+`invalid`; selectors that cannot resolve after file drift are listed separately.
+The tab never reads values into its response, and delivery-time validation
+remains authoritative.
+
 ### Share a pipeline with another Gitmoot home
 
 Use a private GitHub repository as a reviewable pipeline catalog. The source and

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -124,6 +124,14 @@ post-enqueue revoke fails closed without switching sources. The selected shell
 can still read an injected key. `proxied` mode is reserved for future gateway
 composition and is refused for pipelines; the Claude model gateway is separate.
 
+The pipeline detail **Keys** tab is a names-only view of the same projection. It
+shows every stage, resolved key names with `own`/`shared`/`default` sources and
+delivery modes, plus unresolved selectors. The declared `env_file` is rechecked
+when the detail is requested and reported as `none`, `ok`, `missing`,
+`bad_mode`, `bad_owner`, `bad_location`, or `invalid`; no credential value is
+returned. This is an advisory drift snapshot, while delivery still performs the
+authoritative fail-closed validation.
+
 ### Chain pipelines on success
 
 Use a pipeline trigger when an upstream must finish successfully before the next

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -13602,6 +13602,14 @@ also refuses missing keys and reserved `GITMOOT_*` names. Values are read fresh
 at stage delivery for restart-free rotation. The job audit stores the path and
 expanded names only, not file values.
 
+The pipeline detail **Keys** tab exposes this authorization as names only: every
+stage appears in spec order with each resolved key's `own`, `shared`, or
+`default` source and delivery mode. It live-checks the declared `env_file` and
+reports `none`, `ok`, `missing`, `bad_mode`, `bad_owner`, `bad_location`, or
+`invalid`; selectors that cannot resolve after file drift are listed separately.
+The tab never reads values into its response, and delivery-time validation
+remains authoritative.
+
 ### Share a pipeline with another Gitmoot home
 
 Use a private GitHub repository as a reviewable pipeline catalog. The source and


### PR DESCRIPTION
WHAT:
Implemented issue #974 exactly as frozen, with no deviations. The dashboard module is pinned to ba81b5ad, PipelineDetail now exposes a live names-only Keys projection, and no commit or push was performed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-b7de1e61

RESULTS:
- go version: go1.26.4 linux/amd64
- npm run build:llms: passed
- go generate ./...: passed; pre/post worktree diff hashes identical
- go build -buildvcs=false ./...: passed
- go vet ./...: passed
- go test -buildvcs=false ./internal/...: passed; cli 330.387s, remaining packages green/cached
- git diff --check: passed

RISK:
Review the generated diff before merging.

TASK:
adhoc-b7de1e61

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented issue #974 exactly as frozen, with no deviations. The dashboard module is pinned to ba81b5ad, PipelineDetail now exposes a live names-only Keys projection, and no commit or push was performed.
````
