### PR TITLE
Gitmoot: GITMOOT-COC -> WAVE-IMPL: IMPLEMENT #1175 SLICE 3 —

### DIFF
--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
@@ -80,6 +82,12 @@ var newOrgProvider = func(roles []config.OrgRole) org.Provider { return cockpit.
 
 var orgDoctorRunner subprocess.Runner = subprocess.ExecRunner{}
 
+var orgSeatRunner subprocess.Runner = subprocess.ExecRunner{}
+
+var orgSeatBranchCheck = checkOrgSeatBranches
+
+var orgSeatClosePane = closeOrgSeatPane
+
 var orgRecycleAdvisoryWriter io.Writer = os.Stderr
 
 var orgRecycleOverdueEventWriter io.Writer = os.Stderr
@@ -110,6 +118,8 @@ func runOrg(args []string, stdout, stderr io.Writer) int {
 		return runOrgEscalate(args[1:], stdout, stderr)
 	case "events":
 		return runOrgEvents(args[1:], stdout, stderr)
+	case "seat":
+		return runOrgSeat(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown org command %q\n\n", args[0])
 		printOrgUsage(stderr)
@@ -126,12 +136,477 @@ func printOrgUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot org chart [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org status [--json] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org recycle ROLE --kind KIND --handoff NOTE [--pane ID] [--json] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org seat add NAME --pane LABEL [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org seat rm NAME [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org escalate --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"QUESTION\"")
 	fmt.Fprintln(w, "  gitmoot org escalate resolve NOTE_ID [--by ROLE] [--note ANSWER_NOTE_ID] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule add --on KIND [--match FILTER | --repo SUBSTRING] --wake ROLE [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule list [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule set-scope [--home DIR] ID observer|addressed")
 	fmt.Fprintln(w, "  gitmoot org events rule rm [--home DIR] ID")
+}
+
+var orgSeatDefaultRouteKinds = []string{"blocked", "escalation", "reply"}
+
+const orgSeatExternalTimeout = 10 * time.Second
+
+func runOrgSeat(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printOrgSeatUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "add":
+		return runOrgSeatAdd(args[1:], stdout, stderr)
+	case "rm":
+		return runOrgSeatRemove(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown org seat command %q\n", args[0])
+		printOrgSeatUsage(stderr)
+		return 2
+	}
+}
+
+func printOrgSeatUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot org seat add NAME --pane LABEL [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org seat rm NAME [--home DIR]")
+}
+
+func runOrgSeatAdd(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org seat add", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	paneFlag := fs.String("pane", "", "exact live Herdr pane label to claim")
+	nameArg, flagArgs := leadingOrgSeatName(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if nameArg == "" {
+		if fs.NArg() != 1 {
+			fmt.Fprintln(stderr, "org seat add requires exactly one NAME")
+			return 2
+		}
+		nameArg = fs.Arg(0)
+	} else if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "org seat add requires exactly one NAME")
+		return 2
+	}
+	name := strings.ToLower(strings.TrimSpace(nameArg))
+	if !validOrgSeatName(name) {
+		fmt.Fprintf(stderr, "org seat add: invalid role name %q; use lowercase letters, digits, and hyphens\n", nameArg)
+		return 2
+	}
+	paneLabel := strings.TrimSpace(*paneFlag)
+	if paneLabel == "" {
+		fmt.Fprintln(stderr, "org seat add requires --pane with an exact live Herdr pane label")
+		return 2
+	}
+
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat add: resolve paths: %v\n", err)
+		return 1
+	}
+	if err := config.Initialize(paths); err != nil {
+		fmt.Fprintf(stderr, "org seat add: initialize home: %v\n", err)
+		return 1
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat add: load org registry: %v\n", err)
+		return 1
+	}
+	ctx := context.Background()
+	snapshotCtx, cancel := context.WithTimeout(ctx, orgSeatExternalTimeout)
+	snapshot, err := orgProviderSnapshot(snapshotCtx, cfg)
+	cancel()
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat add: inspect live Herdr panes: %v\n", err)
+		return 1
+	}
+	pane, err := uniqueOrgSeatPaneByLabel(snapshot.Panes, paneLabel)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat add: %v\n", err)
+		return 2
+	}
+	for roleName, binding := range snapshot.PaneBindings {
+		if roleName != name && strings.TrimSpace(binding.PaneID) == pane.PaneID {
+			fmt.Fprintf(stderr, "org seat add: pane %s (%q) is already claimed by role %q\n", pane.PaneID, paneLabel, roleName)
+			return 2
+		}
+	}
+
+	desired, roleExists, err := orgSeatDesiredRole(cfg, snapshot, name, paneLabel, pane.PaneID)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat add: %v\n", err)
+		return 2
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat add: open store: %v\n", err)
+		return 1
+	}
+	rules, err := store.ListEventRules(ctx)
+	if err != nil {
+		store.Close()
+		fmt.Fprintf(stderr, "org seat add: list event rules: %v\n", err)
+		return 1
+	}
+	expectedRules := orgSeatDefaultRules(name)
+	missingRules, existingRuleIDs, err := missingOrgSeatRules(expectedRules, rules)
+	if err != nil {
+		store.Close()
+		fmt.Fprintf(stderr, "org seat add: %v\n", err)
+		return 2
+	}
+	configEdit, roleCreated, err := config.UpsertOrgSeatRole(paths, desired)
+	if err != nil {
+		store.Close()
+		fmt.Fprintf(stderr, "org seat add: write role: %v\n", err)
+		return 1
+	}
+	if err := store.AddEventRules(ctx, missingRules); err != nil {
+		restoreErr := configEdit.Restore()
+		store.Close()
+		fmt.Fprintf(stderr, "org seat add: add wake routes: %v\n", errors.Join(err, restoreErr))
+		return 1
+	}
+	if err := store.Close(); err != nil {
+		fmt.Fprintf(stderr, "org seat add: close store: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "pane %s claimed label=%q\n", pane.PaneID, paneLabel)
+	roleStatus := "existed"
+	if roleCreated || !roleExists {
+		roleStatus = "created"
+	} else if configEdit.Changed() {
+		roleStatus = "repaired"
+	}
+	fmt.Fprintf(stdout, "role %s %s pane=%q\n", name, roleStatus, desired.Pane)
+	for _, rule := range expectedRules {
+		status := "created"
+		if existingRuleIDs[rule.ID] {
+			status = "existed"
+		}
+		fmt.Fprintf(stdout, "route %s %s on=%s wake=%s scope=%s\n", rule.ID, status, rule.OnKind, rule.WakeRole, rule.Scope)
+	}
+	fresh, err := config.LoadOrg(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat add: reload org registry: %v\n", err)
+		return 1
+	}
+	return runOrgValidateReality(ctx, paths, fresh, stdout, stderr)
+}
+
+func runOrgSeatRemove(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org seat rm", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	nameArg, flagArgs := leadingOrgSeatName(args)
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	if nameArg == "" {
+		if fs.NArg() != 1 {
+			fmt.Fprintln(stderr, "org seat rm requires exactly one NAME")
+			return 2
+		}
+		nameArg = fs.Arg(0)
+	} else if fs.NArg() != 0 {
+		fmt.Fprintln(stderr, "org seat rm requires exactly one NAME")
+		return 2
+	}
+	name := strings.ToLower(strings.TrimSpace(nameArg))
+	if !validOrgSeatName(name) {
+		fmt.Fprintf(stderr, "org seat rm: invalid role name %q\n", nameArg)
+		return 2
+	}
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat rm: resolve paths: %v\n", err)
+		return 1
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat rm: load org registry: %v\n", err)
+		return 1
+	}
+	role, ok := cfg.Role(name)
+	if !ok {
+		fmt.Fprintf(stderr, "org seat rm: unknown org role %q\n", name)
+		return 2
+	}
+	if children := cfg.Children(name); len(children) != 0 {
+		names := make([]string, len(children))
+		for i, child := range children {
+			names[i] = child.Name
+		}
+		fmt.Fprintf(stderr, "org seat rm: role %q still parents %s\n", name, strings.Join(names, ", "))
+		return 2
+	}
+
+	ctx := context.Background()
+	snapshotCtx, cancel := context.WithTimeout(ctx, orgSeatExternalTimeout)
+	snapshot, err := orgProviderSnapshot(snapshotCtx, cfg)
+	cancel()
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat rm: inspect live Herdr panes: %v\n", err)
+		return 1
+	}
+	binding := snapshot.PaneBindings[role.Name]
+	if strings.TrimSpace(binding.PaneID) == "" {
+		fmt.Fprintf(stderr, "org seat rm: role %q pane is unresolved: %s\n", role.Name, firstNonEmpty(binding.Detail, "no live pane binding"))
+		return 1
+	}
+	pane, ok := orgSeatPaneByID(snapshot.Panes, binding.PaneID)
+	if !ok {
+		fmt.Fprintf(stderr, "org seat rm: resolved pane %s is absent from the live snapshot\n", binding.PaneID)
+		return 1
+	}
+	if err := orgSeatBranchCheck(ctx, pane); err != nil {
+		fmt.Fprintf(stderr, "org seat rm: refusing to remove %q: %v\n", role.Name, err)
+		return 1
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat rm: open store: %v\n", err)
+		return 1
+	}
+	configEdit, _, err := config.RemoveOrgSeatRole(paths, role.Name)
+	if err != nil {
+		store.Close()
+		fmt.Fprintf(stderr, "org seat rm: remove role: %v\n", err)
+		return 1
+	}
+	removedRules, err := store.DeleteEventRulesForRole(ctx, role.Name)
+	if err != nil {
+		restoreErr := configEdit.Restore()
+		store.Close()
+		fmt.Fprintf(stderr, "org seat rm: remove wake routes: %v\n", errors.Join(err, restoreErr))
+		return 1
+	}
+	closeCtx, closeCancel := context.WithTimeout(ctx, orgSeatExternalTimeout)
+	closeErr := orgSeatClosePane(closeCtx, pane.PaneID)
+	closeCancel()
+	if closeErr != nil {
+		rulesRestoreErr := store.AddEventRules(ctx, removedRules)
+		configRestoreErr := configEdit.Restore()
+		store.Close()
+		fmt.Fprintf(stderr, "org seat rm: close pane %s: %v\n", pane.PaneID, errors.Join(closeErr, rulesRestoreErr, configRestoreErr))
+		return 1
+	}
+	if err := store.Close(); err != nil {
+		fmt.Fprintf(stderr, "org seat rm: close store: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "pane %s closed\n", pane.PaneID)
+	fmt.Fprintf(stdout, "role %s removed with %d wake routes\n", role.Name, len(removedRules))
+	fresh, err := config.LoadOrg(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org seat rm: reload org registry: %v\n", err)
+		return 1
+	}
+	return runOrgValidateReality(ctx, paths, fresh, stdout, stderr)
+}
+
+func leadingOrgSeatName(args []string) (string, []string) {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		return args[0], args[1:]
+	}
+	return "", args
+}
+
+func validOrgSeatName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if !(r >= 'a' && r <= 'z' || r >= '0' && r <= '9' || r == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+func uniqueOrgSeatPaneByLabel(panes []org.LivePane, label string) (org.LivePane, error) {
+	var match org.LivePane
+	count := 0
+	for _, pane := range panes {
+		if pane.PaneID != "" && pane.Label == label {
+			match = pane
+			count++
+		}
+	}
+	switch count {
+	case 0:
+		return org.LivePane{}, fmt.Errorf("no live Herdr pane has exact label %q", label)
+	case 1:
+		return match, nil
+	default:
+		return org.LivePane{}, fmt.Errorf("%d live Herdr panes have label %q; refusing ambiguous adoption", count, label)
+	}
+}
+
+func orgSeatPaneByID(panes []org.LivePane, paneID string) (org.LivePane, bool) {
+	for _, pane := range panes {
+		if pane.PaneID == paneID {
+			return pane, true
+		}
+	}
+	return org.LivePane{}, false
+}
+
+func orgSeatDesiredRole(cfg config.OrgConfig, snapshot org.Snapshot, name, paneLabel, paneID string) (config.OrgRole, bool, error) {
+	if current, ok := cfg.Role(name); ok {
+		if strings.TrimSpace(current.Pane) == "" {
+			current.Pane = paneLabel
+			return current, true, nil
+		}
+		binding := snapshot.PaneBindings[current.Name]
+		if binding.PaneID != paneID {
+			return config.OrgRole{}, true, fmt.Errorf(
+				"role %q already binds %q (%s), not pane %s labeled %q",
+				current.Name, current.Pane, firstNonEmpty(binding.Detail, "resolved to "+binding.PaneID), paneID, paneLabel,
+			)
+		}
+		return current, true, nil
+	}
+	if name == "owner" {
+		if cfg.Enabled() {
+			return config.OrgRole{}, false, errors.New("owner role is missing from a non-empty registry")
+		}
+		return config.OrgRole{Name: name, Scope: []string{"*"}, MergeRule: "owner", Pane: paneLabel}, false, nil
+	}
+	owner, ok := cfg.Role("owner")
+	if !ok {
+		return config.OrgRole{}, false, errors.New("add the owner seat before child seats")
+	}
+	return config.OrgRole{
+		Name: name, Parent: owner.Name, Scope: append([]string(nil), owner.Scope...),
+		MergeRule: "owner", Pane: paneLabel,
+	}, false, nil
+}
+
+func orgSeatDefaultRules(role string) []db.EventRule {
+	rules := make([]db.EventRule, 0, len(orgSeatDefaultRouteKinds))
+	for _, kind := range orgSeatDefaultRouteKinds {
+		rules = append(rules, db.EventRule{
+			ID: "org-seat-" + role + "-" + kind, OnKind: kind, WakeRole: role,
+			Scope: db.EventRuleScopeAddressed, Enabled: true,
+		})
+	}
+	return rules
+}
+
+func missingOrgSeatRules(expected, current []db.EventRule) ([]db.EventRule, map[string]bool, error) {
+	byID := make(map[string]db.EventRule, len(current))
+	for _, rule := range current {
+		byID[rule.ID] = rule
+	}
+	missing := make([]db.EventRule, 0, len(expected))
+	existing := make(map[string]bool, len(expected))
+	for _, want := range expected {
+		got, ok := byID[want.ID]
+		if !ok {
+			missing = append(missing, want)
+			continue
+		}
+		if !sameOrgSeatRule(got, want) {
+			return nil, nil, fmt.Errorf("route id %q already exists with different semantics", want.ID)
+		}
+		existing[want.ID] = true
+	}
+	return missing, existing, nil
+}
+
+func sameOrgSeatRule(got, want db.EventRule) bool {
+	return strings.EqualFold(strings.TrimSpace(got.OnKind), want.OnKind) &&
+		strings.TrimSpace(got.MatchFilter) == want.MatchFilter &&
+		strings.EqualFold(strings.TrimSpace(got.WakeRole), want.WakeRole) &&
+		got.Scope == want.Scope && got.Enabled == want.Enabled
+}
+
+func closeOrgSeatPane(ctx context.Context, paneID string) error {
+	result, err := orgSeatRunner.Run(ctx, "", "herdr", "pane", "close", paneID)
+	if err == nil {
+		return nil
+	}
+	detail := strings.TrimSpace(result.Stderr)
+	if detail == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, detail)
+}
+
+func checkOrgSeatBranches(ctx context.Context, pane org.LivePane) error {
+	directories := []string{strings.TrimSpace(pane.ForegroundCWD), strings.TrimSpace(pane.CWD)}
+	roots := map[string]struct{}{}
+	reported := 0
+	for _, directory := range directories {
+		if directory == "" {
+			continue
+		}
+		reported++
+		result, err := orgSeatRunner.Run(ctx, directory, "git", "rev-parse", "--show-toplevel")
+		if err != nil {
+			if strings.Contains(strings.ToLower(result.Stderr), "not a git repository") {
+				continue
+			}
+			return fmt.Errorf("inspect pane checkout %q: %w", directory, err)
+		}
+		root := strings.TrimSpace(result.Stdout)
+		if root == "" {
+			return fmt.Errorf("pane checkout %q returned an empty git root", directory)
+		}
+		roots[filepath.Clean(root)] = struct{}{}
+	}
+	if reported == 0 {
+		return fmt.Errorf("pane %s reports neither cwd nor foreground_cwd; branch safety is unverified", pane.PaneID)
+	}
+	if len(roots) == 0 {
+		return fmt.Errorf("pane %s reports no Git checkout; branch safety is unverified", pane.PaneID)
+	}
+	for root := range roots {
+		status, err := orgSeatRunner.Run(ctx, root, "git", "status", "--porcelain")
+		if err != nil {
+			return fmt.Errorf("inspect worktree %q: %w", root, err)
+		}
+		if dirty := strings.TrimSpace(status.Stdout); dirty != "" {
+			first, _, _ := strings.Cut(dirty, "\n")
+			return fmt.Errorf("checkout %s has uncommitted work (%s)", root, first)
+		}
+		branchResult, branchErr := orgSeatRunner.Run(ctx, root, "git", "symbolic-ref", "--quiet", "--short", "HEAD")
+		branch := strings.TrimSpace(branchResult.Stdout)
+		if branchErr != nil {
+			branch = "detached HEAD"
+		}
+		baseResult, baseErr := orgSeatRunner.Run(ctx, root, "git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD")
+		base := strings.TrimSpace(baseResult.Stdout)
+		if baseErr != nil || base == "" {
+			if _, err := orgSeatRunner.Run(ctx, root, "git", "rev-parse", "--verify", "--quiet", "refs/remotes/origin/main"); err != nil {
+				return fmt.Errorf("checkout %s has no resolvable origin default branch; branch safety is unverified", root)
+			}
+			base = "origin/main"
+		}
+		_, err = orgSeatRunner.Run(ctx, root, "git", "merge-base", "--is-ancestor", "HEAD", base)
+		if err == nil {
+			continue
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return fmt.Errorf("checkout %s branch %s has commits not merged into %s", root, branch, base)
+		}
+		return fmt.Errorf("compare checkout %s branch %s with %s: %w", root, branch, base, err)
+	}
+	return nil
 }
 
 func runOrgValidateOrShow(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/org_seat_test.go
+++ b/internal/cli/org_seat_test.go
@@ -1,0 +1,351 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/org"
+)
+
+type orgSeatFixtureProvider struct {
+	roles []config.OrgRole
+	panes *[]org.LivePane
+}
+
+func (p orgSeatFixtureProvider) Snapshot(context.Context) (org.Snapshot, error) {
+	panes := append([]org.LivePane(nil), (*p.panes)...)
+	bindings := make(map[string]org.PaneBinding, len(p.roles))
+	for _, role := range p.roles {
+		binding := strings.TrimSpace(role.Pane)
+		if binding == "" {
+			bindings[role.Name] = org.PaneBinding{Detail: "Herdr pane binding is unset"}
+			continue
+		}
+		var matches []string
+		for _, pane := range panes {
+			if pane.PaneID == binding && pane.PaneID != "" {
+				matches = []string{pane.PaneID}
+				break
+			}
+			if pane.PaneID != "" && pane.Label == binding {
+				matches = append(matches, pane.PaneID)
+			}
+		}
+		if len(matches) == 1 {
+			bindings[role.Name] = org.PaneBinding{PaneID: matches[0]}
+		} else if len(matches) > 1 {
+			bindings[role.Name] = org.PaneBinding{Detail: `multiple Herdr panes labeled "` + binding + `"`}
+		} else {
+			bindings[role.Name] = org.PaneBinding{Detail: `no Herdr pane bound as "` + binding + `"`}
+		}
+	}
+	return org.Snapshot{
+		PaneBindings: bindings,
+		Panes:        panes,
+	}, nil
+}
+
+func (orgSeatFixtureProvider) Recycle(context.Context, org.RecycleRequest) error { return nil }
+
+func TestOrgSeatAddEndsGreenOnRealityValidation(t *testing.T) {
+	home, paths, panes := setupOrgSeatTestHome(t)
+	withOrgSeatFixtureProvider(t, &panes)
+
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{"seat", "add", "worker", "--pane", "Worker", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("seat add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		`pane w1:p2 claimed label="Worker"`,
+		`role worker created pane="Worker"`,
+		"route org-seat-worker-blocked created",
+		"route org-seat-worker-escalation created",
+		"route org-seat-worker-reply created",
+		"ok 2 roles, 2 live panes, 4 enabled routes",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("seat add output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker, ok := cfg.Role("worker")
+	if !ok || worker.Pane != "Worker" || worker.Parent != "owner" || len(worker.Scope) != 1 || worker.Scope[0] != "*" {
+		t.Fatalf("worker role = %+v, present=%t", worker, ok)
+	}
+	rules := listOrgSeatTestRules(t, paths)
+	if len(rules) != 4 {
+		t.Fatalf("event rules = %+v, want owner route plus three worker routes", rules)
+	}
+
+	// Re-running add is the repair path and must not duplicate owned routes.
+	stdout.Reset()
+	stderr.Reset()
+	code = runOrg([]string{"seat", "add", "worker", "--pane", "Worker", "--home", home}, &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "route org-seat-worker-reply existed") ||
+		!strings.Contains(stdout.String(), "ok 2 roles, 2 live panes, 4 enabled routes") {
+		t.Fatalf("second seat add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	if got := len(listOrgSeatTestRules(t, paths)); got != 4 {
+		t.Fatalf("event rules after repair = %d, want 4", got)
+	}
+}
+
+func TestOrgSeatAddRejectsDuplicatePaneLabels(t *testing.T) {
+	home, paths, panes := setupOrgSeatTestHome(t)
+	panes = append(panes, org.LivePane{PaneID: "w1:p3", Label: "Worker"})
+	withOrgSeatFixtureProvider(t, &panes)
+
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{"seat", "add", "worker", "--pane", "Worker", "--home", home}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "2 live Herdr panes have label") ||
+		!strings.Contains(stderr.String(), "refusing ambiguous adoption") {
+		t.Fatalf("duplicate-label add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Role("worker"); ok {
+		t.Fatal("duplicate-label mutant selected one pane and created worker")
+	}
+	if got := len(listOrgSeatTestRules(t, paths)); got != 1 {
+		t.Fatalf("duplicate-label add wrote routes: %d", got)
+	}
+}
+
+func TestOrgSeatRemoveRefusesUnshippedBranchWork(t *testing.T) {
+	home, paths, panes := setupOrgSeatTestHome(t)
+	appendOrgSeatWorker(t, paths)
+	addOrgSeatWorkerRoutes(t, paths)
+
+	repo := t.TempDir()
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, repo, "init", "-b", "main")
+	runGit(t, repo, "config", "user.name", "Seat Test")
+	runGit(t, repo, "config", "user.email", "seat@example.test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "base")
+	runGit(t, t.TempDir(), "init", "--bare", remote)
+	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+	runGit(t, repo, "remote", "add", "origin", remote)
+	runGit(t, repo, "push", "-u", "origin", "main")
+	runGit(t, repo, "checkout", "-b", "worker-unshipped")
+	if err := os.WriteFile(filepath.Join(repo, "work.txt"), []byte("not merged\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "work.txt")
+	runGit(t, repo, "commit", "-m", "unshipped")
+	panes[1].CWD = repo
+	panes[1].ForegroundCWD = repo
+	withOrgSeatFixtureProvider(t, &panes)
+	closeCalls := 0
+	originalClose := orgSeatClosePane
+	orgSeatClosePane = func(context.Context, string) error {
+		closeCalls++
+		return nil
+	}
+	t.Cleanup(func() { orgSeatClosePane = originalClose })
+
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{"seat", "rm", "worker", "--home", home}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "branch worker-unshipped has commits not merged into origin/main") {
+		t.Fatalf("seat rm did not refuse unshipped branch: code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	if closeCalls != 0 {
+		t.Fatalf("pane close calls = %d, want 0 after branch refusal", closeCalls)
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Role("worker"); !ok {
+		t.Fatal("branch-check mutant removed worker role")
+	}
+	if got := len(listOrgSeatTestRules(t, paths)); got != 4 {
+		t.Fatalf("branch refusal changed routes: %d", got)
+	}
+}
+
+func TestOrgSeatBranchCheckFailsClosedWithoutGitCheckout(t *testing.T) {
+	err := checkOrgSeatBranches(context.Background(), org.LivePane{
+		PaneID:        "w1:p2",
+		CWD:           t.TempDir(),
+		ForegroundCWD: t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "reports no Git checkout; branch safety is unverified") {
+		t.Fatalf("branch check error = %v, want unverified refusal", err)
+	}
+}
+
+func TestOrgSeatRemoveClosesPaneAndEndsWithValidation(t *testing.T) {
+	home, paths, panes := setupOrgSeatTestHome(t)
+	appendOrgSeatWorker(t, paths)
+	addOrgSeatWorkerRoutes(t, paths)
+	withOrgSeatFixtureProvider(t, &panes)
+	originalBranchCheck := orgSeatBranchCheck
+	orgSeatBranchCheck = func(context.Context, org.LivePane) error { return nil }
+	t.Cleanup(func() { orgSeatBranchCheck = originalBranchCheck })
+	originalClose := orgSeatClosePane
+	orgSeatClosePane = func(_ context.Context, paneID string) error {
+		for i, pane := range panes {
+			if pane.PaneID == paneID {
+				panes = append(panes[:i], panes[i+1:]...)
+				return nil
+			}
+		}
+		return errors.New("pane not found")
+	}
+	t.Cleanup(func() { orgSeatClosePane = originalClose })
+
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{"seat", "rm", "worker", "--home", home}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("seat rm code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{
+		"pane w1:p2 closed",
+		"role worker removed with 3 wake routes",
+		"ok 1 roles, 1 live panes, 1 enabled routes",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("seat rm output missing %q:\n%s", want, stdout.String())
+		}
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Role("worker"); ok {
+		t.Fatal("worker role remains after seat rm")
+	}
+	if got := len(listOrgSeatTestRules(t, paths)); got != 1 {
+		t.Fatalf("routes after seat rm = %d, want 1", got)
+	}
+}
+
+func TestOrgSeatRemoveRestoresOwnedStateWhenPaneCloseFails(t *testing.T) {
+	home, paths, panes := setupOrgSeatTestHome(t)
+	appendOrgSeatWorker(t, paths)
+	addOrgSeatWorkerRoutes(t, paths)
+	withOrgSeatFixtureProvider(t, &panes)
+	originalBranchCheck := orgSeatBranchCheck
+	orgSeatBranchCheck = func(context.Context, org.LivePane) error { return nil }
+	t.Cleanup(func() { orgSeatBranchCheck = originalBranchCheck })
+	originalClose := orgSeatClosePane
+	orgSeatClosePane = func(context.Context, string) error { return errors.New("close refused") }
+	t.Cleanup(func() { orgSeatClosePane = originalClose })
+
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{"seat", "rm", "worker", "--home", home}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "close refused") {
+		t.Fatalf("seat rm close failure code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Role("worker"); !ok {
+		t.Fatal("worker role was not restored after pane-close failure")
+	}
+	if got := len(listOrgSeatTestRules(t, paths)); got != 4 {
+		t.Fatalf("routes after pane-close rollback = %d, want 4", got)
+	}
+}
+
+func setupOrgSeatTestHome(t *testing.T) (string, config.Paths, []org.LivePane) {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(`
+[org.roles."owner"]
+scope = ["*"]
+merge_rule = "owner"
+pane = "Owner"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddEventRule(context.Background(), db.EventRule{
+		ID: "owner-reply", OnKind: "reply", WakeRole: "owner",
+		Scope: db.EventRuleScopeAddressed, Enabled: true,
+	}); err != nil {
+		store.Close()
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return home, paths, []org.LivePane{
+		{PaneID: "w1:p1", Label: "Owner"},
+		{PaneID: "w1:p2", Label: "Worker"},
+	}
+}
+
+func withOrgSeatFixtureProvider(t *testing.T, panes *[]org.LivePane) {
+	t.Helper()
+	original := newOrgProvider
+	newOrgProvider = func(roles []config.OrgRole) org.Provider {
+		return orgSeatFixtureProvider{roles: append([]config.OrgRole(nil), roles...), panes: panes}
+	}
+	t.Cleanup(func() { newOrgProvider = original })
+}
+
+func appendOrgSeatWorker(t *testing.T, paths config.Paths) {
+	t.Helper()
+	edit, _, err := config.UpsertOrgSeatRole(paths, config.OrgRole{
+		Name: "worker", Parent: "owner", Scope: []string{"*"},
+		MergeRule: "owner", Pane: "Worker",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !edit.Changed() {
+		t.Fatal("worker config edit did not change config")
+	}
+}
+
+func addOrgSeatWorkerRoutes(t *testing.T, paths config.Paths) {
+	t.Helper()
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if err := store.AddEventRules(context.Background(), orgSeatDefaultRules("worker")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func listOrgSeatTestRules(t *testing.T, paths config.Paths) []db.EventRule {
+	t.Helper()
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	rules, err := store.ListEventRules(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rules
+}

--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -47,6 +47,8 @@ type herdrOrgSnapshotResult struct {
 type herdrOrgPane struct {
 	PaneID            string                  `json:"pane_id"`
 	Label             string                  `json:"label"`
+	CWD               string                  `json:"cwd"`
+	ForegroundCWD     string                  `json:"foreground_cwd"`
 	AgentStatus       string                  `json:"agent_status"`
 	InputPending      bool                    `json:"input_pending"`
 	LastCompletedTurn *herdrCompletedTurnWire `json:"last_completed_turn"`
@@ -82,7 +84,10 @@ func (p *herdrOrgProvider) Snapshot(ctx context.Context) (org.Snapshot, error) {
 	paneByID := map[string]herdrOrgPane{}
 	panes := make([]org.LivePane, 0, len(decoded.Result.Snapshot.Panes))
 	for _, pane := range decoded.Result.Snapshot.Panes {
-		panes = append(panes, org.LivePane{PaneID: pane.PaneID, Label: pane.Label})
+		panes = append(panes, org.LivePane{
+			PaneID: pane.PaneID, Label: pane.Label,
+			CWD: pane.CWD, ForegroundCWD: pane.ForegroundCWD,
+		})
 		// Mirror the wake resolver (herdr.go resolvePaneByLabel, which matches only
 		// `p.PaneID != ""`): a pane with an empty pane_id is not a resolvable
 		// target. Seeding it would collide every empty-id pane on the "" key of

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -141,6 +141,9 @@ func validateConfigFile(paths Paths) error {
 	if _, err := LoadMemorySettings(paths); err != nil {
 		return err
 	}
+	if _, err := LoadOrg(paths); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/config/org_edit.go
+++ b/internal/config/org_edit.go
@@ -1,0 +1,187 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// OrgSeatConfigEdit retains the exact pre-edit bytes so a caller coordinating
+// config with another owned store can compensate without reformatting or
+// reconstructing the prior role.
+type OrgSeatConfigEdit struct {
+	path     string
+	original []byte
+	changed  bool
+}
+
+func (e OrgSeatConfigEdit) Changed() bool { return e.changed }
+
+// Restore atomically restores the exact config bytes from before the edit.
+func (e OrgSeatConfigEdit) Restore() error {
+	if !e.changed {
+		return nil
+	}
+	return writeConfigAtomic(e.path, e.original)
+}
+
+// UpsertOrgSeatRole adds a role section or fills its previously-empty pane
+// binding. Existing non-empty role fields are never rewritten.
+func UpsertOrgSeatRole(paths Paths, desired OrgRole) (OrgSeatConfigEdit, bool, error) {
+	desired.Name = strings.ToLower(strings.TrimSpace(desired.Name))
+	desired.Pane = strings.TrimSpace(desired.Pane)
+	if desired.Name == "" || desired.Pane == "" {
+		return OrgSeatConfigEdit{}, false, fmt.Errorf("org seat role name and pane are required")
+	}
+	cfg, err := LoadOrg(paths)
+	if err != nil {
+		return OrgSeatConfigEdit{}, false, err
+	}
+	current, exists := cfg.Role(desired.Name)
+	if exists && strings.TrimSpace(current.Pane) != "" {
+		if strings.TrimSpace(current.Pane) != desired.Pane {
+			return OrgSeatConfigEdit{}, false, fmt.Errorf(
+				"org role %q already binds pane %q, not %q",
+				desired.Name, current.Pane, desired.Pane,
+			)
+		}
+		return OrgSeatConfigEdit{path: paths.ConfigFile}, false, nil
+	}
+
+	original, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return OrgSeatConfigEdit{}, false, err
+	}
+	updated := string(original)
+	if exists {
+		updated, err = setOrgRolePane(updated, desired.Name, desired.Pane)
+	} else {
+		updated = appendOrgRoleSection(updated, desired)
+	}
+	if err != nil {
+		return OrgSeatConfigEdit{}, false, err
+	}
+	edit := OrgSeatConfigEdit{path: paths.ConfigFile, original: original, changed: true}
+	if err := writeOrgConfigBytes(paths, []byte(updated), edit); err != nil {
+		return OrgSeatConfigEdit{}, false, err
+	}
+	return edit, !exists, nil
+}
+
+// RemoveOrgSeatRole removes exactly one role table and returns the removed role.
+// The real org parser validates parent references after the edit.
+func RemoveOrgSeatRole(paths Paths, name string) (OrgSeatConfigEdit, OrgRole, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	cfg, err := LoadOrg(paths)
+	if err != nil {
+		return OrgSeatConfigEdit{}, OrgRole{}, err
+	}
+	role, ok := cfg.Role(name)
+	if !ok {
+		return OrgSeatConfigEdit{}, OrgRole{}, fmt.Errorf("org role %q is not declared", name)
+	}
+	original, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		return OrgSeatConfigEdit{}, OrgRole{}, err
+	}
+	lines := strings.Split(string(original), "\n")
+	start, end, ok, err := orgRoleSectionBounds(lines, name)
+	if err != nil {
+		return OrgSeatConfigEdit{}, OrgRole{}, err
+	}
+	if !ok {
+		return OrgSeatConfigEdit{}, OrgRole{}, fmt.Errorf("org role %q section not found", name)
+	}
+	lines = append(lines[:start], lines[end:]...)
+	edit := OrgSeatConfigEdit{path: paths.ConfigFile, original: original, changed: true}
+	if err := writeOrgConfigBytes(paths, []byte(strings.Join(lines, "\n")), edit); err != nil {
+		return OrgSeatConfigEdit{}, OrgRole{}, err
+	}
+	return edit, role, nil
+}
+
+func setOrgRolePane(contents, name, pane string) (string, error) {
+	lines := strings.Split(contents, "\n")
+	start, end, ok, err := orgRoleSectionBounds(lines, name)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("org role %q section not found", name)
+	}
+	paneLine := "pane = " + strconv.Quote(pane)
+	for i := start + 1; i < end; i++ {
+		line := strings.TrimSpace(stripOrgConfigComment(lines[i]))
+		key, _, hasValue := strings.Cut(line, "=")
+		if hasValue && strings.TrimSpace(key) == "pane" {
+			lines[i] = paneLine
+			return strings.Join(lines, "\n"), nil
+		}
+	}
+	insert := end
+	for insert > start+1 && strings.TrimSpace(lines[insert-1]) == "" {
+		insert--
+	}
+	lines = append(lines, "")
+	copy(lines[insert+1:], lines[insert:])
+	lines[insert] = paneLine
+	return strings.Join(lines, "\n"), nil
+}
+
+func appendOrgRoleSection(contents string, role OrgRole) string {
+	var section strings.Builder
+	fmt.Fprintf(&section, "[org.roles.%s]\n", strconv.Quote(role.Name))
+	if role.Parent != "" {
+		fmt.Fprintf(&section, "parent = %s\n", strconv.Quote(role.Parent))
+	}
+	fmt.Fprintf(&section, "scope = %s\n", StringListScalar(role.Scope).toml())
+	if role.MergeRule != "" {
+		fmt.Fprintf(&section, "merge_rule = %s\n", strconv.Quote(role.MergeRule))
+	}
+	fmt.Fprintf(&section, "pane = %s\n", strconv.Quote(role.Pane))
+	if contents != "" && !strings.HasSuffix(contents, "\n") {
+		contents += "\n"
+	}
+	if contents != "" && !strings.HasSuffix(contents, "\n\n") {
+		contents += "\n"
+	}
+	return contents + section.String()
+}
+
+func orgRoleSectionBounds(lines []string, want string) (start, end int, found bool, err error) {
+	start = -1
+	for i, raw := range lines {
+		line := strings.TrimSpace(stripOrgConfigComment(raw))
+		if !strings.HasPrefix(line, "[") || !strings.HasSuffix(line, "]") {
+			continue
+		}
+		_, role, ok, parseErr := parseOrgSection(strings.TrimSpace(line[1 : len(line)-1]))
+		if parseErr != nil {
+			return 0, 0, false, parseErr
+		}
+		if start >= 0 {
+			return start, i, true, nil
+		}
+		if ok && role == want {
+			start = i
+		}
+	}
+	if start >= 0 {
+		return start, len(lines), true, nil
+	}
+	return 0, 0, false, nil
+}
+
+func writeOrgConfigBytes(paths Paths, updated []byte, edit OrgSeatConfigEdit) error {
+	if err := writeConfigAtomic(paths.ConfigFile, updated); err != nil {
+		return err
+	}
+	if err := validateConfigFile(paths); err != nil {
+		if restoreErr := edit.Restore(); restoreErr != nil {
+			return fmt.Errorf("config invalid after org seat edit AND restore failed (file left broken: %v): %w", restoreErr, err)
+		}
+		return fmt.Errorf("config invalid after org seat edit (reverted): %w", err)
+	}
+	return nil
+}

--- a/internal/db/event_rules.go
+++ b/internal/db/event_rules.go
@@ -30,6 +30,41 @@ type EventRule struct {
 
 // AddEventRule persists a new opt-in event rule.
 func (s *Store) AddEventRule(ctx context.Context, rule EventRule) error {
+	rule, err := normalizeEventRule(rule)
+	if err != nil {
+		return err
+	}
+	return insertEventRule(ctx, s.db, rule)
+}
+
+// AddEventRules persists a set of rules in one transaction. A conflict or
+// invalid rule leaves the complete set unchanged.
+func (s *Store) AddEventRules(ctx context.Context, rules []EventRule) error {
+	if len(rules) == 0 {
+		return nil
+	}
+	normalized := make([]EventRule, len(rules))
+	for i, rule := range rules {
+		var err error
+		normalized[i], err = normalizeEventRule(rule)
+		if err != nil {
+			return fmt.Errorf("event rule %d: %w", i, err)
+		}
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, rule := range normalized {
+		if err := insertEventRule(ctx, tx, rule); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+func normalizeEventRule(rule EventRule) (EventRule, error) {
 	rule.ID = strings.TrimSpace(rule.ID)
 	rule.OnKind = strings.TrimSpace(rule.OnKind)
 	rule.WakeRole = strings.TrimSpace(rule.WakeRole)
@@ -38,16 +73,16 @@ func (s *Store) AddEventRule(ctx context.Context, rule EventRule) error {
 		rule.Scope = EventRuleScopeAddressed
 	}
 	if rule.ID == "" {
-		return errors.New("event rule id is required")
+		return EventRule{}, errors.New("event rule id is required")
 	}
 	if rule.OnKind == "" {
-		return errors.New("event rule on_kind is required")
+		return EventRule{}, errors.New("event rule on_kind is required")
 	}
 	if rule.WakeRole == "" {
-		return errors.New("event rule wake_role is required")
+		return EventRule{}, errors.New("event rule wake_role is required")
 	}
 	if rule.Scope != EventRuleScopeAddressed && rule.Scope != EventRuleScopeObserver {
-		return fmt.Errorf("event rule scope %q is invalid; want addressed or observer", rule.Scope)
+		return EventRule{}, fmt.Errorf("event rule scope %q is invalid; want addressed or observer", rule.Scope)
 	}
 	if strings.TrimSpace(rule.CreatedAt) == "" {
 		// Fixed-width nanoseconds (not RFC3339Nano, which trims trailing zeros) so
@@ -55,14 +90,19 @@ func (s *Store) AddEventRule(ctx context.Context, rule EventRule) error {
 		// chronological order even for rules added within the same second.
 		rule.CreatedAt = time.Now().UTC().Format("2006-01-02T15:04:05.000000000Z")
 	}
+	rule.MatchFilter = strings.TrimSpace(rule.MatchFilter)
+	return rule, nil
+}
+
+func insertEventRule(ctx context.Context, execer sqlExecer, rule EventRule) error {
 	enabled := 0
 	if rule.Enabled {
 		enabled = 1
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO event_rules(
+	_, err := execer.ExecContext(ctx, `INSERT INTO event_rules(
 		id, on_kind, match_filter, wake_role, scope, enabled, created_at
 	) VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		rule.ID, rule.OnKind, strings.TrimSpace(rule.MatchFilter), rule.WakeRole,
+		rule.ID, rule.OnKind, rule.MatchFilter, rule.WakeRole,
 		rule.Scope, enabled, rule.CreatedAt)
 	return err
 }
@@ -117,4 +157,50 @@ func (s *Store) ListEventRules(ctx context.Context) ([]EventRule, error) {
 func (s *Store) DeleteEventRule(ctx context.Context, id string) error {
 	_, err := s.db.ExecContext(ctx, `DELETE FROM event_rules WHERE id = ?`, strings.TrimSpace(id))
 	return err
+}
+
+// DeleteEventRulesForRole removes all routes targeting role in one transaction
+// and returns their complete rows so a coordinating caller can compensate.
+func (s *Store) DeleteEventRulesForRole(ctx context.Context, role string) ([]EventRule, error) {
+	role = strings.ToLower(strings.TrimSpace(role))
+	if role == "" {
+		return nil, errors.New("event rule wake_role is required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	rows, err := tx.QueryContext(ctx, `SELECT id, on_kind, COALESCE(match_filter, ''), wake_role, scope, enabled, created_at
+		FROM event_rules
+		WHERE LOWER(TRIM(wake_role)) = ?
+		ORDER BY created_at, id`, role)
+	if err != nil {
+		return nil, err
+	}
+	rules := []EventRule{}
+	for rows.Next() {
+		var rule EventRule
+		var enabled int
+		if err := rows.Scan(&rule.ID, &rule.OnKind, &rule.MatchFilter, &rule.WakeRole, &rule.Scope, &enabled, &rule.CreatedAt); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		rule.Enabled = enabled != 0
+		rules = append(rules, rule)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM event_rules WHERE LOWER(TRIM(wake_role)) = ?`, role); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return rules, nil
 }

--- a/internal/org/provider.go
+++ b/internal/org/provider.go
@@ -49,11 +49,13 @@ type PaneBinding struct {
 	Detail string
 }
 
-// LivePane is the identity needed to verify that every labeled Herdr pane is
-// claimed by an organization role.
+// LivePane carries the live identity used by validation plus the two directories
+// Herdr reports for branch-safety checks when retiring a seat.
 type LivePane struct {
-	PaneID string
-	Label  string
+	PaneID        string
+	Label         string
+	CWD           string
+	ForegroundCWD string
 }
 
 type RecycleRequest struct {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1217,6 +1217,29 @@ role has no live pane, has no enabled wake route, or a labeled live pane is not
 claimed by any role; each failure includes category counts and a reason.
 `gitmoot org show [--home PATH]` prints the resolved role table.
 
+`gitmoot org seat add <name> --pane <label> [--home DIR]` claims the one live
+Herdr pane with that exact label, writes or repairs the role's `pane` binding,
+and installs addressed `reply`, `blocked`, and `escalation` routes with stable
+IDs `org-seat-<name>-<kind>`. Duplicate labels hard-fail instead of choosing a
+pane. New child seats inherit the `owner` role's scope and parent; an empty
+registry must add `owner` first. Re-running the command repairs missing owned
+pieces without duplicating routes. It finishes by running the same reality
+validation as `org validate`, so success includes a green live-pane and route
+verdict rather than only confirming that config parsed.
+
+`gitmoot org seat rm <name> [--home DIR]` resolves the role's live pane and
+checks every distinct Git checkout reported by that pane's `cwd` and
+`foreground_cwd`. It refuses a dirty checkout or a branch whose `HEAD` is not
+merged into the locally known `origin/HEAD` (falling back to `origin/main`);
+unreadable branch state also fails closed. A safe removal deletes the role and
+all of its wake routes, closes the pane, and then runs the same reality
+validation. Roles that still parent another role cannot be removed.
+
+The three provisioned routes are enabled, addressed, and have an empty match
+filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;
+this is destructive and re-running `seat add` recreates it. There is currently
+no non-destructive event-rule disable verb.
+
 The registry uses `[org] enforce = "warn"|"block"` and
 `[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, an optional
 cosmetic `display_name`, an optional `model` runtime pin, an optional per-role

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1182,6 +1182,29 @@ at enqueue.
 `enforce = "block"` is the default; `"warn"` allows the job and records an
 `org_scope_violation` event. Merge rules are advisory in this phase.
 
+`gitmoot org seat add <name> --pane <label> [--home DIR]` claims the one live
+Herdr pane with that exact label, writes or repairs the role's `pane` binding,
+and installs addressed `reply`, `blocked`, and `escalation` routes with stable
+IDs `org-seat-<name>-<kind>`. Duplicate labels hard-fail instead of choosing a
+pane. New child seats inherit the `owner` role's scope and parent; an empty
+registry must add `owner` first. Re-running the command repairs missing owned
+pieces without duplicating routes. It finishes by running the same reality
+validation as `org validate`, so success includes a green live-pane and route
+verdict rather than only confirming that config parsed.
+
+`gitmoot org seat rm <name> [--home DIR]` resolves the role's live pane and
+checks every distinct Git checkout reported by that pane's `cwd` and
+`foreground_cwd`. It refuses a dirty checkout or a branch whose `HEAD` is not
+merged into the locally known `origin/HEAD` (falling back to `origin/main`);
+unreadable branch state also fails closed. A safe removal deletes the role and
+all of its wake routes, closes the pane, and then runs the same reality
+validation. Roles that still parent another role cannot be removed.
+
+The three provisioned routes are enabled, addressed, and have an empty match
+filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;
+this is destructive and re-running `seat add` recreates it. There is currently
+no non-destructive event-rule disable verb.
+
 `gitmoot org recycle <role> --kind <kind> --handoff "<note>" [--pane <id>]
 [--json] [--home <dir>]` journals a typed handoff in the role-lifecycle workflow
 `org/<role>`, builds the successor's boot prompt from `org brief` plus that

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11010,6 +11010,29 @@ role has no live pane, has no enabled wake route, or a labeled live pane is not
 claimed by any role; each failure includes category counts and a reason.
 `gitmoot org show [--home PATH]` prints the resolved role table.
 
+`gitmoot org seat add <name> --pane <label> [--home DIR]` claims the one live
+Herdr pane with that exact label, writes or repairs the role's `pane` binding,
+and installs addressed `reply`, `blocked`, and `escalation` routes with stable
+IDs `org-seat-<name>-<kind>`. Duplicate labels hard-fail instead of choosing a
+pane. New child seats inherit the `owner` role's scope and parent; an empty
+registry must add `owner` first. Re-running the command repairs missing owned
+pieces without duplicating routes. It finishes by running the same reality
+validation as `org validate`, so success includes a green live-pane and route
+verdict rather than only confirming that config parsed.
+
+`gitmoot org seat rm <name> [--home DIR]` resolves the role's live pane and
+checks every distinct Git checkout reported by that pane's `cwd` and
+`foreground_cwd`. It refuses a dirty checkout or a branch whose `HEAD` is not
+merged into the locally known `origin/HEAD` (falling back to `origin/main`);
+unreadable branch state also fails closed. A safe removal deletes the role and
+all of its wake routes, closes the pane, and then runs the same reality
+validation. Roles that still parent another role cannot be removed.
+
+The three provisioned routes are enabled, addressed, and have an empty match
+filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;
+this is destructive and re-running `seat add` recreates it. There is currently
+no non-destructive event-rule disable verb.
+
 The registry uses `[org] enforce = "warn"|"block"` and
 `[org.roles."name"]` entries with `parent`, `scope`, `merge_rule`, an optional
 cosmetic `display_name`, an optional `model` runtime pin, an optional per-role


### PR DESCRIPTION
WHAT:
WAVE-IMPL: Implemented #1175 slice 3 on branch gitmoot/adhoc-380e910e. Current committed HEAD is 7423e48265a640479fc4598de7bc745cf2d27599; changes remain uncommitted for the engine finalizer to commit and push.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-380e910e

RESULTS:
- Bounded build: `go build ./internal/cli/ ./internal/config/` exited 0.
- Six seat tests passed individually, including add ending with green reality validation, duplicate-label refusal, unshipped-work refusal, no-Git fail-closed behavior, successful removal, and rollback after pane-close failure.
- Existing exact regressions `TestOrgValidateAssertsLiveBindingsRoutesAndPaneClaims` and `TestOrgEventRuleAddListRemoveAndValidation` passed.
- Required branch-check mutant: deleting the branch-check call failed `TestOrgSeatRemoveRefusesUnshippedBranchWork` with `seat rm did not refuse unshipped branch: code=1 ... role worker removed with 3 wake routes`; test exit 1. After restoration: `ok github.com/gitmoot/gitmoot/internal/cli 0.409s`, exit 0.
- Duplicate-label mutant named: selecting the first matching label instead of rejecting multiple matches is killed by `TestOrgSeatAddRejectsDuplicatePaneLabels`, which asserts no role or route is written.
- Validation mutant named: returning after config/rule writes without `runOrgValidateReality` is killed by `TestOrgSeatAddEndsGreenOnRealityValidation`, which requires the live-pane and enabled-route verdict.
- `npm run build:llms` exited 0; repeated regeneration retained SHA-256 e161da20ac275abbccfb5052cb9a6d2d5668b7fb28dd9134aed5ede550b9b6b2.
- `git diff --check` exited 0. Full suite intentionally not run per the bounded-gate instruction.

RISK:
Review the generated diff before merging.

TASK:
adhoc-380e910e

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
WAVE-IMPL: Implemented #1175 slice 3 on branch gitmoot/adhoc-380e910e. Current committed HEAD is 7423e48265a640479fc4598de7bc745cf2d27599; changes remain uncommitted for the engine finalizer to commit and push.
````
