### PR TITLE
fix(dashboard): merged PR auto-receipt settles a quiet stalled workflow (#987)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -376,13 +376,7 @@ func (d *webDataSource) Workflow(ctx context.Context, label string, q dashboard.
 			TokensIn: summary.InputTokens, TokensOut: summary.OutputTokens,
 			FirstAt: parseJobTimeMillis(summary.FirstAt), LastAt: parseJobTimeMillis(summary.LastAt),
 		}
-		out.State, out.StalledForS = deriveDashboardWorkflowState(now, dashboardWorkflowActivity{
-			Queued: summary.Queued, Running: summary.Running, Failed: summary.Failed,
-			Blocked: summary.Blocked, LastActivity: workflowMillisTime(out.Summary.LastAt),
-			LastFailure:       workflowMillisTime(parseJobTimeMillis(summary.LastFailureAt)),
-			LastHumanNote:     workflowMillisTime(parseJobTimeMillis(summary.LastHumanNoteAt)),
-			LastMergedReceipt: workflowMillisTime(parseJobTimeMillis(summary.LastMergedReceiptAt)),
-		})
+		out.State, out.StalledForS = deriveDashboardWorkflowState(now, dashboardActivityFromSummary(summary, out.Summary.LastAt))
 		meta, metaErr := store.GetWorkflowMeta(ctx, label)
 		if metaErr != nil && !errors.Is(metaErr, sql.ErrNoRows) {
 			return metaErr

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -379,8 +379,9 @@ func (d *webDataSource) Workflow(ctx context.Context, label string, q dashboard.
 		out.State, out.StalledForS = deriveDashboardWorkflowState(now, dashboardWorkflowActivity{
 			Queued: summary.Queued, Running: summary.Running, Failed: summary.Failed,
 			Blocked: summary.Blocked, LastActivity: workflowMillisTime(out.Summary.LastAt),
-			LastFailure:   workflowMillisTime(parseJobTimeMillis(summary.LastFailureAt)),
-			LastHumanNote: workflowMillisTime(parseJobTimeMillis(summary.LastHumanNoteAt)),
+			LastFailure:       workflowMillisTime(parseJobTimeMillis(summary.LastFailureAt)),
+			LastHumanNote:     workflowMillisTime(parseJobTimeMillis(summary.LastHumanNoteAt)),
+			LastMergedReceipt: workflowMillisTime(parseJobTimeMillis(summary.LastMergedReceiptAt)),
 		})
 		meta, metaErr := store.GetWorkflowMeta(ctx, label)
 		if metaErr != nil && !errors.Is(metaErr, sql.ErrNoRows) {

--- a/internal/cli/dashboard_web_overview_test.go
+++ b/internal/cli/dashboard_web_overview_test.go
@@ -189,15 +189,29 @@ func TestDashboardOverviewTasksAndWorkflows(t *testing.T) {
 	if len(overview.Activity.Workflows) != 1 || overview.Activity.Workflows[0].Label != "fable/redesign" || overview.Activity.Workflows[0].Running != 1 || !reflect.DeepEqual(overview.Activity.Workflows[0].Agents, []string{"alpha", "beta"}) || overview.Activity.Queued != 1 || overview.Activity.UnattendedNote != "1 active job without a workflow label" {
 		t.Fatalf("activity = %+v", overview.Activity)
 	}
-	if overview.Today.Completed != 2 || overview.Today.Failed != 1 || overview.Today.Cancelled != 1 || overview.Today.TokensIn != 68 || overview.Today.TokensOut != 82 || len(overview.Today.Notable) != 4 {
+	if overview.Today.Completed != 2 || overview.Today.Failed != 2 || overview.Today.Cancelled != 1 || overview.Today.TokensIn != 68 || overview.Today.TokensOut != 82 || len(overview.Today.Notable) != 5 {
 		t.Fatalf("today = %+v", overview.Today)
+	}
+	wantNotable := []dashboard.OverviewNotable{
+		{Agent: "alpha", Title: "Deploy failed", Outcome: "failed", ElapsedS: 30 * 60, AgeS: 60 * 60},
+		{Agent: "alpha", Title: "Merge resolved failure", Outcome: "failed", ElapsedS: 30 * 60, AgeS: 60 * 60},
+		{Agent: "alpha", Title: "Nightly ingest", Outcome: "succeeded", ElapsedS: 30 * 60, AgeS: 90 * 60},
+		{Agent: "alpha", Title: "Release complete", Outcome: "succeeded", ElapsedS: 60 * 60, AgeS: 2 * 60 * 60},
+		{Agent: "beta", Title: "Cancelled experiment", Outcome: "cancelled", ElapsedS: 60 * 60, AgeS: 3 * 60 * 60},
+	}
+	if !reflect.DeepEqual(overview.Today.Notable, wantNotable) {
+		t.Fatalf("notable = %+v, want %+v", overview.Today.Notable, wantNotable)
+	}
+	failedHourIndex := len(overview.Today.PerHour) - 1 - int(time.Hour/time.Hour)
+	if overview.Today.PerHour[failedHourIndex] != 3 {
+		t.Fatalf("per_hour[%d]=%d, want 3: %v", failedHourIndex, overview.Today.PerHour[failedHourIndex], overview.Today.PerHour)
 	}
 	hourTotal := 0
 	for _, count := range overview.Today.PerHour {
 		hourTotal += count
 	}
-	if hourTotal != 4 {
-		t.Fatalf("per_hour total=%d want 4: %v", hourTotal, overview.Today.PerHour)
+	if hourTotal != 5 {
+		t.Fatalf("per_hour total=%d want 5: %v", hourTotal, overview.Today.PerHour)
 	}
 	if len(overview.Scheduled) != 1 || overview.Scheduled[0].Name != "nightly" || overview.Scheduled[0].Schedule != "every 6h +30m" || overview.Scheduled[0].LastStatus != pipeline.RunSucceeded || overview.Scheduled[0].NextInS != 5*60*60 {
 		t.Fatalf("scheduled = %+v", overview.Scheduled)

--- a/internal/cli/dashboard_web_overview_test.go
+++ b/internal/cli/dashboard_web_overview_test.go
@@ -89,6 +89,7 @@ func TestDashboardOverviewTasksAndWorkflows(t *testing.T) {
 	seedJob("live-queued", "beta", "queued", "fable/redesign", "acme/app", "Queued review", time.Hour, 10*time.Minute, 0, 0)
 	seedJob("unlabelled-running", "beta", "running", "", "acme/misc", "Unattended work", 45*time.Minute, 5*time.Minute, 3, 5)
 	seedJob("stalled-failed", "alpha", "failed", "ops/stalled", "acme/ops", "Deploy failed", 90*time.Minute, time.Hour, 7, 11)
+	seedJob("merge-settled-failed", "alpha", "failed", "ops/merge-settled", "acme/ops", "Merge resolved failure", 90*time.Minute, time.Hour, 0, 0)
 	seedJob("finished-ok", "alpha", "succeeded", "release/done", "acme/app", "Release complete", 3*time.Hour, 2*time.Hour, 13, 17)
 	seedJob("finished-cancelled", "beta", "cancelled", "release/cancelled", "acme/app", "Cancelled experiment", 4*time.Hour, 3*time.Hour, 19, 23)
 	seedJob("finished-old", "alpha", "succeeded", "archive/old", "acme/app", "Old completion", 26*time.Hour, 25*time.Hour, 101, 103)
@@ -108,6 +109,12 @@ func TestDashboardOverviewTasksAndWorkflows(t *testing.T) {
 		db.WorkflowMeta{Author: "lead", Pane: "ops-pane", SessionID: "ops-session", WorkDir: "/work/ops"})
 	if err != nil {
 		t.Fatalf("InsertWorkflowNoteWithMeta: %v", err)
+	}
+	mergedReceipt, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: "ops/merge-settled", Author: db.WorkflowAutoNoteAuthor, Body: "[auto:pr:987:merged] PR #987 merged"},
+		db.WorkflowMeta{WorkflowID: "ops/merge-settled", Status: "PR #987 merged", StatusSet: true})
+	if err != nil || !inserted {
+		t.Fatalf("InsertWorkflowAutoNoteWithMeta = (inserted=%v, err=%v)", inserted, err)
 	}
 
 	seedTestPipeline(t, store, db.Pipeline{
@@ -144,6 +151,9 @@ func TestDashboardOverviewTasksAndWorkflows(t *testing.T) {
 	if _, err := raw.Exec(`UPDATE workflow_notes SET created_at = ? WHERE id = ?`, stamp(2*time.Hour), note.ID); err != nil {
 		t.Fatalf("update workflow note: %v", err)
 	}
+	if _, err := raw.Exec(`UPDATE workflow_notes SET created_at = ? WHERE id = ?`, stamp(45*time.Minute), mergedReceipt.ID); err != nil {
+		t.Fatalf("update merged workflow receipt: %v", err)
+	}
 	if err := raw.Close(); err != nil {
 		t.Fatalf("close raw DB: %v", err)
 	}
@@ -170,6 +180,11 @@ func TestDashboardOverviewTasksAndWorkflows(t *testing.T) {
 	}
 	if len(overview.NeedsYou) != 3 || overview.NeedsYou[0].Kind != "stalled_workflow" || overview.NeedsYou[0].Label != "ops/stalled" || overview.NeedsYou[0].Pane != "ops-pane" || overview.NeedsYou[1].Kind != "pr_awaiting_merge" || overview.NeedsYou[1].Ref != "#42" || overview.NeedsYou[2].Kind != "blocked_job" || overview.NeedsYou[2].Title != "waiting on deployment credentials" {
 		t.Fatalf("needs_you = %+v", overview.NeedsYou)
+	}
+	for _, item := range overview.NeedsYou {
+		if item.Kind == "stalled_workflow" && item.Label == "ops/merge-settled" {
+			t.Fatalf("merge-settled workflow appeared in needs_you: %+v", overview.NeedsYou)
+		}
 	}
 	if len(overview.Activity.Workflows) != 1 || overview.Activity.Workflows[0].Label != "fable/redesign" || overview.Activity.Workflows[0].Running != 1 || !reflect.DeepEqual(overview.Activity.Workflows[0].Agents, []string{"alpha", "beta"}) || overview.Activity.Queued != 1 || overview.Activity.UnattendedNote != "1 active job without a workflow label" {
 		t.Fatalf("activity = %+v", overview.Activity)

--- a/internal/cli/dashboard_web_workflow_test.go
+++ b/internal/cli/dashboard_web_workflow_test.go
@@ -34,6 +34,11 @@ func TestDeriveDashboardWorkflowState(t *testing.T) {
 		{name: "human note before failure does not acknowledge", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-40 * time.Minute), LastFailure: now.Add(-40 * time.Minute), LastHumanNote: now.Add(-2 * time.Hour)}, state: "stalled", stalled: 40 * 60},
 		{name: "daemon note after failure does not acknowledge", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-40 * time.Minute), LastFailure: now.Add(-1 * time.Hour)}, state: "stalled", stalled: 40 * 60},
 		{name: "human note after failure acknowledges", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-31 * time.Minute), LastFailure: now.Add(-1 * time.Hour), LastHumanNote: now.Add(-31 * time.Minute)}, state: "settled"},
+		{name: "merged receipt after failure acknowledges", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-1 * time.Hour), LastFailure: now.Add(-2 * time.Hour), LastMergedReceipt: now.Add(-1 * time.Hour)}, state: "settled"},
+		{name: "merged receipt before failure does not acknowledge", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-1 * time.Hour), LastFailure: now.Add(-1 * time.Hour), LastMergedReceipt: now.Add(-2 * time.Hour)}, state: "stalled", stalled: 60 * 60},
+		{name: "merged receipt tied with failure acknowledges", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-1 * time.Hour), LastFailure: now.Add(-1 * time.Hour), LastMergedReceipt: now.Add(-1 * time.Hour)}, state: "settled"},
+		{name: "merged receipt acknowledges blocked workflow", activity: dashboardWorkflowActivity{Blocked: 1, LastActivity: now.Add(-1 * time.Hour), LastFailure: now.Add(-2 * time.Hour), LastMergedReceipt: now.Add(-1 * time.Hour)}, state: "settled"},
+		{name: "merged receipt without failure remains settled", activity: dashboardWorkflowActivity{LastActivity: now.Add(-1 * time.Hour), LastMergedReceipt: now.Add(-1 * time.Hour)}, state: "settled"},
 		{name: "failure without timestamp is settled", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-31 * time.Minute)}, state: "settled"},
 		{name: "successful quiet is settled", activity: dashboardWorkflowActivity{LastActivity: now.Add(-45 * time.Minute)}, state: "settled"},
 		{name: "stalled ages out at horizon", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-24 * time.Hour), LastFailure: now.Add(-24 * time.Hour)}, state: "settled"},
