### PR TITLE
fix(jobs): reap ghost session jobs stuck 'running' forever (#1125)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,21 @@ pattern), bounded by depth, a per-root job budget, and loop detection.
    mv /root/.local/bin/gitmoot-dashboard-web.new /root/.local/bin/gitmoot-dashboard-web
    ```
 
-4. Restart at idle (confirm 0 running/queued jobs first):
+4. Restart at idle: confirm 0 running/queued **engine-dispatched** jobs
+   first, not raw job count. Session-recorded jobs (`session-ask-*`/
+   `session-implement-*`, #657) run entirely outside the daemon process — no
+   subprocess, no lease — and may legitimately stay `running` for hours, so
+   they don't belong in this check. #1125's reaper keeps genuinely abandoned
+   session jobs from piling up forever, but on an hours-to-a-day timescale;
+   that is a background-hygiene guarantee, not a substitute for checking
+   right now:
+
+   ```sh
+   gitmoot job list --state running --json | jq '[.[] | select(.id | startswith("session-") | not)]'
+   gitmoot job list --state queued --json | jq '[.[] | select(.id | startswith("session-") | not)]'
+   ```
+
+   Both empty (`[]`), then:
    `systemctl --user restart gitmoot-daemon gitmoot-dashboard-web`.
 5. Config-only changes (e.g. `[memory]`/`[skillopt]`) usually need no restart
    (re-read per tick / warm-reloaded on SIGHUP).

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -110,6 +110,9 @@ func runRegisteredRepoSupervisor(ctx context.Context, home string, live *daemonR
 				if err := runWorkflowAutoSettleOnce(ctx, paths, store, time.Now().UTC(), stdout); err != nil {
 					writeLine(stdout, "workflow auto-settle error: %s", err)
 				}
+				if err := runGhostSessionJobReaperOnce(ctx, paths, store, time.Now().UTC(), stdout); err != nil {
+					writeLine(stdout, "ghost session-job reaper error: %s", err)
+				}
 				if err := runHeartbeatScanOnce(ctx, paths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
 					writeLine(stdout, "heartbeat scan error: %s", err)
 				}
@@ -237,6 +240,9 @@ func runSingleRepoSupervisor(ctx context.Context, home string, d daemon.Daemon, 
 		if heartbeatPathsErr == nil {
 			if err := runWorkflowAutoSettleOnce(ctx, heartbeatPaths, store, time.Now().UTC(), stdout); err != nil {
 				writeLine(stdout, "workflow auto-settle error: %s", err)
+			}
+			if err := runGhostSessionJobReaperOnce(ctx, heartbeatPaths, store, time.Now().UTC(), stdout); err != nil {
+				writeLine(stdout, "ghost session-job reaper error: %s", err)
 			}
 			if err := runHeartbeatScanOnce(ctx, heartbeatPaths, store, heartbeatEnqueue, time.Now().UTC()); err != nil {
 				writeLine(stdout, "heartbeat scan error: %s", err)

--- a/internal/cli/workflow_lifecycle.go
+++ b/internal/cli/workflow_lifecycle.go
@@ -44,3 +44,24 @@ func runWorkflowAutoSettleOnce(ctx context.Context, paths config.Paths, store *d
 	}
 	return nil
 }
+
+// runGhostSessionJobReaperOnce performs one home-scoped orphan sweep. Unlike
+// workflow auto-settle, a disabled age threshold still leaves the independent
+// terminal-workflow signal enabled.
+func runGhostSessionJobReaperOnce(ctx context.Context, paths config.Paths, store *db.Store, now time.Time, stdout io.Writer) error {
+	policy, err := config.LoadWorkflowLifecycle(paths)
+	after := time.Duration(0)
+	if err != nil {
+		writeLine(stdout, "ghost session-job reaper config error: %s; age-based reaping disabled for this sweep", err)
+	} else {
+		after = policy.AutoSettleAfter
+	}
+	reaped, err := store.ReapGhostSessionJobs(ctx, now, after)
+	if err != nil {
+		return err
+	}
+	for _, jobID := range reaped {
+		writeLine(stdout, "reaped ghost session job %s", jobID)
+	}
+	return nil
+}

--- a/internal/cli/workflow_lifecycle_test.go
+++ b/internal/cli/workflow_lifecycle_test.go
@@ -82,6 +82,142 @@ auto_settle_after = "0"
 	}
 }
 
+func TestRunGhostSessionJobReaperOnceUsesLifecyclePolicy(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[workflow]
+auto_settle_after = "24h"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	if err := store.CreateExternallyDrivenJobWithEvent(ctx, db.Job{
+		ID:    "session-stale",
+		Agent: "coordinator",
+		Type:  "ask",
+		State: "running",
+	}, db.JobEvent{Kind: "running", Message: "job started"}); err != nil {
+		t.Fatalf("CreateExternallyDrivenJobWithEvent: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := runGhostSessionJobReaperOnce(ctx, paths, store, time.Now().UTC().Add(48*time.Hour), &stdout); err != nil {
+		t.Fatalf("runGhostSessionJobReaperOnce: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "reaped ghost session job session-stale") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	job, err := store.GetJob(ctx, "session-stale")
+	if err != nil || job.State != "cancelled" {
+		t.Fatalf("job = %+v, err=%v", job, err)
+	}
+	events, err := store.ListJobEvents(ctx, "session-stale")
+	if err != nil || len(events) != 2 || events[1].Kind != "cancelled" ||
+		events[1].Message != "reaped: no activity for >24h0m0s (workflow status: none)" {
+		t.Fatalf("events = %+v, err=%v", events, err)
+	}
+
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[workflow]
+auto_settle_after = "0"
+`), 0o600); err != nil {
+		t.Fatalf("write disabled config: %v", err)
+	}
+	for _, job := range []db.Job{
+		{ID: "session-disabled-age", Agent: "coordinator", Type: "ask", State: "running"},
+		{ID: "session-disabled-settled", Agent: "coordinator", Type: "ask", State: "running", Payload: `{"workflow_id":"release/done"}`},
+	} {
+		if err := store.CreateExternallyDrivenJobWithEvent(ctx, job, db.JobEvent{Kind: "running", Message: "job started"}); err != nil {
+			t.Fatalf("CreateExternallyDrivenJobWithEvent(%s): %v", job.ID, err)
+		}
+	}
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: "release/done", Author: "operator", Body: "done"},
+		db.WorkflowMeta{Status: string(db.WorkflowStatusDone), StatusSet: true}); err != nil {
+		t.Fatalf("InsertWorkflowNoteWithMeta: %v", err)
+	}
+	stdout.Reset()
+	if err := runGhostSessionJobReaperOnce(ctx, paths, store, time.Now().UTC().Add(72*time.Hour), &stdout); err != nil {
+		t.Fatalf("disabled runGhostSessionJobReaperOnce: %v", err)
+	}
+	disabledAge, err := store.GetJob(ctx, "session-disabled-age")
+	if err != nil || disabledAge.State != "running" {
+		t.Fatalf("disabled age job = %+v, err=%v", disabledAge, err)
+	}
+	settled, err := store.GetJob(ctx, "session-disabled-settled")
+	if err != nil || settled.State != "cancelled" {
+		t.Fatalf("settled job = %+v, err=%v", settled, err)
+	}
+	if strings.Contains(stdout.String(), "session-disabled-age") ||
+		!strings.Contains(stdout.String(), "session-disabled-settled") {
+		t.Fatalf("disabled stdout = %q", stdout.String())
+	}
+}
+
+func TestRunGhostSessionJobReaperOnceMalformedConfigPreservesTerminalSignal(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[workflow]
+auto_settle_after = "not-a-duration"
+`), 0o600); err != nil {
+		t.Fatalf("write malformed config: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	for _, job := range []db.Job{
+		{ID: "session-malformed-age", Agent: "coordinator", Type: "ask", State: "running"},
+		{ID: "session-malformed-settled", Agent: "coordinator", Type: "ask", State: "running", Payload: `{"workflow_id":"release/settled"}`},
+	} {
+		if err := store.CreateExternallyDrivenJobWithEvent(ctx, job, db.JobEvent{Kind: "running", Message: "job started"}); err != nil {
+			t.Fatalf("CreateExternallyDrivenJobWithEvent(%s): %v", job.ID, err)
+		}
+	}
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: "release/settled", Author: "operator", Body: "settled"},
+		db.WorkflowMeta{Status: string(db.WorkflowStatusSettled), StatusSet: true}); err != nil {
+		t.Fatalf("InsertWorkflowNoteWithMeta: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	if err := runGhostSessionJobReaperOnce(ctx, paths, store, time.Now().UTC().Add(48*time.Hour), &stdout); err != nil {
+		t.Fatalf("runGhostSessionJobReaperOnce: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "ghost session-job reaper config error:") ||
+		!strings.Contains(got, "age-based reaping disabled for this sweep") ||
+		!strings.Contains(got, "reaped ghost session job session-malformed-settled") ||
+		strings.Contains(got, "reaped ghost session job session-malformed-age") {
+		t.Fatalf("stdout = %q", got)
+	}
+	ageOnly, err := store.GetJob(ctx, "session-malformed-age")
+	if err != nil || ageOnly.State != "running" {
+		t.Fatalf("age-only job = %+v, err=%v", ageOnly, err)
+	}
+	settled, err := store.GetJob(ctx, "session-malformed-settled")
+	if err != nil || settled.State != "cancelled" {
+		t.Fatalf("settled job = %+v, err=%v", settled, err)
+	}
+	events, err := store.ListJobEvents(ctx, "session-malformed-settled")
+	if err != nil || len(events) != 2 || events[1].Kind != "cancelled" ||
+		events[1].Message != "reaped: parent workflow release/settled settled" {
+		t.Fatalf("settled events = %+v, err=%v", events, err)
+	}
+}
+
 func seedWorkflowAutoSettleCLI(t *testing.T, store *db.Store, workflowID string, pullRequest int, prState string) {
 	t.Helper()
 	ctx := context.Background()

--- a/internal/db/session_job_reaper.go
+++ b/internal/db/session_job_reaper.go
@@ -1,0 +1,142 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+)
+
+const (
+	// A terminal workflow is a strong orphan signal, but status writes and a live
+	// session's CloseExternalJob are separate transactions. Keep one short sweep
+	// grace so a normal close racing an operator's terminal status can win first.
+	ghostSessionTerminalWorkflowGrace = 5 * time.Minute
+
+	// A store constructed directly in low-level migration tests has no path from
+	// which to resolve config. Use the same historical default in that case.
+	ghostSessionBackfillAfter = 24 * time.Hour
+)
+
+type ghostSessionJobCandidate struct {
+	id         string
+	workflowID string
+	updatedAt  time.Time
+}
+
+// ReapGhostSessionJobs cancels orphaned externally-driven jobs using the same
+// running-state CAS and durable event for migration cleanup and daemon sweeps.
+// A terminal workflow is the fast path; every other workflow state falls back
+// to the job's configured inactivity threshold. A non-positive threshold
+// disables only that age-based path.
+func (s *Store) ReapGhostSessionJobs(ctx context.Context, now time.Time, autoSettleAfter time.Duration) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT id, workflow_id, updated_at
+FROM jobs
+WHERE state = 'running' AND externally_driven = 1
+ORDER BY updated_at, id`)
+	if err != nil {
+		return nil, err
+	}
+	var candidates []ghostSessionJobCandidate
+	for rows.Next() {
+		var candidate ghostSessionJobCandidate
+		var updatedAt string
+		if err := rows.Scan(&candidate.id, &candidate.workflowID, &updatedAt); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		candidate.workflowID = strings.TrimSpace(candidate.workflowID)
+		candidate.updatedAt = parseStoredTimestamp(updatedAt)
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+
+	now = now.UTC()
+	reaped := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		reason := ""
+		useAgeFallback := candidate.workflowID == ""
+		workflowStatus := "none"
+		if candidate.workflowID != "" {
+			meta, err := s.GetWorkflowMeta(ctx, candidate.workflowID)
+			switch {
+			case err == nil && IsTerminalWorkflowStatus(meta.Status):
+				terminalAt := parseStoredTimestamp(meta.UpdatedAt)
+				if terminalAt.IsZero() {
+					terminalAt = candidate.updatedAt
+				}
+				if terminalAt.IsZero() || now.Before(terminalAt) || now.Sub(terminalAt) < ghostSessionTerminalWorkflowGrace {
+					continue
+				}
+				reason = fmt.Sprintf("reaped: parent workflow %s settled", candidate.workflowID)
+			case err == nil:
+				// A non-terminal workflow does not prove this specific job is
+				// alive: a long-lived workflow can move on to newer session jobs
+				// without closing an older one. Apply the job-age safety net.
+				useAgeFallback = true
+				workflowStatus = strings.TrimSpace(meta.Status)
+				if workflowStatus == "" {
+					workflowStatus = "unset"
+				}
+			case errors.Is(err, sql.ErrNoRows):
+				useAgeFallback = true
+			default:
+				return reaped, err
+			}
+		}
+		if reason == "" && useAgeFallback {
+			if autoSettleAfter <= 0 || candidate.updatedAt.IsZero() || now.Before(candidate.updatedAt) ||
+				now.Sub(candidate.updatedAt) < autoSettleAfter {
+				continue
+			}
+			reason = fmt.Sprintf("reaped: no activity for >%s (workflow status: %s)", autoSettleAfter, workflowStatus)
+		}
+		if reason == "" {
+			continue
+		}
+		transitioned, err := s.TransitionJobStateWithEvent(ctx, candidate.id, "running", "cancelled", JobEvent{
+			Kind:    "cancelled",
+			Message: reason,
+		})
+		if err != nil {
+			return reaped, err
+		}
+		if transitioned {
+			reaped = append(reaped, candidate.id)
+		}
+	}
+	return reaped, nil
+}
+
+// backfillGhostSessionJobs converges the pre-#1125 backlog through the same CAS
+// and event-emitting reaper as steady-state maintenance. Re-running it is safe:
+// already-cancelled rows no longer match the running candidate query.
+func (s *Store) backfillGhostSessionJobs(ctx context.Context) error {
+	after := ghostSessionBackfillAfter
+	if strings.TrimSpace(s.path) != "" {
+		policy, err := config.LoadWorkflowLifecycle(config.Paths{
+			ConfigFile: filepath.Join(filepath.Dir(s.path), config.ConfigName),
+		})
+		if err != nil {
+			// A malformed lifecycle policy must never become permission to reap.
+			// Preserve the always-safe terminal-workflow signal while disabling
+			// age-only cleanup; the daemon's normal sweep reports the config error.
+			after = 0
+		} else {
+			after = policy.AutoSettleAfter
+		}
+	}
+	_, err := s.ReapGhostSessionJobs(ctx, time.Now().UTC(), after)
+	return err
+}

