### PR TITLE
Gitmoot: # LANE A / A0 — status-ordering at

### DIFF
--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -213,15 +213,6 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 	if pr.Mergeable != nil && !*pr.Mergeable {
 		return g.block(ctx, request, headSHA, "pull request is not mergeable; rebase or update the branch", MergeBlockTransient)
 	}
-	if _, err := g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
-		Repo:        repo,
-		SHA:         headSHA,
-		State:       "success",
-		Context:     gitmootMergeGateContext,
-		Description: "Gitmoot merge gate passed",
-	}); err != nil {
-		return MergeDecision{}, err
-	}
 	result, err := executePullRequestMerge(ctx, g.GitHub, github.MergePullRequestInput{
 		Repo:            repo,
 		Number:          int64(request.PullRequest),
@@ -241,6 +232,15 @@ func (g PolicyMergeGate) Evaluate(ctx context.Context, request MergeRequest) (Me
 		}
 		return g.pending(ctx, request, headSHA, reason)
 	}
+	// The merge is already durable. This status is observability and cannot
+	// retroactively turn a completed merge into an error.
+	_, _ = g.GitHub.CreateCommitStatus(ctx, github.CommitStatusInput{
+		Repo:        repo,
+		SHA:         headSHA,
+		State:       "success",
+		Context:     gitmootMergeGateContext,
+		Description: "Gitmoot merge gate passed",
+	})
 	return g.finishMerged(ctx, request, pr, strings.TrimSpace(result.SHA))
 }
 

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -103,6 +103,12 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 	if !hasStatus(gh.statuses, gitmootMergeGateContext, "success") || hasStatus(gh.statuses, gitmootNoCIContext, "success") {
 		t.Fatalf("statuses = %+v", gh.statuses)
 	}
+	if len(gh.statuses) != 1 || gh.statuses[0].SHA != "head123" {
+		t.Fatalf("success status inputs = %+v, want head SHA head123 after branch deletion", gh.statuses)
+	}
+	if got := strings.Join(gh.operations, ","); got != "merge,status:gitmoot/merge-gate:success" {
+		t.Fatalf("GitHub write order = %q, want merge before success status", got)
+	}
 	if _, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-9"); !errors.Is(err, sql.ErrNoRows) {
 		t.Fatalf("branch lock after merge error = %v, want sql.ErrNoRows", err)
 	}
@@ -144,6 +150,93 @@ func TestPolicyMergeGateMergesPassingPullRequest(t *testing.T) {
 		Repo: "gitmoot/gitmoot", Branch: "task-9", PullRequest: 9,
 	}, PullRequestJournalMerged); err != nil || inserted {
 		t.Fatalf("daemon replay = (inserted=%v, err=%v), want deduplicated no-op", inserted, err)
+	}
+}
+
+func TestPolicyMergeGateMergeFailureDoesNotPostSuccess(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	mergeErr := errors.New("draft pull request cannot be merged")
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number:    9,
+			State:     "open",
+			HeadRef:   "task-9",
+			BaseRef:   "main",
+			HeadSHA:   "head123",
+			Mergeable: &mergeable,
+		},
+		status: github.CombinedStatus{
+			State:    "success",
+			Statuses: []github.CommitStatus{{Context: "ci", State: "success"}},
+		},
+		checks:   []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeErr: mergeErr,
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	_, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if !errors.Is(err, mergeErr) {
+		t.Fatalf("Evaluate error = %v, want %v", err, mergeErr)
+	}
+	if hasStatus(gh.statuses, gitmootMergeGateContext, "success") {
+		t.Fatalf("statuses after failed merge = %+v, must not contain merge-gate success", gh.statuses)
+	}
+}
+
+func TestPolicyMergeGateStatusFailureAfterMergeIsBestEffort(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-9",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-1",
+		Result:      &AgentResult{Decision: "approved", Summary: "ready"},
+	})
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number:    9,
+			State:     "open",
+			HeadRef:   "task-9",
+			BaseRef:   "main",
+			HeadSHA:   "head123",
+			Mergeable: &mergeable,
+		},
+		status: github.CombinedStatus{
+			State:    "success",
+			Statuses: []github.CommitStatus{{Context: "ci", State: "success"}},
+		},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+		statusErr:   errors.New("status API unavailable"),
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error after completed merge: %v", err)
+	}
+	if !decision.Merged || decision.MergeCommitSHA != "merge123" {
+		t.Fatalf("decision = %+v, want completed merge despite status error", decision)
+	}
+	if got := strings.Join(gh.operations, ","); got != "merge,status:gitmoot/merge-gate:success" {
+		t.Fatalf("GitHub write order = %q, want merge before best-effort success status", got)
 	}
 }
 
