### PR TITLE
Gitmoot: GITMOOT-COC -> IMPLEMENTER: IMPLEMENT gitmoot#1379 — 4-space-indented code

### DIFF
--- a/internal/daemon/command.go
+++ b/internal/daemon/command.go
@@ -56,6 +56,10 @@ func prepareCommentCommandInput(body string) commentCommandInput {
 	input := commentCommandInput{lines: make([]commentCommandLine, 0, len(lines))}
 	var fence markdownFence
 	for _, line := range lines {
+		if isMarkdownIndentedCodeLine(line) {
+			input.lines = append(input.lines, commentCommandLine{})
+			continue
+		}
 		if fence.marker != 0 {
 			if isMarkdownFenceClose(line, fence) {
 				fence = markdownFence{}
@@ -76,6 +80,27 @@ func prepareCommentCommandInput(body string) commentCommandInput {
 		})
 	}
 	return input
+}
+
+// isMarkdownIndentedCodeLine recognizes CommonMark's older indented-code form.
+// Tabs advance to four-column stops, so a leading tab or spaces followed by a
+// tab can establish the same code indentation as four literal spaces.
+func isMarkdownIndentedCodeLine(line string) bool {
+	column := 0
+	for offset := 0; offset < len(line); offset++ {
+		switch line[offset] {
+		case ' ':
+			column++
+		case '\t':
+			column += 4 - column%4
+		default:
+			return false
+		}
+		if column >= 4 {
+			return true
+		}
+	}
+	return false
 }
 
 func parseCommentCommands(input commentCommandInput, parse func(string) (Command, bool)) []parsedCommentCommand {

--- a/internal/daemon/command_test.go
+++ b/internal/daemon/command_test.go
@@ -80,6 +80,32 @@ func TestParseCommandsOnlyReturnsGitmootLines(t *testing.T) {
 	}
 }
 
+func TestParseCommandsIgnoreIndentedCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantAction string
+	}{
+		{name: "four spaces", body: "    ```\n    /gitmoot status"},
+		{name: "tab", body: "\t```\n\t/gitmoot status"},
+		{name: "unindented command", body: "/gitmoot status", wantAction: "status"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			commands := ParseCommandsWithoutAuthorization(test.body)
+			if test.wantAction == "" {
+				if len(commands) != 0 {
+					t.Fatalf("commands = %+v, want none", commands)
+				}
+				return
+			}
+			if len(commands) != 1 || commands[0].Action != test.wantAction {
+				t.Fatalf("commands = %+v, want one %s command", commands, test.wantAction)
+			}
+		})
+	}
+}
+
 func TestParseJobRecoveryCommands(t *testing.T) {
 	command, ok := ParseCommand("/gitmoot retry job-123")
 	if !ok {

--- a/internal/daemon/comment_command_security_test.go
+++ b/internal/daemon/comment_command_security_test.go
@@ -74,6 +74,48 @@ func TestHandleCommentAuthorizedCommandStillDispatches(t *testing.T) {
 	}
 }
 
+func TestHandleCommentAuthorizedIndentedCodeDoesNotDispatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		indent string
+	}{
+		{name: "four spaces", indent: "    "},
+		{name: "tab", indent: "\t"},
+	}
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, _, client, daemon := commentCommandFixture(t, ctx)
+			client.permissions = map[string]string{"alice": "write"}
+			var parsed []Command
+			daemon.parseCommentCommand = func(line string) (Command, bool) {
+				command, ok := ParseCommand(line)
+				if ok {
+					parsed = append(parsed, command)
+				}
+				return command, ok
+			}
+			pull := github.PullRequest{Number: 10, Title: "Camera design", HeadRef: "camera-state"}
+			comment := github.IssueComment{
+				ID:     int64(5148922250 + index),
+				Author: "alice",
+				Body: "/gitmoot status\n" + test.indent +
+					"@helper ask this indented code must not dispatch",
+			}
+
+			if err := daemon.handleComment(ctx, pull, comment); err != nil {
+				t.Fatalf("handleComment returned error: %v", err)
+			}
+			if len(parsed) != 1 || parsed[0].Action != "status" {
+				t.Fatalf("parsed commands = %+v, want only the unindented status command", parsed)
+			}
+			if jobs, err := store.ListJobs(ctx); err != nil || len(jobs) != 0 {
+				t.Fatalf("indented code jobs = %+v, err=%v, want none", jobs, err)
+			}
+		})
+	}
+}
+
 func TestHandleCommentMixedProseAndAddressedCommandPostsOnlyAck(t *testing.T) {
 	ctx := context.Background()
 	store, repo, client, daemon := commentCommandFixture(t, ctx)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1840,8 +1840,9 @@ retry|continue|abort|answer` resumes a delegation tree paused by
 `references/RESULT_CONTRACT.md` for the pause/resume semantics (`answer` is
 PR-comment-only).
 
-Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks and
-closed inline backtick spans (including single-backtick spans). GitHub must then
+Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks,
+four-space/tab-indented code blocks, and closed inline backtick spans (including
+single-backtick spans). GitHub must then
 report that the comment author currently has `write`, `maintain`, or `admin`
 repository permission; unauthorized addressed commands are rejected without
 parsing their command text. Ordinary prose and code examples produce no reply.

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -1840,9 +1840,27 @@ retry|continue|abort|answer` resumes a delegation tree paused by
 `references/RESULT_CONTRACT.md` for the pause/resume semantics (`answer` is
 PR-comment-only).
 
-Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks,
-four-space/tab-indented code blocks, and closed inline backtick spans (including
-single-backtick spans). GitHub must then
+Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks and
+closed inline backtick spans (including single-backtick spans).
+
+**Symptom: my command in a bulleted list did nothing.** Any command line
+indented by four spaces or a tab is treated as code and will not run, including
+list-item continuation under a bullet or numbered item. For example, this
+command is ignored:
+
+```text
+- Please run:
+
+    @helper ask check the build
+```
+
+Put the command at column zero to run it:
+
+```text
+@helper ask check the build
+```
+
+GitHub must then
 report that the comment author currently has `write`, `maintain`, or `admin`
 repository permission; unauthorized addressed commands are rejected without
 parsing their command text. Ordinary prose and code examples produce no reply.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1665,9 +1665,27 @@ retry|continue|abort|answer` resumes a delegation tree paused by
 [result contract](result-contract.md) for the pause/resume semantics. See also
 the [PR comment workflow](../workflows/pr-comment-workflow.md).
 
-Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks,
-four-space/tab-indented code blocks, and closed inline backtick spans (including
-single-backtick spans). GitHub must then
+Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks and
+closed inline backtick spans (including single-backtick spans).
+
+**Symptom: my command in a bulleted list did nothing.** Any command line
+indented by four spaces or a tab is treated as code and will not run, including
+list-item continuation under a bullet or numbered item. For example, this
+command is ignored:
+
+```text
+- Please run:
+
+    @helper ask check the build
+```
+
+Put the command at column zero to run it:
+
+```text
+@helper ask check the build
+```
+
+GitHub must then
 report that the comment author currently has `write`, `maintain`, or `admin`
 repository permission; unauthorized addressed commands are rejected without
 parsing their command text. Ordinary prose and code examples produce no reply.

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -1665,8 +1665,9 @@ retry|continue|abort|answer` resumes a delegation tree paused by
 [result contract](result-contract.md) for the pause/resume semantics. See also
 the [PR comment workflow](../workflows/pr-comment-workflow.md).
 
-Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks and
-closed inline backtick spans (including single-backtick spans). GitHub must then
+Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks,
+four-space/tab-indented code blocks, and closed inline backtick spans (including
+single-backtick spans). GitHub must then
 report that the comment author currently has `write`, `maintain`, or `admin`
 repository permission; unauthorized addressed commands are rejected without
 parsing their command text. Ordinary prose and code examples produce no reply.

--- a/website/docs/workflows/pr-comment-workflow.md
+++ b/website/docs/workflows/pr-comment-workflow.md
@@ -24,9 +24,27 @@ A bare `@<agent>` mention works as the same command (#389):
 Mentions are also routed on **issue** comments when the daemon runs with
 `--watch-issues` (on issues only the `ask` action is acted on).
 
-Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks,
-four-space/tab-indented code blocks, and closed inline backtick spans (including
-single-backtick spans). GitHub must then
+Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks and
+closed inline backtick spans (including single-backtick spans).
+
+**Symptom: my command in a bulleted list did nothing.** Any command line
+indented by four spaces or a tab is treated as code and will not run, including
+list-item continuation under a bullet or numbered item. For example, this
+command is ignored:
+
+```text
+- Please run:
+
+    @helper ask check the build
+```
+
+Put the command at column zero to run it:
+
+```text
+@helper ask check the build
+```
+
+GitHub must then
 report that the comment author currently has `write`, `maintain`, or `admin`
 repository permission; unauthorized addressed commands are rejected without
 parsing their command text. Ordinary prose and code examples produce no reply.

--- a/website/docs/workflows/pr-comment-workflow.md
+++ b/website/docs/workflows/pr-comment-workflow.md
@@ -24,8 +24,9 @@ A bare `@<agent>` mention works as the same command (#389):
 Mentions are also routed on **issue** comments when the daemon runs with
 `--watch-issues` (on issues only the `ask` action is acted on).
 
-Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks and
-closed inline backtick spans (including single-backtick spans). GitHub must then
+Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks,
+four-space/tab-indented code blocks, and closed inline backtick spans (including
+single-backtick spans). GitHub must then
 report that the comment author currently has `write`, `maintain`, or `admin`
 repository permission; unauthorized addressed commands are rejected without
 parsing their command text. Ordinary prose and code examples produce no reply.

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -11685,7 +11685,26 @@ retry|continue|abort|answer` resumes a delegation tree paused by
 PR-comment-only).
 
 Before parsing, Gitmoot removes triple-backtick and tilde fenced code blocks and
-closed inline backtick spans (including single-backtick spans). GitHub must then
+closed inline backtick spans (including single-backtick spans).
+
+**Symptom: my command in a bulleted list did nothing.** Any command line
+indented by four spaces or a tab is treated as code and will not run, including
+list-item continuation under a bullet or numbered item. For example, this
+command is ignored:
+
+```text
+- Please run:
+
+    @helper ask check the build
+```
+
+Put the command at column zero to run it:
+
+```text
+@helper ask check the build
+```
+
+GitHub must then
 report that the comment author currently has `write`, `maintain`, or `admin`
 repository permission; unauthorized addressed commands are rejected without
 parsing their command text. Ordinary prose and code examples produce no reply.


### PR DESCRIPTION
WHAT:
CODEX: Implemented #1379 on gitmoot/1379-indented-code-blocks. Fast-forwarded the stale branch to current main first. Pre-finalizer HEAD is 2e2100a8c9fa905ae43de1dd819a331364f42beb; Gitmoot will create the final commit/head.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-a52df5fa

RESULTS:
- Required pre-fix revert mutant removed the sole indented-code strip call. Direct parse guard failed: both four-space and tab cases parsed `{Action:status}`.
- Under the same revert mutant, the authorized-handler guard failed: both cases parsed `status` plus a real `ask` command for `helper`.
- The unindented-command case and existing Markdown/authorized-command guards still passed under the revert mutant.
- Tab-only mutant changed tab-stop advancement to one column. Only the tab parse and authorized-handler cases failed; four-space and unindented cases passed.
- Over-filter mutant classified exact unindented `/gitmoot status` as code. The legitimate-command guard failed with `commands = []`; both indented cases and the existing authorized ask guard passed.
- Strength: each semantic regression failed the guard for its claimed behavior.
- Independence: asymmetric tab and over-filter mutants left the other cases passing.
- Each command.go mutant was applied exactly once and restored to SHA-256 c1df2449c706cca8a2ec2440a558a7015ca1f85a1948c7d95c0cf822dfcd38bd.
- Bounded `TestParseCommand|TestParseCommands|TestHandleComment` daemon family: PASS.
- `go build ./internal/daemon/` and `git diff --check`: PASS.

RISK:
Review the generated diff before merging.

TASK:
adhoc-a52df5fa

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
CODEX: Implemented #1379 on gitmoot/1379-indented-code-blocks. Fast-forwarded the stale branch to current main first. Pre-finalizer HEAD is 2e2100a8c9fa905ae43de1dd819a331364f42beb; Gitmoot will create the final commit/head.
````
