### PR TITLE
feat(org): recycle-overdue detection (read-only) — org phase 3 slice 1 (#1061)

### DIFF
--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -260,6 +260,8 @@ type orgStatusOutput struct {
 	ProviderDetail  string             `json:"provider_detail,omitempty"`
 	ObservedAt      time.Time          `json:"observed_at,omitempty"`
 	ProviderVersion string             `json:"provider_version,omitempty"`
+	RecycleStatus   string             `json:"recycle,omitempty"`
+	RecycleAfter    string             `json:"recycle_after,omitempty"`
 }
 
 func runOrgBrief(args []string, stdout, stderr io.Writer) int {
@@ -377,10 +379,25 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 			live = org.RoleLiveState{State: org.StateUnknown, Detail: "provider snapshot omitted this role"}
 		}
 		seen := presence[role.Name]
+		recycleStatus := ""
+		recycleAfterText := ""
+		if command == "status" {
+			recycleAfter := cfg.RecycleAfterFor(role.Name)
+			if recycleAfter > 0 {
+				activeJobs, err := store.CountActiveJobsByOrgRole(ctx, role.Name)
+				if err != nil {
+					fmt.Fprintf(stderr, "org status: count active jobs for role %q: %v\n", role.Name, err)
+					return 1
+				}
+				recycleStatus = orgRecycleStatus(seen.LastSeenAt, observedNow, live.State, activeJobs, recycleAfter)
+				recycleAfterText = formatOrgRecycleAfter(recycleAfter)
+			}
+		}
 		rows = append(rows, orgStatusOutput{
 			Role: role.Name, Parent: role.Parent, Pane: role.Pane, Depth: len(cfg.Path(role.Name)) - 1,
 			Scope: role.Scope, MergeRule: role.MergeRule, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
 			ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: snapshot.ObservedAt, ProviderVersion: snapshot.ProviderVersion,
+			RecycleStatus: recycleStatus, RecycleAfter: recycleAfterText,
 		})
 	}
 	if command == "chart" {
@@ -402,9 +419,9 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 		}
 		return 0
 	}
-	fmt.Fprintln(stdout, "ROLE\tSTATE\tLAST SEEN\tAGE\tLAST COMMAND\tDETAIL")
+	fmt.Fprintln(stdout, "ROLE\tSTATE\tLAST SEEN\tAGE\tLAST COMMAND\tDETAIL\tRECYCLE")
 	for _, row := range rows {
-		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\n", row.Role, row.ProviderState, dash(row.LastSeenAt), dash(row.LastSeenAge), dash(row.LastCommand), dash(row.ProviderDetail))
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\trecycle=%s\n", row.Role, row.ProviderState, dash(row.LastSeenAt), dash(row.LastSeenAge), dash(row.LastCommand), dash(row.ProviderDetail), firstNonEmpty(row.RecycleStatus, "off"))
 	}
 	return 0
 }
