### PR TITLE
feat(org): org phase 2 slice 2b — missed-wake counter + org-chart flag (#1060)

### DIFF
--- a/docs/cockpit-orchestrate.md
+++ b/docs/cockpit-orchestrate.md
@@ -102,6 +102,7 @@ inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
 inject_upstream_dep_context = false  # inject succeeded upstream dependency results into a dependent leg's prompt; default off
 max_delegation_token_budget = 0  # per-root delegation token budget (input+output); 0 = unlimited (off)
 max_delegation_cost_usd = 0      # per-root delegation dollar-cost budget (USD); 0 = unlimited (off)
+max_consecutive_missed_wakes = 0 # flag org roles after N stalled wakes; 0 = disabled
 default_delegation_timeout = ""  # default child-job timeout when a delegation omits one; "" = unbounded
 default_plan_timeout = ""        # per-phase defaults (plan/implement/review/gate/repair) that
 default_implement_timeout = ""   # win over default_delegation_timeout for legs tagged with
@@ -128,6 +129,10 @@ default_repair_timeout = ""
   aggregate cap also bounds the total inlined across all children.
 - `inject_upstream_dep_context` (default `false`) injects succeeded upstream
   dependency results into a dependent leg's prompt; default off.
+- `max_consecutive_missed_wakes` (default `0` = disabled) flags an organization
+  role in `org chart` and `org status` after that many consecutive
+  `agent_prompt_stalled` wake outcomes. A delivered wake resets the role; Herdr
+  transport failures do not count.
 - `max_delegation_token_budget` (default `0` = unlimited/off) bounds a delegation
   tree by **cost** in addition to depth/width/total-jobs/wall-clock. When set to a
   positive value, the whole tree under one root is capped at that many cumulative

--- a/docs/events.md
+++ b/docs/events.md
@@ -196,6 +196,16 @@ as delivered, `error.code = "agent_prompt_stalled"` as not delivered. Missing
 bindings, unavailable Herdr, stalls, and transport errors are swallowed after
 lightweight logging; they never block or fail a job.
 
+Each `agent_prompt_stalled` outcome increments a durable, consecutive counter
+for the wake role; a delivered prompt resets that role's counter. Transport
+errors and other non-delivery outcomes do not change it because a Herdr outage
+is infrastructure failure, not evidence that every role ignored a wake. Set
+`[orchestrate].max_consecutive_missed_wakes` to a positive integer to append a
+`⚠ flagged (N missed wakes)` marker to that role in `gitmoot org chart` and
+`gitmoot org status`; their JSON rows expose `missed_wakes`, `flagged`, and
+`flag_reason`. The default `0` disables flagging while leaving the best-effort
+counter available.
+
 ## Configuration
 
 Add an `[events]` section to the Gitmoot config file:

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -111,13 +111,23 @@ func (s *eventRuleSink) evaluate(ctx context.Context, event events.Event) {
 		delivered, stalled, err := s.wake.AgentPrompt(callCtx, pane, prompt, "")
 		cancel()
 		switch {
-		case err != nil:
-			slog.Warn("org event wake failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", err)
-		case stalled:
-			slog.Info("org event wake stalled", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", false)
 		case delivered:
+			if resetErr := s.store.ResetRoleMissedWake(ctx, rule.WakeRole); resetErr != nil {
+				slog.Warn("org event wake counter reset failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", resetErr)
+			}
 			slog.Info("org event wake delivered", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", true)
+		case stalled:
+			if incrementErr := s.store.IncrementRoleMissedWake(ctx, rule.WakeRole, time.Now().UTC()); incrementErr != nil {
+				slog.Warn("org event wake counter increment failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", incrementErr)
+			}
+			slog.Info("org event wake stalled", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", false)
+		case err != nil:
+			// A Herdr outage is infrastructure failure, not a role ignoring a wake;
+			// it must not falsely increment every role's missed-wake counter.
+			slog.Warn("org event wake failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", err)
 		default:
+			// An odd non-delivery is not proof that the role ignored a delivered
+			// prompt, so leave the counter unchanged just as for infrastructure errors.
 			slog.Info("org event wake not delivered", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", false)
 		}
 	}

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -112,14 +112,21 @@ func (s *eventRuleSink) evaluate(ctx context.Context, event events.Event) {
 		cancel()
 		switch {
 		case delivered:
-			if resetErr := s.store.ResetRoleMissedWake(ctx, rule.WakeRole); resetErr != nil {
+			// Bound the best-effort counter write like every other op on this path,
+			// so a SQLite-busy stall (shared-DB write contention) is cut at the probe
+			// timeout instead of blocking the next rule's wake for the 15s busy-timeout.
+			counterCtx, ccancel := context.WithTimeout(ctx, eventRuleProbeTimeout)
+			if resetErr := s.store.ResetRoleMissedWake(counterCtx, rule.WakeRole); resetErr != nil {
 				slog.Warn("org event wake counter reset failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", resetErr)
 			}
+			ccancel()
 			slog.Info("org event wake delivered", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", true)
 		case stalled:
-			if incrementErr := s.store.IncrementRoleMissedWake(ctx, rule.WakeRole, time.Now().UTC()); incrementErr != nil {
+			counterCtx, ccancel := context.WithTimeout(ctx, eventRuleProbeTimeout)
+			if incrementErr := s.store.IncrementRoleMissedWake(counterCtx, rule.WakeRole, time.Now().UTC()); incrementErr != nil {
 				slog.Warn("org event wake counter increment failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", incrementErr)
 			}
+			ccancel()
 			slog.Info("org event wake stalled", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "delivered", false)
 		case err != nil:
 			// A Herdr outage is infrastructure failure, not a role ignoring a wake;

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -21,6 +21,7 @@ type fakeEventWake struct {
 	prompt         string
 	until          string
 	labelToPane    map[string]string
+	stalled        bool
 }
 
 func (f *fakeEventWake) Available(context.Context) bool {
@@ -31,6 +32,9 @@ func (f *fakeEventWake) Available(context.Context) bool {
 func (f *fakeEventWake) AgentPrompt(_ context.Context, pane, prompt, until string) (bool, bool, error) {
 	f.promptCalls++
 	f.pane, f.prompt, f.until = pane, prompt, until
+	if f.stalled {
+		return false, true, nil
+	}
 	return true, false, nil
 }
 
@@ -102,6 +106,41 @@ func TestEventRuleEvaluatorResolvesPaneAndWakes(t *testing.T) {
 	}
 	if want := "gitmoot attention event for job job-1: Please choose"; wake.prompt != want {
 		t.Fatalf("prompt=%q want=%q", wake.prompt, want)
+	}
+}
+
+func TestEventRuleWakeStallIncrementsAndDeliveryResetsCounter(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[org.roles.\"owner\"]\nscope=[\"*\"]\npane=\"w1:p1\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{ID: "rule-counter", OnKind: "attention", WakeRole: "OWNER", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	wake := &fakeEventWake{stalled: true}
+	sink := &eventRuleSink{store: store, home: home, wake: wake}
+	event := events.Event{Type: events.EventJobNeedsAttention, Cause: "ask_gate", JobID: "job-counter"}
+	sink.evaluate(ctx, event)
+	misses, err := store.ListRoleMissedWakes(ctx)
+	if err != nil || len(misses) != 1 || misses[0].Role != "owner" || misses[0].Consecutive != 1 {
+		t.Fatalf("misses after stalled wake = %+v, err=%v", misses, err)
+	}
+
+	wake.stalled = false
+	sink.evaluate(ctx, event)
+	misses, err = store.ListRoleMissedWakes(ctx)
+	if err != nil || len(misses) != 0 {
+		t.Fatalf("misses after delivered wake = %+v, err=%v", misses, err)
 	}
 }
 

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -262,6 +262,9 @@ type orgStatusOutput struct {
 	ProviderVersion string             `json:"provider_version,omitempty"`
 	RecycleStatus   string             `json:"recycle,omitempty"`
 	RecycleAfter    string             `json:"recycle_after,omitempty"`
+	MissedWakes     int                `json:"missed_wakes,omitempty"`
+	Flagged         bool               `json:"flagged,omitempty"`
+	FlagReason      string             `json:"flag_reason,omitempty"`
 }
 
 func runOrgBrief(args []string, stdout, stderr io.Writer) int {
@@ -365,6 +368,25 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 		return 1
 	}
 	defer store.Close()
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org %s: %v\n", command, err)
+		return 1
+	}
+	policy, err := config.LoadOrchestratePolicy(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org %s: load orchestrate policy: %v\n", command, err)
+		return 1
+	}
+	missedWakeRows, err := store.ListRoleMissedWakes(ctx)
+	if err != nil {
+		fmt.Fprintf(stderr, "org %s: list missed wakes: %v\n", command, err)
+		return 1
+	}
+	missedWakes := make(map[string]int, len(missedWakeRows))
+	for _, row := range missedWakeRows {
+		missedWakes[row.Role] = row.Consecutive
+	}
 	snapshot, err := orgProviderSnapshot(ctx, cfg)
 	if err != nil {
 		fmt.Fprintf(stderr, "org %s: Herdr snapshot unavailable: %v\n", command, err)
@@ -379,6 +401,12 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 			live = org.RoleLiveState{State: org.StateUnknown, Detail: "provider snapshot omitted this role"}
 		}
 		seen := presence[role.Name]
+		consecutive := missedWakes[role.Name]
+		flagged := policy.MaxConsecutiveMissedWakes > 0 && consecutive >= policy.MaxConsecutiveMissedWakes
+		flagReason := ""
+		if flagged {
+			flagReason = fmt.Sprintf("%d consecutive missed wakes", consecutive)
+		}
 		recycleStatus := ""
 		recycleAfterText := ""
 		if command == "status" {
@@ -398,6 +426,7 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 			Scope: role.Scope, MergeRule: role.MergeRule, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
 			ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: snapshot.ObservedAt, ProviderVersion: snapshot.ProviderVersion,
 			RecycleStatus: recycleStatus, RecycleAfter: recycleAfterText,
+			MissedWakes: consecutive, Flagged: flagged, FlagReason: flagReason,
 		})
 	}
 	if command == "chart" {
@@ -415,15 +444,22 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 	}
 	if command == "chart" {
 		for _, row := range rows {
-			fmt.Fprintf(stdout, "%s%s · %s · scope=%s · merge=%s · seen=%s\n", strings.Repeat("  ", row.Depth), row.Role, row.ProviderState, strings.Join(row.Scope, ","), dash(row.MergeRule), dash(row.LastSeenAge))
+			fmt.Fprintf(stdout, "%s%s · %s · scope=%s · merge=%s · seen=%s%s\n", strings.Repeat("  ", row.Depth), row.Role, row.ProviderState, strings.Join(row.Scope, ","), dash(row.MergeRule), dash(row.LastSeenAge), orgMissedWakeFlag(row))
 		}
 		return 0
 	}
 	fmt.Fprintln(stdout, "ROLE\tSTATE\tLAST SEEN\tAGE\tLAST COMMAND\tDETAIL\tRECYCLE")
 	for _, row := range rows {
-		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\trecycle=%s\n", row.Role, row.ProviderState, dash(row.LastSeenAt), dash(row.LastSeenAge), dash(row.LastCommand), dash(row.ProviderDetail), firstNonEmpty(row.RecycleStatus, "off"))
+		fmt.Fprintf(stdout, "%s\t%s\t%s\t%s\t%s\t%s\trecycle=%s%s\n", row.Role, row.ProviderState, dash(row.LastSeenAt), dash(row.LastSeenAge), dash(row.LastCommand), dash(row.ProviderDetail), firstNonEmpty(row.RecycleStatus, "off"), orgMissedWakeFlag(row))
 	}
 	return 0
+}
+
+func orgMissedWakeFlag(row orgStatusOutput) string {
+	if !row.Flagged {
+		return ""
+	}
+	return fmt.Sprintf(" ⚠ flagged (%d missed wakes)", row.MissedWakes)
 }
 
 func printOrgBrief(w io.Writer, brief orgBriefOutput) {

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -373,19 +373,26 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 		fmt.Fprintf(stderr, "org %s: %v\n", command, err)
 		return 1
 	}
-	policy, err := config.LoadOrchestratePolicy(paths)
-	if err != nil {
-		fmt.Fprintf(stderr, "org %s: load orchestrate policy: %v\n", command, err)
-		return 1
+	// The missed-wake flag is a best-effort add-on (#1060 slice 2b): an unreadable
+	// [orchestrate] policy or missed-wake table must NEVER break the org chart/status
+	// diagnostic view, so a load error degrades to "flagging off" rather than exit 1.
+	// Reading the counters only when K>0 also keeps them fully invisible when flagging
+	// is disabled (the off-by-default contract — no missed_wakes JSON leak at K=0).
+	maxMissedWakes := 0
+	if policy, err := config.LoadOrchestratePolicy(paths); err != nil {
+		fmt.Fprintf(stderr, "org %s: missed-wake flag disabled (orchestrate policy unreadable): %v\n", command, err)
+	} else {
+		maxMissedWakes = policy.MaxConsecutiveMissedWakes
 	}
-	missedWakeRows, err := store.ListRoleMissedWakes(ctx)
-	if err != nil {
-		fmt.Fprintf(stderr, "org %s: list missed wakes: %v\n", command, err)
-		return 1
-	}
-	missedWakes := make(map[string]int, len(missedWakeRows))
-	for _, row := range missedWakeRows {
-		missedWakes[row.Role] = row.Consecutive
+	missedWakes := map[string]int{}
+	if maxMissedWakes > 0 {
+		if rows, err := store.ListRoleMissedWakes(ctx); err != nil {
+			fmt.Fprintf(stderr, "org %s: missed-wake counts unavailable: %v\n", command, err)
+		} else {
+			for _, row := range rows {
+				missedWakes[row.Role] = row.Consecutive
+			}
+		}
 	}
 	snapshot, err := orgProviderSnapshot(ctx, cfg)
 	if err != nil {
@@ -402,7 +409,7 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 		}
 		seen := presence[role.Name]
 		consecutive := missedWakes[role.Name]
-		flagged := policy.MaxConsecutiveMissedWakes > 0 && consecutive >= policy.MaxConsecutiveMissedWakes
+		flagged := maxMissedWakes > 0 && consecutive >= maxMissedWakes
 		flagReason := ""
 		if flagged {
 			flagReason = fmt.Sprintf("%d consecutive missed wakes", consecutive)

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -376,6 +376,105 @@ func TestRunOrgBriefChartStatusAndPresence(t *testing.T) {
 	}
 }
 
+func TestRunOrgOverviewFlagsConsecutiveMissedWakes(t *testing.T) {
+	home, paths := setupOrgHome(t)
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("\n[orchestrate]\nmax_consecutive_missed_wakes = 2\n"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	for range 2 {
+		if err := store.IncrementRoleMissedWake(ctx, "REVIEW", time.Now()); err != nil {
+			store.Close()
+			t.Fatal(err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	withOrgProvider(t, orgFixtureProvider{snapshot: org.Snapshot{
+		States: map[string]org.RoleLiveState{
+			"owner":  {State: org.StateWorking},
+			"review": {State: org.StateIdle},
+		},
+		ObservedAt: time.Date(2026, 7, 22, 9, 0, 0, 0, time.UTC), ProviderVersion: "0.7.5",
+	}})
+
+	for _, command := range []string{"chart", "status"} {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"org", command, "--home", home}, &stdout, &stderr); code != 0 {
+			t.Fatalf("%s code = %d stderr=%s", command, code, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "review") || !strings.Contains(stdout.String(), "⚠ flagged (2 missed wakes)") {
+			t.Fatalf("%s output = %q, want flagged review", command, stdout.String())
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "status", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status JSON code = %d stderr=%s", code, stderr.String())
+	}
+	var rows []orgStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("decode status JSON: %v; output=%s", err, stdout.String())
+	}
+	for _, row := range rows {
+		if row.Role == "review" {
+			if row.MissedWakes != 2 || !row.Flagged || row.FlagReason != "2 consecutive missed wakes" {
+				t.Fatalf("review status = %+v", row)
+			}
+			return
+		}
+	}
+	t.Fatalf("review role missing from status: %+v", rows)
+}
+
+func TestRunOrgOverviewZeroThresholdNeverFlags(t *testing.T) {
+	home, paths := setupOrgHome(t)
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.IncrementRoleMissedWake(context.Background(), "review", time.Now()); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	withOrgProvider(t, orgFixtureProvider{snapshot: org.Snapshot{States: map[string]org.RoleLiveState{
+		"owner": {State: org.StateWorking}, "review": {State: org.StateIdle},
+	}}})
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "chart", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("chart JSON code = %d stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), `"flagged"`) || strings.Contains(stdout.String(), `"flag_reason"`) {
+		t.Fatalf("zero threshold emitted flag fields: %s", stdout.String())
+	}
+	var rows []orgStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.Role == "review" && (row.Flagged || row.FlagReason != "" || row.MissedWakes != 1) {
+			t.Fatalf("review status with threshold off = %+v", row)
+		}
+	}
+}
+
 func TestRunOrgBriefAndStatusJSONSurfacePane(t *testing.T) {
 	home, paths := setupOrgHome(t)
 	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -461,17 +461,51 @@ func TestRunOrgOverviewZeroThresholdNeverFlags(t *testing.T) {
 	if code := Run([]string{"org", "chart", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("chart JSON code = %d stderr=%s", code, stderr.String())
 	}
-	if strings.Contains(stdout.String(), `"flagged"`) || strings.Contains(stdout.String(), `"flag_reason"`) {
-		t.Fatalf("zero threshold emitted flag fields: %s", stdout.String())
+	// Off-by-default: with the threshold at 0, the counter is FULLY invisible — no
+	// flag fields AND no missed_wakes leak — even though "review" has a stored miss.
+	if strings.Contains(stdout.String(), `"flagged"`) || strings.Contains(stdout.String(), `"flag_reason"`) || strings.Contains(stdout.String(), `"missed_wakes"`) {
+		t.Fatalf("zero threshold surfaced missed-wake state: %s", stdout.String())
 	}
 	var rows []orgStatusOutput
 	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
 		t.Fatal(err)
 	}
 	for _, row := range rows {
-		if row.Role == "review" && (row.Flagged || row.FlagReason != "" || row.MissedWakes != 1) {
+		if row.Role == "review" && (row.Flagged || row.FlagReason != "" || row.MissedWakes != 0) {
 			t.Fatalf("review status with threshold off = %+v", row)
 		}
+	}
+}
+
+// TestRunOrgOverviewDegradesOnBadOrchestrateConfig pins that a malformed
+// [orchestrate] value never breaks the org chart/status diagnostic view — the
+// missed-wake flag is a best-effort add-on that degrades to "off".
+func TestRunOrgOverviewDegradesOnBadOrchestrateConfig(t *testing.T) {
+	home, paths := setupOrgHome(t)
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("\n[orchestrate]\nmax_consecutive_missed_wakes = -1\n"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	withOrgProvider(t, orgFixtureProvider{snapshot: org.Snapshot{States: map[string]org.RoleLiveState{
+		"owner": {State: org.StateWorking}, "review": {State: org.StateIdle},
+	}}})
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "chart", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("org chart hard-failed on a bad [orchestrate] value: code=%d stderr=%s", code, stderr.String())
+	}
+	var rows []orgStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("org chart output not renderable after degrade: %v (out=%s)", err, stdout.String())
+	}
+	if len(rows) == 0 {
+		t.Fatal("org chart returned no rows despite a valid [org] registry")
 	}
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -131,6 +131,9 @@ escalation_ttl = ""
 # Emit one synthetic blocked event per continuously blocked task or Herdr org
 # role after this Go duration. 0s keeps both evaluators disabled.
 blocked_role_wake_after = "0s"
+# Flag an org role in chart/status after this many consecutive stalled wakes.
+# 0 keeps flagging disabled while the best-effort counter remains available.
+max_consecutive_missed_wakes = 0
 # Optional default timeouts for child delegation jobs. Empty means unbounded,
 # preserving historical behavior. Per-delegation timeout always wins; otherwise
 # phase-specific defaults apply, then default_delegation_timeout, then unbounded.

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -81,6 +81,10 @@ type OrchestratePolicy struct {
 	// task or Herdr-backed organization role emits one synthesized blocked event.
 	// Zero (the default) disables both evaluators; negative values are rejected.
 	BlockedRoleWakeAfter time.Duration
+	// MaxConsecutiveMissedWakes is the per-role threshold at which org chart and
+	// status flag a role whose delivered prompts repeatedly stall. 0 (the default)
+	// disables flagging; negative values are rejected.
+	MaxConsecutiveMissedWakes int
 	// MaxDelegationNonProgressStreak is the per-root threshold for the result-aware
 	// non-progress loop detector (#339): how many consecutive continuation
 	// generations a delegation tree may produce with no new durable side effect
@@ -126,6 +130,7 @@ func DefaultOrchestratePolicy() OrchestratePolicy {
 		EscalationTTL:                  "",
 		BlockedTTL:                     "",
 		BlockedRoleWakeAfter:           0,
+		MaxConsecutiveMissedWakes:      0,
 		MaxDelegationNonProgressStreak: 0,
 		MaxVerifyReplanAttempts:        0,
 		DefaultDelegationTimeout:       "",
@@ -233,6 +238,10 @@ func applyOrchestratePolicyField(policy *OrchestratePolicy, key string, value st
 		}
 		policy.BlockedRoleWakeAfter, err = time.ParseDuration(parsed)
 		return err
+	case "max_consecutive_missed_wakes":
+		parsed, err := strconv.Atoi(value)
+		policy.MaxConsecutiveMissedWakes = parsed
+		return err
 	case "max_delegation_non_progress_streak":
 		parsed, err := strconv.Atoi(value)
 		policy.MaxDelegationNonProgressStreak = parsed
@@ -313,6 +322,9 @@ func validateOrchestratePolicy(policy OrchestratePolicy) error {
 	}
 	if policy.BlockedRoleWakeAfter < 0 {
 		return fmt.Errorf("orchestrate.blocked_role_wake_after must be zero (disabled) or a positive duration")
+	}
+	if policy.MaxConsecutiveMissedWakes < 0 {
+		return fmt.Errorf("orchestrate.max_consecutive_missed_wakes must be 0 (disabled) or positive")
 	}
 	if policy.MaxDelegationNonProgressStreak < 0 {
 		return fmt.Errorf("orchestrate.max_delegation_non_progress_streak must be 0 (engine default) or positive")

--- a/internal/config/orchestrate_test.go
+++ b/internal/config/orchestrate_test.go
@@ -54,6 +54,9 @@ func TestLoadOrchestratePolicyDefaults(t *testing.T) {
 	if policy.BlockedTTL != "" {
 		t.Fatalf("BlockedTTL = %q, want empty (disabled) by default", policy.BlockedTTL)
 	}
+	if policy.MaxConsecutiveMissedWakes != 0 {
+		t.Fatalf("MaxConsecutiveMissedWakes = %d, want disabled by default", policy.MaxConsecutiveMissedWakes)
+	}
 	if policy.DefaultDelegationTimeout != "" || policy.DefaultPlanTimeout != "" || policy.DefaultImplementTimeout != "" || policy.DefaultReviewTimeout != "" || policy.DefaultGateTimeout != "" || policy.DefaultRepairTimeout != "" {
 		t.Fatalf("delegation timeout defaults = %+v, want all empty by default", policy)
 	}
@@ -421,6 +424,40 @@ func TestLoadOrchestratePolicyBlockedRoleWakeAfter(t *testing.T) {
 		}
 		if policy.BlockedRoleWakeAfter != test.want {
 			t.Fatalf("blocked_role_wake_after %q = %s, want %s", test.value, policy.BlockedRoleWakeAfter, test.want)
+		}
+	}
+}
+
+func TestLoadOrchestratePolicyMaxConsecutiveMissedWakes(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{value: "3", want: 3},
+		{value: "0", want: 0},
+		{value: "-1", wantErr: true},
+		{value: "many", wantErr: true},
+	} {
+		if err := os.WriteFile(paths.ConfigFile, []byte("[orchestrate]\nmax_consecutive_missed_wakes = "+test.value+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		policy, err := LoadOrchestratePolicy(paths)
+		if test.wantErr {
+			if err == nil {
+				t.Fatalf("max_consecutive_missed_wakes %q accepted, want error", test.value)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("max_consecutive_missed_wakes %q error = %v", test.value, err)
+		}
+		if policy.MaxConsecutiveMissedWakes != test.want {
+			t.Fatalf("max_consecutive_missed_wakes %q = %d, want %d", test.value, policy.MaxConsecutiveMissedWakes, test.want)
 		}
 	}
 }

--- a/internal/db/org_role_missed_wakes.go
+++ b/internal/db/org_role_missed_wakes.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+type RoleMissedWake struct {
+	Role        string `json:"role"`
+	Consecutive int    `json:"consecutive"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+func (s *Store) IncrementRoleMissedWake(ctx context.Context, role string, at time.Time) error {
+	role = strings.ToLower(strings.TrimSpace(role))
+	if role == "" {
+		return errors.New("org role is required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO org_role_missed_wakes(role, consecutive, updated_at)
+		VALUES (?, 1, ?)
+		ON CONFLICT(role) DO UPDATE SET
+			consecutive = consecutive + 1,
+			updated_at = excluded.updated_at`, role, at.UTC().Format(BlockedEpisodeTimeLayout))
+	return err
+}
+
+func (s *Store) ResetRoleMissedWake(ctx context.Context, role string) error {
+	role = strings.ToLower(strings.TrimSpace(role))
+	if role == "" {
+		return errors.New("org role is required")
+	}
+	_, err := s.db.ExecContext(ctx, `DELETE FROM org_role_missed_wakes WHERE role = ?`, role)
+	return err
+}
+
+func (s *Store) ListRoleMissedWakes(ctx context.Context) ([]RoleMissedWake, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT role, consecutive, updated_at
+		FROM org_role_missed_wakes ORDER BY role`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []RoleMissedWake
+	for rows.Next() {
+		var missed RoleMissedWake
+		if err := rows.Scan(&missed.Role, &missed.Consecutive, &missed.UpdatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, missed)
+	}
+	return result, rows.Err()
+}

--- a/internal/db/org_role_missed_wakes_test.go
+++ b/internal/db/org_role_missed_wakes_test.go
@@ -1,0 +1,69 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRoleMissedWakeRoundTripAndReset(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	var table string
+	if err := store.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name='org_role_missed_wakes'`).Scan(&table); err != nil {
+		t.Fatalf("org_role_missed_wakes migration missing: %v", err)
+	}
+	first := time.Date(2026, 7, 22, 8, 1, 2, 345678901, time.UTC)
+	if err := store.IncrementRoleMissedWake(ctx, " Review ", first); err != nil {
+		t.Fatalf("IncrementRoleMissedWake(insert) error = %v", err)
+	}
+	if err := store.IncrementRoleMissedWake(ctx, "REVIEW", first.Add(time.Minute)); err != nil {
+		t.Fatalf("IncrementRoleMissedWake(update) error = %v", err)
+	}
+	if err := store.IncrementRoleMissedWake(ctx, "Owner", first.Add(2*time.Minute)); err != nil {
+		t.Fatalf("IncrementRoleMissedWake(second role) error = %v", err)
+	}
+
+	misses, err := store.ListRoleMissedWakes(ctx)
+	if err != nil {
+		t.Fatalf("ListRoleMissedWakes() error = %v", err)
+	}
+	if len(misses) != 2 || misses[0].Role != "owner" || misses[0].Consecutive != 1 || misses[1].Role != "review" || misses[1].Consecutive != 2 {
+		t.Fatalf("misses = %+v, want role-sorted normalized counters", misses)
+	}
+	if got, want := misses[1].UpdatedAt, first.Add(time.Minute).Format(BlockedEpisodeTimeLayout); got != want {
+		t.Fatalf("UpdatedAt = %q, want %q", got, want)
+	}
+
+	if err := store.ResetRoleMissedWake(ctx, " REVIEW "); err != nil {
+		t.Fatalf("ResetRoleMissedWake() error = %v", err)
+	}
+	if err := store.ResetRoleMissedWake(ctx, "review"); err != nil {
+		t.Fatalf("ResetRoleMissedWake(idempotent) error = %v", err)
+	}
+	misses, err = store.ListRoleMissedWakes(ctx)
+	if err != nil || len(misses) != 1 || misses[0].Role != "owner" {
+		t.Fatalf("misses after reset = %+v, err=%v", misses, err)
+	}
+}
+
+func TestRoleMissedWakeRejectsEmptyRole(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	if err := store.IncrementRoleMissedWake(ctx, " ", time.Now()); err == nil {
+		t.Fatal("IncrementRoleMissedWake() error = nil, want validation error")
+	}
+	if err := store.ResetRoleMissedWake(ctx, " "); err == nil {
+		t.Fatal("ResetRoleMissedWake() error = nil, want validation error")
+	}
+}

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1685,4 +1685,13 @@ CREATE TABLE org_blocked_episodes (
 	updated_at TEXT NOT NULL
 );
 	`,
+	// #1060 per-role consecutive missed-wake counters. A missing row means zero;
+	// successful delivery deletes the row so the default path stays sparse.
+	`
+CREATE TABLE org_role_missed_wakes (
+	role TEXT PRIMARY KEY,
+	consecutive INTEGER NOT NULL DEFAULT 0,
+	updated_at TEXT NOT NULL
+);
+	`,
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1174,8 +1174,12 @@ org configuration fails closed and loudly. `brief` records passive last-seen
 presence for its role and can render static context with provider state
 `unknown` during an outage; `chart` and `status` require a live compatible
 Herdr snapshot. When configured, `brief --json` and `status --json` include the
-role's `pane` binding. Open escalations remain deferred to #1058's resolution
-and correlation contract.
+role's `pane` binding. `chart` and `status` also show a `⚠ flagged (N missed
+wakes)` marker once a role reaches the positive
+`[orchestrate].max_consecutive_missed_wakes` threshold; their JSON rows expose
+`missed_wakes`, `flagged`, and `flag_reason`. The threshold defaults to `0`, so
+flagging is off. Open escalations remain deferred to #1058's resolution and
+correlation contract.
 
 Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
 `orchestrate`, and `task run` dispatches accept `--org-role <name>` (or the
@@ -1212,8 +1216,10 @@ with a `:` is a `wX:pY` id, otherwise a pane label resolved to the current id at
 wake time). The daemon calls `herdr agent prompt <pane> <text> --wait --timeout
 8000` and treats delivered (`result.type = "agent_prompted"`, or a post-delivery
 `error.code = "timeout"`) apart from stalled (`error.code =
-"agent_prompt_stalled"`). Rules, pane resolution, and wakes are best-effort; with
-no rule rows this path is off.
+"agent_prompt_stalled"`). Stalls increment the role's consecutive missed-wake
+counter and delivery resets it; transport failures leave it unchanged. Rules,
+pane resolution, counter writes, and wakes are best-effort; with no rule rows
+this path is off.
 
 ## External-coordinator workflow groups
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1010,9 +1010,12 @@ exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
 records passive last-seen presence for its role and can render static context
 with provider state `unknown` during an outage; `chart` and `status` require a
 live compatible Herdr snapshot. When configured, `brief --json` and `status
---json` include the role's `pane` binding. Escalations are recorded with
-`gitmoot org escalate`; their resolution and correlation surfaces are phase 2
-work.
+--json` include the role's `pane` binding. `chart` and `status` append a `⚠
+flagged (N missed wakes)` marker after the role reaches the positive
+`[orchestrate].max_consecutive_missed_wakes` threshold; their JSON rows expose
+`missed_wakes`, `flagged`, and `flag_reason`. The default threshold is `0`
+(disabled). Escalations are recorded with `gitmoot org escalate`; their
+resolution and correlation surfaces are phase 2 work.
 
 Agent `ask`, `run`, `review`, `implement`, and `orchestrate` accept
 `--org-role <name>`. The role is validated and touched before dispatch, then

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -194,6 +194,16 @@ as delivered, `error.code = "agent_prompt_stalled"` as not delivered. Missing
 bindings, unavailable Herdr, stalls, and transport errors are swallowed after
 lightweight logging; they never block or fail a job.
 
+Each `agent_prompt_stalled` outcome increments a durable, consecutive counter
+for the wake role; a delivered prompt resets that role's counter. Transport
+errors and other non-delivery outcomes do not change it because a Herdr outage
+is infrastructure failure, not evidence that every role ignored a wake. Set
+`[orchestrate].max_consecutive_missed_wakes` to a positive integer to append a
+`⚠ flagged (N missed wakes)` marker to that role in `gitmoot org chart` and
+`gitmoot org status`; their JSON rows expose `missed_wakes`, `flagged`, and
+`flag_reason`. The default `0` disables flagging while leaving the best-effort
+counter available.
+
 ## Configuration
 
 Add an `[events]` section to the Gitmoot config file:

--- a/website/docs/workflows/cockpit-orchestrate-workflow.md
+++ b/website/docs/workflows/cockpit-orchestrate-workflow.md
@@ -100,6 +100,7 @@ inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
 inject_upstream_dep_context = false  # inject succeeded upstream dependency results into a dependent leg's prompt; default off
 max_delegation_token_budget = 0  # per-root delegation token budget (input+output); 0 = unlimited (off)
 max_delegation_cost_usd = 0      # per-root delegation dollar-cost budget (USD); 0 = unlimited (off)
+max_consecutive_missed_wakes = 0 # flag org roles after N stalled wakes; 0 = disabled
 default_delegation_timeout = ""  # default child-job timeout when a delegation omits one; "" = unbounded
 default_plan_timeout = ""        # per-phase defaults (plan/implement/review/gate/repair) that
 default_implement_timeout = ""   # win over default_delegation_timeout for legs tagged with
@@ -126,6 +127,10 @@ default_repair_timeout = ""
   aggregate cap also bounds the total inlined across all children.
 - `inject_upstream_dep_context` (default `false`) injects succeeded upstream
   dependency results into a dependent leg's prompt; default off.
+- `max_consecutive_missed_wakes` (default `0` = disabled) flags an organization
+  role in `org chart` and `org status` after that many consecutive
+  `agent_prompt_stalled` wake outcomes. A delivered wake resets the role; Herdr
+  transport failures do not count.
 - `max_delegation_token_budget` (default `0` = unlimited/off) bounds a delegation
   tree by **cost** in addition to depth/width/total-jobs/wall-clock. When set to a
   positive value, the whole tree under one root is capped at that many cumulative

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2672,6 +2672,16 @@ as delivered, `error.code = "agent_prompt_stalled"` as not delivered. Missing
 bindings, unavailable Herdr, stalls, and transport errors are swallowed after
 lightweight logging; they never block or fail a job.
 
+Each `agent_prompt_stalled` outcome increments a durable, consecutive counter
+for the wake role; a delivered prompt resets that role's counter. Transport
+errors and other non-delivery outcomes do not change it because a Herdr outage
+is infrastructure failure, not evidence that every role ignored a wake. Set
+`[orchestrate].max_consecutive_missed_wakes` to a positive integer to append a
+`⚠ flagged (N missed wakes)` marker to that role in `gitmoot org chart` and
+`gitmoot org status`; their JSON rows expose `missed_wakes`, `flagged`, and
+`flag_reason`. The default `0` disables flagging while leaving the best-effort
+counter available.
+
 ## Configuration
 
 Add an `[events]` section to the Gitmoot config file:
@@ -4555,6 +4565,7 @@ inline_artifact_max_bytes = 32768  # per-body cap (bytes) when inlining is on
 inject_upstream_dep_context = false  # inject succeeded upstream dependency results into a dependent leg's prompt; default off
 max_delegation_token_budget = 0  # per-root delegation token budget (input+output); 0 = unlimited (off)
 max_delegation_cost_usd = 0      # per-root delegation dollar-cost budget (USD); 0 = unlimited (off)
+max_consecutive_missed_wakes = 0 # flag org roles after N stalled wakes; 0 = disabled
 default_delegation_timeout = ""  # default child-job timeout when a delegation omits one; "" = unbounded
 default_plan_timeout = ""        # per-phase defaults (plan/implement/review/gate/repair) that
 default_implement_timeout = ""   # win over default_delegation_timeout for legs tagged with
@@ -4581,6 +4592,10 @@ default_repair_timeout = ""
   aggregate cap also bounds the total inlined across all children.
 - `inject_upstream_dep_context` (default `false`) injects succeeded upstream
   dependency results into a dependent leg's prompt; default off.
+- `max_consecutive_missed_wakes` (default `0` = disabled) flags an organization
+  role in `org chart` and `org status` after that many consecutive
+  `agent_prompt_stalled` wake outcomes. A delivered wake resets the role; Herdr
+  transport failures do not count.
 - `max_delegation_token_budget` (default `0` = unlimited/off) bounds a delegation
   tree by **cost** in addition to depth/width/total-jobs/wall-clock. When set to a
   positive value, the whole tree under one root is capped at that many cumulative
@@ -10798,12 +10813,17 @@ resolved role table.
 The registry uses `[org] enforce = "warn"|"block"` and
 `[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, and an
 optional `pane` Herdr binding (used by org event-rule wakes). There is
-exactly one root named `owner`; accepted scopes are `*`, `owner/*`, `*/repo`,
-and `owner/repo`, and each child scope must be covered by its parent. Malformed
+exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
+`owner/repo`, and each child scope must be covered by its parent. Malformed
 org configuration fails closed and loudly. `brief` records passive last-seen
 presence for its role and can render static context with provider state
 `unknown` during an outage; `chart` and `status` require a live compatible
-Herdr snapshot. Open escalations remain deferred to #1058's resolution and
+Herdr snapshot. When configured, `brief --json` and `status --json` include the
+role's `pane` binding. `chart` and `status` also show a `⚠ flagged (N missed
+wakes)` marker once a role reaches the positive
+`[orchestrate].max_consecutive_missed_wakes` threshold; their JSON rows expose
+`missed_wakes`, `flagged`, and `flag_reason`. The threshold defaults to `0`, so
+flagging is off. Open escalations remain deferred to #1058's resolution and
 correlation contract.
 
 Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
@@ -10841,8 +10861,10 @@ with a `:` is a `wX:pY` id, otherwise a pane label resolved to the current id at
 wake time). The daemon calls `herdr agent prompt <pane> <text> --wait --timeout
 8000` and treats delivered (`result.type = "agent_prompted"`, or a post-delivery
 `error.code = "timeout"`) apart from stalled (`error.code =
-"agent_prompt_stalled"`). Rules, pane resolution, and wakes are best-effort; with
-no rule rows this path is off.
+"agent_prompt_stalled"`). Stalls increment the role's consecutive missed-wake
+counter and delivery resets it; transport failures leave it unchanged. Rules,
+pane resolution, counter writes, and wakes are best-effort; with no rule rows
+this path is off.
 
 ## External-coordinator workflow groups
 


### PR DESCRIPTION
## #1060 — org phase 2, slice 2b: per-role missed-wake counter + org-chart flag

The final piece of org phase 2. Rides slice 1 (the wake path) and slice 2a, and
extends #1071's `org chart`/`status`. Off by default:
`[orchestrate].max_consecutive_missed_wakes = 0` (the default) never flags a role
and never surfaces any counter state.

### What ships
- **Counter** — a new `org_role_missed_wakes` table. Spliced into slice 1's
  wake-outcome switch (`internal/cli/event_rule_sink.go`): a `stalled` wake
  increments the role's consecutive count, a `delivered` wake resets it (DELETE);
  an `err` (herdr infra) or odd non-delivery leaves it unchanged, so a herdr
  outage never falsely flags every role. Best-effort and timeout-bounded — a
  counter store error/stall is logged and never blocks or delays a wake.
- **Flag** — `gitmoot org chart`/`org status` gain `MissedWakes`/`Flagged`/
  `FlagReason` on each role (text marker + `--json`), flagged when
  `consecutive >= K`. The counter is read and surfaced only when `K > 0`.
- **Knob** — `[orchestrate].max_consecutive_missed_wakes` (default `0` = off).

### Review
`/code-review high` then a focused `/code-review high` re-review (each on the
exact committed head). The first pass caught four defects — all fixed and the
re-review returned no findings:
- `org chart`/`status` hard-failing (exit 1) on an unrelated `[orchestrate]`
  typo → now degrades to flagging-off; the diagnostic view always renders.
- a `missed_wakes` JSON leak at `K=0` → the counter is invisible when flagging is
  off (a seat test that asserted the leaky behavior was corrected).
- the counter store writes using the unbounded base context in the wake loop →
  bounded with the probe timeout, preserving slice 1's timeout-bounded invariant.

Regression tests: stall-increments/delivery-resets, K-boundary flag, off-by-
default hides the counter, and degrade-on-malformed-config.

### Verification
- `go build ./...`, `go generate ./... && git diff --exit-code`, `go vet ./...`
  clean.
- `go test ./...` green except the 4 pre-existing Landlock E2Es (the known
  `/tmp`-checkout sandbox confound; unchanged by this branch; pass on CI runners).
- Docs shipped in-PR (`docs/cockpit-orchestrate.md`, website docs, `llms-full.txt`).

### Follow-up (separate, not in this PR)
Swap the herdr provider's poll loop for `events.subscribe`
(`pane.agent_status_changed`) — its own contained change.

### Deploy
**No deploy.** Judging window live through Aug 5; merges to `main` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
