### PR TITLE
feat(org): [org] registry + scope-enforced dispatch + attributed actions (#1057)

### DIFF
--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -125,6 +125,7 @@ type agentAskOptions struct {
 	effort      string
 	workflowID  string
 	workflowSet bool
+	orgRole     string
 	runtime     string
 	session     string
 	force       bool
@@ -158,6 +159,8 @@ func runAgentAsk(args []string, stdout, stderr io.Writer) int {
 			Model:                options.model,
 			Effort:               options.effort,
 			WorkflowID:           options.workflowID,
+			ActingOrgRole:        options.orgRole,
+			OperatorOrigin:       true,
 			Runtime:              options.runtime,
 			RuntimeSession:       options.session,
 			Home:                 options.home,
@@ -253,9 +256,18 @@ func parseAgentAskOptions(args []string, stderr io.Writer) (agentAskOptions, boo
 			index++
 			options.workflowSet = true
 			options.workflowID = strings.TrimSpace(args[index])
+		case arg == "--org-role":
+			if index+1 >= len(args) {
+				fmt.Fprintln(stderr, "agent ask requires a value for --org-role")
+				return agentAskOptions{}, false
+			}
+			index++
+			options.orgRole = strings.TrimSpace(args[index])
 		case strings.HasPrefix(arg, "--workflow="):
 			options.workflowSet = true
 			options.workflowID = strings.TrimSpace(strings.TrimPrefix(arg, "--workflow="))
+		case strings.HasPrefix(arg, "--org-role="):
+			options.orgRole = strings.TrimSpace(strings.TrimPrefix(arg, "--org-role="))
 		case arg == "--runtime" || arg == "--session":
 			if index+1 >= len(args) {
 				fmt.Fprintf(stderr, "agent ask requires a value for %s\n", arg)
@@ -305,6 +317,9 @@ func parseAgentAskOptions(args []string, stderr io.Writer) (agentAskOptions, boo
 	}
 	options.agent = strings.TrimSpace(positionals[0])
 	options.message = strings.TrimSpace(positionals[1])
+	if options.orgRole == "" {
+		options.orgRole = strings.TrimSpace(os.Getenv("GITMOOT_ORG_ROLE"))
+	}
 	if options.agent == "" || options.message == "" {
 		fmt.Fprintln(stderr, "agent ask requires exactly one agent and one message")
 		return agentAskOptions{}, false
@@ -335,7 +350,7 @@ func containsHelpFlag(args []string) bool {
 
 func printAgentAskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--type type] [--action ask] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json] [--force]")
+	fmt.Fprintln(w, "  gitmoot agent ask <name> \"message\" [--repo owner/repo] [--background] [--type type] [--action ask] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--home path] [--json] [--force]")
 	printAgentRuntimeOverrideHelp(w)
 }
 
@@ -364,6 +379,7 @@ type agentRunOptions struct {
 	effort                 string
 	workflowID             string
 	workflowSet            bool
+	orgRole                string
 	runtime                string
 	session                string
 	taskID                 string
@@ -552,6 +568,8 @@ func dispatchAgentCommand(options agentRunOptions, action string, reason string,
 			Model:                  options.model,
 			Effort:                 options.effort,
 			WorkflowID:             options.workflowID,
+			ActingOrgRole:          options.orgRole,
+			OperatorOrigin:         true,
 			Runtime:                options.runtime,
 			RuntimeSession:         options.session,
 			Home:                   options.home,
@@ -631,7 +649,7 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 			options.cockpit = true
 		case arg == "--skip-native-review-fanout":
 			options.skipNativeReviewFanout = true
-		case arg == "--type" || arg == "--action" || arg == "--model" || arg == "--effort" || arg == "--workflow" || arg == "--runtime" || arg == "--session" || arg == "--repo" || arg == "--home" || arg == "--task" || arg == "--pr" || arg == "--head-sha" || arg == "--base" || arg == "--branch" || arg == "--cockpit-session" || arg == "--recipe":
+		case arg == "--type" || arg == "--action" || arg == "--model" || arg == "--effort" || arg == "--workflow" || arg == "--org-role" || arg == "--runtime" || arg == "--session" || arg == "--repo" || arg == "--home" || arg == "--task" || arg == "--pr" || arg == "--head-sha" || arg == "--base" || arg == "--branch" || arg == "--cockpit-session" || arg == "--recipe":
 			if index+1 >= len(args) {
 				fmt.Fprintf(stderr, "%s requires a value for %s\n", label, arg)
 				return agentRunOptions{}, false
@@ -655,6 +673,8 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 		case strings.HasPrefix(arg, "--workflow="):
 			options.workflowSet = true
 			options.workflowID = strings.TrimSpace(strings.TrimPrefix(arg, "--workflow="))
+		case strings.HasPrefix(arg, "--org-role="):
+			options.orgRole = strings.TrimSpace(strings.TrimPrefix(arg, "--org-role="))
 		case strings.HasPrefix(arg, "--runtime="):
 			options.runtime = strings.TrimSpace(strings.TrimPrefix(arg, "--runtime="))
 		case strings.HasPrefix(arg, "--session="):
@@ -690,6 +710,9 @@ func parseAgentRunOptions(command string, args []string, stderr io.Writer) (agen
 	}
 	options.agent = strings.TrimSpace(positionals[0])
 	options.message = strings.TrimSpace(positionals[1])
+	if options.orgRole == "" {
+		options.orgRole = strings.TrimSpace(os.Getenv("GITMOOT_ORG_ROLE"))
+	}
 	if options.agent == "" || options.message == "" {
 		fmt.Fprintf(stderr, "%s requires exactly one agent and one message\n", label)
 		return agentRunOptions{}, false
@@ -757,6 +780,8 @@ func setAgentRunOption(options *agentRunOptions, flagName string, value string, 
 	case "--workflow":
 		options.workflowSet = true
 		options.workflowID = value
+	case "--org-role":
+		options.orgRole = value
 	case "--runtime":
 		options.runtime = value
 	case "--session":
@@ -829,13 +854,13 @@ func printAgentRunUsage(w io.Writer, command string) {
 	fmt.Fprintln(w, "Usage:")
 	switch command {
 	case "orchestrate":
-		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--action ask|review|implement] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--recipe id] [--cockpit] [--cockpit-session name] [--skip-native-review-fanout] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot orchestrate <agent> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--branch branch] [--type type] [--action ask|review|implement] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--recipe id] [--cockpit] [--cockpit-session name] [--skip-native-review-fanout] [--home path] [--json]")
 	case "review":
-		fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--head-sha sha] [--branch branch] [--background] [--type type] [--action review] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot agent review <name> \"message\" --repo owner/repo --pr number [--head-sha sha] [--branch branch] [--background] [--type type] [--action review] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--home path] [--json]")
 	case "implement":
-		fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--base ref] [--head-sha sha] [--branch branch] [--background] [--type type] [--action implement] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--skip-native-review-fanout] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot agent implement <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--base ref] [--head-sha sha] [--branch branch] [--background] [--type type] [--action implement] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--skip-native-review-fanout] [--home path] [--json]")
 	default:
-		fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--base ref] [--branch branch] [--background] [--type type] [--action ask|review|implement] [--model model] [--effort effort] [--workflow id] [--runtime rt] [--session ref] [--recipe id] [--skip-native-review-fanout] [--home path] [--json]")
+		fmt.Fprintln(w, "  gitmoot agent run <name> \"message\" [--repo owner/repo] [--task task-id] [--pr number] [--head-sha sha] [--base ref] [--branch branch] [--background] [--type type] [--action ask|review|implement] [--model model] [--effort effort] [--workflow id] [--org-role role] [--runtime rt] [--session ref] [--recipe id] [--skip-native-review-fanout] [--home path] [--json]")
 	}
 	if command == "implement" || command == "run" {
 		fmt.Fprintln(w, "  --base <ref> selects the starting commit for implement worktrees; origin/* refs are fetched before resolution.")

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -25,15 +25,17 @@ var newAgentDispatchGitHubClient = func(checkout string) github.Client {
 }
 
 type localAgentDispatchRequest struct {
-	RepoFlag     string
-	Agent        string
-	Action       string
-	Instructions string
-	Background   bool
-	Type         string
-	Model        string
-	Effort       string
-	WorkflowID   string
+	RepoFlag       string
+	Agent          string
+	Action         string
+	Instructions   string
+	Background     bool
+	Type           string
+	Model          string
+	Effort         string
+	WorkflowID     string
+	ActingOrgRole  string
+	OperatorOrigin bool
 	// Runtime, when non-empty, is the per-job runtime override (#531): this one
 	// job runs through the named runtime while the agent's registered default
 	// runtime (and its session) stays untouched. RuntimeSession optionally names
@@ -117,10 +119,26 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
+	// Resolve once per human dispatch. The snapshot is shared by the mutation
+	// preflight and the enqueue chokepoint so both see precisely one registry.
+	orgPolicy := orgPolicyResolver(request.Home)
+	var resolvedOrgPolicy workflow.OrgEnforcement
+	if request.OperatorOrigin {
+		resolvedOrgPolicy = orgPolicy(repo.FullName())
+		orgPolicy = fixedOrgPolicy(resolvedOrgPolicy)
+		request.ActingOrgRole = workflow.NormalizeActingOrgRole(request.ActingOrgRole)
+	}
 	// Strict workflow rejection must happen before repo/task/worktree/branch-lock
 	// mutation. Otherwise a retry without --workflow strands a fresh adhoc task.
 	if request.Action == "implement" {
 		if err := preflightStrictWorkflowPolicy(request.Home, repo.FullName(), request.WorkflowID, ""); err != nil {
+			return localAgentJobOutput{}, err
+		}
+	}
+	// Implement and review both allocate durable state before enqueue. Check the
+	// shared decision first so a block never strands a task or worktree.
+	if request.Action == "implement" || request.Action == "review" {
+		if err := preflightOrgScope(resolvedOrgPolicy, repo.FullName(), request.ActingOrgRole, request.OperatorOrigin); err != nil {
 			return localAgentJobOutput{}, err
 		}
 	}
@@ -163,7 +181,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if agent, blocked, err := readOnlyManagedImplementationBlock(ctx, store, request, repo.FullName()); err != nil {
 		return localAgentJobOutput{}, err
 	} else if blocked {
-		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name, overrideRuntime, overrideRef)
+		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name, overrideRuntime, overrideRef, orgPolicy)
 	}
 	agent, releaseAgentReservation, err := resolveLocalDispatchAgent(ctx, store, request, repo.FullName(), record)
 	if err != nil {
@@ -198,7 +216,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		}
 	}
 	if readOnlyImplementationBlocked(request.Action, effectiveAgent) {
-		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name, overrideRuntime, overrideRef)
+		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name, overrideRuntime, overrideRef, orgPolicy)
 	}
 	switch request.Action {
 	case "review":
@@ -256,7 +274,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			request.Instructions += note
 		}
 	}
