### PR TITLE
Gitmoot: URGENT SMALL FIX — a DISMISSED task halts

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"path/filepath"
@@ -857,6 +858,133 @@ func TestPollOnceRetriesReadyToMergePullRequestWithoutHeadChange(t *testing.T) {
 	}
 	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 || gate.requests[0].HeadSHA != "abc123" {
 		t.Fatalf("merge gate requests = %+v", gate.requests)
+	}
+}
+
+func TestPollOnceDismissedEscalationDoesNotBlockEligibleMerge(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-ready",
+		RepoFullName: repo.FullName(),
+		State:        string(workflow.TaskReadyToMerge),
+		Branch:       "ready-branch",
+	}); err != nil {
+		t.Fatalf("UpsertTask ready: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{
+		ID:           "task-dismissed",
+		RepoFullName: repo.FullName(),
+		State:        string(workflow.TaskDismissed),
+		Branch:       "dismissed-branch",
+	}); err != nil {
+		t.Fatalf("UpsertTask dismissed: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: repo.FullName(),
+		Branch:       "ready-branch",
+		Owner:        "lead",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name:           "coordinator",
+		Role:           "coordinator",
+		Runtime:        "codex",
+		RuntimeRef:     "last",
+		RepoScope:      repo.FullName(),
+		Capabilities:   []string{"ask"},
+		AutonomyPolicy: "auto",
+		HealthStatus:   "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent coordinator: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: repo.FullName(),
+		Number:       7,
+		HeadBranch:   "ready-branch",
+		BaseBranch:   "main",
+		HeadSHA:      "abc123",
+		State:        "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest: %v", err)
+	}
+	payload, err := json.Marshal(workflow.JobPayload{
+		Repo:      repo.FullName(),
+		Branch:    "dismissed-branch",
+		TaskID:    "task-dismissed",
+		Result:    &workflow.AgentResult{Decision: "approved", Summary: "stale escalation"},
+		LeadAgent: "coordinator",
+	})
+	if err != nil {
+		t.Fatalf("Marshal payload: %v", err)
+	}
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      "dismissed-coordinator",
+		Agent:   "coordinator",
+		Type:    "ask",
+		State:   string(workflow.JobSucceeded),
+		Payload: string(payload),
+	}, db.JobEvent{
+		JobID:   "dismissed-coordinator",
+		Kind:    string(workflow.JobSucceeded),
+		Message: "completed",
+	}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	escalation, err := json.Marshal(workflow.EscalationRecord{
+		DelegationID: "stale-leg",
+		PausedAt:     time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("Marshal escalation: %v", err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{
+		JobID:   "dismissed-coordinator",
+		Kind:    "delegation_escalation_requested",
+		Message: string(escalation),
+	}); err != nil {
+		t.Fatalf("AddJobEvent escalation: %v", err)
+	}
+
+	client := &fakeGitHub{
+		pulls: []github.PullRequest{{
+			Number:  7,
+			Title:   "Ready",
+			State:   "open",
+			HeadRef: "ready-branch",
+			BaseRef: "main",
+			HeadSHA: "abc123",
+		}},
+		comments: map[int64][]github.IssueComment{7: {}},
+	}
+	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true, Merged: true}}
+	engine := workflow.Engine{Store: store, MergeGate: gate}
+	d := Daemon{
+		Repo:          repo,
+		Store:         store,
+		GitHub:        client,
+		Workflow:      &engine,
+		EscalationTTL: time.Hour,
+	}
+
+	if err := d.PollOnce(ctx); err != nil {
+		t.Fatalf("PollOnce returned error: %v", err)
+	}
+	if len(gate.requests) != 1 || gate.requests[0].PullRequest != 7 {
+		t.Fatalf("merge gate requests = %+v, want eligible PR #7", gate.requests)
+	}
+	ready, err := store.GetTask(ctx, "task-ready")
+	if err != nil || ready.State != string(workflow.TaskMerged) {
+		t.Fatalf("ready task = %+v, err=%v; want merged", ready, err)
+	}
+	dismissed, err := store.GetTask(ctx, "task-dismissed")
+	if err != nil || dismissed.State != string(workflow.TaskDismissed) {
+		t.Fatalf("dismissed task = %+v, err=%v; want dismissed", dismissed, err)
+	}
+	if _, err := store.GetJob(ctx, workflow.DelegationContinuationID("dismissed-coordinator")); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("dismissed task continuation error = %v, want no row", err)
 	}
 }
 

--- a/internal/workflow/engine_escalation_resume.go
+++ b/internal/workflow/engine_escalation_resume.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -834,11 +835,22 @@ func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Dur
 		if payload.Result == nil {
 			continue
 		}
+		ref := taskRefFromPayload(payload)
+		dismissedTaskID, dismissed, err := e.dismissedTaskForAdvancement(ctx, ref)
+		if err != nil {
+			return finalized, err
+		}
+		if dismissed {
+			slog.Debug("workflow advancement skipped dismissed task",
+				"task_id", dismissedTaskID,
+				"job_id", jobID)
+			continue
+		}
 		reason := fmt.Sprintf("escalation TTL of %s elapsed with no human response", ttl)
 		if err := e.enqueueFinalizeContinuation(ctx, job, payload, reason); err != nil {
 			return finalized, err
 		}
-		if err := e.setTaskState(ctx, taskRefFromPayload(payload), TaskPlanned); err != nil {
+		if err := e.setTaskState(ctx, ref, TaskPlanned); err != nil {
 			return finalized, err
 		}
 		resolution := EscalationRecord{
@@ -861,4 +873,32 @@ func (e Engine) AutoFinalizeExpiredEscalations(ctx context.Context, ttl time.Dur
 		finalized++
 	}
 	return finalized, nil
+}
+
+// dismissedTaskForAdvancement checks both identities setTaskState can resolve:
+// the payload task ID and the canonical task owning its repo branch. A dismissed
+// task is terminal, so automatic advancement must skip it before enqueueing any
+// continuation work.
+func (e Engine) dismissedTaskForAdvancement(ctx context.Context, ref taskRef) (string, bool, error) {
+	if strings.TrimSpace(ref.ID) != "" {
+		task, err := e.Store.GetTask(ctx, ref.ID)
+		if err == nil {
+			if task.State == string(TaskDismissed) {
+				return task.ID, true, nil
+			}
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return "", false, err
+		}
+	}
+	if strings.TrimSpace(ref.Repo) == "" || strings.TrimSpace(ref.Branch) == "" {
+		return "", false, nil
+	}
+	task, err := e.Store.GetTaskByRepoBranch(ctx, ref.Repo, ref.Branch)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return task.ID, task.State == string(TaskDismissed), nil
 }


### PR DESCRIPTION
WHAT:
Dismissed tasks no longer abort expired-escalation advancement or block eligible repo merges. Changes remain uncommitted at base fda569e24cc10c1892f5532c326e36173a00d5e3 for the finalizer.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-76272c71

RESULTS:
- Pre-fix regression: FAIL with `task task-dismissed is dismissed; workflow advancement cannot move it to planned`.
- Focused workflow and daemon regressions: PASS.
- go build ./...: build=0
- go vet ./...: vet=0
- Scoped test gate with four authorized Landlock skips: internal/workflow ok (192.988s), internal/cli ok (658.890s), internal/daemon ok (45.073s), test=0
- git diff --check: PASS

RISK:
Review the generated diff before merging.

TASK:
adhoc-76272c71

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Dismissed tasks no longer abort expired-escalation advancement or block eligible repo merges. Changes remain uncommitted at base fda569e24cc10c1892f5532c326e36173a00d5e3 for the finalizer.
````
