### PR TITLE
fix(daemon): resume a dead implement job's own dirty worktree instead of failing it (#994)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -87,11 +87,16 @@ planned tasks. `task run` starts one task branch in a dedicated worktree,
 records its branch lock, and stores the worktree path on the task.
 
 If an implementer dies mid-work — after editing the task worktree but before it
-commits, pushes, and opens a PR — the edits are left uncommitted. `task run`
-(and `agent implement`) refuse to restart over a dirty worktree with no active
-job, rather than silently discard the work, and point at `task recover <id>
---owner <agent>`. `task recover` commits the full worktree state (`git add -A`,
-including untracked non-ignored files), pushes the branch, and opens or adopts
+commits, pushes, and opens a PR — the edits are left uncommitted. A retry of that
+same implement job re-delivers into its recorded task worktree when both the
+worktree process probe and runtime-owner lease prove the prior attempt is dead;
+the prompt tells the agent to review and preserve the uncommitted work, and the
+normal finalizer commits it. A live worktree, a dirty registered/other checkout,
+or an exhausted retry budget still blocks. A new `task run` (or `agent implement`)
+refuses a dirty worktree with no active job rather than silently discard the work,
+and points at `task recover <id> --owner <agent>`. `task recover` commits the
+full worktree state (`git add -A`, including untracked non-ignored files), pushes
+the branch, and opens or adopts
 the task's PR — the finalize steps the dead implementer never reached. `--repo`
 is optional (it falls back to the task's stored repo). `--owner` is required for
 this artifact-finalization path, while a dismissed task with no branch can be

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5141,24 +5141,28 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	}
 	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
 	if err != nil {
-		// Checkout-contention deferral (#532 slice C): a NON-delegation job whose
-		// daemon pre-flight checkout failed on a classified contention string (a
-		// branch-lock conflict that self-heals, or a dirty/wrong-head checkout that
-		// needs a human) is HELD with a backoff instead of terminally failing —
-		// pre-terminal, so no job.failed precedes the additive job.deferred. Every
-		// other checkout error (and every delegation child) falls through to the
-		// existing terminal path byte-identically.
-		if deferred, deferErr := w.deferCheckoutContention(ctx, job, payload, err); deferErr != nil {
-			writeLine(w.Stdout, "job %s checkout-contention deferral failed: %v", job.ID, deferErr)
-		} else if deferred {
-			writeLine(w.Stdout, "job %s deferred on checkout contention: %v", job.ID, err)
+		if resumedCheckout, resumedPayload, ok := w.resumeSelfDirtyWorktree(ctx, job, payload, agent, err); ok {
+			checkout, payload, err = resumedCheckout, resumedPayload, nil
+		} else {
+			// Checkout-contention deferral (#532 slice C): a NON-delegation job whose
+			// daemon pre-flight checkout failed on a classified contention string (a
+			// branch-lock conflict that self-heals, or a dirty/wrong-head checkout that
+			// needs a human) is HELD with a backoff instead of terminally failing —
+			// pre-terminal, so no job.failed precedes the additive job.deferred. Every
+			// other checkout error (and every delegation child) falls through to the
+			// existing terminal path byte-identically.
+			if deferred, deferErr := w.deferCheckoutContention(ctx, job, payload, err); deferErr != nil {
+				writeLine(w.Stdout, "job %s checkout-contention deferral failed: %v", job.ID, deferErr)
+			} else if deferred {
+				writeLine(w.Stdout, "job %s deferred on checkout contention: %v", job.ID, err)
+				return nil
+			}
+			if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
+				return finishErr
+			}
+			_ = w.postJobResultComment(ctx, job.ID, agent, "", err)
 			return nil
 		}
-		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
-			return finishErr
-		}
-		_ = w.postJobResultComment(ctx, job.ID, agent, "", err)
-		return nil
 	}
 	// #732 moot-seat relay injection: a `gitmoot moot` SEAT (payload.MootSeat) must
 	// converse via `gitmoot chat send/wait` mid-run, but its runtime sandbox makes

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -2792,6 +2792,124 @@ func TestRunQueuedJobsUsesTaskWorktreeForImplement(t *testing.T) {
 	}
 }
 
