### PR TITLE
feat(daemon): fail-closed disk dispatch guard (#1196)

### DIFF
--- a/internal/cli/daemon_lifecycle.go
+++ b/internal/cli/daemon_lifecycle.go
@@ -581,6 +581,7 @@ func runDaemonStatus(args []string, stdout, stderr io.Writer) int {
 		writeLine(stdout, "%s", daemonClaudeAuthLine(paths))
 	}
 	writeLine(stdout, "%s", daemonAdmissionLine(paths))
+	writeLine(stdout, "%s", daemonDiskGuardLine(paths))
 	writeLine(stdout, "%s", daemonGitHubLimiterLine(paths))
 	writeLine(stdout, "%s", daemonPreflightFailureLine(*home))
 	if line := daemonMemoryHarvestLine(paths, *home); line != "" {

--- a/internal/cli/daemon_log_test.go
+++ b/internal/cli/daemon_log_test.go
@@ -146,6 +146,9 @@ func TestDaemonStatusFreshLogPreservesExistingOutput(t *testing.T) {
 	paths := stageLiveDaemon(t, home, "dev-log-test", "logtest0")
 	stubOnDiskBuild(t, "dev-log-test", "logtest0")
 	state := daemonProcessState(paths)
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{TotalBytes: 100 << 30, FreeBytes: 20 << 30}, nil
+	})
 
 	started := time.Date(2026, 7, 27, 8, 30, 0, 0, time.UTC)
 	lastWrite := started

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -1223,6 +1223,13 @@ func listPendingQueuedJobs(ctx context.Context, worker jobWorker, repoFilter str
 	if err != nil {
 		return nil, err
 	}
+	// Both barrier and pool schedulers (including every continuous-pool re-query)
+	// pass through this exact forDispatch path immediately before selecting work.
+	// Returning an empty eligible set pauses dispatch without changing job state,
+	// so low disk is retriable and queued work resumes automatically once healthy.
+	if forDispatch && !diskGuardAllowsQueuedDispatch(ctx, worker, jobs, repoFilter, rootFilter) {
+		return nil, nil
+	}
 	unavailableRows, err := worker.Store.ListActiveOrgRolesUnavailable(ctx, time.Now().UTC())
 	if err != nil {
 		return nil, err

--- a/internal/cli/disk_guard.go
+++ b/internal/cli/disk_guard.go
@@ -15,8 +15,10 @@ import (
 )
 
 const (
-	diskGuardRefusalEventKind = "dispatch_refused_disk_guard"
-	diskGuardLogRepeat        = 15 * time.Minute
+	diskGuardRefusalEventKind  = "dispatch_refused_disk_guard"
+	diskGuardLogRepeat         = 15 * time.Minute
+	diskGuardRefusalLogKind    = "refusal"
+	diskGuardEventErrorLogKind = "event_error"
 )
 
 type diskFilesystemUsage struct {
@@ -58,6 +60,23 @@ func (e diskGuardEvaluation) detail() string {
 		e.FreePercent,
 		e.Usage.TotalBytes,
 		floors,
+	)
+}
+
+func (e diskGuardEvaluation) refusalReason() string {
+	if e.Err != nil {
+		return "measurement_unavailable"
+	}
+	return "below_configured_floor"
+}
+
+func (e diskGuardEvaluation) refusalFingerprint() string {
+	return fmt.Sprintf(
+		"path=%s reason=%s min_free_bytes=%d min_free_percent=%.2f",
+		e.Path,
+		e.refusalReason(),
+		e.Policy.MinFreeBytes,
+		e.Policy.MinFreePercent,
 	)
 }
 
@@ -128,8 +147,8 @@ func evaluateConfiguredDiskGuard(paths config.Paths) diskGuardEvaluation {
 }
 
 type diskGuardLogEntry struct {
-	detail string
-	at     time.Time
+	fingerprint string
+	at          time.Time
 }
 
 var (
@@ -137,21 +156,35 @@ var (
 	diskGuardLogEntries = map[string]diskGuardLogEntry{}
 )
 
-func shouldLogDiskGuardRefusal(path, detail string, now time.Time) bool {
+func diskGuardLogKey(kind, path string) string {
+	return kind + "\x00" + path
+}
+
+func shouldLogDiskGuard(kind, path, fingerprint string, now time.Time) bool {
 	diskGuardLogMu.Lock()
 	defer diskGuardLogMu.Unlock()
-	previous, ok := diskGuardLogEntries[path]
-	if ok && previous.detail == detail && now.Sub(previous.at) < diskGuardLogRepeat {
+	key := diskGuardLogKey(kind, path)
+	previous, ok := diskGuardLogEntries[key]
+	if ok && previous.fingerprint == fingerprint && now.Sub(previous.at) < diskGuardLogRepeat {
 		return false
 	}
-	diskGuardLogEntries[path] = diskGuardLogEntry{detail: detail, at: now}
+	diskGuardLogEntries[key] = diskGuardLogEntry{fingerprint: fingerprint, at: now}
 	return true
+}
+
+func shouldLogDiskGuardRefusal(path, fingerprint string, now time.Time) bool {
+	return shouldLogDiskGuard(diskGuardRefusalLogKind, path, fingerprint, now)
+}
+
+func shouldLogDiskGuardEventError(path, fingerprint string, now time.Time) bool {
+	return shouldLogDiskGuard(diskGuardEventErrorLogKind, path, fingerprint, now)
 }
 
 func clearDiskGuardRefusal(path string) {
 	diskGuardLogMu.Lock()
 	defer diskGuardLogMu.Unlock()
-	delete(diskGuardLogEntries, path)
+	delete(diskGuardLogEntries, diskGuardLogKey(diskGuardRefusalLogKind, path))
+	delete(diskGuardLogEntries, diskGuardLogKey(diskGuardEventErrorLogKind, path))
 }
 
 func diskGuardPaths(worker jobWorker) (config.Paths, error) {
@@ -208,17 +241,35 @@ func diskGuardAllowsQueuedDispatch(ctx context.Context, worker jobWorker, jobs [
 	}
 
 	detail := evaluation.detail()
-	if shouldLogDiskGuardRefusal(evaluation.Path, detail, time.Now()) {
+	fingerprint := evaluation.refusalFingerprint()
+	now := time.Now()
+	if shouldLogDiskGuardRefusal(evaluation.Path, fingerprint, now) {
 		writeLine(worker.Stdout, "DISK GUARD REFUSED JOB DISPATCH: %s", detail)
 	}
+	failedEventWrites := 0
+	var firstEventWriteErr error
 	for _, job := range matching {
 		if err := worker.Store.AddJobEventIfAbsent(ctx, db.JobEvent{
 			JobID:   job.ID,
 			Kind:    diskGuardRefusalEventKind,
 			Message: detail,
 		}); err != nil {
-			writeLine(worker.Stdout, "DISK GUARD event write failed for job %s: %v", job.ID, err)
+			failedEventWrites++
+			if firstEventWriteErr == nil {
+				firstEventWriteErr = err
+			}
 		}
+	}
+	if failedEventWrites > 0 && shouldLogDiskGuardEventError(evaluation.Path, fingerprint, now) {
+		writeLine(
+			worker.Stdout,
+			"DISK GUARD event writes failed: failed=%d matching_jobs=%d path=%s reason=%s first_error=%v",
+			failedEventWrites,
+			len(matching),
+			evaluation.Path,
+			evaluation.refusalReason(),
+			firstEventWriteErr,
+		)
 	}
 	return false
 }

--- a/internal/cli/disk_guard.go
+++ b/internal/cli/disk_guard.go
@@ -1,0 +1,236 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+const (
+	diskGuardRefusalEventKind = "dispatch_refused_disk_guard"
+	diskGuardLogRepeat        = 15 * time.Minute
+)
+
+type diskFilesystemUsage struct {
+	TotalBytes uint64
+	FreeBytes  uint64
+}
+
+type diskGuardEvaluation struct {
+	Path        string
+	Policy      config.DiskGuardPolicy
+	Usage       diskFilesystemUsage
+	FreePercent float64
+	Err         error
+}
+
+func (e diskGuardEvaluation) allowsDispatch() bool {
+	if !e.Policy.Enabled {
+		return true
+	}
+	if e.Err != nil {
+		return false
+	}
+	return e.Usage.FreeBytes >= e.Policy.MinFreeBytes &&
+		e.FreePercent >= e.Policy.MinFreePercent
+}
+
+func (e diskGuardEvaluation) detail() string {
+	if !e.Policy.Enabled {
+		return fmt.Sprintf("path=%s disabled", e.Path)
+	}
+	floors := fmt.Sprintf("min_free_bytes=%d min_free_percent=%.2f", e.Policy.MinFreeBytes, e.Policy.MinFreePercent)
+	if e.Err != nil {
+		return fmt.Sprintf("path=%s free_bytes=unknown free_percent=unknown %s error=%v", e.Path, floors, e.Err)
+	}
+	return fmt.Sprintf(
+		"path=%s free_bytes=%d free_percent=%.2f total_bytes=%d %s",
+		e.Path,
+		e.Usage.FreeBytes,
+		e.FreePercent,
+		e.Usage.TotalBytes,
+		floors,
+	)
+}
+
+var measureDiskGuardFilesystem = statfsDiskGuardFilesystem
+
+func statfsDiskGuardFilesystem(path string) (diskFilesystemUsage, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return diskFilesystemUsage{}, fmt.Errorf("filesystem path is empty")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return diskFilesystemUsage{}, fmt.Errorf("resolve filesystem path %q: %w", path, err)
+	}
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(absolute, &stat); err != nil {
+		return diskFilesystemUsage{}, fmt.Errorf("statfs %s: %w", absolute, err)
+	}
+	if stat.Bsize <= 0 {
+		return diskFilesystemUsage{}, fmt.Errorf("statfs %s returned invalid block size %d", absolute, stat.Bsize)
+	}
+	blockSize := uint64(stat.Bsize)
+	totalBlocks := uint64(stat.Blocks)
+	freeBlocks := uint64(stat.Bavail)
+	if totalBlocks == 0 {
+		return diskFilesystemUsage{}, fmt.Errorf("statfs %s returned zero total blocks", absolute)
+	}
+	if freeBlocks > totalBlocks {
+		return diskFilesystemUsage{}, fmt.Errorf("statfs %s returned available blocks greater than total blocks", absolute)
+	}
+	if totalBlocks > math.MaxUint64/blockSize || freeBlocks > math.MaxUint64/blockSize {
+		return diskFilesystemUsage{}, fmt.Errorf("statfs %s byte count overflows uint64", absolute)
+	}
+	return diskFilesystemUsage{
+		TotalBytes: totalBlocks * blockSize,
+		FreeBytes:  freeBlocks * blockSize,
+	}, nil
+}
+
+func evaluateConfiguredDiskGuard(paths config.Paths) diskGuardEvaluation {
+	path := paths.Home
+	if absolute, err := filepath.Abs(path); err == nil {
+		path = absolute
+	}
+	policy, err := config.LoadDiskGuardPolicy(paths)
+	if err != nil {
+		return diskGuardEvaluation{
+			Path:   path,
+			Policy: config.DefaultDiskGuardPolicy(),
+			Err:    fmt.Errorf("load policy: %w", err),
+		}
+	}
+	evaluation := diskGuardEvaluation{Path: path, Policy: policy}
+	if !policy.Enabled {
+		return evaluation
+	}
+	usage, err := measureDiskGuardFilesystem(path)
+	if err != nil {
+		evaluation.Err = err
+		return evaluation
+	}
+	evaluation.Usage = usage
+	evaluation.FreePercent = float64(usage.FreeBytes) / float64(usage.TotalBytes) * 100
+	if math.IsNaN(evaluation.FreePercent) || math.IsInf(evaluation.FreePercent, 0) {
+		evaluation.Err = fmt.Errorf("free-space percentage is not finite")
+	}
+	return evaluation
+}
+
+type diskGuardLogEntry struct {
+	detail string
+	at     time.Time
+}
+
+var (
+	diskGuardLogMu      sync.Mutex
+	diskGuardLogEntries = map[string]diskGuardLogEntry{}
+)
+
+func shouldLogDiskGuardRefusal(path, detail string, now time.Time) bool {
+	diskGuardLogMu.Lock()
+	defer diskGuardLogMu.Unlock()
+	previous, ok := diskGuardLogEntries[path]
+	if ok && previous.detail == detail && now.Sub(previous.at) < diskGuardLogRepeat {
+		return false
+	}
+	diskGuardLogEntries[path] = diskGuardLogEntry{detail: detail, at: now}
+	return true
+}
+
+func clearDiskGuardRefusal(path string) {
+	diskGuardLogMu.Lock()
+	defer diskGuardLogMu.Unlock()
+	delete(diskGuardLogEntries, path)
+}
+
+func diskGuardPaths(worker jobWorker) (config.Paths, error) {
+	if worker.Store == nil {
+		return worker.configPaths()
+	}
+	storeHome := filepath.Dir(worker.Store.DatabasePath())
+	if !worker.ConfigHomeExplicit && strings.TrimSpace(worker.ConfigHome) == "" {
+		return config.Paths{
+			Home:       storeHome,
+			ConfigFile: filepath.Join(storeHome, config.ConfigName),
+		}, nil
+	}
+	paths, err := worker.configPaths()
+	if err != nil {
+		return config.Paths{}, err
+	}
+	// The opened store is the authoritative resolved Gitmoot home. Measuring its
+	// parent filesystem covers the database and the sibling worktree roots even
+	// if a caller supplied a relative raw --home.
+	paths.Home = storeHome
+	return paths, nil
+}
+
+// diskGuardAllowsQueuedDispatch is called only by the normal queued-job
+// dispatch listing. Daemon maintenance and reconciliation do not pass through
+// this function, so future in-process reclaim remains able to free disk while
+// agent dispatch is paused.
+func diskGuardAllowsQueuedDispatch(ctx context.Context, worker jobWorker, jobs []db.Job, repoFilter, rootFilter string) bool {
+	matching := make([]db.Job, 0, len(jobs))
+	for _, job := range jobs {
+		if queuedJobMatchesRepo(job, repoFilter) && queuedJobMatchesSession(job, rootFilter) {
+			matching = append(matching, job)
+		}
+	}
+	if len(matching) == 0 {
+		return true
+	}
+
+	paths, err := diskGuardPaths(worker)
+	var evaluation diskGuardEvaluation
+	if err != nil {
+		evaluation = diskGuardEvaluation{
+			Path:   strings.TrimSpace(worker.ConfigHome),
+			Policy: config.DefaultDiskGuardPolicy(),
+			Err:    fmt.Errorf("resolve Gitmoot home: %w", err),
+		}
+	} else {
+		evaluation = evaluateConfiguredDiskGuard(paths)
+	}
+	if evaluation.allowsDispatch() {
+		clearDiskGuardRefusal(evaluation.Path)
+		return true
+	}
+
+	detail := evaluation.detail()
+	if shouldLogDiskGuardRefusal(evaluation.Path, detail, time.Now()) {
+		writeLine(worker.Stdout, "DISK GUARD REFUSED JOB DISPATCH: %s", detail)
+	}
+	for _, job := range matching {
+		if err := worker.Store.AddJobEventIfAbsent(ctx, db.JobEvent{
+			JobID:   job.ID,
+			Kind:    diskGuardRefusalEventKind,
+			Message: detail,
+		}); err != nil {
+			writeLine(worker.Stdout, "DISK GUARD event write failed for job %s: %v", job.ID, err)
+		}
+	}
+	return false
+}
+
+func daemonDiskGuardLine(paths config.Paths) string {
+	evaluation := evaluateConfiguredDiskGuard(paths)
+	switch {
+	case !evaluation.Policy.Enabled:
+		return "disk guard: disabled, " + evaluation.detail()
+	case evaluation.allowsDispatch():
+		return "disk guard: healthy, " + evaluation.detail()
+	default:
+		return "disk guard: UNHEALTHY, dispatch paused, " + evaluation.detail()
+	}
+}

--- a/internal/cli/disk_guard_test.go
+++ b/internal/cli/disk_guard_test.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func diskGuardDispatchFixture(t *testing.T) (context.Context, *db.Store, config.Paths, jobWorker) {
+	t.Helper()
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatalf("Open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	job := db.Job{
+		ID:      "disk-guard-job",
+		Agent:   "worker",
+		Type:    "ask",
+		State:   string(workflow.JobQueued),
+		Payload: `{"repo":"owner/repo"}`,
+	}
+	if err := store.CreateJobWithEvent(ctx, job, db.JobEvent{Kind: string(workflow.JobQueued), Message: "seed"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	return ctx, store, paths, defaultJobWorker(store, io.Discard, home)
+}
+
+func replaceDiskGuardMeasurement(t *testing.T, fn func(string) (diskFilesystemUsage, error)) {
+	t.Helper()
+	original := measureDiskGuardFilesystem
+	measureDiskGuardFilesystem = fn
+	t.Cleanup(func() {
+		measureDiskGuardFilesystem = original
+		diskGuardLogMu.Lock()
+		diskGuardLogEntries = map[string]diskGuardLogEntry{}
+		diskGuardLogMu.Unlock()
+	})
+}
+
+func TestDispatchDiskGuardFailsClosedOnStatfsError(t *testing.T) {
+	ctx, store, paths, worker := diskGuardDispatchFixture(t)
+	var output bytes.Buffer
+	worker.Stdout = &output
+	var measuredPath string
+	replaceDiskGuardMeasurement(t, func(path string) (diskFilesystemUsage, error) {
+		measuredPath = path
+		return diskFilesystemUsage{}, errors.New("injected statfs failure")
+	})
+
+	pending, err := listPendingQueuedJobs(ctx, worker, "owner/repo", "", true)
+	if err != nil {
+		t.Fatalf("listPendingQueuedJobs: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("pending jobs = %d, want 0 while disk state is unknown", len(pending))
+	}
+	if measuredPath != paths.Home {
+		t.Fatalf("measured path = %q, want Gitmoot home %q", measuredPath, paths.Home)
+	}
+	job, err := store.GetJob(ctx, "disk-guard-job")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state = %q, want queued", job.State)
+	}
+	for _, want := range []string{
+		"DISK GUARD REFUSED JOB DISPATCH",
+		"path=" + paths.Home,
+		"free_bytes=unknown",
+		"min_free_bytes=2147483648",
+		"min_free_percent=5.00",
+		"injected statfs failure",
+	} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("dispatch log missing %q:\n%s", want, output.String())
+		}
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	found := false
+	for _, event := range events {
+		if event.Kind == diskGuardRefusalEventKind {
+			found = strings.Contains(event.Message, "free_bytes=unknown") &&
+				strings.Contains(event.Message, "injected statfs failure") &&
+				strings.Contains(event.Message, "path="+paths.Home)
+		}
+	}
+	if !found {
+		t.Fatalf("missing detailed %s event: %+v", diskGuardRefusalEventKind, events)
+	}
+}
+
+func TestDispatchDiskGuardLowSpaceThenAutomaticRecovery(t *testing.T) {
+	ctx, store, paths, worker := diskGuardDispatchFixture(t)
+	var output bytes.Buffer
+	worker.Stdout = &output
+	usage := diskFilesystemUsage{
+		TotalBytes: 100 << 30,
+		FreeBytes:  1 << 30,
+	}
+	replaceDiskGuardMeasurement(t, func(path string) (diskFilesystemUsage, error) {
+		if path != filepath.Clean(paths.Home) {
+			t.Fatalf("measured path = %q, want %q", path, paths.Home)
+		}
+		return usage, nil
+	})
+
+	pending, err := listPendingQueuedJobs(ctx, worker, "owner/repo", "", true)
+	if err != nil {
+		t.Fatalf("low-space listPendingQueuedJobs: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("low-space pending jobs = %d, want 0", len(pending))
+	}
+	if !strings.Contains(output.String(), "free_bytes=1073741824") ||
+		!strings.Contains(output.String(), "free_percent=1.00") {
+		t.Fatalf("low-space log lacks measured values:\n%s", output.String())
+	}
+
+	usage.FreeBytes = 20 << 30
+	pending, err = listPendingQueuedJobs(ctx, worker, "owner/repo", "", true)
+	if err != nil {
+		t.Fatalf("recovered listPendingQueuedJobs: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != "disk-guard-job" {
+		t.Fatalf("healthy pending jobs = %+v, want original queued job", pending)
+	}
+	job, err := store.GetJob(ctx, "disk-guard-job")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	if job.State != string(workflow.JobQueued) {
+		t.Fatalf("job state after recovery = %q, want queued until normal dispatcher claims it", job.State)
+	}
+}
+
+func TestDiskGuardUsesMoreConservativeConfiguredFloor(t *testing.T) {
+	evaluation := diskGuardEvaluation{
+		Policy: config.DiskGuardPolicy{
+			Enabled:        true,
+			MinFreeBytes:   100,
+			MinFreePercent: 10,
+		},
+		Usage:       diskFilesystemUsage{TotalBytes: 2000, FreeBytes: 150},
+		FreePercent: 7.5,
+	}
+	if evaluation.allowsDispatch() {
+		t.Fatal("percent floor failed but dispatch was allowed")
+	}
+	evaluation.Usage = diskFilesystemUsage{TotalBytes: 1000, FreeBytes: 90}
+	evaluation.FreePercent = 9
+	if evaluation.allowsDispatch() {
+		t.Fatal("byte and percent floors failed but dispatch was allowed")
+	}
+	evaluation.Usage = diskFilesystemUsage{TotalBytes: 1000, FreeBytes: 150}
+	evaluation.FreePercent = 15
+	if !evaluation.allowsDispatch() {
+		t.Fatal("both floors passed but dispatch was refused")
+	}
+}
+
+func TestDaemonDiskGuardLineReportsHealthyAndUnhealthy(t *testing.T) {
+	paths := config.PathsForHome(t.TempDir())
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{TotalBytes: 100 << 30, FreeBytes: 20 << 30}, nil
+	})
+	if line := daemonDiskGuardLine(paths); !strings.Contains(line, "disk guard: healthy") ||
+		!strings.Contains(line, "free_bytes=21474836480") {
+		t.Fatalf("healthy status line = %q", line)
+	}
+
+	measureDiskGuardFilesystem = func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{}, errors.New("status probe denied")
+	}
+	if line := daemonDiskGuardLine(paths); !strings.Contains(line, "UNHEALTHY") ||
+		!strings.Contains(line, "dispatch paused") ||
+		!strings.Contains(line, "status probe denied") {
+		t.Fatalf("unhealthy status line = %q", line)
+	}
+}

--- a/internal/cli/disk_guard_test.go
+++ b/internal/cli/disk_guard_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -152,6 +153,70 @@ func TestDispatchDiskGuardLowSpaceThenAutomaticRecovery(t *testing.T) {
 	}
 }
 
+func TestDispatchDiskGuardRateLimitIgnoresFluctuatingMeasurements(t *testing.T) {
+	ctx, _, _, worker := diskGuardDispatchFixture(t)
+	var output bytes.Buffer
+	worker.Stdout = &output
+	measurements := []diskFilesystemUsage{
+		{TotalBytes: 100 << 30, FreeBytes: 1 << 30},
+		// This clears the byte floor but remains below the percentage floor.
+		// Crossing one threshold must not turn a continuing refusal into a new
+		// log identity.
+		{TotalBytes: 100 << 30, FreeBytes: 3 << 30},
+	}
+	measurement := 0
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		usage := measurements[measurement]
+		measurement++
+		return usage, nil
+	})
+
+	for range measurements {
+		pending, err := listPendingQueuedJobs(ctx, worker, "owner/repo", "", true)
+		if err != nil {
+			t.Fatalf("listPendingQueuedJobs: %v", err)
+		}
+		if len(pending) != 0 {
+			t.Fatalf("pending jobs = %d, want 0 below disk floor", len(pending))
+		}
+	}
+
+	if got := strings.Count(output.String(), "DISK GUARD REFUSED JOB DISPATCH:"); got != 1 {
+		t.Fatalf("refusal log count = %d, want 1 across fluctuating measurements:\n%s", got, output.String())
+	}
+}
+
+func TestDispatchDiskGuardAggregatesAndRateLimitsEventWriteFailures(t *testing.T) {
+	ctx, store, _, worker := diskGuardDispatchFixture(t)
+	var output bytes.Buffer
+	worker.Stdout = &output
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{TotalBytes: 100 << 30, FreeBytes: 1 << 30}, nil
+	})
+	jobs := []db.Job{
+		{ID: "disk-guard-job-1", State: string(workflow.JobQueued), Payload: `{"repo":"owner/repo"}`},
+		{ID: "disk-guard-job-2", State: string(workflow.JobQueued), Payload: `{"repo":"owner/repo"}`},
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close store: %v", err)
+	}
+
+	for range 2 {
+		if diskGuardAllowsQueuedDispatch(ctx, worker, jobs, "owner/repo", "") {
+			t.Fatal("dispatch allowed below disk floor")
+		}
+	}
+
+	if got := strings.Count(output.String(), "DISK GUARD event writes failed:"); got != 1 {
+		t.Fatalf("event-write failure log count = %d, want 1 summary across repeated passes:\n%s", got, output.String())
+	}
+	for _, want := range []string{"failed=2", "matching_jobs=2"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("event-write failure summary missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
 func TestDiskGuardUsesMoreConservativeConfiguredFloor(t *testing.T) {
 	evaluation := diskGuardEvaluation{
 		Policy: config.DiskGuardPolicy{
@@ -174,6 +239,43 @@ func TestDiskGuardUsesMoreConservativeConfiguredFloor(t *testing.T) {
 	evaluation.FreePercent = 15
 	if !evaluation.allowsDispatch() {
 		t.Fatal("both floors passed but dispatch was refused")
+	}
+}
+
+func TestDiskGuardStableFingerprintChangesOnlyWithReasonOrFloor(t *testing.T) {
+	t.Cleanup(func() {
+		diskGuardLogMu.Lock()
+		diskGuardLogEntries = map[string]diskGuardLogEntry{}
+		diskGuardLogMu.Unlock()
+	})
+	base := diskGuardEvaluation{
+		Path:        "/tmp/gitmoot",
+		Policy:      config.DiskGuardPolicy{Enabled: true, MinFreeBytes: 100, MinFreePercent: 10},
+		Usage:       diskFilesystemUsage{TotalBytes: 1000, FreeBytes: 50},
+		FreePercent: 5,
+	}
+	fingerprint := base.refusalFingerprint()
+	base.Usage.FreeBytes = 40
+	base.FreePercent = 4
+	if got := base.refusalFingerprint(); got != fingerprint {
+		t.Fatalf("measurement changed fingerprint:\nfirst: %s\nsecond: %s", fingerprint, got)
+	}
+	base.Policy.MinFreeBytes++
+	if got := base.refusalFingerprint(); got == fingerprint {
+		t.Fatalf("floor change did not change fingerprint: %s", got)
+	}
+	base.Policy.MinFreeBytes--
+	base.Err = errors.New("measurement failed")
+	if got := base.refusalFingerprint(); got == fingerprint {
+		t.Fatalf("reason change did not change fingerprint: %s", got)
+	}
+
+	now := time.Now()
+	if !shouldLogDiskGuardRefusal("/tmp/gitmoot", fingerprint, now) {
+		t.Fatal("first refusal was suppressed")
+	}
+	if shouldLogDiskGuardRefusal("/tmp/gitmoot", fingerprint, now.Add(time.Minute)) {
+		t.Fatal("matching stable fingerprint was not suppressed")
 	}
 }
 

--- a/internal/config/disk_guard.go
+++ b/internal/config/disk_guard.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// DefaultDiskGuardMinFreeBytes leaves enough absolute headroom for SQLite,
+	// logs, and ordinary checkout growth on small filesystems.
+	DefaultDiskGuardMinFreeBytes uint64 = 2 << 30
+	// DefaultDiskGuardMinFreePercent scales the floor on larger filesystems where
+	// a fixed byte reserve would be too small relative to agent cache growth.
+	DefaultDiskGuardMinFreePercent = 5.0
+)
+
+// DiskGuardPolicy controls the default-on dispatch guard for the filesystem
+// holding the Gitmoot home and its worktrees.
+type DiskGuardPolicy struct {
+	Enabled        bool
+	MinFreeBytes   uint64
+	MinFreePercent float64
+}
+
+func DefaultDiskGuardPolicy() DiskGuardPolicy {
+	return DiskGuardPolicy{
+		Enabled:        true,
+		MinFreeBytes:   DefaultDiskGuardMinFreeBytes,
+		MinFreePercent: DefaultDiskGuardMinFreePercent,
+	}
+}
+
+// LoadDiskGuardPolicy reads the independent [disk_guard] section. Missing
+// configuration keeps the guard enabled with conservative defaults.
+func LoadDiskGuardPolicy(paths Paths) (DiskGuardPolicy, error) {
+	policy := DefaultDiskGuardPolicy()
+	content, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return policy, nil
+		}
+		return DiskGuardPolicy{}, fmt.Errorf("read disk guard config: %w", err)
+	}
+
+	current := ""
+	for _, raw := range strings.Split(string(content), "\n") {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			if strings.HasSuffix(line, "]") {
+				current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]"))
+			} else {
+				current = ""
+			}
+			continue
+		}
+		if current != "disk_guard" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		switch key {
+		case "enabled":
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return DiskGuardPolicy{}, fmt.Errorf("parse [disk_guard].enabled: %w", err)
+			}
+			policy.Enabled = parsed
+		case "min_free_bytes":
+			parsed, err := strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return DiskGuardPolicy{}, fmt.Errorf("parse [disk_guard].min_free_bytes: %w", err)
+			}
+			policy.MinFreeBytes = parsed
+		case "min_free_percent":
+			parsed, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				return DiskGuardPolicy{}, fmt.Errorf("parse [disk_guard].min_free_percent: %w", err)
+			}
+			policy.MinFreePercent = parsed
+		}
+	}
+	if err := validateDiskGuardPolicy(policy); err != nil {
+		return DiskGuardPolicy{}, err
+	}
+	return policy, nil
+}
+
+func validateDiskGuardPolicy(policy DiskGuardPolicy) error {
+	if math.IsNaN(policy.MinFreePercent) || math.IsInf(policy.MinFreePercent, 0) ||
+		policy.MinFreePercent < 0 || policy.MinFreePercent > 100 {
+		return fmt.Errorf("disk_guard.min_free_percent must be between 0 and 100")
+	}
+	if policy.Enabled && policy.MinFreeBytes == 0 && policy.MinFreePercent == 0 {
+		return fmt.Errorf("disk_guard requires min_free_bytes or min_free_percent when enabled")
+	}
+	return nil
+}