-	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(request.Home)}).Enqueue(ctx, workflow.JobRequest{
+	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(request.Home), OrgPolicy: orgPolicy}).Enqueue(ctx, workflow.JobRequest{
 		ID:                     jobID,
 		Agent:                  agent.Name,
 		Action:                 request.Action,
@@ -270,6 +288,8 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		LeadAgent:              firstNonEmpty(request.LeadAgent, agent.Name),
 		Reviewers:              request.Reviewers,
 		Sender:                 "local",
+		ActingOrgRole:          request.ActingOrgRole,
+		OperatorOrigin:         request.OperatorOrigin,
 		Instructions:           request.Instructions,
 		Model:                  request.Model,
 		Effort:                 request.Effort,
@@ -541,22 +561,24 @@ func buildLocalAgentJobOutput(latest db.Job, request localAgentDispatchRequest) 
 	}, nil
 }
 
-func enqueuePermissionBlockedLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, defaultBranch string, agentName string, overrideRuntime string, overrideRef string) (localAgentJobOutput, error) {
-	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(request.Home)}).Enqueue(ctx, workflow.JobRequest{
-		ID:           localAgentJobID(request.Action, agentName),
-		Agent:        agentName,
-		Action:       request.Action,
-		Repo:         repo,
-		Branch:       firstNonEmpty(request.Branch, defaultBranch),
-		PullRequest:  request.PullRequest,
-		HeadSHA:      request.HeadSHA,
-		GoalID:       request.GoalID,
-		TaskID:       request.TaskID,
-		TaskTitle:    request.TaskTitle,
-		LeadAgent:    request.LeadAgent,
-		Reviewers:    request.Reviewers,
-		Sender:       "local",
-		Instructions: request.Instructions,
+func enqueuePermissionBlockedLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, defaultBranch string, agentName string, overrideRuntime string, overrideRef string, orgPolicy func(string) workflow.OrgEnforcement) (localAgentJobOutput, error) {
+	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(request.Home), OrgPolicy: orgPolicy}).Enqueue(ctx, workflow.JobRequest{
+		ID:             localAgentJobID(request.Action, agentName),
+		Agent:          agentName,
+		Action:         request.Action,
+		Repo:           repo,
+		Branch:         firstNonEmpty(request.Branch, defaultBranch),
+		PullRequest:    request.PullRequest,
+		HeadSHA:        request.HeadSHA,
+		GoalID:         request.GoalID,
+		TaskID:         request.TaskID,
+		TaskTitle:      request.TaskTitle,
+		LeadAgent:      request.LeadAgent,
+		Reviewers:      request.Reviewers,
+		Sender:         "local",
+		ActingOrgRole:  request.ActingOrgRole,
+		OperatorOrigin: request.OperatorOrigin,
+		Instructions:   request.Instructions,
 		// Persist the per-job --model and the resolved --runtime/--session override
 		// (#531) on the BLOCKED job too: `gitmoot job retry` re-runs the stored
 		// payload as-is, so dropping them here would silently retry the job on the

--- a/internal/cli/agent_implement_base_test.go
+++ b/internal/cli/agent_implement_base_test.go
@@ -133,6 +133,89 @@ func TestLocalImplementStrictWorkflowPreflightLeavesNoTaskWorktreeOrLock(t *test
 	}
 }
 
+func TestLocalImplementOrgScopePreflightLeavesNoTaskWorktreeOrLock(t *testing.T) {
+	fixture := newImplementBaseFixture(t)
+	paths := config.PathsForHome(fixture.home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	content := config.DefaultConfig(paths) + "\n[org.roles.\"owner\"]\nscope = [\"other/*\"]\n"
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, fixture.home)
+	defer store.Close()
+	ctx := context.Background()
+	runGit(t, fixture.checkout, "remote", "set-url", "origin", "https://github.com/owner/repo.git")
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: fixture.checkout}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "builder", Action: "implement", Home: fixture.home, Instructions: "Implement the requested change.", OperatorOrigin: true, ActingOrgRole: "owner",
+	})
+	if err == nil || !strings.Contains(err.Error(), "out of scope") {
+		t.Fatalf("org dispatch err=%v", err)
+	}
+	tasks, err := store.ListTasks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("org rejection created tasks: %+v", tasks)
+	}
+	locks, err := store.ListBranchLocks(ctx, "owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(locks) != 0 {
+		t.Fatalf("org rejection created branch locks: %+v", locks)
+	}
+	worktreeRoot := filepath.Join(paths.Workspaces, "owner", "repo")
+	if entries, err := os.ReadDir(worktreeRoot); err == nil && len(entries) != 0 {
+		t.Fatalf("org rejection created worktrees: %+v", entries)
+	} else if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+}
+
+func TestLocalReviewOrgScopePreflightLeavesNoTaskOrWorktree(t *testing.T) {
+	fixture := newImplementBaseFixture(t)
+	paths := config.PathsForHome(fixture.home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	content := config.DefaultConfig(paths) + "\n[org.roles.\"owner\"]\nscope = [\"other/*\"]\n"
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, fixture.home)
+	defer store.Close()
+	ctx := context.Background()
+	runGit(t, fixture.checkout, "remote", "set-url", "origin", "https://github.com/owner/repo.git")
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: fixture.checkout}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "reviewer", Action: "review", Home: fixture.home, Instructions: "Review the change.", OperatorOrigin: true, ActingOrgRole: "owner",
+	})
+	if err == nil || !strings.Contains(err.Error(), "out of scope") {
+		t.Fatalf("org review err=%v", err)
+	}
+	tasks, err := store.ListTasks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("org review rejection created tasks: %+v", tasks)
+	}
+	worktreeRoot := filepath.Join(paths.Workspaces, "owner", "repo")
+	if entries, err := os.ReadDir(worktreeRoot); err == nil && len(entries) != 0 {
+		t.Fatalf("org review rejection created worktrees: %+v", entries)
+	} else if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+}
+
 func TestAgentImplementBaseHEADUsesCheckoutHead(t *testing.T) {
 	fixture := newImplementBaseFixture(t)
 	task, _, err := prepareImplementBaseFixture(t, fixture, localAgentDispatchRequest{Branch: "test-head", ImplementBase: "HEAD"})

--- a/internal/cli/daemon_lifecycle.go
+++ b/internal/cli/daemon_lifecycle.go
@@ -362,6 +362,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		engine := workflow.Engine{
 			Store:                 store,
 			RequireWorkflowPolicy: requireWorkflowPolicyResolverRoot(config.PathsForHome(*home).Home),
+			OrgPolicy:             orgPolicyResolverRoot(config.PathsForHome(*home).Home),
 			ProduceCheckDir:       checkout,
 			MergeGate:             mergeGate,
 			// Registry default model/effort fallbacks, home-aware and fail-open — see

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -275,7 +275,7 @@ type heartbeatEnqueuer func(ctx context.Context, request workflow.JobRequest) (d
 // construction so a heartbeat job is indistinguishable from a normal background
 // job once enqueued.
 func newHeartbeatEnqueuer(store *db.Store, home string) heartbeatEnqueuer {
-	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home)}
+	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home), OrgPolicy: orgPolicyResolver(home)}
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
 		return mailbox.Enqueue(ctx, request)
 	}

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1747,7 +1747,7 @@ func (w jobWorker) queueTempWorkerMergeBack(ctx context.Context, completedJobID 
 			"Do not edit files, create commits, open pull requests, or dispatch more agents unless the summary explicitly requires follow-up.",
 		},
 	}
