### PR TITLE
feat(jobs): surface a worktree-process badge on terminal jobs (#1132)

### DIFF
--- a/internal/cli/job.go
+++ b/internal/cli/job.go
@@ -86,7 +86,7 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 	repo := fs.String("repo", "", "repo scope as owner/repo")
 	state := fs.String("state", "", "job state filter")
 	workflowID := fs.String("workflow", "", "external-coordinator workflow label")
-	jsonOutput := fs.Bool("json", false, "print jobs (with why-stuck detail) as JSON")
+	jsonOutput := fs.Bool("json", false, "print jobs (with operational detail) as JSON")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
@@ -143,6 +143,7 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 			payload, _ := jobListPayload(job)
 			ev, ok := reasonEvents[job.ID]
 			reason := deriveStuckReason(job, ev, ok, locks)
+			processActive := deriveWorktreeProcessActive(job, jobWorktreeLiveness)
 			entries = append(entries, jobListEntry{
 				ID:              job.ID,
 				State:           job.State,
@@ -155,6 +156,7 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 				WhyStuck:        reason.Reason,
 				NextRetryAt:     reason.NextRetryAt,
 				SuggestedAction: reason.SuggestedAction,
+				ProcessActive:   processActive,
 			})
 		}
 		if err := writeJSON(stdout, entries); err != nil {
@@ -182,6 +184,9 @@ func runJobList(args []string, stdout, stderr io.Writer) int {
 				fmt.Fprintf(stdout, " [action: %s]", reason.SuggestedAction)
 			}
 		}
+		if deriveWorktreeProcessActive(job, jobWorktreeLiveness) {
+			fmt.Fprint(stdout, "\tLIVE PROCESS: worktree still has an active process")
+		}
 		fmt.Fprintln(stdout)
 	}
 	return 0
@@ -198,8 +203,8 @@ func flagWasSupplied(fs *flag.FlagSet, name string) bool {
 }
 
 // jobListEntry is the JSON shape for `job list --json`: the existing table
