### PR TITLE
perf(dashboard): shared SSE poller — kill per-viewer full-state rebuilds (#1110)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -177,9 +177,17 @@ type webDataSource struct {
 	cacheOnce     sync.Once
 	responseCache *dashboardJSONCache
 
+	registryMu sync.Mutex
+	pollers    map[string]*ssePoller
+
+	// These hooks keep the shared-poller concurrency tests fast and
+	// deterministic. Production leaves them nil/zero.
+	sseState        func(context.Context, string) (dashboard.State, error)
+	ssePollInterval time.Duration
+
 	// mu guards the Health() caches below (Health can be called concurrently and
 	// its resolvers run in goroutines). Everything else on the source is stateless
-	// per call, so only the caches need protection.
+	// per call; SSE pollers use registryMu and their own locks.
 	mu sync.Mutex
 	// daemonVersionKey/daemonVersion cache the running daemon binary's reported
 	// version, keyed by (executable path, file mtime) so SEQUENTIAL 12s health
@@ -1906,44 +1914,164 @@ func healthStuckSince(job db.Job, cutoffMillis int64) (since int64, stuck bool) 
 	return since, false
 }
 
-// Subscribe polls State for the requested run and pushes a fresh snapshot to the
-// returned channel whenever it changes (plus one initial snapshot). It is a
-// read-only poller — no store writes — and stops when the caller invokes the
-// returned cancel func or the parent context is cancelled.
+const (
+	sseMaxSubscribersPerRun = 64
+	ssePollInterval         = 2 * time.Second
+)
+
+type ssePoller struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	mu   sync.Mutex
+	subs map[int]chan dashboard.State
+	seq  int
+	refs int
+
+	last      string
+	lastState dashboard.State
+	haveState bool
+}
+
+// Subscribe shares one read-only State poller between every viewer of the same
+// requested run and fans changed snapshots out to per-connection channels.
+// The registry uses the trimmed raw run id: canonicalizing "" or a child id to
+// its root currently requires the same full ListJobs rebuild this path avoids.
+// In practice dashboard viewers use the same run query, so equivalent requests
+// still collapse in the common case.
 func (d *webDataSource) Subscribe(ctx context.Context, runID string) (<-chan dashboard.State, func(), error) {
+	_ = ctx // The module handler owns connection cancellation and calls cancel.
+	runID = strings.TrimSpace(runID)
+
+	d.registryMu.Lock()
+	if d.pollers == nil {
+		d.pollers = make(map[string]*ssePoller)
+	}
+	poller := d.pollers[runID]
+	created := poller == nil
+	var pollCtx context.Context
+	if created {
+		poller = &ssePoller{}
+		pollCtx, poller.cancel = context.WithCancel(context.Background())
+		poller.done = make(chan struct{})
+		poller.subs = make(map[int]chan dashboard.State)
+		d.pollers[runID] = poller
+	}
+
+	poller.mu.Lock()
+	if len(poller.subs) >= sseMaxSubscribersPerRun {
+		// Only an existing over-capacity poller can reject: a freshly created
+		// poller has zero subscribers and always admits its first below.
+		poller.mu.Unlock()
+		d.registryMu.Unlock()
+		return nil, nil, errors.New("dashboard: too many SSE subscribers for run")
+	}
+	id := poller.seq
+	poller.seq++
+	// Buffer 1 with coalescing fanout (see runSSEPoller): the channel holds at
+	// most the newest snapshot for a slow subscriber, never a stale backlog.
 	ch := make(chan dashboard.State, 1)
-	pollCtx, cancel := context.WithCancel(ctx)
-	go func() {
-		defer close(ch)
-		ticker := time.NewTicker(2 * time.Second)
-		defer ticker.Stop()
-		var last string
-		push := func() {
-			state, err := d.State(pollCtx, runID)
-			if err != nil {
-				return
+	poller.subs[id] = ch
+	poller.refs++
+	poller.mu.Unlock()
+	d.registryMu.Unlock()
+	if created {
+		go d.runSSEPoller(pollCtx, runID, poller)
+	}
+
+	// Seed only after releasing registryMu: the hard lock rule forbids channel
+	// sends while the registry is held. Re-taking only the poller's own lock
+	// serializes this with fanout. If fanout already queued a fresher snapshot,
+	// the channel is non-empty and no stale cached seed is appended behind it.
+	poller.mu.Lock()
+	if poller.haveState && len(ch) == 0 {
+		ch <- poller.lastState
+	}
+	poller.mu.Unlock()
+
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			d.registryMu.Lock()
+			poller.mu.Lock()
+			if sub, ok := poller.subs[id]; ok {
+				delete(poller.subs, id)
+				close(sub)
+				poller.refs--
+				if poller.refs == 0 {
+					poller.cancel()
+					delete(d.pollers, runID)
+				}
 			}
-			key := stateFingerprint(state)
-			if key == last {
-				return
-			}
-			last = key
-			select {
-			case ch <- state:
-			case <-pollCtx.Done():
-			}
-		}
-		push()
-		for {
-			select {
-			case <-pollCtx.Done():
-				return
-			case <-ticker.C:
-				push()
-			}
-		}
-	}()
+			poller.mu.Unlock()
+			d.registryMu.Unlock()
+		})
+	}
 	return ch, cancel, nil
