### PR TITLE
feat(cockpit): surface herdr pane activity — successor to #1190 (#1108 item 3, slice 1)

### DIFF
--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -45,10 +45,17 @@ type herdrOrgSnapshotResult struct {
 }
 
 type herdrOrgPane struct {
-	PaneID       string `json:"pane_id"`
-	Label        string `json:"label"`
-	AgentStatus  string `json:"agent_status"`
-	InputPending bool   `json:"input_pending"`
+	PaneID            string                  `json:"pane_id"`
+	Label             string                  `json:"label"`
+	AgentStatus       string                  `json:"agent_status"`
+	InputPending      bool                    `json:"input_pending"`
+	LastCompletedTurn *herdrCompletedTurnWire `json:"last_completed_turn"`
+}
+
+type herdrCompletedTurnWire struct {
+	Turn            *int64 `json:"turn"`
+	TurnEpoch       *int64 `json:"turn_epoch"`
+	CompletedUnixMS *int64 `json:"completed_unix_ms"`
 }
 
 func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
@@ -130,6 +137,17 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 	return org.Snapshot{States: states, ObservedAt: now().UTC(), ProviderVersion: version}, nil
 }
 
+func mapHerdrCompletedTurn(turn *herdrCompletedTurnWire) *org.RoleActivity {
+	if turn == nil || turn.Turn == nil || turn.TurnEpoch == nil || turn.CompletedUnixMS == nil {
+		return nil
+	}
+	return &org.RoleActivity{
+		Turn:        *turn.Turn,
+		TurnEpoch:   *turn.TurnEpoch,
+		CompletedAt: time.UnixMilli(*turn.CompletedUnixMS).UTC(),
+	}
+}
+
 // Recycle starts a fresh interactive agent in a pane that has already returned
 // to its shell prompt. Herdr cannot safely prove or cause that transition, so
 // winding down the prior agent remains an explicit operator precondition.
@@ -178,14 +196,17 @@ func herdrKindSupportsModelFlag(kind string) bool {
 }
 
 func mapHerdrPaneState(pane herdrOrgPane) org.RoleLiveState {
+	state := mapHerdrAgentStatus(pane.AgentStatus)
+	state.Activity = mapHerdrCompletedTurn(pane.LastCompletedTurn)
 	// input_pending is orthogonal to Herdr's agent_status enum
 	// (idle/working/blocked/done/unknown). It wins whenever true because an
 	// interactive dialog prevents forward progress even if the last activity
 	// detector still reports idle or working.
 	if pane.InputPending {
-		return org.RoleLiveState{State: org.StateInputPending}
+		state.State = org.StateInputPending
+		state.Detail = ""
 	}
-	return mapHerdrAgentStatus(pane.AgentStatus)
+	return state
 }
 
 func mapHerdrAgentStatus(raw string) org.RoleLiveState {

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -53,9 +53,9 @@ type herdrOrgPane struct {
 }
 
 type herdrCompletedTurnWire struct {
-	Turn            *int64 `json:"turn"`
-	TurnEpoch       *int64 `json:"turn_epoch"`
-	CompletedUnixMS *int64 `json:"completed_unix_ms"`
+	Turn            *json.Number `json:"turn"`
+	TurnEpoch       *json.Number `json:"turn_epoch"`
+	CompletedUnixMS *json.Number `json:"completed_unix_ms"`
 }
 
 func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
@@ -138,14 +138,28 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 }
 
 func mapHerdrCompletedTurn(turn *herdrCompletedTurnWire) *org.RoleActivity {
-	if turn == nil || turn.Turn == nil || turn.TurnEpoch == nil || turn.CompletedUnixMS == nil {
+	if turn == nil {
+		return nil
+	}
+	turnNumber, turnOK := positiveHerdrInt64(turn.Turn)
+	turnEpoch, epochOK := positiveHerdrInt64(turn.TurnEpoch)
+	completedUnixMS, completedOK := positiveHerdrInt64(turn.CompletedUnixMS)
+	if !turnOK || !epochOK || !completedOK {
 		return nil
 	}
 	return &org.RoleActivity{
-		Turn:        *turn.Turn,
-		TurnEpoch:   *turn.TurnEpoch,
-		CompletedAt: time.UnixMilli(*turn.CompletedUnixMS).UTC(),
+		Turn:        turnNumber,
+		TurnEpoch:   turnEpoch,
+		CompletedAt: time.UnixMilli(completedUnixMS).UTC(),
 	}
+}
+
+func positiveHerdrInt64(value *json.Number) (int64, bool) {
+	if value == nil {
+		return 0, false
+	}
+	parsed, err := strconv.ParseInt(value.String(), 10, 64)
+	return parsed, err == nil && parsed > 0
 }
 
 // Recycle starts a fresh interactive agent in a pane that has already returned

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -185,6 +185,67 @@ func TestHerdrOrgProviderSnapshotPartialTurnIsAbsent(t *testing.T) {
 	}
 }
 
