### PR TITLE
fix(db): make wake outbox state classification exhaustive

### DIFF
--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -40,16 +40,11 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 	}
 	attemptedBefore := now.UTC().Add(-replyWakeAttemptedUnknownAfter)
 	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedBefore)
-	if err != nil || len(obligations) == 0 {
+	if err != nil || obligations.Len() == 0 {
 		return err
 	}
 
-	agedAttempted := 0
-	for _, entry := range obligations {
-		if entry.State == db.WakeOutboxStateAttempted {
-			agedAttempted++
-		}
-	}
+	agedAttempted := len(obligations.AgedAttempted)
 	if agedAttempted > 0 {
 		expired, err := store.ExpireAgedWakeOutbox(ctx, attemptedBefore, now)
 		if err != nil {
@@ -63,11 +58,8 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 		}
 	}
 
-	groups := make(map[string][]db.WakeOutboxEntry)
-	for _, entry := range obligations {
-		if entry.State != db.WakeOutboxStatePending {
-			continue
-		}
+	groups := make(map[string][]db.WakeOutboxObligation)
+	for _, entry := range obligations.Pending {
 		if !strings.HasPrefix(entry.CoalesceKey, db.WakeOutboxReplyCoalescePrefix) {
 			continue
 		}
@@ -152,16 +144,8 @@ func wakeOutboxObligationHealth(ctx context.Context, store *db.Store, attemptedB
 	if err != nil {
 		return fmt.Errorf("read wake outbox obligations: %w", err)
 	}
-	pending := 0
-	agedAttempted := 0
-	for _, entry := range obligations {
-		switch entry.State {
-		case db.WakeOutboxStatePending:
-			pending++
-		case db.WakeOutboxStateAttempted:
-			agedAttempted++
-		}
-	}
+	pending := len(obligations.Pending)
+	agedAttempted := len(obligations.AgedAttempted)
 	if pending == 0 && agedAttempted == 0 {
 		return nil
 	}
@@ -183,7 +167,7 @@ func emitReplyWakeOutboxEvent(ctx context.Context, sink events.Sink, event event
 	return errors.New("wake outbox sink does not support synchronous delivery")
 }
 
-func replyWakeEvent(batch []db.WakeOutboxEntry, now time.Time) events.Event {
+func replyWakeEvent(batch []db.WakeOutboxObligation, now time.Time) events.Event {
 	oldest := batch[0]
 	role := strings.ToLower(strings.TrimSpace(oldest.TargetRole))
 	detail := fmt.Sprintf("%d new items, oldest id %s", len(batch), oldest.SourceID)

--- a/internal/db/testdata/wake_outbox_handwritten_query.go.txt
+++ b/internal/db/testdata/wake_outbox_handwritten_query.go.txt
@@ -1,0 +1,23 @@
+package db
+
+import "time"
+
+func handwrittenWakeOutboxObligationQuery(attemptedBefore time.Time) (string, []any) {
+	return `
+SELECT id, source_kind, source_id, target_role, coalesce_key, state,
+		attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
+		COALESCE(finished_at, ''), updated_at
+FROM wake_outbox
+WHERE state = ? OR (state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)
+ORDER BY created_at, id`, []any{
+			WakeOutboxStatePending,
+			WakeOutboxStateAttempted,
+			attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout),
+		}
+}
+
+func handwrittenListWakeOutboxObligations() (WakeOutboxObligationProjection, error) {
+	query, args := handwrittenWakeOutboxObligationQuery(time.Time{})
+	_, _ = query, args
+	return WakeOutboxObligationProjection{}, nil
+}

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -20,12 +20,45 @@ const (
 	// disappeared before recording whether Herdr accepted the wake. It is
 	// terminal and MUST NOT be retried blindly.
 	WakeOutboxStateDeliveryUnknown = "delivery_unknown"
+	wakeOutboxStateCount = iota
+)
 
+const (
 	WakeOutboxDeliveryUnknownEventKind = "wake_delivery_unknown"
 
 	WakeOutboxSourceWorkflowNote  = "workflow_note"
 	WakeOutboxSourceChatMessage   = "chat_message"
 	WakeOutboxReplyCoalescePrefix = "reply:"
+)
+
+type wakeOutboxStateClass uint8
+
+const (
+	wakeOutboxStateObligation wakeOutboxStateClass = iota
+	wakeOutboxStateTerminal
+	wakeOutboxStateDeliveryUnknown
+)
+
+type wakeOutboxStateDefinition struct {
+	state               string
+	class               wakeOutboxStateClass
+	obligationPredicate string
+	agedAttempt         bool
+}
+
+var wakeOutboxStateDefinitions = [...]wakeOutboxStateDefinition{
+	{WakeOutboxStatePending, wakeOutboxStateObligation, "state = ?", false},
+	{WakeOutboxStateAttempted, wakeOutboxStateObligation, "(state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)", true},
+	{WakeOutboxStateDelivered, wakeOutboxStateTerminal, "", false},
+	{WakeOutboxStateStalled, wakeOutboxStateTerminal, "", false},
+	{WakeOutboxStateFailed, wakeOutboxStateTerminal, "", false},
+	{WakeOutboxStateDeliveryUnknown, wakeOutboxStateDeliveryUnknown, "", false},
+}
+
+// Opposing lengths make an unclassified state or a stray definition fail compilation.
+var (
+	_ [wakeOutboxStateCount - len(wakeOutboxStateDefinitions)]struct{}
+	_ [len(wakeOutboxStateDefinitions) - wakeOutboxStateCount]struct{}
 )
 
 // WakeOutboxEntry is one durable delivery item. A pending row is positive,
@@ -138,15 +171,15 @@ FROM wake_outbox`
 // wake delivery. Pending rows and attempted rows older than attemptedBefore are
 // the only non-terminal obligations; terminal outcomes never appear.
 func (s *Store) ListWakeOutboxObligations(ctx context.Context, attemptedBefore time.Time) ([]WakeOutboxEntry, error) {
+	predicate, args := wakeOutboxObligationPredicate(attemptedBefore)
 	rows, err := s.db.QueryContext(ctx, `
 SELECT id, source_kind, source_id, target_role, coalesce_key, state,
-	attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
-	COALESCE(finished_at, ''), updated_at
+		attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
+		COALESCE(finished_at, ''), updated_at
 FROM wake_outbox
-WHERE state = 'pending'
-	OR (state = 'attempted' AND attempted_at IS NOT NULL AND attempted_at <= ?)
+WHERE `+predicate+`
 ORDER BY created_at, id`,
-		attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout))
+		args...)
 	if err != nil {
 		return nil, err
 	}
@@ -287,9 +320,8 @@ WHERE state = 'pending' AND id IN (`, ids, at)
 // FinishWakeOutbox records the existing event-rule delivery classification for
 // every row in one attempted batch.
 func (s *Store) FinishWakeOutbox(ctx context.Context, ids []int64, state, detail string, at time.Time) error {
-	switch state {
-	case WakeOutboxStateDelivered, WakeOutboxStateStalled, WakeOutboxStateFailed:
-	default:
+	class, ok := classifyWakeOutboxState(state)
+	if !ok || class != wakeOutboxStateTerminal {
 		return fmt.Errorf("invalid terminal wake outbox state %q", state)
 	}
 	query, args, err := wakeOutboxIDUpdate(`
@@ -311,6 +343,31 @@ WHERE state = 'attempted' AND id IN (`, ids, at, state, strings.TrimSpace(detail
 		return fmt.Errorf("finish wake outbox updated %d rows, want %d", affected, len(ids))
 	}
 	return nil
+}
+
+func classifyWakeOutboxState(state string) (wakeOutboxStateClass, bool) {
+	for _, definition := range wakeOutboxStateDefinitions {
+		if state == definition.state {
+			return definition.class, true
+		}
+	}
+	return 0, false
+}
+
+func wakeOutboxObligationPredicate(attemptedBefore time.Time) (string, []any) {
+	var clauses []string
+	var args []any
+	for _, definition := range wakeOutboxStateDefinitions {
+		if definition.class != wakeOutboxStateObligation {
+			continue
+		}
+		clauses = append(clauses, definition.obligationPredicate)
+		args = append(args, definition.state)
+		if definition.agedAttempt {
+			args = append(args, attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout))
+		}
+	}
+	return strings.Join(clauses, " OR "), args
 }
 
 func wakeOutboxIDUpdate(prefix string, ids []int64, at time.Time, leading ...string) (string, []any, error) {

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -20,7 +20,7 @@ const (
 	// disappeared before recording whether Herdr accepted the wake. It is
 	// terminal and MUST NOT be retried blindly.
 	WakeOutboxStateDeliveryUnknown = "delivery_unknown"
-	wakeOutboxStateCount = iota
+	wakeOutboxStateCount           = iota
 )
 
 const (
@@ -31,27 +31,27 @@ const (
 	WakeOutboxReplyCoalescePrefix = "reply:"
 )
 
-type wakeOutboxStateClass uint8
+type wakeOutboxStateInterpretation uint8
 
 const (
-	wakeOutboxStateObligation wakeOutboxStateClass = iota
+	wakeOutboxStatePendingObligation wakeOutboxStateInterpretation = iota
+	wakeOutboxStateAgedAttemptObligation
 	wakeOutboxStateTerminal
 	wakeOutboxStateDeliveryUnknown
 )
 
 type wakeOutboxStateDefinition struct {
-	state       string
-	class       wakeOutboxStateClass
-	agedAttempt bool
+	state          string
+	interpretation wakeOutboxStateInterpretation
 }
 
 var wakeOutboxStateDefinitions = [...]wakeOutboxStateDefinition{
-	{WakeOutboxStatePending, wakeOutboxStateObligation, false},
-	{WakeOutboxStateAttempted, wakeOutboxStateObligation, true},
-	{WakeOutboxStateDelivered, wakeOutboxStateTerminal, false},
-	{WakeOutboxStateStalled, wakeOutboxStateTerminal, false},
-	{WakeOutboxStateFailed, wakeOutboxStateTerminal, false},
-	{WakeOutboxStateDeliveryUnknown, wakeOutboxStateDeliveryUnknown, false},
+	{WakeOutboxStatePending, wakeOutboxStatePendingObligation},
+	{WakeOutboxStateAttempted, wakeOutboxStateAgedAttemptObligation},
+	{WakeOutboxStateDelivered, wakeOutboxStateTerminal},
+	{WakeOutboxStateStalled, wakeOutboxStateTerminal},
+	{WakeOutboxStateFailed, wakeOutboxStateTerminal},
+	{WakeOutboxStateDeliveryUnknown, wakeOutboxStateDeliveryUnknown},
 }
 
 // Opposing lengths make an unclassified state or a stray definition fail compilation.
@@ -170,15 +170,20 @@ FROM wake_outbox`
 // wake delivery. Pending rows and attempted rows older than attemptedBefore are
 // the only non-terminal obligations; terminal outcomes never appear.
 func (s *Store) ListWakeOutboxObligations(ctx context.Context, attemptedBefore time.Time) ([]WakeOutboxEntry, error) {
-	predicate, args := wakeOutboxObligationPredicate(attemptedBefore)
-	rows, err := s.db.QueryContext(ctx, `
-SELECT id, source_kind, source_id, target_role, coalesce_key, state,
-		attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
-		COALESCE(finished_at, ''), updated_at
-FROM wake_outbox
-WHERE `+predicate+`
-ORDER BY created_at, id`,
-		args...)
+	return listWakeOutboxObligations(ctx, s.db, attemptedBefore)
+}
+
+type wakeOutboxQueryer interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+func listWakeOutboxObligations(
+	ctx context.Context,
+	queryer wakeOutboxQueryer,
+	attemptedBefore time.Time,
+) ([]WakeOutboxEntry, error) {
+	query, args := wakeOutboxObligationQuery(attemptedBefore)
+	rows, err := queryer.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -197,6 +202,17 @@ ORDER BY created_at, id`,
 		out = append(out, entry)
 	}
 	return out, rows.Err()
+}
+
+func wakeOutboxObligationQuery(attemptedBefore time.Time) (string, []any) {
+	predicate, args := wakeOutboxObligationPredicate(attemptedBefore)
+	return `
+SELECT id, source_kind, source_id, target_role, coalesce_key, state,
+		attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
+		COALESCE(finished_at, ''), updated_at
+FROM wake_outbox
+WHERE ` + predicate + `
+ORDER BY created_at, id`, args
 }
 
 // ExpireAgedWakeOutbox marks delivery-unknown rows terminal without re-emitting
@@ -319,8 +335,8 @@ WHERE state = 'pending' AND id IN (`, ids, at)
 // FinishWakeOutbox records the existing event-rule delivery classification for
 // every row in one attempted batch.
 func (s *Store) FinishWakeOutbox(ctx context.Context, ids []int64, state, detail string, at time.Time) error {
-	class, ok := classifyWakeOutboxState(state)
-	if !ok || class != wakeOutboxStateTerminal {
+	interpretation, ok := interpretWakeOutboxState(state)
+	if !ok || interpretation != wakeOutboxStateTerminal {
 		return fmt.Errorf("invalid terminal wake outbox state %q", state)
 	}
 	query, args, err := wakeOutboxIDUpdate(`
@@ -344,10 +360,10 @@ WHERE state = 'attempted' AND id IN (`, ids, at, state, strings.TrimSpace(detail
 	return nil
 }
 
-func classifyWakeOutboxState(state string) (wakeOutboxStateClass, bool) {
+func interpretWakeOutboxState(state string) (wakeOutboxStateInterpretation, bool) {
 	for _, definition := range wakeOutboxStateDefinitions {
 		if state == definition.state {
-			return definition.class, true
+			return definition.interpretation, true
 		}
 	}
 	return 0, false
@@ -357,16 +373,23 @@ func wakeOutboxObligationPredicate(attemptedBefore time.Time) (string, []any) {
 	var clauses []string
 	var args []any
 	for _, definition := range wakeOutboxStateDefinitions {
-		if definition.class != wakeOutboxStateObligation {
-			continue
+		interpretation, ok := interpretWakeOutboxState(definition.state)
+		if !ok {
+			panic(fmt.Sprintf("wake outbox state %q has no interpretation", definition.state))
 		}
-		clause := "state = ?"
-		args = append(args, definition.state)
-		if definition.agedAttempt {
-			clause = "(state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)"
+		switch interpretation {
+		case wakeOutboxStatePendingObligation:
+			clauses = append(clauses, "state = ?")
+			args = append(args, definition.state)
+		case wakeOutboxStateAgedAttemptObligation:
+			clauses = append(clauses, "(state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)")
+			args = append(args, definition.state)
 			args = append(args, attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout))
+		case wakeOutboxStateTerminal, wakeOutboxStateDeliveryUnknown:
+			continue
+		default:
+			panic(fmt.Sprintf("wake outbox state %q has invalid interpretation %d", definition.state, interpretation))
 		}
-		clauses = append(clauses, clause)
 	}
 	return strings.Join(clauses, " OR "), args
 }

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -40,19 +40,18 @@ const (
 )
 
 type wakeOutboxStateDefinition struct {
-	state               string
-	class               wakeOutboxStateClass
-	obligationPredicate string
-	agedAttempt         bool
+	state       string
+	class       wakeOutboxStateClass
+	agedAttempt bool
 }
 
 var wakeOutboxStateDefinitions = [...]wakeOutboxStateDefinition{
-	{WakeOutboxStatePending, wakeOutboxStateObligation, "state = ?", false},
-	{WakeOutboxStateAttempted, wakeOutboxStateObligation, "(state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)", true},
-	{WakeOutboxStateDelivered, wakeOutboxStateTerminal, "", false},
-	{WakeOutboxStateStalled, wakeOutboxStateTerminal, "", false},
-	{WakeOutboxStateFailed, wakeOutboxStateTerminal, "", false},
-	{WakeOutboxStateDeliveryUnknown, wakeOutboxStateDeliveryUnknown, "", false},
+	{WakeOutboxStatePending, wakeOutboxStateObligation, false},
+	{WakeOutboxStateAttempted, wakeOutboxStateObligation, true},
+	{WakeOutboxStateDelivered, wakeOutboxStateTerminal, false},
+	{WakeOutboxStateStalled, wakeOutboxStateTerminal, false},
+	{WakeOutboxStateFailed, wakeOutboxStateTerminal, false},
+	{WakeOutboxStateDeliveryUnknown, wakeOutboxStateDeliveryUnknown, false},
 }
 
 // Opposing lengths make an unclassified state or a stray definition fail compilation.
@@ -361,11 +360,13 @@ func wakeOutboxObligationPredicate(attemptedBefore time.Time) (string, []any) {
 		if definition.class != wakeOutboxStateObligation {
 			continue
 		}
-		clauses = append(clauses, definition.obligationPredicate)
+		clause := "state = ?"
 		args = append(args, definition.state)
 		if definition.agedAttempt {
+			clause = "(state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)"
 			args = append(args, attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout))
 		}
+		clauses = append(clauses, clause)
 	}
 	return strings.Join(clauses, " OR "), args
 }

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -77,6 +77,28 @@ type WakeOutboxEntry struct {
 	UpdatedAt    string `json:"updated_at"`
 }
 
+// WakeOutboxObligation is the row data needed to act on an outstanding wake.
+// State is deliberately absent: ListWakeOutboxObligations classifies it before
+// returning across the package boundary.
+type WakeOutboxObligation struct {
+	ID          int64
+	SourceKind  string
+	SourceID    string
+	TargetRole  string
+	CoalesceKey string
+	CreatedAt   string
+}
+
+// WakeOutboxObligationProjection exposes decisions, not persisted states.
+type WakeOutboxObligationProjection struct {
+	Pending       []WakeOutboxObligation
+	AgedAttempted []WakeOutboxObligation
+}
+
+func (p WakeOutboxObligationProjection) Len() int {
+	return len(p.Pending) + len(p.AgedAttempted)
+}
+
 func insertWorkflowNoteWakeOutboxTx(ctx context.Context, tx *sql.Tx, noteID int64, targetRole string) error {
 	if err := insertWakeOutboxTx(
 		ctx, tx, WakeOutboxSourceWorkflowNote, strconv.FormatInt(noteID, 10), targetRole,
@@ -169,7 +191,10 @@ FROM wake_outbox`
 // ListWakeOutboxObligations is the authoritative health projection for durable
 // wake delivery. Pending rows and attempted rows older than attemptedBefore are
 // the only non-terminal obligations; terminal outcomes never appear.
-func (s *Store) ListWakeOutboxObligations(ctx context.Context, attemptedBefore time.Time) ([]WakeOutboxEntry, error) {
+func (s *Store) ListWakeOutboxObligations(
+	ctx context.Context,
+	attemptedBefore time.Time,
+) (WakeOutboxObligationProjection, error) {
 	return listWakeOutboxObligations(ctx, s.db, attemptedBefore)
 }
 
@@ -181,14 +206,14 @@ func listWakeOutboxObligations(
 	ctx context.Context,
 	queryer wakeOutboxQueryer,
 	attemptedBefore time.Time,
-) ([]WakeOutboxEntry, error) {
+) (WakeOutboxObligationProjection, error) {
 	query, args := wakeOutboxObligationQuery(attemptedBefore)
 	rows, err := queryer.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, err
+		return WakeOutboxObligationProjection{}, err
 	}
 	defer rows.Close()
-	out := []WakeOutboxEntry{}
+	out := WakeOutboxObligationProjection{}
 	for rows.Next() {
 		var entry WakeOutboxEntry
 		if err := rows.Scan(
@@ -197,11 +222,34 @@ func listWakeOutboxObligations(
 			&entry.LastError, &entry.CreatedAt, &entry.AttemptedAt,
 			&entry.FinishedAt, &entry.UpdatedAt,
 		); err != nil {
-			return nil, err
+			return WakeOutboxObligationProjection{}, err
 		}
-		out = append(out, entry)
+		obligation := WakeOutboxObligation{
+			ID: entry.ID, SourceKind: entry.SourceKind, SourceID: entry.SourceID,
+			TargetRole: entry.TargetRole, CoalesceKey: entry.CoalesceKey,
+			CreatedAt: entry.CreatedAt,
+		}
+		interpretation, ok := interpretWakeOutboxState(entry.State)
+		if !ok {
+			return WakeOutboxObligationProjection{}, fmt.Errorf(
+				"wake outbox obligation row has unclassified state %q", entry.State,
+			)
+		}
+		switch interpretation {
+		case wakeOutboxStatePendingObligation:
+			out.Pending = append(out.Pending, obligation)
+		case wakeOutboxStateAgedAttemptObligation:
+			out.AgedAttempted = append(out.AgedAttempted, obligation)
+		default:
+			return WakeOutboxObligationProjection{}, fmt.Errorf(
+				"wake outbox obligation query returned non-obligation state %q", entry.State,
+			)
+		}
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return WakeOutboxObligationProjection{}, err
+	}
+	return out, nil
 }
 
 func wakeOutboxObligationQuery(attemptedBefore time.Time) (string, []any) {

--- a/internal/db/wake_outbox_binding_guard_test.go
+++ b/internal/db/wake_outbox_binding_guard_test.go
@@ -1,0 +1,254 @@
+package db
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+const wakeOutboxPredicateGenerator = "wakeOutboxObligationPredicate"
+
+type wakeOutboxBindingFunction struct {
+	decl *ast.FuncDecl
+}
+
+type wakeOutboxBindingAnalysis struct {
+	constructionSites map[string]struct{}
+	predicateBound    map[string]struct{}
+}
+
+func TestWakeOutboxObligationBindingIsTransitive(t *testing.T) {
+	dir := wakeOutboxGuardDirectory(t)
+	files := wakeOutboxProductionFiles(t, dir)
+	analysis := analyzeWakeOutboxBinding(t, files)
+	if err := wakeOutboxBindingViolation(analysis); err != nil {
+		t.Fatal(err)
+	}
+
+	fixture := filepath.Join(dir, "testdata", "wake_outbox_handwritten_query.go.txt")
+	negative := analyzeWakeOutboxBinding(t, []string{fixture})
+	err := wakeOutboxBindingViolation(negative)
+	if err == nil {
+		t.Fatalf("committed handwritten-query fixture %s unexpectedly passed the binding guard", fixture)
+	}
+	if !strings.Contains(err.Error(), "construction/projection sites only") {
+		t.Fatalf("committed handwritten-query fixture violation = %v, want set mismatch", err)
+	}
+}
+
+func wakeOutboxGuardDirectory(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve wake outbox guard source path")
+	}
+	return filepath.Dir(file)
+}
+
+func wakeOutboxProductionFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var files []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		files = append(files, filepath.Join(dir, name))
+	}
+	sort.Strings(files)
+	return files
+}
+
+func analyzeWakeOutboxBinding(t *testing.T, paths []string) wakeOutboxBindingAnalysis {
+	t.Helper()
+	fset := token.NewFileSet()
+	functions := make(map[string]wakeOutboxBindingFunction)
+	idsByName := make(map[string][]string)
+	for _, path := range paths {
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil {
+				continue
+			}
+			id := wakeOutboxFunctionID(function)
+			functions[id] = wakeOutboxBindingFunction{decl: function}
+			idsByName[function.Name.Name] = append(idsByName[function.Name.Name], id)
+		}
+	}
+
+	calls := make(map[string]map[string]struct{}, len(functions))
+	reverseCalls := make(map[string]map[string]struct{}, len(functions))
+	constructionSites := make(map[string]struct{})
+	for id, function := range functions {
+		calls[id] = make(map[string]struct{})
+		ast.Inspect(function.decl.Body, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := wakeOutboxCalledFunctionName(call.Fun)
+			for _, callee := range idsByName[name] {
+				calls[id][callee] = struct{}{}
+				if reverseCalls[callee] == nil {
+					reverseCalls[callee] = make(map[string]struct{})
+				}
+				reverseCalls[callee][id] = struct{}{}
+			}
+			return true
+		})
+		if wakeOutboxReturnsProjection(function.decl) ||
+			(wakeOutboxReturnsSQLTuple(function.decl) && wakeOutboxContainsSelect(function.decl)) {
+			constructionSites[id] = struct{}{}
+		}
+	}
+
+	predicateBound := make(map[string]struct{})
+	for id, functionCalls := range calls {
+		for _, generatorID := range idsByName[wakeOutboxPredicateGenerator] {
+			if _, ok := functionCalls[generatorID]; ok {
+				predicateBound[id] = struct{}{}
+			}
+		}
+	}
+	queue := wakeOutboxSetNames(predicateBound)
+	for len(queue) > 0 {
+		callee := queue[0]
+		queue = queue[1:]
+		for caller := range reverseCalls[callee] {
+			if _, seen := predicateBound[caller]; seen {
+				continue
+			}
+			predicateBound[caller] = struct{}{}
+			queue = append(queue, caller)
+		}
+	}
+	return wakeOutboxBindingAnalysis{
+		constructionSites: constructionSites,
+		predicateBound:    predicateBound,
+	}
+}
+
+func wakeOutboxFunctionID(function *ast.FuncDecl) string {
+	if function.Recv == nil || len(function.Recv.List) == 0 {
+		return function.Name.Name
+	}
+	return wakeOutboxExpressionName(function.Recv.List[0].Type) + "." + function.Name.Name
+}
+
+func wakeOutboxExpressionName(expression ast.Expr) string {
+	switch value := expression.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.StarExpr:
+		return wakeOutboxExpressionName(value.X)
+	case *ast.SelectorExpr:
+		return wakeOutboxExpressionName(value.X) + "." + value.Sel.Name
+	default:
+		return fmt.Sprintf("%T", expression)
+	}
+}
+
+func wakeOutboxCalledFunctionName(expression ast.Expr) string {
+	switch value := expression.(type) {
+	case *ast.Ident:
+		return value.Name
+	case *ast.SelectorExpr:
+		return value.Sel.Name
+	default:
+		return ""
+	}
+}
+
+func wakeOutboxReturnsProjection(function *ast.FuncDecl) bool {
+	if function.Type.Results == nil {
+		return false
+	}
+	for _, result := range function.Type.Results.List {
+		if wakeOutboxExpressionName(result.Type) == "WakeOutboxObligationProjection" {
+			return true
+		}
+	}
+	return false
+}
+
+func wakeOutboxReturnsSQLTuple(function *ast.FuncDecl) bool {
+	if function.Type.Results == nil || len(function.Type.Results.List) != 2 {
+		return false
+	}
+	first, firstOK := function.Type.Results.List[0].Type.(*ast.Ident)
+	second, secondOK := function.Type.Results.List[1].Type.(*ast.ArrayType)
+	if !firstOK || first.Name != "string" || !secondOK {
+		return false
+	}
+	element, ok := second.Elt.(*ast.Ident)
+	return ok && element.Name == "any"
+}
+
+func wakeOutboxContainsSelect(function *ast.FuncDecl) bool {
+	found := false
+	ast.Inspect(function.Body, func(node ast.Node) bool {
+		literal, ok := node.(*ast.BasicLit)
+		if !ok || literal.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(literal.Value)
+		if err == nil && strings.Contains(strings.ToLower(value), "from wake_outbox") {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func wakeOutboxBindingViolation(analysis wakeOutboxBindingAnalysis) error {
+	onlyConstruction := wakeOutboxSetDifference(analysis.constructionSites, analysis.predicateBound)
+	onlyPredicate := wakeOutboxSetDifference(analysis.predicateBound, analysis.constructionSites)
+	if len(analysis.constructionSites) == 0 {
+		return fmt.Errorf("wake outbox obligation guard found no construction or projection sites")
+	}
+	if len(onlyConstruction) == 0 && len(onlyPredicate) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"wake outbox obligation binding set mismatch: construction/projection sites only=%v; predicate-bound transitive callers only=%v",
+		onlyConstruction,
+		onlyPredicate,
+	)
+}
+
+func wakeOutboxSetDifference(left, right map[string]struct{}) []string {
+	var difference []string
+	for value := range left {
+		if _, ok := right[value]; !ok {
+			difference = append(difference, value)
+		}
+	}
+	sort.Strings(difference)
+	return difference
+}
+
+func wakeOutboxSetNames(values map[string]struct{}) []string {
+	names := make([]string, 0, len(values))
+	for value := range values {
+		names = append(names, value)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/db/wake_outbox_test.go
+++ b/internal/db/wake_outbox_test.go
@@ -9,6 +9,29 @@ import (
 	"time"
 )
 
+func TestWakeOutboxStateClassificationIsExhaustive(t *testing.T) {
+	tests := []struct {
+		state string
+		class wakeOutboxStateClass
+	}{
+		{WakeOutboxStatePending, wakeOutboxStateObligation},
+		{WakeOutboxStateAttempted, wakeOutboxStateObligation},
+		{WakeOutboxStateDelivered, wakeOutboxStateTerminal},
+		{WakeOutboxStateStalled, wakeOutboxStateTerminal},
+		{WakeOutboxStateFailed, wakeOutboxStateTerminal},
+		{WakeOutboxStateDeliveryUnknown, wakeOutboxStateDeliveryUnknown},
+	}
+	if len(tests) != int(wakeOutboxStateCount) {
+		t.Fatalf("classified states = %d, declared states = %d", len(tests), wakeOutboxStateCount)
+	}
+	for _, test := range tests {
+		class, ok := classifyWakeOutboxState(test.state)
+		if !ok || class != test.class {
+			t.Errorf("classifyWakeOutboxState(%q) = (%d, %v), want (%d, true)", test.state, class, ok, test.class)
+		}
+	}
+}
+
 func TestAddressedWorkflowNoteWritesOutboxThroughEveryInsertEntryPoint(t *testing.T) {
 	store := openWorkflowTestStore(t)
 	ctx := context.Background()

--- a/internal/db/wake_outbox_test.go
+++ b/internal/db/wake_outbox_test.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -36,86 +35,6 @@ func TestWakeOutboxStateClassificationIsExhaustive(t *testing.T) {
 			)
 		}
 	}
-}
-
-type recordingWakeOutboxQueryer struct {
-	delegate wakeOutboxQueryer
-	query    string
-	args     []any
-}
-
-func (r *recordingWakeOutboxQueryer) QueryContext(
-	ctx context.Context,
-	query string,
-	args ...any,
-) (*sql.Rows, error) {
-	r.query = query
-	r.args = append([]any(nil), args...)
-	return r.delegate.QueryContext(ctx, query, args...)
-}
-
-const expectedWakeOutboxObligationQuery = `
-SELECT id, source_kind, source_id, target_role, coalesce_key, state,
-		attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
-		COALESCE(finished_at, ''), updated_at
-FROM wake_outbox
-WHERE state = ? OR (state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)
-ORDER BY created_at, id`
-
-const handwrittenWakeOutboxObligationQueryFixture = `
-SELECT id, source_kind, source_id, target_role, coalesce_key, state,
-		attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
-		COALESCE(finished_at, ''), updated_at
-FROM wake_outbox
-WHERE state = 'pending'
-	OR (state = 'attempted' AND attempted_at IS NOT NULL AND attempted_at <= ?)
-ORDER BY created_at, id`
-
-func validateWakeOutboxObligationQuery(
-	query string,
-	args []any,
-	attemptedBefore time.Time,
-) error {
-	if query != expectedWakeOutboxObligationQuery {
-		return fmt.Errorf("executed query does not match the independent obligation contract")
-	}
-	wantArgs := []any{
-		"pending",
-		"attempted",
-		attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout),
-	}
-	if !reflect.DeepEqual(args, wantArgs) {
-		return fmt.Errorf("executed args = %#v, want independent args %#v", args, wantArgs)
-	}
-	return nil
-}
-
-func TestListWakeOutboxObligationsExecutesGeneratedQuery(t *testing.T) {
-	store := openWorkflowTestStore(t)
-	ctx := context.Background()
-	attemptedBefore := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
-	recorder := &recordingWakeOutboxQueryer{delegate: store.db}
-
-	if _, err := listWakeOutboxObligations(ctx, recorder, attemptedBefore); err != nil {
-		t.Fatal(err)
-	}
-	if err := validateWakeOutboxObligationQuery(recorder.query, recorder.args, attemptedBefore); err != nil {
-		t.Fatal(err)
-	}
-	t.Run("rejects handwritten bypass fixture", func(t *testing.T) {
-		args := []any{attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout)}
-		err := validateWakeOutboxObligationQuery(
-			handwrittenWakeOutboxObligationQueryFixture,
-			args,
-			attemptedBefore,
-		)
-		if err == nil {
-			t.Fatal("handwritten query fixture unexpectedly satisfied the obligation query contract")
-		}
-		if !strings.Contains(err.Error(), "does not match") {
-			t.Fatalf("handwritten query violation = %v, want query mismatch", err)
-		}
-	})
 }
 
 func TestWakeOutboxEntryStateRemainsSerializable(t *testing.T) {

--- a/internal/db/wake_outbox_test.go
+++ b/internal/db/wake_outbox_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -53,6 +54,42 @@ func (r *recordingWakeOutboxQueryer) QueryContext(
 	return r.delegate.QueryContext(ctx, query, args...)
 }
 
+const expectedWakeOutboxObligationQuery = `
+SELECT id, source_kind, source_id, target_role, coalesce_key, state,
+		attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
+		COALESCE(finished_at, ''), updated_at
+FROM wake_outbox
+WHERE state = ? OR (state = ? AND attempted_at IS NOT NULL AND attempted_at <= ?)
+ORDER BY created_at, id`
+
+const handwrittenWakeOutboxObligationQueryFixture = `
+SELECT id, source_kind, source_id, target_role, coalesce_key, state,
+		attempt_count, last_error, created_at, COALESCE(attempted_at, ''),
+		COALESCE(finished_at, ''), updated_at
+FROM wake_outbox
+WHERE state = 'pending'
+	OR (state = 'attempted' AND attempted_at IS NOT NULL AND attempted_at <= ?)
+ORDER BY created_at, id`
+
+func validateWakeOutboxObligationQuery(
+	query string,
+	args []any,
+	attemptedBefore time.Time,
+) error {
+	if query != expectedWakeOutboxObligationQuery {
+		return fmt.Errorf("executed query does not match the independent obligation contract")
+	}
+	wantArgs := []any{
+		"pending",
+		"attempted",
+		attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout),
+	}
+	if !reflect.DeepEqual(args, wantArgs) {
+		return fmt.Errorf("executed args = %#v, want independent args %#v", args, wantArgs)
+	}
+	return nil
+}
+
 func TestListWakeOutboxObligationsExecutesGeneratedQuery(t *testing.T) {
 	store := openWorkflowTestStore(t)
 	ctx := context.Background()
@@ -62,12 +99,39 @@ func TestListWakeOutboxObligationsExecutesGeneratedQuery(t *testing.T) {
 	if _, err := listWakeOutboxObligations(ctx, recorder, attemptedBefore); err != nil {
 		t.Fatal(err)
 	}
-	wantQuery, wantArgs := wakeOutboxObligationQuery(attemptedBefore)
-	if recorder.query != wantQuery {
-		t.Errorf("executed query:\n%s\nwant generated query:\n%s", recorder.query, wantQuery)
+	if err := validateWakeOutboxObligationQuery(recorder.query, recorder.args, attemptedBefore); err != nil {
+		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(recorder.args, wantArgs) {
-		t.Errorf("executed args = %#v, want generated args %#v", recorder.args, wantArgs)
+	t.Run("rejects handwritten bypass fixture", func(t *testing.T) {
+		args := []any{attemptedBefore.UTC().Format(BlockedEpisodeTimeLayout)}
+		err := validateWakeOutboxObligationQuery(
+			handwrittenWakeOutboxObligationQueryFixture,
+			args,
+			attemptedBefore,
+		)
+		if err == nil {
+			t.Fatal("handwritten query fixture unexpectedly satisfied the obligation query contract")
+		}
+		if !strings.Contains(err.Error(), "does not match") {
+			t.Fatalf("handwritten query violation = %v, want query mismatch", err)
+		}
+	})
+}
+
+func TestWakeOutboxEntryStateRemainsSerializable(t *testing.T) {
+	encoded, err := json.Marshal(WakeOutboxEntry{State: WakeOutboxStatePending})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(encoded), `"state":"pending"`) {
+		t.Fatalf("encoded wake outbox entry = %s, want serialized state", encoded)
+	}
+	var decoded WakeOutboxEntry
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.State != WakeOutboxStatePending {
+		t.Fatalf("decoded state = %q, want %q", decoded.State, WakeOutboxStatePending)
 	}
 }
 
@@ -102,8 +166,11 @@ INSERT INTO wake_outbox(
 		t.Fatal(err)
 	}
 	var got []string
-	for _, obligation := range obligations {
-		got = append(got, obligation.State)
+	for range obligations.Pending {
+		got = append(got, WakeOutboxStatePending)
+	}
+	for range obligations.AgedAttempted {
+		got = append(got, WakeOutboxStateAttempted)
 	}
 	want := []string{WakeOutboxStatePending, WakeOutboxStateAttempted}
 	if !reflect.DeepEqual(got, want) {
@@ -337,7 +404,7 @@ func TestExpireAgedWakeOutboxRecordsDeliveryUnknownWithoutRetry(t *testing.T) {
 	}
 
 	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedAt)
-	if err != nil || len(obligations) != 1 || obligations[0].State != WakeOutboxStateAttempted {
+	if err != nil || len(obligations.Pending) != 0 || len(obligations.AgedAttempted) != 1 {
 		t.Fatalf("obligations = %+v, err=%v", obligations, err)
 	}
 	expired, err := store.ExpireAgedWakeOutbox(ctx, attemptedAt, attemptedAt.Add(time.Minute))
@@ -358,7 +425,7 @@ func TestExpireAgedWakeOutboxRecordsDeliveryUnknownWithoutRetry(t *testing.T) {
 		t.Fatalf("delivery unknown events = %+v, err=%v", events, err)
 	}
 	obligations, err = store.ListWakeOutboxObligations(ctx, attemptedAt.Add(time.Hour))
-	if err != nil || len(obligations) != 0 {
+	if err != nil || obligations.Len() != 0 {
 		t.Fatalf("obligations after expiry = %+v, err=%v", obligations, err)
 	}
 	expired, err = store.ExpireAgedWakeOutbox(ctx, attemptedAt.Add(time.Hour), attemptedAt.Add(2*time.Hour))

--- a/internal/db/wake_outbox_test.go
+++ b/internal/db/wake_outbox_test.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -11,11 +13,11 @@ import (
 
 func TestWakeOutboxStateClassificationIsExhaustive(t *testing.T) {
 	tests := []struct {
-		state string
-		class wakeOutboxStateClass
+		state          string
+		interpretation wakeOutboxStateInterpretation
 	}{
-		{WakeOutboxStatePending, wakeOutboxStateObligation},
-		{WakeOutboxStateAttempted, wakeOutboxStateObligation},
+		{WakeOutboxStatePending, wakeOutboxStatePendingObligation},
+		{WakeOutboxStateAttempted, wakeOutboxStateAgedAttemptObligation},
 		{WakeOutboxStateDelivered, wakeOutboxStateTerminal},
 		{WakeOutboxStateStalled, wakeOutboxStateTerminal},
 		{WakeOutboxStateFailed, wakeOutboxStateTerminal},
@@ -25,10 +27,87 @@ func TestWakeOutboxStateClassificationIsExhaustive(t *testing.T) {
 		t.Fatalf("classified states = %d, declared states = %d", len(tests), wakeOutboxStateCount)
 	}
 	for _, test := range tests {
-		class, ok := classifyWakeOutboxState(test.state)
-		if !ok || class != test.class {
-			t.Errorf("classifyWakeOutboxState(%q) = (%d, %v), want (%d, true)", test.state, class, ok, test.class)
+		interpretation, ok := interpretWakeOutboxState(test.state)
+		if !ok || interpretation != test.interpretation {
+			t.Errorf(
+				"interpretWakeOutboxState(%q) = (%d, %v), want (%d, true)",
+				test.state, interpretation, ok, test.interpretation,
+			)
 		}
+	}
+}
+
+type recordingWakeOutboxQueryer struct {
+	delegate wakeOutboxQueryer
+	query    string
+	args     []any
+}
+
+func (r *recordingWakeOutboxQueryer) QueryContext(
+	ctx context.Context,
+	query string,
+	args ...any,
+) (*sql.Rows, error) {
+	r.query = query
+	r.args = append([]any(nil), args...)
+	return r.delegate.QueryContext(ctx, query, args...)
+}
+
+func TestListWakeOutboxObligationsExecutesGeneratedQuery(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	attemptedBefore := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	recorder := &recordingWakeOutboxQueryer{delegate: store.db}
+
+	if _, err := listWakeOutboxObligations(ctx, recorder, attemptedBefore); err != nil {
+		t.Fatal(err)
+	}
+	wantQuery, wantArgs := wakeOutboxObligationQuery(attemptedBefore)
+	if recorder.query != wantQuery {
+		t.Errorf("executed query:\n%s\nwant generated query:\n%s", recorder.query, wantQuery)
+	}
+	if !reflect.DeepEqual(recorder.args, wantArgs) {
+		t.Errorf("executed args = %#v, want generated args %#v", recorder.args, wantArgs)
+	}
+}
+
+func TestListWakeOutboxObligationsClassifiesAllStates(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	attemptedBefore := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	states := []struct {
+		state       string
+		attemptedAt any
+	}{
+		{WakeOutboxStatePending, nil},
+		{WakeOutboxStateAttempted, attemptedBefore.Add(-time.Minute).Format(BlockedEpisodeTimeLayout)},
+		{WakeOutboxStateDelivered, nil},
+		{WakeOutboxStateStalled, nil},
+		{WakeOutboxStateFailed, nil},
+		{WakeOutboxStateDeliveryUnknown, nil},
+	}
+	for index, state := range states {
+		if _, err := store.db.ExecContext(ctx, `
+INSERT INTO wake_outbox(
+	source_kind, source_id, target_role, coalesce_key, state, attempted_at
+) VALUES ('test', ?, 'owner', 'reply:owner', ?, ?)`,
+			strconv.Itoa(index), state.state, state.attemptedAt,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	obligations, err := store.ListWakeOutboxObligations(ctx, attemptedBefore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, obligation := range obligations {
+		got = append(got, obligation.State)
+	}
+	want := []string{WakeOutboxStatePending, WakeOutboxStateAttempted}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("obligation states = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
WAVE-IMPL: Make wake-outbox obligation classification exhaustive over every declared row state.

Closes #1225.

## What changed

- Define one authoritative state-definition array classifying all six states as obligation-bearing, terminal, or delivery-unknown.
- Add compile-time opposing length assertions tied to an `iota` declaration count, so adding an unclassified state or an undeclared definition fails compilation.
- Build the SQL obligation predicate from that same array; pending and aged attempted retain their exact existing predicates, while delivered, stalled, failed, and delivery_unknown remain excluded.
- Reuse the same classifier for `FinishWakeOutbox` terminal validation.
- Add an exhaustive test asserting the exact classification of every current state.

## Drift prevention

SQL and Go classification have one source of truth: `wakeOutboxStateDefinitions`. `ListWakeOutboxObligations` derives its clauses and arguments from the obligation-class entries instead of maintaining a handwritten state predicate. The declaration-count assertions make a state/definition mismatch a compile error in either direction.

## Mutation proof

Temporarily added `WakeOutboxStateDummy = "dummy"` inside the counted state block without a definition. The focused test command failed during compilation with:

```text
invalid array length len(wakeOutboxStateDefinitions) - wakeOutboxStateCount (constant -1 of type int)
dummy_state_test=1
```

The dummy state was removed; the focused exhaustive test then passed with `restored_test=0`.

## Verification

Shared caches used exactly as required. Full gate: **4,010 passed, 1 skipped**.

```text
build=0
vet=0
ok github.com/gitmoot/gitmoot/internal/db 260.373s
ok github.com/gitmoot/gitmoot/internal/workflow 251.201s
ok github.com/gitmoot/gitmoot/internal/cli 776.612s
test=0
diff_check=0
```

The four named #1215 Landlock skip patterns were the complete waiver; no other failure occurred.

---

## Consumer search record (round 4, criterion 4) — do not re-search

Recorded in the PR body rather than a comment so the next round starts from it. Search performed by `local-review-wave-impl-b-18c69e336d8eae65` at head `0250ebedb65d1d2d4d1b2861d4b62672444e629d`.

**Searched:** every state definition, every interpreter, every query builder, every `ListWakeOutboxObligations` caller, every `WakeOutboxState` reference, every raw `pending`/`attempted` SQL predicate, migration `CHECK`/index copies, the outstanding-obligation message, and the test-side expected list.

**Found — a third consumer, outside the `db` package entirely:** `internal/cli/reply_wake_outbox.go:42-75,150-173` independently recognizes only `pending`/`attempted`. Proven by probe: `wakeOutboxObligationHealth returned nil while the generated projection contained a delivered obligation`.

**Not found:** no other independent notion of *outstanding* in the locations above. That is a negative result with a scope — it does not cover consumers added since, or any that reach the projection indirectly.

### Round-4 criteria outcomes

| | |
|---|---|
| 1 — one total function, every consumer notices a field change | **MET** — pending→aged-attempt mutation fails both db consumers (`interpretWakeOutboxState("pending") = (1, true), want (0, true)`; `obligation states = [attempted], want [pending attempted]`) |
| 2 — generator binding proven by demonstrated failure | **NOT MET** — the guard derives expected SQL through the same bypassable wrapper under test; `criterion2_exact_bypass=0` |
| 3 — dummy-state compile failure | **MET** — `invalid array length len(wakeOutboxStateDefinitions) - wakeOutboxStateCount (constant -1 of type int)` |
| 4 — no remaining way for consumers to disagree | **NOT MET** — see the CLI consumer above |

Criteria 1 and 3 are **regression-forbidden** for any subsequent round.

*This defect has relocated in all four rounds. A three-seat design panel has been convened automatically under a standing pre-commitment; implementation is held until it reports.*