### PR TITLE
feat(dashboard): Comms page — org traffic in the chat idiom (#1294)

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -90,6 +90,7 @@ func newDashboardWebHandler(ds *webDataSource) http.Handler {
 	mux.HandleFunc("GET /api/learning/knowledge", ds.handleLearningKnowledge)
 	mux.HandleFunc("GET /api/brain/events", ds.handleBrainEvents)
 	mux.HandleFunc("GET /api/brain/fact", ds.handleBrainFact)
+	registerDashboardCommsRoutes(mux, ds)
 	// #958 single-label detail widening (no module cache policy for this route).
 	mux.HandleFunc("GET /api/workflow/{label}", ds.handleWorkflowAPI)
 	// Public pipeline receipts are deliberately narrow, read-only projections of

--- a/internal/cli/dashboard_web_comms.go
+++ b/internal/cli/dashboard_web_comms.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,7 +16,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
-const dashboardCommsDiscoveryLimit = 200
+const dashboardCommsMessagesPerThread = 200
 
 type dashboardCommsResponse struct {
 	GeneratedAt string                 `json:"generated_at"`
@@ -62,7 +65,16 @@ func registerDashboardCommsRoutes(mux *http.ServeMux, ds *webDataSource) {
 }
 
 func (d *webDataSource) handleCommsAPI(w http.ResponseWriter, r *http.Request) {
-	payload, err := d.comms(r.Context())
+	var requestedNoteID int64
+	if value := strings.TrimSpace(r.URL.Query().Get("note")); value != "" {
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || parsed <= 0 {
+			http.Error(w, "note must be a positive integer", http.StatusBadRequest)
+			return
+		}
+		requestedNoteID = parsed
+	}
+	payload, err := d.comms(r.Context(), requestedNoteID)
 	if err != nil {
 		http.Error(w, "comms source unavailable: "+err.Error(), http.StatusServiceUnavailable)
 		return
@@ -85,19 +97,28 @@ func (d *webDataSource) handleCommsPage(w http.ResponseWriter, _ *http.Request) 
 	_, _ = fmt.Fprint(w, dashboardCommsPage)
 }
 
-func (d *webDataSource) comms(ctx context.Context) (dashboardCommsResponse, error) {
+func (d *webDataSource) comms(ctx context.Context, requestedNoteID int64) (dashboardCommsResponse, error) {
 	out := dashboardCommsResponse{
 		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
 		Threads:     []dashboardCommsThread{},
 	}
 	err := withStore(d.home, func(store *db.Store) error {
 		workflows := map[string]struct{}{}
-		for _, prefix := range []string{workflow.OrgEscalatePrefix, "[auto:pr:"} {
-			notes, err := store.ListWorkflowNotesByBodyPrefix(ctx, prefix, dashboardCommsDiscoveryLimit)
-			if err != nil {
+		summaries, err := store.ListWorkflowSummaries(ctx)
+		if err != nil {
+			return err
+		}
+		for _, summary := range summaries {
+			if id := strings.TrimSpace(summary.WorkflowID); id != "" {
+				workflows[id] = struct{}{}
+			}
+		}
+		if requestedNoteID > 0 {
+			note, err := store.GetWorkflowNote(ctx, requestedNoteID)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return err
 			}
-			for _, note := range notes {
+			if err == nil {
 				if id := strings.TrimSpace(note.WorkflowID); id != "" {
 					workflows[id] = struct{}{}
 				}
@@ -114,7 +135,7 @@ func (d *webDataSource) comms(ctx context.Context) (dashboardCommsResponse, erro
 				return err
 			}
 			if thread, ok := dashboardCommsProjectThread(id, notes); ok {
-				out.Threads = append(out.Threads, thread)
+				out.Threads = append(out.Threads, dashboardCommsBoundThread(thread, requestedNoteID))
 			}
 		}
 		return nil
@@ -134,6 +155,44 @@ func (d *webDataSource) comms(ctx context.Context) (dashboardCommsResponse, erro
 		return out.Threads[i].WorkflowID < out.Threads[j].WorkflowID
 	})
 	return out, nil
+}
+
+// dashboardCommsBoundThread bounds ordinary payload per workflow without ever
+// dropping an unresolved escalation or the note explicitly requested by a deep
+// link. Discovery and unresolved accounting happen before this projection, so a
+// noisy store cannot turn a note limit into a workflow or obligation limit.
+func dashboardCommsBoundThread(thread dashboardCommsThread, requestedNoteID int64) dashboardCommsThread {
+	if len(thread.Messages) <= dashboardCommsMessagesPerThread {
+		return thread
+	}
+	keep := make([]bool, len(thread.Messages))
+	ordinaryBudget := dashboardCommsMessagesPerThread
+	for i, message := range thread.Messages {
+		requested := message.ID == requestedNoteID ||
+			(message.Resolution != nil && message.Resolution.NoteID == requestedNoteID)
+		unresolved := message.Kind == "escalation" && message.Resolution == nil
+		if requested || unresolved {
+			keep[i] = true
+			if ordinaryBudget > 0 {
+				ordinaryBudget--
+			}
+		}
+	}
+	for i := len(thread.Messages) - 1; i >= 0 && ordinaryBudget > 0; i-- {
+		if keep[i] {
+			continue
+		}
+		keep[i] = true
+		ordinaryBudget--
+	}
+	messages := make([]dashboardCommsMessage, 0, dashboardCommsMessagesPerThread)
+	for i, message := range thread.Messages {
+		if keep[i] {
+			messages = append(messages, message)
+		}
+	}
+	thread.Messages = messages
+	return thread
 }
 
 func dashboardCommsProjectThread(workflowID string, notes []db.WorkflowNote) (dashboardCommsThread, bool) {
@@ -349,9 +408,10 @@ footer{display:flex;align-items:center;justify-content:center;border-top:1px sol
   const saved=localStorage.getItem('gitmoot-comms-theme'),preferred=matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';
   document.documentElement.dataset.theme=saved||preferred;
   $('theme').onclick=()=>{const next=document.documentElement.dataset.theme==='dark'?'light':'dark';document.documentElement.dataset.theme=next;localStorage.setItem('gitmoot-comms-theme',next)};
-  fetch('/api/comms',{cache:'no-store'}).then(async r=>{if(!r.ok)throw new Error(await r.text());return r.json()}).then(data=>{
+  const p=new URLSearchParams(location.search),note=p.get('note')||(location.hash.match(/^#note-(\d+)$/)||[])[1],wanted=p.get('workflow');
+  const api=new URL('/api/comms',location.origin);if(note)api.searchParams.set('note',note);
+  fetch(api.pathname+api.search,{cache:'no-store'}).then(async r=>{if(!r.ok)throw new Error(await r.text());return r.json()}).then(data=>{
     state.data=Array.isArray(data.threads)?data.threads:[];roleOptions();
-    const p=new URLSearchParams(location.search),note=p.get('note')||(location.hash.match(/^#note-(\d+)$/)||[])[1],wanted=p.get('workflow');
     if(note){state.deep=String(note);const found=state.data.find(t=>t.messages.some(m=>String(m.id)===state.deep||(m.resolution&&String(m.resolution.note_id)===state.deep)));if(found)state.selected=found.workflow_id}
     if(!state.selected&&wanted&&state.data.some(t=>t.workflow_id===wanted))state.selected=wanted;
     if(!state.data.length){$('threads').innerHTML=stateBox('No org traffic yet','Typed escalations and engine markers will appear here when workflow notes are written.');$('messages').innerHTML=stateBox('Conversation is empty','There are no Comms threads to display.');return}

--- a/internal/cli/dashboard_web_comms.go
+++ b/internal/cli/dashboard_web_comms.go
@@ -1,0 +1,363 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const dashboardCommsDiscoveryLimit = 200
+
+type dashboardCommsResponse struct {
+	GeneratedAt string                 `json:"generated_at"`
+	Threads     []dashboardCommsThread `json:"threads"`
+}
+
+type dashboardCommsThread struct {
+	WorkflowID string                  `json:"workflow_id"`
+	Repo       string                  `json:"repo,omitempty"`
+	UpdatedAt  string                  `json:"updated_at"`
+	Unresolved int                     `json:"unresolved"`
+	Messages   []dashboardCommsMessage `json:"messages"`
+}
+
+type dashboardCommsMessage struct {
+	ID         int64                     `json:"id"`
+	Kind       string                    `json:"kind"`
+	From       string                    `json:"from,omitempty"`
+	To         string                    `json:"to,omitempty"`
+	Body       string                    `json:"body"`
+	CreatedAt  string                    `json:"created_at"`
+	Resolution *dashboardCommsResolution `json:"resolution,omitempty"`
+}
+
+type dashboardCommsResolution struct {
+	NoteID       int64  `json:"note_id"`
+	By           string `json:"by"`
+	AnswerNoteID int64  `json:"answer_note_id,omitempty"`
+	CreatedAt    string `json:"created_at"`
+}
+
+type dashboardCommsResolutionRecord struct {
+	resolution dashboardCommsResolution
+}
+
+type dashboardCommsEscalationRecord struct {
+	note db.WorkflowNote
+	from string
+	to   string
+	body string
+}
+
+func registerDashboardCommsRoutes(mux *http.ServeMux, ds *webDataSource) {
+	mux.HandleFunc("GET /api/comms", ds.handleCommsAPI)
+	mux.HandleFunc("GET /comms", ds.handleCommsPage)
+}
+
+func (d *webDataSource) handleCommsAPI(w http.ResponseWriter, r *http.Request) {
+	payload, err := d.comms(r.Context())
+	if err != nil {
+		http.Error(w, "comms source unavailable: "+err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+func (d *webDataSource) handleCommsPage(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprint(w, dashboardCommsPage)
+}
+
+func (d *webDataSource) comms(ctx context.Context) (dashboardCommsResponse, error) {
+	out := dashboardCommsResponse{
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Threads:     []dashboardCommsThread{},
+	}
+	err := withStore(d.home, func(store *db.Store) error {
+		workflows := map[string]struct{}{}
+		for _, prefix := range []string{workflow.OrgEscalatePrefix, "[auto:pr:"} {
+			notes, err := store.ListWorkflowNotesByBodyPrefix(ctx, prefix, dashboardCommsDiscoveryLimit)
+			if err != nil {
+				return err
+			}
+			for _, note := range notes {
+				if id := strings.TrimSpace(note.WorkflowID); id != "" {
+					workflows[id] = struct{}{}
+				}
+			}
+		}
+		ids := make([]string, 0, len(workflows))
+		for id := range workflows {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			notes, err := store.ListWorkflowNotes(ctx, id, 0)
+			if err != nil {
+				return err
+			}
+			if thread, ok := dashboardCommsProjectThread(id, notes); ok {
+				out.Threads = append(out.Threads, thread)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return dashboardCommsResponse{}, err
+	}
+	sort.Slice(out.Threads, func(i, j int) bool {
+		iOpen := out.Threads[i].Unresolved > 0
+		jOpen := out.Threads[j].Unresolved > 0
+		if iOpen != jOpen {
+			return iOpen
+		}
+		if out.Threads[i].UpdatedAt != out.Threads[j].UpdatedAt {
+			return out.Threads[i].UpdatedAt > out.Threads[j].UpdatedAt
+		}
+		return out.Threads[i].WorkflowID < out.Threads[j].WorkflowID
+	})
+	return out, nil
+}
+
+func dashboardCommsProjectThread(workflowID string, notes []db.WorkflowNote) (dashboardCommsThread, bool) {
+	resolutions := map[int64]dashboardCommsResolutionRecord{}
+	escalations := map[int64]dashboardCommsEscalationRecord{}
+	answers := map[int64]int64{}
+	for _, note := range notes {
+		if from, to, _, body, ok := workflow.ParseOrgEscalateNote(note.Body); ok {
+			escalations[note.ID] = dashboardCommsEscalationRecord{note: note, from: from, to: to, body: body}
+			continue
+		}
+		escalationID, by, answerID, ok := workflow.ParseOrgEscalateResolvedNote(note.Body)
+		if !ok {
+			continue
+		}
+		resolutions[escalationID] = dashboardCommsResolutionRecord{resolution: dashboardCommsResolution{
+			NoteID: note.ID, By: by, AnswerNoteID: answerID, CreatedAt: dashboardCommsTimestamp(note.CreatedAt),
+		}}
+		if answerID > 0 {
+			answers[answerID] = escalationID
+		}
+	}
+
+	thread := dashboardCommsThread{WorkflowID: workflowID, Messages: []dashboardCommsMessage{}}
+	for _, note := range notes {
+		at := dashboardCommsTimestamp(note.CreatedAt)
+		if thread.Repo == "" && strings.TrimSpace(note.Repo) != "" {
+			thread.Repo = strings.TrimSpace(note.Repo)
+		}
+		if record, ok := escalations[note.ID]; ok {
+			message := dashboardCommsMessage{
+				ID: note.ID, Kind: "escalation", From: record.from, To: record.to,
+				Body: record.body, CreatedAt: at,
+			}
+			if resolved, ok := resolutions[note.ID]; ok {
+				value := resolved.resolution
+				message.Resolution = &value
+			} else {
+				thread.Unresolved++
+			}
+			thread.Messages = append(thread.Messages, message)
+			thread.UpdatedAt = dashboardCommsLater(thread.UpdatedAt, at)
+			continue
+		}
+		if strings.HasPrefix(note.Body, "[auto:pr:") {
+			thread.Messages = append(thread.Messages, dashboardCommsMessage{
+				ID: note.ID, Kind: "system", Body: note.Body, CreatedAt: at,
+			})
+			thread.UpdatedAt = dashboardCommsLater(thread.UpdatedAt, at)
+			continue
+		}
+		escalationID, ok := answers[note.ID]
+		if !ok {
+			continue
+		}
+		escalation, exists := escalations[escalationID]
+		if !exists {
+			continue
+		}
+		resolved := resolutions[escalationID].resolution
+		from := strings.TrimSpace(note.Author)
+		if from == "" {
+			from = resolved.By
+		}
+		thread.Messages = append(thread.Messages, dashboardCommsMessage{
+			ID: note.ID, Kind: "reply", From: from, To: escalation.from,
+			Body: note.Body, CreatedAt: at,
+		})
+		thread.UpdatedAt = dashboardCommsLater(thread.UpdatedAt, at)
+	}
+	sort.SliceStable(thread.Messages, func(i, j int) bool {
+		if thread.Messages[i].CreatedAt != thread.Messages[j].CreatedAt {
+			return thread.Messages[i].CreatedAt < thread.Messages[j].CreatedAt
+		}
+		return thread.Messages[i].ID < thread.Messages[j].ID
+	})
+	return thread, len(thread.Messages) > 0
+}
+
+func dashboardCommsTimestamp(value string) string {
+	value = strings.TrimSpace(value)
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339, "2006-01-02 15:04:05"} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC().Format(time.RFC3339)
+		}
+	}
+	return value
+}
+
+func dashboardCommsLater(current, candidate string) string {
+	if candidate > current {
+		return candidate
+	}
+	return current
+}
+
+const dashboardCommsPage = `<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Comms · gitmoot</title>
+<style>
+:root{color-scheme:dark;--bg:#080a10;--panel:#0f131d;--panel2:#151a27;--line:#272e3d;--text:#edf1f7;--muted:#929bae;--faint:#687185;--accent:#9ece6a;--loud:#ff9e64;--bubble:#18202e;--reply:#17271f;--shadow:0 18px 50px rgba(0,0,0,.22)}
+[data-theme="light"]{color-scheme:light;--bg:#f3f5f8;--panel:#fff;--panel2:#f8fafc;--line:#dce1e9;--text:#172033;--muted:#5e687b;--faint:#8790a0;--accent:#467a2b;--loud:#bd4b1c;--bubble:#eef3f9;--reply:#eef7ed;--shadow:0 16px 40px rgba(24,36,58,.1)}
+*{box-sizing:border-box}html,body{height:100%;margin:0}body{background:var(--bg);color:var(--text);font:14px/1.45 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;overflow:hidden}
+button,input,select{font:inherit;color:inherit}button{cursor:pointer}.shell{height:100%;display:grid;grid-template-rows:58px auto minmax(0,1fr) 36px}
+header{display:flex;align-items:center;gap:14px;padding:0 20px;border-bottom:1px solid var(--line);background:var(--panel)}
+.brand{display:flex;align-items:center;gap:9px;color:var(--text);font-weight:750;text-decoration:none;font-size:18px}.mark{width:25px;height:25px;display:grid;place-items:center;border:1px solid color-mix(in srgb,var(--accent) 55%,var(--line));border-radius:8px;color:var(--accent);font-weight:900}
+.crumb{color:var(--muted);font-size:12px}.crumb b{color:var(--text)}.spacer{flex:1}.navlink,.theme{border:1px solid var(--line);background:var(--panel2);border-radius:8px;padding:7px 10px;text-decoration:none;color:var(--muted)}.navlink.active{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 45%,var(--line))}
+.filters{display:grid;grid-template-columns:minmax(160px,1fr) repeat(3,minmax(110px,160px)) minmax(130px,180px) auto;gap:8px;padding:10px 14px;border-bottom:1px solid var(--line);background:var(--panel2)}
+.control{min-width:0;border:1px solid var(--line);background:var(--panel);border-radius:8px;padding:8px 10px}.check{display:flex;align-items:center;gap:7px;padding:0 8px;color:var(--muted);white-space:nowrap}
+.workspace{display:grid;grid-template-columns:minmax(260px,340px) minmax(0,1fr);min-height:0}.rail{border-right:1px solid var(--line);background:var(--panel);display:flex;flex-direction:column;min-height:0}
+.railhead{padding:13px;border-bottom:1px solid var(--line)}.seg{display:flex;gap:5px}.seg button{flex:1;border:1px solid var(--line);background:var(--panel2);padding:7px;border-radius:7px;color:var(--muted)}.seg button.active{background:color-mix(in srgb,var(--accent) 15%,var(--panel2));color:var(--accent);border-color:color-mix(in srgb,var(--accent) 40%,var(--line))}
+.threads{overflow:auto;padding:7px}.thread{width:100%;text-align:left;border:1px solid transparent;background:transparent;border-radius:10px;padding:11px;margin-bottom:5px}.thread:hover{background:var(--panel2)}.thread.active{background:var(--panel2);border-color:var(--line);box-shadow:var(--shadow)}
+.threadtop{display:flex;align-items:center;gap:8px}.workflow{font:600 12px/1.3 ui-monospace,SFMono-Regular,Menlo,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.badge{margin-left:auto;min-width:22px;text-align:center;padding:2px 6px;border-radius:99px;background:color-mix(in srgb,var(--loud) 18%,transparent);color:var(--loud);font-size:11px;font-weight:750}.threadmeta{margin-top:5px;color:var(--faint);font-size:11px;display:flex;justify-content:space-between;gap:8px}
+.conversation{min-width:0;display:flex;flex-direction:column;background:var(--bg)}.conversation-head{height:58px;flex:none;display:flex;align-items:center;gap:10px;padding:0 20px;border-bottom:1px solid var(--line);background:color-mix(in srgb,var(--panel) 88%,transparent)}.conversation-head h1{font-size:15px;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.conversation-head small{color:var(--muted)}
+.messages{overflow:auto;padding:22px max(20px,6vw) 40px;scroll-behavior:smooth}.message{max-width:760px;margin:0 0 18px}.message.reply{margin-left:auto}.message.system{max-width:900px;margin:16px auto;text-align:center;color:var(--faint);font-size:12px}.systemline{display:inline-flex;gap:8px;align-items:center;padding:6px 12px;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+.bubble{border:1px solid var(--line);border-radius:14px 14px 14px 4px;background:var(--bubble);padding:12px 14px;box-shadow:var(--shadow)}.reply .bubble{background:var(--reply);border-radius:14px 14px 4px 14px}.message.open .bubble{border-left:4px solid var(--loud)}
+.meta{display:flex;align-items:center;gap:7px;margin-bottom:7px;color:var(--muted);font-size:11px}.role{color:var(--text);font-weight:700}.arrow{color:var(--faint)}.chip{padding:2px 6px;border:1px solid var(--line);border-radius:99px;color:var(--accent);text-transform:uppercase;font-size:9px;letter-spacing:.08em}.note{margin-left:auto;color:var(--faint);text-decoration:none;font:10px ui-monospace,SFMono-Regular,Menlo,monospace}
+.body{white-space:pre-wrap;overflow-wrap:anywhere;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:5;overflow:hidden}.body.expanded{-webkit-line-clamp:unset;display:block}.expand{display:none;margin-top:8px;border:0;background:none;padding:0;color:var(--accent);font-size:11px}.footer{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px;padding-top:9px;border-top:1px solid var(--line);color:var(--faint);font-size:11px}.footer.open{color:var(--loud);font-weight:650}.footer a{color:inherit}
+.state{margin:auto;max-width:480px;padding:44px;text-align:center;color:var(--muted)}.state strong{display:block;color:var(--text);font-size:17px;margin-bottom:7px}.source-down strong{color:var(--loud)}
+footer{display:flex;align-items:center;justify-content:center;border-top:1px solid var(--line);background:var(--panel);color:var(--faint);font-size:11px}.pulse{width:7px;height:7px;border-radius:50%;background:var(--accent);margin-right:7px}
+.focus{animation:flash 1.8s ease}@keyframes flash{0%,100%{outline:0 solid transparent}30%{outline:4px solid color-mix(in srgb,var(--accent) 30%,transparent)}}
+@media(max-width:820px){.filters{grid-template-columns:1fr 1fr}.filters .search{grid-column:1/-1}.workspace{grid-template-columns:1fr}.rail{position:absolute;z-index:4;inset:117px 0 36px 0}.rail.thread-open{display:none}.conversation{display:none}.conversation.thread-open{display:flex}.conversation-head{padding:0 12px}.messages{padding:16px 12px 34px}.mobile-back{display:inline-flex!important}}
+@media(min-width:821px){.mobile-back{display:none!important}}
+@media(prefers-reduced-motion:reduce){.messages{scroll-behavior:auto}.focus{animation:none;outline:3px solid color-mix(in srgb,var(--accent) 35%,transparent)}}
+</style>
+</head>
+<body>
+<main class="shell">
+  <header>
+    <a class="brand" href="/"><span class="mark">g</span><span>gitmoot<span style="color:var(--accent)">.</span></span></a>
+    <span class="crumb">dashboard / <b>Comms</b></span><span class="spacer"></span>
+    <a class="navlink" href="/">Dashboard</a><a class="navlink active" href="/comms">Comms</a>
+    <button class="theme" id="theme" type="button" aria-label="Toggle light and dark theme">◐</button>
+  </header>
+  <section class="filters" aria-label="Comms filters">
+    <input class="control search" id="search" type="search" placeholder="Search workflows, roles, bodies…" aria-label="Search comms">
+    <select class="control" id="from"><option value="">From: anyone</option></select>
+    <select class="control" id="to"><option value="">To: anyone</option></select>
+    <select class="control" id="resolution"><option value="">Any resolution</option><option value="open">Unresolved</option><option value="resolved">Resolved</option></select>
+    <input class="control" id="date" type="date" aria-label="From date">
+    <label class="check"><input id="systems" type="checkbox" checked> Engine markers</label>
+  </section>
+  <section class="workspace">
+    <aside class="rail" id="rail">
+      <div class="railhead"><div class="seg"><button id="open" type="button">Open</button><button id="all" class="active" type="button">All</button></div></div>
+      <div class="threads" id="threads"><div class="state"><strong>Loading comms</strong>Reading workflow notes…</div></div>
+    </aside>
+    <section class="conversation" id="conversation">
+      <div class="conversation-head" id="conversation-head"><button class="navlink mobile-back" id="back" type="button">← Threads</button><div><h1>Comms</h1><small>Select a workflow thread</small></div></div>
+      <div class="messages" id="messages"><div class="state"><strong>No thread selected</strong>Choose a workflow from the thread rail.</div></div>
+    </section>
+  </section>
+  <footer><span class="pulse"></span>Read-only org traffic · resolve escalations with <code style="margin-left:4px">gitmoot org escalate resolve</code></footer>
+</main>
+<script>
+(()=>{
+  const $=id=>document.getElementById(id), state={data:[],selected:'',mode:'all',deep:'',error:false};
+  const esc=v=>String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  const when=v=>{const d=new Date(v);return isNaN(d)?v:d.toLocaleString([], {dateStyle:'medium',timeStyle:'short'})};
+  const age=v=>{const ms=Math.max(0,Date.now()-new Date(v).getTime()),m=Math.floor(ms/60000);if(m<60)return m+'m open';const h=Math.floor(m/60);if(h<48)return h+'h open';return Math.floor(h/24)+'d open'};
+  const latest=t=>t.updated_at?when(t.updated_at):'no timestamp';
+  const matchesMessage=(m,q,from,to,res,date,systems)=>{
+    if(m.kind==='system'&&!systems)return false;
+    if(from&&m.from!==from)return false;if(to&&m.to!==to)return false;
+    if(res==='open'&&(m.kind!=='escalation'||m.resolution))return false;
+    if(res==='resolved'&&(m.kind!=='escalation'||!m.resolution))return false;
+    if(date&&String(m.created_at).slice(0,10)<date)return false;
+    return !q||[m.body,m.from,m.to,String(m.id)].join(' ').toLowerCase().includes(q);
+  };
+  const visible=()=>{
+    const q=$('search').value.trim().toLowerCase(),from=$('from').value,to=$('to').value,res=$('resolution').value,date=$('date').value,systems=$('systems').checked;
+    return state.data.map(t=>({...t,_messages:t.messages.filter(m=>matchesMessage(m,q,from,to,res,date,systems))}))
+      .filter(t=>(state.mode==='all'||t.unresolved>0)&&(!q||t.workflow_id.toLowerCase().includes(q)||t._messages.length)&&t._messages.length);
+  };
+  const stateBox=(title,copy,cls='')=>'<div class="state '+cls+'" role="status"><strong>'+esc(title)+'</strong>'+esc(copy)+'</div>';
+  const renderThreads=()=>{
+    if(state.error){$('threads').innerHTML=stateBox('Comms source unavailable','The workflow-note store could not be read. Retry after the dashboard source recovers.','source-down');return;}
+    const list=visible();
+    if(!list.length){$('threads').innerHTML=stateBox('No matching comms','No workflow threads match the current filters.');$('messages').innerHTML=stateBox('No matching conversation','Change the filters or switch from Open to All.');return;}
+    $('threads').innerHTML=list.map(t=>'<button class="thread '+(t.workflow_id===state.selected?'active':'')+'" data-thread="'+esc(t.workflow_id)+'"><span class="threadtop"><span class="workflow">'+esc(t.workflow_id)+'</span>'+(t.unresolved?'<span class="badge" title="Unresolved escalations">'+t.unresolved+'</span>':'')+'</span><span class="threadmeta"><span>'+esc(t.repo||'workflow notes')+'</span><span>'+esc(latest(t))+'</span></span></button>').join('');
+    document.querySelectorAll('[data-thread]').forEach(el=>el.onclick=()=>select(el.dataset.thread));
+    if(!state.selected||!list.some(t=>t.workflow_id===state.selected))select(list[0].workflow_id,false);else renderConversation();
+  };
+  const messageHTML=m=>{
+    if(m.kind==='system')return '<div class="message system" id="note-'+m.id+'"><div class="systemline"><span>'+esc(m.body)+'</span><a class="note" href="?note='+m.id+'#note-'+m.id+'">#'+m.id+'</a><span>'+esc(when(m.created_at))+'</span></div></div>';
+    const open=m.kind==='escalation'&&!m.resolution,reply=m.kind==='reply';
+    let foot='';
+    if(open)foot='<div class="footer open">● Unresolved · '+esc(age(m.created_at))+'</div>';
+    if(m.resolution)foot='<div class="footer" id="note-'+m.resolution.note_id+'">Resolved by <b>'+esc(m.resolution.by)+'</b> · '+esc(when(m.resolution.created_at))+' <a href="?note='+m.resolution.note_id+'#note-'+m.resolution.note_id+'">marker #'+m.resolution.note_id+'</a></div>';
+    return '<article class="message '+(reply?'reply ':'')+(open?'open':'')+'" id="note-'+m.id+'"><div class="bubble"><div class="meta"><span class="role">'+esc(m.from||'unknown')+'</span><span class="arrow">→</span><span class="role">'+esc(m.to||'unknown')+'</span><span class="chip">'+esc(m.kind)+'</span><span>'+esc(when(m.created_at))+'</span><a class="note" href="?note='+m.id+'#note-'+m.id+'">#'+m.id+'</a></div><div class="body">'+esc(m.body)+'</div><button class="expand" type="button">Expand</button>'+foot+'</div></article>';
+  };
+  const renderConversation=()=>{
+    const t=visible().find(x=>x.workflow_id===state.selected)||state.data.find(x=>x.workflow_id===state.selected);
+    if(!t)return;
+    $('conversation-head').innerHTML='<button class="navlink mobile-back" id="back" type="button">← Threads</button><div><h1>'+esc(t.workflow_id)+'</h1><small>'+(t.unresolved?t.unresolved+' unresolved escalation'+(t.unresolved===1?'':'s'):'All escalations resolved')+(t.repo?' · '+esc(t.repo):'')+'</small></div>';
+    $('back').onclick=()=>{$('rail').classList.remove('thread-open');$('conversation').classList.remove('thread-open')};
+    const msgs=t._messages||t.messages;
+    $('messages').innerHTML=msgs.length?msgs.map(messageHTML).join(''):stateBox('No matching conversation','This workflow has traffic, but none matches the active filters.');
+    document.querySelectorAll('.body').forEach(body=>{const btn=body.nextElementSibling;if(body.scrollHeight>body.clientHeight+2){btn.style.display='inline-block';btn.onclick=()=>{body.classList.toggle('expanded');btn.textContent=body.classList.contains('expanded')?'Collapse':'Expand'}}});
+    if(state.deep){requestAnimationFrame(()=>{const node=$('note-'+state.deep);if(node){node.scrollIntoView({block:'center'});node.classList.add('focus');setTimeout(()=>node.classList.remove('focus'),1900)}state.deep=''})}
+  };
+  const select=(id,push=true)=>{state.selected=id;$('rail').classList.add('thread-open');$('conversation').classList.add('thread-open');if(push){const u=new URL(location.href);u.searchParams.set('workflow',id);u.searchParams.delete('note');history.replaceState({},'',u)}renderThreads()};
+  const roleOptions=()=>{
+    const roles=new Set();state.data.forEach(t=>t.messages.forEach(m=>{if(m.from)roles.add(m.from);if(m.to)roles.add(m.to)}));
+    [...roles].sort().forEach(role=>{$('from').insertAdjacentHTML('beforeend','<option>'+esc(role)+'</option>');$('to').insertAdjacentHTML('beforeend','<option>'+esc(role)+'</option>')});
+  };
+  ['search','from','to','resolution','date','systems'].forEach(id=>$(id).addEventListener(id==='search'?'input':'change',renderThreads));
+  $('open').onclick=()=>{state.mode='open';$('open').classList.add('active');$('all').classList.remove('active');renderThreads()};
+  $('all').onclick=()=>{state.mode='all';$('all').classList.add('active');$('open').classList.remove('active');renderThreads()};
+  const saved=localStorage.getItem('gitmoot-comms-theme'),preferred=matchMedia('(prefers-color-scheme: light)').matches?'light':'dark';
+  document.documentElement.dataset.theme=saved||preferred;
+  $('theme').onclick=()=>{const next=document.documentElement.dataset.theme==='dark'?'light':'dark';document.documentElement.dataset.theme=next;localStorage.setItem('gitmoot-comms-theme',next)};
+  fetch('/api/comms',{cache:'no-store'}).then(async r=>{if(!r.ok)throw new Error(await r.text());return r.json()}).then(data=>{
+    state.data=Array.isArray(data.threads)?data.threads:[];roleOptions();
+    const p=new URLSearchParams(location.search),note=p.get('note')||(location.hash.match(/^#note-(\d+)$/)||[])[1],wanted=p.get('workflow');
+    if(note){state.deep=String(note);const found=state.data.find(t=>t.messages.some(m=>String(m.id)===state.deep||(m.resolution&&String(m.resolution.note_id)===state.deep)));if(found)state.selected=found.workflow_id}
+    if(!state.selected&&wanted&&state.data.some(t=>t.workflow_id===wanted))state.selected=wanted;
+    if(!state.data.length){$('threads').innerHTML=stateBox('No org traffic yet','Typed escalations and engine markers will appear here when workflow notes are written.');$('messages').innerHTML=stateBox('Conversation is empty','There are no Comms threads to display.');return}
+    renderThreads();
+  }).catch(()=>{state.error=true;renderThreads();$('messages').innerHTML=stateBox('Comms source unavailable','The workflow-note store could not be read.','source-down')});
+})();
+</script>
+</body>
+</html>`

--- a/internal/cli/dashboard_web_comms_test.go
+++ b/internal/cli/dashboard_web_comms_test.go
@@ -2,15 +2,20 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -26,7 +31,6 @@ type dashboardCommsSeed struct {
 func seedDashboardComms(t *testing.T, home string) dashboardCommsSeed {
 	t.Helper()
 	store := openCLIJobStore(t, home)
-	defer store.Close()
 	ctx := context.Background()
 	insert := func(note db.WorkflowNote) db.WorkflowNote {
 		t.Helper()
@@ -57,9 +61,135 @@ func seedDashboardComms(t *testing.T, home string) dashboardCommsSeed {
 		WorkflowID: "release/resolved", Author: "owner", Repo: "gitmoot/gitmoot",
 		Body: workflow.FormatOrgEscalateResolvedNote(resolved.ID, "owner", answer.ID),
 	})
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	base := time.Date(2026, 7, 31, 4, 0, 0, 0, time.UTC)
+	for _, update := range []struct {
+		id int64
+		at time.Time
+	}{
+		{id: open.ID, at: base.Add(-4 * time.Hour)},
+		{id: system.ID, at: base.Add(-3 * time.Hour)},
+		{id: resolved.ID, at: base.Add(-2 * time.Hour)},
+		{id: answer.ID, at: base.Add(-time.Hour)},
+		{id: resolution.ID, at: base},
+	} {
+		if _, err := raw.ExecContext(ctx, `UPDATE workflow_notes SET created_at = ? WHERE id = ?`,
+			update.at.Format("2006-01-02 15:04:05"), update.id); err != nil {
+			t.Fatal(err)
+		}
+	}
 	return dashboardCommsSeed{
 		openEscalationID: open.ID, systemID: system.ID, resolvedEscalationID: resolved.ID,
 		answerID: answer.ID, resolutionID: resolution.ID,
+	}
+}
+
+func TestDashboardCommsEndpointDiscoversEveryWorkflow(t *testing.T) {
+	home := dashboardTestHome(t)
+	store := openCLIJobStore(t, home)
+	ctx := context.Background()
+	old, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "target/old-unresolved", Author: "review", Repo: "gitmoot/gitmoot",
+		Body: workflow.FormatOrgEscalateNote("review", "owner", "target/old-unresolved", "Do not lose this obligation."),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 200; i++ {
+		workflowID := fmt.Sprintf("newer/%03d", i)
+		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: workflowID, Author: "review", Repo: "gitmoot/gitmoot",
+			Body: workflow.FormatOrgEscalateNote("review", "owner", workflowID, "Newer traffic."),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := httptest.NewRecorder()
+	newDashboardWebHandler(&webDataSource{home: home}).ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/api/comms", nil),
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /api/comms status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	var payload dashboardCommsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	for _, thread := range payload.Threads {
+		if thread.WorkflowID == "target/old-unresolved" {
+			if thread.Unresolved != 1 || len(thread.Messages) != 1 || thread.Messages[0].ID != old.ID {
+				t.Fatalf("old unresolved thread=%+v, want complete obligation", thread)
+			}
+			return
+		}
+	}
+	t.Fatalf("old unresolved workflow missing from %d projected threads", len(payload.Threads))
+}
+
+func TestDashboardCommsEndpointDeepLinkOlderThanOrdinaryWindow(t *testing.T) {
+	home := dashboardTestHome(t)
+	store := openCLIJobStore(t, home)
+	ctx := context.Background()
+	target, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/noisy", Author: db.WorkflowAutoNoteAuthor, Repo: "gitmoot/gitmoot",
+		Body: "[auto:pr:1:opened] oldest target marker",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < dashboardCommsMessagesPerThread; i++ {
+		if _, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: "release/noisy", Author: db.WorkflowAutoNoteAuthor, Repo: "gitmoot/gitmoot",
+			Body: fmt.Sprintf("[auto:pr:%d:ready] newer marker", i+2),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	request := func(path string) dashboardCommsResponse {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		newDashboardWebHandler(&webDataSource{home: home}).ServeHTTP(
+			recorder, httptest.NewRequest(http.MethodGet, path, nil),
+		)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("GET %s status=%d body=%s", path, recorder.Code, recorder.Body.String())
+		}
+		var payload dashboardCommsResponse
+		if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+			t.Fatal(err)
+		}
+		return payload
+	}
+	hasTarget := func(payload dashboardCommsResponse) bool {
+		for _, thread := range payload.Threads {
+			for _, message := range thread.Messages {
+				if message.ID == target.ID {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	if hasTarget(request("/api/comms")) {
+		t.Fatal("ordinary per-thread window unexpectedly contains oldest target note")
+	}
+	if !hasTarget(request(fmt.Sprintf("/api/comms?note=%d", target.ID))) {
+		t.Fatalf("note deep link did not force-include old target note %d", target.ID)
 	}
 }
 
@@ -158,40 +288,149 @@ func TestDashboardCommsPageContract(t *testing.T) {
 		recorder, httptest.NewRequest(http.MethodGet, "/comms?note=42#note-42", nil),
 	)
 	body := recorder.Body.String()
-	for _, test := range []struct {
-		name string
-		want string
-	}{
-		{name: "thread rail open filter", want: `id="open"`},
-		{name: "thread rail all filter", want: `id="all"`},
-		{name: "search", want: `id="search"`},
-		{name: "from filter", want: `id="from"`},
-		{name: "to filter", want: `id="to"`},
-		{name: "resolution filter", want: `id="resolution"`},
-		{name: "date filter", want: `id="date"`},
-		{name: "engine toggle", want: `id="systems"`},
-		{name: "expand toggle", want: `class="expand"`},
-		{name: "deep link anchor", want: `id="note-`},
-		{name: "resolution footer", want: `Resolved by`},
-		{name: "open duration", want: `m open`},
-		{name: "source down state", want: `Comms source unavailable`},
-		{name: "empty filter state", want: `No matching comms`},
-		{name: "dark theme", want: `data-theme="dark"`},
-		{name: "light theme", want: `[data-theme="light"]`},
-		{name: "no external assets", want: `<script>`},
-		{name: "read only footer", want: `gitmoot org escalate resolve`},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			if !strings.Contains(body, test.want) {
-				t.Fatalf("Comms page missing %q (%s)", test.want, test.name)
-			}
-		})
+	start := strings.Index(body, "<script>")
+	end := strings.LastIndex(body, "</script>")
+	if start < 0 || end <= start {
+		t.Fatal("Comms page has no executable inline script")
 	}
-	for _, forbidden := range []string{"https://", "http://", "<link rel=\"stylesheet\"", "cdn"} {
-		t.Run("forbids "+fmt.Sprintf("%q", forbidden), func(t *testing.T) {
-			if strings.Contains(body, forbidden) {
-				t.Fatalf("Comms page contains forbidden external asset marker %q", forbidden)
-			}
-		})
+	script := body[start+len("<script>") : end]
+	input, err := json.Marshal(map[string]any{
+		"script": script,
+		"threads": []dashboardCommsThread{
+			{
+				WorkflowID: "release/alpha", UpdatedAt: "2026-07-31T01:00:00Z", Unresolved: 1,
+				Messages: []dashboardCommsMessage{{
+					ID: 42, Kind: "escalation", From: "review", To: "owner",
+					Body: "alpha needle with enough body text to require expansion", CreatedAt: "2026-07-31T01:00:00Z",
+				}},
+			},
+			{
+				WorkflowID: "release/beta", UpdatedAt: "2026-07-31T02:00:00Z",
+				Messages: []dashboardCommsMessage{{
+					ID: 84, Kind: "reply", From: "owner", To: "review",
+					Body: "beta needle with enough body text to require expansion", CreatedAt: "2026-07-31T02:00:00Z",
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command := exec.Command("node", "-e", dashboardCommsPageHarness)
+	command.Stdin = strings.NewReader(string(input))
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("executable Comms page contract failed: %v\n%s", err, output)
+	}
+
+	assetRef := regexp.MustCompile(`(?i)(?:src|href)\s*=\s*["']([^"']+)["']`)
+	for _, match := range assetRef.FindAllStringSubmatch(body, -1) {
+		ref := strings.TrimSpace(match[1])
+		if strings.HasPrefix(ref, "//") || regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.-]*:`).MatchString(ref) {
+			t.Fatalf("Comms page contains external asset reference %q", ref)
+		}
 	}
 }
+
+const dashboardCommsPageHarness = `
+const fs = require('fs');
+const vm = require('vm');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+const fail = message => { throw new Error(message); };
+class ClassList {
+  constructor(){ this.values = new Set(); }
+  add(...names){ names.forEach(name => this.values.add(name)); }
+  remove(...names){ names.forEach(name => this.values.delete(name)); }
+  contains(name){ return this.values.has(name); }
+  toggle(name){ if(this.values.has(name)){this.values.delete(name);return false;}this.values.add(name);return true; }
+}
+const elements = new Map(), threadButtons = [];
+let bodies = [], fetched = '';
+class Element {
+  constructor(id=''){
+    this.id=id;this.value='';this.checked=id==='systems';this.dataset={};this.style={};
+    this.classList=new ClassList();this.listeners={};this._innerHTML='';this.textContent='';
+    this.scrollHeight=100;this.clientHeight=10;this.scrolled=0;this.nextElementSibling=null;
+  }
+  addEventListener(kind, fn){this.listeners[kind]=fn;}
+  dispatch(kind){if(!this.listeners[kind])fail(this.id+' has no '+kind+' listener');this.listeners[kind]();}
+  insertAdjacentHTML(_where, html){this._innerHTML+=html;}
+  scrollIntoView(){this.scrolled++;}
+  set innerHTML(html){
+    this._innerHTML=html;
+    if(this.id==='threads'){
+      threadButtons.length=0;
+      for(const match of html.matchAll(/data-thread="([^"]+)"/g)){
+        const button=new Element();button.dataset.thread=match[1];threadButtons.push(button);
+      }
+    }
+    if(this.id==='messages'){
+      bodies=[];
+      for(const match of html.matchAll(/id="note-(\d+)"/g)){
+        const note=new Element('note-'+match[1]);elements.set(note.id,note);
+      }
+      for(const _match of html.matchAll(/class="body"/g)){
+        const body=new Element(), button=new Element();body.nextElementSibling=button;bodies.push(body);
+      }
+    }
+  }
+  get innerHTML(){return this._innerHTML;}
+}
+for(const id of ['search','from','to','resolution','date','systems','threads','messages','conversation-head','back','rail','conversation','open','all','theme']){
+  elements.set(id,new Element(id));
+}
+elements.get('all').classList.add('active');
+const documentElement={dataset:{theme:'dark'}};
+global.document={
+  documentElement,
+  getElementById:id=>elements.get(id)||null,
+  querySelectorAll:selector=>selector==='[data-thread]'?threadButtons:selector==='.body'?bodies:[],
+};
+const saved=new Map();
+global.localStorage={getItem:key=>saved.get(key)||null,setItem:(key,value)=>saved.set(key,value)};
+global.matchMedia=()=>({matches:false});
+global.location={
+  origin:'http://localhost',href:'http://localhost/comms?note=42#note-42',
+  search:'?note=42',hash:'#note-42',
+};
+global.history={replaceState(){}};
+global.requestAnimationFrame=fn=>fn();
+global.setTimeout=fn=>{fn();return 0;};
+global.fetch=(url, options)=>{
+  fetched=String(url);
+  if(!options||options.cache!=='no-store')fail('fetch must disable caching');
+  return Promise.resolve({ok:true,json:()=>Promise.resolve({threads:input.threads})});
+};
+vm.runInThisContext(input.script,{filename:'dashboard-comms-inline.js'});
+setImmediate(()=>{
+  try{
+    if(fetched!=='/api/comms?note=42')fail('deep-link note was not passed to API: '+fetched);
+    const target=elements.get('note-42');
+    if(!target||target.scrolled!==1)fail('deep-linked note was not scrolled into view');
+
+    elements.get('all').onclick();
+    elements.get('search').value='beta needle';
+    elements.get('search').dispatch('input');
+    if(!elements.get('threads').innerHTML.includes('release/beta')||elements.get('threads').innerHTML.includes('release/alpha')){
+      fail('search filter did not execute');
+    }
+
+    const body=bodies[0], expand=body&&body.nextElementSibling;
+    if(!expand||typeof expand.onclick!=='function')fail('overflowing message has no expand behavior');
+    expand.onclick();
+    if(!body.classList.contains('expanded')||expand.textContent!=='Collapse')fail('expand toggle did not execute');
+
+    elements.get('search').value='';
+    elements.get('search').dispatch('input');
+    elements.get('open').onclick();
+    if(!elements.get('threads').innerHTML.includes('release/alpha')||elements.get('threads').innerHTML.includes('release/beta')){
+      fail('open-thread filter did not execute');
+    }
+
+    elements.get('theme').onclick();
+    if(documentElement.dataset.theme!=='light'||saved.get('gitmoot-comms-theme')!=='light'){
+      fail('theme switch did not execute');
+    }
+    process.stdout.write('ok\n');
+  }catch(error){console.error(error.stack||error);process.exitCode=1;}
+});
+`

--- a/internal/cli/dashboard_web_comms_test.go
+++ b/internal/cli/dashboard_web_comms_test.go
@@ -1,0 +1,197 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+type dashboardCommsSeed struct {
+	openEscalationID     int64
+	systemID             int64
+	resolvedEscalationID int64
+	answerID             int64
+	resolutionID         int64
+}
+
+func seedDashboardComms(t *testing.T, home string) dashboardCommsSeed {
+	t.Helper()
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	ctx := context.Background()
+	insert := func(note db.WorkflowNote) db.WorkflowNote {
+		t.Helper()
+		got, err := store.InsertWorkflowNote(ctx, note)
+		if err != nil {
+			t.Fatalf("InsertWorkflowNote(%q): %v", note.Body, err)
+		}
+		return got
+	}
+
+	open := insert(db.WorkflowNote{
+		WorkflowID: "release/open", Author: "operator", Repo: "gitmoot/gitmoot",
+		Body: workflow.FormatOrgEscalateNote("operator", "owner", "release/open", "Can we ship the candidate?"),
+	})
+	system := insert(db.WorkflowNote{
+		WorkflowID: "release/open", Author: db.WorkflowAutoNoteAuthor, Repo: "gitmoot/gitmoot",
+		Body: "[auto:pr:1294:ready] PR #1294 checks green",
+	})
+	resolved := insert(db.WorkflowNote{
+		WorkflowID: "release/resolved", Author: "review", Repo: "gitmoot/gitmoot",
+		Body: workflow.FormatOrgEscalateNote("review", "owner", "release/resolved", "Which rollout window?"),
+	})
+	answer := insert(db.WorkflowNote{
+		WorkflowID: "release/resolved", Author: "owner", Repo: "gitmoot/gitmoot",
+		Body: "Use the first quiet window after the gate.",
+	})
+	resolution := insert(db.WorkflowNote{
+		WorkflowID: "release/resolved", Author: "owner", Repo: "gitmoot/gitmoot",
+		Body: workflow.FormatOrgEscalateResolvedNote(resolved.ID, "owner", answer.ID),
+	})
+	return dashboardCommsSeed{
+		openEscalationID: open.ID, systemID: system.ID, resolvedEscalationID: resolved.ID,
+		answerID: answer.ID, resolutionID: resolution.ID,
+	}
+}
+
+func TestDashboardCommsEndpointProjectsThreads(t *testing.T) {
+	home := dashboardTestHome(t)
+	seed := seedDashboardComms(t, home)
+	handler := newDashboardWebHandler(&webDataSource{home: home})
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/comms", nil))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /api/comms status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q, want application/json", got)
+	}
+
+	var payload dashboardCommsResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode /api/comms: %v\n%s", err, recorder.Body.String())
+	}
+	if len(payload.Threads) != 2 {
+		t.Fatalf("threads=%+v, want open and resolved workflows", payload.Threads)
+	}
+	if payload.Threads[0].WorkflowID != "release/open" || payload.Threads[0].Unresolved != 1 {
+		t.Fatalf("first thread=%+v, want unresolved release/open floated first", payload.Threads[0])
+	}
+
+	byWorkflow := map[string]dashboardCommsThread{}
+	for _, thread := range payload.Threads {
+		byWorkflow[thread.WorkflowID] = thread
+	}
+	open := byWorkflow["release/open"]
+	if len(open.Messages) != 2 ||
+		open.Messages[0].ID != seed.openEscalationID || open.Messages[0].Kind != "escalation" ||
+		open.Messages[0].From != "operator" || open.Messages[0].To != "owner" ||
+		open.Messages[1].ID != seed.systemID || open.Messages[1].Kind != "system" {
+		t.Fatalf("open messages=%+v, want escalation bubble plus system line", open.Messages)
+	}
+	resolved := byWorkflow["release/resolved"]
+	if resolved.Unresolved != 0 || len(resolved.Messages) != 2 {
+		t.Fatalf("resolved thread=%+v, want two bubbles and no unresolved badge", resolved)
+	}
+	escalation := resolved.Messages[0]
+	if escalation.ID != seed.resolvedEscalationID || escalation.Resolution == nil ||
+		escalation.Resolution.NoteID != seed.resolutionID ||
+		escalation.Resolution.AnswerNoteID != seed.answerID ||
+		escalation.Resolution.By != "owner" {
+		t.Fatalf("resolved escalation=%+v, want folded resolution marker", escalation)
+	}
+	reply := resolved.Messages[1]
+	if reply.ID != seed.answerID || reply.Kind != "reply" || reply.From != "owner" ||
+		reply.To != "review" || reply.Body != "Use the first quiet window after the gate." {
+		t.Fatalf("reply=%+v, want linked answer note projected as owner-to-review bubble", reply)
+	}
+	for _, message := range resolved.Messages {
+		if message.ID == seed.resolutionID {
+			t.Fatalf("resolution marker leaked as a bubble: %+v", resolved.Messages)
+		}
+	}
+}
+
+func TestDashboardCommsHTTPStates(t *testing.T) {
+	emptyHome := dashboardTestHome(t)
+	badHome := filepath.Join(t.TempDir(), "home-is-a-file")
+	if err := os.WriteFile(badHome, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name       string
+		home       string
+		path       string
+		wantStatus int
+		want       string
+	}{
+		{name: "empty endpoint is an explicit empty array", home: emptyHome, path: "/api/comms", wantStatus: http.StatusOK, want: `"threads":[]`},
+		{name: "source down is service unavailable", home: badHome, path: "/api/comms", wantStatus: http.StatusServiceUnavailable, want: "comms source unavailable"},
+		{name: "page route is self contained", home: emptyHome, path: "/comms", wantStatus: http.StatusOK, want: "Read-only org traffic"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			newDashboardWebHandler(&webDataSource{home: test.home}).ServeHTTP(
+				recorder, httptest.NewRequest(http.MethodGet, test.path, nil),
+			)
+			if recorder.Code != test.wantStatus || !strings.Contains(recorder.Body.String(), test.want) {
+				t.Fatalf("GET %s status=%d body=%q, want status=%d containing %q",
+					test.path, recorder.Code, recorder.Body.String(), test.wantStatus, test.want)
+			}
+		})
+	}
+}
+
+func TestDashboardCommsPageContract(t *testing.T) {
+	home := dashboardTestHome(t)
+	recorder := httptest.NewRecorder()
+	newDashboardWebHandler(&webDataSource{home: home}).ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/comms?note=42#note-42", nil),
+	)
+	body := recorder.Body.String()
+	for _, test := range []struct {
+		name string
+		want string
+	}{
+		{name: "thread rail open filter", want: `id="open"`},
+		{name: "thread rail all filter", want: `id="all"`},
+		{name: "search", want: `id="search"`},
+		{name: "from filter", want: `id="from"`},
+		{name: "to filter", want: `id="to"`},
+		{name: "resolution filter", want: `id="resolution"`},
+		{name: "date filter", want: `id="date"`},
+		{name: "engine toggle", want: `id="systems"`},
+		{name: "expand toggle", want: `class="expand"`},
+		{name: "deep link anchor", want: `id="note-`},
+		{name: "resolution footer", want: `Resolved by`},
+		{name: "open duration", want: `m open`},
+		{name: "source down state", want: `Comms source unavailable`},
+		{name: "empty filter state", want: `No matching comms`},
+		{name: "dark theme", want: `data-theme="dark"`},
+		{name: "light theme", want: `[data-theme="light"]`},
+		{name: "no external assets", want: `<script>`},
+		{name: "read only footer", want: `gitmoot org escalate resolve`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if !strings.Contains(body, test.want) {
+				t.Fatalf("Comms page missing %q (%s)", test.want, test.name)
+			}
+		})
+	}
+	for _, forbidden := range []string{"https://", "http://", "<link rel=\"stylesheet\"", "cdn"} {
+		t.Run("forbids "+fmt.Sprintf("%q", forbidden), func(t *testing.T) {
+			if strings.Contains(body, forbidden) {
+				t.Fatalf("Comms page contains forbidden external asset marker %q", forbidden)
+			}
+		})
+	}
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -576,6 +576,12 @@ until interrupted; `--addr` sets the listen address (default
 `127.0.0.1:8080`). Use it when the user wants a browser view of a running
 orchestration.
 
+The web dashboard's `/comms` route is a read-only operator inbox for typed org
+escalations and workflow engine markers. Org-note bodies are operator-visible
+on this page. Open escalations float above resolved traffic, and `?note=<id>`
+deep-links to the note's workflow conversation. The page never resolves an
+escalation itself; use `gitmoot org escalate resolve` from the CLI.
+
 In the one-shot styled output the dashboard leads with a "needs attention" block,
 colors and truncates long lists, and groups near-identical runtime sessions;
 `--all` shows everything. `--watch` redraws on an interval (default 5s) and cannot

--- a/website/docs/dashboard/overview.md
+++ b/website/docs/dashboard/overview.md
@@ -36,8 +36,9 @@ gitmoot dashboard serving read-only at http://127.0.0.1:8080 (Ctrl-C to stop)
 
 ## Routes
 
-The UI is a single-page app with client-side routing (the browser URL updates as
-you navigate, so every view is linkable and reloadable):
+The main UI is a single-page app with client-side routing (the browser URL
+updates as you navigate, so every view is linkable and reloadable). Comms is a
+self-contained read-only page served at its own route:
 
 | Route | View |
 | --- | --- |
@@ -51,12 +52,13 @@ you navigate, so every view is linkable and reloadable):
 | `/charts` | Charts — activity time series |
 | `/health` | Health — daemon status, totals, stuck jobs, locks, failures |
 | `/attention` | Needs a human — blocked gates, pending approvals, candidates |
+| `/comms` (or `/comms?note=<id>`) | Comms — org escalation conversations and engine markers |
 
 Unknown paths normalize back to `/`. Each view is backed by a small read-only
 JSON API (`/api/runs`, `/api/jobs`, `/api/agents`, `/api/agent/{name}`,
 `/api/charts`, `/api/health`, `/api/attention`, `/api/job/{id}/checks`,
-`/api/run/{id}/verdicts`, `/api/state`, `/api/job/{id}`, `/api/graph`) plus a
-Server-Sent Events stream at `/events`.
+`/api/run/{id}/verdicts`, `/api/state`, `/api/job/{id}`, `/api/graph`,
+`/api/comms`) plus a Server-Sent Events stream at `/events`.
 
 See [Dashboard Views](./views.md) for what each view shows.
 
@@ -88,8 +90,9 @@ unchanged.
 ## Security
 
 The dashboard serves **private data**: job prompts, agent outputs, template
-bodies, repo names and lock owners are all visible to anyone who can reach the
-port. There is **no authentication** built in.
+bodies, repo names, lock owners, and org-note bodies shown in Comms are all
+visible to anyone who can reach the port. There is **no authentication** built
+in.
 
 By default `--web` binds to `127.0.0.1:8080`, reachable only from the local
 machine — keep it that way for normal use. If you must expose it beyond

--- a/website/docs/dashboard/views.md
+++ b/website/docs/dashboard/views.md
@@ -1,6 +1,6 @@
 # Dashboard Views
 
-The web dashboard has fourteen views, reachable from the left nav rail (or the mobile
+The web dashboard has fifteen views, reachable from the left nav rail (or the mobile
 bottom tab bar). Each is described below with its screenshot. See
 [Dashboard Overview](./overview.md) for launching, routes, refresh cadences, and
 security.
@@ -365,6 +365,22 @@ compact human-action status to post into a thread. Two read-only endpoints expos
 them for bridge consumers: `GET /api/job/{id}/checks` (a job's failed result checks
 + policy mode) and `GET /api/run/{id}/verdicts` (a SkillOpt run's per-question
 binary verdicts with pass/fail counts).
+
+## Comms
+
+Route: `/comms` (or `/comms?note=<id>` to open a specific note)
+
+Comms is the read-only operator inbox for typed org escalations and workflow
+engine markers. It projects one conversation thread per workflow, keeps every
+unresolved obligation discoverable, and floats workflows with open escalations
+above resolved traffic. Search, role, resolution, date, and engine-marker
+filters narrow the conversations without mutating their source notes.
+
+Org-note bodies are operator-visible on this page. A note deep link selects its
+workflow, includes the requested note even when it is older than the ordinary
+per-thread payload window, and scrolls to the matching escalation, reply,
+resolution footer, or system marker. Comms is strictly read-only: resolve an
+escalation from the CLI with `gitmoot org escalate resolve`.
 
 ## Config
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6830,8 +6830,9 @@ gitmoot dashboard serving read-only at http://127.0.0.1:8080 (Ctrl-C to stop)
 
 ## Routes
 
-The UI is a single-page app with client-side routing (the browser URL updates as
-you navigate, so every view is linkable and reloadable):
+The main UI is a single-page app with client-side routing (the browser URL
+updates as you navigate, so every view is linkable and reloadable). Comms is a
+self-contained read-only page served at its own route:
 
 | Route | View |
 | --- | --- |
@@ -6845,12 +6846,13 @@ you navigate, so every view is linkable and reloadable):
 | `/charts` | Charts — activity time series |
 | `/health` | Health — daemon status, totals, stuck jobs, locks, failures |
 | `/attention` | Needs a human — blocked gates, pending approvals, candidates |
+| `/comms` (or `/comms?note=<id>`) | Comms — org escalation conversations and engine markers |
 
 Unknown paths normalize back to `/`. Each view is backed by a small read-only
 JSON API (`/api/runs`, `/api/jobs`, `/api/agents`, `/api/agent/{name}`,
 `/api/charts`, `/api/health`, `/api/attention`, `/api/job/{id}/checks`,
-`/api/run/{id}/verdicts`, `/api/state`, `/api/job/{id}`, `/api/graph`) plus a
-Server-Sent Events stream at `/events`.
+`/api/run/{id}/verdicts`, `/api/state`, `/api/job/{id}`, `/api/graph`,
+`/api/comms`) plus a Server-Sent Events stream at `/events`.
 
 See [Dashboard Views](./views.md) for what each view shows.
 
@@ -6861,6 +6863,10 @@ The dashboard stays live without a manual reload:
 - **Graph** — the runs column reloads every **15s**; the selected run's graph
   streams over **SSE** (`/events?run=<id>`), so nodes change state as the
   orchestra runs (running nodes pulse).
+- **Fleet activity** — Overview and Org share one server-side Herdr poller and
+  receive changed snapshots over **SSE** (`/api/fleet/activity/events`).
+  Session counts are independent from engine-job and escalation counts; a
+  healthy source with no sessions is labeled differently from a source outage.
 - **Galaxy, Jobs, Agents, Charts, Health** — each polls its data every **12s**
   while it is the active view (background views do not poll).
 - **Health** additionally re-renders its relative-time cells every second, so
@@ -6882,8 +6888,9 @@ unchanged.
 ## Security
 
 The dashboard serves **private data**: job prompts, agent outputs, template
-bodies, repo names and lock owners are all visible to anyone who can reach the
-port. There is **no authentication** built in.
+bodies, repo names, lock owners, and org-note bodies shown in Comms are all
+visible to anyone who can reach the port. There is **no authentication** built
+in.
 
 By default `--web` binds to `127.0.0.1:8080`, reachable only from the local
 machine — keep it that way for normal use. If you must expose it beyond
@@ -6898,7 +6905,7 @@ proxy or a private tunnel). The dashboard trusts every request it receives.
 
 # Dashboard Views
 
-The web dashboard has fourteen views, reachable from the left nav rail (or the mobile
+The web dashboard has fifteen views, reachable from the left nav rail (or the mobile
 bottom tab bar). Each is described below with its screenshot. See
 [Dashboard Overview](./overview.md) for launching, routes, refresh cadences, and
 security.
@@ -6911,6 +6918,11 @@ Overview is the operator-first landing page. It combines local Gitmoot state int
 five compact blocks without making GitHub requests or scanning job payloads on
 each refresh:
 
+- **Fleet activity strip** answers whether the host is busy even when session
+  work has no engine job: sessions working, live sessions, blocked/input-pending
+  sessions, running jobs, and unresolved escalations are counted separately.
+  It links each count to the relevant read-only view and labels Herdr-down and
+  healthy-with-no-sessions states rather than rendering either as zero silently.
 - **Needs you** collects stalled workflows, pull-request tasks awaiting merge,
   and blocked jobs. Stalled workflow cards include the coordinator pane,
   session id, and last journal note needed to resume in the right place.
@@ -6926,6 +6938,26 @@ each refresh:
 The page is read-only and polls every 12 seconds. Groom proposals appear only
 when Gitmoot has a cheap persisted proposal source; the server does not walk
 artifact directories during a dashboard request.
+
+## Org
+
+Route: `/org`
+
+Org preserves the role hierarchy as its primary tree canvas and decorates each
+fixed-height node with live Herdr session data: a shape-and-color status marker,
+the pane's stripped terminal title, and a tabular turn-age badge. Working,
+blocked, and input-pending states also use motion unless the browser requests
+reduced motion; edges inherit the child session state. Filtering dims unmatched
+nodes without replacing the tree, and a no-match filter explains why the canvas
+looks empty.
+
+Selecting a node opens the existing right-hand detail drawer while the tree
+remains visible. It shows the full task title, current turn and inferred age,
+last-completed turn and UTC time, agent/pane identity, role scope, and configured
+wake routes. Herdr currently lacks a current-turn start timestamp, so active-turn
+age is explicitly inferred from the preceding turn's completion. A role with no
+active agent session and an unavailable Herdr source are separate labeled
+states. Titles and statuses are shown, but transcript content is never exposed.
 
 ## Tasks
 
@@ -7263,6 +7295,22 @@ compact human-action status to post into a thread. Two read-only endpoints expos
 them for bridge consumers: `GET /api/job/{id}/checks` (a job's failed result checks
 + policy mode) and `GET /api/run/{id}/verdicts` (a SkillOpt run's per-question
 binary verdicts with pass/fail counts).
+
+## Comms
+
+Route: `/comms` (or `/comms?note=<id>` to open a specific note)
+
+Comms is the read-only operator inbox for typed org escalations and workflow
+engine markers. It projects one conversation thread per workflow, keeps every
+unresolved obligation discoverable, and floats workflows with open escalations
+above resolved traffic. Search, role, resolution, date, and engine-marker
+filters narrow the conversations without mutating their source notes.
+
+Org-note bodies are operator-visible on this page. A note deep link selects its
+workflow, includes the requested note even when it is older than the ordinary
+per-thread payload window, and scrolls to the matching escalation, reply,
+resolution footer, or system marker. Comms is strictly read-only: resolve an
+escalation from the CLI with `gitmoot org escalate resolve`.
 
 ## Config
 
@@ -9453,7 +9501,10 @@ status, `gitmoot daemon status` for daemon state, `gitmoot agent list` and
 or `gitmoot task list --repo owner/repo --json` for imported task state. Use
 `gitmoot job list --repo owner/repo` for jobs, and use
 `gitmoot dashboard --json` only when a structured full dashboard snapshot is
-needed. Do not use nonexistent commands such as `gitmoot status --json` or
+needed. The read-only web dashboard's Overview and Org pages distinguish live
+Herdr session activity from engine jobs and label a missing session differently
+from an unavailable Herdr source. Do not use nonexistent commands such as
+`gitmoot status --json` or
 `gitmoot task show`. Use `gitmoot org events rule add|list|set-scope|rm` to manage opt-in
 organization event wakes; add validates the event kind, target org role, and
 `addressed` (default) or `observer` scope. Use
@@ -10367,7 +10418,19 @@ gitmoot dashboard --web [--addr 127.0.0.1:8080]
 orchestration/delegation graph with run summaries and prompt/output inspection)
 until interrupted; `--addr` sets the listen address (default
 `127.0.0.1:8080`). Use it when the user wants a browser view of a running
-orchestration.
+orchestration. The Overview and Org pages also show the fleet activity strip:
+live Herdr sessions are counted separately from engine jobs and unresolved
+escalations. Org tree nodes retain the hierarchy while adding session status,
+terminal task title, turn age, and last-completed-turn detail. No session,
+Herdr unavailable, and an empty filter are distinct labeled states. One shared
+server-side poller feeds all viewers through `/api/fleet/activity/events`; the
+surface remains read-only and exposes no transcript content.
+
+The web dashboard's `/comms` route is a read-only operator inbox for typed org
+escalations and workflow engine markers. Org-note bodies are operator-visible
+on this page. Open escalations float above resolved traffic, and `?note=<id>`
+deep-links to the note's workflow conversation. The page never resolves an
+escalation itself; use `gitmoot org escalate resolve` from the CLI.
 
 In the one-shot styled output the dashboard leads with a "needs attention" block,
 colors and truncates long lists, and groups near-identical runtime sessions;

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -38,8 +38,8 @@ full expanded context.
 
 ## Dashboard
 
-- [Dashboard Overview](https://gitmoot.io/docs/dashboard/overview): The read-only live web dashboard (`gitmoot dashboard --web [--addr host:port]`) over the local store — launching, the URL route table, auto-refresh cadences (12s polls, 15s runs, SSE per-run graph), mobile support, and the localhost-default/no-auth security model.
-- [Dashboard Views](https://gitmoot.io/docs/dashboard/views): The six views — Graph (per-run delegation DAG), Galaxy (whole-history force graph), Jobs (filterable table, 400-row cap), Agents (cards + detail with template prompt, version history, and per-version diff), Charts (7d/30d/90d/all series), and Health (daemon status, stuck jobs with reasons, locks, recent failures, delegation-worktree count and size).
+- [Dashboard Overview](https://gitmoot.io/docs/dashboard/overview): The read-only live web dashboard (`gitmoot dashboard --web [--addr host:port]`) over the local store — launching, the URL route table including `/comms`, auto-refresh cadences (12s polls, 15s runs, SSE per-run graph), mobile support, operator-visible private data, and the localhost-default/no-auth security model.
+- [Dashboard Views](https://gitmoot.io/docs/dashboard/views): The fifteen views, including Graph, Galaxy, Jobs, Pipelines, Workflows, Brain, Agents, Charts, Health, Attention, and Comms — the read-only org escalation inbox with complete unresolved-workflow discovery, note deep links, filters, and CLI-only resolution via `gitmoot org escalate resolve`.
 
 ## References
 

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -38,13 +38,8 @@ full expanded context.
 
 ## Dashboard
 
-<<<<<<< HEAD
-- [Dashboard Overview](https://gitmoot.io/docs/dashboard/overview): The read-only live web dashboard (`gitmoot dashboard --web [--addr host:port]`) over the local store — launching, the URL route table including `/comms`, auto-refresh cadences (12s polls, 15s runs, SSE per-run graph), mobile support, operator-visible private data, and the localhost-default/no-auth security model.
-- [Dashboard Views](https://gitmoot.io/docs/dashboard/views): The fifteen views, including Graph, Galaxy, Jobs, Pipelines, Workflows, Brain, Agents, Charts, Health, Attention, and Comms — the read-only org escalation inbox with complete unresolved-workflow discovery, note deep links, filters, and CLI-only resolution via `gitmoot org escalate resolve`.
-=======
-- [Dashboard Overview](https://gitmoot.io/docs/dashboard/overview): The read-only live web dashboard (`gitmoot dashboard --web [--addr host:port]`) over the local store — launching, the URL route table, shared fleet-activity SSE, auto-refresh cadences, mobile support, and the localhost-default/no-auth security model.
-- [Dashboard Views](https://gitmoot.io/docs/dashboard/views): Overview and Org distinguish live Herdr sessions from engine jobs, decorate the preserved role tree with task/status/turn detail, and label no-session, source-down, and filter-empty states; the reference also covers Graph, Galaxy, Jobs, Agents, Charts, Health, and the other read-only views.
->>>>>>> origin/main
+- [Dashboard Overview](https://gitmoot.io/docs/dashboard/overview): The read-only live web dashboard (`gitmoot dashboard --web [--addr host:port]`) over the local store — launching, the URL route table including `/comms`, shared fleet-activity SSE, auto-refresh cadences (12s polls, 15s runs, SSE per-run graph), mobile support, operator-visible private data, and the localhost-default/no-auth security model.
+- [Dashboard Views](https://gitmoot.io/docs/dashboard/views): Overview and Org distinguish live Herdr sessions from engine jobs, decorate the preserved role tree with task/status/turn detail, and label no-session, source-down, and filter-empty states; Comms is the read-only org escalation inbox with complete unresolved-workflow discovery, note deep links, filters, and CLI-only resolution via `gitmoot org escalate resolve`; the reference also covers Graph, Galaxy, Jobs, Pipelines, Workflows, Brain, Agents, Charts, Health, and Attention.
 
 ## References
 


### PR DESCRIPTION
Salvaged-and-continued dashboard slice 2 (see #1294 and its JARVIS spec comment; predecessor job killed per #1308, work salvaged, continuation seat verified the salvage complete with zero delta — this PR delivers that verified state for adversarial review). Thread rail per workflow with unresolved badges; sender-attributed bubbles with note ids; resolutions as quiet footers; engine markers as system lines; filters + note-id deep links; loud emptiness; dark+light; read-only. Deploy note: the public dashboard runs its own binary copy — deploy touches both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)