### PR TITLE
Gitmoot: WAVE-IMPL: #1241 — ROUTE blocked AND escalation THROUGH

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -155,8 +155,8 @@ blocks or fails a job — this mirrors the `escalate_human` notifier contract:
   **dropped** and a single best-effort `event_sink_drop` job event is recorded
   locally (so a drop is observable without coupling delivery to the job).
 
-Webhook delivery has no outbox or retry. Addressed-message role wakes are the
-exception: their producer-agnostic SQL outbox is described below.
+Webhook delivery has no outbox or retry. Reply, blocked, and escalation role
+wakes are the exception: their producer-agnostic SQL outbox is described below.
 
 ## Organization event-rule wakes
 
@@ -202,26 +202,30 @@ observation, or once the subject stops matching for a short grace
 within that grace never resets it, and a later re-block starts a fresh episode.
 Each synthesized event's `detail` carries the stable since-time, so a re-nudge
 (same `job_id` + same since) is distinguishable from a fresh episode.
-`reply` consumes addressed workflow notes and `kind=chat` messages from the
-durable wake outbox and only wakes the role named by both the message and the
-rule. Non-triggering chat back-links such as `job_result` do not enter the
-outbox. The daemon uses rolling five-second windows per role: one wake carries
-`N new items, oldest id X`.
-Pending, attempted, delivered, stalled, and failed remain queryable per outbox
-row, so an escalation that was never attempted is distinct from a successful
-wake. A quiet burst tail is flushed by a later daemon tick; it does not require
-another note. If the outbox or its delivery rules cannot be queried, or an
-outbox row cannot be parsed or claimed, the worker tick fails and the existing
-recovering supervisor retries and escalates a persistent shared-store fault; an
-indeterminate drain is never reported as healthy.
+`reply`, `blocked`, and `escalation` consume durable wake-outbox obligations.
+Reply obligations come from addressed workflow notes and `kind=chat` messages
+and only wake the role named by both the message and the rule. Non-triggering
+chat back-links such as `job_result` do not enter the outbox. Blocked and
+escalation obligations retain the redacted source event. Reply rows commit in
+the source note/chat transaction. Blocked and escalation rows are synchronously
+persisted after the source transition; insert failure is logged but cannot roll
+back the emitting job. The daemon uses rolling five-second windows per event
+kind and role, so same-kind events coalesce while a blocked event and a reply for
+the same role remain separate.
+Pending, attempted, delivered, stalled, failed, and `delivery_unknown` remain
+queryable per outbox row, and outstanding obligations contribute to daemon tick
+health. A quiet burst tail is flushed by a later daemon tick; it does not require
+another event. If the outbox or its delivery rules cannot be queried, or an
+outbox row cannot be parsed or claimed, the drain is logged as unhealthy and
+retried on a later tick without aborting unrelated repository work.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
 current id at wake time (so a recycled pane is still reached). Wake delivery runs
 `herdr agent prompt <pane> <prompt> --wait --timeout 8000` and treats
 `result.type = "agent_prompted"` — and a post-delivery `error.code = "timeout"` —
 as delivered, `error.code = "agent_prompt_stalled"` as not delivered. Missing
-bindings, unavailable Herdr, stalls, and transport errors are swallowed after
-lightweight logging; they never block or fail a job.
+bindings, unavailable Herdr, stalls, and transport errors never block or fail
+the emitting job; durable outcomes remain recorded on their outbox rows.
 
 Each `agent_prompt_stalled` outcome increments a durable, consecutive counter
 for the wake role; a delivered prompt resets that role's counter. Transport

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -32,9 +33,9 @@ type eventWakeClient interface {
 	ResolvePaneByLabel(context.Context, string) (string, bool)
 }
 
