### PR TITLE
Gitmoot: CAMPAIGN 1206/1304 SLICE 2 — THE CHECKER (from

### DIFF
--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -19,6 +19,7 @@ import (
 const (
 	blockedRoleWakeInterval    = time.Minute
 	blockedRoleSnapshotTimeout = 5 * time.Second
+	directiveTTLSweepLimit     = 200
 	// blockedEpisodeStaleGap bounds how long a role episode survives without being
 	// re-observed blocked. Within it, a transient unknown/absent snapshot blip is
 	// tolerated (the accrued blocked duration is preserved); beyond it the subject is
@@ -36,6 +37,12 @@ type blockedRoleWakeDependencies struct {
 	availability blockedRoleAvailability
 	provider     func([]config.OrgRole) org.Provider
 	eventSink    func(context.Context, *db.Store, string) (events.Sink, error)
+	directives   directiveTTLDependencies
+}
+
+type directiveTTLDependencies struct {
+	list func(context.Context, *db.Store, int) ([]db.OrgDirectiveObligation, error)
+	mark func(context.Context, *db.Store, int64, int, string, time.Time) (int, bool, error)
 }
 
 func defaultBlockedRoleWakeDependencies() blockedRoleWakeDependencies {
@@ -44,6 +51,20 @@ func defaultBlockedRoleWakeDependencies() blockedRoleWakeDependencies {
 		provider:     cockpit.NewHerdrOrgProvider,
 		eventSink:    enabledBlockedSinceEventSink,
 	}
+}
+
+func (d directiveTTLDependencies) listOpen(ctx context.Context, store *db.Store, limit int) ([]db.OrgDirectiveObligation, error) {
+	if d.list != nil {
+		return d.list(ctx, store, limit)
+	}
+	return store.ListOpenOrgDirectiveObligations(ctx, limit)
+}
+
+func (d directiveTTLDependencies) markNudged(ctx context.Context, store *db.Store, item db.OrgDirectiveObligation, now time.Time) (int, bool, error) {
+	if d.mark != nil {
+		return d.mark(ctx, store, item.ID, item.NudgeCount, item.LastNudgedAt, now)
+	}
+	return store.MarkOrgDirectiveNudged(ctx, item.ID, item.NudgeCount, item.LastNudgedAt, now)
 }
 
 // enabledBlockedSinceEventSink preserves the blocked-since path's stricter
@@ -226,6 +247,20 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 		// common OSS/automated-user case — never probes herdr and never logs.
 		return
 	}
+	// Directive supervision shares this existing one-minute lane but does not
+	// depend on a Herdr snapshot. Resolve the event-rule guard first: with zero
+	// enabled rules, sink is nil and no directive query is issued (config-inert).
+	var sink events.Sink
+	if deps.eventSink != nil {
+		sink, err = deps.eventSink(ctx, store, home)
+		if err != nil {
+			writeLine(stdout, "org directive TTL event sink unavailable: %v", err)
+		} else if sink != nil {
+			if err := evaluateOrgDirectiveTTLs(ctx, store, sink, orgConfig, stdout, now.UTC(), deps.directives); err != nil {
+				writeLine(stdout, "org directive TTL evaluation failed: %v", err)
+			}
+		}
+	}
 	// Herdr reachability gates the snapshot that BOTH org live-presence and the
 	// blocked-role wake need. This return was previously silent, which made a
 	// broken /org page impossible to diagnose from daemon.log for a deployment
@@ -264,15 +299,7 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 	// Blocked-role WAKE evaluation is the opt-in half: only when a wake threshold
 	// is configured and the blocked-role event rule yields a sink.
 	wakeAfter := resolveBlockedRoleWakeAfter(home)
-	if wakeAfter <= 0 || deps.eventSink == nil {
-		return
-	}
-	sink, err := deps.eventSink(ctx, store, home)
-	if err != nil {
-		writeLine(stdout, "blocked_since role event sink unavailable: %v", err)
-		return
-	}
-	if sink == nil {
+	if wakeAfter <= 0 || sink == nil {
 		return
 	}
 	if err := evaluateBlockedRoleEpisodes(ctx, store, sink, snapshot, wakeAfter, stdout, now.UTC()); err != nil {
@@ -281,6 +308,90 @@ func runBlockedRoleWakeOnce(ctx context.Context, store *db.Store, home string, s
 	if err := evaluateInputPendingRoleEpisodes(ctx, store, sink, snapshot, wakeAfter, stdout, now.UTC()); err != nil {
 		writeLine(stdout, "input_pending role evaluation failed: %v", err)
 	}
+}
+
+func evaluateOrgDirectiveTTLs(ctx context.Context, store *db.Store, sink events.Sink, orgConfig config.OrgConfig, stdout io.Writer, now time.Time, deps directiveTTLDependencies) error {
+	if store == nil || sink == nil {
+		return nil
+	}
+	now = now.UTC()
+	items, err := deps.listOpen(ctx, store, directiveTTLSweepLimit)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		from, to, _, _, ok := workflow.ParseOrgDirectiveNote(item.Body)
+		if !ok {
+			writeLine(stdout, "org directive %d TTL skipped: malformed directive marker", item.ID)
+			continue
+		}
+		anchor, ttl, phase, unacked, due := directiveTTLDue(item, orgConfig, now)
+		if !due {
+			continue
+		}
+		newCount, claimed, err := deps.markNudged(ctx, store, item, now)
+		if err != nil {
+			writeLine(stdout, "org directive %d nudge mark failed: %v", item.ID, err)
+			continue
+		}
+		if !claimed {
+			continue
+		}
+		events.EmitEvent(ctx, sink, buildDirectiveNudgeEvent(item, to, phase, anchor, ttl, newCount, now))
+		if unacked && newCount == orgConfig.DirectiveMaxNudges() {
+			events.EmitEvent(ctx, sink, buildDirectiveEscalationEvent(item, orgConfig, from, to, newCount, now))
+		}
+	}
+	return nil
+}
+
+func directiveTTLDue(item db.OrgDirectiveObligation, orgConfig config.OrgConfig, now time.Time) (anchor time.Time, ttl time.Duration, phase string, unacked, due bool) {
+	if strings.TrimSpace(item.AckedAt) == "" {
+		if item.NudgeCount >= orgConfig.DirectiveMaxNudges() {
+			return time.Time{}, 0, "", true, false
+		}
+		anchor = parseTranscriptStoreTime(item.CreatedAt)
+		ttl = orgConfig.DirectiveAckTTL()
+		phase = "acknowledgment"
+		unacked = true
+	} else {
+		anchor = parseTranscriptStoreTime(item.AckedAt)
+		ttl = orgConfig.DirectiveDoneTTL()
+		if item.DoneTTLOverrideSeconds >= 0 {
+			ttl = time.Duration(item.DoneTTLOverrideSeconds) * time.Second
+		}
+		phase = "completion"
+	}
+	if anchor.IsZero() || ttl <= 0 || now.Sub(anchor) <= ttl {
+		return anchor, ttl, phase, unacked, false
+	}
+	if lastText := strings.TrimSpace(item.LastNudgedAt); lastText != "" {
+		last := parseTranscriptStoreTime(lastText)
+		if last.IsZero() || now.Sub(last) <= ttl {
+			return anchor, ttl, phase, unacked, false
+		}
+	}
+	return anchor, ttl, phase, unacked, true
+}
+
+func buildDirectiveNudgeEvent(item db.OrgDirectiveObligation, target, phase string, anchor time.Time, ttl time.Duration, nudgeCount int, now time.Time) events.Event {
+	id := fmt.Sprint(item.ID)
+	detail := fmt.Sprintf("directive %s to %s awaits %s after %s; nudge %d", id, target, phase, now.Sub(anchor).Round(time.Second), nudgeCount)
+	ev := events.NewEvent(events.EventOrgDirective, id, db.WakeOutboxSourceWorkflowNote+":"+id, item.Repo, "overdue", detail, now, workflow.RedactCommentText)
+	ev.Cause = "directive_" + phase + "_overdue"
+	ev.WakeTargetRole = target
+	return ev
+}
+
+func buildDirectiveEscalationEvent(item db.OrgDirectiveObligation, orgConfig config.OrgConfig, sender, target string, nudgeCount int, now time.Time) events.Event {
+	id := fmt.Sprint(item.ID)
+	detail := fmt.Sprintf("directive %s to %s remains unacknowledged after %d nudges", id, target, nudgeCount)
+	ev := events.NewEvent(events.EventJobNeedsAttention, "org-directive:"+id, db.WakeOutboxSourceWorkflowNote+":"+id, item.Repo, "overdue", detail, now, workflow.RedactCommentText)
+	ev.Cause = "escalation"
+	if role, ok := orgConfig.Role(sender); ok {
+		ev.WakeTargetRole = role.Parent
+	}
+	return ev
 }
 
 func persistOrgRoleLivePresence(ctx context.Context, store *db.Store, snapshot org.Snapshot, stdout io.Writer) {

--- a/internal/cli/doctor_event_observers.go
+++ b/internal/cli/doctor_event_observers.go
@@ -23,10 +23,28 @@ type wakeTargetRoleProducer struct {
 
 var wakeTargetRoleProducers = []wakeTargetRoleProducer{
 	{
+		File:     "internal/cli/blocked_since.go",
+		Function: "buildDirectiveNudgeEvent",
+		Kinds:    directiveNudgeDirectedKinds,
+	},
+	{
+		File:     "internal/cli/blocked_since.go",
+		Function: "buildDirectiveEscalationEvent",
+		Kinds:    directiveEscalationDirectedKinds,
+	},
+	{
 		File:     "internal/cli/reply_wake_outbox.go",
 		Function: "wakeOutboxEvent",
 		Kinds:    wakeOutboxDirectedKinds,
 	},
+}
+
+func directiveNudgeDirectedKinds() []string {
+	return []string{db.WakeOutboxKindDirective}
+}
+
+func directiveEscalationDirectedKinds() []string {
+	return []string{db.WakeOutboxKindEscalation}
 }
 
 func eventObserverDoctorCheck(paths config.Paths) (doctor.Check, bool) {

--- a/internal/cli/event_rule_sink_test.go
+++ b/internal/cli/event_rule_sink_test.go
@@ -101,9 +101,9 @@ func TestClassifyEventRuleKinds(t *testing.T) {
 	}
 }
 
-func TestWakeTargetRoleHasExactlyOneProductionWriteInWakeOutboxEvent(t *testing.T) {
+func TestWakeTargetRoleProductionWritesMatchObserverRegistry(t *testing.T) {
 	writes := productionWakeTargetRoleWrites(t)
-	if got, want := fmt.Sprint(writes), "[internal/cli/reply_wake_outbox.go:wakeOutboxEvent]"; got != want {
+	if got, want := fmt.Sprint(writes), "[internal/cli/blocked_since.go:buildDirectiveEscalationEvent internal/cli/blocked_since.go:buildDirectiveNudgeEvent internal/cli/reply_wake_outbox.go:wakeOutboxEvent]"; got != want {
 		t.Fatalf("production WakeTargetRole writes = %s, want %s", got, want)
 	}
 	registryWrites := make([]wakeTargetRoleWrite, 0, len(wakeTargetRoleProducers))

--- a/internal/cli/org_directive_ttl_test.go
+++ b/internal/cli/org_directive_ttl_test.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/events"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func writeDirectiveTTLConfig(t *testing.T, home, supervisor string, ackTTL, doneTTL time.Duration, maxNudges int) config.OrgConfig {
+	t.Helper()
+	paths := config.PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	body := fmt.Sprintf(`[org]
+directive_ack_ttl = %q
+directive_done_ttl = %q
+directive_max_nudges = %d
+[org.roles."owner"]
+scope = ["*"]
+[org.roles.%q]
+parent = "owner"
+scope = ["*"]
+[org.roles."sender"]
+parent = %q
+scope = ["*"]
+[org.roles."worker"]
+parent = "sender"
+scope = ["*"]
+`, ackTTL.String(), doneTTL.String(), maxNudges, supervisor, supervisor)
+	if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.LoadOrg(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
+}
+
+func openDirectiveTTLStore(t *testing.T, home string) *db.Store {
+	t.Helper()
+	store, err := db.Open(config.PathsForHome(home).Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func seedDirectiveTTLNote(t *testing.T, store *db.Store, body string, doneTTL time.Duration, override bool) db.WorkflowNote {
+	t.Helper()
+	note, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID:              "release/ttl",
+		Author:                  "sender",
+		Body:                    workflow.FormatOrgDirectiveNote("sender", "worker", "release/ttl", body),
+		Repo:                    "gitmoot/gitmoot",
+		DirectiveDoneTTLSeconds: int64(doneTTL / time.Second),
+		DirectiveDoneTTLSet:     override,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return note
+}
+
+func acknowledgeDirectiveTTLNote(t *testing.T, store *db.Store, directive db.WorkflowNote) {
+	t.Helper()
+	if _, err := store.InsertWorkflowNote(context.Background(), db.WorkflowNote{
+		WorkflowID: directive.WorkflowID,
+		Author:     "worker",
+		Body:       workflow.FormatOrgDirectiveAckNote(directive.ID, "worker"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readDirectiveTTLObligation(t *testing.T, store *db.Store, id int64) db.OrgDirectiveObligation {
+	t.Helper()
+	items, err := store.ListOpenOrgDirectiveObligations(context.Background(), 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range items {
+		if item.ID == id {
+			return item
+		}
+	}
+	t.Fatalf("directive %d not found in %+v", id, items)
+	return db.OrgDirectiveObligation{}
+}
+
+func TestDirectiveTTLNudgesOncePerInterval(t *testing.T) {
+	home := t.TempDir()
+	cfg := writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, 0, 3)
+	store := openDirectiveTTLStore(t, home)
+	defer store.Close()
+	directive := seedDirectiveTTLNote(t, store, "ack this", 0, false)
+	now := time.Now().UTC().Add(20 * time.Minute)
+	sink := &recordingSink{}
+
+	for _, step := range []struct {
+		at        time.Time
+		wantCount int
+		wantWakes int
+	}{
+		{at: now, wantCount: 1, wantWakes: 1},
+		{at: now.Add(time.Minute), wantCount: 1, wantWakes: 1},
+		{at: now.Add(11 * time.Minute), wantCount: 2, wantWakes: 2},
+	} {
+		if err := evaluateOrgDirectiveTTLs(context.Background(), store, sink, cfg, io.Discard, step.at, directiveTTLDependencies{}); err != nil {
+			t.Fatal(err)
+		}
+		item := readDirectiveTTLObligation(t, store, directive.ID)
+		if item.NudgeCount != step.wantCount || len(sink.byType(events.EventOrgDirective)) != step.wantWakes {
+			t.Fatalf("at %s nudge_count=%d wakes=%d, want %d/%d", step.at, item.NudgeCount, len(sink.byType(events.EventOrgDirective)), step.wantCount, step.wantWakes)
+		}
+	}
+}
+
+func TestDirectiveTTLNudgeCountSurvivesDaemonRestart(t *testing.T) {
+	home := t.TempDir()
+	cfg := writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, 0, 3)
+	store := openDirectiveTTLStore(t, home)
+	directive := seedDirectiveTTLNote(t, store, "persist the counter", 0, false)
+	now := time.Now().UTC().Add(20 * time.Minute)
+	if err := evaluateOrgDirectiveTTLs(context.Background(), store, &recordingSink{}, cfg, io.Discard, now, directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// A fresh store and evaluator instance must continue from the durable row.
+	store = openDirectiveTTLStore(t, home)
+	defer store.Close()
+	if err := evaluateOrgDirectiveTTLs(context.Background(), store, &recordingSink{}, cfg, io.Discard, now.Add(11*time.Minute), directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := readDirectiveTTLObligation(t, store, directive.ID).NudgeCount; got != 2 {
+		t.Fatalf("nudge_count after restart = %d, want 2", got)
+	}
+}
+
+func TestDirectiveTTLEscalatesAtMaxToCurrentSenderParent(t *testing.T) {
+	home := t.TempDir()
+	cfg := writeDirectiveTTLConfig(t, home, "old-supervisor", 10*time.Minute, 0, 2)
+	store := openDirectiveTTLStore(t, home)
+	defer store.Close()
+	directive := seedDirectiveTTLNote(t, store, "needs supervision", 0, false)
+	now := time.Now().UTC().Add(20 * time.Minute)
+	sink := &recordingSink{}
+	if err := evaluateOrgDirectiveTTLs(context.Background(), store, sink, cfg, io.Discard, now, directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(sink.byType(events.EventJobNeedsAttention)); got != 0 {
+		t.Fatalf("escalations after first nudge = %d, want 0", got)
+	}
+
+	// Parentage is resolved at evaluation time, not copied from the send.
+	cfg = writeDirectiveTTLConfig(t, home, "new-supervisor", 10*time.Minute, 0, 2)
+	if err := evaluateOrgDirectiveTTLs(context.Background(), store, sink, cfg, io.Discard, now.Add(11*time.Minute), directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	escalations := sink.byType(events.EventJobNeedsAttention)
+	if len(escalations) != 1 {
+		t.Fatalf("escalations = %+v, want exactly one at max_nudges", escalations)
+	}
+	ev := escalations[0]
+	if ev.WakeTargetRole != "new-supervisor" || ev.WakeTargetRole == "worker" || ev.Cause != "escalation" {
+		t.Fatalf("escalation routing = %+v", ev)
+	}
+	for _, want := range []string{fmt.Sprint(directive.ID), "worker", "2 nudges"} {
+		if !strings.Contains(ev.Detail, want) {
+			t.Fatalf("escalation detail %q missing %q", ev.Detail, want)
+		}
+	}
+	if err := evaluateOrgDirectiveTTLs(context.Background(), store, sink, cfg, io.Discard, now.Add(22*time.Minute), directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(sink.byType(events.EventJobNeedsAttention)); got != 1 {
+		t.Fatalf("escalations after max = %d, want 1", got)
+	}
+}
+
+func TestDirectiveTTLAckSkipsAckNudgesAndDoneOverrideWins(t *testing.T) {
+	home := t.TempDir()
+	cfg := writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, 0, 3)
+	store := openDirectiveTTLStore(t, home)
+	defer store.Close()
+	ackOnly := seedDirectiveTTLNote(t, store, "ack only", 0, false)
+	overridden := seedDirectiveTTLNote(t, store, "completion override", time.Minute, true)
+	acknowledgeDirectiveTTLNote(t, store, ackOnly)
+	acknowledgeDirectiveTTLNote(t, store, overridden)
+	sink := &recordingSink{}
+	now := time.Now().UTC().Add(20 * time.Minute)
+	if err := evaluateOrgDirectiveTTLs(context.Background(), store, sink, cfg, io.Discard, now, directiveTTLDependencies{}); err != nil {
+		t.Fatal(err)
+	}
+	wakes := sink.byType(events.EventOrgDirective)
+	if len(wakes) != 1 || wakes[0].JobID != fmt.Sprint(overridden.ID) || !strings.Contains(wakes[0].Detail, "completion") {
+		t.Fatalf("completion wakes = %+v, want only overridden directive %d", wakes, overridden.ID)
+	}
+	if got := readDirectiveTTLObligation(t, store, ackOnly.ID).NudgeCount; got != 0 {
+		t.Fatalf("acked directive got %d ack nudges, want 0", got)
+	}
+}
+
+func TestDirectiveTTLEvaluatorIsConfigInertWithNoRules(t *testing.T) {
+	home := t.TempDir()
+	writeDirectiveTTLConfig(t, home, "supervisor", 10*time.Minute, 0, 3)
+	store := openDirectiveTTLStore(t, home)
+	defer store.Close()
+	directive := seedDirectiveTTLNote(t, store, "must remain untouched", 0, false)
+	listCalls := 0
+	deps := blockedRoleWakeDependencies{
+		availability: &fakeBlockedRoleAvailability{available: false},
+		eventSink:    enabledBlockedSinceEventSink,
+		directives: directiveTTLDependencies{list: func(context.Context, *db.Store, int) ([]db.OrgDirectiveObligation, error) {
+			listCalls++
+			t.Fatal("directive query ran without an enabled org event rule")
+			return nil, nil
+		}},
+	}
+	runBlockedRoleWakeOnce(context.Background(), store, home, io.Discard, time.Now().UTC().Add(time.Hour), deps)
+	if listCalls != 0 {
+		t.Fatalf("directive queries beyond rule guard = %d, want 0", listCalls)
+	}
+	if got := readDirectiveTTLObligation(t, store, directive.ID).NudgeCount; got != 0 {
+		t.Fatalf("config-inert nudge_count = %d, want 0", got)
+	}
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -607,6 +607,9 @@ path = ""
 # this phase (owner | self | none).
 # [org]
 # enforce = "block"
+# directive_ack_ttl = "10m"
+# directive_done_ttl = "0s" # disabled; a per-directive override takes precedence
+# directive_max_nudges = 3
 # [org.roles."owner"]
 # scope = ["*"]
 # merge_rule = "owner"

--- a/internal/config/org.go
+++ b/internal/config/org.go
@@ -28,10 +28,13 @@ type OrgRole struct {
 // OrgConfig is the local organization registry. Its fields stay private so the
 // loader remains the single place that establishes its invariants.
 type OrgConfig struct {
-	enforce        string
-	recycleAfter   time.Duration
-	recycleEnforce string
-	roles          map[string]OrgRole
+	enforce            string
+	recycleAfter       time.Duration
+	recycleEnforce     string
+	directiveAckTTL    time.Duration
+	directiveDoneTTL   time.Duration
+	directiveMaxNudges int
+	roles              map[string]OrgRole
 }
 
 func (c OrgConfig) Enabled() bool { return len(c.roles) > 0 }
@@ -60,6 +63,24 @@ func (c OrgConfig) RecycleEnforce() string {
 		return "off"
 	}
 	return c.recycleEnforce
+}
+
+func (c OrgConfig) DirectiveAckTTL() time.Duration {
+	if c.directiveAckTTL <= 0 {
+		return 10 * time.Minute
+	}
+	return c.directiveAckTTL
+}
+
+func (c OrgConfig) DirectiveDoneTTL() time.Duration {
+	return c.directiveDoneTTL
+}
+
+func (c OrgConfig) DirectiveMaxNudges() int {
+	if c.directiveMaxNudges <= 0 {
+		return 3
+	}
+	return c.directiveMaxNudges
 }
 
 // Ancestors returns name's parent chain, nearest parent first. The cycle guard
@@ -154,6 +175,9 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 	seenEnforce := false
 	seenRecycleAfter := false
 	seenRecycleEnforce := false
+	seenDirectiveAckTTL := false
+	seenDirectiveDoneTTL := false
+	seenDirectiveMaxNudges := false
 	current := ""
 	inOrg := false
 	lines := strings.Split(string(content), "\n")
@@ -210,7 +234,8 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 		if current == "" {
 			// Recycle fields are binary-first: binaries predating this allowlist
 			// fail closed on a config that uses either field.
-			if key != "enforce" && key != "recycle_after" && key != "recycle_enforce" {
+			if key != "enforce" && key != "recycle_after" && key != "recycle_enforce" &&
+				key != "directive_ack_ttl" && key != "directive_done_ttl" && key != "directive_max_nudges" {
 				return OrgConfig{}, fmt.Errorf("unknown [org] field %q", key)
 			}
 			switch key {
@@ -244,6 +269,42 @@ func LoadOrg(paths Paths) (OrgConfig, error) {
 					return OrgConfig{}, fmt.Errorf("parse [org].recycle_enforce: %w", err)
 				}
 				cfg.recycleEnforce = v
+			case "directive_ack_ttl":
+				if seenDirectiveAckTTL {
+					return OrgConfig{}, fmt.Errorf("duplicate [org].directive_ack_ttl")
+				}
+				seenDirectiveAckTTL = true
+				v, err := parseOrgDuration(value)
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("parse [org].directive_ack_ttl: %w", err)
+				}
+				if v <= 0 {
+					return OrgConfig{}, fmt.Errorf("org directive_ack_ttl must be positive")
+				}
+				cfg.directiveAckTTL = v
+			case "directive_done_ttl":
+				if seenDirectiveDoneTTL {
+					return OrgConfig{}, fmt.Errorf("duplicate [org].directive_done_ttl")
+				}
+				seenDirectiveDoneTTL = true
+				v, err := parseOrgDuration(value)
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("parse [org].directive_done_ttl: %w", err)
+				}
+				cfg.directiveDoneTTL = v
+			case "directive_max_nudges":
+				if seenDirectiveMaxNudges {
+					return OrgConfig{}, fmt.Errorf("duplicate [org].directive_max_nudges")
+				}
+				seenDirectiveMaxNudges = true
+				v, err := strconv.Atoi(strings.TrimSpace(value))
+				if err != nil {
+					return OrgConfig{}, fmt.Errorf("parse [org].directive_max_nudges: expected integer")
+				}
+				if v <= 0 {
+					return OrgConfig{}, fmt.Errorf("org directive_max_nudges must be positive")
+				}
+				cfg.directiveMaxNudges = v
 			}
 			continue
 		}
@@ -423,6 +484,15 @@ func ValidateOrg(cfg OrgConfig) error {
 	}
 	if cfg.recycleAfter < 0 {
 		return fmt.Errorf("org recycle_after must not be negative")
+	}
+	if cfg.directiveAckTTL < 0 {
+		return fmt.Errorf("org directive_ack_ttl must not be negative")
+	}
+	if cfg.directiveDoneTTL < 0 {
+		return fmt.Errorf("org directive_done_ttl must not be negative")
+	}
+	if cfg.directiveMaxNudges < 0 {
+		return fmt.Errorf("org directive_max_nudges must not be negative")
 	}
 	if mode := cfg.RecycleEnforce(); mode != "off" && mode != "warn" && mode != "block" {
 		return fmt.Errorf("org recycle_enforce must be \"off\", \"warn\", or \"block\"")

--- a/internal/config/org_test.go
+++ b/internal/config/org_test.go
@@ -124,6 +124,48 @@ recycle_after = "0s"
 	}
 }
 
+func TestLoadOrgDirectiveTTLPolicy(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name       string
+		fields     string
+		wantAck    time.Duration
+		wantDone   time.Duration
+		wantNudges int
+		wantErr    string
+	}{
+		{name: "defaults", wantAck: 10 * time.Minute, wantNudges: 3},
+		{name: "configured", fields: "directive_ack_ttl = \"15m\"\ndirective_done_ttl = \"2h\"\ndirective_max_nudges = 5\n", wantAck: 15 * time.Minute, wantDone: 2 * time.Hour, wantNudges: 5},
+		{name: "done disabled", fields: "directive_done_ttl = \"0s\"\n", wantAck: 10 * time.Minute, wantNudges: 3},
+		{name: "ack must be positive", fields: "directive_ack_ttl = \"0s\"\n", wantErr: "directive_ack_ttl must be positive"},
+		{name: "nudges must be positive", fields: "directive_max_nudges = 0\n", wantErr: "directive_max_nudges must be positive"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body := "[org]\n" + test.fields + "[org.roles.\"owner\"]\nscope=[\"*\"]\n"
+			if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadOrg(paths)
+			if test.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+					t.Fatalf("LoadOrg() error = %v, want containing %q", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.DirectiveAckTTL() != test.wantAck || cfg.DirectiveDoneTTL() != test.wantDone || cfg.DirectiveMaxNudges() != test.wantNudges {
+				t.Fatalf("directive policy = ack %s done %s nudges %d", cfg.DirectiveAckTTL(), cfg.DirectiveDoneTTL(), cfg.DirectiveMaxNudges())
+			}
+		})
+	}
+}
+
 func TestLoadOrgRecycleAfterFailsClosed(t *testing.T) {
 	paths := PathsForHome(t.TempDir())
 	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {

--- a/internal/db/event_rules_test.go
+++ b/internal/db/event_rules_test.go
@@ -119,18 +119,31 @@ func TestEventRuleScopeMigrationDefaultsLegacyRowsToAddressed(t *testing.T) {
 
 func TestEventRuleCatchAllMigrationPromotesOnlyNonReplyRulesToObserver(t *testing.T) {
 	ctx := context.Background()
+	const (
+		wantBackfillMigration  = 107
+		wantDirectiveMigration = 108
+	)
 	var backfillMigration int
+	var directiveMigration int
 	for i, migration := range migrations {
 		if strings.Contains(migration, "scope = 'observer'") && strings.Contains(migration, "on_kind <> 'reply'") {
 			backfillMigration = i
-			break
+		}
+		if strings.Contains(migration, "directive_nudge_count") && strings.Contains(migration, "directive_last_nudged_at") {
+			directiveMigration = i
 		}
 	}
 	if backfillMigration == 0 {
 		t.Fatal("event rule observer catch-all migration not found")
 	}
-	if backfillMigration != len(migrations)-1 {
-		t.Fatalf("observer catch-all migration index=%d, want append-only tail index=%d", backfillMigration, len(migrations)-1)
+	if directiveMigration == 0 {
+		t.Fatal("directive supervision migration not found")
+	}
+	if backfillMigration != wantBackfillMigration {
+		t.Fatalf("observer catch-all migration index=%d, want preserved append-only index=%d", backfillMigration, wantBackfillMigration)
+	}
+	if directiveMigration != wantDirectiveMigration || directiveMigration != len(migrations)-1 {
+		t.Fatalf("directive supervision migration index=%d, want append-only tail index=%d (slice tail=%d)", directiveMigration, wantDirectiveMigration, len(migrations)-1)
 	}
 
 	raw, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "catch-all.db"))

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1860,4 +1860,18 @@ WHERE scope = 'addressed'
 	AND on_kind <> 'reply'
 	AND TRIM(COALESCE(match_filter, '')) = '';
 	`,
+	// #1206/#1304 restart-safe directive supervision. The directive remains the
+	// original workflow_notes row; these additive columns persist evaluator
+	// cadence across daemon restarts. -1 means inherit the global done TTL, while
+	// 0 is an explicit per-directive disable.
+	`
+ALTER TABLE workflow_notes ADD COLUMN directive_done_ttl_seconds INTEGER NOT NULL DEFAULT -1
+	CHECK(directive_done_ttl_seconds >= -1);
+ALTER TABLE workflow_notes ADD COLUMN directive_nudge_count INTEGER NOT NULL DEFAULT 0
+	CHECK(directive_nudge_count >= 0);
+ALTER TABLE workflow_notes ADD COLUMN directive_last_nudged_at TEXT NOT NULL DEFAULT '';
+CREATE INDEX idx_workflow_notes_directive_oldest
+	ON workflow_notes(created_at, id)
+	WHERE substr(body, 1, length('[org:directive ')) = '[org:directive ';
+	`,
 }

--- a/internal/db/workflow_store.go
+++ b/internal/db/workflow_store.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 	"unicode/utf8"
 )
 
@@ -72,9 +73,25 @@ type WorkflowNote struct {
 	AddressedTarget string `json:"-"`
 	// AddressedWakeKind selects the durable addressed-note route. Empty keeps
 	// the established reply route for every existing caller.
-	AddressedWakeKind   string `json:"-"`
-	MemoryObservationID int64  `json:"memory_observation_id,omitempty"`
-	CreatedAt           string `json:"created_at"`
+	AddressedWakeKind string `json:"-"`
+	// DirectiveDoneTTLSeconds is evaluator-only metadata. When Set is false the
+	// row stores -1 and inherits [org].directive_done_ttl; zero explicitly turns
+	// completion nudges off for this directive.
+	DirectiveDoneTTLSeconds int64  `json:"-"`
+	DirectiveDoneTTLSet     bool   `json:"-"`
+	MemoryObservationID     int64  `json:"memory_observation_id,omitempty"`
+	CreatedAt               string `json:"created_at"`
+}
+
+// OrgDirectiveObligation is the evaluator projection for one open directive.
+// AckedAt is empty until a typed ack receipt exists. Cancelled and completed
+// directives are excluded by the query.
+type OrgDirectiveObligation struct {
+	WorkflowNote
+	AckedAt                string
+	NudgeCount             int
+	LastNudgedAt           string
+	DoneTTLOverrideSeconds int64
 }
 
 // WorkflowMeta is the latest external-coordinator handoff identity recorded for
@@ -419,9 +436,16 @@ func workflowMetaStatusTx(ctx context.Context, tx *sql.Tx, workflowID string) (s
 }
 
 func insertWorkflowNoteTx(ctx context.Context, tx *sql.Tx, note WorkflowNote) (int64, error) {
+	doneTTLSeconds := int64(-1)
+	if note.DirectiveDoneTTLSet {
+		if note.DirectiveDoneTTLSeconds < 0 {
+			return 0, fmt.Errorf("directive done TTL seconds must not be negative")
+		}
+		doneTTLSeconds = note.DirectiveDoneTTLSeconds
+	}
 	res, err := tx.ExecContext(ctx, `
-INSERT INTO workflow_notes(workflow_id, author, body, repo, memory_observation_id)
-VALUES (?, ?, ?, ?, ?)`, note.WorkflowID, note.Author, note.Body, note.Repo, note.MemoryObservationID)
+INSERT INTO workflow_notes(workflow_id, author, body, repo, memory_observation_id, directive_done_ttl_seconds)
+VALUES (?, ?, ?, ?, ?, ?)`, note.WorkflowID, note.Author, note.Body, note.Repo, note.MemoryObservationID, doneTTLSeconds)
 	if err != nil {
 		return 0, fmt.Errorf("insert workflow note: %w", err)
 	}
@@ -809,6 +833,78 @@ ORDER BY d.created_at ASC, d.id ASC`, targetRole, targetRole, targetRole)
 		notes = append(notes, note)
 	}
 	return notes, rows.Err()
+}
+
+// ListOpenOrgDirectiveObligations returns open directives oldest-first. The
+// bounded ASC window is deliberate: a DESC+LIMIT query would discard exactly
+// the oldest, most overdue obligations.
+func (s *Store) ListOpenOrgDirectiveObligations(ctx context.Context, limit int) ([]OrgDirectiveObligation, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 200
+	}
+	rows, err := s.db.QueryContext(ctx, `
+SELECT d.id, d.workflow_id, d.author, d.body, d.repo, d.memory_observation_id, d.created_at,
+	d.directive_nudge_count, d.directive_last_nudged_at, d.directive_done_ttl_seconds,
+	COALESCE((
+		SELECT MIN(a.created_at) FROM workflow_notes a
+		WHERE a.workflow_id = d.workflow_id
+			AND substr(a.body, 1, length('[org:directive-ack id=' || d.id || ' ')) = '[org:directive-ack id=' || d.id || ' '
+	), '')
+FROM workflow_notes d INDEXED BY idx_workflow_notes_directive_oldest
+WHERE substr(d.body, 1, length('[org:directive ')) = '[org:directive '
+	AND NOT EXISTS (
+		SELECT 1 FROM workflow_notes r
+		WHERE r.workflow_id = d.workflow_id AND (
+			substr(r.body, 1, length('[org:directive-cancel id=' || d.id || ' ')) = '[org:directive-cancel id=' || d.id || ' '
+			OR substr(r.body, 1, length('[org:directive-done id=' || d.id || ' ')) = '[org:directive-done id=' || d.id || ' '
+		)
+	)
+ORDER BY d.created_at ASC, d.id ASC
+LIMIT ?`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	obligations := make([]OrgDirectiveObligation, 0)
+	for rows.Next() {
+		var item OrgDirectiveObligation
+		if err := rows.Scan(
+			&item.ID, &item.WorkflowID, &item.Author, &item.Body, &item.Repo,
+			&item.MemoryObservationID, &item.CreatedAt, &item.NudgeCount,
+			&item.LastNudgedAt, &item.DoneTTLOverrideSeconds, &item.AckedAt,
+		); err != nil {
+			return nil, err
+		}
+		obligations = append(obligations, item)
+	}
+	return obligations, rows.Err()
+}
+
+// MarkOrgDirectiveNudged atomically advances one persisted counter. The
+// expected values make a repeated or concurrent evaluator pass a no-op rather
+// than a duplicate wake.
+func (s *Store) MarkOrgDirectiveNudged(ctx context.Context, id int64, expectedCount int, expectedLastNudgedAt string, nudgedAt time.Time) (int, bool, error) {
+	stamp := nudgedAt.UTC().Format(time.RFC3339Nano)
+	result, err := s.db.ExecContext(ctx, `
+UPDATE workflow_notes
+SET directive_nudge_count = directive_nudge_count + 1,
+	directive_last_nudged_at = ?
+WHERE id = ?
+	AND directive_nudge_count = ?
+	AND directive_last_nudged_at = ?
+	AND substr(body, 1, length('[org:directive ')) = '[org:directive '`,
+		stamp, id, expectedCount, expectedLastNudgedAt)
+	if err != nil {
+		return expectedCount, false, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return expectedCount, false, err
+	}
+	if affected == 0 {
+		return expectedCount, false, nil
+	}
+	return expectedCount + 1, true, nil
 }
 
 func (s *Store) ListWorkflowSummaries(ctx context.Context) ([]WorkflowSummary, error) {

--- a/internal/db/workflow_store_test.go
+++ b/internal/db/workflow_store_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -216,6 +217,66 @@ func TestListUnacknowledgedOrgDirectivesKeepsOldestFirst(t *testing.T) {
 	}
 	if len(notes) != 2 || notes[0].ID != second.ID || notes[1].ID != third.ID {
 		t.Fatalf("unacknowledged directives = %+v, want ids [%d %d] oldest first", notes, second.ID, third.ID)
+	}
+}
+
+func TestListOpenOrgDirectiveObligationsKeepsOldestAndPersistsNudges(t *testing.T) {
+	store := openWorkflowTestStore(t)
+	ctx := context.Background()
+	insert := func(body string, doneTTLSeconds int64, set bool) WorkflowNote {
+		t.Helper()
+		note, err := store.InsertWorkflowNote(ctx, WorkflowNote{
+			WorkflowID: "release/ttl", Author: "owner", Body: body,
+			DirectiveDoneTTLSeconds: doneTTLSeconds, DirectiveDoneTTLSet: set,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return note
+	}
+	first := insert("[org:directive to=worker from=owner wf=release/ttl] first", 90, true)
+	second := insert("[org:directive to=worker from=owner wf=release/ttl] second", 0, false)
+	third := insert("[org:directive to=worker from=owner wf=release/ttl] third", 0, false)
+	done := insert("[org:directive to=worker from=owner wf=release/ttl] done", 0, false)
+	for id, createdAt := range map[int64]string{
+		first.ID:  "2026-07-01 00:00:00",
+		second.ID: "2026-07-02 00:00:00",
+		third.ID:  "2026-07-03 00:00:00",
+		done.ID:   "2026-07-04 00:00:00",
+	} {
+		if _, err := store.db.ExecContext(ctx, `UPDATE workflow_notes SET created_at = ? WHERE id = ?`, createdAt, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/ttl", Author: "worker", Body: fmt.Sprintf("[org:directive-ack id=%d by=worker]", first.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.InsertWorkflowNote(ctx, WorkflowNote{WorkflowID: "release/ttl", Author: "worker", Body: fmt.Sprintf("[org:directive-done id=%d by=worker]", done.ID)}); err != nil {
+		t.Fatal(err)
+	}
+
+	items, err := store.ListOpenOrgDirectiveObligations(ctx, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// MUTANT F6: ORDER BY created_at DESC drops first, the oldest obligation.
+	if len(items) != 2 || items[0].ID != first.ID || items[1].ID != second.ID {
+		t.Fatalf("open directives = %+v, want oldest ids [%d %d]", items, first.ID, second.ID)
+	}
+	if items[0].AckedAt == "" || items[0].DoneTTLOverrideSeconds != 90 {
+		t.Fatalf("first obligation = %+v, want ack plus 90s done override", items[0])
+	}
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	count, claimed, err := store.MarkOrgDirectiveNudged(ctx, first.ID, 0, "", now)
+	if err != nil || !claimed || count != 1 {
+		t.Fatalf("mark nudge = count %d claimed %v err %v", count, claimed, err)
+	}
+	if _, claimed, err := store.MarkOrgDirectiveNudged(ctx, first.ID, 0, "", now); err != nil || claimed {
+		t.Fatalf("stale nudge CAS claimed=%v err=%v", claimed, err)
+	}
+	items, err = store.ListOpenOrgDirectiveObligations(ctx, 1)
+	if err != nil || len(items) != 1 || items[0].NudgeCount != 1 || items[0].LastNudgedAt == "" {
+		t.Fatalf("persisted nudge = %+v err=%v", items, err)
 	}
 }
 

--- a/internal/workflow/org_directive.go
+++ b/internal/workflow/org_directive.go
@@ -6,6 +6,7 @@ const (
 	OrgDirectivePrefix       = "[org:directive "
 	OrgDirectiveAckPrefix    = "[org:directive-ack "
 	OrgDirectiveCancelPrefix = "[org:directive-cancel "
+	OrgDirectiveDonePrefix   = "[org:directive-done "
 )
 
 func FormatOrgDirectiveNote(from, to, wf, directive string) string {
@@ -36,6 +37,14 @@ func FormatOrgDirectiveCancelNote(directiveID int64, by string) string {
 
 func ParseOrgDirectiveCancelNote(body string) (directiveID int64, by string, ok bool) {
 	return parseOrgDirectiveReceipt("directive-cancel", body)
+}
+
+func FormatOrgDirectiveDoneNote(directiveID int64, by string) string {
+	return formatOrgDirectiveReceipt("directive-done", directiveID, by)
+}
+
+func ParseOrgDirectiveDoneNote(body string) (directiveID int64, by string, ok bool) {
+	return parseOrgDirectiveReceipt("directive-done", body)
 }
 
 func formatOrgDirectiveReceipt(kind string, directiveID int64, by string) string {

--- a/internal/workflow/org_directive_test.go
+++ b/internal/workflow/org_directive_test.go
@@ -15,6 +15,7 @@ func TestOrgDirectiveNoteSchemas(t *testing.T) {
 	}{
 		{"ack", FormatOrgDirectiveAckNote(42, "worker"), ParseOrgDirectiveAckNote},
 		{"cancel", FormatOrgDirectiveCancelNote(42, "owner"), ParseOrgDirectiveCancelNote},
+		{"done", FormatOrgDirectiveDoneNote(42, "worker"), ParseOrgDirectiveDoneNote},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1388,8 +1388,20 @@ the addressed target or one of its configured ancestors and records receipt,
 not completion. `gitmoot org directive cancel <id> [--by <role>] [--home
 <dir>]` is restricted to the sender. Both commands require an acting identity
 from `--by` or `GITMOOT_ORG_ROLE`; missing identity fails closed. They append
-typed markers to the directive's workflow journal; completion tracking belongs
-to the later directive-ledger slice.
+typed markers to the directive's workflow journal.
+
+The daemon evaluates directive TTLs on the existing one-minute org supervision
+lane. `[org].directive_ack_ttl` defaults to `10m`,
+`[org].directive_done_ttl` defaults to `0s` (completion nudges off), and
+`[org].directive_max_nudges` defaults to `3`. An unacknowledged directive is
+re-woken at most once per ack-TTL interval. When its persisted nudge count
+reaches the maximum, Gitmoot emits an escalation addressed to the sender's
+current parent in the org chart. Acknowledgment stops ack nudges; an acknowledged
+but unfinished directive is evaluated only when its completion TTL is enabled.
+An internal per-directive completion-TTL override, when present, takes
+precedence over the global value. Typed completion or cancellation receipts
+close the evaluator obligation. With no enabled org event rules, the lane is
+config-inert: it performs no directive scan and emits nothing.
 
 Event-rule wakes are separately opt-in:
 

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1257,6 +1257,19 @@ not completion. `gitmoot org directive cancel <id> [--by <role>] [--home
 from `--by` or `GITMOOT_ORG_ROLE`; missing identity fails closed. They append
 typed markers to the directive's workflow journal.
 
+The daemon evaluates directive TTLs on the existing one-minute org supervision
+lane. `[org].directive_ack_ttl` defaults to `10m`,
+`[org].directive_done_ttl` defaults to `0s` (completion nudges off), and
+`[org].directive_max_nudges` defaults to `3`. An unacknowledged directive is
+re-woken at most once per ack-TTL interval. When its persisted nudge count
+reaches the maximum, Gitmoot emits an escalation addressed to the sender's
+current parent in the org chart. Acknowledgment stops ack nudges; an acknowledged
+but unfinished directive is evaluated only when its completion TTL is enabled.
+An internal per-directive completion-TTL override, when present, takes
+precedence over the global value. Typed completion or cancellation receipts
+close the evaluator obligation. With no enabled org event rules, the lane is
+config-inert: it performs no directive scan and emits nothing.
+
 Event-rule wakes are separately opt-in:
 
 ```sh

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11232,8 +11232,20 @@ the addressed target or one of its configured ancestors and records receipt,
 not completion. `gitmoot org directive cancel <id> [--by <role>] [--home
 <dir>]` is restricted to the sender. Both commands require an acting identity
 from `--by` or `GITMOOT_ORG_ROLE`; missing identity fails closed. They append
-typed markers to the directive's workflow journal; completion tracking belongs
-to the later directive-ledger slice.
+typed markers to the directive's workflow journal.
+
+The daemon evaluates directive TTLs on the existing one-minute org supervision
+lane. `[org].directive_ack_ttl` defaults to `10m`,
+`[org].directive_done_ttl` defaults to `0s` (completion nudges off), and
+`[org].directive_max_nudges` defaults to `3`. An unacknowledged directive is
+re-woken at most once per ack-TTL interval. When its persisted nudge count
+reaches the maximum, Gitmoot emits an escalation addressed to the sender's
+current parent in the org chart. Acknowledgment stops ack nudges; an acknowledged
+but unfinished directive is evaluated only when its completion TTL is enabled.
+An internal per-directive completion-TTL override, when present, takes
+precedence over the global value. Typed completion or cancellation receipts
+close the evaluator obligation. With no enabled org event rules, the lane is
+config-inert: it performs no directive scan and emits nothing.
 
 Event-rule wakes are separately opt-in:
 


### PR DESCRIPTION
WHAT:
SLICE-2: Implemented persistent directive TTL supervision in the existing one-minute blocked-role lane. Pre-finalizer HEAD is 11133b0bbb0855b345ab0996e2cd863515e3b5cd; changes remain uncommitted for Gitmoot to commit and deliver.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-41703da6

RESULTS:
- PASS: targeted config, workflow, DB, directive TTL, blocked-role lane, observer registry, and slice-1 directive families.
- PASS: npm run build:llms; a second generation produced an identical SHA-256.
- PASS: git diff --check.
- MUTANT interval pacing, expected failure:
--- FAIL: TestDirectiveTTLNudgesOncePerInterval (0.37s)
    org_directive_ttl_test.go:125: ... nudge_count=2 wakes=2, want 1/1
FAIL
- MUTANT in-memory counter, expected failure:
--- FAIL: TestDirectiveTTLNudgeCountSurvivesDaemonRestart (0.37s)
    org_directive_ttl_test.go:150: nudge_count after restart = 1, want 2
FAIL
- MUTANT escalation to addressee, expected failure:
--- FAIL: TestDirectiveTTLEscalatesAtMaxToCurrentSenderParent (0.27s)
    org_directive_ttl_test.go:180: escalation routing = {... WakeTargetRole:worker ...}
FAIL
- MUTANT acknowledged row treated as unacknowledged, expected failure:
--- FAIL: TestDirectiveTTLAckSkipsAckNudgesAndDoneOverrideWins (0.27s)
    org_directive_ttl_test.go:211: completion wakes = [... acknowledgment ...], want only overridden directive 2
FAIL
- MUTANT config-inert guard removed, expected failure:
--- FAIL: TestDirectiveTTLEvaluatorIsConfigInertWithNoRules (0.24s)
    org_directive_ttl_test.go:230: directive query ran without an enabled org event rule
FAIL
- MUTANT DESC ordering, expected failure:
--- FAIL: TestListOpenOrgDirectiveObligationsKeepsOldestAndPersistsNudges (0.27s)
    workflow_store_test.go:264: open directives returned ids [3 2], want oldest ids [1 2]
FAIL
- MUTANT per-directive completion override disabled, expected failure:
--- FAIL: TestDirectiveTTLAckSkipsAckNudgesAndDoneOverrideWins (0.26s)
    org_directive_ttl_test.go:211: completion wakes = [], want only overridden directive 2
FAIL

RISK:
Review the generated diff before merging.

TASK:
adhoc-41703da6

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
SLICE-2: Implemented persistent directive TTL supervision in the existing one-minute blocked-role lane. Pre-finalizer HEAD is 11133b0bbb0855b345ab0996e2cd863515e3b5cd; changes remain uncommitted for Gitmoot to commit and deliver.
````
