### PR TITLE
feat(org): org phase 1b — brief/chart/status + passive presence + herdr provider seam + version gate (#1059)

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -115,6 +115,13 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
+	// #1059: validate the --org-role against the registry (unknown role fails
+	// loudly at ingress) and record passive presence for this dispatch. Restored
+	// during the #1057 reconcile — #1057's preflightOrgScope covers scope
+	// enforcement but not role-existence validation or presence.
+	if err := validateAndTouchActingOrgRole(ctx, store, request.Home, request.ActingOrgRole, request.ExecutionPath); err != nil {
+		return localAgentJobOutput{}, err
+	}
 	repo, record, err := resolveLocalAgentRepo(ctx, store, request.RepoFlag)
 	if err != nil {
 		return localAgentJobOutput{}, err

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -9,10 +9,16 @@ import (
 	"io"
 	"os"
 	"slices"
+	"sort"
 	"strings"
+	"time"
 
+	"github.com/gitmoot/gitmoot/internal/cockpit"
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/doctor"
+	"github.com/gitmoot/gitmoot/internal/org"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -65,18 +71,47 @@ func fixedOrgPolicy(policy workflow.OrgEnforcement) func(string) workflow.OrgEnf
 	return func(string) workflow.OrgEnforcement { return policy }
 }
 
+var newOrgProvider = func(roles []string) org.Provider { return cockpit.NewHerdrOrgProvider(roles) }
+
+var orgDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
+
 func runOrg(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
-		fmt.Fprintln(stdout, "Usage:\n  gitmoot org validate [--home path]\n  gitmoot org show [--home path]\n  gitmoot org escalate --to <role> --workflow <label> [--org-role <role>] [--repo <owner/repo>] [--home path] [--json] \"<question>\"")
+		printOrgUsage(stdout)
 		return 0
 	}
-	if args[0] == "escalate" {
+	switch args[0] {
+	case "validate", "show":
+		return runOrgValidateOrShow(args, stdout, stderr)
+	case "init":
+		return runOrgInit(args[1:], stdout, stderr)
+	case "brief":
+		return runOrgBrief(args[1:], stdout, stderr)
+	case "chart":
+		return runOrgChart(args[1:], stdout, stderr)
+	case "status":
+		return runOrgStatus(args[1:], stdout, stderr)
+	case "escalate":
 		return runOrgEscalate(args[1:], stdout, stderr)
-	}
-	if args[0] != "validate" && args[0] != "show" {
-		fmt.Fprintf(stderr, "unknown org command %q\n", args[0])
+	default:
+		fmt.Fprintf(stderr, "unknown org command %q\n\n", args[0])
+		printOrgUsage(stderr)
 		return 2
 	}
+}
+
+func printOrgUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot org validate [--home PATH]")
+	fmt.Fprintln(w, "  gitmoot org show [--home PATH]")
+	fmt.Fprintln(w, "  gitmoot org init [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org brief --role NAME [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org chart [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org status [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org escalate --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"QUESTION\"")
+}
+
+func runOrgValidateOrShow(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("org "+args[0], flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
@@ -108,6 +143,369 @@ func runOrg(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "%s\tparent=%s\tscope=%s\tmerge_rule=%s\n", role.Name, role.Parent, strings.Join(role.Scope, ","), firstNonEmpty(role.MergeRule, "owner"))
 	}
 	return 0
+}
+
+const starterOrgConfig = `
+
+# Organization registry (#1042). enforce = "warn" logs a durable event without
+# rejecting; set "block" to reject out-of-scope dispatches (see gitmoot org validate).
+[org]
+enforce = "warn"
+
+[org.roles."owner"]
+scope = ["*"]
+merge_rule = "owner"
+`
+
+func runOrgInit(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org init", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "org init accepts no positional arguments")
+		return 2
+	}
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org init: resolve paths: %v\n", err)
+		return 1
+	}
+	if err := config.Initialize(paths); err != nil {
+		fmt.Fprintf(stderr, "org init: %v\n", err)
+		return 1
+	}
+	registry, err := config.LoadOrgRegistry(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org init: %v\n", err)
+		return 1
+	}
+	if !registry.Enabled() {
+		file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			fmt.Fprintf(stderr, "org init: open config: %v\n", err)
+			return 1
+		}
+		_, writeErr := io.WriteString(file, starterOrgConfig)
+		closeErr := file.Close()
+		if writeErr != nil {
+			fmt.Fprintf(stderr, "org init: write config: %v\n", writeErr)
+			return 1
+		}
+		if closeErr != nil {
+			fmt.Fprintf(stderr, "org init: close config: %v\n", closeErr)
+			return 1
+		}
+		registry, err = config.LoadOrgRegistry(paths)
+		if err != nil {
+			fmt.Fprintf(stderr, "org init: validate scaffold: %v\n", err)
+			return 1
+		}
+	}
+	check := doctor.CheckHerdrVersion(context.Background(), orgDoctorRunner, doctor.OrgMinimumHerdrVersion)
+	if !check.OK {
+		fmt.Fprintf(stderr, "org init: %s\n", check.Detail)
+		return 1
+	}
+	if _, err := orgProviderSnapshot(context.Background(), registry); err != nil {
+		fmt.Fprintf(stderr, "org init: Herdr snapshot unavailable: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "initialized organization registry at %s\n", paths.ConfigFile)
+	fmt.Fprintf(stdout, "herdr: %s\n", check.Detail)
+	return 0
+}
+
+type orgBriefOutput struct {
+	Role            string             `json:"role"`
+	Parent          string             `json:"parent,omitempty"`
+	Children        []string           `json:"children"`
+	Path            []string           `json:"path"`
+	Scope           []string           `json:"scope"`
+	MergeRule       string             `json:"merge_rule"`
+	LastSeenAt      string             `json:"last_seen_at,omitempty"`
+	LastCommand     string             `json:"last_command,omitempty"`
+	ProviderState   org.LifecycleState `json:"provider_state"`
+	ProviderDetail  string             `json:"provider_detail,omitempty"`
+	ObservedAt      time.Time          `json:"observed_at,omitempty"`
+	ProviderVersion string             `json:"provider_version,omitempty"`
+	// TODO(#1058): add bounded open escalations only after creation, resolution,
+	// and correlation identifiers have a frozen store contract.
+}
+
+type orgStatusOutput struct {
+	Role            string             `json:"role"`
+	Parent          string             `json:"parent,omitempty"`
+	Depth           int                `json:"depth,omitempty"`
+	Scope           []string           `json:"scope"`
+	MergeRule       string             `json:"merge_rule"`
+	LastSeenAt      string             `json:"last_seen_at,omitempty"`
+	LastSeenAge     string             `json:"last_seen_age,omitempty"`
+	LastCommand     string             `json:"last_command,omitempty"`
+	ProviderState   org.LifecycleState `json:"provider_state"`
+	ProviderDetail  string             `json:"provider_detail,omitempty"`
+	ObservedAt      time.Time          `json:"observed_at,omitempty"`
+	ProviderVersion string             `json:"provider_version,omitempty"`
+}
+
+func runOrgBrief(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org brief", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	roleName := fs.String("role", "", "organization role to brief")
+	jsonOutput := fs.Bool("json", false, "print JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 || strings.TrimSpace(*roleName) == "" {
+		fmt.Fprintln(stderr, "org brief requires --role NAME")
+		return 2
+	}
+	ctx := context.Background()
+	registry, presence, store, err := loadOrgCommandState(ctx, *home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org brief: %v\n", err)
+		return 1
+	}
+	defer store.Close()
+	role, ok := registry.Role(*roleName)
+	if !ok {
+		fmt.Fprintf(stderr, "org brief: unknown org role %q\n", strings.TrimSpace(*roleName))
+		return 1
+	}
+	if err := store.TouchOrgRolePresence(ctx, role.Name, "org brief"); err != nil {
+		fmt.Fprintf(stderr, "org brief: touch presence: %v\n", err)
+		return 1
+	}
+	updatedPresence, err := store.ListOrgRolePresence(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "org brief: reload presence: %v\n", err)
+		return 1
+	}
+	for _, row := range updatedPresence {
+		presence[row.Role] = row
+	}
+	snapshot, snapshotErr := orgProviderSnapshot(ctx, registry)
+	live := org.RoleLiveState{State: org.StateUnknown}
+	if snapshotErr != nil {
+		live.Detail = snapshotErr.Error()
+	} else if value, exists := snapshot.States[role.Name]; exists {
+		live = value
+	} else {
+		live.Detail = "provider snapshot omitted this role"
+	}
+	children := registry.Children(role.Name)
+	childNames := make([]string, 0, len(children))
+	for _, child := range children {
+		childNames = append(childNames, child.Name)
+	}
+	row := presence[role.Name]
+	out := orgBriefOutput{
+		Role: role.Name, Parent: role.Parent, Children: childNames, Path: registry.Path(role.Name), Scope: role.Scope,
+		MergeRule: role.MergeRule, LastSeenAt: row.LastSeenAt, LastCommand: row.LastCommand,
+		ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: snapshot.ObservedAt, ProviderVersion: snapshot.ProviderVersion,
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, out); err != nil {
+			fmt.Fprintf(stderr, "org brief: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printOrgBrief(stdout, out)
+	return 0
+}
+
+func runOrgChart(args []string, stdout, stderr io.Writer) int {
+	return runOrgOverview("chart", args, stdout, stderr)
+}
+
+func runOrgStatus(args []string, stdout, stderr io.Writer) int {
+	return runOrgOverview("status", args, stdout, stderr)
+}
+
+func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org "+command, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	jsonOutput := fs.Bool("json", false, "print JSON")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "org %s accepts no positional arguments\n", command)
+		return 2
+	}
+	ctx := context.Background()
+	registry, presence, store, err := loadOrgCommandState(ctx, *home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org %s: %v\n", command, err)
+		return 1
+	}
+	defer store.Close()
+	snapshot, err := orgProviderSnapshot(ctx, registry)
+	if err != nil {
+		fmt.Fprintf(stderr, "org %s: Herdr snapshot unavailable: %v\n", command, err)
+		return 1
+	}
+	rows := make([]orgStatusOutput, 0, len(registry.Roles))
+	observedNow := time.Now().UTC()
+	for _, role := range registry.SortedRoles() {
+		live, ok := snapshot.States[role.Name]
+		if !ok {
+			live = org.RoleLiveState{State: org.StateUnknown, Detail: "provider snapshot omitted this role"}
+		}
+		seen := presence[role.Name]
+		rows = append(rows, orgStatusOutput{
+			Role: role.Name, Parent: role.Parent, Depth: len(registry.Path(role.Name)) - 1,
+			Scope: role.Scope, MergeRule: role.MergeRule, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
+			ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: snapshot.ObservedAt, ProviderVersion: snapshot.ProviderVersion,
+		})
+	}
+	if command == "chart" {
+		sort.Slice(rows, func(i, j int) bool {
+			left, right := strings.Join(registry.Path(rows[i].Role), "/"), strings.Join(registry.Path(rows[j].Role), "/")
+			return left < right
+		})
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, rows); err != nil {
+			fmt.Fprintf(stderr, "org %s: %v\n", command, err)
+			return 1
+		}
+		return 0
+	}
+	if command == "chart" {
+		for _, row := range rows {
+			fmt.Fprintf(stdout, "%s%s · %s · scope=%s · merge=%s · seen=%s\n", strings.Repeat("  ", row.Depth), row.Role, row.ProviderState, strings.Join(row.Scope, ","), dash(row.MergeRule), dash(row.LastSeenAge))
+		}
+		return 0
+	}
+	fmt.Fprintln(stdout, "ROLE\tSTATE\tLAST SEEN\tAGE\tLAST COMMAND\tDETAIL")
+	for _, row := range rows {
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\n", row.Role, row.ProviderState, dash(row.LastSeenAt), dash(row.LastSeenAge), dash(row.LastCommand), dash(row.ProviderDetail))
+	}
+	return 0
+}
+
+func printOrgBrief(w io.Writer, brief orgBriefOutput) {
+	fmt.Fprintf(w, "role: %s\n", brief.Role)
+	fmt.Fprintf(w, "parent: %s\n", dash(brief.Parent))
+	fmt.Fprintf(w, "children: %s\n", dash(strings.Join(brief.Children, ", ")))
+	fmt.Fprintf(w, "path: %s\n", dash(strings.Join(brief.Path, " > ")))
+	fmt.Fprintf(w, "scope: %s\n", dash(strings.Join(brief.Scope, ", ")))
+	fmt.Fprintf(w, "merge_rule: %s\n", dash(brief.MergeRule))
+	fmt.Fprintf(w, "last_seen: %s\n", dash(brief.LastSeenAt))
+	fmt.Fprintf(w, "last_command: %s\n", dash(brief.LastCommand))
+	fmt.Fprintf(w, "provider: %s\n", brief.ProviderState)
+	fmt.Fprintf(w, "provider_detail: %s\n", dash(brief.ProviderDetail))
+}
+
+func loadOrgCommandState(ctx context.Context, home string) (org.Registry, map[string]db.OrgRolePresence, *db.Store, error) {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return org.Registry{}, nil, nil, err
+	}
+	registry, err := config.LoadOrgRegistry(paths)
+	if err != nil {
+		return org.Registry{}, nil, nil, err
+	}
+	if !registry.Enabled() {
+		return org.Registry{}, nil, nil, errors.New("organization registry is disabled; run `gitmoot org init`")
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		return org.Registry{}, nil, nil, err
+	}
+	rows, err := store.ListOrgRolePresence(ctx)
+	if err != nil {
+		store.Close()
+		return org.Registry{}, nil, nil, err
+	}
+	presence := make(map[string]db.OrgRolePresence, len(rows))
+	for _, row := range rows {
+		presence[row.Role] = row
+	}
+	return registry, presence, store, nil
+}
+
+func orgProviderSnapshot(ctx context.Context, registry org.Registry) (org.Snapshot, error) {
+	roles := registry.SortedRoles()
+	names := make([]string, 0, len(roles))
+	for _, role := range roles {
+		names = append(names, role.Name)
+	}
+	provider := newOrgProvider(names)
+	if provider == nil {
+		return org.Snapshot{}, errors.New("organization live-state provider is not configured")
+	}
+	return provider.Snapshot(ctx)
+}
+
+// validateAndTouchActingOrgRole is the shared local job ingress for --org-role.
+// Validation happens before dispatch mutation; invalid/disabled config creates
+// neither a presence row nor a job.
+func validateAndTouchActingOrgRole(ctx context.Context, store *db.Store, home, role, command string) error {
+	role = strings.TrimSpace(role)
+	if role == "" {
+		return nil
+	}
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return err
+	}
+	registry, err := config.LoadOrgRegistry(paths)
+	if err != nil {
+		return err
+	}
+	if !registry.Enabled() {
+		return errors.New("--org-role requires an enabled organization registry; run `gitmoot org init`")
+	}
+	if _, ok := registry.Role(role); !ok {
+		return fmt.Errorf("unknown org role %q", role)
+	}
+	return store.TouchOrgRolePresence(ctx, role, command)
+}
+
+func dash(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
+}
+
+func orgPresenceAge(value string, now time.Time) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	var observed time.Time
+	var err error
+	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339Nano, time.RFC3339} {
+		observed, err = time.Parse(layout, value)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return "unknown"
+	}
+	age := now.Sub(observed.UTC())
+	if age < 0 {
+		age = 0
+	}
+	return age.Round(time.Second).String()
 }
 
 type orgEscalateOutput struct {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -3,13 +3,18 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/org"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -246,5 +251,230 @@ func orgParityPolicy(enforce string) workflow.OrgEnforcement {
 		ScopeMatches: func(scopes []string, repo string) bool {
 			return len(scopes) == 1 && scopes[0] == "owner/*" && strings.HasPrefix(repo, "owner/")
 		},
+	}
+}
+
+type orgFixtureProvider struct {
+	snapshot org.Snapshot
+	err      error
+}
+
+func (p orgFixtureProvider) Snapshot(context.Context) (org.Snapshot, error) {
+	return p.snapshot, p.err
+}
+
+type orgFixtureRunner struct {
+	version string
+}
+
+func (r orgFixtureRunner) LookPath(string) (string, error) { return "/usr/bin/herdr", nil }
+
+func (r orgFixtureRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
+	return subprocess.Result{Stdout: r.version}, nil
+}
+
+func setupOrgHome(t *testing.T) (string, config.Paths) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = file.WriteString(`
+[org]
+enforce = "warn"
+[org.roles."owner"]
+scope = ["*"]
+merge_rule = "owner"
+[org.roles."review"]
+parent = "owner"
+scope = ["gitmoot/*"]
+merge_rule = "parent"
+`)
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return home, paths
+}
+
+func withOrgProvider(t *testing.T, provider org.Provider) {
+	t.Helper()
+	original := newOrgProvider
+	newOrgProvider = func([]string) org.Provider { return provider }
+	t.Cleanup(func() { newOrgProvider = original })
+}
+
+func TestRunOrgBriefChartStatusAndPresence(t *testing.T) {
+	home, paths := setupOrgHome(t)
+	observed := time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC)
+	withOrgProvider(t, orgFixtureProvider{snapshot: org.Snapshot{
+		States: map[string]org.RoleLiveState{
+			"owner":  {State: org.StateWorking},
+			"review": {State: org.StateIdle},
+		},
+		ObservedAt: observed, ProviderVersion: "0.7.5",
+	}})
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "brief", "--home", home, "--role", "review", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("brief code = %d stderr=%s", code, stderr.String())
+	}
+	var brief orgBriefOutput
+	if err := json.Unmarshal(stdout.Bytes(), &brief); err != nil {
+		t.Fatalf("decode brief: %v; output=%s", err, stdout.String())
+	}
+	if brief.Role != "review" || brief.Parent != "owner" || brief.ProviderState != org.StateIdle || brief.LastSeenAt == "" || brief.LastCommand != "org brief" {
+		t.Fatalf("brief = %+v", brief)
+	}
+	if got := strings.Join(brief.Path, "/"); got != "owner/review" {
+		t.Fatalf("brief path = %q", got)
+	}
+
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	presence, err := store.ListOrgRolePresence(context.Background())
+	store.Close()
+	if err != nil || len(presence) != 1 || presence[0].Role != "review" || presence[0].LastCommand != "org brief" {
+		t.Fatalf("presence = %+v, err=%v", presence, err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"org", "chart", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("chart code = %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "owner · working") || !strings.Contains(stdout.String(), "  review · idle") {
+		t.Fatalf("chart output = %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"org", "status", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status code = %d stderr=%s", code, stderr.String())
+	}
+	var status []orgStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil || len(status) != 2 {
+		t.Fatalf("status = %+v err=%v output=%s", status, err, stdout.String())
+	}
+}
+
+func TestRunOrgProviderFailureSemantics(t *testing.T) {
+	home, _ := setupOrgHome(t)
+	withOrgProvider(t, orgFixtureProvider{err: errors.New("socket unavailable")})
+	for _, command := range []string{"chart", "status"} {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"org", command, "--home", home}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "snapshot unavailable") {
+			t.Fatalf("%s code/stderr = %d/%q", command, code, stderr.String())
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "brief", "--home", home, "--role", "owner", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("brief code = %d stderr=%s", code, stderr.String())
+	}
+	var brief orgBriefOutput
+	if err := json.Unmarshal(stdout.Bytes(), &brief); err != nil {
+		t.Fatal(err)
+	}
+	if brief.ProviderState != org.StateUnknown || !strings.Contains(brief.ProviderDetail, "socket unavailable") {
+		t.Fatalf("brief = %+v", brief)
+	}
+}
+
+func TestValidateAndTouchActingOrgRole(t *testing.T) {
+	home, paths := setupOrgHome(t)
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "review", "agent_run"); err != nil {
+		t.Fatalf("validateAndTouchActingOrgRole() error = %v", err)
+	}
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "missing", "agent_run"); err == nil {
+		t.Fatal("unknown role accepted")
+	}
+	presence, err := store.ListOrgRolePresence(ctx)
+	if err != nil || len(presence) != 1 || presence[0].Role != "review" || presence[0].LastCommand != "agent_run" {
+		t.Fatalf("presence = %+v err=%v", presence, err)
+	}
+}
+
+func TestRunOrgInitScaffoldsAndRunsHerdrGate(t *testing.T) {
+	home := t.TempDir()
+	originalRunner := orgDoctorRunner
+	orgDoctorRunner = orgFixtureRunner{version: "herdr 0.7.5\n"}
+	t.Cleanup(func() { orgDoctorRunner = originalRunner })
+	withOrgProvider(t, orgFixtureProvider{snapshot: org.Snapshot{
+		States:     map[string]org.RoleLiveState{"owner": {State: org.StateUnknown}},
+		ObservedAt: time.Now().UTC(), ProviderVersion: "0.7.5",
+	}})
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "init", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("init code = %d stderr=%s", code, stderr.String())
+	}
+	registry, err := config.LoadOrgRegistry(config.PathsForHome(home))
+	if err != nil || !registry.Enabled() {
+		t.Fatalf("registry = %+v err=%v", registry, err)
+	}
+	if !strings.Contains(stdout.String(), "herdr 0.7.5") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunOrgInitRejectsOldHerdrLoudly(t *testing.T) {
+	home := t.TempDir()
+	originalRunner := orgDoctorRunner
+	orgDoctorRunner = orgFixtureRunner{version: "herdr 0.7.4\n"}
+	t.Cleanup(func() { orgDoctorRunner = originalRunner })
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "init", "--home", home}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "org requires herdr >=0.7.5") {
+		t.Fatalf("init code/stderr = %d/%q", code, stderr.String())
+	}
+	registry, err := config.LoadOrgRegistry(config.PathsForHome(home))
+	if err != nil || !registry.Enabled() {
+		t.Fatalf("scaffold should remain inspectable after gate failure: registry=%+v err=%v", registry, err)
+	}
+}
+
+func TestRunOrgMalformedConfigFailsClosedWithoutPresence(t *testing.T) {
+	home, paths := setupOrgHome(t)
+	if err := os.WriteFile(paths.ConfigFile, []byte("[org]\nenforce = \"invalid\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "brief", "--home", home, "--role", "owner"}, &stdout, &stderr); code == 0 || !strings.Contains(stderr.String(), "load org registry") {
+		t.Fatalf("brief code/stderr = %d/%q", code, stderr.String())
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	presence, err := store.ListOrgRolePresence(context.Background())
+	if err != nil || len(presence) != 0 {
+		t.Fatalf("presence = %+v err=%v", presence, err)
+	}
+}
+
+func TestParseAgentOrgRoleFlags(t *testing.T) {
+	var stderr bytes.Buffer
+	ask, ok := parseAgentAskOptions([]string{"agent", "message", "--org-role", "owner"}, &stderr)
+	if !ok || ask.orgRole != "owner" {
+		t.Fatalf("ask = %+v ok=%v stderr=%s", ask, ok, stderr.String())
+	}
+	stderr.Reset()
+	run, ok := parseAgentRunOptions("run", []string{"agent", "message", "--org-role=review"}, &stderr)
+	if !ok || run.orgRole != "review" {
+		t.Fatalf("run = %+v ok=%v stderr=%s", run, ok, stderr.String())
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -30,7 +30,7 @@ var rootCommands = []command{
 	{name: "doctor", summary: "check local Gitmoot prerequisites", run: runDoctor},
 	{name: "version", summary: "show Gitmoot version and build metadata", run: runVersion},
 	{name: "config", summary: "show local Gitmoot config paths", run: runConfig},
-	{name: "org", summary: "org registry + attribution (RFC #1042)", run: runOrg},
+	{name: "org", summary: "org registry, attribution, and brief/chart/status (RFC #1042)", run: runOrg},
 	{name: "auth", summary: "manage runtime authentication", run: runAuth},
 	{name: "key", summary: "manage keycard registry metadata and grants", run: runKey},
 	{name: "update", summary: "check for and apply Gitmoot releases", run: runUpdate},

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -1,0 +1,121 @@
+package cockpit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/org"
+)
+
+type herdrOrgProvider struct {
+	run   runner
+	roles []string
+	now   func() time.Time
+}
+
+// NewHerdrOrgProvider returns the v1 organization live-state provider. Role
+// identity is exact pane-label equality; runtime/agent names are never inferred.
+func NewHerdrOrgProvider(roles []string) org.Provider {
+	return newHerdrOrgProvider(newExecRunner("herdr"), roles, time.Now)
+}
+
+func newHerdrOrgProvider(run runner, roles []string, now func() time.Time) *herdrOrgProvider {
+	roles = append([]string(nil), roles...)
+	sort.Strings(roles)
+	return &herdrOrgProvider{run: run, roles: roles, now: now}
+}
+
+type herdrOrgSnapshotResult struct {
+	Result struct {
+		Snapshot struct {
+			Version json.RawMessage `json:"version"`
+			Panes   []struct {
+				Label       string `json:"label"`
+				AgentStatus string `json:"agent_status"`
+			} `json:"panes"`
+		} `json:"snapshot"`
+	} `json:"result"`
+}
+
+func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
+	if p == nil || p.run == nil {
+		return org.Snapshot{}, fmt.Errorf("herdr org provider is not configured")
+	}
+	out, err := p.run(ctx, "api", "snapshot")
+	if err != nil {
+		return org.Snapshot{}, fmt.Errorf("herdr api snapshot: %w", err)
+	}
+	var decoded herdrOrgSnapshotResult
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		return org.Snapshot{}, fmt.Errorf("parse herdr api snapshot: %w", err)
+	}
+	version, err := herdrProviderVersion(decoded.Result.Snapshot.Version)
+	if err != nil {
+		return org.Snapshot{}, err
+	}
+	if version == "" || decoded.Result.Snapshot.Panes == nil {
+		return org.Snapshot{}, fmt.Errorf("herdr api snapshot returned an incomplete snapshot shape")
+	}
+
+	byLabel := map[string][]string{}
+	for _, pane := range decoded.Result.Snapshot.Panes {
+		label := pane.Label
+		if label == "" {
+			continue
+		}
+		byLabel[label] = append(byLabel[label], pane.AgentStatus)
+	}
+	states := make(map[string]org.RoleLiveState, len(p.roles))
+	for _, role := range p.roles {
+		matches := byLabel[role]
+		switch len(matches) {
+		case 0:
+			states[role] = org.RoleLiveState{State: org.StateUnknown, Detail: "no Herdr pane has this exact role label"}
+		case 1:
+			states[role] = mapHerdrAgentStatus(matches[0])
+		default:
+			states[role] = org.RoleLiveState{State: org.StateUnknown, Detail: "multiple Herdr panes have this exact role label"}
+		}
+	}
+	now := time.Now
+	if p.now != nil {
+		now = p.now
+	}
+	return org.Snapshot{States: states, ObservedAt: now().UTC(), ProviderVersion: version}, nil
+}
+
+func mapHerdrAgentStatus(raw string) org.RoleLiveState {
+	switch raw {
+	case string(org.StateIdle):
+		return org.RoleLiveState{State: org.StateIdle}
+	case string(org.StateWorking):
+		return org.RoleLiveState{State: org.StateWorking}
+	case string(org.StateBlocked):
+		return org.RoleLiveState{State: org.StateBlocked}
+	case string(org.StateDone):
+		return org.RoleLiveState{State: org.StateDone}
+	case "":
+		return org.RoleLiveState{State: org.StateUnknown, Detail: "Herdr pane has no agent_status"}
+	default:
+		return org.RoleLiveState{State: org.StateUnknown, Detail: fmt.Sprintf("unknown Herdr agent_status %q", raw)}
+	}
+}
+
+func herdrProviderVersion(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", nil
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return strings.TrimSpace(text), nil
+	}
+	var number json.Number
+	if err := json.Unmarshal(raw, &number); err == nil {
+		return number.String(), nil
+	}
+	return "", fmt.Errorf("parse herdr snapshot version")
+}

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -1,0 +1,76 @@
+package cockpit
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/org"
+)
+
+func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
+	observed := time.Date(2026, 7, 22, 8, 0, 0, 0, time.UTC)
+	run := func(_ context.Context, args ...string) (string, error) {
+		if strings.Join(args, " ") != "api snapshot" {
+			t.Fatalf("args = %v", args)
+		}
+		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"label":"owner","agent_status":"working"},
+{"label":"review","agent_status":"blocked"},
+{"label":"done","agent_status":"done"},
+{"label":"idle","agent_status":"idle"},
+{"label":"future","agent_status":"paused"},
+{"label":"duplicate","agent_status":"working"},
+{"label":"duplicate","agent_status":"idle"},
+{"label":"claude","agent_status":"working"},
+{"label":" whitespace-label ","agent_status":"working"},
+{"label":"whitespace-status","agent_status":" working "}
+]}}}`, nil
+	}
+	provider := newHerdrOrgProvider(run, []string{"owner", "review", "done", "idle", "future", "duplicate", "missing", "whitespace-label", "whitespace-status"}, func() time.Time { return observed })
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if snapshot.ProviderVersion != "0.7.5" || !snapshot.ObservedAt.Equal(observed) {
+		t.Fatalf("snapshot metadata = %+v", snapshot)
+	}
+	wants := map[string]org.LifecycleState{
+		"owner": org.StateWorking, "review": org.StateBlocked, "done": org.StateDone,
+		"idle": org.StateIdle, "future": org.StateUnknown, "duplicate": org.StateUnknown,
+		"missing": org.StateUnknown, "whitespace-label": org.StateUnknown, "whitespace-status": org.StateUnknown,
+	}
+	for role, want := range wants {
+		if got := snapshot.States[role].State; got != want {
+			t.Errorf("state[%s] = %q, want %q (%+v)", role, got, want, snapshot.States[role])
+		}
+	}
+	if _, inferred := snapshot.States["claude"]; inferred {
+		t.Fatal("provider inferred a runtime label that was not a configured role")
+	}
+}
+
+func TestHerdrOrgProviderFailures(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		err  error
+		want string
+	}{
+		{name: "command", err: errors.New("socket unavailable"), want: "herdr api snapshot"},
+		{name: "json", out: `{`, want: "parse herdr api snapshot"},
+		{name: "missing version", out: `{"result":{"snapshot":{"panes":[]}}}`, want: "incomplete snapshot"},
+		{name: "missing panes", out: `{"result":{"snapshot":{"version":"0.7.5"}}}`, want: "incomplete snapshot"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			provider := newHerdrOrgProvider(func(context.Context, ...string) (string, error) { return test.out, test.err }, []string{"owner"}, time.Now)
+			_, err := provider.Snapshot(context.Background())
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("Snapshot() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}

--- a/internal/config/org_registry.go
+++ b/internal/config/org_registry.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gitmoot/gitmoot/internal/org"
+)
+
+// LoadOrgRegistry is the canonical phase-1b loader. A future #1057 LoadOrg
+// should reconcile by wrapping this function rather than introducing a second
+// parser or policy model.
+func LoadOrgRegistry(paths Paths) (org.Registry, error) {
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return org.Registry{}, nil
+		}
+		return org.Registry{}, err
+	}
+	registry, err := org.ParseRegistry(content)
+	if err != nil {
+		return org.Registry{}, fmt.Errorf("load org registry: %w", err)
+	}
+	return registry, nil
+}

--- a/internal/config/org_registry_test.go
+++ b/internal/config/org_registry_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadOrgRegistry(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := `[org]
+enforce = "warn"
+[org.roles."owner"]
+scope = ["*"]
+merge_rule = "owner"
+`
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registry, err := LoadOrgRegistry(paths)
+	if err != nil {
+		t.Fatalf("LoadOrgRegistry() error = %v", err)
+	}
+	if !registry.Enabled() || registry.Enforce != "warn" {
+		t.Fatalf("registry = %+v", registry)
+	}
+}
+
+func TestLoadOrgRegistryMalformedFailsClosed(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[org]\nenforce = \"maybe\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadOrgRegistry(paths)
+	if err == nil || !strings.Contains(err.Error(), "load org registry") {
+		t.Fatalf("LoadOrgRegistry() error = %v", err)
+	}
+}
+
+func TestLoadOrgRegistryMissingIsDisabled(t *testing.T) {
+	registry, err := LoadOrgRegistry(PathsForHome(t.TempDir()))
+	if err != nil {
+		t.Fatalf("LoadOrgRegistry() error = %v", err)
+	}
+	if registry.Enabled() {
+		t.Fatalf("registry unexpectedly enabled: %+v", registry)
+	}
+}

--- a/internal/db/org_presence_store.go
+++ b/internal/db/org_presence_store.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+type OrgRolePresence struct {
+	Role        string `json:"role"`
+	LastSeenAt  string `json:"last_seen_at"`
+	LastCommand string `json:"last_command"`
+}
+
+func (s *Store) TouchOrgRolePresence(ctx context.Context, role, command string) error {
+	role = strings.TrimSpace(role)
+	command = strings.TrimSpace(command)
+	if role == "" {
+		return errors.New("org role is required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO org_role_presence(role, last_seen_at, last_command)
+		VALUES (?, CURRENT_TIMESTAMP, ?)
+		ON CONFLICT(role) DO UPDATE SET
+			last_seen_at = CURRENT_TIMESTAMP,
+			last_command = excluded.last_command`, role, command)
+	return err
+}
+
+func (s *Store) ListOrgRolePresence(ctx context.Context) ([]OrgRolePresence, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT role, last_seen_at, last_command
+		FROM org_role_presence ORDER BY role`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []OrgRolePresence
+	for rows.Next() {
+		var presence OrgRolePresence
+		if err := rows.Scan(&presence.Role, &presence.LastSeenAt, &presence.LastCommand); err != nil {
+			return nil, err
+		}
+		result = append(result, presence)
+	}
+	return result, rows.Err()
+}

--- a/internal/db/org_presence_store_test.go
+++ b/internal/db/org_presence_store_test.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestOrgRolePresenceMigrationAndUpsert(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	var table string
+	if err := store.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name='org_role_presence'`).Scan(&table); err != nil {
+		t.Fatalf("org_role_presence migration missing: %v", err)
+	}
+	if err := store.TouchOrgRolePresence(ctx, "owner", "org brief"); err != nil {
+		t.Fatalf("TouchOrgRolePresence(insert) error = %v", err)
+	}
+	if err := store.TouchOrgRolePresence(ctx, "owner", "agent run"); err != nil {
+		t.Fatalf("TouchOrgRolePresence(update) error = %v", err)
+	}
+	if err := store.TouchOrgRolePresence(ctx, "review", "org status"); err != nil {
+		t.Fatalf("TouchOrgRolePresence(second role) error = %v", err)
+	}
+	presence, err := store.ListOrgRolePresence(ctx)
+	if err != nil {
+		t.Fatalf("ListOrgRolePresence() error = %v", err)
+	}
+	if len(presence) != 2 || presence[0].Role != "owner" || presence[0].LastCommand != "agent run" || presence[0].LastSeenAt == "" || presence[1].Role != "review" {
+		t.Fatalf("presence = %+v", presence)
+	}
+}
+
+func TestTouchOrgRolePresenceRejectsEmptyRole(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer store.Close()
+	if err := store.TouchOrgRolePresence(context.Background(), " ", "org brief"); err == nil {
+		t.Fatal("TouchOrgRolePresence() error = nil, want validation error")
+	}
+}

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1651,4 +1651,13 @@ CREATE TABLE pipeline_service_runs (
 );
 CREATE INDEX idx_pipeline_service_runs_pipeline ON pipeline_service_runs(pipeline_name, created_at, run_id);
 	`,
+	// #1059 passive organization-role presence. This is durable role activity,
+	// distinct from workflow notes and intentionally contains no command output.
+	`
+CREATE TABLE org_role_presence (
+	role TEXT PRIMARY KEY,
+	last_seen_at TEXT NOT NULL,
+	last_command TEXT NOT NULL DEFAULT ''
+);
+	`,
 }

--- a/internal/doctor/checker.go
+++ b/internal/doctor/checker.go
@@ -108,6 +108,14 @@ func (c Checker) GlobalChecks(ctx context.Context) []Check {
 	if c.Build != nil {
 		checks = append(checks, CheckBuild(*c.Build))
 	}
+	if strings.TrimSpace(c.Paths.ConfigFile) != "" {
+		registry, err := config.LoadOrgRegistry(c.Paths)
+		if err != nil {
+			checks = append(checks, Check{Name: "org registry", Required: true, Detail: err.Error()})
+		} else if registry.Enabled() {
+			checks = append(checks, CheckHerdrVersion(ctx, runner, OrgMinimumHerdrVersion))
+		}
+	}
 	return checks
 }
 

--- a/internal/doctor/herdr.go
+++ b/internal/doctor/herdr.go
@@ -1,0 +1,149 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+const OrgMinimumHerdrVersion = "0.7.5"
+
+const orgHerdrUpgradeMessage = "org requires herdr >=0.7.5; upgrade herdr (0.7.0-0.7.4 have delivery bugs)"
+
+var strictSemVerPattern = regexp.MustCompile(`^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
+
+// CheckHerdrVersion enforces the org provider's minimum supported Herdr CLI.
+// It does not fall back to cockpit availability: versions 0.7.0-0.7.4 are
+// present but have delivery bugs and therefore fail this required check.
+func CheckHerdrVersion(ctx context.Context, runner subprocess.Runner, minimum string) Check {
+	check := Check{Name: "herdr", Required: true}
+	if runner == nil {
+		check.Detail = orgHerdrUpgradeMessage + "; command runner unavailable"
+		return check
+	}
+	if _, err := runner.LookPath("herdr"); err != nil {
+		check.Detail = orgHerdrUpgradeMessage + "; install herdr: " + err.Error()
+		return check
+	}
+	result, err := runner.Run(ctx, "", "herdr", "--version")
+	if err != nil {
+		detail := strings.TrimSpace(result.Stderr)
+		if detail == "" {
+			detail = err.Error()
+		}
+		check.Detail = orgHerdrUpgradeMessage + "; `herdr --version` failed: " + detail
+		return check
+	}
+	found, err := parseHerdrVersion(result.Stdout)
+	if err != nil {
+		check.Detail = orgHerdrUpgradeMessage + "; " + err.Error()
+		return check
+	}
+	minimumVersion, err := parseStrictSemVer(strings.TrimSpace(minimum))
+	if err != nil {
+		check.Detail = "invalid minimum Herdr version: " + err.Error()
+		return check
+	}
+	foundVersion, _ := parseStrictSemVer(found)
+	if compareSemVer(foundVersion, minimumVersion) < 0 {
+		check.Detail = fmt.Sprintf("%s; found %s", orgHerdrUpgradeMessage, found)
+		return check
+	}
+	check.OK = true
+	check.Detail = fmt.Sprintf("herdr %s (org requires >=%s)", found, minimum)
+	return check
+}
+
+type semVersion struct {
+	major, minor, patch int
+	prerelease          []string
+}
+
+func parseHerdrVersion(output string) (string, error) {
+	fields := strings.Fields(strings.TrimSpace(output))
+	if len(fields) == 0 {
+		return "", fmt.Errorf("malformed `herdr --version` output")
+	}
+	version := fields[len(fields)-1]
+	if _, err := parseStrictSemVer(version); err != nil {
+		return "", fmt.Errorf("malformed `herdr --version` output %q", strings.TrimSpace(output))
+	}
+	return version, nil
+}
+
+func parseStrictSemVer(value string) (semVersion, error) {
+	match := strictSemVerPattern.FindStringSubmatch(value)
+	if match == nil {
+		return semVersion{}, fmt.Errorf("%q is not strict SemVer", value)
+	}
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	patch, _ := strconv.Atoi(match[3])
+	version := semVersion{major: major, minor: minor, patch: patch}
+	if match[4] != "" {
+		version.prerelease = strings.Split(match[4], ".")
+		for _, identifier := range version.prerelease {
+			if len(identifier) > 1 && identifier[0] == '0' {
+				allNumeric := true
+				for _, r := range identifier {
+					allNumeric = allNumeric && r >= '0' && r <= '9'
+				}
+				if allNumeric {
+					return semVersion{}, fmt.Errorf("%q is not strict SemVer", value)
+				}
+			}
+		}
+	}
+	return version, nil
+}
+
+func compareSemVer(left, right semVersion) int {
+	for _, pair := range [][2]int{{left.major, right.major}, {left.minor, right.minor}, {left.patch, right.patch}} {
+		if pair[0] < pair[1] {
+			return -1
+		}
+		if pair[0] > pair[1] {
+			return 1
+		}
+	}
+	if len(left.prerelease) == 0 && len(right.prerelease) == 0 {
+		return 0
+	}
+	if len(left.prerelease) == 0 {
+		return 1
+	}
+	if len(right.prerelease) == 0 {
+		return -1
+	}
+	for index := 0; index < len(left.prerelease) && index < len(right.prerelease); index++ {
+		leftID, rightID := left.prerelease[index], right.prerelease[index]
+		leftNumber, leftErr := strconv.Atoi(leftID)
+		rightNumber, rightErr := strconv.Atoi(rightID)
+		switch {
+		case leftErr == nil && rightErr == nil && leftNumber != rightNumber:
+			if leftNumber < rightNumber {
+				return -1
+			}
+			return 1
+		case leftErr == nil && rightErr != nil:
+			return -1
+		case leftErr != nil && rightErr == nil:
+			return 1
+		case leftID < rightID:
+			return -1
+		case leftID > rightID:
+			return 1
+		}
+	}
+	if len(left.prerelease) < len(right.prerelease) {
+		return -1
+	}
+	if len(left.prerelease) > len(right.prerelease) {
+		return 1
+	}
+	return 0
+}

