### PR TITLE
Gitmoot: COMMS PAGE SHELL INTEGRATION (gitmoot issue 1333 —

### DIFF
--- a/internal/cli/dashboard_web.go
+++ b/internal/cli/dashboard_web.go
@@ -110,10 +110,50 @@ func newDashboardWebHandler(ds *webDataSource) http.Handler {
 const dashboardChatNavTail = `      <span style="{{ chatNavDotStyle }}"></span>
     </div>`
 
-const dashboardCommsNavItem = `    <a href="/comms" title="Org communication threads" style="display:flex;align-items:center;gap:11px;padding:9px 11px;border-radius:9px;font-size:13.5px;font-weight:500;cursor:pointer;margin-top:2px;background:transparent;color:#a8aecf;border:1px solid transparent;box-shadow:none;position:relative;text-decoration:none">
+type dashboardNavItem struct {
+	Href  string
+	Title string
+	Group string
+}
+
+var dashboardNavManifest = []dashboardNavItem{
+	{Href: "/", Title: "Overview", Group: "WORK"},
+	{Href: "/tasks", Title: "Tasks", Group: "WORK"},
+	{Href: "/workflows", Title: "Workflows", Group: "WORK"},
+	{Href: "/jobs", Title: "Jobs", Group: "WORK"},
+	{Href: "/pipelines", Title: "Pipelines", Group: "WORK"},
+	{Href: "/agents", Title: "Agents", Group: "FLEET"},
+	{Href: "/org", Title: "Org", Group: "FLEET"},
+	{Href: "/chat", Title: "Chat", Group: "FLEET"},
+	{Href: "/comms", Title: "Comms", Group: "FLEET"},
+	{Href: "/brain", Title: "Brain", Group: "INSIGHT"},
+	{Href: "/galaxy", Title: "Galaxy", Group: "INSIGHT"},
+	{Href: "/charts", Title: "Charts", Group: "INSIGHT"},
+	{Href: "/learning", Title: "Learning", Group: "INSIGHT"},
+	{Href: "/attention", Title: "Needs a human", Group: "SYSTEM"},
+	{Href: "/health", Title: "Health", Group: "SYSTEM"},
+	{Href: "/config", Title: "Config", Group: "SYSTEM"},
+}
+
+func dashboardNavItemForHref(href string) (dashboardNavItem, bool) {
+	for _, item := range dashboardNavManifest {
+		if item.Href == href {
+			return item, true
+		}
+	}
+	return dashboardNavItem{}, false
+}
+
+func dashboardCommsSPAItem() string {
+	item, ok := dashboardNavItemForHref("/comms")
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf(`    <a href="%s" title="Org communication threads" style="display:flex;align-items:center;gap:11px;padding:9px 11px;border-radius:9px;font-size:13.5px;font-weight:500;cursor:pointer;margin-top:2px;background:transparent;color:#a8aecf;border:1px solid transparent;box-shadow:none;position:relative;text-decoration:none">
       <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round" stroke-linecap="round"><path d="M4 5h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"/><path d="M9 10h11a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-3l-3 2v-2"/></svg>
-      <span style="flex:1">Comms</span>
-    </a>`
+      <span style="flex:1">%s</span>
+    </a>`, item.Href, item.Title)
+}
 
 // withDashboardCommsNav adds the gitmoot-owned Comms route to the embedded
 // dashboard module's sidebar. Comms is a standalone read-only page, so the
