### PR TITLE
fix(workflow): skip-native-review-fanout is an intent that survives every engine hop (#1277)

### DIFF
--- a/internal/cli/daemon_workflow_test.go
+++ b/internal/cli/daemon_workflow_test.go
@@ -704,3 +704,94 @@ func TestBuildAskGateComment(t *testing.T) {
 		t.Fatalf("ask-gate comment parsed into %d command(s); want 0: %+v\nbody:\n%s", len(cmds), cmds, body)
 	}
 }
+
+// #1277, coverage axis: finalizerRan x executor-identity-differs.
+//
+// The write-ahead persist above closes the #390 TOCTOU — the daemon's PR-watcher
+// must never observe a PR for this branch with the skip flag still unwritten. It
+// is correctly IDENTITY-BLIND in production (daemon_workflow.go: `if
+// payload.SkipNativeReviewFanout`), but every committed finalizer fixture runs
+// with job.Agent == payload.LeadAgent, so nothing pinned that blindness.
+//
+// A FINALIZER_REQUIRES_EXECUTOR_IDENTITY mutant — adding
+// `&& payload.LeadAgent == job.Agent` to that condition — survived BOTH committed
+// finalizer tests and all three cells of the workflow-package mixed-identity
+// matrix. The shape it breaks is real: runtime_session_busy delegates execution
+// to a TEMPORARY WORKER, so job.Agent is the worker while LeadAgent and the branch
+// lock owner remain the original agent. Under the mutant the flag is not written
+// ahead, and the PR opens on a branch whose lock still reads false.
+//
+// Test-only guard: production behaviour is unchanged, this freezes it.
+func TestDaemonImplementationFinalizerPersistsSkipFanoutWhenExecutorIsDelegatedWorker(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "task-busy")
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("delegated work\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-busy", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task Busy", State: string(workflow.TaskImplementing), Branch: "task-busy", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	// The lock — and the branch — belong to the ORIGINAL agent, not the executor.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-busy", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	gh := &stubSkipFlagAtOpenGitHub{store: store, repo: "owner/repo", branch: "task-busy", pr: github.PullRequest{
+		Number:  8,
+		URL:     "https://github.com/owner/repo/pull/8",
+		State:   "open",
+		HeadRef: "task-busy",
+		BaseRef: "main",
+	}}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	payload := workflow.JobPayload{
+		Repo:                   "owner/repo",
+		Branch:                 "task-busy",
+		GoalID:                 "goal-1",
+		TaskID:                 "task-busy",
+		TaskTitle:              "Task Busy",
+		LeadAgent:              "lead",
+		DelegationReason:       "runtime_session_busy",
+		DelegatedAgent:         "temp-worker",
+		OriginalAgent:          "lead",
+		SkipNativeReviewFanout: true,
+		Result:                 &workflow.AgentResult{Decision: "implemented", Summary: "delegated worker finished"},
+	}
+
+	// The EXECUTOR is the temporary worker; LeadAgent and the lock owner are not.
+	if _, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-busy", Agent: "temp-worker", Type: "implement"}, payload); err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	if !gh.opened {
+		t.Fatal("EnsurePullRequest was never called; cannot assert ordering")
+	}
+	if !gh.skipAtOpen {
+		t.Fatal("#390 regression: branch-lock skip flag was NOT persisted before the PR was opened")
+	}
+	lock, err := store.GetBranchLock(ctx, "owner/repo", "task-busy")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if !lock.SkipNativeReviewFanout {
+		t.Fatalf("expected lock.SkipNativeReviewFanout = true after finalize, got %+v", lock)
+	}
+}

--- a/internal/cli/daemon_workflow_test.go
+++ b/internal/cli/daemon_workflow_test.go
@@ -795,3 +795,99 @@ func TestDaemonImplementationFinalizerPersistsSkipFanoutWhenExecutorIsDelegatedW
 		t.Fatalf("expected lock.SkipNativeReviewFanout = true after finalize, got %+v", lock)
 	}
 }
