### PR TITLE
test(cli): fix flaky heartbeat ownership-guard test — test-side format bug, not a production race (#1045)

### DIFF
--- a/internal/cli/runtime_lock_heartbeat_test.go
+++ b/internal/cli/runtime_lock_heartbeat_test.go
@@ -137,8 +137,20 @@ func TestRuntimeSessionLockHeartbeatOwnershipGuardStopsStaleOwner(t *testing.T) 
 	if err != nil {
 		t.Fatalf("GetResourceLock returned error: %v", err)
 	}
-	if lock.OwnerToken != "token-new" || lock.ExpiresAt != newExpiry.Format(time.RFC3339Nano) {
-		t.Fatalf("reacquired lock changed by stale heartbeat: %+v", lock)
+	// Compare the reacquired lease by INSTANT, not by raw string: the store
+	// persists times via a fixed-width layout (…".000000000Z", always 9
+	// fractional digits) while time.RFC3339Nano trims trailing zeros, so a
+	// direct string compare spuriously fails ~10% of the time — whenever the
+	// captured `now` happens to have a trailing-zero nanosecond — even though the
+	// stored expiry is the exact same instant. The real assertion is that a stale
+	// token-old heartbeat did NOT change the reacquired token-new lease; the
+	// explicit HeartbeatResourceLock check below covers the owner-token CAS.
+	gotExpiry, err := time.Parse(time.RFC3339Nano, lock.ExpiresAt)
+	if err != nil {
+		t.Fatalf("parse reacquired lock expiry %q: %v", lock.ExpiresAt, err)
+	}
+	if lock.OwnerToken != "token-new" || !gotExpiry.Equal(newExpiry) {
+		t.Fatalf("reacquired lock changed by stale heartbeat: %+v (want owner token-new, expiry %s)", lock, newExpiry.Format(time.RFC3339Nano))
 	}
 	updated, err := store.HeartbeatResourceLock(ctx, lockKey, "token-old", now.Add(3*time.Minute))
 	if err != nil || updated {


### PR DESCRIPTION
Fixes the intermittent `TestRuntimeSessionLockHeartbeatOwnershipGuardStopsStaleOwner` flake (#1045) that reddened #1050's CI lane twice and muddies the SHA-green merge gate.

## Determination: test-side format bug, **not** a production race

G3 filed this with base-vs-branch evidence proving it pre-exists (fails on `38459c7` and unrelated #1040), and hypothesized a real race needing an owner-token CAS on the heartbeat UPDATE. I root-caused it to a **test-side string-format bug**; the production owner-token CAS G3 hypothesized **already exists** and works.

**Evidence (444 instrumented runs):** every failure kept `OwnerToken=token-new` and an `ExpiresAt` equal to the **same instant** as expected (`sameInstant=true`, never a minute-off value a stale heartbeat would write); the `-race` detector found no data race. The failures are purely a string divergence:

| | layout | example |
|---|---|---|
| store persists (`formatResourceLockTime`) | `…​.000000000Z` (always 9 digits) | `…45.720053320Z` |
| test expected (`time.RFC3339Nano`) | trims trailing zeros | `…45.72005332Z` |

Same instant, different string — so ~10% of runs (whenever the captured `now` has a trailing-zero nanosecond) the raw compare fails. This is a per-run nanosecond lottery, not load: `-count=20` gives 20 draws (usually ≥1 red), `-count=5` usually gives zero — which is exactly the reported signature.

**Production is correct.** `HeartbeatResourceLock` already does `UPDATE … SET expires_at WHERE resource_key = ? AND owner_token = ?` (#986/#990). Once the lease is reacquired under `token-new`, a stale `token-old` heartbeat's UPDATE matches **zero rows** and the loop stops (`updated==false`). The test's own explicit final check — `HeartbeatResourceLock(token-old) → updated=false`, which is deterministic and never flaked — already verifies this guard. No production change is needed and there is no real bug to sev-note.

## Fix

Assert the reacquired lease by **parsed instant** (`time.Parse` + `time.Equal`), not raw string. This asserts the true intent (the stale heartbeat did not change the reacquired lease) and is immune to format representation. The explicit CAS check below it is unchanged.

Sibling-checked: this was the only test comparing a store-returned `ExpiresAt` string against an `RFC3339Nano`-formatted value. `agent_test.go` / `e2e_560_lease_grace_536_safe_test.go` already parse-and-compare instants; `internal/db/store_test.go` compares via the store's own `formatResourceLockTime` (unreachable from `internal/cli`, which is why this test reached for `RFC3339Nano` and diverged).

Fixed test is green at `-count=500` (was ~11% failing).

## Deploy notes

**No deploy** — test-only change, no production code touched. Unblocks #1050 and any future PR the flake would redden.

Closes #1045.
