### PR TITLE
Gitmoot: GMC-GATE -> WAVE-IMPL. Lane A slice A3 of

### DIFF
--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -475,7 +475,9 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			continue
 		}
 		for _, candidate := range reviewsAtHead {
-			if strings.TrimSpace(candidate.job.Agent) == reviewer && reviewJobRecordedAfter(candidate.job, review.job) {
+			if strings.TrimSpace(candidate.job.Agent) == reviewer &&
+				isReviewReplacementDecision(candidate.payload.Result.Decision) &&
+				reviewJobRecordedAfter(candidate.job, review.job) {
 				supersededReviewIDs[review.job.ID] = struct{}{}
 				break
 			}
@@ -615,6 +617,15 @@ func reviewJobRecordedAfter(left db.Job, right db.Job) bool {
 		return after
 	}
 	return false
+}
+
+func isReviewReplacementDecision(decision string) bool {
+	switch decision {
+	case "approved", "changes_requested", "blocked", "failed":
+		return true
+	default:
+		return false
+	}
 }
 
 func recordedTimestampAfter(left string, right string) (after bool, decided bool) {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -444,6 +444,27 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			implementingAgents[agent] = struct{}{}
 		}
 	}
+	// A round can order remediation, but it must not hide a blocking verdict
+	// captured at the head currently being evaluated.
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			return err
+		}
+		if !sameTask(current, payload) || payload.Result == nil {
+			continue
+		}
+		if err := g.ensureReviewMatchesHead(payload, headSHA, job.Agent); err != nil {
+			continue
+		}
+		switch payload.Result.Decision {
+		case "changes_requested", "blocked", "failed":
+			return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", job.Agent)}
+		}
+	}
 	latest := ""
 	for _, job := range jobs {
 		if job.Type != "review" {

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -446,6 +446,11 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 	}
 	// A round can order remediation, but it must not hide a blocking verdict
 	// captured at the head currently being evaluated.
+	type reviewAtHead struct {
+		job     db.Job
+		payload JobPayload
+	}
+	var reviewsAtHead []reviewAtHead
 	for _, job := range jobs {
 		if job.Type != "review" {
 			continue
@@ -457,12 +462,32 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		if !sameTask(current, payload) || payload.Result == nil {
 			continue
 		}
-		if err := g.ensureReviewMatchesHead(payload, headSHA, job.Agent); err != nil {
+		reviewHead := strings.TrimSpace(payload.HeadSHA)
+		if reviewHead == "" || reviewHead != headSHA {
 			continue
 		}
-		switch payload.Result.Decision {
+		reviewsAtHead = append(reviewsAtHead, reviewAtHead{job: job, payload: payload})
+	}
+	supersededReviewIDs := map[string]struct{}{}
+	for _, review := range reviewsAtHead {
+		reviewer := strings.TrimSpace(review.job.Agent)
+		if reviewer == "" {
+			continue
+		}
+		for _, candidate := range reviewsAtHead {
+			if strings.TrimSpace(candidate.job.Agent) == reviewer && reviewJobRecordedAfter(candidate.job, review.job) {
+				supersededReviewIDs[review.job.ID] = struct{}{}
+				break
+			}
+		}
+	}
+	for _, review := range reviewsAtHead {
+		if _, superseded := supersededReviewIDs[review.job.ID]; superseded {
+			continue
+		}
+		switch review.payload.Result.Decision {
 		case "changes_requested", "blocked", "failed":
-			return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", job.Agent)}
+			return mergeBlocked{reason: fmt.Sprintf("review at evaluated head has blocking result from %s", review.job.Agent)}
 		}
 	}
 	latest := ""
@@ -475,6 +500,9 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			return err
 		}
 		if !sameTask(current, payload) {
+			continue
+		}
+		if _, superseded := supersededReviewIDs[job.ID]; superseded {
 			continue
 		}
 		round := strings.TrimSpace(payload.ReviewRound)
@@ -510,6 +538,9 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 			round = job.ID
 		}
 		if !sameTask(current, payload) || round != latest || payload.Result == nil {
+			continue
+		}
+		if _, superseded := supersededReviewIDs[job.ID]; superseded {
 			continue
 		}
 		if payload.Result.Decision == "approved" {
@@ -574,6 +605,25 @@ func reviewAuthorshipFailureReason(selfApproval string, unknownImplementer strin
 		}
 	}
 	return ""
+}
+
+func reviewJobRecordedAfter(left db.Job, right db.Job) bool {
+	if after, decided := recordedTimestampAfter(left.UpdatedAt, right.UpdatedAt); decided {
+		return after
+	}
+	if after, decided := recordedTimestampAfter(left.CreatedAt, right.CreatedAt); decided {
+		return after
+	}
+	return false
+}
+
+func recordedTimestampAfter(left string, right string) (after bool, decided bool) {
+	leftTime, leftOK := parseStoredJobTime(left)
+	rightTime, rightOK := parseStoredJobTime(right)
+	if !leftOK || !rightOK || leftTime.Equal(rightTime) {
+		return false, false
+	}
+	return leftTime.After(rightTime), true
 }
 
 func (g PolicyMergeGate) ensureBranchFresh(ctx context.Context, repo github.Repository, request MergeRequest, pr github.PullRequest, headSHA string) (MergeDecision, bool, error) {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -1510,6 +1510,137 @@ func TestPolicyMergeGateBlocksAnyVerdictAtEvaluatedHeadBeforeRoundSelection(t *t
 	}
 }
 
+func TestPolicyMergeGateSameReviewerLaterVerdictSupersedesObjection(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	basePayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+	}
+	objection := basePayload
+	objection.Result = &AgentResult{Decision: "changes_requested", Summary: "must fix"}
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-z-objection", Agent: "reviewer", Type: "review"}, objection)
+	setMergeGateJobTimestamps(t, store, "review-z-objection", "2026-07-31 12:00:00")
+
+	approval := basePayload
+	approval.Result = &AgentResult{Decision: "approved", Summary: "objection resolved"}
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-a-approval", Agent: "reviewer", Type: "review"}, approval)
+	setMergeGateJobTimestamps(t, store, "review-a-approval", "2026-07-31 12:01:00")
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v, want later verdict from same reviewer to supersede objection", decision)
+	}
+}
+
+func TestPolicyMergeGateDifferentReviewerCannotSupersedeObjection(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	basePayload := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+	}
+	objection := basePayload
+	objection.Result = &AgentResult{Decision: "changes_requested", Summary: "must fix"}
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-a-objection", Agent: "objector", Type: "review"}, objection)
+	setMergeGateJobTimestamps(t, store, "review-a-objection", "2026-07-31 12:00:00")
+
+	approval := basePayload
+	approval.Result = &AgentResult{Decision: "approved", Summary: "ready"}
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-z-approval", Agent: "approver", Type: "review"}, approval)
+	setMergeGateJobTimestamps(t, store, "review-z-approval", "2026-07-31 12:01:00")
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Merged {
+		t.Fatalf("decision = %+v, want different reviewer's objection to remain blocking", decision)
+	}
+	if !strings.Contains(decision.Reason, "blocking result from objector") {
+		t.Fatalf("decision reason = %q, want objector's blocking result", decision.Reason)
+	}
+}
+
+func TestPolicyMergeGateHeadlessIntegrationObjectionDoesNotMatchEveryHead(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	headlessObjection := JobPayload{
+		Repo:         "gitmoot/gitmoot",
+		PullRequest:  9,
+		TaskID:       "task-9",
+		ReviewRound:  "review-1",
+		DelegationID: "verify-old",
+		WorktreePath: "/tmp/gitmoot/integration-verify-old",
+		Result:       &AgentResult{Decision: "changes_requested", Summary: "integration objection"},
+	}
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-headless-objection", Agent: "objector", Type: "review"}, headlessObjection)
+
+	currentApproval := JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		PullRequest: 9,
+		HeadSHA:     "head123",
+		TaskID:      "task-9",
+		ReviewRound: "review-2",
+		Result:      &AgentResult{Decision: "approved", Summary: "current head approved"},
+	}
+	insertIndependentMergeGateReview(t, store, db.Job{ID: "review-current-approval", Agent: "approver", Type: "review"}, currentApproval)
+
+	mergeable := true
+	gh := &fakeMergeGateGitHub{
+		pr: github.PullRequest{
+			Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+			HeadSHA: "head123", Mergeable: &mergeable,
+		},
+		status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+		checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+		mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+	}
+	gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+	decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !decision.Merged {
+		t.Fatalf("decision = %+v, want headless integration objection excluded from strict-head pre-pass", decision)
+	}
+}
+
 func TestPolicyMergeGateBlocksReviewForStaleHead(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
@@ -1796,4 +1927,23 @@ func hasStatus(statuses []github.CommitStatusInput, context string, state string
 		}
 	}
 	return false
