### PR TITLE
Gitmoot: BLOCKED-WAKE BROADCAST FIX (from JARVIS — read gitmoot

### DIFF
--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -441,6 +441,7 @@ func emitInputPendingEpisode(ctx context.Context, store *db.Store, sink events.S
 	detail := fmt.Sprintf("role %s input pending %s (since %s)", role, pendingFor.Round(time.Second), pendingSince.UTC().Format(time.RFC3339))
 	ev := events.NewEvent(events.EventOrgInputPending, subjectID, subjectID, "", string(org.StateInputPending), detail, now, workflow.RedactCommentText)
 	ev.Cause = "input_pending_since"
+	ev.WakeTargetRole = role
 	events.EmitEvent(ctx, sink, ev)
 	return nil
 }

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -716,6 +716,17 @@ func loadMergeGateOrgConfig(home string) (config.OrgConfig, bool) {
 }
 
 func mergeGateEscalationFrom(cfg config.OrgConfig, repo string) string {
+	if owner, ok := repoOrgOwner(cfg, repo); ok {
+		return owner
+	}
+	parts := strings.Split(strings.TrimSpace(repo), "/")
+	if len(parts) == 2 && parts[1] != "" {
+		return parts[1]
+	}
+	return "gitmoot"
+}
+
+func repoOrgOwner(cfg config.OrgConfig, repo string) (string, bool) {
 	best, bestDepth := "", -1
 	for _, role := range cfg.Roles() {
 		if config.ScopeMatches(role.Scope, repo) {
@@ -724,14 +735,7 @@ func mergeGateEscalationFrom(cfg config.OrgConfig, repo string) string {
 			}
 		}
 	}
-	if best != "" {
-		return best
-	}
-	parts := strings.Split(strings.TrimSpace(repo), "/")
-	if len(parts) == 2 && parts[1] != "" {
-		return parts[1]
-	}
-	return "gitmoot"
+	return best, best != ""
 }
 
 func nativeMergeGateDisabled() bool {

--- a/internal/cli/doctor_event_observers.go
+++ b/internal/cli/doctor_event_observers.go
@@ -23,10 +23,33 @@ type wakeTargetRoleProducer struct {
 
 var wakeTargetRoleProducers = []wakeTargetRoleProducer{
 	{
+		File:     "internal/cli/event_rule_sink.go",
+		Function: "addressBlockedEvent",
+		Kinds:    blockedWakeDirectedKinds,
+	},
+	{
+		File:     "internal/cli/event_sink.go",
+		Function: "emitDaemonTerminalEvent",
+		Kinds:    blockedWakeDirectedKinds,
+	},
+	{
+		File:     "internal/cli/blocked_since.go",
+		Function: "emitInputPendingEpisode",
+		Kinds:    inputPendingDirectedKinds,
+	},
+	{
 		File:     "internal/cli/reply_wake_outbox.go",
 		Function: "wakeOutboxEvent",
 		Kinds:    wakeOutboxDirectedKinds,
 	},
+}
+
+func blockedWakeDirectedKinds() []string {
+	return []string{db.WakeOutboxKindBlocked}
+}
+
+func inputPendingDirectedKinds() []string {
+	return []string{"pane_input_pending"}
 }
 
 func eventObserverDoctorCheck(paths config.Paths) (doctor.Check, bool) {

--- a/internal/cli/doctor_json_test.go
+++ b/internal/cli/doctor_json_test.go
@@ -83,9 +83,9 @@ func TestDoctorWarnsWhenDirectedEventKindHasNoObserverRule(t *testing.T) {
 	}
 	detail := check["detail"].(string)
 	if check["status"] != "warn" ||
-		!strings.Contains(detail, "blocked, escalation") ||
-		strings.Contains(detail, "blocked, escalation, reply") {
-		t.Fatalf("event observers check = %#v, want blocked and escalation warning with reply covered", check)
+		!strings.Contains(detail, "blocked, escalation, pane_input_pending") ||
+		strings.Contains(detail, "reply") {
+		t.Fatalf("event observers check = %#v, want blocked, escalation, and pane_input_pending warning with reply covered", check)
 	}
 	t.Logf("reviewer probe: warned=true detail=%q", detail)
 
@@ -105,6 +105,12 @@ func TestDoctorWarnsWhenDirectedEventKindHasNoObserverRule(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if err := store.AddEventRule(context.Background(), db.EventRule{
+		ID: "observer-pane-input", OnKind: "pane_input_pending", WakeRole: "owner",
+		Scope: db.EventRuleScopeObserver, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if err := store.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -119,6 +125,7 @@ func TestBuildEventObserverDoctorCheckWarnsForEachMissingDirectedKind(t *testing
 		db.WakeOutboxKindReply,
 		db.WakeOutboxKindBlocked,
 		db.WakeOutboxKindEscalation,
+		"pane_input_pending",
 	}
 	for _, missingKind := range kinds {
 		t.Run(missingKind, func(t *testing.T) {

--- a/internal/cli/event_rule_sink.go
+++ b/internal/cli/event_rule_sink.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/events"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 const (
@@ -47,6 +48,7 @@ func (s *eventRuleSink) Emit(ctx context.Context, event events.Event) {
 	if s == nil {
 		return
 	}
+	event = s.addressBlockedEvent(ctx, event)
 	events.EmitEvent(ctx, s.inner, event)
 	if s.store == nil {
 		return
@@ -119,7 +121,7 @@ func partitionDurableWakeRules(
 	event events.Event,
 ) (targetRoles []string, remaining []db.EventRule) {
 	for _, rule := range rules {
-		if !rule.Enabled || !containsEventRuleKind(kinds, rule.OnKind) || !eventRuleMatches(rule.MatchFilter, event) {
+		if !rule.Enabled || !containsEventRuleKind(kinds, rule.OnKind) || !eventRuleMatches(rule.MatchFilter, event) || !eventRuleMatchesAddressee(rule, event) {
 			continue
 		}
 		if strings.EqualFold(strings.TrimSpace(rule.OnKind), wakeKind) {
@@ -190,17 +192,13 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 		return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, "organization registry unavailable", errors.New("organization registry unavailable"))
 	}
 	isReply := event.Type == events.EventOrgReply
-	hasAddressee := strings.TrimSpace(event.WakeTargetRole) != ""
 	replyHandled := false
 	addressedReplyHandled := false
 	for _, rule := range rules {
-		if !rule.Enabled || !containsEventRuleKind(kinds, rule.OnKind) || !eventRuleMatches(rule.MatchFilter, event) {
+		if !rule.Enabled || !containsEventRuleKind(kinds, rule.OnKind) || !eventRuleMatches(rule.MatchFilter, event) || !eventRuleMatchesAddressee(rule, event) {
 			continue
 		}
 		observer := rule.Scope == db.EventRuleScopeObserver
-		if hasAddressee && !observer && !strings.EqualFold(strings.TrimSpace(rule.WakeRole), strings.TrimSpace(event.WakeTargetRole)) {
-			continue
-		}
 		// Preserve the existing one-attempt-per-target behavior for duplicate
 		// addressed reply rules while allowing every observer rule to see the
 		// directed event independently.
@@ -213,6 +211,9 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 				slog.Warn("org event unresolved wake counter failed", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "error", err)
 			}
 			slog.Warn("org event wake skipped", "rule_id", rule.ID, "role", rule.WakeRole, "job_id", event.JobID, "reason", "role pane binding unresolved")
+			if err := s.finishWakeOutbox(ctx, event, db.WakeOutboxStateStalled, "role pane binding unresolved"); err != nil {
+				return err
+			}
 			continue
 		}
 		prompt := eventRuleWakePrompt(rule.OnKind, event)
@@ -273,6 +274,47 @@ func (s *eventRuleSink) evaluateRules(ctx context.Context, event events.Event, r
 		return s.completeWakeOutbox(ctx, event, db.WakeOutboxStateFailed, "no matching reply rule or role binding", errors.New("no matching reply rule or role binding"))
 	}
 	return nil
+}
+
+// eventRuleMatchesAddressee is the single scope gate shared by durable enqueue
+// and live evaluation. Addressed rules require positive target evidence;
+// observer rules deliberately retain fleet-wide oversight for address-less and
+// directed events alike.
+func eventRuleMatchesAddressee(rule db.EventRule, event events.Event) bool {
+	if rule.Scope == db.EventRuleScopeObserver {
+		return true
+	}
+	target := strings.TrimSpace(event.WakeTargetRole)
+	return target != "" && strings.EqualFold(strings.TrimSpace(rule.WakeRole), target)
+}
+
+// addressBlockedEvent enriches every blocked event at the event-sink source
+// boundary before webhook fanout or durable routing. Persisted job attribution
+// is the strongest ownership evidence; synthesized blocked-since events fall
+// back to the most-specific org role scoped to the event repository.
+func (s *eventRuleSink) addressBlockedEvent(ctx context.Context, event events.Event) events.Event {
+	if event.Type != events.EventJobBlocked || strings.TrimSpace(event.WakeTargetRole) != "" {
+		return event
+	}
+	targetRole := ""
+	if s.store != nil && strings.TrimSpace(event.JobID) != "" {
+		if job, err := s.store.GetJob(ctx, event.JobID); err == nil {
+			if payload, err := daemonJobPayload(job); err == nil {
+				if role := workflow.NormalizeActingOrgRole(payload.ActingOrgRole); role != "" {
+					targetRole = role
+				}
+			}
+		}
+	}
+	if targetRole == "" {
+		if cfg, ok := s.loadOrgConfig(); ok {
+			targetRole, _ = repoOrgOwner(cfg, event.Repo)
+		}
+	}
+	if targetRole != "" {
+		event.WakeTargetRole = targetRole
+	}
+	return event
 }
 
 func recordUnresolvedRoleWake(ctx context.Context, store *db.Store, role string) error {

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/events"
+	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
 type fakeEventWake struct {
@@ -102,7 +103,7 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 
 func TestWakeTargetRoleHasExactlyOneProductionWriteInWakeOutboxEvent(t *testing.T) {
 	writes := productionWakeTargetRoleWrites(t)
-	if got, want := fmt.Sprint(writes), "[internal/cli/reply_wake_outbox.go:wakeOutboxEvent]"; got != want {
+	if got, want := fmt.Sprint(writes), "[internal/cli/blocked_since.go:emitInputPendingEpisode internal/cli/event_rule_sink.go:addressBlockedEvent internal/cli/event_sink.go:emitDaemonTerminalEvent internal/cli/reply_wake_outbox.go:wakeOutboxEvent]"; got != want {
 		t.Fatalf("production WakeTargetRole writes = %s, want %s", got, want)
 	}
 	registryWrites := make([]wakeTargetRoleWrite, 0, len(wakeTargetRoleProducers))
@@ -341,6 +342,121 @@ pane="w1:p3"
 	}
 }
 
+func TestAddresslessBlockedWakeMatchesObserversOnly(t *testing.T) {
+	store := daemonWorkerStore(t)
+	ctx := context.Background()
+	for _, rule := range []db.EventRule{
+		{ID: "addressed-uninvolved", OnKind: "blocked", WakeRole: "uninvolved", Scope: db.EventRuleScopeAddressed, Enabled: true},
+		{ID: "observer-jarvis", OnKind: "blocked", WakeRole: "jarvis", Scope: db.EventRuleScopeObserver, Enabled: true},
+		{ID: "observer-audit", OnKind: "blocked", WakeRole: "audit", Scope: db.EventRuleScopeObserver, Enabled: true},
+	} {
+		if err := store.AddEventRule(ctx, rule); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	(&eventRuleSink{store: store}).Emit(ctx, events.Event{
+		Type: events.EventJobBlocked, Cause: "blocked_since", JobID: "task-without-owner",
+	})
+
+	if got, want := pendingWakeTargetRoles(t, store), []string{"audit", "jarvis"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("address-less blocked wake targets = %v, want observer roles %v", got, want)
+	}
+}
+
+func TestBlockedWakeTargetsRecordedOrResolvedOwnerPlusObservers(t *testing.T) {
+	tests := []struct {
+		name        string
+		repo        string
+		jobRole     string
+		wantRoles   []string
+		wantTarget  string
+		useTerminal bool
+	}{
+		{name: "terminal uses recorded workflow role", repo: "gitmoot/gitmoot", jobRole: "lane", useTerminal: true, wantRoles: []string{"jarvis", "lane"}, wantTarget: "lane"},
+		{name: "blocked-since resolves repo owner", repo: "gitmoot/gitmoot", wantRoles: []string{"jarvis", "lane"}, wantTarget: "lane"},
+		{name: "repo without owner is observers only", repo: "unknown/repo", wantRoles: []string{"jarvis"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			paths := config.PathsForHome(home)
+			if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			const orgConfig = `
+[org.roles."owner"]
+scope=["gitmoot/*", "other/*", "oversight/*"]
+pane="w1:p1"
+[org.roles."lane"]
+parent="owner"
+scope=["gitmoot/gitmoot"]
+pane="w1:p2"
+[org.roles."other"]
+parent="owner"
+scope=["other/*"]
+pane="w1:p3"
+[org.roles."jarvis"]
+parent="owner"
+scope=["oversight/*"]
+pane="w1:p4"
+`
+			if err := os.WriteFile(paths.ConfigFile, []byte(orgConfig), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			store, err := db.Open(paths.Database)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			ctx := context.Background()
+			for _, rule := range []db.EventRule{
+				{ID: "addressed-lane", OnKind: "blocked", WakeRole: "lane", Scope: db.EventRuleScopeAddressed, Enabled: true},
+				{ID: "addressed-other", OnKind: "blocked", WakeRole: "other", Scope: db.EventRuleScopeAddressed, Enabled: true},
+				{ID: "observer-jarvis", OnKind: "blocked", WakeRole: "jarvis", Scope: db.EventRuleScopeObserver, Enabled: true},
+			} {
+				if err := store.AddEventRule(ctx, rule); err != nil {
+					t.Fatal(err)
+				}
+			}
+			recorded := &recordingSink{}
+			sink := &eventRuleSink{inner: recorded, store: store, home: home}
+			if test.useTerminal {
+				if err := store.CreateJob(ctx, db.Job{
+					ID: "blocked-job", Agent: "worker", Type: "ask", State: string(workflow.JobBlocked),
+					Payload: mustJobPayload(t, workflow.JobPayload{Repo: test.repo, ActingOrgRole: test.jobRole}),
+				}); err != nil {
+					t.Fatal(err)
+				}
+				emitDaemonTerminalEvent(ctx, sink, store, "blocked-job", events.EventJobBlocked, string(workflow.JobBlocked), "blocked")
+			} else {
+				sink.Emit(ctx, events.Event{Type: events.EventJobBlocked, Cause: "blocked_since", JobID: "blocked-task", Repo: test.repo})
+			}
+			if got := pendingWakeTargetRoles(t, store); !reflect.DeepEqual(got, test.wantRoles) {
+				t.Fatalf("blocked wake targets = %v, want %v", got, test.wantRoles)
+			}
+			gotEvents := recorded.byType(events.EventJobBlocked)
+			if len(gotEvents) != 1 || gotEvents[0].WakeTargetRole != test.wantTarget {
+				t.Fatalf("blocked event target = %+v, want %q", gotEvents, test.wantTarget)
+			}
+		})
+	}
+}
+
+func pendingWakeTargetRoles(t *testing.T, store *db.Store) []string {
+	t.Helper()
+	rows, err := store.ListWakeOutbox(context.Background(), db.WakeOutboxStatePending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roles := make([]string, 0, len(rows))
+	for _, row := range rows {
+		roles = append(roles, row.TargetRole)
+	}
+	sort.Strings(roles)
+	return roles
+}
+
 func TestReplyObserverDoesNotConsumeAddressedTargetAttempt(t *testing.T) {
 	home := t.TempDir()
 	paths := config.PathsForHome(home)
@@ -416,7 +532,7 @@ func TestEventRuleEvaluatorResolvesPaneAndWakes(t *testing.T) {
 	}
 	wake := &fakeEventWake{}
 	sink := &eventRuleSink{store: store, home: home, wake: wake}
-	sink.evaluate(context.Background(), events.Event{Type: events.EventJobNeedsAttention, Cause: "ask_gate", Repo: "acme/widget", JobID: "job-1", Detail: "Please choose"})
+	sink.evaluate(context.Background(), events.Event{Type: events.EventJobNeedsAttention, Cause: "ask_gate", Repo: "acme/widget", JobID: "job-1", Detail: "Please choose", WakeTargetRole: "owner"})
 	if wake.availableCalls != 1 || wake.pane != "w1:p1" || wake.until != "" {
 		t.Fatalf("wake=%+v", wake)
 	}
@@ -445,7 +561,7 @@ func TestEventRuleWakeStallIncrementsAndDeliveryResetsCounter(t *testing.T) {
 	}
 	wake := &fakeEventWake{stalled: true}
 	sink := &eventRuleSink{store: store, home: home, wake: wake}
-	event := events.Event{Type: events.EventJobNeedsAttention, Cause: "ask_gate", JobID: "job-counter"}
+	event := events.Event{Type: events.EventJobNeedsAttention, Cause: "ask_gate", JobID: "job-counter", WakeTargetRole: "owner"}
 	sink.evaluate(ctx, event)
 	misses, err := store.ListRoleMissedWakes(ctx)
 	if err != nil || len(misses) != 1 || misses[0].Role != "owner" || misses[0].Consecutive != 1 {
@@ -480,7 +596,7 @@ func TestEventRuleEvaluatorResolvesPaneLabel(t *testing.T) {
 	}
 	wake := &fakeEventWake{labelToPane: map[string]string{"coordinator-a": "w2:p5"}}
 	sink := &eventRuleSink{store: store, home: home, wake: wake}
-	sink.evaluate(context.Background(), events.Event{Type: events.EventJobBlocked, Cause: "merge_guard", JobID: "job-9"})
+	sink.evaluate(context.Background(), events.Event{Type: events.EventJobBlocked, Cause: "merge_guard", JobID: "job-9", WakeTargetRole: "owner"})
 	if wake.pane != "w2:p5" {
 		t.Fatalf("label did not resolve to live pane id: %+v", wake)
 	}
@@ -508,7 +624,7 @@ func TestEventRuleEvaluatorCountsUnresolvedRoleBinding(t *testing.T) {
 	wake := &fakeEventWake{}
 	sink := &eventRuleSink{store: store, home: home, wake: wake}
 	if err := sink.evaluate(context.Background(), events.Event{
-		Type: events.EventJobNeedsAttention, Cause: "ask_gate", JobID: "job-unresolved",
+		Type: events.EventJobNeedsAttention, Cause: "ask_gate", JobID: "job-unresolved", WakeTargetRole: "owner",
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -521,6 +637,47 @@ func TestEventRuleEvaluatorCountsUnresolvedRoleBinding(t *testing.T) {
 	}
 	if wake.promptCalls != 0 {
 		t.Fatalf("unresolved binding prompted %d times", wake.promptCalls)
+	}
+}
+
+func TestDurableWakeWithUnresolvedPaneParksAsStalled(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[org.roles.\"owner\"]\nscope=[\"*\"]\npane=\"missing-pane\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+	if err := store.AddEventRule(ctx, db.EventRule{
+		ID: "blocked-owner", OnKind: "blocked", WakeRole: "owner", Scope: db.EventRuleScopeAddressed, Enabled: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	ruleSink := &eventRuleSink{store: store, home: home, wake: &fakeEventWake{}}
+	ruleSink.Emit(ctx, events.Event{
+		Type: events.EventJobBlocked, Cause: "blocked_since", JobID: "blocked-task", Repo: "owner/repo", WakeTargetRole: "owner",
+	})
+	if err := drainReplyWakeAfterAllRowsAreDueResult(t, store, synchronousEventRuleTestSink{sink: ruleSink}); err != nil {
+		t.Fatalf("drain unresolved pane wake: %v", err)
+	}
+	stalled, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateStalled)
+	if err != nil || len(stalled) != 1 || stalled[0].TargetRole != "owner" || stalled[0].LastError != "role pane binding unresolved" {
+		t.Fatalf("stalled unresolved wake = %+v, err=%v", stalled, err)
+	}
+	failed, err := store.ListWakeOutbox(ctx, db.WakeOutboxStateFailed)
+	if err != nil || len(failed) != 0 {
+		t.Fatalf("failed unresolved wake rows = %+v, err=%v", failed, err)
+	}
+	missed, err := store.ListRoleMissedWakes(ctx)
+	if err != nil || len(missed) != 1 || missed[0].Role != "owner" || missed[0].Consecutive != 1 {
+		t.Fatalf("unresolved wake counter = %+v, err=%v", missed, err)
 	}
 }
 
@@ -596,7 +753,7 @@ func TestEventRuleWakeFiresEachMatchingRule(t *testing.T) {
 	}
 	wake := &fakeEventWake{}
 	sink := &eventRuleSink{store: store, home: home, wake: wake}
-	sink.evaluate(context.Background(), events.Event{Type: events.EventJobBlocked, JobID: "job-1"})
+	sink.evaluate(context.Background(), events.Event{Type: events.EventJobBlocked, JobID: "job-1", WakeTargetRole: "owner"})
 	if wake.promptCalls != 2 {
 		t.Fatalf("want a wake for each of the 2 matching rules, got %d", wake.promptCalls)
 	}

--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -195,10 +195,12 @@ func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.St
 	}
 	repo := ""
 	rootID := jobID
+	wakeTargetRole := ""
 	if store != nil {
 		if job, err := store.GetJob(ctx, jobID); err == nil {
 			if payload, perr := daemonJobPayload(job); perr == nil {
 				repo = payload.Repo
+				wakeTargetRole = workflow.NormalizeActingOrgRole(payload.ActingOrgRole)
 				if strings.TrimSpace(payload.RootJobID) != "" {
 					rootID = payload.RootJobID
 				}
@@ -217,6 +219,9 @@ func emitDaemonTerminalEvent(ctx context.Context, sink events.Sink, store *db.St
 	)
 	if len(cause) > 0 {
 		event.Cause = strings.TrimSpace(cause[0])
+	}
+	if eventType == events.EventJobBlocked && wakeTargetRole != "" {
+		event.WakeTargetRole = wakeTargetRole
 	}
 	events.EmitEvent(ctx, sink, event)
 }

--- a/internal/cli/event_sink_daemon_test.go
+++ b/internal/cli/event_sink_daemon_test.go
@@ -109,6 +109,11 @@ func TestFinishQueuedJobEmitsJobBlocked(t *testing.T) {
 	if err := store.CreateJob(ctx, db.Job{ID: "queued-job", Agent: "coord", Type: "ask", State: string(workflow.JobQueued)}); err != nil {
 		t.Fatalf("CreateJob returned error: %v", err)
 	}
+	if err := store.UpdateJobPayload(ctx, "queued-job", mustJobPayload(t, workflow.JobPayload{
+		Repo: "gitmoot/gitmoot", ActingOrgRole: "gmc-gate",
+	})); err != nil {
+		t.Fatalf("UpdateJobPayload returned error: %v", err)
+	}
 	sink := &recordingSink{}
 	worker := defaultJobWorker(store, io.Discard)
 	worker.EventSinkOverride = sink
@@ -118,6 +123,8 @@ func TestFinishQueuedJobEmitsJobBlocked(t *testing.T) {
 	}
 	if got := sink.byType(events.EventJobBlocked); len(got) != 1 {
 		t.Fatalf("job.blocked emissions = %d, want 1", len(got))
+	} else if got[0].WakeTargetRole != "gmc-gate" {
+		t.Fatalf("job.blocked wake target = %q, want recorded role gmc-gate", got[0].WakeTargetRole)
 	}
 }
 

--- a/internal/cli/reply_wake_outbox_test.go
+++ b/internal/cli/reply_wake_outbox_test.go
@@ -162,11 +162,13 @@ func TestWakeOutboxTickHealthIncludesBlockedAndEscalation(t *testing.T) {
 		events.EventJobBlocked, "job-blocked", "root-blocked", "owner/repo",
 		"blocked", "blocked", now, workflow.RedactCommentText,
 	)
+	blocked.WakeTargetRole = "owner"
 	escalation := events.NewEvent(
 		events.EventJobNeedsAttention, "job-escalated", "root-escalated", "owner/repo",
 		"awaiting_human", "answer required", now, workflow.RedactCommentText,
 	)
 	escalation.Cause = "escalation"
+	escalation.WakeTargetRole = "owner"
 	sink.Emit(ctx, blocked)
 	sink.Emit(ctx, escalation)
 

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1404,10 +1404,11 @@ emitting job. The daemon coalesces a rolling five-second window per event kind
 and role. Reply prompts carry `N new items, oldest id X`; blocked and escalation
 events retain their redacted event detail. Different event kinds never share a
 coalescing key, and a later tick flushes a quiet tail without another event.
-Rules default to `--scope addressed`: when an event names a target role, only
-the matching addressed rule receives it. During rule evaluation,
-`--scope observer` exempts a rule from that addressee gate.
-Events without a target role keep matching both scopes exactly as before.
+Rules default to `--scope addressed`: an addressed rule is eligible only when
+the event names a target role and that role matches `--wake`.
+`--scope observer` exempts a rule from the addressee gate, so observers receive
+both directed events and events without a target; address-less events never
+broadcast to addressed rules.
 Durable-outbox claim authorization is scope-blind: among enabled,
 filter-matching rules for the event's own kind, wake-role equality with the
 addressed target is the only routing condition. An observer-scoped rule is

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1272,10 +1272,11 @@ emitting job. The daemon coalesces a rolling five-second window per event kind
 and role. Reply prompts carry `N new items, oldest id X`; blocked and escalation
 events retain their redacted event detail. Different event kinds never share a
 coalescing key, and a later tick flushes a quiet tail without another event.
-Rules default to `--scope addressed`: when an event names a target role, only
-the matching addressed rule receives it. During rule evaluation,
-`--scope observer` exempts a rule from that addressee gate.
-Events without a target role keep matching both scopes exactly as before.
+Rules default to `--scope addressed`: an addressed rule is eligible only when
+the event names a target role and that role matches `--wake`.
+`--scope observer` exempts a rule from the addressee gate, so observers receive
+both directed events and events without a target; address-less events never
+broadcast to addressed rules.
 Durable-outbox claim authorization is scope-blind: among enabled,
 filter-matching rules for the event's own kind, wake-role equality with the
 addressed target is the only routing condition. An observer-scoped rule is

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11248,10 +11248,11 @@ emitting job. The daemon coalesces a rolling five-second window per event kind
 and role. Reply prompts carry `N new items, oldest id X`; blocked and escalation
 events retain their redacted event detail. Different event kinds never share a
 coalescing key, and a later tick flushes a quiet tail without another event.
-Rules default to `--scope addressed`: when an event names a target role, only
-the matching addressed rule receives it. During rule evaluation,
-`--scope observer` exempts a rule from that addressee gate.
-Events without a target role keep matching both scopes exactly as before.
+Rules default to `--scope addressed`: an addressed rule is eligible only when
+the event names a target role and that role matches `--wake`.
+`--scope observer` exempts a rule from the addressee gate, so observers receive
+both directed events and events without a target; address-less events never
+broadcast to addressed rules.
 Durable-outbox claim authorization is scope-blind: among enabled,
 filter-matching rules for the event's own kind, wake-role equality with the
 addressed target is the only routing condition. An observer-scoped rule is
@@ -12660,7 +12661,7 @@ gitmoot memory ingest <path|dir> --agent NAME [--shared] [--repo owner/repo] [--
 gitmoot memory ingest sweep [--json]
 gitmoot memory observations [--agent NAME] [--provenance-prefix P] [--json]
 gitmoot memory confirm <obs-id>... | --provenance-prefix P [--agent NAME] [--to-shared] [--yes] [--json]
-gitmoot memory retire --provenance-prefix P [--agent NAME] [--dry-run] [--yes] [--json]
+gitmoot memory retire [--pending] --provenance-prefix P [--agent NAME] [--dry-run] [--yes] [--json]
 gitmoot memory promote --to-shared <id>... [--json]
 gitmoot memory links backfill [--dry-run] [--json]
 gitmoot memory links list <id> [--json]
@@ -12729,7 +12730,9 @@ the plan sets `retired_at` and `retired_reason` and removes the rows from FTS in
 the same transaction, so they stop being injected and exported while the audit
 rows remain. Retired keys are not resurrected by ingest or collectors on
 re-ingest; only explicit human-controlled confirmation paths may revive a retired
-key.
+key. Add `--pending` to select and remove matching pending observation rows
+instead; this mode never reads or retires confirmed memories. Without
+`--pending`, pending observations are never selected.
 
 The built-in `memory-ingest-sweep` pipeline calls
 `gitmoot memory ingest sweep --json` and then summarizes the run totals. Configure


### PR DESCRIPTION
WHAT:
WAKE-FIX: Implemented fail-closed wake matching, owner-addressed blocked events, observer-only fallback, and stalled unresolved-pane delivery. HEAD remains f5858e60ff20c6363caf568cf345db1b43d3b8e7 pending finalizer commit and PR creation.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-2d221286

RESULTS:
- PASS: bounded internal/cli regression family, 11.693s.
- MUTANT FAIL: restored original address-less broadcast condition. TestAddresslessBlockedWakeMatchesObserversOnly failed: targets [audit jarvis uninvolved], want [audit jarvis].
- POLARITY MUTANT FAIL: required addressees for observers. TestAddresslessBlockedWakeMatchesObserversOnly failed: targets [], want [audit jarvis].
- SOURCE MUTANT FAIL: removed blocked-event ownership addressing. Terminal and blocked-since cases produced [jarvis], want [jarvis lane].
- PASS: npm run build:llms.
- PASS: git diff --check.
- Full suite intentionally not run per bounded-test instruction.

RISK:
Review the generated diff before merging.

TASK:
adhoc-2d221286

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
WAKE-FIX: Implemented fail-closed wake matching, owner-addressed blocked events, observer-only fallback, and stalled unresolved-pane delivery. HEAD remains f5858e60ff20c6363caf568cf345db1b43d3b8e7 pending finalizer commit and PR creation.
````
