### PR TITLE
fix(workflow): the review fanout stops enlisting the implementer and is repo-aware (#1236)

### DIFF
--- a/internal/workflow/engine_fanout_roster_1236_test.go
+++ b/internal/workflow/engine_fanout_roster_1236_test.go
@@ -1,0 +1,164 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+)
+
+// #1236, the serious half: the native review fanout must never enlist the
+// agent that implemented the head as a reviewer of that head. Observed on
+// dashboard PR #137, where the fanout picked `galaxy-impl` — the seat that
+// implemented it — to review its own work. The merge gate ignores verdict
+// authorship (#1114), so a self-approval produced this way is indistinguishable
+// from a real one at the gate.
+func TestFanoutRefusesToEnlistTheImplementer(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "impl", []string{"implement", "review"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "gitmoot/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		HeadSHA:           "head123",
+		TaskID:            "task-7",
+		TaskTitle:         "Workflow Engine",
+		LeadAgent:         "impl",
+		Sender:            "impl",
+		RequiredReviewers: []string{"impl", "reviewer"},
+	})
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var reviewers []string
+	for _, job := range jobs {
+		if job.Type == "review" {
+			reviewers = append(reviewers, job.Agent)
+		}
+	}
+	for _, agent := range reviewers {
+		if agent == "impl" {
+			t.Fatalf("the implementer was enlisted to review its own head: review jobs = %v", reviewers)
+		}
+	}
+	if len(reviewers) != 1 || reviewers[0] != "reviewer" {
+		t.Fatalf("review jobs = %v, want exactly [reviewer]", reviewers)
+	}
+}
+
+// #1236, the second defect: the default reviewer roster is not repo-aware. On
+// dashboard PR #137 the roster was ["lead"], a seat scoped to gitmoot/gitmoot,
+// so the fanout could not have produced a verdict even if left alone.
+func TestFanoutDropsReviewersNotScopedToTheRepo(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "impl", []string{"implement"}, "gitmoot/gitmoot-dashboard")
+	seedAgent(t, store, "offscope", []string{"review"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "dash-reviewer", []string{"review"}, "gitmoot/gitmoot-dashboard")
+	engine := testEngine(store)
+
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "gitmoot/gitmoot-dashboard",
+		Branch:            "task-137",
+		PullRequest:       137,
+		HeadSHA:           "9ec5ceb916a9",
+		TaskID:            "task-137",
+		LeadAgent:         "impl",
+		Sender:            "impl",
+		RequiredReviewers: []string{"offscope", "dash-reviewer"},
+	})
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	var reviewers []string
+	for _, job := range jobs {
+		if job.Type == "review" {
+			reviewers = append(reviewers, job.Agent)
+		}
+	}
+	if len(reviewers) != 1 || reviewers[0] != "dash-reviewer" {
+		t.Fatalf("review jobs = %v, want exactly [dash-reviewer]", reviewers)
+	}
+}
+
+// The safety-critical consequence of filtering. HandlePullRequestOpened treats
+// an EMPTY roster as "this repo has no native review discipline" and runs the
+// MERGE GATE directly. Filtering must therefore never let a roster that WAS
+// configured collapse into that path: a PR whose every configured reviewer is
+// ineligible must fail CLOSED — no review jobs, and above all no merge gate —
+// rather than inheriting the unconfigured-repo behaviour and becoming eligible
+// to merge with no review at all.
+func TestFanoutWithNoEligibleReviewerDoesNotRunTheMergeGate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "impl", []string{"implement", "review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Merged: true}}
+	engine.MergeGate = gate
+
+	// The only configured reviewer IS the implementer, so the roster empties.
+	err := engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:              "gitmoot/gitmoot",
+		Branch:            "task-7",
+		PullRequest:       7,
+		HeadSHA:           "head123",
+		TaskID:            "task-7",
+		LeadAgent:         "impl",
+		Sender:            "impl",
+		RequiredReviewers: []string{"impl"},
+	})
+	if err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+
+	if len(gate.requests) != 0 {
+		t.Fatalf("merge gate ran for a PR with no eligible reviewer: %+v", gate.requests)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	for _, job := range jobs {
+		if job.Type == "review" {
+			t.Fatalf("expected no review jobs, found %+v", job)
+		}
+	}
+}
+
+// A repo with NO reviewers configured at all must keep its existing behaviour —
+// the merge gate runs. This is the arm the filter must not disturb.
+func TestFanoutUnconfiguredRosterStillRunsTheMergeGate(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "impl", []string{"implement"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	gate := &fakeMergeGate{decision: MergeDecision{Reason: "ci is pending"}}
+	engine.MergeGate = gate
+
+	// The gate's "ci is pending" decision blocks the task, so an error here is
+	// the expected shape; what this test asserts is that the gate RAN.
+	_ = engine.HandlePullRequestOpened(ctx, PullRequestEvent{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-7",
+		PullRequest: 7,
+		HeadSHA:     "head123",
+		TaskID:      "task-7",
+		LeadAgent:   "impl",
+		Sender:      "impl",
+	})
+	if len(gate.requests) != 1 {
+		t.Fatalf("merge gate requests = %+v, want exactly one for an unconfigured roster", gate.requests)
+	}
+}

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -37,6 +37,41 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 	if event.SkipReviewFanout {
 		return e.recordPullRequestBaseline(ctx, event)
 	}
+	// #1236: filter the roster down to agents that may actually review THIS head.
+	// Only runs when a roster was configured, so the unconfigured-repo arm below
+	// is reached exactly as before.
+	//
+	// The empty-roster arm below means "this repo has no native review
+	// discipline" and runs the MERGE GATE. A filtered roster must therefore never
+	// be allowed to collapse into it: a PR whose every configured reviewer turns
+	// out ineligible has to fail CLOSED — no reviews, and above all no merge gate
+	// — rather than inheriting unconfigured-repo behaviour and becoming eligible
+	// to merge with no review at all. That is why this returns rather than
+	// falling through.
+	if len(reviewers) > 0 {
+		eligible, dropped := e.eligibleReviewers(ctx, event.Repo, event.LeadAgent, reviewers)
+		if len(dropped) > 0 {
+			// Provenance: the fanout decision was previously silent, so the only way
+			// to notice a bad roster was to query the job table for workflow-* rows
+			// nobody dispatched (#1277, #1260).
+			_ = e.Store.AddTaskEvent(ctx, db.TaskEvent{
+				TaskID: event.TaskID,
+				Kind:   "review_fanout_roster_filtered",
+				Reason: fmt.Sprintf("pull request #%d at %s: enlisting [%s]; dropped %s",
+					event.PullRequest, event.HeadSHA, strings.Join(eligible, " "), strings.Join(dropped, "; ")),
+			})
+		}
+		if len(eligible) == 0 {
+			_ = e.Store.AddTaskEvent(ctx, db.TaskEvent{
+				TaskID: event.TaskID,
+				Kind:   "review_fanout_no_eligible_reviewer",
+				Reason: fmt.Sprintf("pull request #%d at %s: every configured reviewer was ineligible (%s); no review dispatched and the native merge gate was NOT run",
+					event.PullRequest, event.HeadSHA, strings.Join(dropped, "; ")),
+			})
+			return e.recordPullRequestBaseline(ctx, event)
+		}
+		reviewers = eligible
+	}
 	if len(reviewers) == 0 {
 		decision, err := e.runMergeGate(ctx, "", JobPayload{
 			Repo:        event.Repo,
@@ -527,6 +562,61 @@ func (e Engine) mergeGateReviewRequired(ctx context.Context, payload JobPayload)
 		}
 	}
 	return false, nil
+}
+
+// eligibleReviewers filters a configured reviewer roster down to the agents that
+// may actually review THIS head, and explains every drop so the fanout decision
+// stops being silent (#1236, #1277).
+//
+// Two filters, neither of which the fanout previously had:
+//
+//   - THE IMPLEMENTER IS NEVER A REVIEWER OF ITS OWN HEAD. event.LeadAgent
+//     identifies the implementer on both triggers — the implementing job's agent
+//     on the in-process path, the branch-lock owner on the daemon PR-watcher path
+//     — so one exclusion covers both. Reviewer identity distinct from implementer
+//     is already fleet doctrine; it belongs in the engine and not only in briefs,
+//     because the merge gate ignores verdict authorship (#1114) and a
+//     self-approval produced this way is indistinguishable from a real one.
+//   - THE ROSTER IS REPO-AWARE. The default roster is global config applied to
+//     every repo, so a seat scoped elsewhere was enlisted anyway — on dashboard
+//     PR #137 that was ["lead"], scoped to gitmoot/gitmoot. That fanout could not
+//     have produced a verdict, and worse, the off-scope reviewer BLOCKED the task
+//     at the dispatch preflight instead of being quietly skipped.
+//
+// It filters ONLY those two cases. Every other roster problem — an unsubscribed
+// name, a missing `review` capability — is left in the roster deliberately, so
+// the existing dispatch preflight still BLOCKS it exactly as before. That
+// distinction is the point: a name that resolves to nothing is a MISCONFIGURED
+// ROSTER and a human has to fix it, and silently dropping it would hide a typo
+// while quietly reducing review coverage. A reviewer that exists but is wrong
+// FOR THIS HEAD is not a misconfiguration — it is a correct global roster meeting
+// a specific PR — and that is what gets filtered.
+//
+// Note an unknown agent is indistinguishable from an off-scope one at
+// AgentCanAccessRepo (both return false, nil), so existence is checked first and
+// unknown names are KEPT for the preflight to reject.
+func (e Engine) eligibleReviewers(ctx context.Context, repo string, implementer string, reviewers []string) ([]string, []string) {
+	implementer = strings.TrimSpace(implementer)
+	eligible := make([]string, 0, len(reviewers))
+	dropped := make([]string, 0, len(reviewers))
+	for _, name := range reviewers {
+		if implementer != "" && name == implementer {
+			dropped = append(dropped, fmt.Sprintf("%s (implemented this head)", name))
+			continue
+		}
+		if _, err := e.Store.GetAgent(ctx, name); err != nil {
+			// Unknown or unreadable: keep it so the preflight blocks the task.
+			eligible = append(eligible, name)
+			continue
+		}
+		allowed, err := e.Store.AgentCanAccessRepo(ctx, name, repo)
+		if err == nil && !allowed {
+			dropped = append(dropped, fmt.Sprintf("%s (not scoped to %s)", name, repo))
+			continue
+		}
+		eligible = append(eligible, name)
+	}
+	return eligible, dropped
 }
 
 func (e Engine) recordPullRequestBaseline(ctx context.Context, event PullRequestEvent) error {


### PR DESCRIPTION
GMC-FANOUT, lane C of campaign #1300. **Draft, and stays draft** — only jarvis's five-condition checklist merges campaign PRs. Branched from `main` and independent of #1277 (PR #1348), so it stands alone.

## Two defects, one filter

The native fanout built its reviewer roster from configured names and enlisted them unconditionally.

### 1. The implementer reviewed its own head

Observed on dashboard PR #137, where the fanout picked `galaxy-impl` — the seat that implemented it. The merge gate ignores verdict authorship (#1114), so a self-approval produced this way is **indistinguishable from a real one at the gate**. And nothing prompts anyone: no human chose the reviewer, so the separate-identity rule never gets a chance to catch it.

`event.LeadAgent` identifies the implementer on **both** triggers — the implementing job's agent in-process, the branch-lock owner on the daemon PR-watcher path — so one exclusion covers both entrances.

### 2. The roster was not repo-aware

The default roster is global config applied to every repo. On PR #137 it was `["lead"]`, scoped to `gitmoot/gitmoot`, not the dashboard.

The issue says such a fanout "could not have produced a verdict". **It is worse than that**, and the fail-before proves it — an off-scope reviewer does not fail harmlessly, it **blocks the whole task** at the dispatch preflight:

```
workflow blocked: agent "offscope" is not allowed on "gitmoot/gitmoot-dashboard"
```

## The safety-critical part

This is why it isn't a two-line filter.

`HandlePullRequestOpened` treats an **empty** roster as "this repo has no native review discipline" and **runs the merge gate**. A filter that empties a roster would therefore hand the PR straight to the merge gate with no review at all — turning a review-integrity fix into a *merge*-integrity hole.

A configured roster whose every member is ineligible now **fails closed**: no reviews, no merge gate, and a recorded reason. Two tests hold both sides of that line — one that the filtered-empty case never reaches the gate, one that the genuinely-unconfigured case still does.

## What is deliberately NOT filtered

Only the two cases above. An unsubscribed name, or one missing the `review` capability, **stays in the roster** so the existing preflight blocks it exactly as before.

That distinction is the point: a name that resolves to nothing is a **misconfigured roster** and a human has to fix it — silently dropping it would hide a typo while quietly reducing review coverage. A reviewer that exists but is wrong *for this head* is not a misconfiguration.

I found this by **breaking** `TestEngineHandlePullRequestOpenedPreflightsReviewersBeforeEnqueue` on the first attempt. It is now preserved and passing.

Implementation note: an unknown agent is indistinguishable from an off-scope one at `AgentCanAccessRepo` (both return `false, nil`), so existence is checked first and unknown names are kept.

## Provenance

The fanout decision was silent — the only way to notice a bad roster was to query the job table for `workflow-*` rows nobody dispatched (#1277, #1260). It now records `review_fanout_roster_filtered` naming the PR, the head, who was enlisted and who was dropped with a reason; and `review_fanout_no_eligible_reviewer` when the roster empties.

## Tests — fail-before captured, mutants named

| test | before |
|---|---|
| `TestFanoutRefusesToEnlistTheImplementer` | **FAIL** — `review jobs = [impl reviewer]` |
| `TestFanoutDropsReviewersNotScopedToTheRepo` | **FAIL** — task blocked: `agent "offscope" is not allowed on "gitmoot/gitmoot-dashboard"` |
| `TestFanoutWithNoEligibleReviewerDoesNotRunTheMergeGate` | **FAIL** — enqueued a review job for the implementer |
| `TestFanoutUnconfiguredRosterStillRunsTheMergeGate` | guards the arm that must not change |
| `TestEngineHandlePullRequestOpenedPreflightsReviewersBeforeEnqueue` (pre-existing) | still passes |

Bounded runs only, no full suite (#1267), `env -u GITMOOT_STALE_RUNNING_AFTER` on every line, fresh clone under `/root`:

- `go test ./internal/workflow/ -run 'Review|Fanout|PullRequest|Merge'` → ok, 95.3s
- `go build ./...` clean

Reviewer must not be the implementer, and the verdict must name the exact head **and be posted to this PR** (#1193).

GMC-FANOUT