### PR TITLE
fix(worktree): TTL-reclaim terminal-owned delegation worktrees + surface leaks (#1056)

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -113,6 +113,13 @@ activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
 set it to `"0"` to disable this poll leg. Candidates with a same-repo open PR,
 a remote branch, a live job, or an uncertain remote check are not dismissed.
 
+Delegation worktrees have a separate default-on retention bound:
+`[workflow].delegation_worktree_ttl = "72h"`. Only worktrees owned by final jobs
+(`succeeded`, `failed`, or `cancelled`) older than the TTL are force-removed;
+`"0"` disables the pass. Blocked, queued, and running owners stay pinned. Run
+`gitmoot doctor` to see stale count, logical size, and the
+reclaimable/pinned/unproven breakdown; dashboard `/api/health` mirrors it.
+
 Never-started plans have a separate destructive opt-in:
 `[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
 `"0"`, and invalid values all mean off because dismissing a plan can destroy

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -639,3 +639,45 @@ Fixes:
   `GITMOOT_DISABLE_NATIVE_MERGE_GATE=1` (also `true`/`yes`/`on`; #545): Gitmoot
   then abstains from its native merge gate — fail-closed, it never merges
   gatelessly; the external gate makes the call.
+
+## Delegation worktrees consume too much disk
+
+`gitmoot doctor` reports delegation-worktree usage as
+`N stale worktrees / X GB under <home>/worktrees`. The detail separates aged
+final owners that are **reclaimable**, resumable/non-final owners that are
+**pinned**, and directories whose owner is **unproven**. Pinned includes
+`blocked`, `queued`, and `running`; Gitmoot never force-removes those.
+
+`[workflow].delegation_worktree_ttl = "72h"` is default-on because a final
+delegation owner cannot resume, while the grace period preserves short-term
+debugging access. Set it to `"0"` to disable the TTL pass. Aged final owners are
+force-removed even when dirty, Git worktree metadata is pruned, and
+`delegation_worktree_reclaimed_ttl` is recorded. The dashboard `/api/health`
+response exposes the same count, bytes, path, breakdown, and summary in its
+top-level `worktrees` field.
+
+For immediate manual relief, list paths and then prove the owner is final. Do
+not infer safety from directory age alone:
+
+```sh
+find "$HOME/.gitmoot/worktrees" -type d -path '*/delegations/*/*' -prune -print
+
+# sqlite3 is an optional operator aid, not a Gitmoot runtime dependency.
+sqlite3 "$HOME/.gitmoot/gitmoot.db" -header -column '
+SELECT id, state, updated_at, json_extract(payload, "$.worktree_path") AS path
+FROM jobs
+WHERE state IN ("succeeded", "failed", "cancelled")
+  AND datetime(updated_at) <= datetime("now", "-72 hours")
+  AND json_extract(payload, "$.worktree_path") <> ""
+  AND (json_extract(payload, "$.delegation_id") <> ""
+       OR json_extract(payload, "$.read_only_worktree") = 1);
+'
+
+gitmoot job show <job-id> --json
+git -C <registered-checkout> worktree remove --force <verified-worktree-path>
+git -C <registered-checkout> worktree prune
+```
+
+Before removal, verify that `job show` still reports `succeeded`, `failed`, or
+`cancelled` and the exact same `payload.worktree_path`. Never manually remove a
+worktree owned by a blocked, queued, or running job; settle that job first.

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -498,6 +499,7 @@ type tickCandidateStore interface {
 	JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, error)
 	JobIDsWithPendingCommentRetry(ctx context.Context) ([]string, error)
 	JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) ([]string, error)
+	JobIDsWithAgedTerminalDelegationWorktree(ctx context.Context, cutoff time.Time) ([]string, error)
 }
 
 // candidateMemo lazily runs one per-tick candidate query and shares its RESULT
@@ -525,10 +527,11 @@ func (m *candidateMemo) get(fetch func() ([]string, error)) ([]string, error) {
 }
 
 type tickCandidates struct {
-	store   tickCandidateStore
-	advance candidateMemo
-	comment candidateMemo
-	reclaim candidateMemo
+	store       tickCandidateStore
+	advance     candidateMemo
+	comment     candidateMemo
+	reclaim     candidateMemo
+	agedReclaim candidateMemo
 }
 
 // newTickCandidates is a package var (not a plain func) only so the once-per-tick
@@ -553,6 +556,12 @@ func (c *tickCandidates) commentRetryCandidates(ctx context.Context) ([]string, 
 func (c *tickCandidates) delegationReclaimCandidates(ctx context.Context) ([]string, error) {
 	return c.reclaim.get(func() ([]string, error) {
 		return c.store.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
+	})
+}
+
+func (c *tickCandidates) agedDelegationReclaimCandidates(ctx context.Context, cutoff time.Time) ([]string, error) {
+	return c.agedReclaim.get(func() ([]string, error) {
+		return c.store.JobIDsWithAgedTerminalDelegationWorktree(ctx, cutoff)
 	})
 }
 
@@ -669,6 +678,46 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 	return nil
 }
 
+// reclaimAgedTerminalDelegationWorktrees closes the cleanup crash window that
+// has no _cleanup_skipped marker. The bounded store query selects only FINAL
+// owners older than the configured TTL. Re-verification happens both here and
+// in Engine.ReclaimAgedTerminalDelegationWorktree; blocked/queued/running jobs
+// are never force-removed.
+func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorker, repoFilter string, rootFilter string, checkoutHeld func(string) bool, cand *tickCandidates, now time.Time, ttl time.Duration) error {
+	if ttl <= 0 {
+		return nil
+	}
+	jobIDs, err := cand.agedDelegationReclaimCandidates(ctx, now.Add(-ttl))
+	if err != nil {
+		return err
+	}
+	for _, jobID := range jobIDs {
+		job, err := worker.Store.GetJob(ctx, jobID)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if !workflow.IsFinalJobState(job.State) || !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
+			continue
+		}
+		if checkoutHeld != nil {
+			if checkoutHeld(queuedJobCheckoutKey(ctx, worker.Store, job)) {
+				continue
+			}
+			if repoFilter != "" && checkoutHeld("repo:"+repoFilter) {
+				continue
+			}
+		}
+		engine := worker.WorkflowFactory(worker.delegationParentCheckout(ctx, job))
+		if err := engine.ReclaimAgedTerminalDelegationWorktree(ctx, jobID, now.Add(-ttl)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // runDaemonWorkerTickTracked is the per-tick worker pass. With a nil tracker it
 // follows the historical synchronous tick behavior: maintenance scans,
 // then a BLOCKING runQueuedJobsForRepo dispatch. The supervisors pass a live
@@ -742,6 +791,14 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 			return err
 		}
 		if err := reclaimSkippedDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand); err != nil {
+			return err
+		}
+		// The store path is already the resolved Gitmoot root. Using it keeps this
+		// hot-read on the daemon's actual home and prevents the raw/resolved
+		// double-resolution bug class; isolated tests likewise stay in /tmp.
+		if ttl, err := resolveDelegationWorktreeTTL(filepath.Dir(store.DatabasePath())); err != nil {
+			writeLine(stdout, "delegation_worktree_ttl reclaim skipped: %v", err)
+		} else if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, repoFilter, rootFilter, tracker.checkoutHeld, cand, now, ttl); err != nil {
 			return err
 		}
 	}
@@ -838,15 +895,13 @@ func jobStateCanRetryAdvancement(state string) bool {
 }
 
 // jobStateEligibleForWorktreeReclaim gates the delegation/read-only worktree
-// reclaim pass. It is the advancement-retry set PLUS cancelled: a job aborted
-// (cancel / kill / supersede) before its terminal AdvanceJob leaves a
-// dispatch-allocated read-only worktree (#739) on disk with a
-// delegation_worktree_cleanup_skipped marker but a JobCancelled state, so the
-// reclaim pass must still dispose it. Cancelled is intentionally NOT added to
-// jobStateCanRetryAdvancement (a cancelled job must never RE-ADVANCE) — only its
-// worktree is reclaimed here, via the same idempotent, liveness-gated cleanup.
+// reclaim pass on FINAL states. Cancelled is included because an abort can leave
+// a dispatch-allocated read-only worktree, while blocked is excluded because it
+// is resumable and still owns its worktree. Cancelled remains intentionally out
+// of jobStateCanRetryAdvancement: its resources may be reclaimed, but the job
+// itself must never re-advance.
 func jobStateEligibleForWorktreeReclaim(state string) bool {
-	return jobStateCanRetryAdvancement(state) || state == string(workflow.JobCancelled)
+	return workflow.IsFinalJobState(state)
 }
 
 // retryPendingJobComments re-posts the result comment for any terminal job whose

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -4287,13 +4287,13 @@ func TestWarnSerializedParallelJobsSilentBelowTwo(t *testing.T) {
 func TestJobStateEligibleForWorktreeReclaim(t *testing.T) {
 	for _, s := range []string{
 		string(workflow.JobSucceeded), string(workflow.JobFailed),
-		string(workflow.JobBlocked), string(workflow.JobCancelled),
+		string(workflow.JobCancelled),
 	} {
 		if !jobStateEligibleForWorktreeReclaim(s) {
 			t.Fatalf("state %q must be worktree-reclaim eligible", s)
 		}
 	}
-	for _, s := range []string{string(workflow.JobQueued), string(workflow.JobRunning)} {
+	for _, s := range []string{string(workflow.JobQueued), string(workflow.JobRunning), string(workflow.JobBlocked)} {
 		if jobStateEligibleForWorktreeReclaim(s) {
 			t.Fatalf("state %q must not be worktree-reclaim eligible", s)
 		}
@@ -4678,6 +4678,7 @@ func TestTickCandidatesComputedOncePerTick(t *testing.T) {
 		atomic.StoreInt32(&counter.advance, 0)
 		atomic.StoreInt32(&counter.comment, 0)
 		atomic.StoreInt32(&counter.reclaim, 0)
+		atomic.StoreInt32(&counter.agedReclaim, 0)
 	}
 	now := time.Now().UTC()
 
@@ -4694,6 +4695,9 @@ func TestTickCandidatesComputedOncePerTick(t *testing.T) {
 	if got := atomic.LoadInt32(&counter.reclaim); got != 1 {
 		t.Fatalf("delegation-reclaim query ran %d times across %d repos, want 1", got, repoCount)
 	}
+	if got := atomic.LoadInt32(&counter.agedReclaim); got != 1 {
+		t.Fatalf("aged delegation-reclaim query ran %d times across %d repos, want 1", got, repoCount)
+	}
 
 	// Single-repo tick with a nil carrier self-computes each query at most once.
 	reset()
@@ -4709,13 +4713,16 @@ func TestTickCandidatesComputedOncePerTick(t *testing.T) {
 	if got := atomic.LoadInt32(&counter.reclaim); got != 1 {
 		t.Fatalf("single-repo delegation-reclaim query ran %d times, want 1", got)
 	}
+	if got := atomic.LoadInt32(&counter.agedReclaim); got != 1 {
+		t.Fatalf("single-repo aged delegation-reclaim query ran %d times, want 1", got)
+	}
 
 	// A dry-run tick returns before computing any candidate set.
 	reset()
 	if err := runDaemonWorkerTickTracked(ctx, store, worker, 1, true, "owner/repo0", "", io.Discard, now, nil, nil); err != nil {
 		t.Fatalf("dry-run runDaemonWorkerTickTracked returned error: %v", err)
 	}
-	if got := atomic.LoadInt32(&counter.advance) + atomic.LoadInt32(&counter.comment) + atomic.LoadInt32(&counter.reclaim); got != 0 {
+	if got := atomic.LoadInt32(&counter.advance) + atomic.LoadInt32(&counter.comment) + atomic.LoadInt32(&counter.reclaim) + atomic.LoadInt32(&counter.agedReclaim); got != 0 {
 		t.Fatalf("dry-run ran %d candidate queries, want 0", got)
 	}
 }
@@ -4772,5 +4779,14 @@ func TestTickCandidatesRetriesOnError(t *testing.T) {
 	}
 	if got := atomic.LoadInt32(&store.reclaimCalls); got != 2 {
 		t.Fatalf("reclaim query ran %d times, want 2", got)
+	}
+	if _, err := cand.agedDelegationReclaimCandidates(ctx, time.Now()); !errors.Is(err, errCandidateTransient) {
+		t.Fatalf("first agedDelegationReclaimCandidates err = %v, want transient", err)
+	}
+	if ids, err := cand.agedDelegationReclaimCandidates(ctx, time.Now()); err != nil || len(ids) != 1 || ids[0] != "aged-reclaim-job" {
+		t.Fatalf("second agedDelegationReclaimCandidates ids=%v err=%v, want [aged-reclaim-job] nil", ids, err)
+	}
+	if got := atomic.LoadInt32(&store.agedReclaimCalls); got != 2 {
+		t.Fatalf("aged reclaim query ran %d times, want 2", got)
 	}
 }

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -966,6 +966,14 @@ func resolveBlockedTTL(home string) time.Duration {
 	return ttl
 }
 
+// resolveDelegationWorktreeTTL reads the default-on terminal worktree retention
+// policy without initializing or re-resolving the daemon home. Parse errors are
+// returned so the caller can surface the skipped housekeeping pass instead of
+// silently falling back to destructive defaults.
+func resolveDelegationWorktreeTTL(home string) (time.Duration, error) {
+	return config.LoadDelegationWorktreeTTL(config.Paths{ConfigFile: resolveConfigFile(home)})
+}
+
 func pollRegisteredReposWithPoller(ctx context.Context, poller registeredRepoPoller, schedule registeredRepoSchedule, now time.Time, fallbackPoll time.Duration) (time.Duration, error) {
 	schedule = schedule.ensure()
 	repos, err := poller.Store.ListRepos(ctx)

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -289,6 +289,7 @@ type fakeReclaimWorktreeManager struct {
 	removed  []string
 	deleted  []string
 	branches map[string]bool
+	pruned   int
 }
 
 func (m *fakeReclaimWorktreeManager) AddWorktree(context.Context, string, string, string) error {
@@ -308,6 +309,10 @@ func (m *fakeReclaimWorktreeManager) DeleteBranch(_ context.Context, branch stri
 }
 func (m *fakeReclaimWorktreeManager) BranchExists(_ context.Context, branch string) (bool, error) {
 	return m.branches[branch], nil
+}
+func (m *fakeReclaimWorktreeManager) PruneWorktrees(context.Context) error {
+	m.pruned++
+	return nil
 }
 
 func delegationWorktreeCleanupPendingForTest(ctx context.Context, store tickCandidateStore, jobID string) (bool, error) {
@@ -843,10 +848,11 @@ func resetRuntimeLockWaitEpisodes() {
 // backs TestTickCandidatesComputedOncePerTick's proof that the #619 hoist runs each
 // candidate query once per tick, not once per enabled repo.
 type countingCandidateStore struct {
-	inner   *db.Store
-	advance int32
-	comment int32
-	reclaim int32
+	inner       *db.Store
+	advance     int32
+	comment     int32
+	reclaim     int32
+	agedReclaim int32
 }
 
 func (c *countingCandidateStore) JobIDsWithPendingAdvanceRetry(ctx context.Context) ([]string, error) {
@@ -864,15 +870,21 @@ func (c *countingCandidateStore) JobIDsWithPendingDelegationWorktreeReclaim(ctx 
 	return c.inner.JobIDsWithPendingDelegationWorktreeReclaim(ctx)
 }
 
+func (c *countingCandidateStore) JobIDsWithAgedTerminalDelegationWorktree(ctx context.Context, cutoff time.Time) ([]string, error) {
+	atomic.AddInt32(&c.agedReclaim, 1)
+	return c.inner.JobIDsWithAgedTerminalDelegationWorktree(ctx, cutoff)
+}
+
 // flakyCandidateStore returns an error on the first call to each candidate query and
 // the memoized success on every later call, counting total calls per query. It backs
 // TestTickCandidatesRetriesOnError's proof that tickCandidates memoizes SUCCESSES
 // only: a query that errors on one repo's pass must be re-attempted (not replayed as
 // the same error) on the next pass within the same tick.
 type flakyCandidateStore struct {
-	advanceCalls int32
-	commentCalls int32
-	reclaimCalls int32
+	advanceCalls     int32
+	commentCalls     int32
+	reclaimCalls     int32
+	agedReclaimCalls int32
 }
 
 var errCandidateTransient = errors.New("transient store fault")
@@ -896,4 +908,11 @@ func (s *flakyCandidateStore) JobIDsWithPendingDelegationWorktreeReclaim(context
 		return nil, errCandidateTransient
 	}
 	return []string{"reclaim-job"}, nil
+}
+
+func (s *flakyCandidateStore) JobIDsWithAgedTerminalDelegationWorktree(context.Context, time.Time) ([]string, error) {
+	if atomic.AddInt32(&s.agedReclaimCalls, 1) == 1 {
+		return nil, errCandidateTransient
+	}
+	return []string{"aged-reclaim-job"}, nil
 }

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -210,8 +210,9 @@ type dashboardHealthDaemon struct {
 
 type dashboardHealthResponse struct {
 	dashboard.Health
-	Daemon dashboardHealthDaemon `json:"daemon"`
-	Server dashboardServerBuild  `json:"server"`
+	Daemon    dashboardHealthDaemon   `json:"daemon"`
+	Server    dashboardServerBuild    `json:"server"`
+	Worktrees delegationWorktreeUsage `json:"worktrees"`
 }
 
 // handleHealth shadows the module's /api/health to add the build of the process
@@ -244,6 +245,23 @@ func (d *webDataSource) healthJSON(ctx context.Context) ([]byte, error) {
 	if health.RecentFailures == nil {
 		health.RecentFailures = []dashboard.HealthFailure{}
 	}
+	paths, err := initializedPaths(d.home)
+	if err != nil {
+		return nil, err
+	}
+	ttl, err := config.LoadDelegationWorktreeTTL(paths)
+	if err != nil {
+		return nil, err
+	}
+	var worktrees delegationWorktreeUsage
+	err = withStore(d.home, func(store *db.Store) error {
+		var inspectErr error
+		worktrees, inspectErr = inspectDelegationWorktreeUsage(ctx, paths, store, time.Now().UTC(), ttl)
+		return inspectErr
+	})
+	if err != nil {
+		return nil, err
+	}
 	build := buildinfo.Current()
 	versionSource := "unknown"
 	if health.Daemon.Version != "" {
@@ -255,7 +273,8 @@ func (d *webDataSource) healthJSON(ctx context.Context) ([]byte, error) {
 			HealthDaemon:  health.Daemon,
 			VersionSource: versionSource,
 		},
-		Server: dashboardServerBuild{Version: build.Version, Commit: build.Commit},
+		Server:    dashboardServerBuild{Version: build.Version, Commit: build.Commit},
+		Worktrees: worktrees,
 	}
 	return marshalDashboardJSON(response)
 }

--- a/internal/cli/delegation_worktree_ttl_test.go
+++ b/internal/cli/delegation_worktree_ttl_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestReclaimAgedTerminalDelegationWorktreesTTLAndStateGate(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	type seeded struct {
+		id    string
+		state workflow.JobState
+		age   time.Duration
+		path  string
+	}
+	rows := []seeded{
+		{id: "terminal-old", state: workflow.JobFailed, age: 73 * time.Hour, path: t.TempDir()},
+		{id: "terminal-fresh", state: workflow.JobSucceeded, age: time.Hour, path: t.TempDir()},
+		{id: "blocked-old", state: workflow.JobBlocked, age: 30 * 24 * time.Hour, path: t.TempDir()},
+	}
+	sharedPath := t.TempDir()
+	rows = append(rows,
+		seeded{id: "shared-old", state: workflow.JobFailed, age: 10 * 24 * time.Hour, path: sharedPath},
+		seeded{id: "shared-fresh", state: workflow.JobSucceeded, age: time.Hour, path: sharedPath},
+	)
+	for _, row := range rows {
+		payload, err := json.Marshal(workflow.JobPayload{Repo: "owner/repo", DelegationID: row.id, WorktreePath: row.path})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.CreateJobWithEvent(ctx, db.Job{
+			ID: row.id, Agent: "reader", Type: "ask", State: string(row.state),
+			ParentJobID: "parent", DelegationID: row.id, Payload: string(payload),
+		}, db.JobEvent{Kind: string(row.state), Message: "seed"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	store.Close()
+	const layout = "2006-01-02 15:04:05"
+	for _, row := range rows {
+		at := now.Add(-row.age).Format(layout)
+		setJobTimes(t, home, row.id, at, at)
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+
+	manager := &fakeReclaimWorktreeManager{branches: map[string]bool{}}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
+	}
+	if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(store), now, 72*time.Hour); err != nil {
+		t.Fatalf("reclaimAgedTerminalDelegationWorktrees: %v", err)
+	}
+	if len(manager.removed) != 1 || manager.removed[0] != rows[0].path {
+		t.Fatalf("removed = %v, want only aged final worktree %s", manager.removed, rows[0].path)
+	}
+	if manager.pruned != 1 {
+		t.Fatalf("prune calls = %d, want 1", manager.pruned)
+	}
+	events, err := store.ListJobEvents(ctx, "terminal-old")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == "delegation_worktree_reclaimed_ttl" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("events = %+v, want delegation_worktree_reclaimed_ttl", events)
+	}
+
+	engine := worker.WorkflowFactory("")
+	if err := engine.ReclaimAgedTerminalDelegationWorktree(ctx, "blocked-old", now.Add(-72*time.Hour)); err == nil || !strings.Contains(err.Error(), "non-final") {
+		t.Fatalf("blocked force reclaim error = %v, want non-final refusal", err)
+	}
+}
+
+func TestReclaimAgedTerminalDelegationWorktreesDisabled(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	manager := &fakeReclaimWorktreeManager{branches: map[string]bool{}}
+	worker := defaultJobWorker(store, io.Discard, t.TempDir())
+	worker.WorkflowFactory = func(string) workflow.Engine {
+		return workflow.Engine{Store: store, DelegationCheckout: t.TempDir(), DelegationWorktrees: manager}
+	}
+	if err := reclaimAgedTerminalDelegationWorktrees(ctx, worker, "", "", nil, newTickCandidates(store), time.Now(), 0); err != nil {
+		t.Fatal(err)
+	}
+	if len(manager.removed) != 0 {
+		t.Fatalf("TTL=0 removed %v", manager.removed)
+	}
+}

--- a/internal/cli/doctor_worktrees.go
+++ b/internal/cli/doctor_worktrees.go
@@ -1,0 +1,240 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/doctor"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const (
+	delegationWorktreeWarnCount = 10
+	delegationWorktreeWarnBytes = int64(1_000_000_000)
+)
+
+type delegationWorktreeUsage struct {
+	Stale          int    `json:"stale"`
+	SizeBytes      int64  `json:"sizeBytes"`
+	Size           string `json:"size"`
+	Reclaimable    int    `json:"reclaimable"`
+	Pinned         int    `json:"pinned"`
+	Unproven       int    `json:"unproven"`
+	RecentTerminal int    `json:"recentTerminal"`
+	Root           string `json:"root"`
+	Summary        string `json:"summary"`
+}
+
+type delegationWorktreeClass int
+
+const (
+	worktreeRecentTerminal delegationWorktreeClass = iota
+	worktreeReclaimable
+	worktreePinned
+	worktreeUnproven
+)
+
+// inspectDelegationWorktreeUsage accounts only for per-delegation/read-only
+// worktrees under <home>/worktrees. Ordinary task worktrees are excluded. It
+// combines recorded job ownership with an exact-depth directory scan so a
+// crash-before-enqueue orphan is still visible as unproven, never reclaimed.
+func inspectDelegationWorktreeUsage(ctx context.Context, paths config.Paths, store *db.Store, now time.Time, ttl time.Duration) (delegationWorktreeUsage, error) {
+	root := filepath.Join(paths.Home, "worktrees")
+	usage := delegationWorktreeUsage{Root: root}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return usage, err
+	}
+
+	owned := map[string]delegationWorktreeClass{}
+	for _, job := range jobs {
+		payload, err := workflow.ParseJobPayload(job.Payload)
+		if err != nil || strings.TrimSpace(payload.WorktreePath) == "" {
+			continue
+		}
+		if strings.TrimSpace(payload.DelegationID) == "" && !payload.ReadOnlyWorktree {
+			continue // ordinary task/shared-checkout payload
+		}
+		path, ok := worktreePathUnderRoot(root, payload.WorktreePath)
+		if !ok {
+			continue
+		}
+		class := worktreePinned
+		if workflow.IsFinalJobState(job.State) {
+			stamp := parseJobTimeMillis(job.UpdatedAt)
+			if stamp == 0 {
+				stamp = parseJobTimeMillis(job.CreatedAt)
+			}
+			switch {
+			case stamp == 0:
+				class = worktreeUnproven
+			case ttl > 0 && !time.UnixMilli(stamp).After(now.Add(-ttl)):
+				class = worktreeReclaimable
+			default:
+				class = worktreeRecentTerminal
+			}
+		}
+		// A path referenced by multiple rows is pinned if ANY owner is resumable;
+		// safety wins over an older terminal record for the same deterministic path.
+		if prior, exists := owned[path]; !exists || worktreeClassPriority(class) > worktreeClassPriority(prior) {
+			owned[path] = class
+		}
+	}
+
+	pathsOnDisk := map[string]struct{}{}
+	for path := range owned {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			pathsOnDisk[path] = struct{}{}
+		}
+	}
+	// Canonical layout: <root>/<owner--repo>/delegations/<parent>/<leg>.
+	// Stop at each leg root; size accounting below walks it exactly once.
+	_ = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || path == root || !entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		if len(parts) == 4 && parts[1] == "delegations" {
+			pathsOnDisk[path] = struct{}{}
+			return filepath.SkipDir
+		}
+		return nil
+	})
+
+	ordered := make([]string, 0, len(pathsOnDisk))
+	for path := range pathsOnDisk {
+		ordered = append(ordered, path)
+	}
+	sort.Strings(ordered)
+	for _, path := range ordered {
+		class, ok := owned[path]
+		if !ok {
+			class = worktreeUnproven
+		}
+		if class == worktreeRecentTerminal {
+			usage.RecentTerminal++
+			continue
+		}
+		usage.Stale++
+		switch class {
+		case worktreeReclaimable:
+			usage.Reclaimable++
+		case worktreePinned:
+			usage.Pinned++
+		case worktreeUnproven:
+			usage.Unproven++
+		}
+		usage.SizeBytes += directoryLogicalSize(path)
+	}
+	usage.Size = formatWorktreeBytes(usage.SizeBytes)
+	usage.Summary = fmt.Sprintf("%d stale worktree%s / %s under %s", usage.Stale, pluralSuffix(usage.Stale), usage.Size, usage.Root)
+	return usage, nil
+}
+
+func worktreeClassPriority(class delegationWorktreeClass) int {
+	switch class {
+	case worktreePinned:
+		return 4
+	case worktreeUnproven:
+		return 3
+	case worktreeRecentTerminal:
+		return 2
+	case worktreeReclaimable:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func worktreePathUnderRoot(root, candidate string) (string, bool) {
+	root, err := filepath.Abs(strings.TrimSpace(root))
+	if err != nil {
+		return "", false
+	}
+	path, err := filepath.Abs(strings.TrimSpace(candidate))
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.Clean(path), true
+}
+
+func directoryLogicalSize(root string) int64 {
+	var total int64
+	_ = filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return nil
+		}
+		if info, err := entry.Info(); err == nil {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+func formatWorktreeBytes(size int64) string {
+	const (
+		kb = int64(1_000)
+		mb = int64(1_000_000)
+		gb = int64(1_000_000_000)
+	)
+	switch {
+	case size >= gb:
+		return fmt.Sprintf("%.1f GB", float64(size)/float64(gb))
+	case size >= mb:
+		return fmt.Sprintf("%.1f MB", float64(size)/float64(mb))
+	case size >= kb:
+		return fmt.Sprintf("%.1f KB", float64(size)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", size)
+	}
+}
+
+func pluralSuffix(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func delegationWorktreeDoctorCheck(paths config.Paths) (doctor.Check, bool) {
+	if strings.TrimSpace(paths.Database) == "" {
+		return doctor.Check{}, false
+	}
+	store, err := db.OpenReadOnly(paths.Database)
+	if err != nil {
+		return doctor.Check{}, false
+	}
+	defer store.Close()
+	ttl, err := config.LoadDelegationWorktreeTTL(paths)
+	if err != nil {
+		return doctor.Check{Name: "worktrees", Required: false, Detail: fmt.Sprintf("cannot read delegation worktree TTL: %v", err)}, true
+	}
+	usage, err := inspectDelegationWorktreeUsage(context.Background(), paths, store, time.Now().UTC(), ttl)
+	if err != nil {
+		return doctor.Check{}, false
+	}
+	return buildDelegationWorktreeDoctorCheck(usage), true
+}
+
+func buildDelegationWorktreeDoctorCheck(usage delegationWorktreeUsage) doctor.Check {
+	detail := fmt.Sprintf("%s (%d reclaimable, %d pinned by non-terminal owners, %d unproven; %d recent terminal within TTL)", usage.Summary, usage.Reclaimable, usage.Pinned, usage.Unproven, usage.RecentTerminal)
+	warn := usage.Stale >= delegationWorktreeWarnCount || usage.SizeBytes >= delegationWorktreeWarnBytes
+	return doctor.Check{Name: "worktrees", OK: !warn, Required: false, Detail: detail}
+}

--- a/internal/cli/doctor_worktrees_test.go
+++ b/internal/cli/doctor_worktrees_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestInspectDelegationWorktreeUsageClassifiesOwnersAndSize(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	store := openCLIJobStore(t, home)
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	root := filepath.Join(paths.Home, "worktrees", "owner--repo", "delegations", "parent")
+	type item struct {
+		id    string
+		state workflow.JobState
+		age   time.Duration
+		size  int
+	}
+	items := []item{
+		{id: "old-final", state: workflow.JobFailed, age: 73 * time.Hour, size: 7},
+		{id: "fresh-final", state: workflow.JobSucceeded, age: time.Hour, size: 11},
+		{id: "blocked", state: workflow.JobBlocked, age: 30 * 24 * time.Hour, size: 13},
+	}
+	for _, item := range items {
+		path := filepath.Join(root, item.id)
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "payload.bin"), make([]byte, item.size), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		seedCLIJob(t, store, db.Job{
+			ID: item.id, Agent: "reader", Type: "ask", State: string(item.state),
+			ParentJobID: "parent", DelegationID: item.id,
+			Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", DelegationID: item.id, WorktreePath: path}),
+		}, string(item.state))
+	}
+	unproven := filepath.Join(root, "unproven")
+	if err := os.MkdirAll(unproven, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unproven, "payload.bin"), make([]byte, 17), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	const layout = "2006-01-02 15:04:05"
+	for _, item := range items {
+		at := now.Add(-item.age).Format(layout)
+		setJobTimes(t, home, item.id, at, at)
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+
+	usage, err := inspectDelegationWorktreeUsage(context.Background(), paths, store, now, 72*time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.Stale != 3 || usage.Reclaimable != 1 || usage.Pinned != 1 || usage.Unproven != 1 || usage.RecentTerminal != 1 {
+		t.Fatalf("usage = %+v", usage)
+	}
+	if usage.SizeBytes != 37 { // 7 old + 13 blocked + 17 unproven; fresh excluded
+		t.Fatalf("size = %d, want 37", usage.SizeBytes)
+	}
+	if !strings.Contains(usage.Summary, "3 stale worktrees / 37 B") {
+		t.Fatalf("summary = %q", usage.Summary)
+	}
+}
+
+func TestBuildDelegationWorktreeDoctorCheckThresholds(t *testing.T) {
+	ok := buildDelegationWorktreeDoctorCheck(delegationWorktreeUsage{Stale: 1, Pinned: 1, Size: "10 B", Summary: "1 stale worktree / 10 B under /tmp/home/worktrees"})
+	if !ok.OK || ok.Required || !strings.Contains(ok.Detail, "1 pinned") {
+		t.Fatalf("below-threshold check = %+v", ok)
+	}
+	warn := buildDelegationWorktreeDoctorCheck(delegationWorktreeUsage{Stale: delegationWorktreeWarnCount, Reclaimable: delegationWorktreeWarnCount, Size: "2.0 GB", SizeBytes: 2_000_000_000, Summary: "10 stale worktrees / 2.0 GB under /tmp/home/worktrees"})
+	if warn.OK || warn.Required || !strings.Contains(warn.Detail, "10 stale worktrees / 2.0 GB") {
+		t.Fatalf("warning check = %+v", warn)
+	}
+}
+
+func TestHealthEndpointSurfacesDelegationWorktreeUsage(t *testing.T) {
+	home := dashboardTestHome(t)
+	paths := config.PathsForHome(home)
+	path := filepath.Join(paths.Home, "worktrees", "owner--repo", "delegations", "parent", "pinned")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "payload.bin"), []byte("dashboard"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, home)
+	seedCLIJob(t, store, db.Job{
+		ID: "pinned", Agent: "reader", Type: "ask", State: string(workflow.JobBlocked),
+		ParentJobID: "parent", DelegationID: "pinned",
+		Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", DelegationID: "pinned", WorktreePath: path}),
+	}, string(workflow.JobBlocked))
+	store.Close()
+
+	stubOnDiskBuild(t, "", "")
+	stubUpdateCheck(t, "")
+	recorder := httptest.NewRecorder()
+	(&webDataSource{home: home}).handleHealth(recorder, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("health status = %d: %s", recorder.Code, recorder.Body.String())
+	}
+	var payload struct {
+		Worktrees delegationWorktreeUsage `json:"worktrees"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Worktrees.Stale != 1 || payload.Worktrees.Pinned != 1 || payload.Worktrees.SizeBytes != int64(len("dashboard")) {
+		t.Fatalf("worktrees = %+v", payload.Worktrees)
+	}
+	if !strings.Contains(payload.Worktrees.Summary, "1 stale worktree") {
+		t.Fatalf("summary = %q", payload.Worktrees.Summary)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -181,6 +181,9 @@ func runDoctor(args []string, stdout, stderr io.Writer) int {
 	if check, ok := unlabeledJobsDoctorCheck(paths); ok {
 		checks = append(checks, check)
 	}
+	if check, ok := delegationWorktreeDoctorCheck(paths); ok {
+		checks = append(checks, check)
+	}
 	checks = append(checks, repoCheckoutDoctorChecks(paths)...)
 	if *jsonOutput {
 		type checkJSON struct {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -45,6 +45,9 @@ artifact_blobs = %q
 # off | warn | block and defaults to warn when omitted. stale_task_ttl is the
 # conservative updated_at age after which abandoned implementing/blocked tasks
 # may be auto-dismissed; it defaults to 168h and "0" disables that reconciler.
+# delegation_worktree_ttl defaults to 72h and bounds terminal-job worktree
+# retention; terminal owners cannot resume, so this safe cleanup is default-on.
+# Set it to "0" to disable the TTL reclaim pass.
 # planned_ttl is a separate destructive retirement policy for never-started
 # plans. It is OPT-IN and disabled by default because dismissal can discard human
 # planning context that a later goal-file import cannot reconstruct.
@@ -58,6 +61,7 @@ artifact_blobs = %q
 # implement_base = "origin/main"
 # result_checks = "warn"
 # stale_task_ttl = "168h"
+# delegation_worktree_ttl = "72h"
 # planned_ttl = "720h" # opt-in; unset/empty/0/invalid disables
 # require_workflow = false # opt out (default is true)
 # require_workflow_mode = "auto" # auto | strict

--- a/internal/config/stale_tasks.go
+++ b/internal/config/stale_tasks.go
@@ -7,7 +7,10 @@ import (
 	"time"
 )
 
-const DefaultStaleTaskTTL = 168 * time.Hour
+const (
+	DefaultStaleTaskTTL          = 168 * time.Hour
+	DefaultDelegationWorktreeTTL = 72 * time.Hour
+)
 
 // LoadPlannedTaskTTL resolves the hot-read [workflow].planned_ttl setting.
 // Planned-task retirement is destructive to human planning context, so every
@@ -105,6 +108,66 @@ func LoadStaleTaskTTL(paths Paths) (time.Duration, error) {
 				err = fmt.Errorf("duration must not be negative")
 			}
 			return 0, fmt.Errorf("invalid [workflow].stale_task_ttl %q: %w", value, err)
+		}
+	}
+	return ttl, nil
+}
+
+// LoadDelegationWorktreeTTL resolves the hot-read
+// [workflow].delegation_worktree_ttl setting. It is default-on at 72 hours:
+// delegation worktrees are disposable once their owning job is final, and the
+// grace period leaves ample time for post-mortem inspection while still bounding
+// disk growth after a killed daemon misses the normal cleanup path. Omitted or
+// empty uses the default, exactly "0" disables the TTL reclaim pass, and every
+// other value must be a non-negative Go duration.
+func LoadDelegationWorktreeTTL(paths Paths) (time.Duration, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultDelegationWorktreeTTL, nil
+		}
+		return 0, err
+	}
+	ttl := DefaultDelegationWorktreeTTL
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			continue
+		}
+		if current != "workflow" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "delegation_worktree_ttl" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "\"") {
+			value, err = parseConfigString(value)
+			if err != nil {
+				return 0, fmt.Errorf("parse [workflow].delegation_worktree_ttl: %w", err)
+			}
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			ttl = DefaultDelegationWorktreeTTL
+			continue
+		}
+		if value == "0" {
+			ttl = 0
+			continue
+		}
+		ttl, err = time.ParseDuration(value)
+		if err != nil || ttl < 0 {
+			if err == nil {
+				err = fmt.Errorf("duration must not be negative")
+			}
+			return 0, fmt.Errorf("invalid [workflow].delegation_worktree_ttl %q: %w", value, err)
 		}
 	}
 	return ttl, nil