-// eventRuleSink decorates the existing outbound sink. Its rule work is detached
-// and timeout-bounded so a DB, config, or Herdr failure can never affect the job
-// emitting the event.
+// eventRuleSink decorates the existing outbound sink. Durable event families
+// persist their obligations before Emit returns; remaining rule work is detached
+// and timeout-bounded so delivery failures cannot fail the emitting job.
 type eventRuleSink struct {
 	inner events.Sink
 	store *db.Store
@@ -47,12 +48,47 @@ func (s *eventRuleSink) Emit(ctx context.Context, event events.Event) {
 		return
 	}
 	events.EmitEvent(ctx, s.inner, event)
-	if s.store == nil || s.wake == nil {
+	if s.store == nil {
 		return
 	}
 	// Classify BEFORE spawning: the webhook's normal (non-classifiable) traffic
 	// never touches the wake path, so it costs no goroutine or context.
-	if len(classifyEventRuleKinds(event)) == 0 {
+	kinds := classifyEventRuleKinds(event)
+	if len(kinds) == 0 {
+		return
+	}
+	if wakeKind, durable := durableWakeKind(kinds); durable {
+		rules, err := s.store.ListEventRules(ctx)
+		if err != nil {
+			slog.Warn("org event rules list failed", "job_id", event.JobID, "error", err)
+			return
+		}
+		targetRoles, remainingRules := partitionDurableWakeRules(rules, kinds, wakeKind, event)
+		if len(targetRoles) > 0 {
+			payload, err := json.Marshal(event)
+			if err != nil {
+				slog.Warn("durable wake event encode failed", "job_id", event.JobID, "kind", wakeKind, "error", err)
+				return
+			}
+			if err := s.store.InsertWakeOutbox(
+				ctx, wakeKind, string(payload), wakeKind, targetRoles,
+			); err != nil {
+				slog.Warn("durable wake outbox insert failed", "job_id", event.JobID, "kind", wakeKind, "error", err)
+				return
+			}
+		}
+		if s.wake == nil || len(remainingRules) == 0 {
+			return
+		}
+		base := context.WithoutCancel(ctx)
+		go func() {
+			if err := s.evaluateSafely(base, event, remainingRules); err != nil {
+				slog.Warn("org event wake failed", "job_id", event.JobID, "error", err)
+			}
+		}()
+		return
+	}
+	if s.wake == nil {
 		return
 	}
 	// Detach from the emitting job's ctx (a cancelled job must never cancel a
@@ -64,6 +100,35 @@ func (s *eventRuleSink) Emit(ctx context.Context, event events.Event) {
 			slog.Warn("org event wake failed", "job_id", event.JobID, "error", err)
 		}
 	}()
+}
+
+func durableWakeKind(kinds []string) (string, bool) {
+	for _, kind := range kinds {
+		switch kind {
+		case db.WakeOutboxKindBlocked, db.WakeOutboxKindEscalation:
+			return kind, true
+		}
+	}
+	return "", false
+}
+
+func partitionDurableWakeRules(
+	rules []db.EventRule,
+	kinds []string,
+	wakeKind string,
+	event events.Event,
+) (targetRoles []string, remaining []db.EventRule) {
+	for _, rule := range rules {
+		if !rule.Enabled || !containsEventRuleKind(kinds, rule.OnKind) || !eventRuleMatches(rule.MatchFilter, event) {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(rule.OnKind), wakeKind) {
+			targetRoles = append(targetRoles, rule.WakeRole)
+			continue
+		}
+		remaining = append(remaining, rule)
+	}
+	return targetRoles, remaining
 }
 
 // emitWakeOutbox evaluates one already-claimed durable wake synchronously. The

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -60,9 +61,6 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 
 	groups := make(map[string][]db.WakeOutboxObligation)
 	for _, entry := range obligations.Pending {
-		if !strings.HasPrefix(entry.CoalesceKey, db.WakeOutboxReplyCoalescePrefix) {
-			continue
-		}
 		key := strings.ToLower(strings.TrimSpace(entry.TargetRole)) + "\x00" + entry.CoalesceKey
 		groups[key] = append(groups[key], entry)
 	}
@@ -102,7 +100,10 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 			}
 
 			batch := items[start:end]
