### PR TITLE
Gitmoot: GITMOOT-COC -> IMPLEMENTER: IMPLEMENT gitmoot#1344 — task rows

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -116,10 +116,23 @@ first.
 `implementing` or `blocked` task. It refuses while a matching job or worktree
 process is live, preserves the branch and worktree, releases the branch lock
 best-effort, and records `task_dismissed_manual`. The daemon can record
-`task_dismissed_auto` for stale candidates using `updated_at` as a conservative
-activity proxy. Configure `[workflow].stale_task_ttl = "168h"` (the default), or
-set it to `"0"` to disable this poll leg. Candidates with a same-repo open PR,
-a remote branch, a live job, or an uncertain remote check are not dismissed.
+`task_dismissed_auto` for stale `implementing` candidates using `updated_at` as
+a conservative activity proxy. Configure `[workflow].stale_task_ttl = "168h"`
+(the default), or set it to `"0"` to disable this poll leg. Candidates with a
+same-repo open PR, a remote branch, a live job, or an uncertain remote check are
+not dismissed.
+
+The same TTL bounds `blocked` and `awaiting_human_merge` rows through a separate,
+evidence-based disposal pass. In order, an own merged PR produces `merged`; a
+later merged task or PR for the same referenced issue produces `superseded`; a
+closed referenced issue/PR produces `superseded`; and the bounded fallback is
+`stranded`. No tier uses git ancestry. An open `awaiting_human_merge` PR remains
+protected and falls to the visible `stranded` queue rather than being inferred
+complete. `task list --state stranded --json` exposes `disposal_tier`,
+`disposal_reason`, `disposed_at`, and the terminal escalation route.
+Separately, a continuous blocked episode emits at most three interval-spaced
+alerts plus one terminal escalation; alert exhaustion stays queryable and does
+not itself dispose the task.
 
 `task resume-work` is the coordinator-only, non-terminal exit from orphaned
 `reviewing`/`ready_to_merge` machinery back to `implementing`. It also supports

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -684,8 +684,8 @@ func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.
 	}
 	if strings.TrimSpace(request.Branch) != "" {
 		if task, err := store.GetTaskByRepoBranch(ctx, repo.FullName(), request.Branch); err == nil {
-			if task.State == string(workflow.TaskDismissed) {
-				return localAgentDispatchRequest{}, "", dismissedReviewTaskError(task.ID)
+			if workflow.IsDisposedTaskState(task.State) {
+				return localAgentDispatchRequest{}, "", disposedReviewTaskError(task)
 			}
 			if strings.TrimSpace(task.WorktreePath) != "" {
 				head, headErr := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
@@ -712,8 +712,8 @@ func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.
 		taskID = fmt.Sprintf("review-pr-%d-%s", request.PullRequest, shortHash(repo.FullName()+"\x00"+request.HeadSHA))
 	}
 	if existing, err := store.GetTask(ctx, taskID); err == nil {
-		if existing.State == string(workflow.TaskDismissed) {
-			return localAgentDispatchRequest{}, "", dismissedReviewTaskError(existing.ID)
+		if workflow.IsDisposedTaskState(existing.State) {
+			return localAgentDispatchRequest{}, "", disposedReviewTaskError(existing)
 		}
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return localAgentDispatchRequest{}, "", err
@@ -744,12 +744,18 @@ func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.
 		State:        string(workflow.TaskReviewing),
 		WorktreePath: path,
 	}
-	updated, err := store.UpsertTaskUnlessState(ctx, task, string(workflow.TaskDismissed))
+	updated, err := store.UpsertTaskUnlessStates(ctx, task, []string{
+		string(workflow.TaskDismissed), string(workflow.TaskSuperseded), string(workflow.TaskStranded),
+	})
 	if err != nil {
 		return localAgentDispatchRequest{}, "", err
 	}
 	if !updated {
-		return localAgentDispatchRequest{}, "", dismissedReviewTaskError(task.ID)
+		existing, loadErr := store.GetTask(ctx, task.ID)
+		if loadErr != nil {
+			return localAgentDispatchRequest{}, "", loadErr
+		}
+		return localAgentDispatchRequest{}, "", disposedReviewTaskError(existing)
 	}
 	request.TaskID = task.ID
 	request.GoalID = task.GoalID
@@ -759,6 +765,13 @@ func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.
 
 func dismissedReviewTaskError(taskID string) error {
 	return fmt.Errorf("task %s is dismissed; run task recover first", taskID)
+}
+
+func disposedReviewTaskError(task db.Task) error {
+	if task.State == string(workflow.TaskDismissed) {
+		return dismissedReviewTaskError(task.ID)
+	}
+	return fmt.Errorf("task %s is %s; create a successor task before dispatching another review", task.ID, task.State)
 }
 
 func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, record db.Repo, repo github.Repository, request localAgentDispatchRequest) (db.Task, localAgentDispatchRequest, error) {

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -861,11 +861,12 @@ func TestPrepareLocalReviewDispatchRequestDoesNotReuseStaleReviewWorktree(t *tes
 	}
 }
 
-func TestPrepareLocalReviewWorktreeRejectsDismissedTask(t *testing.T) {
+func TestPrepareLocalReviewWorktreeRejectsDisposedTask(t *testing.T) {
 	for _, test := range []struct {
 		name       string
 		task       db.Task
 		setRequest func(*localAgentDispatchRequest)
+		wantError  []string
 	}{
 		{
 			name: "matching head worktree",
@@ -873,6 +874,7 @@ func TestPrepareLocalReviewWorktreeRejectsDismissedTask(t *testing.T) {
 			setRequest: func(request *localAgentDispatchRequest) {
 				request.Branch = "feature/review"
 			},
+			wantError: []string{"is dismissed", "task recover"},
 		},
 		{
 			name: "requested task upsert",
@@ -880,6 +882,23 @@ func TestPrepareLocalReviewWorktreeRejectsDismissedTask(t *testing.T) {
 			setRequest: func(request *localAgentDispatchRequest) {
 				request.TaskID = "dismissed-by-id"
 			},
+			wantError: []string{"is dismissed", "task recover"},
+		},
+		{
+			name: "superseded matching branch",
+			task: db.Task{ID: "superseded-by-branch", RepoFullName: "owner/repo", State: string(workflow.TaskSuperseded), Branch: "feature/review"},
+			setRequest: func(request *localAgentDispatchRequest) {
+				request.Branch = "feature/review"
+			},
+			wantError: []string{"is superseded", "successor task"},
+		},
+		{
+			name: "stranded requested task",
+			task: db.Task{ID: "stranded-by-id", RepoFullName: "owner/repo", State: string(workflow.TaskStranded)},
+			setRequest: func(request *localAgentDispatchRequest) {
+				request.TaskID = "stranded-by-id"
+			},
+			wantError: []string{"is stranded", "successor task"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -907,11 +926,16 @@ func TestPrepareLocalReviewWorktreeRejectsDismissedTask(t *testing.T) {
 			_, _, err = prepareLocalReviewWorktree(ctx, store,
 				db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir},
 				github.Repository{Owner: "owner", Name: "repo"}, request)
-			if err == nil || !strings.Contains(err.Error(), "task "+test.task.ID+" is dismissed") || !strings.Contains(err.Error(), "task recover") {
+			if err == nil || !strings.Contains(err.Error(), "task "+test.task.ID) {
 				t.Fatalf("prepareLocalReviewWorktree error = %v", err)
 			}
+			for _, fragment := range test.wantError {
+				if !strings.Contains(err.Error(), fragment) {
+					t.Fatalf("prepareLocalReviewWorktree error = %v, want fragment %q", err, fragment)
+				}
+			}
 			stored, getErr := store.GetTask(ctx, test.task.ID)
-			if getErr != nil || stored.State != string(workflow.TaskDismissed) {
+			if getErr != nil || stored.State != test.task.State {
 				t.Fatalf("stored task=%+v err=%v", stored, getErr)
 			}
 		})

--- a/internal/cli/blocked_since.go
+++ b/internal/cli/blocked_since.go
@@ -20,6 +20,10 @@ const (
 	blockedRoleWakeInterval    = time.Minute
 	blockedRoleSnapshotTimeout = 5 * time.Second
 	directiveTTLSweepLimit     = 200
+	// A blocked task gets a finite alert ladder independent of disposal. The
+	// third nudge also emits the one terminal escalation; the episode then stays
+	// queryable but silent until evidence disposal transitions the task itself.
+	blockedTaskMaxNudges = 3
 	// blockedEpisodeStaleGap bounds how long a role episode survives without being
 	// re-observed blocked. Within it, a transient unknown/absent snapshot blip is
 	// tolerated (the accrued blocked duration is preserved); beyond it the subject is
@@ -210,6 +214,7 @@ func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink even
 	}
 	taskPrefix := "task:" + strings.TrimSpace(repo) + ":"
 	var digestItems []blockedTaskDigestItem
+	var exhaustedItems []blockedTaskDigestItem
 	for _, episode := range episodes {
 		if !strings.HasPrefix(episode.Subject, taskPrefix) {
 			continue
@@ -227,6 +232,9 @@ func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink even
 		if !stale {
 			continue
 		}
+		if strings.TrimSpace(episode.TaskExhaustedAt) != "" {
+			continue
+		}
 		blockedSince, blockedFor, due, err := blockedEpisodeDue(episode, wakeAfter, now)
 		if err != nil {
 			writeLine(stdout, "blocked_since task %s emit failed: %v", taskID, err)
@@ -235,26 +243,32 @@ func evaluateBlockedTaskEpisodes(ctx context.Context, store *db.Store, sink even
 		if !due {
 			continue
 		}
-		if err := markBlockedEpisodeEmitted(ctx, store, episode, now); err != nil {
+		newCount, exhausted, err := store.MarkBlockedTaskEpisodeEmitted(ctx, episode.Subject,
+			episode.TaskEmitCount, blockedTaskMaxNudges, now)
+		if err != nil {
 			writeLine(stdout, "blocked_since task %s emit failed: %v", taskID, err)
 			continue
 		}
-		digestItems = append(digestItems, blockedTaskDigestItem{
+		if newCount == episode.TaskEmitCount {
+			continue
+		}
+		item := blockedTaskDigestItem{
 			taskID:       taskID,
 			blockedSince: blockedSince,
 			blockedFor:   blockedFor,
-		})
-	}
-	if len(digestItems) == 0 {
-		return nil
-	}
-	sort.Slice(digestItems, func(i, j int) bool {
-		if digestItems[i].blockedFor == digestItems[j].blockedFor {
-			return digestItems[i].taskID < digestItems[j].taskID
 		}
-		return digestItems[i].blockedFor > digestItems[j].blockedFor
-	})
-	events.EmitEvent(ctx, sink, buildBlockedTaskDigestEvent(repo, digestItems, now))
+		digestItems = append(digestItems, item)
+		if exhausted {
+			exhaustedItems = append(exhaustedItems, item)
+		}
+	}
+	if len(digestItems) > 0 {
+		sortBlockedTaskDigestItems(digestItems)
+		events.EmitEvent(ctx, sink, buildBlockedTaskDigestEvent(repo, digestItems, now))
+	}
+	for _, item := range exhaustedItems {
+		events.EmitEvent(ctx, sink, buildBlockedTaskAlertExhaustedEvent(repo, item, now))
+	}
 	return nil
 }
 
@@ -786,6 +800,15 @@ type blockedTaskDigestItem struct {
 	blockedFor   time.Duration
 }
 
+func sortBlockedTaskDigestItems(items []blockedTaskDigestItem) {
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].blockedFor == items[j].blockedFor {
+			return items[i].taskID < items[j].taskID
+		}
+		return items[i].blockedFor > items[j].blockedFor
+	})
+}
+
 func buildBlockedTaskDigestEvent(repo string, items []blockedTaskDigestItem, now time.Time) events.Event {
 	oldest := items[0]
 	suffix := ""
@@ -801,6 +824,15 @@ func buildBlockedTaskDigestEvent(repo string, items []blockedTaskDigestItem, now
 		len(items), oldest.blockedFor.Round(time.Second), oldest.blockedSince.UTC().Format(time.RFC3339), oldest.taskID, suffix)
 	ev := events.NewEvent(events.EventJobBlocked, oldest.taskID, oldest.taskID, repo, string(workflow.TaskBlocked), detail, now, workflow.RedactCommentText)
 	ev.Cause = "blocked_since"
+	return ev
+}
+
+func buildBlockedTaskAlertExhaustedEvent(repo string, item blockedTaskDigestItem, now time.Time) events.Event {
+	detail := fmt.Sprintf("task %s remains blocked after %d alerts over %s (since %s); alert ladder exhausted, task remains queryable pending evidence disposal",
+		item.taskID, blockedTaskMaxNudges, item.blockedFor.Round(time.Second), item.blockedSince.UTC().Format(time.RFC3339))
+	ev := events.NewEvent(events.EventJobNeedsAttention, item.taskID, item.taskID, repo,
+		string(workflow.TaskBlocked), detail, now, workflow.RedactCommentText)
+	ev.Cause = "escalation"
 	return ev
 }
 

--- a/internal/cli/blocked_since_test.go
+++ b/internal/cli/blocked_since_test.go
@@ -185,6 +185,57 @@ func TestEvaluateBlockedTaskEpisodesSingleTaskUsesOneItemDigest(t *testing.T) {
 	}
 }
 
+func TestEvaluateBlockedTaskEpisodesCapsAlertsWithoutDisposingTask(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	repo := "owner/repo"
+	taskID := "task-exhausted-alerts"
+	wakeAfter := time.Hour
+	firstSweep := time.Now().UTC().Truncate(time.Second).Add(2 * time.Hour)
+	blockedSince := firstSweep.Add(-8 * time.Hour)
+	if err := store.UpsertTask(ctx, db.Task{ID: taskID, RepoFullName: repo, State: string(workflow.TaskBlocked)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertBlockedEpisode(ctx, taskEpisodeSubject(repo, taskID), blockedSince, blockedSince); err != nil {
+		t.Fatal(err)
+	}
+
+	sink := &recordingSink{}
+	for pass := 0; pass < blockedTaskMaxNudges+1; pass++ {
+		now := firstSweep.Add(time.Duration(pass) * (wakeAfter + time.Second))
+		if err := evaluateBlockedTaskEpisodes(ctx, store, sink, repo, wakeAfter, io.Discard, now); err != nil {
+			t.Fatalf("evaluateBlockedTaskEpisodes(pass %d) error = %v", pass+1, err)
+		}
+	}
+	if got := len(sink.byType(events.EventJobBlocked)); got != blockedTaskMaxNudges {
+		t.Fatalf("job.blocked nudges = %d, want capped %d", got, blockedTaskMaxNudges)
+	}
+	escalations := sink.byType(events.EventJobNeedsAttention)
+	if len(escalations) != 1 {
+		t.Fatalf("terminal escalations = %d, want 1", len(escalations))
+	}
+	if ev := escalations[0]; ev.Cause != "escalation" || ev.JobID != taskID ||
+		ev.RootID != taskID || !strings.Contains(ev.Detail, "alert ladder exhausted") ||
+		!strings.Contains(ev.Detail, taskID) {
+		t.Fatalf("terminal escalation = %+v", ev)
+	}
+
+	episodes, err := store.ListBlockedEpisodes(ctx)
+	if err != nil || len(episodes) != 1 {
+		t.Fatalf("blocked episodes = %+v, err=%v", episodes, err)
+	}
+	if got := episodes[0].TaskEmitCount; got != blockedTaskMaxNudges {
+		t.Fatalf("task_emit_count = %d, want %d", got, blockedTaskMaxNudges)
+	}
+	if episodes[0].TaskExhaustedAt == "" {
+		t.Fatal("task_exhausted_at is empty; exhausted alert ladder is not queryable")
+	}
+	blocked, err := store.ListTasksByRepoState(ctx, repo, string(workflow.TaskBlocked))
+	if err != nil || len(blocked) != 1 || blocked[0].ID != taskID {
+		t.Fatalf("blocked tasks after alert exhaustion = %+v, err=%v", blocked, err)
+	}
+}
+
 type fakeBlockedRoleAvailability struct {
 	available bool
 	calls     int

--- a/internal/cli/task_disposal_query_test.go
+++ b/internal/cli/task_disposal_query_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestTaskListQueriesStrandedDisposal(t *testing.T) {
+	home := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"init", "--home", home}, &stdout, &stderr); code != 0 {
+		t.Fatalf("init code=%d stderr=%s", code, stderr.String())
+	}
+	store, err := db.Open(filepath.Join(home, ".gitmoot", "gitmoot.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertTask(context.Background(), db.Task{ID: "task-stranded", RepoFullName: "owner/repo", State: string(workflow.TaskBlocked)}); err != nil {
+		t.Fatal(err)
+	}
+	if changed, _, err := store.DisposeTask(context.Background(), "task-stranded", []string{string(workflow.TaskBlocked)}, string(workflow.TaskStranded), "tier4_stranded", "no disposal evidence; escalation unroutable: no live ancestor", "", "", time.Now()); err != nil || !changed {
+		t.Fatalf("DisposeTask changed=%v err=%v", changed, err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"task", "list", "--home", home, "--state", "stranded", "--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("task list stranded code=%d stderr=%s", code, stderr.String())
+	}
+	var listed []taskListOutput
+	if err := json.Unmarshal(stdout.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 || listed[0].ID != "task-stranded" || listed[0].DisposalTier != "tier4_stranded" || !strings.Contains(listed[0].DisposalReason, "no disposal evidence") {
+		t.Fatalf("stranded task list = %+v", listed)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"task", "list", "--home", home, "--state", "blocked", "--json"}, &stdout, &stderr); code != 0 || strings.TrimSpace(stdout.String()) != "[]" {
+		t.Fatalf("blocked task list code=%d stdout=%q stderr=%s", code, stdout.String(), stderr.String())
+	}
+}

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -279,13 +279,17 @@ func printTaskUsage(w io.Writer) {
 }
 
 type taskListOutput struct {
-	ID           string `json:"id"`
-	Repo         string `json:"repo"`
-	GoalID       string `json:"goal_id"`
-	Title        string `json:"title"`
-	State        string `json:"state"`
-	Branch       string `json:"branch"`
-	WorktreePath string `json:"worktree_path"`
+	ID                     string `json:"id"`
+	Repo                   string `json:"repo"`
+	GoalID                 string `json:"goal_id"`
+	Title                  string `json:"title"`
+	State                  string `json:"state"`
+	Branch                 string `json:"branch"`
+	WorktreePath           string `json:"worktree_path"`
+	DisposalTier           string `json:"disposal_tier,omitempty"`
+	DisposalReason         string `json:"disposal_reason,omitempty"`
+	DisposedAt             string `json:"disposed_at,omitempty"`
+	DisposalEscalationRole string `json:"disposal_escalation_role,omitempty"`
 }
 
 func runTaskList(args []string, stdout, stderr io.Writer) int {
@@ -332,13 +336,17 @@ func runTaskList(args []string, stdout, stderr io.Writer) int {
 			continue
 		}
 		outputs = append(outputs, taskListOutput{
-			ID:           task.ID,
-			Repo:         task.RepoFullName,
-			GoalID:       task.GoalID,
-			Title:        task.Title,
-			State:        task.State,
-			Branch:       task.Branch,
-			WorktreePath: task.WorktreePath,
+			ID:                     task.ID,
+			Repo:                   task.RepoFullName,
+			GoalID:                 task.GoalID,
+			Title:                  task.Title,
+			State:                  task.State,
+			Branch:                 task.Branch,
+			WorktreePath:           task.WorktreePath,
+			DisposalTier:           task.DisposalTier,
+			DisposalReason:         task.DisposalReason,
+			DisposedAt:             task.DisposedAt,
+			DisposalEscalationRole: task.DisposalEscalationRole,
 		})
 	}
 	if *jsonOutput {
@@ -795,6 +803,8 @@ func taskStateOwner(state string) string {
 		owner = "the human merge decision"
 	case workflow.TaskMerged:
 		owner = "the terminal merge record"
+	case workflow.TaskSuperseded, workflow.TaskStranded:
+		owner = "the terminal disposal record"
 	case workflow.TaskAwaitingHuman:
 		owner = "the explicit human-resume machinery"
 	case workflow.TaskDismissed:

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -43,8 +43,9 @@ artifact_blobs = %q
 # default, or "HEAD" to follow the registered checkout. With no value, implement
 # follows checkout HEAD and guards stale non-default checkouts. result_checks is
 # off | warn | block and defaults to warn when omitted. stale_task_ttl is the
-# conservative updated_at age after which abandoned implementing/blocked tasks
-# may be auto-dismissed; it defaults to 168h and "0" disables that reconciler.
+# conservative updated_at age after which abandoned implementing tasks are
+# branch-cleaned and blocked/awaiting_human_merge tasks are evidence-disposed
+# to a terminal state; it defaults to 168h and "0" disables those reconcilers.
 # delegation_worktree_ttl defaults to 72h and bounds terminal-job worktree
 # retention; terminal owners cannot resume, so this safe cleanup is default-on.
 # Set it to "0" to disable the TTL reclaim pass.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -124,6 +124,15 @@ func (d Daemon) PollOnce(ctx context.Context) error {
 	if err := d.rearmAutoMergeDisabledTasks(ctx); err != nil && firstErr == nil {
 		firstErr = err
 	}
+	// Disposal is independent of repository admission. Run it before the open-PR
+	// listing so an unavailable forge cannot bypass an already-expired task's
+	// terminal bound; the per-item evaluator records "subject unavailable".
+	paths := config.Paths{ConfigFile: filepath.Join(filepath.Dir(d.Store.DatabasePath()), config.ConfigName)}
+	if disposalTTL, err := config.LoadStaleTaskTTL(paths); err != nil {
+		d.logf("task disposal skipped for %s: %v", d.Repo.FullName(), err)
+	} else if err := d.reconcileTaskDisposals(ctx, disposalTTL); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	pulls, err := d.GitHub.ListPullRequests(ctx, d.Repo, "open")
 	if err != nil {
 		return err
@@ -265,7 +274,7 @@ func (d Daemon) reconcileStaleTasks(ctx context.Context, openBranches map[string
 	}
 	return d.reconcileTaskTTL(ctx, openBranches, taskTTLReconcilePolicy{
 		ttl:          staleTTL,
-		states:       []string{string(workflow.TaskImplementing), string(workflow.TaskBlocked)},
+		states:       []string{string(workflow.TaskImplementing)},
 		eventKind:    "task_dismissed_auto",
 		reasonPrefix: "stale task auto-dismissed",
 		logLabel:     "stale task reconciler",

--- a/internal/daemon/stale_task_reconcile_test.go
+++ b/internal/daemon/stale_task_reconcile_test.go
@@ -47,7 +47,7 @@ func TestStaleTaskReconcilerDecisions(t *testing.T) {
 		{name: "open PR branch", state: workflow.TaskImplementing, branch: "feature/one", open: true},
 		{name: "remote present", state: workflow.TaskImplementing, branch: "feature/one", remote: true, wantCalls: 1},
 		{name: "remote absent", state: workflow.TaskImplementing, branch: "feature/one", wantDismiss: true, wantCalls: 1, wantReason: "refs/heads/feature/one absent"},
-		{name: "blocked remote absent", state: workflow.TaskBlocked, branch: "feature/blocked", wantDismiss: true, wantCalls: 1, wantReason: "refs/heads/feature/blocked absent"},
+		{name: "blocked is owned by evidence disposal", state: workflow.TaskBlocked, branch: "feature/blocked"},
 		{name: "empty branch", state: workflow.TaskImplementing, wantDismiss: true, wantReason: "empty branch"},
 		{name: "live job", state: workflow.TaskImplementing, branch: "feature/live", live: true},
 	}
@@ -169,7 +169,7 @@ func TestStaleTaskReconcilerLogsTickCounts(t *testing.T) {
 	if err := d.reconcileStaleTasks(ctx, map[string]struct{}{}); err != nil {
 		t.Fatal(err)
 	}
-	if len(logs) != 1 || logs[0] != "stale task reconciler for owner/repo: candidates=3 checked=3 dismissed=2" {
+	if len(logs) != 1 || logs[0] != "stale task reconciler for owner/repo: candidates=2 checked=2 dismissed=1" {
 		t.Fatalf("logs = %v", logs)
 	}
 }

--- a/internal/daemon/task_disposal.go
+++ b/internal/daemon/task_disposal.go
@@ -1,0 +1,297 @@
+package daemon
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/events"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+const (
+	taskDisposalTierOwnPRMerged     = "tier1_own_pr_merged"
+	taskDisposalTierSuccessorMerged = "tier2_successor_merged"
+	taskDisposalTierSubjectClosed   = "tier3_subject_closed"
+	taskDisposalTierStranded        = "tier4_stranded"
+	taskDisposalReasonUnavailable   = "subject unavailable"
+	taskDisposalReasonNoEvidence    = "no disposal evidence"
+)
+
+var (
+	qualifiedIssuePattern = regexp.MustCompile(`(?i)([a-z0-9_.-]+/[a-z0-9_.-]+)#([1-9][0-9]*)`)
+	shortRepoIssuePattern = regexp.MustCompile(`(?i)\b([a-z0-9_.-]+)#([1-9][0-9]*)\b`)
+	issueWordPattern      = regexp.MustCompile(`(?i)\bissue\s+#?([1-9][0-9]*)\b`)
+	bareIssuePattern      = regexp.MustCompile(`(?:^|[\s(])#([1-9][0-9]*)\b`)
+)
+
+type taskDisposalEvidence struct {
+	subjectRepo  string
+	subjectIssue int64
+	pullRequest  int64
+}
+
+type issueGetter interface {
+	GetIssue(context.Context, github.Repository, int64) (github.Issue, error)
+}
+
+// reconcileTaskDisposals terminates old blocked obligations by forge evidence,
+// strongest first, then by the bounded stranded fallback. It deliberately does
+// not inspect git ancestry: superseding branches need not be ancestors of main.
+func (d Daemon) reconcileTaskDisposals(ctx context.Context, ttl time.Duration) error {
+	if ttl <= 0 {
+		return nil
+	}
+	candidates, err := d.Store.ListStaleTaskCandidates(ctx, d.Repo.FullName(), []string{
+		string(workflow.TaskBlocked), string(workflow.TaskAwaitingHumanMerge),
+	}, d.now().Add(-ttl), staleTaskReconcileScanLimit)
+	if err != nil || len(candidates) == 0 {
+		return err
+	}
+	if len(candidates) > staleTaskReconcileLimit {
+		candidates = candidates[:staleTaskReconcileLimit]
+	}
+
+	tasks, taskErr := d.Store.ListTasksByRepo(ctx, d.Repo.FullName())
+	jobs, jobErr := d.Store.ListJobsByRepo(ctx, d.Repo.FullName())
+	evidence := buildTaskDisposalEvidence(d.Repo.FullName(), tasks, jobs)
+	orgConfig, orgErr := config.LoadOrg(config.Paths{ConfigFile: taskDisposalConfigPath(d.Store)})
+	if orgErr != nil {
+		orgConfig = config.OrgConfig{}
+	}
+
+	var firstErr error
+	for _, candidate := range candidates {
+		if err := d.disposeTaskCandidate(ctx, candidate, tasks, evidence, taskErr, jobErr, orgConfig); err != nil {
+			// One bad row never aborts the pass. The candidate helper attempts the
+			// stranded transition before returning; only a failed terminal write lands
+			// here, and later candidates still receive their bound.
+			d.logf("task disposal %s failed: %v", candidate.ID, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func (d Daemon) disposeTaskCandidate(ctx context.Context, candidate db.StaleTaskCandidate, tasks []db.Task, evidence map[string]taskDisposalEvidence, taskErr, jobErr error, orgConfig config.OrgConfig) error {
+	blockedAt, err := parseTaskStoreTime(candidate.UpdatedAt)
+	if err != nil {
+		return d.strandTask(ctx, candidate, taskDisposalReasonUnavailable+": invalid task timestamp", orgConfig)
+	}
+	if taskErr != nil || jobErr != nil {
+		return d.strandTask(ctx, candidate, taskDisposalReasonUnavailable, orgConfig)
+	}
+	itemEvidence := evidence[candidate.ID]
+	if itemEvidence.pullRequest == 0 && strings.TrimSpace(candidate.Branch) != "" {
+		stored, lookupErr := d.Store.GetPullRequestByRepoBranch(ctx, candidate.RepoFullName, candidate.Branch)
+		if lookupErr == nil {
+			itemEvidence.pullRequest = stored.Number
+		} else if !errors.Is(lookupErr, sql.ErrNoRows) {
+			return d.strandTask(ctx, candidate, taskDisposalReasonUnavailable, orgConfig)
+		}
+	}
+
+	var ownPR github.PullRequest
+	var ownPRKnown bool
+	if itemEvidence.pullRequest > 0 {
+		ownPR, err = d.GitHub.GetPullRequest(ctx, d.Repo, itemEvidence.pullRequest)
+		if err != nil {
+			return d.strandTask(ctx, candidate, taskDisposalReasonUnavailable, orgConfig)
+		}
+		ownPRKnown = true
+		if pullRequestListedAsMerged(ownPR) {
+			return d.commitTaskDisposal(ctx, candidate, workflow.TaskMerged, taskDisposalTierOwnPRMerged,
+				fmt.Sprintf("own PR #%d is merged in forge", ownPR.Number), "", "")
+		}
+		if workflow.TaskState(candidate.State) == workflow.TaskAwaitingHumanMerge && strings.EqualFold(strings.TrimSpace(ownPR.State), "open") {
+			return d.strandTask(ctx, candidate, taskDisposalReasonNoEvidence+": own PR remains open and awaiting_human_merge is protected", orgConfig)
+		}
+	}
+
+	if itemEvidence.subjectIssue > 0 {
+		for _, successor := range tasks {
+			if successor.ID == candidate.ID || !taskUpdatedAfter(successor.UpdatedAt, blockedAt) {
+				continue
+			}
+			peerEvidence := evidence[successor.ID]
+			if peerEvidence.subjectIssue != itemEvidence.subjectIssue || !strings.EqualFold(peerEvidence.subjectRepo, itemEvidence.subjectRepo) {
+				continue
+			}
+			if workflow.TaskState(successor.State) == workflow.TaskMerged {
+				return d.commitTaskDisposal(ctx, candidate, workflow.TaskSuperseded, taskDisposalTierSuccessorMerged,
+					fmt.Sprintf("successor task %s on %s#%d merged after this task blocked", successor.ID, itemEvidence.subjectRepo, itemEvidence.subjectIssue), "", "")
+			}
+			if peerEvidence.pullRequest <= 0 {
+				continue
+			}
+			pull, pullErr := d.GitHub.GetPullRequest(ctx, d.Repo, peerEvidence.pullRequest)
+			if pullErr != nil {
+				return d.strandTask(ctx, candidate, taskDisposalReasonUnavailable, orgConfig)
+			}
+			if pullRequestListedAsMerged(pull) && mergedAfter(pull.MergedAt, blockedAt) {
+				return d.commitTaskDisposal(ctx, candidate, workflow.TaskSuperseded, taskDisposalTierSuccessorMerged,
+					fmt.Sprintf("successor PR #%d on %s#%d merged after this task blocked", pull.Number, itemEvidence.subjectRepo, itemEvidence.subjectIssue), "", "")
+			}
+		}
+		getter, ok := d.GitHub.(issueGetter)
+		if ok {
+			subjectRepo, parseErr := ParseRepository(itemEvidence.subjectRepo)
+			if parseErr != nil {
+				return d.strandTask(ctx, candidate, taskDisposalReasonUnavailable, orgConfig)
+			}
+			issue, issueErr := getter.GetIssue(ctx, subjectRepo, itemEvidence.subjectIssue)
+			if issueErr != nil {
+				return d.strandTask(ctx, candidate, taskDisposalReasonUnavailable, orgConfig)
+			}
+			if strings.EqualFold(strings.TrimSpace(issue.State), "closed") {
+				return d.commitTaskDisposal(ctx, candidate, workflow.TaskSuperseded, taskDisposalTierSubjectClosed,
+					fmt.Sprintf("referenced subject %s#%d is closed", itemEvidence.subjectRepo, itemEvidence.subjectIssue), "", "")
+			}
+		}
+	}
+	if itemEvidence.subjectIssue == 0 && ownPRKnown && strings.EqualFold(strings.TrimSpace(ownPR.State), "closed") {
+		return d.commitTaskDisposal(ctx, candidate, workflow.TaskSuperseded, taskDisposalTierSubjectClosed,
+			fmt.Sprintf("referenced PR #%d is closed without a merge", ownPR.Number), "", "")
+	}
+	return d.strandTask(ctx, candidate, taskDisposalReasonNoEvidence, orgConfig)
+}
+
+func (d Daemon) strandTask(ctx context.Context, candidate db.StaleTaskCandidate, reason string, orgConfig config.OrgConfig) error {
+	role := d.taskDisposalEscalationRole(ctx, candidate, orgConfig)
+	routeDetail := "escalation unroutable: no live ancestor"
+	if role != "" {
+		routeDetail = "escalation addressed to " + role
+	}
+	fullReason := strings.TrimSpace(reason) + "; " + routeDetail
+	payload := ""
+	if role != "" {
+		ev := events.NewEvent(events.EventJobNeedsAttention, candidate.ID, candidate.ID, candidate.RepoFullName,
+			string(workflow.TaskStranded), fmt.Sprintf("task %s stranded: %s", candidate.ID, fullReason), d.now(), workflow.RedactCommentText)
+		ev.Cause = "task_disposal_stranded"
+		ev.WakeKind = db.WakeOutboxKindEscalation
+		ev.WakeTargetRole = role
+		encoded, err := json.Marshal(ev)
+		if err != nil {
+			return err
+		}
+		payload = string(encoded)
+	}
+	return d.commitTaskDisposal(ctx, candidate, workflow.TaskStranded, taskDisposalTierStranded, fullReason, role, payload)
+}
+
+func (d Daemon) commitTaskDisposal(ctx context.Context, candidate db.StaleTaskCandidate, state workflow.TaskState, tier, reason, role, event string) error {
+	_, _, err := d.Store.DisposeTask(ctx, candidate.ID,
+		[]string{string(workflow.TaskBlocked), string(workflow.TaskAwaitingHumanMerge)},
+		string(state), tier, reason, role, event, d.now())
+	return err
+}
+
+func (d Daemon) taskDisposalEscalationRole(ctx context.Context, candidate db.StaleTaskCandidate, orgConfig config.OrgConfig) string {
+	actingRole := ""
+	if lock, err := d.Store.GetBranchLock(ctx, candidate.RepoFullName, candidate.Branch); err == nil {
+		actingRole = strings.ToLower(strings.TrimSpace(lock.ActingOrgRole))
+	}
+	if _, ok := orgConfig.Role(actingRole); ok {
+		for _, ancestor := range orgConfig.Ancestors(actingRole) {
+			if role, exists := orgConfig.Role(ancestor); exists && config.ScopeMatches(role.Scope, candidate.RepoFullName) {
+				return ancestor
+			}
+		}
+	}
+	for _, root := range orgConfig.Roots() {
+		if role, ok := orgConfig.Role(root); ok && config.ScopeMatches(role.Scope, candidate.RepoFullName) {
+			return root
+		}
+	}
+	return ""
+}
+
+func buildTaskDisposalEvidence(repo string, tasks []db.Task, jobs []db.Job) map[string]taskDisposalEvidence {
+	byID := make(map[string]taskDisposalEvidence, len(tasks))
+	byBranch := make(map[string]string, len(tasks))
+	for _, task := range tasks {
+		subjectRepo, subjectIssue := taskIssueSubject(repo, task.Title)
+		byID[task.ID] = taskDisposalEvidence{subjectRepo: subjectRepo, subjectIssue: subjectIssue}
+		if branch := strings.TrimSpace(task.Branch); branch != "" {
+			byBranch[branch] = task.ID
+		}
+	}
+	for _, job := range jobs {
+		payload, err := workflow.ParseJobPayload(job.Payload)
+		if err != nil {
+			continue
+		}
+		taskID := strings.TrimSpace(payload.TaskID)
+		if taskID == "" && strings.TrimSpace(payload.Repo) == strings.TrimSpace(repo) {
+			taskID = byBranch[strings.TrimSpace(payload.Branch)]
+		}
+		if _, ok := byID[taskID]; !ok {
+			continue
+		}
+		item := byID[taskID]
+		if payload.PullRequest > 0 {
+			item.pullRequest = int64(payload.PullRequest)
+		}
+		if subjectRepo, issue := taskIssueSubject(repo, payload.Instructions); issue > 0 {
+			item.subjectRepo, item.subjectIssue = subjectRepo, issue
+		}
+		byID[taskID] = item
+	}
+	return byID
+}
+
+func taskIssueSubject(defaultRepo, text string) (string, int64) {
+	if match := qualifiedIssuePattern.FindStringSubmatch(text); len(match) == 3 {
+		number, _ := strconv.ParseInt(match[2], 10, 64)
+		return strings.ToLower(match[1]), number
+	}
+	if match := shortRepoIssuePattern.FindStringSubmatch(text); len(match) == 3 {
+		owner, repoName, ok := strings.Cut(strings.ToLower(strings.TrimSpace(defaultRepo)), "/")
+		if ok && strings.EqualFold(repoName, match[1]) {
+			number, _ := strconv.ParseInt(match[2], 10, 64)
+			return owner + "/" + repoName, number
+		}
+	}
+	for _, pattern := range []*regexp.Regexp{issueWordPattern, bareIssuePattern} {
+		if match := pattern.FindStringSubmatch(text); len(match) == 2 {
+			number, _ := strconv.ParseInt(match[1], 10, 64)
+			return strings.ToLower(strings.TrimSpace(defaultRepo)), number
+		}
+	}
+	return "", 0
+}
+
+func parseTaskStoreTime(value string) (time.Time, error) {
+	for _, layout := range []string{time.RFC3339Nano, "2006-01-02 15:04:05"} {
+		if parsed, err := time.Parse(layout, strings.TrimSpace(value)); err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("invalid task timestamp %q", value)
+}
+
+func taskUpdatedAfter(value string, after time.Time) bool {
+	parsed, err := parseTaskStoreTime(value)
+	return err == nil && parsed.After(after)
+}
+
+func mergedAfter(value string, after time.Time) bool {
+	parsed, err := parseTaskStoreTime(value)
+	return err == nil && parsed.After(after)
+}
+
+func taskDisposalConfigPath(store *db.Store) string {
+	return filepath.Join(filepath.Dir(store.DatabasePath()), config.ConfigName)
+}

--- a/internal/daemon/task_disposal_test.go
+++ b/internal/daemon/task_disposal_test.go
@@ -1,0 +1,279 @@
+package daemon
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+type taskDisposalGitHub struct {
+	*fakeGitHub
+	issues   map[int64]github.Issue
+	issueErr error
+}
+
+func (f *taskDisposalGitHub) GetIssue(_ context.Context, _ github.Repository, number int64) (github.Issue, error) {
+	if f.issueErr != nil {
+		return github.Issue{}, f.issueErr
+	}
+	issue, ok := f.issues[number]
+	if !ok {
+		return github.Issue{}, fmt.Errorf("issue %d missing", number)
+	}
+	return issue, nil
+}
+
+func TestTaskDisposalEvidenceTiers(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(t *testing.T, store *db.Store, gh *taskDisposalGitHub, repo github.Repository)
+		wantState  workflow.TaskState
+		wantTier   string
+		wantReason string
+	}{
+		{
+			name: "tier1 own PR merged",
+			configure: func(t *testing.T, store *db.Store, gh *taskDisposalGitHub, repo github.Repository) {
+				seedTaskDisposalJob(t, store, "job-own", "task-under-test", repo.FullName(), "feature/own", 41, "Implement issue #1344")
+				gh.pullsByNumber[41] = github.PullRequest{Number: 41, State: "closed", Merged: true, HeadRef: "feature/own"}
+			},
+			wantState: workflow.TaskMerged, wantTier: taskDisposalTierOwnPRMerged, wantReason: "own PR #41",
+		},
+		{
+			name: "tier2 successor task merged",
+			configure: func(t *testing.T, store *db.Store, _ *taskDisposalGitHub, repo github.Repository) {
+				seedTaskDisposalJob(t, store, "job-original", "task-under-test", repo.FullName(), "feature/original", 0, "Implement issue #1344")
+				if err := store.UpsertTask(context.Background(), db.Task{ID: "task-successor", RepoFullName: repo.FullName(), State: string(workflow.TaskMerged), Branch: "feature/successor"}); err != nil {
+					t.Fatal(err)
+				}
+				seedTaskDisposalJob(t, store, "job-successor", "task-successor", repo.FullName(), "feature/successor", 52, "Fix issue #1344")
+				setTaskUpdatedAt(t, store, "task-successor", time.Now().UTC().Add(time.Hour))
+			},
+			wantState: workflow.TaskSuperseded, wantTier: taskDisposalTierSuccessorMerged, wantReason: "successor task task-successor",
+		},
+		{
+			name: "tier3 referenced subject closed",
+			configure: func(t *testing.T, store *db.Store, gh *taskDisposalGitHub, repo github.Repository) {
+				seedTaskDisposalJob(t, store, "job-subject", "task-under-test", repo.FullName(), "feature/subject", 0, "Implement issue #1344")
+				gh.issues[1344] = github.Issue{Number: 1344, State: "closed"}
+			},
+			wantState: workflow.TaskSuperseded, wantTier: taskDisposalTierSubjectClosed, wantReason: "referenced subject owner/repo#1344",
+		},
+		{
+			name: "tier4 bounded fallback",
+			configure: func(t *testing.T, store *db.Store, gh *taskDisposalGitHub, repo github.Repository) {
+				seedTaskDisposalJob(t, store, "job-no-evidence", "task-under-test", repo.FullName(), "feature/none", 0, "Investigate the scheduler")
+			},
+			wantState: workflow.TaskStranded, wantTier: taskDisposalTierStranded, wantReason: taskDisposalReasonNoEvidence,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := testStore(t)
+			repo := github.Repository{Owner: "owner", Name: "repo"}
+			seedStaleRepo(t, store, repo)
+			if err := store.UpsertTask(ctx, db.Task{ID: "task-under-test", RepoFullName: repo.FullName(), State: string(workflow.TaskBlocked), Branch: "feature/original"}); err != nil {
+				t.Fatal(err)
+			}
+			gh := &taskDisposalGitHub{fakeGitHub: &fakeGitHub{pullsByNumber: map[int64]github.PullRequest{}, comments: map[int64][]github.IssueComment{}}, issues: map[int64]github.Issue{}}
+			test.configure(t, store, gh, repo)
+			d := Daemon{Repo: repo, Store: store, GitHub: gh, Now: futureClock}
+			if err := d.reconcileTaskDisposals(ctx, time.Hour); err != nil {
+				t.Fatalf("reconcileTaskDisposals: %v", err)
+			}
+			got, err := store.GetTask(ctx, "task-under-test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.State != string(test.wantState) || got.DisposalTier != test.wantTier || !strings.Contains(got.DisposalReason, test.wantReason) || got.DisposedAt == "" {
+				t.Fatalf("disposed task = %+v, want state=%s tier=%s reason containing %q", got, test.wantState, test.wantTier, test.wantReason)
+			}
+			if test.wantState == workflow.TaskStranded && !strings.Contains(got.DisposalReason, "escalation unroutable") {
+				t.Fatalf("unroutable stranded task did not record routing fact: %+v", got)
+			}
+			events, err := store.ListTaskEvents(ctx, got.ID)
+			if err != nil || len(events) != 1 || events[0].Kind != "task_disposed_"+test.wantTier {
+				t.Fatalf("task events = %+v, err=%v", events, err)
+			}
+		})
+	}
+}
+
+func TestTaskDisposalAwaitingHumanMergeOpenPRFallsToStranded(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	if err := store.UpsertTask(ctx, db.Task{ID: "protected", RepoFullName: repo.FullName(), State: string(workflow.TaskAwaitingHumanMerge), Branch: "feature/protected"}); err != nil {
+		t.Fatal(err)
+	}
+	seedTaskDisposalJob(t, store, "job-protected", "protected", repo.FullName(), "feature/protected", 77, "Implement issue #1344")
+	gh := &taskDisposalGitHub{fakeGitHub: &fakeGitHub{pullsByNumber: map[int64]github.PullRequest{77: {Number: 77, State: "open"}}}, issues: map[int64]github.Issue{1344: {Number: 1344, State: "closed"}}}
+	if err := (Daemon{Repo: repo, Store: store, GitHub: gh, Now: futureClock}).reconcileTaskDisposals(ctx, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := store.GetTask(ctx, "protected")
+	if got.State != string(workflow.TaskStranded) || !strings.Contains(got.DisposalReason, "awaiting_human_merge is protected") {
+		t.Fatalf("protected task = %+v", got)
+	}
+}
+
+func TestTaskDisposalClosedOwnPRDoesNotMasqueradeAsClosedIssue(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	if err := store.UpsertTask(ctx, db.Task{ID: "closed-pr-open-issue", RepoFullName: repo.FullName(), State: string(workflow.TaskBlocked), Branch: "feature/closed-pr"}); err != nil {
+		t.Fatal(err)
+	}
+	seedTaskDisposalJob(t, store, "job-closed-pr", "closed-pr-open-issue", repo.FullName(), "feature/closed-pr", 78, "Implement issue #1344")
+	gh := &taskDisposalGitHub{
+		fakeGitHub: &fakeGitHub{pullsByNumber: map[int64]github.PullRequest{78: {Number: 78, State: "closed"}}},
+		issues:     map[int64]github.Issue{1344: {Number: 1344, State: "open"}},
+	}
+	if err := (Daemon{Repo: repo, Store: store, GitHub: gh, Now: futureClock}).reconcileTaskDisposals(ctx, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := store.GetTask(ctx, "closed-pr-open-issue")
+	if got.State != string(workflow.TaskStranded) || got.DisposalTier != taskDisposalTierStranded {
+		t.Fatalf("closed own PR incorrectly substituted for open issue state: %+v", got)
+	}
+}
+
+func TestTaskDisposalUnresolvableTerminatesAndPassContinues(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	for _, task := range []db.Task{
+		{ID: "task-unavailable", RepoFullName: repo.FullName(), State: string(workflow.TaskBlocked), Branch: "feature/unavailable"},
+		{ID: "task-later", RepoFullName: repo.FullName(), State: string(workflow.TaskBlocked), Branch: "feature/later"},
+	} {
+		if err := store.UpsertTask(ctx, task); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedTaskDisposalJob(t, store, "job-unavailable", "task-unavailable", repo.FullName(), "feature/unavailable", 90, "Implement issue #1400")
+	seedTaskDisposalJob(t, store, "job-later", "task-later", repo.FullName(), "feature/later", 0, "Implement issue #1401")
+	gh := &taskDisposalGitHub{fakeGitHub: &fakeGitHub{pullsByNumber: map[int64]github.PullRequest{}}, issues: map[int64]github.Issue{1401: {Number: 1401, State: "closed"}}}
+	if err := (Daemon{Repo: repo, Store: store, GitHub: gh, Now: futureClock}).reconcileTaskDisposals(ctx, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	stranded, err := store.ListTasksByRepoState(ctx, repo.FullName(), string(workflow.TaskStranded))
+	if err != nil || len(stranded) != 1 || stranded[0].ID != "task-unavailable" || !strings.Contains(stranded[0].DisposalReason, taskDisposalReasonUnavailable) {
+		t.Fatalf("stranded query = %+v, err=%v", stranded, err)
+	}
+	blocked, err := store.ListTasksByRepoState(ctx, repo.FullName(), string(workflow.TaskBlocked))
+	if err != nil || len(blocked) != 0 {
+		t.Fatalf("blocked query after disposal = %+v, err=%v", blocked, err)
+	}
+	later, _ := store.GetTask(ctx, "task-later")
+	if later.State != string(workflow.TaskSuperseded) {
+		t.Fatalf("later task was starved by prior failure: %+v", later)
+	}
+}
+
+func TestTaskDisposalStrandedEscalationIsOneShotAndRoutingIndependent(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	paths := config.Paths{Home: strings.TrimSuffix(store.DatabasePath(), "/gitmoot.db"), ConfigFile: taskDisposalConfigPath(store)}
+	// The task was owned by lane, but that seat has left the chart. Disposal must
+	// still terminate and route to the live repo root instead of retrying forever.
+	if err := os.WriteFile(paths.ConfigFile, []byte("[org.roles.\"owner\"]\nscope=[\"*\"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-routed", RepoFullName: repo.FullName(), State: string(workflow.TaskBlocked), Branch: "feature/routed"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateLock(ctx, db.BranchLock{RepoFullName: repo.FullName(), Branch: "feature/routed", Owner: "worker", ActingOrgRole: "lane"}); err != nil {
+		t.Fatal(err)
+	}
+	gh := &taskDisposalGitHub{fakeGitHub: &fakeGitHub{}, issues: map[int64]github.Issue{}}
+	d := Daemon{Repo: repo, Store: store, GitHub: gh, Now: futureClock}
+	for i := 0; i < 3; i++ {
+		if err := d.reconcileTaskDisposals(ctx, time.Hour); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, _ := store.GetTask(ctx, "task-routed")
+	if got.State != string(workflow.TaskStranded) || got.DisposalEscalationRole != "owner" {
+		t.Fatalf("routed stranded task = %+v", got)
+	}
+	stranded, err := store.ListTasksByRepoState(ctx, repo.FullName(), string(workflow.TaskStranded))
+	if err != nil || len(stranded) != 1 || stranded[0].ID != "task-routed" {
+		t.Fatalf("stranded query after three sweeps = %+v, err=%v", stranded, err)
+	}
+	blocked, err := store.ListTasksByRepoState(ctx, repo.FullName(), string(workflow.TaskBlocked))
+	if err != nil || len(blocked) != 0 {
+		t.Fatalf("blocked query after three sweeps = %+v, err=%v", blocked, err)
+	}
+	outbox, err := store.ListWakeOutbox(ctx, "")
+	if err != nil || len(outbox) != 1 || outbox[0].TargetRole != "owner" || outbox[0].SourceKind != db.WakeOutboxSourceEscalation {
+		t.Fatalf("terminal escalation outbox = %+v, err=%v", outbox, err)
+	}
+}
+
+func TestPollOnceTaskDisposalTerminatesBeforeForgeListFailure(t *testing.T) {
+	ctx := context.Background()
+	store := testStore(t)
+	repo := github.Repository{Owner: "owner", Name: "repo"}
+	seedStaleRepo(t, store, repo)
+	writeStaleTaskConfig(t, store, "1h")
+	if err := store.UpsertTask(ctx, db.Task{ID: "past-ttl", RepoFullName: repo.FullName(), State: string(workflow.TaskBlocked)}); err != nil {
+		t.Fatal(err)
+	}
+	client := &taskDisposalGitHub{
+		fakeGitHub: &fakeGitHub{listPullRequestsErrs: []error{errors.New("forge unavailable")}},
+		issues:     map[int64]github.Issue{},
+	}
+	err := (Daemon{Repo: repo, Store: store, GitHub: client, Now: futureClock}).PollOnce(ctx)
+	if err == nil || !strings.Contains(err.Error(), "forge unavailable") {
+		t.Fatalf("PollOnce error = %v", err)
+	}
+	stranded, queryErr := store.ListTasksByRepoState(ctx, repo.FullName(), string(workflow.TaskStranded))
+	if queryErr != nil || len(stranded) != 1 || stranded[0].ID != "past-ttl" ||
+		!strings.Contains(stranded[0].DisposalReason, taskDisposalReasonNoEvidence) {
+		t.Fatalf("stranded query after forge failure = %+v, err=%v", stranded, queryErr)
+	}
+	blocked, queryErr := store.ListTasksByRepoState(ctx, repo.FullName(), string(workflow.TaskBlocked))
+	if queryErr != nil || len(blocked) != 0 {
+		t.Fatalf("blocked query after forge failure = %+v, err=%v", blocked, queryErr)
+	}
+}
+
+func seedTaskDisposalJob(t *testing.T, store *db.Store, id, taskID, repo, branch string, pullRequest int, instructions string) {
+	t.Helper()
+	payload, err := json.Marshal(workflow.JobPayload{TaskID: taskID, Repo: repo, Branch: branch, PullRequest: pullRequest, Instructions: instructions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CreateJob(context.Background(), db.Job{ID: id, Type: "implement", State: string(workflow.JobSucceeded), Payload: string(payload)}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setTaskUpdatedAt(t *testing.T, store *db.Store, taskID string, at time.Time) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`UPDATE tasks SET updated_at = ? WHERE id = ?`, at.UTC().Format("2006-01-02 15:04:05"), taskID); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/db/org_blocked_episodes.go
+++ b/internal/db/org_blocked_episodes.go
@@ -20,9 +20,11 @@ const BlockedEpisodeTimeLayout = "2006-01-02T15:04:05.000000000Z"
 // interval while the condition persists (self-healing against a dropped wake)
 // rather than firing a single durable one-shot.
 type BlockedEpisode struct {
-	Subject      string `json:"subject"`
-	BlockedSince string `json:"blocked_since"`
-	EmittedAt    string `json:"emitted_at,omitempty"`
+	Subject         string `json:"subject"`
+	BlockedSince    string `json:"blocked_since"`
+	EmittedAt       string `json:"emitted_at,omitempty"`
+	TaskEmitCount   int    `json:"task_emit_count,omitempty"`
+	TaskExhaustedAt string `json:"task_exhausted_at,omitempty"`
 	// UpdatedAt is the last instant the subject matched its condition (refreshed on
 	// every UpsertBlockedEpisode). The role evaluator reaps an episode whose
 	// UpdatedAt has gone stale — the subject stopped matching — which
@@ -59,6 +61,31 @@ func (s *Store) MarkBlockedEpisodeEmitted(ctx context.Context, subject string, a
 	return err
 }
 
+// MarkBlockedTaskEpisodeEmitted advances the finite alert ladder for a task
+// episode. The count and exhaustion stamp are durable so daemon restarts cannot
+// reset the ladder. A previously exhausted or concurrently changed row is an
+// idempotent no-op.
+func (s *Store) MarkBlockedTaskEpisodeEmitted(ctx context.Context, subject string, expectedCount, maxEmits int, at time.Time) (int, bool, error) {
+	if maxEmits <= 0 {
+		return expectedCount, false, errors.New("blocked task max emits must be positive")
+	}
+	stamp := at.UTC().Format(BlockedEpisodeTimeLayout)
+	result, err := s.db.ExecContext(ctx, `UPDATE org_blocked_episodes
+		SET emitted_at = ?, updated_at = ?, task_emit_count = task_emit_count + 1,
+			task_exhausted_at = CASE WHEN task_emit_count + 1 >= ? THEN ? ELSE task_exhausted_at END
+		WHERE subject = ? AND task_emit_count = ? AND task_exhausted_at = ''`,
+		stamp, stamp, maxEmits, stamp, strings.TrimSpace(subject), expectedCount)
+	if err != nil {
+		return expectedCount, false, err
+	}
+	changed, err := result.RowsAffected()
+	if err != nil || changed == 0 {
+		return expectedCount, false, err
+	}
+	newCount := expectedCount + 1
+	return newCount, newCount >= maxEmits, nil
+}
+
 // ClearBlockedEpisode closes a blocked episode. Deleting a missing row is an
 // idempotent no-op.
 func (s *Store) ClearBlockedEpisode(ctx context.Context, subject string) error {
@@ -68,7 +95,8 @@ func (s *Store) ClearBlockedEpisode(ctx context.Context, subject string) error {
 
 // ListBlockedEpisodes returns every open episode in stable subject order.
 func (s *Store) ListBlockedEpisodes(ctx context.Context) ([]BlockedEpisode, error) {
-	return s.queryBlockedEpisodes(ctx, `SELECT subject, blocked_since, COALESCE(emitted_at, ''), updated_at
+	return s.queryBlockedEpisodes(ctx, `SELECT subject, blocked_since, COALESCE(emitted_at, ''),
+			task_emit_count, task_exhausted_at, updated_at
 		FROM org_blocked_episodes ORDER BY subject`)
 }
 
@@ -81,7 +109,8 @@ func (s *Store) queryBlockedEpisodes(ctx context.Context, query string, args ...
 	result := []BlockedEpisode{}
 	for rows.Next() {
 		var episode BlockedEpisode
-		if err := rows.Scan(&episode.Subject, &episode.BlockedSince, &episode.EmittedAt, &episode.UpdatedAt); err != nil {
+		if err := rows.Scan(&episode.Subject, &episode.BlockedSince, &episode.EmittedAt,
+			&episode.TaskEmitCount, &episode.TaskExhaustedAt, &episode.UpdatedAt); err != nil {
 			return nil, err
 		}
 		result = append(result, episode)

--- a/internal/db/store_migrations.go
+++ b/internal/db/store_migrations.go
@@ -1922,4 +1922,21 @@ CREATE INDEX idx_awaited_facts_waiting_deadline
 	ON awaited_facts(deadline, id)
 	WHERE state = 'waiting';
 	`,
+	// #1344 evidence-based task disposal. The task columns keep the terminal
+	// outcome and notification-routing result queryable; the episode columns cap
+	// blocked alerts independently without disposing the task. Empty/zero defaults
+	// preserve every pre-migration row. Append-only tail; migrations are positional
+	// and this entry must never be inserted earlier in the slice.
+	`
+ALTER TABLE tasks ADD COLUMN disposal_tier TEXT NOT NULL DEFAULT '';
+ALTER TABLE tasks ADD COLUMN disposal_reason TEXT NOT NULL DEFAULT '';
+ALTER TABLE tasks ADD COLUMN disposal_at TEXT NOT NULL DEFAULT '';
+ALTER TABLE tasks ADD COLUMN disposal_escalation_role TEXT NOT NULL DEFAULT '';
+ALTER TABLE org_blocked_episodes ADD COLUMN task_emit_count INTEGER NOT NULL DEFAULT 0
+	CHECK(task_emit_count >= 0);
+ALTER TABLE org_blocked_episodes ADD COLUMN task_exhausted_at TEXT NOT NULL DEFAULT '';
+CREATE INDEX idx_tasks_disposal_candidates
+	ON tasks(repo_full_name, state, updated_at, id)
+	WHERE state IN ('blocked', 'awaiting_human_merge');
+	`,
 }

--- a/internal/db/store_tasks.go
+++ b/internal/db/store_tasks.go
@@ -218,11 +218,20 @@ func (s *Store) UpsertTask(ctx context.Context, task Task) error {
 	return upsertTask(ctx, s.db, task)
 }
 
-// UpsertTaskUnlessState applies the normal task upsert unless an existing row
-// is currently in forbiddenState. The predicate lives on the conflict UPDATE so
+// UpsertTaskUnlessStates applies the normal task upsert unless an existing row
+// is currently in a forbidden state. The predicate lives on the conflict UPDATE so
 // callers that must not resurrect a terminal task remain safe if its state
 // changes after their initial read.
-func (s *Store) UpsertTaskUnlessState(ctx context.Context, task Task, forbiddenState string) (bool, error) {
+func (s *Store) UpsertTaskUnlessStates(ctx context.Context, task Task, forbiddenStates []string) (bool, error) {
+	if len(forbiddenStates) == 0 {
+		return false, errors.New("at least one forbidden task state is required")
+	}
+	placeholders := make([]string, 0, len(forbiddenStates))
+	args := []any{task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch, task.WorktreePath}
+	for _, state := range forbiddenStates {
+		placeholders = append(placeholders, "?")
+		args = append(args, strings.TrimSpace(state))
+	}
 	result, err := s.db.ExecContext(ctx, `INSERT INTO tasks(id, repo_full_name, goal_id, title, state, branch, worktree_path, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		ON CONFLICT(id) DO UPDATE SET
@@ -236,9 +245,7 @@ func (s *Store) UpsertTaskUnlessState(ctx context.Context, task Task, forbiddenS
 				ELSE tasks.worktree_path
 			END,
 			updated_at = CURRENT_TIMESTAMP
-		WHERE tasks.state <> ?`,
-		task.ID, task.RepoFullName, task.GoalID, task.Title, task.State, task.Branch, task.WorktreePath,
-		strings.TrimSpace(forbiddenState))
+		WHERE tasks.state NOT IN (`+strings.Join(placeholders, ",")+`)`, args...)
 	if err != nil {
 		return false, err
 	}
@@ -489,6 +496,66 @@ func (s *Store) TransitionTaskStateWithEventIfNoActiveJob(ctx context.Context, t
 	return changed, currentState, err
 }
 
+// DisposeTask atomically records an evidence-based terminal task disposition,
+// its audit event, and (when routable) the single durable terminal escalation.
+// Notification routing never controls whether the row terminates: an empty
+// escalation role is recorded on the task and the state transition still commits.
+func (s *Store) DisposeTask(ctx context.Context, taskID string, fromStates []string, to, tier, reason, escalationRole, escalationEvent string, at time.Time) (bool, string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, "", err
+	}
+	defer tx.Rollback()
+
+	var current string
+	if err := tx.QueryRowContext(ctx, `SELECT state FROM tasks WHERE id = ?`, strings.TrimSpace(taskID)).Scan(&current); err != nil {
+		return false, "", err
+	}
+	allowed := false
+	for _, state := range fromStates {
+		if current == strings.TrimSpace(state) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return false, current, tx.Commit()
+	}
+	stamp := at.UTC().Format(time.RFC3339Nano)
+	result, err := tx.ExecContext(ctx, `UPDATE tasks
+		SET state = ?, disposal_tier = ?, disposal_reason = ?, disposal_at = ?,
+			disposal_escalation_role = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE id = ? AND state = ?`,
+		strings.TrimSpace(to), strings.TrimSpace(tier), strings.TrimSpace(reason), stamp,
+		strings.ToLower(strings.TrimSpace(escalationRole)), strings.TrimSpace(taskID), current)
+	if err != nil {
+		return false, current, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return false, current, err
+	}
+	if affected != 1 {
+		return false, current, tx.Commit()
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO task_events(task_id, kind, from_state, to_state, reason)
+		VALUES (?, ?, ?, ?, ?)`, strings.TrimSpace(taskID), "task_disposed_"+strings.TrimSpace(tier), current, strings.TrimSpace(to), strings.TrimSpace(reason)); err != nil {
+		return false, current, err
+	}
+	if role := strings.ToLower(strings.TrimSpace(escalationRole)); role != "" {
+		if strings.TrimSpace(escalationEvent) == "" {
+			return false, current, errors.New("task disposal escalation event is required for a routed escalation")
+		}
+		if err := insertWakeOutboxTx(ctx, tx, WakeOutboxSourceEscalation, escalationEvent, WakeOutboxKindEscalation, role); err != nil {
+			return false, current, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return false, current, err
+	}
+	return true, strings.TrimSpace(to), nil
+}
+
 func (s *Store) transitionTaskStateWithEvent(ctx context.Context, taskID string, fromStates []string, to string, kind string, reason string, rejectActiveJob bool) (changed bool, observedState string, currentState string, err error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -575,14 +642,16 @@ func activeJobMatchingTaskTx(ctx context.Context, tx *sql.Tx, taskID string, rep
 
 func scanTask(row interface{ Scan(dest ...any) error }) (Task, error) {
 	var task Task
-	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch, &task.WorktreePath); err != nil {
+	if err := row.Scan(&task.ID, &task.RepoFullName, &task.GoalID, &task.Title, &task.State, &task.Branch, &task.WorktreePath,
+		&task.UpdatedAt, &task.DisposalTier, &task.DisposalReason, &task.DisposedAt, &task.DisposalEscalationRole); err != nil {
 		return Task{}, err
 	}
 	return task, nil
 }
 
 func taskSelectSQL() string {
-	return `SELECT id, repo_full_name, goal_id, title, state, branch, worktree_path`
+	return `SELECT id, repo_full_name, goal_id, title, state, branch, worktree_path, updated_at,
+		disposal_tier, disposal_reason, disposal_at, disposal_escalation_role`
 }
 
 func (s *Store) UpsertPullRequest(ctx context.Context, pr PullRequest) error {

--- a/internal/db/store_types.go
+++ b/internal/db/store_types.go
@@ -169,13 +169,18 @@ type Goal struct {
 }
 
 type Task struct {
-	ID           string
-	RepoFullName string
-	GoalID       string
-	Title        string
-	State        string
-	Branch       string
-	WorktreePath string
+	ID                     string
+	RepoFullName           string
+	GoalID                 string
+	Title                  string
+	State                  string
+	Branch                 string
+	WorktreePath           string
+	UpdatedAt              string
+	DisposalTier           string
+	DisposalReason         string
+	DisposedAt             string
+	DisposalEscalationRole string
 }
 
 // TaskEvent is one append-only task lifecycle transition. FromState and

--- a/internal/db/task_disposal_store_test.go
+++ b/internal/db/task_disposal_store_test.go
@@ -1,0 +1,46 @@
+package db
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTaskDisposalMigrationIsAppendOnlyTail(t *testing.T) {
+	if len(migrations) < 2 {
+		t.Fatalf("migrations length = %d", len(migrations))
+	}
+	tail := migrations[len(migrations)-1]
+	if !strings.Contains(tail, "disposal_tier") || !strings.Contains(tail, "idx_tasks_disposal_candidates") ||
+		!strings.Contains(tail, "task_emit_count") || !strings.Contains(tail, "task_exhausted_at") {
+		t.Fatalf("last migration is not #1344 task disposal migration")
+	}
+	if !strings.Contains(migrations[len(migrations)-2], "CREATE TABLE awaited_facts") {
+		t.Fatalf("#1368 awaited-facts migration was not preserved immediately before the new tail")
+	}
+}
+
+func TestTaskDisposalStatesCannotBeOverwrittenByConditionalUpsert(t *testing.T) {
+	for _, terminal := range []string{"superseded", "stranded"} {
+		t.Run(terminal, func(t *testing.T) {
+			store, err := Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			ctx := context.Background()
+			if err := store.UpsertTask(ctx, Task{ID: "task-terminal", State: terminal}); err != nil {
+				t.Fatal(err)
+			}
+			changed, err := store.UpsertTaskUnlessStates(ctx, Task{ID: "task-terminal", State: "reviewing"}, []string{"dismissed", "superseded", "stranded"})
+			if err != nil || changed {
+				t.Fatalf("conditional upsert changed=%v err=%v", changed, err)
+			}
+			got, _ := store.GetTask(ctx, "task-terminal")
+			if got.State != terminal {
+				t.Fatalf("task state = %q, want %q", got.State, terminal)
+			}
+		})
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -654,6 +654,23 @@ func (c *GhClient) ListIssues(ctx context.Context, repo Repository, state string
 	return filtered, nil
 }
 
+// GetIssue returns one canonical issue row. It is intentionally a concrete
+// capability rather than part of Client: task disposal discovers it through a
+// narrow optional interface, avoiding a repository-wide widening of test fakes.
+func (c *GhClient) GetIssue(ctx context.Context, repo Repository, number int64) (Issue, error) {
+	if number <= 0 {
+		return Issue{}, fmt.Errorf("issue number must be positive")
+	}
+	var issue Issue
+	if err := c.apiJSON(ctx, false, &issue, endpoint(repo, "issues", number)); err != nil {
+		return Issue{}, err
+	}
+	if issue.IsPullRequest {
+		return Issue{}, fmt.Errorf("%s#%d is a pull request, not an issue", repo.FullName(), number)
+	}
+	return issue, nil
+}
+
 func (c *GhClient) GetPullRequest(ctx context.Context, repo Repository, number int64) (PullRequest, error) {
 	return c.getPullRequest(ctx, repo, number)
 }

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -402,6 +402,24 @@ func TestListIssuesFiltersOutPullRequests(t *testing.T) {
 	runner.wantArgs(t, 0, "api", "-i", "-X", "GET", "repos/gitmoot/gitmoot/issues", "-f", "state=open", "-f", "per_page=100")
 }
 
+func TestGetIssueReturnsCanonicalIssueAndRejectsPullRequest(t *testing.T) {
+	repo := Repository{Owner: "gitmoot", Name: "gitmoot"}
+	t.Run("issue", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"number":42,"title":"Task disposal","state":"closed","html_url":"https://github.com/gitmoot/gitmoot/issues/42"}`}}}
+		issue, err := (&GhClient{Runner: runner}).GetIssue(context.Background(), repo, 42)
+		if err != nil || issue.Number != 42 || issue.State != "closed" || issue.IsPullRequest {
+			t.Fatalf("GetIssue = %+v, err=%v", issue, err)
+		}
+		runner.wantArgs(t, 0, "api", "repos/gitmoot/gitmoot/issues/42")
+	})
+	t.Run("pull request", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: `{"number":43,"state":"closed","pull_request":{"url":"https://api.github.com/repos/gitmoot/gitmoot/pulls/43"}}`}}}
+		if _, err := (&GhClient{Runner: runner}).GetIssue(context.Background(), repo, 43); err == nil || !strings.Contains(err.Error(), "pull request, not an issue") {
+			t.Fatalf("GetIssue(PR) error = %v", err)
+		}
+	})
+}
+
 func TestPreflightChecksGhAuthAndRepoAccess(t *testing.T) {
 	runner := &fakeRunner{
 		results: []subprocess.Result{

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -393,8 +393,8 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 		return err
 	}
 	if err == nil {
-		if existing.State == string(TaskDismissed) && state != TaskDismissed {
-			return fmt.Errorf("task %s is dismissed; workflow advancement cannot move it to %s", existing.ID, state)
+		if IsDisposedTaskState(existing.State) && existing.State != string(state) {
+			return fmt.Errorf("task %s is %s; workflow advancement cannot move it to %s", existing.ID, existing.State, state)
 		}
 		if task.GoalID == "" {
 			task.GoalID = existing.GoalID
@@ -422,8 +422,8 @@ func (e Engine) setTaskState(ctx context.Context, ref taskRef, state TaskState) 
 			return berr
 		}
 		if berr == nil && byBranch.ID != task.ID {
-			if byBranch.State == string(TaskDismissed) && state != TaskDismissed {
-				return fmt.Errorf("task %s is dismissed; workflow advancement cannot move it to %s", byBranch.ID, state)
+			if IsDisposedTaskState(byBranch.State) && byBranch.State != string(state) {
+				return fmt.Errorf("task %s is %s; workflow advancement cannot move it to %s", byBranch.ID, byBranch.State, state)
 			}
 			byBranch.State = string(state)
 			return e.Store.UpsertTask(ctx, byBranch)

--- a/internal/workflow/set_task_state_branch_test.go
+++ b/internal/workflow/set_task_state_branch_test.go
@@ -86,3 +86,33 @@ func TestSetTaskStateCannotResurrectDismissedTask(t *testing.T) {
 		t.Fatalf("task resurrected to %s", task.State)
 	}
 }
+
+func TestSetTaskStateCannotResurrectEvidenceDisposedTask(t *testing.T) {
+	for _, terminal := range []TaskState{TaskSuperseded, TaskStranded} {
+		t.Run(string(terminal), func(t *testing.T) {
+			store, err := db.Open(filepath.Join(t.TempDir(), "gitmoot.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			ctx := context.Background()
+			branch := "feature/" + string(terminal)
+			if err := store.UpsertTask(ctx, db.Task{ID: "canonical", RepoFullName: "owner/repo", State: string(terminal), Branch: branch}); err != nil {
+				t.Fatal(err)
+			}
+			engine := Engine{Store: store}
+			for _, ref := range []taskRef{
+				{ID: "canonical", Repo: "owner/repo", Branch: branch},
+				{ID: "late-review", Repo: "owner/repo", Branch: branch},
+			} {
+				if err := engine.setTaskState(ctx, ref, TaskReviewing); err == nil || !strings.Contains(err.Error(), string(terminal)) {
+					t.Fatalf("setTaskState(%+v) error = %v", ref, err)
+				}
+			}
+			stored, _ := store.GetTask(ctx, "canonical")
+			if stored.State != string(terminal) {
+				t.Fatalf("task resurrected to %s", stored.State)
+			}
+		})
+	}
+}

--- a/internal/workflow/types.go
+++ b/internal/workflow/types.go
@@ -10,6 +10,8 @@ const (
 	TaskChangesRequested TaskState = "changes_requested"
 	TaskReadyToMerge     TaskState = "ready_to_merge"
 	TaskMerged           TaskState = "merged"
+	TaskSuperseded       TaskState = "superseded"
+	TaskStranded         TaskState = "stranded"
 	TaskBlocked          TaskState = "blocked"
 	// TaskAwaitingHumanMerge parks an otherwise-ready pull request for a human
 	// merge. It is intentionally distinct from TaskBlocked and TaskAwaitingHuman:
@@ -24,6 +26,18 @@ const (
 	// it via `/gitmoot resume <jobID> retry|continue|abort`.
 	TaskAwaitingHuman TaskState = "awaiting_human"
 )
+
+// IsDisposedTaskState reports terminal disposal outcomes that ordinary workflow
+// advancement must never resurrect. Dismissed retains its explicit recovery
+// path; superseded and stranded are evidence/audit outcomes requiring a new task.
+func IsDisposedTaskState(state string) bool {
+	switch TaskState(state) {
+	case TaskDismissed, TaskSuperseded, TaskStranded:
+		return true
+	default:
+		return false
+	}
+}
 
 type JobState string
 

--- a/internal/workflow/worktree.go
+++ b/internal/workflow/worktree.go
@@ -178,6 +178,9 @@ func (e Engine) AllocateTaskWorktree(ctx context.Context, request TaskWorktreeRe
 	if task.State == string(TaskDismissed) {
 		return db.Task{}, fmt.Errorf("task %s is dismissed; recover it explicitly before allocating a worktree", request.TaskID)
 	}
+	if task.State == string(TaskSuperseded) || task.State == string(TaskStranded) {
+		return db.Task{}, fmt.Errorf("task %s is %s; create a successor task before allocating a worktree", request.TaskID, task.State)
+	}
 	if task.State == string(TaskAwaitingHumanMerge) {
 		return db.Task{}, fmt.Errorf("task %s is awaiting a human merge decision; resolve it before allocating a worktree", request.TaskID)
 	}

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -134,6 +134,27 @@ func TestEngineAllocateTaskWorktreeRejectsDismissedTask(t *testing.T) {
 	}
 }
 
+func TestEngineAllocateTaskWorktreeRejectsEvidenceDisposedTask(t *testing.T) {
+	for _, terminal := range []TaskState{TaskSuperseded, TaskStranded} {
+		t.Run(string(terminal), func(t *testing.T) {
+			ctx := context.Background()
+			store := openEngineStore(t)
+			branch := "feature/" + string(terminal)
+			if err := store.UpsertTask(ctx, db.Task{ID: "task-terminal", RepoFullName: "owner/repo", State: string(terminal), Branch: branch, WorktreePath: "/tmp/preserved"}); err != nil {
+				t.Fatal(err)
+			}
+			manager := &fakeWorktreeManager{}
+			_, err := testEngine(store).AllocateTaskWorktree(ctx, TaskWorktreeRequest{Home: t.TempDir(), Repo: "owner/repo", TaskID: "task-terminal", Branch: branch, Owner: "lead"}, manager)
+			if err == nil || !strings.Contains(err.Error(), string(terminal)) {
+				t.Fatalf("AllocateTaskWorktree error = %v", err)
+			}
+			if len(manager.calls) != 0 {
+				t.Fatalf("manager calls = %+v", manager.calls)
+			}
+		})
+	}
+}
+
 func TestEngineAllocateTaskWorktreeRejectsAwaitingHumanMergeTask(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1701,6 +1701,7 @@ Start a task in its dedicated branch worktree and inspect task state:
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task list --repo owner/repo
 gitmoot task list --repo owner/repo --state implementing --json
+gitmoot task list --repo owner/repo --state stranded --json
 gitmoot task dismiss task-001 --reason "abandoned experiment"
 gitmoot task resume-work task-001 --reason "review requires another fix pass"
 gitmoot task resume-work task-001 --reason "withdraw pending merge" --override-pending-human-decision
@@ -1719,6 +1720,16 @@ the task worktree also blocks dismissal. The default reason is `dismissed by
 operator`. Success preserves the branch and worktree, releases the branch lock
 best-effort, and appends `task_dismissed_manual` to `task events`. Repeating the
 command is an exit-0 no-op with `changed:false` in JSON.
+
+Past `[workflow].stale_task_ttl`, blocked tasks are disposed by forge evidence:
+own merged PR (`merged`), later merged work on the same referenced issue
+(`superseded`), closed subject (`superseded`), then the bounded `stranded`
+fallback. The JSON list includes `disposal_tier`, `disposal_reason`,
+`disposed_at`, and `disposal_escalation_role`. The pass never uses branch
+ancestry, and an open `awaiting_human_merge` PR is not inferred complete.
+Blocked-task alerts have their own finite ladder: after three interval-spaced
+nudges Gitmoot emits one terminal escalation and stops nagging. The task remains
+queryable until the separate evidence-disposal pass transitions it.
 
 `task resume-work` is the explicit coordinator-only path for taking an orphaned
 `reviewing` or `ready_to_merge` task back into development, or for withdrawing a

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -743,7 +743,7 @@ released best-effort. Manual and daemon transitions are audited as
 `task_dismissed_manual` and `task_dismissed_auto` in `gitmoot task events <id>`.
 
 Each repo poll reads a bounded oldest-first stale window and processes up to 20
-qualifying `implementing`/`blocked` tasks whose `updated_at` predates
+qualifying `implementing` tasks whose `updated_at` predates
 `[workflow].stale_task_ttl` (default `168h`; `"0"` disables the leg).
 `updated_at` is deliberately a conservative activity proxy, not proof of
 abandonment. A candidate is skipped for a live job, a same-repo open-PR branch,
@@ -752,6 +752,22 @@ mutation. A branchless candidate needs no remote lookup. Explicit `task
 recover` restores preserved artifacts through `implementing` to `pr_open`, or
 restores a branchless task to `planned`; job retry records its own recovery
 event. The server-side task board omits dismissed rows immediately.
+
+`blocked` and `awaiting_human_merge` use a separate evidence-based disposal
+ladder at that TTL: own PR merged -> `merged`; a later merged task/PR on the same
+referenced issue -> `superseded`; referenced issue/PR closed -> `superseded`;
+otherwise -> terminal `stranded`. Git ancestry is never evidence because a
+superseding branch need not be an ancestor of main. An open
+`awaiting_human_merge` PR stays protected and reaches `stranded` for human
+inspection. Every outcome records its tier and reason on the task; the stranded
+fallback writes at most one durable escalation, and an unavailable route is
+recorded without keeping the task alive. Query with `gitmoot task list --state
+stranded --json`.
+
+The periodic blocked-task alert is bounded independently: three
+interval-separated nudges, one terminal escalation, then no further alerts for
+that episode. Its persisted exhausted stamp does not dispose the task; disposal
+still requires the evidence ladder or its TTL fallback.
 
 Delegation worktrees use a separate default-on retention policy:
 `[workflow].delegation_worktree_ttl = "72h"` (`"0"` disables it). Only final

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1510,6 +1510,7 @@ Start a task in its dedicated branch worktree and inspect task state:
 gitmoot task run task-001 --repo owner/repo --owner lead --base main
 gitmoot task list --repo owner/repo
 gitmoot task list --repo owner/repo --state implementing --json
+gitmoot task list --repo owner/repo --state stranded --json
 gitmoot task dismiss task-001 --reason "abandoned experiment"
 gitmoot task resume-work task-001 --reason "review requires another fix pass"
 gitmoot task resume-work task-001 --reason "withdraw pending merge" --override-pending-human-decision
@@ -1530,6 +1531,17 @@ including daemon `task_dismissed_auto`, opt-in
 `task_dismissed_planned_ttl`, closed-unmerged `pr_closed_unmerged`, terminal
 top-level implement triage (`task_blocked_terminal_no_pr` or
 `task_blocked_job_failed`), and explicit recovery events.
+
+Past `[workflow].stale_task_ttl`, blocked tasks follow an evidence ladder: own
+merged PR (`merged`), later merged work on the same referenced issue
+(`superseded`), closed subject (`superseded`), then terminal `stranded`. No tier
+uses git ancestry. An open `awaiting_human_merge` PR remains protected and lands
+in the visible `stranded` queue. JSON task rows expose `disposal_tier`,
+`disposal_reason`, `disposed_at`, and `disposal_escalation_role`; an unroutable
+terminal escalation is recorded without keeping the task alive.
+The blocked-task alert has a separate finite ladder: three interval-spaced
+nudges, one terminal escalation, then no further alerts while the task remains
+queryable. Only the evidence-disposal pass transitions task state.
 
 `task resume-work` is an explicit coordinator-only return to development from
 `reviewing`, `ready_to_merge`, or `awaiting_human_merge`. It requires `--reason`,
@@ -1590,7 +1602,7 @@ record `stale_worktree_dirty_blocked`; manually salvage, commit, stash, or clean
 the changes before retrying.
 
 The daemon reads a bounded oldest-first stale window and processes up to 20
-qualifying `implementing`/`blocked` tasks per repo poll.
+qualifying `implementing` tasks per repo poll.
 `[workflow].stale_task_ttl = "168h"` is the default and `"0"` disables the leg.
 `updated_at` is a conservative activity proxy. Live jobs, same-repo open-PR
 branches, branches still present on `origin`, and remote-check uncertainty all


### PR DESCRIPTION
WHAT:
Implemented #1344 on gitmoot/1344-task-disposal. Current pre-finalizer HEAD is 78accd0235eb06c51c982fb8ce06496a66f97deb; Gitmoot will create the final commit and draft PR. Added an append-only migration tail after #1368. CODEX.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-283aaeef

RESULTS:
- PASS: go build ./...
- PASS: bounded daemon, CLI, DB, workflow, and GitHub behavior families; all test commands scrubbed GITMOOT_STALE_RUNNING_AFTER.
- STRENGTH T1 mutant disable own-PR evidence: tier1 failed with state=stranded, want merged.
- STRENGTH T2 mutant disable successor evidence: tier2 failed with state=stranded, want superseded.
- STRENGTH T3 mutant disable closed-subject evidence: tier3 failed with state=stranded, want superseded.
- STRENGTH T4 pre-fix fallback mutant: tier4 remained blocked, want stranded.
- INDEPENDENCE: for each T1-T4 mutant, the other three tier subtests passed in the same verbose run.
- PRE-FIX WIRING mutant removing PollOnce disposal: TestPollOnceTaskDisposalTerminatesBeforeForgeListFailure failed with stranded query=[], proving the call is load-bearing.
- UNBOUNDED ALERT mutant restoring generic recurring marks: TestEvaluateBlockedTaskEpisodesCapsAlertsWithoutDisposingTask failed with job.blocked nudges=4, want capped 3.
- TERMINATION BY QUERY: after three sweeps, TestTaskDisposalStrandedEscalationIsOneShotAndRoutingIndependent found the row under stranded, absent under blocked, and exactly one outbox escalation; TestTaskListQueriesStrandedDisposal verified the CLI state filters.
- PASS: git diff --check; no mutant remnants found.

RISK:
Review the generated diff before merging.

TASK:
adhoc-283aaeef

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented #1344 on gitmoot/1344-task-disposal. Current pre-finalizer HEAD is 78accd0235eb06c51c982fb8ce06496a66f97deb; Gitmoot will create the final commit and draft PR. Added an append-only migration tail after #1368. CODEX.
````
