### PR TITLE
feat(org): durable recycle_overdue event on the refusal path (#1061)

### DIFF
--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -204,6 +204,8 @@ func classifyEventRuleKinds(event events.Event) []string {
 		case "ask_gate":
 			return []string{"attention"}
 		}
+	case events.EventOrgRecycleOverdue:
+		return []string{"recycle-overdue"}
 	}
 	return nil
 }

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -54,6 +54,7 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 		{name: "merge guard", event: events.Event{Type: events.EventJobBlocked, Cause: "merge_guard"}, want: []string{"guard"}},
 		{name: "permission guard", event: events.Event{Type: events.EventJobBlocked, Cause: "permission_guard"}, want: []string{"guard"}},
 		{name: "blocked since only", event: events.Event{Type: events.EventJobBlocked, Cause: "blocked_since"}, want: []string{"blocked"}},
+		{name: "recycle overdue", event: events.Event{Type: events.EventOrgRecycleOverdue, Cause: "recycle_overdue"}, want: []string{"recycle-overdue"}},
 		{name: "finished terminal", event: events.Event{Type: events.EventJobFinished}, want: []string{"job-terminal"}},
 		{name: "failed terminal", event: events.Event{Type: events.EventJobFailed, Cause: "unrelated"}, want: []string{"job-terminal"}},
 		{name: "plain blocked terminal and blocked", event: events.Event{Type: events.EventJobBlocked}, want: []string{"job-terminal", "blocked"}},

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/doctor"
+	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/org"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -78,6 +79,12 @@ var newOrgProvider = func(roles []string) org.Provider { return cockpit.NewHerdr
 var orgDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
 
 var orgRecycleAdvisoryWriter io.Writer = os.Stderr
