### PR TITLE
feat(dashboard-web): brain fact lookup + events total + ingest event source (#988)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -89,6 +89,7 @@ func newDashboardWebHandler(ds *webDataSource) http.Handler {
 	mux.HandleFunc("GET /api/workflows", ds.handleWorkflows)
 	mux.HandleFunc("GET /api/learning/knowledge", ds.handleLearningKnowledge)
 	mux.HandleFunc("GET /api/brain/events", ds.handleBrainEvents)
+	mux.HandleFunc("GET /api/brain/fact", ds.handleBrainFact)
 	// #958 single-label detail widening (no module cache policy for this route).
 	mux.HandleFunc("GET /api/workflow/{label}", ds.handleWorkflowAPI)
 	mux.Handle("/", dashboard.Serve(ds))

--- a/internal/cli/dashboard_web_brain_events.go
+++ b/internal/cli/dashboard_web_brain_events.go
@@ -31,6 +31,23 @@ type dashboardBrainEvent struct {
 type dashboardBrainEventsResponse struct {
 	Events     []dashboardBrainEvent `json:"events"`
 	NextCursor int64                 `json:"nextCursor"`
+	Total      int64                 `json:"total"`
+}
+
+type dashboardBrainFact struct {
+	ID               int64  `json:"id"`
+	Key              string `json:"key"`
+	Content          string `json:"content"`
+	Status           string `json:"status"`
+	Repo             string `json:"repo,omitempty"`
+	Scope            string `json:"scope"`
+	OwnerKind        string `json:"ownerKind"`
+	OwnerRef         string `json:"ownerRef"`
+	RetiredAt        string `json:"retiredAt,omitempty"`
+	RetiredReason    string `json:"retiredReason,omitempty"`
+	SupersededBy     int64  `json:"supersededBy,omitempty"`
+	FirstConfirmedAt string `json:"firstConfirmedAt"`
+	UpdatedAt        string `json:"updatedAt"`
 }
 
 func (d *webDataSource) BrainEvents(ctx context.Context, cursor int64, limit int) (dashboardBrainEventsResponse, error) {
@@ -42,6 +59,11 @@ func (d *webDataSource) BrainEvents(ctx context.Context, cursor int64, limit int
 	}
 	out := dashboardBrainEventsResponse{Events: []dashboardBrainEvent{}}
 	err := withStore(d.home, func(store *db.Store) error {
+		var err error
+		out.Total, err = store.MaxMemoryEventID(ctx)
+		if err != nil {
+			return err
+		}
 		events, err := store.ListMemoryEvents(ctx, db.MemoryEventFilter{BeforeID: cursor, Limit: limit + 1})
 		if err != nil {
 			return err
@@ -58,6 +80,30 @@ func (d *webDataSource) BrainEvents(ctx context.Context, cursor int64, limit int
 			out.Events = append(out.Events, dashboardBrainEvent{ID: event.ID, At: event.At, Kind: event.Kind,
 				MemoryID: event.MemoryID, Key: event.Key, OwnerKind: event.OwnerKind, OwnerRef: event.OwnerRef,
 				Repo: event.Repo, Scope: event.Scope, Actor: event.Actor, Detail: detail})
+		}
+		return nil
+	})
+	return out, err
+}
+
+func (d *webDataSource) BrainFact(ctx context.Context, id int64) (dashboardBrainFact, error) {
+	var out dashboardBrainFact
+	err := withStore(d.home, func(store *db.Store) error {
+		record, err := store.GetConfirmedMemoryByID(ctx, id)
+		if err != nil {
+			return err
+		}
+		status := "active"
+		if record.SupersededBy != 0 {
+			status = "superseded"
+		} else if record.RetiredAt != "" {
+			status = "retired"
+		}
+		out = dashboardBrainFact{
+			ID: record.ID, Key: record.Key, Content: record.Content, Status: status,
+			Repo: record.Repo, Scope: record.Scope, OwnerKind: record.Owner.Kind, OwnerRef: record.Owner.Ref,
+			RetiredAt: record.RetiredAt, RetiredReason: record.RetiredReason, SupersededBy: record.SupersededBy,
+			FirstConfirmedAt: record.FirstConfirmedAt, UpdatedAt: record.UpdatedAt,
 		}
 		return nil
 	})
@@ -99,6 +145,50 @@ func (d *webDataSource) handleBrainEvents(w http.ResponseWriter, r *http.Request
 
 func dashboardBrainEventsCacheKey(cursor, limit int64) string {
 	return fmt.Sprintf("brain-events:%d.%d", cursor, limit)
+}
+
+func (d *webDataSource) handleBrainFact(w http.ResponseWriter, r *http.Request) {
+	id, err := dashboardBrainFactID(r)
+	if err != nil {
+		writeDashboardBrainError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	pageKey := dashboardBrainFactCacheKey(id)
+	body, outcome, err := d.cacheForDashboard().get(r.Context(), pageKey, "", dashboardBrainFactCachePolicy, func(ctx context.Context) ([]byte, error) {
+		fact, err := d.BrainFact(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(fact)
+	})
+	w.Header().Set(dashboardCacheHeader, outcome)
+	if errors.Is(err, db.ErrConfirmedMemoryNotFound) {
+		writeDashboardBrainError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	d.writeCachedDashboardJSON(w, outcome, body, err)
+}
+
+func dashboardBrainFactCacheKey(id int64) string {
+	return fmt.Sprintf("brain-fact:%d", id)
+}
+
+func dashboardBrainFactID(r *http.Request) (int64, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get("id"))
+	if raw == "" {
+		return 0, fmt.Errorf("id is required")
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id < 0 {
+		return 0, fmt.Errorf("id must be a non-negative integer")
+	}
+	return id, nil
+}
+
+func writeDashboardBrainError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
 }
 
 func dashboardBrainEventIntQuery(r *http.Request, name string, fallback int64) (int64, error) {

--- a/internal/cli/dashboard_web_brain_events_test.go
+++ b/internal/cli/dashboard_web_brain_events_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -16,7 +17,7 @@ func TestWebDataSourceBrainEventsPagingEmptyAndChangeCursor(t *testing.T) {
 	ds := &webDataSource{home: home}
 	ctx := context.Background()
 	empty, err := ds.BrainEvents(ctx, 0, 2)
-	if err != nil || empty.Events == nil || len(empty.Events) != 0 || empty.NextCursor != 0 {
+	if err != nil || empty.Events == nil || len(empty.Events) != 0 || empty.NextCursor != 0 || empty.Total != 0 {
 		t.Fatalf("empty brain events = %+v err=%v", empty, err)
 	}
 	before, err := ds.ChangeCursor(ctx)
@@ -34,11 +35,11 @@ func TestWebDataSourceBrainEventsPagingEmptyAndChangeCursor(t *testing.T) {
 		t.Fatalf("cursor before=%q after=%q err=%v", before, after, err)
 	}
 	first, err := ds.BrainEvents(ctx, 0, 2)
-	if err != nil || len(first.Events) != 2 || first.Events[0].Key != "three" || first.Events[1].Key != "two" || first.NextCursor != first.Events[1].ID {
+	if err != nil || len(first.Events) != 2 || first.Events[0].Key != "three" || first.Events[1].Key != "two" || first.NextCursor != first.Events[1].ID || first.Total != 3 {
 		t.Fatalf("first page = %+v err=%v", first, err)
 	}
 	second, err := ds.BrainEvents(ctx, first.NextCursor, 2)
-	if err != nil || len(second.Events) != 1 || second.Events[0].Key != "one" || second.NextCursor != 0 {
+	if err != nil || len(second.Events) != 1 || second.Events[0].Key != "one" || second.NextCursor != 0 || second.Total != 3 {
 		t.Fatalf("second page = %+v err=%v", second, err)
 	}
 }
@@ -59,11 +60,110 @@ func TestBrainEventsHTTPAPIShape(t *testing.T) {
 	var body struct {
 		Events []map[string]any `json:"events"`
 		Next   int64            `json:"nextCursor"`
+		Total  int64            `json:"total"`
 	}
 	if err := json.Unmarshal(recorder.Body.Bytes(), &body); err != nil {
 		t.Fatal(err)
 	}
-	if body.Events == nil || len(body.Events) != 1 || body.Events[0]["memoryId"] == nil || body.Events[0]["ownerKind"] != "agent" {
+	if body.Events == nil || len(body.Events) != 1 || body.Events[0]["memoryId"] == nil || body.Events[0]["ownerKind"] != "agent" || body.Total != 1 {
 		t.Fatalf("body=%s", recorder.Body.String())
+	}
+}
+
+func TestBrainFactHTTPAPIIncludesHistoricalRowsAndErrors(t *testing.T) {
+	home, store := memoryTestHome(t)
+	ctx := context.Background()
+	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
+	activeID, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "active", Content: "active fact"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	retiredID, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Scope: "general", Key: "retired", Content: "retired fact"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RetireConfirmedMemory(ctx, retiredID, "outdated runbook"); err != nil {
+		t.Fatal(err)
+	}
+	liveID, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "edition", Content: "before"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "edition", Content: "after"}, db.PreserveSupersededEdition()); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := store.ListConfirmedMemoriesByOwnerKind(ctx, "agent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var supersededID int64
+	for _, row := range rows {
+		if row.SupersededBy == liveID {
+			supersededID = row.ID
+		}
+	}
+	if supersededID == 0 {
+		t.Fatal("superseded archive not found")
+	}
+
+	handler := newDashboardWebHandler(&webDataSource{home: home})
+	tests := []struct {
+		name, status string
+		id           int64
+	}{
+		{name: "active", id: activeID, status: "active"},
+		{name: "retired", id: retiredID, status: "retired"},
+		{name: "superseded", id: supersededID, status: "superseded"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/brain/fact?id="+strconv.FormatInt(tc.id, 10), nil))
+			if recorder.Code != http.StatusOK || recorder.Header().Get(dashboardCacheHeader) != "miss" {
+				t.Fatalf("status=%d cache=%q body=%s", recorder.Code, recorder.Header().Get(dashboardCacheHeader), recorder.Body.String())
+			}
+			var fact map[string]any
+			if err := json.Unmarshal(recorder.Body.Bytes(), &fact); err != nil {
+				t.Fatal(err)
+			}
+			if fact["status"] != tc.status || fact["ownerKind"] != "agent" || fact["ownerRef"] != "builder" || fact["content"] == "" || fact["firstConfirmedAt"] == "" || fact["updatedAt"] == "" {
+				t.Fatalf("fact=%s", recorder.Body.String())
+			}
+			switch tc.status {
+			case "active":
+				if _, ok := fact["retiredAt"]; ok {
+					t.Fatalf("active fact carries retiredAt: %s", recorder.Body.String())
+				}
+			case "retired":
+				if fact["retiredReason"] != "outdated runbook" || fact["retiredAt"] == "" {
+					t.Fatalf("retired fact=%s", recorder.Body.String())
+				}
+			case "superseded":
+				if fact["supersededBy"] != float64(liveID) {
+					t.Fatalf("superseded fact=%s", recorder.Body.String())
+				}
+			}
+		})
+	}
+
+	for _, path := range []string{"/api/brain/fact", "/api/brain/fact?id=nope", "/api/brain/fact?id=-1"} {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+		if recorder.Code != http.StatusBadRequest || !strings.HasPrefix(recorder.Header().Get("Content-Type"), "application/json") {
+			t.Fatalf("path=%s status=%d type=%q body=%s", path, recorder.Code, recorder.Header().Get("Content-Type"), recorder.Body.String())
+		}
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/brain/fact?id=999999", nil))
+	if recorder.Code != http.StatusNotFound || !strings.HasPrefix(recorder.Header().Get("Content-Type"), "application/json") {
+		t.Fatalf("missing status=%d type=%q body=%s", recorder.Code, recorder.Header().Get("Content-Type"), recorder.Body.String())
+	}
+	var apiErr map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &apiErr); err != nil || apiErr["error"] == "" {
+		t.Fatalf("missing error=%v body=%s", err, recorder.Body.String())
 	}
 }

--- a/internal/cli/dashboard_web_cache.go
+++ b/internal/cli/dashboard_web_cache.go
@@ -52,6 +52,10 @@ var dashboardCachePolicies = []dashboardCachePolicy{
 	// nothing is retained — but concurrent identical polls (public dashboard on
 	// the ~1s SSE tick) still coalesce into one store read per page variant.
 	{endpoint: "brain-events", keyKind: "singleflight-only", retain: false},
+	// brain-fact (#988): facts may retire or be superseded at any time, so the
+	// selected row is re-read on every request while identical id lookups share
+	// one in-flight read.
+	{endpoint: "brain-fact", keyKind: "singleflight-only", retain: false},
 }
 
 var (
@@ -65,6 +69,7 @@ var (
 	dashboardWorkflowsCachePolicy   = dashboardCachePolicies[7]
 	dashboardKnowledgeCachePolicy   = dashboardCachePolicies[8]
 	dashboardBrainEventsCachePolicy = dashboardCachePolicies[9]
+	dashboardBrainFactCachePolicy   = dashboardCachePolicies[10]
 )
 
 type dashboardCacheEntry struct {

--- a/internal/cli/dashboard_web_cache_test.go
+++ b/internal/cli/dashboard_web_cache_test.go
@@ -38,6 +38,7 @@ func TestDashboardCachePolicyTable(t *testing.T) {
 		{endpoint: "workflows", keyKind: "job-event-id+workflow-note-id", retain: true, minRecompute: 5 * time.Second, maxAge: 15 * time.Second},
 		{endpoint: "knowledge", keyKind: "ttl-only", retain: true, minRecompute: 15 * time.Second, maxAge: 60 * time.Second},
 		{endpoint: "brain-events", keyKind: "singleflight-only", retain: false},
+		{endpoint: "brain-fact", keyKind: "singleflight-only", retain: false},
 	}
 	if !reflect.DeepEqual(dashboardCachePolicies, want) {
 		t.Fatalf("policies = %#v, want %#v", dashboardCachePolicies, want)
@@ -333,6 +334,12 @@ func TestDashboardBrainEventsCacheSeparatesPageFlights(t *testing.T) {
 	seen := map[string]bool{<-results: true, <-results: true}
 	if !seen["newest-page"] || !seen["older-page"] {
 		t.Fatalf("page results = %#v", seen)
+	}
+}
+
+func TestDashboardBrainFactCacheKeyIncludesID(t *testing.T) {
+	if first, second := dashboardBrainFactCacheKey(1), dashboardBrainFactCacheKey(2); first == second {
+		t.Fatalf("fact cache keys must differ by id: %q", first)
 	}
 }
 
@@ -772,7 +779,7 @@ func TestDashboardCacheMetricsReportUsesPolicyTable(t *testing.T) {
 	cache.mu.Lock()
 	report := cache.recordLocked("overview", "hit", 42, base.Add(dashboardCacheReportInterval))
 	cache.mu.Unlock()
-	want := "dashboard cache: jobs hits=0 misses=0 shared=0 bytes=0; charts hits=0 misses=0 shared=0 bytes=0; health hits=0 misses=0 shared=0 bytes=0; overview hits=1 misses=0 shared=0 bytes=42; attention hits=0 misses=0 shared=0 bytes=0; agents hits=0 misses=0 shared=0 bytes=0; tasks hits=0 misses=0 shared=0 bytes=0; workflows hits=0 misses=0 shared=0 bytes=0; knowledge hits=0 misses=0 shared=0 bytes=0; brain-events hits=0 misses=0 shared=0 bytes=0\n"
+	want := "dashboard cache: jobs hits=0 misses=0 shared=0 bytes=0; charts hits=0 misses=0 shared=0 bytes=0; health hits=0 misses=0 shared=0 bytes=0; overview hits=1 misses=0 shared=0 bytes=42; attention hits=0 misses=0 shared=0 bytes=0; agents hits=0 misses=0 shared=0 bytes=0; tasks hits=0 misses=0 shared=0 bytes=0; workflows hits=0 misses=0 shared=0 bytes=0; knowledge hits=0 misses=0 shared=0 bytes=0; brain-events hits=0 misses=0 shared=0 bytes=0; brain-fact hits=0 misses=0 shared=0 bytes=0\n"
 	if report != want {
 		t.Fatalf("metrics report:\n%s\nwant:\n%s", report, want)
 	}

--- a/internal/cli/memory_ingest.go
+++ b/internal/cli/memory_ingest.go
@@ -309,7 +309,8 @@ func autoConfirmObservationIfEnabled(ctx context.Context, store *db.Store, obs d
 		Content:    obs.Content,
 		Provenance: obs.Provenance,
 		SourceJob:  obs.SourceJob,
-	}, db.PreserveSupersededEdition(), db.WithConfirmedMemoryEvent(db.MemoryEventIngested, actor))
+	}, db.PreserveSupersededEdition(), db.WithConfirmedMemoryEvent(db.MemoryEventIngested, actor),
+		db.WithConfirmedMemoryEventDetail(ingestedMemoryEventDetail(obs.Provenance)))
 	if err != nil {
 		if errors.Is(err, db.ErrConfirmedMemoryRetired) {
 			return false, true, nil
@@ -320,6 +321,14 @@ func autoConfirmObservationIfEnabled(ctx context.Context, store *db.Store, obs d
 		ID: id, Owner: owner, Repo: obs.Repo, Scope: obs.Scope, Key: obs.Key, Content: obs.Content,
 	})
 	return true, false, nil
+}
+
+func ingestedMemoryEventDetail(provenance string) map[string]string {
+	source := strings.TrimSpace(provenance)
+	if strings.HasPrefix(source, "ingest:") {
+		source = strings.TrimPrefix(source, "ingest:")
+	}
+	return map[string]string{"source": source}
 }
 
 // autoConfirmEligibleProvenance is deliberately fail-closed. Only the three

--- a/internal/cli/memory_ingest_test.go
+++ b/internal/cli/memory_ingest_test.go
@@ -33,6 +33,22 @@ func writeFixture(t *testing.T, dir, name, content string) {
 	}
 }
 
+func assertIngestedEventSource(t *testing.T, store *db.Store, want string) {
+	t.Helper()
+	events, err := store.ListMemoryEvents(context.Background(), db.MemoryEventFilter{
+		Kinds: []string{db.MemoryEventIngested}, Limit: 10,
+	})
+	if err != nil || len(events) != 1 {
+		t.Fatalf("ingested events=%+v err=%v", events, err)
+	}
+	var detail struct {
+		Source string `json:"source"`
+	}
+	if err := json.Unmarshal([]byte(events[0].Detail), &detail); err != nil || detail.Source != want {
+		t.Fatalf("ingested detail=%s parsed=%+v err=%v", events[0].Detail, detail, err)
+	}
+}
+
 // TestMemoryIngestPreFilterAccountingAndDedup drives ingest over a fixture dir
 // containing a clean fact, a secret-shaped chunk, and a directive chunk, then
 // re-ingests to prove exact-content dedup yields zero new inserts.
@@ -223,6 +239,7 @@ ingest_auto_confirm = true
 	if len(sharedRows) != 0 {
 		t.Fatalf("auto-confirm must not write shared memory, got %+v", sharedRows)
 	}
+	assertIngestedEventSource(t, storeOn, "note.md")
 }
 
 // TestMemoryIngestConfirmExportRoundTrip is the P3 end-to-end: ingest → the note
@@ -456,6 +473,7 @@ tier = "repo"
 	if len(sharedRows) != 0 {
 		t.Fatalf("sweep auto-confirm must not write shared memory, got %+v", sharedRows)
 	}
+	assertIngestedEventSource(t, store, "sweep.md")
 }
 
 func TestMemoryIngestSweepAllSourcesFailExitsNonZero(t *testing.T) {

--- a/internal/cli/workflow_journal.go
+++ b/internal/cli/workflow_journal.go
@@ -558,7 +558,8 @@ func autoConfirmWorkflowObservationIfEnabled(ctx context.Context, store *db.Stor
 	id, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
 		Owner: obs.Owner, AuthorRef: obs.AuthorRef, Repo: obs.Repo, Scope: obs.Scope,
 		Key: obs.Key, Content: obs.Content, Provenance: obs.Provenance,
-	}, db.PreserveSupersededEdition(), db.WithConfirmedMemoryEvent(db.MemoryEventIngested, actor))
+	}, db.PreserveSupersededEdition(), db.WithConfirmedMemoryEvent(db.MemoryEventIngested, actor),
+		db.WithConfirmedMemoryEventDetail(ingestedMemoryEventDetail(obs.Provenance)))
 	if err != nil {
 		if errors.Is(err, db.ErrConfirmedMemoryRetired) {
 			return false, true, nil

--- a/internal/db/memory_store.go
+++ b/internal/db/memory_store.go
@@ -64,6 +64,14 @@ type ConfirmedMemory struct {
 	SupersededBy     int64 // 0 == not superseded
 }
 
+// ConfirmedMemoryRecord is the complete read-only row shape used by audit
+// surfaces that must include retired and superseded facts.
+type ConfirmedMemoryRecord struct {
+	ConfirmedMemory
+	RetiredAt     string
+	RetiredReason string
+}
+
 // MemoryLink is one persisted, derived edge from a source confirmed memory to a
 // related target confirmed memory. It never mutates fact content; vault export and
 // inspection commands opt into this side table explicitly.
@@ -118,11 +126,15 @@ const (
 // than reviving content an operator already pulled from circulation.
 var ErrConfirmedMemoryRetired = errors.New("confirmed memory is retired")
 
+// ErrConfirmedMemoryNotFound reports a confirmed-memory id with no backing row.
+var ErrConfirmedMemoryNotFound = errors.New("confirmed memory not found")
+
 type upsertConfirmedMemoryOptions struct {
 	allowResurrect   bool
 	preserveEditions bool
 	eventKind        string
 	actor            string
+	eventDetail      any
 }
 
 // UpsertConfirmedMemoryOption tunes confirmed-memory upsert behavior.
@@ -157,6 +169,15 @@ func WithConfirmedMemoryEvent(kind, actor string) UpsertConfirmedMemoryOption {
 	return func(o *upsertConfirmedMemoryOptions) {
 		o.eventKind = strings.TrimSpace(kind)
 		o.actor = strings.TrimSpace(actor)
+	}
+}
+
+// WithConfirmedMemoryEventDetail attaches compact JSON detail to an event when
+// the mutation path does not already require a stronger detail payload (for
+// example, an updated event's before-content).
+func WithConfirmedMemoryEventDetail(detail any) UpsertConfirmedMemoryOption {
+	return func(o *upsertConfirmedMemoryOptions) {
+		o.eventDetail = detail
 	}
 }
 
@@ -360,6 +381,32 @@ ORDER BY id`)
 	return out, rows.Err()
 }
 
+// GetConfirmedMemoryByID returns one complete confirmed-memory row, including
+// retired and superseded facts. It is an audit read and deliberately applies no
+// active-fact filter.
+func (s *Store) GetConfirmedMemoryByID(ctx context.Context, id int64) (ConfirmedMemoryRecord, error) {
+	var record ConfirmedMemoryRecord
+	var repo sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+SELECT id, owner_kind, owner_ref, owner_version, author_ref, repo, scope, key, content, context,
+	provenance, source_job, first_confirmed_at, updated_at, COALESCE(superseded_by, 0),
+	retired_at, retired_reason
+FROM confirmed_memories
+WHERE id = ?`, id).Scan(
+		&record.ID, &record.Owner.Kind, &record.Owner.Ref, &record.Owner.Version, &record.AuthorRef, &repo,
+		&record.Scope, &record.Key, &record.Content, &record.Context, &record.Provenance, &record.SourceJob,
+		&record.FirstConfirmedAt, &record.UpdatedAt, &record.SupersededBy,
+		&record.RetiredAt, &record.RetiredReason)
+	if err == sql.ErrNoRows {
+		return ConfirmedMemoryRecord{}, fmt.Errorf("%w: %d", ErrConfirmedMemoryNotFound, id)
+	}
+	if err != nil {
+		return ConfirmedMemoryRecord{}, fmt.Errorf("get confirmed memory %d: %w", id, err)
+	}
+	record.Repo = repo.String
+	return record, nil
+}
+
 // ObservationKeyWitnesses is a per-(owner_ref, repo, key) tally of how many
 // append-only observation sightings back that triple — the "witness" count a
 // confirmed fact on the same key accumulated. Repo is normalized ("" == general /
@@ -539,6 +586,12 @@ WHERE id = ?`,
 	case !inserted:
 		kind = MemoryEventUpdated
 		detail, err = memoryEventBeforeDetail(previousContent)
+		if err != nil {
+			return 0, err
+		}
+	}
+	if recordEvent && detail == "" && options.eventDetail != nil {
+		detail, err = compactMemoryEventDetail(options.eventDetail)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/db/memory_store_test.go
+++ b/internal/db/memory_store_test.go
@@ -20,6 +20,60 @@ func openMemTestStore(t *testing.T) *Store {
 	return store
 }
 
+func TestGetConfirmedMemoryByIDIncludesEveryLifecycleState(t *testing.T) {
+	ctx := context.Background()
+	store := openMemTestStore(t)
+	owner := MemoryOwner{Kind: "agent", Ref: "builder"}
+	activeID := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "active", Content: "active fact"})
+	retiredID := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Scope: "general", Key: "retired", Content: "retired fact"})
+	if err := store.RetireConfirmedMemory(ctx, retiredID, "stale source"); err != nil {
+		t.Fatal(err)
+	}
+	liveID := mustUpsert(t, store, ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "edition", Content: "before"})
+	if _, err := store.UpsertConfirmedMemory(ctx,
+		ConfirmedMemory{Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "edition", Content: "after"},
+		PreserveSupersededEdition()); err != nil {
+		t.Fatal(err)
+	}
+	var supersededID int64
+	if err := store.db.QueryRowContext(ctx, `SELECT id FROM confirmed_memories WHERE superseded_by = ?`, liveID).Scan(&supersededID); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name, status, repo, reason string
+		id                         int64
+		supersededBy               int64
+	}{
+		{name: "active", id: activeID, status: "active", repo: "acme/widget"},
+		{name: "retired", id: retiredID, status: "retired", reason: "stale source"},
+		{name: "superseded", id: supersededID, status: "superseded", repo: "acme/widget", supersededBy: liveID},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			record, err := store.GetConfirmedMemoryByID(ctx, tc.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			status := "active"
+			if record.SupersededBy != 0 {
+				status = "superseded"
+			} else if record.RetiredAt != "" {
+				status = "retired"
+			}
+			if status != tc.status || record.Repo != tc.repo || record.RetiredReason != tc.reason || record.SupersededBy != tc.supersededBy {
+				t.Fatalf("record = %+v, status=%q", record, status)
+			}
+			if record.FirstConfirmedAt == "" || record.UpdatedAt == "" {
+				t.Fatalf("timestamps missing: %+v", record)
+			}
+		})
+	}
+	if _, err := store.GetConfirmedMemoryByID(ctx, 999999); !errors.Is(err, ErrConfirmedMemoryNotFound) {
+		t.Fatalf("missing error = %v", err)
+	}
+}
+
 func TestMemoryEvalProbeAndCorpusFingerprint(t *testing.T) {
 	ctx := context.Background()
 	store := openMemTestStore(t)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2365,6 +2365,10 @@ filters answer operational questions such as “what changed this week.” Valid
 `superseded` receipts from existing tombstones; `--dry-run` previews the work and
 repeat runs do not duplicate events. Edit details retain the previous content
 inline up to 2 KiB, then use a SHA-256 hash and 300-character preview.
+The read-only dashboard API exposes the same feed at
+`GET /api/brain/events?cursor=ID&limit=N`; its `total` is the exact append-only
+event count. `GET /api/brain/fact?id=ID` returns the selected fact even when it
+has been retired or superseded.
 
 > **Trust boundary.** Ingested Markdown is untrusted input — an
 > **indirect-prompt-injection vector**. Ingest records `trust_mark = low` on every

--- a/website/docs/concepts/agent-memory.md
+++ b/website/docs/concepts/agent-memory.md
@@ -432,7 +432,9 @@ their reason, and split, promotion, and cluster operations retain compact JSON
 details. `memory log backfill` synthesizes historical creation, retirement, and
 supersession receipts from existing tombstones; it is idempotent and supports
 `--dry-run`. The dashboard server exposes the same chronology at
-`GET /api/brain/events?cursor=ID&limit=N`.
+`GET /api/brain/events?cursor=ID&limit=N`; each page includes the exact
+append-only event `total`. A selected chronology entry can load its full fact,
+including retired and superseded rows, from `GET /api/brain/fact?id=ID`.
 
 :::warning Ingested Markdown is untrusted
 Ingested Markdown is an **indirect-prompt-injection vector**. Ingest stamps

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -238,6 +238,10 @@ deep cluster trees, and the fact-links / cross-repo / history header toggles.
 See the Learning section above for how facts are produced; Brain is where you
 read them.
 
+The changelog feed comes from `/api/brain/events`, whose `total` reports the
+exact append-only event count. Selecting an event loads `/api/brain/fact?id=ID`,
+which can return active, retired, or superseded facts for historical inspection.
+
 ## Agents
 
 Route: `/agents` (or `/agents/<name>`)

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -673,6 +673,8 @@ gitmoot job list
 gitmoot job show <job-id>
 gitmoot job watch <job-id>
 gitmoot job watch <job-id> --transcript   # readable cockpit tee log; falls back to events if unavailable
+gitmoot job transcript <job-id> --export md|jsonl
+gitmoot job transcript --all --state succeeded,failed --since 720h --export jsonl
 gitmoot job retry <job-id>
 gitmoot job cancel <job-id>               # abandon one queued|running|blocked job
 gitmoot job cancel --state blocked --older-than 7d --yes   # bulk-dismiss a blocked backlog (dry-run without --yes)
@@ -684,6 +686,15 @@ gitmoot daemon start --repo owner/repo --poll 30s --workers 1
 gitmoot daemon start
 gitmoot daemon status
 ```
+
+Transcript retention is opt-in through `[transcripts] enabled = true` with a
+default `retain = "168h"` and `max_total_bytes = 2147483648`. It captures
+foreground, daemon, temporary-session, ephemeral, and delegated runtime jobs;
+externally driven session jobs have no subprocess to capture. Raw retained logs
+are unredacted mode-`0600` files, seat logs remain transient, and observed disk
+cost on this host is roughly 440 MB/week. JSONL exports redact known credential
+patterns best-effort, but that masking is not a vault. `--output` writes through
+a private temporary file and atomic rename.
 
 Goal import turns Markdown headings shaped like `### Task N: Title` into local
 planned tasks. `task run` starts one task branch in a dedicated worktree,
@@ -4246,8 +4257,9 @@ pane labeled `<agent> · d<depth> · <branch>`, and that pane streams the child'
 progress while the job runs. Children inherit the cockpit setting from their
 parent, so a single `--cockpit` on the root lights up the whole orchestra.
 
-Each pane renders the cockpit-only tee log through `gitmoot job watch
---transcript`. Codex JSONL is readable live. Kimi stream-json is turn-buffered,
+Each pane renders its explicitly selected job or seat tee log through `gitmoot
+job watch --transcript`. With opt-in `[transcripts]`, a universal per-job tee is
+retained independently of cockpit; seat logs stay transient. Codex JSONL is readable live. Kimi stream-json is turn-buffered,
 and kimi-code 0.19.2 emits no usage. Claude currently emits one final JSON
 envelope, so its pane remains quiet until completion and then shows final text
 and usage. Shell output is redacted raw passthrough. Unknown or malformed lines
@@ -4257,10 +4269,11 @@ and pipeline progress stream are unchanged.
 
 On an interactive terminal, tool-specific icons, honest multi-line output
 previews, elapsed times, and lightweight narration markup make the stream easier
-to scan. Pipes and redirects retain the byte-stable plain format. While the tee
-log still exists, `gitmoot job transcript <id> --export md` creates a
-deterministic ANSI-free snapshot for an issue or pull request; add `--output`
-to write it to a file.
+to scan. Pipes and redirects retain the byte-stable plain format. `gitmoot job
+transcript <id> --export md` creates a deterministic ANSI-free snapshot;
+`--export jsonl` creates a schema-versioned redacted trajectory, and `job
+transcript --all ... --export jsonl` is the guarded bulk form. Raw retained logs
+are unredacted mode-`0600` files; export masking is best-effort, not a vault.
 
 Verified Codex command/file-change events and Kimi function tool calls/results
 use typed compact lines; other shapes retain the generic/raw path. Render-time
@@ -6761,6 +6774,10 @@ sub-cluster hub columns, enrolled agents as wells, progressive disclosure for
 deep cluster trees, and the fact-links / cross-repo / history header toggles.
 See the Learning section above for how facts are produced; Brain is where you
 read them.
+
+The changelog feed comes from `/api/brain/events`, whose `total` reports the
+exact append-only event count. Selecting an event loads `/api/brain/fact?id=ID`,
+which can return active, retired, or superseded facts for historical inspection.
 
 ## Agents
 
@@ -9580,6 +9597,31 @@ requires Landlock read-rules for `runtime-auth.env` (same-UID read is currently
 possible) — that is P3. Codex/Kimi custody and hard egress enforcement also
 remain P3.
 
+## Transcript Retention
+
+Runtime transcript retention is opt-in and invalid or missing configuration
+fails closed to disabled capture:
+
+```toml
+[transcripts]
+enabled = true
+retain = "168h"
+max_total_bytes = 2147483648
+```
+
+Enabled capture appends every engine-delivered job attempt (foreground, daemon,
+temporary session, ephemeral, and delegated jobs) to a private canonical log
+under `<home>/logs/jobs/`. Externally driven session jobs have no runtime
+subprocess and therefore no log. A home-scoped sweep removes settled logs after
+`retain`, then evicts the oldest settled logs when the total exceeds
+`max_total_bytes`; queued/running jobs and recently finalized jobs are protected.
+Seat logs remain transient. Expect roughly 440 MB/week at this host's observed
+rate, though workload output varies.
+
+Raw retained logs are mode `0600` and **unredacted on disk**. Treat the Gitmoot
+home as sensitive. JSONL exports redact known credential patterns best-effort,
+but that redaction is not a vault and cannot guarantee removal of every secret.
+
 ## Runtime Launch Sandbox
 
 ```sh
@@ -10667,7 +10709,8 @@ gitmoot job list --repo owner/repo   # add --json for machine-readable rows
 gitmoot job show <job-id>            # add --json for the full job + why-stuck detail
 gitmoot job watch <job-id>
 gitmoot job watch <job-id> --transcript [--log-path <path>] [--runtime codex|claude|kimi|kimi-cli|shell]
-gitmoot job transcript <job-id> --export md [--output <path>] [--log-path <path>] [--runtime codex|claude|kimi|kimi-cli|shell]
+gitmoot job transcript <job-id> --export md|jsonl [--output <path>] [--log-path <path>] [--runtime codex|claude|kimi|kimi-cli|shell]
+gitmoot job transcript --all [--state succeeded,failed] [--since 720h] --export jsonl [--output <path>]
 gitmoot job events <job-id>
 gitmoot job retry <job-id>
 gitmoot job gates <job-id>                                         # list resumable gates; add --json
@@ -10710,12 +10753,18 @@ completion; shell output passes through as redacted raw lines. Usage is labeled
 Malformed or unknown lines degrade individually to redacted capped raw output
 without stopping later lines.
 
-`job transcript <job-id> --export md` reads the same tee log as a snapshot and
-writes deterministic, ANSI-free Markdown to stdout. Add `--output <path>` to
-write a mode-`0600` file instead. The export includes user/assistant headings,
-model and elapsed details when reported, and fenced tool input/output. It does
-not fall back to lifecycle events: cockpit tee logs are removed after delivery
-today, so export fails clearly when the requested log is no longer retained.
+`job transcript <job-id> --export md` remains the deterministic, ANSI-free
+Markdown snapshot. `--export jsonl` emits schema-versioned, self-contained
+trajectory rows for every normalized event. Bulk export requires the explicit
+`--all` guard; `--state` and `--since` filter the created-time-then-id ordered
+stream. Bulk mode skips pre-retention or GC-missing logs and reports counts on
+stderr, while explicit single-job absence is an error. `--output <path>` uses a
+mode-`0600` temporary file plus atomic rename. Oversized runtime lines become
+marked truncated raw steps instead of aborting the export.
+
+JSONL export redacts every text-bearing event field with Gitmoot's best-effort
+credential masker and has no raw bypass. The source log remains unredacted and
+mode `0600`; best-effort export masking is not a vault.
 
 Verified Codex command/file-change events and Kimi function tool calls/results
 render as typed compact lines; unrecognized shapes keep the generic/raw
@@ -11697,6 +11746,10 @@ filters answer operational questions such as “what changed this week.” Valid
 `superseded` receipts from existing tombstones; `--dry-run` previews the work and
 repeat runs do not duplicate events. Edit details retain the previous content
 inline up to 2 KiB, then use a SHA-256 hash and 300-character preview.
+The read-only dashboard API exposes the same feed at
+`GET /api/brain/events?cursor=ID&limit=N`; its `total` is the exact append-only
+event count. `GET /api/brain/fact?id=ID` returns the selected fact even when it
+has been retired or superseded.
 
 > **Trust boundary.** Ingested Markdown is untrusted input — an
 > **indirect-prompt-injection vector**. Ingest records `trust_mark = low` on every
@@ -13615,9 +13668,11 @@ its progress; children inherit the cockpit setting from their parent, so one
 `--cockpit` on the root lights up the whole orchestra. The same panes are visible
 in the terminal (open the Herdr workspace) and on Telegram via the herdres bridge.
 
-The pane reads the cockpit-only tee log through `job watch --transcript`; this
-does not alter runtime invocation, result parsing, or the pipeline progress
-stream. Codex JSONL is readable live. Kimi stream-json is turn-buffered (and
+The pane reads its explicitly selected job or seat tee log through `job watch
+--transcript`; this does not alter runtime invocation, result parsing, or the
+pipeline progress stream. With opt-in `[transcripts]`, the same universal tee
+retains a private per-job append log even when no cockpit exists; seat logs stay
+transient. Codex JSONL is readable live. Kimi stream-json is turn-buffered (and
 kimi-code 0.19.2 emits no usage). Claude currently emits one final JSON envelope,
 so its pane remains quiet until completion and then shows final text and usage.
 Shell output is redacted raw passthrough. Unknown or malformed lines fail open
@@ -13627,6 +13682,11 @@ use typed compact lines; other shapes retain the generic/raw path. Render-time
 redaction is per-line best-effort defense in depth: a secret split across
 physical lines may be only partially masked, and the raw log plus external tail
 fallback remain unredacted.
+
+For offline trajectories, use `job transcript <id> --export jsonl` or the
+guarded bulk form `job transcript --all --state succeeded,failed --since 720h
+--export jsonl`. Exports are best-effort redacted (not a vault); retained source
+logs are unredacted `0600` files and retention has real disk cost.
 
 A cockpit pane is a **view, not the job**: closing a pane (in the terminal or
 from Telegram) tears down the visible surface but does NOT cancel the underlying


### PR DESCRIPTION
Slice-2 companion for #988 (owner-adjudicated): `GET /api/brain/fact?id=` returning any confirmed memory including retired/superseded (status derived; 404/400 on unknown/invalid; singleflight cache with id-variant key, frozen goldens updated), `total` on `/api/brain/events` (MaxMemoryEventID — exact for the append-only journal), and ingest events now record `detail.source` (old events fall back to actor). Docs in all three trees + llms regen.

Consumed by the Brain Changelog UI (gitmoot-dashboard PR #115). Salvaged from an implement job that completed but died pre-commit — #994 occurrence 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)