### PR TITLE
Gitmoot: GITMOOT-COC -> IMPLEMENTER: IMPLEMENT SLICE 1 (C1) OF

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -709,7 +709,7 @@ func prepareLocalReviewWorktree(ctx context.Context, store *db.Store, record db.
 	}
 	taskID := strings.TrimSpace(request.TaskID)
 	if taskID == "" {
-		taskID = fmt.Sprintf("review-pr-%d-%s", request.PullRequest, shortHash(repo.FullName()+"\x00"+request.HeadSHA))
+		taskID = fmt.Sprintf("review-pr-%d-%s", request.PullRequest, shortHash(repo.FullName()))
 	}
 	if existing, err := store.GetTask(ctx, taskID); err == nil {
 		if existing.State == string(workflow.TaskDismissed) {

--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestStableReviewTaskIdentityLetsSecondRoundVerdictReachGate(t *testing.T) {
+	repoDir, oldHead, newHead := c1ReviewRepository(t)
+	firstTaskID := mintC1ReviewTaskID(t, repoDir, oldHead)
+	secondTaskID := mintC1ReviewTaskID(t, repoDir, newHead)
+
+	decision := evaluateC1GateScenario(t, firstTaskID, secondTaskID, oldHead, newHead, firstTaskID, true)
+	if !decision.Merged {
+		t.Fatalf("second-round verdict did not reach first-round task: first=%q second=%q decision=%+v", firstTaskID, secondTaskID, decision)
+	}
+}
+
+func TestStableReviewTaskIdentityKeepsHeadRoundIsolation(t *testing.T) {
+	const stableTaskID = "review-pr-17-stable"
+	decision := evaluateC1GateScenario(t, stableTaskID, stableTaskID, "old-head", "new-head", stableTaskID, false)
+	if !decision.LeaveOpen || decision.Merged || !strings.Contains(decision.Reason, "different head SHA") {
+		t.Fatalf("wrong-head verdict was not rejected by the head comparison: %+v", decision)
+	}
+}
+
+func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
+	repoDir, oldHead, newHead := c1ReviewRepository(t)
+	stableFirst := mintC1ReviewTaskID(t, repoDir, oldHead)
+	stableSecond := mintC1ReviewTaskID(t, repoDir, newHead)
+	legacyFirst := fmt.Sprintf("review-pr-%d-%s", 17, shortHash("owner/repo\x00"+oldHead))
+	legacySecond := fmt.Sprintf("review-pr-%d-%s", 17, shortHash("owner/repo\x00"+newHead))
+
+	for _, tc := range []struct {
+		name            string
+		implementTaskID string
+		reviewTaskID    string
+		wantAgents      int
+		wantFailClosed  bool
+	}{
+		{name: "before_C1", implementTaskID: legacyFirst, reviewTaskID: legacySecond, wantAgents: 0, wantFailClosed: true},
+		{name: "after_C1", implementTaskID: stableFirst, reviewTaskID: stableSecond, wantAgents: 1, wantFailClosed: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := evaluateC1GateScenario(t, tc.implementTaskID, tc.reviewTaskID, oldHead, newHead, tc.reviewTaskID, true)
+			implementingAgents := 0
+			if tc.implementTaskID == tc.reviewTaskID {
+				implementingAgents = 1
+			}
+			failClosed := decision.LeaveOpen && strings.Contains(decision.Reason, "implementing agent for this task could not be determined")
+			if implementingAgents != tc.wantAgents || failClosed != tc.wantFailClosed {
+				t.Fatalf("implementingAgents=%d failClosed=%v decision=%+v; want agents=%d failClosed=%v", implementingAgents, failClosed, decision, tc.wantAgents, tc.wantFailClosed)
+			}
+			if tc.wantFailClosed && decision.Merged {
+				t.Fatalf("unknown implementer passed independence gate: %+v", decision)
+			}
+			if !tc.wantFailClosed && !decision.Merged {
+				t.Fatalf("independent review did not merge after implementer resolution: %+v", decision)
+			}
+			t.Logf("implementingAgents=%d independence_fail_closed=%v", implementingAgents, failClosed)
+		})
+	}
+}
+
+func c1ReviewRepository(t *testing.T) (repoDir string, oldHead string, newHead string) {
+	t.Helper()
+	ctx := context.Background()
+	repoDir = t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("round one\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile round one: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "round one")
+	var err error
+	oldHead, err = (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil || oldHead == "" {
+		t.Fatalf("round-one head = %q, err=%v", oldHead, err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("round two\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile round two: %v", err)
+	}
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "round two")
+	newHead, err = (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil || newHead == "" || newHead == oldHead {
+		t.Fatalf("round heads old=%q new=%q err=%v", oldHead, newHead, err)
+	}
+	return repoDir, oldHead, newHead
+}
+
+func mintC1ReviewTaskID(t *testing.T, repoDir string, headSHA string) string {
+	t.Helper()
+	home := t.TempDir()
+	store := openCLIJobStore(t, home)
+	t.Cleanup(func() { _ = store.Close() })
+	request, _, err := prepareLocalReviewWorktree(
+		context.Background(),
+		store,
+		db.Repo{Owner: "owner", Name: "repo", CheckoutPath: repoDir},
+		github.Repository{Owner: "owner", Name: "repo"},
+		localAgentDispatchRequest{Home: home, PullRequest: 17, HeadSHA: headSHA},
+	)
+	if err != nil {
+		t.Fatalf("prepareLocalReviewWorktree(%s): %v", headSHA, err)
+	}
+	return request.TaskID
+}
+
+func evaluateC1GateScenario(t *testing.T, implementTaskID string, reviewTaskID string, oldHead string, newHead string, gateTaskID string, includeCurrentReview bool) workflow.MergeDecision {
+	t.Helper()
+	store, checkout, gh, request := daemonMergeGateActiveJobFixture(t, false)
+	gh.pr.HeadSHA = newHead
+	request.HeadSHA = newHead
+	request.TaskID = gateTaskID
+	seedDaemonMergeGateJob(t, store, db.Job{
+		ID: "implement-round", Agent: "implementer", Type: "implement", State: string(workflow.JobSucceeded),
+	}, workflow.JobPayload{
+		Repo: "owner/repo", Branch: "fix-round", PullRequest: 17, HeadSHA: oldHead, TaskID: implementTaskID,
+		Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented"},
+	})
+	seedDaemonMergeGateJob(t, store, db.Job{
+		ID: "review-round-one", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded),
+	}, workflow.JobPayload{
+		Repo: "owner/repo", Branch: "fix-round", PullRequest: 17, HeadSHA: oldHead, TaskID: implementTaskID,
+		ReviewRound: "review-1", Result: &workflow.AgentResult{Decision: "approved", Summary: "round one approved"},
+	})
+	if includeCurrentReview {
+		seedDaemonMergeGateJob(t, store, db.Job{
+			ID: "review-round-two", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded),
+		}, workflow.JobPayload{
+			Repo: "owner/repo", Branch: "fix-round", PullRequest: 17, HeadSHA: newHead, TaskID: reviewTaskID,
+			ReviewRound: "review-2", Result: &workflow.AgentResult{Decision: "approved", Summary: "round two approved"},
+		})
+	}
+	decision, err := (daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout}).Evaluate(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	return decision
+}

--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -19,7 +19,7 @@ func TestStableReviewTaskIdentityLetsSecondRoundVerdictReachGate(t *testing.T) {
 	firstTaskID := mintC1ReviewTaskID(t, repoDir, oldHead)
 	secondTaskID := mintC1ReviewTaskID(t, repoDir, newHead)
 
-	decision := evaluateC1GateScenario(t, firstTaskID, secondTaskID, oldHead, newHead, firstTaskID, true)
+	decision := evaluateC1GateScenario(t, firstTaskID, secondTaskID, oldHead, newHead, firstTaskID, "reviewer", true)
 	if !decision.Merged {
 		t.Fatalf("second-round verdict did not reach first-round task: first=%q second=%q decision=%+v", firstTaskID, secondTaskID, decision)
 	}
@@ -27,7 +27,7 @@ func TestStableReviewTaskIdentityLetsSecondRoundVerdictReachGate(t *testing.T) {
 
 func TestStableReviewTaskIdentityKeepsHeadRoundIsolation(t *testing.T) {
 	const stableTaskID = "review-pr-17-stable"
-	decision := evaluateC1GateScenario(t, stableTaskID, stableTaskID, "old-head", "new-head", stableTaskID, false)
+	decision := evaluateC1GateScenario(t, stableTaskID, stableTaskID, "old-head", "new-head", stableTaskID, "reviewer", false)
 	if !decision.LeaveOpen || decision.Merged || !strings.Contains(decision.Reason, "different head SHA") {
 		t.Fatalf("wrong-head verdict was not rejected by the head comparison: %+v", decision)
 	}
@@ -35,6 +35,9 @@ func TestStableReviewTaskIdentityKeepsHeadRoundIsolation(t *testing.T) {
 
 func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
 	repoDir, oldHead, newHead := c1ReviewRepository(t)
+	if oldHead == newHead {
+		t.Fatalf("measurement requires different heads, both were %q", oldHead)
+	}
 	stableFirst := mintC1ReviewTaskID(t, repoDir, oldHead)
 	stableSecond := mintC1ReviewTaskID(t, repoDir, newHead)
 	legacyFirst := fmt.Sprintf("review-pr-%d-%s", 17, shortHash("owner/repo\x00"+oldHead))
@@ -51,11 +54,9 @@ func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
 		{name: "after_C1", implementTaskID: stableFirst, reviewTaskID: stableSecond, wantAgents: 1, wantFailClosed: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			decision := evaluateC1GateScenario(t, tc.implementTaskID, tc.reviewTaskID, oldHead, newHead, tc.reviewTaskID, true)
-			implementingAgents := 0
-			if tc.implementTaskID == tc.reviewTaskID {
-				implementingAgents = 1
-			}
+			collectionProbe := evaluateC1GateScenario(t, tc.implementTaskID, tc.reviewTaskID, oldHead, newHead, tc.reviewTaskID, "implementer", true)
+			implementingAgents := observedC1ImplementingAgentCount(t, collectionProbe)
+			decision := evaluateC1GateScenario(t, tc.implementTaskID, tc.reviewTaskID, oldHead, newHead, tc.reviewTaskID, "reviewer", true)
 			failClosed := decision.LeaveOpen && strings.Contains(decision.Reason, "implementing agent for this task could not be determined")
 			if implementingAgents != tc.wantAgents || failClosed != tc.wantFailClosed {
 				t.Fatalf("implementingAgents=%d failClosed=%v decision=%+v; want agents=%d failClosed=%v", implementingAgents, failClosed, decision, tc.wantAgents, tc.wantFailClosed)
@@ -66,8 +67,21 @@ func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
 			if !tc.wantFailClosed && !decision.Merged {
 				t.Fatalf("independent review did not merge after implementer resolution: %+v", decision)
 			}
-			t.Logf("implementingAgents=%d independence_fail_closed=%v", implementingAgents, failClosed)
+			t.Logf("old_head=%s new_head=%s implementingAgents=%d independence_fail_closed=%v", oldHead, newHead, implementingAgents, failClosed)
 		})
+	}
+}
+
+func observedC1ImplementingAgentCount(t *testing.T, decision workflow.MergeDecision) int {
+	t.Helper()
+	switch {
+	case strings.Contains(decision.Reason, "approval was authored by implementer, the implementing agent"):
+		return 1
+	case strings.Contains(decision.Reason, "implementing agent for this task could not be determined"):
+		return 0
+	default:
+		t.Fatalf("gate decision did not expose the seeded implementer's collection membership: %+v", decision)
+		return 0
 	}
 }
 
@@ -118,7 +132,7 @@ func mintC1ReviewTaskID(t *testing.T, repoDir string, headSHA string) string {
 	return request.TaskID
 }
 
-func evaluateC1GateScenario(t *testing.T, implementTaskID string, reviewTaskID string, oldHead string, newHead string, gateTaskID string, includeCurrentReview bool) workflow.MergeDecision {
+func evaluateC1GateScenario(t *testing.T, implementTaskID string, reviewTaskID string, oldHead string, newHead string, gateTaskID string, reviewerAgent string, includeCurrentReview bool) workflow.MergeDecision {
 	t.Helper()
 	store, checkout, gh, request := daemonMergeGateActiveJobFixture(t, false)
 	gh.pr.HeadSHA = newHead
@@ -131,14 +145,14 @@ func evaluateC1GateScenario(t *testing.T, implementTaskID string, reviewTaskID s
 		Result: &workflow.AgentResult{Decision: "implemented", Summary: "implemented"},
 	})
 	seedDaemonMergeGateJob(t, store, db.Job{
-		ID: "review-round-one", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded),
+		ID: "review-round-one", Agent: reviewerAgent, Type: "review", State: string(workflow.JobSucceeded),
 	}, workflow.JobPayload{
 		Repo: "owner/repo", Branch: "fix-round", PullRequest: 17, HeadSHA: oldHead, TaskID: implementTaskID,
 		ReviewRound: "review-1", Result: &workflow.AgentResult{Decision: "approved", Summary: "round one approved"},
 	})
 	if includeCurrentReview {
 		seedDaemonMergeGateJob(t, store, db.Job{
-			ID: "review-round-two", Agent: "reviewer", Type: "review", State: string(workflow.JobSucceeded),
+			ID: "review-round-two", Agent: reviewerAgent, Type: "review", State: string(workflow.JobSucceeded),
 		}, workflow.JobPayload{
 			Repo: "owner/repo", Branch: "fix-round", PullRequest: 17, HeadSHA: newHead, TaskID: reviewTaskID,
 			ReviewRound: "review-2", Result: &workflow.AgentResult{Decision: "approved", Summary: "round two approved"},


### PR DESCRIPTION
WHAT:
Implemented approved plan 25674 C1: "REVIEW TASK IDENTITY IS (repo, PR). NOT (repo, PR, head)." Branch gitmoot/1354-c1-stable-review-task-identity remains at base e00b0f1f881b7513a3f097f83fa913fe68384718; Gitmoot will commit, push, and produce the new head after handback. CODEX.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-ec3d45e7

RESULTS:
- M1 strength, restored HeadSHA in the synthetic ID: TestStableReviewTaskIdentityLetsSecondRoundVerdictReachGate failed. Round IDs differed and the gate returned "latest review from reviewer is for a different head SHA"; M2's round-isolation guard passed.
- M2 strength, forced non-empty review heads to match: TestStableReviewTaskIdentityKeepsHeadRoundIsolation failed because the wrong-head verdict merged; M1's second-round visibility guard passed.
- Independence: each mutant failed only its own guard while the other guard passed in the same bounded invocation.
- Measurement before C1: implementingAgents=0; independence_fail_closed=true.
- Measurement after C1: implementingAgents=1; independence_fail_closed=false; the independent review merged.
- Targeted review-worktree regressions, stale-head gate regression, and unverifiable-authorship regression passed.
- Bounded builds for internal/cli and internal/workflow passed; git diff --check passed.
- Per-file restoration verified: agent_dispatch.go SHA-256 6ab420af17aed613eef515520196aeb689486dd535c2d23c7d09af5e868874a0 and merge_gate.go SHA-256 4c9dfbfb3bd832ee67ce42c8d65bec9beb559afad1729327fa1c1e418bdb13b8 matched their pre-mutation snapshots.

RISK:
Review the generated diff before merging.

TASK:
adhoc-ec3d45e7

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented approved plan 25674 C1: "REVIEW TASK IDENTITY IS (repo, PR). NOT (repo, PR, head)." Branch gitmoot/1354-c1-stable-review-task-identity remains at base e00b0f1f881b7513a3f097f83fa913fe68384718; Gitmoot will commit, push, and produce the new head after handback. CODEX.
````

## Transition effect — read this before diagnosing a duplicate

**A PR mid-flight when this ships gets one new stable-keyed task alongside its existing head-keyed ones. That is acceptable and self-healing, but IT LOOKS LIKE A DUPLICATE to anyone reading the task list that day.**

This is expected and requires no action. Historical head-keyed task rows remain valid and inert; there is **no backfill**, deliberately — rewriting historical task ids would rewrite the attribution record, which is the opposite of what this round exists to protect.

## Deploy notes

- No migration. This changes an id **format**, not a table.
- On the first dispatch after deploy, an in-flight PR may show one additional task row. See the transition effect above.
- Implements slice 1 (C1) of approved plan **25674** (workflow `campaign/p0-merge-integrity`, approved in note 25682).