--- a/internal/config/disk_guard_test.go
+++ b/internal/config/disk_guard_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadDiskGuardPolicyDefaultsEnabled(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	got, err := LoadDiskGuardPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadDiskGuardPolicy: %v", err)
+	}
+	if got != DefaultDiskGuardPolicy() {
+		t.Fatalf("policy = %+v, want %+v", got, DefaultDiskGuardPolicy())
+	}
+	if !got.Enabled {
+		t.Fatal("default disk guard must be enabled")
+	}
+}
+
+func TestLoadDiskGuardPolicyParsesSection(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[disk_guard]
+enabled = true
+min_free_bytes = 123456
+min_free_percent = 12.5
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadDiskGuardPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadDiskGuardPolicy: %v", err)
+	}
+	if !got.Enabled || got.MinFreeBytes != 123456 || got.MinFreePercent != 12.5 {
+		t.Fatalf("policy = %+v", got)
+	}
+}
+
+func TestLoadDiskGuardPolicyValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "bad boolean", body: "enabled = maybe", want: "enabled"},
+		{name: "negative bytes", body: "min_free_bytes = -1", want: "min_free_bytes"},
+		{name: "percent too high", body: "min_free_percent = 101", want: "between 0 and 100"},
+		{name: "no enabled floor", body: "min_free_bytes = 0\nmin_free_percent = 0", want: "requires"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := os.MkdirAll(paths.Home, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(paths.ConfigFile, []byte("[disk_guard]\n"+tc.body+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := LoadDiskGuardPolicy(paths)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -76,6 +76,15 @@ artifact_blobs = %q
 # enabled = true
 # dir = "/root/.gitmoot/cache/tools" # default: "<home>/cache/tools"
 
+# [disk_guard] prevents normal agent dispatch when the filesystem holding the
+# Gitmoot home/worktrees is below either configured free-space floor. It is
+# enabled by default. When both floors are non-zero, both must pass (the more
+# conservative floor wins). Set enabled=false only for an explicit opt-out.
+# [disk_guard]
+# enabled = true
+# min_free_bytes = 2147483648 # 2 GiB
+# min_free_percent = 5
+
 # [daemon] is the OPTIONAL warm-reloadable runtime config (issue #577). CLI flags to
 # "daemon start" / "daemon run" remain the initial value; a key here is applied only
 # where the matching flag was NOT passed (flag = override). Its real purpose is WARM

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -416,6 +416,31 @@ parallelism, `idle_grace_ticks`, `idle_max_multiplier`) live (#577) — no teard
 re-inheritance. Values pinned by explicit launch flags win over the re-read
 config. Prefer SIGHUP over a restart when only tuning throughput.
 
+The default-on `[disk_guard]` section pauses normal queued-job dispatch when the
+filesystem holding the Gitmoot home and worktrees has less than either
+`min_free_bytes` (default `2147483648`, 2 GiB) or `min_free_percent` (default
+`5`) available. Both checks apply when both are non-zero, so the more
+conservative floor wins:
+
+```toml
+[disk_guard]
+enabled = true
+min_free_bytes = 2147483648
+min_free_percent = 5
+```
+
+The guard fails closed: an unreadable config, missing path, `statfs` error, or
+invalid filesystem measurement pauses dispatch instead of assuming the disk is
+healthy. Paused jobs remain `queued` and retry automatically on the next healthy
+daemon pass. The daemon writes a greppable
+`DISK GUARD REFUSED JOB DISPATCH` log and a
+`dispatch_refused_disk_guard` job event containing the measured free space,
+configured floors, and measured path. `gitmoot daemon status` always reports the
+current measurement and prints `UNHEALTHY, dispatch paused` when the measurement
+cannot be established or a floor is breached. The guard applies only to normal
+agent-job dispatch; daemon maintenance/reconciliation remains runnable so an
+internal reclaim pass can free space.
+
 Claude runtime auth is independent of daemon restarts. Use `gitmoot auth set
 claude` to rotate the owner-only `runtime-auth.env`; the next delivery observes
 it. Use `gitmoot auth unset claude` to write the explicit-empty state. Do not

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -326,6 +326,31 @@ jobs, no environment re-inheritance. Values pinned by explicit launch flags win
 over the re-read config. Prefer SIGHUP over a restart when only tuning
 throughput.
 
+The default-on `[disk_guard]` section pauses normal queued-job dispatch when the
+filesystem holding the Gitmoot home and worktrees has less than either
+`min_free_bytes` (default `2147483648`, 2 GiB) or `min_free_percent` (default
+`5`) available. Both checks apply when both are non-zero, so the more
+conservative floor wins:
+
+```toml
+[disk_guard]
+enabled = true
+min_free_bytes = 2147483648
+min_free_percent = 5
+```
+
+The guard fails closed: an unreadable config, missing path, `statfs` error, or
+invalid filesystem measurement pauses dispatch instead of assuming the disk is
+healthy. Paused jobs remain `queued` and retry automatically on the next healthy
+daemon pass. The daemon writes a greppable
+`DISK GUARD REFUSED JOB DISPATCH` log and a
+`dispatch_refused_disk_guard` job event containing the measured free space,
+configured floors, and measured path. `gitmoot daemon status` always reports the
+current measurement and prints `UNHEALTHY, dispatch paused` when the measurement
+cannot be established or a floor is breached. The guard applies only to normal
+agent-job dispatch; daemon maintenance/reconciliation remains runnable so an
+internal reclaim pass can free space.
+
 ### Claude Runtime Auth
 
 Claude runtime auth lives in owner-only (0600) `runtime-auth.env` and is re-read


### PR DESCRIPTION
Implements the fail-closed disk dispatch guard — part 1 of #1196.

The daemon refuses to dispatch below a disk floor rather than dispatching into a full filesystem. Overnight on 2026-07-27, `/` hit 100%, Postgres dropped into crash recovery and two joltra services crash-looped at ~30 restarts/min. A guard converts that into a loud refusal.

**Fail-closed is the point.** A guard that soft-degrades when it cannot stat the filesystem would report healthy while providing nothing — the same defect class refused three times in this batch (#1142's hold, #1173's flag, #1206's org chart rendering a status it has no basis for).

Closes #1196 partially — parts 2 (share the dep cache, checking whether #1113's shared host tool cache extends) and 3 (reclaim on terminal job state, coordinating with #1157's lifecycle seam) remain.

**Reviewer note — the gate is currently broken on this host, use these commands:**

```sh
export GOTOOLCHAIN=local PATH=/root/.local/toolchains/go1.26.4/bin:$PATH
go build -buildvcs=false ./... ; echo "build=$?"   # #1209: plain go build fails in a linked worktree
go vet ./... ; echo "vet=$?"
go test -timeout 1800s ./internal/... ; echo "test=$?"  # #1210: internal/cli exceeds Go's 600s default
```

Do not pipe the gate through `tail` — that captures tail's exit status and reports a red suite as green.