### PR TITLE
feat(memory): human-readable memory names — derived titles + readable harvest slugs (#1077)

### DIFF
--- a/internal/cli/dashboard_web_brain_events.go
+++ b/internal/cli/dashboard_web_brain_events.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/memory"
 )
 
 const dashboardBrainEventsMaxLimit = 200
@@ -37,6 +38,7 @@ type dashboardBrainEventsResponse struct {
 type dashboardBrainFact struct {
 	ID               int64  `json:"id"`
 	Key              string `json:"key"`
+	Title            string `json:"title"`
 	Content          string `json:"content"`
 	Status           string `json:"status"`
 	Repo             string `json:"repo,omitempty"`
@@ -99,8 +101,12 @@ func (d *webDataSource) BrainFact(ctx context.Context, id int64) (dashboardBrain
 		} else if record.RetiredAt != "" {
 			status = "retired"
 		}
+		title := memory.Title(record.Content)
+		if title == "" {
+			title = record.Key
+		}
 		out = dashboardBrainFact{
-			ID: record.ID, Key: record.Key, Content: record.Content, Status: status,
+			ID: record.ID, Key: record.Key, Title: title, Content: record.Content, Status: status,
 			Repo: record.Repo, Scope: record.Scope, OwnerKind: record.Owner.Kind, OwnerRef: record.Owner.Ref,
 			RetiredAt: record.RetiredAt, RetiredReason: record.RetiredReason, SupersededBy: record.SupersededBy,
 			FirstConfirmedAt: record.FirstConfirmedAt, UpdatedAt: record.UpdatedAt,

--- a/internal/cli/dashboard_web_brain_events_test.go
+++ b/internal/cli/dashboard_web_brain_events_test.go
@@ -75,7 +75,7 @@ func TestBrainFactHTTPAPIIncludesHistoricalRowsAndErrors(t *testing.T) {
 	ctx := context.Background()
 	owner := db.MemoryOwner{Kind: "agent", Ref: "builder"}
 	activeID, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
-		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "active", Content: "active fact"})
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "active", Content: "Active fact. More detail."})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,15 +109,21 @@ func TestBrainFactHTTPAPIIncludesHistoricalRowsAndErrors(t *testing.T) {
 	if supersededID == 0 {
 		t.Fatal("superseded archive not found")
 	}
+	degenerateID, err := store.UpsertConfirmedMemory(ctx, db.ConfirmedMemory{
+		Owner: owner, Repo: "acme/widget", Scope: "repo", Key: "code-only", Content: "```go\nfmt.Println(\"hello\")\n```"})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	handler := newDashboardWebHandler(&webDataSource{home: home})
 	tests := []struct {
-		name, status string
-		id           int64
+		name, status, title string
+		id                  int64
 	}{
-		{name: "active", id: activeID, status: "active"},
-		{name: "retired", id: retiredID, status: "retired"},
-		{name: "superseded", id: supersededID, status: "superseded"},
+		{name: "active", id: activeID, status: "active", title: "Active fact"},
+		{name: "retired", id: retiredID, status: "retired", title: "retired fact"},
+		{name: "superseded", id: supersededID, status: "superseded", title: "before"},
+		{name: "degenerate title fallback", id: degenerateID, status: "active", title: "code-only"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -130,7 +136,7 @@ func TestBrainFactHTTPAPIIncludesHistoricalRowsAndErrors(t *testing.T) {
 			if err := json.Unmarshal(recorder.Body.Bytes(), &fact); err != nil {
 				t.Fatal(err)
 			}
-			if fact["status"] != tc.status || fact["ownerKind"] != "agent" || fact["ownerRef"] != "builder" || fact["content"] == "" || fact["firstConfirmedAt"] == "" || fact["updatedAt"] == "" {
+			if fact["status"] != tc.status || fact["title"] != tc.title || fact["ownerKind"] != "agent" || fact["ownerRef"] != "builder" || fact["content"] == "" || fact["firstConfirmedAt"] == "" || fact["updatedAt"] == "" {
 				t.Fatalf("fact=%s", recorder.Body.String())
 			}
 			switch tc.status {

--- a/internal/cli/memory_harvest.go
+++ b/internal/cli/memory_harvest.go
@@ -396,6 +396,7 @@ func harvestObservations(ctx context.Context, store *db.Store, candidate db.Memo
 			continue
 		}
 		hash := memory.ContentHash(content)
+		slug := memory.Slug(firstWords(memory.Title(content), 6))
 		dkey := db.MemoryDedupKey(memory.ScopeRepo, payload.Repo, hash)
 		if _, duplicate := seen[dkey]; duplicate {
 			continue
@@ -407,12 +408,23 @@ func harvestObservations(ctx context.Context, store *db.Store, candidate db.Memo
 		out = append(out, db.MemoryObservation{
 			Owner:     db.MemoryOwner{Kind: memory.OwnerKindShared, Ref: memory.SharedOwnerRef},
 			AuthorRef: author, Repo: payload.Repo, Scope: memory.ScopeRepo,
-			Key: "harvest-" + hash, Content: content,
+			Key: "harvest-" + slug + "-" + hash[:16], Content: content,
 			Provenance: "harvest:" + candidate.ResultHash, TrustMark: memory.TrustLow,
 			SourceJob: candidate.JobID,
 		})
 	}
 	return out, nil
+}
+
+func firstWords(s string, n int) string {
+	words := strings.Fields(s)
+	if n <= 0 {
+		return ""
+	}
+	if len(words) > n {
+		words = words[:n]
+	}
+	return strings.Join(words, " ")
 }
 
 func normalizeHarvestAtom(value string) string {

--- a/internal/cli/memory_harvest_test.go
+++ b/internal/cli/memory_harvest_test.go
@@ -155,8 +155,68 @@ func TestHarvestObservationDedupAndMetadata(t *testing.T) {
 	if got.Owner.Kind != memory.OwnerKindShared || got.Owner.Ref != memory.SharedOwnerRef || got.AuthorRef != "persistent-author" ||
 		got.Repo != "owner/repo" || got.Scope != memory.ScopeRepo || got.TrustMark != memory.TrustLow ||
 		got.Provenance != "harvest:"+candidate.ResultHash || got.SourceJob != candidate.JobID ||
-		got.Key != "harvest-"+memory.ContentHash(got.Content) {
+		got.Key != "harvest-sqlite-uses-a-pure-go-modernc-driver-"+memory.ContentHash(got.Content)[:16] {
 		t.Fatalf("harvest metadata = %+v", got)
+	}
+}
+
+func harvestObservationForContent(t *testing.T, content string) db.MemoryObservation {
+	t.Helper()
+	store, err := db.Open(filepath.Join(t.TempDir(), "harvest-key.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	candidate := harvestTestCandidate(t, nil, nil)
+	var payload workflow.JobPayload
+	if err := json.Unmarshal([]byte(candidate.Payload), &payload); err != nil {
+		t.Fatal(err)
+	}
+	observations, err := harvestObservations(context.Background(), store, candidate, payload, []string{content})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(observations) != 1 {
+		t.Fatalf("observations = %+v, want one", observations)
+	}
+	return observations[0]
+}
+
+func TestHarvestSlugReadable(t *testing.T) {
+	got := harvestObservationForContent(t, "Deployments use canaries before production traffic moves. Rollback remains automatic.")
+	want := "harvest-deployments-use-canaries-before-production-traffic-" + memory.ContentHash(got.Content)[:16]
+	if got.Key != want {
+		t.Fatalf("key = %q, want %q", got.Key, want)
+	}
+}
+
+func TestHarvestSlugStableForSameContent(t *testing.T) {
+	content := "Deployments use canaries before production traffic moves."
+	first := harvestObservationForContent(t, content)
+	second := harvestObservationForContent(t, content)
+	if first.Key != second.Key {
+		t.Fatalf("same content keys differ: %q vs %q", first.Key, second.Key)
+	}
+}
+
+func TestHarvestSlugDistinctForDistinctContent(t *testing.T) {
+	first := harvestObservationForContent(t, "Deployments use canaries. First detail follows.")
+	second := harvestObservationForContent(t, "Deployments use canaries! Second detail follows.")
+	firstPrefix := strings.TrimSuffix(first.Key, memory.ContentHash(first.Content)[:16])
+	secondPrefix := strings.TrimSuffix(second.Key, memory.ContentHash(second.Content)[:16])
+	if firstPrefix != secondPrefix {
+		t.Fatalf("title slugs differ: %q vs %q", firstPrefix, secondPrefix)
+	}
+	if first.Key == second.Key {
+		t.Fatalf("distinct content produced the same key: %q", first.Key)
+	}
+}
+
+func TestHarvestSlugDegenerateContent(t *testing.T) {
+	got := harvestObservationForContent(t, "```go\nfmt.Println(\"hello\")\n```")
+	want := "harvest-untitled-" + memory.ContentHash(got.Content)[:16]
+	if got.Key != want {
+		t.Fatalf("key = %q, want %q", got.Key, want)
 	}
 }
 

--- a/internal/memory/title.go
+++ b/internal/memory/title.go
@@ -1,0 +1,155 @@
+package memory
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const titleMaxRunes = 60
+
+// Title derives a short, human-readable display title from memory content.
+// It is deliberately pure: titles are derived at presentation time and never
+// participate in stable memory keys or persistence.
+func Title(content string) string {
+	// Reuse the same frontmatter parser as ingest so title derivation and
+	// chunking agree — notably it keeps the whole body when an opening "---"
+	// has no closing fence, rather than swallowing it.
+	_, body := StripFrontmatter(content)
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+
+	inFence := false
+	var line string
+	for _, candidate := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(candidate)
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || trimmed == "" {
+			continue
+		}
+		line = trimmed
+		break
+	}
+	if line == "" {
+		return ""
+	}
+
+	line = stripTitleBlockMarkers(line)
+	line = stripTitleBoldLabel(line)
+	line = stripTitleInlineMarkup(line)
+	line = strings.Join(strings.Fields(line), " ")
+	if line == "" {
+		return ""
+	}
+
+	for i := 0; i < len(line); i++ {
+		if (line[i] == '.' || line[i] == '!' || line[i] == '?') && (i+1 == len(line) || line[i+1] == ' ') {
+			line = strings.TrimSpace(line[:i])
+			break
+		}
+	}
+	if line == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(line) <= titleMaxRunes {
+		return line
+	}
+
+	runes := []rune(line)
+	prefix := runes[:titleMaxRunes]
+	for i := len(prefix) - 1; i >= 0; i-- {
+		if prefix[i] == ' ' {
+			return string(prefix[:i]) + "…"
+		}
+	}
+	return string(prefix) + "…"
+}
+
+func stripTitleBlockMarkers(line string) string {
+	for {
+		before := line
+		if strings.HasPrefix(line, ">") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, ">"))
+		}
+		if headingLen := titleHeadingMarkerLen(line); headingLen > 0 {
+			line = strings.TrimSpace(line[headingLen:])
+		}
+		if listLen := titleListMarkerLen(line); listLen > 0 {
+			line = strings.TrimSpace(line[listLen:])
+		}
+		if line == before {
+			return line
+		}
+	}
+}
+
+func titleHeadingMarkerLen(line string) int {
+	i := 0
+	for i < len(line) && line[i] == '#' && i < 6 {
+		i++
+	}
+	if i > 0 && i < len(line) && line[i] == ' ' {
+		return i + 1
+	}
+	return 0
+}
+
+func titleListMarkerLen(line string) int {
+	if len(line) >= 2 && (line[0] == '-' || line[0] == '*' || line[0] == '+') && line[1] == ' ' {
+		return 2
+	}
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+	if i > 0 && i+1 < len(line) && (line[i] == '.' || line[i] == ')') && line[i+1] == ' ' {
+		return i + 2
+	}
+	return 0
+}
+
+func stripTitleBoldLabel(line string) string {
+	for _, marker := range []string{"**", "__"} {
+		if !strings.HasPrefix(line, marker) {
+			continue
+		}
+		if end := strings.Index(line[len(marker):], marker); end >= 0 {
+			end += len(marker)
+			if strings.HasSuffix(line[len(marker):end], ":") {
+				return strings.TrimSpace(line[end+len(marker):])
+			}
+		}
+	}
+	return line
+}
+
+func stripTitleInlineMarkup(line string) string {
+	var out strings.Builder
+	for i := 0; i < len(line); {
+		labelStart := i
+		if line[i] == '!' && i+1 < len(line) && line[i+1] == '[' {
+			labelStart++
+		}
+		if line[labelStart] == '[' {
+			if labelEnd := strings.IndexByte(line[labelStart+1:], ']'); labelEnd >= 0 {
+				labelEnd += labelStart + 1
+				if labelEnd+1 < len(line) && line[labelEnd+1] == '(' {
+					if targetEnd := strings.IndexByte(line[labelEnd+2:], ')'); targetEnd >= 0 {
+						out.WriteString(line[labelStart+1 : labelEnd])
+						i = labelEnd + 2 + targetEnd + 1
+						continue
+					}
+				}
+			}
+		}
+		if line[i] != '`' && line[i] != '*' && line[i] != '_' {
+			out.WriteByte(line[i])
+		}
+		i++
+	}
+	return out.String()
+}

--- a/internal/memory/title_test.go
+++ b/internal/memory/title_test.go
@@ -1,0 +1,46 @@
+package memory
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTitle(t *testing.T) {
+	sixty := strings.Repeat("a", 60)
+	tests := []struct {
+		name, content, want string
+	}{
+		{name: "plain sentence", content: "Deployment uses the canary lane", want: "Deployment uses the canary lane"},
+		{name: "first sentence", content: "Deployment uses canaries. Rollback is automatic.", want: "Deployment uses canaries"},
+		{name: "word boundary truncation", content: "The deployment process always verifies production health before moving traffic to the newest release", want: "The deployment process always verifies production health…"},
+		{name: "heading", content: "# Deployment process", want: "Deployment process"},
+		{name: "list bullet", content: "- Deployment process", want: "Deployment process"},
+		{name: "ordered list", content: "12) Deployment process", want: "Deployment process"},
+		{name: "blockquote", content: "> Deployment process", want: "Deployment process"},
+		{name: "bold label", content: "**Why:** Deployment process", want: "Deployment process"},
+		{name: "underscore bold label", content: "__How to apply:__ Use the canary lane", want: "Use the canary lane"},
+		{name: "plain label stays", content: "Note: Deployment process", want: "Note: Deployment process"},
+		{name: "inline markup", content: "Use `git status` with [the guide](https://example.com) and ![diagram](diagram.png) for **safe** _deploys_", want: "Use git status with the guide and diagram for safe deploys"},
+		{name: "frontmatter", content: "---\nrepo: acme/widget\n---\n\n## Deployment process", want: "Deployment process"},
+		{name: "all code", content: "```go\nfmt.Println(\"hello\")\n```", want: ""},
+		{name: "empty", content: " \n\t ", want: ""},
+		{name: "slug hard cut", content: strings.Repeat("a", 70), want: sixty + "…"},
+		{name: "multibyte rune boundary", content: strings.Repeat("界", 61), want: strings.Repeat("界", 60) + "…"},
+		{name: "exact boundary", content: sixty, want: sixty},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Title(tc.content)
+			if got != tc.want {
+				t.Fatalf("Title(%q) = %q, want %q", tc.content, got, tc.want)
+			}
+			if gotAgain := Title(tc.content); gotAgain != got {
+				t.Fatalf("Title is not deterministic: first %q, second %q", got, gotAgain)
+			}
+			if tc.name == "multibyte rune boundary" && !utf8.ValidString(got) {
+				t.Fatalf("Title returned invalid UTF-8: %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes part of #1077 (parts 1+2). The Brain page showed `confirmed_memories.key` as a fact's name, and two of three creation paths mint unreadable keys (`harvest-<sha256>`, `>60-char`/`-untitled` ingest keys).

## What ships here

**Part 1 — derived display titles (retroactive, zero-migration).** New deterministic, pure `memory.Title(content)` (`internal/memory/title.go`): frontmatter via the shared `memory.StripFrontmatter`, then markdown-scaffolding / bold-label (`**Why:**`) / inline-markup stripping → first sentence → 60-rune word-boundary truncation. Returns `""` so callers fall back to `key`. `dashboardBrainFact` gains a `Title` field (always non-empty). Because titles derive from content at render time, **all existing rows are fixed with zero data migration**, and the 249 stable `#804` ingest keys are untouched (title is display-only, never written to `key`).

**Part 2 — readable harvest keys.** Harvest observations now key on `harvest-<slug>-<hash16>` — a deterministic Go slug from the derived title plus a 64-bit content-hash discriminator. Still content-addressed, so a re-harvest of identical content stays idempotent via the existing key-match; the content hash stays recomputable; provenance is unchanged.

## Provenance / quality

- Design came from a **tri-model design panel** (sol + kimi + opus) that converged on this approach; a **`/code-review high`** (fresh-context finders + verifiers) reviewed the diff.
- That review is *why* **part 3 (content-hash dedup at confirm) was split out** into **#1082**: the naive content-match collapsed distinct-key notes, dropped `Context`, and suppressed the #988 changelog event. Groom already retires exact-duplicate content downstream, so deferring it is transient-cosmetic, not an integrity gap. #1082 carries the findings + two candidate redesigns; it sequences after #1078.
- Two review nits fixed here: part-1 reuses `StripFrontmatter` (was a divergent copy that mishandled unterminated frontmatter); part-2 hash suffix widened 48→64-bit (the old full-hash key was collision-free — this keeps overwrite risk negligible).

## Deferred fast-follows (out of scope, noted)
- **Cross-module `KnowledgeFact.Title`** (the Brain **graph-node label** — the primary UI surface): additive field in the separate `gitmoot-dashboard` module + a pin bump, riding the post-Aug-5 frontend change.
- **Distiller job-domain tightening** (drop off-domain web trivia) — separate PR with a harvest-yield eval.

## Deploy notes
Code-only, **zero database migration**. Dashboard-visible behavior (a client rendering the new `title` field) rides the **post-Aug-5** deploy (judging freeze); nothing to deploy from this PR. Single static binary invariant preserved (stdlib only, no new deps).

## Gate
`go build` / `go vet` / `go test ./...` / `go generate && git diff` all green; focused `-race` on memory/db/cli green. Full sharded race runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
