### PR TITLE
Gitmoot: CAMPAIGN 1308 SLICE D — PROCESS-GROUP KILL +

### DIFF
--- a/internal/cli/daemon_liveness.go
+++ b/internal/cli/daemon_liveness.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -37,17 +39,21 @@ type livenessLogSample struct {
 // daemonLivenessSweep retains one prior transcript observation per candidate.
 // A single stat can never turn temporary silence into a terminal verdict.
 type daemonLivenessSweep struct {
-	mu      sync.Mutex
-	samples map[string]livenessLogSample
-	stat    func(string) (os.FileInfo, error)
-	probe   func(int, string) runtimePIDState
+	mu       sync.Mutex
+	samples  map[string]livenessLogSample
+	stat     func(string) (os.FileInfo, error)
+	probe    func(int, string) runtimePIDState
+	identity func(int) string
+	signal   func(int, syscall.Signal) error
 }
 
 func newDaemonLivenessSweep() *daemonLivenessSweep {
 	return &daemonLivenessSweep{
-		samples: make(map[string]livenessLogSample),
-		stat:    os.Stat,
-		probe:   probeRuntimePID,
+		samples:  make(map[string]livenessLogSample),
+		stat:     os.Stat,
+		probe:    probeRuntimePID,
+		identity: workflow.RuntimeProcessIdentity,
+		signal:   syscall.Kill,
 	}
 }
 
@@ -72,7 +78,29 @@ func probeRuntimePID(pid int, recordedIdentity string) runtimePIDState {
 	if current != strings.TrimSpace(recordedIdentity) {
 		return runtimePIDIdentityMismatch
 	}
+	// A zombie still answers kill(0), but it cannot produce work. Its /proc
+	// identity remains available until reaped, which lets the liveness verdict
+	// safely kill any surviving members of its recorded process group.
+	if runtimeProcessState(pid) == "Z" {
+		return runtimePIDDead
+	}
 	return runtimePIDLive
+}
+
+func runtimeProcessState(pid int) string {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return ""
+	}
+	closeParen := strings.LastIndexByte(string(data), ')')
+	if closeParen < 0 {
+		return ""
+	}
+	fields := strings.Fields(string(data[closeParen+1:]))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 func configuredDaemonQuietKillAfter(home string, stdout io.Writer) time.Duration {
@@ -145,7 +173,7 @@ func (s *daemonLivenessSweep) evaluate(ctx context.Context, store *db.Store, std
 				_ = store.AddJobEvent(ctx, db.JobEvent{
 					JobID: job.ID,
 					Kind:  "job_liveness_identity_mismatch",
-					Message: fmt.Sprintf("identity mismatch: runtime pid %d no longer has recorded starttime %s; job left running",
+					Message: fmt.Sprintf("identity mismatch: pgid recycle suspected, orphans leaked; runtime pid %d no longer has recorded starttime %s; no process-group signal sent; job left running",
 						payload.RuntimePID, payload.RuntimePIDStartTime),
 				})
 				previous.identityReported = true
@@ -169,6 +197,7 @@ func (s *daemonLivenessSweep) evaluate(ctx context.Context, store *db.Store, std
 
 	runtimePID := payload.RuntimePID
 	runtimeStart := payload.RuntimePIDStartTime
+	runtimePGID := payload.RuntimePGID
 	payload.RuntimePID = 0
 	payload.RuntimePIDStartTime = ""
 	payload.RuntimePGID = 0
@@ -188,11 +217,47 @@ func (s *daemonLivenessSweep) evaluate(ctx context.Context, store *db.Store, std
 		return err
 	}
 	if transitioned {
+		if !legacy {
+			s.killRecordedRuntimeGroup(ctx, store, job.ID, runtimePID, runtimePGID, runtimeStart)
+		}
 		_, _ = store.DeleteResourceLocksByOwnerIfNotRunning(ctx, job.ID)
 		writeLine(stdout, "failed stale running job %s: %s", job.ID, message)
 	}
 	s.forget(job.ID)
 	return nil
+}
+
+// killRecordedRuntimeGroup runs only after this sweep wins the running->failed
+// transition. RuntimePIDStartTime belongs to the immediate child, which is also
+// the group leader because GroupRunner uses Setpgid. Requiring both IDs to match
+// and re-reading the leader identity immediately before kill(-pgid) prevents a
+// recycled PGID from targeting an unrelated process tree.
+func (s *daemonLivenessSweep) killRecordedRuntimeGroup(ctx context.Context, store *db.Store, jobID string, runtimePID, runtimePGID int, recordedIdentity string) {
+	recordedIdentity = strings.TrimSpace(recordedIdentity)
+	currentIdentity := ""
+	if s.identity != nil && runtimePGID > 0 {
+		currentIdentity = strings.TrimSpace(s.identity(runtimePGID))
+	}
+	if runtimePGID <= 0 || runtimePID != runtimePGID || recordedIdentity == "" || currentIdentity != recordedIdentity {
+		_ = store.AddJobEvent(ctx, db.JobEvent{
+			JobID: jobID,
+			Kind:  "job_liveness_pgid_recycle_suspected",
+			Message: fmt.Sprintf("pgid recycle suspected, orphans leaked: pid=%d pgid=%d recorded_starttime=%q current_leader_starttime=%q; no process-group signal sent",
+				runtimePID, runtimePGID, recordedIdentity, currentIdentity),
+		})
+		return
+	}
+	if s.signal == nil {
+		return
+	}
+	if err := s.signal(-runtimePGID, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		_ = store.AddJobEvent(ctx, db.JobEvent{
+			JobID: jobID,
+			Kind:  "job_liveness_group_kill_failed",
+			Message: fmt.Sprintf("process-group kill failed for pgid %d after verified leader identity: %v; orphans may remain",
+				runtimePGID, err),
+		})
+	}
 }
 
 func (s *daemonLivenessSweep) previousStable(jobID string, info os.FileInfo, now time.Time) (livenessLogSample, bool) {

--- a/internal/cli/daemon_liveness_test.go
+++ b/internal/cli/daemon_liveness_test.go
@@ -5,8 +5,11 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -99,7 +102,16 @@ func TestDaemonLivenessSweepDeadPIDFrozenLogFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	message := events[len(events)-1].Message
+	message := ""
+	for _, event := range events {
+		if event.Kind == string(workflow.JobFailed) {
+			message = event.Message
+			break
+		}
+	}
+	if message == "" {
+		t.Fatalf("events = %+v, want terminal failed event", events)
+	}
 	for _, leg := range []string{"updated_at frozen", "job log byte-frozen", "runtime pid 4242 is dead"} {
 		if !strings.Contains(message, leg) {
 			t.Fatalf("failed event %q missing predicate leg %q", message, leg)
@@ -158,6 +170,155 @@ func TestDaemonLivenessSweepPIDReuseIsIndeterminate(t *testing.T) {
 	if len(events) != 1 || events[0].Kind != "job_liveness_identity_mismatch" || !strings.Contains(events[0].Message, "identity mismatch") {
 		t.Fatalf("identity mismatch events = %+v", events)
 	}
+}
+
+func TestDaemonLivenessSweepKillsRecordedProcessGroup(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	cmd := exec.Command("sh", "-c", "sleep 300 & echo $! > "+pidFile+"; exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pgid := cmd.Process.Pid
+	defer func() {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	}()
+
+	grandchild := waitForPIDFile(t, pidFile)
+	waitForProcessState(t, pgid, "Z")
+	identity := workflow.RuntimeProcessIdentity(pgid)
+	if identity == "" {
+		t.Fatal("group leader start-time identity is empty")
+	}
+
+	ctx, paths, store, now, quiet := livenessTestJob(t, "group-dead", pgid)
+	job, err := store.GetJob(ctx, "group-dead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload.RuntimePID = pgid
+	payload.RuntimePGID = pgid
+	payload.RuntimePIDStartTime = identity
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateJobPayload(ctx, job.ID, string(encoded)); err != nil {
+		t.Fatal(err)
+	}
+
+	runLivenessSamples(t, newDaemonLivenessSweep(), ctx, store, paths, now, quiet)
+	job, err = store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.State != string(workflow.JobFailed) {
+		t.Fatalf("zombie-leader job state = %q, want failed", job.State)
+	}
+	waitForProcessGone(t, grandchild)
+}
+
+func TestDaemonLivenessSweepPGIDIdentityMismatchLeaksWithoutSignal(t *testing.T) {
+	cmd := exec.Command("sleep", "300")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pgid := cmd.Process.Pid
+	defer func() {
+		_ = syscall.Kill(-pgid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	}()
+
+	ctx, paths, store, now, quiet := livenessTestJob(t, "pgid-reused", pgid)
+	sweep := newDaemonLivenessSweep()
+	sweep.probe = func(int, string) runtimePIDState { return runtimePIDDead }
+	runLivenessSamples(t, sweep, ctx, store, paths, now, quiet)
+
+	if err := syscall.Kill(pgid, 0); err != nil {
+		t.Fatalf("identity-mismatched group leader was signaled: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if state := runtimeProcessState(pgid); state == "" || state == "Z" {
+		t.Fatalf("identity-mismatched group leader state = %q, want live and unsignaled", state)
+	}
+	events, err := store.ListJobEvents(ctx, "pgid-reused")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, event := range events {
+		if strings.Contains(event.Message, "pgid recycle suspected, orphans leaked") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("events = %+v, want pgid recycle suspected, orphans leaked", events)
+	}
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pid file %s was not written", path)
+	return 0
+}
+
+func waitForProcessState(t *testing.T, pid int, want string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+		if err == nil {
+			closeParen := strings.LastIndexByte(string(data), ')')
+			if closeParen >= 0 {
+				fields := strings.Fields(string(data[closeParen+1:]))
+				if len(fields) > 0 && fields[0] == want {
+					return
+				}
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("process %d did not reach state %s", pid, want)
+}
+
+func waitForProcessGone(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+		if os.IsNotExist(err) {
+			return
+		}
+		if err == nil {
+			closeParen := strings.LastIndexByte(string(data), ')')
+			if closeParen >= 0 {
+				fields := strings.Fields(string(data[closeParen+1:]))
+				if len(fields) > 0 && fields[0] == "Z" {
+					return
+				}
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("process %d survived process-group kill", pid)
 }
 
 func TestDaemonLivenessSweepLegacyNeedsDoubleQuietAndNoLease(t *testing.T) {

--- a/internal/subprocess/group.go
+++ b/internal/subprocess/group.go
@@ -231,10 +231,7 @@ func RunGroupEnvStreamWithPID(ctx context.Context, dir string, extraEnv []string
 func newGroupCmd(ctx context.Context, dir string, command string, args []string) (*exec.Cmd, func()) {
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = dir
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:   true,
-		Pdeathsig: syscall.SIGKILL,
-	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	var pgid int
 	cmd.Cancel = func() error {

--- a/internal/subprocess/group.go
+++ b/internal/subprocess/group.go
@@ -19,7 +19,8 @@ const groupKillGrace = 10 * time.Second
 // period). Plain exec.CommandContext only kills the immediate child, which
 // orphans grandchildren — runtime CLIs like codex/claude spawn helpers that
 // must die with the job. Used by the runtime adapters; short-lived tool calls
-// (gh, git) keep the plain ExecRunner.
+// (gh, git) keep the plain ExecRunner. A child that deliberately calls setsid
+// escapes both this group and its cleanup; that residual is out of scope.
 type GroupRunner struct {
 	// MaxOutputBytes, when positive, retains only the tail of stdout and stderr
 	// independently. Zero preserves the historical unbounded capture behavior.
@@ -230,7 +231,10 @@ func RunGroupEnvStreamWithPID(ctx context.Context, dir string, extraEnv []string
 func newGroupCmd(ctx context.Context, dir string, command string, args []string) (*exec.Cmd, func()) {
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = dir
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid:   true,
+		Pdeathsig: syscall.SIGKILL,
+	}
 
 	var pgid int
 	cmd.Cancel = func() error {

--- a/internal/subprocess/group_test.go
+++ b/internal/subprocess/group_test.go
@@ -75,6 +75,13 @@ func TestRunGroupNormalCompletionUnaffected(t *testing.T) {
 	}
 }
 
+func TestGroupCommandKillsImmediateChildWhenParentDies(t *testing.T) {
+	cmd, _ := newGroupCmd(context.Background(), "", "sh", []string{"-c", "exit 0"})
+	if cmd.SysProcAttr == nil || cmd.SysProcAttr.Pdeathsig != syscall.SIGKILL {
+		t.Fatalf("group command SysProcAttr = %+v, want Pdeathsig SIGKILL", cmd.SysProcAttr)
+	}
+}
+
 // TestRunGroupStreamTeesAndBuffers: the streaming group runner tees live to out
 // while returning the same buffered Result as RunGroup — the tee is additive.
 func TestRunGroupStreamTeesAndBuffers(t *testing.T) {

--- a/internal/subprocess/group_test.go
+++ b/internal/subprocess/group_test.go
@@ -75,13 +75,6 @@ func TestRunGroupNormalCompletionUnaffected(t *testing.T) {
 	}
 }
 
-func TestGroupCommandKillsImmediateChildWhenParentDies(t *testing.T) {
-	cmd, _ := newGroupCmd(context.Background(), "", "sh", []string{"-c", "exit 0"})
-	if cmd.SysProcAttr == nil || cmd.SysProcAttr.Pdeathsig != syscall.SIGKILL {
-		t.Fatalf("group command SysProcAttr = %+v, want Pdeathsig SIGKILL", cmd.SysProcAttr)
-	}
-}
-
 // TestRunGroupStreamTeesAndBuffers: the streaming group runner tees live to out
 // while returning the same buffered Result as RunGroup — the tee is additive.
 func TestRunGroupStreamTeesAndBuffers(t *testing.T) {

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2113,13 +2113,13 @@ twice the quiet threshold and no held runtime lease.
 On Linux, runtime commands start as the leader of a dedicated process group;
 the OnPID write persists that PID, its `/proc` start time, and the PGID before
 the runner waits. Context cancellation signals the whole group (TERM, then
-KILL), and the immediate child carries `PDEATHSIG=SIGKILL` so daemon death also
-reaps it. After a same-boot liveness verdict wins the `running` → `failed`
+KILL). After a same-boot liveness verdict wins the `running` → `failed`
 transition, cleanup signals the recorded negative PGID only when the current
 group leader still has the persisted start time. A mismatch sends no signal and
-records `pgid recycle suspected, orphans leaked`. A descendant that deliberately
-calls `setsid` escapes the recorded process group; reaping such escapees remains
-an explicit out-of-scope residual.
+records `pgid recycle suspected, orphans leaked`. Daemon death does not itself
+reap the process group. A descendant that deliberately calls `setsid` escapes
+the recorded process group; reaping such escapees remains an explicit
+out-of-scope residual.
 
 The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` env var; the smallest honored value is 1m —

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2110,6 +2110,17 @@ absolute veto however quiet the log; a recycled PID records an identity-mismatch
 event and leaves the job running. Legacy rows without a runtime PID require
 twice the quiet threshold and no held runtime lease.
 
+On Linux, runtime commands start as the leader of a dedicated process group;
+the OnPID write persists that PID, its `/proc` start time, and the PGID before
+the runner waits. Context cancellation signals the whole group (TERM, then
+KILL), and the immediate child carries `PDEATHSIG=SIGKILL` so daemon death also
+reaps it. After a same-boot liveness verdict wins the `running` → `failed`
+transition, cleanup signals the recorded negative PGID only when the current
+group leader still has the persisted start time. A mismatch sends no signal and
+records `pgid recycle suspected, orphans leaked`. A descendant that deliberately
+calls `setsid` escapes the recorded process group; reaping such escapees remains
+an explicit out-of-scope residual.
+
 The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` env var; the smallest honored value is 1m —
 below-1m, malformed, or non-positive values are rejected (with a one-time

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1872,13 +1872,13 @@ twice the quiet threshold and no held runtime lease.
 On Linux, runtime commands start as the leader of a dedicated process group;
 the OnPID write persists that PID, its `/proc` start time, and the PGID before
 the runner waits. Context cancellation signals the whole group (TERM, then
-KILL), and the immediate child carries `PDEATHSIG=SIGKILL` so daemon death also
-reaps it. After a same-boot liveness verdict wins the `running` → `failed`
+KILL). After a same-boot liveness verdict wins the `running` → `failed`
 transition, cleanup signals the recorded negative PGID only when the current
 group leader still has the persisted start time. A mismatch sends no signal and
-records `pgid recycle suspected, orphans leaked`. A descendant that deliberately
-calls `setsid` escapes the recorded process group; reaping such escapees remains
-an explicit out-of-scope residual.
+records `pgid recycle suspected, orphans leaked`. Daemon death does not itself
+reap the process group. A descendant that deliberately calls `setsid` escapes
+the recorded process group; reaping such escapees remains an explicit
+out-of-scope residual.
 
 The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1869,6 +1869,17 @@ absolute veto however quiet the log; a recycled PID records an identity-mismatch
 event and leaves the job running. Legacy rows without a runtime PID require
 twice the quiet threshold and no held runtime lease.
 
+On Linux, runtime commands start as the leader of a dedicated process group;
+the OnPID write persists that PID, its `/proc` start time, and the PGID before
+the runner waits. Context cancellation signals the whole group (TERM, then
+KILL), and the immediate child carries `PDEATHSIG=SIGKILL` so daemon death also
+reaps it. After a same-boot liveness verdict wins the `running` → `failed`
+transition, cleanup signals the recorded negative PGID only when the current
+group leader still has the persisted start time. A mismatch sends no signal and
+records `pgid recycle suspected, orphans leaked`. A descendant that deliberately
+calls `setsid` escapes the recorded process group; reaping such escapees remains
+an explicit out-of-scope residual.
+
 The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` environment variable; the smallest honored value
 is 1m — below-1m, malformed, or non-positive values are rejected (with a

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11957,13 +11957,13 @@ twice the quiet threshold and no held runtime lease.
 On Linux, runtime commands start as the leader of a dedicated process group;
 the OnPID write persists that PID, its `/proc` start time, and the PGID before
 the runner waits. Context cancellation signals the whole group (TERM, then
-KILL), and the immediate child carries `PDEATHSIG=SIGKILL` so daemon death also
-reaps it. After a same-boot liveness verdict wins the `running` → `failed`
+KILL). After a same-boot liveness verdict wins the `running` → `failed`
 transition, cleanup signals the recorded negative PGID only when the current
 group leader still has the persisted start time. A mismatch sends no signal and
-records `pgid recycle suspected, orphans leaked`. A descendant that deliberately
-calls `setsid` escapes the recorded process group; reaping such escapees remains
-an explicit out-of-scope residual.
+records `pgid recycle suspected, orphans leaked`. Daemon death does not itself
+reap the process group. A descendant that deliberately calls `setsid` escapes
+the recorded process group; reaping such escapees remains an explicit
+out-of-scope residual.
 
 The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` env var; the smallest honored value is 1m —

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11954,6 +11954,17 @@ absolute veto however quiet the log; a recycled PID records an identity-mismatch
 event and leaves the job running. Legacy rows without a runtime PID require
 twice the quiet threshold and no held runtime lease.
 
+On Linux, runtime commands start as the leader of a dedicated process group;
+the OnPID write persists that PID, its `/proc` start time, and the PGID before
+the runner waits. Context cancellation signals the whole group (TERM, then
+KILL), and the immediate child carries `PDEATHSIG=SIGKILL` so daemon death also
+reaps it. After a same-boot liveness verdict wins the `running` → `failed`
+transition, cleanup signals the recorded negative PGID only when the current
+group leader still has the persisted start time. A mismatch sends no signal and
+records `pgid recycle suspected, orphans leaked`. A descendant that deliberately
+calls `setsid` escapes the recorded process group; reaping such escapees remains
+an explicit out-of-scope residual.
+
 The staleness age leg is tunable via the
 `GITMOOT_STALE_RUNNING_AFTER` env var; the smallest honored value is 1m —
 below-1m, malformed, or non-positive values are rejected (with a one-time


### PR DESCRIPTION
WHAT:
SLICE-D implements identity-verified process-group cleanup for stale runtimes. The reviewed PDEATHSIG change was removed because signaling only the immediate group leader does not reap helper processes in the same group and can strand them after daemon death.

WHY:
Recovery must signal the recorded process group only after verifying the leader identity. A leader-only parent-death signal does not close #1308 defect 3 and risks killing the runtime while leaving its helpers orphaned with no daemon left to sweep them.

CHANGES:
- Persist and use the runtime PGID recorded through OnPID.
- Signal the negative PGID only when the recorded PID is the group leader and its current /proc start identity matches the recorded value.
- Refuse signaling on identity mismatch and emit the queryable pgid recycle suspected, orphans leaked event.
- Preserve the documented residual that descendants which call setsid escape the process group.
- Remove PDEATHSIG and its struct-literal test after behavioral review demonstrated that killing the leader does not kill the group.

LIVENESS VERDICT CHANGE:
probeRuntimePID now classifies a zombie process leader as dead. This changes the slice-C liveness verdict, not only slice-D cleanup behavior: previously a zombie leader answered kill(0) and could keep the job running forever; it now permits the job to transition to failed. This is deliberate and necessary because otherwise the zombie leader vetoes the identity-verified group cleanup.

VERIFICATION:
- PASS: existing subprocess behavioral guards prove context cancellation kills spawned grandchildren and preserves normal completion.
- PASS: TestProbeRuntimePIDUsesProcessStartIdentity.
- PASS: TestDaemonLivenessSweepKillsRecordedProcessGroup.
- PASS: TestDaemonLivenessSweepPGIDIdentityMismatchLeaksWithoutSignal.
- MUTANT KILLED: signaling RuntimePID instead of -RuntimePGID leaves the grandchild alive.
- MUTANT KILLED: removing the leader identity refusal permits signaling after a start-time mismatch.
- Full suite not run per campaign instruction.

CONFIG AUDIT:
No existing configuration value becomes newly load-bearing. The liveness sweep continues to use the existing stale-running and quiet-kill thresholds; this change only corrects process identity classification and cleanup targeting.

RISK / RESIDUAL:
Daemon death itself does not reap the process group after PDEATHSIG removal. The implemented cleanup runs in the surviving daemon liveness sweep. Deliberate setsid escapees remain out of scope.

TASK:
adhoc-550eedd6