### PR TITLE
Gitmoot: GITMOOT-COC: IMPLEMENT F1 — give result_checks.go an OBSERVATION

### DIFF
--- a/internal/proof/project.go
+++ b/internal/proof/project.go
@@ -27,13 +27,14 @@ type PRReceipt struct {
 }
 
 type payloadProjection struct {
-	Repo               string                `json:"repo"`
-	PullRequest        int                   `json:"pull_request"`
-	HeadSHA            string                `json:"head_sha"`
-	WorkflowID         string                `json:"workflow_id"`
-	RuntimeOverride    string                `json:"runtime_override"`
-	RuntimeOverrideRef string                `json:"runtime_override_ref"`
-	Result             *workflow.AgentResult `json:"result"`
+	Repo               string                      `json:"repo"`
+	PullRequest        int                         `json:"pull_request"`
+	HeadSHA            string                      `json:"head_sha"`
+	WorkflowID         string                      `json:"workflow_id"`
+	RuntimeOverride    string                      `json:"runtime_override"`
+	RuntimeOverrideRef string                      `json:"runtime_override_ref"`
+	Result             *workflow.AgentResult       `json:"result"`
+	ResultObservation  *workflow.ResultObservation `json:"result_observation"`
 }
 
 type projector struct {
@@ -211,7 +212,7 @@ func (p *projector) factNodes(job db.Job, projection payloadProjection, result *
 		claims := make([]Claim, 0, len(result.ChangesMade)+1)
 		for i, change := range result.ChangesMade {
 			attrs[fmt.Sprintf("change.%d", i)] = change
-			claims = append(claims, reportedClaim("change", job, job.UpdatedAt))
+			claims = append(claims, projectedChangeClaim(job, projection.ResultObservation, i, change))
 		}
 		if job.ResultHash != "" {
 			matches := resultHashMatches(job.Payload, job.ResultHash)
@@ -316,6 +317,24 @@ func (p *projector) factNodes(job db.Job, projection payloadProjection, result *
 		}))
 	}
 	return children
