### PR TITLE
feat(daemon): shared host tool cache for isolated-worktree jobs (#1113)

### DIFF
--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -1652,6 +1652,17 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
 		return nil
 	}
+	// Shared tool-cache grant (#1113 lever 1): mirrors the primary worker path so
+	// runtime-session contention rerouting through the temp worker doesn't
+	// silently lose the cache redirect. Fail-open (disk hygiene, not security).
+	var tempToolCacheEnv []string
+	if cachePaths, cacheErr := w.configPaths(); cacheErr != nil {
+		writeLine(w.Stdout, "job %s tool cache config load failed: %v", delegatedJob.ID, cacheErr)
+	} else if env, grantErr := applyIsolatedToolCacheGrants(cachePaths, payload, &started.Agent); grantErr != nil {
+		writeLine(w.Stdout, "job %s tool cache grant failed: %v", delegatedJob.ID, grantErr)
+	} else {
+		tempToolCacheEnv = env
+	}
 	adapter, err = wrapProduceSandboxAdapter(delegatedJob.Type, started.Agent, adapter)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, delegatedJob.ID, workflow.JobFailed, err); finishErr != nil {
@@ -1659,6 +1670,13 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		}
 		_ = w.postJobResultComment(ctx, delegatedJob.ID, started.Agent, checkout, err)
 		return nil
+	}
+	if len(tempToolCacheEnv) > 0 {
+		if envAdapter, envErr := injectDeliveryAdapterEnv(adapter, tempToolCacheEnv); envErr != nil {
+			writeLine(w.Stdout, "job %s tool cache env inject failed: %v", delegatedJob.ID, envErr)
+		} else {
+			adapter = envAdapter
+		}
 	}
 	adapter = pipeline.WrapPipelineEnvDeliveryAdapter(w.Store, w.ConfigHome, payload, adapter)
 	// Temp-session delivery is a separate early-return path; attach the same

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -406,6 +406,19 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
 	}
+	// Shared tool-cache grant (#1113 lever 1): disk hygiene, not a security
+	// precondition, so any failure is fail-open (logged, job proceeds without the
+	// cache redirect) rather than failing the job like the produce grants above.
+	// MUST run after applyProduceRuntimeGrants: that call overwrites
+	// agent.WritablePaths for produce jobs, so appending earlier would be lost.
+	var toolCacheEnv []string
+	if cachePaths, cacheErr := w.configPaths(); cacheErr != nil {
+		writeLine(w.Stdout, "job %s tool cache config load failed: %v", job.ID, cacheErr)
+	} else if env, grantErr := applyIsolatedToolCacheGrants(cachePaths, payload, &agent); grantErr != nil {
+		writeLine(w.Stdout, "job %s tool cache grant failed: %v", job.ID, grantErr)
+	} else {
+		toolCacheEnv = env
+	}
 	adapter, err = wrapProduceSandboxAdapter(job.Type, agent, adapter)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
@@ -413,6 +426,13 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		}
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
+	}
+	if len(toolCacheEnv) > 0 {
+		if envAdapter, envErr := injectDeliveryAdapterEnv(adapter, toolCacheEnv); envErr != nil {
+			writeLine(w.Stdout, "job %s tool cache env inject failed: %v", job.ID, envErr)
+		} else {
+			adapter = envAdapter
+		}
 	}
 	// Opt-in retained capture is attached to the already-composed adapter so
 	// relay env, credential curation, gateway leases, Landlock, and pipeline

