### PR TITLE
fix(workflow): close missing job_events emission in task-recover CAS-miss fallback (#1133)

### DIFF
--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -1137,10 +1137,7 @@ func finishTaskRecoverJob(ctx context.Context, store *db.Store, jobID string, st
 		return err
 	}
 	if !ok {
-		if err := store.UpdateJobPayload(ctx, jobID, encoded); err != nil {
-			return err
-		}
-		return store.UpdateJobState(ctx, jobID, state)
+		return store.UpdateJobPayloadAndStateWithEvent(ctx, jobID, encoded, state, db.JobEvent{Kind: state, Message: message})
 	}
 	return nil
 }

--- a/internal/cli/workflow_test.go
+++ b/internal/cli/workflow_test.go
@@ -851,6 +851,49 @@ func (s *stubTaskRecoverGitHub) EnsurePullRequest(_ context.Context, input githu
 	}, nil
 }
 
+func TestFinishTaskRecoverJobCASMissEmitsTerminalEvent(t *testing.T) {
+	ctx := context.Background()
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	jobID := "task-task-001-recover-lead"
+	payload := workflow.JobPayload{
+		Repo:        "owner/repo",
+		Branch:      "task-001-bootstrap",
+		PullRequest: 4,
+		TaskID:      "task-001",
+		WorkflowID:  "release-42",
+	}
+	if err := store.CreateJob(ctx, db.Job{
+		ID:      jobID,
+		Agent:   "lead",
+		Type:    "implement",
+		State:   string(workflow.JobQueued),
+		Payload: mustJobPayload(t, payload),
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	payload.HeadSHA = "abc123"
+	message := "recovered task implementation"
+	if err := finishTaskRecoverJob(ctx, store, jobID, string(workflow.JobSucceeded), payload, message); err != nil {
+		t.Fatalf("finishTaskRecoverJob: %v", err)
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(workflow.JobSucceeded) || job.Payload != mustJobPayload(t, payload) {
+		t.Fatalf("job = %+v", job)
+	}
+	events, err := store.ListJobEvents(ctx, jobID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != string(workflow.JobSucceeded) || events[0].Message != message {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
 func TestRecoverTaskImplementationFinalizesDirtyWorktree(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -846,6 +846,38 @@ func (s *Store) UpdateJobPayload(ctx context.Context, id string, payload string)
 	return tx.Commit()
 }
 
+func (s *Store) UpdateJobPayloadAndStateWithEvent(ctx context.Context, id string, payload string, state string, event JobEvent) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	projection := jobProjectionFromPayload(payload)
+	result, err := tx.ExecContext(ctx, `UPDATE jobs SET state = ?, payload = ?, result_hash = ?, repo = ?, pull_request = ?, blocker_retry_at = ?, blocker_suggested_action = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND workflow_id = ?`,
+		state, payload, jobResultHashFromPayload(payload), projection.Repo, projection.PullRequest, projection.BlockerRetryAt,
+		projection.BlockerSuggestedAction, id, projection.WorkflowID)
+	if err != nil {
+		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		if err := rejectWorkflowIDMismatch(ctx, tx, id, projection.WorkflowID); err != nil {
+			return err
+		}
+		return requireAffected(result, "job", id)
+	}
+	if event.JobID == "" {
+		event.JobID = id
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 type queryRower interface {
 	QueryRowContext(context.Context, string, ...any) *sql.Row
 }

--- a/internal/db/workflow_store_test.go
+++ b/internal/db/workflow_store_test.go
@@ -297,6 +297,49 @@ func TestWorkflowIDImmutableAcrossPayloadUpdatePaths(t *testing.T) {
 	}
 }
 
+func TestUpdateJobPayloadAndStateWithEventUpdatesAtomicallyWithoutCAS(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	original := `{"repo":"acme/old","pull_request":3,"workflow_id":"release-42"}`
+	if err := store.CreateJob(ctx, Job{
+		ID:      "recover-race",
+		Agent:   "lead",
+		Type:    "implement",
+		State:   "succeeded",
+		Payload: original,
+	}); err != nil {
+		t.Fatalf("CreateJob: %v", err)
+	}
+
+	payload := `{"repo":"acme/new","pull_request":9,"workflow_id":"release-42","blocker_retry_at":"2026-07-26T10:00:00Z","blocker_suggested_action":"inspect recovery","result":{"decision":"changes_requested","summary":"blocked"}}`
+	if err := store.UpdateJobPayloadAndStateWithEvent(ctx, "recover-race", payload, "blocked", JobEvent{
+		Kind:    "blocked",
+		Message: "recovery finalization raced",
+	}); err != nil {
+		t.Fatalf("UpdateJobPayloadAndStateWithEvent: %v", err)
+	}
+
+	var state, gotPayload, resultHash, repo, blockerRetryAt, blockerSuggestedAction string
+	var pullRequest int
+	if err := store.db.QueryRowContext(ctx, `SELECT state, payload, result_hash, repo, pull_request, blocker_retry_at, blocker_suggested_action FROM jobs WHERE id = ?`, "recover-race").
+		Scan(&state, &gotPayload, &resultHash, &repo, &pullRequest, &blockerRetryAt, &blockerSuggestedAction); err != nil {
+		t.Fatalf("read updated job: %v", err)
+	}
+	if state != "blocked" || gotPayload != payload || resultHash != jobResultHashFromPayload(payload) ||
+		repo != "acme/new" || pullRequest != 9 || blockerRetryAt != "2026-07-26T10:00:00Z" ||
+		blockerSuggestedAction != "inspect recovery" {
+		t.Fatalf("updated job state=%q payload=%q result_hash=%q repo=%q pull_request=%d blocker_retry_at=%q blocker_suggested_action=%q",
+			state, gotPayload, resultHash, repo, pullRequest, blockerRetryAt, blockerSuggestedAction)
+	}
+	events, err := store.ListJobEvents(ctx, "recover-race")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].JobID != "recover-race" || events[0].Kind != "blocked" || events[0].Message != "recovery finalization raced" {
+		t.Fatalf("events = %+v", events)
+	}
+}
+
 func TestWorkflowIDDerivedAtEveryJobInsertPath(t *testing.T) {
 	store := openWorkflowTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## What

Closes ONE confirmed gap in the "bare-jobs writes bypass job_events" wart
(#1110's history): `finishTaskRecoverJob` (`internal/cli/workflow.go`), called
from `gitmoot task recover`'s finalization path when a job reaches a terminal
state (`JobFailed`/`JobBlocked`/`JobSucceeded`), first tries the atomic
`TransitionJobStatePayloadWithEvent` CAS from `running`. If that CAS misses —
a real, reachable race during recovery/retry, when the job's row wasn't in
`running` when this ran — the fallback previously called two bare, event-less
store functions (`UpdateJobPayload` + `UpdateJobState`). A job reaching a
terminal state through that fallback left **no `job_events` row**: invisible
to anything that treats `job_events` as the source of truth (dashboard,
wake-on-terminal, audit trail).

## Fix

- New `UpdateJobPayloadAndStateWithEvent` (`internal/db/store_jobs.go`),
  mirroring `UpdateJobPayload`'s existing transaction shape (payload +
  projection sync: repo, pull_request, blocker_retry_at,
  blocker_suggested_action, result_hash) but setting `state` unconditionally
  (no FROM-state check — that's precisely why the caller is in this fallback)
  and inserting the `job_events` row in the same transaction.
- `finishTaskRecoverJob`'s CAS-miss fallback now routes through it, matching
  the `Kind`/`Message` shape the CAS-success branch already uses one line
  above.

## Scope

This is the shared prerequisite for the "jobs-honesty spine" (#1125/#1132/#1133
— owner's design: ONE terminal event, THREE consumers). It does **not** touch
any consumer-side behavior yet (ghost-session reaper, `/jobs` display,
wake-on-terminal) — that's separate follow-up work. Deliberately left alone,
per explicit scope discipline:
- `internal/workflow/engine_run_budgets.go`'s bare `UpdateJobState` call — does
  call `AddJobEvent` right after (non-atomic but not missing-event); a
  narrower atomicity nit, not in scope here.
- `Store.TransitionJobState` — the *other* bare, event-less function, zero
  production callers anywhere in the repo. Dead code, left as-is; noted for a
  possible follow-up cleanup.

## Review

One fresh-context adversarial pass (sol/codex, isolated clone, no prior
context) — proportionate to this smaller, narrowly-scoped change rather than
a multi-round treatment. Returned `decision: approved`, zero findings:
confirmed the new store function is atomic/parameterized/projection-complete
and preserves workflow-ID-mismatch and missing-row handling; confirmed the
CLI wiring and both regression tests are genuine; confirmed the diff is
exactly the four intended files; independently re-ran both new tests
(`TestUpdateJobPayloadAndStateWithEventUpdatesAtomicallyWithoutCAS`,
`TestFinishTaskRecoverJobCASMissEmitsTerminalEvent`) and confirmed pass.

Full `db`/`cli`/`workflow` suites green. `go generate ./...` zero drift
(SHA-256 verified before/after). `gofmt`/`go vet`/`go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)