### PR TITLE
chore(deps): pin gitmoot-dashboard at the pan-from-cards Org build (#126)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723145238-6a85b65c2051
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723145238-6a85b65c2051 h1:RAS/xjo7eRlxbGHgKTtjjYQESqiRSVlIFH0ZwSr352A=
-github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723145238-6a85b65c2051/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf h1:ooqc+bZwdHYzh2nMzSKHKTv6Z3Fytwr1vAbUCN4cbZg=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
Dep-only pin bump: dashboard module 6a85b65 -> 2ee2d26 (dashboard PR #127, issue #126 — org chart pans from anywhere including cards, grab cursor, pointer-capture race fix reviewed by an independent codex pass).

Deploy note: dashboard-web rebuild + restart only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)