### PR TITLE
Gitmoot: gitmoot/gitmoot #1112 — dispatch routes seats to a

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -805,15 +805,17 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 			if dirty, err := taskWorktreeDirty(ctx, existing); err != nil {
 				return db.Task{}, localAgentDispatchRequest{}, err
 			} else if dirty {
-				handled, blockErr := (workflow.Engine{Store: store}).ReconcileDirtyTaskWorktreeLineage(
-					ctx,
-					gitutil.Client{Dir: record.CheckoutPath},
-					existing,
-					existing.WorktreePath,
-					baseSHA,
-				)
-				if handled {
-					return db.Task{}, localAgentDispatchRequest{}, blockErr
+				if baseSHA != "" {
+					handled, blockErr := (workflow.Engine{Store: store}).ReconcileDirtyTaskWorktreeLineage(
+						ctx,
+						gitutil.Client{Dir: record.CheckoutPath},
+						existing,
+						existing.WorktreePath,
+						baseSHA,
+					)
+					if handled {
+						return db.Task{}, localAgentDispatchRequest{}, blockErr
+					}
 				}
 				if prOpenFixPass {
 					return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has uncommitted changes in task worktree %s; inspect and commit/push them, or clean/stash them before retrying the PR fix-pass", branchHint, existing.WorktreePath)
@@ -875,15 +877,16 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 	}
 	owner := strings.TrimSpace(request.Agent)
 	started, err := (workflow.Engine{Store: store}).AllocateTaskWorktree(ctx, workflow.TaskWorktreeRequest{
-		Home:       paths.Home,
-		Repo:       repo.FullName(),
-		GoalID:     task.GoalID,
-		TaskID:     task.ID,
-		TaskTitle:  task.Title,
-		Branch:     branch,
-		BaseBranch: baseSHA,
-		Owner:      owner,
-		Checkout:   record.CheckoutPath,
+		Home:           paths.Home,
+		Repo:           repo.FullName(),
+		GoalID:         task.GoalID,
+		TaskID:         task.ID,
+		TaskTitle:      task.Title,
+		Branch:         branch,
+		BaseBranch:     baseSHA,
+		LineageUnknown: deferImplicitPRBase && baseSHA == "",
+		Owner:          owner,
+		Checkout:       record.CheckoutPath,
 	}, gitutil.Client{Dir: record.CheckoutPath})
 	if err != nil {
 		return db.Task{}, localAgentDispatchRequest{}, err

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -805,6 +805,16 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 			if dirty, err := taskWorktreeDirty(ctx, existing); err != nil {
 				return db.Task{}, localAgentDispatchRequest{}, err
 			} else if dirty {
+				handled, blockErr := (workflow.Engine{Store: store}).ReconcileDirtyTaskWorktreeLineage(
+					ctx,
+					gitutil.Client{Dir: record.CheckoutPath},
+					existing,
+					existing.WorktreePath,
+					baseSHA,
+				)
+				if handled {
+					return db.Task{}, localAgentDispatchRequest{}, blockErr
+				}
 				if prOpenFixPass {
 					return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has uncommitted changes in task worktree %s; inspect and commit/push them, or clean/stash them before retrying the PR fix-pass", branchHint, existing.WorktreePath)
 				}

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -460,6 +460,16 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 				return err
 			}
 			if dirty {
+				handled, blockErr := (workflow.Engine{Store: store}).ReconcileDirtyTaskWorktreeLineage(
+					context.Background(),
+					gitutil.Client{Dir: checkout},
+					candidate,
+					candidate.WorktreePath,
+					*base,
+				)
+				if handled {
+					return blockErr
+				}
 				skipFanout := taskRecoverSkipFanout(context.Background(), store, requestRepo, requestBranch)
 				recoverCmd := taskRecoverCommand(task.ID, *home, requestRepo, strings.TrimSpace(*owner), skipFanout)
 				return fmt.Errorf("task %s worktree has uncommitted changes at %s; inspect it, then run %s to commit/push/open a PR, or clean/stash it before retrying task run", task.ID, candidate.WorktreePath, recoverCmd)

--- a/internal/cli/worktree_lineage_reachability_test.go
+++ b/internal/cli/worktree_lineage_reachability_test.go
@@ -1,0 +1,259 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+type dirtyTaskLineageFixture struct {
+	home     string
+	checkout string
+	worktree string
+	task     db.Task
+	store    *db.Store
+}
+
+func newDirtyTaskLineageFixture(t *testing.T, offLineage bool) dirtyTaskLineageFixture {
+	t.Helper()
+	ctx := context.Background()
+	home := t.TempDir()
+	checkout := filepath.Join(t.TempDir(), "checkout")
+	if err := os.MkdirAll(checkout, 0o755); err != nil {
+		t.Fatalf("MkdirAll checkout: %v", err)
+	}
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runGit(t, checkout, "config", "user.name", "Gitmoot Test")
+	runGit(t, checkout, "branch", "-m", "main")
+	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
+	writeFile(t, filepath.Join(checkout, "README.md"), "initial\n")
+	runGit(t, checkout, "add", "README.md")
+	runGit(t, checkout, "commit", "-m", "initial")
+
+	store := openCLIJobStore(t, home)
+	paths := config.PathsForHome(home)
+	worktree, err := workflow.TaskWorktreePath(paths.Home, "owner/repo", "task-lineage")
+	if err != nil {
+		store.Close()
+		t.Fatalf("TaskWorktreePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(worktree), 0o755); err != nil {
+		store.Close()
+		t.Fatalf("MkdirAll worktree parent: %v", err)
+	}
+	runGit(t, checkout, "worktree", "add", "-b", "feature/lineage", worktree, "main")
+	if offLineage {
+		writeFile(t, filepath.Join(checkout, "base-moved.txt"), "new base\n")
+		runGit(t, checkout, "add", "base-moved.txt")
+		runGit(t, checkout, "commit", "-m", "advance base")
+	}
+	writeFile(t, filepath.Join(worktree, "salvage.txt"), "uncommitted salvage\n")
+
+	task := db.Task{
+		ID:           "task-lineage",
+		RepoFullName: "owner/repo",
+		GoalID:       "goal-lineage",
+		Title:        "Lineage reachability",
+		State:        string(workflow.TaskImplementing),
+		Branch:       "feature/lineage",
+		WorktreePath: worktree,
+	}
+	if err := store.UpsertTask(ctx, task); err != nil {
+		store.Close()
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	if err := store.UpsertRepo(ctx, db.Repo{
+		Owner:         "owner",
+		Name:          "repo",
+		DefaultBranch: "main",
+		RemoteURL:     "https://github.com/owner/repo.git",
+		CheckoutPath:  checkout,
+		PollInterval:  "30s",
+	}); err != nil {
+		store.Close()
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "lead",
+		Runtime:        "shell",
+		RuntimeRef:     "true",
+		RepoScope:      "owner/repo",
+		Capabilities:   []string{"implement"},
+		AutonomyPolicy: "workspace-write",
+		HealthStatus:   "ok",
+	}); err != nil {
+		store.Close()
+		t.Fatalf("UpsertAgent: %v", err)
+	}
+	return dirtyTaskLineageFixture{
+		home:     home,
+		checkout: checkout,
+		worktree: worktree,
+		task:     task,
+		store:    store,
+	}
+}
+
+func TestPrepareLocalImplementDispatchRequestReconcilesDirtyWorktreeLineage(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		offLineage  bool
+		wantBlocked bool
+	}{
+		{name: "on-lineage keeps existing recovery guidance"},
+		{name: "off-lineage blocks and journals", offLineage: true, wantBlocked: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newDirtyTaskLineageFixture(t, tc.offLineage)
+			defer fixture.store.Close()
+
+			_, _, err := prepareLocalImplementDispatchRequest(
+				context.Background(),
+				fixture.store,
+				db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: fixture.checkout},
+				github.Repository{Owner: "owner", Name: "repo"},
+				localAgentDispatchRequest{
+					Home:          fixture.home,
+					Agent:         "lead",
+					Action:        "implement",
+					Instructions:  "Continue implementation.",
+					Branch:        fixture.task.Branch,
+					ImplementBase: "HEAD",
+				},
+			)
+			if err == nil {
+				t.Fatal("prepareLocalImplementDispatchRequest succeeded for dirty worktree")
+			}
+
+			stored, getErr := fixture.store.GetTask(context.Background(), fixture.task.ID)
+			if getErr != nil {
+				t.Fatalf("GetTask: %v", getErr)
+			}
+			events, eventsErr := fixture.store.ListTaskEvents(context.Background(), fixture.task.ID)
+			if eventsErr != nil {
+				t.Fatalf("ListTaskEvents: %v", eventsErr)
+			}
+			if tc.wantBlocked {
+				var blocked workflow.BlockedError
+				if !errors.As(err, &blocked) {
+					t.Fatalf("error = %v, want BlockedError", err)
+				}
+				if stored.State != string(workflow.TaskBlocked) {
+					t.Fatalf("task state = %q, want blocked", stored.State)
+				}
+				if len(events) != 1 || events[0].Kind != "stale_worktree_dirty_blocked" {
+					t.Fatalf("task events = %+v", events)
+				}
+				for _, want := range []string{"is stale", "uncommitted changes", "manually salvage"} {
+					if !strings.Contains(err.Error(), want) {
+						t.Fatalf("blocked error %q missing %q", err, want)
+					}
+				}
+				if strings.Contains(err.Error(), "gitmoot task recover") {
+					t.Fatalf("off-lineage error points at stale-branch recovery: %v", err)
+				}
+			} else {
+				if !strings.Contains(err.Error(), "gitmoot task recover task-lineage") {
+					t.Fatalf("on-lineage error changed existing recovery guidance: %v", err)
+				}
+				if stored.State != fixture.task.State {
+					t.Fatalf("on-lineage task state = %q, want %q", stored.State, fixture.task.State)
+				}
+				if len(events) != 0 {
+					t.Fatalf("on-lineage task events = %+v, want none", events)
+				}
+			}
+			if content, readErr := os.ReadFile(filepath.Join(fixture.worktree, "salvage.txt")); readErr != nil || string(content) != "uncommitted salvage\n" {
+				t.Fatalf("salvage file = %q, %v", content, readErr)
+			}
+			if _, lockErr := fixture.store.GetBranchLock(context.Background(), "owner/repo", fixture.task.Branch); !errors.Is(lockErr, sql.ErrNoRows) {
+				t.Fatalf("dirty preflight created branch lock: %v", lockErr)
+			}
+		})
+	}
+}
+
+func TestRunTaskRunReconcilesDirtyWorktreeLineage(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		offLineage  bool
+		wantBlocked bool
+	}{
+		{name: "on-lineage keeps existing recovery guidance"},
+		{name: "off-lineage blocks and journals", offLineage: true, wantBlocked: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newDirtyTaskLineageFixture(t, tc.offLineage)
+			if err := fixture.store.Close(); err != nil {
+				t.Fatalf("close seed store: %v", err)
+			}
+			withWorkingDirectory(t, fixture.checkout)
+
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{
+				"task", "run", fixture.task.ID,
+				"--home", fixture.home,
+				"--repo", "owner/repo",
+				"--owner", "lead",
+				"--base", "HEAD",
+			}, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("task run code = %d, want 1; stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+
+			store := openCLIJobStore(t, fixture.home)
+			defer store.Close()
+			stored, err := store.GetTask(context.Background(), fixture.task.ID)
+			if err != nil {
+				t.Fatalf("GetTask: %v", err)
+			}
+			events, err := store.ListTaskEvents(context.Background(), fixture.task.ID)
+			if err != nil {
+				t.Fatalf("ListTaskEvents: %v", err)
+			}
+			if tc.wantBlocked {
+				if stored.State != string(workflow.TaskBlocked) {
+					t.Fatalf("task state = %q, want blocked", stored.State)
+				}
+				if len(events) != 1 || events[0].Kind != "stale_worktree_dirty_blocked" {
+					t.Fatalf("task events = %+v", events)
+				}
+				for _, want := range []string{"is stale", "uncommitted changes", "manually salvage"} {
+					if !strings.Contains(stderr.String(), want) {
+						t.Fatalf("blocked stderr %q missing %q", stderr.String(), want)
+					}
+				}
+				if strings.Contains(stderr.String(), "gitmoot task recover") {
+					t.Fatalf("off-lineage stderr points at stale-branch recovery: %s", stderr.String())
+				}
+			} else {
+				if !strings.Contains(stderr.String(), "gitmoot task recover task-lineage") {
+					t.Fatalf("on-lineage stderr changed existing recovery guidance: %s", stderr.String())
+				}
+				if stored.State != fixture.task.State {
+					t.Fatalf("on-lineage task state = %q, want %q", stored.State, fixture.task.State)
+				}
+				if len(events) != 0 {
+					t.Fatalf("on-lineage task events = %+v, want none", events)
+				}
+			}
+			if content, readErr := os.ReadFile(filepath.Join(fixture.worktree, "salvage.txt")); readErr != nil || string(content) != "uncommitted salvage\n" {
+				t.Fatalf("salvage file = %q, %v", content, readErr)
+			}
+			if _, lockErr := store.GetBranchLock(context.Background(), "owner/repo", fixture.task.Branch); !errors.Is(lockErr, sql.ErrNoRows) {
+				t.Fatalf("dirty preflight created branch lock: %v", lockErr)
+			}
+		})
+	}
+}

--- a/internal/cli/worktree_lineage_reachability_test.go
+++ b/internal/cli/worktree_lineage_reachability_test.go
@@ -184,6 +184,91 @@ func TestPrepareLocalImplementDispatchRequestReconcilesDirtyWorktreeLineage(t *t
 	}
 }
 