--- a/internal/doctor/herdr_test.go
+++ b/internal/doctor/herdr_test.go
@@ -1,0 +1,97 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+func TestCheckHerdrVersionBoundaries(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		wantOK bool
+	}{
+		{name: "delivery bug release", output: "herdr 0.7.4\n", wantOK: false},
+		{name: "minimum", output: "herdr 0.7.5\n", wantOK: true},
+		{name: "newer", output: "herdr version 1.0.0\n", wantOK: true},
+		{name: "minimum prerelease", output: "herdr 0.7.5-rc.1\n", wantOK: false},
+		{name: "malformed", output: "herdr v0.7.5\n", wantOK: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runner := fakeRunner{paths: map[string]bool{"herdr": true}, runs: map[string]subprocess.Result{"herdr --version": {Stdout: test.output}}}
+			check := CheckHerdrVersion(context.Background(), runner, OrgMinimumHerdrVersion)
+			if check.OK != test.wantOK || !check.Required {
+				t.Fatalf("check = %+v, want OK=%v required", check, test.wantOK)
+			}
+			if !test.wantOK && !strings.Contains(check.Detail, "org requires herdr >=0.7.5") {
+				t.Fatalf("detail = %q", check.Detail)
+			}
+		})
+	}
+}
+
+func TestCheckHerdrVersionCommandFailures(t *testing.T) {
+	missing := CheckHerdrVersion(context.Background(), fakeRunner{}, OrgMinimumHerdrVersion)
+	if missing.OK || !strings.Contains(missing.Detail, "install herdr") {
+		t.Fatalf("missing check = %+v", missing)
+	}
+	runner := fakeRunner{paths: map[string]bool{"herdr": true}, errs: map[string]error{"herdr --version": errors.New("boom")}}
+	failed := CheckHerdrVersion(context.Background(), runner, OrgMinimumHerdrVersion)
+	if failed.OK || !strings.Contains(failed.Detail, "--version` failed") {
+		t.Fatalf("failed check = %+v", failed)
+	}
+}
+
+func TestGlobalChecksGatesHerdrOnlyWhenOrgEnabled(t *testing.T) {
+	writeConfig := func(t *testing.T, body string) config.Paths {
+		t.Helper()
+		paths := config.PathsForHome(t.TempDir())
+		if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return paths
+	}
+	runner := fakeRunner{paths: map[string]bool{"herdr": true}, runs: map[string]subprocess.Result{"herdr --version": {Stdout: "herdr 0.7.5\n"}}}
+	for _, test := range []struct {
+		name      string
+		body      string
+		wantHerdr bool
+		wantOrg   bool
+	}{
+		{name: "absent", body: "[workflow]\nresult_checks = \"warn\"\n"},
+		{name: "enabled", body: "[org]\nenforce = \"warn\"\n[org.roles.\"owner\"]\nscope = [\"*\"]\nmerge_rule = \"owner\"\n", wantHerdr: true},
+		{name: "malformed", body: "[org]\nenforce = \"invalid\"\n", wantOrg: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			checks := (Checker{Runner: runner, Paths: writeConfig(t, test.body), SkipDaemonAuth: true}).GlobalChecks(context.Background())
+			var foundHerdr, foundOrg bool
+			for _, check := range checks {
+				foundHerdr = foundHerdr || check.Name == "herdr"
+				foundOrg = foundOrg || check.Name == "org registry"
+			}
+			if foundHerdr != test.wantHerdr || foundOrg != test.wantOrg {
+				t.Fatalf("checks = %+v", checks)
+			}
+		})
+	}
+}
+
+func TestGlobalChecksMissingConfigDoesNotEnableOrg(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	checks := (Checker{Runner: fakeRunner{}, Paths: paths, SkipDaemonAuth: true}).GlobalChecks(context.Background())
+	for _, check := range checks {
+		if check.Name == "herdr" || check.Name == "org registry" {
+			t.Fatalf("absent org config added check: %+v", check)
+		}
+	}
+}

