### PR TITLE
fix(config): require_workflow_mode is inert without an explicit enable (#1067)

### DIFF
--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -50,9 +50,10 @@ artifact_blobs = %q
 # planning context that a later goal-file import cannot reconstruct.
 # require_workflow is true by default. In the default auto mode, fresh unlabeled
 # agent dispatches are filed under adhoc/<agent>-<yyyy-mm-dd> and never
-# rejected. Set require_workflow = false to opt out, or require_workflow_mode =
-# "strict" to reject unlabeled dispatches. Both can be overridden in a flat
-# [repos."owner/repo"] section.
+# rejected. Set require_workflow = false to opt out. To reject unlabeled
+# dispatches, explicitly set require_workflow and set require_workflow_mode =
+# "strict"; a mode-only override remains inert for pre-#1053 compatibility.
+# Both can be overridden in a flat [repos."owner/repo"] section.
 # [workflow]
 # implement_base = "origin/main"
 # result_checks = "warn"

--- a/internal/config/require_workflow.go
+++ b/internal/config/require_workflow.go
@@ -15,7 +15,9 @@ type RequireWorkflowPolicy struct {
 	Mode    string
 }
 
-func defaultRequireWorkflowPolicy() RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "auto"} }
+func defaultRequireWorkflowPolicy() RequireWorkflowPolicy {
+	return RequireWorkflowPolicy{Enabled: true, Mode: "auto"}
+}
 
 // RequireWorkflowConfig holds global [workflow] defaults and flat
 // [repos."owner/repo"] overrides. Pointer fields preserve inheritance when a
@@ -31,17 +33,22 @@ type requireWorkflowOverride struct {
 }
 
 func (c RequireWorkflowConfig) For(repo string) RequireWorkflowPolicy {
+	repoOverride := c.repos[strings.TrimSpace(repo)]
+	enabledExplicit := c.global.enabled != nil || repoOverride.enabled != nil
 	p := defaultRequireWorkflowPolicy()
-	applyRequireWorkflowOverride(&p, c.global)
-	applyRequireWorkflowOverride(&p, c.repos[strings.TrimSpace(repo)])
+	applyRequireWorkflowOverride(&p, c.global, enabledExplicit)
+	applyRequireWorkflowOverride(&p, repoOverride, enabledExplicit)
 	return p
 }
 