+
+// #1277, coverage axis: finalizerRan x payload-intent-false x prearmed-lock-intent-true.
+//
+// This is the FINALIZER's mirror of the polarity already pinned on the engine
+// writer by TestEngineAdvanceImplementWithoutIntentDoesNotTouchTheLock. There are
+// TWO independent writers of the branch-lock intent — the engine's post-advance
+// write and this finalizer's write-ahead — and pinning one says nothing about the
+// other. A FINALIZER_EXTRA_DEFAULT_UPDATE mutant, calling
+// SetBranchLockReviewFanout unconditionally with the payload's own value
+// (including false), passed the ENTIRE committed finalizer family.
+//
+// It is wrong on a real #1277 path rather than a theoretical one. dispatchFix
+// creates a PARENTLESS implement job whose payload intent is FALSE while the
+// branch lock still holds TRUE — that is precisely the case the in-process lock
+// fallback exists to rescue. The finalizer runs BEFORE that fallback reads the
+// lock, so an unconditional false write ERASES the branch command in between,
+// and native review re-arms on a branch that was explicitly exempted.
+//
+// The lock must therefore be pre-armed true and survive a false-payload finalize
+// untouched: false-written and never-written are indistinguishable from a bare
+// boolean read, so preservation is the only assertion that separates them.
+//
+// Test-only guard: production behaviour is unchanged, this freezes it.
+func TestDaemonImplementationFinalizerPreservesPrearmedSkipFanoutWhenPayloadIsFalse(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	remoteDir := filepath.Join(home, "remote.git")
+	repoDir := filepath.Join(home, "repo")
+	runGit(t, home, "init", "--bare", remoteDir)
+	runGit(t, home, "clone", remoteDir, repoDir)
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot Test")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "initial")
+	runGit(t, repoDir, "branch", "-m", "main")
+	runGit(t, repoDir, "push", "-u", "origin", "main")
+	runGit(t, repoDir, "switch", "-c", "task-fixround")
+	if err := os.WriteFile(filepath.Join(repoDir, "feature.txt"), []byte("fix round work\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	if err := store.UpsertRepo(ctx, db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir, DefaultBranch: "main", PollInterval: "30s"}); err != nil {
+		t.Fatalf("UpsertRepo returned error: %v", err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-fixround", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Fix Round", State: string(workflow.TaskImplementing), Branch: "task-fixround", WorktreePath: repoDir}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "owner/repo", Branch: "task-fixround", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	// The branch was exempted earlier in its life; the fix-round payload carries
+	// no intent of its own, exactly as dispatchFix builds it.
+	if err := store.SetBranchLockReviewFanout(ctx, "owner/repo", "task-fixround", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+	}
+	gh := &stubSkipFlagAtOpenGitHub{store: store, repo: "owner/repo", branch: "task-fixround", pr: github.PullRequest{
+		Number:  9,
+		URL:     "https://github.com/owner/repo/pull/9",
+		State:   "open",
+		HeadRef: "task-fixround",
+		BaseRef: "main",
+	}}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	payload := workflow.JobPayload{
+		Repo:                   "owner/repo",
+		Branch:                 "task-fixround",
+		GoalID:                 "goal-1",
+		TaskID:                 "task-fixround",
+		TaskTitle:              "Fix Round",
+		LeadAgent:              "lead",
+		SkipNativeReviewFanout: false,
+		Result:                 &workflow.AgentResult{Decision: "implemented", Summary: "addressed requested changes"},
+	}
+
+	if _, err := finalizer.FinalizeImplementation(ctx, db.Job{ID: "job-fixround", Agent: "lead", Type: "implement"}, payload); err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	if !gh.opened {
+		t.Fatal("EnsurePullRequest was never called; cannot assert ordering")
+	}
+	if !gh.skipAtOpen {
+		t.Fatal("#390 regression: a false-payload finalize ERASED the branch intent before the PR was opened")
+	}
+	lock, err := store.GetBranchLock(ctx, "owner/repo", "task-fixround")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if !lock.SkipNativeReviewFanout {
+		t.Fatalf("a false-payload finalize cleared the pre-armed branch intent: %+v", lock)
+	}
+}

--- a/internal/workflow/engine_fanout_intent_1277_test.go
+++ b/internal/workflow/engine_fanout_intent_1277_test.go
@@ -428,3 +428,175 @@ func TestBranchLockIntentSuppressesTheMergeGateWithNoConfiguredRoster(t *testing
 		}
 	}
 }
