### PR TITLE
Gitmoot: TASK: Fix gitmoot issue #983 — the produce

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -385,6 +385,18 @@ pushes that cwd. Unlike read-only ask/review isolation, produce worktree allocat
 fails closed and records a failed stage job rather than falling back to the managed
 checkout.
 
+For a Claude produce stage that declares `reads:`, Gitmoot also inspects the
+operator's user-level Claude settings (`$CLAUDE_CONFIG_DIR/settings.json`, or
+`$HOME/.claude/settings.json`, plus `$HOME/.claude.json`). Absolute script paths
+referenced by command hooks are admitted by parent directory as read-only runtime
+resources; `.claude.json` is admitted as an individual read-only file. Gitmoot
+never auto-admits a resource that would expose its home, the configured keychain,
+or the pipeline `env_file`. A protected, missing, or unreadable hook fails delivery
+before Claude starts and names the path; a relative or malformed hook command adds
+a `produce_runtime_resource_warning` job event. Stages without `reads:` retain the
+historical unrestricted-read behavior. Kimi exposes no analogous command-hook
+surface in its supported config, and Codex continues to use its native sandbox.
+
 Landlock governs filesystem access only in this feature. It does **not** implement
 the stage's network policy; network behavior remains whatever the selected runtime
 and its CLI policy enforce. There is no advisory fallback for Claude/Kimi: if

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5500,10 +5500,143 @@ func applyProduceRuntimeGrants(ctx context.Context, store *db.Store, home string
 	if err != nil {
 		return fmt.Errorf("produce readable path preflight failed: %w", err)
 	}
+	var readableFiles []string
+	if len(payload.ReadablePaths) > 0 && agent.Runtime == runtime.ClaudeRuntime {
+		var warnings []runtime.ClaudeHookWarning
+		readable, readableFiles, warnings, err = claudeProduceRuntimeReadAccess(ctx, store, home, envFile, readable)
+		recordClaudeProduceHookWarnings(ctx, store, job.ID, warnings)
+		if err != nil {
+			return fmt.Errorf("produce Claude runtime resource preflight failed: %w", err)
+		}
+	}
 	agent.WritablePaths = writable
 	agent.ReadablePaths = readable
+	agent.ReadableFiles = readableFiles
 	agent.ProduceNetwork = payload.Network
 	return nil
+}
+
+func claudeProduceRuntimeReadAccess(ctx context.Context, store *db.Store, homeFlag, envFile string, declared []string) ([]string, []string, []runtime.ClaudeHookWarning, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("resolve Claude operator home: %w", err)
+	}
+	home = filepath.Clean(home)
+	configDir := realClaudeConfigDir()
+	if strings.TrimSpace(configDir) == "" {
+		configDir = filepath.Join(home, ".claude")
+	}
+	configDir, err = resolveProduceSafetyPath(configDir)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("resolve Claude config directory: %w", err)
+	}
+	protected, err := resolveProduceReadProtectedPaths(ctx, store, homeFlag, envFile)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	resources, warnings := runtime.DiscoverClaudeHookResources(home, configDir)
+	readable := compactCleanPaths(declared)
+	readableFiles := []string{}
+	addDir := func(path, resource string) error {
+		resolved, resolveErr := resolveProduceSafetyPath(path)
+		if resolveErr != nil {
+			return fmt.Errorf("resolve Claude runtime resource %q: %w", resource, resolveErr)
+		}
+		if label, excluded := protected.exclusion(resolved); excluded {
+			return fmt.Errorf("Claude runtime resource %q cannot be read because its parent %q overlaps %s; move it outside protected state, then add reads: [%q] if needed", resource, resolved, label, resolved)
+		}
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return fmt.Errorf("inspect Claude runtime resource directory %q: %w", resolved, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("Claude runtime resource parent %q is not a directory", resolved)
+		}
+		readable = compactCleanPaths(append(readable, resolved))
+		return nil
+	}
+	if info, statErr := os.Stat(configDir); statErr == nil && info.IsDir() {
+		if err := addDir(configDir, configDir); err != nil {
+			return nil, nil, warnings, err
+		}
+	} else if statErr != nil && !os.IsNotExist(statErr) {
+		return nil, nil, warnings, fmt.Errorf("inspect Claude config directory %q: %w", configDir, statErr)
+	}
+
+	userState := filepath.Join(home, ".claude.json")
+	if _, statErr := os.Stat(userState); statErr == nil {
+		resolved, err := resolveProduceSafetyPath(userState)
+		if err != nil {
+			return nil, nil, warnings, fmt.Errorf("resolve Claude user settings %q: %w", userState, err)
+		}
+		if label, excluded := protected.exclusion(resolved); excluded {
+			return nil, nil, warnings, fmt.Errorf("Claude user settings %q cannot be read because it overlaps %s", userState, label)
+		}
+		readableFiles = compactCleanPaths(append(readableFiles, resolved))
+	} else if !os.IsNotExist(statErr) {
+		return nil, nil, warnings, fmt.Errorf("inspect Claude user settings %q: %w", userState, statErr)
+	}
+
+	for _, resource := range resources {
+		resolved, err := resolveProduceSafetyPath(resource.Path)
+		if err != nil {
+			return nil, nil, warnings, fmt.Errorf("resolve Claude hook path %q: %w", resource.Path, err)
+		}
+		parent := filepath.Dir(resolved)
+		if err := addDir(parent, resource.Path); err != nil {
+			return nil, nil, warnings, err
+		}
+		if info, statErr := os.Stat(resolved); statErr == nil {
+			if info.IsDir() {
+				return nil, nil, warnings, fmt.Errorf("Claude hook path %q is a directory, not a readable script", resource.Path)
+			}
+			file, openErr := os.Open(resolved)
+			if openErr != nil {
+				return nil, nil, warnings, fmt.Errorf("Claude hook path %q is not readable: %w", resource.Path, openErr)
+			}
+			_ = file.Close()
+		} else if os.IsNotExist(statErr) {
+			return nil, nil, warnings, fmt.Errorf("Claude hook path %q does not exist; fix the hook or add a readable absolute script", resource.Path)
+		} else {
+			return nil, nil, warnings, fmt.Errorf("inspect Claude hook path %q: %w", resource.Path, statErr)
+		}
+		if !pathCoveredByRuntimeReads(resolved, readable, readableFiles) {
+			return nil, nil, warnings, fmt.Errorf("Claude hook path %q is outside the final read allowlist; add reads: [%q]", resource.Path, parent)
+		}
+	}
+	return readable, readableFiles, warnings, nil
+}
+
+func pathCoveredByRuntimeReads(path string, dirs, files []string) bool {
+	for _, dir := range dirs {
+		if pathWithin(path, dir) {
+			return true
+		}
+	}
+	for _, file := range files {
+		if path == file {
+			return true
+		}
+	}
+	return false
+}
+
+func recordClaudeProduceHookWarnings(ctx context.Context, store *db.Store, jobID string, warnings []runtime.ClaudeHookWarning) {
+	if store == nil || strings.TrimSpace(jobID) == "" {
+		return
+	}
+	for _, warning := range warnings {
+		origin := warning.SettingsPath
+		if warning.Event != "" {
+			origin += " (" + warning.Event + ")"
+		}
+		_ = store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   jobID,
+			Kind:    "produce_runtime_resource_warning",
+			Message: fmt.Sprintf("Claude hook settings %s: %s", origin, warning.Reason),
+		})
+	}
 }
 
 func (w jobWorker) produceDispatchError(action string, agent runtime.Agent) error {
@@ -5567,7 +5700,7 @@ func wrapProduceSandboxAdapter(action string, agent runtime.Agent, adapter workf
 	if agent.Runtime != runtime.ClaudeRuntime && agent.Runtime != runtime.KimiRuntime {
 		return adapter, nil
 	}
-	reads, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.WritablePaths)
+	reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
 	if err != nil {
 		return nil, err
 	}
@@ -5584,26 +5717,26 @@ func wrapProduceSandboxAdapter(action string, agent runtime.Agent, adapter workf
 		a.Adapter = runtimeAdapter
 		return a, nil
 	case runtime.ClaudeAdapter:
-		a.Runner = landlockProduceRunner(a.Runner, reads, writes, env)
+		a.Runner = landlockProduceRunner(a.Runner, reads, readFiles, writes, env)
 		return a, nil
 	case *runtime.ClaudeAdapter:
-		a.Runner = landlockProduceRunner(a.Runner, reads, writes, env)
+		a.Runner = landlockProduceRunner(a.Runner, reads, readFiles, writes, env)
 		return a, nil
 	case runtime.KimiAdapter:
-		a.Runner = landlockProduceRunner(a.Runner, reads, writes, env)
+		a.Runner = landlockProduceRunner(a.Runner, reads, readFiles, writes, env)
 		return a, nil
 	case *runtime.KimiAdapter:
-		a.Runner = landlockProduceRunner(a.Runner, reads, writes, env)
+		a.Runner = landlockProduceRunner(a.Runner, reads, readFiles, writes, env)
 		return a, nil
 	default:
 		return nil, fmt.Errorf("produce Landlock sandbox cannot wrap %s adapter %T", agent.Runtime, adapter)
 	}
 }
 
