### PR TITLE
feat(engine): persist the effective model per job at enqueue (#998)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -249,7 +249,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			request.Instructions += note
 		}
 	}
-	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home)}).Enqueue(ctx, workflow.JobRequest{
+	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home)}).Enqueue(ctx, workflow.JobRequest{
 		ID:                     jobID,
 		Agent:                  agent.Name,
 		Action:                 request.Action,
@@ -535,7 +535,7 @@ func buildLocalAgentJobOutput(latest db.Job, request localAgentDispatchRequest) 
 }
 
 func enqueuePermissionBlockedLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, defaultBranch string, agentName string, overrideRuntime string, overrideRef string) (localAgentJobOutput, error) {
-	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home)}).Enqueue(ctx, workflow.JobRequest{
+	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home)}).Enqueue(ctx, workflow.JobRequest{
 		ID:           localAgentJobID(request.Action, agentName),
 		Agent:        agentName,
 		Action:       request.Action,

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -2105,7 +2105,7 @@ type heartbeatEnqueuer func(ctx context.Context, request workflow.JobRequest) (d
 // construction so a heartbeat job is indistinguishable from a normal background
 // job once enqueued.
 func newHeartbeatEnqueuer(store *db.Store, home string) heartbeatEnqueuer {
-	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home)}
+	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home)}
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
 		return mailbox.Enqueue(ctx, request)
 	}
@@ -6622,7 +6622,7 @@ func (w jobWorker) queueTempWorkerMergeBack(ctx context.Context, completedJobID 
 			"Do not edit files, create commits, open pull requests, or dispatch more agents unless the summary explicitly requires follow-up.",
 		},
 	}