+func TestPrepareLocalImplementDispatchRequestImplicitPRBaseSkipsGenericLineage(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		dirty bool
+	}{
+		{name: "dirty validated PR keeps existing refusal", dirty: true},
+		{name: "clean validated PR keeps worktree and head"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := newDirtyTaskLineageFixture(t, true)
+			defer fixture.store.Close()
+
+			runGit(t, fixture.worktree, "add", "salvage.txt")
+			runGit(t, fixture.worktree, "commit", "-m", "PR branch work")
+			prHead := strings.TrimSpace(runGitOutput(t, fixture.worktree, "rev-parse", "HEAD"))
+			if tc.dirty {
+				writeFile(t, filepath.Join(fixture.worktree, "follow-up.txt"), "uncommitted follow-up\n")
+			}
+			fixture.task.State = string(workflow.TaskPullRequestOpen)
+			if err := fixture.store.UpsertTask(context.Background(), fixture.task); err != nil {
+				t.Fatalf("UpsertTask PR state: %v", err)
+			}
+
+			started, _, err := prepareLocalImplementDispatchRequest(
+				context.Background(),
+				fixture.store,
+				db.Repo{Owner: "owner", Name: "repo", DefaultBranch: "main", CheckoutPath: fixture.checkout},
+				github.Repository{Owner: "owner", Name: "repo"},
+				localAgentDispatchRequest{
+					Home:                 fixture.home,
+					Agent:                "lead",
+					Action:               "implement",
+					Instructions:         "Apply a PR fix-pass.",
+					PullRequest:          42,
+					ImplementPRValidated: true,
+					Branch:               fixture.task.Branch,
+					HeadSHA:              prHead,
+				},
+			)
+
+			stored, getErr := fixture.store.GetTask(context.Background(), fixture.task.ID)
+			if getErr != nil {
+				t.Fatalf("GetTask: %v", getErr)
+			}
+			events, eventsErr := fixture.store.ListTaskEvents(context.Background(), fixture.task.ID)
+			if eventsErr != nil {
+				t.Fatalf("ListTaskEvents: %v", eventsErr)
+			}
+			if tc.dirty {
+				if err == nil {
+					t.Fatal("dirty implicit PR fix-pass succeeded")
+				}
+				want := "branch " + fixture.task.Branch + " has uncommitted changes in task worktree " + fixture.worktree + "; inspect and commit/push them, or clean/stash them before retrying the PR fix-pass"
+				if err.Error() != want {
+					t.Fatalf("dirty implicit PR error = %q, want unchanged %q", err, want)
+				}
+				if stored.State != string(workflow.TaskPullRequestOpen) {
+					t.Fatalf("dirty implicit PR task state = %q, want pr_open", stored.State)
+				}
+				if len(events) != 0 {
+					t.Fatalf("dirty implicit PR task events = %+v, want none", events)
+				}
+				if content, readErr := os.ReadFile(filepath.Join(fixture.worktree, "follow-up.txt")); readErr != nil || string(content) != "uncommitted follow-up\n" {
+					t.Fatalf("dirty implicit PR follow-up = %q, %v", content, readErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("clean implicit PR fix-pass: %v", err)
+			}
+			if started.WorktreePath != fixture.worktree {
+				t.Fatalf("clean implicit PR worktree = %q, want %q", started.WorktreePath, fixture.worktree)
+			}
+			afterHead := strings.TrimSpace(runGitOutput(t, fixture.worktree, "rev-parse", "HEAD"))
+			if afterHead != prHead {
+				t.Fatalf("clean implicit PR head = %s, want preserved %s", afterHead, prHead)
+			}
+			if len(events) != 0 {
+				t.Fatalf("clean implicit PR task events = %+v, want none", events)
+			}
+		})
+	}
+}
+
 func TestRunTaskRunReconcilesDirtyWorktreeLineage(t *testing.T) {
 	for _, tc := range []struct {
 		name        string

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -421,6 +422,14 @@ func (c Client) WorktreeClean(ctx context.Context) (bool, error) {
 	return strings.TrimSpace(result.Stdout) == "", nil
 }
 
+func (c Client) WorktreeCleanAt(ctx context.Context, path string) (bool, error) {
+	path, err := validateWorktreePath(path)
+	if err != nil {
+		return false, err
+	}
+	return (Client{Runner: c.Runner, Dir: path}).WorktreeClean(ctx)
+}
+
 func (c Client) StatusPorcelain(ctx context.Context) (string, error) {
 	result, err := c.run(ctx, "status", "--porcelain")
 	if err != nil {
@@ -453,6 +462,14 @@ func (c Client) HeadSHA(ctx context.Context) (string, error) {
 	return sha, nil
 }
 
+func (c Client) HeadSHAAt(ctx context.Context, path string) (string, error) {
+	path, err := validateWorktreePath(path)
+	if err != nil {
+		return "", err
+	}
+	return (Client{Runner: c.Runner, Dir: path}).HeadSHA(ctx)
+}
+
 func (c Client) RevParse(ctx context.Context, rev string) (string, error) {
 	rev = strings.TrimSpace(rev)
 	if rev == "" {
@@ -473,6 +490,29 @@ func (c Client) RevParse(ctx context.Context, rev string) (string, error) {
 		return "", errors.New("git revision SHA is empty")
 	}
 	return sha, nil
+}
+
+// IsAncestor reports whether ancestor is reachable from descendant. Git uses
+// exit status 1 for the ordinary "not an ancestor" result; every other failure
+// remains an error so invalid refs and repository failures fail closed.
+func (c Client) IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error) {
+	ancestor = strings.TrimSpace(ancestor)
+	descendant = strings.TrimSpace(descendant)
+	if err := validateRef(ancestor); err != nil {
+		return false, err
+	}
+	if err := validateRef(descendant); err != nil {
+		return false, err
+	}
+	_, err := c.run(ctx, "merge-base", "--is-ancestor", ancestor, descendant)
+	if err == nil {
+		return true, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false, nil
+	}
+	return false, err
 }
 
 // BehindCount reports how many commits upstream has that HEAD does not. It is

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -484,6 +484,57 @@ func TestClientBehindCountRejectsInvalidOutput(t *testing.T) {
 	}
 }
 
+func TestClientIsAncestor(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	ctx := context.Background()
+	dir := t.TempDir()
+	runGit(t, dir, "init", "-b", "main")
+	runGit(t, dir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, dir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(dir, "history.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile base: %v", err)
+	}
+	runGit(t, dir, "add", "history.txt")
+	runGit(t, dir, "commit", "-m", "base")
+	client := Client{Dir: dir}
+	base, err := client.HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA base: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "history.txt"), []byte("base\nchild\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile child: %v", err)
+	}
+	runGit(t, dir, "commit", "-am", "child")
+	child, err := client.HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA child: %v", err)
+	}
+	isAncestor, err := client.IsAncestor(ctx, base, child)
+	if err != nil || !isAncestor {
+		t.Fatalf("IsAncestor true case = %t, %v", isAncestor, err)
+	}
+
+	runGit(t, dir, "switch", "--detach", base)
+	if err := os.WriteFile(filepath.Join(dir, "sibling.txt"), []byte("sibling\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile sibling: %v", err)
+	}
+	runGit(t, dir, "add", "sibling.txt")
+	runGit(t, dir, "commit", "-m", "sibling")
+	sibling, err := client.HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA sibling: %v", err)
+	}
+	isAncestor, err = client.IsAncestor(ctx, child, sibling)
+	if err != nil || isAncestor {
+		t.Fatalf("IsAncestor false case = %t, %v", isAncestor, err)
+	}
+	if _, err := client.IsAncestor(ctx, "missing-ref", sibling); err == nil {
+		t.Fatal("IsAncestor accepted an invalid ref")
+	}
+}
+
 func TestClientCreateBranchSmoke(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not installed")

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -84,15 +84,23 @@ type WorktreeCommitter interface {
 }
 
 type TaskWorktreeRequest struct {
-	Home       string
-	Repo       string
-	TaskID     string
-	GoalID     string
-	TaskTitle  string
-	Branch     string
+	Home      string
+	Repo      string
+	TaskID    string
+	GoalID    string
+	TaskTitle string
+	Branch    string
+	// BaseBranch is the independently resolved lineage base for ordinary
+	// allocation and reuse checks.
 	BaseBranch string
-	Owner      string
-	Checkout   string
+	// LineageUnknown is set when no independently resolved base applies because
+	// a more precise validation already proved an existing worktree correct,
+	// such as an implicit PR fix-pass's exact branch and HEAD match. The
+	// existing-worktree reuse path treats lineage as satisfied without deriving
+	// a fallback base or performing another Git probe.
+	LineageUnknown bool
+	Owner          string
+	Checkout       string
 }
 
 // ReconcileDirtyTaskWorktreeLineage distinguishes ordinary resumable dirtiness
@@ -210,27 +218,31 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		}
 	}()
 	if task.Branch == request.Branch && task.WorktreePath == path {
-		lineage, err := ensureExistingWorktreeLineage(ctx, manager, request.Branch, path, request.BaseBranch)
-		if err != nil {
-			if createdLock {
-				_, _ = e.Store.ReleaseLock(ctx, lock)
-			}
-			return db.Task{}, err
-		}
-		if lineage.DirtyBlocked {
-			reason := lineage.dirtyBlockedMessage(path)
-			blockErr := blockTaskForDirtyWorktree(ctx, e.Store, task, request, path, reason)
-			if createdLock {
-				_, _ = e.Store.ReleaseLock(ctx, lock)
-			}
-			return db.Task{}, blockErr
-		}
-		if lineage.Recut {
-			if err := addTaskWorktreeLineageEvent(ctx, e.Store, task.ID, "stale_worktree_recut", lineage.message("stale task worktree detected and re-cut")); err != nil {
+		// An implicit PR fix-pass may already have proved this exact branch and
+		// HEAD through PR-specific validation, with no applicable ancestry base.
+		if !request.LineageUnknown {
+			lineage, err := ensureExistingWorktreeLineage(ctx, manager, request.Branch, path, request.BaseBranch)
+			if err != nil {
 				if createdLock {
 					_, _ = e.Store.ReleaseLock(ctx, lock)
 				}
 				return db.Task{}, err
+			}
+			if lineage.DirtyBlocked {
+				reason := lineage.dirtyBlockedMessage(path)
+				blockErr := blockTaskForDirtyWorktree(ctx, e.Store, task, request, path, reason)
+				if createdLock {
+					_, _ = e.Store.ReleaseLock(ctx, lock)
+				}
+				return db.Task{}, blockErr
+			}
+			if lineage.Recut {
+				if err := addTaskWorktreeLineageEvent(ctx, e.Store, task.ID, "stale_worktree_recut", lineage.message("stale task worktree detected and re-cut")); err != nil {
+					if createdLock {
+						_, _ = e.Store.ReleaseLock(ctx, lock)
+					}
+					return db.Task{}, err
+				}
 			}
 		}
 		if claimPlanned {

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -95,6 +95,48 @@ type TaskWorktreeRequest struct {
 	Checkout   string
 }
 
+// ReconcileDirtyTaskWorktreeLineage distinguishes ordinary resumable dirtiness
+// from a dirty worktree whose base has moved. Callers invoke it only after their
+// existing dirty-worktree preflight has succeeded.
+//
+// A confirmed off-lineage worktree is blocked and journaled through the same
+// path used by AllocateTaskWorktree. An intact or indeterminate lineage returns
+// handled=false so callers preserve their existing recover-or-clean guidance.
+func (e Engine) ReconcileDirtyTaskWorktreeLineage(ctx context.Context, manager WorktreeManager, task db.Task, path, baseRef string) (handled bool, blockErr error) {
+	// Every probe/setup failure is deliberately indeterminate. This method may
+	// only replace the caller's existing dirty-worktree behavior when it can
+	// affirmatively prove the worktree is off-lineage.
+	if err := e.validate(); err != nil {
+		return false, nil
+	}
+	lineage, err := writableWorktreeLineageManager(manager)
+	if err != nil {
+		return false, nil
+	}
+	baseHead, err := fetchAndResolveLineageBase(ctx, lineage, baseRef)
+	if err != nil {
+		return false, nil
+	}
+	worktreeHead, err := lineage.HeadSHAAt(ctx, path)
+	if err != nil {
+		return false, nil
+	}
+	isAncestor, err := lineage.IsAncestor(ctx, baseHead, worktreeHead)
+	if err != nil || isAncestor {
+		return false, nil
+	}
+	result := worktreeLineageResult{DirtyBlocked: true, BaseHead: baseHead, OldHead: worktreeHead}
+	reason := result.dirtyBlockedMessage(path)
+	request := TaskWorktreeRequest{
+		Repo:      task.RepoFullName,
+		TaskID:    task.ID,
+		GoalID:    task.GoalID,
+		TaskTitle: task.Title,
+		Branch:    task.Branch,
+	}
+	return true, blockTaskForDirtyWorktree(ctx, e.Store, task, request, path, reason)
+}
+
 func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRequest, manager WorktreeManager) (db.Task, error) {
 	if err := e.validate(); err != nil {
 		return db.Task{}, err

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -28,6 +28,19 @@ type BranchExistenceChecker interface {
 	BranchExists(ctx context.Context, branch string) (bool, error)
 }
 
+// WritableWorktreeLineageManager is implemented by the checkout-bound Git
+// client. It keeps lineage checks and any stale-worktree replacement inside the
+// same checkout mutation lock used for ordinary worktree allocation.
+type WritableWorktreeLineageManager interface {
+	FetchRemote(ctx context.Context, remote string) error
+	HeadSHAAt(ctx context.Context, path string) (string, error)
+	RevParse(ctx context.Context, rev string) (string, error)
+	IsAncestor(ctx context.Context, ancestor, descendant string) (bool, error)
+	WorktreeCleanAt(ctx context.Context, path string) (bool, error)
+	RemoveWorktree(ctx context.Context, path string) error
+	DeleteBranch(ctx context.Context, branch string) error
+}
+
 // ReadOnlyWorktreeManager allocates and disposes throwaway detached worktrees
 // for read-only (ask/review) delegation fan-out. Unlike implement worktrees
 // these carry no branch and no branch lock: the worker only reads the checkout,
@@ -142,7 +155,42 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 			return db.Task{}, BlockedError{Reason: "branch lock rejected action for " + request.Branch}
 		}
 	}
+	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, e.Store, request.Checkout, "worktree:"+request.TaskID, time.Now().UTC())
+	if err != nil {
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
+		return db.Task{}, err
+	}
+	defer func() {
+		if releaseCheckoutLock != nil {
+			_ = releaseCheckoutLock(context.Background())
+		}
+	}()
 	if task.Branch == request.Branch && task.WorktreePath == path {
+		lineage, err := ensureExistingWorktreeLineage(ctx, manager, request.Branch, path, request.BaseBranch)
+		if err != nil {
+			if createdLock {
+				_, _ = e.Store.ReleaseLock(ctx, lock)
+			}
+			return db.Task{}, err
+		}
+		if lineage.DirtyBlocked {
+			reason := lineage.dirtyBlockedMessage(path)
+			blockErr := blockTaskForDirtyWorktree(ctx, e.Store, task, request, path, reason)
+			if createdLock {
+				_, _ = e.Store.ReleaseLock(ctx, lock)
+			}
+			return db.Task{}, blockErr
+		}
+		if lineage.Recut {
+			if err := addTaskWorktreeLineageEvent(ctx, e.Store, task.ID, "stale_worktree_recut", lineage.message("stale task worktree detected and re-cut")); err != nil {
+				if createdLock {
+					_, _ = e.Store.ReleaseLock(ctx, lock)
+				}
+				return db.Task{}, err
+			}
+		}
 		if claimPlanned {
 			if err := e.claimPlannedTaskForImplementation(ctx, task.ID); err != nil {
 				if createdLock {
@@ -160,23 +208,28 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 		}
 		return task, nil
 	}
-	releaseCheckoutLock, _, err := acquireCheckoutMutationLockWithWait(ctx, e.Store, request.Checkout, "worktree:"+request.TaskID, time.Now().UTC())
+	lineage, err := addTaskWorktree(ctx, manager, request.Branch, path, request.BaseBranch)
 	if err != nil {
 		if createdLock {
 			_, _ = e.Store.ReleaseLock(ctx, lock)
 		}
 		return db.Task{}, err
 	}
-	defer func() {
-		if releaseCheckoutLock != nil {
-			_ = releaseCheckoutLock(context.Background())
-		}
-	}()
-	if err := addTaskWorktree(ctx, manager, request.Branch, path, request.BaseBranch); err != nil {
+	if lineage.DirtyBlocked {
+		reason := lineage.dirtyBlockedMessage(path)
+		blockErr := blockTaskForDirtyWorktree(ctx, e.Store, task, request, path, reason)
 		if createdLock {
 			_, _ = e.Store.ReleaseLock(ctx, lock)
 		}
-		return db.Task{}, err
+		return db.Task{}, blockErr
+	}
+	if lineage.Recut {
+		if err := addTaskWorktreeLineageEvent(ctx, e.Store, task.ID, "stale_worktree_recut", lineage.message("stale task worktree detected and re-cut")); err != nil {
+			if createdLock {
+				_, _ = e.Store.ReleaseLock(ctx, lock)
+			}
+			return db.Task{}, err
+		}
 	}
 	taskGoalID := task.GoalID
 	if taskGoalID == "" {
@@ -315,11 +368,41 @@ func (e Engine) AllocateDelegationWorktree(ctx context.Context, request Delegati
 			_ = releaseCheckoutLock(context.Background())
 		}
 	}()
-	if err := addTaskWorktree(ctx, manager, branch, path, request.BaseBranch); err != nil {
+	lineage, err := addTaskWorktree(ctx, manager, branch, path, request.BaseBranch)
+	if err != nil {
 		if createdLock {
 			_, _ = e.Store.ReleaseLock(ctx, lock)
 		}
 		return DelegationWorktreeResult{}, err
+	}
+	if lineage.DirtyBlocked {
+		reason := lineage.dirtyBlockedMessage(path)
+		if err := e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   request.ParentJobID,
+			Kind:    "stale_worktree_dirty_blocked",
+			Message: reason,
+		}); err != nil {
+			if createdLock {
+				_, _ = e.Store.ReleaseLock(ctx, lock)
+			}
+			return DelegationWorktreeResult{}, err
+		}
+		if createdLock {
+			_, _ = e.Store.ReleaseLock(ctx, lock)
+		}
+		return DelegationWorktreeResult{}, BlockedError{Reason: reason}
+	}
+	if lineage.Recut {
+		if err := e.Store.AddJobEvent(ctx, db.JobEvent{
+			JobID:   request.ParentJobID,
+			Kind:    "stale_worktree_recut",
+			Message: lineage.message("stale delegation worktree detected and re-cut"),
+		}); err != nil {
+			if createdLock {
+				_, _ = e.Store.ReleaseLock(ctx, lock)
+			}
+			return DelegationWorktreeResult{}, err
+		}
 	}
 	return DelegationWorktreeResult{Path: path, Branch: branch}, nil
 }
@@ -1113,21 +1196,217 @@ func (e Engine) cleanupConsumedImplementLegWorktrees(ctx context.Context, payloa
 	}
 }
 
-func addTaskWorktree(ctx context.Context, manager WorktreeManager, branch string, path string, base string) error {
+type worktreeLineageResult struct {
+	Recut        bool
+	DirtyBlocked bool
+	BaseHead     string
+	OldHead      string
+	NewHead      string
+}
+
+func (r worktreeLineageResult) message(prefix string) string {
+	return fmt.Sprintf("%s: base=%s old_head=%s new_head=%s", prefix, r.BaseHead, r.OldHead, r.NewHead)
+}
+
+func (r worktreeLineageResult) dirtyBlockedMessage(path string) string {
+	return fmt.Sprintf("worktree at %s is stale (HEAD %s is not a descendant of resolved base %s) and has uncommitted changes; manually salvage, commit, stash, or clean them before retrying so the worktree can be re-cut", path, r.OldHead, r.BaseHead)
+}
+
+func addTaskWorktree(ctx context.Context, manager WorktreeManager, branch string, path string, base string) (worktreeLineageResult, error) {
 	if checker, ok := manager.(BranchExistenceChecker); ok {
 		exists, err := checker.BranchExists(ctx, branch)
 		if err != nil {
-			return err
+			return worktreeLineageResult{}, err
 		}
 		if exists {
 			existingManager, ok := manager.(ExistingBranchWorktreeManager)
 			if !ok {
-				return errors.New("existing branch worktree manager is required")
+				return worktreeLineageResult{}, errors.New("existing branch worktree manager is required")
 			}
-			return existingManager.AddExistingBranchWorktree(ctx, branch, path)
+			return reuseExistingBranchWorktree(ctx, manager, existingManager, branch, path, base)
 		}
 	}
-	return manager.AddWorktree(ctx, branch, path, base)
+	return worktreeLineageResult{}, manager.AddWorktree(ctx, branch, path, base)
+}
+
+func ensureExistingWorktreeLineage(ctx context.Context, manager WorktreeManager, branch, path, base string) (worktreeLineageResult, error) {
+	lineage, err := writableWorktreeLineageManager(manager)
+	if err != nil {
+		return worktreeLineageResult{}, err
+	}
+	baseHead, err := fetchAndResolveLineageBase(ctx, lineage, base)
+	if err != nil {
+		return worktreeLineageResult{}, err
+	}
+	oldHead, err := lineage.HeadSHAAt(ctx, path)
+	if err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("resolve existing worktree head: %w", err)
+	}
+	isAncestor, err := lineage.IsAncestor(ctx, baseHead, oldHead)
+	if err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("verify existing worktree lineage: %w", err)
+	}
+	if isAncestor {
+		return worktreeLineageResult{BaseHead: baseHead, OldHead: oldHead, NewHead: oldHead}, nil
+	}
+	clean, err := lineage.WorktreeCleanAt(ctx, path)
+	if err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("inspect stale worktree for uncommitted changes: %w", err)
+	}
+	if !clean {
+		return worktreeLineageResult{DirtyBlocked: true, BaseHead: baseHead, OldHead: oldHead}, nil
+	}
+	if err := lineage.RemoveWorktree(ctx, path); err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("remove stale worktree: %w", err)
+	}
+	if err := lineage.DeleteBranch(ctx, branch); err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("delete stale worktree branch: %w", err)
+	}
+	if err := manager.AddWorktree(ctx, branch, path, baseHead); err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("re-create stale worktree: %w", err)
+	}
+	newHead, err := lineage.HeadSHAAt(ctx, path)
+	if err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("resolve re-created worktree head: %w", err)
+	}
+	return worktreeLineageResult{Recut: true, BaseHead: baseHead, OldHead: oldHead, NewHead: newHead}, nil
+}
+
+func reuseExistingBranchWorktree(ctx context.Context, manager WorktreeManager, existing ExistingBranchWorktreeManager, branch, path, base string) (worktreeLineageResult, error) {
+	lineage, err := writableWorktreeLineageManager(manager)
+	if err != nil {
+		return worktreeLineageResult{}, err
+	}
+	baseHead, err := fetchAndResolveLineageBase(ctx, lineage, base)
+	if err != nil {
+		return worktreeLineageResult{}, err
+	}
+	pathExists := false
+	if _, statErr := os.Stat(path); statErr == nil {
+		pathExists = true
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return worktreeLineageResult{}, fmt.Errorf("inspect existing worktree path: %w", statErr)
+	}
+	var oldHead string
+	if pathExists {
+		oldHead, err = lineage.HeadSHAAt(ctx, path)
+	} else {
+		oldHead, err = lineage.RevParse(ctx, branch)
+	}
+	if err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("resolve existing worktree branch head: %w", err)
+	}
+	isAncestor, err := lineage.IsAncestor(ctx, baseHead, oldHead)
+	if err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("verify existing worktree branch lineage: %w", err)
+	}
+	if isAncestor {
+		if pathExists {
+			return worktreeLineageResult{BaseHead: baseHead, OldHead: oldHead, NewHead: oldHead}, nil
+		}
+		return worktreeLineageResult{}, existing.AddExistingBranchWorktree(ctx, branch, path)
+	}
+	if pathExists {
+		clean, err := lineage.WorktreeCleanAt(ctx, path)
+		if err != nil {
+			return worktreeLineageResult{}, fmt.Errorf("inspect stale worktree for uncommitted changes: %w", err)
+		}
+		if !clean {
+			return worktreeLineageResult{DirtyBlocked: true, BaseHead: baseHead, OldHead: oldHead}, nil
+		}
+		if err := lineage.RemoveWorktree(ctx, path); err != nil {
+			return worktreeLineageResult{}, fmt.Errorf("remove stale worktree: %w", err)
+		}
+	}
+	if err := lineage.DeleteBranch(ctx, branch); err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("delete stale worktree branch: %w", err)
+	}
+	if err := manager.AddWorktree(ctx, branch, path, baseHead); err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("re-create stale worktree branch: %w", err)
+	}
+	newHead, err := lineage.HeadSHAAt(ctx, path)
+	if err != nil {
+		return worktreeLineageResult{}, fmt.Errorf("resolve re-created worktree head: %w", err)
+	}
+	return worktreeLineageResult{Recut: true, BaseHead: baseHead, OldHead: oldHead, NewHead: newHead}, nil
+}
+
+func writableWorktreeLineageManager(manager WorktreeManager) (WritableWorktreeLineageManager, error) {
+	lineage, ok := manager.(WritableWorktreeLineageManager)
+	if !ok {
+		return nil, errors.New("writable worktree lineage manager is required")
+	}
+	return lineage, nil
+}
+
+func fetchAndResolveLineageBase(ctx context.Context, manager WritableWorktreeLineageManager, base string) (string, error) {
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "HEAD"
+	}
+	// HEAD and full object IDs already identify the prepared checkout's exact
+	// local commit; fetching cannot change what either resolves to and would make
+	// local-only repositories fail a purely local retry. Mutable base refs still
+	// refresh origin before resolution.
+	if base != "HEAD" && !isFullGitObjectID(base) {
+		if err := manager.FetchRemote(ctx, "origin"); err != nil {
+			return "", fmt.Errorf("fetch origin before worktree lineage check: %w", err)
+		}
+	}
+	head, err := manager.RevParse(ctx, base)
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree lineage base %q: %w", base, err)
+	}
+	return head, nil
+}
+
+func isFullGitObjectID(ref string) bool {
+	if len(ref) != 40 && len(ref) != 64 {
+		return false
+	}
+	for _, char := range ref {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') && (char < 'A' || char > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func addTaskWorktreeLineageEvent(ctx context.Context, store *db.Store, taskID, kind, reason string) error {
+	return store.AddTaskEvent(ctx, db.TaskEvent{
+		TaskID: taskID,
+		Kind:   kind,
+		Reason: reason,
+	})
+}
+
+func blockTaskForDirtyWorktree(ctx context.Context, store *db.Store, task db.Task, request TaskWorktreeRequest, path, reason string) error {
+	fromState := task.State
+	task.State = string(TaskBlocked)
+	task.Branch = request.Branch
+	task.WorktreePath = path
+	if task.RepoFullName == "" {
+		task.RepoFullName = request.Repo
+	}
+	if task.GoalID == "" {
+		task.GoalID = request.GoalID
+	}
+	if task.Title == "" {
+		task.Title = request.TaskTitle
+	}
+	if err := store.UpsertTask(ctx, task); err != nil {
+		return err
+	}
+	if err := store.AddTaskEvent(ctx, db.TaskEvent{
+		TaskID:    task.ID,
+		Kind:      "stale_worktree_dirty_blocked",
+		FromState: fromState,
+		ToState:   string(TaskBlocked),
+		Reason:    reason,
+	}); err != nil {
+		return err
+	}
+	return BlockedError{Reason: reason}
 }
 
 func TaskWorktreePath(home string, repo string, taskID string) (string, error) {

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
 )
 
 func TestTaskWorktreePath(t *testing.T) {
@@ -380,7 +383,11 @@ func TestEngineAllocateTaskWorktreeReusesExistingTaskWorktree(t *testing.T) {
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-1", Owner: "lead"}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
-	manager := &fakeWorktreeManager{}
+	manager := &fakeWorktreeManager{
+		pathHeads: map[string]string{path: "agent-head"},
+		revHeads:  map[string]string{"HEAD": "base-head"},
+		ancestor:  true,
+	}
 
 	task, err := engine.AllocateTaskWorktree(ctx, TaskWorktreeRequest{
 		Home:     home,
@@ -399,6 +406,86 @@ func TestEngineAllocateTaskWorktreeReusesExistingTaskWorktree(t *testing.T) {
 	}
 	if len(manager.calls) != 0 {
 		t.Fatalf("AddWorktree ran despite existing task worktree: %+v", manager.calls)
+	}
+	if len(manager.removed) != 0 || len(manager.deletedBranches) != 0 || len(manager.cleanCalls) != 0 {
+		t.Fatalf("fresh worktree was mutated or dirty-checked: removed=%v deleted=%v clean_checks=%v", manager.removed, manager.deletedBranches, manager.cleanCalls)
+	}
+	if len(manager.ancestorCalls) != 1 || manager.ancestorCalls[0] != [2]string{"base-head", "agent-head"} {
+		t.Fatalf("ancestor calls = %v, want base-head -> agent-head", manager.ancestorCalls)
+	}
+}
+
+func TestEngineAllocateTaskWorktreeRecutsCleanOffLineageWorktree(t *testing.T) {
+	ctx, store, engine, manager, request, path, oldHead, baseHead := setupOffLineageTaskWorktree(t, false)
+
+	task, err := engine.AllocateTaskWorktree(ctx, request, manager)
+	if err != nil {
+		t.Fatalf("AllocateTaskWorktree: %v", err)
+	}
+	if task.WorktreePath != path {
+		t.Fatalf("task worktree = %q, want %q", task.WorktreePath, path)
+	}
+	newHead, err := (gitutil.Client{Dir: path}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA re-cut worktree: %v", err)
+	}
+	if newHead != baseHead || newHead == oldHead {
+		t.Fatalf("re-cut head = %s, want base %s and not old %s", newHead, baseHead, oldHead)
+	}
+	events, err := store.ListTaskEvents(ctx, request.TaskID)
+	if err != nil {
+		t.Fatalf("ListTaskEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "stale_worktree_recut" ||
+		!strings.Contains(events[0].Reason, "old_head="+oldHead) ||
+		!strings.Contains(events[0].Reason, "new_head="+newHead) {
+		t.Fatalf("task events = %+v", events)
+	}
+}
+
+func TestEngineAllocateTaskWorktreeBlocksDirtyOffLineageWorktree(t *testing.T) {
+	ctx, store, engine, manager, request, path, oldHead, baseHead := setupOffLineageTaskWorktree(t, true)
+
+	_, err := engine.AllocateTaskWorktree(ctx, request, manager)
+	var blocked BlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("AllocateTaskWorktree error = %v, want BlockedError", err)
+	}
+	for _, want := range []string{path, oldHead, baseHead, "uncommitted changes", "manually salvage"} {
+		if !strings.Contains(blocked.Reason, want) {
+			t.Fatalf("blocked reason %q missing %q", blocked.Reason, want)
+		}
+	}
+	headAfter, err := (gitutil.Client{Dir: path}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA preserved worktree: %v", err)
+	}
+	if headAfter != oldHead {
+		t.Fatalf("dirty worktree head = %s, want preserved %s", headAfter, oldHead)
+	}
+	dirtyPath := filepath.Join(path, "salvage.txt")
+	content, err := os.ReadFile(dirtyPath)
+	if err != nil {
+		t.Fatalf("read preserved dirty file: %v", err)
+	}
+	if string(content) != "salvage me\n" {
+		t.Fatalf("preserved dirty content = %q", content)
+	}
+	task, err := store.GetTask(ctx, request.TaskID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if task.State != string(TaskBlocked) || task.WorktreePath != path {
+		t.Fatalf("blocked task = %+v, want blocked with preserved worktree", task)
+	}
+	events, err := store.ListTaskEvents(ctx, request.TaskID)
+	if err != nil {
+		t.Fatalf("ListTaskEvents: %v", err)
+	}
+	if len(events) != 1 || events[0].Kind != "stale_worktree_dirty_blocked" ||
+		events[0].ToState != string(TaskBlocked) ||
+		!strings.Contains(events[0].Reason, "uncommitted changes") {
+		t.Fatalf("task events = %+v", events)
 	}
 }
 
@@ -694,6 +781,81 @@ func TestAllocateDelegationWorktreeReusesExistingBranch(t *testing.T) {
 	}
 }
 
+func TestAllocateDelegationWorktreeExistingBranchLineageOutcomes(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		clean     bool
+		wantBlock bool
+		wantEvent string
+	}{
+		{name: "clean stale worktree is re-cut", clean: true, wantEvent: "stale_worktree_recut"},
+		{name: "dirty stale worktree is preserved and blocked", clean: false, wantBlock: true, wantEvent: "stale_worktree_dirty_blocked"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			engine := testEngine(store)
+			home := t.TempDir()
+			branch := delegationBranchName(Delegation{ID: "d1"}, "job-1", "d1", 0)
+			path, err := DelegationWorktreePath(home, "owner/repo", "job-1", "d1", 0)
+			if err != nil {
+				t.Fatalf("DelegationWorktreePath: %v", err)
+			}
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				t.Fatalf("MkdirAll delegation worktree: %v", err)
+			}
+			manager := &fakeWorktreeManager{
+				existingBranches: map[string]bool{branch: true},
+				pathHeads:        map[string]string{path: "stale-head"},
+				revHeads:         map[string]string{"parent": "parent-head"},
+				ancestor:         false,
+				ancestorSet:      true,
+				clean:            tc.clean,
+				cleanSet:         true,
+			}
+
+			result, err := engine.AllocateDelegationWorktree(ctx, DelegationWorktreeRequest{
+				Home:         home,
+				Repo:         "owner/repo",
+				ParentJobID:  "job-1",
+				DelegationID: "d1",
+				BaseBranch:   "parent",
+				Owner:        "helper",
+				Checkout:     t.TempDir(),
+			}, manager)
+			var blocked BlockedError
+			if tc.wantBlock {
+				if !errors.As(err, &blocked) {
+					t.Fatalf("AllocateDelegationWorktree error = %v, want BlockedError", err)
+				}
+				if len(manager.removed) != 0 || len(manager.deletedBranches) != 0 || len(manager.calls) != 0 {
+					t.Fatalf("dirty delegation worktree was mutated: removed=%v deleted=%v add=%v", manager.removed, manager.deletedBranches, manager.calls)
+				}
+				if !strings.Contains(blocked.Reason, "uncommitted changes") {
+					t.Fatalf("blocked reason = %q", blocked.Reason)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("AllocateDelegationWorktree: %v", err)
+				}
+				if result.Path != path {
+					t.Fatalf("result path = %q, want %q", result.Path, path)
+				}
+				if len(manager.removed) != 1 || len(manager.deletedBranches) != 1 || len(manager.calls) != 1 {
+					t.Fatalf("clean delegation recut calls: removed=%v deleted=%v add=%v", manager.removed, manager.deletedBranches, manager.calls)
+				}
+			}
+			events, err := store.ListJobEvents(ctx, "job-1")
+			if err != nil {
+				t.Fatalf("ListJobEvents: %v", err)
+			}
+			if len(events) != 1 || events[0].Kind != tc.wantEvent {
+				t.Fatalf("job events = %+v, want kind %q", events, tc.wantEvent)
+			}
+		})
+	}
+}
+
 func TestAllocateDelegationWorktreeReleasesBranchLockOnFailure(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -717,13 +879,113 @@ func TestAllocateDelegationWorktreeReleasesBranchLockOnFailure(t *testing.T) {
 	}
 }
 
+func setupOffLineageTaskWorktree(t *testing.T, dirty bool) (context.Context, *db.Store, Engine, gitutil.Client, TaskWorktreeRequest, string, string, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	ctx := context.Background()
+	root := t.TempDir()
+	remote := filepath.Join(root, "origin.git")
+	checkout := filepath.Join(root, "checkout")
+	if err := os.MkdirAll(checkout, 0o755); err != nil {
+		t.Fatalf("MkdirAll checkout: %v", err)
+	}
+	runWorktreeGit(t, root, "init", "--bare", remote)
+	runWorktreeGit(t, checkout, "init", "-b", "main")
+	runWorktreeGit(t, checkout, "config", "user.email", "gitmoot@example.com")
+	runWorktreeGit(t, checkout, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(checkout, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile base: %v", err)
+	}
+	runWorktreeGit(t, checkout, "add", "base.txt")
+	runWorktreeGit(t, checkout, "commit", "-m", "base")
+	runWorktreeGit(t, checkout, "remote", "add", "origin", remote)
+	runWorktreeGit(t, checkout, "push", "-u", "origin", "main")
+
+	home := filepath.Join(root, "home")
+	path, err := TaskWorktreePath(home, "owner/repo", "task-1")
+	if err != nil {
+		t.Fatalf("TaskWorktreePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll worktree parent: %v", err)
+	}
+	runWorktreeGit(t, checkout, "worktree", "add", "-b", "task-1", path, "HEAD")
+	if err := os.WriteFile(filepath.Join(path, "stale.txt"), []byte("committed stale work\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile stale: %v", err)
+	}
+	runWorktreeGit(t, path, "add", "stale.txt")
+	runWorktreeGit(t, path, "commit", "-m", "stale branch")
+	oldHead, err := (gitutil.Client{Dir: path}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatalf("HeadSHA stale worktree: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(checkout, "current.txt"), []byte("current base\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile current: %v", err)
+	}
+	runWorktreeGit(t, checkout, "add", "current.txt")
+	runWorktreeGit(t, checkout, "commit", "-m", "advance base")
+	runWorktreeGit(t, checkout, "push", "origin", "main")
+	baseHead, err := (gitutil.Client{Dir: checkout}).RevParse(ctx, "origin/main")
+	if err != nil {
+		t.Fatalf("RevParse origin/main: %v", err)
+	}
+	if dirty {
+		if err := os.WriteFile(filepath.Join(path, "salvage.txt"), []byte("salvage me\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile salvage: %v", err)
+		}
+	}
+
+	store := openEngineStore(t)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-1",
+		RepoFullName: "owner/repo",
+		State:        string(TaskImplementing),
+		Branch:       "task-1",
+		WorktreePath: path,
+	}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	request := TaskWorktreeRequest{
+		Home:       home,
+		Repo:       "owner/repo",
+		TaskID:     "task-1",
+		Branch:     "task-1",
+		BaseBranch: "origin/main",
+		Owner:      "lead",
+		Checkout:   checkout,
+	}
+	return ctx, store, testEngine(store), gitutil.Client{Dir: checkout}, request, path, oldHead, baseHead
+}
+
+func runWorktreeGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, output)
+	}
+}
+
 type fakeWorktreeManager struct {
 	err              error
 	onAdd            func()
 	existingBranches map[string]bool
+	fetchedRemotes   []string
+	pathHeads        map[string]string
+	revHeads         map[string]string
+	ancestor         bool
+	ancestorSet      bool
+	clean            bool
+	cleanSet         bool
+	cleanCalls       []string
+	ancestorCalls    [][2]string
 	calls            []worktreeCall
 	existingCalls    []worktreeCall
 	detachedCalls    []worktreeCall // AddDetachedWorktree: path in .path, ref in .base
+	removed          []string       // RemoveWorktree paths
 	removedForce     []string       // RemoveWorktreeForce paths
 	removeErr        error
 	deletedBranches  []string // DeleteBranch branches
@@ -751,6 +1013,9 @@ func (f *fakeWorktreeManager) AddWorktree(_ context.Context, branch string, path
 		f.onAdd()
 	}
 	f.calls = append(f.calls, worktreeCall{branch: branch, path: path, base: base})
+	if f.pathHeads != nil {
+		f.pathHeads[path] = base
+	}
 	return f.err
 }
 