--- a/internal/org/provider.go
+++ b/internal/org/provider.go
@@ -1,0 +1,31 @@
+package org
+
+import (
+	"context"
+	"time"
+)
+
+type LifecycleState string
+
+const (
+	StateIdle    LifecycleState = "idle"
+	StateWorking LifecycleState = "working"
+	StateBlocked LifecycleState = "blocked"
+	StateDone    LifecycleState = "done"
+	StateUnknown LifecycleState = "unknown"
+)
+
+type RoleLiveState struct {
+	State  LifecycleState `json:"state"`
+	Detail string         `json:"detail,omitempty"`
+}
+
+type Snapshot struct {
+	States          map[string]RoleLiveState `json:"states"`
+	ObservedAt      time.Time                `json:"observed_at"`
+	ProviderVersion string                   `json:"provider_version,omitempty"`
+}
+
+type Provider interface {
+	Snapshot(ctx context.Context) (Snapshot, error)
+}

--- a/internal/org/registry.go
+++ b/internal/org/registry.go
@@ -1,0 +1,468 @@
+// Package org defines the configured organization registry and its live-state
+// provider contract. It deliberately has no config, database, CLI, or Herdr
+// dependencies so parsing and policy validation stay deterministic and testable.
+package org
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type EnforceMode string
+
+const (
+	EnforceWarn  EnforceMode = "warn"
+	EnforceBlock EnforceMode = "block"
+)
+
+type Role struct {
+	Name      string   `json:"name"`
+	Parent    string   `json:"parent,omitempty"`
+	Scope     []string `json:"scope"`
+	MergeRule string   `json:"merge_rule"`
+}
+
+type Registry struct {
+	Enforce EnforceMode     `json:"enforce,omitempty"`
+	Roles   map[string]Role `json:"roles,omitempty"`
+}
+
+func (r Registry) Enabled() bool { return len(r.Roles) > 0 }
+
+func (r Registry) Role(name string) (Role, bool) {
+	role, ok := r.Roles[strings.TrimSpace(name)]
+	return role, ok
+}
+
+func (r Registry) SortedRoles() []Role {
+	roles := make([]Role, 0, len(r.Roles))
+	for _, role := range r.Roles {
+		roles = append(roles, role)
+	}
+	sort.Slice(roles, func(i, j int) bool { return roles[i].Name < roles[j].Name })
+	return roles
+}
+
+func (r Registry) Children(name string) []Role {
+	var children []Role
+	for _, role := range r.Roles {
+		if role.Parent == name {
+			children = append(children, role)
+		}
+	}
+	sort.Slice(children, func(i, j int) bool { return children[i].Name < children[j].Name })
+	return children
+}
+
+func (r Registry) Path(name string) []string {
+	role, ok := r.Role(name)
+	if !ok {
+		return nil
+	}
+	path := []string{role.Name}
+	visited := map[string]bool{role.Name: true}
+	for role.Parent != "" {
+		parent, ok := r.Role(role.Parent)
+		if !ok {
+			return nil
+		}
+		if visited[parent.Name] {
+			break
+		}
+		visited[parent.Name] = true
+		path = append(path, parent.Name)
+		role = parent
+	}
+	for left, right := 0, len(path)-1; left < right; left, right = left+1, right-1 {
+		path[left], path[right] = path[right], path[left]
+	}
+	return path
+}
+
+func (r Registry) Matches(roleName, repo string) bool {
+	role, ok := r.Role(roleName)
+	if !ok {
+		return false
+	}
+	for _, pattern := range role.Scope {
+		if ScopeMatches(pattern, repo) {
+			return true
+		}
+	}
+	return false
+}
+
+// ScopeMatches implements the frozen v1 scope grammar: *, owner/*, */repo, and
+// owner/repo. Scope is display-only in #1059; this helper is the canonical
+// matcher for the later enforcement change.
+func ScopeMatches(pattern, repo string) bool {
+	pattern = strings.TrimSpace(pattern)
+	repo = strings.TrimSpace(repo)
+	if validateScope(pattern) != nil {
+		return false
+	}
+	if pattern == "*" {
+		return validRepo(repo)
+	}
+	patternOwner, patternRepo, ok := splitScope(pattern)
+	if !ok || !validRepo(repo) {
+		return false
+	}
+	repoOwner, repoName, _ := strings.Cut(repo, "/")
+	return (patternOwner == "*" || patternOwner == repoOwner) && (patternRepo == "*" || patternRepo == repoName)
+}
+
+// ParseRegistry parses only [org] and [org.roles."name"] sections. An absent
+// org configuration is disabled/open. Once any org section is present, every
+// malformed field or hierarchy is returned as an error so callers fail closed.
+func ParseRegistry(data []byte) (Registry, error) {
+	registry := Registry{Roles: map[string]Role{}}
+	roleFields := map[string]map[string]bool{}
+	seenOrg := false
+	seenOrgSection := false
+	seenEnforce := false
+	sectionKind := ""
+	sectionRole := ""
+
+	for lineNumber, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(stripComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			sectionKind, sectionRole = "", ""
+			if !strings.HasSuffix(line, "]") {
+				candidate := strings.TrimSpace(strings.TrimPrefix(line, "["))
+				if candidate == "org.roles" || strings.HasPrefix(candidate, "org.roles.") {
+					return Registry{}, fmt.Errorf("line %d: malformed org role section header", lineNumber+1)
+				}
+				continue
+			}
+			section := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			switch {
+			case section == "org":
+				if seenOrgSection {
+					return Registry{}, fmt.Errorf("line %d: duplicate [org] section", lineNumber+1)
+				}
+				seenOrg, seenOrgSection = true, true
+				sectionKind, sectionRole = "org", ""
+			case section == "org.roles" || strings.HasPrefix(section, "org.roles."):
+				seenOrg = true
+				name, err := parseRoleSection(section)
+				if err != nil {
+					return Registry{}, fmt.Errorf("line %d: %w", lineNumber+1, err)
+				}
+				if _, exists := registry.Roles[name]; exists {
+					return Registry{}, fmt.Errorf("line %d: duplicate org role %q", lineNumber+1, name)
+				}
+				registry.Roles[name] = Role{Name: name}
+				roleFields[name] = map[string]bool{}
+				sectionKind, sectionRole = "role", name
+			default:
+				continue
+			}
+			continue
+		}
+
+		if sectionKind == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			return Registry{}, fmt.Errorf("line %d: malformed org field", lineNumber+1)
+		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+		if sectionKind == "org" {
+			if key != "enforce" {
+				return Registry{}, fmt.Errorf("line %d: unknown [org] field %q", lineNumber+1, key)
+			}
+			if seenEnforce {
+				return Registry{}, fmt.Errorf("line %d: duplicate [org].enforce", lineNumber+1)
+			}
+			seenEnforce = true
+			parsed, err := parseString(value)
+			if err != nil {
+				return Registry{}, fmt.Errorf("line %d: parse [org].enforce: %w", lineNumber+1, err)
+			}
+			registry.Enforce = EnforceMode(parsed)
+			continue
+		}
+
+		if key != "parent" && key != "scope" && key != "merge_rule" {
+			return Registry{}, fmt.Errorf("line %d: unknown org role field %q", lineNumber+1, key)
+		}
+		if roleFields[sectionRole][key] {
+			return Registry{}, fmt.Errorf("line %d: duplicate field %q for org role %q", lineNumber+1, key, sectionRole)
+		}
+		roleFields[sectionRole][key] = true
+		role := registry.Roles[sectionRole]
+		switch key {
+		case "parent":
+			parsed, err := parseString(value)
+			if err != nil {
+				return Registry{}, fmt.Errorf("line %d: parse org role %q parent: %w", lineNumber+1, sectionRole, err)
+			}
+			role.Parent = strings.TrimSpace(parsed)
+		case "scope":
+			parsed, err := parseStringArray(value)
+			if err != nil {
+				return Registry{}, fmt.Errorf("line %d: parse org role %q scope: %w", lineNumber+1, sectionRole, err)
+			}
+			role.Scope = parsed
+		case "merge_rule":
+			parsed, err := parseString(value)
+			if err != nil {
+				return Registry{}, fmt.Errorf("line %d: parse org role %q merge_rule: %w", lineNumber+1, sectionRole, err)
+			}
+			role.MergeRule = strings.TrimSpace(parsed)
+		}
+		registry.Roles[sectionRole] = role
+	}
+
+	if !seenOrg {
+		return Registry{}, nil
+	}
+	// #1067/#1073 reconcile: presence of any [org.roles.*] turns the registry ON;
+	// an explicit [org] section is OPTIONAL (its only key, enforce, is optional and
+	// defaults to block — it cannot be an activation switch). This matches the
+	// authoritative config.LoadOrg semantics (OrgConfig.Enforce() defaults to
+	// "block"). A roles-only config is valid, not malformed. Genuinely malformed
+	// input (bad enforce value, cycles, out-of-subset scope) still fails closed below.
+	if registry.Enforce == "" {
+		registry.Enforce = EnforceBlock
+	}
+	if registry.Enforce != EnforceWarn && registry.Enforce != EnforceBlock {
+		return Registry{}, fmt.Errorf("[org].enforce must be %q or %q", EnforceWarn, EnforceBlock)
+	}
+	if err := registry.Validate(); err != nil {
+		return Registry{}, err
+	}
+	return registry, nil
+}
+
+func (r Registry) Validate() error {
+	if len(r.Roles) == 0 {
+		return fmt.Errorf("org registry must declare at least one role")
+	}
+	// Iterate in sorted name order across every pass so fail-closed errors are
+	// deterministic regardless of Go's map iteration order. The passes are also
+	// ordered by structural precedence: a role's own fields and the single-owner
+	// root rule are validated before parent references, so a mis-named root
+	// always surfaces as a root error rather than an incidental undeclared-parent
+	// error on some child (whichever the map happened to visit first).
+	names := make([]string, 0, len(r.Roles))
+	for name := range r.Roles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Pass 1: per-role field validity + root identification.
+	roots := 0
+	for _, name := range names {
+		role := r.Roles[name]
+		if strings.TrimSpace(name) == "" || role.Name != name {
+			return fmt.Errorf("invalid org role name %q", name)
+		}
+		if len(role.Scope) == 0 {
+			return fmt.Errorf("org role %q requires a non-empty scope", name)
+		}
+		seenScope := map[string]bool{}
+		for _, scope := range role.Scope {
+			if err := validateScope(scope); err != nil {
+				return fmt.Errorf("org role %q scope %q: %w", name, scope, err)
+			}
+			if seenScope[scope] {
+				return fmt.Errorf("org role %q has duplicate scope %q", name, scope)
+			}
+			seenScope[scope] = true
+		}
+		// #1057 reconcile: merge_rule is OPTIONAL — "deliberately advisory in
+		// phase 1a" (see config.OrgConfig). A role may omit it, matching the
+		// authoritative config.LoadOrg acceptance rule. A malformed merge_rule
+		// line (key with no value) still fails closed in the field parser above.
+		if role.Parent == "" {
+			roots++
+			if name != "owner" {
+				return fmt.Errorf("root org role must be named %q; got %q", "owner", name)
+			}
+		}
+	}
+	if roots != 1 {
+		return fmt.Errorf("org registry requires exactly one root role named owner; got %d roots", roots)
+	}
+
+	// Pass 2: parent references.
+	for _, name := range names {
+		role := r.Roles[name]
+		if role.Parent == "" {
+			continue
+		}
+		if role.Parent == name {
+			return fmt.Errorf("org role %q cannot parent itself", name)
+		}
+		if _, ok := r.Roles[role.Parent]; !ok {
+			return fmt.Errorf("org role %q references undeclared parent %q", name, role.Parent)
+		}
+	}
+
+	// Pass 3: cycle detection.
+	for _, name := range names {
+		seen := map[string]bool{}
+		for current := name; current != ""; current = r.Roles[current].Parent {
+			if seen[current] {
+				return fmt.Errorf("org role hierarchy contains a cycle at %q", current)
+			}
+			seen[current] = true
+		}
+	}
+
+	// Pass 4: child scope must be a subset of its parent's scope.
+	for _, name := range names {
+		role := r.Roles[name]
+		if role.Parent == "" {
+			continue
+		}
+		parent := r.Roles[role.Parent]
+		for _, childScope := range role.Scope {
+			covered := false
+			for _, parentScope := range parent.Scope {
+				if scopeContains(parentScope, childScope) {
+					covered = true
+					break
+				}
+			}
+			if !covered {
+				return fmt.Errorf("org role %q scope %q is not a subset of parent %q scope", name, childScope, role.Parent)
+			}
+		}
+	}
+	return nil
+}
+
+func parseRoleSection(section string) (string, error) {
+	raw := strings.TrimPrefix(section, "org.roles.")
+	if raw == "" || !strings.HasPrefix(raw, "\"") || !strings.HasSuffix(raw, "\"") {
+		return "", fmt.Errorf("org role section must be [org.roles.\"name\"]")
+	}
+	name, err := strconv.Unquote(raw)
+	if err != nil || strings.TrimSpace(name) == "" || name != strings.TrimSpace(name) {
+		return "", fmt.Errorf("invalid org role section %q", section)
+	}
+	if strings.ContainsAny(name, "[]/\t\r\n") {
+		return "", fmt.Errorf("invalid org role name %q", name)
+	}
+	return name, nil
+}
+
+func parseString(value string) (string, error) {
+	if !strings.HasPrefix(value, "\"") || !strings.HasSuffix(value, "\"") {
+		return "", fmt.Errorf("must be a quoted string")
+	}
+	return strconv.Unquote(value)
+}
+
+func parseStringArray(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		return nil, fmt.Errorf("must be an array of quoted strings")
+	}
+	body := strings.TrimSpace(value[1 : len(value)-1])
+	if body == "" {
+		return nil, nil
+	}
+	var parts []string
+	start, quoted, escaped := 0, false, false
+	for i, runeValue := range body {
+		switch {
+		case escaped:
+			escaped = false
+		case runeValue == '\\' && quoted:
+			escaped = true
+		case runeValue == '"':
+			quoted = !quoted
+		case runeValue == ',' && !quoted:
+			parts = append(parts, body[start:i])
+			start = i + 1
+		}
+	}
+	if quoted || escaped {
+		return nil, fmt.Errorf("unterminated quoted string")
+	}
+	parts = append(parts, body[start:])
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		parsed, err := parseString(strings.TrimSpace(part))
+		if err != nil {
+			return nil, err
+		}
+		parsed = strings.TrimSpace(parsed)
+		if parsed == "" {
+			return nil, fmt.Errorf("scope entries must be non-empty")
+		}
+		result = append(result, parsed)
+	}
+	return result, nil
+}
+
+func stripComment(line string) string {
+	quoted, escaped := false, false
+	for i, runeValue := range line {
+		switch {
+		case escaped:
+			escaped = false
+		case runeValue == '\\' && quoted:
+			escaped = true
+		case runeValue == '"':
+			quoted = !quoted
+		case runeValue == '#' && !quoted:
+			return line[:i]
+		}
+	}
+	return line
+}
+
+func validateScope(scope string) error {
+	if scope == "*" {
+		return nil
+	}
+	owner, repo, ok := splitScope(scope)
+	if !ok || (owner == "*" && repo == "*") {
+		return fmt.Errorf("must be *, owner/*, */repo, or owner/repo")
+	}
+	return nil
+}
+
+func splitScope(scope string) (string, string, bool) {
+	if scope != strings.TrimSpace(scope) || strings.Count(scope, "/") != 1 {
+		return "", "", false
+	}
+	owner, repo, ok := strings.Cut(scope, "/")
+	if !ok || owner == "" || repo == "" || strings.ContainsAny(owner+repo, " \t\r\n") {
+		return "", "", false
+	}
+	return owner, repo, true
+}
+
+func validRepo(repo string) bool {
+	owner, name, ok := splitScope(repo)
+	return ok && owner != "*" && name != "*"
+}
+
+func scopeContains(parent, child string) bool {
+	if parent == "*" {
+		return true
+	}
+	if child == "*" {
+		return false
+	}
+	parentOwner, parentRepo, parentOK := splitScope(parent)
+	childOwner, childRepo, childOK := splitScope(child)
+	if !parentOK || !childOK {
+		return false
+	}
+	ownerCovered := parentOwner == "*" || parentOwner == childOwner
+	repoCovered := parentRepo == "*" || parentRepo == childRepo
+	return ownerCovered && repoCovered
+}

