### PR TITLE
feat(pipeline): pipeline watch + run --payload CLI parity (#1043, #1018)

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -709,7 +709,8 @@ gitmoot pipeline show <name> [--json]        # registry view for a pipeline name
 gitmoot pipeline show <run-id> [--json]      # run funnel for a "prun-…" run id
 gitmoot pipeline bind-trigger <name>         # create/re-sync the owned AP flow
 
-gitmoot pipeline run <name>                  # start a manual run; prints the run id
+gitmoot pipeline run <name> [--payload key=value ...] [--payload-json '<obj>']
+gitmoot pipeline watch <run-id> [--timeout 10m] [--poll 5s] [--json]
 gitmoot pipeline resume <run-id> [--from <stage>]
 gitmoot pipeline cancel <run-id>
 
@@ -752,9 +753,17 @@ the available `agent_runtime`, `prompt_preview`, and `cmd_preview` fields withou
 removing the full `prompt` or `cmd`.
 
 `pipeline run` prints just the run id (script-stable), so `RUN=$(gitmoot pipeline
-run nightly-sync)` works. A manual run ignores the `enabled` flag — a disabled
+run nightly-sync)` works. Repeat `--payload key=value` to inject manual trigger
+data, or pass one `--payload-json` object of string values; the two forms are
+mutually exclusive and use the bridge's existing key/count/size limits. A manual run ignores the `enabled` flag — a disabled
 pipeline can still be run by hand — but still requires a `repo` and refuses to
 start while the pipeline already has an active run (one active run per pipeline).
+
+`pipeline watch <run-id>` blocks until the run succeeds, fails, blocks, or is
+cancelled. It prints each stage state change once and exits `0` only for success;
+terminal non-success states exit `1`. A still-active run at `--timeout` exits `2`
+with `still running`, so automation can re-invoke the same command. `--json`
+suppresses transition lines and emits the final `pipeline show --json` shape.
 
 `pipeline show <run-id>` renders the run as a **text funnel**:
 
@@ -885,6 +894,7 @@ of `gitmoot agent list`**; `pipeline remove` disposes them.
 - `gitmoot pipeline show <name>` shows the registry view (spec hash, schedule,
   last/next run bookkeeping, and the stage DAG).
 - `gitmoot pipeline show <run-id>` shows the run funnel.
+- `gitmoot pipeline watch <run-id>` waits for terminal state without an agent-side poll loop.
 - Stage jobs are ordinary jobs (sender `pipeline`), so they also appear in the usual
   job/status surfaces.
 

--- a/internal/cli/bridge.go
+++ b/internal/cli/bridge.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -34,13 +33,10 @@ import (
 )
 
 const (
-	defaultBridgeAddr                 = "127.0.0.1:8791"
-	bridgeTokenName                   = "bridge.token"
-	bridgeBodyLimit                   = 1 << 20
-	bridgePipelineRunBodyLimit        = 64 << 10
-	bridgePipelinePayloadMaxEntries   = 32
-	bridgePipelinePayloadValueLimit   = 32 << 10
-	bridgePipelinePayloadDecodedLimit = 48 << 10
+	defaultBridgeAddr          = "127.0.0.1:8791"
+	bridgeTokenName            = "bridge.token"
+	bridgeBodyLimit            = 1 << 20
+	bridgePipelineRunBodyLimit = 64 << 10
 )
 
 var errBridgeConflict = errors.New("bridge conflict")
@@ -491,36 +487,7 @@ func decodeBridgePipelineRunPayload(r *http.Request) (string, error) {
 			return "", fmt.Errorf("payload must be a JSON object with string values: %w", err)
 		}
 	}
-	if len(payload) > bridgePipelinePayloadMaxEntries {
-		return "", fmt.Errorf("payload has %d entries; maximum is %d", len(payload), bridgePipelinePayloadMaxEntries)
-	}
-	keys := make([]string, 0, len(payload))
-	for key := range payload {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	total := 0
-	for _, key := range keys {
-		value := payload[key]
-		if !pipeline.ValidTriggerPayloadKey(key) {
-			return "", fmt.Errorf("payload key %q must be 1-64 bytes and match ^[a-z][a-z0-9_]*$", key)
-		}
-		if len(value) > bridgePipelinePayloadValueLimit {
-			return "", fmt.Errorf("payload value for key %q exceeds the 32 KiB limit", key)
-		}
-		if strings.ContainsRune(value, '\x00') {
-			return "", fmt.Errorf("payload value for key %q must not contain U+0000", key)
-		}
-		total += len(key) + len(value)
-		if total > bridgePipelinePayloadDecodedLimit {
-			return "", fmt.Errorf("payload decoded key/value total exceeds the 48 KiB limit (at key %q)", key)
-		}
-	}
-	canonical, err := json.Marshal(payload)
-	if err != nil {
-		return "", fmt.Errorf("marshal validated payload: %w", err)
-	}
-	return string(canonical), nil
+	return pipeline.ValidateAndEncodeTriggerPayload(payload)
 }
 
 func (s *bridgeServer) handleRunGet(w http.ResponseWriter, r *http.Request, id string) {

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/workflow"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -51,6 +52,8 @@ func runPipeline(args []string, stdout, stderr io.Writer) int {
 		return runPipelineList(args[1:], stdout, stderr)
 	case "run":
 		return runPipelineRunCmd(args[1:], stdout, stderr)
+	case "watch":
+		return runPipelineWatchCmd(args[1:], stdout, stderr)
 	case "show":
 		return runPipelineShow(args[1:], stdout, stderr)
 	case "bind-trigger":
@@ -86,7 +89,8 @@ func printPipelineUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot pipeline remote show")
 	fmt.Fprintln(w, "  gitmoot pipeline install-defaults")
 	fmt.Fprintln(w, "  gitmoot pipeline list [--json]")
-	fmt.Fprintln(w, "  gitmoot pipeline run <name>")
+	fmt.Fprintln(w, "  gitmoot pipeline run <name> [--payload key=value ...] [--payload-json '<obj>']")
+	fmt.Fprintln(w, "  gitmoot pipeline watch <run-id> [--timeout 10m] [--poll 5s] [--json]")
 	fmt.Fprintln(w, "  gitmoot pipeline show <name|run-id> [--json]")
 	fmt.Fprintln(w, "  gitmoot pipeline bind-trigger <name>")
 	fmt.Fprintln(w, "  gitmoot pipeline resume <run-id> [--from <stage>]")
@@ -1064,6 +1068,10 @@ func runPipelineRunCmd(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("pipeline run", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	var payloadFlags repeatedStringFlag
+	fs.Var(&payloadFlags, "payload", "trigger payload entry key=value (repeatable)")
+	var payloadJSONFlag pipelinePayloadJSONFlag
+	fs.Var(&payloadJSONFlag, "payload-json", "trigger payload as a JSON object of string values")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printPipelineUsage(stderr)
 		if len(args) == 0 {
@@ -1081,6 +1089,11 @@ func runPipelineRunCmd(args []string, stdout, stderr io.Writer) int {
 	}
 	if fs.NArg() != 0 {
 		fmt.Fprintln(stderr, "pipeline run accepts exactly one name")
+		return 2
+	}
+	payloadJSON, err := pipelineRunPayload(payloadFlags, payloadJSONFlag.value, payloadJSONFlag.set)
+	if err != nil {
+		fmt.Fprintf(stderr, "pipeline run: %v\n", err)
 		return 2
 	}
 	var runID string
@@ -1113,7 +1126,7 @@ func runPipelineRunCmd(args []string, stdout, stderr io.Writer) int {
 			return err
 		}
 		now := time.Now().UTC()
-		run, err := pipeline.CreatePipelineRun(ctx, store, rec, spec, "manual", "{}", now)
+		run, err := pipeline.CreatePipelineRun(ctx, store, rec, spec, "manual", payloadJSON, now)
 		if err != nil {
 			return err
 		}
@@ -1129,6 +1142,154 @@ func runPipelineRunCmd(args []string, stdout, stderr io.Writer) int {
 	}
 	writeLine(stdout, "%s", runID)
 	return 0
+}
+
+type pipelinePayloadJSONFlag struct {
+	value string
+	set   bool
+}
+
+func (f *pipelinePayloadJSONFlag) String() string { return f.value }
+
+func (f *pipelinePayloadJSONFlag) Set(value string) error {
+	f.value = value
+	f.set = true
+	return nil
+}
+
+func pipelineRunPayload(entries []string, rawJSON string, rawJSONSet ...bool) (string, error) {
+	jsonSet := rawJSON != ""
+	if len(rawJSONSet) > 0 {
+		jsonSet = rawJSONSet[0]
+	}
+	if len(entries) > 0 && jsonSet {
+		return "", errors.New("--payload and --payload-json are mutually exclusive")
+	}
+	payload := make(map[string]string)
+	if jsonSet {
+		trimmed := strings.TrimSpace(rawJSON)
+		if len(trimmed) == 0 || trimmed[0] != '{' {
+			return "", errors.New("--payload-json must be a JSON object with string values")
+		}
+		if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
+			return "", fmt.Errorf("--payload-json must be a JSON object with string values: %w", err)
+		}
+	} else {
+		for _, entry := range entries {
+			key, value, ok := strings.Cut(entry, "=")
+			if !ok {
+				return "", fmt.Errorf("--payload %q must be key=value", entry)
+			}
+			if key == "" {
+				return "", errors.New("--payload key must not be empty")
+			}
+			payload[key] = value
+		}
+	}
+	return pipeline.ValidateAndEncodeTriggerPayload(payload)
+}
+
+var errPipelineWatchTimeout = errors.New("pipeline watch timed out while still running")
+
+func runPipelineWatchCmd(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("pipeline watch", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	timeout := fs.Duration("timeout", 10*time.Minute, "maximum time to wait")
+	poll := fs.Duration("poll", 5*time.Second, "poll interval")
+	jsonOut := fs.Bool("json", false, "print the final run summary as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printPipelineUsage(stderr)
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "pipeline watch requires a run id")
+			return 2
+		}
+		return 0
+	}
+	runID := strings.TrimSpace(args[0])
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "pipeline watch accepts exactly one run id")
+		return 2
+	}
+	if *poll <= 0 {
+		fmt.Fprintln(stderr, "pipeline watch poll interval must be positive")
+		return 2
+	}
+
+	var final pipelineRunView
+	err := withStore(*home, func(store *db.Store) error {
+		deadline := time.Now().Add(*timeout)
+		lastState := make(map[string]string)
+		for {
+			view, ok, err := loadPipelineRunView(context.Background(), store, runID)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return fmt.Errorf("run %s not found", runID)
+			}
+			if !*jsonOut {
+				printPipelineStageTransitions(stdout, view.stages, lastState)
+			}
+			if pipelineRunTerminal(view.run.State) {
+				final = view
+				return nil
+			}
+			remaining := time.Until(deadline)
+			if remaining <= 0 {
+				return errPipelineWatchTimeout
+			}
+			wait := *poll
+			if wait > remaining {
+				wait = remaining
+			}
+			time.Sleep(wait)
+		}
+	})
+	if errors.Is(err, errPipelineWatchTimeout) {
+		fmt.Fprintf(stderr, "pipeline watch: still running after %s\n", *timeout)
+		return 2
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "pipeline watch: %v\n", err)
+		return 1
+	}
+	if *jsonOut {
+		if code := encodePipelineJSON(stdout, stderr, pipelineRunToJSON(final)); code != 0 {
+			return code
+		}
+	} else {
+		writeLine(stdout, "state: %s", final.run.State)
+	}
+	if final.run.State == pipeline.RunSucceeded {
+		return 0
+	}
+	return 1
+}
+
+func pipelineRunTerminal(state string) bool {
+	switch state {
+	case pipeline.RunSucceeded, pipeline.RunFailed, pipeline.RunBlocked, pipeline.RunCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func printPipelineStageTransitions(w io.Writer, stages []db.PipelineRunStage, lastState map[string]string) {
+	for _, stage := range stages {
+		if lastState[stage.StageID] == stage.State {
+			continue
+		}
+		lastState[stage.StageID] = stage.State
+		writeLine(w, "%s: %s", stage.StageID, strings.ToUpper(stage.State))
+	}
 }
 
 // pipelineRunView is the resolved data behind `pipeline show <run-id>`: the run
@@ -1263,9 +1424,7 @@ func printPipelineRunFunnelAt(stdout io.Writer, view pipelineRunView, now time.T
 	writeLine(stdout, "run: %s", run.ID)
 	writeLine(stdout, "pipeline: %s", run.Pipeline)
 	writeLine(stdout, "trigger: %s", firstNonEmpty(run.Trigger, "-"))
-	if payload := strings.TrimSpace(run.PayloadJSON); payload != "" && payload != "{}" {
-		writeLine(stdout, "payload_json: %s", payload)
-	}
+	printPipelinePayloadPreview(stdout, run.PayloadJSON)
 	writeLine(stdout, "state: %s", run.State)
 	writeLine(stdout, "started: %s", heartbeatTimeForStatus(run.StartedAt))
 	writeLine(stdout, "finished: %s", heartbeatTimeForStatus(run.FinishedAt))
@@ -1311,6 +1470,39 @@ func printPipelineRunFunnelAt(stdout io.Writer, view pipelineRunView, now time.T
 			writeLine(stdout, "  gitmoot report bug --job %s", jobID)
 		}
 	}
+}
+
+func printPipelinePayloadPreview(w io.Writer, payloadJSON string) {
+	if payloadJSON = strings.TrimSpace(payloadJSON); payloadJSON == "" || payloadJSON == "{}" {
+		return
+	}
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil || len(payload) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(payload))
+	for key := range payload {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	writeLine(w, "payload:")
+	for _, key := range keys {
+		value := "[redacted]"
+		if !pipelinePayloadKeyLooksSecret(key) {
+			value = pipelinePreview(payload[key], " ", 40)
+		}
+		writeLine(w, "  %s: %s", key, strconv.Quote(value))
+	}
+}
+
+func pipelinePayloadKeyLooksSecret(key string) bool {
+	key = strings.ToLower(key)
+	for _, marker := range []string{"secret", "token", "password", "passwd", "credential", "api_key", "private_key", "auth", "cookie"} {
+		if strings.Contains(key, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func pipelineElapsed(now, started time.Time) string {

--- a/internal/cli/pipeline.go
+++ b/internal/cli/pipeline.go
@@ -1476,8 +1476,14 @@ func printPipelinePayloadPreview(w io.Writer, payloadJSON string) {
 	if payloadJSON = strings.TrimSpace(payloadJSON); payloadJSON == "" || payloadJSON == "{}" {
 		return
 	}
-	var payload map[string]string
+	// Decode into map[string]any, not map[string]string: manual runs carry string
+	// values but SERVICE runs persist typed payloads (canonicalPipelineServicePayload
+	// emits integers/booleans), and a map[string]string decode would fail on those
+	// and silently drop the whole payload. Any non-object / undecodable payload
+	// falls back to the raw line so provenance is never silently hidden.
+	var payload map[string]any
 	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil || len(payload) == 0 {
+		writeLine(w, "payload_json: %s", payloadJSON)
 		return
 	}
 	keys := make([]string, 0, len(payload))
@@ -1489,15 +1495,36 @@ func printPipelinePayloadPreview(w io.Writer, payloadJSON string) {
 	for _, key := range keys {
 		value := "[redacted]"
 		if !pipelinePayloadKeyLooksSecret(key) {
-			value = pipelinePreview(payload[key], " ", 40)
+			value = pipelinePreview(pipelinePayloadValueString(payload[key]), " ", 40)
 		}
 		writeLine(w, "  %s: %s", key, strconv.Quote(value))
 	}
 }
 
+// pipelinePayloadValueString renders a decoded JSON payload value for the text
+// funnel: strings verbatim, everything else (numbers, bools, null, nested) as
+// its compact JSON literal.
+func pipelinePayloadValueString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if b, err := json.Marshal(v); err == nil {
+		return string(b)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// pipelinePayloadKeyLooksSecret reports whether a payload key names something
+// sensitive enough to redact in the text funnel. The trigger payload is UNTRUSTED
+// run input, not a secrets channel (secrets flow through keycard grants), so this
+// is a light guard against a caller accidentally passing a credential as a run
+// input. Markers are matched as substrings but kept LONG and unambiguous so
+// benign keys are not caught — the earlier short markers "auth"/"cookie"
+// over-redacted "author", "oauth_provider", and "cookie_domain". The full value
+// remains available via `pipeline show --json`.
 func pipelinePayloadKeyLooksSecret(key string) bool {
 	key = strings.ToLower(key)
-	for _, marker := range []string{"secret", "token", "password", "passwd", "credential", "api_key", "private_key", "auth", "cookie"} {
+	for _, marker := range []string{"secret", "password", "passwd", "token", "credential", "api_key", "apikey", "private_key", "access_key"} {
 		if strings.Contains(key, marker) {
 			return true
 		}

--- a/internal/cli/pipeline_watch_payload_test.go
+++ b/internal/cli/pipeline_watch_payload_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/pipeline"
+)
+
+func TestPipelineRunPayloadParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		rawJSON string
+		want    string
+		wantErr string
+	}{
+		{name: "repeatable", entries: []string{"z=last", "a=first=rest"}, want: `{"a":"first=rest","z":"last"}`},
+		{name: "json", rawJSON: `{"subject":"hello"}`, want: `{"subject":"hello"}`},
+		{name: "missing equals", entries: []string{"broken"}, wantErr: "must be key=value"},
+		{name: "empty key", entries: []string{"=value"}, wantErr: "key must not be empty"},
+		{name: "mutually exclusive", entries: []string{"a=b"}, rawJSON: `{"c":"d"}`, wantErr: "mutually exclusive"},
+		{name: "json array", rawJSON: `[]`, wantErr: "must be a JSON object"},
+		{name: "json non-string", rawJSON: `{"a":1}`, wantErr: "string values"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pipelineRunPayload(tc.entries, tc.rawJSON)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("got %q, err=%v; want %q", got, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPipelineRunPayloadEmptyJSONFlagStillConflicts(t *testing.T) {
+	if _, err := pipelineRunPayload([]string{"a=b"}, "", true); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestPipelineRunThreadsPayloadIntoRun(t *testing.T) {
+	home := t.TempDir()
+	runCLI := func(args ...string) (string, string, int) {
+		var stdout, stderr bytes.Buffer
+		code := Run(append(args, "--home", home), &stdout, &stderr)
+		return stdout.String(), stderr.String(), code
+	}
+	spec := writeSpec(t, "name: payload-flow\nrepo: owner/repo\nstages:\n  - id: a\n    cmd: echo a\n")
+	if _, stderr, code := runCLI("pipeline", "add", spec); code != 0 {
+		t.Fatalf("add exit=%d stderr=%s", code, stderr)
+	}
+	stdout, stderr, code := runCLI("pipeline", "run", "payload-flow", "--payload", "subject=hello")
+	if code != 0 {
+		t.Fatalf("run exit=%d stderr=%s", code, stderr)
+	}
+	runID := strings.TrimSpace(stdout)
+	if err := withStore(home, func(store *db.Store) error {
+		run, ok, err := store.GetPipelineRun(context.Background(), runID)
+		if err != nil {
+			return err
+		}
+		if !ok || run.PayloadJSON != `{"subject":"hello"}` {
+			t.Fatalf("run = %+v, found=%v", run, ok)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPipelineWatchTerminalRuns(t *testing.T) {
+	tests := []struct {
+		state string
+		code  int
+	}{
+		{state: pipeline.RunSucceeded, code: 0},
+		{state: pipeline.RunFailed, code: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.state, func(t *testing.T) {
+			home, _, store := heartbeatLoopE2EHome(t)
+			runID := "prun-watch-" + tc.state
+			now := time.Now().UTC()
+			if err := store.CreatePipelineRun(context.Background(), db.PipelineRun{ID: runID, Pipeline: "watch", Trigger: "manual", PayloadJSON: "{}", SpecHash: "hash", State: tc.state, StartedAt: now, FinishedAt: now}); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.CreatePipelineRunStage(context.Background(), db.PipelineRunStage{RunID: runID, StageID: "build", State: map[bool]string{true: pipeline.StageSucceeded, false: pipeline.StageFailed}[tc.state == pipeline.RunSucceeded], StartedAt: now, FinishedAt: now}); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			code := runPipelineWatchCmd([]string{runID, "--home", home, "--poll", "1ms"}, &stdout, &stderr)
+			if code != tc.code || !strings.HasSuffix(stdout.String(), "state: "+tc.state+"\n") || stderr.Len() != 0 {
+				t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+		})
+	}
+}
+
+func TestPipelineWatchTerminalJSON(t *testing.T) {
+	home, _, store := heartbeatLoopE2EHome(t)
+	now := time.Now().UTC()
+	run := db.PipelineRun{ID: "prun-watch-json", Pipeline: "watch", Trigger: "manual", PayloadJSON: `{"subject":"hello"}`, SpecHash: "hash", State: pipeline.RunSucceeded, StartedAt: now, FinishedAt: now}
+	if err := store.CreatePipelineRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runPipelineWatchCmd([]string{run.ID, "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	var got pipelineRunJSON
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil || got.ID != run.ID || got.State != pipeline.RunSucceeded {
+		t.Fatalf("json=%s err=%v decoded=%+v", stdout.String(), err, got)
+	}
+}
+
+func TestPipelineWatchTimeoutAndPollValidation(t *testing.T) {
+	home, _, store := heartbeatLoopE2EHome(t)
+	run := db.PipelineRun{ID: "prun-watch-running", Pipeline: "watch", Trigger: "manual", State: pipeline.RunRunning, StartedAt: time.Now().UTC()}
+	if err := store.CreatePipelineRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runPipelineWatchCmd([]string{run.ID, "--home", home, "--timeout", "1ms", "--poll", "1ms"}, &stdout, &stderr); code != 2 || !strings.Contains(stderr.String(), "still running") {
+		t.Fatalf("timeout code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runPipelineWatchCmd([]string{run.ID, "--home", home, "--poll", "0s"}, &stdout, &stderr); code != 2 || !strings.Contains(stderr.String(), "poll interval must be positive") {
+		t.Fatalf("poll code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestPrintPipelineStageTransitionsDedupes(t *testing.T) {
+	last := make(map[string]string)
+	var out bytes.Buffer
+	rows := []db.PipelineRunStage{{StageID: "a", State: pipeline.StageRunning}}
+	printPipelineStageTransitions(&out, rows, last)
+	printPipelineStageTransitions(&out, rows, last)
+	rows[0].State = pipeline.StageSucceeded
+	printPipelineStageTransitions(&out, rows, last)
+	if got, want := out.String(), "a: RUNNING\na: SUCCEEDED\n"; got != want {
+		t.Fatalf("transitions=%q want=%q", got, want)
+	}
+}
+
+func TestPrintPipelinePayloadPreviewRedactsAndTruncates(t *testing.T) {
+	var out bytes.Buffer
+	printPipelinePayloadPreview(&out, `{"api_token":"do-not-print","subject":"`+strings.Repeat("x", 50)+`"}`)
+	got := out.String()
+	if strings.Contains(got, "do-not-print") || !strings.Contains(got, `api_token: "[redacted]"`) || !strings.Contains(got, strings.Repeat("x", 40)+"…") {
+		t.Fatalf("payload preview=%q", got)
+	}
+}

--- a/internal/cli/pipeline_watch_payload_test.go
+++ b/internal/cli/pipeline_watch_payload_test.go
@@ -163,3 +163,43 @@ func TestPrintPipelinePayloadPreviewRedactsAndTruncates(t *testing.T) {
 		t.Fatalf("payload preview=%q", got)
 	}
 }
+
+// A SERVICE run persists a typed payload with integer/boolean values
+// (canonicalPipelineServicePayload). The preview must render them, not silently
+// drop the whole payload the way a map[string]string decode would.
+func TestPrintPipelinePayloadPreviewRendersNonStringValues(t *testing.T) {
+	var out bytes.Buffer
+	printPipelinePayloadPreview(&out, `{"count":5,"enabled":true,"name":"foo"}`)
+	got := out.String()
+	for _, want := range []string{`count: "5"`, `enabled: "true"`, `name: "foo"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("preview %q missing %q", got, want)
+		}
+	}
+}
+
+// A non-object / undecodable payload falls back to the raw line so provenance is
+// never silently hidden.
+func TestPrintPipelinePayloadPreviewFallsBackToRaw(t *testing.T) {
+	var out bytes.Buffer
+	printPipelinePayloadPreview(&out, `[1,2,3]`)
+	if got := out.String(); !strings.Contains(got, "payload_json: [1,2,3]") {
+		t.Fatalf("expected raw fallback, got %q", got)
+	}
+}
+
+// Long unambiguous markers redact; short benign keys that merely contain a
+// fragment ("author" superset of "auth", "cookie_domain" superset of "cookie")
+// must NOT be redacted.
+func TestPipelinePayloadKeyRedactionBoundaries(t *testing.T) {
+	for _, key := range []string{"secret", "api_key", "access_token", "db_password", "my_credential", "private_key"} {
+		if !pipelinePayloadKeyLooksSecret(key) {
+			t.Errorf("expected %q to be redacted", key)
+		}
+	}
+	for _, key := range []string{"author", "oauth_provider", "cookie_domain", "person", "transcript_path", "count"} {
+		if pipelinePayloadKeyLooksSecret(key) {
+			t.Errorf("expected %q to NOT be redacted", key)
+		}
+	}
+}

