### PR TITLE
fix(pipeline): job-scope the shell runtime-session key for isolated stages (#1034)

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -111,7 +111,7 @@ stages:                     # the DAG, keyed by unique id and wired by needs
 | `allow_auto_merge`          | pipeline     | no       | Pipeline-level half of the auto-merge double key. Required with a gate's `merge: auto`; default `false`. It does not replace `allow_scheduled_writes` on scheduled pipelines. |
 | `stages[].id`               | stage        | yes      | Unique, name-safe stage id. Appears verbatim in the stage job's fingerprint and deterministic id. |
 | `stages[].cmd`              | stage        | cond.    | Shell command run verbatim via `sh -c` (see the stage contract below). A stage is **exactly one** of `cmd`, `agent`, or `gate`. |
-| `stages[].isolate`          | stage        | no       | Shell-only opt-in to a detached read-only committed-tip worktree, removing checkout-lock serialization so same-repo siblings with different commands can run concurrently. Default `false` preserves the shared checkout; rejected on non-shell stages. See [Shell-stage isolation](#shell-stage-isolation). |
+| `stages[].isolate`          | stage        | no       | Shell-only opt-in to a detached read-only committed-tip worktree, removing checkout-lock serialization so same-repo siblings can run concurrently — including siblings that share the identical `cmd`, which also take a job-scoped shell runtime-session key (#1034). Default `false` preserves the shared checkout; rejected on non-shell stages. See [Shell-stage isolation](#shell-stage-isolation). |
 | `stages[].agent`            | stage        | cond.    | Name of a managed gitmoot agent to run this stage (instead of a shell `cmd`). Must be a name-safe token; `pipeline add` warns (does not block) if the agent does not exist yet, but it must exist before the stage runs. Mutually exclusive with `cmd`/`gate`. The stage kind depends on `action`/`write`/`orchestrate` — see [Agent stages](#agent-stages). |
 | `stages[].prompt`           | stage        | cond.    | Instruction handed to an agent stage's agent. **Required** for an agent stage; rejected for a shell/gate stage. Prepended with the upstream `needs` stages' result summaries at enqueue. |
 | `stages[].action`           | stage        | no       | `ask` (default), `review`, `implement`, or `produce`. Produce writes operator-owned data but never the repo or a PR. |
@@ -306,13 +306,11 @@ Non-service shell stages use the managed shared checkout by default, preserving
 access to uncommitted and gitignored files and commands that intentionally write
 there. Set `isolate: true` on a `cmd` stage to run it in a disposable detached
 read-only worktree at the checkout's committed tip. Isolated fork stages key on
-their own worktree paths, removing checkout-lock serialization so siblings with
-different commands can run concurrently. Agent stages already have their own
+their own worktree paths, removing checkout-lock serialization, and each also
+takes a **job-scoped** shell runtime-session key (`runtime:shell:job:<hash(job)>`)
+instead of the command-hash key, so same-repo siblings run concurrently even when
+they share the **identical** `cmd` (#1034). Agent stages already have their own
 isolation rules, so `isolate` is rejected on them.
-
-**Known v1 limitation (tracked follow-up):** two isolated forks with the identical `cmd`
-still share `runtime:shell:<hash(cmd)>` and serialize on that separate shell
-session lock. This field does not change runtime-session identity.
 
 This opt-in path is fail-open: if Gitmoot cannot allocate the worktree, it emits a
 `readonly_worktree_skipped` job event and runs the command in the shared checkout.

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -5020,6 +5020,12 @@ func queuedJobRuntimeResourceKey(ctx context.Context, store *db.Store, job db.Jo
 	// it under that key (fully payload-derived — no GetAgent needed) rather than
 	// the agent's default-runtime session it will never take.
 	if payload, err := daemonJobPayload(job); err == nil && strings.TrimSpace(payload.RuntimeOverride) != "" {
+		// An isolated shell stage keys by job id so identical-command isolated
+		// forks don't serialize (#1034). The worker's lock acquisition uses the
+		// SAME helper, so the gate and the lock can never disagree.
+		if key, ok := isolatedShellStageRuntimeSessionKey(payload, job.ID); ok {
+			return key
+		}
 		key, ok := overrideRuntimeSessionResourceKey(applyJobRuntimeOverride(runtime.Agent{}, payload))
 		if !ok {
 			return ""
@@ -5222,7 +5228,22 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// SESSION SAFETY (#531): the lock is taken on the EFFECTIVE agent, so an
 	// overridden job locks the OVERRIDE runtime's session key and can never
 	// collide with (or occupy) the agent's default-runtime session lock.
-	releaseLock, acquired, lockKey, ownerToken, err := acquireJobRuntimeSessionLock(ctx, w.Store, job.ID, agent, overridden, time.Now().UTC(), lockTTL)
+	var (
+		releaseLock func(context.Context) error
+		acquired    bool
+		lockKey     string
+		ownerToken  string
+	)
+	if key, ok := isolatedShellStageRuntimeSessionKey(payload, job.ID); ok {
+		// #1034: an isolated shell stage acquires the SAME job-scoped shell key the
+		// selector (queuedJobRuntimeResourceKey) gates on, so identical-command
+		// isolated forks neither serialize at the gate nor collide at acquisition.
+		// acquireRuntimeSessionLockWithKey is the shared low-level acquirer that
+		// acquireJobRuntimeSessionLock itself delegates to.
+		releaseLock, acquired, lockKey, ownerToken, err = acquireRuntimeSessionLockWithKey(ctx, w.Store, job.ID, key, true, time.Now().UTC(), lockTTL)
+	} else {
+		releaseLock, acquired, lockKey, ownerToken, err = acquireJobRuntimeSessionLock(ctx, w.Store, job.ID, agent, overridden, time.Now().UTC(), lockTTL)
+	}
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
 			return finishErr

--- a/internal/cli/pipeline_enqueue.go
+++ b/internal/cli/pipeline_enqueue.go
@@ -152,7 +152,7 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 			if serviceShell {
 				message = fmt.Sprintf("detached worktree %s allocated for service shell stage (#1011); registered checkout is never used", worktreePath)
 			} else if isolateShell {
-				message = fmt.Sprintf("read-only worktree %s allocated for opted-in shell stage (#1016); job keyed worktree:<path> to remove shared-checkout serialization (identical shell commands still share a runtime-session key)", worktreePath)
+				message = fmt.Sprintf("read-only worktree %s allocated for opted-in shell stage (#1016); job keyed worktree:<path> and a job-scoped shell runtime-session key so it runs concurrently with same-repo siblings, including identical-command forks (#1034)", worktreePath)
 			}
 			_ = store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "readonly_worktree_allocated", Message: message})
 		} else if worktreeErr != nil {

--- a/internal/cli/runtime_override.go
+++ b/internal/cli/runtime_override.go
@@ -110,6 +110,47 @@ func overrideRuntimeSessionResourceKey(agent runtime.Agent) (string, bool) {
 	return "runtime:" + runtimeName + ":" + shortHash(runtimeRef), true
 }
 
+// isolatedShellStageRuntimeSessionKey returns a JOB-SCOPED runtime-session lock
+// key for a shell-override stage that runs in its OWN detached worktree, or
+// ok=false for any other job (leaving the normal key derivation in force).
+//
+// A pipeline shell stage runs as a runtime override, so it takes the bounded
+// override key runtime:shell:<hash(cmd)> (overrideRuntimeSessionResourceKey).
+// That key exists (#531) ONLY so the lock provably names the OVERRIDE runtime
+// and can never collide with the agent's default-runtime session lock —
+// serializing identical commands is an incidental side effect of hashing the
+// command, not a guarantee the key was created to provide. For an ISOLATED stage
+// that side effect is spurious: each such stage runs in its own detached
+// read-only worktree (#1016) and shares no checkout or session state, yet two
+// isolated forks of the identical command still hash to the same key and
+// serialize (#1034). Keying by job id removes that false dependency while
+// preserving the #531 invariant — the key keeps the runtime:shell: prefix (still
+// names the override runtime, still cannot collide with a resumable runtime's
+// runtime:<rt>:<ref> key) but is unique per job, so distinct isolated forks never
+// wait on one another. Non-isolated shell stages (shared checkout, no
+// WorktreePath) keep the command-hash key and stay serialized — their shared
+// checkout genuinely needs it (and the checkout lock covers it besides) — and
+// resumable runtimes are untouched.
+//
+// The signal is read from the PERSISTED payload: ReadOnlyWorktree + WorktreePath
+// are set synchronously at enqueue, before the job is visible to the daemon
+// selector, so this resolves identically at scheduling time
+// (queuedJobRuntimeResourceKey) and at lock acquisition — the two MUST agree or
+// the gate and the lock diverge.
+func isolatedShellStageRuntimeSessionKey(payload workflow.JobPayload, jobID string) (string, bool) {
+	if strings.TrimSpace(payload.RuntimeOverride) != runtime.ShellRuntime {
+		return "", false
+	}
+	if !payload.ReadOnlyWorktree || strings.TrimSpace(payload.WorktreePath) == "" {
+		return "", false
+	}
+	id := strings.TrimSpace(jobID)
+	if id == "" {
+		return "", false
+	}
+	return "runtime:" + runtime.ShellRuntime + ":job:" + shortHash(id), true
+}
+
 // jobRuntimeOverrideEventMessage renders the runtime_override job event that
 // exposes the effective runtime (and the session lock it ran under) in job
 // history.

--- a/internal/cli/runtime_override_isolate_test.go
+++ b/internal/cli/runtime_override_isolate_test.go
@@ -1,0 +1,131 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// isolatedShellPayload is a persisted shell-override stage payload that ran in
+// its own detached read-only worktree (the #1016 shape the #1034 fix keys off).
+func isolatedShellPayload(cmd, worktree string) workflow.JobPayload {
+	return workflow.JobPayload{
+		Repo:               "owner/repo",
+		RuntimeOverride:    runtime.ShellRuntime,
+		RuntimeOverrideRef: cmd,
+		ReadOnlyWorktree:   true,
+		WorktreePath:       worktree,
+	}
+}
+
+func TestIsolatedShellStageRuntimeSessionKey(t *testing.T) {
+	const cmd = `printf '%s' '{"gitmoot_result":{}}'`
+
+	// An isolated shell stage keys by JOB, not by command: the key is
+	// runtime:shell:job:<hash(job)> and never embeds the command.
+	key, ok := isolatedShellStageRuntimeSessionKey(isolatedShellPayload(cmd, "/wt/a"), "job-a")
+	if !ok || !strings.HasPrefix(key, "runtime:shell:job:") {
+		t.Fatalf("isolated shell key = %q ok=%v, want runtime:shell:job:<hash>", key, ok)
+	}
+	if strings.Contains(key, "gitmoot_result") {
+		t.Fatalf("isolated shell key must not embed the command, got %q", key)
+	}
+
+	// THE FIX: two isolated forks of the IDENTICAL command get DISTINCT keys, so
+	// they never serialize on one another (#1034).
+	keyA, okA := isolatedShellStageRuntimeSessionKey(isolatedShellPayload(cmd, "/wt/a"), "job-a")
+	keyB, okB := isolatedShellStageRuntimeSessionKey(isolatedShellPayload(cmd, "/wt/b"), "job-b")
+	if !okA || !okB {
+		t.Fatalf("both isolated forks must key: okA=%v okB=%v", okA, okB)
+	}
+	if keyA == keyB {
+		t.Fatalf("identical-command isolated forks must get distinct keys, both = %q", keyA)
+	}
+
+	// THE GUARANTEE IT MUST NOT BREAK: a NON-isolated shell stage (shared
+	// checkout — no worktree) keeps the command-hash key, so two identical
+	// commands still share a key and stay serialized.
+	nonIso := workflow.JobPayload{Repo: "owner/repo", RuntimeOverride: runtime.ShellRuntime, RuntimeOverrideRef: cmd}
+	if _, ok := isolatedShellStageRuntimeSessionKey(nonIso, "job-a"); ok {
+		t.Fatal("a non-isolated shell stage must not get a job-scoped key")
+	}
+	sharedA, _ := overrideRuntimeSessionResourceKey(applyJobRuntimeOverride(runtime.Agent{}, nonIso))
+	sharedB, _ := overrideRuntimeSessionResourceKey(applyJobRuntimeOverride(runtime.Agent{}, nonIso))
+	if sharedA != sharedB || !strings.HasPrefix(sharedA, "runtime:shell:") || strings.HasPrefix(sharedA, "runtime:shell:job:") {
+		t.Fatalf("non-isolated identical commands must share the command-hash key, got %q / %q", sharedA, sharedB)
+	}
+
+	// A resumable-runtime override with a worktree must NOT be job-scoped here:
+	// only shell overrides get the treatment (codex keeps its session identity).
+	codexIso := workflow.JobPayload{Repo: "owner/repo", RuntimeOverride: runtime.CodexRuntime, RuntimeOverrideRef: "abc", ReadOnlyWorktree: true, WorktreePath: "/wt/c"}
+	if _, ok := isolatedShellStageRuntimeSessionKey(codexIso, "job-c"); ok {
+		t.Fatal("a resumable-runtime override must not be treated as an isolated shell stage")
+	}
+
+	// COLLISION INVARIANT (#531): the job-scoped shell key still names the shell
+	// runtime, so it can never collide with a resumable runtime's key or with the
+	// command-hash key for the same command.
+	if key == sharedA {
+		t.Fatalf("isolated key %q must differ from the command-hash key %q", key, sharedA)
+	}
+	if !strings.HasPrefix(key, "runtime:shell:") {
+		t.Fatalf("isolated key must stay shell-namespaced, got %q", key)
+	}
+
+	// Edge: worktree opted-in but path not allocated (fail-open fallback) → no
+	// job-scoped key, so the normal derivation stays in force.
+	if _, ok := isolatedShellStageRuntimeSessionKey(isolatedShellPayload(cmd, ""), "job-a"); ok {
+		t.Fatal("an isolated shell stage with no worktree path must not get a job-scoped key")
+	}
+	// Edge: empty job id cannot be scoped.
+	if _, ok := isolatedShellStageRuntimeSessionKey(isolatedShellPayload(cmd, "/wt/a"), ""); ok {
+		t.Fatal("an empty job id must not get a job-scoped key")
+	}
+}
+
+// TestQueuedJobRuntimeResourceKeyIsolatedShellStage proves the daemon SELECTOR
+// gates on exactly the key the worker ACQUIRES: both resolve through
+// isolatedShellStageRuntimeSessionKey, so the gate and the lock can never
+// disagree (a mismatch would let two forks pass the gate and then collide at
+// acquisition — the bug this fix must not introduce).
+func TestQueuedJobRuntimeResourceKeyIsolatedShellStage(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	const cmd = `echo hi`
+
+	newJob := func(id, worktree string) db.Job {
+		encoded, err := json.Marshal(isolatedShellPayload(cmd, worktree))
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		return db.Job{ID: id, Agent: "runner", Payload: string(encoded)}
+	}
+
+	jobA := newJob("pipe-run-stageX-0", "/wt/a")
+	jobB := newJob("pipe-run-stageX-1", "/wt/b")
+
+	gateA := queuedJobRuntimeResourceKey(ctx, store, jobA)
+	gateB := queuedJobRuntimeResourceKey(ctx, store, jobB)
+
+	// The selector returns the job-scoped key...
+	if !strings.HasPrefix(gateA, "runtime:shell:job:") {
+		t.Fatalf("selector key = %q, want runtime:shell:job:<hash>", gateA)
+	}
+	// ...distinct per job (identical command, different jobs), so the daemon
+	// dispatches them concurrently instead of bouncing the second on the first.
+	if gateA == gateB {
+		t.Fatalf("identical-command isolated forks must gate on distinct keys, both = %q", gateA)
+	}
+
+	// gate == lock: the selector key equals the key the worker acquisition path
+	// derives from the same payload + job id.
+	lockA, ok := isolatedShellStageRuntimeSessionKey(isolatedShellPayload(cmd, "/wt/a"), jobA.ID)
+	if !ok || gateA != lockA {
+		t.Fatalf("selector key %q must equal the acquisition key %q (ok=%v)", gateA, lockA, ok)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -3007,10 +3007,10 @@ checkout, including its uncommitted/gitignored data and any intentional writes.
 Opt-in allocation is fail-open: failure emits `readonly_worktree_skipped` and runs
 on the shared checkout. On success the command receives
 `GITMOOT_CHECKOUT=<live-checkout>` for cwd-independent access to data omitted from
-the clean worktree. This removes checkout-lock serialization, so same-repo stages
-with different commands can run concurrently. **Known v1 limitation (tracked follow-up):**
-identical commands still share `runtime:shell:<hash(cmd)>` and serialize on the
-separate shell session lock. Service shell stages retain their unconditional,
+the clean worktree. This removes checkout-lock serialization, and each isolated stage
+also takes a job-scoped shell runtime-session key (`runtime:shell:job:<hash(job)>`)
+instead of the command-hash key, so same-repo stages run concurrently even when they
+share the identical command (#1034). Service shell stages retain their unconditional,
 fail-closed isolation; agent and gate stages reject this shell-only field.
 
 Shell and agent stages can opt into scoped key access with `env_keys`. Source

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1381,10 +1381,11 @@ Its disposable worktree is the committed tip, while the default `false` continue
 to run in the shared checkout for commands that need dirty/gitignored data or write
 there. Allocation is fail-open (`readonly_worktree_skipped` records fallback), and
 successful isolation adds `GITMOOT_CHECKOUT=<live-checkout>` to the shell env. This
-removes checkout-lock serialization for siblings with different commands. **Known
-v1 limitation (tracked follow-up):** identical commands retain the same shell runtime-session
-key and serialize. Service shell stages remain unconditionally isolated and fail
-closed. The field is rejected on agent and gate stages.
+removes checkout-lock serialization for siblings, and each isolated stage also
+takes a job-scoped shell runtime-session key (`runtime:shell:job:<hash(job)>`)
+instead of the command-hash key, so siblings run concurrently even when they share
+the **identical** command (#1034). Service shell stages remain unconditionally
+isolated and fail closed. The field is rejected on agent and gate stages.
 
 A dependent `cmd` stage receives the same settled upstream results through a data
 channel, not shell interpolation. All pipeline shell stages get

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2066,9 +2066,10 @@ A non-service shell stage can opt in with `isolate: true`; it then runs in a
 disposable detached read-only committed-tip worktree. Default `false` preserves the
 shared checkout. Allocation failure records `readonly_worktree_skipped` and falls
 back to that checkout; success adds `GITMOOT_CHECKOUT=<live-checkout>` to the shell
-environment. This removes checkout-lock serialization for stages with different
-commands. **Known v1 limitation (tracked follow-up):** identical commands retain the same
-shell runtime-session key and serialize. The field is rejected on agent/gate stages,
+environment. This removes checkout-lock serialization, and each isolated stage also
+takes a job-scoped shell runtime-session key (`runtime:shell:job:<hash(job)>`) rather
+than the command-hash key, so same-repo stages run concurrently even when they share
+the identical command (#1034). The field is rejected on agent/gate stages,
 while service shell stages retain unconditional fail-closed isolation.
 For shell-stage API credentials, set an absolute pipeline `env_file` and list
 exact names or globs in each stage's `env_keys`. The file must be a regular,

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -426,11 +426,12 @@ never evaluate them as shell source, and do not put credentials in summaries.
 
 Set `isolate: true` on a non-service `cmd` stage to opt into a disposable detached
 read-only worktree at the managed checkout's committed tip. This gives forked
-same-repo shell stages distinct checkout keys so a multi-worker daemon can run
-stages with different commands concurrently. **Known v1 limitation (tracked follow-up):**
-identical commands still share a shell runtime-session key and serialize. The
-default remains the shared checkout, preserving uncommitted and gitignored inputs
-and intentional checkout writes; `isolate` is rejected on agent and gate stages.
+same-repo shell stages distinct checkout keys, and each also takes a job-scoped
+shell runtime-session key (`runtime:shell:job:<hash(job)>`) rather than the
+command-hash key, so a multi-worker daemon runs them concurrently even when they
+share the **identical** command (#1034). The default remains the shared checkout,
+preserving uncommitted and gitignored inputs and intentional checkout writes;
+`isolate` is rejected on agent and gate stages.
 
 Allocation is fail-open: Gitmoot records `readonly_worktree_skipped` and uses the
 shared checkout if it cannot create the worktree. Successful isolation adds the


### PR DESCRIPTION
## What & why

Two isolated shell stages (`isolate: true`, #1016) running the **identical** command still serialized on the shell runtime-session key `runtime:shell:<hash(cmd)>`, defeating the parallelism isolation exists to provide — any DAG whose sibling branches run the same script fell back to serial. This is the #1016 pre-PR `/code-review` follow-up (#1034).

### Root cause (the key was never meant to serialize commands)

`runtimeSessionResourceKey` returns **no key for shell** (non-resumable) — shell stages normally take no session lock. The command-hash key appears **only for runtime-override jobs** (how pipeline shell stages run), and its documented purpose (#531) is *collision-avoidance*: the lock must provably name the **override** runtime so it can never collide with the agent's default-runtime (codex/claude) session lock. Serializing identical commands is an **incidental side effect of hashing the command**, not a guarantee the key was created to provide — and it is spurious for an isolated stage, which runs in its own detached read-only worktree and shares no checkout or session state.

## The fix

`isolatedShellStageRuntimeSessionKey(payload, jobID)` returns a **job-scoped** key `runtime:shell:job:<hash(job)>` for a shell-override job whose persisted payload has `ReadOnlyWorktree && WorktreePath != ""`. The **same helper** drives both the daemon selector (`queuedJobRuntimeResourceKey`) and the worker's lock acquisition (`jobWorker.run` → `acquireRuntimeSessionLockWithKey`), so **the gate and the lock can never disagree**.

Invariants preserved:
- **#531 collision-avoidance**: the key keeps the `runtime:shell:` prefix, so it still names the override runtime and can never collide with a resumable runtime's `runtime:<rt>:<ref>` key.
- **Non-isolated shell stages** (shared checkout, no `WorktreePath`) keep the command-hash key and stay serialized — their shared checkout genuinely needs it (and the checkout lock covers it besides).
- **Resumable runtimes** untouched (the helper gates on `RuntimeOverride == shell`).

### Scope note (deliberate)

The own-worktree signal (`ReadOnlyWorktree + WorktreePath`) also matches **service** shell stages (#1011 PaaS), which are likewise born-isolated — so this de-serializes identical-command service stages too. That is correct and desirable (per-request worktree concurrency is the point of the per-stage worktree) and was chartered explicitly into the review. Narrowing to non-service-only would require an extra condition and is not recommended.

## Verification

**Unit tests** (`internal/cli/runtime_override_isolate_test.go`): distinct-key-per-job, identical-command de-serialization, non-isolated serialization **preserved**, codex-override **not** job-scoped, collision invariant, and the **gate == lock** consistency (selector key equals the acquisition key).

**Live daemon A/B E2E** (shell runtime, isolated `/tmp` homes, 2 workers, pool scheduler) — same pipeline of two `isolate: true` stages with an identical `sleep 4` command, both allocated their own worktree (`readonly_worktree_allocated`, no skip):

| binary | stage a | stage b | outcome |
|---|---|---|---|
| **OLD** `dev-38459c7` (pre-fix) | running 22:26:00 → done 22:26:05 | running **22:26:05** → done 22:26:09 | **serialized** (b waits for a) |
| **NEW** `dev-feff0c8` (this PR) | running 22:22:44 → done 22:22:48 | running **22:22:44** → done 22:22:48 | **concurrent** |

Both had distinct worktrees on the OLD binary too, so the A/B isolates the *runtime-session key* as the serializer — exactly what the fix removes.

**`/code-review` (xhigh, fresh-context):** 0 correctness findings on the lock seam. The only design candidate (fold the derivation into one function) was verified **REFUTED** — both live gate/lock sites already share the helper and cannot diverge. It surfaced three stale operator-facing strings still asserting the old limitation (the `readonly_worktree_allocated` event message + `reference/cli.md` + skill `CLI.md`), now fixed in the second commit alongside the `pipelines.md` / `WORKFLOWS.md` / `pipelines-workflow.md` updates.

## Docs

Dropped the "Known v1 limitation" note in every place it appeared (in-repo `docs/pipelines.md`, skill `WORKFLOWS.md` + `CLI.md`, site `pipelines-workflow.md` + `reference/cli.md`) and the in-code job-event message. `llms-full.txt` does not carry it (no regen needed).

## Deploy notes

**No deploy.** Live box is frozen for the Devpost submission through Aug 5. This is `internal/cli` (daemon selector + worker lock acquisition) plus docs — no schema/migration change, single-binary invariant intact. CI race matrix already covers `internal/cli`.

Closes #1034.
