### PR TITLE
Gitmoot: CAMPAIGN 1308 SLICE A — TERMINAL-WRITE INTEGRITY (from

### DIFF
--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -103,7 +104,12 @@ func (w jobWorker) finalizePreflightDelegationChild(ctx context.Context, jobID s
 	return nil
 }
 
-func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause error) error {
+type jobTimeoutEvidence struct {
+	Deadline time.Time
+	Started  time.Time
+}
+
+func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause error, timeoutEvidence ...jobTimeoutEvidence) error {
 	latest, err := w.Store.GetJob(ctx, jobID)
 	if err != nil {
 		return err
@@ -154,6 +160,27 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 		return err
 	}
 	payload, payloadErr := daemonJobPayload(latest)
+	if errors.Is(cause, context.DeadlineExceeded) || len(timeoutEvidence) > 0 {
+		evidence := jobTimeoutEvidence{}
+		if len(timeoutEvidence) > 0 {
+			evidence = timeoutEvidence[0]
+		}
+		finalized, finalizeErr := w.finalizeTimedOutJob(ctx, latest, payload, cause, evidence)
+		if finalizeErr != nil {
+			var awaiting workflow.AwaitingHumanError
+			if errors.As(finalizeErr, &awaiting) {
+				return nil
+			}
+			var blocked workflow.BlockedError
+			if errors.As(finalizeErr, &blocked) {
+				return nil
+			}
+			return finalizeErr
+		}
+		if finalized {
+			return nil
+		}
+	}
 	if payloadErr == nil && payload.Result != nil {
 		var awaiting workflow.AwaitingHumanError
 		if errors.As(cause, &awaiting) {
@@ -207,6 +234,32 @@ func (w jobWorker) handleRunJobError(ctx context.Context, jobID string, cause er
 		return nil
 	}
 	return cause
+}
+
+func (w jobWorker) finalizeTimedOutJob(ctx context.Context, job db.Job, payload workflow.JobPayload, cause error, evidence jobTimeoutEvidence) (bool, error) {
+	deadline := evidence.Deadline.UTC()
+	elapsed := time.Duration(0)
+	if !evidence.Started.IsZero() {
+		elapsed = time.Since(evidence.Started).Round(time.Millisecond)
+	}
+	stderrTail := ""
+	if payload.FailureDiagnostics != nil {
+		stderrTail = payload.FailureDiagnostics.StderrTail
+	}
+	detailBytes, _ := json.Marshal(struct {
+		Deadline   string `json:"deadline"`
+		Elapsed    string `json:"elapsed"`
+		StderrTail string `json:"stderr_tail,omitempty"`
+	}{
+		Deadline:   deadline.Format(time.RFC3339Nano),
+		Elapsed:    elapsed.String(),
+		StderrTail: stderrTail,
+	})
+	reason := fmt.Sprintf("job %s exceeded its run deadline: %v", job.ID, cause)
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	engine := w.WorkflowFactory(w.delegationParentCheckout(writeCtx, job))
+	return engine.FinalizeTimedOutJob(writeCtx, job.ID, reason, string(detailBytes))
 }
 
 // finalizeTimedOutDelegationChild bridges the daemon run-error path into the

--- a/internal/cli/daemon_result_test.go
+++ b/internal/cli/daemon_result_test.go
@@ -2,10 +2,122 @@ package cli
 
 import (
 	"context"
+	"io"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
+
+type deadlineBlockingAdapter struct{}
+
+func (deadlineBlockingAdapter) Deliver(ctx context.Context, _ runtime.Agent, _ runtime.Job) (runtime.Result, error) {
+	<-ctx.Done()
+	return runtime.Result{
+		SessionDiag: &runtime.SessionDiag{Stderr: "runner stderr deadline-tail"},
+	}, ctx.Err()
+}
+
+func TestRunDeadlinePersistsTopLevelTimeoutEvidence(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "job-timeout", Agent: "audit", Action: "ask", Repo: "owner/repo",
+		Branch: "main", JobTimeout: "2s",
+	})
+	job, err := store.GetJob(ctx, "job-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return deadlineBlockingAdapter{}, nil
+	}
+
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatalf("worker.run returned error: %v", err)
+	}
+	stored, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.State != string(workflow.JobFailed) {
+		t.Fatalf("stored job state = %q, want failed", stored.State)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var timeoutMessage string
+	for _, event := range events {
+		if event.Kind == "job_timeout" {
+			timeoutMessage = event.Message
+		}
+	}
+	if timeoutMessage == "" {
+		t.Fatalf("stored events = %+v, want job_timeout", events)
+	}
+	for _, want := range []string{`"deadline":`, `"elapsed":`, "deadline-tail"} {
+		if !strings.Contains(timeoutMessage, want) {
+			t.Fatalf("stored job_timeout = %q, want %q", timeoutMessage, want)
+		}
+	}
+}
+
+func TestRecoverKillPendingJobFailsInsteadOfRequeueing(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	for _, id := range []string{"job-witnessed", "job-no-witness"} {
+		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: id, Agent: "audit", Action: "review", Repo: "owner/repo"})
+		if claimed, err := store.ClaimRunningJob(ctx, id, string(workflow.JobQueued), string(workflow.JobRunning), db.JobEvent{Kind: string(workflow.JobRunning)}, 1, "boot"); err != nil || !claimed {
+			t.Fatalf("ClaimRunningJob(%s) claimed=%v err=%v", id, claimed, err)
+		}
+	}
+	// A prior attempt's terminal event must not mask a later attempt's fresh kill
+	// witness; recovery is ordered relative to the newest job_kill_pending event.
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-witnessed", Kind: "job_kill_pending", Message: "prior deadline"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: "job-witnessed", Kind: string(workflow.JobFailed), Message: "prior attempt"}); err != nil {
+		t.Fatal(err)
+	}
+	stop := armJobKillPending(store, "job-witnessed", time.Now().Add(time.Second))
+	defer stop()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if event, found, err := store.GetLatestJobEventByKind(ctx, "job-witnessed", "job_kill_pending"); err != nil {
+			t.Fatal(err)
+		} else if found && strings.Contains(event.Message, "deadline=") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("job_kill_pending was not journaled before the deadline")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := recoverKillPendingJobs(ctx, store, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	witnessed, _ := store.GetJob(ctx, "job-witnessed")
+	if witnessed.State != string(workflow.JobFailed) {
+		t.Fatalf("witnessed job state = %q, want failed", witnessed.State)
+	}
+	events, _ := store.ListJobEvents(ctx, witnessed.ID)
+	if !daemonWorkerHasEvent(events, string(workflow.JobFailed)) || !strings.Contains(events[len(events)-1].Message, "killed-by-deadline-unwitnessed") {
+		t.Fatalf("witnessed job events = %+v, want terminal unwitnessed-deadline reason", events)
+	}
+	noWitness, _ := store.GetJob(ctx, "job-no-witness")
+	if noWitness.State != string(workflow.JobRunning) {
+		t.Fatalf("job without kill witness state = %q, want running", noWitness.State)
+	}
+}
 
 func TestHandleRunJobErrorTimedOutDelegationChildTriggersRetry(t *testing.T) {
 	ctx := context.Background()

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/cockpit"
@@ -153,8 +154,15 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	worker.WorkflowFactory = worker.defaultWorkflow
 	worker.AuthProbe = worker.defaultAuthProbe
 	worker.QuotaWake = newQuotaRoleUnavailableWakeClient()
+	recoverKillPendingAtWorkerStartup.Do(func() {
+		if err := recoverKillPendingJobs(context.Background(), store, stdout); err != nil {
+			writeLine(stdout, "job kill-pending recovery failed: %v", err)
+		}
+	})
 	return worker
 }
