### PR TITLE
feat(workflow): terminal statuses, close verb, reopen-on-note, terminal-aware dashboard (#1094)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -414,11 +414,11 @@ func (d *webDataSource) Workflow(ctx context.Context, label string, q dashboard.
 			TokensIn: summary.InputTokens, TokensOut: summary.OutputTokens,
 			FirstAt: parseJobTimeMillis(summary.FirstAt), LastAt: parseJobTimeMillis(summary.LastAt),
 		}
-		out.State, out.StalledForS = deriveDashboardWorkflowState(now, dashboardActivityFromSummary(summary, out.Summary.LastAt))
 		meta, metaErr := store.GetWorkflowMeta(ctx, label)
 		if metaErr != nil && !errors.Is(metaErr, sql.ErrNoRows) {
 			return metaErr
 		}
+		out.State, out.StalledForS = deriveDashboardWorkflowState(now, dashboardActivityFromSummary(summary, out.Summary.LastAt), meta.Status)
 		description := workflowDisplayDescription(label, meta.Description)
 		out.Summary.Summary = firstNonEmpty(meta.Summary, description)
 		author := strings.TrimSpace(meta.Author)

--- a/internal/cli/dashboard_web_overview_test.go
+++ b/internal/cli/dashboard_web_overview_test.go
@@ -199,7 +199,7 @@ func TestDashboardOverviewTasksAndWorkflows(t *testing.T) {
 	}
 	mergedReceipt, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
 		db.WorkflowNote{WorkflowID: "ops/merge-settled", Author: db.WorkflowAutoNoteAuthor, Body: "[auto:pr:987:merged] PR #987 merged"},
-		db.WorkflowMeta{WorkflowID: "ops/merge-settled", Status: "PR #987 merged", StatusSet: true})
+		db.WorkflowMeta{WorkflowID: "ops/merge-settled", Status: string(db.WorkflowStatusActive), StatusSet: true})
 	if err != nil || !inserted {
 		t.Fatalf("InsertWorkflowAutoNoteWithMeta = (inserted=%v, err=%v)", inserted, err)
 	}

--- a/internal/cli/dashboard_web_workflow_test.go
+++ b/internal/cli/dashboard_web_workflow_test.go
@@ -24,12 +24,18 @@ func TestDeriveDashboardWorkflowState(t *testing.T) {
 	tests := []struct {
 		name     string
 		activity dashboardWorkflowActivity
+		status   string
 		state    string
 		stalled  int64
 	}{
 		{name: "running stays active", activity: dashboardWorkflowActivity{Running: 1, LastActivity: now.Add(-48 * time.Hour)}, state: "active"},
 		{name: "queued stays active", activity: dashboardWorkflowActivity{Queued: 1, LastActivity: now.Add(-48 * time.Hour)}, state: "active"},
-		{name: "recent terminal is recent", activity: dashboardWorkflowActivity{LastActivity: now.Add(-10 * time.Minute)}, state: "recent"},
+		{name: "terminal with running work stays active", activity: dashboardWorkflowActivity{Running: 1, LastActivity: now.Add(-48 * time.Hour)}, status: "done", state: "active"},
+		{name: "terminal with queued work stays active", activity: dashboardWorkflowActivity{Queued: 1, LastActivity: now.Add(-48 * time.Hour)}, status: "settled", state: "active"},
+		{name: "recent done is settled", activity: dashboardWorkflowActivity{LastActivity: now.Add(-10 * time.Minute)}, status: "done", state: "settled"},
+		{name: "recent settled is settled", activity: dashboardWorkflowActivity{LastActivity: now.Add(-10 * time.Minute)}, status: "settled", state: "settled"},
+		{name: "recent quiet is recent", activity: dashboardWorkflowActivity{LastActivity: now.Add(-10 * time.Minute)}, state: "recent"},
+		{name: "legacy status keeps existing derivation", activity: dashboardWorkflowActivity{LastActivity: now.Add(-10 * time.Minute)}, status: "PR #1 open", state: "recent"},
 		{name: "unacknowledged failure is stalled", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-31 * time.Minute), LastFailure: now.Add(-31 * time.Minute)}, state: "stalled", stalled: 31 * 60},
 		{name: "unacknowledged block is stalled", activity: dashboardWorkflowActivity{Blocked: 1, LastActivity: now.Add(-23 * time.Hour), LastFailure: now.Add(-23 * time.Hour)}, state: "stalled", stalled: 23 * 60 * 60},
 		{name: "human note before failure does not acknowledge", activity: dashboardWorkflowActivity{Failed: 1, LastActivity: now.Add(-40 * time.Minute), LastFailure: now.Add(-40 * time.Minute), LastHumanNote: now.Add(-2 * time.Hour)}, state: "stalled", stalled: 40 * 60},
@@ -49,11 +55,43 @@ func TestDeriveDashboardWorkflowState(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			state, stalled := deriveDashboardWorkflowState(now, test.activity)
+			state, stalled := deriveDashboardWorkflowState(now, test.activity, test.status)
 			if state != test.state || stalled != test.stalled {
 				t.Fatalf("derive = (%q, %d), want (%q, %d)", state, stalled, test.state, test.stalled)
 			}
 		})
+	}
+}
+
+func TestDashboardWorkflowTerminalStatusIndexAndDetailAgree(t *testing.T) {
+	t.Parallel()
+	home, store := workflowJournalTestHome(t)
+	ctx := context.Background()
+	const label = "release/terminal"
+	payload := workflow.JobPayload{WorkflowID: label, Repo: "acme/widget", TaskTitle: "Terminal workflow"}
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "terminal-job", Agent: "worker", Type: "ask", State: "succeeded", Payload: mustJSON(t, payload),
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: label, Author: "operator", Body: "[workflow:close] shipped"},
+		db.WorkflowMeta{Status: string(db.WorkflowStatusDone), StatusSet: true}); err != nil {
+		t.Fatalf("InsertWorkflowNoteWithMeta: %v", err)
+	}
+	store.Close()
+
+	ds := &webDataSource{home: home}
+	entries, err := ds.Workflows(ctx)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("Workflows = %+v, err=%v", entries, err)
+	}
+	detail, err := ds.Workflow(ctx, label, dashboard.WorkflowQuery{})
+	if err != nil {
+		t.Fatalf("Workflow: %v", err)
+	}
+	if entries[0].State != "settled" || detail.State != "settled" {
+		t.Fatalf("terminal state mismatch: index=%q detail=%q", entries[0].State, detail.State)
 	}
 }
 
@@ -506,7 +544,7 @@ func TestDashboardWorkflowDaemonNotesDoNotAcknowledgeFailuresOrImpersonateCoordi
 	}
 	auto, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
 		db.WorkflowNote{WorkflowID: label, Author: db.WorkflowAutoNoteAuthor, Body: "[auto:pr:958:closed] PR #958 closed without merging"},
-		db.WorkflowMeta{WorkflowID: label, Status: "PR #958 closed without merging", StatusSet: true})
+		db.WorkflowMeta{WorkflowID: label, Status: string(db.WorkflowStatusActive), StatusSet: true})
 	if err != nil || !inserted {
 		t.Fatalf("Insert daemon note = (inserted=%v, err=%v)", inserted, err)
 	}
@@ -556,7 +594,7 @@ func TestDashboardWorkflowDaemonNotesDoNotAcknowledgeFailuresOrImpersonateCoordi
 	}
 	merged, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
 		db.WorkflowNote{WorkflowID: label, Author: db.WorkflowAutoNoteAuthor, Body: "[auto:pr:958:merged] PR #958 merged"},
-		db.WorkflowMeta{WorkflowID: label, Status: "PR #958 merged", StatusSet: true})
+		db.WorkflowMeta{WorkflowID: label, Status: string(db.WorkflowStatusActive), StatusSet: true})
 	if err != nil || !inserted {
 		t.Fatalf("Insert merged daemon note = (inserted=%v, err=%v)", inserted, err)
 	}
