### PR TITLE
Gitmoot: P1 gitmoot#1130 — ListCheckRunsForRef is fail-closed-erroring on EVERY

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1017,37 +1018,42 @@ func (c *GhClient) GetCombinedStatus(ctx context.Context, repo Repository, ref s
 }
 
 func (c *GhClient) ListCheckRunsForRef(ctx context.Context, repo Repository, ref string) ([]PullRequestCheck, error) {
-	type checkRunsPage struct {
-		CheckRuns []struct {
-			Name        string `json:"name"`
-			Status      string `json:"status"`
-			Conclusion  string `json:"conclusion"`
-			HTMLURL     string `json:"html_url"`
-			CompletedAt string `json:"completed_at"`
-		} `json:"check_runs"`
+	type checkRun struct {
+		Name        string `json:"name"`
+		Status      string `json:"status"`
+		Conclusion  string `json:"conclusion"`
+		HTMLURL     string `json:"html_url"`
+		CompletedAt string `json:"completed_at"`
 	}
 	result, err := c.run(ctx, false,
-		"api", "--paginate", "--slurp",
+		"api", "--paginate", "--jq",
+		".check_runs[] | {name, status, conclusion, html_url, completed_at}",
 		endpoint(repo, "commits", ref, "check-runs")+"?per_page=100",
 	)
 	if err != nil {
 		return nil, err
 	}
-	var pages []checkRunsPage
-	if err := json.Unmarshal([]byte(result.Stdout), &pages); err != nil {
-		return nil, fmt.Errorf("decode gh api response: %w", err)
-	}
 	checks := []PullRequestCheck{}
-	for _, page := range pages {
-		for _, run := range page.CheckRuns {
-			state := strings.TrimSpace(run.Conclusion)
-			if state == "" {
-				state = strings.TrimSpace(run.Status)
-			}
-			checks = append(checks, PullRequestCheck{
-				Name: run.Name, State: state, Link: run.HTMLURL, CompletedAt: run.CompletedAt,
-			})
+	scanner := bufio.NewScanner(strings.NewReader(result.Stdout))
+	for line := 1; scanner.Scan(); line++ {
+		raw := strings.TrimSpace(scanner.Text())
+		if raw == "" {
+			continue
 		}
+		var run checkRun
+		if err := json.Unmarshal([]byte(raw), &run); err != nil {
+			return nil, fmt.Errorf("decode gh check-run line %d: %w", line, err)
+		}
+		state := strings.TrimSpace(run.Conclusion)
+		if state == "" {
+			state = strings.TrimSpace(run.Status)
+		}
+		checks = append(checks, PullRequestCheck{
+			Name: run.Name, State: state, Link: run.HTMLURL, CompletedAt: run.CompletedAt,
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan gh check-runs response: %w", err)
 	}
 	return checks, nil
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -796,15 +796,11 @@ func TestListPullRequestChecksUsesGhChecksOutput(t *testing.T) {
 }
 
 func TestListCheckRunsForRefUsesExactCommitSHAAndPaginates(t *testing.T) {
-	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `[{
-		"check_runs": [
-			{"name":"build","status":"completed","conclusion":"success","html_url":"https://example.test/build","completed_at":"2026-07-23T10:00:00Z"}
-		]
-	},{
-		"check_runs": [
-			{"name":"lint","status":"in_progress","conclusion":"","html_url":"https://example.test/lint","completed_at":null}
-		]
-	}]`}}}
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `
+{"name":"page-1-build","status":"completed","conclusion":"success","html_url":"https://example.test/build","completed_at":"2026-07-23T10:00:00Z"}
+
+{"name":"page-2-lint","status":"in_progress","conclusion":"","html_url":"https://example.test/lint","completed_at":null}
+`}}}
 	client := GhClient{Runner: runner}
 
 	checks, err := client.ListCheckRunsForRef(
@@ -816,14 +812,33 @@ func TestListCheckRunsForRefUsesExactCommitSHAAndPaginates(t *testing.T) {
 		t.Fatalf("ListCheckRunsForRef: %v", err)
 	}
 	if len(checks) != 2 ||
-		checks[0].Name != "build" || checks[0].State != "success" ||
-		checks[1].Name != "lint" || checks[1].State != "in_progress" {
+		checks[0].Name != "page-1-build" || checks[0].State != "success" ||
+		checks[1].Name != "page-2-lint" || checks[1].State != "in_progress" {
 		t.Fatalf("checks = %+v", checks)
 	}
 	runner.wantArgs(t, 0,
-		"api", "--paginate", "--slurp",
+		"api", "--paginate", "--jq",
+		".check_runs[] | {name, status, conclusion, html_url, completed_at}",
 		"repos/gitmoot/gitmoot/commits/head123/check-runs?per_page=100",
 	)
+}
+
+func TestListCheckRunsForRefRejectsMalformedNDJSON(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: `
+{"name":"build","status":"completed","conclusion":"success"}
+not-json
+{"name":"lint","status":"completed","conclusion":"success"}
+`}}}
+	client := GhClient{Runner: runner}
+
+	_, err := client.ListCheckRunsForRef(
+		context.Background(),
+		Repository{Owner: "gitmoot", Name: "gitmoot"},
+		"head123",
+	)
+	if err == nil || !strings.Contains(err.Error(), "decode gh check-run line 3") {
+		t.Fatalf("error = %v, want malformed NDJSON line", err)
+	}
 }
 
 func TestListPullRequestChecksAcceptsPendingExitWithJSON(t *testing.T) {


### PR DESCRIPTION
WHAT:
Replaced unsupported gh api --slurp pagination with gh 2.45.0-compatible paginated NDJSON parsing for exact-head check runs.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-f66d3637

RESULTS:
- Live verification: gh 2.45.0 help confirms --paginate/--jq and no --slurp; exact command returned 27 check runs for d9a73a6.
- go test -count=1 ./internal/github/... -run TestListCheckRunsForRef: pass.
- go test -count=1 ./internal/github/... ./internal/workflow/... ./internal/cli/...: pass; workflow 112.673s, CLI 495.492s.
- go build -buildvcs=false ./...: pass; plain go build ./... is blocked by this uncommitted worktree's VCS-stamping error.
- go vet ./...: pass.
- go generate ./...: clean; pre/post diff hashes identical. git diff --check: pass.

RISK:
Review the generated diff before merging.

TASK:
adhoc-f66d3637

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Replaced unsupported gh api --slurp pagination with gh 2.45.0-compatible paginated NDJSON parsing for exact-head check runs.
````