-	if _, err := (workflow.Mailbox{Store: w.Store, CanaryEnabled: canaryRoutingEnabled(w.workflowHome()), RuntimeDefaultModel: runtimeDefaultModelResolver(w.workflowHome()), RequireWorkflowPolicy: requireWorkflowPolicyResolver(w.workflowHome())}).Enqueue(ctx, request); err != nil {
+	if _, err := (workflow.Mailbox{Store: w.Store, CanaryEnabled: canaryRoutingEnabled(w.workflowHome()), RuntimeDefaultModel: runtimeDefaultModelResolver(w.workflowHome()), RequireWorkflowPolicy: requireWorkflowPolicyResolver(w.workflowHome()), OrgPolicy: orgPolicyResolver(w.workflowHome())}).Enqueue(ctx, request); err != nil {
 		return err
 	}
 	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: completedJob.ID, Kind: "temp_worker_merge_back_queued", Message: fmt.Sprintf("queued summary merge-back job %s for %s", mergeBackID, original.Name)})

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -39,6 +39,7 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 	engine := workflow.Engine{
 		Store:                   store,
 		RequireWorkflowPolicy:   requireWorkflowPolicyResolverRoot(home),
+		OrgPolicy:               orgPolicyResolverRoot(home),
 		ProduceCheckDir:         checkout,
 		MergeGate:               daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout, Home: home},
 		ImplementationFinalizer: daemonImplementationFinalizer{Store: store, GitHub: gh, FallbackCheckout: checkout},

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// orgPolicyResolver accepts a raw --home, while the Root variant below accepts
+// the already resolved <home>/.gitmoot path used by daemon engines.
+func orgPolicyResolver(home string) func(string) workflow.OrgEnforcement {
+	if strings.TrimSpace(home) == "" {
+		paths, err := pathsFromFlag("")
+		if err != nil {
+			return func(string) workflow.OrgEnforcement { return workflow.OrgEnforcement{LoadErr: err} }
+		}
+		return orgPolicyResolverPaths(paths)
+	}
+	return orgPolicyResolverPaths(config.PathsForHome(home))
+}
+
+func orgPolicyResolverRoot(root string) func(string) workflow.OrgEnforcement {
+	return orgPolicyResolverPaths(config.Paths{ConfigFile: configFileAtRoot(root)})
+}
+
+func orgPolicyResolverPaths(paths config.Paths) func(string) workflow.OrgEnforcement {
+	return func(string) workflow.OrgEnforcement {
+		cfg, err := config.LoadOrg(paths)
+		if err != nil {
+			return workflow.OrgEnforcement{LoadErr: err}
+		}
+		return workflow.OrgEnforcement{
+			Enabled: cfg.Enabled(), Enforce: cfg.Enforce(),
+			Role: func(name string) (workflow.OrgRole, bool) {
+				r, ok := cfg.Role(name)
+				return workflow.OrgRole{Name: r.Name, Parent: r.Parent, Scope: append([]string(nil), r.Scope...), MergeRule: r.MergeRule}, ok
+			},
+			ScopeMatches: config.ScopeMatches,
+		}
+	}
+}
+
+// preflightOrgScope prevents an org-blocked implement/task-run request from
+// allocating a task worktree or branch lock before Mailbox.Enqueue can reject.
+// Warn mode intentionally leaves the durable event to the enqueue chokepoint.
+func preflightOrgScope(policy workflow.OrgEnforcement, repo, actingRole string, operatorOrigin bool) error {
+	if !operatorOrigin {
+		return nil
+	}
+	_, err := workflow.OrgScopeDecision(policy, actingRole, repo)
+	return err
+}
+
+func fixedOrgPolicy(policy workflow.OrgEnforcement) func(string) workflow.OrgEnforcement {
+	return func(string) workflow.OrgEnforcement { return policy }
+}
+
+func runOrg(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprintln(stdout, "Usage:\n  gitmoot org validate [--home path]\n  gitmoot org show [--home path]")
+		return 0
+	}
+	if args[0] != "validate" && args[0] != "show" {
+		fmt.Fprintf(stderr, "unknown org command %q\n", args[0])
+		return 2
+	}
+	fs := flag.NewFlagSet("org "+args[0], flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "org %s does not accept positional arguments\n", args[0])
+		return 2
+	}
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org %s: resolve paths: %v\n", args[0], err)
+		return 1
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org %s: %v\n", args[0], err)
+		return 1
+	}
+	if args[0] == "validate" {
+		fmt.Fprintf(stdout, "ok %d roles\n", len(cfg.Roles()))
+		return 0
+	}
+	for _, role := range cfg.Roles() {
+		fmt.Fprintf(stdout, "%s\tparent=%s\tscope=%s\tmerge_rule=%s\n", role.Name, role.Parent, strings.Join(role.Scope, ","), firstNonEmpty(role.MergeRule, "owner"))
+	}
+	return 0
+}

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestOrgPolicyResolverFailsClosed(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[org.roles.\"owner\"]\nscope=[\"bad/extra/path\"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := orgPolicyResolver(home)("owner/repo"); got.LoadErr == nil {
+		t.Fatal("malformed config did not surface LoadErr")
+	}
+}
+
+func TestOrgCommandAndAgentOrgRolePrecedence(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[org.roles.\"owner\"]\nscope=[\"*\"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	if code := runOrg([]string{"validate", "--home", home}, &out, &errOut); code != 0 || out.String() != "ok 1 roles\n" {
+		t.Fatalf("validate code=%d out=%q err=%q", code, out.String(), errOut.String())
+	}
+	out.Reset()
+	if code := runOrg([]string{"show", "--home", home}, &out, &errOut); code != 0 || !strings.Contains(out.String(), "owner\tparent=\tscope=*\tmerge_rule=owner") {
+		t.Fatalf("show code=%d out=%q err=%q", code, out.String(), errOut.String())
+	}
+	t.Setenv("GITMOOT_ORG_ROLE", "env-role")
+	options, ok := parseAgentAskOptions([]string{"agent", "message"}, &errOut)
+	if !ok || options.orgRole != "env-role" {
+		t.Fatalf("env options=%+v ok=%v", options, ok)
+	}
+	options, ok = parseAgentAskOptions([]string{"--org-role", "flag-role", "agent", "message"}, &errOut)
+	if !ok || options.orgRole != "flag-role" {
+		t.Fatalf("flag options=%+v ok=%v", options, ok)
+	}
+}
+
+func TestOrgPreflightEnqueueParity(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		enforce       string
+		role          string
+		repo          string
+		wantViolation bool
+		wantErr       bool
+	}{
+		{name: "block role-less", enforce: "block", repo: "owner/repo", wantErr: true},
+		{name: "block unknown", enforce: "block", role: "unknown", repo: "owner/repo", wantErr: true},
+		{name: "block out-of-scope", enforce: "block", role: "owner", repo: "other/repo", wantErr: true},
+		{name: "block in-scope", enforce: "block", role: "OWNER", repo: "owner/repo"},
+		{name: "warn role-less", enforce: "warn", repo: "owner/repo", wantViolation: true},
+		{name: "warn unknown", enforce: "warn", role: "unknown", repo: "owner/repo", wantViolation: true},
+		{name: "warn out-of-scope", enforce: "warn", role: "owner", repo: "other/repo", wantViolation: true},
+		{name: "warn in-scope", enforce: "warn", role: "owner", repo: "owner/repo"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := orgParityPolicy(tt.enforce)
+			violation, decisionErr := workflow.OrgScopeDecision(policy, tt.role, tt.repo)
+			if (decisionErr != nil) != tt.wantErr || (violation != "") != tt.wantViolation {
+				t.Fatalf("shared decision violation=%q err=%v", violation, decisionErr)
+			}
+			if err := preflightOrgScope(policy, tt.repo, tt.role, true); (err != nil) != tt.wantErr {
+				t.Fatalf("preflight err=%v, shared err=%v", err, decisionErr)
+			}
+			store := openCLIJobStore(t, t.TempDir())
+			defer store.Close()
+			job, err := (workflow.Mailbox{Store: store, OrgPolicy: fixedOrgPolicy(policy)}).Enqueue(context.Background(), workflow.JobRequest{ID: "parity", Agent: "agent", Action: "ask", Repo: tt.repo, OperatorOrigin: true, ActingOrgRole: tt.role})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("enqueue err=%v, shared err=%v", err, decisionErr)
+			}
+			if err != nil {
+				return
+			}
+			events, err := store.ListJobEvents(context.Background(), job.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotViolation := false
+			for _, event := range events {
+				gotViolation = gotViolation || event.Kind == "org_scope_violation"
+			}
+			if gotViolation != tt.wantViolation {
+				t.Fatalf("warning event=%v want %v; events=%+v", gotViolation, tt.wantViolation, events)
+			}
+		})
+	}
+}
+
+func orgParityPolicy(enforce string) workflow.OrgEnforcement {
+	return workflow.OrgEnforcement{
+		Enabled: true,
+		Enforce: enforce,
+		Role: func(name string) (workflow.OrgRole, bool) {
+			if name == "owner" {
+				return workflow.OrgRole{Name: "owner", Scope: []string{"owner/*"}}, true
+			}
+			return workflow.OrgRole{}, false
+		},
+		ScopeMatches: func(scopes []string, repo string) bool {
+			return len(scopes) == 1 && scopes[0] == "owner/*" && strings.HasPrefix(repo, "owner/")
+		},
+	}
+}

