### PR TITLE
Gitmoot: #1108 item 3, SLICE 1 — surface herdr

### DIFF
--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -40,12 +40,19 @@ type herdrOrgSnapshotResult struct {
 		Snapshot struct {
 			Version json.RawMessage `json:"version"`
 			Panes   []struct {
-				PaneID      string `json:"pane_id"`
-				Label       string `json:"label"`
-				AgentStatus string `json:"agent_status"`
+				PaneID            string                  `json:"pane_id"`
+				Label             string                  `json:"label"`
+				AgentStatus       string                  `json:"agent_status"`
+				LastCompletedTurn *herdrCompletedTurnWire `json:"last_completed_turn"`
 			} `json:"panes"`
 		} `json:"snapshot"`
 	} `json:"result"`
+}
+
+type herdrCompletedTurnWire struct {
+	Turn            *int64 `json:"turn"`
+	TurnEpoch       *int64 `json:"turn_epoch"`
+	CompletedUnixMS *int64 `json:"completed_unix_ms"`
 }
 
 func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
@@ -68,22 +75,24 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 		return org.Snapshot{}, fmt.Errorf("herdr api snapshot returned an incomplete snapshot shape")
 	}
 
-	byLabel := map[string][]string{}
+	byLabel := map[string][]org.RoleLiveState{}
 	labelToPaneIDs := map[string][]string{}
-	statusByPaneID := map[string]string{}
+	stateByPaneID := map[string]org.RoleLiveState{}
 	for _, pane := range decoded.Result.Snapshot.Panes {
+		state := mapHerdrAgentStatus(pane.AgentStatus)
+		state.Activity = mapHerdrCompletedTurn(pane.LastCompletedTurn)
 		// Mirror the wake resolver (herdr.go resolvePaneByLabel, which matches only
 		// `p.PaneID != ""`): a pane with an empty pane_id is not a resolvable
 		// target. Seeding it would collide every empty-id pane on the "" key of
-		// statusByPaneID and let a binding read the wrong pane's status.
+		// stateByPaneID and let a binding read the wrong pane's state.
 		if pane.PaneID != "" {
-			statusByPaneID[pane.PaneID] = pane.AgentStatus
+			stateByPaneID[pane.PaneID] = state
 			if pane.Label != "" {
 				labelToPaneIDs[pane.Label] = append(labelToPaneIDs[pane.Label], pane.PaneID)
 			}
 		}
 		if pane.Label != "" {
-			byLabel[pane.Label] = append(byLabel[pane.Label], pane.AgentStatus)
+			byLabel[pane.Label] = append(byLabel[pane.Label], state)
 		}
 	}
 	states := make(map[string]org.RoleLiveState, len(p.roles))
@@ -101,12 +110,12 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 				}
 				return "", false
 			})
-			status, present := statusByPaneID[paneID]
+			state, present := stateByPaneID[paneID]
 			if !present {
 				states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: fmt.Sprintf("no Herdr pane bound as %q", binding)}
 				continue
 			}
-			states[role.Name] = mapHerdrAgentStatus(status)
+			states[role.Name] = state
 			continue
 		}
 
@@ -115,7 +124,7 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 		case 0:
 			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: "no Herdr pane has this exact role label"}
 		case 1:
-			states[role.Name] = mapHerdrAgentStatus(matches[0])
+			states[role.Name] = matches[0]
 		default:
 			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: "multiple Herdr panes have this exact role label"}
 		}
@@ -125,6 +134,17 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 		now = p.now
 	}
 	return org.Snapshot{States: states, ObservedAt: now().UTC(), ProviderVersion: version}, nil
