### PR TITLE
feat(workflow): conservative daemon auto-settle for quiescent workflows (#1094)

### DIFF
--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -107,6 +107,9 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 				wait = baseInterval
 			}
 			if !dryRun {
+				if err := runWorkflowAutoSettleOnce(ctx, paths, store, time.Now().UTC(), stdout); err != nil {
+					writeLine(stdout, "workflow auto-settle error: %s", err)
+				}
 				if err := runHeartbeatScanOnce(ctx, paths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
 					writeLine(stdout, "heartbeat scan error: %s", err)
 				}
@@ -232,6 +235,9 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 			_ = runDaemonPollWithTimeout(ctx, daemonPollTimeout, d.PollRecoveryCommandsOnce)
 		}
 		if heartbeatPathsErr == nil {
+			if err := runWorkflowAutoSettleOnce(ctx, heartbeatPaths, store, time.Now().UTC(), stdout); err != nil {
+				writeLine(stdout, "workflow auto-settle error: %s", err)
+			}
 			if err := runHeartbeatScanOnce(ctx, heartbeatPaths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
 				writeLine(stdout, "heartbeat scan error: %s", err)
 			}

--- a/internal/cli/workflow_lifecycle.go
+++ b/internal/cli/workflow_lifecycle.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// runWorkflowAutoSettleOnce performs one home-scoped lifecycle sweep. Candidate
+// failures are isolated so one malformed workflow cannot abort daemon
+// maintenance or prevent other eligible workflows from settling.
+func runWorkflowAutoSettleOnce(ctx context.Context, paths config.Paths, store *db.Store, now time.Time, stdout io.Writer) error {
+	policy, err := config.LoadWorkflowLifecycle(paths)
+	if err != nil {
+		return err
+	}
+	if policy.AutoSettleAfter <= 0 {
+		return nil
+	}
+	candidates, err := store.ListWorkflowAutoSettleCandidates(ctx)
+	if err != nil {
+		return err
+	}
+	for _, candidate := range candidates {
+		// Cheap pre-filter using the anchor the candidate query already computed:
+		// skip workflows that are not yet quiet so the common (recently active)
+		// case never opens a transaction. The authoritative in-tx recheck still
+		// recomputes the anchor, so a stale skip only defers a settle by one tick.
+		if candidate.QuietAnchor.IsZero() || now.Before(candidate.QuietAnchor) ||
+			now.Sub(candidate.QuietAnchor) < policy.AutoSettleAfter {
+			continue
+		}
+		settled, err := store.SettleWorkflowIfEligible(ctx, candidate.WorkflowID, now, policy.AutoSettleAfter)
+		if err != nil {
+			writeLine(stdout, "workflow auto-settle %s error: %s", candidate.WorkflowID, err)
+			continue
+		}
+		if settled {
+			writeLine(stdout, "auto-settled workflow %s", candidate.WorkflowID)
+		}
+	}
+	return nil
+}

--- a/internal/cli/workflow_lifecycle_test.go
+++ b/internal/cli/workflow_lifecycle_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+func TestRunWorkflowAutoSettleOnce(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+`
+[workflow]
+auto_settle_after = "24h"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	seedWorkflowAutoSettleCLI(t, store, "release/merged", 41, "merged")
+	seedWorkflowAutoSettleCLI(t, store, "release/open", 42, "open")
+	now := time.Now().UTC().Add(72 * time.Hour)
+
+	var stdout bytes.Buffer
+	if err := runWorkflowAutoSettleOnce(ctx, paths, store, now, &stdout); err != nil {
+		t.Fatalf("runWorkflowAutoSettleOnce: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "auto-settled workflow release/merged") ||
+		strings.Contains(got, "auto-settled workflow release/open") {
+		t.Fatalf("stdout = %q", got)
+	}
+	meta, err := store.GetWorkflowMeta(ctx, "release/merged")
+	if err != nil || meta.Status != string(db.WorkflowStatusSettled) {
+		t.Fatalf("merged workflow meta = %+v, err=%v", meta, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, "release/merged", 0)
+	if err != nil || len(notes) != 2 ||
+		notes[1].Body != "[auto:workflow:settled] merged/closed PRs, quiet ≥ 24h0m0s" {
+		t.Fatalf("merged workflow notes = %+v, err=%v", notes, err)
+	}
+	allMeta, err := store.ListWorkflowMeta(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowMeta: %v", err)
+	}
+	if open := allMeta["release/open"]; open.Status == string(db.WorkflowStatusSettled) {
+		t.Fatalf("open workflow unexpectedly settled: %+v", open)
+	}
+
+	seedWorkflowAutoSettleCLI(t, store, "release/disabled", 43, "merged")
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[workflow]
+auto_settle_after = "0"
+`), 0o600); err != nil {
+		t.Fatalf("write disabled config: %v", err)
+	}
+	stdout.Reset()
+	if err := runWorkflowAutoSettleOnce(ctx, paths, store, now, &stdout); err != nil {
+		t.Fatalf("disabled runWorkflowAutoSettleOnce: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("disabled stdout = %q", stdout.String())
+	}
+	allMeta, err = store.ListWorkflowMeta(ctx)
+	if err != nil {
+		t.Fatalf("ListWorkflowMeta after disabled sweep: %v", err)
+	}
+	if disabled := allMeta["release/disabled"]; disabled.Status == string(db.WorkflowStatusSettled) {
+		t.Fatalf("disabled workflow unexpectedly settled: %+v", disabled)
+	}
+}
+
+func seedWorkflowAutoSettleCLI(t *testing.T, store *db.Store, workflowID string, pullRequest int, prState string) {
+	t.Helper()
+	ctx := context.Background()
+	payload := fmt.Sprintf(`{"repo":"acme/widget","workflow_id":%q,"pull_request":%d}`, workflowID, pullRequest)
+	if err := store.CreateJob(ctx, db.Job{
+		ID:      fmt.Sprintf("job-%d", pullRequest),
+		Agent:   "shell-worker",
+		Type:    "ask",
+		State:   "succeeded",
+		Payload: payload,
+	}); err != nil {
+		t.Fatalf("CreateJob(%s): %v", workflowID, err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: workflowID,
+		Author:     "operator",
+		Body:       "old human checkpoint",
+	}); err != nil {
+		t.Fatalf("InsertWorkflowNote(%s): %v", workflowID, err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "acme/widget",
+		Number:       int64(pullRequest),
+		URL:          fmt.Sprintf("https://example.invalid/acme/widget/pull/%d", pullRequest),
+		HeadBranch:   fmt.Sprintf("feature/%d", pullRequest),
+		BaseBranch:   "main",
+		State:        prState,
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest(%d): %v", pullRequest, err)
+	}
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -61,6 +61,7 @@ artifact_blobs = %q
 # implement_base = "origin/main"
 # result_checks = "warn"
 # stale_task_ttl = "168h"
+# auto_settle_after = "24h" # default 24h; 0 disables workflow auto-settle
 # delegation_worktree_ttl = "72h"
 # planned_ttl = "720h" # opt-in; unset/empty/0/invalid disables
 # require_workflow = false # opt out (default is true)

--- a/internal/config/workflow_lifecycle.go
+++ b/internal/config/workflow_lifecycle.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+const DefaultWorkflowAutoSettleAfter = 24 * time.Hour
+
+// WorkflowLifecyclePolicy controls conservative workflow lifecycle maintenance.
+type WorkflowLifecyclePolicy struct {
+	AutoSettleAfter time.Duration
+}
+
+// LoadWorkflowLifecycle resolves the independent
+// [workflow].auto_settle_after setting. Omitted or empty uses 24 hours, zero
+// disables auto-settle, and every other value must be a non-negative Go
+// duration.
+func LoadWorkflowLifecycle(paths Paths) (WorkflowLifecyclePolicy, error) {
+	policy := WorkflowLifecyclePolicy{AutoSettleAfter: DefaultWorkflowAutoSettleAfter}
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return policy, nil
+		}
+		return WorkflowLifecyclePolicy{}, err
+	}
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			continue
+		}
+		if current != "workflow" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "auto_settle_after" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "\"") {
+			value, err = parseConfigString(value)
+			if err != nil {
+				return WorkflowLifecyclePolicy{}, fmt.Errorf("parse [workflow].auto_settle_after: %w", err)
+			}
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			policy.AutoSettleAfter = DefaultWorkflowAutoSettleAfter
+			continue
+		}
+		after, err := time.ParseDuration(value)
+		if err != nil || after < 0 {
+			if err == nil {
+				err = fmt.Errorf("duration must not be negative")
+			}
+			return WorkflowLifecyclePolicy{}, fmt.Errorf("invalid [workflow].auto_settle_after %q: %w", value, err)
+		}
+		policy.AutoSettleAfter = after
+	}
+	return policy, nil
+}

