### PR TITLE
Gitmoot: GITMOOT-COC -> IMPLEMENTER: IMPLEMENT SLICE 2 (C2) OF

### DIFF
--- a/docs/local-workflow.md
+++ b/docs/local-workflow.md
@@ -564,6 +564,14 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    PR branch with the expected head SHA and leaves the merge gate pending so the
    daemon can reload the new head and checks on a later poll tick.
 
+   When review independence cannot be verified, the decline names the observed
+   cause: no implement job for the task, task-identity mismatch, a matching job
+   with no agent, or a malformed implement payload. All four remain fail-closed.
+   For the no-job case, the coordinator bridge is to inspect the exact-head
+   engine review with `gitmoot job show <job-id>`, confirm the implementer from
+   the pane session, and journal both facts with `gitmoot workflow note`. The
+   journal is an operator record, never an attestation consumed by the gate.
+
    When a head reports **no** external CI at all (zero commit-statuses and zero
    check-runs), Gitmoot does not conclude "this repo has no CI" from a single
    observation — GitHub Actions creates a check-run a few seconds after a push,

--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -54,10 +54,8 @@ func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
 		{name: "after_C1", implementTaskID: stableFirst, reviewTaskID: stableSecond, wantAgents: 1, wantFailClosed: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			collectionProbe := evaluateC1GateScenario(t, tc.implementTaskID, tc.reviewTaskID, oldHead, newHead, tc.reviewTaskID, "implementer", true)
-			implementingAgents := observedC1ImplementingAgentCount(t, collectionProbe)
 			decision := evaluateC1GateScenario(t, tc.implementTaskID, tc.reviewTaskID, oldHead, newHead, tc.reviewTaskID, "reviewer", true)
-			failClosed := decision.LeaveOpen && strings.Contains(decision.Reason, "implementing agent for this task could not be determined")
+			implementingAgents, failClosed := observedC1ImplementerResolution(t, decision)
 			if implementingAgents != tc.wantAgents || failClosed != tc.wantFailClosed {
 				t.Fatalf("implementingAgents=%d failClosed=%v decision=%+v; want agents=%d failClosed=%v", implementingAgents, failClosed, decision, tc.wantAgents, tc.wantFailClosed)
 			}
@@ -72,16 +70,16 @@ func TestC1MeasurementEngineDispatchedImplementerIdentity(t *testing.T) {
 	}
 }
 
-func observedC1ImplementingAgentCount(t *testing.T, decision workflow.MergeDecision) int {
+func observedC1ImplementerResolution(t *testing.T, decision workflow.MergeDecision) (int, bool) {
 	t.Helper()
 	switch {
-	case strings.Contains(decision.Reason, "approval was authored by implementer, the implementing agent"):
-		return 1
-	case strings.Contains(decision.Reason, "implementing agent for this task could not be determined"):
-		return 0
+	case decision.Ready && decision.Merged && !decision.LeaveOpen && !decision.EscalateMergeGateMiss && !decision.Deferred:
+		return 1, false
+	case !decision.Ready && !decision.Merged && decision.LeaveOpen && decision.EscalateMergeGateMiss && !decision.Deferred:
+		return 0, true
 	default:
-		t.Fatalf("gate decision did not expose the seeded implementer's collection membership: %+v", decision)
-		return 0
+		t.Fatalf("gate decision did not expose a structured implementer-resolution outcome: %+v", decision)
+		return 0, false
 	}
 }
 

--- a/internal/workflow/merge_gate.go
+++ b/internal/workflow/merge_gate.go
@@ -437,25 +437,9 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 		return err
 	}
 	current := JobPayload{Repo: request.Repo, PullRequest: request.PullRequest, TaskID: request.TaskID}
