### PR TITLE
Gitmoot: CAMPAIGN 1308 SLICE C, CONTINUATION (your predecessor was

### DIFF
--- a/internal/cli/daemon_dispatch_tracked.go
+++ b/internal/cli/daemon_dispatch_tracked.go
@@ -84,6 +84,7 @@ type inflightJobTracker struct {
 	errs                         map[string][]error
 	foreignBootRecoveryAt        time.Time
 	agedDelegationWorktreeReapAt time.Time
+	liveness                     *daemonLivenessSweep
 }
 
 func newInflightJobTracker(ctx context.Context) *inflightJobTracker {
@@ -97,6 +98,7 @@ func newInflightJobTracker(ctx context.Context) *inflightJobTracker {
 		perRepo:   map[string]int{},
 		poolRuns:  map[string]bool{},
 		errs:      map[string][]error{},
+		liveness:  newDaemonLivenessSweep(),
 	}
 }
 

--- a/internal/cli/daemon_liveness.go
+++ b/internal/cli/daemon_liveness.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/transcript"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+type runtimePIDState int
+
+const (
+	runtimePIDUnknown runtimePIDState = iota
+	runtimePIDLive
+	runtimePIDDead
+	runtimePIDIdentityMismatch
+)
+
+type livenessLogSample struct {
+	size             int64
+	modified         time.Time
+	observed         time.Time
+	identityReported bool
+}
+
+// daemonLivenessSweep retains one prior transcript observation per candidate.
+// A single stat can never turn temporary silence into a terminal verdict.
+type daemonLivenessSweep struct {
+	mu      sync.Mutex
+	samples map[string]livenessLogSample
+	stat    func(string) (os.FileInfo, error)
+	probe   func(int, string) runtimePIDState
+}
+
+func newDaemonLivenessSweep() *daemonLivenessSweep {
+	return &daemonLivenessSweep{
+		samples: make(map[string]livenessLogSample),
+		stat:    os.Stat,
+		probe:   probeRuntimePID,
+	}
+}
+
+// probeRuntimePID combines kill(0) with the recorded /proc starttime. A live
+// PID with a different starttime is a recycled PID, not proof the old runtime
+// died safely; that ambiguity vetoes reaping and gets its own event.
+func probeRuntimePID(pid int, recordedIdentity string) runtimePIDState {
+	if pid <= 0 || strings.TrimSpace(recordedIdentity) == "" {
+		return runtimePIDUnknown
+	}
+	err := syscall.Kill(pid, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return runtimePIDDead
+	}
+	if err != nil && !errors.Is(err, syscall.EPERM) {
+		return runtimePIDUnknown
+	}
+	current := workflow.RuntimeProcessIdentity(pid)
+	if current == "" {
+		return runtimePIDUnknown
+	}
+	if current != strings.TrimSpace(recordedIdentity) {
+		return runtimePIDIdentityMismatch
+	}
+	return runtimePIDLive
+}
+
+func configuredDaemonQuietKillAfter(home string, stdout io.Writer) time.Duration {
+	paths, err := pathsFromFlag(home)
+	if err != nil {
+		return config.DefaultDaemonQuietKillAfter
+	}
+	cfg, err := config.LoadDaemonRuntimeConfig(paths)
+	if err != nil {
+		writeLine(stdout, "quiet_kill_after config invalid; using default %s: %v", config.DefaultDaemonQuietKillAfter, err)
+		return config.DefaultDaemonQuietKillAfter
+	}
+	return cfg.QuietKillPolicy()
+}
+
+// sweepRunningJobLiveness is the recurring same-boot crash detector. Startup
+// and foreign-boot recovery stay separate: this path only fails a job after
+// age, byte-progress, and runtime-process evidence converge.
+func (s *daemonLivenessSweep) sweepRunningJobLiveness(ctx context.Context, store *db.Store, stdout io.Writer, paths config.Paths, now time.Time, staleAfter, quietAfter time.Duration, repoFilter, rootFilter string) error {
+	if s == nil {
+		return nil
+	}
+	jobs, err := store.ListRunningJobsUpdatedBefore(ctx, now.Add(-staleAfter))
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if !queuedJobMatchesRepo(job, repoFilter) || !queuedJobMatchesSession(job, rootFilter) {
+			continue
+		}
+		if err := s.evaluate(ctx, store, stdout, paths, now, staleAfter, quietAfter, job); err != nil {
+			return err
+		}
+	}
+	s.prune(now, 4*quietAfter)
+	return nil
+}
+
+func (s *daemonLivenessSweep) evaluate(ctx context.Context, store *db.Store, stdout io.Writer, paths config.Paths, now time.Time, staleAfter, quietAfter time.Duration, job db.Job) error {
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return nil // malformed evidence degrades to unknown, never to reaped
+	}
+	info, err := s.stat(transcript.JobLogPath(paths.Logs, job.ID))
+	if err != nil || info.IsDir() {
+		s.forget(job.ID)
+		return nil
+	}
+	requiredQuiet := quietAfter
+	legacy := payload.RuntimePID <= 0
+	if legacy {
+		requiredQuiet = 2 * quietAfter
+	}
+	if now.Sub(info.ModTime()) < requiredQuiet {
+		s.remember(job.ID, livenessLogSample{size: info.Size(), modified: info.ModTime(), observed: now})
+		return nil
+	}
+
+	previous, stable := s.previousStable(job.ID, info, now)
+	if !stable {
+		return nil
+	}
+
+	if !legacy {
+		switch s.probe(payload.RuntimePID, payload.RuntimePIDStartTime) {
+		case runtimePIDLive:
+			return nil // absolute veto: a quiet, thinking runtime remains live
+		case runtimePIDIdentityMismatch:
+			if !previous.identityReported {
+				_ = store.AddJobEvent(ctx, db.JobEvent{
+					JobID: job.ID,
+					Kind:  "job_liveness_identity_mismatch",
+					Message: fmt.Sprintf("identity mismatch: runtime pid %d no longer has recorded starttime %s; job left running",
+						payload.RuntimePID, payload.RuntimePIDStartTime),
+				})
+				previous.identityReported = true
+				s.remember(job.ID, previous)
+			}
+			return nil
+		case runtimePIDUnknown:
+			return nil
+		case runtimePIDDead:
+			// All three required legs are named in the terminal event below.
+		}
+	} else {
+		leaseHeld, leaseErr := runtimeOwnerLeaseHeld(ctx, store, job.ID, now)
+		if leaseErr != nil {
+			return leaseErr
+		}
+		if leaseHeld {
+			return nil
+		}
+	}
+
+	runtimePID := payload.RuntimePID
+	runtimeStart := payload.RuntimePIDStartTime
+	payload.RuntimePID = 0
+	payload.RuntimePIDStartTime = ""
+	payload.RuntimePGID = 0
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	processLeg := "legacy row has no runtime PID and holds no runtime lease"
+	if !legacy {
+		processLeg = fmt.Sprintf("runtime pid %d is dead (recorded starttime %s)", runtimePID, runtimeStart)
+	}
+	message := fmt.Sprintf("liveness predicate satisfied: updated_at frozen past %s; job log byte-frozen for %s across two samples; %s", staleAfter, requiredQuiet, processLeg)
+	transitioned, err := store.TransitionJobStatePayloadWithEvent(ctx, job.ID, string(workflow.JobRunning), string(workflow.JobFailed), string(encoded), db.JobEvent{
+		JobID: job.ID, Kind: string(workflow.JobFailed), Message: message,
+	})
+	if err != nil {
+		return err
+	}
+	if transitioned {
+		_, _ = store.DeleteResourceLocksByOwnerIfNotRunning(ctx, job.ID)
+		writeLine(stdout, "failed stale running job %s: %s", job.ID, message)
+	}
+	s.forget(job.ID)
+	return nil
+}
+
+func (s *daemonLivenessSweep) previousStable(jobID string, info os.FileInfo, now time.Time) (livenessLogSample, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	previous, ok := s.samples[jobID]
+	current := livenessLogSample{size: info.Size(), modified: info.ModTime(), observed: now, identityReported: previous.identityReported}
+	s.samples[jobID] = current
+	stable := ok && previous.size == current.size && previous.modified.Equal(current.modified) && now.Sub(previous.observed) >= daemonWorkerLoopInterval
+	return current, stable
+}
+
+func (s *daemonLivenessSweep) remember(jobID string, sample livenessLogSample) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.samples[jobID] = sample
+}
+
+func (s *daemonLivenessSweep) forget(jobID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.samples, jobID)
+}
+
+func (s *daemonLivenessSweep) prune(now time.Time, maxAge time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for id, sample := range s.samples {
+		if now.Sub(sample.observed) > maxAge {
+			delete(s.samples, id)
+		}
+	}
+}

