### PR TITLE
fix(health): report daemon.version as unknown (not the on-disk fallback) for pre-#932 daemons (#1003)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,7 +43,11 @@ Notes:
   with no VCS commit are both just `dev`, so comparing them would prove nothing.
 - If you run the web dashboard as a **separate service**, it is its own process
   with its own build. `/api/health` reports the serving process's build separately
-  from the daemon's, so restart both after an upgrade.
+  from the daemon's, so restart both after an upgrade. The daemon block includes
+  `versionSource: "recorded"` when its version came from daemon startup metadata.
+  A daemon started by a pre-build-recording gitmoot instead reports
+  `versionSource: "unknown"` with an empty `version`; unknown is never a skew or
+  healthy-agreement verdict and never falls back to the binary now on disk.
 
 ## `gh`
 

--- a/internal/cli/build_skew_test.go
+++ b/internal/cli/build_skew_test.go
@@ -196,7 +196,8 @@ func TestHealthEndpointAddsServingBuildAndKeepsListsNonNil(t *testing.T) {
 
 	var payload struct {
 		Daemon struct {
-			Version string `json:"version"`
+			Version       string `json:"version"`
+			VersionSource string `json:"versionSource"`
 		} `json:"daemon"`
 		Server struct {
 			Version string `json:"version"`
@@ -212,6 +213,9 @@ func TestHealthEndpointAddsServingBuildAndKeepsListsNonNil(t *testing.T) {
 	}
 	if payload.Daemon.Version != "dev-stale-daemon" {
 		t.Fatalf("daemon build = %q", payload.Daemon.Version)
+	}
+	if payload.Daemon.VersionSource != "recorded" {
+		t.Fatalf("daemon version source = %q, want recorded", payload.Daemon.VersionSource)
 	}
 	current := buildinfo.Current()
 	if payload.Server.Version != current.Version || payload.Server.Commit != current.Commit {
@@ -231,6 +235,79 @@ func TestHealthEndpointAddsServingBuildAndKeepsListsNonNil(t *testing.T) {
 		if raw == nil || string(*raw) == "null" {
 			t.Fatalf("%s serialized as null; the contract promises an array", name)
 		}
+	}
+}
+
+// A daemon started before build recording was added has no trustworthy running
+// version. The binary now sitting at its path may already have been replaced,
+// so substituting that on-disk version would turn unknown into a false fact.
+func TestHealthEndpointDoesNotSubstituteOnDiskVersionForLegacyDaemon(t *testing.T) {
+	home := t.TempDir()
+	stageLiveDaemon(t, home, "", "")
+	stubOnDiskBuild(t, "dev-fresh-on-disk", "freshdisk")
+	stubUpdateCheck(t, "")
+
+	ds := &webDataSource{home: home}
+	recorder := httptest.NewRecorder()
+	ds.handleHealth(recorder, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+
+	var payload struct {
+		Daemon struct {
+			Version       string `json:"version"`
+			VersionSource string `json:"versionSource"`
+		} `json:"daemon"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Daemon.Version != "" {
+		t.Fatalf("legacy daemon build = %q, want unknown (not the on-disk build)", payload.Daemon.Version)
+	}
+	if payload.Daemon.VersionSource != "unknown" {
+		t.Fatalf("daemon version source = %q, want unknown", payload.Daemon.VersionSource)
+	}
+}
+
+// In the incident scenario, the serving dashboard and the freshly replaced
+// on-disk daemon binary are the same build while the still-running legacy daemon
+// is not. Unknown must not become a false server==daemon healthy match.
+func TestHealthEndpointUnknownDaemonVersionCannotFalseMatchServer(t *testing.T) {
+	home := t.TempDir()
+	stageLiveDaemon(t, home, "", "")
+	current := buildinfo.Current()
+	stubOnDiskBuild(t, current.Version, current.Commit)
+	stubUpdateCheck(t, "")
+
+	ds := &webDataSource{home: home}
+	recorder := httptest.NewRecorder()
+	ds.handleHealth(recorder, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d", recorder.Code)
+	}
+
+	var payload struct {
+		Daemon struct {
+			Version       string `json:"version"`
+			VersionSource string `json:"versionSource"`
+		} `json:"daemon"`
+		Server struct {
+			Version string `json:"version"`
+		} `json:"server"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Server.Version == "" {
+		t.Fatal("serving build version is empty; test cannot prove the false-match regression")
+	}
+	if payload.Daemon.Version != "" || payload.Daemon.VersionSource != "unknown" {
+		t.Fatalf("legacy daemon = version %q source %q, want empty/unknown", payload.Daemon.Version, payload.Daemon.VersionSource)
+	}
+	if payload.Server.Version == payload.Daemon.Version {
+		t.Fatalf("unknown daemon falsely matches serving build %q", payload.Server.Version)
 	}
 }
 

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -203,9 +203,15 @@ type dashboardServerBuild struct {
 	Commit  string `json:"commit"`
 }
 
+type dashboardHealthDaemon struct {
+	dashboard.HealthDaemon
+	VersionSource string `json:"versionSource,omitempty"`
+}
+
 type dashboardHealthResponse struct {
 	dashboard.Health
-	Server dashboardServerBuild `json:"server"`
+	Daemon dashboardHealthDaemon `json:"daemon"`
+	Server dashboardServerBuild  `json:"server"`
 }
 
 // handleHealth shadows the module's /api/health to add the build of the process
@@ -239,8 +245,16 @@ func (d *webDataSource) healthJSON(ctx context.Context) ([]byte, error) {
 		health.RecentFailures = []dashboard.HealthFailure{}
 	}
 	build := buildinfo.Current()
+	versionSource := "unknown"
+	if health.Daemon.Version != "" {
+		versionSource = "recorded"
+	}
 	response := dashboardHealthResponse{
 		Health: health,
+		Daemon: dashboardHealthDaemon{
+			HealthDaemon:  health.Daemon,
+			VersionSource: versionSource,
+		},
 		Server: dashboardServerBuild{Version: build.Version, Commit: build.Commit},
 	}
 	return marshalDashboardJSON(response)
@@ -1655,14 +1669,11 @@ func (d *webDataSource) Health(ctx context.Context) (dashboard.Health, error) {
 
 	probes.Wait()
 
-	// What the daemon PROCESS is running: its recorded build. Only a daemon
-	// started by an older gitmoot recorded none — then, and only then, fall back
-	// to asking the binary at its path (the pre-#932 behavior, which is wrong the
-	// moment the binary has been swapped, but is the best available answer).
+	// What the daemon PROCESS is running: its recorded build. A daemon started by
+	// an older gitmoot recorded none, so its running build remains unknown. The
+	// binary now sitting at its path may have been replaced and cannot answer for
+	// the already-running process (#1003).
 	out.Daemon.Version = recordedDaemonVersion
-	if out.Daemon.Version == "" {
-		out.Daemon.Version = onDiskVersion
-	}
 
 	// What an update would replace: the binary on disk. Keeping the badge
 	// on-disk-relative is what stops it from sticking on after `gitmoot update`

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -312,10 +312,13 @@ just `dev`: indistinguishable, so comparing them would prove nothing.
 
 The web dashboard's `/api/health` reports the daemon's **recorded** build (what
 the process is actually running — not the version of whatever binary now sits at
-its path) plus, separately, the serving dashboard process's own build, so a
-dashboard left on a stale binary is visible rather than silently wrong. The
-update badge stays relative to the binary on disk, since that is what an update
-replaces.
+its path) plus, separately, the serving dashboard process's own build. Its
+`daemon.versionSource` is `recorded` when `daemon.version` came from daemon
+startup metadata, or `unknown` when an older daemon recorded no build; in the
+latter case `daemon.version` is empty and must never be treated as either skew or
+agreement. This keeps a stale dashboard or daemon visible rather than silently
+wrong. The update badge stays relative to the binary on disk, since that is what
+an update replaces.
 
 The `gitmoot repo` commands manage the **watched-repo registry**: one daemon
 per Gitmoot home supervises every **enabled** registered repo. An omitted

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -297,7 +297,10 @@ Health is the operability view for unattended runs:
 
 - **Daemon** — running/stopped, PID, uptime, the running binary's version, and an
   update chip (`up to date`, or `update available: <version>` linking to the
-  release).
+  release). In `/api/health`, `daemon.versionSource` is `recorded` when the
+  running version came from daemon startup metadata. A daemon started by an
+  older gitmoot reports `unknown` with an empty `daemon.version`; clients must
+  treat that as neither build skew nor healthy agreement.
 - **State totals** — a chip per state (queued, running, blocked, succeeded,
   failed, cancelled).
 - **Stuck jobs** — blocked jobs (surfaced at any age) plus queued jobs older than

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -215,10 +215,13 @@ indistinguishable, so comparing them would prove nothing.
 
 The web dashboard's `/api/health` reports the daemon's **recorded** build — what
 the daemon process is actually running, not the version of whatever binary now
-sits at its path — plus, separately, the serving dashboard process's own build,
-so a dashboard left on a stale binary is visible rather than silently wrong. The
-update badge remains relative to the binary on disk, since that is what an update
-replaces.
+sits at its path — plus, separately, the serving dashboard process's own build.
+Its `daemon.versionSource` is `recorded` when `daemon.version` came from daemon
+startup metadata, or `unknown` when an older daemon recorded no build; in the
+latter case `daemon.version` is empty and must never be treated as either skew or
+agreement. This keeps a stale dashboard or daemon visible rather than silently
+wrong. The update badge remains relative to the binary on disk, since that is
+what an update replaces.
 
 ### Watched Repos
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -25,6 +25,25 @@ needs fuller local workflow, CLI, plugin, safety, and result-contract context.
 
 </div>
 
+
+## Built with Codex (OpenAI Build Week 2026)
+
+**The Build Week submission is one feature of this repo: [Gitmoot Pipelines](https://gitmoot.io/docs/workflows/pipelines-workflow)**,
+agent graphs saved as yaml files that you can rerun, inspect, share, and expose as a typed
+service API with verifiable receipts. Start there if you came from Devpost. Demo video: <https://www.youtube.com/watch?v=oiX8OiXAVrM>. The repo keeps evolving after the
+hackathon; the exact tree as submitted on July 21 is frozen at the
+[`buildweek-2026-submission` tag](https://github.com/gitmoot/gitmoot/tree/buildweek-2026-submission). Submission assets, the Codex session table, and a
+verbatim proof receipt live in [`buildweek-2026/`](buildweek-2026/) (temporary folder,
+removed after judging).
+
+The Pipelines-as-a-Service layer (`pipeline expose` / `serve`, typed input firewall, public
+receipts) and the proof spine were implemented by **Codex running gpt-5.6-sol**, coordinated
+through gitmoot itself. Gitmoot mints receipts for its own implementation jobs, so the
+collaboration is verifiable: Codex session `019f6e86-fdf2-78f1-8f6a-7c5e0f948340`, proof
+manifest `sha256:78b3ab08...` (`gitmoot proof` reproduces it offline). The Build Week demo
+pipeline lives at [gitmoot/appkit-demo](https://github.com/gitmoot/appkit-demo), and its runs
+are public at <https://gitmoot.themartian.app/pipelines/appkit-pro>.
+
 ## Our Vision
 
 AI agents can already write code, review diffs, and run your tools. What they can't do is coordinate across sessions, runtimes, and days without losing the one thing software teams actually trust: **the pull request audit trail**.
@@ -1782,7 +1801,11 @@ Notes:
   with no VCS commit are both just `dev`, so comparing them would prove nothing.
 - If you run the web dashboard as a **separate service**, it is its own process
   with its own build. `/api/health` reports the serving process's build separately
-  from the daemon's, so restart both after an upgrade.
+  from the daemon's, so restart both after an upgrade. The daemon block includes
+  `versionSource: "recorded"` when its version came from daemon startup metadata.
+  A daemon started by a pre-build-recording gitmoot instead reports
+  `versionSource: "unknown"` with an empty `version`; unknown is never a skew or
+  healthy-agreement verdict and never falls back to the binary now on disk.
 
 ## `gh`
 
@@ -6839,7 +6862,10 @@ Health is the operability view for unattended runs:
 
 - **Daemon** — running/stopped, PID, uptime, the running binary's version, and an
   update chip (`up to date`, or `update available: <version>` linking to the
-  release).
+  release). In `/api/health`, `daemon.versionSource` is `recorded` when the
+  running version came from daemon startup metadata. A daemon started by an
+  older gitmoot reports `unknown` with an empty `daemon.version`; clients must
+  treat that as neither build skew nor healthy agreement.
 - **State totals** — a chip per state (queued, running, blocked, succeeded,
   failed, cancelled).
 - **Stuck jobs** — blocked jobs (surfaced at any age) plus queued jobs older than
@@ -9706,10 +9732,13 @@ just `dev`: indistinguishable, so comparing them would prove nothing.
 
 The web dashboard's `/api/health` reports the daemon's **recorded** build (what
 the process is actually running — not the version of whatever binary now sits at
-its path) plus, separately, the serving dashboard process's own build, so a
-dashboard left on a stale binary is visible rather than silently wrong. The
-update badge stays relative to the binary on disk, since that is what an update
-replaces.
+its path) plus, separately, the serving dashboard process's own build. Its
+`daemon.versionSource` is `recorded` when `daemon.version` came from daemon
+startup metadata, or `unknown` when an older daemon recorded no build; in the
+latter case `daemon.version` is empty and must never be treated as either skew or
+agreement. This keeps a stale dashboard or daemon visible rather than silently
+wrong. The update badge stays relative to the binary on disk, since that is what
+an update replaces.
 
 The `gitmoot repo` commands manage the **watched-repo registry**: one daemon
 per Gitmoot home supervises every **enabled** registered repo. An omitted


### PR DESCRIPTION
## Report `daemon.version` as unknown (not the on-disk fallback) for pre-#932 daemons — closes #1003

`/api/health`'s `daemon.version` silently fell back to the version of the binary currently **on disk** when the daemon process recorded no build version (a daemon started by a **pre-#932** gitmoot) — the exact proxy #932 exists to avoid. Consequence: deploy a new binary without restarting the old daemon → `daemon.version` reports the fresh on-disk build → `server.version == daemon.version` → a **stale daemon reads HEALTHY**, the precise build-skew incident #932/#103 exist to surface.

### Fix
- **Remove the on-disk fallback**: when the daemon recorded no version, leave `daemon.version` empty (unknown). Both consumers already treat empty as *"do not compare"* — `doctor`'s `daemonBuildStatus`/`CheckBuild` skips an unidentifiable daemon build (`identifiableBuild` treats `""`/`"unknown"` as skip), and the #103 build-skew banner requires **both** versions before rendering — so unknown never becomes a false "healthy". (`server.version` defaults to the `"dev"` const and is never empty, so `daemon.version==""` can never false-match.)
- **Additive `daemon.versionSource`** (`"recorded"` | `"unknown"`) makes the previously-silent fallback **explicit**. It lives on a gitmoot-local `dashboardHealthDaemon` that **embeds** the module's `dashboard.HealthDaemon` (gitmoot already shadows the module's `/api/health` handler), so the field reaches the JSON via Go's field-conflict shadowing with **no gitmoot-dashboard module change and no go.mod bump**; `omitempty` keeps existing clients unaffected.
- **Update badge unchanged**: health selects the on-disk version before `daemon.version`, so an unrecorded daemon with a resolvable executable still shows the badge relative to disk.

### Review & tests
Reviewed by an independent design-validation (V03) + a fresh-context `/code-review high`, both **clean**. Tests: RED-confirmed on unpatched behavior (legacy daemon returned the on-disk version); `recorded → daemon.version==recorded, versionSource=="recorded"`; `unrecorded → daemon.version=="", versionSource=="unknown"`, no false skew-match; the existing on-disk update-badge test stays green. Independent gate green (`build`/`vet`/`generate`-clean + `go test ./internal/cli` 531s — note the cli suite is ~530s and can trip the *default* 10m go-test timeout on a busy box; CI's sharded lanes are unaffected).

### Cross-repo note (handoff, not in this PR)
This PR adds the `versionSource` field the **gitmoot-dashboard frontend** needs, but can't wire it (separate repo). Any web/UI skew check must gate on `versionSource === "unknown"` (or an empty `daemon.version`) before rendering a verdict — otherwise an empty `daemon.version` could read as a *false-skew*. The #103 branch already requires both versions, and the currently-vendored module has no such banner, so this is a latent/forward-looking guard.

## Deploy notes
Daemon + dashboard read-path change — deploy `gitmoot` + `gitmoot-dashboard-web` (the health handler is served by both binaries). No migration. The pre-#932 window closes naturally as those daemons restart; until then this converts a confidently-wrong version into an honest "unknown". **No deploy requested — owner-gated during the judging window.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