-			event := replyWakeEvent(batch, now)
+			event, err := wakeOutboxEvent(batch, now)
+			if err != nil {
+				return err
+			}
 			// Authorization is deliberately batch-scoped and pre-claim. A rule
 			// removed while an earlier synchronous batch is delivering cannot
 			// authorize this later claim, and no post-claim rule read can strand
@@ -114,7 +115,8 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 			if delivery.sink == nil {
 				break
 			}
-			if !hasMatchingReplyRule(delivery.rules, event) {
+			matchingRules := matchingWakeRules(delivery.rules, event)
+			if len(matchingRules) == 0 {
 				// Pending remains an explicit never-attempted state. A rule added
 				// later can deliver the same batch; nothing is silently erased.
 				break
@@ -129,8 +131,8 @@ func drainReplyWakeOutbox(ctx context.Context, store *db.Store, now time.Time, r
 			}
 			if claimed {
 				event.WakeOutboxIDs = ids
-				if err := emitReplyWakeOutboxEvent(ctx, delivery.sink, event, delivery.rules); err != nil {
-					return fmt.Errorf("emit claimed reply wake: %w", err)
+				if err := emitReplyWakeOutboxEvent(ctx, delivery.sink, event, matchingRules); err != nil {
+					return fmt.Errorf("emit claimed %s wake: %w", event.WakeKind, err)
 				}
 			}
 			start = end
@@ -167,33 +169,58 @@ func emitReplyWakeOutboxEvent(ctx context.Context, sink events.Sink, event event
 	return errors.New("wake outbox sink does not support synchronous delivery")
 }
 
-func replyWakeEvent(batch []db.WakeOutboxObligation, now time.Time) events.Event {
+func wakeOutboxEvent(batch []db.WakeOutboxObligation, now time.Time) (events.Event, error) {
+	if len(batch) == 0 {
+		return events.Event{}, errors.New("wake outbox batch is empty")
+	}
 	oldest := batch[0]
 	role := strings.ToLower(strings.TrimSpace(oldest.TargetRole))
-	detail := fmt.Sprintf("%d new items, oldest id %s", len(batch), oldest.SourceID)
-	event := events.NewEvent(
-		events.EventOrgReply,
-		"org-reply:"+role,
-		oldest.SourceKind+":"+oldest.SourceID,
-		"",
-		db.WakeOutboxStateAttempted,
-		detail,
-		now,
-		workflow.RedactCommentText,
-	)
-	event.Cause = "addressed_note"
+	var event events.Event
+	var wakeKind string
+	switch oldest.SourceKind {
+	case db.WakeOutboxSourceWorkflowNote, db.WakeOutboxSourceChatMessage:
+		wakeKind = db.WakeOutboxKindReply
+		detail := fmt.Sprintf("%d new items, oldest id %s", len(batch), oldest.SourceID)
+		event = events.NewEvent(
+			events.EventOrgReply,
+			"org-reply:"+role,
+			oldest.SourceKind+":"+oldest.SourceID,
+			"",
+			db.WakeOutboxStateAttempted,
+			detail,
+			now,
+			workflow.RedactCommentText,
+		)
+		event.Cause = "addressed_note"
+	case db.WakeOutboxSourceBlocked:
+		wakeKind = db.WakeOutboxKindBlocked
+		if err := json.Unmarshal([]byte(oldest.SourceID), &event); err != nil {
+			return events.Event{}, fmt.Errorf("decode blocked wake outbox event for row %d: %w", oldest.ID, err)
+		}
+	case db.WakeOutboxSourceEscalation:
+		wakeKind = db.WakeOutboxKindEscalation
+		if err := json.Unmarshal([]byte(oldest.SourceID), &event); err != nil {
+			return events.Event{}, fmt.Errorf("decode escalation wake outbox event for row %d: %w", oldest.ID, err)
+		}
+	default:
+		return events.Event{}, fmt.Errorf(
+			"wake outbox row %d has unsupported source kind %q",
+			oldest.ID, oldest.SourceKind,
+		)
+	}
+	event.WakeKind = wakeKind
 	event.WakeTargetRole = role
-	return event
+	return event, nil
 }
 
-func hasMatchingReplyRule(rules []db.EventRule, event events.Event) bool {
+func matchingWakeRules(rules []db.EventRule, event events.Event) []db.EventRule {
 	for _, rule := range rules {
 		if rule.Enabled &&
-			strings.EqualFold(strings.TrimSpace(rule.OnKind), "reply") &&
+			strings.EqualFold(strings.TrimSpace(rule.OnKind), strings.TrimSpace(event.WakeKind)) &&
 			strings.EqualFold(strings.TrimSpace(rule.WakeRole), strings.TrimSpace(event.WakeTargetRole)) &&
 			eventRuleMatches(rule.MatchFilter, event) {
-			return true
+			return []db.EventRule{rule}
 		}
 	}
-	return false
+	return nil
 }

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -17,9 +17,178 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/events"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
+
+func TestBlockedEventProducesDurableWakeOutboxObligation(t *testing.T) {
+	store, deliverySink, wake, _ := replyWakeTestHarness(
+		t,
+		[]replyWakeTestRole{{name: "owner", pane: "w1:p1"}},
+	)
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "blocked-owner", OnKind: "blocked", WakeRole: "owner", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	event := events.NewEvent(
+		events.EventJobBlocked,
+		"job-blocked",
+		"root-blocked",
+		"owner/repo",
+		"blocked",
+		"needs operator input",
+		time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC),
+		workflow.RedactCommentText,
+	)
+	deliverySink.sink.Emit(ctx, event)
+
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("blocked durable obligations = %d, want 1: %+v", len(pending), pending)
+	}
+	if pending[0].SourceKind != "blocked" ||
+		pending[0].TargetRole != "owner" ||
+		pending[0].CoalesceKey != "blocked:owner" {
+		t.Fatalf("blocked durable obligation = %+v", pending[0])
+	}
+
+	drainReplyWakeAfterAllRowsAreDue(t, store, deliverySink)
+	if wake.promptCalls != 1 || !strings.Contains(wake.prompt, "gitmoot blocked event") {
+		t.Fatalf("blocked wake = calls=%d prompt=%q, want one blocked wake", wake.promptCalls, wake.prompt)
+	}
+	delivered, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateDelivered)
+	if err != nil || len(delivered) != 1 {
+		t.Fatalf("delivered blocked obligations = %+v, err=%v", delivered, err)
+	}
+}
+
+func TestWakeOutboxCoalescesPerKindAndRole(t *testing.T) {
+	store, deliverySink, wake, _ := replyWakeTestHarness(
+		t,
+		[]replyWakeTestRole{{name: "owner", pane: "w1:p1"}},
+	)
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "blocked-owner", OnKind: "blocked", WakeRole: "owner", Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	for index := 0; index < 2; index++ {
+		event := events.NewEvent(
+			events.EventJobBlocked,
+			fmt.Sprintf("job-blocked-%d", index),
+			fmt.Sprintf("root-blocked-%d", index),
+			"owner/repo",
+			"blocked",
+			"needs operator input",
+			base.Add(time.Duration(index)*time.Second),
+			workflow.RedactCommentText,
+		)
+		deliverySink.sink.Emit(ctx, event)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID:      "release/coalesce-kinds",
+		Author:          "worker",
+		Body:            "reply for owner",
+		AddressedTarget: "owner",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 3 {
+		t.Fatalf("durable obligations = %d, want 3: %+v", len(pending), pending)
+	}
+	keysByKind := map[string]map[string]bool{}
+	for _, entry := range pending {
+		if keysByKind[entry.SourceKind] == nil {
+			keysByKind[entry.SourceKind] = map[string]bool{}
+		}
+		keysByKind[entry.SourceKind][entry.CoalesceKey] = true
+	}
+	if len(keysByKind["blocked"]) != 1 || !keysByKind["blocked"]["blocked:owner"] {
+		t.Fatalf("blocked coalesce keys = %v, want one blocked:owner key", keysByKind["blocked"])
+	}
+	if len(keysByKind[db.WakeOutboxSourceWorkflowNote]) != 1 ||
+		!keysByKind[db.WakeOutboxSourceWorkflowNote]["reply:owner"] {
+		t.Fatalf("reply coalesce keys = %v, want one reply:owner key", keysByKind[db.WakeOutboxSourceWorkflowNote])
+	}
+	if keysByKind["blocked"]["reply:owner"] {
+		t.Fatalf("blocked and reply obligations collided: %+v", pending)
+	}
+
+	drainReplyWakeAfterAllRowsAreDue(t, store, deliverySink)
+	if wake.promptCalls != 2 {
+		t.Fatalf("wake calls = %d, want one blocked and one reply wake: %q", wake.promptCalls, wake.prompts)
+	}
+	var blockedWakes, replyWakes int
+	for _, prompt := range wake.prompts {
+		switch {
+		case strings.Contains(prompt, "gitmoot blocked event"):
+			blockedWakes++
+		case strings.Contains(prompt, "gitmoot reply event"):
+			replyWakes++
+		}
+	}
+	if blockedWakes != 1 || replyWakes != 1 {
+		t.Fatalf("wake kinds = blocked:%d reply:%d, prompts=%q", blockedWakes, replyWakes, wake.prompts)
+	}
+}
+
+func TestWakeOutboxTickHealthIncludesBlockedAndEscalation(t *testing.T) {
+	store := daemonWorkerStore(t)
+	ctx := context.Background()
+	for _, rule := range []db.EventRule{
+		{ID: "blocked-owner", OnKind: "blocked", WakeRole: "owner", Enabled: true},
+		{ID: "escalation-owner", OnKind: "escalation", WakeRole: "owner", Enabled: true},
+	} {
+		if err := store.AddEventRule(ctx, rule); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sink := &eventRuleSink{store: store}
+	now := time.Now().UTC()
+	blocked := events.NewEvent(
+		events.EventJobBlocked, "job-blocked", "root-blocked", "owner/repo",
+		"blocked", "blocked", now, workflow.RedactCommentText,
+	)
+	escalation := events.NewEvent(
+		events.EventJobNeedsAttention, "job-escalated", "root-escalated", "owner/repo",
+		"awaiting_human", "answer required", now, workflow.RedactCommentText,
+	)
+	escalation.Cause = "escalation"
+	sink.Emit(ctx, blocked)
+	sink.Emit(ctx, escalation)
+
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pending) != 2 {
+		t.Fatalf("blocked/escalation obligations = %d, want 2: %+v", len(pending), pending)
+	}
+	kinds := map[string]bool{}
+	for _, entry := range pending {
+		kinds[entry.SourceKind] = true
+	}
+	if !kinds["blocked"] || !kinds["escalation"] {
+		t.Fatalf("pending source kinds = %v, want blocked and escalation", kinds)
+	}
+	if err := wakeOutboxObligationHealth(ctx, store, now.Add(-replyWakeAttemptedUnknownAfter)); err == nil ||
+		!strings.Contains(err.Error(), "pending=2") {
+		t.Fatalf("tick health = %v, want two outstanding obligations", err)
+	}
+}
 
 func TestReplyWakeOutboxDrainFailureDoesNotAbortRepoWork(t *testing.T) {
 	store := daemonWorkerStore(t)

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -26,9 +26,16 @@ const (
 const (
 	WakeOutboxDeliveryUnknownEventKind = "wake_delivery_unknown"
 
-	WakeOutboxSourceWorkflowNote  = "workflow_note"
-	WakeOutboxSourceChatMessage   = "chat_message"
-	WakeOutboxReplyCoalescePrefix = "reply:"
+	WakeOutboxKindReply      = "reply"
+	WakeOutboxKindBlocked    = "blocked"
+	WakeOutboxKindEscalation = "escalation"
+
+	WakeOutboxSourceWorkflowNote = "workflow_note"
+	WakeOutboxSourceChatMessage  = "chat_message"
+	WakeOutboxSourceBlocked      = WakeOutboxKindBlocked
+	WakeOutboxSourceEscalation   = WakeOutboxKindEscalation
+
+	WakeOutboxReplyCoalescePrefix = WakeOutboxKindReply + ":"
 )
 
 type wakeOutboxStateInterpretation uint8
@@ -101,7 +108,8 @@ func (p WakeOutboxObligationProjection) Len() int {
 
 func insertWorkflowNoteWakeOutboxTx(ctx context.Context, tx *sql.Tx, noteID int64, targetRole string) error {
 	if err := insertWakeOutboxTx(
-		ctx, tx, WakeOutboxSourceWorkflowNote, strconv.FormatInt(noteID, 10), targetRole,
+		ctx, tx, WakeOutboxSourceWorkflowNote, strconv.FormatInt(noteID, 10),
+		WakeOutboxKindReply, targetRole,
 	); err != nil {
 		return fmt.Errorf("insert workflow note wake outbox: %w", err)
 	}
@@ -119,14 +127,46 @@ func insertChatMessageWakeOutboxTx(ctx context.Context, tx *sql.Tx, messageID st
 			continue
 		}
 		seen[role] = struct{}{}
-		if err := insertWakeOutboxTx(ctx, tx, WakeOutboxSourceChatMessage, messageID, role); err != nil {
+		if err := insertWakeOutboxTx(
+			ctx, tx, WakeOutboxSourceChatMessage, messageID, WakeOutboxKindReply, role,
+		); err != nil {
 			return fmt.Errorf("insert chat message wake outbox: %w", err)
 		}
 	}
 	return nil
 }
 
-func insertWakeOutboxTx(ctx context.Context, tx *sql.Tx, sourceKind, sourceID, targetRole string) error {
+// InsertWakeOutbox persists one event as a durable obligation for each target
+// role. All rows share the event-kind coalescing namespace.
+func (s *Store) InsertWakeOutbox(
+	ctx context.Context,
+	sourceKind, sourceID, wakeKind string,
+	targetRoles []string,
+) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	seen := make(map[string]struct{}, len(targetRoles))
+	for _, targetRole := range targetRoles {
+		role := strings.ToLower(strings.TrimSpace(targetRole))
+		if role == "" {
+			continue
+		}
+		if _, exists := seen[role]; exists {
+			continue
+		}
+		seen[role] = struct{}{}
+		if err := insertWakeOutboxTx(ctx, tx, sourceKind, sourceID, wakeKind, role); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func insertWakeOutboxTx(ctx context.Context, tx *sql.Tx, sourceKind, sourceID, wakeKind, targetRole string) error {
 	sourceKind = strings.TrimSpace(sourceKind)
 	if sourceKind == "" {
 		return errors.New("wake outbox source kind is required")
@@ -139,17 +179,31 @@ func insertWakeOutboxTx(ctx context.Context, tx *sql.Tx, sourceKind, sourceID, t
 	if role == "" {
 		return errors.New("wake outbox target role is required")
 	}
-	_, err := tx.ExecContext(ctx, `
+	coalesceKey, err := wakeOutboxCoalesceKey(wakeKind, role)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
 INSERT INTO wake_outbox(source_kind, source_id, target_role, coalesce_key)
 VALUES (?, ?, ?, ?)`,
 		sourceKind,
 		sourceID,
 		role,
-		WakeOutboxReplyCoalescePrefix+role)
+		coalesceKey)
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func wakeOutboxCoalesceKey(wakeKind, role string) (string, error) {
+	kind := strings.ToLower(strings.TrimSpace(wakeKind))
+	switch kind {
+	case WakeOutboxKindReply, WakeOutboxKindBlocked, WakeOutboxKindEscalation:
+	default:
+		return "", fmt.Errorf("unsupported wake outbox kind %q", wakeKind)
+	}
+	return kind + ":" + strings.ToLower(strings.TrimSpace(role)), nil
 }
 
 // ListWakeOutbox returns durable delivery rows in insertion order. An empty

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -138,17 +138,19 @@ type Event struct {
 	// EventType. It is assigned by trusted emit sites and deliberately bypasses
 	// free-text redaction and path scrubbing.
 	Cause string `json:"cause,omitempty"`
-	// WakeTargetRole and WakeOutboxIDs are internal delivery metadata for the
-	// durable wake drain. They never alter the public event JSON contract.
+	// WakeKind, WakeTargetRole, and WakeOutboxIDs are internal delivery metadata
+	// for the durable wake drain. They never alter the public event JSON contract.
+	WakeKind       string  `json:"-"`
 	WakeTargetRole string  `json:"-"`
 	WakeOutboxIDs  []int64 `json:"-"`
 }
 
-// Sink is the injected, best-effort outbound seam the engine and daemon call
-// from the terminal-transition path. Implementations MUST be non-blocking and
-// MUST NOT return an error path that can fail a job: Emit is fire-and-forget.
-// A nil Sink is a no-op (callers guard with EmitEvent / a nil check), so the
-// default (no [events] config) path is byte-identical.
+// Sink is the injected outbound seam the engine and daemon call from the
+// terminal-transition path. Implementations may synchronously persist local
+// durable obligations, but network delivery stays detached and bounded. Emit
+// has no error path that can fail a job. A nil Sink is a no-op (callers guard
+// with EmitEvent / a nil check), so the default (no [events] config) path is
+// byte-identical.
 type Sink interface {
 	// Emit dispatches an event best-effort. It must not block beyond a bounded
 	// transport timeout and must never panic or fail the caller. ctx is honored

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1347,14 +1347,19 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that
 interval while the dialog remains pending. The pending signal takes precedence
 over the pane's last `idle` or `working` activity status.
-`reply` matches durable batches of workflow notes and `kind=chat` messages
-addressed to the same role as `--wake`; non-triggering chat back-links such as
-`job_result` are excluded. The daemon coalesces a rolling five-second window
-into one prompt carrying `N new items, oldest id X`; separate roles and later
-windows stay separate. A later tick flushes the quiet tail without requiring
-another message.
+`reply`, `blocked`, and `escalation` wakes use the durable wake outbox.
+`reply` matches workflow notes and `kind=chat` messages addressed to the same
+role as `--wake`; non-triggering chat back-links such as `job_result` are
+excluded. Reply rows commit atomically with their source note or chat message.
+Blocked and escalation rows are persisted synchronously by the event sink after
+the source transition; an insert failure is logged but cannot roll back the
+emitting job. The daemon coalesces a rolling five-second window per event kind
+and role. Reply prompts carry `N new items, oldest id X`; blocked and escalation
+events retain their redacted event detail. Different event kinds never share a
+coalescing key, and a later tick flushes a quiet tail without another event.
 Every outbox row retains a queryable `pending`, `attempted`, `delivered`,
-`stalled`, or `failed` state, so never-attempted is not confused with success.
+`stalled`, `failed`, or `delivery_unknown` state, so never-attempted is not
+confused with success and outstanding rows contribute to daemon tick health.
 `--match` is a case-insensitive substring matched independently against the
 event repo and job id; omit it to match every event of that kind. `--repo` is a
 discoverable alias for the same substring filter, useful for repo-to-role
@@ -1365,10 +1370,11 @@ literal pane id. The daemon calls `herdr agent prompt <pane> <text> --wait --tim
 8000` and treats delivered (`result.type = "agent_prompted"`, or a post-delivery
 `error.code = "timeout"`) apart from stalled (`error.code =
 "agent_prompt_stalled"`). Stalls increment the role's consecutive missed-wake
-counter and delivery resets it; transport failures leave it unchanged. Rules,
-pane resolution, counter writes, and wakes are best-effort; with no rule rows
-this path is off. Task episodes due in one evaluator pass produce one
-oldest-first digest event; blocked roles retain one event per role.
+counter and delivery resets it; transport failures leave it unchanged.
+`attention`, `guard`, `job-terminal`, `recycle-overdue`, and
+`pane_input_pending` wakes remain best-effort. With no rule rows this path is
+off. Task episodes due in one evaluator pass produce one oldest-first digest
+event; blocked roles retain one event per role.
 
 ## External-coordinator workflow groups
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1226,21 +1226,28 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that
 interval while the dialog remains pending. The pending signal takes precedence
 over the pane's last `idle` or `working` activity status.
-`reply` matches durable batches of workflow notes and `kind=chat` messages
-addressed to the same role as `--wake`; non-triggering chat back-links such as
-`job_result` are excluded. The daemon coalesces a rolling five-second window
-into one prompt carrying `N new items, oldest id X`; separate roles and later
-windows stay separate. A later tick flushes the quiet tail without requiring
-another message.
+`reply`, `blocked`, and `escalation` wakes use the durable wake outbox.
+`reply` matches workflow notes and `kind=chat` messages addressed to the same
+role as `--wake`; non-triggering chat back-links such as `job_result` are
+excluded. Reply rows commit atomically with their source note or chat message.
+Blocked and escalation rows are persisted synchronously by the event sink after
+the source transition; an insert failure is logged but cannot roll back the
+emitting job. The daemon coalesces a rolling five-second window per event kind
+and role. Reply prompts carry `N new items, oldest id X`; blocked and escalation
+events retain their redacted event detail. Different event kinds never share a
+coalescing key, and a later tick flushes a quiet tail without another event.
 Every outbox row retains a queryable `pending`, `attempted`, `delivered`,
-`stalled`, or `failed` state, so never-attempted is not confused with success.
+`stalled`, `failed`, or `delivery_unknown` state, so never-attempted is not
+confused with success and outstanding rows contribute to daemon tick health.
 `--match` is a case-insensitive substring matched against the event repo or job
 id; empty matches all. `--repo` is a discoverable alias for the same substring
 filter; pass only one of `--match` or `--repo`. The wake role must exist and set
 `pane = "<herdr-pane>"`; Gitmoot resolves that value as an exact pane label first
 and otherwise treats it as a literal pane id.
-Delivery is best-effort and verified with Herdr's `agent_prompted` versus
-`agent_prompt_stalled` result; zero rules leaves the feature off.
+Delivery is verified with Herdr's `agent_prompted` versus
+`agent_prompt_stalled` result. `attention`, `guard`, `job-terminal`,
+`recycle-overdue`, and `pane_input_pending` wakes remain best-effort; zero rules
+leaves the feature off.
 
 ```sh
 gitmoot orchestrate planner "Coordinate the dashboard wave." --repo owner/repo --workflow fable/dashboard-redesign


### PR DESCRIPTION
WHAT:
WAVE-IMPL: Implemented #1241 on base HEAD 4f573094b54182a0dbcfbd4ded9e112a1dc5b61e. Blocked and escalation wakes now create durable, health-visible obligations and drain by their own event kind.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-ec15adc5

RESULTS:
- Pre-fix focused tests: exit 1. Observed blocked obligations=0, mixed obligations=1 want 3, blocked/escalation obligations=0 want 2.
- Post-fix focused tests: PASS. Mutants caught: removing durable insertion or restoring reply-only matching; restoring reply-only/unique-per-event coalescing; omitting either new source kind from health. Exact nonzero row and wake counts prevent empty-input passes.
- go build ./...: build=0.
- go vet ./...: vet=0.
- env -u GITMOOT_STALE_RUNNING_AFTER go test ./internal/db/ ./internal/cli/: test=1; package pass=1, fail=1 due solely to the 600-second internal/cli timeout, skip=0.
- env -u GITMOOT_STALE_RUNNING_AFTER go test -timeout 25m ./internal/db/ ./internal/cli/: test_25m=0; package pass=2, fail=0, skip=0. DB 183.203s; CLI 646.665s.
- git diff --check: passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-ec15adc5

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
WAVE-IMPL: Implemented #1241 on base HEAD 4f573094b54182a0dbcfbd4ded9e112a1dc5b61e. Blocked and escalation wakes now create durable, health-visible obligations and drain by their own event kind.
````
