### PR TITLE
Gitmoot: IMPLEMENT: #1463 - THE TWO-GRAMMAR CONFIG (v2). Authorized

### DIFF
--- a/docs/skillopt-exchange-contract.md
+++ b/docs/skillopt-exchange-contract.md
@@ -299,8 +299,10 @@ quality, the checker runs plain external **tools** that *measure* it exactly:
 - **`complexity`** — over-threshold function count via `gocyclo`.
 
 Each tool dimension is normalized to `[0,1]` (fewer issues → higher). The optional
-`[skillopt].deterministic_checkers` comma list selects which run (default:
-`diff_size` only); widen it to opt heavy tools in. The dimensions map to
+`[skillopt].deterministic_checkers` TOML string array selects which run (default:
+`["diff_size"]`); widen it to opt heavy tools in. Legacy bare comma lists remain
+readable but are deprecated. Quoted whole lists and unknown checker names fail
+config loading rather than silently dropping checks. The dimensions map to
 `dimension_scores`, are fused by the **mean-of-dimensions** path, and are written as
 a **third** `FeedbackEvent` in the SAME `auto-trace:<version>` run under a distinct
 item id (`checker#<repo>#<pr>`) and the fixed `gitmoot-checker` reviewer sentinel —

--- a/internal/cli/agent_heartbeat_test.go
+++ b/internal/cli/agent_heartbeat_test.go
@@ -120,6 +120,56 @@ func TestAgentHeartbeatAddPreservesAgentType(t *testing.T) {
 	}
 }
 
+func TestAgentHeartbeatAddAcceptsLegacyDeterministicCheckers(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	const legacy = "deterministic_checkers = diff_size,duplication,lint,complexity"
+	contents, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	contents = append(contents, []byte("\n[skillopt]\n"+legacy+"\n")...)
+	if err := os.WriteFile(paths.ConfigFile, contents, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "heartbeat", "add", "probe", "compat",
+		"--home", home, "--repo", "gitmoot/gitmoot", "--interval", "1h", "--prompt", "check config grammar",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("heartbeat add exit=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "configured heartbeat probe/compat") {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+	after, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read updated config: %v", err)
+	}
+	if count := strings.Count(string(after), legacy); count != 1 {
+		t.Fatalf("legacy checker syntax count = %d, want 1; config:\n%s", count, after)
+	}
+	policy, err := config.LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy: %v", err)
+	}
+	want := []string{"diff_size", "duplication", "lint", "complexity"}
+	got := policy.ResolvedDeterministicCheckers()
+	if len(got) != len(want) {
+		t.Fatalf("resolved checkers = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("resolved checkers = %v, want %v", got, want)
+		}
+	}
+}
+
 // TestAgentHeartbeatAddReviewRejectsMissingCapability proves the write path
 // refuses a review heartbeat for an agent lacking the review capability.
 func TestAgentHeartbeatAddReviewRejectsMissingCapability(t *testing.T) {

--- a/internal/cli/agent_heartbeat_test.go
+++ b/internal/cli/agent_heartbeat_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -167,6 +168,50 @@ func TestAgentHeartbeatAddAcceptsLegacyDeterministicCheckers(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("resolved checkers = %v, want %v", got, want)
 		}
+	}
+}
+
+func TestAgentHeartbeatAddAcceptsMultilineDeterministicCheckers(t *testing.T) {
+	home := t.TempDir()
+	paths := config.PathsForHome(home)
+	if err := config.Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	contents, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	contents = append(contents, []byte(`
+[skillopt]
+deterministic_checkers = [
+  "diff_size",
+  "duplication",
+  "lint",
+  "complexity",
+]
+`)...)
+	if err := os.WriteFile(paths.ConfigFile, contents, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"agent", "heartbeat", "add", "probe", "multiline",
+		"--home", home, "--repo", "gitmoot/gitmoot", "--interval", "1h", "--prompt", "check multiline grammar",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("heartbeat add exit=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "configured heartbeat probe/multiline") {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+	policy, err := config.LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy: %v", err)
+	}
+	want := []string{"diff_size", "duplication", "lint", "complexity"}
+	if got := policy.ResolvedDeterministicCheckers(); !slices.Equal(got, want) {
+		t.Fatalf("resolved checkers = %v, want %v", got, want)
 	}
 }
 

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/creachadair/tomledit"
 	"github.com/creachadair/tomledit/parser"
 )
 
