### PR TITLE
Gitmoot: CAMPAIGN 1308 SLICE B — TIMEOUT AUTHORITY (from

### DIFF
--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -334,7 +334,18 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, agent, checkout, err)
 		return nil
 	}
-	jobTimeout := effectiveJobTimeout(payload, managed)
+	timeoutResolution := resolveEffectiveJobTimeout(payload, managed)
+	jobTimeout := timeoutResolution.Timeout
+	if timeoutResolution.Clamped {
+		message := fmt.Sprintf("%s job_timeout %s exceeds [daemon].job_timeout_max %s; clamped to %s",
+			timeoutResolution.Source, timeoutResolution.Requested, timeoutResolution.Max, timeoutResolution.Timeout)
+		if eventErr := w.Store.AddJobEventIfAbsent(ctx, db.JobEvent{JobID: job.ID, Kind: "job_timeout_clamped", Message: message}); eventErr != nil {
+			if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, eventErr); finishErr != nil {
+				return finishErr
+			}
+			return nil
+		}
+	}
 	// Size the runtime-session lease to jobTimeout PLUS a teardown grace so the
 	// lease strictly OUTLIVES the run-context deadline (armed at exactly jobTimeout
 	// below) and the terminal worktree teardown that runs while this lock is still
@@ -342,10 +353,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	// expires; without the grace the lease would expire in the live-worker teardown
 	// window and the expired-lock reaper would requeue the still-'running' owner
 	// onto its dirty worktree — the #536 clobber. See runtimeLeaseTeardownGrace.
-	lockTTL := defaultDaemonRunningJobStaleAfter
-	if jobTimeout > 0 {
-		lockTTL = jobTimeout + runtimeLeaseTeardownGrace
-	}
+	lockTTL := jobTimeout + runtimeLeaseTeardownGrace
 	// SESSION SAFETY (#531): the lock is taken on the EFFECTIVE agent, so an
 	// overridden job locks the OVERRIDE runtime's session key and can never
 	// collide with (or occupy) the agent's default-runtime session lock.
@@ -587,8 +595,8 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			defer w.finalizeCockpitRootIfDone(cp, job, payload, meta.RootJobID)
 		}
 	}
