### PR TITLE
fix(org): presence provider honors the pane binding — share the wake resolver (#1095)

### DIFF
--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -33,7 +33,7 @@ type blockedRoleAvailability interface {
 
 type blockedRoleWakeDependencies struct {
 	availability blockedRoleAvailability
-	provider     func([]string) org.Provider
+	provider     func([]config.OrgRole) org.Provider
 	eventSink    func(context.Context, *db.Store, string) (events.Sink, error)
 }
 
@@ -195,15 +195,10 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 		writeLine(stdout, "blocked_since role org config load failed: %v", err)
 		return
 	}
-	roles := orgConfig.Roles()
-	names := make([]string, 0, len(roles))
-	for _, role := range roles {
-		names = append(names, role.Name)
-	}
 	if deps.provider == nil {
 		return
 	}
-	provider := deps.provider(names)
+	provider := deps.provider(orgConfig.Roles())
 	if provider == nil {
 		return
 	}
@@ -335,4 +330,3 @@ func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.S
 func taskEpisodeSubject(repo, taskID string) string {
 	return "task:" + strings.TrimSpace(repo) + ":" + strings.TrimSpace(taskID)
 }
-

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -118,10 +118,12 @@ enforce = "warn"
 [org.roles."owner"]
 scope = ["*"]
 merge_rule = "owner"
+pane = "Gitmoot"
 [org.roles."review"]
 parent = "owner"
 scope = ["gitmoot/*"]
 merge_rule = "self"
+pane = "Gitmoot Review"
 [orchestrate]
 blocked_role_wake_after = "1h"
 `); err != nil {
@@ -147,11 +149,11 @@ blocked_role_wake_after = "1h"
 	}
 	availability := &fakeBlockedRoleAvailability{available: true}
 	sink := &recordingSink{}
-	var providerRoles []string
+	var providerRoles []config.OrgRole
 	deps := blockedRoleWakeDependencies{
 		availability: availability,
-		provider: func(roles []string) org.Provider {
-			providerRoles = append([]string(nil), roles...)
+		provider: func(roles []config.OrgRole) org.Provider {
+			providerRoles = append([]config.OrgRole(nil), roles...)
 			return orgFixtureProvider{snapshot: snapshot}
 		},
 		eventSink: func(context.Context, *db.Store, string) (events.Sink, error) { return sink, nil },
@@ -166,7 +168,9 @@ blocked_role_wake_after = "1h"
 	if len(blocked) != 1 {
 		t.Fatalf("job.blocked events = %d, want 1; output=%s", len(blocked), output.String())
 	}
-	if len(providerRoles) != 2 || providerRoles[0] != "owner" || providerRoles[1] != "review" {
+	if len(providerRoles) != 2 ||
+		providerRoles[0].Name != "owner" || providerRoles[0].Pane != "Gitmoot" ||
+		providerRoles[1].Name != "review" || providerRoles[1].Pane != "Gitmoot Review" {
 		t.Fatalf("provider roles = %v", providerRoles)
 	}
 	ev := blocked[0]

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -156,30 +156,18 @@ func (s *eventRuleSink) loadOrgConfig() (config.OrgConfig, bool) {
 
 // resolveRolePane is the v1 config-backed role→pane binding seam. Keeping it in
 // one small method lets a later live registry replace config without changing
-// classification, matching, or wake delivery. The configured value is resolved as
-// a herdr pane LABEL first: a wX:pY pane id matches no pane's label, so an id
-// binding falls through to literal use, while a label — even one that itself
-// contains ':' — resolves to its live pane's CURRENT id (recycle-safe, since ids
-// rot on recycle but a stable label does not).
+// classification, matching, or wake delivery.
 func (s *eventRuleSink) resolveRolePane(ctx context.Context, cfg config.OrgConfig, role string) (pane string, ok bool) {
 	orgRole, ok := cfg.Role(role)
 	if !ok {
 		return "", false
 	}
-	binding := strings.TrimSpace(orgRole.Pane)
-	if binding == "" {
-		return "", false
-	}
-	// Bound the `pane list` resolution so it cannot hang the wake path.
-	resolveCtx, cancel := context.WithTimeout(ctx, eventRuleProbeTimeout)
-	resolved, found := s.wake.ResolvePaneByLabel(resolveCtx, binding)
-	cancel()
-	if found {
-		return resolved, true
-	}
-	// Not a live label: use the value as a literal pane id (best-effort — herdr
-	// no-ops an unknown id, which is the correct outcome for a down role).
-	return binding, true
+	return config.ResolveRolePaneBinding(ctx, orgRole.Pane, func(ctx context.Context, label string) (string, bool) {
+		// Bound the `pane list` resolution so it cannot hang the wake path.
+		resolveCtx, cancel := context.WithTimeout(ctx, eventRuleProbeTimeout)
+		defer cancel()
+		return s.wake.ResolvePaneByLabel(resolveCtx, label)
+	})
 }
 
 func classifyEventRuleKinds(event events.Event) []string {

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -74,7 +74,7 @@ func fixedOrgPolicy(policy workflow.OrgEnforcement) func(string) workflow.OrgEnf
 	return func(string) workflow.OrgEnforcement { return policy }
 }
 
-var newOrgProvider = func(roles []string) org.Provider { return cockpit.NewHerdrOrgProvider(roles) }
+var newOrgProvider = func(roles []config.OrgRole) org.Provider { return cockpit.NewHerdrOrgProvider(roles) }
 
 var orgDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
 
@@ -584,7 +584,7 @@ func runOrgRecycle(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	provider := newOrgProvider([]string{role.Name})
+	provider := newOrgProvider([]config.OrgRole{role})
 	if provider == nil {
 		fmt.Fprintf(stderr, "org recycle: organization provider is not configured (handoff journaled in workflow %s)\n", workflowID)
 		return 1
@@ -649,12 +649,7 @@ func loadOrgCommandState(ctx context.Context, home string) (config.OrgConfig, ma
 }
 
 func orgProviderSnapshot(ctx context.Context, cfg config.OrgConfig) (org.Snapshot, error) {
-	roles := cfg.Roles()
-	names := make([]string, 0, len(roles))
-	for _, role := range roles {
-		names = append(names, role.Name)
-	}
-	provider := newOrgProvider(names)
+	provider := newOrgProvider(cfg.Roles())
 	if provider == nil {
 		return org.Snapshot{}, errors.New("organization live-state provider is not configured")
 	}

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -318,8 +318,45 @@ merge_rule = "self"
 func withOrgProvider(t *testing.T, provider org.Provider) {
 	t.Helper()
 	original := newOrgProvider
-	newOrgProvider = func([]string) org.Provider { return provider }
+	newOrgProvider = func([]config.OrgRole) org.Provider { return provider }
 	t.Cleanup(func() { newOrgProvider = original })
+}
+
+func TestOrgProviderSnapshotPassesRolePaneBindings(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[org.roles."owner"]
+scope = ["*"]
+pane = "Gitmoot"
+[org.roles."review"]
+parent = "owner"
+scope = ["gitmoot/*"]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := newOrgProvider
+	var got []config.OrgRole
+	newOrgProvider = func(roles []config.OrgRole) org.Provider {
+		got = append([]config.OrgRole(nil), roles...)
+		return orgFixtureProvider{snapshot: org.Snapshot{ObservedAt: time.Now()}}
+	}
+	t.Cleanup(func() { newOrgProvider = original })
+
+	if _, err := orgProviderSnapshot(context.Background(), cfg); err != nil {
+		t.Fatalf("orgProviderSnapshot() error = %v", err)
+	}
+	if len(got) != 2 || got[0].Name != "owner" || got[0].Pane != "Gitmoot" || got[1].Name != "review" {
+		t.Fatalf("provider roles = %+v", got)
+	}
 }
 
 func TestRunOrgBriefChartStatusAndPresence(t *testing.T) {

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/org"
 )
 
 type herdrOrgProvider struct {
 	run   runner
-	roles []string
+	roles []config.OrgRole
 	now   func() time.Time
 }
 
@@ -23,15 +24,14 @@ const (
 	herdrOrgRecycleDeadline  = 35 * time.Second
 )
 
-// NewHerdrOrgProvider returns the v1 organization live-state provider. Role
-// identity is exact pane-label equality; runtime/agent names are never inferred.
-func NewHerdrOrgProvider(roles []string) org.Provider {
+// NewHerdrOrgProvider returns the v1 organization live-state provider.
+func NewHerdrOrgProvider(roles []config.OrgRole) org.Provider {
 	return newHerdrOrgProvider(newExecRunner("herdr"), roles, time.Now)
 }
 
-func newHerdrOrgProvider(run runner, roles []string, now func() time.Time) *herdrOrgProvider {
-	roles = append([]string(nil), roles...)
-	sort.Strings(roles)
+func newHerdrOrgProvider(run runner, roles []config.OrgRole, now func() time.Time) *herdrOrgProvider {
+	roles = append([]config.OrgRole(nil), roles...)
+	sort.Slice(roles, func(i, j int) bool { return roles[i].Name < roles[j].Name })
 	return &herdrOrgProvider{run: run, roles: roles, now: now}
 }
 
@@ -40,6 +40,7 @@ type herdrOrgSnapshotResult struct {
 		Snapshot struct {
 			Version json.RawMessage `json:"version"`
 			Panes   []struct {
+				PaneID      string `json:"pane_id"`
 				Label       string `json:"label"`
 				AgentStatus string `json:"agent_status"`
 			} `json:"panes"`
@@ -68,23 +69,55 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 	}
 
 	byLabel := map[string][]string{}
+	labelToPaneIDs := map[string][]string{}
+	statusByPaneID := map[string]string{}
 	for _, pane := range decoded.Result.Snapshot.Panes {
-		label := pane.Label
-		if label == "" {
-			continue
+		// Mirror the wake resolver (herdr.go resolvePaneByLabel, which matches only
+		// `p.PaneID != ""`): a pane with an empty pane_id is not a resolvable
+		// target. Seeding it would collide every empty-id pane on the "" key of
+		// statusByPaneID and let a binding read the wrong pane's status.
+		if pane.PaneID != "" {
+			statusByPaneID[pane.PaneID] = pane.AgentStatus
+			if pane.Label != "" {
+				labelToPaneIDs[pane.Label] = append(labelToPaneIDs[pane.Label], pane.PaneID)
+			}
 		}
-		byLabel[label] = append(byLabel[label], pane.AgentStatus)
+		if pane.Label != "" {
+			byLabel[pane.Label] = append(byLabel[pane.Label], pane.AgentStatus)
+		}
 	}
 	states := make(map[string]org.RoleLiveState, len(p.roles))
 	for _, role := range p.roles {
-		matches := byLabel[role]
+		binding := strings.TrimSpace(role.Pane)
+		if binding != "" {
+			if len(labelToPaneIDs[binding]) > 1 {
+				states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: fmt.Sprintf("multiple Herdr panes labeled %q", binding)}
+				continue
+			}
+			paneID, _ := config.ResolveRolePaneBinding(ctx, binding, func(_ context.Context, label string) (string, bool) {
+				ids := labelToPaneIDs[label]
+				if len(ids) == 1 {
+					return ids[0], true
+				}
+				return "", false
+			})
+			status, present := statusByPaneID[paneID]
+			if !present {
+				states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: fmt.Sprintf("no Herdr pane bound as %q", binding)}
+				continue
+			}
+			states[role.Name] = mapHerdrAgentStatus(status)
+			continue
+		}
+
+		matches := byLabel[role.Name]
 		switch len(matches) {
 		case 0:
-			states[role] = org.RoleLiveState{State: org.StateUnknown, Detail: "no Herdr pane has this exact role label"}
+			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: "no Herdr pane has this exact role label"}
 		case 1:
-			states[role] = mapHerdrAgentStatus(matches[0])
+			states[role.Name] = mapHerdrAgentStatus(matches[0])
 		default:
-			states[role] = org.RoleLiveState{State: org.StateUnknown, Detail: "multiple Herdr panes have this exact role label"}
+			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: "multiple Herdr panes have this exact role label"}
 		}
 	}
 	now := time.Now

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/org"
 )
 
@@ -17,19 +18,22 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 			t.Fatalf("args = %v", args)
 		}
 		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
-{"label":"owner","agent_status":"working"},
-{"label":"review","agent_status":"blocked"},
-{"label":"done","agent_status":"done"},
-{"label":"idle","agent_status":"idle"},
-{"label":"future","agent_status":"paused"},
-{"label":"duplicate","agent_status":"working"},
-{"label":"duplicate","agent_status":"idle"},
-{"label":"claude","agent_status":"working"},
-{"label":" whitespace-label ","agent_status":"working"},
-{"label":"whitespace-status","agent_status":" working "}
+{"pane_id":"w1:p1","label":"owner","agent_status":"working"},
+{"pane_id":"w1:p2","label":"review","agent_status":"blocked"},
+{"pane_id":"w1:p3","label":"done","agent_status":"done"},
+{"pane_id":"w1:p4","label":"idle","agent_status":"idle"},
+{"pane_id":"w1:p5","label":"future","agent_status":"paused"},
+{"pane_id":"w1:p6","label":"duplicate","agent_status":"working"},
+{"pane_id":"w1:p7","label":"duplicate","agent_status":"idle"},
+{"pane_id":"w1:p8","label":"claude","agent_status":"working"},
+{"pane_id":"w1:p9","label":" whitespace-label ","agent_status":"working"},
+{"pane_id":"w1:p10","label":"whitespace-status","agent_status":" working "}
 ]}}}`, nil
 	}