+
+// #1277 x #1236 — the MIXED-IDENTITY matrix guard.
+//
+// g7-review audited the full cross-product of (payload intent, lock intent,
+// roster shape, executor-owns-lock, PR opened) and found the committed suite was
+// systematically thin along ONE axis: identity. Three cells were unpinned, and
+// each supported a wrong mutant that passed all twenty committed tests.
+//
+// The axis matters because runtime_session_busy makes executor identity diverge
+// from branch ownership: a temporary worker runs the job while OriginalAgent owns
+// the lock and is restored as LeadAgent. There are exactly three places where
+// identity is semantically active, and this table pins one cell for each:
+//
+//	fallback              — reading the branch intent must not depend on who owns
+//	                        the lock or on whether a roster exists.
+//	no-PR persistence     — writing the branch intent must happen even when a
+//	                        delegated worker advances the job.
+//	implementer exclusion — the roster filter must key on LeadAgent (the restored
+//	                        ORIGINAL implementer), never on Sender (the worker),
+//	                        or the real implementer reviews its own head.
+//
+// Table-driven rather than three point tests, per the reviewer, so the identity
+// axis is explicit and the next cell is cheap to add.
+func TestMixedIdentityFanoutIntentMatrix(t *testing.T) {
+	const repo = "gitmoot/gitmoot"
+
+	cases := []struct {
+		name string
+		// branch setup
+		branch      string
+		lockOwner   string
+		lockIntent  bool
+		roster      []string
+		payloadIntt bool
+		pullRequest int
+		assert      func(t *testing.T, ctx context.Context, store *db.Store, gate *fakeMergeGate)
+	}{
+		{
+			// Mutant killed: ROSTER_OR_OWNER_LOCK_FALLBACK — honouring the lock only
+			// when a roster exists OR the executor owns it. With neither true, an
+			// intent-bearing branch fell through to the MERGE GATE.
+			name:        "fallback: zero roster and a worker that does not own the lock",
+			branch:      "task-m1",
+			lockOwner:   "orig",
+			lockIntent:  true,
+			roster:      nil,
+			payloadIntt: false,
+			pullRequest: 16,
+			assert: func(t *testing.T, ctx context.Context, store *db.Store, gate *fakeMergeGate) {
+				if len(gate.requests) != 0 {
+					t.Fatalf("mixed identity + zero roster bypassed the branch intent and reached the merge gate: %+v", gate.requests)
+				}
+				assertNoReviewJobs(t, ctx, store)
+			},
+		},
+		{
+			// Mutant killed: DROP_TEMP_NO_PR_PERSIST — skipping the branch-lock write
+			// for a delegated worker. The ORIGINAL owner's lock stayed false, so a
+			// later hand-opened PR re-armed through the daemon watcher.
+			name:        "no-PR persistence: delegated worker must publish onto the original owner's lock",
+			branch:      "task-m2",
+			lockOwner:   "orig",
+			lockIntent:  false,
+			roster:      nil,
+			payloadIntt: true,
+			pullRequest: 0,
+			assert: func(t *testing.T, ctx context.Context, store *db.Store, gate *fakeMergeGate) {
+				lock, err := store.GetBranchLock(ctx, repo, "task-m2")
+				if err != nil {
+					t.Fatalf("GetBranchLock returned error: %v", err)
+				}
+				if !lock.SkipNativeReviewFanout {
+					t.Fatalf("delegated worker did not publish the intent onto the original owner's lock: %+v", lock)
+				}
+			},
+		},
+		{
+			// Mutant killed: SENDER_AS_IMPLEMENTER — filtering the roster by
+			// event.Sender (the temporary worker) instead of event.LeadAgent (the
+			// restored original implementer). The real implementer was then eligible
+			// and got enlisted to review its OWN head.
+			name:        "implementer exclusion: roster must key on the restored LeadAgent, not the worker",
+			branch:      "task-m3",
+			lockOwner:   "orig",
+			lockIntent:  false,
+			roster:      []string{"orig"},
+			payloadIntt: false,
+			pullRequest: 17,
+			assert: func(t *testing.T, ctx context.Context, store *db.Store, gate *fakeMergeGate) {
+				jobs, err := store.ListJobs(ctx)
+				if err != nil {
+					t.Fatalf("ListJobs returned error: %v", err)
+				}
+				for _, job := range jobs {
+					if job.Type == "review" && job.Agent == "orig" {
+						t.Fatalf("the original implementer was enlisted to review its own head via the worker's Sender: %+v", job)
+					}
+				}
+				assertNoReviewJobs(t, ctx, store)
+				// Roster filtered to empty must fail CLOSED, never reach the gate.
+				if len(gate.requests) != 0 {
+					t.Fatalf("all-ineligible roster reached the merge gate: %+v", gate.requests)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			// "orig" owns the branch and is the real implementer; it carries review
+			// capability so that a filter keying on the WRONG identity would in fact
+			// enlist it — otherwise cell 3's mutant could not be observed.
+			seedAgent(t, store, "orig", []string{"implement", "review"}, repo)
+			seedAgent(t, store, "temp-worker", []string{"implement"}, repo)
+			engine := testEngine(store)
+			engine.RequiredReviewers = tc.roster
+			gate := &fakeMergeGate{decision: MergeDecision{Reason: "ci is pending"}}
+			engine.MergeGate = gate
+
+			if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo, Branch: tc.branch, Owner: tc.lockOwner}); err != nil || !acquired {
+				t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+			}
+			if tc.lockIntent {
+				if err := store.SetBranchLockReviewFanout(ctx, repo, tc.branch, true); err != nil {
+					t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+				}
+			}
+			// Every cell advances a runtime_session_busy job: the DELEGATED worker
+			// executes while "orig" owns the lock and is restored as LeadAgent.
+			insertCompletedJob(t, store, db.Job{
+				ID:    "matrix-" + tc.branch,
+				Agent: "temp-worker",
+				Type:  "implement",
+			}, JobPayload{
+				Repo:                   repo,
+				Branch:                 tc.branch,
+				PullRequest:            tc.pullRequest,
+				HeadSHA:                "head-" + tc.branch,
+				TaskID:                 tc.branch,
+				LeadAgent:              "",
+				DelegationReason:       "runtime_session_busy",
+				DelegatedAgent:         "temp-worker",
+				OriginalAgent:          "orig",
+				SkipNativeReviewFanout: tc.payloadIntt,
+				Result:                 &AgentResult{Decision: "implemented", Summary: "delegated worker advanced the branch"},
+			})
+
+			// Assert side effects before any advance error: a gate that runs can also
+			// error, and a naive ordering would hide the real defect behind it.
+			advanceErr := engine.AdvanceJob(ctx, "matrix-"+tc.branch)
+			tc.assert(t, ctx, store, gate)
+			if advanceErr != nil {
+				t.Fatalf("AdvanceJob returned error: %v", advanceErr)
+			}
+		})
+	}
+}
+
+func assertNoReviewJobs(t *testing.T, ctx context.Context, store *db.Store) {
+	t.Helper()
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("expected no review jobs, found %+v", job)
+		}
+	}
+}

--- a/internal/workflow/engine_fanout_intent_1277_test.go
+++ b/internal/workflow/engine_fanout_intent_1277_test.go
@@ -82,9 +82,17 @@ func TestEngineAdvanceImplementPersistsSkipReviewFanoutWithoutPR(t *testing.T) {
 	}
 }
 
