### PR TITLE
feat(org): wake digests + repo routing convenience flag (#1096)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -168,15 +168,19 @@ pane = "w1:p2"
 
 ```sh
 gitmoot org events rule add --on guard --match owner/repo --wake maintainer
+gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule list
 gitmoot org events rule rm <rule-id>
 ```
 
 Kinds are `escalation`, `attention`, `guard`, `job-terminal`, and `blocked`.
 The v1 `--match` filter is a case-insensitive substring tested against the event
-repo and job id; empty matches all. A plain `job.blocked` event matches both
+repo and job id; empty matches all. `--repo` is an alias for that same filter;
+pass only one of the two flags. A plain `job.blocked` event matches both
 `job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
-synthesized `blocked_since` event matches only `blocked`. Set
+synthesized `blocked_since` event matches only `blocked`. Task episodes due in
+one evaluator pass are emitted as one oldest-first digest; blocked roles retain
+one event per role. Set
 `[orchestrate].blocked_role_wake_after` to a positive Go duration to emit such an
 event when a task or Herdr role stays blocked past the threshold, re-nudging at
 most once per that interval while it remains blocked (so a dropped wake

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -128,6 +129,7 @@ func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink even
 		return err
 	}
 	taskPrefix := "task:" + strings.TrimSpace(repo) + ":"
+	var digestItems []blockedTaskDigestItem
 	for _, episode := range episodes {
 		if !strings.HasPrefix(episode.Subject, taskPrefix) {
 			continue
@@ -145,10 +147,34 @@ func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink even
 		if !stale {
 			continue
 		}
-		if err := emitBlockedSinceEpisode(ctx, store, sink, episode, taskID, taskID, repo, "task "+taskID, wakeAfter, now); err != nil {
+		blockedSince, blockedFor, due, err := blockedEpisodeDue(episode, wakeAfter, now)
+		if err != nil {
 			writeLine(stdout, "blocked_since task %s emit failed: %v", taskID, err)
+			continue
 		}
+		if !due {
+			continue
+		}
+		if err := markBlockedEpisodeEmitted(ctx, store, episode, now); err != nil {
+			writeLine(stdout, "blocked_since task %s emit failed: %v", taskID, err)
+			continue
+		}
+		digestItems = append(digestItems, blockedTaskDigestItem{
+			taskID:       taskID,
+			blockedSince: blockedSince,
+			blockedFor:   blockedFor,
+		})
 	}
+	if len(digestItems) == 0 {
+		return nil
+	}
+	sort.Slice(digestItems, func(i, j int) bool {
+		if digestItems[i].blockedFor == digestItems[j].blockedFor {
+			return digestItems[i].taskID < digestItems[j].taskID
+		}
+		return digestItems[i].blockedFor > digestItems[j].blockedFor
+	})
+	events.EmitEvent(ctx, sink, buildBlockedTaskDigestEvent(repo, digestItems, now))
 	return nil
 }
 
@@ -345,15 +371,15 @@ func blockedEpisodeStale(updatedAt string, staleBefore time.Time) bool {
 	return !parsed.After(staleBefore)
 }
 
-func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.Sink, episode db.BlockedEpisode, subjectID, rootID, repo, detailSubject string, wakeAfter time.Duration, now time.Time) error {
+func blockedEpisodeDue(episode db.BlockedEpisode, wakeAfter time.Duration, now time.Time) (time.Time, time.Duration, bool, error) {
 	now = now.UTC()
 	blockedSince, err := time.Parse(db.BlockedEpisodeTimeLayout, episode.BlockedSince)
 	if err != nil {
-		return fmt.Errorf("parse blocked_since %q: %w", episode.BlockedSince, err)
+		return time.Time{}, 0, false, fmt.Errorf("parse blocked_since %q: %w", episode.BlockedSince, err)
 	}
 	blockedFor := now.Sub(blockedSince)
 	if blockedFor <= wakeAfter {
-		return nil // not blocked long enough yet
+		return time.Time{}, 0, false, nil // not blocked long enough yet
 	}
 	// Re-nudge at most once per wakeAfter interval while the subject stays blocked
 	// (an alert repeat_interval), rather than a single durable one-shot: a wake that
@@ -361,23 +387,65 @@ func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.S
 	// failure) self-heals on the next interval instead of being lost forever.
 	if last := strings.TrimSpace(episode.EmittedAt); last != "" {
 		if lastEmitted, err := time.Parse(db.BlockedEpisodeTimeLayout, last); err == nil && now.Sub(lastEmitted) <= wakeAfter {
-			return nil // already nudged within the current interval
+			return time.Time{}, 0, false, nil // already nudged within the current interval
 		}
 	}
+	return blockedSince, blockedFor, true, nil
+}
+
+func markBlockedEpisodeEmitted(ctx context.Context, store *db.Store, episode db.BlockedEpisode, now time.Time) error {
 	// Mark BEFORE emit: a mark-write failure then means no emit this tick (retry
 	// next tick, the gate is still open) — never a per-tick duplicate — and a
 	// mark-success whose async wake is dropped re-nudges on the next interval.
 	if err := store.MarkBlockedEpisodeEmitted(ctx, episode.Subject, now); err != nil {
 		return fmt.Errorf("mark blocked episode emitted: %w", err)
 	}
+	return nil
+}
+
+func buildBlockedSinceEvent(subjectID, rootID, repo, detailSubject string, blockedSince time.Time, blockedFor time.Duration, now time.Time) events.Event {
 	// Carry the stable first_since (blocked_since) so a consumer distinguishes a
 	// re-nudge (same job_id + same since) from a genuinely fresh episode after a
 	// re-block (same job_id, new since) — a repeat must not read as a fresh alert.
 	detail := fmt.Sprintf("%s blocked %s (since %s)", detailSubject, blockedFor.Round(time.Second), blockedSince.UTC().Format(time.RFC3339))
 	ev := events.NewEvent(events.EventJobBlocked, subjectID, rootID, repo, string(workflow.TaskBlocked), detail, now, workflow.RedactCommentText)
 	ev.Cause = "blocked_since"
+	return ev
+}
+
+func emitBlockedSinceEpisode(ctx context.Context, store *db.Store, sink events.Sink, episode db.BlockedEpisode, subjectID, rootID, repo, detailSubject string, wakeAfter time.Duration, now time.Time) error {
+	now = now.UTC()
+	blockedSince, blockedFor, due, err := blockedEpisodeDue(episode, wakeAfter, now)
+	if err != nil {
+		return err
+	}
+	if !due {
+		return nil
+	}
+	if err := markBlockedEpisodeEmitted(ctx, store, episode, now); err != nil {
+		return err
+	}
+	ev := buildBlockedSinceEvent(subjectID, rootID, repo, detailSubject, blockedSince, blockedFor, now)
 	events.EmitEvent(ctx, sink, ev)
 	return nil
+}
+
+type blockedTaskDigestItem struct {
+	taskID       string
+	blockedSince time.Time
+	blockedFor   time.Duration
+}
+
+func buildBlockedTaskDigestEvent(repo string, items []blockedTaskDigestItem, now time.Time) events.Event {
+	oldest := items[0]
+	suffix := ""
+	if len(items) > 1 {
+		suffix = fmt.Sprintf(" (+%d more)", len(items)-1)
+	}
+	detail := fmt.Sprintf("%d tasks blocked — oldest %s — %s%s", len(items), oldest.blockedFor.Round(time.Second), oldest.taskID, suffix)
+	ev := events.NewEvent(events.EventJobBlocked, oldest.taskID, oldest.taskID, repo, string(workflow.TaskBlocked), detail, now, workflow.RedactCommentText)
+	ev.Cause = "blocked_since"
+	return ev
 }
 
 func taskEpisodeSubject(repo, taskID string) string {

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -442,7 +442,13 @@ func buildBlockedTaskDigestEvent(repo string, items []blockedTaskDigestItem, now
 	if len(items) > 1 {
 		suffix = fmt.Sprintf(" (+%d more)", len(items)-1)
 	}
-	detail := fmt.Sprintf("%d tasks blocked — oldest %s — %s%s", len(items), oldest.blockedFor.Round(time.Second), oldest.taskID, suffix)
+	// Carry the anchor's "(since ...)" the same way buildBlockedSinceEvent does
+	// for the role path: JobID/RootID here is the oldest item's taskID, so a
+	// consumer keying off (job_id, since) can still tell a re-nudge of the SAME
+	// anchor apart from a fresh digest whose oldest task changed identity
+	// between ticks.
+	detail := fmt.Sprintf("%d tasks blocked — oldest %s (since %s) — %s%s",
+		len(items), oldest.blockedFor.Round(time.Second), oldest.blockedSince.UTC().Format(time.RFC3339), oldest.taskID, suffix)
 	ev := events.NewEvent(events.EventJobBlocked, oldest.taskID, oldest.taskID, repo, string(workflow.TaskBlocked), detail, now, workflow.RedactCommentText)
 	ev.Cause = "blocked_since"
 	return ev

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -127,7 +127,8 @@ func TestEvaluateBlockedTaskEpisodesDigestsDueTasksAndMarksEachEpisode(t *testin
 	if ev.JobID != "task-oldest" || ev.RootID != "task-oldest" || ev.Repo != repo || ev.Cause != "blocked_since" {
 		t.Fatalf("digest event = %+v", ev)
 	}
-	for _, want := range []string{"3 tasks blocked", "oldest 4h0m0s", "task-oldest", "(+2 more)"} {
+	wantSince := tasks[1].blockedSince.UTC().Format(time.RFC3339) // task-oldest, the digest anchor
+	for _, want := range []string{"3 tasks blocked", "oldest 4h0m0s", "(since " + wantSince + ")", "task-oldest", "(+2 more)"} {
 		if !strings.Contains(ev.Detail, want) {
 			t.Fatalf("digest detail %q missing %q", ev.Detail, want)
 		}
@@ -176,8 +177,10 @@ func TestEvaluateBlockedTaskEpisodesSingleTaskUsesOneItemDigest(t *testing.T) {
 	if len(blocked) != 1 {
 		t.Fatalf("job.blocked events = %d, want 1", len(blocked))
 	}
-	if ev := blocked[0]; ev.Detail != "1 tasks blocked — oldest 2h0m0s — task-only" || strings.Contains(ev.Detail, "(+") {
-		t.Fatalf("one-item digest detail = %q", ev.Detail)
+	wantSince := now.Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	wantDetail := "1 tasks blocked — oldest 2h0m0s (since " + wantSince + ") — task-only"
+	if ev := blocked[0]; ev.Detail != wantDetail || strings.Contains(ev.Detail, "(+") {
+		t.Fatalf("one-item digest detail = %q, want %q", ev.Detail, wantDetail)
 	}
 }
 
@@ -438,8 +441,8 @@ func TestBlockedSinceReNudgesOncePerIntervalWhileStillBlocked(t *testing.T) {
 	nudgeAt(base.Add(30*time.Minute), 1)        // within interval → no re-emit
 	nudgeAt(base.Add(wakeAfter+time.Minute), 2) // past interval, still blocked → re-nudge #2
 
-	// The task digest no longer carries each item's first_since, but the durable
-	// per-task episode must retain that stable identity across re-nudges.
+	// The digest carries only the anchor item's first_since, not every item's, but
+	// the durable per-task episode must retain that stable identity across re-nudges.
 	episodes, err = store.ListBlockedEpisodes(ctx)
 	if err != nil || len(episodes) != 1 || episodes[0].BlockedSince != firstSince {
 		t.Fatalf("re-nudge changed episode identity: episodes=%+v first_since=%q err=%v", episodes, firstSince, err)

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -92,6 +92,95 @@ func assertBlockedSinceTaskEvent(t *testing.T, sink *recordingSink, want int) {
 	}
 }
 
+func TestEvaluateBlockedTaskEpisodesDigestsDueTasksAndMarksEachEpisode(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	repo := "owner/repo"
+	now := time.Now().UTC().Truncate(time.Second).Add(4 * time.Hour)
+	wakeAfter := time.Hour
+	tasks := []struct {
+		id           string
+		blockedSince time.Time
+	}{
+		{id: "task-newest", blockedSince: now.Add(-2 * time.Hour)},
+		{id: "task-oldest", blockedSince: now.Add(-4 * time.Hour)},
+		{id: "task-middle", blockedSince: now.Add(-3 * time.Hour)},
+	}
+	for _, task := range tasks {
+		if err := store.UpsertTask(ctx, db.Task{ID: task.id, RepoFullName: repo, State: string(workflow.TaskBlocked)}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.UpsertBlockedEpisode(ctx, taskEpisodeSubject(repo, task.id), task.blockedSince, now.Add(-time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sink := &recordingSink{}
+	if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, wakeAfter, io.Discard, now); err != nil {
+		t.Fatalf("evaluateBlockedTaskEpisodes() error = %v", err)
+	}
+	blocked := sink.byType(events.EventJobBlocked)
+	if len(blocked) != 1 {
+		t.Fatalf("job.blocked events = %d, want one digest", len(blocked))
+	}
+	ev := blocked[0]
+	if ev.JobID != "task-oldest" || ev.RootID != "task-oldest" || ev.Repo != repo || ev.Cause != "blocked_since" {
+		t.Fatalf("digest event = %+v", ev)
+	}
+	for _, want := range []string{"3 tasks blocked", "oldest 4h0m0s", "task-oldest", "(+2 more)"} {
+		if !strings.Contains(ev.Detail, want) {
+			t.Fatalf("digest detail %q missing %q", ev.Detail, want)
+		}
+	}
+
+	episodes, err := store.ListBlockedEpisodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(episodes) != len(tasks) {
+		t.Fatalf("blocked episodes = %d, want %d", len(episodes), len(tasks))
+	}
+	wantEmittedAt := now.Format(db.BlockedEpisodeTimeLayout)
+	for _, episode := range episodes {
+		if episode.EmittedAt != wantEmittedAt {
+			t.Errorf("episode %q emitted_at = %q, want %q", episode.Subject, episode.EmittedAt, wantEmittedAt)
+		}
+	}
+
+	if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, wakeAfter, io.Discard, now.Add(time.Minute)); err != nil {
+		t.Fatalf("evaluateBlockedTaskEpisodes(subsequent) error = %v", err)
+	}
+	if got := len(sink.byType(events.EventJobBlocked)); got != 1 {
+		t.Fatalf("job.blocked events after subsequent pass = %d, want 1", got)
+	}
+}
+
+func TestEvaluateBlockedTaskEpisodesSingleTaskUsesOneItemDigest(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	repo := "owner/repo"
+	taskID := "task-only"
+	now := time.Now().UTC().Truncate(time.Second).Add(2 * time.Hour)
+	if err := store.UpsertTask(ctx, db.Task{ID: taskID, RepoFullName: repo, State: string(workflow.TaskBlocked)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertBlockedEpisode(ctx, taskEpisodeSubject(repo, taskID), now.Add(-2*time.Hour), now.Add(-time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	sink := &recordingSink{}
+	if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, time.Hour, io.Discard, now); err != nil {
+		t.Fatalf("evaluateBlockedTaskEpisodes() error = %v", err)
+	}
+	blocked := sink.byType(events.EventJobBlocked)
+	if len(blocked) != 1 {
+		t.Fatalf("job.blocked events = %d, want 1", len(blocked))
+	}
+	if ev := blocked[0]; ev.Detail != "1 tasks blocked — oldest 2h0m0s — task-only" || strings.Contains(ev.Detail, "(+") {
+		t.Fatalf("one-item digest detail = %q", ev.Detail)
+	}
+}
+
 type fakeBlockedRoleAvailability struct {
 	available bool
 	calls     int
@@ -340,21 +429,53 @@ func TestBlockedSinceReNudgesOncePerIntervalWhileStillBlocked(t *testing.T) {
 			t.Fatalf("blocked events at %s = %d, want %d", at, got, want)
 		}
 	}
-	nudgeAt(base, 1)                            // crosses threshold → emit #1
+	nudgeAt(base, 1) // crosses threshold → emit #1
+	episodes, err := store.ListBlockedEpisodes(ctx)
+	if err != nil || len(episodes) != 1 {
+		t.Fatalf("episodes after first nudge = %+v, err=%v", episodes, err)
+	}
+	firstSince := episodes[0].BlockedSince
 	nudgeAt(base.Add(30*time.Minute), 1)        // within interval → no re-emit
 	nudgeAt(base.Add(wakeAfter+time.Minute), 2) // past interval, still blocked → re-nudge #2
 
-	// Repeats must be self-identifying: both re-nudges of the SAME episode carry the
-	// SAME first_since, so a consumer never reads a re-nudge as a fresh episode.
-	blocked := sink.byType(events.EventJobBlocked)
-	sinceOf := func(detail string) string {
-		if i := strings.Index(detail, "(since "); i >= 0 {
-			return detail[i:]
-		}
-		return ""
+	// The task digest no longer carries each item's first_since, but the durable
+	// per-task episode must retain that stable identity across re-nudges.
+	episodes, err = store.ListBlockedEpisodes(ctx)
+	if err != nil || len(episodes) != 1 || episodes[0].BlockedSince != firstSince {
+		t.Fatalf("re-nudge changed episode identity: episodes=%+v first_since=%q err=%v", episodes, firstSince, err)
 	}
-	if s0, s1 := sinceOf(blocked[0].Detail), sinceOf(blocked[1].Detail); s0 == "" || s0 != s1 {
-		t.Fatalf("re-nudges not self-identifying by first_since: %q vs %q", blocked[0].Detail, blocked[1].Detail)
+	blocked := sink.byType(events.EventJobBlocked)
+	for _, ev := range blocked {
+		if !strings.Contains(ev.Detail, "1 tasks blocked — oldest") || strings.Contains(ev.Detail, "(+") {
+			t.Fatalf("re-nudge event is not a one-item digest: %q", ev.Detail)
+		}
+	}
+}
+
+func TestEvaluateBlockedRoleEpisodesStillEmitsPerRole(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	sink := &recordingSink{}
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	snapshot := org.Snapshot{
+		States: map[string]org.RoleLiveState{
+			"owner":  {State: org.StateBlocked},
+			"review": {State: org.StateBlocked},
+			"worker": {State: org.StateBlocked},
+		},
+		ObservedAt: now.Add(-2 * time.Hour),
+	}
+	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snapshot, time.Hour, io.Discard, now); err != nil {
+		t.Fatalf("evaluateBlockedRoleEpisodes() error = %v", err)
+	}
+	blocked := sink.byType(events.EventJobBlocked)
+	if len(blocked) != 3 {
+		t.Fatalf("job.blocked role events = %d, want one per role", len(blocked))
+	}
+	for _, ev := range blocked {
+		if ev.Cause != "blocked_since" || !strings.HasPrefix(ev.JobID, "org-blocked:") || !strings.HasPrefix(ev.Detail, "role ") {
+			t.Fatalf("role event changed shape: %+v", ev)
+		}
 	}
 }
 

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -127,7 +127,7 @@ func printOrgUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot org recycle ROLE --kind KIND --handoff NOTE [--pane ID] [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org escalate --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"QUESTION\"")
 	fmt.Fprintln(w, "  gitmoot org escalate resolve NOTE_ID [--by ROLE] [--note ANSWER_NOTE_ID] [--home DIR]")
-	fmt.Fprintln(w, "  gitmoot org events rule add --on KIND [--match FILTER] --wake ROLE [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org events rule add --on KIND [--match FILTER | --repo SUBSTRING] --wake ROLE [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule list [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule rm [--home DIR] ID")
 }
@@ -1104,7 +1104,7 @@ var eventRuleKinds = map[string]struct{}{
 
 func runOrgEvents(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
-		fmt.Fprintln(stdout, "Usage:\n  gitmoot org events rule add --on <kind> [--match <filter>] --wake <role> [--home path]\n  gitmoot org events rule list [--home path]\n  gitmoot org events rule rm [--home path] <id>")
+		fmt.Fprintln(stdout, "Usage:\n  gitmoot org events rule add --on <kind> [--match <filter> | --repo <substring>] --wake <role> [--home path]\n  gitmoot org events rule list [--home path]\n  gitmoot org events rule rm [--home path] <id>")
 		return 0
 	}
 	if args[0] != "rule" {
@@ -1112,7 +1112,7 @@ func runOrgEvents(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if len(args) == 1 || args[1] == "-h" || args[1] == "--help" {
-		fmt.Fprintln(stdout, "Usage:\n  gitmoot org events rule add --on <kind> [--match <filter>] --wake <role> [--home path]\n  gitmoot org events rule list [--home path]\n  gitmoot org events rule rm [--home path] <id>")
+		fmt.Fprintln(stdout, "Usage:\n  gitmoot org events rule add --on <kind> [--match <filter> | --repo <substring>] --wake <role> [--home path]\n  gitmoot org events rule list [--home path]\n  gitmoot org events rule rm [--home path] <id>")
 		return 0
 	}
 	switch args[1] {
@@ -1137,6 +1137,7 @@ func runOrgEventRuleAdd(args []string, stdout, stderr io.Writer) int {
 	// case-insensitive substring tested independently against repo and job id;
 	// an empty filter matches every event of the selected kind.
 	match := fs.String("match", "", "case-insensitive substring matched against event repo or job id; empty matches all")
+	repo := fs.String("repo", "", "case-insensitive repo substring (alias for --match)")
 	wake := fs.String("wake", "", "organization role to wake")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -1147,6 +1148,15 @@ func runOrgEventRuleAdd(args []string, stdout, stderr io.Writer) int {
 	if fs.NArg() != 0 {
 		fmt.Fprintln(stderr, "org events rule add does not accept positional arguments")
 		return 2
+	}
+	matchFilter := strings.TrimSpace(*match)
+	repoFilter := strings.TrimSpace(*repo)
+	if matchFilter != "" && repoFilter != "" {
+		fmt.Fprintln(stderr, "org events rule add: --match and --repo cannot both be set; choose one")
+		return 2
+	}
+	if repoFilter != "" {
+		matchFilter = repoFilter
 	}
 	kind := strings.ToLower(strings.TrimSpace(*onKind))
 	if _, ok := eventRuleKinds[kind]; !ok {
@@ -1178,7 +1188,7 @@ func runOrgEventRuleAdd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "org events rule add: generate id: %v\n", err)
 		return 1
 	}
-	rule := db.EventRule{ID: id, OnKind: kind, MatchFilter: strings.TrimSpace(*match), WakeRole: role.Name, Enabled: true}
+	rule := db.EventRule{ID: id, OnKind: kind, MatchFilter: matchFilter, WakeRole: role.Name, Enabled: true}
 	if err := withStore(*home, func(store *db.Store) error {
 		return store.AddEventRule(context.Background(), rule)
 	}); err != nil {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -1553,3 +1553,74 @@ func TestOrgEventRuleAddListRemoveAndValidation(t *testing.T) {
 		t.Fatalf("post-positional --home code=%d err=%q", code, errOut.String())
 	}
 }
+
+func TestOrgEventRuleRepoAliasUsesMatchFilter(t *testing.T) {
+	home, paths := setupOrgHome(t)
+	add := func(flagName string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		if code := runOrg([]string{"events", "rule", "add", "--home", home, "--on", "blocked", flagName, "tendwire", "--wake", "owner"}, &stdout, &stderr); code != 0 {
+			t.Fatalf("add %s code=%d out=%q err=%q", flagName, code, stdout.String(), stderr.String())
+		}
+		return strings.TrimSpace(strings.TrimPrefix(stdout.String(), "added "))
+	}
+	matchID := add("--match")
+	repoID := add("--repo")
+
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	rules, err := store.ListEventRules(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("event rules = %d, want 2", len(rules))
+	}
+	byID := make(map[string]db.EventRule, len(rules))
+	for _, rule := range rules {
+		byID[rule.ID] = rule
+	}
+	matchRule, matchOK := byID[matchID]
+	repoRule, repoOK := byID[repoID]
+	if !matchOK || !repoOK {
+		t.Fatalf("created rules missing: ids=%q,%q rules=%+v", matchID, repoID, rules)
+	}
+	if matchRule.OnKind != repoRule.OnKind ||
+		matchRule.MatchFilter != repoRule.MatchFilter ||
+		matchRule.WakeRole != repoRule.WakeRole ||
+		matchRule.Enabled != repoRule.Enabled ||
+		repoRule.MatchFilter != "tendwire" {
+		t.Fatalf("--match rule = %+v, --repo rule = %+v", matchRule, repoRule)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"events", "rule", "list", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("list code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	lineSuffixes := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		id, suffix, ok := strings.Cut(line, "\t")
+		if ok {
+			lineSuffixes[id] = suffix
+		}
+	}
+	if lineSuffixes[matchID] == "" || lineSuffixes[matchID] != lineSuffixes[repoID] || !strings.Contains(lineSuffixes[repoID], "match=tendwire") {
+		t.Fatalf("list output differs by input alias: %q", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"events", "rule", "add", "--home", home, "--on", "blocked", "--match", "tendwire", "--repo", "gitmoot/", "--wake", "owner"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("both filters code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--match and --repo cannot both be set") {
+		t.Fatalf("both filters error = %q", stderr.String())
+	}
+	rules, err = store.ListEventRules(context.Background())
+	if err != nil || len(rules) != 2 {
+		t.Fatalf("ambiguous add changed rules: rules=%+v err=%v", rules, err)
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1255,14 +1255,17 @@ Event-rule wakes are separately opt-in:
 
 ```sh
 gitmoot org events rule add --on attention --match owner/repo --wake maintainer
+gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule list
 gitmoot org events rule rm --home /alternate/home <rule-id>
 ```
 
 `--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, or `blocked`.
 `--match` is a case-insensitive substring matched independently against the
-event repo and job id; omit it to match every event of that kind. `--wake` must
-name a declared role whose config sets `pane = "<pane-id-or-label>"`. Gitmoot
+event repo and job id; omit it to match every event of that kind. `--repo` is a
+discoverable alias for the same substring filter, useful for repo-to-role
+routing. Pass only one of `--match` or `--repo`. `--wake` must name a declared
+role whose config sets `pane = "<pane-id-or-label>"`. Gitmoot
 first resolves the value as an exact pane label and otherwise uses it as a
 literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --timeout
 8000` and treats delivered (`result.type = "agent_prompted"`, or a post-delivery
@@ -1270,7 +1273,8 @@ literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --tim
 "agent_prompt_stalled"`). Stalls increment the role's consecutive missed-wake
 counter and delivery resets it; transport failures leave it unchanged. Rules,
 pane resolution, counter writes, and wakes are best-effort; with no rule rows