@@ -140,7 +180,7 @@ func withDashboardCommsNav(next http.Handler) http.Handler {
 		if status == http.StatusOK && strings.Contains(w.Header().Get("Content-Type"), "text/html") {
 			anchor := []byte(dashboardChatNavTail)
 			if bytes.Contains(body, anchor) {
-				replacement := []byte(dashboardChatNavTail + "\n" + dashboardCommsNavItem)
+				replacement := []byte(dashboardChatNavTail + "\n" + dashboardCommsSPAItem())
 				body = bytes.Replace(body, anchor, replacement, 1)
 				w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 			}

--- a/internal/cli/dashboard_web_comms.go
+++ b/internal/cli/dashboard_web_comms.go
@@ -296,59 +296,87 @@ const dashboardCommsPage = `<!doctype html>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Comms · gitmoot</title>
 <style>
-:root{color-scheme:dark;--bg:#080a10;--panel:#0f131d;--panel2:#151a27;--line:#272e3d;--text:#edf1f7;--muted:#929bae;--faint:#687185;--accent:#9ece6a;--loud:#ff9e64;--bubble:#18202e;--reply:#17271f;--shadow:0 18px 50px rgba(0,0,0,.22)}
-[data-theme="light"]{color-scheme:light;--bg:#f3f5f8;--panel:#fff;--panel2:#f8fafc;--line:#dce1e9;--text:#172033;--muted:#5e687b;--faint:#8790a0;--accent:#467a2b;--loud:#bd4b1c;--bubble:#eef3f9;--reply:#eef7ed;--shadow:0 16px 40px rgba(24,36,58,.1)}
-*{box-sizing:border-box}html,body{height:100%;margin:0}body{background:var(--bg);color:var(--text);font:14px/1.45 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;overflow:hidden}
-button,input,select{font:inherit;color:inherit}button{cursor:pointer}.shell{height:100%;display:grid;grid-template-rows:58px auto minmax(0,1fr) 36px}
-header{display:flex;align-items:center;gap:14px;padding:0 20px;border-bottom:1px solid var(--line);background:var(--panel)}
-.brand{display:flex;align-items:center;gap:9px;color:var(--text);font-weight:750;text-decoration:none;font-size:18px}.mark{width:25px;height:25px;display:grid;place-items:center;border:1px solid color-mix(in srgb,var(--accent) 55%,var(--line));border-radius:8px;color:var(--accent);font-weight:900}
-.crumb{color:var(--muted);font-size:12px}.crumb b{color:var(--text)}.spacer{flex:1}.navlink,.theme{border:1px solid var(--line);background:var(--panel2);border-radius:8px;padding:7px 10px;text-decoration:none;color:var(--muted)}.navlink.active{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 45%,var(--line))}
+:root{color-scheme:dark;--bg:#07080f;--panel:#0f1120;--panel2:#151827;--line:rgba(160,168,220,.13);--text:#eef0ff;--muted:#a8aecf;--faint:#5a6088;--accent:#9ece6a;--loud:#ff9e64;--bubble:#18202e;--reply:#17271f;--shadow:0 18px 50px rgba(0,0,0,.22);--header:rgba(10,11,22,.96)}
+[data-theme="light"]{color-scheme:light;--bg:#f3f5f8;--panel:#fff;--panel2:#f8fafc;--line:#dce1e9;--text:#172033;--muted:#5e687b;--faint:#8790a0;--accent:#467a2b;--loud:#bd4b1c;--bubble:#eef3f9;--reply:#eef7ed;--shadow:0 16px 40px rgba(24,36,58,.1);--header:rgba(255,255,255,.96)}
+*{box-sizing:border-box}html{min-height:100%;margin:0}body{min-height:100%;margin:0;background:var(--bg);color:var(--text);font:14px/1.45 Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;overflow:auto}
+button,input,select{font:inherit;color:inherit}button{cursor:pointer}.shell{height:100vh;height:100dvh;min-height:620px;display:flex;flex-direction:column;background:var(--bg)}
+.gm-header{height:54px;flex:none;display:flex;align-items:center;gap:14px;padding:0 18px;border-bottom:1px solid var(--line);background:var(--header);backdrop-filter:blur(10px);position:relative;z-index:10}.brand{display:flex;align-items:center;gap:9px;color:var(--text);font-weight:750;text-decoration:none;font-size:18px}.brand img{display:block;border-radius:6px;box-shadow:0 0 20px color-mix(in srgb,var(--accent) 18%,transparent)}
+.crumb-divider{width:1px;height:20px;background:var(--line);flex:none}.crumb{display:flex;align-items:center;gap:9px;min-width:0;color:var(--faint);font:12.5px ui-monospace,SFMono-Regular,Menlo,monospace}.crumb b{color:var(--text);font-weight:500}.spacer{flex:1}.live{display:flex;align-items:center;gap:7px;padding:5px 9px;border:1px solid var(--line);border-radius:7px;color:var(--muted);font:10.5px ui-monospace,SFMono-Regular,Menlo,monospace}.live-dot{width:6px;height:6px;border-radius:50%;background:var(--accent)}.navlink,.theme{border:1px solid var(--line);background:var(--panel2);border-radius:8px;padding:7px 10px;text-decoration:none;color:var(--muted)}
+.gm-frame{display:flex;flex:1;min-height:0;min-width:0}.gm-sidebar{width:216px;flex:none;min-height:0;overflow-y:auto;padding:12px 10px 0;border-right:1px solid var(--line);background:color-mix(in srgb,var(--panel) 88%,var(--bg));display:flex;flex-direction:column}.gm-nav-group{font:9.5px ui-monospace,SFMono-Regular,Menlo,monospace;letter-spacing:.15em;color:var(--faint);padding:4px 10px 7px}.gm-nav-group:not(:first-child){padding-top:14px}.gm-nav-link{display:flex;align-items:center;gap:11px;padding:9px 11px;border:1px solid transparent;border-radius:9px;margin-top:2px;color:var(--muted);font-size:13.5px;font-weight:500;text-decoration:none;white-space:nowrap}.gm-nav-link:hover{background:color-mix(in srgb,var(--muted) 8%,transparent);color:var(--text)}.gm-nav-link.active{background:color-mix(in srgb,var(--accent) 12%,transparent);color:var(--accent);border-color:color-mix(in srgb,var(--accent) 30%,transparent);box-shadow:inset 3px 0 0 var(--accent)}.gm-nav-link svg{width:17px;height:17px;flex:none}.gm-sidebar-foot{margin-top:auto;padding:10px;border-top:1px solid var(--line);display:flex;align-items:center;gap:8px;color:var(--faint);font:10.5px ui-monospace,SFMono-Regular,Menlo,monospace}.gm-content{flex:1;min-width:0;min-height:0;display:flex;flex-direction:column}
 .filters{display:grid;grid-template-columns:minmax(160px,1fr) repeat(3,minmax(110px,160px)) minmax(130px,180px) auto;gap:8px;padding:10px 14px;border-bottom:1px solid var(--line);background:var(--panel2)}
 .control{min-width:0;border:1px solid var(--line);background:var(--panel);border-radius:8px;padding:8px 10px}.check{display:flex;align-items:center;gap:7px;padding:0 8px;color:var(--muted);white-space:nowrap}
-.workspace{display:grid;grid-template-columns:minmax(260px,340px) minmax(0,1fr);min-height:0}.rail{border-right:1px solid var(--line);background:var(--panel);display:flex;flex-direction:column;min-height:0}
+.workspace{flex:1;display:grid;grid-template-columns:minmax(260px,340px) minmax(0,1fr);min-height:0}.rail{border-right:1px solid var(--line);background:var(--panel);display:flex;flex-direction:column;min-height:0}
 .railhead{padding:13px;border-bottom:1px solid var(--line)}.seg{display:flex;gap:5px}.seg button{flex:1;border:1px solid var(--line);background:var(--panel2);padding:7px;border-radius:7px;color:var(--muted)}.seg button.active{background:color-mix(in srgb,var(--accent) 15%,var(--panel2));color:var(--accent);border-color:color-mix(in srgb,var(--accent) 40%,var(--line))}
-.threads{overflow:auto;padding:7px}.thread{width:100%;text-align:left;border:1px solid transparent;background:transparent;border-radius:10px;padding:11px;margin-bottom:5px}.thread:hover{background:var(--panel2)}.thread.active{background:var(--panel2);border-color:var(--line);box-shadow:var(--shadow)}
+.threads{flex:1;min-height:0;overflow:auto;padding:7px}.thread{width:100%;text-align:left;border:1px solid transparent;background:transparent;border-radius:10px;padding:11px;margin-bottom:5px}.thread:hover{background:var(--panel2)}.thread.active{background:var(--panel2);border-color:var(--line);box-shadow:var(--shadow)}
 .threadtop{display:flex;align-items:center;gap:8px}.workflow{font:600 12px/1.3 ui-monospace,SFMono-Regular,Menlo,monospace;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.badge{margin-left:auto;min-width:22px;text-align:center;padding:2px 6px;border-radius:99px;background:color-mix(in srgb,var(--loud) 18%,transparent);color:var(--loud);font-size:11px;font-weight:750}.threadmeta{margin-top:5px;color:var(--faint);font-size:11px;display:flex;justify-content:space-between;gap:8px}
 .conversation{min-width:0;display:flex;flex-direction:column;background:var(--bg)}.conversation-head{height:58px;flex:none;display:flex;align-items:center;gap:10px;padding:0 20px;border-bottom:1px solid var(--line);background:color-mix(in srgb,var(--panel) 88%,transparent)}.conversation-head h1{font-size:15px;margin:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.conversation-head small{color:var(--muted)}
-.messages{overflow:auto;padding:22px max(20px,6vw) 40px;scroll-behavior:smooth}.message{max-width:760px;margin:0 0 18px}.message.reply{margin-left:auto}.message.system{max-width:900px;margin:16px auto;text-align:center;color:var(--faint);font-size:12px}.systemline{display:inline-flex;gap:8px;align-items:center;padding:6px 12px;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+.messages{flex:1;min-height:0;overflow:auto;padding:22px max(20px,6vw) 40px;scroll-behavior:smooth}.message{max-width:760px;margin:0 0 18px}.message.reply{margin-left:auto}.message.system{max-width:900px;margin:16px auto;text-align:center;color:var(--faint);font-size:12px}.systemline{display:inline-flex;gap:8px;align-items:center;padding:6px 12px;border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
 .bubble{border:1px solid var(--line);border-radius:14px 14px 14px 4px;background:var(--bubble);padding:12px 14px;box-shadow:var(--shadow)}.reply .bubble{background:var(--reply);border-radius:14px 14px 4px 14px}.message.open .bubble{border-left:4px solid var(--loud)}
 .meta{display:flex;align-items:center;gap:7px;margin-bottom:7px;color:var(--muted);font-size:11px}.role{color:var(--text);font-weight:700}.arrow{color:var(--faint)}.chip{padding:2px 6px;border:1px solid var(--line);border-radius:99px;color:var(--accent);text-transform:uppercase;font-size:9px;letter-spacing:.08em}.note{margin-left:auto;color:var(--faint);text-decoration:none;font:10px ui-monospace,SFMono-Regular,Menlo,monospace}
 .body{white-space:pre-wrap;overflow-wrap:anywhere;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:5;overflow:hidden}.body.expanded{-webkit-line-clamp:unset;display:block}.expand{display:none;margin-top:8px;border:0;background:none;padding:0;color:var(--accent);font-size:11px}.footer{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px;padding-top:9px;border-top:1px solid var(--line);color:var(--faint);font-size:11px}.footer.open{color:var(--loud);font-weight:650}.footer a{color:inherit}
 .state{margin:auto;max-width:480px;padding:44px;text-align:center;color:var(--muted)}.state strong{display:block;color:var(--text);font-size:17px;margin-bottom:7px}.source-down strong{color:var(--loud)}
-footer{display:flex;align-items:center;justify-content:center;border-top:1px solid var(--line);background:var(--panel);color:var(--faint);font-size:11px}.pulse{width:7px;height:7px;border-radius:50%;background:var(--accent);margin-right:7px}
+.comms-footer{min-height:36px;flex:none;display:flex;align-items:center;justify-content:center;border-top:1px solid var(--line);background:var(--panel);color:var(--faint);font-size:11px;padding:7px 12px;text-align:center}.pulse{width:7px;height:7px;border-radius:50%;background:var(--accent);margin-right:7px;flex:none}
 .focus{animation:flash 1.8s ease}@keyframes flash{0%,100%{outline:0 solid transparent}30%{outline:4px solid color-mix(in srgb,var(--accent) 30%,transparent)}}
-@media(max-width:820px){.filters{grid-template-columns:1fr 1fr}.filters .search{grid-column:1/-1}.workspace{grid-template-columns:1fr}.rail{position:absolute;z-index:4;inset:117px 0 36px 0}.rail.thread-open{display:none}.conversation{display:none}.conversation.thread-open{display:flex}.conversation-head{padding:0 12px}.messages{padding:16px 12px 34px}.mobile-back{display:inline-flex!important}}
+@media(max-width:820px){.shell{height:auto;min-height:100dvh}.gm-header{position:sticky;top:0}.live{display:none}.gm-frame{display:block}.gm-sidebar{width:100%;height:auto;display:flex;flex-direction:row;overflow-x:auto;overflow-y:hidden;padding:7px 8px;border-right:0;border-bottom:1px solid var(--line)}.gm-nav-group,.gm-sidebar-foot{display:none}.gm-nav-link{flex:none;margin:0 2px;padding:8px 10px}.gm-content{display:block}.filters{grid-template-columns:1fr 1fr}.filters .search{grid-column:1/-1}.workspace{display:block}.rail{position:static;min-height:0;border-right:0}.threads{overflow:visible}.rail.thread-open{display:none}.conversation{display:none}.conversation.thread-open{display:block}.conversation-head{padding:0 12px}.messages{overflow:visible;padding:16px 12px 34px}.mobile-back{display:inline-flex!important}.comms-footer{min-height:44px}}
 @media(min-width:821px){.mobile-back{display:none!important}}
 @media(prefers-reduced-motion:reduce){.messages{scroll-behavior:auto}.focus{animation:none;outline:3px solid color-mix(in srgb,var(--accent) 35%,transparent)}}
 </style>
 </head>
 <body>
 <main class="shell">
-  <header>
-    <a class="brand" href="/"><span class="mark">g</span><span>gitmoot<span style="color:var(--accent)">.</span></span></a>
-    <span class="crumb">dashboard / <b>Comms</b></span><span class="spacer"></span>
-    <a class="navlink" href="/">Dashboard</a><a class="navlink active" href="/comms">Comms</a>
+  <header class="gm-header">
+    <a class="brand" href="/"><img src="/logo.svg" width="22" height="22" alt="gitmoot"><span>gitmoot<span style="color:var(--accent)">.</span></span></a>
+    <span class="crumb-divider"></span>
+    <span class="crumb"><span>dashboard</span><span>›</span><b>Comms</b></span><span class="spacer"></span>
+    <span class="live"><span class="live-dot"></span>read-only</span>
     <button class="theme" id="theme" type="button" aria-label="Toggle light and dark theme">◐</button>
   </header>
-  <section class="filters" aria-label="Comms filters">
-    <input class="control search" id="search" type="search" placeholder="Search workflows, roles, bodies…" aria-label="Search comms">
-    <select class="control" id="from"><option value="">From: anyone</option></select>
-    <select class="control" id="to"><option value="">To: anyone</option></select>
-    <select class="control" id="resolution"><option value="">Any resolution</option><option value="open">Unresolved</option><option value="resolved">Resolved</option></select>
-    <input class="control" id="date" type="date" aria-label="From date">
-    <label class="check"><input id="systems" type="checkbox" checked> Engine markers</label>
-  </section>
-  <section class="workspace">
-    <aside class="rail" id="rail">
-      <div class="railhead"><div class="seg"><button id="open" type="button">Open</button><button id="all" class="active" type="button">All</button></div></div>
-      <div class="threads" id="threads"><div class="state"><strong>Loading comms</strong>Reading workflow notes…</div></div>
+  <div class="gm-frame">
+    <aside class="gm-sidebar" data-dashboard-sidebar aria-label="Dashboard navigation">
+      <div class="gm-nav-group">WORK</div>
+      <a class="gm-nav-link" href="/" title="Fleet overview"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="4" y="4" width="6" height="6" rx="1.4"/><rect x="14" y="4" width="6" height="6" rx="1.4"/><rect x="4" y="14" width="6" height="6" rx="1.4"/><rect x="14" y="14" width="6" height="6" rx="1.4"/></svg><span>Overview</span></a>
+      <a class="gm-nav-link" href="/tasks" title="Task lifecycle board"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M7 4v16M17 4v16M4 7h6M14 12h6M4 17h6"/><circle cx="7" cy="7" r="1.8"/><circle cx="17" cy="12" r="1.8"/><circle cx="7" cy="17" r="1.8"/></svg><span>Tasks</span></a>
+      <a class="gm-nav-link" href="/workflows" title="Workflow mission logs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M7 4v16"/><circle cx="7" cy="7" r="2"/><circle cx="7" cy="13" r="2"/><circle cx="7" cy="19" r="2"/><path d="M11 7h8M11 13h6M11 19h8"/></svg><span>Workflows</span></a>
+      <a class="gm-nav-link" href="/jobs" title="All jobs across every run"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M8 6h11M8 12h11M8 18h11"/><circle cx="4" cy="6" r="1.1"/><circle cx="4" cy="12" r="1.1"/><circle cx="4" cy="18" r="1.1"/></svg><span>Jobs</span></a>
+      <a class="gm-nav-link" href="/pipelines" title="Declared pipelines and run history"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="5" cy="6" r="2"/><circle cx="5" cy="18" r="2"/><circle cx="18" cy="12" r="2"/><path d="M7 7l9 4M7 17l9-4"/></svg><span>Pipelines</span></a>
+      <div class="gm-nav-group">FLEET</div>
+      <a class="gm-nav-link" href="/agents" title="Registered agents"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="5" y="8" width="14" height="11" rx="2.5"/><path d="M12 8V5"/><circle cx="12" cy="3.6" r="1"/><path d="M9.6 13h.01M14.4 13h.01"/></svg><span>Agents</span></a>
+      <a class="gm-nav-link" href="/org" title="Fleet hierarchy and presence"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="9" y="3" width="6" height="5" rx="1.4"/><rect x="3" y="16" width="6" height="5" rx="1.4"/><rect x="15" y="16" width="6" height="5" rx="1.4"/><path d="M12 8v3.5M6 16v-2.5h12V16"/></svg><span>Org</span></a>
+      <a class="gm-nav-link" href="/chat" title="Agent chat threads"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 5h13a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"/></svg><span>Chat</span></a>
+      <a href="/comms" aria-current="page" class="gm-nav-link active" title="Org communication threads"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 5h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"/><path d="M9 10h11a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-3l-3 2v-2"/></svg><span>Comms</span></a>
+      <div class="gm-nav-group">INSIGHT</div>
+      <a class="gm-nav-link" href="/brain" title="Memory fact galaxy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="2.2"/><circle cx="5" cy="7" r="1.6"/><circle cx="19" cy="6" r="1.6"/><circle cx="18" cy="18" r="1.6"/><circle cx="6" cy="18" r="1.6"/><path d="M10.2 10.8 6.4 8M13.6 10.5 17.6 7.2M13.7 13.5l3.2 3.2M10.3 13.5l-3 3.2"/></svg><span>Brain</span></a>
+      <a class="gm-nav-link" href="/galaxy" title="Cross-run galaxy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 3l1.7 4.5L18 9l-4.3 1.5L12 15l-1.7-4.5L6 9l4.3-1.5z"/><circle cx="18.5" cy="17.5" r="1"/></svg><span>Galaxy</span></a>
+      <a class="gm-nav-link" href="/charts" title="Charts across every run"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="4" y="12" width="3.2" height="8" rx="1"/><rect x="10.4" y="7" width="3.2" height="13" rx="1"/><rect x="16.8" y="4" width="3.2" height="16" rx="1"/></svg><span>Charts</span></a>
+      <a class="gm-nav-link" href="/learning" title="SkillOpt evolution"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 3a6 6 0 0 0-3.5 10.9c.6.4.9 1 .9 1.6v.5h5.2v-.5c0-.6.3-1.2.9-1.6A6 6 0 0 0 12 3zM9.6 20h4.8M10.6 22h2.8"/></svg><span>Learning</span></a>
+      <div class="gm-nav-group">SYSTEM</div>
+      <a class="gm-nav-link" href="/attention" title="Needs a human"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 0 1-3.4 0"/></svg><span>Needs a human</span></a>
+      <a class="gm-nav-link" href="/health" title="Daemon health and locks"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M3 12h4l2-6 4 12 2-6h6"/></svg><span>Health</span></a>
+      <a class="gm-nav-link" href="/config" title="Effective configuration"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 7h10M18 7h2M4 17h2M10 17h10"/><circle cx="16" cy="7" r="2"/><circle cx="8" cy="17" r="2"/></svg><span>Config</span></a>
+      <div class="gm-sidebar-foot"><span class="live-dot"></span><span>local · dashboard</span></div>
     </aside>
-    <section class="conversation" id="conversation">
-      <div class="conversation-head" id="conversation-head"><button class="navlink mobile-back" id="back" type="button">← Threads</button><div><h1>Comms</h1><small>Select a workflow thread</small></div></div>
-      <div class="messages" id="messages"><div class="state"><strong>No thread selected</strong>Choose a workflow from the thread rail.</div></div>
+    <section class="gm-content">
+      <section class="filters" aria-label="Comms filters">
+        <input class="control search" id="search" type="search" placeholder="Search workflows, roles, bodies…" aria-label="Search comms">
+        <select class="control" id="from"><option value="">From: anyone</option></select>
+        <select class="control" id="to"><option value="">To: anyone</option></select>
+        <select class="control" id="resolution"><option value="">Any resolution</option><option value="open">Unresolved</option><option value="resolved">Resolved</option></select>
+        <input class="control" id="date" type="date" aria-label="From date">
+        <label class="check"><input id="systems" type="checkbox" checked> Engine markers</label>
+      </section>
+      <section class="workspace">
+        <aside class="rail" id="rail">
+          <div class="railhead"><div class="seg"><button id="open" type="button">Open</button><button id="all" class="active" type="button">All</button></div></div>
+          <div class="threads" id="threads"><div class="state"><strong>Loading comms</strong>Reading workflow notes…</div></div>
+        </aside>
+        <section class="conversation" id="conversation">
+          <div class="conversation-head" id="conversation-head"><button class="navlink mobile-back" id="back" type="button">← Threads</button><div><h1>Comms</h1><small>Select a workflow thread</small></div></div>
+          <div class="messages" id="messages"><div class="state"><strong>No thread selected</strong>Choose a workflow from the thread rail.</div></div>
+        </section>
+      </section>
+      <footer class="comms-footer"><span class="pulse"></span>Read-only org traffic · resolve escalations with <code style="margin-left:4px">gitmoot org escalate resolve</code></footer>
     </section>
-  </section>
-  <footer><span class="pulse"></span>Read-only org traffic · resolve escalations with <code style="margin-left:4px">gitmoot org escalate resolve</code></footer>
+  </div>
 </main>
 <script>
 (()=>{

--- a/internal/cli/dashboard_web_comms.go
+++ b/internal/cli/dashboard_web_comms.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"net/http"
 	"sort"
 	"strconv"
@@ -94,7 +95,63 @@ func (d *webDataSource) handleCommsPage(w http.ResponseWriter, _ *http.Request) 
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprint(w, dashboardCommsPage)
+	page := strings.Replace(dashboardCommsPage, dashboardCommsSidebarPlaceholder, renderDashboardCommsSidebar("/comms"), 1)
+	_, _ = fmt.Fprint(w, page)
+}
+
+const dashboardCommsSidebarPlaceholder = "<!-- gitmoot-dashboard-sidebar -->"
+
+func renderDashboardCommsSidebar(activeHref string) string {
+	var out strings.Builder
+	out.WriteString(`<aside class="gm-sidebar" data-dashboard-sidebar aria-label="Dashboard navigation">`)
+	group := ""
+	for _, item := range dashboardNavManifest {
+		if item.Group != group {
+			group = item.Group
+			fmt.Fprintf(&out, `<div class="gm-nav-group">%s</div>`, html.EscapeString(group))
+		}
+		className := "gm-nav-link"
+		current := ""
+		if item.Href == activeHref {
+			className += " active"
+			current = ` aria-current="page"`
+		}
+		fmt.Fprintf(&out, `<a class="%s" href="%s"%s>%s<span>%s</span></a>`,
+			className,
+			html.EscapeString(item.Href),
+			current,
+			dashboardCommsNavIcon(item.Href),
+			html.EscapeString(item.Title),
+		)
+	}
+	out.WriteString(`<div class="gm-sidebar-foot"><span class="live-dot"></span><span>local · dashboard</span></div></aside>`)
+	return out.String()
+}
+
+func dashboardCommsNavIcon(href string) string {
+	const generic = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="6"/></svg>`
+	icons := map[string]string{
+		"/":          `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="4" y="4" width="6" height="6" rx="1.4"/><rect x="14" y="4" width="6" height="6" rx="1.4"/><rect x="4" y="14" width="6" height="6" rx="1.4"/><rect x="14" y="14" width="6" height="6" rx="1.4"/></svg>`,
+		"/tasks":     `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M7 4v16M17 4v16M4 7h6M14 12h6M4 17h6"/><circle cx="7" cy="7" r="1.8"/><circle cx="17" cy="12" r="1.8"/><circle cx="7" cy="17" r="1.8"/></svg>`,
+		"/workflows": `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M7 4v16"/><circle cx="7" cy="7" r="2"/><circle cx="7" cy="13" r="2"/><circle cx="7" cy="19" r="2"/><path d="M11 7h8M11 13h6M11 19h8"/></svg>`,
+		"/jobs":      `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M8 6h11M8 12h11M8 18h11"/><circle cx="4" cy="6" r="1.1"/><circle cx="4" cy="12" r="1.1"/><circle cx="4" cy="18" r="1.1"/></svg>`,
+		"/pipelines": `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="5" cy="6" r="2"/><circle cx="5" cy="18" r="2"/><circle cx="18" cy="12" r="2"/><path d="M7 7l9 4M7 17l9-4"/></svg>`,
+		"/agents":    `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="5" y="8" width="14" height="11" rx="2.5"/><path d="M12 8V5"/><circle cx="12" cy="3.6" r="1"/><path d="M9.6 13h.01M14.4 13h.01"/></svg>`,
+		"/org":       `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="9" y="3" width="6" height="5" rx="1.4"/><rect x="3" y="16" width="6" height="5" rx="1.4"/><rect x="15" y="16" width="6" height="5" rx="1.4"/><path d="M12 8v3.5M6 16v-2.5h12V16"/></svg>`,
+		"/chat":      `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 5h13a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"/></svg>`,
+		"/comms":     `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 5h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"/><path d="M9 10h11a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-3l-3 2v-2"/></svg>`,
+		"/brain":     `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="2.2"/><circle cx="5" cy="7" r="1.6"/><circle cx="19" cy="6" r="1.6"/><circle cx="18" cy="18" r="1.6"/><circle cx="6" cy="18" r="1.6"/><path d="M10.2 10.8 6.4 8M13.6 10.5 17.6 7.2M13.7 13.5l3.2 3.2M10.3 13.5l-3 3.2"/></svg>`,
+		"/galaxy":    `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 3l1.7 4.5L18 9l-4.3 1.5L12 15l-1.7-4.5L6 9l4.3-1.5z"/><circle cx="18.5" cy="17.5" r="1"/></svg>`,
+		"/charts":    `<svg viewBox="0 0 24 24" fill="currentColor"><rect x="4" y="12" width="3.2" height="8" rx="1"/><rect x="10.4" y="7" width="3.2" height="13" rx="1"/><rect x="16.8" y="4" width="3.2" height="16" rx="1"/></svg>`,
+		"/learning":  `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 3a6 6 0 0 0-3.5 10.9c.6.4.9 1 .9 1.6v.5h5.2v-.5c0-.6.3-1.2.9-1.6A6 6 0 0 0 12 3zM9.6 20h4.8M10.6 22h2.8"/></svg>`,
+		"/attention": `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 0 1-3.4 0"/></svg>`,
+		"/health":    `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M3 12h4l2-6 4 12 2-6h6"/></svg>`,
+		"/config":    `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 7h10M18 7h2M4 17h2M10 17h10"/><circle cx="16" cy="7" r="2"/><circle cx="8" cy="17" r="2"/></svg>`,
+	}
+	if icon := icons[href]; icon != "" {
+		return icon
+	}
+	return generic
 }
 
 func (d *webDataSource) comms(ctx context.Context, requestedNoteID int64) (dashboardCommsResponse, error) {
@@ -332,29 +389,7 @@ button,input,select{font:inherit;color:inherit}button{cursor:pointer}.shell{heig
     <button class="theme" id="theme" type="button" aria-label="Toggle light and dark theme">◐</button>
   </header>
   <div class="gm-frame">
-    <aside class="gm-sidebar" data-dashboard-sidebar aria-label="Dashboard navigation">
-      <div class="gm-nav-group">WORK</div>
-      <a class="gm-nav-link" href="/" title="Fleet overview"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="4" y="4" width="6" height="6" rx="1.4"/><rect x="14" y="4" width="6" height="6" rx="1.4"/><rect x="4" y="14" width="6" height="6" rx="1.4"/><rect x="14" y="14" width="6" height="6" rx="1.4"/></svg><span>Overview</span></a>
-      <a class="gm-nav-link" href="/tasks" title="Task lifecycle board"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M7 4v16M17 4v16M4 7h6M14 12h6M4 17h6"/><circle cx="7" cy="7" r="1.8"/><circle cx="17" cy="12" r="1.8"/><circle cx="7" cy="17" r="1.8"/></svg><span>Tasks</span></a>
-      <a class="gm-nav-link" href="/workflows" title="Workflow mission logs"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M7 4v16"/><circle cx="7" cy="7" r="2"/><circle cx="7" cy="13" r="2"/><circle cx="7" cy="19" r="2"/><path d="M11 7h8M11 13h6M11 19h8"/></svg><span>Workflows</span></a>
-      <a class="gm-nav-link" href="/jobs" title="All jobs across every run"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M8 6h11M8 12h11M8 18h11"/><circle cx="4" cy="6" r="1.1"/><circle cx="4" cy="12" r="1.1"/><circle cx="4" cy="18" r="1.1"/></svg><span>Jobs</span></a>
-      <a class="gm-nav-link" href="/pipelines" title="Declared pipelines and run history"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="5" cy="6" r="2"/><circle cx="5" cy="18" r="2"/><circle cx="18" cy="12" r="2"/><path d="M7 7l9 4M7 17l9-4"/></svg><span>Pipelines</span></a>
-      <div class="gm-nav-group">FLEET</div>
-      <a class="gm-nav-link" href="/agents" title="Registered agents"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="5" y="8" width="14" height="11" rx="2.5"/><path d="M12 8V5"/><circle cx="12" cy="3.6" r="1"/><path d="M9.6 13h.01M14.4 13h.01"/></svg><span>Agents</span></a>
-      <a class="gm-nav-link" href="/org" title="Fleet hierarchy and presence"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><rect x="9" y="3" width="6" height="5" rx="1.4"/><rect x="3" y="16" width="6" height="5" rx="1.4"/><rect x="15" y="16" width="6" height="5" rx="1.4"/><path d="M12 8v3.5M6 16v-2.5h12V16"/></svg><span>Org</span></a>
-      <a class="gm-nav-link" href="/chat" title="Agent chat threads"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 5h13a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"/></svg><span>Chat</span></a>
-      <a href="/comms" aria-current="page" class="gm-nav-link active" title="Org communication threads"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 5h12a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2H9l-4 3v-3H4a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"/><path d="M9 10h11a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-3l-3 2v-2"/></svg><span>Comms</span></a>
-      <div class="gm-nav-group">INSIGHT</div>
-      <a class="gm-nav-link" href="/brain" title="Memory fact galaxy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="2.2"/><circle cx="5" cy="7" r="1.6"/><circle cx="19" cy="6" r="1.6"/><circle cx="18" cy="18" r="1.6"/><circle cx="6" cy="18" r="1.6"/><path d="M10.2 10.8 6.4 8M13.6 10.5 17.6 7.2M13.7 13.5l3.2 3.2M10.3 13.5l-3 3.2"/></svg><span>Brain</span></a>
-      <a class="gm-nav-link" href="/galaxy" title="Cross-run galaxy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 3l1.7 4.5L18 9l-4.3 1.5L12 15l-1.7-4.5L6 9l4.3-1.5z"/><circle cx="18.5" cy="17.5" r="1"/></svg><span>Galaxy</span></a>
-      <a class="gm-nav-link" href="/charts" title="Charts across every run"><svg viewBox="0 0 24 24" fill="currentColor"><rect x="4" y="12" width="3.2" height="8" rx="1"/><rect x="10.4" y="7" width="3.2" height="13" rx="1"/><rect x="16.8" y="4" width="3.2" height="16" rx="1"/></svg><span>Charts</span></a>
-      <a class="gm-nav-link" href="/learning" title="SkillOpt evolution"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M12 3a6 6 0 0 0-3.5 10.9c.6.4.9 1 .9 1.6v.5h5.2v-.5c0-.6.3-1.2.9-1.6A6 6 0 0 0 12 3zM9.6 20h4.8M10.6 22h2.8"/></svg><span>Learning</span></a>
-      <div class="gm-nav-group">SYSTEM</div>
-      <a class="gm-nav-link" href="/attention" title="Needs a human"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M18 8a6 6 0 1 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 0 1-3.4 0"/></svg><span>Needs a human</span></a>
-      <a class="gm-nav-link" href="/health" title="Daemon health and locks"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M3 12h4l2-6 4 12 2-6h6"/></svg><span>Health</span></a>
-      <a class="gm-nav-link" href="/config" title="Effective configuration"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7"><path d="M4 7h10M18 7h2M4 17h2M10 17h10"/><circle cx="16" cy="7" r="2"/><circle cx="8" cy="17" r="2"/></svg><span>Config</span></a>
-      <div class="gm-sidebar-foot"><span class="live-dot"></span><span>local · dashboard</span></div>
-    </aside>
+    <!-- gitmoot-dashboard-sidebar -->
     <section class="gm-content">
       <section class="filters" aria-label="Comms filters">
         <input class="control search" id="search" type="search" placeholder="Search workflows, roles, bodies…" aria-label="Search comms">

--- a/internal/cli/dashboard_web_comms_test.go
+++ b/internal/cli/dashboard_web_comms_test.go
@@ -332,6 +332,32 @@ func TestDashboardCommsPageContract(t *testing.T) {
 	}
 }
 
+func TestDashboardCommsPageUsesDashboardShellAndFlowLayout(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	newDashboardWebHandler(&webDataSource{}).ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/comms", nil),
+	)
+	body := recorder.Body.String()
+	for _, test := range []struct {
+		name string
+		want string
+	}{
+		{name: "dashboard sidebar", want: `data-dashboard-sidebar`},
+		{name: "active Comms item", want: `href="/comms" aria-current="page"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if !strings.Contains(body, test.want) {
+				t.Fatalf("GET /comms missing %q", test.want)
+			}
+		})
+	}
+	t.Run("mobile layout has no fixed rail inset", func(t *testing.T) {
+		if strings.Contains(body, "117px") {
+			t.Fatal("GET /comms still contains the hardcoded 117px mobile rail inset")
+		}
+	})
+}
+
 func TestDashboardSidebarLinksCommsDirectlyAfterChat(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	newDashboardWebHandler(&webDataSource{}).ServeHTTP(

--- a/internal/cli/dashboard_web_comms_test.go
+++ b/internal/cli/dashboard_web_comms_test.go
@@ -358,6 +358,122 @@ func TestDashboardCommsPageUsesDashboardShellAndFlowLayout(t *testing.T) {
 	})
 }
 
+func TestDashboardCommsSidebarMatchesManifest(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	newDashboardWebHandler(&webDataSource{}).ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/comms", nil),
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET /comms status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+	got := dashboardCommsRenderedNav(t, recorder.Body.String())
+	if !reflect.DeepEqual(got, dashboardNavManifest) {
+		t.Fatalf("rendered Comms sidebar = %#v, want manifest %#v", got, dashboardNavManifest)
+	}
+}
+
+func TestDashboardSidebarManifestMatchesEmbeddedModule(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	newDashboardWebHandler(&webDataSource{}).ServeHTTP(
+		recorder, httptest.NewRequest(http.MethodGet, "/", nil),
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GET / status=%d body=%q", recorder.Code, recorder.Body.String())
+	}
+	got := dashboardEmbeddedModuleNav(t, recorder.Body.String())
+	if !reflect.DeepEqual(got, dashboardNavManifest) {
+		t.Fatalf("embedded SPA sidebar = %#v, want manifest %#v", got, dashboardNavManifest)
+	}
+}
+
+func dashboardCommsRenderedNav(t *testing.T, body string) []dashboardNavItem {
+	t.Helper()
+	start := strings.Index(body, `<aside class="gm-sidebar"`)
+	if start < 0 {
+		t.Fatal("rendered Comms page has no dashboard sidebar")
+	}
+	end := strings.Index(body[start:], `</aside>`)
+	if end < 0 {
+		t.Fatal("rendered Comms sidebar has no closing tag")
+	}
+	sidebar := body[start : start+end]
+	tokens := regexp.MustCompile(`(?s)<div class="gm-nav-group">([^<]+)</div>|<a class="gm-nav-link(?: active)?" href="([^"]+)"(?: aria-current="page")?>.*?<span>([^<]+)</span></a>`).FindAllStringSubmatch(sidebar, -1)
+	items := make([]dashboardNavItem, 0, len(dashboardNavManifest))
+	group := ""
+	for _, token := range tokens {
+		if token[1] != "" {
+			group = token[1]
+			continue
+		}
+		items = append(items, dashboardNavItem{Href: token[2], Title: token[3], Group: group})
+	}
+	if len(items) == 0 {
+		t.Fatal("rendered Comms sidebar yielded zero navigation items")
+	}
+	return items
+}
+
+func dashboardEmbeddedModuleNav(t *testing.T, body string) []dashboardNavItem {
+	t.Helper()
+	start := strings.Index(body, `<aside style="{{ railStyle }}">`)
+	if start < 0 {
+		t.Fatal("embedded dashboard page has no primary sidebar")
+	}
+	end := strings.Index(body[start:], `<div style="margin-top:auto;`)
+	if end < 0 {
+		t.Fatal("embedded dashboard sidebar has no footer boundary")
+	}
+	lines := strings.Split(body[start:start+end], "\n")
+	groupPattern := regexp.MustCompile(`>(WORK|FLEET|INSIGHT|SYSTEM)</div>`)
+	actionPattern := regexp.MustCompile(`onClick="\{\{ show([A-Za-z]+) \}\}"`)
+	hrefPattern := regexp.MustCompile(`<a href="([^"]+)"`)
+	labelPattern := regexp.MustCompile(`<span style="flex:1">([^<]+)</span>`)
+	items := make([]dashboardNavItem, 0, len(dashboardNavManifest))
+	group := ""
+	for index, line := range lines {
+		if match := groupPattern.FindStringSubmatch(line); match != nil {
+			group = match[1]
+			continue
+		}
+		action := ""
+		href := ""
+		closing := ""
+		if match := actionPattern.FindStringSubmatch(line); match != nil {
+			action = match[1]
+			closing = `</div>`
+		} else if match := hrefPattern.FindStringSubmatch(line); match != nil {
+			href = match[1]
+			closing = `</a>`
+		} else {
+			continue
+		}
+		label := ""
+		for cursor := index; cursor < len(lines); cursor++ {
+			if match := labelPattern.FindStringSubmatch(lines[cursor]); match != nil {
+				label = match[1]
+			}
+			if strings.Contains(lines[cursor], closing) {
+				break
+			}
+		}
+		if action != "" {
+			route := strings.ToLower(action)
+			href = "/" + route
+			if route == "overview" {
+				href = "/"
+			}
+		}
+		if group == "" || href == "" || label == "" {
+			t.Fatalf("could not extract embedded nav item from line %q: group=%q href=%q label=%q", line, group, href, label)
+		}
+		items = append(items, dashboardNavItem{Href: href, Title: label, Group: group})
+	}
+	if len(items) == 0 {
+		t.Fatal("embedded dashboard sidebar yielded zero navigation items")
+	}
+	return items
+}
+
 func TestDashboardSidebarLinksCommsDirectlyAfterChat(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	newDashboardWebHandler(&webDataSource{}).ServeHTTP(


### PR DESCRIPTION
WHAT:
COMMS-SHELL: Rebuilt /comms inside a server-rendered dashboard shell. The embedded module exposes only its SPA handler/static index, not a reusable shell API, so matching its header/sidebar vocabulary locally was the least-duplicative supported mechanism. Changes remain uncommitted for Gitmoot’s finalizer.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-3e023432

RESULTS:
- Fail-before: TestDashboardCommsPageUsesDashboardShellAndFlowLayout failed for missing data-dashboard-sidebar, missing active Comms markup, and the retained hardcoded 117px inset.
- Sidebar mutant: removing the dashboard-sidebar marker failed only the dashboard_sidebar subtest with GET /comms missing "data-dashboard-sidebar".
- Active-state mutant: removing aria-current and the active class failed only the active_Comms_item subtest with GET /comms missing "href=\"/comms\" aria-current=\"page\"".
- Final targeted command: go test -count=1 -run Comms ./internal/cli/ — passed.
- git diff --check — passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-3e023432

AGENTS:
- wave-impl-b

RAW FINAL REVIEW OUTPUT:
````text
COMMS-SHELL: Rebuilt /comms inside a server-rendered dashboard shell. The embedded module exposes only its SPA handler/static index, not a reusable shell API, so matching its header/sidebar vocabulary locally was the least-duplicative supported mechanism. Changes remain uncommitted for Gitmoot’s finalizer.
````
