### PR TITLE
chore(deps): pin gitmoot-dashboard at the Brain mobile graph fix (#129)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726152319-0f0153ec1626
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726160023-a6365fe9d2cf
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf h1:ooqc+
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260723235132-2ee2d26694cf/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726152319-0f0153ec1626 h1:+Ku2cRcpJsx3ZD2ajIXR4mbAbkVg3IbCJ312mxWrOKA=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726152319-0f0153ec1626/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726160023-a6365fe9d2cf h1:7t0BUp6dx9E/tEc4oUhiI4bflxi8w6Qg9pB+BDw7kyg=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726160023-a6365fe9d2cf/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## Summary
- Bumps `github.com/gitmoot/gitmoot-dashboard` to `a6365fe9d2cf148ec92ede64cd2779b7b9efa212`, the squash-merge of gitmoot-dashboard#133.
- #133 closes issue #129: the Brain graph was invisible on mobile (deliberately `display:none`'d in favor of a repo-accordion list). Adds an explicit List/Graph toggle so the real, touch-interactive force-graph is reachable on demand; the accordion stays the default. Includes a fix for a real bug an independent review caught (a Changelog-switch + viewport-resize sequence leaving the canvas at stale internal dimensions), independently re-verified live (Playwright + real screenshots) before merge.
- No gitmoot core logic changes — `go.mod`/`go.sum` only.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go generate ./... && git diff --exit-code` (clean, no drift)
- [x] `go test ./internal/cli/... -run TestDashboard` (dashboard-web integration tests green)
- [x] Upstream gitmoot-dashboard#133 CI green at the merged commit

Deploy note: needs a `gitmoot-dashboard-web` restart to pick up the new pin (per the two-binaries deploy note in AGENTS.md) once merged.