### PR TITLE
chore(deps): pin gitmoot-dashboard at the org-chart pan fix (#126)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723145238-6a85b65c2051
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723145238-6a85b65c2051 h1:RAS/xjo7eRlxbGHgKTtjjYQESqiRSVlIFH0ZwSr352A=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723145238-6a85b65c2051/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf h1:ooqc+bZwdHYzh2nMzSKHKTv6Z3Fytwr1vAbUCN4cbZg=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## Summary
- Bumps `github.com/gitmoot/gitmoot-dashboard` to `2ee2d26694cf80e00fc5274aeec194626bcbc508`, the squash-merge of gitmoot-dashboard#127.
- #127 fixes #126: org chart drag-to-pan was frozen because the pointerdown guard excluded the role/workflow cards (which cover most of the chart) from starting a pan. A follow-up round also closed a pointer-capture escape-race an independent review caught (a fast drag whose first move lands outside the chart before capture is acquired could leave a stale drag record and get the chart stuck in a panning state).
- No gitmoot core logic changes — `go.mod`/`go.sum` only.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go generate ./... && git diff --exit-code` (clean, no drift)
- [x] `go test ./internal/cli/... -run TestDashboard` (dashboard-web integration tests green)
- [x] Upstream gitmoot-dashboard#127 CI green at the pinned commit; diff independently reviewed (not just self-report) before and after a real, reproduced regression was found and fixed

Deploy note: this needs a `gitmoot-dashboard-web` restart to pick up the new pin (per the two-binaries deploy note in AGENTS.md) once merged.