### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1493 - the inert-config branch. Authorized by

### DIFF
--- a/internal/cli/event_sink.go
+++ b/internal/cli/event_sink.go
@@ -136,9 +136,10 @@ func loadEventsPolicy(home string) (config.EventsPolicy, error) {
 }
 
 // resolveConfigFile resolves the gitmoot config.toml for a `home` that may be
-// EITHER an already-resolved <home>/.gitmoot ROOT or a RAW --home, returning ""
-// for an empty home. It is the single, side-effect-free home->config.toml
-// resolver shared by the daemon's read-only policy loaders (loadEventsPolicy,
+// EITHER an already-resolved <home>/.gitmoot ROOT or a RAW --home. An empty
+// home resolves through config.DefaultPaths, matching the CLI's omitted --home
+// behavior. It is the single, side-effect-free home->config.toml resolver
+// shared by the daemon's read-only policy loaders (loadEventsPolicy,
 // resolveEscalationTTL).
 //
 // On main the daemon's engine wiring (daemonWorkflowEngine -> daemonEventSink)
@@ -156,7 +157,11 @@ func loadEventsPolicy(home string) (config.EventsPolicy, error) {
 func resolveConfigFile(home string) string {
 	home = strings.TrimSpace(home)
 	if home == "" {
-		return ""
+		paths, err := config.DefaultPaths()
+		if err != nil {
+			return ""
+		}
+		return paths.ConfigFile
 	}
 	cfg := filepath.Join(home, config.ConfigName)
 	if _, err := os.Stat(cfg); err != nil {

--- a/internal/cli/permission_policy_config_test.go
+++ b/internal/cli/permission_policy_config_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/config"
+)
+
+func TestResolveConfigFileEmptyHomeUsesDefaultConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(paths.ConfigFile, []byte("[daemon]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveConfigFile(""); got != paths.ConfigFile {
+		t.Fatalf("resolveConfigFile(empty) = %q, want default config %q", got, paths.ConfigFile)
+	}
+}
+
+func TestPermissionPolicyObservationEmptyHomeReadsConfiguredValue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(paths.ConfigFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	contents := "[daemon]\npermission_policy_observation_enabled = true\n"
+	if err := os.WriteFile(paths.ConfigFile, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !resolvePermissionPolicyObservationEnabled("") {
+		t.Fatal("empty home ignored configured permission_policy_observation_enabled=true")
+	}
+}
+
+func TestResolveConfigFileEmptyHomeMissingConfigUsesDefaultsWithoutCreatingFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	paths, err := config.DefaultPaths()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveConfigFile(""); got != paths.ConfigFile {
+		t.Fatalf("resolveConfigFile(empty) = %q, want missing default config path %q", got, paths.ConfigFile)
+	}
+	if resolvePermissionPolicyObservationEnabled("") {
+		t.Fatal("missing config enabled permission-policy observation")
+	}
+	if _, err := os.Stat(paths.ConfigFile); !os.IsNotExist(err) {
+		t.Fatalf("default config stat error = %v, want not-exist without creating a file", err)
+	}
+}


### PR DESCRIPTION
WHAT:
CODEX implemented #1493 from base e41e644831964da1c538c6b5ee0f232c4c525f71 using shape (a). The draft PR body must center this host delta table:
| setting | live | compiled default | effect |
| [skillopt] revert_detection_enabled | true | false | WOULD TURN ON |
| [daemon] permission_policy_observation_enabled | true | false | WOULD TURN ON |
Everything else already coincides: escalation_ttl is unset and 24h either way; auto_merge/[merge_gate], [review], [router], and [runtime.*] are unset; delegation_worktree_ttl is configured 72h and defaults to 72h; memory and router already use correct default-home resolution.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-a36e7dff

RESULTS:
- go build ./...: no output; exit 0.
- go vet ./...: no output; exit 0.
- T1 clean: ok github.com/gitmoot/gitmoot/internal/cli 0.010s. Reverted fix: FAIL, resolveConfigFile(empty) = "", want default config <temp>/.gitmoot/config.toml.
- T2 clean: ok github.com/gitmoot/gitmoot/internal/cli 0.010s. Reverted fix: FAIL, empty home ignored configured permission_policy_observation_enabled=true.
- T3 clean: ok github.com/gitmoot/gitmoot/internal/cli 0.008s. Reverted fix: FAIL, resolveConfigFile(empty) = "", want missing default config path <temp>/.gitmoot/config.toml.
- Post-mutant SHA-256 restoration confirmed: event_sink.go 6694ab144ea9cbdb0d9bc16db272ee8527367bd8404be3f9c9130a14d7b38789; permission_policy_config_test.go f88037524471f18366ee0da1c1126c18896bf5ca8f40495f2dfe8f156fa6166c.
- git diff --check: clean. Final status contains only modified internal/cli/event_sink.go and new internal/cli/permission_policy_config_test.go. The full internal/cli suite was not run, as required by #1486.

RISK:
Review the generated diff before merging.

TASK:
adhoc-a36e7dff

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
CODEX implemented #1493 from base e41e644831964da1c538c6b5ee0f232c4c525f71 using shape (a). The draft PR body must center this host delta table:
| setting | live | compiled default | effect |
| [skillopt] revert_detection_enabled | true | false | WOULD TURN ON |
| [daemon] permission_policy_observation_enabled | true | false | WOULD TURN ON |
Everything else already coincides: escalation_ttl is unset and 24h either way; auto_merge/[merge_gate], [review], [router], and [runtime.*] are unset; delegation_worktree_ttl is configured 72h and defaults to 72h; memory and router already use correct default-home resolution.
````
