### PR TITLE
Gitmoot: COMMS NAV FIX-PASS (from JARVIS). PR 1328 took

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -102,8 +103,48 @@ func newDashboardWebHandler(ds *webDataSource) http.Handler {
 	// module fallback so no /api or module behavior changes.
 	mux.HandleFunc("GET /receipts/{id}", ds.handlePipelineReceipt)
 	mux.HandleFunc("GET /receipts/{id}/bundle", ds.handlePipelineReceiptBundle)
-	mux.Handle("/", withFleetActivityAssets(dashboard.Serve(ds)))
+	mux.Handle("/", withDashboardCommsNav(withFleetActivityAssets(dashboard.Serve(ds))))
 	return mux
+}
+
+const dashboardChatNavTail = `      <span style="{{ chatNavDotStyle }}"></span>
+    </div>`
+
+const dashboardCommsNavItem = `    <a href="/comms" title="Org communication threads" style="display:flex;align-items:center;gap:11px;padding:9px 11px;border-radius:9px;font-size:13.5px;font-weight:500;cursor:pointer;margin-top:2px;background:transparent;color:#a8aecf;border:1px solid transparent;box-shadow:none;position:relative;text-decoration:none">
+      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" stroke-linecap="round"><path d="M4 5h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"/><path d="M9 10h11a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-3l-3 2v-2"/></svg>
+      <span style="flex:1">Comms</span>
+    </a>`
+
+// withDashboardCommsNav adds the gitmoot-owned Comms route to the embedded
+// dashboard module's sidebar. Comms is a standalone read-only page, so the
+// sidebar entry is an ordinary link; the destination page owns its active-state
+// treatment. The replacement is intentionally anchored to Chat's unique nav
+// tail so module markup drift fails the rendered-page regression instead of
+// placing the link in an arbitrary section.
+func withDashboardCommsNav(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !dashboardDocumentPath(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		buffered := &dashboardBufferedResponse{header: make(http.Header)}
+		next.ServeHTTP(buffered, r)
+		for key, values := range buffered.header {
+			w.Header()[key] = append([]string(nil), values...)
+		}
+		status := buffered.status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		body := buffered.body.Bytes()
+		if status == http.StatusOK && strings.Contains(w.Header().Get("Content-Type"), "text/html") {
+			replacement := []byte(dashboardChatNavTail + "\n" + dashboardCommsNavItem)
+			body = bytes.Replace(body, []byte(dashboardChatNavTail), replacement, 1)
+			w.Header().Del("Content-Length")
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	})
 }
 
 type dashboardWorkflowAPIView struct {

--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -138,9 +138,12 @@ func withDashboardCommsNav(next http.Handler) http.Handler {
 		}
 		body := buffered.body.Bytes()
 		if status == http.StatusOK && strings.Contains(w.Header().Get("Content-Type"), "text/html") {
-			replacement := []byte(dashboardChatNavTail + "\n" + dashboardCommsNavItem)
-			body = bytes.Replace(body, []byte(dashboardChatNavTail), replacement, 1)
-			w.Header().Del("Content-Length")
+			anchor := []byte(dashboardChatNavTail)
+			if bytes.Contains(body, anchor) {
+				replacement := []byte(dashboardChatNavTail + "\n" + dashboardCommsNavItem)
+				body = bytes.Replace(body, anchor, replacement, 1)
+				w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			}
 		}
 		w.WriteHeader(status)
 		_, _ = w.Write(body)

--- a/internal/cli/dashboard_web_comms_test.go
+++ b/internal/cli/dashboard_web_comms_test.go
@@ -331,6 +331,26 @@ func TestDashboardCommsPageContract(t *testing.T) {
 	}
 }
 
+func TestDashboardSidebarLinksCommsDirectlyAfterChat(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	newDashboardWebHandler(&webDataSource{}).ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/", nil),
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET / status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	chat := strings.Index(body, `<span style="flex:1">Chat</span>`)
+	comms := strings.Index(body, `href="/comms"`)
+	brain := strings.Index(body, `<span style="flex:1">Brain</span>`)
+	if chat < 0 || comms < 0 || brain < 0 || !(chat < comms && comms < brain) {
+		t.Fatalf("sidebar ordering chat=%d comms=%d brain=%d, want Chat < Comms < Brain", chat, comms, brain)
+	}
+	if !strings.Contains(body[comms:brain], `<span style="flex:1">Comms</span>`) {
+		t.Fatal("Comms sidebar link is missing its visible label")
+	}
+}
+
 const dashboardCommsPageHarness = `
 const fs = require('fs');
 const vm = require('vm');

--- a/internal/cli/dashboard_web_comms_test.go
+++ b/internal/cli/dashboard_web_comms_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -348,6 +349,37 @@ func TestDashboardSidebarLinksCommsDirectlyAfterChat(t *testing.T) {
 	}
 	if !strings.Contains(body[comms:brain], `<span style="flex:1">Comms</span>`) {
 		t.Fatal("Comms sidebar link is missing its visible label")
+	}
+}
+
+func TestDashboardCommsNavNoAnchorPreservesResponse(t *testing.T) {
+	const body = "<!doctype html><html><body>no sidebar anchor</body></html>"
+	wantHeader := http.Header{
+		"Content-Length": {fmt.Sprint(len(body))},
+		"Content-Type":   {"text/html; charset=utf-8"},
+		"X-Upstream":     {"unchanged"},
+	}
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for key, values := range wantHeader {
+			w.Header()[key] = append([]string(nil), values...)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	})
+
+	recorder := httptest.NewRecorder()
+	withDashboardCommsNav(upstream).ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/", nil),
+	)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d, want %d", recorder.Code, http.StatusOK)
+	}
+	if got := recorder.Body.String(); got != body {
+		t.Fatalf("body=%q, want byte-identical %q", got, body)
+	}
+	if got := recorder.Header(); !reflect.DeepEqual(got, wantHeader) {
+		t.Fatalf("headers=%v, want unchanged %v", got, wantHeader)
 	}
 }
 


### PR DESCRIPTION
WHAT:
GITMOOT-DASH-NAV-B: Fixed PR #1328’s no-match response corruption at reviewed head 2f4d33b18466bf7afcf2a4012dd21688fc6a810a. Changes remain uncommitted for Gitmoot’s finalizer.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-4c2dca77

RESULTS:
- Fail-before: TestDashboardCommsNavNoAnchorPreservesResponse failed with: headers=map[Content-Type:[text/html; charset=utf-8] X-Upstream:[unchanged]], want unchanged map[Content-Length:[58] Content-Type:[text/html; charset=utf-8] X-Upstream:[unchanged]].
- Targeted pass: go test -count=1 -run '^(TestDashboardCommsNavNoAnchorPreservesResponse|TestDashboardSidebarLinksCommsDirectlyAfterChat)$' ./internal/cli/ — passed.
- git diff --check — passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-4c2dca77

AGENTS:
- wave-impl-b

RAW FINAL REVIEW OUTPUT:
````text
GITMOOT-DASH-NAV-B: Fixed PR #1328’s no-match response corruption at reviewed head 2f4d33b18466bf7afcf2a4012dd21688fc6a810a. Changes remain uncommitted for Gitmoot’s finalizer.
````
