### PR TITLE
feat(org): per-role model pinning at recycle (#1120)

### DIFF
--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -250,6 +250,7 @@ type orgBriefOutput struct {
 	Path            []string           `json:"path"`
 	Scope           []string           `json:"scope"`
 	MergeRule       string             `json:"merge_rule"`
+	Model           string             `json:"model"`
 	LastSeenAt      string             `json:"last_seen_at,omitempty"`
 	LastCommand     string             `json:"last_command,omitempty"`
 	ProviderState   org.LifecycleState `json:"provider_state"`
@@ -267,6 +268,7 @@ type orgStatusOutput struct {
 	Depth           int                `json:"depth,omitempty"`
 	Scope           []string           `json:"scope"`
 	MergeRule       string             `json:"merge_rule"`
+	Model           string             `json:"model"`
 	LastSeenAt      string             `json:"last_seen_at,omitempty"`
 	LastSeenAge     string             `json:"last_seen_age,omitempty"`
 	LastCommand     string             `json:"last_command,omitempty"`
@@ -351,7 +353,7 @@ func buildOrgBriefOutput(cfg config.OrgConfig, presence map[string]db.OrgRolePre
 	row := presence[role.Name]
 	return orgBriefOutput{
 		Role: role.Name, Parent: role.Parent, Pane: role.Pane, Children: childNames, Path: cfg.Path(role.Name), Scope: role.Scope,
-		MergeRule: role.MergeRule, LastSeenAt: row.LastSeenAt, LastCommand: row.LastCommand,
+		MergeRule: role.MergeRule, Model: role.Model, LastSeenAt: row.LastSeenAt, LastCommand: row.LastCommand,
 		ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: snapshot.ObservedAt, ProviderVersion: snapshot.ProviderVersion,
 	}
 }
@@ -418,7 +420,7 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 	}
 	if command == "chart" {
 		for _, row := range rows {
-			fmt.Fprintf(stdout, "%s%s · %s · scope=%s · merge=%s · seen=%s%s\n", strings.Repeat("  ", row.Depth), row.Role, row.ProviderState, strings.Join(row.Scope, ","), dash(row.MergeRule), dash(row.LastSeenAge), orgMissedWakeFlag(row))
+			fmt.Fprintf(stdout, "%s%s · %s · scope=%s · merge=%s · model=%s · seen=%s%s\n", strings.Repeat("  ", row.Depth), row.Role, row.ProviderState, strings.Join(row.Scope, ","), dash(row.MergeRule), dash(row.Model), dash(row.LastSeenAge), orgMissedWakeFlag(row))
 		}
 		return 0
 	}
@@ -443,6 +445,7 @@ func printOrgBrief(w io.Writer, brief orgBriefOutput) {
 	fmt.Fprintf(w, "path: %s\n", dash(strings.Join(brief.Path, " > ")))
 	fmt.Fprintf(w, "scope: %s\n", dash(strings.Join(brief.Scope, ", ")))
 	fmt.Fprintf(w, "merge_rule: %s\n", dash(brief.MergeRule))
+	fmt.Fprintf(w, "model: %s\n", dash(brief.Model))
 	fmt.Fprintf(w, "last_seen: %s\n", dash(brief.LastSeenAt))
 	fmt.Fprintf(w, "last_command: %s\n", dash(brief.LastCommand))
 	fmt.Fprintf(w, "provider: %s\n", brief.ProviderState)
@@ -547,7 +550,7 @@ func runOrgRecycle(args []string, stdout, stderr io.Writer) int {
 	var boot strings.Builder
 	printOrgBrief(&boot, brief)
 	fmt.Fprintf(&boot, "\nhandoff: %s\n", handoff)
-	req := org.RecycleRequest{Role: role.Name, Pane: pane, Kind: kind, AgentName: role.Name, BootPrompt: boot.String()}
+	req := org.RecycleRequest{Role: role.Name, Pane: pane, Kind: kind, AgentName: role.Name, Model: role.Model, BootPrompt: boot.String()}
 	if err := provider.Recycle(ctx, req); err != nil {
 		fmt.Fprintf(stderr, "org recycle: %v (handoff journaled in workflow %s)\n", err, workflowID)
 		return 1

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -232,7 +232,7 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 		}
 		rows = append(rows, orgStatusOutput{
 			Role: role.Name, Parent: role.Parent, Pane: role.Pane, Depth: len(shared.Config.Path(role.Name)) - 1,
-			Scope: role.Scope, MergeRule: role.MergeRule, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
+			Scope: role.Scope, MergeRule: role.MergeRule, Model: role.Model, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
 			ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: observedAt, ProviderVersion: providerVersion,
 			RecycleStatus: recycleStatus, RecycleAfter: recycleAfterText,
 			MissedWakes: consecutive, Flagged: flagged, FlagReason: flagReason,

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -613,6 +613,44 @@ func TestRunOrgBriefAndChartSurfaceModelPin(t *testing.T) {
 		!strings.Contains(stdout.String(), "review · idle · scope=gitmoot/* · merge=self · model=sonnet") {
 		t.Fatalf("chart output = %q", stdout.String())
 	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"org", "brief", "--home", home, "--role", "review", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("brief --json code = %d stderr=%s", code, stderr.String())
+	}
+	var brief orgBriefOutput
+	if err := json.Unmarshal(stdout.Bytes(), &brief); err != nil || brief.Model != "sonnet" {
+		t.Fatalf("brief.Model = %+v err=%v output=%s", brief, err, stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"org", "status", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("status --json code = %d stderr=%s", code, stderr.String())
+	}
+	var status []orgStatusOutput
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("decode status: %v; output=%s", err, stdout.String())
+	}
+	seen := map[string]bool{}
+	for _, row := range status {
+		switch row.Role {
+		case "review":
+			if row.Model != "sonnet" {
+				t.Fatalf("review status model = %q, want sonnet", row.Model)
+			}
+			seen["review"] = true
+		case "owner":
+			if row.Model != "" {
+				t.Fatalf("owner status model = %q, want empty (unpinned)", row.Model)
+			}
+			seen["owner"] = true
+		}
+	}
+	if !seen["review"] || !seen["owner"] {
+		t.Fatalf("expected roles missing from status: %+v", status)
+	}
 }
 
 func TestRunOrgOverviewFlagsConsecutiveMissedWakes(t *testing.T) {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -572,6 +572,49 @@ func TestRunOrgBriefChartStatusAndPresence(t *testing.T) {
 	}
 }
 
+func TestRunOrgBriefAndChartSurfaceModelPin(t *testing.T) {
+	home, paths := setupOrgHome(t)
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("model = \"sonnet\"\n"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	withOrgProvider(t, orgFixtureProvider{snapshot: org.Snapshot{States: map[string]org.RoleLiveState{
+		"owner": {State: org.StateWorking}, "review": {State: org.StateIdle},
+	}}})
+
+	for _, test := range []struct {
+		role string
+		want string
+	}{
+		{role: "review", want: "model: sonnet\n"},
+		{role: "owner", want: "model: -\n"},
+	} {
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"org", "brief", "--home", home, "--role", test.role}, &stdout, &stderr); code != 0 {
+			t.Fatalf("brief %s code = %d stderr=%s", test.role, code, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), test.want) {
+			t.Fatalf("brief %s output = %q, want containing %q", test.role, stdout.String(), test.want)
+		}
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"org", "chart", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("chart code = %d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "owner · working · scope=* · merge=owner · model=-") ||
+		!strings.Contains(stdout.String(), "review · idle · scope=gitmoot/* · merge=self · model=sonnet") {
+		t.Fatalf("chart output = %q", stdout.String())
+	}
+}
+
 func TestRunOrgOverviewFlagsConsecutiveMissedWakes(t *testing.T) {
 	home, paths := setupOrgHome(t)
 	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
@@ -964,6 +1007,17 @@ func TestRunOrgRecycleValidation(t *testing.T) {
 
 func TestRunOrgRecycleJournalsAndBootsSuccessor(t *testing.T) {
 	home, paths := setupOrgRecycleHome(t, "w1:p2")
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("model = \"sonnet\"\n"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
 	store, err := db.Open(paths.Database)
 	if err != nil {
 		t.Fatal(err)
@@ -995,7 +1049,7 @@ func TestRunOrgRecycleJournalsAndBootsSuccessor(t *testing.T) {
 		t.Fatalf("Recycle requests = %+v", requests)
 	}
 	req := requests[0]
-	if req.Role != "owner" || req.Pane != "w1:p2" || req.Kind != "codex" || req.AgentName != "owner" {
+	if req.Role != "owner" || req.Pane != "w1:p2" || req.Kind != "codex" || req.AgentName != "owner" || req.Model != "sonnet" {
 		t.Fatalf("Recycle request = %+v", req)
 	}
 	for _, want := range []string{"role: owner", "path: owner", "provider: idle", "last_command: agent_run", "handoff: Release is ready for final verification."} {

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -143,7 +143,15 @@ func (p *herdrOrgProvider) Recycle(ctx context.Context, req org.RecycleRequest) 
 	}
 	bounded, cancel := context.WithTimeout(ctx, herdrOrgRecycleDeadline)
 	defer cancel()
-	_, err := p.run(bounded, "agent", "start", agentName, "--kind", kind, "--pane", pane, "--timeout", strconv.Itoa(herdrOrgRecycleTimeoutMS), "--", req.BootPrompt)
+	args := []string{"agent", "start", agentName, "--kind", kind, "--pane", pane, "--timeout", strconv.Itoa(herdrOrgRecycleTimeoutMS), "--"}
+	// Herdr snapshots do not expose the running model, so this can enforce the
+	// configured pin at recycle but cannot detect live-vs-pinned drift until
+	// Herdr provides that signal.
+	if strings.TrimSpace(req.Model) != "" {
+		args = append(args, "--model", req.Model)
+	}
+	args = append(args, req.BootPrompt)
+	_, err := p.run(bounded, args...)
 	if err != nil {
 		return fmt.Errorf("herdr agent start for org role %q (pane %q must already be at an interactive shell prompt): %w", role, pane, err)
 	}

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -146,9 +146,12 @@ func (p *herdrOrgProvider) Recycle(ctx context.Context, req org.RecycleRequest) 
 	args := []string{"agent", "start", agentName, "--kind", kind, "--pane", pane, "--timeout", strconv.Itoa(herdrOrgRecycleTimeoutMS), "--"}
 	// Herdr snapshots do not expose the running model, so this can enforce the
 	// configured pin at recycle but cannot detect live-vs-pinned drift until
-	// Herdr provides that signal.
-	if strings.TrimSpace(req.Model) != "" {
-		args = append(args, "--model", req.Model)
+	// Herdr provides that signal. Only inject --model for kinds gitmoot has
+	// verified support it (its own codex/claude/kimi runtimes) — herdr's other
+	// ~18 agent kinds are unverified and a rejected flag would break recycle
+	// outright, so an unsupported kind silently ignores the pin.
+	if model := strings.TrimSpace(req.Model); model != "" && herdrKindSupportsModelFlag(kind) {
+		args = append(args, "--model", model)
 	}
 	args = append(args, req.BootPrompt)
 	_, err := p.run(bounded, args...)
@@ -156,6 +159,19 @@ func (p *herdrOrgProvider) Recycle(ctx context.Context, req org.RecycleRequest) 
 		return fmt.Errorf("herdr agent start for org role %q (pane %q must already be at an interactive shell prompt): %w", role, pane, err)
 	}
 	return nil
+}
+
+// herdrKindSupportsModelFlag reports whether the named herdr agent kind's CLI
+// is verified to accept a startup `-m/--model <value>` flag. Restricted to
+// gitmoot's own three driven runtimes (codex, claude, kimi) — herdr supports
+// many more kinds, but their model-flag support has not been checked.
+func herdrKindSupportsModelFlag(kind string) bool {
+	switch kind {
+	case "codex", "claude", "kimi":
+		return true
+	default:
+		return false
+	}
 }
 
 func mapHerdrAgentStatus(raw string) org.RoleLiveState {

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -136,17 +136,38 @@ func TestHerdrOrgProviderFailures(t *testing.T) {
 func TestHerdrOrgProviderRecycleCommand(t *testing.T) {
 	for _, test := range []struct {
 		name  string
+		kind  string
 		model string
 		want  []string
 	}{
 		{
 			name: "unpinned preserves command",
+			kind: "codex",
 			want: []string{"agent", "start", "owner", "--kind", "codex", "--pane", "w1:p2", "--timeout", "30000", "--", "role: owner\n\nhandoff: ship it"},
 		},
 		{
 			name:  "pinned model precedes boot prompt",
+			kind:  "codex",
 			model: "sonnet",
 			want:  []string{"agent", "start", "owner", "--kind", "codex", "--pane", "w1:p2", "--timeout", "30000", "--", "--model", "sonnet", "role: owner\n\nhandoff: ship it"},
+		},
+		{
+			name:  "pinned model trims stray whitespace",
+			kind:  "claude",
+			model: "  sonnet  ",
+			want:  []string{"agent", "start", "owner", "--kind", "claude", "--pane", "w1:p2", "--timeout", "30000", "--", "--model", "sonnet", "role: owner\n\nhandoff: ship it"},
+		},
+		{
+			name:  "pinned model applies for kimi",
+			kind:  "kimi",
+			model: "k2",
+			want:  []string{"agent", "start", "owner", "--kind", "kimi", "--pane", "w1:p2", "--timeout", "30000", "--", "--model", "k2", "role: owner\n\nhandoff: ship it"},
+		},
+		{
+			name:  "pinned model ignored for an unverified kind",
+			kind:  "gemini",
+			model: "sonnet",
+			want:  []string{"agent", "start", "owner", "--kind", "gemini", "--pane", "w1:p2", "--timeout", "30000", "--", "role: owner\n\nhandoff: ship it"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -160,7 +181,7 @@ func TestHerdrOrgProviderRecycleCommand(t *testing.T) {
 			}
 			provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
 			req := org.RecycleRequest{
-				Role: "owner", Pane: "w1:p2", Kind: "codex", AgentName: "owner",
+				Role: "owner", Pane: "w1:p2", Kind: test.kind, AgentName: "owner",
 				Model: test.model, BootPrompt: "role: owner\n\nhandoff: ship it",
 			}
 			if err := provider.Recycle(context.Background(), req); err != nil {

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -134,22 +134,42 @@ func TestHerdrOrgProviderFailures(t *testing.T) {
 }
 
 func TestHerdrOrgProviderRecycleCommand(t *testing.T) {
-	var got []string
-	run := func(ctx context.Context, args ...string) (string, error) {
-		if _, ok := ctx.Deadline(); !ok {
-			t.Fatal("Recycle runner context has no deadline")
-		}
-		got = append([]string(nil), args...)
-		return "", nil
-	}
-	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
-	req := org.RecycleRequest{Role: "owner", Pane: "w1:p2", Kind: "codex", AgentName: "owner", BootPrompt: "role: owner\n\nhandoff: ship it"}
-	if err := provider.Recycle(context.Background(), req); err != nil {
-		t.Fatalf("Recycle() error = %v", err)
-	}
-	want := []string{"agent", "start", "owner", "--kind", "codex", "--pane", "w1:p2", "--timeout", "30000", "--", req.BootPrompt}
-	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("Recycle() args = %q, want %q", got, want)
+	for _, test := range []struct {
+		name  string
+		model string
+		want  []string
+	}{
+		{
+			name: "unpinned preserves command",
+			want: []string{"agent", "start", "owner", "--kind", "codex", "--pane", "w1:p2", "--timeout", "30000", "--", "role: owner\n\nhandoff: ship it"},
+		},
+		{
+			name:  "pinned model precedes boot prompt",
+			model: "sonnet",
+			want:  []string{"agent", "start", "owner", "--kind", "codex", "--pane", "w1:p2", "--timeout", "30000", "--", "--model", "sonnet", "role: owner\n\nhandoff: ship it"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var got []string
+			run := func(ctx context.Context, args ...string) (string, error) {
+				if _, ok := ctx.Deadline(); !ok {
+					t.Fatal("Recycle runner context has no deadline")
+				}
+				got = append([]string(nil), args...)
+				return "", nil
+			}
+			provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+			req := org.RecycleRequest{
+				Role: "owner", Pane: "w1:p2", Kind: "codex", AgentName: "owner",
+				Model: test.model, BootPrompt: "role: owner\n\nhandoff: ship it",
+			}
+			if err := provider.Recycle(context.Background(), req); err != nil {
+				t.Fatalf("Recycle() error = %v", err)
+			}
+			if strings.Join(got, "\x00") != strings.Join(test.want, "\x00") {
+				t.Fatalf("Recycle() args = %q, want %q", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -601,6 +601,7 @@ path = ""
 # [org.roles."owner"]
 # scope = ["*"]
 # merge_rule = "owner"
+# model = "gpt-5.6-sol"  # optional: pin the runtime model honored at org recycle
 # [org.roles."maintainer"]
 # parent = "owner"
 # scope = ["owner/*"]

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -305,7 +305,7 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 			if err != nil {
 				return OrgConfig{}, fmt.Errorf("org role %q: parse model: %w", current, err)
 			}
-			role.Model = v
+			role.Model = strings.TrimSpace(v)
 		case "recycle_after":
 			v, err := parseOrgDuration(value)
 			if err != nil {

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -18,6 +18,7 @@ type OrgRole struct {
 	Parent      string
 	Scope       []string
 	MergeRule   string
+	Model       string
 	// Pane optionally binds this role to a Herdr pane for live presence and
 	// event-rule wakes.
 	Pane         string
@@ -246,7 +247,7 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 			}
 			continue
 		}
-		if key != "display_name" && key != "parent" && key != "scope" && key != "merge_rule" && key != "pane" && key != "recycle_after" {
+		if key != "display_name" && key != "parent" && key != "scope" && key != "merge_rule" && key != "pane" && key != "model" && key != "recycle_after" {
 			return OrgConfig{}, fmt.Errorf("unknown field %q for org role %q", key, current)
 		}
 		if roleFields[current][key] {
@@ -299,6 +300,12 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 				return OrgConfig{}, fmt.Errorf("org role %q: parse pane: %w", current, err)
 			}
 			role.Pane = strings.TrimSpace(v)
+		case "model":
+			v, err := parseOrgTOMLString(value)
+			if err != nil {
+				return OrgConfig{}, fmt.Errorf("org role %q: parse model: %w", current, err)
+			}
+			role.Model = v
 		case "recycle_after":
 			v, err := parseOrgDuration(value)
 			if err != nil {

--- a/internal/config/org_test.go
+++ b/internal/config/org_test.go
@@ -37,6 +37,50 @@ func TestLoadOrgAndScopeMatching(t *testing.T) {
 	}
 }
 
+func TestLoadOrgRoleModel(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	base := `[org.roles."owner"]
+scope = ["*"]
+[org.roles."g2"]
+parent = "owner"
+scope = ["gitmoot/*"]
+`
+	for _, test := range []struct {
+		name      string
+		suffix    string
+		wantModel string
+		wantErr   string
+	}{
+		{name: "configured", suffix: `model = "sonnet"` + "\n", wantModel: "sonnet"},
+		{name: "absent", wantModel: ""},
+		{name: "unknown remains rejected", suffix: "network = true\n", wantErr: "unknown field"},
+		{name: "duplicate", suffix: "model = \"sonnet\"\nmodel = \"opus\"\n", wantErr: `duplicate field "model"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.WriteFile(paths.ConfigFile, []byte(base+test.suffix), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadOrg(paths)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("LoadOrg() error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadOrg() error = %v", err)
+			}
+			role, ok := cfg.Role("g2")
+			if !ok || role.Model != test.wantModel {
+				t.Fatalf("Role(g2) = %+v, %v; want model %q", role, ok, test.wantModel)
+			}
+		})
+	}
+}
+
 func TestLoadOrgRecycleAfterPrecedence(t *testing.T) {
 	paths := PathsForHome(t.TempDir())
 	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {

--- a/internal/config/org_test.go
+++ b/internal/config/org_test.go
@@ -55,6 +55,7 @@ scope = ["gitmoot/*"]
 		wantErr   string
 	}{
 		{name: "configured", suffix: `model = "sonnet"` + "\n", wantModel: "sonnet"},
+		{name: "padded value is trimmed", suffix: `model = "  sonnet  "` + "\n", wantModel: "sonnet"},
 		{name: "absent", wantModel: ""},
 		{name: "unknown remains rejected", suffix: "network = true\n", wantErr: "unknown field"},
 		{name: "duplicate", suffix: "model = \"sonnet\"\nmodel = \"opus\"\n", wantErr: `duplicate field "model"`},

--- a/internal/org/provider.go
+++ b/internal/org/provider.go
@@ -31,6 +31,7 @@ type RecycleRequest struct {
 	Pane       string
 	Kind       string
 	AgentName  string
+	Model      string
 	BootPrompt string
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1167,8 +1167,8 @@ resolved role table.
 
 The registry uses `[org] enforce = "warn"|"block"` and
 `[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, an optional
-cosmetic `display_name`, and an optional `pane` Herdr binding (used by live
-presence and org event-rule wakes).
+cosmetic `display_name`, an optional `model` runtime pin, and an optional `pane`
+Herdr binding (used by live presence and org event-rule wakes).
 The binding resolves as an exact live pane label first, then as a literal pane
 id; roles without a binding retain exact role-name-as-label presence lookup. There is
 exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
@@ -1223,6 +1223,10 @@ configured `pane`. A pane binding and non-empty handoff are required. For safety
 recycle does not kill or send exit keys to the old agent: the pane must already
 be at its interactive shell prompt. The Herdr start wait is bounded to 30
 seconds; a failed start leaves the durable handoff note available for recovery.
+When a role configures `model`, recycle passes `--model <value>` to the successor
+agent; deploy this binary before adding the fail-closed field to config. Brief
+and chart surface the configured pin, but live-vs-pinned drift detection awaits
+a running-model signal from Herdr.
 
 Fresh local `agent ask`, `agent run`, `agent review`, `agent implement`,
 `orchestrate`, and `task run` dispatches accept `--org-role <name>` (or the


### PR DESCRIPTION
## Motivation: measured, not hypothetical

A fleet-wide audit (gitmoot-coc, 2026-07-26 — see #1120 for the full writeup)
found the fleet is unpinned *today*, not merely at risk of drifting:

- 28 of 45 agents declared in `config.toml` have no model line at all.
- Additional agents exist only in the DB with no model and no config entry —
  including `wave-impl` (`policy=danger-full-access`), the seat that ran every
  implementation this wave.
- `herdr-sol-impl` (Lane 4's implementer for all of herdr#7) is declared but
  its config block has no model line.
- There's no global fallback: models are declared per-agent where present, so
  absence means the seat silently takes the runtime's own default.

Every implementation this wave — herdr#7, the #1134 P0, #130/#129/#131,
#1126 — ran on a seat with no model pin, and nothing visibly broke, which is
exactly why it went unnoticed for what looks like months. That's the argument
for pinning at spawn/recycle rather than repairing after the fact: repair
requires *noticing*.

Note: that audit is about the separate `[agents.X].model` fleet registry
(`gitmoot agent start`/`subscribe`), not the `[org.roles.X].model` this PR
ships (`org recycle`) — different mechanisms, same underlying problem. Repair
of the fleet's unpinned seats and surfacing `model` in `gitmoot agent show`
are jarvis's fleet-wide call (already escalated), out of scope here.

## Summary

- Closes #1120: org roles can pin a runtime model, honored at `org recycle`.
- `config.OrgRole` gains `Model string`; `LoadOrg`'s fail-closed per-role field
  allowlist gains `"model"` (binary-first — no config anywhere carried a
  `model` key before this PR, so schema and behavior ship together).
- `org.RecycleRequest` gains `Model`; `herdrOrgProvider.Recycle` injects
  `--model <value>` as a trailing arg before the boot prompt when set. An
  unpinned role produces a byte-identical command line to today.
- `org brief`/`org chart` display the pinned value only (dash-fallback,
  mirrors `merge_rule`). Live-vs-pinned drift detection is explicitly out of
  scope: herdr's pane snapshot API exposes no model field to compare
  against (verified directly), noted as a herdr-capability-dependent
  follow-up.
- Docs: `DefaultConfig [org]` template comment + skill `CLI.md`.

**Review-caught fixes** (`/code-review high`, applied before opening this
PR — 3 findings, 2 CONFIRMED-real, 1 CONFIRMED test-coverage gap):
1. `Recycle` originally appended `--model` for *every* herdr `--kind` (21
   supported kinds), but gitmoot has only verified `--model` support for
   its own three driven runtimes (codex, claude, kimi — confirmed via each
   CLI's `--help`). A pin configured for a role later recycled under an
   unverified kind (gemini, cursor, devin, ...) could pass an unrecognized
   flag and break recycle outright. Now gated behind a small verified-kinds
   allowlist; unsupported kinds silently ignore the pin instead of risking
   a broken recycle.
2. `role.Model` wasn't trimmed on config load (unlike the adjacent `pane`
   field), so a padded TOML value would reach the downstream agent's argv
   still padded, silently defeating the pin. Trimmed at parse time.
3. `org brief`/`status --json` had no assertion on the new `Model` field
   (unlike the equivalent `pane` coverage). Added matching JSON-decode
   tests.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout 25m ./internal/cli/ ./internal/config/ ./internal/cockpit/` — green (743s)
- [x] `go generate ./... && git diff --exit-code` — clean
- [x] New tests: config-load round-trip + trim + fail-closed regression
      (`TestLoadOrgRoleModel`), recycle command-line shape for
      pinned/unpinned/trimmed/kimi/unverified-kind cases
      (`TestHerdrOrgProviderRecycleCommand`), brief/chart text +
      `--json` coverage for pinned and unpinned roles
      (`TestRunOrgBriefAndChartSurfaceModelPin`).
- [x] `/code-review high` (workflow, fresh-context finders + verify pass) —
      3 findings, all fixed pre-PR (see above).
- [x] SHA-keyed CI watch — 27/27 green, CLEAN/MERGEABLE at head `438b57b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)