--- a/internal/cli/daemon_liveness_test.go
+++ b/internal/cli/daemon_liveness_test.go
@@ -141,9 +141,8 @@ func TestDaemonLivenessSweepQuietThresholdVetoes(t *testing.T) {
 }
 
 func TestDaemonLivenessSweepPIDReuseIsIndeterminate(t *testing.T) {
-	ctx, paths, store, now, quiet := livenessTestJob(t, "reused", 4242)
+	ctx, paths, store, now, quiet := livenessTestJob(t, "reused", os.Getpid())
 	sweep := newDaemonLivenessSweep()
-	sweep.probe = func(int, string) runtimePIDState { return runtimePIDIdentityMismatch }
 	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
 	job, err := store.GetJob(ctx, "reused")
 	if err != nil {

--- a/internal/cli/daemon_liveness_test.go
+++ b/internal/cli/daemon_liveness_test.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/transcript"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func livenessTestJob(t *testing.T, id string, pid int) (context.Context, config.Paths, *db.Store, time.Time, time.Duration) {
+	t.Helper()
+	ctx := context.Background()
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	store, err := db.Open(paths.Database)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	payload := workflow.JobPayload{Repo: "owner/repo", RuntimePID: pid, RuntimePIDStartTime: "recorded-start", RuntimePGID: pid}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJob(ctx, db.Job{ID: id, Agent: "reviewer", Type: "review", State: string(workflow.JobRunning), Payload: string(encoded)}); err != nil {
+		t.Fatal(err)
+	}
+	quiet := 5 * time.Minute
+	now := time.Now().UTC().Add(2 * time.Hour)
+	path := transcript.JobLogPath(paths.Logs, id)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("frozen transcript\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old := now.Add(-quiet - time.Minute)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	return ctx, paths, store, now, quiet
+}
+
+func runLivenessSamples(t *testing.T, sweep *daemonLivenessSweep, ctx context.Context, store *db.Store, paths config.Paths, now time.Time, quiet time.Duration) {
+	t.Helper()
+	for _, at := range []time.Time{now, now.Add(daemonWorkerLoopInterval)} {
+		if err := sweep.sweepRunningJobLiveness(ctx, store, io.Discard, paths, at, 30*time.Minute, quiet, "owner/repo", ""); err != nil {
+			t.Fatalf("sweep at %s: %v", at, err)
+		}
+	}
+}
+
+func TestProbeRuntimePIDUsesProcessStartIdentity(t *testing.T) {
+	pid := os.Getpid()
+	identity := workflow.RuntimeProcessIdentity(pid)
+	if identity == "" {
+		t.Fatal("current process identity is empty")
+	}
+	if got := probeRuntimePID(pid, identity); got != runtimePIDLive {
+		t.Fatalf("probe current pid = %v, want live", got)
+	}
+	if got := probeRuntimePID(pid, identity+"-reused"); got != runtimePIDIdentityMismatch {
+		t.Fatalf("probe reused pid = %v, want identity mismatch", got)
+	}
+}
+
+func TestDaemonLivenessSweepDeadPIDFrozenLogFails(t *testing.T) {
+	ctx, paths, store, now, quiet := livenessTestJob(t, "dead", 4242)
+	sweep := newDaemonLivenessSweep()
+	sweep.probe = func(int, string) runtimePIDState { return runtimePIDDead }
+	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
+	job, err := store.GetJob(ctx, "dead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("dead frozen job state = %q, want failed", job.State)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.RuntimePID != 0 || payload.RuntimePIDStartTime != "" || payload.RuntimePGID != 0 {
+		t.Fatalf("terminal runtime identity = %+v, want cleared", payload)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := events[len(events)-1].Message
+	for _, leg := range []string{"updated_at frozen", "job log byte-frozen", "runtime pid 4242 is dead"} {
+		if !strings.Contains(message, leg) {
+			t.Fatalf("failed event %q missing predicate leg %q", message, leg)
+		}
+	}
+}
+
+func TestDaemonLivenessSweepLivePIDVetoesFrozenLog(t *testing.T) {
+	ctx, paths, store, now, quiet := livenessTestJob(t, "live", os.Getpid())
+	sweep := newDaemonLivenessSweep()
+	sweep.probe = func(int, string) runtimePIDState { return runtimePIDLive }
+	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
+	job, err := store.GetJob(ctx, "live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("live quiet job state = %q, want running", job.State)
+	}
+}
+
+func TestDaemonLivenessSweepQuietThresholdVetoes(t *testing.T) {
+	ctx, paths, store, now, quiet := livenessTestJob(t, "recent", 4242)
+	path := transcript.JobLogPath(paths.Logs, "recent")
+	recent := now.Add(-quiet + time.Minute)
+	if err := os.Chtimes(path, recent, recent); err != nil {
+		t.Fatal(err)
+	}
+	sweep := newDaemonLivenessSweep()
+	sweep.probe = func(int, string) runtimePIDState { return runtimePIDDead }
+	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
+	job, err := store.GetJob(ctx, "recent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("under-threshold job state = %q, want running", job.State)
+	}
+}
+
+func TestDaemonLivenessSweepPIDReuseIsIndeterminate(t *testing.T) {
+	ctx, paths, store, now, quiet := livenessTestJob(t, "reused", 4242)
+	sweep := newDaemonLivenessSweep()
+	sweep.probe = func(int, string) runtimePIDState { return runtimePIDIdentityMismatch }
+	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
+	job, err := store.GetJob(ctx, "reused")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("identity-mismatch job state = %q, want running", job.State)
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].Kind != "job_liveness_identity_mismatch" || !strings.Contains(events[0].Message, "identity mismatch") {
+		t.Fatalf("identity mismatch events = %+v", events)
+	}
+}
+
+func TestDaemonLivenessSweepLegacyNeedsDoubleQuietAndNoLease(t *testing.T) {
+	ctx, paths, store, now, quiet := livenessTestJob(t, "legacy", 0)
+	path := transcript.JobLogPath(paths.Logs, "legacy")
+	old := now.Add(-2*quiet - time.Minute)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	sweep := newDaemonLivenessSweep()
+	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
+	job, err := store.GetJob(ctx, "legacy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("legacy frozen job state = %q, want failed after 2x quiet with no lease", job.State)
+	}
+}
+
+func TestDaemonLivenessSweepLegacyHeldLeaseVetoes(t *testing.T) {
+	ctx, paths, store, now, quiet := livenessTestJob(t, "legacy-held", 0)
+	path := transcript.JobLogPath(paths.Logs, "legacy-held")
+	old := now.Add(-2*quiet - time.Minute)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if acquired, err := store.AcquireResourceLock(ctx, db.ResourceLock{
+		ResourceKey: "runtime:codex:legacy-held", OwnerJobID: "legacy-held", OwnerToken: "token",
+		ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano),
+	}, now); err != nil || !acquired {
+		t.Fatalf("AcquireResourceLock = %v, %v", acquired, err)
+	}
+	sweep := newDaemonLivenessSweep()
+	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
+	job, err := store.GetJob(ctx, "legacy-held")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("legacy lease-held job state = %q, want running", job.State)
+	}
+}

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -783,7 +783,17 @@ func runDaemonWorkerTickTracked(ctx context.Context, store *db.Store, worker job
 		cand.skipAgedReclaim = !tracker.agedDelegationWorktreeReclaimDue(now)
 	}
 	inflightIDs := tracker.inflightIDs()
