### PR TITLE
feat(org): org phase 2 slice 2a — blocked-since event source (#1060)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -181,9 +181,10 @@ synthesized `blocked_since` event matches only `blocked`. Set
 event when a task or Herdr role stays blocked past the threshold, re-nudging at
 most once per that interval while it remains blocked (so a dropped wake
 self-heals on the next interval instead of being lost); `0s` (the default)
-disables both evaluators. An episode is cleared only on a definitive non-blocked
-observation — a transient `unknown` snapshot never resets it — so a later
-re-block starts a fresh episode.
+disables both evaluators. An episode is cleared on a definitive non-blocked
+observation, or once the subject stops being observed blocked for a short grace
+(so a role gone for good is not leaked); a brief `unknown`/absent snapshot blip
+within that grace never resets it, and a later re-block starts a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/docs/events.md
+++ b/docs/events.md
@@ -113,7 +113,7 @@ Every event is a single JSON object:
 | `status`         | string | Terminal/lifecycle state (`succeeded`/`failed`/`blocked`/`awaiting_human`). |
 | `ts`             | string | RFC3339 emit time.                                                          |
 | `detail`         | string | Short redacted human-facing string (failure summary, the escalation question). |
-| `cause`          | string | Optional internal discriminator (`escalation`, `ask_gate`, `merge_guard`, or `permission_guard`). |
+| `cause`          | string | Optional internal discriminator (`escalation`, `ask_gate`, `merge_guard`, `permission_guard`, or `blocked_since`). |
 
 `cause` is an additive optional field, so `schema_version` remains `1` and
 existing events serialize unchanged. It is a trusted enum assigned at emit
@@ -175,7 +175,12 @@ gitmoot org events rule rm <rule-id>
 Kinds are `escalation`, `attention`, `guard`, `job-terminal`, and `blocked`.
 The v1 `--match` filter is a case-insensitive substring tested against the event
 repo and job id; empty matches all. A plain `job.blocked` event matches both
-`job-terminal` and `blocked`, while guard-caused blocks match `guard` first.
+`job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
+synthesized `blocked_since` event matches only `blocked`. Set
+`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit one
+such event when a task or Herdr role remains blocked past the threshold; `0s`
+(the default) disables both evaluators. The episode is cleared when the subject
+leaves blocked, so a later re-block can emit once again.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/docs/events.md
+++ b/docs/events.md
@@ -177,10 +177,13 @@ The v1 `--match` filter is a case-insensitive substring tested against the event
 repo and job id; empty matches all. A plain `job.blocked` event matches both
 `job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
 synthesized `blocked_since` event matches only `blocked`. Set
-`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit one
-such event when a task or Herdr role remains blocked past the threshold; `0s`
-(the default) disables both evaluators. The episode is cleared when the subject
-leaves blocked, so a later re-block can emit once again.
+`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit such an
+event when a task or Herdr role stays blocked past the threshold, re-nudging at
+most once per that interval while it remains blocked (so a dropped wake
+self-heals on the next interval instead of being lost); `0s` (the default)
+disables both evaluators. An episode is cleared only on a definitive non-blocked
+observation — a transient `unknown` snapshot never resets it — so a later
+re-block starts a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/docs/events.md
+++ b/docs/events.md
@@ -185,6 +185,8 @@ disables both evaluators. An episode is cleared on a definitive non-blocked
 observation, or once the subject stops being observed blocked for a short grace
 (so a role gone for good is not leaked); a brief `unknown`/absent snapshot blip
 within that grace never resets it, and a later re-block starts a fresh episode.
+Each synthesized event's `detail` carries the stable since-time, so a re-nudge
+(same `job_id` + same since) is distinguishable from a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -1,0 +1,298 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/cockpit"
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/events"
+	"github.com/gitmoot/gitmoot/internal/org"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const (
+	blockedRoleWakeInterval    = time.Minute
+	blockedRoleSnapshotTimeout = 5 * time.Second
+	blockedEpisodeTimeLayout   = "2006-01-02T15:04:05.000000000Z"
+)
+
+type blockedRoleAvailability interface {
+	Available(context.Context) bool
+}
+
+type blockedRoleWakeDependencies struct {
+	availability blockedRoleAvailability
+	provider     func([]string) org.Provider
+	eventSink    func(context.Context, *db.Store, string) (events.Sink, error)
+}
+
+func defaultBlockedRoleWakeDependencies() blockedRoleWakeDependencies {
+	return blockedRoleWakeDependencies{
+		availability: cockpit.New(cockpit.Options{HerdrBin: "herdr"}, nil),
+		provider:     cockpit.NewHerdrOrgProvider,
+		eventSink:    enabledBlockedSinceEventSink,
+	}
+}
+
+// enabledBlockedSinceEventSink preserves the blocked-since path's stricter
+// off-by-default contract: a configured webhook alone is not enough; at least
+// one enabled organization event rule must exist before either evaluator does
+// any episode work or emits a synthesized event.
+func enabledBlockedSinceEventSink(ctx context.Context, store *db.Store, home string) (events.Sink, error) {
+	if store == nil {
+		return nil, nil
+	}
+	rules, err := store.ListEventRules(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if !hasEnabledEventRule(rules) {
+		return nil, nil
+	}
+	return daemonEventSink(store, home), nil
+}
+
+// sweepBlockedTaskWakeEvents is the per-repo tick entrypoint. Every failure is
+// returned only for logging by the caller; it must never fail the daemon tick.
+func sweepBlockedTaskWakeEvents(ctx context.Context, store *db.Store, home, repo string, stdout io.Writer, now time.Time) error {
+	wakeAfter := resolveBlockedRoleWakeAfter(home)
+	if wakeAfter <= 0 {
+		return nil
+	}
+	sink, err := enabledBlockedSinceEventSink(ctx, store, home)
+	if err != nil || sink == nil {
+		return err
+	}
+	return evaluateBlockedTaskEpisodes(ctx, store, sink, repo, wakeAfter, stdout, now)
+}
+
+func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink events.Sink, repo string, wakeAfter time.Duration, stdout io.Writer, now time.Time) error {
+	if store == nil || sink == nil || wakeAfter <= 0 {
+		return nil
+	}
+	now = now.UTC()
+	blockedTasks, err := store.ListTasksByRepoState(ctx, repo, string(workflow.TaskBlocked))
+	if err != nil {
+		return err
+	}
+	blockedSubjects := make(map[string]struct{}, len(blockedTasks))
+	for _, task := range blockedTasks {
+		blockedSubjects[taskEpisodeSubject(repo, task.ID)] = struct{}{}
+	}
+	var candidates []db.StaleTaskCandidate
+	if len(blockedTasks) > 0 {
+		// Bound the stale projection to the current blocked population, rather
+		// than a fixed oldest-N window that could starve later task ids forever.
+		candidates, err = store.ListStaleTaskCandidates(ctx, repo, []string{string(workflow.TaskBlocked)}, now.Add(-wakeAfter), len(blockedTasks))
+		if err != nil {
+			return err
+		}
+	}
+
+	staleSubjects := make(map[string]string, len(candidates))
+	for _, candidate := range candidates {
+		subject := taskEpisodeSubject(repo, candidate.ID)
+		// Keep the current-state set as a defensive guard around the two-query
+		// snapshot. Do not open or emit an episode absent from that set.
+		if _, blocked := blockedSubjects[subject]; !blocked {
+			continue
+		}
+		blockedSince, err := parseTaskUpdatedAt(candidate.UpdatedAt)
+		if err != nil {
+			writeLine(stdout, "blocked_since task %s skipped: %v", candidate.ID, err)
+			continue
+		}
+		if err := store.UpsertBlockedEpisode(ctx, subject, blockedSince); err != nil {
+			writeLine(stdout, "blocked_since task %s episode upsert failed: %v", candidate.ID, err)
+			continue
+		}
+		staleSubjects[subject] = candidate.ID
+	}
+
+	episodes, err := store.ListBlockedEpisodes(ctx)
+	if err != nil {
+		return err
+	}
+	prefix := "task:" + strings.TrimSpace(repo) + ":"
+	for _, episode := range episodes {
+		if !strings.HasPrefix(episode.Subject, prefix) {
+			continue
+		}
+		if _, blocked := blockedSubjects[episode.Subject]; !blocked {
+			if err := store.ClearBlockedEpisode(ctx, episode.Subject); err != nil {
+				writeLine(stdout, "blocked_since task episode clear failed for %s: %v", episode.Subject, err)
+			}
+			continue
+		}
+		taskID, stale := staleSubjects[episode.Subject]
+		if !stale {
+			continue
+		}
+		if err := emitBlockedSinceEpisode(ctx, store, sink, episode, taskID, taskID, repo, "task "+taskID, wakeAfter, now); err != nil {
+			writeLine(stdout, "blocked_since task %s emit failed: %v", taskID, err)
+		}
+	}
+	return nil
+}
+
+// startBlockedRoleWakeLoop owns the single host-global Herdr blocked-role lane.
+// It is independent of repo ticks because a Herdr snapshot is host-global.
+func startBlockedRoleWakeLoop(ctx context.Context, store *db.Store, home string, stdout io.Writer) {
+	deps := defaultBlockedRoleWakeDependencies()
+	go func() {
+		ticker := time.NewTicker(blockedRoleWakeInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				runBlockedRoleWakeOnce(ctx, store, home, stdout, now.UTC(), deps)
+			}
+		}
+	}()
+}
+
+// runBlockedRoleWakeOnce performs one best-effort, dependency-injectable Herdr
+// evaluation. It swallows and logs every failure so the background lane can
+// never affect daemon supervision.
+func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, stdout io.Writer, now time.Time, deps blockedRoleWakeDependencies) {
+	wakeAfter := resolveBlockedRoleWakeAfter(home)
+	if wakeAfter <= 0 || store == nil || deps.eventSink == nil {
+		return
+	}
+	sink, err := deps.eventSink(ctx, store, home)
+	if err != nil {
+		writeLine(stdout, "blocked_since role event sink unavailable: %v", err)
+		return
+	}
+	if sink == nil || deps.availability == nil || !deps.availability.Available(ctx) {
+		return
+	}
+	configFile := resolveConfigFile(home)
+	if configFile == "" {
+		return
+	}
+	orgConfig, err := config.LoadOrg(config.Paths{ConfigFile: configFile})
+	if err != nil {
+		writeLine(stdout, "blocked_since role org config load failed: %v", err)
+		return
+	}
+	roles := orgConfig.Roles()
+	names := make([]string, 0, len(roles))
+	for _, role := range roles {
+		names = append(names, role.Name)
+	}
+	if deps.provider == nil {
+		return
+	}
+	provider := deps.provider(names)
+	if provider == nil {
+		return
+	}
+	snapshotCtx, cancel := context.WithTimeout(ctx, blockedRoleSnapshotTimeout)
+	snapshot, err := provider.Snapshot(snapshotCtx)
+	cancel()
+	if err != nil {
+		writeLine(stdout, "blocked_since role snapshot failed: %v", err)
+		return
+	}
+	if snapshot.ObservedAt.IsZero() {
+		writeLine(stdout, "blocked_since role snapshot skipped: observed_at is zero")
+		return
+	}
+	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snapshot, wakeAfter, stdout, now.UTC()); err != nil {
+		writeLine(stdout, "blocked_since role evaluation failed: %v", err)
+	}
+}
+
+func evaluateBlockedRoleEpisodes(ctx context.Context, store *db.Store, sink events.Sink, snapshot org.Snapshot, wakeAfter time.Duration, stdout io.Writer, now time.Time) error {
+	if store == nil || sink == nil || wakeAfter <= 0 {
+		return nil
+	}
+	blockedSubjects := map[string]string{}
+	readySubjects := map[string]struct{}{}
+	for role, live := range snapshot.States {
+		if live.State != org.StateBlocked {
+			continue
+		}
+		role = strings.TrimSpace(role)
+		if role == "" {
+			continue
+		}
+		subject := "role:" + role
+		blockedSubjects[subject] = role
+		if err := store.UpsertBlockedEpisode(ctx, subject, snapshot.ObservedAt); err != nil {
+			writeLine(stdout, "blocked_since role %s episode upsert failed: %v", role, err)
+			continue
+		}
+		readySubjects[subject] = struct{}{}
+	}
+
+	episodes, err := store.ListBlockedEpisodes(ctx)
+	if err != nil {
+		return err
+	}
+	for _, episode := range episodes {
+		if !strings.HasPrefix(episode.Subject, "role:") {
+			continue
+		}
+		role, blocked := blockedSubjects[episode.Subject]
+		if !blocked {
+			if err := store.ClearBlockedEpisode(ctx, episode.Subject); err != nil {
+				writeLine(stdout, "blocked_since role episode clear failed for %s: %v", episode.Subject, err)
+			}
+			continue
+		}
+		if _, ready := readySubjects[episode.Subject]; !ready {
+			continue
+		}
+		subjectID := "org-blocked:" + role
+		if err := emitBlockedSinceEpisode(ctx, store, sink, episode, subjectID, subjectID, "", "role "+role, wakeAfter, now); err != nil {
+			writeLine(stdout, "blocked_since role %s emit failed: %v", role, err)
+		}
+	}
+	return nil
+}
+
+func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.Sink, episode db.BlockedEpisode, subjectID, rootID, repo, detailSubject string, wakeAfter time.Duration, now time.Time) error {
+	if strings.TrimSpace(episode.EmittedAt) != "" {
+		return nil
+	}
+	blockedSince, err := time.Parse(blockedEpisodeTimeLayout, episode.BlockedSince)
+	if err != nil {
+		return fmt.Errorf("parse blocked_since %q: %w", episode.BlockedSince, err)
+	}
+	blockedFor := now.UTC().Sub(blockedSince)
+	if blockedFor <= wakeAfter {
+		return nil
+	}
+	if blockedFor < 0 {
+		blockedFor = 0
+	}
+	blockedFor = blockedFor.Round(time.Second)
+	detail := fmt.Sprintf("%s blocked %s", detailSubject, blockedFor)
+	ev := events.NewEvent(events.EventJobBlocked, subjectID, rootID, repo, string(workflow.TaskBlocked), detail, now, workflow.RedactCommentText)
+	ev.Cause = "blocked_since"
+	events.EmitEvent(ctx, sink, ev)
+	return store.MarkBlockedEpisodeEmitted(ctx, episode.Subject)
+}
+
+func taskEpisodeSubject(repo, taskID string) string {
+	return "task:" + strings.TrimSpace(repo) + ":" + strings.TrimSpace(taskID)
+}
+
+func parseTaskUpdatedAt(raw string) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339Nano, blockedEpisodeTimeLayout} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("parse task updated_at %q", raw)
+}

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -18,7 +18,13 @@ import (
 const (
 	blockedRoleWakeInterval    = time.Minute
 	blockedRoleSnapshotTimeout = 5 * time.Second
-	blockedEpisodeTimeLayout   = "2006-01-02T15:04:05.000000000Z"
+	// blockedEpisodeStaleGap bounds how long a role episode survives without being
+	// re-observed blocked. Within it, a transient unknown/absent snapshot blip is
+	// tolerated (the accrued blocked duration is preserved); beyond it the subject is
+	// treated as no longer blocked (unblocked undetected, or the role gone for good)
+	// and the episode is reaped — so a permanently-unknown role neither leaks a row
+	// nor reuses a stale blocked_since on a later re-block.
+	blockedEpisodeStaleGap = 5 * blockedRoleWakeInterval
 )
 
 type blockedRoleAvailability interface {
@@ -107,22 +113,22 @@ func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink even
 			writeLine(stdout, "blocked_since task %s skipped: unparseable updated_at %q", candidate.ID, candidate.UpdatedAt)
 			continue
 		}
-		if err := store.UpsertBlockedEpisode(ctx, subject, blockedSince); err != nil {
+		if err := store.UpsertBlockedEpisode(ctx, subject, blockedSince, now); err != nil {
 			writeLine(stdout, "blocked_since task %s episode upsert failed: %v", candidate.ID, err)
 			continue
 		}
 		staleSubjects[subject] = candidate.ID
 	}
 
-	episodes, err := store.ListBlockedEpisodes(ctx)
+	// Prefix-scoped so a per-repo tick reads only this repo's task episodes.
+	episodes, err := store.ListBlockedEpisodesByPrefix(ctx, "task:"+strings.TrimSpace(repo)+":")
 	if err != nil {
 		return err
 	}
-	prefix := "task:" + strings.TrimSpace(repo) + ":"
 	for _, episode := range episodes {
-		if !strings.HasPrefix(episode.Subject, prefix) {
-			continue
-		}
+		// Tasks have an authoritative blocked set (gitmoot's own state), so an
+		// episode whose task is no longer blocked is cleared immediately — no
+		// staleness heuristic needed (unlike the ambiguous Herdr role source).
 		if _, blocked := blockedSubjects[episode.Subject]; !blocked {
 			if err := store.ClearBlockedEpisode(ctx, episode.Subject); err != nil {
 				writeLine(stdout, "blocked_since task episode clear failed for %s: %v", episode.Subject, err)
@@ -227,7 +233,7 @@ func evaluateBlockedRoleEpisodes(ctx context.Context, store *db.Store, sink even
 		switch live.State {
 		case org.StateBlocked:
 			blockedSubjects[subject] = role
-			if err := store.UpsertBlockedEpisode(ctx, subject, snapshot.ObservedAt); err != nil {
+			if err := store.UpsertBlockedEpisode(ctx, subject, snapshot.ObservedAt, now); err != nil {
 				writeLine(stdout, "blocked_since role %s episode upsert failed: %v", role, err)
 				continue
 			}
@@ -242,14 +248,13 @@ func evaluateBlockedRoleEpisodes(ctx context.Context, store *db.Store, sink even
 		}
 	}
 
-	episodes, err := store.ListBlockedEpisodes(ctx)
+	// Prefix-scoped read of only the role episodes.
+	episodes, err := store.ListBlockedEpisodesByPrefix(ctx, "role:")
 	if err != nil {
 		return err
 	}
+	staleBefore := now.Add(-blockedEpisodeStaleGap)
 	for _, episode := range episodes {
-		if !strings.HasPrefix(episode.Subject, "role:") {
-			continue
-		}
 		if role, blocked := blockedSubjects[episode.Subject]; blocked {
 			if _, ready := readySubjects[episode.Subject]; !ready {
 				continue
@@ -260,7 +265,11 @@ func evaluateBlockedRoleEpisodes(ctx context.Context, store *db.Store, sink even
 			}
 			continue
 		}
-		if _, confirmed := confirmedUnblocked[episode.Subject]; confirmed {
+		// Not observed blocked this tick. Clear on a DEFINITIVE non-blocked state, or
+		// once the episode has gone STALE (not re-observed blocked within the gap) —
+		// reaping a role gone permanently unknown/absent without letting a single
+		// transient blip discard the accrued duration or leak the row forever.
+		if _, confirmed := confirmedUnblocked[episode.Subject]; confirmed || blockedEpisodeStale(episode.UpdatedAt, staleBefore) {
 			if err := store.ClearBlockedEpisode(ctx, episode.Subject); err != nil {
 				writeLine(stdout, "blocked_since role episode clear failed for %s: %v", episode.Subject, err)
 			}
@@ -269,9 +278,20 @@ func evaluateBlockedRoleEpisodes(ctx context.Context, store *db.Store, sink even
 	return nil
 }
 
+// blockedEpisodeStale reports whether an episode's last blocked observation
+// (updatedAt, fixed-width UTC) is at or before staleBefore. An unparseable stamp
+// is treated as stale so a malformed row can never linger forever.
+func blockedEpisodeStale(updatedAt string, staleBefore time.Time) bool {
+	parsed, err := time.Parse(db.BlockedEpisodeTimeLayout, strings.TrimSpace(updatedAt))
+	if err != nil {
+		return true
+	}
+	return !parsed.After(staleBefore)
+}
+
 func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.Sink, episode db.BlockedEpisode, subjectID, rootID, repo, detailSubject string, wakeAfter time.Duration, now time.Time) error {
 	now = now.UTC()
-	blockedSince, err := time.Parse(blockedEpisodeTimeLayout, episode.BlockedSince)
+	blockedSince, err := time.Parse(db.BlockedEpisodeTimeLayout, episode.BlockedSince)
 	if err != nil {
 		return fmt.Errorf("parse blocked_since %q: %w", episode.BlockedSince, err)
 	}
@@ -284,7 +304,7 @@ func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.S
 	// is dropped downstream (herdr briefly down, a transient sink, a mark-write
 	// failure) self-heals on the next interval instead of being lost forever.
 	if last := strings.TrimSpace(episode.EmittedAt); last != "" {
-		if lastEmitted, err := time.Parse(blockedEpisodeTimeLayout, last); err == nil && now.Sub(lastEmitted) <= wakeAfter {
+		if lastEmitted, err := time.Parse(db.BlockedEpisodeTimeLayout, last); err == nil && now.Sub(lastEmitted) <= wakeAfter {
 			return nil // already nudged within the current interval
 		}
 	}

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -102,9 +102,9 @@ func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink even
 		if _, blocked := blockedSubjects[subject]; !blocked {
 			continue
 		}
-		blockedSince, err := parseTaskUpdatedAt(candidate.UpdatedAt)
-		if err != nil {
-			writeLine(stdout, "blocked_since task %s skipped: %v", candidate.ID, err)
+		blockedSince := parseTranscriptStoreTime(candidate.UpdatedAt)
+		if blockedSince.IsZero() {
+			writeLine(stdout, "blocked_since task %s skipped: unparseable updated_at %q", candidate.ID, candidate.UpdatedAt)
 			continue
 		}
 		if err := store.UpsertBlockedEpisode(ctx, subject, blockedSince); err != nil {
@@ -217,21 +217,29 @@ func evaluateBlockedRoleEpisodes(ctx context.Context, store *db.Store, sink even
 	}
 	blockedSubjects := map[string]string{}
 	readySubjects := map[string]struct{}{}
+	confirmedUnblocked := map[string]struct{}{}
 	for role, live := range snapshot.States {
-		if live.State != org.StateBlocked {
-			continue
-		}
 		role = strings.TrimSpace(role)
 		if role == "" {
 			continue
 		}
 		subject := "role:" + role
-		blockedSubjects[subject] = role
-		if err := store.UpsertBlockedEpisode(ctx, subject, snapshot.ObservedAt); err != nil {
-			writeLine(stdout, "blocked_since role %s episode upsert failed: %v", role, err)
-			continue
+		switch live.State {
+		case org.StateBlocked:
+			blockedSubjects[subject] = role
+			if err := store.UpsertBlockedEpisode(ctx, subject, snapshot.ObservedAt); err != nil {
+				writeLine(stdout, "blocked_since role %s episode upsert failed: %v", role, err)
+				continue
+			}
+			readySubjects[subject] = struct{}{}
+		case org.StateIdle, org.StateWorking, org.StateDone:
+			// A DEFINITIVE non-blocked observation is the only thing that closes an
+			// episode. StateUnknown — or a role absent from the snapshot (pane recycle,
+			// transient agent_status, a brief exact-label mismatch) — is ambiguous and
+			// MUST NOT clear the episode, else a momentary blip would discard the
+			// accrued blocked duration and reset the wake timer.
+			confirmedUnblocked[subject] = struct{}{}
 		}
-		readySubjects[subject] = struct{}{}
 	}
 
 	episodes, err := store.ListBlockedEpisodes(ctx)
@@ -242,57 +250,58 @@ func evaluateBlockedRoleEpisodes(ctx context.Context, store *db.Store, sink even
 		if !strings.HasPrefix(episode.Subject, "role:") {
 			continue
 		}
-		role, blocked := blockedSubjects[episode.Subject]
-		if !blocked {
-			if err := store.ClearBlockedEpisode(ctx, episode.Subject); err != nil {
-				writeLine(stdout, "blocked_since role episode clear failed for %s: %v", episode.Subject, err)
+		if role, blocked := blockedSubjects[episode.Subject]; blocked {
+			if _, ready := readySubjects[episode.Subject]; !ready {
+				continue
+			}
+			subjectID := "org-blocked:" + role
+			if err := emitBlockedSinceEpisode(ctx, store, sink, episode, subjectID, subjectID, "", "role "+role, wakeAfter, now); err != nil {
+				writeLine(stdout, "blocked_since role %s emit failed: %v", role, err)
 			}
 			continue
 		}
-		if _, ready := readySubjects[episode.Subject]; !ready {
-			continue
-		}
-		subjectID := "org-blocked:" + role
-		if err := emitBlockedSinceEpisode(ctx, store, sink, episode, subjectID, subjectID, "", "role "+role, wakeAfter, now); err != nil {
-			writeLine(stdout, "blocked_since role %s emit failed: %v", role, err)
+		if _, confirmed := confirmedUnblocked[episode.Subject]; confirmed {
+			if err := store.ClearBlockedEpisode(ctx, episode.Subject); err != nil {
+				writeLine(stdout, "blocked_since role episode clear failed for %s: %v", episode.Subject, err)
+			}
 		}
 	}
 	return nil
 }
 
 func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.Sink, episode db.BlockedEpisode, subjectID, rootID, repo, detailSubject string, wakeAfter time.Duration, now time.Time) error {
-	if strings.TrimSpace(episode.EmittedAt) != "" {
-		return nil
-	}
+	now = now.UTC()
 	blockedSince, err := time.Parse(blockedEpisodeTimeLayout, episode.BlockedSince)
 	if err != nil {
 		return fmt.Errorf("parse blocked_since %q: %w", episode.BlockedSince, err)
 	}
-	blockedFor := now.UTC().Sub(blockedSince)
+	blockedFor := now.Sub(blockedSince)
 	if blockedFor <= wakeAfter {
-		return nil
+		return nil // not blocked long enough yet
 	}
-	if blockedFor < 0 {
-		blockedFor = 0
+	// Re-nudge at most once per wakeAfter interval while the subject stays blocked
+	// (an alert repeat_interval), rather than a single durable one-shot: a wake that
+	// is dropped downstream (herdr briefly down, a transient sink, a mark-write
+	// failure) self-heals on the next interval instead of being lost forever.
+	if last := strings.TrimSpace(episode.EmittedAt); last != "" {
+		if lastEmitted, err := time.Parse(blockedEpisodeTimeLayout, last); err == nil && now.Sub(lastEmitted) <= wakeAfter {
+			return nil // already nudged within the current interval
+		}
 	}
-	blockedFor = blockedFor.Round(time.Second)
-	detail := fmt.Sprintf("%s blocked %s", detailSubject, blockedFor)
+	// Mark BEFORE emit: a mark-write failure then means no emit this tick (retry
+	// next tick, the gate is still open) — never a per-tick duplicate — and a
+	// mark-success whose async wake is dropped re-nudges on the next interval.
+	if err := store.MarkBlockedEpisodeEmitted(ctx, episode.Subject, now); err != nil {
+		return fmt.Errorf("mark blocked episode emitted: %w", err)
+	}
+	detail := fmt.Sprintf("%s blocked %s", detailSubject, blockedFor.Round(time.Second))
 	ev := events.NewEvent(events.EventJobBlocked, subjectID, rootID, repo, string(workflow.TaskBlocked), detail, now, workflow.RedactCommentText)
 	ev.Cause = "blocked_since"
 	events.EmitEvent(ctx, sink, ev)
-	return store.MarkBlockedEpisodeEmitted(ctx, episode.Subject)
+	return nil
 }
 
 func taskEpisodeSubject(repo, taskID string) string {
 	return "task:" + strings.TrimSpace(repo) + ":" + strings.TrimSpace(taskID)
 }
 
-func parseTaskUpdatedAt(raw string) (time.Time, error) {
-	raw = strings.TrimSpace(raw)
-	for _, layout := range []string{"2006-01-02 15:04:05", time.RFC3339Nano, blockedEpisodeTimeLayout} {
-		if parsed, err := time.Parse(layout, raw); err == nil {
-			return parsed.UTC(), nil
-		}
-	}
-	return time.Time{}, fmt.Errorf("parse task updated_at %q", raw)
-}

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -120,12 +120,18 @@ func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink even
 		staleSubjects[subject] = candidate.ID
 	}
 
-	// Prefix-scoped so a per-repo tick reads only this repo's task episodes.
-	episodes, err := store.ListBlockedEpisodesByPrefix(ctx, "task:"+strings.TrimSpace(repo)+":")
+	// The episode table is tiny (off-by-default, few blocked subjects), so a full
+	// list + byte-exact Go prefix filter is negligible and — unlike a SQL LIKE —
+	// cannot case-fold a sibling repo whose name differs only in ASCII case.
+	episodes, err := store.ListBlockedEpisodes(ctx)
 	if err != nil {
 		return err
 	}
+	taskPrefix := "task:" + strings.TrimSpace(repo) + ":"
 	for _, episode := range episodes {
+		if !strings.HasPrefix(episode.Subject, taskPrefix) {
+			continue
+		}
 		// Tasks have an authoritative blocked set (gitmoot's own state), so an
 		// episode whose task is no longer blocked is cleared immediately — no
 		// staleness heuristic needed (unlike the ambiguous Herdr role source).
@@ -248,13 +254,15 @@ func evaluateBlockedRoleEpisodes(ctx context.Context, store *db.Store, sink even
 		}
 	}
 
-	// Prefix-scoped read of only the role episodes.
-	episodes, err := store.ListBlockedEpisodesByPrefix(ctx, "role:")
+	episodes, err := store.ListBlockedEpisodes(ctx)
 	if err != nil {
 		return err
 	}
 	staleBefore := now.Add(-blockedEpisodeStaleGap)
 	for _, episode := range episodes {
+		if !strings.HasPrefix(episode.Subject, "role:") {
+			continue
+		}
 		if role, blocked := blockedSubjects[episode.Subject]; blocked {
 			if _, ready := readySubjects[episode.Subject]; !ready {
 				continue
@@ -314,7 +322,10 @@ func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.S
 	if err := store.MarkBlockedEpisodeEmitted(ctx, episode.Subject, now); err != nil {
 		return fmt.Errorf("mark blocked episode emitted: %w", err)
 	}
-	detail := fmt.Sprintf("%s blocked %s", detailSubject, blockedFor.Round(time.Second))
+	// Carry the stable first_since (blocked_since) so a consumer distinguishes a
+	// re-nudge (same job_id + same since) from a genuinely fresh episode after a
+	// re-block (same job_id, new since) — a repeat must not read as a fresh alert.
+	detail := fmt.Sprintf("%s blocked %s (since %s)", detailSubject, blockedFor.Round(time.Second), blockedSince.UTC().Format(time.RFC3339))
 	ev := events.NewEvent(events.EventJobBlocked, subjectID, rootID, repo, string(workflow.TaskBlocked), detail, now, workflow.RedactCommentText)
 	ev.Cause = "blocked_since"
 	events.EmitEvent(ctx, sink, ev)

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -1,0 +1,182 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/events"
+	"github.com/gitmoot/gitmoot/internal/org"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestBlockedSinceAdmissionIsOffByDefaultAndRequiresEnabledRule(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	if sink, err := enabledBlockedSinceEventSink(ctx, store, ""); err != nil || sink != nil {
+		t.Fatalf("sink with zero rules = %T, err=%v; want nil", sink, err)
+	}
+	if err := store.AddEventRule(ctx, db.EventRule{ID: "disabled", OnKind: "blocked", WakeRole: "owner", Enabled: false}); err != nil {
+		t.Fatal(err)
+	}
+	if sink, err := enabledBlockedSinceEventSink(ctx, store, ""); err != nil || sink != nil {
+		t.Fatalf("sink with disabled rule = %T, err=%v; want nil", sink, err)
+	}
+	if err := store.AddEventRule(ctx, db.EventRule{ID: "enabled", OnKind: "blocked", WakeRole: "owner", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	if sink, err := enabledBlockedSinceEventSink(ctx, store, ""); err != nil || sink == nil {
+		t.Fatalf("sink with enabled rule = %T, err=%v; want non-nil", sink, err)
+	}
+}
+
+func TestEvaluateBlockedTaskEpisodesEmitsOnceAndReopensAfterClear(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	repo := "owner/repo"
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: repo, State: string(workflow.TaskBlocked)}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second).Add(2 * time.Hour)
+	sink := &recordingSink{}
+
+	if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, time.Hour, io.Discard, now); err != nil {
+		t.Fatalf("evaluateBlockedTaskEpisodes(first) error = %v", err)
+	}
+	assertBlockedSinceTaskEvent(t, sink, 1)
+	if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, time.Hour, io.Discard, now.Add(time.Minute)); err != nil {
+		t.Fatalf("evaluateBlockedTaskEpisodes(second) error = %v", err)
+	}
+	assertBlockedSinceTaskEvent(t, sink, 1)
+
+	changed, _, err := store.CompareAndSwapTaskState(ctx, "task-1", string(workflow.TaskBlocked), string(workflow.TaskMerged))
+	if err != nil || !changed {
+		t.Fatalf("unblock task: changed=%v err=%v", changed, err)
+	}
+	if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, time.Hour, io.Discard, now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("evaluateBlockedTaskEpisodes(clear) error = %v", err)
+	}
+	episodes, err := store.ListBlockedEpisodes(ctx)
+	if err != nil || len(episodes) != 0 {
+		t.Fatalf("episodes after unblock = %+v, err=%v", episodes, err)
+	}
+
+	changed, _, err = store.CompareAndSwapTaskState(ctx, "task-1", string(workflow.TaskMerged), string(workflow.TaskBlocked))
+	if err != nil || !changed {
+		t.Fatalf("re-block task: changed=%v err=%v", changed, err)
+	}
+	if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, time.Hour, io.Discard, now.Add(3*time.Minute)); err != nil {
+		t.Fatalf("evaluateBlockedTaskEpisodes(re-block) error = %v", err)
+	}
+	assertBlockedSinceTaskEvent(t, sink, 2)
+}
+
+func assertBlockedSinceTaskEvent(t *testing.T, sink *recordingSink, want int) {
+	t.Helper()
+	blocked := sink.byType(events.EventJobBlocked)
+	if len(blocked) != want {
+		t.Fatalf("job.blocked events = %d, want %d", len(blocked), want)
+	}
+	if want == 0 {
+		return
+	}
+	ev := blocked[len(blocked)-1]
+	if ev.Cause != "blocked_since" || ev.JobID != "task-1" || ev.RootID != "task-1" || ev.Repo != "owner/repo" || ev.Status != string(workflow.TaskBlocked) {
+		t.Fatalf("event = %+v", ev)
+	}
+}
+
+type fakeBlockedRoleAvailability struct {
+	available bool
+	calls     int
+}
+
+func (f *fakeBlockedRoleAvailability) Available(context.Context) bool {
+	f.calls++
+	return f.available
+}
+
+func TestRunBlockedRoleWakeOnceUsesInjectedProviderAndDedups(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(`
+[org]
+enforce = "warn"
+[org.roles."owner"]
+scope = ["*"]
+merge_rule = "owner"
+[org.roles."review"]
+parent = "owner"
+scope = ["gitmoot/*"]
+merge_rule = "self"
+[orchestrate]
+blocked_role_wake_after = "1h"
+`); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	snapshot := org.Snapshot{
+		States: map[string]org.RoleLiveState{
+			"owner":  {State: org.StateBlocked},
+			"review": {State: org.StateIdle},
+		},
+		ObservedAt: now.Add(-2 * time.Hour), ProviderVersion: "test-v1",
+	}
+	availability := &fakeBlockedRoleAvailability{available: true}
+	sink := &recordingSink{}
+	var providerRoles []string
+	deps := blockedRoleWakeDependencies{
+		availability: availability,
+		provider: func(roles []string) org.Provider {
+			providerRoles = append([]string(nil), roles...)
+			return orgFixtureProvider{snapshot: snapshot}
+		},
+		eventSink: func(context.Context, *db.Store, string) (events.Sink, error) { return sink, nil },
+	}
+
+	if got := resolveBlockedRoleWakeAfter(home); got != time.Hour {
+		t.Fatalf("resolveBlockedRoleWakeAfter() = %s, want 1h", got)
+	}
+	var output bytes.Buffer
+	runBlockedRoleWakeOnce(context.Background(), store, home, &output, now, deps)
+	blocked := sink.byType(events.EventJobBlocked)
+	if len(blocked) != 1 {
+		t.Fatalf("job.blocked events = %d, want 1; output=%s", len(blocked), output.String())
+	}
+	if len(providerRoles) != 2 || providerRoles[0] != "owner" || providerRoles[1] != "review" {
+		t.Fatalf("provider roles = %v", providerRoles)
+	}
+	ev := blocked[0]
+	if ev.Cause != "blocked_since" || ev.JobID != "org-blocked:owner" || ev.RootID != "org-blocked:owner" || ev.Repo != "" {
+		t.Fatalf("event = %+v", ev)
+	}
+	runBlockedRoleWakeOnce(context.Background(), store, home, io.Discard, now.Add(time.Minute), deps)
+	if got := len(sink.byType(events.EventJobBlocked)); got != 1 {
+		t.Fatalf("duplicate job.blocked events = %d, want 1", got)
+	}
+	if availability.calls != 2 {
+		t.Fatalf("availability calls = %d, want 2", availability.calls)
+	}
+}

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -250,3 +250,53 @@ func TestBlockedRoleEpisodeSurvivesTransientUnknownSnapshot(t *testing.T) {
 		t.Fatalf("StateIdle did not clear the episode: %+v", episodes)
 	}
 }
+
+// TestBlockedRoleEpisodeReapedWhenStaleThenReblockStartsFresh pins the staleness
+// reap: a role that goes permanently unknown/absent is NOT leaked forever (its
+// row is reaped once it stops being re-observed blocked past the gap), and a
+// later re-block under the same label starts a FRESH episode rather than reusing
+// the stale blocked_since to fire a spurious inflated-duration wake.
+func TestBlockedRoleEpisodeReapedWhenStaleThenReblockStartsFresh(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	sink := &recordingSink{}
+	wakeAfter := time.Hour
+	base := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	blocked := func(observedAt time.Time) org.Snapshot {
+		return org.Snapshot{States: map[string]org.RoleLiveState{"gone": {State: org.StateBlocked}}, ObservedAt: observedAt}
+	}
+	absent := func(observedAt time.Time) org.Snapshot {
+		return org.Snapshot{States: map[string]org.RoleLiveState{}, ObservedAt: observedAt}
+	}
+	run := func(snap org.Snapshot, now time.Time) {
+		t.Helper()
+		if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snap, wakeAfter, io.Discard, now); err != nil {
+			t.Fatalf("evaluate at %s: %v", now, err)
+		}
+	}
+	run(blocked(base.Add(-2*time.Hour)), base) // blocked 2h → emit #1, episode open
+	if got := len(sink.byType(events.EventJobBlocked)); got != 1 {
+		t.Fatalf("first emit = %d, want 1", got)
+	}
+	run(absent(base.Add(time.Minute)), base.Add(time.Minute)) // vanished, within gap → survives
+	if eps, _ := store.ListBlockedEpisodes(ctx); len(eps) != 1 {
+		t.Fatalf("episode reaped within stale gap: %+v", eps)
+	}
+	past := base.Add(blockedEpisodeStaleGap + time.Minute)
+	run(absent(past), past) // past the gap → reaped, no leak
+	if eps, _ := store.ListBlockedEpisodes(ctx); len(eps) != 0 {
+		t.Fatalf("stale absent-role episode was not reaped (leak): %+v", eps)
+	}
+	reblock := past.Add(time.Minute)
+	run(blocked(reblock), reblock) // fresh incarnation blocks → fresh episode, no spurious wake
+	if got := len(sink.byType(events.EventJobBlocked)); got != 1 {
+		t.Fatalf("re-block fired a spurious wake: emits = %d, want still 1", got)
+	}
+	eps, _ := store.ListBlockedEpisodes(ctx)
+	if len(eps) != 1 {
+		t.Fatalf("re-block episode set = %+v, want exactly 1", eps)
+	}
+	if got, want := eps[0].BlockedSince, reblock.UTC().Format(db.BlockedEpisodeTimeLayout); got != want {
+		t.Fatalf("re-block blocked_since = %q, want fresh %q (not the stale 2h-old instant)", got, want)
+	}
+}

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -180,3 +180,73 @@ blocked_role_wake_after = "1h"
 		t.Fatalf("availability calls = %d, want 2", availability.calls)
 	}
 }
+
+// TestBlockedSinceReNudgesOncePerIntervalWhileStillBlocked pins the self-healing
+// semantic: while a subject stays blocked it is re-nudged at most once per
+// wakeAfter, not a single durable one-shot (so a dropped wake recovers).
+func TestBlockedSinceReNudgesOncePerIntervalWhileStillBlocked(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	repo := "owner/repo"
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-nudge", RepoFullName: repo, State: string(workflow.TaskBlocked)}); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now().UTC().Truncate(time.Second).Add(2 * time.Hour)
+	wakeAfter := time.Hour
+	sink := &recordingSink{}
+	nudgeAt := func(at time.Time, want int) {
+		t.Helper()
+		if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, wakeAfter, io.Discard, at); err != nil {
+			t.Fatalf("evaluate at %s: %v", at, err)
+		}
+		if got := len(sink.byType(events.EventJobBlocked)); got != want {
+			t.Fatalf("blocked events at %s = %d, want %d", at, got, want)
+		}
+	}
+	nudgeAt(base, 1)                            // crosses threshold → emit #1
+	nudgeAt(base.Add(30*time.Minute), 1)        // within interval → no re-emit
+	nudgeAt(base.Add(wakeAfter+time.Minute), 2) // past interval, still blocked → re-nudge #2
+}
+
+// TestBlockedRoleEpisodeSurvivesTransientUnknownSnapshot pins the fix that a
+// momentary StateUnknown (or absent) role observation must NOT clear the episode
+// or reset its accrued blocked duration; only a definitive non-blocked state does.
+func TestBlockedRoleEpisodeSurvivesTransientUnknownSnapshot(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	sink := &recordingSink{}
+	wakeAfter := time.Hour
+	base := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	snap := func(state org.LifecycleState, observedAt time.Time) org.Snapshot {
+		return org.Snapshot{States: map[string]org.RoleLiveState{"owner": {State: state}}, ObservedAt: observedAt}
+	}
+	// Blocked, first observed 2h ago → crosses threshold → emit #1, episode open.
+	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snap(org.StateBlocked, base.Add(-2*time.Hour)), wakeAfter, io.Discard, base); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(sink.byType(events.EventJobBlocked)); got != 1 {
+		t.Fatalf("emit after first blocked tick = %d, want 1", got)
+	}
+	// Transient StateUnknown → episode MUST survive.
+	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snap(org.StateUnknown, base.Add(time.Minute)), wakeAfter, io.Discard, base.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	episodes, err := store.ListBlockedEpisodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(episodes) != 1 || episodes[0].Subject != "role:owner" {
+		t.Fatalf("StateUnknown cleared/altered the episode: %+v", episodes)
+	}
+	// A definitive idle observation clears it.
+	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snap(org.StateIdle, base.Add(2*time.Minute)), wakeAfter, io.Discard, base.Add(2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	episodes, err = store.ListBlockedEpisodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(episodes) != 0 {
+		t.Fatalf("StateIdle did not clear the episode: %+v", episodes)
+	}
+}

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -206,6 +207,19 @@ func TestBlockedSinceReNudgesOncePerIntervalWhileStillBlocked(t *testing.T) {
 	nudgeAt(base, 1)                            // crosses threshold → emit #1
 	nudgeAt(base.Add(30*time.Minute), 1)        // within interval → no re-emit
 	nudgeAt(base.Add(wakeAfter+time.Minute), 2) // past interval, still blocked → re-nudge #2
+
+	// Repeats must be self-identifying: both re-nudges of the SAME episode carry the
+	// SAME first_since, so a consumer never reads a re-nudge as a fresh episode.
+	blocked := sink.byType(events.EventJobBlocked)
+	sinceOf := func(detail string) string {
+		if i := strings.Index(detail, "(since "); i >= 0 {
+			return detail[i:]
+		}
+		return ""
+	}
+	if s0, s1 := sinceOf(blocked[0].Detail), sinceOf(blocked[1].Detail); s0 == "" || s0 != s1 {
+		t.Fatalf("re-nudges not self-identifying by first_since: %q vs %q", blocked[0].Detail, blocked[1].Detail)
+	}
 }
 
 // TestBlockedRoleEpisodeSurvivesTransientUnknownSnapshot pins the fix that a

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -774,6 +774,13 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 	if err := sweepExpiredBlockedJobs(ctx, store, resolveBlockedTTL(worker.workflowHome()), stdout, now); err != nil {
 		writeLine(stdout, "blocked_ttl sweep failed: %v", err)
 	}
+	// Opt-in blocked-since source (#1060): stale BLOCKED tasks synthesize one
+	// blocked event per continuous episode for the existing event-rule engine.
+	// Like blocked_ttl, every failure is logged and swallowed so this optional
+	// evaluator can never fail the repo tick.
+	if err := sweepBlockedTaskWakeEvents(ctx, store, worker.workflowHome(), repoFilter, stdout, now); err != nil {
+		writeLine(stdout, "blocked_since task sweep failed: %v", err)
+	}
 	// Checkout-mutating maintenance (advancement/merge retries, delegation
 	// worktree reclaims) is gated on the ACTUAL mutation hazard — each
 	// candidate is skipped while an in-flight job holds the checkout key the

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -75,6 +75,7 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 			// outside daemonWorkflowEngine, which is rebuilt per repo/tick.
 			startMemoryHarvestLoop(ctx, paths, home, store, stdout)
 			startCockpitReconcileLoop(ctx, store, paths.Home, stdout)
+			startBlockedRoleWakeLoop(ctx, store, paths.Home, stdout)
 			startTranscriptRetentionLoop(ctx, paths, store, stdout)
 		}
 		// Heartbeat schedules (#533) reuse the normal job queue. Off-by-default: with
@@ -179,6 +180,7 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 	defer tracker.drain(stdout, daemonShutdownDrainTimeout)
 	workerErr := startSingleRepoWorkerLoop(ctx, daemonWorkerLoopInterval, store, worker, live, &checkoutLock, tracker, d.Repo.FullName(), rootFilter, stdout)
 	startCockpitReconcileLoop(ctx, store, home, stdout)
+	startBlockedRoleWakeLoop(ctx, store, home, stdout)
 	// Heartbeat schedules (#533) must also fire in the single-repo daemon, or a
 	// single-repo daemon would silently never run them. Off-by-default: with no
 	// heartbeat sections the scan returns before any store touch. A failure to
@@ -964,6 +966,24 @@ func resolveBlockedTTL(home string) time.Duration {
 		return 0
 	}
 	return ttl
+}
+
+// resolveBlockedRoleWakeAfter reads the opt-in blocked-since threshold. It is
+// read-only and shape-tolerant like resolveBlockedTTL: either a raw --home or an
+// already-resolved <home>/.gitmoot root is accepted without initializing or
+// re-resolving the home. Zero, missing, or invalid values keep both evaluators
+// disabled.
+func resolveBlockedRoleWakeAfter(home string) time.Duration {
+	policy := config.DefaultOrchestratePolicy()
+	if cfg := resolveConfigFile(home); cfg != "" {
+		if loaded, err := config.LoadOrchestratePolicy(config.Paths{ConfigFile: cfg}); err == nil {
+			policy = loaded
+		}
+	}
+	if policy.BlockedRoleWakeAfter <= 0 {
+		return 0
+	}
+	return policy.BlockedRoleWakeAfter
 }
 
 // resolveDelegationWorktreeTTL reads the default-on terminal worktree retention

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -173,6 +173,8 @@ func classifyEventRuleKinds(event events.Event) []string {
 		switch event.Cause {
 		case "merge_guard", "permission_guard":
 			return []string{"guard"}
+		case "blocked_since":
+			return []string{"blocked"}
 		case "":
 			// A plain blocked transition is both a terminal outcome and the
 			// narrower blocked rule kind.

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -49,6 +49,7 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 		{name: "attention", event: events.Event{Type: events.EventJobNeedsAttention, Cause: "ask_gate"}, want: []string{"attention"}},
 		{name: "merge guard", event: events.Event{Type: events.EventJobBlocked, Cause: "merge_guard"}, want: []string{"guard"}},
 		{name: "permission guard", event: events.Event{Type: events.EventJobBlocked, Cause: "permission_guard"}, want: []string{"guard"}},
+		{name: "blocked since only", event: events.Event{Type: events.EventJobBlocked, Cause: "blocked_since"}, want: []string{"blocked"}},
 		{name: "finished terminal", event: events.Event{Type: events.EventJobFinished}, want: []string{"job-terminal"}},
 		{name: "failed terminal", event: events.Event{Type: events.EventJobFailed, Cause: "unrelated"}, want: []string{"job-terminal"}},
 		{name: "plain blocked terminal and blocked", event: events.Event{Type: events.EventJobBlocked}, want: []string{"job-terminal", "blocked"}},

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -128,6 +128,9 @@ cockpit_pane_key = "job"
 # (Go duration; default 24h). Both optional.
 escalation_handle = ""
 escalation_ttl = ""
+# Emit one synthetic blocked event per continuously blocked task or Herdr org
+# role after this Go duration. 0s keeps both evaluators disabled.
+blocked_role_wake_after = "0s"
 # Optional default timeouts for child delegation jobs. Empty means unbounded,
 # preserving historical behavior. Per-delegation timeout always wins; otherwise
 # phase-specific defaults apply, then default_delegation_timeout, then unbounded.

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -77,6 +77,10 @@ type OrchestratePolicy struct {
 	// default — this dismisses a SINGLE blocked job and is OFF by default. The daemon
 	// resolves it per tick via resolveBlockedTTL.
 	BlockedTTL string
+	// BlockedRoleWakeAfter is the opt-in age after which a continuously blocked
+	// task or Herdr-backed organization role emits one synthesized blocked event.
+	// Zero (the default) disables both evaluators; negative values are rejected.
+	BlockedRoleWakeAfter time.Duration
 	// MaxDelegationNonProgressStreak is the per-root threshold for the result-aware
 	// non-progress loop detector (#339): how many consecutive continuation
 	// generations a delegation tree may produce with no new durable side effect
@@ -121,6 +125,7 @@ func DefaultOrchestratePolicy() OrchestratePolicy {
 		EscalationHandle:               "",
 		EscalationTTL:                  "",
 		BlockedTTL:                     "",
+		BlockedRoleWakeAfter:           0,
 		MaxDelegationNonProgressStreak: 0,
 		MaxVerifyReplanAttempts:        0,
 		DefaultDelegationTimeout:       "",
@@ -216,6 +221,18 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 		parsed, err := parseConfigString(value)
 		policy.BlockedTTL = strings.TrimSpace(parsed)
 		return err
+	case "blocked_role_wake_after":
+		parsed, err := parseConfigString(value)
+		if err != nil {
+			return err
+		}
+		parsed = strings.TrimSpace(parsed)
+		if parsed == "" {
+			policy.BlockedRoleWakeAfter = 0
+			return nil
+		}
+		policy.BlockedRoleWakeAfter, err = time.ParseDuration(parsed)
+		return err
 	case "max_delegation_non_progress_streak":
 		parsed, err := strconv.Atoi(value)
 		policy.MaxDelegationNonProgressStreak = parsed
@@ -293,6 +310,9 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 		if parsed < 0 {
 			return fmt.Errorf("orchestrate.blocked_ttl must be zero (disabled) or a positive duration")
 		}
+	}
+	if policy.BlockedRoleWakeAfter < 0 {
+		return fmt.Errorf("orchestrate.blocked_role_wake_after must be zero (disabled) or a positive duration")
 	}
 	if policy.MaxDelegationNonProgressStreak < 0 {
 		return fmt.Errorf("orchestrate.max_delegation_non_progress_streak must be 0 (engine default) or positive")

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestLoadOrchestratePolicyDefaults(t *testing.T) {
@@ -378,6 +379,49 @@ blocked_ttl = "soon"
 	}
 	if _, err := LoadOrchestratePolicy(paths); err == nil {
 		t.Fatal("LoadOrchestratePolicy accepted an invalid blocked_ttl")
+	}
+}
+
+func TestLoadOrchestratePolicyBlockedRoleWakeAfter(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize returned error: %v", err)
+	}
+
+	policy, err := LoadOrchestratePolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadOrchestratePolicy(default) error = %v", err)
+	}
+	if policy.BlockedRoleWakeAfter != 0 {
+		t.Fatalf("BlockedRoleWakeAfter = %s, want disabled", policy.BlockedRoleWakeAfter)
+	}
+
+	for _, test := range []struct {
+		value   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{value: "36h", want: 36 * time.Hour},
+		{value: "0s", want: 0},
+		{value: "-1m", wantErr: true},
+		{value: "soon", wantErr: true},
+	} {
+		if err := os.WriteFile(paths.ConfigFile, []byte("[orchestrate]\nblocked_role_wake_after = \""+test.value+"\"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		policy, err := LoadOrchestratePolicy(paths)
+		if test.wantErr {
+			if err == nil {
+				t.Fatalf("blocked_role_wake_after %q accepted, want error", test.value)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("blocked_role_wake_after %q error = %v", test.value, err)
+		}
+		if policy.BlockedRoleWakeAfter != test.want {
+			t.Fatalf("blocked_role_wake_after %q = %s, want %s", test.value, policy.BlockedRoleWakeAfter, test.want)
+		}
 	}
 }
 

--- a/internal/db/org_blocked_episodes.go
+++ b/internal/db/org_blocked_episodes.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+const blockedEpisodeTimeLayout = "2006-01-02T15:04:05.000000000Z"
+
+// BlockedEpisode tracks one continuous task or organization-role blocked
+// episode. EmittedAt is empty until its synthesized blocked event is emitted.
+type BlockedEpisode struct {
+	Subject      string `json:"subject"`
+	BlockedSince string `json:"blocked_since"`
+	EmittedAt    string `json:"emitted_at,omitempty"`
+}
+
+// UpsertBlockedEpisode opens an episode at blockedSince. Repeated observations
+// refresh updated_at but deliberately retain the first blocked_since instant.
+func (s *Store) UpsertBlockedEpisode(ctx context.Context, subject string, blockedSince time.Time) error {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return errors.New("blocked episode subject is required")
+	}
+	now := time.Now().UTC().Format(blockedEpisodeTimeLayout)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO org_blocked_episodes(subject, blocked_since, emitted_at, updated_at)
+		VALUES (?, ?, NULL, ?)
+		ON CONFLICT(subject) DO UPDATE SET updated_at = excluded.updated_at`,
+		subject, blockedSince.UTC().Format(blockedEpisodeTimeLayout), now)
+	return err
+}
+
+// MarkBlockedEpisodeEmitted records that the episode's one synthesized event
+// has been emitted. Marking a missing episode is an idempotent no-op.
+func (s *Store) MarkBlockedEpisodeEmitted(ctx context.Context, subject string) error {
+	now := time.Now().UTC().Format(blockedEpisodeTimeLayout)
+	_, err := s.db.ExecContext(ctx, `UPDATE org_blocked_episodes SET emitted_at = ?, updated_at = ? WHERE subject = ?`,
+		now, now, strings.TrimSpace(subject))
+	return err
+}
+
+// ClearBlockedEpisode closes a blocked episode. Deleting a missing row is an
+// idempotent no-op.
+func (s *Store) ClearBlockedEpisode(ctx context.Context, subject string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM org_blocked_episodes WHERE subject = ?`, strings.TrimSpace(subject))
+	return err
+}
+
+// ListBlockedEpisodes returns every open episode in stable subject order.
+func (s *Store) ListBlockedEpisodes(ctx context.Context) ([]BlockedEpisode, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT subject, blocked_since, COALESCE(emitted_at, '')
+		FROM org_blocked_episodes ORDER BY subject`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := []BlockedEpisode{}
+	for rows.Next() {
+		var episode BlockedEpisode
+		if err := rows.Scan(&episode.Subject, &episode.BlockedSince, &episode.EmittedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, episode)
+	}
+	return result, rows.Err()
+}