-this path is off.
+this path is off. Task episodes due in one evaluator pass produce one
+oldest-first digest event; blocked roles retain one event per role.
 
 ## External-coordinator workflow groups
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1127,15 +1127,17 @@ Event-rule wakes are separately opt-in:
 
 ```sh
 gitmoot org events rule add --on attention --match owner/repo --wake maintainer
+gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule list
 gitmoot org events rule rm --home /alternate/home <rule-id>
 ```
 
 `--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, or `blocked`.
 `--match` is a case-insensitive substring matched against the event repo or job
-id; empty matches all. The wake role must exist and set `pane = "<herdr-pane>"`;
-Gitmoot resolves that value as an exact pane label first and otherwise treats it
-as a literal pane id.
+id; empty matches all. `--repo` is a discoverable alias for the same substring
+filter; pass only one of `--match` or `--repo`. The wake role must exist and set
+`pane = "<herdr-pane>"`; Gitmoot resolves that value as an exact pane label first
+and otherwise treats it as a literal pane id.
 Delivery is best-effort and verified with Herdr's `agent_prompted` versus
 `agent_prompt_stalled` result; zero rules leaves the feature off.
 

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -166,15 +166,19 @@ pane = "w1:p2"
 
 ```sh
 gitmoot org events rule add --on guard --match owner/repo --wake maintainer
+gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule list
 gitmoot org events rule rm <rule-id>
 ```
 
 Kinds are `escalation`, `attention`, `guard`, `job-terminal`, and `blocked`.
 The v1 `--match` filter is a case-insensitive substring tested against the event
-repo and job id; empty matches all. A plain `job.blocked` event matches both
+repo and job id; empty matches all. `--repo` is an alias for that same filter;
+pass only one of the two flags. A plain `job.blocked` event matches both
 `job-terminal` and `blocked`, while guard-caused blocks match `guard` first. A
-synthesized `blocked_since` event matches only `blocked`. Set
+synthesized `blocked_since` event matches only `blocked`. Task episodes due in
+one evaluator pass are emitted as one oldest-first digest; blocked roles retain
+one event per role. Set
 `[orchestrate].blocked_role_wake_after` to a positive Go duration to emit such an
 event when a task or Herdr role stays blocked past the threshold, re-nudging at
 most once per that interval while it remains blocked (so a dropped wake


### PR DESCRIPTION
## Summary

- Closes #1096: task-blocked and role-blocked wake events digest instead of
  storming one event per subject, plus an `org events rule add --repo` flag
  as a clearer alias for `--match`.
- `evaluateBlockedTaskEpisodes` now accumulates all due-this-tick task
  episodes and emits **one** oldest-first digest event per pass (still
  marking each episode's own `emitted_at` individually), instead of one
  event per task. The role evaluator (`evaluateBlockedRoleEpisodes`) is
  unchanged — one event per role, deliberately not batched.
- `org events rule add` gains `--repo <filter>` as a same-field alias for
  `--match` (mutually exclusive with it); both feed the same
  `db.EventRule.MatchFilter`.
- **Review-caught fix** (`/code-review high`, applied before opening this
  PR): the digest's `Detail` string initially dropped the `(since ...)`
  marker that the role path and the pre-refactor per-task path both carry —
  silently breaking the documented re-nudge-vs-fresh-episode contract for
  task digests. Restored the anchor (oldest) item's `blocked_since` into the
  digest detail in the same RFC3339 format `buildBlockedSinceEvent` uses.
  This also resolves a plausible anchor-identity-shift concern the review
  raised: the since-value now changes whenever the digest's anchor task
  changes between ticks, so a shift is detectable rather than silently
  ambiguous.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout 25m ./internal/cli/...` — green (615s)
- [x] `go generate ./... && git diff --exit-code` — clean (no generated-artifact drift)
- [x] New/updated tests: `TestEvaluateBlockedTaskEpisodesDigestsDueTasksAndMarksEachEpisode`,
      `TestEvaluateBlockedTaskEpisodesSingleTaskUsesOneItemDigest`,
      `TestEvaluateBlockedRoleEpisodesStillEmitsPerRole` (regression guard: role
      path stays unbatched), plus `--repo`/`--match` mutual-exclusion coverage
      for `org events rule add`.
- [x] `/code-review high` (workflow, fresh-context finders + verify pass) —
      one confirmed finding, fixed pre-PR (see above).
- [x] SHA-keyed CI watch on the pushed head — pending, will confirm green
      before requesting merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
