### PR TITLE
fix(org): #1175 slice 1 — collapse the two role-to-pane resolvers into one

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -240,7 +240,9 @@ outbox row cannot be parsed or claimed, the drain is logged as unhealthy and
 retried on a later tick without aborting unrelated repository work.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
-current id at wake time (so a recycled pane is still reached). Wake delivery runs
+current id at wake time (so a recycled pane is still reached). The same explicit
+binding drives live org presence; an unset binding reports unknown presence and
+causes event wakes to be skipped with an observable log. Wake delivery runs
 `herdr agent prompt <pane> <prompt> --wait --timeout 8000` and treats
 `result.type = "agent_prompted"` — and a post-delivery `error.code = "timeout"` —
 as delivered, `error.code = "agent_prompt_stalled"` as not delivered. Missing

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -209,6 +209,7 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 		}
 		pane, ok := s.resolveRolePane(ctx, cfg, rule.WakeRole)
 		if !ok {
+			slog.Warn("org event wake skipped", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "reason", "role pane binding unresolved")
 			continue
 		}
 		prompt := eventRuleWakePrompt(rule.OnKind, event)

--- a/internal/cockpit/herdr.go
+++ b/internal/cockpit/herdr.go
@@ -121,6 +121,7 @@ const herdrWakeTimeoutMS = 8000
 //   - error.code=agent_prompt_stalled (stderr, non-zero exit): submitted but no
 //     state change in herdr's effect window: not delivered, but a normal outcome,
 //     not a transport error.
+//
 // It reads the combined stream so the stderr envelopes above stay parseable.
 func (c herdrClient) agentPrompt(ctx context.Context, pane, prompt, until string) (delivered bool, stalled bool, err error) {
 	args := []string{"agent", "prompt", pane, prompt, "--wait", "--timeout", strconv.Itoa(herdrWakeTimeoutMS)}
@@ -296,7 +297,8 @@ func (c herdrClient) paneList(ctx context.Context) ([]string, error) {
 // resolvePaneByLabel returns the CURRENT pane id whose herdr label exactly equals
 // label. It is resolved at call (wake) time so a recycled pane's fresh id is
 // always used — the reason the org binding may name a stable label instead of a
-// wX:pY id. ok is false (with a nil error) when no live pane carries the label.
+// wX:pY id. ok is false (with a nil error) unless exactly one live pane carries
+// the label.
 func (c herdrClient) resolvePaneByLabel(ctx context.Context, label string) (string, bool, error) {
 	label = strings.TrimSpace(label)
 	if label == "" {
@@ -310,12 +312,16 @@ func (c herdrClient) resolvePaneByLabel(ctx context.Context, label string) (stri
 	if err := json.Unmarshal([]byte(out), &pl); err != nil {
 		return "", false, fmt.Errorf("parse pane list: %w", err)
 	}
+	resolved := ""
 	for _, p := range pl.Result.Panes {
 		if p.PaneID != "" && p.Label == label {
-			return p.PaneID, true, nil
+			if resolved != "" {
+				return "", false, nil
+			}
+			resolved = p.PaneID
 		}
 	}
-	return "", false, nil
+	return resolved, resolved != "", nil
 }
 
 // shortJobID trims a job id to the 8-char form used in the gm-<jobid8> agent

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -78,7 +78,6 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 		return org.Snapshot{}, fmt.Errorf("herdr api snapshot returned an incomplete snapshot shape")
 	}
 
-	byLabel := map[string][]herdrOrgPane{}
 	labelToPaneIDs := map[string][]string{}
 	paneByID := map[string]herdrOrgPane{}
 	for _, pane := range decoded.Result.Snapshot.Panes {
@@ -92,43 +91,31 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 				labelToPaneIDs[pane.Label] = append(labelToPaneIDs[pane.Label], pane.PaneID)
 			}
 		}
-		if pane.Label != "" {
-			byLabel[pane.Label] = append(byLabel[pane.Label], pane)
-		}
 	}
 	states := make(map[string]org.RoleLiveState, len(p.roles))
 	for _, role := range p.roles {
 		binding := strings.TrimSpace(role.Pane)
-		if binding != "" {
-			if len(labelToPaneIDs[binding]) > 1 {
-				states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: fmt.Sprintf("multiple Herdr panes labeled %q", binding)}
-				continue
-			}
-			paneID, _ := config.ResolveRolePaneBinding(ctx, binding, func(_ context.Context, label string) (string, bool) {
-				ids := labelToPaneIDs[label]
-				if len(ids) == 1 {
-					return ids[0], true
-				}
-				return "", false
-			})
-			pane, present := paneByID[paneID]
-			if !present {
-				states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: fmt.Sprintf("no Herdr pane bound as %q", binding)}
-				continue
-			}
-			states[role.Name] = mapHerdrPaneState(pane)
+		if binding == "" {
+			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: "Herdr pane binding is unset"}
 			continue
 		}
