### PR TITLE
fix(cli): isolate reply wake drain failures (#1229)

### DIFF
--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -869,7 +869,7 @@ func runEnabledRepoWorkerTicksTracked(ctx context.Context, store *db.Store, work
 	// any repository. Drain before listing repos so zero enabled repos cannot
 	// suppress delivery or hide an unreadable outbox behind a healthy fleet tick.
 	if err := drainFleetReplyWakeOutbox(ctx, store, worker, now); err != nil {
-		return err
+		writeLine(stdout, "reply wake outbox drain unhealthy: %v", err)
 	}
 	repos, err := store.ListRepos(ctx)
 	if err != nil {

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -698,7 +698,7 @@ func startSingleRepoWorkerLoop(ctx context.Context, interval time.Duration, stor
 		// the supervisor boundary, outside the repository tick, matching the
 		// multi-repo fleet loop.
 		if err := drainFleetReplyWakeOutbox(ctx, store, worker, now); err != nil {
-			return err
+			writeLine(stdout, "reply wake outbox drain unhealthy: %v", err)
 		}
 		// The checkout lock now guards the TICK (maintenance + claim/dispatch),
 		// not whole job runs: dispatched jobs execute on their own goroutines

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -10,12 +11,103 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
+
+func TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork(t *testing.T) {
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-after-unhealthy-wake", Agent: "audit", Action: "ask",
+		Repo: "owner/repo", Branch: "main", PullRequest: 1,
+	})
+	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "release/drain-isolation", Author: "worker", Body: "no matching route",
+		AddressedTarget: "owner",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	worker := poolSchedulerWorker(t, store, &cliWorkerFakeAdapter{output: poolSchedulerAskResult}, false)
+	if err := runEnabledRepoWorkerTicksTracked(
+		context.Background(), store, worker, 1, "", &stdout, time.Now().UTC(), nil, nil,
+	); err != nil {
+		t.Fatalf("fleet tick aborted on reply wake drain failure: %v", err)
+	}
+	job, err := store.GetJob(context.Background(), "job-after-unhealthy-wake")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobSucceeded) {
+		t.Fatalf("repo job state = %q, want succeeded after unhealthy wake drain", job.State)
+	}
+	if !strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") {
+		t.Fatalf("fleet tick log = %q, want unhealthy wake drain", stdout.String())
+	}
+}
+
+func TestReplyWakeOutboxDrainFailureDoesNotEscalateSingleRepoLoop(t *testing.T) {
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
+	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "release/drain-streak", Author: "worker", Body: "persistently unroutable",
+		AddressedTarget: "owner",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	worker := defaultJobWorker(store, io.Discard, t.TempDir())
+	live := newDaemonReloadableConfig(30*time.Second, 1, false)
+	tracker := newInflightJobTracker(ctx)
+	var checkoutLock sync.Mutex
+	var stdout syncBuffer
+	errCh := startSingleRepoWorkerLoop(
+		ctx, 100*time.Microsecond, store, worker, live, &checkoutLock, tracker,
+		"owner/repo", "", &stdout,
+	)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for strings.Count(stdout.String(), "reply wake outbox drain unhealthy:") <= maxConsecutiveWorkerTickFailures {
+		select {
+		case err := <-errCh:
+			t.Fatalf("single-repo loop escalated persistent reply wake drain failure: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("single-repo loop did not survive beyond %d drain failures; log=%q", maxConsecutiveWorkerTickFailures, stdout.String())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	select {
+	case err := <-errCh:
+		t.Fatalf("single-repo loop exited after drain failures: %v", err)
+	default:
+	}
+
+	cancel()
+	select {
+	case err, ok := <-errCh:
+		if ok && err != nil {
+			t.Fatalf("single-repo loop shutdown surfaced error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("single-repo loop did not stop after cancellation")
+	}
+	if strings.Contains(stdout.String(), "consecutive failures, escalating") {
+		t.Fatalf("reply wake drain failure reached escalation ladder: %q", stdout.String())
+	}
+}
 
 func TestReplyWakeOutboxBurstCoalescesToExactlyOneWake(t *testing.T) {
 	store, sink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
@@ -223,7 +315,7 @@ func TestReplyWakeOutboxRecordsExistingDeliveryOutcomeStates(t *testing.T) {
 	}
 }
 
-func TestReplyWakeOutboxReadFailureFailsFleetTickClosedWithoutSinkOverride(t *testing.T) {
+func TestReplyWakeOutboxReadFailureLogsUnhealthyWithoutAbortingFleetTick(t *testing.T) {
 	store, _, _, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
 	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
 		WorkflowID: "release/read-failure", Author: "worker", Body: "must stay visible",
@@ -242,20 +334,21 @@ func TestReplyWakeOutboxReadFailureFailsFleetTickClosedWithoutSinkOverride(t *te
 	}
 
 	worker := defaultJobWorker(store, io.Discard, home)
+	var stdout bytes.Buffer
 	err = runEnabledRepoWorkerTicksTracked(
-		context.Background(), store, worker, 0, "", io.Discard,
+		context.Background(), store, worker, 0, "", &stdout,
 		time.Now().UTC(), nil, nil,
 	)
-	if err == nil {
-		t.Fatal("daemon tick reported healthy after the wake outbox became unreadable")
+	if err != nil {
+		t.Fatalf("daemon tick aborted after the wake outbox became unreadable: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reply wake outbox drain failed") ||
-		!strings.Contains(err.Error(), "no such table: wake_outbox") {
-		t.Fatalf("daemon tick error = %q, want explicit unreadable wake outbox cause", err)
+	if !strings.Contains(stdout.String(), "reply wake outbox drain unhealthy:") ||
+		!strings.Contains(stdout.String(), "no such table: wake_outbox") {
+		t.Fatalf("daemon tick log = %q, want explicit unreadable wake outbox cause", stdout.String())
 	}
 }
 
-func TestReplyWakeOutboxEventRulesReadFailureFailsFleetTickClosedWithoutSinkOverride(t *testing.T) {
+func TestReplyWakeOutboxEventRulesReadFailureLogsUnhealthyWithoutAbortingFleetTick(t *testing.T) {
 	store, _, _, home := replyWakeTestHarness(t, []replyWakeTestRole{{"owner", "w1:p1"}})
 	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
 		WorkflowID: "release/rules-read-failure", Author: "worker", Body: "must stay pending",
@@ -282,24 +375,25 @@ func TestReplyWakeOutboxEventRulesReadFailureFailsFleetTickClosedWithoutSinkOver
 	}
 
 	worker := defaultJobWorker(store, io.Discard, home)
+	var stdout bytes.Buffer
 	tickErr := runEnabledRepoWorkerTicksTracked(
-		context.Background(), store, worker, 0, "", io.Discard,
+		context.Background(), store, worker, 0, "", &stdout,
 		createdAt.Add(replyWakeCoalescingWindow+time.Second), nil, nil,
 	)
 	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
 	if err != nil || len(pending) != 1 {
 		t.Fatalf("pending rows after event_rules read failure = %+v, err=%v", pending, err)
 	}
-	if tickErr == nil {
-		t.Fatal("daemon tick reported healthy after sink resolution skipped a pending wake")
+	if tickErr != nil {
+		t.Fatalf("daemon tick aborted after sink resolution skipped a pending wake: %v", tickErr)
 	}
-	if !strings.Contains(tickErr.Error(), "resolve wake outbox delivery") ||
-		!strings.Contains(tickErr.Error(), "no such table: event_rules") {
-		t.Fatalf("daemon tick error = %q, want explicit event_rules read cause", tickErr)
+	if !strings.Contains(stdout.String(), "resolve wake outbox delivery") ||
+		!strings.Contains(stdout.String(), "no such table: event_rules") {
+		t.Fatalf("daemon tick log = %q, want explicit event_rules read cause", stdout.String())
 	}
 }
 
-func TestReplyWakeOutboxZeroRulesFailsFleetTickClosedWithoutSinkOverride(t *testing.T) {
+func TestReplyWakeOutboxZeroRulesLogsUnhealthyWithoutAbortingFleetTick(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
 	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
@@ -318,12 +412,16 @@ func TestReplyWakeOutboxZeroRulesFailsFleetTickClosedWithoutSinkOverride(t *test
 	}
 
 	worker := defaultJobWorker(store, io.Discard, home)
+	var stdout bytes.Buffer
 	tickErr := runEnabledRepoWorkerTicksTracked(
-		context.Background(), store, worker, 0, "", io.Discard,
+		context.Background(), store, worker, 0, "", &stdout,
 		time.Now().UTC(), nil, nil,
 	)
-	if tickErr == nil || !strings.Contains(tickErr.Error(), "outstanding obligations: pending=1") {
-		t.Fatalf("fleet tick error = %v, want pending-obligation health failure", tickErr)
+	if tickErr != nil {
+		t.Fatalf("fleet tick aborted on pending-obligation health failure: %v", tickErr)
+	}
+	if !strings.Contains(stdout.String(), "outstanding obligations: pending=1") {
+		t.Fatalf("fleet tick log = %q, want pending-obligation health failure", stdout.String())
 	}
 	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
 	if err != nil || len(pending) != 1 {
@@ -366,12 +464,16 @@ func TestReplyWakeOutboxUnrelatedEnabledRuleLeavesPendingObligationUnhealthy(t *
 	}
 
 	worker := defaultJobWorker(store, io.Discard, home)
+	var stdout bytes.Buffer
 	tickErr := runEnabledRepoWorkerTicksTracked(
-		context.Background(), store, worker, 0, "", io.Discard,
+		context.Background(), store, worker, 0, "", &stdout,
 		createdAt.Add(replyWakeCoalescingWindow+time.Second), nil, nil,
 	)
-	if tickErr == nil || !strings.Contains(tickErr.Error(), "outstanding obligations: pending=1") {
-		t.Fatalf("fleet tick error = %v, want pending-obligation health failure", tickErr)
+	if tickErr != nil {
+		t.Fatalf("fleet tick aborted on pending-obligation health failure: %v", tickErr)
+	}
+	if !strings.Contains(stdout.String(), "outstanding obligations: pending=1") {
+		t.Fatalf("fleet tick log = %q, want pending-obligation health failure", stdout.String())
 	}
 	pending, err = store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
 	if err != nil || len(pending) != 1 || pending[0].AttemptCount != 0 {
@@ -400,12 +502,16 @@ func TestReplyWakeOutboxAgedAttemptedExpiresDeliveryUnknownWithoutDuplicateWake(
 	worker := defaultJobWorker(store, io.Discard, home)
 	installReplyWakeProductionSink(t, worker, sink.sink)
 	recoveryAt := attemptedAt.Add(replyWakeAttemptedUnknownAfter)
+	var stdout bytes.Buffer
 	tickErr := runEnabledRepoWorkerTicksTracked(
-		context.Background(), store, worker, 0, "", io.Discard,
+		context.Background(), store, worker, 0, "", &stdout,
 		recoveryAt, nil, nil,
 	)
-	if tickErr == nil || !strings.Contains(tickErr.Error(), "delivery unknown") {
-		t.Fatalf("crash-recovery tick error = %v, want delivery-unknown health failure", tickErr)
+	if tickErr != nil {
+		t.Fatalf("crash-recovery tick aborted on delivery-unknown health failure: %v", tickErr)
+	}
+	if !strings.Contains(stdout.String(), "delivery unknown") {
+		t.Fatalf("crash-recovery tick log = %q, want delivery-unknown health failure", stdout.String())
 	}
 	if wake.promptCalls != 0 {
 		t.Fatalf("aged attempted row was blindly re-emitted: calls=%d prompts=%v", wake.promptCalls, wake.prompts)
@@ -460,12 +566,16 @@ func TestReplyWakeOutboxRuleDeletedMidDrainRefusesLaterBatch(t *testing.T) {
 
 	worker := defaultJobWorker(store, io.Discard, home)
 	installReplyWakeProductionSink(t, worker, sink.sink)
+	var stdout bytes.Buffer
 	tickErr := runEnabledRepoWorkerTicksTracked(
-		ctx, store, worker, 0, "", io.Discard,
+		ctx, store, worker, 0, "", &stdout,
 		base.Add(2*replyWakeCoalescingWindow+time.Second), nil, nil,
 	)
-	if tickErr == nil || !strings.Contains(tickErr.Error(), "outstanding obligations: pending=1") {
-		t.Fatalf("fleet tick error = %v, want later batch refusal", tickErr)
+	if tickErr != nil {
+		t.Fatalf("fleet tick aborted on later batch refusal: %v", tickErr)
+	}
+	if !strings.Contains(stdout.String(), "outstanding obligations: pending=1") {
+		t.Fatalf("fleet tick log = %q, want later batch refusal", stdout.String())
 	}
 	if wake.promptCalls != 1 {
 		t.Fatalf("wake calls = %d, want only the authorized first batch; prompts=%v", wake.promptCalls, wake.prompts)
@@ -513,14 +623,17 @@ END`); err != nil {
 
 	worker := defaultJobWorker(store, io.Discard, home)
 	installReplyWakeProductionSink(t, worker, sink.sink)
+	var stdout bytes.Buffer
 	tickErr := runEnabledRepoWorkerTicksTracked(
-		context.Background(), store, worker, 0, "", io.Discard,
+		context.Background(), store, worker, 0, "", &stdout,
 		createdAt.Add(replyWakeCoalescingWindow+time.Second), nil, nil,
 	)
-	if tickErr == nil ||
-		!strings.Contains(tickErr.Error(), "finish wake outbox as delivered") ||
-		!strings.Contains(tickErr.Error(), "forced wake outbox finish failure") {
-		t.Fatalf("fleet tick error = %v, want propagated post-claim finish failure", tickErr)
+	if tickErr != nil {
+		t.Fatalf("fleet tick aborted on post-claim finish failure: %v", tickErr)
+	}
+	if !strings.Contains(stdout.String(), "finish wake outbox as delivered") ||
+		!strings.Contains(stdout.String(), "forced wake outbox finish failure") {
+		t.Fatalf("fleet tick log = %q, want surfaced post-claim finish failure", stdout.String())
 	}
 	attempted, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStateAttempted)
 	if err != nil || len(attempted) != 1 {


### PR DESCRIPTION
WAVE-IMPL: Isolate durable reply-wake drain health from repo worker-tick failure escalation while preserving loud diagnostics and the #555 infra-fault ladder.

Closes #1229.

## Why

Four correct behaviours compose into a crash loop. #1201's producer correctly creates durable wake obligations. The drain correctly REFUSES to deliver a batch with no matching route. Obligation-derived health correctly reports outstanding work. The #555 ladder correctly escalates a persistent tick error. No component is misbehaving — which is precisely why three independent reviews and a reproduced mutation-probe suite all passed it. Component-level verification cannot see this class of defect.
The specific coupling: drainFleetReplyWakeOutbox runs BEFORE repo enumeration (round 7 acceptance criterion 3, correctly — so zero enabled repos cannot hide outstanding work). But returning its error there aborts the ENTIRE tick, so one role's undeliverable wake stopped polling, merging, and every other repository's work, and after 12 consecutive failures exited the daemon. Fail-closed became fail-dead. The ratified round-7 contract demanded an UNHEALTHY TICK while obligations exist; it never licensed process death.

## Change

The production diff is exactly the two ratified substitutions:
- Multi-repo fleet loop logs `reply wake outbox drain unhealthy` and continues to repo enumeration/work.
- Single-repo supervisor logs the same diagnostic and continues to its repo tick.

`maxConsecutiveWorkerTickFailures` and `startSupervisorWorkerLoopInternal` are unchanged.

## Regression evidence

1. `TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork`
   - Unfixed main: failed because `runEnabledRepoWorkerTicksTracked` returned the outstanding-obligation error before the queued repo job ran.
   - Branch: passes; the drain logs unhealthy and the following repo job reaches `succeeded`.
2. `TestReplyWakeOutboxDrainFailureDoesNotEscalateSingleRepoLoop`
   - Unfixed main: failed after the persistent drain error reached the 12-failure ceiling and exited the loop.
   - Branch: passes after more than 12 persistent drain refusals; the loop remains alive until explicit cancellation.
3. `TestRecoveringWorkerLoopEscalatesPersistentFault_555_E2E`
   - Unfixed main: passes, escalating a non-drain persistent SQLite-class fault at exactly the configured ceiling.
   - Branch: still passes unchanged, proving #555 remains fully armed.

Focused unfixed-main run: `unfixed_main_regressions=1`, with both new regressions failing for the expected causes. Focused branch run: all three acceptance tests pass.

## Gate

- `go build ./...`: `build=0`
- `go vet ./...`: `vet=0`
- Required three-package test: `test=0`
- Exact accounting: **4,031 passes / 2 skips** across 3 passing packages.
- Skips: `TestMaybeWrapCockpitDecision` (Herdr unavailable; covered by package tests) and `TestLiveKimiProduceLandlockState` (authenticated live opt-in).