+}
+
+func mapHerdrCompletedTurn(turn *herdrCompletedTurnWire) *org.RoleActivity {
+	if turn == nil || turn.Turn == nil || turn.TurnEpoch == nil || turn.CompletedUnixMS == nil {
+		return nil
+	}
+	return &org.RoleActivity{
+		Turn:        *turn.Turn,
+		TurnEpoch:   *turn.TurnEpoch,
+		CompletedAt: time.UnixMilli(*turn.CompletedUnixMS).UTC(),
+	}
 }
 
 // Recycle starts a fresh interactive agent in a pane that has already returned

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -50,9 +50,9 @@ type herdrOrgSnapshotResult struct {
 }
 
 type herdrCompletedTurnWire struct {
-	Turn            *int64 `json:"turn"`
-	TurnEpoch       *int64 `json:"turn_epoch"`
-	CompletedUnixMS *int64 `json:"completed_unix_ms"`
+	Turn            *json.Number `json:"turn"`
+	TurnEpoch       *json.Number `json:"turn_epoch"`
+	CompletedUnixMS *json.Number `json:"completed_unix_ms"`
 }
 
 func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
@@ -137,14 +137,28 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 }
 
 func mapHerdrCompletedTurn(turn *herdrCompletedTurnWire) *org.RoleActivity {
-	if turn == nil || turn.Turn == nil || turn.TurnEpoch == nil || turn.CompletedUnixMS == nil {
+	if turn == nil {
+		return nil
+	}
+	turnNumber, turnOK := positiveHerdrInt64(turn.Turn)
+	turnEpoch, epochOK := positiveHerdrInt64(turn.TurnEpoch)
+	completedUnixMS, completedOK := positiveHerdrInt64(turn.CompletedUnixMS)
+	if !turnOK || !epochOK || !completedOK {
 		return nil
 	}
 	return &org.RoleActivity{
-		Turn:        *turn.Turn,
-		TurnEpoch:   *turn.TurnEpoch,
-		CompletedAt: time.UnixMilli(*turn.CompletedUnixMS).UTC(),
+		Turn:        turnNumber,
+		TurnEpoch:   turnEpoch,
+		CompletedAt: time.UnixMilli(completedUnixMS).UTC(),
 	}
+}
+
+func positiveHerdrInt64(value *json.Number) (int64, bool) {
+	if value == nil {
+		return 0, false
+	}
+	parsed, err := strconv.ParseInt(value.String(), 10, 64)
+	return parsed, err == nil && parsed > 0
 }
 
 // Recycle starts a fresh interactive agent in a pane that has already returned

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -177,6 +177,67 @@ func TestHerdrOrgProviderSnapshotPartialTurnIsAbsent(t *testing.T) {
 	}
 }
 