-
-		matches := byLabel[role.Name]
-		switch len(matches) {
-		case 0:
-			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: "no Herdr pane has this exact role label"}
-		case 1:
-			states[role.Name] = mapHerdrPaneState(matches[0])
-		default:
-			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: "multiple Herdr panes have this exact role label"}
+		if len(labelToPaneIDs[binding]) > 1 {
+			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: fmt.Sprintf("multiple Herdr panes labeled %q", binding)}
+			continue
 		}
+		paneID, _ := config.ResolveRolePaneBinding(ctx, binding, func(_ context.Context, label string) (string, bool) {
+			ids := labelToPaneIDs[label]
+			if len(ids) == 1 {
+				return ids[0], true
+			}
+			return "", false
+		})
+		pane, present := paneByID[paneID]
+		if !present {
+			states[role.Name] = org.RoleLiveState{State: org.StateUnknown, Detail: fmt.Sprintf("no Herdr pane bound as %q", binding)}
+			continue
+		}
+		states[role.Name] = mapHerdrPaneState(pane)
 	}
 	now := time.Now
 	if p.now != nil {

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -35,9 +35,11 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 ]}}}`, nil
 	}
 	provider := newHerdrOrgProvider(run, []config.OrgRole{
-		{Name: "owner"}, {Name: "review"}, {Name: "done"}, {Name: "idle"}, {Name: "future"},
-		{Name: "duplicate"}, {Name: "missing"}, {Name: "whitespace-label"}, {Name: "whitespace-status"},
-		{Name: "pending-working"}, {Name: "pending-idle"}, {Name: "pending-unknown"},
+		{Name: "owner", Pane: "owner"}, {Name: "review", Pane: "review"}, {Name: "done", Pane: "done"},
+		{Name: "idle", Pane: "idle"}, {Name: "future", Pane: "future"}, {Name: "duplicate", Pane: "duplicate"},
+		{Name: "missing", Pane: "missing"}, {Name: "whitespace-label", Pane: "whitespace-label"},
+		{Name: "whitespace-status", Pane: "whitespace-status"}, {Name: "pending-working", Pane: "pending-working"},
+		{Name: "pending-idle", Pane: "pending-idle"}, {Name: "pending-unknown", Pane: "pending-unknown"},
 	}, func() time.Time { return observed })
 	snapshot, err := provider.Snapshot(context.Background())
 	if err != nil {
@@ -72,6 +74,78 @@ func TestHerdrOrgProviderSnapshotMapping(t *testing.T) {
 		if activity := snapshot.States[role].Activity; activity != nil {
 			t.Errorf("activity[%s] = %+v, want absent", role, activity)
 		}
+	}
+}
+
+func TestHerdrOrgProviderPresenceWakePaneBindingParity(t *testing.T) {
+	const panes = `[
+{"pane_id":"w1:p1","label":"unique-label","agent_status":"working"},
+{"pane_id":"w1:p2","label":"duplicate-label","agent_status":"idle"},
+{"pane_id":"w1:p3","label":"duplicate-label","agent_status":"blocked"},
+{"pane_id":"w1:p4","label":"literal-label","agent_status":"done"},
+{"pane_id":"w1:p5","label":"empty-binding","agent_status":"working"}
+]`
+	run := func(_ context.Context, args ...string) (string, error) {
+		switch strings.Join(args, " ") {
+		case "api snapshot":
+			return `{"result":{"snapshot":{"version":"0.7.5","panes":` + panes + `}}}`, nil
+		case "pane list":
+			return `{"result":{"panes":` + panes + `}}`, nil
+		default:
+			t.Fatalf("unexpected Herdr args: %v", args)
+			return "", nil
+		}
+	}
+	client := herdrClient{run: run}
+	resolveWake := func(binding string) (string, bool) {
+		paneID, ok := config.ResolveRolePaneBinding(context.Background(), binding, func(_ context.Context, label string) (string, bool) {
+			resolved, found, err := client.resolvePaneByLabel(context.Background(), label)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !found {
+				return "", false
+			}
+			return resolved, true
+		})
+		return paneID, ok
+	}
+	tests := []struct {
+		name       string
+		binding    string
+		wantPane   string
+		wantState  org.LifecycleState
+		wantDetail string
+		wantOK     bool
+	}{
+		{name: "empty binding", binding: "", wantState: org.StateUnknown, wantDetail: "Herdr pane binding is unset"},
+		{name: "binding matching one label", binding: "unique-label", wantPane: "w1:p1", wantState: org.StateWorking, wantOK: true},
+		{name: "binding matching multiple labels", binding: "duplicate-label", wantState: org.StateUnknown},
+		{name: "literal pane id", binding: "w1:p4", wantPane: "w1:p4", wantState: org.StateDone, wantOK: true},
+		{name: "binding matching nothing", binding: "missing-label", wantState: org.StateUnknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot, err := newHerdrOrgProvider(run, []config.OrgRole{{
+				Name: "empty-binding", Pane: test.binding,
+			}}, time.Now).Snapshot(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			wakePane, wakeOK := resolveWake(test.binding)
+			if wakePane != test.wantPane || wakeOK != test.wantOK {
+				t.Fatalf("wake resolution = (%q, %t), want (%q, %t)", wakePane, wakeOK, test.wantPane, test.wantOK)
+			}
+			if got := snapshot.States["empty-binding"].State; got != test.wantState {
+				t.Fatalf("presence state = %q, want %q; wake resolution = (%q, %t)", got, test.wantState, wakePane, wakeOK)
+			}
+			if test.wantDetail != "" && snapshot.States["empty-binding"].Detail != test.wantDetail {
+				t.Fatalf("presence detail = %q, want %q", snapshot.States["empty-binding"].Detail, test.wantDetail)
+			}
+			if (snapshot.States["empty-binding"].State != org.StateUnknown) != wakeOK {
+				t.Fatalf("presence/wake parity: presence = %+v, wake resolution = (%q, %t)", snapshot.States["empty-binding"], wakePane, wakeOK)
+			}
+		})
 	}
 }
 
@@ -148,7 +222,7 @@ func TestHerdrOrgProviderSnapshotAbsentTurnIsOmitted(t *testing.T) {
 {"pane_id":"w1:p1","label":"owner","agent_status":"idle"}
 ]}}}`, nil
 	}
