### PR TITLE
feat(org): Org page polish: display_name, presence persistence, detection + em-dash fixes (#1105)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723064525-d72a54e99794
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723124035-b9d840a702c3
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723064525-d72a54e99794 h1:SeSgFLxrR6Ho/P5iY7e527ovtvwnNmOEeoQrkMsAM/U=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723064525-d72a54e99794/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723124035-b9d840a702c3 h1:mawlWcfhVSF1HNgPpv6OLXRbV6Ar/9FAYQbHtTVqQj0=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723124035-b9d840a702c3/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -213,8 +213,32 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 		writeLine(stdout, "blocked_since role snapshot skipped: observed_at is zero")
 		return
 	}
+	persistOrgRoleLivePresence(ctx, store, snapshot, stdout)
 	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snapshot, wakeAfter, stdout, now.UTC()); err != nil {
 		writeLine(stdout, "blocked_since role evaluation failed: %v", err)
+	}
+}
+
+func persistOrgRoleLivePresence(ctx context.Context, store *db.Store, snapshot org.Snapshot, stdout io.Writer) {
+	roles := make([]string, 0, len(snapshot.States))
+	persistedAll := true
+	for role, live := range snapshot.States {
+		role = strings.TrimSpace(role)
+		if role == "" {
+			continue
+		}
+		if err := store.UpsertRoleLivePresence(ctx, role, string(live.State), snapshot.ObservedAt); err != nil {
+			writeLine(stdout, "blocked_since role live presence persist failed for %s: %v", role, err)
+			persistedAll = false
+			continue
+		}
+		roles = append(roles, role)
+	}
+	// Do not prune a previously complete snapshot after a partial write failure.
+	if persistedAll {
+		if err := store.DeleteRoleLivePresenceExcept(ctx, roles); err != nil {
+			writeLine(stdout, "blocked_since role live presence reap failed: %v", err)
+		}
 	}
 }
 

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -164,6 +164,14 @@ blocked_role_wake_after = "1h"
 	}
 	var output bytes.Buffer
 	runBlockedRoleWakeOnce(context.Background(), store, home, &output, now, deps)
