### PR TITLE
fix(dashboard): terminal workflow status wins over a lingering job (#1106)

### DIFF
--- a/internal/cli/dashboard_web_workflow_test.go
+++ b/internal/cli/dashboard_web_workflow_test.go
@@ -30,8 +30,11 @@ func TestDeriveDashboardWorkflowState(t *testing.T) {
 	}{
 		{name: "running stays active", activity: dashboardWorkflowActivity{Running: 1, LastActivity: now.Add(-48 * time.Hour)}, state: "active"},
 		{name: "queued stays active", activity: dashboardWorkflowActivity{Queued: 1, LastActivity: now.Add(-48 * time.Hour)}, state: "active"},
-		{name: "terminal with running work stays active", activity: dashboardWorkflowActivity{Running: 1, LastActivity: now.Add(-48 * time.Hour)}, status: "done", state: "active"},
-		{name: "terminal with queued work stays active", activity: dashboardWorkflowActivity{Queued: 1, LastActivity: now.Add(-48 * time.Hour)}, status: "settled", state: "active"},
+		// #1106: a deliberate terminal status wins over a lingering job. A coordinator
+		// workflow born via `job open` has a perpetually-running job, so an explicitly
+		// closed (`done`) workflow must NOT read active; revival is note-based.
+		{name: "done with running coordinator job is settled", activity: dashboardWorkflowActivity{Running: 1, LastActivity: now.Add(-48 * time.Hour)}, status: "done", state: "settled"},
+		{name: "settled with queued job is settled", activity: dashboardWorkflowActivity{Queued: 1, LastActivity: now.Add(-48 * time.Hour)}, status: "settled", state: "settled"},
 		{name: "recent done is settled", activity: dashboardWorkflowActivity{LastActivity: now.Add(-10 * time.Minute)}, status: "done", state: "settled"},
 		{name: "recent settled is settled", activity: dashboardWorkflowActivity{LastActivity: now.Add(-10 * time.Minute)}, status: "settled", state: "settled"},
 		{name: "recent quiet is recent", activity: dashboardWorkflowActivity{LastActivity: now.Add(-10 * time.Minute)}, state: "recent"},
@@ -92,6 +95,45 @@ func TestDashboardWorkflowTerminalStatusIndexAndDetailAgree(t *testing.T) {
 	}
 	if entries[0].State != "settled" || detail.State != "settled" {
 		t.Fatalf("terminal state mismatch: index=%q detail=%q", entries[0].State, detail.State)
+	}
+}
+
+// TestDashboardClosedWorkflowWithRunningJobIsNotActive pins #1106 on the consumed
+// /api/workflows path: a coordinator workflow born via `job open` keeps a
+// perpetually-running job, so closing it (status=done) must leave the active
+// bucket -- the terminal status wins over the lingering running job.
+func TestDashboardClosedWorkflowWithRunningJobIsNotActive(t *testing.T) {
+	t.Parallel()
+	home, store := workflowJournalTestHome(t)
+	ctx := context.Background()
+	const label = "g4/1106-repro"
+	payload := workflow.JobPayload{WorkflowID: label, Repo: "acme/widget", TaskTitle: "Coordinator track"}
+	if err := store.CreateJob(ctx, db.Job{
+		ID: "coordinator-job", Agent: "coord", Type: "ask", State: "running", Payload: mustJSON(t, payload),
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: label, Author: "operator", Body: "[workflow:close] done"},
+		db.WorkflowMeta{Status: string(db.WorkflowStatusDone), StatusSet: true}); err != nil {
+		t.Fatalf("InsertWorkflowNoteWithMeta: %v", err)
+	}
+	store.Close()
+
+	ds := &webDataSource{home: home}
+	entries, err := ds.Workflows(ctx)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("Workflows = %+v, err=%v", entries, err)
+	}
+	detail, err := ds.Workflow(ctx, label, dashboard.WorkflowQuery{})
+	if err != nil {
+		t.Fatalf("Workflow: %v", err)
+	}
+	if entries[0].State == "active" || detail.State == "active" {
+		t.Fatalf("closed workflow with running job read active: index=%q detail=%q", entries[0].State, detail.State)
+	}
+	if entries[0].State != "settled" || detail.State != "settled" {
+		t.Fatalf("want settled, got index=%q detail=%q", entries[0].State, detail.State)
 	}
 }
 

