### PR TITLE
fix(org): decouple live-presence from blocked-role waking + log the silent gates (#1118)

### DIFF
--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -174,16 +174,7 @@ func startBlockedRoleWakeLoop(ctx context.Context, store *db.Store, home string,
 // evaluation. It swallows and logs every failure so the background lane can
 // never affect daemon supervision.
 func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, stdout io.Writer, now time.Time, deps blockedRoleWakeDependencies) {
-	wakeAfter := resolveBlockedRoleWakeAfter(home)
-	if wakeAfter <= 0 || store == nil || deps.eventSink == nil {
-		return
-	}
-	sink, err := deps.eventSink(ctx, store, home)
-	if err != nil {
-		writeLine(stdout, "blocked_since role event sink unavailable: %v", err)
-		return
-	}
-	if sink == nil || deps.availability == nil || !deps.availability.Available(ctx) {
+	if store == nil {
 		return
 	}
 	configFile := resolveConfigFile(home)
@@ -195,11 +186,30 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 		writeLine(stdout, "blocked_since role org config load failed: %v", err)
 		return
 	}
-	if deps.provider == nil {
+	roles := orgConfig.Roles()
+	if len(roles) == 0 {
+		// No org roles configured: there is nothing to snapshot or persist, so
+		// skip silently (matches the pre-#1118 behavior for an unconfigured
+		// daemon). Checking this FIRST means a herdr-less/no-org deployment — the
+		// common OSS/automated-user case — never probes herdr and never logs.
 		return
 	}
-	provider := deps.provider(orgConfig.Roles())
+	// Herdr reachability gates the snapshot that BOTH org live-presence and the
+	// blocked-role wake need. This return was previously silent, which made a
+	// broken /org page impossible to diagnose from daemon.log for a deployment
+	// that DOES configure org roles (#1118). Scoped to the roles-configured case
+	// above so it cannot spam an unconfigured daemon's log every tick.
+	if deps.availability == nil || !deps.availability.Available(ctx) {
+		writeLine(stdout, "blocked_since role loop: herdr not available; org presence + wake skipped this tick")
+		return
+	}
+	if deps.provider == nil {
+		writeLine(stdout, "blocked_since role loop: nil org presence provider factory; skipped")
+		return
+	}
+	provider := deps.provider(roles)
 	if provider == nil {
+		writeLine(stdout, "blocked_since role loop: nil org presence provider; skipped")
 		return
 	}
 	snapshotCtx, cancel := context.WithTimeout(ctx, blockedRoleSnapshotTimeout)
@@ -213,7 +223,26 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 		writeLine(stdout, "blocked_since role snapshot skipped: observed_at is zero")
 		return
 	}
+
+	// Org live-presence persists on EVERY tick herdr is reachable, INDEPENDENT of
+	// whether blocked-role waking is enabled — the /org page must populate even
+	// when blocked_role_wake_after is 0 (its default). Coupling these was #1118.
 	persistOrgRoleLivePresence(ctx, store, snapshot, stdout)
+
+	// Blocked-role WAKE evaluation is the opt-in half: only when a wake threshold
+	// is configured and the blocked-role event rule yields a sink.
+	wakeAfter := resolveBlockedRoleWakeAfter(home)
+	if wakeAfter <= 0 || deps.eventSink == nil {
+		return
+	}
+	sink, err := deps.eventSink(ctx, store, home)
+	if err != nil {
+		writeLine(stdout, "blocked_since role event sink unavailable: %v", err)
+		return
+	}
+	if sink == nil {
+		return
+	}
 	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snapshot, wakeAfter, stdout, now.UTC()); err != nil {
 		writeLine(stdout, "blocked_since role evaluation failed: %v", err)
 	}

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -205,6 +205,119 @@ blocked_role_wake_after = "1h"
 	}
 }
 