--- a/internal/cli/pipeline_enqueue.go
+++ b/internal/cli/pipeline_enqueue.go
@@ -34,7 +34,7 @@ func pipelineStageCheckoutPath(ctx context.Context, store *db.Store, repo string
 // indistinguishable from a normal background job once enqueued (the runner agent
 // carries no template, so canary never actually samples).
 func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueuer {
-	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home)}
+	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home), OrgPolicy: orgPolicyResolver(home)}
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
 		// #1011 service shell stages are an explicit fail-CLOSED exception to the
 		// generic read-only allocator below. Their run row is authoritative: every

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,6 +30,7 @@ var rootCommands = []command{
 	{name: "doctor", summary: "check local Gitmoot prerequisites", run: runDoctor},
 	{name: "version", summary: "show Gitmoot version and build metadata", run: runVersion},
 	{name: "config", summary: "show local Gitmoot config paths", run: runConfig},
+	{name: "org", summary: "org registry + attribution (RFC #1042)", run: runOrg},
 	{name: "auth", summary: "manage runtime authentication", run: runAuth},
 	{name: "key", summary: "manage keycard registry metadata and grants", run: runKey},
 	{name: "update", summary: "check for and apply Gitmoot releases", run: runUpdate},

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -268,7 +268,7 @@ func runTask(args []string, stdout, stderr io.Writer) int {
 
 func printTaskUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>] [--workflow <label>]")
+	fmt.Fprintln(w, "  gitmoot task run <id> --repo owner/repo --owner <agent> [--branch <branch>] [--base <branch>] [--workflow <label>] [--org-role <role>]")
 	fmt.Fprintln(w, "  gitmoot task recover <id> [--owner <agent>] [--repo owner/repo] [--skip-native-review-fanout] [--json]")
 	fmt.Fprintln(w, "  gitmoot task dismiss <id> [--reason text] [--json]")
 	fmt.Fprintln(w, "  gitmoot task events <id> [--json]")
@@ -360,6 +360,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	branch := fs.String("branch", "", "task branch name")
 	base := fs.String("base", "", "base branch for git worktree add")
 	workflowID := fs.String("workflow", "", "workflow label as namespace/campaign")
+	orgRole := fs.String("org-role", strings.TrimSpace(os.Getenv("GITMOOT_ORG_ROLE")), "organization role for this operator dispatch")
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		fs.Usage()
 		if len(args) == 0 {
@@ -412,6 +413,12 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("invalid repo: %w", err)
 		}
+		// Capture the registry once before any repo/task/worktree mutation, then
+		// hand the identical policy to the enqueue chokepoint below.
+		orgPolicy := orgPolicyResolverRoot(paths.Home)(requestRepo)
+		if err := preflightOrgScope(orgPolicy, requestRepo, *orgRole, true); err != nil {
+			return err
+		}
 		policy := requireWorkflowPolicyResolverRoot(paths.Home)(requestRepo)
 		if policy.Enabled && policy.Mode == "strict" && strings.TrimSpace(*workflowID) == "" {
 			return fmt.Errorf("repo %s has require_workflow=strict: pass --workflow <namespace>/<campaign>", requestRepo)
@@ -440,7 +447,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 			if err != nil {
 				return fmt.Errorf("resolve task worktree head: %w", err)
 			}
-			request := taskRunImplementJobRequest(taskRunImplementJobID(candidate.ID, strings.TrimSpace(*owner)), candidate, strings.TrimSpace(*owner), headSHA, *workflowID)
+			request := taskRunImplementJobRequest(taskRunImplementJobID(candidate.ID, strings.TrimSpace(*owner)), candidate, strings.TrimSpace(*owner), headSHA, *workflowID, *orgRole)
 			if active, ok, err := findActiveTaskRunJob(context.Background(), store, request); err != nil {
 				return err
 			} else if ok {
@@ -477,14 +484,14 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 		if err != nil {
 			return fmt.Errorf("resolve task worktree head: %w", err)
 		}
-		request := taskRunImplementJobRequest(taskRunImplementJobID(started.ID, strings.TrimSpace(*owner)), started, strings.TrimSpace(*owner), headSHA, *workflowID)
+		request := taskRunImplementJobRequest(taskRunImplementJobID(started.ID, strings.TrimSpace(*owner)), started, strings.TrimSpace(*owner), headSHA, *workflowID, *orgRole)
 		if active, ok, err := findActiveTaskRunJob(context.Background(), store, request); err != nil {
 			return err
 		} else if ok {
 			startedJob = active
 			return nil
 		}
-		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA, paths.Home, *workflowID)
+		startedJob, err = enqueueTaskRunImplementJob(context.Background(), store, started, strings.TrimSpace(*owner), headSHA, paths.Home, *workflowID, *orgRole, orgPolicy)
 		return err
 	}); err != nil {
 		fmt.Fprintf(stderr, "run task: %v\n", err)
@@ -1159,10 +1166,10 @@ func taskRecoverJobID(taskID string, owner string) string {
 	return value
 }
 
-func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string, home string, workflowID string) (db.Job, error) {
+func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Task, owner string, headSHA string, home string, workflowID string, orgRole string, orgPolicy workflow.OrgEnforcement) (db.Job, error) {
 	baseJobID := taskRunImplementJobID(task.ID, owner)
 	jobID := baseJobID
-	request := taskRunImplementJobRequest(jobID, task, owner, headSHA, workflowID)
+	request := taskRunImplementJobRequest(jobID, task, owner, headSHA, workflowID, orgRole)
 	if existing, err := store.GetJob(ctx, jobID); err == nil {
 		if (existing.State == string(workflow.JobQueued) || existing.State == string(workflow.JobRunning)) && taskRunJobMatchesRequest(existing, request) {
 			return existing, nil
@@ -1173,11 +1180,11 @@ func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Ta
 			return active, nil
 		}
 		jobID = baseJobID + "-" + shortHash(existing.State+"\x00"+headSHA+"\x00"+time.Now().UTC().Format(time.RFC3339Nano))
-		request = taskRunImplementJobRequest(jobID, task, owner, headSHA, workflowID)
+		request = taskRunImplementJobRequest(jobID, task, owner, headSHA, workflowID, orgRole)
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return db.Job{}, err
 	}
-	return (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home)}).Enqueue(ctx, request)
+	return (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home), OrgPolicy: fixedOrgPolicy(orgPolicy)}).Enqueue(ctx, request)
 }
 
 func findActiveTaskRunJob(ctx context.Context, store *db.Store, request workflow.JobRequest) (db.Job, bool, error) {
@@ -1196,26 +1203,28 @@ func findActiveTaskRunJob(ctx context.Context, store *db.Store, request workflow
 	return db.Job{}, false, nil
 }
 
-func taskRunImplementJobRequest(jobID string, task db.Task, owner string, headSHA string, workflowID string) workflow.JobRequest {
+func taskRunImplementJobRequest(jobID string, task db.Task, owner string, headSHA string, workflowID string, orgRole string) workflow.JobRequest {
 	title := strings.TrimSpace(task.Title)
 	label := task.ID
 	if title != "" {
 		label += ": " + title
 	}
 	return workflow.JobRequest{
-		ID:           jobID,
-		Agent:        owner,
-		Action:       "implement",
-		Repo:         task.RepoFullName,
-		Branch:       task.Branch,
-		HeadSHA:      headSHA,
-		GoalID:       task.GoalID,
-		TaskID:       task.ID,
-		TaskTitle:    task.Title,
-		LeadAgent:    owner,
-		Sender:       "task run",
-		WorkflowID:   strings.TrimSpace(workflowID),
-		Instructions: "Implement task " + label + ".",
+		ID:             jobID,
+		Agent:          owner,
+		Action:         "implement",
+		Repo:           task.RepoFullName,
+		Branch:         task.Branch,
+		HeadSHA:        headSHA,
+		GoalID:         task.GoalID,
+		TaskID:         task.ID,
+		TaskTitle:      task.Title,
+		LeadAgent:      owner,
+		Sender:         "task run",
+		ActingOrgRole:  orgRole,
+		OperatorOrigin: true,
+		WorkflowID:     strings.TrimSpace(workflowID),
+		Instructions:   "Implement task " + label + ".",
 	}
 }
 

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -45,7 +45,7 @@ func TestTaskRunRequireWorkflowPolicy(t *testing.T) {
 	if task.State != "planned" || task.WorktreePath != "" {
 		t.Fatalf("strict preflight mutated task=%+v", task)
 	}
-	if _, err := enqueueTaskRunImplementJob(context.Background(), store, db.Task{ID: "strict-task", RepoFullName: "owner/repo", Title: "Strict", Branch: "strict-task"}, "lead", "abc", home, "team/campaign"); err != nil {
+	if _, err := enqueueTaskRunImplementJob(context.Background(), store, db.Task{ID: "strict-task", RepoFullName: "owner/repo", Title: "Strict", Branch: "strict-task"}, "lead", "abc", home, "team/campaign", "", workflow.OrgEnforcement{}); err != nil {
 		t.Fatalf("strict explicit workflow enqueue: %v", err)
 	}
 	if _, err := store.GetJob(context.Background(), "task-strict-task-implement-lead"); err != nil {
@@ -63,7 +63,7 @@ func TestTaskRunRequireWorkflowPolicy(t *testing.T) {
 	}
 	autoStore := openCLIJobStore(t, autoHome)
 	defer autoStore.Close()
-	job, err := enqueueTaskRunImplementJob(context.Background(), autoStore, db.Task{ID: "auto-task", RepoFullName: "owner/repo", Branch: "auto-task"}, "lead", "abc", autoHome, "")
+	job, err := enqueueTaskRunImplementJob(context.Background(), autoStore, db.Task{ID: "auto-task", RepoFullName: "owner/repo", Branch: "auto-task"}, "lead", "abc", autoHome, "", "", workflow.OrgEnforcement{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,6 +74,69 @@ func TestTaskRunRequireWorkflowPolicy(t *testing.T) {
 	if !strings.HasPrefix(payload.WorkflowID, "adhoc/") {
 		t.Fatalf("auto workflow=%q", payload.WorkflowID)
 	}
+}
+
+func TestTaskRunOrgScopePreflightLeavesTaskUntouched(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+"\n[org.roles.\"owner\"]\nscope=[\"other/*\"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, home)
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "org-task", RepoFullName: "owner/repo", Title: "Org", State: "planned", Branch: "org-task"}); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"task", "run", "org-task", "--home", home, "--repo", "owner/repo", "--owner", "lead", "--org-role", "OWNER"}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "out of scope") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	store = openCLIJobStore(t, home)
+	defer store.Close()
+	task, err := store.GetTask(context.Background(), "org-task")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.State != "planned" || task.WorktreePath != "" {
+		t.Fatalf("org preflight mutated task=%+v", task)
+	}
+	if _, err := store.GetBranchLock(context.Background(), "owner/repo", "org-task"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("org preflight created branch lock: %v", err)
+	}
+}
+
+func TestTaskRunOrgScopeWarnRecordsEnqueueEvent(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+"\n[org]\nenforce = \"warn\"\n[org.roles.\"owner\"]\nscope=[\"other/*\"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	policy := orgPolicyResolverRoot(paths.Home)("owner/repo")
+	if err := preflightOrgScope(policy, "owner/repo", "OWNER", true); err != nil {
+		t.Fatalf("warn preflight: %v", err)
+	}
+	job, err := enqueueTaskRunImplementJob(context.Background(), store, db.Task{ID: "warn-task", RepoFullName: "owner/repo", Branch: "warn-task"}, "lead", "abc", paths.Home, "", "OWNER", policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListJobEvents(context.Background(), job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Kind == "org_scope_violation" {
+			return
+		}
+	}
+	t.Fatalf("task-run warning event missing: %+v", events)
 }
 
 func TestRunGoalImportAndStatus(t *testing.T) {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -570,5 +570,21 @@ path = ""
 # require_external_ci = false
 # min_ci_wait = "60s"
 # max_ci_wait = "10m"
+
+# [org] optionally registers organization roles for scoped local dispatch. Any
+# [org.roles.*] entry turns enforcement on. One parent-less role is the org
+# owner; child scopes must be subsets of their parent's scope. scope accepts
+# "*" (all repos), "owner/*", or exact "owner/name". enforce is "block"
+# (default) or "warn". Scope is checked at dispatch; merge_rule is advisory in
+# this phase (owner | self | none).
+# [org]
+# enforce = "block"
+# [org.roles."owner"]
+# scope = ["*"]
+# merge_rule = "owner"
+# [org.roles."maintainer"]
+# parent = "owner"
+# scope = ["owner/*"]
+# merge_rule = "self"
 `, paths.Database, paths.Logs, paths.Workspaces, paths.Evals, paths.ArtifactBlobs)
 }

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -1,0 +1,390 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// OrgRole is one role in the local organization registry. MergeRule is
+// deliberately advisory in phase 1a; scope is enforced at dispatch.
+type OrgRole struct {
+	Name      string
+	Parent    string
+	Scope     []string
+	MergeRule string
+}
+
+// OrgConfig is the local organization registry. Its fields stay private so the
+// loader remains the single place that establishes its invariants.
+type OrgConfig struct {
+	enforce string
+	roles   map[string]OrgRole
+}
+
+func (c OrgConfig) Enabled() bool { return len(c.roles) > 0 }
+
+func (c OrgConfig) Enforce() string {
+	if c.enforce == "" {
+		return "block"
+	}
+	return c.enforce
+}
+
+func (c OrgConfig) Role(name string) (OrgRole, bool) {
+	r, ok := c.roles[strings.ToLower(strings.TrimSpace(name))]
+	return r, ok
+}
+
+func (c OrgConfig) Roots() []string {
+	roots := make([]string, 0, len(c.roles))
+	for name, role := range c.roles {
+		if role.Parent == "" {
+			roots = append(roots, name)
+		}
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+func (c OrgConfig) Roles() []OrgRole {
+	names := make([]string, 0, len(c.roles))
+	for name := range c.roles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]OrgRole, 0, len(names))
+	for _, name := range names {
+		out = append(out, c.roles[name])
+	}
+	return out
+}
+
+// LoadOrg reads the optional [org] registry. A missing file means org has not
+// been configured; any other IO or parse error is intentionally returned so the
+// enqueue resolver can fail closed.
+func LoadOrg(paths Paths) (OrgConfig, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return OrgConfig{roles: map[string]OrgRole{}}, nil
+		}
+		return OrgConfig{}, err
+	}
+	cfg := OrgConfig{roles: map[string]OrgRole{}}
+	current := ""
+	inOrg := false
+	lines := strings.Split(string(content), "\n")
+	for index := 0; index < len(lines); index++ {
+		line := strings.TrimSpace(stripOrgConfigComment(lines[index]))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && !strings.HasSuffix(line, "]") {
+			// Match the other narrowly-scoped config loaders: a typo in an
+			// unrelated section must not make an absent org policy fail closed.
+			inOrg, current = false, ""
+			// Fail closed ONLY for a genuinely org-shaped header — "org" as a
+			// complete token (end, a "." path separator, or a stray-space typo
+			// of [org.roles...]) — so a typo in the registry cannot silently
+			// disable the gate. Unrelated sections whose name merely starts with
+			// "org" ([organization], [orgs], [org_settings]) stay tolerated: an
+			// unrelated typo must not brick dispatch.
+			body := strings.TrimSpace(strings.TrimPrefix(line, "["))
+			if strings.HasPrefix(body, "org") && (len(body) == 3 || body[3] == '.' || unicode.IsSpace(rune(body[3]))) {
+				return OrgConfig{}, fmt.Errorf("parse org section: missing closing ]")
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			name, role, ok, err := parseOrgSection(strings.TrimSpace(line[1 : len(line)-1]))
+			if err != nil {
+				return OrgConfig{}, err
+			}
+			inOrg, current = name, role
+			if current != "" && ok {
+				if _, exists := cfg.roles[current]; exists {
+					return OrgConfig{}, fmt.Errorf("org role %q: duplicate section", current)
+				}
+				cfg.roles[current] = OrgRole{Name: current}
+			}
+			continue
+		}
+		if !inOrg {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return OrgConfig{}, fmt.Errorf("parse [org]: expected key = value")
+		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+		if current == "" {
+			if key == "enforce" {
+				v, err := parseOrgTOMLString(value)
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("parse [org].enforce: %w", err)
+				}
+				cfg.enforce = v
+			}
+			continue
+		}
+		role := cfg.roles[current]
+		switch key {
+		case "parent":
+			v, err := parseOrgTOMLString(value)
+			if err != nil {
+				return OrgConfig{}, fmt.Errorf("org role %q: parse parent: %w", current, err)
+			}
+			role.Parent = v
+		case "scope":
+			for !strings.HasSuffix(strings.TrimSpace(value), "]") {
+				index++
+				if index >= len(lines) {
+					return OrgConfig{}, fmt.Errorf("org role %q: parse scope: unterminated array", current)
+				}
+				value += "\n" + strings.TrimSpace(stripOrgConfigComment(lines[index]))
+			}
+			v, err := parseOrgScopeArray(value)
+			if err != nil {
+				return OrgConfig{}, fmt.Errorf("org role %q: parse scope: %w", current, err)
+			}
+			for i := range v {
+				normalized, err := normalizeOrgScope(v[i])
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("org role %q: %w", current, err)
+				}
+				v[i] = normalized
+			}
+			role.Scope = v
+		case "merge_rule":
+			v, err := parseOrgTOMLString(value)
+			if err != nil {
+				return OrgConfig{}, fmt.Errorf("org role %q: parse merge_rule: %w", current, err)
+			}
+			role.MergeRule = v
+		}
+		cfg.roles[current] = role
+	}
+	if err := ValidateOrg(cfg); err != nil {
+		return OrgConfig{}, err
+	}
+	return cfg, nil
+}
+
+func parseOrgSection(section string) (inOrg bool, role string, ok bool, err error) {
+	if section == "org" {
+		return true, "", true, nil
+	}
+	const prefix = "org.roles."
+	if !strings.HasPrefix(section, prefix) {
+		return false, "", false, nil
+	}
+	tail := strings.TrimSpace(strings.TrimPrefix(section, prefix))
+	name, err := parseOrgTOMLString(tail)
+	if err != nil {
+		return false, "", false, fmt.Errorf("parse org role section: %w", err)
+	}
+	if name == "" {
+		return false, "", false, fmt.Errorf("parse org role section: empty role name")
+	}
+	return true, name, true, nil
+}
+
+func parseOrgScopeArray(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 || value[0] != '[' || value[len(value)-1] != ']' {
+		return nil, fmt.Errorf("scope must be a single-line array")
+	}
+	body := strings.TrimSpace(value[1 : len(value)-1])
+	if body == "" {
+		return []string{}, nil
+	}
+	parts := strings.Split(body, ",")
+	out := make([]string, 0, len(parts))
+	for index, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" && index == len(parts)-1 {
+			continue // TOML permits a trailing comma in an array.
+		}
+		item, err := parseOrgTOMLString(part)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, nil
+}
+
+func parseOrgTOMLString(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) >= 2 && value[0] == '\'' && value[len(value)-1] == '\'' {
+		return value[1 : len(value)-1], nil
+	}
+	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+		return strconv.Unquote(value)
+	}
+	return "", fmt.Errorf("expected quoted TOML string")
+}
+
+// stripOrgConfigComment understands both TOML basic and literal strings. The
+// repo's older scanners only need basic strings; org also accepts TOML literals.
+func stripOrgConfigComment(value string) string {
+	var quote rune
+	escaped := false
+	for index, r := range value {
+		switch {
+		case quote != 0 && quote == '\'' && r == '\'':
+			quote = 0
+		case quote != 0 && quote == '"' && escaped:
+			escaped = false
+		case quote != 0 && quote == '"' && r == '\\':
+			escaped = true
+		case quote != 0 && quote == '"' && r == '"':
+			quote = 0
+		case quote == 0 && (r == '\'' || r == '"'):
+			quote = r
+		case quote == 0 && r == '#':
+			return value[:index]
+		}
+	}
+	return value
+}
+
+// ValidateOrg verifies the registry invariants before it is exposed to a
+// permission gate.
+func ValidateOrg(cfg OrgConfig) error {
+	if cfg.Enforce() != "block" && cfg.Enforce() != "warn" {
+		return fmt.Errorf("org enforce must be \"block\" or \"warn\"")
+	}
+	for name, role := range cfg.roles {
+		if !validOrgRoleName(name) {
+			return fmt.Errorf("org role %q: invalid name", name)
+		}
+		if role.Name != "" && role.Name != name {
+			return fmt.Errorf("org role %q: name mismatch", name)
+		}
+		if role.MergeRule != "" && role.MergeRule != "owner" && role.MergeRule != "self" && role.MergeRule != "none" {
+			return fmt.Errorf("org role %q: invalid merge_rule %q", name, role.MergeRule)
+		}
+		for _, scope := range role.Scope {
+			if _, err := normalizeOrgScope(scope); err != nil {
+				return fmt.Errorf("org role %q: %w", name, err)
+			}
+		}
+		if role.Parent != "" {
+			if _, ok := cfg.roles[role.Parent]; !ok {
+				return fmt.Errorf("org role %q: parent %q is not declared", name, role.Parent)
+			}
+		}
+	}
+	if len(cfg.roles) == 0 {
+		return nil
+	}
+	if len(cfg.Roots()) != 1 {
+		return fmt.Errorf("org: expected exactly one root role, got %d", len(cfg.Roots()))
+	}
+	for name := range cfg.roles {
+		seen := map[string]bool{}
+		for current := name; current != ""; {
+			if seen[current] {
+				return fmt.Errorf("org role %q: parent cycle", name)
+			}
+			seen[current] = true
+			current = cfg.roles[current].Parent
+		}
+	}
+	for name, role := range cfg.roles {
+		if role.Parent == "" {
+			continue
+		}
+		if !scopeSubset(role.Scope, cfg.roles[role.Parent].Scope) {
+			return fmt.Errorf("org role %q: scope is not a subset of parent %q", name, role.Parent)
+		}
+	}
+	return nil
+}
+
+func validOrgRoleName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeOrgScope(scope string) (string, error) {
+	if strings.TrimSpace(scope) != scope || scope == "" {
+		return "", fmt.Errorf("invalid scope %q", scope)
+	}
+	if scope == "*" {
+		return scope, nil
+	}
+	parts := strings.Split(scope, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("invalid scope %q", scope)
+	}
+	if strings.Contains(parts[0], "*") || (parts[1] != "*" && strings.Contains(parts[1], "*")) {
+		return "", fmt.Errorf("invalid scope %q", scope)
+	}
+	for _, part := range parts {
+		for _, r := range part {
+			if unicode.IsSpace(r) {
+				return "", fmt.Errorf("invalid scope %q", scope)
+			}
+		}
+	}
+	return strings.ToLower(scope), nil
+}
+
+// ScopeMatches expects LoadOrg-normalized scopes. It remains harmless for raw
+// case variants, but callers must validate scopes through LoadOrg before using
+// this as an authorization decision.
+func ScopeMatches(scope []string, repo string) bool {
+	repo = strings.ToLower(strings.TrimSpace(repo))
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return false
+	}
+	for _, raw := range scope {
+		entry := strings.ToLower(raw)
+		if entry == "*" || entry == repo || entry == parts[0]+"/*" {
+			return true
+		}
+	}
+	return false
+}
+
+func scopeSubset(child, parent []string) bool {
+	for _, rawChild := range child {
+		c, err := normalizeOrgScope(rawChild)
+		if err != nil {
+			return false
+		}
+		covered := false
+		for _, rawParent := range parent {
+			p, err := normalizeOrgScope(rawParent)
+			if err != nil {
+				continue
+			}
+			if p == "*" || p == c {
+				covered = true
+				break
+			}
+			if strings.HasSuffix(p, "/*") && strings.HasPrefix(c, strings.TrimSuffix(p, "*")) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/config/org_test.go
+++ b/internal/config/org_test.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadOrgAndScopeMatching(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := "[org]\nenforce = \"block\"\n[org.roles.\"owner\"]\nscope = [\"*\"]\n[org.roles.\"maintainer\"]\nparent = \"owner\"\nscope = [\"Acme/*\", \"other/repo\"]\nmerge_rule = \"self\"\n"
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Enabled() || cfg.Enforce() != "block" || len(cfg.Roots()) != 1 || cfg.Roots()[0] != "owner" {
+		t.Fatalf("cfg=%+v roots=%v", cfg, cfg.Roots())
+	}
+	role, ok := cfg.Role("maintainer")
+	if !ok || role.Scope[0] != "acme/*" {
+		t.Fatalf("role=%+v ok=%v", role, ok)
+	}
+	if !ScopeMatches(role.Scope, "ACME/one") || !ScopeMatches([]string{"*"}, "any/repo") || ScopeMatches(role.Scope, "acme") || ScopeMatches(role.Scope, "wrong/repo") {
+		t.Fatal("scope matching mismatch")
+	}
+}
+
+func TestLoadOrgToleratesUnrelatedMalformedAndTOMLForms(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[skillopt\nanything = nope\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err := LoadOrg(paths); err != nil || cfg.Enabled() {
+		t.Fatalf("unrelated malformed cfg=%+v err=%v", cfg, err)
+	}
+	content := "[org]\nenforce = 'block'\n[org.roles.'owner']\nscope = [\n  'owner/*', # comment\n]\nmerge_rule = 'owner'\n"
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	role, ok := cfg.Role("OWNER")
+	if !ok || cfg.Enforce() != "block" || len(role.Scope) != 1 || role.Scope[0] != "owner/*" {
+		t.Fatalf("cfg=%+v role=%+v ok=%v", cfg, role, ok)
+	}
+	for _, content := range []string{"[org\nenforce=\"block\"\n", "[ org.roles.owner\nscope=[\"*\"]\n", "[org .roles.x\nscope=[\"*\"]\n"} {
+		if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadOrg(paths); err == nil {
+			t.Fatalf("malformed org header unexpectedly succeeded: %q", content)
+		}
+	}
+	// Unrelated sections whose name merely starts with "org" must stay tolerated
+	// (the org-prefix must be a complete token), not brick dispatch.
+	for _, content := range []string{"[organization\nx = 1\n", "[orgs\nx = 1\n", "[org_settings\nx = 1\n"} {
+		if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if cfg, err := LoadOrg(paths); err != nil || cfg.Enabled() {
+			t.Fatalf("org-prefixed unrelated malformed header should be tolerated: %q cfg=%+v err=%v", content, cfg, err)
+		}
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[ skillopt\nanything = nope\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cfg, err := LoadOrg(paths); err != nil || cfg.Enabled() {
+		t.Fatalf("spaced unrelated malformed cfg=%+v err=%v", cfg, err)
+	}
+}
+
+func TestLoadOrgAbsentAndInvalid(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if cfg, err := LoadOrg(paths); err != nil || cfg.Enabled() {
+		t.Fatalf("absent cfg=%+v err=%v", cfg, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range map[string]string{
+		"bad-role":   "[org.roles.\"Upper\"]\nscope=[\"*\"]\n",
+		"empty-role": "[org.roles.\"\"]\nscope=[\"*\"]\n",
+		"dangling":   "[org.roles.\"owner\"]\nscope=[\"*\"]\n[org.roles.\"child\"]\nparent=\"missing\"\nscope=[\"*\"]\n",
+		"cycle":      "[org.roles.\"one\"]\nparent=\"two\"\nscope=[\"*\"]\n[org.roles.\"two\"]\nparent=\"one\"\nscope=[\"*\"]\n",
+		"roots":      "[org.roles.\"one\"]\nscope=[\"*\"]\n[org.roles.\"two\"]\nscope=[\"*\"]\n",
+		"rule":       "[org.roles.\"owner\"]\nscope=[\"*\"]\nmerge_rule=\"bad\"\n",
+		"scope":      "[org.roles.\"owner\"]\nscope=[\"owner/repo/extra\"]\n",
+		"wild-owner": "[org.roles.\"owner\"]\nscope=[\"*/*\"]\n",
+		"subset":     "[org.roles.\"owner\"]\nscope=[\"one/*\"]\n[org.roles.\"child\"]\nparent=\"owner\"\nscope=[\"two/repo\"]\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadOrg(paths); err == nil {
+				t.Fatal("LoadOrg unexpectedly succeeded")
+			}
+		})
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[org.roles.\"owner\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadOrg(paths); err == nil || !strings.Contains(err.Error(), "section") {
+		t.Fatalf("malformed err=%v", err)
+	}
+}
+
+func TestScopeSubset(t *testing.T) {
+	for _, tt := range []struct {
+		child, parent []string
+		want          bool
+	}{
+		{[]string{"one/repo"}, []string{"one/*"}, true}, {[]string{"one/*"}, []string{"*"}, true},
+		{[]string{"one/*"}, []string{"two/*"}, false}, {[]string{"*"}, []string{"one/*"}, false},
+	} {
+		if got := scopeSubset(tt.child, tt.parent); got != tt.want {
+			t.Fatalf("scopeSubset(%v,%v)=%v", tt.child, tt.parent, got)
+		}
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2068,10 +2068,12 @@ func (d Daemon) enqueueJob(ctx context.Context, request workflow.JobRequest) (db
 		runtimeDefaultModel = d.Workflow.RuntimeDefaultModel
 	}
 	var requireWorkflowPolicy func(string) workflow.RequireWorkflowPolicy
+	var orgPolicy func(string) workflow.OrgEnforcement
 	if d.Workflow != nil {
 		requireWorkflowPolicy = d.Workflow.RequireWorkflowPolicy
+		orgPolicy = d.Workflow.OrgPolicy
 	}
-	job, err := (workflow.Mailbox{Store: d.Store, CanaryEnabled: canaryEnabled, RuntimeDefaultModel: runtimeDefaultModel, RequireWorkflowPolicy: requireWorkflowPolicy}).Enqueue(ctx, request)
+	job, err := (workflow.Mailbox{Store: d.Store, CanaryEnabled: canaryEnabled, RuntimeDefaultModel: runtimeDefaultModel, RequireWorkflowPolicy: requireWorkflowPolicy, OrgPolicy: orgPolicy}).Enqueue(ctx, request)
 	return job, true, err
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -19,6 +19,9 @@ type Engine struct {
 	// RequireWorkflowPolicy is passed to every mailbox the engine creates so
 	// continuations and delegation enqueue share the same home-aware policy.
 	RequireWorkflowPolicy func(repo string) RequireWorkflowPolicy
+	// OrgPolicy is passed to every mailbox the engine creates. Descendant jobs are
+	// exempt from the gate but preserve their initiating role as provenance.
+	OrgPolicy func(repo string) OrgEnforcement
 	// ProduceCheckDir is the resolved checkout cwd for trusted produce-stage
 	// deterministic checks when no disposable worktree path is present.
 	ProduceCheckDir         string

--- a/internal/workflow/engine_continuation_synthesis.go
+++ b/internal/workflow/engine_continuation_synthesis.go
@@ -169,6 +169,7 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 			DelegatedBy:     parentJob.Agent,
 			RootJobID:       e.rootJobID(parentJob, parentPayload),
 			WorkflowID:      parentPayload.WorkflowID,
+			ActingOrgRole:   parentPayload.ActingOrgRole,
 			ThreadID:        parentPayload.ThreadID,
 			ChatMessageID:   parentPayload.ChatMessageID,
 			// Carry the window forward and mark that a corrective nudge has fired so a
@@ -269,6 +270,7 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 			DelegatedBy:     parentJob.Agent,
 			RootJobID:       e.rootJobID(parentJob, parentPayload),
 			WorkflowID:      parentPayload.WorkflowID,
+			ActingOrgRole:   parentPayload.ActingOrgRole,
 			// Consume one verify attempt so a still-failing verdict next generation
 			// climbs toward the cap and eventually finalizes.
 			VerifyAttempt: attempt,
@@ -355,8 +357,9 @@ func (e Engine) maybeEnqueueContinuation(ctx context.Context, parentJob db.Job, 
 		DelegatedBy:     parentJob.Agent,
 		// Share the originating coordinator's root so the whole continuation
 		// chain counts against one per-root budget and is visible to loop detection.
-		RootJobID:  e.rootJobID(parentJob, parentPayload),
-		WorkflowID: parentPayload.WorkflowID,
+		RootJobID:     e.rootJobID(parentJob, parentPayload),
+		WorkflowID:    parentPayload.WorkflowID,
+		ActingOrgRole: parentPayload.ActingOrgRole,
 		// Record the delegation set that was actually dispatched in the sliding
 		// window so the next generation can detect a non-progress repeat. A real
 		// dispatch happened => progress, so reset the repeat counter; the

--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -316,6 +316,7 @@ func (e Engine) handleDelegationLoop(ctx context.Context, job db.Job, payload Jo
 		DelegatedBy:        job.Agent,
 		RootJobID:          e.rootJobID(job, payload),
 		WorkflowID:         payload.WorkflowID,
+		ActingOrgRole:      payload.ActingOrgRole,
 		// Carry the window forward (now including this repeat) and mark that a
 		// corrective nudge has fired, so if the next generation repeats again the
 		// detector escalates to delegation_loop_detected.
@@ -408,6 +409,7 @@ func (e Engine) handleDelegationPreflightFailure(ctx context.Context, job db.Job
 		DelegatedBy:        job.Agent,
 		RootJobID:          e.rootJobID(job, payload),
 		WorkflowID:         payload.WorkflowID,
+		ActingOrgRole:      payload.ActingOrgRole,
 		// Carry the window forward and mark that a corrective nudge has fired, and
 		// thread the streak forward, so a coordinator that keeps naming bad agents
 		// escalates to a graceful finalize.
@@ -482,6 +484,7 @@ func (e Engine) enqueueFinalizeContinuation(ctx context.Context, job db.Job, pay
 		DelegatedBy:        job.Agent,
 		RootJobID:          e.rootJobID(job, payload),
 		WorkflowID:         payload.WorkflowID,
+		ActingOrgRole:      payload.ActingOrgRole,
 		DelegationFinalize: true,
 		ThreadID:           payload.ThreadID,
 		ChatMessageID:      payload.ChatMessageID,

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -78,9 +78,10 @@ func (e Engine) dispatchFix(ctx context.Context, reviewer string, payload JobPay
 		TaskID:       payload.TaskID,
 		TaskTitle:    payload.TaskTitle,
 		LeadAgent:    leadAgent,
-		Reviewers:    e.requiredReviewers(payload),
-		ReviewRound:  payload.ReviewRound,
-		Sender:       reviewer,
+		Reviewers:     e.requiredReviewers(payload),
+		ReviewRound:   payload.ReviewRound,
+		Sender:        reviewer,
+		ActingOrgRole: payload.ActingOrgRole,
 		Instructions: fmt.Sprintf(
 			"Address requested changes from %s: %s",
 			reviewer,

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -758,6 +758,7 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		DelegatedBy:     job.Agent,
 		RootJobID:       rootID,
 		WorkflowID:      payload.WorkflowID,
+		ActingOrgRole:   payload.ActingOrgRole,
 		Deps:            compactStrings(d.Deps),
 		JobTimeout:      effectiveDelegationTimeout(d, e.DelegationTimeoutDefaults),
 		Fingerprint:     strings.TrimSpace(d.Fingerprint),

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -123,7 +123,7 @@ func (e Engine) now() time.Time {
 // path is byte-identical. The hook maps the terminal JobState to the event_type,
 // resolves root_id from the payload, and ships a redacted event fire-and-forget.
 func (e Engine) mailbox() Mailbox {
-	mb := Mailbox{Store: e.Store, RequireWorkflowPolicy: e.RequireWorkflowPolicy, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer, RuntimeDefaultModel: e.RuntimeDefaultModel, RuntimeDefaultEffort: e.RuntimeDefaultEffort, routerContextEnabled: e.RouterContextEnabled, resultCheckMode: normalizeResultCheckMode(e.ResultCheckMode), produceCheckDir: e.ProduceCheckDir}
+	mb := Mailbox{Store: e.Store, RequireWorkflowPolicy: e.RequireWorkflowPolicy, OrgPolicy: e.OrgPolicy, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer, RuntimeDefaultModel: e.RuntimeDefaultModel, RuntimeDefaultEffort: e.RuntimeDefaultEffort, routerContextEnabled: e.RouterContextEnabled, resultCheckMode: normalizeResultCheckMode(e.ResultCheckMode), produceCheckDir: e.ProduceCheckDir}
 	// Wire the off-by-default memory hooks (#626). When e.Memory is nil (every
 	// non-enrolled path) both hooks stay nil, so Run's prompt assembly and terminal
 	// path are byte-identical. The hooks themselves also no-op when the executor

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -35,6 +35,9 @@ type Mailbox struct {
 	// enqueue chokepoint. Nil deliberately means feature disabled so existing
 	// direct Mailbox users remain byte-identical.
 	RequireWorkflowPolicy func(repo string) RequireWorkflowPolicy
+	// OrgPolicy resolves the optional organization registry at the enqueue
+	// chokepoint. Nil deliberately leaves direct Mailbox users byte-identical.
+	OrgPolicy func(repo string) OrgEnforcement
 	// emitTerminal, when set, is called best-effort AFTER a genuine running->
 	// terminal transition in BOTH finishWithPayload (success/advance + timeout-
 	// finalize) and finish (the m.fail delivery/parse-failure path) (#446). Wiring
@@ -138,21 +141,27 @@ type JobRequest struct {
 	ID string
 	// PolicyExempt is enqueue-only policy routing; it is never persisted.
 	PolicyExempt string
-	Agent        string
-	Action       string
-	Repo         string
-	Branch       string
-	PullRequest  int
-	HeadSHA      string
-	GoalID       string
-	TaskID       string
-	TaskTitle    string
-	LeadAgent    string
-	Reviewers    []string
-	ReviewRound  string
-	Sender       string
-	Instructions string
-	Constraints  []string
+	// OperatorOrigin marks a genuine human CLI dispatch. It is deliberately
+	// enqueue-only: shared local dispatch helpers also serve automated producers.
+	OperatorOrigin bool
+	Agent          string
+	Action         string
+	Repo           string
+	Branch         string
+	PullRequest    int
+	HeadSHA        string
+	GoalID         string
+	TaskID         string
+	TaskTitle      string
+	LeadAgent      string
+	Reviewers      []string
+	ReviewRound    string
+	Sender         string
+	// ActingOrgRole attributes a fresh local dispatch to an organization role.
+	// It is persisted for audit provenance, then inherited by engine children.
+	ActingOrgRole string
+	Instructions  string
+	Constraints   []string
 	// TemplateOverride, when non-nil, replaces the agent's own template snapshot
 	// for this job only (the agent's identity is unchanged). Used by the
 	// orchestrate/run --recipe flag to route a coordinator to a built-in recipe
@@ -288,6 +297,7 @@ type JobPayload struct {
 	Reviewers             []string `json:"reviewers,omitempty"`
 	ReviewRound           string   `json:"review_round,omitempty"`
 	Sender                string   `json:"sender"`
+	ActingOrgRole         string   `json:"acting_org_role,omitempty"`
 	Instructions          string   `json:"instructions"`
 	Constraints           []string `json:"constraints"`
 	ParentJobID           string   `json:"parent_job_id,omitempty"`
@@ -429,6 +439,10 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 	if err := validateJobRequest(request); err != nil {
 		return db.Job{}, err
 	}
+	orgWarning, err := m.resolveEnqueueOrgScope(&request)
+	if err != nil {
+		return db.Job{}, err
+	}
 	autolabeled, err := m.resolveEnqueueWorkflowID(&request)
 	if err != nil {
 		return db.Job{}, err
@@ -456,6 +470,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		Reviewers:              compactStrings(request.Reviewers),
 		ReviewRound:            request.ReviewRound,
 		Sender:                 request.Sender,
+		ActingOrgRole:          strings.TrimSpace(request.ActingOrgRole),
 		Instructions:           request.Instructions,
 		Constraints:            compactStrings(request.Constraints),
 		ParentJobID:            request.ParentJobID,
@@ -546,6 +561,12 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 			fmt.Fprintf(os.Stderr, "gitmoot: add workflow_autolabeled event for %s: %v\n", job.ID, err)
 		}
 	}
+	if orgWarning != "" {
+		if err := m.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "org_scope_violation", Message: orgWarning}); err != nil {
+			// The queued job is durable. An advisory warning event must never undo it.
+			fmt.Fprintf(os.Stderr, "gitmoot: add org_scope_violation event for %s: %v\n", job.ID, err)
+		}
+	}
 	return job, nil
 }
 
@@ -554,6 +575,82 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 type RequireWorkflowPolicy struct {
 	Enabled bool
 	Mode    string
+}
+
+// OrgRole and OrgEnforcement are workflow-local copies of the registry surface.
+// CLI owns config loading so workflow stays independent from config.
+type OrgRole struct {
+	Name, Parent string
+	Scope        []string
+	MergeRule    string
+}
+
+type OrgEnforcement struct {
+	Enabled      bool
+	Enforce      string
+	LoadErr      error
+	Role         func(string) (OrgRole, bool)
+	ScopeMatches func([]string, string) bool
+}
+
+// NormalizeActingOrgRole is the canonical persisted representation of an
+// operator-selected org role.
+func NormalizeActingOrgRole(role string) string {
+	return strings.ToLower(strings.TrimSpace(role))
+}
+
+// OrgScopeDecision is the single org permission decision ladder. Callers that
+// mutate state before enqueue use it as a preflight; Mailbox uses the same
+// result at its durable chokepoint to retain warn-mode audit events.
+func OrgScopeDecision(policy OrgEnforcement, actingRole, repo string) (string, error) {
+	repo = strings.TrimSpace(repo)
+	roleName := NormalizeActingOrgRole(actingRole)
+	violation := func(reason string) (string, error) {
+		message := fmt.Sprintf("org scope violation for repo %s: role %s; %s", repo, firstNonEmptyString(roleName, "(none)"), reason)
+		if policy.Enforce == "warn" {
+			return message, nil
+		}
+		return "", errors.New(reason)
+	}
+	if policy.LoadErr != nil {
+		return "", fmt.Errorf("org config could not be loaded: %w", policy.LoadErr)
+	}
+	if !policy.Enabled {
+		return "", nil
+	}
+	if roleName == "" {
+		return violation(fmt.Sprintf("org enforcement on for %s: pass --org-role <role>", repo))
+	}
+	if policy.Role == nil {
+		return violation("org policy is missing role lookup")
+	}
+	role, ok := policy.Role(roleName)
+	if !ok {
+		return violation(fmt.Sprintf("unknown org role %q", roleName))
+	}
+	if policy.ScopeMatches == nil || !policy.ScopeMatches(role.Scope, repo) {
+		return violation(fmt.Sprintf("org role %q out of scope for repo %q", roleName, repo))
+	}
+	return "", nil
+}
+
+// resolveEnqueueOrgScope is deliberately independent of require_workflow: a
+// repo that opted out of workflow labels remains protected by its org registry.
+// Only explicit human CLI dispatches carry OperatorOrigin; shared local helpers
+// also serve comment, chat, pipeline, heartbeat, and other automated producers.
+func (m Mailbox) resolveEnqueueOrgScope(request *JobRequest) (string, error) {
+	if request.PolicyExempt == "exempt" || strings.TrimSpace(request.ParentJobID) != "" || strings.TrimSpace(request.DelegationReason) == "temp_worker_merge_back" || !request.OperatorOrigin {
+		return "", nil
+	}
+	if m.OrgPolicy == nil {
+		return "", nil
+	}
+	p := m.OrgPolicy(strings.TrimSpace(request.Repo))
+	if p.LoadErr != nil {
+		fmt.Fprintf(os.Stderr, "gitmoot: org policy load for %s: %v\n", strings.TrimSpace(request.Repo), p.LoadErr)
+	}
+	request.ActingOrgRole = NormalizeActingOrgRole(request.ActingOrgRole)
+	return OrgScopeDecision(p, request.ActingOrgRole, request.Repo)
 }
 
 // IsUnlabeledAgentDispatch is the shared eligibility predicate for enforcement

--- a/internal/workflow/org_test.go
+++ b/internal/workflow/org_test.go
@@ -1,0 +1,132 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func testOrgPolicy(enforce string) func(string) OrgEnforcement {
+	return func(string) OrgEnforcement {
+		return OrgEnforcement{Enabled: true, Enforce: enforce,
+			Role: func(name string) (OrgRole, bool) {
+				if name == "owner" {
+					return OrgRole{Name: name, Scope: []string{"owner/*"}}, true
+				}
+				return OrgRole{}, false
+			},
+			ScopeMatches: func(scopes []string, repo string) bool {
+				return len(scopes) == 1 && scopes[0] == "owner/*" && strings.HasPrefix(repo, "owner/")
+			},
+		}
+	}
+}
+
+func TestMailboxOrgScopeGate(t *testing.T) {
+	ctx, store := context.Background(), openTestStore(t)
+	mb := Mailbox{Store: store, OrgPolicy: testOrgPolicy("block"), RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{} }}
+	job, err := mb.Enqueue(ctx, JobRequest{ID: "ok", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local", OperatorOrigin: true, ActingOrgRole: "OWNER"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := ParseJobPayload(job.Payload)
+	if err != nil || p.ActingOrgRole != "owner" {
+		t.Fatalf("payload=%+v err=%v", p, err)
+	}
+	for _, request := range []JobRequest{
+		{ID: "missing", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local", OperatorOrigin: true},
+		{ID: "unknown", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local", OperatorOrigin: true, ActingOrgRole: "nope"},
+		{ID: "scope", Agent: "a", Action: "ask", Repo: "other/repo", Sender: "local", OperatorOrigin: true, ActingOrgRole: "owner"},
+		{ID: "task-run", Agent: "a", Action: "implement", Repo: "owner/repo", Sender: "task run", OperatorOrigin: true},
+	} {
+		if _, err := mb.Enqueue(ctx, request); err == nil {
+			t.Fatalf("%s unexpectedly accepted", request.ID)
+		}
+	}
+	for _, request := range []JobRequest{
+		{ID: "automated-local", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local"},
+		{ID: "comment", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "commenter"},
+		{ID: "heartbeat", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "heartbeat"}, {ID: "pipeline", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: PipelineJobSender},
+		{ID: "child", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "worker", ParentJobID: "parent"}, {ID: "exempt", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local", PolicyExempt: "exempt"},
+	} {
+		if _, err := mb.Enqueue(ctx, request); err != nil {
+			t.Fatalf("%s: %v", request.ID, err)
+		}
+	}
+}
+
+func TestMailboxOrgWarnAndMalformed(t *testing.T) {
+	ctx, store := context.Background(), openTestStore(t)
+	warn := Mailbox{Store: store, OrgPolicy: testOrgPolicy("warn")}
+	job, err := warn.Enqueue(ctx, JobRequest{ID: "warn", Agent: "a", Action: "ask", Repo: "other/repo", Sender: "local", OperatorOrigin: true, ActingOrgRole: "owner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 || events[1].Kind != "org_scope_violation" {
+		t.Fatalf("events=%+v", events)
+	}
+	bad := Mailbox{Store: store, OrgPolicy: func(string) OrgEnforcement { return OrgEnforcement{LoadErr: errors.New("bad org toml")} }}
+	if _, err := bad.Enqueue(ctx, JobRequest{ID: "bad-automated", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local"}); err != nil {
+		t.Fatalf("automated malformed config: %v", err)
+	}
+	if _, err := bad.Enqueue(ctx, JobRequest{ID: "bad", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local", OperatorOrigin: true}); err == nil || !strings.Contains(err.Error(), "could not be loaded") {
+		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestOrgScopeDecisionEnqueueParity(t *testing.T) {
+	ctx := context.Background()
+	for _, tt := range []struct {
+		name          string
+		enforce       string
+		role          string
+		repo          string
+		wantViolation bool
+		wantErr       bool
+	}{
+		{name: "block missing role", enforce: "block", repo: "owner/repo", wantErr: true},
+		{name: "block unknown role", enforce: "block", role: "unknown", repo: "owner/repo", wantErr: true},
+		{name: "block out of scope", enforce: "block", role: "owner", repo: "other/repo", wantErr: true},
+		{name: "block in scope", enforce: "block", role: "owner", repo: "owner/repo"},
+		{name: "warn missing role", enforce: "warn", repo: "owner/repo", wantViolation: true},
+		{name: "warn unknown role", enforce: "warn", role: "unknown", repo: "owner/repo", wantViolation: true},
+		{name: "warn out of scope", enforce: "warn", role: "owner", repo: "other/repo", wantViolation: true},
+		{name: "warn in scope", enforce: "warn", role: "owner", repo: "owner/repo"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := testOrgPolicy(tt.enforce)(tt.repo)
+			violation, decisionErr := OrgScopeDecision(policy, tt.role, tt.repo)
+			if (decisionErr != nil) != tt.wantErr || (violation != "") != tt.wantViolation {
+				t.Fatalf("decision violation=%q err=%v", violation, decisionErr)
+			}
+			store := openTestStore(t)
+			job, enqueueErr := (Mailbox{Store: store, OrgPolicy: fixedOrgPolicyForTest(policy)}).Enqueue(ctx, JobRequest{ID: "parity", Agent: "a", Action: "ask", Repo: tt.repo, OperatorOrigin: true, ActingOrgRole: tt.role})
+			if (enqueueErr != nil) != tt.wantErr {
+				t.Fatalf("enqueue err=%v, decision err=%v", enqueueErr, decisionErr)
+			}
+			if enqueueErr != nil {
+				return
+			}
+			events, err := store.ListJobEvents(ctx, job.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotViolation := false
+			for _, event := range events {
+				gotViolation = gotViolation || event.Kind == "org_scope_violation"
+			}
+			if gotViolation != tt.wantViolation {
+				t.Fatalf("warning event=%v, want %v; events=%+v", gotViolation, tt.wantViolation, events)
+			}
+		})
+	}
+}
+
+func fixedOrgPolicyForTest(policy OrgEnforcement) func(string) OrgEnforcement {
+	return func(string) OrgEnforcement { return policy }
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1147,6 +1147,22 @@ configured, those commands require an explicit `--repo`. **Caution: templates
 are stored and published VERBATIM (prompt body + metadata) — point the remote
 at a PRIVATE repo unless the prompts are meant to be public.**
 
+## Organization registry and scoped dispatch
+
+`gitmoot org validate [--home PATH]` validates the optional local `[org]`
+registry and prints its role count. `gitmoot org show [--home PATH]` prints the
+resolved role table. Any `[org.roles."name"]` section enables the registry.
+Roles have optional `parent`, `scope`, and advisory `merge_rule` (`owner`,
+`self`, or `none`); exactly one role has no parent. Scope is `*`, `owner/*`, or
+exact `owner/name`, and each child scope must be covered by its parent.
+
+Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
+`orchestrate`, and `task run` dispatches pass `--org-role <role>` (or the narrow
+`GITMOOT_ORG_ROLE` fallback) when enabled. The role scope is enforced at
+enqueue. `[org] enforce = "block"` rejects violations; `"warn"` queues and
+records an `org_scope_violation` event. Pane/agent creation permissions, Herdr
+checks, and escalation are later work (escalation is #1058).
+
 ## External-coordinator workflow groups
 
 Attach a global workflow label to work started outside Gitmoot's own goal/task

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1017,6 +1017,22 @@ With `require_workflow = false`, dispatch and enqueue remain byte-identical;
 doctor drift diagnostics remain always-on advisory, and the overview item
 remains policy-gated.
 
+### Organization registry and scoped dispatch
+
+The optional `[org]` registry is enabled by any `[org.roles."name"]` section.
+Roles have `parent`, `scope`, and advisory `merge_rule` (`owner`, `self`, or
+`none`); exactly one parent-less role is required. Scope entries are `*`,
+`owner/*`, or exact `owner/name`, and child scope must be a subset of its parent.
+
+Use `gitmoot org validate` to validate the registry and `gitmoot org show` to
+view its roles. When enabled, fresh local `agent ask`, `agent run`, `agent
+review`, `agent implement`, `orchestrate`, and `task run` dispatches require
+`--org-role <role>` (or `GITMOOT_ORG_ROLE`) and reject out-of-scope repositories
+at enqueue.
+`enforce = "block"` is the default; `"warn"` allows the job and records an
+`org_scope_violation` event. Merge rules are advisory in this phase; pane/agent
+creation permissions, Herdr checks, and escalation are later work.
+
 ```sh
 gitmoot orchestrate planner "Coordinate the dashboard wave." --repo owner/repo --workflow fable/dashboard-redesign
 gitmoot job list --workflow fable/dashboard-redesign

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10672,6 +10672,22 @@ configured, those commands require an explicit `--repo`. **Caution: templates
 are stored and published VERBATIM (prompt body + metadata) — point the remote
 at a PRIVATE repo unless the prompts are meant to be public.**
 
+## Organization registry and scoped dispatch
+
+`gitmoot org validate [--home PATH]` validates the optional local `[org]`
+registry and prints its role count. `gitmoot org show [--home PATH]` prints the
+resolved role table. Any `[org.roles."name"]` section enables the registry.
+Roles have optional `parent`, `scope`, and advisory `merge_rule` (`owner`,
+`self`, or `none`); exactly one role has no parent. Scope is `*`, `owner/*`, or
+exact `owner/name`, and each child scope must be covered by its parent.
+
+Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
+`orchestrate`, and `task run` dispatches pass `--org-role <role>` (or the narrow
+`GITMOOT_ORG_ROLE` fallback) when enabled. The role scope is enforced at
+enqueue. `[org] enforce = "block"` rejects violations; `"warn"` queues and
+records an `org_scope_violation` event. Pane/agent creation permissions, Herdr
+checks, and escalation are later work (escalation is #1058).
+
 ## External-coordinator workflow groups
 
 Attach a global workflow label to work started outside Gitmoot's own goal/task


### PR DESCRIPTION
Closes #1057. RFC #1042 phase 1a — the foundation of the org track. Rides the existing config + enqueue-gate spine (no new state stores).

## What this ships
- **`[org]` registry** (internal/config/org.go): roles with `parent`, `scope` (repo globs `*` / `owner/*` / `owner/name`), and `merge_rule` (advisory in 1a). Hand-rolled `LoadOrg` scanner (nested `[org.roles."name"]` via the merge_gate precedent, TOML single/double-quoted strings, single- and multi-line scope arrays). `ValidateOrg`: unique lowercase role names, declared parents, no parent cycles, exactly one root (the org owner), child-scope ⊆ parent-scope (no privilege escalation via config). New `owner/*` matcher with the `*`=all special case.
- **Scope enforcement at `Mailbox.Enqueue`**, a SEPARATE check independent of require_workflow (a `require_workflow=false` repo still gets org scope). Enforced on genuine **operator dispatches only** — an explicit `OperatorOrigin` marker set solely by the human CLI commands (`agent ask/run/implement/review`, `orchestrate`, `task run`); the automated fleet (chat auto-respond, skillopt, moot, chat-task, bridge), engine children, heartbeat, and pipeline are exempt. Role required + must exist + must be in scope, else rejected; `enforce=warn` records a durable `org_scope_violation` event instead. **Fail-closed** on a genuinely malformed `[org]` section; an absent config (or an unrelated typo elsewhere) is org-off.
- **Attribution**: `ActingOrgRole` persisted to the job payload for audit; engine children inherit it. `--org-role` flag (distinct from the agent-subscribe `--role`) + `GITMOOT_ORG_ROLE` env.
- One shared `workflow.OrgScopeDecision` is the single source for both the pre-mutation CLI preflight and the Enqueue gate, so they cannot drift. The preflight (implement/review/task run) blocks before any task/worktree/branch-lock mutation, so an org block never strands state.
- `gitmoot org validate` / `org show` (read-only). `OrgPolicy` resolver wired into every production Mailbox constructor + engine fan-out. Docs + `[org]` DefaultConfig block.

## Review provenance (this is a permission gate — it earned the passes)
Adversarial review + a design panel (sol + opus + seam scout) + **`/code-review xhigh`** + two focused **`/code-review high`** convergence rounds. The reviews caught and this PR fixes: a fleet-breaking `Sender=="local"` misclassification, a config-typo brick, a fail-open-on-org-typo, a dead task-run gate from the #446/#459 home double-resolution class, and strand paths — then converged (3→1→0 correctness findings). No findings remain.

## Deferred (per panel + owner ruling — schema is forward-compatible, additive)
`may_spawn_panes` / `may_create_agents` enforcement (presence/agent-gate issues), the herdr≥0.7.5 check (presence/wake), escalate (#1058), comment-author→role mapping, and the session-job/`task recover` attribution gap (they bypass Enqueue). The three design forks are flagged in the workflow journal for owner ruling; the schema contract is stable so G2/G4 build unblocked. Also filed: #1067 (a latent #1053 strict-flip interaction, separate).

## Verification
Full local gate green: build / `go generate`+diff / vet / `go test ./...` (no breakage — org is opt-in, nil resolver = byte-identical) / scoped `-race` across config, workflow, cli, daemon, pipeline.

## Deploy notes — HOLD
Config-gated feature (off until `[org.roles.*]` is authored); no schema/protocol change. Enabling it changes live-box dispatch behavior (out-of-scope operator dispatches rejected / warn-logged). **Do not deploy without owner go (judging window through Aug 5).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)