--- a/internal/cli/dashboard_web_workflows.go
+++ b/internal/cli/dashboard_web_workflows.go
@@ -45,11 +45,18 @@ func dashboardActivityFromSummary(summary db.WorkflowSummary, lastAt int64) dash
 // workflow index and detail responses.
 func deriveDashboardWorkflowState(now time.Time, activity dashboardWorkflowActivity, status string) (state string, stalledForS int64) {
 	age := now.Sub(activity.LastActivity)
-	if activity.Queued > 0 || activity.Running > 0 {
-		return "active", 0
-	}
+	// A deliberate terminal status (`done` via close, `settled` via auto-settle or
+	// manual --status) leaves the active bucket regardless of note recency AND of
+	// any lingering job. This MUST precede the live-job check: a coordinator
+	// workflow born via `job open` keeps a perpetually-running job for the life of
+	// the coordination, so an explicitly-closed workflow would otherwise read
+	// `active` forever (#1106). Revival is note-based -- reopen-on-note flips a
+	// terminal workflow back to non-terminal, after which live work shows active.
 	if db.IsTerminalWorkflowStatus(status) {
 		return "settled", 0
+	}
+	if activity.Queued > 0 || activity.Running > 0 {
+		return "active", 0
 	}
 	// A merged receipt records the daemon's observation time (note created_at),
 	// not the true GitHub merge time. A failure landing in the poll window before


### PR DESCRIPTION
## What

Fixes #1106 — closed (`status=done`) workflows still showed `state=active` on the deployed `/api/workflows` (the owner-visible dashboard). Root-caused against live data, not guessed.

## Root cause (not a second site, not a string mismatch)

`deriveDashboardWorkflowState` (the **single** state-derivation site — both the index `dashboard_web.go` and detail `dashboard_web_workflows.go` callers share it) checked `queued/running → active` **before** the terminal-status check. A coordinator workflow born via `gitmoot job open` keeps a **perpetually-running** `job open` job for the life of the coordination, so an explicitly-closed (`done`) coordinator workflow matched the live-job rule and returned `active` before the terminal rule was ever reached.

Live probe of `/api/workflows` @ `9aec27f` confirmed the mechanism precisely: all **8** `done`-but-`active` workflows have `run=1` (a running coordinator job); all **6** `done`-and-`settled` workflows have `run=0`. The terminal check was already running on this path — it was just being pre-empted.

This also means my #1103 test literally **pinned the bug**: `"terminal with running work stays active"` asserted the wrong invariant. That test is corrected here.

## Fix

Reorder `deriveDashboardWorkflowState` so a deliberate terminal status (`done`/`settled`) wins over a lingering job. Revival is **note-based** — reopen-on-note (#1103) flips a terminal workflow back to non-terminal, after which live work shows `active` again. This is consistent with #1104's auto-settle design (a settled workflow is revived by a note, not by job presence), so status and displayed state now agree. The non-terminal derivation (stalled/recent/settled) is unchanged.

## Test — pins `done ⇒ never active` on the consumed path

- Corrected the two inverted `TestDeriveDashboardWorkflowState` cases (`done`/`settled` + running/queued ⇒ **settled**, not active).
- Added `TestDashboardClosedWorkflowWithRunningJobIsNotActive` — an end-to-end test through `webDataSource.Workflows`/`.Workflow` (the exact `/api/workflows` index+detail path): a `done` workflow with a **running** job must not read `active`.

## Deploy

The fix is in the dashboard server derivation. Deploying it (dashboard-web binary) clears the 8 stuck workflows immediately — no data change; the underlying `status=done` was already correct. Owner-gated as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