-	if managed.OK {
-		if err := w.Store.MarkAgentInstanceRunning(ctx, agent.Name, time.Now().UTC(), managed.JobTimeout); err != nil {
+	if managed.Instance {
+		if err := w.Store.MarkAgentInstanceRunning(ctx, agent.Name, time.Now().UTC(), jobTimeout); err != nil {
 			if finishErr := w.finishQueuedJob(ctx, job.ID, workflow.JobFailed, err); finishErr != nil {
 				return finishErr
 			}
@@ -614,11 +622,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
 	defer stopRun()
 	runStartedAt := time.Now().UTC()
-	if jobTimeout > 0 {
-		var cancel context.CancelFunc
-		runCtx, cancel = context.WithTimeout(runCtx, jobTimeout)
-		defer cancel()
-	}
+	var cancel context.CancelFunc
+	runCtx, cancel = context.WithTimeout(runCtx, jobTimeout)
+	defer cancel()
 	runDeadline, hasRunDeadline := runCtx.Deadline()
 	stopKillPending := func() {}
 	if hasRunDeadline {
@@ -1617,11 +1623,6 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 		}
 		return fmt.Errorf("%w: %s", errRuntimeSessionBusy, waitMessage)
 	}
-	// A per-delegation timeout on the payload overrides the agent-type job
-	// timeout for both the lock TTL and the run deadline below.
-	if d, perr := time.ParseDuration(strings.TrimSpace(payload.JobTimeout)); perr == nil && d > 0 {
-		started.JobTimeout = d
-	}
 	payload.OriginalAgent = original.Name
 	payload.DelegatedAgent = started.Agent.Name
 	payload.DelegationReason = "runtime_session_busy"
@@ -1658,10 +1659,7 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 	// Same lease-outlives-context invariant as run(): the temp-worker run context is
 	// armed at started.JobTimeout below, so the lease must be jobTimeout+grace to
 	// cover teardown and avoid the #536 live-worker reap+requeue window.
-	tempLockTTL := defaultDaemonRunningJobStaleAfter
-	if started.JobTimeout > 0 {
-		tempLockTTL = started.JobTimeout + runtimeLeaseTeardownGrace
-	}
+	tempLockTTL := started.JobTimeout + runtimeLeaseTeardownGrace
 	releaseLock, acquired, lockKey, ownerToken, err := acquireRuntimeSessionLock(ctx, w.Store, delegatedJob.ID, started.Agent, time.Now().UTC(), tempLockTTL)
 	if err != nil {
 		if finishErr := w.finishQueuedJob(ctx, delegatedJob.ID, workflow.JobFailed, err); finishErr != nil {
@@ -1765,11 +1763,9 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 	runCtx, stopRun := w.runningJobContext(ctx, job.ID)
 	defer stopRun()
 	runStartedAt := time.Now().UTC()
-	if started.JobTimeout > 0 {
-		var cancel context.CancelFunc
-		runCtx, cancel = context.WithTimeout(runCtx, started.JobTimeout)
-		defer cancel()
-	}
+	var cancel context.CancelFunc
+	runCtx, cancel = context.WithTimeout(runCtx, started.JobTimeout)
+	defer cancel()
 	runDeadline, hasRunDeadline := runCtx.Deadline()
 	stopKillPending := func() {}
 	if hasRunDeadline {
@@ -1914,13 +1910,16 @@ func compactMergeBackStrings(values []string) []string {
 
 func (w jobWorker) startTempWorker(ctx context.Context, job db.Job, payload workflow.JobPayload, original runtime.Agent, checkout string) (tempWorkerStartResult, error) {
 	idleTimeout := 20 * time.Minute
-	jobTimeout := defaultDaemonRunningJobStaleAfter
-	if managed, err := w.managedJobConfig(ctx, original.Name); err == nil && managed.OK {
-		idleTimeout = managed.IdleTimeout
-		jobTimeout = managed.JobTimeout
-	} else if err != nil {
+	managed, err := w.managedJobConfig(ctx, original.Name)
+	if err != nil {
 		return tempWorkerStartResult{}, err
 	}
+	if managed.OK {
+		idleTimeout = managed.IdleTimeout
+	}
+	// Resolve the same authority as the primary dispatch path so runtime-session
+	// contention cannot route a payload around the hard ceiling.
+	jobTimeout := effectiveJobTimeout(payload, managed)
 	tempAgent := original
 	tempAgent.Name = tempWorkerInstanceName(original.Name, job.ID)
 	tempAgent.RuntimeRef = ""
@@ -2149,29 +2148,72 @@ func tempWorkerInstanceName(agentName string, jobID string) string {
 }
 
 type managedJobRuntimeConfig struct {
-	OK          bool
-	JobTimeout  time.Duration
-	IdleTimeout time.Duration
+	OK                bool
+	Instance          bool
+	JobTimeout        time.Duration
+	IdleTimeout       time.Duration
+	JobTimeoutDefault time.Duration
+	JobTimeoutMax     time.Duration
 }
 
 func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (managedJobRuntimeConfig, error) {
-	instance, err := w.Store.GetAgentInstance(ctx, agentName)
+	runtimeConfig := managedJobRuntimeConfig{
+		JobTimeoutDefault: config.DefaultDaemonJobTimeoutDefault,
+		JobTimeoutMax:     config.DefaultDaemonJobTimeoutMax,
+	}
+	if w.ConfigHomeExplicit || strings.TrimSpace(w.ConfigHome) != "" {
+		paths, err := w.configPaths()
+		if err != nil {
+			return managedJobRuntimeConfig{}, err
+		}
+		daemonConfig, err := config.LoadDaemonRuntimeConfig(paths)
+		if err != nil {
+			return managedJobRuntimeConfig{}, err
+		}
+		runtimeConfig.JobTimeoutDefault, runtimeConfig.JobTimeoutMax = daemonConfig.JobTimeoutPolicy()
+	}
+
+	registered, err := w.Store.GetAgent(ctx, agentName)
 	if errors.Is(err, sql.ErrNoRows) {
-		return managedJobRuntimeConfig{}, nil
+		return runtimeConfig, nil
 	}
 	if err != nil {
 		return managedJobRuntimeConfig{}, err
 	}
-	configType := instance.Type
-	if original := originalAgentForTempWorkerType(instance.Type); original != "" {
-		originalInstance, err := w.Store.GetAgentInstance(ctx, original)
+	// A normal registered agent's stable name is also its [agents.<type>]
+	// enrollment key. A live instance row, when present, is an explicit override
+	// layer: managed/temp workers retain the type that created them even when their
+	// generated instance name differs.
+	configType := registered.Name
+	instance, err := w.Store.GetAgentInstance(ctx, agentName)
+	if err == nil {
+		runtimeConfig.Instance = true
+		configType = instance.Type
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return managedJobRuntimeConfig{}, err
+	}
+	if original := originalAgentForTempWorkerType(configType); original != "" {
+		// Ephemeral specs have no registered parent type by design; they inherit the
+		// daemon default while retaining their instance lifecycle row.
+		if original == ephemeralWorkerInstanceOrigin {
+			return runtimeConfig, nil
+		}
+		originalAgent, err := w.Store.GetAgent(ctx, original)
 		if errors.Is(err, sql.ErrNoRows) {
-			return managedJobRuntimeConfig{}, nil
+			return runtimeConfig, nil
 		}
 		if err != nil {
 			return managedJobRuntimeConfig{}, err
 		}
-		configType = originalInstance.Type
+		configType = originalAgent.Name
+		if originalInstance, instanceErr := w.Store.GetAgentInstance(ctx, original); instanceErr == nil {
+			configType = originalInstance.Type
+		} else if !errors.Is(instanceErr, sql.ErrNoRows) {
+			return managedJobRuntimeConfig{}, instanceErr
+		}
+	}
+	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
+		return runtimeConfig, nil
 	}
 	types, err := loadAgentTypeConfig(w.ConfigHome)
 	if err != nil {
@@ -2179,7 +2221,10 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 	}
 	agentType, ok := types[configType]
 	if !ok {
-		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %q not found for managed instance %s", configType, agentName)
+		if runtimeConfig.Instance {
+			return managedJobRuntimeConfig{}, fmt.Errorf("agent type %q not found for managed instance %s", configType, agentName)
+		}
+		return runtimeConfig, nil
 	}
 	jobTimeout, err := time.ParseDuration(agentType.JobTimeout)
 	if err != nil {
@@ -2195,26 +2240,52 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 	if idleTimeout <= 0 {
 		return managedJobRuntimeConfig{}, fmt.Errorf("agent type %s idle_timeout must be positive", configType)
 	}
-	return managedJobRuntimeConfig{OK: true, JobTimeout: jobTimeout, IdleTimeout: idleTimeout}, nil
+	runtimeConfig.OK = true
+	runtimeConfig.JobTimeout = jobTimeout
+	runtimeConfig.IdleTimeout = idleTimeout
+	return runtimeConfig, nil
 }
 
-// effectiveJobTimeout returns the timeout to enforce for a job: the
-// per-delegation payload.JobTimeout when it parses to a positive duration,
-// otherwise the agent-type managed.JobTimeout, otherwise the daemon stale window
-// for unmanaged jobs (so an unmanaged job still has a watchdog, #555). This value
-// drives the run context deadline directly; the runtime-session lock TTL is this
-// value PLUS runtimeLeaseTeardownGrace (#536/#560) so the lease strictly outlives
-// the deadline and the terminal teardown — the lock cannot expire while the
-// worker is still finishing, which would otherwise let the reaper requeue a live
-// job onto its dirty worktree.
+type jobTimeoutResolution struct {
+	Timeout   time.Duration
+	Requested time.Duration
+	Max       time.Duration
+	Source    string
+	Clamped   bool
+}
+
+// effectiveJobTimeout returns the kill deadline selected by the independent
+// timeout authority. The stale-running threshold is deliberately absent: it is
+// only a crash/staleness predicate and can never become a run-context deadline.
 func effectiveJobTimeout(payload workflow.JobPayload, managed managedJobRuntimeConfig) time.Duration {
-	if d, err := time.ParseDuration(strings.TrimSpace(payload.JobTimeout)); err == nil && d > 0 {
-		return d
+	return resolveEffectiveJobTimeout(payload, managed).Timeout
+}
+
+func resolveEffectiveJobTimeout(payload workflow.JobPayload, managed managedJobRuntimeConfig) jobTimeoutResolution {
+	jobTimeoutDefault := managed.JobTimeoutDefault
+	if jobTimeoutDefault <= 0 {
+		jobTimeoutDefault = config.DefaultDaemonJobTimeoutDefault
 	}
+	jobTimeoutMax := managed.JobTimeoutMax
+	if jobTimeoutMax <= 0 {
+		jobTimeoutMax = config.DefaultDaemonJobTimeoutMax
+	}
+	requested := jobTimeoutDefault
+	source := "daemon default"
 	if managed.JobTimeout > 0 {
-		return managed.JobTimeout
+		requested = managed.JobTimeout
+		source = "agent type"
 	}
-	return daemonRunningJobStaleAfter
+	if d, err := time.ParseDuration(strings.TrimSpace(payload.JobTimeout)); err == nil && d > 0 {
+		requested = d
+		source = "payload"
+	}
+	resolution := jobTimeoutResolution{Timeout: requested, Requested: requested, Max: jobTimeoutMax, Source: source}
+	if requested > jobTimeoutMax {
+		resolution.Timeout = jobTimeoutMax
+		resolution.Clamped = true
+	}
+	return resolution
 }
 
 const jobKillPendingLead = 5 * time.Second

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -2161,16 +2161,26 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 		JobTimeoutDefault: config.DefaultDaemonJobTimeoutDefault,
 		JobTimeoutMax:     config.DefaultDaemonJobTimeoutMax,
 	}
+	var paths config.Paths
+	configFilePresent := false
 	if w.ConfigHomeExplicit || strings.TrimSpace(w.ConfigHome) != "" {
-		paths, err := w.configPaths()
+		var err error
+		paths, err = w.configPaths()
 		if err != nil {
 			return managedJobRuntimeConfig{}, err
 		}
 		daemonConfig, err := config.LoadDaemonRuntimeConfig(paths)
-		if err != nil {
+		// ConfigHome also enables checkout isolation in tests and embedders; it
+		// does not prove that a config file or agent-type registry exists. Absence
+		// is the normal unmanaged case and falls through to the daemon defaults.
+		// A present-but-malformed file still returns its parse error below.
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return managedJobRuntimeConfig{}, err
 		}
-		runtimeConfig.JobTimeoutDefault, runtimeConfig.JobTimeoutMax = daemonConfig.JobTimeoutPolicy()
+		if err == nil {
+			configFilePresent = true
+			runtimeConfig.JobTimeoutDefault, runtimeConfig.JobTimeoutMax = daemonConfig.JobTimeoutPolicy()
+		}
 	}
 
 	registered, err := w.Store.GetAgent(ctx, agentName)
@@ -2212,18 +2222,17 @@ func (w jobWorker) managedJobConfig(ctx context.Context, agentName string) (mana
 			return managedJobRuntimeConfig{}, instanceErr
 		}
 	}
-	if !w.ConfigHomeExplicit && strings.TrimSpace(w.ConfigHome) == "" {
+	if !configFilePresent {
 		return runtimeConfig, nil
 	}
-	types, err := loadAgentTypeConfig(w.ConfigHome)
+	types, err := config.LoadAgentTypes(paths)
 	if err != nil {
 		return managedJobRuntimeConfig{}, err
 	}
 	agentType, ok := types[configType]
 	if !ok {
-		if runtimeConfig.Instance {
-			return managedJobRuntimeConfig{}, fmt.Errorf("agent type %q not found for managed instance %s", configType, agentName)
-		}
+		// Enrollment is optional for both stable agents and live instances. Keep
+		// Instance above for lifecycle updates, but use the daemon timeout default.
 		return runtimeConfig, nil
 	}
 	jobTimeout, err := time.ParseDuration(agentType.JobTimeout)

--- a/internal/cli/daemon_worker_test.go
+++ b/internal/cli/daemon_worker_test.go
@@ -330,6 +330,36 @@ func TestDaemonDispatchUsesRegisteredAgentTypeTimeoutWithoutInstance(t *testing.
 	assertCapturedTimeout(t, capture, started, 10*time.Minute)
 }
 
+func TestDaemonDispatchPlainAgentWithoutTypeConfigUsesDefaultTimeout(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir() // Intentionally has no config file or [agents.plain] block.
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "plain", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-plain-default-timeout", Agent: "plain", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	job, err := store.GetJob(ctx, "job-plain-default-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture := &timeoutCaptureAdapter{}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) { return capture, nil }
+	started := time.Now()
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.State != string(workflow.JobSucceeded) {
+		t.Fatalf("plain agent job state = %q, want succeeded with daemon default timeout", stored.State)
+	}
+	assertCapturedTimeout(t, capture, started, config.DefaultDaemonJobTimeoutDefault)
+}
+
 func TestManagedJobConfigLoadsDaemonTimeoutAuthority(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()

--- a/internal/cli/daemon_worker_test.go
+++ b/internal/cli/daemon_worker_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
+type timeoutCaptureAdapter struct {
+	deadline    time.Time
+	hasDeadline bool
+}
+
+func (a *timeoutCaptureAdapter) Deliver(ctx context.Context, _ runtime.Agent, _ runtime.Job) (runtime.Result, error) {
+	a.deadline, a.hasDeadline = ctx.Deadline()
+	return runtime.Result{Raw: `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}, nil
+}
+
 func TestTempWorkerEligibleAllowsWritableImplementWithTaskWorktree(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
@@ -266,15 +276,204 @@ func TestEffectiveJobTimeout(t *testing.T) {
 		t.Fatalf("effectiveJobTimeout(zero payload) = %v, want 10m", got)
 	}
 
-	// With no managed config, an empty payload timeout falls back to the daemon
-	// stale window so an unmanaged job still has a watchdog.
-	if got := effectiveJobTimeout(workflow.JobPayload{}, managedJobRuntimeConfig{}); got != daemonRunningJobStaleAfter {
-		t.Fatalf("effectiveJobTimeout(unmanaged, empty) = %v, want %v", got, daemonRunningJobStaleAfter)
+	// With no agent-type config, the independent daemon kill default applies;
+	// stale-running detection is never reused as the deadline.
+	if got := effectiveJobTimeout(workflow.JobPayload{}, managedJobRuntimeConfig{}); got != config.DefaultDaemonJobTimeoutDefault {
+		t.Fatalf("effectiveJobTimeout(unmanaged, empty) = %v, want %v", got, config.DefaultDaemonJobTimeoutDefault)
 	}
 
 	// With no managed config, a valid payload timeout still applies.
 	if got := effectiveJobTimeout(workflow.JobPayload{JobTimeout: "45s"}, managedJobRuntimeConfig{}); got != 45*time.Second {
 		t.Fatalf("effectiveJobTimeout(unmanaged, payload) = %v, want 45s", got)
+	}
+
+	// Configured daemon authority replaces both defaults, and its maximum is a
+	// hard ceiling regardless of which higher-precedence source supplied the
+	// candidate duration.
+	authority := managedJobRuntimeConfig{JobTimeoutDefault: 3 * time.Hour, JobTimeoutMax: 6 * time.Hour}
+	if got := effectiveJobTimeout(workflow.JobPayload{}, authority); got != 3*time.Hour {
+		t.Fatalf("effectiveJobTimeout(configured default) = %v, want 3h", got)
+	}
+	resolution := resolveEffectiveJobTimeout(workflow.JobPayload{JobTimeout: "7h"}, authority)
+	if resolution.Timeout != 6*time.Hour || !resolution.Clamped || resolution.Source != "payload" {
+		t.Fatalf("resolveEffectiveJobTimeout(configured max) = %+v, want payload clamped to 6h", resolution)
+	}
+}
+
+func TestDaemonDispatchUsesRegisteredAgentTypeTimeoutWithoutInstance(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveAgentType(paths, config.AgentType{Name: "plain", Runtime: runtime.ShellRuntime, JobTimeout: "10m"}); err != nil {
+		t.Fatal(err)
+	}
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "plain", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-plain-timeout", Agent: "plain", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	job, err := store.GetJob(ctx, "job-plain-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture := &timeoutCaptureAdapter{}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) { return capture, nil }
+	started := time.Now()
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	assertCapturedTimeout(t, capture, started, 10*time.Minute)
+}
+
+func TestManagedJobConfigLoadsDaemonTimeoutAuthority(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[daemon]\njob_timeout_default = \"3h\"\njob_timeout_max = \"6h\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "plain", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	got, err := (jobWorker{Store: store, ConfigHome: home, ConfigHomeExplicit: true}).managedJobConfig(ctx, "plain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.JobTimeoutDefault != 3*time.Hour || got.JobTimeoutMax != 6*time.Hour {
+		t.Fatalf("managed job timeout authority = (%v, %v), want (3h, 6h)", got.JobTimeoutDefault, got.JobTimeoutMax)
+	}
+}
+
+func TestDaemonDispatchClampsPayloadTimeoutAndRecordsEvent(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "plain", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-clamped-timeout", Agent: "plain", Action: "ask", Repo: "owner/repo", Branch: "main", JobTimeout: "12h"})
+	job, err := store.GetJob(ctx, "job-clamped-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture := &timeoutCaptureAdapter{}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) { return capture, nil }
+	started := time.Now()
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	assertCapturedTimeout(t, capture, started, 8*time.Hour)
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clampMessage string
+	for _, event := range events {
+		if event.Kind == "job_timeout_clamped" {
+			clampMessage = event.Message
+		}
+	}
+	if !strings.Contains(clampMessage, "12h") || !strings.Contains(clampMessage, "8h") {
+		t.Fatalf("job_timeout_clamped event = %q, want requested 12h and max 8h", clampMessage)
+	}
+}
+
+func TestDaemonDispatchInstanceTypeOverridesRegisteredTypeTimeout(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveAgentType(paths, config.AgentType{Name: "plain", Runtime: runtime.ShellRuntime, JobTimeout: "10m"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveAgentType(paths, config.AgentType{Name: "override", Runtime: runtime.ShellRuntime, JobTimeout: "20m"}); err != nil {
+		t.Fatal(err)
+	}
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "plain", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	now := time.Now().UTC()
+	if err := store.UpsertAgentInstance(ctx, db.AgentInstance{
+		Name: "plain", Type: "override", Runtime: runtime.ShellRuntime, RepoFullName: "owner/repo",
+		Role: "plain", Capabilities: []string{"ask"}, State: "idle",
+		CreatedAt: now.Format(time.RFC3339Nano), LastUsedAt: now.Format(time.RFC3339Nano), ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-instance-timeout", Agent: "plain", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	job, err := store.GetJob(ctx, "job-instance-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture := &timeoutCaptureAdapter{}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) { return capture, nil }
+	started := time.Now()
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	assertCapturedTimeout(t, capture, started, 20*time.Minute)
+}
+
+func TestDaemonJobTimeoutIsSeparateFromStaleDetection(t *testing.T) {
+	if !(daemonRunningJobStaleAfter < config.DefaultDaemonJobTimeoutDefault) {
+		t.Fatalf("stale_after = %v, kill default = %v; want stale_after < kill default", daemonRunningJobStaleAfter, config.DefaultDaemonJobTimeoutDefault)
+	}
+	if got := effectiveJobTimeout(workflow.JobPayload{}, managedJobRuntimeConfig{}); got == daemonRunningJobStaleAfter {
+		t.Fatalf("effectiveJobTimeout returned stale detector constant %v", got)
+	}
+
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store := daemonWorkerStore(t)
+	seedDaemonWorkerAgent(t, store, "defaulted", runtime.ShellRuntime, "", []string{"ask"}, "owner/repo")
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-default-timeout", Agent: "defaulted", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	job, err := store.GetJob(ctx, "job-default-timeout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture := &timeoutCaptureAdapter{}
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return t.TempDir(), nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) { return capture, nil }
+	started := time.Now()
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	assertCapturedTimeout(t, capture, started, config.DefaultDaemonJobTimeoutDefault)
+}
+
+func assertCapturedTimeout(t *testing.T, capture *timeoutCaptureAdapter, started time.Time, want time.Duration) {
+	t.Helper()
+	if !capture.hasDeadline {
+		t.Fatal("delivery context has no deadline")
+	}
+	got := capture.deadline.Sub(started)
+	if got < want-time.Second || got > want+time.Second {
+		t.Fatalf("delivery timeout = %v, want %v", got, want)
 	}
 }
 

--- a/internal/config/daemon_runtime.go
+++ b/internal/config/daemon_runtime.go
@@ -11,6 +11,8 @@ import (
 const (
 	DefaultDaemonIdleGraceTicks    = 3
 	DefaultDaemonIdleMaxMultiplier = 4
+	DefaultDaemonJobTimeoutDefault = 4 * time.Hour
+	DefaultDaemonJobTimeoutMax     = 8 * time.Hour
 )
 
 // DaemonRuntimeConfig is the daemon's WARM-reloadable runtime settings, read from
@@ -53,6 +55,15 @@ type DaemonRuntimeConfig struct {
 	IdleGraceTicksSet    bool
 	IdleMaxMultiplier    int
 	IdleMaxMultiplierSet bool
+	// JobTimeoutDefault is the kill deadline for jobs without a positive payload
+	// or agent-type timeout. JobTimeoutMax is the hard ceiling for every effective
+	// timeout, preventing a delegation tree from granting itself an unbounded run.
+	// Both are read when a job is dispatched; changing either affects only jobs
+	// that have not started yet.
+	JobTimeoutDefault    time.Duration
+	JobTimeoutDefaultSet bool
+	JobTimeoutMax        time.Duration
+	JobTimeoutMaxSet     bool
 }
 
 // LoadDaemonRuntimeConfig parses the [daemon] section. A file with no [daemon]
@@ -132,6 +143,20 @@ func LoadDaemonRuntimeConfig(paths Paths) (DaemonRuntimeConfig, error) {
 			}
 			cfg.IdleMaxMultiplier = parsed
 			cfg.IdleMaxMultiplierSet = true
+		case "job_timeout_default":
+			parsed, err := parseConfigDuration(value)
+			if err != nil {
+				return DaemonRuntimeConfig{}, fmt.Errorf("parse [daemon].job_timeout_default: %w", err)
+			}
+			cfg.JobTimeoutDefault = parsed
+			cfg.JobTimeoutDefaultSet = true
+		case "job_timeout_max":
+			parsed, err := parseConfigDuration(value)
+			if err != nil {
+				return DaemonRuntimeConfig{}, fmt.Errorf("parse [daemon].job_timeout_max: %w", err)
+			}
+			cfg.JobTimeoutMax = parsed
+			cfg.JobTimeoutMaxSet = true
 		default:
 			// Unknown keys are ignored so the section can grow (e.g. #576 per-repo
 			// caps) without breaking older binaries.
@@ -189,5 +214,29 @@ func validateDaemonRuntimeConfig(cfg DaemonRuntimeConfig) error {
 	if cfg.IdleMaxMultiplierSet && cfg.IdleMaxMultiplier <= 0 {
 		return fmt.Errorf("[daemon].idle_max_multiplier must be positive")
 	}
+	if cfg.JobTimeoutDefaultSet && cfg.JobTimeoutDefault <= 0 {
+		return fmt.Errorf("[daemon].job_timeout_default must be positive")
+	}
+	if cfg.JobTimeoutMaxSet && cfg.JobTimeoutMax <= 0 {
+		return fmt.Errorf("[daemon].job_timeout_max must be positive")
+	}
+	jobTimeoutDefault, jobTimeoutMax := cfg.JobTimeoutPolicy()
+	if jobTimeoutDefault > jobTimeoutMax {
+		return fmt.Errorf("[daemon].job_timeout_default (%s) must not exceed [daemon].job_timeout_max (%s)", jobTimeoutDefault, jobTimeoutMax)
+	}
 	return nil
+}
+
+// JobTimeoutPolicy returns the effective daemon kill-deadline policy, applying
+// the safe defaults when either optional key is absent.
+func (cfg DaemonRuntimeConfig) JobTimeoutPolicy() (jobTimeoutDefault, jobTimeoutMax time.Duration) {
+	jobTimeoutDefault = DefaultDaemonJobTimeoutDefault
+	if cfg.JobTimeoutDefaultSet {
+		jobTimeoutDefault = cfg.JobTimeoutDefault
+	}
+	jobTimeoutMax = DefaultDaemonJobTimeoutMax
+	if cfg.JobTimeoutMaxSet {
+		jobTimeoutMax = cfg.JobTimeoutMax
+	}
+	return jobTimeoutDefault, jobTimeoutMax
 }

--- a/internal/config/daemon_runtime_test.go
+++ b/internal/config/daemon_runtime_test.go
@@ -33,7 +33,7 @@ func TestLoadDaemonRuntimeConfigParsesFields(t *testing.T) {
 	if err := Initialize(paths); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
-	writeConfig(t, paths, "[daemon]\npoll = \"45s\"\nworkers = 4\nscheduler = \"pool\"\nidle_grace_ticks = 5\nidle_max_multiplier = 8\n")
+	writeConfig(t, paths, "[daemon]\npoll = \"45s\"\nworkers = 4\nscheduler = \"pool\"\nidle_grace_ticks = 5\nidle_max_multiplier = 8\njob_timeout_default = \"3h\"\njob_timeout_max = \"6h\"\n")
 	cfg, err := LoadDaemonRuntimeConfig(paths)
 	if err != nil {
 		t.Fatalf("LoadDaemonRuntimeConfig: %v", err)
@@ -49,6 +49,16 @@ func TestLoadDaemonRuntimeConfigParsesFields(t *testing.T) {
 	}
 	if !cfg.IdleGraceTicksSet || cfg.IdleGraceTicks != 5 || !cfg.IdleMaxMultiplierSet || cfg.IdleMaxMultiplier != 8 {
 		t.Fatalf("idle cadence = %+v, want grace=5 max=8", cfg)
+	}
+	if gotDefault, gotMax := cfg.JobTimeoutPolicy(); gotDefault != 3*time.Hour || gotMax != 6*time.Hour {
+		t.Fatalf("job timeout policy = (%v, %v), want (3h, 6h)", gotDefault, gotMax)
+	}
+}
+
+func TestDaemonJobTimeoutPolicyDefaults(t *testing.T) {
+	gotDefault, gotMax := (DaemonRuntimeConfig{}).JobTimeoutPolicy()
+	if gotDefault != 4*time.Hour || gotMax != 8*time.Hour {
+		t.Fatalf("default job timeout policy = (%v, %v), want (4h, 8h)", gotDefault, gotMax)
 	}
 }
 
@@ -84,14 +94,19 @@ func TestLoadDaemonRuntimeConfigParallelSugar(t *testing.T) {
 
 func TestLoadDaemonRuntimeConfigRejectsBadValues(t *testing.T) {
 	cases := map[string]string{
-		"bad poll":               "[daemon]\npoll = \"nope\"\n",
-		"nonpositive poll":       "[daemon]\npoll = \"0s\"\n",
-		"bad workers":            "[daemon]\nworkers = 0\n",
-		"bad scheduler":          "[daemon]\nscheduler = \"turbo\"\n",
-		"parallel+workers":       "[daemon]\nparallel = 2\nworkers = 3\n",
-		"nonpositive parallel":   "[daemon]\nparallel = 0\n",
-		"nonpositive idle grace": "[daemon]\nidle_grace_ticks = 0\n",
-		"nonpositive idle max":   "[daemon]\nidle_max_multiplier = 0\n",
+		"bad poll":                "[daemon]\npoll = \"nope\"\n",
+		"nonpositive poll":        "[daemon]\npoll = \"0s\"\n",
+		"bad workers":             "[daemon]\nworkers = 0\n",
+		"bad scheduler":           "[daemon]\nscheduler = \"turbo\"\n",
+		"parallel+workers":        "[daemon]\nparallel = 2\nworkers = 3\n",
+		"nonpositive parallel":    "[daemon]\nparallel = 0\n",
+		"nonpositive idle grace":  "[daemon]\nidle_grace_ticks = 0\n",
+		"nonpositive idle max":    "[daemon]\nidle_max_multiplier = 0\n",
+		"bad job default":         "[daemon]\njob_timeout_default = \"nope\"\n",
+		"nonpositive job default": "[daemon]\njob_timeout_default = \"0s\"\n",
+		"bad job max":             "[daemon]\njob_timeout_max = \"nope\"\n",
+		"nonpositive job max":     "[daemon]\njob_timeout_max = \"0s\"\n",
+		"default exceeds max":     "[daemon]\njob_timeout_default = \"9h\"\njob_timeout_max = \"8h\"\n",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -101,6 +101,8 @@ artifact_blobs = %q
 # scheduler = "barrier"
 # idle_grace_ticks = 3       # consecutive all-304 polls before decay starts
 # idle_max_multiplier = 4   # 1 disables idle cadence decay
+# job_timeout_default = "4h" # kill deadline when payload and agent type omit one
+# job_timeout_max = "8h"     # hard ceiling; larger payload requests are clamped
 
 # [credentials] is OFF by default. When env_curation=true, only a pinned base
 # environment plus runtime-specific auth/state variables reaches runtime-agent

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -410,6 +410,25 @@ repo's in-flight jobs (`0` or unset = use the global worker count), and an
 optional `scheduler = "pool"|"barrier"` overrides that repo's scheduler. The
 keys are re-read every tick, so edits apply live.
 
+Job kill deadlines are independent from stale-running detection. Configure the
+daemon defaults with:
+
+```toml
+[daemon]
+job_timeout_default = "4h"
+job_timeout_max = "8h"
+```
+
+The effective deadline resolves in this order: a positive `job_timeout` in the
+job payload, the registered agent type's `[agents.<type>].job_timeout`, then
+`job_timeout_default`. `job_timeout_max` is a hard ceiling (default `8h`); a
+larger request is clamped and the job receives a `job_timeout_clamped` event
+recording the requested and applied durations. This prevents a delegation tree
+from granting itself an unbounded run. These keys are read when a job dispatches,
+so edits affect newly started jobs without changing an in-flight deadline.
+The 30-minute stale-running threshold remains only a crash-detection predicate;
+it is never used as a job kill deadline.
+
 Reconfigure the running daemon without a restart: `kill -HUP <daemon-pid>`
 re-reads the `[daemon]` config section (`poll`, `workers`, `scheduler`,
 parallelism, `idle_grace_ticks`, `idle_max_multiplier`) live (#577) — no teardown, no dropped jobs, no environment

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -317,6 +317,25 @@ One repo's concurrency can also be capped **from config, without any relaunch**,
 via a `[repos."owner/repo"]` section with `max_parallel = N` (#576) — see
 [Cap one repo's parallelism from config](../workflows/parallel-jobs-workflow.md#cap-one-repos-parallelism-from-config).
 
+Job kill deadlines are independent from stale-running detection. Configure the
+daemon defaults with:
+
+```toml
+[daemon]
+job_timeout_default = "4h"
+job_timeout_max = "8h"
+```
+
+The effective deadline resolves in this order: a positive `job_timeout` in the
+job payload, the registered agent type's `[agents.<type>].job_timeout`, then
+`job_timeout_default`. `job_timeout_max` is a hard ceiling (default `8h`); a
+larger request is clamped and the job receives a `job_timeout_clamped` event
+recording the requested and applied durations. This prevents a delegation tree
+from granting itself an unbounded run. These keys are read when a job dispatches,
+so edits affect newly started jobs without changing an in-flight deadline.
+The 30-minute stale-running threshold remains only a crash-detection predicate;
+it is never used as a job kill deadline.
+
 ### Reconfigure Without Restarting
 
 `kill -HUP <daemon-pid>` re-reads the `[daemon]` config section (`poll`,

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10254,6 +10254,25 @@ repo's in-flight jobs (`0` or unset = use the global worker count), and an
 optional `scheduler = "pool"|"barrier"` overrides that repo's scheduler. The
 keys are re-read every tick, so edits apply live.
 
+Job kill deadlines are independent from stale-running detection. Configure the
+daemon defaults with:
+
+```toml
+[daemon]
+job_timeout_default = "4h"
+job_timeout_max = "8h"
+```
+
+The effective deadline resolves in this order: a positive `job_timeout` in the
+job payload, the registered agent type's `[agents.<type>].job_timeout`, then
+`job_timeout_default`. `job_timeout_max` is a hard ceiling (default `8h`); a
+larger request is clamped and the job receives a `job_timeout_clamped` event
+recording the requested and applied durations. This prevents a delegation tree
+from granting itself an unbounded run. These keys are read when a job dispatches,
+so edits affect newly started jobs without changing an in-flight deadline.
+The 30-minute stale-running threshold remains only a crash-detection predicate;
+it is never used as a job kill deadline.
+
 Reconfigure the running daemon without a restart: `kill -HUP <daemon-pid>`
 re-reads the `[daemon]` config section (`poll`, `workers`, `scheduler`,
 parallelism, `idle_grace_ticks`, `idle_max_multiplier`) live (#577) — no teardown, no dropped jobs, no environment


### PR DESCRIPTION
WHAT:
SLICE-B: Implemented independent timeout authority for #1308 with a 4h default, 8h ceiling, correct registered-agent type lookup, instance overrides, and clamp auditing.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-85be3635

RESULTS:
- Targeted internal/config timeout tests passed.
- Targeted internal/cli timeout, Slice A compatibility, managed-agent, runtime-lock, and temporary-worker tests passed.
- All three required mutation checks produced the expected failures.
- npm run build:llms passed.
- git diff --check passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-85be3635

AGENTS:
- wave-impl-b-temp-local-implement-wave-impl-b-18c7683df59531a1

RAW FINAL REVIEW OUTPUT:
````text
SLICE-B: Implemented independent timeout authority for #1308 with a 4h default, 8h ceiling, correct registered-agent type lookup, instance overrides, and clamp auditing.
````