+// TestRunBlockedRoleWakeOncePersistsPresenceWithWakeDisabled guards #1118: org
+// live-presence must populate even when blocked-role WAKING is off
+// (blocked_role_wake_after=0, the default), i.e. presence is decoupled from wake.
+func TestRunBlockedRoleWakeOncePersistsPresenceWithWakeDisabled(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No blocked_role_wake_after override → defaults to 0 (waking disabled).
+	if _, err := file.WriteString(`
+[org]
+enforce = "warn"
+[org.roles."owner"]
+scope = ["*"]
+merge_rule = "owner"
+pane = "Gitmoot"
+`); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if got := resolveBlockedRoleWakeAfter(home); got != 0 {
+		t.Fatalf("resolveBlockedRoleWakeAfter() = %s, want 0 (disabled)", got)
+	}
+
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	snapshot := org.Snapshot{
+		States:     map[string]org.RoleLiveState{"owner": {State: org.StateWorking}},
+		ObservedAt: now, ProviderVersion: "test-v1",
+	}
+	availability := &fakeBlockedRoleAvailability{available: true}
+	sink := &recordingSink{}
+	deps := blockedRoleWakeDependencies{
+		availability: availability,
+		provider:     func([]config.OrgRole) org.Provider { return orgFixtureProvider{snapshot: snapshot} },
+		eventSink:    func(context.Context, *db.Store, string) (events.Sink, error) { return sink, nil },
+	}
+
+	var output bytes.Buffer
+	runBlockedRoleWakeOnce(context.Background(), store, home, &output, now, deps)
+
+	// Presence persists despite waking being disabled — the #1118 decoupling.
+	livePresence, err := store.ListRoleLivePresence(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(livePresence) != 1 || livePresence[0].Role != "owner" || livePresence[0].State != string(org.StateWorking) {
+		t.Fatalf("presence not persisted with wake disabled: %+v (output=%s)", livePresence, output.String())
+	}
+	// Waking is disabled → the snapshot was still taken (availability probed) but
+	// NO blocked-role evaluation ran, so no events were emitted.
+	if availability.calls != 1 {
+		t.Fatalf("availability calls = %d, want 1", availability.calls)
+	}
+	if got := len(sink.byType(events.EventJobBlocked)); got != 0 {
+		t.Fatalf("blocked events with waking disabled = %d, want 0", got)
+	}
+}
+
+// TestRunBlockedRoleWakeOnceSkipsSilentlyWithNoOrgRolesConfigured guards the
+// regression a high review caught in #1118's first pass: a herdr-less/no-org
+// deployment (the common OSS/automated-user case) must NEVER probe herdr or log
+// on this once-a-minute loop — with zero org roles configured there is nothing
+// to snapshot, so the availability check (and its diagnostic line) must not run.
+func TestRunBlockedRoleWakeOnceSkipsSilentlyWithNoOrgRolesConfigured(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	availability := &fakeBlockedRoleAvailability{available: false}
+	deps := blockedRoleWakeDependencies{
+		availability: availability,
+		provider: func([]config.OrgRole) org.Provider {
+			t.Fatal("provider factory must not be called with zero org roles configured")
+			return nil
+		},
+		eventSink: func(context.Context, *db.Store, string) (events.Sink, error) {
+			t.Fatal("event sink must not be resolved with zero org roles configured")
+			return nil, nil
+		},
+	}
+
+	var output bytes.Buffer
+	runBlockedRoleWakeOnce(context.Background(), store, home, &output, time.Now().UTC(), deps)
+
+	if availability.calls != 0 {
+		t.Fatalf("availability.Available calls = %d, want 0 (herdr must not be probed)", availability.calls)
+	}
+	if output.Len() != 0 {
+		t.Fatalf("output = %q, want empty (no log spam for an unconfigured daemon)", output.String())
+	}
+}
+
 // TestBlockedSinceReNudgesOncePerIntervalWhileStillBlocked pins the self-healing
 // semantic: while a subject stays blocked it is re-nudged at most once per
 // wakeAfter, not a single durable one-shot (so a dropped wake recovers).


### PR DESCRIPTION
Closes #1118. The public /org page showed every role as never-seen because `org_role_live_presence` stayed empty on the deployed daemon, despite herdr being reachable.

## Root cause
The issue's availability hypothesis didn't hold — verified live: `herdr status --json` returns `running:true` with just `HERDR_SOCKET_PATH`, and the exec runner has inherited the daemon's environment since #1060 (already in v0.9.4), so `cockpit.Available()` passes in the daemon context.

The real cause: `persistOrgRoleLivePresence` sat **after** the `wakeAfter<=0 || eventSink==nil` gate in `runBlockedRoleWakeOnce`, so org live-presence was coupled to blocked-role **waking** being opted in. `blocked_role_wake_after` defaults to `"0s"` (disabled), so a default daemon never persisted presence — and every early-return in that loop was **silent** (no log line), making the empty page undiagnosable from `daemon.log`.

## Fix
- Org live-presence is now snapshotted and persisted on **every tick herdr is reachable**, independent of the wake threshold and event sink. Blocked-role **wake evaluation** stays the opt-in half, gated separately on `wakeAfter>0 + sink`.
- Org config/roles load **first**: with zero roles configured, the function returns before ever probing herdr — a high review on the first pass of this fix caught that an unconditional availability probe + log would spam `daemon.log` every 60s on any herdr-less/no-org deployment (the common case). Scoping the probe to roles-configured deployments fixed that.
- Diagnostic log lines now cover the herdr-unavailable, no-provider-factory, and nil-provider returns that were previously silent.

## Deferred (noted, not in scope)
`resolveBlockedRoleWakeAfter` redundantly re-resolves the config file and reloads `OrchestratePolicy` once/minute even though the caller already has both — real cost is a small extra TOML parse (not a hot path). Fixing it means changing a shared function's signature across 4 call sites; deferred as a follow-up cleanup to keep this bug-fix PR scoped.

## Verify (post-deploy)
`org_role_live_presence` should populate within 1 minute of daemon restart; `/org` should show working/idle/blocked for pane-bound roles.

## Gate
`go build` / `go vet` / `go test ./...` / `go generate && git diff` green; `-race` on the blocked-role/presence tests green. Full sharded race runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