--- a/internal/db/org_blocked_episodes.go
+++ b/internal/db/org_blocked_episodes.go
@@ -7,7 +7,11 @@ import (
 	"time"
 )
 
-const blockedEpisodeTimeLayout = "2006-01-02T15:04:05.000000000Z"
+// BlockedEpisodeTimeLayout is the fixed-width UTC layout for the stored
+// blocked_since / emitted_at / updated_at timestamps. It is EXPORTED so the cli
+// evaluator parses exactly what this package formats — one shared round-trip
+// contract rather than two constants that could silently drift apart.
+const BlockedEpisodeTimeLayout = "2006-01-02T15:04:05.000000000Z"
 
 // BlockedEpisode tracks one continuous task or organization-role blocked
 // episode. EmittedAt is empty until the first synthesized blocked event, then
@@ -18,20 +22,28 @@ type BlockedEpisode struct {
 	Subject      string `json:"subject"`
 	BlockedSince string `json:"blocked_since"`
 	EmittedAt    string `json:"emitted_at,omitempty"`
+	// UpdatedAt is the last instant the subject was observed blocked (refreshed on
+	// every UpsertBlockedEpisode). The role evaluator reaps an episode whose
+	// UpdatedAt has gone stale — the subject stopped being observed blocked — which
+	// distinguishes a genuinely ended block (or a role gone for good) from a
+	// transient unknown/absent snapshot blip, without leaking rows forever.
+	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-// UpsertBlockedEpisode opens an episode at blockedSince. Repeated observations
-// refresh updated_at but deliberately retain the first blocked_since instant.
-func (s *Store) UpsertBlockedEpisode(ctx context.Context, subject string, blockedSince time.Time) error {
+// UpsertBlockedEpisode opens an episode at blockedSince, or refreshes updated_at
+// to `now` for an existing one while deliberately retaining its first
+// blocked_since instant. `now` must be the evaluator's clock so the staleness
+// reap (which compares UpdatedAt against the evaluator's now) is deterministic.
+func (s *Store) UpsertBlockedEpisode(ctx context.Context, subject string, blockedSince, now time.Time) error {
 	subject = strings.TrimSpace(subject)
 	if subject == "" {
 		return errors.New("blocked episode subject is required")
 	}
-	now := time.Now().UTC().Format(blockedEpisodeTimeLayout)
+	stamp := now.UTC().Format(BlockedEpisodeTimeLayout)
 	_, err := s.db.ExecContext(ctx, `INSERT INTO org_blocked_episodes(subject, blocked_since, emitted_at, updated_at)
 		VALUES (?, ?, NULL, ?)
 		ON CONFLICT(subject) DO UPDATE SET updated_at = excluded.updated_at`,
-		subject, blockedSince.UTC().Format(blockedEpisodeTimeLayout), now)
+		subject, blockedSince.UTC().Format(BlockedEpisodeTimeLayout), stamp)
 	return err
 }
 
@@ -40,7 +52,7 @@ func (s *Store) UpsertBlockedEpisode(ctx context.Context, subject string, blocke
 // gate). `at` must be the evaluator's clock so the gate is deterministic and
 // testable. Marking a missing episode is an idempotent no-op.
 func (s *Store) MarkBlockedEpisodeEmitted(ctx context.Context, subject string, at time.Time) error {
-	stamp := at.UTC().Format(blockedEpisodeTimeLayout)
+	stamp := at.UTC().Format(BlockedEpisodeTimeLayout)
 	_, err := s.db.ExecContext(ctx, `UPDATE org_blocked_episodes SET emitted_at = ?, updated_at = ? WHERE subject = ?`,
 		stamp, stamp, strings.TrimSpace(subject))
 	return err
@@ -55,8 +67,20 @@ func (s *Store) ClearBlockedEpisode(ctx context.Context, subject string) error {
 
 // ListBlockedEpisodes returns every open episode in stable subject order.
 func (s *Store) ListBlockedEpisodes(ctx context.Context) ([]BlockedEpisode, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT subject, blocked_since, COALESCE(emitted_at, '')
+	return s.queryBlockedEpisodes(ctx, `SELECT subject, blocked_since, COALESCE(emitted_at, ''), updated_at
 		FROM org_blocked_episodes ORDER BY subject`)
+}
+
+// ListBlockedEpisodesByPrefix returns only episodes whose subject starts with
+// prefix (e.g. "task:owner/repo:" or "role:"), so a per-repo tick reads only the
+// rows it can act on instead of scanning the whole table every tick.
+func (s *Store) ListBlockedEpisodesByPrefix(ctx context.Context, prefix string) ([]BlockedEpisode, error) {
+	return s.queryBlockedEpisodes(ctx, `SELECT subject, blocked_since, COALESCE(emitted_at, ''), updated_at
+		FROM org_blocked_episodes WHERE subject LIKE ? ESCAPE '\' ORDER BY subject`, likeLiteralPrefix(prefix))
+}
+
+func (s *Store) queryBlockedEpisodes(ctx context.Context, query string, args ...any) ([]BlockedEpisode, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -64,10 +88,17 @@ func (s *Store) ListBlockedEpisodes(ctx context.Context) ([]BlockedEpisode, erro
 	result := []BlockedEpisode{}
 	for rows.Next() {
 		var episode BlockedEpisode
-		if err := rows.Scan(&episode.Subject, &episode.BlockedSince, &episode.EmittedAt); err != nil {
+		if err := rows.Scan(&episode.Subject, &episode.BlockedSince, &episode.EmittedAt, &episode.UpdatedAt); err != nil {
 			return nil, err
 		}
 		result = append(result, episode)
 	}
 	return result, rows.Err()
+}
+
+// likeLiteralPrefix escapes the LIKE metacharacters in a literal prefix (a repo
+// name can contain '_') so it matches by prefix rather than as a wildcard.
+func likeLiteralPrefix(prefix string) string {
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
+	return escaped + "%"
 }

--- a/internal/db/org_blocked_episodes.go
+++ b/internal/db/org_blocked_episodes.go
@@ -10,7 +10,10 @@ import (
 const blockedEpisodeTimeLayout = "2006-01-02T15:04:05.000000000Z"
 
 // BlockedEpisode tracks one continuous task or organization-role blocked
-// episode. EmittedAt is empty until its synthesized blocked event is emitted.
+// episode. EmittedAt is empty until the first synthesized blocked event, then
+// carries the LAST-emitted instant so the evaluator can re-nudge at most once per
+// interval while the subject stays blocked (self-healing against a dropped wake)
+// rather than firing a single durable one-shot.
 type BlockedEpisode struct {
 	Subject      string `json:"subject"`
 	BlockedSince string `json:"blocked_since"`
@@ -32,12 +35,14 @@ func (s *Store) UpsertBlockedEpisode(ctx context.Context, subject string, blocke
 	return err
 }
 
-// MarkBlockedEpisodeEmitted records that the episode's one synthesized event
-// has been emitted. Marking a missing episode is an idempotent no-op.
-func (s *Store) MarkBlockedEpisodeEmitted(ctx context.Context, subject string) error {
-	now := time.Now().UTC().Format(blockedEpisodeTimeLayout)
+// MarkBlockedEpisodeEmitted records the instant a synthesized event was emitted
+// for the episode (the LAST-emitted time, used by the once-per-interval re-nudge
+// gate). `at` must be the evaluator's clock so the gate is deterministic and
+// testable. Marking a missing episode is an idempotent no-op.
+func (s *Store) MarkBlockedEpisodeEmitted(ctx context.Context, subject string, at time.Time) error {
+	stamp := at.UTC().Format(blockedEpisodeTimeLayout)
 	_, err := s.db.ExecContext(ctx, `UPDATE org_blocked_episodes SET emitted_at = ?, updated_at = ? WHERE subject = ?`,
-		now, now, strings.TrimSpace(subject))
+		stamp, stamp, strings.TrimSpace(subject))
 	return err
 }
 

--- a/internal/db/org_blocked_episodes.go
+++ b/internal/db/org_blocked_episodes.go
@@ -71,14 +71,6 @@ func (s *Store) ListBlockedEpisodes(ctx context.Context) ([]BlockedEpisode, erro
 		FROM org_blocked_episodes ORDER BY subject`)
 }
 
-// ListBlockedEpisodesByPrefix returns only episodes whose subject starts with
-// prefix (e.g. "task:owner/repo:" or "role:"), so a per-repo tick reads only the
-// rows it can act on instead of scanning the whole table every tick.
-func (s *Store) ListBlockedEpisodesByPrefix(ctx context.Context, prefix string) ([]BlockedEpisode, error) {
-	return s.queryBlockedEpisodes(ctx, `SELECT subject, blocked_since, COALESCE(emitted_at, ''), updated_at
-		FROM org_blocked_episodes WHERE subject LIKE ? ESCAPE '\' ORDER BY subject`, likeLiteralPrefix(prefix))
-}
-
 func (s *Store) queryBlockedEpisodes(ctx context.Context, query string, args ...any) ([]BlockedEpisode, error) {
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -94,11 +86,4 @@ func (s *Store) queryBlockedEpisodes(ctx context.Context, query string, args ...
 		result = append(result, episode)
 	}
 	return result, rows.Err()
-}
-
-// likeLiteralPrefix escapes the LIKE metacharacters in a literal prefix (a repo
-// name can contain '_') so it matches by prefix rather than as a wildcard.
-func likeLiteralPrefix(prefix string) string {
-	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
-	return escaped + "%"
 }

--- a/internal/db/org_blocked_episodes_test.go
+++ b/internal/db/org_blocked_episodes_test.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestBlockedEpisodeRoundTripKeepsFirstBlockedSince(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	var table string
+	if err := store.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name='org_blocked_episodes'`).Scan(&table); err != nil {
+		t.Fatalf("org_blocked_episodes migration missing: %v", err)
+	}
+	first := time.Date(2026, 7, 22, 8, 1, 2, 345678901, time.UTC)
+	if err := store.UpsertBlockedEpisode(ctx, "task:owner/repo:task-1", first); err != nil {
+		t.Fatalf("UpsertBlockedEpisode(insert) error = %v", err)
+	}
+	if err := store.UpsertBlockedEpisode(ctx, "task:owner/repo:task-1", first.Add(3*time.Hour)); err != nil {
+		t.Fatalf("UpsertBlockedEpisode(update) error = %v", err)
+	}
+	if err := store.UpsertBlockedEpisode(ctx, "role:review", first.Add(time.Minute)); err != nil {
+		t.Fatalf("UpsertBlockedEpisode(second subject) error = %v", err)
+	}
+
+	episodes, err := store.ListBlockedEpisodes(ctx)
+	if err != nil {
+		t.Fatalf("ListBlockedEpisodes() error = %v", err)
+	}
+	if len(episodes) != 2 || episodes[0].Subject != "role:review" || episodes[1].Subject != "task:owner/repo:task-1" {
+		t.Fatalf("episodes = %+v, want subject-sorted rows", episodes)
+	}
+	if got, want := episodes[1].BlockedSince, first.Format(blockedEpisodeTimeLayout); got != want {
+		t.Fatalf("BlockedSince = %q, want first-seen %q", got, want)
+	}
+	if episodes[1].EmittedAt != "" {
+		t.Fatalf("EmittedAt = %q, want empty", episodes[1].EmittedAt)
+	}
+
+	if err := store.MarkBlockedEpisodeEmitted(ctx, episodes[1].Subject); err != nil {
+		t.Fatalf("MarkBlockedEpisodeEmitted() error = %v", err)
+	}
+	episodes, err = store.ListBlockedEpisodes(ctx)
+	if err != nil {
+		t.Fatalf("ListBlockedEpisodes(after mark) error = %v", err)
+	}
+	if episodes[1].EmittedAt == "" {
+		t.Fatal("EmittedAt is empty after mark")
+	}
+	if _, err := time.Parse(blockedEpisodeTimeLayout, episodes[1].EmittedAt); err != nil {
+		t.Fatalf("EmittedAt = %q, want fixed-width UTC timestamp: %v", episodes[1].EmittedAt, err)
+	}
+
+	if err := store.ClearBlockedEpisode(ctx, episodes[1].Subject); err != nil {
+		t.Fatalf("ClearBlockedEpisode() error = %v", err)
+	}
+	if err := store.ClearBlockedEpisode(ctx, episodes[1].Subject); err != nil {
+		t.Fatalf("ClearBlockedEpisode(idempotent) error = %v", err)
+	}
+	episodes, err = store.ListBlockedEpisodes(ctx)
+	if err != nil || len(episodes) != 1 || episodes[0].Subject != "role:review" {
+		t.Fatalf("episodes after clear = %+v, err=%v", episodes, err)
+	}
+}
+
+func TestUpsertBlockedEpisodeRejectsEmptySubject(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.UpsertBlockedEpisode(context.Background(), " ", time.Now()); err == nil {
+		t.Fatal("UpsertBlockedEpisode() error = nil, want validation error")
+	}
+}

--- a/internal/db/org_blocked_episodes_test.go
+++ b/internal/db/org_blocked_episodes_test.go
@@ -44,7 +44,7 @@ func TestBlockedEpisodeRoundTripKeepsFirstBlockedSince(t *testing.T) {
 		t.Fatalf("EmittedAt = %q, want empty", episodes[1].EmittedAt)
 	}
 
-	if err := store.MarkBlockedEpisodeEmitted(ctx, episodes[1].Subject); err != nil {
+	if err := store.MarkBlockedEpisodeEmitted(ctx, episodes[1].Subject, time.Now().UTC()); err != nil {
 		t.Fatalf("MarkBlockedEpisodeEmitted() error = %v", err)
 	}
 	episodes, err = store.ListBlockedEpisodes(ctx)

--- a/internal/db/org_blocked_episodes_test.go
+++ b/internal/db/org_blocked_episodes_test.go
@@ -20,13 +20,13 @@ func TestBlockedEpisodeRoundTripKeepsFirstBlockedSince(t *testing.T) {
 		t.Fatalf("org_blocked_episodes migration missing: %v", err)
 	}
 	first := time.Date(2026, 7, 22, 8, 1, 2, 345678901, time.UTC)
-	if err := store.UpsertBlockedEpisode(ctx, "task:owner/repo:task-1", first); err != nil {
+	if err := store.UpsertBlockedEpisode(ctx, "task:owner/repo:task-1", first, first); err != nil {
 		t.Fatalf("UpsertBlockedEpisode(insert) error = %v", err)
 	}
-	if err := store.UpsertBlockedEpisode(ctx, "task:owner/repo:task-1", first.Add(3*time.Hour)); err != nil {
+	if err := store.UpsertBlockedEpisode(ctx, "task:owner/repo:task-1", first.Add(3*time.Hour), first.Add(3*time.Hour)); err != nil {
 		t.Fatalf("UpsertBlockedEpisode(update) error = %v", err)
 	}
-	if err := store.UpsertBlockedEpisode(ctx, "role:review", first.Add(time.Minute)); err != nil {
+	if err := store.UpsertBlockedEpisode(ctx, "role:review", first.Add(time.Minute), first.Add(time.Minute)); err != nil {
 		t.Fatalf("UpsertBlockedEpisode(second subject) error = %v", err)
 	}
 
@@ -37,7 +37,7 @@ func TestBlockedEpisodeRoundTripKeepsFirstBlockedSince(t *testing.T) {
 	if len(episodes) != 2 || episodes[0].Subject != "role:review" || episodes[1].Subject != "task:owner/repo:task-1" {
 		t.Fatalf("episodes = %+v, want subject-sorted rows", episodes)
 	}
-	if got, want := episodes[1].BlockedSince, first.Format(blockedEpisodeTimeLayout); got != want {
+	if got, want := episodes[1].BlockedSince, first.Format(BlockedEpisodeTimeLayout); got != want {
 		t.Fatalf("BlockedSince = %q, want first-seen %q", got, want)
 	}
 	if episodes[1].EmittedAt != "" {
@@ -54,7 +54,7 @@ func TestBlockedEpisodeRoundTripKeepsFirstBlockedSince(t *testing.T) {
 	if episodes[1].EmittedAt == "" {
 		t.Fatal("EmittedAt is empty after mark")
 	}
-	if _, err := time.Parse(blockedEpisodeTimeLayout, episodes[1].EmittedAt); err != nil {
+	if _, err := time.Parse(BlockedEpisodeTimeLayout, episodes[1].EmittedAt); err != nil {
 		t.Fatalf("EmittedAt = %q, want fixed-width UTC timestamp: %v", episodes[1].EmittedAt, err)
 	}
 
@@ -76,7 +76,7 @@ func TestUpsertBlockedEpisodeRejectsEmptySubject(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer store.Close()
-	if err := store.UpsertBlockedEpisode(context.Background(), " ", time.Now()); err == nil {
+	if err := store.UpsertBlockedEpisode(context.Background(), " ", time.Now(), time.Now()); err == nil {
 		t.Fatal("UpsertBlockedEpisode() error = nil, want validation error")
 	}
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1674,4 +1674,15 @@ CREATE TABLE event_rules (
 	created_at TEXT NOT NULL
 );
 	`,
+	// #1060 durable de-duplication for synthesized blocked-since events. A row
+	// represents one continuous blocked episode; leaving blocked deletes it so a
+	// later episode can emit once again.
+	`
+CREATE TABLE org_blocked_episodes (
+	subject TEXT PRIMARY KEY,
+	blocked_since TEXT NOT NULL,
+	emitted_at TEXT,
+	updated_at TEXT NOT NULL
+);
+	`,
 }

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -111,7 +111,7 @@ Every event is a single JSON object:
 | `status`         | string | Terminal/lifecycle state (`succeeded`/`failed`/`blocked`/`awaiting_human`). |
 | `ts`             | string | RFC3339 emit time.                                                          |
 | `detail`         | string | Short redacted human-facing string (failure summary, the escalation question). |
-| `cause`          | string | Optional internal discriminator (`escalation`, `ask_gate`, `merge_guard`, or `permission_guard`). |
+| `cause`          | string | Optional internal discriminator (`escalation`, `ask_gate`, `merge_guard`, `permission_guard`, or `blocked_since`). |
 
 `cause` is an additive optional field, so `schema_version` remains `1` and
 existing events serialize unchanged. It is a trusted enum assigned at emit
@@ -173,7 +173,12 @@ gitmoot org events rule rm <rule-id>
 Kinds are `escalation`, `attention`, `guard`, `job-terminal`, and `blocked`.
 The v1 `--match` filter is a case-insensitive substring tested against the event
 repo and job id; empty matches all. A plain `job.blocked` event matches both
-`job-terminal` and `blocked`, while guard-caused blocks match `guard` first.
+`job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
+synthesized `blocked_since` event matches only `blocked`. Set
+`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit one
+such event when a task or Herdr role remains blocked past the threshold; `0s`
+(the default) disables both evaluators. The episode is cleared when the subject
+leaves blocked, so a later re-block can emit once again.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -179,9 +179,10 @@ synthesized `blocked_since` event matches only `blocked`. Set
 event when a task or Herdr role stays blocked past the threshold, re-nudging at
 most once per that interval while it remains blocked (so a dropped wake
 self-heals on the next interval instead of being lost); `0s` (the default)
-disables both evaluators. An episode is cleared only on a definitive non-blocked
-observation — a transient `unknown` snapshot never resets it — so a later
-re-block starts a fresh episode.
+disables both evaluators. An episode is cleared on a definitive non-blocked
+observation, or once the subject stops being observed blocked for a short grace
+(so a role gone for good is not leaked); a brief `unknown`/absent snapshot blip
+within that grace never resets it, and a later re-block starts a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -175,10 +175,13 @@ The v1 `--match` filter is a case-insensitive substring tested against the event
 repo and job id; empty matches all. A plain `job.blocked` event matches both
 `job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
 synthesized `blocked_since` event matches only `blocked`. Set
-`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit one
-such event when a task or Herdr role remains blocked past the threshold; `0s`
-(the default) disables both evaluators. The episode is cleared when the subject
-leaves blocked, so a later re-block can emit once again.
+`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit such an
+event when a task or Herdr role stays blocked past the threshold, re-nudging at
+most once per that interval while it remains blocked (so a dropped wake
+self-heals on the next interval instead of being lost); `0s` (the default)
+disables both evaluators. An episode is cleared only on a definitive non-blocked
+observation — a transient `unknown` snapshot never resets it — so a later
+re-block starts a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -183,6 +183,8 @@ disables both evaluators. An episode is cleared on a definitive non-blocked
 observation, or once the subject stops being observed blocked for a short grace
 (so a role gone for good is not leaked); a brief `unknown`/absent snapshot blip
 within that grace never resets it, and a later re-block starts a fresh episode.
+Each synthesized event's `detail` carries the stable since-time, so a re-nudge
+(same `job_id` + same since) is distinguishable from a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2589,7 +2589,7 @@ Every event is a single JSON object:
 | `status`         | string | Terminal/lifecycle state (`succeeded`/`failed`/`blocked`/`awaiting_human`). |
 | `ts`             | string | RFC3339 emit time.                                                          |
 | `detail`         | string | Short redacted human-facing string (failure summary, the escalation question). |
-| `cause`          | string | Optional internal discriminator (`escalation`, `ask_gate`, `merge_guard`, or `permission_guard`). |
+| `cause`          | string | Optional internal discriminator (`escalation`, `ask_gate`, `merge_guard`, `permission_guard`, or `blocked_since`). |
 
 `cause` is an additive optional field, so `schema_version` remains `1` and
 existing events serialize unchanged. It is a trusted enum assigned at emit
@@ -2651,7 +2651,12 @@ gitmoot org events rule rm <rule-id>
 Kinds are `escalation`, `attention`, `guard`, `job-terminal`, and `blocked`.
 The v1 `--match` filter is a case-insensitive substring tested against the event
 repo and job id; empty matches all. A plain `job.blocked` event matches both
-`job-terminal` and `blocked`, while guard-caused blocks match `guard` first.
+`job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
+synthesized `blocked_since` event matches only `blocked`. Set
+`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit one
+such event when a task or Herdr role remains blocked past the threshold; `0s`
+(the default) disables both evaluators. The episode is cleared when the subject
+leaves blocked, so a later re-block can emit once again.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2653,10 +2653,13 @@ The v1 `--match` filter is a case-insensitive substring tested against the event
 repo and job id; empty matches all. A plain `job.blocked` event matches both
 `job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
 synthesized `blocked_since` event matches only `blocked`. Set
-`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit one
-such event when a task or Herdr role remains blocked past the threshold; `0s`
-(the default) disables both evaluators. The episode is cleared when the subject
-leaves blocked, so a later re-block can emit once again.
+`[orchestrate].blocked_role_wake_after` to a positive Go duration to emit such an
+event when a task or Herdr role stays blocked past the threshold, re-nudging at
+most once per that interval while it remains blocked (so a dropped wake
+self-heals on the next interval instead of being lost); `0s` (the default)
+disables both evaluators. An episode is cleared only on a definitive non-blocked
+observation — a transient `unknown` snapshot never resets it — so a later
+re-block starts a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2657,9 +2657,10 @@ synthesized `blocked_since` event matches only `blocked`. Set
 event when a task or Herdr role stays blocked past the threshold, re-nudging at
 most once per that interval while it remains blocked (so a dropped wake
 self-heals on the next interval instead of being lost); `0s` (the default)
-disables both evaluators. An episode is cleared only on a definitive non-blocked
-observation — a transient `unknown` snapshot never resets it — so a later
-re-block starts a fresh episode.
+disables both evaluators. An episode is cleared on a definitive non-blocked
+observation, or once the subject stops being observed blocked for a short grace
+(so a role gone for good is not leaked); a brief `unknown`/absent snapshot blip
+within that grace never resets it, and a later re-block starts a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2661,6 +2661,8 @@ disables both evaluators. An episode is cleared on a definitive non-blocked
 observation, or once the subject stops being observed blocked for a short grace
 (so a role gone for good is not leaked); a brief `unknown`/absent snapshot blip
 within that grace never resets it, and a later re-block starts a fresh episode.
+Each synthesized event's `detail` carries the stable since-time, so a re-nudge
+(same `job_id` + same since) is distinguishable from a fresh episode.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs


### PR DESCRIPTION
## #1060 — org phase 2, slice 2a: blocked-since event source

Rides slice 1 (the event-rule engine + delivery-verified herdr wake, #1076) and
org phase 1b (#1071's herdr provider seam + org chart). Off by default: with no
`event_rules` and `blocked_role_wake_after = 0s` (the default), both evaluators
are no-ops.

### What ships
Synthesizes an `EventJobBlocked` with `cause = "blocked_since"` (routes only to
`--on blocked` rules) when a role or task has been blocked past
`[orchestrate].blocked_role_wake_after`, so slice 1's rule engine wakes whatever
role an operator's `--on blocked` rule targets (the "wake parent" is
rule-configured). Two sources:
- **Task** — a per-repo tick reuses the existing `ListStaleTaskCandidates` over
  gitmoot's own `TaskBlocked` state (authoritative clear-on-unblock).
- **Herdr role** — a host-global, herdr-gated loop reads #1071's
  `Provider.Snapshot` (`StateBlocked`). herdr gives no per-role timestamp, so the
  first-observed instant is persisted in a new `org_blocked_episodes` table.

**Re-nudge, not one-shot:** while a subject stays blocked it is re-emitted at
most once per interval (an alert `repeat_interval`) with mark-before-emit, so a
wake dropped on a best-effort sink self-heals next interval instead of being lost
(fable-approved). Each event's `detail` carries the stable `since` so a re-nudge
is distinguishable from a fresh episode.

**Staleness reap:** a role episode is cleared on a definitive non-blocked state
or once it stops being observed blocked past a grace gap — so a transient
`unknown` blip preserves the accrued duration, while a role gone for good is
neither leaked nor stale-reused.

Deferred to **slice 2b**: per-role missed-wake counter + org-chart flag.

### Review
`/code-review xhigh` then two `/code-review high` convergence passes (each on the
exact committed head). The ladder caught, in order: 8 lifecycle defects (dropped/
delayed/duplicated wakes) → the transient-guard fix's leak+stale-reuse regression
→ a case-insensitive `LIKE` prefix scan. All fixed; final head reviewed clean on
the lifecycle. Regression tests: once-per-interval re-nudge (self-identifying),
transient-unknown-survives, staleness-reap + re-block-fresh, off-by-default,
mark-before-emit.

### Verification
- `go build ./...`, `go generate ./... && git diff --exit-code`, `go vet ./...`
  clean.
- `go test ./...` green except the 4 pre-existing Landlock E2Es (the known
  `/tmp`-checkout sandbox confound; unchanged by this branch; pass on CI runners).
- Docs shipped in-PR (`docs/events.md`, website `event-stream.md`, `llms-full.txt`).

### Deploy
**No deploy.** Judging window live through Aug 5; merges to `main` only. Off
unless an operator sets `blocked_role_wake_after` AND an `--on blocked` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
