### PR TITLE
fix(pipeline): stage rows reflect real job-event transitions, not advancer ticks (#1016 half 2)

### DIFF
--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -1534,7 +1534,11 @@ func printPipelineRunFunnelAt(stdout io.Writer, view pipelineRunView, now time.T
 		if stage.State != pipeline.StageQueued && stage.State != pipeline.StageRunning {
 			continue
 		}
-		writeLine(stdout, "  %s: %s; enqueued %s ago", stage.StageID, strings.ToUpper(stage.State), pipelineElapsed(now, stage.StartedAt))
+		timingLabel := "enqueued"
+		if stage.State == pipeline.StageRunning {
+			timingLabel = "started"
+		}
+		writeLine(stdout, "  %s: %s; %s %s ago", stage.StageID, strings.ToUpper(stage.State), timingLabel, pipelineElapsed(now, stage.StartedAt))
 		event, hasProgress := view.progress[stage.JobID]
 		progress, validProgress := decodePipelineProgress(event.Message)
 		if stage.State == pipeline.StageRunning && hasProgress && validProgress {

--- a/internal/cli/pipeline_advance_test.go
+++ b/internal/cli/pipeline_advance_test.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -82,6 +84,50 @@ func settleStageJob(t *testing.T, store *db.Store, jobID, decision, summary stri
 		db.JobEvent{JobID: jobID, Kind: to, Message: "settled by test"})
 	if err != nil || !ok {
 		t.Fatalf("settle %s -> %s: ok=%v err=%v", jobID, to, ok, err)
+	}
+}
+
+func startStageJob(t *testing.T, store *db.Store, jobID string) {
+	t.Helper()
+	ok, err := store.TransitionJobStateWithEvent(context.Background(), jobID, string(workflow.JobQueued), string(workflow.JobRunning), db.JobEvent{
+		JobID: jobID, Kind: string(workflow.JobRunning), Message: "job started by test",
+	})
+	if err != nil || !ok {
+		t.Fatalf("start %s: ok=%v err=%v", jobID, ok, err)
+	}
+}
+
+func setPipelineJobEventTime(t *testing.T, store *db.Store, jobID, kind string, at time.Time) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer conn.Close()
+	result, err := conn.Exec(`UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`, at.UTC().Format(time.RFC3339Nano), jobID, kind)
+	if err != nil {
+		t.Fatalf("UPDATE job event time: %v", err)
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		t.Fatalf("updated job event rows = %d, err=%v, want 1", changed, err)
+	}
+}
+
+func setPipelineJobEventTimeAtIndex(t *testing.T, store *db.Store, jobID, kind string, index int, at time.Time) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer conn.Close()
+	result, err := conn.Exec(`UPDATE job_events SET created_at = ? WHERE id = (
+		SELECT id FROM job_events WHERE job_id = ? AND kind = ? ORDER BY id ASC LIMIT 1 OFFSET ?
+	)`, at.UTC().Format(time.RFC3339Nano), jobID, kind, index)
+	if err != nil {
+		t.Fatalf("UPDATE indexed job event time: %v", err)
+	}
+	if changed, err := result.RowsAffected(); err != nil || changed != 1 {
+		t.Fatalf("updated indexed job event rows = %d, err=%v, want 1", changed, err)
 	}
 }
 
@@ -278,6 +324,112 @@ func TestAdvancerDiamond(t *testing.T) {
 	}
 }
 