--- a/internal/config/stale_tasks_test.go
+++ b/internal/config/stale_tasks_test.go
@@ -41,6 +41,43 @@ func TestLoadStaleTaskTTL(t *testing.T) {
 	}
 }
 
+func TestLoadDelegationWorktreeTTL(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    time.Duration
+		wantErr bool
+	}{
+		{name: "missing config", want: DefaultDelegationWorktreeTTL},
+		{name: "omitted", content: "[workflow]\nresult_checks = \"warn\"\n", want: DefaultDelegationWorktreeTTL},
+		{name: "empty", content: "[workflow]\ndelegation_worktree_ttl = \"\"\n", want: DefaultDelegationWorktreeTTL},
+		{name: "disabled", content: "[workflow]\ndelegation_worktree_ttl = \"0\"\n", want: 0},
+		{name: "duration", content: "[workflow]\ndelegation_worktree_ttl = \"24h\"\n", want: 24 * time.Hour},
+		{name: "invalid", content: "[workflow]\ndelegation_worktree_ttl = \"later\"\n", wantErr: true},
+		{name: "negative", content: "[workflow]\ndelegation_worktree_ttl = \"-1h\"\n", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := Paths{ConfigFile: filepath.Join(t.TempDir(), ConfigName)}
+			if tc.content != "" {
+				if err := os.WriteFile(paths.ConfigFile, []byte(tc.content), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := LoadDelegationWorktreeTTL(paths)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("LoadDelegationWorktreeTTL() = %s, want error", got)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("LoadDelegationWorktreeTTL() = %s, %v; want %s, nil", got, err, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadPlannedTaskTTLOptIn(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -1245,6 +1245,49 @@ func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) 
 	return s.jobIDsByQuery(ctx, jobIDsWithPendingDelegationWorktreeReclaimSQL)
 }
 
+// JobIDsWithAgedTerminalDelegationWorktree returns final jobs whose recorded
+// delegation/read-only worktree has outlived cutoff and has no successful
+// cleanup event. Unlike the pending-marker query above, this deliberately finds
+// crash-window leftovers that never got far enough to emit a cleanup-skipped
+// marker. Blocked is excluded: it is resumable and therefore still owns its
+// worktree. The payload predicates exclude ordinary task worktrees.
+func (s *Store) JobIDsWithAgedTerminalDelegationWorktree(ctx context.Context, cutoff time.Time) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT j.id
+		FROM jobs j
+		WHERE j.state IN ('succeeded', 'failed', 'cancelled')
+		  AND unixepoch(COALESCE(NULLIF(j.updated_at, ''), j.created_at)) <= unixepoch(?)
+		  AND COALESCE(json_extract(j.payload, '$.worktree_path'), '') <> ''
+		  AND (COALESCE(json_extract(j.payload, '$.delegation_id'), '') <> ''
+		       OR COALESCE(json_extract(j.payload, '$.read_only_worktree'), 0) = 1)
+		  AND NOT EXISTS (
+			SELECT 1 FROM jobs owner
+			WHERE owner.id <> j.id
+			  AND json_extract(owner.payload, '$.worktree_path') = json_extract(j.payload, '$.worktree_path')
+			  AND (owner.state NOT IN ('succeeded', 'failed', 'cancelled')
+			       OR unixepoch(COALESCE(NULLIF(owner.updated_at, ''), owner.created_at)) IS NULL
+			       OR unixepoch(COALESCE(NULLIF(owner.updated_at, ''), owner.created_at)) > unixepoch(?))
+		  )
+		  AND NOT EXISTS (
+			SELECT 1 FROM job_events e
+			WHERE e.job_id = j.id
+			  AND e.kind IN ('delegation_worktree_removed', 'delegation_worktree_reclaimed_ttl')
+		  )
+		ORDER BY j.id`, cutoff.UTC().Format("2006-01-02 15:04:05"), cutoff.UTC().Format("2006-01-02 15:04:05"))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // JobIDsWithPendingAdvanceRetry returns the IDs of jobs whose LATEST post-delivery
 // advancement event (by id) is still an unreconciled attempt marker
 // (advance_started/advance_retry) — exactly jobWorker.jobNeedsAdvanceRetry's

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -188,6 +188,14 @@ func (c Client) RemoveWorktreeForce(ctx context.Context, path string) error {
 	return err
 }
 
+// PruneWorktrees removes stale administrative entries left by interrupted or
+// forcibly removed worktrees. It runs against the primary checkout's shared git
+// directory and is idempotent.
+func (c Client) PruneWorktrees(ctx context.Context) error {
+	_, err := c.run(ctx, "worktree", "prune")
+	return err
+}
+
 // DeleteBranch force-deletes a local branch (git branch -D). It is used to tear
 // down a terminal implement delegation's gitmoot-delegation-* branch so it does
 // not linger in the shared checkout and contaminate a later coordinator's

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -213,7 +213,7 @@ func TestClientAddWorktreeRejectsInvalidInput(t *testing.T) {
 }
 
 func TestClientDetachedAndForceRemoveCommandConstruction(t *testing.T) {
-	runner := &fakeRunner{results: []subprocess.Result{{}, {}}}
+	runner := &fakeRunner{results: []subprocess.Result{{}, {}, {}}}
 	client := Client{Runner: runner, Dir: "/repo"}
 	if err := client.AddDetachedWorktree(context.Background(), "/worktrees/d1", "main"); err != nil {
 		t.Fatalf("AddDetachedWorktree returned error: %v", err)
@@ -221,8 +221,12 @@ func TestClientDetachedAndForceRemoveCommandConstruction(t *testing.T) {
 	if err := client.RemoveWorktreeForce(context.Background(), "/worktrees/d1"); err != nil {
 		t.Fatalf("RemoveWorktreeForce returned error: %v", err)
 	}
+	if err := client.PruneWorktrees(context.Background()); err != nil {
+		t.Fatalf("PruneWorktrees returned error: %v", err)
+	}
 	runner.wantArgs(t, 0, "git", "worktree", "add", "--detach", "/worktrees/d1", "main")
 	runner.wantArgs(t, 1, "git", "worktree", "remove", "--force", "/worktrees/d1")
+	runner.wantArgs(t, 2, "git", "worktree", "prune")
 }
 
 func TestClientRemoveWorktreeForceSmoke(t *testing.T) {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -39,6 +39,13 @@ type ReadOnlyWorktreeManager interface {
 	RemoveWorktreeForce(ctx context.Context, path string) error
 }
 
+// WorktreePruner removes stale worktree administrative entries after a forced
+// TTL reclaim. The checkout-bound git client satisfies it; tests may omit it
+// because pruning is cleanup of shared git metadata, not the safety gate.
+type WorktreePruner interface {
+	PruneWorktrees(ctx context.Context) error
+}
+
 // BranchDeleter deletes a local branch. The checkout-bound gitutil.Client
 // satisfies it; used to tear down a terminal implement delegation's branch.
 type BranchDeleter interface {
@@ -896,6 +903,127 @@ func (e Engine) ReclaimTerminalDelegationWorktree(ctx context.Context, jobID str
 	e.cleanupImplementDelegationWorktree(ctx, jobID, job.Type, payload)
 	e.cleanupReadOnlyDelegationWorktree(ctx, jobID, job.Type, payload)
 	return nil
+}
+
+// ReclaimAgedTerminalDelegationWorktree force-removes a delegation/read-only
+// worktree only when the owning job is FINAL and its terminal updated_at is at
+// or before cutoff. This is the crash-window backstop: unlike the ordinary
+// cleanup path it intentionally bypasses dirty/unprovable-content and stale
+// runtime-owner preservation after the 72h default grace period. Blocked jobs
+// are resumable (not final), so they can never pass this gate.
+func (e Engine) ReclaimAgedTerminalDelegationWorktree(ctx context.Context, jobID string, cutoff time.Time) error {
+	if err := e.validate(); err != nil {
+		return err
+	}
+	job, payload, err := e.jobPayload(ctx, jobID)
+	if err != nil {
+		return err
+	}
+	if !IsFinalJobState(job.State) {
+		return fmt.Errorf("refusing TTL worktree reclaim for non-final job %s in state %s", jobID, job.State)
+	}
+	terminalAt, ok := parseStoredJobTime(job.UpdatedAt)
+	if !ok {
+		terminalAt, ok = parseStoredJobTime(job.CreatedAt)
+	}
+	if !ok || terminalAt.After(cutoff.UTC()) {
+		return nil
+	}
+	readOnly := isReadOnlyDelegationWorktree(job.Type, payload)
+	implement := isImplementDelegationWorktree(job.Type, payload)
+	if !readOnly && !implement {
+		return nil
+	}
+	// A deterministic path can appear in more than one historical row. Never let
+	// an aged row reclaim it out from under a newer or resumable owner.
+	jobs, err := e.Store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	for _, other := range jobs {
+		if other.ID == job.ID {
+			continue
+		}
+		otherPayload, err := ParseJobPayload(other.Payload)
+		if err != nil || filepath.Clean(strings.TrimSpace(otherPayload.WorktreePath)) != filepath.Clean(strings.TrimSpace(payload.WorktreePath)) {
+			continue
+		}
+		if !IsFinalJobState(other.State) {
+			return nil
+		}
+		otherAt, ok := parseStoredJobTime(other.UpdatedAt)
+		if !ok {
+			otherAt, ok = parseStoredJobTime(other.CreatedAt)
+		}
+		if !ok || otherAt.After(cutoff.UTC()) {
+			return nil
+		}
+	}
+	manager, ok := e.DelegationWorktrees.(ReadOnlyWorktreeManager)
+	if !ok || manager == nil {
+		return errors.New("delegation worktree manager cannot force-remove worktrees")
+	}
+
+	opCtx := context.WithoutCancel(ctx)
+	path := strings.TrimSpace(payload.WorktreePath)
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(opCtx, e.Store, e.DelegationCheckout, "worktree-ttl-reclaim:"+jobID, time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("lock checkout for TTL worktree reclaim: %w", err)
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
+
+	if _, statErr := os.Stat(path); statErr == nil {
+		if err := manager.RemoveWorktreeForce(opCtx, path); err != nil {
+			return fmt.Errorf("force-remove aged terminal worktree %s: %w", path, err)
+		}
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("inspect aged terminal worktree %s: %w", path, statErr)
+	}
+
+	branch := strings.TrimSpace(payload.Branch)
+	if implement {
+		if _, err := releaseDelegationBranchLock(opCtx, e.Store, job.Type, payload); err != nil {
+			return fmt.Errorf("release delegation branch lock %s: %w", branch, err)
+		}
+		if deleter, ok := e.DelegationWorktrees.(BranchDeleter); ok && deleter != nil {
+			shouldDelete := true
+			if checker, ok := e.DelegationWorktrees.(BranchExistenceChecker); ok && checker != nil {
+				exists, err := checker.BranchExists(opCtx, branch)
+				if err != nil {
+					return fmt.Errorf("inspect delegation branch %s: %w", branch, err)
+				}
+				shouldDelete = exists
+			}
+			if shouldDelete {
+				if err := deleter.DeleteBranch(opCtx, branch); err != nil {
+					return fmt.Errorf("force-delete aged terminal branch %s: %w", branch, err)
+				}
+			}
+		}
+	}
+	if pruner, ok := e.DelegationWorktrees.(WorktreePruner); ok && pruner != nil {
+		if err := pruner.PruneWorktrees(opCtx); err != nil {
+			return fmt.Errorf("prune worktree metadata after TTL reclaim: %w", err)
+		}
+	}
+	return e.Store.AddJobEvent(opCtx, db.JobEvent{
+		JobID: jobID, Kind: "delegation_worktree_reclaimed_ttl",
+		Message: fmt.Sprintf("aged terminal delegation worktree %s force-removed after TTL", path),
+	})
+}
+
+func parseStoredJobTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339Nano, time.RFC3339} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC(), true
+		}
+	}
+	return time.Time{}, false
 }
 
 // implementLegBranchMayBeMerged reports whether a succeeded implement leg's

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -22,7 +22,9 @@ gh auth status
 `gitmoot doctor` is the environment preflight: it validates `gh auth` (with an
 actionable remediation hint) and live-probes the Claude credential selected by
 `runtime-auth.env`, so a bad credential is caught before jobs stall. Run it
-after install and before starting the daemon.
+after install and before starting the daemon. It also reports delegation
+worktree count and logical disk size, warning at 10 stale worktrees or 1 GB and
+distinguishing aged-final reclaimable owners from pinned non-final owners.
 
 One-shot onboarding: `gitmoot setup` registers the repo and an agent in one
 command (`--repo owner/repo --agent <name> --runtime codex|claude|shell

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -394,3 +394,25 @@ Stop and report `blocked` when the target repo is unclear, GitHub auth is
 missing, the daemon cannot access the repo, branch lock ownership is wrong, or
 continuing would require credentials or destructive operations the user did not
 approve.
+
+## Delegation Worktree Reclaim
+
+The daemon force-reclaims a recorded delegation/read-only worktree only when its
+owning job is final (`succeeded`, `failed`, or `cancelled`) and its terminal
+`updated_at` is older than `[workflow].delegation_worktree_ttl` (default `72h`;
+`"0"` disables). This default is safe because final owners cannot resume; the
+delay preserves a short debugging window. `blocked` is resumable and is never a
+TTL reclaim candidate. A successful force-remove and metadata prune records
+`delegation_worktree_reclaimed_ttl`.
+
+`gitmoot doctor` and dashboard `/api/health` surface stale count and logical
+size, split into reclaimable final owners, pinned non-final owners, and unproven
+directories. Pinned and unproven worktrees are observation-only.
+
+For manual relief, list
+`$GITMOOT_HOME/worktrees/*/delegations/*/*`, map each path to its job's
+`payload.worktree_path`, and run `gitmoot job show <job-id> --json`. Proceed only
+when the current state is `succeeded`, `failed`, or `cancelled` and the exact
+path matches; then run `git -C <registered-checkout> worktree remove --force
+<path>` followed by `git -C <registered-checkout> worktree prune`. Never remove
+a worktree owned by a blocked, queued, or running job.

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -738,6 +738,12 @@ recover` restores preserved artifacts through `implementing` to `pr_open`, or
 restores a branchless task to `planned`; job retry records its own recovery
 event. The server-side task board omits dismissed rows immediately.
 
+Delegation worktrees use a separate default-on retention policy:
+`[workflow].delegation_worktree_ttl = "72h"` (`"0"` disables it). Only final
+owners (`succeeded`, `failed`, `cancelled`) older than the TTL are force-removed.
+Blocked, queued, and running owners remain pinned; `gitmoot doctor` reports the
+reclaimable/pinned/unproven counts and logical size.
+
 Never-started `planned` tasks use a separate opt-in policy:
 `[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
 zero, and invalid values all resolve to off because automatic dismissal can

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -313,6 +313,9 @@ Health is the operability view for unattended runs:
   treat that as neither build skew nor healthy agreement.
 - **State totals** — a chip per state (queued, running, blocked, succeeded,
   failed, cancelled).
+- **Delegation worktrees** — `/api/health` reports a `worktrees.summary` line
+  (`N stale worktrees / X GB`) plus reclaimable, pinned, unproven, and
+  recent-terminal counts and exact bytes.
 - **Stuck jobs** — blocked jobs (surfaced at any age) plus queued jobs older than
   10 minutes, each with a **derived why-stuck reason** (from the job's latest
   reason event and any resource lock it is waiting on) and how long it has been

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -479,3 +479,40 @@ cd /root/gitmoot/website
 npm run build
 rsync -a --delete build/ /var/www/gitmoot-docs/
 ```
+
+## Delegation worktrees consume too much disk
+
+`gitmoot doctor` reports `N stale worktrees / X GB under <home>/worktrees` and
+separates reclaimable final owners, pinned non-final owners, and unproven
+directories. `/api/health` exposes the same metric in its top-level `worktrees`
+field.
+
+`[workflow].delegation_worktree_ttl = "72h"` is default-on: after that grace
+period the daemon force-removes dirty terminal-owned delegation worktrees,
+prunes Git worktree metadata, and records
+`delegation_worktree_reclaimed_ttl`. Set it to `"0"` to disable this pass.
+Blocked, queued, and running owners remain pinned and are never force-removed.
+
+For immediate relief, list candidate directories and prove ownership before
+removing anything:
+
+```sh
+find "$HOME/.gitmoot/worktrees" -type d -path '*/delegations/*/*' -prune -print
+sqlite3 "$HOME/.gitmoot/gitmoot.db" -header -column '
+SELECT id, state, updated_at, json_extract(payload, "$.worktree_path") AS path
+FROM jobs
+WHERE state IN ("succeeded", "failed", "cancelled")
+  AND datetime(updated_at) <= datetime("now", "-72 hours")
+  AND json_extract(payload, "$.worktree_path") <> ""
+  AND (json_extract(payload, "$.delegation_id") <> ""
+       OR json_extract(payload, "$.read_only_worktree") = 1);
+'
+gitmoot job show <job-id> --json
+git -C <registered-checkout> worktree remove --force <verified-worktree-path>
+git -C <registered-checkout> worktree prune
+```
+
+The `sqlite3` command is an optional operator aid, not a Gitmoot dependency.
+Verify that `job show` still reports `succeeded`, `failed`, or `cancelled` and
+the same `payload.worktree_path`. Never remove a worktree for a blocked, queued,
+or running job; settle it first.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -22,7 +22,9 @@ gh auth status
 `gitmoot doctor` is the environment preflight: it validates `gh auth` (with an
 actionable remediation hint) and live-probes the Claude credential selected by
 `runtime-auth.env`, so a bad credential is caught before jobs stall on it. Run
-it after install and before starting the daemon.
+it after install and before starting the daemon. It also reports delegation
+worktree count and logical disk size, warning at 10 stale worktrees or 1 GB and
+distinguishing aged-final reclaimable owners from pinned non-final owners.
 
 One-shot onboarding: `gitmoot setup` registers the repo and an agent in one
 command (`--repo owner/repo --agent <name> --runtime codex|claude|shell
@@ -1201,6 +1203,11 @@ qualifying `implementing`/`blocked` tasks per repo poll.
 branches, branches still present on `origin`, and remote-check uncertainty all
 prevent automatic dismissal; successful transitions record
 `task_dismissed_auto`.
+
+Delegation worktrees use the separate default-on
+`[workflow].delegation_worktree_ttl = "72h"`; `"0"` disables that pass. Only
+final job owners older than the TTL are force-reclaimed. Blocked, queued, and
+running owners remain pinned and are reported by `gitmoot doctor`.
 
 `[workflow].planned_ttl = "720h"` is a separate repository opt-in for old
 never-started plans. It is disabled by default; unset, empty, `"0"`, and invalid

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -746,6 +746,13 @@ activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
 set it to `"0"` to disable this poll leg. Candidates with a same-repo open PR,
 a remote branch, a live job, or an uncertain remote check are not dismissed.
 
+Delegation worktrees have a separate default-on retention bound:
+`[workflow].delegation_worktree_ttl = "72h"`. Only worktrees owned by final jobs
+(`succeeded`, `failed`, or `cancelled`) older than the TTL are force-removed;
+`"0"` disables the pass. Blocked, queued, and running owners stay pinned. Run
+`gitmoot doctor` to see stale count, logical size, and the
+reclaimable/pinned/unproven breakdown; dashboard `/api/health` mirrors it.
+
 Never-started plans have a separate destructive opt-in:
 `[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
 `"0"`, and invalid values all mean off because dismissing a plan can destroy
@@ -2420,6 +2427,48 @@ Fixes:
   `GITMOOT_DISABLE_NATIVE_MERGE_GATE=1` (also `true`/`yes`/`on`; #545): Gitmoot
   then abstains from its native merge gate — fail-closed, it never merges
   gatelessly; the external gate makes the call.
+
+## Delegation worktrees consume too much disk
+
+`gitmoot doctor` reports delegation-worktree usage as
+`N stale worktrees / X GB under <home>/worktrees`. The detail separates aged
+final owners that are **reclaimable**, resumable/non-final owners that are
+**pinned**, and directories whose owner is **unproven**. Pinned includes
+`blocked`, `queued`, and `running`; Gitmoot never force-removes those.
+
+`[workflow].delegation_worktree_ttl = "72h"` is default-on because a final
+delegation owner cannot resume, while the grace period preserves short-term
+debugging access. Set it to `"0"` to disable the TTL pass. Aged final owners are
+force-removed even when dirty, Git worktree metadata is pruned, and
+`delegation_worktree_reclaimed_ttl` is recorded. The dashboard `/api/health`
+response exposes the same count, bytes, path, breakdown, and summary in its
+top-level `worktrees` field.
+
+For immediate manual relief, list paths and then prove the owner is final. Do
+not infer safety from directory age alone:
+
+```sh
+find "$HOME/.gitmoot/worktrees" -type d -path '*/delegations/*/*' -prune -print
+
+# sqlite3 is an optional operator aid, not a Gitmoot runtime dependency.
+sqlite3 "$HOME/.gitmoot/gitmoot.db" -header -column '
+SELECT id, state, updated_at, json_extract(payload, "$.worktree_path") AS path
+FROM jobs
+WHERE state IN ("succeeded", "failed", "cancelled")
+  AND datetime(updated_at) <= datetime("now", "-72 hours")
+  AND json_extract(payload, "$.worktree_path") <> ""
+  AND (json_extract(payload, "$.delegation_id") <> ""
+       OR json_extract(payload, "$.read_only_worktree") = 1);
+'
+
+gitmoot job show <job-id> --json
+git -C <registered-checkout> worktree remove --force <verified-worktree-path>
+git -C <registered-checkout> worktree prune
+```
+
+Before removal, verify that `job show` still reports `succeeded`, `failed`, or
+`cancelled` and the exact same `payload.worktree_path`. Never manually remove a
+worktree owned by a blocked, queued, or running job; settle that job first.
 
 ---
 
@@ -6968,6 +7017,9 @@ Health is the operability view for unattended runs:
   treat that as neither build skew nor healthy agreement.
 - **State totals** — a chip per state (queued, running, blocked, succeeded,
   failed, cancelled).
+- **Delegation worktrees** — `/api/health` reports a `worktrees.summary` line
+  (`N stale worktrees / X GB`) plus reclaimable, pinned, unproven, and
+  recent-terminal counts and exact bytes.
 - **Stuck jobs** — blocked jobs (surfaced at any age) plus queued jobs older than
   10 minutes, each with a **derived why-stuck reason** (from the job's latest
   reason event and any resource lock it is waiting on) and how long it has been
@@ -9547,7 +9599,9 @@ gh auth status
 `gitmoot doctor` is the environment preflight: it validates `gh auth` (with an
 actionable remediation hint) and live-probes the Claude credential selected by
 `runtime-auth.env`, so a bad credential is caught before jobs stall. Run it
-after install and before starting the daemon.
+after install and before starting the daemon. It also reports delegation
+worktree count and logical disk size, warning at 10 stale worktrees or 1 GB and
+distinguishing aged-final reclaimable owners from pinned non-final owners.
 
 One-shot onboarding: `gitmoot setup` registers the repo and an agent in one
 command (`--repo owner/repo --agent <name> --runtime codex|claude|shell
@@ -13784,6 +13838,12 @@ recover` restores preserved artifacts through `implementing` to `pr_open`, or
 restores a branchless task to `planned`; job retry records its own recovery
 event. The server-side task board omits dismissed rows immediately.
 
+Delegation worktrees use a separate default-on retention policy:
+`[workflow].delegation_worktree_ttl = "72h"` (`"0"` disables it). Only final
+owners (`succeeded`, `failed`, `cancelled`) older than the TTL are force-removed.
+Blocked, queued, and running owners remain pinned; `gitmoot doctor` reports the
+reclaimable/pinned/unproven counts and logical size.
+
 Never-started `planned` tasks use a separate opt-in policy:
 `[workflow].planned_ttl = "720h"`. It is disabled by default; unset, empty,
 zero, and invalid values all resolve to off because automatic dismissal can
@@ -15102,6 +15162,28 @@ Stop and report `blocked` when the target repo is unclear, GitHub auth is
 missing, the daemon cannot access the repo, branch lock ownership is wrong, or
 continuing would require credentials or destructive operations the user did not
 approve.
+
+## Delegation Worktree Reclaim
+
+The daemon force-reclaims a recorded delegation/read-only worktree only when its
+owning job is final (`succeeded`, `failed`, or `cancelled`) and its terminal
+`updated_at` is older than `[workflow].delegation_worktree_ttl` (default `72h`;
+`"0"` disables). This default is safe because final owners cannot resume; the
+delay preserves a short debugging window. `blocked` is resumable and is never a
+TTL reclaim candidate. A successful force-remove and metadata prune records
+`delegation_worktree_reclaimed_ttl`.
+
+`gitmoot doctor` and dashboard `/api/health` surface stale count and logical
+size, split into reclaimable final owners, pinned non-final owners, and unproven
+directories. Pinned and unproven worktrees are observation-only.
+
+For manual relief, list
+`$GITMOOT_HOME/worktrees/*/delegations/*/*`, map each path to its job's
+`payload.worktree_path`, and run `gitmoot job show <job-id> --json`. Proceed only
+when the current state is `succeeded`, `failed`, or `cancelled` and the exact
+path matches; then run `git -C <registered-checkout> worktree remove --force
+<path>` followed by `git -C <registered-checkout> worktree prune`. Never remove
+a worktree owned by a blocked, queued, or running job.
 
 ---
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -39,7 +39,7 @@ full expanded context.
 ## Dashboard
 
 - [Dashboard Overview](https://gitmoot.io/docs/dashboard/overview): The read-only live web dashboard (`gitmoot dashboard --web [--addr host:port]`) over the local store — launching, the URL route table, auto-refresh cadences (12s polls, 15s runs, SSE per-run graph), mobile support, and the localhost-default/no-auth security model.
-- [Dashboard Views](https://gitmoot.io/docs/dashboard/views): The six views — Graph (per-run delegation DAG), Galaxy (whole-history force graph), Jobs (filterable table, 400-row cap), Agents (cards + detail with template prompt, version history, and per-version diff), Charts (7d/30d/90d/all series), and Health (daemon status, stuck jobs with reasons, locks, recent failures).
+- [Dashboard Views](https://gitmoot.io/docs/dashboard/views): The six views — Graph (per-run delegation DAG), Galaxy (whole-history force graph), Jobs (filterable table, 400-row cap), Agents (cards + detail with template prompt, version history, and per-version diff), Charts (7d/30d/90d/all series), and Health (daemon status, stuck jobs with reasons, locks, recent failures, delegation-worktree count and size).
 
 ## References
 
@@ -51,7 +51,7 @@ full expanded context.
 - [Event Stream](https://gitmoot.io/docs/reference/event-stream): The `[events]` webhook contract — job.finished/failed/blocked/needs_attention/deferred and candidate.* events, schema_version 1, best-effort delivery.
 - [Codex And Claude Plugins](https://gitmoot.io/docs/plugins/codex-claude): Plugin discovery and runtime skill setup.
 - [SkillOpt Exchange Contract](https://gitmoot.io/docs/reference/skillopt-exchange-contract): Training and candidate package boundary for the external optimizer.
-- [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting): Diagnose GitHub auth, bug reports, runtimes, agent templates, remotes, permissions, daemon lifecycle, stuck/deferred jobs, locks, and transient merge deferrals while branch jobs are active.
+- [Troubleshooting](https://gitmoot.io/docs/operations/troubleshooting): Diagnose GitHub auth, bug reports, runtimes, agent templates, remotes, permissions, daemon lifecycle, stuck/deferred jobs, locks, delegation-worktree disk leaks and safe terminal-owner relief, and transient merge deferrals while branch jobs are active.
 - [Beta Smoke Tests](https://gitmoot.io/docs/operations/beta-smoke-tests): Deterministic smoke checklists for release validation.
 - [Docs Deployment](https://gitmoot.io/docs/operations/deployment): How the docs site itself is built and published.
 - [Release Notes](https://gitmoot.io/docs/release-notes/v0.9.1.3): Latest release (v0.9.1.3) — **the brain changelog**: an append-only `memory_events` journal records every fact mutation in-transaction (edits keep the previous content), browsable from the new `/brain` Graph|Changelog dashboard view (day-grouped live feed, before/after diffs, fact biographies, deep links) and from `gitmoot memory log` (+ idempotent `backfill` seeding history from existing tombstones). Plus keychain-secured pipeline credentials (registry, per-pipeline grants, proxied keys, env_file/env_keys injection), transcript retention with trajectory JSONL export, produce-stage `reads:` allowlists, and daemon reliability fixes (runtime-session lease heartbeats, checkout self-heal).


### PR DESCRIPTION
Delegation worktrees leaked (**53 stale entries / 12GB** under one repo, found in a cross-lane disk audit) because the reclaim pass missed terminal-run leftovers. The disposal machinery exists; this closes the edges.

## TTL reclaim of terminal-owned worktrees

A delegation/read-only worktree whose **owning job is FINAL** (succeeded/failed/cancelled — `blocked` is resumable and excluded, so it still owns its worktree) and older than `[workflow].delegation_worktree_ttl` (**default 72h**; `"0"` disables) is force-removed (disposable by definition once the owner is terminal), its git metadata pruned, and a distinct `delegation_worktree_reclaimed_ttl` event emitted.

**Safety** (destructive reaper — gated hard): `JobIDsWithAgedTerminalDelegationWorktree` selects only final owners past the cutoff with a worktree path, delegation/read-only-only, **no shared-path owner that is non-terminal or newer**, and no prior cleanup event; `ReclaimAgedTerminalDelegationWorktree` re-checks `IsFinalJobState` + the shared-path guard before removing. `jobStateEligibleForWorktreeReclaim` is now `IsFinalJobState` (blocked excluded). Default-72h is safe because a terminal owner can never resume; the 72h grace preserves a debugging window.

## Surface the unreclaimable rest

Worktrees pinned by a **non-terminal** owner are left alone (correct) but made visible:
- `gitmoot doctor` gains a worktree-usage check classifying **reclaimable / pinned (live owner) / recent-terminal / unproven** with counts + logical size, warning past 10 stale / 1 GB.
- `/api/health` gains a `worktrees` summary + structured counts/size.
- Operator manual-relief recipe documented.

Interacts with #1054 (just merged): its terminal-driving-job triage drives stuck tasks to `blocked` and makes their jobs terminal, so their worktrees become reclaimable here.

## Review

`/code-review xhigh` (per my playbook — a destructive worktree reaper). [pending — will summarize]

## Rebase note

Rebased `--onto` merged main (past #1064's cli/daemon.go seam split, which relocated the reclaim/tick machinery). The reclaim pass + config resolver were re-placed into `daemon_scheduler.go` / `daemon_supervision.go`, and the test-double interface methods + tick-candidate assertions into `daemon_test.go` / `daemon_scheduler_test.go`; the re-integrated tick tests + reclaim tests pass.

## Deploy notes

**No deploy** (judging through Aug 5). `delegation_worktree_ttl` defaults 72h — on deploy (post-freeze) it reclaims the existing 12GB leak; until then behavior is unchanged. The separately-versioned dashboard frontend may need a follow-up release to render the new `/api/health` worktrees field as a visible row.

Closes #1056.
