### PR TITLE
Gitmoot: DREAMING RECONCILIATION FOLLOW-UP (from JARVIS — the 1323

### DIFF
--- a/internal/pipeline/pipeline_reconcile_drift_test.go
+++ b/internal/pipeline/pipeline_reconcile_drift_test.go
@@ -1,0 +1,139 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const dreamingLiveCurrentSpec = `name: jarvis-dreaming
+repo: gitmoot/jarvis
+stages:
+  - id: dream
+    agent: jarvis-dreamer
+    action: ask
+    prompt: consolidate pending memories
+`
+
+// TestPipelineScanReconcilesLiveCancelledRunAcrossSpecDrift mirrors the wedged
+// prun-jarvis-dreaming-18c601fe55793258 row family observed on 2026-07-31. The
+// pipeline definition changed after the run started, but the terminal cancelled
+// job remains authoritative evidence that its one running stage cannot progress.
+func TestPipelineScanReconcilesLiveCancelledRunAcrossSpecDrift(t *testing.T) {
+	const (
+		pipelineName = "jarvis-dreaming"
+		runID        = "prun-jarvis-dreaming-18c601fe55793258"
+		jobID        = runID + "-dream-a0"
+		currentHash  = "bbda059fca5a070c2fef99959bff3de237d49efe21060e88e5e7f6e0b7d47c1d"
+		runHash      = "22537b6057e198f7b72ae75f0b3f9914b9f117d972cfb564b2adb80e88c654e8"
+	)
+	ctx := context.Background()
+	store := pipelineAdvanceStore(t)
+	runStarted := time.Date(2026, 7, 27, 1, 41, 34, 166307416, time.UTC)
+	stageStarted := time.Date(2026, 7, 27, 1, 41, 35, 0, time.UTC)
+	jobCancelled := time.Date(2026, 7, 31, 3, 31, 4, 0, time.UTC)
+	scanAt := time.Date(2026, 7, 31, 8, 45, 6, 0, time.UTC)
+
+	rec := db.Pipeline{
+		Name:       pipelineName,
+		Repo:       "gitmoot/jarvis",
+		SpecYAML:   dreamingLiveCurrentSpec,
+		SpecHash:   currentHash,
+		Enabled:    true,
+		Interval:   "24h",
+		Jitter:     "30m",
+		LastRunID:  runID,
+		LastStatus: RunRunning,
+	}
+	if err := store.CreateOrUpdatePipeline(ctx, rec); err != nil {
+		t.Fatalf("CreateOrUpdatePipeline: %v", err)
+	}
+	if err := store.UpdatePipelineLastRun(ctx, pipelineName, runID, RunRunning, runStarted); err != nil {
+		t.Fatalf("UpdatePipelineLastRun: %v", err)
+	}
+	if err := store.AdvancePipelineNextDue(ctx, pipelineName, time.Date(2026, 7, 28, 1, 53, 48, 795871322, time.UTC)); err != nil {
+		t.Fatalf("AdvancePipelineNextDue: %v", err)
+	}
+	run := db.PipelineRun{
+		ID:          runID,
+		Pipeline:    pipelineName,
+		Trigger:     "schedule",
+		PayloadJSON: "{}",
+		SpecHash:    runHash,
+		State:       RunRunning,
+		StartedAt:   runStarted,
+	}
+	if err := store.CreatePipelineRun(ctx, run); err != nil {
+		t.Fatalf("CreatePipelineRun: %v", err)
+	}
+	stage := db.PipelineRunStage{
+		RunID:     runID,
+		StageID:   "dream",
+		State:     StageRunning,
+		JobID:     jobID,
+		Attempt:   0,
+		StartedAt: stageStarted,
+	}
+	if err := store.CreatePipelineRunStage(ctx, stage); err != nil {
+		t.Fatalf("CreatePipelineRunStage: %v", err)
+	}
+	payload := `{"repo":"gitmoot/jarvis","sender":"pipeline","root_job_id":"` + runID + `","job_timeout":"40m","result":{"decision":"blocked","summary":"pending memories cannot be retired"}}`
+	if err := store.CreateJobWithEvent(ctx, db.Job{
+		ID:      jobID,
+		Agent:   "jarvis-dreamer",
+		Type:    "ask",
+		State:   string(workflow.JobCancelled),
+		Payload: payload,
+		Model:   "gpt-5.6-sol",
+	}, db.JobEvent{JobID: jobID, Kind: string(workflow.JobCancelled), Message: "cancel requested from blocked"}); err != nil {
+		t.Fatalf("CreateJobWithEvent: %v", err)
+	}
+	setDreamingLiveFixtureTimes(t, store, jobID, runStarted, jobCancelled)
+
+	if age := scanAt.Sub(stageStarted); age < 103*time.Hour {
+		t.Fatalf("fixture stage age = %s, want at least 103h", age)
+	}
+	if err := RunPipelineScanOnce(ctx, store, testStageEnqueuer(store), scanAt); err != nil {
+		t.Fatalf("RunPipelineScanOnce: %v", err)
+	}
+
+	gotRun, ok, err := store.GetPipelineRun(ctx, runID)
+	if err != nil || !ok {
+		t.Fatalf("GetPipelineRun(%s): ok=%v err=%v", runID, ok, err)
+	}
+	if gotRun.State != RunFailed {
+		t.Fatalf("live-shaped reconciled run state = %q, want %q (pipeline hash=%s run hash=%s)", gotRun.State, RunFailed, currentHash, runHash)
+	}
+	gotStage := stageRow(t, store, runID, "dream")
+	if gotStage.State != StageFailed || gotStage.Summary != "stage job cancelled" {
+		t.Fatalf("live-shaped reconciled stage = {state=%q summary=%q}, want failed cancellation", gotStage.State, gotStage.Summary)
+	}
+	gotPipeline, ok, err := store.GetPipeline(ctx, pipelineName)
+	if err != nil || !ok {
+		t.Fatalf("GetPipeline(%s): ok=%v err=%v", pipelineName, ok, err)
+	}
+	if gotPipeline.LastStatus != RunFailed {
+		t.Fatalf("live-shaped pipeline last_status = %q, want %q", gotPipeline.LastStatus, RunFailed)
+	}
+}
+
+func setDreamingLiveFixtureTimes(t *testing.T, store *db.Store, jobID string, createdAt, cancelledAt time.Time) {
+	t.Helper()
+	conn, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Exec(`UPDATE jobs SET created_at = ?, updated_at = ? WHERE id = ?`,
+		createdAt.UTC().Format(time.RFC3339Nano), cancelledAt.UTC().Format(time.RFC3339Nano), jobID); err != nil {
+		t.Fatalf("UPDATE live fixture job times: %v", err)
+	}
+	if _, err := conn.Exec(`UPDATE job_events SET created_at = ? WHERE job_id = ? AND kind = ?`,
+		cancelledAt.UTC().Format(time.RFC3339Nano), jobID, string(workflow.JobCancelled)); err != nil {
+		t.Fatalf("UPDATE live fixture cancellation time: %v", err)
+	}
+}

--- a/internal/pipeline/pipeline_reconcile_drift_test.go
+++ b/internal/pipeline/pipeline_reconcile_drift_test.go
@@ -121,6 +121,96 @@ func TestPipelineScanReconcilesLiveCancelledRunAcrossSpecDrift(t *testing.T) {
 	}
 }
 
