### PR TITLE
fix(workflow): native merge journals the PR-merged transition — lifecycle slice 1 (#1094)

### DIFF
--- a/internal/daemon/external_merge_reconcile_test.go
+++ b/internal/daemon/external_merge_reconcile_test.go
@@ -79,7 +79,7 @@ func TestBlockedTaskExternalMergeReconcileE2E(t *testing.T) {
 		t.Fatalf("workflow notes after two ticks = %+v, err=%v", notes, err)
 	}
 	meta, err := store.GetWorkflowMeta(ctx, "gitmoot4/blocked-reconcile-953")
-	if err != nil || meta.Status != "PR #953 merged" || meta.Description != "blocked-reconcile-953" {
+	if err != nil || meta.Status != "active" || meta.Description != "blocked-reconcile-953" {
 		t.Fatalf("workflow meta after two ticks = %+v, err=%v", meta, err)
 	}
 }
@@ -176,7 +176,7 @@ func TestPollOnceRecordsClosedBreadcrumbForWorkflowLinkedPROpenTask(t *testing.T
 		t.Fatalf("workflow notes after two ticks = %+v, err=%v", notes, err)
 	}
 	meta, err := store.GetWorkflowMeta(ctx, "gitmoot4/selfdesc-958")
-	if err != nil || meta.Status != "PR #7 closed without merging" {
+	if err != nil || meta.Status != "active" {
 		t.Fatalf("workflow meta after two ticks = %+v, err=%v", meta, err)
 	}
 }

--- a/internal/daemon/pr_open_promotion_test.go
+++ b/internal/daemon/pr_open_promotion_test.go
@@ -140,7 +140,7 @@ func TestReconcilePROpenTasksJournalsWorkflowOnce(t *testing.T) {
 		t.Fatalf("auto note = %+v", notes[0])
 	}
 	meta, err := store.GetWorkflowMeta(ctx, workflowID)
-	if err != nil || meta.Status != "PR #958 open" || meta.Description != "lifecycle" {
+	if err != nil || meta.Status != "active" || meta.Description != "lifecycle" {
 		t.Fatalf("meta = %+v, err=%v", meta, err)
 	}
 }

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -278,7 +278,7 @@ VALUES (?, ?, ?, ?, ?)`, note.WorkflowID, note.Author, note.Body, note.Repo, not
 		return WorkflowNote{}, false, err
 	}
 	meta.WorkflowID = note.WorkflowID
-	if err := upsertWorkflowMetaTx(ctx, tx, meta); err != nil {
+	if err := upsertWorkflowMetaConditionalStatusTx(ctx, tx, meta); err != nil {
 		return WorkflowNote{}, false, err
 	}
 	if !meta.DescriptionSet {
@@ -372,6 +372,18 @@ VALUES (?, ?, ?, ?, ?)`, note.WorkflowID, note.Author, note.Body, note.Repo, not
 }
 
 func upsertWorkflowMetaTx(ctx context.Context, tx *sql.Tx, meta WorkflowMeta) error {
+	return upsertWorkflowMetaTxWithStatusGuard(ctx, tx, meta, false)
+}
+
+// upsertWorkflowMetaConditionalStatusTx preserves operator-owned lifecycle
+// states while allowing daemon PR receipts to canonicalize stale machine-owned
+// status. Only the status field is guarded; coordinator metadata keeps the same
+// last-write-wins behavior as upsertWorkflowMetaTx.
+func upsertWorkflowMetaConditionalStatusTx(ctx context.Context, tx *sql.Tx, meta WorkflowMeta) error {
+	return upsertWorkflowMetaTxWithStatusGuard(ctx, tx, meta, true)
+}
+
+func upsertWorkflowMetaTxWithStatusGuard(ctx context.Context, tx *sql.Tx, meta WorkflowMeta, protectStatus bool) error {
 	if err := validateWorkflowMeta(meta); err != nil {
 		return err
 	}
@@ -384,9 +396,13 @@ ON CONFLICT(workflow_id) DO UPDATE SET
 	workdir = CASE WHEN excluded.workdir != '' THEN excluded.workdir ELSE workflow_meta.workdir END,
 	summary = CASE WHEN ? THEN excluded.summary ELSE workflow_meta.summary END,
 	description = CASE WHEN ? THEN excluded.description ELSE workflow_meta.description END,
-	status = CASE WHEN ? THEN excluded.status ELSE workflow_meta.status END,
+	status = CASE
+		WHEN ? AND (NOT ? OR workflow_meta.status NOT IN ('blocked', 'parked', 'done', 'settled'))
+			THEN excluded.status
+		ELSE workflow_meta.status
+	END,
 	updated_at = CURRENT_TIMESTAMP`, meta.WorkflowID, meta.Author, meta.Pane, meta.SessionID, meta.WorkDir,
-		meta.Summary, meta.Description, meta.Status, meta.SummarySet, meta.DescriptionSet, meta.StatusSet)
+		meta.Summary, meta.Description, meta.Status, meta.SummarySet, meta.DescriptionSet, meta.StatusSet, protectStatus)
 	return err
 }
 

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -257,6 +258,20 @@ func executePullRequestMerge(ctx context.Context, client interface {
 func (g PolicyMergeGate) finishMerged(ctx context.Context, request MergeRequest, pr github.PullRequest, mergeSHA string) (MergeDecision, error) {
 	if err := g.recordMerged(ctx, request, pr, mergeSHA); err != nil {
 		return MergeDecision{}, err
+	}
+	branch := strings.TrimSpace(pr.HeadRef)
+	if branch == "" {
+		branch = strings.TrimSpace(request.Branch)
+	}
+	if _, err := RecordPullRequestWorkflowTransition(ctx, g.Store, PullRequestEvent{
+		Repo:        request.Repo,
+		Branch:      branch,
+		PullRequest: request.PullRequest,
+	}, PullRequestJournalMerged); err != nil {
+		// The GitHub merge and local PR record are already durable. Journaling is
+		// observability only and must never turn a successful merge into a failure
+		// or alter its MergeDecision.
+		log.Printf("WARNING: workflow journal PR-merged breadcrumb failed for %s#%d: %v", request.Repo, request.PullRequest, err)
 	}
 	postMergeWarnings := []string{}
 	lock, err := g.Store.GetBranchLock(ctx, request.Repo, pr.HeadRef)

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -24,9 +24,15 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 		PullRequest: 9,
 		HeadSHA:     "head123",
 		TaskID:      "task-9",
+		WorkflowID:  "release/native-merge",
 		ReviewRound: "review-1",
 		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
 	})
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: "release/native-merge", Author: "operator", Body: "ready"},
+		db.WorkflowMeta{Status: "ready_to_merge", StatusSet: true}); err != nil {
+		t.Fatalf("seed workflow status: %v", err)
+	}
 	mergeable := true
 	gh := &fakeMergeGateGitHub{
 		pr: github.PullRequest{
@@ -90,6 +96,84 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	}
 	if len(git.updated) != 1 || git.updated[0] != "origin/main" {
 		t.Fatalf("updated base calls = %+v", git.updated)
+	}
+	meta, err := store.GetWorkflowMeta(ctx, "release/native-merge")
+	if err != nil || meta.Status != "active" {
+		t.Fatalf("workflow meta after native merge = %+v, err=%v", meta, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, "release/native-merge", 0)
+	if err != nil {
+		t.Fatalf("ListWorkflowNotes: %v", err)
+	}
+	mergedReceipts := 0
+	for _, note := range notes {
+		if note.Body == "[auto:pr:9:merged] PR #9 merged" {
+			mergedReceipts++
+		}
+	}
+	if mergedReceipts != 1 {
+		t.Fatalf("merged receipt count = %d, want 1; notes=%+v", mergedReceipts, notes)
+	}
+	if inserted, err := RecordPullRequestWorkflowTransition(ctx, store, PullRequestEvent{
+		Repo: "gitmoot/gitmoot", Branch: "task-9", PullRequest: 9,
+	}, PullRequestJournalMerged); err != nil || inserted {
+		t.Fatalf("daemon replay = (inserted=%v, err=%v), want deduplicated no-op", inserted, err)
+	}
+}
+
+func TestPolicyMergeGateJournalFailureDoesNotChangeMergedDecision(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertCompletedJob(t, store, db.Job{ID: "native-journal-link", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		WorkflowID:  "release/native-journal-failure",
+	})
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: "release/native-journal-failure", Author: "operator", Body: "ready"},
+		db.WorkflowMeta{Status: "ready_to_merge", StatusSet: true}); err != nil {
+		t.Fatalf("seed workflow status: %v", err)
+	}
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("open raw database: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.ExecContext(ctx, `
+CREATE TRIGGER fail_native_merge_workflow_journal
+BEFORE INSERT ON workflow_notes
+WHEN NEW.author = 'daemon' AND NEW.body LIKE '[auto:pr:%:merged]%'
+BEGIN
+	SELECT RAISE(ABORT, 'forced workflow journal failure');
+END`); err != nil {
+		t.Fatalf("create journal failure trigger: %v", err)
+	}
+
+	gate := PolicyMergeGate{Store: store}
+	decision, err := gate.finishMerged(ctx, MergeRequest{
+		Repo: "gitmoot/gitmoot", Branch: "task-9", PullRequest: 9,
+	}, github.PullRequest{
+		Number: 9, URL: "https://github.com/gitmoot/gitmoot/pull/9",
+		HeadRef: "task-9", BaseRef: "main", HeadSHA: "head123",
+	}, "merge123")
+	if err != nil {
+		t.Fatalf("finishMerged returned journal error: %v", err)
+	}
+	if !decision.Ready || !decision.Merged || decision.MergeCommitSHA != "merge123" || decision.Reason != "merged" {
+		t.Fatalf("decision changed by journal failure: %+v", decision)
+	}
+	pr, err := store.GetPullRequest(ctx, "gitmoot/gitmoot", 9)
+	if err != nil || pr.State != "merged" || pr.MergeCommitSHA != "merge123" {
+		t.Fatalf("durable merged PR = %+v, err=%v", pr, err)
+	}
+	meta, err := store.GetWorkflowMeta(ctx, "release/native-journal-failure")
+	if err != nil || meta.Status != "ready_to_merge" {
+		t.Fatalf("failed journal changed workflow meta = %+v, err=%v", meta, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, "release/native-journal-failure", 0)
+	if err != nil || len(notes) != 1 {
+		t.Fatalf("notes after forced journal failure = %+v, err=%v", notes, err)
 	}
 }
 

--- a/internal/workflow/workflow_journal.go
+++ b/internal/workflow/workflow_journal.go
@@ -21,9 +21,10 @@ const (
 )
 
 // RecordPullRequestWorkflowTransition appends one machine-owned PR breadcrumb
-// and updates live status for the workflow linked to repo+PR/branch. A missing
-// workflow link is a successful no-op. The store's partial unique index makes
-// the structured body an at-most-once receipt for (workflow, PR, transition).
+// and updates live status for the workflow linked to repo+PR/branch unless an
+// operator-owned terminal/hold status is present. A missing workflow link is a
+// successful no-op. The store's partial unique index makes the structured body
+// an at-most-once receipt for (workflow, PR, transition).
 func RecordPullRequestWorkflowTransition(ctx context.Context, store *db.Store, event PullRequestEvent, transition PullRequestJournalTransition) (bool, error) {
 	if store == nil {
 		return false, nil
@@ -49,16 +50,16 @@ func RecordPullRequestWorkflowTransition(ctx context.Context, store *db.Store, e
 	switch transition {
 	case PullRequestJournalOpened:
 		message = fmt.Sprintf("PR #%d opened (%s)", event.PullRequest, strings.TrimSpace(event.Branch))
-		status = fmt.Sprintf("PR #%d open", event.PullRequest)
+		status = "active"
 	case PullRequestJournalReady:
 		message = fmt.Sprintf("PR #%d checks green — ready to merge", event.PullRequest)
-		status = message
+		status = "ready_to_merge"
 	case PullRequestJournalMerged:
 		message = fmt.Sprintf("PR #%d merged", event.PullRequest)
-		status = message
+		status = "active"
 	case PullRequestJournalClosed:
 		message = fmt.Sprintf("PR #%d closed without merging", event.PullRequest)
-		status = message
+		status = "active"
 	default:
 		return false, fmt.Errorf("unknown pull request journal transition %q", transition)
 	}

--- a/internal/workflow/workflow_journal_test.go
+++ b/internal/workflow/workflow_journal_test.go
@@ -41,7 +41,7 @@ func TestHandlePullRequestReadyToMergeJournalsWorkflowOnce(t *testing.T) {
 	if inserted, err := RecordPullRequestWorkflowTransition(context.Background(), store, event, PullRequestJournalOpened); err != nil || inserted {
 		t.Fatalf("late PR-open backfill = inserted %v, err=%v; must not regress ready status", inserted, err)
 	}
-	assertWorkflowJournalTransition(t, store, "[auto:pr:958:ready] PR #958 checks green — ready to merge", "PR #958 checks green — ready to merge")
+	assertWorkflowJournalTransition(t, store, "[auto:pr:958:ready] PR #958 checks green — ready to merge", "ready_to_merge")
 }
 
 func TestHandleReviewPullRequestClosedJournalsWorkflowOnce(t *testing.T) {
@@ -51,8 +51,8 @@ func TestHandleReviewPullRequestClosedJournalsWorkflowOnce(t *testing.T) {
 		wantBody   string
 		wantStatus string
 	}{
-		{name: "merged", merged: true, wantBody: "[auto:pr:958:merged] PR #958 merged", wantStatus: "PR #958 merged"},
-		{name: "closed without merging", merged: false, wantBody: "[auto:pr:958:closed] PR #958 closed without merging", wantStatus: "PR #958 closed without merging"},
+		{name: "merged", merged: true, wantBody: "[auto:pr:958:merged] PR #958 merged", wantStatus: "active"},
+		{name: "closed without merging", merged: false, wantBody: "[auto:pr:958:closed] PR #958 closed without merging", wantStatus: "active"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := openEngineStore(t)
@@ -76,9 +76,10 @@ func TestRecordPullRequestWorkflowTransitionSummaryTracksMergedReceipt(t *testin
 		name       string
 		transition PullRequestJournalTransition
 		wantMerged bool
+		wantStatus string
 	}{
-		{name: "merged", transition: PullRequestJournalMerged, wantMerged: true},
-		{name: "opened", transition: PullRequestJournalOpened},
+		{name: "merged", transition: PullRequestJournalMerged, wantMerged: true, wantStatus: "active"},
+		{name: "opened", transition: PullRequestJournalOpened, wantStatus: "active"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			store := openEngineStore(t)
@@ -95,8 +96,101 @@ func TestRecordPullRequestWorkflowTransitionSummaryTracksMergedReceipt(t *testin
 			if got := summary.LastMergedReceiptAt != ""; got != tc.wantMerged {
 				t.Fatalf("LastMergedReceiptAt = %q, want merged=%v", summary.LastMergedReceiptAt, tc.wantMerged)
 			}
+			meta, err := store.GetWorkflowMeta(ctx, "release/lifecycle")
+			if err != nil || meta.Status != tc.wantStatus {
+				t.Fatalf("meta = %+v, err=%v; want status %q", meta, err, tc.wantStatus)
+			}
 		})
 	}
+}
+
+func TestRecordPullRequestWorkflowTransitionConditionallyUpdatesStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		initial    string
+		wantStatus string
+	}{
+		{name: "ready to merge", initial: "ready_to_merge", wantStatus: "active"},
+		{name: "legacy open", initial: "PR #123 open", wantStatus: "active"},
+		{name: "empty", wantStatus: "active"},
+		{name: "active", initial: "active", wantStatus: "active"},
+		{name: "blocked protected", initial: "blocked", wantStatus: "blocked"},
+		{name: "parked protected", initial: "parked", wantStatus: "parked"},
+		{name: "done protected", initial: "done", wantStatus: "done"},
+		{name: "settled protected", initial: "settled", wantStatus: "settled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := openEngineStore(t)
+			ctx := context.Background()
+			event := seedWorkflowJournalLifecycle(t, store, TaskReviewing)
+			if tc.initial != "" {
+				if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+					db.WorkflowNote{WorkflowID: "release/lifecycle", Author: "operator", Body: "status seed"},
+					db.WorkflowMeta{Status: tc.initial, StatusSet: true}); err != nil {
+					t.Fatalf("seed status: %v", err)
+				}
+			}
+
+			inserted, err := RecordPullRequestWorkflowTransition(ctx, store, event, PullRequestJournalMerged)
+			if err != nil || !inserted {
+				t.Fatalf("RecordPullRequestWorkflowTransition = (inserted=%v, err=%v)", inserted, err)
+			}
+			meta, err := store.GetWorkflowMeta(ctx, "release/lifecycle")
+			if err != nil || meta.Status != tc.wantStatus {
+				t.Fatalf("meta = %+v, err=%v; want status %q", meta, err, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestRecordPullRequestWorkflowTransitionMissingLinkAndReplayAreNoOps(t *testing.T) {
+	t.Run("missing workflow link", func(t *testing.T) {
+		store := openEngineStore(t)
+		inserted, err := RecordPullRequestWorkflowTransition(context.Background(), store, PullRequestEvent{
+			Repo: "owner/repo", Branch: "feat/unlinked", PullRequest: 958,
+		}, PullRequestJournalMerged)
+		if err != nil || inserted {
+			t.Fatalf("RecordPullRequestWorkflowTransition = (inserted=%v, err=%v)", inserted, err)
+		}
+		summaries, err := store.ListWorkflowSummaries(context.Background())
+		if err != nil || len(summaries) != 0 {
+			t.Fatalf("summaries = %+v, err=%v; want none", summaries, err)
+		}
+	})
+
+	t.Run("duplicate receipt preserves later manual status", func(t *testing.T) {
+		store := openEngineStore(t)
+		ctx := context.Background()
+		event := seedWorkflowJournalLifecycle(t, store, TaskReviewing)
+		if inserted, err := RecordPullRequestWorkflowTransition(ctx, store, event, PullRequestJournalMerged); err != nil || !inserted {
+			t.Fatalf("first transition = (inserted=%v, err=%v)", inserted, err)
+		}
+		if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+			db.WorkflowNote{WorkflowID: "release/lifecycle", Author: "operator", Body: "manual block"},
+			db.WorkflowMeta{Status: "blocked", StatusSet: true}); err != nil {
+			t.Fatalf("manual status: %v", err)
+		}
+		if inserted, err := RecordPullRequestWorkflowTransition(ctx, store, event, PullRequestJournalMerged); err != nil || inserted {
+			t.Fatalf("duplicate transition = (inserted=%v, err=%v)", inserted, err)
+		}
+		meta, err := store.GetWorkflowMeta(ctx, "release/lifecycle")
+		if err != nil || meta.Status != "blocked" {
+			t.Fatalf("meta = %+v, err=%v; want protected blocked status", meta, err)
+		}
+		notes, err := store.ListWorkflowNotes(ctx, "release/lifecycle", 0)
+		if err != nil {
+			t.Fatalf("ListWorkflowNotes: %v", err)
+		}
+		merged := 0
+		for _, note := range notes {
+			if note.Body == "[auto:pr:958:merged] PR #958 merged" {
+				merged++
+			}
+		}
+		if merged != 1 {
+			t.Fatalf("merged receipt count = %d, want 1; notes=%+v", merged, notes)
+		}
+	})
 }
 
 func assertWorkflowJournalTransition(t *testing.T, store *db.Store, wantBody, wantStatus string) {


### PR DESCRIPTION
## What

Workflow lifecycle hygiene (#1094), **slice 1 of 4** — fixes the root cause of statuses stuck at `ready_to_merge` / `PR #N open` after a merge, and canonicalizes machine-owned status safely. Standalone.

## Root cause

`PolicyMergeGate.finishMerged` persisted the merge (`recordMerged`) but never called `RecordPullRequestWorkflowTransition` — only the daemon PR-watcher and engine PR-lifecycle paths journal transitions. So when gitmoot merges a PR *itself* (the policy merge-gate), the workflow's status is never updated and rots.

## Changes

- **Native merge journals the transition**: `finishMerged` now calls `RecordPullRequestWorkflowTransition(...Merged)` **after** the durable `recordMerged`. Journaling is observability-only — a failure logs a warning and **never** reverses the merge or alters its `MergeDecision`. The existing at-most-once `[auto:pr:N:merged]` dedup makes a later daemon-observed merge a no-op.
- **Canonical statuses**: PR transitions set `active` (opened/merged/closed) / `ready_to_merge` (ready) instead of free-text `"PR #N merged"` — the same vocabulary slice 2 will enumerate. Note **bodies are unchanged**.
- **Conditional status-guard**: the auto-note meta write (`upsertWorkflowMetaConditionalStatusTx`) canonicalizes a stale *machine-owned* status but **never** overwrites an operator-owned `blocked`/`parked`/`done`/`settled`. Plain `workflow note --status` keeps last-write-wins.

## Review — high (fresh finders, isolated worktree)

Two fresh finders (merge-safety/never-reverse + conditional-status correctness), **zero findings**:
- **Merge-safety**: the hook can't reach a return path (error swallowed/logged); the `MergeDecision` is byte-identical whether journaling succeeds or fails (the failure-injection test is non-vacuous — it verified the SQLite trigger + `INSERT OR IGNORE` rollback semantics); double-journal dedup skips the meta upsert; post-merge ordering intact.
- **Conditional-status**: guard SQL binding/logic correct; guarded path is auto-notes **only** (operator `--status` can still set *and* clear `blocked`); all 8 preserve/overwrite + replay + missing-linkage + legacy cases test-covered. Machine auto-notes only ever write `active`/`ready_to_merge`, so a preserved status always reflects operator intent (safe across rolling upgrade).

## Sequence

Slice 1 of 4: **merge-hook (this)** → enum + `workflow close` + reopen-on-note → terminal-aware dashboard → auto-settle (last). Docs land with the user-facing slices (2/3/4). No migration (`workflow_meta.status` exists). No deploy (judging window). Merge owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