-// Guard the default: a job WITHOUT the intent must never write the flag onto a
-// branch lock, so the common path stays byte-identical.
-func TestEngineAdvanceImplementWithoutIntentLeavesLockUntouched(t *testing.T) {
+// Guard the default path, and make the guard LOAD-BEARING. An earlier version of
+// this test asserted only that the stored boolean was false, which an
+// EXTRA_DEFAULT_UPDATE mutant — one that always calls the setter, passing the
+// payload's own false — survived, because false-written and never-written look
+// identical from the boolean alone.
+//
+// Seeding the lock with skip=TRUE and advancing a job that carries NO intent
+// makes the two distinguishable without depending on timestamp granularity: if
+// the default path calls the setter at all it writes false and flips the lock,
+// so the mutant is killed by the assertion rather than by a clock.
+func TestEngineAdvanceImplementWithoutIntentDoesNotTouchTheLock(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
@@ -92,6 +100,10 @@ func TestEngineAdvanceImplementWithoutIntentLeavesLockUntouched(t *testing.T) {
 
 	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-8", Owner: "lead"}); err != nil || !acquired {
 		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	// Pre-arm the lock. A correct default path must leave this alone.
+	if err := store.SetBranchLockReviewFanout(ctx, "gitmoot/gitmoot", "task-8", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
 	}
 	insertCompletedJob(t, store, db.Job{
 		ID:    "implement-job-plain",
@@ -113,7 +125,115 @@ func TestEngineAdvanceImplementWithoutIntentLeavesLockUntouched(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetBranchLock returned error: %v", err)
 	}
-	if lock.SkipNativeReviewFanout {
-		t.Fatalf("a job with no intent armed the skip flag: %+v", lock)
+	if !lock.SkipNativeReviewFanout {
+		t.Fatalf("the default path WROTE to the lock and cleared a pre-armed flag: %+v", lock)
+	}
+}
+
+// #1277, the escape g7-review reproduced against the first version of this fix.
+// The branch lock cannot rescue a multi-generation tree, because at the moment
+// the intent is dropped NO intent-bearing implement job has advanced yet, so
+// nothing has published the intent onto the lock.
+//
+// The path: an intent-bearing coordinator delegates a child; the child's
+// continuation is built by a constructor that does NOT set the flag (there are
+// nine such constructors and none set it); that continuation then delegates the
+// implement leg, which opens the PR and re-arms the fanout.
+//
+// Enqueue-time inheritance closes it for every constructor at once, which is why
+// the continuation request below deliberately leaves SkipNativeReviewFanout
+// unset — exactly as engine_continuation_synthesis.go builds it.
+func TestIntentSurvivesContinuationThenImplementChild(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "coordinator", []string{"ask", "review"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "impl", []string{"implement"}, "gitmoot/gitmoot")
+	mailbox := Mailbox{Store: store}
+
+	root, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:                     "root-coordinator",
+		Agent:                  "coordinator",
+		Action:                 "ask",
+		Repo:                   "gitmoot/gitmoot",
+		Branch:                 "task-9",
+		TaskID:                 "task-9",
+		Instructions:           "coordinate",
+		SkipNativeReviewFanout: true,
+	})
+	if err != nil {
+		t.Fatalf("Enqueue root returned error: %v", err)
+	}
+
+	// Generation 2: a continuation constructor that drops the flag.
+	continuation, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:           "continuation-1",
+		Agent:        "coordinator",
+		Action:       "ask",
+		Repo:         "gitmoot/gitmoot",
+		Branch:       "task-9",
+		TaskID:       "task-9",
+		Instructions: "synthesize",
+		ParentJobID:  root.ID,
+	})
+	if err != nil {
+		t.Fatalf("Enqueue continuation returned error: %v", err)
+	}
+	continuationPayload, err := ParseJobPayload(continuation.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(continuation) returned error: %v", err)
+	}
+	if !continuationPayload.SkipNativeReviewFanout {
+		t.Fatalf("continuation dropped the intent: %+v", continuationPayload)
+	}
+
+	// Generation 3: the implement child that would open the PR.
+	child, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:           "implement-child",
+		Agent:        "impl",
+		Action:       "implement",
+		Repo:         "gitmoot/gitmoot",
+		Branch:       "task-9",
+		TaskID:       "task-9",
+		Instructions: "do the work",
+		ParentJobID:  continuation.ID,
+	})
+	if err != nil {
+		t.Fatalf("Enqueue implement child returned error: %v", err)
+	}
+	childPayload, err := ParseJobPayload(child.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload(child) returned error: %v", err)
+	}
+	if !childPayload.SkipNativeReviewFanout {
+		t.Fatalf("implement child after continuation re-armed native fanout: %+v", childPayload)
+	}
+}
+
+// A root dispatch with no intent and no parent must stay exactly as built — the
+// inheritance lookup must not invent an intent.
+func TestEnqueueWithoutParentDoesNotInventIntent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "impl", []string{"implement"}, "gitmoot/gitmoot")
+	mailbox := Mailbox{Store: store}
+
+	job, err := mailbox.Enqueue(ctx, JobRequest{
+		ID:           "plain-root",
+		Agent:        "impl",
+		Action:       "implement",
+		Repo:         "gitmoot/gitmoot",
+		Branch:       "task-10",
+		TaskID:       "task-10",
+		Instructions: "do the work",
+	})
+	if err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	payload, err := ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	}
+	if payload.SkipNativeReviewFanout {
+		t.Fatalf("a parentless root invented the intent: %+v", payload)
 	}
 }

