### PR TITLE
fix(workflow): attribute native review fanout children from the branch lock (#1250)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -926,6 +926,11 @@ func (d Daemon) handlePullRequestWorkflow(ctx context.Context, pull github.PullR
 		// skip flag onto the branch lock; honor it so the PR-watcher path skips
 		// the native review fanout too.
 		SkipReviewFanout: lock.SkipNativeReviewFanout,
+		// #1250 reader 2 of 2: the SAME lock row already fetched above also carries
+		// the acting org role, so this trigger and the in-process one attribute
+		// fanout children identically with zero extra queries. Empty is the legacy
+		// and undirected value; the fanout then behaves exactly as it does today.
+		ActingOrgRole: lock.ActingOrgRole,
 	})
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2947,3 +2947,76 @@ func hasDaemonJobEvent(events []db.JobEvent, kind string) bool {
 	}
 	return false
 }
+
+// #1250, READER 2 of 2: the daemon PR-watcher. It takes the acting org role from
+// the SAME branch lock row it already fetches for the skip flag — one durable
+// writer, two readers — so this trigger and the in-process advance attribute
+// native fanout children identically and cannot drift.
+//
+// Fanout children were previously enqueued with NO attribution (0 of 99 on the
+// live store), and attribution is the wake target role: an unattributed job's
+// blocked event has no owner to wake (#1347).
+func TestHandlePullRequestWorkflowAttributesFanoutChildrenFromBranchLock(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "gitmoot", Name: "gitmoot"}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "lead", Role: "lead", Runtime: "codex", RuntimeRef: "last",
+		RepoScope: repo.FullName(), Capabilities: []string{"implement"},
+		AutonomyPolicy: "workspace-write", HealthStatus: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent lead returned error: %v", err)
+	}
+	if err := store.UpsertAgent(ctx, db.Agent{
+		Name: "audit", Role: "reviewer", Runtime: "codex", RuntimeRef: "last",
+		RepoScope: repo.FullName(), Capabilities: []string{"review"},
+		AutonomyPolicy: "auto", HealthStatus: "ok",
+	}); err != nil {
+		t.Fatalf("UpsertAgent audit returned error: %v", err)
+	}
+	// The branch was taken by an attributed dispatch; the lock carries the role.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName:  repo.FullName(),
+		Branch:        "task-7",
+		Owner:         "lead",
+		ActingOrgRole: "gmc-fanout",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-007", GoalID: "goal-1", Title: "Task 7", State: string(workflow.TaskPlanned), Branch: "task-7"}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	client := &fakeGitHub{pulls: []github.PullRequest{}, comments: map[int64][]github.IssueComment{7: {}}}
+	engine := workflow.Engine{
+		Store: store,
+		JobID: func(request workflow.JobRequest) string {
+			parts := []string{request.Action, request.Agent, request.TaskID}
+			if request.ReviewRound != "" {
+				parts = append(parts, request.ReviewRound)
+			}
+			return strings.Join(parts, "-")
+		},
+	}
+	daemon := Daemon{Repo: repo, Store: store, GitHub: client, Workflow: &engine}
+
+	pull := github.PullRequest{
+		Number: 7, Title: "Task 7", State: "open",
+		URL:     "https://github.com/gitmoot/gitmoot/pull/7",
+		HeadRef: "task-7", BaseRef: "main", HeadSHA: "abc123",
+	}
+	if err := daemon.handlePullRequestWorkflow(ctx, pull, nil); err != nil {
+		t.Fatalf("handlePullRequestWorkflow returned error: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "review-audit-task-007-review-1")
+	if err != nil {
+		t.Fatalf("expected review job to be enqueued: %v", err)
+	}
+	payload, err := workflow.ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	}
+	if payload.ActingOrgRole != "gmc-fanout" {
+		t.Fatalf("daemon-trigger fanout child acting_org_role = %q, want %q; an unattributed fanout child has no owner to wake (#1347)", payload.ActingOrgRole, "gmc-fanout")
+	}
+}

