### PR TITLE
Gitmoot: SET GOFLAGS=-buildvcs=false IN THE RUNTIME SEAT ENVIRONMENT for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,9 @@ go test -timeout 25m ./...
 )
 ```
 
+Managed-worktree runtime seats append `-buildvcs=false` to inherited `GOFLAGS`
+so stray ancestor `.git` directories cannot confuse Go's VCS root detection.
+
 The explicit temporary `GOCACHE` is also part of the host setup. Managed
 worktrees can inherit a read-only `/root/.cache/go-build`; redirecting the cache
 keeps build, vet, and test from failing during package setup before compilation.

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -574,6 +574,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	}
 	writeLine(w.Stdout, "running job %s for %s in %s", job.ID, agent.Name, payload.Repo)
 	adapter = pipeline.WrapPipelineEnvDeliveryAdapter(w.Store, w.ConfigHome, payload, adapter)
+	adapter = wrapManagedWorktreeRuntimeEnv(payload, adapter)
 	engine := w.WorkflowFactory(checkout)
 	// Wire the PRE-TERMINAL operational-blocker deferrer (#532 slice E) on the LIVE
 	// worker (not the WorkflowFactory-captured copy) so it observes this worker's
@@ -1706,6 +1707,7 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 			defer func() { _ = retainedLogFile.Close() }()
 		}
 	}
+	adapter = wrapManagedWorktreeRuntimeEnv(payload, adapter)
 	if err := w.Store.MarkAgentInstanceRunning(ctx, started.Agent.Name, time.Now().UTC(), started.JobTimeout); err != nil {
 		if finishErr := w.finishQueuedJob(ctx, delegatedJob.ID, workflow.JobFailed, err); finishErr != nil {
 			return finishErr

--- a/internal/cli/managed_worktree_env.go
+++ b/internal/cli/managed_worktree_env.go
@@ -1,0 +1,62 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const managedWorktreeBuildVCSFlag = "-buildvcs=false"
+
+type managedWorktreeEnvAdapter struct {
+	inner            workflow.DeliveryAdapter
+	inheritedGoFlags string
+}
+
+func wrapManagedWorktreeRuntimeEnv(payload workflow.JobPayload, adapter workflow.DeliveryAdapter) workflow.DeliveryAdapter {
+	if adapter == nil || strings.TrimSpace(payload.WorktreePath) == "" {
+		return adapter
+	}
+	return managedWorktreeEnvAdapter{inner: adapter, inheritedGoFlags: os.Getenv("GOFLAGS")}
+}
+
+func (a managedWorktreeEnvAdapter) Deliver(ctx context.Context, agent runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	job.AgentEnv = appendManagedWorktreeGoFlags(job.AgentEnv, a.inheritedGoFlags)
+	job.ShellEnv = appendManagedWorktreeGoFlags(job.ShellEnv, a.inheritedGoFlags)
+	return a.inner.Deliver(ctx, agent, job)
+}
+
+func appendManagedWorktreeGoFlags(env []string, inherited string) []string {
+	effective := inherited
+	last := -1
+	for i, entry := range env {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && name == "GOFLAGS" {
+			effective = value
+			last = i
+		}
+	}
+	if !containsGoFlag(effective, managedWorktreeBuildVCSFlag) {
+		effective = strings.TrimSpace(effective + " " + managedWorktreeBuildVCSFlag)
+	}
+
+	out := append([]string(nil), env...)
+	entry := "GOFLAGS=" + effective
+	if last >= 0 {
+		out[last] = entry
+		return out
+	}
+	return append(out, entry)
+}
+
+func containsGoFlag(value, want string) bool {
+	for _, flag := range strings.Fields(value) {
+		if flag == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/managed_worktree_env_test.go
+++ b/internal/cli/managed_worktree_env_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+type managedWorktreeEnvCaptureAdapter struct {
+	jobs []runtime.Job
+}
+
+func (a *managedWorktreeEnvCaptureAdapter) Deliver(_ context.Context, _ runtime.Agent, job runtime.Job) (runtime.Result, error) {
+	a.jobs = append(a.jobs, job)
+	return runtime.Result{}, nil
+}
+
+func TestManagedWorktreeRuntimeEnvContainsBuildVCSFlag(t *testing.T) {
+	t.Setenv("GOFLAGS", "-mod=readonly")
+	capture := &managedWorktreeEnvCaptureAdapter{}
+	adapter := wrapManagedWorktreeRuntimeEnv(
+		workflow.JobPayload{WorktreePath: t.TempDir()},
+		capture,
+	)
+
+	_, err := adapter.Deliver(context.Background(), runtime.Agent{}, runtime.Job{
+		AgentEnv: []string{"GOFLAGS=-trimpath"},
+		ShellEnv: []string{"SHELL_MARKER=1"},
+	})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if len(capture.jobs) != 1 {
+		t.Fatalf("deliveries = %d, want 1", len(capture.jobs))
+	}
+	if got, want := capture.jobs[0].AgentEnv, []string{"GOFLAGS=-trimpath -buildvcs=false"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("AgentEnv = %#v, want %#v", got, want)
+	}
+	if got, want := capture.jobs[0].ShellEnv, []string{"SHELL_MARKER=1", "GOFLAGS=-mod=readonly -buildvcs=false"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ShellEnv = %#v, want %#v", got, want)
+	}
+}


### PR DESCRIPTION
WHAT:
Managed-worktree runtime seats now receive GOFLAGS with -buildvcs=false. Changes remain uncommitted for the finalizer; current base HEAD is 94b35f22343a87f66ce50b83af0186294cb05414.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-592ff286

RESULTS:
- Focused unit test: PASS
- go build -buildvcs=false ./...: build=0
- go vet ./...: vet=0
- go test -timeout 1800s -skip 'TestClaudeProduceHookAutoReadLandlockE2E|TestSandboxExecKernelE2E|TestSandboxProbeSupported' ./internal/cli/: test=0 (662.859s)
- git diff --check: 0

RISK:
Review the generated diff before merging.

TASK:
adhoc-592ff286

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Managed-worktree runtime seats now receive GOFLAGS with -buildvcs=false. Changes remain uncommitted for the finalizer; current base HEAD is 94b35f22343a87f66ce50b83af0186294cb05414.
````
