### PR TITLE
Gitmoot: TASK: Implement gitmoot issue #973. Read it first,

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -32,6 +32,7 @@ and does not affect an in-flight run.
 ```yaml
 name: nightly-sync          # required, name-safe token (letters, digits, - _)
 repo: owner/repo            # optional to register; REQUIRED to actually run
+description: Syncs nightly data for deployment. # optional purpose shown in inspection views
 env_file: /root/.config/nightly-sync/env # optional 0600 secret file
 env:                       # optional inline NON-secret defaults
   OUTPUT_DIR: /srv/nightly-sync
@@ -71,6 +72,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | --------------------------- | ------------ | -------- | ----- |
 | `name`                      | pipeline     | yes      | Stable identifier and DB primary key; a name-safe token (letters, digits, `-`, `_`). |
 | `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
+| `description`               | pipeline     | no       | Optional purpose (up to 500 characters) shown by `pipeline show`, dashboard detail, and `pipeline list` (truncated there). |
 | `env_file`                  | pipeline     | no       | Absolute operator-owned secret file. It must exist, be a regular file owned by the current uid with mode exactly `0600`, and live outside the Gitmoot home and every managed checkout. |
 | `env`                       | pipeline     | no       | Inline **non-secret** `KEY: value` defaults. Pipeline-owned and granted shared values take precedence. Values are delivered only when a shell stage selects the key. |
 | `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
@@ -637,9 +639,11 @@ stages:
 Shell commands are collapsed to a single-line preview (about 80 characters), and
 agent prompts to an escaped preview (about 100 characters); an ellipsis marks
 truncation. Missing agent registrations render as `(unregistered)` instead of
-making inspection fail. `pipeline list` keeps its existing six-column shape but
-uses `email` in the interval column for trigger pipelines (`email+6h` when a schedule is also present, and the mode reads `email-triggered (unbound)` before the first bind). `--json` remains
-additive: pipeline objects include `mode`, while stage objects include `kind` and
+making inspection fail. `pipeline list` appends an eighth description column,
+truncated to about 60 characters, and uses `email` in the interval column for
+trigger pipelines (`email+6h` when a schedule is also present, and the mode reads
+`email-triggered (unbound)` before the first bind). `--json` remains additive:
+pipeline objects include the full `description` and `mode`, while stage objects include `kind` and
 the available `agent_runtime`, `prompt_preview`, and `cmd_preview` fields without
 removing the full `prompt` or `cmd`.
 

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -557,6 +557,7 @@ type pipelineJSON struct {
 	Name                string                       `json:"name"`
 	Repo                string                       `json:"repo,omitempty"`
 	Group               string                       `json:"group"`
+	Description         string                       `json:"description,omitempty"`
 	Enabled             bool                         `json:"enabled"`
 	Mode                string                       `json:"mode"`
 	Interval            string                       `json:"interval,omitempty"`
@@ -606,7 +607,7 @@ func runPipelineList(args []string, stdout, stderr io.Writer) int {
 	}
 	for _, p := range pipelines {
 		group, _ := resolvedPipelineGroup(p)
-		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", p.Name, enabledLabel(p.Enabled), pipelineListInterval(p, pipelineUpstreamMissing(p, knownPipelines)), firstNonEmpty(p.Repo, "-"), firstNonEmpty(group, "-"), firstNonEmpty(p.LastStatus, "-"), firstNonEmpty(triggerBindingState(p.TriggerBinding), "-"))
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", p.Name, enabledLabel(p.Enabled), pipelineListInterval(p, pipelineUpstreamMissing(p, knownPipelines)), firstNonEmpty(p.Repo, "-"), firstNonEmpty(group, "-"), firstNonEmpty(p.LastStatus, "-"), firstNonEmpty(triggerBindingState(p.TriggerBinding), "-"), pipelineDescriptionPreview(pipelineDescription(p)))
 	}
 	return 0
 }
@@ -876,6 +877,7 @@ func pipelineToJSON(record db.Pipeline, withStages bool, agents map[string]db.Ag
 		Name:                record.Name,
 		Repo:                record.Repo,
 		Group:               group,
+		Description:         pipelineDescription(record),
 		Enabled:             record.Enabled,
 		Mode:                pipelineDisplayMode(record, upstreamMissing...),
 		Interval:            record.Interval,
@@ -937,6 +939,17 @@ func resolvedPipelineGroup(record db.Pipeline) (string, bool) {
 		return spec.Group, false
 	}
 	return strings.TrimSpace(record.Repo), true
+}
+
+func pipelineDescription(record db.Pipeline) string {
+	if spec, err := pipeline.Load([]byte(record.SpecYAML)); err == nil {
+		return spec.Description
+	}
+	return ""
+}
+
+func pipelineDescriptionPreview(description string) string {
+	return pipelinePreview(description, " ", 60)
 }
 
 func pipelineDisplayMode(record db.Pipeline, upstreamMissing ...bool) string {

--- a/internal/cli/pipeline_test.go
+++ b/internal/cli/pipeline_test.go
@@ -310,11 +310,12 @@ stages:
 	if code := Run([]string{"pipeline", "list", "--home", home}, &stdout, &stderr); code != 0 {
 		t.Fatalf("list exit=%d stderr=%s", code, stderr.String())
 	}
-	rows := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	rows := strings.Split(strings.TrimSuffix(stdout.String(), "\n"), "\n")
 	foundTrigger := false
+	foundDisplay := false
 	for _, row := range rows {
 		columns := strings.Split(row, "\t")
-		if len(columns) != 7 {
+		if len(columns) != 8 {
 			t.Fatalf("pipeline list changed column count: row=%q", row)
 		}
 		if columns[0] == "mail-flow" {
@@ -325,18 +326,55 @@ stages:
 			if columns[4] != "owner/repo" {
 				t.Fatalf("trigger pipeline group column = %q, want repo fallback", columns[4])
 			}
+			if columns[7] != "" {
+				t.Fatalf("trigger pipeline description column = %q, want empty", columns[7])
+			}
 		}
 		if columns[0] == "display-flow" {
+			foundDisplay = true
 			if columns[2] != "-" {
 				t.Fatalf("manual pipeline interval column = %q, want -", columns[2])
 			}
 			if columns[4] != "Product Operations" {
 				t.Fatalf("explicit pipeline group column = %q, want Product Operations", columns[4])
 			}
+			if columns[7] != "Coordinates product operations. Preserves the declared stage…" {
+				t.Fatalf("pipeline description column = %q, want truncated description", columns[7])
+			}
 		}
 	}
 	if !foundTrigger {
 		t.Fatalf("trigger pipeline missing from list: %s", stdout.String())
+	}
+	if !foundDisplay {
+		t.Fatalf("display pipeline missing from list: %s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"pipeline", "list", "--json", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("list --json exit=%d stderr=%s", code, stderr.String())
+	}
+	var listed []pipelineJSON
+	if err := json.Unmarshal(stdout.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list json: %v (%s)", err, stdout.String())
+	}
+	foundJSONDescription := false
+	for _, item := range listed {
+		switch item.Name {
+		case "display-flow":
+			foundJSONDescription = true
+			if item.Description != "Coordinates product operations.\nPreserves the declared stage order." {
+				t.Fatalf("list JSON description = %q, want full text", item.Description)
+			}
+		case "mail-flow":
+			if item.Description != "" {
+				t.Fatalf("list JSON empty description = %q", item.Description)
+			}
+		}
+	}
+	if !foundJSONDescription {
+		t.Fatalf("display pipeline missing from list JSON: %s", stdout.String())
 	}
 }
 
@@ -523,6 +561,18 @@ func TestPipelinePreviewMultibyteSafe(t *testing.T) {
 	}
 	if !strings.HasSuffix(preview, "\u2026") {
 		t.Fatalf("truncated preview should end with ellipsis: %q", preview)
+	}
+
+	description := strings.Repeat("界", 61)
+	descriptionPreview := pipelineDescriptionPreview(description)
+	if !utf8.ValidString(descriptionPreview) {
+		t.Fatalf("description preview is not valid UTF-8: %q", descriptionPreview)
+	}
+	if got := len([]rune(descriptionPreview)); got != 61 {
+		t.Fatalf("description preview rune length = %d, want 61", got)
+	}
+	if !strings.HasSuffix(descriptionPreview, "\u2026") {
+		t.Fatalf("truncated description should end with ellipsis: %q", descriptionPreview)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2739,9 +2739,11 @@ stages:
 ```
 
 An absent agent row renders as `(unregistered)` without failing `show`.