+func TestRunQueuedJobsResumesSelfDirtyTaskWorktree(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	worktree := filepath.Join(t.TempDir(), "task-resume")
+	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-resume", worktree, "main")
+	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	completedWork := filepath.Join(worktree, "completed-work.txt")
+	if err := os.WriteFile(completedWork, []byte("completed before runtime death\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile completed work returned error: %v", err)
+	}
+
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-resume",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-1",
+		Title:        "Resume completed work",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "task-resume",
+		WorktreePath: worktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-resume", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:           "job-resume-dirty",
+		Agent:        "lead",
+		Action:       "implement",
+		Repo:         "owner/repo",
+		Branch:       "task-resume",
+		HeadSHA:      head,
+		GoalID:       "goal-1",
+		TaskID:       "task-resume",
+		TaskTitle:    "Resume completed work",
+		Instructions: "Finish the implementation.",
+	})
+
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"prior work is complete","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	adapterCheckout := ""
+	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
+		adapterCheckout = checkout
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+
+	if adapter.calls != 1 {
+		t.Fatalf("adapter calls = %d, want 1 resumed delivery", adapter.calls)
+	}
+	wantCheckout, err := normalizeTaskWorktreePath(worktree)
+	if err != nil {
+		t.Fatalf("normalizeTaskWorktreePath returned error: %v", err)
+	}
+	if adapterCheckout != wantCheckout {
+		t.Fatalf("adapter checkout = %q, want task worktree %q", adapterCheckout, wantCheckout)
+	}
+	if len(adapter.prompts) != 1 || !strings.Contains(adapter.prompts[0], "COMPLETED work that is present but UNCOMMITTED") {
+		t.Fatalf("delivered prompt missing self-dirty resume notice: %q", adapter.prompts)
+	}
+	if strings.Contains(adapter.prompts[0], "NOTE (operational retry") || strings.Contains(adapter.prompts[0], "pushed branches") {
+		t.Fatalf("delivered prompt carried generic operational-blocker reconciliation notice: %q", adapter.prompts[0])
+	}
+
+	job, err := store.GetJob(ctx, "job-resume-dirty")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if !payload.ResumedSelfDirtyWorktree {
+		t.Fatalf("payload does not mark resumed self-dirty worktree: %+v", payload)
+	}
+	if payload.BlockerAttempts != 1 || payload.BlockerRetryAt != "" || !payload.BlockerPreDelivery {
+		t.Fatalf("resume blocker fields = attempts=%d retry_at=%q pre_delivery=%v", payload.BlockerAttempts, payload.BlockerRetryAt, payload.BlockerPreDelivery)
+	}
+	if payload.HeadSHA != head {
+		t.Fatalf("payload head = %q, want original base %q", payload.HeadSHA, head)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	resumedEvent := false
+	failedEvent := false
+	for _, event := range events {
+		resumedEvent = resumedEvent || event.Kind == "worktree_resumed"
+		failedEvent = failedEvent || event.Kind == string(workflow.JobFailed) || event.Kind == "job.failed"
+	}
+	if !resumedEvent {
+		t.Fatalf("job events missing worktree_resumed: %+v", events)
+	}
+	if failedEvent {
+		t.Fatalf("resumed job recorded a failure event: %+v", events)
+	}
+	contents, err := os.ReadFile(completedWork)
+	if err != nil {
+		t.Fatalf("prior completed work did not survive re-delivery: %v", err)
+	}
+	if string(contents) != "completed before runtime death\n" {
+		t.Fatalf("prior completed work changed during resume: %q", contents)
+	}
+}
+
 func TestValidateTargetCheckoutSkipsHeadShaForDelegationWorktreeChild(t *testing.T) {
 	// A delegated implement child runs in its own freshly-allocated worktree whose
 	// HEAD is the base-branch tip at allocation time; the dispatcher clears the
@@ -6169,6 +6287,7 @@ type cliWorkerFakeAdapter struct {
 	startCheckouts       []string
 	calls                int
 	delivered            []string
+	prompts              []string
 	onStart              func()
 	onDeliver            func()
 	waitForContextCancel bool
@@ -6205,6 +6324,7 @@ func (f *cliWorkerFakeAdapter) Deliver(ctx context.Context, _ runtime.Agent, job
 	f.mu.Lock()
 	f.calls++
 	f.delivered = append(f.delivered, job.ID)
+	f.prompts = append(f.prompts, job.Prompt)
 	onDeliver := f.onDeliver
 	waitForContextCancel := f.waitForContextCancel
 	f.mu.Unlock()

--- a/internal/cli/job_resume_worktree.go
+++ b/internal/cli/job_resume_worktree.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// resumeSelfDirtyWorktree recognizes one narrowly-owned checkout-contention
+// case: a queued, top-level implement job being retried into its own dirty task
+// worktree after the prior runtime owner died. It bypasses only the dirty
+// pre-flight guard; every predicate miss or probe/persistence error returns false
+// so jobWorker.run takes the existing checkout-contention path unchanged.
+func (w jobWorker) resumeSelfDirtyWorktree(ctx context.Context, job db.Job, payload workflow.JobPayload, agent runtime.Agent, cause error) (string, workflow.JobPayload, bool) {
+	kind, _ := classifyCheckoutContention(cause)
+	if kind != checkoutContentionDirty || cause == nil || !strings.Contains(cause.Error(), "has uncommitted changes") {
+		return "", payload, false
+	}
+	if job.Type != "implement" || job.State != string(workflow.JobQueued) {
+		return "", payload, false
+	}
+	if strings.TrimSpace(payload.ParentJobID) != "" || strings.TrimSpace(payload.DelegationID) != "" {
+		return "", payload, false
+	}
+	if strings.TrimSpace(payload.WorktreePath) != "" || strings.TrimSpace(payload.TaskID) == "" || w.Store == nil {
+		return "", payload, false
+	}
+
+	task, err := w.Store.GetTask(ctx, payload.TaskID)
+	if err != nil || strings.TrimSpace(task.WorktreePath) == "" {
+		return "", payload, false
+	}
+	if task.RepoFullName != payload.Repo || task.Branch != payload.Branch {
+		return "", payload, false
+	}
+	resolvedCheckout, ok, err := w.taskWorktreeCheckout(ctx, payload)
+	if err != nil || !ok || resolvedCheckout == "" {
+		return "", payload, false
+	}
+	normalizedTaskWorktree, err := normalizeTaskWorktreePath(task.WorktreePath)
+	if err != nil || normalizedTaskWorktree == "" || !sameCheckoutPath(resolvedCheckout, normalizedTaskWorktree) {
+		return "", payload, false
+	}
+
+	// The normal checkout validator reports dirtiness before checking HEAD, then
+	// defaultCheckout checks the unconditional implementation branch lock. Since
+	// this recovery path bypasses only that dirty result, positively re-establish
+	// both later invariants before allowing delivery.
+	expectedHead := strings.TrimSpace(payload.HeadSHA)
+	if expectedHead == "" {
+		return "", payload, false
+	}
+	head, err := (gitutil.Client{Dir: resolvedCheckout}).HeadSHA(ctx)
+	if err != nil || head != expectedHead {
+		return "", payload, false
+	}
+	if err := w.validateImplementationLock(ctx, payload, implementationLockOwner(agent, payload)); err != nil {
+		return "", payload, false
+	}
+
+	// Never re-deliver into a worktree that may still have an owner. The process
+	// probe is the lock-independent gate; the runtime lease covers a worker whose
+	// cwd is not observable. Any indeterminate process or lease state fails closed.
+	live, known := taskWorktreeLiveness(resolvedCheckout)
+	if live || !known {
+		return "", payload, false
+	}
+	leaseHeld, err := runtimeOwnerLeaseHeld(ctx, w.Store, job.ID, time.Now().UTC())
+	if err != nil || leaseHeld {
+		return "", payload, false
+	}
+
+	if payload.BlockerAttempts < 0 || payload.BlockerAttempts >= maxOperationalBlockerRetries {
+		return "", payload, false
+	}
+	attempt := payload.BlockerAttempts + 1
+	resumed := payload
+	resumed.BlockerClass = string(blockerClassCheckoutContention)
+	resumed.BlockerAttempts = attempt
+	resumed.BlockerRetryAt = ""
+	resumed.BlockerSuggestedAction = ""
+	resumed.BlockerPreDelivery = true
+	resumed.ResumedSelfDirtyWorktree = true
+	encoded, err := json.Marshal(resumed)
+	if err != nil {
+		return "", payload, false
+	}
+	if err := w.Store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		return "", payload, false
+	}
+	message := fmt.Sprintf("%s: attempt %d/%d; prior attempt's completed work present uncommitted; re-delivering",
+		resolvedCheckout, attempt, maxOperationalBlockerRetries)
+	if err := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "worktree_resumed", Message: message}); err != nil {
+		return "", payload, false
+	}
+	return resolvedCheckout, resumed, true
+}