+func TestAdvancerFastStageUsesJobEventTimes(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	enqueueAt := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	startedAt := enqueueAt.Add(17 * time.Second)
+	finishedAt := startedAt.Add(23 * time.Second)
+	foldAt := enqueueAt.Add(2 * time.Minute)
+
+	run := startTestRun(t, store, rec, spec, enqueue, enqueueAt)
+	jobID := stageRow(t, store, run.ID, "a").JobID
+	startStageJob(t, store, jobID)
+	setPipelineJobEventTime(t, store, jobID, string(workflow.JobRunning), startedAt)
+	settleStageJob(t, store, jobID, "approved", "fast", nil)
+	setPipelineJobEventTime(t, store, jobID, string(workflow.JobSucceeded), finishedAt)
+
+	run = advance(t, store, rec, spec, enqueue, run, foldAt)
+	got := stageRow(t, store, run.ID, "a")
+	if !got.StartedAt.Equal(startedAt) || !got.FinishedAt.Equal(finishedAt) {
+		t.Fatalf("fast stage times = (%s, %s), want job events (%s, %s)", got.StartedAt, got.FinishedAt, startedAt, finishedAt)
+	}
+	if got.StartedAt.Equal(enqueueAt) || got.FinishedAt.Equal(foldAt) {
+		t.Fatalf("fast stage retained advancer ticks: %+v", got)
+	}
+}
+
+func TestAdvancerStageUsesEarliestRunningEventAcrossReclaim(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	enqueueAt := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	firstStartedAt := enqueueAt.Add(time.Minute)
+	reclaimedAt := enqueueAt.Add(16 * time.Minute)
+	finishedAt := enqueueAt.Add(21 * time.Minute)
+	run := startTestRun(t, store, rec, spec, enqueue, enqueueAt)
+	jobID := stageRow(t, store, run.ID, "a").JobID
+
+	startStageJob(t, store, jobID)
+	ok, err := store.TransitionJobStateWithEvent(context.Background(), jobID, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
+		JobID: jobID, Kind: string(workflow.JobQueued), Message: "requeued after reboot by test",
+	})
+	if err != nil || !ok {
+		t.Fatalf("requeue %s: ok=%v err=%v", jobID, ok, err)
+	}
+	startStageJob(t, store, jobID)
+	setPipelineJobEventTimeAtIndex(t, store, jobID, string(workflow.JobRunning), 0, firstStartedAt)
+	setPipelineJobEventTimeAtIndex(t, store, jobID, string(workflow.JobRunning), 1, reclaimedAt)
+	settleStageJob(t, store, jobID, "approved", "survived reclaim", nil)
+	setPipelineJobEventTime(t, store, jobID, string(workflow.JobSucceeded), finishedAt)
+
+	run = advance(t, store, rec, spec, enqueue, run, finishedAt.Add(time.Minute))
+	got := stageRow(t, store, run.ID, "a")
+	if !got.StartedAt.Equal(firstStartedAt) || !got.FinishedAt.Equal(finishedAt) {
+		t.Fatalf("reclaimed stage times = (%s, %s), want earliest start %s and finish %s", got.StartedAt, got.FinishedAt, firstStartedAt, finishedAt)
+	}
+	if duration := got.FinishedAt.Sub(got.StartedAt); duration != 20*time.Minute {
+		t.Fatalf("reclaimed stage duration = %s, want 20m (not 5m from reclaim)", duration)
+	}
+}
+
+func TestAdvancerForkedStagesUseDistinctJobEventTimes(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "fork", independentBranchSpec)
+	tick := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, tick)
+
+	want := map[string][2]time.Time{
+		"a": {tick.Add(10 * time.Second), tick.Add(20 * time.Second)},
+		"b": {tick.Add(30 * time.Second), tick.Add(50 * time.Second)},
+	}
+	for stageID, times := range want {
+		jobID := stageRow(t, store, run.ID, stageID).JobID
+		startStageJob(t, store, jobID)
+		setPipelineJobEventTime(t, store, jobID, string(workflow.JobRunning), times[0])
+		settleStageJob(t, store, jobID, "approved", stageID+" done", nil)
+		setPipelineJobEventTime(t, store, jobID, string(workflow.JobSucceeded), times[1])
+	}
+
+	run = advance(t, store, rec, spec, enqueue, run, tick.Add(5*time.Minute))
+	for stageID, times := range want {
+		got := stageRow(t, store, run.ID, stageID)
+		if !got.StartedAt.Equal(times[0]) || !got.FinishedAt.Equal(times[1]) {
+			t.Fatalf("stage %s times = (%s, %s), want (%s, %s)", stageID, got.StartedAt, got.FinishedAt, times[0], times[1])
+		}
+	}
+}
+
+func TestAdvancerPreClaimFailureHasNonNegativeDuration(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "chain", linearChainSpec)
+	tick := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, tick)
+	jobID := stageRow(t, store, run.ID, "a").JobID
+	terminalAt := tick.Add(45 * time.Second)
+
+	settleStageJob(t, store, jobID, "failed", "failed before claim", nil)
+	setPipelineJobEventTime(t, store, jobID, string(workflow.JobFailed), terminalAt)
+	run = advance(t, store, rec, spec, enqueue, run, tick.Add(time.Minute))
+	got := stageRow(t, store, run.ID, "a")
+	if got.State != pipeline.StageFailed || !got.StartedAt.Equal(terminalAt) || !got.FinishedAt.Equal(terminalAt) {
+		t.Fatalf("pre-claim failure stage = %+v, want terminal with zero non-negative duration at %s", got, terminalAt)
+	}
+}
+
 // TestAdvancerBlockedPark proves a blocked stage parks the run: needs are
 // persisted at stage AND run level, and the downstream stage is never enqueued.
 func TestAdvancerBlockedPark(t *testing.T) {
@@ -437,6 +589,49 @@ func TestAdvancerFailedRetryBudget(t *testing.T) {
 	}
 	if got := stageRow(t, store, run.ID, "b"); got.State != pipeline.StageSkipped || got.JobID != "" {
 		t.Fatalf("stage b = %+v, want skipped never-enqueued", got)
+	}
+}
+
+func TestAdvancerRetryResetsAndRederivesAttemptTimes(t *testing.T) {
+	store := pipelineAdvanceStore(t)
+	enqueue := testStageEnqueuer(store)
+	rec, spec := newTestPipeline(t, store, "retry", retrySpec)
+	tick := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	run := startTestRun(t, store, rec, spec, enqueue, tick)
+	firstJob := stageRow(t, store, run.ID, "a").JobID
+
+	startStageJob(t, store, firstJob)
+	settleStageJob(t, store, firstJob, "failed", "retry me", nil)
+	failingEnqueue := func(context.Context, workflow.JobRequest) (db.Job, error) {
+		return db.Job{}, errors.New("pause after retry reset")
+	}
+	if _, err := advancePipelineRun(context.Background(), store, failingEnqueue, rec, spec, run, tick.Add(time.Minute)); err == nil {
+		t.Fatal("advance with failing retry enqueue returned nil error")
+	}
+	reset := stageRow(t, store, run.ID, "a")
+	if reset.State != pipeline.StagePending || reset.JobID != "" || !reset.StartedAt.IsZero() || !reset.FinishedAt.IsZero() {
+		t.Fatalf("retry reset stage = %+v, want pending with both timestamps zero", reset)
+	}
+
+	run = advance(t, store, rec, spec, enqueue, run, tick.Add(2*time.Minute))
+	second := stageRow(t, store, run.ID, "a")
+	if second.JobID == "" || second.JobID == firstJob {
+		t.Fatalf("retry job id = %q, want new id after %q", second.JobID, firstJob)
+	}
+	startedAt := tick.Add(3 * time.Minute)
+	finishedAt := tick.Add(4 * time.Minute)
+	startStageJob(t, store, second.JobID)
+	setPipelineJobEventTime(t, store, second.JobID, string(workflow.JobRunning), startedAt)
+	run = advance(t, store, rec, spec, enqueue, run, startedAt.Add(10*time.Second))
+	if live := stageRow(t, store, run.ID, "a"); live.State != pipeline.StageRunning || !live.StartedAt.Equal(startedAt) {
+		t.Fatalf("live retry stage = %+v, want real running-event start %s", live, startedAt)
+	}
+	settleStageJob(t, store, second.JobID, "approved", "retry passed", nil)
+	setPipelineJobEventTime(t, store, second.JobID, string(workflow.JobSucceeded), finishedAt)
+	run = advance(t, store, rec, spec, enqueue, run, tick.Add(10*time.Minute))
+	got := stageRow(t, store, run.ID, "a")
+	if !got.StartedAt.Equal(startedAt) || !got.FinishedAt.Equal(finishedAt) {
+		t.Fatalf("retried stage times = (%s, %s), want new job events (%s, %s)", got.StartedAt, got.FinishedAt, startedAt, finishedAt)
 	}
 }
 

