### PR TITLE
perf(daemon): O(n) aged delegation-worktree reclaim query (#1111)

### DIFF
--- a/internal/db/aged_delegation_worktree_test.go
+++ b/internal/db/aged_delegation_worktree_test.go
@@ -1,0 +1,117 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestJobIDsWithAgedTerminalDelegationWorktree locks the behavior of the #1111
+// CTE-materialized rewrite across every branch: owner still active vs terminal-
+// and-old, an existing cleanup event, aged vs recent, worktree presence, the
+// delegation-vs-read-only payload predicate, a resumable blocked job, and two
+// aged jobs sharing one worktree. Running on the modernc driver also proves it
+// accepts the `WITH ... AS MATERIALIZED` CTE hint the rewrite depends on.
+func TestJobIDsWithAgedTerminalDelegationWorktree(t *testing.T) {
+	ctx := context.Background()
+	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer store.Close()
+
+	now := time.Now().UTC()
+	old := now.Add(-2 * time.Hour)      // <= cutoff (aged)
+	recent := now.Add(-1 * time.Minute) // > cutoff (still fresh)
+	cutoff := now.Add(-30 * time.Minute)
+
+	wt := func(path, extra string) string {
+		if extra == "" {
+			return fmt.Sprintf(`{"worktree_path":%q}`, path)
+		}
+		return fmt.Sprintf(`{"worktree_path":%q,%s}`, path, extra)
+	}
+	seeds := []struct {
+		id      string
+		state   string
+		payload string
+		updated time.Time
+		events  []string
+		want    bool
+	}{
+		{id: "aged-delegation", state: "succeeded", payload: wt("/wt/a", `"delegation_id":"d1"`), updated: old, want: true},
+		{id: "aged-readonly", state: "failed", payload: wt("/wt/f", `"read_only_worktree":true`), updated: old, want: true},
+		// owned-by-active shares /wt/b with a still-running owner -> not reclaimable.
+		{id: "owned-by-active", state: "cancelled", payload: wt("/wt/b", `"delegation_id":"d2"`), updated: old, want: false},
+		{id: "active-owner", state: "running", payload: wt("/wt/b", `"delegation_id":"d2b"`), updated: recent, want: false},
+		// has-cleanup already emitted a removal event -> excluded.
+		{id: "has-cleanup", state: "succeeded", payload: wt("/wt/d", `"delegation_id":"d3"`), updated: old, events: []string{"delegation_worktree_removed"}, want: false},
+		{id: "no-worktree", state: "succeeded", payload: `{"delegation_id":"d4"}`, updated: old, want: false},
+		{id: "not-aged", state: "succeeded", payload: wt("/wt/g", `"delegation_id":"d5"`), updated: recent, want: false},
+		{id: "blocked-resumable", state: "blocked", payload: wt("/wt/h", `"delegation_id":"d6"`), updated: old, want: false},
+		// ordinary task worktree: no delegation_id and not read-only -> excluded.
+		{id: "ordinary-task", state: "succeeded", payload: wt("/wt/i", ""), updated: old, want: false},
+		// two aged terminal jobs sharing one worktree: neither owner is active or
+		// newer than cutoff, so BOTH are reclaim candidates (matches the old query).
+		{id: "shared-both-aged-1", state: "succeeded", payload: wt("/wt/s", `"delegation_id":"s1"`), updated: old, want: true},
+		{id: "shared-both-aged-2", state: "failed", payload: wt("/wt/s", `"delegation_id":"s2"`), updated: old, want: true},
+	}
+
+	want := map[string]bool{}
+	for _, s := range seeds {
+		if err := store.CreateJob(ctx, Job{ID: s.id, Agent: "producer", Type: "implement", State: s.state, Payload: s.payload}); err != nil {
+			t.Fatalf("CreateJob(%s): %v", s.id, err)
+		}
+		if _, err := store.db.ExecContext(ctx, `UPDATE jobs SET updated_at=? WHERE id=?`,
+			s.updated.Format("2006-01-02 15:04:05"), s.id); err != nil {
+			t.Fatalf("set updated_at(%s): %v", s.id, err)
+		}
+		for _, k := range s.events {
+			if err := store.AddJobEvent(ctx, JobEvent{JobID: s.id, Kind: k, Message: "m"}); err != nil {
+				t.Fatalf("AddJobEvent(%s,%s): %v", s.id, k, err)
+			}
+		}
+		if s.want {
+			want[s.id] = true
+		}
+	}
+
+	// Invalid/empty payload is a tolerated store state ('' is the schema default,
+	// and the write path swallows marshal errors). The eager json_valid-guarded
+	// CTE must silently ignore these rows, not error the whole reclaim pass
+	// (#1111 finder). Neither is a candidate. Without the guard this query errors.
+	for _, bad := range []struct{ id, payload string }{
+		{id: "bad-empty-payload", payload: ""},
+		{id: "bad-garbage-payload", payload: "not json at all"},
+	} {
+		if err := store.CreateJob(ctx, Job{ID: bad.id, Agent: "producer", Type: "implement", State: "succeeded", Payload: "{}"}); err != nil {
+			t.Fatalf("CreateJob(%s): %v", bad.id, err)
+		}
+		if _, err := store.db.ExecContext(ctx, `UPDATE jobs SET payload=?, updated_at=? WHERE id=?`,
+			bad.payload, old.Format("2006-01-02 15:04:05"), bad.id); err != nil {
+			t.Fatalf("force payload(%s): %v", bad.id, err)
+		}
+	}
+
+	got, err := store.JobIDsWithAgedTerminalDelegationWorktree(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("JobIDsWithAgedTerminalDelegationWorktree: %v", err)
+	}
+	gotSet := map[string]bool{}
+	for _, id := range got {
+		if gotSet[id] {
+			t.Fatalf("duplicate id %q in %v", id, got)
+		}
+		gotSet[id] = true
+	}
+	if len(gotSet) != len(want) {
+		t.Fatalf("result = %v, want exactly %v", got, want)
+	}
+	for id := range want {
+		if !gotSet[id] {
+			t.Fatalf("expected %q in result, got %v", id, got)
+		}
+	}
+}

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -1329,28 +1329,58 @@ func (s *Store) JobIDsWithPendingDelegationWorktreeReclaim(ctx context.Context) 
 // crash-window leftovers that never got far enough to emit a cleanup-skipped
 // marker. Blocked is excluded: it is resumable and therefore still owns its
 // worktree. The payload predicates exclude ordinary task worktrees.
+//
+// The `job_wt` MATERIALIZED CTE extracts each job's worktree_path (and the other
+// payload fields) EXACTLY ONCE. The prior form correlated the owner NOT EXISTS
+// with json_extract(owner.payload,...) = json_extract(j.payload,...), so SQLite
+// re-parsed every owner row's full JSON payload for every outer candidate row —
+// O(jobs^2) JSON reparses. On this host's live store (~3500 jobs, some payloads
+// >10MB) that made a single run take ~100s, and it runs every ~1s reclaim tick,
+// pinning a core in modernc's VDBE/JSON1 (#1111). Materializing the extract once
+// turns it into O(jobs) parses + an equality join on the plain column: same rows,
+// ~700x faster (verified against a live snapshot). The MATERIALIZED hint is
+// required — without it SQLite inlines the CTE and re-parses per reference.
+//
+// The `WHERE json_valid(payload)` guard is load-bearing: the CTE extracts eagerly
+// over every row, and json_extract ERRORS on a non-JSON payload — and ” is the
+// column's schema default (payload TEXT NOT NULL DEFAULT ”), a tolerated store
+// state (the write path swallows marshal errors). Without the guard a single
+// bad-payload row would fail this query on every reclaim tick. Invalid-payload
+// rows have no worktree_path, so they can never be a candidate or an owner: the
+// guard is a no-op on the result set and matches the sibling json_valid guards
+// (store_jobs.go json*Reclaim queries).
 func (s *Store) JobIDsWithAgedTerminalDelegationWorktree(ctx context.Context, cutoff time.Time) ([]string, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT j.id
-		FROM jobs j
+	cutoffStr := cutoff.UTC().Format("2006-01-02 15:04:05")
+	rows, err := s.db.QueryContext(ctx, `
+		WITH job_wt AS MATERIALIZED (
+			SELECT id, state,
+			       unixepoch(COALESCE(NULLIF(updated_at, ''), created_at)) AS ts,
+			       json_extract(payload, '$.worktree_path') AS worktree_path,
+			       COALESCE(json_extract(payload, '$.delegation_id'), '') AS delegation_id,
+			       COALESCE(json_extract(payload, '$.read_only_worktree'), 0) AS read_only_worktree
+			FROM jobs
+			WHERE json_valid(payload)
+		)
+		SELECT j.id
+		FROM job_wt j
 		WHERE j.state IN ('succeeded', 'failed', 'cancelled')
-		  AND unixepoch(COALESCE(NULLIF(j.updated_at, ''), j.created_at)) <= unixepoch(?)
-		  AND COALESCE(json_extract(j.payload, '$.worktree_path'), '') <> ''
-		  AND (COALESCE(json_extract(j.payload, '$.delegation_id'), '') <> ''
-		       OR COALESCE(json_extract(j.payload, '$.read_only_worktree'), 0) = 1)
+		  AND j.ts <= unixepoch(?)
+		  AND COALESCE(j.worktree_path, '') <> ''
+		  AND (j.delegation_id <> '' OR j.read_only_worktree = 1)
 		  AND NOT EXISTS (
-			SELECT 1 FROM jobs owner
+			SELECT 1 FROM job_wt owner
 			WHERE owner.id <> j.id
-			  AND json_extract(owner.payload, '$.worktree_path') = json_extract(j.payload, '$.worktree_path')
+			  AND owner.worktree_path = j.worktree_path
 			  AND (owner.state NOT IN ('succeeded', 'failed', 'cancelled')
-			       OR unixepoch(COALESCE(NULLIF(owner.updated_at, ''), owner.created_at)) IS NULL
-			       OR unixepoch(COALESCE(NULLIF(owner.updated_at, ''), owner.created_at)) > unixepoch(?))
+			       OR owner.ts IS NULL
+			       OR owner.ts > unixepoch(?))
 		  )
 		  AND NOT EXISTS (
 			SELECT 1 FROM job_events e
 			WHERE e.job_id = j.id
 			  AND e.kind IN ('delegation_worktree_removed', 'delegation_worktree_reclaimed_ttl')
 		  )
-		ORDER BY j.id`, cutoff.UTC().Format("2006-01-02 15:04:05"), cutoff.UTC().Format("2006-01-02 15:04:05"))
+		ORDER BY j.id`, cutoffStr, cutoffStr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

Fixes #1111 — the daemon burning ~1 core continuously. Rewrites `JobIDsWithAgedTerminalDelegationWorktree` (the aged delegation-worktree reclaim query) from an O(jobs²) JSON-reparse into an O(jobs) single-pass. **~700× faster on the live data set, byte-identical result rows.**

## Root cause (profiled + reproduced, not guessed)

The prescribed "32 workers claim-polling" framing was a misread — the scheduler has no busy-poll and it's one hot goroutine, not 32 (see the pprof endpoint #1117). A live CPU profile (`/debug/pprof/profile?seconds=10`) showed **53.6% cumulative in modernc `_sqlite3VdbeExec`**, with `encoding/json.checkValid`/`unquoteBytes`, `runtime.memmove` (17%), and `memory.Allocator.mmap` churn — SQL execution reparsing JSON, not an I/O spin.

The cost is `JobIDsWithAgedTerminalDelegationWorktree` (`internal/db/store_jobs.go`). Its owner `NOT EXISTS` correlated `json_extract(owner.payload,'$.worktree_path')` against `json_extract(j.payload,'$.worktree_path')`, so SQLite re-parsed **every** owner row's full JSON payload for **every** outer candidate. On this host's live store (~3500 jobs, some payloads >10MB) that is O(jobs²) JSON parses; it runs on **every ~1s reclaim tick** (`daemon_scheduler.go` `reclaimAgedTerminalDelegationWorktrees` → `agedDelegationReclaimCandidates`), so runs overlap into a pinned core. (The sibling `JobIDsWithPendingDelegationWorktreeReclaim` already carries a comment about fixing this exact "burned a core" O(n²) class — the aged variant just never got the same treatment.)

## Fix

A `WITH job_wt AS MATERIALIZED (...)` CTE extracts `worktree_path` / `delegation_id` / `read_only_worktree` / the aged timestamp **once per job**; the owner `NOT EXISTS` then joins on the plain materialized column (`owner.worktree_path = j.worktree_path`) — no per-comparison reparse. The `MATERIALIZED` hint is required (without it SQLite inlines the CTE and reparses per reference); modernc v1.50.1 accepts it. Semantics are otherwise unchanged.

## Verification

- **On a safe read-only `.backup` snapshot of the live 3500-job store**: OLD query **107.6s**, NEW **0.151s**; row sets **identical** (`OLD EXCEPT NEW = 0`, `NEW EXCEPT OLD = 0`).
- **New db test** (`aged_delegation_worktree_test.go`) covers every branch — owner active vs terminal-and-old, existing cleanup event, aged vs recent, worktree presence, delegation-vs-read-only, resumable `blocked`, and two aged jobs sharing one worktree — and running on the **modernc driver** proves the `MATERIALIZED` hint is accepted.
- Fresh CPU re-profile confirmed the `_sqlite3VdbeExec`/JSON1 hotspot before the fix. Build / vet / the reclaim integration test / full `db`+`cli` suites green.

## Deploy note

Deploying the daemon binary clears the live CPU burn immediately (owner-gated). No migration, no behavior change beyond the query plan. The `--pprof-addr` diagnostic from #1117 can stay or be removed from the ExecStart afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review — fresh finder (SQL semantic equivalence)

A de-anchored finder ran a differential harness against the modernc v1.50.1 driver — 34 targeted edge cases + a 4000-iteration randomized fuzz (states × path/`updated_at`/`read_only`/`delegation_id` encodings × event kinds): **0 row-set divergences**, confirming no false-positive (never a wrong worktree deletion). It caught one fail-safe divergence — the eager CTE errors on a non-JSON/empty payload where the old lazy form sometimes succeeded-empty — now closed by the `json_valid(payload)` guard (a no-op on valid data, and it removes the old form's latent lazy error too). Covered by a new invalid-payload test case.