--- a/internal/org/registry_test.go
+++ b/internal/org/registry_test.go
@@ -1,0 +1,157 @@
+package org
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const validRegistry = `
+[org]
+enforce = "block"
+
+[org.roles."owner"]
+scope = ["*"]
+merge_rule = "owner"
+
+[org.roles."platform"]
+parent = "owner"
+scope = ["gitmoot/*", "*/docs"]
+merge_rule = "parent"
+
+[org.roles."api"]
+parent = "platform"
+scope = ["gitmoot/api"]
+merge_rule = "review"
+`
+
+func TestParseRegistryValidHierarchyAndScope(t *testing.T) {
+	registry, err := ParseRegistry([]byte(validRegistry))
+	if err != nil {
+		t.Fatalf("ParseRegistry() error = %v", err)
+	}
+	if !registry.Enabled() || registry.Enforce != EnforceBlock || len(registry.Roles) != 3 {
+		t.Fatalf("registry = %+v", registry)
+	}
+	if got := registry.Path("api"); !reflect.DeepEqual(got, []string{"owner", "platform", "api"}) {
+		t.Fatalf("Path(api) = %v", got)
+	}
+	if got := registry.Children("owner"); len(got) != 1 || got[0].Name != "platform" {
+		t.Fatalf("Children(owner) = %+v", got)
+	}
+	if !registry.Matches("platform", "gitmoot/cli") || !registry.Matches("platform", "other/docs") || registry.Matches("platform", "other/api") {
+		t.Fatalf("scope matching did not honor configured patterns")
+	}
+}
+
+func TestParseRegistryAbsentIsDisabled(t *testing.T) {
+	tests := []string{
+		"[workflow]\nresult_checks = \"warn\"\n[[plugins]]\nname = \"org-helper\"\n",
+		"[organization]\nenabled = true\n",
+		"[orgchart]\nlayout = \"tree\"\n",
+		"[org]]\nenforce = \"block\"\n",
+		"[org\nenforce = \"block\"\n",
+		"[[org]]\nenforce = \"block\"\n",
+		"[[org.roles.\"owner\"]]\nscope = [\"*\"]\n",
+	}
+	for _, body := range tests {
+		registry, err := ParseRegistry([]byte(body))
+		if err != nil {
+			t.Errorf("ParseRegistry(%q) error = %v", body, err)
+			continue
+		}
+		if registry.Enabled() {
+			t.Errorf("ParseRegistry(%q) unexpectedly enabled: %+v", body, registry)
+		}
+	}
+}
+
+func TestParseRegistryRejectsMalformedFailClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "bad enforcement", body: strings.Replace(validRegistry, `"block"`, `"open"`, 1), want: "enforce"},
+		{name: "unquoted role header", body: strings.Replace(validRegistry, `[org.roles."platform"]`, `[org.roles.platform]`, 1), want: "section"},
+		{name: "bad org header", body: "[org.roles]\nname = \"x\"\n", want: "org role section"},
+		{name: "empty first duplicate enforcement", body: "[org]\nenforce = \"\"\nenforce = \"block\"\n[org.roles.\"owner\"]\nscope = [\"*\"]\nmerge_rule = \"owner\"\n", want: "duplicate [org].enforce"},
+		{name: "duplicate org", body: validRegistry + "\n[org]\nenforce = \"warn\"\n", want: "duplicate [org]"},
+		{name: "duplicate role", body: validRegistry + "\n[org.roles.\"api\"]\nscope = [\"*\"]\nmerge_rule = \"x\"\n", want: "duplicate org role"},
+		{name: "unknown field", body: strings.Replace(validRegistry, `merge_rule = "review"`, "merge_rule = \"review\"\nnetwork = true", 1), want: "unknown org role field"},
+		{name: "missing parent", body: strings.Replace(validRegistry, `parent = "platform"`, `parent = "missing"`, 1), want: "undeclared parent"},
+		{name: "multiple roots", body: strings.Replace(validRegistry, `parent = "owner"`, "", 1), want: "root org role"},
+		{name: "root not owner", body: strings.Replace(validRegistry, `"owner"`, `"lead"`, 1), want: "root org role"},
+		{name: "cycle", body: strings.Replace(validRegistry, "[org.roles.\"owner\"]\nscope", "[org.roles.\"owner\"]\nparent = \"api\"\nscope", 1), want: "exactly one root"},
+		{name: "scope broadens owner", body: strings.Replace(validRegistry, `scope = ["*"]`, `scope = ["gitmoot/*"]`, 1), want: "not a subset"},
+		{name: "scope broadens repo", body: strings.Replace(validRegistry, `scope = ["gitmoot/api"]`, `scope = ["other/api"]`, 1), want: "not a subset"},
+		{name: "invalid scope", body: strings.Replace(validRegistry, `scope = ["gitmoot/api"]`, `scope = ["gitmoot"]`, 1), want: "must be"},
+		{name: "empty scope", body: strings.Replace(validRegistry, `scope = ["gitmoot/api"]`, `scope = []`, 1), want: "non-empty scope"},
+		{name: "malformed field", body: strings.Replace(validRegistry, `merge_rule = "review"`, "merge_rule", 1), want: "malformed org field"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseRegistry([]byte(test.body))
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("ParseRegistry() error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestParseRegistryOptionalFieldsMatchConfigLoadOrg(t *testing.T) {
+	// #1057/#1073 reconcile: the [org] section, its enforce key, and a role's
+	// merge_rule are all OPTIONAL — matching the authoritative config.LoadOrg
+	// acceptance rule (enforce defaults to "block"; merge_rule is advisory in
+	// phase 1a). The presence of any [org.roles.*] enables the registry.
+	// Genuinely malformed input still fails closed (covered by the reject table).
+	for _, tc := range []struct{ name, body string }{
+		{"roles without [org] section", strings.Replace(validRegistry, "[org]\nenforce = \"block\"\n", "", 1)},
+		{"[org] without enforce key", strings.Replace(validRegistry, `enforce = "block"`, "", 1)},
+		{"role without merge_rule (advisory/optional)", strings.Replace(validRegistry, `merge_rule = "review"`, "", 1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reg, err := ParseRegistry([]byte(tc.body))
+			if err != nil {
+				t.Fatalf("ParseRegistry() error = %v, want valid", err)
+			}
+			if !reg.Enabled() {
+				t.Fatal("registry not enabled; any [org.roles.*] must enable it")
+			}
+			if reg.Enforce != EnforceBlock {
+				t.Fatalf("Enforce = %q, want default %q", reg.Enforce, EnforceBlock)
+			}
+		})
+	}
+}
+
+func TestRegistryPathTerminatesOnDirectCycle(t *testing.T) {
+	registry := Registry{Roles: map[string]Role{
+		"a": {Name: "a", Parent: "b"},
+		"b": {Name: "b", Parent: "a"},
+	}}
+	if got := registry.Path("a"); len(got) == 0 || len(got) > len(registry.Roles) {
+		t.Fatalf("Path(a) = %v, want a bounded non-empty path", got)
+	}
+}
+
+func TestScopeMatchesFrozenGrammar(t *testing.T) {
+	tests := []struct {
+		pattern string
+		repo    string
+		want    bool
+	}{
+		{"*", "gitmoot/gitmoot", true},
+		{"gitmoot/*", "gitmoot/gitmoot", true},
+		{"gitmoot/*", "other/gitmoot", false},
+		{"*/gitmoot", "other/gitmoot", true},
+		{"gitmoot/gitmoot", "gitmoot/gitmoot", true},
+		{"*/*", "gitmoot/gitmoot", false},
+		{"gitmoot", "gitmoot/gitmoot", false},
+	}
+	for _, test := range tests {
+		if got := ScopeMatches(test.pattern, test.repo); got != test.want {
+			t.Errorf("ScopeMatches(%q, %q) = %v, want %v", test.pattern, test.repo, got, test.want)
+		}
+	}
+}

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -56,6 +56,24 @@ func TestMailboxEnqueueCreatesQueuedJobAndEvent(t *testing.T) {
 	}
 }
 