+}
+
+func setMergeGateJobTimestamps(t *testing.T, store *db.Store, jobID string, timestamp string) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("open store for timestamp update: %v", err)
+	}
+	defer raw.Close()
+	result, err := raw.ExecContext(context.Background(),
+		`UPDATE jobs SET created_at = ?, updated_at = ? WHERE id = ?`,
+		timestamp, timestamp, jobID)
+	if err != nil {
+		t.Fatalf("set job %s timestamps: %v", jobID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected != 1 {
+		t.Fatalf("set job %s timestamps affected=%d, err=%v; want 1", jobID, affected, err)
+	}
 }

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -1444,6 +1444,72 @@ func TestPolicyMergeGateUsesLatestNumericReviewRound(t *testing.T) {
 	}
 }
 
+func TestPolicyMergeGateBlocksAnyVerdictAtEvaluatedHeadBeforeRoundSelection(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		approvalRound string
+	}{
+		{
+			name: "empty rounds do not use job ID to mask objection",
+		},
+		{
+			name:          "numbered round does not mask unnumbered objection",
+			approvalRound: "review-2",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			basePayload := JobPayload{
+				Repo:        "gitmoot/gitmoot",
+				PullRequest: 9,
+				HeadSHA:     "head123",
+				TaskID:      "task-9",
+			}
+			implementPayload := basePayload
+			implementPayload.HeadSHA = ""
+			implementPayload.Result = &AgentResult{Decision: "implemented", Summary: "implemented"}
+			insertCompletedJob(t, store, db.Job{ID: "implement-job", Agent: "implementer", Type: "implement"}, implementPayload)
+
+			objection := basePayload
+			objection.Result = &AgentResult{Decision: "changes_requested", Summary: "must fix"}
+			insertCompletedJob(t, store, db.Job{ID: "review-a-objection", Agent: "objector", Type: "review"}, objection)
+
+			approval := basePayload
+			approval.ReviewRound = tc.approvalRound
+			approval.Result = &AgentResult{Decision: "approved", Summary: "ready"}
+			insertCompletedJob(t, store, db.Job{ID: "review-z-approval", Agent: "approver", Type: "review"}, approval)
+
+			mergeable := true
+			gh := &fakeMergeGateGitHub{
+				pr: github.PullRequest{
+					Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+					HeadSHA: "head123", Mergeable: &mergeable,
+				},
+				status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+				checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+				mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+			}
+			gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+			decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Merged {
+				t.Fatalf("decision = %+v, want objection to block merge", decision)
+			}
+			if !strings.Contains(decision.Reason, "blocking result from objector") {
+				t.Fatalf("decision reason = %q, want objector's blocking result", decision.Reason)
+			}
+			if len(gh.merges) != 0 {
+				t.Fatalf("merge calls = %+v, want none", gh.merges)
+			}
+		})
+	}
+}
+
 func TestPolicyMergeGateBlocksReviewForStaleHead(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -1595,6 +1595,70 @@ func TestPolicyMergeGateDifferentReviewerCannotSupersedeObjection(t *testing.T) 
 	}
 }
 
