### PR TITLE
fix(daemon): heartbeat runtime-session leases while in-process runners are live (#986)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -373,6 +373,8 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	defer func() {
 		_ = releaseLock(context.Background())
 	}()
+	stopRuntimeLockHeartbeat := startRuntimeSessionLockHeartbeat(ctx, store, lockKey, ownerToken, lockTTL)
+	defer stopRuntimeLockHeartbeat()
 	// Thread the owner token so a foreground run's terminal cleanup (RunJob ->
 	// AdvanceJob, which fires while this lock is still held) recognizes its own lock
 	// and does not refuse the healthy-path cleanup as a foreign live owner (#536).

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5264,6 +5264,8 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			writeLine(w.Stdout, "job %s runtime lock release failed: %v", job.ID, err)
 		}
 	}()
+	stopRuntimeLockHeartbeat := startRuntimeSessionLockHeartbeat(ctx, w.Store, lockKey, ownerToken, lockTTL)
+	defer stopRuntimeLockHeartbeat()
 	// Thread the owner token into the context so the terminal worktree cleanup
 	// (which runs inside RunJob -> AdvanceJob while THIS lock is still held — it is
 	// released only by the defer above, after RunJob returns) recognizes the run's
@@ -6443,6 +6445,8 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 			writeLine(w.Stdout, "job %s temp runtime lock release failed: %v", delegatedJob.ID, err)
 		}
 	}()
+	stopRuntimeLockHeartbeat := startRuntimeSessionLockHeartbeat(ctx, w.Store, lockKey, ownerToken, tempLockTTL)
+	defer stopRuntimeLockHeartbeat()
 	// See runQueuedJob: thread the owner token so terminal cleanup recognizes this
 	// run's own still-held lock and does not refuse the healthy-path cleanup (#536).
 	ctx = workflow.WithRuntimeSelfOwnerToken(ctx, ownerToken)

--- a/internal/cli/runtime_lock.go
+++ b/internal/cli/runtime_lock.go
@@ -7,8 +7,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -81,6 +83,52 @@ func acquireRuntimeSessionLockWithKey(ctx context.Context, store *db.Store, jobI
 		_, err := store.ReleaseResourceLock(releaseCtx, key, jobID, ownerToken)
 		return err
 	}, true, key, ownerToken, nil