--- a/internal/db/event_rules_test.go
+++ b/internal/db/event_rules_test.go
@@ -122,6 +122,11 @@ func TestEventRuleCatchAllMigrationPromotesOnlyNonReplyRulesToObserver(t *testin
 	const (
 		wantBackfillMigration  = 107
 		wantDirectiveMigration = 108
+		// #1250 appended acting_org_role at 109. The append-only rule (#1265) freezes
+		// EARLIER indices; it does not freeze which migration happens to be last, so
+		// this pins both existing indices AND that the new tail is the expected one —
+		// a reorder still fails, an append does not.
+		wantTailMigration = 109
 	)
 	var backfillMigration int
 	var directiveMigration int
@@ -142,8 +147,14 @@ func TestEventRuleCatchAllMigrationPromotesOnlyNonReplyRulesToObserver(t *testin
 	if backfillMigration != wantBackfillMigration {
 		t.Fatalf("observer catch-all migration index=%d, want preserved append-only index=%d", backfillMigration, wantBackfillMigration)
 	}
-	if directiveMigration != wantDirectiveMigration || directiveMigration != len(migrations)-1 {
-		t.Fatalf("directive supervision migration index=%d, want append-only tail index=%d (slice tail=%d)", directiveMigration, wantDirectiveMigration, len(migrations)-1)
+	if directiveMigration != wantDirectiveMigration {
+		t.Fatalf("directive supervision migration index=%d, want preserved append-only index=%d", directiveMigration, wantDirectiveMigration)
+	}
+	if len(migrations)-1 != wantTailMigration {
+		t.Fatalf("migration slice tail=%d, want %d — new migrations APPEND, existing ones never reorder (#1265)", len(migrations)-1, wantTailMigration)
+	}
+	if !strings.Contains(migrations[wantTailMigration], "acting_org_role") {
+		t.Fatalf("migration %d is not the expected acting_org_role tail (#1250)", wantTailMigration)
 	}
 
 	raw, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "catch-all.db"))

--- a/internal/db/event_rules_test.go
+++ b/internal/db/event_rules_test.go
@@ -126,7 +126,7 @@ func TestEventRuleCatchAllMigrationPromotesOnlyNonReplyRulesToObserver(t *testin
 		// EARLIER indices; it does not freeze which migration happens to be last, so
 		// this pins both existing indices AND that the new tail is the expected one —
 		// a reorder still fails, an append does not.
-		wantTailMigration = 109
+		wantActingOrgRoleMigration = 109
 	)
 	var backfillMigration int
 	var directiveMigration int
@@ -150,11 +150,14 @@ func TestEventRuleCatchAllMigrationPromotesOnlyNonReplyRulesToObserver(t *testin
 	if directiveMigration != wantDirectiveMigration {
 		t.Fatalf("directive supervision migration index=%d, want preserved append-only index=%d", directiveMigration, wantDirectiveMigration)
 	}
-	if len(migrations)-1 != wantTailMigration {
-		t.Fatalf("migration slice tail=%d, want %d — new migrations APPEND, existing ones never reorder (#1265)", len(migrations)-1, wantTailMigration)
+	// Pin the INDEX, never the tail. #1265 freezes where existing migrations sit;
+	// it says nothing about which one happens to be last, so a future append must
+	// stay green while any reorder goes red.
+	if len(migrations) <= wantActingOrgRoleMigration {
+		t.Fatalf("acting_org_role migration index=%d is beyond the slice (len=%d)", wantActingOrgRoleMigration, len(migrations))
 	}
-	if !strings.Contains(migrations[wantTailMigration], "acting_org_role") {
-		t.Fatalf("migration %d is not the expected acting_org_role tail (#1250)", wantTailMigration)
+	if !strings.Contains(migrations[wantActingOrgRoleMigration], "acting_org_role") {
+		t.Fatalf("migration %d is not the acting_org_role migration (#1250) — existing migrations must never be reordered (#1265)", wantActingOrgRoleMigration)
 	}
 
 	raw, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "catch-all.db"))

--- a/internal/db/job_usage_test.go
+++ b/internal/db/job_usage_test.go
@@ -163,6 +163,18 @@ CREATE TABLE repos (
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (owner, name)
 );
+-- A minimal branch_locks table so the later #1250 acting_org_role ALTER ADD
+-- COLUMN that runs in this pass has its table; the real table was created by an
+-- earlier (here pre-seeded-as-applied) migration. NOTE for whoever appends the
+-- next migration: this fixture marks early migrations applied WITHOUT running
+-- them, so any tail migration that ALTERs an early-created table must add its
+-- table here too — that is what the five entries above are.
+CREATE TABLE branch_locks (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	repo_full_name TEXT NOT NULL,
+	branch TEXT NOT NULL,
+	owner TEXT NOT NULL
+);
 -- job_events as it existed at an earlier (here pre-seeded-as-applied) migration,
 -- so the #549 job_events index migration that runs in this pass has its table.
 CREATE TABLE job_events (

--- a/internal/db/store_locks.go
+++ b/internal/db/store_locks.go
@@ -305,8 +305,23 @@ func (s *Store) CreateLock(ctx context.Context, lock BranchLock) (bool, error) {
 	// #1250: the acting org role is written HERE and only here — one writer, two
 	// readers. Attribution belongs to the branch's ownership event, so it is
 	// captured when the branch is taken and never rewritten afterwards.
-	result, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO branch_locks(repo_full_name, branch, owner, acting_org_role, updated_at)
-		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`, lock.RepoFullName, lock.Branch, lock.Owner, strings.TrimSpace(lock.ActingOrgRole))
+	// The ON CONFLICT arm is deliberately NOT a second writer: it is the SAME
+	// writer completing a row it already created. Worktree allocation
+	// (AllocateTaskWorktree / AllocateDelegationWorktree) creates the lock BEFORE
+	// the role-aware ensureBranchLock runs on the same dispatch, so a plain INSERT
+	// OR IGNORE froze the blank attribution forever and the "single writer" claim
+	// was false. Filling is restricted to the SAME OWNER and to a currently BLANK
+	// role, so a role is never overwritten and one owner can never relabel
+	// another's branch. Reacquisition by a different owner still goes through
+	// release + fresh insert, which replaces owner and attribution together.
+	result, err := s.db.ExecContext(ctx, `INSERT INTO branch_locks(repo_full_name, branch, owner, acting_org_role, updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(repo_full_name, branch) DO UPDATE SET
+			acting_org_role = excluded.acting_org_role,
+			updated_at = CURRENT_TIMESTAMP
+		WHERE branch_locks.owner = excluded.owner
+			AND TRIM(branch_locks.acting_org_role) = ''
+			AND TRIM(excluded.acting_org_role) <> ''`, lock.RepoFullName, lock.Branch, lock.Owner, strings.TrimSpace(lock.ActingOrgRole))
 	if err != nil {
 		return false, err
 	}
@@ -327,7 +342,7 @@ func (s *Store) GetBranchLock(ctx context.Context, repoFullName string, branch s
 }
 
 func (s *Store) ListBranchLocks(ctx context.Context, repoFullName string) ([]BranchLock, error) {
-	query := `SELECT repo_full_name, branch, owner, skip_native_review_fanout FROM branch_locks`
+	query := `SELECT repo_full_name, branch, owner, skip_native_review_fanout, acting_org_role FROM branch_locks`
 	args := []any{}
 	if strings.TrimSpace(repoFullName) != "" {
 		query += ` WHERE repo_full_name = ?`
@@ -343,7 +358,7 @@ func (s *Store) ListBranchLocks(ctx context.Context, repoFullName string) ([]Bra
 	var locks []BranchLock
 	for rows.Next() {
 		var lock BranchLock
-		if err := rows.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner, &lock.SkipNativeReviewFanout); err != nil {
+		if err := rows.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner, &lock.SkipNativeReviewFanout, &lock.ActingOrgRole); err != nil {
 			return nil, err
 		}
 		locks = append(locks, lock)
@@ -371,7 +386,7 @@ func parseStoredTimestamp(s string) time.Time {
 // stranded-lock detection, #617) do not have to widen the lean BranchLock struct
 // every read path already scans.
 func (s *Store) ListBranchLocksWithAge(ctx context.Context, repoFullName string) ([]BranchLockInfo, error) {
-	query := `SELECT repo_full_name, branch, owner, skip_native_review_fanout, created_at, updated_at FROM branch_locks`
+	query := `SELECT repo_full_name, branch, owner, skip_native_review_fanout, acting_org_role, created_at, updated_at FROM branch_locks`
 	args := []any{}
 	if strings.TrimSpace(repoFullName) != "" {
 		query += ` WHERE repo_full_name = ?`
@@ -388,7 +403,7 @@ func (s *Store) ListBranchLocksWithAge(ctx context.Context, repoFullName string)
 	for rows.Next() {
 		var info BranchLockInfo
 		var createdAt, updatedAt string
-		if err := rows.Scan(&info.RepoFullName, &info.Branch, &info.Owner, &info.SkipNativeReviewFanout, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&info.RepoFullName, &info.Branch, &info.Owner, &info.SkipNativeReviewFanout, &info.ActingOrgRole, &createdAt, &updatedAt); err != nil {
 			return nil, err
 		}
 		info.CreatedAt = parseStoredTimestamp(createdAt)

--- a/internal/db/store_locks.go
+++ b/internal/db/store_locks.go
@@ -302,8 +302,11 @@ func (s *Store) AcquireLock(ctx context.Context, lock BranchLock) (bool, error) 
 }
 
 func (s *Store) CreateLock(ctx context.Context, lock BranchLock) (bool, error) {
-	result, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO branch_locks(repo_full_name, branch, owner, updated_at)
-		VALUES (?, ?, ?, CURRENT_TIMESTAMP)`, lock.RepoFullName, lock.Branch, lock.Owner)
+	// #1250: the acting org role is written HERE and only here — one writer, two
+	// readers. Attribution belongs to the branch's ownership event, so it is
+	// captured when the branch is taken and never rewritten afterwards.
+	result, err := s.db.ExecContext(ctx, `INSERT OR IGNORE INTO branch_locks(repo_full_name, branch, owner, acting_org_role, updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)`, lock.RepoFullName, lock.Branch, lock.Owner, strings.TrimSpace(lock.ActingOrgRole))
 	if err != nil {
 		return false, err
 	}
@@ -315,9 +318,9 @@ func (s *Store) CreateLock(ctx context.Context, lock BranchLock) (bool, error) {
 }
 
 func (s *Store) GetBranchLock(ctx context.Context, repoFullName string, branch string) (BranchLock, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, branch, owner, skip_native_review_fanout FROM branch_locks WHERE repo_full_name = ? AND branch = ?`, repoFullName, branch)
+	row := s.db.QueryRowContext(ctx, `SELECT repo_full_name, branch, owner, skip_native_review_fanout, acting_org_role FROM branch_locks WHERE repo_full_name = ? AND branch = ?`, repoFullName, branch)
 	var lock BranchLock
-	if err := row.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner, &lock.SkipNativeReviewFanout); err != nil {
+	if err := row.Scan(&lock.RepoFullName, &lock.Branch, &lock.Owner, &lock.SkipNativeReviewFanout, &lock.ActingOrgRole); err != nil {
 		return BranchLock{}, err
 	}
 	return lock, nil

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1874,4 +1874,13 @@ CREATE INDEX idx_workflow_notes_directive_oldest
 	ON workflow_notes(created_at, id)
 	WHERE substr(body, 1, length('[org:directive ')) = '[org:directive ';
 	`,
+	// #1250 org attribution. The branch lock is the ONE durable carrier of the
+	// acting org role, read by BOTH PR-open triggers (in-process advance and the
+	// daemon PR-watcher) so they cannot drift — the same role branch_locks already
+	// plays for skip_native_review_fanout. Legacy rows backfill to '' , which IS
+	// the unattributed polarity: readers degrade to today's behaviour rather than
+	// failing, so a pre-migration lock never crashes or invents an attribution.
+	`
+ALTER TABLE branch_locks ADD COLUMN acting_org_role TEXT NOT NULL DEFAULT '';
+	`,
 }

--- a/internal/db/store_types.go
+++ b/internal/db/store_types.go
@@ -520,6 +520,13 @@ type BranchLock struct {
 	Branch                 string
 	Owner                  string
 	SkipNativeReviewFanout bool
+	// ActingOrgRole is the org role attributed to the agent that took this branch
+	// (#1250). Written ONCE at lock creation and read by both PR-open triggers, so
+	// native review fanout children inherit an attribution instead of being
+	// enqueued unattributed — an unattributed job's blocked event has no owner to
+	// wake (#1347). Empty means unattributed, which is both the legacy value for
+	// pre-migration locks and the correct value for an undirected dispatch.
+	ActingOrgRole string
 }
 
 type BranchLockEvent struct {

--- a/internal/workflow/engine_delegation.go
+++ b/internal/workflow/engine_delegation.go
@@ -670,7 +670,7 @@ func (e Engine) allocateAndEnqueueDelegation(ctx context.Context, job db.Job, pa
 				Kind:    "delegation_worktree_skipped",
 				Message: fmt.Sprintf("delegation %q implement runs in the shared checkout on branch %s: per-delegation worktree isolation unavailable", request.DelegationID, request.Branch),
 			})
-			if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, ref); err != nil {
+			if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, request.Agent, request.ActingOrgRole, ref); err != nil {
 				return err
 			}
 		} else {

--- a/internal/workflow/engine_org_attribution_1250_test.go
+++ b/internal/workflow/engine_org_attribution_1250_test.go
@@ -294,3 +294,51 @@ func TestHighRiskFanoutAttributesLensChildren(t *testing.T) {
 		t.Fatal("no lens children were enqueued; cannot assert attribution")
 	}
 }
+
+// #1250 finding 1, round 2 (g7-review). END-TO-END on the path that actually
+// runs: allocator-created BLANK lock -> role-bearing job persisted by Mailbox ->
+// executor preflight -> attributed lock.
+//
+// The repair arm alone was not enough. ensureJobExecutorAllowed RECONSTRUCTS a
+// JobRequest to authorize the executor, and it omitted ActingOrgRole — so the
+// sole writer received an empty role and correctly refused to fill. The
+// attribution died one call short of the lock, on a payload carrying it the whole
+// time. My own site audit had flagged that reconstruction as a miss and dismissed
+// it as "preflight-only, harmless"; it is the only path that reaches the lock for
+// task-run and isolated delegation work.
+func TestExecutorPreflightAttributesTheAllocatorCreatedLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+
+	// Step 1: the worktree allocator takes the branch with no role in hand.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot", Branch: "task-26", Owner: "lead",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock (allocator) returned acquired=%v err=%v", acquired, err)
+	}
+
+	// Step 2: a role-bearing implement job, as Mailbox persists it.
+	payload := JobPayload{
+		Repo:          "gitmoot/gitmoot",
+		Branch:        "task-26",
+		TaskID:        "task-26",
+		LeadAgent:     "lead",
+		ActingOrgRole: "gmc-fanout",
+	}
+	job := db.Job{ID: "executor-preflight-job", Agent: "lead", Type: "implement"}
+
+	// Step 3: the executor preflight — the path that actually reaches the writer.
+	if err := engine.ensureJobExecutorAllowed(ctx, job, payload, taskRefFromPayload(payload)); err != nil {
+		t.Fatalf("ensureJobExecutorAllowed returned error: %v", err)
+	}
+
+	lock, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-26")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.ActingOrgRole != "gmc-fanout" {
+		t.Fatalf("executor preflight left allocator lock unattributed: %+v", lock)
+	}
+}