-	if err := recoverRunningJobsBeforeForRepoSkipping(ctx, store, stdout, now, now.Add(-configuredDaemonRunningJobStaleAfter(stdout)), repoFilter, rootFilter, inflightIDs); err != nil {
+	paths, pathsErr := worker.configPaths()
+	if pathsErr != nil {
+		return pathsErr
+	}
+	staleAfter := configuredDaemonRunningJobStaleAfter(stdout)
+	quietAfter := configuredDaemonQuietKillAfter(worker.ConfigHome, stdout)
+	liveness := newDaemonLivenessSweep()
+	if tracker != nil && tracker.liveness != nil {
+		liveness = tracker.liveness
+	}
+	if err := liveness.sweepRunningJobLiveness(ctx, store, stdout, paths, now, staleAfter, quietAfter, repoFilter, rootFilter); err != nil {
 		return err
 	}
 	if err := recoverExpiredRuntimeSessionLocksSkipping(ctx, store, stdout, now, inflightIDs); err != nil {

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -28,11 +28,10 @@ const defaultDaemonRunningJobStaleAfter = daemonRunningJobStaleAfter
 // daemonRunningJobStaleFloor is the smallest GITMOOT_STALE_RUNNING_AFTER we
 // honor. The stale-running window is a CRASH BACKSTOP, not a job timeout: it is
 // how long a job may sit in 'running' with no lease progress before the daemon
-// assumes the worker died and requeues it. A tiny value (e.g. 1s) turns that
-// backstop into an aggressive killer — especially for NON-resumable runtimes
-// (shell/no runtime-session lock) where runtimeOwnerLeaseHeld is always false,
-// so there is no lease to protect a live worker and the coarse threshold is the
-// ONLY gate. Sub-floor values are rejected in favor of the default (#560).
+// considers the worker for the stricter same-boot liveness conjunction. A tiny
+// value (e.g. 1s) would make the age leg meaningless, so sub-floor values are
+// rejected in favor of the default (#560). Transcript progress and runtime
+// process identity remain independent mandatory legs before any job is failed.
 const daemonRunningJobStaleFloor = 1 * time.Minute
 
 // runtimeLeaseTeardownGrace is added to a job's timeout when sizing its
@@ -754,9 +753,9 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 // then a BLOCKING runQueuedJobsForRepo dispatch. The supervisors pass a live
 // tracker (#562), which changes the tick to claim-and-dispatch-async:
 //
-//   - recovery scans skip jobs THIS process is running (an in-flight >30m job
-//     with no runtime lease — e.g. a shell-runtime job — must not be requeued
-//     out from under its own live worker by its own daemon's tick);
+//   - same-boot stale-job detection requires age, two frozen transcript samples,
+//     and dead runtime identity; a recorded live PID absolutely vetoes settlement,
+//     including for an in-flight >30m shell-runtime job with no runtime lease;
 //   - the expired runtime-lock reaper likewise skips locks owned by in-flight
 //     jobs (their goroutine is alive; releasing the lock could double-run the
 //     session);

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -3360,9 +3360,12 @@ func TestRecoverRunningJobsKeepsRecentRunningJobsOnStartup(t *testing.T) {
 	}
 }
 
-func TestRecoverRunningJobsUsesConfiguredStaleWindow(t *testing.T) {
+func TestDaemonLivenessAgeLegUsesConfiguredStaleWindow(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("GITMOOT_STALE_RUNNING_AFTER", "2m")
+	if got := configuredDaemonRunningJobStaleAfter(io.Discard); got != 2*time.Minute {
+		t.Fatalf("configured stale window = %s, want 2m", got)
+	}
 	store := daemonWorkerStore(t)
 	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
 	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
@@ -3378,8 +3381,8 @@ func TestRecoverRunningJobsUsesConfiguredStaleWindow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetJob returned error: %v", err)
 	}
-	if job.State != string(workflow.JobQueued) {
-		t.Fatalf("job state = %q, want queued", job.State)
+	if job.State != string(workflow.JobRunning) {
+		t.Fatalf("job state = %q, want running without transcript and process evidence", job.State)
 	}
 }
 
@@ -3902,26 +3905,28 @@ func TestRecoverCancelledRunningJobsForRepoSkipsOtherRepos(t *testing.T) {
 	}
 }
 
-func TestDaemonWorkerTickRechecksStaleRunningJobs(t *testing.T) {
-	ctx := context.Background()
-	store := daemonWorkerStore(t)
-	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-running", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1})
-	if err := store.UpdateJobState(ctx, "job-running", string(workflow.JobRunning)); err != nil {
-		t.Fatalf("UpdateJobState returned error: %v", err)
+func TestDaemonWorkerTickRunsLivenessSweep(t *testing.T) {
+	ctx, paths, store, now, _ := livenessTestJob(t, "job-running", 4242)
+	t.Setenv("GITMOOT_STALE_RUNNING_AFTER", "1m")
+	if err := os.WriteFile(paths.ConfigFile, []byte("[daemon]\nquiet_kill_after = \"5m\"\n"), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	worker := defaultJobWorker(store, io.Discard)
-	now := time.Now().UTC().Add(defaultDaemonRunningJobStaleAfter + time.Second)
+	worker := defaultJobWorker(store, io.Discard, filepath.Dir(paths.Home))
+	tracker := newInflightJobTracker(ctx)
+	tracker.liveness.probe = func(int, string) runtimePIDState { return runtimePIDDead }
 
-	if err := runDaemonWorkerTickTracked(ctx, store, worker, 0, false, "", "", io.Discard, now, nil, nil); err != nil {
-		t.Fatalf("runDaemonWorkerTickTracked returned error: %v", err)
+	for _, at := range []time.Time{now, now.Add(daemonWorkerLoopInterval)} {
+		if err := runDaemonWorkerTickTracked(ctx, store, worker, 0, false, "", "", io.Discard, at, tracker, nil); err != nil {
+			t.Fatalf("runDaemonWorkerTickTracked(%s): %v", at, err)
+		}
 	}
 
 	job, err := store.GetJob(ctx, "job-running")
 	if err != nil {
 		t.Fatalf("GetJob returned error: %v", err)
 	}
-	if job.State != string(workflow.JobQueued) {
-		t.Fatalf("job state = %q, want queued", job.State)
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("job state = %q, want failed by production tick liveness sweep", job.State)
 	}
 }
 

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -476,7 +476,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 			adapter = envAdapter
 		}
 	}
-	// Opt-in retained capture is attached to the already-composed adapter so
+	// Default-on retained capture is attached to the already-composed adapter so
 	// relay env, credential curation, gateway leases, Landlock, and pipeline
 	// progress all survive. Any open/composition failure is fail-open.
 	retainedLogPath, retainedLogFile, retainedLogErr := openRetainedTranscriptLog(w.ConfigHome, job.ID)

--- a/internal/cli/e2e_560_lease_grace_536_safe_test.go
+++ b/internal/cli/e2e_560_lease_grace_536_safe_test.go
@@ -218,18 +218,21 @@ func TestE2E560ExpiredLeaseRequeuesStuckWorker(t *testing.T) {
 }
 
 // TestE2E560SubFloorStaleWindowRejected pins the env floor (#560 finding 3):
-// GITMOOT_STALE_RUNNING_AFTER is a CRASH BACKSTOP, not a timeout, so a sub-floor
-// value must be rejected in favor of the default window rather than turned into an
-// aggressive killer. The danger is sharpest for NON-resumable runtimes (shell)
-// that hold no lease — there the coarse window is the ONLY gate, so a 1s window
-// would requeue a healthy worker on its next tick.
+// GITMOOT_STALE_RUNNING_AFTER is one crash-detection leg, not a timeout, so a
+// sub-floor value must be rejected in favor of the default window rather than
+// turned into an aggressive killer. Even after the age leg matures, missing
+// transcript and process evidence must leave the job running.
 func TestE2E560SubFloorStaleWindowRejected(t *testing.T) {
 	t.Setenv("GITMOOT_STALE_RUNNING_AFTER", "1s") // below the 1m floor
+	if got := configuredDaemonRunningJobStaleAfter(io.Discard); got != defaultDaemonRunningJobStaleAfter {
+		t.Fatalf("sub-floor stale window = %s, want default %s", got, defaultDaemonRunningJobStaleAfter)
+	}
 
 	seed := func(t *testing.T) (*db.Store, jobWorker, time.Time) {
 		store := daemonWorkerStore(t)
 		seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
-		// shell runtime => no runtime-session lease => the coarse window is the sole gate.
+		// A shell runtime has no runtime-session lease; the new liveness predicate
+		// must therefore stay fail-closed when transcript/PID evidence is absent.
 		seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "unused", []string{"ask"}, "owner/repo")
 		enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
 			ID: "job-x", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", PullRequest: 1,
@@ -240,9 +243,8 @@ func TestE2E560SubFloorStaleWindowRejected(t *testing.T) {
 		return store, defaultJobWorker(store, io.Discard), time.Now().UTC()
 	}
 
-	// A 5m-old running job: OLDER than the sub-floor 1s (which would requeue it) but
-	// well YOUNGER than the enforced 30m default (which leaves it running). Staying
-	// 'running' proves the 1s was rejected.
+	// A 5m-old running job is older than the rejected 1s value but younger than
+	// the enforced 30m default, so it remains outside the age candidate set.
 	t.Run("sub_floor_rejected_uses_default_window", func(t *testing.T) {
 		ctx := context.Background()
 		store, worker, now := seed(t)
@@ -258,9 +260,9 @@ func TestE2E560SubFloorStaleWindowRejected(t *testing.T) {
 		}
 	})
 
-	// Positive control: past the enforced 30m default the SAME job IS recovered, so
-	// the floor falls back to a real finite window, not an infinite one.
-	t.Run("default_window_still_recovers_when_truly_stale", func(t *testing.T) {
+	// Past the enforced 30m default, age alone is still insufficient: the new
+	// same-boot sweep requires frozen transcript bytes and process evidence too.
+	t.Run("default_window_is_not_an_age_only_killer", func(t *testing.T) {
 		ctx := context.Background()
 		store, worker, now := seed(t)
 		if err := runDaemonWorkerTickTracked(ctx, store, worker, 0, false, "owner/repo", "", io.Discard, now.Add(31*time.Minute), nil, nil); err != nil {
@@ -270,8 +272,8 @@ func TestE2E560SubFloorStaleWindowRejected(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetJob returned error: %v", err)
 		}
-		if job.State != string(workflow.JobQueued) {
-			t.Fatalf("job state at +31m = %q, want queued; the enforced default 30m window must still recover a truly-stale job", job.State)
+		if job.State != string(workflow.JobRunning) {
+			t.Fatalf("job state at +31m = %q, want running without transcript and process evidence", job.State)
 		}
 	})
 }

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -559,12 +559,26 @@ func TestJobWatchTranscriptShellNoLLME2E(t *testing.T) {
 }
 
 func TestRunJobRunUsesDaemonWorkerInternals(t *testing.T) {
+	runJobRunLifecycleContract(t, false)
+}
+
+func TestRunJobRunTranscriptOffSwitch(t *testing.T) {
+	home := runJobRunLifecycleContract(t, true)
+	if _, err := os.Stat(filepath.Join(config.PathsForHome(home).Logs, "jobs")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("disabled transcript capture changed daemon lifecycle: %v", err)
+	}
+}
+
+func runJobRunLifecycleContract(t *testing.T, transcriptsDisabled bool) string {
+	t.Helper()
 	home := t.TempDir()
 	store := openCLIJobStore(t, home)
 	defer store.Close()
-	paths := config.PathsForHome(home)
-	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+"\n[transcripts]\nenabled = false\n"), 0o600); err != nil {
-		t.Fatal(err)
+	if transcriptsDisabled {
+		paths := config.PathsForHome(home)
+		if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+"\n[transcripts]\nenabled = false\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
 	checkout := t.TempDir()
 	runGit(t, checkout, "init")
@@ -595,9 +609,7 @@ func TestRunJobRunUsesDaemonWorkerInternals(t *testing.T) {
 	if job.State != string(workflow.JobSucceeded) || !strings.Contains(job.Payload, `"summary":"done"`) {
 		t.Fatalf("job after run = %+v", job)
 	}
-	if _, err := os.Stat(filepath.Join(config.PathsForHome(home).Logs, "jobs")); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("disabled transcript capture changed daemon lifecycle: %v", err)
-	}
+	return home
 }
 
 func TestRunJobRunRefusesUnavailableRoleAndAllowsExpiredIncident(t *testing.T) {

--- a/internal/cli/job_test.go
+++ b/internal/cli/job_test.go
@@ -562,6 +562,10 @@ func TestRunJobRunUsesDaemonWorkerInternals(t *testing.T) {
 	home := t.TempDir()
 	store := openCLIJobStore(t, home)
 	defer store.Close()
+	paths := config.PathsForHome(home)
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+"\n[transcripts]\nenabled = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	checkout := t.TempDir()
 	runGit(t, checkout, "init")
 	runGit(t, checkout, "branch", "-m", "main")

--- a/internal/cli/runtime_lock.go
+++ b/internal/cli/runtime_lock.go
@@ -203,18 +203,18 @@ func runtimeSessionHeldByLiveOwner(ctx context.Context, store *db.Store, agent r
 
 // runtimeOwnerLeaseHeld reports whether the running job jobID still holds a
 // runtime-session lock whose LEASE has not elapsed (or whose owner is on an
-// unverifiable cross-host). It is the gate stale-running-job recovery consults so
-// a long-running job is not requeued while its real job timeout — encoded in the
-// lease — has not elapsed (#536).
+// unverifiable cross-host). Same-boot liveness uses this only for legacy rows
+// that predate persisted runtime PID identity; it keeps those rows from being
+// failed while their real job timeout — encoded in the lease — has not elapsed
+// (#536).
 //
 // It deliberately keys on the lease, NOT on owner-PID liveness: the lock records
 // the gitmoot DAEMON's PID, not the spawned runtime worker's, so on a daemon
 // restart the recorded PID is the dead prior daemon even while the reparented
-// worker is still progressing. Honoring the lease is therefore correct across a
-// restart and immune to PID reuse; see db.ResourceLockLiveness.LeaseHeld. A job
-// with no runtime lock (released on a normal terminal, or a non-resumable runtime)
-// is never lease-held, so it is recovered as before; once a lease expires
-// (recoverExpiredRuntimeSessionLocks reclaims it) the job is recovered too.
+// worker is still progressing. Honoring the lease is therefore correct and
+// immune to PID reuse; see db.ResourceLockLiveness.LeaseHeld. A job with no
+// runtime lock is never lease-held, so a legacy row still requires the longer
+// transcript-silence threshold before the liveness sweep can settle it.
 func runtimeOwnerLeaseHeld(ctx context.Context, store *db.Store, jobID string, now time.Time) (bool, error) {
 	thisHost, _ := os.Hostname()
 	// excludeOwnerToken is "" — recovery runs from a daemon tick/startup that holds

--- a/internal/cli/transcript_retention.go
+++ b/internal/cli/transcript_retention.go
@@ -26,8 +26,8 @@ const (
 	transcriptSweepDeleteLimit  = 256
 )
 
-// openRetainedTranscriptLog is side-effect-free while capture is disabled or
-// invalid. Enabled logs are canonical, private, and append-only across retries.
+// openRetainedTranscriptLog is side-effect-free when capture is explicitly
+// disabled. Enabled logs are canonical, private, and append-only across retries.
 func openRetainedTranscriptLog(home, jobID string) (string, *os.File, error) {
 	paths, err := pathsFromFlag(home)
 	if err != nil {

--- a/internal/cli/transcript_retention_test.go
+++ b/internal/cli/transcript_retention_test.go
@@ -192,6 +192,9 @@ func TestRetainedTranscriptLogAppendPermissionsDisabledAndOpenFailure(t *testing
 	if err := config.Initialize(paths); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+"\n[transcripts]\nenabled = false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	if path, file, err := openRetainedTranscriptLog(home, "disabled"); err != nil || path != "" || file != nil {
 		t.Fatalf("disabled open = path %q file %v err %v", path, file, err)
 	}

--- a/internal/cli/transcript_retention_test.go
+++ b/internal/cli/transcript_retention_test.go
@@ -236,3 +236,31 @@ func TestRetainedTranscriptLogAppendPermissionsDisabledAndOpenFailure(t *testing
 		t.Fatalf("oversized filename open = file %v err %v, want fail-open signal", file, err)
 	}
 }
+
+func TestRetainedTranscriptLogDefaultOn(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	path, file, err := openRetainedTranscriptLog(home, "default-on")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if file == nil || path != transcript.JobLogPath(paths.Logs, "default-on") {
+		t.Fatalf("default-on log = path %q file %v", path, file)
+	}
+	if _, err := file.WriteString("stdout and stderr stream\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 || info.Size() == 0 {
+		t.Fatalf("default-on log mode=%v size=%d", info.Mode().Perm(), info.Size())
+	}
+}

--- a/internal/config/daemon_runtime.go
+++ b/internal/config/daemon_runtime.go
@@ -13,6 +13,8 @@ const (
 	DefaultDaemonIdleMaxMultiplier = 4
 	DefaultDaemonJobTimeoutDefault = 4 * time.Hour
 	DefaultDaemonJobTimeoutMax     = 8 * time.Hour
+	DefaultDaemonQuietKillAfter    = 45 * time.Minute
+	MinimumDaemonQuietKillAfter    = 5 * time.Minute
 )
 
 // DaemonRuntimeConfig is the daemon's WARM-reloadable runtime settings, read from
@@ -64,6 +66,10 @@ type DaemonRuntimeConfig struct {
 	JobTimeoutDefaultSet bool
 	JobTimeoutMax        time.Duration
 	JobTimeoutMaxSet     bool
+	// QuietKillAfter is one leg of the same-boot liveness predicate. A recorded
+	// live runtime PID always vetoes reaping regardless of transcript silence.
+	QuietKillAfter    time.Duration
+	QuietKillAfterSet bool
 }
 
 // LoadDaemonRuntimeConfig parses the [daemon] section. A file with no [daemon]
@@ -157,6 +163,13 @@ func LoadDaemonRuntimeConfig(paths Paths) (DaemonRuntimeConfig, error) {
 			}
 			cfg.JobTimeoutMax = parsed
 			cfg.JobTimeoutMaxSet = true
+		case "quiet_kill_after":
+			parsed, err := parseConfigDuration(value)
+			if err != nil {
+				return DaemonRuntimeConfig{}, fmt.Errorf("parse [daemon].quiet_kill_after: %w", err)
+			}
+			cfg.QuietKillAfter = parsed
+			cfg.QuietKillAfterSet = true
 		default:
 			// Unknown keys are ignored so the section can grow (e.g. #576 per-repo
 			// caps) without breaking older binaries.
@@ -220,11 +233,22 @@ func validateDaemonRuntimeConfig(cfg DaemonRuntimeConfig) error {
 	if cfg.JobTimeoutMaxSet && cfg.JobTimeoutMax <= 0 {
 		return fmt.Errorf("[daemon].job_timeout_max must be positive")
 	}
+	if cfg.QuietKillAfterSet && cfg.QuietKillAfter < MinimumDaemonQuietKillAfter {
+		return fmt.Errorf("[daemon].quiet_kill_after must be at least %s", MinimumDaemonQuietKillAfter)
+	}
 	jobTimeoutDefault, jobTimeoutMax := cfg.JobTimeoutPolicy()
 	if jobTimeoutDefault > jobTimeoutMax {
 		return fmt.Errorf("[daemon].job_timeout_default (%s) must not exceed [daemon].job_timeout_max (%s)", jobTimeoutDefault, jobTimeoutMax)
 	}
 	return nil
+}
+
+// QuietKillPolicy returns the liveness sweep's quiet-output threshold.
+func (cfg DaemonRuntimeConfig) QuietKillPolicy() time.Duration {
+	if cfg.QuietKillAfterSet {
+		return cfg.QuietKillAfter
+	}
+	return DefaultDaemonQuietKillAfter
 }
 
 // JobTimeoutPolicy returns the effective daemon kill-deadline policy, applying

--- a/internal/config/daemon_runtime_test.go
+++ b/internal/config/daemon_runtime_test.go
@@ -107,6 +107,8 @@ func TestLoadDaemonRuntimeConfigRejectsBadValues(t *testing.T) {
 		"bad job max":             "[daemon]\njob_timeout_max = \"nope\"\n",
 		"nonpositive job max":     "[daemon]\njob_timeout_max = \"0s\"\n",
 		"default exceeds max":     "[daemon]\njob_timeout_default = \"9h\"\njob_timeout_max = \"8h\"\n",
+		"zero quiet kill":         "[daemon]\nquiet_kill_after = \"0s\"\n",
+		"subfloor quiet kill":     "[daemon]\nquiet_kill_after = \"4m59s\"\n",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -119,6 +121,24 @@ func TestLoadDaemonRuntimeConfigRejectsBadValues(t *testing.T) {
 				t.Fatalf("expected error for %q", strings.TrimSpace(body))
 			}
 		})
+	}
+}
+
+func TestDaemonRuntimeQuietKillPolicyDefaultsAndLoads(t *testing.T) {
+	if got := (DaemonRuntimeConfig{}).QuietKillPolicy(); got != DefaultDaemonQuietKillAfter {
+		t.Fatalf("default quiet kill = %s, want %s", got, DefaultDaemonQuietKillAfter)
+	}
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, paths, "[daemon]\nquiet_kill_after = \"50m\"\n")
+	cfg, err := LoadDaemonRuntimeConfig(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.QuietKillPolicy(); got != 50*time.Minute {
+		t.Fatalf("configured quiet kill = %s, want 50m", got)
 	}
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -103,6 +103,7 @@ artifact_blobs = %q
 # idle_max_multiplier = 4   # 1 disables idle cadence decay
 # job_timeout_default = "4h" # kill deadline when payload and agent type omit one
 # job_timeout_max = "8h"     # hard ceiling; larger payload requests are clamped
+# quiet_kill_after = "45m"   # liveness transcript-silence threshold; floor 5m
 
 # [credentials] is OFF by default. When env_curation=true, only a pinned base
 # environment plus runtime-specific auth/state variables reaches runtime-agent
@@ -119,11 +120,11 @@ artifact_blobs = %q
 # model_gateway_allow_hosts = ["api.anthropic.com"]
 # keychain_path = "" # default: <base-home>/.config/gitmoot/keychain.env
 
-# [transcripts] is OFF by default. When enabled, raw unredacted runtime output
+# [transcripts] is ON by default. Raw unredacted runtime output
 # is retained in 0600 per-job append logs for deterministic trajectory export.
 # retain and max_total_bytes bound home-scoped garbage collection.
 # [transcripts]
-# enabled = false
+# enabled = true
 # retain = "168h"
 # max_total_bytes = 2147483648
 

--- a/internal/config/transcripts.go
+++ b/internal/config/transcripts.go
@@ -13,8 +13,8 @@ const (
 	DefaultTranscriptMaxTotalBytes = int64(2 * 1024 * 1024 * 1024)
 )
 
-// TranscriptsConfig controls opt-in raw runtime transcript retention. Invalid
-// or missing configuration always resolves to the safe disabled default.
+// TranscriptsConfig controls default-on raw runtime transcript retention.
+// Invalid or missing configuration resolves to safe bounded defaults.
 type TranscriptsConfig struct {
 	Enabled       bool
 	Retain        time.Duration

--- a/internal/config/transcripts.go
+++ b/internal/config/transcripts.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	MinimumTranscriptRetain        = 24 * time.Hour
 	DefaultTranscriptRetain        = 168 * time.Hour
 	DefaultTranscriptMaxTotalBytes = int64(2 * 1024 * 1024 * 1024)
 )
@@ -22,15 +23,15 @@ type TranscriptsConfig struct {
 
 func DefaultTranscriptsConfig() TranscriptsConfig {
 	return TranscriptsConfig{
-		Enabled:       false,
+		Enabled:       true,
 		Retain:        DefaultTranscriptRetain,
 		MaxTotalBytes: DefaultTranscriptMaxTotalBytes,
 	}
 }
 
-// LoadTranscriptsConfig reads only [transcripts]. Capture is deliberately
-// fail-closed: a missing file/section, malformed value, non-positive retention,
-// or non-positive total cap returns the disabled defaults and never fails a job.
+// LoadTranscriptsConfig reads only [transcripts]. Capture is default-on so every
+// engine delivery has a durable liveness/forensics stream. A malformed section
+// falls back to the safe defaults; retention can never be configured below 24h.
 func LoadTranscriptsConfig(paths Paths) TranscriptsConfig {
 	fallback := DefaultTranscriptsConfig()
 	content, err := os.ReadFile(paths.ConfigFile)
@@ -87,7 +88,10 @@ func LoadTranscriptsConfig(paths Paths) TranscriptsConfig {
 			}
 		}
 	}
-	if !found || !valid || cfg.Retain <= 0 || cfg.MaxTotalBytes <= 0 {
+	if !found {
+		return fallback
+	}
+	if !valid || cfg.Retain < MinimumTranscriptRetain || cfg.MaxTotalBytes <= 0 {
 		return fallback
 	}
 	return cfg

--- a/internal/config/transcripts_test.go
+++ b/internal/config/transcripts_test.go
@@ -47,9 +47,24 @@ func TestLoadTranscriptsConfigInvalidDegradesToDisabled(t *testing.T) {
 			if err := os.WriteFile(paths.ConfigFile, []byte(body), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			if got := LoadTranscriptsConfig(paths); got.Enabled || got.Retain != DefaultTranscriptRetain || got.MaxTotalBytes != DefaultTranscriptMaxTotalBytes {
-				t.Fatalf("invalid config = %+v, want disabled defaults", got)
+			if got := LoadTranscriptsConfig(paths); !got.Enabled || got.Retain != DefaultTranscriptRetain || got.MaxTotalBytes != DefaultTranscriptMaxTotalBytes {
+				t.Fatalf("invalid config = %+v, want default-on safe defaults", got)
 			}
 		})
+	}
+}
+
+func TestLoadTranscriptsConfigRetentionHas24HourFloor(t *testing.T) {
+	home := t.TempDir()
+	paths := PathsForHome(home)
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[transcripts]\nenabled = true\nretain = \"23h59m\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := LoadTranscriptsConfig(paths)
+	if !got.Enabled || got.Retain != DefaultTranscriptRetain {
+		t.Fatalf("subfloor retain = %+v, want default retention", got)
 	}
 }

--- a/internal/config/transcripts_test.go
+++ b/internal/config/transcripts_test.go
@@ -31,7 +31,7 @@ max_total_bytes = 4096
 	}
 }
 
-func TestLoadTranscriptsConfigInvalidDegradesToDisabled(t *testing.T) {
+func TestLoadTranscriptsConfigInvalidDegradesToSafeDefaults(t *testing.T) {
 	for _, body := range []string{
 		"[transcripts]\nenabled = nope\n",
 		"[transcripts]\nenabled = true\nretain = \"0s\"\n",

--- a/internal/workflow/failure_diagnostics.go
+++ b/internal/workflow/failure_diagnostics.go
@@ -24,7 +24,7 @@ const (
 // MaxStderrTailBytes is the hard cap on the stored stderr tail. The tail is
 // redacted BEFORE it is cut (so a secret split by the cut can never leak) and
 // the stored string never exceeds this many bytes.
-const MaxStderrTailBytes = 2048
+const MaxStderrTailBytes = 4096
 
 // FailureDiagnostics captures process-level crash context for a job whose
 // runtime session ended WITHOUT producing a gitmoot_result envelope (#806).

--- a/internal/workflow/failure_diagnostics_test.go
+++ b/internal/workflow/failure_diagnostics_test.go
@@ -62,6 +62,14 @@ func TestMailboxRunCapturesCrashDiagnosticsOnNonZeroExit(t *testing.T) {
 	if !strings.Contains(diag.StderrTail, "[REDACTED]") {
 		t.Fatalf("stderr tail = %q, want the redaction marker", diag.StderrTail)
 	}
+	events, err := store.ListJobEvents(ctx, "job-crash")
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	failedMessage := events[len(events)-1].Message
+	if !strings.Contains(failedMessage, "stderr tail:") || !strings.Contains(failedMessage, "runtime exploded") || strings.Contains(failedMessage, "super-secret-crash-value") {
+		t.Fatalf("failed event diagnostics = %q", failedMessage)
+	}
 }
 
 func TestMailboxRunCrashDiagnosticsStreamingPhase(t *testing.T) {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -321,6 +321,7 @@ type JobPayload struct {
 	// dispatched through legacy/custom runners simply omit them.
 	RuntimePID          int    `json:"runtime_pid,omitempty"`
 	RuntimePIDStartTime string `json:"runtime_pid_start_time,omitempty"`
+	RuntimePGID         int    `json:"runtime_pgid,omitempty"`
 	// ReadOnlyWorktree marks a top-level read-only (ask) worktree allocated at
 	// dispatch time (#739): its WorktreePath is a throwaway detached committed-tip
 	// worktree with no DelegationID and no Branch. Additive/omitempty so a payload
@@ -1389,6 +1390,7 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		OnPID: func(pid int) {
 			payload.RuntimePID = pid
 			payload.RuntimePIDStartTime = RuntimeProcessIdentity(pid)
+			payload.RuntimePGID = RuntimeProcessGroupID(pid)
 			// Persist before the runner blocks so an independently invoked doctor
 			// can inspect the running job. Best-effort: observability must never
 			// turn a successful runtime start into a delivery failure.
@@ -1408,14 +1410,9 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		delivery.RuntimeDefaultEffort = m.RuntimeDefaultEffort(agent.Runtime)
 	}
 	result, err := adapter.Deliver(ctx, agent, delivery)
-	// The recorded identity describes only a process that is currently executing
-	// this delivery. Clear it immediately when Deliver returns, before parsing,
-	// retry backoff, or a produce check keeps the job legitimately running without
-	// a runtime subprocess. Best-effort persistence mirrors the start callback:
-	// observability must never change the delivery result.
-	payload.RuntimePID = 0
-	payload.RuntimePIDStartTime = ""
-	_ = m.savePayload(ctx, job.ID, *payload)
+	// Preserve the last runtime identity while the job remains running. The
+	// liveness sweep needs the exact process that produced the retained transcript;
+	// terminal transitions clear it atomically with settlement below.
 	// Record best-effort runtime token usage so the per-root delegation token
 	// budget (#338 Part B) can sum a tree's cost. Usage accounting must never fail
 	// a delivery, so every write error here is swallowed.
@@ -1492,11 +1489,24 @@ func (m Mailbox) persistRefreshedRuntimeRef(ctx context.Context, jobID string, a
 func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, message string) error {
 	writeCtx, cancel := terminalWriteContext(ctx)
 	defer cancel()
-	transitioned, err := m.Store.TransitionJobStateWithEvent(writeCtx, jobID, string(JobRunning), string(state), db.JobEvent{
-		JobID:   jobID,
-		Kind:    string(state),
-		Message: message,
-	})
+	var transitioned bool
+	var err error
+	if job, loadErr := m.Store.GetJob(writeCtx, jobID); loadErr == nil {
+		if payload, payloadErr := unmarshalPayload(job.Payload); payloadErr == nil {
+			clearRuntimeIdentity(&payload)
+			message = terminalMessageWithDiagnostics(state, message, payload.FailureDiagnostics)
+			if encoded, encodeErr := marshalPayload(payload); encodeErr == nil {
+				transitioned, err = m.Store.TransitionJobStatePayloadWithEvent(writeCtx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
+					JobID: jobID, Kind: string(state), Message: message,
+				})
+			}
+		}
+	}
+	if err == nil && !transitioned {
+		transitioned, err = m.Store.TransitionJobStateWithEvent(writeCtx, jobID, string(JobRunning), string(state), db.JobEvent{
+			JobID: jobID, Kind: string(state), Message: message,
+		})
+	}
 	if err != nil {
 		return err
 	}
@@ -1549,6 +1559,8 @@ func (m Mailbox) loadTerminalEmitPayload(ctx context.Context, jobID, message str
 func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobState, message string, payload JobPayload) error {
 	writeCtx, cancel := terminalWriteContext(ctx)
 	defer cancel()
+	clearRuntimeIdentity(&payload)
+	message = terminalMessageWithDiagnostics(state, message, payload.FailureDiagnostics)
 	encoded, err := marshalPayload(payload)
 	if err != nil {
 		return err
@@ -1599,6 +1611,22 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 		}
 	}
 	return nil
+}
+
+func clearRuntimeIdentity(payload *JobPayload) {
+	if payload == nil {
+		return
+	}
+	payload.RuntimePID = 0
+	payload.RuntimePIDStartTime = ""
+	payload.RuntimePGID = 0
+}
+
+func terminalMessageWithDiagnostics(state JobState, message string, diag *FailureDiagnostics) string {
+	if state != JobFailed || diag == nil || strings.TrimSpace(diag.StderrTail) == "" {
+		return message
+	}
+	return message + "\nstderr tail:\n" + diag.StderrTail
 }
 
 func (m Mailbox) ensureRunning(ctx context.Context, jobID string) error {

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1626,7 +1626,7 @@ func terminalMessageWithDiagnostics(state JobState, message string, diag *Failur
 	if state != JobFailed || diag == nil || strings.TrimSpace(diag.StderrTail) == "" {
 		return message
 	}
-	return message + "\nstderr tail:\n" + diag.StderrTail
+	return RedactCommentText(message) + "\nstderr tail:\n" + diag.StderrTail
 }
 
 func (m Mailbox) ensureRunning(ctx context.Context, jobID string) error {

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -120,7 +120,7 @@ func TestMailboxPersistsActingOrgRoleProvenance(t *testing.T) {
 	}
 }
 
-func TestMailboxPersistsRuntimePIDOnlyWhileDeliveryRuns(t *testing.T) {
+func TestMailboxPersistsRuntimeIdentityUntilTerminal(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
 	mailbox := Mailbox{Store: store}
@@ -140,8 +140,8 @@ func TestMailboxPersistsRuntimePIDOnlyWhileDeliveryRuns(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseJobPayload during delivery: %v", err)
 			}
-			if payload.RuntimePID != os.Getpid() || payload.RuntimePIDStartTime == "" {
-				t.Fatalf("runtime identity during delivery = pid %d start %q, want pid %d with starttime", payload.RuntimePID, payload.RuntimePIDStartTime, os.Getpid())
+			if payload.RuntimePID != os.Getpid() || payload.RuntimePIDStartTime == "" || payload.RuntimePGID <= 0 {
+				t.Fatalf("runtime identity during delivery = pid %d pgid %d start %q, want pid %d with process identity", payload.RuntimePID, payload.RuntimePGID, payload.RuntimePIDStartTime, os.Getpid())
 			}
 		},
 		outputs: []string{
@@ -159,12 +159,12 @@ func TestMailboxPersistsRuntimePIDOnlyWhileDeliveryRuns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseJobPayload: %v", err)
 	}
-	if payload.RuntimePID != 0 || payload.RuntimePIDStartTime != "" {
-		t.Fatalf("runtime identity after delivery = pid %d start %q, want cleared", payload.RuntimePID, payload.RuntimePIDStartTime)
+	if payload.RuntimePID != 0 || payload.RuntimePIDStartTime != "" || payload.RuntimePGID != 0 {
+		t.Fatalf("runtime identity after terminal = pid %d pgid %d start %q, want cleared", payload.RuntimePID, payload.RuntimePGID, payload.RuntimePIDStartTime)
 	}
 }
 
-func TestMailboxClearsRuntimePIDBeforeProduceCheck(t *testing.T) {
+func TestMailboxKeepsRuntimePIDThroughProduceCheckUntilTerminal(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
 	dir := t.TempDir()
@@ -207,11 +207,11 @@ func TestMailboxClearsRuntimePIDBeforeProduceCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseJobPayload during produce check: %v", err)
 	}
-	if stored.State != string(JobRunning) || payload.RuntimePID != 0 || payload.RuntimePIDStartTime != "" {
-		t.Fatalf("produce check window = state %q pid %d start %q, want running with no runtime identity", stored.State, payload.RuntimePID, payload.RuntimePIDStartTime)
+	if stored.State != string(JobRunning) || payload.RuntimePID != os.Getpid() || payload.RuntimePIDStartTime == "" {
+		t.Fatalf("produce check window = state %q pid %d start %q, want last runtime identity retained", stored.State, payload.RuntimePID, payload.RuntimePIDStartTime)
 	}
-	if live, known := RuntimeProcessLiveness(payload.RuntimePID, payload.RuntimePIDStartTime); live || known {
-		t.Fatalf("produce-check runtime liveness = (%v, %v), want neutral unknown", live, known)
+	if live, known := RuntimeProcessLiveness(payload.RuntimePID, payload.RuntimePIDStartTime); !live || !known {
+		t.Fatalf("produce-check runtime liveness = (%v, %v), want retained live identity", live, known)
 	}
 	if err := os.WriteFile(release, []byte("go"), 0o600); err != nil {
 		t.Fatalf("release produce check: %v", err)

--- a/internal/workflow/runtime_process_liveness.go
+++ b/internal/workflow/runtime_process_liveness.go
@@ -8,6 +8,25 @@ import (
 	"strings"
 )
 
+// RuntimeProcessGroupID returns the process group recorded for pid from Linux
+// /proc. It is observation-only in Slice C; group killing belongs to Slice D.
+func RuntimeProcessGroupID(pid int) int {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return 0
+	}
+	closeParen := strings.LastIndexByte(string(data), ')')
+	if closeParen < 0 {
+		return 0
+	}
+	fields := strings.Fields(string(data[closeParen+1:]))
+	if len(fields) <= 2 {
+		return 0
+	}
+	pgid, _ := strconv.Atoi(fields[2])
+	return pgid
+}
+
 // RuntimeProcessIdentity returns the Linux /proc starttime identity for pid.
 // Empty means the identity is unavailable. Starttime is stable for a process's
 // lifetime and changes when the kernel recycles a PID.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -237,8 +237,9 @@ remain P3.
 
 ## Transcript Retention
 
-Runtime transcript retention is opt-in and invalid or missing configuration
-fails closed to disabled capture:
+Runtime transcript retention is default-on. Every engine delivery appends its
+stdout and stderr to a private per-job log; set `enabled = false` only for an
+explicit opt-out. Missing or invalid configuration uses the safe defaults:
 
 ```toml
 [transcripts]
@@ -254,7 +255,8 @@ subprocess and therefore no log. A home-scoped sweep removes settled logs after
 `retain`, then evicts the oldest settled logs when the total exceeds
 `max_total_bytes`; queued/running jobs and recently finalized jobs are protected.
 Seat logs remain transient. Expect roughly 440 MB/week at this host's observed
-rate, though workload output varies.
+rate, though workload output varies. `retain` has a hard 24-hour floor; shorter
+or malformed retention falls back to the 168-hour default.
 
 Raw retained logs are mode `0600` and **unredacted on disk**. Treat the Gitmoot
 home as sensitive. JSONL exports redact known credential patterns best-effort,
@@ -417,6 +419,7 @@ daemon defaults with:
 [daemon]
 job_timeout_default = "4h"
 job_timeout_max = "8h"
+quiet_kill_after = "45m"
 ```
 
 The effective deadline resolves in this order: a positive `job_timeout` in the
@@ -426,12 +429,14 @@ larger request is clamped and the job receives a `job_timeout_clamped` event
 recording the requested and applied durations. This prevents a delegation tree
 from granting itself an unbounded run. These keys are read when a job dispatches,
 so edits affect newly started jobs without changing an in-flight deadline.
-The 30-minute stale-running threshold remains only a crash-detection predicate;
-it is never used as a job kill deadline.
+`quiet_kill_after` controls the transcript-silence leg of the liveness
+conjunction (default `45m`, hard floor `5m`). The 30-minute stale-running
+threshold remains only an age predicate; neither value is a job kill deadline.
 
 Reconfigure the running daemon without a restart: `kill -HUP <daemon-pid>`
 re-reads the `[daemon]` config section (`poll`, `workers`, `scheduler`,
-parallelism, `idle_grace_ticks`, `idle_max_multiplier`) live (#577) — no teardown, no dropped jobs, no environment
+parallelism, `idle_grace_ticks`, `idle_max_multiplier`, `quiet_kill_after`) live
+(#577) — no teardown, no dropped jobs, no environment
 re-inheritance. Values pinned by explicit launch flags win over the re-read
 config. Prefer SIGHUP over a restart when only tuning throughput.
 
@@ -2074,22 +2079,30 @@ never emitted a valid envelope even after repair attempts — the job records
 **failure diagnostics** (#806): a `phase` marker (`launched` = died before any
 stdout, `streaming` = died mid-output, `result-parse` = every delivery completed
 but no valid envelope was found), the process `exit_code` **or** terminating
-`signal`, a **redacted** stderr tail (hard-capped at 2 KB; redaction runs over
+`signal`, a **redacted** stderr tail (hard-capped at 4 KB; redaction runs over
 the full text with the same token-redaction rules as job comments *before* the
 tail is cut, so a secret can never leak partially), and the runtime session id
 when one is known. `gitmoot job show` prints a `failure_diagnostics:` block,
 `job show --json` carries `payload.failure_diagnostics`, and `gitmoot report
 bug` includes a "Failure diagnostics" section. Successful jobs never store one,
-and a retried job clears the previous run's crash report.
+and a retried job clears the previous run's crash report. Terminal `failed`
+events embed the same bounded, redacted stderr tail for durable triage.
 
-Jobs stuck in `running` are also backstopped: a running job with no lease
-progress past the staleness window (default 30m) is assumed orphaned by a dead
-worker and recovered/re-queued. The window is tunable via the
+Jobs stuck in `running` are also backstopped, but transcript silence alone never
+kills work. The recurring same-boot sweep moves `running` to `failed` only when
+all three facts agree: `updated_at` is frozen past the staleness window, the
+default-on job log is byte-identical across two sweeps and older than
+`[daemon].quiet_kill_after` (default 45m, minimum 5m), and the recorded runtime
+PID is dead. A live PID with the recorded `/proc` start-time identity is an
+absolute veto however quiet the log; a recycled PID records an identity-mismatch
+event and leaves the job running. Legacy rows without a runtime PID require
+twice the quiet threshold and no held runtime lease.
+
+The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` env var; the smallest honored value is 1m —
 below-1m, malformed, or non-positive values are rejected (with a one-time
-warning) in favor of the 30m default rather than clamped (#560). That window is a
-same-boot crash backstop, not a timeout: a running job whose runtime-session lease
-has not elapsed is left held regardless of the window. After a **reboot** there is
+warning) in favor of the 30m default rather than clamped (#560). It is a crash
+backstop, not a kill deadline. After a **reboot** there is
 no wait at all — the daemon detects the changed kernel boot id and, on its next
 startup and every tick, immediately requeues every job claimed on a previous boot
 and reclaims its stranded `runtime:<rt>:<session>` lock, regardless of any

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -144,8 +144,9 @@ runtime name is a config error surfaced by `gitmoot runtime list`.
 
 ## Transcript Retention
 
-Runtime transcript retention is opt-in and invalid or missing configuration
-fails closed to disabled capture:
+Runtime transcript retention is default-on. Every engine delivery appends its
+stdout and stderr to a private per-job log; set `enabled = false` only for an
+explicit opt-out. Missing or invalid configuration uses the safe defaults:
 
 ```toml
 [transcripts]
@@ -161,7 +162,8 @@ subprocess and therefore no log. A home-scoped sweep removes settled logs after
 `retain`, then evicts the oldest settled logs when the total exceeds
 `max_total_bytes`; queued/running jobs and recently finalized jobs are protected.
 Seat logs remain transient. Expect roughly 440 MB/week at this host's observed
-rate, though workload output varies.
+rate, though workload output varies. `retain` has a hard 24-hour floor; shorter
+or malformed retention falls back to the 168-hour default.
 
 Raw retained logs are mode `0600` and **unredacted on disk**. Treat the Gitmoot
 home as sensitive. JSONL exports redact known credential patterns best-effort,
@@ -324,6 +326,7 @@ daemon defaults with:
 [daemon]
 job_timeout_default = "4h"
 job_timeout_max = "8h"
+quiet_kill_after = "45m"
 ```
 
 The effective deadline resolves in this order: a positive `job_timeout` in the
@@ -333,14 +336,15 @@ larger request is clamped and the job receives a `job_timeout_clamped` event
 recording the requested and applied durations. This prevents a delegation tree
 from granting itself an unbounded run. These keys are read when a job dispatches,
 so edits affect newly started jobs without changing an in-flight deadline.
-The 30-minute stale-running threshold remains only a crash-detection predicate;
-it is never used as a job kill deadline.
+`quiet_kill_after` controls the transcript-silence leg of the liveness
+conjunction (default `45m`, hard floor `5m`). The 30-minute stale-running
+threshold remains only an age predicate; neither value is a job kill deadline.
 
 ### Reconfigure Without Restarting
 
 `kill -HUP <daemon-pid>` re-reads the `[daemon]` config section (`poll`,
-`workers`, `scheduler`, parallelism, `idle_grace_ticks`, and
-`idle_max_multiplier`) live (#577) — no teardown, no dropped
+`workers`, `scheduler`, parallelism, `idle_grace_ticks`,
+`idle_max_multiplier`, and `quiet_kill_after`) live (#577) — no teardown, no dropped
 jobs, no environment re-inheritance. Values pinned by explicit launch flags win
 over the re-read config. Prefer SIGHUP over a restart when only tuning
 throughput.
@@ -1833,20 +1837,30 @@ never emitted a valid envelope even after repair attempts — the job records
 **failure diagnostics** (#806): a `phase` marker (`launched` = died before any stdout,
 `streaming` = died mid-output, `result-parse` = every delivery completed but no
 valid envelope was found), the process `exit_code` **or** terminating `signal`,
-a **redacted** stderr tail (hard-capped at 2 KB; redaction runs over the full
+a **redacted** stderr tail (hard-capped at 4 KB; redaction runs over the full
 text with the same token-redaction rules as job comments *before* the tail is
 cut, so a secret can never leak partially), and the runtime session id when one
 is known. `gitmoot job show` prints a `failure_diagnostics:` block,
 `job show --json` carries `payload.failure_diagnostics`, and `gitmoot report
 bug` includes a "Failure diagnostics" section. Successful jobs never store one,
-and a retried job clears the previous run's crash report.
+and a retried job clears the previous run's crash report. Terminal `failed`
+events embed the same bounded, redacted stderr tail for durable triage.
 
-Jobs stuck in `running` are backstopped too: a running job with no lease
-progress past the staleness window (default 30m) is assumed orphaned by a dead
-worker and recovered/re-queued. The window is tunable via the
+Jobs stuck in `running` are backstopped too, but transcript silence alone never
+kills work. The recurring same-boot sweep moves `running` to `failed` only when
+all three facts agree: `updated_at` is frozen past the staleness window, the
+default-on job log is byte-identical across two sweeps and older than
+`[daemon].quiet_kill_after` (default 45m, minimum 5m), and the recorded runtime
+PID is dead. A live PID with the recorded `/proc` start-time identity is an
+absolute veto however quiet the log; a recycled PID records an identity-mismatch
+event and leaves the job running. Legacy rows without a runtime PID require
+twice the quiet threshold and no held runtime lease.
+
+The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value
 is 1m — below-1m, malformed, or non-positive values are rejected (with a
-one-time warning) in favor of the 30m default rather than clamped (#560).
+one-time warning) in favor of the 30m default rather than clamped (#560). It is a
+crash backstop, not a kill deadline.
 
 `gitmoot job kill <root-job-id>` is the operator kill switch for a runaway
 delegation tree: it terminates the tree identified by its **root** job id

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10081,8 +10081,9 @@ remain P3.
 
 ## Transcript Retention
 
-Runtime transcript retention is opt-in and invalid or missing configuration
-fails closed to disabled capture:
+Runtime transcript retention is default-on. Every engine delivery appends its
+stdout and stderr to a private per-job log; set `enabled = false` only for an
+explicit opt-out. Missing or invalid configuration uses the safe defaults:
 
 ```toml
 [transcripts]
@@ -10098,7 +10099,8 @@ subprocess and therefore no log. A home-scoped sweep removes settled logs after
 `retain`, then evicts the oldest settled logs when the total exceeds
 `max_total_bytes`; queued/running jobs and recently finalized jobs are protected.
 Seat logs remain transient. Expect roughly 440 MB/week at this host's observed
-rate, though workload output varies.
+rate, though workload output varies. `retain` has a hard 24-hour floor; shorter
+or malformed retention falls back to the 168-hour default.
 
 Raw retained logs are mode `0600` and **unredacted on disk**. Treat the Gitmoot
 home as sensitive. JSONL exports redact known credential patterns best-effort,
@@ -10261,6 +10263,7 @@ daemon defaults with:
 [daemon]
 job_timeout_default = "4h"
 job_timeout_max = "8h"
+quiet_kill_after = "45m"
 ```
 
 The effective deadline resolves in this order: a positive `job_timeout` in the
@@ -10270,12 +10273,14 @@ larger request is clamped and the job receives a `job_timeout_clamped` event
 recording the requested and applied durations. This prevents a delegation tree
 from granting itself an unbounded run. These keys are read when a job dispatches,
 so edits affect newly started jobs without changing an in-flight deadline.
-The 30-minute stale-running threshold remains only a crash-detection predicate;
-it is never used as a job kill deadline.
+`quiet_kill_after` controls the transcript-silence leg of the liveness
+conjunction (default `45m`, hard floor `5m`). The 30-minute stale-running
+threshold remains only an age predicate; neither value is a job kill deadline.
 
 Reconfigure the running daemon without a restart: `kill -HUP <daemon-pid>`
 re-reads the `[daemon]` config section (`poll`, `workers`, `scheduler`,
-parallelism, `idle_grace_ticks`, `idle_max_multiplier`) live (#577) — no teardown, no dropped jobs, no environment
+parallelism, `idle_grace_ticks`, `idle_max_multiplier`, `quiet_kill_after`) live
+(#577) — no teardown, no dropped jobs, no environment
 re-inheritance. Values pinned by explicit launch flags win over the re-read
 config. Prefer SIGHUP over a restart when only tuning throughput.
 
@@ -11918,22 +11923,30 @@ never emitted a valid envelope even after repair attempts — the job records
 **failure diagnostics** (#806): a `phase` marker (`launched` = died before any
 stdout, `streaming` = died mid-output, `result-parse` = every delivery completed
 but no valid envelope was found), the process `exit_code` **or** terminating
-`signal`, a **redacted** stderr tail (hard-capped at 2 KB; redaction runs over
+`signal`, a **redacted** stderr tail (hard-capped at 4 KB; redaction runs over
 the full text with the same token-redaction rules as job comments *before* the
 tail is cut, so a secret can never leak partially), and the runtime session id
 when one is known. `gitmoot job show` prints a `failure_diagnostics:` block,
 `job show --json` carries `payload.failure_diagnostics`, and `gitmoot report
 bug` includes a "Failure diagnostics" section. Successful jobs never store one,
-and a retried job clears the previous run's crash report.
+and a retried job clears the previous run's crash report. Terminal `failed`
+events embed the same bounded, redacted stderr tail for durable triage.
 
-Jobs stuck in `running` are also backstopped: a running job with no lease
-progress past the staleness window (default 30m) is assumed orphaned by a dead
-worker and recovered/re-queued. The window is tunable via the
+Jobs stuck in `running` are also backstopped, but transcript silence alone never
+kills work. The recurring same-boot sweep moves `running` to `failed` only when
+all three facts agree: `updated_at` is frozen past the staleness window, the
+default-on job log is byte-identical across two sweeps and older than
+`[daemon].quiet_kill_after` (default 45m, minimum 5m), and the recorded runtime
+PID is dead. A live PID with the recorded `/proc` start-time identity is an
+absolute veto however quiet the log; a recycled PID records an identity-mismatch
+event and leaves the job running. Legacy rows without a runtime PID require
+twice the quiet threshold and no held runtime lease.
+
+The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` env var; the smallest honored value is 1m —
 below-1m, malformed, or non-positive values are rejected (with a one-time
-warning) in favor of the 30m default rather than clamped (#560). That window is a
-same-boot crash backstop, not a timeout: a running job whose runtime-session lease
-has not elapsed is left held regardless of the window. After a **reboot** there is
+warning) in favor of the 30m default rather than clamped (#560). It is a crash
+backstop, not a kill deadline. After a **reboot** there is
 no wait at all — the daemon detects the changed kernel boot id and, on its next
 startup and every tick, immediately requeues every job claimed on a previous boot
 and reclaims its stranded `runtime:<rt>:<session>` lock, regardless of any


### PR DESCRIPTION
WHAT:
SLICE-C: Completed Campaign #1308 Slice C atop salvaged HEAD eb5ec3e6d5a482e99eb3acfb7699b06f0a8f52a4. Changes remain uncommitted for the finalizer.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-56187ad3

RESULTS:
- Targeted Go tests: packages passed=3, failed=0, skipped=0 for internal/cli, internal/config, and internal/workflow.
- Unchanged startup and expired-lease recovery tests passed.
- npm run build:llms passed; git diff --check passed.
- Dead-PID mutant failed as required: dead frozen job state = "running", want failed.
- Live-PID and frozen-log-alone mutants failed as required: live quiet job state = "failed", want running.
- Quiet-threshold mutant failed as required: under-threshold job state = "failed", want running.
- PID-reuse mutant failed as required: identity-mismatch job state = "failed", want running.
- Zero-floor mutant failed as required: expected error for quiet_kill_after = "0s".
- Production-wiring mutant failed as required: job state = "running", want failed by production tick liveness sweep.
- Default-off transcript mutant failed as required: default-on log path was empty and file was nil.

RISK:
Review the generated diff before merging.

TASK:
adhoc-56187ad3

AGENTS:
- wave-impl-b

RAW FINAL REVIEW OUTPUT:
````text
SLICE-C: Completed Campaign #1308 Slice C atop salvaged HEAD eb5ec3e6d5a482e99eb3acfb7699b06f0a8f52a4. Changes remain uncommitted for the finalizer.
````

## Sweep-requeue measurement

Read-only measurement against the deployed Gitmoot event history on 2026-07-31:

- Historical stale-running recovery requeues: **238 events across 158 jobs**.
- Requeues confirmably involving a live runtime process: **0**.
- This does **not** establish that no live work was requeued: all 238 events are historically unclassifiable because the old event rows contain no contemporaneous runtime PID/start-time evidence. Joining to the jobs table now would read later mutable state, not state at requeue time.

Count query:

```sql
WITH stale_requeues AS (
  SELECT job_id, created_at
  FROM job_events
  WHERE kind = 'queued'
    AND message = 'recovered stale running job on daemon startup'
)
SELECT COUNT(*) AS requeue_events,
       COUNT(DISTINCT job_id) AS jobs
FROM stale_requeues;
-- 238 | 158
```

Contemporaneous-evidence query:

```sql
WITH stale_requeues AS (
  SELECT id, job_id, created_at
  FROM job_events
  WHERE kind = 'queued'
    AND message = 'recovered stale running job on daemon startup'
),
with_process_evidence AS (
  SELECT DISTINCT r.id
  FROM stale_requeues r
  JOIN job_events e ON e.job_id = r.job_id AND e.id < r.id
  WHERE e.kind IN ('runtime_pid_recorded', 'job_liveness_identity_mismatch')
     OR lower(e.message) LIKE '%runtime pid%'
     OR lower(e.message) LIKE '%starttime%'
)
SELECT (SELECT COUNT(*) FROM stale_requeues) AS requeue_events,
       COUNT(*) AS with_prior_process_evidence
FROM with_process_evidence;
-- 238 | 0
```