--- a/internal/cli/pipeline_gate_stage_e2e_test.go
+++ b/internal/cli/pipeline_gate_stage_e2e_test.go
@@ -227,6 +227,9 @@ stages:
 	if gate.State != pipeline.StageBlocked {
 		t.Fatalf("gate stage = %s, want blocked after the timeout", gate.State)
 	}
+	if !gate.StartedAt.Equal(start.UTC()) {
+		t.Fatalf("jobless gate StartedAt = %s, want unchanged enqueue tick %s", gate.StartedAt, start.UTC())
+	}
 	if run.State != pipeline.RunBlocked {
 		t.Fatalf("run = %s, want blocked", run.State)
 	}

--- a/internal/cli/pipeline_orchestrate_wait_758_test.go
+++ b/internal/cli/pipeline_orchestrate_wait_758_test.go
@@ -116,6 +116,13 @@ func TestOrchestrateStageFollowsContinuationChainAndFoldsTail(t *testing.T) {
 	if cj, _ := store.GetJob(context.Background(), coordJob); mustPayloadRoot(t, cj) != coordJob {
 		t.Fatalf("coordinator RootJobID = %q, want its own id %q", mustPayloadRoot(t, cj), coordJob)
 	}
+	rootStartedAt := now.Add(10 * time.Second)
+	startStageJob(t, store, coordJob)
+	setPipelineJobEventTime(t, store, coordJob, string(workflow.JobRunning), rootStartedAt)
+	run = advance(t, store, rec, spec, enqueue, run, rootStartedAt.Add(time.Second))
+	if got := stageRow(t, store, run.ID, "coord"); !got.StartedAt.Equal(rootStartedAt) {
+		t.Fatalf("orchestrate root start = %s, want running event %s", got.StartedAt, rootStartedAt)
+	}
 
 	contID := coordJob + "/continuation"
 	contID2 := contID + "/continuation"
@@ -125,6 +132,8 @@ func TestOrchestrateStageFollowsContinuationChainAndFoldsTail(t *testing.T) {
 	settleChainJob(t, store, contID, "approved", "gen-1 placeholder", nil, oneDelegation(), false)
 	seedContinuationJob(t, store, contID2, contID, coordJob)
 	settleChainJob(t, store, contID2, "approved", "final synthesis", nil, nil, false)
+	tailFinishedAt := now.Add(2 * time.Minute)
+	setPipelineJobEventTime(t, store, contID2, string(workflow.JobSucceeded), tailFinishedAt)
 
 	// Scan 1: coordinator settled + continuation exists → re-point to gen-1, stay running.
 	run = advance(t, store, rec, spec, enqueue, run, now)
@@ -152,6 +161,9 @@ func TestOrchestrateStageFollowsContinuationChainAndFoldsTail(t *testing.T) {
 	}
 	if got.Summary != "final synthesis" {
 		t.Fatalf("stage folded summary = %q, want the TAIL's %q (not the coordinator's)", got.Summary, "final synthesis")
+	}
+	if !got.StartedAt.Equal(rootStartedAt) || !got.FinishedAt.Equal(tailFinishedAt) {
+		t.Fatalf("orchestrate times = (%s, %s), want root start %s and tail finish %s", got.StartedAt, got.FinishedAt, rootStartedAt, tailFinishedAt)
 	}
 	if run.State != pipeline.RunSucceeded {
 		t.Fatalf("run = %s, want succeeded", run.State)
@@ -292,13 +304,37 @@ func TestOrchestrateStageTimeoutTripsKillAndFoldsFinalizeTail(t *testing.T) {
 	run := startTestRun(t, store, rec, spec, enqueue, start)
 	coordJob := stageRow(t, store, run.ID, "coord").JobID
 	contID := coordJob + "/continuation"
+	realStart := start.Add(30 * time.Minute)
+	reclaimedAt := realStart.Add(15 * time.Minute)
+	startStageJob(t, store, coordJob)
+	ok, err := store.TransitionJobStateWithEvent(ctx, coordJob, string(workflow.JobRunning), string(workflow.JobQueued), db.JobEvent{
+		JobID: coordJob, Kind: string(workflow.JobQueued), Message: "requeued after reboot by test",
+	})
+	if err != nil || !ok {
+		t.Fatalf("requeue coordinator: ok=%v err=%v", ok, err)
+	}
+	startStageJob(t, store, coordJob)
+	setPipelineJobEventTimeAtIndex(t, store, coordJob, string(workflow.JobRunning), 0, realStart)
+	setPipelineJobEventTimeAtIndex(t, store, coordJob, string(workflow.JobRunning), 1, reclaimedAt)
+	run = advance(t, store, rec, spec, enqueue, run, reclaimedAt.Add(time.Second))
+	if got := stageRow(t, store, run.ID, "coord"); !got.StartedAt.Equal(realStart) {
+		t.Fatalf("orchestrate timeout anchor after reclaim = %s, want earliest running-event start %s", got.StartedAt, realStart)
+	}
 
 	// Coordinator fanned out; its sub-tree is still live (no continuation yet).
 	settleChainJob(t, store, coordJob, "approved", "coordinator", nil, oneDelegation(), false)
 
-	// A scan PAST the 1h stage timeout trips the kill switch on the sub-tree root and
-	// keeps waiting (no fold — the finalize tail has not arrived).
-	past := start.Add(2 * time.Hour)
+	// Queue wait is excluded: only 45 minutes have elapsed from the first running
+	// event, so the timeout must not trip yet.
+	beforeRealTimeout := start.Add(75 * time.Minute)
+	run = advance(t, store, rec, spec, enqueue, run, beforeRealTimeout)
+	if killed, err := store.IsRootJobKilled(ctx, coordJob); err != nil || killed {
+		t.Fatalf("timeout measured from enqueue instead of real start: killed=%v err=%v", killed, err)
+	}
+
+	// A scan past one hour from the FIRST start trips the kill switch even though the
+	// reclaim was only 45 minutes ago. The timeout is reboot-stable.
+	past := realStart.Add(time.Hour + time.Second)
 	run = advance(t, store, rec, spec, enqueue, run, past)
 	if killed, err := store.IsRootJobKilled(ctx, coordJob); err != nil || !killed {
 		t.Fatalf("stage timeout must trip the #341 kill switch on the sub-tree root: killed=%v err=%v", killed, err)

--- a/internal/cli/pipeline_progress_test.go
+++ b/internal/cli/pipeline_progress_test.go
@@ -134,10 +134,13 @@ func TestPipelineRunProgressRenderingAndJSON(t *testing.T) {
 	}
 	var out bytes.Buffer
 	printPipelineRunFunnelAt(&out, view, now)
-	for _, want := range []string{"tokens: 123 (best-effort)", "work: RUNNING; enqueued 2m0s ago", "last activity 5s ago: testing", "gate: QUEUED; enqueued 1m0s ago", "last activity 2m0s ago: delegating", "(sub-tree running; no per-stage progress)"} {
+	for _, want := range []string{"tokens: 123 (best-effort)", "work: RUNNING; started 2m0s ago", "last activity 5s ago: testing", "gate: QUEUED; enqueued 1m0s ago", "last activity 2m0s ago: delegating", "(sub-tree running; no per-stage progress)"} {
 		if !strings.Contains(out.String(), want) {
 			t.Fatalf("output missing %q:\n%s", want, out.String())
 		}
+	}
+	if strings.Contains(out.String(), "gate: QUEUED; started") {
+		t.Fatalf("queued stage rendered as started:\n%s", out.String())
 	}
 	jsonView := pipelineRunToJSON(view)
 	if jsonView.Stages[0].StartedAt == "" || jsonView.Stages[0].Progress == nil || jsonView.Stages[0].Progress.Activity != "testing" {

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -1149,8 +1149,16 @@ func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enque
 		return run, err
 	}
 	byID := make(map[string]db.PipelineRunStage, len(rows))
+	jobIDs := make([]string, 0, len(rows))
 	for _, row := range rows {
 		byID[row.StageID] = row
+		if (row.State == pipeline.StageQueued || row.State == pipeline.StageRunning) && strings.TrimSpace(row.JobID) != "" {
+			jobIDs = append(jobIDs, row.JobID)
+		}
+	}
+	eventSnapshot, err := loadPipelineJobEventSnapshot(ctx, store, jobIDs)
+	if err != nil {
+		return run, err
 	}
 
 	// --- FOLD: settle stage jobs by decision ---------------------------------
@@ -1167,7 +1175,8 @@ func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enque
 		// reflect. That is deliberate — a future JOBLESS kind (gate) is reachable here
 		// without moving a guard out of a shared loop, and an unsettled kind can hand
 		// back a row mutation (nextRow) to persist while it keeps waiting.
-		deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now, autoMerge: autoMerge}
+		terminalJobState := ""
+		deps := pipelineStageSettleDeps{store: store, rec: rec, run: run, now: now, autoMerge: autoMerge, events: eventSnapshot, terminalJobState: &terminalJobState}
 		settled, state, summary, needs, nextRow, err := stageSettleOutcome(ctx, deps, spec, stage, row)
 		if err != nil {
 			return run, err
@@ -1192,12 +1201,21 @@ func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enque
 			row.JobID = ""
 			row.Summary = summary
 			row.NeedsJSON = ""
+			row.StartedAt = time.Time{}
 			row.FinishedAt = time.Time{}
 		} else {
+			preserveStartedAt := stage.Kind() == pipeline.StageKindOrchestrate && row.State == pipeline.StageRunning
 			row.State = state
 			row.Summary = summary
 			row.NeedsJSON = marshalPipelineNeeds(needs)
-			row.FinishedAt = now
+			if strings.TrimSpace(row.JobID) != "" {
+				row.StartedAt, row.FinishedAt, err = stampStageTimestampsFromJobEvents(ctx, eventSnapshot, row.JobID, terminalJobState, now, row.StartedAt, preserveStartedAt)
+				if err != nil {
+					return run, err
+				}
+			} else {
+				row.FinishedAt = now
+			}
 		}
 		if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
 			return run, err
@@ -1300,7 +1318,10 @@ func advancePipelineRunWithAutoMerge(ctx context.Context, store *db.Store, enque
 				row.JobID = job.ID
 				row.Summary = summary
 				row.NeedsJSON = marshalPipelineNeeds(needs)
-				row.FinishedAt = now
+				row.StartedAt, row.FinishedAt, err = stampStageTimestampsFromJobEvents(ctx, eventSnapshot, job.ID, job.State, now, row.StartedAt, false)
+				if err != nil {
+					return run, err
+				}
 			}
 			if err := persistPipelineStage(ctx, store, byID[stage.ID], row); err != nil {
 				return run, err
@@ -1423,12 +1444,139 @@ func applyPipelineRunSettlement(ctx context.Context, store *db.Store, rec db.Pip
 //     terminal tail. While the tail is still live it re-points the row's JobID at the
 //     current continuation and stays unsettled by returning that row as nextRow. ctx
 //     bounds those store reads.
+type pipelineJobEventSnapshot struct {
+	store          *db.Store
+	preloaded      map[string]bool
+	runningByJobID map[string]db.JobEvent
+	latest         map[pipelineJobEventKey]pipelineJobEventLookup
+}
+
+type pipelineJobEventKey struct {
+	jobID string
+	kind  string
+}
+
+type pipelineJobEventLookup struct {
+	event db.JobEvent
+	ok    bool
+}
+
+func loadPipelineJobEventSnapshot(ctx context.Context, store *db.Store, jobIDs []string) (*pipelineJobEventSnapshot, error) {
+	snapshot := &pipelineJobEventSnapshot{
+		store:     store,
+		preloaded: make(map[string]bool, len(jobIDs)),
+		latest:    make(map[pipelineJobEventKey]pipelineJobEventLookup),
+	}
+	for _, jobID := range jobIDs {
+		snapshot.preloaded[jobID] = true
+	}
+	running, err := store.GetEarliestJobEventsByKind(ctx, jobIDs, string(workflow.JobRunning))
+	if err != nil {
+		return nil, err
+	}
+	snapshot.runningByJobID = running
+	return snapshot, nil
+}
+
+func (s *pipelineJobEventSnapshot) getRunning(ctx context.Context, jobID string) (db.JobEvent, bool, error) {
+	if s.preloaded[jobID] {
+		if event, ok := s.runningByJobID[jobID]; ok {
+			return event, true, nil
+		}
+		// The worker can transition a job after the batch snapshot but before its
+		// row is folded in this pass. Recheck only the missing job.
+	}
+	event, ok, err := s.store.GetEarliestJobEventByKind(ctx, jobID, string(workflow.JobRunning))
+	if err == nil && ok {
+		s.runningByJobID[jobID] = event
+	}
+	return event, ok, err
+}
+
+func (s *pipelineJobEventSnapshot) getLatest(ctx context.Context, jobID, kind string) (db.JobEvent, bool, error) {
+	key := pipelineJobEventKey{jobID: jobID, kind: kind}
+	if lookup, ok := s.latest[key]; ok {
+		return lookup.event, lookup.ok, nil
+	}
+	event, ok, err := s.store.GetLatestJobEventByKind(ctx, jobID, kind)
+	if err == nil {
+		s.latest[key] = pipelineJobEventLookup{event: event, ok: ok}
+	}
+	return event, ok, err
+}
+
+// stampStageTimestampsFromJobEvents projects job lifecycle truth onto a terminal
+// job-minting stage. Running events come from the preloaded earliest-event batch;
+// the matching latest terminal event is fetched lazily only when a stage settles.
+func stampStageTimestampsFromJobEvents(ctx context.Context, events *pipelineJobEventSnapshot, jobID, terminalState string, tickNow, existingStartedAt time.Time, preserveStartedAt bool) (started, finished time.Time, err error) {
+	tickNow = tickNow.UTC()
+	terminalEvent, terminalFound, err := events.getLatest(ctx, jobID, terminalState)
+	if err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	finished = tickNow
+	if terminalFound {
+		if eventTime := pipelineEventTime(terminalEvent.CreatedAt); !eventTime.IsZero() {
+			finished = eventTime
+		}
+	}
+
+	started = existingStartedAt.UTC()
+	if !preserveStartedAt || started.IsZero() {
+		runningEvent, runningFound, eventErr := events.getRunning(ctx, jobID)
+		if eventErr != nil {
+			return time.Time{}, time.Time{}, eventErr
+		}
+		if eventTime := pipelineEventTime(runningEvent.CreatedAt); runningFound && !eventTime.IsZero() {
+			started = eventTime
+		} else if terminalFound {
+			// A queued job can fail before claim. It never started, so represent the
+			// terminal transition as a zero-duration stage rather than queue wait.
+			started = finished
+		} else if started.IsZero() {
+			started = tickNow
+		}
+	}
+	if started.After(finished) {
+		started = finished
+	}
+	return started, finished, nil
+}
+
+func recordPipelineTerminalJobState(deps pipelineStageSettleDeps, state string) {
+	if deps.terminalJobState != nil {
+		*deps.terminalJobState = state
+	}
+}
+
+func reflectPipelineStageRunning(ctx context.Context, deps pipelineStageSettleDeps, stageRow db.PipelineRunStage) (*db.PipelineRunStage, error) {
+	next := stageRow
+	next.State = pipeline.StageRunning
+	var event db.JobEvent
+	var ok bool
+	var err error
+	if deps.events != nil {
+		event, ok, err = deps.events.getRunning(ctx, stageRow.JobID)
+	} else {
+		event, ok, err = deps.store.GetEarliestJobEventByKind(ctx, stageRow.JobID, string(workflow.JobRunning))
+	}
+	if err != nil {
+		return nil, err
+	}
+	if started := pipelineEventTime(event.CreatedAt); ok && !started.IsZero() {
+		next.StartedAt = started
+	}
+	return &next, nil
+}
+
 type pipelineStageSettleDeps struct {
-	store     *db.Store
-	rec       db.Pipeline
-	run       db.PipelineRun
-	now       time.Time
-	autoMerge pipelineAutoMergeExecutor
+	store            *db.Store
+	rec              db.Pipeline
+	run              db.PipelineRun
+	now              time.Time
+	autoMerge        pipelineAutoMergeExecutor
+	events           *pipelineJobEventSnapshot
+	terminalJobState *string
 }
 
 // stageSettleOutcome is the per-stage-kind SETTLE PREDICATE seam. Given an in-flight
@@ -1504,12 +1652,12 @@ func decisionStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDep
 	}
 	if !workflow.IsSettledJobState(job.State) {
 		if job.State == string(workflow.JobRunning) && stageRow.State == pipeline.StageQueued {
-			next := stageRow
-			next.State = pipeline.StageRunning
-			return false, "", "", nil, &next, nil
+			next, eventErr := reflectPipelineStageRunning(ctx, deps, stageRow)
+			return false, "", "", nil, next, eventErr
 		}
 		return false, "", "", nil, nil, nil
 	}
+	recordPipelineTerminalJobState(deps, job.State)
 	state, summary, needs = foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
 	return true, state, summary, needs, nil, nil
 }
@@ -1581,7 +1729,10 @@ func orchestrateStageSettleOutcome(ctx context.Context, deps pipelineStageSettle
 		}
 	}
 
-	// Stage-timeout bound → sub-tree per-root wall-clock. On expiry trip the #341 kill
+	// Stage-timeout bound → sub-tree per-root wall-clock. StartedAt is the root
+	// job's first running-event time (not its enqueue or reclaim tick), so queue wait
+	// is excluded and host-reboot recovery cannot extend the bound.
+	// On expiry trip the #341 kill
 	// switch on the root ONCE; the killed frontier routes its next dispatch to the #305
 	// finalize continuation, so the walk below still terminates in a foldable tail. The
 	// kill is graceful (in-flight children finish); we do not fold here — we keep
@@ -1600,9 +1751,8 @@ func orchestrateStageSettleOutcome(ctx context.Context, deps pipelineStageSettle
 		// The current frontier job is still running: reflect a queued->running funnel
 		// transition so the stage tracks the live frontier, otherwise leave it in flight.
 		if job.State == string(workflow.JobRunning) && stageRow.State == pipeline.StageQueued {
-			next := stageRow
-			next.State = pipeline.StageRunning
-			return false, "", "", nil, &next, nil
+			next, eventErr := reflectPipelineStageRunning(ctx, deps, stageRow)
+			return false, "", "", nil, next, eventErr
 		}
 		return false, "", "", nil, nil, nil
 	}
@@ -1612,12 +1762,18 @@ func orchestrateStageSettleOutcome(ctx context.Context, deps pipelineStageSettle
 	// waiting. This is the walk's one hop per scan.
 	contID := workflow.DelegationContinuationID(job.ID)
 	if _, cerr := deps.store.GetJob(ctx, contID); cerr == nil {
-		next := stageRow
+		next := &stageRow
+		if stageRow.State == pipeline.StageQueued {
+			next, err = reflectPipelineStageRunning(ctx, deps, stageRow)
+			if err != nil {
+				return false, "", "", nil, nil, err
+			}
+		}
 		next.JobID = contID
 		// The continuation is the live frontier now; keep the stage RUNNING so a later
 		// scan re-enters this walk rather than treating the row as freshly queued.
 		next.State = pipeline.StageRunning
-		return false, "", "", nil, &next, nil
+		return false, "", "", nil, next, nil
 	} else if !errors.Is(cerr, sql.ErrNoRows) {
 		return false, "", "", nil, nil, cerr
 	}
@@ -1632,6 +1788,7 @@ func orchestrateStageSettleOutcome(ctx context.Context, deps pipelineStageSettle
 	if perr == nil && payload.Result != nil && len(payload.Result.Delegations) > 0 && !payload.DelegationFinalize {
 		return false, "", "", nil, nil, nil
 	}
+	recordPipelineTerminalJobState(deps, job.State)
 	state, summary, needs = foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
 	return true, state, summary, needs, nil, nil
 }
@@ -1670,12 +1827,12 @@ func implementStageSettleOutcome(ctx context.Context, deps pipelineStageSettleDe
 	}
 	if !workflow.IsSettledJobState(job.State) {
 		if job.State == string(workflow.JobRunning) && stageRow.State == pipeline.StageQueued {
-			next := stageRow
-			next.State = pipeline.StageRunning
-			return false, "", "", nil, &next, nil
+			next, eventErr := reflectPipelineStageRunning(ctx, deps, stageRow)
+			return false, "", "", nil, next, eventErr
 		}
 		return false, "", "", nil, nil, nil
 	}
+	recordPipelineTerminalJobState(deps, job.State)
 	state, summary, needs = foldPipelineStageOutcome(spec.EffectiveSuccessDecisions(stage), job)
 	payload, payloadErr := workflow.ParseJobPayload(job.Payload)
 	if state == pipeline.StageSucceeded {

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -3676,6 +3676,19 @@ func (s *Store) GetLatestJobEventByKind(ctx context.Context, jobID, kind string)
 	return event, err == nil, err
 }
 
+// GetEarliestJobEventByKind returns the oldest event of kind for jobID. The
+// idx_job_events_kind_job_id covering index serves the lookup.
+func (s *Store) GetEarliestJobEventByKind(ctx context.Context, jobID, kind string) (JobEvent, bool, error) {
+	var event JobEvent
+	err := s.db.QueryRowContext(ctx, `SELECT job_id, kind, message, created_at
+		FROM job_events WHERE kind = ? AND job_id = ? ORDER BY id ASC LIMIT 1`,
+		kind, jobID).Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return JobEvent{}, false, nil
+	}
+	return event, err == nil, err
+}
+
 // LatestAdvancementMarker returns the most recent post-delivery advancement
 // marker kind for jobID (or "" when the job has none). The kind set is exactly
 // the one jobNeedsAdvanceRetry (daemon.go) evaluates last-one-wins, so this is a
@@ -3739,6 +3752,42 @@ func (s *Store) GetLatestJobEventsByKind(ctx context.Context, jobIDs []string, k
 	query := `SELECT job_id, kind, message, created_at FROM job_events
 		WHERE kind = ? AND job_id IN (` + placeholders + `)
 		  AND id IN (SELECT MAX(id) FROM job_events
+			WHERE kind = ? AND job_id IN (` + placeholders + `) GROUP BY job_id)`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var event JobEvent
+		if err := rows.Scan(&event.JobID, &event.Kind, &event.Message, &event.CreatedAt); err != nil {
+			return nil, err
+		}
+		out[event.JobID] = event
+	}
+	return out, rows.Err()
+}
+
+// GetEarliestJobEventsByKind returns the oldest event of kind for each requested
+// job in one indexed query. Empty input returns an initialized empty map.
+func (s *Store) GetEarliestJobEventsByKind(ctx context.Context, jobIDs []string, kind string) (map[string]JobEvent, error) {
+	out := map[string]JobEvent{}
+	if len(jobIDs) == 0 {
+		return out, nil
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(jobIDs)), ",")
+	args := make([]any, 0, 2*(len(jobIDs)+1))
+	args = append(args, kind)
+	for _, jobID := range jobIDs {
+		args = append(args, jobID)
+	}
+	args = append(args, kind)
+	for _, jobID := range jobIDs {
+		args = append(args, jobID)
+	}
+	query := `SELECT job_id, kind, message, created_at FROM job_events
+		WHERE kind = ? AND job_id IN (` + placeholders + `)
+		  AND id IN (SELECT MIN(id) FROM job_events
 			WHERE kind = ? AND job_id IN (` + placeholders + `) GROUP BY job_id)`
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/internal/db/store_progress_test.go
+++ b/internal/db/store_progress_test.go
@@ -85,9 +85,12 @@ func TestGetLatestJobEventByKindAndBulk(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	if err := store.AddJobEvent(ctx, JobEvent{JobID: "job-a", Kind: "progress", Message: "a-latest"}); err != nil {
+		t.Fatal(err)
+	}
 
 	event, ok, err := store.GetLatestJobEventByKind(ctx, "job-a", "progress")
-	if err != nil || !ok || event.Message != "a" || event.CreatedAt == "" {
+	if err != nil || !ok || event.Message != "a-latest" || event.CreatedAt == "" {
 		t.Fatalf("by-kind event: ok=%v event=%+v err=%v", ok, event, err)
 	}
 	if _, ok, err := store.GetLatestJobEventByKind(ctx, "job-a", "missing"); err != nil || ok {
@@ -98,11 +101,30 @@ func TestGetLatestJobEventByKindAndBulk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(bulk) != 2 || bulk["job-a"].Message != "a" || bulk["job-b"].Message != "b" {
+	if len(bulk) != 2 || bulk["job-a"].Message != "a-latest" || bulk["job-b"].Message != "b" {
 		t.Fatalf("bulk = %+v", bulk)
 	}
 	empty, err := store.GetLatestJobEventsByKind(ctx, nil, "progress")
 	if err != nil || len(empty) != 0 {
 		t.Fatalf("empty bulk = %+v err=%v", empty, err)
+	}
+
+	earliest, ok, err := store.GetEarliestJobEventByKind(ctx, "job-a", "progress")
+	if err != nil || !ok || earliest.Message != "a" || earliest.CreatedAt == "" {
+		t.Fatalf("earliest by-kind event: ok=%v event=%+v err=%v", ok, earliest, err)
+	}
+	if _, ok, err := store.GetEarliestJobEventByKind(ctx, "job-a", "missing"); err != nil || ok {
+		t.Fatalf("missing earliest by-kind: ok=%v err=%v", ok, err)
+	}
+	earliestBulk, err := store.GetEarliestJobEventsByKind(ctx, []string{"job-a", "job-b"}, "progress")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(earliestBulk) != 2 || earliestBulk["job-a"].Message != "a" || earliestBulk["job-b"].Message != "b" {
+		t.Fatalf("earliest bulk = %+v", earliestBulk)
+	}
+	earliestEmpty, err := store.GetEarliestJobEventsByKind(ctx, nil, "progress")
+	if err != nil || len(earliestEmpty) != 0 {
+		t.Fatalf("empty earliest bulk = %+v err=%v", earliestEmpty, err)
 	}
 }


### PR DESCRIPTION
Half 2 of #1016 (the timing-truth half; half 1 — non-service shell isolation — follows as a second PR so its parallelism is measurable against these now-truthful timestamps).

## Problem
`pipeline_run_stages.started_at/finished_at` were stamped with the advancer **tick** time (`now`): `StartedAt` at the enqueue tick, `FinishedAt` at the fold tick. Two stages enqueued or folded in one ~1s tick got identical timestamps, so any overlap or duration read built on the stage rows lied — this is exactly the confounded `overlap=true` from the Build-Week appkit-pro round-4 e2e. `job_events` (`running`/terminal) are the truth.

## Change (job-minting stages only)
- **StartedAt** ← the **earliest** `running` job_event for the stage's current job; **FinishedAt** ← the terminal event. Earliest (not latest) running because a mid-run reboot/reclaim (`RequeueRunningJobsFromForeignBoot`, 30m stale-running recovery, retry-to-queued) emits a *second* `running` event — the first is the true start and is reboot-stable. (`GetEarliestJobEventByKind`, `ORDER BY id ASC`.)
- **Fold stamps unconditionally** — a stage that runs and finishes within one advancer tick never hits the queued→running reflect, so it must get real event times at fold, never the tick. Fallbacks: never-started ⇒ zero-duration (never negative); absent event ⇒ tick. `StartedAt` clamped ≤ `FinishedAt`.
- Queued→running reflect also stamps a truthful live `StartedAt`; **retry resets** `StartedAt` too; **orchestrate preserves the root start** across a `JobID`→continuation-tail advance (FinishedAt from the tail).
- **`pipeline show`** relabels per state — queued: `enqueued N ago`; running: `started N ago` — so a queued-but-unclaimed stage is never mislabeled as executing.
- Per-tick event snapshot preloads only `running`; the terminal kind is fetched lazily per settled job (no eager 4-terminal-kind queries on the hot advancer loop).

## Semantic change (called out for review)
The orchestrate/stage timeout (`now.Sub(StartedAt)`) now measures from **real running start** instead of the enqueue tick — queue wait is excluded from the sub-tree wall-clock budget. This is intentional and covered by an explicit test; using the *earliest* running event keeps it reboot-stable. Jobless **gate** stages are scoped out entirely and keep their enqueue-tick anchor, so gate timeout math is unchanged.

## Tests
New `pipeline_advance_test.go` + additions: fast-job (runs+finishes in one tick → real event times), two forked stages folded in the same tick carry distinct times (the round-4 regression guard), pre-claim failure (no running event → zero-duration, non-negative), retry reset, multi-running-event reboot/reclaim (StartedAt = earliest, duration not understated), orchestrate root/tail timing, real-start timeout assertion, jobless-gate unchanged, and the `pipeline show` queued-vs-running label.

Reviewed with tri-model panel (design) + `/code-review xhigh` before this PR; xhigh caught the earliest-vs-latest running-event bug and the queued relabel, both fixed here.

## Gate
`go build` / `go generate` (clean) / `go vet` / `go test ./internal/cli/ ./internal/db/ ./internal/workflow/` all green locally (minus `TestClaudeProduceHookAutoReadLandlockE2E`, the known Landlock-from-`/tmp` confound — fails identically on `origin/main` from a `/tmp` checkout). The scoped `-race` exceeds the local wall budget on this box; CI's sharded race lanes are authoritative.

## Deploy
**No deploy** — engine merge only; owner merges. (Live Devpost submission through Aug 5.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)