--- a/internal/workflow/engine_fanout_intent_1277_test.go
+++ b/internal/workflow/engine_fanout_intent_1277_test.go
@@ -1,0 +1,119 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1277. The skip-native-review-fanout intent must survive an engine-initiated
+// hop. A coordinator dispatched with --skip-native-review-fanout that delegates
+// its implement leg produced a child whose payload had the flag CLEARED, so the
+// child's PR-open re-armed the native fanout and enlisted the implementer as its
+// own reviewer (#1236). delegationRequest inherits ~25 parent fields — including
+// RiskTier, ActingOrgRole and the cockpit trio — but dropped this one.
+func TestDelegationChildInheritsSkipNativeReviewFanout(t *testing.T) {
+	store := openEngineStore(t)
+	engine := testEngine(store)
+
+	parent := db.Job{ID: "coordinator-job", Agent: "lead", Type: "ask"}
+	payload := JobPayload{
+		Repo:                   "gitmoot/gitmoot",
+		Branch:                 "task-7",
+		TaskID:                 "task-7",
+		LeadAgent:              "lead",
+		SkipNativeReviewFanout: true,
+	}
+
+	child := engine.delegationRequest(parent, payload, Delegation{
+		ID:     "leg-1",
+		Agent:  "impl",
+		Action: "implement",
+		Prompt: "do the work",
+	})
+
+	if !child.SkipNativeReviewFanout {
+		t.Fatalf("delegation child dropped SkipNativeReviewFanout: %+v", child)
+	}
+}
+
+// #1277. An implement job that carries the intent but does NOT open a PR must
+// still publish it onto the branch lock. This is the arm the issue measured:
+// PR #1275 was opened BY HAND on a branch whose implement dispatch had passed
+// the flag, and because the persist lived behind the PullRequest > 0 branch the
+// lock still read skip=false, so the daemon's PR-watcher armed six review jobs.
+// Persisting on the no-PR advance makes the intent a property of the BRANCH, so
+// it no longer matters who opens the PR.
+func TestEngineAdvanceImplementPersistsSkipReviewFanoutWithoutPR(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-7", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job-no-pr",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:                   "gitmoot/gitmoot",
+		Branch:                 "task-7",
+		PullRequest:            0,
+		TaskID:                 "task-7",
+		TaskTitle:              "Workflow Engine",
+		LeadAgent:              "lead",
+		SkipNativeReviewFanout: true,
+		Result:                 &AgentResult{Decision: "implemented", Summary: "pushed the branch, PR opened by hand"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "implement-job-no-pr"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	lock, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-7")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if !lock.SkipNativeReviewFanout {
+		t.Fatalf("no-PR implement advance did not publish the intent onto the lock: %+v", lock)
+	}
+}
+
+// Guard the default: a job WITHOUT the intent must never write the flag onto a
+// branch lock, so the common path stays byte-identical.
+func TestEngineAdvanceImplementWithoutIntentLeavesLockUntouched(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-8", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "implement-job-plain",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:      "gitmoot/gitmoot",
+		Branch:    "task-8",
+		TaskID:    "task-8",
+		LeadAgent: "lead",
+		Result:    &AgentResult{Decision: "implemented", Summary: "no intent set"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "implement-job-plain"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	lock, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-8")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.SkipNativeReviewFanout {
+		t.Fatalf("a job with no intent armed the skip flag: %+v", lock)
+	}
+}

--- a/internal/workflow/engine_fanout_intent_1277_test.go
+++ b/internal/workflow/engine_fanout_intent_1277_test.go
@@ -359,3 +359,72 @@ func TestInProcessPROpenHonoursBranchLockAcrossSessionBusyDelegation(t *testing.
 		}
 	}
 }
+
+// #1277 x #1236, the cross-product g7-review found by mutation — and the
+// highest-stakes cell in this whole change, because the failure mode is a MERGE
+// GATE RUN rather than a spurious review.
+//
+// The two fixes install two different fail-closed mechanisms in the same
+// function, and this is where they meet. When NO reviewer roster is configured,
+// HandlePullRequestOpened treats the PR as "no native review discipline" and runs
+// the MERGE GATE. The branch intent is what must return through the baseline
+// BEFORE that arm is reached. So if the lock fallback is ever narrowed to only
+// apply when a roster exists, an intent-bearing zero-roster PR stops being
+// suppressed and starts being MERGE-GATED — the intent inverts from "do not
+// review this" into "consider this for merge unreviewed".
+//
+// A ROSTER_ONLY_LOCK_FALLBACK mutant survived all nineteen fanout/PR-open/
+// implement/dispatchFix/preflight/zero-roster tests, so nothing pinned this.
+func TestBranchLockIntentSuppressesTheMergeGateWithNoConfiguredRoster(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	// Deliberately NO configured reviewers — this is the zero-roster arm.
+	engine.RequiredReviewers = nil
+	gate := &fakeMergeGate{decision: MergeDecision{Merged: true}}
+	engine.MergeGate = gate
+
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-15", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	// The branch carries the intent; the payload does not.
+	if err := store.SetBranchLockReviewFanout(ctx, "gitmoot/gitmoot", "task-15", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "zero-roster-implement",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:                   "gitmoot/gitmoot",
+		Branch:                 "task-15",
+		PullRequest:            15,
+		HeadSHA:                "head015",
+		TaskID:                 "task-15",
+		LeadAgent:              "lead",
+		SkipNativeReviewFanout: false,
+		Result:                 &AgentResult{Decision: "implemented", Summary: "opened PR on an intent-bearing branch"},
+	})
+
+	// Assert on the gate BEFORE the advance error: when the intent is dropped the
+	// gate runs and its decision can itself error, which would otherwise mask the
+	// real defect behind a generic "merge gate rejected action". This regression
+	// has to name what went wrong, not merely go red.
+	advanceErr := engine.AdvanceJob(ctx, "zero-roster-implement")
+	if len(gate.requests) != 0 {
+		t.Fatalf("branch intent was dropped and let a zero-roster PR reach the merge gate: %+v", gate.requests)
+	}
+	if advanceErr != nil {
+		t.Fatalf("AdvanceJob returned error: %v", advanceErr)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("expected no review jobs, found %+v", job)
+		}
+	}
+}

--- a/internal/workflow/engine_fanout_intent_1277_test.go
+++ b/internal/workflow/engine_fanout_intent_1277_test.go
@@ -237,3 +237,60 @@ func TestEnqueueWithoutParentDoesNotInventIntent(t *testing.T) {
 		t.Fatalf("a parentless root invented the intent: %+v", payload)
 	}
 }
