### PR TITLE
Gitmoot: DIRECTIVE SLICE 1 FIX-PASS (from JARVIS). PR 1329

### DIFF
--- a/internal/cli/doctor_json_test.go
+++ b/internal/cli/doctor_json_test.go
@@ -83,9 +83,9 @@ func TestDoctorWarnsWhenDirectedEventKindHasNoObserverRule(t *testing.T) {
 	}
 	detail := check["detail"].(string)
 	if check["status"] != "warn" ||
-		!strings.Contains(detail, "blocked, escalation") ||
-		strings.Contains(detail, "blocked, escalation, reply") {
-		t.Fatalf("event observers check = %#v, want blocked and escalation warning with reply covered", check)
+		!strings.Contains(detail, "blocked, directive, escalation") ||
+		strings.Contains(detail, "reply") {
+		t.Fatalf("event observers check = %#v, want blocked, directive, and escalation warning with reply covered", check)
 	}
 	t.Logf("reviewer probe: warned=true detail=%q", detail)
 
@@ -105,6 +105,12 @@ func TestDoctorWarnsWhenDirectedEventKindHasNoObserverRule(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if err := store.AddEventRule(context.Background(), db.EventRule{
+		ID: "observer-directive", OnKind: "directive", WakeRole: "owner",
+		Scope: db.EventRuleScopeObserver, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -119,6 +125,7 @@ func TestBuildEventObserverDoctorCheckWarnsForEachMissingDirectedKind(t *testing
 		db.WakeOutboxKindReply,
 		db.WakeOutboxKindBlocked,
 		db.WakeOutboxKindEscalation,
+		db.WakeOutboxKindDirective,
 	}
 	for _, missingKind := range kinds {
 		t.Run(missingKind, func(t *testing.T) {

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -189,7 +189,7 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 	if !ok {
 		return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, "organization registry unavailable", errors.New("organization registry unavailable"))
 	}
-	isReply := event.Type == events.EventOrgReply
+	isAddressedNoteWake := event.Type == events.EventOrgReply || event.Type == events.EventOrgDirective
 	hasAddressee := strings.TrimSpace(event.WakeTargetRole) != ""
 	replyHandled := false
 	addressedReplyHandled := false
@@ -204,7 +204,7 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 		// Preserve the existing one-attempt-per-target behavior for duplicate
 		// addressed reply rules while allowing every observer rule to see the
 		// directed event independently.
-		if isReply && !observer && addressedReplyHandled {
+		if isAddressedNoteWake && !observer && addressedReplyHandled {
 			continue
 		}
 		pane, ok := s.resolveRolePane(ctx, cfg, rule.WakeRole)
@@ -262,15 +262,15 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 		// A coalesced reply batch still gives its addressed target one attempt per
 		// window. Observer rules are independent copies and do not consume that
 		// target attempt.
-		if isReply {
+		if isAddressedNoteWake {
 			replyHandled = true
 			if !observer {
 				addressedReplyHandled = true
 			}
 		}
 	}
-	if isReply && !replyHandled {
-		return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, "no matching reply rule or role binding", errors.New("no matching reply rule or role binding"))
+	if isAddressedNoteWake && !replyHandled {
+		return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, "no matching addressed rule or role binding", errors.New("no matching addressed rule or role binding"))
 	}
 	return nil
 }
@@ -363,6 +363,8 @@ func classifyEventRuleKinds(event events.Event) []string {
 		return []string{"pane_input_pending"}
 	case events.EventOrgReply:
 		return []string{"reply"}
+	case events.EventOrgDirective:
+		return []string{"directive"}
 	}
 	return nil
 }
@@ -396,6 +398,13 @@ func eventRuleMatches(filter string, event events.Event) bool {
 }
 
 func eventRuleWakePrompt(kind string, event events.Event) string {
+	if strings.EqualFold(strings.TrimSpace(kind), db.WakeOutboxKindDirective) {
+		directiveID := strings.TrimPrefix(event.RootID, db.WakeOutboxSourceWorkflowNote+":")
+		return fmt.Sprintf(
+			"gitmoot directive %s for %s; acknowledge receipt with: gitmoot org directive ack %s --by %s",
+			directiveID, event.WakeTargetRole, directiveID, event.WakeTargetRole,
+		)
+	}
 	// event.Detail is already redacted + absolute-path-scrubbed by events.NewEvent,
 	// so it is used as-is here (only trimmed and rune-safe truncated for the arg).
 	detail := truncateForWake(strings.TrimSpace(event.Detail), 320)

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -85,6 +85,7 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 		{name: "recycle overdue", event: events.Event{Type: events.EventOrgRecycleOverdue, Cause: "recycle_overdue"}, want: []string{"recycle-overdue"}},
 		{name: "pane input pending", event: events.Event{Type: events.EventOrgInputPending, Cause: "input_pending_since"}, want: []string{"pane_input_pending"}},
 		{name: "addressed reply", event: events.Event{Type: events.EventOrgReply, Cause: "addressed_note"}, want: []string{"reply"}},
+		{name: "addressed directive", event: events.Event{Type: events.EventOrgDirective, Cause: "addressed_directive"}, want: []string{"directive"}},
 		{name: "finished terminal", event: events.Event{Type: events.EventJobFinished}, want: []string{"job-terminal"}},
 		{name: "failed terminal", event: events.Event{Type: events.EventJobFailed, Cause: "unrelated"}, want: []string{"job-terminal"}},
 		{name: "plain blocked terminal and blocked", event: events.Event{Type: events.EventJobBlocked}, want: []string{"job-terminal", "blocked"}},

--- a/internal/cli/org.go
+++ b/internal/cli/org.go
@@ -116,6 +116,8 @@ func runOrg(args []string, stdout, stderr io.Writer) int {
 		return runOrgRecycle(args[1:], stdout, stderr)
 	case "escalate":
 		return runOrgEscalate(args[1:], stdout, stderr)
+	case "directive":
+		return runOrgDirective(args[1:], stdout, stderr)
 	case "events":
 		return runOrgEvents(args[1:], stdout, stderr)
 	case "seat":
@@ -140,13 +142,16 @@ func printOrgUsage(w io.Writer) {
 	fmt.Fprintln(w, "  gitmoot org seat rm NAME [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org escalate --to ROLE --workflow LABEL [--org-role ROLE] [--repo OWNER/REPO] [--json] [--home DIR] \"QUESTION\"")
 	fmt.Fprintln(w, "  gitmoot org escalate resolve NOTE_ID [--by ROLE] [--note ANSWER_NOTE_ID] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org directive send --to ROLE --workflow LABEL (--stdin | -F FILE | TEXT) [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org directive ack ID [--by ROLE] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org directive cancel ID [--by ROLE] [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule add --on KIND [--match FILTER | --repo SUBSTRING] --wake ROLE [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule list [--home DIR]")
 	fmt.Fprintln(w, "  gitmoot org events rule set-scope [--home DIR] ID observer|addressed")
 	fmt.Fprintln(w, "  gitmoot org events rule rm [--home DIR] ID")
 }
 
-var orgSeatDefaultRouteKinds = []string{"blocked", "escalation", "reply"}
+var orgSeatDefaultRouteKinds = []string{"blocked", "directive", "escalation", "reply"}
 
 const orgSeatExternalTimeout = 10 * time.Second
 
@@ -1763,6 +1768,7 @@ var eventRuleKinds = map[string]struct{}{
 	"recycle-overdue":    {},
 	"pane_input_pending": {},
 	"reply":              {},
+	"directive":          {},
 }
 
 func runOrgEvents(args []string, stdout, stderr io.Writer) int {
@@ -1805,7 +1811,7 @@ func runOrgEventRuleAdd(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("org events rule add", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	home := fs.String("home", "", "home directory to use instead of the current user's home")
-	onKind := fs.String("on", "", "event kind: escalation, attention, guard, job-terminal, blocked, recycle-overdue, pane_input_pending, or reply")
+	onKind := fs.String("on", "", "event kind: escalation, attention, guard, job-terminal, blocked, recycle-overdue, pane_input_pending, reply, or directive")
 	// V1 intentionally keeps matching simple and inspectable: one
 	// case-insensitive substring tested independently against repo and job id;
 	// an empty filter matches every event of the selected kind.
@@ -1839,7 +1845,7 @@ func runOrgEventRuleAdd(args []string, stdout, stderr io.Writer) int {
 	}
 	kind := strings.ToLower(strings.TrimSpace(*onKind))
 	if _, ok := eventRuleKinds[kind]; !ok {
-		fmt.Fprintf(stderr, "unknown event rule kind %q; want escalation, attention, guard, job-terminal, blocked, recycle-overdue, pane_input_pending, or reply\n", kind)
+		fmt.Fprintf(stderr, "unknown event rule kind %q; want escalation, attention, guard, job-terminal, blocked, recycle-overdue, pane_input_pending, reply, or directive\n", kind)
 		return 2
 	}
 	roleName := strings.ToLower(strings.TrimSpace(*wake))

--- a/internal/cli/org_directive.go
+++ b/internal/cli/org_directive.go
@@ -184,6 +184,14 @@ func runOrgDirectiveReceipt(kind string, args []string, stdout, stderr io.Writer
 		fmt.Fprintf(stderr, "org directive %s: %v\n", kind, err)
 		return 1
 	}
+	by := strings.ToLower(strings.TrimSpace(*byFlag))
+	if by == "" {
+		by = strings.ToLower(strings.TrimSpace(os.Getenv("GITMOOT_ORG_ROLE")))
+	}
+	if by == "" {
+		fmt.Fprintf(stderr, "org directive %s: acting org role is required; pass --by or set GITMOOT_ORG_ROLE\n", kind)
+		return 1
+	}
 	var workflowID string
 	if err := withStore(*home, func(store *db.Store) error {
 		ctx := context.Background()
@@ -198,24 +206,13 @@ func runOrgDirectiveReceipt(kind string, args []string, stdout, stderr io.Writer
 		if !ok {
 			return fmt.Errorf("note %d is not an org directive", directiveID)
 		}
-		by := strings.ToLower(strings.TrimSpace(*byFlag))
-		if by == "" {
-			by = strings.ToLower(strings.TrimSpace(os.Getenv("GITMOOT_ORG_ROLE")))
-		}
-		if by == "" {
-			if kind == "ack" {
-				by = to
-			} else {
-				by = from
-			}
-		}
 		if _, ok := cfg.Role(by); !ok {
 			return fmt.Errorf("unknown org role %q", by)
 		}
 		var body string
 		if kind == "ack" {
-			if by != to {
-				return fmt.Errorf("role %q cannot acknowledge directive %d addressed to %q", by, directiveID, to)
+			if by != to && !slicesContains(cfg.Ancestors(to), by) {
+				return fmt.Errorf("role %q cannot acknowledge directive %d addressed to %q; only the target or an ancestor may acknowledge", by, directiveID, to)
 			}
 			body = workflow.FormatOrgDirectiveAckNote(directiveID, by)
 		} else {

--- a/internal/cli/org_directive.go
+++ b/internal/cli/org_directive.go
@@ -1,0 +1,275 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+var orgDirectiveStdin io.Reader = os.Stdin
+
+func runOrgDirective(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 || args[0] == "-h" || args[0] == "--help" {
+		printOrgDirectiveUsage(stdout)
+		return 0
+	}
+	switch args[0] {
+	case "send":
+		return runOrgDirectiveSend(args[1:], stdout, stderr)
+	case "ack":
+		return runOrgDirectiveReceipt("ack", args[1:], stdout, stderr)
+	case "cancel":
+		return runOrgDirectiveReceipt("cancel", args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown org directive command %q\n", args[0])
+		printOrgDirectiveUsage(stderr)
+		return 2
+	}
+}
+
+func printOrgDirectiveUsage(w io.Writer) {
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  gitmoot org directive send --to ROLE --workflow LABEL (--stdin | -F FILE | TEXT) [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org directive ack ID [--by ROLE] [--home DIR]")
+	fmt.Fprintln(w, "  gitmoot org directive cancel ID [--by ROLE] [--home DIR]")
+	fmt.Fprintln(w, "Acknowledgment records receipt, not completion; completion tracking is separate.")
+}
+
+func runOrgDirectiveSend(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org directive send", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	toFlag := fs.String("to", "", "descendant organization role receiving the directive")
+	workflowID := fs.String("workflow", "", "workflow label for the directive note")
+	stdin := fs.Bool("stdin", false, "read directive body from stdin")
+	file := fs.String("F", "", "read directive body from file")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	body, err := readOrgDirectiveBody(fs.Args(), *stdin, *file)
+	if err != nil {
+		fmt.Fprintf(stderr, "org directive send: %v\n", err)
+		return 2
+	}
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org directive send: resolve paths: %v\n", err)
+		return 1
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org directive send: %v\n", err)
+		return 1
+	}
+	from := strings.ToLower(strings.TrimSpace(os.Getenv("GITMOOT_ORG_ROLE")))
+	if _, ok := cfg.Role(from); !ok {
+		fmt.Fprintf(stderr, "org directive send: unknown acting org role %q; set GITMOOT_ORG_ROLE\n", from)
+		return 2
+	}
+	to := strings.ToLower(strings.TrimSpace(*toFlag))
+	if _, ok := cfg.Role(to); !ok {
+		fmt.Fprintf(stderr, "org directive send: unknown target org role %q\n", to)
+		return 2
+	}
+	if from == to || !slicesContains(cfg.Ancestors(to), from) {
+		fmt.Fprintf(stderr, "org directive send: role %q is not an ancestor of target %q; peer and upward directives are refused\n", from, to)
+		return 2
+	}
+	label := strings.TrimSpace(*workflowID)
+	if err := workflow.ValidateWorkflowID(label); err != nil {
+		fmt.Fprintf(stderr, "org directive send: %v\n", err)
+		return 2
+	}
+	noteBody := workflow.FormatOrgDirectiveNote(from, to, label, body)
+	if noteBody == "" || len(noteBody) > workflowNoteBodyMax {
+		fmt.Fprintf(stderr, "org directive send: body must produce a note of at most %d bytes\n", workflowNoteBodyMax)
+		return 2
+	}
+	var note db.WorkflowNote
+	if err := withStore(*home, func(store *db.Store) error {
+		var err error
+		note, err = store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+			WorkflowID: label, Author: from, Body: noteBody,
+			AddressedTarget: to, AddressedWakeKind: db.WakeOutboxKindDirective,
+		})
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "org directive send: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "sent directive %d from %s to %s in workflow %s\n", note.ID, from, to, label)
+	return 0
+}
+
+func readOrgDirectiveBody(args []string, stdin bool, file string) (string, error) {
+	sources := 0
+	if stdin {
+		sources++
+	}
+	if strings.TrimSpace(file) != "" {
+		sources++
+	}
+	if len(args) != 0 {
+		sources++
+	}
+	if sources != 1 || len(args) > 1 {
+		return "", errors.New("choose exactly one body source: --stdin, -F FILE, or one TEXT argument")
+	}
+	var raw []byte
+	var err error
+	switch {
+	case stdin:
+		raw, err = io.ReadAll(io.LimitReader(orgDirectiveStdin, workflowNoteBodyMax+1))
+	case file != "":
+		raw, err = os.ReadFile(file)
+	default:
+		raw = []byte(args[0])
+	}
+	if err != nil {
+		return "", err
+	}
+	if len(raw) > workflowNoteBodyMax || strings.TrimSpace(string(raw)) == "" {
+		return "", fmt.Errorf("body must be non-empty and at most %d bytes", workflowNoteBodyMax)
+	}
+	return string(raw), nil
+}
+
+func runOrgDirectiveReceipt(kind string, args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("org directive "+kind, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	home := fs.String("home", "", "home directory to use instead of the current user's home")
+	byFlag := fs.String("by", "", "organization role recording the "+kind)
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" {
+			_ = fs.Parse([]string{"--help"})
+			return 0
+		}
+	}
+	idText, flagArgs, ok := orgDirectiveReceiptIDAndFlags(args)
+	if !ok {
+		fmt.Fprintf(stderr, "org directive %s requires exactly one directive id\n", kind)
+		return 2
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+	directiveID, err := strconv.ParseInt(idText, 10, 64)
+	if err != nil || directiveID <= 0 {
+		fmt.Fprintf(stderr, "org directive %s: invalid directive id %q\n", kind, idText)
+		return 2
+	}
+	paths, err := pathsFromFlag(*home)
+	if err != nil {
+		fmt.Fprintf(stderr, "org directive %s: resolve paths: %v\n", kind, err)
+		return 1
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		fmt.Fprintf(stderr, "org directive %s: %v\n", kind, err)
+		return 1
+	}
+	var workflowID string
+	if err := withStore(*home, func(store *db.Store) error {
+		ctx := context.Background()
+		target, err := store.GetWorkflowNote(ctx, directiveID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("directive %d not found", directiveID)
+		}
+		if err != nil {
+			return err
+		}
+		from, to, _, _, ok := workflow.ParseOrgDirectiveNote(target.Body)
+		if !ok {
+			return fmt.Errorf("note %d is not an org directive", directiveID)
+		}
+		by := strings.ToLower(strings.TrimSpace(*byFlag))
+		if by == "" {
+			by = strings.ToLower(strings.TrimSpace(os.Getenv("GITMOOT_ORG_ROLE")))
+		}
+		if by == "" {
+			if kind == "ack" {
+				by = to
+			} else {
+				by = from
+			}
+		}
+		if _, ok := cfg.Role(by); !ok {
+			return fmt.Errorf("unknown org role %q", by)
+		}
+		var body string
+		if kind == "ack" {
+			if by != to {
+				return fmt.Errorf("role %q cannot acknowledge directive %d addressed to %q", by, directiveID, to)
+			}
+			body = workflow.FormatOrgDirectiveAckNote(directiveID, by)
+		} else {
+			if by != from {
+				return fmt.Errorf("role %q cannot cancel directive %d sent by %q", by, directiveID, from)
+			}
+			body = workflow.FormatOrgDirectiveCancelNote(directiveID, by)
+		}
+		if body == "" {
+			return errors.New("could not format directive receipt")
+		}
+		_, err = store.InsertWorkflowNote(ctx, db.WorkflowNote{
+			WorkflowID: target.WorkflowID, Author: by, Body: body, Repo: target.Repo,
+		})
+		workflowID = target.WorkflowID
+		return err
+	}); err != nil {
+		fmt.Fprintf(stderr, "org directive %s: %v\n", kind, err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "%sed directive %d in workflow %s\n", kind, directiveID, workflowID)
+	return 0
+}
+
+func orgDirectiveReceiptIDAndFlags(args []string) (string, []string, bool) {
+	needsValue := map[string]bool{"--home": true, "--by": true}
+	idIndex := -1
+	for i := 0; i < len(args); i++ {
+		if needsValue[args[i]] {
+			i++
+			if i >= len(args) {
+				return "", nil, false
+			}
+			continue
+		}
+		if strings.HasPrefix(args[i], "--home=") || strings.HasPrefix(args[i], "--by=") {
+			continue
+		}
+		if strings.HasPrefix(args[i], "-") || idIndex >= 0 {
+			return "", nil, false
+		}
+		idIndex = i
+	}
+	if idIndex < 0 {
+		return "", nil, false
+	}
+	return args[idIndex], append(append([]string{}, args[:idIndex]...), args[idIndex+1:]...), true
+}
+
+func slicesContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -98,6 +98,16 @@ func TestOrgDirectiveSendBodySourcesAndDirectionPolicy(t *testing.T) {
 	}
 }
 
+func TestOrgDirectiveSendRefusesUpward(t *testing.T) {
+	home := directiveTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "worker")
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{"directive", "send", "--home", home, "--to", "owner", "--workflow", "release/upward", "must fail"}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "peer and upward directives are refused") {
+		t.Fatalf("upward send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}
+
 func TestOrgDirectiveAckAuthorizationAndUnackedQuery(t *testing.T) {
 	home := directiveTestHome(t)
 	t.Setenv("GITMOOT_ORG_ROLE", "owner")
@@ -136,6 +146,40 @@ func TestOrgDirectiveAckAuthorizationAndUnackedQuery(t *testing.T) {
 	if err != nil || len(unacked) != 0 {
 		t.Fatalf("unacked after ack=%+v err=%v", unacked, err)
 	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/ancestor-ack", "inspect another result"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("second send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	ancestorDirectiveID := strings.Fields(stdout.String())[2]
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"directive", "ack", ancestorDirectiveID, "--home", home, "--by", "owner"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("ancestor ack code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestOrgDirectiveReceiptRequiresActingRole(t *testing.T) {
+	home := directiveTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "owner")
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/actorless", "inspect the result"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	directiveID := strings.Fields(stdout.String())[2]
+	t.Setenv("GITMOOT_ORG_ROLE", "")
+
+	for _, kind := range []string{"ack", "cancel"} {
+		t.Run(kind, func(t *testing.T) {
+			stdout.Reset()
+			stderr.Reset()
+			code := runOrg([]string{"directive", kind, directiveID, "--home", home}, &stdout, &stderr)
+			if code != 1 || !strings.Contains(stderr.String(), "acting org role is required") {
+				t.Fatalf("actorless %s code=%d out=%q err=%q", kind, code, stdout.String(), stderr.String())
+			}
+		})
+	}
 }
 
 func TestOrgDirectiveCancelIsRestrictedToSender(t *testing.T) {
@@ -160,23 +204,30 @@ func TestOrgDirectiveCancelIsRestrictedToSender(t *testing.T) {
 
 func TestDirectiveWakeOutboxIsConfigInert(t *testing.T) {
 	home := directiveTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "owner")
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/inert", "act"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
 	store, err := db.Open(config.PathsForHome(home).Database)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = store.Close() })
-	directive, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
-		WorkflowID: "release/inert", Author: "owner", Body: workflow.FormatOrgDirectiveNote("owner", "worker", "release/inert", "act"),
-		AddressedTarget: "worker", AddressedWakeKind: db.WakeOutboxKindDirective,
-	})
-	if err != nil {
-		t.Fatal(err)
+	notes, err := store.ListWorkflowNotes(context.Background(), "release/inert", 0)
+	if err != nil || len(notes) != 1 {
+		t.Fatalf("stored directives=%+v err=%v", notes, err)
 	}
+	directive := notes[0]
 	wake := &fakeEventWake{}
 	deliverySink := synchronousEventRuleTestSink{sink: &eventRuleSink{store: store, home: home, wake: wake}}
 	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
-	if err != nil || len(pending) != 1 {
-		t.Fatalf("pending=%+v err=%v", pending, err)
+	if err != nil || len(pending) != 1 ||
+		pending[0].SourceKind != db.WakeOutboxSourceWorkflowNote ||
+		pending[0].SourceID != fmt.Sprint(directive.ID) ||
+		pending[0].TargetRole != "worker" ||
+		pending[0].CoalesceKey != db.WakeOutboxDirectiveCoalescePrefix+"worker" {
+		t.Fatalf("stored directive=%+v pending=%+v err=%v", directive, pending, err)
 	}
 	createdAt, _ := time.Parse(time.RFC3339Nano, pending[0].CreatedAt)
 

--- a/internal/cli/org_directive_test.go
+++ b/internal/cli/org_directive_test.go
@@ -1,0 +1,255 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func directiveTestHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configBody := `[org.roles."owner"]
+scope=["*"]
+pane="owner-pane"
+[org.roles."worker"]
+parent="owner"
+scope=["*"]
+pane="worker-pane"
+[org.roles."peer"]
+parent="owner"
+scope=["*"]
+pane="peer-pane"
+`
+	if err := os.WriteFile(paths.ConfigFile, []byte(configBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func TestOrgDirectiveSendBodySourcesAndDirectionPolicy(t *testing.T) {
+	t.Setenv("GITMOOT_ORG_ROLE", "owner")
+	tests := []struct {
+		name string
+		args func(string) []string
+		body string
+	}{
+		{"text", func(home string) []string {
+			return []string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/text", "use `a=b` [now]"}
+		}, "use `a=b` [now]"},
+		{"file", func(home string) []string {
+			path := filepath.Join(home, "directive.txt")
+			if err := os.WriteFile(path, []byte("line one\n`$HOME` ] line two"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return []string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/file", "-F", path}
+		}, "line one\n`$HOME` ] line two"},
+		{"stdin", func(home string) []string {
+			return []string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/stdin", "--stdin"}
+		}, "$(printf unsafe)\nnext"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := directiveTestHome(t)
+			oldStdin := orgDirectiveStdin
+			orgDirectiveStdin = strings.NewReader(test.body)
+			t.Cleanup(func() { orgDirectiveStdin = oldStdin })
+			var stdout, stderr bytes.Buffer
+			if code := runOrg(test.args(home), &stdout, &stderr); code != 0 {
+				t.Fatalf("send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+			}
+			store, err := db.Open(config.PathsForHome(home).Database)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = store.Close() })
+			notes, err := store.ListWorkflowNotes(context.Background(), "release/"+test.name, 0)
+			if err != nil || len(notes) != 1 {
+				t.Fatalf("notes=%+v err=%v", notes, err)
+			}
+			_, to, _, body, ok := workflow.ParseOrgDirectiveNote(notes[0].Body)
+			if !ok || to != "worker" || body != test.body {
+				t.Fatalf("directive parse=(to=%q body=%q ok=%v), want body %q", to, body, ok, test.body)
+			}
+		})
+	}
+
+	// MUTANT: allowing a non-ancestor sender would make this peer send succeed.
+	home := directiveTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "peer")
+	var stdout, stderr bytes.Buffer
+	code := runOrg([]string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/peer", "must fail"}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "peer and upward directives are refused") {
+		t.Fatalf("peer send code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestOrgDirectiveAckAuthorizationAndUnackedQuery(t *testing.T) {
+	home := directiveTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "owner")
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/ack", "inspect the result"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("send code=%d err=%q", code, stderr.String())
+	}
+	fields := strings.Fields(stdout.String())
+	directiveID, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// MUTANT: trusting --by without checking the addressed target would accept peer.
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"directive", "ack", fmt.Sprint(directiveID), "--home", home, "--by", "peer"}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "cannot acknowledge") {
+		t.Fatalf("unauthorized ack code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	unacked, err := store.ListUnacknowledgedOrgDirectives(context.Background(), "worker")
+	if err != nil || len(unacked) != 1 || unacked[0].ID != directiveID {
+		t.Fatalf("unacked=%+v err=%v", unacked, err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"directive", "ack", fmt.Sprint(directiveID), "--home", home, "--by", "worker"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("ack code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	unacked, err = store.ListUnacknowledgedOrgDirectives(context.Background(), "worker")
+	if err != nil || len(unacked) != 0 {
+		t.Fatalf("unacked after ack=%+v err=%v", unacked, err)
+	}
+}
+
+func TestOrgDirectiveCancelIsRestrictedToSender(t *testing.T) {
+	home := directiveTestHome(t)
+	t.Setenv("GITMOOT_ORG_ROLE", "owner")
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"directive", "send", "--home", home, "--to", "worker", "--workflow", "release/cancel", "stop if obsolete"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("send code=%d err=%q", code, stderr.String())
+	}
+	id := strings.Fields(stdout.String())[2]
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"directive", "cancel", id, "--home", home, "--by", "worker"}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "cannot cancel") {
+		t.Fatalf("target cancel code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runOrg([]string{"directive", "cancel", id, "--home", home, "--by", "owner"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("sender cancel code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestDirectiveWakeOutboxIsConfigInert(t *testing.T) {
+	home := directiveTestHome(t)
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	directive, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: "release/inert", Author: "owner", Body: workflow.FormatOrgDirectiveNote("owner", "worker", "release/inert", "act"),
+		AddressedTarget: "worker", AddressedWakeKind: db.WakeOutboxKindDirective,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wake := &fakeEventWake{}
+	deliverySink := synchronousEventRuleTestSink{sink: &eventRuleSink{store: store, home: home, wake: wake}}
+	pending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("pending=%+v err=%v", pending, err)
+	}
+	createdAt, _ := time.Parse(time.RFC3339Nano, pending[0].CreatedAt)
+
+	// MUTANT F3: treating an unmatched directive as an unhealthy obligation
+	// makes this zero-directive-rule drain return a permanent error.
+	if err := drainReplyWakeOutbox(context.Background(), store, createdAt.Add(replyWakeCoalescingWindow+time.Second), replyWakeTestDeliveryResolver(deliverySink)); err != nil {
+		t.Fatalf("config-inert drain for directive %d: %v", directive.ID, err)
+	}
+	if err := wakeOutboxObligationHealth(context.Background(), store, createdAt.Add(-time.Minute)); err != nil {
+		t.Fatalf("config-inert directive health: %v", err)
+	}
+	stillPending, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
+	if err != nil || len(stillPending) != 1 || wake.promptCalls != 0 {
+		t.Fatalf("pending=%+v prompts=%d err=%v", stillPending, wake.promptCalls, err)
+	}
+}
+
+func TestOrgEventRuleAddAcceptsDirective(t *testing.T) {
+	home := directiveTestHome(t)
+	var stdout, stderr bytes.Buffer
+	if code := runOrg([]string{"events", "rule", "add", "--home", home, "--on", "directive", "--wake", "worker"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("rule add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestDirectiveWakeOutboxUsesSeparateCoalesceNamespace(t *testing.T) {
+	store, deliverySink, wake, _ := replyWakeTestHarness(t, []replyWakeTestRole{{name: "owner", pane: "w1:p1"}})
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{ID: "directive-owner", OnKind: "directive", WakeRole: "owner", Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	thread, err := store.CreateChatThread(ctx, db.ChatThread{Slug: "directive-coalesce", Repo: "owner/repo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < 2; index++ {
+		if _, err := store.AddChatMessage(ctx, db.ChatMessage{
+			ThreadID: thread.ID, AuthorName: "worker", Kind: db.ChatKindChat,
+			Body: fmt.Sprintf("@owner reply %d", index), Mentions: []string{"owner"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	directive, err := store.InsertWorkflowNote(ctx, db.WorkflowNote{
+		WorkflowID: "release/coalesce", Author: "worker", Body: workflow.FormatOrgDirectiveNote("worker", "owner", "release/coalesce", "act"),
+		AddressedTarget: "owner", AddressedWakeKind: db.WakeOutboxKindDirective,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := store.ListWakeOutbox(ctx, db.WakeOutboxStatePending)
+	if err != nil || len(pending) != 3 {
+		t.Fatalf("pending=%+v err=%v", pending, err)
+	}
+	keys := map[string]int{}
+	for _, row := range pending {
+		keys[row.CoalesceKey]++
+	}
+	if keys["reply:owner"] != 2 || keys["directive:owner"] != 1 {
+		t.Fatalf("coalesce namespaces=%v", keys)
+	}
+
+	latest, _ := time.Parse(time.RFC3339Nano, pending[len(pending)-1].CreatedAt)
+	if err := drainReplyWakeOutbox(ctx, store, latest.Add(replyWakeCoalescingWindow+time.Second), replyWakeTestDeliveryResolver(deliverySink)); err != nil {
+		t.Fatalf("coalesced drain: %v", err)
+	}
+	directivePrompt := ""
+	for _, prompt := range wake.prompts {
+		if strings.Contains(prompt, "gitmoot org directive ack") {
+			directivePrompt = prompt
+		}
+	}
+	if wake.promptCalls != 2 || !strings.Contains(directivePrompt, fmt.Sprintf("directive %d", directive.ID)) || !strings.Contains(directivePrompt, fmt.Sprintf("gitmoot org directive ack %d --by owner", directive.ID)) {
+		t.Fatalf("directive wake calls=%d prompts=%q", wake.promptCalls, wake.prompts)
+	}
+}

--- a/internal/cli/org_seat_test.go
+++ b/internal/cli/org_seat_test.go
@@ -67,9 +67,10 @@ func TestOrgSeatAddEndsGreenOnRealityValidation(t *testing.T) {
 		`pane w1:p2 claimed label="Worker"`,
 		`role worker created pane="Worker"`,
 		"route org-seat-worker-blocked created",
+		"route org-seat-worker-directive created",
 		"route org-seat-worker-escalation created",
 		"route org-seat-worker-reply created",
-		"ok 2 roles, 2 live panes, 4 enabled routes",
+		"ok 2 roles, 2 live panes, 5 enabled routes",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Fatalf("seat add output missing %q:\n%s", want, stdout.String())
@@ -84,8 +85,8 @@ func TestOrgSeatAddEndsGreenOnRealityValidation(t *testing.T) {
 		t.Fatalf("worker role = %+v, present=%t", worker, ok)
 	}
 	rules := listOrgSeatTestRules(t, paths)
-	if len(rules) != 4 {
-		t.Fatalf("event rules = %+v, want owner route plus three worker routes", rules)
+	if len(rules) != 5 {
+		t.Fatalf("event rules = %+v, want owner route plus four worker routes", rules)
 	}
 
 	// Re-running add is the repair path and must not duplicate owned routes.
@@ -93,11 +94,11 @@ func TestOrgSeatAddEndsGreenOnRealityValidation(t *testing.T) {
 	stderr.Reset()
 	code = runOrg([]string{"seat", "add", "worker", "--pane", "Worker", "--home", home}, &stdout, &stderr)
 	if code != 0 || !strings.Contains(stdout.String(), "route org-seat-worker-reply existed") ||
-		!strings.Contains(stdout.String(), "ok 2 roles, 2 live panes, 4 enabled routes") {
+		!strings.Contains(stdout.String(), "ok 2 roles, 2 live panes, 5 enabled routes") {
 		t.Fatalf("second seat add code=%d out=%q err=%q", code, stdout.String(), stderr.String())
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 4 {
-		t.Fatalf("event rules after repair = %d, want 4", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 5 {
+		t.Fatalf("event rules after repair = %d, want 5", got)
 	}
 }
 
@@ -175,7 +176,7 @@ func TestOrgSeatRemoveRefusesUnshippedBranchWork(t *testing.T) {
 	if _, ok := cfg.Role("worker"); !ok {
 		t.Fatal("branch-check mutant removed worker role")
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 4 {
+	if got := len(listOrgSeatTestRules(t, paths)); got != 5 {
 		t.Fatalf("branch refusal changed routes: %d", got)
 	}
 }
@@ -218,7 +219,7 @@ func TestOrgSeatRemoveClosesPaneAndEndsWithValidation(t *testing.T) {
 	}
 	for _, want := range []string{
 		"pane w1:p2 closed",
-		"role worker removed with 3 wake routes",
+		"role worker removed with 4 wake routes",
 		"ok 1 roles, 1 live panes, 1 enabled routes",
 	} {
 		if !strings.Contains(stdout.String(), want) {
@@ -261,8 +262,8 @@ func TestOrgSeatRemoveRestoresOwnedStateWhenPaneCloseFails(t *testing.T) {
 	if _, ok := cfg.Role("worker"); !ok {
 		t.Fatal("worker role was not restored after pane-close failure")
 	}
-	if got := len(listOrgSeatTestRules(t, paths)); got != 4 {
-		t.Fatalf("routes after pane-close rollback = %d, want 4", got)
+	if got := len(listOrgSeatTestRules(t, paths)); got != 5 {
+		t.Fatalf("routes after pane-close rollback = %d, want 5", got)
 	}
 }
 

--- a/internal/cli/reply_wake_outbox.go
+++ b/internal/cli/reply_wake_outbox.go
@@ -146,7 +146,16 @@ func wakeOutboxObligationHealth(ctx context.Context, store *db.Store, attemptedB
 	if err != nil {
 		return fmt.Errorf("read wake outbox obligations: %w", err)
 	}
-	pending := len(obligations.Pending)
+	pending := 0
+	for _, obligation := range obligations.Pending {
+		// Directives are config-inert by contract: without a matching rule their
+		// durable row remains pending for later configuration, not as a permanent
+		// daemon health error stream.
+		if strings.HasPrefix(strings.ToLower(obligation.CoalesceKey), db.WakeOutboxDirectiveCoalescePrefix) {
+			continue
+		}
+		pending++
+	}
 	agedAttempted := len(obligations.AgedAttempted)
 	if pending == 0 && agedAttempted == 0 {
 		return nil
@@ -174,7 +183,10 @@ var wakeOutboxSourceKinds = []wakeOutboxSourceKind{
 	{sourceKind: db.WakeOutboxSourceEscalation, wakeKind: db.WakeOutboxKindEscalation},
 }
 
-func wakeOutboxKindForSource(sourceKind string) (string, bool) {
+func wakeOutboxKindForSource(sourceKind, coalesceKey string) (string, bool) {
+	if sourceKind == db.WakeOutboxSourceWorkflowNote && strings.HasPrefix(strings.ToLower(coalesceKey), db.WakeOutboxDirectiveCoalescePrefix) {
+		return db.WakeOutboxKindDirective, true
+	}
 	for _, definition := range wakeOutboxSourceKinds {
 		if definition.sourceKind == sourceKind {
 			return definition.wakeKind, true
@@ -184,7 +196,7 @@ func wakeOutboxKindForSource(sourceKind string) (string, bool) {
 }
 
 func wakeOutboxDirectedKinds() []string {
-	unique := make(map[string]struct{})
+	unique := map[string]struct{}{db.WakeOutboxKindDirective: {}}
 	for _, definition := range wakeOutboxSourceKinds {
 		unique[definition.wakeKind] = struct{}{}
 	}
@@ -209,7 +221,7 @@ func wakeOutboxEvent(batch []db.WakeOutboxObligation, now time.Time) (events.Eve
 	}
 	oldest := batch[0]
 	role := strings.ToLower(strings.TrimSpace(oldest.TargetRole))
-	wakeKind, ok := wakeOutboxKindForSource(oldest.SourceKind)
+	wakeKind, ok := wakeOutboxKindForSource(oldest.SourceKind, oldest.CoalesceKey)
 	if !ok {
 		return events.Event{}, fmt.Errorf(
 			"wake outbox row %d has unsupported source kind %q",
@@ -219,6 +231,21 @@ func wakeOutboxEvent(batch []db.WakeOutboxObligation, now time.Time) (events.Eve
 	var event events.Event
 	switch oldest.SourceKind {
 	case db.WakeOutboxSourceWorkflowNote, db.WakeOutboxSourceChatMessage:
+		if wakeKind == db.WakeOutboxKindDirective {
+			detail := fmt.Sprintf("directive id %s for %s", oldest.SourceID, role)
+			event = events.NewEvent(
+				events.EventOrgDirective,
+				"org-directive:"+role,
+				oldest.SourceKind+":"+oldest.SourceID,
+				"",
+				db.WakeOutboxStateAttempted,
+				detail,
+				now,
+				workflow.RedactCommentText,
+			)
+			event.Cause = "addressed_directive"
+			break
+		}
 		detail := fmt.Sprintf("%d new items, oldest id %s", len(batch), oldest.SourceID)
 		event = events.NewEvent(
 			events.EventOrgReply,

--- a/internal/db/wake_outbox.go
+++ b/internal/db/wake_outbox.go
@@ -29,13 +29,15 @@ const (
 	WakeOutboxKindReply      = "reply"
 	WakeOutboxKindBlocked    = "blocked"
 	WakeOutboxKindEscalation = "escalation"
+	WakeOutboxKindDirective  = "directive"
 
 	WakeOutboxSourceWorkflowNote = "workflow_note"
 	WakeOutboxSourceChatMessage  = "chat_message"
 	WakeOutboxSourceBlocked      = WakeOutboxKindBlocked
 	WakeOutboxSourceEscalation   = WakeOutboxKindEscalation
 
-	WakeOutboxReplyCoalescePrefix = WakeOutboxKindReply + ":"
+	WakeOutboxReplyCoalescePrefix     = WakeOutboxKindReply + ":"
+	WakeOutboxDirectiveCoalescePrefix = WakeOutboxKindDirective + ":"
 )
 
 type wakeOutboxStateInterpretation uint8
@@ -106,10 +108,10 @@ func (p WakeOutboxObligationProjection) Len() int {
 	return len(p.Pending) + len(p.AgedAttempted)
 }
 
-func insertWorkflowNoteWakeOutboxTx(ctx context.Context, tx *sql.Tx, noteID int64, targetRole string) error {
+func insertWorkflowNoteWakeOutboxTx(ctx context.Context, tx *sql.Tx, noteID int64, targetRole, wakeKind string) error {
 	if err := insertWakeOutboxTx(
 		ctx, tx, WakeOutboxSourceWorkflowNote, strconv.FormatInt(noteID, 10),
-		WakeOutboxKindReply, targetRole,
+		wakeKind, targetRole,
 	); err != nil {
 		return fmt.Errorf("insert workflow note wake outbox: %w", err)
 	}
@@ -199,7 +201,7 @@ VALUES (?, ?, ?, ?)`,
 func wakeOutboxCoalesceKey(wakeKind, role string) (string, error) {
 	kind := strings.ToLower(strings.TrimSpace(wakeKind))
 	switch kind {
-	case WakeOutboxKindReply, WakeOutboxKindBlocked, WakeOutboxKindEscalation:
+	case WakeOutboxKindReply, WakeOutboxKindBlocked, WakeOutboxKindEscalation, WakeOutboxKindDirective:
 	default:
 		return "", fmt.Errorf("unsupported wake outbox kind %q", wakeKind)
 	}

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -69,7 +69,10 @@ type WorkflowNote struct {
 	Repo       string `json:"repo,omitempty"`
 	// AddressedTarget is write-only routing metadata. The CLI parses typed note
 	// bodies and sets it; db must not import workflow merely to rediscover it.
-	AddressedTarget     string `json:"-"`
+	AddressedTarget string `json:"-"`
+	// AddressedWakeKind selects the durable addressed-note route. Empty keeps
+	// the established reply route for every existing caller.
+	AddressedWakeKind   string `json:"-"`
 	MemoryObservationID int64  `json:"memory_observation_id,omitempty"`
 	CreatedAt           string `json:"created_at"`
 }
@@ -427,7 +430,11 @@ VALUES (?, ?, ?, ?, ?)`, note.WorkflowID, note.Author, note.Body, note.Repo, not
 		return 0, err
 	}
 	if note.AddressedTarget != "" {
-		if err := insertWorkflowNoteWakeOutboxTx(ctx, tx, noteID, note.AddressedTarget); err != nil {
+		wakeKind := note.AddressedWakeKind
+		if strings.TrimSpace(wakeKind) == "" {
+			wakeKind = WakeOutboxKindReply
+		}
+		if err := insertWorkflowNoteWakeOutboxTx(ctx, tx, noteID, note.AddressedTarget, wakeKind); err != nil {
 			return 0, err
 		}
 	}
@@ -757,6 +764,38 @@ FROM workflow_notes
 WHERE substr(body, 1, length(?)) = ?
 ORDER BY created_at DESC, id DESC
 LIMIT ?`, prefix, prefix, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	notes := []WorkflowNote{}
+	for rows.Next() {
+		var note WorkflowNote
+		if err := rows.Scan(&note.ID, &note.WorkflowID, &note.Author, &note.Body, &note.Repo, &note.MemoryObservationID, &note.CreatedAt); err != nil {
+			return nil, err
+		}
+		notes = append(notes, note)
+	}
+	return notes, rows.Err()
+}
+
+// ListUnacknowledgedOrgDirectives returns the oldest outstanding directives.
+// It is intentionally ASC and unbounded: a newer directive must never push the
+// oldest unacknowledged obligation out of a DESC+LIMIT window.
+func (s *Store) ListUnacknowledgedOrgDirectives(ctx context.Context, targetRole string) ([]WorkflowNote, error) {
+	targetRole = strings.ToLower(strings.TrimSpace(targetRole))
+	rows, err := s.db.QueryContext(ctx, `SELECT d.id, d.workflow_id, d.author, d.body, d.repo, d.memory_observation_id, d.created_at
+FROM workflow_notes d
+WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
+	AND (? = '' OR substr(d.body, 1, length('[org:directive to=' || ? || ' ')) = '[org:directive to=' || ? || ' ')
+	AND NOT EXISTS (
+		SELECT 1 FROM workflow_notes r
+		WHERE r.workflow_id = d.workflow_id AND (
+			substr(r.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
+			OR substr(r.body, 1, length('[org:directive-cancel id=' || d.id || ' ')) = '[org:directive-cancel id=' || d.id || ' '
+		)
+	)
+ORDER BY d.created_at ASC, d.id ASC`, targetRole, targetRole, targetRole)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/workflow_store_test.go
+++ b/internal/db/workflow_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -180,6 +181,41 @@ func TestListWorkflowNotesByBodyPrefix(t *testing.T) {
 	}
 	if len(handoffs) != 1 || handoffs[0].WorkflowID != "release/two" {
 		t.Fatalf("handoffs = %+v", handoffs)
+	}
+}
+
+func TestListUnacknowledgedOrgDirectivesKeepsOldestFirst(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	first, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/directives", Author: "owner", Body: "[org:directive to=worker from=owner wf=release/directives] first"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/directives", Author: "owner", Body: "[org:directive to=worker from=owner wf=release/directives] second"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/directives", Author: "worker", Body: fmt.Sprintf("[org:directive-ack id=%d by=worker]", first.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	third, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/directives", Author: "owner", Body: "[org:directive to=worker from=owner wf=release/directives] third"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelled, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/directives", Author: "owner", Body: "[org:directive to=worker from=owner wf=release/directives] cancelled"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/directives", Author: "owner", Body: fmt.Sprintf("[org:directive-cancel id=%d by=owner]", cancelled.ID)}); err != nil {
+		t.Fatal(err)
+	}
+
+	notes, err := store.ListUnacknowledgedOrgDirectives(ctx, "worker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(notes) != 2 || notes[0].ID != second.ID || notes[1].ID != third.ID {
+		t.Fatalf("unacknowledged directives = %+v, want ids [%d %d] oldest first", notes, second.ID, third.ID)
 	}
 }
 

--- a/internal/events/sink.go
+++ b/internal/events/sink.go
@@ -67,6 +67,9 @@ const (
 	// EventOrgReply is emitted by the daemon for a durable, coalesced batch of
 	// notes addressed to one organization role.
 	EventOrgReply EventType = "org.reply"
+	// EventOrgDirective is emitted for an addressed directive wake. It remains
+	// separate from conversational replies so routing and coalescing cannot mix.
+	EventOrgDirective EventType = "org.directive"
 
 	// EventCandidateAwaitingPromotion is emitted once when a SkillOpt template
 	// candidate becomes PENDING (the post-import notify, #471): a new pending

--- a/internal/events/sink_test.go
+++ b/internal/events/sink_test.go
@@ -81,6 +81,7 @@ func TestEventTypeEnumValues(t *testing.T) {
 		EventOrgRecycleOverdue:          "org.recycle_overdue",
 		EventOrgInputPending:            "org.input_pending",
 		EventOrgReply:                   "org.reply",
+		EventOrgDirective:               "org.directive",
 		EventCandidateAwaitingPromotion: "candidate.awaiting_promotion",
 		EventCandidateAutoPromoted:      "candidate.auto_promoted",
 		EventJobStarted:                 "job.started",

--- a/internal/workflow/org_directive.go
+++ b/internal/workflow/org_directive.go
@@ -1,0 +1,60 @@
+package workflow
+
+import "strconv"
+
+const (
+	OrgDirectivePrefix       = "[org:directive "
+	OrgDirectiveAckPrefix    = "[org:directive-ack "
+	OrgDirectiveCancelPrefix = "[org:directive-cancel "
+)
+
+func FormatOrgDirectiveNote(from, to, wf, directive string) string {
+	return formatAddressedOrgNote("directive", []addressedOrgNoteField{
+		{key: "to", value: to}, {key: "from", value: from}, {key: "wf", value: wf},
+	}, directive)
+}
+
+func ParseOrgDirectiveNote(body string) (from, to, wf, directive string, ok bool) {
+	values, directive, ok := parseAddressedOrgNote("directive", body)
+	if !ok || directive == "" || len(values) != 3 || values["from"] == "" || values["to"] == "" || values["wf"] == "" {
+		return "", "", "", "", false
+	}
+	return values["from"], values["to"], values["wf"], directive, true
+}
+
+func FormatOrgDirectiveAckNote(directiveID int64, by string) string {
+	return formatOrgDirectiveReceipt("directive-ack", directiveID, by)
+}
+
+func ParseOrgDirectiveAckNote(body string) (directiveID int64, by string, ok bool) {
+	return parseOrgDirectiveReceipt("directive-ack", body)
+}
+
+func FormatOrgDirectiveCancelNote(directiveID int64, by string) string {
+	return formatOrgDirectiveReceipt("directive-cancel", directiveID, by)
+}
+
+func ParseOrgDirectiveCancelNote(body string) (directiveID int64, by string, ok bool) {
+	return parseOrgDirectiveReceipt("directive-cancel", body)
+}
+
+func formatOrgDirectiveReceipt(kind string, directiveID int64, by string) string {
+	if directiveID <= 0 {
+		return ""
+	}
+	return formatAddressedOrgNote(kind, []addressedOrgNoteField{
+		{key: "id", value: strconv.FormatInt(directiveID, 10)}, {key: "by", value: by},
+	}, "")
+}
+
+func parseOrgDirectiveReceipt(kind, body string) (directiveID int64, by string, ok bool) {
+	values, content, ok := parseAddressedOrgNote(kind, body)
+	if !ok || content != "" || len(values) != 2 || values["by"] == "" {
+		return 0, "", false
+	}
+	directiveID, err := strconv.ParseInt(values["id"], 10, 64)
+	if err != nil || directiveID <= 0 {
+		return 0, "", false
+	}
+	return directiveID, values["by"], true
+}

--- a/internal/workflow/org_directive_test.go
+++ b/internal/workflow/org_directive_test.go
@@ -1,0 +1,27 @@
+package workflow
+
+import "testing"
+
+func TestOrgDirectiveNoteSchemas(t *testing.T) {
+	body := FormatOrgDirectiveNote("owner", "worker", "release/one", "run `x=y` ] then report")
+	from, to, wf, directive, ok := ParseOrgDirectiveNote(body)
+	if !ok || from != "owner" || to != "worker" || wf != "release/one" || directive != "run `x=y` ] then report" {
+		t.Fatalf("ParseOrgDirectiveNote(%q) = (%q, %q, %q, %q, %v)", body, from, to, wf, directive, ok)
+	}
+	tests := []struct {
+		name  string
+		body  string
+		parse func(string) (int64, string, bool)
+	}{
+		{"ack", FormatOrgDirectiveAckNote(42, "worker"), ParseOrgDirectiveAckNote},
+		{"cancel", FormatOrgDirectiveCancelNote(42, "owner"), ParseOrgDirectiveCancelNote},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			id, by, ok := test.parse(test.body)
+			if !ok || id != 42 || by == "" {
+				t.Fatalf("parse(%q) = (%d, %q, %v)", test.body, id, by, ok)
+			}
+		})
+	}
+}

--- a/internal/workflow/org_escalate.go
+++ b/internal/workflow/org_escalate.go
@@ -12,39 +12,19 @@ const OrgEscalateResolvedPrefix = "[org:escalate-resolved "
 // schema. Invalid delimiter-bearing fields return an empty string; normal CLI
 // callers validate role and workflow values before reaching this helper.
 func FormatOrgEscalateNote(from, to, wf, question string) string {
-	if !validOrgEscalateField(from) || !validOrgEscalateField(to) || !validOrgEscalateField(wf) || strings.TrimSpace(question) == "" {
-		return ""
-	}
-	return OrgEscalatePrefix + "to=" + to + " from=" + from + " wf=" + wf + "] " + question
+	return formatAddressedOrgNote("escalate", []addressedOrgNoteField{
+		{key: "to", value: to}, {key: "from", value: from}, {key: "wf", value: wf},
+	}, question)
 }
 
 // ParseOrgEscalateNote decodes the typed escalation prefix. The first closing
 // bracket ends the key block, so brackets in the question are preserved.
 func ParseOrgEscalateNote(body string) (from, to, wf, question string, ok bool) {
-	if !strings.HasPrefix(body, OrgEscalatePrefix) {
+	values, question, ok := parseAddressedOrgNote("escalate", body)
+	if !ok || len(values) != 3 {
 		return "", "", "", "", false
-	}
-	end := strings.IndexByte(body, ']')
-	if end < 0 || end == len(OrgEscalatePrefix)-1 || end+1 >= len(body) || body[end+1] != ' ' {
-		return "", "", "", "", false
-	}
-	fields := strings.Fields(body[len(OrgEscalatePrefix):end])
-	if len(fields) != 3 {
-		return "", "", "", "", false
-	}
-	values := make(map[string]string, 3)
-	for _, field := range fields {
-		key, value, hasValue := strings.Cut(field, "=")
-		if !hasValue || (key != "to" && key != "from" && key != "wf") || !validOrgEscalateField(value) {
-			return "", "", "", "", false
-		}
-		if _, duplicate := values[key]; duplicate {
-			return "", "", "", "", false
-		}
-		values[key] = value
 	}
 	from, to, wf = values["from"], values["to"], values["wf"]
-	question = body[end+2:]
 	if from == "" || to == "" || wf == "" || strings.TrimSpace(question) == "" {
 		return "", "", "", "", false
 	}
@@ -57,36 +37,19 @@ func FormatOrgEscalateResolvedNote(escalationNoteID int64, resolvedBy string, an
 	if escalationNoteID <= 0 || !validOrgEscalateField(resolvedBy) {
 		return ""
 	}
-	body := OrgEscalateResolvedPrefix + "id=" + strconv.FormatInt(escalationNoteID, 10) + " by=" + resolvedBy
+	fields := []addressedOrgNoteField{{key: "id", value: strconv.FormatInt(escalationNoteID, 10)}, {key: "by", value: resolvedBy}}
 	if answerNoteID > 0 {
-		body += " note=" + strconv.FormatInt(answerNoteID, 10)
+		fields = append(fields, addressedOrgNoteField{key: "note", value: strconv.FormatInt(answerNoteID, 10)})
 	}
-	return body + "] resolved"
+	return formatAddressedOrgNote("escalate-resolved", fields, "resolved")
 }
 
 // ParseOrgEscalateResolvedNote decodes an escalation resolution marker.
 func ParseOrgEscalateResolvedNote(body string) (escalationNoteID int64, resolvedBy string, answerNoteID int64, ok bool) {
-	if !strings.HasPrefix(body, OrgEscalateResolvedPrefix) {
+	values, content, ok := parseAddressedOrgNote("escalate-resolved", body)
+	if !ok || content != "resolved" || len(values) < 2 || len(values) > 3 ||
+		(len(values) == 3 && values["note"] == "") {
 		return 0, "", 0, false
-	}
-	end := strings.IndexByte(body, ']')
-	if end < 0 || body[end:] != "] resolved" {
-		return 0, "", 0, false
-	}
-	fields := strings.Fields(body[len(OrgEscalateResolvedPrefix):end])
-	if len(fields) < 2 || len(fields) > 3 {
-		return 0, "", 0, false
-	}
-	values := make(map[string]string, 3)
-	for _, field := range fields {
-		key, value, hasValue := strings.Cut(field, "=")
-		if !hasValue || (key != "id" && key != "by" && key != "note") || value == "" {
-			return 0, "", 0, false
-		}
-		if _, duplicate := values[key]; duplicate {
-			return 0, "", 0, false
-		}
-		values[key] = value
 	}
 	if !validOrgEscalateField(values["by"]) || values["id"] == "" {
 		return 0, "", 0, false

--- a/internal/workflow/org_handoff.go
+++ b/internal/workflow/org_handoff.go
@@ -1,33 +1,19 @@
 package workflow
 
-import "strings"
-
 const OrgHandoffPrefix = "[org:handoff "
 
 // FormatOrgHandoffNote encodes a role-session handoff in the durable workflow
 // journal. Invalid delimiter-bearing roles or empty notes return an empty body.
 func FormatOrgHandoffNote(role, note string) string {
-	if !validOrgEscalateField(role) || strings.TrimSpace(note) == "" {
-		return ""
-	}
-	return OrgHandoffPrefix + "role=" + role + "] " + note
+	return formatAddressedOrgNote("handoff", []addressedOrgNoteField{{key: "role", value: role}}, note)
 }
 
 // ParseOrgHandoffNote decodes the typed handoff prefix. The first closing
 // bracket ends the header, so brackets in the handoff text are preserved.
 func ParseOrgHandoffNote(body string) (role, handoff string, ok bool) {
-	if !strings.HasPrefix(body, OrgHandoffPrefix) {
+	values, handoff, ok := parseAddressedOrgNote("handoff", body)
+	if !ok || handoff == "" || len(values) != 1 || values["role"] == "" {
 		return "", "", false
 	}
-	end := strings.IndexByte(body, ']')
-	if end < 0 || end == len(OrgHandoffPrefix)-1 || end+1 >= len(body) || body[end+1] != ' ' {
-		return "", "", false
-	}
-	header := body[len(OrgHandoffPrefix):end]
-	key, value, hasValue := strings.Cut(header, "=")
-	handoff = body[end+2:]
-	if !hasValue || key != "role" || !validOrgEscalateField(value) || strings.TrimSpace(handoff) == "" {
-		return "", "", false
-	}
-	return value, handoff, true
+	return values["role"], handoff, true
 }

--- a/internal/workflow/org_note.go
+++ b/internal/workflow/org_note.go
@@ -1,0 +1,71 @@
+package workflow
+
+import "strings"
+
+type addressedOrgNoteField struct {
+	key   string
+	value string
+}
+
+func formatAddressedOrgNote(kind string, fields []addressedOrgNoteField, body string) string {
+	if !validOrgEscalateField(kind) || len(fields) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(fields))
+	seen := make(map[string]struct{}, len(fields))
+	for _, field := range fields {
+		if !validOrgEscalateField(field.key) || !validOrgEscalateField(field.value) {
+			return ""
+		}
+		if _, duplicate := seen[field.key]; duplicate {
+			return ""
+		}
+		seen[field.key] = struct{}{}
+		parts = append(parts, field.key+"="+field.value)
+	}
+	note := "[org:" + kind + " " + strings.Join(parts, " ") + "]"
+	if body == "" {
+		return note
+	}
+	if strings.TrimSpace(body) == "" {
+		return ""
+	}
+	return note + " " + body
+}
+
+func parseAddressedOrgNote(kind, body string) (map[string]string, string, bool) {
+	if !validOrgEscalateField(kind) {
+		return nil, "", false
+	}
+	prefix := "[org:" + kind + " "
+	if !strings.HasPrefix(body, prefix) {
+		return nil, "", false
+	}
+	end := strings.IndexByte(body, ']')
+	if end < 0 || end == len(prefix)-1 {
+		return nil, "", false
+	}
+	content := ""
+	if end+1 < len(body) {
+		if body[end+1] != ' ' {
+			return nil, "", false
+		}
+		content = body[end+2:]
+		if strings.TrimSpace(content) == "" {
+			return nil, "", false
+		}
+	}
+	fields := strings.Fields(body[len(prefix):end])
+	values := make(map[string]string, len(fields))
+	for _, field := range fields {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok || !validOrgEscalateField(key) || !validOrgEscalateField(value) {
+			return nil, "", false
+		}
+		if _, duplicate := values[key]; duplicate {
+			return nil, "", false
+		}
+		values[key] = value
+	}
+	return values, content, true
+}

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1384,10 +1384,12 @@ exact acknowledgment command. With no matching directive rule, the note and
 pending outbox row remain durable and the drain stays config-inert.
 
 `gitmoot org directive ack <id> [--by <role>] [--home <dir>]` is restricted to
-the addressed target and records receipt, not completion. `gitmoot org
-directive cancel <id> [--by <role>] [--home <dir>]` is restricted to the
-sender. Both append typed markers to the directive's workflow journal;
-completion tracking belongs to the later directive-ledger slice.
+the addressed target or one of its configured ancestors and records receipt,
+not completion. `gitmoot org directive cancel <id> [--by <role>] [--home
+<dir>]` is restricted to the sender. Both commands require an acting identity
+from `--by` or `GITMOOT_ORG_ROLE`; missing identity fails closed. They append
+typed markers to the directive's workflow journal; completion tracking belongs
+to the later directive-ledger slice.
 
 Event-rule wakes are separately opt-in:
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1231,7 +1231,7 @@ claimed by any role; each failure includes category counts and a reason.
 
 `gitmoot org seat add <name> --pane <label> [--home DIR]` claims the one live
 Herdr pane with that exact label, writes or repairs the role's `pane` binding,
-and installs addressed `reply`, `blocked`, and `escalation` routes with stable
+and installs addressed `reply`, `blocked`, `directive`, and `escalation` routes with stable
 IDs `org-seat-<name>-<kind>`. Duplicate labels hard-fail instead of choosing a
 pane. New child seats inherit the `owner` role's scope and parent; an empty
 registry must add `owner` first. Re-running the command repairs missing owned
@@ -1247,7 +1247,7 @@ unreadable branch state also fails closed. A safe removal deletes the role and
 all of its wake routes, closes the pane, and then runs the same reality
 validation. Roles that still parent another role cannot be removed.
 
-The three provisioned routes are enabled, addressed, and have an empty match
+The four provisioned routes are enabled, addressed, and have an empty match
 filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;
 this is destructive and re-running `seat add` recreates it. There is currently
 no non-destructive event-rule disable verb.
@@ -1374,6 +1374,21 @@ escalation with no identifiable asker still resolves, prints a warning, and
 records no invented target. Resolved escalations are omitted from org dashboard
 projections while the original journal entry remains intact.
 
+`gitmoot org directive send --to <role> --workflow <label> (--stdin | -F
+<file> | <text>) [--home <dir>]` records a typed, downward-only assignment from
+the acting `GITMOOT_ORG_ROLE`. The sender must be an ancestor of the target;
+peer, upward, and same-role directives fail closed. The note and its pending
+`directive:<role>` wake obligation commit atomically, separately from reply
+coalescing. A directive rule wakes the target with the directive note ID and
+exact acknowledgment command. With no matching directive rule, the note and
+pending outbox row remain durable and the drain stays config-inert.
+
+`gitmoot org directive ack <id> [--by <role>] [--home <dir>]` is restricted to
+the addressed target and records receipt, not completion. `gitmoot org
+directive cancel <id> [--by <role>] [--home <dir>]` is restricted to the
+sender. Both append typed markers to the directive's workflow journal;
+completion tracking belongs to the later directive-ledger slice.
+
 Event-rule wakes are separately opt-in:
 
 ```sh
@@ -1381,6 +1396,7 @@ gitmoot org events rule add --on attention --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
+gitmoot org events rule add --on directive --wake maintainer
 gitmoot org events rule add --on reply --wake operator --scope observer
 gitmoot org events rule list
 gitmoot org events rule set-scope --home /alternate/home <rule-id> observer
@@ -1388,7 +1404,7 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 ```
 
 `--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, or `reply`. `pane_input_pending` matches the
+`recycle-overdue`, `pane_input_pending`, `reply`, or `directive`. `pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1184,7 +1184,7 @@ at enqueue.
 
 `gitmoot org seat add <name> --pane <label> [--home DIR]` claims the one live
 Herdr pane with that exact label, writes or repairs the role's `pane` binding,
-and installs addressed `reply`, `blocked`, and `escalation` routes with stable
+and installs addressed `reply`, `blocked`, `directive`, and `escalation` routes with stable
 IDs `org-seat-<name>-<kind>`. Duplicate labels hard-fail instead of choosing a
 pane. New child seats inherit the `owner` role's scope and parent; an empty
 registry must add `owner` first. Re-running the command repairs missing owned
@@ -1200,7 +1200,7 @@ unreadable branch state also fails closed. A safe removal deletes the role and
 all of its wake routes, closes the pane, and then runs the same reality
 validation. Roles that still parent another role cannot be removed.
 
-The three provisioned routes are enabled, addressed, and have an empty match
+The four provisioned routes are enabled, addressed, and have an empty match
 filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;
 this is destructive and re-running `seat add` recreates it. There is currently
 no non-destructive event-rule disable verb.
@@ -1242,6 +1242,19 @@ escalation with no identifiable asker still resolves, prints a warning, and
 records no invented target. Resolved escalations are omitted from org dashboard
 projections while the original journal entry remains intact.
 
+`gitmoot org directive send --to <role> --workflow <label> (--stdin | -F
+<file> | <text>) [--home <dir>]` writes a typed downward assignment from
+`GITMOOT_ORG_ROLE`. The sender must be an ancestor of the target; peer, upward,
+and same-role sends are refused. Its note and pending `directive:<role>` wake
+obligation commit atomically and never share reply coalescing. With no matching
+directive rule, the durable row stays pending without making the drain
+unhealthy.
+
+`gitmoot org directive ack <id> [--by <role>] [--home <dir>]` is restricted to
+the addressed target and records receipt, not completion. `gitmoot org
+directive cancel <id> [--by <role>] [--home <dir>]` is restricted to the sender.
+Both append typed markers to the directive's workflow journal.
+
 Event-rule wakes are separately opt-in:
 
 ```sh
@@ -1249,6 +1262,7 @@ gitmoot org events rule add --on attention --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
+gitmoot org events rule add --on directive --wake maintainer
 gitmoot org events rule add --on reply --wake operator --scope observer
 gitmoot org events rule list
 gitmoot org events rule set-scope --home /alternate/home <rule-id> observer
@@ -1256,7 +1270,7 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 ```
 
 `--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, or `reply`. `pane_input_pending` matches the
+`recycle-overdue`, `pane_input_pending`, `reply`, or `directive`. `pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1251,9 +1251,11 @@ directive rule, the durable row stays pending without making the drain
 unhealthy.
 
 `gitmoot org directive ack <id> [--by <role>] [--home <dir>]` is restricted to
-the addressed target and records receipt, not completion. `gitmoot org
-directive cancel <id> [--by <role>] [--home <dir>]` is restricted to the sender.
-Both append typed markers to the directive's workflow journal.
+the addressed target or one of its configured ancestors and records receipt,
+not completion. `gitmoot org directive cancel <id> [--by <role>] [--home
+<dir>]` is restricted to the sender. Both commands require an acting identity
+from `--by` or `GITMOOT_ORG_ROLE`; missing identity fails closed. They append
+typed markers to the directive's workflow journal.
 
 Event-rule wakes are separately opt-in:
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11228,10 +11228,12 @@ exact acknowledgment command. With no matching directive rule, the note and
 pending outbox row remain durable and the drain stays config-inert.
 
 `gitmoot org directive ack <id> [--by <role>] [--home <dir>]` is restricted to
-the addressed target and records receipt, not completion. `gitmoot org
-directive cancel <id> [--by <role>] [--home <dir>]` is restricted to the
-sender. Both append typed markers to the directive's workflow journal;
-completion tracking belongs to the later directive-ledger slice.
+the addressed target or one of its configured ancestors and records receipt,
+not completion. `gitmoot org directive cancel <id> [--by <role>] [--home
+<dir>]` is restricted to the sender. Both commands require an acting identity
+from `--by` or `GITMOOT_ORG_ROLE`; missing identity fails closed. They append
+typed markers to the directive's workflow journal; completion tracking belongs
+to the later directive-ledger slice.
 
 Event-rule wakes are separately opt-in:
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11075,7 +11075,7 @@ claimed by any role; each failure includes category counts and a reason.
 
 `gitmoot org seat add <name> --pane <label> [--home DIR]` claims the one live
 Herdr pane with that exact label, writes or repairs the role's `pane` binding,
-and installs addressed `reply`, `blocked`, and `escalation` routes with stable
+and installs addressed `reply`, `blocked`, `directive`, and `escalation` routes with stable
 IDs `org-seat-<name>-<kind>`. Duplicate labels hard-fail instead of choosing a
 pane. New child seats inherit the `owner` role's scope and parent; an empty
 registry must add `owner` first. Re-running the command repairs missing owned
@@ -11091,7 +11091,7 @@ unreadable branch state also fails closed. A safe removal deletes the role and
 all of its wake routes, closes the pane, and then runs the same reality
 validation. Roles that still parent another role cannot be removed.
 
-The three provisioned routes are enabled, addressed, and have an empty match
+The four provisioned routes are enabled, addressed, and have an empty match
 filter. Remove one by its stable ID with `org events rule rm` to quiet that kind;
 this is destructive and re-running `seat add` recreates it. There is currently
 no non-destructive event-rule disable verb.
@@ -11218,6 +11218,21 @@ escalation with no identifiable asker still resolves, prints a warning, and
 records no invented target. Resolved escalations are omitted from org dashboard
 projections while the original journal entry remains intact.
 
+`gitmoot org directive send --to <role> --workflow <label> (--stdin | -F
+<file> | <text>) [--home <dir>]` records a typed, downward-only assignment from
+the acting `GITMOOT_ORG_ROLE`. The sender must be an ancestor of the target;
+peer, upward, and same-role directives fail closed. The note and its pending
+`directive:<role>` wake obligation commit atomically, separately from reply
+coalescing. A directive rule wakes the target with the directive note ID and
+exact acknowledgment command. With no matching directive rule, the note and
+pending outbox row remain durable and the drain stays config-inert.
+
+`gitmoot org directive ack <id> [--by <role>] [--home <dir>]` is restricted to
+the addressed target and records receipt, not completion. `gitmoot org
+directive cancel <id> [--by <role>] [--home <dir>]` is restricted to the
+sender. Both append typed markers to the directive's workflow journal;
+completion tracking belongs to the later directive-ledger slice.
+
 Event-rule wakes are separately opt-in:
 
 ```sh
@@ -11225,6 +11240,7 @@ gitmoot org events rule add --on attention --match owner/repo --wake maintainer
 gitmoot org events rule add --on blocked --repo tendwire --wake maintainer
 gitmoot org events rule add --on pane_input_pending --wake maintainer
 gitmoot org events rule add --on reply --wake maintainer
+gitmoot org events rule add --on directive --wake maintainer
 gitmoot org events rule add --on reply --wake operator --scope observer
 gitmoot org events rule list
 gitmoot org events rule set-scope --home /alternate/home <rule-id> observer
@@ -11232,7 +11248,7 @@ gitmoot org events rule rm --home /alternate/home <rule-id>
 ```
 
 `--on` accepts `escalation`, `attention`, `guard`, `job-terminal`, `blocked`,
-`recycle-overdue`, `pane_input_pending`, or `reply`. `pane_input_pending` matches the
+`recycle-overdue`, `pane_input_pending`, `reply`, or `directive`. `pane_input_pending` matches the
 `org.input_pending` event emitted when Herdr continuously reports
 `input_pending: true` for a role's pane longer than
 `[orchestrate].blocked_role_wake_after`; it re-nudges at most once per that
@@ -12660,7 +12676,7 @@ gitmoot memory ingest <path|dir> --agent NAME [--shared] [--repo owner/repo] [--
 gitmoot memory ingest sweep [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
 gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--to-shared] [--yes] [--json]
-gitmoot memory retire --provenance-prefix P [--agent NAME] [--dry-run] [--yes] [--json]
+gitmoot memory retire [--pending] --provenance-prefix P [--agent NAME] [--dry-run] [--yes] [--json]
 gitmoot memory promote --to-shared <id>... [--json]
 gitmoot memory links backfill [--dry-run] [--json]
 gitmoot memory links list <id> [--json]
@@ -12729,7 +12745,9 @@ the plan sets `retired_at` and `retired_reason` and removes the rows from FTS in
 the same transaction, so they stop being injected and exported while the audit
 rows remain. Retired keys are not resurrected by ingest or collectors on
 re-ingest; only explicit human-controlled confirmation paths may revive a retired
-key.
+key. Add `--pending` to select and remove matching pending observation rows
+instead; this mode never reads or retires confirmed memories. Without
+`--pending`, pending observations are never selected.
 
 The built-in `memory-ingest-sweep` pipeline calls
 `gitmoot memory ingest sweep --json` and then summarizes the run totals. Configure


### PR DESCRIPTION
WHAT:
DIRECTIVE-S1B: Addressed every PR #1329 finding at reviewed head dbe8e4eadbab00e32484d1640de5a94722cdf3f0. Receipt identity now fails closed, authorized ancestors may explicitly acknowledge, and both previously inert guards are load-bearing. Changes remain uncommitted for Gitmoot’s finalizer.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-e82eeb8e

RESULTS:
- Fail-before actorless receipts: TestOrgDirectiveReceiptRequiresActingRole failed with actorless ack code=0 out="acked directive 1 in workflow release/actorless\n" and actorless cancel code=0 out="canceled directive 1 in workflow release/actorless\n".
- Authorization mutant kill: disabling the ACK authorization condition failed TestOrgDirectiveAckAuthorizationAndUnackedQuery with unauthorized ack code=0 out="acked directive 1 in workflow release/ack\n".
- Public-send mutant kill: removing AddressedTarget and AddressedWakeKind failed TestDirectiveWakeOutboxIsConfigInert with pending=[]; TestOrgDirectiveReceiptRequiresActingRole and both subtests still passed.
- Upward-policy mutant kill: allowing upward sends while still refusing peers failed TestOrgDirectiveSendRefusesUpward with upward send code=0 out="sent directive 1 from worker to owner in workflow release/upward\n"; the peer/body-source sibling test and all three subtests still passed.
- Final targeted command: go test -count=1 -run '^(TestOrgDirective.*|TestDirectiveWakeOutboxIsConfigInert)$' ./internal/cli/ — passed.
- npm run build:llms — passed.
- git diff --check — passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-e82eeb8e

AGENTS:
- wave-impl-b

RAW FINAL REVIEW OUTPUT:
````text
DIRECTIVE-S1B: Addressed every PR #1329 finding at reviewed head dbe8e4eadbab00e32484d1640de5a94722cdf3f0. Receipt identity now fails closed, authorized ancestors may explicitly acknowledge, and both previously inert guards are load-bearing. Changes remain uncommitted for Gitmoot’s finalizer.
````