+func TestHerdrOrgProviderSnapshotInvalidTurnValuesAreAbsent(t *testing.T) {
+	tests := []struct {
+		name string
+		turn string
+	}{
+		{name: "zero turn", turn: `{"turn":0,"turn_epoch":2,"completed_unix_ms":3}`},
+		{name: "zero turn epoch", turn: `{"turn":1,"turn_epoch":0,"completed_unix_ms":3}`},
+		{name: "zero completion time", turn: `{"turn":1,"turn_epoch":2,"completed_unix_ms":0}`},
+		{name: "all zero", turn: `{"turn":0,"turn_epoch":0,"completed_unix_ms":0}`},
+		{name: "negative turn", turn: `{"turn":-1,"turn_epoch":2,"completed_unix_ms":3}`},
+		{name: "negative turn epoch", turn: `{"turn":1,"turn_epoch":-2,"completed_unix_ms":3}`},
+		{name: "negative completion time", turn: `{"turn":1,"turn_epoch":2,"completed_unix_ms":-3}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			run := func(_ context.Context, _ ...string) (string, error) {
+				return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"owner","agent_status":"working","last_completed_turn":` + test.turn + `}
+]}}}`, nil
+			}
+			provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+			snapshot, err := provider.Snapshot(context.Background())
+			if err != nil {
+				t.Fatalf("Snapshot() error = %v", err)
+			}
+			if activity := snapshot.States["owner"].Activity; activity != nil {
+				t.Fatalf("owner activity = %+v, want absent for invalid turn", activity)
+			}
+		})
+	}
+}
+
+func TestHerdrOrgProviderSnapshotOversizedUint64TurnEpochFailsClosedPerPane(t *testing.T) {
+	run := func(_ context.Context, _ ...string) (string, error) {
+		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"oversized","agent_status":"working","last_completed_turn":{"turn":1,"turn_epoch":9223372036854775808,"completed_unix_ms":3}},
+{"pane_id":"w1:p2","label":"valid","agent_status":"idle","last_completed_turn":{"turn":4,"turn_epoch":5,"completed_unix_ms":6}},
+{"pane_id":"w1:p3","label":"absent","agent_status":"blocked"}
+]}}}`, nil
+	}
+	provider := newHerdrOrgProvider(run, []config.OrgRole{
+		{Name: "oversized"}, {Name: "valid"}, {Name: "absent"},
+	}, time.Now)
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if state := snapshot.States["oversized"]; state.State != org.StateWorking || state.Activity != nil {
+		t.Errorf("oversized state = %+v, want working with absent activity", state)
+	}
+	valid := snapshot.States["valid"]
+	if valid.State != org.StateIdle || valid.Activity == nil ||
+		valid.Activity.Turn != 4 || valid.Activity.TurnEpoch != 5 ||
+		!valid.Activity.CompletedAt.Equal(time.UnixMilli(6).UTC()) {
+		t.Errorf("valid state = %+v", valid)
+	}
+	if state := snapshot.States["absent"]; state.State != org.StateBlocked || state.Activity != nil {
+		t.Errorf("absent state = %+v, want blocked with absent activity", state)
+	}
+}
+
 func TestHerdrOrgProviderFailures(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -2,6 +2,7 @@ package cockpit
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -18,7 +19,7 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 			t.Fatalf("args = %v", args)
 		}
 		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
-{"pane_id":"w1:p1","label":"owner","agent_status":"working"},
+{"pane_id":"w1:p1","label":"owner","agent_status":"working","last_completed_turn":{"turn":1,"turn_epoch":1785163074397066532,"completed_unix_ms":1785163510704}},
 {"pane_id":"w1:p2","label":"review","agent_status":"blocked"},
 {"pane_id":"w1:p3","label":"done","agent_status":"done"},
 {"pane_id":"w1:p4","label":"idle","agent_status":"idle"},
@@ -59,12 +60,25 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 	if _, inferred := snapshot.States["claude"]; inferred {
 		t.Fatal("provider inferred a runtime label that was not a configured role")
 	}
+	ownerActivity := snapshot.States["owner"].Activity
+	if ownerActivity == nil {
+		t.Fatal("owner activity is absent")
+	}
+	if ownerActivity.Turn != 1 || ownerActivity.TurnEpoch != 1785163074397066532 ||
+		!ownerActivity.CompletedAt.Equal(time.UnixMilli(1785163510704).UTC()) {
+		t.Errorf("owner activity = %+v", ownerActivity)
+	}
+	for _, role := range []string{"review", "done", "idle", "future", "duplicate", "missing"} {
+		if activity := snapshot.States[role].Activity; activity != nil {
+			t.Errorf("activity[%s] = %+v, want absent", role, activity)
+		}
+	}
 }
 
 func TestHerdrOrgProviderSnapshotPaneBindings(t *testing.T) {
 	run := func(_ context.Context, _ ...string) (string, error) {
 		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
-{"pane_id":"w1:p1","label":"Gitmoot Idle","agent_status":"idle"},
+{"pane_id":"w1:p1","label":"Gitmoot Idle","agent_status":"idle","last_completed_turn":{"turn":7,"turn_epoch":99,"completed_unix_ms":1785163510704}},
 {"pane_id":"w1:p2","label":"Gitmoot Working","agent_status":"working"},
 {"pane_id":"w1:p3","label":"Gitmoot Blocked","agent_status":"blocked"},
 {"pane_id":"w1:p4","label":"Gitmoot Done","agent_status":"done"},
@@ -115,6 +129,59 @@ func TestHerdrOrgProviderSnapshotPaneBindings(t *testing.T) {
 	}
 	if got := snapshot.States["empty-id-role"].Detail; got != `no Herdr pane bound as "Empty A"` {
 		t.Errorf("empty-id detail = %q", got)
+	}
+	if activity := snapshot.States["idle-role"].Activity; activity == nil ||
+		activity.Turn != 7 || activity.TurnEpoch != 99 ||
+		!activity.CompletedAt.Equal(time.UnixMilli(1785163510704).UTC()) {
+		t.Errorf("idle-role activity = %+v", activity)
+	}
+	for _, role := range []string{"working-role", "blocked-role", "done-role", "literal-role", "missing-role", "ambiguous-role", "empty-id-role"} {
+		if activity := snapshot.States[role].Activity; activity != nil {
+			t.Errorf("activity[%s] = %+v, want absent", role, activity)
+		}
+	}
+}
+
+func TestHerdrOrgProviderSnapshotAbsentTurnIsOmitted(t *testing.T) {
+	run := func(_ context.Context, _ ...string) (string, error) {
+		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"owner","agent_status":"idle"}
+]}}}`, nil
+	}
+	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	state := snapshot.States["owner"]
+	if state.State != org.StateIdle || state.Detail != "" {
+		t.Fatalf("owner state = %+v", state)
+	}
+	if state.Activity != nil {
+		t.Fatalf("owner activity = %+v, want absent", state.Activity)
+	}
+	encoded, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	if got, want := string(encoded), `{"state":"idle"}`; got != want {
+		t.Fatalf("encoded state = %s, want %s", got, want)
+	}
+}
+
+func TestHerdrOrgProviderSnapshotPartialTurnIsAbsent(t *testing.T) {
+	run := func(_ context.Context, _ ...string) (string, error) {
+		return `{"result":{"snapshot":{"version":"0.7.5","panes":[
+{"pane_id":"w1:p1","label":"owner","agent_status":"working","last_completed_turn":{"turn":1,"turn_epoch":2}}
+]}}}`, nil
+	}
+	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+	snapshot, err := provider.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if activity := snapshot.States["owner"].Activity; activity != nil {
+		t.Fatalf("owner activity = %+v, want absent for incomplete turn", activity)
 	}
 }
 

