### PR TITLE
feat(org): org recycle orchestration — org phase 3 slice 3 (#1061)

### DIFF
--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -95,6 +95,8 @@ func runOrg(args []string, stdout, stderr io.Writer) int {
 		return runOrgChart(args[1:], stdout, stderr)
 	case "status":
 		return runOrgStatus(args[1:], stdout, stderr)
+	case "recycle":
+		return runOrgRecycle(args[1:], stdout, stderr)
 	case "escalate":
 		return runOrgEscalate(args[1:], stdout, stderr)
 	case "events":
@@ -114,6 +116,7 @@ func printOrgUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot org brief --role NAME [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org chart [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org status [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org recycle ROLE --kind KIND --handoff NOTE [--pane ID] [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org escalate --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"QUESTION\"")
 	fmt.Fprintln(w, "  gitmoot org events rule add --on KIND [--match FILTER] --wake ROLE [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule list [--home DIR]")
@@ -307,6 +310,19 @@ func runOrgBrief(args []string, stdout, stderr io.Writer) int {
 		presence[row.Role] = row
 	}
 	snapshot, snapshotErr := orgProviderSnapshot(ctx, cfg)
+	out := buildOrgBriefOutput(cfg, presence, role, snapshot, snapshotErr)
+	if *jsonOutput {
+		if err := writeJSON(stdout, out); err != nil {
+			fmt.Fprintf(stderr, "org brief: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	printOrgBrief(stdout, out)
+	return 0
+}
+
+func buildOrgBriefOutput(cfg config.OrgConfig, presence map[string]db.OrgRolePresence, role config.OrgRole, snapshot org.Snapshot, snapshotErr error) orgBriefOutput {
 	live := org.RoleLiveState{State: org.StateUnknown}
 	if snapshotErr != nil {
 		live.Detail = snapshotErr.Error()
@@ -321,20 +337,11 @@ func runOrgBrief(args []string, stdout, stderr io.Writer) int {
 		childNames = append(childNames, child.Name)
 	}
 	row := presence[role.Name]
-	out := orgBriefOutput{
+	return orgBriefOutput{
 		Role: role.Name, Parent: role.Parent, Pane: role.Pane, Children: childNames, Path: cfg.Path(role.Name), Scope: role.Scope,
 		MergeRule: role.MergeRule, LastSeenAt: row.LastSeenAt, LastCommand: row.LastCommand,
 		ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: snapshot.ObservedAt, ProviderVersion: snapshot.ProviderVersion,
 	}
-	if *jsonOutput {
-		if err := writeJSON(stdout, out); err != nil {
-			fmt.Fprintf(stderr, "org brief: %v\n", err)
-			return 1
-		}
-		return 0
-	}
-	printOrgBrief(stdout, out)
-	return 0
 }
 
 func runOrgChart(args []string, stdout, stderr io.Writer) int {
@@ -439,6 +446,128 @@ func printOrgBrief(w io.Writer, brief orgBriefOutput) {
 	fmt.Fprintf(w, "last_command: %s\n", dash(brief.LastCommand))
 	fmt.Fprintf(w, "provider: %s\n", brief.ProviderState)
 	fmt.Fprintf(w, "provider_detail: %s\n", dash(brief.ProviderDetail))
+}
+
+type orgRecycleOutput struct {
+	Role       string `json:"role"`
+	Pane       string `json:"pane"`
+	Kind       string `json:"kind"`
+	AgentName  string `json:"agent_name"`
+	WorkflowID string `json:"workflow_id"`
+}
+
+const orgRecycleSnapshotTimeout = 10 * time.Second
+
+func runOrgRecycle(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org recycle", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	kindFlag := fs.String("kind", "", "Herdr agent kind for the successor session")
+	handoffFlag := fs.String("handoff", "", "handoff note for the successor session")
+	paneFlag := fs.String("pane", "", "Herdr pane id (overrides the role's configured pane)")
+	jsonOutput := fs.Bool("json", false, "print JSON")
+	roleArg := ""
+	flagArgs := args
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		roleArg, flagArgs = args[0], args[1:]
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if roleArg == "" {
+		if fs.NArg() != 1 {
+			fmt.Fprintln(stderr, "org recycle requires exactly one ROLE")
+			return 2
+		}
+		roleArg = fs.Arg(0)
+	} else if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "org recycle requires exactly one ROLE")
+		return 2
+	}
+	handoff := strings.TrimSpace(*handoffFlag)
+	if handoff == "" {
+		fmt.Fprintln(stderr, "org recycle requires a non-empty --handoff note")
+		return 2
+	}
+	kind := strings.ToLower(strings.TrimSpace(*kindFlag))
+	if !validOrgRecycleKind(kind) {
+		fmt.Fprintf(stderr, "org recycle requires a valid --kind (got %q)\n", strings.TrimSpace(*kindFlag))
+		return 2
+	}
+
+	ctx := context.Background()
+	cfg, presence, store, err := loadOrgCommandState(ctx, *home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org recycle: %v\n", err)
+		return 1
+	}
+	defer store.Close()
+	role, ok := cfg.Role(roleArg)
+	if !ok {
+		fmt.Fprintf(stderr, "org recycle: unknown org role %q\n", strings.TrimSpace(roleArg))
+		return 2
+	}
+	pane := strings.TrimSpace(*paneFlag)
+	if pane == "" {
+		pane = strings.TrimSpace(role.Pane)
+	}
+	if pane == "" {
+		fmt.Fprintf(stderr, "org recycle: role %q has no bound pane; set [org.roles.%q].pane or pass --pane\n", role.Name, role.Name)
+		return 2
+	}
+
+	workflowID := "org/" + role.Name
+	if err := workflow.ValidateWorkflowID(workflowID); err != nil {
+		fmt.Fprintf(stderr, "org recycle: role lifecycle workflow: %v\n", err)
+		return 1
+	}
+	noteBody := workflow.FormatOrgHandoffNote(role.Name, handoff)
+	if noteBody == "" || len(noteBody) > workflowNoteBodyMax {
+		fmt.Fprintf(stderr, "org recycle handoff must produce a note of at most %d bytes\n", workflowNoteBodyMax)
+		return 2
+	}
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{WorkflowID: workflowID, Author: role.Name, Body: noteBody}); err != nil {
+		fmt.Fprintf(stderr, "org recycle: journal handoff: %v\n", err)
+		return 1
+	}
+
+	provider := newOrgProvider([]string{role.Name})
+	if provider == nil {
+		fmt.Fprintf(stderr, "org recycle: organization provider is not configured (handoff journaled in workflow %s)\n", workflowID)
+		return 1
+	}
+	snapshotCtx, cancelSnapshot := context.WithTimeout(ctx, orgRecycleSnapshotTimeout)
+	snapshot, snapshotErr := provider.Snapshot(snapshotCtx)
+	cancelSnapshot()
+	brief := buildOrgBriefOutput(cfg, presence, role, snapshot, snapshotErr)
+	var boot strings.Builder
+	printOrgBrief(&boot, brief)
+	fmt.Fprintf(&boot, "\nhandoff: %s\n", handoff)
+	req := org.RecycleRequest{Role: role.Name, Pane: pane, Kind: kind, AgentName: role.Name, BootPrompt: boot.String()}
+	if err := provider.Recycle(ctx, req); err != nil {
+		fmt.Fprintf(stderr, "org recycle: %v (handoff journaled in workflow %s)\n", err, workflowID)
+		return 1
+	}
+	out := orgRecycleOutput{Role: role.Name, Pane: pane, Kind: kind, AgentName: role.Name, WorkflowID: workflowID}
+	if *jsonOutput {
+		if err := writeJSON(stdout, out); err != nil {
+			fmt.Fprintf(stderr, "org recycle: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Fprintf(stdout, "recycled org role %s as %s in pane %s; handoff journaled in workflow %s\n", role.Name, kind, pane, workflowID)
+	return 0
+}
+
+func validOrgRecycleKind(kind string) bool {
+	return slices.Contains([]string{
+		"pi", "claude", "codex", "gemini", "cursor", "devin", "agy", "cline", "omp", "mastracode", "opencode",
+		"copilot", "kimi", "kiro", "droid", "amp", "grok", "hermes", "kilo", "qodercli", "maki",
+	}, kind)
 }
 
 func loadOrgCommandState(ctx context.Context, home string) (config.OrgConfig, map[string]db.OrgRolePresence, *db.Store, error) {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -259,10 +259,18 @@ func orgParityPolicy(enforce string) workflow.OrgEnforcement {
 type orgFixtureProvider struct {
 	snapshot org.Snapshot
 	err      error
+	recycle  func(context.Context, org.RecycleRequest) error
 }
 
 func (p orgFixtureProvider) Snapshot(context.Context) (org.Snapshot, error) {
 	return p.snapshot, p.err
+}
+
+func (p orgFixtureProvider) Recycle(ctx context.Context, req org.RecycleRequest) error {
+	if p.recycle == nil {
+		return nil
+	}
+	return p.recycle(ctx, req)
 }
 
 type orgFixtureRunner struct {
@@ -592,6 +600,155 @@ func TestRunOrgProviderFailureSemantics(t *testing.T) {
 	if brief.ProviderState != org.StateUnknown || !strings.Contains(brief.ProviderDetail, "socket unavailable") {
 		t.Fatalf("brief = %+v", brief)
 	}
+}
+
+func TestRunOrgRecycleValidation(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		pane string
+		args []string
+		want string
+	}{
+		{name: "missing handoff", pane: "w1:p2", args: []string{"owner", "--kind", "codex"}, want: "requires a non-empty --handoff"},
+		{name: "missing kind", pane: "w1:p2", args: []string{"owner", "--handoff", "done"}, want: "requires a valid --kind"},
+		{name: "invalid kind", pane: "w1:p2", args: []string{"owner", "--kind", "shell", "--handoff", "done"}, want: "requires a valid --kind"},
+		{name: "unbound pane", args: []string{"owner", "--kind", "codex", "--handoff", "done"}, want: "has no bound pane"},
+		{name: "unknown role", pane: "w1:p2", args: []string{"missing", "--kind", "codex", "--handoff", "done"}, want: "unknown org role"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home, paths := setupOrgRecycleHome(t, test.pane)
+			calls := 0
+			withOrgProvider(t, orgFixtureProvider{recycle: func(context.Context, org.RecycleRequest) error {
+				calls++
+				return nil
+			}})
+			var stdout, stderr bytes.Buffer
+			args := append(append([]string(nil), test.args...), "--home", home)
+			if code := runOrgRecycle(args, &stdout, &stderr); code != 2 || !strings.Contains(stderr.String(), test.want) {
+				t.Fatalf("code=%d stdout=%q stderr=%q, want %q", code, stdout.String(), stderr.String(), test.want)
+			}
+			if calls != 0 {
+				t.Fatalf("provider Recycle called %d times on validation failure", calls)
+			}
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			notes, err := store.ListWorkflowNotes(context.Background(), "org/owner", 0)
+			if err != nil || len(notes) != 0 {
+				t.Fatalf("validation failure journaled notes: %+v err=%v", notes, err)
+			}
+		})
+	}
+}
+
+func TestRunOrgRecycleJournalsAndBootsSuccessor(t *testing.T) {
+	home, paths := setupOrgRecycleHome(t, "w1:p2")
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.TouchOrgRolePresence(context.Background(), "owner", "agent_run"); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var requests []org.RecycleRequest
+	withOrgProvider(t, orgFixtureProvider{
+		snapshot: org.Snapshot{
+			States:     map[string]org.RoleLiveState{"owner": {State: org.StateIdle}},
+			ObservedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC), ProviderVersion: "0.7.5",
+		},
+		recycle: func(_ context.Context, req org.RecycleRequest) error {
+			requests = append(requests, req)
+			return nil
+		},
+	})
+	var stdout, stderr bytes.Buffer
+	code := runOrgRecycle([]string{"OWNER", "--kind", "codex", "--handoff", "Release is ready for final verification.", "--home", home, "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	if len(requests) != 1 {
+		t.Fatalf("Recycle requests = %+v", requests)
+	}
+	req := requests[0]
+	if req.Role != "owner" || req.Pane != "w1:p2" || req.Kind != "codex" || req.AgentName != "owner" {
+		t.Fatalf("Recycle request = %+v", req)
+	}
+	for _, want := range []string{"role: owner", "path: owner", "provider: idle", "last_command: agent_run", "handoff: Release is ready for final verification."} {
+		if !strings.Contains(req.BootPrompt, want) {
+			t.Fatalf("BootPrompt missing %q: %q", want, req.BootPrompt)
+		}
+	}
+	var out orgRecycleOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode output: %v; output=%q", err, stdout.String())
+	}
+	if out.Role != "owner" || out.Pane != "w1:p2" || out.Kind != "codex" || out.AgentName != "owner" || out.WorkflowID != "org/owner" {
+		t.Fatalf("output = %+v", out)
+	}
+	store, err = db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	notes, err := store.ListWorkflowNotes(context.Background(), "org/owner", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notes) != 1 || notes[0].Author != "owner" || notes[0].Body != workflow.FormatOrgHandoffNote("owner", "Release is ready for final verification.") {
+		t.Fatalf("handoff notes = %+v", notes)
+	}
+}
+
+func TestRunOrgRecycleProviderFailureKeepsHandoff(t *testing.T) {
+	home, paths := setupOrgRecycleHome(t, "w1:p2")
+	withOrgProvider(t, orgFixtureProvider{
+		snapshot: org.Snapshot{States: map[string]org.RoleLiveState{"owner": {State: org.StateDone}}},
+		recycle:  func(context.Context, org.RecycleRequest) error { return errors.New("pane is not at shell") },
+	})
+	var stdout, stderr bytes.Buffer
+	if code := runOrgRecycle([]string{"owner", "--kind", "codex", "--handoff", "Safe to resume.", "--home", home}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "handoff journaled in workflow org/owner") {
+		t.Fatalf("code/stderr = %d/%q", code, stderr.String())
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	notes, err := store.ListWorkflowNotes(context.Background(), "org/owner", 0)
+	if err != nil || len(notes) != 1 {
+		t.Fatalf("handoff notes after provider failure = %+v err=%v", notes, err)
+	}
+}
+
+func setupOrgRecycleHome(t *testing.T, pane string) (string, config.Paths) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	content := "\n[org.roles.\"owner\"]\nscope = [\"*\"]\nmerge_rule = \"owner\"\n"
+	if pane != "" {
+		content += fmt.Sprintf("pane = %q\n", pane)
+	}
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(content); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return home, paths
 }
 
 func TestValidateAndTouchActingOrgRole(t *testing.T) {

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +17,11 @@ type herdrOrgProvider struct {
 	roles []string
 	now   func() time.Time
 }
+
+const (
+	herdrOrgRecycleTimeoutMS = 30000
+	herdrOrgRecycleDeadline  = 35 * time.Second
+)
 
 // NewHerdrOrgProvider returns the v1 organization live-state provider. Role
 // identity is exact pane-label equality; runtime/agent names are never inferred.
@@ -86,6 +92,29 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 		now = p.now
 	}
 	return org.Snapshot{States: states, ObservedAt: now().UTC(), ProviderVersion: version}, nil
+}
+
+// Recycle starts a fresh interactive agent in a pane that has already returned
+// to its shell prompt. Herdr cannot safely prove or cause that transition, so
+// winding down the prior agent remains an explicit operator precondition.
+func (p *herdrOrgProvider) Recycle(ctx context.Context, req org.RecycleRequest) error {
+	if p == nil || p.run == nil {
+		return fmt.Errorf("herdr org provider is not configured")
+	}
+	role := strings.TrimSpace(req.Role)
+	pane := strings.TrimSpace(req.Pane)
+	kind := strings.TrimSpace(req.Kind)
+	agentName := strings.TrimSpace(req.AgentName)
+	if role == "" || pane == "" || kind == "" || agentName == "" || strings.TrimSpace(req.BootPrompt) == "" {
+		return fmt.Errorf("herdr recycle requires role, pane, kind, agent name, and boot prompt")
+	}
+	bounded, cancel := context.WithTimeout(ctx, herdrOrgRecycleDeadline)
+	defer cancel()
+	_, err := p.run(bounded, "agent", "start", agentName, "--kind", kind, "--pane", pane, "--timeout", strconv.Itoa(herdrOrgRecycleTimeoutMS), "--", req.BootPrompt)
+	if err != nil {
+		return fmt.Errorf("herdr agent start for org role %q (pane %q must already be at an interactive shell prompt): %w", role, pane, err)
+	}
+	return nil
 }
 
 func mapHerdrAgentStatus(raw string) org.RoleLiveState {

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -74,3 +74,33 @@ func TestHerdrOrgProviderFailures(t *testing.T) {
 		})
 	}
 }
+
+func TestHerdrOrgProviderRecycleCommand(t *testing.T) {
+	var got []string
+	run := func(ctx context.Context, args ...string) (string, error) {
+		if _, ok := ctx.Deadline(); !ok {
+			t.Fatal("Recycle runner context has no deadline")
+		}
+		got = append([]string(nil), args...)
+		return "", nil
+	}
+	provider := newHerdrOrgProvider(run, []string{"owner"}, time.Now)
+	req := org.RecycleRequest{Role: "owner", Pane: "w1:p2", Kind: "codex", AgentName: "owner", BootPrompt: "role: owner\n\nhandoff: ship it"}
+	if err := provider.Recycle(context.Background(), req); err != nil {
+		t.Fatalf("Recycle() error = %v", err)
+	}
+	want := []string{"agent", "start", "owner", "--kind", "codex", "--pane", "w1:p2", "--timeout", "30000", "--", req.BootPrompt}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("Recycle() args = %q, want %q", got, want)
+	}
+}
+
+func TestHerdrOrgProviderRecycleFailureIsActionable(t *testing.T) {
+	provider := newHerdrOrgProvider(func(context.Context, ...string) (string, error) {
+		return "", errors.New("pane is not at shell")
+	}, []string{"owner"}, time.Now)
+	err := provider.Recycle(context.Background(), org.RecycleRequest{Role: "owner", Pane: "w1:p2", Kind: "codex", AgentName: "owner", BootPrompt: "brief"})
+	if err == nil || !strings.Contains(err.Error(), "interactive shell prompt") || !strings.Contains(err.Error(), "pane is not at shell") {
+		t.Fatalf("Recycle() error = %v", err)
+	}
+}

--- a/internal/org/provider.go
+++ b/internal/org/provider.go
@@ -26,6 +26,15 @@ type Snapshot struct {
 	ProviderVersion string                   `json:"provider_version,omitempty"`
 }
 
+type RecycleRequest struct {
+	Role       string
+	Pane       string
+	Kind       string
+	AgentName  string
+	BootPrompt string
+}
+
 type Provider interface {
 	Snapshot(ctx context.Context) (Snapshot, error)
+	Recycle(ctx context.Context, req RecycleRequest) error
 }

--- a/internal/workflow/org_handoff.go
+++ b/internal/workflow/org_handoff.go
@@ -1,0 +1,14 @@
+package workflow
+
+import "strings"
+
+const orgHandoffPrefix = "[org:handoff "
+
+// FormatOrgHandoffNote encodes a role-session handoff in the durable workflow
+// journal. Invalid delimiter-bearing roles or empty notes return an empty body.
+func FormatOrgHandoffNote(role, note string) string {
+	if !validOrgEscalateField(role) || strings.TrimSpace(note) == "" {
+		return ""
+	}
+	return orgHandoffPrefix + "role=" + role + "] " + note
+}

--- a/internal/workflow/org_handoff_test.go
+++ b/internal/workflow/org_handoff_test.go
@@ -1,0 +1,22 @@
+package workflow
+
+import "testing"
+
+func TestFormatOrgHandoffNote(t *testing.T) {
+	if got, want := FormatOrgHandoffNote("owner", "Finished release ] with follow-up"), "[org:handoff role=owner] Finished release ] with follow-up"; got != want {
+		t.Fatalf("FormatOrgHandoffNote() = %q, want %q", got, want)
+	}
+	for _, test := range []struct {
+		role string
+		note string
+	}{
+		{note: "handoff"},
+		{role: "owner", note: "  "},
+		{role: "owner]", note: "handoff"},
+		{role: "owner name", note: "handoff"},
+	} {
+		if got := FormatOrgHandoffNote(test.role, test.note); got != "" {
+			t.Fatalf("FormatOrgHandoffNote(%q, %q) = %q, want empty", test.role, test.note, got)
+		}
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1190,6 +1190,15 @@ configured `recycle_after` to have any effect. Both fields are **binary-first**:
 a binary predating them fails closed on a config that uses them, so deploy the
 binary before any config sets them.
 
+`gitmoot org recycle <role> --kind <kind> --handoff "<note>" [--pane <id>]
+[--json] [--home <dir>]` journals a typed handoff in the role-lifecycle workflow
+`org/<role>`, builds the successor's boot prompt from `org brief` plus that
+handoff, and starts the requested Herdr agent kind in `--pane` or the role's
+configured `pane`. A pane binding and non-empty handoff are required. For safety,
+recycle does not kill or send exit keys to the old agent: the pane must already
+be at its interactive shell prompt. The Herdr start wait is bounded to 30
+seconds; a failed start leaves the durable handoff note available for recovery.
+
 Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
 `orchestrate`, and `task run` dispatches accept `--org-role <name>` (or the
 narrow `GITMOOT_ORG_ROLE` fallback). The role is validated and touched before

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1075,6 +1075,15 @@ at enqueue.
 `enforce = "block"` is the default; `"warn"` allows the job and records an
 `org_scope_violation` event. Merge rules are advisory in this phase.
 
+`gitmoot org recycle <role> --kind <kind> --handoff "<note>" [--pane <id>]
+[--json] [--home <dir>]` journals a typed handoff in the role-lifecycle workflow
+`org/<role>`, builds the successor's boot prompt from `org brief` plus that
+handoff, and starts the requested Herdr agent kind in `--pane` or the role's
+configured `pane`. A pane binding and non-empty handoff are required. For safety,
+recycle does not kill or send exit keys to the old agent: the pane must already
+be at its interactive shell prompt. The Herdr start wait is bounded to 30
+seconds; a failed start leaves the durable handoff note available for recovery.
+
 `gitmoot org escalate --to <ancestor-role> --workflow <label> [--org-role
 <from-role>] [--repo <owner/repo>] "<question>"` writes a workflow journal
 note. The acting role is `--org-role` when given, otherwise `GITMOOT_ORG_ROLE`;


### PR DESCRIPTION
## What

Final slice of RFC #1042 **phase 3**, closing #1061. `gitmoot org recycle <role>` orchestrates a coordinator-session recycle: journal a handoff note, then restart the role's pane session from `org brief` via the herdr provider seam.

## Changes

- **`gitmoot org recycle <role> --kind <KIND> --handoff "<note>" [--pane <ID>] [--json]`**:
  1. Validates the role and resolves a bound pane (`--pane`, else `[org.roles."x"].pane`; errors clearly if neither).
  2. Journals a typed handoff note (`[org:handoff role=X] …`, mirroring `org escalate`) to the durable `org/<role>` workflow **before** the respawn — so the handoff survives even a failed respawn.
  3. Boots the successor from the role's `org brief` + the handoff note.
- **Provider seam** gains `Recycle(RecycleRequest)`. The herdr v1 impl runs `herdr agent start <name> --kind <kind> --pane <pane> --timeout 30000 -- <boot>` via the existing exec runner. **Exit-old is a documented operator precondition** — herdr cannot safely prove/cause a pane's return to a shell, so the command errors clearly rather than risk a fragile kill that could lose an unsaved session.
- `runOrgBrief` factored into `buildOrgBriefOutput` (behavior-preserving) so recycle reuses the exact boot context.
- The real herdr call is **stubbed in tests** (like `Snapshot`) — no real herdr is ever invoked.

## Scope fences (coordination with G2's concurrent slice-2b)

Zero change to `orgStatusOutput`/`runOrgOverview` chart rendering (slice-2b owns that) and zero change to the blocked-since / `org_blocked_episodes` area. No engine/daemon change. The **deferred durable overdue event** (which reuses #1081's blocked-since sink) remains a separate follow-up.

## Review — high (fresh finders, isolated worktree)

Two fresh-context finders (recycle-flow correctness + provider-seam/herdr/scope-fences), **both SHIP-READY, no blocking findings**. Verified: the interface widening compiles for every `org.Provider` implementer; the herdr argv + `--kind` list are byte-identical to the live binary; the `buildOrgBriefOutput` extract is byte-equivalent; handoff journaling is durable and ordered before the respawn; no injection (format-only note); scope fences intact; no real herdr in any test.

## Follow-ups (LOW, noted not fixed — finders agreed "nothing warrants changing this diff")

- A real recycle failure surfaces the generic pane-precondition hint but not herdr's specific stderr reason (`cmd.Output()` leaves it in `ExitError.Stderr`) — an observability improvement, best done in the shared runner.
- `validOrgRoleName` is more permissive than the workflow-ID contract, so a pathological role name (`a--b`, `-lead`) recycles with a clean exit-1 before any journaling — tightening `validOrgRoleName` is a separate change.

## Sequence / deploy

Slice 3 of 3 — closes phase 3 (#1061): detection → refusal → **recycle orchestration (this)**. The one remaining item is the deferred durable overdue event on #1081's sink. No deploy (judging window). Merge owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