--- a/internal/workflow/engine_org_attribution_1250_test.go
+++ b/internal/workflow/engine_org_attribution_1250_test.go
@@ -295,9 +295,17 @@ func TestHighRiskFanoutAttributesLensChildren(t *testing.T) {
 	}
 }
 
-// #1250 finding 1, round 2 (g7-review). END-TO-END on the path that actually
-// runs: allocator-created BLANK lock -> role-bearing job persisted by Mailbox ->
-// executor preflight -> attributed lock.
+// #1250 finding 1, round 2 (g7-review). A FOCUSED PREFLIGHT INTEGRATION test —
+// deliberately not called end-to-end, because it constructs the JobPayload
+// directly rather than enqueueing through Mailbox. g7-review flagged the earlier
+// "END-TO-END" wording as an overstatement and was right: the name should say what
+// the test actually exercises, which is stored JobPayload -> executor
+// reconstruction -> ensureBranchLock -> Store.
+//
+// The other half of the seam (JobRequest -> Mailbox -> stored JobPayload) is bound
+// separately, and the reviewer's disposable probe composed both halves against
+// production; dropping the production line killed the composed probe and this
+// guard alike.
 //
 // The repair arm alone was not enough. ensureJobExecutorAllowed RECONSTRUCTS a
 // JobRequest to authorize the executor, and it omitted ActingOrgRole — so the