-`pipeline list` retains six columns and uses `email` or `after: <upstream>` in
-the interval column for a trigger pipeline. A removed or missing upstream is
-shown as `after: <upstream> (upstream missing)`. JSON adds pipeline `mode` and stage `kind`, `agent_runtime`,
+`pipeline list` appends an eighth description column, truncated to about 60
+characters, and uses `email` or `after: <upstream>` in the interval column for a
+trigger pipeline. A removed or missing upstream is shown as
+`after: <upstream> (upstream missing)`. JSON includes the full pipeline
+`description` plus `mode`, and stage `kind`, `agent_runtime`,
 `prompt_preview`, and `cmd_preview`; the existing full fields remain unchanged.
 
 An enabled `trigger.kind: email` pipeline auto-binds. If Activepieces is down,

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -280,11 +280,12 @@ stages:
 Shell commands are collapsed to a single-line preview (about 80 characters), and
 agent prompts to an escaped preview (about 100 characters); an ellipsis marks
 truncation. Missing agent registrations render as `(unregistered)` instead of
-making inspection fail. `pipeline list` keeps its existing six-column shape but
-uses `email` or `after: <upstream>` in the interval column for trigger pipelines
-(`email+6h` when an email schedule is also present, and the mode reads
-`email-triggered (unbound)` before the first bind). `--json` remains
-additive: pipeline objects include `mode`, while stage objects include `kind` and
+making inspection fail. `pipeline list` appends an eighth description column,
+truncated to about 60 characters, and uses `email` or `after: <upstream>` in the
+interval column for trigger pipelines (`email+6h` when an email schedule is also
+present, and the mode reads `email-triggered (unbound)` before the first bind).
+`--json` remains additive: pipeline objects include the full `description` plus
+`mode`, while stage objects include `kind` and
 the available `agent_runtime`, `prompt_preview`, and `cmd_preview` fields without
 removing the full `prompt` or `cmd`.
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2745,6 +2745,7 @@ and does not affect an in-flight run.
 ```yaml
 name: nightly-sync          # required, name-safe token (letters, digits, - _)
 repo: owner/repo            # optional to register; REQUIRED to actually run
+description: Syncs nightly data for deployment. # optional purpose shown in inspection views
 env_file: /root/.config/nightly-sync/env # optional 0600 secret file
 env:                       # optional inline NON-secret defaults
   OUTPUT_DIR: /srv/nightly-sync
@@ -2784,6 +2785,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | --------------------------- | ------------ | -------- | ----- |
 | `name`                      | pipeline     | yes      | Stable identifier and DB primary key; a name-safe token (letters, digits, `-`, `_`). |
 | `repo`                      | pipeline     | no\*     | `owner/name` the stages run against. Optional to **register**, but **required to run** — stage jobs need a managed repo for the worker to claim them. |
+| `description`               | pipeline     | no       | Optional purpose (up to 500 characters) shown by `pipeline show`, dashboard detail, and `pipeline list` (truncated there). |
 | `env_file`                  | pipeline     | no       | Absolute operator-owned secret file. It must exist, be a regular file owned by the current uid with mode exactly `0600`, and live outside the Gitmoot home and every managed checkout. |
 | `env`                       | pipeline     | no       | Inline **non-secret** `KEY: value` defaults. Pipeline-owned and granted shared values take precedence. Values are delivered only when a shell stage selects the key. |
 | `schedule.interval`         | pipeline     | cond.    | Required when a `schedule:` block is present. A positive Go duration (`24h`, `1h30m`). |
@@ -3350,9 +3352,11 @@ stages:
 Shell commands are collapsed to a single-line preview (about 80 characters), and
 agent prompts to an escaped preview (about 100 characters); an ellipsis marks
 truncation. Missing agent registrations render as `(unregistered)` instead of
-making inspection fail. `pipeline list` keeps its existing six-column shape but
-uses `email` in the interval column for trigger pipelines (`email+6h` when a schedule is also present, and the mode reads `email-triggered (unbound)` before the first bind). `--json` remains
-additive: pipeline objects include `mode`, while stage objects include `kind` and
+making inspection fail. `pipeline list` appends an eighth description column,
+truncated to about 60 characters, and uses `email` in the interval column for
+trigger pipelines (`email+6h` when a schedule is also present, and the mode reads
+`email-triggered (unbound)` before the first bind). `--json` remains additive:
+pipeline objects include the full `description` and `mode`, while stage objects include `kind` and
 the available `agent_runtime`, `prompt_preview`, and `cmd_preview` fields without
 removing the full `prompt` or `cmd`.
 
@@ -12034,9 +12038,11 @@ stages:
 ```
 
 An absent agent row renders as `(unregistered)` without failing `show`.