+func TestMailboxPersistsActingOrgRoleProvenance(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	job, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+		ID: "org-role-job", Agent: "audit", Action: "ask", Repo: "gitmoot/gitmoot", ActingOrgRole: " owner ",
+	})
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	payload, err := ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload() error = %v", err)
+	}
+	if payload.ActingOrgRole != "owner" || !strings.Contains(job.Payload, `"acting_org_role":"owner"`) {
+		t.Fatalf("payload = %+v raw=%s", payload, job.Payload)
+	}
+}
+
 func TestMailboxProduceCheckRetriesSameSessionAndRecordsTokens(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)

--- a/internal/workflow/org_role_test.go
+++ b/internal/workflow/org_role_test.go
@@ -1,0 +1,18 @@
+package workflow
+
+import (
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+func TestDelegationRequestInheritsActingOrgRole(t *testing.T) {
+	request := (Engine{}).delegationRequest(
+		db.Job{ID: "root", Agent: "coordinator"},
+		JobPayload{Repo: "owner/repo", ActingOrgRole: "owner"},
+		Delegation{ID: "review", Agent: "reviewer", Action: "review", Prompt: "review it"},
+	)
+	if request.ActingOrgRole != "owner" {
+		t.Fatalf("ActingOrgRole = %q, want owner", request.ActingOrgRole)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1149,18 +1149,36 @@ at a PRIVATE repo unless the prompts are meant to be public.**
 
 ## Organization registry and scoped dispatch
 
+Organization mode is opt-in. Initialize a starter registry and verify the
+required Herdr provider (`>=0.7.5`) with:
+
+```sh
+gitmoot org init
+gitmoot org brief --role owner [--json]
+gitmoot org chart [--json]
+gitmoot org status [--json]
+```
+
 `gitmoot org validate [--home PATH]` validates the optional local `[org]`
 registry and prints its role count. `gitmoot org show [--home PATH]` prints the
-resolved role table. Any `[org.roles."name"]` section enables the registry.
-Roles have optional `parent`, `scope`, and advisory `merge_rule` (`owner`,
-`self`, or `none`); exactly one role has no parent. Scope is `*`, `owner/*`, or
-exact `owner/name`, and each child scope must be covered by its parent.
+resolved role table.
+
+The registry uses `[org] enforce = "warn"|"block"` and
+`[org.roles."name"]` entries with `parent`, `scope`, and `merge_rule`. There is
+exactly one root named `owner`; accepted scopes are `*`, `owner/*`, `*/repo`,
+and `owner/repo`, and each child scope must be covered by its parent. Malformed
+org configuration fails closed and loudly. `brief` records passive last-seen
+presence for its role and can render static context with provider state
+`unknown` during an outage; `chart` and `status` require a live compatible
+Herdr snapshot. Open escalations remain deferred to #1058's resolution and
+correlation contract.
 
 Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
-`orchestrate`, and `task run` dispatches pass `--org-role <role>` (or the narrow
-`GITMOOT_ORG_ROLE` fallback) when enabled. The role scope is enforced at
-enqueue. `[org] enforce = "block"` rejects violations; `"warn"` queues and
-records an `org_scope_violation` event.
+`orchestrate`, and `task run` dispatches accept `--org-role <name>` (or the
+narrow `GITMOOT_ORG_ROLE` fallback). The role is validated and touched before
+dispatch, stored as `acting_org_role` in the job payload for provenance, and
+its scope is enforced at enqueue. `[org] enforce = "block"` rejects violations;
+`"warn"` queues and records an `org_scope_violation` event.
 
 `gitmoot org escalate --to <ancestor-role> --workflow <label> [--org-role
 <from-role>] [--repo <owner/repo>] "<question>"` records an escalation as a

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -989,6 +989,32 @@ at a PRIVATE repo unless the prompts are meant to be public.** See the
 [template capture workflow](../workflows/template-capture-workflow.md#back-up-and-share-templates-via-github)
 for the full flow.
 
+## Organization Registry
+
+Organization mode is opt-in. Initialize a starter registry and verify the
+required Herdr provider (`>=0.7.5`) with:
+
+```sh
+gitmoot org init
+gitmoot org brief --role owner [--json]
+gitmoot org chart [--json]
+gitmoot org status [--json]
+```
+
+The registry uses `[org] enforce = "warn"|"block"` and
+`[org.roles."name"]` entries with `parent`, `scope`, and `merge_rule`. There is
+exactly one root named `owner`; accepted scopes are `*`, `owner/*`, `*/repo`,
+and `owner/repo`. Malformed org configuration fails closed and loudly. `brief`
+records passive last-seen presence for its role and can render static context
+with provider state `unknown` during an outage; `chart` and `status` require a
+live compatible Herdr snapshot. Escalations are recorded with `gitmoot org
+escalate`; their resolution and correlation surfaces are phase 2 work.
+
+Agent `ask`, `run`, `review`, `implement`, and `orchestrate` accept
+`--org-role <name>`. The role is validated and touched before dispatch, then
+stored as `acting_org_role` in the job payload for provenance, and its scope is
+enforced at enqueue. Capability booleans are not part of this phase.
+
 ## External-coordinator workflow groups
 
 Pass `--workflow <label>` to `agent ask`, `agent run`, `agent review`, `agent

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10674,18 +10674,36 @@ at a PRIVATE repo unless the prompts are meant to be public.**
 
 ## Organization registry and scoped dispatch
 
+Organization mode is opt-in. Initialize a starter registry and verify the
+required Herdr provider (`>=0.7.5`) with:
+
+```sh
+gitmoot org init
+gitmoot org brief --role owner [--json]
+gitmoot org chart [--json]
+gitmoot org status [--json]
+```
+
 `gitmoot org validate [--home PATH]` validates the optional local `[org]`
 registry and prints its role count. `gitmoot org show [--home PATH]` prints the
-resolved role table. Any `[org.roles."name"]` section enables the registry.
-Roles have optional `parent`, `scope`, and advisory `merge_rule` (`owner`,
-`self`, or `none`); exactly one role has no parent. Scope is `*`, `owner/*`, or
-exact `owner/name`, and each child scope must be covered by its parent.
+resolved role table.
+
+The registry uses `[org] enforce = "warn"|"block"` and
+`[org.roles."name"]` entries with `parent`, `scope`, and `merge_rule`. There is
+exactly one root named `owner`; accepted scopes are `*`, `owner/*`, `*/repo`,
+and `owner/repo`, and each child scope must be covered by its parent. Malformed
+org configuration fails closed and loudly. `brief` records passive last-seen
+presence for its role and can render static context with provider state
+`unknown` during an outage; `chart` and `status` require a live compatible
+Herdr snapshot. Open escalations remain deferred to #1058's resolution and
+correlation contract.
 
 Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
-`orchestrate`, and `task run` dispatches pass `--org-role <role>` (or the narrow
-`GITMOOT_ORG_ROLE` fallback) when enabled. The role scope is enforced at
-enqueue. `[org] enforce = "block"` rejects violations; `"warn"` queues and
-records an `org_scope_violation` event.
+`orchestrate`, and `task run` dispatches accept `--org-role <name>` (or the
+narrow `GITMOOT_ORG_ROLE` fallback). The role is validated and touched before
+dispatch, stored as `acting_org_role` in the job payload for provenance, and
+its scope is enforced at enqueue. `[org] enforce = "block"` rejects violations;
+`"warn"` queues and records an `org_scope_violation` event.
 
 `gitmoot org escalate --to <ancestor-role> --workflow <label> [--org-role
 <from-role>] [--repo <owner/repo>] "<question>"` records an escalation as a


### PR DESCRIPTION
## org phase 1b — brief/chart/status, passive presence, herdr provider seam, version gate (#1059)

Implements RFC #1042 phase 1b, built **against the frozen #1057 schema contract** (independent — does not depend on #1057's code landing; reconcilable later).

### The four pieces
1. **`gitmoot org brief --role X [--json]`** — generated thin boot context (role's chart position, parent/children/path, scope, merge rule, last-seen, live provider state) — the one-command respawn enabler.
2. **Passive presence** — `org_role_presence` SQLite table + store; last-seen per role, touched by any `--org-role` CLI call.
3. **`org chart` / `org status`** — hierarchy + liveness + herdr **lifecycle states** (`idle|working|blocked|done|unknown`) via an internal `org.Provider` seam (herdr v1 provider over `herdr api snapshot`, in `internal/cockpit/herdr_org.go`).
4. **herdr version gate** — `doctor.CheckHerdrVersion` (strict SemVer, require **≥0.7.5**, loud upgrade message; 0.7.0–0.7.4 have delivery bugs, no silent fallback), wired into `GlobalChecks` **only when org is enabled**. `org init` scaffolds a starter `[org]` and runs the gate.

### Design notes
- New `internal/org` package: the `[org]` registry (hand-rolled line-scanner via the `merge_gate` nested-section precedent) + validation (exactly-one-root=`owner`, no cycles, declared parents, **child scope ⊆ parent**). Malformed config is **fail-closed + loud**; absent = disabled.
- `config.LoadOrgRegistry` — named to avoid a future `LoadOrg` collision with #1057; reconcilable when #1057 lands.
- `--org-role` flag + `ActingOrgRole` payload provenance, threaded through dispatch and **inherited across the delegation tree** (additive — empty role is a pure no-op on every existing path).

### Deferrals (documented)
- Scope is **display-only** here — enforcement is #1057's job.
- **Open-escalations** wait on #1058's close/correlation contract (`TODO(#1058)`; no invented semantics).
- Capability booleans deferred per the contract.

### Review (`/code-review high`, three fresh-context finders)
Core logic confirmed **sound** — the registry is fail-closed (no constructible malformed config silently disables enforcement), the scope matcher is exact (no prefix/substring over-match), the provider maps unknown/missing/duplicate herdr labels to `unknown` (never a false idle or panic), the SemVer boundary is correct (0.7.4 rejected / 0.7.5 accepted, numeric compare), the migration is appended (positional), and the provenance is additive with complete delegation inheritance. Three **LOW** fixes applied: precise org-section-header recognition (a foreign `[organization]`/`[orgchart]` section no longer produces a false *required* doctor failure for non-org users), an empty-first-`enforce` duplicate guard, and a `Registry.Path()` cycle-safety visited-set.

Gate: `go build`/`vet`/`generate` clean, `gofmt` clean, `go test` green (org/config/db/doctor/cli/cockpit/workflow); `llms-full` regenerated. ~27 tests across all pieces.

## Deploy notes
Additive feature — off unless a `[org]` config exists; no behavior change for non-org users (empty `ActingOrgRole` is a no-op; the doctor gate only runs when org is enabled). One appended migration (`org_role_presence`), no destructive schema change. Standard `gitmoot` rebuild when deployed. **No deploy requested — owner-gated during the judging window.**

Closes #1059.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