@@ -628,7 +666,7 @@ func TestDashboardWorkflowDescriptionStatusAPI(t *testing.T) {
 	ctx := context.Background()
 	const label = "release/api-fields"
 	description := strings.Repeat("d", db.WorkflowMetaTextMax)
-	status := strings.Repeat("s", db.WorkflowMetaTextMax)
+	status := string(db.WorkflowStatusBlocked)
 	payload, err := json.Marshal(workflow.JobPayload{WorkflowID: label, Repo: "acme/widget", TaskTitle: "API fields"})
 	if err != nil {
 		t.Fatal(err)
@@ -660,7 +698,7 @@ func TestDashboardWorkflowDescriptionStatusAPI(t *testing.T) {
 		t.Fatalf("index entries=%+v err=%v body=%s", entries, err, indexRecorder.Body.String())
 	}
 	if entries[0].Description != description || entries[0].Status != status || entries[0].Summary != description {
-		t.Fatalf("index entry lost untruncated fields: description=%d status=%d entry=%+v", len(entries[0].Description), len(entries[0].Status), entries[0])
+		t.Fatalf("index entry lost fields: description=%d status=%q entry=%+v", len(entries[0].Description), entries[0].Status, entries[0])
 	}
 
 	detailRecorder := httptest.NewRecorder()

--- a/internal/cli/dashboard_web_workflows.go
+++ b/internal/cli/dashboard_web_workflows.go
@@ -43,10 +43,13 @@ func dashboardActivityFromSummary(summary db.WorkflowSummary, lastAt int64) dash
 
 // deriveDashboardWorkflowState is the single lifecycle definition shared by
 // workflow index and detail responses.
-func deriveDashboardWorkflowState(now time.Time, activity dashboardWorkflowActivity) (state string, stalledForS int64) {
+func deriveDashboardWorkflowState(now time.Time, activity dashboardWorkflowActivity, status string) (state string, stalledForS int64) {
 	age := now.Sub(activity.LastActivity)
 	if activity.Queued > 0 || activity.Running > 0 {
 		return "active", 0
+	}
+	if db.IsTerminalWorkflowStatus(status) {
+		return "settled", 0
 	}
 	// A merged receipt records the daemon's observation time (note created_at),
 	// not the true GitHub merge time. A failure landing in the poll window before
@@ -138,7 +141,7 @@ func dashboardWorkflowEntries(ctx context.Context, store *db.Store, now time.Tim
 
 func dashboardWorkflowEntry(now time.Time, summary db.WorkflowSummary, meta db.WorkflowMeta, repos []string) dashboardWorkflowAPIEntry {
 	lastAt := parseJobTimeMillis(summary.LastAt)
-	state, stalledFor := deriveDashboardWorkflowState(now, dashboardActivityFromSummary(summary, lastAt))
+	state, stalledFor := deriveDashboardWorkflowState(now, dashboardActivityFromSummary(summary, lastAt), meta.Status)
 	author := strings.TrimSpace(meta.Author)
 	if author == "" {
 		author = strings.TrimSpace(summary.LastHumanAuthor)

--- a/internal/cli/workflow_journal.go
+++ b/internal/cli/workflow_journal.go
@@ -37,6 +37,8 @@ func runWorkflowJournal(args []string, stdout, stderr io.Writer) int {
 		return runWorkflowDescribe(args[1:], stdout, stderr)
 	case "note":
 		return runWorkflowNote(args[1:], stdout, stderr)
+	case "close":
+		return runWorkflowClose(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown workflow command %q\n\n", args[0])
 		printWorkflowJournalUsage(stderr)
@@ -52,6 +54,7 @@ func printWorkflowJournalUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot workflow show <label> [--json] [--limit N]")
 	fmt.Fprintln(w, "  gitmoot workflow describe <label> \"<text>\" [--json]")
 	fmt.Fprintln(w, "  gitmoot workflow note <label> \"<body>\" [--author A] [--pane P] [--session ID] [--workdir PATH] [--no-auto] [--summary DESCRIPTION] [--status STATUS] [--remember [--remember-status] [--agent NAME] [--repo R]]")
+	fmt.Fprintln(w, "  gitmoot workflow close <label> [--reason R] [--json]")
 }
 
 func runWorkflowList(args []string, stdout, stderr io.Writer) int {
@@ -281,6 +284,67 @@ func runWorkflowDescribe(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+func runWorkflowClose(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("workflow close", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	reason := fs.String("reason", "", "reason for closing the workflow")
+	jsonOutput := fs.Bool("json", false, "print the close result as JSON")
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		if len(args) == 0 {
+			fmt.Fprintln(stderr, "workflow close requires a label")
+			return 2
+		}
+		return 0
+	}
+	label := strings.TrimSpace(args[0])
+	if err := workflowpkg.ValidateWorkflowID(label); err != nil {
+		fmt.Fprintf(stderr, "workflow close: %v\n", err)
+		return 2
+	}
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "workflow close accepts one label")
+		return 2
+	}
+	reasonText := strings.TrimSpace(*reason)
+	closeNoteLen := len("[workflow:close]")
+	if reasonText != "" {
+		closeNoteLen += 1 + len(reasonText)
+	}
+	if closeNoteLen > workflowNoteBodyMax {
+		fmt.Fprintf(stderr, "workflow close reason must produce a note of at most %d bytes\n", workflowNoteBodyMax)
+		return 2
+	}
+	var result db.CloseWorkflowResult
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		result, err = store.CloseWorkflow(context.Background(), label, *reason)
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "workflow close: %v\n", err)
+		return 1
+	}
+	if *jsonOutput {
+		if err := writeJSON(stdout, result); err != nil {
+			fmt.Fprintf(stderr, "workflow close: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if result.AlreadyTerminal {
+		fmt.Fprintf(stdout, "workflow %s already terminal (%s)\n", label, result.Status)
+		return 0
+	}
+	fmt.Fprintf(stdout, "closed workflow %s\n", label)
+	return 0
+}
+
 const workflowTextLineMaxRunes = 512
 
 // terminalSafeWorkflowText is used only by the plain-text renderer. Storage and
@@ -440,6 +504,12 @@ func runWorkflowNote(args []string, stdout, stderr io.Writer) int {
 	if len(*status) > workflowSummaryMax {
 		fmt.Fprintf(stderr, "workflow note status must be at most %d bytes\n", workflowSummaryMax)
 		return 2
+	}
+	if statusSet {
+		if err := db.ValidateWorkflowStatus(*status); err != nil {
+			fmt.Fprintf(stderr, "workflow note: %v\n", err)
+			return 2
+		}
 	}
 	if !*remember && (strings.TrimSpace(*agent) != "" || strings.TrimSpace(*repo) != "" || *rememberStatus) {
 		fmt.Fprintln(stderr, "workflow note: --agent, --repo, and --remember-status require --remember")

--- a/internal/cli/workflow_journal_test.go
+++ b/internal/cli/workflow_journal_test.go
@@ -445,9 +445,9 @@ func TestWorkflowNoteDescriptionStatusSetPreserveClearAndLimit(t *testing.T) {
 		return code
 	}
 
-	runNote("kickoff", "--summary", "Ship the dashboard redesign.", "--status", "Implementation started")
+	runNote("kickoff", "--summary", "Ship the dashboard redesign.", "--status", "active")
 	meta, err := store.GetWorkflowMeta(ctx, workflowID)
-	if err != nil || meta.Summary != "Ship the dashboard redesign." || meta.Description != meta.Summary || meta.Status != "Implementation started" {
+	if err != nil || meta.Summary != "Ship the dashboard redesign." || meta.Description != meta.Summary || meta.Status != "active" {
 		t.Fatalf("metadata after set = %+v, err=%v", meta, err)
 	}
 	var stdout, stderr bytes.Buffer
@@ -455,14 +455,14 @@ func TestWorkflowNoteDescriptionStatusSetPreserveClearAndLimit(t *testing.T) {
 		t.Fatalf("workflow show exit=%d stderr=%q", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "description: Ship the dashboard redesign.\n") ||
-		!strings.Contains(stdout.String(), "status: Implementation started\n") ||
+		!strings.Contains(stdout.String(), "status: active\n") ||
 		!strings.Contains(stdout.String(), "summary: Ship the dashboard redesign.\n") {
 		t.Fatalf("workflow show missing metadata headers: %q", stdout.String())
 	}
 
 	runNote("progress")
 	meta, err = store.GetWorkflowMeta(ctx, workflowID)
-	if err != nil || meta.Description != "Ship the dashboard redesign." || meta.Status != "Implementation started" {
+	if err != nil || meta.Description != "Ship the dashboard redesign." || meta.Status != "active" {
 		t.Fatalf("metadata after absent flags = %+v, err=%v", meta, err)
 	}
 
@@ -488,6 +488,123 @@ func TestWorkflowNoteDescriptionStatusSetPreserveClearAndLimit(t *testing.T) {
 	}, &stdout, &stderr)
 	if code != 2 || !strings.Contains(stderr.String(), "workflow note status must be at most 300 bytes") {
 		t.Fatalf("over-length status exit=%d stderr=%q", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runWorkflowJournal([]string{
+		"note", workflowID, "bad status", "--status", "Implementation started", "--home", home,
+	}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "active, blocked, ready_to_merge, done, settled, parked") {
+		t.Fatalf("invalid status exit=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestWorkflowCloseReasonJSONAndUnknownLabel(t *testing.T) {
+	home, store := workflowJournalTestHome(t)
+	ctx := context.Background()
+	const label = "release/close-cli"
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "close-cli-job", Agent: "coord", Type: "ask", State: "succeeded",
+		Payload: `{"repo":"acme/widget","workflow_id":"release/close-cli"}`,
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runWorkflowJournal([]string{
+		"close", label, "--reason", "shipped successfully", "--home", home, "--json",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("workflow close exit=%d stderr=%q", code, stderr.String())
+	}
+	var result db.CloseWorkflowResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode close result: %v body=%s", err, stdout.String())
+	}
+	if result.Status != db.WorkflowStatusDone || result.Note == nil ||
+		result.Note.Body != "[workflow:close] shipped successfully" {
+		t.Fatalf("close result = %+v", result)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runWorkflowJournal([]string{"close", "release/missing", "--home", home}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), `workflow "release/missing" not found`) {
+		t.Fatalf("unknown close exit=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestWorkflowNoteExplicitStatusBypassesReopen(t *testing.T) {
+	home, store := workflowJournalTestHome(t)
+	ctx := context.Background()
+	const label = "release/explicit-cli"
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "explicit-cli-job", Agent: "coord", Type: "ask", State: "succeeded",
+		Payload: `{"repo":"acme/widget","workflow_id":"release/explicit-cli"}`,
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: label, Body: "settled seed"},
+		db.WorkflowMeta{Status: string(db.WorkflowStatusSettled), StatusSet: true}); err != nil {
+		t.Fatalf("seed settled: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runWorkflowJournal([]string{
+		"note", label, "operator block", "--status", "blocked", "--no-auto", "--home", home,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("workflow note exit=%d stderr=%q", code, stderr.String())
+	}
+	meta, err := store.GetWorkflowMeta(ctx, label)
+	if err != nil || meta.Status != string(db.WorkflowStatusBlocked) {
+		t.Fatalf("meta = %+v, err=%v", meta, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, label, 0)
+	if err != nil || len(notes) != 2 {
+		t.Fatalf("notes = %+v, err=%v", notes, err)
+	}
+	for _, note := range notes {
+		if strings.HasPrefix(note.Body, "[auto:workflow:reopened]") {
+			t.Fatalf("explicit status emitted reopen receipt: %+v", notes)
+		}
+	}
+}
+
+func TestWorkflowNoteWithoutStatusReopensDoneWorkflow(t *testing.T) {
+	home, store := workflowJournalTestHome(t)
+	ctx := context.Background()
+	const label = "release/reopen-cli"
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "reopen-cli-job", Agent: "coord", Type: "ask", State: "succeeded",
+		Payload: `{"repo":"acme/widget","workflow_id":"release/reopen-cli"}`,
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: label, Body: "[workflow:close] shipped"},
+		db.WorkflowMeta{Status: string(db.WorkflowStatusDone), StatusSet: true}); err != nil {
+		t.Fatalf("seed done: %v", err)
+	}
+	const body = "follow-up note\nkept verbatim"
+	var stdout, stderr bytes.Buffer
+	code := runWorkflowJournal([]string{
+		"note", label, body, "--author", "operator", "--no-auto", "--home", home,
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("workflow note exit=%d stderr=%q", code, stderr.String())
+	}
+	meta, err := store.GetWorkflowMeta(ctx, label)
+	if err != nil || meta.Status != string(db.WorkflowStatusActive) {
+		t.Fatalf("meta = %+v, err=%v", meta, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, label, 0)
+	if err != nil || len(notes) != 3 {
+		t.Fatalf("notes = %+v, err=%v", notes, err)
+	}
+	if notes[1].Body != "[auto:workflow:reopened] reopened from done" ||
+		notes[2].Body != body || notes[2].Author != "operator" {
+		t.Fatalf("reopen ordering/content = %+v", notes)
 	}
 }
 

--- a/internal/db/workflow_lifecycle_store.go
+++ b/internal/db/workflow_lifecycle_store.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// UnknownWorkflowError identifies a workflow label rejected by lifecycle
+// mutation because it has no workflow-linked jobs.
+type UnknownWorkflowError struct {
+	Label string
+}
+
+func (e UnknownWorkflowError) Error() string {
+	return fmt.Sprintf("workflow %q not found", e.Label)
+}
+
+// CloseWorkflowResult describes an explicit terminal transition.
+type CloseWorkflowResult struct {
+	WorkflowID      string         `json:"workflow_id"`
+	Status          WorkflowStatus `json:"status"`
+	AlreadyTerminal bool           `json:"already_terminal,omitempty"`
+	Note            *WorkflowNote  `json:"note,omitempty"`
+}
+
+// CloseWorkflow atomically refuses live work or records an explicit close.
+// A workflow already in done or settled is returned unchanged without another
+// close note, making repeated close requests idempotent.
+func (s *Store) CloseWorkflow(ctx context.Context, label, reason string) (CloseWorkflowResult, error) {
+	label = strings.TrimSpace(label)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var jobCount int
+	if err := tx.QueryRowContext(ctx, CountJobsByWorkflowSQL, label).Scan(&jobCount); err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	if jobCount == 0 {
+		return CloseWorkflowResult{}, &UnknownWorkflowError{Label: label}
+	}
+	activeJobs, err := countActiveWorkflowJobsTx(ctx, tx, label)
+	if err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	if activeJobs > 0 {
+		return CloseWorkflowResult{}, fmt.Errorf("cannot close workflow %q: %d job(s) still queued/running", label, activeJobs)
+	}
+	status, err := workflowMetaStatusTx(ctx, tx, label)
+	if err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	if IsTerminalWorkflowStatus(status) {
+		if err := tx.Commit(); err != nil {
+			return CloseWorkflowResult{}, err
+		}
+		return CloseWorkflowResult{
+			WorkflowID:      label,
+			Status:          WorkflowStatus(status),
+			AlreadyTerminal: true,
+		}, nil
+	}
+
+	body := "[workflow:close]"
+	if reason = strings.TrimSpace(reason); reason != "" {
+		body += " " + reason
+	}
+	// The close breadcrumb is a structured machine-recorded note, like the
+	// [auto:workflow:reopened] receipt and the daemon [auto:pr:*] notes: author
+	// it "daemon" so it does not pollute last_human_author or seed the workflow
+	// description (ensureWorkflowDescriptionTx only reads author != daemon notes).
+	noteID, err := insertWorkflowNoteTx(ctx, tx, WorkflowNote{WorkflowID: label, Author: WorkflowAutoNoteAuthor, Body: body})
+	if err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	if err := upsertWorkflowMetaTx(ctx, tx, WorkflowMeta{
+		WorkflowID: label,
+		Status:     string(WorkflowStatusDone),
+		StatusSet:  true,
+	}); err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	if err := ensureWorkflowDescriptionTx(ctx, tx, label); err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	note, err := s.getWorkflowNote(ctx, noteID)
+	if err != nil {
+		return CloseWorkflowResult{}, err
+	}
+	return CloseWorkflowResult{WorkflowID: label, Status: WorkflowStatusDone, Note: &note}, nil
+}
+
+func countActiveWorkflowJobsTx(ctx context.Context, tx *sql.Tx, label string) (int, error) {
+	var count int
+	err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs INDEXED BY idx_jobs_workflow_id
+WHERE workflow_id != '' AND workflow_id = ? AND state IN ('queued','running')`, label).Scan(&count)
+	return count, err
+}

--- a/internal/db/workflow_lifecycle_store_test.go
+++ b/internal/db/workflow_lifecycle_store_test.go
@@ -1,0 +1,264 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateWorkflowStatus(t *testing.T) {
+	for _, status := range []string{"", "active", "blocked", "ready_to_merge", "done", "settled", "parked"} {
+		t.Run("valid_"+status, func(t *testing.T) {
+			if err := ValidateWorkflowStatus(status); err != nil {
+				t.Fatalf("ValidateWorkflowStatus(%q): %v", status, err)
+			}
+		})
+	}
+	for _, status := range []string{"garbage", "PR #1 open", "recent"} {
+		t.Run("invalid_"+status, func(t *testing.T) {
+			err := ValidateWorkflowStatus(status)
+			if err == nil || !strings.Contains(err.Error(), "active, blocked, ready_to_merge, done, settled, parked") {
+				t.Fatalf("ValidateWorkflowStatus(%q) error = %v", status, err)
+			}
+		})
+	}
+	store := openWorkflowTestStore(t)
+	if _, err := store.InsertWorkflowNoteWithMeta(context.Background(),
+		WorkflowNote{WorkflowID: "release/invalid-status", Body: "invalid"},
+		WorkflowMeta{Status: "garbage", StatusSet: true}); err == nil ||
+		!strings.Contains(err.Error(), "workflow status must be empty or one of") {
+		t.Fatalf("store write invalid status error = %v", err)
+	}
+}
+
+func TestWorkflowLegacyStatusRemainsReadable(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	seedWorkflowJob(t, store, "legacy-job", "release/legacy", "succeeded", "acme/widget", 0, 0)
+	if _, err := store.db.ExecContext(ctx, `INSERT INTO workflow_meta(workflow_id, status) VALUES (?, ?)`,
+		"release/legacy", "PR #1 open"); err != nil {
+		t.Fatalf("seed legacy metadata: %v", err)
+	}
+	summaries, err := store.ListWorkflowSummaries(ctx)
+	if err != nil || len(summaries) != 1 || summaries[0].WorkflowID != "release/legacy" {
+		t.Fatalf("ListWorkflowSummaries = %+v, err=%v", summaries, err)
+	}
+	meta, err := store.GetWorkflowMeta(ctx, "release/legacy")
+	if err != nil || meta.Status != "PR #1 open" {
+		t.Fatalf("GetWorkflowMeta = %+v, err=%v", meta, err)
+	}
+}
+
+func TestCloseWorkflowRecordsDoneAndIsIdempotent(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	seedWorkflowJob(t, store, "done-job", "release/done", "succeeded", "acme/widget", 0, 0)
+
+	result, err := store.CloseWorkflow(ctx, "release/done", "shipped successfully")
+	if err != nil {
+		t.Fatalf("CloseWorkflow: %v", err)
+	}
+	if result.WorkflowID != "release/done" || result.Status != WorkflowStatusDone || result.AlreadyTerminal ||
+		result.Note == nil || result.Note.Body != "[workflow:close] shipped successfully" ||
+		result.Note.Author != WorkflowAutoNoteAuthor {
+		t.Fatalf("close result = %+v", result)
+	}
+	meta, err := store.GetWorkflowMeta(ctx, "release/done")
+	if err != nil || meta.Status != string(WorkflowStatusDone) {
+		t.Fatalf("meta = %+v, err=%v", meta, err)
+	}
+
+	replay, err := store.CloseWorkflow(ctx, "release/done", "duplicate")
+	if err != nil || !replay.AlreadyTerminal || replay.Status != WorkflowStatusDone || replay.Note != nil {
+		t.Fatalf("replayed close = %+v, err=%v", replay, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, "release/done", 0)
+	if err != nil || len(notes) != 1 || notes[0].Body != "[workflow:close] shipped successfully" ||
+		notes[0].Author != WorkflowAutoNoteAuthor {
+		t.Fatalf("notes after replay = %+v, err=%v", notes, err)
+	}
+}
+
+func TestCloseWorkflowPreservesAlreadySettledWithoutCloseNote(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	const label = "release/settled-close"
+	seedWorkflowJob(t, store, "settled-close-job", label, "succeeded", "acme/widget", 0, 0)
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		WorkflowNote{WorkflowID: label, Author: WorkflowAutoNoteAuthor, Body: "auto-settled"},
+		WorkflowMeta{Status: string(WorkflowStatusSettled), StatusSet: true}); err != nil {
+		t.Fatalf("seed settled: %v", err)
+	}
+	result, err := store.CloseWorkflow(ctx, label, "late close")
+	if err != nil || !result.AlreadyTerminal || result.Status != WorkflowStatusSettled || result.Note != nil {
+		t.Fatalf("CloseWorkflow = %+v, err=%v", result, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, label, 0)
+	if err != nil || len(notes) != 1 || notes[0].Body != "auto-settled" {
+		t.Fatalf("notes = %+v, err=%v", notes, err)
+	}
+}
+
+func TestCloseWorkflowRefusesLiveJobsWithoutChanges(t *testing.T) {
+	for _, state := range []string{"queued", "running"} {
+		t.Run(state, func(t *testing.T) {
+			store := openWorkflowTestStore(t)
+			ctx := context.Background()
+			label := "release/" + state
+			seedWorkflowJob(t, store, state+"-job", label, state, "acme/widget", 0, 0)
+			if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+				WorkflowNote{WorkflowID: label, Author: "operator", Body: "in progress"},
+				WorkflowMeta{Status: string(WorkflowStatusActive), StatusSet: true}); err != nil {
+				t.Fatalf("seed metadata: %v", err)
+			}
+
+			if _, err := store.CloseWorkflow(ctx, label, "not yet"); err == nil ||
+				!strings.Contains(err.Error(), "1 job(s) still queued/running") {
+				t.Fatalf("CloseWorkflow error = %v", err)
+			}
+			meta, err := store.GetWorkflowMeta(ctx, label)
+			if err != nil || meta.Status != string(WorkflowStatusActive) {
+				t.Fatalf("meta changed = %+v, err=%v", meta, err)
+			}
+			notes, err := store.ListWorkflowNotes(ctx, label, 0)
+			if err != nil || len(notes) != 1 || notes[0].Body != "in progress" {
+				t.Fatalf("notes changed = %+v, err=%v", notes, err)
+			}
+		})
+	}
+}
+
+func TestCloseWorkflowUnknownLabelReturnsTypedError(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	_, err := store.CloseWorkflow(context.Background(), "release/missing", "")
+	var unknown *UnknownWorkflowError
+	if !errors.As(err, &unknown) || unknown.Label != "release/missing" {
+		t.Fatalf("CloseWorkflow error = %T %v", err, err)
+	}
+}
+
+func TestWorkflowPlainNoteReopensTerminalStatus(t *testing.T) {
+	for _, terminal := range []WorkflowStatus{WorkflowStatusDone, WorkflowStatusSettled} {
+		t.Run(string(terminal), func(t *testing.T) {
+			store := openWorkflowTestStore(t)
+			ctx := context.Background()
+			label := "release/" + string(terminal)
+			if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+				WorkflowNote{WorkflowID: label, Author: "operator", Body: "terminal seed"},
+				WorkflowMeta{Status: string(terminal), StatusSet: true}); err != nil {
+				t.Fatalf("seed terminal metadata: %v", err)
+			}
+			const body = "verbatim human note\nwith a second line"
+			human, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: label, Author: "human", Body: body})
+			if err != nil {
+				t.Fatalf("InsertWorkflowNote: %v", err)
+			}
+			notes, err := store.ListWorkflowNotes(ctx, label, 0)
+			if err != nil || len(notes) != 3 {
+				t.Fatalf("notes = %+v, err=%v", notes, err)
+			}
+			if notes[1].Author != WorkflowAutoNoteAuthor ||
+				notes[1].Body != "[auto:workflow:reopened] reopened from "+string(terminal) ||
+				notes[2].ID != human.ID || notes[2].Body != body {
+				t.Fatalf("reopen note ordering/content = %+v", notes)
+			}
+			meta, err := store.GetWorkflowMeta(ctx, label)
+			if err != nil || meta.Status != string(WorkflowStatusActive) {
+				t.Fatalf("meta = %+v, err=%v", meta, err)
+			}
+			summary, err := store.WorkflowSummary(ctx, label)
+			if err != nil || summary.LastNote != body || summary.LastHumanAuthor != "human" {
+				t.Fatalf("summary = %+v, err=%v", summary, err)
+			}
+		})
+	}
+}
+
+func TestWorkflowExplicitStatusAndMachineReceiptDoNotImplicitlyReopen(t *testing.T) {
+	t.Run("explicit status", func(t *testing.T) {
+		store := openWorkflowTestStore(t)
+		ctx := context.Background()
+		const label = "release/explicit"
+		if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+			WorkflowNote{WorkflowID: label, Body: "settled seed"},
+			WorkflowMeta{Status: string(WorkflowStatusSettled), StatusSet: true}); err != nil {
+			t.Fatalf("seed settled: %v", err)
+		}
+		if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+			WorkflowNote{WorkflowID: label, Author: "operator", Body: "blocked again"},
+			WorkflowMeta{Status: string(WorkflowStatusBlocked), StatusSet: true}); err != nil {
+			t.Fatalf("explicit status note: %v", err)
+		}
+		meta, err := store.GetWorkflowMeta(ctx, label)
+		if err != nil || meta.Status != string(WorkflowStatusBlocked) {
+			t.Fatalf("meta = %+v, err=%v", meta, err)
+		}
+		assertNoWorkflowReopenReceipt(t, store, label)
+	})
+
+	t.Run("machine PR receipt", func(t *testing.T) {
+		store := openWorkflowTestStore(t)
+		ctx := context.Background()
+		const label = "release/machine"
+		if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+			WorkflowNote{WorkflowID: label, Body: "settled seed"},
+			WorkflowMeta{Status: string(WorkflowStatusSettled), StatusSet: true}); err != nil {
+			t.Fatalf("seed settled: %v", err)
+		}
+		if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+			WorkflowNote{WorkflowID: label, Author: WorkflowAutoNoteAuthor, Body: "[auto:pr:7:merged] PR #7 merged"},
+			WorkflowMeta{Status: string(WorkflowStatusActive), StatusSet: true}); err != nil || !inserted {
+			t.Fatalf("InsertWorkflowAutoNoteWithMeta = (inserted=%v, err=%v)", inserted, err)
+		}
+		meta, err := store.GetWorkflowMeta(ctx, label)
+		if err != nil || meta.Status != string(WorkflowStatusSettled) {
+			t.Fatalf("machine receipt changed terminal status: %+v, err=%v", meta, err)
+		}
+		assertNoWorkflowReopenReceipt(t, store, label)
+	})
+}
+
+func TestWorkflowObservationNoteReopensAtomically(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	const label = "release/observation"
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		WorkflowNote{WorkflowID: label, Body: "done seed"},
+		WorkflowMeta{Status: string(WorkflowStatusDone), StatusSet: true}); err != nil {
+		t.Fatalf("seed done: %v", err)
+	}
+	note, obs, err := store.InsertWorkflowNoteWithObservationAndMeta(ctx,
+		WorkflowNote{WorkflowID: label, Author: "human", Body: "durable fact", Repo: "acme/widget"},
+		MemoryObservation{
+			Owner: MemoryOwner{Kind: "shared", Ref: "shared"}, AuthorRef: "human",
+			Repo: "acme/widget", Scope: "repo", Content: "durable fact", TrustMark: "low",
+		},
+		WorkflowMeta{Author: "human"})
+	if err != nil || note.MemoryObservationID == 0 || obs.ID != note.MemoryObservationID {
+		t.Fatalf("observation note = %+v, observation=%+v, err=%v", note, obs, err)
+	}
+	meta, err := store.GetWorkflowMeta(ctx, label)
+	if err != nil || meta.Status != string(WorkflowStatusActive) {
+		t.Fatalf("meta = %+v, err=%v", meta, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, label, 0)
+	if err != nil || len(notes) != 3 ||
+		notes[1].Body != "[auto:workflow:reopened] reopened from done" ||
+		notes[2].ID != note.ID {
+		t.Fatalf("notes = %+v, err=%v", notes, err)
+	}
+}
+
+func assertNoWorkflowReopenReceipt(t *testing.T, store *Store, label string) {
+	t.Helper()
+	notes, err := store.ListWorkflowNotes(context.Background(), label, 0)
+	if err != nil {
+		t.Fatalf("ListWorkflowNotes: %v", err)
+	}
+	for _, note := range notes {
+		if strings.HasPrefix(note.Body, "[auto:workflow:reopened]") {
+			t.Fatalf("unexpected reopen receipt: %+v", notes)
+		}
+	}
+}

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -21,6 +21,42 @@ const (
 	WorkflowAutoNoteAuthor = "daemon"
 )
 
+// WorkflowStatus is the canonical lifecycle vocabulary accepted by new writes.
+// Legacy values remain readable; validation is intentionally write-only.
+type WorkflowStatus string
+
+const (
+	WorkflowStatusActive       WorkflowStatus = "active"
+	WorkflowStatusBlocked      WorkflowStatus = "blocked"
+	WorkflowStatusReadyToMerge WorkflowStatus = "ready_to_merge"
+	WorkflowStatusDone         WorkflowStatus = "done"
+	WorkflowStatusSettled      WorkflowStatus = "settled"
+	WorkflowStatusParked       WorkflowStatus = "parked"
+)
+
+// ValidateWorkflowStatus accepts the canonical lifecycle values and the empty
+// string, which means unset. Existing legacy values are never validated on read.
+func ValidateWorkflowStatus(status string) error {
+	switch WorkflowStatus(status) {
+	case "", WorkflowStatusActive, WorkflowStatusBlocked, WorkflowStatusReadyToMerge,
+		WorkflowStatusDone, WorkflowStatusSettled, WorkflowStatusParked:
+		return nil
+	default:
+		return fmt.Errorf("workflow status must be empty or one of active, blocked, ready_to_merge, done, settled, parked")
+	}
+}
+
+// IsTerminalWorkflowStatus reports the only statuses that leave the active
+// workflow lifecycle: explicit completion and quiescent settlement.
+func IsTerminalWorkflowStatus(status string) bool {
+	switch WorkflowStatus(status) {
+	case WorkflowStatusDone, WorkflowStatusSettled:
+		return true
+	default:
+		return false
+	}
+}
+
 var workflowIssueReferencePattern = regexp.MustCompile(`#([1-9][0-9]*)`)
 
 // WorkflowNote is one append-only external-coordinator journal entry.
@@ -200,49 +236,15 @@ func workflowQueryLimit(limit int) int {
 }
 
 func (s *Store) InsertWorkflowNote(ctx context.Context, note WorkflowNote) (WorkflowNote, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return WorkflowNote{}, err
-	}
-	defer func() { _ = tx.Rollback() }()
-	id, err := insertWorkflowNoteTx(ctx, tx, note)
-	if err != nil {
-		return WorkflowNote{}, err
-	}
-	if err := ensureWorkflowDescriptionTx(ctx, tx, note.WorkflowID); err != nil {
-		return WorkflowNote{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return WorkflowNote{}, err
-	}
-	return s.getWorkflowNote(ctx, id)
+	stored, _, err := s.insertWorkflowNoteWithObservationAndMeta(ctx, note, MemoryObservation{}, WorkflowMeta{}, false, false)
+	return stored, err
 }
 
 // InsertWorkflowNoteWithMeta atomically appends a note and updates the
 // workflow's coordinator handoff metadata with the values from this note.
 func (s *Store) InsertWorkflowNoteWithMeta(ctx context.Context, note WorkflowNote, meta WorkflowMeta) (WorkflowNote, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return WorkflowNote{}, err
-	}
-	defer func() { _ = tx.Rollback() }()
-	noteID, err := insertWorkflowNoteTx(ctx, tx, note)
-	if err != nil {
-		return WorkflowNote{}, err
-	}
-	meta.WorkflowID = note.WorkflowID
-	if err := upsertWorkflowMetaTx(ctx, tx, meta); err != nil {
-		return WorkflowNote{}, err
-	}
-	if !meta.DescriptionSet {
-		if err := ensureWorkflowDescriptionTx(ctx, tx, note.WorkflowID); err != nil {
-			return WorkflowNote{}, err
-		}
-	}
-	if err := tx.Commit(); err != nil {
-		return WorkflowNote{}, err
-	}
-	return s.getWorkflowNote(ctx, noteID)
+	stored, _, err := s.insertWorkflowNoteWithObservationAndMeta(ctx, note, MemoryObservation{}, meta, true, false)
+	return stored, err
 }
 
 // InsertWorkflowAutoNoteWithMeta atomically appends one structured daemon note
@@ -309,22 +311,45 @@ func (s *Store) WorkflowAutoNoteExists(ctx context.Context, workflowID, key stri
 // pending memory observation. The note id is part of the stable ingest key and
 // provenance, so both rows are derived and committed in this one transaction.
 func (s *Store) InsertWorkflowNoteWithObservation(ctx context.Context, note WorkflowNote, obs MemoryObservation) (WorkflowNote, MemoryObservation, error) {
-	return s.insertWorkflowNoteWithObservationAndMeta(ctx, note, obs, WorkflowMeta{}, false)
+	return s.insertWorkflowNoteWithObservationAndMeta(ctx, note, obs, WorkflowMeta{}, false, true)
 }
 
 // InsertWorkflowNoteWithObservationAndMeta is the coordinator-metadata variant
 // of InsertWorkflowNoteWithObservation. Note, metadata, and memory observation
 // either all commit or all roll back.
 func (s *Store) InsertWorkflowNoteWithObservationAndMeta(ctx context.Context, note WorkflowNote, obs MemoryObservation, meta WorkflowMeta) (WorkflowNote, MemoryObservation, error) {
-	return s.insertWorkflowNoteWithObservationAndMeta(ctx, note, obs, meta, true)
+	return s.insertWorkflowNoteWithObservationAndMeta(ctx, note, obs, meta, true, true)
 }
 
-func (s *Store) insertWorkflowNoteWithObservationAndMeta(ctx context.Context, note WorkflowNote, obs MemoryObservation, meta WorkflowMeta, writeMeta bool) (WorkflowNote, MemoryObservation, error) {
+func (s *Store) insertWorkflowNoteWithObservationAndMeta(ctx context.Context, note WorkflowNote, obs MemoryObservation, meta WorkflowMeta, writeMeta, writeObservation bool) (WorkflowNote, MemoryObservation, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return WorkflowNote{}, MemoryObservation{}, err
 	}
 	defer func() { _ = tx.Rollback() }()
+	if !writeMeta || !meta.StatusSet {
+		status, err := workflowMetaStatusTx(ctx, tx, note.WorkflowID)
+		if err != nil {
+			return WorkflowNote{}, MemoryObservation{}, err
+		}
+		if IsTerminalWorkflowStatus(status) {
+			if _, err := insertWorkflowNoteTx(ctx, tx, WorkflowNote{
+				WorkflowID: note.WorkflowID,
+				Author:     WorkflowAutoNoteAuthor,
+				Body:       fmt.Sprintf("[auto:workflow:reopened] reopened from %s", status),
+				Repo:       note.Repo,
+			}); err != nil {
+				return WorkflowNote{}, MemoryObservation{}, err
+			}
+			if err := upsertWorkflowMetaTx(ctx, tx, WorkflowMeta{
+				WorkflowID: note.WorkflowID,
+				Status:     string(WorkflowStatusActive),
+				StatusSet:  true,
+			}); err != nil {
+				return WorkflowNote{}, MemoryObservation{}, err
+			}
+		}
+	}
 	noteID, err := insertWorkflowNoteTx(ctx, tx, note)
 	if err != nil {
 		return WorkflowNote{}, MemoryObservation{}, err
@@ -339,6 +364,13 @@ func (s *Store) insertWorkflowNoteWithObservationAndMeta(ctx context.Context, no
 		if err := ensureWorkflowDescriptionTx(ctx, tx, note.WorkflowID); err != nil {
 			return WorkflowNote{}, MemoryObservation{}, err
 		}
+	}
+	if !writeObservation {
+		if err := tx.Commit(); err != nil {
+			return WorkflowNote{}, MemoryObservation{}, err
+		}
+		stored, err := s.getWorkflowNote(ctx, noteID)
+		return stored, MemoryObservation{}, err
 	}
 	obs.Key = "workflow-" + note.WorkflowID + "-" + strconv.FormatInt(noteID, 10)
 	obs.Provenance = fmt.Sprintf("workflow:%s#%d", note.WorkflowID, noteID)
@@ -359,6 +391,15 @@ func (s *Store) insertWorkflowNoteWithObservationAndMeta(ctx context.Context, no
 		return WorkflowNote{}, MemoryObservation{}, err
 	}
 	return stored, obs, nil
+}
+
+func workflowMetaStatusTx(ctx context.Context, tx *sql.Tx, workflowID string) (string, error) {
+	var status string
+	err := tx.QueryRowContext(ctx, `SELECT status FROM workflow_meta WHERE workflow_id = ?`, workflowID).Scan(&status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return status, err
 }
 
 func insertWorkflowNoteTx(ctx context.Context, tx *sql.Tx, note WorkflowNote) (int64, error) {
@@ -407,6 +448,11 @@ ON CONFLICT(workflow_id) DO UPDATE SET
 }
 
 func validateWorkflowMeta(meta WorkflowMeta) error {
+	if meta.StatusSet {
+		if err := ValidateWorkflowStatus(meta.Status); err != nil {
+			return err
+		}
+	}
 	for _, field := range []struct {
 		name  string
 		value string

--- a/internal/db/workflow_store_test.go
+++ b/internal/db/workflow_store_test.go
@@ -361,13 +361,13 @@ func TestWorkflowAutoNotePreservesCoordinatorAuthor(t *testing.T) {
 	// empty so a daemon receipt cannot replace the coordinator identity.
 	_, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
 		WorkflowNote{WorkflowID: workflowID, Author: WorkflowAutoNoteAuthor, Body: "[auto:pr:958:opened] PR #958 opened (feature/958)"},
-		WorkflowMeta{WorkflowID: workflowID, Status: "PR #958 open", StatusSet: true})
+		WorkflowMeta{WorkflowID: workflowID, Status: string(WorkflowStatusActive), StatusSet: true})
 	if err != nil || !inserted {
 		t.Fatalf("InsertWorkflowAutoNoteWithMeta = (inserted=%v, err=%v)", inserted, err)
 	}
 
 	meta, err := store.GetWorkflowMeta(ctx, workflowID)
-	if err != nil || meta.Author != "fable" || meta.Pane != "Gitmoot2" || meta.SessionID != "full-session" || meta.WorkDir != "/work/fable" || meta.Status != "PR #958 open" {
+	if err != nil || meta.Author != "fable" || meta.Pane != "Gitmoot2" || meta.SessionID != "full-session" || meta.WorkDir != "/work/fable" || meta.Status != string(WorkflowStatusActive) {
 		t.Fatalf("metadata after production-shaped auto note = %+v, err=%v", meta, err)
 	}
 }
@@ -381,7 +381,7 @@ func TestWorkflowSummarySeparatesDaemonNotesFromHumanAcknowledgment(t *testing.T
 	}
 	if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
 		WorkflowNote{WorkflowID: workflowID, Author: WorkflowAutoNoteAuthor, Body: "[auto:pr:958:closed] PR #958 closed without merging"},
-		WorkflowMeta{WorkflowID: workflowID, Status: "PR #958 closed without merging", StatusSet: true}); err != nil || !inserted {
+		WorkflowMeta{WorkflowID: workflowID, Status: string(WorkflowStatusActive), StatusSet: true}); err != nil || !inserted {
 		t.Fatalf("InsertWorkflowAutoNoteWithMeta = (inserted=%v, err=%v)", inserted, err)
 	}
 
@@ -434,7 +434,7 @@ func TestWorkflowSummaryTracksMergedDaemonReceipt(t *testing.T) {
 		if fixture.author == WorkflowAutoNoteAuthor {
 			if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
 				WorkflowNote{WorkflowID: fixture.workflowID, Author: fixture.author, Body: fixture.body},
-				WorkflowMeta{WorkflowID: fixture.workflowID, Status: fixture.body, StatusSet: true}); err != nil || !inserted {
+				WorkflowMeta{WorkflowID: fixture.workflowID, Status: string(WorkflowStatusActive), StatusSet: true}); err != nil || !inserted {
 				t.Fatalf("InsertWorkflowAutoNoteWithMeta(%q) = (inserted=%v, err=%v)", fixture.workflowID, inserted, err)
 			}
 			continue
@@ -485,11 +485,11 @@ func TestWorkflowMetaTextSetPreserveClearAndLimit(t *testing.T) {
 	write("kickoff", WorkflowMeta{
 		Author: "coord", Summary: "Ship the dashboard redesign.", SummarySet: true,
 		Description: "Stable intent", DescriptionSet: true,
-		Status: "Starting", StatusSet: true,
+		Status: string(WorkflowStatusActive), StatusSet: true,
 	})
 	write("progress", WorkflowMeta{Author: "coord"})
 	meta, err := store.GetWorkflowMeta(ctx, workflowID)
-	if err != nil || meta.Summary != "Ship the dashboard redesign." || meta.Description != "Stable intent" || meta.Status != "Starting" {
+	if err != nil || meta.Summary != "Ship the dashboard redesign." || meta.Description != "Stable intent" || meta.Status != string(WorkflowStatusActive) {
 		t.Fatalf("metadata after omitted update = %+v, err=%v", meta, err)
 	}
 
@@ -505,7 +505,6 @@ func TestWorkflowMetaTextSetPreserveClearAndLimit(t *testing.T) {
 	}{
 		{name: "summary", meta: WorkflowMeta{Summary: strings.Repeat("s", WorkflowMetaTextMax+1), SummarySet: true}},
 		{name: "description", meta: WorkflowMeta{Description: strings.Repeat("d", WorkflowMetaTextMax+1), DescriptionSet: true}},
-		{name: "status", meta: WorkflowMeta{Status: strings.Repeat("x", WorkflowMetaTextMax+1), StatusSet: true}},
 	} {
 		t.Run(tc.name+"_over_limit", func(t *testing.T) {
 			if _, err := store.InsertWorkflowNoteWithMeta(ctx,

--- a/internal/workflow/workflow_journal_test.go
+++ b/internal/workflow/workflow_journal_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"testing"
 
@@ -124,7 +125,19 @@ func TestRecordPullRequestWorkflowTransitionConditionallyUpdatesStatus(t *testin
 			ctx := context.Background()
 			event := seedWorkflowJournalLifecycle(t, store, TaskReviewing)
 			if tc.initial != "" {
-				if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+				if tc.initial == "PR #123 open" {
+					raw, err := sql.Open("sqlite", store.DatabasePath())
+					if err != nil {
+						t.Fatalf("open raw database: %v", err)
+					}
+					if _, err := raw.ExecContext(ctx, `UPDATE workflow_meta SET status = ? WHERE workflow_id = ?`, tc.initial, "release/lifecycle"); err != nil {
+						_ = raw.Close()
+						t.Fatalf("seed legacy status: %v", err)
+					}
+					if err := raw.Close(); err != nil {
+						t.Fatalf("close raw database: %v", err)
+					}
+				} else if _, err := store.InsertWorkflowNoteWithMeta(ctx,
 					db.WorkflowNote{WorkflowID: "release/lifecycle", Author: "operator", Body: "status seed"},
 					db.WorkflowMeta{Status: tc.initial, StatusSet: true}); err != nil {
 					t.Fatalf("seed status: %v", err)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1289,7 +1289,8 @@ gitmoot job list --workflow fable/dashboard-redesign
 gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
 gitmoot workflow describe fable/dashboard-redesign "Coordinate and ship the dashboard redesign."
-gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --status "Implementation started"
+gitmoot workflow note fable/dashboard-redesign "Implementation started." --author operator --status active
+gitmoot workflow close fable/dashboard-redesign --reason "Shipped and verified."
 ```
 
 `workflow list` reports per-state counts, note count, first/last activity, and
@@ -1302,7 +1303,9 @@ while queued/running, `recent` when no work is live but activity occurred within
 30 minutes, `stalled` when failed/blocked with an unacknowledged failure (newer
 than any non-daemon journal note and any merged-PR daemon receipt; other daemon
 receipts never acknowledge) and quiet for 30 minutes to 24 hours, and `settled`
-otherwise. The optional
+otherwise. A workflow whose status is `done` or `settled` leaves the active
+bucket immediately regardless of note recency, unless it has queued/running
+work. The optional
 `--pane`, `--session`, and `--workdir` note flags persist the latest coordinator
 handoff shown on that page. When those flags are omitted inside Herdr
 (`HERDR_SOCKET_PATH` or `HERDR_ENV=1`), `workflow note` reads the current pane
@@ -1318,8 +1321,18 @@ issue title, else the first kickoff-note sentence, else the label campaign.
 `workflow describe <label> "<text>"` overrides it. Legacy `workflow note
 --summary` remains an alias for description and also mirrors the value into the
 retained summary field for older clients. `workflow note --status "..."` is the
-manual status escape hatch. Each field is stored verbatim and limited to 300
+manual status control and accepts only `active`, `blocked`, `ready_to_merge`,
+`done`, `settled`, or `parked` (plus an explicit empty value to unset it).
+Put free-text detail in the note body. Existing legacy status strings remain
+readable but cannot be written anew. Each metadata field is limited to 300
 bytes.
+
+`workflow close <label> [--reason "..."]` refuses workflows with queued/running
+jobs, appends a typed `[workflow:close]` journal note, and sets status to `done`
+atomically. Repeating close on a `done` or `settled` workflow is an idempotent
+success without another close note. A later note without an explicit
+`--status` records a preceding `[auto:workflow:reopened]` receipt and returns
+the workflow to `active`; an explicit status remains authoritative.
 
 For a workflow-linked PR, the daemon adds a structured `[auto:pr:...]` note as
 author `daemon` and advances status when the PR opens, checks turn green, and it

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1132,7 +1132,8 @@ gitmoot job list --workflow fable/dashboard-redesign
 gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
 gitmoot workflow describe fable/dashboard-redesign "Coordinate and ship the dashboard redesign."
-gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --status "Implementation started"
+gitmoot workflow note fable/dashboard-redesign "Implementation started." --author operator --status active
+gitmoot workflow close fable/dashboard-redesign --reason "Shipped and verified."
 ```
 
 List/show include state counts, notes, first/last activity, and best-effort token
@@ -1141,7 +1142,9 @@ also renders labels as Galaxy hubs and provides a Workflows index plus mission
 log at `/workflows/<label>`. `active` means queued/running; `recent` means no work
 is live but activity occurred within 30 minutes; failed/blocked workflows with
 an unacknowledged failure and 30 minutes to 24 hours of silence are `stalled`;
-everything else is `settled`. The optional `--pane`, `--session`, and
+everything else is `settled`. A `done` or `settled` status immediately projects
+as settled regardless of note recency, unless queued/running work makes it
+active. The optional `--pane`, `--session`, and
 `--workdir` note flags persist the latest coordinator handoff. Inside Herdr,
 omitted identity flags are filled from the current pane: its label, full agent
 session UUID, and working directory. Explicit flags always win; `--no-auto`
@@ -1154,7 +1157,17 @@ auto-seeded from a referenced local issue title, else the first note sentence,
 else the label campaign; override it with `workflow describe`. Legacy
 `workflow note --summary` remains a description alias and mirrors the retained
 summary field for older clients. `workflow note --status` is the manual status
-escape hatch. Each field is limited to 300 bytes.
+control and accepts only `active`, `blocked`, `ready_to_merge`, `done`,
+`settled`, or `parked` (plus an explicit empty value to unset it). Put free-text
+detail in the note body. Legacy status strings remain readable but cannot be
+written anew. Each metadata field is limited to 300 bytes.
+
+`workflow close <label> [--reason "..."]` refuses queued/running work, appends
+a typed `[workflow:close]` note, and sets status to `done` atomically. Repeating
+close on `done` or `settled` is an idempotent success without another close
+note. A later note without explicit `--status` writes a preceding
+`[auto:workflow:reopened]` receipt and returns the workflow to `active`;
+explicit status remains authoritative.
 
 Linked PR transitions add structured `[auto:pr:...]` notes as author `daemon`
 and advance status at open, checks-green/ready-to-merge, and merged or


### PR DESCRIPTION
## What

Workflow lifecycle hygiene (#1094), **slice 2 of 3** — gives workflows a real *death*: a first-class terminal vocabulary, a `workflow close` verb, automatic reopen when work resumes, and a dashboard that finally drops terminal workflows out of the active bucket. This is the direct fix for zombie-active workflows and rotting statuses after a wave. Builds on slice 1 (#1101). No migration (`workflow_meta.status` exists).

## Changes

- **Status enum** (`internal/db/workflow_store.go`): canonical `WorkflowStatus` = `active` / `blocked` / `ready_to_merge` / `done` / `settled` / `parked`; **terminal = `done` + `settled`**. `ValidateWorkflowStatus` is enforced **write-only** at the shared meta-upsert choke point (`upsertWorkflowMetaTxWithStatusGuard`) and surfaced with a friendly error in `workflow note --status`. Legacy free-text values remain **readable** and are treated as non-terminal — no read ever validates.
- **`gitmoot workflow close <label> [--reason]`** (new verb; `internal/db/workflow_lifecycle_store.go`): one transaction — reuses the note typo-guard (label must have workflow-linked jobs), **refuses while any job is `queued`/`running`**, else appends `[workflow:close] <reason>` and sets `done`. **Idempotent**: an already-terminal workflow returns success with no duplicate note.
- **Reopen-on-note** (centralized in the shared `insertWorkflowNoteWithObservationAndMeta`): a note carrying **no explicit status** on a terminal workflow first inserts a daemon-authored `[auto:workflow:reopened] reopened from <done|settled>` receipt, then the caller's **verbatim** note, and sets `active`. The receipt precedes the human note (human text stays newest); only the *first* post-terminal note reopens. Explicit `--status` (incl. explicit empty) is authoritative and bypasses reopening. Applies uniformly to plain / metadata / memory-observation writers, so org and other callers can't bypass it.
- **Terminal-aware dashboard** (`deriveDashboardWorkflowState`): precedence `queued|running → active` (live work always wins) → `done|settled → settled` (leaves active bucket **regardless of note recency**) → otherwise the existing stalled/recent/settled calc **byte-for-byte unchanged**. Index and detail share the one function. Legacy/unknown status falls through as non-terminal.
- **Docs**: `skills/gitmoot/references/CLI.md` + `website/docs/reference/cli.md` document `workflow close`, the `--status` enum, reopen behavior, and terminal dashboard semantics. `llms-full.txt` regenerated via the website build.

## Review — high (two fresh finders, isolated worktrees, de-anchored)

**No HIGH or MEDIUM defects.** Both finders verified against the code + SQL (and Finder B drove the real CLI empirically); `go build`/`go vet`/tests all pass.

- **Shared-seam / reopen ripple**: reopen fires exactly when intended (`!(writeMeta && StatusSet)` + terminal); the daemon auto-note path is a genuinely separate function, so a `[auto:pr:*]` receipt can **not** reopen a settled workflow; no status clobber (the guard SQL binds `StatusSet` first, so a `StatusSet=false` follow-up upsert preserves the reopen's `active`); the reopen receipt is exempt from the partial `[auto:pr:` unique index, so repeat reopen cycles don't collide; transaction is all-or-nothing; receipt precedes the human note.
- **Choke-point enum validation breaks no existing writer**: the only `workflow_meta.status` writers are PR-lifecycle (`active`/`ready_to_merge`), `CloseWorkflow` (`done`), reopen (`active`), and the pre-validated CLI note path — all in-enum. The `merged`/`closed`/`open` literals elsewhere belong to *other tables'* status columns.
- **close / enum / dashboard**: the typo-guard does not false-reject `job open`/`OpenExternalJob` workflows (they carry a workflow-linked job); enum validation is write-only (legacy free-text still loads); dashboard precedence is `live → terminal → original calc` with the non-terminal branch **byte-for-byte identical** to `main`; index and detail both pass `meta.Status`.

**Polish applied** (LOW): the `[workflow:close]` breadcrumb is now authored `daemon` (like the reopen receipt), so it no longer pollutes `last_human_author` or seed the auto-description — with a test assertion. Two other LOW notes were left deliberately: `close --help` matches its sibling `workflow describe` (both parse label-first, return 0 without usage — changing it would *diverge*), and close refusing only `queued`/`running` (not resumable `blocked`) is consistent with PR 3's auto-settle predicate and self-corrects on the dashboard.

## Sequence

Slice 2 of 3: merge-hook (#1101, merged) → **enum + close + reopen + dashboard (this)** → auto-settle (daemon evaluator, last). No deploy (judging window). Merge owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