--- a/internal/cli/isolated_tool_cache.go
+++ b/internal/cli/isolated_tool_cache.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// toolCacheEnvSubdirs maps each tool's cache-directory env var to the
+// subdirectory it gets under the shared tool-cache root.
+var toolCacheEnvSubdirs = []struct{ env, subdir string }{
+	{"UV_CACHE_DIR", "uv"},
+	{"PIP_CACHE_DIR", "pip"},
+	{"npm_config_cache", "npm"},
+	{"GOCACHE", "go-build"},
+	{"GOMODCACHE", "go-mod"},
+}
+
+// applyIsolatedToolCacheGrants widens agent.WritablePaths with ONE shared,
+// host-level tool-cache root for isolated-worktree jobs, and returns the env
+// vars pointing each tool's cache at that shared root instead of the
+// per-worktree fallback that duplicates gigabytes of immutable, content-
+// addressed packages per job (#1113 lever 1).
+//
+// MUST be called AFTER applyProduceRuntimeGrants: that call unconditionally
+// OVERWRITES agent.WritablePaths for produce jobs, so appending before it would
+// be silently discarded. Appending (not replacing) here preserves whatever
+// applyProduceRuntimeGrants set.
+//
+// Scope: isolated jobs only (payload.WorktreePath != "") — a non-isolated job
+// uses the persistent registered checkout, which does not duplicate caches per
+// job. Widening WritablePaths reaches codex (its sandbox is always on and reads
+// the agent value fresh at Deliver time, so this is what actually makes the
+// cache dir writable there) and claude/kimi "produce" jobs (whose Landlock grant
+// is computed from this same field, later, in wrapProduceSandboxAdapter).
+// Non-produce claude/kimi and shell runtimes run unsandboxed already, so
+// widening WritablePaths for them is a harmless no-op — nothing reads it — and
+// the env vars alone suffice to redirect their cache.
+//
+// Errors here are the caller's to treat as fail-open: this is disk hygiene, not
+// a security precondition, and must never fail a job.
+func applyIsolatedToolCacheGrants(paths config.Paths, payload workflow.JobPayload, agent *runtime.Agent) ([]string, error) {
+	if strings.TrimSpace(payload.WorktreePath) == "" {
+		return nil, nil
+	}
+	policy, err := config.LoadToolCache(paths)
+	if err != nil {
+		return nil, fmt.Errorf("load tool cache config: %w", err)
+	}
+	if !policy.Enabled || strings.TrimSpace(policy.Dir) == "" {
+		return nil, nil
+	}
+	if err := os.MkdirAll(policy.Dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create shared tool cache dir %s: %w", policy.Dir, err)
+	}
+	env := make([]string, 0, len(toolCacheEnvSubdirs))
+	for _, e := range toolCacheEnvSubdirs {
+		dir := filepath.Join(policy.Dir, e.subdir)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, fmt.Errorf("create shared tool cache subdir %s: %w", dir, err)
+		}
+		env = append(env, e.env+"="+dir)
+	}
+	agent.WritablePaths = appendUniquePath(agent.WritablePaths, policy.Dir)
+	return env, nil
+}
+
+func appendUniquePath(paths []string, add string) []string {
+	for _, p := range paths {
+		if p == add {
+			return paths
+		}
+	}
+	return append(paths, add)
+}
+
+// injectDeliveryAdapterEnv wraps an already-composed adapter's runner with an
+// EnvInjectingRunner carrying env, mirroring appendDeliveryAdapterOutput's
+// per-adapter-type rewrap (transcript_retention.go) so the wrap composes safely
+// with whatever the adapter already carries (Landlock, credential curation,
+// process-group kill).
+func injectDeliveryAdapterEnv(adapter workflow.DeliveryAdapter, env []string) (workflow.DeliveryAdapter, error) {
+	if adapter == nil || len(env) == 0 {
+		return adapter, nil
+	}
+	switch a := adapter.(type) {
+	case modelGatewayRuntimeAdapter:
+		inner, err := injectDeliveryAdapterEnv(a.Adapter, env)
+		if err != nil {
+			return nil, err
+		}
+		runtimeAdapter, ok := inner.(runtime.Adapter)
+		if !ok {
+			return nil, fmt.Errorf("tool cache env inject returned incompatible %T model-gateway adapter", inner)
+		}
+		a.Adapter = runtimeAdapter
+		return a, nil
+	case runtime.CodexAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case *runtime.CodexAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case runtime.ClaudeAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case *runtime.ClaudeAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case runtime.KimiAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case *runtime.KimiAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case runtime.KimiCLIAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case *runtime.KimiCLIAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case runtime.ShellAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	case *runtime.ShellAdapter:
+		a.Runner = subprocess.EnvInjectingRunner{Inner: a.Runner, Env: env}
+		return a, nil
+	default:
+		return nil, fmt.Errorf("tool cache env inject cannot wrap adapter %T", adapter)
+	}
+}

