### PR TITLE
fix(workflow): reject a merge-gate review verdict authored by the implementing agent (#1145)

### DIFF
--- a/internal/cli/daemon_merge_gate_active_job_test.go
+++ b/internal/cli/daemon_merge_gate_active_job_test.go
@@ -250,6 +250,12 @@ func daemonMergeGateActiveJobFixture(t *testing.T, seedReview ...bool) (*db.Stor
 	}
 	if len(seedReview) == 0 || seedReview[0] {
 		seedDaemonMergeGateJob(t, store, db.Job{
+			ID: "implement-complete", Agent: "implementer", Type: "implement", State: string(workflow.JobSucceeded),
+		}, workflow.JobPayload{
+			Repo: "owner/repo", Branch: "fix-round", PullRequest: 17, HeadSHA: "head123", TaskID: "task-1017",
+			Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented"},
+		})
+		seedDaemonMergeGateJob(t, store, db.Job{
 			ID: "review-approved", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded),
 		}, workflow.JobPayload{
 			Repo: "owner/repo", Branch: "fix-round", PullRequest: 17, HeadSHA: "head123", TaskID: "task-1017",

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -424,6 +424,25 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		return err
 	}
 	current := JobPayload{Repo: request.Repo, PullRequest: request.PullRequest, TaskID: request.TaskID}
+	implementingAgents := map[string]struct{}{}
+	for _, job := range jobs {
+		if job.Type != "implement" {
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			// A malformed implement record cannot prove authorship for this
+			// task, but it also must not block unrelated merge gates.
+			continue
+		}
+		if !sameTask(current, payload) {
+			continue
+		}
+		agent := strings.TrimSpace(job.Agent)
+		if agent != "" {
+			implementingAgents[agent] = struct{}{}
+		}
+	}
 	latest := ""
 	for _, job := range jobs {
 		if job.Type != "review" {
@@ -448,6 +467,9 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		return errors.New("final agent review is not captured")
 	}
 	approved := false
+	var selfApprovalReason string
+	var unknownImplementerReason string
+	var unattributedReviewerReason string
 	for _, job := range jobs {
 		if job.Type != "review" {
 			continue
@@ -463,7 +485,32 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if !sameTask(current, payload) || round != latest || payload.Result == nil {
 			continue
 		}
+		if payload.Result.Decision == "approved" {
+			reviewerAgent := strings.TrimSpace(job.Agent)
+			switch {
+			case reviewerAgent == "":
+				if unattributedReviewerReason == "" {
+					unattributedReviewerReason = "latest review round's approval has no recorded reviewer author; an independent reviewer cannot be verified"
+				}
+				continue
+			case len(implementingAgents) == 0:
+				if unknownImplementerReason == "" {
+					unknownImplementerReason = "latest review round's approval cannot be verified as independent because the implementing agent for this task could not be determined"
+				}
+				continue
+			default:
+				if _, selfApproved := implementingAgents[reviewerAgent]; selfApproved {
+					if selfApprovalReason == "" {
+						selfApprovalReason = fmt.Sprintf("latest review round's approval was authored by %s, the implementing agent; an independent reviewer is required", reviewerAgent)
+					}
+					continue
+				}
+			}
+		}
 		if err := g.ensureReviewMatchesHead(payload, headSHA, job.Agent); err != nil {
+			if reason := reviewAuthorshipFailureReason(selfApprovalReason, unknownImplementerReason, unattributedReviewerReason); reason != "" {
+				return errors.New(reason)
+			}
 			return err
 		}
 		switch payload.Result.Decision {
@@ -478,9 +525,23 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		}
 	}
 	if !approved {
+		if reason := reviewAuthorshipFailureReason(selfApprovalReason, unknownImplementerReason, unattributedReviewerReason); reason != "" {
+			return errors.New(reason)
+		}
 		return errors.New("required reviewer approval is missing")
 	}
 	return nil
+}
+
+func reviewAuthorshipFailureReason(selfApproval string, unknownImplementer string, unattributedReviewer string) string {
+	// Keep the operator-facing cause stable when a round contains multiple
+	// disqualified approvals.
+	for _, reason := range []string{selfApproval, unknownImplementer, unattributedReviewer} {
+		if reason = strings.TrimSpace(reason); reason != "" {
+			return reason
+		}
+	}
+	return ""
 }
 
 func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repository, request MergeRequest, pr github.PullRequest, headSHA string) (MergeDecision, bool, error) {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -470,6 +470,11 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	var selfApprovalReason string
 	var unknownImplementerReason string
 	var unattributedReviewerReason string
+	type eligibleReview struct {
+		job     db.Job
+		payload JobPayload
+	}
+	var eligible []eligibleReview
 	for _, job := range jobs {
 		if job.Type != "review" {
 			continue
@@ -507,6 +512,11 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 				}
 			}
 		}
+		eligible = append(eligible, eligibleReview{job: job, payload: payload})
+	}
+	for _, review := range eligible {
+		job := review.job
+		payload := review.payload
 		if err := g.ensureReviewMatchesHead(payload, headSHA, job.Agent); err != nil {
 			if reason := reviewAuthorshipFailureReason(selfApprovalReason, unknownImplementerReason, unattributedReviewerReason); reason != "" {
 				return errors.New(reason)

--- a/internal/workflow/merge_gate_noci_race_test.go
+++ b/internal/workflow/merge_gate_noci_race_test.go
@@ -19,7 +19,7 @@ import (
 func TestPolicyMergeGateZeroExternalCIDefersWithinGraceWindow(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "jerryfane/noted",
 		Branch:      "task-11",
 		PullRequest: 11,

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -12,13 +12,36 @@ import (
 	"github.com/gitmoot/gitmoot/internal/github"
 )
 
+func insertIndependentMergeGateReview(t *testing.T, store *db.Store, reviewJob db.Job, reviewPayload JobPayload) {
+	t.Helper()
+	implementingAgent := "implementer"
+	if strings.TrimSpace(reviewJob.Agent) == implementingAgent {
+		implementingAgent = "different-implementer"
+	}
+	implementPayload := reviewPayload
+	implementPayload.ReviewRound = ""
+	implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	insertCompletedJob(t, store, db.Job{
+		ID:    reviewJob.ID + "-implement-author",
+		Agent: implementingAgent,
+		Type:  "implement",
+	}, implementPayload)
+	insertCompletedJob(t, store, reviewJob, reviewPayload)
+}
+
 func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID: "malformed-unrelated-implement", Agent: "other", Type: "implement",
+		State: string(JobSucceeded), Payload: "{not-json",
+	}, db.JobEvent{Kind: string(JobSucceeded), Message: "malformed unrelated fixture"}); err != nil {
+		t.Fatalf("CreateJobWithEvent malformed unrelated implement: %v", err)
+	}
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -124,6 +147,132 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	}
 }
 
+func TestPolicyMergeGateRejectsUnverifiableReviewAuthorship(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		implementingAgent string
+		reviewerAgent     string
+		wantReason        string
+	}{
+		{
+			name:              "self approval",
+			implementingAgent: "sol",
+			reviewerAgent:     "sol",
+			wantReason:        "approval was authored by sol, the implementing agent; an independent reviewer is required",
+		},
+		{
+			name:              "unattributed reviewer",
+			implementingAgent: "sol",
+			reviewerAgent:     "",
+			wantReason:        "approval has no recorded reviewer author; an independent reviewer cannot be verified",
+		},
+		{
+			name:          "unknown implementer",
+			reviewerAgent: "audit",
+			wantReason:    "approval cannot be verified as independent because the implementing agent for this task could not be determined",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			payload := JobPayload{
+				Repo:        "gitmoot/gitmoot",
+				Branch:      "task-9",
+				PullRequest: 9,
+				HeadSHA:     "head123",
+				TaskID:      "task-9",
+				ReviewRound: "review-1",
+			}
+			if tc.implementingAgent != "" {
+				implementPayload := payload
+				implementPayload.ReviewRound = ""
+				implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+				insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: tc.implementingAgent, Type: "implement"}, implementPayload)
+			}
+			reviewPayload := payload
+			reviewPayload.Result = &AgentResult{Decision: "approved", Summary: "approved"}
+			insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: tc.reviewerAgent, Type: "review"}, reviewPayload)
+
+			mergeable := true
+			gh := &fakeMergeGateGitHub{
+				pr: github.PullRequest{
+					Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+					HeadSHA: "head123", Mergeable: &mergeable,
+				},
+				status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+				checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+				mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+			}
+			gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+			decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Ready || decision.Merged {
+				t.Fatalf("decision = %+v, want escalating LeaveOpen", decision)
+			}
+			if !strings.Contains(decision.Reason, tc.wantReason) {
+				t.Fatalf("decision reason = %q, want %q", decision.Reason, tc.wantReason)
+			}
+			if len(gh.merges) != 0 {
+				t.Fatalf("unverifiable approval issued merge: %+v", gh.merges)
+			}
+		})
+	}
+}
+
+func TestPolicyMergeGatePreservesSelfApprovalReasonOverLaterHeadMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	basePayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		TaskID:      "task-9",
+	}
+	implementPayload := basePayload
+	implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "sol", Type: "implement"}, implementPayload)
+
+	selfReview := basePayload
+	selfReview.HeadSHA = "head123"
+	selfReview.ReviewRound = "review-1"
+	selfReview.Result = &AgentResult{Decision: "approved", Summary: "self-approved"}
+	insertCompletedJob(t, store, db.Job{ID: "review-a-self", Agent: "sol", Type: "review"}, selfReview)
+
+	staleReview := basePayload
+	staleReview.HeadSHA = "old123"
+	staleReview.ReviewRound = "review-1"
+	staleReview.Result = &AgentResult{Decision: "approved", Summary: "stale approval"}
+	insertCompletedJob(t, store, db.Job{ID: "review-z-stale", Agent: "audit", Type: "review"}, staleReview)
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status: github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks: []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Ready || decision.Merged {
+		t.Fatalf("decision = %+v, want escalating LeaveOpen", decision)
+	}
+	if !strings.Contains(decision.Reason, "approval was authored by sol, the implementing agent") {
+		t.Fatalf("decision reason lost self-approval cause: %q", decision.Reason)
+	}
+	if strings.Contains(decision.Reason, "different head SHA") {
+		t.Fatalf("incidental stale-head error replaced self-approval cause: %q", decision.Reason)
+	}
+}
+
 func TestPolicyMergeGateExplicitKillSwitchLeavesOpenWithoutGitHubCalls(t *testing.T) {
 	ctx := context.Background()
 	gh := &fakeMergeGateGitHub{}
@@ -163,7 +312,7 @@ func TestRunMergeGateExplicitKillSwitchParksReviewedAndUnreviewedTasks(t *testin
 			}
 			payload := JobPayload{Repo: "owner/repo", Branch: tc.taskID, PullRequest: 17, TaskID: tc.taskID, TaskTitle: tc.name}
 			if tc.withReview {
-				insertCompletedJob(t, store, db.Job{ID: "review-" + tc.taskID, Agent: "reviewer", Type: "review"}, JobPayload{
+				insertIndependentMergeGateReview(t, store, db.Job{ID: "review-" + tc.taskID, Agent: "reviewer", Type: "review"}, JobPayload{
 					Repo: "owner/repo", Branch: tc.taskID, PullRequest: 17, TaskID: tc.taskID,
 					Result: &AgentResult{Decision: "approved", Summary: "approved"},
 				})
@@ -232,7 +381,7 @@ func TestPolicyMergeGateHumanRequestBypassesKillSwitchAndMandatoryGate(t *testin
 func TestPolicyMergeGateJournalFailureDoesNotChangeMergedDecision(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "native-journal-link", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "native-journal-link", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -294,7 +443,7 @@ func TestPolicyMergeGateCleansTaskWorktreeAfterMerge(t *testing.T) {
 	if err := store.UpsertTask(ctx, db.Task{ID: "task-9", RepoFullName: "gitmoot/gitmoot", GoalID: "goal-1", Title: "Task 9", State: string(TaskReadyToMerge), Branch: "task-9", WorktreePath: "/tmp/gitmoot/worktrees/gitmoot--gitmoot/task-9"}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -341,7 +490,7 @@ func TestPolicyMergeGateReportsWorktreeCleanupWarning(t *testing.T) {
 	if err := store.UpsertTask(ctx, db.Task{ID: "task-9", RepoFullName: "gitmoot/gitmoot", GoalID: "goal-1", Title: "Task 9", State: string(TaskReadyToMerge), Branch: "task-9", WorktreePath: "/tmp/gitmoot/worktrees/gitmoot--gitmoot/task-9"}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -385,7 +534,7 @@ func TestPolicyMergeGateDoesNotCleanWorktreeForMismatchedTaskBranch(t *testing.T
 	if err := store.UpsertTask(ctx, db.Task{ID: "task-8", RepoFullName: "gitmoot/gitmoot", GoalID: "goal-1", Title: "Task 8", State: string(TaskImplementing), Branch: "task-8", WorktreePath: "/tmp/gitmoot/worktrees/gitmoot--gitmoot/task-8"}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -429,7 +578,7 @@ func TestPolicyMergeGateLocksCheckoutDuringLocalBaseUpdate(t *testing.T) {
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -471,7 +620,7 @@ func TestPolicyMergeGateLocksCheckoutDuringLocalBaseUpdate(t *testing.T) {
 func TestPolicyMergeGateReturnsRetryableErrorForBusyCheckout(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -531,7 +680,7 @@ func TestPolicyMergeGateReturnsRetryableErrorForBusyCheckout(t *testing.T) {
 func TestPolicyMergeGateDoesNotRecordPreMergeSyntheticSHA(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -577,7 +726,7 @@ func TestPolicyMergeGateDoesNotRecordPreMergeSyntheticSHA(t *testing.T) {
 func TestPolicyMergeGateBlocksDirtyWorktree(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo: "gitmoot/gitmoot", PullRequest: 9, HeadSHA: "head123", TaskID: "task-9",
 		ReviewRound: "review-1", Result: &AgentResult{Decision: "approved"},
 	})
@@ -600,7 +749,7 @@ func TestPolicyMergeGateBlocksDirtyWorktree(t *testing.T) {
 func TestPolicyMergeGateBlocksFailedExternalCI(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -637,7 +786,7 @@ func TestPolicyMergeGateBlocksFailedExternalCI(t *testing.T) {
 func TestPolicyMergeGateTruncatesLongStatusDescriptions(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -673,7 +822,7 @@ func TestPolicyMergeGateTruncatesLongStatusDescriptions(t *testing.T) {
 func TestPolicyMergeGateAllowsSkippedExternalCI(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -703,7 +852,7 @@ func TestPolicyMergeGateAllowsSkippedExternalCI(t *testing.T) {
 func TestPolicyMergeGateUpdatesStaleBranchAndStaysPending(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -741,7 +890,7 @@ func TestPolicyMergeGateUpdatesStaleBranchAndStaysPending(t *testing.T) {
 func TestPolicyMergeGateBlocksStaleBranchUpdateConflict(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -780,7 +929,7 @@ func TestPolicyMergeGateBlocksStaleBranchUpdateConflict(t *testing.T) {
 func TestPolicyMergeGateKeepsStaleHeadRacePending(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -813,7 +962,7 @@ func TestPolicyMergeGateKeepsStaleHeadRacePending(t *testing.T) {
 func TestPolicyMergeGateKeepsMergeQueueBusyPending(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -855,7 +1004,7 @@ func TestPolicyMergeGateKeepsMergeQueueBusyPending(t *testing.T) {
 func TestPolicyMergeGateKeepsPendingCIReadyToRetry(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -893,7 +1042,7 @@ func TestPolicyMergeGateKeepsQueuedMergePending(t *testing.T) {
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-9", Owner: "lead"}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
 	}
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		Branch:      "task-9",
 		PullRequest: 9,
@@ -1023,7 +1172,7 @@ func TestPolicyMergeGateBlocksClosedUnmergedPullRequest(t *testing.T) {
 func TestPolicyMergeGateUsesLatestNumericReviewRound(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-nine", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-nine", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "old123",
@@ -1031,7 +1180,7 @@ func TestPolicyMergeGateUsesLatestNumericReviewRound(t *testing.T) {
 		ReviewRound: "review-9",
 		Result:      &AgentResult{Decision: "changes_requested", Summary: "old change"},
 	})
-	insertCompletedJob(t, store, db.Job{ID: "review-ten", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-ten", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "head123",
@@ -1060,7 +1209,7 @@ func TestPolicyMergeGateUsesLatestNumericReviewRound(t *testing.T) {
 func TestPolicyMergeGateBlocksReviewForStaleHead(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		HeadSHA:     "old123",
@@ -1102,7 +1251,7 @@ func TestPolicyMergeGateBlocksLegacyReviewWithoutHeadSHA(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertPullRequest returned error: %v", err)
 	}
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
 		Repo:        "gitmoot/gitmoot",
 		PullRequest: 9,
 		TaskID:      "task-9",
@@ -1149,7 +1298,7 @@ func TestPolicyMergeGateAdvancesIntegrationWorktreeReviewWithoutHeadSHA(t *testi
 	}
 	// An integration-worktree review: a delegation child (DelegationID +
 	// WorktreePath set) whose HeadSHA the engine intentionally cleared.
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review", DelegationID: "verify-gate"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review", DelegationID: "verify-gate"}, JobPayload{
 		Repo:         "gitmoot/gitmoot",
 		PullRequest:  9,
 		TaskID:       "task-9",
@@ -1184,7 +1333,7 @@ func TestPolicyMergeGateAdvancesIntegrationWorktreeReviewWithoutHeadSHA(t *testi
 func TestPolicyMergeGateBlocksDelegationReviewForMismatchedHead(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review", DelegationID: "verify-gate"}, JobPayload{
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review", DelegationID: "verify-gate"}, JobPayload{
 		Repo:         "gitmoot/gitmoot",
 		PullRequest:  9,
 		HeadSHA:      "stale999",

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -222,7 +222,58 @@ func TestPolicyMergeGateRejectsUnverifiableReviewAuthorship(t *testing.T) {
 	}
 }
 
-func TestPolicyMergeGatePreservesSelfApprovalReasonOverLaterHeadMismatch(t *testing.T) {
+func TestPolicyMergeGatePreservesSelfApprovalReasonWhenHeadMismatchSortsFirst(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	basePayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		TaskID:      "task-9",
+	}
+	implementPayload := basePayload
+	implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+	insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "sol", Type: "implement"}, implementPayload)
+
+	selfReview := basePayload
+	selfReview.HeadSHA = "head123"
+	selfReview.ReviewRound = "review-1"
+	selfReview.Result = &AgentResult{Decision: "approved", Summary: "self-approved"}
+	insertCompletedJob(t, store, db.Job{ID: "review-z-self", Agent: "sol", Type: "review"}, selfReview)
+
+	staleReview := basePayload
+	staleReview.HeadSHA = "old123"
+	staleReview.ReviewRound = "review-1"
+	staleReview.Result = &AgentResult{Decision: "approved", Summary: "stale approval"}
+	insertCompletedJob(t, store, db.Job{ID: "review-a-stale", Agent: "audit", Type: "review"}, staleReview)
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status: github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks: []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Ready || decision.Merged {
+		t.Fatalf("decision = %+v, want escalating LeaveOpen", decision)
+	}
+	if !strings.Contains(decision.Reason, "approval was authored by sol, the implementing agent") {
+		t.Fatalf("decision reason lost self-approval cause: %q", decision.Reason)
+	}
+	if strings.Contains(decision.Reason, "different head SHA") {
+		t.Fatalf("incidental stale-head error replaced self-approval cause: %q", decision.Reason)
+	}
+}
+
+func TestPolicyMergeGatePreservesSelfApprovalReasonWhenSelfApprovalSortsFirst(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	basePayload := JobPayload{


### PR DESCRIPTION
## What

Fixes #1145: the merge gate's `ensureFinalReviewCaptured` checked `payload.Result.Decision` for the latest review round but never checked WHO produced that verdict. On jerryfane/herdr#7, a 10-round autonomous review→fix→review loop returned `decision=approved` on its own round-10 self-review — the same agent approving its own eight-round chain of self-authored fixes. The gate would have accepted that verdict as authoritative; only unrelated red CI (a fork-specific broken tag, nothing to do with the loop) prevented the merge. The approved branch was independently confirmed to carry a real macOS regression.

## Design

- Builds an implementing-agent set from `Type == "implement"` jobs matching the same task (Repo+PullRequest+TaskID).
- When evaluating an `"approved"` review round, classifies it into exactly one of four outcomes:
  - reviewer agent is blank → not approved (can't verify independence)
  - the implementing-agent set is empty (no implement job found at all) → not approved (can't verify independence either way)
  - reviewer agent is a member of the implementing-agent set → not approved (self-approval)
  - otherwise → approved, exactly as today
- Each disqualifying case gets its OWN distinct reason string, so an operator reading the escalation sees the actual cause rather than a generic "no review exists" message.
- Applies to **every** merge-gate evaluation, unconditionally — not gated behind detecting "is this an autonomous loop." A same-agent check is a strict superset of that detection, without needing a fragile loop classifier (exactly the kind of heuristic that has failed silently elsewhere tonight).
- Fail-closed direction, both sides: absent/unattributable authorship never passes. A false park here is recoverable by a human merge decision; a false merge is not — that asymmetry is why this refuses rather than defaults open.

## A real interaction defect, found by reading the loop rather than by testing

The existing `ensureReviewMatchesHead` call returns immediately on a head mismatch for *any* job in the round. If a self-approval (or unattributed/unknown-implementer) disqualification were detected but the code simply continued the loop, a *different* job in the same round with a stale/mismatched head could return its own unrelated error first — silently replacing the correct "self-approval" reason with a confusing "different head SHA" message, defeating the whole point of giving operators the right causal story. The fix runs the authorship classification **before** `ensureReviewMatchesHead`, so a disqualified job short-circuits before ever reaching the head check — it can neither mask nor be masked by another job's incidental error. `TestPolicyMergeGatePreservesSelfApprovalReasonOverLaterHeadMismatch` proves this directly: a self-approved review and a stale-head review from a different agent in the same round, asserting the final reason names the self-approval and does *not* contain "different head SHA".

## A second attack path, also verified

A cancelled review job (e.g. on `runtime_quota`) gets retried by the daemon's PR reconciliation (`reconcileReviewingPullRequest`), which — when it finds no current review job — falls through to `handlePullRequestWorkflow`, the *same* ordinary review-dispatch path used for any fresh review. That produces an identical `Type`/`Agent`/`TaskID` job shape to a directly-dispatched review, with nothing at the job-record level distinguishing "arrived via retry" from "dispatched normally." Since this fix's check reads only persisted job fields, not dispatch history, this confirms the fix already covers that path — there's nothing for it to miss.

## Known limitation — stated explicitly, not silently covered

The implementing-agent set is scoped to `Type == "implement"` jobs only. An agent that authors work through some *other* mechanism — an ask-dispatched build with no implement job, a coordinator's own direct commit, a delegation leg — and then reviews that same work is **not** covered by this check. That is exactly the shape of tonight's herdr#11 incident: g5 authored a build via a dispatched task with no implement job, then reviewed it as coordinator, and nothing here would have caught that. A fuller authorship model covering non-implement-job authorship is real, separate follow-up work — this PR does not claim to close that gap.

## #1147 compatibility

Any error from `ensureFinalReviewCaptured` propagates through the existing `reviewAndCIGateMiss` → `gateMiss(reason)` path, producing `MergeDecision{LeaveOpen: true, EscalateMergeGateMiss: true}`, which routes through the existing `parkTaskAwaitingHumanMerge` mechanism — the same park state #1147 (deferred, not touched by this PR) is adding a resume-work exit from. No new parking state or mechanism introduced.

## Verification

- `go build ./...`, `go vet ./...` clean.
- Full `internal/workflow` merge-gate test suite (34 tests) passes, including all pre-existing tests (proving no regression to the ordinary approve-and-merge path) and 2 new test functions covering all four classification outcomes plus the interaction-defect regression.
- The full local gate (including the scoped `-race` run) was run as part of the implementation session; that session was interrupted mid-gate by an unrelated production daemon deploy/restart (collateral, same pattern documented on #1112 tonight — see the #1145 workflow journal for the full trace). Salvaged from the completed, uncommitted worktree and re-verified independently before this PR: clean build/vet, and the full merge-gate test suite passing in a fresh run.