+
+// #1277, the third escape g7-review reproduced. dispatchFix builds a PARENTLESS
+// implement request carrying neither ParentJobID nor SkipNativeReviewFanout, so
+// it slips past the enqueue-chokepoint inheritance (which requires a parent) and
+// its fix round re-armed the fanout — on a branch whose lock already read true.
+//
+// The root cause is an asymmetry between the two PR-open triggers: the daemon
+// PR-watcher read the branch lock, the in-process trigger read only the payload.
+// This pins the fix from the OUTSIDE — a payload with no intent, on a branch
+// whose lock carries it, must not fan out.
+func TestInProcessPROpenHonoursTheBranchLockIntent(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"reviewer"}
+	gate := &fakeMergeGate{decision: MergeDecision{Reason: "ci is pending"}}
+	engine.MergeGate = gate
+
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-11", Owner: "lead"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	// The branch was already told, e.g. by the original intent-bearing implement.
+	if err := store.SetBranchLockReviewFanout(ctx, "gitmoot/gitmoot", "task-11", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+	}
+	// The fix-round job, as dispatchFix builds it: no intent, no parent.
+	insertCompletedJob(t, store, db.Job{
+		ID:    "fix-round-implement",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:                   "gitmoot/gitmoot",
+		Branch:                 "task-11",
+		PullRequest:            11,
+		HeadSHA:                "head456",
+		TaskID:                 "task-11",
+		LeadAgent:              "lead",
+		SkipNativeReviewFanout: false,
+		Result:                 &AgentResult{Decision: "implemented", Summary: "addressed requested changes"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "fix-round-implement"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("parentless fix round re-armed native fanout despite the branch lock: %+v", job)
+		}
+	}
+}

--- a/internal/workflow/engine_fanout_intent_1277_test.go
+++ b/internal/workflow/engine_fanout_intent_1277_test.go
@@ -294,3 +294,68 @@ func TestInProcessPROpenHonoursTheBranchLockIntent(t *testing.T) {
 		}
 	}
 }
+
+// #1277, the guard gap g7-review found by mutation. The branch-lock fallback
+// must hold across the engine's OWN identity rewrite, and the previous test only
+// covered the homogeneous case where the implement job's agent is also the lock
+// owner. A mutant narrowing the fallback to lock.Owner == job.Agent survived all
+// twelve fanout/PR-open/dispatchFix tests while being wrong for a shape the
+// engine actively supports.
+//
+// That shape is runtime_session_busy: when a runtime session is occupied the work
+// is delegated to a TEMPORARY WORKER, so job.Agent is the worker while the branch
+// lock is still owned by OriginalAgent — and it is OriginalAgent that
+// leadAgent-resolution restores. The branch carries the intent; the worker's
+// payload does not. Ownership must be irrelevant to reading it.
+func TestInProcessPROpenHonoursBranchLockAcrossSessionBusyDelegation(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "orig", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "temp-worker", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"reviewer"}
+	gate := &fakeMergeGate{decision: MergeDecision{Reason: "ci is pending"}}
+	engine.MergeGate = gate
+
+	// The lock — and therefore the branch intent — belongs to the ORIGINAL agent.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{RepoFullName: "gitmoot/gitmoot", Branch: "task-14", Owner: "orig"}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.SetBranchLockReviewFanout(ctx, "gitmoot/gitmoot", "task-14", true); err != nil {
+		t.Fatalf("SetBranchLockReviewFanout returned error: %v", err)
+	}
+	// The advancing job is the DELEGATED temporary worker, carrying no intent of
+	// its own. LeadAgent is empty so the runtime_session_busy restore runs.
+	insertCompletedJob(t, store, db.Job{
+		ID:    "session-busy-implement",
+		Agent: "temp-worker",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:                   "gitmoot/gitmoot",
+		Branch:                 "task-14",
+		PullRequest:            14,
+		HeadSHA:                "head789",
+		TaskID:                 "task-14",
+		LeadAgent:              "",
+		DelegationReason:       "runtime_session_busy",
+		DelegatedAgent:         "temp-worker",
+		OriginalAgent:          "orig",
+		SkipNativeReviewFanout: false,
+		Result:                 &AgentResult{Decision: "implemented", Summary: "delegated worker pushed the branch"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "session-busy-implement"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("temporary worker re-armed fanout despite the original owner's branch intent: %+v", job)
+		}
+	}
+}

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -411,6 +411,24 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			}
 			payload = finalized
 		}
+		// #1277: publish the skip-native-review-fanout intent onto the BRANCH LOCK
+		// before the no-PR early return, so it is a property of the branch rather
+		// than of whoever opens the PR. The persist used to live inside the
+		// PullRequest > 0 arm below, which meant an implement job that carried the
+		// intent but did NOT open a PR left the lock reading skip=false — and a PR
+		// opened by hand on that branch minutes later re-armed the native fanout
+		// through the daemon's PR-watcher path (the measured #1275 arm: six review
+		// jobs, the implementer among them). Placed AFTER the finalizer block so it
+		// sees exactly the payload the PR path sees. The write is a bare UPDATE and
+		// never creates a lock, so it can neither establish nor transfer branch
+		// ownership; skipping it on the default (false) keeps the common path free
+		// of an extra UPDATE, since a freshly created lock already defaults to
+		// not-skip.
+		if payload.SkipNativeReviewFanout && !finalizerRan && strings.TrimSpace(payload.Branch) != "" {
+			if err := e.Store.SetBranchLockReviewFanout(ctx, payload.Repo, payload.Branch, true); err != nil {
+				return err
+			}
+		}
 		if payload.PullRequest <= 0 {
 			return e.recordImplementNoPRAdvance(ctx, job.ID, payload.Result.Decision)
 		}