-`pipeline list` retains six columns and uses `email` or `after: <upstream>` in
-the interval column for a trigger pipeline. A removed or missing upstream is
-shown as `after: <upstream> (upstream missing)`. JSON adds pipeline `mode` and stage `kind`, `agent_runtime`,
+`pipeline list` appends an eighth description column, truncated to about 60
+characters, and uses `email` or `after: <upstream>` in the interval column for a
+trigger pipeline. A removed or missing upstream is shown as
+`after: <upstream> (upstream missing)`. JSON includes the full pipeline
+`description` plus `mode`, and stage `kind`, `agent_runtime`,
 `prompt_preview`, and `cmd_preview`; the existing full fields remain unchanged.
 
 An enabled `trigger.kind: email` pipeline auto-binds. If Activepieces is down,


### PR DESCRIPTION
WHAT:
Implemented issue #973: pipeline list now appends a truncated description column, while JSON returns the full description. Documentation and generated website corpus were updated. No commit or push performed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-64b0ec26

RESULTS:
- Focused CLI tests: ok github.com/gitmoot/gitmoot/internal/cli 0.294s.
- go generate ./...: passed; working diff remained byte-identical.
- go build -buildvcs=false ./...: passed.
- go vet ./...: passed.
- go test -buildvcs=false ./internal/cli/...: internal/cli passed in 331.574s; style passed in 0.004s; tui passed in 0.514s.
- git diff --check: passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-64b0ec26

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented issue #973: pipeline list now appends a truncated description column, while JSON returns the full description. Documentation and generated website corpus were updated. No commit or push performed.
````