--- a/internal/pipeline/trigger_payload_test.go
+++ b/internal/pipeline/trigger_payload_test.go
@@ -1,0 +1,41 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAndEncodeTriggerPayload(t *testing.T) {
+	tooMany := make(map[string]string)
+	for i := 0; i < 33; i++ {
+		tooMany["k"+string(rune('a'+i%26))+strings.Repeat("x", i/26)] = "v"
+	}
+	tests := []struct {
+		name    string
+		payload map[string]string
+		want    string
+		wantErr string
+	}{
+		{name: "valid canonical JSON", payload: map[string]string{"z": "last", "a": "first"}, want: `{"a":"first","z":"last"}`},
+		{name: "bad key", payload: map[string]string{"Bad-Key": "v"}, wantErr: `payload key "Bad-Key" must be 1-64 bytes`},
+		{name: "key too long", payload: map[string]string{"a" + strings.Repeat("x", 64): "v"}, wantErr: "must be 1-64 bytes"},
+		{name: "value too big", payload: map[string]string{"body": strings.Repeat("x", (32<<10)+1)}, wantErr: `payload value for key "body" exceeds the 32 KiB limit`},
+		{name: "too many entries", payload: tooMany, wantErr: "maximum is 32"},
+		{name: "decoded total too big", payload: map[string]string{"a": strings.Repeat("a", 24<<10), "b": strings.Repeat("b", 24<<10)}, wantErr: "decoded key/value total exceeds the 48 KiB limit"},
+		{name: "nul", payload: map[string]string{"body": "a\x00b"}, wantErr: "must not contain U+0000"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ValidateAndEncodeTriggerPayload(tc.payload)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("got %q, err=%v; want %q", got, err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -21,6 +22,47 @@ var triggerMapSelectors = []string{"subject", "from_address", "text", "message_i
 // decoded-size limits are byte budgets.
 func ValidTriggerPayloadKey(key string) bool {
 	return len(key) >= 1 && len(key) <= 64 && triggerPayloadKeyPattern.MatchString(key)
+}
+
+const (
+	triggerPayloadMaxEntries   = 32
+	triggerPayloadValueLimit   = 32 << 10
+	triggerPayloadDecodedLimit = 48 << 10
+)
+
+// ValidateAndEncodeTriggerPayload applies the shared trigger transport limits
+// and returns the canonical JSON persisted on the pipeline run row.
+func ValidateAndEncodeTriggerPayload(payload map[string]string) (string, error) {
+	if len(payload) > triggerPayloadMaxEntries {
+		return "", fmt.Errorf("payload has %d entries; maximum is %d", len(payload), triggerPayloadMaxEntries)
+	}
+	keys := make([]string, 0, len(payload))
+	for key := range payload {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	total := 0
+	for _, key := range keys {
+		value := payload[key]
+		if !ValidTriggerPayloadKey(key) {
+			return "", fmt.Errorf("payload key %q must be 1-64 bytes and match ^[a-z][a-z0-9_]*$", key)
+		}
+		if len(value) > triggerPayloadValueLimit {
+			return "", fmt.Errorf("payload value for key %q exceeds the 32 KiB limit", key)
+		}
+		if strings.ContainsRune(value, '\x00') {
+			return "", fmt.Errorf("payload value for key %q must not contain U+0000", key)
+		}
+		total += len(key) + len(value)
+		if total > triggerPayloadDecodedLimit {
+			return "", fmt.Errorf("payload decoded key/value total exceeds the 48 KiB limit (at key %q)", key)
+		}
+	}
+	canonical, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal validated payload: %w", err)
+	}
+	return string(canonical), nil
 }
 
 // normalize trims surrounding whitespace off every free-text field so validation

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2785,7 +2785,8 @@ gitmoot pipeline install-defaults                 # install built-in memory pipe
 gitmoot pipeline list [--json]
 gitmoot pipeline show nightly-sync [--json]        # registry view for a name
 gitmoot pipeline bind-trigger nightly-sync         # create/re-sync owned AP flow
-gitmoot pipeline run nightly-sync                  # start a manual run; prints the run id
+gitmoot pipeline run nightly-sync [--payload key=value ...] [--payload-json '<obj>']
+gitmoot pipeline watch <run-id> [--timeout 10m] [--poll 5s] [--json]
 gitmoot pipeline show <run-id> [--json]            # run funnel for a "prun-…" id
 gitmoot pipeline expose --schema schema.json <name> # issue one bearer token (shown once)
 gitmoot pipeline serve                              # loopback API on 127.0.0.1:8792
@@ -3053,8 +3054,9 @@ dynamically fenced, 6000-byte-bounded `UNTRUSTED external data` block before
 upstream context; each rendered value is capped at 1500 bytes. Shell stages receive
 exact `GITMOOT_TRIGGER_<UPPERCASE_KEY>` exec environment entries, never shell-source
 interpolation. The full canonical payload is retained in the SQLite run row and
-shown by `pipeline show <run-id>` as `payload_json`; job
-env/prompt projections follow normal job-data retention.
+shown as redacted/truncated key provenance by text `pipeline show <run-id>` and
+as `payload_json` in JSON; job env/prompt projections follow normal job-data
+retention.
 
 Every pipeline shell stage also receives `GITMOOT_PIPELINE_NAME`,
 `GITMOOT_PIPELINE_RUN_ID`, and `GITMOOT_PIPELINE_STAGE_ID`. A dependent shell
@@ -3154,11 +3156,18 @@ strict: omitting `skipped` makes it fail. A `pr_merged` gate whose source skippe
 parks blocked because no PR can exist for that run.
 
 `pipeline run` prints only the run id (script-stable: `RUN=$(gitmoot pipeline run
-nightly-sync)`); a manual run ignores `enabled` but still needs a `repo` and refuses
+nightly-sync)`); repeat `--payload key=value` or use one `--payload-json` string
+object to enter the existing trigger-input seam. The forms are mutually exclusive
+and share the bridge's key/count/size validation. A manual run ignores `enabled` but still needs a `repo` and refuses
 to start while a run is already active. `pipeline show <run-id>` renders the **text
 funnel** (`source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED`) under a
 run header; a **failed** run also prints the exact `gitmoot report bug --job
 <stage-job>` command (gitmoot never auto-files it).
+
+`pipeline watch <run-id>` is the blocking completion primitive. It prints each
+stage state transition once, returns `0` for succeeded, `1` for terminal
+failed/blocked/cancelled, and `2` with `still running` when `--timeout` expires.
+Use `--json` for the same final summary shape as `pipeline show --json`.
 
 While a stage is queued or running, the run view adds an honest
 `STATE; enqueued <elapsed> ago` detail (the stage timestamp is enqueue time, not

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -1103,7 +1103,7 @@ stages:
 ```sh
 gitmoot pipeline add nightly-sync.yaml --enable   # validate + store; --enable turns on the schedule
 RUN=$(gitmoot pipeline run nightly-sync)          # or trigger a manual run now
-gitmoot pipeline show "$RUN"                       # watch the text funnel
+gitmoot pipeline watch "$RUN"                      # one blocking call; no agent poll loop
 ```
 
 ### Pipelines as a service
@@ -1422,6 +1422,19 @@ Produce batches use the existing result decisions: `implemented` = complete,
 `changes_requested` = partial (only advances when opted into `success_decisions`),
 `blocked` = needs a human, and `skipped` = no work. `pipeline show` reports a
 best-effort run token total and per-stage input/output usage in JSON.
+
+Manual runs can carry the same trigger payload as bridge-started runs:
+
+```sh
+RUN=$(gitmoot pipeline run nightly-sync --payload batch=nightly --payload region=eu)
+gitmoot pipeline watch "$RUN" --timeout 10m
+```
+
+Use `--payload-json '{"batch":"nightly"}'` instead of repeatable `--payload`
+when the input already exists as JSON. The forms are mutually exclusive and use
+the bridge's shared payload limits. If watch exits `2` with `still running`,
+re-invoke it with another timeout window; do not teach agents to poll `pipeline
+show` in a loop.
 
 ### Park and resume
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1998,7 +1998,8 @@ gitmoot pipeline install-defaults                 # install built-in memory pipe
 gitmoot pipeline list [--json]
 gitmoot pipeline show nightly-sync [--json]        # registry view for a name
 gitmoot pipeline bind-trigger nightly-sync         # create/re-sync owned AP flow
-gitmoot pipeline run nightly-sync                  # start a manual run; prints the run id
+gitmoot pipeline run nightly-sync [--payload key=value ...] [--payload-json '<obj>']
+gitmoot pipeline watch <run-id> [--timeout 10m] [--poll 5s] [--json]
 gitmoot pipeline show <run-id> [--json]            # run funnel for a "prun-…" id
 gitmoot pipeline expose --schema schema.json <name>
 gitmoot pipeline serve [--addr 127.0.0.1:8792] [--allow-remote]
@@ -2155,7 +2156,9 @@ is a succeeded job but folds as a stage **failure** by default):
 strict: omitting `skipped` makes it fail. A `pr_merged` gate whose terminal succeeded
 source opened no PR parks blocked because there is nothing to wait for.
 
-`pipeline run` prints only the run id (script-stable), ignores the `enabled` flag but
+`pipeline run` prints only the run id (script-stable). Repeat `--payload key=value`
+or provide one `--payload-json` string object to use the same validated trigger
+input seam as the bridge; the forms are mutually exclusive. It ignores the `enabled` flag but
 still needs a `repo` and refuses to start while a run is active. `pipeline show
 <run-id>` renders the **text funnel** (`source OK -> score BLOCKED (needs: R2 token)
 -> deploy SKIPPED`); a **failed** run also prints the exact `gitmoot report bug --job
@@ -2164,6 +2167,11 @@ from its halted stage (or `--from`) plus its transitive dependents while **never
 re-running a succeeded stage. A pipeline stage is a **leaf**: a stage result carrying
 `delegations[]` never spawns children. See
 [Pipelines](../workflows/pipelines-workflow.md) for the full workflow.
+
+`pipeline watch <run-id>` blocks until terminal state, printing each stage state
+change once. It exits `0` for succeeded, `1` for failed/blocked/cancelled, and `2`
+with `still running` when the timeout expires. `--json` emits the final
+`pipeline show --json` summary without transition lines.
 
 ## Native Chat (agent threads)
 

--- a/website/docs/workflows/pipelines-workflow.md
+++ b/website/docs/workflows/pipelines-workflow.md
@@ -65,10 +65,10 @@ Register it and run it:
 gitmoot pipeline add nightly-sync.yaml --enable
 
 # Or trigger a manual run right now (script-stable: prints just the run id).
-RUN=$(gitmoot pipeline run nightly-sync)
+RUN=$(gitmoot pipeline run nightly-sync --payload batch=nightly)
 
-# Watch the run as a text funnel.
-gitmoot pipeline show "$RUN"
+# Block until terminal state without an agent-side poll loop.
+gitmoot pipeline watch "$RUN" --timeout 10m
 ```
 
 ### Expose a pipeline as a service
@@ -302,7 +302,8 @@ gitmoot pipeline remote show
 gitmoot pipeline publish <name> [--remote owner/repo] [--create]
 gitmoot pipeline pull --list [--remote owner/repo]
 gitmoot pipeline pull <name> [--remote owner/repo] --repo owner/repo [--agent-map exported=local]
-gitmoot pipeline run <name>                  # start a manual run; prints the run id
+gitmoot pipeline run <name> [--payload key=value ...] [--payload-json '<obj>']
+gitmoot pipeline watch <run-id> [--timeout 10m] [--poll 5s] [--json]
 gitmoot pipeline resume <run-id> [--from <stage>]
 gitmoot pipeline cancel <run-id>
 gitmoot pipeline enable <name>
@@ -346,7 +347,9 @@ removing the full `prompt` or `cmd`.
 
 A manual `pipeline run` ignores the `enabled` flag — a disabled pipeline can still be
 run by hand — but still requires a `repo` and refuses to start while the pipeline
-already has an active run (one active run per pipeline). `pipeline add` also
+already has an active run (one active run per pipeline). Repeat `--payload
+key=value` or use one `--payload-json` object of strings to supply trigger data;
+the forms are mutually exclusive and use the bridge's shared limits. `pipeline add` also
 auto-creates one hidden shell runner agent per pipeline (`pipeline-<name>-runner`)
 that owns the stage jobs; it is filtered out of `gitmoot agent list` and disposed by
 `pipeline remove`.
@@ -388,8 +391,9 @@ fenced block labeled `UNTRUSTED external data`; each rendered value is capped at
 Every shell stage receives exact `GITMOOT_TRIGGER_<UPPERCASE_KEY>` exec environment
 entries. Values are never interpolated into shell source, so newlines and UTF-8
 remain data. The full canonical payload lives in the SQLite run row, is printed
-as `payload_json` by `pipeline show <run-id>`, and shell env and
-agent prompt projections also live in normal job data.
+as redacted/truncated key provenance in the text `pipeline show <run-id>` view
+(and as `payload_json` in JSON), and shell env and agent prompt projections also
+live in normal job data.
 
 ### Shell-stage upstream context
 
@@ -746,6 +750,12 @@ needs: R2 token
 
 source OK -> score BLOCKED (needs: R2 token) -> deploy SKIPPED
 ```
+
+Use `pipeline watch "$RUN"` as the normal blocking completion call. It emits each
+stage state change once and exits `0` only for success. Failed, blocked, or
+cancelled runs exit `1`; an active run that reaches `--timeout` exits `2` with
+`still running`, so a harness can re-invoke watch for another bounded window.
+`--json` emits the final `pipeline show --json` shape.
 
 Active runs also show queued/running stage details. The duration is labeled
 `enqueued` because the stage timestamp is recorded at enqueue, not worker claim.


### PR DESCRIPTION
Combines two additive pipeline-CLI ergonomics features (one PR, no engine changes). Base is current `main` (includes #1044).

## #1043 — `gitmoot pipeline watch <run-id> [--timeout 10m] [--poll 5s] [--json]`

A blocking wait on a run, modeled on the existing `job watch`. Ends the agent **polling tax** (the Build Week demo measured the driving session at **2.39M tokens**, mostly cached re-reads from `pipeline show` poll loops).

- Prints stage transitions as they fold (deduped — one line per stage state change); blocks until the run is terminal or `--timeout`.
- Exit codes: **0** succeeded · **1** failed/blocked/cancelled or error · **2** timeout (prints "still running" so a harness `--timeout 5m` re-invoke loop collapses ~60 model turns into ~3). Non-positive `--poll` rejected; poll clamps to the remaining deadline.
- `--json` prints the final run summary via the **same `pipelineRunToJSON` path** as `pipeline show --json`.
- Terminal detection covers every terminal run state (`running` is the only non-terminal state).

## #1018 — `gitmoot pipeline run <name> --payload key=value` (repeatable) / `--payload-json '<obj>'`

A CLI transport into the existing **#863** run-input contract — no new semantics. Previously the only transport was the bridge HTTP endpoint; a human doing a manual parameterized run had to hand-roll an authenticated curl.

- The bridge's validate-and-encode logic is **extracted verbatim** into `pipeline.ValidateAndEncodeTriggerPayload` (internal/pipeline), and `bridge.go` now calls it — so the limits are **single-sourced** and can't drift: ≤32 entries, key `^[a-z][a-z0-9_]*$` ≤64 B, value ≤32 KiB, NUL rejected, decoded total ≤48 KiB, same rejection messages. The raw-body 64 KiB cap correctly stays bridge-only. The pre-existing `TestBridgePipelineRunPayloadValidation` still passes against the refactor.
- `--payload` / `--payload-json` are mutually exclusive; `key=value` splits on the first `=` (empty key rejected, value may contain `=`); the validated JSON threads into `CreatePipelineRun` (was hardcoded `"{}"`).
- `pipeline show` now renders payload keys (values truncated) for run provenance.

## Review

`/code-review high` (fresh-context) found **2 confirmed regressions**, both fixed in the second commit (1 style nit refuted):

1. The payload preview decoded into `map[string]string` and returned silently on error, so **service/PaaS runs** (`canonicalPipelineServicePayload` persists integers/booleans) had their whole payload dropped from `pipeline show`. Now decodes `map[string]any` + stringifies, with a **raw-JSON fallback** so provenance is never silently hidden.
2. Secret-key redaction used short substring markers (`auth`/`cookie`) that over-redacted benign keys (`author`, `oauth_provider`, `cookie_domain`). Tightened to long unambiguous markers.

New tests lock in both: non-string value rendering, the raw fallback, and the redaction boundaries.

## Docs

Both commands documented in `docs/pipelines.md`, skill `CLI.md` + `WORKFLOWS.md`, site `reference/cli.md` + `workflows/pipelines-workflow.md`; the agent playbook is flipped from poll loops to `pipeline watch`. `llms-full.txt` is generated (not hand-edited).

## Deploy notes

**No deploy** — live box frozen for the Devpost submission through Aug 5. Additive CLI + docs; no schema/migration; single-binary invariant intact. CI race matrix covers internal/cli + internal/pipeline.

Closes #1043, #1018.
