### PR TITLE
Gitmoot: GITMOOT-COC -> WAVE-IMPL: FIX gitmoot#1292 — scheduled pipeline

### DIFF
--- a/internal/subprocess/runner.go
+++ b/internal/subprocess/runner.go
@@ -208,6 +208,18 @@ func (r EnvInjectingRunner) Run(ctx context.Context, dir string, command string,
 	return Result{}, errors.New("environment-injecting runner inner does not support environment injection")
 }
 
+func (r EnvInjectingRunner) RunStream(ctx context.Context, dir string, out io.Writer, command string, args ...string) (Result, error) {
+	if inner, ok := r.inner().(EnvStreamRunner); ok {
+		return inner.RunEnvStream(ctx, dir, r.Env, out, command, args...)
+	}
+	if len(r.Env) == 0 {
+		if inner, ok := r.inner().(StreamRunner); ok {
+			return inner.RunStream(ctx, dir, out, command, args...)
+		}
+	}
+	return Result{}, errors.New("environment-injecting runner inner does not support environment streaming")
+}
+
 func (r EnvInjectingRunner) RunWithPID(ctx context.Context, dir string, onPID PIDCallback, command string, args ...string) (Result, error) {
 	if inner, ok := r.inner().(EnvPIDRunner); ok {
 		return inner.RunEnvWithPID(ctx, dir, r.Env, onPID, command, args...)
@@ -231,6 +243,19 @@ func (r EnvInjectingRunner) RunEnv(ctx context.Context, dir string, env []string
 	return Result{}, errors.New("environment-injecting runner inner does not support environment injection")
 }
 
+func (r EnvInjectingRunner) RunEnvStream(ctx context.Context, dir string, env []string, out io.Writer, command string, args ...string) (Result, error) {
+	merged := append(append([]string{}, r.Env...), env...)
+	if inner, ok := r.inner().(EnvStreamRunner); ok {
+		return inner.RunEnvStream(ctx, dir, merged, out, command, args...)
+	}
+	if len(merged) == 0 {
+		if inner, ok := r.inner().(StreamRunner); ok {
+			return inner.RunStream(ctx, dir, out, command, args...)
+		}
+	}
+	return Result{}, errors.New("environment-injecting runner inner does not support environment streaming")
+}
+
 func (r EnvInjectingRunner) RunEnvWithPID(ctx context.Context, dir string, env []string, onPID PIDCallback, command string, args ...string) (Result, error) {
 	merged := append(append([]string{}, r.Env...), env...)
 	if inner, ok := r.inner().(EnvPIDRunner); ok {
@@ -242,6 +267,19 @@ func (r EnvInjectingRunner) RunEnvWithPID(ctx context.Context, dir string, env [
 		}
 	}
 	return Result{}, errors.New("environment-injecting runner inner does not support environment PID capture")
+}
+
+func (r EnvInjectingRunner) RunEnvStreamWithPID(ctx context.Context, dir string, env []string, out io.Writer, onPID PIDCallback, command string, args ...string) (Result, error) {
+	merged := append(append([]string{}, r.Env...), env...)
+	if inner, ok := r.inner().(EnvPIDStreamRunner); ok {
+		return inner.RunEnvStreamWithPID(ctx, dir, merged, out, onPID, command, args...)
+	}
+	if len(merged) == 0 {
+		if inner, ok := r.inner().(PIDStreamRunner); ok {
+			return inner.RunStreamWithPID(ctx, dir, out, onPID, command, args...)
+		}
+	}
+	return Result{}, errors.New("environment-injecting runner inner does not support environment PID streaming")
 }
 
 func (r EnvInjectingRunner) LookPath(file string) (string, error) {

--- a/internal/subprocess/runner_test.go
+++ b/internal/subprocess/runner_test.go
@@ -117,6 +117,84 @@ func TestTeeRunnerRunEnvTeesAndInjects(t *testing.T) {
 	}
 }
 
+func TestTeeRunnerEnvInjectingRunnerStreamsEnvironmentAndPID(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command differs on windows")
+	}
+
+	newRunner := func(out *bytes.Buffer) TeeRunner {
+		return TeeRunner{
+			Inner: EnvInjectingRunner{
+				Inner: GroupRunner{},
+				Env: []string{
+					"GITMOOT_INJECTED=wrapper",
+					"GITMOOT_SHARED=wrapper",
+				},
+			},
+			Out: out,
+		}
+	}
+	callEnv := []string{
+		"GITMOOT_CALL_ENV=call",
+		"GITMOOT_SHARED=call",
+	}
+
+	t.Run("RunEnv", func(t *testing.T) {
+		var tee bytes.Buffer
+		result, err := newRunner(&tee).RunEnv(
+			context.Background(),
+			"",
+			callEnv,
+			"sh",
+			"-c",
+			`printf '%s' "$GITMOOT_INJECTED:$GITMOOT_CALL_ENV:$GITMOOT_SHARED"`,
+		)
+		if err != nil {
+			t.Fatalf("TeeRunner.RunEnv: %v", err)
+		}
+		const want = "wrapper:call:call"
+		if result.Stdout != want || strings.TrimSuffix(tee.String(), "\n") != want {
+			t.Fatalf("stdout=%q tee=%q, want %q", result.Stdout, tee.String(), want)
+		}
+	})
+
+	t.Run("RunEnvWithPID", func(t *testing.T) {
+		var (
+			tee      bytes.Buffer
+			captured int
+		)
+		result, err := newRunner(&tee).RunEnvWithPID(
+			context.Background(),
+			"",
+			callEnv,
+			func(pid int) { captured = pid },
+			"sh",
+			"-c",
+			`printf '%s' "$GITMOOT_INJECTED:$GITMOOT_CALL_ENV:$GITMOOT_SHARED:$$"`,
+		)
+		if err != nil {
+			t.Fatalf("TeeRunner.RunEnvWithPID: %v", err)
+		}
+		fields := strings.Split(result.Stdout, ":")
+		if len(fields) != 4 {
+			t.Fatalf("stdout=%q, want injected env and child PID", result.Stdout)
+		}
+		if got := strings.Join(fields[:3], ":"); got != "wrapper:call:call" {
+			t.Fatalf("injected env = %q, want %q", got, "wrapper:call:call")
+		}
+		reported, err := strconv.Atoi(fields[3])
+		if err != nil {
+			t.Fatalf("parse child PID from stdout %q: %v", result.Stdout, err)
+		}
+		if captured <= 0 || captured != reported {
+			t.Fatalf("captured PID = %d, child reported %d", captured, reported)
+		}
+		if strings.TrimSuffix(tee.String(), "\n") != result.Stdout {
+			t.Fatalf("tee=%q, want stdout %q", tee.String(), result.Stdout)
+		}
+	})
+}
+
 // TestTeeRunnerNilOutDegradesToRun: a nil Out leaves behavior byte-identical to
 // the inner runner's plain Run — the tee is opt-in via a non-nil writer.
 func TestTeeRunnerNilOutDegradesToRun(t *testing.T) {


### PR DESCRIPTION
WHAT:
WAVE-IMPL: Fixed #1292 on branch gitmoot/adhoc-68e0024d at base HEAD ed8a4c8cad3199ec2fdb86773893abf028570e78. EnvInjectingRunner now preserves environment injection across plain and PID streaming, delegating to GroupRunner so process-group behavior remains intact. Changes remain uncommitted for the finalizer.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-68e0024d

RESULTS:
- PASS: go build ./internal/subprocess/ ./internal/pipeline/ (exit 0).
- PASS after restoration: go test -count=1 -run '^TestTeeRunnerEnvInjectingRunnerStreamsEnvironmentAndPID$' ./internal/subprocess/ -> ok.
- PASS existing regression: go test -count=1 -run '^TestTeeRunnerRunEnvTeesAndInjects$' ./internal/subprocess/ -> ok.
- MUTANT RunEnv: removed RunEnvStream while retaining RunStream; failed with `runner_test.go:153: TeeRunner.RunEnv: tee runner inner does not support environment streaming`.
- MUTANT RunEnvWithPID: removed RunEnvStreamWithPID while retaining RunStream; failed with `runner_test.go:176: TeeRunner.RunEnvWithPID: tee runner inner does not support environment PID streaming`.
- Mutant command exited 1 with both subtests failing; both methods were restored and the same guard then passed.
- git diff --check passed. Full suite intentionally not run per task instructions.

RISK:
Review the generated diff before merging.

TASK:
adhoc-68e0024d

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
WAVE-IMPL: Fixed #1292 on branch gitmoot/adhoc-68e0024d at base HEAD ed8a4c8cad3199ec2fdb86773893abf028570e78. EnvInjectingRunner now preserves environment injection across plain and PID streaming, delegating to GroupRunner so process-group behavior remains intact. Changes remain uncommitted for the finalizer.
````