-	implementingAgents := map[string]struct{}{}
-	for _, job := range jobs {
-		if job.Type != "implement" {
-			continue
-		}
-		payload, err := unmarshalPayload(job.Payload)
-		if err != nil {
-			// A malformed implement record cannot prove authorship for this
-			// task, but it also must not block unrelated merge gates.
-			continue
-		}
-		if !sameTask(current, payload) {
-			continue
-		}
-		agent := strings.TrimSpace(job.Agent)
-		if agent != "" {
-			implementingAgents[agent] = struct{}{}
-		}
-	}
+	implementerAttribution := collectImplementerAttribution(jobs, current)
+	implementingAgents := implementerAttribution.agents
+	missingImplementerReason := implementerAttribution.failureReason()
 	delegationChildrenByParent := make(map[string][]db.Job)
 	for _, job := range jobs {
 		parentID := strings.TrimSpace(job.ParentJobID)
@@ -566,7 +550,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 					}
 				case len(implementingAgents) == 0:
 					if unknownImplementerReason == "" {
-						unknownImplementerReason = "latest review round's approval cannot be verified as independent because the implementing agent for this task could not be determined"
+						unknownImplementerReason = missingImplementerReason
 					}
 				default:
 					if _, selfApproved := implementingAgents[reviewer]; selfApproved && selfApprovalReason == "" {
@@ -647,7 +631,7 @@ func (g PolicyMergeGate) ensureFinalReviewCaptured(ctx context.Context, request 
 				continue
 			case len(implementingAgents) == 0:
 				if unknownImplementerReason == "" {
-					unknownImplementerReason = "latest review round's approval cannot be verified as independent because the implementing agent for this task could not be determined"
+					unknownImplementerReason = missingImplementerReason
 				}
 				continue
 			default:
@@ -815,6 +799,68 @@ func ensureDelegatedReviewEvidence(parent db.Job, children []db.Job) error {
 		"delegated review parent %s has no surviving delegation evidence; rerun or repair the delegated review",
 		parent.ID,
 	)
+}
+
+const (
+	noImplementJobAttributionReason            = "latest review round's approval cannot be verified as independent: no implement job is recorded for this task. Use the coordinator bridge: read the engine review job's agent identity and decision at the exact head with gitmoot job show <job-id>, confirm the implementer identity from the pane session, journal both with gitmoot workflow note, then merge the lane"
+	mismatchedImplementTaskAttributionReason   = "latest review round's approval cannot be verified as independent: implement jobs are recorded, but none match this task identity; this is an attribution anomaly and may indicate a stable-task-identity regression"
+	emptyImplementAgentAttributionReason       = "latest review round's approval cannot be verified as independent: an implement job matches this task but has no recorded agent; this is an attribution data anomaly"
+	malformedImplementPayloadAttributionReason = "latest review round's approval cannot be verified as independent: an implement job has a malformed payload, so attribution for this task cannot be verified; this is a corrupt-record anomaly"
+)
+
+type implementerAttributionEvidence struct {
+	agents              map[string]struct{}
+	sawImplementJob     bool
+	sawTaskMismatch     bool
+	sawEmptyAgent       bool
+	sawMalformedPayload bool
+}
+
+func collectImplementerAttribution(jobs []db.Job, current JobPayload) implementerAttributionEvidence {
+	evidence := implementerAttributionEvidence{agents: make(map[string]struct{})}
+	for _, job := range jobs {
+		if job.Type != "implement" {
+			continue
+		}
+		evidence.sawImplementJob = true
+		payload, err := unmarshalPayload(job.Payload)
+		if err != nil {
+			evidence.sawMalformedPayload = true
+			continue
+		}
+		if !sameTask(current, payload) {
+			if current.Repo != "" && current.Repo == payload.Repo &&
+				current.PullRequest > 0 && current.PullRequest == payload.PullRequest {
+				evidence.sawTaskMismatch = true
+			}
+			continue
+		}
+		agent := strings.TrimSpace(job.Agent)
+		if agent == "" {
+			evidence.sawEmptyAgent = true
+			continue
+		}
+		evidence.agents[agent] = struct{}{}
+	}
+	return evidence
+}
+
+func (e implementerAttributionEvidence) failureReason() string {
+	if len(e.agents) > 0 {
+		return ""
+	}
+	switch {
+	case e.sawMalformedPayload:
+		return malformedImplementPayloadAttributionReason
+	case e.sawEmptyAgent:
+		return emptyImplementAgentAttributionReason
+	case e.sawTaskMismatch:
+		return mismatchedImplementTaskAttributionReason
+	case !e.sawImplementJob:
+		return noImplementJobAttributionReason
+	default:
+		return noImplementJobAttributionReason
+	}
 }
 
 func reviewAuthorshipFailureReason(selfApproval string, unknownImplementer string, unattributedReviewer string) string {

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -443,11 +443,23 @@ func TestPolicyMergeGateNamesImplementerAttributionDeclineCause(t *testing.T) {
 		{name: "legacy_round", reviewHead: "old123"},
 	}
 	causes := []struct {
-		name      string
-		seed      seedImplementJobs
-		want      []string
-		doNotWant []string
+		name             string
+		seed             seedImplementJobs
+		omitUnrelatedJob bool
+		want             []string
+		doNotWant        []string
 	}{
+		{
+			name:             "zero_implement_jobs_anywhere",
+			omitUnrelatedJob: true,
+			want: []string{
+				"no implement job is recorded for this task",
+				"coordinator bridge",
+				"gitmoot job show <job-id>",
+				"gitmoot workflow note",
+			},
+			doNotWant: []string{"implemented in a pane"},
+		},
 		{
 			name: "no_implement_job",
 			want: []string{
@@ -496,11 +508,13 @@ func TestPolicyMergeGateNamesImplementerAttributionDeclineCause(t *testing.T) {
 						Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
 						Result: &AgentResult{Decision: "implemented", Summary: "implemented"},
 					}
-					unrelatedPayload := basePayload
-					unrelatedPayload.Repo = "other/repo"
-					unrelatedPayload.PullRequest = 99
-					unrelatedPayload.TaskID = "other-task"
-					insertCompletedJob(t, store, db.Job{ID: "unrelated-implement", Agent: "other", Type: "implement"}, unrelatedPayload)
+					if !cause.omitUnrelatedJob {
+						unrelatedPayload := basePayload
+						unrelatedPayload.Repo = "other/repo"
+						unrelatedPayload.PullRequest = 99
+						unrelatedPayload.TaskID = "other-task"
+						insertCompletedJob(t, store, db.Job{ID: "unrelated-implement", Agent: "other", Type: "implement"}, unrelatedPayload)
+					}
 					if cause.seed != nil {
 						cause.seed(t, store, basePayload)
 					}

--- a/internal/workflow/merge_gate_test.go
+++ b/internal/workflow/merge_gate_test.go
@@ -378,9 +378,9 @@ func TestPolicyMergeGateRejectsUnverifiableReviewAuthorship(t *testing.T) {
 			wantReason:        "approval has no recorded reviewer author; an independent reviewer cannot be verified",
 		},
 		{
-			name:          "unknown implementer",
+			name:          "no implement job",
 			reviewerAgent: "audit",
-			wantReason:    "approval cannot be verified as independent because the implementing agent for this task could not be determined",
+			wantReason:    "no implement job is recorded for this task",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -428,6 +428,121 @@ func TestPolicyMergeGateRejectsUnverifiableReviewAuthorship(t *testing.T) {
 			}
 			if len(gh.merges) != 0 {
 				t.Fatalf("unverifiable approval issued merge: %+v", gh.merges)
+			}
+		})
+	}
+}
+
+func TestPolicyMergeGateNamesImplementerAttributionDeclineCause(t *testing.T) {
+	type seedImplementJobs func(*testing.T, *db.Store, JobPayload)
+	sites := []struct {
+		name       string
+		reviewHead string
+	}{
+		{name: "current_head", reviewHead: "head123"},
+		{name: "legacy_round", reviewHead: "old123"},
+	}
+	causes := []struct {
+		name      string
+		seed      seedImplementJobs
+		want      []string
+		doNotWant []string
+	}{
+		{
+			name: "no_implement_job",
+			want: []string{
+				"no implement job is recorded for this task",
+				"coordinator bridge",
+				"gitmoot job show <job-id>",
+				"gitmoot workflow note",
+			},
+			doNotWant: []string{"implemented in a pane"},
+		},
+		{
+			name: "task_identity_mismatch",
+			seed: func(t *testing.T, store *db.Store, payload JobPayload) {
+				payload.TaskID = "different-task"
+				insertCompletedJob(t, store, db.Job{ID: "implement-mismatch", Agent: "implementer", Type: "implement"}, payload)
+			},
+			want: []string{"none match this task identity", "stable-task-identity regression"},
+		},
+		{
+			name: "empty_implement_agent",
+			seed: func(t *testing.T, store *db.Store, payload JobPayload) {
+				insertCompletedJob(t, store, db.Job{ID: "implement-empty-agent", Type: "implement"}, payload)
+			},
+			want: []string{"matches this task but has no recorded agent", "attribution data anomaly"},
+		},
+		{
+			name: "malformed_implement_payload",
+			seed: func(t *testing.T, store *db.Store, _ JobPayload) {
+				if err := store.CreateJobWithEvent(context.Background(), db.Job{
+					ID: "implement-malformed", Agent: "implementer", Type: "implement", State: string(JobSucceeded), Payload: "{",
+				}, db.JobEvent{Kind: string(JobSucceeded), Message: "done"}); err != nil {
+					t.Fatalf("CreateJobWithEvent returned error: %v", err)
+				}
+			},
+			want: []string{"implement job has a malformed payload", "corrupt-record anomaly"},
+		},
+	}
+
+	for _, site := range sites {
+		t.Run(site.name, func(t *testing.T) {
+			for _, cause := range causes {
+				t.Run(cause.name, func(t *testing.T) {
+					ctx := context.Background()
+					store := openEngineStore(t)
+					basePayload := JobPayload{
+						Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9",
+						Result: &AgentResult{Decision: "implemented", Summary: "implemented"},
+					}
+					unrelatedPayload := basePayload
+					unrelatedPayload.Repo = "other/repo"
+					unrelatedPayload.PullRequest = 99
+					unrelatedPayload.TaskID = "other-task"
+					insertCompletedJob(t, store, db.Job{ID: "unrelated-implement", Agent: "other", Type: "implement"}, unrelatedPayload)
+					if cause.seed != nil {
+						cause.seed(t, store, basePayload)
+					}
+					reviewPayload := basePayload
+					reviewPayload.HeadSHA = site.reviewHead
+					reviewPayload.ReviewRound = "review-1"
+					reviewPayload.Result = &AgentResult{Decision: "approved", Summary: "approved"}
+					insertCompletedJob(t, store, db.Job{ID: "review-job", Agent: "audit", Type: "review"}, reviewPayload)
+
+					mergeable := true
+					gh := &fakeMergeGateGitHub{
+						pr: github.PullRequest{
+							Number: 9, State: "open", HeadRef: "task-9", BaseRef: "main",
+							HeadSHA: "head123", Mergeable: &mergeable,
+						},
+						status:      github.CombinedStatus{State: "success", Statuses: []github.CommitStatus{{Context: "ci", State: "success"}}},
+						checks:      []github.PullRequestCheck{{Name: "ci", Bucket: "pass", State: "SUCCESS"}},
+						mergeResult: github.MergeResult{Merged: true, SHA: "merge123"},
+					}
+					gate := PolicyMergeGate{AutoMerge: true, Store: store, GitHub: gh, Git: &fakeMergeGateGit{clean: true}}
+
+					decision, err := gate.Evaluate(ctx, MergeRequest{Repo: "gitmoot/gitmoot", PullRequest: 9, TaskID: "task-9"})
+					if err != nil {
+						t.Fatalf("Evaluate returned error: %v", err)
+					}
+					if !decision.LeaveOpen || !decision.EscalateMergeGateMiss || decision.Ready || decision.Merged {
+						t.Fatalf("decision = %+v, want fail-closed escalating LeaveOpen", decision)
+					}
+					if len(gh.merges) != 0 {
+						t.Fatalf("unverifiable approval issued merge: %+v", gh.merges)
+					}
+					for _, want := range cause.want {
+						if !strings.Contains(decision.Reason, want) {
+							t.Errorf("decision reason = %q, want named evidence/remedy %q", decision.Reason, want)
+						}
+					}
+					for _, doNotWant := range cause.doNotWant {
+						if strings.Contains(decision.Reason, doNotWant) {
+							t.Errorf("decision reason inferred unobserved workflow %q: %q", doNotWant, decision.Reason)
+						}
+					}
+				})
 			}
 		})
 	}

--- a/skills/gitmoot/references/SAFETY.md
+++ b/skills/gitmoot/references/SAFETY.md
@@ -52,6 +52,15 @@ is an explicit authorized merge request. Turning `auto_merge` back on re-arms
 only tasks parked for this exact kill-switch reason.
 Pipeline `allow_auto_merge` remains a separate double-keyed mechanism.
 
+When review independence cannot be verified, the merge gate names the evidence
+it observed: no implement job for the task, implement jobs that do not match the
+task identity, a matching implement job with no agent, or a malformed implement
+payload. All four remain fail-closed. For the no-job case, use the **coordinator
+bridge**: inspect the engine review job with `gitmoot job show <job-id>` and
+confirm its agent and decision at the exact head, confirm the implementer from
+the pane session, then journal both facts with `gitmoot workflow note`. That
+journal is an operator record only; it is not an attestation or merge-gate input.
+
 ### No external CI: grace window, not instant pass (#596)
 
 When a PR head reports **zero** external commit-statuses **and** zero check-runs,

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2078,6 +2078,15 @@ review and green SHA-scoped commit statuses/check-runs. A miss parks the task as
 `[repos."owner/repo".merge_gate] auto_merge = false` as an explicit kill-switch;
 that deliberate hold does not escalate. Pipeline `allow_auto_merge` is independent.
 
+When review independence cannot be verified, the merge gate names the evidence
+it observed: no implement job for the task, implement jobs that do not match the
+task identity, a matching implement job with no agent, or a malformed implement
+payload. All four remain fail-closed. For the no-job case, use the **coordinator
+bridge**: inspect the engine review job with `gitmoot job show <job-id>` and
+confirm its agent and decision at the exact head, confirm the implementer from
+the pane session, then journal both facts with `gitmoot workflow note`. That
+journal is an operator record only; it is not an attestation or merge-gate input.
+
 Merge-gate retries are automatic while the daemon is running. Retryable states,
 such as a busy base-branch merge queue or a GitHub branch update in progress,
 are retried on the next daemon poll tick. The default poll interval is `30s`

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1197,6 +1197,14 @@ If a job is not eligible, Gitmoot keeps the old queue/wait behavior.
    PR branch with the expected head SHA and leaves the merge gate pending so the
    daemon can reload the new head and checks on a later poll tick.
 
+   When review independence cannot be verified, the decline names the observed
+   cause: no implement job for the task, task-identity mismatch, a matching job
+   with no agent, or a malformed implement payload. All four remain fail-closed.
+   For the no-job case, the coordinator bridge is to inspect the exact-head
+   engine review with `gitmoot job show <job-id>`, confirm the implementer from
+   the pane session, and journal both facts with `gitmoot workflow note`. The
+   journal is an operator record, never an attestation consumed by the gate.
+
    When a head reports **no** external CI at all (zero commit-statuses and zero
    check-runs), Gitmoot does not conclude "this repo has no CI" from a single
    observation — GitHub Actions creates a check-run a few seconds after a push,
@@ -15888,6 +15896,15 @@ not escalate. A human GitHub merge is reconciled normally, while `@gitmoot merge
 is an explicit authorized merge request. Turning `auto_merge` back on re-arms
 only tasks parked for this exact kill-switch reason.
 Pipeline `allow_auto_merge` remains a separate double-keyed mechanism.
+
+When review independence cannot be verified, the merge gate names the evidence
+it observed: no implement job for the task, implement jobs that do not match the
+task identity, a matching implement job with no agent, or a malformed implement
+payload. All four remain fail-closed. For the no-job case, use the **coordinator
+bridge**: inspect the engine review job with `gitmoot job show <job-id>` and
+confirm its agent and decision at the exact head, confirm the implementer from
+the pane session, then journal both facts with `gitmoot workflow note`. That
+journal is an operator record only; it is not an attestation or merge-gate input.
 
 ### No external CI: grace window, not instant pass (#596)
 


### PR DESCRIPTION
WHAT:
Implemented approved plan 26590: “C2 — named implementer-attribution decline.” Gate decisions and fail-closed polarity are unchanged; only observed-cause reporting changed. Current pre-finalizer HEAD is 5c9cc3408b4a41784027fc73635742d01b1d597c. CODEX.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-b448576b

RESULTS:
- Final bounded family passed: env -u GITMOOT_STALE_RUNNING_AFTER go test -count=1 -run '^TestPolicyMergeGate' ./internal/workflow/ (94.309s).
- N1 collapse mutant: all eight cause/site guards failed because every reason reverted to “implementing agent ... could not be determined”.
- N2 inference mutant: both no-job guards failed on “this was implemented in a pane”; the six anomaly guards passed.
- N3 remedy-removal mutant: both no-job guards failed specifically on missing “coordinator bridge”, “gitmoot job show <job-id>”, and “gitmoot workflow note”; the six anomaly guards passed.
- N4 polarity mutant: current_head/no_implement_job failed with decision `{Ready:true Merged:true ... Reason:merged}`, while the legacy no-job guard and all anomaly guards passed.
- N5 current-head-site mutant: all four current-head guards failed on “mutated current-head attribution reason”; all four legacy-round guards passed.
- N5 legacy-round-site mutant: all four current-head guards passed; all four legacy-round guards failed on “mutated legacy-round attribution reason”.
- Strength: N1-N4 each failed on its claimed semantic axis; N4 observed an actual merge, not merely a changed string.
- Independence: N2/N3 left anomaly guards passing, N4 left the other site and anomaly guards passing, and N5 produced exact inverse pass/fail sets for its two separate site mutations.
- Every mutation was applied exactly once and restored per-file. Final merge_gate.go SHA-256 is 8fc2e6cd9d98d8cb56260c793a67d6ef8eb6ee42c7cc96fb280d7d4fbc264822; git diff --check passed.

RISK:
Review the generated diff before merging.

TASK:
adhoc-b448576b

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented approved plan 26590: “C2 — named implementer-attribution decline.” Gate decisions and fail-closed polarity are unchanged; only observed-cause reporting changed. Current pre-finalizer HEAD is 5c9cc3408b4a41784027fc73635742d01b1d597c. CODEX.
````

## What this changes for an operator

The merge gate's implementer-attribution decline was ONE sentence covering FOUR distinct conditions — true for all of them, actionable for none. An operator could not tell whether to run the coordinator bridge, file a bug, or fix a record. Each cause now names what the gate **observed**:

| cause | decline says |
|---|---|
| no implement job recorded for this task | names it, and teaches the **coordinator bridge** as the remedy |
| implement jobs exist but none match this task identity | flags an attribution anomaly that **may indicate a stable-task-identity regression** (C1) |
| implement job matches but has no recorded agent | attribution data anomaly |
| implement job has a malformed payload | corrupt-record anomaly |

**The gate's decision is unchanged.** Fail-closed polarity is identical; only the reported cause is more precise. No merge that previously declined now proceeds.

**The decline states what the gate observed, never what it infers** — "no implement job is recorded for this task", not "this was implemented in a pane". A gate that speculates in its decline text is one step from accepting speculation as input.

## Coordinator bridge — journal-only, never a gate input

The remedy named in the first decline is an **operator procedure**: read the engine review job's agent identity and decision at the exact head, confirm implementer identity from the pane session, journal both, then merge. Its output is a journal entry a human wrote after checking. It is deliberately **not** an attestation the gate consumes — caller-supplied attribution is forbidden for gate inputs.

## Migration and deploy notes

- **No migration.** This adds branch discrimination among conditions the gate already computes, plus strings.
- **No transition effect.** Unlike slice C1 (#1404), nothing about task identity or id format changes, so no task will read as a duplicate and there is no backfill question.
- Implements approved plan **26590** (workflow `campaign/p0-merge-integrity`, approved in directive 26597), slice 2 of the dispatch-contract family.