@@ -531,6 +536,46 @@ func TestDashboardWorkflowDaemonNotesDoNotAcknowledgeFailuresOrImpersonateCoordi
 	}
 	if detail.State != "stalled" || detail.Coordinator.Author != "coordinator" {
 		t.Fatalf("detail = %+v; want stalled workflow with human coordinator", detail)
+	}
+
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	merged, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: label, Author: db.WorkflowAutoNoteAuthor, Body: "[auto:pr:958:merged] PR #958 merged"},
+		db.WorkflowMeta{WorkflowID: label, Status: "PR #958 merged", StatusSet: true})
+	if err != nil || !inserted {
+		t.Fatalf("Insert merged daemon note = (inserted=%v, err=%v)", inserted, err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close reopened store: %v", err)
+	}
+	raw, err = sql.Open("sqlite", paths.Database)
+	if err != nil {
+		t.Fatalf("reopen raw DB: %v", err)
+	}
+	if _, err := raw.Exec(`UPDATE workflow_notes SET created_at = ? WHERE id = ?`, format(now.Add(-40*time.Minute)), merged.ID); err != nil {
+		t.Fatalf("UPDATE merged workflow note: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close reopened raw DB: %v", err)
+	}
+
+	entries, err = ds.Workflows(ctx)
+	if err != nil {
+		t.Fatalf("Workflows after merged receipt: %v", err)
+	}
+	entry = workflowIndexEntryByLabel(t, entries, label)
+	if entry.State != "settled" || entry.StalledForS != 0 {
+		t.Fatalf("index entry after merged receipt = %+v; want settled workflow", entry)
+	}
+	detail, err = ds.Workflow(ctx, label, dashboard.WorkflowQuery{})
+	if err != nil {
+		t.Fatalf("Workflow after merged receipt: %v", err)
+	}
+	if detail.State != "settled" || detail.StalledForS != 0 {
+		t.Fatalf("detail after merged receipt = %+v; want settled workflow", detail)
 	}
 }
 

