### PR TITLE
feat(pipeline): opt-in worktree isolation for non-service shell stages (#1016 half 1)

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -56,6 +56,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
+    isolate: true           # optional shell-only detached read-only worktree
     needs: [source]         # runs only after every listed stage SUCCEEDS
   - id: deploy
     cmd: "rclone copy out/ r2:bucket"
@@ -87,6 +88,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `allow_auto_merge`          | pipeline     | no       | Pipeline-level half of the auto-merge double key. Required with a gate's `merge: auto`; default `false`. It does not replace `allow_scheduled_writes` on scheduled pipelines. |
 | `stages[].id`               | stage        | yes      | Unique, name-safe stage id. Appears verbatim in the stage job's fingerprint and deterministic id. |
 | `stages[].cmd`              | stage        | cond.    | Shell command run verbatim via `sh -c` (see the stage contract below). A stage is **exactly one** of `cmd`, `agent`, or `gate`. |
+| `stages[].isolate`          | stage        | no       | Shell-only opt-in to a detached read-only committed-tip worktree, removing checkout-lock serialization so same-repo siblings with different commands can run concurrently. Default `false` preserves the shared checkout; rejected on non-shell stages. See [Shell-stage isolation](#shell-stage-isolation). |
 | `stages[].agent`            | stage        | cond.    | Name of a managed gitmoot agent to run this stage (instead of a shell `cmd`). Must be a name-safe token; `pipeline add` warns (does not block) if the agent does not exist yet, but it must exist before the stage runs. Mutually exclusive with `cmd`/`gate`. The stage kind depends on `action`/`write`/`orchestrate` — see [Agent stages](#agent-stages). |
 | `stages[].prompt`           | stage        | cond.    | Instruction handed to an agent stage's agent. **Required** for an agent stage; rejected for a shell/gate stage. Prepended with the upstream `needs` stages' result summaries at enqueue. |
 | `stages[].action`           | stage        | no       | `ask` (default), `review`, `implement`, or `produce`. Produce writes operator-owned data but never the repo or a PR. |
@@ -110,7 +112,8 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 non-name-safe name/id, a duplicate stage id, a stage that is not **exactly one** of
 `cmd`, `agent`, or `gate` (and, per kind: an agent stage's missing `prompt`, an
 invalid `action`, `implement` without `write: true` or `write: true` off an
-implement stage, a mutating stage on a scheduled pipeline without
+implement stage, `isolate: true` on a non-shell stage, a mutating stage on a
+scheduled pipeline without
 `allow_scheduled_writes`, a mutating stage on a triggered pipeline without
 `allow_triggered_writes`, a gate/review `source` that is not an upstream implement
 stage in `needs`, or `source` on another stage kind), an unknown/self/cyclic `needs`, an invalid
@@ -273,6 +276,34 @@ summary=$(jq -r '.stages.extract.summary' \
 Upstream summaries are **untrusted data flowing into your trusted script**. Parse
 them as data; never evaluate them as shell source, and do not put credentials in
 stage summaries.
+
+### Shell-stage isolation
+
+Non-service shell stages use the managed shared checkout by default, preserving
+access to uncommitted and gitignored files and commands that intentionally write
+there. Set `isolate: true` on a `cmd` stage to run it in a disposable detached
+read-only worktree at the checkout's committed tip. Isolated fork stages key on
+their own worktree paths, removing checkout-lock serialization so siblings with
+different commands can run concurrently. Agent stages already have their own
+isolation rules, so `isolate` is rejected on them.
+
+**Known v1 limitation (tracked follow-up):** two isolated forks with the identical `cmd`
+still share `runtime:shell:<hash(cmd)>` and serialize on that separate shell
+session lock. This field does not change runtime-session identity.
+
+This opt-in path is fail-open: if Gitmoot cannot allocate the worktree, it emits a
+`readonly_worktree_skipped` job event and runs the command in the shared checkout.
+On successful allocation, the shell environment includes the best-effort path
+`GITMOOT_CHECKOUT=<live managed checkout>` so the command can read gitignored
+`repos/**` or uncommitted data absent from the committed-tip worktree. Prefer the
+stage cwd for committed files. Treat `GITMOOT_CHECKOUT` as read-only: a concurrent
+default shell stage that mutates the live checkout can produce inconsistent reads
+(including a torn tree or `index.lock` contention), so do not run an isolated reader
+beside a checkout-mutating stage. The existing `GITMOOT_INPUT_*`,
+`GITMOOT_TRIGGER_*`, metadata, selected `env_keys`, and absolute upstream-context
+file remain available independent of the stage cwd.
+Service-triggered shell stages remain always isolated and fail closed; their policy
+does not depend on this field.
 
 ### Agent stages
 

--- a/internal/cli/pipeline_run.go
+++ b/internal/cli/pipeline_run.go
@@ -104,10 +104,16 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 		// most ReadOnlyWorktreeDispatchLockWaitBudget for the checkout mutation lock,
 		// and any failure leaves ask/review requests unchanged (serialized on the shared
 		// checkout) rather than stalling the pipeline scan loop. Produce is the explicit
-		// fail-closed exception below. Shell stages carry a RuntimeOverride and are
-		// excluded, so their request is byte-identical.
+		// fail-closed exception below. Shell stages carry a RuntimeOverride and stay
+		// excluded from this agent path; opted-in non-service shell stages use their
+		// own fail-open allocator so the three policies remain independent.
+		isolateShell := !serviceShell && pipelineShellStageReadOnlyWorktreeEligible(request)
 		if !serviceShell {
-			request, worktreePath, worktreeErr = allocatePipelineStageReadOnlyWorktree(ctx, store, home, request)
+			if isolateShell {
+				request, worktreePath, worktreeErr = allocatePipelineShellStageReadOnlyWorktree(ctx, store, home, request)
+			} else {
+				request, worktreePath, worktreeErr = allocatePipelineStageReadOnlyWorktree(ctx, store, home, request)
+			}
 		}
 		if strings.TrimSpace(request.Action) == "produce" && strings.TrimSpace(request.WorktreePath) == "" {
 			reason := "produce stage requires a disposable detached worktree; managed repo checkout is unavailable"
@@ -164,10 +170,16 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 			message := fmt.Sprintf("read-only worktree %s allocated for agent stage (#757/#739); job keyed worktree:<path> to run beside same-repo stages", worktreePath)
 			if serviceShell {
 				message = fmt.Sprintf("detached worktree %s allocated for service shell stage (#1011); registered checkout is never used", worktreePath)
+			} else if isolateShell {
+				message = fmt.Sprintf("read-only worktree %s allocated for opted-in shell stage (#1016); job keyed worktree:<path> to remove shared-checkout serialization (identical shell commands still share a runtime-session key)", worktreePath)
 			}
 			_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_worktree_allocated", Message: message})
 		} else if worktreeErr != nil {
-			_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_worktree_skipped", Message: fmt.Sprintf("read-only worktree isolation skipped for agent stage (#757/#739); job runs serialized in the shared checkout: %v", worktreeErr)})
+			message := fmt.Sprintf("read-only worktree isolation skipped for agent stage (#757/#739); job runs serialized in the shared checkout: %v", worktreeErr)
+			if isolateShell {
+				message = fmt.Sprintf("read-only worktree isolation skipped for opted-in shell stage (#1016); job runs serialized in the shared checkout: %v", worktreeErr)
+			}
+			_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_worktree_skipped", Message: message})
 		}
 		return job, nil
 	}
@@ -276,6 +288,44 @@ func pipelineStageReadOnlyWorktreeEligible(request workflow.JobRequest) bool {
 	return strings.TrimSpace(request.WorktreePath) == ""
 }
 
+// pipelineShellStageReadOnlyWorktreeEligible reports whether a non-service shell
+// stage explicitly opted into fail-open committed-tip isolation. Service shell
+// stages are detected before this seam and retain their fail-closed #1011 path.
+func pipelineShellStageReadOnlyWorktreeEligible(request workflow.JobRequest) bool {
+	return request.Sender == workflow.PipelineJobSender &&
+		request.IsolateShellStage &&
+		strings.TrimSpace(request.RuntimeOverride) == runtime.ShellRuntime &&
+		strings.TrimSpace(request.Repo) != "" &&
+		strings.TrimSpace(request.WorktreePath) == ""
+}
+
+// allocatePipelineShellStageReadOnlyWorktree gives an opted-in non-service shell
+// stage its own detached committed-tip worktree. Allocation is FAIL-OPEN: callers
+// enqueue the unchanged request on any error and emit readonly_worktree_skipped.
+// Unlike agent isolation, shell commands receive the live managed checkout through
+// GITMOOT_CHECKOUT and do not get prose appended to their fixed instructions.
+func allocatePipelineShellStageReadOnlyWorktree(ctx context.Context, store *db.Store, home string, request workflow.JobRequest) (workflow.JobRequest, string, error) {
+	checkout := pipelineStageCheckoutPath(ctx, store, request.Repo)
+	if checkout == "" {
+		return request, "", nil // repo not managed/checked out yet — serialize as before
+	}
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return request, "", err
+	}
+	path, err := workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, request.Repo, checkout, request.ID, "pipeline-stage", 0, "", workflow.ReadOnlyWorktreeDispatchLockWaitBudget, gitutil.Client{Dir: checkout})
+	if err != nil {
+		return request, "", err
+	}
+	if strings.TrimSpace(path) == "" {
+		return request, "", errors.New("read-only worktree allocator returned an empty path")
+	}
+	request.WorktreePath = path
+	request.ReadOnlyWorktree = true
+	request.ShellEnv = append(request.ShellEnv, "GITMOOT_CHECKOUT="+checkout)
+	return request, path, nil
+}
+
 // allocatePipelineStageReadOnlyWorktree allocates a detached committed-tip worktree
 // for an eligible repo-bound agent stage and returns the request with WorktreePath +
 // the ReadOnlyWorktree disposal marker set (so the existing terminal cleanup and
@@ -321,8 +371,8 @@ func allocatePipelineStageReadOnlyWorktree(ctx context.Context, store *db.Store,
 }
 
 // pipelineStageCheckoutPath resolves a repo's on-disk checkout path, or "" when the
-// repo is unknown or not checked out. Used to allocate/roll back the agent-stage
-// read-only worktree.
+// repo is unknown or not checked out. Used to allocate/roll back pipeline-stage
+// read-only worktrees.
 func pipelineStageCheckoutPath(ctx context.Context, store *db.Store, repo string) string {
 	if strings.TrimSpace(repo) == "" {
 		return ""
@@ -672,6 +722,7 @@ func pipelineStageJobRequest(rec db.Pipeline, stage pipeline.Stage, run db.Pipel
 		JobTimeout:         stage.Timeout,
 		RuntimeOverride:    runtime.ShellRuntime,
 		RuntimeOverrideRef: stage.Cmd,
+		IsolateShellStage:  stage.Isolate && strings.TrimSpace(run.Trigger) != "service",
 		ShellEnv: append(triggerEnv,
 			"GITMOOT_PIPELINE_NAME="+rec.Name,
 			"GITMOOT_PIPELINE_RUN_ID="+run.ID,

--- a/internal/cli/pipeline_shell_isolation_test.go
+++ b/internal/cli/pipeline_shell_isolation_test.go
@@ -1,0 +1,319 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/pipeline"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestPipelineShellIsolationRequestMarker(t *testing.T) {
+	rec := db.Pipeline{Name: "shell-isolation", Repo: "owner/repo"}
+	stage := pipeline.Stage{ID: "run", Cmd: "printf ok", Isolate: true}
+
+	manual := pipelineStageJobRequest(rec, stage, db.PipelineRun{ID: "manual-run", Trigger: "manual"}, 0, "", pipelineStagePRBinding{}, false)
+	if !manual.IsolateShellStage {
+		t.Fatal("manual isolate:true shell stage did not carry its enqueue-only isolation marker")
+	}
+	if got := envEntryValue(manual.ShellEnv, "GITMOOT_CHECKOUT"); got != "" {
+		t.Fatalf("GITMOOT_CHECKOUT was injected before worktree allocation: %q", got)
+	}
+
+	legacy := pipelineStageJobRequest(rec, pipeline.Stage{ID: "run", Cmd: "printf ok"}, db.PipelineRun{ID: "legacy-run", Trigger: "manual"}, 0, "", pipelineStagePRBinding{}, false)
+	if legacy.IsolateShellStage || legacy.ReadOnlyWorktree || legacy.WorktreePath != "" {
+		t.Fatalf("default shell request changed from shared-checkout shape: %+v", legacy)
+	}
+
+	service := pipelineStageJobRequest(rec, stage, db.PipelineRun{ID: "service-run", Trigger: "service"}, 0, "", pipelineStagePRBinding{}, false)
+	if service.IsolateShellStage {
+		t.Fatal("service shell stage entered the non-service fail-open isolation path")
+	}
+}
+
+func TestPipelineShellIsolationUnmanagedRepoFallsBackSilently(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	request := pipelineStageJobRequest(
+		db.Pipeline{Name: "shell-unmanaged", Repo: "owner/unmanaged"},
+		pipeline.Stage{ID: "run", Cmd: "printf ok", Isolate: true},
+		db.PipelineRun{ID: "unmanaged-run", Trigger: "manual"},
+		0, "", pipelineStagePRBinding{}, false,
+	)
+	job, err := newPipelineStageEnqueuer(store, home)(ctx, request)
+	if err != nil {
+		t.Fatalf("enqueue unmanaged isolate:true shell stage: %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.WorktreePath != "" || payload.ReadOnlyWorktree || queuedJobCheckoutKey(ctx, store, job) != "repo:owner/unmanaged" {
+		t.Fatalf("unmanaged shell stage did not retain serialized shared-repo shape: %+v", payload)
+	}
+	if countCLIJobEvents(t, store, job.ID, "readonly_worktree_skipped") != 0 {
+		t.Fatal("unmanaged checkout emitted readonly_worktree_skipped, want silent fallback")
+	}
+	if countCLIJobEvents(t, store, job.ID, "readonly_worktree_allocated") != 0 {
+		t.Fatal("unmanaged checkout emitted readonly_worktree_allocated without a worktree")
+	}
+}
+
+func TestPipelineForkedShellIsolationEventWindowsE2E(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		isolate bool
+	}{
+		{name: "opted-in stages overlap", isolate: true},
+		{name: "default stages serialize", isolate: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			t.Setenv("HERDR_SOCKET_PATH", filepath.Join(t.TempDir(), "throwaway.sock"))
+			t.Setenv("HERDR_ENV", "")
+			home, _, store := heartbeatLoopE2EHome(t)
+			checkout := createDaemonWorkerGitCheckout(t, "main")
+			seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+			envFile := writePipelineEnvFile(t, t.TempDir(), "ISOLATION_TOKEN=delivered\n", 0o600)
+
+			pipelineName := "shell-fork-legacy"
+			isolateLine := ""
+			checkoutCheck := `[ -z "${GITMOOT_CHECKOUT+x}" ] || exit 72`
+			if tc.isolate {
+				pipelineName = "shell-fork-isolated"
+				isolateLine = "    isolate: true\n"
+				checkoutCheck = `[ "$GITMOOT_CHECKOUT" = ` + posixQuote(checkout) + ` ] || exit 72`
+			}
+			childCmd := func(stageID string) string {
+				return strings.Join([]string{
+					checkoutCheck,
+					`[ "$ISOLATION_TOKEN" = delivered ] || exit 73`,
+					`[ -r "$GITMOOT_PIPELINE_UPSTREAM_CONTEXT_FILE" ] || exit 74`,
+					"sleep 2",
+					pipelineShellResultCommand(t, "approved", "fork stage "+stageID+" complete"),
+				}, "; ")
+			}
+			specYAML := fmt.Sprintf("name: %s\nrepo: owner/repo\nenv_file: %q\nstages:\n  - id: root\n    cmd: |\n      %s\n  - id: b\n    cmd: |\n      %s\n%s    env_keys: [ISOLATION_TOKEN]\n    needs: [root]\n  - id: c\n    cmd: |\n      %s\n%s    env_keys: [ISOLATION_TOKEN]\n    needs: [root]\n", pipelineName, envFile, pipelineShellResultCommand(t, "approved", "root complete"), childCmd("b"), isolateLine, childCmd("c"), isolateLine)
+			runID := addAndStartPipeline(t, home, pipelineName, specYAML)
+
+			enqueue := newPipelineStageEnqueuer(store, home)
+			tickWorker := defaultJobWorker(store, io.Discard, home)
+			now := time.Now().UTC()
+			var b, c db.PipelineRunStage
+			for i := 0; i < 8; i++ {
+				if err := runEnabledRepoWorkerTicks(ctx, store, tickWorker, 1, io.Discard, now); err != nil {
+					t.Fatalf("worker tick %d: %v", i, err)
+				}
+				if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+					t.Fatalf("pipeline scan %d: %v", i, err)
+				}
+				b = stageRow(t, store, runID, "b")
+				c = stageRow(t, store, runID, "c")
+				if b.State == pipeline.StageQueued && c.State == pipeline.StageQueued {
+					break
+				}
+			}
+			if b.State != pipeline.StageQueued || c.State != pipeline.StageQueued {
+				t.Fatalf("fork stages were not both queued: b=%s c=%s", b.State, c.State)
+			}
+
+			jobs := make([]db.Job, 0, 2)
+			keys := make([]string, 0, 2)
+			for _, row := range []db.PipelineRunStage{b, c} {
+				job, err := store.GetJob(ctx, row.JobID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				payload, err := workflow.ParseJobPayload(job.Payload)
+				if err != nil {
+					t.Fatal(err)
+				}
+				key := queuedJobCheckoutKey(ctx, store, job)
+				if tc.isolate {
+					if payload.WorktreePath == "" || !payload.ReadOnlyWorktree || !strings.HasPrefix(key, "worktree:") {
+						t.Fatalf("isolated shell payload/key = %+v / %q", payload, key)
+					}
+					if got := envEntryValue(payload.ShellEnv, "GITMOOT_CHECKOUT"); got != checkout {
+						t.Fatalf("GITMOOT_CHECKOUT = %q, want %q", got, checkout)
+					}
+					if strings.Contains(payload.Instructions, checkout) {
+						t.Fatalf("shell instructions contain agent-only checkout prose: %q", payload.Instructions)
+					}
+					if n := countCLIJobEvents(t, store, row.JobID, "readonly_worktree_allocated"); n != 1 {
+						t.Fatalf("readonly_worktree_allocated events = %d, want 1", n)
+					}
+				} else {
+					if payload.WorktreePath != "" || payload.ReadOnlyWorktree || key != "repo:owner/repo" {
+						t.Fatalf("default shell payload/key changed: %+v / %q", payload, key)
+					}
+					if got := envEntryValue(payload.ShellEnv, "GITMOOT_CHECKOUT"); got != "" {
+						t.Fatalf("default shell received GITMOOT_CHECKOUT=%q", got)
+					}
+				}
+				jobs = append(jobs, job)
+				keys = append(keys, key)
+			}
+			if tc.isolate && keys[0] == keys[1] {
+				t.Fatalf("isolated fork stages share checkout key %q", keys[0])
+			}
+
+			if err := runQueuedJobsForRepo(ctx, tickWorker, 2, "", ""); err != nil {
+				t.Fatalf("two-worker dispatch: %v", err)
+			}
+			for _, job := range jobs {
+				settled, _ := terminalJobDecision(t, ctx, store, job.ID)
+				if settled.State != string(workflow.JobSucceeded) {
+					t.Fatalf("job %s state = %s, want succeeded", job.ID, settled.State)
+				}
+			}
+			bStart, bFinish := pipelineShellJobEventWindow(t, store, b.JobID)
+			cStart, cFinish := pipelineShellJobEventWindow(t, store, c.JobID)
+			overlapped := bStart.Before(cFinish) && cStart.Before(bFinish)
+			if overlapped != tc.isolate {
+				t.Fatalf("job-event windows overlap = %v, want %v (b=%s..%s c=%s..%s)", overlapped, tc.isolate, bStart, bFinish, cStart, cFinish)
+			}
+
+			if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+				t.Fatal(err)
+			}
+			run, ok, err := store.GetPipelineRun(ctx, runID)
+			if err != nil || !ok || run.State != pipeline.RunSucceeded {
+				t.Fatalf("run did not succeed: run=%+v ok=%v err=%v", run, ok, err)
+			}
+		})
+	}
+}
+
+func TestPipelineShellIsolationAllocationFailureFallsOpenE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	const pipelineName = "shell-isolation-fail-open"
+	specYAML := "name: " + pipelineName + "\nrepo: owner/repo\nstages:\n  - id: root\n    cmd: |\n      " + pipelineShellResultCommand(t, "approved", "root complete") + "\n  - id: run\n    cmd: |\n      " + pipelineShellResultCommand(t, "approved", "shared fallback ran") + "\n    isolate: true\n    needs: [root]\n"
+	runID := addAndStartPipeline(t, home, pipelineName, specYAML)
+	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Now().UTC()
+	if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+		t.Fatal(err)
+	}
+	brokenHome := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(brokenHome, []byte("force worktree parent creation failure\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	enqueue := newPipelineStageEnqueuer(store, brokenHome)
+	if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+		t.Fatalf("fail-open enqueue: %v", err)
+	}
+	row := stageRow(t, store, runID, "run")
+	job, err := store.GetJob(ctx, row.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.WorktreePath != "" || payload.ReadOnlyWorktree || queuedJobCheckoutKey(ctx, store, job) != "repo:owner/repo" {
+		t.Fatalf("allocation failure did not keep shared-checkout request: %+v", payload)
+	}
+	if got := envEntryValue(payload.ShellEnv, "GITMOOT_CHECKOUT"); got != "" {
+		t.Fatalf("failed allocation injected GITMOOT_CHECKOUT=%q", got)
+	}
+	if countCLIJobEvents(t, store, row.JobID, "readonly_worktree_skipped") != 1 {
+		t.Fatal("allocation failure did not emit readonly_worktree_skipped")
+	}
+	if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := runPipelineScanOnce(ctx, store, newPipelineStageEnqueuer(store, home), now); err != nil {
+		t.Fatal(err)
+	}
+	run, ok, err := store.GetPipelineRun(ctx, runID)
+	if err != nil || !ok || run.State != pipeline.RunSucceeded {
+		t.Fatalf("fail-open run did not succeed: run=%+v ok=%v err=%v", run, ok, err)
+	}
+}
+
+func TestPipelineShellDefaultStillMutatesSharedCheckoutE2E(t *testing.T) {
+	ctx := context.Background()
+	home, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	const pipelineName = "shell-shared-mutation"
+	cmd := "printf legacy-write > shared-output.txt; " + pipelineShellResultCommand(t, "approved", "wrote shared checkout")
+	runID := addAndStartPipeline(t, home, pipelineName, "name: "+pipelineName+"\nrepo: owner/repo\nstages:\n  - id: run\n    cmd: |\n      "+cmd+"\n")
+	enqueue := newPipelineStageEnqueuer(store, home)
+	worker := defaultJobWorker(store, io.Discard, home)
+	now := time.Now().UTC()
+	for i := 0; i < 4; i++ {
+		if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {
+			t.Fatal(err)
+		}
+		if err := runEnabledRepoWorkerTicks(ctx, store, worker, 1, io.Discard, now); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := os.ReadFile(filepath.Join(checkout, "shared-output.txt"))
+	if err != nil || string(got) != "legacy-write" {
+		t.Fatalf("default shell stage did not write shared checkout: content=%q err=%v", got, err)
+	}
+	row := stageRow(t, store, runID, "run")
+	job, err := store.GetJob(ctx, row.JobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.WorktreePath != "" || payload.ReadOnlyWorktree || countCLIJobEvents(t, store, row.JobID, "readonly_worktree_allocated") != 0 {
+		t.Fatalf("default shell stage unexpectedly isolated: %+v", payload)
+	}
+}
+
+func addAndStartPipeline(t *testing.T, home, name, specYAML string) string {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	if code := Run([]string{"pipeline", "add", writeSpec(t, specYAML), "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline add exit=%d stderr=%s", code, errBuf.String())
+	}
+	out.Reset()
+	errBuf.Reset()
+	if code := Run([]string{"pipeline", "run", name, "--home", home}, &out, &errBuf); code != 0 {
+		t.Fatalf("pipeline run exit=%d stderr=%s", code, errBuf.String())
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func pipelineShellJobEventWindow(t *testing.T, store *db.Store, jobID string) (time.Time, time.Time) {
+	t.Helper()
+	events, err := store.ListJobEvents(context.Background(), jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var started, finished time.Time
+	for _, event := range events {
+		switch event.Kind {
+		case string(workflow.JobRunning):
+			if started.IsZero() {
+				started = pipelineEventTime(event.CreatedAt)
+			}
+		case string(workflow.JobSucceeded):
+			finished = pipelineEventTime(event.CreatedAt)
+		}
+	}
+	if started.IsZero() || finished.IsZero() {
+		t.Fatalf("job %s has incomplete event window: %s..%s events=%+v", jobID, started, finished, events)
+	}
+	return started, finished
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -18,6 +18,7 @@ stages:
     cmd: git fetch --all
   - id: score
     cmd: ./score.sh
+    isolate: true
     needs: [source]
     timeout: 10m
     retry: 2
@@ -41,7 +42,7 @@ func TestLoadValidSpec(t *testing.T) {
 	if len(spec.Stages) != 3 {
 		t.Fatalf("stages = %d, want 3", len(spec.Stages))
 	}
-	if spec.Stages[1].ID != "score" || spec.Stages[1].Retry != 2 || spec.Stages[1].Timeout != "10m" {
+	if spec.Stages[1].ID != "score" || !spec.Stages[1].Isolate || spec.Stages[1].Retry != 2 || spec.Stages[1].Timeout != "10m" {
 		t.Fatalf("unexpected score stage: %+v", spec.Stages[1])
 	}
 	if !reflect.DeepEqual(spec.Stages[1].Needs, []string{"source"}) {
@@ -465,6 +466,11 @@ func TestLoadValidationErrors(t *testing.T) {
 			name:    "write without implement rejected",
 			spec:    "name: p\nstages:\n  - {id: a, cmd: echo, write: true}\n",
 			wantSub: "write: true is only valid with action: implement",
+		},
+		{
+			name:    "isolate on agent rejected",
+			spec:    "name: p\nstages:\n  - {id: a, agent: rev, prompt: hi, isolate: true}\n",
+			wantSub: "isolate: true but is not a shell stage",
 		},
 		{
 			name:    "scheduled implement without allow rejected",

--- a/internal/pipeline/spec.go
+++ b/internal/pipeline/spec.go
@@ -145,6 +145,11 @@ type Stage struct {
 	// Cmd is the shell command run verbatim via `sh -c`. Exactly one of Cmd or
 	// Agent must be set per stage (#757); a cmd stage's behavior is unchanged.
 	Cmd string `yaml:"cmd,omitempty"`
+	// Isolate opts a shell stage into a detached read-only committed-tip worktree
+	// so same-repo shell siblings with different commands may run concurrently.
+	// Agent stages are already isolated where appropriate; this field is valid
+	// only with Cmd.
+	Isolate bool `yaml:"isolate,omitempty"`
 	// Agent, when set, runs the named managed gitmoot agent for this stage instead
 	// of a shell command (#757). The agent runs as a LEAF: it may only ask/review
 	// (read-only) and its delegations are stripped. Mutually exclusive with Cmd.

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -155,6 +155,9 @@ func (s Spec) Validate() error {
 		if err := validateStageExecutor(s.Name, stage); err != nil {
 			return err
 		}
+		if stage.Isolate && stage.Kind() != StageKindShell {
+			return fmt.Errorf("pipeline %q stage %q sets isolate: true but is not a shell stage", s.Name, stage.ID)
+		}
 		if len(stage.EnvKeys) > 0 && stage.Kind() == StageKindGate {
 			return fmt.Errorf("pipeline %q stage %q sets env_keys but is a gate stage; gates do not run a process and cannot receive keys", s.Name, stage.ID)
 		}

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -172,7 +172,11 @@ type JobRequest struct {
 	// Branch). It is the explicit signal the terminal cleanup uses to dispose a
 	// TOP-LEVEL read-only worktree that has no DelegationID. Additive/omitempty:
 	// false leaves the enqueued payload byte-identical.
-	ReadOnlyWorktree       bool
+	ReadOnlyWorktree bool
+	// IsolateShellStage is an enqueue-only marker for a non-service pipeline shell
+	// stage that opted into a detached read-only worktree. It is consumed before
+	// payload persistence; false preserves the legacy shared-checkout request.
+	IsolateShellStage      bool
 	OriginalAgent          string
 	DelegatedAgent         string
 	DelegationReason       string

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2722,6 +2722,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
+    isolate: true          # optional shell-only detached read-only worktree
     needs: [source]         # runs only after every listed stage SUCCEEDS
   - id: triage              # an AGENT stage instead of a shell cmd (exactly one of cmd|agent|gate)
     agent: reply-triager    #   #757 read-only leaf
@@ -2966,7 +2967,8 @@ a stage that is not exactly one of `cmd`/`agent`/`gate`, an agent stage
 missing a `prompt` / invalid `action` / `implement` without `write: true` / a mutating
 stage on a scheduled pipeline without `allow_scheduled_writes` / a mutating stage on
 a triggered pipeline without `allow_triggered_writes` / a gate or review's
-bad `source` / `source` on another stage kind, invalid durations, a `success_decisions` outside
+bad `source` / `source` on another stage kind / `isolate: true` on a non-shell
+stage, invalid durations, a `success_decisions` outside
 `approved`/`implemented`/`changes_requested`/`skipped`) so a mistake is a clear error, not a
 stuck run. It stores the raw YAML **verbatim** plus a content hash; each run
 snapshots that hash and executes its snapshot, so editing the file later never
@@ -2977,6 +2979,18 @@ runs a named managed agent on its own runtime as a read-only leaf (`ask`/`review
 its `needs` stages' result summaries are prepended to the prompt, and a repo-bound
 agent stage runs in its own detached read-only worktree so same-repo agent stages
 parallelize without touching the live checkout.
+
+A shell stage may set `isolate: true` to opt into a disposable detached read-only
+worktree at the managed checkout's committed tip. The default remains the shared
+checkout, including its uncommitted/gitignored data and any intentional writes.
+Opt-in allocation is fail-open: failure emits `readonly_worktree_skipped` and runs
+on the shared checkout. On success the command receives
+`GITMOOT_CHECKOUT=<live-checkout>` for cwd-independent access to data omitted from
+the clean worktree. This removes checkout-lock serialization, so same-repo stages
+with different commands can run concurrently. **Known v1 limitation (tracked follow-up):**
+identical commands still share `runtime:shell:<hash(cmd)>` and serialize on the
+separate shell session lock. Service shell stages retain their unconditional,
+fail-closed isolation; agent and gate stages reject this shell-only field.
 
 Shell and agent stages can opt into scoped key access with `env_keys`. Source
 files must be absolute, operator-owned regular files
@@ -3032,6 +3046,13 @@ signals partial data. The content is persisted and re-created at a fresh path fo
 retries; the file is removed after delivery. Treat summaries as untrusted data,
 never shell source, and keep credentials out of them. A strict consumer can start
 with `jq -e '.schema_version == 1 and .complete == true' "$GITMOOT_PIPELINE_UPSTREAM_CONTEXT_FILE"`.
+A successfully isolated non-service shell stage additionally receives
+`GITMOOT_CHECKOUT`, a best-effort path to the live managed checkout for reading
+gitignored `repos/**` or uncommitted data. Prefer the stage cwd for committed files.
+Treat this path as read-only, and do not run the isolated reader beside a default
+stage that mutates the checkout: those live reads can observe a torn tree or
+`index.lock` contention. The input, trigger, metadata, keycard, and upstream-context
+variables are unchanged by the detached cwd.
 
 `action: produce` (#814/#825) is a sandboxed pipeline leaf for writing operator-owned
 data, never repo/branch/task/PR state. Codex uses its native sandbox; Claude and

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1092,6 +1092,7 @@ stages:
     env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
+    isolate: true          # optional shell-only detached read-only worktree
     needs: [source]         # runs only after source SUCCEEDS
   - id: deploy
     cmd: "rclone copy out/ r2:bucket"
@@ -1375,6 +1376,16 @@ downstream agent stage acts on upstream output as real dataflow. A repo-bound
 ask/review agent stage runs in its own detached read-only worktree (#739), so
 same-repo agent stages parallelize and never touch the live checkout.
 
+A `cmd` stage can opt into the same concurrency boundary with `isolate: true`.
+Its disposable worktree is the committed tip, while the default `false` continues
+to run in the shared checkout for commands that need dirty/gitignored data or write
+there. Allocation is fail-open (`readonly_worktree_skipped` records fallback), and
+successful isolation adds `GITMOOT_CHECKOUT=<live-checkout>` to the shell env. This
+removes checkout-lock serialization for siblings with different commands. **Known
+v1 limitation (tracked follow-up):** identical commands retain the same shell runtime-session
+key and serialize. Service shell stages remain unconditionally isolated and fail
+closed. The field is rejected on agent and gate stages.
+
 A dependent `cmd` stage receives the same settled upstream results through a data
 channel, not shell interpolation. All pipeline shell stages get
 `GITMOOT_PIPELINE_NAME`, `GITMOOT_PIPELINE_RUN_ID`, and
@@ -1383,6 +1394,12 @@ channel, not shell interpolation. All pipeline shell stages get
 `0600` JSON tempfile for the duration of the delivery. Gitmoot persists the JSON
 content (not the path), recreates identical bytes on retry/restart, and removes the
 file after every exit path. Root stages have no context-file variable.
+An isolated non-service shell stage additionally receives `GITMOOT_CHECKOUT`, a
+best-effort path to the live checkout for gitignored or uncommitted reads. Prefer
+the stage cwd for committed files, treat the live path as read-only, and never run
+that reader beside a default stage mutating the checkout because reads can be torn
+or contend on `index.lock`. `GITMOOT_INPUT_*`, `GITMOOT_TRIGGER_*`, selected keys,
+and the absolute upstream context path remain cwd-independent.
 
 The v1 shape is
 `{"schema_version":1,"complete":true,"stages":{"extract":{"id":"extract","state":"succeeded","summary":"...","summary_truncated":false}}}`.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1957,6 +1957,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
+    isolate: true          # optional shell-only detached read-only worktree
     needs: [source]         # runs only after source SUCCEEDS
   - id: triage              # #757: an AGENT stage (exactly one of cmd|agent)
     agent: reply-triager    #   an existing managed agent, run as a read-only leaf
@@ -2040,6 +2041,14 @@ coordinator that fans out owned children and folds the synthesis); and **gate** 
 implement stage's PR merges). A read-only stage's `needs` result summaries are prepended
 to its prompt, and a repo-bound read-only agent stage runs in its own detached
 read-only worktree so same-repo stages parallelize without touching the live checkout.
+A non-service shell stage can opt in with `isolate: true`; it then runs in a
+disposable detached read-only committed-tip worktree. Default `false` preserves the
+shared checkout. Allocation failure records `readonly_worktree_skipped` and falls
+back to that checkout; success adds `GITMOOT_CHECKOUT=<live-checkout>` to the shell
+environment. This removes checkout-lock serialization for stages with different
+commands. **Known v1 limitation (tracked follow-up):** identical commands retain the same
+shell runtime-session key and serialize. The field is rejected on agent/gate stages,
+while service shell stages retain unconditional fail-closed isolation.
 For shell-stage API credentials, set an absolute pipeline `env_file` and list
 exact names or globs in each stage's `env_keys`. The file must be a regular,
 operator-owned `0600` file outside Gitmoot state and managed checkouts; inline

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -49,6 +49,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
     env_keys: [SOURCE_API_TOKEN]
   - id: score
     cmd: "python score.py data.json"
+    isolate: true          # optional shell-only detached read-only worktree
     needs: [source]         # runs only after source SUCCEEDS
   - id: deploy
     cmd: "rclone copy out/ r2:bucket"
@@ -420,6 +421,25 @@ summary=$(jq -r '.stages.extract.summary' \
 
 Summaries are untrusted data flowing into your trusted script. Parse them as data,
 never evaluate them as shell source, and do not put credentials in summaries.
+
+### Shell-stage isolation
+
+Set `isolate: true` on a non-service `cmd` stage to opt into a disposable detached
+read-only worktree at the managed checkout's committed tip. This gives forked
+same-repo shell stages distinct checkout keys so a multi-worker daemon can run
+stages with different commands concurrently. **Known v1 limitation (tracked follow-up):**
+identical commands still share a shell runtime-session key and serialize. The
+default remains the shared checkout, preserving uncommitted and gitignored inputs
+and intentional checkout writes; `isolate` is rejected on agent and gate stages.
+
+Allocation is fail-open: Gitmoot records `readonly_worktree_skipped` and uses the
+shared checkout if it cannot create the worktree. Successful isolation adds the
+best-effort live path `GITMOOT_CHECKOUT=<managed checkout>` for data omitted from
+the clean worktree. Prefer cwd for committed files, treat the live path as read-only,
+and do not overlap the isolated reader with a default checkout-mutating stage because
+reads may be inconsistent. Existing input, trigger, metadata, selected-key, and
+absolute upstream-context variables remain available.
+Service shell stages keep their unconditional fail-closed isolation.
 
 A triggered pipeline containing an `implement` or `produce` stage must set
 `allow_triggered_writes: true`, in addition to each stage's `write: true`. This is


### PR DESCRIPTION
Half 1 of #1016 (parallel fork/join for shell stages). Independent of the timing-truth half (#1032) — either merges in any order; this PR's parallelism proof reads `job_events` directly.

## Problem
`pipelineServiceShellStage` isolates a pipeline shell stage only when `trigger == "service"` (#1011). Manual (`gitmoot pipeline run`) and chained (`trigger: pipeline`) shell stages run on the **shared repo checkout**, so two forked shell branches serialize on the `repo:<repo>` resource lock — observed on the Build-Week appkit-pro fork/join: `capture` succeeded then `content` dispatched 1s later, strictly serial, on a 32-worker daemon. Agent (ask/review/produce) stages are already born-isolated on any trigger (#757).

## Change — opt-in, zero-regression
- New shell-only **`isolate: true`** stage field (`spec.go`), rejected on agent stages at validate (`validate.go`).
- The enqueuer keeps **three cleanly separated paths**: service-shell **fail-closed** (#1011, unchanged), agent read-only **fail-open** (unchanged), and the new non-service-shell **opt-in read-only fail-open**. An allocation failure or unmanaged checkout leaves the request on the shared checkout (serialize as before, no stall — the #739 lesson). A **default (non-isolate) shell request is byte-identical to before** — existing pipelines are untouched.
- **`GITMOOT_CHECKOUT`** env exposes the canonical checkout to an isolated shell cmd (whose cwd is now the committed-tip worktree) so it can still read gitignored `repos/**` and uncommitted files; the agent-only #654 prose note is skipped for shell.

Opt-in (not default-on) deliberately: a read-only committed-tip worktree would silently drop writes a legacy shell stage makes to the shared checkout, so isolation is only taken when the author asks for it.

## Verification
- Shell-runtime E2E (no LLM, isolated `/tmp` home): a `a -> {b, c}` fork with `isolate: true` runs **concurrently** (b and c `job_events` running windows overlap on a ≥2-worker daemon); a non-isolate fork serializes. Plus: worktree allocated + `worktree:<path>` key, fail-open on allocation failure (shared checkout, run still succeeds), unmanaged-repo serializes **silently**, non-isolate & service-shell requests unchanged, `GITMOOT_CHECKOUT` present and `GITMOOT_INPUT_*`/upstream-context still delivered after the cwd change.
- Full gate: `go build` / `go generate` (clean) / `go vet` / `go test ./internal/cli/ ./internal/pipeline/` green (minus `TestClaudeProduceHookAutoReadLandlockE2E`, the known Landlock-from-`/tmp` confound — fails identically on `origin/main`). Local full `-race` exceeds this box's wall budget; CI's sharded race lanes are authoritative.

Reviewed with a tri-model design panel + `/code-review high` before this PR.

## Known limitations (documented)
- Two isolated forks running the **identical** command still serialize on the shell runtime-session key (a separate lock from the checkout lock this PR fixes) — follow-up **#1034**.
- `GITMOOT_CHECKOUT` is a best-effort read of the **live** checkout; don't run an isolated reader concurrently with a checkout-mutating stage.

## Deploy
**No deploy** — engine merge only; owner merges. (Live Devpost submission through Aug 5.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)