--- a/internal/cli/job_resume_worktree_test.go
+++ b/internal/cli/job_resume_worktree_test.go
@@ -1,0 +1,545 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+type selfDirtyResumeFixture struct {
+	store         *db.Store
+	worktree      string
+	completedWork string
+	head          string
+	adapter       *cliWorkerFakeAdapter
+	worker        jobWorker
+}
+
+func newSelfDirtyResumeFixture(t *testing.T, jobID string) selfDirtyResumeFixture {
+	return newSelfDirtyResumeFixtureWithLockOwner(t, jobID, "lead")
+}
+
+func newSelfDirtyResumeFixtureWithLockOwner(t *testing.T, jobID string, lockOwner string) selfDirtyResumeFixture {
+	t.Helper()
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	worktree := filepath.Join(t.TempDir(), "task-resume")
+	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-resume", worktree, "main")
+	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	completedWork := filepath.Join(worktree, "completed-work.txt")
+	if err := os.WriteFile(completedWork, []byte("completed before runtime death\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile completed work returned error: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-resume",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-1",
+		Title:        "Resume completed work",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "task-resume",
+		WorktreePath: worktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if lockOwner != "" {
+		if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-resume", Owner: lockOwner}); err != nil || !acquired {
+			t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+		}
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID:           jobID,
+		Agent:        "lead",
+		Action:       "implement",
+		Repo:         "owner/repo",
+		Branch:       "task-resume",
+		HeadSHA:      head,
+		GoalID:       "goal-1",
+		TaskID:       "task-resume",
+		TaskTitle:    "Resume completed work",
+		Instructions: "Finish the implementation.",
+	})
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store}
+	}
+	return selfDirtyResumeFixture{
+		store:         store,
+		worktree:      worktree,
+		completedWork: completedWork,
+		head:          head,
+		adapter:       adapter,
+		worker:        worker,
+	}
+}
+
+func assertSelfDirtyResumeDeferred(t *testing.T, fixture selfDirtyResumeFixture, jobID string) workflow.JobPayload {
+	t.Helper()
+	job, err := fixture.store.GetJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) || payload.BlockerAttempts != 1 ||
+		payload.BlockerClass != string(blockerClassCheckoutContention) || payload.BlockerRetryAt == "" ||
+		payload.BlockerSuggestedAction == "" || payload.ResumedSelfDirtyWorktree {
+		t.Fatalf("self-dirty fallback = state=%q payload=%+v", job.State, payload)
+	}
+	events, err := fixture.store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "worktree_resumed" {
+			t.Fatalf("blocked job recorded a resume event: %+v", events)
+		}
+	}
+	return payload
+}
+
+func TestResumeSelfDirtySkipsWhenProcessLive(t *testing.T) {
+	ctx := context.Background()
+	fixture := newSelfDirtyResumeFixture(t, "job-live-worktree")
+	previous := taskWorktreeLiveness
+	taskWorktreeLiveness = func(path string) (bool, bool) {
+		return sameCheckoutPath(path, fixture.worktree), true
+	}
+	t.Cleanup(func() { taskWorktreeLiveness = previous })
+
+	if err := runQueuedJobs(ctx, fixture.worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	if fixture.adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want live-process gate to stop delivery", fixture.adapter.calls)
+	}
+	job, err := fixture.store.GetJob(ctx, "job-live-worktree")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) || payload.BlockerAttempts != 1 || payload.BlockerClass != string(blockerClassCheckoutContention) {
+		t.Fatalf("live-process fallback = state=%q payload=%+v", job.State, payload)
+	}
+	retryAt, err := time.Parse(time.RFC3339Nano, payload.BlockerRetryAt)
+	if err != nil {
+		t.Fatalf("parse BlockerRetryAt: %v", err)
+	}
+	if until := time.Until(retryAt); until < checkoutDirtyBackoff-time.Minute || until > checkoutDirtyBackoff+time.Minute {
+		t.Fatalf("live-process fallback retry delay = %s, want about %s", until, checkoutDirtyBackoff)
+	}
+	if payload.BlockerSuggestedAction == "" || payload.ResumedSelfDirtyWorktree {
+		t.Fatalf("live-process fallback lost defer shape: %+v", payload)
+	}
+	if _, err := os.Stat(fixture.completedWork); err != nil {
+		t.Fatalf("live-process fallback changed the worktree: %v", err)
+	}
+}
+
+func TestResumeSelfDirtySkipsWrongHeadWhileDirty(t *testing.T) {
+	ctx := context.Background()
+	fixture := newSelfDirtyResumeFixture(t, "job-wrong-head-dirty")
+	runDaemonWorkerGit(t, fixture.worktree, "add", filepath.Base(fixture.completedWork))
+	runDaemonWorkerGit(t, fixture.worktree, "commit", "-m", "advance worktree head")
+	stillDirty := filepath.Join(fixture.worktree, "still-dirty.txt")
+	if err := os.WriteFile(stillDirty, []byte("unfinished correction\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile still-dirty work: %v", err)
+	}
+
+	if err := runQueuedJobs(ctx, fixture.worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	if fixture.adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want wrong HEAD to stop delivery", fixture.adapter.calls)
+	}
+	payload := assertSelfDirtyResumeDeferred(t, fixture, "job-wrong-head-dirty")
+	if payload.HeadSHA != fixture.head {
+		t.Fatalf("fallback payload head = %q, want original %q", payload.HeadSHA, fixture.head)
+	}
+	actualHead, err := (gitutil.Client{Dir: fixture.worktree}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	if actualHead == fixture.head {
+		t.Fatalf("test setup did not move worktree HEAD from %q", fixture.head)
+	}
+	for _, path := range []string{fixture.completedWork, stillDirty} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("wrong-HEAD fallback changed %s: %v", path, err)
+		}
+	}
+}
+
+func TestResumeSelfDirtySkipsMissingBranchLock(t *testing.T) {
+	ctx := context.Background()
+	fixture := newSelfDirtyResumeFixtureWithLockOwner(t, "job-missing-lock", "")
+
+	if err := runQueuedJobs(ctx, fixture.worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	if fixture.adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want missing branch lock to stop delivery", fixture.adapter.calls)
+	}
+	assertSelfDirtyResumeDeferred(t, fixture, "job-missing-lock")
+	if _, err := os.Stat(fixture.completedWork); err != nil {
+		t.Fatalf("missing-lock fallback changed the worktree: %v", err)
+	}
+}
+
+func TestResumeSelfDirtySkipsForeignBranchLock(t *testing.T) {
+	ctx := context.Background()
+	fixture := newSelfDirtyResumeFixtureWithLockOwner(t, "job-foreign-lock", "another-agent")
+
+	if err := runQueuedJobs(ctx, fixture.worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	if fixture.adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want foreign branch lock to stop delivery", fixture.adapter.calls)
+	}
+	assertSelfDirtyResumeDeferred(t, fixture, "job-foreign-lock")
+	if _, err := os.Stat(fixture.completedWork); err != nil {
+		t.Fatalf("foreign-lock fallback changed the worktree: %v", err)
+	}
+}
+
+func TestResumeSelfDirtySkipsWhenLivenessUnknown(t *testing.T) {
+	tests := []struct {
+		name  string
+		live  bool
+		known bool
+	}{
+		{name: "unknown", live: false, known: false},
+		{name: "live", live: true, known: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newSelfDirtyResumeFixture(t, "job-liveness-"+tc.name)
+			previous := taskWorktreeLiveness
+			taskWorktreeLiveness = func(string) (bool, bool) { return tc.live, tc.known }
+			defer func() { taskWorktreeLiveness = previous }()
+
+			if err := runQueuedJobs(context.Background(), fixture.worker, 1); err != nil {
+				t.Fatalf("runQueuedJobs returned error: %v", err)
+			}
+			if fixture.adapter.calls != 0 {
+				t.Fatalf("adapter calls = %d, want liveness (%v, %v) to stop delivery", fixture.adapter.calls, tc.live, tc.known)
+			}
+			assertSelfDirtyResumeDeferred(t, fixture, "job-liveness-"+tc.name)
+			if _, err := os.Stat(fixture.completedWork); err != nil {
+				t.Fatalf("liveness fallback changed the worktree: %v", err)
+			}
+		})
+	}
+}
+
+func TestResumeSelfDirtySkipsDirtyByOther(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA returned error: %v", err)
+	}
+	dirtyFile := filepath.Join(checkout, "someone-elses-work.txt")
+	if err := os.WriteFile(dirtyFile, []byte("do not touch\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile dirty registered checkout: %v", err)
+	}
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "main", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-dirty-by-other", Agent: "lead", Action: "implement", Repo: "owner/repo", Branch: "main", HeadSHA: head,
+	})
+	adapter := &cliWorkerFakeAdapter{output: `{"gitmoot_result":{"decision":"implemented","summary":"unexpected","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) { return adapter, nil }
+
+	if err := runQueuedJobs(ctx, worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want dirty registered checkout to remain blocked", adapter.calls)
+	}
+	job, err := store.GetJob(ctx, "job-dirty-by-other")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	_, wantAction := classifyCheckoutContention(errors.New("checkout " + checkout + " has uncommitted changes"))
+	if job.State != string(workflow.JobQueued) || payload.BlockerClass != string(blockerClassCheckoutContention) ||
+		payload.BlockerAttempts != 1 || payload.BlockerRetryAt == "" || payload.BlockerSuggestedAction != wantAction ||
+		!payload.BlockerPreDelivery || payload.ResumedSelfDirtyWorktree {
+		t.Fatalf("dirty-by-other defer shape changed: state=%q payload=%+v", job.State, payload)
+	}
+	if _, err := os.Stat(dirtyFile); err != nil {
+		t.Fatalf("dirty-by-other file was touched: %v", err)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind == "worktree_resumed" {
+			t.Fatalf("dirty-by-other job recorded a resume event: %+v", events)
+		}
+	}
+}
+
+func TestResumeSelfDirtyPredicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		cause    func(selfDirtyResumeFixture) error
+		mutate   func(*testing.T, selfDirtyResumeFixture, *db.Job, *workflow.JobPayload)
+		liveness func(string) (bool, bool)
+	}{
+		{name: "delegation child", mutate: func(_ *testing.T, _ selfDirtyResumeFixture, _ *db.Job, p *workflow.JobPayload) {
+			p.ParentJobID, p.DelegationID = "parent", "child"
+		}},
+		{name: "wrong head string", cause: func(selfDirtyResumeFixture) error {
+			return errors.New("checkout head is abc, not job head def")
+		}},
+		{name: "lock string", cause: func(selfDirtyResumeFixture) error {
+			return errors.New("branch task-resume is locked by another worker")
+		}},
+		{name: "payload worktree set", mutate: func(_ *testing.T, f selfDirtyResumeFixture, _ *db.Job, p *workflow.JobPayload) {
+			p.WorktreePath = f.worktree
+		}},
+		{name: "missing task", mutate: func(_ *testing.T, _ selfDirtyResumeFixture, _ *db.Job, p *workflow.JobPayload) {
+			p.TaskID = "missing"
+		}},
+		{name: "repo mismatch", mutate: func(_ *testing.T, _ selfDirtyResumeFixture, _ *db.Job, p *workflow.JobPayload) {
+			p.Repo = "other/repo"
+		}},
+		{name: "branch mismatch", mutate: func(_ *testing.T, _ selfDirtyResumeFixture, _ *db.Job, p *workflow.JobPayload) {
+			p.Branch = "other-branch"
+		}},
+		{name: "non implement type", mutate: func(_ *testing.T, _ selfDirtyResumeFixture, j *db.Job, _ *workflow.JobPayload) {
+			j.Type = "review"
+		}},
+		{name: "not queued", mutate: func(_ *testing.T, _ selfDirtyResumeFixture, j *db.Job, _ *workflow.JobPayload) {
+			j.State = string(workflow.JobRunning)
+		}},
+		{name: "budget spent", mutate: func(_ *testing.T, _ selfDirtyResumeFixture, _ *db.Job, p *workflow.JobPayload) {
+			p.BlockerAttempts = maxOperationalBlockerRetries
+		}},
+		{name: "missing expected head", mutate: func(_ *testing.T, _ selfDirtyResumeFixture, _ *db.Job, p *workflow.JobPayload) {
+			p.HeadSHA = ""
+		}},
+		{name: "wrong head while dirty", mutate: func(t *testing.T, f selfDirtyResumeFixture, _ *db.Job, _ *workflow.JobPayload) {
+			runDaemonWorkerGit(t, f.worktree, "add", filepath.Base(f.completedWork))
+			runDaemonWorkerGit(t, f.worktree, "commit", "-m", "move predicate head")
+			if err := os.WriteFile(filepath.Join(f.worktree, "still-dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+				t.Fatalf("WriteFile still-dirty predicate file: %v", err)
+			}
+		}},
+		{name: "missing branch lock", mutate: func(t *testing.T, f selfDirtyResumeFixture, _ *db.Job, _ *workflow.JobPayload) {
+			released, err := f.store.ReleaseLock(context.Background(), db.BranchLock{RepoFullName: "owner/repo", Branch: "task-resume", Owner: "lead"})
+			if err != nil || !released {
+				t.Fatalf("ReleaseLock returned released=%v err=%v", released, err)
+			}
+		}},
+		{name: "foreign branch lock", mutate: func(t *testing.T, f selfDirtyResumeFixture, _ *db.Job, _ *workflow.JobPayload) {
+			ctx := context.Background()
+			released, err := f.store.ReleaseLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-resume", Owner: "lead"})
+			if err != nil || !released {
+				t.Fatalf("ReleaseLock returned released=%v err=%v", released, err)
+			}
+			acquired, err := f.store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-resume", Owner: "another-agent"})
+			if err != nil || !acquired {
+				t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+			}
+		}},
+		{name: "liveness unknown", liveness: func(string) (bool, bool) { return false, false }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			fixture := newSelfDirtyResumeFixture(t, "predicate-job")
+			job, err := fixture.store.GetJob(ctx, "predicate-job")
+			if err != nil {
+				t.Fatalf("GetJob returned error: %v", err)
+			}
+			payload, err := daemonJobPayload(job)
+			if err != nil {
+				t.Fatalf("daemonJobPayload returned error: %v", err)
+			}
+			cause := errors.New("checkout " + fixture.worktree + " has uncommitted changes")
+			if tc.cause != nil {
+				cause = tc.cause(fixture)
+			}
+			if tc.mutate != nil {
+				tc.mutate(t, fixture, &job, &payload)
+			}
+			if tc.liveness != nil {
+				previous := taskWorktreeLiveness
+				taskWorktreeLiveness = tc.liveness
+				defer func() { taskWorktreeLiveness = previous }()
+			}
+
+			checkout, gotPayload, ok := fixture.worker.resumeSelfDirtyWorktree(ctx, job, payload, runtime.Agent{Name: "lead"}, cause)
+			if ok || checkout != "" {
+				t.Fatalf("resumeSelfDirtyWorktree = (%q, ok=%v), want predicate miss", checkout, ok)
+			}
+			if !reflect.DeepEqual(gotPayload, payload) {
+				t.Fatalf("predicate miss mutated payload: got=%+v want=%+v", gotPayload, payload)
+			}
+		})
+	}
+}
+
+func TestResumeSelfDirtyBudgetExhaustedStaysTerminal(t *testing.T) {
+	ctx := context.Background()
+	fixture := newSelfDirtyResumeFixture(t, "job-resume-budget")
+	job, err := fixture.store.GetJob(ctx, "job-resume-budget")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	payload.BlockerAttempts = maxOperationalBlockerRetries
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal payload: %v", err)
+	}
+	if err := fixture.store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		t.Fatalf("UpdateJobPayload returned error: %v", err)
+	}
+
+	if err := runQueuedJobs(ctx, fixture.worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	if fixture.adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want exhausted resume budget to stop delivery", fixture.adapter.calls)
+	}
+	job, err = fixture.store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetJob after run returned error: %v", err)
+	}
+	payload, err = daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload after run returned error: %v", err)
+	}
+	if job.State != string(workflow.JobFailed) || payload.BlockerAttempts != maxOperationalBlockerRetries || payload.ResumedSelfDirtyWorktree {
+		t.Fatalf("budget-exhausted result = state=%q payload=%+v", job.State, payload)
+	}
+	events, err := fixture.store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	foundExhausted := false
+	for _, event := range events {
+		foundExhausted = foundExhausted || event.Kind == blockerExhaustedEventKind
+		if event.Kind == "worktree_resumed" {
+			t.Fatalf("budget-exhausted job recorded a resume event: %+v", events)
+		}
+	}
+	if !foundExhausted {
+		t.Fatalf("budget-exhausted job missing %s event: %+v", blockerExhaustedEventKind, events)
+	}
+	if _, err := os.Stat(fixture.completedWork); err != nil {
+		t.Fatalf("budget-exhausted fallback changed the worktree: %v", err)
+	}
+	if payload.HeadSHA != fixture.head {
+		t.Fatalf("budget-exhausted payload head = %q, want %q", payload.HeadSHA, fixture.head)
+	}
+}
+
+func TestResumeSelfDirtySkipsWhenRuntimeLeaseHeld(t *testing.T) {
+	ctx := context.Background()
+	fixture := newSelfDirtyResumeFixture(t, "job-live-lease")
+	now := time.Now().UTC()
+	acquired, err := fixture.store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey:   "runtime:codex:self-dirty-test",
+		OwnerJobID:    "job-live-lease",
+		OwnerToken:    "owner-token",
+		OwnerHostname: "other-host",
+		OwnerPID:      123,
+		ExpiresAt:     now.Add(time.Hour).Format(time.RFC3339Nano),
+	}, now)
+	if err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := runQueuedJobs(ctx, fixture.worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	if fixture.adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want live runtime lease to stop delivery", fixture.adapter.calls)
+	}
+	job, err := fixture.store.GetJob(ctx, "job-live-lease")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload returned error: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) || payload.BlockerAttempts != 1 || payload.ResumedSelfDirtyWorktree {
+		t.Fatalf("live-lease fallback = state=%q payload=%+v", job.State, payload)
+	}
+}
+
+func TestResumeSelfDirtyPredicateRequiresExactDirtyText(t *testing.T) {
+	worker := defaultJobWorker(daemonWorkerStore(t), io.Discard)
+	job := db.Job{ID: "job", Type: "implement", State: string(workflow.JobQueued)}
+	payload := workflow.JobPayload{Repo: "owner/repo", Branch: "task", TaskID: "task"}
+	for _, cause := range []error{nil, errors.New("checkout is dirty"), errors.New("checkout head is abc, not job head def")} {
+		if checkout, got, ok := worker.resumeSelfDirtyWorktree(context.Background(), job, payload, runtime.Agent{Name: "lead"}, cause); ok || checkout != "" || !reflect.DeepEqual(got, payload) {
+			t.Fatalf("cause %v unexpectedly resumed: checkout=%q payload=%+v ok=%v", cause, checkout, got, ok)
+		}
+	}
+}
+
+func TestResumeSelfDirtyEventMessageNamesPathAndAttempt(t *testing.T) {
+	fixture := newSelfDirtyResumeFixture(t, "job-resume-event")
+	if err := runQueuedJobs(context.Background(), fixture.worker, 1); err != nil {
+		t.Fatalf("runQueuedJobs returned error: %v", err)
+	}
+	events, err := fixture.store.ListJobEvents(context.Background(), "job-resume-event")
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	for _, event := range events {
+		if event.Kind != "worktree_resumed" {
+			continue
+		}
+		if !strings.Contains(event.Message, fixture.worktree) || !strings.Contains(event.Message, "attempt 1/") ||
+			!strings.Contains(event.Message, "prior attempt's completed work present uncommitted; re-delivering") {
+			t.Fatalf("worktree_resumed message = %q", event.Message)
+		}
+		return
+	}
+	t.Fatalf("worktree_resumed event missing: %+v", events)
+}

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -32,6 +32,7 @@ import (
 var taskHeadingPattern = regexp.MustCompile(`^### Task ([0-9]+):\s*(.+)$`)
 
 var taskWorktreeHasLiveProcess = workflow.WorktreeHasLiveProcess
+var taskWorktreeLiveness = workflow.WorktreeLiveness
 
 type importedGoal struct {
 	Goal  db.Goal

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -395,6 +395,11 @@ type JobPayload struct {
 	// later runtime_auth/quota/network deferral still carries the at-least-once
 	// side-effect warning. Additive/omitempty (byte-identical when unset).
 	BlockerPreDelivery bool `json:"blocker_pre_delivery,omitempty"`
+	// ResumedSelfDirtyWorktree marks a dead implement job re-delivered into its own
+	// task worktree with the prior attempt's completed work still uncommitted. It
+	// selects the accurate recovery notice below instead of the generic operational
+	// retry reconciliation warning. Additive/omitempty when unset.
+	ResumedSelfDirtyWorktree bool `json:"resumed_self_dirty_worktree,omitempty"`
 }
 
 type DeliveryAdapter interface {
@@ -668,6 +673,12 @@ func blockerRetryReconciliationNotice(class string, attempt int) string {
 		"artifacts and reuse/reconcile them instead of redoing or duplicating the work.", attempt, class)
 }
 
+func resumedSelfDirtyWorktreeNotice() string {
+	return "A previous attempt of this job COMPLETED work that is present but UNCOMMITTED in your worktree. " +
+		"It was NOT pushed and NO PR was opened. Review the uncommitted changes, finish/correct as needed, and leave them in place — " +
+		"the finalizer will commit and open the PR. Do not discard prior work."
+}
+
 func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, adapter DeliveryAdapter) (AgentResult, error) {
 	if m.Store == nil {
 		return AgentResult{}, errors.New("mailbox store is required")
@@ -733,7 +744,9 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			prompt = prompt + "\n\n" + block
 		}
 	}
-	if payload.BlockerAttempts > 0 && strings.TrimSpace(payload.BlockerClass) != "" && !payload.BlockerPreDelivery {
+	if payload.ResumedSelfDirtyWorktree {
+		prompt = resumedSelfDirtyWorktreeNotice() + "\n\n" + prompt
+	} else if payload.BlockerAttempts > 0 && strings.TrimSpace(payload.BlockerClass) != "" && !payload.BlockerPreDelivery {
 		// This run is an automatic operational-blocker retry (#532): the previous
 		// attempt died on an environment condition, not on its own output, and may
 		// have executed side effects before the blocker hit — so warn the agent its

--- a/internal/workflow/mailbox_resume_worktree_test.go
+++ b/internal/workflow/mailbox_resume_worktree_test.go
@@ -1,0 +1,71 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/prompts"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+func TestMailboxRunPrependsResumeNotice(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	const output = `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+
+	run := func(t *testing.T, id string, resumed bool) (string, string) {
+		t.Helper()
+		if _, err := mailbox.Enqueue(ctx, JobRequest{
+			ID: id, Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", HeadSHA: "base",
+			TaskTitle: "Inspect recovery", Instructions: "Inspect the worktree.",
+		}); err != nil {
+			t.Fatalf("Enqueue returned error: %v", err)
+		}
+		job, err := store.GetJob(ctx, id)
+		if err != nil {
+			t.Fatalf("GetJob returned error: %v", err)
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			t.Fatalf("unmarshalPayload returned error: %v", err)
+		}
+		payload.BlockerClass = "checkout_contention"
+		payload.BlockerAttempts = 1
+		payload.BlockerPreDelivery = true
+		payload.ResumedSelfDirtyWorktree = resumed
+		encoded, err := marshalPayload(payload)
+		if err != nil {
+			t.Fatalf("marshalPayload returned error: %v", err)
+		}
+		if err := store.UpdateJobPayload(ctx, id, encoded); err != nil {
+			t.Fatalf("UpdateJobPayload returned error: %v", err)
+		}
+		adapter := &fakeDelivery{outputs: []string{output}}
+		if _, err := mailbox.Run(ctx, id, runtime.Agent{Name: "audit"}, adapter); err != nil {
+			t.Fatalf("Mailbox.Run returned error: %v", err)
+		}
+		if len(adapter.prompts) != 1 {
+			t.Fatalf("delivered prompts = %d, want 1", len(adapter.prompts))
+		}
+		return adapter.prompts[0], prompts.RenderJob(payload.prompt("ask"))
+	}
+
+	resumedPrompt, resumedBase := run(t, "resume-notice", true)
+	wantPrefix := resumedSelfDirtyWorktreeNotice() + "\n\n"
+	if !strings.HasPrefix(resumedPrompt, wantPrefix) {
+		t.Fatalf("resumed prompt missing exact notice prefix:\n%s", resumedPrompt)
+	}
+	if strings.TrimPrefix(resumedPrompt, wantPrefix) != resumedBase {
+		t.Fatalf("resume notice changed the base prompt:\n%s", resumedPrompt)
+	}
+	if strings.Contains(resumedPrompt, "NOTE (operational retry") || strings.Contains(resumedPrompt, "pushed branches") {
+		t.Fatalf("resumed prompt carried generic blocker reconciliation:\n%s", resumedPrompt)
+	}
+
+	controlPrompt, controlBase := run(t, "resume-notice-control", false)
+	if controlPrompt != controlBase {
+		t.Fatalf("unset resumed flag changed the existing pre-delivery prompt:\ngot:  %q\nwant: %q", controlPrompt, controlBase)
+	}
+}

--- a/internal/workflow/runtime_owner_liveness.go
+++ b/internal/workflow/runtime_owner_liveness.go
@@ -83,12 +83,21 @@ func (e Engine) worktreeHasLiveProcess(path string) bool {
 	return defaultWorktreeHasLiveProcess(path)
 }
 
+// WorktreeLiveness reports whether a live process on this host has its cwd in
+// path and whether the /proc scan was conclusive. A false, false result means
+// the process table could not be read, so safety-sensitive recovery callers must
+// treat the worktree as potentially live.
+func WorktreeLiveness(path string) (live bool, known bool) {
+	return worktreeLiveness(path, "/proc")
+}
+
 // WorktreeHasLiveProcess exposes the same conservative /proc cwd liveness probe
 // used by destructive worktree cleanup to CLI recovery/dispatch paths. It is
 // intentionally best-effort: false means "no same-host cwd owner observed", not a
 // proof that no external process can write.
 func WorktreeHasLiveProcess(path string) bool {
-	return defaultWorktreeHasLiveProcess(path)
+	live, _ := WorktreeLiveness(path)
+	return live
 }
 
 // defaultWorktreeHasLiveProcess is a best-effort Linux /proc scan: it returns true
@@ -100,17 +109,22 @@ func WorktreeHasLiveProcess(path string) bool {
 // applies while the lease is unexpired). A worktree mid-removal can report a cwd of
 // "<path> (deleted)"; that suffix is stripped before comparison.
 func defaultWorktreeHasLiveProcess(path string) bool {
+	live, _ := WorktreeLiveness(path)
+	return live
+}
+
+func worktreeLiveness(path string, procRoot string) (live bool, known bool) {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return false
+		return false, true
 	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		abs = path
 	}
-	entries, err := os.ReadDir("/proc")
+	entries, err := os.ReadDir(procRoot)
 	if err != nil {
-		return false
+		return false, false
 	}
 	self := os.Getpid()
 	for _, entry := range entries {
@@ -124,16 +138,16 @@ func defaultWorktreeHasLiveProcess(path string) bool {
 		if pid, perr := strconv.Atoi(name); perr == nil && pid == self {
 			continue
 		}
-		cwd, err := os.Readlink(filepath.Join("/proc", name, "cwd"))
+		cwd, err := os.Readlink(filepath.Join(procRoot, name, "cwd"))
 		if err != nil {
 			continue
 		}
 		cwd = strings.TrimSuffix(strings.TrimSpace(cwd), " (deleted)")
 		if cwd == abs || strings.HasPrefix(cwd, abs+string(os.PathSeparator)) {
-			return true
+			return true, true
 		}
 	}
-	return false
+	return false, true
 }
 
 // defaultOwnerPIDLive probes same-host process liveness via signal 0, mirroring

--- a/internal/workflow/runtime_owner_liveness_test.go
+++ b/internal/workflow/runtime_owner_liveness_test.go
@@ -1,0 +1,44 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWorktreeLiveness(t *testing.T) {
+	t.Run("unknown when proc scan cannot start", func(t *testing.T) {
+		missingProc := filepath.Join(t.TempDir(), "missing-proc")
+		live, known := worktreeLiveness(t.TempDir(), missingProc)
+		if live || known {
+			t.Fatalf("worktreeLiveness with unreadable proc = (%v, %v), want (false, false)", live, known)
+		}
+	})
+
+	t.Run("known live cwd", func(t *testing.T) {
+		worktree := t.TempDir()
+		procRoot := t.TempDir()
+		processDir := filepath.Join(procRoot, "999999999")
+		if err := os.Mkdir(processDir, 0o755); err != nil {
+			t.Fatalf("Mkdir process dir: %v", err)
+		}
+		if err := os.Symlink(worktree, filepath.Join(processDir, "cwd")); err != nil {
+			t.Fatalf("Symlink cwd: %v", err)
+		}
+		live, known := worktreeLiveness(worktree, procRoot)
+		if !live || !known {
+			t.Fatalf("worktreeLiveness with matching cwd = (%v, %v), want (true, true)", live, known)
+		}
+	})
+
+	t.Run("legacy bool wrapper ignores certainty", func(t *testing.T) {
+		worktree := t.TempDir()
+		live, known := WorktreeLiveness(worktree)
+		if !known {
+			t.Skip("host process table is not readable")
+		}
+		if got := WorktreeHasLiveProcess(worktree); got != live {
+			t.Fatalf("WorktreeHasLiveProcess = %v, WorktreeLiveness live = %v", got, live)
+		}
+	})
+}

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -335,6 +335,15 @@ cannot recurse or fan out forever:
   an explicit audited recovery. Dismissal never deletes the task branch or
   worktree.
 
+- Dead implement worktree retries (#994): a queued top-level implement job may
+  bypass only the dirty-checkout pre-flight when the dirty path resolves to that
+  job's own recorded task worktree, its repo and branch still match, no worktree
+  process or runtime-owner lease is live, and the bounded retry budget remains.
+  Gitmoot re-delivers with an explicit uncommitted-work notice and leaves commit,
+  push, and PR creation to the normal finalizer. Delegation children, dirty
+  registered/other checkouts, wrong-head and lock failures, and any live or
+  uncertain owner keep their existing blocking/failure paths.
+
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, a delegation batch
 of new jobs would exceed the per-root job budget of 64). Rather than stopping

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1075,8 +1075,16 @@ including daemon `task_dismissed_auto` and explicit recovery events.
 
 If an implementer dies mid-work — its process exits after editing the task
 worktree but before it commits, pushes, and opens a PR — the changes are left
-uncommitted in the worktree. `task run` (and `agent implement`) refuse to
-restart over that state rather than silently discard the work, and point you at
+uncommitted in the worktree. A retry of that same implement job re-delivers into
+its recorded task worktree when both the worktree process probe and runtime-owner
+lease prove the prior attempt is dead and the bounded retry budget remains. The
+retry prompt tells the agent to review and preserve the uncommitted work; the
+normal finalizer still owns commit, push, and PR creation. A live worktree, a
+dirty registered/other checkout, wrong-head state, or an exhausted retry budget
+keeps the existing block/failure path.
+
+A new `task run` (or `agent implement`) still refuses a dirty worktree with no
+active job rather than silently discarding the work, and points you at
 `task recover`:
 
 ```sh

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -701,11 +701,16 @@ planned tasks. `task run` starts one task branch in a dedicated worktree,
 records its branch lock, and stores the worktree path on the task.
 
 If an implementer dies mid-work — after editing the task worktree but before it
-commits, pushes, and opens a PR — the edits are left uncommitted. `task run`
-(and `agent implement`) refuse to restart over a dirty worktree with no active
-job, rather than silently discard the work, and point at `task recover <id>
---owner <agent>`. `task recover` commits the full worktree state (`git add -A`,
-including untracked non-ignored files), pushes the branch, and opens or adopts
+commits, pushes, and opens a PR — the edits are left uncommitted. A retry of that
+same implement job re-delivers into its recorded task worktree when both the
+worktree process probe and runtime-owner lease prove the prior attempt is dead;
+the prompt tells the agent to review and preserve the uncommitted work, and the
+normal finalizer commits it. A live worktree, a dirty registered/other checkout,
+or an exhausted retry budget still blocks. A new `task run` (or `agent implement`)
+refuses a dirty worktree with no active job rather than silently discard the work,
+and points at `task recover <id> --owner <agent>`. `task recover` commits the
+full worktree state (`git add -A`, including untracked non-ignored files), pushes
+the branch, and opens or adopts
 the task's PR — the finalize steps the dead implementer never reached. `--repo`
 is optional (it falls back to the task's stored repo). `--owner` is required for
 this artifact-finalization path, while a dismissed task with no branch can be
@@ -14593,6 +14598,15 @@ cannot recurse or fan out forever:
   closed instead of overwriting it. Only `task recover` or retrying a job performs
   an explicit audited recovery. Dismissal never deletes the task branch or
   worktree.
+
+- Dead implement worktree retries (#994): a queued top-level implement job may
+  bypass only the dirty-checkout pre-flight when the dirty path resolves to that
+  job's own recorded task worktree, its repo and branch still match, no worktree
+  process or runtime-owner lease is live, and the bounded retry budget remains.
+  Gitmoot re-delivers with an explicit uncommitted-work notice and leaves commit,
+  push, and PR creation to the normal finalizer. Delegation children, dirty
+  registered/other checkouts, wrong-head and lock failures, and any live or
+  uncertain owner keep their existing blocking/failure paths.
 
 When a bound trips, the offending delegations are not dispatched and the parent
 receives a typed lifecycle event explaining why (for example, a delegation batch


### PR DESCRIPTION
## Resume a dead implement job's own dirty worktree instead of failing it — closes #994

An implement job that **completes its work but whose runtime dies before the finalizer commits** leaves its own adhoc task worktree dirty. The retry's pre-flight classified this as `checkout_contention` (dirty), deferred it `2min × maxOperationalBlockerRetries`, then **terminally failed — destroying completed work** (3 hand-salvages in 3 days: #911, #988, #993 waves).

### Fix (Option A — resume, no auto-commit)
`resumeSelfDirtyWorktree` (`internal/cli/job_resume_worktree.go`): when a **queued, non-delegation implement** job's pre-flight fails **only** on `"has uncommitted changes"` in its **own** task worktree, bypass just the dirty guard and re-deliver in the same tick with an accurate resume note. **No git ops, HeadSHA unchanged** — the existing finalizer's own `CommitAll` recovers the work and opens the PR even if the retry is a no-op.

Auto-commit (Option B) was **rejected by design**: setting `HeadSHA=WIP` trips the finalizer's `clean && head==HeadSHA` "produced no changes" guard (`daemon.go:7646→7654`) and strands the work on an unpushed commit with no PR.

### Safety (positive re-validation — from adversarial review)
The pre-flight validator short-circuits on the dirty check **before** its HEAD check, and `defaultCheckout` runs the unconditional implementation-lock check after it. So the resume path **positively re-establishes both invariants the dirty error masked**:
- **HEAD == `payload.HeadSHA`** (reads the worktree HEAD; mismatch or error → defer) — closes the wrong-HEAD-while-dirty hole.
- **Branch lock held by this job's owner** via `validateImplementationLock` (missing/foreign → defer) — a genuinely-resuming dead job still holds its own lock (released only on completion or manual dismissal; branch locks have no TTL).
- **Fail-closed liveness**: new `workflow.WorktreeLiveness(path) (live, known)` — any unknown/`/proc`-unreadable state is treated as **live**; plus the runtime-owner lease check. `WorktreeHasLiveProcess` stays a thin wrapper (all existing callers byte-identical).

Fails closed on any predicate miss / probe / lease / persistence error. **Dirty-by-other, delegation children, wrong-head, wrong-branch, missing/foreign lock, lock contention, ask/review, and budget-exhausted all keep their existing defer/terminal routing byte-identically.**

### Tests (no-LLM deterministic)
RED→GREEN work-survives-and-redelivers with HeadSHA untouched; skips when the process is live, when liveness is unknown, on dirty-by-other, on wrong-HEAD-while-dirty, on missing/foreign branch lock, and when the budget is exhausted; predicate table; `WorktreeLiveness` unit; mailbox resume-notice. Docs updated (`local-workflow`, `SAFETY.md`, `cli.md`, `llms-full`).

### Gate
`go build`/`vet`/`generate`-clean + `go test ./internal/{cli,workflow,db,daemon}` green independently (cli 408s, workflow 95s, db 114s, daemon 21s). Single-binary `-race` hits the 35m busy-box budget with **zero DATA RACE** lines; CI sharded race lanes are authoritative.

## Deploy notes
Daemon/engine change only — deploy `gitmoot` at idle. No migration, no config change. First PR from the coordinator-of-coordinators round (workflow `g4/994-retry-wedge`); reviewed by an independent adversarial pass (3 P1s found and fixed) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