+// TestPipelineScanDoesNotSettleSpecDriftedLiveStages pins the destructive
+// polarity of the terminal-only reconciler. A drifted run may be inspected for
+// terminal evidence, but a queued or running stage backed by a live job must
+// remain in flight rather than falling through to a false successful settlement.
+func TestPipelineScanDoesNotSettleSpecDriftedLiveStages(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		stageState string
+		jobState   workflow.JobState
+	}{
+		{name: "running", stageState: StageRunning, jobState: workflow.JobRunning},
+		{name: "queued", stageState: StageQueued, jobState: workflow.JobQueued},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := pipelineAdvanceStore(t)
+			pipelineName := "drifted-live-" + tc.name
+			runID := "prun-drifted-live-" + tc.name
+			jobID := runID + "-work-a0"
+			startedAt := time.Date(2026, 7, 31, 9, 0, 0, 0, time.UTC)
+			scanAt := startedAt.Add(5 * time.Minute)
+
+			if err := store.CreateOrUpdatePipeline(ctx, db.Pipeline{
+				Name:       pipelineName,
+				Repo:       "owner/repo",
+				SpecYAML:   dreamingLiveCurrentSpec,
+				SpecHash:   "current-" + tc.name,
+				Enabled:    false,
+				LastRunID:  runID,
+				LastStatus: RunRunning,
+			}); err != nil {
+				t.Fatalf("CreateOrUpdatePipeline: %v", err)
+			}
+			if err := store.UpdatePipelineLastRun(ctx, pipelineName, runID, RunRunning, startedAt); err != nil {
+				t.Fatalf("UpdatePipelineLastRun: %v", err)
+			}
+			if err := store.CreatePipelineRun(ctx, db.PipelineRun{
+				ID:          runID,
+				Pipeline:    pipelineName,
+				Trigger:     "schedule",
+				PayloadJSON: "{}",
+				SpecHash:    "snapshot-" + tc.name,
+				State:       RunRunning,
+				StartedAt:   startedAt,
+			}); err != nil {
+				t.Fatalf("CreatePipelineRun: %v", err)
+			}
+			if err := store.CreatePipelineRunStage(ctx, db.PipelineRunStage{
+				RunID:     runID,
+				StageID:   "work",
+				State:     tc.stageState,
+				JobID:     jobID,
+				StartedAt: startedAt,
+			}); err != nil {
+				t.Fatalf("CreatePipelineRunStage: %v", err)
+			}
+			if err := store.CreateJobWithEvent(ctx, db.Job{
+				ID:      jobID,
+				Agent:   "worker",
+				Type:    "ask",
+				State:   string(tc.jobState),
+				Payload: `{"repo":"owner/repo","sender":"pipeline","root_job_id":"` + runID + `"}`,
+			}, db.JobEvent{JobID: jobID, Kind: string(tc.jobState), Message: "live job"}); err != nil {
+				t.Fatalf("CreateJobWithEvent: %v", err)
+			}
+
+			if err := RunPipelineScanOnce(ctx, store, testStageEnqueuer(store), scanAt); err != nil {
+				t.Fatalf("RunPipelineScanOnce: %v", err)
+			}
+			gotRun, ok, err := store.GetPipelineRun(ctx, runID)
+			if err != nil || !ok {
+				t.Fatalf("GetPipelineRun(%s): ok=%v err=%v", runID, ok, err)
+			}
+			if gotRun.State != RunRunning || !gotRun.FinishedAt.IsZero() {
+				t.Fatalf("spec-drifted %s stage settled run = {state=%q finished_at=%s}, want running with no finish", tc.stageState, gotRun.State, gotRun.FinishedAt)
+			}
+			if gotStage := stageRow(t, store, runID, "work"); gotStage.State != tc.stageState {
+				t.Fatalf("spec-drifted stage state = %q, want %q", gotStage.State, tc.stageState)
+			}
+			gotPipeline, ok, err := store.GetPipeline(ctx, pipelineName)
+			if err != nil || !ok {
+				t.Fatalf("GetPipeline(%s): ok=%v err=%v", pipelineName, ok, err)
+			}
+			if gotPipeline.LastStatus != RunRunning {
+				t.Fatalf("spec-drifted pipeline last_status = %q, want %q", gotPipeline.LastStatus, RunRunning)
+			}
+		})
+	}
+}
+
 func setDreamingLiveFixtureTimes(t *testing.T, store *db.Store, jobID string, createdAt, cancelledAt time.Time) {
 	t.Helper()
 	conn, err := sql.Open("sqlite", store.DatabasePath())

--- a/internal/pipeline/run.go
+++ b/internal/pipeline/run.go
@@ -700,7 +700,10 @@ func scheduleOnePipeline(ctx context.Context, store *db.Store, rec db.Pipeline, 
 // terminal runs consume zero compute. A per-run error is collected (first wins)
 // but never stops the remaining runs. Runs whose pipeline was removed, whose
 // stored spec no longer parses, or whose spec drifted (hash no longer matches the
-// run's snapshot) are skipped rather than executed against a changed spec.
+// run's snapshot) are never executed against a changed spec. A drifted run still
+// gets a narrow terminal-only reconciliation pass: cancelled jobs are immutable
+// evidence of failure, and already-terminal stage rows can settle without
+// interpreting or launching the changed spec.
 func advancePipelineRuns(ctx context.Context, store *db.Store, enqueue PipelineStageEnqueuer, now time.Time) error {
 	runs, err := store.ListActivePipelineRuns(ctx)
 	if err != nil {
@@ -719,15 +722,20 @@ func advancePipelineRuns(ctx context.Context, store *db.Store, enqueue PipelineS
 		if !ok {
 			continue
 		}
-		spec, err := Load([]byte(rec.SpecYAML))
-		if err != nil {
+		// A run executes its SNAPSHOT: if the pipeline's spec was edited since the run
+		// was created, its hash no longer matches and we do NOT enqueue or interpret
+		// the changed DAG/commands. We can still fold a cancelled job (which is
+		// terminal independent of stage semantics) and settle a fully-terminal set of
+		// persisted stage rows. This is what lets old runs stop blocking schedules
+		// after their pipeline prompt/configuration was edited.
+		if strings.TrimSpace(rec.SpecHash) != strings.TrimSpace(run.SpecHash) {
+			if _, err := reconcileSpecDriftedTerminalRun(ctx, store, rec, run, now); err != nil && firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
-		// A run executes its SNAPSHOT: if the pipeline's spec was edited since the run
-		// was created, its hash no longer matches and we do NOT advance against the
-		// changed DAG/commands. Parking/repairing spec drift is a follow-up; skipping
-		// is safe (the run stays running and is left untouched).
-		if strings.TrimSpace(rec.SpecHash) != strings.TrimSpace(run.SpecHash) {
+		spec, err := Load([]byte(rec.SpecYAML))
+		if err != nil {
 			continue
 		}
 		if _, err := AdvancePipelineRun(ctx, store, enqueue, rec, spec, run, now); err != nil && firstErr == nil {
@@ -735,6 +743,115 @@ func advancePipelineRuns(ctx context.Context, store *db.Store, enqueue PipelineS
 		}
 	}
 	return firstErr
+}
+
+// reconcileSpecDriftedTerminalRun is deliberately weaker than AdvancePipelineRun:
+// it never reads stage definitions, enqueues work, retries a stage, or interprets
+// an agent decision. It only projects a cancelled job onto its persisted stage
+// row, then settles when every persisted row is already terminal. Cancellation
+// has one meaning for every stage kind, so this remains valid when the current
+// pipeline spec no longer matches the run's unavailable historical snapshot.
+func reconcileSpecDriftedTerminalRun(ctx context.Context, store *db.Store, rec db.Pipeline, run db.PipelineRun, now time.Time) (db.PipelineRun, error) {
+	rows, err := store.ListPipelineRunStages(ctx, run.ID)
+	if err != nil || len(rows) == 0 {
+		return run, err
+	}
+	jobIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if (row.State == StageQueued || row.State == StageRunning) && strings.TrimSpace(row.JobID) != "" {
+			jobIDs = append(jobIDs, row.JobID)
+		}
+	}
+	events, err := loadPipelineJobEventSnapshot(ctx, store, jobIDs)
+	if err != nil {
+		return run, err
+	}
+	for i, row := range rows {
+		if (row.State != StageQueued && row.State != StageRunning) || strings.TrimSpace(row.JobID) == "" {
+			continue
+		}
+		job, err := store.GetJob(ctx, row.JobID)
+		if err != nil {
+			return run, err
+		}
+		if job.State != string(workflow.JobCancelled) {
+			continue
+		}
+		updated := row
+		updated.State = StageFailed
+		updated.Summary = "stage job cancelled"
+		updated.NeedsJSON = ""
+		updated.StartedAt, updated.FinishedAt, err = stampStageTimestampsFromJobEvents(
+			ctx, events, row.JobID, string(workflow.JobCancelled), now, row.StartedAt, true,
+		)
+		if err != nil {
+			return run, err
+		}
+		if err := persistPipelineStage(ctx, store, row, updated); err != nil {
+			return run, err
+		}
+		rows[i] = updated
+	}
+	settled, ok := computeSpecDriftedRunSettlement(rows, now)
+	if !ok {
+		return run, nil
+	}
+	return applyPipelineRunSettlement(ctx, store, rec, run, settled)
+}
+
+// computeSpecDriftedRunSettlement uses only terminal persisted stage states. Rows
+// come from ListPipelineRunStages in stage_id order, which gives a stable halt
+// stage without pretending that the current (drifted) spec's topology belongs to
+// the historical run. Empty, in-flight, pending, cancelled, and unknown sets do
+// not settle.
+func computeSpecDriftedRunSettlement(rows []db.PipelineRunStage, now time.Time) (pipelineRunSettlement, bool) {
+	if len(rows) == 0 {
+		return pipelineRunSettlement{}, false
+	}
+	var firstFailed, firstBlocked *db.PipelineRunStage
+	seenNeeds := make(map[string]struct{})
+	var blockedNeeds []string
+	for i := range rows {
+		row := &rows[i]
+		switch row.State {
+		case StageSucceeded, StageSkipped:
+		case StageFailed:
+			if firstFailed == nil {
+				firstFailed = row
+			}
+		case StageBlocked:
+			if firstBlocked == nil {
+				firstBlocked = row
+			}
+			for _, need := range decodePipelineNeeds(row.NeedsJSON) {
+				if _, exists := seenNeeds[need]; exists {
+					continue
+				}
+				seenNeeds[need] = struct{}{}
+				blockedNeeds = append(blockedNeeds, need)
+			}
+		default:
+			return pipelineRunSettlement{}, false
+		}
+	}
+	if firstFailed != nil {
+		return pipelineRunSettlement{
+			State:      RunFailed,
+			HaltStage:  firstFailed.StageID,
+			HaltReason: firstFailed.Summary,
+			FinishedAt: now,
+		}, true
+	}
+	if firstBlocked != nil {
+		return pipelineRunSettlement{
+			State:      RunBlocked,
+			HaltStage:  firstBlocked.StageID,
+			HaltReason: firstBlocked.Summary,
+			NeedsJSON:  marshalPipelineNeeds(blockedNeeds),
+			FinishedAt: now,
+		}, true
+	}
+	return pipelineRunSettlement{State: RunSucceeded, FinishedAt: now}, true
 }
 
 // AdvancePipelineRun is the per-run advancer (decision 6). It is a single


### PR DESCRIPTION
WHAT:
DREAM-FIX-2: Confirmed predicate mismatch—not inert wiring—and implemented terminal-only reconciliation for spec-drifted pipeline runs. Base HEAD was 5ba40c050a30f8139d1c0b96926ba3b120b3419e.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-44784eb7

RESULTS:
- Fail-before: go test -count=1 -run '^TestPipelineScanReconcilesLiveCancelledRunAcrossSpecDrift$' ./internal/pipeline/ — FAILED as required: `pipeline_reconcile_drift_test.go:105: live-shaped reconciled run state = "running", want "failed" (pipeline hash=bbda059fca5a070c2fef99959bff3de237d49efe21060e88e5e7f6e0b7d47c1d run hash=22537b6057e198f7b72ae75f0b3f9914b9f117d972cfb564b2adb80e88c654e8)`; package output ended `FAIL github.com/gitmoot/gitmoot/internal/pipeline`.
- Pass-after: targeted live-shape regression plus the original matching-hash cancellation regression — 2 passed, 0 failed, 0 skipped.
- git diff --check — passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-44784eb7

AGENTS:
- wave-impl-b

RAW FINAL REVIEW OUTPUT:
````text
DREAM-FIX-2: Confirmed predicate mismatch—not inert wiring—and implemented terminal-only reconciliation for spec-drifted pipeline runs. Base HEAD was 5ba40c050a30f8139d1c0b96926ba3b120b3419e.
````
