### PR TITLE
Gitmoot: GITMOOT-COC -> WAVE-IMPL: #1292 ROUND 2 — the

### DIFF
--- a/internal/cli/isolated_tool_cache_test.go
+++ b/internal/cli/isolated_tool_cache_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/config"
@@ -164,6 +168,152 @@ func TestInjectDeliveryAdapterEnvRealSubprocess(t *testing.T) {
 	}
 	if result.Summary != "shared-cache-value" {
 		t.Fatalf("Summary = %q, want %q (injected env did not reach the subprocess)", result.Summary, "shared-cache-value")
+	}
+}
+
+func TestFreshIsolatedProduceRunnerStreamsInjectedEnvAndPID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := writeRuntimeAuthFile(runtimeAuthFilePath(paths.Home), map[string]string{
+		runtime.ClaudeOAuthTokenEnv: testOAuthToken,
+	}); err != nil {
+		t.Fatalf("write runtime auth: %v", err)
+	}
+
+	checkout := t.TempDir()
+	payload := workflow.JobPayload{
+		Sender:       workflow.PipelineJobSender,
+		WorktreePath: checkout,
+	}
+	agent := runtime.Agent{
+		Name:      "scout",
+		Runtime:   runtime.ClaudeRuntime,
+		RepoScope: "owner/repo",
+	}
+	var progress bytes.Buffer
+	worker := defaultJobWorker(nil, io.Discard, home)
+
+	// This is the fresh pipeline-stage construction order in jobWorker.run:
+	// progress tee, produce sandbox, then isolated tool-cache env injection.
+	adapter, _, err := worker.buildSeatAwareAdapter(&agent, checkout, payload, &progress)
+	if err != nil {
+		t.Fatalf("buildSeatAwareAdapter: %v", err)
+	}
+	toolCacheEnv, err := applyIsolatedToolCacheGrants(paths, payload, &agent)
+	if err != nil {
+		t.Fatalf("applyIsolatedToolCacheGrants: %v", err)
+	}
+	adapter, err = wrapProduceSandboxAdapter("produce", agent, adapter)
+	if err != nil {
+		t.Fatalf("wrapProduceSandboxAdapter: %v", err)
+	}
+	adapter, err = injectDeliveryAdapterEnv(adapter, toolCacheEnv)
+	if err != nil {
+		t.Fatalf("injectDeliveryAdapterEnv: %v", err)
+	}
+
+	claude, ok := adapter.(runtime.ClaudeAdapter)
+	if !ok {
+		t.Fatalf("adapter = %T, want runtime.ClaudeAdapter", adapter)
+	}
+	shim := writeSandboxPassthrough(t)
+	claude.Runner = setSandboxWrapperExecutable(t, claude.Runner, shim)
+	envPIDRunner, ok := claude.Runner.(subprocess.EnvPIDRunner)
+	if !ok {
+		t.Fatalf("runner = %T, want subprocess.EnvPIDRunner", claude.Runner)
+	}
+
+	var captured int
+	result, err := envPIDRunner.RunEnvWithPID(
+		context.Background(),
+		checkout,
+		[]string{"GITMOOT_STAGE_ENV=stage"},
+		func(pid int) { captured = pid },
+		"sh",
+		"-c",
+		`printf '%s' "$GOCACHE:$GITMOOT_STAGE_ENV:$$"`,
+	)
+	if err != nil {
+		t.Fatalf("fresh isolated produce RunEnvWithPID: %v", err)
+	}
+	fields := strings.Split(result.Stdout, ":")
+	if len(fields) != 3 {
+		t.Fatalf("stdout = %q, want tool-cache env, stage env, and child PID", result.Stdout)
+	}
+	wantCache := filepath.Join(paths.Home, "cache", "tools", "go-build")
+	if fields[0] != wantCache || fields[1] != "stage" {
+		t.Fatalf("subprocess env = %q:%q, want %q:%q", fields[0], fields[1], wantCache, "stage")
+	}
+	reported, err := strconv.Atoi(fields[2])
+	if err != nil {
+		t.Fatalf("parse child PID from stdout %q: %v", result.Stdout, err)
+	}
+	if captured <= 0 || captured != reported {
+		t.Fatalf("captured PID = %d, child reported %d", captured, reported)
+	}
+	if !strings.Contains(progress.String(), result.Stdout) {
+		t.Fatalf("progress tee = %q, want subprocess output %q", progress.String(), result.Stdout)
+	}
+}
+
+func writeSandboxPassthrough(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sandbox-passthrough")
+	body := "#!/bin/sh\n" +
+		"while [ \"$#\" -gt 0 ] && [ \"$1\" != \"--\" ]; do shift; done\n" +
+		"[ \"$1\" = \"--\" ] && shift\n" +
+		"exec \"$@\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+		t.Fatalf("write sandbox passthrough: %v", err)
+	}
+	return path
+}
+
+func setSandboxWrapperExecutable(t *testing.T, runner subprocess.Runner, executable string) subprocess.Runner {
+	t.Helper()
+	switch r := runner.(type) {
+	case subprocess.EnvInjectingRunner:
+		r.Inner = setSandboxWrapperExecutable(t, r.Inner, executable)
+		return r
+	case *subprocess.EnvInjectingRunner:
+		copy := *r
+		copy.Inner = setSandboxWrapperExecutable(t, copy.Inner, executable)
+		return &copy
+	case subprocess.TeeRunner:
+		inner := subprocess.Runner(r.Inner)
+		configured := setSandboxWrapperExecutable(t, inner, executable)
+		stream, ok := configured.(subprocess.StreamRunner)
+		if !ok {
+			t.Fatalf("configured tee inner = %T, want subprocess.StreamRunner", configured)
+		}
+		r.Inner = stream
+		return r
+	case *subprocess.TeeRunner:
+		copy := *r
+		inner := subprocess.Runner(copy.Inner)
+		configured := setSandboxWrapperExecutable(t, inner, executable)
+		stream, ok := configured.(subprocess.StreamRunner)
+		if !ok {
+			t.Fatalf("configured tee inner = %T, want subprocess.StreamRunner", configured)
+		}
+		copy.Inner = stream
+		return &copy
+	case subprocess.WrappingRunner:
+		r.Executable = executable
+		r.Inner = setSandboxWrapperExecutable(t, r.Inner, executable)
+		return r
+	case *subprocess.WrappingRunner:
+		copy := *r
+		copy.Executable = executable
+		copy.Inner = setSandboxWrapperExecutable(t, copy.Inner, executable)
+		return &copy
+	default:
+		return runner
 	}
 }
 