+}
+
+func startRuntimeSessionLockHeartbeat(ctx context.Context, store *db.Store, lockKey string, ownerToken string, ttl time.Duration) func() {
+	cadence := ttl / 3
+	if cadence < 5*time.Second {
+		cadence = 5 * time.Second
+	}
+	return startRuntimeSessionLockHeartbeatWithCadence(ctx, store, lockKey, ownerToken, ttl, cadence, os.Stderr)
+}
+
+func startRuntimeSessionLockHeartbeatWithCadence(ctx context.Context, store *db.Store, lockKey string, ownerToken string, ttl time.Duration, cadence time.Duration, stderr io.Writer) func() {
+	if strings.TrimSpace(lockKey) == "" || strings.TrimSpace(ownerToken) == "" || ttl <= 0 {
+		return func() {}
+	}
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	var logOnce sync.Once
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(cadence)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case now := <-ticker.C:
+				updated, err := store.HeartbeatResourceLock(context.Background(), lockKey, ownerToken, now.UTC().Add(ttl))
+				if err != nil {
+					logOnce.Do(func() {
+						writeLine(stderr, "runtime session lock %s heartbeat failed: %v", lockKey, err)
+					})
+					continue
+				}
+				if !updated {
+					return
+				}
+			}
+		}
+	}()
+	var stopOnce sync.Once
+	return func() {
+		stopOnce.Do(func() {
+			cancel()
+			<-done
+		})
+	}
 }
 
 func runtimeSessionResourceKey(agent runtime.Agent) (string, bool) {

--- a/internal/cli/runtime_lock_heartbeat_test.go
+++ b/internal/cli/runtime_lock_heartbeat_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestRuntimeSessionLockHeartbeatKeepsLiveJobSafe(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-live", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	if err := store.UpdateJobState(ctx, "job-live", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	now := time.Now().UTC()
+	// ttl is deliberately wide relative to the beat cadence: the assertion below
+	// needs the LAST beat before stop() to still be within ttl of reapNow even on
+	// a heavily loaded -race CI runner, so keep hundreds of ms of margin.
+	ttl := 500 * time.Millisecond
+	lockKey := "runtime:codex:session-live"
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: lockKey,
+		OwnerJobID:  "job-live",
+		OwnerToken:  "token-live",
+		ExpiresAt:   now.Add(ttl).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+
+	stop := startRuntimeSessionLockHeartbeatWithCadence(ctx, store, lockKey, "token-live", ttl, 10*time.Millisecond, io.Discard)
+	t.Cleanup(stop)
+	time.Sleep(ttl + 10*time.Millisecond)
+	stop()
+	reapNow := time.Now().UTC()
+	if !reapNow.After(now.Add(ttl)) {
+		t.Fatalf("reap time %s did not pass original expiry %s", reapNow, now.Add(ttl))
+	}
+	if err := recoverExpiredRuntimeSessionLocks(ctx, store, io.Discard, reapNow); err != nil {
+		t.Fatalf("recoverExpiredRuntimeSessionLocks returned error: %v", err)
+	}
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, io.Discard, reapNow, reapNow.Add(time.Minute), "", ""); err != nil {
+		t.Fatalf("recoverRunningJobsBeforeForRepo returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "job-live")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("job state = %q, want running", job.State)
+	}
+	if _, err := store.GetResourceLock(ctx, lockKey); err != nil {
+		t.Fatalf("runtime lock missing after recovery passes: %v", err)
+	}
+}
+
+func TestRuntimeSessionLockHeartbeatStoppedRunnerRecovers(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-dead", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	if err := store.UpdateJobState(ctx, "job-dead", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	now := time.Now().UTC()
+	ttl := time.Minute
+	lockKey := "runtime:codex:session-dead"
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: lockKey,
+		OwnerJobID:  "job-dead",
+		OwnerToken:  "token-dead",
+		ExpiresAt:   now.Add(ttl).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	stop := startRuntimeSessionLockHeartbeatWithCadence(ctx, store, lockKey, "token-dead", ttl, time.Hour, io.Discard)
+	stop()
+
+	reapNow := now.Add(ttl + time.Second)
+	if err := recoverExpiredRuntimeSessionLocks(ctx, store, io.Discard, reapNow); err != nil {
+		t.Fatalf("recoverExpiredRuntimeSessionLocks returned error: %v", err)
+	}
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, io.Discard, reapNow, reapNow.Add(time.Minute), "", ""); err != nil {
+		t.Fatalf("recoverRunningJobsBeforeForRepo returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-dead")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+	if _, err := store.GetResourceLock(ctx, lockKey); err != sql.ErrNoRows {
+		t.Fatalf("GetResourceLock after recovery error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestRuntimeSessionLockHeartbeatOwnershipGuardStopsStaleOwner(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	now := time.Now().UTC()
+	lockKey := "runtime:codex:session-reacquired"
+	acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: lockKey,
+		OwnerJobID:  "job-old",
+		OwnerToken:  "token-old",
+		ExpiresAt:   now.Add(time.Minute).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		t.Fatalf("old AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	stop := startRuntimeSessionLockHeartbeatWithCadence(ctx, store, lockKey, "token-old", time.Minute, time.Millisecond, io.Discard)
+	t.Cleanup(stop)
+	if released, err := store.ReleaseResourceLock(ctx, lockKey, "job-old", "token-old"); err != nil || !released {
+		t.Fatalf("ReleaseResourceLock returned released=%v err=%v", released, err)
+	}
+	newExpiry := now.Add(2 * time.Minute)
+	acquired, err = store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: lockKey,
+		OwnerJobID:  "job-new",
+		OwnerToken:  "token-new",
+		ExpiresAt:   newExpiry.Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		t.Fatalf("new AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	stop()
+	lock, err := store.GetResourceLock(ctx, lockKey)
+	if err != nil {
+		t.Fatalf("GetResourceLock returned error: %v", err)
+	}
+	if lock.OwnerToken != "token-new" || lock.ExpiresAt != newExpiry.Format(time.RFC3339Nano) {
+		t.Fatalf("reacquired lock changed by stale heartbeat: %+v", lock)
+	}
+	updated, err := store.HeartbeatResourceLock(ctx, lockKey, "token-old", now.Add(3*time.Minute))
+	if err != nil || updated {
+		t.Fatalf("stale HeartbeatResourceLock returned updated=%v err=%v", updated, err)
+	}
+}
+
+func TestRuntimeSessionLockHeartbeatLeavesShellRecoveryUnchanged(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-shell", Agent: "shell", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	if err := store.UpdateJobState(ctx, "job-shell", string(workflow.JobRunning)); err != nil {
+		t.Fatalf("UpdateJobState returned error: %v", err)
+	}
+	stop := startRuntimeSessionLockHeartbeat(ctx, store, "", "", time.Minute)
+	stop()
+	now := time.Now().UTC()
+	if err := recoverRunningJobsBeforeForRepo(ctx, store, io.Discard, now, now.Add(time.Minute), "", ""); err != nil {
+		t.Fatalf("recoverRunningJobsBeforeForRepo returned error: %v", err)
+	}
+	job, err := store.GetJob(ctx, "job-shell")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+}
+
+func TestRuntimeSessionLockHeartbeatErrorsAreBestEffort(t *testing.T) {
+	store := daemonWorkerStore(t)
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	stop := startRuntimeSessionLockHeartbeatWithCadence(context.Background(), store, "runtime:codex:closed", "token", time.Minute, time.Millisecond, io.Discard)
+	time.Sleep(5 * time.Millisecond)
+	stop()
+}

--- a/internal/cli/skillopt.go
+++ b/internal/cli/skillopt.go
@@ -5165,7 +5165,7 @@ func startSkillOptTrainOptimizerLockHeartbeat(ctx context.Context, store *db.Sto
 			case <-heartbeatCtx.Done():
 				return
 			case now := <-ticker.C:
-				_, _ = store.HeartbeatResourceLock(context.Background(), key, ownerJobID, ownerToken, now.UTC(), now.UTC().Add(leaseTTL))
+				_, _ = store.HeartbeatResourceLock(context.Background(), key, ownerToken, now.UTC().Add(leaseTTL))
 			}
 		}
 	}()
@@ -5364,7 +5364,7 @@ func acquireSkillOptTrainGenerationLock(ctx context.Context, store *db.Store, se
 	// outlive the upfront estimate (called from the per-option progress hook).
 	extend = func() error {
 		extendNow := time.Now().UTC()
-		_, err := store.HeartbeatResourceLock(context.Background(), key, ownerJobID, token, extendNow, extendNow.Add(ttl))
+		_, err := store.HeartbeatResourceLock(context.Background(), key, token, extendNow.Add(ttl))
 		return err
 	}
 	return release, extend, true, nil

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -6495,11 +6495,11 @@ func (s *Store) ListExpiredRuntimeSessionLocks(ctx context.Context, now time.Tim
 	return locks, rows.Err()
 }
 
-func (s *Store) HeartbeatResourceLock(ctx context.Context, resourceKey string, ownerJobID string, ownerToken string, now time.Time, expiresAt time.Time) (bool, error) {
+func (s *Store) HeartbeatResourceLock(ctx context.Context, resourceKey string, ownerToken string, expiresAt time.Time) (bool, error) {
 	result, err := s.db.ExecContext(ctx, `UPDATE resource_locks
-		SET updated_at = ?, expires_at = ?
-		WHERE resource_key = ? AND owner_job_id = ? AND owner_token = ?`,
-		formatResourceLockTime(now), formatResourceLockTime(expiresAt), strings.TrimSpace(resourceKey), strings.TrimSpace(ownerJobID), strings.TrimSpace(ownerToken))
+		SET expires_at = ?, updated_at = ?
+		WHERE resource_key = ? AND owner_token = ?`,
+		formatResourceLockTime(expiresAt), formatResourceLockTime(time.Now().UTC()), strings.TrimSpace(resourceKey), strings.TrimSpace(ownerToken))
 	if err != nil {
 		return false, err
 	}

--- a/internal/db/store_test.go
+++ b/internal/db/store_test.go
@@ -1461,17 +1461,23 @@ func TestResourceLockMethods(t *testing.T) {
 	if stored.ExpiresAt != formatResourceLockTime(now.Add(time.Minute)) {
 		t.Fatalf("resource lock expiry = %q, want fixed-width timestamp", stored.ExpiresAt)
 	}
-	if updated, err := store.HeartbeatResourceLock(ctx, lock.ResourceKey, "job-a", "wrong-token", now.Add(20*time.Second), now.Add(2*time.Minute)); err != nil || updated {
+	if updated, err := store.HeartbeatResourceLock(ctx, lock.ResourceKey, "wrong-token", now.Add(2*time.Minute)); err != nil || updated {
 		t.Fatalf("wrong-token HeartbeatResourceLock returned updated=%v err=%v", updated, err)
 	}
-	if updated, err := store.HeartbeatResourceLock(ctx, lock.ResourceKey, "job-a", "token-a", now.Add(30*time.Second), now.Add(2*time.Minute)); err != nil || !updated {
+	heartbeatBefore := time.Now().UTC()
+	if updated, err := store.HeartbeatResourceLock(ctx, lock.ResourceKey, "token-a", now.Add(2*time.Minute)); err != nil || !updated {
 		t.Fatalf("HeartbeatResourceLock returned updated=%v err=%v", updated, err)
 	}
+	heartbeatAfter := time.Now().UTC()
 	stored, err = store.GetResourceLock(ctx, lock.ResourceKey)
 	if err != nil {
 		t.Fatalf("GetResourceLock after heartbeat returned error: %v", err)
 	}
-	if stored.UpdatedAt != formatResourceLockTime(now.Add(30*time.Second)) || stored.ExpiresAt != formatResourceLockTime(now.Add(2*time.Minute)) {
+	updatedAt, err := time.Parse(time.RFC3339Nano, stored.UpdatedAt)
+	if err != nil {
+		t.Fatalf("parse heartbeat updated_at %q: %v", stored.UpdatedAt, err)
+	}
+	if updatedAt.Before(heartbeatBefore) || updatedAt.After(heartbeatAfter) || stored.ExpiresAt != formatResourceLockTime(now.Add(2*time.Minute)) {
 		t.Fatalf("heartbeat lock times = updated %q expires %q", stored.UpdatedAt, stored.ExpiresAt)
 	}
 	released, err := store.ReleaseResourceLock(ctx, lock.ResourceKey, "job-b", "token-a")


### PR DESCRIPTION
Closes #986.

## Bug

Local dispatch (`agent_dispatch.go`) and both daemon worker paths sized the runtime-session lock TTL to `daemonRunningJobStaleAfter` (30m) whenever the job had no explicit timeout — exactly the stale-running reaper's threshold, never renewed. The lease expired at the precise moment the reaper became suspicious: `recoverExpiredRuntimeSessionLocks` (which runs first each tick and requeues owners of expired locks unconditionally) requeued the **still-running** job; the requeued copy failed on the live worker's dirty worktree (`checkout_contention` ×3) and the job was permanently marked failed even though the real worker finished and its PR merged.

**Production evidence** (both at exactly start+30m): `local-implement-wave-impl-18c27c2c` (7/15, work shipped as #958) and `local-implement-wave-impl-18c2a037` (7/16, work shipped as PR #975) — full event chains in #986. Downstream symptom: shipped campaigns pinned as **stalled** on the dashboard for 24h.

## Fix (panel-reviewed: sol + kimi, unanimous)

Renew the lease while the in-process runner is alive; change nothing else.

- `startRuntimeSessionLockHeartbeat` (cadence `ttl/3`, floor 5s) bumps `expires_at` via the existing owner-token-guarded `HeartbeatResourceLock` primitive; self-stops when the lock is released/reacquired (0-row beat) and tolerates beat errors (log-once).
- Armed at all three in-process runner sites: `dispatchLocalAgentJob`, `jobWorker.run`, `jobWorker.runWithTempWorker` — stop is deferred before release.
- `HeartbeatResourceLock` signature simplified (token is the 128-bit capability; `owner_job_id` in the WHERE was redundant); both skillopt callers updated.
- **Unchanged by design:** reaper semantics, `LeaseHeld()` lease-only philosophy (#536), initial TTL sizing, shell-runtime (no-lock) reaping, daemon-restart recovery (dead runner stops beating → lease expires → recovered exactly as today).

## Tests (red behavior = the production incident above)

- `KeepsLiveJobSafe`: heartbeat-kept lock survives BOTH reapers past the original expiry; job stays running.
- `StoppedRunnerRecovers`: no heartbeat → both reapers requeue + reclaim exactly as today (regression guard).
- `OwnershipGuardStopsStaleOwner`: stale beat cannot touch a reacquired lock; heartbeat self-stops.
- `LeavesShellRecoveryUnchanged`, `ErrorsAreBestEffort`.
- Gate: build ✓ generate-diff ✓ vet ✓ `go test ./...` 36 pkgs ✓; scoped race lanes running locally in parallel with CI.

## Deploy notes

Internal reliability fix, no CLI/config/docs surface change. Deploy = standard binary swap at idle; observable live probe: `resource_locks.expires_at` of a long-running job's runtime lock advances every ~ttl/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)