@@ -28,10 +27,13 @@ func SetConfigScalar(paths Paths, keyPath []string, value ConfigScalar) error {
 	if err != nil {
 		return err
 	}
-	doc, err := tomledit.Parse(strings.NewReader(string(original)))
+	editedSection := strings.Join(keyPath[:len(keyPath)-1], ".")
+	preserveLegacy := editedSection != "skillopt" || keyPath[len(keyPath)-1] != "deterministic_checkers"
+	editable, err := parseEditableConfig(original, editedSection, preserveLegacy)
 	if err != nil {
-		return fmt.Errorf("parse config: %w", err)
+		return err
 	}
+	doc := editable.doc
 	entry := doc.First(keyPath...)
 	if entry == nil || entry.KeyValue == nil {
 		return fmt.Errorf("config key %q not found", strings.Join(keyPath, "."))
@@ -46,12 +48,12 @@ func SetConfigScalar(paths Paths, keyPath []string, value ConfigScalar) error {
 	parsed.Trailer = entry.Value.Trailer
 	entry.Value = parsed
 
-	var buf strings.Builder
-	if err := tomledit.Format(&buf, doc); err != nil {
-		return fmt.Errorf("format config: %w", err)
+	updated, err := editable.format()
+	if err != nil {
+		return err
 	}
 
-	if err := writeConfigAtomic(paths.ConfigFile, []byte(buf.String())); err != nil {
+	if err := writeConfigAtomic(paths.ConfigFile, updated); err != nil {
 		return err
 	}
 	// Validate through the real parsers; restore the original on any failure so

--- a/internal/config/edit_compat.go
+++ b/internal/config/edit_compat.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/creachadair/tomledit"
+)
+
+type legacyConfigLine struct {
+	occurrence int
+	original   string
+}
+
+type editableConfig struct {
+	doc         *tomledit.Document
+	legacyLines []legacyConfigLine
+}
+
+// parseEditableConfig keeps tomledit's strict TOML parser while admitting the
+// one legacy scalar grammar Gitmoot previously documented for
+// deterministic_checkers. The compatibility rewrite exists only in memory; the
+// formatter restores the operator's exact legacy line unless that field itself
+// is the edit target.
+func parseEditableConfig(original []byte, editedSection string, preserveLegacy bool) (editableConfig, error) {
+	normalized, legacyLines, err := normalizeLegacyDeterministicCheckerLines(string(original))
+	if err != nil {
+		return editableConfig{}, err
+	}
+	doc, err := tomledit.Parse(strings.NewReader(normalized))
+	if err != nil {
+		return editableConfig{}, configMutationParseError(string(original), editedSection, err)
+	}
+	if !preserveLegacy {
+		legacyLines = nil
+	}
+	return editableConfig{doc: doc, legacyLines: legacyLines}, nil
+}
+
+func normalizeLegacyDeterministicCheckerLines(contents string) (string, []legacyConfigLine, error) {
+	lines := strings.Split(contents, "\n")
+	section := ""
+	occurrence := 0
+	var legacyLines []legacyConfigLine
+	for i, raw := range lines {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(line[1 : len(line)-1])
+			continue
+		}
+		if section != "skillopt" {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "deterministic_checkers" {
+			continue
+		}
+		names, err := parseDeterministicCheckerList(strings.TrimSpace(value))
+		if err != nil {
+			return "", nil, fmt.Errorf("parse [skillopt].deterministic_checkers: %w", err)
+		}
+		trimmed := strings.TrimSpace(value)
+		if strings.HasPrefix(trimmed, "[") {
+			occurrence++
+			continue
+		}
+		equals := strings.IndexByte(raw, '=')
+		if equals < 0 {
+			continue
+		}
+		comment := ""
+		if hash := strings.IndexByte(raw[equals+1:], '#'); hash >= 0 {
+			comment = strings.TrimSpace(raw[equals+1+hash:])
+		}
+		normalized := raw[:equals+1] + " " + StringListScalar(names).toml()
+		if comment != "" {
+			normalized += " " + comment
+		}
+		legacyLines = append(legacyLines, legacyConfigLine{occurrence: occurrence, original: raw})
+		lines[i] = normalized
+		occurrence++
+	}
+	return strings.Join(lines, "\n"), legacyLines, nil
+}
+
+func (c editableConfig) format() ([]byte, error) {
+	var formatted strings.Builder
+	if err := tomledit.Format(&formatted, c.doc); err != nil {
+		return nil, fmt.Errorf("format config: %w", err)
+	}
+	if len(c.legacyLines) == 0 {
+		return []byte(formatted.String()), nil
+	}
+
+	restore := make(map[int]string, len(c.legacyLines))
+	for _, line := range c.legacyLines {
+		restore[line.occurrence] = line.original
+	}
+	lines := strings.Split(formatted.String(), "\n")
+	section := ""
+	occurrence := 0
+	for i, raw := range lines {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(line[1 : len(line)-1])
+			continue
+		}
+		if section != "skillopt" {
+			continue
+		}
+		key, _, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "deterministic_checkers" {
+			continue
+		}
+		if original, ok := restore[occurrence]; ok {
+			lines[i] = original
+		}
+		occurrence++
+	}
+	return []byte(strings.Join(lines, "\n")), nil
+}
+
+func configMutationParseError(contents, editedSection string, parseErr error) error {
+	offending := configSectionAtParseError(contents, parseErr)
+	if offending != "" && offending != editedSection {
+		return fmt.Errorf(
+			"parse config: invalid TOML in [%s], not the [%s] section being edited: %w; remedy: correct [%s] syntax (list values use TOML arrays such as [\"a\", \"b\"])",
+			offending, editedSection, parseErr, offending,
+		)
+	}
+	return fmt.Errorf(
+		"parse config while editing [%s]: %w; remedy: correct the named section's TOML (list values use arrays such as [\"a\", \"b\"])",
+		editedSection, parseErr,
+	)
+}
+
+func configSectionAtParseError(contents string, parseErr error) string {
+	message := strings.TrimSpace(parseErr.Error())
+	location, _, ok := strings.Cut(strings.TrimPrefix(message, "at "), ":")
+	if !ok {
+		return ""
+	}
+	lineNumber, err := strconv.Atoi(location)
+	if err != nil || lineNumber <= 0 {
+		return ""
+	}
+	lines := strings.Split(contents, "\n")
+	if lineNumber > len(lines) {
+		lineNumber = len(lines)
+	}
+	section := ""
+	for _, raw := range lines[:lineNumber] {
+		line := strings.TrimSpace(stripConfigComment(raw))
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section = strings.TrimSpace(line[1 : len(line)-1])
+		}
+	}
+	return section
+}

--- a/internal/config/edit_compat.go
+++ b/internal/config/edit_compat.go
@@ -43,7 +43,8 @@ func normalizeLegacyDeterministicCheckerLines(contents string) (string, []legacy
 	section := ""
 	occurrence := 0
 	var legacyLines []legacyConfigLine
-	for i, raw := range lines {
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
 		line := strings.TrimSpace(stripConfigComment(raw))
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
 			section = strings.TrimSpace(line[1 : len(line)-1])
@@ -56,13 +57,15 @@ func normalizeLegacyDeterministicCheckerLines(contents string) (string, []legacy
 		if !ok || strings.TrimSpace(key) != "deterministic_checkers" {
 			continue
 		}
-		names, err := parseDeterministicCheckerList(strings.TrimSpace(value))
+		value, end := joinDeterministicCheckerArrayValue(lines, i, strings.TrimSpace(value))
+		names, err := parseDeterministicCheckerList(value)
 		if err != nil {
 			return "", nil, fmt.Errorf("parse [skillopt].deterministic_checkers: %w", err)
 		}
 		trimmed := strings.TrimSpace(value)
 		if strings.HasPrefix(trimmed, "[") {
 			occurrence++
+			i = end
 			continue
 		}
 		equals := strings.IndexByte(raw, '=')

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -108,6 +108,21 @@ func TestSetConfigScalarRevertsOnInvalidResult(t *testing.T) {
 	}
 }
 
+// TestValidateConfigFilePinsIndirectSkillOptPolicyCoverage pins the intentional
+// transitive dependency validateConfigFile -> LoadSkillOptABPolicy ->
+// LoadSkillOptPolicy. If the AB loader is later split or inlined, this guard must
+// fail rather than silently orphan validation for the rest of [skillopt].
+func TestValidateConfigFilePinsIndirectSkillOptPolicyCoverage(t *testing.T) {
+	paths := editTestPaths(t, editFixture+`
+[skillopt]
+deterministic_checkers = ["diff_size", "orphaned_checker"]
+`)
+	err := validateConfigFile(paths)
+	if err == nil || !strings.Contains(err.Error(), `unknown deterministic checker "orphaned_checker"`) {
+		t.Fatalf("validateConfigFile error = %v, want transitive checker validation", err)
+	}
+}
+
 func TestSetConfigScalarPreservesTrailingComment(t *testing.T) {
 	fixture := "[agents.planner]\nmax_background = 4 # ops cap, do not exceed\n"
 	paths := editTestPaths(t, fixture)

--- a/internal/config/heartbeat_edit.go
+++ b/internal/config/heartbeat_edit.go
@@ -32,10 +32,12 @@ func SaveHeartbeat(paths Paths, entry Heartbeat) error {
 	if err != nil {
 		return err
 	}
-	doc, err := tomledit.Parse(strings.NewReader(string(original)))
+	editedSection := strings.Join([]string{"agents", entry.Agent, "heartbeats", entry.Name}, ".")
+	editable, err := parseEditableConfig(original, editedSection, true)
 	if err != nil {
-		return fmt.Errorf("parse config: %w", err)
+		return err
 	}
+	doc := editable.doc
 	tableName := parser.Key{"agents", entry.Agent, "heartbeats", entry.Name}
 	section := findSection(doc, tableName)
 	// Field order mirrors the documented config example so a freshly written block
@@ -92,7 +94,7 @@ func SaveHeartbeat(paths Paths, entry Heartbeat) error {
 			removeSectionScalar(section, "runtime")
 		}
 	}
-	return formatAndValidateConfig(paths, doc, original)
+	return formatAndValidateConfig(paths, editable, original)
 }
 
 // SetHeartbeatEnabled flips just the `enabled` flag of an existing heartbeat via
@@ -140,10 +142,12 @@ func RemoveHeartbeat(paths Paths, agent, name string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	doc, err := tomledit.Parse(strings.NewReader(string(original)))
+	editedSection := strings.Join([]string{"agents", agent, "heartbeats", name}, ".")
+	editable, err := parseEditableConfig(original, editedSection, true)
 	if err != nil {
-		return false, fmt.Errorf("parse config: %w", err)
+		return false, err
 	}
+	doc := editable.doc
 	entry := doc.First("agents", agent, "heartbeats", name)
 	if entry == nil || !entry.IsSection() {
 		return false, nil
@@ -151,7 +155,7 @@ func RemoveHeartbeat(paths Paths, agent, name string) (bool, error) {
 	if !entry.Remove() {
 		return false, nil
 	}
-	if err := formatAndValidateConfig(paths, doc, original); err != nil {
+	if err := formatAndValidateConfig(paths, editable, original); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -230,12 +234,12 @@ func removeSectionScalar(section *tomledit.Section, key string) bool {
 // formatAndValidateConfig serializes doc, writes it atomically, then re-validates
 // through every Load* parser; on any validation failure it restores original so a
 // malformed write can never wedge the daemon. It mirrors SetConfigScalar's tail.
-func formatAndValidateConfig(paths Paths, doc *tomledit.Document, original []byte) error {
-	var buf strings.Builder
-	if err := tomledit.Format(&buf, doc); err != nil {
-		return fmt.Errorf("format config: %w", err)
+func formatAndValidateConfig(paths Paths, editable editableConfig, original []byte) error {
+	updated, err := editable.format()
+	if err != nil {
+		return err
 	}
-	if err := writeConfigAtomic(paths.ConfigFile, []byte(buf.String())); err != nil {
+	if err := writeConfigAtomic(paths.ConfigFile, updated); err != nil {
 		return err
 	}
 	if err := validateConfigFile(paths); err != nil {

--- a/internal/config/heartbeat_edit_test.go
+++ b/internal/config/heartbeat_edit_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -47,6 +48,46 @@ func TestSaveHeartbeatCreateRoundTrip(t *testing.T) {
 		hb.Repo != "gitmoot/gitmoot" || hb.Interval != "24h" || hb.Jitter != "15m" ||
 		hb.Action != "ask" || hb.Prompt != "Review open issues and PRs." || hb.MaxConcurrent != 1 {
 		t.Fatalf("round-trip mismatch: %+v", hb)
+	}
+}
+
+func TestSaveHeartbeatPreservesLegacyDeterministicCheckerSyntax(t *testing.T) {
+	const legacy = "deterministic_checkers = diff_size,duplication,lint,complexity"
+	paths := newHeartbeatEditPaths(t, "\n[skillopt]\n"+legacy+"\n")
+	if err := SaveHeartbeat(paths, Heartbeat{
+		Agent: "probe", Name: "compat", Repo: "gitmoot/gitmoot", Interval: "1h", Action: "ask", Prompt: "check",
+	}); err != nil {
+		t.Fatalf("SaveHeartbeat: %v", err)
+	}
+	contents, err := os.ReadFile(paths.ConfigFile)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if count := strings.Count(string(contents), legacy); count != 1 {
+		t.Fatalf("legacy checker syntax count = %d, want 1; config:\n%s", count, contents)
+	}
+	policy, err := LoadSkillOptPolicy(paths)
+	if err != nil {
+		t.Fatalf("LoadSkillOptPolicy: %v", err)
+	}
+	want := []string{"diff_size", "duplication", "lint", "complexity"}
+	if got := policy.ResolvedDeterministicCheckers(); !slices.Equal(got, want) {
+		t.Fatalf("resolved checkers = %v, want %v", got, want)
+	}
+}
+
+func TestSaveHeartbeatParseErrorNamesUnrelatedSection(t *testing.T) {
+	paths := newHeartbeatEditPaths(t, "\n[skillopt]\npace_alpha = invalid\n")
+	err := SaveHeartbeat(paths, Heartbeat{
+		Agent: "probe", Name: "diagnostic", Repo: "gitmoot/gitmoot", Interval: "1h", Action: "ask", Prompt: "check",
+	})
+	if err == nil {
+		t.Fatal("expected strict TOML parse error")
+	}
+	for _, want := range []string{"[skillopt]", "not the [agents.probe.heartbeats.diagnostic] section being edited", "remedy"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("SaveHeartbeat error = %q, want %q", err, want)
+		}
 	}
 }
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -380,11 +380,14 @@ path = ""
 #     fails the harvest or blocks the merge; an all-skipped run writes no row.
 #     diff_size is pure-Go and always available; tool dims appear only when their
 #     binary AND a checkout are present. Off ⇒ byte-identical. Promotion stays MANUAL.
-#   deterministic_checkers (#485): optional comma list selecting which checkers run
-#     when enabled (diff_size,duplication,lint,complexity). UNSET/empty ⇒ the safe
+#   deterministic_checkers (#485): optional TOML string array selecting which
+#     checkers run when enabled (diff_size,duplication,lint,complexity). The legacy
+#     bare comma list remains readable but is deprecated. Quoted whole lists and
+#     unknown checker names fail config loading instead of silently disabling checks.
+#     UNSET/empty ⇒ the safe
 #     default (diff_size only) so a tool-less host runs the always-available metric
 #     and never a heavy tool. Narrow it to run only the cheap dims, or widen it to
-#     opt heavy tools (jscpd/golangci-lint) in. An unknown name is ignored.
+#     opt heavy tools (jscpd/golangci-lint) in.
 #   hard_verifiers_enabled (#474): OFF by default; requires auto_trace AND at least one
 #     hard_verifier_commands line. When true, a MERGED implement job runs the configured
 #     build/test/lint COMMANDS in a FRESH clean sandbox checkout at the merged head (an
@@ -449,7 +452,7 @@ path = ""
 # cross_family_review_enabled = false
 # revert_detection_enabled = true
 # deterministic_checkers_enabled = false
-# deterministic_checkers = diff_size
+# deterministic_checkers = ["diff_size"]
 # hard_verifiers_enabled = false
 # hard_verifier_commands = go build ./...
 # hard_verifier_commands = go test ./...

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -1145,8 +1145,9 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 		policy.DeterministicCheckers = parsed
 		return err
 	case "deterministic_checkers":
-		policy.DeterministicCheckerList = parseDeterministicCheckerList(value)
-		return nil
+		parsed, err := parseDeterministicCheckerList(value)
+		policy.DeterministicCheckerList = parsed
+		return err
 	case "hard_verifiers_enabled":
 		parsed, err := strconv.ParseBool(value)
 		policy.HardVerifiers = parsed
@@ -1215,13 +1216,44 @@ func applySkillOptPolicyField(policy *SkillOptPolicy, key string, value string) 
 }
 
 // parseDeterministicCheckerList parses the [skillopt].deterministic_checkers
-// per-checker selector — a plain comma list like "diff_size,duplication" — into a
-// trimmed, non-empty slice (#485). An empty value (or one with only blanks) yields
-// nil so ResolvedDeterministicCheckers falls back to the safe default set. It never
-// errors: an unknown name is simply ignored downstream (best-effort), so a typo
-// degrades to fewer dimensions rather than failing the daemon's config load.
-func parseDeterministicCheckerList(value string) []string {
-	return parseConfigStringList(value)
+// per-checker selector. TOML string arrays are canonical; the historical bare
+// comma list remains a compatibility read. Quoted whole-list values are rejected
+// because they previously split into corrupted checker names, and every resolved
+// name is validated so a typo cannot silently disable a checker.
+func parseDeterministicCheckerList(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	var (
+		checkers []string
+		err      error
+	)
+	switch {
+	case value == "":
+		return nil, nil
+	case strings.HasPrefix(value, "["):
+		checkers, err = parseConfigStringArray(value)
+	case strings.HasPrefix(value, "\"") || strings.HasPrefix(value, "'"):
+		return nil, fmt.Errorf("quoted checker lists are invalid; use a TOML array such as [\"diff_size\", \"lint\"]")
+	default:
+		checkers = parseConfigStringList(value)
+	}
+	if err != nil {
+		return nil, err
+	}
+	for _, checker := range checkers {
+		if !validDeterministicChecker(checker) {
+			return nil, fmt.Errorf("unknown deterministic checker %q", checker)
+		}
+	}
+	return checkers, nil
+}
+
+func validDeterministicChecker(name string) bool {
+	switch name {
+	case "diff_size", "duplication", "lint", "complexity":
+		return true
+	default:
+		return false
+	}
 }
 
 // parseConfigStringList parses a plain comma list (e.g. "a, b ,c") into a

--- a/internal/config/orchestrate.go
+++ b/internal/config/orchestrate.go
@@ -1006,7 +1006,9 @@ func LoadSkillOptPolicy(paths Paths) (SkillOptPolicy, error) {
 	}
 	policy := DefaultSkillOptPolicy()
 	current := false
-	for _, raw := range strings.Split(string(content), "\n") {
+	lines := strings.Split(string(content), "\n")
+	for i := 0; i < len(lines); i++ {
+		raw := lines[i]
 		line := strings.TrimSpace(stripConfigComment(raw))
 		if line == "" {
 			continue
@@ -1023,8 +1025,13 @@ func LoadSkillOptPolicy(paths Paths) (SkillOptPolicy, error) {
 		if !ok {
 			continue
 		}
-		if err := applySkillOptPolicyField(&policy, strings.TrimSpace(key), strings.TrimSpace(value)); err != nil {
-			return SkillOptPolicy{}, fmt.Errorf("parse [skillopt].%s: %w", strings.TrimSpace(key), err)
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "deterministic_checkers" {
+			value, i = joinDeterministicCheckerArrayValue(lines, i, value)
+		}
+		if err := applySkillOptPolicyField(&policy, key, value); err != nil {
+			return SkillOptPolicy{}, fmt.Errorf("parse [skillopt].%s: %w", key, err)
 		}
 	}
 	return policy, nil
@@ -1230,7 +1237,7 @@ func parseDeterministicCheckerList(value string) ([]string, error) {
 	case value == "":
 		return nil, nil
 	case strings.HasPrefix(value, "["):
-		checkers, err = parseConfigStringArray(value)
+		checkers, err = parseDeterministicCheckerArray(value)
 	case strings.HasPrefix(value, "\"") || strings.HasPrefix(value, "'"):
 		return nil, fmt.Errorf("quoted checker lists are invalid; use a TOML array such as [\"diff_size\", \"lint\"]")
 	default:
@@ -1245,6 +1252,51 @@ func parseDeterministicCheckerList(value string) ([]string, error) {
 		}
 	}
 	return checkers, nil
+}
+
+func joinDeterministicCheckerArrayValue(lines []string, start int, value string) (string, int) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "[") || strings.HasSuffix(value, "]") {
+		return value, start
+	}
+	parts := []string{value}
+	end := start
+	for i := start + 1; i < len(lines); i++ {
+		end = i
+		part := strings.TrimSpace(stripConfigComment(lines[i]))
+		if part == "" {
+			continue
+		}
+		parts = append(parts, part)
+		if strings.HasSuffix(part, "]") {
+			break
+		}
+	}
+	return strings.Join(parts, " "), end
+}
+
+func parseDeterministicCheckerArray(value string) ([]string, error) {
+	value = strings.TrimSpace(value)
+	if !strings.HasPrefix(value, "[") || !strings.HasSuffix(value, "]") {
+		return nil, fmt.Errorf("expected string array")
+	}
+	inner := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(value, "["), "]"))
+	if inner == "" {
+		return nil, nil
+	}
+	parts := strings.Split(inner, ",")
+	values := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		parsed, err := parseConfigString(part)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, parsed)
+	}
+	return compactConfigStrings(values), nil
 }
 
 func validDeterministicChecker(name string) bool {

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -434,14 +434,23 @@ deterministic_checkers = diff_size, duplication ,lint
 }
 
 func TestLoadSkillOptPolicyDeterministicCheckerListGrammar(t *testing.T) {
-	want := []string{"diff_size", "duplication", "lint", "complexity"}
+	all := []string{"diff_size", "duplication", "lint", "complexity"}
 	for _, tc := range []struct {
-		name    string
-		value   string
-		wantErr string
+		name          string
+		value         string
+		after         string
+		want          []string
+		wantAutoTrace bool
+		wantErr       string
 	}{
-		{name: "legacy bare", value: `diff_size, duplication, lint, complexity`},
-		{name: "canonical array", value: `["diff_size", "duplication", "lint", "complexity"]`},
+		{name: "legacy bare", value: `diff_size, duplication, lint, complexity`, want: all},
+		{name: "canonical array", value: `["diff_size", "duplication", "lint", "complexity"]`, want: all},
+		{name: "single-line trailing comma", value: `["diff_size", "duplication", "lint", "complexity",]`, want: all},
+		{name: "multi-line array", value: "[\n  \"diff_size\",\n  \"duplication\",\n  \"lint\",\n  \"complexity\"\n]", want: all},
+		{name: "multi-line trailing comma", value: "[\n  \"diff_size\",\n  \"duplication\",\n  \"lint\",\n  \"complexity\",\n]", want: all},
+		{name: "empty multi-line array", value: "[\n\n]", want: DefaultDeterministicCheckers},
+		{name: "multi-line comment", value: "[\n  \"diff_size\",\n  # retained TOML comment\n  \"duplication\",\n  \"lint\",\n  \"complexity\",\n]", want: all},
+		{name: "following key is not swallowed", value: "[\n  \"diff_size\",\n  \"duplication\",\n  \"lint\",\n  \"complexity\",\n]", after: "auto_trace_enabled = true\n", want: all, wantAutoTrace: true},
 		{name: "quoted whole", value: `"diff_size, duplication, lint, complexity"`, wantErr: "quoted checker lists"},
 		{name: "single quoted whole", value: `'diff_size, duplication, lint, complexity'`, wantErr: "quoted checker lists"},
 	} {
@@ -450,7 +459,7 @@ func TestLoadSkillOptPolicyDeterministicCheckerListGrammar(t *testing.T) {
 			if err := Initialize(paths); err != nil {
 				t.Fatalf("Initialize: %v", err)
 			}
-			contents := DefaultConfig(paths) + "\n[skillopt]\ndeterministic_checkers = " + tc.value + "\n"
+			contents := DefaultConfig(paths) + "\n[skillopt]\ndeterministic_checkers = " + tc.value + "\n" + tc.after
 			if err := os.WriteFile(paths.ConfigFile, []byte(contents), 0o600); err != nil {
 				t.Fatalf("write config: %v", err)
 			}
@@ -465,8 +474,11 @@ func TestLoadSkillOptPolicyDeterministicCheckerListGrammar(t *testing.T) {
 				t.Fatalf("LoadSkillOptPolicy: %v", err)
 			}
 			got := policy.ResolvedDeterministicCheckers()
-			if !slices.Equal(got, want) {
-				t.Fatalf("resolved checkers = %v, want %v", got, want)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("resolved checkers = %v, want %v", got, tc.want)
+			}
+			if policy.AutoTraceEnabled != tc.wantAutoTrace {
+				t.Fatalf("auto_trace_enabled = %v, want %v", policy.AutoTraceEnabled, tc.wantAutoTrace)
 			}
 		})
 	}

--- a/internal/config/skillopt_test.go
+++ b/internal/config/skillopt_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -428,6 +430,63 @@ deterministic_checkers = diff_size, duplication ,lint
 		if got[i] != want[i] {
 			t.Fatalf("resolved checkers[%d] = %q, want %q (got %v)", i, got[i], want[i], got)
 		}
+	}
+}
+
+func TestLoadSkillOptPolicyDeterministicCheckerListGrammar(t *testing.T) {
+	want := []string{"diff_size", "duplication", "lint", "complexity"}
+	for _, tc := range []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "legacy bare", value: `diff_size, duplication, lint, complexity`},
+		{name: "canonical array", value: `["diff_size", "duplication", "lint", "complexity"]`},
+		{name: "quoted whole", value: `"diff_size, duplication, lint, complexity"`, wantErr: "quoted checker lists"},
+		{name: "single quoted whole", value: `'diff_size, duplication, lint, complexity'`, wantErr: "quoted checker lists"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := PathsForHome(t.TempDir())
+			if err := Initialize(paths); err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			contents := DefaultConfig(paths) + "\n[skillopt]\ndeterministic_checkers = " + tc.value + "\n"
+			if err := os.WriteFile(paths.ConfigFile, []byte(contents), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+			policy, err := LoadSkillOptPolicy(paths)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("LoadSkillOptPolicy error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadSkillOptPolicy: %v", err)
+			}
+			got := policy.ResolvedDeterministicCheckers()
+			if !slices.Equal(got, want) {
+				t.Fatalf("resolved checkers = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestLoadSkillOptPolicyRejectsUnknownDeterministicChecker(t *testing.T) {
+	paths := PathsForHome(t.TempDir())
+	if err := Initialize(paths); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	contents := DefaultConfig(paths) + `
+[skillopt]
+deterministic_checkers = ["diff_size", "typo_checker"]
+`
+	if err := os.WriteFile(paths.ConfigFile, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, err := LoadSkillOptPolicy(paths)
+	if err == nil || !strings.Contains(err.Error(), `unknown deterministic checker "typo_checker"`) {
+		t.Fatalf("LoadSkillOptPolicy error = %v, want offending checker name", err)
 	}
 }
 

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -650,7 +650,9 @@ mean-of-dimensions path, and written as a **third** `FeedbackEvent` in the SAME
 distinct item id (`checker#<repo>#<pr>`), so it **coexists with** both the
 verifiable floor (`gitmoot-auto`) and the cross-family review (`gitmoot-review`)
 instead of overwriting either. The optional `[skillopt].deterministic_checkers`
-comma list selects which run (default `diff_size` only).
+TOML string array selects which run (default `["diff_size"]`). Legacy bare comma
+lists remain readable but are deprecated; quoted whole lists and unknown checker
+names fail config loading rather than silently dropping checks.
 
 These dimensions are **objective and un-gameable** (tool-measured, not estimated),
 tagged `objective = true` on the eval item (alongside the projected `checker_score`

--- a/skills/gitmoot/references/WORKFLOWS.md
+++ b/skills/gitmoot/references/WORKFLOWS.md
@@ -582,7 +582,7 @@ auto_trace_enabled = true              # off by default
 cross_family_review_enabled = false    # off by default; also needs auto_trace_enabled
 revert_detection_enabled = true        # unset = on when auto_trace_enabled; set false to opt out (#467)
 deterministic_checkers_enabled = false # off by default; also needs auto_trace_enabled (#485)
-deterministic_checkers = diff_size     # optional comma list; default = diff_size only
+deterministic_checkers = ["diff_size"] # optional TOML array; default = diff_size only
 ```
 
 With `auto_trace_enabled = true`, a merge (passing CI vs. empty-gate), a
@@ -640,8 +640,10 @@ patches; always available, no tool/checkout needed), normalizes each to `[0,1]`,
 and writes a **third** `FeedbackEvent` in the SAME `auto-trace:<version>` run under
 the fixed `gitmoot-checker` reviewer sentinel + a distinct item id
 (`checker#<repo>#<pr>`), so it coexists with both the verifiable floor and the
-cross-family review. The `deterministic_checkers` comma list selects which run
-(default `diff_size` only). It is **fail-safe**: a missing tool, no checkout, a
+cross-family review. The `deterministic_checkers` TOML string array selects which
+run (default `diff_size` only). Legacy bare comma lists remain readable but are
+deprecated; quoted whole lists and unknown checker names fail config loading
+rather than silently dropping checks. It is **fail-safe**: a missing tool, no checkout, a
 tool error, or a timeout SKIPS that one dimension (never the harvest, never the
 merge); an all-skipped run writes no row. The dimensions are objective and
 un-gameable, tagged `objective = true`, additive (`contract_version` stays `1`),

--- a/website/docs/reference/skillopt-exchange-contract.md
+++ b/website/docs/reference/skillopt-exchange-contract.md
@@ -322,8 +322,10 @@ quality, the checker runs plain external **tools** that *measure* it exactly:
 - **`complexity`** — over-threshold function count via `gocyclo`.
 
 Each tool dimension is normalized to `[0,1]` (fewer issues → higher). The optional
-`[skillopt].deterministic_checkers` comma list selects which run (default:
-`diff_size` only); widen it to opt heavy tools in. The dimensions map to
+`[skillopt].deterministic_checkers` TOML string array selects which run (default:
+`["diff_size"]`); widen it to opt heavy tools in. Legacy bare comma lists remain
+readable but are deprecated. Quoted whole lists and unknown checker names fail
+config loading rather than silently dropping checks. The dimensions map to
 `dimension_scores`, are fused by the **mean-of-dimensions** path, and are written as
 a **third** `FeedbackEvent` in the SAME `auto-trace:<version>` run under a distinct
 item id (`checker#<repo>#<pr>`) and the fixed `gitmoot-checker` reviewer sentinel —

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -6152,8 +6152,10 @@ quality, the checker runs plain external **tools** that *measure* it exactly:
 - **`complexity`** — over-threshold function count via `gocyclo`.
 
 Each tool dimension is normalized to `[0,1]` (fewer issues → higher). The optional
-`[skillopt].deterministic_checkers` comma list selects which run (default:
-`diff_size` only); widen it to opt heavy tools in. The dimensions map to
+`[skillopt].deterministic_checkers` TOML string array selects which run (default:
+`["diff_size"]`); widen it to opt heavy tools in. Legacy bare comma lists remain
+readable but are deprecated. Quoted whole lists and unknown checker names fail
+config loading rather than silently dropping checks. The dimensions map to
 `dimension_scores`, are fused by the **mean-of-dimensions** path, and are written as
 a **third** `FeedbackEvent` in the SAME `auto-trace:<version>` run under a distinct
 item id (`checker#<repo>#<pr>`) and the fixed `gitmoot-checker` reviewer sentinel —
@@ -14974,7 +14976,7 @@ auto_trace_enabled = true              # off by default
 cross_family_review_enabled = false    # off by default; also needs auto_trace_enabled
 revert_detection_enabled = true        # unset = on when auto_trace_enabled; set false to opt out (#467)
 deterministic_checkers_enabled = false # off by default; also needs auto_trace_enabled (#485)
-deterministic_checkers = diff_size     # optional comma list; default = diff_size only
+deterministic_checkers = ["diff_size"] # optional TOML array; default = diff_size only
 ```
 
 With `auto_trace_enabled = true`, a merge (passing CI vs. empty-gate), a
@@ -15032,8 +15034,10 @@ patches; always available, no tool/checkout needed), normalizes each to `[0,1]`,
 and writes a **third** `FeedbackEvent` in the SAME `auto-trace:<version>` run under
 the fixed `gitmoot-checker` reviewer sentinel + a distinct item id
 (`checker#<repo>#<pr>`), so it coexists with both the verifiable floor and the
-cross-family review. The `deterministic_checkers` comma list selects which run
-(default `diff_size` only). It is **fail-safe**: a missing tool, no checkout, a
+cross-family review. The `deterministic_checkers` TOML string array selects which
+run (default `diff_size` only). Legacy bare comma lists remain readable but are
+deprecated; quoted whole lists and unknown checker names fail config loading
+rather than silently dropping checks. It is **fail-safe**: a missing tool, no checkout, a
 tool error, or a timeout SKIPS that one dimension (never the harvest, never the
 merge); an all-skipped run writes no row. The dimensions are objective and
 un-gameable, tagged `objective = true`, additive (`contract_version` stays `1`),
@@ -17359,7 +17363,9 @@ mean-of-dimensions path, and written as a **third** `FeedbackEvent` in the SAME
 distinct item id (`checker#<repo>#<pr>`), so it **coexists with** both the
 verifiable floor (`gitmoot-auto`) and the cross-family review (`gitmoot-review`)
 instead of overwriting either. The optional `[skillopt].deterministic_checkers`
-comma list selects which run (default `diff_size` only).
+TOML string array selects which run (default `["diff_size"]`). Legacy bare comma
+lists remain readable but are deprecated; quoted whole lists and unknown checker
+names fail config loading rather than silently dropping checks.
 
 These dimensions are **objective and un-gameable** (tool-measured, not estimated),
 tagged `objective = true` on the eval item (alongside the projected `checker_score`


### PR DESCRIPTION
WHAT:
CODEX Implemented #1463 v2 from base a3481426. Deterministic checker lists now accept canonical TOML arrays and legacy bare comma lists identically, reject quoted-whole and unknown values loudly, preserve legacy syntax during config mutations, and provide section-aware parse diagnostics. No direct validateConfigFile call was added.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-5058931f

RESULTS:
- go build ./...: exit 0, no output.
- go vet ./...: exit 0, no output.
- go test ./internal/config/: ok github.com/gitmoot/gitmoot/internal/config 0.357s.
- go test ./internal/cli/ -run '^TestAgentHeartbeat': ok github.com/gitmoot/gitmoot/internal/cli 1.621s. The full internal/cli package was not run per #1486.
- M1 DROP_LEGACY_BARE compiled: ok internal/config 0.003s [no tests to run]. TestLoadSkillOptPolicyDeterministicCheckerListGrammar/legacy_bare failed with `LoadSkillOptPolicy: parse [skillopt].deterministic_checkers: expected string array`. Restored guard passed: ok internal/config 0.024s.
- M2 SILENT_UNKNOWN_SKIP compiled: ok internal/config 0.003s [no tests to run]. TestLoadSkillOptPolicyRejectsUnknownDeterministicChecker failed with `LoadSkillOptPolicy error = <nil>, want offending checker name`. Restored guard passed: ok internal/config 0.013s.
- M3 INLINE_AB_FIELDS compiled: ok internal/config 0.003s [no tests to run]. TestValidateConfigFilePinsIndirectSkillOptPolicyCoverage failed with `validateConfigFile error = <nil>, want transitive checker validation`. Restored guard passed: ok internal/config 0.005s.
- M4 DROP_SECTION_CONTEXT compiled: ok internal/config 0.003s [no tests to run]. TestSaveHeartbeatParseErrorNamesUnrelatedSection failed because the error lacked `[skillopt]`. Restored guard passed: ok internal/config 0.013s.
- Mutant distinctness: M1-M4 were applied, compiled, executed, restored, and passed in four separate runs.
- Pre-fix isolated E2E: exit 1 with `agent heartbeat add: parse config: at 598:25: got word ("diff_size"), wanted value, array, or inline table`.
- Post-fix E2E against the same /tmp home and command: `configured heartbeat probe/check`; heartbeat show returned the persisted schedule, the checker policy resolved all four names, and the config retained `deterministic_checkers = diff_size,duplication,lint,complexity` unchanged.
- npm run build:llms ran twice; both outputs had SHA-256 dd9afa34271a8acbbf8bde351134a4987114ae401f21c9fca778c006b8f83970.
- go generate ./... && git diff --exit-code: exit 0, no output.
- git diff --cached --check and the unstaged git diff check passed. Final staged scope is 14 files, 425 insertions, and 45 deletions.

RISK:
Review the generated diff before merging.

TASK:
adhoc-5058931f

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
CODEX Implemented #1463 v2 from base a3481426. Deterministic checker lists now accept canonical TOML arrays and legacy bare comma lists identically, reject quoted-whole and unknown values loudly, preserve legacy syntax during config mutations, and provide section-aware parse diagnostics. No direct validateConfigFile call was added.
````
