### PR TITLE
chore(deps): pin gitmoot-dashboard at the build-skew banner (dashboard#120)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260717014803-f4a7f6a0df82
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260717020659-787caabbe249
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260717014803-f4a7f6a0df82 h1:my4MroopNdn8fTxeqlGR2QX35lgWArqHZHqtVm+ZvLA=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260717014803-f4a7f6a0df82/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260717020659-787caabbe249 h1:TkYxq3bquPwujooAh1N9EsDcL12/EpblqUMatSlTsJA=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260717020659-787caabbe249/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
Re-pin train for gitmoot-dashboard PR #120 (dashboard#103 — build-skew banner), merged as `787caab`.

- `go.mod`/`go.sum` only: `gitmoot-dashboard v0.0.0-20260717014803-f4a7f6a0df82 → v0.0.0-20260717020659-787caabbe249`
- Local gate: `go build`, `go generate` (clean), `go vet`, full `go test ./...` — all green on the pinned tree.
- Awaiting owner/fable merge decision (an earlier revision of this body cited a relayed approval; that claim was unverified and is withdrawn — see workflow journal g2/117-modsplit entry 761). Deploy note: the banner is the feature that would have caught the original stale-dashboard incident — after deploy, a stale `gitmoot-dashboard-web` binary will self-report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