+
+var recoverKillPendingAtWorkerStartup sync.Once
 
 func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	payload, err := daemonJobPayload(job)
@@ -605,10 +613,16 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	engine.BlockerDeferrer = w.deferOperationalBlockerPreTerminal
 	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
 	defer stopRun()
+	runStartedAt := time.Now().UTC()
 	if jobTimeout > 0 {
 		var cancel context.CancelFunc
 		runCtx, cancel = context.WithTimeout(runCtx, jobTimeout)
 		defer cancel()
+	}
+	runDeadline, hasRunDeadline := runCtx.Deadline()
+	stopKillPending := func() {}
+	if hasRunDeadline {
+		stopKillPending = armJobKillPending(w.Store, job.ID, runDeadline)
 	}
 	stopProgress := func() {}
 	if progressTracker != nil {
@@ -637,6 +651,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		}
 	}
 	_, err = engine.RunJob(runCtx, job.ID, agent, adapter)
+	stopKillPending()
 	stopProgress()
 	if err != nil {
 		if quotaErr := w.quotaRoleUnavailableHooks().recordRuntimeOutcome(ctx, job, payload, agent, err, time.Now().UTC()); quotaErr != nil {
@@ -654,7 +669,13 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			writeLine(w.Stdout, "job %s deferred on operational blocker (pre-terminal): %v", job.ID, err)
 			return nil
 		}
-		if markErr := w.handleRunJobError(ctx, job.ID, err); markErr != nil {
+		var markErr error
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			markErr = w.handleRunJobError(ctx, job.ID, context.DeadlineExceeded, jobTimeoutEvidence{Deadline: runDeadline, Started: runStartedAt})
+		} else {
+			markErr = w.handleRunJobError(ctx, job.ID, err)
+		}
+		if markErr != nil {
 			return markErr
 		}
 		if reconcileErr := engine.ReconcileTerminalDrivingJob(ctx, job.ID); reconcileErr != nil {
@@ -1743,18 +1764,31 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 	}()
 	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
 	defer stopRun()
+	runStartedAt := time.Now().UTC()
 	if started.JobTimeout > 0 {
 		var cancel context.CancelFunc
 		runCtx, cancel = context.WithTimeout(runCtx, started.JobTimeout)
 		defer cancel()
 	}
+	runDeadline, hasRunDeadline := runCtx.Deadline()
+	stopKillPending := func() {}
+	if hasRunDeadline {
+		stopKillPending = armJobKillPending(w.Store, delegatedJob.ID, runDeadline)
+	}
 	engine := w.WorkflowFactory(checkout)
 	_, err = engine.RunJob(runCtx, delegatedJob.ID, started.Agent, adapter)
+	stopKillPending()
 	if err != nil {
 		if quotaErr := w.quotaRoleUnavailableHooks().recordRuntimeOutcome(ctx, delegatedJob, payload, started.Agent, err, time.Now().UTC()); quotaErr != nil {
 			writeLine(w.Stdout, "job %s org-role quota unavailability capture failed: %v", delegatedJob.ID, quotaErr)
 		}
-		if markErr := w.handleRunJobError(ctx, delegatedJob.ID, err); markErr != nil {
+		var markErr error
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			markErr = w.handleRunJobError(ctx, delegatedJob.ID, context.DeadlineExceeded, jobTimeoutEvidence{Deadline: runDeadline, Started: runStartedAt})
+		} else {
+			markErr = w.handleRunJobError(ctx, delegatedJob.ID, err)
+		}
+		if markErr != nil {
 			return markErr
 		}
 		if reconcileErr := engine.ReconcileTerminalDrivingJob(ctx, delegatedJob.ID); reconcileErr != nil {
@@ -2181,6 +2215,73 @@ func effectiveJobTimeout(payload workflow.JobPayload, managed managedJobRuntimeC
 		return managed.JobTimeout
 	}
 	return daemonRunningJobStaleAfter
+}
+
+const jobKillPendingLead = 5 * time.Second
+
+// armJobKillPending records intent before the run context expires. The callback
+// deliberately uses Background: the witness must survive the deadline it
+// predicts. A completed run stops the timer before terminal handling.
+func armJobKillPending(store *db.Store, jobID string, deadline time.Time) func() {
+	delay := time.Until(deadline) - jobKillPendingLead
+	if delay < 0 {
+		delay = 0
+	}
+	timer := time.AfterFunc(delay, func() {
+		message := fmt.Sprintf("deadline=%s", deadline.UTC().Format(time.RFC3339Nano))
+		_ = store.AddJobEvent(context.Background(), db.JobEvent{
+			JobID:   jobID,
+			Kind:    "job_kill_pending",
+			Message: message,
+		})
+	})
+	return func() { timer.Stop() }
+}
+
+// recoverKillPendingJobs is the startup anti-immortality pass. A running job
+// with a pre-kill witness but no terminal event consumed its deadline and the
+// daemon died during the kill unwind; it must be failed, never silently requeued.
+func recoverKillPendingJobs(ctx context.Context, store *db.Store, stdout io.Writer) error {
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if job.State != string(workflow.JobRunning) {
+			continue
+		}
+		events, err := store.ListJobEvents(ctx, job.ID)
+		if err != nil {
+			return err
+		}
+		pending, terminalAfterPending := false, false
+		for _, event := range events {
+			switch event.Kind {
+			case "job_kill_pending":
+				pending = true
+				terminalAfterPending = false
+			case string(workflow.JobSucceeded), string(workflow.JobFailed), string(workflow.JobBlocked), string(workflow.JobCancelled), "job_timeout":
+				if pending {
+					terminalAfterPending = true
+				}
+			}
+		}
+		if !pending || terminalAfterPending {
+			continue
+		}
+		settled, err := store.TransitionJobStateWithEvent(ctx, job.ID, string(workflow.JobRunning), string(workflow.JobFailed), db.JobEvent{
+			JobID:   job.ID,
+			Kind:    string(workflow.JobFailed),
+			Message: "killed-by-deadline-unwitnessed",
+		})
+		if err != nil {
+			return err
+		}
+		if settled {
+			writeLine(stdout, "failed deadline-killed job %s after unwitnessed daemon shutdown", job.ID)
+		}
+	}
+	return nil
 }
 
 func originalAgentForTempWorkerType(typ string) string {

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -49,21 +49,19 @@ func (e Engine) RunJob(ctx context.Context, jobID string, agent runtime.Agent, a
 	return result, nil
 }
 
-// FinalizeTimedOutDelegationChild turns a delegation child that was killed by its
-// per-delegation timeout (or any runtime failure that left it JobRunning with no
-// parseable gitmoot_result) into a terminal FAILED child carrying a synthetic
-// failed result, then runs AdvanceJob so the parent's advanceDelegations applies
-// the delegation's retry/failure_policy/continuation. Without this a timeout kill
-// strands the child in JobRunning forever (Mailbox.Run errored, so RunJob returned
-// before AdvanceJob), and only the blind 30m stale-running recovery would re-queue
-// it, bypassing delegation.Retry and failure_policy.
+// FinalizeTimedOutJob turns any job killed by its run deadline into a terminal
+// FAILED job carrying a synthetic result and a job_timeout witness. Delegation
+// children additionally run AdvanceJob so retry/failure_policy/continuation still
+// apply. Top-level jobs deliberately stop after terminal persistence.
 //
-// It is a no-op (returns false) for a non-delegation job, a job that already left
-// JobRunning, or a job that already stored a result, so it is safe to call from
-// the daemon's run-error handler and idempotent under concurrent recovery. When
-// the synthetic failure blocks the parent task under block_parent, AdvanceJob
-// returns a BlockedError, which is propagated like the result-bearing path.
-func (e Engine) FinalizeTimedOutDelegationChild(ctx context.Context, jobID string, reason string) (bool, error) {
+// timeoutDetail is persisted verbatim and is expected to carry the effective
+// deadline, elapsed duration, and bounded stderr tail. The method is idempotent:
+// a result-bearing or non-failed terminal job is never rewritten.
+func (e Engine) FinalizeTimedOutJob(ctx context.Context, jobID string, reason string, timeoutDetail string) (bool, error) {
+	return e.finalizeTimedOutJob(ctx, jobID, reason, "job_timeout", timeoutDetail, false)
+}
+
+func (e Engine) finalizeTimedOutJob(ctx context.Context, jobID string, reason string, eventKind string, eventDetail string, delegationOnly bool) (bool, error) {
 	if err := e.validate(); err != nil {
 		return false, err
 	}
@@ -71,7 +69,7 @@ func (e Engine) FinalizeTimedOutDelegationChild(ctx context.Context, jobID strin
 	if err != nil {
 		return false, err
 	}
-	if strings.TrimSpace(payload.ParentJobID) == "" {
+	if delegationOnly && strings.TrimSpace(payload.ParentJobID) == "" {
 		return false, nil
 	}
 	// Already has a result -> the normal RunJob/AdvanceJob path handled it; nothing
@@ -110,10 +108,13 @@ func (e Engine) FinalizeTimedOutDelegationChild(ctx context.Context, jobID strin
 	}
 	if err := e.Store.AddJobEvent(ctx, db.JobEvent{
 		JobID:   jobID,
-		Kind:    "delegation_timeout_finalized",
-		Message: reason,
+		Kind:    eventKind,
+		Message: strings.TrimSpace(eventDetail),
 	}); err != nil {
 		return false, err
+	}
+	if strings.TrimSpace(payload.ParentJobID) == "" {
+		return true, nil
 	}
 	if err := e.AdvanceJob(ctx, jobID); err != nil {
 		return true, err
@@ -122,6 +123,12 @@ func (e Engine) FinalizeTimedOutDelegationChild(ctx context.Context, jobID strin
 		return true, err
 	}
 	return true, nil
+}
+
+// FinalizeTimedOutDelegationChild preserves the established engine API for
+// delegation callers while routing through the all-job terminalizer.
+func (e Engine) FinalizeTimedOutDelegationChild(ctx context.Context, jobID string, reason string) (bool, error) {
+	return e.finalizeTimedOutJob(ctx, jobID, reason, "delegation_timeout_finalized", reason, true)
 }
 
 func (e Engine) refreshJobPayload(ctx context.Context, jobID string) error {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1471,7 +1471,9 @@ func (m Mailbox) storeFailureDiagnostics(ctx context.Context, jobID string, payl
 		return
 	}
 	payload.FailureDiagnostics = diag
-	_ = m.savePayload(ctx, jobID, *payload)
+	writeCtx, cancel := terminalWriteContext(ctx)
+	defer cancel()
+	_ = m.savePayload(writeCtx, jobID, *payload)
 }
 
 // persistRefreshedRuntimeRef re-pins an agent that self-healed a dead session
@@ -1488,7 +1490,9 @@ func (m Mailbox) persistRefreshedRuntimeRef(ctx context.Context, jobID string, a
 }
 
 func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, message string) error {
-	transitioned, err := m.Store.TransitionJobStateWithEvent(ctx, jobID, string(JobRunning), string(state), db.JobEvent{
+	writeCtx, cancel := terminalWriteContext(ctx)
+	defer cancel()
+	transitioned, err := m.Store.TransitionJobStateWithEvent(writeCtx, jobID, string(JobRunning), string(state), db.JobEvent{
 		JobID:   jobID,
 		Kind:    string(state),
 		Message: message,
@@ -1497,7 +1501,7 @@ func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, messa
 		return err
 	}
 	if !transitioned {
-		latest, getErr := m.Store.GetJob(ctx, jobID)
+		latest, getErr := m.Store.GetJob(writeCtx, jobID)
 		if getErr != nil {
 			return getErr
 		}
@@ -1515,8 +1519,8 @@ func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, messa
 	// byte-identical). The load failure degrades gracefully to an id-rooted emit
 	// rather than dropping the event or failing the finish.
 	if m.emitTerminal != nil {
-		payload := m.loadTerminalEmitPayload(ctx, jobID, message)
-		m.emitTerminal(ctx, jobID, state, payload)
+		payload := m.loadTerminalEmitPayload(writeCtx, jobID, message)
+		m.emitTerminal(writeCtx, jobID, state, payload)
 	}
 	return nil
 }
@@ -1543,11 +1547,13 @@ func (m Mailbox) loadTerminalEmitPayload(ctx context.Context, jobID, message str
 }
 
 func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobState, message string, payload JobPayload) error {
+	writeCtx, cancel := terminalWriteContext(ctx)
+	defer cancel()
 	encoded, err := marshalPayload(payload)
 	if err != nil {
 		return err
 	}
-	transitioned, err := m.Store.TransitionJobStatePayloadWithEvent(ctx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
+	transitioned, err := m.Store.TransitionJobStatePayloadWithEvent(writeCtx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
 		JobID:   jobID,
 		Kind:    string(state),
 		Message: message,
@@ -1560,7 +1566,7 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 		return err
 	}
 	if !transitioned {
-		latest, getErr := m.Store.GetJob(ctx, jobID)
+		latest, getErr := m.Store.GetJob(writeCtx, jobID)
 		if getErr != nil {
 			return getErr
 		}
@@ -1570,7 +1576,7 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 	// (#446). Gated on transitioned==true so a re-run never double-emits; nil-safe
 	// so the default (no EventSink) path is byte-identical.
 	if m.emitTerminal != nil {
-		m.emitTerminal(ctx, jobID, state, payload)
+		m.emitTerminal(writeCtx, jobID, state, payload)
 	}
 	// Record resumable gates for a blocked stage that carries a `needs` list (#682)
 	// so the blocker becomes actionable: `gitmoot job gates` lists them and clearing
@@ -1588,8 +1594,8 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 	// pipeline advancer never folds, and a double execution once the run is
 	// properly resumed.
 	if state == JobBlocked && payload.Result != nil && len(payload.Result.Needs) > 0 && payload.Sender != PipelineJobSender {
-		if _, gateErr := m.Store.RecordJobGates(ctx, jobID, payload.Result.Needs); gateErr == nil {
-			_ = m.addEvent(ctx, jobID, "gates_recorded", fmt.Sprintf("recorded %d resumable gate(s) from needs", len(payload.Result.Needs)))
+		if _, gateErr := m.Store.RecordJobGates(writeCtx, jobID, payload.Result.Needs); gateErr == nil {
+			_ = m.addEvent(writeCtx, jobID, "gates_recorded", fmt.Sprintf("recorded %d resumable gate(s) from needs", len(payload.Result.Needs)))
 		}
 	}
 	return nil
@@ -1635,6 +1641,15 @@ func (m Mailbox) claim(ctx context.Context, job db.Job) error {
 
 func (m Mailbox) fail(ctx context.Context, jobID string, message string) error {
 	return m.finish(ctx, jobID, JobFailed, message)
+}
+
+const terminalWriteGrace = 30 * time.Second
+
+// terminalWriteContext detaches terminal persistence from the run deadline while
+// retaining values (including the runtime-session owner token), and bounds every
+// detached write so a stuck store can never hold the worker indefinitely.
+func terminalWriteContext(runCtx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(runCtx), terminalWriteGrace)
 }
 
 func (m Mailbox) addEvent(ctx context.Context, jobID string, kind string, message string) error {

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -16,6 +16,52 @@ import (
 	"github.com/gitmoot/gitmoot/internal/runtime"
 )
 
+func TestTerminalWriteContextSurvivesRunCancellationAndHasGraceDeadline(t *testing.T) {
+	runCtx, stopRun := context.WithCancel(context.Background())
+	stopRun()
+
+	writeCtx, cancel := terminalWriteContext(runCtx)
+	defer cancel()
+	if err := writeCtx.Err(); err != nil {
+		t.Fatalf("terminal write context inherited run cancellation: %v", err)
+	}
+	deadline, ok := writeCtx.Deadline()
+	if !ok {
+		t.Fatal("terminal write context has no grace deadline")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > terminalWriteGrace {
+		t.Fatalf("terminal write grace remaining = %v, want >0 and <=%v", remaining, terminalWriteGrace)
+	}
+}
+
+func TestMailboxFailPersistsAfterRunContextDeadline(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	job, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "job-terminal-write", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mailbox.claim(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	runCtx, cancelRun := context.WithCancel(ctx)
+	cancelRun()
+	if err := mailbox.fail(runCtx, job.ID, "deadline exceeded"); err != nil {
+		t.Fatalf("mailbox.fail on expired run context: %v", err)
+	}
+	stored, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.State != string(JobFailed) {
+		t.Fatalf("stored job state = %q, want failed", stored.State)
+	}
+}
+
 func TestMailboxEnqueueCreatesQueuedJobAndEvent(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)


### PR DESCRIPTION
WHAT:
GHOST-KILL-A: Implemented terminal-write integrity for deadline-killed jobs. Deadline expiry now records failed state plus job_timeout evidence; pre-kill intent survives daemon crashes and startup recovery never requeues deadline-consumed jobs.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-8105c363

RESULTS:
- Fail-before on unmodified HEAD f7da6894b320f2e1b11347c8332be5018b367f88: `--- FAIL: TestGhostKillFailBefore (2.31s)\n    ghost_kill_fail_before_test.go:37: worker.run returned error: context deadline exceeded\nFAIL\nFAIL github.com/gitmoot/gitmoot/internal/cli 2.317s\nFAIL`
- Mutant fail-write-uses-runCtx: `--- FAIL: TestMailboxFailPersistsAfterRunContextDeadline (0.23s)\n    mailbox_test.go:54: mailbox.fail on expired run context: context canceled`
- Mutant WithoutCancel-without-grace-timeout: `--- FAIL: TestTerminalWriteContextSurvivesRunCancellationAndHasGraceDeadline (0.00s)\n    mailbox_test.go:30: terminal write context has no grace deadline`
- Mutant kill-before-journal: `--- FAIL: TestRecoverKillPendingJobFailsInsteadOfRequeueing (1.30s)\n    daemon_result_test.go:93: job_kill_pending was not journaled before the deadline`
- Final targeted workflow tests: 2 passed, 0 failed, 0 skipped.
- Final targeted CLI tests: 5 passed, 0 failed, 0 skipped.
- git diff --check: passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-8105c363

AGENTS:
- wave-impl-b

RAW FINAL REVIEW OUTPUT:
````text
GHOST-KILL-A: Implemented terminal-write integrity for deadline-killed jobs. Deadline expiry now records failed state plus job_timeout evidence; pre-kill intent survives daemon crashes and startup recovery never requeues deadline-consumed jobs.
````