+func TestPolicyMergeGateNonEvidenceVerdictDoesNotSupersedeObjection(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		decision string
+	}{
+		{name: "skipped", decision: "skipped"},
+		{name: "empty"},
+		{name: "unknown future decision", decision: "future_verdict"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			basePayload := JobPayload{
+				Repo:        "gitmoot/gitmoot",
+				PullRequest: 9,
+				HeadSHA:     "head123",
+				TaskID:      "task-9",
+				ReviewRound: "review-1",
+			}
+			objection := basePayload
+			objection.Result = &AgentResult{Decision: "changes_requested", Summary: "must fix"}
+			insertIndependentMergeGateReview(t, store, db.Job{ID: "review-objector-objection", Agent: "objector", Type: "review"}, objection)
+			setMergeGateJobTimestamps(t, store, "review-objector-objection", "2026-07-31 12:00:00")
+
+			nonEvidence := basePayload
+			nonEvidence.Result = &AgentResult{Decision: tc.decision, Summary: "no replacement evidence"}
+			insertIndependentMergeGateReview(t, store, db.Job{ID: "review-objector-later", Agent: "objector", Type: "review"}, nonEvidence)
+			setMergeGateJobTimestamps(t, store, "review-objector-later", "2026-07-31 12:01:00")
+
+			approval := basePayload
+			approval.Result = &AgentResult{Decision: "approved", Summary: "ready"}
+			insertIndependentMergeGateReview(t, store, db.Job{ID: "review-approver", Agent: "approver", Type: "review"}, approval)
+			setMergeGateJobTimestamps(t, store, "review-approver", "2026-07-31 12:02:00")
+
+			mergeable := true
+			gh := &fakeMergeGateGitHub{
+				pr: github.PullRequest{
+					Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+					HeadSHA: "head123", Mergeable: &mergeable,
+				},
+				status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+				checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+				mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+			}
+			gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+			decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Merged {
+				t.Fatalf("decision = %+v, want non-evidence decision %q to leave objection blocking", decision, tc.decision)
+			}
+			if !strings.Contains(decision.Reason, "blocking result from objector") {
+				t.Fatalf("decision reason = %q, want objector's blocking result", decision.Reason)
+			}
+			if len(gh.merges) != 0 {
+				t.Fatalf("merge calls = %+v, want none", gh.merges)
+			}
+		})
+	}
+}
+
 func TestPolicyMergeGateHeadlessIntegrationObjectionDoesNotMatchEveryHead(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)


