### PR TITLE
Gitmoot: GITMOOT-COC -> WAVE-IMPL: IMPLEMENT gitmoot#1302 — the @gitmoot

### DIFF
--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -127,7 +127,8 @@ type workflowAwareGitHub interface {
 
 func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (MergeDecision, error) {
 	// An explicit operator kill-switch must remain before validation and every
-	// GitHub/local-store operation.
+	// GitHub/local-store operation. An authenticated human merge request may
+	// override this policy, but not the independently verified evidence below.
 	if !g.AutoMerge && !request.HumanMergeRequested {
 		return MergeDecision{LeaveOpen: true, Reason: MergeLeaveOpenAutoMergeKillSwitchReason}, nil
 	}
@@ -149,7 +150,7 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	if headSHA == "" {
 		return g.gateMiss("pull request head SHA is missing"), nil
 	}
-	if !request.HumanMergeRequested && !pullRequestMerged(pr) && strings.TrimSpace(pr.State) != "closed" {
+	if !pullRequestMerged(pr) && strings.TrimSpace(pr.State) != "closed" {
 		pendingDecision, isPending, reason, err := g.reviewAndCIGateMiss(ctx, repo, request, headSHA)
 		if err != nil {
 			return MergeDecision{}, err

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -392,7 +392,7 @@ func TestRunMergeGateExplicitKillSwitchParksReviewedAndUnreviewedTasks(t *testin
 	}
 }
 
-func TestPolicyMergeGateHumanRequestBypassesKillSwitchAndMandatoryGate(t *testing.T) {
+func TestPolicyMergeGateHumanRequestRequiresFinalReview(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	mergeable := true
@@ -401,8 +401,102 @@ func TestPolicyMergeGateHumanRequestBypassesKillSwitchAndMandatoryGate(t *testin
 			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
 			HeadSHA: "head123", Mergeable: &mergeable,
 		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
 		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
-		noChecks:    true,
+	}
+	gate := PolicyMergeGate{
+		AutoMerge: false,
+		Store:     store,
+		GitHub:    gh,
+		Git:       &fakeMergeGateGit{clean: true},
+	}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+		HumanMergeRequested: true,
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Merged {
+		t.Fatalf("decision = %+v, want escalating LeaveOpen", decision)
+	}
+	if !strings.Contains(decision.Reason, "final agent review is not captured") {
+		t.Fatalf("decision reason = %q, want missing final review", decision.Reason)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge calls = %+v, want none", gh.merges)
+	}
+}
+
+func TestPolicyMergeGateHumanRequestRequiresPassingCI(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success"},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "fail", State: "COMPLETED"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{
+		AutoMerge: false,
+		Store:     store,
+		GitHub:    gh,
+		Git:       &fakeMergeGateGit{clean: true},
+	}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{
+		Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+		HumanMergeRequested: true,
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Merged {
+		t.Fatalf("decision = %+v, want escalating LeaveOpen", decision)
+	}
+	if !strings.Contains(decision.Reason, "external CI") {
+		t.Fatalf("decision reason = %q, want external CI failure", decision.Reason)
+	}
+	if len(gh.merges) != 0 {
+		t.Fatalf("merge calls = %+v, want none", gh.merges)
+	}
+}
+
+func TestPolicyMergeGateHumanRequestBypassesOnlyAutoMergePolicy(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
 	}
 	gate := PolicyMergeGate{
 		AutoMerge: false,
@@ -421,8 +515,8 @@ func TestPolicyMergeGateHumanRequestBypassesKillSwitchAndMandatoryGate(t *testin
 	if !decision.Merged || decision.LeaveOpen || decision.EscalateMergeGateMiss {
 		t.Fatalf("decision = %+v", decision)
 	}
-	if gh.statusCalls != 0 || gh.checkCalls != 0 {
-		t.Fatalf("human override evaluated mandatory review/CI gate: status=%d checks=%d", gh.statusCalls, gh.checkCalls)
+	if gh.statusCalls != 1 || gh.checkCalls != 1 {
+		t.Fatalf("human request evidence calls: status=%d checks=%d, want 1 each", gh.statusCalls, gh.checkCalls)
 	}
 	if len(gh.merges) != 1 || gh.merges[0].MatchHeadCommit != "head123" {
 		t.Fatalf("merge calls = %+v", gh.merges)


### PR DESCRIPTION
WHAT:
WAVE-IMPL: Implemented #1302 on branch gitmoot/adhoc-b404d5c3 at working head 39f29dff2993f1c3eee751e4754f3ce0bfb457c1. HumanMergeRequested now bypasses only auto_merge policy; review and CI evidence remain mandatory. Engine commit/push and draft PR delivery are pending.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-b404d5c3

RESULTS:
- PASS: go build ./internal/workflow/ (exit 0).
- MUTANT fail-before, missing review: TestPolicyMergeGateHumanRequestRequiresFinalReview failed: decision = {Ready:true Merged:true MergeCommitSHA:merge123 Reason:merged LeaveOpen:false EscalateMergeGateMiss:false Deferred:false BlockClass:0}, want escalating LeaveOpen. Restored fix; PASS: ok github.com/gitmoot/gitmoot/internal/workflow 0.318s.
- MUTANT fail-before, red CI: TestPolicyMergeGateHumanRequestRequiresPassingCI failed with the same unsafe merged decision, want escalating LeaveOpen. Restored fix; PASS: ok github.com/gitmoot/gitmoot/internal/workflow 0.354s.
- MUTANT fail-before, positive evidence path: TestPolicyMergeGateHumanRequestBypassesOnlyAutoMergePolicy failed: human request evidence calls: status=0 checks=0, want 1 each. Restored fix; PASS: ok github.com/gitmoot/gitmoot/internal/workflow 0.424s.
- PASS: TestPolicyMergeGateExplicitKillSwitchLeavesOpenWithoutGitHubCalls.
- PASS: TestPolicyMergeGateRecordsAlreadyMergedPullRequest.
- PASS: TestPolicyMergeGateBlocksClosedUnmergedPullRequest.
- PASS: git diff --check. Full suite intentionally not run per job instructions.

RISK:
Review the generated diff before merging.

TASK:
adhoc-b404d5c3

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
WAVE-IMPL: Implemented #1302 on branch gitmoot/adhoc-b404d5c3 at working head 39f29dff2993f1c3eee751e4754f3ce0bfb457c1. HumanMergeRequested now bypasses only auto_merge policy; review and CI evidence remain mandatory. Engine commit/push and draft PR delivery are pending.
````