+
+var orgRecycleOverdueEventWriter io.Writer = os.Stderr
+
+var orgRecycleOverdueEventSink = enabledBlockedSinceEventSink
+
+var orgRecycleOverdueEpisodeEmitter = emitRecycleOverdueEpisode
 
 func runOrg(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
@@ -695,7 +702,16 @@ func validateAndTouchActingOrgRole(ctx context.Context, store *db.Store, home, r
 				return fmt.Errorf("read org role %q presence: %w", configuredRole.Name, err)
 			}
 			if found {
-				age, known, overdue := orgRecycleAge(presence.LastSeenAt, time.Now().UTC(), recycleAfter)
+				now := time.Now().UTC()
+				age, known, overdue := orgRecycleAge(presence.LastSeenAt, now, recycleAfter)
+				if known {
+					overdueSince := time.Time{}
+					if overdue {
+						lastSeen, _ := parseOrgPresenceTime(presence.LastSeenAt)
+						overdueSince = lastSeen.UTC().Add(recycleAfter)
+					}
+					updateRecycleOverdueEpisodeBestEffort(ctx, store, home, configuredRole.Name, overdueSince, recycleAfter, now)
+				}
 				if known && overdue {
 					message := fmt.Sprintf("org role %q is overdue for recycling (idle %s ≥ recycle_after %s); journal a handoff note and recycle before dispatching new work", configuredRole.Name, age, formatOrgRecycleAfter(recycleAfter))
 					if mode == "block" {
@@ -707,6 +723,90 @@ func validateAndTouchActingOrgRole(ctx context.Context, store *db.Store, home, r
 		}
 	}
 	return store.TouchOrgRolePresence(ctx, touchRole, command)
+}
+
+// updateRecycleOverdueEpisodeBestEffort mirrors the blocked-since episode
+// pattern without coupling the CLI ingress to its daemon evaluator. A zero
+// overdueSince means the role is fresh and closes any prior episode. Every
+// failure is advisory-only so event bookkeeping can never change dispatch.
+func updateRecycleOverdueEpisodeBestEffort(ctx context.Context, store *db.Store, home, role string, overdueSince time.Time, repeatAfter time.Duration, now time.Time) {
+	if store == nil || repeatAfter <= 0 {
+		return
+	}
+	// ALWAYS clear on a fresh dispatch, regardless of whether notifications are
+	// enabled, so a prior episode can't linger stale across a rule toggle and
+	// later mis-report overdue_since or wrongly suppress a legitimate emit.
+	if overdueSince.IsZero() {
+		if err := store.ClearRecycleOverdueEpisode(ctx, role); err != nil {
+			fmt.Fprintf(orgRecycleOverdueEventWriter, "warning: org role %q recycle-overdue episode clear failed: %v\n", role, err)
+		}
+		return
+	}
+	// The overdue episode is a notification-dedup record (read only by this emit
+	// path), so open/refresh it and emit only when an org event rule is enabled
+	// (a nil sink otherwise). The wake/webhook is fire-and-forget; on a
+	// short-lived --background/orchestrate dispatch the process may exit before
+	// delivery, so the notification is best-effort (reliable on foreground
+	// `agent ask`). Reliable background delivery is a tracked follow-up.
+	if orgRecycleOverdueEventSink == nil {
+		return
+	}
+	sink, err := orgRecycleOverdueEventSink(ctx, store, home)
+	if err != nil {
+		fmt.Fprintf(orgRecycleOverdueEventWriter, "warning: org role %q recycle-overdue event sink unavailable: %v\n", role, err)
+		return
+	}
+	if sink == nil {
+		return
+	}
+	if err := store.UpsertRecycleOverdueEpisode(ctx, role, overdueSince, now); err != nil {
+		fmt.Fprintf(orgRecycleOverdueEventWriter, "warning: org role %q recycle-overdue episode upsert failed: %v\n", role, err)
+		return
+	}
+	episodes, err := store.ListRecycleOverdueEpisodes(ctx)
+	if err != nil {
+		fmt.Fprintf(orgRecycleOverdueEventWriter, "warning: org role %q recycle-overdue episode read failed: %v\n", role, err)
+		return
+	}
+	for _, episode := range episodes {
+		if episode.Subject != role {
+			continue
+		}
+		if err := orgRecycleOverdueEpisodeEmitter(ctx, store, sink, episode, repeatAfter, now); err != nil {
+			fmt.Fprintf(orgRecycleOverdueEventWriter, "warning: org role %q recycle-overdue event emit failed: %v\n", role, err)
+		}
+		return
+	}
+}
+
+// emitRecycleOverdueEpisode marks before emitting and carries the stable first
+// overdue instant so consumers can distinguish a repeat from a fresh episode.
+func emitRecycleOverdueEpisode(ctx context.Context, store *db.Store, sink events.Sink, episode db.RecycleOverdueEpisode, repeatAfter time.Duration, now time.Time) error {
+	if store == nil || sink == nil || repeatAfter <= 0 {
+		return nil
+	}
+	now = now.UTC()
+	overdueSince, err := time.Parse(db.BlockedEpisodeTimeLayout, episode.OverdueSince)
+	if err != nil {
+		return fmt.Errorf("parse overdue_since %q: %w", episode.OverdueSince, err)
+	}
+	if last := strings.TrimSpace(episode.EmittedAt); last != "" {
+		if lastEmitted, err := time.Parse(db.BlockedEpisodeTimeLayout, last); err == nil && now.Sub(lastEmitted) <= repeatAfter {
+			return nil
+		}
+	}
+	if err := store.MarkRecycleOverdueEpisodeEmitted(ctx, episode.Subject, now); err != nil {
+		return fmt.Errorf("mark recycle-overdue episode emitted: %w", err)
+	}
+	overdueFor := now.Sub(overdueSince)
+	if overdueFor < 0 {
+		overdueFor = 0
+	}
+	detail := fmt.Sprintf("role %s overdue for recycling %s (since %s)", episode.Subject, overdueFor.Round(time.Second), overdueSince.UTC().Format(time.RFC3339))
+	ev := events.NewEvent(events.EventOrgRecycleOverdue, episode.Subject, episode.Subject, "", "overdue", detail, now, workflow.RedactCommentText)
+	ev.Cause = "recycle_overdue"
+	events.EmitEvent(ctx, sink, ev)
+	return nil
 }
 
 func dash(value string) string {
@@ -930,11 +1030,12 @@ func orgEscalateQuestionAndFlags(args []string) (string, []string, bool) {
 }
 
 var eventRuleKinds = map[string]struct{}{
-	"escalation":   {},
-	"attention":    {},
-	"guard":        {},
-	"job-terminal": {},
-	"blocked":      {},
+	"escalation":      {},
+	"attention":       {},
+	"guard":           {},
+	"job-terminal":    {},
+	"blocked":         {},
+	"recycle-overdue": {},
 }
 
 func runOrgEvents(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/org"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -978,6 +979,223 @@ func TestValidateAndTouchActingOrgRoleRecycleEnforcement(t *testing.T) {
 			}
 			if beforeFound && test.seedAt.Equal(old) && after.LastSeenAt == before.LastSeenAt {
 				t.Fatalf("allowed overdue dispatch did not reset last_seen_at: before=%+v after=%+v", before, after)
+			}
+		})
+	}
+}
+
+type recycleOverdueRecordingSink struct {
+	t      *testing.T
+	store  *db.Store
+	events []events.Event
+}
+
+func (s *recycleOverdueRecordingSink) Emit(ctx context.Context, event events.Event) {
+	s.t.Helper()
+	episodes, err := s.store.ListRecycleOverdueEpisodes(ctx)
+	if err != nil {
+		s.t.Fatalf("ListRecycleOverdueEpisodes(at emit) error = %v", err)
+	}
+	marked := false
+	for _, episode := range episodes {
+		if episode.Subject == event.JobID && episode.EmittedAt != "" {
+			marked = true
+			break
+		}
+	}
+	if !marked {
+		s.t.Fatalf("event emitted before episode mark: event=%+v episodes=%+v", event, episodes)
+	}
+	s.events = append(s.events, event)
+}
+
+func TestRecycleOverdueEventBlockCadenceAndFreshClear(t *testing.T) {
+	home, paths := setupOrgRecycleEnforcementHome(t, "block", "1h")
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{ID: "recycle-overdue", OnKind: "blocked", WakeRole: "owner", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	seedAt := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	seedOrgRolePresenceAt(t, paths, "owner", seedAt, "seed")
+	sink := &recycleOverdueRecordingSink{t: t, store: store}
+	originalSink := orgRecycleOverdueEventSink
+	orgRecycleOverdueEventSink = func(ctx context.Context, store *db.Store, _ string) (events.Sink, error) {
+		rules, err := store.ListEventRules(ctx)
+		if err != nil || !hasEnabledEventRule(rules) {
+			return nil, err
+		}
+		return sink, nil
+	}
+	t.Cleanup(func() { orgRecycleOverdueEventSink = originalSink })
+
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "owner", "agent_run"); err == nil {
+		t.Fatal("overdue block dispatch error = nil")
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("first dispatch events = %+v, want one", sink.events)
+	}
+	ev := sink.events[0]
+	if ev.Type != events.EventOrgRecycleOverdue || ev.JobID != "owner" || ev.RootID != "owner" || ev.Status != "overdue" || ev.Cause != "recycle_overdue" {
+		t.Fatalf("recycle-overdue event = %+v", ev)
+	}
+	if !strings.Contains(ev.Detail, "role owner overdue for recycling") || !strings.Contains(ev.Detail, "since ") {
+		t.Fatalf("recycle-overdue detail = %q", ev.Detail)
+	}
+	episodes, err := store.ListRecycleOverdueEpisodes(ctx)
+	if err != nil || len(episodes) != 1 {
+		t.Fatalf("episodes after first dispatch = %+v err=%v", episodes, err)
+	}
+	if got, want := episodes[0].OverdueSince, seedAt.Add(time.Hour).Format(db.BlockedEpisodeTimeLayout); got != want {
+		t.Fatalf("OverdueSince = %q, want stable threshold %q", got, want)
+	}
+
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "owner", "agent_run"); err == nil {
+		t.Fatal("repeat overdue block dispatch error = nil")
+	}
+	if len(sink.events) != 1 {
+		t.Fatalf("within-interval events = %d, want 1", len(sink.events))
+	}
+	if err := store.MarkRecycleOverdueEpisodeEmitted(ctx, "owner", time.Now().UTC().Add(-2*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "owner", "agent_run"); err == nil {
+		t.Fatal("post-interval overdue block dispatch error = nil")
+	}
+	if len(sink.events) != 2 {
+		t.Fatalf("post-interval events = %d, want 2", len(sink.events))
+	}
+	episodes, err = store.ListRecycleOverdueEpisodes(ctx)
+	if err != nil || len(episodes) != 1 || episodes[0].OverdueSince != seedAt.Add(time.Hour).Format(db.BlockedEpisodeTimeLayout) {
+		t.Fatalf("repeat changed episode identity: %+v err=%v", episodes, err)
+	}
+
+	seedOrgRolePresenceAt(t, paths, "owner", time.Now().UTC(), "fresh")
+	if err := validateAndTouchActingOrgRole(ctx, store, home, "owner", "agent_run"); err != nil {
+		t.Fatalf("fresh dispatch error = %v", err)
+	}
+	episodes, err = store.ListRecycleOverdueEpisodes(ctx)
+	if err != nil || len(episodes) != 0 {
+		t.Fatalf("fresh dispatch did not clear episode: %+v err=%v", episodes, err)
+	}
+}
+
+func TestRecycleOverdueEventOffAndNoRuleAreNoOps(t *testing.T) {
+	old := time.Now().UTC().Add(-2 * time.Hour)
+	t.Run("enforcement off", func(t *testing.T) {
+		home, paths := setupOrgRecycleEnforcementHome(t, "off", "1h")
+		store, err := db.Open(paths.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		seedOrgRolePresenceAt(t, paths, "owner", old, "seed")
+		calls := 0
+		original := orgRecycleOverdueEventSink
+		orgRecycleOverdueEventSink = func(context.Context, *db.Store, string) (events.Sink, error) {
+			calls++
+			return &recordingSink{}, nil
+		}
+		t.Cleanup(func() { orgRecycleOverdueEventSink = original })
+		if err := validateAndTouchActingOrgRole(context.Background(), store, home, "owner", "agent_run"); err != nil {
+			t.Fatalf("off dispatch error = %v", err)
+		}
+		if calls != 0 {
+			t.Fatalf("off enforcement constructed event sink %d times", calls)
+		}
+	})
+
+	t.Run("no enabled event rule", func(t *testing.T) {
+		home, paths := setupOrgRecycleEnforcementHome(t, "block", "1h")
+		store, err := db.Open(paths.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		seedOrgRolePresenceAt(t, paths, "owner", old, "seed")
+		if err := validateAndTouchActingOrgRole(context.Background(), store, home, "owner", "agent_run"); err == nil {
+			t.Fatal("block dispatch error = nil")
+		}
+		episodes, err := store.ListRecycleOverdueEpisodes(context.Background())
+		if err != nil || len(episodes) != 0 {
+			t.Fatalf("no-rule dispatch created episodes: %+v err=%v", episodes, err)
+		}
+	})
+
+	t.Run("fresh dispatch clears a stale episode without a rule", func(t *testing.T) {
+		home, paths := setupOrgRecycleEnforcementHome(t, "block", "1h")
+		store, err := db.Open(paths.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+		ctx := context.Background()
+		// A prior episode (e.g. from when a rule was enabled) must be cleared by a
+		// later fresh dispatch even with no rule now, so a re-overdue opens fresh.
+		if err := store.UpsertRecycleOverdueEpisode(ctx, "owner", old, time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+		seedOrgRolePresenceAt(t, paths, "owner", time.Now().UTC(), "seed")
+		if err := validateAndTouchActingOrgRole(ctx, store, home, "owner", "agent_run"); err != nil {
+			t.Fatalf("fresh dispatch error = %v", err)
+		}
+		episodes, err := store.ListRecycleOverdueEpisodes(ctx)
+		if err != nil || len(episodes) != 0 {
+			t.Fatalf("fresh dispatch left a stale episode (clear must run without a rule): %+v err=%v", episodes, err)
+		}
+	})
+}
+
+func TestRecycleOverdueEventFailurePreservesEnforcementOutcome(t *testing.T) {
+	for _, mode := range []string{"block", "warn"} {
+		t.Run(mode, func(t *testing.T) {
+			home, paths := setupOrgRecycleEnforcementHome(t, mode, "1h")
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			ctx := context.Background()
+			seedOrgRolePresenceAt(t, paths, "owner", time.Now().UTC().Add(-2*time.Hour), "seed")
+			originalSink := orgRecycleOverdueEventSink
+			originalEmitter := orgRecycleOverdueEpisodeEmitter
+			originalEventWriter := orgRecycleOverdueEventWriter
+			orgRecycleOverdueEventSink = func(context.Context, *db.Store, string) (events.Sink, error) { return &recordingSink{}, nil }
+			orgRecycleOverdueEpisodeEmitter = func(context.Context, *db.Store, events.Sink, db.RecycleOverdueEpisode, time.Duration, time.Time) error {
+				return errors.New("synthetic emit failure")
+			}
+			var eventWarnings bytes.Buffer
+			orgRecycleOverdueEventWriter = &eventWarnings
+			t.Cleanup(func() {
+				orgRecycleOverdueEventSink = originalSink
+				orgRecycleOverdueEpisodeEmitter = originalEmitter
+				orgRecycleOverdueEventWriter = originalEventWriter
+			})
+
+			var advisory bytes.Buffer
+			originalAdvisory := orgRecycleAdvisoryWriter
+			orgRecycleAdvisoryWriter = &advisory
+			t.Cleanup(func() { orgRecycleAdvisoryWriter = originalAdvisory })
+			err = validateAndTouchActingOrgRole(ctx, store, home, "owner", "agent_run")
+			if (err != nil) != (mode == "block") {
+				t.Fatalf("mode=%s error=%v", mode, err)
+			}
+			if !strings.Contains(eventWarnings.String(), "synthetic emit failure") {
+				t.Fatalf("event failure was not logged: %q", eventWarnings.String())
+			}
+			presence, found, readErr := store.GetOrgRolePresence(ctx, "owner")
+			if readErr != nil || !found {
+				t.Fatalf("presence = %+v found=%v err=%v", presence, found, readErr)
+			}
+			if mode == "warn" && presence.LastCommand != "agent_run" {
+				t.Fatalf("warn emit failure changed allow/touch outcome: %+v", presence)
+			}
+			if mode == "block" && presence.LastCommand != "seed" {
+				t.Fatalf("block emit failure changed refuse/no-touch outcome: %+v", presence)
 			}
 		})
 	}

--- a/internal/db/memory_usage_test.go
+++ b/internal/db/memory_usage_test.go
@@ -10,10 +10,22 @@ import (
 
 func TestMigrationAddsUsageColumns_Idempotent(t *testing.T) {
 	ctx := context.Background()
-	usageMigration := migrations[len(migrations)-1]
+	// Locate the usage migration by content, not by tail position: versions are
+	// positional and later migrations legitimately append after this one.
+	usageIndex := -1
+	for i, m := range migrations {
+		if strings.Contains(m, "ADD COLUMN injected_count") {
+			usageIndex = i
+			break
+		}
+	}
+	if usageIndex < 0 {
+		t.Fatal("usage-columns migration not found")
+	}
+	usageMigration := migrations[usageIndex]
 	for _, column := range []string{"injected_count", "last_injected_at", "recalled_count", "last_recalled_at"} {
 		if !strings.Contains(usageMigration, "ADD COLUMN "+column) {
-			t.Fatalf("tail migration missing %s", column)
+			t.Fatalf("usage migration missing %s", column)
 		}
 	}
 	path := filepath.Join(t.TempDir(), "pre-usage.db")
@@ -28,7 +40,7 @@ func TestMigrationAddsUsageColumns_Idempotent(t *testing.T) {
 	}
 	store := &Store{db: raw}
 	t.Cleanup(func() { _ = store.Close() })
-	for i, migration := range migrations[:len(migrations)-1] {
+	for i, migration := range migrations[:usageIndex] {
 		if err := store.applyMigration(ctx, i+1, migration); err != nil {
 			t.Fatalf("apply pre-usage migration %d: %v", i+1, err)
 		}
@@ -36,7 +48,7 @@ func TestMigrationAddsUsageColumns_Idempotent(t *testing.T) {
 	id := mustUpsert(t, store, ConfirmedMemory{
 		Owner: agentOwner("builder"), Repo: "acme/widget", Scope: "repo", Key: "legacy", Content: "legacy fact",
 	})
-	if err := store.applyMigration(ctx, len(migrations), usageMigration); err != nil {
+	if err := store.applyMigration(ctx, usageIndex+1, usageMigration); err != nil {
 		t.Fatalf("apply usage migration: %v", err)
 	}
 	var injected int64

--- a/internal/db/org_recycle_overdue_episodes.go
+++ b/internal/db/org_recycle_overdue_episodes.go
@@ -1,0 +1,68 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+// RecycleOverdueEpisode tracks one continuous organization-role recycle
+// overdue episode. EmittedAt carries the last emitted instant so the CLI ingress
+// can re-nudge at most once per recycle interval while the role stays overdue.
+type RecycleOverdueEpisode struct {
+	Subject      string `json:"subject"`
+	OverdueSince string `json:"overdue_since"`
+	EmittedAt    string `json:"emitted_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+}
+
+// UpsertRecycleOverdueEpisode opens an episode at overdueSince, or refreshes
+// updated_at for an existing one while retaining its first overdue_since.
+func (s *Store) UpsertRecycleOverdueEpisode(ctx context.Context, subject string, overdueSince, now time.Time) error {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return errors.New("recycle overdue episode subject is required")
+	}
+	stamp := now.UTC().Format(BlockedEpisodeTimeLayout)
+	_, err := s.db.ExecContext(ctx, `INSERT INTO org_recycle_overdue_episodes(subject, overdue_since, emitted_at, updated_at)
+		VALUES (?, ?, NULL, ?)
+		ON CONFLICT(subject) DO UPDATE SET updated_at = excluded.updated_at`,
+		subject, overdueSince.UTC().Format(BlockedEpisodeTimeLayout), stamp)
+	return err
+}
+
+// MarkRecycleOverdueEpisodeEmitted records the last emitted instant for the
+// episode. Marking a missing episode is an idempotent no-op.
+func (s *Store) MarkRecycleOverdueEpisodeEmitted(ctx context.Context, subject string, at time.Time) error {
+	stamp := at.UTC().Format(BlockedEpisodeTimeLayout)
+	_, err := s.db.ExecContext(ctx, `UPDATE org_recycle_overdue_episodes SET emitted_at = ?, updated_at = ? WHERE subject = ?`,
+		stamp, stamp, strings.TrimSpace(subject))
+	return err
+}
+
+// ClearRecycleOverdueEpisode closes an episode. Deleting a missing row is an
+// idempotent no-op.
+func (s *Store) ClearRecycleOverdueEpisode(ctx context.Context, subject string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM org_recycle_overdue_episodes WHERE subject = ?`, strings.TrimSpace(subject))
+	return err
+}
+
+// ListRecycleOverdueEpisodes returns every open episode in stable subject order.
+func (s *Store) ListRecycleOverdueEpisodes(ctx context.Context) ([]RecycleOverdueEpisode, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT subject, overdue_since, COALESCE(emitted_at, ''), updated_at
+		FROM org_recycle_overdue_episodes ORDER BY subject`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := []RecycleOverdueEpisode{}
+	for rows.Next() {
+		var episode RecycleOverdueEpisode
+		if err := rows.Scan(&episode.Subject, &episode.OverdueSince, &episode.EmittedAt, &episode.UpdatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, episode)
+	}
+	return result, rows.Err()
+}

--- a/internal/db/org_recycle_overdue_episodes_test.go
+++ b/internal/db/org_recycle_overdue_episodes_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRecycleOverdueEpisodeRoundTripKeepsFirstOverdueSince(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	var table string
+	if err := store.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master WHERE type='table' AND name='org_recycle_overdue_episodes'`).Scan(&table); err != nil {
+		t.Fatalf("org_recycle_overdue_episodes migration missing: %v", err)
+	}
+	first := time.Date(2026, 7, 23, 8, 1, 2, 345678901, time.UTC)
+	if err := store.UpsertRecycleOverdueEpisode(ctx, "review", first, first); err != nil {
+		t.Fatalf("UpsertRecycleOverdueEpisode(insert) error = %v", err)
+	}
+	if err := store.UpsertRecycleOverdueEpisode(ctx, "review", first.Add(3*time.Hour), first.Add(3*time.Hour)); err != nil {
+		t.Fatalf("UpsertRecycleOverdueEpisode(update) error = %v", err)
+	}
+	if err := store.UpsertRecycleOverdueEpisode(ctx, "owner", first.Add(time.Minute), first.Add(time.Minute)); err != nil {
+		t.Fatalf("UpsertRecycleOverdueEpisode(second subject) error = %v", err)
+	}
+
+	episodes, err := store.ListRecycleOverdueEpisodes(ctx)
+	if err != nil {
+		t.Fatalf("ListRecycleOverdueEpisodes() error = %v", err)
+	}
+	if len(episodes) != 2 || episodes[0].Subject != "owner" || episodes[1].Subject != "review" {
+		t.Fatalf("episodes = %+v, want subject-sorted rows", episodes)
+	}
+	if got, want := episodes[1].OverdueSince, first.Format(BlockedEpisodeTimeLayout); got != want {
+		t.Fatalf("OverdueSince = %q, want first-seen %q", got, want)
+	}
+	if got, want := episodes[1].UpdatedAt, first.Add(3*time.Hour).Format(BlockedEpisodeTimeLayout); got != want {
+		t.Fatalf("UpdatedAt = %q, want refreshed %q", got, want)
+	}
+	if episodes[1].EmittedAt != "" {
+		t.Fatalf("EmittedAt = %q, want empty", episodes[1].EmittedAt)
+	}
+
+	markedAt := first.Add(4 * time.Hour)
+	if err := store.MarkRecycleOverdueEpisodeEmitted(ctx, episodes[1].Subject, markedAt); err != nil {
+		t.Fatalf("MarkRecycleOverdueEpisodeEmitted() error = %v", err)
+	}
+	if err := store.MarkRecycleOverdueEpisodeEmitted(ctx, "missing", markedAt); err != nil {
+		t.Fatalf("MarkRecycleOverdueEpisodeEmitted(missing) error = %v", err)
+	}
+	episodes, err = store.ListRecycleOverdueEpisodes(ctx)
+	if err != nil {
+		t.Fatalf("ListRecycleOverdueEpisodes(after mark) error = %v", err)
+	}
+	if got, want := episodes[1].EmittedAt, markedAt.Format(BlockedEpisodeTimeLayout); got != want {
+		t.Fatalf("EmittedAt = %q, want %q", got, want)
+	}
+
+	if err := store.ClearRecycleOverdueEpisode(ctx, episodes[1].Subject); err != nil {
+		t.Fatalf("ClearRecycleOverdueEpisode() error = %v", err)
+	}
+	if err := store.ClearRecycleOverdueEpisode(ctx, episodes[1].Subject); err != nil {
+		t.Fatalf("ClearRecycleOverdueEpisode(idempotent) error = %v", err)
+	}
+	episodes, err = store.ListRecycleOverdueEpisodes(ctx)
+	if err != nil || len(episodes) != 1 || episodes[0].Subject != "owner" {
+		t.Fatalf("episodes after clear = %+v, err=%v", episodes, err)
+	}
+}
+
+func TestUpsertRecycleOverdueEpisodeRejectsEmptySubject(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.UpsertRecycleOverdueEpisode(context.Background(), " ", time.Now(), time.Now()); err == nil {
+		t.Fatal("UpsertRecycleOverdueEpisode() error = nil, want validation error")
+	}
+}

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1703,4 +1703,16 @@ ALTER TABLE confirmed_memories ADD COLUMN last_injected_at TEXT NOT NULL DEFAULT
 ALTER TABLE confirmed_memories ADD COLUMN recalled_count INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE confirmed_memories ADD COLUMN last_recalled_at TEXT NOT NULL DEFAULT '';
 	`,
+	// #1061 durable de-duplication for recycle-overdue dispatch events. This is
+	// deliberately parallel to org_blocked_episodes: the CLI ingress owns these
+	// episodes and never mutates the daemon's blocked-since state. Appended AFTER
+	// #1078's confirmed_memories telemetry entry — positional versions, never reorder.
+	`
+CREATE TABLE org_recycle_overdue_episodes (
+	subject TEXT PRIMARY KEY,
+	overdue_since TEXT NOT NULL,
+	emitted_at TEXT,
+	updated_at TEXT NOT NULL
+);
+	`,
 }

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -58,6 +58,9 @@ const (
 	// handling (recovery, alerting, cleanup) for that job until a later
 	// job.failed arrives WITHOUT a following job.deferred.
 	EventJobDeferred EventType = "job.deferred"
+	// EventOrgRecycleOverdue is emitted when an organization role crosses its
+	// configured recycle age and the CLI dispatch ingress warns or refuses it.
+	EventOrgRecycleOverdue EventType = "org.recycle_overdue"
 
 	// EventCandidateAwaitingPromotion is emitted once when a SkillOpt template
 	// candidate becomes PENDING (the post-import notify, #471): a new pending

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1192,7 +1192,12 @@ dispatches with an actionable error or logs a one-line advisory (`warn`) — the
 never blocked, so an overdue role can always hand off. `recycle_enforce` needs a
 configured `recycle_after` to have any effect. Both fields are **binary-first**:
 a binary predating them fails closed on a config that uses them, so deploy the
-binary before any config sets them.
+binary before any config sets them. When `recycle_enforce` is not `off`, an
+overdue refusal or warning also emits a repeating (once per `recycle_after`)
+`org.recycle_overdue` event through the org event sink; route it to a wake with
+`org events rule add --on recycle-overdue --wake <role>`. Notification delivery
+is best-effort — reliable from a foreground `agent ask`, but a short-lived
+`--background`/`orchestrate` dispatch may exit before the wake fires.
 
 `gitmoot org recycle <role> --kind <kind> --handoff "<note>" [--pane <id>]
 [--json] [--home <dir>]` journals a typed handoff in the role-lifecycle workflow

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1025,7 +1025,13 @@ shown read-only in the `recycle` column of `org status`
 `--org-role` dispatches from a role past its `recycle_after`, until it hands off
 and recycles; journaling a handoff note is never blocked. `recycle_enforce`
 needs a configured `recycle_after` to take effect. Both are binary-first —
-deploy the binary before any config sets them.
+deploy the binary before any config sets them. When `recycle_enforce` is not
+`off`, an overdue refusal or warning also emits a repeating (once per
+`recycle_after`) `org.recycle_overdue` event through the org event sink; route
+it to a wake with `org events rule add --on recycle-overdue --wake <role>`.
+Notification delivery is best-effort — reliable from a foreground `agent ask`,
+but a short-lived `--background`/`orchestrate` dispatch may exit before the wake
+fires.
 
 Agent `ask`, `run`, `review`, `implement`, and `orchestrate` accept
 `--org-role <name>`. The role is validated and touched before dispatch, then


### PR DESCRIPTION
## What

Deferred phase-3 follow-up (#1061). When an overdue role is refused/warned at the `--org-role` dispatch ingress (`recycle_enforce != off`), emit a durable, self-identifying, once-per-`recycle_after` `org.recycle_overdue` signal — reusing #1081's blocked-since machinery (the `events.Sink` + the mark-before-emit episode pattern) **without touching it**.

## Changes

- New **parallel** `org_recycle_overdue_episodes` table + store (`Upsert`/`MarkEmitted`/`Clear`/`List`), deliberately separate from `org_blocked_episodes` so the daemon's blocked evaluator never reaps CLI-owned overdue episodes. Migration appended.
- `EventOrgRecycleOverdue` classified as a **dedicated `recycle-overdue` event-rule kind** (not `blocked`), so an operator opts into overdue wakes with `org events rule add --on recycle-overdue --wake <role>` without overloading existing blocked rules.
- CLI-side, **best-effort**: overdue → upsert episode + mark-before-emit once per interval; **fresh → always clear** (independent of the sink, so a rule toggle across a recycle can't strand a stale episode). Every episode/emit failure is advisory-only and can **never** change the enforcement decision (`block` still refuses).

## Review — high (fresh finders, isolated worktree)

Two fresh finders. The `#1` concern — **the event bookkeeping never alters enforcement** — is clean (all failure paths swallowed; `off` a total no-op; strong tests including one that proves an emit failure changes neither the return code nor the presence touch). Scope fences, migration append, `overdue_since` stability, and reaping isolation all verified clean.

Two findings, both notification-side (not enforcement), addressed:
- **LOW (lifecycle) — fixed:** the fresh-clear was gated behind the sink, so a recycle while no rule was enabled could strand a stale episode. Now the clear runs regardless of the sink; a re-overdue opens a fresh episode. Locked with a test.
- **MEDIUM (delivery, owner-ruled to ship + track):** the async wake/webhook is fire-and-forget, so on a short-lived `--background`/`orchestrate` dispatch the process can exit before delivery, and mark-before-emit then suppresses retry for the interval. The **durable episode row is unaffected**; only the proactive notification is unreliable there. Foreground `agent ask` is fine. Documented in the code + docs; reliable background delivery tracked in **#1091** (needs a synchronous flush coordinated with G2's #1076 `eventRuleSink`, or a daemon-side evaluator).

## Scope

Zero change to the blocked-since/missed-wake evaluation, the daemon, or the chart surface. Closes out RFC #1042 phase 3 (detection #1080, refusal #1084, recycle #1089, + this observability signal).

## Deploy

No deploy (judging window). Merge owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