+func TestHerdrOrgProviderSnapshotInvalidTurnValuesAreAbsent(t *testing.T) {
+	tests := []struct {
+		name string
+		turn string
+	}{
+		{name: "zero turn", turn: `{"turn":0,"turn_epoch":2,"completed_unix_ms":3}`},
+		{name: "zero turn epoch", turn: `{"turn":1,"turn_epoch":0,"completed_unix_ms":3}`},
+		{name: "zero completion time", turn: `{"turn":1,"turn_epoch":2,"completed_unix_ms":0}`},
+		{name: "all zero", turn: `{"turn":0,"turn_epoch":0,"completed_unix_ms":0}`},
+		{name: "negative turn", turn: `{"turn":-1,"turn_epoch":2,"completed_unix_ms":3}`},
+		{name: "negative turn epoch", turn: `{"turn":1,"turn_epoch":-2,"completed_unix_ms":3}`},
+		{name: "negative completion time", turn: `{"turn":1,"turn_epoch":2,"completed_unix_ms":-3}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			run := func(_ context.Context, _ ...string) (string, error) {
+				return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"owner","agent_status":"working","last_completed_turn":` + test.turn + `}
+]}}}`, nil
+			}
+			provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+			snapshot, err := provider.Snapshot(context.Background())
+			if err != nil {
+				t.Fatalf("Snapshot() error = %v", err)
+			}
+			if activity := snapshot.States["owner"].Activity; activity != nil {
+				t.Fatalf("owner activity = %+v, want absent for invalid turn", activity)
+			}
+		})
+	}
+}
+
+func TestHerdrOrgProviderSnapshotOversizedUint64TurnEpochFailsClosedPerPane(t *testing.T) {
+	run := func(_ context.Context, _ ...string) (string, error) {
+		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"oversized","agent_status":"working","last_completed_turn":{"turn":1,"turn_epoch":9223372036854775808,"completed_unix_ms":3}},
+{"pane_id":"w1:p2","label":"valid","agent_status":"idle","last_completed_turn":{"turn":4,"turn_epoch":5,"completed_unix_ms":6}},
+{"pane_id":"w1:p3","label":"absent","agent_status":"blocked"}
+]}}}`, nil
+	}
+	provider := newHerdrOrgProvider(run, []config.OrgRole{
+		{Name: "oversized"}, {Name: "valid"}, {Name: "absent"},
+	}, time.Now)
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if state := snapshot.States["oversized"]; state.State != org.StateWorking || state.Activity != nil {
+		t.Errorf("oversized state = %+v, want working with absent activity", state)
+	}
+	valid := snapshot.States["valid"]
+	if valid.State != org.StateIdle || valid.Activity == nil ||
+		valid.Activity.Turn != 4 || valid.Activity.TurnEpoch != 5 ||
+		!valid.Activity.CompletedAt.Equal(time.UnixMilli(6).UTC()) {
+		t.Errorf("valid state = %+v", valid)
+	}
+	if state := snapshot.States["absent"]; state.State != org.StateBlocked || state.Activity != nil {
+		t.Errorf("absent state = %+v, want blocked with absent activity", state)
+	}
+}
+
 func TestHerdrOrgProviderFailures(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -2,6 +2,7 @@ package cockpit
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -18,7 +19,7 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 			t.Fatalf("args = %v", args)
 		}
 		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
-{"pane_id":"w1:p1","label":"owner","agent_status":"working"},
+{"pane_id":"w1:p1","label":"owner","agent_status":"working","last_completed_turn":{"turn":1,"turn_epoch":1785163074397066532,"completed_unix_ms":1785163510704}},
 {"pane_id":"w1:p2","label":"review","agent_status":"blocked"},
 {"pane_id":"w1:p3","label":"done","agent_status":"done"},
 {"pane_id":"w1:p4","label":"idle","agent_status":"idle"},
@@ -54,12 +55,25 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 	if _, inferred := snapshot.States["claude"]; inferred {
 		t.Fatal("provider inferred a runtime label that was not a configured role")
 	}
+	ownerActivity := snapshot.States["owner"].Activity
+	if ownerActivity == nil {
+		t.Fatal("owner activity is absent")
+	}
+	if ownerActivity.Turn != 1 || ownerActivity.TurnEpoch != 1785163074397066532 ||
+		!ownerActivity.CompletedAt.Equal(time.UnixMilli(1785163510704).UTC()) {
+		t.Errorf("owner activity = %+v", ownerActivity)
+	}
+	for _, role := range []string{"review", "done", "idle", "future", "duplicate", "missing"} {
+		if activity := snapshot.States[role].Activity; activity != nil {
+			t.Errorf("activity[%s] = %+v, want absent", role, activity)
+		}
+	}
 }
 
 func TestHerdrOrgProviderSnapshotPaneBindings(t *testing.T) {
 	run := func(_ context.Context, _ ...string) (string, error) {
 		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
-{"pane_id":"w1:p1","label":"Gitmoot Idle","agent_status":"idle"},
+{"pane_id":"w1:p1","label":"Gitmoot Idle","agent_status":"idle","last_completed_turn":{"turn":7,"turn_epoch":99,"completed_unix_ms":1785163510704}},
 {"pane_id":"w1:p2","label":"Gitmoot Working","agent_status":"working"},
 {"pane_id":"w1:p3","label":"Gitmoot Blocked","agent_status":"blocked"},
 {"pane_id":"w1:p4","label":"Gitmoot Done","agent_status":"done"},
@@ -107,6 +121,59 @@ func TestHerdrOrgProviderSnapshotPaneBindings(t *testing.T) {
 	}
 	if got := snapshot.States["empty-id-role"].Detail; got != `no Herdr pane bound as "Empty A"` {
 		t.Errorf("empty-id detail = %q", got)
+	}
+	if activity := snapshot.States["idle-role"].Activity; activity == nil ||
+		activity.Turn != 7 || activity.TurnEpoch != 99 ||
+		!activity.CompletedAt.Equal(time.UnixMilli(1785163510704).UTC()) {
+		t.Errorf("idle-role activity = %+v", activity)
+	}
+	for _, role := range []string{"working-role", "blocked-role", "done-role", "literal-role", "missing-role", "ambiguous-role", "empty-id-role"} {
+		if activity := snapshot.States[role].Activity; activity != nil {
+			t.Errorf("activity[%s] = %+v, want absent", role, activity)
+		}
+	}
+}
+
+func TestHerdrOrgProviderSnapshotAbsentTurnIsOmitted(t *testing.T) {
+	run := func(_ context.Context, _ ...string) (string, error) {
+		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"owner","agent_status":"idle"}
+]}}}`, nil
+	}
+	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	state := snapshot.States["owner"]
+	if state.State != org.StateIdle || state.Detail != "" {
+		t.Fatalf("owner state = %+v", state)
+	}
+	if state.Activity != nil {
+		t.Fatalf("owner activity = %+v, want absent", state.Activity)
+	}
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	if got, want := string(encoded), `{"state":"idle"}`; got != want {
+		t.Fatalf("encoded state = %s, want %s", got, want)
+	}
+}
+
+func TestHerdrOrgProviderSnapshotPartialTurnIsAbsent(t *testing.T) {
+	run := func(_ context.Context, _ ...string) (string, error) {
+		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"owner","agent_status":"working","last_completed_turn":{"turn":1,"turn_epoch":2}}
+]}}}`, nil
+	}
+	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if activity := snapshot.States["owner"].Activity; activity != nil {
+		t.Fatalf("owner activity = %+v, want absent for incomplete turn", activity)
 	}
 }
 

--- a/internal/org/provider.go
+++ b/internal/org/provider.go
@@ -16,8 +16,18 @@ const (
 )
 
 type RoleLiveState struct {
-	State  LifecycleState `json:"state"`
-	Detail string         `json:"detail,omitempty"`
+	State    LifecycleState `json:"state"`
+	Detail   string         `json:"detail,omitempty"`
+	Activity *RoleActivity  `json:"activity,omitempty"`
+}
+
+// RoleActivity identifies a completed provider turn. A nil *RoleActivity means
+// the provider did not report turn activity; callers must not treat that as a
+// zero-valued or stale turn.
+type RoleActivity struct {
+	Turn        int64     `json:"turn"`
+	TurnEpoch   int64     `json:"turn_epoch"`
+	CompletedAt time.Time `json:"completed_at"`
 }
 
 type Snapshot struct {


### PR DESCRIPTION
WHAT:
Implemented observation-only Herdr turn activity in internal/org/provider.go, internal/cockpit/herdr_org.go, and internal/cockpit/herdr_org_test.go. go build ./... and go vet ./... passed. The default go test ./... run verified every non-CLI package but internal/cli exceeded its 10-minute timeout under host contention; go test -timeout 25m ./internal/cli then passed in 634.012s, completing the package set. Absent or incomplete last_completed_turn remains Activity=nil and is omitted from JSON, never synthesized as zero activity, epoch 0, or a zero timestamp.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /tmp/g6home/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-fddca31b

RESULTS:
- go test ./internal/cockpit ./internal/org — passed
- go build ./... — passed
- go vet ./... — passed
- go test ./... — all non-CLI packages passed; internal/cli hit the default 10-minute package timeout under concurrent host load
- go test -timeout 25m ./internal/cli — passed in 634.012s
- go test ./internal/sandbox from the requested /root checkout — passed

RISK:
Review the generated diff before merging.

TASK:
adhoc-fddca31b

AGENTS:
- g6-impl-sol

RAW FINAL REVIEW OUTPUT:
````text
Implemented observation-only Herdr turn activity in internal/org/provider.go, internal/cockpit/herdr_org.go, and internal/cockpit/herdr_org_test.go. go build ./... and go vet ./... passed. The default go test ./... run verified every non-CLI package but internal/cli exceeded its 10-minute timeout under host contention; go test -timeout 25m ./internal/cli then passed in 634.012s, completing the package set. Absent or incomplete last_completed_turn remains Activity=nil and is omitted from JSON, never synthesized as zero activity, epoch 0, or a zero timestamp.
````