@@ -438,18 +456,11 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			// skip_native_review_fanout straight onto the PR event.
 			SkipReviewFanout: payload.SkipNativeReviewFanout,
 		}
-		// Persist the flag onto the branch lock for the daemon's PR-watcher path
-		// (trigger 2). When the finalizer ran it already wrote the flag BEFORE
-		// opening the PR (closing the #390 TOCTOU), so this write would be
-		// redundant; only the non-finalizer path (PR pre-attached, no managed
-		// worktree) reaches the PR with the flag unpersisted. Skipping the write on
-		// the common default (false) keeps that path free of an extra lock UPDATE —
-		// a freshly created lock already defaults to not-skip.
-		if payload.SkipNativeReviewFanout && !finalizerRan {
-			if err := e.Store.SetBranchLockReviewFanout(ctx, payload.Repo, payload.Branch, true); err != nil {
-				return err
-			}
-		}
+		// The branch-lock persist for the daemon's PR-watcher path (trigger 2) now
+		// happens above, before the no-PR early return, so it covers the PR arm and
+		// the no-PR arm alike. When the finalizer ran it already wrote the flag
+		// BEFORE opening the PR (closing the #390 TOCTOU), which is why both sites
+		// share the !finalizerRan guard.
 		return e.HandlePullRequestOpened(ctx, event)
 	case "review":
 		// A PR-less review (e.g. a review heartbeat enqueues Action="review" with
@@ -777,6 +788,16 @@ func (e Engine) delegationRequest(job db.Job, payload JobPayload, d Delegation) 
 		// Inherit the coordinator's resolved risk tier (#650) so a high-risk lens
 		// child carries it for explainable escalation. Empty for every non-risk tree.
 		RiskTier: strings.TrimSpace(payload.RiskTier),
+		// #1277: inherit the skip-native-review-fanout intent. Without this the
+		// intent survived exactly one hop — the dispatched coordinator — and died
+		// at the first engine-initiated hop, so a coordinator dispatched with
+		// --skip-native-review-fanout that delegated its implement leg (the normal
+		// orchestration shape) produced a child with the flag cleared. That child
+		// opened the PR, the fanout re-armed, and it enlisted the implementer as a
+		// reviewer of its own head (#1236). The intent is an operator COMMAND about
+		// how this tree is reviewed, so it belongs to the whole tree, not to the one
+		// job that happened to receive the flag.
+		SkipNativeReviewFanout: payload.SkipNativeReviewFanout,
 		// Cockpit settings are inherited from the coordinator so every delegation
 		// subagent in one tree renders a pane under the same workspace/session.
 		Cockpit:        payload.Cockpit,

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -441,6 +441,26 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 				leadAgent = payload.OriginalAgent
 			}
 		}
+		// Trigger 1 (in-process path): carry the implement job's
+		// skip_native_review_fanout onto the PR event, falling back to the BRANCH
+		// LOCK when the payload does not carry it.
+		//
+		// The lock fallback is what makes the intent genuinely branch-scoped. Until
+		// now the two PR-open triggers disagreed: the daemon PR-watcher read
+		// lock.SkipNativeReviewFanout, while this in-process trigger read only the
+		// payload — so an engine hop that lost the flag re-armed the fanout here even
+		// though the branch had already been told. dispatchFix is exactly that hop:
+		// it builds a PARENTLESS implement request with no SkipNativeReviewFanout, so
+		// it escapes the enqueue-chokepoint inheritance (which requires a parent) and
+		// its fix round re-armed review on a branch whose lock already read true.
+		// Reading the lock here closes that class for every parentless engine
+		// re-dispatch, present and future, without reaching into the constructors.
+		skipFanout := payload.SkipNativeReviewFanout
+		if !skipFanout && strings.TrimSpace(payload.Branch) != "" {
+			if lock, lockErr := e.Store.GetBranchLock(ctx, payload.Repo, payload.Branch); lockErr == nil && lock.SkipNativeReviewFanout {
+				skipFanout = true
+			}
+		}
 		event := PullRequestEvent{
 			Repo:              payload.Repo,
 			Branch:            payload.Branch,
@@ -452,9 +472,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			LeadAgent:         leadAgent,
 			Sender:            job.Agent,
 			RequiredReviewers: e.requiredReviewers(payload),
-			// Trigger 1 (in-process path): carry the implement job's
-			// skip_native_review_fanout straight onto the PR event.
-			SkipReviewFanout: payload.SkipNativeReviewFanout,
+			SkipReviewFanout:  skipFanout,
 		}
 		// The branch-lock persist for the daemon's PR-watcher path (trigger 2) now
 		// happens above, before the no-PR early return, so it covers the PR arm and

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -485,6 +485,32 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		snapshot = *request.TemplateOverride
 	}
 