-	if _, err := (workflow.Mailbox{Store: w.Store, CanaryEnabled: canaryRoutingEnabled(w.workflowHome())}).Enqueue(ctx, request); err != nil {
+	if _, err := (workflow.Mailbox{Store: w.Store, CanaryEnabled: canaryRoutingEnabled(w.workflowHome()), RuntimeDefaultModel: runtimeDefaultModelResolver(w.workflowHome())}).Enqueue(ctx, request); err != nil {
 		return err
 	}
 	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: completedJob.ID, Kind: "temp_worker_merge_back_queued", Message: fmt.Sprintf("queued summary merge-back job %s for %s", mergeBackID, original.Name)})

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -533,14 +533,11 @@ func buildDashboardWorkflowRuns(jobs []db.Job, runtimeByAgent map[string]string,
 				ID: job.ID, ParentID: strings.TrimSpace(job.ParentJobID), Deps: deps,
 				Title: nodeTitle(payload, job, action), Agent: job.Agent,
 				Runtime: resolveJobRuntime(job, payload, runtimeByAgent),
-				Model:   strings.TrimSpace(payload.Model), State: mapNodeState(job.State),
+				Model:   strings.TrimSpace(job.Model), State: mapNodeState(job.State),
 				StartedAt: parseJobTimeMillis(job.CreatedAt),
 			}
 			if node.ParentID == "" {
 				node.ParentID = strings.TrimSpace(payload.ParentJobID)
-			}
-			if node.Model == "" && payload.Ephemeral != nil {
-				node.Model = strings.TrimSpace(payload.Ephemeral.Model)
 			}
 			if workflow.IsFinalJobState(strings.TrimSpace(job.State)) {
 				node.EndedAt = parseJobTimeMillis(job.UpdatedAt)
@@ -1945,13 +1942,10 @@ func buildDashboardNode(job db.Job, payload workflow.JobPayload, events []db.Job
 		Title:    nodeTitle(payload, job, action),
 		Agent:    job.Agent,
 		Runtime:  resolveJobRuntime(job, payload, runtimeByAgent),
-		Model:    strings.TrimSpace(payload.Model),
+		Model:    strings.TrimSpace(job.Model),
 		State:    mapNodeState(job.State),
 		Depth:    job.DelegationDepth,
 		Events:   []dashboard.Event{},
-	}
-	if node.Model == "" && payload.Ephemeral != nil {
-		node.Model = strings.TrimSpace(payload.Ephemeral.Model)
 	}
 	if payload.PullRequest > 0 && strings.TrimSpace(payload.Repo) != "" {
 		node.PRURL = fmt.Sprintf("https://github.com/%s/pull/%d", payload.Repo, payload.PullRequest)

--- a/internal/cli/dashboard_web_cache_test.go
+++ b/internal/cli/dashboard_web_cache_test.go
@@ -410,6 +410,16 @@ func TestDashboardCachedHandlersMatchModuleBytes(t *testing.T) {
 	if err := raw.Close(); err != nil {
 		t.Fatal(err)
 	}
+	// The dashboard module has no JobSummary.Model field in this pane, so /api/jobs
+	// byte parity remains unchanged. The gitmoot-owned node builder must still carry
+	// the persisted model while the cached and uncached module responses match.
+	modelNode, err := (&webDataSource{home: home}).Job(context.Background(), "child-search")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if modelNode.Model != "claude-fable-5" {
+		t.Fatalf("persisted model did not reach node builder: %+v", modelNode)
+	}
 
 	cached := newDashboardWebHandler(&webDataSource{home: home, responseCache: newDashboardJSONCache(nil)})
 	uncached := dashboard.Serve(&webDataSource{home: home})

--- a/internal/cli/dashboard_web_test.go
+++ b/internal/cli/dashboard_web_test.go
@@ -55,8 +55,8 @@ func seedWebDashboardTree(t *testing.T, home string) {
 	}
 	mustCreateJob(t, store, db.Job{ID: "coord", Agent: "project-lead", Type: "orchestrate", State: "succeeded", Payload: mustJSON(t, coordPayload)}, "delegation_enqueued", "fanned out 2 delegations")
 
-	searchPayload := workflow.JobPayload{Repo: "jerryfane/noted", TaskTitle: "implement: search", PullRequest: 12}
-	mustCreateJob(t, store, db.Job{ID: "child-search", Agent: "builder", Type: "implement", State: "succeeded", Payload: mustJSON(t, searchPayload), ParentJobID: "coord", DelegationID: "d-search", DelegationDepth: 1}, "worker_started", "picked up d-search")
+	searchPayload := workflow.JobPayload{Repo: "jerryfane/noted", TaskTitle: "implement: search", PullRequest: 12, Model: "payload-override-is-not-history"}
+	mustCreateJob(t, store, db.Job{ID: "child-search", Agent: "builder", Type: "implement", State: "succeeded", Payload: mustJSON(t, searchPayload), Model: "claude-fable-5", ParentJobID: "coord", DelegationID: "d-search", DelegationDepth: 1}, "worker_started", "picked up d-search")
 
 	exportPayload := workflow.JobPayload{Repo: "jerryfane/noted", TaskTitle: "implement: export"}
 	mustCreateJob(t, store, db.Job{ID: "child-export", Agent: "builder", Type: "implement", State: "running", Payload: mustJSON(t, exportPayload), ParentJobID: "coord", DelegationID: "d-export", DelegationDepth: 1}, "worker_started", "picked up d-export")
@@ -161,6 +161,9 @@ func TestWebDataSourceBuildsGraphFromStore(t *testing.T) {
 	}
 	if search.Runtime != "claude" {
 		t.Fatalf("child-search runtime = %q, want claude", search.Runtime)
+	}
+	if search.Model != "claude-fable-5" {
+		t.Fatalf("child-search model = %q, want persisted claude-fable-5", search.Model)
 	}
 	if search.State != "succeeded" {
 		t.Fatalf("child-search state = %q, want succeeded", search.State)
@@ -654,6 +657,15 @@ func TestWebDataSourceJobs(t *testing.T) {
 	if search.TokensIn != 2000 || search.TokensOut != 500 {
 		t.Errorf("child-search tokens = (%d,%d), want (2000,500)", search.TokensIn, search.TokensOut)
 	}
+	// JobSummary has no model field until the dashboard-module handoff lands, but
+	// the gitmoot-owned detail builder must already source the durable column.
+	node, err := ds.Job(context.Background(), "child-search")
+	if err != nil {
+		t.Fatalf("Job(child-search): %v", err)
+	}
+	if node.Model != "claude-fable-5" {
+		t.Fatalf("Job(child-search).Model = %q, want persisted claude-fable-5", node.Model)
+	}
 	wantStart := parseJobTimeMillis("2026-05-23 10:05:00")
 	wantUpdated := parseJobTimeMillis("2026-05-23 10:30:00")
 	if search.Started != wantStart || search.Updated != wantUpdated {
@@ -691,7 +703,7 @@ func TestWebDataSourceJobsEphemeralRuntime(t *testing.T) {
 	}
 	if err := store.CreateJob(context.Background(), db.Job{
 		ID: "eph-job", Agent: "task-9-ephemeral-abc123", Type: "implement",
-		State: "running", Payload: mustJSON(t, ephPayload),
+		State: "running", Payload: mustJSON(t, ephPayload), Model: "k3",
 	}); err != nil {
 		t.Fatalf("CreateJob: %v", err)
 	}
@@ -708,6 +720,13 @@ func TestWebDataSourceJobsEphemeralRuntime(t *testing.T) {
 	}
 	if eph.Runtime != "kimi" {
 		t.Fatalf("ephemeral runtime = %q, want kimi (from payload spec)", eph.Runtime)
+	}
+	node, err := ds.Job(context.Background(), "eph-job")
+	if err != nil {
+		t.Fatalf("Job(eph-job): %v", err)
+	}
+	if node.Model != "k3" {
+		t.Fatalf("ephemeral node model = %q, want persisted k3", node.Model)
 	}
 }
 

--- a/internal/cli/dashboard_web_workflow_test.go
+++ b/internal/cli/dashboard_web_workflow_test.go
@@ -255,11 +255,11 @@ func TestWebDataSourceWorkflowGroupsTreesAndPaginates(t *testing.T) {
 			{ID: "ship", Agent: "worker", Action: "ship", Deps: []string{"prep"}},
 		}},
 	}
-	mustCreateJob(t, store, db.Job{ID: "root", Agent: "lead", Type: "orchestrate", State: "succeeded", Payload: mustJSON(t, rootPayload)}, "", "")
+	mustCreateJob(t, store, db.Job{ID: "root", Agent: "lead", Type: "orchestrate", State: "succeeded", Payload: mustJSON(t, rootPayload), Model: "gpt-root"}, "", "")
 	prepPayload := workflow.JobPayload{WorkflowID: "release-42", RootJobID: "root", ParentJobID: "root", DelegationID: "prep", TaskTitle: "prepare release"}
 	mustCreateJob(t, store, db.Job{ID: "child-prep", Agent: "worker", Type: "ask", State: "succeeded", Payload: mustJSON(t, prepPayload), ParentJobID: "root", DelegationID: "prep", DelegationDepth: 1}, "", "")
 	shipPayload := workflow.JobPayload{WorkflowID: "release-42", RootJobID: "root", ParentJobID: "root", DelegationID: "ship", Deps: []string{"prep"}, Model: "sonnet"}
-	mustCreateJob(t, store, db.Job{ID: "child-ship", Agent: "worker", Type: "implement", State: "running", Payload: mustJSON(t, shipPayload), ParentJobID: "root", DelegationID: "ship", DelegationDepth: 1}, "", "")
+	mustCreateJob(t, store, db.Job{ID: "child-ship", Agent: "worker", Type: "implement", State: "running", Payload: mustJSON(t, shipPayload), Model: "sonnet", ParentJobID: "root", DelegationID: "ship", DelegationDepth: 1}, "", "")
 	singlePayload := workflow.JobPayload{WorkflowID: "release-42", TaskTitle: "standalone audit"}
 	mustCreateJob(t, store, db.Job{ID: "single", Agent: "worker", Type: "review", State: "succeeded", Payload: mustJSON(t, singlePayload)}, "", "")
 	for id, usage := range map[string][2]int{"root": {2, 3}, "child-prep": {5, 7}, "child-ship": {11, 13}, "single": {17, 19}} {

--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -1220,6 +1220,11 @@ func printJob(stdout io.Writer, job db.Job, payload workflow.JobPayload, reason 
 	}
 	fmt.Fprintf(stdout, "type: %s\n", job.Type)
 	fmt.Fprintf(stdout, "agent: %s\n", job.Agent)
+	model := strings.TrimSpace(job.Model)
+	if model == "" {
+		model = "-"
+	}
+	fmt.Fprintf(stdout, "model: %s\n", model)
 	if payload.WorkflowID != "" {
 		fmt.Fprintf(stdout, "workflow: %s\n", payload.WorkflowID)
 	}
@@ -1287,21 +1292,14 @@ func transcriptStyleTerminal(w io.Writer) bool {
 
 // transcriptHeader assembles the orientation block shown before a transcript:
 // job action, agent, runtime/model, workflow label, and the (capped, redacted)
-// prompt. Model resolution mirrors dispatch: per-job override first, then the
-// agent's registered default; empty stays empty rather than guessing a runtime
-// default. Agent-registry lookup is best-effort — ephemeral workers have no row.
+// prompt. Model comes from the durable enqueue-time snapshot on the job row;
+// mutable agent/runtime defaults are never re-read for historical jobs.
 func transcriptHeader(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, runtimeName string) transcript.Header {
-	model := strings.TrimSpace(payload.Model)
-	if model == "" {
-		if agent, err := store.GetAgent(ctx, job.Agent); err == nil {
-			model = strings.TrimSpace(agent.Model)
-		}
-	}
 	return transcript.Header{
 		Action:   job.Type,
 		Agent:    job.Agent,
 		Runtime:  runtimeName,
-		Model:    model,
+		Model:    strings.TrimSpace(job.Model),
 		Workflow: job.WorkflowID,
 		Prompt:   payload.Instructions,
 	}

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -28,6 +28,7 @@ func TestRunJobListShowEventsRetryCancel(t *testing.T) {
 		Agent:   "audit",
 		Type:    "ask",
 		State:   string(workflow.JobFailed),
+		Model:   "gpt-5.6-sol",
 		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Branch: "main", PullRequest: 7, RawOutputs: []string{"raw"}}),
 	}, "failed")
 	seedCLIJob(t, store, db.Job{
@@ -53,10 +54,34 @@ func TestRunJobListShowEventsRetryCancel(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("job show exit code = %d, stderr=%s", code, stderr.String())
 	}
-	for _, want := range []string{"id: job-failed", "state: failed", "repo: owner/repo", "raw_outputs: 1 retained locally"} {
+	for _, want := range []string{"id: job-failed", "state: failed", "model: gpt-5.6-sol", "repo: owner/repo", "raw_outputs: 1 retained locally"} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("job show missing %q:\n%s", want, stdout.String())
 		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "show", "job-failed", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("job show --json exit code = %d, stderr=%s", code, stderr.String())
+	}
+	var shown jobShowOutput
+	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil {
+		t.Fatalf("decode job show --json: %v\n%s", err, stdout.String())
+	}
+	if shown.Job.Model != "gpt-5.6-sol" {
+		t.Fatalf("job show --json model = %q, want gpt-5.6-sol", shown.Job.Model)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"job", "show", "job-queued", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("empty-model job show exit code = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "model: -") {
+		t.Fatalf("empty-model job show output missing model placeholder:\n%s", stdout.String())
 	}
 
 	stdout.Reset()
@@ -984,18 +1009,22 @@ func TestTranscriptHeaderModelResolution(t *testing.T) {
 	if err := store.UpsertAgent(context.Background(), db.Agent{Name: "modeled", Runtime: runtime.CodexRuntime, Model: "gpt-5.5"}); err != nil {
 		t.Fatal(err)
 	}
-	job := db.Job{ID: "hdr", Type: "ask", Agent: "modeled", WorkflowID: "wf"}
+	job := db.Job{ID: "hdr", Type: "ask", Agent: "modeled", WorkflowID: "wf", Model: "gpt-5.6-sol"}
 	h := transcriptHeader(context.Background(), store, job, workflow.JobPayload{Model: "gpt-5.4", Instructions: "prompt text"}, runtime.CodexRuntime)
-	if h.Model != "gpt-5.4" || h.Action != "ask" || h.Workflow != "wf" || h.Prompt != "prompt text" {
-		t.Fatalf("override header = %+v", h)
+	if h.Model != "gpt-5.6-sol" || h.Action != "ask" || h.Workflow != "wf" || h.Prompt != "prompt text" {
+		t.Fatalf("persisted-model header = %+v", h)
+	}
+	// Mutable agent config must not rewrite the historical transcript header.
+	if err := store.UpsertAgent(context.Background(), db.Agent{Name: "modeled", Runtime: runtime.CodexRuntime, Model: "new-agent-default"}); err != nil {
+		t.Fatal(err)
 	}
 	h = transcriptHeader(context.Background(), store, job, workflow.JobPayload{}, runtime.CodexRuntime)
-	if h.Model != "gpt-5.5" {
-		t.Fatalf("registry model = %q, want gpt-5.5", h.Model)
+	if h.Model != "gpt-5.6-sol" {
+		t.Fatalf("model after agent mutation = %q, want persisted gpt-5.6-sol", h.Model)
 	}
-	eph := db.Job{ID: "hdr2", Type: "ask", Agent: "no-row"}
+	eph := db.Job{ID: "hdr2", Type: "ask", Agent: "no-row", Model: "k3"}
 	h = transcriptHeader(context.Background(), store, eph, workflow.JobPayload{}, runtime.KimiRuntime)
-	if h.Model != "" {
-		t.Fatalf("ephemeral model = %q, want empty", h.Model)
+	if h.Model != "k3" {
+		t.Fatalf("ephemeral model = %q, want k3", h.Model)
 	}
 }

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -52,7 +52,7 @@ type pipelineAutoMergeExecutor interface {
 // indistinguishable from a normal background job once enqueued (the runner agent
 // carries no template, so canary never actually samples).
 func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueuer {
-	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home)}
+	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home)}
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
 		// #757 read-only isolation: a repo-bound AGENT stage (ask/review) is born
 		// with its OWN detached committed-tip worktree (the #739 shape) so it keys

--- a/internal/cli/runtime_override.go
+++ b/internal/cli/runtime_override.go
@@ -75,15 +75,7 @@ func resolveJobRuntimeOverride(overrideRuntime string, session string) (string, 
 // and --effort still flow through the job payload). A payload with no override
 // returns the agent unchanged. The stored agent row is never modified.
 func applyJobRuntimeOverride(agent runtime.Agent, payload workflow.JobPayload) runtime.Agent {
-	rt := strings.TrimSpace(payload.RuntimeOverride)
-	if rt == "" {
-		return agent
-	}
-	agent.Runtime = rt
-	agent.RuntimeRef = strings.TrimSpace(payload.RuntimeOverrideRef)
-	agent.Model = ""
-	agent.Effort = ""
-	return agent
+	return runtime.ApplyJobRuntimeOverride(agent, payload.RuntimeOverride, payload.RuntimeOverrideRef)
 }
 
 // scopeRegisteredFreshRefForJob rewrites a stored fresh:<seat> ref to a

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -1156,7 +1156,7 @@ func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Ta
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return db.Job{}, err
 	}
-	return (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home)}).Enqueue(ctx, request)
+	return (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home)}).Enqueue(ctx, request)
 }
 
 func findActiveTaskRunJob(ctx context.Context, store *db.Store, request workflow.JobRequest) (db.Job, bool, error) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2009,7 +2009,11 @@ func (d Daemon) enqueueJob(ctx context.Context, request workflow.JobRequest) (db
 	// (and its regression comparator) is gated on, so a stranded canary is never
 	// sampled once the knob is off. The engine carries the resolved flag.
 	canaryEnabled := d.Workflow != nil && d.Workflow.CanaryEnabled
-	job, err := (workflow.Mailbox{Store: d.Store, CanaryEnabled: canaryEnabled}).Enqueue(ctx, request)
+	var runtimeDefaultModel func(string) string
+	if d.Workflow != nil {
+		runtimeDefaultModel = d.Workflow.RuntimeDefaultModel
+	}
+	job, err := (workflow.Mailbox{Store: d.Store, CanaryEnabled: canaryEnabled, RuntimeDefaultModel: runtimeDefaultModel}).Enqueue(ctx, request)
 	return job, true, err
 }
 

--- a/internal/db/dashboard_store.go
+++ b/internal/db/dashboard_store.go
@@ -41,6 +41,7 @@ type DashboardJobSummaryRow struct {
 	Agent             string
 	Type              string
 	State             string
+	Model             string
 	Instructions      string
 	ParentJobID       string
 	DelegationDepth   int
@@ -93,7 +94,7 @@ func (s *Store) DashboardChangeCursor(ctx context.Context) (jobEventID, workflow
 // parser tolerated by returning an empty payload.
 func (s *Store) ListDashboardJobSummaries(ctx context.Context) ([]DashboardJobSummaryRow, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT
-		j.id, j.agent, j.type, j.state,
+		j.id, j.agent, j.type, j.state, j.model,
 		CASE WHEN json_valid(j.payload) AND json_type(j.payload, '$.instructions') = 'text'
 			THEN json_extract(j.payload, '$.instructions') ELSE '' END,
 		j.parent_job_id, j.delegation_depth, COALESCE(a.runtime, ''),
@@ -116,7 +117,7 @@ func (s *Store) ListDashboardJobSummaries(ctx context.Context) ([]DashboardJobSu
 	for rows.Next() {
 		var item DashboardJobSummaryRow
 		if err := rows.Scan(
-			&item.ID, &item.Agent, &item.Type, &item.State, &item.Instructions,
+			&item.ID, &item.Agent, &item.Type, &item.State, &item.Model, &item.Instructions,
 			&item.ParentJobID, &item.DelegationDepth, &item.RegisteredRuntime,
 			&item.EphemeralRuntime, &item.Repo, &item.PullRequest,
 			&item.InputTokens, &item.OutputTokens, &item.UpdatedAt, &item.CreatedAt,

--- a/internal/db/dashboard_store_test.go
+++ b/internal/db/dashboard_store_test.go
@@ -88,11 +88,13 @@ func TestListDashboardJobSummariesProjectsLegacyAndMalformedPayloads(t *testing.
 	jobs := []Job{
 		{
 			ID: "current", Agent: "registered", Type: "ask", State: "running",
+			Model:       "gpt-5.6-sol",
 			Payload:     `{"instructions":"  current title  ","repo":"acme/current","pull_request":42,"ephemeral":{"runtime":"kimi"}}`,
 			InputTokens: 3, OutputTokens: 5,
 		},
 		{
 			ID: "ephemeral", Agent: "temp-worker", Type: "implement", State: "queued",
+			Model:   "claude-fable-5",
 			Payload: `{"instructions":"inline","repo":"acme/inline","ephemeral":{"runtime":"claude"}}`,
 		},
 		{
@@ -129,19 +131,19 @@ func TestListDashboardJobSummariesProjectsLegacyAndMalformedPayloads(t *testing.
 	}
 	current := byID["current"]
 	if current.Instructions != "  current title  " || current.Repo != "acme/current" || current.PullRequest != 42 ||
-		current.RegisteredRuntime != "codex" || current.EphemeralRuntime != "kimi" || current.InputTokens != 3 || current.OutputTokens != 5 {
+		current.RegisteredRuntime != "codex" || current.EphemeralRuntime != "kimi" || current.Model != "gpt-5.6-sol" || current.InputTokens != 3 || current.OutputTokens != 5 {
 		t.Fatalf("current projection = %+v", current)
 	}
 	inline := byID["ephemeral"]
-	if inline.RegisteredRuntime != "" || inline.EphemeralRuntime != "claude" || inline.Repo != "acme/inline" {
+	if inline.RegisteredRuntime != "" || inline.EphemeralRuntime != "claude" || inline.Model != "claude-fable-5" || inline.Repo != "acme/inline" {
 		t.Fatalf("ephemeral projection = %+v", inline)
 	}
 	legacy := byID["legacy"]
-	if legacy.Repo != "acme/legacy" || legacy.PullRequest != 7 || legacy.Instructions != "legacy" {
+	if legacy.Repo != "acme/legacy" || legacy.PullRequest != 7 || legacy.Instructions != "legacy" || legacy.Model != "" {
 		t.Fatalf("legacy projection = %+v", legacy)
 	}
 	malformed := byID["malformed"]
-	if malformed.Instructions != "" || malformed.Repo != "" || malformed.PullRequest != 0 || malformed.EphemeralRuntime != "" {
+	if malformed.Instructions != "" || malformed.Repo != "" || malformed.PullRequest != 0 || malformed.EphemeralRuntime != "" || malformed.Model != "" {
 		t.Fatalf("malformed projection = %+v, want empty payload fields", malformed)
 	}
 }

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestUpdateJobUsageRoundTrip pins the #338 Part B usage write path: a job starts
@@ -266,4 +267,116 @@ INSERT INTO jobs(id, agent, type, state, payload) VALUES ('old', 'w', 'ask', 'su
 	if got.InputTokens != 42 || got.OutputTokens != 7 {
 		t.Fatalf("migrated row usage after write = (%d, %d), want (42, 7)", got.InputTokens, got.OutputTokens)
 	}
+}
+
+// TestJobModelMigrationOnPreExistingDB pins the additive model migration and
+// every Job-valued projection. A legacy row defaults to the honest unknown
+// value, while all three insert paths and every selector round-trip a new
+// enqueue-time snapshot without positional scan drift.
+func TestJobModelMigrationOnPreExistingDB(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "gitmoot.db")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	preModel := &Store{db: raw, path: path}
+	modelMigration := -1
+	for i, migration := range migrations {
+		if strings.Contains(migration, "ALTER TABLE jobs ADD COLUMN model TEXT") {
+			modelMigration = i
+			break
+		}
+	}
+	if modelMigration < 0 {
+		t.Fatal("model migration not found")
+	}
+	for version, migration := range migrations[:modelMigration] {
+		if err := preModel.applyMigration(ctx, version+1, migration); err != nil {
+			t.Fatalf("apply pre-model migration %d: %v", version+1, err)
+		}
+	}
+	if _, err := raw.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload) VALUES ('legacy-model', 'old-agent', 'ask', 'succeeded', '{}')`); err != nil {
+		t.Fatalf("insert legacy job: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close pre-model db: %v", err)
+	}
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open migrated db: %v", err)
+	}
+	defer store.Close()
+	legacy, err := store.GetJob(ctx, "legacy-model")
+	if err != nil {
+		t.Fatalf("GetJob legacy: %v", err)
+	}
+	if legacy.Model != "" {
+		t.Fatalf("legacy Model = %q, want empty", legacy.Model)
+	}
+
+	basePayload := `{"root_job_id":"model-root","workflow_id":"model-wf","repo":"owner/repo"}`
+	if err := store.CreateJob(ctx, Job{
+		ID: "model-base", Agent: "worker", Type: "ask", State: "queued", Payload: basePayload,
+		Model: "gpt-5.6-sol", ParentJobID: "model-parent",
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, Job{
+		ID: "model-event", Agent: "worker", Type: "review", State: "running", Payload: `{}`, Model: "k3",
+	}, JobEvent{Kind: "queued", Message: "created"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	if err := store.CreateExternallyDrivenJobWithEvent(ctx, Job{
+		ID: "model-external", Agent: "worker", Type: "ask", State: "running", Payload: `{}`, Model: "claude-fable-5",
+	}, JobEvent{Kind: "running", Message: "opened"}); err != nil {
+		t.Fatalf("CreateExternallyDrivenJobWithEvent: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE jobs SET updated_at = '2000-01-01 00:00:00' WHERE id = 'model-event'`); err != nil {
+		t.Fatalf("backdate running job: %v", err)
+	}
+
+	assertJobModel := func(label string, jobs []Job, err error, id, want string) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		for _, job := range jobs {
+			if job.ID == id {
+				if job.Model != want {
+					t.Fatalf("%s %s Model = %q, want %q", label, id, job.Model, want)
+				}
+				return
+			}
+		}
+		t.Fatalf("%s missing %s: %+v", label, id, jobs)
+	}
+
+	got, err := store.GetJob(ctx, "model-base")
+	if err != nil || got.Model != "gpt-5.6-sol" {
+		t.Fatalf("GetJob model-base = %+v, err=%v", got, err)
+	}
+	for id, want := range map[string]string{"model-event": "k3", "model-external": "claude-fable-5"} {
+		got, err := store.GetJob(ctx, id)
+		if err != nil || got.Model != want {
+			t.Fatalf("GetJob %s = %+v, err=%v, want Model %q", id, got, err, want)
+		}
+	}
+	jobs, err := store.ListJobs(ctx)
+	assertJobModel("ListJobs", jobs, err, "model-base", "gpt-5.6-sol")
+	jobs, err = store.ListJobsByType(ctx, "ask")
+	assertJobModel("ListJobsByType", jobs, err, "model-base", "gpt-5.6-sol")
+	jobs, err = store.ListJobsByParent(ctx, "model-parent")
+	assertJobModel("ListJobsByParent", jobs, err, "model-base", "gpt-5.6-sol")
+	jobs, err = store.ListJobsByRoot(ctx, "model-root")
+	assertJobModel("ListJobsByRoot", jobs, err, "model-base", "gpt-5.6-sol")
+	jobs, err = store.ListQueuedJobs(ctx)
+	assertJobModel("ListQueuedJobs", jobs, err, "model-base", "gpt-5.6-sol")
+	jobs, err = store.ListRunningJobsUpdatedBefore(ctx, time.Now().Add(time.Hour))
+	assertJobModel("ListRunningJobsUpdatedBefore", jobs, err, "model-event", "k3")
+	jobs, err = store.ListJobsByWorkflow(ctx, "model-wf", 0)
+	assertJobModel("ListJobsByWorkflow", jobs, err, "model-base", "gpt-5.6-sol")
+	jobs, err = store.ListWorkflowGraphJobs(ctx, "model-wf")
+	assertJobModel("ListWorkflowGraphJobs", jobs, err, "model-base", "gpt-5.6-sol")
 }

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -258,11 +258,15 @@ type Comment struct {
 }
 
 type Job struct {
-	ID              string
-	Agent           string
-	Type            string
-	State           string
-	Payload         string
+	ID      string
+	Agent   string
+	Type    string
+	State   string
+	Payload string
+	// Model is the durable model selected when the job was enqueued. Unlike the
+	// payload's per-job override, it also snapshots agent and runtime defaults so
+	// historical jobs do not change when mutable configuration changes.
+	Model           string
 	ParentJobID     string
 	DelegationID    string
 	DelegationDepth int
@@ -2765,9 +2769,9 @@ func (s *Store) CreateJob(ctx context.Context, job Job) error {
 	// the invariant — payload root when set, else self-root — holds regardless of
 	// caller. payload.RootJobID stays the value source of truth.
 	projection := jobProjectionFromPayload(job.Payload)
-	_, err := s.db.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
-		job.ID, job.Agent, job.Type, job.State, job.Payload,
+	_, err := s.db.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		job.ID, job.Agent, job.Type, job.State, job.Payload, job.Model,
 		jobResultHashFromPayload(job.Payload),
 		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy,
 		rootIDFromPayload(job.Payload), job.ID, projection.WorkflowID, projection.Repo, projection.PullRequest,
@@ -2785,9 +2789,9 @@ func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent)
 	// See CreateJob: same COALESCE(NULLIF(?,''), ?) bound to (payload.RootJobID,
 	// job.ID) denormalizes the rootJobID() rule onto the indexed root_id column.
 	projection := jobProjectionFromPayload(job.Payload)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
-		job.ID, job.Agent, job.Type, job.State, job.Payload,
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)`,
+		job.ID, job.Agent, job.Type, job.State, job.Payload, job.Model,
 		jobResultHashFromPayload(job.Payload),
 		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy,
 		rootIDFromPayload(job.Payload), job.ID, projection.WorkflowID, projection.Repo, projection.PullRequest,
@@ -2819,9 +2823,9 @@ func (s *Store) CreateExternallyDrivenJobWithEvent(ctx context.Context, job Job,
 	defer tx.Rollback()
 
 	projection := jobProjectionFromPayload(job.Payload)
-	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, externally_driven, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)`,
-		job.ID, job.Agent, job.Type, job.State, job.Payload,
+	if _, err := tx.ExecContext(ctx, `INSERT INTO jobs(id, agent, type, state, payload, model, result_hash, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, blocker_retry_at, blocker_suggested_action, externally_driven, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(NULLIF(?,''), ?), ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)`,
+		job.ID, job.Agent, job.Type, job.State, job.Payload, job.Model,
 		jobResultHashFromPayload(job.Payload),
 		job.ParentJobID, job.DelegationID, job.DelegationDepth, job.DelegatedBy,
 		rootIDFromPayload(job.Payload), job.ID, projection.WorkflowID, projection.Repo, projection.PullRequest,
@@ -2875,9 +2879,9 @@ func (s *Store) IsRootJobKilled(ctx context.Context, rootID string) (bool, error
 }
 
 func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, workflow_id, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven FROM jobs WHERE id = ?`, id)
+	row := s.db.QueryRowContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, workflow_id, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven FROM jobs WHERE id = ?`, id)
 	var job Job
-	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.WorkflowID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven); err != nil {
+	if err := row.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.WorkflowID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven); err != nil {
 		return Job{}, err
 	}
 	return job, nil
@@ -2886,7 +2890,7 @@ func (s *Store) GetJob(ctx context.Context, id string) (Job, error) {
 // jobColumns is the shared core projection ListJobs and ListJobsByType both
 // read, kept as one const so their SELECT lists and scanJobs order cannot drift.
 // Workflow-only scalar projections are selected by ListJobsByWorkflow.
-const jobColumns = `id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, workflow_id, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven`
+const jobColumns = `id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, workflow_id, root_killed, input_tokens, output_tokens, updated_at, created_at, externally_driven`
 
 // scanJobs reads every row of a *sql.Rows produced by a `SELECT `+jobColumns+`
 // FROM jobs …` query into Jobs, in jobColumns order, and closes rows. Shared by
@@ -2896,7 +2900,7 @@ func scanJobs(rows *sql.Rows) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.WorkflowID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.WorkflowID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ExternallyDriven); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2954,7 +2958,7 @@ func (s *Store) ListJobsByType(ctx context.Context, jobType string) ([]Job, erro
 // id for a stable tree. It selects updated_at like ListJobs so callers can show
 // child age; the idx_jobs_parent_job_id index backs the filter.
 func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens, updated_at
 		FROM jobs WHERE parent_job_id = ? ORDER BY delegation_id, id`, parentJobID)
 	if err != nil {
 		return nil, err
@@ -2964,7 +2968,7 @@ func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -2979,7 +2983,7 @@ func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job
 // idx_jobs_root_id for an indexed lookup instead of a full-table scan that
 // unmarshals every payload. ORDER BY id is deterministic.
 func (s *Store) ListJobsByRoot(ctx context.Context, rootID string) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, root_killed, input_tokens, output_tokens, updated_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, root_killed, input_tokens, output_tokens, updated_at
 		FROM jobs WHERE root_id = ? ORDER BY id`, rootID)
 	if err != nil {
 		return nil, err
@@ -2989,7 +2993,7 @@ func (s *Store) ListJobsByRoot(ctx context.Context, rootID string) ([]Job, error
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -3023,7 +3027,7 @@ func (s *Store) SumJobTokensByRoot(ctx context.Context, rootID string) (int, err
 // so the plan test (TestListQueuedJobsUsesQueuedIndex) can EXPLAIN QUERY PLAN the
 // PRODUCTION text rather than a hand-copied duplicate — a change to this query is then
 // what the test actually asserts a plan for.
-const listQueuedJobsSQL = `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
+const listQueuedJobsSQL = `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
 		FROM jobs WHERE state = 'queued' AND externally_driven = 0 ORDER BY created_at, rowid`
 
 // ListQueuedJobs returns the queued jobs in created_at (then rowid) order. The
@@ -3051,7 +3055,7 @@ func (s *Store) ListQueuedJobs(ctx context.Context) ([]Job, error) {
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -3079,7 +3083,7 @@ func (s *Store) CountQueuedJobsForRepo(ctx context.Context, repo string) (int, e
 // must never time it out and requeue it (which would try to Deliver work the
 // engine never owned). Engine-driven jobs default externally_driven = 0, so their
 // reaping is byte-identical.
-const listRunningJobsUpdatedBeforeSQL = `SELECT id, agent, type, state, payload, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
+const listRunningJobsUpdatedBeforeSQL = `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_killed, input_tokens, output_tokens
 		FROM jobs WHERE state = 'running' AND externally_driven = 0 AND updated_at < ? ORDER BY updated_at`
 
 // ListRunningJobsUpdatedBefore returns the running jobs whose updated_at predates
@@ -3104,7 +3108,7 @@ func (s *Store) ListRunningJobsUpdatedBefore(ctx context.Context, before time.Ti
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootKilled, &job.InputTokens, &job.OutputTokens); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)
@@ -9253,5 +9257,11 @@ CREATE TABLE memory_events (
 );
 CREATE INDEX idx_memory_events_at ON memory_events(at);
 CREATE INDEX idx_memory_events_memory_id ON memory_events(memory_id);
+	`,
+	// #998 P1 durable enqueue-time model snapshot. Existing jobs honestly remain
+	// unknown; every mailbox-created job writes the selected override, agent
+	// default, or runtime default into this additive scalar column.
+	`
+ALTER TABLE jobs ADD COLUMN model TEXT NOT NULL DEFAULT '';
 	`,
 }

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -153,7 +153,7 @@ ORDER BY last_at DESC, labels.workflow_id`
 const WorkflowSummarySQL = workflowSummarySelectSQL + `
 WHERE labels.workflow_id = ?`
 
-const ListJobsByWorkflowSQL = `SELECT id, agent, type, state, workflow_id, repo, pull_request,
+const ListJobsByWorkflowSQL = `SELECT id, agent, type, state, model, workflow_id, repo, pull_request,
 	blocker_retry_at, blocker_suggested_action, input_tokens, output_tokens, created_at, updated_at
 FROM jobs INDEXED BY idx_jobs_workflow_id
 WHERE workflow_id != '' AND workflow_id = ?
@@ -164,7 +164,7 @@ ORDER BY created_at, id LIMIT ?`
 // labeled job's payload to render titles, dependency edges, runtime overrides,
 // and models. The workflow_id predicate keeps that payload scan scoped to one
 // indexed label instead of materializing payloads globally.
-const ListWorkflowGraphJobsSQL = `SELECT id, agent, type, state, payload, parent_job_id,
+const ListWorkflowGraphJobsSQL = `SELECT id, agent, type, state, payload, model, parent_job_id,
 	delegation_id, delegation_depth, root_id, workflow_id, input_tokens, output_tokens,
 	created_at, updated_at
 FROM jobs INDEXED BY idx_jobs_workflow_id
@@ -675,7 +675,7 @@ func (s *Store) ListJobsByWorkflow(ctx context.Context, workflowID string, limit
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.WorkflowID, &job.Repo, &job.PullRequest,
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Model, &job.WorkflowID, &job.Repo, &job.PullRequest,
 			&job.BlockerRetryAt, &job.BlockerSuggestedAction,
 			&job.InputTokens, &job.OutputTokens, &job.CreatedAt, &job.UpdatedAt); err != nil {
 			return nil, err
@@ -697,7 +697,7 @@ func (s *Store) ListWorkflowGraphJobs(ctx context.Context, workflowID string) ([
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload,
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model,
 			&job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.RootID,
 			&job.WorkflowID, &job.InputTokens, &job.OutputTokens, &job.CreatedAt,
 			&job.UpdatedAt); err != nil {

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -128,7 +128,7 @@ type Job struct {
 	// RuntimeDefaultModel is the runtime's configured registry default_model
 	// (#652), threaded in by the dispatch layer from the HOME-AWARE resolved runtime
 	// registry (built-in defaults overlaid with [runtimes.<name>] config). It is the
-	// FINAL model fallback: effectiveModel uses it ONLY when neither the job (Model)
+	// FINAL model fallback: EffectiveModel uses it ONLY when neither the job (Model)
 	// nor the agent (Agent.Model) pins a model, so an agent/job --model always wins.
 	// Empty — the built-in default for every runtime, and the value when no config
 	// sets it — means "no registry default", so delivery defers to the runtime CLI's
@@ -541,7 +541,7 @@ func (a CodexAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result
 	if err := a.Validate(ctx, agent); err != nil {
 		return Result{}, err
 	}
-	model := effectiveModel(agent, job)
+	model := EffectiveModel(agent, job)
 	effort := effectiveEffort(agent, job)
 	// A fresh ref (per-job --runtime override, #531) starts a brand-new exec
 	// session — never `resume` — so an overridden job cannot read or pollute any
@@ -732,14 +732,14 @@ func (a CodexAdapter) sessionResolver() CodexSessionResolver {
 	return CodexSessionIndex{}
 }
 
-// effectiveModel resolves which model a delivered job runs on. Precedence, most
+// EffectiveModel resolves which model a delivered job runs on. Precedence, most
 // specific first: the per-job/per-delegation override (job.Model) wins, then the
 // agent's configured default (agent.Model), then — when NEITHER pins a model — the
 // runtime's configured registry default_model (job.RuntimeDefaultModel, #652). An
 // empty result means "no --model arg" (the runtime CLI's own default). Because the
 // registry default is consulted last and defaults to empty, an agent/job pin
 // always wins and an unset registry default is byte-identical to before #652.
-func effectiveModel(agent Agent, job Job) string {
+func EffectiveModel(agent Agent, job Job) string {
 	if job.Model != "" {
 		return job.Model
 	}
@@ -749,8 +749,24 @@ func effectiveModel(agent Agent, job Job) string {
 	return strings.TrimSpace(job.RuntimeDefaultModel)
 }
 
+// ApplyJobRuntimeOverride returns the effective agent identity for a job-level
+// runtime override. Model and effort defaults belong to the registered runtime,
+// so both are cleared when switching runtimes; the caller's per-job Model and
+// Effort continue to travel on Job.
+func ApplyJobRuntimeOverride(agent Agent, runtimeName, runtimeRef string) Agent {
+	runtimeName = strings.TrimSpace(runtimeName)
+	if runtimeName == "" {
+		return agent
+	}
+	agent.Runtime = runtimeName
+	agent.RuntimeRef = strings.TrimSpace(runtimeRef)
+	agent.Model = ""
+	agent.Effort = ""
+	return agent
+}
+
 // effectiveEffort resolves which reasoning effort a delivered job runs with.
-// Precedence mirrors effectiveModel exactly: the per-job override wins, then the
+// Precedence mirrors EffectiveModel exactly: the per-job override wins, then the
 // agent default, then the runtime registry default_effort. An empty result means
 // no `-c model_reasoning_effort=...` argument is emitted.
 func effectiveEffort(agent Agent, job Job) string {
@@ -929,7 +945,7 @@ func (a ClaudeAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resul
 	if err := a.Validate(ctx, agent); err != nil {
 		return Result{}, err
 	}
-	model := effectiveModel(agent, job)
+	model := EffectiveModel(agent, job)
 	// A fresh ref (per-job --runtime override, #531) delivers on a brand-new
 	// dedicated --session-id — never --resume/--continue — so an overridden job
 	// cannot read or pollute any stored session's state.

--- a/internal/runtime/adapter_test.go
+++ b/internal/runtime/adapter_test.go
@@ -227,9 +227,9 @@ func TestEffectiveModelResolutionOrder(t *testing.T) {
 		{"rt default trimmed", "", "", "  gpt-5.5  ", "gpt-5.5"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := effectiveModel(Agent{Model: tc.agentModel}, Job{Model: tc.jobModel, RuntimeDefaultModel: tc.rtDefault})
+			got := EffectiveModel(Agent{Model: tc.agentModel}, Job{Model: tc.jobModel, RuntimeDefaultModel: tc.rtDefault})
 			if got != tc.want {
-				t.Fatalf("effectiveModel(agent=%q, job=%q, rtDefault=%q) = %q, want %q", tc.agentModel, tc.jobModel, tc.rtDefault, got, tc.want)
+				t.Fatalf("EffectiveModel(agent=%q, job=%q, rtDefault=%q) = %q, want %q", tc.agentModel, tc.jobModel, tc.rtDefault, got, tc.want)
 			}
 		})
 	}

--- a/internal/runtime/kimi.go
+++ b/internal/runtime/kimi.go
@@ -139,7 +139,7 @@ func (a KimiAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result,
 		return Result{}, err
 	}
 	args := kimiPermissionArgs(agent)
-	model := effectiveModel(agent, job)
+	model := EffectiveModel(agent, job)
 	if model != "" {
 		args = append(args, "--model", model)
 	}
@@ -255,7 +255,7 @@ func (a KimiCLIAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Resu
 		return Result{}, err
 	}
 	defer cleanup()
-	result, err := runAgentCommand(ctx, a.runner(), a.Dir, job.AgentEnv, "kimi", kimiCLIPromptArgs(agent, effectiveModel(agent, job), promptArg, extraArgs)...)
+	result, err := runAgentCommand(ctx, a.runner(), a.Dir, job.AgentEnv, "kimi", kimiCLIPromptArgs(agent, EffectiveModel(agent, job), promptArg, extraArgs)...)
 	if err != nil {
 		return Result{Raw: result.Stdout + result.Stderr, SessionDiag: newSessionDiag(result, err, "")}, kimiCommandError(result, err)
 	}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -506,10 +506,46 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationDepth: request.DelegationDepth,
 		DelegatedBy:     request.DelegatedBy,
 	}
+	job.Model, err = m.resolveEnqueueModel(ctx, request)
+	if err != nil {
+		return db.Job{}, err
+	}
 	if err := m.Store.CreateJobWithEvent(ctx, job, db.JobEvent{JobID: job.ID, Kind: string(JobQueued), Message: "job queued"}); err != nil {
 		return db.Job{}, err
 	}
 	return job, nil
+}
+
+// resolveEnqueueModel snapshots the model selected for this job at the enqueue
+// chokepoint. It deliberately mirrors delivery: the job override wins, then the
+// effective agent's model, then that effective runtime's registry default. A
+// runtime override changes the runtime and clears the registered model because
+// that model belongs to the agent's original runtime. Ephemeral workers have no
+// agent row, so their inline runtime/model spec is their effective agent config.
+func (m Mailbox) resolveEnqueueModel(ctx context.Context, request JobRequest) (string, error) {
+	agent := runtime.Agent{}
+	if request.Ephemeral != nil {
+		agent.Runtime = strings.TrimSpace(request.Ephemeral.Runtime)
+		agent.Model = request.Ephemeral.Model
+	} else {
+		stored, err := m.Store.GetAgent(ctx, request.Agent)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return "", err
+		}
+		if err == nil {
+			agent.Runtime = stored.Runtime
+			agent.Model = stored.Model
+		}
+	}
+	agent = runtime.ApplyJobRuntimeOverride(agent, request.RuntimeOverride, request.RuntimeOverrideRef)
+	runtimeDefaultModel := ""
+	if m.RuntimeDefaultModel != nil {
+		runtimeDefaultModel = m.RuntimeDefaultModel(strings.TrimSpace(agent.Runtime))
+	}
+	return runtime.EffectiveModel(agent, runtime.Job{
+		Model:               request.Model,
+		RuntimeDefaultModel: runtimeDefaultModel,
+	}), nil
 }
 
 func (m Mailbox) templateSnapshot(ctx context.Context, agentName string) (db.AgentTemplate, error) {
@@ -1096,7 +1132,7 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		ShellUpstreamContext: payload.ShellUpstreamContext,
 	}
 	// #652: thread in the runtime's configured registry default_model as the FINAL
-	// model fallback. effectiveModel applies the precedence (job.Model > agent.Model
+	// model fallback. EffectiveModel applies the precedence (job.Model > agent.Model
 	// > this default), so an agent/job --model always wins; a nil hook or empty
 	// default forces nothing and is byte-identical. Resolved for the agent's
 	// EFFECTIVE runtime, so a #531 per-job runtime override picks up the override

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -385,6 +385,81 @@ func TestMailboxEnqueuePersistsModel(t *testing.T) {
 	}
 }
 
+// TestMailboxEnqueuePersistsResolvedModel proves the enqueue chokepoint stores
+// the selected model before any runtime delivery. It covers the complete
+// precedence plus the two agent shapes that cannot safely reuse a registered
+// default: runtime-overridden and ephemeral jobs.
+func TestMailboxEnqueuePersistsResolvedModel(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	for _, agent := range []db.Agent{
+		{Name: "pinned", Runtime: runtime.CodexRuntime, Model: "agent-codex"},
+		{Name: "defaulted", Runtime: runtime.KimiRuntime},
+		{Name: "overridden", Runtime: runtime.CodexRuntime, Model: "agent-codex"},
+	} {
+		if err := store.UpsertAgent(ctx, agent); err != nil {
+			t.Fatalf("UpsertAgent(%s): %v", agent.Name, err)
+		}
+	}
+	mailbox := Mailbox{Store: store, RuntimeDefaultModel: func(runtimeName string) string {
+		if runtimeName == runtime.KimiRuntime {
+			return "k3"
+		}
+		return ""
+	}}
+
+	for _, tc := range []struct {
+		name string
+		req  JobRequest
+		want string
+	}{
+		{
+			name: "explicit override beats agent and runtime",
+			req:  JobRequest{ID: "resolved-explicit", Agent: "pinned", Action: "ask", Repo: "owner/repo", Model: "job-model"},
+			want: "job-model",
+		},
+		{
+			name: "agent model beats runtime",
+			req:  JobRequest{ID: "resolved-agent", Agent: "pinned", Action: "ask", Repo: "owner/repo"},
+			want: "agent-codex",
+		},
+		{
+			name: "kimi runtime default",
+			req:  JobRequest{ID: "resolved-runtime", Agent: "defaulted", Action: "ask", Repo: "owner/repo"},
+			want: "k3",
+		},
+		{
+			name: "runtime override clears registered model",
+			req: JobRequest{ID: "resolved-runtime-override", Agent: "overridden", Action: "ask", Repo: "owner/repo",
+				RuntimeOverride: runtime.KimiRuntime, RuntimeOverrideRef: "fresh:override"},
+			want: "k3",
+		},
+		{
+			name: "ephemeral inline model",
+			req: JobRequest{ID: "resolved-ephemeral", Agent: "worker-ephemeral-test", Action: "review", Repo: "owner/repo",
+				ParentJobID: "parent", DelegationID: "worker", Ephemeral: &EphemeralSpec{Runtime: runtime.ClaudeRuntime, Model: "claude-fable-5"}},
+			want: "claude-fable-5",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			queued, err := mailbox.Enqueue(ctx, tc.req)
+			if err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			if queued.Model != tc.want {
+				t.Fatalf("returned Model = %q, want %q", queued.Model, tc.want)
+			}
+			persisted, err := store.GetJob(ctx, tc.req.ID)
+			if err != nil {
+				t.Fatalf("GetJob before Run: %v", err)
+			}
+			if persisted.Model != tc.want {
+				t.Fatalf("persisted Model before Run = %q, want %q", persisted.Model, tc.want)
+			}
+		})
+	}
+}
+
 func TestMailboxEnqueueOmitsEmptyModel(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
@@ -489,7 +564,7 @@ func TestMailboxRunDeliversModelAndEffortOverrides(t *testing.T) {
 // home-aware RuntimeDefaultModel hook is consulted at delivery and threaded onto the
 // delivered runtime.Job as the FINAL model fallback. With no agent --model and no
 // job --model, the job carries the runtime's configured default (RuntimeDefaultModel
-// set) while its explicit Model pin stays empty — so effectiveModel uses the default,
+// set) while its explicit Model pin stays empty — so EffectiveModel uses the default,
 // yet an agent/job pin (which would populate job.Model) still wins.
 func TestMailboxRunThreadsRuntimeDefaultModel(t *testing.T) {
 	ctx := context.Background()

--- a/internal/workflow/routing_telemetry.go
+++ b/internal/workflow/routing_telemetry.go
@@ -27,19 +27,17 @@ func (m Mailbox) recordRoutingTelemetry(ctx context.Context, job db.Job, agent r
 	if m.Store == nil {
 		return
 	}
-	// Mirror deliver()'s effective-model precedence (job.Model > agent.Model >
-	// runtime registry default_model, #652) so the recorded model dimension matches
-	// the model the delivery ACTUALLY ran on. Without the final fallback a job with
-	// no --model/agent.Model but a configured [runtimes.<rt>].default_model would
-	// record an empty bucket even though delivery used that default, mislabeling the
-	// observation as "default"/"-" and splitting the telemetry buckets.
-	model := strings.TrimSpace(payload.Model)
-	if model == "" {
-		model = strings.TrimSpace(agent.Model)
+	// Use the delivery resolver so telemetry cannot drift from the runtime's model
+	// precedence. Inputs are trimmed here to preserve this advisory surface's
+	// historical normalization behavior.
+	runtimeDefaultModel := ""
+	if m.RuntimeDefaultModel != nil {
+		runtimeDefaultModel = m.RuntimeDefaultModel(strings.TrimSpace(agent.Runtime))
 	}
-	if model == "" && m.RuntimeDefaultModel != nil {
-		model = strings.TrimSpace(m.RuntimeDefaultModel(strings.TrimSpace(agent.Runtime)))
-	}
+	model := runtime.EffectiveModel(
+		runtime.Agent{Model: strings.TrimSpace(agent.Model)},
+		runtime.Job{Model: strings.TrimSpace(payload.Model), RuntimeDefaultModel: runtimeDefaultModel},
+	)
 	durationMS := duration.Milliseconds()
 	if durationMS < 0 {
 		durationMS = 0

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1341,6 +1341,13 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+`gitmoot job show` reports the model selected when the job was enqueued: an
+explicit per-job/delegation model first, then the agent model, then the effective
+runtime's configured default model. Text output prints `model: -` when no model
+was known; `--json` carries the same durable value on the job row. This is the
+enqueue-time selection Gitmoot knew (P1), not a later runtime-reported effective
+model; runtime-reported truth is reserved for P2.
+
 When standard output is an interactive terminal (and `NO_COLOR` is unset),
 the transcript renders styled: agent turns get blank-line spacing and keep
 their line breaks plus lightweight heading/list/inline-code treatment. Tool

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10722,6 +10722,13 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+`gitmoot job show` reports the model selected when the job was enqueued: an
+explicit per-job/delegation model first, then the agent model, then the effective
+runtime's configured default model. Text output prints `model: -` when no model
+was known; `--json` carries the same durable value on the job row. This is the
+enqueue-time selection Gitmoot knew (P1), not a later runtime-reported effective
+model; runtime-reported truth is reserved for P2.
+
 When standard output is an interactive terminal (and `NO_COLOR` is unset),
 the transcript renders styled: agent turns get blank-line spacing and keep
 their line breaks plus lightweight heading/list/inline-code treatment. Tool


### PR DESCRIPTION
## Persist the effective model per job at enqueue — closes #998 (P1)

Jobs and `job show` exposed only the **runtime** (codex/claude/kimi), never the **model** (gpt-5.6-sol, k3, fable-5…). `payload.model` was set only for explicit `--model` overrides; agent-default and runtime-default models (e.g. kimi's config `default_model`) were invisible — answering *"which model produced this?"* required `ps` + `/proc` + reading the kimi CLI config.

### P1 — snapshot the model selected at enqueue onto a durable `jobs.model` column
- **Reuse the delivery precedence**: export `runtime.EffectiveModel` (`job.Model` override → `agent.Model` → runtime registry `default_model`) and `runtime.ApplyJobRuntimeOverride`; refactor `routing_telemetry` to the shared helper (**behavior-preserving**).
- **Capture in `Mailbox.Enqueue`** — the single chokepoint covering local dispatch, daemon PR/comment, delegation/continuations, pipeline stages, task-run, heartbeat, and merge-back. A **runtime override clears the registered agent model** so an overridden kimi job records `k3`, not its codex agent default. Ephemeral workers resolve from their inline spec. Never-delivered creators (session/external, task-recover, synthetic coordinator, failed produce) keep `model=''` → render `-`.
- **Column, not compute-on-read**: agent/runtime defaults are mutable and vanish on ephemeral cleanup, so a durable snapshot is the correct source for the **gitmoot-routing (model × task-class) telemetry** consumer. Threaded through the migration + every jobs INSERT/SELECT/scan + both workflow projections + `DashboardJobSummaryRow`.
- **Surface gitmoot-side**: `gitmoot job show` prints `model: <value>` / `-`; `transcriptHeader` and the workflow-graph `Node.Model` now use the durable snapshot instead of re-reading mutable agent config. `CLI.md` documented.

### Tests
Enqueue precedence (override / agent-default / kimi runtime-default / runtime-override-clears-agent-model / ephemeral) persisted **before** `Run`; migration on a pre-existing DB (legacy `''`) with every Job projection round-tripping; dashboard summary + cached `/api/jobs` byte-equivalence; `job show` text/json. Independent gate green: build/vet/generate-clean + `go test ./internal/{cli,workflow,db,runtime,daemon}` (cli 402s, workflow 105s, db 111s). Independent adversarial review confirmed scan-site completeness (no positional DB drift).

## Scope & handoff (this round's firewall)
gitmoot repo **only**. The `/api/jobs` wire field — `dashboard.JobSummary.Model` in the imported `gitmoot-dashboard` module — plus the `go.mod` bump and the dashboard **UI chip** are a **follow-up handoff** (module type + `go.mod` untouched here). The model already surfaces on the workflow-graph `Node.Model` (existing module field) and in `job show`.

## Deploy notes
Engine/db change — deploy `gitmoot` at idle. Additive migration (`ALTER TABLE jobs ADD COLUMN model TEXT NOT NULL DEFAULT ''`); old rows render `-`, no backfill. No config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