+}
+
+func (d *webDataSource) runSSEPoller(ctx context.Context, runID string, poller *ssePoller) {
+	defer close(poller.done)
+	interval := d.ssePollInterval
+	if interval <= 0 {
+		interval = ssePollInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	publish := func() {
+		// One shared rebuild per tick regardless of viewer count, deduped by
+		// fingerprint — byte-identical to the old per-connection poller, just
+		// shared. (A cheap version-cache was rejected: no cheap signal covers a
+		// bare jobs-table state write, so it risked freezing a live viewer.)
+		state, err := d.sseStateSnapshot(ctx, runID)
+		if err != nil {
+			return
+		}
+		key := stateFingerprint(state)
+
+		poller.mu.Lock()
+		changed := !poller.haveState || key != poller.last
+		poller.lastState = state
+		poller.haveState = true
+		if changed {
+			poller.last = key
+			for _, sub := range poller.subs {
+				// Coalescing latest-wins delivery: drop any stale queued snapshot
+				// then enqueue the newest, so a briefly-slow viewer converges to
+				// the current state instead of freezing on an intermediate one,
+				// and the shared poller never blocks on one lagging subscriber.
+				select {
+				case <-sub:
+				default:
+				}
+				select {
+				case sub <- state:
+				default:
+				}
+			}
+		}
+		poller.mu.Unlock()
+	}
+
+	publish()
+	for {
+		select {
+		case <-ctx.Done():
+			// Cancelled only at refs==0, after the last unsubscribe removed and
+			// closed its channel under poller.mu, so nothing remains to close.
+			return
+		case <-ticker.C:
+			publish()
+		}
+	}
+}
+
+func (d *webDataSource) sseStateSnapshot(ctx context.Context, runID string) (dashboard.State, error) {
+	if d.sseState != nil {
+		return d.sseState(ctx, runID)
+	}
+	return d.State(ctx, runID)
 }
 
 // agentRuntimeMap builds a name->runtime lookup from the agent registry so a

--- a/internal/cli/dashboard_web_sse_test.go
+++ b/internal/cli/dashboard_web_sse_test.go
@@ -1,0 +1,318 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dashboard "github.com/gitmoot/gitmoot-dashboard"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+func TestWebDataSourceSubscribeSharesPollerAndSeedsLateJoiner(t *testing.T) {
+	var stateCalls atomic.Int64
+	ds := &webDataSource{
+		ssePollInterval: 20 * time.Millisecond,
+		sseState: func(context.Context, string) (dashboard.State, error) {
+			stateCalls.Add(1)
+			return dashboard.State{RunID: "root", Title: "cached"}, nil
+		},
+	}
+
+	first, cancelFirst, err := ds.Subscribe(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("Subscribe(first): %v", err)
+	}
+	defer cancelFirst()
+	want := receiveSSEState(t, first)
+
+	second, cancelSecond, err := ds.Subscribe(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("Subscribe(second): %v", err)
+	}
+	defer cancelSecond()
+	started := time.Now()
+	if got := receiveSSEState(t, second); got.RunID != want.RunID || got.Title != want.Title {
+		t.Fatalf("late-join seed = %+v, want %+v", got, want)
+	}
+	if elapsed := time.Since(started); elapsed >= ds.ssePollInterval {
+		t.Fatalf("late joiner waited %v for cached state (poll interval %v)", elapsed, ds.ssePollInterval)
+	}
+
+	ds.registryMu.Lock()
+	poller := ds.pollers["root"]
+	pollerCount := len(ds.pollers)
+	ds.registryMu.Unlock()
+	if pollerCount != 1 || poller == nil {
+		t.Fatalf("poller registry = %d entries, root=%v; want one shared poller", pollerCount, poller != nil)
+	}
+	poller.mu.Lock()
+	refs := poller.refs
+	poller.mu.Unlock()
+	if refs != 2 {
+		t.Fatalf("shared poller refs = %d, want 2", refs)
+	}
+
+	// The single shared poller keeps rebuilding on its own ticker; pollerCount==1
+	// above already proves two viewers do NOT get one rebuild loop each.
+	if !waitForCondition(t, time.Second, func() bool { return stateCalls.Load() >= 3 }) {
+		t.Fatal("shared poller did not keep rebuilding")
+	}
+}
+
+func TestWebDataSourceSubscribeSharedFanoutOnChange(t *testing.T) {
+	home := dashboardTestHome(t)
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if err := store.CreateJobWithEvent(context.Background(),
+		db.Job{ID: "root", Agent: "worker", Type: "ask", State: "running"},
+		db.JobEvent{Kind: "running", Message: "initial"}); err != nil {
+		store.Close()
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	store.Close()
+
+	ds := &webDataSource{home: home, ssePollInterval: 20 * time.Millisecond}
+	ds.sseState = func(ctx context.Context, runID string) (dashboard.State, error) {
+		return ds.State(ctx, runID)
+	}
+
+	first, cancelFirst, err := ds.Subscribe(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("Subscribe(first): %v", err)
+	}
+	initial := receiveSSEState(t, first)
+	if len(initial.Nodes) != 1 || len(initial.Nodes[0].Events) != 1 {
+		t.Fatalf("initial state = %+v, want one node with one event", initial)
+	}
+
+	second, cancelSecond, err := ds.Subscribe(context.Background(), "root")
+	if err != nil {
+		cancelFirst()
+		t.Fatalf("Subscribe(second): %v", err)
+	}
+	_ = receiveSSEState(t, second)
+	ds.registryMu.Lock()
+	poller := ds.pollers["root"]
+	ds.registryMu.Unlock()
+	t.Cleanup(func() {
+		cancelFirst()
+		cancelSecond()
+		select {
+		case <-poller.done:
+		case <-time.After(time.Second):
+			t.Error("SSE poller did not stop during cleanup")
+		}
+	})
+
+	store, err = db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if err := store.AddJobEvent(context.Background(), db.JobEvent{
+		JobID: "root", Kind: "progress", Message: "changed",
+	}); err != nil {
+		store.Close()
+		t.Fatalf("AddJobEvent: %v", err)
+	}
+	store.Close()
+
+	for i, ch := range []<-chan dashboard.State{first, second} {
+		got := receiveSSEState(t, ch)
+		if len(got.Nodes) != 1 || len(got.Nodes[0].Events) != 2 {
+			t.Fatalf("subscriber %d update = %+v, want two events", i, got)
+		}
+	}
+}
+
+// TestWebDataSourceSubscribeCoalescingLatestWins proves F2's fix: a subscriber
+// that lags behind a burst of distinct snapshots receives the LATEST state, not
+// a stale queued one, and never freezes (buffer-1 drain-then-send fanout).
+func TestWebDataSourceSubscribeCoalescingLatestWins(t *testing.T) {
+	var ticks atomic.Int64
+	ds := &webDataSource{
+		ssePollInterval: 5 * time.Millisecond,
+		sseState: func(context.Context, string) (dashboard.State, error) {
+			// A distinct fingerprint every tick (event count grows) so every tick
+			// is a real change that the poller pushes.
+			n := int(ticks.Add(1))
+			return dashboard.State{RunID: "root", Nodes: []dashboard.Node{
+				{ID: "root", State: "running", Events: make([]dashboard.Event, n)},
+			}}, nil
+		},
+	}
+	ch, cancel, err := ds.Subscribe(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	defer cancel()
+
+	// Do NOT read while the poller pushes several distinct snapshots into the
+	// buffer-1 channel; coalescing must keep only the newest.
+	if !waitForCondition(t, time.Second, func() bool { return ticks.Load() >= 6 }) {
+		t.Fatal("poller did not produce enough ticks")
+	}
+	got := receiveSSEState(t, ch)
+	if len(got.Nodes) == 0 || len(got.Nodes[0].Events) < 5 {
+		t.Fatalf("coalescing delivered a stale snapshot with %d events; want the latest (>=5)", len(got.Nodes[0].Events))
+	}
+}
+
+func TestWebDataSourceSubscribeRefCountTeardownAndRestart(t *testing.T) {
+	ds := newFakeSSEDataSource(time.Hour)
+	first, cancelFirst, err := ds.Subscribe(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("Subscribe(first): %v", err)
+	}
+	_ = receiveSSEState(t, first)
+	second, cancelSecond, err := ds.Subscribe(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("Subscribe(second): %v", err)
+	}
+	_ = receiveSSEState(t, second)
+
+	ds.registryMu.Lock()
+	original := ds.pollers["root"]
+	ds.registryMu.Unlock()
+	cancelFirst()
+	ds.registryMu.Lock()
+	remaining := len(ds.pollers)
+	ds.registryMu.Unlock()
+	if remaining != 1 {
+		t.Fatalf("pollers after first unsubscribe = %d, want 1", remaining)
+	}
+
+	cancelSecond()
+	ds.registryMu.Lock()
+	remaining = len(ds.pollers)
+	ds.registryMu.Unlock()
+	if remaining != 0 {
+		t.Fatalf("pollers after last unsubscribe = %d, want 0", remaining)
+	}
+	select {
+	case <-original.done:
+	case <-time.After(time.Second):
+		t.Fatal("poller goroutine did not stop after last unsubscribe")
+	}
+
+	third, cancelThird, err := ds.Subscribe(context.Background(), "root")
+	if err != nil {
+		t.Fatalf("Subscribe(after teardown): %v", err)
+	}
+	_ = receiveSSEState(t, third)
+	ds.registryMu.Lock()
+	restarted := ds.pollers["root"]
+	ds.registryMu.Unlock()
+	if restarted == nil || restarted == original {
+		t.Fatal("subscribe after teardown did not start a fresh poller")
+	}
+	cancelThird()
+	select {
+	case <-restarted.done:
+	case <-time.After(time.Second):
+		t.Fatal("restarted poller did not stop")
+	}
+}
+
+func TestWebDataSourceSubscribeSubscriberCap(t *testing.T) {
+	ds := newFakeSSEDataSource(time.Hour)
+	cancels := make([]func(), 0, sseMaxSubscribersPerRun)
+	channels := make([]<-chan dashboard.State, 0, sseMaxSubscribersPerRun)
+	for i := 0; i < sseMaxSubscribersPerRun; i++ {
+		ch, cancel, err := ds.Subscribe(context.Background(), "root")
+		if err != nil {
+			t.Fatalf("Subscribe(%d): %v", i, err)
+		}
+		channels = append(channels, ch)
+		cancels = append(cancels, cancel)
+	}
+	if ch, cancel, err := ds.Subscribe(context.Background(), "root"); err == nil || ch != nil || cancel != nil {
+		t.Fatalf("over-cap Subscribe returned channel=%t cancel=%t err=%v; want false, false, error", ch != nil, cancel != nil, err)
+	}
+
+	for i, ch := range channels {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				t.Fatalf("existing subscriber %d closed by over-cap request", i)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("existing subscriber %d did not receive initial state", i)
+		}
+	}
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
+func TestWebDataSourceSubscribeConcurrentChurn(t *testing.T) {
+	ds := newFakeSSEDataSource(time.Millisecond)
+	const workers = 16
+	const iterations = 40
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				ch, cancel, err := ds.Subscribe(context.Background(), "root")
+				if err != nil {
+					errs <- err
+					return
+				}
+				select {
+				case <-ch:
+				case <-time.After(time.Second):
+					errs <- fmt.Errorf("timed out waiting for SSE state")
+					cancel()
+					return
+				}
+				cancel()
+				cancel()
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if !waitForCondition(t, time.Second, func() bool {
+		ds.registryMu.Lock()
+		defer ds.registryMu.Unlock()
+		return len(ds.pollers) == 0
+	}) {
+		t.Fatal("pollers were not torn down after concurrent churn")
+	}
+}
+
+func newFakeSSEDataSource(interval time.Duration) *webDataSource {
+	return &webDataSource{
+		ssePollInterval: interval,
+		sseState: func(context.Context, string) (dashboard.State, error) {
+			return dashboard.State{RunID: "root", Title: "state"}, nil
+		},
+	}
+}
+
+func receiveSSEState(t *testing.T, ch <-chan dashboard.State) dashboard.State {
+	t.Helper()
+	select {
+	case state, ok := <-ch:
+		if !ok {
+			t.Fatal("SSE channel closed before state arrived")
+		}
+		return state
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for SSE state")
+		return dashboard.State{}
+	}
+}


### PR DESCRIPTION
Closes #1110. Measured on the live box: `gitmoot-dashboard-web` at ~194% CPU, 45k SQLite reads/sec, 118 unreaped SSE connections from traefik.

## Root cause
`webDataSource.Subscribe` spawned a **per-connection** 2s goroutine calling `State()` — a full `ListJobs` rebuild over the 140MB store. The SSE handler calls `Subscribe` per connection, so N viewers = N full rebuilds every 2s. With 118 unreaped half-open proxy connections that was the ~2-core burn; public sharing makes N unbounded.

## Fix (in-repo, parts 1 of the issue)
Collapse to **one ref-counted poller per requested run** that fans changed snapshots out to per-connection channels — work is now **O(1) in viewer count** (~1 rebuild/2s regardless of viewers ≈ 1.7% of a core; a ~99% reduction). Behavior is **byte-identical to the old poller** — same 2s rebuild + fingerprint dedupe, just shared:
- **Late joiner** synchronously seeded with the poller's cached snapshot; the first subscriber forces an immediate rebuild — a live viewer's behavior is unchanged.
- **Coalescing latest-wins fanout** (buffer-1, drain-then-send): a briefly-slow viewer converges to the current state instead of freezing on a stale one, and one lagging subscriber never blocks the shared poller.
- **Per-run subscriber cap** returns an error so a public flood closes over-limit connections cleanly (the module handler returns on a Subscribe error).
- Last unsubscribe cancels the poller — no goroutine leak.

## Provenance / quality
- Design-sanity (one seat) approved the shape with corrections; a `/code-review high` then caught **two real parity regressions** and a follow-up focused re-review verified the fixes:
  - **Dropped the version cache** — a cheap `MAX(job_events.id)` signal can't see a bare `jobs`-table state write (e.g. the task-recover fallback), so it risked freezing a live viewer for a marginal CPU gain the shared poller already captures. The shared poller alone meets "idle CPU near zero."
  - **Coalescing fanout** replaces a non-blocking drop-newest send that could permanently freeze a slowed viewer on a stale snapshot.

## Deploy notes
Code-only, no migration, single static binary. Serves the **public** dashboard — reaches the box on the next batch deploy.

**Part 2** — write-deadline dead-client reaping in the `gitmoot-dashboard` SSE handler (to bound the connection *count*, not the CPU) — is a separate coordinated fast-follow.

## Gate
`go build` / `go vet` / `go test ./...` / `go generate && git diff` green; `-race` on the SSE subscribe tests green (shared-poller, late-joiner seed, coalescing-latest-wins, ref-count teardown, cap, concurrent churn). Full sharded race runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