@@ -764,6 +1029,41 @@ func (f *fakeWorktreeManager) AddExistingBranchWorktree(_ context.Context, branc
 
 func (f *fakeWorktreeManager) BranchExists(_ context.Context, branch string) (bool, error) {
 	return f.existingBranches[branch], nil
+}
+
+func (f *fakeWorktreeManager) FetchRemote(_ context.Context, remote string) error {
+	f.fetchedRemotes = append(f.fetchedRemotes, remote)
+	return nil
+}
+
+func (f *fakeWorktreeManager) HeadSHAAt(_ context.Context, path string) (string, error) {
+	if head := f.pathHeads[path]; head != "" {
+		return head, nil
+	}
+	return "existing-head", nil
+}
+
+func (f *fakeWorktreeManager) RevParse(_ context.Context, rev string) (string, error) {
+	if head := f.revHeads[rev]; head != "" {
+		return head, nil
+	}
+	return rev + "-head", nil
+}
+
+func (f *fakeWorktreeManager) IsAncestor(_ context.Context, ancestor, descendant string) (bool, error) {
+	f.ancestorCalls = append(f.ancestorCalls, [2]string{ancestor, descendant})
+	if f.ancestorSet {
+		return f.ancestor, nil
+	}
+	return true, nil
+}
+
+func (f *fakeWorktreeManager) WorktreeCleanAt(_ context.Context, path string) (bool, error) {
+	f.cleanCalls = append(f.cleanCalls, path)
+	if f.cleanSet {
+		return f.clean, nil
+	}
+	return true, nil
 }
 
 func (f *fakeWorktreeManager) AddDetachedWorktree(_ context.Context, path string, ref string) error {
@@ -786,6 +1086,11 @@ func (f *fakeWorktreeManager) CommitWorktree(_ context.Context, dir string, _ st
 
 func (f *fakeWorktreeManager) RemoveWorktreeForce(_ context.Context, path string) error {
 	f.removedForce = append(f.removedForce, path)
+	return f.removeErr
+}
+
+func (f *fakeWorktreeManager) RemoveWorktree(_ context.Context, path string) error {
+	f.removed = append(f.removed, path)
 	return f.removeErr
 }
 


### PR DESCRIPTION
## What

Fixes #1112: dispatch could route an implement seat to a writable worktree that was not lineage-correct — the seat's task worktree could be stale/off-lineage relative to the resolved base, with nothing checking this at allocation time. Failure was silent until a seat burned a turn discovering the target file/symbol lived in a different tree.

## Design

- New `internal/git.Client.IsAncestor(ctx, ancestor, descendant)` — `git merge-base --is-ancestor`, exit 1 treated as a normal "false" result, any other error fails closed.
- `internal/workflow/worktree.go`: at the two places a worktree can be silently reused (`AllocateTaskWorktree`'s existing-worktree early return, and `addTaskWorktree`'s existing-branch reuse path used by both task and delegation allocation), the resolved base is fetched/resolved and asserted to be an ancestor of the existing worktree's HEAD before reuse:
  - **Ancestor holds (fresh, or has legitimate additional commits on top of a valid base):** reused as before, no mutation.
  - **Ancestor fails and the worktree is clean:** re-cut — remove and recreate from the current resolved base — so the seat starts on a lineage-correct tree. A durable event (`stale_worktree_recut`, task or job event depending on call-site scope) records the old/new HEAD.
  - **Ancestor fails and the worktree has uncommitted changes:** **not** re-cut. This preserves a partial/interrupted run's salvageable work rather than destroying it — the same "preserve dirty worktrees for salvage" doctrine `cleanupImplementDelegationWorktree` already applies to cleanup is now applied to allocation-time reuse too. The task is set to `blocked` with an actionable message (worktree path, stale HEAD, resolved base) and a `stale_worktree_dirty_blocked` event, so an operator can inspect/salvage/clean it and retry rather than silently losing work.
- Reuse of an already-fresh worktree fetches origin (for a mutable base ref) but performs no further git mutation — the existing idempotent no-op contract for a same-branch/same-path retry is preserved.

## Jarvis's ask #2 addressed by design, not new code

Ask #2 was "the writable worktree must be the lineage-correct one — never allocate a correct tree read-only while a stale one is writable." This fix does not add a second, read-only root to reconcile against the writable one, because gitmoot's dispatch machinery doesn't wire one up in the first place: exactly one checkout path is threaded to the runtime as writable (`internal/runtime/adapter.go`), and Codex's `workspace-write` sandbox restricts *writes* to that path but does not restrict *reads* at all — so the "correct tree was visible but unwritable" experience in the original incident came from Codex's own read-anywhere sandbox exposing whatever else happened to be on disk, not from gitmoot granting read access to a second tree. Once the writable tree itself is guaranteed lineage-correct (asks #1/#3), there is no separate read-only-vs-writable reconciliation left to do. Flagging this explicitly so a reviewer can check the reasoning rather than it being silently assumed.

## Explicitly out of scope (left for follow-up issues, not silently absorbed)

- Standardizing base-resolution rigor across the three callers that feed these shared primitives (`agent run --action implement` already fetches+guards; `gitmoot task run` passes a raw `--base` with no guard; delegation legs use the parent's own branch) — real, separate hardening.
- The disk-hygiene / aged-worktree TTL reaper — being split into its own issue per the original scoping call.
- The ask-action ephemeral read-only delegation-worktree path (`AllocateReadOnlyWorktree`/`cleanupReadOnlyDelegationWorktree`) — traced to an unrelated occurrence (worktree torn down synchronously on job completion before output retrieval) with a different mechanism; not touched here.
- A related liveness gap this investigation surfaced (a daemon restart mid-implement-job can fail the job via checkout-contention retries even while a live process is still legitimately writing in the worktree, because that path doesn't consult liveness the way `cleanupImplementDelegationWorktree` already does) — filed separately, not folded into this PR.

## Live corroborating evidence

Every one of the three implementation rounds on this PR (round 1 → e253d24, round 2 → 7536f78, round 3 → 9c349ef) was itself interrupted mid-work by a production daemon deploy/restart, and each time the resume attempt hit `checkout_contention: ... has uncommitted changes` on its own task worktree, exhausted its auto-retries, and the job was marked `failed` — while the actual implementation work sitting in that worktree was completely intact. That is a live, real-world reproduction of exactly the class of bug this PR fixes (dispatch/resume machinery misjudging a worktree it should have handed off cleanly), occurring three separate times on the very fix for it, independent of and stronger than any constructed test scenario. Each time, the interrupted worktree was inspected for a live owning process before being touched, verified for completeness against the design, and salvaged by committing/pushing directly from the worktree as coordinator rather than losing the work — see the `#1112 dispatch worktree/checkout allocation correctness` workflow journal for the full per-round trace. This is also corroborating evidence for the separately-filed liveness-gap issue below (the checkout-contention path doesn't consult live-process liveness the way `cleanupImplementDelegationWorktree` already does).

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./internal/workflow/... ./internal/git/...` passes, including new coverage: a stale-but-clean worktree is re-cut with the correct new HEAD and a recorded event; a stale-and-dirty worktree is left untouched (HEAD unchanged, on-disk file content read back and verified intact) and blocks with the correct event; an already-ancestor worktree is neither re-cut nor treated as dirty; equivalent coverage for `AllocateDelegationWorktree`'s existing-branch reuse path.
- The full local gate (including the scoped `-race` run across `internal/workflow`, `internal/cli`, `internal/db`, `internal/daemon`, `internal/pipeline`) was run as part of the original implementation session; that session was interrupted mid-gate by an unrelated production daemon deploy/restart (collateral, not a defect in this change — see #1112 workflow journal for the full trace). The change was salvaged via `gitmoot task recover` from the completed, uncommitted worktree rather than re-implemented from scratch, and re-verified independently before this PR was opened: clean build/vet, and the two directly-affected packages' full test suites passing in a fresh run.