-// columns plus the additive why-stuck fields (#552). The stuck fields are omitted
-// when empty so a healthy job's JSON is not bloated.
+// columns plus additive operational fields (#552, #1132). Zero-value detail is
+// omitted so a healthy job's JSON is not bloated.
 type jobListEntry struct {
 	ID              string `json:"id"`
 	State           string `json:"state"`
@@ -212,13 +217,14 @@ type jobListEntry struct {
 	WhyStuck        string `json:"why_stuck,omitempty"`
 	NextRetryAt     string `json:"next_retry_at,omitempty"`
 	SuggestedAction string `json:"suggested_action,omitempty"`
+	ProcessActive   bool   `json:"process_active,omitempty"`
 }
 
 func runJobShow(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("job show", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	jsonOutput := fs.Bool("json", false, "print the job (with why-stuck detail) as JSON")
+	jsonOutput := fs.Bool("json", false, "print the job (with operational detail) as JSON")
 	jobID, ok := parseSingleJobID(fs, args, stderr, "job show")
 	if !ok {
 		return parseSingleJobIDExitCode(args)
@@ -245,27 +251,36 @@ func runJobShow(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "job show: %v\n", err)
 		return 1
 	}
+	processActive := deriveWorktreeProcessActive(job, jobWorktreeLiveness)
 	if *jsonOutput {
-		out := jobShowOutput{Job: job, Payload: payload, WhyStuck: reason.Reason, NextRetryAt: reason.NextRetryAt, SuggestedAction: reason.SuggestedAction}
+		out := jobShowOutput{
+			Job:             job,
+			Payload:         payload,
+			WhyStuck:        reason.Reason,
+			NextRetryAt:     reason.NextRetryAt,
+			SuggestedAction: reason.SuggestedAction,
+			ProcessActive:   processActive,
+		}
 		if err := writeJSON(stdout, out); err != nil {
 			fmt.Fprintf(stderr, "job show: %v\n", err)
 			return 1
 		}
 		return 0
 	}
-	printJob(stdout, job, payload, reason)
+	printJob(stdout, job, payload, reason, processActive)
 	return 0
 }
 
 // jobShowOutput is the JSON shape for `job show --json`: the job, its decoded
-// payload, and the additive why-stuck detail (#552). The stuck fields are omitted
-// when empty so a healthy job's JSON is unchanged in spirit.
+// payload, and additive operational detail (#552, #1132). Zero-value detail is
+// omitted so a healthy job's JSON is unchanged in spirit.
 type jobShowOutput struct {
 	Job             db.Job              `json:"job"`
 	Payload         workflow.JobPayload `json:"payload"`
 	WhyStuck        string              `json:"why_stuck,omitempty"`
 	NextRetryAt     string              `json:"next_retry_at,omitempty"`
 	SuggestedAction string              `json:"suggested_action,omitempty"`
+	ProcessActive   bool                `json:"process_active,omitempty"`
 }
 
 // loadStuckReason derives a queued/blocked job's why-stuck reason from its full
@@ -1206,7 +1221,7 @@ func jobListPayload(job db.Job) (workflow.JobPayload, error) {
 	return daemonJobPayload(job)
 }
 
-func printJob(stdout io.Writer, job db.Job, payload workflow.JobPayload, reason stuckReason) {
+func printJob(stdout io.Writer, job db.Job, payload workflow.JobPayload, reason stuckReason, processActive bool) {
 	fmt.Fprintf(stdout, "id: %s\n", job.ID)
 	fmt.Fprintf(stdout, "state: %s\n", job.State)
 	if !reason.empty() {
@@ -1217,6 +1232,9 @@ func printJob(stdout io.Writer, job db.Job, payload workflow.JobPayload, reason 
 		if reason.SuggestedAction != "" {
 			fmt.Fprintf(stdout, "suggested_action: %s\n", reason.SuggestedAction)
 		}
+	}
+	if processActive {
+		fmt.Fprintln(stdout, "process_active: worktree still has an active process")
 	}
 	fmt.Fprintf(stdout, "type: %s\n", job.Type)
 	fmt.Fprintf(stdout, "agent: %s\n", job.Agent)

--- a/internal/cli/job_process_badge.go
+++ b/internal/cli/job_process_badge.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+type worktreeLivenessProbe func(path string) (live bool, known bool)
+
+var jobWorktreeLiveness worktreeLivenessProbe = workflow.WorktreeLiveness
+
+// deriveWorktreeProcessActive reports the passive process badge for a job.
+// Non-terminal jobs short-circuit before payload decoding or the /proc probe:
+// live worktree activity is expected while a job is still progressing.
+func deriveWorktreeProcessActive(job db.Job, probe worktreeLivenessProbe) bool {
+	if !workflow.IsSettledJobState(job.State) {
+		return false
+	}
+	payload, err := jobListPayload(job)
+	if err != nil {
+		return false
+	}
+	path := strings.TrimSpace(payload.WorktreePath)
+	if path == "" || probe == nil {
+		return false
+	}
+	live, known := probe(path)
+	return known && live
+}

--- a/internal/cli/job_process_badge_test.go
+++ b/internal/cli/job_process_badge_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestDeriveWorktreeProcessActive(t *testing.T) {
+	withWorktree := mustJobPayload(t, workflow.JobPayload{WorktreePath: "/tmp/job-worktree"})
+	tests := []struct {
+		name       string
+		job        db.Job
+		live       bool
+		known      bool
+		want       bool
+		wantProbes int
+	}{
+		{name: "succeeded live", job: db.Job{State: string(workflow.JobSucceeded), Payload: withWorktree}, live: true, known: true, want: true, wantProbes: 1},
+		{name: "failed live", job: db.Job{State: string(workflow.JobFailed), Payload: withWorktree}, live: true, known: true, want: true, wantProbes: 1},
+		{name: "cancelled live", job: db.Job{State: string(workflow.JobCancelled), Payload: withWorktree}, live: true, known: true, want: true, wantProbes: 1},
+		{name: "blocked live", job: db.Job{State: string(workflow.JobBlocked), Payload: withWorktree}, live: true, known: true, want: true, wantProbes: 1},
+		{name: "unknown liveness", job: db.Job{State: string(workflow.JobSucceeded), Payload: withWorktree}, live: false, known: false, wantProbes: 1},
+		{name: "known inactive", job: db.Job{State: string(workflow.JobSucceeded), Payload: withWorktree}, live: false, known: true, wantProbes: 1},
+		{name: "running short circuits", job: db.Job{State: string(workflow.JobRunning), Payload: withWorktree}, live: true, known: true},
+		{name: "queued short circuits", job: db.Job{State: string(workflow.JobQueued), Payload: withWorktree}, live: true, known: true},
+		{name: "no worktree", job: db.Job{State: string(workflow.JobSucceeded), Payload: mustJobPayload(t, workflow.JobPayload{})}},
+		{name: "malformed payload", job: db.Job{State: string(workflow.JobSucceeded), Payload: "{"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			probes := 0
+			got := deriveWorktreeProcessActive(tc.job, func(path string) (bool, bool) {
+				probes++
+				if path != "/tmp/job-worktree" {
+					t.Fatalf("probe path = %q", path)
+				}
+				return tc.live, tc.known
+			})
+			if got != tc.want {
+				t.Fatalf("deriveWorktreeProcessActive = %v, want %v", got, tc.want)
+			}
+			if probes != tc.wantProbes {
+				t.Fatalf("probe calls = %d, want %d", probes, tc.wantProbes)
+			}
+		})
+	}
+}
+
+func TestRunJobListShowSurfaceWorktreeProcessBadge(t *testing.T) {
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+
+	jobs := []struct {
+		id    string
+		state workflow.JobState
+		path  string
+	}{
+		{id: "live-terminal", state: workflow.JobSucceeded, path: "/tmp/live-worktree"},
+		{id: "inactive-terminal", state: workflow.JobFailed, path: "/tmp/inactive-worktree"},
+		{id: "unknown-terminal", state: workflow.JobCancelled, path: "/tmp/unknown-worktree"},
+		{id: "blocked-live", state: workflow.JobBlocked, path: "/tmp/blocked-worktree"},
+		{id: "running-live", state: workflow.JobRunning, path: "/tmp/running-worktree"},
+		{id: "no-worktree", state: workflow.JobFailed},
+	}
+	for _, item := range jobs {
+		seedCLIJob(t, store, db.Job{
+			ID:      item.id,
+			Agent:   "worker",
+			Type:    "ask",
+			State:   string(item.state),
+			Payload: mustJobPayload(t, workflow.JobPayload{Repo: "owner/repo", WorktreePath: item.path}),
+		}, string(item.state))
+	}
+
+	probes := map[string]int{}
+	previous := jobWorktreeLiveness
+	jobWorktreeLiveness = func(path string) (bool, bool) {
+		probes[path]++
+		switch path {
+		case "/tmp/live-worktree", "/tmp/blocked-worktree":
+			return true, true
+		case "/tmp/inactive-worktree":
+			return false, true
+		case "/tmp/unknown-worktree":
+			return false, false
+		case "/tmp/running-worktree":
+			t.Fatalf("running job unexpectedly invoked liveness probe")
+			return true, true
+		default:
+			t.Fatalf("unexpected liveness probe path %q", path)
+			return false, false
+		}
+	}
+	t.Cleanup(func() { jobWorktreeLiveness = previous })
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"job", "list", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job list --json exit = %d, stderr=%s", code, stderr.String())
+	}
+	var entries []jobListEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatalf("decode job list --json: %v\n%s", err, stdout.String())
+	}
+	var rawEntries []map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &rawEntries); err != nil {
+		t.Fatalf("decode raw job list --json: %v", err)
+	}
+	for i, entry := range entries {
+		_, fieldPresent := rawEntries[i]["process_active"]
+		want := entry.ID == "live-terminal" || entry.ID == "blocked-live"
+		if entry.ProcessActive != want || fieldPresent != want {
+			t.Fatalf("entry %s process_active = %v, present=%v, want %v", entry.ID, entry.ProcessActive, fieldPresent, want)
+		}
+	}
+	if probes["/tmp/running-worktree"] != 0 {
+		t.Fatalf("running worktree probe calls = %d", probes["/tmp/running-worktree"])
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "list", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("job list exit = %d, stderr=%s", code, stderr.String())
+	}
+	lines := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		id, _, _ := strings.Cut(line, "\t")
+		lines[id] = line
+	}
+	for _, id := range []string{"live-terminal", "blocked-live"} {
+		if !strings.Contains(lines[id], "LIVE PROCESS: worktree still has an active process") {
+			t.Fatalf("%s line missing live-process badge: %q", id, lines[id])
+		}
+	}
+	if got := lines["inactive-terminal"]; got != "inactive-terminal\tfailed\task\tworker\towner/repo\t#0" {
+		t.Fatalf("healthy terminal line changed: %q", got)
+	}
+	for _, id := range []string{"unknown-terminal", "running-live", "no-worktree"} {
+		if strings.Contains(lines[id], "LIVE PROCESS:") {
+			t.Fatalf("%s line unexpectedly has live-process badge: %q", id, lines[id])
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "show", "live-terminal", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("live job show --json exit = %d, stderr=%s", code, stderr.String())
+	}
+	var shown jobShowOutput
+	if err := json.Unmarshal(stdout.Bytes(), &shown); err != nil {
+		t.Fatalf("decode live job show --json: %v\n%s", err, stdout.String())
+	}
+	if !shown.ProcessActive || !strings.Contains(stdout.String(), `"process_active": true`) {
+		t.Fatalf("live job show missing process_active: %+v\n%s", shown, stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "show", "inactive-terminal", "--home", home, "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("inactive job show --json exit = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "process_active") {
+		t.Fatalf("inactive job show must omit process_active:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"job", "show", "live-terminal", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("live job show exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "process_active: worktree still has an active process") {
+		t.Fatalf("live job show missing process_active line:\n%s", stdout.String())
+	}
+}

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -956,7 +956,7 @@ func TestPrintJobRendersFailureDiagnosticsBlock(t *testing.T) {
 		},
 	}
 
-	printJob(&buf, db.Job{ID: "job-x", State: "failed", Type: "review", Agent: "audit"}, payload, stuckReason{})
+	printJob(&buf, db.Job{ID: "job-x", State: "failed", Type: "review", Agent: "audit"}, payload, stuckReason{}, false)
 
 	out := buf.String()
 	for _, want := range []string{
@@ -977,7 +977,7 @@ func TestPrintJobRendersFailureDiagnosticsBlock(t *testing.T) {
 func TestPrintJobOmitsFailureDiagnosticsWhenAbsent(t *testing.T) {
 	var buf bytes.Buffer
 
-	printJob(&buf, db.Job{ID: "job-y", State: "succeeded", Type: "review", Agent: "audit"}, workflow.JobPayload{Repo: "owner/repo"}, stuckReason{})
+	printJob(&buf, db.Job{ID: "job-y", State: "succeeded", Type: "review", Agent: "audit"}, workflow.JobPayload{Repo: "owner/repo"}, stuckReason{}, false)
 
 	if strings.Contains(buf.String(), "failure_diagnostics:") {
 		t.Fatalf("job show output has a failure diagnostics block for a healthy job:\n%s", buf.String())

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1528,7 +1528,7 @@ PR-comment-only).
 
 ```sh
 gitmoot job list --repo owner/repo   # add --json for machine-readable rows
-gitmoot job show <job-id>            # add --json for the full job + why-stuck detail
+gitmoot job show <job-id>            # add --json for the full job + operational detail
 gitmoot job watch <job-id>
 gitmoot job watch <job-id> --transcript [--log-path <path>] [--runtime codex|claude|kimi|kimi-cli|shell]
 gitmoot job transcript <job-id> --export md|jsonl [--output <path>] [--log-path <path>] [--runtime codex|claude|kimi|kimi-cli|shell]
@@ -1731,6 +1731,14 @@ deferral usually needs a human (a dirty or wrong-head checkout), the row/`job
 show` also carries a `suggested_action` naming the concrete fix. `gitmoot doctor`
 proactively validates `gh auth` (with an actionable remediation hint) and the
 Claude runtime token so a bad credential is caught before a job stalls on it.
+
+For a terminal (`succeeded`, `failed`, `blocked`, or `cancelled`) job whose
+recorded worktree still has a locally observable process, `job list` reports
+`LIVE PROCESS: worktree still has an active process` and `job show` prints the
+same detail as `process_active: worktree still has an active process`; their
+JSON forms carry `process_active: true`. The badge is omitted when no live
+process is observed, when local process liveness is unavailable, or while the
+job is still non-terminal.
 
 Operational blockers auto-retry (#532): a delivery failure classified as an
 operational blocker — `runtime_auth`, `runtime_quota`, `network_outage`

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1358,7 +1358,7 @@ the [PR comment workflow](../workflows/pr-comment-workflow.md).
 
 ```sh
 gitmoot job list --repo owner/repo   # add --json for machine-readable rows
-gitmoot job show <job-id>            # add --json for the full job + why-stuck detail
+gitmoot job show <job-id>            # add --json for the full job + operational detail
 gitmoot job watch <job-id>
 gitmoot job watch <job-id> --transcript [--log-path <path>] [--runtime codex|claude|kimi|kimi-cli|shell]
 gitmoot job transcript <job-id> --export md|jsonl [--output <path>] [--log-path <path>] [--runtime codex|claude|kimi|kimi-cli|shell]
@@ -1502,6 +1502,14 @@ human`, `auth failing: …`, `throttled: …`, or `retrying: …` (#552). The re
 is derived from the most authoritative existing signal (the latest
 reason-bearing `job events` entry plus the owning resource lock's lease); a
 healthy job's output is unchanged.
+
+For a terminal (`succeeded`, `failed`, `blocked`, or `cancelled`) job whose
+recorded worktree still has a locally observable process, `job list` reports
+`LIVE PROCESS: worktree still has an active process` and `job show` prints the
+same detail as `process_active: worktree still has an active process`; their
+JSON forms carry `process_active: true`. The badge is omitted when no live
+process is observed, when local process liveness is unavailable, or while the
+job is still non-terminal.
 
 Operational blockers auto-retry (#532): a delivery failure classified as
 `runtime_auth` or `runtime_quota` does **not** fail the job terminally — the


### PR DESCRIPTION
## What

Partial fix for https://github.com/gitmoot/gitmoot/issues/1132 — **"direction
2"** only (real work outliving a terminal job row). A terminal job
(succeeded/failed/blocked/cancelled) whose worktree still has a locally
observable live process was completely silent — the engine already has this
signal (`workflow.WorktreeLiveness`, a best-effort `/proc/<pid>/cwd` scan)
but only ever used it as a dismissal/cleanup **guard**
(`internal/cli/workflow.go`, `internal/workflow/worktree.go`), never
surfaced it passively on `job list`/`job show`.

**"Direction 1"** of #1132 (bare pane-driven coordinator work that creates no
job row at all — a materially bigger, still-undecided question, overlapping
with #1127) is explicitly **not** attempted in this PR. Full writeup on the
issue: https://github.com/gitmoot/gitmoot/issues/1132#issuecomment-5085104748

## Fix

`deriveWorktreeProcessActive` (`internal/cli/job_process_badge.go`), mirroring
`internal/cli/job_stuck.go`'s existing `stuckReason` pattern (#552) closely:

- Short-circuits to "no badge" for any **non-terminal** job before even
  decoding the payload or touching `/proc` — a running job legitimately
  having worktree activity is expected, not worth flagging, and this avoids
  an unnecessary scan on the hot `job list` path.
- For a terminal job with a worktree path, calls `WorktreeLiveness` directly
  (not the collapsed `WorktreeHasLiveProcess` wrapper) so **"liveness
  unknown"** (e.g. no readable `/proc`, as on darwin) is correctly treated as
  **"omit the badge"**, not as "confirmed healthy."
- Wired as an additive `omitempty` `process_active` field on `job list
  --json`, `job show --json`, and both plain-text renderers — byte-identical
  output for every job that isn't a terminal job with a confirmed live
  process.

Deliberately does **not** touch `gitmoot-dashboard` (a separately pinned Go
module — `go.mod` pins `github.com/gitmoot/gitmoot-dashboard`) or
`internal/cli/dashboard_web.go`. Surfacing this on the web dashboard needs its
own cross-repo PR + pin bump and is a deliberate follow-up, not bundled here.

## Review

One fresh-context adversarial pass (sol/codex, isolated clone, no prior
context): `decision: approved`, zero findings. Independently confirmed: the
non-terminal short-circuit happens before the probe is ever called (not just
after), the unknown-vs-confirmed-false distinction holds in both the unit
test and the CLI integration test (verified via raw JSON field presence, not
just the typed struct), and every non-matching case (no worktree, non-terminal,
unknown liveness) produces byte-identical output to before this change.

Full `db`/`cli`/`workflow` suites green. `go generate ./...` zero drift
(SHA-256 verified). `gofmt`/`go vet`/`go build` clean. Docs updated in both
trees (`skills/gitmoot/references/CLI.md` and `website/docs/reference/cli.md`),
per this repo's docs-ship-with-code convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)