--- a/internal/config/workflow_lifecycle_test.go
+++ b/internal/config/workflow_lifecycle_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadWorkflowLifecycle(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    time.Duration
+		wantErr string
+	}{
+		{name: "missing config", want: 24 * time.Hour},
+		{name: "omitted", content: "[workflow]\nimplement_base = \"HEAD\"\n", want: 24 * time.Hour},
+		{name: "custom", content: "[workflow]\nauto_settle_after = \"48h\"\n", want: 48 * time.Hour},
+		{name: "zero", content: "[workflow]\nauto_settle_after = \"0\"\n", want: 0},
+		{name: "zero duration", content: "[workflow]\nauto_settle_after = \"0s\"\n", want: 0},
+		{name: "negative", content: "[workflow]\nauto_settle_after = \"-1h\"\n", wantErr: "must not be negative"},
+		{name: "garbage", content: "[workflow]\nauto_settle_after = \"later\"\n", wantErr: "invalid [workflow].auto_settle_after"},
+		{name: "other section", content: "[memory]\nauto_settle_after = \"2h\"\n", want: 24 * time.Hour},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if test.content != "" {
+				if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+					t.Fatalf("mkdir home: %v", err)
+				}
+				if err := os.WriteFile(paths.ConfigFile, []byte(test.content), 0o600); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+			got, err := LoadWorkflowLifecycle(paths)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("LoadWorkflowLifecycle error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil || got.AutoSettleAfter != test.want {
+				t.Fatalf("LoadWorkflowLifecycle = %+v, err=%v, want %s", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestDefaultConfigLoadsWorkflowLifecycle(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	policy, err := LoadWorkflowLifecycle(paths)
+	if err != nil || policy.AutoSettleAfter != DefaultWorkflowAutoSettleAfter {
+		t.Fatalf("LoadWorkflowLifecycle(DefaultConfig) = %+v, err=%v", policy, err)
+	}
+	body, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(body), `# auto_settle_after = "24h"`) {
+		t.Fatalf("DefaultConfig missing commented auto_settle_after")
+	}
+}

--- a/internal/db/workflow_lifecycle_store.go
+++ b/internal/db/workflow_lifecycle_store.go
@@ -3,8 +3,12 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // UnknownWorkflowError identifies a workflow label rejected by lifecycle
@@ -23,6 +27,25 @@ type CloseWorkflowResult struct {
 	Status          WorkflowStatus `json:"status"`
 	AlreadyTerminal bool           `json:"already_terminal,omitempty"`
 	Note            *WorkflowNote  `json:"note,omitempty"`
+}
+
+// PullRequestRef is one repository-scoped pull request referenced by a
+// workflow's jobs or structured PR lifecycle notes.
+type PullRequestRef struct {
+	Repo   string
+	Number int64
+}
+
+// WorkflowAutoSettleCandidate is the narrow projection used by the daemon
+// lifecycle sweep. QuietAnchor excludes daemon-authored receipts.
+type WorkflowAutoSettleCandidate struct {
+	WorkflowID  string
+	QuietAnchor time.Time
+}
+
+type workflowLifecycleQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 // CloseWorkflow atomically refuses live work or records an explicit close.
@@ -102,4 +125,294 @@ func countActiveWorkflowJobsTx(ctx context.Context, tx *sql.Tx, label string) (i
 	err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM jobs INDEXED BY idx_jobs_workflow_id
 WHERE workflow_id != '' AND workflow_id = ? AND state IN ('queued','running')`, label).Scan(&count)
 	return count, err
+}
+
+// WorkflowPullRequestRefs returns the deterministic union of scalar job PR
+// references and structured [auto:pr:N:*] workflow receipts.
+func (s *Store) WorkflowPullRequestRefs(ctx context.Context, workflowID string) ([]PullRequestRef, error) {
+	return workflowPullRequestRefs(ctx, s.db, workflowID)
+}
+
+func workflowPullRequestRefs(ctx context.Context, q workflowLifecycleQueryer, workflowID string) ([]PullRequestRef, error) {
+	type refKey struct {
+		repo   string
+		number int64
+	}
+	refs := make(map[refKey]struct{})
+	jobRepos := make(map[string]struct{})
+	rows, err := q.QueryContext(ctx, `SELECT DISTINCT repo, pull_request
+FROM jobs INDEXED BY idx_jobs_workflow_id
+WHERE workflow_id != '' AND workflow_id = ? AND pull_request > 0 AND repo != ''
+ORDER BY repo, pull_request`, workflowID)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var repo string
+		var number int64
+		if err := rows.Scan(&repo, &number); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		repo = strings.TrimSpace(repo)
+		if repo != "" && number > 0 {
+			refs[refKey{repo: repo, number: number}] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	rows, err = q.QueryContext(ctx, WorkflowReposSQL, workflowID)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var repo string
+		if err := rows.Scan(&repo); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		if repo = strings.TrimSpace(repo); repo != "" {
+			jobRepos[repo] = struct{}{}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	fallbackRepo := ""
+	if len(jobRepos) == 1 {
+		for repo := range jobRepos {
+			fallbackRepo = repo
+		}
+	}
+	rows, err = q.QueryContext(ctx, `SELECT body, repo
+FROM workflow_notes INDEXED BY idx_workflow_notes_wid
+WHERE workflow_id = ? AND author = ?
+ORDER BY created_at, id`, workflowID, WorkflowAutoNoteAuthor)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var body, repo string
+		if err := rows.Scan(&body, &repo); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		number, ok := workflowPullRequestNumber(body)
+		if !ok {
+			continue
+		}
+		repo = strings.TrimSpace(repo)
+		if repo == "" {
+			repo = fallbackRepo
+		}
+		// Keep an unresolved empty-repo reference. Eligibility then fails closed
+		// because no local pull_requests mirror row can match it.
+		refs[refKey{repo: repo, number: number}] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	out := make([]PullRequestRef, 0, len(refs))
+	for ref := range refs {
+		out = append(out, PullRequestRef{Repo: ref.repo, Number: ref.number})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		return out[i].Number < out[j].Number
+	})
+	return out, nil
+}
+
+func workflowPullRequestNumber(body string) (int64, bool) {
+	body = strings.TrimSpace(body)
+	end := strings.IndexByte(body, ']')
+	if end <= 0 || body[0] != '[' {
+		return 0, false
+	}
+	parts := strings.Split(body[1:end], ":")
+	if len(parts) != 4 || parts[0] != "auto" || parts[1] != "pr" || parts[3] == "" {
+		return 0, false
+	}
+	number, err := strconv.ParseInt(parts[2], 10, 64)
+	return number, err == nil && number > 0
+}
+
+// ListWorkflowAutoSettleCandidates lists workflows that could plausibly settle:
+// status not terminal/parked/blocked (blocked is a deliberate human-awaiting
+// signal, #1094), AND referencing at least one PR (a workflow with zero PR refs
+// can never settle, so journal-only coordinator workflows are excluded here to
+// keep the per-tick sweep from opening a no-op transaction for each of them).
+// The QuietAnchor is display-only; the authoritative gate rechecks in-tx.
+func (s *Store) ListWorkflowAutoSettleCandidates(ctx context.Context) ([]WorkflowAutoSettleCandidate, error) {
+	rows, err := s.db.QueryContext(ctx, `WITH workflow_ids(workflow_id) AS (
+	SELECT workflow_id FROM jobs WHERE workflow_id != ''
+	UNION
+	SELECT workflow_id FROM workflow_notes WHERE workflow_id != ''
+	UNION
+	SELECT workflow_id FROM workflow_meta WHERE workflow_id != ''
+)
+SELECT w.workflow_id,
+	COALESCE((
+		SELECT MAX(n.created_at)
+		FROM workflow_notes n INDEXED BY idx_workflow_notes_wid
+		WHERE n.workflow_id = w.workflow_id AND n.author != ?
+	), ''),
+	COALESCE((
+		SELECT MAX(j.updated_at)
+		FROM jobs j INDEXED BY idx_jobs_workflow_id
+		WHERE j.workflow_id != '' AND j.workflow_id = w.workflow_id
+	), '')
+FROM workflow_ids w
+LEFT JOIN workflow_meta m ON m.workflow_id = w.workflow_id
+WHERE COALESCE(m.status, '') NOT IN ('parked', 'done', 'settled', 'blocked')
+	AND (
+		EXISTS (
+			SELECT 1 FROM jobs jr INDEXED BY idx_jobs_workflow_id
+			WHERE jr.workflow_id != '' AND jr.workflow_id = w.workflow_id AND jr.pull_request > 0
+		)
+		OR EXISTS (
+			SELECT 1 FROM workflow_notes nr
+			WHERE nr.workflow_id = w.workflow_id AND nr.author = ? AND substr(nr.body, 1, 9) = '[auto:pr:'
+		)
+	)
+ORDER BY w.workflow_id`, WorkflowAutoNoteAuthor, WorkflowAutoNoteAuthor)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var candidates []WorkflowAutoSettleCandidate
+	for rows.Next() {
+		var candidate WorkflowAutoSettleCandidate
+		var humanNoteAt, jobUpdatedAt string
+		if err := rows.Scan(&candidate.WorkflowID, &humanNoteAt, &jobUpdatedAt); err != nil {
+			return nil, err
+		}
+		candidate.QuietAnchor = latestWorkflowActivity(humanNoteAt, jobUpdatedAt)
+		candidates = append(candidates, candidate)
+	}
+	return candidates, rows.Err()
+}
+
+func workflowQuietAnchor(ctx context.Context, q workflowLifecycleQueryer, workflowID string) (time.Time, error) {
+	var humanNoteAt, jobUpdatedAt string
+	if err := q.QueryRowContext(ctx, `SELECT
+	COALESCE((
+		SELECT MAX(created_at)
+		FROM workflow_notes INDEXED BY idx_workflow_notes_wid
+		WHERE workflow_id = ? AND author != ?
+	), ''),
+	COALESCE((
+		SELECT MAX(updated_at)
+		FROM jobs INDEXED BY idx_jobs_workflow_id
+		WHERE workflow_id != '' AND workflow_id = ?
+	), '')`, workflowID, WorkflowAutoNoteAuthor, workflowID).Scan(&humanNoteAt, &jobUpdatedAt); err != nil {
+		return time.Time{}, err
+	}
+	return latestWorkflowActivity(humanNoteAt, jobUpdatedAt), nil
+}
+
+func latestWorkflowActivity(values ...string) time.Time {
+	var latest time.Time
+	for _, value := range values {
+		if parsed := parseStoredTimestamp(value); parsed.After(latest) {
+			latest = parsed
+		}
+	}
+	return latest
+}
+
+// SettleWorkflowIfEligible atomically rechecks every conservative lifecycle
+// condition and records one reversible settled transition.
+func (s *Store) SettleWorkflowIfEligible(ctx context.Context, workflowID string, now time.Time, after time.Duration) (bool, error) {
+	if after <= 0 {
+		return false, nil
+	}
+	workflowID = strings.TrimSpace(workflowID)
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	status, err := workflowMetaStatusTx(ctx, tx, workflowID)
+	if err != nil {
+		return false, err
+	}
+	if IsTerminalWorkflowStatus(status) || status == string(WorkflowStatusParked) ||
+		status == string(WorkflowStatusBlocked) {
+		return false, nil
+	}
+	refs, err := workflowPullRequestRefs(ctx, tx, workflowID)
+	if err != nil {
+		return false, err
+	}
+	if len(refs) == 0 {
+		return false, nil
+	}
+	for _, ref := range refs {
+		var state string
+		err := tx.QueryRowContext(ctx, `SELECT state
+FROM pull_requests
+WHERE repo_full_name = ? AND number = ?`, ref.Repo, ref.Number).Scan(&state)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return false, nil
+			}
+			return false, err
+		}
+		if state != "merged" && state != "closed" {
+			return false, nil
+		}
+	}
+	activeJobs, err := countActiveWorkflowJobsTx(ctx, tx, workflowID)
+	if err != nil {
+		return false, err
+	}
+	if activeJobs != 0 {
+		return false, nil
+	}
+	anchor, err := workflowQuietAnchor(ctx, tx, workflowID)
+	if err != nil {
+		return false, err
+	}
+	now = now.UTC()
+	if anchor.IsZero() || now.Before(anchor) || now.Sub(anchor) < after {
+		return false, nil
+	}
+	if _, err := insertWorkflowNoteTx(ctx, tx, WorkflowNote{
+		WorkflowID: workflowID,
+		Author:     WorkflowAutoNoteAuthor,
+		Body:       fmt.Sprintf("[auto:workflow:settled] merged/closed PRs, quiet ≥ %s", after),
+	}); err != nil {
+		return false, err
+	}
+	if err := upsertWorkflowMetaTx(ctx, tx, WorkflowMeta{
+		WorkflowID: workflowID,
+		Status:     string(WorkflowStatusSettled),
+		StatusSet:  true,
+	}); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/db/workflow_lifecycle_store_test.go
+++ b/internal/db/workflow_lifecycle_store_test.go
@@ -3,8 +3,11 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateWorkflowStatus(t *testing.T) {
@@ -260,5 +263,281 @@ func assertNoWorkflowReopenReceipt(t *testing.T, store *Store, label string) {
 		if strings.HasPrefix(note.Body, "[auto:workflow:reopened]") {
 			t.Fatalf("unexpected reopen receipt: %+v", notes)
 		}
+	}
+}
+
+func TestWorkflowPullRequestRefsUnionsJobsAndAutoNotes(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	const label = "release/refs"
+	seedAutoSettleJob(t, store, "ref-job", label, "succeeded", "acme/widget", 5)
+	if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+		WorkflowNote{
+			WorkflowID: label,
+			Author:     WorkflowAutoNoteAuthor,
+			Body:       "[auto:pr:7:merged] PR #7 merged",
+		},
+		WorkflowMeta{Status: string(WorkflowStatusActive), StatusSet: true}); err != nil || !inserted {
+		t.Fatalf("insert fallback-repo receipt = (inserted=%v, err=%v)", inserted, err)
+	}
+	if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+		WorkflowNote{
+			WorkflowID: label,
+			Author:     WorkflowAutoNoteAuthor,
+			Body:       "[auto:pr:9:closed] PR #9 closed",
+			Repo:       "acme/other",
+		},
+		WorkflowMeta{Status: string(WorkflowStatusActive), StatusSet: true}); err != nil || !inserted {
+		t.Fatalf("insert explicit-repo receipt = (inserted=%v, err=%v)", inserted, err)
+	}
+	refs, err := store.WorkflowPullRequestRefs(ctx, label)
+	want := []PullRequestRef{
+		{Repo: "acme/other", Number: 9},
+		{Repo: "acme/widget", Number: 5},
+		{Repo: "acme/widget", Number: 7},
+	}
+	if err != nil || !reflect.DeepEqual(refs, want) {
+		t.Fatalf("WorkflowPullRequestRefs = %+v, err=%v, want %+v", refs, err, want)
+	}
+}
+
+func TestWorkflowPullRequestRefsKeepsAmbiguousRepoUnresolved(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	const label = "release/ambiguous"
+	seedAutoSettleJob(t, store, "ref-a", label, "succeeded", "acme/a", 0)
+	seedAutoSettleJob(t, store, "ref-b", label, "succeeded", "acme/b", 0)
+	if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+		WorkflowNote{
+			WorkflowID: label,
+			Author:     WorkflowAutoNoteAuthor,
+			Body:       "[auto:pr:7:merged] PR #7 merged",
+		},
+		WorkflowMeta{Status: string(WorkflowStatusActive), StatusSet: true}); err != nil || !inserted {
+		t.Fatalf("insert receipt = (inserted=%v, err=%v)", inserted, err)
+	}
+	refs, err := store.WorkflowPullRequestRefs(ctx, label)
+	if err != nil || len(refs) != 1 || refs[0] != (PullRequestRef{Number: 7}) {
+		t.Fatalf("WorkflowPullRequestRefs = %+v, err=%v", refs, err)
+	}
+	settled, err := store.SettleWorkflowIfEligible(ctx, label, time.Now().UTC().Add(48*time.Hour), 24*time.Hour)
+	if err != nil || settled {
+		t.Fatalf("ambiguous ref settled=%v, err=%v", settled, err)
+	}
+}
+
+func TestSettleWorkflowIfEligibleConservativeGates(t *testing.T) {
+	tests := []struct {
+		name       string
+		jobState   string
+		prState    string
+		addPRRow   bool
+		addPRRef   bool
+		recentNote bool
+		recentJob  bool
+		status     string
+		want       bool
+	}{
+		{name: "all terminal", jobState: "succeeded", prState: "merged", addPRRow: true, addPRRef: true, want: true},
+		{name: "closed terminal", jobState: "succeeded", prState: "closed", addPRRow: true, addPRRef: true, want: true},
+		{name: "open PR", jobState: "succeeded", prState: "open", addPRRow: true, addPRRef: true},
+		{name: "missing PR row", jobState: "succeeded", addPRRef: true},
+		{name: "zero PR refs", jobState: "succeeded"},
+		{name: "queued job", jobState: "queued", prState: "merged", addPRRow: true, addPRRef: true},
+		{name: "running job", jobState: "running", prState: "merged", addPRRow: true, addPRRef: true},
+		{name: "recent human note", jobState: "succeeded", prState: "merged", addPRRow: true, addPRRef: true, recentNote: true},
+		{name: "recent job update", jobState: "succeeded", prState: "merged", addPRRow: true, addPRRef: true, recentJob: true},
+		{name: "blocked status", jobState: "succeeded", prState: "merged", addPRRow: true, addPRRef: true, status: "blocked"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := openWorkflowTestStore(t)
+			ctx := context.Background()
+			label := "release/" + strings.ReplaceAll(test.name, " ", "-")
+			pr := 0
+			if test.addPRRef {
+				pr = 11
+			}
+			seedAutoSettleJob(t, store, "job-"+label, label, test.jobState, "acme/widget", pr)
+			note := WorkflowNote{WorkflowID: label, Author: "operator", Body: "human checkpoint"}
+			if test.status != "" {
+				if _, err := store.InsertWorkflowNoteWithMeta(ctx, note,
+					WorkflowMeta{Status: test.status, StatusSet: true}); err != nil {
+					t.Fatalf("insert human note: %v", err)
+				}
+			} else if _, err := store.InsertWorkflowNote(ctx, note); err != nil {
+				t.Fatalf("insert human note: %v", err)
+			}
+			if test.addPRRow {
+				seedAutoSettlePullRequest(t, store, "acme/widget", int64(pr), test.prState)
+			}
+			now := time.Now().UTC().Add(72 * time.Hour)
+			if test.recentNote {
+				setWorkflowNoteTimes(t, store, label, "operator", now.Add(-time.Hour))
+			}
+			if test.recentJob {
+				setWorkflowJobTime(t, store, "job-"+label, now.Add(-time.Hour))
+			}
+			settled, err := store.SettleWorkflowIfEligible(ctx, label, now, 24*time.Hour)
+			if err != nil || settled != test.want {
+				t.Fatalf("SettleWorkflowIfEligible = %v, err=%v, want %v", settled, err, test.want)
+			}
+		})
+	}
+}
+
+func TestSettleWorkflowIfEligibleRequiresEveryReferencedPRTerminal(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	const label = "release/multi-pr"
+	seedAutoSettleJob(t, store, "multi-pr-job", label, "succeeded", "acme/widget", 1)
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: label, Author: "operator", Body: "old"}); err != nil {
+		t.Fatalf("insert human note: %v", err)
+	}
+	if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+		WorkflowNote{
+			WorkflowID: label,
+			Author:     WorkflowAutoNoteAuthor,
+			Body:       "[auto:pr:2:opened] PR #2 opened",
+			Repo:       "acme/widget",
+		},
+		WorkflowMeta{Status: string(WorkflowStatusActive), StatusSet: true}); err != nil || !inserted {
+		t.Fatalf("insert second PR receipt = (inserted=%v, err=%v)", inserted, err)
+	}
+	seedAutoSettlePullRequest(t, store, "acme/widget", 1, "merged")
+	seedAutoSettlePullRequest(t, store, "acme/widget", 2, "open")
+	now := time.Now().UTC().Add(72 * time.Hour)
+	if settled, err := store.SettleWorkflowIfEligible(ctx, label, now, 24*time.Hour); err != nil || settled {
+		t.Fatalf("settled with one open ref = %v, err=%v", settled, err)
+	}
+	seedAutoSettlePullRequest(t, store, "acme/widget", 2, "closed")
+	if settled, err := store.SettleWorkflowIfEligible(ctx, label, now, 24*time.Hour); err != nil || !settled {
+		t.Fatalf("settled after all refs terminal = %v, err=%v", settled, err)
+	}
+}
+
+func TestSettleWorkflowIgnoresRecentDaemonNoteAndIsIdempotent(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	const label = "release/daemon-quiet"
+	seedAutoSettleJob(t, store, "daemon-quiet-job", label, "succeeded", "acme/widget", 17)
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: label, Author: "operator", Body: "old human"}); err != nil {
+		t.Fatalf("insert human note: %v", err)
+	}
+	if _, inserted, err := store.InsertWorkflowAutoNoteWithMeta(ctx,
+		WorkflowNote{
+			WorkflowID: label,
+			Author:     WorkflowAutoNoteAuthor,
+			Body:       "[auto:pr:17:merged] PR #17 merged",
+			Repo:       "acme/widget",
+		},
+		WorkflowMeta{Status: string(WorkflowStatusActive), StatusSet: true}); err != nil || !inserted {
+		t.Fatalf("insert daemon receipt = (inserted=%v, err=%v)", inserted, err)
+	}
+	seedAutoSettlePullRequest(t, store, "acme/widget", 17, "merged")
+	now := time.Now().UTC().Add(72 * time.Hour)
+	setWorkflowNoteTimes(t, store, label, WorkflowAutoNoteAuthor, now.Add(-time.Minute))
+
+	candidates, err := store.ListWorkflowAutoSettleCandidates(ctx)
+	if err != nil || len(candidates) != 1 || candidates[0].WorkflowID != label ||
+		now.Sub(candidates[0].QuietAnchor) < 24*time.Hour {
+		t.Fatalf("candidates = %+v, err=%v", candidates, err)
+	}
+	settled, err := store.SettleWorkflowIfEligible(ctx, label, now, 24*time.Hour)
+	if err != nil || !settled {
+		t.Fatalf("first settle = %v, err=%v", settled, err)
+	}
+	settled, err = store.SettleWorkflowIfEligible(ctx, label, now.Add(time.Hour), 24*time.Hour)
+	if err != nil || settled {
+		t.Fatalf("repeat settle = %v, err=%v", settled, err)
+	}
+	notes, err := store.ListWorkflowNotes(ctx, label, 0)
+	if err != nil {
+		t.Fatalf("ListWorkflowNotes: %v", err)
+	}
+	settleNotes := 0
+	for _, note := range notes {
+		if note.Body == "[auto:workflow:settled] merged/closed PRs, quiet ≥ 24h0m0s" {
+			settleNotes++
+		}
+	}
+	if settleNotes != 1 {
+		t.Fatalf("settle note count = %d, notes=%+v", settleNotes, notes)
+	}
+
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: label, Author: "operator", Body: "new work"}); err != nil {
+		t.Fatalf("reopen with human note: %v", err)
+	}
+	meta, err := store.GetWorkflowMeta(ctx, label)
+	if err != nil || meta.Status != string(WorkflowStatusActive) {
+		t.Fatalf("meta after reopen = %+v, err=%v", meta, err)
+	}
+}
+
+func TestListWorkflowAutoSettleCandidatesExcludesProtectedStates(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	for _, status := range []WorkflowStatus{
+		WorkflowStatusParked,
+		WorkflowStatusDone,
+		WorkflowStatusSettled,
+		WorkflowStatusBlocked,
+	} {
+		label := "release/" + string(status)
+		seedAutoSettleJob(t, store, label+"-job", label, "succeeded", "acme/widget", 1)
+		if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+			WorkflowNote{WorkflowID: label, Author: "operator", Body: "protected"},
+			WorkflowMeta{Status: string(status), StatusSet: true}); err != nil {
+			t.Fatalf("seed %s: %v", status, err)
+		}
+	}
+	// A journal-only coordinator workflow with no PR reference can never settle,
+	// so it must be excluded from candidates (keeps the per-tick sweep bounded).
+	seedAutoSettleJob(t, store, "journal-job", "release/journal-only", "succeeded", "acme/widget", 0)
+	seedAutoSettleJob(t, store, "active-job", "release/active-candidate", "succeeded", "acme/widget", 1)
+	candidates, err := store.ListWorkflowAutoSettleCandidates(ctx)
+	if err != nil || len(candidates) != 1 || candidates[0].WorkflowID != "release/active-candidate" {
+		t.Fatalf("candidates = %+v, err=%v", candidates, err)
+	}
+}
+
+func seedAutoSettleJob(t *testing.T, store *Store, id, workflowID, state, repo string, pullRequest int) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"repo":%q,"workflow_id":%q,"pull_request":%d}`, repo, workflowID, pullRequest)
+	if err := store.CreateJob(context.Background(), Job{
+		ID: id, Agent: "worker", Type: "ask", State: state, Payload: payload,
+	}); err != nil {
+		t.Fatalf("CreateJob(%s): %v", id, err)
+	}
+}
+
+func seedAutoSettlePullRequest(t *testing.T, store *Store, repo string, number int64, state string) {
+	t.Helper()
+	if err := store.UpsertPullRequest(context.Background(), PullRequest{
+		RepoFullName: repo,
+		Number:       number,
+		URL:          fmt.Sprintf("https://example.invalid/%s/pull/%d", repo, number),
+		HeadBranch:   fmt.Sprintf("feature/%d", number),
+		BaseBranch:   "main",
+		State:        state,
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest(%s#%d): %v", repo, number, err)
+	}
+}
+
+func setWorkflowNoteTimes(t *testing.T, store *Store, workflowID, author string, at time.Time) {
+	t.Helper()
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE workflow_notes
+SET created_at = ? WHERE workflow_id = ? AND author = ?`,
+		at.UTC().Format("2006-01-02 15:04:05"), workflowID, author); err != nil {
+		t.Fatalf("set note times: %v", err)
+	}
+}
+
+func setWorkflowJobTime(t *testing.T, store *Store, jobID string, at time.Time) {
+	t.Helper()
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE jobs SET updated_at = ? WHERE id = ?`,
+		at.UTC().Format("2006-01-02 15:04:05"), jobID); err != nil {
+		t.Fatalf("set job time: %v", err)
 	}
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1344,6 +1344,18 @@ success without another close note. A later note without an explicit
 `--status` records a preceding `[auto:workflow:reopened]` receipt and returns
 the workflow to `active`; an explicit status remains authoritative.
 
+The daemon conservatively auto-settles a workflow only when it references at
+least one PR, every referenced PR is locally known as merged or closed, no job
+is queued or running, its status is not `blocked`/`parked`/`done`/`settled`
+(deliberate human-set states are never auto-settled), and the latest human note
+or job update has been quiet for `[workflow].auto_settle_after` (default `24h`;
+set `"0"` to disable). Daemon receipts do not extend the quiet period.
+Auto-settle appends an `[auto:workflow:settled]` note, sets status to `settled`,
+never deletes data, and any later note revives the workflow. Two edges are
+reversible-by-note rather than auto-revived: a task paused at `awaiting_human`
+(still shown in the dashboard Attention section regardless of workflow status),
+and a PR reopened after auto-settle — post a workflow note to revive it.
+
 For a workflow-linked PR, the daemon adds a structured `[auto:pr:...]` note as
 author `daemon` and advances status when the PR opens, checks turn green, and it
 merges or closes without merging. The structured workflow/PR/transition key

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1179,6 +1179,18 @@ note. A later note without explicit `--status` writes a preceding
 `[auto:workflow:reopened]` receipt and returns the workflow to `active`;
 explicit status remains authoritative.
 
+The daemon conservatively auto-settles a workflow only when it references at
+least one PR, every referenced PR is locally known as merged or closed, no job
+is queued or running, its status is not `blocked`/`parked`/`done`/`settled`
+(deliberate human-set states are never auto-settled), and the latest human note
+or job update has been quiet for `[workflow].auto_settle_after` (default `24h`;
+set `"0"` to disable). Daemon receipts do not extend the quiet period.
+Auto-settle appends an `[auto:workflow:settled]` note, sets status to `settled`,
+never deletes data, and any later note revives the workflow. Two edges are
+reversible-by-note rather than auto-revived: a task paused at `awaiting_human`
+(still shown in the dashboard Attention section regardless of workflow status),
+and a PR reopened after auto-settle — post a workflow note to revive it.
+
 Linked PR transitions add structured `[auto:pr:...]` notes as author `daemon`
 and advance status at open, checks-green/ready-to-merge, and merged or
 closed-without-merging. The workflow/PR/transition key deduplicates poll replays,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10949,7 +10949,8 @@ gitmoot job list --workflow fable/dashboard-redesign
 gitmoot workflow list
 gitmoot workflow show fable/dashboard-redesign --limit 100
 gitmoot workflow describe fable/dashboard-redesign "Coordinate and ship the dashboard redesign."
-gitmoot workflow note fable/dashboard-redesign "Kickoff." --author operator --status "Implementation started"
+gitmoot workflow note fable/dashboard-redesign "Implementation started." --author operator --status active
+gitmoot workflow close fable/dashboard-redesign --reason "Shipped and verified."
 ```
 
 `workflow list` reports per-state counts, note count, first/last activity, and
@@ -10962,7 +10963,9 @@ while queued/running, `recent` when no work is live but activity occurred within
 30 minutes, `stalled` when failed/blocked with an unacknowledged failure (newer
 than any non-daemon journal note and any merged-PR daemon receipt; other daemon
 receipts never acknowledge) and quiet for 30 minutes to 24 hours, and `settled`
-otherwise. The optional
+otherwise. A workflow whose status is `done` or `settled` leaves the active
+bucket immediately regardless of note recency, unless it has queued/running
+work. The optional
 `--pane`, `--session`, and `--workdir` note flags persist the latest coordinator
 handoff shown on that page. When those flags are omitted inside Herdr
 (`HERDR_SOCKET_PATH` or `HERDR_ENV=1`), `workflow note` reads the current pane
@@ -10978,8 +10981,30 @@ issue title, else the first kickoff-note sentence, else the label campaign.
 `workflow describe <label> "<text>"` overrides it. Legacy `workflow note
 --summary` remains an alias for description and also mirrors the value into the
 retained summary field for older clients. `workflow note --status "..."` is the
-manual status escape hatch. Each field is stored verbatim and limited to 300
+manual status control and accepts only `active`, `blocked`, `ready_to_merge`,
+`done`, `settled`, or `parked` (plus an explicit empty value to unset it).
+Put free-text detail in the note body. Existing legacy status strings remain
+readable but cannot be written anew. Each metadata field is limited to 300
 bytes.
+
+`workflow close <label> [--reason "..."]` refuses workflows with queued/running
+jobs, appends a typed `[workflow:close]` journal note, and sets status to `done`
+atomically. Repeating close on a `done` or `settled` workflow is an idempotent
+success without another close note. A later note without an explicit
+`--status` records a preceding `[auto:workflow:reopened]` receipt and returns
+the workflow to `active`; an explicit status remains authoritative.
+
+The daemon conservatively auto-settles a workflow only when it references at
+least one PR, every referenced PR is locally known as merged or closed, no job
+is queued or running, its status is not `blocked`/`parked`/`done`/`settled`
+(deliberate human-set states are never auto-settled), and the latest human note
+or job update has been quiet for `[workflow].auto_settle_after` (default `24h`;
+set `"0"` to disable). Daemon receipts do not extend the quiet period.
+Auto-settle appends an `[auto:workflow:settled]` note, sets status to `settled`,
+never deletes data, and any later note revives the workflow. Two edges are
+reversible-by-note rather than auto-revived: a task paused at `awaiting_human`
+(still shown in the dashboard Attention section regardless of workflow status),
+and a PR reopened after auto-settle — post a workflow note to revive it.
 
 For a workflow-linked PR, the daemon adds a structured `[auto:pr:...]` note as
 author `daemon` and advances status when the PR opens, checks turn green, and it


### PR DESCRIPTION
## What

Workflow lifecycle hygiene (#1094), **slice 3** — conservative daemon **auto-settle**: a workflow whose referenced PRs are all merged/closed, with no live jobs, quiet past a configurable horizon, is marked `settled` automatically. Never deletes; any later note revives it (the reopen-on-note path from #1103). This closes the loop on rotting/zombie workflows after a wave. No migration.

## Changes

- **Config** `[workflow] auto_settle_after` (`internal/config/workflow_lifecycle.go`, own independent scanner like `implement_base`): a Go duration, **default 24h**, **`0` disables**. Documented (commented) in `DefaultConfig`.
- **Store evaluator** (`internal/db/workflow_lifecycle_store.go`):
  - `WorkflowPullRequestRefs` — the **union** of `(repo, pull_request)` from workflow-linked jobs and PR numbers parsed from structured `[auto:pr:N:*]` daemon notes (covers branch-fallback jobs whose scalar PR is 0). An unresolved (empty-repo) ref is kept so eligibility fails closed.
  - `ListWorkflowAutoSettleCandidates` — non-terminal, non-parked workflows (`COALESCE(status,'') NOT IN ('parked','done','settled')`).
  - `SettleWorkflowIfEligible` — the **authoritative gate**, one transaction, **re-checks every condition in-tx** (defeats scan→settle races): status not terminal/parked, **≥1 PR ref** (zero-PR never settles), **every ref's local `pull_requests` row is `merged`/`closed`** (missing or `open` **fails closed**), no `queued`/`running` jobs, and quiet `now-anchor ≥ after` where the anchor is `max(last non-daemon note, last job update)` — daemon receipts never extend quiet. On pass it appends a daemon `[auto:workflow:settled]` note and sets `settled`. Idempotent, never deletes.
- **Daemon sweep** (`internal/cli/workflow_lifecycle.go` `runWorkflowAutoSettleOnce`, wired into `runRegisteredRepoSupervisor`'s `!dryRun` maintenance block after the repo poll): once per **host** iteration. Disabled (`after<=0`) is an immediate early return (hot-path byte-identical). Per-candidate and top-level errors are **logged, never fatal** — a bad workflow can't abort daemon maintenance.
- **Docs**: `CLI.md` + website `cli.md` — the conditions, the config, and the explicit limitation below.

## Scope / limitation (deliberate)

The **reopened-PR-after-settle edge** is intentionally a separate follow PR (#TBD): a PR reopened *before* settlement blocks it (eligibility reads current `pull_requests.state`), but a PR reopened *after* a workflow has auto-settled does not by itself revive it — post a note to revive. That auto-revive touches the hot `UpsertPullRequest` poller seam (different blast radius) and is scoped out here so this daemon-evaluator PR stays reviewable. Documented in the CLI docs.

## Review — high (two fresh finders, isolated worktrees, de-anchored)

**No HIGH defects.** Both finders verified the fail-closed invariant holds *by compute* (not just by test): every gate — missing/open PR row, zero refs, queued/running job, zero/future/insufficient quiet — is re-checked in-tx; the `[auto:pr:N]` parser is robust against adversarial bodies; ambiguous/empty-repo refs fail closed; the quiet anchor correctly excludes daemon receipts; the settle is idempotent, reversible, TOCTOU-safe, and never deletes; config parsing is section-scoped and warm-reload-safe; the no-LLM E2E is genuine (temp home, no sleeps, non-vacuous negatives). Findings applied:

- **Excluded `blocked` status from auto-settle** (owner-ruled): a workflow a coordinator deliberately marked `blocked` (awaiting a human/owner decision) is a human-set signal and is now never auto-settled — added to both the candidate query and the in-tx recheck, with tests. (The `awaiting_human` task state stays surfaced by the dashboard Attention section independently of workflow status, and a `blocked` job is already a settled job state per `IsSettledJobState`; both are revive-by-note and documented.)
- **Bounded the per-tick sweep**: the candidate query now requires ≥1 PR ref (journal-only coordinator workflows can never settle, so they no longer open a no-op transaction each tick), and the sweep skips not-yet-quiet candidates using the already-computed anchor before opening any transaction.
- **Wired auto-settle into the single-repo supervisor too** (was registered-repo only, so a `daemon --repo X` deployment would never have settled).

All build/vet/gofmt + full `internal/db`/`internal/cli`/`internal/config` suites green after the fixes.

## Sequence

Slice 3 of #1094: merge-hook (#1101) → enum/close/reopen/dashboard (#1103) → **auto-settle (this)** → reopened-PR edge (small follow). No deploy (judging window). Merge owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
