### PR TITLE
Gitmoot: TASK: Implement the gitmoot SERVER half of issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716012516-ba81b5ad8e51
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716130329-dc862b677af0
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716012516-ba81b5ad8e51 h1:bBVBn74Xv9yt4/AHtSsSY45I5CE5wfrQf19pDkKFQJM=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716012516-ba81b5ad8e51/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716130329-dc862b677af0 h1:4QYhEQkpzOwNe435nZrvQrDDiQTnHzHIb+dNYfp68L4=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716130329-dc862b677af0/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/cli/dashboard_web_config.go
+++ b/internal/cli/dashboard_web_config.go
@@ -93,7 +93,13 @@ var dashboardConfigProjection = []dashboardConfigProjectionRow{
 // comes from a canonical loader and every default comes from its canonical
 // constructor; arbitrary TOML values are never copied into the response.
 func (d *webDataSource) Config(ctx context.Context) (dashboard.ConfigSnapshot, error) {
-	out := dashboard.ConfigSnapshot{ContractVersion: 1, Sections: []dashboard.ConfigSection{}, Agents: []dashboard.ConfigAgent{}, UnknownKeys: []string{}}
+	out := dashboard.ConfigSnapshot{
+		ContractVersion: 1,
+		Sections:        []dashboard.ConfigSection{},
+		Agents:          []dashboard.ConfigAgent{},
+		UnknownKeys:     []string{},
+		Keychain:        dashboard.KeychainView{Keys: []dashboard.KeychainKeyView{}},
+	}
 	err := withStoreAndPaths(d.home, func(paths config.Paths, store *db.Store) error {
 		out.Path = paths.ConfigFile
 		if info, err := os.Stat(paths.ConfigFile); err == nil {
@@ -118,6 +124,10 @@ func (d *webDataSource) Config(ctx context.Context) (dashboard.ConfigSnapshot, e
 			return fmt.Errorf("list agents: %w", err)
 		}
 		out.Agents = projectDashboardConfigAgents(agents, agentTypes)
+		out.Keychain, err = projectDashboardConfigKeychain(ctx, store, d.home)
+		if err != nil {
+			return fmt.Errorf("project keychain config: %w", err)
+		}
 		// Unknown-key discovery re-parses the file with a strict TOML reader,
 		// which can reject values gitmoot's lenient loader accepts (e.g. the
 		// live box's bare-word list `deterministic_checkers = diff_size,...`).
@@ -130,6 +140,54 @@ func (d *webDataSource) Config(ctx context.Context) (dashboard.ConfigSnapshot, e
 	})
 	if err != nil {
 		return dashboard.ConfigSnapshot{}, err
+	}
+	return out, nil
+}
+
+// projectDashboardConfigKeychain exposes registry metadata only. The live file
+// check reuses the names-only pipeline classifier; credential values have no
+// representation in this projection or in the dashboard contract.
+func projectDashboardConfigKeychain(ctx context.Context, store *db.Store, home string) (dashboard.KeychainView, error) {
+	path, err := resolveKeychainPath(store, home)
+	if err != nil {
+		return dashboard.KeychainView{}, err
+	}
+	inspection := classifyPipelineEnvFile(ctx, store, home, path)
+	out := dashboard.KeychainView{
+		File: dashboard.KeychainFileStatus{Path: path, Status: inspection.Status},
+		Keys: []dashboard.KeychainKeyView{},
+	}
+
+	keys, err := store.ListKeychainKeys(ctx)
+	if err != nil {
+		return dashboard.KeychainView{}, fmt.Errorf("list keychain keys: %w", err)
+	}
+	grants, err := store.ListKeychainGrants(ctx, "")
+	if err != nil {
+		return dashboard.KeychainView{}, fmt.Errorf("list keychain grants: %w", err)
+	}
+	grantsByKey := make(map[string][]dashboard.KeychainGrantView, len(keys))
+	for _, grant := range grants {
+		grantsByKey[grant.KeyName] = append(grantsByKey[grant.KeyName], dashboard.KeychainGrantView{
+			ConsumerKind: grant.ConsumerKind,
+			ConsumerID:   grant.ConsumerID,
+		})
+	}
+	for _, key := range keys {
+		row := dashboard.KeychainKeyView{
+			Name:      key.Name,
+			Mode:      key.Mode,
+			Grants:    grantsByKey[key.Name],
+			CreatedAt: key.CreatedAt,
+		}
+		if row.Grants == nil {
+			row.Grants = []dashboard.KeychainGrantView{}
+		}
+		if key.ProxyConfigured() {
+			row.ProxyUpstream = key.ProxyUpstream
+			row.ProxyAuth = keyProxyAuthLabel(key)
+		}
+		out.Keys = append(out.Keys, row)
 	}
 	return out, nil
 }

--- a/internal/cli/dashboard_web_config_test.go
+++ b/internal/cli/dashboard_web_config_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"strings"
@@ -201,4 +204,169 @@ func dashboardConfigKnob(t *testing.T, snapshot dashboard.ConfigSnapshot, sectio
 	}
 	t.Fatalf("missing config knob %s.%s", section, key)
 	return dashboard.ConfigKnob{}
+}
+
+func TestWebDataSourceConfigKeychainProjection(t *testing.T) {
+	home := dashboardTestHome(t)
+	path, _ := seedDashboardConfigKeychain(t, home)
+	snapshot, err := (&webDataSource{home: home}).Config(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Keychain.File.Path != path || snapshot.Keychain.File.Status != pipelineEnvFileStatusOK {
+		t.Fatalf("keychain file = %+v", snapshot.Keychain.File)
+	}
+	wantNames := []string{"GH_TOKEN", "OPENAI_API_KEY", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID"}
+	if len(snapshot.Keychain.Keys) != len(wantNames) {
+		t.Fatalf("keys = %+v", snapshot.Keychain.Keys)
+	}
+	for i, want := range wantNames {
+		if snapshot.Keychain.Keys[i].Name != want || snapshot.Keychain.Keys[i].Grants == nil || snapshot.Keychain.Keys[i].CreatedAt == "" {
+			t.Fatalf("key[%d] = %+v, want %s with non-nil grants and created_at", i, snapshot.Keychain.Keys[i], want)
+		}
+	}
+	ghGrants := snapshot.Keychain.Keys[0].Grants
+	wantGrants := []dashboard.KeychainGrantView{
+		{ConsumerKind: "pipeline", ConsumerID: "alpha"},
+		{ConsumerKind: "pipeline", ConsumerID: "zeta"},
+	}
+	if !reflect.DeepEqual(ghGrants, wantGrants) {
+		t.Fatalf("GH_TOKEN grants = %+v, want %+v", ghGrants, wantGrants)
+	}
+	proxied := snapshot.Keychain.Keys[1]
+	if proxied.Mode != db.KeychainModeProxied || proxied.ProxyUpstream != "https://api.example.test/v1" || proxied.ProxyAuth != "header:X-Service-Key" {
+		t.Fatalf("proxied key = %+v", proxied)
+	}
+	for _, key := range []dashboard.KeychainKeyView{snapshot.Keychain.Keys[0], snapshot.Keychain.Keys[2], snapshot.Keychain.Keys[3]} {
+		if key.Mode != db.KeychainModeInjected || key.ProxyUpstream != "" || key.ProxyAuth != "" || len(key.Grants) == 0 {
+			t.Fatalf("injected key = %+v", key)
+		}
+	}
+}
+
+func TestWebDataSourceConfigKeychainLiveDriftKeepsRegistry(t *testing.T) {
+	home := dashboardTestHome(t)
+	path, _ := seedDashboardConfigKeychain(t, home)
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := (&webDataSource{home: home}).Config(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Keychain.File.Path != path || snapshot.Keychain.File.Status != pipelineEnvFileStatusMissing || len(snapshot.Keychain.Keys) != 4 {
+		t.Fatalf("drifted keychain = %+v", snapshot.Keychain)
+	}
+	if got := snapshot.Keychain.Keys[0].Grants; !reflect.DeepEqual(got, []dashboard.KeychainGrantView{
+		{ConsumerKind: "pipeline", ConsumerID: "alpha"},
+		{ConsumerKind: "pipeline", ConsumerID: "zeta"},
+	}) {
+		t.Fatalf("registry grants changed after file drift: %+v", got)
+	}
+}
+
+func TestWebDataSourceConfigKeychainNeverLeaksValues(t *testing.T) {
+	home := dashboardTestHome(t)
+	_, sentinels := seedDashboardConfigKeychain(t, home)
+	snapshot, err := (&webDataSource{home: home}).Config(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sentinel := range sentinels {
+		if strings.Contains(string(raw), sentinel) {
+			t.Fatalf("config payload leaked keychain value %q: %s", sentinel, raw)
+		}
+	}
+}
+
+func TestDashboardConfigKeychainHTTPShape(t *testing.T) {
+	home := dashboardTestHome(t)
+	_, sentinels := seedDashboardConfigKeychain(t, home)
+	server := httptest.NewServer(dashboard.Serve(&webDataSource{home: home}))
+	defer server.Close()
+	resp, err := http.Get(server.URL + "/api/config")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d body=%s", resp.StatusCode, body)
+	}
+	text := string(body)
+	for _, want := range []string{`"keychain"`, `"proxyUpstream"`, `"proxyAuth"`, `"consumerKind"`, `"consumerID"`, `"createdAt"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("config wire payload missing %s: %s", want, body)
+		}
+	}
+	for _, unwanted := range []string{`"proxy_upstream"`, `"proxy_auth"`, `"consumer_kind"`, `"consumer_id"`, `"created_at"`} {
+		if strings.Contains(text, unwanted) {
+			t.Fatalf("config wire payload contains non-camelCase key %s: %s", unwanted, body)
+		}
+	}
+	for _, sentinel := range sentinels {
+		if strings.Contains(text, sentinel) {
+			t.Fatalf("config wire payload leaked keychain value %q: %s", sentinel, body)
+		}
+	}
+	var snapshot dashboard.ConfigSnapshot
+	if err := json.Unmarshal(body, &snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Keychain.Keys == nil || len(snapshot.Keychain.Keys) != 4 || snapshot.Keychain.Keys[0].Grants == nil {
+		t.Fatalf("non-null array contract failed: %+v", snapshot.Keychain)
+	}
+}
+
+func seedDashboardConfigKeychain(t *testing.T, home string) (string, []string) {
+	t.Helper()
+	sentinels := []string{
+		"sentinel-gh-982-value",
+		"sentinel-openai-982-value",
+		"sentinel-telegram-bot-982-value",
+		"sentinel-telegram-chat-982-value",
+	}
+	path := writeDefaultKeychain(t, home, strings.Join([]string{
+		"GH_TOKEN=" + sentinels[0],
+		"OPENAI_API_KEY=" + sentinels[1],
+		"TELEGRAM_BOT_TOKEN=" + sentinels[2],
+		"TELEGRAM_CHAT_ID=" + sentinels[3],
+	}, "\n")+"\n")
+	store := openPipelineTestStore(t, home)
+	defer store.Close()
+	for _, name := range []string{"zeta", "alpha", "beta"} {
+		seedTestPipeline(t, store, db.Pipeline{Name: name, SpecYAML: "name: " + name + "\nstages:\n  - {id: run, cmd: echo}\n"})
+	}
+	for _, key := range []struct{ name, mode string }{
+		{"TELEGRAM_CHAT_ID", db.KeychainModeInjected},
+		{"GH_TOKEN", db.KeychainModeInjected},
+		{"OPENAI_API_KEY", db.KeychainModeProxied},
+		{"TELEGRAM_BOT_TOKEN", db.KeychainModeInjected},
+	} {
+		if _, err := store.AddKeychainKey(context.Background(), key.name, key.mode); err != nil {
+			t.Fatalf("AddKeychainKey %s: %v", key.name, err)
+		}
+	}
+	if _, err := store.ConfigureKeychainProxy(context.Background(), "OPENAI_API_KEY", "https://api.example.test/v1", db.KeychainProxyAuthHeader, "X-Service-Key"); err != nil {
+		t.Fatal(err)
+	}
+	for _, grant := range []struct{ key, pipeline string }{
+		{"GH_TOKEN", "zeta"},
+		{"GH_TOKEN", "alpha"},
+		{"OPENAI_API_KEY", "alpha"},
+		{"TELEGRAM_BOT_TOKEN", "beta"},
+		{"TELEGRAM_CHAT_ID", "zeta"},
+	} {
+		if _, err := store.GrantKeychainKey(context.Background(), db.KeychainConsumerPipeline, grant.pipeline, grant.key); err != nil {
+			t.Fatalf("GrantKeychainKey %s/%s: %v", grant.pipeline, grant.key, err)
+		}
+	}
+	return path, sentinels
 }

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -59,6 +59,9 @@ inferred. The dashboard only builds a resume command from a full UUID.
 In `gitmoot dashboard --web`, labeled jobs cluster around workflow hubs in
 Galaxy; a labeled run links to `/workflows/<label>`, which shows the complete
 run forest, state totals, best-effort token totals, and shared journal.
+The dashboard Config page also includes a read-only, names-only Keychain section
+with live file status, registry modes, configured proxy placement, and sorted
+pipeline grants. Credential values and value-derived data are never projected.
 
 The append-only journal stores text and authors verbatim. JSON show output keeps
 them verbatim; terminal text output sanitizes escapes/control bytes and caps each

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -358,6 +358,12 @@ filter box narrows by key, section, or value, and every knob carries a
 click-to-copy `key = value` snippet for pasting into `config.toml`, whose path
 and last-modified time are shown in the footer.
 
+The Keychain section is a names-only registry view: it shows the configured
+keychain path and live file status, each registered key's injected/proxied mode,
+configured proxy upstream and auth placement, and sorted consumer grants. It
+never returns credential values or value-derived data; file rotation and drift
+are reflected on the next request.
+
 Values come from a strict server-side allowlist: only known, registered
 settings are ever serialized, so secrets and tokens can never appear. Keys
 present in `config.toml` that the allowlist does not recognize are listed by

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6860,6 +6860,12 @@ filter box narrows by key, section, or value, and every knob carries a
 click-to-copy `key = value` snippet for pasting into `config.toml`, whose path
 and last-modified time are shown in the footer.
 
+The Keychain section is a names-only registry view: it shows the configured
+keychain path and live file status, each registered key's injected/proxied mode,
+configured proxy upstream and auth placement, and sorted consumer grants. It
+never returns credential values or value-derived data; file rotation and drift
+are reflected on the next request.
+
 Values come from a strict server-side allowlist: only known, registered
 settings are ever serialized, so secrets and tokens can never appear. Keys
 present in `config.toml` that the allowlist does not recognize are listed by
@@ -12621,6 +12627,9 @@ inferred. The dashboard only builds a resume command from a full UUID.
 In `gitmoot dashboard --web`, labeled jobs cluster around workflow hubs in
 Galaxy; a labeled run links to `/workflows/<label>`, which shows the complete
 run forest, state totals, best-effort token totals, and shared journal.
+The dashboard Config page also includes a read-only, names-only Keychain section
+with live file status, registry modes, configured proxy placement, and sorted
+pipeline grants. Credential values and value-derived data are never projected.
 
 The append-only journal stores text and authors verbatim. JSON show output keeps
 them verbatim; terminal text output sanitizes escapes/control bytes and caps each


### PR DESCRIPTION
WHAT:
Implemented issue #982 server half. ConfigSnapshot now includes a deterministic, names-only Keychain projection with live file status, registry metadata, proxy configuration, and grants. No credential values are exposed. No commit or push was performed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-63c2776c

RESULTS:
- Focused Config/keychain tests: PASS, internal/cli in 0.856s.
- npm run build:llms: PASS.
- go generate ./...: PASS; pre/post diff SHA-256 remained c41033fab552331fde289c83b671fde942ef83f1aee9feb8088530da6efc2e92.
- go build -buildvcs=false ./...: PASS with go1.26.4.
- go vet ./...: PASS.
- go test -buildvcs=false ./internal/...: PASS. Tail included internal/cli 376.122s, internal/db 111.329s, internal/workflow 109.164s, and internal/daemon 23.816s.
- git diff --check: PASS.

RISK:
Review the generated diff before merging.

TASK:
adhoc-63c2776c

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented issue #982 server half. ConfigSnapshot now includes a deterministic, names-only Keychain projection with live file status, registry metadata, proxy configuration, and grants. No credential values are exposed. No commit or push was performed.
````