-	provider := newHerdrOrgProvider(run, []string{"owner", "review", "done", "idle", "future", "duplicate", "missing", "whitespace-label", "whitespace-status"}, func() time.Time { return observed })
+	provider := newHerdrOrgProvider(run, []config.OrgRole{
+		{Name: "owner"}, {Name: "review"}, {Name: "done"}, {Name: "idle"}, {Name: "future"},
+		{Name: "duplicate"}, {Name: "missing"}, {Name: "whitespace-label"}, {Name: "whitespace-status"},
+	}, func() time.Time { return observed })
 	snapshot, err := provider.Snapshot(context.Background())
 	if err != nil {
 		t.Fatalf("Snapshot() error = %v", err)
@@ -52,6 +56,60 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 	}
 }
 
+func TestHerdrOrgProviderSnapshotPaneBindings(t *testing.T) {
+	run := func(_ context.Context, _ ...string) (string, error) {
+		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"Gitmoot Idle","agent_status":"idle"},
+{"pane_id":"w1:p2","label":"Gitmoot Working","agent_status":"working"},
+{"pane_id":"w1:p3","label":"Gitmoot Blocked","agent_status":"blocked"},
+{"pane_id":"w1:p4","label":"Gitmoot Done","agent_status":"done"},
+{"pane_id":"w1:p5","label":"literal-pane","agent_status":"working"},
+{"pane_id":"w1:p6","label":"duplicate-label","agent_status":"idle"},
+{"pane_id":"w1:p7","label":"duplicate-label","agent_status":"blocked"},
+{"pane_id":"","label":"Empty A","agent_status":"blocked"},
+{"pane_id":"","label":"Empty B","agent_status":"idle"}
+]}}}`, nil
+	}
+	provider := newHerdrOrgProvider(run, []config.OrgRole{
+		{Name: "idle-role", Pane: "Gitmoot Idle"},
+		{Name: "working-role", Pane: "Gitmoot Working"},
+		{Name: "blocked-role", Pane: "Gitmoot Blocked"},
+		{Name: "done-role", Pane: "Gitmoot Done"},
+		{Name: "literal-role", Pane: "w1:p5"},
+		{Name: "missing-role", Pane: "missing-label"},
+		{Name: "ambiguous-role", Pane: "duplicate-label"},
+		// #1095 regression: a pane with an empty pane_id is not a resolvable
+		// target (mirrors the wake resolver). It must NOT seed statusByPaneID[""]
+		// and leak another empty-id pane's status; the bound role stays Unknown.
+		{Name: "empty-id-role", Pane: "Empty A"},
+	}, time.Now)
+
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	wants := map[string]org.LifecycleState{
+		"idle-role": org.StateIdle, "working-role": org.StateWorking,
+		"blocked-role": org.StateBlocked, "done-role": org.StateDone,
+		"literal-role": org.StateWorking, "missing-role": org.StateUnknown,
+		"ambiguous-role": org.StateUnknown, "empty-id-role": org.StateUnknown,
+	}
+	for role, want := range wants {
+		if got := snapshot.States[role].State; got != want {
+			t.Errorf("state[%s] = %q, want %q (%+v)", role, got, want, snapshot.States[role])
+		}
+	}
+	if got := snapshot.States["missing-role"].Detail; got != `no Herdr pane bound as "missing-label"` {
+		t.Errorf("missing detail = %q", got)
+	}
+	if got := snapshot.States["ambiguous-role"].Detail; got != `multiple Herdr panes labeled "duplicate-label"` {
+		t.Errorf("ambiguous detail = %q", got)
+	}
+	if got := snapshot.States["empty-id-role"].Detail; got != `no Herdr pane bound as "Empty A"` {
+		t.Errorf("empty-id detail = %q", got)
+	}
+}
+
 func TestHerdrOrgProviderFailures(t *testing.T) {
 	tests := []struct {
 		name string
@@ -66,7 +124,7 @@ func TestHerdrOrgProviderFailures(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			provider := newHerdrOrgProvider(func(context.Context, ...string) (string, error) { return test.out, test.err }, []string{"owner"}, time.Now)
+			provider := newHerdrOrgProvider(func(context.Context, ...string) (string, error) { return test.out, test.err }, []config.OrgRole{{Name: "owner"}}, time.Now)
 			_, err := provider.Snapshot(context.Background())
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("Snapshot() error = %v, want containing %q", err, test.want)
@@ -84,7 +142,7 @@ func TestHerdrOrgProviderRecycleCommand(t *testing.T) {
 		got = append([]string(nil), args...)
 		return "", nil
 	}
-	provider := newHerdrOrgProvider(run, []string{"owner"}, time.Now)
+	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
 	req := org.RecycleRequest{Role: "owner", Pane: "w1:p2", Kind: "codex", AgentName: "owner", BootPrompt: "role: owner\n\nhandoff: ship it"}
 	if err := provider.Recycle(context.Background(), req); err != nil {
 		t.Fatalf("Recycle() error = %v", err)
@@ -98,7 +156,7 @@ func TestHerdrOrgProviderRecycleCommand(t *testing.T) {
 func TestHerdrOrgProviderRecycleFailureIsActionable(t *testing.T) {
 	provider := newHerdrOrgProvider(func(context.Context, ...string) (string, error) {
 		return "", errors.New("pane is not at shell")
-	}, []string{"owner"}, time.Now)
+	}, []config.OrgRole{{Name: "owner"}}, time.Now)
 	err := provider.Recycle(context.Background(), org.RecycleRequest{Role: "owner", Pane: "w1:p2", Kind: "codex", AgentName: "owner", BootPrompt: "brief"})
 	if err == nil || !strings.Contains(err.Error(), "interactive shell prompt") || !strings.Contains(err.Error(), "pane is not at shell") {
 		t.Fatalf("Recycle() error = %v", err)

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -17,8 +17,8 @@ type OrgRole struct {
 	Parent    string
 	Scope     []string
 	MergeRule string
-	// Pane optionally binds this role to a Herdr pane for event-rule wakes. It is
-	// advisory and unused unless an enabled event rule targets the role.
+	// Pane optionally binds this role to a Herdr pane for live presence and
+	// event-rule wakes.
 	Pane         string
 	RecycleAfter time.Duration
 }

--- a/internal/config/org_binding.go
+++ b/internal/config/org_binding.go
@@ -1,0 +1,20 @@
+package config
+
+import (
+	"context"
+	"strings"
+)
+
+// ResolveRolePaneBinding resolves an OrgRole.Pane binding to a Herdr pane id.
+// A binding is treated as a pane label first and as a literal pane id when no
+// live pane has that label. Empty bindings do not resolve.
+func ResolveRolePaneBinding(ctx context.Context, binding string, resolveLabel func(context.Context, string) (string, bool)) (string, bool) {
+	binding = strings.TrimSpace(binding)
+	if binding == "" {
+		return "", false
+	}
+	if resolved, found := resolveLabel(ctx, binding); found {
+		return resolved, true
+	}
+	return binding, true
+}

--- a/internal/config/org_binding_test.go
+++ b/internal/config/org_binding_test.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResolveRolePaneBinding(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name        string
+		binding     string
+		resolutions map[string]string
+		wantPane    string
+		wantOK      bool
+	}{
+		{name: "empty", binding: " \t ", wantPane: "", wantOK: false},
+		{name: "label resolves", binding: " coordinator ", resolutions: map[string]string{"coordinator": "w2:p5"}, wantPane: "w2:p5", wantOK: true},
+		{name: "unknown label is literal id", binding: "w1:p2", wantPane: "w1:p2", wantOK: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pane, ok := ResolveRolePaneBinding(ctx, test.binding, func(_ context.Context, label string) (string, bool) {
+				resolved, found := test.resolutions[label]
+				return resolved, found
+			})
+			if pane != test.wantPane || ok != test.wantOK {
+				t.Fatalf("ResolveRolePaneBinding(%q) = (%q, %t), want (%q, %t)", test.binding, pane, ok, test.wantPane, test.wantOK)
+			}
+		})
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1167,7 +1167,9 @@ resolved role table.
 
 The registry uses `[org] enforce = "warn"|"block"` and
 `[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, and an
-optional `pane` Herdr binding (used by org event-rule wakes). There is
+optional `pane` Herdr binding (used by live presence and org event-rule wakes).
+The binding resolves as an exact live pane label first, then as a literal pane
+id; roles without a binding retain exact role-name-as-label presence lookup. There is
 exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
 `owner/repo`, and each child scope must be covered by its parent. Malformed
 org configuration fails closed and loudly. `brief` records passive last-seen
@@ -1238,9 +1240,9 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 `--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, or `blocked`.
 `--match` is a case-insensitive substring matched independently against the
 event repo and job id; omit it to match every event of that kind. `--wake` must
-name a declared role whose config sets `pane = "<pane-id-or-label>"` (a value
-with a `:` is a `wX:pY` id, otherwise a pane label resolved to the current id at
-wake time). The daemon calls `herdr agent prompt <pane> <text> --wait --timeout
+name a declared role whose config sets `pane = "<pane-id-or-label>"`. Gitmoot
+first resolves the value as an exact pane label and otherwise uses it as a
+literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --timeout
 8000` and treats delivered (`result.type = "agent_prompted"`, or a post-delivery
 `error.code = "timeout"`) apart from stalled (`error.code =
 "agent_prompt_stalled"`). Stalls increment the role's consecutive missed-wake

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1004,7 +1004,10 @@ gitmoot org status [--json]
 ```
 
 The registry uses `[org] enforce = "warn"|"block"` and
-`[org.roles."name"]` entries with `parent`, `scope`, and `merge_rule`. There is
+`[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, and an
+optional `pane` Herdr binding. The binding resolves as an exact live pane label
+first, then as a literal pane id; roles without a binding retain exact
+role-name-as-label presence lookup. There is
 exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
 `owner/repo`. Malformed org configuration fails closed and loudly. `brief`
 records passive last-seen presence for its role and can render static context
@@ -1072,7 +1075,8 @@ remains policy-gated.
 
 The optional `[org]` registry is enabled by any `[org.roles."name"]` section.
 Roles have `parent`, `scope`, advisory `merge_rule` (`owner`, `self`, or
-`none`), and an optional Herdr `pane`; exactly one parent-less role is required.
+`none`), and an optional Herdr `pane` used by live presence and event-rule
+wakes; exactly one parent-less role is required.
 Scope entries are `*`, `owner/*`, or exact `owner/name`, and child scope must be
 a subset of its parent.
 
@@ -1116,7 +1120,9 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 
 `--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, or `blocked`.
 `--match` is a case-insensitive substring matched against the event repo or job
-id; empty matches all. The wake role must exist and set `pane = "<herdr-pane>"`.
+id; empty matches all. The wake role must exist and set `pane = "<herdr-pane>"`;
+Gitmoot resolves that value as an exact pane label first and otherwise treats it
+as a literal pane id.
 Delivery is best-effort and verified with Herdr's `agent_prompted` versus
 `agent_prompt_stalled` result; zero rules leaves the feature off.
 


### PR DESCRIPTION
Closes #1095. Found on the org layer's first live activation (warn-mode bring-up on this box).

## The bug
The org presence provider matched herdr panes by **role name** and ignored the `OrgRole.Pane` binding (#1076). So every role whose pane label differs from its name — g2 ("Gitmoot2"), g3 ("Gitmoot 3"), g4 ("Gitmoot4"), lead ("Gitmoot") — read `unknown`, while name-coincidence roles (vetrina/joltra/herdres) worked. Because blocked-since detection reads presence through this provider, the **blocked→wake alarm was blind for exactly the coordinator panes it exists to watch**. The wake path already resolved the binding correctly, so presence and wake resolved the same binding differently — the duplicated-resolver drift class.

## The fix — share the wake resolver (no third resolver)
- Extract the binding decision into one shared `config.ResolveRolePaneBinding(binding, resolveLabel)` — label-first, literal pane id otherwise, empty→false. **Both** the wake path (`resolveRolePane`, behavior-preserving) and the presence provider call it.
- The presence provider decodes `pane_id`, resolves each role's `Pane` binding to a pane and reads that pane's status, and falls back to **role-name-as-label** for unbound roles (keeps the name-coincidence lanes working). Ambiguity → `Unknown`.
- `NewHerdrOrgProvider([]string → []config.OrgRole)`; both callers updated.

## Provenance / quality
- A `/code-review high` caught a real divergence the first pass missed: presence seeded `statusByPaneID` for panes with an **empty pane_id** (all colliding on the `""` key) while the wake resolver skips empty ids — so a binding could read the wrong pane's status and fire a spurious wake. Fixed by mirroring wake's `PaneID != ""` guard; guarded by a 2-empty-id-pane regression test.
- **Ambiguity policy (noted):** presence returns `Unknown` on a label matching >1 panes (per the issue spec and the prior behavior) — deliberately conservative for a status/alarm surface, where an ambiguous binding is a misconfig/transient and showing `Unknown` (no false alarm) beats guessing. The wake path best-effort-picks-first; if full wake-parity on ambiguity is wanted, that's a one-line follow-up.

## Live verify
`org chart` on this box's live config with the built binary: **all 8 pane-bound roles show real states** — `lead·idle g2·working g3·working g4·idle herdres·done joltra·idle trend-scout·idle vetrina·done` (lead/g2/g3/g4 were `unknown` before); `jarvis` (no pane) stays hollow by design.

## Deploy notes
Code-only, no migration, single static binary preserved. This is the org layer (warn-mode bring-up); no dashboard-visible surface.

## Gate
`go build` / `go vet` / `go test` / `go generate && git diff` green; focused `-race` on config/cockpit/cli green. Full sharded race runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
