### PR TITLE
chore(deps): pin gitmoot-dashboard at the /jobs default view fix (#131)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726160023-a6365fe9d2cf
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726165048-244e664c8863
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726152319-0f0153ec1626 h1:+Ku2c
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726152319-0f0153ec1626/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726160023-a6365fe9d2cf h1:7t0BUp6dx9E/tEc4oUhiI4bflxi8w6Qg9pB+BDw7kyg=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726160023-a6365fe9d2cf/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726165048-244e664c8863 h1:+Ry6kglFxd8ikE5LS7DIYcHs6O9E07yHieZr+RYIF/g=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726165048-244e664c8863/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## Summary
- Bumps `github.com/gitmoot/gitmoot-dashboard` to `244e664c88638bdd73effb1c126c731d56a5138b`, the squash-merge of gitmoot-dashboard#134.
- #134 closes issue #131: the /jobs default view now demotes only old `succeeded` jobs into a collapsed "N older completed jobs" section. Active jobs (pending/queued/running/blocked), failed jobs, cancelled jobs, unrecognized/future states, and any job without a trustworthy timestamp always stay in the default view regardless of age — only settled successes age out, and only when no explicit State facet is selected (picking a facet, including "succeeded", still shows the full unfiltered history). Went through two independent adversarial review passes; the first caught a real one-click-doesn't-open interaction bug in the disclosure, fixed and re-verified clean.
- Completes the Lane 2 sequence: #130/#132 (org chart canvas rebuild), #129/#133 (Brain graph mobile), #131/#134 (this one) — all three now merged and pinned.
- No gitmoot core logic changes — `go.mod`/`go.sum` only.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go generate ./... && git diff --exit-code` (clean, no drift)
- [x] `go test ./internal/cli/... -run TestDashboard` (dashboard-web integration tests green)
- [x] Upstream gitmoot-dashboard#134 CI green at the merged commit

Deploy note: needs a `gitmoot-dashboard-web` restart to pick up the new pin (per the two-binaries deploy note in AGENTS.md) once merged.