### PR TITLE
feat(credentials): agent-stage grants — proxied-only keychain keys for pipeline agent stages (#874)

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -58,8 +58,10 @@ gitmoot key add SOURCE_API_TOKEN --mode injected
 gitmoot key grant SOURCE_API_TOKEN --pipeline nightly-sync
 gitmoot key add PARTNER_API_TOKEN --mode proxied
 gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
+gitmoot key grant PARTNER_API_TOKEN --agent researcher
 gitmoot key list --json
 gitmoot key show SOURCE_API_TOKEN
+gitmoot key revoke PARTNER_API_TOKEN --agent researcher
 gitmoot key revoke SOURCE_API_TOKEN --pipeline nightly-sync
 gitmoot key rm SOURCE_API_TOKEN       # refuses while grants remain
 gitmoot key rm SOURCE_API_TOKEN --force
@@ -70,14 +72,20 @@ gitmoot key rm SOURCE_API_TOKEN --force
 places the real value in the upstream `Authorization` header; `--auth
 header:X-Api-Key` uses an approved custom header. The upstream must be an
 absolute HTTPS origin and its normalized base path is pinned. Pipeline shell
-stages may request granted `injected` or configured `proxied` names with
-`env_keys`; agent and gate stages remain ineligible. Resolution is Gitmoot's
-reserved `GITMOOT_*` namespace, then the pipeline's own `env_file`, then a
-granted shared key, then inline non-secret `env`. Registered but ungranted names
-are not visible to exact or glob selectors.
+stages may request pipeline-granted `injected` or configured `proxied` names
+with `env_keys`. An agent stage can request only a configured `proxied` key,
+and both the named agent seat grant and that stage's explicit `env_keys`
+selector are required. Injected agent grants are always refused; gate stages
+remain ineligible. Shell resolution is Gitmoot's reserved `GITMOOT_*`
+namespace, then the pipeline's own `env_file`, then a granted shared key, then
+inline non-secret `env`. Agent stages never resolve from the pipeline file,
+inline defaults, or pipeline grants. Registered but ungranted names are not
+visible to exact or glob selectors.
 
-For a proxied key, the shell receives a per-job `gitmoot-kc-...` placeholder in
-the requested variable and a `GITMOOT_PROXY_<KEY>_URL` loopback URL. Gitmoot
+For a proxied key, the selected shell or agent process receives a per-job
+`gitmoot-kc-...` placeholder in the requested variable and a
+`GITMOOT_PROXY_<KEY>_URL` loopback URL. The real value never enters an agent
+process. Gitmoot
 rechecks the grant and configuration and rereads the keychain on every request,
 so rotation applies to the next request and revocation fails closed with `401`.
 The lease is revoked when the stage delivery ends.
@@ -108,9 +116,11 @@ delivery (#936). The mirror never contains a credential; the operator's real
 config is only read, never modified.
 
 Pipeline key delivery is independent of the Claude gateway. `injected` keys
-give the selected shell process the real value. `proxied` keys use generic
-per-job loopback leases whose values are resolved for each request; they do not
-alter Claude's model-gateway placeholder flow.
+give only a selected shell process the real value. `proxied` keys use generic
+per-job loopback leases for selected shell or agent stages; their values are
+resolved for each request and they do not alter Claude's model-gateway
+placeholder flow. Ordinary non-pipeline agent jobs and delegated children
+receive no pipeline-stage keys.
 
 The feature is off by default and currently covers Claude only. A populated
 `runtime-auth.env` is required while it is enabled; Gitmoot fails the delivery

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -103,7 +103,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
-| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from the pipeline's `env_file`, granted shared registry keys, or inline `env`. Shell stages only; no entry means no key access. |
+| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`). Shell stages resolve pipeline-owned, pipeline-granted, and inline sources. Agent stages resolve only configured proxied keys granted to their named seat. Gates reject this field; no entry means no key access. |
 | `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
 
 `gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
@@ -120,10 +120,13 @@ rather than a stuck run later.
 
 ### Stage-scoped environment
 
-Pipeline secrets are deny-by-default. A shell stage receives only the concrete
-names selected by its `env_keys`; a sibling with different or empty `env_keys`
-does not receive them. Agent and gate stages cannot declare `env_keys`. Shared
-keys must be registered and granted separately:
+Pipeline secrets are deny-by-default. A stage receives only the concrete names
+selected by its own `env_keys`; a sibling with different or empty `env_keys`
+does not receive them. Shell grants belong to the pipeline. Agent stages require
+two independent locks: a configured proxied key granted to the registered agent
+seat, plus that stage's explicit selector. Injected agent grants are refused,
+and gate stages cannot declare `env_keys`. Shared keys must be registered and
+granted separately:
 
 ```sh
 gitmoot key path # edit this 0600 file; the CLI never accepts values
@@ -132,6 +135,7 @@ gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
 gitmoot key add PARTNER_API_TOKEN --mode proxied
 gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
 gitmoot key grant PARTNER_API_TOKEN --pipeline trend-scout
+gitmoot key grant PARTNER_API_TOKEN --agent researcher
 ```
 
 ```yaml
@@ -157,7 +161,10 @@ again immediately before each stage process starts, so an atomic rewrite of a
 `0600` source rotates credentials without a daemon restart. Resolution is own
 `env_file`, then granted shared key, then inline default; Gitmoot's reserved
 `GITMOOT_*` entries always win. Registered but ungranted names are not glob or
-exact-match candidates.
+exact-match candidates. Agent stages resolve only from their seat's configured
+proxied grants: pipeline `env_file`, inline defaults, pipeline grants, and
+injected keys are never candidates. Ordinary agent jobs receive nothing, and
+delegated children do not inherit a pipeline stage's key access.
 
 The persisted stage job payload is the audit record: `PipelineKeyAccess` carries
 only `{stage,name,source,mode}` rows (plus legacy env-file/name fields for
@@ -168,14 +175,17 @@ after enqueue fails the stage rather than switching to another source. Inline
 injected key is visible to its shell process; this is scoping and audit, not a
 vault.
 
-A configured `proxied` shared key instead gives the shell a per-job placeholder
-in `<KEY>` and a loopback endpoint in `GITMOOT_PROXY_<KEY>_URL`. The endpoint is
+A configured `proxied` shared key gives the selected shell or agent stage a
+per-job placeholder in `<KEY>` and a loopback endpoint in
+`GITMOOT_PROXY_<KEY>_URL`. The endpoint is
 pinned to the configured HTTPS origin and normalized base path. Gitmoot places
 the real credential as either bearer auth or an approved custom header, rereads
 the keychain and rechecks the grant on every request, and revokes the lease when
 delivery ends. Rotation therefore applies to the next request; revocation
-returns `401` without contacting the upstream. Agent and gate stages remain
-ineligible, and the Claude model gateway remains independent.
+returns `401` without contacting the upstream. The real value never enters an
+agent process, though that authorized agent can exercise it against the pinned
+upstream. Gate stages remain ineligible, and the Claude model gateway remains
+independent.
 
 Proxied mode hides key bytes; it does **not** prevent an authorized child from
 exercising the credential on the pinned upstream. Curated upstreams and base

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -6464,6 +6464,7 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
 		return nil
 	}
+	adapter = wrapPipelineEnvDeliveryAdapter(w.Store, w.ConfigHome, payload, adapter)
 	if err := w.Store.MarkAgentInstanceRunning(ctx, started.Agent.Name, time.Now().UTC(), started.JobTimeout); err != nil {
 		if finishErr := w.finishQueuedJob(ctx, delegatedJob.ID, workflow.JobFailed, err); finishErr != nil {
 			return finishErr

--- a/internal/cli/dashboard_web_pipelines.go
+++ b/internal/cli/dashboard_web_pipelines.go
@@ -273,16 +273,12 @@ func dashboardPipelineKeys(ctx context.Context, store *db.Store, home string, sp
 	if err != nil {
 		return dashboard.PipelineKeys{}, err
 	}
-	availableShared := make(map[string]db.KeychainKey)
-	if len(sharedCandidates) > 0 {
+	availableShared := pipelineSharedKeys{pipeline: map[string]db.KeychainKey{}, agents: map[string]map[string]db.KeychainKey{}}
+	if sharedCandidates.any() {
 		// Keychain drift is advisory on this read-only endpoint. A missing or invalid
 		// file makes shared selectors unresolved; delivery remains fail-closed.
 		if names, loadErr := loadValidatedKeychainNames(ctx, store, home); loadErr == nil {
-			for name, key := range sharedCandidates {
-				if _, present := names[name]; present {
-					availableShared[name] = key
-				}
-			}
+			availableShared = sharedCandidates.available(names)
 		}
 	}
 	resolution := projectPipelineEnvironment(spec, inspection.Names, availableShared)

--- a/internal/cli/dashboard_web_pipelines_test.go
+++ b/internal/cli/dashboard_web_pipelines_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
+	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
 // diamondSpecYAML is a fan-out/fan-in pipeline whose declared (spec) stage order —
@@ -723,9 +724,13 @@ stages:
     agent: scout
     action: ask
     prompt: inspect
+    env_keys: [PROXY_TOKEN]
 `, envFile, defaultSentinel)
 	store := openPipelineTestStore(t, home)
 	seedTestPipeline(t, store, db.Pipeline{Name: "keys-view", SpecYAML: raw})
+	if err := store.UpsertAgent(context.Background(), db.Agent{Name: "scout", Runtime: runtime.CodexRuntime}); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := store.AddKeychainKey(context.Background(), "SHARED_TOKEN", db.KeychainModeInjected); err != nil {
 		t.Fatal(err)
 	}
@@ -739,6 +744,9 @@ stages:
 		t.Fatal(err)
 	}
 	if _, err := store.GrantKeychainKey(context.Background(), db.KeychainConsumerPipeline, "keys-view", "PROXY_TOKEN"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantKeychainKey(context.Background(), db.KeychainConsumerAgent, "scout", "PROXY_TOKEN"); err != nil {
 		t.Fatal(err)
 	}
 	store.Close()
@@ -764,10 +772,15 @@ stages:
 	if got := detail.Keys.Stages[0]; got.ID != "deliver" || got.Kind != "shell" || !reflect.DeepEqual(got.Keys, wantKeys) || len(got.UnresolvedSelectors) != 0 {
 		t.Fatalf("deliver keys = %+v", got)
 	}
-	for _, stage := range detail.Keys.Stages[1:] {
-		if stage.Keys == nil || stage.UnresolvedSelectors == nil || len(stage.Keys) != 0 || len(stage.UnresolvedSelectors) != 0 {
-			t.Fatalf("empty stage arrays = %+v", stage)
-		}
+	if stage := detail.Keys.Stages[1]; stage.Keys == nil || stage.UnresolvedSelectors == nil || len(stage.Keys) != 0 || len(stage.UnresolvedSelectors) != 0 {
+		t.Fatalf("empty shell stage arrays = %+v", stage)
+	}
+	if got, want := detail.Keys.Stages[2], (dashboard.PipelineStageKeys{
+		ID: "inspect", Kind: "agent_ask",
+		Keys:                []dashboard.PipelineKeyEntry{{Name: "PROXY_TOKEN", Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied}},
+		UnresolvedSelectors: []string{},
+	}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("agent stage keys = %+v, want %+v", got, want)
 	}
 	encoded, err := json.Marshal(detail)
 	if err != nil {

--- a/internal/cli/key.go
+++ b/internal/cli/key.go
@@ -72,8 +72,8 @@ func printKeyUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot key show <NAME> [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot key configure <NAME> --upstream <URL> --auth bearer|header:<HeaderName> [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot key rm <NAME> [--force] [--json] [--home DIR]")
-	fmt.Fprintln(w, "  gitmoot key grant <NAME> --pipeline <PIPELINE> [--json] [--home DIR]")
-	fmt.Fprintln(w, "  gitmoot key revoke <NAME> --pipeline <PIPELINE> [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key grant <NAME> (--pipeline <PIPELINE> | --agent <SEAT>) [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot key revoke <NAME> (--pipeline <PIPELINE> | --agent <SEAT>) [--json] [--home DIR]")
 }
 
 func inspectKeychain(ctx context.Context, store *db.Store, home string) keychainPathStatus {
@@ -524,24 +524,35 @@ func runKeyGrantMutation(grant bool, args []string, stdout, stderr io.Writer) in
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
 	jsonOut := fs.Bool("json", false, "print JSON")
 	pipelineName := fs.String("pipeline", "", "pipeline consumer")
+	agentName := fs.String("agent", "", "registered agent seat consumer")
 	if err := fs.Parse(args[1:]); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
 		return 2
 	}
-	if fs.NArg() != 0 || strings.TrimSpace(*pipelineName) == "" {
-		fmt.Fprintf(stderr, "key %s requires one name and --pipeline <pipeline>\n", verb)
+	pipelineID := strings.TrimSpace(*pipelineName)
+	agentID := strings.TrimSpace(*agentName)
+	if fs.NArg() != 0 || (pipelineID == "") == (agentID == "") {
+		fmt.Fprintf(stderr, "key %s requires one name and exactly one of --pipeline <pipeline> or --agent <seat>\n", verb)
 		return 2
+	}
+	consumerKind, consumerID := db.KeychainConsumerPipeline, pipelineID
+	if agentID != "" {
+		consumerKind, consumerID = db.KeychainConsumerAgent, agentID
 	}
 	changed := false
 	if err := withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
 		if grant {
-			if _, found, err := store.GetPipeline(ctx, *pipelineName); err != nil {
-				return err
-			} else if !found {
-				return fmt.Errorf("pipeline %s not found", *pipelineName)
+			if consumerKind == db.KeychainConsumerPipeline {
+				if _, found, err := store.GetPipeline(ctx, consumerID); err != nil {
+					return err
+				} else if !found {
+					return fmt.Errorf("pipeline %s not found", consumerID)
+				}
+			} else if _, err := store.GetAgent(ctx, consumerID); err != nil {
+				return fmt.Errorf("agent %s not found", consumerID)
 			}
 			key, found, err := store.GetKeychainKey(ctx, name)
 			if err != nil {
@@ -549,6 +560,9 @@ func runKeyGrantMutation(grant bool, args []string, stdout, stderr io.Writer) in
 			}
 			if !found {
 				return fmt.Errorf("key %s is not registered", name)
+			}
+			if consumerKind == db.KeychainConsumerAgent && key.Mode != db.KeychainModeProxied {
+				return fmt.Errorf("key %s uses injected mode; agent grants are proxied-only", name)
 			}
 			if key.Mode == db.KeychainModeProxied && !key.ProxyConfigured() {
 				return fmt.Errorf("key %s uses proxied mode but is not configured; run %s", name, keyConfigureCommand(name))
@@ -560,11 +574,11 @@ func runKeyGrantMutation(grant bool, args []string, stdout, stderr io.Writer) in
 			if values[name] == "" {
 				return fmt.Errorf("key %q is absent or empty in %s", name, path)
 			}
-			changed, err = store.GrantKeychainKey(ctx, db.KeychainConsumerPipeline, *pipelineName, name)
+			changed, err = store.GrantKeychainKey(ctx, consumerKind, consumerID, name)
 			return err
 		}
 		var err error
-		changed, err = store.RevokeKeychainKey(ctx, db.KeychainConsumerPipeline, *pipelineName, name)
+		changed, err = store.RevokeKeychainKey(ctx, consumerKind, consumerID, name)
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "key %s: %v\n", verb, err)
@@ -573,19 +587,20 @@ func runKeyGrantMutation(grant bool, args []string, stdout, stderr io.Writer) in
 	if *jsonOut {
 		return encodeKeyJSON(stdout, stderr, struct {
 			Name     string `json:"name"`
-			Pipeline string `json:"pipeline"`
+			Pipeline string `json:"pipeline,omitempty"`
+			Agent    string `json:"agent,omitempty"`
 			Changed  bool   `json:"changed"`
-		}{name, strings.TrimSpace(*pipelineName), changed})
+		}{name, pipelineID, agentID, changed})
 	}
 	past := "granted"
 	if !grant {
 		past = "revoked"
 	}
 	if !changed {
-		writeLine(stdout, "key %s already %s for pipeline %s", name, past, *pipelineName)
+		writeLine(stdout, "key %s already %s for %s %s", name, past, consumerKind, consumerID)
 		return 0
 	}
-	writeLine(stdout, "%s key %s for pipeline %s", past, name, *pipelineName)
+	writeLine(stdout, "%s key %s for %s %s", past, name, consumerKind, consumerID)
 	return 0
 }
 

--- a/internal/cli/key_test.go
+++ b/internal/cli/key_test.go
@@ -62,7 +62,11 @@ func TestKeyCLIRegistryGrantsAndSecretSafety(t *testing.T) {
 		}
 	}
 	if err := withStore(home, func(store *db.Store) error {
-		return store.CreateOrUpdatePipeline(context.Background(), db.Pipeline{Name: "pipe", SpecYAML: "name: pipe\nstages: [{id: run, cmd: echo}]\n"})
+		ctx := context.Background()
+		if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "pipe", SpecYAML: "name: pipe\nstages: [{id: run, cmd: echo}]\n"}); err != nil {
+			return err
+		}
+		return store.UpsertAgent(ctx, db.Agent{Name: "seat", Runtime: "codex"})
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -72,6 +76,9 @@ func TestKeyCLIRegistryGrantsAndSecretSafety(t *testing.T) {
 	} else if strings.Contains(out+errOut, keychainSentinel) {
 		t.Fatalf("proxied refusal leaked value: %q %q", out, errOut)
 	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "PROXY", "--agent", "seat", "--home", home); code == 0 || !strings.Contains(errOut, "not configured") {
+		t.Fatalf("unconfigured agent grant code=%d out=%q err=%q", code, out, errOut)
+	}
 	if code, out, errOut := runKeyTestCommand(t, "key", "configure", "PROXY", "--upstream", "https://api.example.test/v1/", "--auth", "header:X-Api-Token", "--home", home, "--json"); code != 0 || !strings.Contains(out, `"proxy_upstream": "https://api.example.test/v1"`) || !strings.Contains(out, `"proxy_auth_kind": "header"`) || !strings.Contains(out, `"proxy_header": "X-Api-Token"`) {
 		t.Fatalf("key configure code=%d out=%q err=%q", code, out, errOut)
 	} else if strings.Contains(out+errOut, keychainSentinel) {
@@ -79,6 +86,17 @@ func TestKeyCLIRegistryGrantsAndSecretSafety(t *testing.T) {
 	}
 	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "PROXY", "--pipeline", "pipe", "--home", home); code != 0 {
 		t.Fatalf("configured proxied grant code=%d out=%q err=%q", code, out, errOut)
+	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "SHARED", "--agent", "seat", "--home", home); code == 0 || !strings.Contains(errOut, "proxied-only") {
+		t.Fatalf("injected agent grant code=%d out=%q err=%q", code, out, errOut)
+	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "PROXY", "--agent", "seat", "--home", home, "--json"); code != 0 || !strings.Contains(out, `"agent": "seat"`) {
+		t.Fatalf("agent grant code=%d out=%q err=%q", code, out, errOut)
+	} else if strings.Contains(out+errOut, keychainSentinel) {
+		t.Fatalf("agent grant leaked value: %q %q", out, errOut)
+	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "PROXY", "--pipeline", "pipe", "--agent", "seat", "--home", home); code == 0 || !strings.Contains(errOut, "exactly one") {
+		t.Fatalf("mutually exclusive consumer flags code=%d out=%q err=%q", code, out, errOut)
 	}
 	if code, out, errOut := runKeyTestCommand(t, "key", "grant", "SHARED", "--pipeline", "pipe", "--home", home, "--json"); code != 0 {
 		t.Fatalf("grant code=%d out=%q err=%q", code, out, errOut)
@@ -106,9 +124,17 @@ func TestKeyCLIRegistryGrantsAndSecretSafety(t *testing.T) {
 		if wantName == "PROXY" && (!strings.Contains(out, "https://api.example.test/v1") || !strings.Contains(out, "X-Api-Token")) {
 			t.Fatalf("%v omitted proxy configuration: %q", args, out)
 		}
+		if wantName == "PROXY" && wantGrantTarget && !strings.Contains(out, "seat") {
+			t.Fatalf("%v omitted agent grant: %q", args, out)
+		}
 		if strings.Contains(out+errOut, keychainSentinel) {
 			t.Fatalf("%v leaked value: %q %q", args, out, errOut)
 		}
+	}
+	if code, out, errOut := runKeyTestCommand(t, "key", "revoke", "PROXY", "--agent", "seat", "--home", home, "--json"); code != 0 || !strings.Contains(out, `"agent": "seat"`) || !strings.Contains(out, `"changed": true`) {
+		t.Fatalf("agent revoke code=%d out=%q err=%q", code, out, errOut)
+	} else if strings.Contains(out+errOut, keychainSentinel) {
+		t.Fatalf("agent revoke leaked value: %q %q", out, errOut)
 	}
 
 	before, err := os.ReadFile(path)

--- a/internal/cli/pipeline_env.go
+++ b/internal/cli/pipeline_env.go
@@ -57,6 +57,11 @@ type pipelineEnvironmentResolution struct {
 	Unresolved []pipelineEnvUnresolved
 }
 
+type pipelineSharedKeys struct {
+	pipeline map[string]db.KeychainKey
+	agents   map[string]map[string]db.KeychainKey
+}
+
 type pipelineEnvFileInspection struct {
 	Path   string
 	Status string
@@ -81,29 +86,25 @@ func resolvePipelineEnvironment(ctx context.Context, store *db.Store, home strin
 	if err != nil {
 		return pipelineEnvironmentResolution{}, err
 	}
-	availableShared := make(map[string]db.KeychainKey)
-	if len(sharedCandidates) > 0 {
+	availableShared := pipelineSharedKeys{pipeline: map[string]db.KeychainKey{}, agents: map[string]map[string]db.KeychainKey{}}
+	if sharedCandidates.any() {
 		shared, err := loadValidatedKeychainNames(ctx, store, home)
 		if err != nil {
 			return pipelineEnvironmentResolution{}, err
 		}
-		for name, key := range sharedCandidates {
-			if _, present := shared[name]; present {
-				availableShared[name] = key
-			}
-		}
+		availableShared = sharedCandidates.available(shared)
 	}
 	return projectPipelineEnvironment(spec, ownNames, availableShared), nil
 }
 
-func projectPipelineEnvironment(spec pipeline.Spec, ownNames map[string]struct{}, sharedKeys map[string]db.KeychainKey) pipelineEnvironmentResolution {
+func projectPipelineEnvironment(spec pipeline.Spec, ownNames map[string]struct{}, sharedKeys pipelineSharedKeys) pipelineEnvironmentResolution {
 	defaultNames := make(map[string]struct{}, len(spec.Env))
 	for name := range spec.Env {
 		defaultNames[name] = struct{}{}
 	}
 	sharedInjected := make(map[string]struct{})
 	sharedProxied := make(map[string]struct{})
-	for name, key := range sharedKeys {
+	for name, key := range sharedKeys.pipeline {
 		switch key.Mode {
 		case db.KeychainModeInjected:
 			sharedInjected[name] = struct{}{}
@@ -111,7 +112,7 @@ func projectPipelineEnvironment(spec pipeline.Spec, ownNames map[string]struct{}
 			sharedProxied[name] = struct{}{}
 		}
 	}
-	sources := []pipeline.EnvKeySource{
+	shellSources := []pipeline.EnvKeySource{
 		{Source: pipelineKeySourceOwn, Mode: db.KeychainModeInjected, Names: ownNames},
 		{Source: pipelineKeySourceShared, Mode: db.KeychainModeInjected, Names: sharedInjected},
 		{Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied, Names: sharedProxied},
@@ -119,6 +120,16 @@ func projectPipelineEnvironment(spec pipeline.Spec, ownNames map[string]struct{}
 	}
 	resolution := pipelineEnvironmentResolution{}
 	for _, stage := range spec.Stages {
+		sources := shellSources
+		if stage.Kind() != pipeline.StageKindShell {
+			agentProxied := make(map[string]struct{})
+			for name, key := range sharedKeys.agents[stage.Agent] {
+				if key.Mode == db.KeychainModeProxied && key.ProxyConfigured() {
+					agentProxied[name] = struct{}{}
+				}
+			}
+			sources = []pipeline.EnvKeySource{{Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied, Names: agentProxied}}
+		}
 		projected, unresolved := pipeline.ProjectEnvKeys(stage.EnvKeys, sources)
 		for _, key := range projected {
 			resolution.Access = append(resolution.Access, workflow.PipelineKeyAccess{
@@ -132,54 +143,143 @@ func projectPipelineEnvironment(spec pipeline.Spec, ownNames map[string]struct{}
 	return resolution
 }
 
-func pipelineSharedKeyCandidates(ctx context.Context, store *db.Store, spec pipeline.Spec, ownNames map[string]struct{}) (map[string]db.KeychainKey, error) {
-	candidates := make(map[string]db.KeychainKey)
+func pipelineSharedKeyCandidates(ctx context.Context, store *db.Store, spec pipeline.Spec, ownNames map[string]struct{}) (pipelineSharedKeys, error) {
+	candidates := pipelineSharedKeys{pipeline: make(map[string]db.KeychainKey), agents: make(map[string]map[string]db.KeychainKey)}
 	if strings.TrimSpace(spec.Name) == "" {
 		return candidates, nil
 	}
 	grants, err := store.ListKeychainGrantsForConsumer(ctx, db.KeychainConsumerPipeline, spec.Name)
 	if err != nil {
-		return nil, err
+		return pipelineSharedKeys{}, err
 	}
 	for _, grant := range grants {
 		if _, owned := ownNames[grant.KeyName]; owned {
 			continue
 		}
-		if !pipelineSelectorUsed(spec, grant.KeyName) {
+		if !pipelineShellSelectorUsed(spec, grant.KeyName) {
 			continue
 		}
 		key, found, err := store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, spec.Name, grant.KeyName)
 		if err != nil {
-			return nil, err
+			return pipelineSharedKeys{}, err
 		}
 		if !found {
 			continue
 		}
 		if key.Mode == db.KeychainModeProxied && !key.ProxyConfigured() {
-			return nil, fmt.Errorf("key %s uses proxied mode but is not configured; run %s", key.Name, keyConfigureCommand(key.Name))
+			return pipelineSharedKeys{}, fmt.Errorf("key %s uses proxied mode but is not configured; run %s", key.Name, keyConfigureCommand(key.Name))
 		}
 		if key.Mode == db.KeychainModeInjected || key.Mode == db.KeychainModeProxied {
-			candidates[key.Name] = key
+			candidates.pipeline[key.Name] = key
+		}
+	}
+	seenAgents := make(map[string]struct{})
+	for _, stage := range spec.Stages {
+		seat := strings.TrimSpace(stage.Agent)
+		if seat == "" || len(stage.EnvKeys) == 0 {
+			continue
+		}
+		if _, seen := seenAgents[seat]; seen {
+			continue
+		}
+		seenAgents[seat] = struct{}{}
+		grants, err := store.ListKeychainGrantsForConsumer(ctx, db.KeychainConsumerAgent, seat)
+		if err != nil {
+			return pipelineSharedKeys{}, err
+		}
+		for _, grant := range grants {
+			if !pipelineAgentSelectorUsed(spec, seat, grant.KeyName) {
+				continue
+			}
+			key, found, err := store.GetGrantedKey(ctx, db.KeychainConsumerAgent, seat, grant.KeyName)
+			if err != nil {
+				return pipelineSharedKeys{}, err
+			}
+			if !found || key.Mode != db.KeychainModeProxied {
+				continue
+			}
+			if !key.ProxyConfigured() {
+				return pipelineSharedKeys{}, fmt.Errorf("key %s uses proxied mode but is not configured; run %s", key.Name, keyConfigureCommand(key.Name))
+			}
+			if candidates.agents[seat] == nil {
+				candidates.agents[seat] = make(map[string]db.KeychainKey)
+			}
+			candidates.agents[seat][key.Name] = key
 		}
 	}
 	return candidates, nil
 }
 
-func pipelineSelectorUsed(spec pipeline.Spec, name string) bool {
+func pipelineShellSelectorUsed(spec pipeline.Spec, name string) bool {
 	for _, stage := range spec.Stages {
-		for _, selector := range stage.EnvKeys {
-			if selector == name {
+		if stage.Kind() != pipeline.StageKindShell {
+			continue
+		}
+		if pipelineStageSelectorUsed(stage, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func pipelineAgentSelectorUsed(spec pipeline.Spec, seat, name string) bool {
+	for _, stage := range spec.Stages {
+		if strings.TrimSpace(stage.Agent) != seat {
+			continue
+		}
+		if pipelineStageSelectorUsed(stage, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func pipelineStageSelectorUsed(stage pipeline.Stage, name string) bool {
+	for _, selector := range stage.EnvKeys {
+		if selector == name {
+			return true
+		}
+		if strings.ContainsAny(selector, "*?[") {
+			matched, _ := path.Match(selector, name)
+			if matched {
 				return true
-			}
-			if strings.ContainsAny(selector, "*?[") {
-				matched, _ := path.Match(selector, name)
-				if matched {
-					return true
-				}
 			}
 		}
 	}
 	return false
+}
+
+func (k pipelineSharedKeys) any() bool {
+	if len(k.pipeline) > 0 {
+		return true
+	}
+	for _, keys := range k.agents {
+		if len(keys) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (k pipelineSharedKeys) available(names map[string]struct{}) pipelineSharedKeys {
+	out := pipelineSharedKeys{pipeline: make(map[string]db.KeychainKey), agents: make(map[string]map[string]db.KeychainKey)}
+	for name, key := range k.pipeline {
+		if _, present := names[name]; present {
+			out.pipeline[name] = key
+		}
+	}
+	for seat, keys := range k.agents {
+		for name, key := range keys {
+			if _, present := names[name]; !present {
+				continue
+			}
+			if out.agents[seat] == nil {
+				out.agents[seat] = make(map[string]db.KeychainKey)
+			}
+			out.agents[seat][name] = key
+		}
+	}
+	return out
 }
 
 func pipelineEnvironmentResolutionError(spec pipeline.Spec, unresolved []pipelineEnvUnresolved) error {
@@ -190,6 +290,11 @@ func pipelineEnvironmentResolutionError(spec pipeline.Spec, unresolved []pipelin
 	name := item.Selector
 	if strings.ContainsAny(name, "*?[") {
 		name = "<name>"
+	}
+	for _, stage := range spec.Stages {
+		if stage.ID == item.Stage && strings.TrimSpace(stage.Agent) != "" {
+			return fmt.Errorf("stage %q env_keys entry %q is unresolved; register a configured proxied key and run gitmoot key grant %s --agent %s", item.Stage, item.Selector, name, stage.Agent)
+		}
 	}
 	return fmt.Errorf("stage %q env_keys entry %q is unresolved; register a matching key and run gitmoot key grant %s --pipeline %s", item.Stage, item.Selector, name, spec.Name)
 }
@@ -464,6 +569,8 @@ type pipelineEnvDeliveryAdapter struct {
 	store        *db.Store
 	home         string
 	pipelineName string
+	consumerKind string
+	consumerID   string
 	access       []workflow.PipelineKeyAccess
 	file         string
 	keys         []string
@@ -474,8 +581,13 @@ func wrapPipelineEnvDeliveryAdapter(store *db.Store, home string, payload workfl
 	if inner == nil || (len(payload.PipelineKeyAccess) == 0 && len(payload.PipelineEnvKeys) == 0) {
 		return inner
 	}
+	consumerKind, consumerID := db.KeychainConsumerPipeline, payload.PipelineName
+	if seat := strings.TrimSpace(payload.PipelineKeyAgent); seat != "" {
+		consumerKind, consumerID = db.KeychainConsumerAgent, seat
+	}
 	return pipelineEnvDeliveryAdapter{
 		inner: inner, store: store, home: home, pipelineName: payload.PipelineName,
+		consumerKind: consumerKind, consumerID: strings.TrimSpace(consumerID),
 		access: append([]workflow.PipelineKeyAccess(nil), payload.PipelineKeyAccess...),
 		file:   payload.PipelineEnvFile, keys: append([]string(nil), payload.PipelineEnvKeys...), env: payload.PipelineEnv,
 	}
@@ -502,7 +614,7 @@ func (a pipelineEnvDeliveryAdapter) Deliver(ctx context.Context, agent runtime.A
 			if strings.TrimSpace(job.ID) == "" {
 				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: proxied key %q requires a job id", access.Name)
 			}
-			key, granted, err := a.store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, a.pipelineName, access.Name)
+			key, granted, err := a.store.GetGrantedKey(ctx, a.consumerKind, a.consumerID, access.Name)
 			if err != nil {
 				return runtime.Result{}, fmt.Errorf("load pipeline stage environment: re-check proxied grant for key %q: %w", access.Name, err)
 			}
@@ -534,6 +646,9 @@ func (a pipelineEnvDeliveryAdapter) Deliver(ctx context.Context, agent runtime.A
 			entries = append(entries, access.Name+"="+lease.Placeholder())
 			entries = append(entries, "GITMOOT_PROXY_"+access.Name+"_URL="+lease.URL())
 			continue
+		}
+		if a.consumerKind == db.KeychainConsumerAgent {
+			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: agent key %q must use proxied mode", access.Name)
 		}
 		if access.Mode != db.KeychainModeInjected {
 			return runtime.Result{}, fmt.Errorf("load pipeline stage environment: key %q has unsupported mode %q", access.Name, access.Mode)
@@ -578,13 +693,17 @@ func (a pipelineEnvDeliveryAdapter) Deliver(ctx context.Context, agent runtime.A
 		}
 		entries = append(entries, access.Name+"="+value)
 	}
-	job.ShellEnv = prependPipelineEnvironment(entries, job.ShellEnv)
+	if a.consumerKind == db.KeychainConsumerAgent {
+		job.AgentEnv = prependPipelineEnvironment(entries, job.AgentEnv)
+	} else {
+		job.ShellEnv = prependPipelineEnvironment(entries, job.ShellEnv)
+	}
 	return a.inner.Deliver(ctx, agent, job)
 }
 
 func (a pipelineEnvDeliveryAdapter) proxyResolver(name string) credgw.CredentialResolver {
 	return func(ctx context.Context) (credgw.ResolvedCredential, error) {
-		key, granted, err := a.store.GetGrantedKey(ctx, db.KeychainConsumerPipeline, a.pipelineName, name)
+		key, granted, err := a.store.GetGrantedKey(ctx, a.consumerKind, a.consumerID, name)
 		if err != nil {
 			return credgw.ResolvedCredential{}, err
 		}

--- a/internal/cli/pipeline_env_test.go
+++ b/internal/cli/pipeline_env_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	dashboard "github.com/gitmoot/gitmoot-dashboard"
 
 	"github.com/gitmoot/gitmoot/internal/credgw"
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -102,11 +105,12 @@ func TestPipelineAddEnvFileValidation(t *testing.T) {
 			enable: true,
 		},
 		{
-			name: "agent stage denied",
+			name: "agent env file key unresolved",
 			setup: func(t *testing.T, _ string) (string, string, string) {
 				return writePipelineEnvFile(t, t.TempDir(), "TOKEN="+pipelineEnvSecretA+"\n", 0o600), "", "{id: run, agent: scout, action: ask, prompt: inspect, env_keys: [TOKEN]}"
 			},
-			want: "agent and gate stages receive no injected environment",
+			want:   "gitmoot key grant TOKEN --agent scout",
+			enable: true,
 		},
 	}
 
@@ -214,11 +218,15 @@ func TestClassifyPipelineEnvFileStatuses(t *testing.T) {
 }
 
 type pipelineEnvCaptureAdapter struct {
-	jobs []runtime.Job
+	jobs    []runtime.Job
+	deliver func(runtime.Job) (runtime.Result, error)
 }
 
 func (a *pipelineEnvCaptureAdapter) Deliver(_ context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
 	a.jobs = append(a.jobs, job)
+	if a.deliver != nil {
+		return a.deliver(job)
+	}
 	return runtime.Result{Raw: `{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}, nil
 }
 
@@ -360,6 +368,83 @@ func TestPipelineKeyAccessResolutionPrecedenceAndGrantBoundary(t *testing.T) {
 	}
 	if len(capture.jobs) != 0 {
 		t.Fatalf("disappeared own source reached delivery: %#v", capture.jobs)
+	}
+}
+
+func TestPipelineAgentKeyResolutionRequiresSeatGrantAndProxiedMode(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	writeDefaultKeychain(t, home, strings.Join([]string{
+		"AGENT_PROXY=agent-proxy-value",
+		"PIPELINE_ONLY=pipeline-proxy-value",
+		"AGENT_INJECTED=injected-value",
+		"OWN_ONLY=own-value",
+	}, "\n")+"\n")
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: "agent-sources", SpecYAML: "name: agent-sources\nstages: [{id: shell, cmd: echo}]\n"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: "scout", Runtime: "codex"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []struct {
+		name string
+		mode string
+	}{
+		{name: "AGENT_PROXY", mode: db.KeychainModeProxied},
+		{name: "PIPELINE_ONLY", mode: db.KeychainModeProxied},
+		{name: "AGENT_INJECTED", mode: db.KeychainModeInjected},
+	} {
+		if _, err := store.AddKeychainKey(ctx, key.name, key.mode); err != nil {
+			t.Fatal(err)
+		}
+		if key.mode == db.KeychainModeProxied {
+			if _, err := store.ConfigureKeychainProxy(ctx, key.name, "https://api.example.test/v1", db.KeychainProxyAuthBearer, ""); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if _, err := store.GrantKeychainKey(ctx, db.KeychainConsumerAgent, "scout", "AGENT_PROXY"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantKeychainKey(ctx, db.KeychainConsumerPipeline, "agent-sources", "PIPELINE_ONLY"); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(ctx, `INSERT INTO keychain_grants(consumer_kind, consumer_id, key_name) VALUES (?, ?, ?)`, db.KeychainConsumerAgent, "scout", "AGENT_INJECTED"); err != nil {
+		t.Fatal(err)
+	}
+	envFile := writePipelineEnvFile(t, t.TempDir(), "OWN_ONLY=own-value\n", 0o600)
+	spec := pipeline.Spec{
+		Name: "agent-sources", EnvFile: envFile, Env: map[string]string{"DEFAULT_ONLY": "default"},
+		Stages: []pipeline.Stage{
+			{ID: "agent", Agent: "scout", Action: "ask", Prompt: "inspect", EnvKeys: []string{"AGENT_PROXY", "PIPELINE_ONLY", "AGENT_INJECTED", "OWN_ONLY", "DEFAULT_ONLY"}},
+			{ID: "shell", Cmd: "echo", EnvKeys: []string{"PIPELINE_ONLY", "DEFAULT_ONLY"}},
+		},
+	}
+	resolution, err := resolvePipelineEnvironment(ctx, store, home, spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantAccess := []workflow.PipelineKeyAccess{
+		{Stage: "agent", Name: "AGENT_PROXY", Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied},
+		{Stage: "shell", Name: "PIPELINE_ONLY", Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied},
+		{Stage: "shell", Name: "DEFAULT_ONLY", Source: pipelineKeySourceDefault, Mode: db.KeychainModeInjected},
+	}
+	wantUnresolved := []pipelineEnvUnresolved{
+		{Stage: "agent", Selector: "PIPELINE_ONLY"},
+		{Stage: "agent", Selector: "AGENT_INJECTED"},
+		{Stage: "agent", Selector: "OWN_ONLY"},
+		{Stage: "agent", Selector: "DEFAULT_ONLY"},
+	}
+	if !reflect.DeepEqual(resolution.Access, wantAccess) || !reflect.DeepEqual(resolution.Unresolved, wantUnresolved) {
+		t.Fatalf("resolution access=%#v unresolved=%#v", resolution.Access, resolution.Unresolved)
+	}
+	if err := pipelineEnvironmentResolutionError(spec, []pipelineEnvUnresolved{{Stage: "agent", Selector: "MISSING"}}); err == nil || !strings.Contains(err.Error(), "gitmoot key grant MISSING --agent scout") {
+		t.Fatalf("agent unresolved hint = %v", err)
 	}
 }
 
@@ -508,6 +593,192 @@ func TestPipelineProxiedKeyResolutionAndDeliveryLease(t *testing.T) {
 	}
 }
 
+func TestPipelineAgentProxiedKeyDeliveryE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	const (
+		keyName      = "AGENT_PROXY"
+		real         = "agent-real-value-874-pr2"
+		pipelineName = "agent-proxy-e2e"
+		seatName     = "scout"
+	)
+	keychainPath := writeDefaultKeychain(t, home, keyName+"="+real+"\n")
+	specYAML := "name: " + pipelineName + "\nrepo: owner/repo\nstages: [{id: inspect, agent: " + seatName + ", action: ask, prompt: inspect, env_keys: [" + keyName + "]}]\n"
+	if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{Name: pipelineName, Repo: "owner/repo", SpecYAML: specYAML}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{Name: seatName, Runtime: runtime.CodexRuntime}); err != nil {
+		t.Fatal(err)
+	}
+	upstreamCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls++
+		if got := r.Header.Get("Authorization"); got != "Bearer "+real {
+			t.Errorf("upstream Authorization = %q, want real credential", got)
+		}
+		if strings.Contains(r.Header.Get("Authorization"), "gitmoot-kc-") {
+			t.Errorf("upstream received placeholder: %q", r.Header.Get("Authorization"))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+	if _, err := store.AddKeychainKey(ctx, keyName, db.KeychainModeProxied); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ConfigureKeychainProxy(ctx, keyName, upstream.URL+"/v1", db.KeychainProxyAuthBearer, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.GrantKeychainKey(ctx, db.KeychainConsumerAgent, seatName, keyName); err != nil {
+		t.Fatal(err)
+	}
+	spec := pipeline.Spec{Name: pipelineName, Repo: "owner/repo", Stages: []pipeline.Stage{{ID: "inspect", Agent: seatName, Action: "ask", Prompt: "inspect", EnvKeys: []string{keyName}}}}
+	access, err := resolvePipelineStageEnvAccess(ctx, store, home, spec, spec.Stages[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantAccess := []workflow.PipelineKeyAccess{{Stage: "inspect", Name: keyName, Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied}}
+	if !reflect.DeepEqual(access.Access, wantAccess) {
+		t.Fatalf("agent access = %#v, want %#v", access.Access, wantAccess)
+	}
+	rec, found, err := store.GetPipeline(ctx, pipelineName)
+	if err != nil || !found {
+		t.Fatalf("GetPipeline: found=%t err=%v", found, err)
+	}
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	run, err := createPipelineRun(ctx, store, rec, spec, "manual", "{}", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := advancePipelineRun(ctx, store, testStageEnqueuer(store), rec, spec, run, now); err != nil {
+		t.Fatal(err)
+	}
+	stageRow, ok, err := store.GetPipelineRunStage(ctx, run.ID, "inspect")
+	if err != nil || !ok || stageRow.JobID == "" {
+		t.Fatalf("agent stage row: ok=%t row=%+v err=%v", ok, stageRow, err)
+	}
+	queued, err := store.GetJob(ctx, stageRow.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queuedPayload, err := workflow.ParseJobPayload(queued.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if queuedPayload.PipelineName != pipelineName || queuedPayload.PipelineKeyAgent != seatName || !reflect.DeepEqual(queuedPayload.PipelineKeyAccess, wantAccess) {
+		t.Fatalf("queued names-only authority = %+v", queuedPayload)
+	}
+	events, err := store.ListJobEvents(ctx, queued.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if strings.Contains(event.Message, real) {
+			t.Fatalf("real credential persisted in event %q", event.Kind)
+		}
+	}
+	detail, err := (&webDataSource{home: home}).PipelineDetail(ctx, pipelineName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Keys.Stages) != 1 || !reflect.DeepEqual(detail.Keys.Stages[0].Keys, []dashboard.PipelineKeyEntry{{Name: keyName, Source: pipelineKeySourceShared, Mode: db.KeychainModeProxied}}) {
+		t.Fatalf("agent Keys projection = %+v", detail.Keys)
+	}
+	detailJSON, err := json.Marshal(detail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(detailJSON), real) {
+		t.Fatalf("dashboard projection contains real credential: %s", detailJSON)
+	}
+	payload := workflow.JobPayload{PipelineName: pipelineName, PipelineKeyAgent: seatName, PipelineKeyAccess: access.Access}
+	persisted, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(persisted), real) || strings.Contains(string(persisted), "gitmoot-kc-") {
+		t.Fatalf("persisted payload contains credential material: %s", persisted)
+	}
+
+	previousRegistry := modelGatewayRegistry
+	previousLogf := modelGatewayLogf
+	previousLoopback := pipelineProxyAllowLoopbackHTTP
+	modelGatewayRegistry = credgw.NewRegistry()
+	modelGatewayLogf = func(string, ...any) {}
+	pipelineProxyAllowLoopbackHTTP = true
+	paths, err := configPathsForPipelineStore(store, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = modelGatewayRegistry.CloseHome(context.Background(), paths.Home)
+		modelGatewayRegistry = previousRegistry
+		modelGatewayLogf = previousLogf
+		pipelineProxyAllowLoopbackHTTP = previousLoopback
+	})
+	capture := &pipelineEnvCaptureAdapter{deliver: func(job runtime.Job) (runtime.Result, error) {
+		if len(job.ShellEnv) != 0 {
+			t.Fatalf("agent delivery populated ShellEnv: %#v", job.ShellEnv)
+		}
+		placeholder := envEntryValue(job.AgentEnv, keyName)
+		leaseURL := envEntryValue(job.AgentEnv, "GITMOOT_PROXY_"+keyName+"_URL")
+		if !strings.HasPrefix(placeholder, "gitmoot-kc-agent-proxy-job-") || !strings.HasPrefix(leaseURL, "http://127.0.0.1:") {
+			t.Fatalf("agent env = %#v", job.AgentEnv)
+		}
+		if strings.Contains(strings.Join(job.AgentEnv, "\n"), real) {
+			t.Fatalf("real credential reached AgentEnv: %#v", job.AgentEnv)
+		}
+		req, err := http.NewRequest(http.MethodGet, leaseURL+"/models", nil)
+		if err != nil {
+			return runtime.Result{}, err
+		}
+		req.Header.Set("Authorization", "Bearer "+placeholder)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return runtime.Result{}, err
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			return runtime.Result{}, fmt.Errorf("proxy status %d", resp.StatusCode)
+		}
+		return runtime.Result{Raw: "ok"}, nil
+	}}
+	wrapper := wrapPipelineEnvDeliveryAdapter(store, home, payload, capture)
+	result, err := wrapper.Deliver(ctx, runtime.Agent{}, runtime.Job{ID: "agent-proxy-job"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(result.Raw, real) {
+		t.Fatalf("delivery result contains real credential: %q", result.Raw)
+	}
+	if upstreamCalls != 1 {
+		t.Fatalf("upstream calls = %d, want 1", upstreamCalls)
+	}
+
+	if _, err := store.RevokeKeychainKey(ctx, db.KeychainConsumerAgent, seatName, keyName); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapper.Deliver(ctx, runtime.Agent{}, runtime.Job{ID: "agent-proxy-revoked"}); err == nil || !strings.Contains(err.Error(), "revoked") {
+		t.Fatalf("revoked agent grant delivery error = %v", err)
+	}
+	if len(capture.jobs) != 1 || upstreamCalls != 1 {
+		t.Fatalf("revoked delivery reached child/upstream: jobs=%d upstream=%d", len(capture.jobs), upstreamCalls)
+	}
+
+	for _, file := range []string{store.DatabasePath(), store.DatabasePath() + "-wal"} {
+		body, readErr := os.ReadFile(file)
+		if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+			t.Fatal(readErr)
+		}
+		if bytes.Contains(body, []byte(real)) {
+			t.Fatalf("real credential persisted in %s", file)
+		}
+	}
+	keychainBody, err := os.ReadFile(keychainPath)
+	if err != nil || !bytes.Contains(keychainBody, []byte(real)) {
+		t.Fatalf("operator keychain unexpectedly changed: err=%v body=%q", err, keychainBody)
+	}
+}
+
 func TestPipelineUnconfiguredProxiedKeyFailsAtEnqueue(t *testing.T) {
 	ctx := context.Background()
 	home, _, store := heartbeatLoopE2EHome(t)
@@ -575,6 +846,29 @@ func TestPipelineEnvironmentValidationTiming(t *testing.T) {
 		return err
 	}); err != nil {
 		t.Fatal(err)
+	}
+
+	agentHome := t.TempDir()
+	if err := withStore(agentHome, func(store *db.Store) error {
+		return store.UpsertAgent(context.Background(), db.Agent{Name: "scout", Runtime: runtime.CodexRuntime})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	agentSpec := writeSpec(t, "name: unresolved-agent-env\nrepo: owner/repo\nstages: [{id: inspect, agent: scout, action: ask, prompt: inspect, env_keys: [MISSING]}]\n")
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"pipeline", "add", agentSpec, "--home", agentHome}, &stdout, &stderr); code != 0 || !strings.Contains(stderr.String(), "warning:") || !strings.Contains(stderr.String(), "gitmoot key grant MISSING --agent scout") {
+		t.Fatalf("disabled agent add code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	for _, args := range [][]string{
+		{"pipeline", "enable", "unresolved-agent-env", "--home", agentHome},
+		{"pipeline", "run", "unresolved-agent-env", "--home", agentHome},
+	} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run(args, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "gitmoot key grant MISSING --agent scout") {
+			t.Fatalf("%v code=%d stdout=%q stderr=%q", args, code, stdout.String(), stderr.String())
+		}
 	}
 }
 
@@ -673,6 +967,7 @@ func TestPipelineInjectedEnvShellE2E(t *testing.T) {
 				t.Fatalf("stage %s event %q persisted a secret value", stageID, event.Kind)
 			}
 		}
+
 	}
 	for _, path := range []string{paths.Database, paths.Database + "-wal"} {
 		data, err := os.ReadFile(path)

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -1132,7 +1132,7 @@ func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enque
 		}
 		skipNativeReviewFanout := stage.Kind() == pipeline.StageKindAgentImplement && pipelineImplementHasSourceBoundReview(spec, stage.ID)
 		request := pipelineStageJobRequest(rec, stage, run, row.Attempt, upstreamContext, binding, skipNativeReviewFanout)
-		if stage.Kind() == pipeline.StageKindShell {
+		if len(stage.EnvKeys) > 0 {
 			access, envErr := resolvePipelineStageEnvAccess(ctx, store, "", spec, stage)
 			if envErr != nil {
 				return run, envErr
@@ -1140,9 +1140,13 @@ func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enque
 			if len(access.Access) > 0 {
 				request.PipelineName = rec.Name
 				request.PipelineKeyAccess = access.Access
-				request.PipelineEnvFile = access.File
-				request.PipelineEnvKeys = access.Keys
-				request.PipelineEnv = access.Defaults
+				if stage.Kind() == pipeline.StageKindShell {
+					request.PipelineEnvFile = access.File
+					request.PipelineEnvKeys = access.Keys
+					request.PipelineEnv = access.Defaults
+				} else {
+					request.PipelineKeyAgent = stage.Agent
+				}
 			}
 		}
 		job, err := enqueuePipelineStageJob(ctx, store, enqueue, request, pipelineStageSourceBoundReviewRequest(request))

--- a/internal/credgw/runner_test.go
+++ b/internal/credgw/runner_test.go
@@ -96,3 +96,31 @@ func TestRunnerWithoutChildConfigDirLeavesItUntouched(t *testing.T) {
 		t.Fatalf("CLAUDE_CONFIG_DIR = %q, want the caller's value preserved", dir)
 	}
 }
+
+func TestRunnerGatewayAuthOverridesAgentEnv(t *testing.T) {
+	gateway := newTestGateway(t)
+	capture := &envCapture{}
+	runner := &Runner{
+		Inner:      capture,
+		Gateway:    gateway,
+		Credential: Credential{Kind: CredentialBearer, Value: "real-token"},
+		Policy:     Policy{Upstream: DefaultAnthropicUpstream, AllowedHosts: []string{"api.anthropic.com"}},
+	}
+	if _, err := runner.RunEnv(context.Background(), "", []string{
+		"CLAUDE_CODE_OAUTH_TOKEN=stage-supplied-value",
+		"ANTHROPIC_BASE_URL=https://stage.invalid",
+	}, "claude", "-p", "hi"); err != nil {
+		t.Fatal(err)
+	}
+	token, _ := envValue(capture.env, "CLAUDE_CODE_OAUTH_TOKEN")
+	if !strings.HasPrefix(token, "gitmoot-kc-") || token == "stage-supplied-value" {
+		t.Fatalf("effective Claude token = %q, want model-gateway placeholder", token)
+	}
+	base, _ := envValue(capture.env, "ANTHROPIC_BASE_URL")
+	if !strings.HasPrefix(base, "http://127.0.0.1:") {
+		t.Fatalf("effective Anthropic base URL = %q, want model gateway", base)
+	}
+	if got := strings.Join(capture.env, "\n"); !strings.Contains(got, "CLAUDE_CODE_OAUTH_TOKEN=stage-supplied-value") {
+		t.Fatalf("incoming AgentEnv entry was not composed beneath gateway env: %q", got)
+	}
+}

--- a/internal/db/keychain.go
+++ b/internal/db/keychain.go
@@ -16,12 +16,14 @@ const (
 	KeychainProxyAuthHeader = "header"
 
 	KeychainConsumerPipeline = "pipeline"
+	KeychainConsumerAgent    = "agent"
 )
 
 var (
 	ErrKeychainKeyNotFound       = errors.New("keychain key not found")
 	ErrKeychainConsumerNotFound  = errors.New("keychain consumer not found")
 	ErrKeychainProxyUnconfigured = errors.New("proxied key is not configured")
+	ErrKeychainAgentInjected     = errors.New("agent grants require proxied mode")
 	ErrKeychainKeyHasGrants      = errors.New("keychain key still has grants")
 )
 
@@ -46,8 +48,8 @@ func (k KeychainKey) ProxyConfigured() bool {
 	return k.ProxyAuthKind == KeychainProxyAuthHeader && strings.TrimSpace(k.ProxyHeader) != ""
 }
 
-// KeychainGrant authorizes one named consumer to use one registered key.
-// Pipeline is the only accepted consumer kind in this phase.
+// KeychainGrant authorizes one named pipeline or registered agent seat to use
+// one registered key. Agent grants are proxied-only.
 type KeychainGrant struct {
 	ConsumerKind string `json:"consumer_kind"`
 	ConsumerID   string `json:"consumer_id"`
@@ -57,6 +59,10 @@ type KeychainGrant struct {
 
 func validKeychainMode(mode string) bool {
 	return mode == KeychainModeInjected || mode == KeychainModeProxied
+}
+
+func validKeychainConsumer(kind string) bool {
+	return kind == KeychainConsumerPipeline || kind == KeychainConsumerAgent
 }
 
 func (s *Store) AddKeychainKey(ctx context.Context, name, mode string) (KeychainKey, error) {
@@ -197,8 +203,8 @@ func (s *Store) ListKeychainGrants(ctx context.Context, keyName string) ([]Keych
 func (s *Store) ListKeychainGrantsForConsumer(ctx context.Context, kind, id string) ([]KeychainGrant, error) {
 	kind = strings.TrimSpace(kind)
 	id = strings.TrimSpace(id)
-	if kind != KeychainConsumerPipeline || id == "" {
-		return nil, errors.New("keychain consumer must be a named pipeline")
+	if !validKeychainConsumer(kind) || id == "" {
+		return nil, errors.New("keychain consumer must be a named pipeline or registered agent")
 	}
 	rows, err := s.db.QueryContext(ctx, `SELECT consumer_kind, consumer_id, key_name, created_at
 		FROM keychain_grants WHERE consumer_kind = ? AND consumer_id = ? ORDER BY key_name`, kind, id)
@@ -224,8 +230,8 @@ func (s *Store) GetGrantedKey(ctx context.Context, kind, id, name string) (Keych
 	kind = strings.TrimSpace(kind)
 	id = strings.TrimSpace(id)
 	name = strings.TrimSpace(name)
-	if kind != KeychainConsumerPipeline || id == "" || name == "" {
-		return KeychainKey{}, false, errors.New("keychain grant requires pipeline and key names")
+	if !validKeychainConsumer(kind) || id == "" || name == "" {
+		return KeychainKey{}, false, errors.New("keychain grant requires a pipeline or agent consumer and key name")
 	}
 	var key KeychainKey
 	err := s.db.QueryRowContext(ctx, `SELECT k.name, k.mode,
@@ -244,20 +250,16 @@ func (s *Store) GrantKeychainKey(ctx context.Context, kind, id, name string) (bo
 	kind = strings.TrimSpace(kind)
 	id = strings.TrimSpace(id)
 	name = strings.TrimSpace(name)
-	if kind != KeychainConsumerPipeline || id == "" || name == "" {
-		return false, errors.New("keychain grant requires a named pipeline and key")
+	if !validKeychainConsumer(kind) || id == "" || name == "" {
+		return false, errors.New("keychain grant requires a named pipeline or registered agent and key")
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return false, err
 	}
 	defer tx.Rollback()
-	var exists int
-	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM pipelines WHERE name = ?`, id).Scan(&exists); err != nil {
+	if err := requireKeychainConsumerTx(ctx, tx, kind, id); err != nil {
 		return false, err
-	}
-	if exists == 0 {
-		return false, ErrKeychainConsumerNotFound
 	}
 	var key KeychainKey
 	if err := tx.QueryRowContext(ctx, `SELECT name, mode,
@@ -267,6 +269,9 @@ func (s *Store) GrantKeychainKey(ctx context.Context, kind, id, name string) (bo
 		return false, ErrKeychainKeyNotFound
 	} else if err != nil {
 		return false, err
+	}
+	if kind == KeychainConsumerAgent && key.Mode != KeychainModeProxied {
+		return false, ErrKeychainAgentInjected
 	}
 	if key.Mode == KeychainModeProxied && !key.ProxyConfigured() {
 		return false, ErrKeychainProxyUnconfigured
@@ -289,8 +294,13 @@ func (s *Store) RevokeKeychainKey(ctx context.Context, kind, id, name string) (b
 	kind = strings.TrimSpace(kind)
 	id = strings.TrimSpace(id)
 	name = strings.TrimSpace(name)
-	if kind != KeychainConsumerPipeline || id == "" || name == "" {
-		return false, errors.New("keychain revoke requires a named pipeline and key")
+	if !validKeychainConsumer(kind) || id == "" || name == "" {
+		return false, errors.New("keychain revoke requires a named pipeline or registered agent and key")
+	}
+	if kind == KeychainConsumerAgent {
+		if err := requireKeychainConsumer(ctx, s.db, kind, id); err != nil {
+			return false, err
+		}
 	}
 	result, err := s.db.ExecContext(ctx, `DELETE FROM keychain_grants WHERE consumer_kind = ? AND consumer_id = ? AND key_name = ?`, kind, id, name)
 	if err != nil {
@@ -298,6 +308,25 @@ func (s *Store) RevokeKeychainKey(ctx context.Context, kind, id, name string) (b
 	}
 	affected, err := result.RowsAffected()
 	return affected == 1, err
+}
+
+func requireKeychainConsumerTx(ctx context.Context, tx *sql.Tx, kind, id string) error {
+	return requireKeychainConsumer(ctx, tx, kind, id)
+}
+
+func requireKeychainConsumer(ctx context.Context, q rowQuerier, kind, id string) error {
+	table := "pipelines"
+	if kind == KeychainConsumerAgent {
+		table = "agents"
+	}
+	var exists int
+	if err := q.QueryRowContext(ctx, `SELECT COUNT(*) FROM `+table+` WHERE name = ?`, id).Scan(&exists); err != nil {
+		return err
+	}
+	if exists == 0 {
+		return ErrKeychainConsumerNotFound
+	}
+	return nil
 }
 
 // RemoveKeychainKey removes metadata only. The operator-owned keychain file is

--- a/internal/db/keychain_test.go
+++ b/internal/db/keychain_test.go
@@ -155,3 +155,66 @@ func TestDeletePipelineCleansKeychainGrantsInSameTransaction(t *testing.T) {
 		t.Fatalf("key metadata removed with pipeline: found=%v err=%v", found, err)
 	}
 }
+
+func TestAgentKeychainGrantsAreProxiedOnlyAndDeletionCleansBothPaths(t *testing.T) {
+	store := openPipelineStore(t)
+	ctx := context.Background()
+	for _, name := range []string{"remove-seat", "checked-seat"} {
+		if err := store.UpsertAgent(ctx, Agent{Name: name, Runtime: "codex"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.AddKeychainKey(ctx, "INJECTED", KeychainModeInjected); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.AddKeychainKey(ctx, "PROXY", KeychainModeProxied); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerAgent, "remove-seat", "INJECTED"); changed || !errors.Is(err, ErrKeychainAgentInjected) {
+		t.Fatalf("injected agent grant = changed %v err %v", changed, err)
+	}
+	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerAgent, "remove-seat", "PROXY"); changed || !errors.Is(err, ErrKeychainProxyUnconfigured) {
+		t.Fatalf("unconfigured agent grant = changed %v err %v", changed, err)
+	}
+	if _, err := store.ConfigureKeychainProxy(ctx, "PROXY", "https://api.example.test/v1", KeychainProxyAuthBearer, ""); err != nil {
+		t.Fatal(err)
+	}
+	for _, seat := range []string{"remove-seat", "checked-seat"} {
+		if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerAgent, seat, "PROXY"); err != nil || !changed {
+			t.Fatalf("grant %s = changed %v err %v", seat, changed, err)
+		}
+		if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerAgent, seat, "PROXY"); err != nil || changed {
+			t.Fatalf("duplicate grant %s = changed %v err %v", seat, changed, err)
+		}
+		if key, found, err := store.GetGrantedKey(ctx, KeychainConsumerAgent, seat, "PROXY"); err != nil || !found || !key.ProxyConfigured() {
+			t.Fatalf("GetGrantedKey %s = %+v found=%v err=%v", seat, key, found, err)
+		}
+	}
+	if grants, err := store.ListKeychainGrantsForConsumer(ctx, KeychainConsumerAgent, "remove-seat"); err != nil || len(grants) != 1 || grants[0].ConsumerKind != KeychainConsumerAgent {
+		t.Fatalf("agent grants = %+v err=%v", grants, err)
+	}
+	if changed, err := store.RevokeKeychainKey(ctx, KeychainConsumerAgent, "remove-seat", "PROXY"); err != nil || !changed {
+		t.Fatalf("agent revoke = changed %v err %v", changed, err)
+	}
+	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerAgent, "remove-seat", "PROXY"); err != nil || !changed {
+		t.Fatalf("agent regrant = changed %v err %v", changed, err)
+	}
+	if removed, err := store.RemoveAgent(ctx, "remove-seat"); err != nil || !removed {
+		t.Fatalf("RemoveAgent = removed %v err %v", removed, err)
+	}
+	if grants, err := store.ListKeychainGrants(ctx, "PROXY"); err != nil || len(grants) != 1 || grants[0].ConsumerID != "checked-seat" {
+		t.Fatalf("grants after RemoveAgent = %+v err=%v", grants, err)
+	}
+	if err := store.DeleteAgentChecked(ctx, "checked-seat"); err != nil {
+		t.Fatalf("DeleteAgentChecked: %v", err)
+	}
+	if grants, err := store.ListKeychainGrants(ctx, "PROXY"); err != nil || len(grants) != 0 {
+		t.Fatalf("grants after DeleteAgentChecked = %+v err=%v", grants, err)
+	}
+	if changed, err := store.GrantKeychainKey(ctx, KeychainConsumerAgent, "missing-seat", "PROXY"); changed || !errors.Is(err, ErrKeychainConsumerNotFound) {
+		t.Fatalf("missing agent grant = changed %v err %v", changed, err)
+	}
+	if changed, err := store.RevokeKeychainKey(ctx, KeychainConsumerAgent, "missing-seat", "PROXY"); changed || !errors.Is(err, ErrKeychainConsumerNotFound) {
+		t.Fatalf("missing agent revoke = changed %v err %v", changed, err)
+	}
+}

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -1095,6 +1095,9 @@ func (s *Store) RemoveAgent(ctx context.Context, name string) (bool, error) {
 	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_repos WHERE agent_name = ?`, name); err != nil {
 		return false, err
 	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM keychain_grants WHERE consumer_kind = 'agent' AND consumer_id = ?`, name); err != nil {
+		return false, err
+	}
 	result, err := tx.ExecContext(ctx, `DELETE FROM agents WHERE name = ?`, name)
 	if err != nil {
 		return false, err
@@ -1163,6 +1166,9 @@ func (s *Store) DeleteAgentChecked(ctx context.Context, name string) error {
 		return fmt.Errorf("agent %s has %d queued or running job(s); cancel them first: %w", name, active, ErrAgentHasActiveJobs)
 	}
 	if _, err := tx.ExecContext(ctx, `DELETE FROM agent_repos WHERE agent_name = ?`, name); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM keychain_grants WHERE consumer_kind = 'agent' AND consumer_id = ?`, name); err != nil {
 		return err
 	}
 	// agent_instances are NOT deleted: their `type` column references a managed

--- a/internal/pipeline/env_test.go
+++ b/internal/pipeline/env_test.go
@@ -74,7 +74,7 @@ func TestPipelineEnvSpecValidation(t *testing.T) {
 		{name: "relative file", extra: "env_file: relative.env\n", stage: "{id: run, cmd: echo}", want: "must be absolute"},
 		{name: "reserved inline", extra: "env: {GITMOOT_PIPELINE_NAME: bad}\n", stage: "{id: run, cmd: echo}", want: "reserved GITMOOT_*"},
 		{name: "reserved selector", stage: "{id: run, cmd: echo, env_keys: [GITMOOT_*]}", want: "reserved GITMOOT_*"},
-		{name: "agent denied", stage: "{id: run, agent: scout, action: ask, prompt: inspect, env_keys: [TOKEN]}", want: "agent and gate stages receive no injected environment"},
+		{name: "valid agent selector", stage: "{id: run, agent: scout, action: ask, prompt: inspect, env_keys: [TOKEN]}"},
 		{name: "valid shell", extra: "env_file: /tmp/pipeline.env\nenv: {DATA_DIR: /tmp/data}\n", stage: "{id: run, cmd: echo, env_keys: [API_*, DATA_DIR]}"},
 	}
 	for _, tt := range tests {
@@ -90,9 +90,23 @@ func TestPipelineEnvSpecValidation(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			if tt.name == "valid agent selector" {
+				if spec.Stages[0].Agent != "scout" || !reflect.DeepEqual(spec.Stages[0].EnvKeys, []string{"TOKEN"}) {
+					t.Fatalf("parsed agent spec = %+v", spec)
+				}
+				return
+			}
 			if spec.EnvFile != "/tmp/pipeline.env" || spec.Env["DATA_DIR"] != "/tmp/data" || !reflect.DeepEqual(spec.Stages[0].EnvKeys, []string{"API_*", "DATA_DIR"}) {
 				t.Fatalf("parsed spec = %+v", spec)
 			}
 		})
+	}
+	gate := `name: gate-env
+stages:
+  - {id: impl, agent: builder, action: implement, prompt: build, write: true}
+  - {id: wait, gate: pr_merged, source: impl, needs: [impl], env_keys: [TOKEN]}
+`
+	if _, err := Load([]byte(gate)); err == nil || !strings.Contains(err.Error(), "gates do not run a process") {
+		t.Fatalf("gate env_keys error = %v", err)
 	}
 }

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -187,8 +187,9 @@ type Stage struct {
 	// Retry is how many times a failed stage may be re-attempted (>= 0).
 	Retry int `yaml:"retry,omitempty"`
 	// EnvKeys is the deny-by-default list of environment names (or glob selectors)
-	// made available to this shell stage from own, shared, or default sources.
-	// Agent and gate grants are deliberately deferred to a later keycard phase.
+	// requested by this stage. Shell stages resolve own/shared/default sources;
+	// agent stages resolve only configured proxied keys granted to their seat.
+	// Gates run no process and reject env_keys.
 	EnvKeys []string `yaml:"env_keys,omitempty"`
 	// SuccessDecisions optionally overrides the pipeline default for this stage.
 	SuccessDecisions []string `yaml:"success_decisions,omitempty"`

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -155,8 +155,8 @@ func (s Spec) Validate() error {
 		if err := validateStageExecutor(s.Name, stage); err != nil {
 			return err
 		}
-		if len(stage.EnvKeys) > 0 && stage.Kind() != StageKindShell {
-			return fmt.Errorf("pipeline %q stage %q sets env_keys but is not a shell stage; agent and gate stages receive no injected environment", s.Name, stage.ID)
+		if len(stage.EnvKeys) > 0 && stage.Kind() == StageKindGate {
+			return fmt.Errorf("pipeline %q stage %q sets env_keys but is a gate stage; gates do not run a process and cannot receive keys", s.Name, stage.ID)
 		}
 		for _, selector := range stage.EnvKeys {
 			if err := ValidateEnvSelector(selector); err != nil {

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -117,6 +117,10 @@ type Job struct {
 	// injected into shell-stage subprocesses. Other runtimes ignore it; ordinary
 	// shell jobs leave it empty.
 	ShellEnv []string
+	// AgentEnv is an in-memory-only list of proxied keycard placeholders and
+	// loopback lease URLs for a pipeline agent stage. It is never represented in
+	// workflow.JobPayload. Empty preserves the historical plain Runner path.
+	AgentEnv []string
 	// ShellUpstreamContext is persisted JSON content for a dependent pipeline
 	// shell stage. Shell delivery writes it to a fresh 0600 temporary file and
 	// injects only that path into the subprocess environment.
@@ -548,7 +552,7 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 			return Result{}, err
 		}
 	}
-	result, err := a.runCodex(ctx, agent, job.Prompt, model, effort)
+	result, err := a.runCodex(ctx, agent, job.Prompt, model, effort, job.AgentEnv)
 	// The session id in play: the pinned concrete thread on a resume, or the
 	// thread id codex printed for a fresh/`last` run (best-effort — the stream
 	// may not carry one when the run died early).
@@ -623,10 +627,10 @@ func codexDeliverArgs(agent Agent, dir, prompt, model string, effort string, jso
 // pre-#658 semantics; codexDeliverResult then fails open on the non-JSONL stdout
 // and contributes 0 usage. Only the JSON re-run is retried — a genuine delivery
 // failure surfaces unchanged.
-func (a CodexAdapter) runCodex(ctx context.Context, agent Agent, prompt, model string, effort string) (subprocess.Result, error) {
-	result, err := a.runner().Run(ctx, a.Dir, "codex", codexDeliverArgs(agent, a.Dir, prompt, model, effort, true)...)
+func (a CodexAdapter) runCodex(ctx context.Context, agent Agent, prompt, model string, effort string, env []string) (subprocess.Result, error) {
+	result, err := runAgentCommand(ctx, a.runner(), a.Dir, env, "codex", codexDeliverArgs(agent, a.Dir, prompt, model, effort, true)...)
 	if err != nil && isCodexJSONUnsupported(result) {
-		result, err = a.runner().Run(ctx, a.Dir, "codex", codexDeliverArgs(agent, a.Dir, prompt, model, effort, false)...)
+		result, err = runAgentCommand(ctx, a.runner(), a.Dir, env, "codex", codexDeliverArgs(agent, a.Dir, prompt, model, effort, false)...)
 	}
 	return result, err
 }
@@ -1006,7 +1010,7 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 					refreshedRef = newRef
 				}
 				diagSessionRef = newRef
-				result, err = a.runner().Run(ctx, a.Dir, "claude", claudeFreshSessionArgs(agent, job.Prompt, model, newRef)...)
+				result, err = runAgentCommand(ctx, a.runner(), a.Dir, job.AgentEnv, "claude", claudeFreshSessionArgs(agent, job.Prompt, model, newRef)...)
 				if err != nil {
 					if sessionMissing {
 						return Result{Raw: result.Stdout + result.Stderr, SessionDiag: newSessionDiag(result, err, diagSessionRef)}, a.claudeSessionMissingError(agent, result, err)
@@ -1047,7 +1051,7 @@ func (a ClaudeAdapter) deliverFresh(ctx context.Context, agent Agent, job Job, m
 		if err != nil {
 			return Result{}, err
 		}
-		result, err = a.runner().Run(ctx, a.Dir, "claude", claudeFreshSessionArgs(agent, job.Prompt, model, sessionID)...)
+		result, err = runAgentCommand(ctx, a.runner(), a.Dir, job.AgentEnv, "claude", claudeFreshSessionArgs(agent, job.Prompt, model, sessionID)...)
 		if attempt >= claudeDeliveryMaxAttempts || !isTransientClaudeDeliveryError(result, err) {
 			break
 		}
@@ -1077,11 +1081,22 @@ func (a ClaudeAdapter) deliverFresh(ctx context.Context, agent Agent, job Job, m
 // runClaude performs a single Claude delivery attempt, including the JSON
 // output-format fallback re-run for older CLIs that reject --output-format.
 func (a ClaudeAdapter) runClaude(ctx context.Context, agent Agent, job Job, model string) (subprocess.Result, error) {
-	result, err := a.runner().Run(ctx, a.Dir, "claude", claudeArgs(agent, job.Prompt, true, model)...)
+	result, err := runAgentCommand(ctx, a.runner(), a.Dir, job.AgentEnv, "claude", claudeArgs(agent, job.Prompt, true, model)...)
 	if err != nil && isClaudeJSONUnsupported(result) {
-		result, err = a.runner().Run(ctx, a.Dir, "claude", claudeArgs(agent, job.Prompt, false, model)...)
+		result, err = runAgentCommand(ctx, a.runner(), a.Dir, job.AgentEnv, "claude", claudeArgs(agent, job.Prompt, false, model)...)
 	}
 	return result, err
+}
+
+func runAgentCommand(ctx context.Context, runner subprocess.Runner, dir string, env []string, command string, args ...string) (subprocess.Result, error) {
+	if len(env) == 0 {
+		return runner.Run(ctx, dir, command, args...)
+	}
+	envRunner, ok := runner.(subprocess.EnvRunner)
+	if !ok {
+		return subprocess.Result{}, errors.New("runtime runner does not support agent environment injection")
+	}
+	return envRunner.RunEnv(ctx, dir, env, command, args...)
 }
 
 // waitRetryBackoff pauses before the next delivery attempt (1-indexed), returning

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -1830,6 +1830,151 @@ type shellContextRunner struct {
 	calls   [][]string
 }
 
+type agentEnvRunner struct {
+	results  []subprocess.Result
+	errs     []error
+	runCalls [][]string
+	envCalls []struct {
+		env  []string
+		argv []string
+	}
+}
+
+func (r *agentEnvRunner) result(command string, args []string, index int) (subprocess.Result, error) {
+	result := subprocess.Result{Command: command, Args: args}
+	if index < len(r.results) {
+		result = r.results[index]
+		result.Command = command
+		result.Args = args
+	}
+	var err error
+	if index < len(r.errs) {
+		err = r.errs[index]
+	}
+	return result, err
+}
+
+func (r *agentEnvRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
+	argv := append([]string{command}, args...)
+	r.runCalls = append(r.runCalls, argv)
+	return r.result(command, args, len(r.runCalls)+len(r.envCalls)-1)
+}
+
+func (r *agentEnvRunner) RunEnv(_ context.Context, _ string, env []string, command string, args ...string) (subprocess.Result, error) {
+	argv := append([]string{command}, args...)
+	r.envCalls = append(r.envCalls, struct {
+		env  []string
+		argv []string
+	}{env: append([]string(nil), env...), argv: argv})
+	return r.result(command, args, len(r.runCalls)+len(r.envCalls)-1)
+}
+
+func (r *agentEnvRunner) LookPath(file string) (string, error) {
+	return "/usr/bin/" + file, nil
+}
+
+func TestManagedRuntimeDeliveriesThreadAgentEnv(t *testing.T) {
+	const session = "550e8400-e29b-41d4-a716-446655440002"
+	wantEnv := []string{"PROXY_KEY=gitmoot-kc-agent-test", "GITMOOT_PROXY_PROXY_KEY_URL=http://127.0.0.1:1234/lease"}
+	tests := []struct {
+		name   string
+		output string
+		agent  Agent
+		build  func(subprocess.Runner) Adapter
+	}{
+		{
+			name: "codex", output: "done",
+			agent: Agent{Name: "seat", Role: "reviewer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "gitmoot/gitmoot"},
+			build: func(r subprocess.Runner) Adapter { return CodexAdapter{Runner: r} },
+		},
+		{
+			name: "claude", output: `{"result":"done"}`,
+			agent: Agent{Name: "seat", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: session, RepoScope: "gitmoot/gitmoot"},
+			build: func(r subprocess.Runner) Adapter { return ClaudeAdapter{Runner: r} },
+		},
+		{
+			name: "kimi", output: kimiStreamOK,
+			agent: Agent{Name: "seat", Role: "reviewer", Runtime: KimiRuntime, RuntimeRef: "session_" + session, RepoScope: "gitmoot/gitmoot"},
+			build: func(r subprocess.Runner) Adapter { return KimiAdapter{Runner: r} },
+		},
+		{
+			name: "kimi-cli", output: kimiStreamOK,
+			agent: Agent{Name: "seat", Role: "reviewer", Runtime: KimiCLIRuntime, RuntimeRef: "session_" + session, RepoScope: "gitmoot/gitmoot"},
+			build: func(r subprocess.Runner) Adapter { return KimiCLIAdapter{Runner: r} },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withEnv := &agentEnvRunner{results: []subprocess.Result{{Stdout: tt.output}}}
+			if _, err := tt.build(withEnv).Deliver(context.Background(), tt.agent, Job{Prompt: "work", AgentEnv: wantEnv}); err != nil {
+				t.Fatalf("Deliver with AgentEnv: %v", err)
+			}
+			if len(withEnv.runCalls) != 0 || len(withEnv.envCalls) != 1 {
+				t.Fatalf("runner calls: Run=%#v RunEnv=%#v", withEnv.runCalls, withEnv.envCalls)
+			}
+			if !reflect.DeepEqual(withEnv.envCalls[0].env, wantEnv) {
+				t.Fatalf("RunEnv env = %#v, want %#v", withEnv.envCalls[0].env, wantEnv)
+			}
+
+			withoutEnv := &agentEnvRunner{results: []subprocess.Result{{Stdout: tt.output}}}
+			if _, err := tt.build(withoutEnv).Deliver(context.Background(), tt.agent, Job{Prompt: "work"}); err != nil {
+				t.Fatalf("Deliver without AgentEnv: %v", err)
+			}
+			if len(withoutEnv.runCalls) != 1 || len(withoutEnv.envCalls) != 0 {
+				t.Fatalf("empty AgentEnv changed runner path: Run=%#v RunEnv=%#v", withoutEnv.runCalls, withoutEnv.envCalls)
+			}
+		})
+	}
+}
+
+func TestAgentEnvReachesRuntimeFallbackAttempts(t *testing.T) {
+	wantEnv := []string{"PROXY_KEY=gitmoot-kc-fallback-test"}
+	tests := []struct {
+		name    string
+		results []subprocess.Result
+		errs    []error
+		agent   Agent
+		build   func(subprocess.Runner) Adapter
+	}{
+		{
+			name: "codex json fallback",
+			results: []subprocess.Result{
+				{Stderr: "error: unexpected argument '--json' found"},
+				{Stdout: "done"},
+			},
+			errs:  []error{errors.New("exit 2"), nil},
+			agent: Agent{Name: "seat", Role: "reviewer", Runtime: CodexRuntime, RuntimeRef: LastRef, RepoScope: "gitmoot/gitmoot"},
+			build: func(r subprocess.Runner) Adapter { return CodexAdapter{Runner: r} },
+		},
+		{
+			name: "claude output format fallback",
+			results: []subprocess.Result{
+				{Stderr: "unknown output-format option"},
+				{Stdout: "done"},
+			},
+			errs:  []error{errors.New("exit 2"), nil},
+			agent: Agent{Name: "seat", Role: "reviewer", Runtime: ClaudeRuntime, RuntimeRef: "550e8400-e29b-41d4-a716-446655440002", RepoScope: "gitmoot/gitmoot"},
+			build: func(r subprocess.Runner) Adapter { return ClaudeAdapter{Runner: r} },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &agentEnvRunner{results: tt.results, errs: tt.errs}
+			if _, err := tt.build(runner).Deliver(context.Background(), tt.agent, Job{Prompt: "work", AgentEnv: wantEnv}); err != nil {
+				t.Fatalf("Deliver: %v", err)
+			}
+			if len(runner.envCalls) != 2 || len(runner.runCalls) != 0 {
+				t.Fatalf("fallback calls: Run=%#v RunEnv=%#v", runner.runCalls, runner.envCalls)
+			}
+			for i, call := range runner.envCalls {
+				if !reflect.DeepEqual(call.env, wantEnv) {
+					t.Fatalf("attempt %d env = %#v, want %#v", i, call.env, wantEnv)
+				}
+			}
+		})
+	}
+}
+
 func (r *shellContextRunner) Run(_ context.Context, _ string, command string, args ...string) (subprocess.Result, error) {
 	return subprocess.Result{}, errors.New("unexpected plain Run")
 }

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -157,7 +157,7 @@ func (a KimiAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result,
 	defer cleanup()
 	args = append(args, extraArgs...)
 	args = append(args, "-p", promptArg, "--output-format", "stream-json")
-	result, err := a.runner().Run(ctx, a.Dir, "kimi", args...)
+	result, err := runAgentCommand(ctx, a.runner(), a.Dir, job.AgentEnv, "kimi", args...)
 	// The fresh per-job kimi session never reports its id, so SessionID stays
 	// empty; the exit/stderr diagnostics still apply.
 	if err != nil {
@@ -255,7 +255,7 @@ func (a KimiCLIAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resu
 		return Result{}, err
 	}
 	defer cleanup()
-	result, err := a.runner().Run(ctx, a.Dir, "kimi", kimiCLIPromptArgs(agent, effectiveModel(agent, job), promptArg, extraArgs)...)
+	result, err := runAgentCommand(ctx, a.runner(), a.Dir, job.AgentEnv, "kimi", kimiCLIPromptArgs(agent, effectiveModel(agent, job), promptArg, extraArgs)...)
 	if err != nil {
 		return Result{Raw: result.Stdout + result.Stderr, SessionDiag: newSessionDiag(result, err, "")}, kimiCommandError(result, err)
 	}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -120,7 +120,7 @@ type Mailbox struct {
 	produceCheckTimeout time.Duration
 }
 
-// PipelineKeyAccess is the persisted, names-only authorization for one shell
+// PipelineKeyAccess is the persisted, names-only authorization for one pipeline
 // stage environment name. Source is pinned at enqueue so delivery never changes
 // audit meaning by falling through to another source.
 type PipelineKeyAccess struct {
@@ -200,11 +200,13 @@ type JobRequest struct {
 	// and non-shell job.
 	ShellEnv []string
 	// PipelineName and PipelineKeyAccess are the names-only keycard authority for
-	// a pipeline shell stage. PipelineEnvFile/PipelineEnvKeys remain for in-flight
-	// jobs enqueued before registry/grant resolution shipped. PipelineEnv contains
-	// only selected inline NON-secret defaults; secret values are loaded at
-	// delivery and never enter the persisted payload.
+	// a pipeline stage. PipelineKeyAgent pins an agent stage to its registered seat
+	// grant; empty means the existing pipeline/shell consumer. PipelineEnvFile and
+	// PipelineEnvKeys remain for in-flight shell jobs enqueued before registry/grant
+	// resolution shipped. PipelineEnv contains only selected inline NON-secret
+	// defaults; secret values are loaded at delivery and never enter the payload.
 	PipelineName      string
+	PipelineKeyAgent  string
 	PipelineKeyAccess []PipelineKeyAccess
 	PipelineEnvFile   string
 	PipelineEnvKeys   []string
@@ -312,6 +314,7 @@ type JobPayload struct {
 	RuntimeOverrideRef     string              `json:"runtime_override_ref,omitempty"`
 	ShellEnv               []string            `json:"shell_env,omitempty"`
 	PipelineName           string              `json:"pipeline_name,omitempty"`
+	PipelineKeyAgent       string              `json:"pipeline_key_agent,omitempty"`
 	PipelineKeyAccess      []PipelineKeyAccess `json:"pipeline_key_access,omitempty"`
 	PipelineEnvFile        string              `json:"pipeline_env_file,omitempty"`
 	PipelineEnvKeys        []string            `json:"pipeline_env_keys,omitempty"`
@@ -463,6 +466,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		RuntimeOverrideRef:     strings.TrimSpace(request.RuntimeOverrideRef),
 		ShellEnv:               append([]string(nil), request.ShellEnv...),
 		PipelineName:           strings.TrimSpace(request.PipelineName),
+		PipelineKeyAgent:       strings.TrimSpace(request.PipelineKeyAgent),
 		PipelineKeyAccess:      compactPipelineKeyAccess(request.PipelineKeyAccess),
 		PipelineEnvFile:        strings.TrimSpace(request.PipelineEnvFile),
 		PipelineEnvKeys:        compactStrings(request.PipelineEnvKeys),

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -152,8 +152,8 @@ gitmoot key add <NAME> --mode injected|proxied [--json]
 gitmoot key configure <NAME> --upstream <https-url> --auth bearer|header:<HeaderName> [--json]
 gitmoot key list [--json]
 gitmoot key show <NAME> [--json]
-gitmoot key grant <NAME> --pipeline <pipeline> [--json]
-gitmoot key revoke <NAME> --pipeline <pipeline> [--json]
+gitmoot key grant <NAME> (--pipeline <pipeline> | --agent <seat>) [--json]
+gitmoot key revoke <NAME> (--pipeline <pipeline> | --agent <seat>) [--json]
 gitmoot key rm <NAME> [--force] [--json]
 ```
 
@@ -2808,16 +2808,22 @@ its `needs` stages' result summaries are prepended to the prompt, and a repo-bou
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
 
-Shell stages can opt into pipeline-owned or granted shared environment values
-with `env_keys`. Source files must be absolute, operator-owned regular files
+Shell and agent stages can opt into scoped key access with `env_keys`. Source
+files must be absolute, operator-owned regular files
 with mode exactly `0600`, outside the Gitmoot home and every managed checkout;
-inline `env` is for non-secret defaults. Agent/gate stages cannot set
-`env_keys`; a shell stage with no list gets nothing. Resolution is own
+inline `env` is for non-secret defaults. A shell stage with no list gets
+nothing. Its resolution is own
 `env_file`, then a shared `injected` or configured `proxied` key granted with
 `gitmoot key grant`, then inline default. Registered but ungranted names do not
 match exact or glob selectors. Structural errors always fail add; unresolved
 names warn only while the pipeline remains disabled, then hard-fail
 add-with-enable, enable, manual run, and scheduled/triggered preflight.
+
+Agent stages resolve only configured `proxied` registry keys granted to their
+registered seat. The seat grant and the stage selector are both required;
+injected agent grants, pipeline files/defaults/grants, and gate-stage selectors
+are refused. Ordinary agent jobs receive no keys, and delegation children do
+not inherit the parent stage's key access.
 
 Sources are revalidated and reread at delivery, so rotation applies without a
 daemon restart. Each payload audits `PipelineName` and names-only
@@ -2827,7 +2833,9 @@ delivery: revocation fails closed and never switches to another source. Gitmoot
 internal `GITMOOT_*` entries remain final. Injected mode exposes the value to
 that shell process. Proxied mode puts a per-job placeholder in `<KEY>` and a
 loopback endpoint in `GITMOOT_PROXY_<KEY>_URL`; every request rereads the value,
-rechecks the grant, and is constrained to the configured upstream/base path.
+rechecks the pipeline or agent-seat grant, and is constrained to the configured
+upstream/base path. For agent stages the real value never enters the process,
+but the authorized agent can exercise it against that pinned upstream.
 The lease is revoked when delivery ends.
 
 Proxied mode hides key bytes; it does **not** prevent an authorized child from

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -195,20 +195,24 @@ missing, or unreadable script is refused before runtime launch with its path;
 relative or malformed hook commands emit a `produce_runtime_resource_warning`
 job event. No such discovery runs when `reads:` is absent.
 
-Pipeline key access is deny-by-default. An `injected` selection gives the shell
-the real value, which it can print or transmit. A configured `proxied` shared
-selection instead gives it a per-job placeholder and loopback URL; Gitmoot
+Pipeline key access is deny-by-default. An `injected` selection gives only a
+shell stage the real value, which it can print or transmit. Agent stages require
+both a configured proxied key granted to their registered seat and an explicit
+stage selector; injected agent grants are refused. A configured `proxied`
+selection gives the selected shell or agent a per-job placeholder and loopback URL; Gitmoot
 rereads the value and rechecks the grant on every request, pins forwarding to
 the configured HTTPS origin/base path, and revokes the lease when delivery
 ends. Gitmoot stores only `{stage,name,source,mode}` audit rows, never values or
 hashes. Keychain and pipeline files are revalidated as owner-only `0600` files
 outside Gitmoot state and managed checkouts.
 
-Proxied mode hides key bytes; it does **not** prevent an authorized child from
+For agent stages, the real value never enters the agent process. Proxied mode
+hides key bytes; it does **not** prevent an authorized child from
 exercising the credential on the pinned upstream. Curated upstreams and base
 paths are part of the model, and only trusted upstreams should be configured.
-Agent and gate stages remain ineligible. This generic pipeline proxy is distinct
-from the Claude model gateway.
+Gate stages remain ineligible. Ordinary agent jobs receive nothing, and
+delegation children do not inherit a stage grant. This generic pipeline proxy
+is distinct from the Claude model gateway.
 
 ## External Contracts
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1098,13 +1098,20 @@ RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
 gitmoot pipeline show "$RUN"                       # watch the text funnel
 ```
 
-`env_keys` is a shell-stage-only allowlist of exact names or globs resolved from
-the pipeline's `env_file` and inline non-secret `env`. No list means no injected
-values, and agent stages cannot request them. `pipeline add` requires the file
+`env_keys` is a deny-by-default allowlist of exact names or globs. Shell stages
+resolve the pipeline's `env_file`, pipeline-granted shared keys, and inline
+non-secret `env`. Agent stages resolve only configured proxied keys granted to
+their registered seat; the grant and explicit stage selector are both required,
+and the real value never enters the agent process. Gates reject the field. No
+list means no key access. `pipeline add` requires the file
 to be absolute, operator-owned `0600`, and outside Gitmoot state/checkouts; it
 also refuses missing keys and reserved `GITMOOT_*` names. Values are read fresh
 at stage delivery for restart-free rotation. The job audit stores the path and
 expanded names only, not file values.
+
+Ordinary agent jobs receive no pipeline-stage keys, and a coordinator's
+delegation children inherit nothing. A proxied agent can exercise the credential
+against its pinned upstream even though it never receives the underlying bytes.
 
 The pipeline detail **Keys** tab exposes this authorization as names only: every
 stage appears in spec order with each resolved key's `own`, `shared`, or

--- a/website/docs/reference/credentials.md
+++ b/website/docs/reference/credentials.md
@@ -58,6 +58,7 @@ gitmoot key add SOURCE_API_TOKEN --mode injected
 gitmoot key grant SOURCE_API_TOKEN --pipeline nightly-sync
 gitmoot key add PARTNER_API_TOKEN --mode proxied
 gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
+gitmoot key grant PARTNER_API_TOKEN --agent researcher
 gitmoot key list --json
 gitmoot key show SOURCE_API_TOKEN
 gitmoot key revoke SOURCE_API_TOKEN --pipeline nightly-sync
@@ -67,19 +68,22 @@ gitmoot key rm SOURCE_API_TOKEN --force
 `rm` removes registry metadata and grants, not the operator's file entry.
 `proxied` keys must be configured before grant with an absolute HTTPS upstream
 and either bearer or approved custom-header placement. Pipeline shell stages
-may request granted `injected` or configured `proxied` names with `env_keys`;
-agent and gate stages remain ineligible. Resolution is Gitmoot's reserved
-`GITMOOT_*` namespace, then the pipeline's own `env_file`, then a granted shared
-key, then inline non-secret `env`. Registered but ungranted names are not
-visible to exact or glob selectors.
+may request pipeline-granted `injected` or configured `proxied` names with
+`env_keys`. Agent stages require both a configured proxied key granted to their
+registered seat and an explicit stage selector; injected agent grants are
+refused. Gates remain ineligible. Shell resolution includes the pipeline's own
+file/defaults and pipeline grants, while agent resolution never does.
 
-A proxied shell receives a per-job placeholder in `<KEY>` and a loopback URL in
+A proxied shell or agent stage receives a per-job placeholder in `<KEY>` and a loopback URL in
 `GITMOOT_PROXY_<KEY>_URL`. Gitmoot pins the destination origin/base path,
 rereads the keychain and rechecks the grant for every request, and revokes the
-lease when delivery ends. Proxied mode hides key bytes; it does **not** prevent
+lease when delivery ends. The real value never enters an agent process. Proxied mode hides key bytes; it does **not** prevent
 an authorized child from exercising the credential on the pinned upstream.
 Curated upstreams and base paths are part of the model; configure only trusted
 services.
+
+Ordinary agent jobs receive no keys, and delegation children do not inherit a
+pipeline stage's access.
 
 ## Claude model gateway
 

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -82,7 +82,7 @@ structural mistake is a clear error at registration, not a stuck run later. It s
 plus a content hash; each run snapshots the hash and executes its snapshot, so
 editing the file later never mutates an in-flight run.
 
-### Give each shell stage only the keys it needs
+### Give each stage only the keys it needs
 
 Declare secrets in a pipeline-owned file or the shared keychain and select them
 per shell stage. The key CLI manages names and grants, never values:
@@ -94,6 +94,7 @@ gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
 gitmoot key add PARTNER_API_TOKEN --mode proxied
 gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
 gitmoot key grant PARTNER_API_TOKEN --pipeline trend-scout
+gitmoot key grant PARTNER_API_TOKEN --agent researcher
 ```
 
 ```yaml
@@ -109,8 +110,11 @@ stages:
     env_keys: [TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID]
 ```
 
-No `env_keys` means no injected values. Exact names and globs expand only for
-shell stages; agent and gate stages cannot request them. At registration,
+No `env_keys` means no key access. Shell-stage selectors resolve pipeline-owned,
+pipeline-granted, and inline sources. Agent-stage selectors resolve only
+configured proxied keys granted to that registered seat; both locks are
+required, and injected agent grants are refused. Gate stages cannot request
+keys. At registration,
 Gitmoot requires each source file to be operator-owned, mode exactly `0600`, and
 outside its home and managed checkouts. Structural errors always fail. An
 unresolved name only warns while the pipeline remains disabled; add-with-enable,
@@ -124,16 +128,19 @@ shared keys, which beat inline non-secret defaults; Gitmoot's internal
 exact or glob selectors. The stage job payload and `pipeline show --json` audit
 only `{stage,name,source,mode}` rows. Delivery rechecks shared grants, so a
 post-enqueue revoke fails closed without switching sources. The selected shell
-can still read an injected key.
+can still read an injected key. Ordinary agent jobs receive nothing and
+delegation children do not inherit stage access.
 
-A configured `proxied` shared key gives the shell a per-job placeholder in
+A configured `proxied` shared key gives the selected shell or agent stage a per-job placeholder in
 `<KEY>` and a loopback URL in `GITMOOT_PROXY_<KEY>_URL`. Gitmoot pins requests
 to the configured HTTPS origin/base path, places the real value as bearer auth
 or an approved custom header, rereads the keychain and rechecks the grant per
 request, and revokes the lease when delivery ends. Proxied mode hides key bytes;
 it does **not** prevent an authorized child from exercising the credential on
 the pinned upstream. Curated upstreams and base paths are part of the model;
-configure only trusted services. The Claude model gateway is separate.
+configure only trusted services. The real value never enters an agent process,
+but the authorized agent can still exercise it against the pinned upstream.
+The Claude model gateway is separate.
 
 The pipeline detail **Keys** tab is a names-only view of the same projection. It
 shows every stage, resolved key names with `own`/`shared`/`default` sources and

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2816,7 +2816,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `stages[].needs`            | stage        | no       | Ids of sibling stages that must **succeed** before this stage is enqueued. Must reference known stages, never the stage itself, and form no cycle. |
 | `stages[].timeout`          | stage        | no       | Per-stage job timeout (positive Go duration). |
 | `stages[].retry`            | stage        | no       | How many times a **failed** stage may be re-attempted (`>= 0`, default `0`). |
-| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`) selected from the pipeline's `env_file`, granted shared registry keys, or inline `env`. Shell stages only; no entry means no key access. |
+| `stages[].env_keys`         | stage        | no       | Exact names or globs (for example `REDDIT_*`). Shell stages resolve pipeline-owned, pipeline-granted, and inline sources. Agent stages resolve only configured proxied keys granted to their named seat. Gates reject this field; no entry means no key access. |
 | `stages[].success_decisions`| stage        | no       | Per-stage override of the pipeline default. |
 
 `gitmoot pipeline add` validates the whole spec **at add time** — unknown keys, a
@@ -2833,10 +2833,13 @@ rather than a stuck run later.
 
 ### Stage-scoped environment
 
-Pipeline secrets are deny-by-default. A shell stage receives only the concrete
-names selected by its `env_keys`; a sibling with different or empty `env_keys`
-does not receive them. Agent and gate stages cannot declare `env_keys`. Shared
-keys must be registered and granted separately:
+Pipeline secrets are deny-by-default. A stage receives only the concrete names
+selected by its own `env_keys`; a sibling with different or empty `env_keys`
+does not receive them. Shell grants belong to the pipeline. Agent stages require
+two independent locks: a configured proxied key granted to the registered agent
+seat, plus that stage's explicit selector. Injected agent grants are refused,
+and gate stages cannot declare `env_keys`. Shared keys must be registered and
+granted separately:
 
 ```sh
 gitmoot key path # edit this 0600 file; the CLI never accepts values
@@ -2845,6 +2848,7 @@ gitmoot key grant REDDIT_CLIENT_SECRET --pipeline trend-scout
 gitmoot key add PARTNER_API_TOKEN --mode proxied
 gitmoot key configure PARTNER_API_TOKEN --upstream https://api.partner.example/v1 --auth bearer
 gitmoot key grant PARTNER_API_TOKEN --pipeline trend-scout
+gitmoot key grant PARTNER_API_TOKEN --agent researcher
 ```
 
 ```yaml
@@ -2870,7 +2874,10 @@ again immediately before each stage process starts, so an atomic rewrite of a
 `0600` source rotates credentials without a daemon restart. Resolution is own
 `env_file`, then granted shared key, then inline default; Gitmoot's reserved
 `GITMOOT_*` entries always win. Registered but ungranted names are not glob or
-exact-match candidates.
+exact-match candidates. Agent stages resolve only from their seat's configured
+proxied grants: pipeline `env_file`, inline defaults, pipeline grants, and
+injected keys are never candidates. Ordinary agent jobs receive nothing, and
+delegated children do not inherit a pipeline stage's key access.
 
 The persisted stage job payload is the audit record: `PipelineKeyAccess` carries
 only `{stage,name,source,mode}` rows (plus legacy env-file/name fields for
@@ -2881,14 +2888,17 @@ after enqueue fails the stage rather than switching to another source. Inline
 injected key is visible to its shell process; this is scoping and audit, not a
 vault.
 
-A configured `proxied` shared key instead gives the shell a per-job placeholder
-in `<KEY>` and a loopback endpoint in `GITMOOT_PROXY_<KEY>_URL`. The endpoint is
+A configured `proxied` shared key gives the selected shell or agent stage a
+per-job placeholder in `<KEY>` and a loopback endpoint in
+`GITMOOT_PROXY_<KEY>_URL`. The endpoint is
 pinned to the configured HTTPS origin and normalized base path. Gitmoot places
 the real credential as either bearer auth or an approved custom header, rereads
 the keychain and rechecks the grant on every request, and revokes the lease when
 delivery ends. Rotation therefore applies to the next request; revocation
-returns `401` without contacting the upstream. Agent and gate stages remain
-ineligible, and the Claude model gateway remains independent.
+returns `401` without contacting the upstream. The real value never enters an
+agent process, though that authorized agent can exercise it against the pinned
+upstream. Gate stages remain ineligible, and the Claude model gateway remains
+independent.
 
 Proxied mode hides key bytes; it does **not** prevent an authorized child from
 exercising the credential on the pinned upstream. Curated upstreams and base
@@ -9506,8 +9516,8 @@ gitmoot key add <NAME> --mode injected|proxied [--json]
 gitmoot key configure <NAME> --upstream <https-url> --auth bearer|header:<HeaderName> [--json]
 gitmoot key list [--json]
 gitmoot key show <NAME> [--json]
-gitmoot key grant <NAME> --pipeline <pipeline> [--json]
-gitmoot key revoke <NAME> --pipeline <pipeline> [--json]
+gitmoot key grant <NAME> (--pipeline <pipeline> | --agent <seat>) [--json]
+gitmoot key revoke <NAME> (--pipeline <pipeline> | --agent <seat>) [--json]
 gitmoot key rm <NAME> [--force] [--json]
 ```
 
@@ -12162,16 +12172,22 @@ its `needs` stages' result summaries are prepended to the prompt, and a repo-bou
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
 
-Shell stages can opt into pipeline-owned or granted shared environment values
-with `env_keys`. Source files must be absolute, operator-owned regular files
+Shell and agent stages can opt into scoped key access with `env_keys`. Source
+files must be absolute, operator-owned regular files
 with mode exactly `0600`, outside the Gitmoot home and every managed checkout;
-inline `env` is for non-secret defaults. Agent/gate stages cannot set
-`env_keys`; a shell stage with no list gets nothing. Resolution is own
+inline `env` is for non-secret defaults. A shell stage with no list gets
+nothing. Its resolution is own
 `env_file`, then a shared `injected` or configured `proxied` key granted with
 `gitmoot key grant`, then inline default. Registered but ungranted names do not
 match exact or glob selectors. Structural errors always fail add; unresolved
 names warn only while the pipeline remains disabled, then hard-fail
 add-with-enable, enable, manual run, and scheduled/triggered preflight.
+
+Agent stages resolve only configured `proxied` registry keys granted to their
+registered seat. The seat grant and the stage selector are both required;
+injected agent grants, pipeline files/defaults/grants, and gate-stage selectors
+are refused. Ordinary agent jobs receive no keys, and delegation children do
+not inherit the parent stage's key access.
 
 Sources are revalidated and reread at delivery, so rotation applies without a
 daemon restart. Each payload audits `PipelineName` and names-only
@@ -12181,7 +12197,9 @@ delivery: revocation fails closed and never switches to another source. Gitmoot
 internal `GITMOOT_*` entries remain final. Injected mode exposes the value to
 that shell process. Proxied mode puts a per-job placeholder in `<KEY>` and a
 loopback endpoint in `GITMOOT_PROXY_<KEY>_URL`; every request rereads the value,
-rechecks the grant, and is constrained to the configured upstream/base path.
+rechecks the pipeline or agent-seat grant, and is constrained to the configured
+upstream/base path. For agent stages the real value never enters the process,
+but the authorized agent can exercise it against that pinned upstream.
 The lease is revoked when delivery ends.
 
 Proxied mode hides key bytes; it does **not** prevent an authorized child from
@@ -13678,13 +13696,20 @@ RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
 gitmoot pipeline show "$RUN"                       # watch the text funnel
 ```
 
-`env_keys` is a shell-stage-only allowlist of exact names or globs resolved from
-the pipeline's `env_file` and inline non-secret `env`. No list means no injected
-values, and agent stages cannot request them. `pipeline add` requires the file
+`env_keys` is a deny-by-default allowlist of exact names or globs. Shell stages
+resolve the pipeline's `env_file`, pipeline-granted shared keys, and inline
+non-secret `env`. Agent stages resolve only configured proxied keys granted to
+their registered seat; the grant and explicit stage selector are both required,
+and the real value never enters the agent process. Gates reject the field. No
+list means no key access. `pipeline add` requires the file
 to be absolute, operator-owned `0600`, and outside Gitmoot state/checkouts; it
 also refuses missing keys and reserved `GITMOOT_*` names. Values are read fresh
 at stage delivery for restart-free rotation. The job audit stores the path and
 expanded names only, not file values.
+
+Ordinary agent jobs receive no pipeline-stage keys, and a coordinator's
+delegation children inherit nothing. A proxied agent can exercise the credential
+against its pinned upstream even though it never receives the underlying bytes.
 
 The pipeline detail **Keys** tab exposes this authorization as names only: every
 stage appears in spec order with each resolved key's `own`, `shared`, or
@@ -14354,20 +14379,24 @@ missing, or unreadable script is refused before runtime launch with its path;
 relative or malformed hook commands emit a `produce_runtime_resource_warning`
 job event. No such discovery runs when `reads:` is absent.
 
-Pipeline key access is deny-by-default. An `injected` selection gives the shell
-the real value, which it can print or transmit. A configured `proxied` shared
-selection instead gives it a per-job placeholder and loopback URL; Gitmoot
+Pipeline key access is deny-by-default. An `injected` selection gives only a
+shell stage the real value, which it can print or transmit. Agent stages require
+both a configured proxied key granted to their registered seat and an explicit
+stage selector; injected agent grants are refused. A configured `proxied`
+selection gives the selected shell or agent a per-job placeholder and loopback URL; Gitmoot
 rereads the value and rechecks the grant on every request, pins forwarding to
 the configured HTTPS origin/base path, and revokes the lease when delivery
 ends. Gitmoot stores only `{stage,name,source,mode}` audit rows, never values or
 hashes. Keychain and pipeline files are revalidated as owner-only `0600` files
 outside Gitmoot state and managed checkouts.
 
-Proxied mode hides key bytes; it does **not** prevent an authorized child from
+For agent stages, the real value never enters the agent process. Proxied mode
+hides key bytes; it does **not** prevent an authorized child from
 exercising the credential on the pinned upstream. Curated upstreams and base
 paths are part of the model, and only trusted upstreams should be configured.
-Agent and gate stages remain ineligible. This generic pipeline proxy is distinct
-from the Claude model gateway.
+Gate stages remain ineligible. Ordinary agent jobs receive nothing, and
+delegation children do not inherit a stage grant. This generic pipeline proxy
+is distinct from the Claude model gateway.
 
 ## External Contracts
 


### PR DESCRIPTION
## Agent-stage grants — the final keycard piece (closes #874)

Implements PR-2 of the keycard epic per the FROZEN design in #874's last panel-synthesis comment. Pipeline **agent stages** (ask/review/produce) can now hold keychain keys — **proxied-only**, both-locks-required, fail-closed. This flips the historical "agent stages get nothing" rule under two explicit gates, so it was held for owner sign-off.

### The frozen rules (enforced at every layer)
- **Proxied-only for agents.** Injected agent grants are rejected at the grant CLI, at resolution, and at delivery (`ErrKeychainAgentInjected`). An LLM env value would otherwise leak via `Result.Raw` → persisted payload — there is no acknowledge-exposure escape hatch.
- **Two locks, both required:** a seat grant (`consumer_kind='agent'`, `consumer_id=<registered agent>`) **and** the stage's explicit `env_keys` request. No auto-injection; delegation children inherit nothing.
- Ordinary `agent ask/review/run` (non-pipeline) jobs still receive nothing. Gates stay ineligible. Shell-stage behavior is byte-identical.

### Seams
- **Store** (`internal/db/keychain.go`): `KeychainConsumerAgent`; grant/revoke validate the seat exists and refuse injected / unconfigured-proxied; agent deletion removes grants in its existing transactions. `key grant|revoke <NAME> --agent <seat>` (mutually exclusive with `--pipeline`).
- **Spec/validation** (`internal/pipeline/{spec,validate}.go`): agent stages may declare `env_keys`; selectors resolve **only** to agent-granted, configured, proxied registry keys — never env_file, inline defaults, or pipeline grants. Warn-while-disabled / hard-gate-on-run timing preserved. Gate stages still reject `env_keys`.
- **Runtime delivery** (`internal/runtime/adapter.go`, `kimi.go`): new **in-memory-only** `AgentEnv []string` on `runtime.Job` — never serialized into any persisted payload — threaded through every Codex/Claude/Kimi spawn. The Claude model-gateway placeholder appends **after** `AgentEnv` so auth placeholders always win.
- **Delivery** (`internal/cli/pipeline_env.go`): mints credgw leases exactly like #978's shell path (RegisterProxy + per-request grant/mode/config re-check; revocation between enqueue and delivery fails closed; no silent source switching); the child gets only `<KEY>=<placeholder>` + `GITMOOT_PROXY_<KEY>_URL`. Deferred lease revocation on job end.
- **Dashboard/audit**: names-only `{stage,name,source,mode}` projection extended to cover agent stages (source=shared, mode=proxied). No values anywhere.

### Tests
Store agent-grant CRUD + injected/unconfigured refusals + same-tx deletion cleanup; CLI `--agent`/`--pipeline` mutual exclusion + refusals + names-only list/show; validation matrix (agent-granted proxied resolves; pipeline-granted / env_file / inline names stay unresolved for agent stages; gate still rejects; shell byte-identical); runtime table proving `AgentEnv` reaches every adapter spawn, is absent when unset, never serializes (sentinel scan on payload/events/DB/WAL), and the gateway placeholder overrides a same-named entry; no-LLM E2E (isolated /tmp home + /tmp keychain + httptest upstream): placeholder+URL only in the agent env, real header reaches the upstream via the lease, agent-grant revocation between enqueue and delivery fails closed, Keys tab shows the stage key as shared/proxied.

### Gate
`go generate ./... && git diff --exit-code` clean; `go build ./...`, `go vet ./...`, full `go test ./internal/...` all green (cli 548s fresh; sandbox/runtime/pipeline/db/credgw pass).

### Docs (ship with code)
`docs/credentials.md`, `docs/pipelines.md`, skills `CLI.md`/`SAFETY.md`/`WORKFLOWS.md`, website credentials + pipelines-workflow, regenerated `llms-full.txt` — all state plainly: agents hold **only** proxied keys, the real value never enters the agent process, the agent can still exercise the credential against the pinned upstream.

Closes #874.

## Deploy notes
Server-side only (store/runtime/validation/delivery + docs). Deploy both binaries (`gitmoot` + `gitmoot-dashboard-web`) at idle; the Keys tab projection change is served by the dashboard-web binary. No migration beyond the existing keychain tables. No config change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