-func applyRequireWorkflowOverride(p *RequireWorkflowPolicy, o requireWorkflowOverride) {
+func applyRequireWorkflowOverride(p *RequireWorkflowPolicy, o requireWorkflowOverride, applyMode bool) {
 	if o.enabled != nil {
 		p.Enabled = *o.enabled
 	}
-	if o.mode != nil {
+	// #1067: a mode-only override was inert before #1053 flipped the default
+	// enable to true. Honor mode only when the applicable global or repo policy
+	// explicitly sets require_workflow, preserving that compatibility boundary.
+	if applyMode && o.mode != nil {
 		p.Mode = *o.mode
 	}
 }
@@ -134,6 +141,9 @@ func applyRequireWorkflowField(o *requireWorkflowOverride, key, value string) er
 		v, err := strconv.Unquote(value)
 		if err != nil {
 			return err
+		}
+		if v != "auto" && v != "strict" {
+			return fmt.Errorf("require_workflow_mode must be \"auto\" or \"strict\"")
 		}
 		o.mode = &v
 	}

--- a/internal/config/require_workflow_test.go
+++ b/internal/config/require_workflow_test.go
@@ -41,10 +41,50 @@ func TestLoadRequireWorkflowDefaultsAndRejectsBadMode(t *testing.T) {
 	if got := cfg.For("a/b"); !got.Enabled || got.Mode != "auto" {
 		t.Fatalf("default=%+v", got)
 	}
-	if err := os.WriteFile(paths.ConfigFile, []byte("[workflow]\nrequire_workflow_mode = \"bad\"\n"), 0600); err != nil {
-		t.Fatal(err)
+	for _, body := range []string{
+		"[workflow]\nrequire_workflow_mode = \"bad\"\n",
+		"[workflow]\nrequire_workflow = true\nrequire_workflow_mode = \"bad\"\n",
+	} {
+		if err := os.WriteFile(paths.ConfigFile, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := LoadRequireWorkflow(paths); err == nil || !strings.Contains(err.Error(), "require_workflow_mode") {
+			t.Fatalf("LoadRequireWorkflow(%q) error=%v", body, err)
+		}
 	}
-	if _, err := LoadRequireWorkflow(paths); err == nil || !strings.Contains(err.Error(), "require_workflow_mode") {
-		t.Fatalf("error=%v", err)
+}
+
+func TestRequireWorkflowModeRequiresExplicitEnable(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		repo        string
+		wantEnabled bool
+		wantMode    string
+	}{
+		{name: "mode only stays auto", body: "[workflow]\nrequire_workflow_mode = \"strict\"\n", repo: "owner/repo", wantEnabled: true, wantMode: "auto"},
+		{name: "explicit global enable honors strict", body: "[workflow]\nrequire_workflow = true\nrequire_workflow_mode = \"strict\"\n", repo: "owner/repo", wantEnabled: true, wantMode: "strict"},
+		{name: "global enable activates repo mode", body: "[workflow]\nrequire_workflow = true\n[repos.\"owner/repo\"]\nrequire_workflow_mode = \"strict\"\n", repo: "owner/repo", wantEnabled: true, wantMode: "strict"},
+		{name: "explicit disable remains inert", body: "[workflow]\nrequire_workflow = false\nrequire_workflow_mode = \"strict\"\n", repo: "owner/repo", wantEnabled: false, wantMode: "strict"},
+		{name: "defaults stay enabled auto", body: "[workflow]\n", repo: "owner/repo", wantEnabled: true, wantMode: "auto"},
+		{name: "repo mode only stays auto", body: "[workflow]\n[repos.\"owner/repo\"]\nrequire_workflow_mode = \"strict\"\n", repo: "owner/repo", wantEnabled: true, wantMode: "auto"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(test.body), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadRequireWorkflow(paths)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := cfg.For(test.repo); got.Enabled != test.wantEnabled || got.Mode != test.wantMode {
+				t.Fatalf("For(%q) = %+v, want Enabled=%v Mode=%q", test.repo, got, test.wantEnabled, test.wantMode)
+			}
+		})
 	}
 }

--- a/internal/workflow/require_workflow_test.go
+++ b/internal/workflow/require_workflow_test.go
@@ -2,8 +2,11 @@ package workflow
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
 )
 
 func TestMailboxRequireWorkflow(t *testing.T) {
@@ -39,6 +42,54 @@ func TestMailboxRequireWorkflowStrictRejectsBeforeCreation(t *testing.T) {
 	}
 	if _, err := store.GetJob(ctx, "strict"); err == nil {
 		t.Fatal("strict rejection created a job")
+	}
+}
+
+func TestMailboxRequireWorkflowConfigCompatibility(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		body       string
+		wantStrict bool
+	}{
+		{name: "mode only auto files", body: "[workflow]\nrequire_workflow_mode = \"strict\"\n"},
+		{name: "explicit enable rejects", body: "[workflow]\nrequire_workflow = true\nrequire_workflow_mode = \"strict\"\n", wantStrict: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			paths := config.PathsForHome(t.TempDir())
+			if err := config.Initialize(paths); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte(test.body), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := config.LoadRequireWorkflow(paths)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := context.Background()
+			store := openTestStore(t)
+			mb := Mailbox{Store: store, RequireWorkflowPolicy: func(repo string) RequireWorkflowPolicy {
+				policy := cfg.For(repo)
+				return RequireWorkflowPolicy{Enabled: policy.Enabled, Mode: policy.Mode}
+			}}
+			job, err := mb.Enqueue(ctx, JobRequest{ID: "compat", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local"})
+			if test.wantStrict {
+				if err == nil || !strings.Contains(err.Error(), "pass --workflow") {
+					t.Fatalf("Enqueue() job=%+v err=%v, want strict rejection", job, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Enqueue() error = %v, want auto-file", err)
+			}
+			payload, err := ParseJobPayload(job.Payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.HasPrefix(payload.WorkflowID, "adhoc/") {
+				t.Fatalf("workflow_id = %q, want adhoc auto-file", payload.WorkflowID)
+			}
+		})
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1162,10 +1162,12 @@ continuation inherit it.
 `require_workflow` defaults to `true`. In the default `auto` mode, fresh
 unlabeled agent dispatches are filed as `adhoc/<agent>-<yyyy-mm-dd>` and emit a
 `workflow_autolabeled` event; they are never rejected. Set `[workflow]
-require_workflow = false` to opt a repository out, or set
-`require_workflow_mode = "strict"` to reject unlabeled dispatches with the
-required `--workflow <namespace>/<campaign>` fix. Both settings can be
-overridden per repository in `[repos."owner/repo"]`. GitHub comment dispatches
+require_workflow = false` to opt a repository out. To reject unlabeled
+dispatches, ensure the applicable global or repository policy explicitly sets
+`require_workflow = true`, then set `require_workflow_mode = "strict"`; the
+required fix is `--workflow <namespace>/<campaign>`. Mode-only legacy
+configurations remain in `auto`. Both settings can be overridden per repository
+in `[repos."owner/repo"]`. GitHub comment dispatches
 always take the auto-label path in either mode so acknowledgement ordering stays
 unchanged; engine PR reactions inherit their initiating dispatch's label instead.
 `gitmoot doctor` always reports unlabeled-job drift as advisory diagnostics

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1002,10 +1002,12 @@ Orchestration children and continuations inherit the label.
 `require_workflow` defaults to `true`. In the default `auto` mode, an unlabeled
 fresh agent dispatch is bucketed as `adhoc/<agent>-<yyyy-mm-dd>` and receives a
 `workflow_autolabeled` event; it is never rejected. Set `[workflow]
-require_workflow = false` to opt a repository out, or set
-`require_workflow_mode = "strict"` to reject unlabeled dispatches and require
-`--workflow <namespace>/<campaign>`. Both settings can be overridden in
-`[repos."owner/repo"]`. GitHub comment dispatches always take the auto-label
+require_workflow = false` to opt a repository out. To reject unlabeled
+dispatches, ensure the applicable global or repository policy explicitly sets
+`require_workflow = true`, then set `require_workflow_mode = "strict"` and pass
+`--workflow <namespace>/<campaign>`. Mode-only legacy configurations remain in
+`auto`. Both settings can be overridden in `[repos."owner/repo"]`. GitHub
+comment dispatches always take the auto-label
 path in either mode so acknowledgement ordering stays unchanged; engine PR
 reactions inherit their initiating dispatch's label instead. `gitmoot doctor`
 always reports unlabeled-job drift as advisory diagnostics (including

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10687,10 +10687,12 @@ continuation inherit it.
 `require_workflow` defaults to `true`. In the default `auto` mode, fresh
 unlabeled agent dispatches are filed as `adhoc/<agent>-<yyyy-mm-dd>` and emit a
 `workflow_autolabeled` event; they are never rejected. Set `[workflow]
-require_workflow = false` to opt a repository out, or set
-`require_workflow_mode = "strict"` to reject unlabeled dispatches with the
-required `--workflow <namespace>/<campaign>` fix. Both settings can be
-overridden per repository in `[repos."owner/repo"]`. GitHub comment dispatches
+require_workflow = false` to opt a repository out. To reject unlabeled
+dispatches, ensure the applicable global or repository policy explicitly sets
+`require_workflow = true`, then set `require_workflow_mode = "strict"`; the
+required fix is `--workflow <namespace>/<campaign>`. Mode-only legacy
+configurations remain in `auto`. Both settings can be overridden per repository
+in `[repos."owner/repo"]`. GitHub comment dispatches
 always take the auto-label path in either mode so acknowledgement ordering stays
 unchanged; engine PR reactions inherit their initiating dispatch's label instead.
 `gitmoot doctor` always reports unlabeled-job drift as advisory diagnostics


### PR DESCRIPTION
## `require_workflow_mode` is inert without an explicit enable (#1067)

The #1053 default flip (`defaultRequireWorkflowPolicy` → `{Enabled:true, Mode:"auto"}`) newly activated a pre-existing config that set **only** `require_workflow_mode = "strict"` without `require_workflow = true` — relying on the old default-off to keep it inert. Post-flip, `Enabled` defaulted to true, so `mode=strict` began **rejecting unlabeled dispatches** — a behavior change the operator's config never implied. (Surfaced by the #1057 xhigh review.)

### Fix — the compat rule (Option A)
A `require_workflow_mode` override is honored **only when `require_workflow` is explicitly set** by the applicable policy — global **or** the specific repo:
```go
enabledExplicit := c.global.enabled != nil || repoOverride.enabled != nil
// enabled applies unconditionally; mode applies only under enabledExplicit
```
A mode-only config falls back to the default mode (`auto`), exactly preserving its pre-#1053 non-rejecting behavior. Explicit opt-in (`require_workflow=true` + `mode=strict`) still enforces; global-enable + per-repo mode still inherits.

**Design-sanity:** chosen over the *warn-once migration* alternative, which still changes behavior (surprises the operator eventually) and needs migration state. Option A is stateless and preserves the exact prior behavior.

### Also — preserve invalid-mode validation
The raw `require_workflow_mode` value is now validated at **parse time** (must be `"auto"` or `"strict"`), so an invalid mode still errors loudly regardless of enable — the compat suppression would otherwise resolve a `mode="bad"`-without-enable to `auto` and hide it from the resolved-policy validator.

### Verification
- **Enforcement/enqueue paths (`mailbox.go`) untouched** — the fix changes only *resolution*, not enforcement.
- Tests cover **both directions** + all precedence combinations, each **RED-confirmed before the fix**: mode-only → auto (bug fixed) / explicit-strict → reject / global-enable + repo-mode → strict inheritance / explicit-disable → inert / default → auto / invalid `mode="bad"` → error (with and without enable). Cross-repo isolation verified (one repo opting in doesn't activate a global mode-only setting for another).
- Reviewed by a fresh-context finder + a prior design-sanity pass (`/code-review high`): compat logic + validation correct, no enforcement regression, docs accurate, `llms-full` byte-verified against its generator source (not drifted).
- Gate: `go build`/`vet`/`generate` clean, `gofmt` clean, `go test ./internal/config/ ./internal/workflow/` green.

## Deploy notes
Config-resolution compat fix — no schema change; the only behavior change is that a `require_workflow_mode` override without an explicit enable is (again) inert, restoring pre-#1053 behavior for those configs. Standard `gitmoot` rebuild when deployed. **No deploy requested — owner-gated during the judging window.**

Closes #1067.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
