### PR TITLE
chore(deps): pin gitmoot-dashboard at the org-chart canvas rebuild (#130)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726152319-0f0153ec1626
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf h1:ooqc+bZwdHYzh2nMzSKHKTv6Z3Fytwr1vAbUCN4cbZg=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726152319-0f0153ec1626 h1:+Ku2cRcpJsx3ZD2ajIXR4mbAbkVg3IbCJ312mxWrOKA=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726152319-0f0153ec1626/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## Summary
- Bumps `github.com/gitmoot/gitmoot-dashboard` to `0f0153ec16265f1397a52a6ffbb1e35f0b6ab50e`, the squash-merge of gitmoot-dashboard#132.
- #132 closes owner-directive issue #130 (absorbs #128): the org chart is rebuilt on the run view's own rendering pattern (CSS-transform world + SVG with foreignObject cards, explicit tree layout, camera state architecturally decoupled from data refresh). Free pan from anywhere, cursor-centered wheel zoom, pinch-to-zoom (built fresh), mobile touch, and pan/zoom state that survives SSE/poll re-renders.
- Went through two independent adversarial review passes before merge: the first caught two real, reproduced defects (a breakpoint-resize race and a badge-count layout-cache staleness), both fixed and re-verified by a second pass. No gitmoot core logic changes — `go.mod`/`go.sum` only.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go generate ./... && git diff --exit-code` (clean, no drift)
- [x] `go test ./internal/cli/... -run TestDashboard` (dashboard-web integration tests green)
- [x] Upstream gitmoot-dashboard#132 CI green at the merged commit

Deploy note: needs a `gitmoot-dashboard-web` restart to pick up the new pin (per the two-binaries deploy note in AGENTS.md) once merged.