-func produceRuntimeSandboxGrants(runtimeName string, readable, writable []string) ([]string, []string, []string, error) {
+func produceRuntimeSandboxGrants(runtimeName string, readable, readFiles, writable []string) ([]string, []string, []string, []string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("resolve runtime state home: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("resolve runtime state home: %w", err)
 	}
 	home = filepath.Clean(home)
 	var statePaths []string
@@ -5613,7 +5746,7 @@ func produceRuntimeSandboxGrants(runtimeName string, readable, writable []string
 		stateDir := filepath.Join(home, ".claude")
 		cacheRoot, err := os.UserCacheDir()
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("resolve Claude cache root: %w", err)
+			return nil, nil, nil, nil, fmt.Errorf("resolve Claude cache root: %w", err)
 		}
 		cacheDir := filepath.Join(cacheRoot, "claude-cli-nodejs")
 		statePaths = []string{stateDir, cacheDir}
@@ -5621,16 +5754,17 @@ func produceRuntimeSandboxGrants(runtimeName string, readable, writable []string
 	case runtime.KimiRuntime:
 		statePaths = []string{filepath.Join(home, ".kimi-code")}
 	default:
-		return compactCleanPaths(readable), compactCleanPaths(writable), nil, nil
+		return compactCleanPaths(readable), compactCleanPaths(readFiles), compactCleanPaths(writable), nil, nil
 	}
 	for _, path := range statePaths {
 		if err := os.MkdirAll(path, 0o700); err != nil {
-			return nil, nil, nil, fmt.Errorf("create %s runtime state directory %q: %w", runtimeName, path, err)
+			return nil, nil, nil, nil, fmt.Errorf("create %s runtime state directory %q: %w", runtimeName, path, err)
 		}
 	}
 	reads := compactCleanPaths(readable)
+	files := compactCleanPaths(readFiles)
 	writes := compactCleanPaths(append(append([]string(nil), writable...), statePaths...))
-	return reads, writes, env, nil
+	return reads, files, writes, env, nil
 }
 
 func compactCleanPaths(paths []string) []string {
@@ -5651,8 +5785,9 @@ func compactCleanPaths(paths []string) []string {
 	return out
 }
 
-func landlockProduceRunner(runner subprocess.Runner, reads, writes, env []string) subprocess.Runner {
+func landlockProduceRunner(runner subprocess.Runner, reads, readFiles, writes, env []string) subprocess.Runner {
 	readable := append([]string(nil), reads...)
+	files := append([]string(nil), readFiles...)
 	writable := append([]string(nil), writes...)
 	runtimeEnv := append([]string(nil), env...)
 	if tee, ok := runner.(subprocess.TeeRunner); ok {
@@ -5661,7 +5796,7 @@ func landlockProduceRunner(runner subprocess.Runner, reads, writes, env []string
 			inner = subprocess.GroupRunner{}
 		}
 		if _, wrapped := inner.(subprocess.WrappingRunner); !wrapped {
-			tee.Inner = subprocess.WrappingRunner{Inner: inner, ReadablePaths: readable, WritablePaths: writable, Env: runtimeEnv}
+			tee.Inner = subprocess.WrappingRunner{Inner: inner, ReadablePaths: readable, ReadableFiles: files, WritablePaths: writable, Env: runtimeEnv}
 		}
 		return tee
 	}
@@ -5671,7 +5806,7 @@ func landlockProduceRunner(runner subprocess.Runner, reads, writes, env []string
 			inner = subprocess.GroupRunner{}
 		}
 		if _, wrapped := inner.(subprocess.WrappingRunner); !wrapped {
-			tee.Inner = subprocess.WrappingRunner{Inner: inner, ReadablePaths: readable, WritablePaths: writable, Env: runtimeEnv}
+			tee.Inner = subprocess.WrappingRunner{Inner: inner, ReadablePaths: readable, ReadableFiles: files, WritablePaths: writable, Env: runtimeEnv}
 		}
 		return tee
 	}
@@ -5681,7 +5816,7 @@ func landlockProduceRunner(runner subprocess.Runner, reads, writes, env []string
 	if _, wrapped := runner.(subprocess.WrappingRunner); wrapped {
 		return runner
 	}
-	return subprocess.WrappingRunner{Inner: runner, ReadablePaths: readable, WritablePaths: writable, Env: runtimeEnv}
+	return subprocess.WrappingRunner{Inner: runner, ReadablePaths: readable, ReadableFiles: files, WritablePaths: writable, Env: runtimeEnv}
 }
 
 // configPaths resolves this worker's config.Paths for READ-ONLY policy loading
@@ -7020,12 +7155,12 @@ func buildRuntimeAdapter(home string, agent runtime.Agent, checkout string, runn
 		return nil, err
 	}
 	gatewayRunner, _ := runner.(*credgw.Runner)
-	if (len(agent.WritablePaths) > 0 || len(agent.ReadablePaths) > 0) && (agent.Runtime == runtime.ClaudeRuntime || agent.Runtime == runtime.KimiRuntime) {
-		reads, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.WritablePaths)
+	if (len(agent.WritablePaths) > 0 || len(agent.ReadablePaths) > 0 || len(agent.ReadableFiles) > 0) && (agent.Runtime == runtime.ClaudeRuntime || agent.Runtime == runtime.KimiRuntime) {
+		reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
 		if err != nil {
 			return nil, err
 		}
-		runner = landlockProduceRunner(runner, reads, writes, env)
+		runner = landlockProduceRunner(runner, reads, readFiles, writes, env)
 	}
 	var adapter runtime.Adapter
 	switch agent.Runtime {

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -493,28 +493,9 @@ func canonicalizePipelineProduceReadPaths(ctx context.Context, store *db.Store, 
 	if store == nil {
 		return nil, errors.New("produce read path validation requires a store")
 	}
-	paths, err := pathsFromFlag(homeFlag)
+	protected, err := resolveProduceReadProtectedPaths(ctx, store, homeFlag, envFile)
 	if err != nil {
 		return nil, err
-	}
-	gitmootHome, err := resolveProduceSafetyPath(paths.Home)
-	if err != nil {
-		return nil, fmt.Errorf("resolve gitmoot home: %w", err)
-	}
-	keychainPath, err := resolveKeychainPath(store, homeFlag)
-	if err != nil {
-		return nil, err
-	}
-	keychainPath, err = resolveProduceSafetyPath(keychainPath)
-	if err != nil {
-		return nil, fmt.Errorf("resolve configured keychain_path: %w", err)
-	}
-	resolvedEnvFile := ""
-	if strings.TrimSpace(envFile) != "" {
-		resolvedEnvFile, err = resolveProduceSafetyPath(envFile)
-		if err != nil {
-			return nil, fmt.Errorf("resolve pipeline env_file: %w", err)
-		}
 	}
 
 	resolvedReads := make([]string, 0, len(reads))
@@ -526,14 +507,8 @@ func canonicalizePipelineProduceReadPaths(ctx context.Context, store *db.Store, 
 		if resolved == string(filepath.Separator) {
 			return nil, fmt.Errorf("%s reads path resolves to filesystem root, which is not allowed", subject)
 		}
-		if pathsOverlap(resolved, gitmootHome) {
-			return nil, fmt.Errorf("%s reads path overlaps the Gitmoot home", subject)
-		}
-		if pathsOverlap(resolved, keychainPath) {
-			return nil, fmt.Errorf("%s reads path overlaps the configured keychain_path", subject)
-		}
-		if resolvedEnvFile != "" && pathsOverlap(resolved, resolvedEnvFile) {
-			return nil, fmt.Errorf("%s reads path overlaps the pipeline env_file", subject)
+		if label, excluded := protected.exclusion(resolved); excluded {
+			return nil, fmt.Errorf("%s reads path overlaps %s", subject, label)
 		}
 		for _, writePath := range resolvedWrites {
 			if pathWithin(writePath, resolved) {
@@ -543,6 +518,52 @@ func canonicalizePipelineProduceReadPaths(ctx context.Context, store *db.Store, 
 		resolvedReads = append(resolvedReads, resolved)
 	}
 	return resolvedReads, nil
+}
+
+type produceReadProtectedPaths struct {
+	gitmootHome string
+	keychain    string
+	envFile     string
+}
+
+func resolveProduceReadProtectedPaths(ctx context.Context, store *db.Store, homeFlag, envFile string) (produceReadProtectedPaths, error) {
+	paths, err := pathsFromFlag(homeFlag)
+	if err != nil {
+		return produceReadProtectedPaths{}, err
+	}
+	gitmootHome, err := resolveProduceSafetyPath(paths.Home)
+	if err != nil {
+		return produceReadProtectedPaths{}, fmt.Errorf("resolve gitmoot home: %w", err)
+	}
+	keychainPath, err := resolveKeychainPath(store, homeFlag)
+	if err != nil {
+		return produceReadProtectedPaths{}, err
+	}
+	keychainPath, err = resolveProduceSafetyPath(keychainPath)
+	if err != nil {
+		return produceReadProtectedPaths{}, fmt.Errorf("resolve configured keychain_path: %w", err)
+	}
+	resolvedEnvFile := ""
+	if strings.TrimSpace(envFile) != "" {
+		resolvedEnvFile, err = resolveProduceSafetyPath(envFile)
+		if err != nil {
+			return produceReadProtectedPaths{}, fmt.Errorf("resolve pipeline env_file: %w", err)
+		}
+	}
+	return produceReadProtectedPaths{gitmootHome: gitmootHome, keychain: keychainPath, envFile: resolvedEnvFile}, nil
+}
+
+func (p produceReadProtectedPaths) exclusion(path string) (string, bool) {
+	switch {
+	case pathsOverlap(path, p.gitmootHome):
+		return "the Gitmoot home", true
+	case pathsOverlap(path, p.keychain):
+		return "the configured keychain_path", true
+	case p.envFile != "" && pathsOverlap(path, p.envFile):
+		return "the pipeline env_file", true
+	default:
+		return "", false
+	}
 }
 
 func resolveProduceSafetyPath(path string) (string, error) {

--- a/internal/cli/pipeline_produce_814_test.go
+++ b/internal/cli/pipeline_produce_814_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,6 +149,183 @@ func TestApplyProduceRuntimeReadableGrantsRevalidateAtDelivery(t *testing.T) {
 	err = applyProduceRuntimeGrants(context.Background(), store, home, db.Job{ID: "produce-read", Type: "produce"}, payload, &agent)
 	if err == nil || !strings.Contains(err.Error(), "produce readable path preflight failed") || len(agent.ReadablePaths) != 0 {
 		t.Fatalf("retargeted read symlink preflight = %v agent=%+v", err, agent)
+	}
+}
+
+func TestApplyProduceRuntimeGrantsAutoIncludesClaudeHooksAndPreservesNoReads(t *testing.T) {
+	base := t.TempDir()
+	operatorHome := filepath.Join(base, "operator")
+	configDir := filepath.Join(operatorHome, ".claude")
+	hookDir := filepath.Join(base, "operator-hooks")
+	inputDir := filepath.Join(base, "input")
+	outputDir := filepath.Join(base, "output")
+	for _, dir := range []string{configDir, hookDir, inputDir, outputDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", operatorHome)
+	t.Setenv(runtime.ClaudeConfigDirEnv, "")
+	hookPath := filepath.Join(hookDir, "prompt-hook.sh")
+	if err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeProduceSettings(t, configDir, fmt.Sprintf(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":%q}]}]}}`, hookPath))
+	userState := filepath.Join(operatorHome, ".claude.json")
+	if err := os.WriteFile(userState, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	home := filepath.Join(base, "config-home")
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	createProduceGrantPipeline(t, store, inputDir, outputDir)
+	job := db.Job{ID: "claude-hooks", Agent: "producer", Type: "produce", State: string(workflow.JobQueued)}
+	if err := store.CreateJob(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	payload := workflow.JobPayload{PipelineName: "p", WritablePaths: []string{outputDir}, ReadablePaths: []string{inputDir}}
+	agent := runtime.Agent{Name: "producer", Runtime: runtime.ClaudeRuntime}
+	if err := applyProduceRuntimeGrants(context.Background(), store, home, job, payload, &agent); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{inputDir, configDir, hookDir} {
+		if !containsString(agent.ReadablePaths, want) {
+			t.Fatalf("readable paths = %v, missing %q", agent.ReadablePaths, want)
+		}
+	}
+	if len(agent.ReadableFiles) != 1 || agent.ReadableFiles[0] != userState {
+		t.Fatalf("readable files = %v, want %q", agent.ReadableFiles, userState)
+	}
+
+	withoutReads := runtime.Agent{Name: "producer", Runtime: runtime.ClaudeRuntime}
+	if err := applyProduceRuntimeGrants(context.Background(), store, home, db.Job{ID: "no-reads", Type: "produce"}, workflow.JobPayload{WritablePaths: []string{outputDir}}, &withoutReads); err != nil {
+		t.Fatal(err)
+	}
+	if withoutReads.ReadablePaths != nil || withoutReads.ReadableFiles != nil {
+		t.Fatalf("no-reads stage gained runtime reads: dirs=%v files=%v", withoutReads.ReadablePaths, withoutReads.ReadableFiles)
+	}
+}
+
+func TestApplyProduceRuntimeGrantsRefusesProtectedClaudeHookLoudly(t *testing.T) {
+	base := t.TempDir()
+	operatorHome := filepath.Join(base, "operator")
+	configDir := filepath.Join(operatorHome, ".claude")
+	inputDir := filepath.Join(base, "input")
+	outputDir := filepath.Join(base, "output")
+	for _, dir := range []string{configDir, inputDir, outputDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", operatorHome)
+	t.Setenv(runtime.ClaudeConfigDirEnv, "")
+	home := filepath.Join(base, "config-home")
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hookPath := filepath.Join(paths.Home, "protected-hook.sh")
+	if err := os.WriteFile(hookPath, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeProduceSettings(t, configDir, fmt.Sprintf(`{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":%q}]}]}}`, hookPath))
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	createProduceGrantPipeline(t, store, inputDir, outputDir)
+	agent := runtime.Agent{Name: "producer", Runtime: runtime.ClaudeRuntime}
+	err = applyProduceRuntimeGrants(context.Background(), store, home, db.Job{ID: "protected", Type: "produce"}, workflow.JobPayload{
+		PipelineName: "p", WritablePaths: []string{outputDir}, ReadablePaths: []string{inputDir},
+	}, &agent)
+	if err == nil || !strings.Contains(err.Error(), hookPath) || !strings.Contains(err.Error(), "Gitmoot home") || !strings.Contains(err.Error(), "reads:") {
+		t.Fatalf("protected hook preflight = %v", err)
+	}
+	if agent.ReadablePaths != nil || agent.ReadableFiles != nil {
+		t.Fatalf("failed preflight mutated agent reads: dirs=%v files=%v", agent.ReadablePaths, agent.ReadableFiles)
+	}
+}
+
+func TestApplyProduceRuntimeGrantsRecordsClaudeHookParseWarning(t *testing.T) {
+	base := t.TempDir()
+	operatorHome := filepath.Join(base, "operator")
+	configDir := filepath.Join(operatorHome, ".claude")
+	inputDir := filepath.Join(base, "input")
+	outputDir := filepath.Join(base, "output")
+	for _, dir := range []string{configDir, inputDir, outputDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", operatorHome)
+	t.Setenv(runtime.ClaudeConfigDirEnv, "")
+	writeClaudeProduceSettings(t, configDir, `{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"./relative-hook.sh"}]}]}}`)
+	home := filepath.Join(base, "config-home")
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	createProduceGrantPipeline(t, store, inputDir, outputDir)
+	job := db.Job{ID: "hook-warning", Agent: "producer", Type: "produce", State: string(workflow.JobQueued)}
+	if err := store.CreateJob(context.Background(), job); err != nil {
+		t.Fatal(err)
+	}
+	agent := runtime.Agent{Name: "producer", Runtime: runtime.ClaudeRuntime}
+	if err := applyProduceRuntimeGrants(context.Background(), store, home, job, workflow.JobPayload{
+		PipelineName: "p", WritablePaths: []string{outputDir}, ReadablePaths: []string{inputDir},
+	}, &agent); err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListJobEvents(context.Background(), job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Kind == "produce_runtime_resource_warning" && strings.Contains(event.Message, "relative path") && strings.Contains(event.Message, "UserPromptSubmit") {
+			return
+		}
+	}
+	t.Fatalf("Claude hook warning event missing: %+v", events)
+}
+
+func writeClaudeProduceSettings(t *testing.T, configDir, body string) {
+	t.Helper()
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "settings.json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createProduceGrantPipeline(t *testing.T, store *db.Store, inputDir, outputDir string) {
+	t.Helper()
+	specYAML := "name: p\nstages:\n  - id: export\n    agent: producer\n    action: produce\n    prompt: x\n    write: true\n    reads: [" + inputDir + "]\n    writes: [" + outputDir + "]\n"
+	if err := store.CreateOrUpdatePipeline(context.Background(), db.Pipeline{Name: "p", SpecYAML: specYAML}); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/cli/sandbox.go
+++ b/internal/cli/sandbox.go
@@ -59,8 +59,9 @@ func (v *sandboxPathFlags) Set(value string) error {
 func runSandboxExec(args []string, _ io.Writer, stderr io.Writer) int {
 	fs := flag.NewFlagSet("sandbox-exec", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	var reads, writes sandboxPathFlags
+	var reads, readFiles, writes sandboxPathFlags
 	fs.Var(&reads, "read", "absolute directory readable by the sandbox (repeatable)")
+	fs.Var(&readFiles, "read-file", "absolute file readable by the sandbox (repeatable)")
 	fs.Var(&writes, "write", "absolute directory writable by the sandbox (repeatable)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -73,7 +74,7 @@ func runSandboxExec(args []string, _ io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "sandbox-exec requires -- <command> [args...]")
 		return 2
 	}
-	if err := sandbox.Exec([]string(reads), []string(writes), argv); err != nil {
+	if err := sandbox.Exec([]string(reads), []string(readFiles), []string(writes), argv); err != nil {
 		fmt.Fprintf(stderr, "sandbox-exec: %v\n", err)
 		return 1
 	}

--- a/internal/cli/sandbox_produce_hook_linux_test.go
+++ b/internal/cli/sandbox_produce_hook_linux_test.go
@@ -1,0 +1,125 @@
+//go:build linux
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/sandbox"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestClaudeProduceHookAutoReadLandlockE2E(t *testing.T) {
+	abi, err := sandbox.ABI()
+	if err != nil || abi < sandbox.MinimumABI {
+		t.Skipf("Landlock ABI v%d unavailable (need v%d): %v", abi, sandbox.MinimumABI, err)
+	}
+	base, err := os.MkdirTemp(".", ".gitmoot-claude-hook-sandbox-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base, err = filepath.Abs(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(base)
+
+	operatorHome := filepath.Join(base, "operator")
+	configDir := filepath.Join(operatorHome, ".claude")
+	hookDir := filepath.Join(base, "hooks")
+	siblingDir := filepath.Join(base, "not-included")
+	inputDir := filepath.Join(base, "input")
+	outputDir := filepath.Join(base, "output")
+	workdir := filepath.Join(base, "work")
+	binDir := filepath.Join(base, "bin")
+	for _, dir := range []string{configDir, hookDir, siblingDir, inputDir, outputDir, workdir, binDir} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("HOME", operatorHome)
+	t.Setenv(runtime.ClaudeConfigDirEnv, "")
+	hookPath := filepath.Join(hookDir, "prompt-hook.sh")
+	siblingPath := filepath.Join(siblingDir, "private.txt")
+	outputPath := filepath.Join(outputDir, "result.txt")
+	if err := os.WriteFile(hookPath, []byte("hook-data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(siblingPath, []byte("private-data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeClaudeProduceSettings(t, configDir, fmt.Sprintf(`{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":%q}]}]}}`, hookPath))
+	userState := filepath.Join(operatorHome, ".claude.json")
+	if err := os.WriteFile(userState, []byte(`{"operator":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	home := filepath.Join(base, "config-home")
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	createProduceGrantPipeline(t, store, inputDir, outputDir)
+	agent := runtime.Agent{Name: "producer", Runtime: runtime.ClaudeRuntime}
+	if err := applyProduceRuntimeGrants(context.Background(), store, home, db.Job{ID: "landlock-hook", Type: "produce"}, workflow.JobPayload{
+		PipelineName: "p", WritablePaths: []string{outputDir}, ReadablePaths: []string{inputDir},
+	}, &agent); err != nil {
+		t.Fatal(err)
+	}
+	if !containsString(agent.ReadablePaths, hookDir) {
+		t.Fatalf("hook directory not auto-included: %v", agent.ReadablePaths)
+	}
+
+	gitmoot := filepath.Join(binDir, "gitmoot")
+	build := exec.Command("go", "build", "-buildvcs=false", "-o", gitmoot, "./cmd/gitmoot")
+	build.Dir = filepath.Join("..", "..")
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build gitmoot test binary: %v\n%s", err, output)
+	}
+	reads, readFiles, writes, env, err := produceRuntimeSandboxGrants(agent.Runtime, agent.ReadablePaths, agent.ReadableFiles, agent.WritablePaths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner := subprocess.WrappingRunner{
+		Inner:         subprocess.GroupRunner{},
+		Executable:    gitmoot,
+		ReadablePaths: reads,
+		ReadableFiles: readFiles,
+		WritablePaths: writes,
+		Env:           env,
+	}
+	script := `set -eu
+cat "$1" >/dev/null
+cat "$2" >/dev/null
+if { printf denied > "$1"; } 2>/dev/null; then exit 41; fi
+if cat "$3" >/dev/null 2>&1; then exit 42; fi
+printf ok > "$4"
+`
+	result, err := runner.Run(context.Background(), workdir, "/bin/sh", "-c", script, "gitmoot-test", hookPath, userState, siblingPath, outputPath)
+	if err != nil {
+		t.Fatalf("Landlock hook read test failed: %v\nstdout=%s\nstderr=%s", err, result.Stdout, result.Stderr)
+	}
+	if data, err := os.ReadFile(outputPath); err != nil || string(data) != "ok" {
+		t.Fatalf("output = %q, err=%v", data, err)
+	}
+	if data, err := os.ReadFile(hookPath); err != nil || string(data) != "hook-data" {
+		t.Fatalf("hook was modified: %q, err=%v", data, err)
+	}
+}

--- a/internal/cli/sandbox_produce_test.go
+++ b/internal/cli/sandbox_produce_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -128,6 +129,12 @@ func TestWorkerClaudeKimiProduceDispatchWrappedArgv(t *testing.T) {
 				ref = "session_550e8400-e29b-41d4-a716-446655440000"
 			}
 			agent := runtime.Agent{Name: "p", Role: "producer", Runtime: tc.runtime, RuntimeRef: ref, RepoScope: "owner/repo", AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite, ReadablePaths: []string{"/data/input"}, WritablePaths: []string{"/data/out"}}
+			if tc.runtime == runtime.ClaudeRuntime {
+				agent.ReadableFiles = []string{home + "/.claude.json"}
+				if err := os.WriteFile(agent.ReadableFiles[0], []byte("{}"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
 			wrapped, err := wrapProduceSandboxAdapter("produce", agent, tc.adapter(capture))
 			if err != nil {
 				t.Fatal(err)
@@ -135,13 +142,16 @@ func TestWorkerClaudeKimiProduceDispatchWrappedArgv(t *testing.T) {
 			if _, err := wrapped.Deliver(context.Background(), agent, runtime.Job{Prompt: "write"}); err != nil {
 				t.Fatalf("Deliver: %v", err)
 			}
-			wantPrefix := []string{"sandbox-exec", "--read", "/data/input", "--write", "/data/out"}
+			wantPrefix := []string{"sandbox-exec", "--read", "/data/input"}
 			if tc.runtime == runtime.ClaudeRuntime {
+				wantPrefix = append(wantPrefix, "--read-file", home+"/.claude.json")
+				wantPrefix = append(wantPrefix, "--write", "/data/out")
 				wantPrefix = append(wantPrefix, "--write", home+"/.claude", "--write", home+"/.cache/claude-cli-nodejs")
 				if !reflect.DeepEqual(capture.env, []string{"CLAUDE_CONFIG_DIR=" + home + "/.claude"}) {
 					t.Fatalf("Claude sandbox env = %v", capture.env)
 				}
 			} else {
+				wantPrefix = append(wantPrefix, "--write", "/data/out")
 				wantPrefix = append(wantPrefix, "--write", home+"/.kimi-code")
 				if len(capture.env) != 0 {
 					t.Fatalf("Kimi sandbox env = %v, want empty", capture.env)
@@ -168,7 +178,11 @@ func TestProduceRunnerComposesUnderTeeAndScopesByAction(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CACHE_HOME", home+"/.cache")
-	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadablePaths: []string{"/input"}, WritablePaths: []string{"/data"}}
+	stateFile := filepath.Join(home, ".claude.json")
+	if err := os.WriteFile(stateFile, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	agent := runtime.Agent{Runtime: runtime.ClaudeRuntime, ReadablePaths: []string{"/input"}, ReadableFiles: []string{stateFile}, WritablePaths: []string{"/data"}}
 	base := runtime.ClaudeAdapter{Runner: subprocess.TeeRunner{Inner: subprocess.GroupRunner{}}}
 	wrapped, err := wrapProduceSandboxAdapter("produce", agent, base)
 	if err != nil {
@@ -187,7 +201,7 @@ func TestProduceRunnerComposesUnderTeeAndScopesByAction(t *testing.T) {
 		t.Fatalf("shim inner = %T, want GroupRunner", shim.Inner)
 	}
 	wantPaths := []string{"/data", home + "/.claude", home + "/.cache/claude-cli-nodejs"}
-	if !reflect.DeepEqual(shim.ReadablePaths, []string{"/input"}) || !reflect.DeepEqual(shim.WritablePaths, wantPaths) || !reflect.DeepEqual(shim.Env, []string{"CLAUDE_CONFIG_DIR=" + home + "/.claude"}) {
+	if !reflect.DeepEqual(shim.ReadablePaths, []string{"/input"}) || !reflect.DeepEqual(shim.ReadableFiles, []string{stateFile}) || !reflect.DeepEqual(shim.WritablePaths, wantPaths) || !reflect.DeepEqual(shim.Env, []string{"CLAUDE_CONFIG_DIR=" + home + "/.claude"}) {
 		t.Fatalf("Claude shim = reads %v writes %v env %v, want read /input, writes %v + config env", shim.ReadablePaths, shim.WritablePaths, shim.Env, wantPaths)
 	}
 

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -96,6 +96,10 @@ type Agent struct {
 	// Codex's native workspace sandbox already permits filesystem reads and has no
 	// read-only --add-dir equivalent.
 	ReadablePaths []string
+	// ReadableFiles are runtime-owned configuration files admitted to the
+	// Landlock ruleset without exposing their parent directory. They are not
+	// passed as --add-dir hints and remain read-only.
+	ReadableFiles []string
 	// ProduceNetwork opts that produce delivery into workspace-write network access.
 	ProduceNetwork bool
 }

--- a/internal/runtime/claude_settings.go
+++ b/internal/runtime/claude_settings.go
@@ -1,0 +1,253 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// ClaudeHookResource is an absolute filesystem path referenced by an
+// operator-configured Claude command hook. Command text is deliberately not
+// retained: dispatch only needs the path and its settings origin.
+type ClaudeHookResource struct {
+	Path         string
+	SettingsPath string
+	Event        string
+}
+
+// ClaudeHookWarning describes settings that could not be converted into a safe
+// absolute resource path. The warning contains no hook command body.
+type ClaudeHookWarning struct {
+	SettingsPath string
+	Event        string
+	Reason       string
+}
+
+type claudeHookSettings struct {
+	Hooks map[string][]claudeHookGroup `json:"hooks"`
+}
+
+type claudeHookGroup struct {
+	Hooks []claudeHook `json:"hooks"`
+}
+
+type claudeHook struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+// DiscoverClaudeHookResources reads Claude's user-level settings files and
+// returns absolute paths referenced by command hooks. Missing files are a
+// no-op. Malformed settings and relative/unparseable commands become warnings
+// so dispatch can surface them without guessing at filesystem grants.
+func DiscoverClaudeHookResources(home, configDir string) ([]ClaudeHookResource, []ClaudeHookWarning) {
+	home = filepath.Clean(strings.TrimSpace(home))
+	configDir = strings.TrimSpace(configDir)
+	if configDir == "" && home != "" && filepath.IsAbs(home) {
+		configDir = filepath.Join(home, ".claude")
+	}
+	settingsPaths := []string{}
+	if configDir != "" {
+		settingsPaths = append(settingsPaths, filepath.Join(filepath.Clean(configDir), "settings.json"))
+	}
+	if home != "" && filepath.IsAbs(home) {
+		settingsPaths = append(settingsPaths, filepath.Join(home, ".claude.json"))
+	}
+
+	seenSettings := make(map[string]struct{}, len(settingsPaths))
+	seenResources := make(map[string]struct{})
+	var resources []ClaudeHookResource
+	var warnings []ClaudeHookWarning
+	for _, settingsPath := range settingsPaths {
+		settingsPath = filepath.Clean(settingsPath)
+		if _, ok := seenSettings[settingsPath]; ok {
+			continue
+		}
+		seenSettings[settingsPath] = struct{}{}
+		data, err := os.ReadFile(settingsPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			warnings = append(warnings, ClaudeHookWarning{SettingsPath: settingsPath, Reason: fmt.Sprintf("cannot read settings: %v", err)})
+			continue
+		}
+		var settings claudeHookSettings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			warnings = append(warnings, ClaudeHookWarning{SettingsPath: settingsPath, Reason: fmt.Sprintf("invalid JSON: %v", err)})
+			continue
+		}
+		events := make([]string, 0, len(settings.Hooks))
+		for event := range settings.Hooks {
+			events = append(events, event)
+		}
+		sort.Strings(events)
+		for _, event := range events {
+			for _, group := range settings.Hooks[event] {
+				for _, hook := range group.Hooks {
+					if hook.Type != "" && hook.Type != "command" {
+						continue
+					}
+					command := strings.TrimSpace(hook.Command)
+					if command == "" {
+						warnings = append(warnings, ClaudeHookWarning{SettingsPath: settingsPath, Event: event, Reason: "command hook is empty"})
+						continue
+					}
+					paths, warning := claudeHookCommandPaths(command)
+					if warning != "" {
+						warnings = append(warnings, ClaudeHookWarning{SettingsPath: settingsPath, Event: event, Reason: warning})
+					}
+					for _, path := range paths {
+						path = filepath.Clean(path)
+						key := settingsPath + "\x00" + event + "\x00" + path
+						if _, ok := seenResources[key]; ok {
+							continue
+						}
+						seenResources[key] = struct{}{}
+						resources = append(resources, ClaudeHookResource{Path: path, SettingsPath: settingsPath, Event: event})
+					}
+				}
+			}
+		}
+	}
+	return resources, warnings
+}
+
+func claudeHookCommandPaths(command string) ([]string, string) {
+	words, err := splitHookCommand(command)
+	if err != nil {
+		return nil, err.Error()
+	}
+	seen := make(map[string]struct{})
+	paths := make([]string, 0, len(words))
+	var relative string
+	for _, word := range words {
+		candidate := hookPathCandidate(word)
+		if candidate == "" {
+			continue
+		}
+		if filepath.IsAbs(candidate) {
+			candidate = filepath.Clean(candidate)
+			if _, ok := seen[candidate]; !ok {
+				seen[candidate] = struct{}{}
+				paths = append(paths, candidate)
+			}
+			continue
+		}
+		if relative == "" && looksLikeRelativeHookPath(candidate) {
+			relative = candidate
+		}
+	}
+	if relative == "" {
+		for i, word := range words {
+			if !isHookInterpreter(word) {
+				continue
+			}
+			for _, candidate := range words[i+1:] {
+				if strings.HasPrefix(candidate, "-") {
+					continue
+				}
+				candidate = hookPathCandidate(candidate)
+				if candidate != "" && !filepath.IsAbs(candidate) {
+					relative = candidate
+				}
+				break
+			}
+			if relative != "" {
+				break
+			}
+		}
+	}
+	if relative != "" {
+		return paths, fmt.Sprintf("hook command references relative path %q; use an absolute path", relative)
+	}
+	return paths, ""
+}
+
+func splitHookCommand(command string) ([]string, error) {
+	var words []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+	flush := func() {
+		if current.Len() > 0 {
+			words = append(words, current.String())
+			current.Reset()
+		}
+	}
+	for _, r := range command {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		switch quote {
+		case '\'':
+			if r == '\'' {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+			continue
+		case '"':
+			switch r {
+			case '"':
+				quote = 0
+			case '\\':
+				escaped = true
+			default:
+				current.WriteRune(r)
+			}
+			continue
+		}
+		switch {
+		case r == '\'' || r == '"':
+			quote = r
+		case r == '\\':
+			escaped = true
+		case unicode.IsSpace(r) || strings.ContainsRune(";|&()<>", r):
+			flush()
+		default:
+			current.WriteRune(r)
+		}
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("hook command has an unterminated quote")
+	}
+	if escaped {
+		return nil, fmt.Errorf("hook command has a trailing escape")
+	}
+	flush()
+	return words, nil
+}
+
+func hookPathCandidate(word string) string {
+	word = strings.Trim(strings.TrimSpace(word), "[]")
+	if idx := strings.LastIndex(word, "="); idx >= 0 && idx+1 < len(word) {
+		value := word[idx+1:]
+		if filepath.IsAbs(value) || looksLikeRelativeHookPath(value) {
+			return value
+		}
+	}
+	return strings.TrimPrefix(word, "@")
+}
+
+func looksLikeRelativeHookPath(value string) bool {
+	return strings.HasPrefix(value, "./") || strings.HasPrefix(value, "../") ||
+		strings.HasPrefix(value, "~/") || strings.HasPrefix(value, "$HOME/") ||
+		strings.HasPrefix(value, "${HOME}/")
+}
+
+func isHookInterpreter(word string) bool {
+	word = filepath.Base(hookPathCandidate(word))
+	switch word {
+	case "sh", "bash", "dash", "zsh", "python", "python3", "node", "ruby", "perl":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/runtime/claude_settings_test.go
+++ b/internal/runtime/claude_settings_test.go
@@ -1,0 +1,85 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverClaudeHookResources(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	settings := `{
+  "hooks": {
+    "UserPromptSubmit": [{"hooks": [{"type":"command","command":"if [ -x '/opt/hooks/prompt.sh' ]; then /bin/sh '/opt/hooks/prompt.sh'; fi"}]}],
+    "PreToolUse": [{"hooks": [{"type":"command","command":"python3 \"/srv/hooks/tool hook.py\""}]}]
+  }
+}`
+	if err := os.WriteFile(filepath.Join(configDir, "settings.json"), []byte(settings), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/usr/local/libexec/stop-hook"}]}]}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	resources, warnings := DiscoverClaudeHookResources(home, configDir)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %+v", warnings)
+	}
+	var got []string
+	for _, resource := range resources {
+		got = append(got, resource.Event+":"+resource.Path)
+		if strings.Contains(resource.Path, "if [") {
+			t.Fatalf("resource retained command text: %+v", resource)
+		}
+	}
+	want := []string{
+		"PreToolUse:/srv/hooks/tool hook.py",
+		"UserPromptSubmit:/opt/hooks/prompt.sh",
+		"UserPromptSubmit:/bin/sh",
+		"Stop:/usr/local/libexec/stop-hook",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resources = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverClaudeHookResourcesWarningsAndMissing(t *testing.T) {
+	tests := []struct {
+		name       string
+		settings   string
+		wantReason string
+	}{
+		{name: "relative direct", settings: `{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"./hook.sh"}]}]}}`, wantReason: "relative path"},
+		{name: "relative interpreter", settings: `{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"python3 hook.py"}]}]}}`, wantReason: "relative path"},
+		{name: "malformed command", settings: `{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"'/opt/hook.sh"}]}]}}`, wantReason: "unterminated quote"},
+		{name: "malformed json", settings: `{`, wantReason: "invalid JSON"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			configDir := filepath.Join(home, ".claude")
+			if err := os.MkdirAll(configDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(configDir, "settings.json"), []byte(tc.settings), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, warnings := DiscoverClaudeHookResources(home, configDir)
+			if len(warnings) != 1 || !strings.Contains(warnings[0].Reason, tc.wantReason) {
+				t.Fatalf("warnings = %+v, want one containing %q", warnings, tc.wantReason)
+			}
+		})
+	}
+
+	home := t.TempDir()
+	resources, warnings := DiscoverClaudeHookResources(home, filepath.Join(home, ".claude"))
+	if len(resources) != 0 || len(warnings) != 0 {
+		t.Fatalf("missing settings = resources %+v warnings %+v, want no-op", resources, warnings)
+	}
+}

--- a/internal/sandbox/exec_linux.go
+++ b/internal/sandbox/exec_linux.go
@@ -22,7 +22,7 @@ const MinimumABI = 3
 // Exec applies Gitmoot's strict filesystem ruleset to the current process and
 // replaces it with argv. Landlock restrictions survive execve, so the runtime
 // and every descendant inherit the same filesystem confinement.
-func Exec(readPaths, writePaths []string, argv []string) error {
+func Exec(readPaths, readFiles, writePaths []string, argv []string) error {
 	if len(argv) == 0 || strings.TrimSpace(argv[0]) == "" {
 		return errors.New("sandbox target command is required")
 	}
@@ -48,7 +48,7 @@ func Exec(readPaths, writePaths []string, argv []string) error {
 	}
 
 	var rules []landlock.Rule
-	if len(readPaths) == 0 {
+	if len(readPaths) == 0 && len(readFiles) == 0 {
 		// Preserve the original write-confinement contract for existing produce
 		// stages: the filesystem is readable while writes remain allowlisted.
 		rules = append(rules, landlock.RODirs("/"))
@@ -58,6 +58,13 @@ func Exec(readPaths, writePaths []string, argv []string) error {
 			return err
 		}
 		rules = append(rules, landlock.RODirs(readable...))
+		files, err := readableFiles(readFiles)
+		if err != nil {
+			return err
+		}
+		if len(files) > 0 {
+			rules = append(rules, landlock.ROFiles(files...))
+		}
 	}
 	if len(writable) > 0 {
 		// WithRefer permits rename/link operations only when both the source and
@@ -78,6 +85,34 @@ func Exec(readPaths, writePaths []string, argv []string) error {
 		return fmt.Errorf("apply strict Landlock ruleset: %w", err)
 	}
 	return syscall.Exec(executable, argv, os.Environ())
+}
+
+func readableFiles(paths []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(paths))
+	files := make([]string, 0, len(paths))
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if !filepath.IsAbs(path) {
+			return nil, fmt.Errorf("sandbox read file %q must be absolute", path)
+		}
+		path = filepath.Clean(path)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("sandbox read file %q: %w", path, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("sandbox read file %q is a directory", path)
+		}
+		seen[path] = struct{}{}
+		files = append(files, path)
+	}
+	return files, nil
 }
 
 // readableRoots returns the explicit read-only inputs plus the fixed host roots

--- a/internal/sandbox/exec_other.go
+++ b/internal/sandbox/exec_other.go
@@ -8,6 +8,6 @@ import (
 
 const MinimumABI = 3
 
-func Exec(_ []string, _ []string, _ []string) error {
+func Exec(_ []string, _ []string, _ []string, _ []string) error {
 	return errors.New("Landlock sandboxing is supported only on Linux")
 }

--- a/internal/subprocess/wrapping.go
+++ b/internal/subprocess/wrapping.go
@@ -15,6 +15,7 @@ type WrappingRunner struct {
 	Inner         Runner
 	Executable    string
 	ReadablePaths []string
+	ReadableFiles []string
 	WritablePaths []string
 	// Env is appended to the sandbox-exec process environment and inherited by
 	// the exec'd runtime. It is empty for every existing wrapper except Claude
@@ -41,6 +42,9 @@ func (r WrappingRunner) command(command string, args []string) (string, []string
 	wrapped := []string{"sandbox-exec"}
 	for _, path := range r.ReadablePaths {
 		wrapped = append(wrapped, "--read", path)
+	}
+	for _, path := range r.ReadableFiles {
+		wrapped = append(wrapped, "--read-file", path)
 	}
 	for _, path := range r.WritablePaths {
 		wrapped = append(wrapped, "--write", path)

--- a/internal/subprocess/wrapping_test.go
+++ b/internal/subprocess/wrapping_test.go
@@ -34,11 +34,11 @@ func (r *wrappingCaptureRunner) LookPath(file string) (string, error) { return f
 
 func TestWrappingRunnerRewritesArgvExactly(t *testing.T) {
 	capture := &wrappingCaptureRunner{}
-	runner := WrappingRunner{Inner: capture, Executable: "/opt/gitmoot", ReadablePaths: []string{"/input/a"}, WritablePaths: []string{"/data/a", "/data/b"}}
+	runner := WrappingRunner{Inner: capture, Executable: "/opt/gitmoot", ReadablePaths: []string{"/input/a"}, ReadableFiles: []string{"/home/operator/.claude.json"}, WritablePaths: []string{"/data/a", "/data/b"}}
 	if _, err := runner.Run(context.Background(), "/work", "claude", "-p", "task"); err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"sandbox-exec", "--read", "/input/a", "--write", "/data/a", "--write", "/data/b", "--", "claude", "-p", "task"}
+	want := []string{"sandbox-exec", "--read", "/input/a", "--read-file", "/home/operator/.claude.json", "--write", "/data/a", "--write", "/data/b", "--", "claude", "-p", "task"}
 	if capture.dir != "/work" || capture.command != "/opt/gitmoot" || !reflect.DeepEqual(capture.args, want) {
 		t.Fatalf("wrapped call = dir %q command %q args %v, want /work /opt/gitmoot %v", capture.dir, capture.command, capture.args, want)
 	}

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -187,6 +187,14 @@ Claude/Kimi hosts fail closed instead of falling back to advisory confinement;
 Codex uses its native sandbox, and read paths are never passed as writable
 `--add-dir` grants.
 
+When Claude produce declares `reads:`, Gitmoot derives additional read-only
+runtime resources from the operator's user settings: the Claude config directory,
+`~/.claude.json`, and parent directories of absolute command-hook scripts. The same
+Gitmoot-home/keychain/`env_file` exclusions override auto-discovery. An excluded,
+missing, or unreadable script is refused before runtime launch with its path;
+relative or malformed hook commands emit a `produce_runtime_resource_warning`
+job event. No such discovery runs when `reads:` is absent.
+
 Pipeline key access is deny-by-default. An `injected` selection gives the shell
 the real value, which it can print or transmit. A configured `proxied` shared
 selection instead gives it a per-job placeholder and loopback URL; Gitmoot

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1249,9 +1249,15 @@ runtime (claude / codex). Four kinds:
   `$XDG_CACHE_HOME/claude-cli-nodejs` for Claude and `$HOME/.kimi-code` for Kimi;
   apart from that state/cache and device nodes, only `writes:`, workdir, and temp
   roots are writable. When `reads:` is declared, Landlock gives those paths
-  read-only access and denies unrelated host data. Gitmoot home, keychain, pipeline
-  `env_file`, and read roots containing a write root are rejected after symlink
-  resolution at add and delivery time. Landlock governs filesystem access rather than network access,
+  read-only access and denies unrelated host data. For Claude, delivery also
+  discovers absolute command-hook scripts from the operator's user settings,
+  grants their parent directories read-only, and grants `~/.claude.json` as one
+  read-only file. Gitmoot home, keychain, pipeline `env_file`, and read roots
+  containing a write root are rejected after symlink resolution at add and delivery
+  time; those exclusions also override hook discovery. Missing/protected hooks fail
+  before launch, while relative or malformed hook commands emit a
+  `produce_runtime_resource_warning` event. No discovery runs without `reads:`.
+  Landlock governs filesystem access rather than network access,
   retries must be
   idempotent, and Gitmoot never cleans operator-owned data directories.
 - **orchestrate** (#758) — `orchestrate: true`. Sub-tree **coordinator** (the one

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -637,6 +637,17 @@ add-dir/network arguments. Produce runs from a disposable detached worktree and
 carries no branch, task, or PR fields. Allocation fails closed instead of falling
 back to the managed checkout.
 
+For Claude stages with `reads:`, Gitmoot inspects the operator's user-level Claude
+settings and auto-adds the parent directories of absolute command-hook scripts as
+read-only runtime resources. It also admits the Claude config directory and
+`~/.claude.json` (the latter as an individual read-only file). Gitmoot-home,
+keychain, and pipeline-`env_file` exclusions still win: a protected, missing, or
+unreadable hook fails before Claude starts with an actionable path, while relative
+or malformed commands produce a `produce_runtime_resource_warning` job event.
+Stages without `reads:` keep the historical unrestricted-read behavior. Kimi has
+no analogous command-hook config surface in the supported runtime; Codex remains
+on its native sandbox.
+
 Landlock does **not** govern network access in this feature. Network policy remains
 the selected runtime CLI's responsibility. Claude/Kimi have no advisory fallback:
 unsupported Landlock means produce is refused; Codex keeps its native sandbox.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -3098,6 +3098,18 @@ pushes that cwd. Unlike read-only ask/review isolation, produce worktree allocat
 fails closed and records a failed stage job rather than falling back to the managed
 checkout.
 
+For a Claude produce stage that declares `reads:`, Gitmoot also inspects the
+operator's user-level Claude settings (`$CLAUDE_CONFIG_DIR/settings.json`, or
+`$HOME/.claude/settings.json`, plus `$HOME/.claude.json`). Absolute script paths
+referenced by command hooks are admitted by parent directory as read-only runtime
+resources; `.claude.json` is admitted as an individual read-only file. Gitmoot
+never auto-admits a resource that would expose its home, the configured keychain,
+or the pipeline `env_file`. A protected, missing, or unreadable hook fails delivery
+before Claude starts and names the path; a relative or malformed hook command adds
+a `produce_runtime_resource_warning` job event. Stages without `reads:` retain the
+historical unrestricted-read behavior. Kimi exposes no analogous command-hook
+surface in its supported config, and Codex continues to use its native sandbox.
+
 Landlock governs filesystem access only in this feature. It does **not** implement
 the stage's network policy; network behavior remains whatever the selected runtime
 and its CLI policy enforce. There is no advisory fallback for Claude/Kimi: if
@@ -13811,9 +13823,15 @@ runtime (claude / codex). Four kinds:
   `$XDG_CACHE_HOME/claude-cli-nodejs` for Claude and `$HOME/.kimi-code` for Kimi;
   apart from that state/cache and device nodes, only `writes:`, workdir, and temp
   roots are writable. When `reads:` is declared, Landlock gives those paths
-  read-only access and denies unrelated host data. Gitmoot home, keychain, pipeline
-  `env_file`, and read roots containing a write root are rejected after symlink
-  resolution at add and delivery time. Landlock governs filesystem access rather than network access,
+  read-only access and denies unrelated host data. For Claude, delivery also
+  discovers absolute command-hook scripts from the operator's user settings,
+  grants their parent directories read-only, and grants `~/.claude.json` as one
+  read-only file. Gitmoot home, keychain, pipeline `env_file`, and read roots
+  containing a write root are rejected after symlink resolution at add and delivery
+  time; those exclusions also override hook discovery. Missing/protected hooks fail
+  before launch, while relative or malformed hook commands emit a
+  `produce_runtime_resource_warning` event. No discovery runs without `reads:`.
+  Landlock governs filesystem access rather than network access,
   retries must be
   idempotent, and Gitmoot never cleans operator-owned data directories.
 - **orchestrate** (#758) — `orchestrate: true`. Sub-tree **coordinator** (the one
@@ -14318,6 +14336,14 @@ refuses read roots that expose its home, the configured keychain, or the pipelin
 Claude/Kimi hosts fail closed instead of falling back to advisory confinement;
 Codex uses its native sandbox, and read paths are never passed as writable
 `--add-dir` grants.
+
+When Claude produce declares `reads:`, Gitmoot derives additional read-only
+runtime resources from the operator's user settings: the Claude config directory,
+`~/.claude.json`, and parent directories of absolute command-hook scripts. The same
+Gitmoot-home/keychain/`env_file` exclusions override auto-discovery. An excluded,
+missing, or unreadable script is refused before runtime launch with its path;
+relative or malformed hook commands emit a `produce_runtime_resource_warning`
+job event. No such discovery runs when `reads:` is absent.
 
 Pipeline key access is deny-by-default. An `injected` selection gives the shell
 the real value, which it can print or transmit. A configured `proxied` shared


### PR DESCRIPTION
WHAT:
Implemented #983. Claude produce stages declaring reads now discover operator hook resources, add safe paths read-only, and fail loudly before dispatch when a configured hook cannot be admitted. No commit or push was performed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-a0b515f6

RESULTS:
- TestDiscoverClaudeHookResources and TestDiscoverClaudeHookResourcesWarningsAndMissing cover UserPromptSubmit/PreToolUse parsing, absolute paths, malformed/relative commands, and missing settings.
- TestApplyProduceRuntimeGrantsAutoIncludesClaudeHooksAndPreservesNoReads proves safe auto-inclusion and unchanged no-reads behavior.
- TestApplyProduceRuntimeGrantsRefusesProtectedClaudeHookLoudly and TestApplyProduceRuntimeGrantsRecordsClaudeHookParseWarning cover protected-path refusal and warning events.
- TestClaudeProduceHookAutoReadLandlockE2E proves the hook and ~/.claude.json are readable, the hook directory remains unwritable, and a sibling directory remains unreadable.
- Existing TestSandboxExecReadOnlyInputE2E and the #979 validation suite remain green.
- go generate ./... passed with an unchanged tracked-diff hash; npm run build:llms passed; git diff --check passed.
- go build -buildvcs=false ./... and go vet ./... passed on go1.26.4.
- go test -buildvcs=false ./internal/... passed. Tail: internal/cli 429.596s; internal/sandbox 6.652s; internal/runtime 0.127s; internal/daemon 22.841s; internal/db 118.749s; internal/workflow 112.936s.

RISK:
Review the generated diff before merging.

TASK:
adhoc-a0b515f6

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented #983. Claude produce stages declaring reads now discover operator hook resources, add safe paths read-only, and fail loudly before dispatch when a configured hook cannot be admitted. No commit or push was performed.
````
