### PR TITLE
fix(tasks): distinguish a healthy fix-pass from a genuine strand (#1169)

### DIFF
--- a/internal/workflow/task_liveness.go
+++ b/internal/workflow/task_liveness.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	TaskEventBlockedTerminalNoPR = "task_blocked_terminal_no_pr"
-	TaskEventBlockedJobFailed    = "task_blocked_job_failed"
+	TaskEventBlockedTerminalNoPR    = "task_blocked_terminal_no_pr"
+	TaskEventBlockedJobFailed       = "task_blocked_job_failed"
+	TaskEventTerminalPushedToOpenPR = "task_terminal_pushed_to_open_pr"
 )
 
 // FindLiveTaskJob returns one job that still owns lifecycle progress for task.
@@ -88,8 +89,31 @@ func (e Engine) ReconcileTerminalDrivingJob(ctx context.Context, jobID string) e
 	kind := TaskEventBlockedJobFailed
 	reason := fmt.Sprintf("top-level implement job %s ended in %s without a pull request or live successor", job.ID, job.State)
 	if job.State == string(JobSucceeded) && payload.Result != nil && payload.Result.Decision == "implemented" {
+		pr, prErr := e.Store.GetPullRequestByRepoBranch(ctx, task.RepoFullName, task.Branch)
+		if prErr == nil && strings.EqualFold(strings.TrimSpace(pr.State), "open") {
+			// Repo+branch is the durable task/PR binding. Do not require HeadSHA
+			// equality here: payload.HeadSHA is the allocated/finalized head when
+			// available, while the independently refreshed PR row can lag it. An
+			// equality gate would recreate the false block this reconciliation is
+			// meant to heal.
+			reason = fmt.Sprintf("top-level implement job %s pushed to existing open PR #%d on branch %q", job.ID, pr.Number, task.Branch)
+			_, _, err = e.Store.TransitionTaskStateWithEvent(ctx, task.ID,
+				[]string{string(TaskImplementing)}, string(TaskPullRequestOpen), TaskEventTerminalPushedToOpenPR, reason)
+			return err
+		}
+		if prErr != nil && !errors.Is(prErr, sql.ErrNoRows) {
+			return prErr
+		}
 		kind = TaskEventBlockedTerminalNoPR
-		reason = fmt.Sprintf("top-level implement job %s succeeded with decision implemented but produced no pull request or live successor", job.ID)
+		branch := strings.TrimSpace(task.Branch)
+		if branch == "" {
+			branch = "<unknown>"
+		}
+		headSHA := strings.TrimSpace(payload.HeadSHA)
+		if headSHA == "" {
+			headSHA = "<unknown>"
+		}
+		reason = fmt.Sprintf("top-level implement job %s succeeded with decision implemented on branch %q at commit %s but produced no open pull request or live successor", job.ID, branch, headSHA)
 	} else if payload.Result != nil && strings.TrimSpace(payload.Result.Decision) != "" {
 		reason = fmt.Sprintf("top-level implement job %s ended in %s with decision %s and no pull request or live successor", job.ID, job.State, payload.Result.Decision)
 	}