--- a/internal/cli/dashboard_web_workflows.go
+++ b/internal/cli/dashboard_web_workflows.go
@@ -31,6 +31,16 @@ type dashboardWorkflowActivity struct {
 	LastMergedReceipt time.Time
 }
 
+func dashboardActivityFromSummary(summary db.WorkflowSummary, lastAt int64) dashboardWorkflowActivity {
+	return dashboardWorkflowActivity{
+		Queued: summary.Queued, Running: summary.Running, Failed: summary.Failed,
+		Blocked: summary.Blocked, LastActivity: workflowMillisTime(lastAt),
+		LastFailure:       workflowMillisTime(parseJobTimeMillis(summary.LastFailureAt)),
+		LastHumanNote:     workflowMillisTime(parseJobTimeMillis(summary.LastHumanNoteAt)),
+		LastMergedReceipt: workflowMillisTime(parseJobTimeMillis(summary.LastMergedReceiptAt)),
+	}
+}
+
 // deriveDashboardWorkflowState is the single lifecycle definition shared by
 // workflow index and detail responses.
 func deriveDashboardWorkflowState(now time.Time, activity dashboardWorkflowActivity) (state string, stalledForS int64) {
@@ -43,9 +53,11 @@ func deriveDashboardWorkflowState(now time.Time, activity dashboardWorkflowActiv
 	// that receipt is therefore acknowledged; the bias is bounded by the poll
 	// interval, the same as a human note. A failure newer than the receipt
 	// re-stalls the workflow.
-	humanAcknowledges := !activity.LastHumanNote.IsZero() && !activity.LastHumanNote.Before(activity.LastFailure)
-	mergedReceiptAcknowledges := !activity.LastMergedReceipt.IsZero() && !activity.LastMergedReceipt.Before(activity.LastFailure)
-	failureUnacknowledged := !activity.LastFailure.IsZero() && !humanAcknowledges && !mergedReceiptAcknowledges
+	ackAt := activity.LastHumanNote
+	if activity.LastMergedReceipt.After(ackAt) {
+		ackAt = activity.LastMergedReceipt
+	}
+	failureUnacknowledged := !activity.LastFailure.IsZero() && (ackAt.IsZero() || ackAt.Before(activity.LastFailure))
 	if (activity.Failed > 0 || activity.Blocked > 0) && failureUnacknowledged &&
 		age > dashboardWorkflowActiveWindow && age < dashboardWorkflowStalledHorizon {
 		return "stalled", max(0, int64(age/time.Second))
@@ -126,13 +138,7 @@ func dashboardWorkflowEntries(ctx context.Context, store *db.Store, now time.Tim
 
 func dashboardWorkflowEntry(now time.Time, summary db.WorkflowSummary, meta db.WorkflowMeta, repos []string) dashboardWorkflowAPIEntry {
 	lastAt := parseJobTimeMillis(summary.LastAt)
-	state, stalledFor := deriveDashboardWorkflowState(now, dashboardWorkflowActivity{
-		Queued: summary.Queued, Running: summary.Running, Failed: summary.Failed,
-		Blocked: summary.Blocked, LastActivity: workflowMillisTime(lastAt),
-		LastFailure:       workflowMillisTime(parseJobTimeMillis(summary.LastFailureAt)),
-		LastHumanNote:     workflowMillisTime(parseJobTimeMillis(summary.LastHumanNoteAt)),
-		LastMergedReceipt: workflowMillisTime(parseJobTimeMillis(summary.LastMergedReceiptAt)),
-	})
+	state, stalledFor := deriveDashboardWorkflowState(now, dashboardActivityFromSummary(summary, lastAt))
 	author := strings.TrimSpace(meta.Author)
 	if author == "" {
 		author = strings.TrimSpace(summary.LastHumanAuthor)

--- a/internal/cli/dashboard_web_workflows.go
+++ b/internal/cli/dashboard_web_workflows.go
@@ -23,11 +23,12 @@ const (
 type dashboardWorkflowActivity struct {
 	Queued, Running, Failed, Blocked int
 	LastActivity                     time.Time
-	// LastFailure/LastHumanNote drive the acknowledgment rule: a failure is only
-	// an alarm while no human journal note has been written AFTER it. Daemon PR
-	// receipts remain ordinary activity but cannot acknowledge an alarm.
-	LastFailure   time.Time
-	LastHumanNote time.Time
+	// LastFailure, LastHumanNote, and LastMergedReceipt drive the acknowledgment
+	// rule. Ordinary daemon PR receipts remain activity, but a merged receipt may
+	// acknowledge an alarm like a human journal note.
+	LastFailure       time.Time
+	LastHumanNote     time.Time
+	LastMergedReceipt time.Time
 }
 
 // deriveDashboardWorkflowState is the single lifecycle definition shared by
@@ -37,8 +38,14 @@ func deriveDashboardWorkflowState(now time.Time, activity dashboardWorkflowActiv
 	if activity.Queued > 0 || activity.Running > 0 {
 		return "active", 0
 	}
-	failureUnacknowledged := !activity.LastFailure.IsZero() &&
-		(activity.LastHumanNote.IsZero() || activity.LastHumanNote.Before(activity.LastFailure))
+	// A merged receipt records the daemon's observation time (note created_at),
+	// not the true GitHub merge time. A failure landing in the poll window before
+	// that receipt is therefore acknowledged; the bias is bounded by the poll
+	// interval, the same as a human note. A failure newer than the receipt
+	// re-stalls the workflow.
+	humanAcknowledges := !activity.LastHumanNote.IsZero() && !activity.LastHumanNote.Before(activity.LastFailure)
+	mergedReceiptAcknowledges := !activity.LastMergedReceipt.IsZero() && !activity.LastMergedReceipt.Before(activity.LastFailure)
+	failureUnacknowledged := !activity.LastFailure.IsZero() && !humanAcknowledges && !mergedReceiptAcknowledges
 	if (activity.Failed > 0 || activity.Blocked > 0) && failureUnacknowledged &&
 		age > dashboardWorkflowActiveWindow && age < dashboardWorkflowStalledHorizon {
 		return "stalled", max(0, int64(age/time.Second))
@@ -122,8 +129,9 @@ func dashboardWorkflowEntry(now time.Time, summary db.WorkflowSummary, meta db.W
 	state, stalledFor := deriveDashboardWorkflowState(now, dashboardWorkflowActivity{
 		Queued: summary.Queued, Running: summary.Running, Failed: summary.Failed,
 		Blocked: summary.Blocked, LastActivity: workflowMillisTime(lastAt),
-		LastFailure:   workflowMillisTime(parseJobTimeMillis(summary.LastFailureAt)),
-		LastHumanNote: workflowMillisTime(parseJobTimeMillis(summary.LastHumanNoteAt)),
+		LastFailure:       workflowMillisTime(parseJobTimeMillis(summary.LastFailureAt)),
+		LastHumanNote:     workflowMillisTime(parseJobTimeMillis(summary.LastHumanNoteAt)),
+		LastMergedReceipt: workflowMillisTime(parseJobTimeMillis(summary.LastMergedReceiptAt)),
 	})
 	author := strings.TrimSpace(meta.Author)
 	if author == "" {

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -72,13 +72,14 @@ type WorkflowSummary struct {
 	LastNote     string `json:"last_note,omitempty"`
 	LastAuthor   string `json:"last_author,omitempty"`
 	// LastNote and LastAuthor describe the literal latest journal entry, including
-	// daemon receipts. LastFailureAt/LastHumanNoteAt let the dashboard apply the
-	// acknowledgment rule: daemon lifecycle receipts remain activity, but only a
-	// non-daemon note acknowledges a failure.
-	LastFailureAt   string `json:"last_failure_at,omitempty"`
-	LastNoteAt      string `json:"last_note_at,omitempty"`
-	LastHumanAuthor string `json:"last_human_author,omitempty"`
-	LastHumanNoteAt string `json:"last_human_note_at,omitempty"`
+	// daemon receipts. LastFailureAt/LastHumanNoteAt/LastMergedReceiptAt let the
+	// dashboard apply the acknowledgment rule: daemon lifecycle receipts remain
+	// activity, but merged daemon receipts may acknowledge like human notes.
+	LastFailureAt       string `json:"last_failure_at,omitempty"`
+	LastNoteAt          string `json:"last_note_at,omitempty"`
+	LastHumanAuthor     string `json:"last_human_author,omitempty"`
+	LastHumanNoteAt     string `json:"last_human_note_at,omitempty"`
+	LastMergedReceiptAt string `json:"last_merged_receipt_at,omitempty"`
 }
 
 // Exported query constants keep production SQL and EXPLAIN regression tests on
@@ -87,6 +88,9 @@ const ListWorkflowNotesSQL = `SELECT id, workflow_id, author, body, repo, memory
 FROM workflow_notes INDEXED BY idx_workflow_notes_wid
 WHERE workflow_id = ? ORDER BY created_at, id LIMIT ?`
 
+// SQLite LIKE is ASCII-case-insensitive but harmless here: the sole writer path
+// (InsertWorkflowAutoNoteWithMeta) validates the lowercase "[auto:pr:" prefix,
+// and the anchored ":merged]" excludes opened/ready/closed receipts.
 const workflowSummarySelectSQL = `WITH job_summary AS (
 	SELECT j.workflow_id,
 		COUNT(*) AS job_count,
@@ -118,7 +122,8 @@ const workflowSummarySelectSQL = `WITH job_summary AS (
 		COALESCE((SELECT latest.author FROM workflow_notes latest
 			WHERE latest.workflow_id = n.workflow_id AND latest.author != 'daemon'
 			ORDER BY latest.created_at DESC, latest.id DESC LIMIT 1), '') AS last_human_author,
-		MAX(CASE WHEN n.author != 'daemon' THEN n.created_at END) AS last_human_at
+		MAX(CASE WHEN n.author != 'daemon' THEN n.created_at END) AS last_human_at,
+		MAX(CASE WHEN n.author = 'daemon' AND n.body LIKE '[auto:pr:%:merged]%' THEN n.created_at END) AS last_merged_at
 	FROM workflow_notes n INDEXED BY idx_workflow_notes_wid
 	GROUP BY n.workflow_id
 ), labels AS (
@@ -142,7 +147,7 @@ SELECT labels.workflow_id,
 		WHEN j.last_at >= n.last_at THEN j.last_at ELSE n.last_at
 	END AS last_at,
 	COALESCE(n.last_note, ''), COALESCE(n.last_author, ''), COALESCE(n.last_human_author, ''),
-	COALESCE(j.last_failure_at, ''), COALESCE(n.last_at, ''), COALESCE(n.last_human_at, '')
+	COALESCE(j.last_failure_at, ''), COALESCE(n.last_at, ''), COALESCE(n.last_human_at, ''), COALESCE(n.last_merged_at, '')
 FROM labels
 LEFT JOIN job_summary j ON j.workflow_id = labels.workflow_id
 LEFT JOIN note_summary n ON n.workflow_id = labels.workflow_id`
@@ -656,7 +661,7 @@ func (s *Store) ListWorkflowSummaries(ctx context.Context) ([]WorkflowSummary, e
 			&item.Succeeded, &item.Failed, &item.Blocked, &item.Cancelled,
 			&item.InputTokens, &item.OutputTokens, &item.NoteCount, &item.FirstAt, &item.LastAt,
 			&item.LastNote, &item.LastAuthor, &item.LastHumanAuthor, &item.LastFailureAt,
-			&item.LastNoteAt, &item.LastHumanNoteAt); err != nil {
+			&item.LastNoteAt, &item.LastHumanNoteAt, &item.LastMergedReceiptAt); err != nil {
 			return nil, err
 		}
 		out = append(out, item)
@@ -752,7 +757,8 @@ func (s *Store) WorkflowSummary(ctx context.Context, workflowID string) (Workflo
 		&item.WorkflowID, &item.JobCount, &item.Queued, &item.Running, &item.Succeeded,
 		&item.Failed, &item.Blocked, &item.Cancelled, &item.InputTokens,
 		&item.OutputTokens, &item.NoteCount, &firstAt, &lastAt, &item.LastNote, &item.LastAuthor,
-		&item.LastHumanAuthor, &item.LastFailureAt, &item.LastNoteAt, &item.LastHumanNoteAt)
+		&item.LastHumanAuthor, &item.LastFailureAt, &item.LastNoteAt, &item.LastHumanNoteAt,
+		&item.LastMergedReceiptAt)
 	if err != nil {
 		return WorkflowSummary{}, err
 	}

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -89,8 +89,9 @@ FROM workflow_notes INDEXED BY idx_workflow_notes_wid
 WHERE workflow_id = ? ORDER BY created_at, id LIMIT ?`
 
 // SQLite LIKE is ASCII-case-insensitive but harmless here: the sole writer path
-// (InsertWorkflowAutoNoteWithMeta) validates the lowercase "[auto:pr:" prefix,
-// and the anchored ":merged]" excludes opened/ready/closed receipts.
+// (InsertWorkflowAutoNoteWithMeta) validates the lowercase "[auto:pr:" prefix.
+// Matching only the first bracketed key keeps the anchored ":merged]" from
+// matching opened/ready/closed receipt prose.
 const workflowSummarySelectSQL = `WITH job_summary AS (
 	SELECT j.workflow_id,
 		COUNT(*) AS job_count,
@@ -123,7 +124,7 @@ const workflowSummarySelectSQL = `WITH job_summary AS (
 			WHERE latest.workflow_id = n.workflow_id AND latest.author != 'daemon'
 			ORDER BY latest.created_at DESC, latest.id DESC LIMIT 1), '') AS last_human_author,
 		MAX(CASE WHEN n.author != 'daemon' THEN n.created_at END) AS last_human_at,
-		MAX(CASE WHEN n.author = 'daemon' AND n.body LIKE '[auto:pr:%:merged]%' THEN n.created_at END) AS last_merged_at
+		MAX(CASE WHEN n.author = 'daemon' AND substr(n.body, 1, instr(n.body, ']')) LIKE '[auto:pr:%:merged]' THEN n.created_at END) AS last_merged_at
 	FROM workflow_notes n INDEXED BY idx_workflow_notes_wid
 	GROUP BY n.workflow_id
 ), labels AS (

--- a/internal/db/workflow_store_test.go
+++ b/internal/db/workflow_store_test.go
@@ -403,6 +403,7 @@ func TestWorkflowSummaryTracksMergedDaemonReceipt(t *testing.T) {
 	}{
 		{workflowID: "release/merged", author: WorkflowAutoNoteAuthor, body: "[auto:pr:958:merged] PR #958 merged", merged: true},
 		{workflowID: "release/closed", author: WorkflowAutoNoteAuthor, body: "[auto:pr:959:closed] PR #959 closed without merging"},
+		{workflowID: "release/closed-tail", author: WorkflowAutoNoteAuthor, body: "[auto:pr:961:closed] reverted; see note re :merged] state"},
 		{workflowID: "release/opened", author: WorkflowAutoNoteAuthor, body: "[auto:pr:960:opened] PR #960 opened"},
 		{workflowID: "release/human", author: "coordinator", body: "human handoff"},
 	}

--- a/internal/db/workflow_store_test.go
+++ b/internal/db/workflow_store_test.go
@@ -394,6 +394,58 @@ func TestWorkflowSummarySeparatesDaemonNotesFromHumanAcknowledgment(t *testing.T
 	}
 }
 
+func TestWorkflowSummaryTracksMergedDaemonReceipt(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	fixtures := []struct {
+		workflowID, author, body string
+		merged                   bool
+	}{
+		{workflowID: "release/merged", author: WorkflowAutoNoteAuthor, body: "[auto:pr:958:merged] PR #958 merged", merged: true},
+		{workflowID: "release/closed", author: WorkflowAutoNoteAuthor, body: "[auto:pr:959:closed] PR #959 closed without merging"},
+		{workflowID: "release/opened", author: WorkflowAutoNoteAuthor, body: "[auto:pr:960:opened] PR #960 opened"},
+		{workflowID: "release/human", author: "coordinator", body: "human handoff"},
+	}
+	for _, fixture := range fixtures {
+		if fixture.author == WorkflowAutoNoteAuthor {
+			if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+				WorkflowNote{WorkflowID: fixture.workflowID, Author: fixture.author, Body: fixture.body},
+				WorkflowMeta{WorkflowID: fixture.workflowID, Status: fixture.body, StatusSet: true}); err != nil || !inserted {
+				t.Fatalf("InsertWorkflowAutoNoteWithMeta(%q) = (inserted=%v, err=%v)", fixture.workflowID, inserted, err)
+			}
+			continue
+		}
+		if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: fixture.workflowID, Author: fixture.author, Body: fixture.body}); err != nil {
+			t.Fatalf("InsertWorkflowNote(%q): %v", fixture.workflowID, err)
+		}
+	}
+
+	listed, err := store.ListWorkflowSummaries(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowSummaries: %v", err)
+	}
+	listedByWorkflow := make(map[string]WorkflowSummary, len(listed))
+	for _, summary := range listed {
+		listedByWorkflow[summary.WorkflowID] = summary
+	}
+	for _, fixture := range fixtures {
+		listedSummary, ok := listedByWorkflow[fixture.workflowID]
+		if !ok {
+			t.Fatalf("ListWorkflowSummaries missing %q: %+v", fixture.workflowID, listed)
+		}
+		shownSummary, err := store.WorkflowSummary(ctx, fixture.workflowID)
+		if err != nil {
+			t.Fatalf("WorkflowSummary(%q): %v", fixture.workflowID, err)
+		}
+		if got, want := listedSummary.LastMergedReceiptAt != "", fixture.merged; got != want {
+			t.Fatalf("listed %q LastMergedReceiptAt = %q, want merged=%v", fixture.workflowID, listedSummary.LastMergedReceiptAt, want)
+		}
+		if got, want := shownSummary.LastMergedReceiptAt != "", fixture.merged; got != want {
+			t.Fatalf("shown %q LastMergedReceiptAt = %q, want merged=%v", fixture.workflowID, shownSummary.LastMergedReceiptAt, want)
+		}
+	}
+}
+
 func TestWorkflowMetaTextSetPreserveClearAndLimit(t *testing.T) {
 	store := openWorkflowTestStore(t)
 	ctx := context.Background()

--- a/internal/workflow/workflow_journal_test.go
+++ b/internal/workflow/workflow_journal_test.go
@@ -71,6 +71,34 @@ func TestHandleReviewPullRequestClosedJournalsWorkflowOnce(t *testing.T) {
 	}
 }
 
+func TestRecordPullRequestWorkflowTransitionSummaryTracksMergedReceipt(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		transition PullRequestJournalTransition
+		wantMerged bool
+	}{
+		{name: "merged", transition: PullRequestJournalMerged, wantMerged: true},
+		{name: "opened", transition: PullRequestJournalOpened},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := openEngineStore(t)
+			ctx := context.Background()
+			event := seedWorkflowJournalLifecycle(t, store, TaskReviewing)
+			inserted, err := RecordPullRequestWorkflowTransition(ctx, store, event, tc.transition)
+			if err != nil || !inserted {
+				t.Fatalf("RecordPullRequestWorkflowTransition = (inserted=%v, err=%v)", inserted, err)
+			}
+			summary, err := store.WorkflowSummary(ctx, "release/lifecycle")
+			if err != nil {
+				t.Fatalf("WorkflowSummary: %v", err)
+			}
+			if got := summary.LastMergedReceiptAt != ""; got != tc.wantMerged {
+				t.Fatalf("LastMergedReceiptAt = %q, want merged=%v", summary.LastMergedReceiptAt, tc.wantMerged)
+			}
+		})
+	}
+}
+
 func assertWorkflowJournalTransition(t *testing.T, store *db.Store, wantBody, wantStatus string) {
 	t.Helper()
 	ctx := context.Background()

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1164,12 +1164,16 @@ gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --st
 ```
 
 `workflow list` reports per-state counts, note count, first/last activity, and
-best-effort token totals. `workflow show` merges jobs and notes chronologically.
+best-effort token totals. Its JSON summary also includes the acknowledgment
+timestamps `last_failure_at`, `last_human_note_at`, and
+`last_merged_receipt_at`. `workflow show` merges jobs and notes chronologically.
 The read-only web dashboard shows labels as Galaxy hubs and provides a Workflows
 index plus a mission-log detail at `/workflows/<label>`. Workflows are `active`
 while queued/running, `recent` when no work is live but activity occurred within
-30 minutes, `stalled` when failed/blocked with an unacknowledged failure and quiet
-for 30 minutes to 24 hours, and `settled` otherwise. The optional
+30 minutes, `stalled` when failed/blocked with an unacknowledged failure (newer
+than any non-daemon journal note and any merged-PR daemon receipt; other daemon
+receipts never acknowledge) and quiet for 30 minutes to 24 hours, and `settled`
+otherwise. The optional
 `--pane`, `--session`, and `--workdir` note flags persist the latest coordinator
 handoff shown on that page. When those flags are omitted inside Herdr
 (`HERDR_SOCKET_PATH` or `HERDR_ENV=1`), `workflow note` reads the current pane

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -207,9 +207,11 @@ kickoff-note sentence, or the label campaign. The bundled frontend continues to
 receive the compatibility `summary` field until its separate rendering follow-up
 adopts the two new fields.
 A workflow is stalled only when a failure has gone **unacknowledged** — nothing
-is running, the goal was not reached, and no journal note has been written
-since the last failure (a failure alone is not an alarm; the silence after it
-is). Stalled entries age into settled history after a day of silence.
+is running, the goal was not reached, and neither a journal note from anyone but
+the daemon nor a merged-PR daemon receipt has landed since the last failure
+(a failure alone is not an alarm; the silence after it is; other daemon receipts
+such as `opened` or `closed` never acknowledge). Stalled entries age into
+settled history after a day of silence.
 
 The **detail page** reads as a mission log: journal notes and run trees
 interleaved in reverse-chronological order — the coordinator's intent next to

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6744,9 +6744,11 @@ kickoff-note sentence, or the label campaign. The bundled frontend continues to
 receive the compatibility `summary` field until its separate rendering follow-up
 adopts the two new fields.
 A workflow is stalled only when a failure has gone **unacknowledged** — nothing
-is running, the goal was not reached, and no journal note has been written
-since the last failure (a failure alone is not an alarm; the silence after it
-is). Stalled entries age into settled history after a day of silence.
+is running, the goal was not reached, and neither a journal note from anyone but
+the daemon nor a merged-PR daemon receipt has landed since the last failure
+(a failure alone is not an alarm; the silence after it is; other daemon receipts
+such as `opened` or `closed` never acknowledge). Stalled entries age into
+settled history after a day of silence.
 
 The **detail page** reads as a mission log: journal notes and run trees
 interleaved in reverse-chronological order — the coordinator's intent next to
@@ -10545,12 +10547,16 @@ gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --st
 ```
 
 `workflow list` reports per-state counts, note count, first/last activity, and
-best-effort token totals. `workflow show` merges jobs and notes chronologically.
+best-effort token totals. Its JSON summary also includes the acknowledgment
+timestamps `last_failure_at`, `last_human_note_at`, and
+`last_merged_receipt_at`. `workflow show` merges jobs and notes chronologically.
 The read-only web dashboard shows labels as Galaxy hubs and provides a Workflows
 index plus a mission-log detail at `/workflows/<label>`. Workflows are `active`
 while queued/running, `recent` when no work is live but activity occurred within
-30 minutes, `stalled` when failed/blocked with an unacknowledged failure and quiet
-for 30 minutes to 24 hours, and `settled` otherwise. The optional
+30 minutes, `stalled` when failed/blocked with an unacknowledged failure (newer
+than any non-daemon journal note and any merged-PR daemon receipt; other daemon
+receipts never acknowledge) and quiet for 30 minutes to 24 hours, and `settled`
+otherwise. The optional
 `--pane`, `--session`, and `--workdir` note flags persist the latest coordinator
 handoff shown on that page. When those flags are omitted inside Herdr
 (`HERDR_SOCKET_PATH` or `HERDR_ENV=1`), `workflow note` reads the current pane


### PR DESCRIPTION
Closes #987.

A workflow whose latest daemon `[auto:pr:N:merged]` receipt is newer than its last failure now derives state **settled** instead of **stalled** when nothing is queued or running (the live symptom: `gitmoot6/keycard-registry-874` rendered stalled next to status "PR #975 merged" for 24h). Failures newer than the merge receipt still stall. Display-only — no engine semantics, and the pinned frontend module contract is untouched (`last_merged_receipt_at` lives only on `db.WorkflowSummary`, so `workflow list/show --json` gain it automatically).

## Design (tri-model panel-reviewed: gpt-5.6-sol + kimi k3)
- `workflow_store`: `last_merged_receipt_at` aggregate — `MAX(created_at)` over daemon notes whose **first bracketed key** matches `[auto:pr:%:merged]` (`substr`/`instr` extraction so `:merged]` in receipt prose can never match); wired through both positional scans.
- `deriveDashboardWorkflowState`: a merged receipt acknowledges like a human note (`>=` tie, mirroring the existing rule); single `ackAt` = later of last human note / merged receipt; index + detail share one `dashboardActivityFromSummary` mapper.
- Overview needs-you inherits the fix via `dashboardWorkflowEntries`.

## Known, accepted limitations (panel + /code-review high verdicts)
- The receipt timestamp is the daemon's **observation** time, not the true GitHub merge time: after daemon downtime, a catch-up receipt can acknowledge a failure that post-dates the real merge. No merge timestamp is stored today; documented in a code comment (same bias as a human note written at receipt time).
- Acknowledgment is **workflow-scoped**, not PR-scoped — exactly the semantics #987 proposes, mirroring the existing human-note rule; blocked jobs keep their independent needs-you surface.

## Tests
- Derive table: receipt after/before failure, exact-tie (pins `>=`), blocked-only workflow, receipt-without-failure.
- Daemon-notes regression keeps the `:closed` negative fixture; merged receipt settles index + detail.
- Store level: both scan sites return the field; `:closed`/`:opened`/human and a `:merged]`-in-prose body leave it empty.
- Cross-seam: `RecordPullRequestWorkflowTransition` (the real writer) → `WorkflowSummary.LastMergedReceiptAt`, pinning writer format to reader SQL.
- Overview: merge-settled workflow excluded from needs-you; Today digest assertions extended for the new seed.

## Docs (ship with code)
`skills/gitmoot/references/CLI.md`, `website/docs/dashboard/views.md` (stalled definition now names the non-daemon-note OR merged-receipt rule), regenerated `llms-full.txt`.

## Verification
Full local gate green (build / generate+diff / vet / `go test ./...`). Scoped race: db+daemon+workflow green; the serial `internal/cli` race lane exceeded the 35m binary timeout on the busy box with no DATA RACE reported before the cut — re-running standalone; CI's sharded race lanes are the authoritative verdict per repo policy.

## Deploy notes
Dashboard datasource only — needs the standard two-binary deploy (`gitmoot` + `gitmoot-dashboard-web`) and a restart of both services at idle. Verify with `curl -s http://172.17.0.1:8790/api/workflows` — a quiet workflow whose `last_note` is a merged receipt newer than its last failure should read `"state":"settled"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)