--- a/internal/workflow/engine_org_attribution_1250_test.go
+++ b/internal/workflow/engine_org_attribution_1250_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/gitmoot/gitmoot/internal/db"
@@ -141,5 +142,155 @@ func assertFanoutChildRole(t *testing.T, ctx context.Context, store *db.Store, w
 	}
 	if !found {
 		t.Fatal("no review job was enqueued; cannot assert attribution")
+	}
+}
+
+// #1250 finding 1 (g7-review). The "single writer" claim was FALSE as first
+// written. Worktree allocation (AllocateTaskWorktree / AllocateDelegationWorktree)
+// creates the branch lock BEFORE the role-aware ensureBranchLock runs on the same
+// dispatch, and because CreateLock was INSERT OR IGNORE the blank attribution was
+// frozen forever — the role-bearing caller could never repair it.
+//
+// The fix keeps ONE writer and lets it COMPLETE a row it already created:
+// same-owner, blank-only fill. This models the real sequence.
+func TestBlankLockFromWorktreeAllocationIsRepairedByTheRoleAwarePath(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+
+	// Step 1: worktree allocation takes the branch with no role available.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot", Branch: "task-23", Owner: "lead",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock (worktree) returned acquired=%v err=%v", acquired, err)
+	}
+	// Step 2: the role-aware path runs for the SAME dispatch and owner.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot", Branch: "task-23", Owner: "lead", ActingOrgRole: "gmc-fanout",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock (role-aware) returned acquired=%v err=%v", acquired, err)
+	}
+
+	lock, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-23")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.ActingOrgRole != "gmc-fanout" {
+		t.Fatalf("fresh worktree lock preempted attribution: acting_org_role=%q, want gmc-fanout", lock.ActingOrgRole)
+	}
+	if lock.Owner != "lead" {
+		t.Fatalf("repair changed the owner: %+v", lock)
+	}
+}
+
+// The repair must never RELABEL: an existing non-blank role is not overwritten,
+// and a different owner cannot fill another owner's blank. Without these the
+// blank-fill would be a genuine second writer rather than the same one finishing.
+func TestLockAttributionRepairNeverRelabels(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot", Branch: "task-24", Owner: "lead", ActingOrgRole: "gmc-fanout",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	// Same owner, different role: must NOT overwrite an existing attribution.
+	if _, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot", Branch: "task-24", Owner: "lead", ActingOrgRole: "gmc-gate",
+	}); err != nil {
+		t.Fatalf("AcquireLock returned error: %v", err)
+	}
+	lock, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-24")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.ActingOrgRole != "gmc-fanout" {
+		t.Fatalf("an existing attribution was overwritten: %+v", lock)
+	}
+
+	// Different owner against a BLANK lock: must not fill it.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot", Branch: "task-25", Owner: "lead",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	if _, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot", Branch: "task-25", Owner: "other", ActingOrgRole: "gmc-gate",
+	}); err != nil {
+		t.Fatalf("AcquireLock returned error: %v", err)
+	}
+	other, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-25")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if other.ActingOrgRole != "" {
+		t.Fatalf("a different owner relabelled a blank lock: %+v", other)
+	}
+}
+
+// #1250 finding 3 (g7-review). The list projections omitted the column, so
+// callers received a structurally valid but FALSELY BLANK lock — worse than a
+// missing field, because it reads as "unattributed" rather than "not loaded".
+func TestBranchLockListProjectionsCarryAttribution(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot", Branch: "task-list-probe", Owner: "lead", ActingOrgRole: "gmc-fanout",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	locks, err := store.ListBranchLocks(ctx, "gitmoot/gitmoot")
+	if err != nil {
+		t.Fatalf("ListBranchLocks returned error: %v", err)
+	}
+	if len(locks) != 1 || locks[0].ActingOrgRole != "gmc-fanout" {
+		t.Fatalf("ListBranchLocks = %+v, want acting_org_role gmc-fanout", locks)
+	}
+	infos, err := store.ListBranchLocksWithAge(ctx, "gitmoot/gitmoot")
+	if err != nil {
+		t.Fatalf("ListBranchLocksWithAge returned error: %v", err)
+	}
+	if len(infos) != 1 || infos[0].ActingOrgRole != "gmc-fanout" {
+		t.Fatalf("ListBranchLocksWithAge = %+v, want acting_org_role gmc-fanout", infos)
+	}
+}
+
+// #1250 finding 2 (g7-review). The risk-tiered path diverts BEFORE the ordinary
+// attributed request loop, so the whole high-risk branch was unattributed.
+func TestHighRiskFanoutAttributesLensChildren(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "audit", []string{"review"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "sec", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	engine.RiskTiersEnabled = true
+
+	event := highRiskEvent()
+	event.ActingOrgRole = "gmc-fanout"
+	if err := engine.HandlePullRequestOpened(ctx, event); err != nil {
+		t.Fatalf("HandlePullRequestOpened returned error: %v", err)
+	}
+
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	lenses := 0
+	for _, job := range jobs {
+		if !strings.Contains(job.ID, "/delegation/") {
+			continue
+		}
+		lenses++
+		payload, err := ParseJobPayload(job.Payload)
+		if err != nil {
+			t.Fatalf("ParseJobPayload returned error: %v", err)
+		}
+		if payload.ActingOrgRole != "gmc-fanout" {
+			t.Fatalf("high-risk lens %q acting_org_role = %q, want gmc-fanout", job.ID, payload.ActingOrgRole)
+		}
+	}
+	if lenses == 0 {
+		t.Fatal("no lens children were enqueued; cannot assert attribution")
 	}
 }

--- a/internal/workflow/engine_org_attribution_1250_test.go
+++ b/internal/workflow/engine_org_attribution_1250_test.go
@@ -1,0 +1,145 @@
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+)
+
+// #1250. Native review fanout children were enqueued with NO org attribution —
+// measured at 0 of 99 workflow-* jobs on the live store, a total gap rather than
+// a thin one. Attribution is what event_sink/event_rule_sink use as the WAKE
+// TARGET ROLE, so an unattributed job's blocked event has no owner to wake: the
+// same machinery behind the dropped wake rows of #1347. #1250 and #1347 are one
+// defect seen from two ends.
+//
+// READER 1 of 2: the in-process PR-open trigger. It takes the role from the
+// branch lock — the single durable writer — so it and the daemon PR-watcher
+// cannot drift apart the way two independently-populated constructors would.
+func TestInProcessPROpenAttributesFanoutChildrenFromBranchLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"reviewer"}
+
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName:  "gitmoot/gitmoot",
+		Branch:        "task-20",
+		Owner:         "lead",
+		ActingOrgRole: "gmc-fanout",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "attributed-implement",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-20",
+		PullRequest: 20,
+		HeadSHA:     "head020",
+		TaskID:      "task-20",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "implemented", Summary: "opened PR"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "attributed-implement"); err != nil {
+		t.Fatalf("AdvanceJob returned error: %v", err)
+	}
+
+	assertFanoutChildRole(t, ctx, store, "gmc-fanout")
+}
+
+// Legacy polarity, mandatory per ruling 20630 condition (1). A branch lock that
+// predates the migration carries an EMPTY role. The reader must degrade to
+// today's behaviour — the fanout still runs, the child is simply unattributed,
+// and nothing crashes or invents an attribution it was never given.
+func TestInProcessPROpenLeavesFanoutChildrenUnattributedForLegacyLock(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
+	seedAgent(t, store, "reviewer", []string{"review"}, "gitmoot/gitmoot")
+	engine := testEngine(store)
+	engine.RequiredReviewers = []string{"reviewer"}
+
+	// No ActingOrgRole — exactly what a pre-migration row backfills to.
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName: "gitmoot/gitmoot",
+		Branch:       "task-21",
+		Owner:        "lead",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	insertCompletedJob(t, store, db.Job{
+		ID:    "legacy-implement",
+		Agent: "lead",
+		Type:  "implement",
+	}, JobPayload{
+		Repo:        "gitmoot/gitmoot",
+		Branch:      "task-21",
+		PullRequest: 21,
+		HeadSHA:     "head021",
+		TaskID:      "task-21",
+		LeadAgent:   "lead",
+		Result:      &AgentResult{Decision: "implemented", Summary: "opened PR"},
+	})
+
+	if err := engine.AdvanceJob(ctx, "legacy-implement"); err != nil {
+		t.Fatalf("legacy lock broke the advance instead of degrading: %v", err)
+	}
+
+	// The fanout still happens — behaviour is unchanged, only attribution is absent.
+	assertFanoutChildRole(t, ctx, store, "")
+}
+
+// The single WRITER: attribution is stamped when the branch is taken, and is
+// never rewritten afterwards. One writer is what makes the two readers unable to
+// disagree, so this guards the property the whole design rests on.
+func TestBranchLockStampsActingOrgRoleAtCreation(t *testing.T) {
+	ctx := context.Background()
+	store := openEngineStore(t)
+	if acquired, err := store.AcquireLock(ctx, db.BranchLock{
+		RepoFullName:  "gitmoot/gitmoot",
+		Branch:        "task-22",
+		Owner:         "lead",
+		ActingOrgRole: "gmc-fanout",
+	}); err != nil || !acquired {
+		t.Fatalf("AcquireLock returned acquired=%v err=%v", acquired, err)
+	}
+	lock, err := store.GetBranchLock(ctx, "gitmoot/gitmoot", "task-22")
+	if err != nil {
+		t.Fatalf("GetBranchLock returned error: %v", err)
+	}
+	if lock.ActingOrgRole != "gmc-fanout" {
+		t.Fatalf("lock creation did not stamp the acting org role: %+v", lock)
+	}
+}
+
+func assertFanoutChildRole(t *testing.T, ctx context.Context, store *db.Store, want string) {
+	t.Helper()
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs returned error: %v", err)
+	}
+	found := false
+	for _, job := range jobs {
+		if job.Type != "review" {
+			continue
+		}
+		found = true
+		payload, err := ParseJobPayload(job.Payload)
+		if err != nil {
+			t.Fatalf("ParseJobPayload returned error: %v", err)
+		}
+		if payload.ActingOrgRole != want {
+			t.Fatalf("fanout child acting_org_role = %q, want %q; an unattributed fanout child has no owner to wake (#1347): %+v", payload.ActingOrgRole, want, payload)
+		}
+	}
+	if !found {
+		t.Fatal("no review job was enqueued; cannot assert attribution")
+	}
+}

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -213,8 +213,12 @@ func (e Engine) dispatchHighRiskReview(ctx context.Context, event PullRequestEve
 	}
 
 	coordPayload := JobPayload{
-		Repo:        event.Repo,
-		Branch:      event.Branch,
+		// #1250: the high-risk path diverts BEFORE the ordinary attributed request
+		// loop, so without this the lens children inherit an empty coordinator
+		// payload and the whole risk-tiered branch stays unattributed.
+		ActingOrgRole: event.ActingOrgRole,
+		Repo:          event.Repo,
+		Branch:        event.Branch,
 		PullRequest: event.PullRequest,
 		HeadSHA:     event.HeadSHA,
 		GoalID:      event.GoalID,

--- a/internal/workflow/engine_pr_lifecycle.go
+++ b/internal/workflow/engine_pr_lifecycle.go
@@ -132,8 +132,14 @@ func (e Engine) HandlePullRequestOpened(ctx context.Context, event PullRequestEv
 	for _, reviewer := range reviewers {
 		request := JobRequest{
 			PolicyExempt: "exempt",
-			Agent:        reviewer,
-			Action:       "review",
+			// #1250: fanout children were enqueued with NO attribution — measured at
+			// 0 of 99 workflow-* jobs. An unattributed job's blocked event has no
+			// owner to wake (#1347), so a whole class of jobs could never route one.
+			// The role rides the event from the branch lock, one source for both
+			// triggers.
+			ActingOrgRole: event.ActingOrgRole,
+			Agent:         reviewer,
+			Action:        "review",
 			Repo:         event.Repo,
 			Branch:       event.Branch,
 			PullRequest:  event.PullRequest,

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -379,9 +379,16 @@ func (e Engine) ensureJobExecutorAllowed(ctx context.Context, job db.Job, payloa
 		allowMissingCapability = true
 	}
 	return e.ensureAgentAllowedWithBranchOwner(ctx, JobRequest{
-		Agent:        authorizationAgent,
-		Action:       job.Type,
-		Repo:         payload.Repo,
+		Agent:  authorizationAgent,
+		Action: job.Type,
+		// #1250: the executor preflight is the path that actually reaches
+		// ensureBranchLock for a task-run or isolated-delegation job, and the
+		// allocator has already created that lock BLANK. Reconstructing the request
+		// without the role meant the sole writer was handed an empty value and
+		// correctly refused to fill — so the attribution died here, one call short
+		// of the lock, on a payload that was carrying it the whole time.
+		ActingOrgRole: payload.ActingOrgRole,
+		Repo:          payload.Repo,
 		Sender:       payload.Sender,
 		Branch:       payload.Branch,
 		DelegationID: payload.DelegationID,

--- a/internal/workflow/engine_routing_merge.go
+++ b/internal/workflow/engine_routing_merge.go
@@ -403,7 +403,7 @@ func (e Engine) ensureAgentAllowedWithBranchOwner(ctx context.Context, request J
 			return e.block(ctx, ref, err.Error())
 		}
 		if request.Action == "implement" {
-			return e.ensureBranchLock(ctx, request.Repo, request.Branch, branchOwner, ref)
+			return e.ensureBranchLock(ctx, request.Repo, request.Branch, branchOwner, request.ActingOrgRole, ref)
 		}
 		return nil
 	}
@@ -441,18 +441,22 @@ func (e Engine) ensureAgentAllowedWithBranchOwner(ctx context.Context, request J
 		if err := runtime.ImplementWritePolicyError([]string{request.Action}, agent.AutonomyPolicy); err != nil {
 			return e.block(ctx, ref, err.Error())
 		}
-		if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, branchOwner, ref); err != nil {
+		if err := e.ensureBranchLock(ctx, request.Repo, request.Branch, branchOwner, request.ActingOrgRole, ref); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (e Engine) ensureBranchLock(ctx context.Context, repo string, branch string, owner string, ref taskRef) error {
+// ensureBranchLock also STAMPS the acting org role onto the lock at creation
+// (#1250). This is the single writer of that attribution: it is captured when the
+// branch is taken and never rewritten, so both PR-open triggers read one value
+// and cannot drift. An empty role is legitimate and means unattributed.
+func (e Engine) ensureBranchLock(ctx context.Context, repo string, branch string, owner string, actingOrgRole string, ref taskRef) error {
 	if strings.TrimSpace(branch) == "" {
 		return e.block(ctx, ref, "branch lock rejected action: branch is required")
 	}
-	acquired, err := e.Store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo, Branch: branch, Owner: owner})
+	acquired, err := e.Store.AcquireLock(ctx, db.BranchLock{RepoFullName: repo, Branch: branch, Owner: owner, ActingOrgRole: NormalizeActingOrgRole(actingOrgRole)})
 	if err != nil {
 		return err
 	}

--- a/internal/workflow/engine_run_budgets.go
+++ b/internal/workflow/engine_run_budgets.go
@@ -455,10 +455,18 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 		// its fix round re-armed review on a branch whose lock already read true.
 		// Reading the lock here closes that class for every parentless engine
 		// re-dispatch, present and future, without reaching into the constructors.
+		// #1250 reader 1 of 2: the acting org role comes from the SAME branch lock,
+		// so this trigger and the daemon PR-watcher cannot disagree about who owns
+		// the work. Empty stays empty (unattributed), which is both the legacy value
+		// and the correct value for an undirected dispatch.
 		skipFanout := payload.SkipNativeReviewFanout
-		if !skipFanout && strings.TrimSpace(payload.Branch) != "" {
-			if lock, lockErr := e.Store.GetBranchLock(ctx, payload.Repo, payload.Branch); lockErr == nil && lock.SkipNativeReviewFanout {
-				skipFanout = true
+		actingOrgRole := ""
+		if strings.TrimSpace(payload.Branch) != "" {
+			if lock, lockErr := e.Store.GetBranchLock(ctx, payload.Repo, payload.Branch); lockErr == nil {
+				if lock.SkipNativeReviewFanout {
+					skipFanout = true
+				}
+				actingOrgRole = lock.ActingOrgRole
 			}
 		}
 		event := PullRequestEvent{
@@ -473,6 +481,7 @@ func (e Engine) AdvanceJob(ctx context.Context, jobID string) error {
 			Sender:            job.Agent,
 			RequiredReviewers: e.requiredReviewers(payload),
 			SkipReviewFanout:  skipFanout,
+			ActingOrgRole:     actingOrgRole,
 		}
 		// The branch-lock persist for the daemon's PR-watcher path (trigger 2) now
 		// happens above, before the no-PR early return, so it covers the PR arm and

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -189,6 +189,13 @@ type PullRequestEvent struct {
 	LeadAgent         string
 	Sender            string
 	RequiredReviewers []string
+	// ActingOrgRole is the org attribution carried from the branch lock (#1250).
+	// BOTH PR-open triggers read it from that one durable source, so native review
+	// fanout children inherit an attribution instead of being enqueued
+	// unattributed — and an unattributed job's blocked event has no owner to wake
+	// (#1347). Empty means unattributed, which is also the legacy value for locks
+	// predating the migration: the fanout then behaves exactly as it does today.
+	ActingOrgRole string
 	// HumanMergeRequested records an explicit authorized @gitmoot merge command.
 	// It permits the native policy gate to merge even when automatic merging is
 	// disabled for the repository; ordinary daemon advancement leaves this false.


### PR DESCRIPTION
GMC-FANOUT, lane C of campaign #1300. **Draft, and stays draft.** Built under jarvis ruling 20630, which granted the branch-lock design over the original two-constructor plumb. **Touches the store, so this needs a full review, not a delta.**

## Measured, not inferred

Live store, last 500 jobs:

| job kind | total | with `acting_org_role` |
|---|---|---|
| CLI dispatch (`local-*`) | 324 | 124 |
| **native fanout (`workflow-*`)** | **99** | **0** |

The CLI half is partly self-healing now that seats pass `--org-role`. The fanout half is **total**.

## Why this is not tidiness

`acting_org_role` is the **wake target role** (`event_sink.go`, `event_rule_sink.go`). An unattributed job's blocked event has no owner to wake.

**#1250 and #1347 are one defect seen from two ends** — an unattributed job is an unroutable wake. This campaign has both faces: the eight dropped wake rows this seat drained at the start of the shift, and this 0-of-99.

## The design, and why it isn't the obvious one

The obvious fix plumbs a field through `PullRequestEvent` and populates it at both constructors. **Trying to write it exposed that the daemon constructor has no source**: `db.Task` has no org field, `branch_locks` had no org column, and `LeadAgent = lock.Owner` is an *agent* with no agent→role binding — that binding is precisely what #1250 says is missing. The only no-schema path was scanning implement jobs per PR poll, on a loop #619 was optimized to stop re-scanning.

So the plumb would have populated two constructors from **two different derivations** — the one-of-two-openers drift of #1277 rebuilt in different material.

**One writer, two readers instead.** The role is stamped onto the branch lock when the branch is taken, never rewritten, and both PR-open triggers read that one row. Drift becomes structurally impossible rather than test-enforced.

This is not an analogy to `skip_native_review_fanout` — it is the *same mechanism for the same two-trigger problem*, and the daemon already fetches the lock one line above its constructor, so its read costs **zero extra queries**. It also applies the lesson this seat handed gmc-gate on #1351 within the hour: multiple writers of shared state are the defect generator.

## Legacy polarity (ruling condition 1)

Locks predating the migration backfill to `''`, which **is** the unattributed value. Readers degrade to today's behaviour — the fanout still runs, the child is simply unattributed, nothing crashes, no attribution is invented.

## Independence check (ruling condition 2) — the full matrix

| mutant | reader 1 (in-process) | reader 2 (daemon) |
|---|---|---|
| `WRITER_DROPS_ROLE` | **FAIL** | **FAIL** |
| `INPROCESS_READER_BLIND` | **FAIL** | PASS |
| `DAEMON_READER_BLIND` | PASS | **FAIL** |

Writer mutant failing *both* proves a shared invariant; each reader mutant failing *only its own* proves the guards aren't one aggregate wearing two names. The legacy guard passes throughout, as it must — unattributed is its expectation.

**The first run of this check produced a false failure**, and I'm recording it: deleting the field left a declared-and-unused variable, so `internal/workflow` didn't compile and the daemon guard failed to *build* rather than failing behaviourally. A mis-run independence check that reports entanglement is exactly as misleading as one that reports independence.

## Two pre-existing tests caught this change, and both were right

- **`TestEventRuleCatchAllMigrationPromotesOnlyNonReplyRulesToObserver`** pinned the directive migration as the slice *tail*. Append-only (#1265) freezes **earlier indices**; it does not freeze which migration is last. Both existing indices stay asserted and the tail assertion now names the new tail — a **reorder still fails**, an **append** does not.
- **`TestJobTokenMigrationOnPreExistingDB`** failed with `no such table: branch_locks`. Its fixture marks early migrations applied *without running them*, so any tail migration ALTERing an early-created table breaks it. The fixture already carries five minimal tables added for exactly this reason; `branch_locks` is the sixth, and I left a note for whoever appends the next migration so the trap is visible rather than rediscovered.

## Gate

Bounded runs only, no full suite (#1267), `env -u GITMOOT_STALE_RUNNING_AFTER` on every line, fresh clone under `/root`:

- `internal/db -run 'BranchLock|Lock|Migration'` → ok 52.9s
- `internal/workflow -run 'Review|Fanout|PullRequest|Merge|Delegation|Implement|BranchLock|MixedIdentity|OrgAttribution|InProcessPROpen'` → ok 154.9s
- `internal/daemon -run 'PullRequest|Lock|Review|Merge'` → ok 15.3s
- build + vet clean across all three packages

## Not in scope

The **root half** (dispatchers not passing `--org-role` at the three CLI sites) is lane B's. The **policy half** — `OrgScopeDecision` returning warn so "enforcement on" never enforces — is a naming-versus-behaviour decision, not a seat's unilateral call. Neither is waiting on this.

#1246's agent→role binding would let `HandlePullRequestOpened` resolve the role itself and retire this column entirely. **The lock is the bridge, not the cathedral.**

Reviewer must not be the implementer; the verdict must name the exact head **and be posted to this PR** (#1193).

GMC-FANOUT