+	livePresence, err := store.ListRoleLivePresence(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(livePresence) != 2 || livePresence[0].Role != "owner" || livePresence[0].State != string(org.StateBlocked) ||
+		livePresence[1].Role != "review" || livePresence[1].State != string(org.StateIdle) {
+		t.Fatalf("persisted live presence = %+v", livePresence)
+	}
 	blocked := sink.byType(events.EventJobBlocked)
 	if len(blocked) != 1 {
 		t.Fatalf("job.blocked events = %d, want 1; output=%s", len(blocked), output.String())
@@ -183,6 +191,17 @@ blocked_role_wake_after = "1h"
 	}
 	if availability.calls != 2 {
 		t.Fatalf("availability calls = %d, want 2", availability.calls)
+	}
+
+	snapshot.States = map[string]org.RoleLiveState{"owner": {State: org.StateWorking}}
+	deps.provider = func([]config.OrgRole) org.Provider { return orgFixtureProvider{snapshot: snapshot} }
+	runBlockedRoleWakeOnce(context.Background(), store, home, io.Discard, now.Add(2*time.Minute), deps)
+	livePresence, err = store.ListRoleLivePresence(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(livePresence) != 1 || livePresence[0].Role != "owner" || livePresence[0].State != string(org.StateWorking) {
+		t.Fatalf("persisted live presence after reap = %+v", livePresence)
 	}
 }
 

--- a/internal/cli/dashboard_web_org.go
+++ b/internal/cli/dashboard_web_org.go
@@ -27,8 +27,8 @@ func (d *webDataSource) Org(ctx context.Context) (dashboard.OrgView, error) {
 		return dashboard.OrgView{}, err
 	}
 	// Org-less deployments (the default, plus non-org dashboard hosts) degrade to
-	// an empty view — the page shows the "Org not configured" empty state — rather
-	// than surfacing the "registry disabled" error as an HTTP 500.
+	// an empty view. The page shows the "Org not configured" empty state instead
+	// of surfacing the "registry disabled" error as an HTTP 500.
 	if cfg, cfgErr := config.LoadOrg(paths); cfgErr == nil && !cfg.Enabled() {
 		return dashboard.OrgView{Roles: []dashboard.OrgNode{}, Escalations: []dashboard.OrgEscalation{}, Feed: []dashboard.OrgFeedRow{}}, nil
 	}
@@ -39,7 +39,7 @@ func (d *webDataSource) Org(ctx context.Context) (dashboard.OrgView, error) {
 			return err
 		}
 		body, _, err := d.cacheForDashboard().get(ctx, "org", cursor, dashboardOrgCachePolicy, func(cacheCtx context.Context) ([]byte, error) {
-			view, err := buildDashboardOrg(cacheCtx, paths, store, d.home, time.Now().UTC())
+			view, err := buildDashboardOrg(cacheCtx, paths, store, time.Now().UTC())
 			if err != nil {
 				return nil, err
 			}
@@ -107,7 +107,7 @@ type dashboardOrgInputs struct {
 	dataAsOf         time.Time
 }
 
-func loadDashboardOrgInputs(ctx context.Context, paths config.Paths, store *db.Store, home string) (dashboardOrgInputs, error) {
+func loadDashboardOrgInputs(ctx context.Context, paths config.Paths, store *db.Store) (dashboardOrgInputs, error) {
 	shared, err := loadOrgSharedState(ctx, paths, store)
 	if err != nil {
 		return dashboardOrgInputs{}, err
@@ -141,11 +141,17 @@ func loadDashboardOrgInputs(ctx context.Context, paths config.Paths, store *db.S
 		return dashboardOrgInputs{}, err
 	}
 
-	wakeAfter := resolveBlockedRoleWakeAfter(home)
+	policy, policyErr := config.LoadOrchestratePolicy(paths)
+	wakeAfter := time.Duration(0)
+	if policyErr == nil {
+		wakeAfter = policy.BlockedRoleWakeAfter
+	}
 	enabledRules := hasEnabledEventRule(rules)
 	enabled := wakeAfter > 0 && enabledRules
 	hint := ""
 	switch {
+	case policyErr != nil:
+		hint = "blocked detection off - orchestrate policy is unreadable"
 	case wakeAfter <= 0:
 		hint = "blocked detection off - blocked_role_wake_after is disabled"
 	case !enabledRules:
@@ -159,6 +165,9 @@ func loadDashboardOrgInputs(ctx context.Context, paths config.Paths, store *db.S
 	}
 	for _, presence := range shared.Presence {
 		inputs.observe(presence.LastSeenAt)
+	}
+	for _, presence := range shared.livePresence {
+		inputs.observe(presence.ObservedAt)
 	}
 	for _, episode := range blocked {
 		inputs.observe(episode.UpdatedAt)
@@ -184,8 +193,8 @@ func (i *dashboardOrgInputs) observe(value string) {
 	}
 }
 
-func buildDashboardOrg(ctx context.Context, paths config.Paths, store *db.Store, home string, now time.Time) (dashboard.OrgView, error) {
-	inputs, err := loadDashboardOrgInputs(ctx, paths, store, home)
+func buildDashboardOrg(ctx context.Context, paths config.Paths, store *db.Store, now time.Time) (dashboard.OrgView, error) {
+	inputs, err := loadDashboardOrgInputs(ctx, paths, store)
 	if err != nil {
 		return dashboard.OrgView{}, err
 	}
@@ -205,7 +214,7 @@ func buildDashboardOrg(ctx context.Context, paths config.Paths, store *db.Store,
 		recycleAfter := inputs.shared.Config.RecycleAfterFor(row.Role)
 		_, overdue := dashboardOrgRecycleTiming(row.LastSeenAt, now, recycleAfter)
 		node := dashboard.OrgNode{
-			Name: row.Role, Parent: row.Parent, Depth: row.Depth,
+			Name: row.Role, DisplayName: dashboardOrgDisplayName(inputs.shared.Config, row.Role), Parent: row.Parent, Depth: row.Depth,
 			Scope: append([]string{}, row.Scope...), MergeRule: row.MergeRule, Pane: row.Pane,
 			PresenceState:  dashboardOrgPresenceState(row.ProviderState),
 			PresenceDetail: row.ProviderDetail,
@@ -290,7 +299,7 @@ func buildDashboardOrgRole(ctx context.Context, paths config.Paths, store *db.St
 	remaining, overdue := dashboardOrgRecycleTiming(row.LastSeenAt, now, shared.Config.RecycleAfterFor(role.Name))
 	out := dashboard.OrgRoleView{
 		Identity: dashboard.OrgRoleIdentity{
-			Name: role.Name, Parent: role.Parent, MergeRule: role.MergeRule, Pane: role.Pane,
+			Name: role.Name, DisplayName: role.DisplayName, Parent: role.Parent, MergeRule: role.MergeRule, Pane: role.Pane,
 			Scope: append([]string{}, role.Scope...), Depth: len(path) - 1, Path: append([]string{}, path...),
 		},
 		Presence: dashboard.OrgRolePresence{
@@ -329,6 +338,11 @@ func dashboardOrgPresenceState(state org.LifecycleState) string {
 	default:
 		return "never-seen"
 	}
+}
+
+func dashboardOrgDisplayName(cfg config.OrgConfig, role string) string {
+	configured, _ := cfg.Role(role)
+	return configured.DisplayName
 }
 
 func dashboardOrgBlockedSince(episodes []db.BlockedEpisode) map[string]string {

--- a/internal/cli/dashboard_web_org.go
+++ b/internal/cli/dashboard_web_org.go
@@ -107,6 +107,17 @@ type dashboardOrgInputs struct {
 	dataAsOf         time.Time
 }
 
+// hasFreshLivePresence reports whether any persisted Herdr snapshot row is still
+// within the read freshness window, i.e. the daemon is actually persisting.
+func hasFreshLivePresence(rows map[string]db.RoleLivePresence, now time.Time) bool {
+	for _, row := range rows {
+		if observedAt, ok := parseOrgPresenceTime(row.ObservedAt); ok && !observedAt.After(now) && now.Sub(observedAt) <= storeOrgLivePresenceMaxAge {
+			return true
+		}
+	}
+	return false
+}
+
 func loadDashboardOrgInputs(ctx context.Context, paths config.Paths, store *db.Store) (dashboardOrgInputs, error) {
 	shared, err := loadOrgSharedState(ctx, paths, store)
 	if err != nil {
@@ -156,6 +167,13 @@ func loadDashboardOrgInputs(ctx context.Context, paths config.Paths, store *db.S
 		hint = "blocked detection off - blocked_role_wake_after is disabled"
 	case !enabledRules:
 		hint = "blocked detection off - no enabled org event rules"
+	}
+	// Detection is configured on, but the daemon only persists live presence after
+	// passing its own Herdr-availability gate. If nothing fresh has been written,
+	// the page would otherwise show every role never-seen with no explanation, so
+	// distinguish "configured off" from "on but no data yet".
+	if enabled && !hasFreshLivePresence(shared.livePresence, time.Now().UTC()) {
+		hint = "blocked detection on, waiting for live presence (the daemon or Herdr may be unavailable)"
 	}
 
 	inputs := dashboardOrgInputs{

--- a/internal/cli/dashboard_web_org_test.go
+++ b/internal/cli/dashboard_web_org_test.go
@@ -69,6 +69,12 @@ func TestDashboardOrgDataSourceStoreBackedProjection(t *testing.T) {
 
 	base := time.Now().UTC().Truncate(time.Second)
 	sourceMax := base.Add(5 * time.Hour)
+	if err := store.UpsertRoleLivePresence(ctx, "owner", "working", base); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertRoleLivePresence(ctx, "review", "blocked", base); err != nil {
+		t.Fatal(err)
+	}
 	if err := store.UpsertBlockedEpisode(ctx, "role:review", base.Add(-2*time.Hour), base.Add(-time.Hour)); err != nil {
 		t.Fatal(err)
 	}
@@ -145,6 +151,9 @@ func TestDashboardOrgDataSourceStoreBackedProjection(t *testing.T) {
 	if len(view.Roles) != 2 || view.Roles[0].Name != "owner" || view.Roles[1].Name != "review" {
 		t.Fatalf("roles = %+v", view.Roles)
 	}
+	if view.Roles[0].DisplayName != "Owner" {
+		t.Fatalf("owner display_name = %q", view.Roles[0].DisplayName)
+	}
 	if view.Roles[0].PresenceState != "working" || view.Roles[0].Badges.Overdue == "" {
 		t.Fatalf("owner = %+v", view.Roles[0])
 	}
@@ -180,7 +189,7 @@ func TestDashboardOrgDataSourceStoreBackedProjection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if role.Identity.Name != "owner" || len(role.Identity.Path) != 1 || role.Presence.State != "working" {
+	if role.Identity.Name != "owner" || role.Identity.DisplayName != "Owner" || len(role.Identity.Path) != 1 || role.Presence.State != "working" {
 		t.Fatalf("owner role = %+v", role)
 	}
 	if role.Recycle.LastHandoffText != "Latest handoff." || role.Recycle.LastHandoffAt == "" || role.Recycle.Overdue == "" {
@@ -227,6 +236,51 @@ func TestDashboardOrgDetectionDisabledIsHonest(t *testing.T) {
 	}
 	if view.DetectionEnabled || !strings.Contains(view.DetectionHint, "no enabled org event rules") {
 		t.Fatalf("detection = %v hint %q", view.DetectionEnabled, view.DetectionHint)
+	}
+}
+
+func TestDashboardOrgDetectionUsesLoadedOrchestratePolicy(t *testing.T) {
+	tests := []struct {
+		name        string
+		enableKnob  bool
+		wantEnabled bool
+		wantHint    string
+	}{
+		{name: "configured", enableKnob: true, wantEnabled: true},
+		{name: "zero knob", wantHint: "blocked_role_wake_after is disabled"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home, paths := setupOrgHome(t)
+			if test.enableKnob {
+				enableDashboardOrgDetection(t, paths.ConfigFile)
+			}
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := store.AddEventRule(context.Background(), db.EventRule{
+				ID: "org-signals", OnKind: "blocked", WakeRole: "owner", Enabled: true,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := store.Close(); err != nil {
+				t.Fatal(err)
+			}
+			view, err := (&webDataSource{home: home}).Org(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if view.DetectionEnabled != test.wantEnabled {
+				t.Fatalf("DetectionEnabled = %v, want %v (hint %q)", view.DetectionEnabled, test.wantEnabled, view.DetectionHint)
+			}
+			if test.wantHint == "" && view.DetectionHint != "" {
+				t.Fatalf("DetectionHint = %q, want empty", view.DetectionHint)
+			}
+			if test.wantHint != "" && !strings.Contains(view.DetectionHint, test.wantHint) {
+				t.Fatalf("DetectionHint = %q, want substring %q", view.DetectionHint, test.wantHint)
+			}
+		})
 	}
 }
 

--- a/internal/cli/dashboard_web_org_test.go
+++ b/internal/cli/dashboard_web_org_test.go
@@ -243,10 +243,12 @@ func TestDashboardOrgDetectionUsesLoadedOrchestratePolicy(t *testing.T) {
 	tests := []struct {
 		name        string
 		enableKnob  bool
+		seedLive    bool
 		wantEnabled bool
 		wantHint    string
 	}{
-		{name: "configured", enableKnob: true, wantEnabled: true},
+		{name: "configured with live presence", enableKnob: true, seedLive: true, wantEnabled: true},
+		{name: "configured but no live presence yet", enableKnob: true, wantEnabled: true, wantHint: "waiting for live presence"},
 		{name: "zero knob", wantHint: "blocked_role_wake_after is disabled"},
 	}
 	for _, test := range tests {
@@ -263,6 +265,11 @@ func TestDashboardOrgDetectionUsesLoadedOrchestratePolicy(t *testing.T) {
 				ID: "org-signals", OnKind: "blocked", WakeRole: "owner", Enabled: true,
 			}); err != nil {
 				t.Fatal(err)
+			}
+			if test.seedLive {
+				if err := store.UpsertRoleLivePresence(context.Background(), "owner", "working", time.Now().UTC()); err != nil {
+					t.Fatal(err)
+				}
 			}
 			if err := store.Close(); err != nil {
 				t.Fatal(err)

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -15,6 +15,8 @@ import (
 
 type orgLiveSource func(ctx context.Context, cfg config.OrgConfig) (states map[string]org.RoleLiveState, observedAt time.Time, providerVersion string, err error)
 
+const storeOrgLivePresenceMaxAge = 5 * time.Minute
+
 type orgSharedState struct {
 	Config          config.OrgConfig
 	Presence        map[string]db.OrgRolePresence
@@ -26,6 +28,8 @@ type orgSharedState struct {
 	jobCountsLoaded bool
 	blockedEpisodes []db.BlockedEpisode
 	blockedLoaded   bool
+	livePresence    map[string]db.RoleLivePresence
+	liveLoaded      bool
 }
 
 type orgLiveSourceError struct {
@@ -86,39 +90,50 @@ func herdrOrgLiveSource(ctx context.Context, cfg config.OrgConfig) (map[string]o
 	return snapshot.States, snapshot.ObservedAt, snapshot.ProviderVersion, err
 }
 
-// storeOrgLiveSource derives live state entirely from persisted Gitmoot data.
-// It does not construct or contact a Herdr provider.
+// storeOrgLiveSource derives live state entirely from the latest persisted
+// Herdr snapshot. It does not construct or contact a Herdr provider.
 func storeOrgLiveSource(shared *orgSharedState) orgLiveSource {
 	return func(ctx context.Context, cfg config.OrgConfig) (map[string]org.RoleLiveState, time.Time, string, error) {
-		episodes, err := shared.loadBlockedEpisodes(ctx)
+		presence, err := shared.loadLivePresence(ctx)
 		if err != nil {
 			return nil, time.Time{}, "", err
 		}
-		jobCounts, err := shared.loadJobCounts(ctx)
-		if err != nil {
-			return nil, time.Time{}, "", err
-		}
-		blocked := make(map[string]bool)
-		for _, episode := range episodes {
-			if strings.HasPrefix(episode.Subject, "role:") {
-				blocked[strings.TrimPrefix(episode.Subject, "role:")] = true
-			}
-		}
+		now := time.Now().UTC()
+		var latest time.Time
 		states := make(map[string]org.RoleLiveState, len(cfg.Roles()))
 		for _, role := range cfg.Roles() {
 			state := org.StateUnknown
-			switch {
-			case blocked[role.Name]:
-				state = org.StateBlocked
-			case jobCounts[role.Name]["running"] > 0:
-				state = org.StateWorking
-			case shared.Presence[role.Name].Role != "":
-				state = org.StateIdle
+			row, ok := presence[role.Name]
+			observedAt, parsed := parseOrgPresenceTime(row.ObservedAt)
+			if ok && parsed && !observedAt.After(now) && now.Sub(observedAt) <= storeOrgLivePresenceMaxAge {
+				switch org.LifecycleState(row.State) {
+				case org.StateBlocked, org.StateWorking, org.StateIdle:
+					state = org.LifecycleState(row.State)
+				}
+				if observedAt.After(latest) {
+					latest = observedAt
+				}
 			}
 			states[role.Name] = org.RoleLiveState{State: state}
 		}
-		return states, time.Now().UTC(), "store", nil
+		return states, latest, "store", nil
 	}
+}
+
+func (shared *orgSharedState) loadLivePresence(ctx context.Context) (map[string]db.RoleLivePresence, error) {
+	if shared.liveLoaded {
+		return shared.livePresence, nil
+	}
+	rows, err := shared.Store.ListRoleLivePresence(ctx)
+	if err != nil {
+		return nil, err
+	}
+	shared.livePresence = make(map[string]db.RoleLivePresence, len(rows))
+	for _, row := range rows {
+		shared.livePresence[row.Role] = row
+	}
+	shared.liveLoaded = true
+	return shared.livePresence, nil
 }
 
 func (shared *orgSharedState) loadBlockedEpisodes(ctx context.Context) ([]db.BlockedEpisode, error) {

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -98,20 +98,37 @@ func storeOrgLiveSource(shared *orgSharedState) orgLiveSource {
 		if err != nil {
 			return nil, time.Time{}, "", err
 		}
+		// Blocked stays sourced from org_blocked_episodes so the node dot cannot
+		// contradict the blocked_since badge, Health.Blocked, or the feed: an
+		// episode persists through a transient absent/unknown snapshot, while the
+		// live-presence row for that role is reaped or ages out of the freshness
+		// window. Working/idle come from the persisted Herdr snapshot.
+		episodes, err := shared.loadBlockedEpisodes(ctx)
+		if err != nil {
+			return nil, time.Time{}, "", err
+		}
+		blocked := make(map[string]bool, len(episodes))
+		for _, episode := range episodes {
+			if strings.HasPrefix(episode.Subject, "role:") {
+				blocked[strings.TrimPrefix(episode.Subject, "role:")] = true
+			}
+		}
 		now := time.Now().UTC()
 		var latest time.Time
 		states := make(map[string]org.RoleLiveState, len(cfg.Roles()))
 		for _, role := range cfg.Roles() {
 			state := org.StateUnknown
-			row, ok := presence[role.Name]
-			observedAt, parsed := parseOrgPresenceTime(row.ObservedAt)
-			if ok && parsed && !observedAt.After(now) && now.Sub(observedAt) <= storeOrgLivePresenceMaxAge {
-				switch org.LifecycleState(row.State) {
-				case org.StateBlocked, org.StateWorking, org.StateIdle:
-					state = org.LifecycleState(row.State)
-				}
-				if observedAt.After(latest) {
-					latest = observedAt
+			if blocked[role.Name] {
+				state = org.StateBlocked
+			} else if row, ok := presence[role.Name]; ok {
+				if observedAt, parsed := parseOrgPresenceTime(row.ObservedAt); parsed && !observedAt.After(now) && now.Sub(observedAt) <= storeOrgLivePresenceMaxAge {
+					switch org.LifecycleState(row.State) {
+					case org.StateWorking, org.StateIdle:
+						state = org.LifecycleState(row.State)
+						if observedAt.After(latest) {
+							latest = observedAt
+						}
+					}
 				}
 			}
 			states[role.Name] = org.RoleLiveState{State: state}

--- a/internal/cli/org_overview_test.go
+++ b/internal/cli/org_overview_test.go
@@ -9,20 +9,21 @@ import (
 	"github.com/gitmoot/gitmoot/internal/org"
 )
 
-func TestStoreOrgLiveSourcePrecedence(t *testing.T) {
+func TestStoreOrgLiveSourcePersistedFreshness(t *testing.T) {
+	fresh := time.Now().UTC().Add(-time.Minute)
 	tests := []struct {
-		name     string
-		presence bool
-		jobState string
-		blocked  string
-		want     org.LifecycleState
+		name       string
+		state      org.LifecycleState
+		observedAt time.Time
+		want       org.LifecycleState
 	}{
-		{name: "blocked wins over working", presence: true, jobState: "running", blocked: "role:review", want: org.StateBlocked},
-		{name: "working wins over idle", presence: true, jobState: "running", want: org.StateWorking},
-		{name: "queued is not working", presence: true, jobState: "queued", want: org.StateIdle},
-		{name: "task episode does not block role", presence: true, blocked: "task:repo:review", want: org.StateIdle},
-		{name: "presence is idle", presence: true, want: org.StateIdle},
-		{name: "never seen", want: org.StateUnknown},
+		{name: "fresh blocked", state: org.StateBlocked, observedAt: fresh, want: org.StateBlocked},
+		{name: "fresh working", state: org.StateWorking, observedAt: fresh, want: org.StateWorking},
+		{name: "fresh idle", state: org.StateIdle, observedAt: fresh, want: org.StateIdle},
+		{name: "stale", state: org.StateWorking, observedAt: fresh.Add(-storeOrgLivePresenceMaxAge), want: org.StateUnknown},
+		{name: "done", state: org.StateDone, observedAt: fresh, want: org.StateUnknown},
+		{name: "unknown", state: org.StateUnknown, observedAt: fresh, want: org.StateUnknown},
+		{name: "absent", want: org.StateUnknown},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -33,22 +34,8 @@ func TestStoreOrgLiveSourcePrecedence(t *testing.T) {
 			}
 			t.Cleanup(func() { _ = store.Close() })
 			ctx := context.Background()
-			if test.presence {
-				if err := store.TouchOrgRolePresence(ctx, "review", "test"); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if test.jobState != "" {
-				if err := store.CreateJob(ctx, db.Job{
-					ID: "review-job", Agent: "worker", Type: "ask", State: test.jobState,
-					Payload: `{"acting_org_role":"review"}`,
-				}); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if test.blocked != "" {
-				now := time.Now().UTC()
-				if err := store.UpsertBlockedEpisode(ctx, test.blocked, now, now); err != nil {
+			if !test.observedAt.IsZero() {
+				if err := store.UpsertRoleLivePresence(ctx, "review", string(test.state), test.observedAt); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -56,17 +43,18 @@ func TestStoreOrgLiveSourcePrecedence(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			before := time.Now()
 			states, observedAt, version, err := storeOrgLiveSource(&shared)(ctx, shared.Config)
-			after := time.Now()
 			if err != nil {
 				t.Fatal(err)
 			}
 			if got := states["review"].State; got != test.want {
 				t.Fatalf("review state = %q, want %q", got, test.want)
 			}
-			if version != "store" || observedAt.Before(before) || observedAt.After(after) {
+			if version != "store" {
 				t.Fatalf("source metadata = observed %v version %q", observedAt, version)
+			}
+			if test.want == org.StateUnknown && !observedAt.IsZero() && test.state != org.StateDone && test.state != org.StateUnknown {
+				t.Fatalf("unknown source observedAt = %v, want zero", observedAt)
 			}
 		})
 	}

--- a/internal/cli/org_overview_test.go
+++ b/internal/cli/org_overview_test.go
@@ -15,9 +15,15 @@ func TestStoreOrgLiveSourcePersistedFreshness(t *testing.T) {
 		name       string
 		state      org.LifecycleState
 		observedAt time.Time
+		episode    bool // seed an open org_blocked_episodes row for role:review
 		want       org.LifecycleState
 	}{
-		{name: "fresh blocked", state: org.StateBlocked, observedAt: fresh, want: org.StateBlocked},
+		// Blocked is authoritative from org_blocked_episodes (keeps the dot in
+		// agreement with the blocked_since badge / Health.Blocked), NOT from a
+		// live-presence "blocked" row.
+		{name: "blocked from episode", episode: true, want: org.StateBlocked},
+		{name: "episode wins over live working", state: org.StateWorking, observedAt: fresh, episode: true, want: org.StateBlocked},
+		{name: "live blocked without episode is not blocked", state: org.StateBlocked, observedAt: fresh, want: org.StateUnknown},
 		{name: "fresh working", state: org.StateWorking, observedAt: fresh, want: org.StateWorking},
 		{name: "fresh idle", state: org.StateIdle, observedAt: fresh, want: org.StateIdle},
 		{name: "stale", state: org.StateWorking, observedAt: fresh.Add(-storeOrgLivePresenceMaxAge), want: org.StateUnknown},
@@ -36,6 +42,11 @@ func TestStoreOrgLiveSourcePersistedFreshness(t *testing.T) {
 			ctx := context.Background()
 			if !test.observedAt.IsZero() {
 				if err := store.UpsertRoleLivePresence(ctx, "review", string(test.state), test.observedAt); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.episode {
+				if err := store.UpsertBlockedEpisode(ctx, "role:review", fresh, time.Now().UTC()); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -299,6 +299,7 @@ func setupOrgHome(t *testing.T) (string, config.Paths) {
 [org]
 enforce = "warn"
 [org.roles."owner"]
+display_name = "Owner"
 scope = ["*"]
 merge_rule = "owner"
 [org.roles."review"]

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -13,10 +13,11 @@ import (
 // OrgRole is one role in the local organization registry. MergeRule is
 // deliberately advisory in phase 1a; scope is enforced at dispatch.
 type OrgRole struct {
-	Name      string
-	Parent    string
-	Scope     []string
-	MergeRule string
+	Name        string
+	DisplayName string
+	Parent      string
+	Scope       []string
+	MergeRule   string
 	// Pane optionally binds this role to a Herdr pane for live presence and
 	// event-rule wakes.
 	Pane         string
@@ -245,7 +246,7 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 			}
 			continue
 		}
-		if key != "parent" && key != "scope" && key != "merge_rule" && key != "pane" && key != "recycle_after" {
+		if key != "display_name" && key != "parent" && key != "scope" && key != "merge_rule" && key != "pane" && key != "recycle_after" {
 			return OrgConfig{}, fmt.Errorf("unknown field %q for org role %q", key, current)
 		}
 		if roleFields[current][key] {
@@ -254,6 +255,12 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 		roleFields[current][key] = true
 		role := cfg.roles[current]
 		switch key {
+		case "display_name":
+			v, err := parseOrgTOMLString(value)
+			if err != nil {
+				return OrgConfig{}, fmt.Errorf("org role %q: parse display_name: %w", current, err)
+			}
+			role.DisplayName = v
 		case "parent":
 			v, err := parseOrgTOMLString(value)
 			if err != nil {

--- a/internal/config/org_test.go
+++ b/internal/config/org_test.go
@@ -14,7 +14,7 @@ func TestLoadOrgAndScopeMatching(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	content := "[org]\nenforce = \"block\"\n[org.roles.\"owner\"]\nscope = [\"*\"]\n[org.roles.\"maintainer\"]\nparent = \"owner\"\nscope = [\"Acme/*\", \"other/repo\"]\nmerge_rule = \"self\"\npane = \"w1:p2\"\n"
+	content := "[org]\nenforce = \"block\"\n[org.roles.\"owner\"]\ndisplay_name = \"Owner\"\nscope = [\"*\"]\n[org.roles.\"maintainer\"]\nparent = \"owner\"\nscope = [\"Acme/*\", \"other/repo\"]\nmerge_rule = \"self\"\npane = \"w1:p2\"\n"
 	if err := os.WriteFile(paths.ConfigFile, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -24,6 +24,9 @@ func TestLoadOrgAndScopeMatching(t *testing.T) {
 	}
 	if !cfg.Enabled() || cfg.Enforce() != "block" || len(cfg.Roots()) != 1 || cfg.Roots()[0] != "owner" {
 		t.Fatalf("cfg=%+v roots=%v", cfg, cfg.Roots())
+	}
+	if owner, ok := cfg.Role("owner"); !ok || owner.DisplayName != "Owner" {
+		t.Fatalf("owner=%+v ok=%v", owner, ok)
 	}
 	role, ok := cfg.Role("maintainer")
 	if !ok || role.Scope[0] != "acme/*" || role.Pane != "w1:p2" {

--- a/internal/db/org_role_live_presence.go
+++ b/internal/db/org_role_live_presence.go
@@ -1,0 +1,85 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// RoleLivePresence is the latest Herdr lifecycle observation persisted for one
+// configured organization role.
+type RoleLivePresence struct {
+	Role       string `json:"role"`
+	State      string `json:"state"`
+	ObservedAt string `json:"observed_at"`
+}
+
+func (s *Store) UpsertRoleLivePresence(ctx context.Context, role, state string, observedAt time.Time) error {
+	role = strings.ToLower(strings.TrimSpace(role))
+	if role == "" {
+		return errors.New("org role is required")
+	}
+	if observedAt.IsZero() {
+		return errors.New("org live observed_at is required")
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO org_role_live_presence(role, state, observed_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(role) DO UPDATE SET
+			state = excluded.state,
+			observed_at = excluded.observed_at,
+			updated_at = CURRENT_TIMESTAMP`,
+		role, state, observedAt.UTC().Format(time.RFC3339Nano))
+	return err
+}
+
+func (s *Store) ListRoleLivePresence(ctx context.Context) ([]RoleLivePresence, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT role, state, observed_at
+		FROM org_role_live_presence ORDER BY role`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := []RoleLivePresence{}
+	for rows.Next() {
+		var presence RoleLivePresence
+		if err := rows.Scan(&presence.Role, &presence.State, &presence.ObservedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, presence)
+	}
+	return result, rows.Err()
+}
+
+// DeleteRoleLivePresenceExcept removes observations for roles absent from the
+// latest complete provider snapshot.
+func (s *Store) DeleteRoleLivePresenceExcept(ctx context.Context, roles []string) error {
+	seen := make(map[string]struct{}, len(roles))
+	normalized := make([]string, 0, len(roles))
+	for _, role := range roles {
+		role = strings.ToLower(strings.TrimSpace(role))
+		if role == "" {
+			continue
+		}
+		if _, ok := seen[role]; ok {
+			continue
+		}
+		seen[role] = struct{}{}
+		normalized = append(normalized, role)
+	}
+	if len(normalized) == 0 {
+		_, err := s.db.ExecContext(ctx, `DELETE FROM org_role_live_presence`)
+		return err
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(normalized)), ",")
+	args := make([]any, len(normalized))
+	for i := range normalized {
+		args[i] = normalized[i]
+	}
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf(
+		`DELETE FROM org_role_live_presence WHERE role NOT IN (%s)`, placeholders), args...)
+	return err
+}

--- a/internal/db/org_role_live_presence.go
+++ b/internal/db/org_role_live_presence.go
@@ -70,8 +70,10 @@ func (s *Store) DeleteRoleLivePresenceExcept(ctx context.Context, roles []string
 		normalized = append(normalized, role)
 	}
 	if len(normalized) == 0 {
-		_, err := s.db.ExecContext(ctx, `DELETE FROM org_role_live_presence`)
-		return err
+		// An empty keep-set must NOT wipe the whole table: a transient empty or
+		// all-blank snapshot would erase presence for a still-live fleet. Stale
+		// rows age out of the reader's freshness window instead, so a no-op is safe.
+		return nil
 	}
 
 	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(normalized)), ",")

--- a/internal/db/org_role_live_presence_test.go
+++ b/internal/db/org_role_live_presence_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRoleLivePresenceUpsertListAndReap(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	var table string
+	if err := store.db.QueryRowContext(ctx, `SELECT name FROM sqlite_master
+		WHERE type = 'table' AND name = 'org_role_live_presence'`).Scan(&table); err != nil {
+		t.Fatalf("org_role_live_presence migration missing: %v", err)
+	}
+	first := time.Date(2026, 7, 23, 9, 0, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+
+	if err := store.UpsertRoleLivePresence(ctx, " Owner ", "idle", first); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertRoleLivePresence(ctx, "owner", "working", second); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertRoleLivePresence(ctx, "review", "done", second); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := store.ListRoleLivePresence(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || rows[0].Role != "owner" || rows[0].State != "working" ||
+		rows[0].ObservedAt != second.Format(time.RFC3339Nano) || rows[1].Role != "review" {
+		t.Fatalf("rows = %+v", rows)
+	}
+
+	if err := store.DeleteRoleLivePresenceExcept(ctx, []string{"owner", "owner", ""}); err != nil {
+		t.Fatal(err)
+	}
+	rows, err = store.ListRoleLivePresence(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Role != "owner" {
+		t.Fatalf("rows after reap = %+v", rows)
+	}
+	if err := store.DeleteRoleLivePresenceExcept(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+	rows, err = store.ListRoleLivePresence(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("rows after empty snapshot reap = %+v", rows)
+	}
+}

--- a/internal/db/org_role_live_presence_test.go
+++ b/internal/db/org_role_live_presence_test.go
@@ -50,6 +50,8 @@ func TestRoleLivePresenceUpsertListAndReap(t *testing.T) {
 	if len(rows) != 1 || rows[0].Role != "owner" {
 		t.Fatalf("rows after reap = %+v", rows)
 	}
+	// An empty keep-set is a no-op, NOT a wipe: a transient empty/all-blank
+	// snapshot must never erase presence for a still-live fleet.
 	if err := store.DeleteRoleLivePresenceExcept(ctx, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +59,7 @@ func TestRoleLivePresenceUpsertListAndReap(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 0 {
-		t.Fatalf("rows after empty snapshot reap = %+v", rows)
+	if len(rows) != 1 || rows[0].Role != "owner" {
+		t.Fatalf("empty snapshot reap should be a no-op, rows = %+v", rows)
 	}
 }

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1715,4 +1715,14 @@ CREATE TABLE org_recycle_overdue_episodes (
 	updated_at TEXT NOT NULL
 );
 	`,
+	// #1105 last successful Herdr role snapshot. The daemon writes this only from
+	// the existing blocked-role evaluator tick; dashboard readers remain SQLite-only.
+	`
+CREATE TABLE org_role_live_presence (
+	role TEXT PRIMARY KEY,
+	state TEXT NOT NULL,
+	observed_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+	`,
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1166,8 +1166,9 @@ registry and prints its role count. `gitmoot org show [--home PATH]` prints the
 resolved role table.
 
 The registry uses `[org] enforce = "warn"|"block"` and
-`[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, and an
-optional `pane` Herdr binding (used by live presence and org event-rule wakes).
+`[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, an optional
+cosmetic `display_name`, and an optional `pane` Herdr binding (used by live
+presence and org event-rule wakes).
 The binding resolves as an exact live pane label first, then as a literal pane
 id; roles without a binding retain exact role-name-as-label presence lookup. There is
 exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
@@ -1191,7 +1192,10 @@ Herdr. Responses are cached for at most 15 seconds; `data_as_of` is the newest
 persisted source timestamp, not the request time. `detection_enabled` is true
 only when `blocked_role_wake_after` is positive and at least one org event rule
 is enabled; otherwise `detection_hint` explains why an empty signal feed is not
-evidence that every role is healthy.
+evidence that every role is healthy. The enabled blocked-role evaluator also
+persists its latest Herdr snapshot for these endpoints. Only observations from
+the last five minutes are rendered as `blocked`, `working`, or `idle`; stale,
+missing, `done`, and `unknown` observations render as `never-seen`.
 
 **Session lifecycle (phase 3).** `[org] recycle_after = "24h"` (a duration,
 per-role overridable via `[org.roles."name"] recycle_after`) marks a role

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1004,10 +1004,10 @@ gitmoot org status [--json]
 ```
 
 The registry uses `[org] enforce = "warn"|"block"` and
-`[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, and an
-optional `pane` Herdr binding. The binding resolves as an exact live pane label
-first, then as a literal pane id; roles without a binding retain exact
-role-name-as-label presence lookup. There is
+`[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, an optional
+cosmetic `display_name`, and an optional `pane` Herdr binding. The binding
+resolves as an exact live pane label first, then as a literal pane id; roles
+without a binding retain exact role-name-as-label presence lookup. There is
 exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
 `owner/repo`. Malformed org configuration fails closed and loudly. `brief`
 records passive last-seen presence for its role and can render static context
@@ -1028,7 +1028,10 @@ Herdr. Responses are cached for at most 15 seconds; `data_as_of` is the newest
 persisted source timestamp, not the request time. `detection_enabled` is true
 only when `blocked_role_wake_after` is positive and at least one org event rule
 is enabled; otherwise `detection_hint` explains why an empty signal feed is not
-evidence that every role is healthy.
+evidence that every role is healthy. The enabled blocked-role evaluator also
+persists its latest Herdr snapshot for these endpoints. Only observations from
+the last five minutes are rendered as `blocked`, `working`, or `idle`; stale,
+missing, `done`, and `unknown` observations render as `never-seen`.
 
 Session lifecycle (phase 3): `[org] recycle_after = "24h"` (a duration, per-role
 overridable) marks a role recycle-overdue after it has been idle that long,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10816,8 +10816,9 @@ registry and prints its role count. `gitmoot org show [--home PATH]` prints the
 resolved role table.
 
 The registry uses `[org] enforce = "warn"|"block"` and
-`[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, and an
-optional `pane` Herdr binding (used by live presence and org event-rule wakes).
+`[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, an optional
+cosmetic `display_name`, and an optional `pane` Herdr binding (used by live
+presence and org event-rule wakes).
 The binding resolves as an exact live pane label first, then as a literal pane
 id; roles without a binding retain exact role-name-as-label presence lookup. There is
 exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
@@ -10841,7 +10842,10 @@ Herdr. Responses are cached for at most 15 seconds; `data_as_of` is the newest
 persisted source timestamp, not the request time. `detection_enabled` is true
 only when `blocked_role_wake_after` is positive and at least one org event rule
 is enabled; otherwise `detection_hint` explains why an empty signal feed is not
-evidence that every role is healthy.
+evidence that every role is healthy. The enabled blocked-role evaluator also
+persists its latest Herdr snapshot for these endpoints. Only observations from
+the last five minutes are rendered as `blocked`, `working`, or `idle`; stale,
+missing, `done`, and `unknown` observations render as `never-seen`.
 
 **Session lifecycle (phase 3).** `[org] recycle_after = "24h"` (a duration,
 per-role overridable via `[org.roles."name"] recycle_after`) marks a role


### PR DESCRIPTION
## Org page polish round 1 — core (#1105)

Owner feedback from the first live day. Pairs with dashboard **#124** (display_name render + em-dash purge; also folds in the #123 SPA fixes). No production change until the pin is bumped to the merged #124 SHA + a deploy.

### Changes
1. **`display_name`** — additive `[org.roles."x"] display_name = "..."` (config, cosmetic; the role NAME/key rule is unchanged). Surfaced into `OrgNode.DisplayName` + `OrgRoleIdentity.DisplayName`; the root shows "Jerry" while staying keyed `owner`.
2. **`detection_enabled` fix** — the bridge now reads `blocked_role_wake_after` via `config.LoadOrchestratePolicy(paths)` (the same call the daemon uses) instead of the divergent `resolveBlockedRoleWakeAfter`, which read the knob as disabled while it was set. Pinned by a test.
3. **Presence persistence (the "never-seen" fix)** — the daemon persists its herdr snapshot (role → state + observed_at) into a new `org_role_live_presence` table on the *existing* blocked-role wake tick (`blocked_since.go`), best-effort and gated exactly on the blocked-evaluator being enabled (no new herdr calls, no writes when off). `storeOrgLiveSource` reads it: working/idle from the fresh snapshot (5-min window), **blocked stays authoritative from `org_blocked_episodes`**, else never-seen. The page shows real states within a poll, still store-backed and herdr-free; parity with the CLI chart.
4. **Em-dash purge** of core-emitted strings + a comment.

### `/code-review high` fixes (folded in)
- **State/badge coherence**: blocked is sourced from episodes in the dot too, so a blocked-but-unobserved role can't render a "blocked since" badge next to a never-seen dot / Health.Blocked=0.
- **Honest hint**: when detection is configured on but no live presence is fresh (daemon/herdr unavailable), the page shows `blocked detection on, waiting for live presence...` instead of "enabled" + all-never-seen with no explanation.
- **Safe reap**: `DeleteRoleLivePresenceExcept` is a no-op on an empty keep-set (a transient empty snapshot must not wipe a live fleet).
- *Known follow-up (plausible/edge):* the daemon's own gate still resolves the config via `resolveConfigFile(home)` while the web now uses `pathsFromFlag`; they agree on a normal single-host deploy, and the new hint surfaces any real "enabled but not persisting" state. Unifying the two resolvers is a small separate cleanup.

### Verification
`go build`/`vet`/`generate`(clean)/`test` green; CLI `org chart/status` byte-identical (`TestOrg` goldens unchanged). New tests: detection reads the policy (+ the no-live-presence hint), the live-presence store (upsert/list/no-op-reap), `storeOrgLiveSource` freshness incl. blocked-from-episode precedence, and display_name flow. Migration is an append-tail. `/code-review high` run with extra finder attention on the daemon tick. No deploy (freeze).
