### PR TITLE
fix(cockpit): inject the seat model pin for omp recycles (#1467)

### DIFF
--- a/internal/cockpit/herdr_org.go
+++ b/internal/cockpit/herdr_org.go
@@ -231,11 +231,13 @@ func (p *herdrOrgProvider) Recycle(ctx context.Context, req org.RecycleRequest) 
 
 // herdrKindSupportsModelFlag reports whether the named herdr agent kind's CLI
 // is verified to accept a startup `-m/--model <value>` flag. Restricted to
-// gitmoot's own three driven runtimes (codex, claude, kimi) — herdr supports
-// many more kinds, but their model-flag support has not been checked.
+// gitmoot's own driven runtimes (codex, claude, kimi, omp — omp verified
+// against omp 17.2.4, whose CLI accepts `--model=<value>` with fuzzy matching,
+// #1467) — herdr supports many more kinds, but their model-flag support has
+// not been checked.
 func herdrKindSupportsModelFlag(kind string) bool {
 	switch kind {
-	case "codex", "claude", "kimi":
+	case "codex", "claude", "kimi", "omp":
 		return true
 	default:
 		return false

--- a/internal/cockpit/herdr_org_test.go
+++ b/internal/cockpit/herdr_org_test.go
@@ -389,6 +389,12 @@ func TestHerdrOrgProviderRecycleCommand(t *testing.T) {
 			want:  []string{"agent", "start", "owner", "--kind", "kimi", "--pane", "w1:p2", "--timeout", "30000", "--", "--model", "k2", "role: owner\n\nhandoff: ship it"},
 		},
 		{
+			name:  "pinned model applies for omp",
+			kind:  "omp",
+			model: "claude-opus-5",
+			want:  []string{"agent", "start", "owner", "--kind", "omp", "--pane", "w1:p2", "--timeout", "30000", "--", "--model", "claude-opus-5", "role: owner\n\nhandoff: ship it"},
+		},
+		{
 			name:  "pinned model ignored for an unverified kind",
 			kind:  "gemini",
 			model: "sonnet",


### PR DESCRIPTION
Closes #1467.

An omp seat's configured `Model` pin was silently dropped at every recycle: `herdrKindSupportsModelFlag` whitelists only codex/claude/kimi, while `"omp"` is already a valid recycle kind (`validOrgRecycleKind`). omp 17.2.4's CLI accepts `--model=<value>` (fuzzy-matched; verified against the installed binary and its source), meeting the function's verified-support contract.

**Change**: add `"omp"` to the switch + comment update; one new row in `TestHerdrOrgProviderRecycleCommand` pinning `--model` injection for the omp kind.

**Verified**: `go build` / `go vet` / `go test ./internal/cockpit/` green locally at 8fbc9c2 + this change. No behavior change for any other kind (gemini row still pins the ignored path).

**Context**: omp-coc trial step 2 (#1465). Until this deploys, the trial seat recycles unpinned.

Deploy notes: standard two-binary deploy at idle; no config or migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)