@@ -496,19 +513,11 @@ func dash(value string) string {
 }
 
 func orgPresenceAge(value string, now time.Time) string {
-	value = strings.TrimSpace(value)
-	if value == "" {
+	if strings.TrimSpace(value) == "" {
 		return ""
 	}
-	var observed time.Time
-	var err error
-	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339Nano, time.RFC3339} {
-		observed, err = time.Parse(layout, value)
-		if err == nil {
-			break
-		}
-	}
-	if err != nil {
+	observed, ok := parseOrgPresenceTime(value)
+	if !ok {
 		return "unknown"
 	}
 	age := now.Sub(observed.UTC())
@@ -516,6 +525,59 @@ func orgPresenceAge(value string, now time.Time) string {
 		age = 0
 	}
 	return age.Round(time.Second).String()
+}
+
+func parseOrgPresenceTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339Nano, time.RFC3339} {
+		observed, err := time.Parse(layout, value)
+		if err == nil {
+			return observed, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func orgRecycleStatus(lastSeen string, now time.Time, state org.LifecycleState, activeJobs int, recycleAfter time.Duration) string {
+	if recycleAfter <= 0 {
+		return "off"
+	}
+	observed, ok := parseOrgPresenceTime(lastSeen)
+	if !ok {
+		return "off"
+	}
+	age := now.Sub(observed.UTC())
+	if age < 0 {
+		age = 0
+	}
+	if age < recycleAfter {
+		return "fresh"
+	}
+	if activeJobs > 0 {
+		return "overdue"
+	}
+	switch state {
+	case org.StateIdle, org.StateDone, org.StateUnknown:
+		return "eligible"
+	default:
+		return "overdue"
+	}
+}
+
+func formatOrgRecycleAfter(value time.Duration) string {
+	switch {
+	case value%time.Hour == 0:
+		return fmt.Sprintf("%dh", value/time.Hour)
+	case value%time.Minute == 0:
+		return fmt.Sprintf("%dm", value/time.Minute)
+	case value%time.Second == 0:
+		return fmt.Sprintf("%ds", value/time.Second)
+	default:
+		return value.String()
+	}
 }
 
 type orgEscalateOutput struct {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -367,6 +367,9 @@ func TestRunOrgBriefChartStatusAndPresence(t *testing.T) {
 	if strings.Contains(stdout.String(), `"pane"`) {
 		t.Fatalf("paneless status unexpectedly emitted pane: %s", stdout.String())
 	}
+	if strings.Contains(stdout.String(), `"recycle"`) {
+		t.Fatalf("status without recycle policy unexpectedly emitted recycle fields: %s", stdout.String())
+	}
 	var status []orgStatusOutput
 	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil || len(status) != 2 {
 		t.Fatalf("status = %+v err=%v output=%s", status, err, stdout.String())
@@ -421,6 +424,149 @@ func TestRunOrgBriefAndStatusJSONSurfacePane(t *testing.T) {
 		}
 	}
 	t.Fatalf("review role missing from status: %+v", status)
+}
+
+func TestOrgRecycleStatus(t *testing.T) {
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name         string
+		lastSeen     string
+		state        org.LifecycleState
+		activeJobs   int
+		recycleAfter time.Duration
+		want         string
+	}{
+		{name: "off without policy", lastSeen: now.Add(-48 * time.Hour).Format(time.RFC3339), state: org.StateIdle, want: "off"},
+		{name: "off without presence", state: org.StateIdle, recycleAfter: 24 * time.Hour, want: "off"},
+		{name: "fresh", lastSeen: now.Add(-time.Hour).Format(time.RFC3339), state: org.StateWorking, recycleAfter: 24 * time.Hour, want: "fresh"},
+		{name: "eligible idle", lastSeen: now.Add(-24 * time.Hour).Format(time.RFC3339), state: org.StateIdle, recycleAfter: 24 * time.Hour, want: "eligible"},
+		{name: "eligible done", lastSeen: now.Add(-25 * time.Hour).Format(time.RFC3339), state: org.StateDone, recycleAfter: 24 * time.Hour, want: "eligible"},
+		{name: "eligible unknown", lastSeen: now.Add(-25 * time.Hour).Format(time.RFC3339), state: org.StateUnknown, recycleAfter: 24 * time.Hour, want: "eligible"},
+		{name: "overdue working", lastSeen: now.Add(-25 * time.Hour).Format(time.RFC3339), state: org.StateWorking, recycleAfter: 24 * time.Hour, want: "overdue"},
+		{name: "overdue blocked", lastSeen: now.Add(-25 * time.Hour).Format(time.RFC3339), state: org.StateBlocked, recycleAfter: 24 * time.Hour, want: "overdue"},
+		{name: "overdue active job", lastSeen: now.Add(-25 * time.Hour).Format(time.RFC3339), state: org.StateIdle, activeJobs: 1, recycleAfter: 24 * time.Hour, want: "overdue"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := orgRecycleStatus(test.lastSeen, now, test.state, test.activeJobs, test.recycleAfter); got != test.want {
+				t.Fatalf("orgRecycleStatus() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestRunOrgStatusRecycleStates(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = file.WriteString(`
+[org]
+enforce = "warn"
+[org.roles."owner"]
+scope = ["*"]
+[org.roles."fresh"]
+parent = "owner"
+scope = ["*"]
+recycle_after = "24h"
+[org.roles."eligible"]
+parent = "owner"
+scope = ["*"]
+recycle_after = "1ns"
+[org.roles."working"]
+parent = "owner"
+scope = ["*"]
+recycle_after = "1ns"
+[org.roles."active"]
+parent = "owner"
+scope = ["*"]
+recycle_after = "1ns"
+`)
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	withOrgProvider(t, orgFixtureProvider{snapshot: org.Snapshot{
+		States: map[string]org.RoleLiveState{
+			"owner":    {State: org.StateUnknown},
+			"fresh":    {State: org.StateIdle},
+			"eligible": {State: org.StateDone},
+			"working":  {State: org.StateWorking},
+			"active":   {State: org.StateIdle},
+		},
+		ObservedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), ProviderVersion: "0.7.5",
+	}})
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	for _, role := range []string{"fresh", "eligible", "working", "active"} {
+		if err := store.TouchOrgRolePresence(ctx, role, "test"); err != nil {
+			store.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: "active-job", Agent: "worker", Type: "ask", State: "queued", Payload: `{"acting_org_role":"active"}`}); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "status", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status JSON code = %d stderr=%s", code, stderr.String())
+	}
+	var rows []orgStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("decode status: %v; output=%s", err, stdout.String())
+	}
+	want := map[string]struct{ status, after string }{
+		"owner":    {},
+		"fresh":    {status: "fresh", after: "24h"},
+		"eligible": {status: "eligible", after: "1ns"},
+		"working":  {status: "overdue", after: "1ns"},
+		"active":   {status: "overdue", after: "1ns"},
+	}
+	for _, row := range rows {
+		expected, ok := want[row.Role]
+		if !ok {
+			t.Fatalf("unexpected status role %+v", row)
+		}
+		if row.RecycleStatus != expected.status || row.RecycleAfter != expected.after {
+			t.Fatalf("status[%s] recycle=%q after=%q, want %q/%q", row.Role, row.RecycleStatus, row.RecycleAfter, expected.status, expected.after)
+		}
+		delete(want, row.Role)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing status roles: %+v", want)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"org", "status", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status text code = %d stderr=%s", code, stderr.String())
+	}
+	for role, expected := range map[string]string{"owner": "off", "fresh": "fresh", "eligible": "eligible", "working": "overdue", "active": "overdue"} {
+		found := false
+		for _, line := range strings.Split(stdout.String(), "\n") {
+			if strings.HasPrefix(line, role+"\t") && strings.Contains(line, "recycle="+expected) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("status text missing %s recycle=%s: %q", role, expected, stdout.String())
+		}
+	}
 }
 
 func TestRunOrgProviderFailureSemantics(t *testing.T) {

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -18,14 +19,16 @@ type OrgRole struct {
 	MergeRule string
 	// Pane optionally binds this role to a Herdr pane for event-rule wakes. It is
 	// advisory and unused unless an enabled event rule targets the role.
-	Pane string
+	Pane         string
+	RecycleAfter time.Duration
 }
 
 // OrgConfig is the local organization registry. Its fields stay private so the
 // loader remains the single place that establishes its invariants.
 type OrgConfig struct {
-	enforce string
-	roles   map[string]OrgRole
+	enforce      string
+	recycleAfter time.Duration
+	roles        map[string]OrgRole
 }
 
 func (c OrgConfig) Enabled() bool { return len(c.roles) > 0 }
@@ -40,6 +43,13 @@ func (c OrgConfig) Enforce() string {
 func (c OrgConfig) Role(name string) (OrgRole, bool) {
 	r, ok := c.roles[strings.ToLower(strings.TrimSpace(name))]
 	return r, ok
+}
+
+func (c OrgConfig) RecycleAfterFor(role string) time.Duration {
+	if configured, ok := c.Role(role); ok && configured.RecycleAfter != 0 {
+		return configured.RecycleAfter
+	}
+	return c.recycleAfter
 }
 
 // Ancestors returns name's parent chain, nearest parent first. The cycle guard
@@ -132,6 +142,7 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 	roleFields := map[string]map[string]bool{}
 	seenOrgSection := false
 	seenEnforce := false
+	seenRecycleAfter := false
 	current := ""
 	inOrg := false
 	lines := strings.Split(string(content), "\n")
@@ -186,21 +197,36 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 		}
 		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
 		if current == "" {
-			if key != "enforce" {
+			// recycle_after is binary-first: binaries predating this allowlist
+			// fail closed on a config that uses the field.
+			if key != "enforce" && key != "recycle_after" {
 				return OrgConfig{}, fmt.Errorf("unknown [org] field %q", key)
 			}
-			if seenEnforce {
-				return OrgConfig{}, fmt.Errorf("duplicate [org].enforce")
+			switch key {
+			case "enforce":
+				if seenEnforce {
+					return OrgConfig{}, fmt.Errorf("duplicate [org].enforce")
+				}
+				seenEnforce = true
+				v, err := parseOrgTOMLString(value)
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("parse [org].enforce: %w", err)
+				}
+				cfg.enforce = v
+			case "recycle_after":
+				if seenRecycleAfter {
+					return OrgConfig{}, fmt.Errorf("duplicate [org].recycle_after")
+				}
+				seenRecycleAfter = true
+				v, err := parseOrgDuration(value)
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("parse [org].recycle_after: %w", err)
+				}
+				cfg.recycleAfter = v
 			}
-			seenEnforce = true
-			v, err := parseOrgTOMLString(value)
-			if err != nil {
-				return OrgConfig{}, fmt.Errorf("parse [org].enforce: %w", err)
-			}
-			cfg.enforce = v
 			continue
 		}
-		if key != "parent" && key != "scope" && key != "merge_rule" && key != "pane" {
+		if key != "parent" && key != "scope" && key != "merge_rule" && key != "pane" && key != "recycle_after" {
 			return OrgConfig{}, fmt.Errorf("unknown field %q for org role %q", key, current)
 		}
 		if roleFields[current][key] {
@@ -247,6 +273,12 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 				return OrgConfig{}, fmt.Errorf("org role %q: parse pane: %w", current, err)
 			}
 			role.Pane = strings.TrimSpace(v)
+		case "recycle_after":
+			v, err := parseOrgDuration(value)
+			if err != nil {
+				return OrgConfig{}, fmt.Errorf("org role %q: parse recycle_after: %w", current, err)
+			}
+			role.RecycleAfter = v
 		}
 		cfg.roles[current] = role
 	}
@@ -314,6 +346,18 @@ func parseOrgTOMLString(value string) (string, error) {
 	return "", fmt.Errorf("expected quoted TOML string")
 }
 
+func parseOrgDuration(value string) (time.Duration, error) {
+	parsed, err := parseOrgTOMLString(value)
+	if err != nil {
+		return 0, err
+	}
+	duration, err := time.ParseDuration(parsed)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", parsed, err)
+	}
+	return duration, nil
+}
+
 // stripOrgConfigComment understands both TOML basic and literal strings. The
 // repo's older scanners only need basic strings; org also accepts TOML literals.
 func stripOrgConfigComment(value string) string {
@@ -344,6 +388,9 @@ func ValidateOrg(cfg OrgConfig) error {
 	if cfg.Enforce() != "block" && cfg.Enforce() != "warn" {
 		return fmt.Errorf("org enforce must be \"block\" or \"warn\"")
 	}
+	if cfg.recycleAfter < 0 {
+		return fmt.Errorf("org recycle_after must not be negative")
+	}
 	// Validate in sorted, structural passes so malformed registries return the
 	// same error regardless of Go map iteration order. Root naming deliberately
 	// precedes parent-reference checks, matching the retired Registry validator.
@@ -367,6 +414,9 @@ func ValidateOrg(cfg OrgConfig) error {
 		}
 		if role.MergeRule != "" && role.MergeRule != "owner" && role.MergeRule != "self" && role.MergeRule != "none" {
 			return fmt.Errorf("org role %q: invalid merge_rule %q", name, role.MergeRule)
+		}
+		if role.RecycleAfter < 0 {
+			return fmt.Errorf("org role %q: recycle_after must not be negative", name)
 		}
 		seenScope := map[string]bool{}
 		for _, scope := range role.Scope {

--- a/internal/config/org_test.go
+++ b/internal/config/org_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadOrgAndScopeMatching(t *testing.T) {
@@ -30,6 +31,77 @@ func TestLoadOrgAndScopeMatching(t *testing.T) {
 	}
 	if !ScopeMatches(role.Scope, "ACME/one") || !ScopeMatches([]string{"*"}, "any/repo") || ScopeMatches(role.Scope, "acme") || ScopeMatches(role.Scope, "wrong/repo") {
 		t.Fatal("scope matching mismatch")
+	}
+}
+
+func TestLoadOrgRecycleAfterPrecedence(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	content := `[org]
+recycle_after = "24h"
+[org.roles."owner"]
+scope = ["*"]
+[org.roles."platform"]
+parent = "owner"
+scope = ["gitmoot/*"]
+recycle_after = "12h"
+[org.roles."api"]
+parent = "platform"
+scope = ["gitmoot/api"]
+[org.roles."zero"]
+parent = "owner"
+scope = ["gitmoot/zero"]
+recycle_after = "0s"
+`
+	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.RecycleAfterFor("owner"); got != 24*time.Hour {
+		t.Fatalf("RecycleAfterFor(owner) = %s, want 24h", got)
+	}
+	if got := cfg.RecycleAfterFor("platform"); got != 12*time.Hour {
+		t.Fatalf("RecycleAfterFor(platform) = %s, want 12h", got)
+	}
+	if got := cfg.RecycleAfterFor("api"); got != 24*time.Hour {
+		t.Fatalf("RecycleAfterFor(api) = %s, want inherited 24h", got)
+	}
+	if got := cfg.RecycleAfterFor("zero"); got != 24*time.Hour {
+		t.Fatalf("RecycleAfterFor(zero) = %s, want zero override to inherit 24h", got)
+	}
+}
+
+func TestLoadOrgRecycleAfterFailsClosed(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "bad global", body: "[org]\nrecycle_after=\"tomorrow\"\n[org.roles.\"owner\"]\nscope=[\"*\"]\n", want: "recycle_after"},
+		{name: "negative global", body: "[org]\nrecycle_after=\"-1h\"\n[org.roles.\"owner\"]\nscope=[\"*\"]\n", want: "recycle_after must not be negative"},
+		{name: "bad role", body: "[org.roles.\"owner\"]\nscope=[\"*\"]\nrecycle_after=\"often\"\n", want: "recycle_after"},
+		{name: "negative role", body: "[org.roles.\"owner\"]\nscope=[\"*\"]\nrecycle_after=\"-30m\"\n", want: "recycle_after must not be negative"},
+		{name: "other unknown field", body: "[org]\nrecycle_after=\"24h\"\nunknown_recycle=true\n[org.roles.\"owner\"]\nscope=[\"*\"]\n", want: "unknown [org] field"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.WriteFile(paths.ConfigFile, []byte(test.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadOrg(paths); err == nil {
+				t.Fatal("LoadOrg() error = nil, want fail-closed rejection")
+			} else if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("LoadOrg() error = %q, want substring %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/db/org_recycle_store_test.go
+++ b/internal/db/org_recycle_store_test.go
@@ -1,0 +1,43 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+func TestCountActiveJobsByOrgRole(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	for _, job := range []Job{
+		{ID: "owner-queued", Agent: "a", Type: "ask", State: "queued", Payload: `{"acting_org_role":"owner"}`},
+		{ID: "owner-running", Agent: "a", Type: "ask", State: "running", Payload: `{"acting_org_role":"owner"}`},
+		{ID: "owner-terminal", Agent: "a", Type: "ask", State: "succeeded", Payload: `{"acting_org_role":"owner"}`},
+		{ID: "anchor", Agent: "a", Type: "ask", State: "queued", Payload: `{}`},
+		{ID: "review-queued", Agent: "a", Type: "ask", State: "queued", Payload: `{"acting_org_role":"review"}`},
+	} {
+		if err := store.CreateJob(ctx, job); err != nil {
+			t.Fatalf("CreateJob(%s): %v", job.ID, err)
+		}
+	}
+	for _, test := range []struct {
+		role string
+		want int
+	}{
+		{role: "owner", want: 2},
+		{role: "review", want: 1},
+		{role: "unrelated", want: 0},
+		// role arg is trim+lowered to match persisted (normalized) acting_org_role.
+		{role: "OWNER", want: 2},
+		{role: "  owner  ", want: 2},
+	} {
+		count, err := store.CountActiveJobsByOrgRole(ctx, test.role)
+		if err != nil || count != test.want {
+			t.Fatalf("CountActiveJobsByOrgRole(%q) = %d, %v; want %d", test.role, count, err, test.want)
+		}
+	}
+}

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -388,6 +388,19 @@ func (s *Store) CountQueuedJobsForRepo(ctx context.Context, repo string) (int, e
 	return count, err
 }
 
+// CountActiveJobsByOrgRole reports queued/running dispatched work attributed
+// to role. Anchor jobs omit acting_org_role and therefore do not count. The
+// role arg is trim+lowered to match how acting_org_role is persisted
+// (NormalizeActingOrgRole), so a non-normalized caller cannot silently
+// under-count — this method is trusted by phase-3 recycle enforcement.
+func (s *Store) CountActiveJobsByOrgRole(ctx context.Context, role string) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs
+		WHERE json_extract(payload, '$.acting_org_role') = ?
+		AND state IN ('queued', 'running')`, strings.ToLower(strings.TrimSpace(role))).Scan(&count)
+	return count, err
+}
+
 // listRunningJobsUpdatedBeforeSQL is ListRunningJobsUpdatedBefore's exact query,
 // exported as a package-level const so the plan test (TestListRunningJobsUpdatedBeforeOrder)
 // EXPLAINs the PRODUCTION text (binding the threshold as its `?` parameter) instead of


### PR DESCRIPTION
## What

First slice of RFC #1042 **phase 3** (session lifecycle / "enforced economics"). Detects when an org role is a stale, **recycle-overdue** coordinator session and surfaces it **read-only** on `gitmoot org status`. No enforcement or recycle action yet — that's slices 2–3. Part of #1061.

## Changes

- **`recycle_after` config** — a duration, global `[org] recycle_after = "24h"` default + per-role `[org.roles."x"] recycle_after` override (per-role wins via `RecycleAfterFor`). **Binary-first** (see below): added to the fail-closed field allowlists and validated (`ValidateOrg` rejects negative; unparseable → `LoadErr`).
- **`CountActiveJobsByOrgRole`** — `json_extract(payload,'$.acting_org_role')` + `state IN ('queued','running')`. `job open` anchors (no `acting_org_role`) and terminal/settled jobs don't count; the role arg is trim+lowered to match how `acting_org_role` is persisted.
- **Recycle predicate** `off | fresh | eligible | overdue` combining the three signals: **age** (last-seen presence), **activity** (provider lifecycle state), **workload** (active dispatched jobs). Missing/unparseable presence → `off` (conservative).
- **`org status`** gains a read-only `recycle=` column (text) + `recycle`/`recycle_after` JSON (`omitempty` — no-policy roles stay byte-compatible). `org chart` unchanged.

## Binary-first rider (from the #1075 ruling)

The org reader is now fail-closed on unknown fields. `recycle_after` is therefore **binary-first**: a config using it on a binary that predates this field fails closed (org → disabled). **Deploy the binary before any config sets `recycle_after`.**

## Review

Two fresh-context adversarial reviewers on an isolated read-only checkout (predicate/output correctness + config/query fail-closed), **zero blocking findings**. Both verified: all four labels reachable & correct; the `parseOrgPresenceTime` refactor is byte-equivalent (no `org status` output regression); binary-first allowlist accepts `recycle_after` while still rejecting unknown fields; negative/unparseable durations fail closed and are test-exercised; the SQL excludes anchors (json_extract NULL) and settled `blocked` jobs correctly. One shared non-blocking suggestion applied: normalize the query's role arg (trim+lower) so slice-2 enforcement — which will trust this method — can't under-count.

## Follow-ups (noted for slice 2)

- A role can't opt out of a global `recycle_after` via `"0s"` (0 = inherit) — revisit when enforcement makes an explicit "never recycle" value meaningful.
- Whether `blocked` in-flight jobs should influence the workload signal (currently excluded, matching the settled-state definition; provider-state `blocked` still flags a genuinely-stuck role).

## Sequence / deploy

Slice 1 of 3: **detection (this)** → dispatch-refusal enforcement → `org recycle` orchestration (herdr `agent start --kind` behind the provider seam). No deploy (judging window). Merge owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
