### PR TITLE
Gitmoot: TASK: Implement the PROXIED-MODE GENERALIZATION for pipeline shell

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -39,9 +39,9 @@ from ambient managed variables once. Existing files are never overwritten.
 For systemd deployments, keep `daemon.env` for operational values such as
 `PATH`; do not duplicate Claude secrets there after bootstrap.
 
-## Injected key registry and grants
+## Key registry and grants
 
-The shared injected-key source is an operator-owned env file. Its default path
+The shared key source is an operator-owned env file. Its default path
 is `<base-home>/.config/gitmoot/keychain.env`; `gitmoot key path` prints the
 resolved path and validation status. `[credentials] keychain_path` can select a
 different absolute path. The file must be regular, owned by the current uid,
@@ -56,6 +56,8 @@ print values:
 gitmoot key path
 gitmoot key add SOURCE_API_TOKEN --mode injected
 gitmoot key grant SOURCE_API_TOKEN --pipeline nightly-sync
+gitmoot key add PARTNER_API_TOKEN --mode proxied
+gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
 gitmoot key list --json
 gitmoot key show SOURCE_API_TOKEN
 gitmoot key revoke SOURCE_API_TOKEN --pipeline nightly-sync
@@ -64,12 +66,26 @@ gitmoot key rm SOURCE_API_TOKEN --force
 ```
 
 `rm` removes registry metadata and grants, not the operator's file entry.
-`proxied` mode is reserved for future gateway composition and cannot be granted
-to a pipeline. Pipeline shell stages may request granted `injected` names with
+`proxied` keys must be configured before they can be granted. `--auth bearer`
+places the real value in the upstream `Authorization` header; `--auth
+header:X-Api-Key` uses an approved custom header. The upstream must be an
+absolute HTTPS origin and its normalized base path is pinned. Pipeline shell
+stages may request granted `injected` or configured `proxied` names with
 `env_keys`; agent and gate stages remain ineligible. Resolution is Gitmoot's
 reserved `GITMOOT_*` namespace, then the pipeline's own `env_file`, then a
 granted shared key, then inline non-secret `env`. Registered but ungranted names
 are not visible to exact or glob selectors.
+
+For a proxied key, the shell receives a per-job `gitmoot-kc-...` placeholder in
+the requested variable and a `GITMOOT_PROXY_<KEY>_URL` loopback URL. Gitmoot
+rechecks the grant and configuration and rereads the keychain on every request,
+so rotation applies to the next request and revocation fails closed with `401`.
+The lease is revoked when the stage delivery ends.
+
+Proxied mode hides key bytes; it does **not** prevent an authorized child from
+exercising the credential on the pinned upstream. Curated upstreams and base
+paths are part of the model. A malicious or compromised upstream could still
+reflect a credential, so configure only trusted services.
 
 ## Claude model gateway
 
@@ -91,12 +107,10 @@ credential and ignore the placeholder — the gateway would then `401` the
 delivery (#936). The mirror never contains a credential; the operator's real
 config is only read, never modified.
 
-Pipeline-owned `env_file` values and granted shared keychain values are a
-separate **injected** mode for opaque API credentials whose shell script must
-present the real value. Gitmoot scopes those values to selected shell stages
-and audits names, sources, and modes only, but the selected process necessarily
-receives the real credential. This does not alter the Claude gateway or its
-placeholder flow.
+Pipeline key delivery is independent of the Claude gateway. `injected` keys
+give the selected shell process the real value. `proxied` keys use generic
+per-job loopback leases whose values are resolved for each request; they do not
+alter Claude's model-gateway placeholder flow.
 
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -100,7 +100,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
-| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from the pipeline's `env_file`, granted shared registry keys, or inline `env`. Shell stages only; no entry means no injected values. |
+| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from the pipeline's `env_file`, granted shared registry keys, or inline `env`. Shell stages only; no entry means no key access. |
 | `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
 
 `gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
@@ -126,6 +126,9 @@ keys must be registered and granted separately:
 gitmoot key path # edit this 0600 file; the CLI never accepts values
 gitmoot key add REDDIT_CLIENT_SECRET --mode injected
 gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
+gitmoot key add PARTNER_API_TOKEN --mode proxied
+gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
+gitmoot key grant PARTNER_API_TOKEN --pipeline trend-scout
 ```
 
 ```yaml
@@ -160,8 +163,21 @@ same rows. Delivery rechecks every shared grant and its registry mode; revoking
 after enqueue fails the stage rather than switching to another source. Inline
 `env` is stored in the pipeline spec and is therefore for non-secrets only. An
 injected key is visible to its shell process; this is scoping and audit, not a
-vault. `proxied` registry mode is stored for future gateway composition but is
-refused for pipeline grants. The Claude model gateway remains independent.
+vault.
+
+A configured `proxied` shared key instead gives the shell a per-job placeholder
+in `<KEY>` and a loopback endpoint in `GITMOOT_PROXY_<KEY>_URL`. The endpoint is
+pinned to the configured HTTPS origin and normalized base path. Gitmoot places
+the real credential as either bearer auth or an approved custom header, rereads
+the keychain and rechecks the grant on every request, and revokes the lease when
+delivery ends. Rotation therefore applies to the next request; revocation
+returns `401` without contacting the upstream. Agent and gate stages remain
+ineligible, and the Claude model gateway remains independent.
+
+Proxied mode hides key bytes; it does **not** prevent an authorized child from
+exercising the credential on the pinned upstream. Curated upstreams and base
+paths are part of the model. Configure only trusted upstreams because an
+upstream can observe and potentially reflect the credential.
 
 On `pipeline add --enable`, Gitmoot publishes the owned flow. An unavailable
 Activepieces instance leaves a pending binding; run

--- a/internal/cli/dashboard_web_pipelines.go
+++ b/internal/cli/dashboard_web_pipelines.go
@@ -273,19 +273,19 @@ func dashboardPipelineKeys(ctx context.Context, store *db.Store, home string, sp
 	if err != nil {
 		return dashboard.PipelineKeys{}, err
 	}
-	sharedNames := make(map[string]struct{})
+	availableShared := make(map[string]db.KeychainKey)
 	if len(sharedCandidates) > 0 {
 		// Keychain drift is advisory on this read-only endpoint. A missing or invalid
 		// file makes shared selectors unresolved; delivery remains fail-closed.
 		if names, loadErr := loadValidatedKeychainNames(ctx, store, home); loadErr == nil {
-			for name := range sharedCandidates {
+			for name, key := range sharedCandidates {
 				if _, present := names[name]; present {
-					sharedNames[name] = struct{}{}
+					availableShared[name] = key
 				}
 			}
 		}
 	}
-	resolution := projectPipelineEnvironment(spec, inspection.Names, sharedNames)
+	resolution := projectPipelineEnvironment(spec, inspection.Names, availableShared)
 	for _, stage := range spec.Stages {
 		row := dashboard.PipelineStageKeys{
 			ID:                  stage.ID,

--- a/internal/cli/dashboard_web_pipelines_test.go
+++ b/internal/cli/dashboard_web_pipelines_test.go
@@ -703,11 +703,12 @@ func TestWebDataSourcePipelineDetailKeysNamesOnlyAndLiveDrift(t *testing.T) {
 	const (
 		ownSentinel     = "own-secret-value-974"
 		sharedSentinel  = "shared-secret-value-974"
+		proxiedSentinel = "proxied-secret-value-874"
 		defaultSentinel = "inline-default-value-974"
 	)
 	home := dashboardTestHome(t)
 	envFile := writePipelineEnvFile(t, t.TempDir(), "OWN_TWO="+ownSentinel+"\nOWN_ONE="+ownSentinel+"\n", 0o600)
-	writeDefaultKeychain(t, home, "SHARED_TOKEN="+sharedSentinel+"\n")
+	writeDefaultKeychain(t, home, "SHARED_TOKEN="+sharedSentinel+"\nPROXY_TOKEN="+proxiedSentinel+"\n")
 	raw := fmt.Sprintf(`name: keys-view
 env_file: %q
 env:
@@ -715,7 +716,7 @@ env:
 stages:
   - id: deliver
     cmd: echo deliver
-    env_keys: [OWN_*, SHARED_TOKEN, DEFAULT_TOKEN]
+    env_keys: [OWN_*, SHARED_TOKEN, PROXY_TOKEN, DEFAULT_TOKEN]
   - id: harvest
     cmd: echo harvest
   - id: inspect
