### PR TITLE
feat(org): overdue-dispatch refusal (opt-in) — org phase 3 slice 2 (#1061)

### DIFF
--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -77,6 +77,8 @@ var newOrgProvider = func(roles []string) org.Provider { return cockpit.NewHerdr
 
 var orgDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
 
+var orgRecycleAdvisoryWriter io.Writer = os.Stderr
+
 func runOrg(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
 		printOrgUsage(stdout)
@@ -499,10 +501,40 @@ func validateAndTouchActingOrgRole(ctx context.Context, store *db.Store, home, r
 	if !cfg.Enabled() {
 		return errors.New("--org-role requires an enabled organization registry; run `gitmoot org init`")
 	}
-	if _, ok := cfg.Role(role); !ok {
+	configuredRole, ok := cfg.Role(role)
+	if !ok {
 		return fmt.Errorf("unknown org role %q", role)
 	}
-	return store.TouchOrgRolePresence(ctx, role, command)
+	// Recycle enforcement only applies to operator-origin --org-role dispatches:
+	// this ingress (dispatchLocalAgentJob) is the sole path passing a non-empty
+	// ActingOrgRole, and today only agent ask/run/implement/orchestrate
+	// (OperatorOrigin) do so. Delegated/engine children enqueue via the mailbox
+	// and never reach here, so an inherited role cannot be refused mid-tree.
+	touchRole := role
+	if mode := cfg.RecycleEnforce(); mode != "off" {
+		// Read/touch under the registry's canonical name; TouchOrgRolePresence
+		// also canonicalizes the key, so a stale case-variant presence row cannot
+		// let an overdue role slip past the enforcement read.
+		touchRole = configuredRole.Name
+		recycleAfter := cfg.RecycleAfterFor(configuredRole.Name)
+		if recycleAfter > 0 {
+			presence, found, err := store.GetOrgRolePresence(ctx, configuredRole.Name)
+			if err != nil {
+				return fmt.Errorf("read org role %q presence: %w", configuredRole.Name, err)
+			}
+			if found {
+				age, known, overdue := orgRecycleAge(presence.LastSeenAt, time.Now().UTC(), recycleAfter)
+				if known && overdue {
+					message := fmt.Sprintf("org role %q is overdue for recycling (idle %s ≥ recycle_after %s); journal a handoff note and recycle before dispatching new work", configuredRole.Name, age, formatOrgRecycleAfter(recycleAfter))
+					if mode == "block" {
+						return errors.New(message)
+					}
+					fmt.Fprintf(orgRecycleAdvisoryWriter, "warning: %s\n", message)
+				}
+			}
+		}
+	}
+	return store.TouchOrgRolePresence(ctx, touchRole, command)
 }
 
 func dash(value string) string {
@@ -545,15 +577,11 @@ func orgRecycleStatus(lastSeen string, now time.Time, state org.LifecycleState, 
 	if recycleAfter <= 0 {
 		return "off"
 	}
-	observed, ok := parseOrgPresenceTime(lastSeen)
-	if !ok {
+	_, known, overdue := orgRecycleAge(lastSeen, now, recycleAfter)
+	if !known {
 		return "off"
 	}
-	age := now.Sub(observed.UTC())
-	if age < 0 {
-		age = 0
-	}
-	if age < recycleAfter {
+	if !overdue {
 		return "fresh"
 	}
 	if activeJobs > 0 {
@@ -565,6 +593,21 @@ func orgRecycleStatus(lastSeen string, now time.Time, state org.LifecycleState, 
 	default:
 		return "overdue"
 	}
+}
+
+func orgRecycleAge(lastSeen string, now time.Time, recycleAfter time.Duration) (age time.Duration, known, overdue bool) {
+	if recycleAfter <= 0 {
+		return 0, false, false
+	}
+	observed, ok := parseOrgPresenceTime(lastSeen)
+	if !ok {
+		return 0, false, false
+	}
+	age = now.Sub(observed.UTC())
+	if age < 0 {
+		age = 0
+	}
+	return age, true, age >= recycleAfter
 }
 
 func formatOrgRecycleAfter(value time.Duration) string {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -438,6 +440,7 @@ func TestOrgRecycleStatus(t *testing.T) {
 	}{
 		{name: "off without policy", lastSeen: now.Add(-48 * time.Hour).Format(time.RFC3339), state: org.StateIdle, want: "off"},
 		{name: "off without presence", state: org.StateIdle, recycleAfter: 24 * time.Hour, want: "off"},
+		{name: "off with malformed presence", lastSeen: "not-a-timestamp", state: org.StateIdle, recycleAfter: 24 * time.Hour, want: "off"},
 		{name: "fresh", lastSeen: now.Add(-time.Hour).Format(time.RFC3339), state: org.StateWorking, recycleAfter: 24 * time.Hour, want: "fresh"},
 		{name: "eligible idle", lastSeen: now.Add(-24 * time.Hour).Format(time.RFC3339), state: org.StateIdle, recycleAfter: 24 * time.Hour, want: "eligible"},
 		{name: "eligible done", lastSeen: now.Add(-25 * time.Hour).Format(time.RFC3339), state: org.StateDone, recycleAfter: 24 * time.Hour, want: "eligible"},
@@ -608,6 +611,129 @@ func TestValidateAndTouchActingOrgRole(t *testing.T) {
 	presence, err := store.ListOrgRolePresence(ctx)
 	if err != nil || len(presence) != 1 || presence[0].Role != "review" || presence[0].LastCommand != "agent_run" {
 		t.Fatalf("presence = %+v err=%v", presence, err)
+	}
+}
+
+func TestValidateAndTouchActingOrgRoleRecycleEnforcement(t *testing.T) {
+	old := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+	for _, test := range []struct {
+		name         string
+		requestRole  string
+		mode         string
+		recycleAfter string
+		seedPresence bool
+		seedAt       time.Time
+		wantError    bool
+		wantWarning  bool
+		wantTouch    bool
+	}{
+		{name: "block overdue", mode: "block", recycleAfter: "1h", seedPresence: true, seedAt: old, wantError: true},
+		{name: "block overdue case variant", requestRole: "OWNER", mode: "block", recycleAfter: "1h", seedPresence: true, seedAt: old, wantError: true},
+		{name: "warn overdue", mode: "warn", recycleAfter: "1h", seedPresence: true, seedAt: old, wantWarning: true, wantTouch: true},
+		{name: "off overdue", mode: "off", recycleAfter: "1h", seedPresence: true, seedAt: old, wantTouch: true},
+		{name: "default off overdue", recycleAfter: "1h", seedPresence: true, seedAt: old, wantTouch: true},
+		{name: "block fresh", mode: "block", recycleAfter: "24h", seedPresence: true, seedAt: time.Now().UTC(), wantTouch: true},
+		{name: "block missing presence", mode: "block", recycleAfter: "1h", wantTouch: true},
+		{name: "block without recycle after", mode: "block", seedPresence: true, seedAt: old, wantTouch: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home, paths := setupOrgRecycleEnforcementHome(t, test.mode, test.recycleAfter)
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			if test.seedPresence {
+				seedOrgRolePresenceAt(t, paths, "owner", test.seedAt, "seed")
+			}
+			before, beforeFound, err := store.GetOrgRolePresence(context.Background(), "owner")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var warning bytes.Buffer
+			originalWriter := orgRecycleAdvisoryWriter
+			orgRecycleAdvisoryWriter = &warning
+			t.Cleanup(func() { orgRecycleAdvisoryWriter = originalWriter })
+			requestRole := test.requestRole
+			if requestRole == "" {
+				requestRole = "owner"
+			}
+			err = validateAndTouchActingOrgRole(context.Background(), store, home, requestRole, "agent_run")
+			if (err != nil) != test.wantError {
+				t.Fatalf("validateAndTouchActingOrgRole() error = %v, wantError=%v", err, test.wantError)
+			}
+			if test.wantError && (!strings.Contains(err.Error(), "overdue for recycling") || !strings.Contains(err.Error(), "handoff note")) {
+				t.Fatalf("block error is not actionable: %v", err)
+			}
+			if gotWarning := warning.String() != ""; gotWarning != test.wantWarning {
+				t.Fatalf("warning = %q, wantWarning=%v", warning.String(), test.wantWarning)
+			}
+			if test.wantWarning && (!strings.Contains(warning.String(), "warning:") || !strings.Contains(warning.String(), "handoff note")) {
+				t.Fatalf("warning is not actionable: %q", warning.String())
+			}
+
+			after, afterFound, err := store.GetOrgRolePresence(context.Background(), "owner")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !test.wantTouch {
+				if afterFound != beforeFound || after != before {
+					t.Fatalf("blocked dispatch touched presence: before=%+v/%v after=%+v/%v", before, beforeFound, after, afterFound)
+				}
+				return
+			}
+			if !afterFound || after.LastCommand != "agent_run" {
+				t.Fatalf("allowed dispatch did not touch presence: %+v found=%v", after, afterFound)
+			}
+			if beforeFound && test.seedAt.Equal(old) && after.LastSeenAt == before.LastSeenAt {
+				t.Fatalf("allowed overdue dispatch did not reset last_seen_at: before=%+v after=%+v", before, after)
+			}
+		})
+	}
+}
+
+func setupOrgRecycleEnforcementHome(t *testing.T, mode, recycleAfter string) (string, config.Paths) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	var body strings.Builder
+	body.WriteString("\n[org]\n")
+	if mode != "" {
+		fmt.Fprintf(&body, "recycle_enforce = %q\n", mode)
+	}
+	if recycleAfter != "" {
+		fmt.Fprintf(&body, "recycle_after = %q\n", recycleAfter)
+	}
+	body.WriteString("[org.roles.\"owner\"]\nscope = [\"*\"]\n")
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(body.String()); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return home, paths
+}
+
+func seedOrgRolePresenceAt(t *testing.T, paths config.Paths, role string, at time.Time, command string) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`INSERT INTO org_role_presence(role, last_seen_at, last_command)
+		VALUES (?, ?, ?)
+		ON CONFLICT(role) DO UPDATE SET last_seen_at = excluded.last_seen_at, last_command = excluded.last_command`, role, at.UTC().Format("2006-01-02 15:04:05"), command); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -26,9 +26,10 @@ type OrgRole struct {
 // OrgConfig is the local organization registry. Its fields stay private so the
 // loader remains the single place that establishes its invariants.
 type OrgConfig struct {
-	enforce      string
-	recycleAfter time.Duration
-	roles        map[string]OrgRole
+	enforce        string
+	recycleAfter   time.Duration
+	recycleEnforce string
+	roles          map[string]OrgRole
 }
 
 func (c OrgConfig) Enabled() bool { return len(c.roles) > 0 }
@@ -50,6 +51,13 @@ func (c OrgConfig) RecycleAfterFor(role string) time.Duration {
 		return configured.RecycleAfter
 	}
 	return c.recycleAfter
+}
+
+func (c OrgConfig) RecycleEnforce() string {
+	if c.recycleEnforce == "" {
+		return "off"
+	}
+	return c.recycleEnforce
 }
 
 // Ancestors returns name's parent chain, nearest parent first. The cycle guard
@@ -143,6 +151,7 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 	seenOrgSection := false
 	seenEnforce := false
 	seenRecycleAfter := false
+	seenRecycleEnforce := false
 	current := ""
 	inOrg := false
 	lines := strings.Split(string(content), "\n")
@@ -197,9 +206,9 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 		}
 		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
 		if current == "" {
-			// recycle_after is binary-first: binaries predating this allowlist
-			// fail closed on a config that uses the field.
-			if key != "enforce" && key != "recycle_after" {
+			// Recycle fields are binary-first: binaries predating this allowlist
+			// fail closed on a config that uses either field.
+			if key != "enforce" && key != "recycle_after" && key != "recycle_enforce" {
 				return OrgConfig{}, fmt.Errorf("unknown [org] field %q", key)
 			}
 			switch key {
@@ -223,6 +232,16 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 					return OrgConfig{}, fmt.Errorf("parse [org].recycle_after: %w", err)
 				}
 				cfg.recycleAfter = v
+			case "recycle_enforce":
+				if seenRecycleEnforce {
+					return OrgConfig{}, fmt.Errorf("duplicate [org].recycle_enforce")
+				}
+				seenRecycleEnforce = true
+				v, err := parseOrgTOMLString(value)
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("parse [org].recycle_enforce: %w", err)
+				}
+				cfg.recycleEnforce = v
 			}
 			continue
 		}
@@ -390,6 +409,9 @@ func ValidateOrg(cfg OrgConfig) error {
 	}
 	if cfg.recycleAfter < 0 {
 		return fmt.Errorf("org recycle_after must not be negative")
+	}
+	if mode := cfg.RecycleEnforce(); mode != "off" && mode != "warn" && mode != "block" {
+		return fmt.Errorf("org recycle_enforce must be \"off\", \"warn\", or \"block\"")
 	}
 	// Validate in sorted, structural passes so malformed registries return the
 	// same error regardless of Go map iteration order. Root naming deliberately

--- a/internal/config/org_test.go
+++ b/internal/config/org_test.go
@@ -105,6 +105,58 @@ func TestLoadOrgRecycleAfterFailsClosed(t *testing.T) {
 	}
 }
 
+func TestLoadOrgRecycleEnforce(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{name: "unset defaults off", want: "off"},
+		{name: "explicit off", field: "recycle_enforce = \"off\"\n", want: "off"},
+		{name: "warn", field: "recycle_enforce = \"warn\"\n", want: "warn"},
+		{name: "block", field: "recycle_enforce = \"block\"\n", want: "block"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			body := "[org]\n" + test.field + "[org.roles.\"owner\"]\nscope=[\"*\"]\n"
+			if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadOrg(paths)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := cfg.RecycleEnforce(); got != test.want {
+				t.Fatalf("RecycleEnforce() = %q, want %q", got, test.want)
+			}
+		})
+	}
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "invalid", body: "[org]\nrecycle_enforce=\"strict\"\n[org.roles.\"owner\"]\nscope=[\"*\"]\n", want: "recycle_enforce must be"},
+		{name: "duplicate", body: "[org]\nrecycle_enforce=\"off\"\nrecycle_enforce=\"block\"\n[org.roles.\"owner\"]\nscope=[\"*\"]\n", want: "duplicate [org].recycle_enforce"},
+		{name: "per role override rejected", body: "[org.roles.\"owner\"]\nscope=[\"*\"]\nrecycle_enforce=\"block\"\n", want: "unknown field"},
+		{name: "unknown remains rejected", body: "[org]\nrecycle_enforce=\"off\"\nrecycle_mode=\"block\"\n[org.roles.\"owner\"]\nscope=[\"*\"]\n", want: "unknown [org] field"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.WriteFile(paths.ConfigFile, []byte(test.body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadOrg(paths); err == nil {
+				t.Fatal("LoadOrg() error = nil, want fail-closed rejection")
+			} else if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("LoadOrg() error = %q, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestOrgConfigAncestors(t *testing.T) {
 	cfg := OrgConfig{roles: map[string]OrgRole{
 		"owner":      {Name: "owner"},

--- a/internal/db/org_presence_store.go
+++ b/internal/db/org_presence_store.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"strings"
 )
@@ -13,7 +14,11 @@ type OrgRolePresence struct {
 }
 
 func (s *Store) TouchOrgRolePresence(ctx context.Context, role, command string) error {
-	role = strings.TrimSpace(role)
+	// Canonicalize the key (trim+lower). Org role names are validated lowercase
+	// (validOrgRoleName), but cfg.Role accepts case-insensitively, so a raw
+	// --org-role like "OWNER" must not create a case-variant row the recycle
+	// enforcement read (GetOrgRolePresence) would then miss.
+	role = strings.ToLower(strings.TrimSpace(role))
 	command = strings.TrimSpace(command)
 	if role == "" {
 		return errors.New("org role is required")
@@ -24,6 +29,19 @@ func (s *Store) TouchOrgRolePresence(ctx context.Context, role, command string) 
 			last_seen_at = CURRENT_TIMESTAMP,
 			last_command = excluded.last_command`, role, command)
 	return err
+}
+
+func (s *Store) GetOrgRolePresence(ctx context.Context, role string) (OrgRolePresence, bool, error) {
+	var presence OrgRolePresence
+	err := s.db.QueryRowContext(ctx, `SELECT role, last_seen_at, last_command
+		FROM org_role_presence WHERE role = ?`, strings.ToLower(strings.TrimSpace(role))).Scan(&presence.Role, &presence.LastSeenAt, &presence.LastCommand)
+	if errors.Is(err, sql.ErrNoRows) {
+		return OrgRolePresence{}, false, nil
+	}
+	if err != nil {
+		return OrgRolePresence{}, false, err
+	}
+	return presence, true, nil
 }
 
 func (s *Store) ListOrgRolePresence(ctx context.Context) ([]OrgRolePresence, error) {

--- a/internal/db/org_presence_store_test.go
+++ b/internal/db/org_presence_store_test.go
@@ -34,6 +34,39 @@ func TestOrgRolePresenceMigrationAndUpsert(t *testing.T) {
 	if len(presence) != 2 || presence[0].Role != "owner" || presence[0].LastCommand != "agent run" || presence[0].LastSeenAt == "" || presence[1].Role != "review" {
 		t.Fatalf("presence = %+v", presence)
 	}
+	owner, found, err := store.GetOrgRolePresence(ctx, " owner ")
+	if err != nil || !found || owner.Role != "owner" || owner.LastCommand != "agent run" || owner.LastSeenAt == "" {
+		t.Fatalf("GetOrgRolePresence(owner) = %+v, %v, %v", owner, found, err)
+	}
+	missing, found, err := store.GetOrgRolePresence(ctx, "missing")
+	if err != nil || found || missing != (OrgRolePresence{}) {
+		t.Fatalf("GetOrgRolePresence(missing) = %+v, %v, %v", missing, found, err)
+	}
+}
+
+func TestOrgRolePresenceKeyIsCanonicalized(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	// A raw case-variant --org-role (e.g. "OWNER") must land on the canonical
+	// row so recycle enforcement's canonical read cannot miss it (the off->block
+	// case-staleness class).
+	if err := store.TouchOrgRolePresence(ctx, "OWNER", "agent run"); err != nil {
+		t.Fatalf("TouchOrgRolePresence(OWNER) error = %v", err)
+	}
+	rows, err := store.ListOrgRolePresence(ctx)
+	if err != nil || len(rows) != 1 || rows[0].Role != "owner" {
+		t.Fatalf("presence keyed non-canonically: %+v (err %v)", rows, err)
+	}
+	for _, lookup := range []string{"owner", "OWNER", " Owner "} {
+		got, found, err := store.GetOrgRolePresence(ctx, lookup)
+		if err != nil || !found || got.Role != "owner" {
+			t.Fatalf("GetOrgRolePresence(%q) = %+v, %v, %v; want canonical owner", lookup, got, found, err)
+		}
+	}
 }
 
 func TestTouchOrgRolePresenceRejectsEmptyRole(t *testing.T) {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1177,6 +1177,19 @@ Herdr snapshot. When configured, `brief --json` and `status --json` include the
 role's `pane` binding. Open escalations remain deferred to #1058's resolution
 and correlation contract.
 
+**Session lifecycle (phase 3).** `[org] recycle_after = "24h"` (a duration,
+per-role overridable via `[org.roles."name"] recycle_after`) marks a role
+recycle-overdue once it has been idle at least that long — surfaced read-only in
+the `recycle` column of `org status` (`off | fresh | eligible | overdue`).
+`[org] recycle_enforce = "off" | "warn" | "block"` (default `off`) then, for a
+role past its `recycle_after`, either refuses (`block`) new `--org-role`
+dispatches with an actionable error or logs a one-line advisory (`warn`) — the
+"overgrown sessions become impossible" economics; journaling a handoff note is
+never blocked, so an overdue role can always hand off. `recycle_enforce` needs a
+configured `recycle_after` to have any effect. Both fields are **binary-first**:
+a binary predating them fails closed on a config that uses them, so deploy the
+binary before any config sets them.
+
 Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
 `orchestrate`, and `task run` dispatches accept `--org-role <name>` (or the
 narrow `GITMOOT_ORG_ROLE` fallback). The role is validated and touched before

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1014,6 +1014,16 @@ live compatible Herdr snapshot. When configured, `brief --json` and `status
 `gitmoot org escalate`; their resolution and correlation surfaces are phase 2
 work.
 
+Session lifecycle (phase 3): `[org] recycle_after = "24h"` (a duration, per-role
+overridable) marks a role recycle-overdue after it has been idle that long,
+shown read-only in the `recycle` column of `org status`
+(`off | fresh | eligible | overdue`). `[org] recycle_enforce = "off" | "warn" |
+"block"` (default `off`) then refuses (`block`) or advises (`warn`) new
+`--org-role` dispatches from a role past its `recycle_after`, until it hands off
+and recycles; journaling a handoff note is never blocked. `recycle_enforce`
+needs a configured `recycle_after` to take effect. Both are binary-first —
+deploy the binary before any config sets them.
+
 Agent `ask`, `run`, `review`, `implement`, and `orchestrate` accept
 `--org-role <name>`. The role is validated and touched before dispatch, then
 stored as `acting_org_role` in the job payload for provenance, and its scope is


### PR DESCRIPTION
## What

Second slice of RFC #1042 **phase 3**. Refuses new `--org-role` dispatches from a coordinator role that is past its recycle age (idle ≥ `recycle_after`) — the "overgrown sessions become impossible" economics. Slice-1 detection stays read-only; enforcement is a **separate explicit opt-in**. Part of #1061.

Per owner ruling, this ships the **refusal core only** — the durable overdue event is deferred to a follow-up that will reuse G2's blocked-since repeat-per-interval sink (no parallel emitter built here).

## Changes

- **`[org] recycle_enforce = "off" | "warn" | "block"`** (default `off`), binary-first and fail-closed-validated. Setting `recycle_after` alone stays detection-only.
- Enforced at the single `--org-role` dispatch ingress (`validateAndTouchActingOrgRole`), checked **before** the presence touch — idle age would otherwise reset to ~0 and enforcement would never fire.
  - `block` → refuse with an actionable error (no touch → the role stays overdue until it recycles).
  - `warn` → one stderr advisory, then touch (naturally warns once per idle-overdue episode).
  - `off` → strict no-op, byte-identical to before for every current config.
- **Handoff is structurally exempt**: journaling a handoff note / `org escalate` writes directly to the store and never passes through this ingress, so a blocked role can always hand off + recycle. The refusal message points there.
- Shared `orgRecycleAge` helper so slice-1 display and slice-2 enforcement agree on the age threshold (behavior-preserving refactor of `orgRecycleStatus`).
- Presence keys are canonicalized (trim+lower) in `TouchOrgRolePresence`/`GetOrgRolePresence` so a raw case-variant `--org-role` can't create a stale row the enforcement read would miss.
- Docs: `recycle_after` (slice 1) + `recycle_enforce` documented in `CLI.md` + website `cli.md`, including the enforce-needs-a-threshold caveat and the binary-first deploy note.

No durable org event, no engine/Enqueue change, no `org recycle` command (slice 3).

## Review — xhigh (shared dispatch seam)

Three fresh-context finders on an isolated read-only worktree (enforcement-ordering/bypass, config fail-closed, shared-seam ripple), **no blocking findings**. The two worst-case ripple concerns were confirmed structurally safe:
- **A delegated child is never wrongly refused mid-tree** — delegated/engine jobs enqueue via the workflow mailbox, which never calls this CLI ingress; only operator `agent ask/run/implement/orchestrate` reach it.
- **No handoff deadlock** — the handoff/escalate paths bypass the ingress.

Also verified: `off` is a strict no-op; `block` aborts with zero partial state (no task/lock/worktree/job); the age check is strictly before the touch; the config validator only adds fail-closed rules. Three LOW findings were fixed in this PR: the presence-key case-staleness (canonicalized at the store, with a test), the overclaiming comment, and the docs gap. The operator-origin invariant is documented in a comment.

## Known follow-ups (noted, not fixed here)

- `recycle_enforce != off` with no `recycle_after` anywhere is a silent no-op (opt-in, fails permissive) — documented; a load-time advisory could be added later.
- A per-role `recycle_after = "0"` can't opt a role out of a global policy (0 = inherit) — an explicit per-role disable value is a follow-up.

## Sequence / deploy

Slice 2 of 3: detection → **refusal (this)** → `org recycle` orchestration (herdr `agent start --kind` behind the provider seam) + the deferred durable overdue event. No deploy (judging window). Merge owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