+}
+
+func projectedChangeClaim(job db.Job, observation *workflow.ResultObservation, index int, change string) Claim {
+	if observation != nil && observation.Error == "" && index < len(observation.Changes) {
+		entry := observation.Changes[index]
+		if observation.Source == workflow.ResultObservationSourceWorktreeDiff &&
+			entry.Claim == change &&
+			entry.Grade == GradeObserved &&
+			!entry.Divergent &&
+			len(entry.ClaimedFiles) > 0 &&
+			len(entry.Observation) > 0 {
+			return Claim{
+				Type: "change", Grade: GradeObserved, Source: observation.Source,
+				EvidenceRef: job.ID, AsOf: job.UpdatedAt,
+			}
+		}
+	}
+	return reportedClaim("change", job, job.UpdatedAt)
 }
 
 func (p *projector) delegationNodes(parent db.Job, result *workflow.AgentResult) []string {

--- a/internal/proof/project.go
+++ b/internal/proof/project.go
@@ -324,10 +324,7 @@ func projectedChangeClaim(job db.Job, observation *workflow.ResultObservation, i
 		entry := observation.Changes[index]
 		if observation.Source == workflow.ResultObservationSourceWorktreeDiff &&
 			entry.Claim == change &&
-			entry.Grade == GradeObserved &&
-			!entry.Divergent &&
-			len(entry.ClaimedFiles) > 0 &&
-			len(entry.Observation) > 0 {
+			entry.IsExactPathObserved() {
 			return Claim{
 				Type: "change", Grade: GradeObserved, Source: observation.Source,
 				EvidenceRef: job.ID, AsOf: job.UpdatedAt,

--- a/internal/proof/project_test.go
+++ b/internal/proof/project_test.go
@@ -91,6 +91,36 @@ func TestGradingReportedObservedVerified(t *testing.T) {
 	}
 }
 
+func TestProjectGradesDiffCorroboratedChangeObserved(t *testing.T) {
+	result := &workflow.AgentResult{
+		Decision: "implemented", Summary: "changed result checks",
+		ChangesMade: []string{"updated internal/workflow/result_checks.go"},
+	}
+	observation := &workflow.ResultObservation{
+		Source:       workflow.ResultObservationSourceWorktreeDiff,
+		TouchedFiles: []string{"internal/workflow/result_checks.go"},
+		Changes: []workflow.ChangeObservation{{
+			Claim:        result.ChangesMade[0],
+			ClaimedFiles: []string{"internal/workflow/result_checks.go"},
+			Observation:  []string{"internal/workflow/result_checks.go"},
+			Grade:        GradeObserved,
+			Divergent:    false,
+		}},
+		ClaimedOnlyFiles: []string{},
+		UnclaimedFiles:   []string{},
+		UnboundClaims:    []string{},
+		Divergent:        false,
+	}
+	payload := workflow.JobPayload{Repo: "owner/repo", Result: result, ResultObservation: observation}
+	root := db.Job{
+		ID: "observed-change", RootID: "observed-change", Agent: "implementer",
+		Type: "implement", State: "succeeded", UpdatedAt: "2026-07-29 12:00:00",
+		Payload: proofPayload(t, payload),
+	}
+	manifest := Project(root, []db.Job{root}, map[string]*workflow.AgentResult{root.ID: result}, nil, nil)
+	assertClaim(t, manifest, KindCommit, "change", GradeObserved)
+}
+
 func TestManifestContentAddressStable(t *testing.T) {
 	root, jobs, results, receipts, events := proofFixture(t, false)
 	first := Project(root, jobs, results, receipts, events)

--- a/internal/proof/project_test.go
+++ b/internal/proof/project_test.go
@@ -121,6 +121,31 @@ func TestProjectGradesDiffCorroboratedChangeObserved(t *testing.T) {
 	assertClaim(t, manifest, KindCommit, "change", GradeObserved)
 }
 
+func TestProjectDoesNotPublishMismatchedPathBindingAsObserved(t *testing.T) {
+	result := &workflow.AgentResult{
+		Decision: "implemented", Summary: "changed result checks",
+		ChangesMade: []string{"updated docs/result_checks.go"},
+	}
+	observation := &workflow.ResultObservation{
+		Source:       workflow.ResultObservationSourceWorktreeDiff,
+		TouchedFiles: []string{"internal/workflow/result_checks.go"},
+		Changes: []workflow.ChangeObservation{{
+			Claim:        result.ChangesMade[0],
+			ClaimedFiles: []string{"docs/result_checks.go"},
+			Observation:  []string{"internal/workflow/result_checks.go"},
+			Grade:        GradeObserved,
+		}},
+	}
+	payload := workflow.JobPayload{Repo: "owner/repo", Result: result, ResultObservation: observation}
+	root := db.Job{
+		ID: "mismatched-observed-change", RootID: "mismatched-observed-change", Agent: "implementer",
+		Type: "implement", State: "succeeded", UpdatedAt: "2026-07-29 12:00:00",
+		Payload: proofPayload(t, payload),
+	}
+	manifest := Project(root, []db.Job{root}, map[string]*workflow.AgentResult{root.ID: result}, nil, nil)
+	assertClaim(t, manifest, KindCommit, "change", GradeReported)
+}
+
 func TestManifestContentAddressStable(t *testing.T) {
 	root, jobs, results, receipts, events := proofFixture(t, false)
 	first := Project(root, jobs, results, receipts, events)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -393,6 +393,12 @@ type JobPayload struct {
 	CheckRetries     int          `json:"check_retries,omitempty"`
 	RawOutputs       []string     `json:"raw_outputs,omitempty"`
 	Result           *AgentResult `json:"result,omitempty"`
+	// ResultObservation records the engine-owned git diff of an implement
+	// worktree at result-persistence time and its bidirectional comparison with
+	// changes_made. It is recorded independently of result-check mode; the
+	// existing off/warn/block policy decides whether divergence is merely stored,
+	// surfaced, or blocks the terminal gate.
+	ResultObservation *ResultObservation `json:"result_observation,omitempty"`
 	// FailureDiagnostics captures process-level crash context when the runtime
 	// session ended WITHOUT producing a gitmoot_result envelope (#806): a phase
 	// marker (launched | streaming | result-parse), the exit code or signal, a
@@ -1267,15 +1273,17 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 		result.HumanQuestions = nil
 	}
 	payload.Result = &result
-	// #526 deterministic binary-checklist audit of the parsed result. Off (the
-	// zero value and "off") => no checks run, no event, no payload field, no feed-
-	// forward row, so the terminal path is byte-identical. warn => failures are
-	// recorded (job event + job-detail field + feed-forward row) but the job still
-	// finishes on its own decision. block => a failure additionally routes the job
-	// down the same terminal path a malformed result takes (m.fail), reusing the
-	// contract-violation machinery. The audit itself is pure and LLM-free.
+	if strings.EqualFold(strings.TrimSpace(job.Type), "implement") {
+		payload.ResultObservation = observeResultChanges(ctx, payload.WorktreePath, result)
+	}
+	// #526 deterministic binary-checklist audit of the parsed result. The worktree
+	// observation above is recorded in every mode. Off (the zero value and "off")
+	// runs no checks and emits no failure; warn records failures (job event + job-
+	// detail field + feed-forward row) but preserves the result's decision; block
+	// additionally routes a failure down the same terminal path a malformed result
+	// takes (m.fail). The audit itself is pure and LLM-free.
 	if mode := normalizeResultCheckMode(m.resultCheckMode); mode != ResultChecksOff {
-		if failed := FailedResultChecks(ResultCheckInput{Action: job.Type, IsFinalize: payload.DelegationFinalize, Result: result}); len(failed) > 0 {
+		if failed := FailedResultChecks(ResultCheckInput{Action: job.Type, IsFinalize: payload.DelegationFinalize, Result: result, Observation: payload.ResultObservation}); len(failed) > 0 {
 			payload.ResultChecks = failed
 			summary := SummarizeResultChecks(failed)
 			// Surface in `gitmoot job events`/`job show`. Best-effort in block mode

--- a/internal/workflow/result_checks.go
+++ b/internal/workflow/result_checks.go
@@ -45,8 +45,8 @@ func toDBResultCheckFailures(failed []ResultCheck) []db.ResultCheckFailure {
 type ResultCheckMode string
 
 const (
-	// ResultChecksOff disables the audit (byte-identical pre-#526 behavior). It is
-	// also the meaning of the empty zero value.
+	// ResultChecksOff disables the audit. It is also the meaning of the empty
+	// zero value. Engine observations are persisted independently of this policy.
 	ResultChecksOff ResultCheckMode = "off"
 	// ResultChecksWarn records failures as a job event + job-detail field + feed-
 	// forward row without failing the job.
@@ -98,13 +98,16 @@ type ResultCheck struct {
 }
 
 // ResultCheckInput carries the minimal job context the deterministic checks need
-// beyond the parsed result: the job action and whether the job is a coordinator
-// finalize continuation (payload.DelegationFinalize). Keeping this a small value
-// type makes the check set trivially unit-testable without a store or a job row.
+// beyond the parsed result: the job action, whether the job is a coordinator
+// finalize continuation (payload.DelegationFinalize), and the engine's persisted
+// observation of an implement worktree when one was available. Keeping this a
+// small value type makes the check set trivially unit-testable without a store or
+// a job row.
 type ResultCheckInput struct {
-	Action     string
-	IsFinalize bool
-	Result     AgentResult
+	Action      string
+	IsFinalize  bool
+	Result      AgentResult
+	Observation *ResultObservation
 }
 
 // minActionableAnswerChars is the floor below which an ask/finalize answer is
@@ -117,9 +120,9 @@ const minActionableAnswerChars = 3
 // RunResultChecks evaluates every deterministic check that applies to the given
 // action/result and returns them all (passing and failing), each with its binary
 // verdict and — when failing — an explanation. It performs NO LLM call and reads
-// only fields that exist on AgentResult (see internal/workflow/result.go), so it
-// is pure, fast, and side-effect-free. Callers that only care about failures use
-// FailedResultChecks.
+// only its value input (the claim plus an engine-owned worktree observation), so
+// it is pure, fast, and side-effect-free. Callers that only care about failures
+// use FailedResultChecks.
 func RunResultChecks(in ResultCheckInput) []ResultCheck {
 	action := strings.ToLower(strings.TrimSpace(in.Action))
 	r := in.Result
@@ -154,6 +157,21 @@ func RunResultChecks(in ResultCheckInput) []ResultCheck {
 				Pass:        madePass,
 				Explanation: explain(madePass, "the implement job reports decision \"implemented\" but changes_made[] is empty"),
 			})
+			if in.Observation != nil && in.Observation.Error == "" {
+				consistent := !in.Observation.Divergent
+				checks = append(checks, ResultCheck{
+					ID:       "implement-changes-observed",
+					Action:   "implement",
+					Question: "Do the reported changes_made files match the files observed in the worktree diff?",
+					Pass:     consistent,
+					Explanation: explain(consistent, fmt.Sprintf(
+						"changes_made and the worktree diff diverge (claimed-only: %s; unclaimed diff files: %s; claims without a file path: %s)",
+						displayPaths(in.Observation.ClaimedOnlyFiles),
+						displayPaths(in.Observation.UnclaimedFiles),
+						displayPaths(in.Observation.UnboundClaims),
+					)),
+				})
+			}
 			testsPass := len(r.TestsRun) > 0
 			checks = append(checks, ResultCheck{
 				ID:          "implement-tests-listed",
@@ -211,6 +229,13 @@ func RunResultChecks(in ResultCheckInput) []ResultCheck {
 	}
 
 	return checks
+}
+
+func displayPaths(paths []string) string {
+	if len(paths) == 0 {
+		return "none"
+	}
+	return strings.Join(paths, ", ")
 }
 
 // FailedResultChecks runs the audit and returns only the checks that failed, in

--- a/internal/workflow/result_checks.go
+++ b/internal/workflow/result_checks.go
@@ -158,17 +158,19 @@ func RunResultChecks(in ResultCheckInput) []ResultCheck {
 				Explanation: explain(madePass, "the implement job reports decision \"implemented\" but changes_made[] is empty"),
 			})
 			if in.Observation != nil && in.Observation.Error == "" {
-				consistent := !in.Observation.Divergent
+				invalidObserved := invalidObservedClaims(in.Observation.Changes)
+				consistent := !in.Observation.Divergent && len(invalidObserved) == 0
 				checks = append(checks, ResultCheck{
 					ID:       "implement-changes-observed",
 					Action:   "implement",
 					Question: "Do the reported changes_made files match the files observed in the worktree diff?",
 					Pass:     consistent,
 					Explanation: explain(consistent, fmt.Sprintf(
-						"changes_made and the worktree diff diverge (claimed-only: %s; unclaimed diff files: %s; claims without a file path: %s)",
+						"changes_made and the worktree diff diverge (claimed-only: %s; unclaimed diff files: %s; claims without a file path: %s; invalid observed path bindings: %s)",
 						displayPaths(in.Observation.ClaimedOnlyFiles),
 						displayPaths(in.Observation.UnclaimedFiles),
 						displayPaths(in.Observation.UnboundClaims),
+						displayPaths(invalidObserved),
 					)),
 				})
 			}

--- a/internal/workflow/result_observation.go
+++ b/internal/workflow/result_observation.go
@@ -1,0 +1,280 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/gitmoot/gitmoot/internal/evidence"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+const ResultObservationSourceWorktreeDiff = "worktree_git_diff"
+
+var resultClaimLineSuffix = regexp.MustCompile(`:\d+(?:(?::|-)\d+)?$`)
+
+// ChangeObservation binds one reported changes_made entry to the files the
+// engine observed in the job worktree. GradeObserved means every file named by
+// the claim was present in the diff; it does not verify the claim's prose.
+type ChangeObservation struct {
+	Claim        string         `json:"claim"`
+	ClaimedFiles []string       `json:"claimed_files"`
+	Observation  []string       `json:"observation"`
+	Grade        evidence.Grade `json:"grade"`
+	Divergent    bool           `json:"divergent"`
+}
+
+// ResultObservation is the persisted, read-only comparison between an
+// implement result's changes_made claims and the git diff at result-persistence
+// time. ClaimedOnlyFiles records over-claims; UnclaimedFiles records diff paths
+// no claim mentions. Capture errors are evidence gaps, not persistence errors.
+type ResultObservation struct {
+	Source           string              `json:"source"`
+	TouchedFiles     []string            `json:"touched_files"`
+	Changes          []ChangeObservation `json:"changes"`
+	ClaimedOnlyFiles []string            `json:"claimed_only_files"`
+	UnclaimedFiles   []string            `json:"unclaimed_files"`
+	UnboundClaims    []string            `json:"unbound_claims"`
+	Divergent        bool                `json:"divergent"`
+	Error            string              `json:"error,omitempty"`
+}
+
+// observeResultChanges captures the worktree diff and binds it to the result.
+// A nil observation means the engine has no owned worktree from which to read.
+func observeResultChanges(ctx context.Context, worktree string, result AgentResult) *ResultObservation {
+	worktree = strings.TrimSpace(worktree)
+	if worktree == "" {
+		return nil
+	}
+	files, err := changedWorktreeFiles(ctx, worktree)
+	if err != nil {
+		return &ResultObservation{
+			Source:           ResultObservationSourceWorktreeDiff,
+			TouchedFiles:     []string{},
+			Changes:          reportedChangeObservations(result.ChangesMade),
+			ClaimedOnlyFiles: []string{},
+			UnclaimedFiles:   []string{},
+			UnboundClaims:    []string{},
+			Divergent:        false,
+			Error:            err.Error(),
+		}
+	}
+	return compareResultChanges(result.ChangesMade, files)
+}
+
+func changedWorktreeFiles(ctx context.Context, worktree string) ([]string, error) {
+	runner := subprocess.ExecRunner{}
+	tracked, err := runner.Run(ctx, worktree, "git", "diff", "--name-only", "--no-renames", "--no-ext-diff", "--ignore-submodules=none", "-z", "HEAD", "--")
+	if err != nil {
+		return nil, fmt.Errorf("observe tracked worktree diff: %w", err)
+	}
+	untracked, err := runner.Run(ctx, worktree, "git", "ls-files", "--others", "--exclude-standard", "-z", "--")
+	if err != nil {
+		return nil, fmt.Errorf("observe untracked worktree files: %w", err)
+	}
+	files := append(splitNULPaths(tracked.Stdout), splitNULPaths(untracked.Stdout)...)
+	return sortedUniquePaths(files), nil
+}
+
+func splitNULPaths(output string) []string {
+	var paths []string
+	for _, item := range strings.Split(output, "\x00") {
+		if item = strings.TrimSpace(item); item != "" {
+			paths = append(paths, item)
+		}
+	}
+	return paths
+}
+
+func sortedUniquePaths(files []string) []string {
+	seen := make(map[string]struct{}, len(files))
+	for _, file := range files {
+		file = normalizeClaimPath(file)
+		if file != "" {
+			seen[file] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for file := range seen {
+		out = append(out, file)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func reportedChangeObservations(claims []string) []ChangeObservation {
+	out := make([]ChangeObservation, 0, len(claims))
+	for _, claim := range claims {
+		out = append(out, ChangeObservation{
+			Claim:        claim,
+			ClaimedFiles: []string{},
+			Observation:  []string{},
+			Grade:        evidence.GradeReported,
+			Divergent:    false,
+		})
+	}
+	return out
+}
+
+func compareResultChanges(claims, touchedFiles []string) *ResultObservation {
+	touchedFiles = sortedUniquePaths(touchedFiles)
+	touched := make(map[string]struct{}, len(touchedFiles))
+	byBase := make(map[string][]string, len(touchedFiles))
+	for _, file := range touchedFiles {
+		touched[file] = struct{}{}
+		base := path.Base(file)
+		byBase[base] = append(byBase[base], file)
+	}
+
+	covered := make(map[string]struct{}, len(touchedFiles))
+	claimedOnly := make(map[string]struct{})
+	unboundClaims := make([]string, 0)
+	changes := make([]ChangeObservation, 0, len(claims))
+	for _, claim := range claims {
+		claimedFiles := claimFilePaths(claim, touchedFiles)
+		observed := make([]string, 0, len(claimedFiles))
+		divergent := len(claimedFiles) == 0
+		if divergent {
+			unboundClaims = append(unboundClaims, claim)
+		}
+		for _, claimed := range claimedFiles {
+			switch {
+			case hasPath(touched, claimed):
+				observed = append(observed, claimed)
+				covered[claimed] = struct{}{}
+			case len(byBase[path.Base(claimed)]) == 1:
+				match := byBase[path.Base(claimed)][0]
+				observed = append(observed, match)
+				covered[match] = struct{}{}
+			default:
+				divergent = true
+				claimedOnly[claimed] = struct{}{}
+			}
+		}
+		grade := evidence.GradeReported
+		if !divergent {
+			grade = evidence.GradeObserved
+		}
+		changes = append(changes, ChangeObservation{
+			Claim:        claim,
+			ClaimedFiles: claimedFiles,
+			Observation:  sortedUniquePaths(observed),
+			Grade:        grade,
+			Divergent:    divergent,
+		})
+	}
+
+	unclaimed := make([]string, 0)
+	for _, file := range touchedFiles {
+		if _, ok := covered[file]; !ok {
+			unclaimed = append(unclaimed, file)
+		}
+	}
+	claimedOnlyFiles := setKeys(claimedOnly)
+	return &ResultObservation{
+		Source:           ResultObservationSourceWorktreeDiff,
+		TouchedFiles:     touchedFiles,
+		Changes:          changes,
+		ClaimedOnlyFiles: claimedOnlyFiles,
+		UnclaimedFiles:   unclaimed,
+		UnboundClaims:    unboundClaims,
+		Divergent:        len(claimedOnlyFiles) > 0 || len(unclaimed) > 0 || len(unboundClaims) > 0 || anyDivergentChange(changes),
+	}
+}
+
+func claimFilePaths(claim string, touchedFiles []string) []string {
+	candidates := make([]string, 0)
+	for _, token := range strings.FieldsFunc(claim, claimTokenSeparator) {
+		token = strings.Trim(token, ".,;!?\"'`()[]{}<>")
+		token = resultClaimLineSuffix.ReplaceAllString(token, "")
+		token = strings.TrimSuffix(token, ":")
+		token = normalizeClaimPath(token)
+		if token != "" && looksLikeFilePath(token) {
+			candidates = append(candidates, token)
+		}
+	}
+	// Extensionless paths (for example Makefile) cannot be identified safely from
+	// arbitrary prose. Bind them only when the exact observed path or basename is
+	// explicitly present with token boundaries.
+	for _, file := range touchedFiles {
+		for _, candidate := range []string{file, path.Base(file)} {
+			if containsClaimToken(claim, candidate) {
+				candidates = append(candidates, candidate)
+			}
+		}
+	}
+	return sortedUniquePaths(candidates)
+}
+
+func claimTokenSeparator(r rune) bool {
+	return unicode.IsSpace(r) || strings.ContainsRune("\"'`()[]{}<>,;", r)
+}
+
+func normalizeClaimPath(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	value = strings.TrimPrefix(value, "./")
+	if value == "" || strings.Contains(value, "://") || strings.HasPrefix(value, "/") {
+		return ""
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return ""
+	}
+	return cleaned
+}
+
+func looksLikeFilePath(value string) bool {
+	if strings.Contains(value, "/") {
+		return true
+	}
+	ext := path.Ext(value)
+	if ext == "" || ext == value || len(ext) > 16 {
+		return false
+	}
+	for _, r := range ext[1:] {
+		if unicode.IsLetter(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsClaimToken(claim, candidate string) bool {
+	for _, token := range strings.FieldsFunc(claim, claimTokenSeparator) {
+		token = strings.Trim(token, ".,;!?\"'`()[]{}<>")
+		token = resultClaimLineSuffix.ReplaceAllString(token, "")
+		token = strings.TrimSuffix(token, ":")
+		token = normalizeClaimPath(token)
+		if token == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func hasPath(paths map[string]struct{}, candidate string) bool {
+	_, ok := paths[candidate]
+	return ok
+}
+
+func setKeys(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func anyDivergentChange(changes []ChangeObservation) bool {
+	for _, change := range changes {
+		if change.Divergent {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/workflow/result_observation.go
+++ b/internal/workflow/result_observation.go
@@ -28,6 +28,38 @@ type ChangeObservation struct {
 	Divergent    bool           `json:"divergent"`
 }
 
+// IsExactPathObserved reports whether an observed-grade entry binds every
+// normalized claimed path to that exact path in the worktree diff. It rejects
+// basename substitutions, including malformed observations persisted by older
+// engines, so downstream gates and proof projection do not manufacture
+// observed confidence from a different file with the same name.
+func (c ChangeObservation) IsExactPathObserved() bool {
+	if c.Grade != evidence.GradeObserved || c.Divergent ||
+		len(c.ClaimedFiles) == 0 || len(c.Observation) == 0 {
+		return false
+	}
+	claimed := sortedUniquePaths(c.ClaimedFiles)
+	observed := sortedUniquePaths(c.Observation)
+	if len(claimed) == 0 || len(claimed) != len(observed) {
+		return false
+	}
+	for i := range claimed {
+		if claimed[i] != observed[i] {
+			return false
+		}
+	}
+	fromClaim := claimFilePaths(c.Claim, observed)
+	if len(fromClaim) != len(claimed) {
+		return false
+	}
+	for i := range claimed {
+		if fromClaim[i] != claimed[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // ResultObservation is the persisted, read-only comparison between an
 // implement result's changes_made claims and the git diff at result-persistence
 // time. ClaimedOnlyFiles records over-claims; UnclaimedFiles records diff paths
@@ -138,6 +170,7 @@ func compareResultChanges(claims, touchedFiles []string) *ResultObservation {
 		claimedFiles := claimFilePaths(claim, touchedFiles)
 		observed := make([]string, 0, len(claimedFiles))
 		divergent := len(claimedFiles) == 0
+		exactPaths := len(claimedFiles) > 0
 		if divergent {
 			unboundClaims = append(unboundClaims, claim)
 		}
@@ -146,17 +179,21 @@ func compareResultChanges(claims, touchedFiles []string) *ResultObservation {
 			case hasPath(touched, claimed):
 				observed = append(observed, claimed)
 				covered[claimed] = struct{}{}
-			case len(byBase[path.Base(claimed)]) == 1:
-				match := byBase[path.Base(claimed)][0]
+			case !strings.Contains(claimed, "/") && len(byBase[claimed]) == 1:
+				// A unique basename can assist an unqualified filename claim, but
+				// it is not evidence that the agent named the observed repo path.
+				// Keep the binding reported rather than upgrading it to observed.
+				match := byBase[claimed][0]
 				observed = append(observed, match)
 				covered[match] = struct{}{}
+				exactPaths = false
 			default:
 				divergent = true
 				claimedOnly[claimed] = struct{}{}
 			}
 		}
 		grade := evidence.GradeReported
-		if !divergent {
+		if !divergent && exactPaths {
 			grade = evidence.GradeObserved
 		}
 		changes = append(changes, ChangeObservation{
@@ -277,4 +314,14 @@ func anyDivergentChange(changes []ChangeObservation) bool {
 		}
 	}
 	return false
+}
+
+func invalidObservedClaims(changes []ChangeObservation) []string {
+	var claims []string
+	for _, change := range changes {
+		if change.Grade == evidence.GradeObserved && !change.IsExactPathObserved() {
+			claims = append(claims, change.Claim)
+		}
+	}
+	return claims
 }

--- a/internal/workflow/result_observation_test.go
+++ b/internal/workflow/result_observation_test.go
@@ -1,0 +1,263 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/evidence"
+)
+
+func TestCompareResultChangesFlagsClaimedFileAbsentFromDiff(t *testing.T) {
+	observation := compareResultChanges(
+		[]string{"updated internal/workflow/absent.go"},
+		nil,
+	)
+	if !observation.Divergent {
+		t.Fatal("claim naming a file absent from the diff was not flagged")
+	}
+	if got, want := fmt.Sprint(observation.ClaimedOnlyFiles), "[internal/workflow/absent.go]"; got != want {
+		t.Fatalf("ClaimedOnlyFiles = %s, want %s", got, want)
+	}
+	if got := observation.Changes[0].Grade; got != evidence.GradeReported {
+		t.Fatalf("divergent claim grade = %q, want reported", got)
+	}
+	failed := failedIDs(ResultCheckInput{
+		Action:      "implement",
+		Result:      AgentResult{Decision: "implemented", ChangesMade: []string{"updated internal/workflow/absent.go"}, TestsRun: []string{"go test ./..."}},
+		Observation: observation,
+	})
+	if _, ok := failed["implement-changes-observed"]; !ok {
+		t.Fatalf("claimed-only divergence was not readable by the result gate; failed=%v", keys(failed))
+	}
+}
+
+func TestCompareResultChangesFlagsDiffFileNoClaimMentions(t *testing.T) {
+	observation := compareResultChanges(
+		[]string{"updated internal/workflow/claimed.go"},
+		[]string{"internal/workflow/claimed.go", "internal/workflow/unmentioned.go"},
+	)
+	if !observation.Divergent {
+		t.Fatal("diff file absent from every claim was not flagged")
+	}
+	if got, want := fmt.Sprint(observation.UnclaimedFiles), "[internal/workflow/unmentioned.go]"; got != want {
+		t.Fatalf("UnclaimedFiles = %s, want %s", got, want)
+	}
+	if got := observation.Changes[0].Grade; got != evidence.GradeObserved {
+		t.Fatalf("corroborated claim grade = %q, want observed", got)
+	}
+	failed := failedIDs(ResultCheckInput{
+		Action:      "implement",
+		Result:      AgentResult{Decision: "implemented", ChangesMade: []string{"updated internal/workflow/claimed.go"}, TestsRun: []string{"go test ./..."}},
+		Observation: observation,
+	})
+	if _, ok := failed["implement-changes-observed"]; !ok {
+		t.Fatalf("unclaimed diff file was not readable by the result gate; failed=%v", keys(failed))
+	}
+}
+
+func TestCompareResultChangesFlagsUnboundStructuredClaim(t *testing.T) {
+	claim := "Deleted _clear_private_pane_composer and removed its call"
+	observation := compareResultChanges(
+		[]string{claim},
+		[]string{"src/tendwire/command_submission.py"},
+	)
+	if !observation.Divergent {
+		t.Fatal("changes_made entry without a file path was not flagged")
+	}
+	if got, want := fmt.Sprint(observation.UnboundClaims), "["+claim+"]"; got != want {
+		t.Fatalf("UnboundClaims = %s, want %s", got, want)
+	}
+	if got, want := fmt.Sprint(observation.UnclaimedFiles), "[src/tendwire/command_submission.py]"; got != want {
+		t.Fatalf("UnclaimedFiles = %s, want %s", got, want)
+	}
+}
+
+func TestObserveResultChangesReadsTrackedAndUntrackedWorktreeDiff(t *testing.T) {
+	repo := observationTestRepo(t)
+	writeObservationFile(t, repo, "tracked.go", "package changed\n")
+	writeObservationFile(t, repo, "new.go", "package new\n")
+	runObservationGit(t, repo, "add", "tracked.go")
+
+	observation := observeResultChanges(context.Background(), repo, AgentResult{
+		ChangesMade: []string{"updated tracked.go", "added new.go"},
+	})
+	if observation == nil || observation.Error != "" {
+		t.Fatalf("observation = %+v, want successful worktree diff", observation)
+	}
+	if got, want := fmt.Sprint(observation.TouchedFiles), "[new.go tracked.go]"; got != want {
+		t.Fatalf("TouchedFiles = %s, want %s", got, want)
+	}
+	if observation.Divergent {
+		t.Fatalf("matching tracked + untracked claims diverged: %+v", observation)
+	}
+	for _, change := range observation.Changes {
+		if change.Grade != evidence.GradeObserved {
+			t.Fatalf("corroborated change grade = %q, want observed: %+v", change.Grade, change)
+		}
+	}
+}
+
+func TestMailboxResultObservationFlowsIntoOffWarnBlockGate(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		mode       ResultCheckMode
+		wantErr    bool
+		wantChecks bool
+	}{
+		{name: "off records without gating", mode: ResultChecksOff},
+		{name: "warn surfaces and succeeds", mode: ResultChecksWarn, wantChecks: true},
+		{name: "block surfaces and fails", mode: ResultChecksBlock, wantErr: true, wantChecks: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openTestStore(t)
+			repo := observationTestRepo(t)
+			mailbox := Mailbox{Store: store, resultCheckMode: tc.mode}
+			output := `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["updated absent.go"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
+			adapter := &fakeDelivery{outputs: []string{output}}
+			jobID := "observe-" + string(tc.mode)
+			if _, err := mailbox.Enqueue(ctx, JobRequest{
+				ID: jobID, Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot", WorktreePath: repo,
+			}); err != nil {
+				t.Fatalf("Enqueue: %v", err)
+			}
+			_, runErr := mailbox.Run(ctx, jobID, shellAgent(), adapter)
+			if tc.wantErr {
+				var checksErr *ResultChecksError
+				if !errors.As(runErr, &checksErr) {
+					t.Fatalf("Run error = %T %v, want ResultChecksError", runErr, runErr)
+				}
+			} else if runErr != nil {
+				t.Fatalf("Run: %v", runErr)
+			}
+			job, err := store.GetJob(ctx, jobID)
+			if err != nil {
+				t.Fatalf("GetJob: %v", err)
+			}
+			payload, err := unmarshalPayload(job.Payload)
+			if err != nil {
+				t.Fatalf("unmarshalPayload: %v", err)
+			}
+			if payload.ResultObservation == nil || !payload.ResultObservation.Divergent {
+				t.Fatalf("persisted ResultObservation = %+v, want divergence in every mode", payload.ResultObservation)
+			}
+			_, sawObservationCheck := resultCheckByID(payload.ResultChecks, "implement-changes-observed")
+			if sawObservationCheck != tc.wantChecks {
+				t.Fatalf("observation check present = %v, want %v; checks=%+v", sawObservationCheck, tc.wantChecks, payload.ResultChecks)
+			}
+		})
+	}
+}
+
+func TestMailboxResultObservationFlagsUnclaimedDiffFile(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	repo := observationTestRepo(t)
+	writeObservationFile(t, repo, "claimed.go", "package changed\n")
+	writeObservationFile(t, repo, "unmentioned.go", "package changed\n")
+
+	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksWarn}
+	output := `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["updated claimed.go"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
+	adapter := &fakeDelivery{outputs: []string{output}}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "observe-unclaimed", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot", WorktreePath: repo,
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "observe-unclaimed", shellAgent(), adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	job, err := store.GetJob(ctx, "observe-unclaimed")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if got, want := fmt.Sprint(payload.ResultObservation.UnclaimedFiles), "[unmentioned.go]"; got != want {
+		t.Fatalf("UnclaimedFiles = %s, want %s", got, want)
+	}
+	if _, ok := resultCheckByID(payload.ResultChecks, "implement-changes-observed"); !ok {
+		t.Fatalf("unclaimed diff file did not reach result gate: %+v", payload.ResultChecks)
+	}
+}
+
+func TestMailboxObservationGapRecordsWithoutRefusingPersistence(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	notGit := t.TempDir()
+	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksBlock}
+	output := `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["updated foo.go"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
+	adapter := &fakeDelivery{outputs: []string{output}}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "observe-gap", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot", WorktreePath: notGit,
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if _, err := mailbox.Run(ctx, "observe-gap", shellAgent(), adapter); err != nil {
+		t.Fatalf("an unavailable observation must be recorded, not refused: %v", err)
+	}
+	job, err := store.GetJob(ctx, "observe-gap")
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := unmarshalPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("unmarshalPayload: %v", err)
+	}
+	if payload.ResultObservation == nil || payload.ResultObservation.Error == "" {
+		t.Fatalf("observation gap was not persisted: %+v", payload.ResultObservation)
+	}
+	if len(payload.ResultChecks) != 0 {
+		t.Fatalf("an observation gap is not divergence and must not be refused: %+v", payload.ResultChecks)
+	}
+}
+
+func resultCheckByID(checks []ResultCheck, id string) (ResultCheck, bool) {
+	for _, check := range checks {
+		if check.ID == id {
+			return check, true
+		}
+	}
+	return ResultCheck{}, false
+}
+
+func observationTestRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runObservationGit(t, repo, "init")
+	runObservationGit(t, repo, "config", "user.email", "tests@gitmoot.local")
+	runObservationGit(t, repo, "config", "user.name", "Gitmoot Tests")
+	writeObservationFile(t, repo, "tracked.go", "package original\n")
+	writeObservationFile(t, repo, "claimed.go", "package original\n")
+	writeObservationFile(t, repo, "unmentioned.go", "package original\n")
+	runObservationGit(t, repo, "add", "-A")
+	runObservationGit(t, repo, "commit", "-m", "base")
+	return repo
+}
+
+func writeObservationFile(t *testing.T, repo, name, content string) {
+	t.Helper()
+	fullPath := filepath.Join(repo, name)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", name, err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", name, err)
+	}
+}
+
+func runObservationGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, output)
+	}
+}

--- a/internal/workflow/result_observation_test.go
+++ b/internal/workflow/result_observation_test.go
@@ -36,6 +36,82 @@ func TestCompareResultChangesFlagsClaimedFileAbsentFromDiff(t *testing.T) {
 	}
 }
 
+func TestCompareResultChangesDoesNotRebindQualifiedClaimByBasename(t *testing.T) {
+	const claim = "updated docs/result_checks.go"
+	observation := compareResultChanges(
+		[]string{claim},
+		[]string{"internal/workflow/result_checks.go"},
+	)
+	if !observation.Divergent {
+		t.Fatal("qualified claim was silently rebound by basename instead of flagged")
+	}
+	if got, want := fmt.Sprint(observation.ClaimedOnlyFiles), "[docs/result_checks.go]"; got != want {
+		t.Fatalf("ClaimedOnlyFiles = %s, want %s", got, want)
+	}
+	if got, want := fmt.Sprint(observation.UnclaimedFiles), "[internal/workflow/result_checks.go]"; got != want {
+		t.Fatalf("UnclaimedFiles = %s, want %s", got, want)
+	}
+	change := observation.Changes[0]
+	if got := change.Grade; got != evidence.GradeReported {
+		t.Fatalf("qualified mismatched claim grade = %q, want reported", got)
+	}
+	if got := fmt.Sprint(change.Observation); got != "[]" {
+		t.Fatalf("qualified mismatched claim observation = %s, want []", got)
+	}
+	failed := failedIDs(ResultCheckInput{
+		Action: "implement",
+		Result: AgentResult{
+			Decision: "implemented", ChangesMade: []string{claim}, TestsRun: []string{"go test ./..."},
+		},
+		Observation: observation,
+	})
+	if _, ok := failed["implement-changes-observed"]; !ok {
+		t.Fatalf("qualified-path divergence was not readable by the result gate; failed=%v", keys(failed))
+	}
+}
+
+func TestCompareResultChangesKeepsUnqualifiedBasenameBindingReported(t *testing.T) {
+	const claim = "updated result_checks.go"
+	observation := compareResultChanges(
+		[]string{claim},
+		[]string{"internal/workflow/result_checks.go"},
+	)
+	if observation.Divergent {
+		t.Fatalf("unique unqualified filename should bind without divergence: %+v", observation)
+	}
+	change := observation.Changes[0]
+	if got := change.Grade; got != evidence.GradeReported {
+		t.Fatalf("basename-assisted claim grade = %q, want reported", got)
+	}
+	if got, want := fmt.Sprint(change.Observation), "[internal/workflow/result_checks.go]"; got != want {
+		t.Fatalf("basename-assisted observation = %s, want %s", got, want)
+	}
+}
+
+func TestRunResultChecksRejectsMismatchedObservedPathBinding(t *testing.T) {
+	const claim = "updated docs/result_checks.go"
+	observation := &ResultObservation{
+		Source:       ResultObservationSourceWorktreeDiff,
+		TouchedFiles: []string{"internal/workflow/result_checks.go"},
+		Changes: []ChangeObservation{{
+			Claim:        claim,
+			ClaimedFiles: []string{"docs/result_checks.go"},
+			Observation:  []string{"internal/workflow/result_checks.go"},
+			Grade:        evidence.GradeObserved,
+		}},
+	}
+	failed := failedIDs(ResultCheckInput{
+		Action: "implement",
+		Result: AgentResult{
+			Decision: "implemented", ChangesMade: []string{claim}, TestsRun: []string{"go test ./..."},
+		},
+		Observation: observation,
+	})
+	if _, ok := failed["implement-changes-observed"]; !ok {
+		t.Fatalf("mismatched observed binding was not rejected by the result gate; failed=%v", keys(failed))
+	}
+}
+
 func TestCompareResultChangesFlagsDiffFileNoClaimMentions(t *testing.T) {
 	observation := compareResultChanges(
 		[]string{"updated internal/workflow/claimed.go"},

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2024,7 +2024,10 @@ contract-hygiene audit that catches results that are technically valid but vague
 or missing evidence. Each check is a yes/no question with an explanation, e.g.:
 
 - **implement** — a result whose decision is `implemented` must list its
-  `changes_made` and its `tests_run`.
+  `changes_made` and its `tests_run`. When the engine owns a job worktree, it
+  also persists `payload.result_observation` from the worktree diff and fails
+  `implement-changes-observed` if a claim names a path absent from the diff, a
+  claim names no file path, or the diff contains a path no claim mentions.
 - **review** — a `changes_requested` review must carry `findings` (evidence).
 - **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
   actionable.
@@ -2045,8 +2048,9 @@ result_checks = "warn"   # off | warn | block (default: warn)
   the web dashboard), but the job still finishes on its own decision.
 - `block` — a failing check additionally fails the job through the same terminal
   path a malformed result takes (opt-in, for strict workflows).
-- `off` — the audit is disabled entirely, restoring byte-identical pre-feature
-  behavior (no event, no payload field, no stored record).
+- `off` — the audit emits no check, event, or failure record. The worktree
+  observation is still persisted when available; recording evidence is
+  independent of whether a gate refuses it.
 
 A result that passes every applicable check records nothing, so the audit is
 quiet on healthy jobs. Failed checks are also stored durably so a later SkillOpt

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -555,7 +555,10 @@ work was available. Produce remains a leaf, so its delegations are stripped.
   an engine-run implement job with an owned worktree records
   `payload.result_observation`: the files in `git diff HEAD` plus untracked
   files, each claim's path binding, claimed-only paths, and diff files no claim
-  mentions. A fully bound claim is graded `observed`, not `verified`: Gitmoot
+  mentions. A claim that names a repo-relative path is graded `observed` only
+  when that exact normalized path is in the diff. A unique-basename match may
+  assist an unqualified filename (one with no directory separator), but that
+  binding remains `reported`. Even an exact match is not `verified`: Gitmoot
   observed the path in the diff but did not prove the prose semantics.
 - Use `needs` for missing credentials, unclear scope, unavailable tools, failing
   external services, or required human decisions.

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -550,7 +550,13 @@ work was available. Produce remains a leaf, so its delegations are stripped.
   An omitted `delivery_status` means unknown or not applicable, not "not
   delivered."
 - Do not claim tests were run unless they were actually run.
-- Do not claim files were changed unless they were actually changed.
+- Do not claim files were changed unless they were actually changed. Name
+  repo-relative file paths in each `changes_made` entry. At result persistence,
+  an engine-run implement job with an owned worktree records
+  `payload.result_observation`: the files in `git diff HEAD` plus untracked
+  files, each claim's path binding, claimed-only paths, and diff files no claim
+  mentions. A fully bound claim is graded `observed`, not `verified`: Gitmoot
+  observed the path in the diff but did not prove the prose semantics.
 - Use `needs` for missing credentials, unclear scope, unavailable tools, failing
   external services, or required human decisions.
 - Use `delegations` when another named Gitmoot agent should be invoked.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1811,7 +1811,10 @@ contract-hygiene audit that catches results that are technically valid but vague
 or missing evidence. Each check is a yes/no question with an explanation:
 
 - **implement** — a result whose decision is `implemented` must list its
-  `changes_made` and its `tests_run`.
+  `changes_made` and its `tests_run`. When the engine owns a job worktree, it
+  also persists `payload.result_observation` from the worktree diff and fails
+  `implement-changes-observed` if a claim names a path absent from the diff, a
+  claim names no file path, or the diff contains a path no claim mentions.
 - **review** — a `changes_requested` review must carry `findings` (evidence).
 - **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
   actionable.
@@ -1832,8 +1835,9 @@ result_checks = "warn"   # off | warn | block (default: warn)
   the web dashboard), but the job still finishes on its own decision.
 - `block` — a failing check additionally fails the job through the same terminal
   path a malformed result takes (opt-in, for strict workflows).
-- `off` — the audit is disabled entirely, restoring byte-identical pre-feature
-  behavior (no event, no payload field, no stored record).
+- `off` — the audit emits no check, event, or failure record. The worktree
+  observation is still persisted when available; recording evidence is
+  independent of whether a gate refuses it.
 
 A result that passes every applicable check records nothing, so the audit is
 quiet on healthy jobs. Failed checks are also stored durably for later SkillOpt

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -44,10 +44,15 @@ The `decision` field reports the outcome of the job:
 
 The narrative and evidence fields are reporting-only. Do not claim tests were run
 in `tests_run` unless they were actually run, and do not list files in
-`changes_made` unless they were actually changed. Use `needs` for missing
-credentials, unclear scope, unavailable tools, failing external services, or
-required human decisions. Always redact secrets from summaries, findings, raw
-command output, and examples.
+`changes_made` unless they were actually changed. Name repo-relative file paths
+in each `changes_made` entry. At result persistence, an engine-run implement job
+with an owned worktree records `payload.result_observation`: the files in
+`git diff HEAD` plus untracked files, each claim's path binding, claimed-only
+paths, and diff files no claim mentions. A fully bound claim is graded
+`observed`, not `verified`: Gitmoot observed the path in the diff but did not
+prove the prose semantics. Use `needs` for missing credentials, unclear scope,
+unavailable tools, failing external services, or required human decisions.
+Always redact secrets from summaries, findings, raw command output, and examples.
 
 ## Display-only in-session review state
 

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -48,10 +48,13 @@ in `tests_run` unless they were actually run, and do not list files in
 in each `changes_made` entry. At result persistence, an engine-run implement job
 with an owned worktree records `payload.result_observation`: the files in
 `git diff HEAD` plus untracked files, each claim's path binding, claimed-only
-paths, and diff files no claim mentions. A fully bound claim is graded
-`observed`, not `verified`: Gitmoot observed the path in the diff but did not
-prove the prose semantics. Use `needs` for missing credentials, unclear scope,
-unavailable tools, failing external services, or required human decisions.
+paths, and diff files no claim mentions. A claim that names a repo-relative path
+is graded `observed` only when that exact normalized path is in the diff. A
+unique-basename match may assist an unqualified filename (one with no directory
+separator), but that binding remains `reported`. Even an exact match is not
+`verified`: Gitmoot observed the path in the diff but did not prove the prose
+semantics. Use `needs` for missing credentials, unclear scope, unavailable
+tools, failing external services, or required human decisions.
 Always redact secrets from summaries, findings, raw command output, and examples.
 
 ## Display-only in-session review state

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11767,7 +11767,10 @@ contract-hygiene audit that catches results that are technically valid but vague
 or missing evidence. Each check is a yes/no question with an explanation, e.g.:
 
 - **implement** — a result whose decision is `implemented` must list its
-  `changes_made` and its `tests_run`.
+  `changes_made` and its `tests_run`. When the engine owns a job worktree, it
+  also persists `payload.result_observation` from the worktree diff and fails
+  `implement-changes-observed` if a claim names a path absent from the diff, a
+  claim names no file path, or the diff contains a path no claim mentions.
 - **review** — a `changes_requested` review must carry `findings` (evidence).
 - **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
   actionable.
@@ -11788,8 +11791,9 @@ result_checks = "warn"   # off | warn | block (default: warn)
   the web dashboard), but the job still finishes on its own decision.
 - `block` — a failing check additionally fails the job through the same terminal
   path a malformed result takes (opt-in, for strict workflows).
-- `off` — the audit is disabled entirely, restoring byte-identical pre-feature
-  behavior (no event, no payload field, no stored record).
+- `off` — the audit emits no check, event, or failure record. The worktree
+  observation is still persisted when available; recording evidence is
+  independent of whether a gate refuses it.
 
 A result that passes every applicable check records nothing, so the audit is
 quiet on healthy jobs. Failed checks are also stored durably so a later SkillOpt
@@ -16272,7 +16276,13 @@ work was available. Produce remains a leaf, so its delegations are stripped.
   An omitted `delivery_status` means unknown or not applicable, not "not
   delivered."
 - Do not claim tests were run unless they were actually run.
-- Do not claim files were changed unless they were actually changed.
+- Do not claim files were changed unless they were actually changed. Name
+  repo-relative file paths in each `changes_made` entry. At result persistence,
+  an engine-run implement job with an owned worktree records
+  `payload.result_observation`: the files in `git diff HEAD` plus untracked
+  files, each claim's path binding, claimed-only paths, and diff files no claim
+  mentions. A fully bound claim is graded `observed`, not `verified`: Gitmoot
+  observed the path in the diff but did not prove the prose semantics.
 - Use `needs` for missing credentials, unclear scope, unavailable tools, failing
   external services, or required human decisions.
 - Use `delegations` when another named Gitmoot agent should be invoked.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -16281,7 +16281,10 @@ work was available. Produce remains a leaf, so its delegations are stripped.
   an engine-run implement job with an owned worktree records
   `payload.result_observation`: the files in `git diff HEAD` plus untracked
   files, each claim's path binding, claimed-only paths, and diff files no claim
-  mentions. A fully bound claim is graded `observed`, not `verified`: Gitmoot
+  mentions. A claim that names a repo-relative path is graded `observed` only
+  when that exact normalized path is in the diff. A unique-basename match may
+  assist an unqualified filename (one with no directory separator), but that
+  binding remains `reported`. Even an exact match is not `verified`: Gitmoot
   observed the path in the diff but did not prove the prose semantics.
 - Use `needs` for missing credentials, unclear scope, unavailable tools, failing
   external services, or required human decisions.


### PR DESCRIPTION
WHAT:
WAVE-IMPL-B — Implemented on branch gitmoot/adhoc-38a330b9; PR pending finalizer; engine delivery pending, head unknown to me. Mailbox persistence now observes the owned worktree via git diff HEAD plus untracked files before invoking ResultCheckInput. Bidirectional divergence is persisted and exposed to the existing off/warn/block gate through implement-changes-observed. A corroborated changes_made entry earns grade observed because Gitmoot directly saw its named files in the persistence-time diff; it is not verified because file presence does not prove prose semantics or CI. This catches neither #1243 (representation identity — two renderings of one commit compared as strings), nor any claim made in prose, nor anything outside the F1 'unbound claim' family. A fix whose gaps are written down is worth more than one that looks total.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-38a330b9

RESULTS:
- Required unpiped gate: build=0; vet=0; test=0 — PASS=4047 SKIP=1.
- Focused restored regressions: go test ./internal/workflow/ -run 'TestMailboxResultObservation(FlowsIntoOffWarnBlockGate|FlagsUnclaimedDiffFile)$' -count=1 — pass.
- Proof grading regression: go test ./internal/proof/ -run TestProjectGradesDiffCorroboratedChangeObserved -count=1 — pass.
- Negative-control removal experiment — failed in both divergence directions as quoted, then restored.
- go generate ./... — generate=0; no additional Go artifacts changed.
- npm run build — Docusaurus production build and llms-full generation passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-38a330b9

AGENTS:
- wave-impl-b

RAW FINAL REVIEW OUTPUT:
````text
WAVE-IMPL-B — Implemented on branch gitmoot/adhoc-38a330b9; PR pending finalizer; engine delivery pending, head unknown to me. Mailbox persistence now observes the owned worktree via git diff HEAD plus untracked files before invoking ResultCheckInput. Bidirectional divergence is persisted and exposed to the existing off/warn/block gate through implement-changes-observed. A corroborated changes_made entry earns grade observed because Gitmoot directly saw its named files in the persistence-time diff; it is not verified because file presence does not prove prose semantics or CI. This catches neither #1243 (representation identity — two renderings of one commit compared as strings), nor any claim made in prose, nor anything outside the F1 'unbound claim' family. A fix whose gaps are written down is worth more than one that looks total.
````