--- a/internal/db/session_job_reaper_test.go
+++ b/internal/db/session_job_reaper_test.go
@@ -1,0 +1,194 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+)
+
+func seedGhostSessionJob(t *testing.T, store *Store, id, workflowID string, updatedAt time.Time) {
+	t.Helper()
+	payload := fmt.Sprintf(`{"repo":"acme/widget","workflow_id":%q}`, workflowID)
+	if err := store.CreateExternallyDrivenJobWithEvent(context.Background(), Job{
+		ID:      id,
+		Agent:   "coordinator",
+		Type:    "ask",
+		State:   "running",
+		Payload: payload,
+	}, JobEvent{Kind: "running", Message: "job started"}); err != nil {
+		t.Fatalf("CreateExternallyDrivenJobWithEvent(%s): %v", id, err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE jobs SET updated_at = ? WHERE id = ?`,
+		updatedAt.UTC().Format(time.RFC3339Nano), id); err != nil {
+		t.Fatalf("backdate job %s: %v", id, err)
+	}
+}
+
+func seedGhostSessionWorkflowStatus(t *testing.T, store *Store, workflowID string, status WorkflowStatus, updatedAt time.Time) {
+	t.Helper()
+	if _, err := store.InsertWorkflowNoteWithMeta(context.Background(),
+		WorkflowNote{WorkflowID: workflowID, Author: "operator", Body: "lifecycle"},
+		WorkflowMeta{Status: string(status), StatusSet: true}); err != nil {
+		t.Fatalf("InsertWorkflowNoteWithMeta(%s): %v", workflowID, err)
+	}
+	if _, err := store.db.ExecContext(context.Background(), `UPDATE workflow_meta SET updated_at = ? WHERE workflow_id = ?`,
+		updatedAt.UTC().Format(time.RFC3339Nano), workflowID); err != nil {
+		t.Fatalf("backdate workflow %s: %v", workflowID, err)
+	}
+}
+
+func assertGhostSessionJob(t *testing.T, store *Store, id, wantState, wantMessage string, wantEvents int) {
+	t.Helper()
+	job, err := store.GetJob(context.Background(), id)
+	if err != nil {
+		t.Fatalf("GetJob(%s): %v", id, err)
+	}
+	if job.State != wantState {
+		t.Fatalf("job %s state = %q, want %q", id, job.State, wantState)
+	}
+	events, err := store.ListJobEvents(context.Background(), id)
+	if err != nil {
+		t.Fatalf("ListJobEvents(%s): %v", id, err)
+	}
+	if len(events) != wantEvents {
+		t.Fatalf("job %s events = %+v, want %d", id, events, wantEvents)
+	}
+	if wantMessage != "" {
+		last := events[len(events)-1]
+		if last.Kind != "cancelled" || last.Message != wantMessage {
+			t.Fatalf("job %s final event = %+v", id, last)
+		}
+	}
+}
+
+func TestReapGhostSessionJobsDistinguishesGhostsFromLive(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 26, 18, 0, 0, 0, time.UTC)
+
+	seedGhostSessionJob(t, store, "settled", "release/settled", now.Add(-10*time.Minute))
+	seedGhostSessionWorkflowStatus(t, store, "release/settled", WorkflowStatusSettled, now.Add(-10*time.Minute))
+	seedGhostSessionJob(t, store, "stale-unlinked", "", now.Add(-25*time.Hour))
+	seedGhostSessionJob(t, store, "recent-open", "release/open-recent", now.Add(-time.Minute))
+	seedGhostSessionWorkflowStatus(t, store, "release/open-recent", WorkflowStatusActive, now.Add(-time.Minute))
+	seedGhostSessionJob(t, store, "stale-open", "release/open-stale", now.Add(-48*time.Hour))
+	seedGhostSessionWorkflowStatus(t, store, "release/open-stale", WorkflowStatusActive, now.Add(-48*time.Hour))
+	seedGhostSessionJob(t, store, "recent-unlinked", "", now.Add(-time.Minute))
+	if err := store.CreateJob(ctx, Job{ID: "engine-running", Agent: "worker", Type: "ask", State: "running"}); err != nil {
+		t.Fatalf("CreateJob(engine-running): %v", err)
+	}
+
+	reaped, err := store.ReapGhostSessionJobs(ctx, now, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("ReapGhostSessionJobs: %v", err)
+	}
+	if fmt.Sprint(reaped) != "[stale-open stale-unlinked settled]" {
+		t.Fatalf("reaped = %v", reaped)
+	}
+	assertGhostSessionJob(t, store, "settled", "cancelled", "reaped: parent workflow release/settled settled", 2)
+	assertGhostSessionJob(t, store, "stale-unlinked", "cancelled", "reaped: no activity for >24h0m0s (workflow status: none)", 2)
+	assertGhostSessionJob(t, store, "recent-open", "running", "", 1)
+	assertGhostSessionJob(t, store, "stale-open", "cancelled", "reaped: no activity for >24h0m0s (workflow status: active)", 2)
+	assertGhostSessionJob(t, store, "recent-unlinked", "running", "", 1)
+	assertGhostSessionJob(t, store, "engine-running", "running", "", 0)
+}
+
+func TestReapGhostSessionJobsReapsStaleJobUnderActiveWorkflow(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 26, 18, 0, 0, 0, time.UTC)
+
+	seedGhostSessionJob(t, store, "stale-active", "g2/130-org-canvas-rebuild", now.Add(-48*time.Hour))
+	seedGhostSessionWorkflowStatus(t, store, "g2/130-org-canvas-rebuild", WorkflowStatusActive, now.Add(-time.Minute))
+
+	reaped, err := store.ReapGhostSessionJobs(ctx, now, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("ReapGhostSessionJobs: %v", err)
+	}
+	if fmt.Sprint(reaped) != "[stale-active]" {
+		t.Fatalf("reaped = %v", reaped)
+	}
+	assertGhostSessionJob(t, store, "stale-active", "cancelled",
+		"reaped: no activity for >24h0m0s (workflow status: active)", 2)
+}
+
+func TestReapGhostSessionJobsZeroDisablesOnlyAgeFallback(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 7, 26, 18, 0, 0, 0, time.UTC)
+	seedGhostSessionJob(t, store, "settled", "release/done", now.Add(-10*time.Minute))
+	seedGhostSessionWorkflowStatus(t, store, "release/done", WorkflowStatusDone, now.Add(-10*time.Minute))
+	seedGhostSessionJob(t, store, "stale-unlinked", "", now.Add(-72*time.Hour))
+
+	reaped, err := store.ReapGhostSessionJobs(ctx, now, 0)
+	if err != nil {
+		t.Fatalf("ReapGhostSessionJobs: %v", err)
+	}
+	if fmt.Sprint(reaped) != "[settled]" {
+		t.Fatalf("reaped = %v", reaped)
+	}
+	assertGhostSessionJob(t, store, "settled", "cancelled", "reaped: parent workflow release/done settled", 2)
+	assertGhostSessionJob(t, store, "stale-unlinked", "running", "", 1)
+}
+
+func TestBackfillGhostSessionJobsReusesReaperAndIsIdempotent(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	old := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Now().UTC()
+	seedGhostSessionJob(t, store, "settled", "release/settled", old)
+	seedGhostSessionWorkflowStatus(t, store, "release/settled", WorkflowStatusSettled, old)
+	seedGhostSessionJob(t, store, "stale-unlinked", "", old)
+	seedGhostSessionJob(t, store, "recent-unlinked", "", recent)
+	seedGhostSessionJob(t, store, "stale-open", "release/open", old)
+	seedGhostSessionWorkflowStatus(t, store, "release/open", WorkflowStatusActive, old)
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	assertGhostSessionJob(t, store, "settled", "cancelled", "reaped: parent workflow release/settled settled", 2)
+	assertGhostSessionJob(t, store, "stale-unlinked", "cancelled", "reaped: no activity for >24h0m0s (workflow status: none)", 2)
+	assertGhostSessionJob(t, store, "recent-unlinked", "running", "", 1)
+	assertGhostSessionJob(t, store, "stale-open", "cancelled", "reaped: no activity for >24h0m0s (workflow status: active)", 2)
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("second Migrate: %v", err)
+	}
+	assertGhostSessionJob(t, store, "settled", "cancelled", "reaped: parent workflow release/settled settled", 2)
+	assertGhostSessionJob(t, store, "stale-unlinked", "cancelled", "reaped: no activity for >24h0m0s (workflow status: none)", 2)
+	assertGhostSessionJob(t, store, "stale-open", "cancelled", "reaped: no activity for >24h0m0s (workflow status: active)", 2)
+}
+
+func TestBackfillGhostSessionJobsHonorsDisabledAgePolicy(t *testing.T) {
+	root := filepath.Join(t.TempDir(), config.DirName)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, config.ConfigName), []byte(`
+[workflow]
+auto_settle_after = "0"
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	store, err := Open(filepath.Join(root, config.DBName))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	old := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	seedGhostSessionJob(t, store, "stale-unlinked", "", old)
+	seedGhostSessionJob(t, store, "settled", "release/done", old)
+	seedGhostSessionWorkflowStatus(t, store, "release/done", WorkflowStatusDone, old)
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	assertGhostSessionJob(t, store, "stale-unlinked", "running", "", 1)
+	assertGhostSessionJob(t, store, "settled", "cancelled", "reaped: parent workflow release/done settled", 2)
+}

--- a/internal/db/session_job_test.go
+++ b/internal/db/session_job_test.go
@@ -73,8 +73,9 @@ func TestCreateExternallyDrivenJobWithEvent(t *testing.T) {
 }
 
 // TestListRunningJobsUpdatedBeforeSkipsExternallyDriven is the highest-risk
-// correctness point (#657): the stuck-running reaper MUST NOT reclaim a session job
-// even when it is stale, because the calling session may hold it open for minutes.
+// correctness point (#657): the engine lease-recovery reaper MUST NOT reclaim a
+// session job even when it is stale, because the calling session may hold it open
+// for minutes. Session lifecycle cleanup uses separate workflow/age signals.
 func TestListRunningJobsUpdatedBeforeSkipsExternallyDriven(t *testing.T) {
 	ctx := context.Background()
 	store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -104,7 +104,7 @@ func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent)
 
 // CreateExternallyDrivenJobWithEvent creates a session job (#657) whose execution
 // happens OUTSIDE the engine: it sets externally_driven = 1 so the daemon's
-// queued selector never claims it and the stuck-running reaper skips it. It
+// queued selector never claims it and the engine lease reaper skips it. It
 // mirrors CreateJobWithEvent (same root_id denormalization, same in-tx event) but
 // stamps the extra column; the caller supplies job.State = 'running' so the job
 // is created directly running, never queued. This is the ONLY insert site that

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -16,6 +16,9 @@ func (s *Store) Migrate(ctx context.Context) error {
 	if err := s.backfillJobRootID(ctx); err != nil {
 		return err
 	}
+	if err := s.backfillGhostSessionJobs(ctx); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/workflow/session_job.go
+++ b/internal/workflow/session_job.go
@@ -13,11 +13,12 @@ import (
 // unit of work as a first-class tracked job WITHOUT the engine spawning a runtime
 // (#657). The job is created directly in RUNNING state and flagged
 // externally_driven, so the daemon's queued selector never claims it (no Deliver,
-// no runtime subprocess, no runtime-session/checkout lock) and the stuck-running
+// no runtime subprocess, no runtime-session/checkout lock) and the engine lease
 // reaper skips it. It emits the same running-state ("job started") event a normal
 // job emits on claim, so the job list, events, and dashboard reflect it. The
 // calling session does the real work and later calls CloseExternalJob to apply the
-// result and move the job to its terminal state.
+// result and move the job to its terminal state; lifecycle maintenance separately
+// cancels a genuinely orphaned session row.
 func (m Mailbox) OpenExternalJob(ctx context.Context, request JobRequest) (db.Job, error) {
 	if m.Store == nil {
 		return db.Job{}, errors.New("mailbox store is required")

--- a/internal/workflow/session_job_test.go
+++ b/internal/workflow/session_job_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/events"
@@ -205,6 +206,46 @@ func TestCloseExternalJobErrors(t *testing.T) {
 	}
 	if _, err := mb.CloseExternalJob(ctx, "sess", AgentResult{Decision: "approved"}, 0, ""); err == nil || !strings.Contains(err.Error(), "already been closed") {
 		t.Fatalf("double CloseExternalJob err = %v, want already-been-closed", err)
+	}
+}
+
+func TestCloseExternalJobAfterGhostReaperReturnsCleanAlreadyClosedError(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"ask"}, "gitmoot/gitmoot")
+	mb := Mailbox{Store: store}
+	if _, err := mb.OpenExternalJob(ctx, JobRequest{
+		ID:         "session-race",
+		Agent:      "lead",
+		Action:     "ask",
+		Repo:       "gitmoot/gitmoot",
+		WorkflowID: "release/settled",
+	}); err != nil {
+		t.Fatalf("OpenExternalJob: %v", err)
+	}
+	if _, err := store.InsertWorkflowNoteWithMeta(ctx,
+		db.WorkflowNote{WorkflowID: "release/settled", Author: "operator", Body: "done"},
+		db.WorkflowMeta{Status: string(db.WorkflowStatusDone), StatusSet: true}); err != nil {
+		t.Fatalf("InsertWorkflowNoteWithMeta: %v", err)
+	}
+	reaped, err := store.ReapGhostSessionJobs(ctx, time.Now().UTC().Add(10*time.Minute), 24*time.Hour)
+	if err != nil {
+		t.Fatalf("ReapGhostSessionJobs: %v", err)
+	}
+	if len(reaped) != 1 || reaped[0] != "session-race" {
+		t.Fatalf("reaped = %v", reaped)
+	}
+	if _, err := mb.CloseExternalJob(ctx, "session-race", AgentResult{Decision: "approved"}, 0, ""); err == nil ||
+		!strings.Contains(err.Error(), "already been closed") {
+		t.Fatalf("CloseExternalJob after reaper err = %v, want already-been-closed", err)
+	}
+	job, err := store.GetJob(ctx, "session-race")
+	if err != nil || job.State != string(JobCancelled) {
+		t.Fatalf("job = %+v, err=%v", job, err)
+	}
+	events, err := store.ListJobEvents(ctx, "session-race")
+	if err != nil || len(events) != 2 || events[1].Kind != string(JobCancelled) {
+		t.Fatalf("events = %+v, err=%v", events, err)
 	}
 }
 


### PR DESCRIPTION
## What

Session-scoped job rows (`session-ask-*`/`session-implement-*`, created via
`Mailbox.OpenExternalJob` when a coordinator drives work through its own
interactive session/pane) only leave `running` when that session explicitly
calls `CloseExternalJob`. This job type has no lease or heartbeat — if the
session/pane/wave goes away first, the row is stuck in `running` forever
with a permanently stale `updated_at`.

**Confirmed live and severe, not theoretical**: fleet-wide right now, 20 of
21 jobs in a live state are exactly this ghost pattern (oldest stuck 4.5
days). This isn't just a wrong dashboard number — it breaks real automation.
A "wait for zero live jobs for this agent" watcher hung indefinitely because
of it (galaxy-impl's session-ask rows never clear), and ghosts aren't
confined to dead waves: several of the affected agents did real work today,
so any fix has to discriminate per-job-row, not per-agent.

Full scale data and the operational-cost writeup are on the issue:
https://github.com/gitmoot/gitmoot/issues/1125

## Fix

`Store.ReapGhostSessionJobs` (`internal/db/session_job_reaper.go`) cancels a
ghost job via CAS from `running` (race-safe: if a real session calls
`CloseExternalJob` on an already-reaped job, it gets `CloseExternalJob`'s
existing clean "already been closed" error, not corruption), when either:

- its parent workflow has been terminal (done/settled) for a 5-minute grace
  period since the workflow itself went terminal, **or**
- regardless of whether its workflow is open, closed, or missing — its own
  `updated_at` is older than the existing `[workflow] auto_settle_after`
  threshold (reused rather than adding a new config knob).

The second condition is **deliberately not gated on the parent workflow
being open**: a long-lived workflow can stay `active` for days while
individual session jobs dispatched under it, one per turn, come and go —
the workflow being open doesn't prove any specific job nested under it is
still alive. This was verified against live production data: three real
ghost rows sit under workflows whose status is `active`, and an earlier
version of this fix (workflow-open ⇒ indefinite immunity) would never have
reached them — that's the exact incident that motivated the issue.

A one-time Go-level backfill (`backfillGhostSessionJobs`, wired into
`Migrate()`) converges the existing backlog through the **same** reap
function — deliberately not a bare SQL migration `UPDATE`, since that would
skip `job_events` emission and undercut the entire point of the jobs-honesty
spine this issue belongs to. Wired into the daemon's once-per-home-scoped-
sweep supervisor loop (`daemon_supervision.go`, alongside
`runWorkflowAutoSettleOnce`) — **not** the per-repo tick, avoiding the
redundant-per-repo-work anti-pattern issue #1150 just documented for a
different function (`recoverForeignBootRunners`).

## Review — three rounds of fresh-context adversarial review

1. **Round 1** caught the workflow-open-is-indefinite-immunity gap described
   above. Confirmed against a live read-only DB snapshot before accepting
   the finding and dispatching the fix.
2. **Round 2** caught that the ongoing sweep's config-error handling
   (`runGhostSessionJobReaperOnce`) disabled not just age-based reaping but
   also the always-safe terminal-workflow fast path on a malformed
   `auto_settle_after` value — contradicting its own doc comment, and
   inconsistent with `backfillGhostSessionJobs`, which already handled this
   correctly. Fixed to fall back to `autoSettleAfter = 0` on a config error
   (age fails closed, terminal-workflow stays live) while still logging the
   error.
3. **Round 3 (final)**: `decision: approved`, zero findings, full diff
   re-verified independently including CAS/event behavior, backfill reuse,
   and sweep placement.

Also verified (and rejected, with reasoning) a proposed refinement: using
`updated_at == created_at` as an additional ghost-vs-live discriminator.
Checked directly against live data — it's `true` for **all** running session
jobs without exception, including ones only hours old and plausibly still
legitimately active, because no code path ever updates `updated_at` for this
job type while running. It doesn't add signal beyond age; age remains the
only available discriminator, which is what this fix uses.

Full `db`/`cli`/`workflow` suites green throughout all three rounds.
`go generate ./...` zero drift (SHA-256 verified). `gofmt`/`go vet`/`go build`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)