--- a/internal/cli/isolated_tool_cache.go
+++ b/internal/cli/isolated_tool_cache.go
@@ -43,11 +43,27 @@ var toolCacheEnvSubdirs = []struct{ env, subdir string }{
 // widening WritablePaths for them is a harmless no-op — nothing reads it — and
 // the env vars alone suffice to redirect their cache.
 //
+// codex only honors WritablePaths under the workspace-write autonomy policy
+// (codexSandboxArgs' --add-dir loop; read-only mode grants nothing). Pointing
+// UV_CACHE_DIR/GOCACHE/etc. at the shared dir for a read-only codex job would
+// redirect tools to a directory their sandbox cannot write, breaking Go builds
+// and degrading uv/pip/npm — worse than leaving the env unset. So a read-only
+// (or unrecognized) codex autonomy policy is a no-op here; danger-full-access
+// is unrestricted and proceeds like any other job.
+//
 // Errors here are the caller's to treat as fail-open: this is disk hygiene, not
 // a security precondition, and must never fail a job.
 func applyIsolatedToolCacheGrants(paths config.Paths, payload workflow.JobPayload, agent *runtime.Agent) ([]string, error) {
 	if strings.TrimSpace(payload.WorktreePath) == "" {
 		return nil, nil
+	}
+	if agent.Runtime == runtime.CodexRuntime && !agent.ChatSeat {
+		switch runtime.NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
+		case runtime.AutonomyPolicyWorkspaceWrite, runtime.AutonomyPolicyDangerFullAccess:
+			// proceeds below
+		default:
+			return nil, nil
+		}
 	}
 	policy, err := config.LoadToolCache(paths)
 	if err != nil {

--- a/internal/cli/isolated_tool_cache.go
+++ b/internal/cli/isolated_tool_cache.go
@@ -49,7 +49,13 @@ var toolCacheEnvSubdirs = []struct{ env, subdir string }{
 // redirect tools to a directory their sandbox cannot write, breaking Go builds
 // and degrading uv/pip/npm — worse than leaving the env unset. So a read-only
 // (or unrecognized) codex autonomy policy is a no-op here; danger-full-access
-// is unrestricted and proceeds like any other job.
+// is unrestricted and proceeds like any other job. A ChatSeat is ALSO a no-op:
+// codexSandboxArgs returns workspace-write for a ChatSeat WITHOUT ever reaching
+// the --add-dir loop (its only implicit writable roots are workdir/tmp), so a
+// chat seat never gets the shared directory writable regardless of policy —
+// injecting the env for it would reproduce the exact same-directory-unwritable
+// failure this gate exists to prevent (#1113 finder, confirmed against
+// TestCodexDeliverChatSeatSandbox).
 //
 // Errors here are the caller's to treat as fail-open: this is disk hygiene, not
 // a security precondition, and must never fail a job.
@@ -57,7 +63,10 @@ func applyIsolatedToolCacheGrants(paths config.Paths, payload workflow.JobPayloa
 	if strings.TrimSpace(payload.WorktreePath) == "" {
 		return nil, nil
 	}
-	if agent.Runtime == runtime.CodexRuntime && !agent.ChatSeat {
+	if agent.Runtime == runtime.CodexRuntime {
+		if agent.ChatSeat {
+			return nil, nil
+		}
 		switch runtime.NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy) {
 		case runtime.AutonomyPolicyWorkspaceWrite, runtime.AutonomyPolicyDangerFullAccess:
 			// proceeds below

--- a/internal/cli/isolated_tool_cache_test.go
+++ b/internal/cli/isolated_tool_cache_test.go
@@ -12,6 +12,48 @@ import (
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
+// TestApplyIsolatedToolCacheGrantsCodexAutonomyGate pins the #1113 finder
+// finding: codex only honors WritablePaths under workspace-write, so a
+// read-only (or unrecognized) codex job must get neither the grant nor the env
+// -- pointing its tools at an unwritable shared dir would be worse than doing
+// nothing. workspace-write and danger-full-access proceed; a ChatSeat always
+// proceeds regardless of policy (codex grants it workspace-write unconditionally).
+func TestApplyIsolatedToolCacheGrantsCodexAutonomyGate(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   string
+		chatSeat bool
+		wantNoop bool
+	}{
+		{name: "read-only skipped", policy: runtime.AutonomyPolicyReadOnly, wantNoop: true},
+		{name: "unrecognized policy skipped", policy: "bogus", wantNoop: true},
+		{name: "empty policy skipped", policy: "", wantNoop: true},
+		{name: "workspace-write proceeds", policy: runtime.AutonomyPolicyWorkspaceWrite, wantNoop: false},
+		{name: "danger-full-access proceeds", policy: runtime.AutonomyPolicyDangerFullAccess, wantNoop: false},
+		{name: "chat seat proceeds despite read-only policy", policy: runtime.AutonomyPolicyReadOnly, chatSeat: true, wantNoop: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			paths := config.PathsForHome(t.TempDir())
+			agent := runtime.Agent{Runtime: runtime.CodexRuntime, AutonomyPolicy: test.policy, ChatSeat: test.chatSeat}
+			payload := workflow.JobPayload{WorktreePath: filepath.Join(paths.Home, "worktrees", "w1")}
+			env, err := applyIsolatedToolCacheGrants(paths, payload, &agent)
+			if err != nil {
+				t.Fatalf("applyIsolatedToolCacheGrants: %v", err)
+			}
+			if test.wantNoop {
+				if len(env) != 0 || len(agent.WritablePaths) != 0 {
+					t.Fatalf("policy %q chatSeat=%v must be a no-op: env=%v writable=%v", test.policy, test.chatSeat, env, agent.WritablePaths)
+				}
+				return
+			}
+			if len(env) != len(toolCacheEnvSubdirs) || len(agent.WritablePaths) != 1 {
+				t.Fatalf("policy %q chatSeat=%v must grant: env=%v writable=%v", test.policy, test.chatSeat, env, agent.WritablePaths)
+			}
+		})
+	}
+}
+
 func TestApplyIsolatedToolCacheGrantsNonIsolatedNoop(t *testing.T) {
 	paths := config.PathsForHome(t.TempDir())
 	agent := runtime.Agent{}

--- a/internal/cli/isolated_tool_cache_test.go
+++ b/internal/cli/isolated_tool_cache_test.go
@@ -1,0 +1,135 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestApplyIsolatedToolCacheGrantsNonIsolatedNoop(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	agent := runtime.Agent{}
+	env, err := applyIsolatedToolCacheGrants(paths, workflow.JobPayload{}, &agent)
+	if err != nil {
+		t.Fatalf("applyIsolatedToolCacheGrants: %v", err)
+	}
+	if len(env) != 0 || len(agent.WritablePaths) != 0 {
+		t.Fatalf("non-isolated job must be a no-op: env=%v writable=%v", env, agent.WritablePaths)
+	}
+}
+
+func TestApplyIsolatedToolCacheGrantsDisabledNoop(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatalf("mkdir home: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[cache]\nenabled = false\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	agent := runtime.Agent{}
+	env, err := applyIsolatedToolCacheGrants(paths, workflow.JobPayload{WorktreePath: filepath.Join(paths.Home, "worktrees", "w1")}, &agent)
+	if err != nil {
+		t.Fatalf("applyIsolatedToolCacheGrants: %v", err)
+	}
+	if len(env) != 0 || len(agent.WritablePaths) != 0 {
+		t.Fatalf("disabled config must be a no-op: env=%v writable=%v", env, agent.WritablePaths)
+	}
+}
+
+func TestApplyIsolatedToolCacheGrantsCreatesDirsEnvAndGrant(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	agent := runtime.Agent{WritablePaths: []string{"/already/granted"}}
+	payload := workflow.JobPayload{WorktreePath: filepath.Join(paths.Home, "worktrees", "w1")}
+
+	env, err := applyIsolatedToolCacheGrants(paths, payload, &agent)
+	if err != nil {
+		t.Fatalf("applyIsolatedToolCacheGrants: %v", err)
+	}
+	if len(env) != len(toolCacheEnvSubdirs) {
+		t.Fatalf("env = %v, want %d entries", env, len(toolCacheEnvSubdirs))
+	}
+	wantRoot := filepath.Join(paths.Home, "cache", "tools")
+	envSet := map[string]string{}
+	for _, kv := range env {
+		key, val, ok := splitEnvKV(kv)
+		if !ok {
+			t.Fatalf("malformed env entry %q", kv)
+		}
+		envSet[key] = val
+	}
+	for _, e := range toolCacheEnvSubdirs {
+		wantDir := filepath.Join(wantRoot, e.subdir)
+		if envSet[e.env] != wantDir {
+			t.Fatalf("env[%s] = %q, want %q", e.env, envSet[e.env], wantDir)
+		}
+		if info, statErr := os.Stat(wantDir); statErr != nil || !info.IsDir() {
+			t.Fatalf("subdir %s not created: %v", wantDir, statErr)
+		}
+	}
+	// The existing produce grant is preserved (append, not overwrite), and the
+	// shared cache root is added exactly once.
+	if len(agent.WritablePaths) != 2 || agent.WritablePaths[0] != "/already/granted" || agent.WritablePaths[1] != wantRoot {
+		t.Fatalf("WritablePaths = %v, want [/already/granted %s]", agent.WritablePaths, wantRoot)
+	}
+
+	// A second call (e.g. a retried delivery) must not duplicate the grant.
+	if _, err := applyIsolatedToolCacheGrants(paths, payload, &agent); err != nil {
+		t.Fatalf("second applyIsolatedToolCacheGrants: %v", err)
+	}
+	if len(agent.WritablePaths) != 2 {
+		t.Fatalf("WritablePaths duplicated on second call: %v", agent.WritablePaths)
+	}
+}
+
+func splitEnvKV(kv string) (key, val string, ok bool) {
+	for i := 0; i < len(kv); i++ {
+		if kv[i] == '=' {
+			return kv[:i], kv[i+1:], true
+		}
+	}
+	return "", "", false
+}
+
+// TestInjectDeliveryAdapterEnvRealSubprocess proves the env-injection wrap
+// actually reaches a real subprocess (no LLM): a shell job echoes the injected
+// var, exactly the mechanism codex/claude/kimi's shared runner infrastructure
+// uses (#1113 lever 1).
+func TestInjectDeliveryAdapterEnvRealSubprocess(t *testing.T) {
+	adapter := runtime.ShellAdapter{Dir: t.TempDir(), Runner: subprocess.ExecRunner{}}
+	wrapped, err := injectDeliveryAdapterEnv(adapter, []string{"GITMOOT_TEST_TOOL_CACHE=shared-cache-value"})
+	if err != nil {
+		t.Fatalf("injectDeliveryAdapterEnv: %v", err)
+	}
+	shellAdapter, ok := wrapped.(runtime.ShellAdapter)
+	if !ok {
+		t.Fatalf("wrapped adapter type = %T, want runtime.ShellAdapter", wrapped)
+	}
+	agent := runtime.Agent{Name: "custom", Role: "reviewer", Runtime: runtime.ShellRuntime, RuntimeRef: `echo "$GITMOOT_TEST_TOOL_CACHE"`, RepoScope: "gitmoot/gitmoot"}
+	result, err := shellAdapter.Deliver(context.Background(), agent, runtime.Job{Prompt: "hi"})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if result.Summary != "shared-cache-value" {
+		t.Fatalf("Summary = %q, want %q (injected env did not reach the subprocess)", result.Summary, "shared-cache-value")
+	}
+}
+
+// TestInjectDeliveryAdapterEnvNoopWithoutEnv confirms an empty env leaves the
+// adapter untouched (identity), matching appendDeliveryAdapterOutput's nil-safe
+// convention.
+func TestInjectDeliveryAdapterEnvNoopWithoutEnv(t *testing.T) {
+	adapter := runtime.ShellAdapter{Runner: subprocess.ExecRunner{}}
+	wrapped, err := injectDeliveryAdapterEnv(adapter, nil)
+	if err != nil {
+		t.Fatalf("injectDeliveryAdapterEnv: %v", err)
+	}
+	if wrapped != workflow.DeliveryAdapter(adapter) {
+		t.Fatalf("empty env must return the adapter unchanged")
+	}
+}

--- a/internal/cli/isolated_tool_cache_test.go
+++ b/internal/cli/isolated_tool_cache_test.go
@@ -16,8 +16,12 @@ import (
 // finding: codex only honors WritablePaths under workspace-write, so a
 // read-only (or unrecognized) codex job must get neither the grant nor the env
 // -- pointing its tools at an unwritable shared dir would be worse than doing
-// nothing. workspace-write and danger-full-access proceed; a ChatSeat always
-// proceeds regardless of policy (codex grants it workspace-write unconditionally).
+// nothing. workspace-write and danger-full-access proceed. A ChatSeat is ALSO
+// always a no-op regardless of policy: codexSandboxArgs returns workspace-write
+// for a ChatSeat WITHOUT ever reaching the --add-dir loop, so granting it here
+// would inject env pointing at a directory its sandbox still cannot write —
+// the second-pass finder caught an earlier, backwards version of this gate that
+// bypassed ChatSeat into proceeding, which reproduced the original defect.
 func TestApplyIsolatedToolCacheGrantsCodexAutonomyGate(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -30,7 +34,8 @@ func TestApplyIsolatedToolCacheGrantsCodexAutonomyGate(t *testing.T) {
 		{name: "empty policy skipped", policy: "", wantNoop: true},
 		{name: "workspace-write proceeds", policy: runtime.AutonomyPolicyWorkspaceWrite, wantNoop: false},
 		{name: "danger-full-access proceeds", policy: runtime.AutonomyPolicyDangerFullAccess, wantNoop: false},
-		{name: "chat seat proceeds despite read-only policy", policy: runtime.AutonomyPolicyReadOnly, chatSeat: true, wantNoop: false},
+		{name: "chat seat skipped despite read-only policy", policy: runtime.AutonomyPolicyReadOnly, chatSeat: true, wantNoop: true},
+		{name: "chat seat skipped even with workspace-write policy", policy: runtime.AutonomyPolicyWorkspaceWrite, chatSeat: true, wantNoop: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -67,6 +67,15 @@ artifact_blobs = %q
 # require_workflow = false # opt out (default is true)
 # require_workflow_mode = "auto" # auto | strict
 
+# [cache] gives isolated-worktree jobs (codex is always sandboxed; claude/kimi
+# "produce" jobs are Landlock-sandboxed) a shared, host-level tool-cache
+# directory instead of each job re-materializing its own uv/go/npm/pip caches
+# inside its worktree. Enabled by default; the shared dir is created on first
+# use and is never swept by worktree teardown.
+# [cache]
+# enabled = true
+# dir = "/root/.gitmoot/cache/tools" # default: "<home>/cache/tools"
+
 # [daemon] is the OPTIONAL warm-reloadable runtime config (issue #577). CLI flags to
 # "daemon start" / "daemon run" remain the initial value; a key here is applied only
 # where the matching flag was NOT passed (flag = override). Its real purpose is WARM

--- a/internal/config/tool_cache.go
+++ b/internal/config/tool_cache.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ToolCacheDefaultSubdir is the tool-cache root's location under the gitmoot
+// home when [cache].dir is not overridden.
+const ToolCacheDefaultSubdir = "cache/tools"
+
+// ToolCachePolicy controls whether isolated-worktree jobs get a shared,
+// host-level tool-cache directory injected into their environment (#1113).
+type ToolCachePolicy struct {
+	Enabled bool
+	// Dir is always absolute and non-empty when Enabled is true.
+	Dir string
+}
+
+// LoadToolCache resolves the independent [cache] section: enabled (default
+// true) and dir (default "<home>/cache/tools"). An explicit dir override must
+// be absolute. enabled=false disables the feature entirely regardless of dir.
+func LoadToolCache(paths Paths) (ToolCachePolicy, error) {
+	policy := ToolCachePolicy{Enabled: true, Dir: filepath.Join(paths.Home, filepath.FromSlash(ToolCacheDefaultSubdir))}
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return policy, nil
+		}
+		return ToolCachePolicy{}, err
+	}
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			continue
+		}
+		if current != "cache" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if strings.HasPrefix(value, "\"") {
+			value, err = parseConfigString(value)
+			if err != nil {
+				return ToolCachePolicy{}, fmt.Errorf("parse [cache].%s: %w", key, err)
+			}
+			value = strings.TrimSpace(value)
+		}
+		switch key {
+		case "enabled":
+			switch value {
+			case "", "true":
+				policy.Enabled = true
+			case "false":
+				policy.Enabled = false
+			default:
+				return ToolCachePolicy{}, fmt.Errorf("invalid [cache].enabled %q: must be true or false", value)
+			}
+		case "dir":
+			if value == "" {
+				policy.Dir = filepath.Join(paths.Home, filepath.FromSlash(ToolCacheDefaultSubdir))
+				continue
+			}
+			if !filepath.IsAbs(value) {
+				return ToolCachePolicy{}, fmt.Errorf("[cache].dir %q must be absolute", value)
+			}
+			policy.Dir = value
+		}
+	}
+	return policy, nil
+}

--- a/internal/config/tool_cache.go
+++ b/internal/config/tool_cache.go
@@ -41,8 +41,16 @@ func LoadToolCache(paths Paths) (ToolCachePolicy, error) {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+		if strings.HasPrefix(line, "[") {
+			if strings.HasSuffix(line, "]") {
+				current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			} else {
+				// A malformed header (no closing bracket) ends whatever section
+				// was active rather than silently continuing it — otherwise a
+				// botched "[workflow" typo right after "[cache]" would keep
+				// applying subsequent lines to [cache] instead (#1113 finder).
+				current = ""
+			}
 			continue
 		}
 		if current != "cache" {

--- a/internal/config/tool_cache.go
+++ b/internal/config/tool_cache.go
@@ -23,7 +23,11 @@ type ToolCachePolicy struct {
 // true) and dir (default "<home>/cache/tools"). An explicit dir override must
 // be absolute. enabled=false disables the feature entirely regardless of dir.
 func LoadToolCache(paths Paths) (ToolCachePolicy, error) {
-	policy := ToolCachePolicy{Enabled: true, Dir: filepath.Join(paths.Home, filepath.FromSlash(ToolCacheDefaultSubdir))}
+	defaultDir, err := defaultToolCacheDir(paths.Home)
+	if err != nil {
+		return ToolCachePolicy{}, err
+	}
+	policy := ToolCachePolicy{Enabled: true, Dir: defaultDir}
 	content, err := os.ReadFile(paths.ConfigFile)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -69,7 +73,7 @@ func LoadToolCache(paths Paths) (ToolCachePolicy, error) {
 			}
 		case "dir":
 			if value == "" {
-				policy.Dir = filepath.Join(paths.Home, filepath.FromSlash(ToolCacheDefaultSubdir))
+				policy.Dir = defaultDir
 				continue
 			}
 			if !filepath.IsAbs(value) {
@@ -79,4 +83,22 @@ func LoadToolCache(paths Paths) (ToolCachePolicy, error) {
 		}
 	}
 	return policy, nil
+}
+
+// defaultToolCacheDir joins home with the default subdir and normalizes the
+// result to an absolute path: pathsFromFlag does not itself require --home to
+// be absolute, so home (and therefore this join) can be relative. A relative
+// Dir is rejected outright by Landlock (produce jobs) and, for unsandboxed
+// jobs, would resolve against the CHILD PROCESS's cwd (the worktree checkout)
+// rather than the daemon's — a different absolute path per worktree, silently
+// recreating the exact per-worktree cache duplication this feature exists to
+// eliminate. filepath.Abs only errors if the working directory is
+// unresolvable, which is already fatal for the daemon process itself.
+func defaultToolCacheDir(home string) (string, error) {
+	dir := filepath.Join(home, filepath.FromSlash(ToolCacheDefaultSubdir))
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve default tool cache dir: %w", err)
+	}
+	return abs, nil
 }

--- a/internal/config/tool_cache_test.go
+++ b/internal/config/tool_cache_test.go
@@ -22,6 +22,7 @@ func TestLoadToolCache(t *testing.T) {
 		{name: "relative dir rejected", content: "[cache]\ndir = \"relative/path\"\n", wantErr: "must be absolute"},
 		{name: "garbage enabled", content: "[cache]\nenabled = maybe\n", wantErr: "invalid [cache].enabled"},
 		{name: "other section", content: "[workflow]\nenabled = false\ndir = \"/should/not/apply\"\n", wantEnabled: true},
+		{name: "malformed header ends cache section", content: "[cache]\nenabled = true\n[workflow\nenabled = false\n", wantEnabled: true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/config/tool_cache_test.go
+++ b/internal/config/tool_cache_test.go
@@ -57,3 +57,31 @@ func TestLoadToolCache(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadToolCacheDefaultDirIsAbsoluteEvenWithRelativeHome pins a finder
+// finding: pathsFromFlag does not itself require --home to be absolute, so
+// paths.Home (and therefore the naive join of it with the default subdir) can
+// be relative. A relative Dir is rejected outright by Landlock and, for
+// unsandboxed jobs, resolves against the CHILD PROCESS's cwd (the worktree
+// checkout) rather than the daemon's -- a different path per worktree,
+// silently recreating the per-worktree cache duplication this feature exists
+// to eliminate.
+func TestLoadToolCacheDefaultDirIsAbsoluteEvenWithRelativeHome(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	paths := PathsForHome("relhome")
+	if filepath.IsAbs(paths.Home) {
+		t.Fatalf("test setup invalid: paths.Home %q is already absolute", paths.Home)
+	}
+	got, err := LoadToolCache(paths)
+	if err != nil {
+		t.Fatalf("LoadToolCache: %v", err)
+	}
+	if !filepath.IsAbs(got.Dir) {
+		t.Fatalf("Dir = %q, want an absolute path", got.Dir)
+	}
+	want := filepath.Join(cwd, "relhome", ".gitmoot", "cache", "tools")
+	if got.Dir != want {
+		t.Fatalf("Dir = %q, want %q", got.Dir, want)
+	}
+}

--- a/internal/config/tool_cache_test.go
+++ b/internal/config/tool_cache_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadToolCache(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantEnabled bool
+		wantDir     string // empty means "expect the default <home>/cache/tools"
+		wantErr     string
+	}{
+		{name: "missing config", wantEnabled: true},
+		{name: "omitted", content: "[cache]\nenabled = true\n", wantEnabled: true},
+		{name: "disabled", content: "[cache]\nenabled = false\n", wantEnabled: false},
+		{name: "custom dir", content: "[cache]\ndir = \"/var/gitmoot-tool-cache\"\n", wantEnabled: true, wantDir: "/var/gitmoot-tool-cache"},
+		{name: "relative dir rejected", content: "[cache]\ndir = \"relative/path\"\n", wantErr: "must be absolute"},
+		{name: "garbage enabled", content: "[cache]\nenabled = maybe\n", wantErr: "invalid [cache].enabled"},
+		{name: "other section", content: "[workflow]\nenabled = false\ndir = \"/should/not/apply\"\n", wantEnabled: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if test.content != "" {
+				if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+					t.Fatalf("mkdir home: %v", err)
+				}
+				if err := os.WriteFile(paths.ConfigFile, []byte(test.content), 0o600); err != nil {
+					t.Fatalf("write config: %v", err)
+				}
+			}
+			got, err := LoadToolCache(paths)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("LoadToolCache error = %v, want %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadToolCache: %v", err)
+			}
+			if got.Enabled != test.wantEnabled {
+				t.Fatalf("Enabled = %v, want %v", got.Enabled, test.wantEnabled)
+			}
+			wantDir := test.wantDir
+			if wantDir == "" {
+				wantDir = filepath.Join(paths.Home, "cache", "tools")
+			}
+			if got.Dir != wantDir {
+				t.Fatalf("Dir = %q, want %q", got.Dir, wantDir)
+			}
+		})
+	}
+}

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -416,3 +416,23 @@ when the current state is `succeeded`, `failed`, or `cancelled` and the exact
 path matches; then run `git -C <registered-checkout> worktree remove --force
 <path>` followed by `git -C <registered-checkout> worktree prune`. Never remove
 a worktree owned by a blocked, queued, or running job.
+
+## Shared Tool Cache (isolated worktrees)
+
+An isolated-worktree job (a per-job worktree under `$GITMOOT_HOME/worktrees/...`)
+gets `UV_CACHE_DIR`, `PIP_CACHE_DIR`, `npm_config_cache`, `GOCACHE`, and
+`GOMODCACHE` pointed at one shared, host-level directory (default
+`$GITMOOT_HOME/cache/tools`) instead of each isolated job re-materializing its
+own copy of immutable, content-addressed package caches inside its worktree —
+which otherwise grows unbounded with fleet lifetime and is deleted only when
+the reaper removes the worktree (#1113). Enabled by default; set `[cache]
+enabled = false` to opt out, or `[cache] dir = "/absolute/path"` to relocate it
+(must be absolute). The shared directory is created on first use and is never
+swept by worktree teardown. Non-isolated jobs (the persistent registered
+checkout) are unaffected — they do not duplicate caches per job.
+
+Codex is always sandboxed, so this also widens its `--add-dir` writable-path
+allowlist to the shared cache directory; Claude/Kimi `produce` jobs pick up the
+same grant through their existing Landlock write-allowlist. Non-produce
+Claude/Kimi and `shell` runtime jobs already run unsandboxed, so only the env
+redirect applies to them.

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -436,3 +436,9 @@ allowlist to the shared cache directory; Claude/Kimi `produce` jobs pick up the
 same grant through their existing Landlock write-allowlist. Non-produce
 Claude/Kimi and `shell` runtime jobs already run unsandboxed, so only the env
 redirect applies to them.
+
+A codex job gets neither the grant nor the env when its sandbox mode cannot
+reach the shared directory: a read-only/`auto`/unrecognized autonomy policy
+(codex never emits `--add-dir` there), or a chat seat (codex grants it
+workspace-write, but without ever populating `--add-dir` either). Those jobs
+keep the pre-#1113 behavior — no redirect, no in-worktree cache reuse.

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -532,6 +532,11 @@ across jobs instead of duplicated per worktree. This is on by default; set
 `[cache] enabled = false` in `config.toml` to opt out, or `[cache] dir =
 "/absolute/path"` to relocate the shared directory (must be absolute).
 
+A read-only/`auto` codex job and a codex chat seat do not get the redirect —
+codex never grants writable-path access to either, so pointing their tools at
+the shared directory would break rather than help. Those jobs keep their
+pre-existing (in-worktree) cache behavior.
+
 If an existing worktree already carries a large in-worktree cache from before
 this took effect, it is cleaned up the same way as any other worktree content:
 by the delegation-worktree reclaim pass above, or manually once the owning job

--- a/website/docs/operations/troubleshooting.md
+++ b/website/docs/operations/troubleshooting.md
@@ -516,3 +516,23 @@ The `sqlite3` command is an optional operator aid, not a Gitmoot dependency.
 Verify that `job show` still reports `succeeded`, `failed`, or `cancelled` and
 the same `payload.worktree_path`. Never remove a worktree for a blocked, queued,
 or running job; settle it first.
+
+## Isolated worktrees duplicate gigabytes of tool cache
+
+An isolated-worktree job re-materializing its own `uv`/`go`/`npm`/`pip` cache
+inside its worktree (rather than reusing a shared one) is the largest driver of
+`gitmoot doctor`'s worktree disk figure once a fleet has run for a while — one
+worktree can carry several gigabytes of immutable, content-addressed packages
+that duplicate what every other job already downloaded.
+
+Gitmoot points `UV_CACHE_DIR`, `PIP_CACHE_DIR`, `npm_config_cache`, `GOCACHE`,
+and `GOMODCACHE` at one shared, host-level directory (default
+`<home>/cache/tools`) for isolated-worktree jobs, so package caches are reused
+across jobs instead of duplicated per worktree. This is on by default; set
+`[cache] enabled = false` in `config.toml` to opt out, or `[cache] dir =
+"/absolute/path"` to relocate the shared directory (must be absolute).
+
+If an existing worktree already carries a large in-worktree cache from before
+this took effect, it is cleaned up the same way as any other worktree content:
+by the delegation-worktree reclaim pass above, or manually once the owning job
+is terminal.


### PR DESCRIPTION
## What

#1113 lever 1 (highest-leverage of the 4 disk-footprint levers): isolated-worktree jobs (delegation / read-only worktrees under `$GITMOOT_HOME/worktrees/...`) each re-materialize their own `uv`/`go`/`npm`/`pip` package cache inside the worktree — one live worktree carried **6.5GB** of `.uv-cache` — because codex is always sandboxed and Claude/Kimi "produce" jobs are Landlock-sandboxed, and neither's write-allowlist includes `~/.cache`. This points those tools at ONE shared, host-level cache directory instead.

## Root cause (confirmed against live data)

Live evidence: `$GITMOOT_HOME/worktrees` was **15G**, dominated by the single 6.5G `.uv-cache` plus ~2G of `node_modules`. The shared host caches already exist (`~/.cache/uv` 13G, `~/.cache/go-build` 12G, `go/pkg/mod` 3.3G, `~/.npm` 1.5G) — isolated jobs just can't reach them: `codex`'s `[sandbox_workspace_write]` has no writable roots beyond the workspace, so tools fall back to a worktree-local cache. (Scope note: this fixes the content-addressed *caches*, not `node_modules` — project-local installed deps, not a shareable cache.)

## Changes

- **Config** `[cache]` (`internal/config/tool_cache.go`): `enabled` (default `true`) + `dir` (default `<home>/cache/tools`, override must be absolute). Independent scanner mirroring `workflow_lifecycle.go`'s style.
- **Grant** (`internal/cli/isolated_tool_cache.go` `applyIsolatedToolCacheGrants`): for isolated jobs only (`payload.WorktreePath != ""`), creates the shared root + five subdirs (`uv`/`pip`/`npm`/`go-build`/`go-mod`) and **appends** the root to `agent.WritablePaths`. Must run *after* `applyProduceRuntimeGrants` (which overwrites that field for produce jobs) and *before* `wrapProduceSandboxAdapter` (which reads it to compute the produce Landlock grant). Codex reads the agent value fresh at `Deliver`/`Start` call time (no stored snapshot), so this reaches its `--add-dir` allowlist without any codex-adapter change. Non-produce Claude/Kimi and `shell` jobs already run unsandboxed, so widening `WritablePaths` for them is a no-op.
- **Env injection** (`injectDeliveryAdapterEnv`): wraps the composed adapter's runner with the five cache env vars, mirroring the existing `appendDeliveryAdapterOutput` per-adapter-type rewrap.
- Both steps are **fail-open**: disk hygiene, not a security precondition — an error is logged, the job proceeds unaffected.
- Docs: `SAFETY.md` + website `troubleshooting.md`.

## Security note (owner-authorized)

This widens the sandbox write-allowlist to a directory **shared across isolated jobs** — codex `--add-dir` and Claude/Kimi produce Landlock `writes`. The auto-mode security classifier flagged this correctly as a sandbox-isolation loosening and blocked the wiring pending explicit authorization (a peer coordinator's dispatch doesn't establish that on its own); I escalated and received explicit sign-off to proceed with the design as specified, on the basis that the shared caches are content-addressed/immutable (uv/pip/go-mod verify checksums by default).

**Two vars are the weakest points of that argument, and a fresh-context finder (below) sharpened exactly why, with citations**: Go's module cache is checksum-verified via `go.sum` by default, but `go mod verify` is a *separate*, not-automatic step, and the build cache (`GOCACHE`) is keyed by build-input hash rather than literal content, so a job that engineers an input collision (or one running with verification disabled) could poison an entry a later job trusts ([Go module cache docs](https://go.dev/ref/mod#module-cache)). `npm_config_cache` similarly holds registry-metadata/lookup entries beyond pure content-addressed tarballs ([npm cacache](https://docs.npmjs.com/cli/cache/)); uv's own docs explicitly warn against direct cache modification, and pip's HTTP/wheel caches share the same shape ([uv cache](https://docs.astral.sh/uv/concepts/cache/), [pip caching](https://pip.pypa.io/en/latest/topics/caching/)). This is the accepted tradeoff, not a blocking defect — flagged here so the risk picture stays precise.

## Verification

Full `config`/`cli`/`runtime`/`sandbox`/`subprocess` suites green, plus 7 new tests including a **real-subprocess end-to-end proof** (a shell job echoes the injected env var — not a mock). I traced and confirmed directly against the code (not just design intent):
- The grant-then-produce-recompute ordering in `daemon_worker.go` is exactly as designed (verified by re-reading the diff).
- `CodexAdapter` has no stored `Agent` field — `Deliver`/`Start` read the agent value fresh at call time, so the late `WritablePaths` mutation reaches codex's sandbox args.
- `buildRuntimeAdapter`'s own Landlock-wrap check for non-produce Claude/Kimi runs *before* my mutation (value-copy semantics), so non-produce jobs are not retroactively sandboxed.
- `EnvInjectingRunner` composes correctly with both `WrappingRunner` (produce Landlock) and `TeeRunner` (transcript retention) — both implement `RunEnv` and merge rather than clobber; `appendRuntimeOutputRunner`'s existing `EnvInjectingRunner` case recurses into `.Inner`, so my env wrap stays the outermost layer regardless of tee ordering.

## Review — 5 rounds of fresh-context sol/codex finders, gated on an explicit `approved` verdict

Two Claude-based finders initially hit the account's weekly API limit mid-review; per the ruling, this PR was **not merged on self-verification** — the same lenses were redispatched as fresh-context sol/codex agents instead, iterating until a comprehensive pass returned a clean `approved` on the full combined diff. **5 real defects found and fixed across the loop:**

1. **HIGH** — codex only honors `WritablePaths` under the `workspace-write` autonomy policy; a read-only/auto codex job was getting the cache **env vars** pointed at a directory its sandbox grants nothing for (breaks `go build`, degrades uv/pip/npm). `applyIsolatedToolCacheGrants` now no-ops for codex jobs unless the policy is `workspace-write`/`danger-full-access`.
2. **MEDIUM** — `runWithTempWorker` (the runtime-session-contention reroute path) never called either new function, silently losing the cache redirect for rerouted jobs. Mirrored the primary path's calls there.
3. **HIGH** (a bug in fix #1) — my first attempt let a codex `ChatSeat` bypass the gate on the theory it always gets workspace-write; but `codexSandboxArgs` returns for a `ChatSeat` *before* the `--add-dir` loop ever runs, so a chat seat never gets a real write grant regardless of policy. The bypass reproduced the exact original defect for background moot seats. Fixed: `ChatSeat` is now unconditionally excluded.
4. **HIGH** — `LoadToolCache`'s default directory was never normalized absolute; a relative `--home` (which `pathsFromFlag` doesn't itself reject) would make Landlock hard-error and would make unsandboxed jobs resolve the env var relative to their own worktree — silently recreating the bug this feature exists to fix. Fixed with `filepath.Abs`.
5. **MEDIUM** — a malformed `[section` header (missing closing bracket) didn't clear the config parser's active section, so a botched header right after `[cache]` kept applying subsequent lines to it. Fixed (and applied proactively to the not-yet-shipped lever-3 config file, same copied pattern).

**Disclosed, not fixed** (the accepted design tradeoff, sharpened with citations, not a code defect): `GOCACHE`/`GOMODCACHE`/uv/pip/npm cross-job cache-poisoning risk — see the security note above.

Every fix re-verified by a fresh finder; the final comprehensive pass returned **`decision: approved`** with no remaining findings across the full 5-commit diff. Full `config`/`cli`/`runtime`/`sandbox`/`subprocess`/`db` suites green throughout, gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