+	// #1277: inherit the skip-native-review-fanout intent from the parent job.
+	//
+	// Propagating the flag at each JobRequest construction site is whack-a-mole:
+	// there are nine of them in internal/workflow, none propagated it, and a
+	// review of the first attempt at this fix reproduced a live two-generation
+	// escape that the branch lock could NOT rescue — an intent-bearing ask
+	// coordinator delegates a review child, the normal continuation is enqueued
+	// (dropping the flag), and that continuation delegates the implement child
+	// which re-arms the fanout. No intent-bearing implement job had advanced yet,
+	// so nothing had published the intent onto the lock.
+	//
+	// Enqueue is the ONE chokepoint every request passes through, so inheriting
+	// here fixes the whole class instead of the instances, and the tenth
+	// construction site somebody adds next month inherits it for free. Only a
+	// request that does NOT already carry the intent and HAS a parent pays for the
+	// lookup, so root dispatches are untouched. Fails open: an unreadable parent
+	// leaves the request exactly as the caller built it.
+	skipNativeReviewFanout := request.SkipNativeReviewFanout
+	if !skipNativeReviewFanout && strings.TrimSpace(request.ParentJobID) != "" {
+		if parent, parentErr := m.Store.GetJob(ctx, strings.TrimSpace(request.ParentJobID)); parentErr == nil {
+			if parentPayload, parseErr := unmarshalPayload(parent.Payload); parseErr == nil && parentPayload.SkipNativeReviewFanout {
+				skipNativeReviewFanout = true
+			}
+		}
+	}
+
 	payload, err := marshalPayload(JobPayload{
 		Repo:                   request.Repo,
 		Branch:                 request.Branch,
@@ -544,7 +570,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		Cockpit:                request.Cockpit,
 		CockpitSession:         strings.TrimSpace(request.CockpitSession),
 		CockpitPaneKey:         strings.TrimSpace(request.CockpitPaneKey),
-		SkipNativeReviewFanout: request.SkipNativeReviewFanout,
+		SkipNativeReviewFanout: skipNativeReviewFanout,
 		ValidatedPullRequest:   request.ValidatedPullRequest,
 		Ephemeral:              request.Ephemeral,
 		HumanAnswer:            request.HumanAnswer,


### PR DESCRIPTION
GMC-FANOUT, lane C of campaign #1300. **Draft, and stays draft** — only jarvis's five-condition checklist merges campaign PRs.

## The headline is wrong, and that matters

`--skip-native-review-fanout` does **not** "fence the dispatch entrance only". The flag **is** persisted to the branch lock and **is** honored — five daemon sites plus the PR-open gate at `engine_pr_lifecycle.go:36`. The entrance is fenced. Building against the headline would have produced a fix for a bug that isn't there.

What actually leaks is the **intent**, in two independent places.

### 1. The intent died at the first engine-initiated hop

`delegationRequest` inherits ~25 fields from the coordinator's payload — `RiskTier`, `ActingOrgRole`, `Deps`, the cockpit trio — and dropped `SkipNativeReviewFanout`.

So a coordinator dispatched with `--skip-native-review-fanout` that delegated its implement leg — **the normal orchestration shape** — produced a child with the flag cleared. The child opened the PR, the fanout re-armed, and it enlisted the implementer as a reviewer of its own head (#1236).

I audited all nine `JobRequest` construction sites in `internal/workflow`. **Not one propagated the flag.** The intent survived exactly one hop: the job the operator dispatched.

### 2. The intent was never published when no PR was opened

The branch-lock persist lived *inside* the `PullRequest > 0` arm. An implement job that carried the intent but did not open a PR left the lock reading `skip=false`.

That is precisely the measured #1275 arm in the issue: the implement dispatch **did** pass the flag, the PR was opened by hand minutes later, the daemon's PR-watcher read a lock that had never been told, and six review jobs spawned — the implementer among them.

## The fix

Treat the flag as what it is: an operator **command** about how this tree is reviewed, owned by the tree and the branch, not by the one job that happened to receive it.

- `delegationRequest` inherits the intent, so it survives delegation.
- The branch-lock persist moves ahead of the no-PR early return, covering the PR arm and the no-PR arm alike. The intent becomes a property of the **branch**, so it no longer matters who opens the PR.

That second half is issue #1277's own proposed fix direction (1).

## Scope discipline

Propagating the payload flag at each of the nine sites is whack-a-mole, and two of them (`engine_routing_merge.go`, `engine_continuation_synthesis.go`) sit outside lane C's four files. Making the intent **branch-scoped** covers every opener without entering them. The remaining propagation sites are a follow-up slice, not a lane violation. No forbidden file was touched: `merge_gate.go` (lane A) and `internal/cli/workflow.go` (lane B) are untouched.

## Safety

`SetBranchLockReviewFanout` is a bare `UPDATE` that never creates a row, so this can neither establish nor transfer branch ownership. The default path is unchanged — a job with no intent never writes the flag, and that is held by a test.

## Tests — fail-before captured, mutants named

| test | before |
|---|---|
| `TestDelegationChildInheritsSkipNativeReviewFanout` | **FAIL** — `SkipNativeReviewFanout:false` on the child request |
| `TestEngineAdvanceImplementPersistsSkipReviewFanoutWithoutPR` | **FAIL** — `{RepoFullName:gitmoot/gitmoot Branch:task-7 Owner:lead SkipNativeReviewFanout:false}` |
| `TestEngineAdvanceImplementWithoutIntentLeavesLockUntouched` | passes before and after — guards the default |
| `TestEngineAdvanceImplementPersistsSkipReviewFanoutOntoLock` (pre-existing) | still passes — PR arm did not regress |

Bounded runs only, no full suite (#1267), `env -u GITMOOT_STALE_RUNNING_AFTER` on every line, fresh clone under `/root`:

- `go test ./internal/workflow/ -run 'Delegation|Fanout|Implement|PullRequestOpened'` → ok, 44.4s
- `go test ./internal/cli/ -run 'TestFinalize|SkipNativeReviewFanout|TestPipelineReviewBinding'` → ok
- `go build ./...` and `go vet ./internal/workflow/` clean

Reviewer must not be the implementer, and the verdict must name the exact head **and be posted to this PR** — a verdict living only in the job payload is invisible (#1193).

GMC-FANOUT