-	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner", Pane: "owner"}}, time.Now)
 	snapshot, err := provider.Snapshot(context.Background())
 	if err != nil {
 		t.Fatalf("Snapshot() error = %v", err)
@@ -175,7 +249,7 @@ func TestHerdrOrgProviderSnapshotPartialTurnIsAbsent(t *testing.T) {
 {"pane_id":"w1:p1","label":"owner","agent_status":"working","last_completed_turn":{"turn":1,"turn_epoch":2}}
 ]}}}`, nil
 	}
-	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+	provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner", Pane: "owner"}}, time.Now)
 	snapshot, err := provider.Snapshot(context.Background())
 	if err != nil {
 		t.Fatalf("Snapshot() error = %v", err)
@@ -205,7 +279,7 @@ func TestHerdrOrgProviderSnapshotInvalidTurnValuesAreAbsent(t *testing.T) {
 {"pane_id":"w1:p1","label":"owner","agent_status":"working","last_completed_turn":` + test.turn + `}
 ]}}}`, nil
 			}
-			provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner"}}, time.Now)
+			provider := newHerdrOrgProvider(run, []config.OrgRole{{Name: "owner", Pane: "owner"}}, time.Now)
 			snapshot, err := provider.Snapshot(context.Background())
 			if err != nil {
 				t.Fatalf("Snapshot() error = %v", err)
@@ -226,7 +300,7 @@ func TestHerdrOrgProviderSnapshotOversizedUint64TurnEpochFailsClosedPerPane(t *t
 ]}}}`, nil
 	}
 	provider := newHerdrOrgProvider(run, []config.OrgRole{
-		{Name: "oversized"}, {Name: "valid"}, {Name: "absent"},
+		{Name: "oversized", Pane: "oversized"}, {Name: "valid", Pane: "valid"}, {Name: "absent", Pane: "absent"},
 	}, time.Now)
 	snapshot, err := provider.Snapshot(context.Background())
 	if err != nil {

--- a/internal/config/org_binding.go
+++ b/internal/config/org_binding.go
@@ -16,5 +16,8 @@ func ResolveRolePaneBinding(ctx context.Context, binding string, resolveLabel fu
 	if resolved, found := resolveLabel(ctx, binding); found {
 		return resolved, true
 	}
-	return binding, true
+	if strings.Contains(binding, ":") {
+		return binding, true
+	}
+	return "", false
 }

--- a/internal/config/org_binding_test.go
+++ b/internal/config/org_binding_test.go
@@ -17,6 +17,7 @@ func TestResolveRolePaneBinding(t *testing.T) {
 		{name: "empty", binding: " \t ", wantPane: "", wantOK: false},
 		{name: "label resolves", binding: " coordinator ", resolutions: map[string]string{"coordinator": "w2:p5"}, wantPane: "w2:p5", wantOK: true},
 		{name: "unknown label is literal id", binding: "w1:p2", wantPane: "w1:p2", wantOK: true},
+		{name: "unknown label does not resolve", binding: "coordinator", wantPane: "", wantOK: false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1221,7 +1221,8 @@ cosmetic `display_name`, an optional `model` runtime pin, an optional per-role
 `recycle_after` duration override, and an optional `pane` Herdr binding (used by
 live presence and org event-rule wakes).
 The binding resolves as an exact live pane label first, then as a literal pane
-id; roles without a binding retain exact role-name-as-label presence lookup. There is
+id. Roles without a binding report unknown live presence, and event wakes for
+them are skipped with an observable log rather than inferred from a pane label. There is
 exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
 `owner/repo`, and each child scope must be covered by its parent. Malformed
 org configuration fails closed and loudly. `brief` records passive last-seen

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1057,8 +1057,9 @@ The registry uses `[org] enforce = "warn"|"block"` and
 `[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, an optional
 cosmetic `display_name`, an optional `model` runtime pin, an optional per-role
 `recycle_after` duration override, and an optional `pane` Herdr binding. The
-binding resolves as an exact live pane label first, then as a literal pane id;
-roles without a binding retain exact role-name-as-label presence lookup. There
+binding resolves as an exact live pane label first, then as a literal pane id.
+Roles without a binding report unknown live presence, and event wakes for them
+are skipped with an observable log rather than inferred from a pane label. There
 is exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
 `owner/repo`. Malformed org configuration fails closed and loudly. `brief`
 records passive last-seen presence for its role and can render static context

--- a/website/docs/reference/event-stream.md
+++ b/website/docs/reference/event-stream.md
@@ -238,7 +238,9 @@ outbox row cannot be parsed or claimed, the drain is logged as unhealthy and
 retried on a later tick without aborting unrelated repository work.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
-current id at wake time (so a recycled pane is still reached). Wake delivery runs
+current id at wake time (so a recycled pane is still reached). The same explicit
+binding drives live org presence; an unset binding reports unknown presence and
+causes event wakes to be skipped with an observable log. Wake delivery runs
 `herdr agent prompt <pane> <prompt> --wait --timeout 8000` and treats
 `result.type = "agent_prompted"` — and a post-delivery `error.code = "timeout"` —
 as delivered, `error.code = "agent_prompt_stalled"` as not delivered. Missing

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -2780,7 +2780,9 @@ outbox row cannot be parsed or claimed, the drain is logged as unhealthy and
 retried on a later tick without aborting unrelated repository work.
 The wake role's config sets `pane = "<pane-id-or-label>"`: a value containing `:`
 is a `wX:pY` pane id used as-is, any other value is a pane label resolved to the
-current id at wake time (so a recycled pane is still reached). Wake delivery runs
+current id at wake time (so a recycled pane is still reached). The same explicit
+binding drives live org presence; an unset binding reports unknown presence and
+causes event wakes to be skipped with an observable log. Wake delivery runs
 `herdr agent prompt <pane> <prompt> --wait --timeout 8000` and treats
 `result.type = "agent_prompted"` — and a post-delivery `error.code = "timeout"` —
 as delivered, `error.code = "agent_prompt_stalled"` as not delivered. Missing
@@ -11002,7 +11004,8 @@ cosmetic `display_name`, an optional `model` runtime pin, an optional per-role
 `recycle_after` duration override, and an optional `pane` Herdr binding (used by
 live presence and org event-rule wakes).
 The binding resolves as an exact live pane label first, then as a literal pane
-id; roles without a binding retain exact role-name-as-label presence lookup. There is
+id. Roles without a binding report unknown live presence, and event wakes for
+them are skipped with an observable log rather than inferred from a pane label. There is
 exactly one root named `owner`; accepted scopes are `*`, `owner/*`, and
 `owner/repo`, and each child scope must be covered by its parent. Malformed
 org configuration fails closed and loudly. `brief` records passive last-seen


### PR DESCRIPTION
Refs #1175, #1233 (slice 1 of the seat-lifecycle campaign).

## The defect: one role, two resolvers, and a green lie

`role → pane` was resolved by **two different rules**:

- **Presence** (`internal/cockpit/herdr_org.go`) fell back to *pane-label == role-name* when `pane=` was unset, and reported a real live state from that match.
- **Wake** (`internal/config/org_binding.go` → `internal/cli/event_rule_sink.go`) never did — `ResolveRolePaneBinding`'s own comment says *"Empty bindings do not resolve"* — and its failure was a **bare, unlogged `continue`**.

So a role with no `pane=` but a matching pane label read **idle/present** and was **permanently unwakeable**, with nothing anywhere reporting the dropped wake. `discovery-calls` was in exactly that state on this host: no binding, 2 wake routes, presence `idle`. The tri-model panel proved it 5/5 and counted roughly 4 of 13 roles defective **behind a passing check**.

This is why the panel put the resolver collapse *before* `seat add`: a create-command prevents new drift, but cannot fix a read-path bug that already exists.

## What this changes

1. **Deletes the presence label-fallback** so exactly one resolver remains. The `byLabel` map is gone; an unset binding now yields `org.StateUnknown` with detail `"Herdr pane binding is unset"` instead of inventing a live state.
2. **Adds a presence ⇔ wake parity test** exercising the real resolver functions — not a reimplementation of their logic — over empty / one-label / multi-label / literal-pane-id / no-match bindings.
3. **Makes the dropped wake observable.** The bare `continue` in `event_rule_sink.go` now records why a wake was skipped. In scope deliberately: **an unlogged gate is what hid this for weeks** — the same disease as #1260.

## PROVENANCE — read before reviewing

The implementing runtime **died waiting on the `internal/cli` suite** after staging complete work; its gate never reported. The work was recovered **verbatim and unedited** (patch 372 lines, md5 `1314c0179162`) and committed as `e8cd9946` — identity verified at **11 files, 130 insertions, 49 deletions**, matching the salvage exactly. **This code has not been reviewed by anyone.**

That death is the fourth in this family, and it is the controlled case for #1267: the seat **explicitly obeyed** the no-second-counting-pass rule (*"I am continuing to wait without launching any parallel or counting run"*) and died anyway. The ten-minute package is the hazard, not the counting pass.

## Gate — run as a detached shell run, not by a seat

| check | result |
|---|---|
| `go build ./...` | exit 0 |
| `go vet ./...` (separately) | exit 0 |
| `go generate ./... && git diff --exit-code` | exit 0 |
| `env -u GITMOOT_STALE_RUNNING_AFTER go test -timeout 25m ./...` | **exit 0 — 37 packages ok, 0 failures** |

**A first run from a `/tmp` clone false-red'd** with 4 failures, all Landlock/sandbox (`Err: Landlock probe wrote outside the allowed roots`). Same commit, same environment, only the clone path differing: `/tmp` → sandbox FAIL; `/root` → `ok 14.1s`. Zero failures in parity/org/presence/wake/resolver in either arm. The green above is a **full** suite run from `/root`, not a splice of partial runs.

## Mutation proof — the parity guard is load-bearing

Exercised on a throwaway probe branch off this exact commit (the ghost row fences this branch — #1276), tree reverted byte-identical afterwards.

**MUTANT: restore the deleted presence label-fallback → the parity test FAILED as required:**

```
--- FAIL: TestHerdrOrgProviderPresenceWakePaneBindingParity (0.00s)
    --- FAIL: TestHerdrOrgProviderPresenceWakePaneBindingParity/empty_binding (0.00s)
        herdr_org_test.go:140: presence state = "working", want "unknown"; wake resolution = ("", false)
FAIL    github.com/gitmoot/gitmoot/internal/cockpit     0.006s
```

That failure message *is* the defect, stated: with the fallback restored, presence reports **`working`** while wake resolution is **`("", false)`** — a role that reads live and cannot be woken. The guard asserts both sides in one place, so the two resolvers cannot drift apart silently again.

Reverted completely (`git diff --exit-code HEAD --` → 0, `git status --short` empty, byte-identical to `e8cd9946`); identical targeted re-run then passed (`ok internal/cockpit 0.006s`). No full suite or gate was run in the probe — the gate above is the authoritative run.

**Axis this guard covers:** that presence and wake resolve `role → pane` by the *same* rule. Delete it and the two can diverge again with no test noticing.
