### PR TITLE
test(cli): parallelize the pure test tranche + inject two global seams (#1039)

### DIFF
--- a/internal/cli/agent_dispatch_live_ab.go
+++ b/internal/cli/agent_dispatch_live_ab.go
@@ -268,9 +268,11 @@ func presentLiveABAndCapturePick(prompt, championAnswer, challengerAnswer string
 }
 
 // defaultLiveABPresenter prints both answers (shuffled as Option A/B) to stdout
-// and reads one pick line via the shared readSkillOptABLine seam. A missing pick
-// is the common non-interactive case and returns ok=false (fail-safe skip). When
-// a valid pick arrives it is mapped back through the shuffle to the correct role.
+// and reads one pick line. It wires the production seams — the default randomizer
+// (defaultLiveABShuffle) and the default line reader (defaultReadSkillOptABLine) —
+// into defaultLiveABPresenterWith, which holds the blinding/mapping logic. A
+// missing pick is the common non-interactive case and returns ok=false (fail-safe
+// skip); a valid pick is mapped back through the shuffle to the correct role.
 func defaultLiveABPresenter(prompt, championAnswer, challengerAnswer string) (string, string, bool) {
 	return defaultLiveABPresenterWith(prompt, championAnswer, challengerAnswer, defaultLiveABShuffle, defaultReadSkillOptABLine)
 }

--- a/internal/cli/agent_dispatch_live_ab.go
+++ b/internal/cli/agent_dispatch_live_ab.go
@@ -272,9 +272,16 @@ func presentLiveABAndCapturePick(prompt, championAnswer, challengerAnswer string
 // is the common non-interactive case and returns ok=false (fail-safe skip). When
 // a valid pick arrives it is mapped back through the shuffle to the correct role.
 func defaultLiveABPresenter(prompt, championAnswer, challengerAnswer string) (string, string, bool) {
+	return defaultLiveABPresenterWith(prompt, championAnswer, challengerAnswer, defaultLiveABShuffle, defaultReadSkillOptABLine)
+}
+
+// defaultLiveABPresenterWith presents a blinded comparison with injected input
+// seams. Production supplies the default randomizer and line reader; tests can
+// pin either without mutating package state.
+func defaultLiveABPresenterWith(prompt, championAnswer, challengerAnswer string, shuffle func() bool, readLine func() (string, bool)) (string, string, bool) {
 	// Shuffle so the human cannot infer which answer is the challenger; map the
 	// pick back to the role via the recorded swap.
-	swap := liveABShuffle()
+	swap := shuffle()
 	optionAAnswer, optionAIsChampion := championAnswer, true
 	optionBAnswer := challengerAnswer
 	if swap {
@@ -287,7 +294,7 @@ func defaultLiveABPresenter(prompt, championAnswer, challengerAnswer string) (st
 	fmt.Printf("Option B:\n%s\n\n", optionBAnswer)
 	fmt.Print("Which is better? [a/b] (enter to skip): ")
 
-	line, gotLine := readSkillOptABLine()
+	line, gotLine := readLine()
 	if !gotLine {
 		return "", "", false
 	}
@@ -302,7 +309,6 @@ func defaultLiveABPresenter(prompt, championAnswer, challengerAnswer string) (st
 	return skillOptABChallengerLabel, skillOptABChampionLabel, true
 }
 
-// liveABShuffle is a seam over the one coin flip that decides the A/B label
-// shuffle; tests pin it. The default uses the same package math/rand source as
-// liveABSampler so an unseeded run is non-deterministic (no fixed-seed bias).
-var liveABShuffle = func() bool { return rand.Intn(2) == 1 }
+// defaultLiveABShuffle uses the same package math/rand source as liveABSampler
+// so an unseeded run is non-deterministic (no fixed-seed bias).
+func defaultLiveABShuffle() bool { return rand.Intn(2) == 1 }

--- a/internal/cli/agent_dispatch_live_ab_test.go
+++ b/internal/cli/agent_dispatch_live_ab_test.go
@@ -507,6 +507,28 @@ func TestDefaultLiveABPresenterMapsPickThroughShuffle(t *testing.T) {
 	}
 }
 
+// TestDefaultLiveABShuffleReturnsBothOrientations covers the production shuffle
+// seam (the func defaultLiveABPresenter wires into defaultLiveABPresenterWith):
+// it must be a real coin flip, not stuck on one orientation. math/rand's global
+// source is mutex-safe, so this is parallel-safe. (The presenter's wiring of the
+// two seams is guarded by the type system — the shuffle is func() bool and the
+// reader is func() (string, bool), so they cannot be transposed without a compile
+// error.)
+func TestDefaultLiveABShuffleReturnsBothOrientations(t *testing.T) {
+	t.Parallel()
+	var sawTrue, sawFalse bool
+	for i := 0; i < 200 && !(sawTrue && sawFalse); i++ {
+		if defaultLiveABShuffle() {
+			sawTrue = true
+		} else {
+			sawFalse = true
+		}
+	}
+	if !sawTrue || !sawFalse {
+		t.Fatalf("defaultLiveABShuffle did not produce both orientations in 200 draws (true=%v false=%v)", sawTrue, sawFalse)
+	}
+}
+
 // TestMaybeRunLiveABChallengerUsesForkedSession is the session-isolation guard
 // (#482, goal Risk #4): the challenger Deliver must run on a FORKED/throwaway
 // session, never the agent's live RuntimeRef. The fixture pins the agent to the

--- a/internal/cli/agent_dispatch_live_ab_test.go
+++ b/internal/cli/agent_dispatch_live_ab_test.go
@@ -487,32 +487,22 @@ func assertLiveABSkippedEvent(t *testing.T, store *db.Store, jobID string) {
 // maps a pick back to the correct role under both shuffle orientations, so a
 // captured preference is never silently inverted.
 func TestDefaultLiveABPresenterMapsPickThroughShuffle(t *testing.T) {
-	prevShuffle := liveABShuffle
-	prevLine := readSkillOptABLine
-	t.Cleanup(func() {
-		liveABShuffle = prevShuffle
-		readSkillOptABLine = prevLine
-	})
+	t.Parallel()
 
 	// No swap: Option A = champion. Pick "a" -> champion wins.
-	liveABShuffle = func() bool { return false }
-	readSkillOptABLine = func() (string, bool) { return "a", true }
-	winner, loser, ok := defaultLiveABPresenter("q", "champ", "chal")
+	winner, loser, ok := defaultLiveABPresenterWith("q", "champ", "chal", func() bool { return false }, func() (string, bool) { return "a", true })
 	if !ok || winner != skillOptABChampionLabel || loser != skillOptABChallengerLabel {
 		t.Fatalf("no-swap pick a: winner=%q loser=%q ok=%v, want champion wins", winner, loser, ok)
 	}
 
 	// Swap: Option A = challenger. Pick "a" -> challenger wins.
-	liveABShuffle = func() bool { return true }
-	readSkillOptABLine = func() (string, bool) { return "a", true }
-	winner, loser, ok = defaultLiveABPresenter("q", "champ", "chal")
+	winner, loser, ok = defaultLiveABPresenterWith("q", "champ", "chal", func() bool { return true }, func() (string, bool) { return "a", true })
 	if !ok || winner != skillOptABChallengerLabel || loser != skillOptABChampionLabel {
 		t.Fatalf("swap pick a: winner=%q loser=%q ok=%v, want challenger wins", winner, loser, ok)
 	}
 
 	// No pick line -> ok=false (fail-safe skip).
-	readSkillOptABLine = func() (string, bool) { return "", false }
-	if _, _, ok := defaultLiveABPresenter("q", "champ", "chal"); ok {
+	if _, _, ok := defaultLiveABPresenterWith("q", "champ", "chal", func() bool { return false }, func() (string, bool) { return "", false }); ok {
 		t.Fatal("missing pick line must return ok=false")
 	}
 }

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -636,9 +636,7 @@ func runChatInbox(args []string, stdout, stderr io.Writer) int {
 
 // ---- wait (turn-taking poll) -----------------------------------------------
 
-// chatWaitPollInterval is how often `chat wait` re-polls the store for new
-// messages. A package var so tests can shrink it to keep the poll loop fast.
-var chatWaitPollInterval = 500 * time.Millisecond
+const chatWaitPollInterval = 500 * time.Millisecond
 
 // chatMootCapWaitLine is the exact, machine-detectable line `chat wait` prints
 // when the thread's moot cap is reached — the seat's cue to wrap up (#534 V1.5).
@@ -651,6 +649,13 @@ const chatMootCapWaitLine = "MOOT CAP REACHED — wrap up now"
 // it prints chatMootCapWaitLine and returns immediately (even with no new message),
 // so a seat stops instead of spinning until timeout.
 func runChatWait(args []string, stdout, stderr io.Writer) int {
+	return runChatWaitWithPollInterval(args, stdout, stderr, chatWaitPollInterval)
+}
+
+// runChatWaitWithPollInterval is runChatWait with an injected polling cadence.
+// Production uses chatWaitPollInterval; tests use a short cadence without
+// mutating package state, so independent waits can run concurrently.
+func runChatWaitWithPollInterval(args []string, stdout, stderr io.Writer, pollInterval time.Duration) int {
 	fs := flag.NewFlagSet("chat wait", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
@@ -688,7 +693,7 @@ func runChatWait(args []string, stdout, stderr io.Writer) int {
 			if len(newMsgs) > 0 || capReached || !time.Now().Before(deadline) {
 				break
 			}
-			time.Sleep(chatWaitPollInterval)
+			time.Sleep(pollInterval)
 		}
 	} else if err := withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
@@ -708,7 +713,7 @@ func runChatWait(args []string, stdout, stderr io.Writer) int {
 			if len(newMsgs) > 0 || capReached || !time.Now().Before(deadline) {
 				return nil
 			}
-			time.Sleep(chatWaitPollInterval)
+			time.Sleep(pollInterval)
 		}
 	}); err != nil {
 		fmt.Fprintf(stderr, "chat wait: %v\n", err)

--- a/internal/cli/chat_moot_test.go
+++ b/internal/cli/chat_moot_test.go
@@ -333,18 +333,14 @@ func TestChatWaitSinceSeq(t *testing.T) {
 // message arrives, still reporting the tail last-seq (a seat can then decide to
 // speak or stop).
 func TestChatWaitTimeout(t *testing.T) {
+	t.Parallel()
 	store, home := mootFixtureHome(t, "")
 	thread := seedChatThread(t, store, "quiet", "owner/repo")
 	seedChatMention(t, store, thread, db.ChatKindChat, db.ChatAuthorKindHuman, "human", "only", "")
 
-	// Shrink the poll interval so the timeout loop spins fast.
-	restore := chatWaitPollInterval
-	chatWaitPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { chatWaitPollInterval = restore })
-
 	var stdout bytes.Buffer
 	start := time.Now()
-	code := Run([]string{"chat", "wait", "quiet", "--since-seq", "1", "--timeout", "60ms", "--repo", "owner/repo", "--home", home}, &stdout, &bytes.Buffer{})
+	code := runChatWaitWithPollInterval([]string{"quiet", "--since-seq", "1", "--timeout", "60ms", "--repo", "owner/repo", "--home", home}, &stdout, &bytes.Buffer{}, 10*time.Millisecond)
 	if code != 0 {
 		t.Fatalf("wait exit = %d, want 0", code)
 	}
@@ -359,6 +355,7 @@ func TestChatWaitTimeout(t *testing.T) {
 // TestChatWaitCapSignal proves `chat wait` on a capped moot prints the exact
 // wrap-up line and returns immediately (no timeout spin), even with no new message.
 func TestChatWaitCapSignal(t *testing.T) {
+	t.Parallel()
 	store, home := mootFixtureHome(t, "")
 	ctx := context.Background()
 	thread := seedChatThread(t, store, "done", "owner/repo")
@@ -367,14 +364,10 @@ func TestChatWaitCapSignal(t *testing.T) {
 	}
 	seedChatMention(t, store, thread, db.ChatKindChat, db.ChatAuthorKindAgent, "seat", "final turn", "")
 
-	restore := chatWaitPollInterval
-	chatWaitPollInterval = 10 * time.Millisecond
-	t.Cleanup(func() { chatWaitPollInterval = restore })
-
 	var stdout bytes.Buffer
 	start := time.Now()
 	// A large --timeout: if the cap short-circuit works, wait returns immediately.
-	code := Run([]string{"chat", "wait", "done", "--since-seq", "99", "--timeout", "30s", "--repo", "owner/repo", "--home", home}, &stdout, &bytes.Buffer{})
+	code := runChatWaitWithPollInterval([]string{"done", "--since-seq", "99", "--timeout", "30s", "--repo", "owner/repo", "--home", home}, &stdout, &bytes.Buffer{}, 10*time.Millisecond)
 	if code != 0 {
 		t.Fatalf("wait exit = %d, want 0", code)
 	}

--- a/internal/cli/dashboard_web_pipelines_test.go
+++ b/internal/cli/dashboard_web_pipelines_test.go
@@ -119,6 +119,7 @@ func seedDiamondBlockedRun(t *testing.T, home, runID, specHash string) {
 // TestWebDataSourcePipelinesEmpty pins the empty-store contract: a non-nil, empty
 // slice (never nil), so the API layer's nil->[] coercion has nothing to do.
 func TestWebDataSourcePipelinesEmpty(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	ds := &webDataSource{home: home}
 
@@ -135,6 +136,7 @@ func TestWebDataSourcePipelinesEmpty(t *testing.T) {
 }
 
 func TestWebDataSourcePipelinesPipelineTriggerMode(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	upstreamSpec := "name: upstream\nstages: [{id: run, cmd: echo}]\n"
@@ -169,6 +171,7 @@ func TestWebDataSourcePipelinesPipelineTriggerMode(t *testing.T) {
 // field mapping (including the two time.Time -> epoch-ms conversions), the Recent
 // cap at 10 newest-first, and the Duration = finished-started rule.
 func TestWebDataSourcePipelines(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	ctx := context.Background()
@@ -265,6 +268,7 @@ func TestWebDataSourcePipelines(t *testing.T) {
 // spec-derived cmd + dependency deps merged, the blocked stage carrying its
 // persisted needs, the skipped stage present, and the run-level halt/needs mapped.
 func TestWebDataSourcePipelineRunBlockedDiamond(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	seedDiamondBlockedRun(t, home, "prun-diamond-0001", "")
 
@@ -339,6 +343,7 @@ func TestWebDataSourcePipelineRunBlockedDiamond(t *testing.T) {
 // both spec gates: matching-hash and same-stage-set structural fallback. Stored
 // order is retained; roots and malformed values become non-nil empty slices.
 func TestWebDataSourcePipelineRunStoredDeps(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	realHash := pipeline.Hash([]byte(diamondSpecYAML))
@@ -393,6 +398,7 @@ func TestWebDataSourcePipelineRunStoredDeps(t *testing.T) {
 // latest-event read maps valid progress onto running stages only. Missing and
 // malformed events fail open, and terminal stages never retain stale progress.
 func TestWebDataSourcePipelineRunProgress(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	started := time.UnixMilli(1_751_000_000_000).UTC()
@@ -434,24 +440,28 @@ func TestWebDataSourcePipelineRunProgress(t *testing.T) {
 	}
 
 	t.Run("maps running progress activity and event millis", func(t *testing.T) {
+		t.Parallel()
 		got := byID["mapped"]
 		if got.ProgressActivity != "compiled package 42/100" || got.ProgressAt != wantProgressAt || got.ProgressAt == 0 {
 			t.Fatalf("mapped progress = %q/%d, want activity/%d", got.ProgressActivity, got.ProgressAt, wantProgressAt)
 		}
 	})
 	t.Run("absent event stays zero", func(t *testing.T) {
+		t.Parallel()
 		got := byID["absent"]
 		if got.ProgressActivity != "" || got.ProgressAt != 0 {
 			t.Fatalf("absent progress = %q/%d, want zero values", got.ProgressActivity, got.ProgressAt)
 		}
 	})
 	t.Run("malformed event stays zero without error", func(t *testing.T) {
+		t.Parallel()
 		got := byID["malformed"]
 		if got.ProgressActivity != "" || got.ProgressAt != 0 {
 			t.Fatalf("malformed progress = %q/%d, want zero values", got.ProgressActivity, got.ProgressAt)
 		}
 	})
 	t.Run("terminal stage never carries progress", func(t *testing.T) {
+		t.Parallel()
 		got := byID["terminal"]
 		if got.ProgressActivity != "" || got.ProgressAt != 0 {
 			t.Fatalf("terminal progress = %q/%d, want zero values", got.ProgressActivity, got.ProgressAt)
@@ -463,6 +473,7 @@ func TestWebDataSourcePipelineRunProgress(t *testing.T) {
 // store maps to dashboard.ErrPipelineRunNotFound (the API layer serves 404), NOT an
 // empty 200.
 func TestWebDataSourcePipelineRunNotFound(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	ds := &webDataSource{home: home}
 
@@ -476,6 +487,7 @@ func TestWebDataSourcePipelineRunNotFound(t *testing.T) {
 // metadata-only re-add case: a hash mismatch keeps store ordering and suppresses
 // metadata, but an exact stage-ID set restores dependency edges for layout.
 func TestWebDataSourcePipelineRunSpecHashMismatchSameStageSetFallback(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	seedDiamondBlockedRun(t, home, "prun-diamond-stale", "sha256-stale-mismatch")
 
@@ -535,6 +547,7 @@ func TestWebDataSourcePipelineRunSpecHashMismatchSameStageSetFallback(t *testing
 // honest fallback: when stage membership changed, an old run gets neither current
 // metadata nor current dependency edges.
 func TestWebDataSourcePipelineRunSpecHashMismatchDifferentStageSetFallback(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	seedTestPipeline(t, store, db.Pipeline{
@@ -567,6 +580,7 @@ func TestWebDataSourcePipelineRunSpecHashMismatchDifferentStageSetFallback(t *te
 // TestWebDataSourcePipelinesDeterministic pins byte-stable output (the UI polls with
 // a change-signature skip): two calls produce identical %+v.
 func TestWebDataSourcePipelinesDeterministic(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	seedTestPipeline(t, store, db.Pipeline{Name: "beta", Repo: "acme/b", SpecYAML: diamondSpecYAML, Enabled: false, Interval: "12h"})
@@ -596,6 +610,7 @@ func TestWebDataSourcePipelinesDeterministic(t *testing.T) {
 
 // TestWebDataSourcePipelineRunDeterministic pins byte-stable run detail across calls.
 func TestWebDataSourcePipelineRunDeterministic(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	seedDiamondBlockedRun(t, home, "prun-diamond-det", "")
 
@@ -643,6 +658,7 @@ func diamondStageRows(state string) []db.PipelineRunStage {
 // pipeline that has never run: Declared is the spec DAG in spec order (every stage
 // pending, with cmd/deps merged) and Runs is a non-nil empty slice.
 func TestWebDataSourcePipelineDetailNeverRun(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	seedTestPipeline(t, store, db.Pipeline{
@@ -701,6 +717,7 @@ func TestWebDataSourcePipelineDetailNeverRun(t *testing.T) {
 }
 
 func TestWebDataSourcePipelineDetailKeysNamesOnlyAndLiveDrift(t *testing.T) {
+	t.Parallel()
 	const (
 		ownSentinel     = "own-secret-value-974"
 		sharedSentinel  = "shared-secret-value-974"
@@ -811,6 +828,7 @@ stages:
 }
 
 func TestDashboardPipelineDetailKeysHTTPShape(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	envFile := writePipelineEnvFile(t, t.TempDir(), "TOKEN=http-secret-value-974\n", 0o600)
 	raw := fmt.Sprintf("name: http-keys\nenv_file: %q\nstages:\n  - {id: deliver, cmd: echo, env_keys: [TOKEN]}\n  - {id: idle, cmd: echo}\n", envFile)
@@ -845,6 +863,7 @@ func TestDashboardPipelineDetailKeysHTTPShape(t *testing.T) {
 }
 
 func TestWebDataSourcePipelineDetailKeysFailOpenSpec(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	seedTestPipeline(t, store, db.Pipeline{Name: "broken-keys", SpecYAML: "name: [unterminated"})
@@ -866,6 +885,7 @@ func TestWebDataSourcePipelineDetailKeysFailOpenSpec(t *testing.T) {
 // stage carries its kind and (when the agent is registered) runtime, so the
 // dashboard's declared DAG can badge it (#873).
 func TestWebDataSourcePipelineDetailDeclaredAgentKind(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	specYAML := "name: mailflow\nrepo: owner/repo\nstages:\n  - {id: triage, agent: helper, action: ask, prompt: read it}\n  - {id: run, cmd: echo, needs: [triage]}\n"
@@ -895,6 +915,7 @@ func TestWebDataSourcePipelineDetailDeclaredAgentKind(t *testing.T) {
 // back newest-first, each carrying non-nil per-stage marks in spec order, with
 // run-level state/trigger/duration mapped.
 func TestWebDataSourcePipelineDetailHistory(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	realHash := pipeline.Hash([]byte(diamondSpecYAML))
@@ -952,7 +973,9 @@ func TestWebDataSourcePipelineDetailHistory(t *testing.T) {
 // shared with the run-detail path: spec order when the run's SpecHash matches the
 // current spec, and the store's stage_id fallback order on a hash mismatch.
 func TestWebDataSourcePipelineDetailMarksOrdering(t *testing.T) {
+	t.Parallel()
 	t.Run("spec order on hash match", func(t *testing.T) {
+		t.Parallel()
 		home := dashboardTestHome(t)
 		seedDiamondBlockedRun(t, home, "prun-detail-match", "")
 
@@ -982,6 +1005,7 @@ func TestWebDataSourcePipelineDetailMarksOrdering(t *testing.T) {
 	})
 
 	t.Run("stage_id fallback on hash mismatch", func(t *testing.T) {
+		t.Parallel()
 		home := dashboardTestHome(t)
 		seedDiamondBlockedRun(t, home, "prun-detail-stale", "sha256-stale-mismatch")
 
@@ -1004,6 +1028,7 @@ func TestWebDataSourcePipelineDetailMarksOrdering(t *testing.T) {
 	})
 
 	t.Run("mixed hashes in one history order per run", func(t *testing.T) {
+		t.Parallel()
 		// One history containing BOTH a current-spec run and a stale-spec run:
 		// the ordering decision must be made per run, not hoisted — the matching
 		// run keeps spec order while the stale one falls back to stage_id order
@@ -1046,6 +1071,7 @@ func TestWebDataSourcePipelineDetailMarksOrdering(t *testing.T) {
 // propagates to both the declared DAG (PipelineDetail) and a run's merged stage
 // (PipelineRun) under the hash gate, and is absent on a hash mismatch.
 func TestWebDataSourcePipelineDetailRetry(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	realHash := pipeline.Hash([]byte(retrySpecYAML))
@@ -1099,6 +1125,7 @@ func TestWebDataSourcePipelineDetailRetry(t *testing.T) {
 // stored spec gets no spec-merged metadata — Retry and Cmd stay empty. The exact
 // stage-ID set still permits the structural Deps fallback used for layout.
 func TestWebDataSourcePipelineRunRetryAbsentOnHashMismatch(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	seedTestPipeline(t, store, db.Pipeline{
@@ -1142,6 +1169,7 @@ func TestWebDataSourcePipelineRunRetryAbsentOnHashMismatch(t *testing.T) {
 // pipeline maps to dashboard.ErrPipelineNotFound (the API layer serves 404), not an
 // empty 200.
 func TestWebDataSourcePipelineDetailNotFound(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	ds := &webDataSource{home: home}
 
@@ -1154,6 +1182,7 @@ func TestWebDataSourcePipelineDetailNotFound(t *testing.T) {
 // TestWebDataSourcePipelineDetailDeterministic pins byte-stable detail output across
 // calls (the UI polls with a change-signature skip).
 func TestWebDataSourcePipelineDetailDeterministic(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store := openPipelineTestStore(t, home)
 	seedTestPipeline(t, store, db.Pipeline{

--- a/internal/cli/dashboard_web_workflow_test.go
+++ b/internal/cli/dashboard_web_workflow_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestDeriveDashboardWorkflowState(t *testing.T) {
+	t.Parallel()
 	now := time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC)
 	tests := []struct {
 		name     string
@@ -46,6 +47,7 @@ func TestDeriveDashboardWorkflowState(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			state, stalled := deriveDashboardWorkflowState(now, test.activity)
 			if state != test.state || stalled != test.stalled {
 				t.Fatalf("derive = (%q, %d), want (%q, %d)", state, stalled, test.state, test.stalled)
@@ -55,6 +57,7 @@ func TestDeriveDashboardWorkflowState(t *testing.T) {
 }
 
 func TestDashboardWorkflowIndexLessStateOrder(t *testing.T) {
+	t.Parallel()
 	active := dashboard.WorkflowIndexEntry{Label: "active", State: "active"}
 	recent := dashboard.WorkflowIndexEntry{Label: "recent", State: "recent"}
 	settled := dashboard.WorkflowIndexEntry{Label: "settled", State: "settled"}
@@ -67,6 +70,7 @@ func TestDashboardWorkflowIndexLessStateOrder(t *testing.T) {
 }
 
 func TestWebDataSourceStateCarriesRootWorkflowOnly(t *testing.T) {
+	t.Parallel()
 	unlabelledHome := dashboardTestHome(t)
 	seedWebDashboardTree(t, unlabelledHome)
 	unlabelled, err := (&webDataSource{home: unlabelledHome}).State(context.Background(), "coord")
@@ -96,6 +100,7 @@ func TestWebDataSourceStateCarriesRootWorkflowOnly(t *testing.T) {
 }
 
 func TestWebDataSourceGraphWorkflowHubsRespectVisibleJobs(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store, err := db.Open(config.PathsForHome(home).Database)
 	if err != nil {
@@ -158,6 +163,7 @@ func TestWebDataSourceGraphWorkflowHubsRespectVisibleJobs(t *testing.T) {
 }
 
 func TestWebDataSourceGraphUnlabelledLegacyJSONUnchanged(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store, err := db.Open(config.PathsForHome(home).Database)
 	if err != nil {
@@ -182,6 +188,7 @@ func TestWebDataSourceGraphUnlabelledLegacyJSONUnchanged(t *testing.T) {
 }
 
 func TestWebDashboardUnlabelledLegacyHTTPGolden(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store, err := db.Open(config.PathsForHome(home).Database)
 	if err != nil {
@@ -242,6 +249,7 @@ func assertDashboardHTTPGolden(t *testing.T, handler http.Handler, target, want 
 }
 
 func TestWebDataSourceWorkflowGroupsTreesAndPaginates(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	store, err := db.Open(config.PathsForHome(home).Database)
 	if err != nil {
@@ -313,6 +321,7 @@ func TestWebDataSourceWorkflowGroupsTreesAndPaginates(t *testing.T) {
 }
 
 func TestWebDataSourceWorkflowNotFound(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	ds := &webDataSource{home: home}
 	if _, err := ds.Workflow(context.Background(), "missing", dashboard.WorkflowQuery{}); !errors.Is(err, dashboard.ErrWorkflowNotFound) {
@@ -321,6 +330,7 @@ func TestWebDataSourceWorkflowNotFound(t *testing.T) {
 }
 
 func TestWebDataSourceWorkflowsIndexLifecycleCoordinatorAndSlashDetail(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	paths := config.PathsForHome(home)
 	store, err := db.Open(paths.Database)
@@ -474,6 +484,7 @@ func TestWebDataSourceWorkflowsIndexLifecycleCoordinatorAndSlashDetail(t *testin
 }
 
 func TestDashboardWorkflowDaemonNotesDoNotAcknowledgeFailuresOrImpersonateCoordinator(t *testing.T) {
+	t.Parallel()
 	home := dashboardTestHome(t)
 	paths := config.PathsForHome(home)
 	store, err := db.Open(paths.Database)
@@ -591,6 +602,7 @@ func workflowIndexEntryByLabel(t *testing.T, entries []dashboard.WorkflowIndexEn
 }
 
 func TestCappedWorkflowLimitDefaultsAndCaps(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name             string
 		value, cap, want int
@@ -601,6 +613,7 @@ func TestCappedWorkflowLimitDefaultsAndCaps(t *testing.T) {
 		{name: "in-range", value: 7, cap: dashboardWorkflowMaxNotes, want: 7},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			if got := cappedWorkflowLimit(tc.value, tc.cap); got != tc.want {
 				t.Fatalf("cappedWorkflowLimit(%d, %d) = %d, want %d", tc.value, tc.cap, got, tc.want)
 			}
@@ -609,6 +622,7 @@ func TestCappedWorkflowLimitDefaultsAndCaps(t *testing.T) {
 }
 
 func TestDashboardWorkflowDescriptionStatusAPI(t *testing.T) {
+	t.Parallel()
 	home, store := workflowJournalTestHome(t)
 	ctx := context.Background()
 	const label = "release/api-fields"

--- a/internal/cli/hard_verifier_test.go
+++ b/internal/cli/hard_verifier_test.go
@@ -72,6 +72,7 @@ func hardVerifierImplementPayload() workflow.JobPayload {
 // TestHardVerifierAllPassIsPass: every command exits 0 → HardPassed=true, ok=true, a
 // per-command rubric of all-1.0, tagged HardVerifier, and the sandbox is cleaned up.
 func TestHardVerifierAllPassIsPass(t *testing.T) {
+	t.Parallel()
 	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
 	runner := &fakeVerifierRunner{errByCommand: map[string]error{}} // no errors => all pass
 	d := &hardVerifierDispatcher{
@@ -106,6 +107,7 @@ func TestHardVerifierAllPassIsPass(t *testing.T) {
 // TestHardVerifierAnyFailIsFail: a SINGLE failing command (fail-closed set membership)
 // makes the whole verdict FAIL, and that command's rubric entry is 0.0.
 func TestHardVerifierAnyFailIsFail(t *testing.T) {
+	t.Parallel()
 	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
 	runner := &fakeVerifierRunner{errByCommand: map[string]error{
 		"go test ./...": errors.New("exit status 1"),
@@ -133,6 +135,7 @@ func TestHardVerifierAnyFailIsFail(t *testing.T) {
 // TestHardVerifierTimeoutIsFail: a command whose Run returns a context-deadline error
 // (the leg's bounded context cancelled it) is a FAIL, never a silent pass.
 func TestHardVerifierTimeoutIsFail(t *testing.T) {
+	t.Parallel()
 	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
 	runner := &fakeVerifierRunner{errByCommand: map[string]error{
 		"slow-suite": context.DeadlineExceeded,
@@ -155,6 +158,7 @@ func TestHardVerifierTimeoutIsFail(t *testing.T) {
 // working dir set to the SANDBOX the provisioner returned, never any other checkout.
 // This is the isolation contract the tier depends on for cheat-proofing.
 func TestHardVerifierRunsInSandboxNotRealCheckout(t *testing.T) {
+	t.Parallel()
 	const sandboxDir = "/tmp/gitmoot-hardverify-XYZ/wt"
 	prov := &fakeSandboxProvisioner{dir: sandboxDir}
 	runner := &fakeVerifierRunner{errByCommand: map[string]error{}}
@@ -179,6 +183,7 @@ func TestHardVerifierRunsInSandboxNotRealCheckout(t *testing.T) {
 // TestHardVerifierUnprovisionableSandboxSkips: a provisioner error yields ok=false (no
 // hard row) and runs NO verifier — the leg degrade-skips, never fails the merge.
 func TestHardVerifierUnprovisionableSandboxSkips(t *testing.T) {
+	t.Parallel()
 	prov := &fakeSandboxProvisioner{err: errors.New("merged head not present in base checkout")}
 	runner := &fakeVerifierRunner{errByCommand: map[string]error{}}
 	d := &hardVerifierDispatcher{
@@ -204,6 +209,7 @@ func TestHardVerifierUnprovisionableSandboxSkips(t *testing.T) {
 // negative from a setup failure (#474 false-negative hardening). A genuine exit-1 stays
 // a FAIL — see TestHardVerifierAnyFailIsFail.
 func TestHardVerifierExecLayerFailureSkips(t *testing.T) {
+	t.Parallel()
 	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
 	runner := &fakeVerifierRunner{errByCommand: map[string]error{
 		// The first command passes; the second cannot be run at all.
@@ -226,6 +232,7 @@ func TestHardVerifierExecLayerFailureSkips(t *testing.T) {
 // TestHardVerifierEmptyInputsSkip: no commands, no runner/provisioner, or an empty
 // merged head all skip (ok=false) — byte-identical no-op guards.
 func TestHardVerifierEmptyInputsSkip(t *testing.T) {
+	t.Parallel()
 	prov := &fakeSandboxProvisioner{dir: "/sandbox/wt"}
 	runner := &fakeVerifierRunner{errByCommand: map[string]error{}}
 	cases := []struct {
@@ -240,6 +247,7 @@ func TestHardVerifierEmptyInputsSkip(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			_, ok, err := tc.d.Verify(context.Background(), db.Job{ID: "j"}, hardVerifierImplementPayload(), tc.head)
 			if err != nil || ok {
 				t.Fatalf("%s: Verify = ok %v err %v, want ok=false err=nil", tc.name, ok, err)
@@ -304,6 +312,7 @@ func installHardVerifierTemplate(t *testing.T, store *db.Store) (db.AgentTemplat
 // checkout) through the REAL harvester, proving a PASS lands a choice "a" hard row
 // whose persisted hard_score is 1.0 (EvaluatorScore.Hard=1.0).
 func TestHardVerifierE2EPassFlowsIntoHardScore(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -337,6 +346,7 @@ func TestHardVerifierE2EPassFlowsIntoHardScore(t *testing.T) {
 // hard_score is 0.0 (EvaluatorScore.Hard=0.0). This is the mutation guard for the
 // exit-code mapping: if pass/fail were inverted, this row would be choice "a".
 func TestHardVerifierE2EFailFlowsIntoHardScore(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -372,6 +382,7 @@ func TestHardVerifierE2EFailFlowsIntoHardScore(t *testing.T) {
 // isolation guarantee. This is the mutation guard for the sandbox-fresh contract: if
 // the verifier ran in the base checkout, escapee.txt would appear there.
 func TestHardVerifierE2ESandboxIsolatesWrites(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -402,6 +413,7 @@ func TestHardVerifierE2ESandboxIsolatesWrites(t *testing.T) {
 // the throwaway clone and cannot escape into the live daemon checkout. A detached
 // worktree off the base (the pre-fix design) would have leaked all three.
 func TestHardVerifierE2ESandboxIsolatesGitState(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -446,6 +458,7 @@ func TestHardVerifierE2ESandboxIsolatesGitState(t *testing.T) {
 // (ok=false, no row), never map the missing-toolchain exit onto an authoritative
 // Hard=0 — the false-negative hardening (#474) proven end to end through real `sh`.
 func TestHardVerifierE2ECommandNotFoundSkips(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
@@ -514,6 +527,7 @@ func gitWorktreeRegistryEntries(t *testing.T, repoDir string) []string {
 // TestHardVerifierE2ETimeoutFailsFromRealContext drives a REAL slow command against a
 // short leg context, proving a genuine timeout (not a fake) is a FAIL.
 func TestHardVerifierE2ETimeoutFailsFromRealContext(t *testing.T) {
+	t.Parallel()
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}

--- a/internal/cli/memory_clusters_test.go
+++ b/internal/cli/memory_clusters_test.go
@@ -47,6 +47,7 @@ func clustersJSON(t *testing.T, home string) []clusterListEntry {
 // TestClustersFirstRunApplyAndList: on first run `recompute --apply` (no plan) is
 // allowed; it builds the two communities and the list surfaces them.
 func TestClustersFirstRunApplyAndList(t *testing.T) {
+	t.Parallel()
 	home, store := memoryTestHome(t)
 	dbIDs, netIDs := seedClusterCorpus(t, store)
 
@@ -89,6 +90,7 @@ func TestClustersFirstRunApplyAndList(t *testing.T) {
 // TestClustersApplyWithoutPlanRejectedWhenExist: once clusters exist, a bare
 // `--apply` (no plan) must be rejected — recompute has to go through propose.
 func TestClustersApplyWithoutPlanRejectedWhenExist(t *testing.T) {
+	t.Parallel()
 	home, store := memoryTestHome(t)
 	seedClusterCorpus(t, store)
 
@@ -109,6 +111,7 @@ func TestClustersApplyWithoutPlanRejectedWhenExist(t *testing.T) {
 // TestClustersProposeApplyStalenessAbort: a plan proposed then invalidated by a
 // new fact must abort as stale at apply.
 func TestClustersProposeApplyStalenessAbort(t *testing.T) {
+	t.Parallel()
 	home, store := memoryTestHome(t)
 	seedClusterCorpus(t, store)
 	ctx := context.Background()
@@ -146,6 +149,7 @@ func TestClustersProposeApplyStalenessAbort(t *testing.T) {
 // TestClusterRenameOverrideWinsAndSurvivesRecompute: rename sets an override that
 // wins in the list AND is carried forward across a recompute (medoid-anchored).
 func TestClusterRenameOverrideWinsAndSurvivesRecompute(t *testing.T) {
+	t.Parallel()
 	home, store := memoryTestHome(t)
 	seedClusterCorpus(t, store)
 
@@ -204,6 +208,7 @@ func TestClusterRenameOverrideWinsAndSurvivesRecompute(t *testing.T) {
 // TestClustersProposeDeterministic: two proposes over an unchanged store produce
 // the same anchor and the same cluster assignment.
 func TestClustersProposeDeterministic(t *testing.T) {
+	t.Parallel()
 	home, store := memoryTestHome(t)
 	seedClusterCorpus(t, store)
 
@@ -232,6 +237,7 @@ func TestClustersProposeDeterministic(t *testing.T) {
 // TestClustersIncrementalAttach: a newly confirmed fact attaches to the cluster of
 // its nearest neighbor.
 func TestClustersIncrementalAttach(t *testing.T) {
+	t.Parallel()
 	home, store := memoryTestHome(t)
 	dbIDs, _ := seedClusterCorpus(t, store)
 	ctx := context.Background()
@@ -266,6 +272,7 @@ func TestClustersIncrementalAttach(t *testing.T) {
 }
 
 func TestClustersListHierarchyAndAggregateCounts(t *testing.T) {
+	t.Parallel()
 	home, store := memoryTestHome(t)
 	dbIDs, netIDs := seedClusterCorpus(t, store)
 	ctx := context.Background()
@@ -307,6 +314,7 @@ func TestClustersListHierarchyAndAggregateCounts(t *testing.T) {
 }
 
 func TestClusterPlanIncludesSplitsAndDissolves(t *testing.T) {
+	t.Parallel()
 	const (
 		parentID = int64(1)
 		childAID = int64(1<<52 + 31)
@@ -339,6 +347,7 @@ func TestClusterPlanIncludesSplitsAndDissolves(t *testing.T) {
 }
 
 func TestClusterPlanDeepHierarchyCountsAndLegacyMigration(t *testing.T) {
+	t.Parallel()
 	const (
 		legacyParent = int64(1)
 		legacyA      = int64(1<<52 + 61)
@@ -384,6 +393,7 @@ func TestClusterPlanDeepHierarchyCountsAndLegacyMigration(t *testing.T) {
 }
 
 func TestClusterOwnerRenameSurvivesRegrouping(t *testing.T) {
+	t.Parallel()
 	previous := []db.MemoryCluster{
 		{ClusterID: 1, MedoidID: 7, LabelOverride: "owner-root"},
 		{ClusterID: int64(1<<51 + 77), MedoidID: 9, LabelOverride: "owner-synthetic"},
@@ -406,6 +416,7 @@ func TestClusterOwnerRenameSurvivesRegrouping(t *testing.T) {
 }
 
 func TestClustersIncrementalAttachTargetsLeaf(t *testing.T) {
+	t.Parallel()
 	home, store := memoryTestHome(t)
 	dbIDs, netIDs := seedClusterCorpus(t, store)
 	ctx := context.Background()

--- a/internal/cli/pipeline_test.go
+++ b/internal/cli/pipeline_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestPipelineAddEnabledTriggerPersistsPendingBinding(t *testing.T) {
+	t.Parallel()
 	home := t.TempDir()
 	specFile := writeSpec(t, "name: mail-flow\nrepo: owner/repo\ntrigger:\n  kind: email\nstages:\n  - {id: run, cmd: echo ok}\n")
 	var stdout, stderr bytes.Buffer
@@ -73,6 +74,7 @@ func writeSpec(t *testing.T, content string) string {
 // through Run() with an isolated home, asserting the registry round-trip and the
 // hidden-runner-agent behavior.
 func TestPipelineAddListShowEnableDisableRemove(t *testing.T) {
+	t.Parallel()
 	home := t.TempDir()
 	run := func(args ...string) (string, string, int) {
 		var stdout, stderr bytes.Buffer
@@ -145,6 +147,7 @@ func TestPipelineAddListShowEnableDisableRemove(t *testing.T) {
 }
 
 func TestPipelineDisplayMode(t *testing.T) {
+	t.Parallel()
 	triggerSpec := "name: mail\nrepo: owner/repo\ntrigger: {kind: email}\nstages:\n  - {id: run, cmd: echo}\n"
 	pipelineTriggerSpec := "name: downstream\nrepo: owner/downstream\ntrigger: {kind: pipeline, pipeline: upstream}\nstages:\n  - {id: run, cmd: echo}\n"
 	scheduledSpec := "name: nightly\nschedule: {interval: 24h}\nstages:\n  - {id: run, cmd: echo}\n"
@@ -164,6 +167,7 @@ func TestPipelineDisplayMode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := pipelineDisplayMode(tt.record); got != tt.want {
 				t.Fatalf("pipelineDisplayMode() = %q, want %q", got, tt.want)
 			}
@@ -175,6 +179,7 @@ func TestPipelineDisplayMode(t *testing.T) {
 }
 
 func TestResolvedPipelineGroup(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		record      db.Pipeline
@@ -196,6 +201,7 @@ func TestResolvedPipelineGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, defaulted := resolvedPipelineGroup(tt.record)
 			if got != tt.want || defaulted != tt.wantDefault {
 				t.Fatalf("resolvedPipelineGroup() = %q,%v, want %q,%v", got, defaulted, tt.want, tt.wantDefault)
@@ -205,6 +211,7 @@ func TestResolvedPipelineGroup(t *testing.T) {
 }
 
 func TestPipelineShowSelfDescribingStagesAndTriggerListInterval(t *testing.T) {
+	t.Parallel()
 	home := t.TempDir()
 	if err := withStore(home, func(store *db.Store) error {
 		return store.UpsertAgent(context.Background(), db.Agent{
@@ -379,6 +386,7 @@ stages:
 }
 
 func TestPipelineShowJSON(t *testing.T) {
+	t.Parallel()
 	home := t.TempDir()
 	spec := writeSpec(t, testPipelineSpec)
 	if code := Run([]string{"pipeline", "add", spec, "--home", home}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
@@ -411,6 +419,7 @@ func TestPipelineShowJSON(t *testing.T) {
 }
 
 func TestPipelineListJSON(t *testing.T) {
+	t.Parallel()
 	home := t.TempDir()
 	spec := writeSpec(t, testPipelineSpec)
 	if code := Run([]string{"pipeline", "add", spec, "--enable", "--home", home}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
@@ -435,6 +444,7 @@ func TestPipelineListJSON(t *testing.T) {
 }
 
 func TestPipelineValidationExitCodes(t *testing.T) {
+	t.Parallel()
 	home := t.TempDir()
 	run := func(args ...string) int {
 		return Run(append(args, "--home", home), &bytes.Buffer{}, &bytes.Buffer{})
@@ -465,10 +475,12 @@ func TestPipelineValidationExitCodes(t *testing.T) {
 }
 
 func TestPipelineAddTriggerCycleDetection(t *testing.T) {
+	t.Parallel()
 	triggerSpec := func(name, upstream string) string {
 		return fmt.Sprintf("name: %s\nrepo: owner/%s\ntrigger: {kind: pipeline, pipeline: %s}\nstages: [{id: run, cmd: echo}]\n", name, name, upstream)
 	}
 	t.Run("cycle rejected and dropping edge unblocks", func(t *testing.T) {
+		t.Parallel()
 		home := t.TempDir()
 		a := writeSpec(t, triggerSpec("A", "B"))
 		if code := Run([]string{"pipeline", "add", a, "--home", home}, &bytes.Buffer{}, &bytes.Buffer{}); code != 0 {
@@ -492,6 +504,7 @@ func TestPipelineAddTriggerCycleDetection(t *testing.T) {
 	})
 
 	t.Run("chain accepted", func(t *testing.T) {
+		t.Parallel()
 		home := t.TempDir()
 		for _, edge := range [][2]string{{"A", "B"}, {"B", "C"}} {
 			spec := writeSpec(t, triggerSpec(edge[0], edge[1]))
@@ -506,6 +519,7 @@ func TestPipelineAddTriggerCycleDetection(t *testing.T) {
 // TestPipelineRunnerNameCollisionRefused proves `pipeline add` refuses to clobber
 // a pre-existing non-shell agent occupying the runner name.
 func TestPipelineRunnerNameCollisionRefused(t *testing.T) {
+	t.Parallel()
 	home := t.TempDir()
 	// Pre-seed a real codex agent named like the runner would be.
 	if err := withStore(home, func(store *db.Store) error {
@@ -533,6 +547,7 @@ func TestPipelineRunnerNameCollisionRefused(t *testing.T) {
 // Reviewer-required pins: hybrid list value, multibyte-safe previews, and the
 // orchestrate/produce badges (previously untested).
 func TestPipelineListIntervalHybridKeepsInterval(t *testing.T) {
+	t.Parallel()
 	hybrid := db.Pipeline{SpecYAML: "name: both\nrepo: owner/repo\ntrigger: {kind: email}\nschedule: {interval: 6h}\nstages:\n  - {id: run, cmd: echo}\n", Interval: "6h"}
 	if got := pipelineListInterval(hybrid); got != "email+6h" {
 		t.Fatalf("hybrid list interval = %q, want %q", got, "email+6h")
@@ -551,6 +566,7 @@ func TestPipelineListIntervalHybridKeepsInterval(t *testing.T) {
 }
 
 func TestPipelinePreviewMultibyteSafe(t *testing.T) {
+	t.Parallel()
 	prompt := strings.Repeat("\u65e5\u672c\u8a9e\U0001f680", 60) // 240 runes of multibyte text
 	preview := pipelinePromptPreview(prompt)
 	if !utf8.ValidString(preview) {
@@ -577,6 +593,7 @@ func TestPipelinePreviewMultibyteSafe(t *testing.T) {
 }
 
 func TestPipelineStageBadgesOrchestrateAndProduce(t *testing.T) {
+	t.Parallel()
 	orchestrate := pipeline.Stage{ID: "coord", Agent: "lead", Action: "ask", Prompt: "run the tree", Orchestrate: true}
 	if got := pipelineStageBadge(orchestrate); !strings.Contains(got, "ORCHESTRATE") {
 		t.Fatalf("orchestrate badge = %q", got)

--- a/internal/cli/runtime_registry_test.go
+++ b/internal/cli/runtime_registry_test.go
@@ -26,6 +26,7 @@ func writeCLIConfig(t *testing.T, body string) config.Paths {
 // TestResolveRuntimeRegistryDefaultByteIdentical proves that with no [runtimes.*]
 // section the resolved registry equals the built-in one.
 func TestResolveRuntimeRegistryDefaultByteIdentical(t *testing.T) {
+	t.Parallel()
 	paths := writeCLIConfig(t, "[paths]\ndatabase = \"x\"\n")
 	got, err := resolveRuntimeRegistry(paths)
 	if err != nil {
@@ -39,6 +40,7 @@ func TestResolveRuntimeRegistryDefaultByteIdentical(t *testing.T) {
 // TestResolveRuntimeRegistryMissingFile proves a missing config file resolves to
 // the built-in registry rather than erroring.
 func TestResolveRuntimeRegistryMissingFile(t *testing.T) {
+	t.Parallel()
 	paths := config.Paths{ConfigFile: filepath.Join(t.TempDir(), "nope.toml")}
 	got, err := resolveRuntimeRegistry(paths)
 	if err != nil {
@@ -52,6 +54,7 @@ func TestResolveRuntimeRegistryMissingFile(t *testing.T) {
 // TestResolveRuntimeRegistryOverride proves config overrides are applied on top of
 // the built-ins.
 func TestResolveRuntimeRegistryOverride(t *testing.T) {
+	t.Parallel()
 	paths := writeCLIConfig(t, `
 [runtimes.codex]
 default_model = "gpt-5.5-codex"
@@ -80,6 +83,7 @@ models = ["gpt-5.5-codex"]
 // TestResolveRuntimeRegistryUnknownErrors proves an unknown runtime name in config
 // surfaces the moat-preserving error.
 func TestResolveRuntimeRegistryUnknownErrors(t *testing.T) {
+	t.Parallel()
 	paths := writeCLIConfig(t, "[runtimes.gpt6]\ndefault_model = \"x\"\n")
 	if _, err := resolveRuntimeRegistry(paths); err == nil {
 		t.Fatal("expected error for unknown runtime")
@@ -88,6 +92,7 @@ func TestResolveRuntimeRegistryUnknownErrors(t *testing.T) {
 
 // TestRunRuntimeListText covers the human table output on the default registry.
 func TestRunRuntimeListText(t *testing.T) {
+	t.Parallel()
 	paths := writeCLIConfig(t, "[paths]\ndatabase = \"x\"\n")
 	var stdout, stderr bytes.Buffer
 	code := runRuntimeList([]string{"--home", homeFromConfig(t, paths)}, &stdout, &stderr)
@@ -107,6 +112,7 @@ func TestRunRuntimeListText(t *testing.T) {
 
 // TestRunRuntimeListJSON covers the JSON output shape.
 func TestRunRuntimeListJSON(t *testing.T) {
+	t.Parallel()
 	paths := writeCLIConfig(t, "[runtimes.codex]\ndefault_effort = \"high\"\n")
 	var stdout, stderr bytes.Buffer
 	code := runRuntimeList([]string{"--home", homeFromConfig(t, paths), "--json"}, &stdout, &stderr)
@@ -131,6 +137,7 @@ func TestRunRuntimeListJSON(t *testing.T) {
 // TestRunRuntimeListUnknownRuntimeExits proves the command exits non-zero on a bad
 // override.
 func TestRunRuntimeListUnknownRuntimeExits(t *testing.T) {
+	t.Parallel()
 	paths := writeCLIConfig(t, "[runtimes.gpt6]\ndefault_model = \"x\"\n")
 	var stdout, stderr bytes.Buffer
 	code := runRuntimeList([]string{"--home", homeFromConfig(t, paths)}, &stdout, &stderr)
@@ -146,6 +153,7 @@ func TestRunRuntimeListUnknownRuntimeExits(t *testing.T) {
 // (#652) returns the configured [runtimes.<rt>].default_model for a runtime, and
 // resolves NOTHING (byte-identical) for a runtime with no override.
 func TestRuntimeDefaultModelResolverReadsConfig(t *testing.T) {
+	t.Parallel()
 	src := writeCLIConfig(t, "[runtimes.codex]\ndefault_model = \"gpt-5.5\"\n")
 	home := homeFromConfig(t, src)
 	resolve := runtimeDefaultModelResolver(home)
@@ -159,6 +167,7 @@ func TestRuntimeDefaultModelResolverReadsConfig(t *testing.T) {
 }
 
 func TestRuntimeDefaultEffortResolverReadsConfig(t *testing.T) {
+	t.Parallel()
 	src := writeCLIConfig(t, "[runtimes.codex]\ndefault_effort = \"high\"\n")
 	home := homeFromConfig(t, src)
 	resolve := runtimeDefaultEffortResolver(home)
@@ -171,6 +180,7 @@ func TestRuntimeDefaultEffortResolverReadsConfig(t *testing.T) {
 }
 
 func TestRuntimeDefaultEffortResolverAbsentConfig(t *testing.T) {
+	t.Parallel()
 	if got := runtimeDefaultEffortResolver(t.TempDir())(runtime.CodexRuntime); got != "" {
 		t.Fatalf("missing-config resolve(codex) = %q, want empty", got)
 	}
@@ -183,6 +193,7 @@ func TestRuntimeDefaultEffortResolverAbsentConfig(t *testing.T) {
 // contract: with no config file (fresh box), an empty home, or an unknown runtime,
 // the hook resolves "" so delivery forces no model — byte-identical to before #652.
 func TestRuntimeDefaultModelResolverAbsentConfigByteIdentical(t *testing.T) {
+	t.Parallel()
 	missingHome := t.TempDir() // no config.toml written anywhere under it
 	if got := runtimeDefaultModelResolver(missingHome)(runtime.CodexRuntime); got != "" {
 		t.Fatalf("missing-config resolve(codex) = %q, want empty", got)
@@ -202,6 +213,7 @@ func TestRuntimeDefaultModelResolverAbsentConfigByteIdentical(t *testing.T) {
 // codex override — a single bad section is skipped, not a whole-config failure that
 // silently drops every valid override at delivery.
 func TestRuntimeDefaultModelResolverSkipsBadSection(t *testing.T) {
+	t.Parallel()
 	src := writeCLIConfig(t, `
 [runtimes.codex]
 default_model = "gpt-5.5"
@@ -226,6 +238,7 @@ default_model = "typo-runtime"
 // would reject it, but the delivery resolver skips only that section and keeps a
 // valid sibling's default_model.
 func TestRuntimeDefaultModelResolverSkipsBadCapabilitySection(t *testing.T) {
+	t.Parallel()
 	src := writeCLIConfig(t, `
 [runtimes.codex]
 default_model = "gpt-5.5"

--- a/internal/cli/tui/agents_test.go
+++ b/internal/cli/tui/agents_test.go
@@ -40,6 +40,7 @@ func agentsModel(t *testing.T, deps Deps, snap Snapshot) Model {
 // agent's whole template group, surfaces the active-job skip heads-up, calls
 // DeleteAgents with the group's names, and reports the deleted/skipped result.
 func TestAgentGroupDeleteFlow(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	snap.Agents = append(snap.Agents, Agent{Name: "planner-2", Runtime: "claude", TemplateID: "planner-tpl"})
 	snap.JobRows = append(snap.JobRows, JobRow{ID: "jx", Agent: "planner", Type: "ask", State: "running"})
@@ -84,6 +85,7 @@ func TestAgentGroupDeleteFlow(t *testing.T) {
 // template-less agent opens the single-agent delete (not a bulk delete of the
 // whole heterogeneous "Standalone agents" catch-all).
 func TestAgentGroupDeleteStandaloneFallsBackToSingle(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	snap.Agents = append(snap.Agents, Agent{Name: "drifter", Runtime: "codex"}) // TemplateID ""
 	called := false
@@ -110,6 +112,7 @@ func TestAgentGroupDeleteStandaloneFallsBackToSingle(t *testing.T) {
 // still closes the overlay, reports the committed deletes, and surfaces the error
 // (so the stale list/retry-wedge can't happen).
 func TestAgentGroupDeletePartialErrorReported(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	snap.Agents = append(snap.Agents, Agent{Name: "planner-2", Runtime: "claude", TemplateID: "planner-tpl"})
 	deps := Deps{DeleteAgents: func(names []string) (int, []string, error) {
@@ -135,6 +138,7 @@ func TestAgentGroupDeletePartialErrorReported(t *testing.T) {
 
 // TestAgentGroupDeleteNoDepInert verifies X is inert without a DeleteAgents dep.
 func TestAgentGroupDeleteNoDepInert(t *testing.T) {
+	t.Parallel()
 	m := agentsModel(t, Deps{}, agentsSnapshot())
 	next, _ := m.Update(key("X"))
 	m = next.(Model)
@@ -147,6 +151,7 @@ func TestAgentGroupDeleteNoDepInert(t *testing.T) {
 // showing many training agents) windows around the cursor so the selection stays
 // visible and the scroll markers appear — rather than overflowing unscrollably.
 func TestAgentsListWindowsLongList(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{Daemon: Daemon{Running: true}}
 	for i := 0; i < 80; i++ {
 		snap.Agents = append(snap.Agents, Agent{
@@ -190,6 +195,7 @@ func TestAgentsListWindowsLongList(t *testing.T) {
 // many live sessions belong to hidden training agents (so the LIVE column isn't
 // silently empty when all live work is under hidden agents).
 func TestAgentsHiddenLineShowsLiveCount(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	snap.Agents = append(snap.Agents, Agent{Name: "skillopt-generator", Runtime: "codex"})
 	snap.Sessions = []Session{
@@ -209,6 +215,7 @@ func TestAgentsHiddenLineShowsLiveCount(t *testing.T) {
 // TestAgentsShowAllToggle verifies the 'a' key un-hides the training agents (and
 // hides them again), and that their LIVE counts then appear.
 func TestAgentsShowAllToggle(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	snap.Agents = append(snap.Agents, Agent{Name: "skillopt-generator", Runtime: "codex"})
 	snap.Sessions = []Session{
@@ -237,6 +244,7 @@ func TestAgentsShowAllToggle(t *testing.T) {
 }
 
 func TestAgentsPageHidesTrainingAgents(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	// Add internal training plumbing alongside the real agents.
 	snap.Agents = append(snap.Agents,
@@ -280,6 +288,7 @@ func TestAgentsPageHidesTrainingAgents(t *testing.T) {
 // Ephemeral agents are not training plumbing, so they must not be folded into
 // the "training agents hidden (skillopt-*)" count line.
 func TestAgentsPageHidesEphemeralAgents(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	snap.Agents = append(snap.Agents,
 		Agent{Name: "fixit-ephemeral-abc", Runtime: "claude", TemplateID: "planner-tpl"},
@@ -322,6 +331,7 @@ func TestAgentsPageHidesEphemeralAgents(t *testing.T) {
 }
 
 func TestAgentsPageGroupsByTemplate(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	// A second agent on planner-tpl (stays in the planner-tpl group) and one
 	// with no template (its own "Standalone agents (custom prompt)" group).
@@ -370,6 +380,7 @@ func TestAgentsPageGroupsByTemplate(t *testing.T) {
 // carries a "temp:" prefix) and that the agent list shows the per-agent live
 // count, while another agent's sessions don't leak.
 func TestAgentDetailShowsLiveSessions(t *testing.T) {
+	t.Parallel()
 	snap := agentsSnapshot()
 	snap.Sessions = []Session{
 		{Name: "claude-bg-9f2", Type: "planner", Runtime: "claude", Repo: "o/r", State: "running", Expires: "2026-06-18T10:09:00Z"},
@@ -405,6 +416,7 @@ func TestAgentDetailShowsLiveSessions(t *testing.T) {
 
 // TestAgentDetailNoLiveSessions shows the empty state when an agent has none.
 func TestAgentDetailNoLiveSessions(t *testing.T) {
+	t.Parallel()
 	m := agentsModel(t, Deps{}, agentsSnapshot()) // snapshot has no Sessions
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = next.(Model)
@@ -423,6 +435,7 @@ func TestAgentDetailNoLiveSessions(t *testing.T) {
 }
 
 func TestAgentDetailRendersVersionsAndJobs(t *testing.T) {
+	t.Parallel()
 	var asked string
 	deps := Deps{TemplateVersions: func(templateID string) ([]TemplateVersion, error) {
 		asked = templateID
@@ -482,6 +495,7 @@ func openAgentVersionDetail(t *testing.T, deps Deps) Model {
 }
 
 func TestAgentVersionPreviewLoadsAndRenders(t *testing.T) {
+	t.Parallel()
 	var asked string
 	deps := Deps{TemplateVersionContent: func(versionID string) (string, error) {
 		asked = versionID
@@ -517,6 +531,7 @@ func TestAgentVersionPreviewLoadsAndRenders(t *testing.T) {
 // are selectable; enter on one opens its job detail, and esc returns to the agent
 // detail (not the agents list).
 func TestAgentDetailRecentJobOpensAndReturns(t *testing.T) {
+	t.Parallel()
 	deps := Deps{TemplateVersions: func(string) ([]TemplateVersion, error) { return nil, nil }}
 	m := agentsModel(t, deps, agentsSnapshot()) // cursor 0 = planner (has job-1)
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -547,6 +562,7 @@ func TestAgentDetailRecentJobOpensAndReturns(t *testing.T) {
 // land back on the job detail (and then the agent detail) rather than dropping
 // to the agents list.
 func TestAgentDetailJobActionsReturnToDetail(t *testing.T) {
+	t.Parallel()
 	retried := ""
 	deps := Deps{
 		TemplateVersions: func(string) ([]TemplateVersion, error) { return nil, nil },
@@ -640,6 +656,7 @@ func TestAgentDetailJobActionsReturnToDetail(t *testing.T) {
 // leak: scrolling a job opened from the agent detail and pressing esc must land
 // the agent detail back at the top (showing its header), not stuck scrolled.
 func TestAgentDetailScrollResetsOnReturn(t *testing.T) {
+	t.Parallel()
 	// Many versions make the agent detail tall enough that a stale scroll offset
 	// would NOT be auto-clamped to zero on return — so this fails without the fix.
 	versions := make([]TemplateVersion, 30)
@@ -687,6 +704,7 @@ func TestAgentDetailScrollResetsOnReturn(t *testing.T) {
 // TestAgentDetailRecentJobsWindow guards that a busy agent's recent-jobs list
 // windows around the cursor so the detail stays scrollable.
 func TestAgentDetailRecentJobsWindow(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{Daemon: Daemon{Running: true}, Agents: []Agent{{Name: "busy", Runtime: "codex"}}}
 	for i := 0; i < 40; i++ {
 		snap.JobRows = append(snap.JobRows, JobRow{ID: "j-" + strconv.Itoa(i), Agent: "busy", Type: "ask", State: "succeeded"})
@@ -719,6 +737,7 @@ func TestAgentDetailRecentJobsWindow(t *testing.T) {
 }
 
 func TestAgentVersionPreviewEmptyContent(t *testing.T) {
+	t.Parallel()
 	deps := Deps{TemplateVersionContent: func(string) (string, error) { return "   \n", nil }}
 	m := openAgentVersionDetail(t, deps)
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -731,6 +750,7 @@ func TestAgentVersionPreviewEmptyContent(t *testing.T) {
 }
 
 func TestAgentVersionPreviewCachesPerVersion(t *testing.T) {
+	t.Parallel()
 	calls := map[string]int{}
 	deps := Deps{TemplateVersionContent: func(versionID string) (string, error) {
 		calls[versionID]++
@@ -768,6 +788,7 @@ func TestAgentVersionPreviewCachesPerVersion(t *testing.T) {
 }
 
 func TestAgentSwitchRuntimeFlow(t *testing.T) {
+	t.Parallel()
 	var got []string
 	deps := Deps{SetAgentRuntime: func(name, runtime string) error {
 		got = []string{name, runtime}
@@ -802,6 +823,7 @@ func TestAgentSwitchRuntimeFlow(t *testing.T) {
 }
 
 func TestAgentSwitchRuntimeNoChangeCloses(t *testing.T) {
+	t.Parallel()
 	deps := Deps{SetAgentRuntime: func(string, string) error {
 		t.Fatal("picking the current runtime must not call SetAgentRuntime")
 		return nil
@@ -821,6 +843,7 @@ func TestAgentSwitchRuntimeNoChangeCloses(t *testing.T) {
 }
 
 func TestAgentSwitchRuntimeErrorStaysOpen(t *testing.T) {
+	t.Parallel()
 	deps := Deps{SetAgentRuntime: func(string, string) error {
 		return errors.New("unknown runtime")
 	}}
@@ -842,6 +865,7 @@ func TestAgentSwitchRuntimeErrorStaysOpen(t *testing.T) {
 }
 
 func TestAgentCustomPromptRoutesToEditor(t *testing.T) {
+	t.Parallel()
 	var seededWith string
 	var createdPlain bool
 	deps := Deps{
@@ -874,6 +898,7 @@ func TestAgentCustomPromptRoutesToEditor(t *testing.T) {
 }
 
 func TestAgentCustomPromptCreatesFromContent(t *testing.T) {
+	t.Parallel()
 	var got []string
 	deps := Deps{
 		EditAgentPrompt: func(string) tea.Cmd {
@@ -905,6 +930,7 @@ func TestAgentCustomPromptCreatesFromContent(t *testing.T) {
 }
 
 func TestAgentCustomPromptWarnsWithoutContract(t *testing.T) {
+	t.Parallel()
 	created := false
 	deps := Deps{
 		EditAgentPrompt: func(string) tea.Cmd {
@@ -934,6 +960,7 @@ func TestAgentCustomPromptWarnsWithoutContract(t *testing.T) {
 }
 
 func TestAgentCustomPromptEditorErrorSurfaces(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		EditAgentPrompt: func(string) tea.Cmd {
 			return func() tea.Msg { return AgentPromptEditedMsg{Err: errors.New("editor blew up")} }
@@ -956,6 +983,7 @@ func TestAgentCustomPromptEditorErrorSurfaces(t *testing.T) {
 }
 
 func TestAgentCreateFlowRunsCreateAgent(t *testing.T) {
+	t.Parallel()
 	var created []string
 	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
 	deps := Deps{
@@ -990,6 +1018,7 @@ func TestAgentCreateFlowRunsCreateAgent(t *testing.T) {
 }
 
 func TestAgentCreateAbortedFormDoesNothing(t *testing.T) {
+	t.Parallel()
 	deps := Deps{CreateAgent: func(name, runtime, template string) error {
 		t.Fatal("aborted form must not create")
 		return nil
@@ -1009,6 +1038,7 @@ func TestAgentCreateAbortedFormDoesNothing(t *testing.T) {
 }
 
 func TestAgentCreateErrorRendersInline(t *testing.T) {
+	t.Parallel()
 	deps := Deps{CreateAgent: func(name, runtime, template string) error {
 		return errors.New("agent name already registered")
 	}}
@@ -1023,6 +1053,7 @@ func TestAgentCreateErrorRendersInline(t *testing.T) {
 }
 
 func TestAgentDeleteGuardKeepsConfirmOpen(t *testing.T) {
+	t.Parallel()
 	deps := Deps{DeleteAgent: func(name string) error {
 		return errors.New("agent planner has queued or running jobs")
 	}}
@@ -1045,6 +1076,7 @@ func TestAgentDeleteGuardKeepsConfirmOpen(t *testing.T) {
 }
 
 func TestAgentDeleteSuccess(t *testing.T) {
+	t.Parallel()
 	var deleted string
 	deps := Deps{DeleteAgent: func(name string) error { deleted = name; return nil }}
 	m := agentsModel(t, deps, agentsSnapshot())
@@ -1065,6 +1097,7 @@ func TestAgentDeleteSuccess(t *testing.T) {
 }
 
 func TestAgentRevertPicksSupersededVersion(t *testing.T) {
+	t.Parallel()
 	var gotTemplate, gotVersion string
 	deps := Deps{
 		TemplateVersions: func(templateID string) ([]TemplateVersion, error) {
@@ -1110,6 +1143,7 @@ func TestAgentRevertPicksSupersededVersion(t *testing.T) {
 }
 
 func TestAgentRevertUnavailableWithoutSuperseded(t *testing.T) {
+	t.Parallel()
 	deps := Deps{TemplateVersions: func(templateID string) ([]TemplateVersion, error) {
 		return []TemplateVersion{{ID: "v1-id", Number: 1, State: "current"}}, nil
 	}}
@@ -1126,6 +1160,7 @@ func TestAgentRevertUnavailableWithoutSuperseded(t *testing.T) {
 }
 
 func TestAgentOptimizeFlowOpensPhaseView(t *testing.T) {
+	t.Parallel()
 	var startedTemplate string
 	var startedValues map[string]string
 	pushedTrain := ""
@@ -1199,6 +1234,7 @@ func TestAgentOptimizeFlowOpensPhaseView(t *testing.T) {
 }
 
 func TestAgentOptimizeErrorRendersInline(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		StartOptimize: func(templateID string, values map[string]string) (string, error) {
 			return "", errors.New("train start failed: no items")
@@ -1215,6 +1251,7 @@ func TestAgentOptimizeErrorRendersInline(t *testing.T) {
 }
 
 func TestAgentOptimizeAbortedFormDoesNothing(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		StartOptimize: func(templateID string, values map[string]string) (string, error) {
 			t.Fatal("aborted form must not start a session")
@@ -1230,6 +1267,7 @@ func TestAgentOptimizeAbortedFormDoesNothing(t *testing.T) {
 }
 
 func TestAgentCreateFormCompletionPopsWithResult(t *testing.T) {
+	t.Parallel()
 	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
 	var model tea.Model = form
 	step := func(msg tea.Msg) tea.Cmd {
@@ -1270,6 +1308,7 @@ func TestAgentCreateFormCompletionPopsWithResult(t *testing.T) {
 }
 
 func TestAgentCreateFormExternalFinishPopsNotQuits(t *testing.T) {
+	t.Parallel()
 	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
 	var model tea.Model = form
 	step := func(msg tea.Msg) tea.Cmd {
@@ -1321,6 +1360,7 @@ func TestAgentCreateFormExternalFinishPopsNotQuits(t *testing.T) {
 }
 
 func TestAgentCreateFormAbortPopsAborted(t *testing.T) {
+	t.Parallel()
 	form := NewAgentCreateForm(newFakeStore(), []Choice{{Value: "planner-tpl", Label: "planner"}})
 	next, _ := form.Update(initMsg{})
 	next, cmd := next.Update(tea.KeyMsg{Type: tea.KeyEsc})

--- a/internal/cli/tui/attention_test.go
+++ b/internal/cli/tui/attention_test.go
@@ -36,6 +36,7 @@ func attentionModel(t *testing.T, deps Deps, snap Snapshot) Model {
 func key(s string) tea.KeyMsg { return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)} }
 
 func TestAnswerChoiceHappyPath(t *testing.T) {
+	t.Parallel()
 	var gotID, gotVal string
 	deps := Deps{
 		Load:   func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
@@ -71,6 +72,7 @@ func TestAnswerChoiceHappyPath(t *testing.T) {
 }
 
 func TestAnswerTextHappyPath(t *testing.T) {
+	t.Parallel()
 	var gotVal string
 	deps := Deps{
 		Load:   func() (Snapshot, error) { return promptSnap(textPrompt()), nil },
@@ -101,6 +103,7 @@ func TestAnswerTextHappyPath(t *testing.T) {
 }
 
 func TestAnswerInvalidKeepsOverlay(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		Load:   func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
 		Answer: func(id, value string) error { return errors.New("value \"drop\" is not one of the choices") },
@@ -125,6 +128,7 @@ func TestAnswerInvalidKeepsOverlay(t *testing.T) {
 }
 
 func TestAnswerCancelDoesNotMutate(t *testing.T) {
+	t.Parallel()
 	called := false
 	deps := Deps{
 		Load:   func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
@@ -145,6 +149,7 @@ func TestAnswerCancelDoesNotMutate(t *testing.T) {
 }
 
 func TestAnswerDoubleSubmitSuppressed(t *testing.T) {
+	t.Parallel()
 	count := 0
 	deps := Deps{
 		Load:   func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
@@ -175,6 +180,7 @@ func TestAnswerDoubleSubmitSuppressed(t *testing.T) {
 // PreflightFailed flag must still surface it on the Attention page (with its
 // reason), or the zero-child fan-out this issue set out to fix stays invisible.
 func TestAttentionSurfacesPreflightFailedCoordinator(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
@@ -210,6 +216,7 @@ func TestAttentionSurfacesPreflightFailedCoordinator(t *testing.T) {
 }
 
 func TestAttentionGroupsUnderSectionHeaders(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	snap := Snapshot{
 		Daemon:  Daemon{Running: true},
@@ -268,6 +275,7 @@ func TestAttentionGroupsUnderSectionHeaders(t *testing.T) {
 }
 
 func TestAttentionHeadersDoNotShiftCursor(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	snap := Snapshot{
 		Daemon:  Daemon{Running: true},
@@ -299,6 +307,7 @@ func TestAttentionHeadersDoNotShiftCursor(t *testing.T) {
 }
 
 func TestAttentionLocksOnlyNoNeedsAttentionItems(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	snap := Snapshot{
 		Daemon:        Daemon{Running: true},
@@ -319,6 +328,7 @@ func TestAttentionLocksOnlyNoNeedsAttentionItems(t *testing.T) {
 // at awaiting_human renders under an "Awaiting human" section with the resume
 // hint, even when there are no actionable prompts/jobs.
 func TestAttentionShowsAwaitingHuman(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	snap := Snapshot{
 		Daemon:        Daemon{Running: true},
@@ -341,6 +351,7 @@ func TestAttentionShowsAwaitingHuman(t *testing.T) {
 // renders on the Attention page next to AwaitingHumanTask, with its version id,
 // template id, score, and the decide hint; zero candidates renders unchanged.
 func TestAttentionShowsPendingCandidates(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	snap := Snapshot{
 		Daemon:            Daemon{Running: true},
@@ -362,6 +373,7 @@ func TestAttentionShowsPendingCandidates(t *testing.T) {
 }
 
 func TestAttentionCursorClampedOnRefresh(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	m := attentionModel(t, deps, promptSnap(choicePrompt(), textPrompt()))
 	// Move cursor to the second prompt.
@@ -385,6 +397,7 @@ func TestAttentionCursorClampedOnRefresh(t *testing.T) {
 // repo sub-headers, with same-repo jobs contiguous, and the cursor walking them
 // in that display order.
 func TestAttentionGroupsJobsByRepo(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
@@ -423,6 +436,7 @@ func TestAttentionGroupsJobsByRepo(t *testing.T) {
 // TestAttentionCollapseJobRepo verifies a job repo group folds with space and
 // re-expands, while prompts and other repos stay put.
 func TestAttentionCollapseJobRepo(t *testing.T) {
+	t.Parallel()
 	deps := Deps{Load: func() (Snapshot, error) { return Snapshot{}, nil }}
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},

--- a/internal/cli/tui/config_test.go
+++ b/internal/cli/tui/config_test.go
@@ -46,6 +46,7 @@ func configModel(t *testing.T, deps Deps, snap Snapshot) Model {
 }
 
 func TestConfigPageRendersSections(t *testing.T) {
+	t.Parallel()
 	m := configModel(t, Deps{}, configSnapshot())
 	view := m.View()
 	for _, want := range []string{
@@ -65,6 +66,7 @@ func TestConfigPageRendersSections(t *testing.T) {
 // render grouped under their section sub-headers (in section order) while the
 // cursor still indexes the flat field order across sections.
 func TestConfigEditableSettingsGroupedBySection(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Config: ConfigView{
@@ -118,6 +120,7 @@ func TestConfigEditableSettingsGroupedBySection(t *testing.T) {
 // a 3-part KeyPath (e.g. per agent type) sub-group under the entity name, with the
 // redundant "<entity> · " prefix dropped from the field label.
 func TestConfigEditableSettingsSubgroupedByEntity(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Config: ConfigView{
@@ -157,6 +160,7 @@ func TestConfigEditableSettingsSubgroupedByEntity(t *testing.T) {
 }
 
 func TestConfigEditDispatchesEditorCmd(t *testing.T) {
+	t.Parallel()
 	edited := false
 	deps := Deps{
 		EditConfig: func() tea.Cmd {
@@ -180,6 +184,7 @@ func TestConfigEditDispatchesEditorCmd(t *testing.T) {
 }
 
 func TestConfigEditValidationProblemsRender(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		EditConfig:     func() tea.Cmd { return func() tea.Msg { return ConfigEditedMsg{} } },
 		ValidateConfig: func() []string { return []string{"[agents.*] max_background must be an integer"} },
@@ -196,6 +201,7 @@ func TestConfigEditValidationProblemsRender(t *testing.T) {
 }
 
 func TestConfigEditorLaunchErrorRenders(t *testing.T) {
+	t.Parallel()
 	m := configModel(t, Deps{EditConfig: func() tea.Cmd { return nil }}, configSnapshot())
 	next, _ := m.Update(ConfigEditedMsg{Err: errors.New("editor: command not found")})
 	m = next.(Model)
@@ -205,6 +211,7 @@ func TestConfigEditorLaunchErrorRenders(t *testing.T) {
 }
 
 func TestConfigEditNoOpWithoutDep(t *testing.T) {
+	t.Parallel()
 	m := configModel(t, Deps{}, configSnapshot())
 	next, cmd := m.Update(key("e"))
 	m = next.(Model)
@@ -251,6 +258,7 @@ func configEditModel(t *testing.T, deps Deps) Model {
 }
 
 func TestConfigInlineEditWritesScalar(t *testing.T) {
+	t.Parallel()
 	var gotPath []string
 	var gotValue string
 	deps := Deps{SetConfigScalar: func(keyPath []string, value string, kind ConfigKind) error {
@@ -284,6 +292,7 @@ func TestConfigInlineEditWritesScalar(t *testing.T) {
 }
 
 func TestConfigInlineEditValidatesBeforeWrite(t *testing.T) {
+	t.Parallel()
 	deps := Deps{SetConfigScalar: func(keyPath []string, value string, kind ConfigKind) error {
 		t.Fatal("must not write an invalid value")
 		return nil
@@ -308,6 +317,7 @@ func TestConfigInlineEditValidatesBeforeWrite(t *testing.T) {
 }
 
 func TestConfigInlineEditWriteErrorKeepsOverlay(t *testing.T) {
+	t.Parallel()
 	deps := Deps{SetConfigScalar: func(keyPath []string, value string, kind ConfigKind) error {
 		return errors.New("config invalid after edit (reverted)")
 	}}
@@ -324,6 +334,7 @@ func TestConfigInlineEditWriteErrorKeepsOverlay(t *testing.T) {
 }
 
 func TestConfigDurationFieldValidation(t *testing.T) {
+	t.Parallel()
 	if validateConfigValue(ConfigField{Kind: ConfigDuration}, "10m") != "" {
 		t.Fatal("10m should be a valid duration")
 	}
@@ -336,6 +347,7 @@ func TestConfigDurationFieldValidation(t *testing.T) {
 }
 
 func TestConfigEnumAndListValidation(t *testing.T) {
+	t.Parallel()
 	enum := ConfigField{Kind: ConfigText, Allowed: []string{"queue", "fork_temp_session"}}
 	if validateConfigValue(enum, "queue") != "" {
 		t.Fatal("queue should be allowed")

--- a/internal/cli/tui/dismiss_train_test.go
+++ b/internal/cli/tui/dismiss_train_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestDismissConfirmYes(t *testing.T) {
+	t.Parallel()
 	var dismissed string
 	deps := Deps{
 		Load:    func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
@@ -39,6 +40,7 @@ func TestDismissConfirmYes(t *testing.T) {
 }
 
 func TestDismissConfirmCancel(t *testing.T) {
+	t.Parallel()
 	called := false
 	deps := Deps{
 		Load:    func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
@@ -60,6 +62,7 @@ func TestDismissConfirmCancel(t *testing.T) {
 }
 
 func TestDismissNotFoundTreatedAsSuccess(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		Load: func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
 		Dismiss: func(id string) error {
@@ -83,6 +86,7 @@ func TestDismissNotFoundTreatedAsSuccess(t *testing.T) {
 }
 
 func TestDismissRealErrorKeepsOverlay(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		Load:    func() (Snapshot, error) { return promptSnap(choicePrompt()), nil },
 		Dismiss: func(id string) error { return errors.New("database is locked") },
@@ -126,6 +130,7 @@ func trainsModel(t *testing.T) Model {
 }
 
 func TestTrainDetailShowsSessionLocksOnly(t *testing.T) {
+	t.Parallel()
 	m := trainsModel(t)
 	if pages[m.selected].page != pageTrains {
 		t.Fatalf("expected to be on the Trains page")
@@ -152,6 +157,7 @@ func TestTrainDetailShowsSessionLocksOnly(t *testing.T) {
 }
 
 func TestTrainLocksMatchWholeSegmentNotPrefix(t *testing.T) {
+	t.Parallel()
 	locks := []ResourceLock{
 		{Key: "generation:train-a"},
 		{Key: "generation:train-aaa"},
@@ -169,6 +175,7 @@ func TestTrainLocksMatchWholeSegmentNotPrefix(t *testing.T) {
 }
 
 func TestTrainCursorClampedOnRefresh(t *testing.T) {
+	t.Parallel()
 	m := trainsModel(t)
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	m = next.(Model)
@@ -183,6 +190,7 @@ func TestTrainCursorClampedOnRefresh(t *testing.T) {
 }
 
 func TestTrainStatusCategory(t *testing.T) {
+	t.Parallel()
 	cases := map[string]int{
 		"request_confirmed":                trainCatActive,
 		"items_ready":                      trainCatActive,
@@ -208,6 +216,7 @@ func TestTrainStatusCategory(t *testing.T) {
 }
 
 func TestTrainLineageBase(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		id       string
 		wantBase string
@@ -232,6 +241,7 @@ func TestTrainLineageBase(t *testing.T) {
 // TestTrainsListGroupsAndCollapses renders a mixed list and asserts the section
 // headers, the collapsed lineage parent line, and that flat sessions stay flat.
 func TestTrainsListGroupsAndCollapses(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Trains: []TrainSession{
@@ -286,6 +296,7 @@ func TestTrainsListGroupsAndCollapses(t *testing.T) {
 // is selected first because the Active section renders before Done, so ↑/↓ always
 // move the highlight to the visually adjacent row.
 func TestTrainCursorFollowsDisplayOrder(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Trains: []TrainSession{
@@ -317,6 +328,7 @@ func TestTrainCursorFollowsDisplayOrder(t *testing.T) {
 // sessions are sub-grouped by repo (first-appearance order) with lineage
 // collapse inside each repo, and the cursor follows that display order.
 func TestTrainsGroupByRepoWithinSection(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Trains: []TrainSession{
@@ -355,6 +367,7 @@ func TestTrainsGroupByRepoWithinSection(t *testing.T) {
 // group (hiding its sessions and showing a [+] header) and that the collapsed
 // header is selectable so space re-expands it.
 func TestTrainsCollapseRepoFoldsSessions(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Trains: []TrainSession{
@@ -391,6 +404,7 @@ func TestTrainsCollapseRepoFoldsSessions(t *testing.T) {
 // TestTrainsCollapsedByDefault verifies the live default (CollapseGroupsByDefault)
 // folds repo groups on first show, and space on a [+] header expands one.
 func TestTrainsCollapsedByDefault(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{
 		Daemon: Daemon{Running: true},
 		Trains: []TrainSession{{ID: "s1", Phase: "items_ready", Repo: "o/alpha"}},

--- a/internal/cli/tui/jobs_test.go
+++ b/internal/cli/tui/jobs_test.go
@@ -51,6 +51,7 @@ func selectJob(t *testing.T, m Model, id string) Model {
 }
 
 func TestFormatJobTime(t *testing.T) {
+	t.Parallel()
 	cases := map[string]string{
 		"2026-06-11 14:30:05":  "06-11 14:30",
 		"2026-01-02T15:04:05Z": "01-02 15:04",
@@ -69,6 +70,7 @@ func TestFormatJobTime(t *testing.T) {
 }
 
 func TestJobsRowShowsTime(t *testing.T) {
+	t.Parallel()
 	snap := jobsSnapshot()
 	snap.JobRows[0].UpdatedAt = "2026-06-11 14:30:05"
 	m := jobsModel(t, Deps{}, snap)
@@ -78,6 +80,7 @@ func TestJobsRowShowsTime(t *testing.T) {
 }
 
 func TestJobsListWindowsLongList(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{Daemon: Daemon{Running: true}}
 	for i := 0; i < 100; i++ {
 		snap.JobRows = append(snap.JobRows, JobRow{
@@ -119,6 +122,7 @@ func TestJobsListWindowsLongList(t *testing.T) {
 // (with ×counts) in active-first order, and that the cursor resolves through the
 // grouped order rather than snapshot order.
 func TestJobsGroupedByStatus(t *testing.T) {
+	t.Parallel()
 	m := jobsModel(t, Deps{}, jobsSnapshot())
 	view := m.View()
 	for _, want := range []string{"running  ×1", "failed  ×1", "succeeded  ×1", "cancelled  ×1"} {
@@ -144,6 +148,7 @@ func TestJobsGroupedByStatus(t *testing.T) {
 // TestJobsCollapsedByDefault verifies the live default folds the status groups so
 // the page opens as status headers, and space expands one.
 func TestJobsCollapsedByDefault(t *testing.T) {
+	t.Parallel()
 	snap := jobsSnapshot()
 	deps := Deps{Load: func() (Snapshot, error) { return snap, nil }, CollapseGroupsByDefault: true}
 	m := sizedModel(deps)
@@ -173,6 +178,7 @@ func TestJobsCollapsedByDefault(t *testing.T) {
 // mid-list), the windowed content fits inside the viewport so the "more rows
 // below" marker and the footer help are not clipped off the bottom.
 func TestJobsWindowFitsViewport(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{Daemon: Daemon{Running: true}}
 	for i := 0; i < 100; i++ {
 		snap.JobRows = append(snap.JobRows, JobRow{ID: "job-" + strconv.Itoa(i), Agent: "planner", Type: "ask", State: "succeeded"})
@@ -207,6 +213,7 @@ func TestJobsWindowFitsViewport(t *testing.T) {
 // TestJobsWindowKeepsGroupContext guards that scrolling deep into a status group
 // (so its header scrolls off) keeps the group context on the "above" marker.
 func TestJobsWindowKeepsGroupContext(t *testing.T) {
+	t.Parallel()
 	snap := Snapshot{Daemon: Daemon{Running: true}}
 	for i := 0; i < 100; i++ {
 		snap.JobRows = append(snap.JobRows, JobRow{ID: "job-" + strconv.Itoa(i), Agent: "planner", Type: "ask", State: "succeeded"})
@@ -222,6 +229,7 @@ func TestJobsWindowKeepsGroupContext(t *testing.T) {
 }
 
 func TestJobsPageDetailLoadsEvents(t *testing.T) {
+	t.Parallel()
 	var asked string
 	deps := Deps{JobEvents: func(id string) ([]JobEventView, error) {
 		asked = id
@@ -244,6 +252,7 @@ func TestJobsPageDetailLoadsEvents(t *testing.T) {
 }
 
 func TestJobsRetryConfirmFlow(t *testing.T) {
+	t.Parallel()
 	var retried string
 	deps := Deps{RetryJob: func(id string) error { retried = id; return nil }}
 	m := jobsModel(t, deps, jobsSnapshot())
@@ -269,6 +278,7 @@ func TestJobsRetryConfirmFlow(t *testing.T) {
 }
 
 func TestJobsCancelRunningShowsCancelling(t *testing.T) {
+	t.Parallel()
 	var cancelled string
 	snap := jobsSnapshot()
 	deps := Deps{
@@ -303,6 +313,7 @@ func TestJobsCancelRunningShowsCancelling(t *testing.T) {
 }
 
 func TestJobsRetryOnNonRetryableIgnored(t *testing.T) {
+	t.Parallel()
 	deps := Deps{RetryJob: func(id string) error { t.Fatal("must not retry"); return nil }}
 	m := jobsModel(t, deps, jobsSnapshot())
 	m = selectJob(t, m, "j-done")
@@ -314,6 +325,7 @@ func TestJobsRetryOnNonRetryableIgnored(t *testing.T) {
 }
 
 func TestJobsBugReportPreviewCreateFlow(t *testing.T) {
+	t.Parallel()
 	var previewed, created string
 	deps := Deps{
 		BugReportPreview: func(id string) (BugReportPreview, error) {
@@ -379,6 +391,7 @@ func TestJobsBugReportPreviewCreateFlow(t *testing.T) {
 }
 
 func TestJobsBugReportPreviewKeepsFooterVisibleForLongBody(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		BugReportPreview: func(id string) (BugReportPreview, error) {
 			return BugReportPreview{
@@ -406,6 +419,7 @@ func TestJobsBugReportPreviewKeepsFooterVisibleForLongBody(t *testing.T) {
 }
 
 func TestJobsBugReportCreateErrorKeepsPreview(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		BugReportPreview: func(id string) (BugReportPreview, error) {
 			return BugReportPreview{Title: "draft", Body: "body"}, nil
@@ -433,6 +447,7 @@ func TestJobsBugReportCreateErrorKeepsPreview(t *testing.T) {
 }
 
 func TestJobsBugReportExistingIssueLabel(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		BugReportPreview: func(id string) (BugReportPreview, error) {
 			return BugReportPreview{Title: "draft", Body: "body", Fingerprint: "abc123"}, nil
@@ -461,6 +476,7 @@ func TestJobsBugReportExistingIssueLabel(t *testing.T) {
 }
 
 func TestJobsBugReportCreateResultNotDroppedAfterEsc(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		BugReportPreview: func(id string) (BugReportPreview, error) {
 			return BugReportPreview{Title: "draft", Body: "body", Fingerprint: "abc123"}, nil
@@ -490,6 +506,7 @@ func TestJobsBugReportCreateResultNotDroppedAfterEsc(t *testing.T) {
 }
 
 func TestJobsBugReportBuildErrorKeepsPreview(t *testing.T) {
+	t.Parallel()
 	deps := Deps{BugReportPreview: func(id string) (BugReportPreview, error) {
 		return BugReportPreview{}, errors.New("payload malformed")
 	}}
@@ -509,6 +526,7 @@ func TestJobsBugReportBuildErrorKeepsPreview(t *testing.T) {
 }
 
 func TestJobsBugReportPreviewWithoutCreateDepDoesNotAdvertiseCreate(t *testing.T) {
+	t.Parallel()
 	deps := Deps{BugReportPreview: func(id string) (BugReportPreview, error) {
 		return BugReportPreview{Title: "draft", Body: "body"}, nil
 	}}
@@ -529,6 +547,7 @@ func TestJobsBugReportPreviewWithoutCreateDepDoesNotAdvertiseCreate(t *testing.T
 }
 
 func TestJobsBugReportIgnoredForNonReportableJob(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		BugReportPreview: func(id string) (BugReportPreview, error) {
 			t.Fatalf("must not build report for non-reportable job %s", id)
@@ -548,6 +567,7 @@ func TestJobsBugReportIgnoredForNonReportableJob(t *testing.T) {
 }
 
 func TestAttentionCancelledJobReportable(t *testing.T) {
+	t.Parallel()
 	var previewed string
 	snap := Snapshot{
 		Daemon:  Daemon{Running: true},
@@ -576,6 +596,7 @@ func TestAttentionCancelledJobReportable(t *testing.T) {
 }
 
 func TestAttentionJobRowsActionable(t *testing.T) {
+	t.Parallel()
 	var retried string
 	snap := jobsSnapshot()
 	deps := Deps{
@@ -604,6 +625,7 @@ func TestAttentionJobRowsActionable(t *testing.T) {
 }
 
 func TestAttentionDaemonStart(t *testing.T) {
+	t.Parallel()
 	started := false
 	snap := jobsSnapshot()
 	snap.Daemon.Running = false
@@ -647,6 +669,7 @@ func TestAttentionDaemonStart(t *testing.T) {
 }
 
 func TestDaemonStartResultDoesNotCloseJobConfirm(t *testing.T) {
+	t.Parallel()
 	snap := jobsSnapshot()
 	snap.Daemon.Running = false
 	deps := Deps{
@@ -676,6 +699,7 @@ func TestDaemonStartResultDoesNotCloseJobConfirm(t *testing.T) {
 }
 
 func TestJobDetailZeroEventsShowsNoEvents(t *testing.T) {
+	t.Parallel()
 	deps := Deps{JobEvents: func(id string) ([]JobEventView, error) { return nil, nil }}
 	m := jobsModel(t, deps, jobsSnapshot())
 	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -690,6 +714,7 @@ func TestJobDetailZeroEventsShowsNoEvents(t *testing.T) {
 }
 
 func TestJobConfirmStaysOpenWhileActionInFlight(t *testing.T) {
+	t.Parallel()
 	deps := Deps{RetryJob: func(id string) error { return nil }}
 	m := jobsModel(t, deps, jobsSnapshot())
 	m = selectJob(t, m, "j-failed")
@@ -712,6 +737,7 @@ func TestJobConfirmStaysOpenWhileActionInFlight(t *testing.T) {
 }
 
 func TestJobActionErrorKeepsConfirm(t *testing.T) {
+	t.Parallel()
 	deps := Deps{RetryJob: func(id string) error { return errors.New("db locked") }}
 	m := jobsModel(t, deps, jobsSnapshot())
 	m = selectJob(t, m, "j-failed")
@@ -749,6 +775,7 @@ func drainBatch(t *testing.T, m Model, cmd tea.Cmd) Model {
 }
 
 func TestJobDetailShowsRequestAndResult(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		JobEvents: func(id string) ([]JobEventView, error) {
 			return []JobEventView{{Kind: "failed", Message: "boom"}}, nil
@@ -773,6 +800,7 @@ func TestJobDetailShowsRequestAndResult(t *testing.T) {
 // TestJobDetailWrapsLongResult guards that a long single-line result summary is
 // soft-wrapped to the viewport width instead of being clipped at the right edge.
 func TestJobDetailWrapsLongResult(t *testing.T) {
+	t.Parallel()
 	long := "Implementation blocked because the workspace is mounted read-only. " +
 		strings.Repeat("decrypt-failure replay-poisoning regression coverage ", 12) + "END_TOKEN"
 	deps := Deps{
@@ -798,6 +826,7 @@ func TestJobDetailWrapsLongResult(t *testing.T) {
 }
 
 func TestJobDetailOmitsBlocksWhenAbsent(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
 		JobDetail: func(id string) (JobDetail, error) { return JobDetail{}, nil },
@@ -815,6 +844,7 @@ func TestJobDetailOmitsBlocksWhenAbsent(t *testing.T) {
 }
 
 func TestJobDetailShowsDelegationTree(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
 		JobDetail: func(id string) (JobDetail, error) {
@@ -848,6 +878,7 @@ func TestJobDetailShowsDelegationTree(t *testing.T) {
 }
 
 func TestJobDetailOmitsDelegationsWhenNone(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
 		JobDetail: func(id string) (JobDetail, error) { return JobDetail{Request: "no children here"}, nil },
@@ -862,6 +893,7 @@ func TestJobDetailOmitsDelegationsWhenNone(t *testing.T) {
 }
 
 func TestJobDetailDelegationDepsPending(t *testing.T) {
+	t.Parallel()
 	deps := Deps{
 		JobEvents: func(id string) ([]JobEventView, error) { return nil, nil },
 		JobDetail: func(id string) (JobDetail, error) {
@@ -889,6 +921,7 @@ func TestJobDetailDelegationDepsPending(t *testing.T) {
 }
 
 func TestDepsLabel(t *testing.T) {
+	t.Parallel()
 	if got := depsLabel(JobChild{}); got != "-" {
 		t.Fatalf("depsLabel(no deps) = %q, want -", got)
 	}

--- a/internal/cli/tui/model_test.go
+++ b/internal/cli/tui/model_test.go
@@ -75,6 +75,7 @@ func tabToPage(t *testing.T, m Model, p page) Model {
 }
 
 func TestPagesRenderExpectedContent(t *testing.T) {
+	t.Parallel()
 	m := loadedModel(t)
 	// Page order: Attention, Activity, Trains, Agents, Workers, Jobs, Locks, Health, Config.
 	wants := []string{"Prompts (1)", "No active jobs", "train-s1", "planner", "skillopt-generator", "failed", "branch locks", "environment", "edit in $EDITOR"}
@@ -90,6 +91,7 @@ func TestPagesRenderExpectedContent(t *testing.T) {
 }
 
 func TestTabCyclesAllPages(t *testing.T) {
+	t.Parallel()
 	m := loadedModel(t)
 	for range pages {
 		next, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
@@ -106,6 +108,7 @@ func TestTabCyclesAllPages(t *testing.T) {
 }
 
 func TestRefreshSuppressionWhileInFlight(t *testing.T) {
+	t.Parallel()
 	m := loadedModel(t)
 	if m.inFlight {
 		t.Fatal("model should be idle after a snapshotMsg")
@@ -123,6 +126,7 @@ func TestRefreshSuppressionWhileInFlight(t *testing.T) {
 }
 
 func TestLoadErrorKeepsStaleData(t *testing.T) {
+	t.Parallel()
 	m := loadedModel(t)
 	next, _ := m.Update(snapshotMsg{err: errors.New("db locked"), at: time.Unix(2, 0)})
 	m = next.(Model)
@@ -138,6 +142,7 @@ func TestLoadErrorKeepsStaleData(t *testing.T) {
 }
 
 func TestEmptyStatesRenderWithoutPanic(t *testing.T) {
+	t.Parallel()
 	// Daemon running so the attention page shows the empty state rather than
 	// the (legitimate) daemon-stopped banner.
 	empty := Snapshot{Daemon: Daemon{Running: true}}
@@ -155,6 +160,7 @@ func TestEmptyStatesRenderWithoutPanic(t *testing.T) {
 }
 
 func TestResizeUpdatesViewport(t *testing.T) {
+	t.Parallel()
 	m := loadedModel(t)
 	next, _ := m.Update(tea.WindowSizeMsg{Width: 60, Height: 20})
 	m = next.(Model)
@@ -167,6 +173,7 @@ func TestResizeUpdatesViewport(t *testing.T) {
 }
 
 func TestTickRearmsAndRefreshes(t *testing.T) {
+	t.Parallel()
 	m := loadedModel(t)
 	_, cmd := m.Update(tickMsg{gen: m.tickGen})
 	if cmd == nil {
@@ -175,6 +182,7 @@ func TestTickRearmsAndRefreshes(t *testing.T) {
 }
 
 func TestPopNudgeResetsInFlightLoad(t *testing.T) {
+	t.Parallel()
 	m := loadedModel(t)
 	// A load dispatched just before a push has its snapshotMsg routed to the
 	// covering view and dropped; the latch must not survive the pop.
@@ -192,6 +200,7 @@ func TestPopNudgeResetsInFlightLoad(t *testing.T) {
 }
 
 func TestStaleTickGenerationDropped(t *testing.T) {
+	t.Parallel()
 	m := loadedModel(t)
 	// A pop-nudge starts a new tick generation…
 	next, cmd := m.Update(refreshNudgeMsg{})

--- a/internal/cli/tui/traininit_test.go
+++ b/internal/cli/tui/traininit_test.go
@@ -68,6 +68,7 @@ func startTI(t *testing.T, store PromptStore, fields []Field) TrainInitModel {
 }
 
 func TestTrainInitSkipsConditionalField(t *testing.T) {
+	t.Parallel()
 	skipFields := func() []Field {
 		return []Field{
 			{Name: "first", Label: "First", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "first"}},
@@ -91,6 +92,7 @@ func TestTrainInitSkipsConditionalField(t *testing.T) {
 }
 
 func TestTrainInitTextSubmitAdvances(t *testing.T) {
+	t.Parallel()
 	m := startTI(t, newFakeStore(), tiFields())
 	next, _ := m.Update(key("smithyx"))
 	m = next.(TrainInitModel)
@@ -105,6 +107,7 @@ func TestTrainInitTextSubmitAdvances(t *testing.T) {
 }
 
 func TestTrainInitEmptyTextInlineError(t *testing.T) {
+	t.Parallel()
 	m := startTI(t, newFakeStore(), tiFields())
 	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	m = next.(TrainInitModel)
@@ -117,6 +120,7 @@ func TestTrainInitEmptyTextInlineError(t *testing.T) {
 }
 
 func TestTrainInitChoiceDefaultPreselected(t *testing.T) {
+	t.Parallel()
 	m := startTI(t, newFakeStore(), tiFields())
 	// name → template → preview.
 	m = advanceText(t, m, "smithyx")
@@ -135,6 +139,7 @@ func TestTrainInitChoiceDefaultPreselected(t *testing.T) {
 }
 
 func TestTrainInitTemplateCustomFile(t *testing.T) {
+	t.Parallel()
 	m := startTI(t, newFakeStore(), tiFields())
 	m = advanceText(t, m, "smithyx")
 	// On template field: move to "Custom file" (index 2).
@@ -166,6 +171,7 @@ func TestTrainInitTemplateCustomFile(t *testing.T) {
 }
 
 func TestTrainInitExternalAnswerAdvancesWithFlash(t *testing.T) {
+	t.Parallel()
 	m := startTI(t, newFakeStore(), tiFields())
 	resolved := db.InteractivePrompt{ID: "ti.name", State: db.InteractivePromptStateResolved, AnswerValue: "remote-name", AnswerSource: "agent"}
 	next, _ := m.Update(pollResultMsg{gen: m.gen, prompt: resolved})
@@ -185,6 +191,7 @@ func TestTrainInitExternalAnswerAdvancesWithFlash(t *testing.T) {
 }
 
 func TestTrainInitStalePollIgnored(t *testing.T) {
+	t.Parallel()
 	m := startTI(t, newFakeStore(), tiFields())
 	before := m.idx
 	resolved := db.InteractivePrompt{ID: "ti.name", State: db.InteractivePromptStateResolved, AnswerValue: "x"}
@@ -200,6 +207,7 @@ func TestTrainInitStalePollIgnored(t *testing.T) {
 }
 
 func TestTrainInitConfirmAcceptDeclineAbort(t *testing.T) {
+	t.Parallel()
 	single := []Field{{Name: "name", Label: "Name", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.name"}}}
 
 	// Accept.
@@ -233,6 +241,7 @@ func TestTrainInitConfirmAcceptDeclineAbort(t *testing.T) {
 }
 
 func TestTrainInitAutoAcceptWhenExternallyAnswered(t *testing.T) {
+	t.Parallel()
 	single := []Field{{Name: "name", Label: "Name", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.name"}}}
 	m := startTI(t, newFakeStore(), single)
 	resolved := db.InteractivePrompt{ID: "ti.name", State: db.InteractivePromptStateResolved, AnswerValue: "x", AnswerSource: "agent"}
@@ -247,6 +256,7 @@ func TestTrainInitAutoAcceptWhenExternallyAnswered(t *testing.T) {
 }
 
 func TestTrainInitRepoCreateFlow(t *testing.T) {
+	t.Parallel()
 	created := ""
 	fields := []Field{
 		{Name: "review_repo", Label: "Review repository", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.review_repo"},
@@ -290,6 +300,7 @@ func TestTrainInitRepoCreateFlow(t *testing.T) {
 }
 
 func TestTrainInitRepoReEnter(t *testing.T) {
+	t.Parallel()
 	createCalls := 0
 	fields := []Field{
 		{Name: "review_repo", Label: "Review repository", Kind: FieldText, Prompt: db.InteractivePrompt{ID: "ti.review_repo"},
@@ -321,6 +332,7 @@ func TestTrainInitRepoReEnter(t *testing.T) {
 }
 
 func TestTrainInitProgressHeader(t *testing.T) {
+	t.Parallel()
 	m := startTI(t, newFakeStore(), tiFields())
 	if !strings.Contains(m.View(), "[1/3]") {
 		t.Fatalf("expected progress header:\n%s", m.View())
@@ -330,6 +342,7 @@ func TestTrainInitProgressHeader(t *testing.T) {
 // TestTrainInitPromptCmdsAgainstRealStore proves the upsert/check/delete commands
 // drive real SQL and observe an external answer, one prompt at a time.
 func TestTrainInitPromptCmdsAgainstRealStore(t *testing.T) {
+	t.Parallel()
 	store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
 	if err != nil {
 		t.Fatalf("open: %v", err)

--- a/internal/cli/tui/trainrun_test.go
+++ b/internal/cli/tui/trainrun_test.go
@@ -19,6 +19,7 @@ func trainRunModel(t *testing.T, snap TrainRunSnapshot) TrainRunModel {
 }
 
 func TestTrainPhaseSegment(t *testing.T) {
+	t.Parallel()
 	cases := map[string]int{
 		"items_ready":                0,
 		"generating_options":         0,
@@ -45,6 +46,7 @@ func TestTrainPhaseSegment(t *testing.T) {
 }
 
 func TestTrainRunRendersHeaderAndPhaseBar(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{
 		SessionID: "train-abc", Template: "smithyx@v9", ReviewRepo: "o/r",
 		Phase: "items_ready", ReviewItems: 2, NextAction: "generate review options",
@@ -58,6 +60,7 @@ func TestTrainRunRendersHeaderAndPhaseBar(t *testing.T) {
 }
 
 func TestTrainRunReviewPhaseShowsIssueLink(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{
 		SessionID: "s", Phase: "review_published",
 		IssueURL: "https://github.com/o/r/issues/7", FeedbackCount: 3,
@@ -75,6 +78,7 @@ func TestTrainRunReviewPhaseShowsIssueLink(t *testing.T) {
 }
 
 func TestTrainRunGeneratingShowsJobCounts(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{
 		SessionID: "s", Phase: "generating_options",
 		JobsRunning: 1, JobsSucceeded: 2, JobsFailed: 0, ETA: "41s",
@@ -86,6 +90,7 @@ func TestTrainRunGeneratingShowsJobCounts(t *testing.T) {
 }
 
 func TestTrainRunSurfacesGenerationError(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Template: "t@v1", Phase: "items_ready"})
 	// A spawn first reports the optimistic "started in the background" note…
 	next, _ := m.Update(trainSpawnMsg{logPath: "/tmp/x.log"})
@@ -111,6 +116,7 @@ func TestTrainRunSurfacesGenerationError(t *testing.T) {
 }
 
 func TestTrainRunNoGenerationErrorKeepsNote(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "items_ready"})
 	next, _ := m.Update(trainSpawnMsg{logPath: "/tmp/x.log"})
 	m = next.(TrainRunModel)
@@ -127,6 +133,7 @@ func TestTrainRunNoGenerationErrorKeepsNote(t *testing.T) {
 }
 
 func TestTrainRunLoadErrorKeepsStaleData(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Template: "t@v1", Phase: "items_ready"})
 	next, _ := m.Update(trainSnapshotMsg{err: errors.New("db locked"), at: time.Unix(2, 0)})
 	m = next.(TrainRunModel)
@@ -140,6 +147,7 @@ func TestTrainRunLoadErrorKeepsStaleData(t *testing.T) {
 }
 
 func TestTrainRunRefreshSuppression(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "items_ready"})
 	if m.inFlight {
 		t.Fatal("should be idle after a snapshot")
@@ -153,6 +161,7 @@ func TestTrainRunRefreshSuppression(t *testing.T) {
 }
 
 func TestTrainRunTickRearms(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "items_ready"})
 	_, cmd := m.Update(trainTickMsg{})
 	if cmd == nil {
@@ -170,6 +179,7 @@ func trainRunModelWithDeps(t *testing.T, deps TrainRunDeps, snap TrainRunSnapsho
 }
 
 func TestTrainRunGenerateSpawnsChild(t *testing.T) {
+	t.Parallel()
 	spawned := false
 	deps := TrainRunDeps{
 		Load:          func() (TrainRunSnapshot, error) { return TrainRunSnapshot{SessionID: "s", Phase: "items_ready"}, nil },
@@ -188,6 +198,7 @@ func TestTrainRunGenerateSpawnsChild(t *testing.T) {
 }
 
 func TestTrainRunPublishUsesInProcessContinue(t *testing.T) {
+	t.Parallel()
 	called := false
 	deps := TrainRunDeps{
 		Load: func() (TrainRunSnapshot, error) {
@@ -216,6 +227,7 @@ func TestTrainRunPublishUsesInProcessContinue(t *testing.T) {
 }
 
 func TestTrainRunPromote(t *testing.T) {
+	t.Parallel()
 	var gotPromote bool
 	var gotCandidate string
 	deps := TrainRunDeps{
@@ -240,6 +252,7 @@ func TestTrainRunPromote(t *testing.T) {
 }
 
 func TestTrainRunActionsGateOnIterationPhase(t *testing.T) {
+	t.Parallel()
 	// Post-optimizer, the display phase stays "optimizer_completed_candidate"
 	// while the iteration phase advances; the action keys must follow the
 	// iteration phase or p/x/enter go dead exactly when a human is needed.
@@ -273,6 +286,7 @@ func TestTrainRunActionsGateOnIterationPhase(t *testing.T) {
 }
 
 func TestTrainRunTerminalKeysAndDecisionLinkPostOptimizer(t *testing.T) {
+	t.Parallel()
 	// Display phase stuck at optimizer_completed_candidate, iteration promoted:
 	// the terminal screen must offer n and show the candidate review link.
 	snap := TrainRunSnapshot{
@@ -307,6 +321,7 @@ func TestTrainRunTerminalKeysAndDecisionLinkPostOptimizer(t *testing.T) {
 }
 
 func TestTrainRunPromoteScreenShowsDecisionLink(t *testing.T) {
+	t.Parallel()
 	snap := TrainRunSnapshot{
 		SessionID:          "s",
 		Phase:              "optimizer_completed_candidate",
@@ -324,6 +339,7 @@ func TestTrainRunPromoteScreenShowsDecisionLink(t *testing.T) {
 }
 
 func TestTrainRunRejectRequiresReason(t *testing.T) {
+	t.Parallel()
 	var gotReason string
 	decided := false
 	deps := TrainRunDeps{
@@ -363,6 +379,7 @@ func TestTrainRunRejectRequiresReason(t *testing.T) {
 }
 
 func TestTrainRunStartNextOnTerminal(t *testing.T) {
+	t.Parallel()
 	called := false
 	deps := TrainRunDeps{
 		Load: func() (TrainRunSnapshot, error) {
@@ -383,6 +400,7 @@ func TestTrainRunStartNextOnTerminal(t *testing.T) {
 }
 
 func TestTrainRunActionBusySuppressesReentry(t *testing.T) {
+	t.Parallel()
 	deps := TrainRunDeps{
 		Load: func() (TrainRunSnapshot, error) {
 			return TrainRunSnapshot{SessionID: "s", Phase: "options_generated"}, nil
@@ -400,6 +418,7 @@ func TestTrainRunActionBusySuppressesReentry(t *testing.T) {
 }
 
 func TestTrainRunConfirmCreatesAndEntersPhase(t *testing.T) {
+	t.Parallel()
 	var gotWS string
 	created := false
 	deps := TrainRunDeps{
@@ -434,6 +453,7 @@ func TestTrainRunConfirmCreatesAndEntersPhase(t *testing.T) {
 }
 
 func TestTrainRunConfirmNeedsWorkspaceRepo(t *testing.T) {
+	t.Parallel()
 	called := false
 	deps := TrainRunDeps{
 		Plan:          &TrainRunPlan{Name: "n", Template: "t @v1", ReviewRepo: "o/r", NeedWorkspaceRepo: true},
@@ -464,6 +484,7 @@ func TestTrainRunConfirmNeedsWorkspaceRepo(t *testing.T) {
 }
 
 func TestTrainRunConfirmAbort(t *testing.T) {
+	t.Parallel()
 	called := false
 	deps := TrainRunDeps{
 		Plan:          &TrainRunPlan{Name: "n", Template: "t", ReviewRepo: "o/r", WorkspaceRepo: "o/ws"},
@@ -483,6 +504,7 @@ func TestTrainRunConfirmAbort(t *testing.T) {
 }
 
 func TestTrainRunTailsLogDuringLongPhase(t *testing.T) {
+	t.Parallel()
 	tailCalls := 0
 	deps := TrainRunDeps{
 		Load: func() (TrainRunSnapshot, error) {
@@ -512,6 +534,7 @@ func TestTrainRunTailsLogDuringLongPhase(t *testing.T) {
 }
 
 func TestTrainRunLogClearsDisplayButKeepsOffset(t *testing.T) {
+	t.Parallel()
 	deps := TrainRunDeps{Load: func() (TrainRunSnapshot, error) {
 		return TrainRunSnapshot{SessionID: "s", Phase: "generating_options"}, nil
 	}}
@@ -544,6 +567,7 @@ func TestTrainRunLogClearsDisplayButKeepsOffset(t *testing.T) {
 }
 
 func TestTrainRunLogCapsLines(t *testing.T) {
+	t.Parallel()
 	deps := TrainRunDeps{Load: func() (TrainRunSnapshot, error) {
 		return TrainRunSnapshot{SessionID: "s", Phase: "optimizer_running"}, nil
 	}}
@@ -560,6 +584,7 @@ func TestTrainRunLogCapsLines(t *testing.T) {
 }
 
 func TestTrainRunActionErrorShown(t *testing.T) {
+	t.Parallel()
 	m := trainRunModel(t, TrainRunSnapshot{SessionID: "s", Phase: "options_generated"})
 	next, _ := m.Update(trainActionMsg{err: errors.New("another worker holds the lock")})
 	m = next.(TrainRunModel)


### PR DESCRIPTION
Part of #1039 (the safe, owner-approved subset — see the scope note below).

Reshapes the cli test estate toward CI wall-time reduction. Per the issue, **the payoff is CI wall time and shard count, not line count** — so this focuses on parallelization, the part that actually moves wall time.

## What this does
- **Adds `t.Parallel` to 247 top-level tests + 14 subtests** across 14 files screened as pure state/render/spec (`tui/*`, `dashboard_web_pipelines/workflow`, `runtime_registry`, `pipeline`, `hard_verifier`, `memory_clusters`). Each addition was verified race-clean under `-race -count=2`.
- **Injects two global test seams** so their tests stop racing a shared package var and can parallelize, with production behavior identical:
  - `runChatWait` gains an injected poll interval (`chatWaitPollInterval` is now a `const` default); the timeout test passes 10ms via `runChatWaitWithPollInterval` instead of mutating the var.
  - `defaultLiveABPresenter` gains injected shuffle / read-line funcs via `defaultLiveABPresenterWith`; the mapping test injects its own instead of reassigning `liveABShuffle`/`readSkillOptABLine`.
  Every test that reassigned the old vars was migrated (the package compiles, so nothing references a removed/const seam).

## Deliberately out of scope (owner-ruled)
- **CI shard-count cut** — a measurement-gated **fast-follow**. Shards are hardcoded (`ci.yml` cli: 8) and the partition script balances by a CI `race-test-timings.tsv` that won't reflect the new parallelism until this lands on main and CI reruns. Cutting on a local estimate is unsound (the local cli `-race` package doesn't even complete in 30m on the dev box). So this PR retires **zero** shards by design; the cut follows once a fresh timing artifact exists.
- **github.Client fake consolidation** — skipped. It needs a value-receiver base with pointer-backed state (several fakes are passed by value, so a pointer-receiver base breaks conformance); not worth the migration risk when line count isn't the payoff.
- **Heavy skillopt-runner parallelization** — parked for after #1038 rearranges that neighborhood (the wall-time-dominating tests are cwd/env/worktree-bound, needing a large dependency-injection refactor).
- **env/cwd/credentials-bound tests** — left serial (correctly non-parallel-safe).

## Review
Adversarial review + `/code-review high` focused on the one risk that matters: a `t.Parallel` on a test that isn't actually isolation-safe. **Zero isolation violations found** across all 261 additions. Two low-severity findings on the liveAB injection (a lost-coverage nit on `defaultLiveABShuffle` and a stale doc comment) are fixed in the second commit; the presenter's seam wiring is type-guarded against transposition.

## Verification
Full local gate green: `build` / `vet` / full `go test ./internal/cli/...` (431s) / `-race -count=2` clean on every parallelized file (tui subpackage, the 6 non-tui files' 84 tests, and both injection tests).

## Known pre-existing flake (NOT this diff)
`TestRuntimeSessionLockHeartbeatOwnershipGuardStopsStaleOwner` (#1045) can intermittently redden the cli race lane — a lease-heartbeat race, pre-existing on main, cleared by a re-run.

## Deploy notes — HOLD
Test-only + two behavior-preserving production seam refactors; no runtime/schema/config change. **Do not deploy without owner go (judging window through Aug 5).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)