--- a/internal/org/provider.go
+++ b/internal/org/provider.go
@@ -21,8 +21,18 @@ const (
 )
 
 type RoleLiveState struct {
-	State  LifecycleState `json:"state"`
-	Detail string         `json:"detail,omitempty"`
+	State    LifecycleState `json:"state"`
+	Detail   string         `json:"detail,omitempty"`
+	Activity *RoleActivity  `json:"activity,omitempty"`
+}
+
+// RoleActivity identifies a completed provider turn. A nil *RoleActivity means
+// the provider did not report turn activity; callers must not treat that as a
+// zero-valued or stale turn.
+type RoleActivity struct {
+	Turn        int64     `json:"turn"`
+	TurnEpoch   int64     `json:"turn_epoch"`
+	CompletedAt time.Time `json:"completed_at"`
 }
 
 type Snapshot struct {


### PR DESCRIPTION
Successor to PR #1190, which cannot be merged or rebased in place.

#1190's task record `adhoc-9a5f171c` carries an **empty worktree path**, so both dispatch routes refuse it and the suggested remediation is `git -C ""` — tracked as #1214. #1190 has been CONFLICTING since before this shift, which means GitHub has run **no CI on it at all**; it reads 0/0 forever and has never been reviewable. Rather than serialise the work behind tooling repair, this branch carries it rebased onto current main.

**The rebase conflict and its resolution:** one additive conflict in `internal/cockpit/herdr_org.go`. Main's `input_pending` pane state and #1190's `last_completed_turn` activity are **both retained** in `herdrOrgPane`; `mapHerdrPaneState` preserves activity while input-pending wins. Tests and provider changes merged without conflict. No migrations involved. That resolution was validated across two independent attempts before being reused here.

**Gate:** `build=0`, `vet=0`. The sole test failure was `TestSandboxExecReadOnlyInputE2E` in `internal/sandbox` — waived after a **control run on detached `origin/main` reproduced it there**, confirming it is environmental rather than a defect in this branch.

That is the **fourth** sandbox test found failing for one cause: gitmoot's native Landlock sandbox is **inert on this host**, so sandbox tests correctly detect a non-enforcing mechanism. Filed as #1215 — security-relevant, since `internal/runtime/registry.go:37` has ephemeral workers fail closed on the sandbox probe, and a probe that reports *supported* while nothing enforces means those workers run believing they are confined when they are not.

Closes #1190 on merge (superseded, not abandoned).
