### PR TITLE
docs: link the frozen submission tags in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 
 **The Build Week submission is one feature of this repo: [Gitmoot Pipelines](https://gitmoot.io/docs/workflows/pipelines-workflow)**,
 agent graphs saved as yaml files that you can rerun, inspect, share, and expose as a typed
-service API with verifiable receipts. Start there if you came from Devpost. Demo video: <https://www.youtube.com/watch?v=oiX8OiXAVrM>. Submission assets, the Codex session table, and a
+service API with verifiable receipts. Start there if you came from Devpost. Demo video: <https://www.youtube.com/watch?v=oiX8OiXAVrM>. The repo keeps evolving after the
+hackathon; the exact tree as submitted on July 21 is frozen at the
+[`buildweek-2026-submission` tag](https://github.com/gitmoot/gitmoot/tree/buildweek-2026-submission). Submission assets, the Codex session table, and a
 verbatim proof receipt live in [`buildweek-2026/`](buildweek-2026/) (temporary folder,
 removed after judging).
 

--- a/buildweek-2026/README.md
+++ b/buildweek-2026/README.md
@@ -2,6 +2,12 @@
 
 **Demo video: <https://www.youtube.com/watch?v=oiX8OiXAVrM>**
 
+**Frozen submission state**: development continues after the hackathon, so the exact trees as
+submitted on July 21 are tagged `buildweek-2026-submission` in both repos:
+[gitmoot](https://github.com/gitmoot/gitmoot/tree/buildweek-2026-submission) and
+[appkit-demo](https://github.com/gitmoot/appkit-demo/tree/buildweek-2026-submission).
+Anything after those tags is post-submission work.
+
 This folder documents the **Gitmoot Pipelines** submission for OpenAI Build Week 2026
 (July 13–21). It is temporary and will be removed after judging. The submission is one
 feature of this repo: agent graphs saved as yaml files that you can rerun, inspect, share,


### PR DESCRIPTION
Owner-directed: development continues post-hackathon, so both repos are tagged buildweek-2026-submission at their submitted tips; this links the frozen trees from the README and the buildweek folder. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)