### PR DESCRIPTION
WHAT:
GMC-GATE: Implemented A3 on branch gitmoot/adhoc-bc6fdac6 at base HEAD 94c44ab889bd782f38a38c5ad896dec2823213ba. Blocking verdicts are now evaluated across all completed reviews at the engine-observed PR head before round selection. Approval selection, nil-result handling, authorship checks, and #1263 fail-closed behavior remain unchanged.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-bc6fdac6

RESULTS:
- NAMED MUTANT FAIL-BEFORE: both cases failed because the gate merged. Empty-round output: `decision = {Ready:true Merged:true MergeCommitSHA:merge123 Reason:merged LeaveOpen:false EscalateMergeGateMiss:false Deferred:false BlockClass:0}, want objection to block merge`. Mixed-round output: identical merged decision. Package exit 1.
- PASS-AFTER: `TestPolicyMergeGateBlocksAnyVerdictAtEvaluatedHeadBeforeRoundSelection`: `ok github.com/gitmoot/gitmoot/internal/workflow 1.039s`, exit 0.
- POSITIVE: `TestPolicyMergeGateMergesPassingPullRequest`: `ok github.com/gitmoot/gitmoot/internal/workflow 0.669s`, exit 0.
- STALE-HEAD REGRESSION: `TestPolicyMergeGateUsesLatestNumericReviewRound`: exit 0; `TestPolicyMergeGateBlocksReviewForStaleHead`: exit 0.
- POLARITY REGRESSION: `TestPolicyMergeGateRejectsUnverifiableReviewAuthorship`: `ok github.com/gitmoot/gitmoot/internal/workflow 1.124s`, exit 0.
- A1 REGRESSION: `TestPolicyMergeGateHumanRequestBypassesOnlyAutoMergePolicy`: exit 0.
- A0 REGRESSION: `TestPolicyMergeGateMergeFailureDoesNotPostSuccess`: exit 0.
- `go build ./internal/workflow/`: exit 0.
- `go vet ./internal/workflow/`: exit 0.
- `git diff --check`: exit 0.

RISK:
Review the generated diff before merging.

TASK:
adhoc-bc6fdac6

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
GMC-GATE: Implemented A3 on branch gitmoot/adhoc-bc6fdac6 at base HEAD 94c44ab889bd782f38a38c5ad896dec2823213ba. Blocking verdicts are now evaluated across all completed reviews at the engine-observed PR head before round selection. Approval selection, nil-result handling, authorship checks, and #1263 fail-closed behavior remain unchanged.
````