--- a/internal/subprocess/wrapper_contract_test.go
+++ b/internal/subprocess/wrapper_contract_test.go
@@ -1,0 +1,80 @@
+package subprocess
+
+import (
+	"go/ast"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestRunnerWrappersImplementEnvironmentPIDStreaming(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read subprocess package: %v", err)
+	}
+	fset := token.NewFileSet()
+	files := make([]*ast.File, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Clean(name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		files = append(files, file)
+	}
+	conf := types.Config{Importer: importer.Default()}
+	pkg, err := conf.Check("github.com/gitmoot/gitmoot/internal/subprocess", fset, files, nil)
+	if err != nil {
+		t.Fatalf("type-check subprocess package: %v", err)
+	}
+
+	// A transparent wrapper owns an Inner Runner. TeeRunner is deliberately not
+	// in this class: its Inner is already a StreamRunner and it terminates the
+	// wrapper chain by adapting live output back to the plain Runner surface.
+	runnerType := pkg.Scope().Lookup("Runner").Type()
+	contract := pkg.Scope().Lookup("EnvPIDStreamRunner").Type().Underlying().(*types.Interface)
+	contract.Complete()
+
+	var wrappers []string
+	for _, name := range pkg.Scope().Names() {
+		typeName, ok := pkg.Scope().Lookup(name).(*types.TypeName)
+		if !ok {
+			continue
+		}
+		named, ok := typeName.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		structType, ok := named.Underlying().(*types.Struct)
+		if !ok || !wrapsRunner(structType, runnerType) {
+			continue
+		}
+		wrappers = append(wrappers, name)
+		if !types.Implements(named, contract) && !types.Implements(types.NewPointer(named), contract) {
+			t.Errorf("runner wrapper %s does not implement EnvPIDStreamRunner", name)
+		}
+	}
+	sort.Strings(wrappers)
+	if len(wrappers) == 0 {
+		t.Fatal("found no runner wrappers; contract check passed vacuously")
+	}
+}
+
+func wrapsRunner(structType *types.Struct, runnerType types.Type) bool {
+	for i := 0; i < structType.NumFields(); i++ {
+		field := structType.Field(i)
+		if field.Name() == "Inner" && types.Identical(field.Type(), runnerType) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/subprocess/wrapping.go
+++ b/internal/subprocess/wrapping.go
@@ -141,6 +141,25 @@ func (r WrappingRunner) RunEnv(ctx context.Context, dir string, env []string, co
 	return r.inner().Run(ctx, dir, executable, wrapped...)
 }
 
+func (r WrappingRunner) RunEnvStream(ctx context.Context, dir string, env []string, out io.Writer, command string, args ...string) (Result, error) {
+	executable, wrapped, err := r.command(command, args)
+	if err != nil {
+		return Result{}, err
+	}
+	// Wrapper-owned values remain last, matching RunEnv, so callers cannot move
+	// mutable runtime state outside the paths granted to sandbox-exec.
+	merged := append(append([]string{}, env...), r.Env...)
+	if inner, ok := r.inner().(EnvStreamRunner); ok {
+		return inner.RunEnvStream(ctx, dir, merged, out, executable, wrapped...)
+	}
+	if len(merged) == 0 {
+		if inner, ok := r.inner().(StreamRunner); ok {
+			return inner.RunStream(ctx, dir, out, executable, wrapped...)
+		}
+	}
+	return Result{}, errors.New("wrapped streaming runner does not support environment injection")
+}
+
 func (r WrappingRunner) RunEnvWithPID(ctx context.Context, dir string, env []string, onPID PIDCallback, command string, args ...string) (Result, error) {
 	executable, wrapped, err := r.command(command, args)
 	if err != nil {
@@ -156,6 +175,23 @@ func (r WrappingRunner) RunEnvWithPID(ctx context.Context, dir string, env []str
 		}
 	}
 	return r.RunEnv(ctx, dir, env, command, args...)
+}
+
+func (r WrappingRunner) RunEnvStreamWithPID(ctx context.Context, dir string, env []string, out io.Writer, onPID PIDCallback, command string, args ...string) (Result, error) {
+	executable, wrapped, err := r.command(command, args)
+	if err != nil {
+		return Result{}, err
+	}
+	merged := append(append([]string{}, env...), r.Env...)
+	if inner, ok := r.inner().(EnvPIDStreamRunner); ok {
+		return inner.RunEnvStreamWithPID(ctx, dir, merged, out, onPID, executable, wrapped...)
+	}
+	if len(merged) == 0 {
+		if inner, ok := r.inner().(PIDStreamRunner); ok {
+			return inner.RunStreamWithPID(ctx, dir, out, onPID, executable, wrapped...)
+		}
+	}
+	return r.RunEnvStream(ctx, dir, env, out, command, args...)
 }
 
 func (r WrappingRunner) LookPath(file string) (string, error) {


### PR DESCRIPTION
WHAT:
WAVE-IMPL: Fixed #1292 round 2 on branch gitmoot/adhoc-2a52312f, base HEAD 05af2b50dbe648e14aad1ceda45cac5b6e6f4952. Fresh isolated produce constructs EnvInjectingRunner -> TeeRunner -> WrappingRunner -> group runner; WrappingRunner was the remaining partial streaming wrapper. Engine delivery is pending, so the committed head is not yet observable.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-2a52312f

RESULTS:
- MUTANT 1 FAIL-BEFORE: with WrappingRunner.RunEnvStream and RunEnvStreamWithPID absent, TestFreshIsolatedProduceRunnerStreamsInjectedEnvAndPID failed: `isolated_tool_cache_test.go:242: fresh isolated produce RunEnvWithPID: tee runner inner does not support environment PID streaming`; exit 1.
- MUTANT 1 PASS-AFTER: `go test -count=1 -run '^TestFreshIsolatedProduceRunnerStreamsInjectedEnvAndPID$' ./internal/cli/` -> `ok github.com/gitmoot/gitmoot/internal/cli 0.032s`.
- MUTANT 2 FAIL-BEFORE: added an unused `incompleteRunnerWrapperMutant struct { Inner Runner }`; TestRunnerWrappersImplementEnvironmentPIDStreaming failed: `wrapper_contract_test.go:60: runner wrapper incompleteRunnerWrapperMutant does not implement EnvPIDStreamRunner`; exit 1. The mutant was removed.
- MUTANT 2 PASS-AFTER: `go test -count=1 -run '^TestRunnerWrappersImplementEnvironmentPIDStreaming$' ./internal/subprocess/` -> `ok github.com/gitmoot/gitmoot/internal/subprocess 0.543s`.
- PASS: prior #1295 guard `TestTeeRunnerEnvInjectingRunnerStreamsEnvironmentAndPID`.
- PASS: existing `TestWrappingRunnerInjectsEnvWhileStreaming`.
- PASS: `go build ./internal/subprocess/ ./internal/pipeline/ ./internal/cli/` exited 0.
- PASS: tracked and new-file whitespace checks; no mutant remains. Full suite intentionally not run per instructions.

RISK:
Review the generated diff before merging.

TASK:
adhoc-2a52312f

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
WAVE-IMPL: Fixed #1292 round 2 on branch gitmoot/adhoc-2a52312f, base HEAD 05af2b50dbe648e14aad1ceda45cac5b6e6f4952. Fresh isolated produce constructs EnvInjectingRunner -> TeeRunner -> WrappingRunner -> group runner; WrappingRunner was the remaining partial streaming wrapper. Engine delivery is pending, so the committed head is not yet observable.
````
