### PR TITLE
feat(proof): content-addressed evidence manifest + gitmoot proof <root-id> (v1 core spine)

### DIFF
--- a/internal/cli/proof.go
+++ b/internal/cli/proof.go
@@ -1,0 +1,223 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/proof"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func runProof(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("proof", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print the canonical manifest JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 1 || strings.TrimSpace(fs.Arg(0)) == "" {
+		fmt.Fprintln(stderr, "proof requires one non-empty <root-id> (flags must precede it)")
+		return 2
+	}
+	rootID := strings.TrimSpace(fs.Arg(0))
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "proof: resolve home: %v\n", err)
+		return 1
+	}
+	store, err := db.OpenReadOnly(paths.Database)
+	if err != nil {
+		fmt.Fprintf(stderr, "proof: open read-only store: %v\n", err)
+		return 1
+	}
+	defer store.Close()
+
+	manifest, err := loadProofManifest(context.Background(), store, rootID)
+	if err != nil {
+		fmt.Fprintf(stderr, "proof: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		raw, err := proof.Marshal(manifest)
+		if err != nil {
+			fmt.Fprintf(stderr, "proof: encode manifest: %v\n", err)
+			return 1
+		}
+		if _, err := stdout.Write(append(raw, '\n')); err != nil {
+			fmt.Fprintf(stderr, "proof: write manifest: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if err := proof.RenderTree(stdout, manifest); err != nil {
+		fmt.Fprintf(stderr, "proof: render manifest: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func loadProofManifest(ctx context.Context, store *db.Store, rootID string) (proof.Manifest, error) {
+	jobs, err := store.ListJobsByRoot(ctx, rootID)
+	if err != nil {
+		return proof.Manifest{}, fmt.Errorf("list root %q: %w", rootID, err)
+	}
+	if len(jobs) == 0 {
+		return proof.Manifest{}, fmt.Errorf("unknown root-id %q", rootID)
+	}
+	results := make(map[string]*workflow.AgentResult, len(jobs))
+	payloads := make(map[string]workflow.JobPayload, len(jobs))
+	events := make(map[string][]db.JobEvent, len(jobs))
+	agents := map[string]db.Agent{}
+	rootIndex := -1
+	for i := range jobs {
+		job := &jobs[i]
+		if job.ID == rootID {
+			rootIndex = i
+		}
+		var payload workflow.JobPayload
+		// A corrupt row is evidence of a gap, not a reason to suppress the rest of
+		// the proof. Project records payload_unparseable on that session.
+		_ = json.Unmarshal([]byte(job.Payload), &payload)
+		payloads[job.ID] = payload
+		if payload.Result != nil {
+			results[job.ID] = payload.Result
+		}
+		if job.Repo == "" {
+			job.Repo = payload.Repo
+		}
+		if job.PullRequest == 0 {
+			job.PullRequest = payload.PullRequest
+		}
+		if job.WorkflowID == "" {
+			job.WorkflowID = payload.WorkflowID
+		}
+		if payload.RuntimeOverride != "" {
+			job.Runtime = payload.RuntimeOverride
+			job.RuntimeRef = payload.RuntimeOverrideRef
+		} else if strings.TrimSpace(job.Agent) != "" {
+			agent, ok := agents[job.Agent]
+			if !ok {
+				agent, err = store.GetAgent(ctx, job.Agent)
+				if err != nil && !errors.Is(err, sql.ErrNoRows) {
+					return proof.Manifest{}, fmt.Errorf("load agent %q: %w", job.Agent, err)
+				}
+				agents[job.Agent] = agent
+			}
+			job.Runtime = agent.Runtime
+			job.RuntimeRef = agent.RuntimeRef
+		}
+		jobEvents, err := store.ListJobEvents(ctx, job.ID)
+		if err != nil {
+			return proof.Manifest{}, fmt.Errorf("list events for job %q: %w", job.ID, err)
+		}
+		events[job.ID] = jobEvents
+	}
+	if rootIndex < 0 {
+		return proof.Manifest{}, fmt.Errorf("root-id %q has descendants but no root anchor job", rootID)
+	}
+
+	receipts, err := loadProofPRReceipts(ctx, store, jobs, payloads)
+	if err != nil {
+		return proof.Manifest{}, err
+	}
+	manifest := proof.Project(jobs[rootIndex], jobs, results, receipts, events)
+	if err := proof.VerifyManifest(manifest); err != nil {
+		return proof.Manifest{}, fmt.Errorf("verify projected manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func loadProofPRReceipts(ctx context.Context, store *db.Store, jobs []db.Job, payloads map[string]workflow.JobPayload) ([]proof.PRReceipt, error) {
+	receipts := map[string]proof.PRReceipt{}
+	notesByWorkflow := map[string][]db.WorkflowNote{}
+	for _, job := range jobs {
+		payload := payloads[job.ID]
+		repo := strings.TrimSpace(job.Repo)
+		if repo == "" {
+			repo = strings.TrimSpace(payload.Repo)
+		}
+		number := job.PullRequest
+		if number == 0 {
+			number = payload.PullRequest
+		}
+		if number <= 0 {
+			continue
+		}
+		key := fmt.Sprintf("%s#%d", repo, number)
+		if _, exists := receipts[key]; exists {
+			continue
+		}
+		receipt := proof.PRReceipt{Repo: repo, Number: number, HeadSHA: payload.HeadSHA}
+		storedMergeCommitSHA := ""
+		if repo != "" {
+			storedPR, err := store.GetPullRequest(ctx, repo, int64(number))
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("load stored PR %s: %w", key, err)
+			}
+			if err == nil {
+				receipt.HeadSHA = firstProofValue(storedPR.HeadSHA, receipt.HeadSHA)
+				storedMergeCommitSHA = storedPR.MergeCommitSHA
+				receipt.State = storedPR.State
+			}
+		}
+		workflowID := strings.TrimSpace(job.WorkflowID)
+		if workflowID == "" {
+			workflowID = strings.TrimSpace(payload.WorkflowID)
+		}
+		if workflowID != "" {
+			notes, loaded := notesByWorkflow[workflowID]
+			if !loaded {
+				var loadErr error
+				notes, loadErr = store.ListWorkflowNotes(ctx, workflowID, 0)
+				if loadErr != nil {
+					return nil, fmt.Errorf("load workflow receipts %q: %w", workflowID, loadErr)
+				}
+				notesByWorkflow[workflowID] = notes
+			}
+			for _, note := range notes {
+				if note.Author != db.WorkflowAutoNoteAuthor {
+					continue
+				}
+				if strings.HasPrefix(note.Body, fmt.Sprintf("[auto:pr:%d:opened]", number)) {
+					receipt.OpenedAt = note.CreatedAt
+				}
+				if strings.HasPrefix(note.Body, fmt.Sprintf("[auto:pr:%d:merged]", number)) {
+					receipt.MergedAt = note.CreatedAt
+					receipt.MergeCommitSHA = storedMergeCommitSHA
+				}
+			}
+		}
+		receipts[key] = receipt
+	}
+	keys := make([]string, 0, len(receipts))
+	for key := range receipts {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]proof.PRReceipt, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, receipts[key])
+	}
+	return out, nil
+}
+
+func firstProofValue(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/cli/proof_test.go
+++ b/internal/cli/proof_test.go
@@ -1,0 +1,297 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/proof"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestRunProofGradedTreeAndJSON(t *testing.T) {
+	home := t.TempDir()
+	seedCLIProof(t, home)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"proof", "--home", home, "root-proof"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("proof exit code = %d, stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"root root-proof [verified]", "session root-proof", "implementer · codex · gpt-5.6",
+		"lineage:", "go test ./internal/proof/ [reported; CI verification deferred]",
+		"reviewer · approved · findings 1 · independent [observed]",
+		"#17 · head abc123", "grades: reported=", "observed=", "verified=0",
+		"integrity: all ", "result_hashes matched",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("graded tree missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"proof", "--json", "--home", home, "root-proof"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("proof --json exit code = %d, stderr=%s", code, stderr.String())
+	}
+	firstJSON := append([]byte(nil), stdout.Bytes()...)
+	var manifest proof.Manifest
+	if err := json.Unmarshal(bytes.TrimSpace(firstJSON), &manifest); err != nil {
+		t.Fatalf("decode manifest: %v\n%s", err, firstJSON)
+	}
+	if err := proof.VerifyManifest(manifest); err != nil {
+		t.Fatalf("verify JSON manifest: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"proof", "--json", "--home", home, "root-proof"}, &stdout, &stderr)
+	if code != 0 || !bytes.Equal(firstJSON, stdout.Bytes()) {
+		t.Fatalf("proof --json is not byte-stable: code=%d\nfirst=%s\nsecond=%s\nstderr=%s", code, firstJSON, stdout.Bytes(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"proof", "--home", home, "unknown-root"}, &stdout, &stderr)
+	if code == 0 || !strings.Contains(stderr.String(), `unknown root-id "unknown-root"`) {
+		t.Fatalf("unknown root code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestRunProofDoesNotBorrowMergedReceiptAcrossPRs(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	ctx := context.Background()
+	for _, fixture := range []struct {
+		id  string
+		pr  int
+		sha string
+	}{
+		{id: "merged-pr-root", pr: 17, sha: "aaa111"},
+		{id: "open-pr-root", pr: 18, sha: "bbb222"},
+	} {
+		seedCLIJob(t, store, db.Job{
+			ID: fixture.id, Agent: "impl", Type: "implement", State: string(workflow.JobSucceeded),
+			Payload: mustJobPayload(t, workflow.JobPayload{
+				Repo: "owner/repo", PullRequest: fixture.pr, HeadSHA: fixture.sha, WorkflowID: "proof/shared",
+			}),
+		}, "done")
+	}
+	for _, pr := range []db.PullRequest{
+		{RepoFullName: "owner/repo", Number: 17, HeadSHA: "aaa111", MergeCommitSHA: "merged17", State: "merged"},
+		// A stale merge SHA on the PR row is not a daemon merge receipt and must
+		// not become merged evidence for this still-open PR.
+		{RepoFullName: "owner/repo", Number: 18, HeadSHA: "bbb222", MergeCommitSHA: "stale18", State: "open"},
+	} {
+		if err := store.UpsertPullRequest(ctx, pr); err != nil {
+			t.Fatalf("UpsertPullRequest: %v", err)
+		}
+	}
+	for _, body := range []string{
+		"[auto:pr:17:merged] PR #17 merged",
+		"[auto:pr:18:opened] PR #18 opened",
+	} {
+		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "proof/shared", Author: db.WorkflowAutoNoteAuthor, Body: body, Repo: "owner/repo",
+		}); err != nil {
+			t.Fatalf("InsertWorkflowNote: %v", err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"proof", "--json", "--home", home, "open-pr-root"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("proof --json code=%d stderr=%s", code, stderr.String())
+	}
+	var manifest proof.Manifest
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &manifest); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	var foundPR, foundOpened bool
+	for _, node := range manifest.Nodes {
+		if node.Kind != proof.KindPR || node.Attrs["number"] != "18" {
+			continue
+		}
+		foundPR = true
+		if node.Attrs["merged_at"] != "" || node.Attrs["merge_commit_sha"] != "" {
+			t.Fatalf("open PR borrowed merged attrs: %+v", node.Attrs)
+		}
+		for _, claim := range node.Claims {
+			if claim.Type == "pr.merged" {
+				t.Fatalf("open PR borrowed merged claim: %+v", claim)
+			}
+			if claim.Type == "pr.opened" {
+				foundOpened = true
+			}
+		}
+	}
+	if !foundPR || !foundOpened {
+		t.Fatalf("PR #18 proof missing PR/opened evidence: foundPR=%v foundOpened=%v", foundPR, foundOpened)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"proof", "--home", home, "open-pr-root"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("proof text code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "#18 · head bbb222") || !strings.Contains(stdout.String(), "· merged - · state open") {
+		t.Fatalf("open PR did not render an honest merged gap:\n%s", stdout.String())
+	}
+}
+
+func TestRunProofToleratesMalformedJobPayload(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	rootResult := &workflow.AgentResult{
+		Decision: "implemented", Summary: "root done",
+		Delegations: []workflow.Delegation{{ID: "child", Agent: "worker", Action: "ask", Prompt: "inspect"}},
+	}
+	seedCLIJob(t, store, db.Job{
+		ID: "root-corrupt", Agent: "impl", Type: "implement", State: string(workflow.JobSucceeded),
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", Result: rootResult}),
+	}, "done")
+	seedCLIJob(t, store, db.Job{
+		ID: "child-corrupt", Agent: "worker", Type: "ask", State: string(workflow.JobSucceeded),
+		ParentJobID: "root-corrupt", DelegationID: "child", DelegationDepth: 1, DelegatedBy: "impl",
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo: "owner/repo", RootJobID: "root-corrupt", ParentJobID: "root-corrupt",
+			DelegationID: "child", DelegationDepth: 1, DelegatedBy: "impl",
+		}),
+	}, "done")
+	if err := store.UpdateJobPayload(context.Background(), "child-corrupt", "{not-json"); err != nil {
+		t.Fatalf("corrupt child payload: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"proof", "--home", home, "root-corrupt"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("proof text code=%d stderr=%s", code, stderr.String())
+	}
+	for _, want := range []string{"session child-corrupt", "payload: - (stored payload is not valid JSON)"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("malformed-payload proof missing %q:\n%s", want, stdout.String())
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"proof", "--json", "--home", home, "root-corrupt"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("proof JSON code=%d stderr=%s", code, stderr.String())
+	}
+	var manifest proof.Manifest
+	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &manifest); err != nil {
+		t.Fatalf("decode malformed-payload manifest: %v", err)
+	}
+	foundGap := false
+	for _, node := range manifest.Nodes {
+		if node.Kind == proof.KindSession && node.Ref == "child-corrupt" && node.Attrs["payload_unparseable"] == "true" {
+			foundGap = true
+		}
+	}
+	if !foundGap {
+		t.Fatal("malformed child session lacks payload_unparseable JSON attr")
+	}
+}
+
+// TestRunProofReadOnlyStoreUnchanged pins the data contract: proof opens SQLite
+// mode=ro and leaves the main database bytes untouched. SQLite may create or
+// refresh WAL/SHM bookkeeping sidecars while observing a live WAL database;
+// those sidecars are allowed and are not store-data mutations.
+func TestRunProofReadOnlyStoreUnchanged(t *testing.T) {
+	home := t.TempDir()
+	seedCLIProof(t, home)
+	database := config.PathsForHome(home).Database
+	before, err := os.ReadFile(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeInfo, err := os.Stat(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"proof", "--json", "--home", home, "root-proof"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("proof --json code=%d stderr=%s", code, stderr.String())
+	}
+	after, err := os.ReadFile(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	afterInfo, err := os.Stat(database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) || !beforeInfo.ModTime().Equal(afterInfo.ModTime()) || beforeInfo.Size() != afterInfo.Size() {
+		t.Fatal("proof changed the SQLite store")
+	}
+}
+
+func seedCLIProof(t *testing.T, home string) {
+	t.Helper()
+	store := openCLIJobStore(t, home)
+	ctx := context.Background()
+	for _, agent := range []db.Agent{
+		{Name: "implementer", Runtime: runtime.CodexRuntime, RuntimeRef: "session-implementer"},
+		{Name: "reviewer", Runtime: runtime.CodexRuntime, RuntimeRef: "session-reviewer"},
+	} {
+		if err := store.UpsertAgent(ctx, agent); err != nil {
+			t.Fatalf("UpsertAgent: %v", err)
+		}
+	}
+	rootResult := &workflow.AgentResult{
+		Decision: "implemented", Summary: "proof implemented",
+		ChangesMade: []string{"added proof"}, TestsRun: []string{"go test ./internal/proof/"},
+		Delegations: []workflow.Delegation{{
+			ID: "review", Agent: "reviewer", Action: "review", Prompt: "review proof", SynthesisRule: "verify",
+		}},
+	}
+	reviewResult := &workflow.AgentResult{
+		Decision: "approved", Summary: "clean",
+		Findings: []json.RawMessage{json.RawMessage(`{"severity":"note"}`)},
+	}
+	seedCLIJob(t, store, db.Job{
+		ID: "root-proof", Agent: "implementer", Type: "implement", State: string(workflow.JobSucceeded), Model: "gpt-5.6",
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo: "owner/repo", PullRequest: 17, HeadSHA: "abc123", WorkflowID: "proof/17", Result: rootResult,
+		}),
+	}, "implemented")
+	seedCLIJob(t, store, db.Job{
+		ID: "review-proof", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded), Model: "gpt-5.6",
+		ParentJobID: "root-proof", DelegationID: "review", DelegationDepth: 1, DelegatedBy: "implementer",
+		Payload: mustJobPayload(t, workflow.JobPayload{
+			Repo: "owner/repo", PullRequest: 17, HeadSHA: "abc123", WorkflowID: "proof/17",
+			RootJobID: "root-proof", ParentJobID: "root-proof", DelegationID: "review", DelegationDepth: 1,
+			DelegatedBy: "implementer", Result: reviewResult,
+		}),
+	}, "approved")
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo", Number: 17, HeadSHA: "abc123", MergeCommitSHA: "def456", State: "merged",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest: %v", err)
+	}
+	for _, body := range []string{
+		"[auto:pr:17:opened] PR #17 opened",
+		"[auto:pr:17:merged] PR #17 merged",
+	} {
+		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "proof/17", Author: db.WorkflowAutoNoteAuthor, Body: body, Repo: "owner/repo",
+		}); err != nil {
+			t.Fatalf("InsertWorkflowNote: %v", err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close proof seed store: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -44,6 +44,7 @@ var rootCommands = []command{
 	{name: "goal", summary: "import or inspect goals", run: runGoal},
 	{name: "task", summary: "run or inspect tasks", run: runTask},
 	{name: "job", summary: "inspect and recover jobs", run: runJob},
+	{name: "proof", summary: "evidence-graded proof manifest for a work root", run: runProof},
 	{name: "workflow", summary: "inspect external-coordinator workflow groups and notes", run: runWorkflowJournal},
 	{name: "report", summary: "build and file bug reports", run: runReport},
 	{name: "lock", summary: "inspect and release branch locks", run: runLock},

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -266,7 +266,14 @@ type Job struct {
 	// Model is the durable model selected when the job was enqueued. Unlike the
 	// payload's per-job override, it also snapshots agent and runtime defaults so
 	// historical jobs do not change when mutable configuration changes.
-	Model           string
+	Model string
+	// Runtime and RuntimeRef are optional, best-effort proof projections. The
+	// jobs table does not persist a normal job's immutable runtime session: a
+	// per-job override is carried in payload.runtime_override(_ref), while an
+	// ordinary job can only be enriched from the agent's current registration.
+	// General job readers leave both empty.
+	Runtime         string
+	RuntimeRef      string
 	ParentJobID     string
 	DelegationID    string
 	DelegationDepth int
@@ -317,6 +324,10 @@ type Job struct {
 	// "2006-01-02 15:04:05"). Populated by ListJobs/GetJob so the web dashboard
 	// can stamp a node's StartedAt; other readers may leave it zero.
 	CreatedAt string
+	// ResultHash is the SHA-256 hex of the compacted raw payload.result JSON.
+	// It is populated by ListJobsByRoot for store-integrity projection; general
+	// readers may leave it empty.
+	ResultHash string
 }
 
 // TranscriptJob is the narrow retention-GC projection. It intentionally omits
@@ -2983,7 +2994,7 @@ func (s *Store) ListJobsByParent(ctx context.Context, parentJobID string) ([]Job
 // idx_jobs_root_id for an indexed lookup instead of a full-table scan that
 // unmarshals every payload. ORDER BY id is deterministic.
 func (s *Store) ListJobsByRoot(ctx context.Context, rootID string) ([]Job, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, root_killed, input_tokens, output_tokens, updated_at
+	rows, err := s.db.QueryContext(ctx, `SELECT id, agent, type, state, payload, model, parent_job_id, delegation_id, delegation_depth, delegated_by, root_id, workflow_id, repo, pull_request, root_killed, input_tokens, output_tokens, updated_at, created_at, result_hash
 		FROM jobs WHERE root_id = ? ORDER BY id`, rootID)
 	if err != nil {
 		return nil, err
@@ -2993,7 +3004,7 @@ func (s *Store) ListJobsByRoot(ctx context.Context, rootID string) ([]Job, error
 	var jobs []Job
 	for rows.Next() {
 		var job Job
-		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootID, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt); err != nil {
+		if err := rows.Scan(&job.ID, &job.Agent, &job.Type, &job.State, &job.Payload, &job.Model, &job.ParentJobID, &job.DelegationID, &job.DelegationDepth, &job.DelegatedBy, &job.RootID, &job.WorkflowID, &job.Repo, &job.PullRequest, &job.RootKilled, &job.InputTokens, &job.OutputTokens, &job.UpdatedAt, &job.CreatedAt, &job.ResultHash); err != nil {
 			return nil, err
 		}
 		jobs = append(jobs, job)

--- a/internal/db/store_root_id_test.go
+++ b/internal/db/store_root_id_test.go
@@ -77,7 +77,7 @@ func TestListJobsByRootReturnsTree(t *testing.T) {
 			t.Fatalf("CreateJob(%q) returned error: %v", id, err)
 		}
 	}
-	seed("R", `{}`)
+	seed("R", `{"workflow_id":"wf-proof","repo":"owner/repo","pull_request":12,"result":{"decision":"approved"}}`)
 	seed("R/a", `{"root_job_id":"R"}`)
 	seed("R/b", `{"root_job_id":"R"}`)
 	seed("S", `{}`) // unrelated root
@@ -92,6 +92,9 @@ func TestListJobsByRootReturnsTree(t *testing.T) {
 		gotIDs = append(gotIDs, j.ID)
 		if j.RootID != "R" {
 			t.Fatalf("ListJobsByRoot(R) returned job %q with RootID %q, want R", j.ID, j.RootID)
+		}
+		if j.ID == "R" && (j.WorkflowID != "wf-proof" || j.Repo != "owner/repo" || j.PullRequest != 12 || j.ResultHash == "" || j.CreatedAt == "") {
+			t.Fatalf("ListJobsByRoot(R) proof projection incomplete: %+v", j)
 		}
 	}
 	want := []string{"R", "R/a", "R/b"}

--- a/internal/proof/manifest.go
+++ b/internal/proof/manifest.go
@@ -1,0 +1,214 @@
+// Package proof projects structured Gitmoot store records into a deterministic,
+// content-addressed evidence manifest. It deliberately has no CLI or network
+// coupling.
+package proof
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+)
+
+const hashPrefix = "sha256:"
+
+// Kind identifies one node in a proof manifest.
+type Kind string
+
+const (
+	KindRoot       Kind = "root"
+	KindSession    Kind = "session"
+	KindDelegation Kind = "delegation"
+	KindCommit     Kind = "commit"
+	KindTest       Kind = "test"
+	KindReview     Kind = "review"
+	KindPR         Kind = "pr"
+)
+
+// Grade is the strength of evidence behind a claim.
+type Grade string
+
+const (
+	GradeReported Grade = "reported"
+	GradeObserved Grade = "observed"
+	GradeVerified Grade = "verified"
+)
+
+// Claim is one evidence-graded assertion attached to a node.
+type Claim struct {
+	Type        string `json:"type"`
+	Grade       Grade  `json:"grade"`
+	Source      string `json:"source"`
+	EvidenceRef string `json:"evidence_ref"`
+	AsOf        string `json:"as_of"`
+}
+
+// Node is one content-addressed record. ID is the SHA-256 of the canonical JSON
+// formed by every field except ID; parent nodes refer to child IDs.
+type Node struct {
+	ID       string            `json:"id"`
+	Kind     Kind              `json:"kind"`
+	Ref      string            `json:"ref"`
+	Attrs    map[string]string `json:"attrs"`
+	Children []string          `json:"children"`
+	Claims   []Claim           `json:"claims"`
+}
+
+// Manifest is the portable content-addressed proof artifact. Root is repeated
+// in Nodes so consumers can start either from ProofID or the embedded anchor.
+type Manifest struct {
+	ProofID string          `json:"proof_id"`
+	Root    Node            `json:"root"`
+	Nodes   map[string]Node `json:"nodes"`
+}
+
+type nodeContent struct {
+	Kind     Kind              `json:"kind"`
+	Ref      string            `json:"ref"`
+	Attrs    map[string]string `json:"attrs"`
+	Children []string          `json:"children"`
+	Claims   []Claim           `json:"claims"`
+}
+
+// NodeID recomputes the content address of node.
+func NodeID(node Node) string {
+	normalizeNode(&node)
+	raw, err := json.Marshal(nodeContent{
+		Kind: node.Kind, Ref: node.Ref, Attrs: node.Attrs,
+		Children: node.Children, Claims: node.Claims,
+	})
+	if err != nil {
+		panic(fmt.Sprintf("proof: marshal canonical node: %v", err))
+	}
+	sum := sha256.Sum256(raw)
+	return hashPrefix + hex.EncodeToString(sum[:])
+}
+
+// Marshal returns the canonical JSON representation used by `proof --json`.
+// encoding/json sorts string map keys, while projection normalizes all slices.
+func Marshal(manifest Manifest) ([]byte, error) {
+	return json.Marshal(manifest)
+}
+
+// VerifyManifest recomputes node hashes and validates child references, DAG
+// acyclicity, and that every shipped node is committed by ProofID.
+func VerifyManifest(manifest Manifest) error {
+	if manifest.ProofID == "" {
+		return errors.New("proof id is empty")
+	}
+	root, ok := manifest.Nodes[manifest.ProofID]
+	if !ok {
+		return fmt.Errorf("proof root %q is absent from nodes", manifest.ProofID)
+	}
+	if NodeID(root) != manifest.ProofID || NodeID(manifest.Root) != manifest.ProofID {
+		return errors.New("proof root content hash does not match")
+	}
+	for id, node := range manifest.Nodes {
+		if node.ID != id || NodeID(node) != id {
+			return fmt.Errorf("node %q content hash does not match", id)
+		}
+		for _, child := range node.Children {
+			if _, exists := manifest.Nodes[child]; !exists {
+				return fmt.Errorf("node %q references missing child %q", id, child)
+			}
+		}
+	}
+	reachable, err := reachableNodeIDs(manifest)
+	if err != nil {
+		return err
+	}
+	if len(reachable) != len(manifest.Nodes) {
+		ids := make([]string, 0, len(manifest.Nodes))
+		for id := range manifest.Nodes {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			if _, ok := reachable[id]; !ok {
+				return fmt.Errorf("unreachable node %q not committed by proof id", id)
+			}
+		}
+	}
+	return nil
+}
+
+func reachableNodeIDs(manifest Manifest) (map[string]struct{}, error) {
+	state := make(map[string]uint8, len(manifest.Nodes))
+	reachable := make(map[string]struct{}, len(manifest.Nodes))
+	var visit func(string) error
+	visit = func(id string) error {
+		switch state[id] {
+		case 1:
+			return fmt.Errorf("proof DAG contains a cycle at %q", id)
+		case 2:
+			return nil
+		}
+		node, ok := manifest.Nodes[id]
+		if !ok {
+			return fmt.Errorf("proof DAG references missing node %q", id)
+		}
+		state[id] = 1
+		reachable[id] = struct{}{}
+		for _, child := range node.Children {
+			if err := visit(child); err != nil {
+				return err
+			}
+		}
+		state[id] = 2
+		return nil
+	}
+	if err := visit(manifest.ProofID); err != nil {
+		return nil, err
+	}
+	return reachable, nil
+}
+
+type builder struct {
+	nodes map[string]Node
+}
+
+func newBuilder() *builder {
+	return &builder{nodes: make(map[string]Node)}
+}
+
+func (b *builder) add(node Node) string {
+	node.Claims = append(node.Claims, Claim{
+		Type: "integrity.content_hash", Grade: GradeVerified,
+		Source: "proof.projector", EvidenceRef: "self", AsOf: node.Attrs["as_of"],
+	})
+	normalizeNode(&node)
+	node.ID = NodeID(node)
+	b.nodes[node.ID] = node
+	return node.ID
+}
+
+func normalizeNode(node *Node) {
+	if node.Attrs == nil {
+		node.Attrs = map[string]string{}
+	}
+	if node.Children == nil {
+		node.Children = []string{}
+	}
+	if node.Claims == nil {
+		node.Claims = []Claim{}
+	}
+	sort.Strings(node.Children)
+	sort.Slice(node.Claims, func(i, j int) bool {
+		a, b := node.Claims[i], node.Claims[j]
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		if a.Grade != b.Grade {
+			return a.Grade < b.Grade
+		}
+		if a.Source != b.Source {
+			return a.Source < b.Source
+		}
+		if a.EvidenceRef != b.EvidenceRef {
+			return a.EvidenceRef < b.EvidenceRef
+		}
+		return a.AsOf < b.AsOf
+	})
+}

--- a/internal/proof/project.go
+++ b/internal/proof/project.go
@@ -1,0 +1,648 @@
+package proof
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// PRReceipt is structured store evidence about a pull request and its daemon
+// workflow-journal receipts. Empty fields are honest evidence gaps.
+type PRReceipt struct {
+	Repo           string
+	Number         int
+	HeadSHA        string
+	MergeCommitSHA string
+	State          string
+	OpenedAt       string
+	MergedAt       string
+}
+
+type payloadProjection struct {
+	Repo               string                `json:"repo"`
+	PullRequest        int                   `json:"pull_request"`
+	HeadSHA            string                `json:"head_sha"`
+	WorkflowID         string                `json:"workflow_id"`
+	RuntimeOverride    string                `json:"runtime_override"`
+	RuntimeOverrideRef string                `json:"runtime_override_ref"`
+	Result             *workflow.AgentResult `json:"result"`
+}
+
+type projector struct {
+	root        db.Job
+	jobs        map[string]db.Job
+	jobIDs      []string
+	results     map[string]*workflow.AgentResult
+	receipts    map[string]PRReceipt
+	events      map[string][]db.JobEvent
+	children    map[string][]db.Job
+	builder     *builder
+	sessions    map[string]string
+	visiting    map[string]bool
+	dagOK       bool
+	dagGaps     []string
+	rootAsOf    string
+	implementer map[string]db.Job
+}
+
+// Project builds a deterministic Merkle DAG from already-loaded structured
+// store records. It performs no I/O and uses only stored timestamps.
+func Project(root db.Job, jobs []db.Job, results map[string]*workflow.AgentResult, receipts []PRReceipt, events map[string][]db.JobEvent) Manifest {
+	p := &projector{
+		root: root, jobs: make(map[string]db.Job), results: results,
+		receipts: make(map[string]PRReceipt), events: events,
+		children: make(map[string][]db.Job), builder: newBuilder(),
+		sessions: make(map[string]string), visiting: make(map[string]bool),
+		implementer: make(map[string]db.Job),
+	}
+	if p.results == nil {
+		p.results = map[string]*workflow.AgentResult{}
+	}
+	if p.events == nil {
+		p.events = map[string][]db.JobEvent{}
+	}
+	for _, receipt := range receipts {
+		p.receipts[prKey(receipt.Repo, receipt.Number)] = receipt
+	}
+	foundRoot := false
+	for _, job := range jobs {
+		p.jobs[job.ID] = job
+		p.jobIDs = append(p.jobIDs, job.ID)
+		if job.ID == root.ID {
+			foundRoot = true
+			p.root = job
+		}
+		if job.ParentJobID != "" {
+			p.children[job.ParentJobID] = append(p.children[job.ParentJobID], job)
+		}
+		if job.UpdatedAt > p.rootAsOf {
+			p.rootAsOf = job.UpdatedAt
+		}
+	}
+	if !foundRoot && root.ID != "" {
+		p.jobs[root.ID] = root
+		p.jobIDs = append(p.jobIDs, root.ID)
+	}
+	sort.Strings(p.jobIDs)
+	for parent := range p.children {
+		sort.Slice(p.children[parent], func(i, j int) bool {
+			if p.children[parent][i].DelegationID != p.children[parent][j].DelegationID {
+				return p.children[parent][i].DelegationID < p.children[parent][j].DelegationID
+			}
+			return p.children[parent][i].ID < p.children[parent][j].ID
+		})
+	}
+	p.dagOK, p.dagGaps = p.validateLineage()
+	p.indexImplementers()
+
+	rootChildren := make([]string, 0, len(p.jobIDs))
+	for _, jobID := range p.jobIDs {
+		if id := p.buildSession(jobID); id != "" {
+			rootChildren = append(rootChildren, id)
+		}
+	}
+	rootAttrs := map[string]string{
+		"root_id":        p.root.ID,
+		"as_of":          p.rootAsOf,
+		"dag_consistent": strconv.FormatBool(p.dagOK),
+	}
+	if len(p.dagGaps) > 0 {
+		rootAttrs["evidence_gaps"] = strings.Join(p.dagGaps, "; ")
+	}
+	rootClaims := []Claim{}
+	if p.dagOK {
+		rootClaims = append(rootClaims, Claim{
+			Type: "integrity.delegation_dag", Grade: GradeVerified,
+			Source: "proof.projector", EvidenceRef: p.root.ID, AsOf: p.rootAsOf,
+		})
+	}
+	rootID := p.builder.add(Node{
+		Kind: KindRoot, Ref: p.root.ID, Attrs: rootAttrs,
+		Children: rootChildren, Claims: rootClaims,
+	})
+	rootNode := p.builder.nodes[rootID]
+	return Manifest{ProofID: rootID, Root: rootNode, Nodes: p.builder.nodes}
+}
+
+func (p *projector) buildSession(jobID string) string {
+	if id := p.sessions[jobID]; id != "" {
+		return id
+	}
+	job, ok := p.jobs[jobID]
+	if !ok {
+		return ""
+	}
+	if p.visiting[jobID] {
+		p.dagOK = false
+		return ""
+	}
+	p.visiting[jobID] = true
+	defer delete(p.visiting, jobID)
+
+	projection, payloadParseable := parsePayloadWithStatus(job.Payload)
+	attrs := map[string]string{
+		"agent": job.Agent, "job_type": job.Type, "state": job.State,
+		"input_tokens":  strconv.Itoa(job.InputTokens),
+		"output_tokens": strconv.Itoa(job.OutputTokens),
+		"as_of":         job.UpdatedAt,
+	}
+	if !payloadParseable {
+		attrs["payload_unparseable"] = "true"
+		attrs["evidence_gap"] = "stored payload is not valid JSON"
+	}
+	setAttr(attrs, "runtime", firstNonBlank(job.Runtime, projection.RuntimeOverride))
+	setAttr(attrs, "model", job.Model)
+	setAttr(attrs, "runtime_ref", firstNonBlank(job.RuntimeRef, projection.RuntimeOverrideRef))
+	if attrs["runtime_ref"] != "" {
+		attrs["runtime_ref_quality"] = "best_effort"
+	}
+	setAttr(attrs, "created_at", job.CreatedAt)
+	if job.ParentJobID != "" {
+		attrs["parent_job_id"] = job.ParentJobID
+	}
+
+	claims := make([]Claim, 0)
+	result := p.results[job.ID]
+	if result == nil {
+		result = projection.Result
+	}
+	if result != nil && job.Type != "review" && strings.TrimSpace(result.Decision) != "" {
+		claims = append(claims, reportedClaim("result.decision", job, job.UpdatedAt))
+	}
+	for _, event := range sortedEvents(p.events[job.ID]) {
+		claims = append(claims, Claim{
+			Type: "job.event." + emptyDash(event.Kind), Grade: GradeObserved,
+			Source: "job_event", EvidenceRef: eventRef(event), AsOf: event.CreatedAt,
+		})
+	}
+
+	children := p.factNodes(job, projection, result)
+	children = append(children, p.delegationNodes(job, result)...)
+	sessionID := p.builder.add(Node{
+		Kind: KindSession, Ref: job.ID, Attrs: attrs,
+		Children: children, Claims: claims,
+	})
+	p.sessions[jobID] = sessionID
+	return sessionID
+}
+
+func (p *projector) factNodes(job db.Job, projection payloadProjection, result *workflow.AgentResult) []string {
+	children := make([]string, 0)
+	repo := firstNonBlank(job.Repo, projection.Repo)
+	prNumber := job.PullRequest
+	if prNumber == 0 {
+		prNumber = projection.PullRequest
+	}
+	receipt := p.receipts[prKey(repo, prNumber)]
+	headSHA := firstNonBlank(projection.HeadSHA, receipt.HeadSHA)
+
+	if result != nil && (len(result.ChangesMade) > 0 || job.ResultHash != "" || headSHA != "") {
+		attrs := map[string]string{"job_id": job.ID, "as_of": job.UpdatedAt}
+		setAttr(attrs, "head_sha", headSHA)
+		setAttr(attrs, "result_hash", job.ResultHash)
+		claims := make([]Claim, 0, len(result.ChangesMade)+1)
+		for i, change := range result.ChangesMade {
+			attrs[fmt.Sprintf("change.%d", i)] = change
+			claims = append(claims, reportedClaim("change", job, job.UpdatedAt))
+		}
+		if job.ResultHash != "" {
+			matches := resultHashMatches(job.Payload, job.ResultHash)
+			attrs["result_hash_valid"] = strconv.FormatBool(matches)
+			if matches {
+				claims = append(claims, Claim{
+					Type: "integrity.result_hash", Grade: GradeVerified,
+					Source: "jobs.result_hash", EvidenceRef: hashPrefix + job.ResultHash,
+					AsOf: job.UpdatedAt,
+				})
+			}
+		}
+		children = append(children, p.builder.add(Node{
+			Kind: KindCommit, Ref: firstNonBlank(headSHA, job.ResultHash, job.ID),
+			Attrs: attrs, Claims: claims,
+		}))
+	}
+
+	if result != nil {
+		for i, testRun := range result.TestsRun {
+			children = append(children, p.builder.add(Node{
+				Kind: KindTest, Ref: testRun,
+				Attrs: map[string]string{
+					"job_id": job.ID, "command": testRun, "index": strconv.Itoa(i),
+					"evidence_gap": "CI verification deferred", "as_of": job.UpdatedAt,
+				},
+				Claims: []Claim{reportedClaim("test.run", job, job.UpdatedAt)},
+			}))
+		}
+	}
+
+	if job.Type == "review" {
+		attrs := map[string]string{
+			"job_id": job.ID, "agent": job.Agent, "as_of": job.UpdatedAt,
+			"reviewed_ref": emptyDash(p.reviewedRef(job, headSHA)),
+		}
+		claims := []Claim{}
+		if result != nil {
+			attrs["decision"] = emptyDash(result.Decision)
+			attrs["findings_count"] = strconv.Itoa(len(result.Findings))
+			if strings.TrimSpace(result.Decision) != "" {
+				claims = append(claims, reportedClaim("review.decision", job, job.UpdatedAt))
+			}
+			implementer, known := p.implementer[job.ID]
+			implementerAgent := strings.TrimSpace(implementer.Agent)
+			reviewerAgent := strings.TrimSpace(job.Agent)
+			comparable := known && implementerAgent != "" && reviewerAgent != ""
+			independent := comparable && implementerAgent != reviewerAgent
+			if known {
+				attrs["implementer_agent"] = implementer.Agent
+			}
+			if comparable {
+				attrs["independent"] = strconv.FormatBool(independent)
+			}
+			if result.Decision == "approved" {
+				claimType := "review.approved"
+				if independent {
+					claimType = "review.independent_approved"
+				} else if comparable {
+					claimType = "review.self_approved"
+				}
+				claims = append(claims, Claim{
+					Type: claimType, Grade: GradeObserved, Source: "jobs.review",
+					EvidenceRef: job.ID, AsOf: job.UpdatedAt,
+				})
+			}
+		} else {
+			attrs["decision"] = "-"
+			attrs["findings_count"] = "0"
+		}
+		children = append(children, p.builder.add(Node{
+			Kind: KindReview, Ref: job.ID, Attrs: attrs, Claims: claims,
+		}))
+	}
+
+	if prNumber > 0 {
+		attrs := map[string]string{
+			"repo": emptyDash(repo), "number": strconv.Itoa(prNumber),
+			"as_of": job.UpdatedAt,
+		}
+		setAttr(attrs, "head_sha", receipt.HeadSHA)
+		setAttr(attrs, "merge_commit_sha", receipt.MergeCommitSHA)
+		setAttr(attrs, "state", receipt.State)
+		setAttr(attrs, "opened_at", receipt.OpenedAt)
+		setAttr(attrs, "merged_at", receipt.MergedAt)
+		claims := []Claim{}
+		if receipt.OpenedAt != "" {
+			claims = append(claims, Claim{
+				Type: "pr.opened", Grade: GradeObserved, Source: "workflow_journal",
+				EvidenceRef: fmt.Sprintf("%s#%d:opened", repo, prNumber), AsOf: receipt.OpenedAt,
+			})
+		}
+		if receipt.MergedAt != "" {
+			claims = append(claims, Claim{
+				Type: "pr.merged", Grade: GradeObserved, Source: "workflow_journal",
+				EvidenceRef: fmt.Sprintf("%s#%d:merged", repo, prNumber), AsOf: receipt.MergedAt,
+			})
+		}
+		children = append(children, p.builder.add(Node{
+			Kind: KindPR, Ref: fmt.Sprintf("%s#%d", emptyDash(repo), prNumber),
+			Attrs: attrs, Claims: claims,
+		}))
+	}
+	return children
+}
+
+func (p *projector) delegationNodes(parent db.Job, result *workflow.AgentResult) []string {
+	specs := map[string]workflow.Delegation{}
+	if result != nil {
+		for _, delegation := range result.Delegations {
+			specs[delegation.ID] = delegation
+		}
+	}
+	type edge struct {
+		key   string
+		spec  workflow.Delegation
+		child *db.Job
+	}
+	edges := map[string]edge{}
+	for id, spec := range specs {
+		edges[id] = edge{key: id, spec: spec}
+	}
+	for i := range p.children[parent.ID] {
+		child := p.children[parent.ID][i]
+		key := child.DelegationID
+		if key == "" {
+			key = "job:" + child.ID
+		}
+		if existing, ok := edges[key]; ok && existing.child != nil {
+			key += ":" + child.ID
+		}
+		e := edges[key]
+		e.key, e.child = key, &child
+		if e.spec.ID == "" && child.DelegationID != "" {
+			e.spec = specs[child.DelegationID]
+		}
+		edges[key] = e
+	}
+	keys := make([]string, 0, len(edges))
+	for key := range edges {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	built := map[string]string{}
+	visiting := map[string]bool{}
+	var build func(string) string
+	build = func(key string) string {
+		if id := built[key]; id != "" {
+			return id
+		}
+		e, ok := edges[key]
+		if !ok || visiting[key] {
+			return ""
+		}
+		visiting[key] = true
+		defer delete(visiting, key)
+		attrs := map[string]string{
+			"parent_job_id": parent.ID, "delegation_id": emptyDash(e.spec.ID),
+			"synthesis_rule": emptyDash(e.spec.SynthesisRule),
+			"quorum":         strconv.Itoa(e.spec.Quorum), "as_of": parent.UpdatedAt,
+		}
+		if len(e.spec.Deps) > 0 {
+			deps := append([]string(nil), e.spec.Deps...)
+			sort.Strings(deps)
+			attrs["deps"] = strings.Join(deps, ",")
+		}
+		children := []string{}
+		for _, dep := range e.spec.Deps {
+			if depID := build(dep); depID != "" {
+				children = append(children, depID)
+			}
+		}
+		if e.child != nil {
+			attrs["child_job_id"] = e.child.ID
+			attrs["delegation_depth"] = strconv.Itoa(e.child.DelegationDepth)
+			attrs["delegated_by"] = emptyDash(e.child.DelegatedBy)
+			childID := p.buildSession(e.child.ID)
+			attrs["resolved"] = strconv.FormatBool(childID != "")
+			if childID != "" {
+				children = append(children, childID)
+			}
+		} else {
+			attrs["resolved"] = "false"
+		}
+		id := p.builder.add(Node{
+			Kind: KindDelegation, Ref: parent.ID + "/" + key,
+			Attrs: attrs, Children: children,
+		})
+		built[key] = id
+		return id
+	}
+	ids := make([]string, 0, len(keys))
+	for _, key := range keys {
+		ids = append(ids, build(key))
+	}
+	return ids
+}
+
+func (p *projector) validateLineage() (bool, []string) {
+	gaps := []string{}
+	if len(p.jobs) > workflow.MaxDelegationTotalJobs {
+		gaps = append(gaps, fmt.Sprintf("job budget exceeded: %d>%d", len(p.jobs), workflow.MaxDelegationTotalJobs))
+	}
+	for _, id := range p.jobIDs {
+		job := p.jobs[id]
+		if job.DelegationDepth < 0 || job.DelegationDepth > workflow.MaxDelegationDepth {
+			gaps = append(gaps, fmt.Sprintf("job %s depth %d outside 0..%d", id, job.DelegationDepth, workflow.MaxDelegationDepth))
+		}
+		if job.RootID != "" && job.RootID != p.root.ID {
+			gaps = append(gaps, fmt.Sprintf("job %s belongs to root %s", id, job.RootID))
+		}
+		if id != p.root.ID {
+			parent, ok := p.jobs[job.ParentJobID]
+			if !ok {
+				gaps = append(gaps, fmt.Sprintf("job %s parent %s is absent", id, emptyDash(job.ParentJobID)))
+			} else if job.DelegationDepth != parent.DelegationDepth+1 {
+				gaps = append(gaps, fmt.Sprintf("job %s depth does not follow parent %s", id, parent.ID))
+			}
+		}
+		result := p.results[id]
+		if result == nil {
+			projection := parsePayload(job.Payload)
+			result = projection.Result
+		}
+		if result != nil {
+			gaps = append(gaps, validateDelegationSpecs(id, result.Delegations, p.children[id])...)
+		}
+	}
+	state := map[string]uint8{}
+	var visit func(string)
+	visit = func(id string) {
+		if state[id] == 1 {
+			gaps = append(gaps, "job parent graph contains a cycle at "+id)
+			return
+		}
+		if state[id] == 2 {
+			return
+		}
+		state[id] = 1
+		for _, child := range p.children[id] {
+			visit(child.ID)
+		}
+		state[id] = 2
+	}
+	visit(p.root.ID)
+	sort.Strings(gaps)
+	return len(gaps) == 0, compactStrings(gaps)
+}
+
+func validateDelegationSpecs(parent string, specs []workflow.Delegation, children []db.Job) []string {
+	byID := map[string]workflow.Delegation{}
+	childIDs := map[string]bool{}
+	for _, child := range children {
+		if child.DelegationID != "" {
+			childIDs[child.DelegationID] = true
+		}
+	}
+	for _, spec := range specs {
+		byID[spec.ID] = spec
+	}
+	gaps := []string{}
+	for id, spec := range byID {
+		if !childIDs[id] {
+			gaps = append(gaps, fmt.Sprintf("job %s delegation %s has no stored child", parent, id))
+		}
+		for _, dep := range spec.Deps {
+			if _, ok := byID[dep]; !ok {
+				gaps = append(gaps, fmt.Sprintf("job %s delegation %s dep %s is absent", parent, id, dep))
+			}
+		}
+	}
+	state := map[string]uint8{}
+	var visit func(string)
+	visit = func(id string) {
+		if state[id] == 1 {
+			gaps = append(gaps, fmt.Sprintf("job %s delegation deps contain a cycle at %s", parent, id))
+			return
+		}
+		if state[id] == 2 {
+			return
+		}
+		state[id] = 1
+		for _, dep := range byID[id].Deps {
+			if _, ok := byID[dep]; ok {
+				visit(dep)
+			}
+		}
+		state[id] = 2
+	}
+	for id := range byID {
+		visit(id)
+	}
+	return gaps
+}
+
+func (p *projector) indexImplementers() {
+	for _, id := range p.jobIDs {
+		job := p.jobs[id]
+		current := job
+		seen := map[string]bool{}
+		for current.ParentJobID != "" && !seen[current.ParentJobID] {
+			seen[current.ParentJobID] = true
+			parent, ok := p.jobs[current.ParentJobID]
+			if !ok {
+				break
+			}
+			if parent.Type == "implement" {
+				p.implementer[id] = parent
+				break
+			}
+			current = parent
+		}
+		if _, ok := p.implementer[id]; !ok && p.root.Type == "implement" && id != p.root.ID {
+			p.implementer[id] = p.root
+		}
+	}
+}
+
+func (p *projector) reviewedRef(job db.Job, headSHA string) string {
+	if headSHA != "" {
+		return headSHA
+	}
+	if implementer, ok := p.implementer[job.ID]; ok {
+		if implementer.ResultHash != "" {
+			return hashPrefix + implementer.ResultHash
+		}
+		return implementer.ID
+	}
+	return ""
+}
+
+func parsePayload(raw string) payloadProjection {
+	projection, _ := parsePayloadWithStatus(raw)
+	return projection
+}
+
+func parsePayloadWithStatus(raw string) (payloadProjection, bool) {
+	var projection payloadProjection
+	if err := json.Unmarshal([]byte(raw), &projection); err != nil {
+		return payloadProjection{}, false
+	}
+	return projection, true
+}
+
+func resultHashMatches(payload, stored string) bool {
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if json.Unmarshal([]byte(payload), &envelope) != nil {
+		return false
+	}
+	raw := bytes.TrimSpace(envelope.Result)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return false
+	}
+	var compact bytes.Buffer
+	if json.Compact(&compact, raw) == nil {
+		raw = compact.Bytes()
+	}
+	sum := sha256.Sum256(raw)
+	return stored == hex.EncodeToString(sum[:])
+}
+
+func reportedClaim(claimType string, job db.Job, asOf string) Claim {
+	evidence := job.ID
+	if job.ResultHash != "" {
+		evidence = hashPrefix + job.ResultHash
+	}
+	return Claim{
+		Type: claimType, Grade: GradeReported, Source: "job.result",
+		EvidenceRef: evidence, AsOf: asOf,
+	}
+}
+
+func eventRef(event db.JobEvent) string {
+	raw, _ := json.Marshal(struct {
+		JobID, Kind, Message, CreatedAt string
+	}{event.JobID, event.Kind, event.Message, event.CreatedAt})
+	sum := sha256.Sum256(raw)
+	return hashPrefix + hex.EncodeToString(sum[:])
+}
+
+func sortedEvents(events []db.JobEvent) []db.JobEvent {
+	out := append([]db.JobEvent(nil), events...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt != out[j].CreatedAt {
+			return out[i].CreatedAt < out[j].CreatedAt
+		}
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Message < out[j].Message
+	})
+	return out
+}
+
+func prKey(repo string, number int) string {
+	return strings.TrimSpace(repo) + "#" + strconv.Itoa(number)
+}
+
+func setAttr(attrs map[string]string, key, value string) {
+	if value = strings.TrimSpace(value); value != "" {
+		attrs[key] = value
+	}
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func emptyDash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return strings.TrimSpace(value)
+}
+
+func compactStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/proof/project_test.go
+++ b/internal/proof/project_test.go
@@ -1,0 +1,310 @@
+package proof
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestProjectManifestOverJobDAG(t *testing.T) {
+	root, jobs, results, receipts, events := proofFixture(t, false)
+	manifest := Project(root, jobs, results, receipts, events)
+	if err := VerifyManifest(manifest); err != nil {
+		t.Fatalf("VerifyManifest: %v", err)
+	}
+	if manifest.ProofID == "" || manifest.Root.ID != manifest.ProofID || manifest.Root.Kind != KindRoot {
+		t.Fatalf("root manifest = %+v", manifest)
+	}
+	wantKinds := map[Kind]bool{
+		KindRoot: true, KindSession: true, KindDelegation: true, KindCommit: true,
+		KindTest: true, KindReview: true, KindPR: true,
+	}
+	for _, node := range manifest.Nodes {
+		delete(wantKinds, node.Kind)
+	}
+	if len(wantKinds) != 0 {
+		t.Fatalf("missing node kinds: %v", wantKinds)
+	}
+	var delegationLinksSession bool
+	for _, node := range manifest.Nodes {
+		if node.Kind != KindDelegation {
+			continue
+		}
+		for _, child := range node.Children {
+			if manifest.Nodes[child].Kind == KindSession {
+				delegationLinksSession = true
+			}
+		}
+	}
+	if !delegationLinksSession {
+		t.Fatal("delegation nodes do not link to child session hashes")
+	}
+	first, err := Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondManifest := Project(root, jobs, results, receipts, events)
+	second, err := Marshal(secondManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if manifest.ProofID != secondManifest.ProofID || !bytes.Equal(first, second) {
+		t.Fatalf("projection is not byte-stable:\n%s\n%s", first, second)
+	}
+}
+
+func TestGradingReportedObservedVerified(t *testing.T) {
+	root, jobs, results, receipts, events := proofFixture(t, false)
+	manifest := Project(root, jobs, results, receipts, events)
+	assertClaim(t, manifest, KindTest, "test.run", GradeReported)
+	assertClaim(t, manifest, KindReview, "review.independent_approved", GradeObserved)
+	assertClaim(t, manifest, KindCommit, "integrity.result_hash", GradeVerified)
+	assertClaim(t, manifest, KindRoot, "integrity.delegation_dag", GradeVerified)
+	if tally := GradeTally(manifest); tally[GradeVerified] != 0 {
+		t.Fatalf("substantive verified tally = %d, want 0; integrity claims must be separate", tally[GradeVerified])
+	}
+	if nodes, resultHashes := integrityTally(manifest); nodes != len(manifest.Nodes) || resultHashes != 3 {
+		t.Fatalf("integrity tally = nodes %d result_hashes %d, want %d and 3", nodes, resultHashes, len(manifest.Nodes))
+	}
+
+	selfRoot, selfJobs, selfResults, selfReceipts, selfEvents := proofFixture(t, true)
+	selfManifest := Project(selfRoot, selfJobs, selfResults, selfReceipts, selfEvents)
+	assertClaim(t, selfManifest, KindReview, "review.self_approved", GradeObserved)
+	for _, node := range selfManifest.Nodes {
+		if node.Kind != KindReview {
+			continue
+		}
+		if node.Attrs["independent"] != "false" {
+			t.Fatalf("self review independent = %q, want false", node.Attrs["independent"])
+		}
+		for _, claim := range node.Claims {
+			if strings.HasPrefix(claim.Type, "review.") && claim.Grade == GradeVerified {
+				t.Fatalf("self review received verified review claim: %+v", claim)
+			}
+		}
+	}
+}
+
+func TestManifestContentAddressStable(t *testing.T) {
+	root, jobs, results, receipts, events := proofFixture(t, false)
+	first := Project(root, jobs, results, receipts, events)
+	second := Project(root, jobs, results, receipts, events)
+	if first.ProofID != second.ProofID {
+		t.Fatalf("same input proof ids differ: %s != %s", first.ProofID, second.ProofID)
+	}
+	mutated := first.Root
+	mutated.Attrs = cloneAttrs(mutated.Attrs)
+	mutated.Attrs["root_id"] = "tampered"
+	if NodeID(mutated) == first.Root.ID {
+		t.Fatal("mutating an attribute did not change the node content address")
+	}
+	first.Root = mutated
+	if err := VerifyManifest(first); err == nil {
+		t.Fatal("tampered manifest passed hash verification")
+	}
+
+	orphanManifest := second
+	orphanManifest.Nodes = cloneNodes(second.Nodes)
+	beforeObserved := GradeTally(orphanManifest)[GradeObserved]
+	orphan := Node{
+		Kind: KindTest, Ref: "orphan", Attrs: map[string]string{"command": "fabricated"},
+		Children: []string{}, Claims: []Claim{{
+			Type: "test.run", Grade: GradeObserved, Source: "orphan", EvidenceRef: "orphan", AsOf: "2026-07-17 02:00:00",
+		}},
+	}
+	orphan.ID = NodeID(orphan)
+	orphanManifest.Nodes[orphan.ID] = orphan
+	if orphanManifest.ProofID != second.ProofID {
+		t.Fatal("adding an orphan unexpectedly changed ProofID")
+	}
+	if err := VerifyManifest(orphanManifest); err == nil || !strings.Contains(err.Error(), "unreachable node") {
+		t.Fatalf("orphan manifest verification error = %v, want unreachable-node rejection", err)
+	}
+	if got := GradeTally(orphanManifest)[GradeObserved]; got != beforeObserved {
+		t.Fatalf("orphan inflated observed tally from %d to %d", beforeObserved, got)
+	}
+}
+
+func TestReviewIndependenceRequiresNormalizedNonEmptyAgents(t *testing.T) {
+	for _, tc := range []struct {
+		name, reviewer, wantClaim string
+		wantIndependent           string
+	}{
+		{name: "empty reviewer is unknown", reviewer: "", wantClaim: "review.approved", wantIndependent: ""},
+		{name: "whitespace difference is self", reviewer: "implementer ", wantClaim: "review.self_approved", wantIndependent: "false"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, jobs, results, receipts, events := proofFixture(t, false)
+			for i := range jobs {
+				if jobs[i].Type == "review" {
+					jobs[i].Agent = tc.reviewer
+				}
+			}
+			manifest := Project(root, jobs, results, receipts, events)
+			assertClaim(t, manifest, KindReview, tc.wantClaim, GradeObserved)
+			for _, node := range manifest.Nodes {
+				if node.Kind != KindReview {
+					continue
+				}
+				if got := node.Attrs["independent"]; got != tc.wantIndependent {
+					t.Fatalf("independent attr = %q, want %q", got, tc.wantIndependent)
+				}
+				for _, claim := range node.Claims {
+					if claim.Type == "review.independent_approved" {
+						t.Fatalf("reviewer %q was mislabeled independent", tc.reviewer)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestProjectHonestGapsRenderDash(t *testing.T) {
+	result := &workflow.AgentResult{Decision: "implemented", Summary: "done"}
+	root := db.Job{
+		ID: "root-gap", RootID: "root-gap", Agent: "impl", Type: "implement",
+		State: "succeeded", UpdatedAt: "2026-07-17 01:00:00",
+		Payload: proofPayload(t, workflow.JobPayload{Repo: "owner/repo", Result: result}),
+	}
+	manifest := Project(root, []db.Job{root}, map[string]*workflow.AgentResult{root.ID: result}, nil, nil)
+	var out bytes.Buffer
+	if err := RenderTree(&out, manifest); err != nil {
+		t.Fatalf("RenderTree: %v", err)
+	}
+	for _, want := range []string{
+		"lineage: -", "commits: -", "tests: - (CI verification deferred)",
+		"reviews: -", "PR: -", "PR -",
+	} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("tree missing honest gap %q:\n%s", want, out.String())
+		}
+	}
+	if strings.Contains(out.String(), "#0") {
+		t.Fatalf("tree fabricated PR #0:\n%s", out.String())
+	}
+}
+
+func proofFixture(t *testing.T, selfReview bool) (db.Job, []db.Job, map[string]*workflow.AgentResult, []PRReceipt, map[string][]db.JobEvent) {
+	t.Helper()
+	rootResult := &workflow.AgentResult{
+		Decision: "implemented", Summary: "implemented proof",
+		ChangesMade: []string{"added projection"}, TestsRun: []string{"go test ./..."},
+		Delegations: []workflow.Delegation{
+			{ID: "child", Agent: "child-agent", Action: "implement", Prompt: "implement child", SynthesisRule: "summary"},
+			{ID: "review", Agent: "reviewer", Action: "review", Prompt: "review it", Deps: []string{"child"}, SynthesisRule: "verify"},
+		},
+	}
+	childResult := &workflow.AgentResult{Decision: "implemented", Summary: "child done", ChangesMade: []string{"changed child"}}
+	reviewResult := &workflow.AgentResult{
+		Decision: "approved", Summary: "approved",
+		Findings: []json.RawMessage{json.RawMessage(`{"severity":"note"}`)},
+	}
+	reviewer := "reviewer"
+	if selfReview {
+		reviewer = "implementer"
+	}
+	rootPayload := workflow.JobPayload{
+		Repo: "owner/repo", PullRequest: 42, HeadSHA: "abc123", WorkflowID: "proof/42", Result: rootResult,
+	}
+	childPayload := workflow.JobPayload{
+		Repo: "owner/repo", PullRequest: 42, HeadSHA: "abc123", WorkflowID: "proof/42",
+		RootJobID: "root", ParentJobID: "root", DelegationID: "child", DelegationDepth: 1, DelegatedBy: "implementer", Result: childResult,
+	}
+	reviewPayload := workflow.JobPayload{
+		Repo: "owner/repo", PullRequest: 42, HeadSHA: "abc123", WorkflowID: "proof/42",
+		RootJobID: "root", ParentJobID: "root", DelegationID: "review", DelegationDepth: 1, DelegatedBy: "implementer", Result: reviewResult,
+	}
+	root := db.Job{
+		ID: "root", RootID: "root", Agent: "implementer", Type: "implement", State: "succeeded",
+		Model: "gpt-5.6", Runtime: "codex", RuntimeRef: "session-root", Repo: "owner/repo", PullRequest: 42,
+		InputTokens: 100, OutputTokens: 50, CreatedAt: "2026-07-17 01:00:00", UpdatedAt: "2026-07-17 01:10:00",
+		Payload: proofPayload(t, rootPayload),
+	}
+	root.ResultHash = resultHashForPayload(t, root.Payload)
+	child := db.Job{
+		ID: "child-job", RootID: "root", ParentJobID: "root", DelegationID: "child", DelegationDepth: 1, DelegatedBy: "implementer",
+		Agent: "child-agent", Type: "implement", State: "succeeded", Model: "gpt-5.6-mini", Runtime: "codex",
+		Repo: "owner/repo", PullRequest: 42, CreatedAt: "2026-07-17 01:01:00", UpdatedAt: "2026-07-17 01:08:00",
+		Payload: proofPayload(t, childPayload),
+	}
+	child.ResultHash = resultHashForPayload(t, child.Payload)
+	review := db.Job{
+		ID: "review-job", RootID: "root", ParentJobID: "root", DelegationID: "review", DelegationDepth: 1, DelegatedBy: "implementer",
+		Agent: reviewer, Type: "review", State: "succeeded", Model: "gpt-5.6", Runtime: "codex",
+		Repo: "owner/repo", PullRequest: 42, CreatedAt: "2026-07-17 01:08:00", UpdatedAt: "2026-07-17 01:09:00",
+		Payload: proofPayload(t, reviewPayload),
+	}
+	review.ResultHash = resultHashForPayload(t, review.Payload)
+	receipts := []PRReceipt{{
+		Repo: "owner/repo", Number: 42, HeadSHA: "abc123", MergeCommitSHA: "def456", State: "merged",
+		OpenedAt: "2026-07-17 01:02:00", MergedAt: "2026-07-17 01:11:00",
+	}}
+	events := map[string][]db.JobEvent{
+		"root": {{JobID: "root", Kind: "succeeded", Message: "done", CreatedAt: "2026-07-17 01:10:00"}},
+	}
+	return root, []db.Job{review, root, child}, map[string]*workflow.AgentResult{
+		"root": rootResult, "child-job": childResult, "review-job": reviewResult,
+	}, receipts, events
+}
+
+func proofPayload(t *testing.T, payload workflow.JobPayload) string {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func resultHashForPayload(t *testing.T, payload string) string {
+	t.Helper()
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(payload), &envelope); err != nil {
+		t.Fatal(err)
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, envelope.Result); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(compact.Bytes())
+	return hex.EncodeToString(sum[:])
+}
+
+func assertClaim(t *testing.T, manifest Manifest, kind Kind, claimType string, grade Grade) {
+	t.Helper()
+	for _, node := range manifest.Nodes {
+		if node.Kind != kind {
+			continue
+		}
+		for _, claim := range node.Claims {
+			if claim.Type == claimType && claim.Grade == grade {
+				return
+			}
+		}
+	}
+	t.Fatalf("missing %s claim %q with grade %s", kind, claimType, grade)
+}
+
+func cloneAttrs(attrs map[string]string) map[string]string {
+	out := make(map[string]string, len(attrs))
+	for key, value := range attrs {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneNodes(nodes map[string]Node) map[string]Node {
+	out := make(map[string]Node, len(nodes))
+	for id, node := range nodes {
+		out[id] = node
+	}
+	return out
+}

--- a/internal/proof/render.go
+++ b/internal/proof/render.go
@@ -1,0 +1,224 @@
+package proof
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// RenderTree writes the stable, human-readable graded tree used by the CLI.
+func RenderTree(w io.Writer, manifest Manifest) error {
+	if err := VerifyManifest(manifest); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "proof %s\n", manifest.ProofID)
+	fmt.Fprintf(w, "root %s [%s]\n", dash(manifest.Root.Ref), GradeVerified)
+
+	sessions := directChildren(manifest, manifest.Root, KindSession)
+	models := map[string]bool{}
+	testCount, reviewCount := 0, 0
+	approvedReviews := 0
+	prLabels := map[string]bool{}
+	for _, session := range sessions {
+		attrs := session.Attrs
+		model := dash(attrs["model"])
+		if model != "-" {
+			models[model] = true
+		}
+		fmt.Fprintf(w, "  session %s\n", dash(session.Ref))
+		fmt.Fprintf(w, "    %s · %s · %s · tokens %s/%s · %s · ref %s\n",
+			dash(attrs["agent"]), dash(attrs["runtime"]), model,
+			dash(attrs["input_tokens"]), dash(attrs["output_tokens"]),
+			dash(attrs["state"]), dash(attrs["runtime_ref"]))
+		if attrs["payload_unparseable"] == "true" {
+			fmt.Fprintln(w, "    payload: - (stored payload is not valid JSON)")
+		}
+
+		delegations := directChildren(manifest, session, KindDelegation)
+		if len(delegations) == 0 {
+			fmt.Fprintln(w, "    lineage: -")
+		} else {
+			fmt.Fprintln(w, "    lineage:")
+			for _, delegation := range delegations {
+				d := delegation.Attrs
+				fmt.Fprintf(w, "      %s → %s · depth %s · synthesis %s · quorum %s · deps %s\n",
+					dash(d["delegation_id"]), dash(d["child_job_id"]),
+					dash(d["delegation_depth"]), dash(d["synthesis_rule"]),
+					dash(zeroAsDash(d["quorum"])), dash(d["deps"]))
+			}
+		}
+
+		commits := directChildren(manifest, session, KindCommit)
+		if len(commits) == 0 {
+			fmt.Fprintln(w, "    commits: -")
+		} else {
+			fmt.Fprintln(w, "    commits:")
+			for _, commit := range commits {
+				valid := dash(commit.Attrs["result_hash_valid"])
+				fmt.Fprintf(w, "      %s · result_hash %s · integrity %s\n",
+					dash(commit.Attrs["head_sha"]), dash(commit.Attrs["result_hash"]), valid)
+			}
+		}
+
+		tests := directChildren(manifest, session, KindTest)
+		testCount += len(tests)
+		if len(tests) == 0 {
+			fmt.Fprintln(w, "    tests: - (CI verification deferred)")
+		} else {
+			fmt.Fprintln(w, "    tests:")
+			for _, test := range tests {
+				fmt.Fprintf(w, "      %s [%s; CI verification deferred]\n", dash(test.Attrs["command"]), GradeReported)
+			}
+		}
+
+		reviews := directChildren(manifest, session, KindReview)
+		reviewCount += len(reviews)
+		if len(reviews) == 0 {
+			fmt.Fprintln(w, "    reviews: -")
+		} else {
+			fmt.Fprintln(w, "    reviews:")
+			for _, review := range reviews {
+				independence := "-"
+				switch review.Attrs["independent"] {
+				case "true":
+					independence = "independent"
+				case "false":
+					independence = "self"
+				}
+				if review.Attrs["decision"] == "approved" {
+					approvedReviews++
+				}
+				fmt.Fprintf(w, "      %s · %s · findings %s · %s [%s]\n",
+					dash(review.Attrs["agent"]), dash(review.Attrs["decision"]),
+					dash(review.Attrs["findings_count"]), independence, reviewClaimGrade(review))
+			}
+		}
+
+		prs := directChildren(manifest, session, KindPR)
+		if len(prs) == 0 {
+			fmt.Fprintln(w, "    PR: -")
+		} else {
+			fmt.Fprintln(w, "    PR:")
+			for _, pr := range prs {
+				label := "#" + dash(pr.Attrs["number"])
+				prLabels[label] = true
+				fmt.Fprintf(w, "      %s · head %s · opened %s · merged %s · state %s\n",
+					label, dash(pr.Attrs["head_sha"]), dash(pr.Attrs["opened_at"]),
+					dash(pr.Attrs["merged_at"]), dash(pr.Attrs["state"]))
+			}
+		}
+	}
+
+	modelCount := len(models)
+	fmt.Fprintf(w, "summary: root %s · %d sessions / %d models · %d tests reported, CI verification deferred · %d reviews / %d approved · PR %s\n",
+		dash(manifest.Root.Ref), len(sessions), modelCount, testCount,
+		reviewCount, approvedReviews, joinSet(prLabels))
+	tally := GradeTally(manifest)
+	fmt.Fprintf(w, "grades: reported=%d · observed=%d · verified=%d\n",
+		tally[GradeReported], tally[GradeObserved], tally[GradeVerified])
+	nodes, resultHashes := integrityTally(manifest)
+	delegationDAG := "gap"
+	if manifest.Root.Attrs["dag_consistent"] == "true" {
+		delegationDAG = "consistent"
+	}
+	fmt.Fprintf(w, "integrity: all %d nodes hash-consistent · manifest DAG acyclic · delegation DAG %s · %d result_hashes matched\n",
+		nodes, delegationDAG, resultHashes)
+	return nil
+}
+
+// GradeTally counts substantive claims by grade across nodes reachable from the
+// proof root. integrity.* meta-claims are reported separately by RenderTree.
+func GradeTally(manifest Manifest) map[Grade]int {
+	tally := map[Grade]int{
+		GradeReported: 0,
+		GradeObserved: 0,
+		GradeVerified: 0,
+	}
+	reachable, err := reachableNodeIDs(manifest)
+	if err != nil {
+		return tally
+	}
+	for id := range reachable {
+		node := manifest.Nodes[id]
+		for _, claim := range node.Claims {
+			if strings.HasPrefix(claim.Type, "integrity.") {
+				continue
+			}
+			tally[claim.Grade]++
+		}
+	}
+	return tally
+}
+
+func integrityTally(manifest Manifest) (nodes, resultHashes int) {
+	reachable, err := reachableNodeIDs(manifest)
+	if err != nil {
+		return 0, 0
+	}
+	for id := range reachable {
+		for _, claim := range manifest.Nodes[id].Claims {
+			if claim.Type == "integrity.result_hash" && claim.Grade == GradeVerified {
+				resultHashes++
+			}
+		}
+	}
+	return len(reachable), resultHashes
+}
+
+func directChildren(manifest Manifest, parent Node, kind Kind) []Node {
+	children := make([]Node, 0)
+	seen := map[string]bool{}
+	for _, id := range parent.Children {
+		node, ok := manifest.Nodes[id]
+		if !ok || node.Kind != kind || seen[id] {
+			continue
+		}
+		seen[id] = true
+		children = append(children, node)
+	}
+	sort.Slice(children, func(i, j int) bool {
+		if children[i].Ref != children[j].Ref {
+			return children[i].Ref < children[j].Ref
+		}
+		return children[i].ID < children[j].ID
+	})
+	return children
+}
+
+func reviewClaimGrade(node Node) Grade {
+	grade := GradeReported
+	for _, claim := range node.Claims {
+		if strings.HasPrefix(claim.Type, "review.") && claim.Grade == GradeObserved {
+			grade = GradeObserved
+		}
+	}
+	return grade
+}
+
+func zeroAsDash(value string) string {
+	if n, err := strconv.Atoi(value); err == nil && n == 0 {
+		return ""
+	}
+	return value
+}
+
+func joinSet(values map[string]bool) string {
+	if len(values) == 0 {
+		return "-"
+	}
+	items := make([]string, 0, len(values))
+	for value := range values {
+		items = append(items, value)
+	}
+	sort.Strings(items)
+	return strings.Join(items, ",")
+}
+
+func dash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return strings.TrimSpace(value)
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1345,6 +1345,41 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+### Evidence-graded proof manifests
+
+```sh
+gitmoot proof <root-id>
+gitmoot proof --json <root-id>
+# As with other Go-flag commands, place --home before the positional root id:
+gitmoot proof --home /tmp/isolated-home <root-id>
+```
+
+`gitmoot proof` is a **read-only**, structured-store projection of the complete
+job tree under `<root-id>`. The default output is a graded tree of sessions,
+delegation lineage and synthesis rules, reported tests, reviews, commits, and PR
+receipts. Missing evidence renders as `-`; `tests_run` claims remain
+**reported** with an explicit CI-verification gap. Read-only means the command
+opens SQLite in `mode=ro`, runs no migrations, and never changes store data.
+SQLite may still create or refresh `-wal`/`-shm` bookkeeping sidecars while it
+reads a live WAL database; immutable mode is deliberately not used because it
+can observe a torn live snapshot.
+
+`--json` emits the canonical content-addressed manifest. Every node uses a
+`sha256:<hex>` content id, parents refer to children by hash, and the root hash
+is the proof id. Re-projecting unchanged store records is byte-identical. Core
+grading is store-only: content hashes, DAG consistency, and `result_hash` column
+consistency can be **verified**, while independent review jobs, job events, and
+daemon PR receipts are **observed**. This is internal consistency, not
+cryptographic tamper-proofing against someone who can edit the database; signing
+is future work. The headline grade tally excludes `integrity.*` meta-claims and
+reports those separately on the `integrity:` line. The command never parses
+transcripts, contacts GitHub, or mutates store data.
+
+Remote `--verify`/CI upgrades and a dashboard proof view are future work and are
+not flags or surfaces in the core command. See [RESULT_CONTRACT.md](RESULT_CONTRACT.md)
+for the structured result and delegation inputs, and [SAFETY.md](SAFETY.md) for
+the read-only and bounded-DAG safety contracts.
+
 `gitmoot job show` reports the model selected when the job was enqueued: an
 explicit per-job/delegation model first, then the agent model, then the effective
 runtime's configured default model. Text output prints `model: -` when no model

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10733,6 +10733,41 @@ gitmoot lock list --repo owner/repo
 gitmoot lock show owner/repo <branch>
 ```
 
+### Evidence-graded proof manifests
+
+```sh
+gitmoot proof <root-id>
+gitmoot proof --json <root-id>
+# As with other Go-flag commands, place --home before the positional root id:
+gitmoot proof --home /tmp/isolated-home <root-id>
+```
+
+`gitmoot proof` is a **read-only**, structured-store projection of the complete
+job tree under `<root-id>`. The default output is a graded tree of sessions,
+delegation lineage and synthesis rules, reported tests, reviews, commits, and PR
+receipts. Missing evidence renders as `-`; `tests_run` claims remain
+**reported** with an explicit CI-verification gap. Read-only means the command
+opens SQLite in `mode=ro`, runs no migrations, and never changes store data.
+SQLite may still create or refresh `-wal`/`-shm` bookkeeping sidecars while it
+reads a live WAL database; immutable mode is deliberately not used because it
+can observe a torn live snapshot.
+
+`--json` emits the canonical content-addressed manifest. Every node uses a
+`sha256:<hex>` content id, parents refer to children by hash, and the root hash
+is the proof id. Re-projecting unchanged store records is byte-identical. Core
+grading is store-only: content hashes, DAG consistency, and `result_hash` column
+consistency can be **verified**, while independent review jobs, job events, and
+daemon PR receipts are **observed**. This is internal consistency, not
+cryptographic tamper-proofing against someone who can edit the database; signing
+is future work. The headline grade tally excludes `integrity.*` meta-claims and
+reports those separately on the `integrity:` line. The command never parses
+transcripts, contacts GitHub, or mutates store data.
+
+Remote `--verify`/CI upgrades and a dashboard proof view are future work and are
+not flags or surfaces in the core command. See [RESULT_CONTRACT.md](RESULT_CONTRACT.md)
+for the structured result and delegation inputs, and [SAFETY.md](SAFETY.md) for
+the read-only and bounded-DAG safety contracts.
+
 `gitmoot job show` reports the model selected when the job was enqueued: an
 explicit per-job/delegation model first, then the agent model, then the effective
 runtime's configured default model. Text output prints `model: -` when no model


### PR DESCRIPTION
## The proof-receipts spine — content-addressed evidence manifest + `gitmoot proof <root-id>` (v1 core)

**This is wrapper-agnostic Build-Week foundation, NOT a pre-empt of the owner's PaaS-vs-Arena A/B choice.** The proof-receipts spine was the one element unanimous across all five war-room seats — it is present in every wrapper configuration — so it's built now to protect the Jul 21 deadline. The wrapper decision remains entirely open; nothing here assumes one.

### What it does
Projects a work-root's **structured store records** into a deterministic, **content-addressed**, **evidence-graded** manifest, surfaced via `gitmoot proof <root-id> [--json]`.

- **`internal/proof`** (no CLI/network coupling): a Merkle DAG of `root → session → delegation → commit → test → review → pr` nodes, each addressed by `sha256:` of its canonical JSON (sans id). `VerifyManifest` recomputes every hash, validates child refs, **rejects nodes unreachable from the proof id**, and proves DAG acyclicity — all **offline**. Re-projecting unchanged data is **byte-identical** (only stored timestamps, never `time.Now()`).
- **Evidence grades** — `reported` (the agent's own `gitmoot_result`), `observed` (a first-party record gitmoot did not re-run: an independent-vs-self-distinguished review approval, an **exact-PR-scoped** opened/merged receipt, and lifecycle job-events), `verified` (**store-only integrity**: content-hash recompute, `result_hash` column-match, DAG consistency). Tests stay `reported` with an explicit `CI verification deferred` gap — never faked as verified. The headline `grades:` line counts **substantive reachable claims only**; per-node integrity is shown on a separate `integrity:` line so trivial self-hashes never inflate the evidence summary.
- **`gitmoot proof <root-id>`** renders a graded tree; `--json` emits the canonical manifest. **Read-only** (opens `mode=ro`, no migrations; a test asserts the DB data is unchanged). Honest `-` for absent data; a malformed payload degrades to a gap, never aborting the projection.

### Explicitly deferred (until the wrapper decision — NOT in this PR)
The `--verify` / CI re-query leg, the dashboard Proof tab, and any API surface. No network calls, no `go.mod` / `gitmoot-dashboard` module change, no cryptographic signing.

### Review & validation
Reviewed by a fresh-context **`/code-review high`** pass (three anti-anchoring finders). Five findings — a `pr.merged` cross-PR fabrication, an orphan-node reachability gap, integrity-tally inflation, review-independence normalization, and malformed-payload aborts — **all fixed** before this PR. Independent gate green (`build`/`vet`/`generate`-clean + `go test ./internal/{proof,cli,db,workflow}`; cli 397s). **Live-probed** against a real delegation DAG: byte-stable `--json`, store bytes unchanged, and an honest grade headline (`verified=0` on pre-`#998` data — no substantive verified evidence, correctly reported).

*Note:* the `observed` bucket includes lifecycle job-events (queued/running/succeeded/advance/delegation) — genuine first-party observations per the spec; substantive corroborations (reviews, PR receipts) are itemized in the tree and the summary line. Splitting lifecycle from substantive corroboration in the headline is a candidate v1.1 refinement.

### Deploy notes
CLI/engine read-only feature — deploy `gitmoot` when convenient (no migration beyond `#998`'s already-merged `jobs.model`; `ListJobsByRoot` widening is compatible). Workflow label `hx/proof-spine`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