@@ -729,6 +730,15 @@ stages:
 		t.Fatal(err)
 	}
 	if _, err := store.GrantKeychainKey(context.Background(), db.KeychainConsumerPipeline, "keys-view", "SHARED_TOKEN"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddKeychainKey(context.Background(), "PROXY_TOKEN", db.KeychainModeProxied); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ConfigureKeychainProxy(context.Background(), "PROXY_TOKEN", "https://api.example.test/v1", db.KeychainProxyAuthBearer, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantKeychainKey(context.Background(), db.KeychainConsumerPipeline, "keys-view", "PROXY_TOKEN"); err != nil {
 		t.Fatal(err)
 	}
 	store.Close()
@@ -748,6 +758,7 @@ stages:
 		{Name: "OWN_ONE", Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected},
 		{Name: "OWN_TWO", Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected},
 		{Name: "SHARED_TOKEN", Source: pipelineKeySourceShared, Mode: db.KeychainModeInjected},
+		{Name: "PROXY_TOKEN", Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied},
 		{Name: "DEFAULT_TOKEN", Source: pipelineKeySourceDefault, Mode: db.KeychainModeInjected},
 	}
 	if got := detail.Keys.Stages[0]; got.ID != "deliver" || got.Kind != "shell" || !reflect.DeepEqual(got.Keys, wantKeys) || len(got.UnresolvedSelectors) != 0 {
@@ -762,7 +773,7 @@ stages:
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, sentinel := range []string{ownSentinel, sharedSentinel, defaultSentinel} {
+	for _, sentinel := range []string{ownSentinel, sharedSentinel, proxiedSentinel, defaultSentinel} {
 		if strings.Contains(string(encoded), sentinel) {
 			t.Fatalf("PipelineDetail leaked secret/default value %q: %s", sentinel, encoded)
 		}

--- a/internal/cli/key.go
+++ b/internal/cli/key.go
@@ -10,9 +10,14 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gitmoot/gitmoot/internal/credgw"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 )
+
+// Test-only seam for local httptest upstreams. Production configuration remains
+// HTTPS-only even for loopback addresses.
+var keyConfigureAllowLoopbackHTTP bool
 
 type keychainPathStatus struct {
 	Path   string `json:"path"`
@@ -44,6 +49,8 @@ func runKey(args []string, stdout, stderr io.Writer) int {
 		return runKeyList(args[1:], stdout, stderr)
 	case "show":
 		return runKeyShow(args[1:], stdout, stderr)
+	case "configure":
+		return runKeyConfigure(args[1:], stdout, stderr)
 	case "rm":
 		return runKeyRemove(args[1:], stdout, stderr)
 	case "grant":
@@ -63,6 +70,7 @@ func printKeyUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot key add <NAME> --mode injected|proxied [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot key list [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot key show <NAME> [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key configure <NAME> --upstream <URL> --auth bearer|header:<HeaderName> [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot key rm <NAME> [--force] [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot key grant <NAME> --pipeline <PIPELINE> [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot key revoke <NAME> --pipeline <PIPELINE> [--json] [--home DIR]")
@@ -254,13 +262,112 @@ func runKeyList(args []string, stdout, stderr io.Writer) int {
 		return encodeKeyJSON(stdout, stderr, output)
 	}
 	for _, key := range output.Keys {
-		writeLine(stdout, "%s\t%s\t%s\tgrants=%d", key.Name, key.Mode, key.CreatedAt, len(key.Grants))
+		writeLine(stdout, "%s\t%s\t%s\tgrants=%d\tupstream=%s\tauth=%s", key.Name, key.Mode, key.CreatedAt, len(key.Grants), firstNonEmpty(key.ProxyUpstream, "-"), keyProxyAuthLabel(key.KeychainKey))
 	}
 	return 0
 }
 
 func runKeyShow(args []string, stdout, stderr io.Writer) int {
 	return runKeyNamedRead("show", args, stdout, stderr)
+}
+
+func runKeyConfigure(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printKeyUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "key configure requires a name")
+			return 2
+		}
+		return 0
+	}
+	name := strings.TrimSpace(args[0])
+	fs := flag.NewFlagSet("key configure", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOut := fs.Bool("json", false, "print JSON")
+	upstream := fs.String("upstream", "", "fixed HTTPS upstream origin and base path")
+	auth := fs.String("auth", "", "credential placement: bearer or header:<HeaderName>")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || strings.TrimSpace(*upstream) == "" || strings.TrimSpace(*auth) == "" {
+		fmt.Fprintln(stderr, "key configure requires one name, --upstream <url>, and --auth bearer|header:<HeaderName>")
+		return 2
+	}
+	authKind, header, err := parseKeyProxyAuth(*auth)
+	if err != nil {
+		fmt.Fprintf(stderr, "key configure: %v\n", err)
+		return 2
+	}
+	policy, _, err := credgw.ValidateProxyPolicy(credgw.ProxyPolicy{
+		Upstream: strings.TrimSpace(*upstream), AuthKind: authKind, Header: header,
+		AllowLoopbackHTTP: keyConfigureAllowLoopbackHTTP,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "key configure: %v\n", err)
+		return 2
+	}
+	var output keychainKeyOutput
+	var status keychainPathStatus
+	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		key, found, err := store.GetKeychainKey(ctx, name)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return fmt.Errorf("key %s is not registered", name)
+		}
+		if key.Mode != db.KeychainModeProxied {
+			return fmt.Errorf("key %s uses %s mode; key configure requires proxied mode", name, key.Mode)
+		}
+		configured, err := store.ConfigureKeychainProxy(ctx, name, policy.Upstream, string(policy.AuthKind), policy.Header)
+		if err != nil {
+			return err
+		}
+		rows, err := keyOutputs(ctx, store, []db.KeychainKey{configured})
+		if err != nil {
+			return err
+		}
+		output = rows[0]
+		status = inspectKeychain(ctx, store, *home)
+		return nil
+	}); err != nil {
+		fmt.Fprintf(stderr, "key configure: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		return encodeKeyJSON(stdout, stderr, struct {
+			Keychain keychainPathStatus `json:"keychain"`
+			Key      keychainKeyOutput  `json:"key"`
+		}{status, output})
+	}
+	writeLine(stdout, "configured key %s upstream=%s auth=%s", name, output.ProxyUpstream, keyProxyAuthLabel(output.KeychainKey))
+	return 0
+}
+
+func parseKeyProxyAuth(raw string) (credgw.ProxyAuthKind, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == string(credgw.ProxyAuthBearer) {
+		return credgw.ProxyAuthBearer, "", nil
+	}
+	if header, ok := strings.CutPrefix(raw, "header:"); ok && strings.TrimSpace(header) != "" {
+		return credgw.ProxyAuthHeader, strings.TrimSpace(header), nil
+	}
+	return "", "", fmt.Errorf("invalid --auth %q; use bearer or header:<HeaderName>", raw)
+}
+
+func keyProxyAuthLabel(key db.KeychainKey) string {
+	if key.ProxyAuthKind == db.KeychainProxyAuthHeader {
+		return "header:" + key.ProxyHeader
+	}
+	if key.ProxyAuthKind == db.KeychainProxyAuthBearer {
+		return db.KeychainProxyAuthBearer
+	}
+	return "-"
 }
 
 func runKeyNamedRead(verb string, args []string, stdout, stderr io.Writer) int {
@@ -321,6 +428,8 @@ func runKeyNamedRead(verb string, args []string, stdout, stderr io.Writer) int {
 	}
 	writeLine(stdout, "name: %s", output.Name)
 	writeLine(stdout, "mode: %s", output.Mode)
+	writeLine(stdout, "proxy_upstream: %s", firstNonEmpty(output.ProxyUpstream, "-"))
+	writeLine(stdout, "proxy_auth: %s", keyProxyAuthLabel(output.KeychainKey))
 	writeLine(stdout, "created_at: %s", output.CreatedAt)
 	writeLine(stdout, "keychain: %s (%s)", status.Path, status.Status)
 	writeLine(stdout, "grants:")
@@ -441,8 +550,8 @@ func runKeyGrantMutation(grant bool, args []string, stdout, stderr io.Writer) in
 			if !found {
 				return fmt.Errorf("key %s is not registered", name)
 			}
-			if key.Mode != db.KeychainModeInjected {
-				return fmt.Errorf("key %s uses proxied mode; pipeline grants currently accept injected keys only", name)
+			if key.Mode == db.KeychainModeProxied && !key.ProxyConfigured() {
+				return fmt.Errorf("key %s uses proxied mode but is not configured; run %s", name, keyConfigureCommand(name))
 			}
 			path, values, err := loadValidatedKeychainFile(ctx, store, *home)
 			if err != nil {
@@ -478,4 +587,8 @@ func runKeyGrantMutation(grant bool, args []string, stdout, stderr io.Writer) in
 	}
 	writeLine(stdout, "%s key %s for pipeline %s", past, name, *pipelineName)
 	return 0
+}
+
+func keyConfigureCommand(name string) string {
+	return fmt.Sprintf("gitmoot key configure %s --upstream <url> --auth bearer|header:<HeaderName>", name)
 }

--- a/internal/cli/key_test.go
+++ b/internal/cli/key_test.go
@@ -72,6 +72,14 @@ func TestKeyCLIRegistryGrantsAndSecretSafety(t *testing.T) {
 	} else if strings.Contains(out+errOut, keychainSentinel) {
 		t.Fatalf("proxied refusal leaked value: %q %q", out, errOut)
 	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "configure", "PROXY", "--upstream", "https://api.example.test/v1/", "--auth", "header:X-Api-Token", "--home", home, "--json"); code != 0 || !strings.Contains(out, `"proxy_upstream": "https://api.example.test/v1"`) || !strings.Contains(out, `"proxy_auth_kind": "header"`) || !strings.Contains(out, `"proxy_header": "X-Api-Token"`) {
+		t.Fatalf("key configure code=%d out=%q err=%q", code, out, errOut)
+	} else if strings.Contains(out+errOut, keychainSentinel) {
+		t.Fatalf("key configure leaked value: %q %q", out, errOut)
+	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "PROXY", "--pipeline", "pipe", "--home", home); code != 0 {
+		t.Fatalf("configured proxied grant code=%d out=%q err=%q", code, out, errOut)
+	}
 	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "SHARED", "--pipeline", "pipe", "--home", home, "--json"); code != 0 {
 		t.Fatalf("grant code=%d out=%q err=%q", code, out, errOut)
 	} else if strings.Contains(out+errOut, keychainSentinel) {
@@ -81,13 +89,22 @@ func TestKeyCLIRegistryGrantsAndSecretSafety(t *testing.T) {
 	for _, args := range [][]string{
 		{"key", "list", "--home", home, "--json"},
 		{"key", "show", "SHARED", "--home", home, "--json"},
+		{"key", "show", "PROXY", "--home", home, "--json"},
 		{"key", "list", "--home", home},
 		{"key", "show", "SHARED", "--home", home},
+		{"key", "show", "PROXY", "--home", home},
 	} {
 		code, out, errOut := runKeyTestCommand(t, args...)
 		wantGrantTarget := args[1] == "show" || slices.Contains(args, "--json")
-		if code != 0 || !strings.Contains(out, "SHARED") || (wantGrantTarget && !strings.Contains(out, "pipe")) {
+		wantName := "SHARED"
+		if slices.Contains(args, "PROXY") {
+			wantName = "PROXY"
+		}
+		if code != 0 || !strings.Contains(out, wantName) || (wantGrantTarget && !strings.Contains(out, "pipe")) {
 			t.Fatalf("%v code=%d out=%q err=%q", args, code, out, errOut)
+		}
+		if wantName == "PROXY" && (!strings.Contains(out, "https://api.example.test/v1") || !strings.Contains(out, "X-Api-Token")) {
+			t.Fatalf("%v omitted proxy configuration: %q", args, out)
 		}
 		if strings.Contains(out+errOut, keychainSentinel) {
 			t.Fatalf("%v leaked value: %q %q", args, out, errOut)
@@ -115,6 +132,53 @@ func TestKeyCLIRegistryGrantsAndSecretSafety(t *testing.T) {
 	}
 	if strings.Contains(printKeyUsageString(), "value") {
 		t.Fatal("key command usage exposes a value-input option")
+	}
+}
+
+func TestKeyConfigureRejectsUnsafeProxyMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		upstream string
+		auth     string
+		want     string
+	}{
+		{name: "http non-loopback", upstream: "http://api.example.test/v1", auth: "bearer", want: "HTTPS is required"},
+		{name: "userinfo", upstream: "https://user:pass@api.example.test/v1", auth: "bearer", want: "userinfo is not allowed"},
+		{name: "query", upstream: "https://api.example.test/v1?token=x", auth: "bearer", want: "query is not allowed"},
+		{name: "fragment", upstream: "https://api.example.test/v1#part", auth: "bearer", want: "fragment is not allowed"},
+		{name: "relative", upstream: "api.example.test/v1", auth: "bearer", want: "absolute URL with a host"},
+		{name: "dot path", upstream: "https://api.example.test/v1/../admin", auth: "bearer", want: "escaping segment"},
+		{name: "encoded dot path", upstream: "https://api.example.test/v1/%2e%2e/admin", auth: "bearer", want: "escaping segment"},
+		{name: "bad header token", upstream: "https://api.example.test/v1", auth: "header:Bad Header", want: "HTTP token"},
+		{name: "hop by hop", upstream: "https://api.example.test/v1", auth: "header:Connection", want: "not allowed"},
+		{name: "host", upstream: "https://api.example.test/v1", auth: "header:Host", want: "not allowed"},
+		{name: "cookie", upstream: "https://api.example.test/v1", auth: "header:Cookie", want: "not allowed"},
+		{name: "proxy auth", upstream: "https://api.example.test/v1", auth: "header:Proxy-Authorization", want: "not allowed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			writeDefaultKeychain(t, home, "PROXY=proxy-"+keychainSentinel+"\n")
+			if code, out, errOut := runKeyTestCommand(t, "key", "add", "PROXY", "--mode", "proxied", "--home", home); code != 0 {
+				t.Fatalf("key add code=%d out=%q err=%q", code, out, errOut)
+			}
+			code, out, errOut := runKeyTestCommand(t, "key", "configure", "PROXY", "--upstream", tt.upstream, "--auth", tt.auth, "--home", home)
+			if code == 0 || !strings.Contains(errOut, tt.want) {
+				t.Fatalf("configure code=%d out=%q err=%q want=%q", code, out, errOut, tt.want)
+			}
+			if strings.Contains(out+errOut, keychainSentinel) {
+				t.Fatalf("configure error leaked value: out=%q err=%q", out, errOut)
+			}
+		})
+	}
+
+	home := t.TempDir()
+	writeDefaultKeychain(t, home, "INJECTED="+keychainSentinel+"\n")
+	if code, out, errOut := runKeyTestCommand(t, "key", "add", "INJECTED", "--mode", "injected", "--home", home); code != 0 {
+		t.Fatalf("key add injected code=%d out=%q err=%q", code, out, errOut)
+	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "configure", "INJECTED", "--upstream", "https://api.example.test", "--auth", "bearer", "--home", home); code == 0 || !strings.Contains(errOut, "requires proxied mode") {
+		t.Fatalf("configure injected code=%d out=%q err=%q", code, out, errOut)
 	}
 }
 

--- a/internal/cli/pipeline_env.go
+++ b/internal/cli/pipeline_env.go
@@ -11,11 +11,16 @@ import (
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/credgw"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
+
+// Test-only seam for proxied shell-stage httptest upstreams. Production
+// keycard proxy delivery remains HTTPS-only.
+var pipelineProxyAllowLoopbackHTTP bool
 
 const pipelineEnvFileMode os.FileMode = 0o600
 
@@ -76,29 +81,40 @@ func resolvePipelineEnvironment(ctx context.Context, store *db.Store, home strin
 	if err != nil {
 		return pipelineEnvironmentResolution{}, err
 	}
-	sharedNames := make(map[string]struct{})
+	availableShared := make(map[string]db.KeychainKey)
 	if len(sharedCandidates) > 0 {
 		shared, err := loadValidatedKeychainNames(ctx, store, home)
 		if err != nil {
 			return pipelineEnvironmentResolution{}, err
 		}
-		for name := range sharedCandidates {
+		for name, key := range sharedCandidates {
 			if _, present := shared[name]; present {
-				sharedNames[name] = struct{}{}
+				availableShared[name] = key
 			}
 		}
 	}
-	return projectPipelineEnvironment(spec, ownNames, sharedNames), nil
+	return projectPipelineEnvironment(spec, ownNames, availableShared), nil
 }
 
-func projectPipelineEnvironment(spec pipeline.Spec, ownNames, sharedNames map[string]struct{}) pipelineEnvironmentResolution {
+func projectPipelineEnvironment(spec pipeline.Spec, ownNames map[string]struct{}, sharedKeys map[string]db.KeychainKey) pipelineEnvironmentResolution {
 	defaultNames := make(map[string]struct{}, len(spec.Env))
 	for name := range spec.Env {
 		defaultNames[name] = struct{}{}
 	}
+	sharedInjected := make(map[string]struct{})
+	sharedProxied := make(map[string]struct{})
+	for name, key := range sharedKeys {
+		switch key.Mode {
+		case db.KeychainModeInjected:
+			sharedInjected[name] = struct{}{}
+		case db.KeychainModeProxied:
+			sharedProxied[name] = struct{}{}
+		}
+	}
 	sources := []pipeline.EnvKeySource{
 		{Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected, Names: ownNames},
-		{Source: pipelineKeySourceShared, Mode: db.KeychainModeInjected, Names: sharedNames},
+		{Source: pipelineKeySourceShared, Mode: db.KeychainModeInjected, Names: sharedInjected},
+		{Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied, Names: sharedProxied},
 		{Source: pipelineKeySourceDefault, Mode: db.KeychainModeInjected, Names: defaultNames},
 	}
 	resolution := pipelineEnvironmentResolution{}
@@ -136,7 +152,13 @@ func pipelineSharedKeyCandidates(ctx context.Context, store *db.Store, spec pipe
 		if err != nil {
 			return nil, err
 		}
-		if found && key.Mode == db.KeychainModeInjected {
+		if !found {
+			continue
+		}
+		if key.Mode == db.KeychainModeProxied && !key.ProxyConfigured() {
+			return nil, fmt.Errorf("key %s uses proxied mode but is not configured; run %s", key.Name, keyConfigureCommand(key.Name))
+		}
+		if key.Mode == db.KeychainModeInjected || key.Mode == db.KeychainModeProxied {
 			candidates[key.Name] = key
 		}
 	}
@@ -465,7 +487,54 @@ func (a pipelineEnvDeliveryAdapter) Deliver(ctx context.Context, agent runtime.A
 	}
 	var own, shared map[string]string
 	entries := make([]string, 0, len(a.access))
+	var leases []*credgw.Lease
+	defer func() {
+		for i := len(leases) - 1; i >= 0; i-- {
+			leases[i].Revoke()
+		}
+	}()
+	var proxyGateway *credgw.Gateway
 	for _, access := range a.access {
+		if access.Mode == db.KeychainModeProxied {
+			if access.Source != pipelineKeySourceShared {
+				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: proxied key %q must use shared source", access.Name)
+			}
+			if strings.TrimSpace(job.ID) == "" {
+				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: proxied key %q requires a job id", access.Name)
+			}
+			key, granted, err := a.store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, a.pipelineName, access.Name)
+			if err != nil {
+				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: re-check proxied grant for key %q: %w", access.Name, err)
+			}
+			if !granted || key.Mode != db.KeychainModeProxied || !key.ProxyConfigured() {
+				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: proxied grant for key %q was revoked, changed, or is unconfigured", access.Name)
+			}
+			policy, _, err := credgw.ValidateProxyPolicy(credgw.ProxyPolicy{
+				Upstream: key.ProxyUpstream, AuthKind: credgw.ProxyAuthKind(key.ProxyAuthKind), Header: key.ProxyHeader,
+				AllowLoopbackHTTP: pipelineProxyAllowLoopbackHTTP,
+			})
+			if err != nil {
+				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: invalid proxy configuration for key %q: %w", access.Name, err)
+			}
+			if proxyGateway == nil {
+				paths, err := configPathsForPipelineStore(a.store, a.home)
+				if err != nil {
+					return runtime.Result{}, fmt.Errorf("load pipeline stage environment: resolve credential gateway home: %w", err)
+				}
+				proxyGateway, err = modelGatewayRegistry.Gateway(paths.Home, modelGatewayLogf)
+				if err != nil {
+					return runtime.Result{}, fmt.Errorf("load pipeline stage environment: start credential gateway: %w", err)
+				}
+			}
+			lease, err := proxyGateway.RegisterProxy(job.ID, policy, a.proxyResolver(access.Name))
+			if err != nil {
+				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: mint proxied lease for key %q: %w", access.Name, err)
+			}
+			leases = append(leases, lease)
+			entries = append(entries, access.Name+"="+lease.Placeholder())
+			entries = append(entries, "GITMOOT_PROXY_"+access.Name+"_URL="+lease.URL())
+			continue
+		}
 		if access.Mode != db.KeychainModeInjected {
 			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: key %q has unsupported mode %q", access.Name, access.Mode)
 		}
@@ -511,6 +580,30 @@ func (a pipelineEnvDeliveryAdapter) Deliver(ctx context.Context, agent runtime.A
 	}
 	job.ShellEnv = prependPipelineEnvironment(entries, job.ShellEnv)
 	return a.inner.Deliver(ctx, agent, job)
+}
+
+func (a pipelineEnvDeliveryAdapter) proxyResolver(name string) credgw.CredentialResolver {
+	return func(ctx context.Context) (credgw.ResolvedCredential, error) {
+		key, granted, err := a.store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, a.pipelineName, name)
+		if err != nil {
+			return credgw.ResolvedCredential{}, err
+		}
+		if !granted || key.Mode != db.KeychainModeProxied || !key.ProxyConfigured() {
+			return credgw.ResolvedCredential{}, errors.New("proxied grant is unavailable")
+		}
+		_, values, err := loadValidatedKeychainFile(ctx, a.store, a.home)
+		if err != nil {
+			return credgw.ResolvedCredential{}, err
+		}
+		value := values[name]
+		if strings.TrimSpace(value) == "" {
+			return credgw.ResolvedCredential{}, errors.New("proxied key value is unavailable")
+		}
+		return credgw.ResolvedCredential{
+			Value: value, Upstream: key.ProxyUpstream,
+			AuthKind: credgw.ProxyAuthKind(key.ProxyAuthKind), Header: key.ProxyHeader,
+		}, nil
+	}
 }
 
 func (a pipelineEnvDeliveryAdapter) deliverLegacy(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {

--- a/internal/cli/pipeline_env_test.go
+++ b/internal/cli/pipeline_env_test.go
@@ -3,16 +3,21 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/credgw"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
@@ -433,6 +438,111 @@ func TestPipelineSharedKeyDeliveryRotationAndRevocation(t *testing.T) {
 	}
 }
 
+func TestPipelineProxiedKeyResolutionAndDeliveryLease(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	writeDefaultKeychain(t, home, "PROXY_KEY="+pipelineEnvSecretA+"\n")
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "proxy-delivery", SpecYAML: "name: proxy-delivery\nstages: [{id: run, cmd: echo}]\n"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddKeychainKey(ctx, "PROXY_KEY", db.KeychainModeProxied); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ConfigureKeychainProxy(ctx, "PROXY_KEY", "https://api.example.test/v1", db.KeychainProxyAuthBearer, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantKeychainKey(ctx, db.KeychainConsumerPipeline, "proxy-delivery", "PROXY_KEY"); err != nil {
+		t.Fatal(err)
+	}
+	spec := pipeline.Spec{Name: "proxy-delivery", Stages: []pipeline.Stage{{ID: "run", Cmd: "echo", EnvKeys: []string{"PROXY_KEY"}}}}
+	access, err := resolvePipelineStageEnvAccess(ctx, store, home, spec, spec.Stages[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []workflow.PipelineKeyAccess{{Stage: "run", Name: "PROXY_KEY", Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied}}
+	if !reflect.DeepEqual(access.Access, want) {
+		t.Fatalf("proxied access = %#v, want %#v", access.Access, want)
+	}
+
+	previousRegistry := modelGatewayRegistry
+	previousLogf := modelGatewayLogf
+	modelGatewayRegistry = credgw.NewRegistry()
+	modelGatewayLogf = func(string, ...any) {}
+	paths, err := configPathsForPipelineStore(store, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = modelGatewayRegistry.CloseHome(context.Background(), paths.Home)
+		modelGatewayRegistry = previousRegistry
+		modelGatewayLogf = previousLogf
+	})
+	capture := &pipelineEnvCaptureAdapter{}
+	wrapper := wrapPipelineEnvDeliveryAdapter(store, home, workflow.JobPayload{
+		PipelineName: "proxy-delivery", PipelineKeyAccess: access.Access,
+	}, capture)
+	if _, err := wrapper.Deliver(ctx, runtime.Agent{}, runtime.Job{ID: "proxy-delivery-job"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.jobs) != 1 {
+		t.Fatalf("deliveries = %d", len(capture.jobs))
+	}
+	env := capture.jobs[0].ShellEnv
+	placeholder := envEntryValue(env, "PROXY_KEY")
+	leaseURL := envEntryValue(env, "GITMOOT_PROXY_PROXY_KEY_URL")
+	if !strings.HasPrefix(placeholder, "gitmoot-kc-proxy-delivery-job-") || !strings.HasPrefix(leaseURL, "http://127.0.0.1:") {
+		t.Fatalf("proxied shell env = %#v", env)
+	}
+	if strings.Contains(strings.Join(env, "\n"), pipelineEnvSecretA) {
+		t.Fatalf("real proxied value reached ShellEnv: %#v", env)
+	}
+	request, _ := http.NewRequest(http.MethodGet, leaseURL, nil)
+	request.Header.Set("Authorization", "Bearer "+placeholder)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("deferred lease revocation status = %d", response.StatusCode)
+	}
+}
+
+func TestPipelineUnconfiguredProxiedKeyFailsAtEnqueue(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	writeDefaultKeychain(t, home, "PROXY_KEY="+pipelineEnvSecretA+"\n")
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "unconfigured-proxy", SpecYAML: "name: unconfigured-proxy\nstages: [{id: run, cmd: echo}]\n"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddKeychainKey(ctx, "PROXY_KEY", db.KeychainModeProxied); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(ctx, `INSERT INTO keychain_grants(consumer_kind, consumer_id, key_name) VALUES (?, ?, ?)`, db.KeychainConsumerPipeline, "unconfigured-proxy", "PROXY_KEY"); err != nil {
+		t.Fatal(err)
+	}
+	spec := pipeline.Spec{Name: "unconfigured-proxy", Stages: []pipeline.Stage{{ID: "run", Cmd: "echo", EnvKeys: []string{"PROXY_KEY"}}}}
+	_, err = resolvePipelineStageEnvAccess(ctx, store, home, spec, spec.Stages[0])
+	if err == nil || !strings.Contains(err.Error(), "gitmoot key configure PROXY_KEY") {
+		t.Fatalf("unconfigured proxied resolution error = %v", err)
+	}
+}
+
+func envEntryValue(env []string, name string) string {
+	prefix := name + "="
+	for i := len(env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(env[i], prefix) {
+			return strings.TrimPrefix(env[i], prefix)
+		}
+	}
+	return ""
+}
+
 func TestPipelineEnvironmentValidationTiming(t *testing.T) {
 	home := t.TempDir()
 	specFile := writeSpec(t, "name: unresolved-env\nrepo: owner/repo\nstages: [{id: run, cmd: echo, env_keys: [MISSING]}]\n")
@@ -814,4 +924,237 @@ stages:
 	}); err != nil && !os.IsNotExist(err) {
 		t.Fatal(err)
 	}
+}
+
+func TestPipelineProxiedKeyShellE2E(t *testing.T) {
+	ctx := context.Background()
+	home, paths, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	const (
+		keyName  = "KEYCARD_PROXY_E2E"
+		sentinel = "proxied-real-sentinel-874"
+	)
+	writeDefaultKeychain(t, home, keyName+"="+sentinel+"\n")
+
+	var upstreamMu sync.Mutex
+	upstreamCalls := 0
+	var upstreamProblems []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamMu.Lock()
+		upstreamCalls++
+		if r.URL.Path != "/pinned/action" {
+			upstreamProblems = append(upstreamProblems, "unexpected path "+r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+sentinel {
+			upstreamProblems = append(upstreamProblems, "upstream did not receive the real bearer")
+		}
+		if strings.Contains(r.Header.Get("Authorization"), "gitmoot-kc-") {
+			upstreamProblems = append(upstreamProblems, "upstream received the placeholder")
+		}
+		upstreamMu.Unlock()
+		if _, err := store.RevokeKeychainKey(context.Background(), db.KeychainConsumerPipeline, "proxy-e2e", keyName); err != nil {
+			upstreamMu.Lock()
+			upstreamProblems = append(upstreamProblems, "revoke failed")
+			upstreamMu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	previousRegistry := modelGatewayRegistry
+	previousLogf := modelGatewayLogf
+	previousConfigureHTTP := keyConfigureAllowLoopbackHTTP
+	previousDeliveryHTTP := pipelineProxyAllowLoopbackHTTP
+	modelGatewayRegistry = credgw.NewRegistry()
+	var gatewayLogs gatewayLogSink
+	modelGatewayLogf = gatewayLogs.Logf
+	keyConfigureAllowLoopbackHTTP = true
+	pipelineProxyAllowLoopbackHTTP = true
+	configPaths, err := configPathsForPipelineStore(store, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = modelGatewayRegistry.CloseHome(context.Background(), configPaths.Home)
+		modelGatewayRegistry = previousRegistry
+		modelGatewayLogf = previousLogf
+		keyConfigureAllowLoopbackHTTP = previousConfigureHTTP
+		pipelineProxyAllowLoopbackHTTP = previousDeliveryHTTP
+	})
+
+	testBinary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	envDump := filepath.Join(t.TempDir(), "proxy-child-env.txt")
+	t.Setenv("GITMOOT_PIPELINE_PROXY_HELPER", "1")
+	t.Setenv("GITMOOT_PIPELINE_PROXY_ENV_DUMP", envDump)
+	command := fmt.Sprintf("%q -test.run '^TestPipelineProxiedShellHelperProcess$'", testBinary)
+	specFile := writeSpec(t, fmt.Sprintf(`name: proxy-e2e
+repo: owner/repo
+stages:
+  - id: call
+    cmd: |
+      %s
+    env_keys: [%s]
+`, command, keyName))
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"pipeline", "add", specFile, "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("pipeline add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	for _, args := range [][]string{
+		{"key", "add", keyName, "--mode", "proxied", "--home", home},
+		{"key", "configure", keyName, "--upstream", upstream.URL + "/pinned", "--auth", "bearer", "--home", home},
+		{"key", "grant", keyName, "--pipeline", "proxy-e2e", "--home", home},
+	} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run(args, &stdout, &stderr); code != 0 {
+			t.Fatalf("%v code=%d stdout=%q stderr=%q", args, code, stdout.String(), stderr.String())
+		}
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"pipeline", "run", "proxy-e2e", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("pipeline run code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	runID := strings.TrimSpace(stdout.String())
+	enqueue := newPipelineStageEnqueuer(store, home)
+	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Date(2026, 7, 16, 17, 0, 0, 0, time.UTC)
+	for i := 0; i < 8; i++ {
+		if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+			t.Fatalf("worker tick %d: %v", i, err)
+		}
+		if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+			t.Fatalf("pipeline scan %d: %v", i, err)
+		}
+		run, _, err := store.GetPipelineRun(ctx, runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run.State != pipeline.RunRunning {
+			if run.State != pipeline.RunSucceeded {
+				t.Fatalf("run state=%s halt=%s reason=%s", run.State, run.HaltStage, run.HaltReason)
+			}
+			break
+		}
+	}
+	upstreamMu.Lock()
+	if upstreamCalls != 1 || len(upstreamProblems) != 0 {
+		t.Fatalf("upstream calls=%d problems=%v", upstreamCalls, upstreamProblems)
+	}
+	upstreamMu.Unlock()
+	dump, err := os.ReadFile(envDump)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dumpLines := strings.Split(strings.TrimSpace(string(dump)), "\n")
+	if len(dumpLines) != 2 || !strings.HasPrefix(dumpLines[0], "gitmoot-kc-") || !strings.HasPrefix(dumpLines[1], "http://127.0.0.1:") || strings.Contains(string(dump), sentinel) {
+		t.Fatalf("child proxy env dump = %q", dump)
+	}
+	placeholder := dumpLines[0]
+
+	stage := stageRow(t, store, runID, "call")
+	job, err := store.GetJob(ctx, stage.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantAccess := []workflow.PipelineKeyAccess{{Stage: "call", Name: keyName, Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied}}
+	if !reflect.DeepEqual(payload.PipelineKeyAccess, wantAccess) {
+		t.Fatalf("proxied payload access = %#v", payload.PipelineKeyAccess)
+	}
+	detail, err := (&webDataSource{home: home}).PipelineDetail(ctx, "proxy-e2e")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dashboardJSON, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListJobEvents(ctx, stage.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted := job.Payload + string(dashboardJSON) + gatewayLogs.String()
+	for _, event := range events {
+		persisted += event.Message
+	}
+	for _, forbidden := range []string{sentinel, placeholder} {
+		if strings.Contains(persisted, forbidden) {
+			t.Fatalf("persisted/logged output contains forbidden capability or value")
+		}
+	}
+	for _, persistedPath := range []string{paths.Database, paths.Database + "-wal"} {
+		data, err := os.ReadFile(persistedPath)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		if bytes.Contains(data, []byte(sentinel)) || bytes.Contains(data, []byte(placeholder)) {
+			t.Fatalf("credential material persisted in %s", persistedPath)
+		}
+	}
+	if err := filepath.WalkDir(paths.Logs, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if bytes.Contains(data, []byte(sentinel)) || bytes.Contains(data, []byte(placeholder)) {
+			return fmt.Errorf("credential material persisted in log %s", path)
+		}
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+}
+
+func TestPipelineProxiedShellHelperProcess(t *testing.T) {
+	if os.Getenv("GITMOOT_PIPELINE_PROXY_HELPER") != "1" {
+		return
+	}
+	placeholder := os.Getenv("KEYCARD_PROXY_E2E")
+	leaseURL := os.Getenv("GITMOOT_PROXY_KEYCARD_PROXY_E2E_URL")
+	if !strings.HasPrefix(placeholder, "gitmoot-kc-") || leaseURL == "" || placeholder == "proxied-real-sentinel-874" {
+		fmt.Fprintln(os.Stderr, "invalid proxied child environment")
+		os.Exit(2)
+	}
+	if err := os.WriteFile(os.Getenv("GITMOOT_PIPELINE_PROXY_ENV_DUMP"), []byte(placeholder+"\n"+leaseURL+"\n"), 0o600); err != nil {
+		fmt.Fprintln(os.Stderr, "write proxy environment audit failed")
+		os.Exit(2)
+	}
+	call := func(want int) {
+		request, err := http.NewRequest(http.MethodPost, leaseURL+"/action", strings.NewReader("safe-body"))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "build proxy request failed")
+			os.Exit(2)
+		}
+		request.Header.Set("Authorization", "Bearer "+placeholder)
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "proxy request failed")
+			os.Exit(2)
+		}
+		response.Body.Close()
+		if response.StatusCode != want {
+			fmt.Fprintln(os.Stderr, "unexpected proxy response")
+			os.Exit(2)
+		}
+	}
+	call(http.StatusNoContent)
+	call(http.StatusUnauthorized)
+	fmt.Fprint(os.Stdout, `{"gitmoot_result":{"decision":"approved","summary":"proxied request lifecycle passed","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`)
+	os.Exit(0)
 }

--- a/internal/credgw/gateway.go
+++ b/internal/credgw/gateway.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -31,6 +32,35 @@ type Credential struct {
 	Value string
 }
 
+type ProxyAuthKind string
+
+const (
+	ProxyAuthBearer ProxyAuthKind = "bearer"
+	ProxyAuthHeader ProxyAuthKind = "header"
+)
+
+// ProxyPolicy pins one generic lease to a complete origin, normalized base
+// path, and credential placement. AllowLoopbackHTTP exists solely for tests;
+// production callers leave it false and therefore require HTTPS.
+type ProxyPolicy struct {
+	Upstream          string
+	AuthKind          ProxyAuthKind
+	Header            string
+	AllowLoopbackHTTP bool
+}
+
+// ResolvedCredential is returned for every proxied request. The gateway checks
+// that the current metadata still matches the lease's pinned policy before it
+// uses Value, so grant/config changes fail closed and key rotation is immediate.
+type ResolvedCredential struct {
+	Value    string
+	Upstream string
+	AuthKind ProxyAuthKind
+	Header   string
+}
+
+type CredentialResolver func(context.Context) (ResolvedCredential, error)
+
 // Policy is snapshotted when a job lease is created. Upstream is fixed by the
 // host; AllowedHosts is an exact hostname allowlist, never child-controlled.
 type Policy struct {
@@ -46,9 +76,10 @@ type Gateway struct {
 	client   *http.Client
 	logf     LogFunc
 
-	mu      sync.RWMutex
-	entries map[string]entry
-	closed  bool
+	mu           sync.RWMutex
+	entries      map[string]entry
+	proxyEntries map[string]proxyEntry
+	closed       bool
 }
 
 type entry struct {
@@ -56,6 +87,14 @@ type entry struct {
 	credential Credential
 	upstream   *url.URL
 	allowed    map[string]struct{}
+}
+
+type proxyEntry struct {
+	jobID       string
+	placeholder string
+	policy      ProxyPolicy
+	upstream    *url.URL
+	resolver    CredentialResolver
 }
 
 func Start(logf LogFunc) (*Gateway, error) {
@@ -71,8 +110,9 @@ func Start(logf LogFunc) (*Gateway, error) {
 				return errors.New("model gateway upstream redirects are disabled")
 			},
 		},
-		logf:    logf,
-		entries: make(map[string]entry),
+		logf:         logf,
+		entries:      make(map[string]entry),
+		proxyEntries: make(map[string]proxyEntry),
 	}
 	gateway.server = &http.Server{
 		Handler:           gateway,
@@ -85,6 +125,43 @@ func Start(logf LogFunc) (*Gateway, error) {
 		_ = gateway.server.Serve(listener)
 	}()
 	return gateway, nil
+}
+
+// RegisterProxy creates a route-scoped lease without loading credential bytes.
+// The resolver is called for every request and is the only source of the real
+// value, current grant, mode, and configuration.
+func (g *Gateway) RegisterProxy(jobID string, policy ProxyPolicy, resolver CredentialResolver) (*Lease, error) {
+	if g == nil {
+		return nil, errors.New("credential gateway is not running")
+	}
+	if strings.TrimSpace(jobID) == "" {
+		return nil, errors.New("credential gateway job id is required")
+	}
+	if resolver == nil {
+		return nil, errors.New("credential gateway resolver is required")
+	}
+	validated, upstream, err := ValidateProxyPolicy(policy)
+	if err != nil {
+		return nil, err
+	}
+	placeholder, err := mintPlaceholder(jobID)
+	if err != nil {
+		return nil, err
+	}
+	route, err := mintProxyRoute()
+	if err != nil {
+		return nil, err
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.closed {
+		return nil, errors.New("credential gateway is not running")
+	}
+	g.proxyEntries[route] = proxyEntry{
+		jobID: jobID, placeholder: placeholder, policy: validated,
+		upstream: upstream, resolver: resolver,
+	}
+	return &Lease{gateway: g, placeholder: placeholder, route: route}, nil
 }
 
 func (g *Gateway) URL() string {
@@ -138,6 +215,17 @@ func (g *Gateway) Revoke(placeholder string) {
 	g.mu.Unlock()
 }
 
+func (g *Gateway) revokeProxy(route, placeholder string) {
+	if g == nil || route == "" || placeholder == "" {
+		return
+	}
+	g.mu.Lock()
+	if registered, ok := g.proxyEntries[route]; ok && registered.placeholder == placeholder {
+		delete(g.proxyEntries, route)
+	}
+	g.mu.Unlock()
+}
+
 func (g *Gateway) Close(ctx context.Context) error {
 	if g == nil {
 		return nil
@@ -149,11 +237,16 @@ func (g *Gateway) Close(ctx context.Context) error {
 	}
 	g.closed = true
 	clear(g.entries)
+	clear(g.proxyEntries)
 	g.mu.Unlock()
 	return g.server.Shutdown(ctx)
 }
 
 func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if route, routed := proxyRoute(r.URL.EscapedPath()); routed {
+		g.serveProxy(w, r, route)
+		return
+	}
 	placeholder := requestPlaceholder(r)
 	g.mu.RLock()
 	registered, ok := g.entries[placeholder]
@@ -201,6 +294,260 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(response.StatusCode)
 	streamResponse(w, response.Body)
 	g.writeLog(r.Method, registered.upstream.Hostname(), response.StatusCode, registered.jobID)
+}
+
+func (g *Gateway) serveProxy(w http.ResponseWriter, r *http.Request, route string) {
+	g.mu.RLock()
+	registered, ok := g.proxyEntries[route]
+	g.mu.RUnlock()
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		g.writeLog(r.Method, "", http.StatusUnauthorized, "")
+		return
+	}
+	if proxyRequestPlaceholder(r, registered.policy) != registered.placeholder {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusUnauthorized, registered.jobID)
+		return
+	}
+	if r.URL.IsAbs() || r.URL.Host != "" || !strings.EqualFold(r.Host, g.listener.Addr().String()) {
+		http.Error(w, "request target refused", http.StatusBadRequest)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadRequest, registered.jobID)
+		return
+	}
+	suffix, err := proxyRequestSuffix(r.URL.EscapedPath(), route)
+	if err != nil {
+		http.Error(w, "request path refused", http.StatusBadRequest)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadRequest, registered.jobID)
+		return
+	}
+	resolved, err := registered.resolver(r.Context())
+	if err != nil || strings.TrimSpace(resolved.Value) == "" || !resolvedMatchesProxyPolicy(resolved, registered.policy) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusUnauthorized, registered.jobID)
+		return
+	}
+
+	upstreamURL := *registered.upstream
+	upstreamURL.Path = joinProxyPath(registered.upstream.Path, suffix)
+	upstreamURL.RawPath = ""
+	upstreamURL.RawQuery = r.URL.RawQuery
+	outbound := r.Clone(r.Context())
+	outbound.URL = &upstreamURL
+	outbound.Host = registered.upstream.Host
+	outbound.RequestURI = ""
+	outbound.Header = r.Header.Clone()
+	removeHopHeaders(outbound.Header)
+	removeCredentialHeaders(outbound.Header, registered.policy.Header)
+	switch registered.policy.AuthKind {
+	case ProxyAuthBearer:
+		outbound.Header.Set("Authorization", "Bearer "+resolved.Value)
+	case ProxyAuthHeader:
+		outbound.Header.Set(registered.policy.Header, resolved.Value)
+	}
+
+	response, err := g.client.Do(outbound)
+	if err != nil {
+		http.Error(w, "upstream request failed", http.StatusBadGateway)
+		g.writeLog(r.Method, registered.upstream.Hostname(), http.StatusBadGateway, registered.jobID)
+		return
+	}
+	defer response.Body.Close()
+	removeHopHeaders(response.Header)
+	copyHeader(w.Header(), response.Header)
+	w.WriteHeader(response.StatusCode)
+	streamResponse(w, response.Body)
+	g.writeLog(r.Method, registered.upstream.Hostname(), response.StatusCode, registered.jobID)
+}
+
+// ValidateProxyPolicy returns a canonical policy and parsed upstream. Callers
+// persist the canonical Upstream so later request-time comparisons are exact.
+func ValidateProxyPolicy(policy ProxyPolicy) (ProxyPolicy, *url.URL, error) {
+	raw := strings.TrimSpace(policy.Upstream)
+	upstream, err := url.Parse(raw)
+	if err != nil || raw == "" || !upstream.IsAbs() || upstream.Hostname() == "" || upstream.Opaque != "" {
+		return ProxyPolicy{}, nil, fmt.Errorf("invalid proxy upstream %q: require an absolute URL with a host", raw)
+	}
+	if upstream.User != nil {
+		return ProxyPolicy{}, nil, fmt.Errorf("invalid proxy upstream %q: userinfo is not allowed", raw)
+	}
+	if upstream.RawQuery != "" || upstream.ForceQuery {
+		return ProxyPolicy{}, nil, fmt.Errorf("invalid proxy upstream %q: query is not allowed", raw)
+	}
+	if upstream.Fragment != "" || strings.Contains(raw, "#") {
+		return ProxyPolicy{}, nil, fmt.Errorf("invalid proxy upstream %q: fragment is not allowed", raw)
+	}
+	upstream.Scheme = strings.ToLower(upstream.Scheme)
+	if upstream.Scheme != "https" {
+		if upstream.Scheme != "http" || !policy.AllowLoopbackHTTP || !isLoopbackHost(upstream.Hostname()) {
+			return ProxyPolicy{}, nil, fmt.Errorf("invalid proxy upstream %q: HTTPS is required", raw)
+		}
+	}
+	basePath, err := normalizedProxyPath(upstream.EscapedPath())
+	if err != nil {
+		return ProxyPolicy{}, nil, fmt.Errorf("invalid proxy upstream %q: %w", raw, err)
+	}
+	upstream.Path = basePath
+	upstream.RawPath = ""
+	upstream.RawQuery = ""
+	upstream.Fragment = ""
+
+	validated := ProxyPolicy{
+		Upstream: upstream.String(), AuthKind: policy.AuthKind,
+		AllowLoopbackHTTP: policy.AllowLoopbackHTTP,
+	}
+	switch policy.AuthKind {
+	case ProxyAuthBearer:
+		if strings.TrimSpace(policy.Header) != "" {
+			return ProxyPolicy{}, nil, errors.New("bearer proxy auth cannot set a header name")
+		}
+	case ProxyAuthHeader:
+		header := http.CanonicalHeaderKey(strings.TrimSpace(policy.Header))
+		if !validHTTPToken(header) {
+			return ProxyPolicy{}, nil, fmt.Errorf("invalid proxy header %q: must be an HTTP token", policy.Header)
+		}
+		if forbiddenProxyHeader(header) {
+			return ProxyPolicy{}, nil, fmt.Errorf("proxy header %q is not allowed", policy.Header)
+		}
+		validated.Header = header
+	default:
+		return ProxyPolicy{}, nil, fmt.Errorf("invalid proxy auth kind %q", policy.AuthKind)
+	}
+	return validated, upstream, nil
+}
+
+func resolvedMatchesProxyPolicy(resolved ResolvedCredential, want ProxyPolicy) bool {
+	current, _, err := ValidateProxyPolicy(ProxyPolicy{
+		Upstream: resolved.Upstream, AuthKind: resolved.AuthKind, Header: resolved.Header,
+		AllowLoopbackHTTP: want.AllowLoopbackHTTP,
+	})
+	return err == nil && current.Upstream == want.Upstream && current.AuthKind == want.AuthKind && current.Header == want.Header
+}
+
+func normalizedProxyPath(escaped string) (string, error) {
+	if escaped == "" {
+		return "/", nil
+	}
+	decoded, err := url.PathUnescape(escaped)
+	if err != nil || strings.Contains(decoded, `\`) || hasDotPathSegment(decoded) {
+		return "", errors.New("base path contains an invalid or escaping segment")
+	}
+	if containsEncodedSlashOrBackslash(escaped) {
+		return "", errors.New("base path contains an encoded path separator")
+	}
+	normalized := path.Clean("/" + strings.TrimLeft(decoded, "/"))
+	return normalized, nil
+}
+
+func proxyRequestSuffix(escapedPath, route string) (string, error) {
+	raw := strings.TrimPrefix(escapedPath, route)
+	if raw == "" {
+		return "", nil
+	}
+	if !strings.HasPrefix(raw, "/") || containsEncodedSlashOrBackslash(raw) {
+		return "", errors.New("invalid proxy path")
+	}
+	decoded, err := url.PathUnescape(raw)
+	if err != nil || strings.Contains(decoded, `\`) || hasDotPathSegment(decoded) {
+		return "", errors.New("proxy path escapes the configured base path")
+	}
+	return decoded, nil
+}
+
+func hasDotPathSegment(value string) bool {
+	for _, segment := range strings.Split(value, "/") {
+		if segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEncodedSlashOrBackslash(value string) bool {
+	lower := strings.ToLower(value)
+	return strings.Contains(lower, "%2f") || strings.Contains(lower, "%5c")
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func validHTTPToken(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || strings.ContainsRune("!#$%&'*+-.^_`|~", r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func forbiddenProxyHeader(header string) bool {
+	switch strings.ToLower(header) {
+	case "connection", "proxy-connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+		"te", "trailer", "transfer-encoding", "upgrade", "host", "cookie", "cookie2", "set-cookie":
+		return true
+	default:
+		return false
+	}
+}
+
+func proxyRequestPlaceholder(r *http.Request, policy ProxyPolicy) string {
+	if policy.AuthKind == ProxyAuthHeader {
+		return strings.TrimSpace(r.Header.Get(policy.Header))
+	}
+	authorization := strings.TrimSpace(r.Header.Get("Authorization"))
+	scheme, value, ok := strings.Cut(authorization, " ")
+	if ok && strings.EqualFold(strings.TrimSpace(scheme), "bearer") {
+		return strings.TrimSpace(value)
+	}
+	return ""
+}
+
+func removeCredentialHeaders(header http.Header, configured string) {
+	for _, name := range []string{"Authorization", "X-Api-Key", "Proxy-Authorization", configured} {
+		if name != "" {
+			header.Del(name)
+		}
+	}
+}
+
+func joinProxyPath(basePath, suffix string) string {
+	if suffix == "" {
+		return basePath
+	}
+	if basePath == "/" {
+		return suffix
+	}
+	return strings.TrimRight(basePath, "/") + "/" + strings.TrimLeft(suffix, "/")
+}
+
+func mintProxyRoute() (string, error) {
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("mint credential gateway route: %w", err)
+	}
+	return "/_gitmoot/proxy/" + hex.EncodeToString(random), nil
+}
+
+func proxyRoute(escapedPath string) (string, bool) {
+	const prefix = "/_gitmoot/proxy/"
+	if !strings.HasPrefix(escapedPath, prefix) {
+		return "", false
+	}
+	rest := strings.TrimPrefix(escapedPath, prefix)
+	segment, _, _ := strings.Cut(rest, "/")
+	if len(segment) != 32 {
+		return prefix + segment, true
+	}
+	return prefix + segment, true
 }
 
 func validatePolicy(policy Policy) (*url.URL, map[string]struct{}, error) {

--- a/internal/credgw/gateway_test.go
+++ b/internal/credgw/gateway_test.go
@@ -158,6 +158,245 @@ func TestGatewayAttachesAPIKeyWithoutForwardingPlaceholder(t *testing.T) {
 	}
 }
 
+func TestGenericProxyLeaseBearerRotationRevocationAndPathPinning(t *testing.T) {
+	const rotatedCredential = "rotated-real-credential-874"
+	var mu sync.Mutex
+	credential := testRealCredential
+	granted := true
+	upstreamCalls := 0
+	var seen []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		upstreamCalls++
+		seen = append(seen, r.Method+" "+r.URL.RequestURI()+" "+r.Header.Get("Authorization")+" "+r.Header.Get("X-Api-Key")+" "+r.Host)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	var logs logSink
+	gateway, err := Start(logs.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	policy := ProxyPolicy{Upstream: upstream.URL + "/api/v1/", AuthKind: ProxyAuthBearer, AllowLoopbackHTTP: true}
+	resolver := func(context.Context) (ResolvedCredential, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if !granted {
+			return ResolvedCredential{}, fmt.Errorf("revoked")
+		}
+		return ResolvedCredential{Value: credential, Upstream: policy.Upstream, AuthKind: ProxyAuthBearer}, nil
+	}
+	lease, err := gateway.RegisterProxy("proxy-job", policy, resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(lease.Placeholder(), "gitmoot-kc-proxy-job-") || !strings.HasPrefix(lease.URL(), gateway.URL()+"/_gitmoot/proxy/") {
+		t.Fatalf("lease placeholder/url = %q %q", lease.Placeholder(), lease.URL())
+	}
+
+	call := func(wantStatus int) {
+		t.Helper()
+		request, err := http.NewRequest(http.MethodPost, lease.URL()+"/messages?stream=true", strings.NewReader(testRequestBody))
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.Header.Set("Authorization", "Bearer "+lease.Placeholder())
+		request.Header.Set("X-Api-Key", lease.Placeholder())
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response.Body.Close()
+		if response.StatusCode != wantStatus {
+			t.Fatalf("status = %d, want %d", response.StatusCode, wantStatus)
+		}
+	}
+	call(http.StatusNoContent)
+	mu.Lock()
+	credential = rotatedCredential
+	mu.Unlock()
+	call(http.StatusNoContent)
+
+	mu.Lock()
+	if upstreamCalls != 2 || len(seen) != 2 || !strings.Contains(seen[0], "POST /api/v1/messages?stream=true Bearer "+testRealCredential+"  ") || !strings.Contains(seen[1], "Bearer "+rotatedCredential) {
+		t.Fatalf("upstream calls=%d seen=%q", upstreamCalls, seen)
+	}
+	mu.Unlock()
+
+	refused := []struct {
+		url  string
+		host string
+	}{
+		{url: lease.URL() + "/safe", host: "other.example.test"},
+		{url: lease.URL() + "/safe/%2e%2e/escape"},
+	}
+	for _, probe := range refused {
+		request, _ := http.NewRequest(http.MethodGet, probe.url, nil)
+		request.Header.Set("Authorization", "Bearer "+lease.Placeholder())
+		if probe.host != "" {
+			request.Host = probe.host
+		}
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response.Body.Close()
+		if response.StatusCode != http.StatusBadRequest {
+			t.Fatalf("escaped/foreign request status = %d", response.StatusCode)
+		}
+	}
+	mu.Lock()
+	if upstreamCalls != 2 {
+		t.Fatalf("refused requests reached upstream: calls=%d", upstreamCalls)
+	}
+	granted = false
+	mu.Unlock()
+	call(http.StatusUnauthorized)
+	mu.Lock()
+	if upstreamCalls != 2 {
+		t.Fatalf("revoked request reached upstream: calls=%d", upstreamCalls)
+	}
+	mu.Unlock()
+
+	logged := logs.waitFor(t, "job_id=proxy-job")
+	for _, forbidden := range []string{testRealCredential, rotatedCredential, lease.Placeholder(), testRequestBody, "Authorization", "X-Api-Key"} {
+		if strings.Contains(logged, forbidden) {
+			t.Fatalf("gateway log leaked %q: %q", forbidden, logged)
+		}
+	}
+	lease.Revoke()
+	call(http.StatusUnauthorized)
+}
+
+func TestGenericProxyLeaseCustomHeaderAndRedirectRefusal(t *testing.T) {
+	const headerName = "X-Service-Token"
+	var gotHeader, gotAuthorization string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get(headerName)
+		gotAuthorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer upstream.Close()
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	policy := ProxyPolicy{Upstream: upstream.URL + "/fixed", AuthKind: ProxyAuthHeader, Header: headerName, AllowLoopbackHTTP: true}
+	lease, err := gateway.RegisterProxy("header-job", policy, func(context.Context) (ResolvedCredential, error) {
+		return ResolvedCredential{Value: testRealCredential, Upstream: policy.Upstream, AuthKind: policy.AuthKind, Header: policy.Header}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, _ := http.NewRequest(http.MethodGet, lease.URL(), nil)
+	request.Header.Set(headerName, lease.Placeholder())
+	request.Header.Set("Authorization", "Bearer should-be-stripped")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusAccepted || gotHeader != testRealCredential || gotAuthorization != "" {
+		t.Fatalf("status=%d header=%q authorization=%q", response.StatusCode, gotHeader, gotAuthorization)
+	}
+
+	redirectCalls := 0
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { redirectCalls++ }))
+	defer redirectTarget.Close()
+	redirectSource := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL, http.StatusFound)
+	}))
+	defer redirectSource.Close()
+	redirectPolicy := ProxyPolicy{Upstream: redirectSource.URL, AuthKind: ProxyAuthBearer, AllowLoopbackHTTP: true}
+	redirectLease, err := gateway.RegisterProxy("redirect-job", redirectPolicy, func(context.Context) (ResolvedCredential, error) {
+		return ResolvedCredential{Value: testRealCredential, Upstream: redirectPolicy.Upstream, AuthKind: ProxyAuthBearer}, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirectRequest, _ := http.NewRequest(http.MethodGet, redirectLease.URL(), nil)
+	redirectRequest.Header.Set("Authorization", "Bearer "+redirectLease.Placeholder())
+	redirectResponse, err := http.DefaultClient.Do(redirectRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	redirectResponse.Body.Close()
+	if redirectResponse.StatusCode != http.StatusBadGateway || redirectCalls != 0 {
+		t.Fatalf("redirect status=%d target_calls=%d", redirectResponse.StatusCode, redirectCalls)
+	}
+}
+
+func TestGenericProxyConcurrentLeasesRemainIsolated(t *testing.T) {
+	var mu sync.Mutex
+	seen := map[string]int{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seen[r.Header.Get("Authorization")]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	gateway, err := Start(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer gateway.Close(context.Background())
+	policy := ProxyPolicy{Upstream: upstream.URL, AuthKind: ProxyAuthBearer, AllowLoopbackHTTP: true}
+	makeLease := func(jobID, value string) *Lease {
+		lease, err := gateway.RegisterProxy(jobID, policy, func(context.Context) (ResolvedCredential, error) {
+			return ResolvedCredential{Value: value, Upstream: policy.Upstream, AuthKind: ProxyAuthBearer}, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return lease
+	}
+	first := makeLease("concurrent-a", "real-a")
+	second := makeLease("concurrent-b", "real-b")
+
+	wrong, _ := http.NewRequest(http.MethodGet, first.URL(), nil)
+	wrong.Header.Set("Authorization", "Bearer "+second.Placeholder())
+	wrongResponse, err := http.DefaultClient.Do(wrong)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongResponse.Body.Close()
+	if wrongResponse.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("cross-lease placeholder status=%d", wrongResponse.StatusCode)
+	}
+
+	var wait sync.WaitGroup
+	for _, lease := range []*Lease{first, second} {
+		for i := 0; i < 10; i++ {
+			wait.Add(1)
+			go func(lease *Lease) {
+				defer wait.Done()
+				request, _ := http.NewRequest(http.MethodGet, lease.URL(), nil)
+				request.Header.Set("Authorization", "Bearer "+lease.Placeholder())
+				response, err := http.DefaultClient.Do(request)
+				if err != nil {
+					t.Errorf("request: %v", err)
+					return
+				}
+				response.Body.Close()
+				if response.StatusCode != http.StatusNoContent {
+					t.Errorf("status=%d", response.StatusCode)
+				}
+			}(lease)
+		}
+	}
+	wait.Wait()
+	mu.Lock()
+	defer mu.Unlock()
+	if seen["Bearer real-a"] != 10 || seen["Bearer real-b"] != 10 || len(seen) != 2 {
+		t.Fatalf("isolated credentials = %#v", seen)
+	}
+}
+
 func TestGatewayStreamsFlushedChunks(t *testing.T) {
 	firstSent := make(chan struct{})
 	releaseSecond := make(chan struct{})

--- a/internal/credgw/runner.go
+++ b/internal/credgw/runner.go
@@ -20,6 +20,14 @@ const (
 type Lease struct {
 	gateway     *Gateway
 	placeholder string
+	route       string
+}
+
+func (l *Lease) URL() string {
+	if l == nil || l.gateway == nil || l.route == "" {
+		return ""
+	}
+	return l.gateway.URL() + l.route
 }
 
 func (l *Lease) Placeholder() string {
@@ -31,7 +39,11 @@ func (l *Lease) Placeholder() string {
 
 func (l *Lease) Revoke() {
 	if l != nil && l.gateway != nil {
-		l.gateway.Revoke(l.placeholder)
+		if l.route != "" {
+			l.gateway.revokeProxy(l.route, l.placeholder)
+		} else {
+			l.gateway.Revoke(l.placeholder)
+		}
 	}
 }
 

--- a/internal/db/keychain.go
+++ b/internal/db/keychain.go
@@ -10,25 +10,40 @@ import (
 
 const (
 	KeychainModeInjected = "injected"
-	// Proxied is registry metadata only in this phase. Future work may compose it
-	// with credgw's lease model; pipeline grants deliberately refuse it today.
-	KeychainModeProxied      = "proxied"
+	KeychainModeProxied  = "proxied"
+
+	KeychainProxyAuthBearer = "bearer"
+	KeychainProxyAuthHeader = "header"
+
 	KeychainConsumerPipeline = "pipeline"
 )
 
 var (
-	ErrKeychainKeyNotFound      = errors.New("keychain key not found")
-	ErrKeychainConsumerNotFound = errors.New("keychain consumer not found")
-	ErrKeychainProxiedGrant     = errors.New("proxied keys cannot be granted to pipelines")
-	ErrKeychainKeyHasGrants     = errors.New("keychain key still has grants")
+	ErrKeychainKeyNotFound       = errors.New("keychain key not found")
+	ErrKeychainConsumerNotFound  = errors.New("keychain consumer not found")
+	ErrKeychainProxyUnconfigured = errors.New("proxied key is not configured")
+	ErrKeychainKeyHasGrants      = errors.New("keychain key still has grants")
 )
 
 // KeychainKey is value-free registry metadata. Credential bytes never enter
 // SQLite; callers load them from the separately validated keychain file.
 type KeychainKey struct {
-	Name      string `json:"name"`
-	Mode      string `json:"mode"`
-	CreatedAt string `json:"created_at"`
+	Name          string `json:"name"`
+	Mode          string `json:"mode"`
+	ProxyUpstream string `json:"proxy_upstream,omitempty"`
+	ProxyAuthKind string `json:"proxy_auth_kind,omitempty"`
+	ProxyHeader   string `json:"proxy_header,omitempty"`
+	CreatedAt     string `json:"created_at"`
+}
+
+func (k KeychainKey) ProxyConfigured() bool {
+	if k.Mode != KeychainModeProxied || strings.TrimSpace(k.ProxyUpstream) == "" {
+		return false
+	}
+	if k.ProxyAuthKind == KeychainProxyAuthBearer {
+		return strings.TrimSpace(k.ProxyHeader) == ""
+	}
+	return k.ProxyAuthKind == KeychainProxyAuthHeader && strings.TrimSpace(k.ProxyHeader) != ""
 }
 
 // KeychainGrant authorizes one named consumer to use one registered key.
@@ -72,8 +87,10 @@ func (s *Store) GetKeychainKey(ctx context.Context, name string) (KeychainKey, b
 		return KeychainKey{}, false, errors.New("keychain key name is required")
 	}
 	var key KeychainKey
-	err := s.db.QueryRowContext(ctx, `SELECT name, mode, created_at FROM keychain_keys WHERE name = ?`, name).
-		Scan(&key.Name, &key.Mode, &key.CreatedAt)
+	err := s.db.QueryRowContext(ctx, `SELECT name, mode,
+		COALESCE(proxy_upstream, ''), COALESCE(proxy_auth_kind, ''), COALESCE(proxy_header, ''), created_at
+		FROM keychain_keys WHERE name = ?`, name).
+		Scan(&key.Name, &key.Mode, &key.ProxyUpstream, &key.ProxyAuthKind, &key.ProxyHeader, &key.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return KeychainKey{}, false, nil
 	}
@@ -81,7 +98,9 @@ func (s *Store) GetKeychainKey(ctx context.Context, name string) (KeychainKey, b
 }
 
 func (s *Store) ListKeychainKeys(ctx context.Context) ([]KeychainKey, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT name, mode, created_at FROM keychain_keys ORDER BY name`)
+	rows, err := s.db.QueryContext(ctx, `SELECT name, mode,
+		COALESCE(proxy_upstream, ''), COALESCE(proxy_auth_kind, ''), COALESCE(proxy_header, ''), created_at
+		FROM keychain_keys ORDER BY name`)
 	if err != nil {
 		return nil, err
 	}
@@ -89,12 +108,66 @@ func (s *Store) ListKeychainKeys(ctx context.Context) ([]KeychainKey, error) {
 	var keys []KeychainKey
 	for rows.Next() {
 		var key KeychainKey
-		if err := rows.Scan(&key.Name, &key.Mode, &key.CreatedAt); err != nil {
+		if err := rows.Scan(&key.Name, &key.Mode, &key.ProxyUpstream, &key.ProxyAuthKind, &key.ProxyHeader, &key.CreatedAt); err != nil {
 			return nil, err
 		}
 		keys = append(keys, key)
 	}
 	return keys, rows.Err()
+}
+
+func (s *Store) ConfigureKeychainProxy(ctx context.Context, name, upstream, authKind, header string) (KeychainKey, error) {
+	name = strings.TrimSpace(name)
+	upstream = strings.TrimSpace(upstream)
+	authKind = strings.TrimSpace(authKind)
+	header = strings.TrimSpace(header)
+	if name == "" || upstream == "" {
+		return KeychainKey{}, errors.New("keychain proxy configuration requires a key name and upstream")
+	}
+	if authKind != KeychainProxyAuthBearer && authKind != KeychainProxyAuthHeader {
+		return KeychainKey{}, fmt.Errorf("invalid proxy auth kind %q", authKind)
+	}
+	if authKind == KeychainProxyAuthBearer && header != "" {
+		return KeychainKey{}, errors.New("bearer proxy auth cannot set a header name")
+	}
+	if authKind == KeychainProxyAuthHeader && header == "" {
+		return KeychainKey{}, errors.New("header proxy auth requires a header name")
+	}
+	result, err := s.db.ExecContext(ctx, `UPDATE keychain_keys
+		SET proxy_upstream = ?, proxy_auth_kind = ?, proxy_header = ?
+		WHERE name = ? AND mode = ?`, upstream, authKind, nullableProxyHeader(header), name, KeychainModeProxied)
+	if err != nil {
+		return KeychainKey{}, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return KeychainKey{}, err
+	}
+	if affected == 0 {
+		key, found, getErr := s.GetKeychainKey(ctx, name)
+		if getErr != nil {
+			return KeychainKey{}, getErr
+		}
+		if !found {
+			return KeychainKey{}, ErrKeychainKeyNotFound
+		}
+		return KeychainKey{}, fmt.Errorf("key %s uses %s mode; proxy configuration requires proxied mode", name, key.Mode)
+	}
+	key, found, err := s.GetKeychainKey(ctx, name)
+	if err != nil {
+		return KeychainKey{}, err
+	}
+	if !found {
+		return KeychainKey{}, ErrKeychainKeyNotFound
+	}
+	return key, nil
+}
+
+func nullableProxyHeader(header string) any {
+	if strings.TrimSpace(header) == "" {
+		return nil
+	}
+	return header
 }
 
 func (s *Store) ListKeychainGrants(ctx context.Context, keyName string) ([]KeychainGrant, error) {
@@ -155,11 +228,12 @@ func (s *Store) GetGrantedKey(ctx context.Context, kind, id, name string) (Keych
 		return KeychainKey{}, false, errors.New("keychain grant requires pipeline and key names")
 	}
 	var key KeychainKey
-	err := s.db.QueryRowContext(ctx, `SELECT k.name, k.mode, k.created_at
+	err := s.db.QueryRowContext(ctx, `SELECT k.name, k.mode,
+		COALESCE(k.proxy_upstream, ''), COALESCE(k.proxy_auth_kind, ''), COALESCE(k.proxy_header, ''), k.created_at
 		FROM keychain_keys k
 		JOIN keychain_grants g ON g.key_name = k.name
 		WHERE g.consumer_kind = ? AND g.consumer_id = ? AND g.key_name = ?`, kind, id, name).
-		Scan(&key.Name, &key.Mode, &key.CreatedAt)
+		Scan(&key.Name, &key.Mode, &key.ProxyUpstream, &key.ProxyAuthKind, &key.ProxyHeader, &key.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return KeychainKey{}, false, nil
 	}
@@ -185,14 +259,17 @@ func (s *Store) GrantKeychainKey(ctx context.Context, kind, id, name string) (bo
 	if exists == 0 {
 		return false, ErrKeychainConsumerNotFound
 	}
-	var mode string
-	if err := tx.QueryRowContext(ctx, `SELECT mode FROM keychain_keys WHERE name = ?`, name).Scan(&mode); errors.Is(err, sql.ErrNoRows) {
+	var key KeychainKey
+	if err := tx.QueryRowContext(ctx, `SELECT name, mode,
+		COALESCE(proxy_upstream, ''), COALESCE(proxy_auth_kind, ''), COALESCE(proxy_header, ''), created_at
+		FROM keychain_keys WHERE name = ?`, name).
+		Scan(&key.Name, &key.Mode, &key.ProxyUpstream, &key.ProxyAuthKind, &key.ProxyHeader, &key.CreatedAt); errors.Is(err, sql.ErrNoRows) {
 		return false, ErrKeychainKeyNotFound
 	} else if err != nil {
 		return false, err
 	}
-	if mode != KeychainModeInjected {
-		return false, ErrKeychainProxiedGrant
+	if key.Mode == KeychainModeProxied && !key.ProxyConfigured() {
+		return false, ErrKeychainProxyUnconfigured
 	}
 	result, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO keychain_grants(consumer_kind, consumer_id, key_name) VALUES (?, ?, ?)`, kind, id, name)
 	if err != nil {

--- a/internal/db/keychain_test.go
+++ b/internal/db/keychain_test.go
@@ -15,16 +15,20 @@ func TestKeychainMigrationAppliesToExistingDatabase(t *testing.T) {
 		t.Fatal(err)
 	}
 	version := 0
+	proxyVersion := 0
 	for i, migration := range migrations {
 		if strings.Contains(migration, "CREATE TABLE keychain_keys") {
 			version = i + 1
-			break
+		}
+		if strings.Contains(migration, "ADD COLUMN proxy_upstream") {
+			proxyVersion = i + 1
 		}
 	}
-	if version == 0 {
-		t.Fatal("keychain migration not found")
+	if version == 0 || proxyVersion == 0 {
+		t.Fatalf("keychain migrations not found: create=%d proxy=%d", version, proxyVersion)
 	}
-	if _, err := legacy.db.Exec(`DROP TABLE keychain_grants; DROP TABLE keychain_keys; DELETE FROM schema_migrations WHERE version = ?`, version); err != nil {
+	if _, err := legacy.db.Exec(`DROP TABLE keychain_grants; DROP TABLE keychain_keys;
+		DELETE FROM schema_migrations WHERE version IN (?, ?)`, version, proxyVersion); err != nil {
 		t.Fatalf("rewind keychain migration: %v", err)
 	}
 	if err := legacy.Close(); err != nil {
@@ -38,6 +42,26 @@ func TestKeychainMigrationAppliesToExistingDatabase(t *testing.T) {
 	for _, table := range []string{"keychain_keys", "keychain_grants"} {
 		if ok, err := store.HasTable(context.Background(), table); err != nil || !ok {
 			t.Fatalf("table %s ok=%v err=%v", table, ok, err)
+		}
+	}
+	columns, err := store.db.QueryContext(context.Background(), `PRAGMA table_info(keychain_keys)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer columns.Close()
+	found := map[string]bool{}
+	for columns.Next() {
+		var cid, notNull, primaryKey int
+		var name, typ string
+		var defaultValue any
+		if err := columns.Scan(&cid, &name, &typ, &notNull, &defaultValue, &primaryKey); err != nil {
+			t.Fatal(err)
+		}
+		found[name] = true
+	}
+	for _, name := range []string{"proxy_upstream", "proxy_auth_kind", "proxy_header"} {
+		if !found[name] {
+			t.Fatalf("proxy migration did not add %s", name)
 		}
 	}
 }
@@ -64,8 +88,19 @@ func TestKeychainCRUDGrantIdempotenceAndForcedCleanup(t *testing.T) {
 	if _, err := store.AddKeychainKey(ctx, "MODEL_TOKEN", KeychainModeProxied); err != nil {
 		t.Fatal(err)
 	}
-	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "MODEL_TOKEN"); changed || !errors.Is(err, ErrKeychainProxiedGrant) {
-		t.Fatalf("proxied grant = changed %v err %v", changed, err)
+	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "MODEL_TOKEN"); changed || !errors.Is(err, ErrKeychainProxyUnconfigured) {
+		t.Fatalf("unconfigured proxied grant = changed %v err %v", changed, err)
+	}
+	configured, err := store.ConfigureKeychainProxy(ctx, "MODEL_TOKEN", "https://api.example.test/v1", KeychainProxyAuthHeader, "X-Model-Key")
+	if err != nil || configured.ProxyUpstream != "https://api.example.test/v1" || configured.ProxyAuthKind != KeychainProxyAuthHeader || configured.ProxyHeader != "X-Model-Key" || !configured.ProxyConfigured() {
+		t.Fatalf("ConfigureKeychainProxy = %+v err=%v", configured, err)
+	}
+	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "MODEL_TOKEN"); err != nil || !changed {
+		t.Fatalf("configured proxied grant = changed %v err %v", changed, err)
+	}
+	grantedProxy, found, err := store.GetGrantedKey(ctx, KeychainConsumerPipeline, "deploy-flow", "MODEL_TOKEN")
+	if err != nil || !found || !grantedProxy.ProxyConfigured() {
+		t.Fatalf("GetGrantedKey proxied = %+v found=%v err=%v", grantedProxy, found, err)
 	}
 	changed, err := store.GrantKeychainKey(ctx, KeychainConsumerPipeline, "deploy-flow", "API_TOKEN")
 	if err != nil || !changed {
@@ -93,7 +128,7 @@ func TestKeychainCRUDGrantIdempotenceAndForcedCleanup(t *testing.T) {
 		t.Fatalf("idempotent revoke = changed %v err %v", changed, err)
 	}
 	keys, err := store.ListKeychainKeys(ctx)
-	if err != nil || len(keys) != 1 || keys[0].Name != "MODEL_TOKEN" {
+	if err != nil || len(keys) != 1 || keys[0].Name != "MODEL_TOKEN" || keys[0].ProxyHeader != "X-Model-Key" {
 		t.Fatalf("keys = %+v err=%v", keys, err)
 	}
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -9192,4 +9192,13 @@ CREATE TABLE keychain_grants (
 );
 CREATE INDEX idx_keychain_grants_key_name ON keychain_grants(key_name);
 	`,
+	// #874 fixed-upstream proxy metadata for proxied keycard entries. Existing
+	// proxied rows remain deliberately unconfigured until `gitmoot key configure`
+	// supplies all three fields; credential values remain outside SQLite.
+	`
+ALTER TABLE keychain_keys ADD COLUMN proxy_upstream TEXT;
+ALTER TABLE keychain_keys ADD COLUMN proxy_auth_kind TEXT
+	CHECK(proxy_auth_kind IS NULL OR proxy_auth_kind IN ('bearer', 'header'));
+ALTER TABLE keychain_keys ADD COLUMN proxy_header TEXT;
+	`,
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -149,6 +149,7 @@ defaulting to `<base-home>/.config/gitmoot/keychain.env` (override with
 ```sh
 gitmoot key path [--json]
 gitmoot key add <NAME> --mode injected|proxied [--json]
+gitmoot key configure <NAME> --upstream <https-url> --auth bearer|header:<HeaderName> [--json]
 gitmoot key list [--json]
 gitmoot key show <NAME> [--json]
 gitmoot key grant <NAME> --pipeline <pipeline> [--json]
@@ -157,9 +158,9 @@ gitmoot key rm <NAME> [--force] [--json]
 ```
 
 There is deliberately no value flag, stdin value, or value-derived hash.
-`proxied` metadata is reserved for future gateway composition and cannot be
-granted to a pipeline. `rm --force` removes metadata and grants but leaves the
-file entry untouched.
+`proxied` keys must be configured with a pinned HTTPS origin/base path and
+bearer or approved custom-header placement before they can be granted.
+`rm --force` removes metadata and grants but leaves the file entry untouched.
 
 Runtime-child environment curation is off by default. Enable it in
 `config.toml`:
@@ -2799,19 +2800,27 @@ with `env_keys`. Source files must be absolute, operator-owned regular files
 with mode exactly `0600`, outside the Gitmoot home and every managed checkout;
 inline `env` is for non-secret defaults. Agent/gate stages cannot set
 `env_keys`; a shell stage with no list gets nothing. Resolution is own
-`env_file`, then a shared `injected` key granted with `gitmoot key grant`, then
-inline default. Registered but ungranted names do not match exact or glob
-selectors. Structural errors always fail add; unresolved names warn only while
-the pipeline remains disabled, then hard-fail add-with-enable, enable, manual
-run, and scheduled/triggered preflight.
+`env_file`, then a shared `injected` or configured `proxied` key granted with
+`gitmoot key grant`, then inline default. Registered but ungranted names do not
+match exact or glob selectors. Structural errors always fail add; unresolved
+names warn only while the pipeline remains disabled, then hard-fail
+add-with-enable, enable, manual run, and scheduled/triggered preflight.
 
 Sources are revalidated and reread at delivery, so rotation applies without a
 daemon restart. Each payload audits `PipelineName` and names-only
 `PipelineKeyAccess` rows `{stage,name,source,mode}`; `pipeline show --json`
 exposes the same projection. A shared grant is rechecked immediately before
 delivery: revocation fails closed and never switches to another source. Gitmoot
-internal `GITMOOT_*` entries remain final. This injected mode exposes the value
-to that shell process and stays separate from the Claude model gateway.
+internal `GITMOOT_*` entries remain final. Injected mode exposes the value to
+that shell process. Proxied mode puts a per-job placeholder in `<KEY>` and a
+loopback endpoint in `GITMOOT_PROXY_<KEY>_URL`; every request rereads the value,
+rechecks the grant, and is constrained to the configured upstream/base path.
+The lease is revoked when delivery ends.
+
+Proxied mode hides key bytes; it does **not** prevent an authorized child from
+exercising the credential on the pinned upstream. Curated upstreams and base
+paths are part of the model. Configure only trusted upstreams. Pipeline key
+delivery stays separate from the Claude model gateway.
 
 For a non-empty run payload, every agent stage (including roots) receives a
 dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -177,16 +177,20 @@ in a stage command or inline `env`. Use an operator-owned `0600` pipeline
 grant it to the pipeline, then select it with the shell stage's `env_keys`
 allowlist.
 
-Pipeline injection is deny-by-default but deliberately **opaque**: only a shell
-stage's selected own or granted shared `env_keys` are injected, yet that process
-receives the real values and can print or transmit them. Gitmoot stores only
-`{stage,name,source,mode}` audit rows, never values or hashes. Keychain and
-pipeline files are revalidated as owner-only `0600` files outside Gitmoot state
-and managed checkouts. A shared grant is rechecked at delivery, so revocation
-fails closed without source fallback. `proxied` registry entries cannot be
-granted to pipelines in this phase. This is distinct from the Claude model
-gateway, where the child receives a placeholder and the real model credential
-stays daemon-side.
+Pipeline key access is deny-by-default. An `injected` selection gives the shell
+the real value, which it can print or transmit. A configured `proxied` shared
+selection instead gives it a per-job placeholder and loopback URL; Gitmoot
+rereads the value and rechecks the grant on every request, pins forwarding to
+the configured HTTPS origin/base path, and revokes the lease when delivery
+ends. Gitmoot stores only `{stage,name,source,mode}` audit rows, never values or
+hashes. Keychain and pipeline files are revalidated as owner-only `0600` files
+outside Gitmoot state and managed checkouts.
+
+Proxied mode hides key bytes; it does **not** prevent an authorized child from
+exercising the credential on the pinned upstream. Curated upstreams and base
+paths are part of the model, and only trusted upstreams should be configured.
+Agent and gate stages remain ineligible. This generic pipeline proxy is distinct
+from the Claude model gateway.
 
 ## External Contracts
 

--- a/website/docs/reference/credentials.md
+++ b/website/docs/reference/credentials.md
@@ -39,9 +39,9 @@ from ambient managed variables once. Existing files are never overwritten.
 For systemd deployments, keep `daemon.env` for operational values such as
 `PATH`; do not duplicate Claude secrets there after bootstrap.
 
-## Injected key registry and grants
+## Key registry and grants
 
-The shared injected-key source is an operator-owned env file. Its default path
+The shared key source is an operator-owned env file. Its default path
 is `<base-home>/.config/gitmoot/keychain.env`; `gitmoot key path` prints the
 resolved path and validation status. `[credentials] keychain_path` can select a
 different absolute path. The file must be regular, owned by the current uid,
@@ -56,6 +56,8 @@ print values:
 gitmoot key path
 gitmoot key add SOURCE_API_TOKEN --mode injected
 gitmoot key grant SOURCE_API_TOKEN --pipeline nightly-sync
+gitmoot key add PARTNER_API_TOKEN --mode proxied
+gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
 gitmoot key list --json
 gitmoot key show SOURCE_API_TOKEN
 gitmoot key revoke SOURCE_API_TOKEN --pipeline nightly-sync
@@ -63,12 +65,21 @@ gitmoot key rm SOURCE_API_TOKEN --force
 ```
 
 `rm` removes registry metadata and grants, not the operator's file entry.
-`proxied` mode is reserved for future gateway composition and cannot be granted
-to a pipeline. Pipeline shell stages may request granted `injected` names with
-`env_keys`; agent and gate stages remain ineligible. Resolution is Gitmoot's
-reserved `GITMOOT_*` namespace, then the pipeline's own `env_file`, then a
-granted shared key, then inline non-secret `env`. Registered but ungranted names
-are not visible to exact or glob selectors.
+`proxied` keys must be configured before grant with an absolute HTTPS upstream
+and either bearer or approved custom-header placement. Pipeline shell stages
+may request granted `injected` or configured `proxied` names with `env_keys`;
+agent and gate stages remain ineligible. Resolution is Gitmoot's reserved
+`GITMOOT_*` namespace, then the pipeline's own `env_file`, then a granted shared
+key, then inline non-secret `env`. Registered but ungranted names are not
+visible to exact or glob selectors.
+
+A proxied shell receives a per-job placeholder in `<KEY>` and a loopback URL in
+`GITMOOT_PROXY_<KEY>_URL`. Gitmoot pins the destination origin/base path,
+rereads the keychain and rechecks the grant for every request, and revokes the
+lease when delivery ends. Proxied mode hides key bytes; it does **not** prevent
+an authorized child from exercising the credential on the pinned upstream.
+Curated upstreams and base paths are part of the model; configure only trusted
+services.
 
 ## Claude model gateway
 
@@ -90,12 +101,8 @@ credential and ignore the placeholder — the gateway would then `401` the
 delivery (#936). The mirror never contains a credential; the operator's real
 config is only read, never modified.
 
-Pipeline-owned `env_file` values and granted shared keychain values are a
-separate **injected** mode for opaque API credentials whose shell script must
-present the real value. Gitmoot scopes those values to selected shell stages
-and audits names, sources, and modes only, but the selected process necessarily
-receives the real credential. This does not alter the Claude gateway or its
-placeholder flow.
+Pipeline `injected` and generic `proxied` key delivery is independent of the
+Claude gateway and does not alter its model-runtime placeholder flow.
 
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -91,6 +91,9 @@ per shell stage. The key CLI manages names and grants, never values:
 gitmoot key path
 gitmoot key add REDDIT_CLIENT_SECRET --mode injected
 gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
+gitmoot key add PARTNER_API_TOKEN --mode proxied
+gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
+gitmoot key grant PARTNER_API_TOKEN --pipeline trend-scout
 ```
 
 ```yaml
@@ -121,8 +124,16 @@ shared keys, which beat inline non-secret defaults; Gitmoot's internal
 exact or glob selectors. The stage job payload and `pipeline show --json` audit
 only `{stage,name,source,mode}` rows. Delivery rechecks shared grants, so a
 post-enqueue revoke fails closed without switching sources. The selected shell
-can still read an injected key. `proxied` mode is reserved for future gateway
-composition and is refused for pipelines; the Claude model gateway is separate.
+can still read an injected key.
+
+A configured `proxied` shared key gives the shell a per-job placeholder in
+`<KEY>` and a loopback URL in `GITMOOT_PROXY_<KEY>_URL`. Gitmoot pins requests
+to the configured HTTPS origin/base path, places the real value as bearer auth
+or an approved custom header, rereads the keychain and rechecks the grant per
+request, and revokes the lease when delivery ends. Proxied mode hides key bytes;
+it does **not** prevent an authorized child from exercising the credential on
+the pinned upstream. Curated upstreams and base paths are part of the model;
+configure only trusted services. The Claude model gateway is separate.
 
 The pipeline detail **Keys** tab is a names-only view of the same projection. It
 shows every stage, resolved key names with `own`/`shared`/`default` sources and

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2813,7 +2813,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
-| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from the pipeline's `env_file`, granted shared registry keys, or inline `env`. Shell stages only; no entry means no injected values. |
+| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from the pipeline's `env_file`, granted shared registry keys, or inline `env`. Shell stages only; no entry means no key access. |
 | `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
 
 `gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
@@ -2839,6 +2839,9 @@ keys must be registered and granted separately:
 gitmoot key path # edit this 0600 file; the CLI never accepts values
 gitmoot key add REDDIT_CLIENT_SECRET --mode injected
 gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
+gitmoot key add PARTNER_API_TOKEN --mode proxied
+gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
+gitmoot key grant PARTNER_API_TOKEN --pipeline trend-scout
 ```
 
 ```yaml
@@ -2873,8 +2876,21 @@ same rows. Delivery rechecks every shared grant and its registry mode; revoking
 after enqueue fails the stage rather than switching to another source. Inline
 `env` is stored in the pipeline spec and is therefore for non-secrets only. An
 injected key is visible to its shell process; this is scoping and audit, not a
-vault. `proxied` registry mode is stored for future gateway composition but is
-refused for pipeline grants. The Claude model gateway remains independent.
+vault.
+
+A configured `proxied` shared key instead gives the shell a per-job placeholder
+in `<KEY>` and a loopback endpoint in `GITMOOT_PROXY_<KEY>_URL`. The endpoint is
+pinned to the configured HTTPS origin and normalized base path. Gitmoot places
+the real credential as either bearer auth or an approved custom header, rereads
+the keychain and rechecks the grant on every request, and revokes the lease when
+delivery ends. Rotation therefore applies to the next request; revocation
+returns `401` without contacting the upstream. Agent and gate stages remain
+ineligible, and the Claude model gateway remains independent.
+
+Proxied mode hides key bytes; it does **not** prevent an authorized child from
+exercising the credential on the pinned upstream. Curated upstreams and base
+paths are part of the model. Configure only trusted upstreams because an
+upstream can observe and potentially reflect the credential.
 
 On `pipeline add --enable`, Gitmoot publishes the owned flow. An unavailable
 Activepieces instance leaves a pending binding; run
@@ -9444,6 +9460,7 @@ defaulting to `<base-home>/.config/gitmoot/keychain.env` (override with
 ```sh
 gitmoot key path [--json]
 gitmoot key add <NAME> --mode injected|proxied [--json]
+gitmoot key configure <NAME> --upstream <https-url> --auth bearer|header:<HeaderName> [--json]
 gitmoot key list [--json]
 gitmoot key show <NAME> [--json]
 gitmoot key grant <NAME> --pipeline <pipeline> [--json]
@@ -9452,9 +9469,9 @@ gitmoot key rm <NAME> [--force] [--json]
 ```
 
 There is deliberately no value flag, stdin value, or value-derived hash.
-`proxied` metadata is reserved for future gateway composition and cannot be
-granted to a pipeline. `rm --force` removes metadata and grants but leaves the
-file entry untouched.
+`proxied` keys must be configured with a pinned HTTPS origin/base path and
+bearer or approved custom-header placement before they can be granted.
+`rm --force` removes metadata and grants but leaves the file entry untouched.
 
 Runtime-child environment curation is off by default. Enable it in
 `config.toml`:
@@ -12094,19 +12111,27 @@ with `env_keys`. Source files must be absolute, operator-owned regular files
 with mode exactly `0600`, outside the Gitmoot home and every managed checkout;
 inline `env` is for non-secret defaults. Agent/gate stages cannot set
 `env_keys`; a shell stage with no list gets nothing. Resolution is own
-`env_file`, then a shared `injected` key granted with `gitmoot key grant`, then
-inline default. Registered but ungranted names do not match exact or glob
-selectors. Structural errors always fail add; unresolved names warn only while
-the pipeline remains disabled, then hard-fail add-with-enable, enable, manual
-run, and scheduled/triggered preflight.
+`env_file`, then a shared `injected` or configured `proxied` key granted with
+`gitmoot key grant`, then inline default. Registered but ungranted names do not
+match exact or glob selectors. Structural errors always fail add; unresolved
+names warn only while the pipeline remains disabled, then hard-fail
+add-with-enable, enable, manual run, and scheduled/triggered preflight.
 
 Sources are revalidated and reread at delivery, so rotation applies without a
 daemon restart. Each payload audits `PipelineName` and names-only
 `PipelineKeyAccess` rows `{stage,name,source,mode}`; `pipeline show --json`
 exposes the same projection. A shared grant is rechecked immediately before
 delivery: revocation fails closed and never switches to another source. Gitmoot
-internal `GITMOOT_*` entries remain final. This injected mode exposes the value
-to that shell process and stays separate from the Claude model gateway.
+internal `GITMOOT_*` entries remain final. Injected mode exposes the value to
+that shell process. Proxied mode puts a per-job placeholder in `<KEY>` and a
+loopback endpoint in `GITMOOT_PROXY_<KEY>_URL`; every request rereads the value,
+rechecks the grant, and is constrained to the configured upstream/base path.
+The lease is revoked when delivery ends.
+
+Proxied mode hides key bytes; it does **not** prevent an authorized child from
+exercising the credential on the pinned upstream. Curated upstreams and base
+paths are part of the model. Configure only trusted upstreams. Pipeline key
+delivery stays separate from the Claude model gateway.
 
 For a non-empty run payload, every agent stage (including roots) receives a
 dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before
@@ -14241,16 +14266,20 @@ in a stage command or inline `env`. Use an operator-owned `0600` pipeline
 grant it to the pipeline, then select it with the shell stage's `env_keys`
 allowlist.
 
-Pipeline injection is deny-by-default but deliberately **opaque**: only a shell
-stage's selected own or granted shared `env_keys` are injected, yet that process
-receives the real values and can print or transmit them. Gitmoot stores only
-`{stage,name,source,mode}` audit rows, never values or hashes. Keychain and
-pipeline files are revalidated as owner-only `0600` files outside Gitmoot state
-and managed checkouts. A shared grant is rechecked at delivery, so revocation
-fails closed without source fallback. `proxied` registry entries cannot be
-granted to pipelines in this phase. This is distinct from the Claude model
-gateway, where the child receives a placeholder and the real model credential
-stays daemon-side.
+Pipeline key access is deny-by-default. An `injected` selection gives the shell
+the real value, which it can print or transmit. A configured `proxied` shared
+selection instead gives it a per-job placeholder and loopback URL; Gitmoot
+rereads the value and rechecks the grant on every request, pins forwarding to
+the configured HTTPS origin/base path, and revokes the lease when delivery
+ends. Gitmoot stores only `{stage,name,source,mode}` audit rows, never values or
+hashes. Keychain and pipeline files are revalidated as owner-only `0600` files
+outside Gitmoot state and managed checkouts.
+
+Proxied mode hides key bytes; it does **not** prevent an authorized child from
+exercising the credential on the pinned upstream. Curated upstreams and base
+paths are part of the model, and only trusted upstreams should be configured.
+Agent and gate stages remain ineligible. This generic pipeline proxy is distinct
+from the Claude model gateway.
 
 ## External Contracts
 


### PR DESCRIPTION
WHAT:
Implemented #874 proxied-mode generalization for pipeline shell stages. Configured shared keys now use per-job loopback leases with request-time credential resolution, rotation, revocation, and fixed upstream/path enforcement. Agent-stage grants remain out of scope. No commit or push performed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-5b15a704

RESULTS:
- TestKeychainMigrationAppliesToExistingDatabase and TestKeychainCRUDGrantIdempotenceAndForcedCleanup cover migration, configuration CRUD, grant refusal before configuration, and grant success afterward.
- TestKeyCLIRegistryGrantsAndSecretSafety and TestKeyConfigureRejectsUnsafeProxyMetadata cover value safety, output metadata, and all invalid URL/header forms.
- TestGenericProxyLeaseBearerRotationRevocationAndPathPinning covers bearer placement, fixed origin/base path, request-time rotation, revocation, and log secrecy.
- TestGenericProxyLeaseCustomHeaderAndRedirectRefusal covers named-header placement and disabled redirects.
- TestGenericProxyConcurrentLeasesRemainIsolated covers concurrent lease and placeholder isolation.
- TestPipelineProxiedKeyResolutionAndDeliveryLease and TestPipelineUnconfiguredProxiedKeyFailsAtEnqueue cover names-only resolution, ShellEnv custody, deferred revocation, and configure-hint failure.
- TestPipelineProxiedKeyShellE2E with TestPipelineProxiedShellHelperProcess proves end-to-end placeholder delivery, real upstream credential placement, mid-run grant revocation, one-upstream-call enforcement, and sentinel absence from persisted/runtime surfaces.
- TestWebDataSourcePipelineDetailKeysNamesOnlyAndLiveDrift verifies proxied audit projection without credential values.
- `npm run build:llms`: passed.
- `go generate ./...`: passed; pre/post diff hash remained 36145cc9cd11e27c34036d550e1507e731ebd7aae919435df3c0d2836d57ad4e.
- `go build -buildvcs=false ./...`: passed with no output.
- `go vet ./...`: passed with no output.
- `go test -buildvcs=false ./internal/...`: passed. Tail included cli 370.676s, credgw 0.034s, daemon 23.617s, db 110.701s, and workflow 109.297s.
- `git diff --check`: passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-5b15a704

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented #874 proxied-mode generalization for pipeline shell stages. Configured shared keys now use per-job loopback leases with request-time credential resolution, rotation, revocation, and fixed upstream/path enforcement. Agent-stage grants remain out of scope. No commit or push performed.
````
