### PR TITLE
chore(deps): pin gitmoot-dashboard at the Brain Changelog UI (#988 slice 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716130329-dc862b677af0
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716210211-e1e0bbe9f88f
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716130329-dc862b677af0 h1:4QYhEQkpzOwNe435nZrvQrDDiQTnHzHIb+dNYfp68L4=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716130329-dc862b677af0/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716210211-e1e0bbe9f88f h1:mzgRk9BZLw6y/Qz17TqfunzmZvhTXd5To2AkJnVzaxs=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260716210211-e1e0bbe9f88f/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
Dep-only pin bump pulling dashboard PR #115 (Brain Changelog view). Fast CI lane applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)