--- a/internal/workflow/task_liveness_test.go
+++ b/internal/workflow/task_liveness_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -12,18 +13,42 @@ import (
 
 func TestReconcileTerminalDrivingJob(t *testing.T) {
 	tests := []struct {
-		name          string
-		jobState      JobState
-		decision      string
-		parentJobID   string
-		delegationID  string
-		taskState     TaskState
-		successor     bool
-		wantTaskState TaskState
-		wantEvent     string
+		name             string
+		jobState         JobState
+		decision         string
+		parentJobID      string
+		delegationID     string
+		taskState        TaskState
+		successor        bool
+		pullRequestState string
+		wantTaskState    TaskState
+		wantEvent        string
+		wantReason       string
 	}{
-		{name: "terminal failure blocks", jobState: JobFailed, decision: "failed", taskState: TaskImplementing, wantTaskState: TaskBlocked, wantEvent: TaskEventBlockedJobFailed},
-		{name: "implemented success without PR blocks", jobState: JobSucceeded, decision: "implemented", taskState: TaskImplementing, wantTaskState: TaskBlocked, wantEvent: TaskEventBlockedTerminalNoPR},
+		{
+			name:     "terminal failure without decision blocks",
+			jobState: JobFailed, taskState: TaskImplementing,
+			wantTaskState: TaskBlocked, wantEvent: TaskEventBlockedJobFailed,
+			wantReason: "top-level implement job job-1 ended in failed without a pull request or live successor",
+		},
+		{
+			name:     "terminal failure with decision blocks",
+			jobState: JobFailed, decision: "failed", taskState: TaskImplementing,
+			wantTaskState: TaskBlocked, wantEvent: TaskEventBlockedJobFailed,
+			wantReason: "top-level implement job job-1 ended in failed with decision failed and no pull request or live successor",
+		},
+		{
+			name:     "implemented success without PR blocks",
+			jobState: JobSucceeded, decision: "implemented", taskState: TaskImplementing,
+			wantTaskState: TaskBlocked, wantEvent: TaskEventBlockedTerminalNoPR,
+			wantReason: `top-level implement job job-1 succeeded with decision implemented on branch "feature/one" at commit head123 but produced no open pull request or live successor`,
+		},
+		{
+			name:     "implemented success with closed PR blocks",
+			jobState: JobSucceeded, decision: "implemented", taskState: TaskImplementing, pullRequestState: "closed",
+			wantTaskState: TaskBlocked, wantEvent: TaskEventBlockedTerminalNoPR,
+			wantReason: `top-level implement job job-1 succeeded with decision implemented on branch "feature/one" at commit head123 but produced no open pull request or live successor`,
+		},
 		{name: "already advanced to pr_open is untouched", jobState: JobSucceeded, decision: "implemented", taskState: TaskPullRequestOpen, wantTaskState: TaskPullRequestOpen},
 		{name: "delegation child is untouched", jobState: JobFailed, decision: "failed", parentJobID: "parent", delegationID: "child", taskState: TaskImplementing, wantTaskState: TaskImplementing},
 		{name: "queued successor keeps task live", jobState: JobFailed, decision: "failed", taskState: TaskImplementing, successor: true, wantTaskState: TaskImplementing},
@@ -37,6 +62,7 @@ func TestReconcileTerminalDrivingJob(t *testing.T) {
 			}
 			payload := JobPayload{
 				Repo: "owner/repo", Branch: "feature/one", TaskID: "task-1",
+				HeadSHA:     "head123",
 				ParentJobID: test.parentJobID, DelegationID: test.delegationID,
 				Result: &AgentResult{Decision: test.decision, Summary: "done"},
 			}
@@ -46,6 +72,17 @@ func TestReconcileTerminalDrivingJob(t *testing.T) {
 			}
 			if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-1", Kind: "advance_completed"}); err != nil {
 				t.Fatal(err)
+			}
+			if test.pullRequestState != "" {
+				if err := store.UpsertPullRequest(ctx, db.PullRequest{
+					RepoFullName: "owner/repo",
+					Number:       41,
+					HeadBranch:   "feature/one",
+					HeadSHA:      "head123",
+					State:        test.pullRequestState,
+				}); err != nil {
+					t.Fatal(err)
+				}
 			}
 			if test.successor {
 				successorPayload, _ := json.Marshal(JobPayload{Repo: "owner/repo", Branch: "feature/one", TaskID: "task-1"})
@@ -71,10 +108,109 @@ func TestReconcileTerminalDrivingJob(t *testing.T) {
 				if len(events) != 0 {
 					t.Fatalf("unexpected task events = %+v", events)
 				}
-			} else if len(events) != 1 || events[0].Kind != test.wantEvent {
+			} else if len(events) != 1 || events[0].Kind != test.wantEvent || events[0].Reason != test.wantReason {
 				t.Fatalf("task events = %+v, want one %s", events, test.wantEvent)
 			}
 		})
+	}
+}
+
+func TestReconcileTerminalDrivingJobSplitsOpenPRFromStrand(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	engine := Engine{Store: store}
+
+	type fixture struct {
+		taskID string
+		jobID  string
+		branch string
+		head   string
+	}
+	healthy := fixture{taskID: "task-fix-pass", jobID: "job-fix-pass", branch: "feature/fix-pass", head: "abc123"}
+	stranded := fixture{taskID: "task-stranded", jobID: "job-stranded", branch: "feature/stranded", head: "def456"}
+	for _, item := range []fixture{healthy, stranded} {
+		if err := store.UpsertTask(ctx, db.Task{
+			ID:           item.taskID,
+			RepoFullName: "owner/repo",
+			Branch:       item.branch,
+			State:        string(TaskImplementing),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		encoded, err := json.Marshal(JobPayload{
+			Repo:    "owner/repo",
+			Branch:  item.branch,
+			TaskID:  item.taskID,
+			HeadSHA: item.head,
+			Result:  &AgentResult{Decision: "implemented", Summary: "done"},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.CreateJob(ctx, db.Job{ID: item.jobID, Type: "implement", State: string(JobSucceeded), Payload: string(encoded)}); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: item.jobID, Kind: "advance_completed"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo",
+		Number:       41,
+		HeadBranch:   healthy.branch,
+		HeadSHA:      healthy.head,
+		State:        "open",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, item := range []fixture{healthy, stranded} {
+		if err := engine.ReconcileTerminalDrivingJob(ctx, item.jobID); err != nil {
+			t.Fatalf("ReconcileTerminalDrivingJob(%s): %v", item.jobID, err)
+		}
+	}
+
+	healthyTask, err := store.GetTask(ctx, healthy.taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if healthyTask.State != string(TaskPullRequestOpen) {
+		t.Fatalf("healthy task state = %s, want %s", healthyTask.State, TaskPullRequestOpen)
+	}
+	strandedTask, err := store.GetTask(ctx, stranded.taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strandedTask.State != string(TaskBlocked) {
+		t.Fatalf("stranded task state = %s, want %s", strandedTask.State, TaskBlocked)
+	}
+
+	healthyEvents, err := store.ListTaskEvents(ctx, healthy.taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	strandedEvents, err := store.ListTaskEvents(ctx, stranded.taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(healthyEvents) != 1 || healthyEvents[0].Kind != TaskEventTerminalPushedToOpenPR ||
+		!strings.Contains(healthyEvents[0].Reason, "#41") || !strings.Contains(healthyEvents[0].Reason, healthy.branch) {
+		t.Fatalf("healthy events = %+v, want open-PR informational transition", healthyEvents)
+	}
+	if len(strandedEvents) != 1 || strandedEvents[0].Kind != TaskEventBlockedTerminalNoPR ||
+		!strings.Contains(strandedEvents[0].Reason, stranded.branch) || !strings.Contains(strandedEvents[0].Reason, stranded.head) {
+		t.Fatalf("stranded events = %+v, want blocked event naming branch and SHA", strandedEvents)
+	}
+	if healthyEvents[0].Kind == strandedEvents[0].Kind || healthyEvents[0].Reason == strandedEvents[0].Reason {
+		t.Fatalf("healthy and stranded outcomes must differ: healthy=%+v stranded=%+v", healthyEvents[0], strandedEvents[0])
+	}
+
+	blocked, err := store.ListTasksByRepoState(ctx, "owner/repo", string(TaskBlocked))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(blocked) != 1 || blocked[0].ID != stranded.taskID {
+		t.Fatalf("blocked tasks = %+v, want only %s", blocked, stranded.taskID)
 	}
 }
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1448,9 +1448,12 @@ dismissals use `task_dismissed_auto`; opt-in never-started-plan retirement uses
 and `task_recovered_job_retry`. A clean closed-unmerged PR records
 `pr_closed_unmerged` while moving `pr_open`, `reviewing`, or
 `changes_requested` to `blocked`. Once advancement/delegation handling has no
-live successor, a terminal top-level implement job without a PR records
-`task_blocked_terminal_no_pr` for implemented success or
-`task_blocked_job_failed` for another terminal outcome and blocks the task.
+live successor, an implemented top-level job with no attached PR first checks
+for an existing open PR on the task branch. A match restores the task to
+`pr_open` and records `task_terminal_pushed_to_open_pr`; otherwise the task is
+blocked with `task_blocked_terminal_no_pr`, whose reason names the recoverable
+branch and recorded head SHA when available. Other terminal outcomes remain
+`task_blocked_job_failed`.
 
 ### Recover A Dead Implement
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1337,9 +1337,12 @@ dismissal cannot be resurrected by `task run`; explicit recovery is required.
 A clean closed-unmerged PR moves `pr_open`, `reviewing`, or
 `changes_requested` to `blocked` with `pr_closed_unmerged`; ambiguous PR state
 remains conservative. After advancement and delegation handling, a terminal
-top-level implement job with no PR and no live successor also blocks an
-`implementing` task. Implemented success without a PR records
-`task_blocked_terminal_no_pr`; other terminal outcomes record
+top-level implement job with no attached PR and no live successor checks whether
+the task branch already has an open PR. An implemented success with that binding
+returns the task to `pr_open` and records
+`task_terminal_pushed_to_open_pr`; without an open branch PR it blocks with
+`task_blocked_terminal_no_pr`, whose reason names the recoverable branch and
+recorded head SHA when available. Other terminal outcomes remain
 `task_blocked_job_failed`. Delegation children and queued fixes, retries,
 continuations, or pending advancement are not reclassified.
 


### PR DESCRIPTION
## What

`Engine.ReconcileTerminalDrivingJob` (`internal/workflow/task_liveness.go`)
blocked a task with the identical `task_blocked_terminal_no_pr` reason
whether the top-level implement job genuinely stranded (no PR anywhere) or
correctly pushed a fix-pass commit onto an **already-open PR** bound to the
task's branch — the only signal ever checked was `payload.PullRequest == 0`,
never whether the task's own branch already had a PR. Live evidence on the
issue: 8 real false positives (routine fix-pass rounds on
`luminexord/herdres#199`) buried 1 genuinely stranded **URGENT** correctness
fix behind indistinguishable reason text for two hours, only caught by
hand-checking each task id against the PR's commit list.

https://github.com/gitmoot/gitmoot/issues/1169

## Fix

In the succeeded+implemented branch specifically, now checks
`GetPullRequestByRepoBranch(task.RepoFullName, task.Branch)`:

- **An open PR bound to the branch** means the fix-pass worked as intended.
  The task returns to the already-existing `TaskPullRequestOpen` state (not
  `TaskBlocked`) with a new, distinct `task_terminal_pushed_to_open_pr` kind
  naming the PR number and branch — this removes it from blocked-task
  triage entirely, rather than merely giving it different-but-still-present
  text (which is what actually causes alert fatigue: a noisy signal an
  operator learns to dismiss in bulk, exactly how the one genuine strand got
  missed).
- **No PR (or a closed one)** keeps the existing `task_blocked_terminal_no_pr`
  block, now naming the branch and head SHA in the reason so recovery is one
  command instead of a manual commit-list diff.

Deliberately does **not** require SHA-level equality between
`payload.HeadSHA` and the PR's recorded head — those can lag each other
independently (payload is set at allocation/finalize time, the PR row is
refreshed by an independent poll), and an equality gate would recreate the
exact false block this fix exists to close. "Branch is bound to an open PR"
is the signal, matching the actual shape of all 8 real false positives on
the issue.

Also confirms (worth noting, not itself changed here): the existing
dispatch-time `prOpenFixPass` validation in `agent_dispatch.go` doesn't catch
this — the false-positive path is branch/task-based dispatch that never
attaches an explicit PR number, so `payload.PullRequest` stays `0` even
though the branch genuinely has an open PR.

## Review

One fresh-context adversarial pass (sol/codex, isolated clone, no prior
context): `decision: approved`, zero findings. Independently confirmed the
healthy-fix-pass path returns immediately (can never fall through to the
blocking logic), the PR-state comparison matches how this codebase already
stores PR state elsewhere (`open`/`closed`/`merged`), and every pre-existing
reconciliation case (terminal failure with/without a decision, delegation
child, queued successor, already-`pr_open`) is unchanged.

## Tests

`TestReconcileTerminalDrivingJobSplitsOpenPRFromStrand` mirrors the issue's
own regression spec: two tasks, identical job-terminal shape, one with an
open PR bound to its branch and one without. Asserts they land in
**different task states** (not just different text on the same state), that
their event kinds and reasons are genuinely different from each other, that
the stranded reason names both branch and SHA, and that
`ListTasksByRepoState(..., Blocked)` returns **only** the genuinely stranded
task — proving the healthy case is actually absent from triage, not just
relabeled within it.

Full `db`/`cli`/`workflow` suites green. `go generate ./...` zero drift
(SHA-256 verified). `gofmt`/`go vet`/`go build` clean. Docs updated in both
trees (`skills/gitmoot/references/CLI.md`, `website/docs/reference/cli.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)