### PR TITLE
feat(task): lifecycle reconciliation — closed-PR→blocked, planned_ttl (default-off), terminal-driving-job triage (#1054)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -113,6 +113,24 @@ activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
 set it to `"0"` to disable this poll leg. Candidates with a same-repo open PR,
 a remote branch, a live job, or an uncertain remote check are not dismissed.
 
+Never-started plans have a separate destructive opt-in:
+`[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
+`"0"`, and invalid values all mean off because dismissing a plan can destroy
+human context that a goal-file re-import cannot reconstruct. When enabled, the
+same live-job, open-PR, remote-branch, and uncertain-remote safeguards apply,
+and a dismissal records `task_dismissed_planned_ttl`. `task run` claims
+`planned -> implementing` atomically at allocation time, so a concurrent TTL
+dismissal cannot resurrect the task; use explicit `task recover` before retrying.
+
+A PR cleanly observed closed without merging moves a linked `pr_open`,
+`reviewing`, or `changes_requested` task to `blocked` and records
+`pr_closed_unmerged`; ambiguous observations remain conservative. After
+advancement and delegation handling, a terminal top-level implement job with no
+PR and no live successor also moves `implementing` to `blocked`. Implemented
+success without a PR records `task_blocked_terminal_no_pr`; other terminal
+outcomes record `task_blocked_job_failed`. Delegation children and queued
+fix/retry/continuation jobs are excluded.
+
 Dismissed tasks never return to implementation through ordinary task run,
 allocation, or late workflow advancement. `task recover` is the explicit path:
 preserved branch/worktree artifacts move through `implementing` to `pr_open`,

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -607,6 +607,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
 			return markErr
 		}
+		if reconcileErr := engine.ReconcileTerminalDrivingJob(ctx, job.ID); reconcileErr != nil {
+			return reconcileErr
+		}
 		commentErr := err
 		if job.Type == "implement" && runtimePermissionFailure(err) {
 			latest, latestErr := w.Store.GetJob(ctx, job.ID)
@@ -617,6 +620,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, commentErr)
 		writeLine(w.Stdout, "job %s failed: %v", job.ID, err)
 		return nil
+	}
+	if err := engine.ReconcileTerminalDrivingJob(ctx, job.ID); err != nil {
+		return err
 	}
 	_ = w.postJobResultComment(ctx, job.ID, agent, checkout, nil)
 	writeLine(w.Stdout, "job %s completed", job.ID)
@@ -1676,6 +1682,9 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		if markErr := w.handleRunJobError(ctx, delegatedJob.ID, err); markErr != nil {
 			return markErr
 		}
+		if reconcileErr := engine.ReconcileTerminalDrivingJob(ctx, delegatedJob.ID); reconcileErr != nil {
+			return reconcileErr
+		}
 		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
 		writeLine(w.Stdout, "job %s failed: %v", delegatedJob.ID, err)
 		return nil
@@ -1687,6 +1696,9 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 			}
 			return err
 		}
+	}
+	if err := engine.ReconcileTerminalDrivingJob(ctx, delegatedJob.ID); err != nil {
+		return err
 	}
 	_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, nil)
 	writeLine(w.Stdout, "job %s completed by temporary worker %s", delegatedJob.ID, started.Agent.Name)
@@ -2243,7 +2255,10 @@ func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
 		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry failed: "+err.Error())
 	}
 	writeLine(w.Stdout, "job %s advancement retried", job.ID)
-	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retried", Message: "post-delivery workflow retry completed"})
+	if err := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retried", Message: "post-delivery workflow retry completed"}); err != nil {
+		return err
+	}
+	return engine.ReconcileTerminalDrivingJob(ctx, job.ID)
 }
 
 func (w jobWorker) refreshImplementedPayloadForRetry(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, bool, error) {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -44,7 +44,10 @@ artifact_blobs = %q
 # follows checkout HEAD and guards stale non-default checkouts. result_checks is
 # off | warn | block and defaults to warn when omitted. stale_task_ttl is the
 # conservative updated_at age after which abandoned implementing/blocked tasks
-# may be auto-dismissed; it defaults to 168h and "0" disables the reconciler.
+# may be auto-dismissed; it defaults to 168h and "0" disables that reconciler.
+# planned_ttl is a separate destructive retirement policy for never-started
+# plans. It is OPT-IN and disabled by default because dismissal can discard human
+# planning context that a later goal-file import cannot reconstruct.
 # require_workflow is true by default. In the default auto mode, fresh unlabeled
 # agent dispatches are filed under adhoc/<agent>-<yyyy-mm-dd> and never
 # rejected. Set require_workflow = false to opt out, or require_workflow_mode =
@@ -54,6 +57,7 @@ artifact_blobs = %q
 # implement_base = "origin/main"
 # result_checks = "warn"
 # stale_task_ttl = "168h"
+# planned_ttl = "720h" # opt-in; unset/empty/0/invalid disables
 # require_workflow = false # opt out (default is true)
 # require_workflow_mode = "auto" # auto | strict
 

--- a/internal/config/stale_tasks.go
+++ b/internal/config/stale_tasks.go
@@ -9,6 +9,51 @@ import (
 
 const DefaultStaleTaskTTL = 168 * time.Hour
 
+// LoadPlannedTaskTTL resolves the hot-read [workflow].planned_ttl setting.
+// Planned-task retirement is destructive to human planning context, so every
+// absent, empty, zero, negative, or unparseable value disables it. Only an
+// explicit positive Go duration opts a repository daemon into the sweep.
+func LoadPlannedTaskTTL(paths Paths) (time.Duration, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			continue
+		}
+		if current != "workflow" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "planned_ttl" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "\"") {
+			value, err = parseConfigString(value)
+			if err != nil {
+				return 0, nil
+			}
+		}
+		ttl, err := time.ParseDuration(strings.TrimSpace(value))
+		if err != nil || ttl <= 0 {
+			return 0, nil
+		}
+		return ttl, nil
+	}
+	return 0, nil
+}
+
 // LoadStaleTaskTTL resolves the hot-read [workflow].stale_task_ttl setting.
 // Omitted or empty uses seven days, exactly "0" disables reconciliation, and
 // every other value must be a non-negative Go duration.

--- a/internal/config/stale_tasks_test.go
+++ b/internal/config/stale_tasks_test.go
@@ -40,3 +40,33 @@ func TestLoadStaleTaskTTL(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadPlannedTaskTTLOptIn(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    time.Duration
+	}{
+		{name: "missing"},
+		{name: "omitted", content: "[workflow]\nstale_task_ttl = \"168h\"\n"},
+		{name: "empty", content: "[workflow]\nplanned_ttl = \"\"\n"},
+		{name: "zero", content: "[workflow]\nplanned_ttl = \"0\"\n"},
+		{name: "invalid", content: "[workflow]\nplanned_ttl = \"later\"\n"},
+		{name: "negative", content: "[workflow]\nplanned_ttl = \"-1h\"\n"},
+		{name: "duration", content: "[workflow]\nplanned_ttl = \"720h\"\n", want: 720 * time.Hour},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.toml")
+			if test.name != "missing" {
+				if err := os.WriteFile(path, []byte(test.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := LoadPlannedTaskTTL(Paths{ConfigFile: path})
+			if err != nil || got != test.want {
+				t.Fatalf("LoadPlannedTaskTTL = %v, err=%v; want %v", got, err, test.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/closed_reviewing_pr_test.go
+++ b/internal/daemon/closed_reviewing_pr_test.go
@@ -161,6 +161,82 @@ func TestPollOnceReconcilesClosedReviewingPullRequest(t *testing.T) {
 	}
 }
 
+// TestPollOnceDoesNotFuzzyMergeNonReviewingTasks guards the #1054-review finding:
+// pr_open and changes_requested are folded into reconcileClosedReviewingTasks
+// ONLY for the closed-unmerged -> blocked arm; they must NOT take the fuzzy
+// same-branch merged-sibling resolution that reviewing owns for #543. Otherwise
+// an UNRELATED merged PR that merely shares a (fork) branch name — with the head-
+// SHA guard skipped because the stored PR row has an empty SHA — would drive a
+// still-open task to a spurious `merged` and force-remove its worktree. reviewing
+// keeps the fuzzy resolution; the precise pinned-number reconcileExternallyMergedTasks
+// pass still owns the real merged case for the folded-in states.
+func TestPollOnceDoesNotFuzzyMergeNonReviewingTasks(t *testing.T) {
+	repo := github.Repository{Owner: "acme", Name: "widgets"}
+	const branch = "patch-1" // a generic fork head ref reused across unrelated PRs
+
+	for _, startState := range []workflow.TaskState{
+		workflow.TaskPullRequestOpen,
+		workflow.TaskChangesRequested,
+	} {
+		t.Run(string(startState), func(t *testing.T) {
+			ctx := context.Background()
+			store := testStore(t)
+			if err := store.UpsertTask(ctx, db.Task{
+				ID:           "task-fork",
+				RepoFullName: repo.FullName(),
+				GoalID:       "goal-1",
+				Title:        "Fork PR work",
+				State:        string(startState),
+				Branch:       branch,
+			}); err != nil {
+				t.Fatalf("UpsertTask returned error: %v", err)
+			}
+			// The stored PR row (our own PR #12) carries an EMPTY head SHA, so the
+			// selectReconciledPull SHA guard is skipped.
+			if err := store.UpsertPullRequest(ctx, db.PullRequest{
+				RepoFullName: repo.FullName(),
+				Number:       12,
+				URL:          "https://github.com/acme/widgets/pull/12",
+				HeadBranch:   branch,
+				BaseBranch:   "main",
+				State:        "open",
+			}); err != nil {
+				t.Fatalf("UpsertPullRequest returned error: %v", err)
+			}
+			client := &fakeGitHub{
+				pullsByState: map[string][]github.PullRequest{
+					"open": nil,
+					"closed": {
+						// The task's OWN PR #12 is closed-unmerged...
+						{Number: 12, State: "closed", HeadRef: branch, BaseRef: "main"},
+						// ...alongside an UNRELATED already-merged PR #5 on the same fork head ref.
+						{Number: 5, State: "closed", HeadRef: branch, BaseRef: "main", HeadSHA: "unrelated-sha", MergedAt: "2026-06-30T09:48:20Z"},
+					},
+				},
+				// reconcileExternallyMergedTasks looks up the pinned PR by number; #12
+				// is closed-unmerged, so the precise pass records a breadcrumb only.
+				pullsByNumber: map[int64]github.PullRequest{12: {Number: 12, State: "closed", HeadRef: branch, BaseRef: "main"}},
+				comments:      map[int64][]github.IssueComment{},
+			}
+			engine := workflow.Engine{Store: store}
+			daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+			if err := daemon.PollOnce(ctx); err != nil {
+				t.Fatalf("PollOnce returned error: %v", err)
+			}
+			task, err := store.GetTask(ctx, "task-fork")
+			if err != nil {
+				t.Fatalf("GetTask returned error: %v", err)
+			}
+			if task.State == string(workflow.TaskMerged) {
+				t.Fatalf("task falsely resolved to merged by an unrelated same-branch sibling (state=%q)", task.State)
+			}
+			if task.State != string(startState) {
+				t.Fatalf("task state = %q, want it left at %q (no fuzzy merge, no worktree delete)", task.State, startState)
+			}
+		})
+	}
+}
+
 // TestPollOnceReconcilesMergedSiblingPullRequest covers the literal #543 scenario
 // (finding 1): the real PR (#5) is MERGED while a duplicate (#6) on the SAME
 // branch was closed unmerged. Only #6 was ever recorded locally

--- a/internal/daemon/closed_reviewing_pr_test.go
+++ b/internal/daemon/closed_reviewing_pr_test.go
@@ -19,7 +19,8 @@ func TestPollOnceReconcilesClosedReviewingPullRequest(t *testing.T) {
 	const headSHA = "d0b6891d074f7b5af39c2555c6fe4b6fd3284003"
 
 	cases := []struct {
-		name string
+		name       string
+		startState workflow.TaskState
 		// openPulls / closedPulls are what GitHub reports for each list state.
 		openPulls   []github.PullRequest
 		closedPulls []github.PullRequest
@@ -33,6 +34,20 @@ func TestPollOnceReconcilesClosedReviewingPullRequest(t *testing.T) {
 			// task is still reviewing. Reconcile to terminal blocked + closed PR.
 			name:        "closed unmerged duplicate is reconciled to blocked",
 			openPulls:   nil,
+			closedPulls: []github.PullRequest{{Number: 6, State: "closed", HeadRef: branch, BaseRef: "main", HeadSHA: headSHA}},
+			wantTask:    workflow.TaskBlocked,
+			wantPRState: "closed",
+		},
+		{
+			name:        "closed unmerged pr_open is reconciled to blocked",
+			startState:  workflow.TaskPullRequestOpen,
+			closedPulls: []github.PullRequest{{Number: 6, State: "closed", HeadRef: branch, BaseRef: "main", HeadSHA: headSHA}},
+			wantTask:    workflow.TaskBlocked,
+			wantPRState: "closed",
+		},
+		{
+			name:        "closed unmerged changes_requested is reconciled to blocked",
+			startState:  workflow.TaskChangesRequested,
 			closedPulls: []github.PullRequest{{Number: 6, State: "closed", HeadRef: branch, BaseRef: "main", HeadSHA: headSHA}},
 			wantTask:    workflow.TaskBlocked,
 			wantPRState: "closed",
@@ -71,12 +86,16 @@ func TestPollOnceReconcilesClosedReviewingPullRequest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			store := testStore(t)
+			startState := tc.startState
+			if startState == "" {
+				startState = workflow.TaskReviewing
+			}
 			if err := store.UpsertTask(ctx, db.Task{
 				ID:           "task-7304",
 				RepoFullName: repo.FullName(),
 				GoalID:       "goal-1",
 				Title:        "CSV Export",
-				State:        string(workflow.TaskReviewing),
+				State:        string(startState),
 				Branch:       branch,
 			}); err != nil {
 				t.Fatalf("UpsertTask returned error: %v", err)
@@ -131,6 +150,12 @@ func TestPollOnceReconcilesClosedReviewingPullRequest(t *testing.T) {
 			// The PR row identity must be preserved, never blanked, by reconciliation.
 			if pr.URL != "https://github.com/jerryfane/expensy/pull/6" || pr.HeadBranch != branch {
 				t.Fatalf("PR #6 row not preserved: url=%q head=%q", pr.URL, pr.HeadBranch)
+			}
+			if tc.wantTask == workflow.TaskBlocked {
+				events, err := store.ListTaskEvents(ctx, "task-7304")
+				if err != nil || len(events) != 1 || events[0].Kind != "pr_closed_unmerged" || events[0].FromState != string(startState) {
+					t.Fatalf("task events = %+v, err=%v", events, err)
+				}
 			}
 		})
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1225,6 +1225,17 @@ func (d Daemon) reconcileClosedReviewingTasks(ctx context.Context, openBranches 
 			continue
 		}
 		task := candidate.task
+		// The fuzzy same-branch merged-sibling resolution (#543) is only safe for
+		// `reviewing`, whose merged case this pass has always owned. pr_open and
+		// changes_requested are folded in (#1054) ONLY for the closed-unmerged ->
+		// blocked arm; their merged resolution stays with the precise, pinned-PR-
+		// number reconcileExternallyMergedTasks pass. Otherwise an unrelated merged
+		// PR that merely shares a (fork) branch name — with the head-SHA guard
+		// skipped on an empty stored SHA — could drive a still-open task to a
+		// spurious `merged` and delete its worktree.
+		if merged && workflow.TaskState(task.State) != workflow.TaskReviewing {
+			continue
+		}
 		leadAgent := "github"
 		if lock, err := d.Store.GetBranchLock(ctx, d.Repo.FullName(), task.Branch); err == nil {
 			if owner := strings.TrimSpace(lock.Owner); owner != "" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -222,17 +222,49 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 
 func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string]struct{}) error {
 	paths := config.Paths{ConfigFile: filepath.Join(filepath.Dir(d.Store.DatabasePath()), config.ConfigName)}
-	ttl, err := config.LoadStaleTaskTTL(paths)
+	plannedTTL, err := config.LoadPlannedTaskTTL(paths)
+	if err != nil {
+		d.logf("planned task reconciler skipped for %s: %v", d.Repo.FullName(), err)
+	} else if plannedTTL > 0 {
+		if err := d.reconcileTaskTTL(ctx, openBranches, taskTTLReconcilePolicy{
+			ttl:          plannedTTL,
+			states:       []string{string(workflow.TaskPlanned)},
+			eventKind:    "task_dismissed_planned_ttl",
+			reasonPrefix: "planned task auto-dismissed",
+			logLabel:     "planned task reconciler",
+		}); err != nil {
+			return err
+		}
+	}
+
+	staleTTL, err := config.LoadStaleTaskTTL(paths)
 	if err != nil {
 		d.logf("stale task reconciler skipped for %s: %v", d.Repo.FullName(), err)
 		return nil
 	}
-	if ttl == 0 {
+	if staleTTL == 0 {
 		return nil
 	}
-	candidates, err := d.Store.ListStaleTaskCandidates(ctx, d.Repo.FullName(), []string{
-		string(workflow.TaskImplementing), string(workflow.TaskBlocked),
-	}, d.now().Add(-ttl), staleTaskReconcileScanLimit)
+	return d.reconcileTaskTTL(ctx, openBranches, taskTTLReconcilePolicy{
+		ttl:          staleTTL,
+		states:       []string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
+		eventKind:    "task_dismissed_auto",
+		reasonPrefix: "stale task auto-dismissed",
+		logLabel:     "stale task reconciler",
+	})
+}
+
+type taskTTLReconcilePolicy struct {
+	ttl          time.Duration
+	states       []string
+	eventKind    string
+	reasonPrefix string
+	logLabel     string
+}
+
+func (d Daemon) reconcileTaskTTL(ctx context.Context, openBranches map[string]struct{}, policy taskTTLReconcilePolicy) error {
+	candidates, err := d.Store.ListStaleTaskCandidates(ctx, d.Repo.FullName(), policy.states,
+		d.now().Add(-policy.ttl), staleTaskReconcileScanLimit)
 	if err != nil {
 		return err
 	}
@@ -275,7 +307,7 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 		repo, err := d.Store.GetRepo(ctx, d.Repo.FullName())
 		if err != nil {
 			remoteCertain = false
-			d.logf("stale task reconciler remote check skipped for %s: %v", d.Repo.FullName(), err)
+			d.logf("%s remote check skipped for %s: %v", policy.logLabel, d.Repo.FullName(), err)
 		} else {
 			checker := d.RemoteBranches
 			if checker == nil {
@@ -284,7 +316,7 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 			remotePresent, err = checker.RemoteBranches(ctx, repo.CheckoutPath, branches)
 			if err != nil {
 				remoteCertain = false
-				d.logf("stale task reconciler remote check skipped for %s: %v", d.Repo.FullName(), err)
+				d.logf("%s remote check skipped for %s: %v", policy.logLabel, d.Repo.FullName(), err)
 			}
 		}
 	}
@@ -297,10 +329,9 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 	}
 	dismissed := 0
 	for _, item := range emptyBranch {
-		reason := fmt.Sprintf("stale task auto-dismissed: empty branch; ttl=%s; updated_at=%s", ttl, item.candidate.UpdatedAt)
+		reason := fmt.Sprintf("%s: empty branch; ttl=%s; updated_at=%s", policy.reasonPrefix, policy.ttl, item.candidate.UpdatedAt)
 		changed, _, err := d.Store.TransitionTaskStateWithEventIfNoActiveJob(ctx, item.task.ID,
-			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
-			string(workflow.TaskDismissed), "task_dismissed_auto", reason)
+			policy.states, string(workflow.TaskDismissed), policy.eventKind, reason)
 		if err != nil {
 			if errors.Is(err, db.ErrTaskHasActiveJob) {
 				continue
@@ -316,10 +347,9 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 		if _, present := remotePresent[branch]; present {
 			continue
 		}
-		reason := fmt.Sprintf("stale task auto-dismissed: remote ref refs/heads/%s absent; ttl=%s; updated_at=%s", branch, ttl, item.candidate.UpdatedAt)
+		reason := fmt.Sprintf("%s: remote ref refs/heads/%s absent; ttl=%s; updated_at=%s", policy.reasonPrefix, branch, policy.ttl, item.candidate.UpdatedAt)
 		changed, _, err := d.Store.TransitionTaskStateWithEventIfNoActiveJob(ctx, item.task.ID,
-			[]string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
-			string(workflow.TaskDismissed), "task_dismissed_auto", reason)
+			policy.states, string(workflow.TaskDismissed), policy.eventKind, reason)
 		if err != nil {
 			if errors.Is(err, db.ErrTaskHasActiveJob) {
 				continue
@@ -330,8 +360,8 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 			dismissed++
 		}
 	}
-	d.logf("stale task reconciler for %s: candidates=%d checked=%d dismissed=%d",
-		d.Repo.FullName(), len(candidates), len(emptyBranch)+len(remoteCandidates), dismissed)
+	d.logf("%s for %s: candidates=%d checked=%d dismissed=%d",
+		policy.logLabel, d.Repo.FullName(), len(candidates), len(emptyBranch)+len(remoteCandidates), dismissed)
 	return nil
 }
 
@@ -477,9 +507,11 @@ func (d Daemon) reconcileExternallyMergedTasks(ctx context.Context, openPullNumb
 			// The PR left the open set without merging. If it is closed
 			// (abandoned), record a closed status breadcrumb for any linked
 			// workflow so a pr_open/changes_requested task does not leave its
-			// workflow status frozen at "open". This is observability only, with
-			// NO task state change: the #953 conservatism against advancing or
-			// un-blocking a task on an abandoned PR is preserved. Idempotent and
+			// workflow status frozen at "open". This pass remains observability-
+			// only: reconcileClosedReviewingTasks is the single authoritative home
+			// for the closed-unmerged -> blocked transition, avoiding two passes
+			// racing the same task. The #953 conservatism against advancing or
+			// un-blocking on any ambiguous PR state is preserved. Idempotent and
 			// non-fatal.
 			if strings.EqualFold(strings.TrimSpace(pull.State), "closed") {
 				if _, err := workflow.RecordPullRequestWorkflowTransition(ctx, d.Store, workflow.PullRequestEvent{
@@ -1118,19 +1150,28 @@ func (d Daemon) retryClosedReadyToMerge(ctx context.Context, openBranches map[st
 // a stale local `open` PR row.
 //
 // It mirrors retryClosedReadyToMerge's shape and cheap short-circuit: it only
-// consults GitHub's closed-PR list when a reviewing task has a branch with NO
-// currently-open PR (the wedge), so the healthy path — where a reviewing task's
-// PR is open and thus present in openBranches — makes zero extra GitHub reads.
+// consults GitHub's closed-PR list when a pr_open, reviewing, or
+// changes_requested task has a branch with NO currently-open PR (the wedge), so
+// the healthy path — where the task's PR is open and thus present in openBranches
+// — makes zero extra GitHub reads.
 // A genuinely-open PR is in openBranches and skipped, so the normal review path
 // is never disturbed. Matching is by branch + PR number (+ head SHA when known);
-// the engine transition is no-op unless the task is still `reviewing`.
+// the engine CAS is a no-op unless the task is still one of those three states.
 func (d Daemon) reconcileClosedReviewingTasks(ctx context.Context, openBranches map[string]struct{}) error {
 	if d.Workflow == nil {
 		return nil
 	}
-	tasks, err := d.Store.ListTasksByRepoState(ctx, d.Repo.FullName(), string(workflow.TaskReviewing))
-	if err != nil {
-		return err
+	var tasks []db.Task
+	for _, state := range []workflow.TaskState{
+		workflow.TaskPullRequestOpen,
+		workflow.TaskReviewing,
+		workflow.TaskChangesRequested,
+	} {
+		stateTasks, err := d.Store.ListTasksByRepoState(ctx, d.Repo.FullName(), string(state))
+		if err != nil {
+			return err
+		}
+		tasks = append(tasks, stateTasks...)
 	}
 	if len(tasks) == 0 {
 		return nil

--- a/internal/daemon/external_merge_reconcile_test.go
+++ b/internal/daemon/external_merge_reconcile_test.go
@@ -106,13 +106,15 @@ func TestExternalMergeCandidateState(t *testing.T) {
 	}
 }
 
-func TestPollOnceLeavesClosedUnmergedPullRequestOpenTaskUnchanged(t *testing.T) {
+func TestPollOnceBlocksClosedUnmergedPullRequestOpenTask(t *testing.T) {
 	ctx := context.Background()
 	repo := github.Repository{Owner: "owner", Name: "repo"}
 	store := testStore(t)
 	seedExternalMergeTask(t, store, repo, "task-7", "feature/seven", workflow.TaskPullRequestOpen, 7)
 	client := &fakeGitHub{
-		pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
+		pullsByState: map[string][]github.PullRequest{"open": nil, "closed": {
+			{Number: 7, State: "closed", HeadRef: "feature/seven", HeadSHA: "head-7"},
+		}},
 		pullsByNumber: map[int64]github.PullRequest{7: {Number: 7, State: "closed", HeadRef: "feature/seven", HeadSHA: "head-7"}},
 		comments:      map[int64][]github.IssueComment{},
 	}
@@ -122,15 +124,18 @@ func TestPollOnceLeavesClosedUnmergedPullRequestOpenTaskUnchanged(t *testing.T) 
 	if err := daemon.PollOnce(ctx); err != nil {
 		t.Fatalf("PollOnce: %v", err)
 	}
-	assertExternalMergeState(t, store, repo.FullName(), "task-7", 7, workflow.TaskPullRequestOpen, "open")
+	assertExternalMergeState(t, store, repo.FullName(), "task-7", 7, workflow.TaskBlocked, "closed")
+	events, err := store.ListTaskEvents(ctx, "task-7")
+	if err != nil || len(events) != 1 || events[0].Kind != "pr_closed_unmerged" {
+		t.Fatalf("task events = %+v, err=%v", events, err)
+	}
 }
 
 // TestPollOnceRecordsClosedBreadcrumbForWorkflowLinkedPROpenTask covers #958's
 // acceptance criterion that a closed-unmerged PR reads as "closed" on the
-// workflow view even when the task never entered `reviewing`. The task state
-// must NOT change (an abandoned PR does not advance/un-block a pr_open task —
-// the #953 conservatism), only the workflow status breadcrumb is emitted, and
-// it must be idempotent across ticks and never imply success.
+// workflow view even when the task never entered `reviewing`. The clean closed-
+// unmerged detection blocks the task while the workflow breadcrumb remains
+// idempotent across ticks and never implies success.
 func TestPollOnceRecordsClosedBreadcrumbForWorkflowLinkedPROpenTask(t *testing.T) {
 	t.Setenv("HERDR_SOCKET_PATH", "/tmp/throwaway")
 	t.Setenv("HERDR_ENV", "")
@@ -144,7 +149,9 @@ func TestPollOnceRecordsClosedBreadcrumbForWorkflowLinkedPROpenTask(t *testing.T
 		t.Fatalf("CreateJob: %v", err)
 	}
 	client := &fakeGitHub{
-		pullsByState:  map[string][]github.PullRequest{"open": nil, "closed": nil},
+		pullsByState: map[string][]github.PullRequest{"open": nil, "closed": {
+			{Number: 7, State: "closed", HeadRef: "feature/seven", HeadSHA: "head-7"},
+		}},
 		pullsByNumber: map[int64]github.PullRequest{7: {Number: 7, State: "closed", HeadRef: "feature/seven", HeadSHA: "head-7"}},
 		comments:      map[int64][]github.IssueComment{},
 	}
@@ -158,8 +165,11 @@ func TestPollOnceRecordsClosedBreadcrumbForWorkflowLinkedPROpenTask(t *testing.T
 		t.Fatalf("second PollOnce: %v", err)
 	}
 
-	// Abandoned PR must not change task state; only the workflow view updates.
-	assertExternalMergeState(t, store, repo.FullName(), "task-7", 7, workflow.TaskPullRequestOpen, "open")
+	assertExternalMergeState(t, store, repo.FullName(), "task-7", 7, workflow.TaskBlocked, "closed")
+	taskEvents, err := store.ListTaskEvents(ctx, "task-7")
+	if err != nil || len(taskEvents) != 1 || taskEvents[0].Kind != "pr_closed_unmerged" {
+		t.Fatalf("task events after two ticks = %+v, err=%v", taskEvents, err)
+	}
 
 	notes, err := store.ListWorkflowNotes(ctx, "gitmoot4/selfdesc-958", 0)
 	if err != nil || len(notes) != 1 || notes[0].Author != db.WorkflowAutoNoteAuthor || notes[0].Body != "[auto:pr:7:closed] PR #7 closed without merging" {

--- a/internal/daemon/stale_task_reconcile_test.go
+++ b/internal/daemon/stale_task_reconcile_test.go
@@ -277,6 +277,62 @@ func TestStaleTaskReconcilerDisabledAndInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestPlannedTaskReconcilerDefaultOffAndOptIn(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		config      string
+		liveJob     bool
+		wantDismiss bool
+	}{
+		{name: "default off"},
+		{name: "invalid remains off", config: "later"},
+		{name: "opted in", config: "1h", wantDismiss: true},
+		{name: "in-flight task run stays planned", config: "1h", liveJob: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := testStore(t)
+			repo := github.Repository{Owner: "owner", Name: "repo"}
+			seedStaleRepo(t, store, repo)
+			if test.config != "" {
+				writeTaskTTLConfig(t, store, "0", test.config)
+			}
+			task := db.Task{ID: "task-planned", RepoFullName: repo.FullName(), State: string(workflow.TaskPlanned)}
+			if err := store.UpsertTask(ctx, task); err != nil {
+				t.Fatal(err)
+			}
+			if test.liveJob {
+				payload, _ := json.Marshal(workflow.JobPayload{Repo: repo.FullName(), TaskID: task.ID})
+				if err := store.CreateJob(ctx, db.Job{ID: "task-run", Type: "implement", State: string(workflow.JobQueued), Payload: string(payload)}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			d := Daemon{Repo: repo, Store: store, Now: futureClock, RemoteBranches: &fakeRemoteBranchChecker{present: map[string]struct{}{}}}
+			if err := d.reconcileStaleTasks(ctx, map[string]struct{}{}); err != nil {
+				t.Fatalf("reconcileStaleTasks: %v", err)
+			}
+			got, err := store.GetTask(ctx, task.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if dismissed := got.State == string(workflow.TaskDismissed); dismissed != test.wantDismiss {
+				t.Fatalf("task state = %s, wantDismiss=%v", got.State, test.wantDismiss)
+			}
+			events, err := store.ListTaskEvents(ctx, task.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.wantDismiss {
+				if len(events) != 1 || events[0].Kind != "task_dismissed_planned_ttl" || events[0].FromState != string(workflow.TaskPlanned) || events[0].ToState != string(workflow.TaskDismissed) {
+					t.Fatalf("events = %+v", events)
+				}
+			} else if len(events) != 0 {
+				t.Fatalf("unexpected events = %+v", events)
+			}
+		})
+	}
+}
+
 func TestPollOnceRunsStaleTaskReconciler(t *testing.T) {
 	ctx := context.Background()
 	store := testStore(t)
@@ -335,8 +391,17 @@ func seedStaleRepo(t *testing.T, store *db.Store, repo github.Repository) {
 
 func writeStaleTaskConfig(t *testing.T, store *db.Store, value string) {
 	t.Helper()
+	writeTaskTTLConfig(t, store, value, "")
+}
+
+func writeTaskTTLConfig(t *testing.T, store *db.Store, staleTTL, plannedTTL string) {
+	t.Helper()
 	path := filepath.Join(filepath.Dir(store.DatabasePath()), "config.toml")
-	if err := os.WriteFile(path, []byte("[workflow]\nstale_task_ttl = \""+value+"\"\n"), 0o600); err != nil {
+	content := "[workflow]\nstale_task_ttl = \"" + staleTTL + "\"\n"
+	if plannedTTL != "" {
+		content += "planned_ttl = \"" + plannedTTL + "\"\n"
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/db/store_tasks.go
+++ b/internal/db/store_tasks.go
@@ -440,6 +440,30 @@ func (s *Store) ListTaskEvents(ctx context.Context, taskID string) ([]TaskEvent,
 
 var ErrTaskHasActiveJob = errors.New("task has a queued or running job")
 
+// CompareAndSwapTaskState atomically moves one task state without adding an
+// audit event. It exists for legacy lifecycle writers that already changed state
+// without task_events but need write-time exclusion against a concurrent
+// terminal transition. New audited lifecycle transitions should use
+// TransitionTaskStateWithEvent instead.
+func (s *Store) CompareAndSwapTaskState(ctx context.Context, taskID, from, to string) (changed bool, currentState string, err error) {
+	result, err := s.db.ExecContext(ctx, `UPDATE tasks SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND state = ?`,
+		strings.TrimSpace(to), strings.TrimSpace(taskID), strings.TrimSpace(from))
+	if err != nil {
+		return false, "", err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, "", err
+	}
+	if affected > 0 {
+		return true, strings.TrimSpace(to), nil
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, strings.TrimSpace(taskID)).Scan(&currentState); err != nil {
+		return false, "", err
+	}
+	return false, currentState, nil
+}
+
 // TransitionTaskStateWithEvent atomically compares and moves a task state and
 // appends its audit event. A failed comparison writes no event and returns the
 // current state so callers can distinguish idempotence from a conflicting move.

--- a/internal/workflow/closed_reviewing_cleanup_test.go
+++ b/internal/workflow/closed_reviewing_cleanup_test.go
@@ -200,17 +200,28 @@ func TestHandleReviewPullRequestClosedMergedLifecycleStates(t *testing.T) {
 	}
 }
 
-func TestHandleReviewPullRequestClosedUnmergedLeavesNonReviewingStatesUnchanged(t *testing.T) {
-	states := []TaskState{TaskPullRequestOpen, TaskChangesRequested, TaskReadyToMerge, TaskBlocked}
+func TestHandleReviewPullRequestClosedUnmergedLifecycleStates(t *testing.T) {
+	states := []struct {
+		state       TaskState
+		want        TaskState
+		wantPRState string
+		wantEvent   bool
+	}{
+		{state: TaskPullRequestOpen, want: TaskBlocked, wantPRState: "closed", wantEvent: true},
+		{state: TaskReviewing, want: TaskBlocked, wantPRState: "closed", wantEvent: true},
+		{state: TaskChangesRequested, want: TaskBlocked, wantPRState: "closed", wantEvent: true},
+		{state: TaskReadyToMerge, want: TaskReadyToMerge, wantPRState: "open"},
+		{state: TaskBlocked, want: TaskBlocked, wantPRState: "open"},
+	}
 	for _, state := range states {
-		t.Run(string(state), func(t *testing.T) {
+		t.Run(string(state.state), func(t *testing.T) {
 			ctx := context.Background()
 			store := openEngineStore(t)
 			if err := store.UpsertTask(ctx, db.Task{
 				ID:           "task-893",
 				RepoFullName: "owner/repo",
 				Title:        "Conservative close handling",
-				State:        string(state),
+				State:        string(state.state),
 				Branch:       "feature/893",
 			}); err != nil {
 				t.Fatalf("UpsertTask: %v", err)
@@ -225,25 +236,38 @@ func TestHandleReviewPullRequestClosedUnmergedLeavesNonReviewingStatesUnchanged(
 			}
 
 			engine := Engine{Store: store}
-			if err := engine.HandleReviewPullRequestClosed(ctx, PullRequestEvent{
-				Repo:        "owner/repo",
-				Branch:      "feature/893",
-				PullRequest: 893,
-				TaskID:      "task-893",
-				TaskTitle:   "Conservative close handling",
-				LeadAgent:   "github",
-				Sender:      "github",
-			}, false); err != nil {
-				t.Fatalf("HandleReviewPullRequestClosed: %v", err)
+			for i := 0; i < 2; i++ {
+				if err := engine.HandleReviewPullRequestClosed(ctx, PullRequestEvent{
+					Repo:        "owner/repo",
+					Branch:      "feature/893",
+					PullRequest: 893,
+					TaskID:      "task-893",
+					TaskTitle:   "Conservative close handling",
+					LeadAgent:   "github",
+					Sender:      "github",
+				}, false); err != nil {
+					t.Fatalf("HandleReviewPullRequestClosed pass %d: %v", i+1, err)
+				}
 			}
 
 			task, err := store.GetTask(ctx, "task-893")
-			if err != nil || task.State != string(state) {
-				t.Fatalf("task = %+v, err=%v; want %s", task, err, state)
+			if err != nil || task.State != string(state.want) {
+				t.Fatalf("task = %+v, err=%v; want %s", task, err, state.want)
 			}
 			pr, err := store.GetPullRequest(ctx, "owner/repo", 893)
-			if err != nil || pr.State != "open" {
-				t.Fatalf("pull request = %+v, err=%v; want open", pr, err)
+			if err != nil || pr.State != state.wantPRState {
+				t.Fatalf("pull request = %+v, err=%v; want %s", pr, err, state.wantPRState)
+			}
+			events, err := store.ListTaskEvents(ctx, "task-893")
+			if err != nil {
+				t.Fatalf("ListTaskEvents: %v", err)
+			}
+			if state.wantEvent {
+				if len(events) != 1 || events[0].Kind != "pr_closed_unmerged" || events[0].FromState != string(state.state) || events[0].ToState != string(TaskBlocked) {
+					t.Fatalf("task events = %+v", events)
+				}
+			} else if len(events) != 0 {
+				t.Fatalf("unexpected task events = %+v", events)
 			}
 		})
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1151,10 +1151,11 @@ func (e Engine) HandlePullRequestReadyToMerge(ctx context.Context, event PullReq
 //
 // Merged PRs resolve any of
 // pr_open/reviewing/changes_requested/ready_to_merge/blocked; an already-merged
-// task is accepted only to repair its stale PR mirror. Closed-unmerged behavior
-// remains deliberately narrower: only reviewing uses the existing transition to
-// blocked; the other lifecycle states are untouched. Existing PR row fields
-// (url/base/merge SHA) are preserved.
+// task is accepted only to repair its stale PR mirror. A clean closed-unmerged
+// detection resolves pr_open/reviewing/changes_requested to blocked. The daemon's
+// closed-PR reconcile pass is the sole caller for that transition; the external-
+// merge pass only records its workflow breadcrumb, avoiding double handling.
+// Existing PR row fields (url/base/merge SHA) are preserved.
 func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullRequestEvent, merged bool) error {
 	if err := e.validate(); err != nil {
 		return err
@@ -1182,8 +1183,12 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 		default:
 			return nil
 		}
-	} else if taskState != TaskReviewing {
-		return nil
+	} else {
+		switch taskState {
+		case TaskPullRequestOpen, TaskReviewing, TaskChangesRequested:
+		default:
+			return nil
+		}
 	}
 	prState := "closed"
 	nextTaskState := TaskBlocked
@@ -1200,8 +1205,22 @@ func (e Engine) HandleReviewPullRequestClosed(ctx context.Context, event PullReq
 			// collision fallback advancing the implement task.
 			stateRef.Branch = ""
 		}
-		if err := e.setTaskState(ctx, stateRef, nextTaskState); err != nil {
-			return err
+		if merged {
+			if err := e.setTaskState(ctx, stateRef, nextTaskState); err != nil {
+				return err
+			}
+		} else {
+			changed, _, err := e.Store.TransitionTaskStateWithEvent(ctx, task.ID,
+				[]string{string(TaskPullRequestOpen), string(TaskReviewing), string(TaskChangesRequested)},
+				string(TaskBlocked), "pr_closed_unmerged", "pull request closed without merging")
+			if err != nil {
+				return err
+			}
+			if !changed {
+				// A concurrent lifecycle move won the CAS. Preserve that newer state and
+				// do not let this stale close observation rewrite the PR mirror.
+				return nil
+			}
 		}
 	}
 	pr := db.PullRequest{

--- a/internal/workflow/task_liveness.go
+++ b/internal/workflow/task_liveness.go
@@ -2,9 +2,17 @@ package workflow
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+const (
+	TaskEventBlockedTerminalNoPR = "task_blocked_terminal_no_pr"
+	TaskEventBlockedJobFailed    = "task_blocked_job_failed"
 )
 
 // FindLiveTaskJob returns one job that still owns lifecycle progress for task.
@@ -33,6 +41,55 @@ func FindLiveTaskJob(ctx context.Context, store *db.Store, task db.Task) (db.Job
 		}
 	}
 	return db.Job{}, false, nil
+}
+
+// ReconcileTerminalDrivingJob closes the post-advancement lifecycle gap for a
+// top-level implement job that has finished without a pull request or any live
+// successor. It must be called only after RunJob/AdvanceJob (and delegation
+// dispatch) has settled: FindLiveTaskJob is the authoritative successor/pending-
+// advancement gate, so queued retries and continuation work keep the task live.
+// Delegation children are excluded because their parent DAG owns advancement.
+func (e Engine) ReconcileTerminalDrivingJob(ctx context.Context, jobID string) error {
+	if err := e.validate(); err != nil {
+		return err
+	}
+	job, payload, err := e.jobPayload(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if job.Type != "implement" || strings.TrimSpace(payload.ParentJobID) != "" || strings.TrimSpace(payload.DelegationID) != "" {
+		return nil
+	}
+	if !IsSettledJobState(job.State) || payload.PullRequest > 0 || strings.TrimSpace(payload.TaskID) == "" {
+		return nil
+	}
+	task, err := e.Store.GetTask(ctx, payload.TaskID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	if TaskState(task.State) != TaskImplementing {
+		return nil
+	}
+	if _, live, err := FindLiveTaskJob(ctx, e.Store, task); err != nil {
+		return err
+	} else if live {
+		return nil
+	}
+
+	kind := TaskEventBlockedJobFailed
+	reason := fmt.Sprintf("top-level implement job %s ended in %s without a pull request or live successor", job.ID, job.State)
+	if job.State == string(JobSucceeded) && payload.Result != nil && payload.Result.Decision == "implemented" {
+		kind = TaskEventBlockedTerminalNoPR
+		reason = fmt.Sprintf("top-level implement job %s succeeded with decision implemented but produced no pull request or live successor", job.ID)
+	} else if payload.Result != nil && strings.TrimSpace(payload.Result.Decision) != "" {
+		reason = fmt.Sprintf("top-level implement job %s ended in %s with decision %s and no pull request or live successor", job.ID, job.State, payload.Result.Decision)
+	}
+	_, _, err = e.Store.TransitionTaskStateWithEvent(ctx, task.ID,
+		[]string{string(TaskImplementing)}, string(TaskBlocked), kind, reason)
+	return err
 }
 
 func jobMatchesTask(payload JobPayload, task db.Task) bool {

--- a/internal/workflow/task_liveness_test.go
+++ b/internal/workflow/task_liveness_test.go
@@ -1,10 +1,80 @@
 package workflow
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 )
+
+func TestReconcileTerminalDrivingJob(t *testing.T) {
+	tests := []struct {
+		name          string
+		jobState      JobState
+		decision      string
+		parentJobID   string
+		delegationID  string
+		taskState     TaskState
+		successor     bool
+		wantTaskState TaskState
+		wantEvent     string
+	}{
+		{name: "terminal failure blocks", jobState: JobFailed, decision: "failed", taskState: TaskImplementing, wantTaskState: TaskBlocked, wantEvent: TaskEventBlockedJobFailed},
+		{name: "implemented success without PR blocks", jobState: JobSucceeded, decision: "implemented", taskState: TaskImplementing, wantTaskState: TaskBlocked, wantEvent: TaskEventBlockedTerminalNoPR},
+		{name: "already advanced to pr_open is untouched", jobState: JobSucceeded, decision: "implemented", taskState: TaskPullRequestOpen, wantTaskState: TaskPullRequestOpen},
+		{name: "delegation child is untouched", jobState: JobFailed, decision: "failed", parentJobID: "parent", delegationID: "child", taskState: TaskImplementing, wantTaskState: TaskImplementing},
+		{name: "queued successor keeps task live", jobState: JobFailed, decision: "failed", taskState: TaskImplementing, successor: true, wantTaskState: TaskImplementing},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", Branch: "feature/one", State: string(test.taskState)}); err != nil {
+				t.Fatal(err)
+			}
+			payload := JobPayload{
+				Repo: "owner/repo", Branch: "feature/one", TaskID: "task-1",
+				ParentJobID: test.parentJobID, DelegationID: test.delegationID,
+				Result: &AgentResult{Decision: test.decision, Summary: "done"},
+			}
+			encoded, _ := json.Marshal(payload)
+			if err := store.CreateJob(ctx, db.Job{ID: "job-1", Type: "implement", State: string(test.jobState), Payload: string(encoded)}); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-1", Kind: "advance_completed"}); err != nil {
+				t.Fatal(err)
+			}
+			if test.successor {
+				successorPayload, _ := json.Marshal(JobPayload{Repo: "owner/repo", Branch: "feature/one", TaskID: "task-1"})
+				if err := store.CreateJob(ctx, db.Job{ID: "job-2", Type: "implement", State: string(JobQueued), Payload: string(successorPayload)}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			engine := Engine{Store: store}
+			for i := 0; i < 2; i++ {
+				if err := engine.ReconcileTerminalDrivingJob(ctx, "job-1"); err != nil {
+					t.Fatalf("ReconcileTerminalDrivingJob pass %d: %v", i+1, err)
+				}
+			}
+			task, err := store.GetTask(ctx, "task-1")
+			if err != nil || task.State != string(test.wantTaskState) {
+				t.Fatalf("task = %+v, err=%v; want %s", task, err, test.wantTaskState)
+			}
+			events, err := store.ListTaskEvents(ctx, task.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.wantEvent == "" {
+				if len(events) != 0 {
+					t.Fatalf("unexpected task events = %+v", events)
+				}
+			} else if len(events) != 1 || events[0].Kind != test.wantEvent {
+				t.Fatalf("task events = %+v, want one %s", events, test.wantEvent)
+			}
+		})
+	}
+}
 
 func TestJobKeepsTaskLiveTable(t *testing.T) {
 	completionMarkers := []string{"advance_completed", "advance_retried", "advance_blocked", "advance_retry_skipped", "retry_queued"}

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -96,11 +96,14 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		return db.Task{}, err
 	}
 	task, err := e.Store.GetTask(ctx, request.TaskID)
+	claimPlanned := false
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			return db.Task{}, err
 		}
 		task = db.Task{ID: request.TaskID, RepoFullName: request.Repo, State: string(TaskPlanned)}
+	} else {
+		claimPlanned = task.State == string(TaskPlanned)
 	}
 	if task.State == string(TaskDismissed) {
 		return db.Task{}, fmt.Errorf("task %s is dismissed; recover it explicitly before allocating a worktree", request.TaskID)
@@ -130,6 +133,14 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		}
 	}
 	if task.Branch == request.Branch && task.WorktreePath == path {
+		if claimPlanned {
+			if err := e.claimPlannedTaskForImplementation(ctx, task.ID); err != nil {
+				if createdLock {
+					_, _ = e.Store.ReleaseLock(ctx, lock)
+				}
+				return db.Task{}, err
+			}
+		}
 		task.State = string(TaskImplementing)
 		if err := e.Store.UpsertTask(ctx, task); err != nil {
 			if createdLock {
@@ -174,6 +185,20 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		Branch:       request.Branch,
 		WorktreePath: path,
 	}
+	if claimPlanned {
+		// Close the planned_ttl/task-run race at the write boundary. A TTL
+		// dismissal that won after the initial GetTask makes this CAS fail, so the
+		// following legacy UpsertTask can never resurrect dismissed -> implementing.
+		if err := e.claimPlannedTaskForImplementation(ctx, task.ID); err != nil {
+			if cleaner, ok := manager.(ReadOnlyWorktreeManager); ok {
+				_ = cleaner.RemoveWorktreeForce(context.Background(), path)
+			}
+			if createdLock {
+				_, _ = e.Store.ReleaseLock(ctx, lock)
+			}
+			return db.Task{}, err
+		}
+	}
 	if err := e.Store.UpsertTask(ctx, task); err != nil {
 		if createdLock {
 			_, _ = e.Store.ReleaseLock(ctx, lock)
@@ -181,6 +206,20 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		return db.Task{}, err
 	}
 	return task, nil
+}
+
+func (e Engine) claimPlannedTaskForImplementation(ctx context.Context, taskID string) error {
+	changed, current, err := e.Store.CompareAndSwapTaskState(ctx, taskID, string(TaskPlanned), string(TaskImplementing))
+	if err != nil {
+		return err
+	}
+	if changed {
+		return nil
+	}
+	if current == string(TaskDismissed) {
+		return fmt.Errorf("task %s was dismissed while task run was starting; recover it explicitly before retrying", taskID)
+	}
+	return fmt.Errorf("task %s left planned state while task run was starting (now %s); retry from its current lifecycle state", taskID, current)
 }
 
 // DelegationWorktreeRequest carries the inputs needed to allocate a git

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -131,6 +131,38 @@ func TestEngineAllocateTaskWorktreeRejectsDismissedTask(t *testing.T) {
 	}
 }
 
+func TestEngineAllocateTaskWorktreeDoesNotResurrectConcurrentPlannedTTLDismissal(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-race", RepoFullName: "owner/repo", State: string(TaskPlanned)}); err != nil {
+		t.Fatal(err)
+	}
+	manager := &fakeWorktreeManager{onAdd: func() {
+		changed, _, err := store.TransitionTaskStateWithEventIfNoActiveJob(ctx, "task-race",
+			[]string{string(TaskPlanned)}, string(TaskDismissed), "task_dismissed_planned_ttl", "test interleave")
+		if err != nil || !changed {
+			t.Fatalf("planned_ttl interleave changed=%v err=%v", changed, err)
+		}
+	}}
+	_, err := testEngine(store).AllocateTaskWorktree(ctx, TaskWorktreeRequest{
+		Home: t.TempDir(), Repo: "owner/repo", TaskID: "task-race", Branch: "feature/race", Owner: "lead", Checkout: t.TempDir(),
+	}, manager)
+	if err == nil || !strings.Contains(err.Error(), "was dismissed") {
+		t.Fatalf("AllocateTaskWorktree error = %v, want concurrent dismissal refusal", err)
+	}
+	task, getErr := store.GetTask(ctx, "task-race")
+	if getErr != nil || task.State != string(TaskDismissed) {
+		t.Fatalf("task = %+v, err=%v; dismissed task was resurrected", task, getErr)
+	}
+	events, eventErr := store.ListTaskEvents(ctx, task.ID)
+	if eventErr != nil || len(events) != 1 || events[0].Kind != "task_dismissed_planned_ttl" {
+		t.Fatalf("events = %+v, err=%v", events, eventErr)
+	}
+	if len(manager.removedForce) != 1 {
+		t.Fatalf("worktree cleanup calls = %v, want one", manager.removedForce)
+	}
+}
+
 func TestEngineAllocateTaskWorktreeWaitsForCheckoutMutationLock(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1275,8 +1275,14 @@ best-effort, and appends `task_dismissed_manual` to `task events`. Repeating the
 command is an exit-0 no-op with `changed:false` in JSON.
 
 `task events <id>` prints the append-only task lifecycle trail. Automatic stale
-dismissals use `task_dismissed_auto`; explicit recovery and retry use
-`task_recovered` and `task_recovered_job_retry`.
+dismissals use `task_dismissed_auto`; opt-in never-started-plan retirement uses
+`task_dismissed_planned_ttl`; explicit recovery and retry use `task_recovered`
+and `task_recovered_job_retry`. A clean closed-unmerged PR records
+`pr_closed_unmerged` while moving `pr_open`, `reviewing`, or
+`changes_requested` to `blocked`. Once advancement/delegation handling has no
+live successor, a terminal top-level implement job without a PR records
+`task_blocked_terminal_no_pr` for implemented success or
+`task_blocked_job_failed` for another terminal outcome and blocks the task.
 
 ### Recover A Dead Implement
 
@@ -1323,6 +1329,15 @@ restart that points to it):
 - **Live process still in the worktree** — `task recover` refuses while a live
   process is still inside the task worktree; wait for it to exit or stop the
   orphaned implementer before recovering.
+
+Planned-task retirement is separate from the default-on stale implementation
+sweep. Set `[workflow].planned_ttl = "720h"` only when the repository explicitly
+wants old never-started plans dismissed. It is off by default; unset, empty,
+`"0"`, or invalid values disable it because dismissal can lose human context a
+goal-file import cannot restore. Live jobs, open PRs, remote branches, and
+uncertain remote checks prevent dismissal. A write-time allocation CAS also
+prevents `task run` from resurrecting a concurrently dismissed plan; recover it
+explicitly before retrying.
 
 ## PR Comments
 

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -738,6 +738,24 @@ recover` restores preserved artifacts through `implementing` to `pr_open`, or
 restores a branchless task to `planned`; job retry records its own recovery
 event. The server-side task board omits dismissed rows immediately.
 
+Never-started `planned` tasks use a separate opt-in policy:
+`[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
+zero, and invalid values all resolve to off because automatic dismissal can
+destroy human planning context that goal-file re-import cannot reconstruct.
+When enabled, it reuses the same live-job, same-repo open-PR, remote-branch,
+and remote-uncertainty skips and records `task_dismissed_planned_ttl`. Task
+worktree allocation claims `planned -> implementing` with a write-time CAS, so
+a concurrent TTL dismissal cannot be overwritten; explicit recovery is needed.
+
+A clean closed-unmerged PR moves `pr_open`, `reviewing`, or
+`changes_requested` to `blocked` with `pr_closed_unmerged`; ambiguous PR state
+does not advance or unblock anything. After advancement and delegation handling,
+a terminal top-level implement job with no PR and no live successor blocks an
+otherwise-stuck `implementing` task. Implemented success without a PR records
+`task_blocked_terminal_no_pr`; other terminal outcomes record
+`task_blocked_job_failed`. Delegation children and tasks with queued retries,
+fixes, continuations, or pending advancement remain under their existing owner.
+
 **PR-bound fix pass:** use `gitmoot agent implement <agent> --repo owner/repo
 --pr <number> "..."` or `gitmoot agent run <agent> --repo owner/repo --action
 implement --pr <number> "..."` to send an existing open PR back through its

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1092,7 +1092,10 @@ resume machinery, and refuses while a matching job or worktree process remains
 live. It preserves branch and worktree, releases the branch lock best-effort,
 and records `task_dismissed_manual`; an already-dismissed task is an exit-0
 no-op (`changed:false` in JSON). `task events <id>` lists the append-only trail,
-including daemon `task_dismissed_auto` and explicit recovery events.
+including daemon `task_dismissed_auto`, opt-in
+`task_dismissed_planned_ttl`, closed-unmerged `pr_closed_unmerged`, terminal
+top-level implement triage (`task_blocked_terminal_no_pr` or
+`task_blocked_job_failed`), and explicit recovery events.
 
 ### Recover a dead implement
 
@@ -1142,6 +1145,24 @@ qualifying `implementing`/`blocked` tasks per repo poll.
 branches, branches still present on `origin`, and remote-check uncertainty all
 prevent automatic dismissal; successful transitions record
 `task_dismissed_auto`.
+
+`[workflow].planned_ttl = "720h"` is a separate repository opt-in for old
+never-started plans. It is disabled by default; unset, empty, `"0"`, and invalid
+values all mean off because automatic dismissal can destroy human planning
+context that goal-file re-import cannot reconstruct. When enabled it uses the
+same live-job, same-repo open-PR, remote-branch, and remote-uncertainty skips and
+records `task_dismissed_planned_ttl`. Task allocation claims
+`planned -> implementing` atomically at the write boundary, so a concurrent TTL
+dismissal cannot be resurrected by `task run`; explicit recovery is required.
+
+A clean closed-unmerged PR moves `pr_open`, `reviewing`, or
+`changes_requested` to `blocked` with `pr_closed_unmerged`; ambiguous PR state
+remains conservative. After advancement and delegation handling, a terminal
+top-level implement job with no PR and no live successor also blocks an
+`implementing` task. Implemented success without a PR records
+`task_blocked_terminal_no_pr`; other terminal outcomes record
+`task_blocked_job_failed`. Delegation children and queued fixes, retries,
+continuations, or pending advancement are not reclassified.
 
 Two refusals guard recovery (and the `task run` / `agent implement` restart that
 points to it):

--- a/website/docs/workflows/planner-goal-workflow.md
+++ b/website/docs/workflows/planner-goal-workflow.md
@@ -53,3 +53,19 @@ Then import and run tasks through Gitmoot:
 gitmoot goal import --file GOAL.md --repo owner/repo
 gitmoot task run task-001 --repo owner/repo --owner planner --base main
 ```
+
+Imported plans remain `planned` until explicitly run. Repositories may opt into
+retiring old never-started plans with `[workflow].planned_ttl = "720h"`, but it
+is disabled by default (unset, empty, zero, or invalid means off): automatic
+dismissal can destroy human planning context a goal-file re-import cannot
+reconstruct. Enabled sweeps skip live jobs, open PRs, present remote branches,
+and uncertain remote checks and record `task_dismissed_planned_ttl`. The
+`task run` allocation uses a write-time state claim, so it cannot resurrect a
+plan that a concurrent sweep dismissed; use explicit `task recover` instead.
+
+Once work starts, lifecycle reconciliation favors visible human triage. A clean
+closed-unmerged PR blocks linked `pr_open`, `reviewing`, and
+`changes_requested` tasks (`pr_closed_unmerged`). A terminal top-level implement
+job that finishes advancement/delegation with no PR or live successor also
+blocks the task, while delegation children and queued continuations remain under
+their existing workflow owner.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -746,6 +746,24 @@ activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
 set it to `"0"` to disable this poll leg. Candidates with a same-repo open PR,
 a remote branch, a live job, or an uncertain remote check are not dismissed.
 
+Never-started plans have a separate destructive opt-in:
+`[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
+`"0"`, and invalid values all mean off because dismissing a plan can destroy
+human context that a goal-file re-import cannot reconstruct. When enabled, the
+same live-job, open-PR, remote-branch, and uncertain-remote safeguards apply,
+and a dismissal records `task_dismissed_planned_ttl`. `task run` claims
+`planned -> implementing` atomically at allocation time, so a concurrent TTL
+dismissal cannot resurrect the task; use explicit `task recover` before retrying.
+
+A PR cleanly observed closed without merging moves a linked `pr_open`,
+`reviewing`, or `changes_requested` task to `blocked` and records
+`pr_closed_unmerged`; ambiguous observations remain conservative. After
+advancement and delegation handling, a terminal top-level implement job with no
+PR and no live successor also moves `implementing` to `blocked`. Implemented
+success without a PR records `task_blocked_terminal_no_pr`; other terminal
+outcomes record `task_blocked_job_failed`. Delegation children and queued
+fix/retry/continuation jobs are excluded.
+
 Dismissed tasks never return to implementation through ordinary task run,
 allocation, or late workflow advancement. `task recover` is the explicit path:
 preserved branch/worktree artifacts move through `implementing` to `pr_open`,
@@ -10782,8 +10800,14 @@ best-effort, and appends `task_dismissed_manual` to `task events`. Repeating the
 command is an exit-0 no-op with `changed:false` in JSON.
 
 `task events <id>` prints the append-only task lifecycle trail. Automatic stale
-dismissals use `task_dismissed_auto`; explicit recovery and retry use
-`task_recovered` and `task_recovered_job_retry`.
+dismissals use `task_dismissed_auto`; opt-in never-started-plan retirement uses
+`task_dismissed_planned_ttl`; explicit recovery and retry use `task_recovered`
+and `task_recovered_job_retry`. A clean closed-unmerged PR records
+`pr_closed_unmerged` while moving `pr_open`, `reviewing`, or
+`changes_requested` to `blocked`. Once advancement/delegation handling has no
+live successor, a terminal top-level implement job without a PR records
+`task_blocked_terminal_no_pr` for implemented success or
+`task_blocked_job_failed` for another terminal outcome and blocks the task.
 
 ### Recover A Dead Implement
 
@@ -10830,6 +10854,15 @@ restart that points to it):
 - **Live process still in the worktree** — `task recover` refuses while a live
   process is still inside the task worktree; wait for it to exit or stop the
   orphaned implementer before recovering.
+
+Planned-task retirement is separate from the default-on stale implementation
+sweep. Set `[workflow].planned_ttl = "720h"` only when the repository explicitly
+wants old never-started plans dismissed. It is off by default; unset, empty,
+`"0"`, or invalid values disable it because dismissal can lose human context a
+goal-file import cannot restore. Live jobs, open PRs, remote branches, and
+uncertain remote checks prevent dismissal. A write-time allocation CAS also
+prevents `task run` from resurrecting a concurrently dismissed plan; recover it
+explicitly before retrying.
 
 ## PR Comments
 
@@ -13702,6 +13735,24 @@ mutation. A branchless candidate needs no remote lookup. Explicit `task
 recover` restores preserved artifacts through `implementing` to `pr_open`, or
 restores a branchless task to `planned`; job retry records its own recovery
 event. The server-side task board omits dismissed rows immediately.
+
+Never-started `planned` tasks use a separate opt-in policy:
+`[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
+zero, and invalid values all resolve to off because automatic dismissal can
+destroy human planning context that goal-file re-import cannot reconstruct.
+When enabled, it reuses the same live-job, same-repo open-PR, remote-branch,
+and remote-uncertainty skips and records `task_dismissed_planned_ttl`. Task
+worktree allocation claims `planned -> implementing` with a write-time CAS, so
+a concurrent TTL dismissal cannot be overwritten; explicit recovery is needed.
+
+A clean closed-unmerged PR moves `pr_open`, `reviewing`, or
+`changes_requested` to `blocked` with `pr_closed_unmerged`; ambiguous PR state
+does not advance or unblock anything. After advancement and delegation handling,
+a terminal top-level implement job with no PR and no live successor blocks an
+otherwise-stuck `implementing` task. Implemented success without a PR records
+`task_blocked_terminal_no_pr`; other terminal outcomes record
+`task_blocked_job_failed`. Delegation children and tasks with queued retries,
+fixes, continuations, or pending advancement remain under their existing owner.
 
 **PR-bound fix pass:** use `gitmoot agent implement <agent> --repo owner/repo
 --pr <number> "..."` or `gitmoot agent run <agent> --repo owner/repo --action


### PR DESCRIPTION
Implements the **tri-model-panel-amended** design for #1054 (the panel's unanimous `changes_requested` on the original body; verdict comment on the issue). Root-caused from the live Tasks page (28 active-looking, 11 provably dead).

## Part 1 — closed-unmerged PR → `blocked` (+ `pr_closed_unmerged` event)

The watcher transitioned closed-unmerged→blocked only for `reviewing` (and `ready_to_merge` via the merge gate); `pr_open`/`changes_requested` had no such arm (closed handling was breadcrumb-only), so those tasks sat in `pr_open` forever (live: tendwire PRs #15/#17/#19).

- Widens `HandleReviewPullRequestClosed`'s closed-unmerged gate + `reconcileClosedReviewingTasks`' candidate set to `pr_open`/`reviewing`/`changes_requested`. The external-merge pass stays **observability-only** — a single authoritative transition home, no double-handling.
- **`blocked`, not `dismissed`**: dismissed is hard-terminal and excluded from every reconcile candidate set, so it would wedge PR reopens and race an active fix job. `blocked` stays a live candidate.
- The transition routes through the CAS writer `TransitionTaskStateWithEvent` (the prior arms used `setTaskState` and emitted **no** event), adding a distinct **`pr_closed_unmerged`** task event and making it idempotent — it fires only on a real state move; a concurrent legitimate advance wins the CAS.

## Part 2 — `planned_ttl`, DEFAULT-OFF, opt-in per repo

Nothing auto-retired `planned` tasks (71 immortal ones live). The panel ruled this the one place the destroy-attention risk is real (a goal-file re-import can't restore human context), so it ships **disabled by default**.

- `[workflow].planned_ttl` mirrors `blocked_ttl`'s off-by-default semantics (absent/empty/`0`/negative/unparseable → disabled); distinct `task_dismissed_planned_ttl` event; reuses the stale reconciler's open-branch/remote-present/active-job safeguards via a shared policy helper.
- **Closes the task-run race** sol flagged: `AllocateTaskWorktree` now CAS-claims `planned→implementing` before its blind `UpsertTask` on both write paths, so a TTL dismiss that won the race can never be resurrected (with worktree/lock cleanup on the lost race).

## Part 3 — terminal driving-job triage

A top-level implement job that settles without a PR or live successor no longer strands its task in `implementing` for the full 168h TTL. After advancement/delegation handling, `ReconcileTerminalDrivingJob` → `blocked` (events `task_blocked_job_failed` / `task_blocked_terminal_no_pr` — the live `adhoc-2ecf64e7` succeeded-without-PR case), guarded on **top-level-only** (`ParentJobID`/`DelegationID` empty), settled, no-PR, still-`implementing`, and `FindLiveTaskJob==false` so a queued fix/retry keeps the task live.

## Review

`/code-review xhigh` (per the ladder for state-machine seams). One correctness finding — fixed in the second commit: widening the closed-PR pass exposed `pr_open`/`changes_requested` to `selectReconciledPull`'s fuzzy same-branch merged-**sibling** resolution (#543), which — with a fork PR + an unrelated merged PR sharing the head-ref name + an empty stored HeadSHA — could falsely resolve a still-open task to `merged` and delete its worktree. Gated that fuzzy resolution to `reviewing` only; the folded-in states keep the closed-unmerged→blocked arm, and their real merged case stays with the precise pinned-PR-number pass. Regression test verified load-bearing.

Three efficiency findings (a per-tick duplicate config read; a duplicate git remote check when planned_ttl is enabled; `FindLiveTaskJob`'s full jobs-table scan now on the completion path) are deferred to a follow-up — all bounded/opt-in, and the scan extends a pattern `FindLiveTaskJob` already runs on the daemon tick, so scoping its query is a clean standalone optimization for all its callers.

## Verification

Build/vet clean, `go generate` no drift; core packages (config/db/workflow/daemon) all green; the full cli suite green modulo the known `TestClaudeProduceHookAutoReadLandlockE2E` /tmp-checkout env confound.

## Deploy notes

**No deploy** — judging through Aug 5. `planned_ttl` is default-off so existing daemons are behavior-identical unless opted in; every auto-transition emits a loud distinct event kind, and `dismissed` remains recoverable history. Docs (skill + site + regenerated llms-full) updated.

Closes #1054.