@@ -1531,11 +1624,14 @@ type fakeMergeGateGitHub struct {
 	compare      github.CompareResult
 	checks       []github.PullRequestCheck
 	mergeResult  github.MergeResult
+	mergeErr     error
+	statusErr    error
 	updateErr    error
 	statuses     []github.CommitStatusInput
 	merges       []github.MergePullRequestInput
 	updates      []github.UpdatePullRequestBranchInput
 	comments     []string
+	operations   []string
 	getCalls     int
 	statusCalls  int
 	compareCalls int
@@ -1579,7 +1675,8 @@ func (f *fakeMergeGateGitHub) ListCheckRunsForRef(_ context.Context, _ github.Re
 
 func (f *fakeMergeGateGitHub) CreateCommitStatus(_ context.Context, input github.CommitStatusInput) (github.CommitStatus, error) {
 	f.statuses = append(f.statuses, input)
-	return github.CommitStatus{State: input.State, Context: input.Context}, nil
+	f.operations = append(f.operations, "status:"+input.Context+":"+input.State)
+	return github.CommitStatus{State: input.State, Context: input.Context}, f.statusErr
 }
 
 func (f *fakeMergeGateGitHub) PostIssueComment(_ context.Context, _ github.Repository, _ int64, body string) (github.IssueComment, error) {
@@ -1594,7 +1691,8 @@ func (f *fakeMergeGateGitHub) UpdatePullRequestBranch(_ context.Context, input g
 
 func (f *fakeMergeGateGitHub) MergePullRequest(_ context.Context, input github.MergePullRequestInput) (github.MergeResult, error) {
 	f.merges = append(f.merges, input)
-	return f.mergeResult, nil
+	f.operations = append(f.operations, "merge")
+	return f.mergeResult, f.mergeErr
 }
 
 type fakeMergeGateGit struct {


### PR DESCRIPTION
WHAT:
GMC-GATE: Implemented A0 on branch gitmoot/adhoc-9f2c70b3 at base HEAD 2d26f7c5de4cec1222f02fdea0ae6a1e35fda64f. Success status is now posted only after MergePullRequest confirms Merged=true; merge errors leave no false green, and post-merge status errors remain best-effort.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-9f2c70b3

RESULTS:
- NAMED MUTANT FAIL-BEFORE: TestPolicyMergeGateMergeFailureDoesNotPostSuccess failed: `statuses after failed merge = [{Repo:{Owner:gitmoot Name:gitmoot} SHA:head123 State:success Context:gitmoot/merge-gate Description:Gitmoot merge gate passed TargetURL:}], must not contain merge-gate success`; package FAIL, exit 1.
- PASS-AFTER: TestPolicyMergeGateMergeFailureDoesNotPostSuccess: `ok github.com/gitmoot/gitmoot/internal/workflow 0.292s`, exit 0.
- POSITIVE: TestPolicyMergeGateMergesPassingPullRequest: `ok github.com/gitmoot/gitmoot/internal/workflow 0.314s`, exit 0.
- BEST-EFFORT: TestPolicyMergeGateStatusFailureAfterMergeIsBestEffort: `ok github.com/gitmoot/gitmoot/internal/workflow 0.290s`, exit 0.
- A1 REGRESSION: TestPolicyMergeGateHumanRequestBypassesOnlyAutoMergePolicy: `ok github.com/gitmoot/gitmoot/internal/workflow 0.308s`, exit 0.
- PENDING REGRESSION: TestPolicyMergeGateKeepsQueuedMergePending: `ok github.com/gitmoot/gitmoot/internal/workflow 0.284s`, exit 0.
- `go build ./internal/workflow/`: exit 0.
- `go vet ./internal/workflow/`: exit 0.
- `git diff --check`: exit 0.

RISK:
Review the generated diff before merging.

TASK:
adhoc-9f2c70b3

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GMC-GATE: Implemented A0 on branch gitmoot/adhoc-9f2c70b3 at base HEAD 2d26f7c5de4cec1222f02fdea0ae6a1e35fda64f. Success status is now posted only after MergePullRequest confirms Merged=true; merge errors leave no false green, and post-merge status errors remain best-effort.
````
