### PR TITLE
feat(org): populate ActiveJobs lane-activity badge + bump gitmoot-dashboard pin (#1127)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/creachadair/tomledit v0.0.29
-	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726165048-244e664c8863
+	github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726182004-510fdc8bd010
 	github.com/landlock-lsm/go-landlock v0.9.0
 	github.com/muesli/termenv v0.16.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726160023-a6365fe9d2cf h1:7t0BU
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726160023-a6365fe9d2cf/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726165048-244e664c8863 h1:+Ry6kglFxd8ikE5LS7DIYcHs6O9E07yHieZr+RYIF/g=
 github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726165048-244e664c8863/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726182004-510fdc8bd010 h1:sHOGGE1bpNiw9iMWd6aytsZI/rwmiNzSYPKcWtdqg6Q=
+github.com/gitmoot/gitmoot-dashboard v0.0.0-20260726182004-510fdc8bd010/go.mod h1:uKBMK3kRRDJ1gYrek/XsPzUo/PBOv+aqY2UG8vBETXI=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/cli/dashboard_web_org.go
+++ b/internal/cli/dashboard_web_org.go
@@ -124,7 +124,7 @@ func loadDashboardOrgInputs(ctx context.Context, paths config.Paths, store *db.S
 	if err != nil {
 		return dashboardOrgInputs{}, err
 	}
-	rows, err := buildOrgStatusRows(ctx, &shared, storeOrgLiveSource(&shared), "status")
+	rows, err := buildOrgStatusRows(ctx, &shared, storeOrgLiveSource(&shared), "status", true)
 	if err != nil {
 		return dashboardOrgInputs{}, err
 	}
@@ -293,7 +293,7 @@ func buildDashboardOrgRole(ctx context.Context, paths config.Paths, store *db.St
 	if !ok {
 		return dashboard.OrgRoleView{}, dashboard.ErrOrgRoleNotFound
 	}
-	rows, err := buildOrgStatusRows(ctx, &shared, storeOrgLiveSource(&shared), "status")
+	rows, err := buildOrgStatusRows(ctx, &shared, storeOrgLiveSource(&shared), "status", false)
 	if err != nil {
 		return dashboard.OrgRoleView{}, err
 	}

--- a/internal/cli/dashboard_web_org.go
+++ b/internal/cli/dashboard_web_org.go
@@ -249,6 +249,7 @@ func buildDashboardOrg(ctx context.Context, paths config.Paths, store *db.Store,
 				BlockedSince: dashboardOrgTimestamp(blockedSince[row.Role]),
 				Overdue:      overdue,
 				MissedWakes:  inputs.shared.MissedWakes[row.Role],
+				ActiveJobs:   row.ActiveJobs,
 			},
 			LastSeenAt: dashboardOrgTimestamp(row.LastSeenAt),
 		}

--- a/internal/cli/dashboard_web_org_test.go
+++ b/internal/cli/dashboard_web_org_test.go
@@ -59,10 +59,12 @@ func TestDashboardOrgDataSourceStoreBackedProjection(t *testing.T) {
 		if err := store.TouchOrgRolePresence(ctx, role, "agent dispatch"); err != nil {
 			t.Fatal(err)
 		}
-		if err := store.CreateJob(ctx, db.Job{
-			ID: role + "-running", Agent: role, Type: "ask", State: "running",
-			Payload: `{"acting_org_role":"` + role + `"}`,
-		}); err != nil {
+	}
+	for _, job := range []db.Job{
+		{ID: "owner-running", Agent: "owner", Type: "ask", State: "running", Payload: `{"acting_org_role":"owner"}`},
+		{ID: "owner-queued", Agent: "owner", Type: "ask", State: "queued", Payload: `{"acting_org_role":"owner"}`},
+	} {
+		if err := store.CreateJob(ctx, job); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -168,8 +170,14 @@ func TestDashboardOrgDataSourceStoreBackedProjection(t *testing.T) {
 	if view.Roles[0].PresenceState != "working" || view.Roles[0].Badges.Overdue == "" {
 		t.Fatalf("owner = %+v", view.Roles[0])
 	}
+	if view.Roles[0].Badges.ActiveJobs != 2 {
+		t.Fatalf("owner active_jobs = %d, want 2", view.Roles[0].Badges.ActiveJobs)
+	}
 	if view.Roles[1].PresenceState != "blocked" || view.Roles[1].Badges.BlockedSince == "" || view.Roles[1].Badges.MissedWakes != 1 {
 		t.Fatalf("review = %+v", view.Roles[1])
+	}
+	if view.Roles[1].Badges.ActiveJobs != 0 {
+		t.Fatalf("review active_jobs = %d, want 0", view.Roles[1].Badges.ActiveJobs)
 	}
 	if got := view.Health; got.Roles != 2 || got.Working != 1 || got.Blocked != 1 || got.Overdue != 1 || got.OpenEscalations != 1 || got.StalledWakes != 1 {
 		t.Fatalf("health = %+v", got)

--- a/internal/cli/dashboard_web_org_test.go
+++ b/internal/cli/dashboard_web_org_test.go
@@ -231,6 +231,9 @@ func TestDashboardOrgDataSourceStoreBackedProjection(t *testing.T) {
 		if recorder.Code != http.StatusOK {
 			t.Fatalf("GET %s: status=%d body=%s", route, recorder.Code, recorder.Body.String())
 		}
+		if route == "/api/org/role/owner" && strings.Contains(recorder.Body.String(), `"active_jobs"`) {
+			t.Fatalf("single-role response leaked tree-only active_jobs: %s", recorder.Body.String())
+		}
 	}
 	recorder := httptest.NewRecorder()
 	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/org/role/missing", nil))

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -402,7 +402,8 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 	for _, warning := range shared.Warnings {
 		fmt.Fprintf(stderr, "org %s: %s\n", command, warning)
 	}
-	rows, err := buildOrgStatusRows(ctx, &shared, herdrOrgLiveSource, command)
+	reportedWarnings := len(shared.Warnings)
+	rows, err := buildOrgStatusRows(ctx, &shared, herdrOrgLiveSource, command, command == "status")
 	if err != nil {
 		var liveErr *orgLiveSourceError
 		if errors.As(err, &liveErr) {
@@ -411,6 +412,9 @@ func runOrgOverview(command string, args []string, stdout, stderr io.Writer) int
 			fmt.Fprintf(stderr, "org %s: %v\n", command, err)
 		}
 		return 1
+	}
+	for _, warning := range shared.Warnings[reportedWarnings:] {
+		fmt.Fprintf(stderr, "org %s: %s\n", command, warning)
 	}
 	if *jsonOutput {
 		if err := writeJSON(stdout, rows); err != nil {

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -269,6 +269,7 @@ type orgStatusOutput struct {
 	Scope           []string           `json:"scope"`
 	MergeRule       string             `json:"merge_rule"`
 	Model           string             `json:"model"`
+	ActiveJobs      int                `json:"active_jobs,omitempty"`
 	LastSeenAt      string             `json:"last_seen_at,omitempty"`
 	LastSeenAge     string             `json:"last_seen_age,omitempty"`
 	LastCommand     string             `json:"last_command,omitempty"`

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -29,6 +29,7 @@ type orgSharedState struct {
 	MissedWakes     map[string]int
 	Warnings        []string
 	jobCounts       map[string]map[string]int
+	jobCountsErr    error
 	jobCountsLoaded bool
 	blockedEpisodes []db.BlockedEpisode
 	blockedLoaded   bool
@@ -185,11 +186,13 @@ func (shared *orgSharedState) loadBlockedEpisodes(ctx context.Context) ([]db.Blo
 // projection. Presence and recycle enrichment share the same snapshot.
 func (shared *orgSharedState) loadJobCounts(ctx context.Context) (map[string]map[string]int, error) {
 	if shared.jobCountsLoaded {
-		return shared.jobCounts, nil
+		return shared.jobCounts, shared.jobCountsErr
 	}
 	shared.jobCountsLoaded = true
 	counts, err := shared.Store.CountCurrentJobsByOrgRole(ctx)
 	if err != nil {
+		shared.jobCountsErr = err
+		shared.Warnings = append(shared.Warnings, fmt.Sprintf("active-jobs counts unavailable: %v", err))
 		return nil, err
 	}
 	shared.jobCounts = counts
@@ -221,14 +224,12 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 		activeJobs := 0
 		if command == "status" && includeActiveJobs {
 			jobCounts, err := shared.loadJobCounts(ctx)
-			if err != nil {
-				shared.Warnings = append(shared.Warnings, fmt.Sprintf("active-jobs counts unavailable: %v", err))
-			} else {
+			if err == nil {
 				activeJobs = jobCounts[role.Name]["queued"] + jobCounts[role.Name]["running"]
-			}
-			if recycleAfter := shared.Config.RecycleAfterFor(role.Name); recycleAfter > 0 {
-				recycleStatus = orgRecycleStatus(seen.LastSeenAt, observedNow, live.State, activeJobs, recycleAfter)
-				recycleAfterText = formatOrgRecycleAfter(recycleAfter)
+				if recycleAfter := shared.Config.RecycleAfterFor(role.Name); recycleAfter > 0 {
+					recycleStatus = orgRecycleStatus(seen.LastSeenAt, observedNow, live.State, activeJobs, recycleAfter)
+					recycleAfterText = formatOrgRecycleAfter(recycleAfter)
+				}
 			}
 		}
 		rows = append(rows, orgStatusOutput{

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -218,21 +218,21 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 		}
 		recycleStatus := ""
 		recycleAfterText := ""
+		activeJobs := 0
 		if command == "status" {
-			recycleAfter := shared.Config.RecycleAfterFor(role.Name)
-			if recycleAfter > 0 {
-				jobCounts, err := shared.loadJobCounts(ctx)
-				if err != nil {
-					return nil, fmt.Errorf("count active jobs for role %q: %w", role.Name, err)
-				}
-				activeJobs := jobCounts[role.Name]["queued"] + jobCounts[role.Name]["running"]
+			jobCounts, err := shared.loadJobCounts(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("count active jobs for role %q: %w", role.Name, err)
+			}
+			activeJobs = jobCounts[role.Name]["queued"] + jobCounts[role.Name]["running"]
+			if recycleAfter := shared.Config.RecycleAfterFor(role.Name); recycleAfter > 0 {
 				recycleStatus = orgRecycleStatus(seen.LastSeenAt, observedNow, live.State, activeJobs, recycleAfter)
 				recycleAfterText = formatOrgRecycleAfter(recycleAfter)
 			}
 		}
 		rows = append(rows, orgStatusOutput{
 			Role: role.Name, Parent: role.Parent, Pane: role.Pane, Depth: len(shared.Config.Path(role.Name)) - 1,
-			Scope: role.Scope, MergeRule: role.MergeRule, Model: role.Model, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
+			Scope: role.Scope, MergeRule: role.MergeRule, Model: role.Model, ActiveJobs: activeJobs, LastSeenAt: seen.LastSeenAt, LastSeenAge: orgPresenceAge(seen.LastSeenAt, observedNow), LastCommand: seen.LastCommand,
 			ProviderState: live.State, ProviderDetail: live.Detail, ObservedAt: observedAt, ProviderVersion: providerVersion,
 			RecycleStatus: recycleStatus, RecycleAfter: recycleAfterText,
 			MissedWakes: consecutive, Flagged: flagged, FlagReason: flagReason,

--- a/internal/cli/org_overview.go
+++ b/internal/cli/org_overview.go
@@ -187,16 +187,16 @@ func (shared *orgSharedState) loadJobCounts(ctx context.Context) (map[string]map
 	if shared.jobCountsLoaded {
 		return shared.jobCounts, nil
 	}
+	shared.jobCountsLoaded = true
 	counts, err := shared.Store.CountCurrentJobsByOrgRole(ctx)
 	if err != nil {
 		return nil, err
 	}
 	shared.jobCounts = counts
-	shared.jobCountsLoaded = true
 	return counts, nil
 }
 
-func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLiveSource, command string) ([]orgStatusOutput, error) {
+func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLiveSource, command string, includeActiveJobs bool) ([]orgStatusOutput, error) {
 	states, observedAt, providerVersion, err := src(ctx, shared.Config)
 	if err != nil {
 		return nil, &orgLiveSourceError{err: err}
@@ -219,12 +219,13 @@ func buildOrgStatusRows(ctx context.Context, shared *orgSharedState, src orgLive
 		recycleStatus := ""
 		recycleAfterText := ""
 		activeJobs := 0
-		if command == "status" {
+		if command == "status" && includeActiveJobs {
 			jobCounts, err := shared.loadJobCounts(ctx)
 			if err != nil {
-				return nil, fmt.Errorf("count active jobs for role %q: %w", role.Name, err)
+				shared.Warnings = append(shared.Warnings, fmt.Sprintf("active-jobs counts unavailable: %v", err))
+			} else {
+				activeJobs = jobCounts[role.Name]["queued"] + jobCounts[role.Name]["running"]
 			}
-			activeJobs = jobCounts[role.Name]["queued"] + jobCounts[role.Name]["running"]
 			if recycleAfter := shared.Config.RecycleAfterFor(role.Name); recycleAfter > 0 {
 				recycleStatus = orgRecycleStatus(seen.LastSeenAt, observedNow, live.State, activeJobs, recycleAfter)
 				recycleAfterText = formatOrgRecycleAfter(recycleAfter)

--- a/internal/cli/org_overview_test.go
+++ b/internal/cli/org_overview_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/org"
 )
@@ -130,5 +132,67 @@ func TestLoadOrgSharedStateMissedWakeAgeOut(t *testing.T) {
 	}
 	if missedWakeIsStale(now.Add(-missedWakeStaleAfter).Format(db.BlockedEpisodeTimeLayout), now) {
 		t.Fatal("miss exactly at stale boundary was hidden")
+	}
+}
+
+func TestBuildOrgStatusRowsActiveJobsFailureDegradesOnce(t *testing.T) {
+	_, paths := setupOrgHome(t)
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	shared, err := loadOrgSharedState(ctx, paths, store, time.Now().UTC())
+	if err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	source := func(context.Context, config.OrgConfig) (map[string]org.RoleLiveState, time.Time, string, error) {
+		return map[string]org.RoleLiveState{
+			"owner":  {State: org.StateIdle},
+			"review": {State: org.StateIdle},
+		}, time.Time{}, "fixture", nil
+	}
+
+	rows, err := buildOrgStatusRows(ctx, &shared, source, "status", true)
+	if err != nil {
+		t.Fatalf("buildOrgStatusRows() error = %v, want best-effort rows", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %+v, want owner and review", rows)
+	}
+	for _, row := range rows {
+		if row.ActiveJobs != 0 {
+			t.Fatalf("row[%s].ActiveJobs = %d, want 0", row.Role, row.ActiveJobs)
+		}
+	}
+	if len(shared.Warnings) != 1 || !strings.Contains(shared.Warnings[0], "active-jobs counts unavailable") {
+		t.Fatalf("warnings = %+v, want one active-jobs warning", shared.Warnings)
+	}
+	counts, err := shared.loadJobCounts(ctx)
+	if err != nil || counts != nil {
+		t.Fatalf("cached loadJobCounts() = (%+v, %v), want (nil, nil)", counts, err)
+	}
+
+	withoutActiveJobs := shared
+	withoutActiveJobs.jobCountsLoaded = false
+	withoutActiveJobs.Warnings = nil
+	rows, err = buildOrgStatusRows(ctx, &withoutActiveJobs, source, "status", false)
+	if err != nil {
+		t.Fatalf("buildOrgStatusRows(includeActiveJobs=false) error = %v", err)
+	}
+	if withoutActiveJobs.jobCountsLoaded {
+		t.Fatal("includeActiveJobs=false queried active-job counts")
+	}
+	if len(withoutActiveJobs.Warnings) != 0 {
+		t.Fatalf("includeActiveJobs=false warnings = %+v, want none", withoutActiveJobs.Warnings)
+	}
+	for _, row := range rows {
+		if row.ActiveJobs != 0 {
+			t.Fatalf("row[%s].ActiveJobs = %d with counts excluded, want 0", row.Role, row.ActiveJobs)
+		}
 	}
 }

--- a/internal/cli/org_overview_test.go
+++ b/internal/cli/org_overview_test.go
@@ -137,11 +137,31 @@ func TestLoadOrgSharedStateMissedWakeAgeOut(t *testing.T) {
 
 func TestBuildOrgStatusRowsActiveJobsFailureDegradesOnce(t *testing.T) {
 	_, paths := setupOrgHome(t)
+	file, err := os.OpenFile(paths.ConfigFile, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(`
+[org.roles."recyclable"]
+parent = "owner"
+scope = ["gitmoot/*"]
+recycle_after = "1ns"
+`); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
 	store, err := db.Open(paths.Database)
 	if err != nil {
 		t.Fatal(err)
 	}
 	ctx := context.Background()
+	if err := store.TouchOrgRolePresence(ctx, "recyclable", "test"); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
 	shared, err := loadOrgSharedState(ctx, paths, store, time.Now().UTC())
 	if err != nil {
 		store.Close()
@@ -152,8 +172,9 @@ func TestBuildOrgStatusRowsActiveJobsFailureDegradesOnce(t *testing.T) {
 	}
 	source := func(context.Context, config.OrgConfig) (map[string]org.RoleLiveState, time.Time, string, error) {
 		return map[string]org.RoleLiveState{
-			"owner":  {State: org.StateIdle},
-			"review": {State: org.StateIdle},
+			"owner":      {State: org.StateIdle},
+			"review":     {State: org.StateIdle},
+			"recyclable": {State: org.StateIdle},
 		}, time.Time{}, "fixture", nil
 	}
 
@@ -161,24 +182,43 @@ func TestBuildOrgStatusRowsActiveJobsFailureDegradesOnce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildOrgStatusRows() error = %v, want best-effort rows", err)
 	}
-	if len(rows) != 2 {
-		t.Fatalf("rows = %+v, want owner and review", rows)
+	if len(rows) != 3 {
+		t.Fatalf("rows = %+v, want owner, review, and recyclable", rows)
 	}
+	foundRecyclable := false
 	for _, row := range rows {
 		if row.ActiveJobs != 0 {
 			t.Fatalf("row[%s].ActiveJobs = %d, want 0", row.Role, row.ActiveJobs)
 		}
+		if row.Role == "recyclable" {
+			foundRecyclable = true
+			recycleAfter := shared.Config.RecycleAfterFor(row.Role)
+			if got := orgRecycleStatus(row.LastSeenAt, time.Now().UTC(), row.ProviderState, 0, recycleAfter); got != "eligible" {
+				t.Fatalf("recyclable fixture status with known-zero jobs = %q, want eligible", got)
+			}
+			if row.RecycleStatus != "" || row.RecycleAfter != "" {
+				t.Fatalf("recyclable row exposed recycle=%q after=%q with unknown job counts", row.RecycleStatus, row.RecycleAfter)
+			}
+		}
+	}
+	if !foundRecyclable {
+		t.Fatal("recyclable role missing from rows")
 	}
 	if len(shared.Warnings) != 1 || !strings.Contains(shared.Warnings[0], "active-jobs counts unavailable") {
 		t.Fatalf("warnings = %+v, want one active-jobs warning", shared.Warnings)
 	}
+	cachedErr := shared.jobCountsErr
+	if cachedErr == nil {
+		t.Fatal("job-count failure was not cached")
+	}
 	counts, err := shared.loadJobCounts(ctx)
-	if err != nil || counts != nil {
-		t.Fatalf("cached loadJobCounts() = (%+v, %v), want (nil, nil)", counts, err)
+	if err != cachedErr || counts != nil {
+		t.Fatalf("cached loadJobCounts() = (%+v, %v), want (nil, %v)", counts, err, cachedErr)
 	}
 
 	withoutActiveJobs := shared
 	withoutActiveJobs.jobCountsLoaded = false
+	withoutActiveJobs.jobCountsErr = nil
 	withoutActiveJobs.Warnings = nil
 	rows, err = buildOrgStatusRows(ctx, &withoutActiveJobs, source, "status", false)
 	if err != nil {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -924,9 +924,15 @@ recycle_after = "1ns"
 			t.Fatal(err)
 		}
 	}
-	if err := store.CreateJob(ctx, db.Job{ID: "active-job", Agent: "worker", Type: "ask", State: "queued", Payload: `{"acting_org_role":"active"}`}); err != nil {
-		store.Close()
-		t.Fatal(err)
+	for _, job := range []db.Job{
+		{ID: "owner-queued-job", Agent: "worker", Type: "ask", State: "queued", Payload: `{"acting_org_role":"owner"}`},
+		{ID: "owner-running-job", Agent: "worker", Type: "ask", State: "running", Payload: `{"acting_org_role":"owner"}`},
+		{ID: "active-job", Agent: "worker", Type: "ask", State: "queued", Payload: `{"acting_org_role":"active"}`},
+	} {
+		if err := store.CreateJob(ctx, job); err != nil {
+			store.Close()
+			t.Fatal(err)
+		}
 	}
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
@@ -940,12 +946,27 @@ recycle_after = "1ns"
 	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
 		t.Fatalf("decode status: %v; output=%s", err, stdout.String())
 	}
-	want := map[string]struct{ status, after string }{
-		"owner":    {},
+	var rawRows []map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &rawRows); err != nil {
+		t.Fatalf("decode raw status: %v; output=%s", err, stdout.String())
+	}
+	rawByRole := make(map[string]map[string]json.RawMessage, len(rawRows))
+	for _, raw := range rawRows {
+		var role string
+		if err := json.Unmarshal(raw["role"], &role); err != nil {
+			t.Fatalf("decode raw status role: %v; row=%s", err, raw["role"])
+		}
+		rawByRole[role] = raw
+	}
+	want := map[string]struct {
+		status, after string
+		activeJobs    int
+	}{
+		"owner":    {activeJobs: 2},
 		"fresh":    {status: "fresh", after: "24h"},
 		"eligible": {status: "eligible", after: "1ns"},
 		"working":  {status: "overdue", after: "1ns"},
-		"active":   {status: "overdue", after: "1ns"},
+		"active":   {status: "overdue", after: "1ns", activeJobs: 1},
 	}
 	for _, row := range rows {
 		expected, ok := want[row.Role]
@@ -954,6 +975,13 @@ recycle_after = "1ns"
 		}
 		if row.RecycleStatus != expected.status || row.RecycleAfter != expected.after {
 			t.Fatalf("status[%s] recycle=%q after=%q, want %q/%q", row.Role, row.RecycleStatus, row.RecycleAfter, expected.status, expected.after)
+		}
+		if row.ActiveJobs != expected.activeJobs {
+			t.Fatalf("status[%s] active_jobs=%d, want %d", row.Role, row.ActiveJobs, expected.activeJobs)
+		}
+		_, hasActiveJobs := rawByRole[row.Role]["active_jobs"]
+		if hasActiveJobs != (expected.activeJobs > 0) {
+			t.Fatalf("status[%s] active_jobs JSON presence=%v, want %v", row.Role, hasActiveJobs, expected.activeJobs > 0)
 		}
 		delete(want, row.Role)
 	}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1181,8 +1181,10 @@ role's `pane` binding. `chart` and `status` also show a `⚠ flagged (N missed
 wakes)` marker once a role reaches the positive
 `[orchestrate].max_consecutive_missed_wakes` threshold; their JSON rows expose
 `missed_wakes`, `flagged`, and `flag_reason`. The threshold defaults to `0`, so
-flagging is off. Open escalations remain deferred to #1058's resolution and
-correlation contract.
+flagging is off. `status --json` also exposes `active_jobs`, the live
+queued-plus-running job count attributed to the role through `ActingOrgRole`
+(#1114); it is distinct from daily or historical job counts. Open escalations
+remain deferred to #1058's resolution and correlation contract.
 
 The read-only Org page consumes `GET /api/org` for the store-backed role tree,
 health strip, typed escalations, and current signal feed, plus

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1183,7 +1183,7 @@ wakes)` marker once a role reaches the positive
 `missed_wakes`, `flagged`, and `flag_reason`. The threshold defaults to `0`, so
 flagging is off. `status --json` also exposes `active_jobs`, the live
 queued-plus-running job count attributed to the role through `ActingOrgRole`
-(#1114); it is distinct from daily or historical job counts. Open escalations
+(#1057); it is distinct from daily or historical job counts. Open escalations
 remain deferred to #1058's resolution and correlation contract.
 
 The read-only Org page consumes `GET /api/org` for the store-backed role tree,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1017,8 +1017,11 @@ live compatible Herdr snapshot. When configured, `brief --json` and `status
 flagged (N missed wakes)` marker after the role reaches the positive
 `[orchestrate].max_consecutive_missed_wakes` threshold; their JSON rows expose
 `missed_wakes`, `flagged`, and `flag_reason`. The default threshold is `0`
-(disabled). Escalations are recorded with `gitmoot org escalate`; their
-resolution and correlation surfaces are phase 2 work.
+(disabled). `status --json` also exposes `active_jobs`, the live
+queued-plus-running job count attributed to the role through `ActingOrgRole`
+(#1114); it is distinct from daily or historical job counts. Escalations are
+recorded with `gitmoot org escalate`; their resolution and correlation surfaces
+are phase 2 work.
 
 The read-only Org page consumes `GET /api/org` for the store-backed role tree,
 health strip, typed escalations, and current signal feed, plus

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1019,7 +1019,7 @@ flagged (N missed wakes)` marker after the role reaches the positive
 `missed_wakes`, `flagged`, and `flag_reason`. The default threshold is `0`
 (disabled). `status --json` also exposes `active_jobs`, the live
 queued-plus-running job count attributed to the role through `ActingOrgRole`
-(#1114); it is distinct from daily or historical job counts. Escalations are
+(#1057); it is distinct from daily or historical job counts. Escalations are
 recorded with `gitmoot org escalate`; their resolution and correlation surfaces
 are phase 2 work.
 


### PR DESCRIPTION
## Summary

Closes #1127: a role whose herdr seat goes idle while its dispatched workers
(attributed via `ActingOrgRole`, #1057) are still queued/running currently
reads as plain "idle" on the org page — nothing distinguishes "truly nothing
happening" from "seat quiet, lane busy". This is the CORE half; the DTO
schema shipped separately in `gitmoot-dashboard#135` (merged as `510fdc8`).

- Bumps the `gitmoot-dashboard` pin to `510fdc8bd010c0e2269bc7059728ada666a54d8c`
  (the merged schema commit).
- Computes the live queued+running job count via the pre-existing
  `CountCurrentJobsByOrgRole` (reused as-is, not touched) and threads it
  through `buildOrgStatusRows` into a new `orgStatusOutput.ActiveJobs` field
  (`org status --json`), and into `dashboard.OrgBadges.ActiveJobs` for the
  dashboard org tree (`GET /api/org`).
- The single-role dashboard endpoint (`buildDashboardOrgRole`) is
  intentionally untouched — `OrgRoleView` has no field for this, out of
  scope by design.

## Scope note (gitmoot-coc's ruling)

Discovered the DTO types live in the external `gitmoot-dashboard` module
before implementing, rather than assuming — g2's exclusive ownership of that
repo is a collision guard on `web/dist/index.html` specifically, not a
whole-repo claim, so the schema-only PR there was mine to open directly
(conditions: schema only, notify g2 first, own the pin bump here — all met).

## Review history (three commits, two adversarial passes on the fixes)

- `a9e90de` — initial implementation. `/code-review high`: 3 confirmed
  findings — (1) the new job-counts query ran unconditionally and hard-failed
  the *entire* `org status`/dashboard call on any error, widening the
  failure blast radius to orgs that never used `recycle_after` before; (2)
  the single-role dashboard endpoint ran the same query and discarded the
  result; (3) the new `active_jobs` field shipped undocumented.
- `d4736ab` — first fix: soft-degrade + `includeActiveJobs` gating. A
  follow-up `/code-review high`/medium pass caught that this fix introduced
  a *worse* bug: on a query failure, a fabricated `activeJobs=0` still fed
  into `orgRecycleStatus`, so a busy role could be reported recycle-
  **"eligible"** based on unknown data — and only the first affected role in
  a request even got a warning (the caching masked the error to `(nil,nil)`
  on repeat calls). Also caught a wrong issue citation (#1114, the unrelated
  merge-gate feature) in the new docs.
- `9976c39` — second fix: `loadJobCounts` now caches the error itself
  (`jobCountsErr`), so every role in a request sees a consistent failure
  signal; `orgRecycleStatus` is only ever called inside `if err == nil`, so
  a job-counts failure now withholds `RecycleStatus`/`RecycleAfter` entirely
  (empty, matching "not applicable") rather than fabricating a wrong status
  for any role. Doc citation fixed to #1057. A final `/code-review high`
  pass on this commit: **no findings survived verification**, including on
  an explicit re-check of the #1057 citation.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout 25m ./internal/cli/` — green (540s on the final commit)
- [x] `go generate ./... && git diff --exit-code` — clean
- [x] `TestBuildOrgStatusRowsActiveJobsFailureDegradesOnce` injects a real
      failure (closes the store before the call) across 3 roles, one with
      `recycle_after` configured; sanity-checks via a direct
      `orgRecycleStatus` call that the fixture *would* read "eligible" with
      a genuinely-known zero (proving the test exercises the bug scenario),
      then asserts the actual row withholds `RecycleStatus`/`RecycleAfter`;
      confirms exactly one warning across all affected roles; confirms
      `includeActiveJobs=false` skips the query entirely.
- [x] Three `/code-review` passes (high/high/high, fresh-context finders +
      verify pass each time) — final state: zero outstanding findings.
- [x] SHA-keyed CI watch on the pushed head — pending, will confirm green
      before requesting merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
