### PR TITLE
feat(runtime): plan-mode dispatch surface for the omp adapter (#1479)

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -125,8 +125,17 @@ builder, so no flag can appear on one path and go missing on the other:
 ```sh
 omp -p --mode=json --approval-mode=yolo --no-session \
     [--add-dir <path>]… [--model <M>] [--thinking <level>] [--max-time <s>] \
+    [--plan-yolo [--plan-yolo-into <M>]] \
     [@<staged>/prompt.md] -- '<single prompt token>'
 ```
+
+`--plan-yolo` appears if and only if the job asked for plan mode (`plan` /
+`plan_into` on the job payload): omp plans the work first and then
+auto-executes that plan, with `--plan-yolo-into` pinning the model the execution
+phase runs on. It is orthogonal to `--approval-mode`, which stays `yolo` for
+every job, plan or not. `plan_into` without `plan` and a plan request routed to
+any non-omp runtime are both refused before dispatch — a plan-gated brief never
+silently degrades into an ordinary implementation.
 
 Startup stores the session id from the NDJSON header line, but delivery never
 uses it: omp is stateless in v1 and never passes `--resume`, `--continue`, or

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -130,12 +130,22 @@ omp -p --mode=json --approval-mode=yolo --no-session \
 ```
 
 `--plan-yolo` appears if and only if the job asked for plan mode (`plan` /
-`plan_into` on the job payload): omp plans the work first and then
-auto-executes that plan, with `--plan-yolo-into` pinning the model the execution
-phase runs on. It is orthogonal to `--approval-mode`, which stays `yolo` for
-every job, plan or not. `plan_into` without `plan` and a plan request routed to
-any non-omp runtime are both refused before dispatch — a plan-gated brief never
-silently degrades into an ordinary implementation.
+`plan_into` on the job payload), with `--plan-yolo-into` pinning the model the
+execution phase runs on. `plan_into` must be one non-flag model selector with no
+internal whitespace or control characters. It is orthogonal to
+`--approval-mode`, which stays `yolo` for every job, plan or not. `plan_into`
+without `plan`, malformed targets, and a plan request routed to any non-omp
+runtime are refused before dispatch — a plan-gated brief never silently
+degrades into an ordinary implementation. Runtime preflight requires the two
+plan flags only for plan requests; an ordinary omp job does not require them.
+
+This behavior description is grounded in a versioned CLI declaration, not an
+internal transition Gitmoot can observe. On `omp/17.2.4`, run
+`omp --version && omp --help`: the help declares that `--plan-yolo` starts in
+read-only plan mode, auto-approves the model's plan on its first resolve call,
+then executes it, and that `--plan-yolo-into` selects the execution model with
+the `smol` role as the default. Gitmoot verifies the installed flags and records
+the requested plan shape; it cannot verify omp's internal phase transitions.
 
 Startup stores the session id from the NDJSON header line, but delivery never
 uses it: omp is stateless in v1 and never passes `--resume`, `--continue`, or

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -583,7 +583,21 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	return buildLocalAgentJobOutput(latest, request)
 }
 
-var localRuntimeContractPreflight = runtime.DefaultRuntimeContractChecker().Check
+// localRuntimeContractPreflight is the FOREGROUND dispatch preflight. It is
+// request-shaped on purpose, matching the daemon worker's RuntimePreflight, so the
+// repo has ONE shape for one decision rather than two: the daemon threads
+// payload.Plan, and this must thread the request's plan the moment a CLI surface
+// can carry one.
+//
+// The empty request is correct TODAY and only today: no CLI flag reaches plan mode
+// (gitmoot#1425 owes that surface), so a foreground dispatch can never be a plan
+// request. When #1425 lands `--plan`, this call MUST pass it — otherwise the plan
+// flags are dispatched to an omp CLI whose support was never verified, and the
+// guard fails silently rather than loudly. That is the whole failure mode this
+// contract exists to prevent, so it is named here at the call site.
+var localRuntimeContractPreflight = func(ctx context.Context, agent runtime.Agent) runtime.RuntimeContractResult {
+	return runtime.DefaultRuntimeContractChecker().CheckRequest(ctx, agent, runtime.RuntimeContractRequest{Plan: false})
+}
 
 func promptHeadContradictionWarnings(ctx context.Context, git gitutil.Client, prompt string, dispatchHead string) []string {
 	if strings.TrimSpace(prompt) == "" {

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -63,7 +63,10 @@ func TestRuntimePreflightUnknownRecordsEventAndDispatches(t *testing.T) {
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return checkout, nil
 	}
-	worker.RuntimePreflight = func(context.Context, runtime.Agent) runtime.RuntimeContractResult {
+	worker.RuntimePreflight = func(_ context.Context, _ runtime.Agent, request runtime.RuntimeContractRequest) runtime.RuntimeContractResult {
+		if request.Plan {
+			t.Fatalf("ordinary preflight request = %#v, want no plan mode", request)
+		}
 		return runtime.RuntimeContractResult{Runtime: runtime.ShellRuntime, Version: "unknown", State: runtime.RuntimeContractUnknown, Instrument: "binary-help"}
 	}
 
@@ -91,14 +94,17 @@ func TestRuntimePreflightUnsupportedBlocksBeforeCheckout(t *testing.T) {
 	store := daemonWorkerStore(t)
 	seedDaemonWorkerRepo(t, store, "owner/repo", t.TempDir())
 	seedDaemonWorkerAgent(t, store, "audit", runtime.ShellRuntime, "true", []string{"ask"}, "owner/repo")
-	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-runtime-unsupported", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main"})
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{ID: "job-runtime-unsupported", Agent: "audit", Action: "ask", Repo: "owner/repo", Branch: "main", Plan: true, PlanInto: "@smol"})
 	worker := defaultJobWorker(store, io.Discard)
 	checkoutCalls := 0
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		checkoutCalls++
 		return "", nil
 	}
-	worker.RuntimePreflight = func(context.Context, runtime.Agent) runtime.RuntimeContractResult {
+	worker.RuntimePreflight = func(_ context.Context, _ runtime.Agent, request runtime.RuntimeContractRequest) runtime.RuntimeContractResult {
+		if !request.Plan {
+			t.Fatalf("preflight request = %#v, want plan mode threaded from payload", request)
+		}
 		return runtime.RuntimeContractResult{
 			Runtime: runtime.ShellRuntime, Version: "stub 1.2.3", State: runtime.RuntimeContractUnsupported, Instrument: "binary-help",
 			Requirements: []runtime.RuntimeRequirementResult{{Kind: runtime.RuntimeRequirementFlag, Name: "flag --required", Flag: "--required", Source: "internal/runtime/test::args", Remedy: "install a compatible runtime", State: runtime.RuntimeContractUnsupported, Instrument: "binary-help"}},

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -96,7 +96,7 @@ type jobWorker struct {
 	// RuntimePreflight evaluates the installed CLI contract immediately before
 	// checkout/adapter construction. nil keeps hand-built test workers unchanged;
 	// defaultJobWorker wires the process-wide identity cache.
-	RuntimePreflight func(context.Context, runtime.Agent) runtime.RuntimeContractResult
+	RuntimePreflight func(context.Context, runtime.Agent, runtime.RuntimeContractRequest) runtime.RuntimeContractResult
 	// Progress timing seams keep unit/E2E tests deterministic and short. Zero/nil
 	// values select the package defaults and real timer implementation.
 	PipelineProgressThreshold time.Duration
@@ -163,7 +163,7 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	worker.CheckoutValidator = worker.defaultCheckout
 	worker.WorkflowFactory = worker.defaultWorkflow
 	worker.AuthProbe = worker.defaultAuthProbe
-	worker.RuntimePreflight = runtime.DefaultRuntimeContractChecker().Check
+	worker.RuntimePreflight = runtime.DefaultRuntimeContractChecker().CheckRequest
 	worker.QuotaWake = newQuotaRoleUnavailableWakeClient()
 	recoverKillPendingAtWorkerStartup.Do(func() {
 		if err := recoverKillPendingJobs(context.Background(), store, stdout); err != nil {
@@ -247,7 +247,8 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	if !overridden {
 		agent = scopeRegisteredFreshRefForJob(agent, job.ID)
 	}
-	if result, checked := w.runtimeContractPreflight(ctx, agent); checked {
+	preflightRequest := runtime.RuntimeContractRequest{Plan: payload.Plan}
+	if result, checked := w.runtimeContractPreflight(ctx, agent, preflightRequest); checked {
 		if err := runtime.RuntimeContractDispatchError(agent, result); err != nil {
 			if finishErr := w.finishQueuedJob(ctx, job, workflow.JobBlocked, err); finishErr != nil {
 				return finishErr
@@ -755,11 +756,11 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	return nil
 }
 
-func (w jobWorker) runtimeContractPreflight(ctx context.Context, agent runtime.Agent) (runtime.RuntimeContractResult, bool) {
+func (w jobWorker) runtimeContractPreflight(ctx context.Context, agent runtime.Agent, request runtime.RuntimeContractRequest) (runtime.RuntimeContractResult, bool) {
 	if w.RuntimePreflight == nil {
 		return runtime.RuntimeContractResult{}, false
 	}
-	return w.RuntimePreflight(ctx, agent), true
+	return w.RuntimePreflight(ctx, agent, request), true
 }
 
 func (w jobWorker) lookupAgent(ctx context.Context, name string) (db.Agent, error) {

--- a/internal/cli/runtime_preflight_e2e_test.go
+++ b/internal/cli/runtime_preflight_e2e_test.go
@@ -127,7 +127,7 @@ func runRuntimePreflightStubJob(t *testing.T, rawHome string, checker *runtime.R
 	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
 		return checkout, nil
 	}
-	worker.RuntimePreflight = checker.Check
+	worker.RuntimePreflight = checker.CheckRequest
 	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
 		t.Fatalf("run queued job: %v", err)
 	}

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -531,10 +531,18 @@ func NormalizeStoredAutonomyPolicy(policy string) string {
 
 // SupportsPlanMode reports whether a runtime's CLI can honour a plan-mode job
 // (Job.Plan / Job.PlanInto). Plan mode is WORKFLOW SHAPE — plan first, then
-// auto-execute the plan — and is deliberately ORTHOGONAL to the autonomy policy,
-// which is write permission: conflating the two would repeat #1420's
-// overloaded-field defect and, on omp specifically, mapping it onto
-// --approval-mode would brick the runtime (see the ompRuntimeContract comment).
+// auto-execute the plan — and is a SEPARATE FIELD from the autonomy policy so the
+// two are not conflated into one overloaded knob (#1420's defect).
+//
+// SEPARATE IS NOT INDEPENDENT, and an earlier version of this doc got that wrong
+// twice. It called plan mode "orthogonal to write permission" and justified that
+// by claiming an autonomy-policy-to-approval-mode mapping "would brick the
+// runtime". Both are false: measured against omp 17.2.4, always-ask restricts omp
+// to read-only tools and exits cleanly (see the ompRuntimeContract comment), and
+// upstream plan mode ADDS the write tool to the active set rather than removing
+// it. Plan mode ends in an implementation phase, so a plan request is a WRITE
+// REQUEST and the dispatch gate requires the same write-granting policy an
+// implement job requires.
 //
 // omp is the only runtime with the flag today (`--plan-yolo`). The set is closed
 // on purpose: the dispatch layer refuses a plan request aimed anywhere else, so a
@@ -546,10 +554,15 @@ func SupportsPlanMode(runtimeName string) bool {
 }
 
 // PlanModeDescriptor renders the resolved plan shape as the durable evidence
-// string carried by Result.PlanMode: "" when plan mode is off, "plan" for a bare
-// plan run, and "plan-into:<model>" when the execution phase is pinned to a
-// specific model. A planInto without plan is not representable — it is rejected
-// before dispatch — so an unset plan always renders "".
+// string carried by Result.PlanMode: "" when plan mode is off, "plan-into:<model>"
+// when the execution phase is pinned to a model, and "plan-into:<runtime-default>"
+// when it is not — because the execution phase ALWAYS runs on some model, and the
+// evidence has to say whether Gitmoot chose it. Callers pass the RESOLVED target,
+// not the raw request field: a bare "plan" would let a run whose diff was written
+// by the runtime's cheap default look identical to one written by the pinned
+// model, which is the ambiguity this string exists to remove. A planInto without
+// plan is not representable — it is rejected before dispatch — so an unset plan
+// always renders "".
 func PlanModeDescriptor(plan bool, planInto string) string {
 	if !plan {
 		return ""
@@ -557,7 +570,7 @@ func PlanModeDescriptor(plan bool, planInto string) string {
 	if into := strings.TrimSpace(planInto); into != "" {
 		return "plan-into:" + into
 	}
-	return "plan"
+	return "plan-into:<runtime-default>"
 }
 
 // ImplementWritePolicyGuidance is the single, actionable message emitted whenever

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -206,11 +206,13 @@ type Result struct {
 	SessionEphemeral bool
 	// PlanMode is the adapter's own evidence of the plan shape it DISPATCHED, so a
 	// reader can tell a plan run from a normal one without re-deriving it from the
-	// argv: "" for a normal run, PlanModeDescriptor's "plan" for a bare plan run,
-	// or "plan-into:<model>" when the execution phase was pinned. Adapters that
-	// cannot honour plan mode never set it (the dispatch layer rejects the request
-	// before they are reached), and it is populated on failure returns too — a
-	// plan run that died is still a plan run.
+	// argv: "" for a normal run, "plan-into:<model>" when Gitmoot resolved the
+	// execution target, and "plan-into:<runtime-default>" when it could not. There
+	// is deliberately no bare "plan" value — the execution phase always runs on some
+	// model, and a value that declined to say which is the ambiguity this field
+	// exists to remove. Adapters that cannot honour plan mode never set it (the
+	// dispatch layer rejects the request before they are reached), and it is
+	// populated on failure returns too — a plan run that died is still a plan run.
 	PlanMode string
 	// SessionDiag carries process-level diagnostics for the runtime CLI run
 	// backing this delivery (#806). Adapters populate it best-effort on every

--- a/internal/runtime/adapter.go
+++ b/internal/runtime/adapter.go
@@ -113,6 +113,17 @@ type Job struct {
 	PullRequest int
 	Model       string
 	Effort      string
+	// Plan and PlanInto request PLAN MODE for this delivery: the runtime plans the
+	// work first and then AUTO-EXECUTES that plan, instead of implementing straight
+	// from the prompt. They are PRIMITIVES on purpose — the workflow layer resolves
+	// them from JobPayload exactly the way it resolves Model/Effort, so
+	// internal/runtime never learns the payload type. PlanInto names the model the
+	// execution phase runs on and REQUIRES Plan; the pair is rejected before any
+	// subprocess otherwise. Only the runtimes SupportsPlanMode reports can honour
+	// them — a plan request routed anywhere else fails loudly at dispatch rather
+	// than silently degrading to a normal run.
+	Plan     bool
+	PlanInto string
 	// ShellEnv is an exact list of KEY=value trigger inputs and stage metadata
 	// injected into shell-stage subprocesses. Other runtimes ignore it; ordinary
 	// shell jobs leave it empty.
@@ -193,6 +204,14 @@ type Result struct {
 	// self-heal path (a genuinely dead pinned session, replaced permanently) leaves
 	// this false so its re-pin IS persisted.
 	SessionEphemeral bool
+	// PlanMode is the adapter's own evidence of the plan shape it DISPATCHED, so a
+	// reader can tell a plan run from a normal one without re-deriving it from the
+	// argv: "" for a normal run, PlanModeDescriptor's "plan" for a bare plan run,
+	// or "plan-into:<model>" when the execution phase was pinned. Adapters that
+	// cannot honour plan mode never set it (the dispatch layer rejects the request
+	// before they are reached), and it is populated on failure returns too — a
+	// plan run that died is still a plan run.
+	PlanMode string
 	// SessionDiag carries process-level diagnostics for the runtime CLI run
 	// backing this delivery (#806). Adapters populate it best-effort on every
 	// Deliver return that actually ran a CLI process — success and failure alike —
@@ -508,6 +527,37 @@ func NormalizeStoredAutonomyPolicy(policy string) string {
 		return AutonomyPolicyAuto
 	}
 	return normalized
+}
+
+// SupportsPlanMode reports whether a runtime's CLI can honour a plan-mode job
+// (Job.Plan / Job.PlanInto). Plan mode is WORKFLOW SHAPE — plan first, then
+// auto-execute the plan — and is deliberately ORTHOGONAL to the autonomy policy,
+// which is write permission: conflating the two would repeat #1420's
+// overloaded-field defect and, on omp specifically, mapping it onto
+// --approval-mode would brick the runtime (see the ompRuntimeContract comment).
+//
+// omp is the only runtime with the flag today (`--plan-yolo`). The set is closed
+// on purpose: the dispatch layer refuses a plan request aimed anywhere else, so a
+// runtime that grows the capability must be added HERE and taught to emit its own
+// flag in the same change. Failing loudly beats a plan-gated brief silently
+// running as an ordinary implementation.
+func SupportsPlanMode(runtimeName string) bool {
+	return strings.TrimSpace(runtimeName) == OmpRuntime
+}
+
+// PlanModeDescriptor renders the resolved plan shape as the durable evidence
+// string carried by Result.PlanMode: "" when plan mode is off, "plan" for a bare
+// plan run, and "plan-into:<model>" when the execution phase is pinned to a
+// specific model. A planInto without plan is not representable — it is rejected
+// before dispatch — so an unset plan always renders "".
+func PlanModeDescriptor(plan bool, planInto string) string {
+	if !plan {
+		return ""
+	}
+	if into := strings.TrimSpace(planInto); into != "" {
+		return "plan-into:" + into
+	}
+	return "plan"
 }
 
 // ImplementWritePolicyGuidance is the single, actionable message emitted whenever

--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -213,8 +213,22 @@ func (a OmpAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, 
 	// Plan shape is validated before the PATH preflight: it is a property of the
 	// REQUEST, so it is wrong for its diagnosis to depend on whether omp happens to
 	// be installed.
+	//
+	// The pairing check is about the REQUEST (plan_into without plan is a malformed
+	// ask), so it takes the request field. The character check is about the RESOLVED
+	// target, because carrying the job's effective model into --plan-yolo-into moved
+	// a SECOND value into that argv slot: a plan job with Model "--add-dir=/"
+	// produced `--model --add-dir=/ --plan-yolo --plan-yolo-into --add-dir=/`.
+	// Hardening one input and routing another into the same position is not
+	// hardening. They are separate calls because the resolved target is non-empty
+	// for ordinary non-plan jobs too, where the pairing rule must NOT fire.
 	if err := ompValidatePlan(job.Plan, job.PlanInto); err != nil {
 		return Result{}, err
+	}
+	if job.Plan {
+		if err := ompValidatePlanTarget(ompPlanTarget(EffectiveModel(agent, job), job.PlanInto)); err != nil {
+			return Result{}, err
+		}
 	}
 	// PATH preflight before anything else runs: the daemon's PATH comes from its
 	// systemd EnvironmentFile, so "works in my shell" is not evidence the daemon
@@ -415,20 +429,35 @@ var ompRuntimeContract = RuntimeContract{
 	},
 }
 
-// ompValidatePlan rejects a plan request omp's CLI cannot honour BEFORE any
+// ompValidatePlan rejects a plan REQUEST shape omp's CLI cannot honour BEFORE any
 // subprocess runs. `--plan-yolo-into` without `--plan-yolo` makes omp exit
 // non-zero with no NDJSON envelope at all, which this adapter would diagnose as a
 // truncated stream — the wrong cause for a request shape we can reject here with
-// the actual fix.
+// the actual fix. It also rejects a malformed requested target early, so the
+// operator hears about the field they actually set.
 func ompValidatePlan(plan bool, planInto string) error {
 	into := strings.TrimSpace(planInto)
 	if into != "" && !plan {
 		return fmt.Errorf("omp plan target %q requires plan mode: --plan-yolo-into is only accepted alongside --plan-yolo (set plan on the job, or drop plan_into)", into)
 	}
-	if into != "" && (strings.HasPrefix(into, "-") || strings.IndexFunc(into, func(r rune) bool {
+	return ompValidatePlanTarget(into)
+}
+
+// ompValidatePlanTarget rejects any value that would land at the --plan-yolo-into
+// argv position. It is applied to the RESOLVED target, not only to a caller's
+// plan_into, because the resolver falls back to the job's effective model — so a
+// model value reaches a flag-value slot and inherits this slot's rules. A leading
+// `-` would be read as a flag by a stricter parser than today's; whitespace or a
+// control character in a model selector reaches execve.
+func ompValidatePlanTarget(target string) error {
+	into := strings.TrimSpace(target)
+	if into == "" {
+		return nil
+	}
+	if strings.HasPrefix(into, "-") || strings.IndexFunc(into, func(r rune) bool {
 		return unicode.IsSpace(r) || unicode.IsControl(r)
-	}) >= 0) {
-		return fmt.Errorf("omp plan target %q is invalid: plan_into must be one non-flag model selector without whitespace or control characters (for example @smol or provider/model); correct it or drop plan_into", into)
+	}) >= 0 {
+		return fmt.Errorf("omp plan target %q is invalid: the plan execution target must be one non-flag model selector without whitespace or control characters (for example @smol or provider/model). It is either the job's plan_into or, when that is unset, the job's effective model — correct whichever is set", into)
 	}
 	return nil
 }

--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -232,8 +232,11 @@ func (a OmpAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, 
 		return Result{}, err
 	}
 	defer cleanup()
-	planMode := PlanModeDescriptor(job.Plan, job.PlanInto)
-	args := ompArgs(agent, EffectiveModel(agent, job), ompThinkingLevel(effectiveEffort(agent, job)), ompMaxTimeArg(ctx), job.Plan, job.PlanInto, attachArgs, promptArg)
+	// Evidence and argv resolve the SAME target through the same function, so the
+	// recorded plan_mode can never disagree with the model the run actually used.
+	effModel := EffectiveModel(agent, job)
+	planMode := PlanModeDescriptor(job.Plan, ompPlanTarget(effModel, job.PlanInto))
+	args := ompArgs(agent, effModel, ompThinkingLevel(effectiveEffort(agent, job)), ompMaxTimeArg(ctx), job.Plan, job.PlanInto, attachArgs, promptArg)
 	// STDIN INVARIANT: omp's CLI reads stdin to EOF for every non-protocol mode,
 	// including --mode=json (main.ts:1209 calls readPipedInput, main.ts:191-207 does
 	// `await Bun.stdin.text()` whenever `process.stdin.isTTY === false`). It is safe
@@ -363,16 +366,27 @@ func (a OmpAdapter) preflight() error {
 //
 //   - `-p --mode=json` selects print mode with the NDJSON envelope this adapter
 //     parses; without --mode=json omp prints prose and every job fails extraction.
-//   - `--approval-mode=yolo` is passed EXPLICITLY for every autonomy policy. omp's
-//     default tool tier is "exec" and its read/grep/ls tools declare no tier at
-//     all, so under `always-ask` every headless tool call THROWS ("requires
-//     approval but no interactive UI available") — a policy-to-approval mapping
-//     would brick the runtime rather than restrict it. Omitting the flag instead
+//   - `--approval-mode=yolo` is passed EXPLICITLY for every autonomy policy, for
+//     DETERMINISM, not because a policy mapping is impossible. Omitting the flag
 //     would inherit whatever tools.approvalMode the host config carries, which is
-//     not deterministic across machines. read-only stays enforced Gitmoot-side by
-//     readOnlyImplementationBlocked (the kimi precedent) and by NOTHING ELSE: the
-//     Landlock wrapper selects by runtime NAME and wraps only claude/kimi (both
-//     call sites in cli/daemon_worker.go), so no omp process is ever confined.
+//     not deterministic across machines.
+//     A previous version of this comment claimed always-ask would "brick the
+//     runtime" because read/grep/ls declare no tier and every headless call
+//     throws. That was WRONG and is corrected here against a measurement of the
+//     pinned CLI (omp 17.2.4, headless, stdin closed, no host pre-approvals):
+//     read, grep and read-on-a-directory all return isError:false and SUCCEED;
+//     bash and write return isError:true with "requires approval but no
+//     interactive UI available" and the write does not land; the process still
+//     exits 0 with a full agent_end envelope this adapter parses. So always-ask
+//     RESTRICTS omp to read-only tools and terminates cleanly — which is exactly
+//     what a read-only autonomy policy wants. omp 17.2.4 has no `ls` tool at all.
+//     Mapping autonomy policy onto --approval-mode is therefore a live option for
+//     #1479's dispatch-surface question, not a foreclosed one; it is simply not
+//     done here, and this comment must not be cited as a reason it cannot be.
+//     Today read-only stays enforced Gitmoot-side by readOnlyImplementationBlocked
+//     (the kimi precedent) and by NOTHING ELSE: the Landlock wrapper selects by
+//     runtime NAME and wraps only claude/kimi (both call sites in
+//     cli/daemon_worker.go), so no omp process is ever confined.
 //   - `--no-session` keeps the run in memory: no per-worktree session .jsonl
 //     accretion, and nothing to accidentally resume (v1 never resumes).
 //   - the prompt is exactly ONE token after `--`: multiple positionals become
@@ -419,6 +433,19 @@ func ompValidatePlan(plan bool, planInto string) error {
 	return nil
 }
 
+// ompPlanTarget resolves the model the plan's EXECUTION phase runs on: an explicit
+// plan_into if the caller set one, otherwise the job's effective model so the pin
+// governs the phase that writes the code. Both empty leaves the flag off and omp
+// falls back to its own "@smol" default — the one case Gitmoot cannot name, and the
+// reason PlanModeDescriptor reports "plan-into:<runtime-default>" there instead of
+// claiming a target it did not choose.
+func ompPlanTarget(model string, planInto string) string {
+	if into := strings.TrimSpace(planInto); into != "" {
+		return into
+	}
+	return strings.TrimSpace(model)
+}
+
 func ompArgs(agent Agent, model string, thinking string, maxTime string, plan bool, planInto string, attachArgs []string, prompt string) []string {
 	args := []string{"-p", "--mode=json", "--approval-mode=yolo", "--no-session"}
 	args = append(args, ompWorkspaceArgs(agent)...)
@@ -432,11 +459,19 @@ func ompArgs(agent Agent, model string, thinking string, maxTime string, plan bo
 		args = append(args, "--max-time", maxTime)
 	}
 	// Plan mode is opt-in and never inferred: no plan request, no flag, so a normal
-	// run's argv stays byte-identical. --plan-yolo-into is meaningless on its own
-	// (ompValidatePlan already refused that shape) and so is nested under it here.
+	// run's argv stays byte-identical.
+	//
+	// THE EXECUTION PHASE IS A MODEL SWITCH, so --plan-yolo-into is resolved here
+	// rather than left to omp. Upstream takes `parsed.planYoloInto ?? "@smol"` and
+	// pins the implementing phase to it (main.ts:1030-1042 -> setModelTemporary),
+	// so a bare --plan-yolo means the job's model plans and omp's cheap smol role
+	// writes the diff — the job's pin silently not applying to the phase that
+	// produces the change, and Result.PlanMode unable to say which model did. An
+	// explicit plan_into always wins; otherwise the job's effective model carries
+	// through, so plan mode changes the workflow shape and nothing else.
 	if plan {
 		args = append(args, "--plan-yolo")
-		if into := strings.TrimSpace(planInto); into != "" {
+		if into := ompPlanTarget(model, planInto); into != "" {
 			args = append(args, "--plan-yolo-into", into)
 		}
 	}
@@ -450,8 +485,13 @@ func ompArgs(agent Agent, model string, thinking string, maxTime string, plan bo
 // cooperative visibility hints for omp's own file layer and NOT an enforcement
 // boundary: --add-dir does not make the readable subset read-only, and omp gets no
 // Landlock confinement underneath either (that wrapper selects by runtime name and
-// wraps only claude/kimi). readOnlyImplementationBlocked is the ONLY gate that
-// keeps a read-only omp agent from writing.
+// wraps only claude/kimi). TWO gates keep a read-only omp agent from writing, and
+// they cover disjoint job shapes: readOnlyImplementationBlocked refuses an
+// implement-typed job (it returns false for every other type), and the mailbox
+// plan gate refuses a plan-mode job of ANY type. Before that second gate existed,
+// an `ask` job carrying plan was a write bypass on a read-only seat — plan mode
+// auto-executes and upstream adds the write tool — so if you add a third path that
+// can end in a write, it needs its own gate here; neither existing one will cover it.
 func ompWorkspaceArgs(agent Agent) []string {
 	var args []string
 	for _, path := range agent.WritablePaths {

--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -120,7 +120,10 @@ func (a OmpAdapter) Start(ctx context.Context, request StartRequest) (StartResul
 		return StartResult{}, err
 	}
 	defer cleanup()
-	args := ompArgs(request.Agent, request.Agent.Model, ompThinkingLevel(request.Agent.Effort), ompMaxTimeArg(ctx), attachArgs, promptArg)
+	// Start never carries a plan request: it registers a seat, it does not run a
+	// brief. The primitives are passed explicitly so the single argv builder has no
+	// implicit default to drift from.
+	args := ompArgs(request.Agent, request.Agent.Model, ompThinkingLevel(request.Agent.Effort), ompMaxTimeArg(ctx), false, "", attachArgs, promptArg)
 	result, err := a.runner().Run(ctx, a.Dir, "omp", args...)
 	if err != nil {
 		return StartResult{Raw: result.Stdout + result.Stderr}, ompCommandError(result, err)
@@ -206,6 +209,12 @@ func (a OmpAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, 
 	if err := a.Validate(ctx, agent); err != nil {
 		return Result{}, err
 	}
+	// Plan shape is validated before the PATH preflight: it is a property of the
+	// REQUEST, so it is wrong for its diagnosis to depend on whether omp happens to
+	// be installed.
+	if err := ompValidatePlan(job.Plan, job.PlanInto); err != nil {
+		return Result{}, err
+	}
 	// PATH preflight before anything else runs: the daemon's PATH comes from its
 	// systemd EnvironmentFile, so "works in my shell" is not evidence the daemon
 	// can spawn omp. Failing here means ZERO subprocesses ran and the operator gets
@@ -222,7 +231,8 @@ func (a OmpAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, 
 		return Result{}, err
 	}
 	defer cleanup()
-	args := ompArgs(agent, EffectiveModel(agent, job), ompThinkingLevel(effectiveEffort(agent, job)), ompMaxTimeArg(ctx), attachArgs, promptArg)
+	planMode := PlanModeDescriptor(job.Plan, job.PlanInto)
+	args := ompArgs(agent, EffectiveModel(agent, job), ompThinkingLevel(effectiveEffort(agent, job)), ompMaxTimeArg(ctx), job.Plan, job.PlanInto, attachArgs, promptArg)
 	// STDIN INVARIANT: omp's CLI reads stdin to EOF for every non-protocol mode,
 	// including --mode=json (main.ts:1209 calls readPipedInput, main.ts:191-207 does
 	// `await Bun.stdin.text()` whenever `process.stdin.isTTY === false`). It is safe
@@ -246,6 +256,7 @@ func (a OmpAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, 
 			Raw:          result.Stdout + result.Stderr,
 			InputTokens:  usage.InputTokens,
 			OutputTokens: usage.OutputTokens,
+			PlanMode:     planMode,
 			SessionDiag:  newSessionDiag(result, err, sessionID),
 		}, ompCommandError(result, err)
 	}
@@ -265,6 +276,7 @@ func (a OmpAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, 
 			Raw:          result.Stdout,
 			InputTokens:  usage.InputTokens,
 			OutputTokens: usage.OutputTokens,
+			PlanMode:     planMode,
 			SessionDiag:  newSessionDiag(result, nil, sessionID),
 		}, ompCommandError(result, parseErr)
 	}
@@ -273,6 +285,7 @@ func (a OmpAdapter) Deliver(ctx context.Context, agent Agent, job Job) (Result, 
 		Summary:      strings.TrimSpace(content),
 		InputTokens:  usage.InputTokens,
 		OutputTokens: usage.OutputTokens,
+		PlanMode:     planMode,
 		SessionDiag:  newSessionDiag(result, nil, sessionID),
 	}, nil
 }
@@ -341,7 +354,8 @@ func (a OmpAdapter) preflight() error {
 // path and go missing on the other. Shape (asserted byte-for-byte in tests):
 //
 //	omp -p --mode=json --approval-mode=yolo --no-session [--add-dir <p>]…
-//	    [--model <M>] [--thinking <lvl>] [--max-time <s>] [@<staged>/prompt.md]
+//	    [--model <M>] [--thinking <lvl>] [--max-time <s>]
+//	    [--plan-yolo [--plan-yolo-into <M>]] [@<staged>/prompt.md]
 //	    -- <single prompt token>
 //
 // Every fixed element is load-bearing:
@@ -364,6 +378,16 @@ func (a OmpAdapter) preflight() error {
 //     multiple sequential (separately billed) turns, a prompt starting with `-` is
 //     read as an unknown flag and exits 2, and one starting with `@` is read as a
 //     file attachment. `--` disables all of that for the value that follows.
+//   - `--plan-yolo` is emitted IF AND ONLY IF the job asked for plan mode. It is
+//     ORTHOGONAL to --approval-mode: plan mode is workflow shape (plan first, then
+//     AUTO-EXECUTE the plan), the approval mode is write permission, and --plan-yolo
+//     starts read-only and auto-approves the model's own plan on its first resolve
+//     call. `--plan-yolo-into <M>` pins the model the execution phase runs on and is
+//     only accepted alongside --plan-yolo (omp's own default target is the "smol"
+//     role); ompValidatePlan rejects the unpaired form BEFORE any subprocess, and a
+//     plan request aimed at a runtime SupportsPlanMode rejects never reaches an argv
+//     at all. A silent downgrade to a normal run is the defect this ordering exists
+//     to prevent.
 var ompRuntimeContract = RuntimeContract{
 	Binary: "omp",
 	Requirements: []RuntimeRequirement{
@@ -371,10 +395,24 @@ var ompRuntimeContract = RuntimeContract{
 		{Kind: RuntimeRequirementFlag, Name: "flag --mode", Flag: "--mode", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --mode, or run the job on a runtime whose installed CLI satisfies its declared contract"},
 		{Kind: RuntimeRequirementFlag, Name: "flag --approval-mode", Flag: "--approval-mode", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --approval-mode, or run the job on a runtime whose installed CLI satisfies its declared contract"},
 		{Kind: RuntimeRequirementFlag, Name: "flag --no-session", Flag: "--no-session", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --no-session, or run the job on a runtime whose installed CLI satisfies its declared contract"},
+		{Kind: RuntimeRequirementFlag, Name: "flag --plan-yolo", Flag: "--plan-yolo", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --plan-yolo, or run the job on a runtime whose installed CLI satisfies its declared contract"},
+		{Kind: RuntimeRequirementFlag, Name: "flag --plan-yolo-into", Flag: "--plan-yolo-into", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --plan-yolo-into, or run the job on a runtime whose installed CLI satisfies its declared contract"},
 	},
 }
 
-func ompArgs(agent Agent, model string, thinking string, maxTime string, attachArgs []string, prompt string) []string {
+// ompValidatePlan rejects a plan request omp's CLI cannot honour BEFORE any
+// subprocess runs. `--plan-yolo-into` without `--plan-yolo` makes omp exit
+// non-zero with no NDJSON envelope at all, which this adapter would diagnose as a
+// truncated stream — the wrong cause for a request shape we can reject here with
+// the actual fix.
+func ompValidatePlan(plan bool, planInto string) error {
+	if into := strings.TrimSpace(planInto); into != "" && !plan {
+		return fmt.Errorf("omp plan target %q requires plan mode: --plan-yolo-into is only accepted alongside --plan-yolo (set plan on the job, or drop plan_into)", into)
+	}
+	return nil
+}
+
+func ompArgs(agent Agent, model string, thinking string, maxTime string, plan bool, planInto string, attachArgs []string, prompt string) []string {
 	args := []string{"-p", "--mode=json", "--approval-mode=yolo", "--no-session"}
 	args = append(args, ompWorkspaceArgs(agent)...)
 	if model != "" {
@@ -385,6 +423,15 @@ func ompArgs(agent Agent, model string, thinking string, maxTime string, attachA
 	}
 	if maxTime != "" {
 		args = append(args, "--max-time", maxTime)
+	}
+	// Plan mode is opt-in and never inferred: no plan request, no flag, so a normal
+	// run's argv stays byte-identical. --plan-yolo-into is meaningless on its own
+	// (ompValidatePlan already refused that shape) and so is nested under it here.
+	if plan {
+		args = append(args, "--plan-yolo")
+		if into := strings.TrimSpace(planInto); into != "" {
+			args = append(args, "--plan-yolo-into", into)
+		}
 	}
 	// Attachments must precede `--`; everything after it is message text.
 	args = append(args, attachArgs...)

--- a/internal/runtime/omp.go
+++ b/internal/runtime/omp.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
@@ -379,15 +380,15 @@ func (a OmpAdapter) preflight() error {
 //     read as an unknown flag and exits 2, and one starting with `@` is read as a
 //     file attachment. `--` disables all of that for the value that follows.
 //   - `--plan-yolo` is emitted IF AND ONLY IF the job asked for plan mode. It is
-//     ORTHOGONAL to --approval-mode: plan mode is workflow shape (plan first, then
-//     AUTO-EXECUTE the plan), the approval mode is write permission, and --plan-yolo
-//     starts read-only and auto-approves the model's own plan on its first resolve
-//     call. `--plan-yolo-into <M>` pins the model the execution phase runs on and is
-//     only accepted alongside --plan-yolo (omp's own default target is the "smol"
-//     role); ompValidatePlan rejects the unpaired form BEFORE any subprocess, and a
-//     plan request aimed at a runtime SupportsPlanMode rejects never reaches an argv
-//     at all. A silent downgrade to a normal run is the defect this ordering exists
-//     to prevent.
+//     ORTHOGONAL to --approval-mode: plan mode is workflow shape while approval mode
+//     controls tool approval. omp/17.2.4's `omp --help` DECLARES that --plan-yolo
+//     starts read-only, auto-approves the model's plan on its first resolve call and
+//     then executes it; Gitmoot cannot observe those internal transitions. The same
+//     help declares `--plan-yolo-into <M>` as the execution model selector with the
+//     "smol" role as its default. ompValidatePlan rejects malformed or unpaired
+//     targets BEFORE any subprocess, and a plan request aimed at a runtime
+//     SupportsPlanMode rejects never reaches an argv at all. A silent downgrade to
+//     a normal run is the defect this ordering exists to prevent.
 var ompRuntimeContract = RuntimeContract{
 	Binary: "omp",
 	Requirements: []RuntimeRequirement{
@@ -395,8 +396,8 @@ var ompRuntimeContract = RuntimeContract{
 		{Kind: RuntimeRequirementFlag, Name: "flag --mode", Flag: "--mode", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --mode, or run the job on a runtime whose installed CLI satisfies its declared contract"},
 		{Kind: RuntimeRequirementFlag, Name: "flag --approval-mode", Flag: "--approval-mode", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --approval-mode, or run the job on a runtime whose installed CLI satisfies its declared contract"},
 		{Kind: RuntimeRequirementFlag, Name: "flag --no-session", Flag: "--no-session", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --no-session, or run the job on a runtime whose installed CLI satisfies its declared contract"},
-		{Kind: RuntimeRequirementFlag, Name: "flag --plan-yolo", Flag: "--plan-yolo", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --plan-yolo, or run the job on a runtime whose installed CLI satisfies its declared contract"},
-		{Kind: RuntimeRequirementFlag, Name: "flag --plan-yolo-into", Flag: "--plan-yolo-into", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --plan-yolo-into, or run the job on a runtime whose installed CLI satisfies its declared contract"},
+		{Kind: RuntimeRequirementFlag, Name: "flag --plan-yolo", Flag: "--plan-yolo", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --plan-yolo, or run the job on a runtime whose installed CLI satisfies its declared contract", PlanMode: true},
+		{Kind: RuntimeRequirementFlag, Name: "flag --plan-yolo-into", Flag: "--plan-yolo-into", Source: "internal/runtime/omp.go::ompArgs", Remedy: "install an omp CLI that lists --plan-yolo-into, or run the job on a runtime whose installed CLI satisfies its declared contract", PlanMode: true},
 	},
 }
 
@@ -406,8 +407,14 @@ var ompRuntimeContract = RuntimeContract{
 // truncated stream — the wrong cause for a request shape we can reject here with
 // the actual fix.
 func ompValidatePlan(plan bool, planInto string) error {
-	if into := strings.TrimSpace(planInto); into != "" && !plan {
+	into := strings.TrimSpace(planInto)
+	if into != "" && !plan {
 		return fmt.Errorf("omp plan target %q requires plan mode: --plan-yolo-into is only accepted alongside --plan-yolo (set plan on the job, or drop plan_into)", into)
+	}
+	if into != "" && (strings.HasPrefix(into, "-") || strings.IndexFunc(into, func(r rune) bool {
+		return unicode.IsSpace(r) || unicode.IsControl(r)
+	}) >= 0) {
+		return fmt.Errorf("omp plan target %q is invalid: plan_into must be one non-flag model selector without whitespace or control characters (for example @smol or provider/model); correct it or drop plan_into", into)
 	}
 	return nil
 }

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -386,8 +386,10 @@ func assertNoForbiddenOmpFlags(t *testing.T, argv []string) {
 		}
 	}
 	// Every omp argv, plan or not, carries the explicit yolo approval mode: plan
-	// mode is workflow shape, the approval mode is write permission, and omp bricks
-	// headlessly under always-ask.
+	// mode is workflow shape, the approval mode is write permission, and the flag is
+	// pinned for DETERMINISM (omitting it inherits the host config). It is NOT
+	// pinned because always-ask is unusable — that claim was measured and refuted;
+	// see the ompRuntimeContract comment.
 	if got := ompCountToken(argv, "--approval-mode=yolo"); got != 1 {
 		t.Fatalf("--approval-mode=yolo appears %d times, want exactly 1: %v", got, argv)
 	}
@@ -626,10 +628,11 @@ func TestOmpDeliverIsSessionless(t *testing.T) {
 // TestOmpPlanArgv pins the plan-mode argv byte for byte on BOTH sides of the
 // if-and-only-if: a job that asked for nothing gets no plan flag, a plan job gets
 // --plan-yolo, and a pinned execution model gets --plan-yolo-into directly after
-// it. --approval-mode=yolo survives every variant — plan mode is workflow shape,
-// the approval mode is write permission, and mapping one onto the other would
-// brick the runtime under always-ask. Result.PlanMode is asserted alongside so
-// the durable evidence cannot drift from the argv it describes.
+// it. --approval-mode=yolo survives every variant — plan mode is workflow shape
+// and the approval mode is write permission, two separate things, and the flag is
+// pinned for determinism rather than because always-ask would break omp (measured
+// and refuted; see the ompRuntimeContract comment). Result.PlanMode is asserted
+// alongside so the durable evidence cannot drift from the argv it describes.
 func TestOmpPlanArgv(t *testing.T) {
 	base := []string{"omp", "-p", "--mode=json", "--approval-mode=yolo", "--no-session"}
 	cases := []struct {
@@ -870,8 +873,14 @@ func TestOmpDeliverRejectsPlanIntoWithoutPlan(t *testing.T) {
 }
 
 func TestOmpDeliverRejectsMalformedPlanInto(t *testing.T) {
-	for _, target := range []string{"x --add-dir /etc", "--model", "provider/model\nnext"} {
-		t.Run(strings.ReplaceAll(target, "\n", "_newline_"), func(t *testing.T) {
+	// "provider/model\x07bell" and "\x00" carry a control character that is NOT
+	// whitespace, so they are the only inputs here for which the IsControl half of
+	// the predicate is the DECIDING one. Without them, deleting `|| IsControl(r)`
+	// compiled and left the whole suite green — the previous \n case satisfies
+	// IsSpace first, so the branch looked covered and was not. A control character
+	// in a model selector reaches argv, and argv reaches execve.
+	for _, target := range []string{"x --add-dir /etc", "--model", "provider/model\nnext", "provider/model\x07bell", "\x00"} {
+		t.Run(strings.NewReplacer("\n", "_newline_", "\x07", "_bell_", "\x00", "_nul_").Replace(target), func(t *testing.T) {
 			runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
 			adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
 			_, err := adapter.Deliver(context.Background(), ompTestAgent(), Job{Prompt: "work", Plan: true, PlanInto: target})

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -3705,10 +3705,10 @@ func TestOmpPlanRejectsMalformedResolvedTarget(t *testing.T) {
 func TestOmpPlanTargetPreservesRoleAlias(t *testing.T) {
 	for _, tc := range []struct{ model, into, want string }{
 		{into: "@smol", want: "@smol"},
-		{model: "@smol", want: "@smol"},                     // alias arriving via the model fallback
-		{model: "@smol", into: "@fast", want: "@fast"},       // explicit target still wins
+		{model: "@smol", want: "@smol"},                // alias arriving via the model fallback
+		{model: "@smol", into: "@fast", want: "@fast"}, // explicit target still wins
 		{model: "openai/gpt-5.5", want: "openai/gpt-5.5"},
-		{model: "  @smol  ", want: "@smol"},                  // trimmed, not stripped
+		{model: "  @smol  ", want: "@smol"}, // trimmed, not stripped
 	} {
 		if got := ompPlanTarget(tc.model, tc.into); got != tc.want {
 			t.Fatalf("ompPlanTarget(%q, %q) = %q, want %q", tc.model, tc.into, got, tc.want)

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -362,11 +362,18 @@ func ompTestAgent() Agent {
 // overwrites the parsed --cwd), so a job would edit the previous worktree and
 // leave its own clean; --session-dir would accrete per-worktree session state for
 // a runtime that never resumes; --yolo/--auto-approve are the aliases the explicit
-// --approval-mode replaces; --plan-yolo is a separate runtime, not a v1 flag; and
-// --profile is deferred until per-seat isolation is designed.
+// --approval-mode replaces; and --profile is deferred until per-seat isolation is
+// designed.
+//
+// --plan-yolo is deliberately ABSENT from this list and is NOT unguarded: a
+// blanket ban would be weaker than what the adapter now owes. It is governed by
+// assertOmpPlanArgv's IF-AND-ONLY-IF assertion instead, which subsumes the ban
+// (no plan request => the flag must not appear in any spelling) and additionally
+// catches the two failures a ban cannot see: a plan request whose flag went
+// MISSING, and a plan run that lost --approval-mode=yolo.
 var ompForbiddenFlags = []string{
 	"--resume", "--continue", "--fork", "--session-dir",
-	"--yolo", "--auto-approve", "--plan-yolo", "--profile",
+	"--yolo", "--auto-approve", "--profile",
 }
 
 func assertNoForbiddenOmpFlags(t *testing.T, argv []string) {
@@ -377,6 +384,54 @@ func assertNoForbiddenOmpFlags(t *testing.T, argv []string) {
 				t.Fatalf("argv carries forbidden flag %q: %v", forbidden, argv)
 			}
 		}
+	}
+	// Every omp argv, plan or not, carries the explicit yolo approval mode: plan
+	// mode is workflow shape, the approval mode is write permission, and omp bricks
+	// headlessly under always-ask.
+	if got := ompCountToken(argv, "--approval-mode=yolo"); got != 1 {
+		t.Fatalf("--approval-mode=yolo appears %d times, want exactly 1: %v", got, argv)
+	}
+}
+
+// assertOmpPlanArgv is the plan-mode IF-AND-ONLY-IF guard: --plan-yolo appears
+// exactly when the job asked for plan mode and NEVER otherwise, --plan-yolo-into
+// appears exactly when a target model was pinned, it carries that model, it
+// directly follows --plan-yolo (omp only accepts the pair), and neither flag ever
+// shows up in an `=` spelling the adapter does not emit. --approval-mode=yolo is
+// re-asserted on both sides so plan mode can never be mistaken for an approval
+// setting.
+func assertOmpPlanArgv(t *testing.T, argv []string, plan bool, planInto string) {
+	t.Helper()
+	wantPlan, wantInto := 0, 0
+	if plan {
+		wantPlan = 1
+		if strings.TrimSpace(planInto) != "" {
+			wantInto = 1
+		}
+	}
+	for _, arg := range argv {
+		if strings.HasPrefix(arg, "--plan-yolo") && arg != "--plan-yolo" && arg != "--plan-yolo-into" {
+			t.Fatalf("argv carries an unrecognized plan flag spelling %q: %v", arg, argv)
+		}
+	}
+	if got := ompCountToken(argv, "--plan-yolo"); got != wantPlan {
+		t.Fatalf("--plan-yolo appears %d times, want %d (plan=%v): %v", got, wantPlan, plan, argv)
+	}
+	if got := ompCountToken(argv, "--plan-yolo-into"); got != wantInto {
+		t.Fatalf("--plan-yolo-into appears %d times, want %d (plan=%v into=%q): %v", got, wantInto, plan, planInto, argv)
+	}
+	if wantInto == 1 {
+		if got := ompFlagValue(argv, "--plan-yolo-into"); got != strings.TrimSpace(planInto) {
+			t.Fatalf("--plan-yolo-into = %q, want %q: %v", got, strings.TrimSpace(planInto), argv)
+		}
+		for i, arg := range argv {
+			if arg == "--plan-yolo-into" && (i == 0 || argv[i-1] != "--plan-yolo") {
+				t.Fatalf("--plan-yolo-into must directly follow --plan-yolo (omp rejects it alone): %v", argv)
+			}
+		}
+	}
+	if got := ompCountToken(argv, "--approval-mode=yolo"); got != 1 {
+		t.Fatalf("--approval-mode=yolo appears %d times, want exactly 1 (plan=%v): %v", got, plan, argv)
 	}
 }
 
@@ -539,6 +594,8 @@ func TestOmpDeliverNeverResumes(t *testing.T) {
 			}
 			for _, call := range runner.calls {
 				assertNoForbiddenOmpFlags(t, call)
+				// No plan was requested, so no plan flag may exist in any spelling.
+				assertOmpPlanArgv(t, call, false, "")
 			}
 		})
 	}
@@ -557,6 +614,182 @@ func TestOmpDeliverIsSessionless(t *testing.T) {
 		t.Fatalf("--no-session appears %d times, want exactly 1: %v", got, argv)
 	}
 	assertNoForbiddenOmpFlags(t, argv)
+	assertOmpPlanArgv(t, argv, false, "")
+}
+
+// TestOmpPlanArgv pins the plan-mode argv byte for byte on BOTH sides of the
+// if-and-only-if: a job that asked for nothing gets no plan flag, a plan job gets
+// --plan-yolo, and a pinned execution model gets --plan-yolo-into directly after
+// it. --approval-mode=yolo survives every variant — plan mode is workflow shape,
+// the approval mode is write permission, and mapping one onto the other would
+// brick the runtime under always-ask. Result.PlanMode is asserted alongside so
+// the durable evidence cannot drift from the argv it describes.
+func TestOmpPlanArgv(t *testing.T) {
+	base := []string{"omp", "-p", "--mode=json", "--approval-mode=yolo", "--no-session"}
+	cases := []struct {
+		name         string
+		job          Job
+		wantTail     []string
+		wantPlanMode string
+	}{
+		{
+			name:     "no plan request emits no plan flag",
+			job:      Job{Prompt: "work"},
+			wantTail: []string{"--", "work"},
+		},
+		{
+			name:         "plan emits --plan-yolo alone",
+			job:          Job{Prompt: "work", Plan: true},
+			wantTail:     []string{"--plan-yolo", "--", "work"},
+			wantPlanMode: "plan",
+		},
+		{
+			name:         "plan_into pins the execution model immediately after --plan-yolo",
+			job:          Job{Prompt: "work", Plan: true, PlanInto: "@smol"},
+			wantTail:     []string{"--plan-yolo", "--plan-yolo-into", "@smol", "--", "work"},
+			wantPlanMode: "plan-into:@smol",
+		},
+		{
+			name:         "a blank plan_into is not a target and emits no --plan-yolo-into",
+			job:          Job{Prompt: "work", Plan: true, PlanInto: "   "},
+			wantTail:     []string{"--plan-yolo", "--", "work"},
+			wantPlanMode: "plan",
+		},
+		{
+			// The documented order: model/thinking first, then the plan pair, then
+			// the prompt. A plan flag that drifted after `--` would be read as
+			// message text and the run would silently be a normal one.
+			name:         "plan follows model and effort in the documented order",
+			job:          Job{Prompt: "work", Model: "openai/gpt-5.5", Effort: "high", Plan: true, PlanInto: "anthropic/claude-haiku-4"},
+			wantTail:     []string{"--model", "openai/gpt-5.5", "--thinking", "high", "--plan-yolo", "--plan-yolo-into", "anthropic/claude-haiku-4", "--", "work"},
+			wantPlanMode: "plan-into:anthropic/claude-haiku-4",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+			adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+			result, err := adapter.Deliver(context.Background(), ompTestAgent(), tc.job)
+			if err != nil {
+				t.Fatalf("Deliver: %v", err)
+			}
+			want := append(append([]string(nil), base...), tc.wantTail...)
+			runner.want(t, 0, want...)
+			assertOmpPlanArgv(t, runner.calls[0], tc.job.Plan, tc.job.PlanInto)
+			assertNoForbiddenOmpFlags(t, runner.calls[0])
+			if result.PlanMode != tc.wantPlanMode {
+				t.Fatalf("Result.PlanMode = %q, want %q", result.PlanMode, tc.wantPlanMode)
+			}
+		})
+	}
+}
+
+// TestOmpArgsPlanIffAcrossShapes runs the if-and-only-if guard over the whole
+// primitive matrix the argv builder accepts. It is the "never otherwise" half:
+// no combination of model, effort, workspace grants, max-time, or attachments may
+// conjure a plan flag, and none may swallow one that was asked for.
+func TestOmpArgsPlanIffAcrossShapes(t *testing.T) {
+	agents := map[string]Agent{
+		"bare":   {},
+		"grants": {WritablePaths: []string{"/work/out"}, ReadablePaths: []string{"/inputs"}},
+	}
+	extras := map[string][]string{
+		"no attachment": nil,
+		"attachment":    {"@/staged/prompt.md"},
+	}
+	for agentName, agent := range agents {
+		for extraName, attach := range extras {
+			for _, model := range []string{"", "openai/gpt-5.5"} {
+				for _, thinking := range []string{"", "high"} {
+					for _, maxTime := range []string{"", "600"} {
+						for _, plan := range []bool{false, true} {
+							for _, into := range []string{"", "@smol"} {
+								if !plan && into != "" {
+									continue // rejected before dispatch; not representable
+								}
+								argv := append([]string{"omp"}, ompArgs(agent, model, thinking, maxTime, plan, into, attach, "work")...)
+								assertOmpPlanArgv(t, argv, plan, into)
+								assertNoForbiddenOmpFlags(t, argv)
+								if got := argv[len(argv)-2]; got != "--" {
+									t.Fatalf("%s/%s: prompt is not the single token after `--`: %v", agentName, extraName, argv)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestOmpDeliverRejectsPlanIntoWithoutPlan: upstream omp only accepts
+// --plan-yolo-into alongside --plan-yolo, so the unpaired shape is refused HERE,
+// before any subprocess, with the fix in the message. Silently dropping the
+// target — or shipping the flag alone and letting omp exit non-zero with no
+// envelope, which this adapter would diagnose as a truncated stream — are both
+// worse than a named rejection.
+func TestOmpDeliverRejectsPlanIntoWithoutPlan(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+	adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+	_, err := adapter.Deliver(context.Background(), ompTestAgent(), Job{Prompt: "work", PlanInto: "@smol"})
+	if err == nil {
+		t.Fatal("Deliver accepted plan_into without plan")
+	}
+	if !strings.Contains(err.Error(), "--plan-yolo-into") || !strings.Contains(err.Error(), "--plan-yolo") {
+		t.Fatalf("error must name both flags so the fix is obvious, got: %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("rejected plan shape still ran %d subprocess(es): %v", len(runner.calls), runner.calls)
+	}
+}
+
+// TestOmpStartNeverPlans: Start registers a seat, it does not run a brief, so its
+// argv must never carry a plan flag no matter what the agent looks like.
+func TestOmpStartNeverPlans(t *testing.T) {
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+	adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+	agent := ompTestAgent()
+	agent.RuntimeRef = ""
+	if _, err := adapter.Start(context.Background(), StartRequest{Agent: agent, Prompt: "introduce yourself"}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	assertOmpPlanArgv(t, runner.calls[0], false, "")
+	assertNoForbiddenOmpFlags(t, runner.calls[0])
+}
+
+// TestSupportsPlanMode pins the closed set. omp is the only runtime with the
+// flag; every other runtime must be rejected at dispatch rather than run a
+// plan-gated brief as an ordinary implementation.
+func TestSupportsPlanMode(t *testing.T) {
+	if !SupportsPlanMode(OmpRuntime) || !SupportsPlanMode("  "+OmpRuntime+"  ") {
+		t.Fatal("omp must support plan mode")
+	}
+	for _, name := range []string{CodexRuntime, ClaudeRuntime, KimiRuntime, KimiCLIRuntime, ShellRuntime, "", "bogus"} {
+		if SupportsPlanMode(name) {
+			t.Fatalf("runtime %q must not claim plan mode", name)
+		}
+	}
+}
+
+// TestPlanModeDescriptor pins the durable evidence strings a reader sees instead
+// of re-deriving plan mode from an argv.
+func TestPlanModeDescriptor(t *testing.T) {
+	cases := []struct {
+		plan bool
+		into string
+		want string
+	}{
+		{plan: false, into: "", want: ""},
+		{plan: false, into: "@smol", want: ""},
+		{plan: true, into: "", want: "plan"},
+		{plan: true, into: "  ", want: "plan"},
+		{plan: true, into: " @smol ", want: "plan-into:@smol"},
+	}
+	for _, tc := range cases {
+		if got := PlanModeDescriptor(tc.plan, tc.into); got != tc.want {
+			t.Fatalf("PlanModeDescriptor(%v, %q) = %q, want %q", tc.plan, tc.into, got, tc.want)
+		}
+	}
 }
 
 // TestOmpDeliverStopReasonErrorFailsOnExitZero is the omp landmine: under

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -743,6 +743,27 @@ func TestOmpDeliverRejectsPlanIntoWithoutPlan(t *testing.T) {
 	}
 }
 
+func TestOmpDeliverRejectsMalformedPlanInto(t *testing.T) {
+	for _, target := range []string{"x --add-dir /etc", "--model", "provider/model\nnext"} {
+		t.Run(strings.ReplaceAll(target, "\n", "_newline_"), func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+			adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+			_, err := adapter.Deliver(context.Background(), ompTestAgent(), Job{Prompt: "work", Plan: true, PlanInto: target})
+			if err == nil {
+				t.Fatalf("Deliver accepted malformed plan_into %q", target)
+			}
+			for _, want := range []string{"omp plan target", "one non-flag model selector", "plan_into"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q does not contain %q", err, want)
+				}
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("rejected plan target still ran %d subprocess(es): %v", len(runner.calls), runner.calls)
+			}
+		})
+	}
+}
+
 // TestOmpStartNeverPlans: Start registers a seat, it does not run a brief, so its
 // argv must never carry a plan flag no matter what the agent looks like.
 func TestOmpStartNeverPlans(t *testing.T) {

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -395,17 +395,23 @@ func assertNoForbiddenOmpFlags(t *testing.T, argv []string) {
 
 // assertOmpPlanArgv is the plan-mode IF-AND-ONLY-IF guard: --plan-yolo appears
 // exactly when the job asked for plan mode and NEVER otherwise, --plan-yolo-into
-// appears exactly when a target model was pinned, it carries that model, it
-// directly follows --plan-yolo (omp only accepts the pair), and neither flag ever
-// shows up in an `=` spelling the adapter does not emit. --approval-mode=yolo is
+// appears exactly when a target is resolvable, it carries that target, it directly
+// follows --plan-yolo (omp only accepts the pair), and neither flag ever shows up
+// in an `=` spelling the adapter does not emit. --approval-mode=yolo is
 // re-asserted on both sides so plan mode can never be mistaken for an approval
 // setting.
-func assertOmpPlanArgv(t *testing.T, argv []string, plan bool, planInto string) {
+//
+// wantTarget is what the CALLER expects, stated independently rather than
+// recomputed through ompPlanTarget: a test that asks production for the answer it
+// is checking passes through any change to the resolution rule — including the
+// silent-@smol behaviour this guard now exists to prevent.
+func assertOmpPlanArgv(t *testing.T, argv []string, plan bool, wantTarget string) {
 	t.Helper()
+	wantTarget = strings.TrimSpace(wantTarget)
 	wantPlan, wantInto := 0, 0
 	if plan {
 		wantPlan = 1
-		if strings.TrimSpace(planInto) != "" {
+		if wantTarget != "" {
 			wantInto = 1
 		}
 	}
@@ -418,11 +424,11 @@ func assertOmpPlanArgv(t *testing.T, argv []string, plan bool, planInto string) 
 		t.Fatalf("--plan-yolo appears %d times, want %d (plan=%v): %v", got, wantPlan, plan, argv)
 	}
 	if got := ompCountToken(argv, "--plan-yolo-into"); got != wantInto {
-		t.Fatalf("--plan-yolo-into appears %d times, want %d (plan=%v into=%q): %v", got, wantInto, plan, planInto, argv)
+		t.Fatalf("--plan-yolo-into appears %d times, want %d (plan=%v target=%q): %v", got, wantInto, plan, wantTarget, argv)
 	}
 	if wantInto == 1 {
-		if got := ompFlagValue(argv, "--plan-yolo-into"); got != strings.TrimSpace(planInto) {
-			t.Fatalf("--plan-yolo-into = %q, want %q: %v", got, strings.TrimSpace(planInto), argv)
+		if got := ompFlagValue(argv, "--plan-yolo-into"); got != wantTarget {
+			t.Fatalf("--plan-yolo-into = %q, want %q: %v", got, wantTarget, argv)
 		}
 		for i, arg := range argv {
 			if arg == "--plan-yolo-into" && (i == 0 || argv[i-1] != "--plan-yolo") {
@@ -638,10 +644,23 @@ func TestOmpPlanArgv(t *testing.T) {
 			wantTail: []string{"--", "work"},
 		},
 		{
-			name:         "plan emits --plan-yolo alone",
+			// A bare plan request with no model anywhere is the ONE case Gitmoot
+			// cannot name a target for, so the flag stays off and omp applies its
+			// own default. The evidence says so rather than claiming a pin.
+			name:         "plan with no model resolvable leaves the target to the runtime",
 			job:          Job{Prompt: "work", Plan: true},
 			wantTail:     []string{"--plan-yolo", "--", "work"},
-			wantPlanMode: "plan",
+			wantPlanMode: "plan-into:<runtime-default>",
+		},
+		{
+			// THE REGRESSION GUARD: the execution phase is a model switch, so a
+			// job's pin must reach it. Before this, a bare --plan-yolo let omp
+			// resolve @smol and the cheap default wrote the diff while the pinned
+			// model only planned.
+			name:         "the job model carries into the execution phase when plan_into is absent",
+			job:          Job{Prompt: "work", Model: "openai/gpt-5.5", Plan: true},
+			wantTail:     []string{"--model", "openai/gpt-5.5", "--plan-yolo", "--plan-yolo-into", "openai/gpt-5.5", "--", "work"},
+			wantPlanMode: "plan-into:openai/gpt-5.5",
 		},
 		{
 			name:         "plan_into pins the execution model immediately after --plan-yolo",
@@ -650,10 +669,18 @@ func TestOmpPlanArgv(t *testing.T) {
 			wantPlanMode: "plan-into:@smol",
 		},
 		{
-			name:         "a blank plan_into is not a target and emits no --plan-yolo-into",
-			job:          Job{Prompt: "work", Plan: true, PlanInto: "   "},
-			wantTail:     []string{"--plan-yolo", "--", "work"},
-			wantPlanMode: "plan",
+			// An explicit plan_into always wins over the job's model: the caller
+			// asking for a cheap executor is a choice, not an accident.
+			name:         "an explicit plan_into overrides the job model",
+			job:          Job{Prompt: "work", Model: "openai/gpt-5.5", Plan: true, PlanInto: "@smol"},
+			wantTail:     []string{"--model", "openai/gpt-5.5", "--plan-yolo", "--plan-yolo-into", "@smol", "--", "work"},
+			wantPlanMode: "plan-into:@smol",
+		},
+		{
+			name:         "a blank plan_into falls through to the job model, not to the runtime default",
+			job:          Job{Prompt: "work", Model: "openai/gpt-5.5", Plan: true, PlanInto: "   "},
+			wantTail:     []string{"--model", "openai/gpt-5.5", "--plan-yolo", "--plan-yolo-into", "openai/gpt-5.5", "--", "work"},
+			wantPlanMode: "plan-into:openai/gpt-5.5",
 		},
 		{
 			// The documented order: model/thinking first, then the plan pair, then
@@ -675,13 +702,103 @@ func TestOmpPlanArgv(t *testing.T) {
 			}
 			want := append(append([]string(nil), base...), tc.wantTail...)
 			runner.want(t, 0, want...)
-			assertOmpPlanArgv(t, runner.calls[0], tc.job.Plan, tc.job.PlanInto)
+			// The target the argv must carry is read back out of the evidence string
+			// each case already declares, so argv and plan_mode are checked against
+			// ONE stated expectation instead of two that could drift apart.
+			wantTarget := strings.TrimPrefix(tc.wantPlanMode, "plan-into:")
+			if wantTarget == tc.wantPlanMode || wantTarget == "<runtime-default>" {
+				wantTarget = ""
+			}
+			assertOmpPlanArgv(t, runner.calls[0], tc.job.Plan, wantTarget)
 			assertNoForbiddenOmpFlags(t, runner.calls[0])
 			if result.PlanMode != tc.wantPlanMode {
 				t.Fatalf("Result.PlanMode = %q, want %q", result.PlanMode, tc.wantPlanMode)
 			}
 		})
 	}
+}
+
+// TestOmpPlanEvidenceSurvivesFailure closes surviving mutant M8: dropping
+// `PlanMode: planMode` from BOTH failure returns left the whole suite green, even
+// though three separate comments in this codebase insist "a plan run that died is
+// still a plan run". The only test reading Result.PlanMode fed a healthy stream in
+// every case, so the two error returns were never observed. A plan run's evidence
+// matters MOST when it failed — that is when someone asks what was dispatched.
+func TestOmpPlanEvidenceSurvivesFailure(t *testing.T) {
+	job := Job{Prompt: "work", Model: "openai/gpt-5.5", Plan: true, PlanInto: "@smol"}
+	const want = "plan-into:@smol"
+	t.Run("non-zero exit still reports the plan shape", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}, errs: []error{errors.New("exit status 1")}}
+		adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+		result, err := adapter.Deliver(context.Background(), ompTestAgent(), job)
+		if err == nil {
+			t.Fatal("Deliver succeeded on a failing runner")
+		}
+		if result.PlanMode != want {
+			t.Fatalf("Result.PlanMode on the non-zero-exit return = %q, want %q", result.PlanMode, want)
+		}
+	})
+	t.Run("an unparseable stream still reports the plan shape", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: "not ndjson at all\n"}}}
+		adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+		result, err := adapter.Deliver(context.Background(), ompTestAgent(), job)
+		if err == nil {
+			t.Fatal("Deliver succeeded on an unparseable stream")
+		}
+		if result.PlanMode != want {
+			t.Fatalf("Result.PlanMode on the parse-error return = %q, want %q", result.PlanMode, want)
+		}
+	})
+}
+
+// TestOmpPlanPairPrecedesAttachment closes surviving mutant M18: moving the whole
+// plan block after the attachment append left the suite green, because every
+// byte-exact case used a short prompt and so never staged one. The documented argv
+// shape puts the plan pair BEFORE the attachment, and omp reads a `@`-prefixed
+// token as a file only when it was not already consumed as a flag value — so the
+// ordering is load-bearing, not cosmetic.
+func TestOmpPlanPairPrecedesAttachment(t *testing.T) {
+	argv := ompArgs(Agent{}, "openai/gpt-5.5", "", "", true, "@smol", []string{"@/staged/prompt.md"}, "work")
+	planAt, attachAt := -1, -1
+	for i, a := range argv {
+		if a == "--plan-yolo" && planAt < 0 {
+			planAt = i
+		}
+		if a == "@/staged/prompt.md" {
+			attachAt = i
+		}
+	}
+	if planAt < 0 || attachAt < 0 {
+		t.Fatalf("expected both a plan flag and a staged attachment: %v", argv)
+	}
+	if planAt > attachAt {
+		t.Fatalf("plan pair must precede the staged attachment (omp only reads @tokens it did not consume as a flag value): %v", argv)
+	}
+}
+
+// TestOmpPlanValidationPrecedesPreflight closes surviving mutant M12: moving the
+// ompValidatePlan call after the PATH preflight left the suite green, because the
+// test runner's LookPath always succeeds so the ordering was unobservable. Plan
+// shape is a property of the REQUEST, so its diagnosis must not depend on whether
+// omp happens to be installed — an operator with a malformed plan_into on a host
+// without omp should be told about the plan_into.
+func TestOmpPlanValidationPrecedesPreflight(t *testing.T) {
+	adapter := OmpAdapter{Runner: &lookPathFailRunner{}, Dir: "/repo"}
+	_, err := adapter.Deliver(context.Background(), ompTestAgent(), Job{Prompt: "work", Plan: true, PlanInto: "--add-dir=/"})
+	if err == nil {
+		t.Fatal("Deliver accepted a malformed plan target")
+	}
+	if !strings.Contains(err.Error(), "plan target") {
+		t.Fatalf("with omp absent AND a malformed plan target, the error must name the plan target, got: %v", err)
+	}
+}
+
+// lookPathFailRunner reports omp as absent so the PATH preflight would fail if it
+// ran first.
+type lookPathFailRunner struct{ fakeRunner }
+
+func (r *lookPathFailRunner) LookPath(string) (string, error) {
+	return "", errors.New("executable file not found in $PATH")
 }
 
 // TestOmpArgsPlanIffAcrossShapes runs the if-and-only-if guard over the whole
@@ -708,7 +825,16 @@ func TestOmpArgsPlanIffAcrossShapes(t *testing.T) {
 									continue // rejected before dispatch; not representable
 								}
 								argv := append([]string{"omp"}, ompArgs(agent, model, thinking, maxTime, plan, into, attach, "work")...)
-								assertOmpPlanArgv(t, argv, plan, into)
+								// The rule, restated here rather than borrowed from
+								// production: an explicit plan_into wins, else the
+								// job's model carries into the execution phase, else
+								// no flag and omp picks. Stating it independently is
+								// what makes this a check and not an echo.
+								wantTarget := into
+								if wantTarget == "" {
+									wantTarget = model
+								}
+								assertOmpPlanArgv(t, argv, plan, wantTarget)
 								assertNoForbiddenOmpFlags(t, argv)
 								if got := argv[len(argv)-2]; got != "--" {
 									t.Fatalf("%s/%s: prompt is not the single token after `--`: %v", agentName, extraName, argv)
@@ -802,9 +928,15 @@ func TestPlanModeDescriptor(t *testing.T) {
 	}{
 		{plan: false, into: "", want: ""},
 		{plan: false, into: "@smol", want: ""},
-		{plan: true, into: "", want: "plan"},
-		{plan: true, into: "  ", want: "plan"},
+		// Plan mode ALWAYS executes on some model, so the evidence never says a
+		// bare "plan": either Gitmoot resolved the target and names it, or it did
+		// not and says the runtime chose. A bare "plan" would let a diff written
+		// by the runtime's cheap default look identical to one written by the
+		// pinned model — the exact ambiguity this string exists to remove.
+		{plan: true, into: "", want: "plan-into:<runtime-default>"},
+		{plan: true, into: "  ", want: "plan-into:<runtime-default>"},
 		{plan: true, into: " @smol ", want: "plan-into:@smol"},
+		{plan: true, into: "openai/gpt-5.5", want: "plan-into:openai/gpt-5.5"},
 	}
 	for _, tc := range cases {
 		if got := PlanModeDescriptor(tc.plan, tc.into); got != tc.want {

--- a/internal/runtime/omp_test.go
+++ b/internal/runtime/omp_test.go
@@ -3069,9 +3069,11 @@ func TestOmpSummaryIsFinalAssistantTextNotEnvelope(t *testing.T) {
 }
 
 // TestOmpPolicyArgs: every autonomy policy produces the SAME explicit
-// --approval-mode=yolo. Kills: mapping read-only onto always-ask (under which
-// every headless tool call throws, bricking the runtime) and dropping the flag
-// (which inherits the host's tools.approvalMode). Read-only is enforced
+// --approval-mode=yolo. Kills: mapping read-only onto always-ask, and dropping
+// the flag (which inherits the host's tools.approvalMode). The flag is pinned for
+// DETERMINISM, not because always-ask would break omp — that claim was measured
+// and refuted (see the ompRuntimeContract comment: read/grep succeed, only
+// bash/write are refused, exit 0 with a full agent_end). Read-only is enforced
 // Gitmoot-side, not by omp's approval tier.
 func TestOmpPolicyArgs(t *testing.T) {
 	policies := []string{
@@ -3645,4 +3647,84 @@ func TestOmpHealthUsesLiveCheckPrompt(t *testing.T) {
 		t.Fatalf("Health: %v", err)
 	}
 	runner.want(t, 0, "omp", "-p", "--mode=json", "--approval-mode=yolo", "--no-session", "--", OmpLiveCheckPrompt)
+}
+
+// TestOmpPlanRejectsMalformedResolvedTarget closes the argv-injection BLOCKER that
+// the model-pin fix itself opened. ompValidatePlan hardened the caller's plan_into;
+// the fix then routed the job's effective model into that same --plan-yolo-into
+// slot without extending the guard, so Job{Plan:true, Model:"--add-dir=/"} produced
+// `--model --add-dir=/ --plan-yolo --plan-yolo-into --add-dir=/`. Hardening one
+// input and routing a second into the same position is not hardening.
+//
+// The non-plan half matters as much: a model value only inherits the flag-value
+// slot's rules when it is actually going there, so ordinary jobs with the same
+// model must still dispatch.
+func TestOmpPlanRejectsMalformedResolvedTarget(t *testing.T) {
+	for _, model := range []string{"--add-dir=/", "provider/model next", "provider/model\x07bell", "-p"} {
+		t.Run("plan+"+strings.NewReplacer(" ", "_", "\x07", "_bell_").Replace(model), func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+			adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+			_, err := adapter.Deliver(context.Background(), ompTestAgent(), Job{Prompt: "work", Model: model, Plan: true})
+			if err == nil {
+				t.Fatalf("plan job with model %q was accepted; the model reaches the --plan-yolo-into slot", model)
+			}
+			if !strings.Contains(err.Error(), "plan execution target") {
+				t.Fatalf("error does not name the plan execution target: %v", err)
+			}
+			if len(runner.calls) != 0 {
+				t.Fatalf("rejected plan target still ran a subprocess: %v", runner.calls)
+			}
+		})
+		t.Run("nonplan+"+strings.NewReplacer(" ", "_", "\x07", "_bell_").Replace(model), func(t *testing.T) {
+			runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+			adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+			if _, err := adapter.Deliver(context.Background(), ompTestAgent(), Job{Prompt: "work", Model: model}); err != nil {
+				t.Fatalf("NON-plan job with model %q was refused: the plan-slot rule must not police --model. err=%v", model, err)
+			}
+		})
+	}
+	// The agent-level model reaches the same slot through EffectiveModel.
+	t.Run("agent model reaches the slot too", func(t *testing.T) {
+		runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+		adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+		agent := ompTestAgent()
+		agent.Model = "--add-dir=/"
+		if _, err := adapter.Deliver(context.Background(), agent, Job{Prompt: "work", Plan: true}); err == nil {
+			t.Fatal("plan job with a malformed AGENT model was accepted")
+		}
+	})
+}
+
+// TestOmpPlanTargetPreservesRoleAlias closes a surviving mutant: stripping a
+// leading "@" inside ompPlanTarget compiled and every plan test still passed,
+// because the fallback cases all used a plain provider/model value. omp resolves
+// "@smol" as a ROLE ALIAS (expandRoleAlias) and a bare "smol" is not the same
+// selector — a silent strip would repoint the execution phase at a model the
+// caller never named, which is the exact class of defect the pin fix exists to
+// close, reintroduced one layer down.
+func TestOmpPlanTargetPreservesRoleAlias(t *testing.T) {
+	for _, tc := range []struct{ model, into, want string }{
+		{into: "@smol", want: "@smol"},
+		{model: "@smol", want: "@smol"},                     // alias arriving via the model fallback
+		{model: "@smol", into: "@fast", want: "@fast"},       // explicit target still wins
+		{model: "openai/gpt-5.5", want: "openai/gpt-5.5"},
+		{model: "  @smol  ", want: "@smol"},                  // trimmed, not stripped
+	} {
+		if got := ompPlanTarget(tc.model, tc.into); got != tc.want {
+			t.Fatalf("ompPlanTarget(%q, %q) = %q, want %q", tc.model, tc.into, got, tc.want)
+		}
+	}
+	// End to end: the alias must survive into argv and into the evidence.
+	runner := &fakeRunner{results: []subprocess.Result{{Stdout: ompStreamOK}}}
+	adapter := OmpAdapter{Runner: runner, Dir: "/repo"}
+	result, err := adapter.Deliver(context.Background(), ompTestAgent(), Job{Prompt: "work", Model: "@smol", Plan: true})
+	if err != nil {
+		t.Fatalf("Deliver: %v", err)
+	}
+	if got := ompFlagValue(runner.calls[0], "--plan-yolo-into"); got != "@smol" {
+		t.Fatalf("--plan-yolo-into = %q, want %q: the role alias must reach omp intact", got, "@smol")
+	}
+	if result.PlanMode != "plan-into:@smol" {
+		t.Fatalf("Result.PlanMode = %q, want %q", result.PlanMode, "plan-into:@smol")
+	}
 }

--- a/internal/runtime/preflight.go
+++ b/internal/runtime/preflight.go
@@ -33,13 +33,17 @@ const (
 
 // RuntimeRequirement declares one fact an adapter's argv depends on.
 type RuntimeRequirement struct {
-	Kind       RuntimeRequirementKind
-	Name       string
-	Flag       string
-	Source     string
-	Remedy     string
-	Policies   []string
-	ChatSeat   bool
+	Kind     RuntimeRequirementKind
+	Name     string
+	Flag     string
+	Source   string
+	Remedy   string
+	Policies []string
+	ChatSeat bool
+	// PlanMode scopes a requirement to deliveries whose request enables plan
+	// mode. It is request-scoped rather than inferred from the agent: older CLIs
+	// that lack an optional plan flag must still run ordinary jobs.
+	PlanMode   bool
 	Instrument string
 }
 
@@ -48,6 +52,13 @@ type RuntimeRequirement struct {
 type RuntimeContract struct {
 	Binary       string
 	Requirements []RuntimeRequirement
+}
+
+// RuntimeContractRequest carries only request-scoped axes that select adapter
+// argv requirements. It is deliberately not runtime.Job: constructing the job
+// delivered to an adapter remains the mailbox gate's single responsibility.
+type RuntimeContractRequest struct {
+	Plan bool
 }
 
 func (c RuntimeContract) clone() RuntimeContract {
@@ -138,13 +149,20 @@ var defaultRuntimeContractChecker = NewRuntimeContractChecker(subprocess.GroupRu
 
 func DefaultRuntimeContractChecker() *RuntimeContractChecker { return defaultRuntimeContractChecker }
 
-// Check evaluates only requirements used by this agent's concrete argv.
+// Check evaluates requirements used by an ordinary, non-plan delivery.
 func (c *RuntimeContractChecker) Check(ctx context.Context, agent Agent) RuntimeContractResult {
+	return c.CheckRequest(ctx, agent, RuntimeContractRequest{})
+}
+
+// CheckRequest evaluates only requirements used by this agent and request's
+// concrete argv. Request-scoped features must not be inferred from static agent
+// metadata.
+func (c *RuntimeContractChecker) CheckRequest(ctx context.Context, agent Agent, request RuntimeContractRequest) RuntimeContractResult {
 	meta, ok := c.registry().Metadata(agent.Runtime)
 	if !ok {
 		return RuntimeContractResult{Runtime: agent.Runtime, Version: "unknown", State: RuntimeContractUnknown, Instrument: "runtime-registry"}
 	}
-	return c.check(ctx, meta, func(req RuntimeRequirement) bool { return requirementApplies(req, agent) })
+	return c.check(ctx, meta, func(req RuntimeRequirement) bool { return requirementApplies(req, agent, request) })
 }
 
 // Inspect evaluates every declared requirement for a runtime for doctor.
@@ -320,7 +338,10 @@ func (c *RuntimeContractChecker) runBinaryProbe(ctx context.Context, path string
 	return probe
 }
 
-func requirementApplies(req RuntimeRequirement, agent Agent) bool {
+func requirementApplies(req RuntimeRequirement, agent Agent, request RuntimeContractRequest) bool {
+	if req.PlanMode && !request.Plan {
+		return false
+	}
 	if req.ChatSeat && agent.ChatSeat {
 		return true
 	}

--- a/internal/runtime/preflight.go
+++ b/internal/runtime/preflight.go
@@ -165,13 +165,26 @@ func (c *RuntimeContractChecker) CheckRequest(ctx context.Context, agent Agent, 
 	return c.check(ctx, meta, func(req RuntimeRequirement) bool { return requirementApplies(req, agent, request) })
 }
 
-// Inspect evaluates every declared requirement for a runtime for doctor.
+// Inspect evaluates a runtime's requirements for doctor. It deliberately SKIPS
+// request-scoped requirements (PlanMode), because doctor answers "can this host
+// run this runtime", not "could this host serve every optional capability".
+//
+// Including them made doctor cry wolf: on a host whose omp predates --plan-yolo,
+// Inspect reported the omp contract UNSUPPORTED even though every ordinary omp job
+// dispatches and runs — the dispatch preflight scopes those flags to plan requests,
+// so the two instruments disagreed about the same host. The operator-facing remedy
+// then told them to install a newer CLI they did not need, which is worse than
+// silence: a red that is not a defect teaches people to ignore the instrument.
+//
+// A host that cannot serve plan mode learns it when a plan job is refused, loudly,
+// naming the flag. That refusal is the right place for it, because it is the only
+// place the capability is actually required.
 func (c *RuntimeContractChecker) Inspect(ctx context.Context, runtimeName string) RuntimeContractResult {
 	meta, ok := c.registry().Metadata(runtimeName)
 	if !ok {
 		return RuntimeContractResult{Runtime: runtimeName, Version: "unknown", State: RuntimeContractUnknown, Instrument: "runtime-registry"}
 	}
-	return c.check(ctx, meta, func(RuntimeRequirement) bool { return true })
+	return c.check(ctx, meta, func(req RuntimeRequirement) bool { return !req.PlanMode })
 }
 
 func (c *RuntimeContractChecker) registry() Registry {

--- a/internal/runtime/preflight_test.go
+++ b/internal/runtime/preflight_test.go
@@ -263,3 +263,34 @@ func TestCheckShimIsPlanFalse(t *testing.T) {
 		t.Fatalf("a plan request evaluated %d requirements, no more than the non-plan %d: the plan scoping is inert, so this test could not detect a regression", len(planned.Requirements), len(shim.Requirements))
 	}
 }
+
+// TestInspectSkipsPlanScopedRequirements pins doctor's question. Inspect answers
+// "can this host run this runtime", and an omp that predates --plan-yolo runs every
+// ordinary job fine — the dispatch preflight scopes those flags to plan requests.
+// Before this, Inspect evaluated them unconditionally and reported the omp contract
+// UNSUPPORTED on such a host, so doctor and the dispatch gate disagreed about the
+// same machine and the remedy told operators to upgrade a CLI they did not need.
+// A red that is not a defect teaches people to ignore the instrument.
+func TestInspectSkipsPlanScopedRequirements(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "omp")
+	if err := os.WriteFile(path, []byte("omp-without-plan"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	checker := NewRuntimeContractChecker(&contractProbeRunner{path: path}, BuiltinRuntimeRegistry())
+
+	inspected := checker.Inspect(context.Background(), OmpRuntime)
+	if inspected.State != RuntimeContractSupported {
+		t.Fatalf("doctor Inspect state = %q on an omp that runs ordinary jobs fine, want supported: doctor must not report an optional-capability gap as a broken runtime", inspected.State)
+	}
+	for _, req := range inspected.Requirements {
+		if strings.HasPrefix(req.Flag, "--plan-yolo") {
+			t.Fatalf("Inspect evaluated plan-scoped requirement %q; doctor must skip request-scoped capabilities", req.Flag)
+		}
+	}
+	// The capability gap is still discoverable — at the one place it is required.
+	agent := Agent{Name: "seat", Runtime: OmpRuntime, AutonomyPolicy: AutonomyPolicyWorkspaceWrite}
+	planned := checker.CheckRequest(context.Background(), agent, RuntimeContractRequest{Plan: true})
+	if planned.State != RuntimeContractUnsupported {
+		t.Fatalf("a PLAN request on the same host = %q, want unsupported: skipping the flag in doctor must not skip it at dispatch", planned.State)
+	}
+}

--- a/internal/runtime/preflight_test.go
+++ b/internal/runtime/preflight_test.go
@@ -232,3 +232,34 @@ func registryWithContractForTest(name string, contract RuntimeContract) Registry
 	meta := RuntimeMetadata{Name: name, Dispatchable: true, Contract: contract}
 	return Registry{order: []string{name}, entries: map[string]RuntimeMetadata{name: meta}}
 }
+
+// TestCheckShimIsPlanFalse pins the legacy 2-arg Check shim to its one meaning: a
+// NON-plan delivery. It is a shim over CheckRequest, and an untested shim is how a
+// caller silently acquires the wrong contract — the foreground dispatch preflight
+// relies on it, so if Check ever stopped implying Plan:false a plan request would
+// dispatch with its flags unverified: a guard failing silently instead of loudly.
+//
+// The omp contract is used because it is the only one carrying PlanMode-scoped
+// requirements, and a stub help that omits the plan flags is what makes the two
+// answers differ at all.
+func TestCheckShimIsPlanFalse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "omp")
+	if err := os.WriteFile(path, []byte("omp-without-plan"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	checker := NewRuntimeContractChecker(&contractProbeRunner{path: path}, BuiltinRuntimeRegistry())
+	agent := Agent{Name: "seat", Runtime: OmpRuntime, AutonomyPolicy: AutonomyPolicyWorkspaceWrite}
+
+	shim := checker.Check(context.Background(), agent)
+	explicit := checker.CheckRequest(context.Background(), agent, RuntimeContractRequest{Plan: false})
+	if shim.State != explicit.State {
+		t.Fatalf("Check state = %q but CheckRequest{Plan:false} = %q: the shim must mean exactly a non-plan delivery", shim.State, explicit.State)
+	}
+	if len(shim.Requirements) != len(explicit.Requirements) {
+		t.Fatalf("Check evaluated %d requirements, CheckRequest{Plan:false} evaluated %d", len(shim.Requirements), len(explicit.Requirements))
+	}
+	planned := checker.CheckRequest(context.Background(), agent, RuntimeContractRequest{Plan: true})
+	if len(planned.Requirements) <= len(shim.Requirements) {
+		t.Fatalf("a plan request evaluated %d requirements, no more than the non-plan %d: the plan scoping is inert, so this test could not detect a regression", len(planned.Requirements), len(shim.Requirements))
+	}
+}

--- a/internal/runtime/preflight_test.go
+++ b/internal/runtime/preflight_test.go
@@ -49,6 +49,8 @@ func (r *contractProbeRunner) Run(ctx context.Context, _ string, command string,
 			return subprocess.Result{}, ctx.Err()
 		case strings.Contains(mode, "unparseable"):
 			return subprocess.Result{Stdout: "???\n"}, nil
+		case strings.Contains(mode, "omp-without-plan"):
+			return subprocess.Result{Stdout: "Usage: omp [options]\n  -p, --print\n  --mode=<value>\n  --approval-mode=<value>\n  --no-session\n"}, nil
 		case strings.Contains(mode, "unsupported"):
 			return subprocess.Result{Stdout: "Usage: kimi [options]\n  --prompt\n  --output-format\n"}, nil
 		default:
@@ -102,6 +104,30 @@ func TestRuntimePreflightUnsupportedErrorNamesRequiredFlag(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q does not contain %q", err, want)
 		}
+	}
+}
+
+func TestRuntimePreflightScopesOmpPlanFlagsToPlanJobs(t *testing.T) {
+	checker, _, _ := newContractCheckerForTest(t, "omp-without-plan")
+	agent := Agent{Name: "planner", Runtime: OmpRuntime, AutonomyPolicy: AutonomyPolicyAuto}
+
+	normal := checker.CheckRequest(context.Background(), agent, RuntimeContractRequest{})
+	if normal.State != RuntimeContractSupported {
+		t.Fatalf("normal job state = %q, want supported without optional plan flags: %#v", normal.State, normal)
+	}
+	for _, requirement := range normal.Requirements {
+		if strings.HasPrefix(requirement.Flag, "--plan-yolo") {
+			t.Fatalf("normal job evaluated request-scoped requirement %#v", requirement)
+		}
+	}
+
+	plan := checker.CheckRequest(context.Background(), agent, RuntimeContractRequest{Plan: true})
+	if plan.State != RuntimeContractUnsupported {
+		t.Fatalf("plan job state = %q, want unsupported when plan flags are absent: %#v", plan.State, plan)
+	}
+	err := RuntimeContractDispatchError(agent, plan)
+	if err == nil || !strings.Contains(err.Error(), "--plan-yolo") {
+		t.Fatalf("plan job error = %v, want missing plan flag named", err)
 	}
 }
 

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -360,23 +360,23 @@ type JobPayload struct {
 	// capture bound; Error is the durable failure marker when capture itself
 	// failed. All fields are additive/omitempty so jobs without isolated
 	// read-only worktrees serialize unchanged.
-	ReadOnlyWorktreeDiff          string              `json:"read_only_worktree_diff,omitempty"`
-	ReadOnlyWorktreeDiffTruncated bool                `json:"read_only_worktree_diff_truncated,omitempty"`
-	ReadOnlyWorktreeDiffError     string              `json:"read_only_worktree_diff_error,omitempty"`
-	TemplateID                    string              `json:"template_id,omitempty"`
-	TemplateResolvedCommit        string              `json:"template_resolved_commit,omitempty"`
-	TemplateContent               string              `json:"template_content,omitempty"`
-	OriginalAgent                 string              `json:"original_agent,omitempty"`
-	DelegatedAgent                string              `json:"delegated_agent,omitempty"`
-	DelegationReason              string              `json:"delegation_reason,omitempty"`
-	RecentDelegationHashes        []string            `json:"recent_delegation_hashes,omitempty"`
-	DelegationRepeatCount         int                 `json:"delegation_repeat_count,omitempty"`
-	NonProgressStreak             int                 `json:"non_progress_streak,omitempty"`
-	LastProgressDigest            string              `json:"last_progress_digest,omitempty"`
-	VerifyAttempt                 int                 `json:"verify_attempt,omitempty"`
-	DelegationFinalize            bool                `json:"delegation_finalize,omitempty"`
-	Model                         string              `json:"model,omitempty"`
-	Effort                        string              `json:"effort,omitempty"`
+	ReadOnlyWorktreeDiff          string   `json:"read_only_worktree_diff,omitempty"`
+	ReadOnlyWorktreeDiffTruncated bool     `json:"read_only_worktree_diff_truncated,omitempty"`
+	ReadOnlyWorktreeDiffError     string   `json:"read_only_worktree_diff_error,omitempty"`
+	TemplateID                    string   `json:"template_id,omitempty"`
+	TemplateResolvedCommit        string   `json:"template_resolved_commit,omitempty"`
+	TemplateContent               string   `json:"template_content,omitempty"`
+	OriginalAgent                 string   `json:"original_agent,omitempty"`
+	DelegatedAgent                string   `json:"delegated_agent,omitempty"`
+	DelegationReason              string   `json:"delegation_reason,omitempty"`
+	RecentDelegationHashes        []string `json:"recent_delegation_hashes,omitempty"`
+	DelegationRepeatCount         int      `json:"delegation_repeat_count,omitempty"`
+	NonProgressStreak             int      `json:"non_progress_streak,omitempty"`
+	LastProgressDigest            string   `json:"last_progress_digest,omitempty"`
+	VerifyAttempt                 int      `json:"verify_attempt,omitempty"`
+	DelegationFinalize            bool     `json:"delegation_finalize,omitempty"`
+	Model                         string   `json:"model,omitempty"`
+	Effort                        string   `json:"effort,omitempty"`
 	// Plan / PlanInto are the requested plan mode (#1479); PlanMode is the
 	// resolved EVIDENCE the adapter reported after dispatch —
 	// "plan-into:<model>", "plan-into:<runtime-default>", or absent for a normal
@@ -386,29 +386,29 @@ type JobPayload struct {
 	// actually see most often. All
 	// three are additive/omitempty: a payload without plan mode serializes
 	// byte-identically.
-	Plan                          bool                `json:"plan,omitempty"`
-	PlanInto                      string              `json:"plan_into,omitempty"`
-	PlanMode                      string              `json:"plan_mode,omitempty"`
-	WorkflowID                    string              `json:"workflow_id,omitempty"`
-	RuntimeOverride               string              `json:"runtime_override,omitempty"`
-	RuntimeOverrideRef            string              `json:"runtime_override_ref,omitempty"`
-	ShellEnv                      []string            `json:"shell_env,omitempty"`
-	PipelineInputEnv              []string            `json:"pipeline_input_env,omitempty"`
-	PipelineName                  string              `json:"pipeline_name,omitempty"`
-	PipelineKeyAgent              string              `json:"pipeline_key_agent,omitempty"`
-	PipelineKeyAccess             []PipelineKeyAccess `json:"pipeline_key_access,omitempty"`
-	PipelineEnvFile               string              `json:"pipeline_env_file,omitempty"`
-	PipelineEnvKeys               []string            `json:"pipeline_env_keys,omitempty"`
-	PipelineEnv                   map[string]string   `json:"pipeline_env,omitempty"`
-	ShellUpstreamContext          string              `json:"shell_upstream_context,omitempty"`
-	Phase                         string              `json:"phase,omitempty"`
-	Cockpit                       bool                `json:"cockpit,omitempty"`
-	CockpitSession                string              `json:"cockpit_session,omitempty"`
-	CockpitPaneKey                string              `json:"cockpit_pane_key,omitempty"`
-	SkipNativeReviewFanout        bool                `json:"skip_native_review_fanout,omitempty"`
-	ValidatedPullRequest          bool                `json:"validated_pull_request,omitempty"`
-	Ephemeral                     *EphemeralSpec      `json:"ephemeral,omitempty"`
-	HumanAnswer                   string              `json:"human_answer,omitempty"`
+	Plan                   bool                `json:"plan,omitempty"`
+	PlanInto               string              `json:"plan_into,omitempty"`
+	PlanMode               string              `json:"plan_mode,omitempty"`
+	WorkflowID             string              `json:"workflow_id,omitempty"`
+	RuntimeOverride        string              `json:"runtime_override,omitempty"`
+	RuntimeOverrideRef     string              `json:"runtime_override_ref,omitempty"`
+	ShellEnv               []string            `json:"shell_env,omitempty"`
+	PipelineInputEnv       []string            `json:"pipeline_input_env,omitempty"`
+	PipelineName           string              `json:"pipeline_name,omitempty"`
+	PipelineKeyAgent       string              `json:"pipeline_key_agent,omitempty"`
+	PipelineKeyAccess      []PipelineKeyAccess `json:"pipeline_key_access,omitempty"`
+	PipelineEnvFile        string              `json:"pipeline_env_file,omitempty"`
+	PipelineEnvKeys        []string            `json:"pipeline_env_keys,omitempty"`
+	PipelineEnv            map[string]string   `json:"pipeline_env,omitempty"`
+	ShellUpstreamContext   string              `json:"shell_upstream_context,omitempty"`
+	Phase                  string              `json:"phase,omitempty"`
+	Cockpit                bool                `json:"cockpit,omitempty"`
+	CockpitSession         string              `json:"cockpit_session,omitempty"`
+	CockpitPaneKey         string              `json:"cockpit_pane_key,omitempty"`
+	SkipNativeReviewFanout bool                `json:"skip_native_review_fanout,omitempty"`
+	ValidatedPullRequest   bool                `json:"validated_pull_request,omitempty"`
+	Ephemeral              *EphemeralSpec      `json:"ephemeral,omitempty"`
+	HumanAnswer            string              `json:"human_answer,omitempty"`
 	// ThreadID / ChatMessageID back-link a chat-promoted job (#534) to its origin
 	// message. Additive/omitempty: a non-chat job serializes byte-identically.
 	ThreadID      string `json:"thread_id,omitempty"`

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -1459,6 +1459,19 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		if !runtime.SupportsPlanMode(agent.Runtime) {
 			return "", "", false, nil, planDispatchError(agent.Runtime, payload.Plan, payload.PlanInto)
 		}
+		// A PLAN REQUEST IS A WRITE REQUEST. Plan mode ends in an implementation
+		// phase — upstream omp auto-approves the plan and switches into executing
+		// it, ADDING the write tool to the active set — so it needs the same policy
+		// an implement job needs. Without this, plan mode is a bypass: the only
+		// Gitmoot-side write gate (readOnlyImplementationBlocked) keys on
+		// job type == "implement" and returns false for everything else, so a
+		// read-only seat refused an implement job would accept an `ask` job
+		// carrying plan and write code anyway. Checked here rather than only at
+		// enqueue because the policy lives on the agent row the delivery resolved,
+		// and because a payload can reach delivery without passing Enqueue.
+		if !runtime.PolicyGrantsImplementWrite(agent.AutonomyPolicy) {
+			return "", "", false, nil, fmt.Errorf("agent %q has autonomy policy %q, which does not grant write: a plan-mode job ends in an implementation phase, so it requires the same policy an implement job requires (set the agent's policy to workspace-write or drop plan from the job)", agent.Name, runtime.NormalizeStoredAutonomyPolicy(agent.AutonomyPolicy))
+		}
 	}
 	delivery := runtime.Job{
 		ID:                   job.ID,
@@ -1874,9 +1887,18 @@ func validateJobPlanRequest(request JobRequest) error {
 // request". Proceeding as a normal run instead would turn a plan-gated brief into
 // a silent ordinary implementation, which is the exact defect #1479 exists to
 // remove, so the job fails loudly rather than quietly losing its shape.
+// planDispatchError describes the REQUEST as the operator wrote it, deliberately
+// not via runtime.PlanModeDescriptor. That helper renders the RESOLVED evidence of
+// a run and names a runtime default when Gitmoot did not pick a target — true for
+// a dispatched omp run, nonsense in a refusal aimed at a runtime that has no plan
+// mode and therefore no default. The operator needs to see what they asked for.
 func planDispatchError(runtimeName string, plan bool, planInto string) error {
+	shape := "plan"
+	if into := strings.TrimSpace(planInto); into != "" {
+		shape = "plan-into:" + into
+	}
 	return fmt.Errorf("runtime %q cannot honour plan mode (%s): only the omp runtime implements it; drop plan from the job or route it to an omp seat",
-		strings.TrimSpace(runtimeName), runtime.PlanModeDescriptor(plan, planInto))
+		strings.TrimSpace(runtimeName), shape)
 }
 
 var pipelineInputEnvNamePattern = regexp.MustCompile(`^GITMOOT_INPUT_[A-Z][A-Z0-9_]*$`)

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -378,9 +378,12 @@ type JobPayload struct {
 	Model                         string              `json:"model,omitempty"`
 	Effort                        string              `json:"effort,omitempty"`
 	// Plan / PlanInto are the requested plan mode (#1479); PlanMode is the
-	// resolved EVIDENCE the adapter reported after dispatch ("plan",
-	// "plan-into:<model>", or absent for a normal run), so a reader can tell a plan
-	// run from a normal one without re-deriving it from the runtime's argv. All
+	// resolved EVIDENCE the adapter reported after dispatch —
+	// "plan-into:<model>", "plan-into:<runtime-default>", or absent for a normal
+	// run — so a reader can tell a plan run from a normal one without re-deriving it
+	// from the runtime's argv. There is no bare "plan" value: the bare-request case
+	// renders "plan-into:<runtime-default>", which is the value an operator will
+	// actually see most often. All
 	// three are additive/omitempty: a payload without plan mode serializes
 	// byte-identically.
 	Plan                          bool                `json:"plan,omitempty"`

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -212,6 +212,14 @@ type JobRequest struct {
 	DelegationFinalize     bool
 	Model                  string
 	Effort                 string
+	// Plan and PlanInto request PLAN MODE for this job (#1479): the runtime plans
+	// the work first and then AUTO-EXECUTES that plan. PlanInto pins the model the
+	// execution phase runs on and REQUIRES Plan. Both are rejected at the enqueue
+	// chokepoint when the shape is impossible and again at dispatch when the
+	// effective runtime cannot honour them, so a plan-gated brief never runs as an
+	// ordinary implementation by accident.
+	Plan     bool
+	PlanInto string
 	// WorkflowID groups jobs started by an external coordinator. Empty preserves
 	// the legacy payload byte-for-byte; non-empty values are inherited by every
 	// delegation child and continuation in the coordination tree.
@@ -369,6 +377,15 @@ type JobPayload struct {
 	DelegationFinalize            bool                `json:"delegation_finalize,omitempty"`
 	Model                         string              `json:"model,omitempty"`
 	Effort                        string              `json:"effort,omitempty"`
+	// Plan / PlanInto are the requested plan mode (#1479); PlanMode is the
+	// resolved EVIDENCE the adapter reported after dispatch ("plan",
+	// "plan-into:<model>", or absent for a normal run), so a reader can tell a plan
+	// run from a normal one without re-deriving it from the runtime's argv. All
+	// three are additive/omitempty: a payload without plan mode serializes
+	// byte-identically.
+	Plan                          bool                `json:"plan,omitempty"`
+	PlanInto                      string              `json:"plan_into,omitempty"`
+	PlanMode                      string              `json:"plan_mode,omitempty"`
 	WorkflowID                    string              `json:"workflow_id,omitempty"`
 	RuntimeOverride               string              `json:"runtime_override,omitempty"`
 	RuntimeOverrideRef            string              `json:"runtime_override_ref,omitempty"`
@@ -579,6 +596,8 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 		DelegationFinalize:     request.DelegationFinalize,
 		Model:                  request.Model,
 		Effort:                 request.Effort,
+		Plan:                   request.Plan,
+		PlanInto:               strings.TrimSpace(request.PlanInto),
 		WorkflowID:             strings.TrimSpace(request.WorkflowID),
 		RuntimeOverride:        strings.TrimSpace(request.RuntimeOverride),
 		RuntimeOverrideRef:     strings.TrimSpace(request.RuntimeOverrideRef),
@@ -1426,6 +1445,21 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 	} else {
 		agentEnv = append(agentEnv, payload.PipelineInputEnv...)
 	}
+	// PLAN GATE (#1479), against the EFFECTIVE runtime — after any #531 per-job
+	// override has been applied to the agent. A plan request the runtime cannot
+	// honour FAILS the delivery here: dropping the flag and running normally would
+	// silently turn a plan-gated brief into an ordinary implementation, with the
+	// only evidence being an argv nobody reads. The unpaired plan_into shape is
+	// re-checked because a payload can reach delivery without passing through
+	// Enqueue (re-enqueues, hand-repaired rows).
+	if payload.Plan || strings.TrimSpace(payload.PlanInto) != "" {
+		if !payload.Plan {
+			return "", "", false, nil, errors.New("job plan_into requires plan mode; set plan on the job or drop plan_into")
+		}
+		if !runtime.SupportsPlanMode(agent.Runtime) {
+			return "", "", false, nil, planDispatchError(agent.Runtime, payload.Plan, payload.PlanInto)
+		}
+	}
 	delivery := runtime.Job{
 		ID:                   job.ID,
 		AgentName:            agent.Name,
@@ -1435,6 +1469,8 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		PullRequest:          payload.PullRequest,
 		Model:                payload.Model,
 		Effort:               payload.Effort,
+		Plan:                 payload.Plan,
+		PlanInto:             payload.PlanInto,
 		ShellEnv:             shellEnv,
 		AgentEnv:             agentEnv,
 		ShellUpstreamContext: payload.ShellUpstreamContext,
@@ -1461,6 +1497,11 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		delivery.RuntimeDefaultEffort = m.RuntimeDefaultEffort(agent.Runtime)
 	}
 	result, err := adapter.Deliver(ctx, agent, delivery)
+	// Record the adapter's own evidence of the plan shape it dispatched, so a
+	// reader can tell a plan run from a normal one without re-deriving it from the
+	// argv. Written before the error branch: a plan run that failed is still a plan
+	// run, and that is exactly when the evidence matters.
+	payload.PlanMode = result.PlanMode
 	// Preserve the last runtime identity while the job remains running. The
 	// liveness sweep needs the exact process that produced the retained transcript;
 	// terminal transitions clear it atomically with settlement below.
@@ -1794,7 +1835,48 @@ func validateJobRequest(request JobRequest) error {
 	if err := validatePipelineInputEnv(request.PipelineInputEnv); err != nil {
 		return err
 	}
+	if err := validateJobPlanRequest(request); err != nil {
+		return err
+	}
 	return validateJobRuntimeOverrideRequest(request)
+}
+
+// validateJobPlanRequest rejects an impossible plan request (#1479) at the
+// enqueue chokepoint, BEFORE a job row exists, so every producer fails fast with
+// an actionable error instead of enqueuing a job whose plan intent the worker
+// would have to drop. Two shapes are impossible:
+//
+//   - plan_into without plan: upstream omp only accepts --plan-yolo-into
+//     alongside --plan-yolo, so this exits non-zero at the CLI with no envelope.
+//   - a plan aimed at an EXPLICIT runtime override whose runtime has no plan mode:
+//     the requested runtime is already known here, so the refusal need not wait
+//     for dispatch.
+//
+// The agent's own default runtime is NOT resolvable in this pure check (it needs
+// the store), so the authoritative runtime gate is planDispatchError, applied in
+// deliver against the EFFECTIVE runtime. Both must exist: this one is earlier,
+// that one is complete.
+func validateJobPlanRequest(request JobRequest) error {
+	planInto := strings.TrimSpace(request.PlanInto)
+	if !request.Plan {
+		if planInto != "" {
+			return errors.New("job plan_into requires plan mode; set plan on the job or drop plan_into")
+		}
+		return nil
+	}
+	if override := strings.TrimSpace(request.RuntimeOverride); override != "" && !runtime.SupportsPlanMode(override) {
+		return planDispatchError(override, request.Plan, planInto)
+	}
+	return nil
+}
+
+// planDispatchError is the single message for "this runtime cannot honour a plan
+// request". Proceeding as a normal run instead would turn a plan-gated brief into
+// a silent ordinary implementation, which is the exact defect #1479 exists to
+// remove, so the job fails loudly rather than quietly losing its shape.
+func planDispatchError(runtimeName string, plan bool, planInto string) error {
+	return fmt.Errorf("runtime %q cannot honour plan mode (%s): only the omp runtime implements it; drop plan from the job or route it to an omp seat",
+		strings.TrimSpace(runtimeName), runtime.PlanModeDescriptor(plan, planInto))
 }
 
 var pipelineInputEnvNamePattern = regexp.MustCompile(`^GITMOOT_INPUT_[A-Z][A-Z0-9_]*$`)

--- a/internal/workflow/mailbox_plan_test.go
+++ b/internal/workflow/mailbox_plan_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -37,11 +38,20 @@ func TestMailboxEnqueueRejectsImpossiblePlanRequest(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			_, err := mailbox.Enqueue(ctx, tc.request)
+			// The ID is derived from the case name because `cases` is a map and Go
+			// randomises map iteration: a shared ID on a shared store meant that
+			// when the guard actually regressed, one subtest reported the other's
+			// leftover row (or a UNIQUE-constraint error) and the diagnosis landed
+			// on the wrong plan shape in ~1 run in 5. It never flaked while green,
+			// so CI hid it — the failure message was unreliable at the one moment
+			// it mattered.
+			request := tc.request
+			request.ID = "job-plan-bad-" + strings.ReplaceAll(name, " ", "-")
+			_, err := mailbox.Enqueue(ctx, request)
 			if err == nil || !strings.Contains(err.Error(), tc.wantText) {
 				t.Fatalf("Enqueue error = %v, want one containing %q", err, tc.wantText)
 			}
-			if _, getErr := store.GetJob(ctx, tc.request.ID); getErr == nil {
+			if _, getErr := store.GetJob(ctx, request.ID); getErr == nil {
 				t.Fatal("rejected plan request still created a job row")
 			}
 		})
@@ -118,9 +128,37 @@ func TestMailboxDeliverPlanGate(t *testing.T) {
 		})
 	}
 
+	// THE BYPASS THIS GATE EXISTS TO CLOSE. readOnlyImplementationBlocked keys on
+	// job type == "implement" and returns false for everything else, so before the
+	// write-policy check a read-only seat refused an implement job would accept an
+	// `ask` job carrying plan and write code anyway — plan mode auto-executes and
+	// upstream omp adds the write tool to the active set. Every non-write policy
+	// spelling is exercised because the empty and "auto" cases are the ones a seat
+	// actually lands in by default, not the explicit read-only one.
+	for _, policy := range []string{"", "auto", runtime.AutonomyPolicyReadOnly} {
+		t.Run("a plan job is refused on a seat without write policy "+policy, func(t *testing.T) {
+			adapter := &fakeDelivery{outputs: []string{planResultJSON}}
+			agent := runtime.Agent{Name: "seat", Role: "implementer", Runtime: runtime.OmpRuntime, RepoScope: "o/r", AutonomyPolicy: policy}
+			payload := JobPayload{Plan: true}
+			_, _, _, _, err := mailbox.deliver(ctx, adapter, agent, job, &payload, "work")
+			if err == nil || !strings.Contains(err.Error(), "does not grant write") {
+				t.Fatalf("policy %q: deliver error = %v, want a write-policy refusal", policy, err)
+			}
+			if len(adapter.prompts) != 0 {
+				t.Fatalf("policy %q: refused plan request still reached the adapter: %v", policy, adapter.prompts)
+			}
+			if payload.PlanMode != "" {
+				t.Fatalf("policy %q: refused plan request recorded evidence %q", policy, payload.PlanMode)
+			}
+		})
+	}
+
 	t.Run("an omp seat delivers with the plan primitives intact", func(t *testing.T) {
 		adapter := &fakeDelivery{outputs: []string{planResultJSON}}
-		agent := runtime.Agent{Name: "seat", Role: "implementer", Runtime: runtime.OmpRuntime, RepoScope: "o/r"}
+		// workspace-write is REQUIRED for a plan job now, not incidental scenery: a
+		// plan ends in an implementation phase, so the happy path must name the
+		// policy that authorises the write it will perform.
+		agent := runtime.Agent{Name: "seat", Role: "implementer", Runtime: runtime.OmpRuntime, RepoScope: "o/r", AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite}
 		payload := JobPayload{Plan: true, PlanInto: "@smol"}
 		if _, _, _, _, err := mailbox.deliver(ctx, adapter, agent, job, &payload, "work"); err != nil {
 			t.Fatalf("deliver returned error: %v", err)
@@ -130,6 +168,24 @@ func TestMailboxDeliverPlanGate(t *testing.T) {
 		}
 		if payload.PlanMode != "plan-into:@smol" {
 			t.Fatalf("payload plan_mode = %q, want %q", payload.PlanMode, "plan-into:@smol")
+		}
+	})
+
+	// Closes surviving mutant M15: gating the payload write on `err == nil` left
+	// the suite green, because every plan test used a delivery that always
+	// succeeds. The comment above that write exists solely to justify recording
+	// evidence BEFORE the error branch — "a plan run that failed is still a plan
+	// run, and that is exactly when the evidence matters" — and nothing tested it.
+	// This is the same contract as the adapter-side failure returns, one layer up.
+	t.Run("a failed plan delivery still records the plan evidence", func(t *testing.T) {
+		adapter := &fakeDelivery{outputs: []string{planResultJSON}, err: errors.New("runtime died mid-run")}
+		agent := runtime.Agent{Name: "seat", Role: "implementer", Runtime: runtime.OmpRuntime, RepoScope: "o/r", AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite}
+		payload := JobPayload{Plan: true, PlanInto: "@smol"}
+		if _, _, _, _, err := mailbox.deliver(ctx, adapter, agent, job, &payload, "work"); err == nil {
+			t.Fatal("deliver succeeded against a failing adapter")
+		}
+		if payload.PlanMode != "plan-into:@smol" {
+			t.Fatalf("payload plan_mode after a FAILED plan run = %q, want %q: the evidence matters most when the run died", payload.PlanMode, "plan-into:@smol")
 		}
 	})
 
@@ -164,7 +220,7 @@ func TestMailboxRunPersistsPlanEvidence(t *testing.T) {
 		t.Fatalf("Enqueue returned error: %v", err)
 	}
 	adapter := &fakeDelivery{outputs: []string{planResultJSON}}
-	agent := runtime.Agent{Name: "planner", Role: "implementer", Runtime: runtime.OmpRuntime, RuntimeRef: "fresh:plan-seat", RepoScope: "owner/repo"}
+	agent := runtime.Agent{Name: "planner", Role: "implementer", Runtime: runtime.OmpRuntime, RuntimeRef: "fresh:plan-seat", RepoScope: "owner/repo", AutonomyPolicy: runtime.AutonomyPolicyWorkspaceWrite}
 	if _, err := mailbox.Run(ctx, "job-plan-run", agent, adapter); err != nil {
 		t.Fatalf("Run returned error: %v", err)
 	}

--- a/internal/workflow/mailbox_plan_test.go
+++ b/internal/workflow/mailbox_plan_test.go
@@ -1,0 +1,185 @@
+package workflow
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+)
+
+const planResultJSON = `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
+
+// TestMailboxEnqueueRejectsImpossiblePlanRequest pins the two plan shapes that
+// can never run, refused at the enqueue chokepoint BEFORE a job row exists
+// (#1479). Kills the silent-drop defect: enqueuing either shape and letting the
+// worker quietly run an ordinary implementation turns a plan-gated brief into an
+// unplanned one with no signal anywhere.
+func TestMailboxEnqueueRejectsImpossiblePlanRequest(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+
+	cases := map[string]struct {
+		request  JobRequest
+		wantText string
+	}{
+		"plan_into without plan": {
+			request:  JobRequest{ID: "job-plan-bad", Agent: "a", Action: "ask", Repo: "o/r", PlanInto: "@smol"},
+			wantText: "plan_into requires plan mode",
+		},
+		"plan on a runtime override that cannot plan": {
+			request: JobRequest{ID: "job-plan-bad", Agent: "a", Action: "ask", Repo: "o/r", Plan: true,
+				RuntimeOverride: runtime.CodexRuntime, RuntimeOverrideRef: "codex-session"},
+			wantText: "cannot honour plan mode",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := mailbox.Enqueue(ctx, tc.request)
+			if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("Enqueue error = %v, want one containing %q", err, tc.wantText)
+			}
+			if _, getErr := store.GetJob(ctx, tc.request.ID); getErr == nil {
+				t.Fatal("rejected plan request still created a job row")
+			}
+		})
+	}
+
+	// The same plan aimed at omp is accepted and round-trips into the payload, so
+	// a background daemon job honors it identically to a foreground one.
+	job, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "job-plan-ok", Agent: "a", Action: "ask", Repo: "o/r",
+		Plan: true, PlanInto: "  @smol  ",
+		RuntimeOverride: runtime.OmpRuntime, RuntimeOverrideRef: "fresh:plan-seat",
+	})
+	if err != nil {
+		t.Fatalf("Enqueue on an omp seat returned error: %v", err)
+	}
+	payload, err := ParseJobPayload(job.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	}
+	if !payload.Plan || payload.PlanInto != "@smol" {
+		t.Fatalf("payload plan = %v/%q, want true/%q", payload.Plan, payload.PlanInto, "@smol")
+	}
+	if payload.PlanMode != "" {
+		t.Fatalf("payload plan_mode = %q before any dispatch, want empty (it is delivery evidence, not a request)", payload.PlanMode)
+	}
+}
+
+// TestMailboxDeliverPlanGate is the authoritative dispatch gate, applied against
+// the EFFECTIVE runtime. A plan request routed to a runtime with no plan mode
+// FAILS the delivery and runs no subprocess at all; only an omp seat proceeds.
+// Kills: dropping the flag and delivering anyway, which is the exact
+// convention-only behaviour #1479 exists to remove.
+func TestMailboxDeliverPlanGate(t *testing.T) {
+	ctx := context.Background()
+	mailbox := Mailbox{Store: openTestStore(t)}
+	job := db.Job{ID: "job-plan-gate", Type: "ask"}
+
+	cases := map[string]struct {
+		agentRuntime string
+		payload      JobPayload
+		wantText     string
+	}{
+		"plan on codex is refused": {
+			agentRuntime: runtime.CodexRuntime,
+			payload:      JobPayload{Plan: true},
+			wantText:     "cannot honour plan mode (plan)",
+		},
+		"plan_into on claude names the resolved shape": {
+			agentRuntime: runtime.ClaudeRuntime,
+			payload:      JobPayload{Plan: true, PlanInto: "@smol"},
+			wantText:     "cannot honour plan mode (plan-into:@smol)",
+		},
+		"plan_into without plan is refused even on omp": {
+			agentRuntime: runtime.OmpRuntime,
+			payload:      JobPayload{PlanInto: "@smol"},
+			wantText:     "plan_into requires plan mode",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			adapter := &fakeDelivery{outputs: []string{planResultJSON}}
+			agent := runtime.Agent{Name: "seat", Role: "implementer", Runtime: tc.agentRuntime, RepoScope: "o/r"}
+			payload := tc.payload
+			_, _, _, _, err := mailbox.deliver(ctx, adapter, agent, job, &payload, "work")
+			if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("deliver error = %v, want one containing %q", err, tc.wantText)
+			}
+			if len(adapter.prompts) != 0 {
+				t.Fatalf("refused plan request still reached the adapter: %v", adapter.prompts)
+			}
+			if payload.PlanMode != "" {
+				t.Fatalf("refused plan request recorded evidence %q for a run that never happened", payload.PlanMode)
+			}
+		})
+	}
+
+	t.Run("an omp seat delivers with the plan primitives intact", func(t *testing.T) {
+		adapter := &fakeDelivery{outputs: []string{planResultJSON}}
+		agent := runtime.Agent{Name: "seat", Role: "implementer", Runtime: runtime.OmpRuntime, RepoScope: "o/r"}
+		payload := JobPayload{Plan: true, PlanInto: "@smol"}
+		if _, _, _, _, err := mailbox.deliver(ctx, adapter, agent, job, &payload, "work"); err != nil {
+			t.Fatalf("deliver returned error: %v", err)
+		}
+		if len(adapter.plans) != 1 || !adapter.plans[0] || adapter.planIntos[0] != "@smol" {
+			t.Fatalf("delivered plan primitives = %v/%v, want [true]/[@smol]", adapter.plans, adapter.planIntos)
+		}
+		if payload.PlanMode != "plan-into:@smol" {
+			t.Fatalf("payload plan_mode = %q, want %q", payload.PlanMode, "plan-into:@smol")
+		}
+	})
+
+	t.Run("a normal job carries no plan primitives and records no evidence", func(t *testing.T) {
+		adapter := &fakeDelivery{outputs: []string{planResultJSON}}
+		agent := runtime.Agent{Name: "seat", Role: "implementer", Runtime: runtime.CodexRuntime, RepoScope: "o/r"}
+		payload := JobPayload{}
+		if _, _, _, _, err := mailbox.deliver(ctx, adapter, agent, job, &payload, "work"); err != nil {
+			t.Fatalf("deliver returned error: %v", err)
+		}
+		if adapter.plans[0] || adapter.planIntos[0] != "" {
+			t.Fatalf("non-plan job delivered plan primitives %v/%v", adapter.plans, adapter.planIntos)
+		}
+		if payload.PlanMode != "" {
+			t.Fatalf("non-plan job recorded plan evidence %q", payload.PlanMode)
+		}
+	})
+}
+
+// TestMailboxRunPersistsPlanEvidence proves the resolved plan mode survives to
+// the settled payload, so a reader can tell a plan run from a normal one WITHOUT
+// re-deriving it from the runtime's argv.
+func TestMailboxRunPersistsPlanEvidence(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	mailbox := Mailbox{Store: store}
+	if _, err := mailbox.Enqueue(ctx, JobRequest{
+		ID: "job-plan-run", Agent: "planner", Action: "ask", Repo: "owner/repo",
+		Plan: true, PlanInto: "@smol",
+		RuntimeOverride: runtime.OmpRuntime, RuntimeOverrideRef: "fresh:plan-seat",
+	}); err != nil {
+		t.Fatalf("Enqueue returned error: %v", err)
+	}
+	adapter := &fakeDelivery{outputs: []string{planResultJSON}}
+	agent := runtime.Agent{Name: "planner", Role: "implementer", Runtime: runtime.OmpRuntime, RuntimeRef: "fresh:plan-seat", RepoScope: "owner/repo"}
+	if _, err := mailbox.Run(ctx, "job-plan-run", agent, adapter); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	stored, err := store.GetJob(ctx, "job-plan-run")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	payload, err := ParseJobPayload(stored.Payload)
+	if err != nil {
+		t.Fatalf("ParseJobPayload returned error: %v", err)
+	}
+	if payload.PlanMode != "plan-into:@smol" {
+		t.Fatalf("settled payload plan_mode = %q, want %q", payload.PlanMode, "plan-into:@smol")
+	}
+	if !payload.Plan || payload.PlanInto != "@smol" {
+		t.Fatalf("settled payload lost the plan request: %v/%q", payload.Plan, payload.PlanInto)
+	}
+}

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -1966,7 +1966,14 @@ func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runti
 		f.onDeliver()
 	}
 	if f.err != nil {
-		return runtime.Result{}, f.err
+		// A REAL adapter populates plan evidence on its FAILURE returns too — omp
+		// sets Result.PlanMode on both the non-zero-exit and parse-error paths,
+		// because a plan run that died is still a plan run. Returning a zero Result
+		// here made the mailbox's write-before-the-error-branch behaviour
+		// unobservable, so a mutation that recorded evidence only on success could
+		// not be killed by any test. The double has to honour the contract it
+		// stands in for.
+		return runtime.Result{PlanMode: runtime.PlanModeDescriptor(job.Plan, job.PlanInto)}, f.err
 	}
 	index := len(f.prompts) - 1
 	result := runtime.Result{}

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -1940,6 +1940,8 @@ type fakeDelivery struct {
 	shellEnvs             [][]string
 	agentEnvs             [][]string
 	shellUpstreamContexts []string
+	plans                 []bool
+	planIntos             []string
 	onDeliver             func()
 	pid                   int
 	err                   error
@@ -1955,6 +1957,8 @@ func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runti
 	f.shellEnvs = append(f.shellEnvs, append([]string(nil), job.ShellEnv...))
 	f.agentEnvs = append(f.agentEnvs, append([]string(nil), job.AgentEnv...))
 	f.shellUpstreamContexts = append(f.shellUpstreamContexts, job.ShellUpstreamContext)
+	f.plans = append(f.plans, job.Plan)
+	f.planIntos = append(f.planIntos, job.PlanInto)
 	if f.pid > 0 && job.OnPID != nil {
 		job.OnPID(f.pid)
 	}
@@ -1966,6 +1970,9 @@ func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runti
 	}
 	index := len(f.prompts) - 1
 	result := runtime.Result{}
+	// Stand in for a plan-capable adapter: report the shape that was dispatched.
+	// A job without plan mode yields "", so every non-plan test is unchanged.
+	result.PlanMode = runtime.PlanModeDescriptor(job.Plan, job.PlanInto)
 	if index >= len(f.outputs) {
 		return result, nil
 	}

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -335,12 +335,24 @@ func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string) bool {
 		return false
 	}
 	owner, listed := planFieldAllowlist[spec.Name.Name]
-	// Only inside the OWNING package. A reviewer showed the unrestricted form failing
-	// the census on a compiled internal/cli helper declaring an unrelated
-	// `JobRequest struct{ Value string }` — no plan field, no relation to runtime.Job.
-	// Outside the owner a bare literal is already reported by the package test above,
-	// so the shadow arm adds nothing there and only blocks innocent code.
-	return listed && pkgPath == owner
+	if !listed {
+		return false
+	}
+	// INSIDE the owning package, any declaration of the name shadows the real type.
+	if pkgPath == owner {
+		return true
+	}
+	// OUTSIDE it, only an ALIAS (`type X = Y`, spec.Assign set) is reported. That
+	// distinction is load-bearing in both directions, and a reviewer found the
+	// fail-open half as a BLOCKER: restricting this arm to the owning package assumed
+	// the composite-literal arm would catch the rest, but hasPlanField only recognises
+	// KEYED elements — so a real internal/cli file declaring `type JobPayload =
+	// runtime.Job` and returning an UNKEYED positional literal with Plan set compiled
+	// green past both arms. An alias borrows an identity the census grants exemptions
+	// to and is reported wherever it appears; a fresh `type JobRequest struct{ Value
+	// string }` defines something unrelated that merely reuses a name, carries no plan
+	// field, and is the innocent case a second reviewer found over-reported.
+	return spec.Assign.IsValid()
 }
 
 // planFieldTypeIsAllowlisted reports whether a composite literal's type is one of
@@ -515,7 +527,13 @@ func TestDeclaresAllowlistedNameArmsTheShadowBranch(t *testing.T) {
 		{"local definition, not an alias, still borrows the name", "internal/cli/x.go", "type groomApplyResult struct{ Plan bool }", true},
 		// OVER-REPORT CONTROL. The unrestricted form failed the census on a compiled
 		// internal/cli helper declaring an unrelated JobRequest with no plan field.
-		{"allowlisted name declared OUTSIDE its owning package", "internal/cli/x.go", "type JobRequest struct{ Value string }", false},
+		{"innocent REDEFINITION outside the owner is not reported", "internal/cli/x.go", "type JobRequest struct{ Value string }", false},
+		// BLOCKER CONTROL. Restricting this arm to the owning package assumed the
+		// composite-literal arm covered the rest; it only sees KEYED elements, so an
+		// UNKEYED positional literal of an outside-the-owner alias compiled green past
+		// both. An alias is reported wherever it appears.
+		{"ALIAS outside the owning package is reported", "internal/cli/x.go", "type JobPayload = runtime.Job", true},
+		{"alias of a second allowlisted name, outside the owner", "internal/other/x.go", "type JobRequest = runtime.Job", true},
 		{"unrelated local type", "internal/workflow/x.go", "type somethingElse = runtime.Job", false},
 	} {
 		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package workflow\nfunc f() {\n"+tc.src+"\n_ = 0\n}\n", 0)
@@ -558,6 +576,18 @@ func TestPlanFieldCensusWiresEveryArm(t *testing.T) {
 			rel:  "internal/cli/x.go",
 			src:  "func f() { var j runtime.Job; j.Plan = true; _ = j }",
 			want: []string{"internal/cli/x.go::f"},
+		},
+		{
+			name: "shadow arm, ALIAS outside the owning package (the BLOCKER)",
+			rel:  "internal/cli/x.go",
+			src:  "func f() { type JobPayload = runtime.Job; _ = 0 }",
+			want: []string{"internal/cli/x.go::f"},
+		},
+		{
+			name: "shadow arm, innocent redefinition outside the owner",
+			rel:  "internal/cli/x.go",
+			src:  "func f() { type JobRequest struct{ Value string }; _ = 0 }",
+			want: nil,
 		},
 		{
 			name: "shadow arm, inside the owning package",

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -66,6 +66,22 @@ func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 	var got []string
 	pkgPath := planFieldPackagePath(rel)
 	imports := planFieldImportPaths(parsed)
+	// PACKAGE-LEVEL type declarations first. Two reviewers independently found this
+	// hole: the loop below only walks FuncDecl bodies, so `type JobPayload =
+	// runtime.Job` at package scope — plain or generic — never reached the TypeSpec arm,
+	// and an unkeyed positional literal of it compiled straight past the census.
+	for _, declaration := range parsed.Decls {
+		general, ok := declaration.(*ast.GenDecl)
+		if !ok || general.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range general.Specs {
+			typed, ok := spec.(*ast.TypeSpec)
+			if ok && declaresAllowlistedName(typed, pkgPath, false) {
+				got = append(got, filepath.ToSlash(rel)+"::type "+typed.Name.Name)
+			}
+		}
+	}
 	for _, declaration := range parsed.Decls {
 		function, ok := declaration.(*ast.FuncDecl)
 		if !ok || function.Body == nil {
@@ -107,7 +123,7 @@ func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 				// runtime.Job. Declaring an allowlisted name anywhere inside a body is
 				// therefore reported: the allowlist grants exemption to five specific
 				// types, not to their spellings.
-				if declaresAllowlistedName(n, pkgPath) {
+				if declaresAllowlistedName(n, pkgPath, true) {
 					got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
 				}
 			}
@@ -330,7 +346,7 @@ func planFieldImportPaths(parsed *ast.File) map[string]string {
 // bare literal under that name passes the owning-package test while producing a
 // genuine runtime.Job. The exemption belongs to five specific types, not to their
 // spellings, so any body-scoped declaration of one of those names is reported.
-func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string) bool {
+func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string, bodyScoped bool) bool {
 	if spec == nil || spec.Name == nil {
 		return false
 	}
@@ -338,8 +354,11 @@ func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string) bool {
 	if !listed {
 		return false
 	}
-	// INSIDE the owning package, any declaration of the name shadows the real type.
-	if pkgPath == owner {
+	// INSIDE the owning package, a BODY-SCOPED declaration shadows the real type — and
+	// only a body-scoped one. At package scope inside the owner the declaration IS the
+	// canonical type: reporting it made the census name its own five allowlisted types
+	// as producers. Scope is part of the rule, not an implementation detail.
+	if bodyScoped && pkgPath == owner {
 		return true
 	}
 	// OUTSIDE it, only an ALIAS (`type X = Y`, spec.Assign set) is reported. That
@@ -352,7 +371,36 @@ func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string) bool {
 	// to and is reported wherever it appears; a fresh `type JobRequest struct{ Value
 	// string }` defines something unrelated that merely reuses a name, carries no plan
 	// field, and is the innocent case a second reviewer found over-reported.
-	return spec.Assign.IsValid()
+	return spec.Assign.IsValid() && planCarryingTarget(spec.Type)
+}
+
+// planCarryingTarget reports whether an alias target is a type that can carry plan
+// fields, i.e. runtime.Job itself or an allowlisted shape. A reviewer showed the
+// unrestricted alias rule reporting `type JobPayload = string` in internal/cli as a
+// plan producer: an alias to something that has no plan field borrows a NAME but not
+// an identity, and reporting it fails innocent code for a spelling.
+func planCarryingTarget(expr ast.Expr) bool {
+	switch typed := expr.(type) {
+	case *ast.StarExpr:
+		return planCarryingTarget(typed.X)
+	case *ast.IndexExpr: // generic instantiation, e.g. Wrapper[runtime.Job]
+		return planCarryingTarget(typed.X)
+	case *ast.SelectorExpr:
+		if _, listed := planFieldAllowlist[typed.Sel.Name]; listed {
+			return true
+		}
+		return typed.Sel.Name == "Job"
+	case *ast.Ident:
+		if _, listed := planFieldAllowlist[typed.Name]; listed {
+			return true
+		}
+		return typed.Name == "Job"
+	default:
+		// Cannot name the target: fail CLOSED for an allowlisted NAME, because that is
+		// the borrowed-identity case, and an unnameable target is exactly where a
+		// producer would hide.
+		return true
+	}
 }
 
 // planFieldTypeIsAllowlisted reports whether a composite literal's type is one of
@@ -542,7 +590,7 @@ func TestDeclaresAllowlistedNameArmsTheShadowBranch(t *testing.T) {
 		}
 		var got bool
 		ast.Inspect(file, func(n ast.Node) bool {
-			if spec, ok := n.(*ast.TypeSpec); ok && declaresAllowlistedName(spec, planFieldPackagePath(tc.pkg)) {
+			if spec, ok := n.(*ast.TypeSpec); ok && declaresAllowlistedName(spec, planFieldPackagePath(tc.pkg), true) {
 				got = true
 			}
 			return true
@@ -599,6 +647,75 @@ func TestPlanFieldCensusWiresEveryArm(t *testing.T) {
 			name: "import-alias arm",
 			rel:  "internal/workflow/x.go",
 			src:  "func f() { _ = workflow.JobPayload{Plan: true} }",
+			want: []string{"internal/workflow/x.go::f"},
+		},
+		{
+			// PACKAGE-LEVEL arm. Two reviewers found this hole; four mutations survived
+			// until these fixtures existed, because the wiring test only drove bodies.
+			name: "package-level ALIAS outside the owner is reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobPayload = runtime.Job\nfunc f() { _ = 0 }",
+			want: []string{"internal/cli/x.go::type JobPayload"},
+		},
+		{
+			name: "package-level generic alias is reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobPayload[T any] = runtime.Job\nfunc f() { _ = 0 }",
+			want: []string{"internal/cli/x.go::type JobPayload"},
+		},
+		{
+			// The canonical declarations live at package scope INSIDE their owner; an
+			// earlier version of this arm reported all five as producers.
+			name: "package-level DEFINITION inside the owner is not reported",
+			rel:  "internal/workflow/x.go",
+			src:  "type JobPayload struct{ Plan bool }\nfunc f() { _ = 0 }",
+			want: nil,
+		},
+		{
+			// ALIAS TARGET. An alias to something with no plan field borrows a name, not
+			// an identity — reporting it failed innocent code for a spelling.
+			name: "alias to a non-plan-carrying target is not reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobRequest = string\nfunc f() { _ = 0 }",
+			want: nil,
+		},
+		{
+			name: "body-scoped alias to a non-plan target is not reported",
+			rel:  "internal/cli/x.go",
+			src:  "func f() { type JobPayload = string; _ = 0 }",
+			want: nil,
+		},
+		{
+			// Bare-Ident target: inside package runtime the plan-carrying type is spelled
+			// `Job`, with no qualifier. Nothing covered the Ident arm until this case.
+			name: "alias to a BARE plan-carrying Ident is reported",
+			rel:  "internal/runtime/x.go",
+			src:  "type JobPayload = Job\nfunc f() { _ = 0 }",
+			want: []string{"internal/runtime/x.go::type JobPayload"},
+		},
+		{
+			// Generic INSTANTIATION as the alias target: the target is an IndexExpr and
+			// unwraps to the type being instantiated. My first version of this fixture
+			// expected Wrapper[runtime.Job] to be reported and it was WRONG — that alias
+			// targets Wrapper, which carries no plan field. The instantiated type is what
+			// decides, so a generic Job does report and a wrapper around one does not.
+			name: "alias to a generic PLAN type is reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobPayload = runtime.Job[string]\nfunc f() { _ = 0 }",
+			want: []string{"internal/cli/x.go::type JobPayload"},
+		},
+		{
+			name: "alias to a generic WRAPPER around a plan type is not reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobPayload = Wrapper[runtime.Job]\nfunc f() { _ = 0 }",
+			want: nil,
+		},
+		{
+			// Body-scoped DEFINITION inside the owner: shadows the canonical type without
+			// being an alias, so only the scope rule can catch it.
+			name: "body-scoped definition INSIDE the owner is reported",
+			rel:  "internal/workflow/x.go",
+			src:  "func f() { type JobPayload struct{ Plan bool }; _ = 0 }",
 			want: []string{"internal/workflow/x.go::f"},
 		},
 		{

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -12,14 +12,27 @@ import (
 	"testing"
 )
 
-// TestRuntimeJobPlanFieldsHaveSingleGatedProducer pins the source-level reason
-// the deliver-time plan gate is complete: Mailbox.deliver is the only production
-// code that may construct a runtime.Job carrying Plan or PlanInto, and the gate is
-// immediately above that literal. A new adapter entry path must deliberately join
-// this gate instead of silently creating a second door.
-// MEASURED LIMITS OF THIS CENSUS, stated because a guard that overclaims is worse
-// than one with a documented edge. Every item below was demonstrated by a reviewer
-// with REAL COMPILED CODE that this census left green, over four review rounds:
+// TestRuntimeJobPlanFieldsHaveSingleGatedProducer is a REGRESSION guard on the
+// deliver-time plan gate. It does NOT prove the gate complete, and it does not prove
+// that Mailbox.deliver is the only code that can construct a runtime.Job carrying
+// Plan or PlanInto. An earlier version of this comment claimed both; a reviewer
+// pointed out it claimed them three lines above the list of constructions the census
+// is known to miss, which is the overclaim this file exists to not commit.
+//
+// WHAT IT ACTUALLY PROVES, with every exemption named:
+//
+//   - No composite literal setting Plan or PlanInto BY KEY exists outside
+//     Mailbox.deliver, EXCEPT literals whose type is on planFieldAllowlist and
+//     resolves to its owning package (five shapes that legitimately carry such a
+//     field, listed there with reasons).
+//   - No assignment to a .Plan or .PlanInto selector exists outside Mailbox.deliver.
+//   - No declaration BORROWING an allowlisted type name exists outside its owner,
+//     EXCEPT a non-alias definition of an unrelated type, and EXCEPT an alias whose
+//     target planCarryingTarget cannot see as plan-carrying. Both exceptions are
+//     deliberate: they were measured as false positives on innocent code.
+//
+// WHAT IT DOES NOT PROVE — each demonstrated by a reviewer with REAL COMPILED CODE
+// that this census left green, over four rounds, and tracked on #1513:
 //
 //   - ALIAS CHAINS. `Alias = runtime.Job` then `JobPayload = Alias` is not followed:
 //     planCarryingTarget classifies a target by its immediate spelling only. Same-file,
@@ -33,11 +46,11 @@ import (
 //
 // THE COMMON CAUSE IS NOT A MISSING SPELLING. Following type identity across aliases,
 // packages and generic instantiations requires a repository declaration index or
-// go/types; this census is syntactic. Four rounds of adding one more spelling each
-// time produced one more bypass each time, which is the evidence for that claim
-// rather than an opinion about it. What this census DOES prove is narrow and real:
-// no KEYED plan-field literal, no post-construction plan-field assignment, and no
-// allowlisted-name alias declaration exists outside the single sanctioned producer.
+// go/types; this census is syntactic. Seven rounds of adding one more spelling each
+// produced one more bypass each, which is evidence for that claim rather than an
+// opinion about it. So a new adapter entry path should deliberately join the gate
+// above Mailbox.deliver's literal — this test raises the cost of a second door, it
+// does not lock it.
 func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 	t.Parallel()
 	root := filepath.Clean(filepath.Join("..", ".."))
@@ -745,6 +758,31 @@ func TestPlanFieldCensusWiresEveryArm(t *testing.T) {
 			rel:  "internal/workflow/x.go",
 			src:  "func f() { type JobPayload struct{ Plan bool }; _ = 0 }",
 			want: []string{"internal/workflow/x.go::f"},
+		},
+		{
+			// PIN the import-path identity rule: reverting the selector test to a bare
+			// `Sel.Name == "Job"` survived every fixture until this case existed, which
+			// would restore the exact db.Job false positive this delta closed.
+			name: "alias to a FOREIGN Job is not reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobPayload = db.Job\nfunc f() { _ = 0 }",
+			want: nil,
+		},
+		{
+			// PIN the unnameable-target default: flipping it back to true survived, and
+			// would restore the anonymous-struct false positive.
+			name: "alias to an anonymous struct is not reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobPayload = struct{ Value string }\nfunc f() { _ = 0 }",
+			want: nil,
+		},
+		{
+			// PIN the StarExpr unwrap: disabling it survived, and a pointer alias to the
+			// real type is a genuine borrowed identity.
+			name: "POINTER alias to the plan type is reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobPayload = *runtime.Job\nfunc f() { _ = 0 }",
+			want: []string{"internal/cli/x.go::type JobPayload"},
 		},
 		{
 			name: "clean file reports nothing",

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -25,6 +25,11 @@ import (
 // package-level func literal assigning job.PlanInto both compiled green while the
 // header claimed no such construction existed.
 //
+// WHAT THE WALK SKIPS, so the claims below are read correctly: _test.go files, and
+// the directories shouldSkipPlanProducerDir names (.git, .gitmoot, node_modules,
+// build, dist, repos, GOALS). The claims are about NON-TEST production source only —
+// the plan tests themselves contain keyed runtime.Job{Plan: true} literals by design.
+//
 // WHAT IT ACTUALLY PROVES, with every exemption named:
 //
 //   - No composite literal setting Plan or PlanInto BY KEY exists outside
@@ -115,7 +120,7 @@ var planAssignExemptions = map[string]string{
 	// deps.Plan is a *tui.TrainRunPlan for the SkillOpt confirm screen — a UI plan
 	// object, unrelated to runtime plan mode. Lives inside a package-level var holding
 	// a func literal, which is why the body-only walk never saw it.
-	"internal/cli/skillopt_trainrun_tui.go::var runSkillOptTrainRunConfirmTUI": "tui.TrainRunPlan, not runtime plan mode",
+	"internal/cli/skillopt_trainrun_tui.go::var runSkillOptTrainRunConfirmTUI::deps.Plan": "tui.TrainRunPlan, not runtime plan mode",
 }
 
 func planFieldProducersInFile(rel string, parsed *ast.File) []string {
@@ -170,10 +175,15 @@ func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 				// delivered it straight past the mailbox gate while this test still
 				// passed. A seam guard that recognises only one syntax for writing a
 				// field is not a seam guard.
-				if entry := filepath.ToSlash(rel) + "::" + symbol; assignsPlanField(n) {
-					if _, exempt := planAssignExemptions[entry]; !exempt {
-						got = append(got, entry)
+				// Keyed on the exact RECEIVER.FIELD, never the enclosing symbol: two
+				// reviewers each planted a real `delivery.Plan = true` beside the
+				// innocent `deps.Plan` in the same function and the census stayed green,
+				// so a symbol-wide exemption hid every future genuine write in it.
+				for _, selector := range planAssignSelectors(n) {
+					if _, exempt := planAssignExemptions[filepath.ToSlash(rel)+"::"+symbol+"::"+selector]; exempt {
+						continue
 					}
+					got = append(got, filepath.ToSlash(rel)+"::"+symbol)
 				}
 			case *ast.TypeSpec:
 				// A body-scoped `type JobPayload = runtime.Job` SHADOWS the real type,
@@ -266,6 +276,26 @@ func functionSymbol(function *ast.FuncDecl) string {
 // which reaches the same field and looked like nothing. Recognising one spelling of
 // a write is exactly the defect this helper was added to fix, so it must not
 // reproduce it one level down. Deref, address-of and parens are all peeled.
+// planAssignSelectors renders each plan-field assignment target as receiver.field,
+// so an exemption can name one write instead of silencing a whole function. A target
+// whose receiver is not a plain identifier renders as "?.field", which cannot match
+// an exemption key and is therefore reported.
+func planAssignSelectors(assign *ast.AssignStmt) []string {
+	var selectors []string
+	for _, target := range assign.Lhs {
+		selector, ok := target.(*ast.SelectorExpr)
+		if !ok || !selectorNamesPlanField(selector) {
+			continue
+		}
+		receiver := identName(selector.X)
+		if receiver == "" {
+			receiver = "?"
+		}
+		selectors = append(selectors, receiver+"."+selector.Sel.Name)
+	}
+	return selectors
+}
+
 func assignsPlanField(assign *ast.AssignStmt) bool {
 	for _, lhs := range assign.Lhs {
 		if selectorNamesPlanField(lhs) {
@@ -834,6 +864,29 @@ func TestPlanFieldCensusWiresEveryArm(t *testing.T) {
 			rel:  "internal/cli/x.go",
 			src:  "type JobPayload = *runtime.Job\nfunc f() { _ = 0 }",
 			want: []string{"internal/cli/x.go::type JobPayload"},
+		},
+		{
+			// PACKAGE-SCOPE INITIALIZER arm, pinned. Both round-14 reviewers reverted this
+			// arm to a body-only walk with one line and every test stayed green, which
+			// silently reinstated a BLOCKER-class hole.
+			name: "package-level keyed literal is reported",
+			rel:  "internal/cli/x.go",
+			src:  "var zzV = runtime.Job{Plan: true}",
+			want: []string{"internal/cli/x.go::var zzV"},
+		},
+		{
+			name: "package-level func literal assigning PlanInto is reported",
+			rel:  "internal/cli/x.go",
+			src:  "var zzF = func() { var j runtime.Job; j.PlanInto = \"@smol\"; _ = j }",
+			want: []string{"internal/cli/x.go::var zzF"},
+		},
+		{
+			// The exemption must name ONE write, not a whole function: a genuine
+			// assignment beside an exempt one must still be reported.
+			name: "unexempt selector beside an exempt one is still reported",
+			rel:  "internal/cli/skillopt_trainrun_tui.go",
+			src:  "var runSkillOptTrainRunConfirmTUI = func() { var deps, delivery struct{ Plan bool }; deps.Plan = true; delivery.Plan = true; _, _ = deps, delivery }",
+			want: []string{"internal/cli/skillopt_trainrun_tui.go::var runSkillOptTrainRunConfirmTUI"},
 		},
 		{
 			name: "clean file reports nothing",

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -276,6 +276,31 @@ func functionSymbol(function *ast.FuncDecl) string {
 // which reaches the same field and looked like nothing. Recognising one spelling of
 // a write is exactly the defect this helper was added to fix, so it must not
 // reproduce it one level down. Deref, address-of and parens are all peeled.
+// planAssignTarget peels parens, pointer derefs and address-of from an assignment
+// target and returns the plan-field selector underneath, or nil.
+func planAssignTarget(expr ast.Expr) *ast.SelectorExpr {
+	for {
+		switch e := expr.(type) {
+		case *ast.ParenExpr:
+			expr = e.X
+		case *ast.StarExpr:
+			expr = e.X
+		case *ast.UnaryExpr:
+			if e.Op != token.AND {
+				return nil
+			}
+			expr = e.X
+		case *ast.SelectorExpr:
+			if e.Sel != nil && (e.Sel.Name == "Plan" || e.Sel.Name == "PlanInto") {
+				return e
+			}
+			return nil
+		default:
+			return nil
+		}
+	}
+}
+
 // planAssignSelectors renders each plan-field assignment target as receiver.field,
 // so an exemption can name one write instead of silencing a whole function. A target
 // whose receiver is not a plain identifier renders as "?.field", which cannot match
@@ -283,8 +308,13 @@ func functionSymbol(function *ast.FuncDecl) string {
 func planAssignSelectors(assign *ast.AssignStmt) []string {
 	var selectors []string
 	for _, target := range assign.Lhs {
-		selector, ok := target.(*ast.SelectorExpr)
-		if !ok || !selectorNamesPlanField(selector) {
+		// PEEL the same wrappers selectorNamesPlanField peels. Demanding a bare
+		// SelectorExpr here silently bypassed that logic — a compiled
+		// `*(&delivery.Plan) = true` passed the census while the peeler's own tests
+		// stayed green, so my refactor dropped live coverage and left a dead test
+		// asserting it. The header claimed no such assignment existed.
+		selector := planAssignTarget(target)
+		if selector == nil {
 			continue
 		}
 		receiver := identName(selector.X)
@@ -887,6 +917,29 @@ func TestPlanFieldCensusWiresEveryArm(t *testing.T) {
 			rel:  "internal/cli/skillopt_trainrun_tui.go",
 			src:  "var runSkillOptTrainRunConfirmTUI = func() { var deps, delivery struct{ Plan bool }; deps.Plan = true; delivery.Plan = true; _, _ = deps, delivery }",
 			want: []string{"internal/cli/skillopt_trainrun_tui.go::var runSkillOptTrainRunConfirmTUI"},
+		},
+		{
+			// PIN the qualified allowlisted alias target branch.
+			// The harness aliases 'workflow' to censusshim on purpose, so the qualified
+			// allowlisted target is spelled through the import that resolves: runtime.
+			name: "alias to a QUALIFIED allowlisted type is reported",
+			rel:  "internal/cli/x.go",
+			src:  "type JobPayload = runtime.RuntimeContractRequest\nfunc f() { _ = 0 }",
+			want: []string{"internal/cli/x.go::type JobPayload"},
+		},
+		{
+			// PIN the bare allowlisted alias target branch.
+			name: "alias to a BARE allowlisted type is reported",
+			rel:  "internal/runtime/x.go",
+			src:  "type JobPayload = RuntimeContractRequest\nfunc f() { _ = 0 }",
+			want: []string{"internal/runtime/x.go::type JobPayload"},
+		},
+		{
+			// PIN the wrapper-aware assignment target: `*(&x.Plan) = true` is a write.
+			name: "wrapped selector assignment is reported",
+			rel:  "internal/cli/x.go",
+			src:  "func f() { var j runtime.Job; *(&j.Plan) = true; _ = j }",
+			want: []string{"internal/cli/x.go::f"},
 		},
 		{
 			name: "clean file reports nothing",

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -1,0 +1,141 @@
+package workflow
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestRuntimeJobPlanFieldsHaveSingleGatedProducer pins the source-level reason
+// the deliver-time plan gate is complete: Mailbox.deliver is the only production
+// code that may construct a runtime.Job carrying Plan or PlanInto, and the gate is
+// immediately above that literal. A new adapter entry path must deliberately join
+// this gate instead of silently creating a second door.
+func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
+	t.Parallel()
+	root := filepath.Clean(filepath.Join("..", ".."))
+	want := []string{"internal/workflow/mailbox.go::Mailbox.deliver"}
+	var got []string
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if shouldSkipPlanProducerDir(rel) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			return err
+		}
+		runtimeAliases, dotRuntime := runtimeImportAliases(parsed)
+		inRuntimePackage := parsed.Name.Name == "runtime" && strings.HasPrefix(filepath.ToSlash(rel), "internal/runtime/")
+		for _, declaration := range parsed.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil {
+				continue
+			}
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				literal, ok := node.(*ast.CompositeLit)
+				if !ok || !isRuntimeJobType(literal.Type, runtimeAliases, dotRuntime, inRuntimePackage) || !hasPlanField(literal) {
+					return true
+				}
+				got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+				return true
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scan runtime.Job plan producers: %v", err)
+	}
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Fatalf("runtime.Job plan producers = %v, want exactly %v; route every producer through the deliver-time plan gate", got, want)
+	}
+}
+
+func shouldSkipPlanProducerDir(rel string) bool {
+	if rel == "." {
+		return false
+	}
+	base := filepath.Base(rel)
+	return base == ".git" || base == ".gitmoot" || base == "node_modules" || base == "build" || base == "dist" || base == "repos" || base == "GOALS"
+}
+
+func runtimeImportAliases(file *ast.File) (map[string]bool, bool) {
+	aliases := map[string]bool{}
+	dot := false
+	for _, imported := range file.Imports {
+		path, err := strconv.Unquote(imported.Path.Value)
+		if err != nil || path != "github.com/gitmoot/gitmoot/internal/runtime" {
+			continue
+		}
+		name := "runtime"
+		if imported.Name != nil {
+			name = imported.Name.Name
+		}
+		if name == "." {
+			dot = true
+		} else if name != "_" {
+			aliases[name] = true
+		}
+	}
+	return aliases, dot
+}
+
+func isRuntimeJobType(expr ast.Expr, aliases map[string]bool, dotRuntime, inRuntimePackage bool) bool {
+	switch typed := expr.(type) {
+	case *ast.SelectorExpr:
+		alias, ok := typed.X.(*ast.Ident)
+		return ok && aliases[alias.Name] && typed.Sel.Name == "Job"
+	case *ast.Ident:
+		return typed.Name == "Job" && (dotRuntime || inRuntimePackage)
+	default:
+		return false
+	}
+}
+
+func hasPlanField(literal *ast.CompositeLit) bool {
+	for _, element := range literal.Elts {
+		field, ok := element.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		name, ok := field.Key.(*ast.Ident)
+		if ok && (name.Name == "Plan" || name.Name == "PlanInto") {
+			return true
+		}
+	}
+	return false
+}
+
+func functionSymbol(function *ast.FuncDecl) string {
+	if function.Recv == nil || len(function.Recv.List) == 0 {
+		return function.Name.Name
+	}
+	receiver := function.Recv.List[0].Type
+	if pointer, ok := receiver.(*ast.StarExpr); ok {
+		receiver = pointer.X
+	}
+	if name, ok := receiver.(*ast.Ident); ok {
+		return name.Name + "." + function.Name.Name
+	}
+	return function.Name.Name
+}

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -100,8 +100,6 @@ func shouldSkipPlanProducerDir(rel string) bool {
 	return base == ".git" || base == ".gitmoot" || base == "node_modules" || base == "build" || base == "dist" || base == "repos" || base == "GOALS"
 }
 
-
-
 func hasPlanField(literal *ast.CompositeLit) bool {
 	for _, element := range literal.Elts {
 		field, ok := element.(*ast.KeyValueExpr)
@@ -234,18 +232,29 @@ func TestAssignsPlanFieldArmsTheCensus(t *testing.T) {
 // as a census failure naming itself — a maintainer then decides whether it belongs
 // here. Adding a name to this list is a deliberate act with a diff; being invisible
 // to the census was not.
-var planFieldAllowlist = map[string]bool{
-	"JobPayload":             true, // internal/workflow/mailbox.go — the persisted payload
-	"JobRequest":             true, // internal/workflow/mailbox.go — the enqueue request
-	"RuntimeContractRequest": true, // internal/runtime/preflight.go — preflight scoping
+// planFieldAllowlist maps a type to the PACKAGE that owns it. Keying on the bare
+// type name was itself fail-open: a reviewer showed that `other.JobPayload{Plan:true}`
+// was exempted, and `type JobPayload = runtime.Job` in any other package would be
+// too — recreating the very type-alias bypass this inversion was written to close,
+// now under five borrowed names. The qualifier is part of the identity, so it is part
+// of the key.
+//
+// This is an ALLOWLIST on purpose. The design before the inversion asked "is this a
+// runtime.Job?" and exempted everything it could not identify; three review rounds
+// walked past it with a spelling it did not know. Defaulting to REPORTED means a new
+// type, a rename or an alias names itself in a census failure and a maintainer
+// decides. Adding an entry here is a deliberate act with a diff; being invisible was
+// not.
+var planFieldAllowlist = map[string]string{
+	"JobPayload":             "workflow", // internal/workflow/mailbox.go — the persisted payload
+	"JobRequest":             "workflow", // internal/workflow/mailbox.go — the enqueue request
+	"RuntimeContractRequest": "runtime",  // internal/runtime/preflight.go — preflight scoping
 	// Surfaced BY the inversion, and exactly the decision it exists to force: both
 	// have a field literally named Plan that has nothing to do with plan mode.
 	// groomApplyResult.Plan is a plan-file PATH (string); DelegationTimeoutDefaults.Plan
-	// is a DURATION. The old name-plus-type matcher never saw either, because it only
-	// looked at runtime.Job; the new one sees every Plan field and asks. Listing them
-	// here is a deliberate act with a diff, which is the point.
-	"groomApplyResult":           true, // internal/cli/memory_groom.go — Plan is a file path
-	"DelegationTimeoutDefaults":  true, // internal/workflow — Plan is a timeout duration
+	// is a DURATION. The pre-inversion matcher never saw either.
+	"groomApplyResult":          "cli",      // internal/cli/memory_groom.go — Plan is a file path
+	"DelegationTimeoutDefaults": "workflow", // internal/workflow — Plan is a timeout duration
 }
 
 // planFieldTypeIsAllowlisted reports whether a composite literal's type is one of
@@ -254,18 +263,33 @@ var planFieldAllowlist = map[string]bool{
 func planFieldTypeIsAllowlisted(expr ast.Expr, pkgName string) bool {
 	switch typed := expr.(type) {
 	case *ast.SelectorExpr:
-		// pkg.Type{...} — judge on the type name; a qualified runtime.Job is
-		// deliberately absent from the allowlist and therefore reported.
-		return planFieldAllowlist[typed.Sel.Name]
+		// pkg.Type{...}. The QUALIFIER must be the package that owns the type — an
+		// import alias is compared by its local name, which is the strongest check a
+		// source-level census can make without full type resolution. A same-named
+		// type from any other package is reported, so a borrowed name cannot buy an
+		// exemption.
+		qualifier, ok := typed.X.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		owner, listed := planFieldAllowlist[typed.Sel.Name]
+		return listed && qualifier.Name == owner
 	case *ast.Ident:
-		return planFieldAllowlist[typed.Name]
-	case *ast.StarExpr:
-		return planFieldTypeIsAllowlisted(typed.X, pkgName)
-	case *ast.ParenExpr:
-		return planFieldTypeIsAllowlisted(typed.X, pkgName)
+		// Bare Type{...} — only exempt when the FILE's package is the owning one.
+		owner, listed := planFieldAllowlist[typed.Name]
+		return listed && pkgName == owner
+	// No *ast.StarExpr or *ast.ParenExpr case: Go has no syntax that puts either in
+	// CompositeLit.Type. '&runtime.Job{...}' parses the & OUTSIDE the literal, so the
+	// type is still a SelectorExpr, and element literals inside a slice or map carry
+	// ArrayType, MapType or a nil type. Both branches existed here and were dead:
+	// mutating them to return true changed no test, not because they were untested
+	// but because nothing can reach them. Verified with a parser probe over
+	// &runtime.Job{...}, []*runtime.Job{{...}} and map[string]*runtime.Job{...}.
+	// Dead code in a fail-closed predicate is worse than absent code — it invites
+	// the reader to believe a case is handled.
 	default:
-		// Unnamed, generic-instantiated, array/map element literals and anything
-		// else the walk cannot name: NOT allowlisted. Fail closed.
+		// Unnamed, generic-instantiated, array/map element literals and anything else
+		// the walk cannot name: NOT allowlisted. Fail closed.
 		return false
 	}
 }
@@ -290,6 +314,22 @@ func TestPlanFieldCensusFailsClosedOnUnknownTypes(t *testing.T) {
 		{"allowlisted request", "_ = JobRequest{PlanInto: \"x\"}", false},
 		{"allowlisted qualified", "_ = runtime.RuntimeContractRequest{Plan: true}", false},
 		{"no plan field at all", "_ = runtime.Job{Prompt: \"x\"}", false},
+		// SAME-NAME IMPOSTOR CONTROLS. Keying the allowlist on the bare type name was
+		// fail-open: a borrowed name from any other package bought an exemption, which
+		// recreated the type-alias bypass under five allowlisted names. The qualifier
+		// is now part of the identity, so each of these must be REPORTED.
+		{"impostor: foreign JobPayload", "_ = other.JobPayload{Plan: true}", true},
+		{"impostor: foreign JobRequest", "_ = shim.JobRequest{PlanInto: \"x\"}", true},
+		{"impostor: foreign RuntimeContractRequest", "_ = fake.RuntimeContractRequest{Plan: true}", true},
+		{"impostor: foreign groomApplyResult", "_ = other.groomApplyResult{Plan: true}", true},
+		{"impostor: bare allowlisted name in the WRONG package", "_ = RuntimeContractRequest{Plan: true}", true},
+		{"correct qualifier still exempt", "_ = workflow.JobPayload{Plan: true}", false},
+		// DEFAULT-BRANCH CONTROLS. A reviewer showed that making the default branch
+		// return true survived the earlier fixtures, because none of them reached it:
+		// every case named a type. These do, so the fail-closed default is now armed.
+		{"generic instantiation", "_ = Wrapper[runtime.Job]{Plan: true}", true},
+		{"map element literal", "_ = map[string]runtime.Job{\"k\": {Plan: true}}", true},
+		{"slice element literal", "_ = []runtime.Job{{PlanInto: \"x\"}}", true},
 	}
 	for _, tc := range cases {
 		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package workflow\nfunc f() {\n"+tc.src+"\n}\n", 0)

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -17,6 +17,27 @@ import (
 // code that may construct a runtime.Job carrying Plan or PlanInto, and the gate is
 // immediately above that literal. A new adapter entry path must deliberately join
 // this gate instead of silently creating a second door.
+// MEASURED LIMITS OF THIS CENSUS, stated because a guard that overclaims is worse
+// than one with a documented edge. Every item below was demonstrated by a reviewer
+// with REAL COMPILED CODE that this census left green, over four review rounds:
+//
+//   - ALIAS CHAINS. `Alias = runtime.Job` then `JobPayload = Alias` is not followed:
+//     planCarryingTarget classifies a target by its immediate spelling only. Same-file,
+//     cross-file and cross-package chains all pass.
+//   - UNKEYED CONSTRUCTION. hasPlanField reads KeyValueExpr elements, so a positional
+//     `runtime.Job{..., true, ...}` sets Plan invisibly, with or without an alias.
+//     Nested positional literals behave the same.
+//   - GENERIC EMBEDDING. A generic type embedding runtime.Job, aliased and constructed
+//     positionally, is missed: IndexExpr resolution examines only the base name.
+//   - STRUCT COPY and REFLECTION, accepted from the first round.
+//
+// THE COMMON CAUSE IS NOT A MISSING SPELLING. Following type identity across aliases,
+// packages and generic instantiations requires a repository declaration index or
+// go/types; this census is syntactic. Four rounds of adding one more spelling each
+// time produced one more bypass each time, which is the evidence for that claim
+// rather than an opinion about it. What this census DOES prove is narrow and real:
+// no KEYED plan-field literal, no post-construction plan-field assignment, and no
+// allowlisted-name alias declaration exists outside the single sanctioned producer.
 func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 	t.Parallel()
 	root := filepath.Clean(filepath.Join("..", ".."))
@@ -77,7 +98,7 @@ func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 		}
 		for _, spec := range general.Specs {
 			typed, ok := spec.(*ast.TypeSpec)
-			if ok && declaresAllowlistedName(typed, pkgPath, false) {
+			if ok && declaresAllowlistedName(typed, pkgPath, false, imports) {
 				got = append(got, filepath.ToSlash(rel)+"::type "+typed.Name.Name)
 			}
 		}
@@ -123,7 +144,7 @@ func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 				// runtime.Job. Declaring an allowlisted name anywhere inside a body is
 				// therefore reported: the allowlist grants exemption to five specific
 				// types, not to their spellings.
-				if declaresAllowlistedName(n, pkgPath, true) {
+				if declaresAllowlistedName(n, pkgPath, true, imports) {
 					got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
 				}
 			}
@@ -346,7 +367,7 @@ func planFieldImportPaths(parsed *ast.File) map[string]string {
 // bare literal under that name passes the owning-package test while producing a
 // genuine runtime.Job. The exemption belongs to five specific types, not to their
 // spellings, so any body-scoped declaration of one of those names is reported.
-func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string, bodyScoped bool) bool {
+func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string, bodyScoped bool, imports map[string]string) bool {
 	if spec == nil || spec.Name == nil {
 		return false
 	}
@@ -371,7 +392,16 @@ func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string, bodyScoped bool
 	// to and is reported wherever it appears; a fresh `type JobRequest struct{ Value
 	// string }` defines something unrelated that merely reuses a name, carries no plan
 	// field, and is the innocent case a second reviewer found over-reported.
-	return spec.Assign.IsValid() && planCarryingTarget(spec.Type)
+	return spec.Assign.IsValid() && planCarryingTarget(spec.Type, imports)
+}
+
+// identName returns the identifier spelling of a qualifier, or "" when it is not a
+// plain identifier — the only shape a package qualifier can legally take.
+func identName(expr ast.Expr) string {
+	if ident, ok := expr.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
 }
 
 // planCarryingTarget reports whether an alias target is a type that can carry plan
@@ -379,27 +409,36 @@ func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string, bodyScoped bool
 // unrestricted alias rule reporting `type JobPayload = string` in internal/cli as a
 // plan producer: an alias to something that has no plan field borrows a NAME but not
 // an identity, and reporting it fails innocent code for a spelling.
-func planCarryingTarget(expr ast.Expr) bool {
+func planCarryingTarget(expr ast.Expr, imports map[string]string) bool {
 	switch typed := expr.(type) {
 	case *ast.StarExpr:
-		return planCarryingTarget(typed.X)
-	case *ast.IndexExpr: // generic instantiation, e.g. Wrapper[runtime.Job]
-		return planCarryingTarget(typed.X)
+		return planCarryingTarget(typed.X, imports)
+	case *ast.IndexExpr:
+		// A generic instantiation resolves to the type being instantiated. NOTE the
+		// measured limit: a generic type EMBEDDING runtime.Job is not reached, because
+		// only the base name is examined.
+		return planCarryingTarget(typed.X, imports)
 	case *ast.SelectorExpr:
-		if _, listed := planFieldAllowlist[typed.Sel.Name]; listed {
+		// Package identity, not the spelling. Classifying every selector ending in Job
+		// as plan-carrying reported a compiled `type JobPayload = db.Job`, which cannot
+		// carry a runtime plan field — measured, so "conservative" was really noisy.
+		path := imports[identName(typed.X)]
+		if owner, listed := planFieldAllowlist[typed.Sel.Name]; listed && path == owner {
 			return true
 		}
-		return typed.Sel.Name == "Job"
+		return typed.Sel.Name == "Job" && path == "github.com/gitmoot/gitmoot/internal/runtime"
 	case *ast.Ident:
 		if _, listed := planFieldAllowlist[typed.Name]; listed {
 			return true
 		}
 		return typed.Name == "Job"
 	default:
-		// Cannot name the target: fail CLOSED for an allowlisted NAME, because that is
-		// the borrowed-identity case, and an unnameable target is exactly where a
-		// producer would hide.
-		return true
+		// An unnameable target — an anonymous struct, a func type, a channel — is not
+		// runtime.Job and cannot carry its plan fields. Defaulting to true here reported
+		// a compiled `type JobPayload = struct{ Value string }`, so the "fail-closed"
+		// claim was observably noise rather than caution. The genuine fail-closed
+		// default lives in planFieldTypeIsAllowlisted, on the LITERAL's type.
+		return false
 	}
 }
 
@@ -590,7 +629,7 @@ func TestDeclaresAllowlistedNameArmsTheShadowBranch(t *testing.T) {
 		}
 		var got bool
 		ast.Inspect(file, func(n ast.Node) bool {
-			if spec, ok := n.(*ast.TypeSpec); ok && declaresAllowlistedName(spec, planFieldPackagePath(tc.pkg), true) {
+			if spec, ok := n.(*ast.TypeSpec); ok && declaresAllowlistedName(spec, planFieldPackagePath(tc.pkg), true, map[string]string{"runtime": "github.com/gitmoot/gitmoot/internal/runtime"}) {
 				got = true
 			}
 			return true
@@ -692,17 +731,6 @@ func TestPlanFieldCensusWiresEveryArm(t *testing.T) {
 			rel:  "internal/runtime/x.go",
 			src:  "type JobPayload = Job\nfunc f() { _ = 0 }",
 			want: []string{"internal/runtime/x.go::type JobPayload"},
-		},
-		{
-			// Generic INSTANTIATION as the alias target: the target is an IndexExpr and
-			// unwraps to the type being instantiated. My first version of this fixture
-			// expected Wrapper[runtime.Job] to be reported and it was WRONG — that alias
-			// targets Wrapper, which carries no plan field. The instantiated type is what
-			// decides, so a generic Job does report and a wrapper around one does not.
-			name: "alias to a generic PLAN type is reported",
-			rel:  "internal/cli/x.go",
-			src:  "type JobPayload = runtime.Job[string]\nfunc f() { _ = 0 }",
-			want: []string{"internal/cli/x.go::type JobPayload"},
 		},
 		{
 			name: "alias to a generic WRAPPER around a plan type is not reported",

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -44,8 +43,6 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		runtimeAliases, dotRuntime := runtimeImportAliases(parsed)
-		inRuntimePackage := parsed.Name.Name == "runtime" && strings.HasPrefix(filepath.ToSlash(rel), "internal/runtime/")
 		for _, declaration := range parsed.Decls {
 			function, ok := declaration.(*ast.FuncDecl)
 			if !ok || function.Body == nil {
@@ -54,8 +51,21 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 			ast.Inspect(function.Body, func(node ast.Node) bool {
 				switch n := node.(type) {
 				case *ast.CompositeLit:
-					// runtime.Job{..., Plan: true, ...}
-					if isRuntimeJobType(n.Type, runtimeAliases, dotRuntime, inRuntimePackage) && hasPlanField(n) {
+					// FAIL-CLOSED. This used to ask "is the literal's type runtime.Job?"
+					// and return false when it could not tell — so every type spelling
+					// the matcher did not recognise was silently exempt. Three review
+					// rounds walked past it that way, most recently with
+					// `type X = runtime.Job` (a plain refactor idiom, not an exotic act):
+					// the matcher compares the type NAME syntactically, so an alias under
+					// any other name was invisible and hasPlanField was never consulted.
+					//
+					// The question is inverted: ANY composite literal that sets Plan or
+					// PlanInto is reported unless its type is on an explicit allowlist of
+					// types that legitimately carry those fields. A new type, a rename, or
+					// an alias now defaults to REPORTED. That is noisier and it is the
+					// safe direction: the failure mode becomes "the census names something
+					// you must add to the allowlist", not "the census went quiet".
+					if hasPlanField(n) && !planFieldTypeIsAllowlisted(n.Type, parsed.Name.Name) {
 						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
 					}
 				case *ast.AssignStmt:
@@ -90,38 +100,7 @@ func shouldSkipPlanProducerDir(rel string) bool {
 	return base == ".git" || base == ".gitmoot" || base == "node_modules" || base == "build" || base == "dist" || base == "repos" || base == "GOALS"
 }
 
-func runtimeImportAliases(file *ast.File) (map[string]bool, bool) {
-	aliases := map[string]bool{}
-	dot := false
-	for _, imported := range file.Imports {
-		path, err := strconv.Unquote(imported.Path.Value)
-		if err != nil || path != "github.com/gitmoot/gitmoot/internal/runtime" {
-			continue
-		}
-		name := "runtime"
-		if imported.Name != nil {
-			name = imported.Name.Name
-		}
-		if name == "." {
-			dot = true
-		} else if name != "_" {
-			aliases[name] = true
-		}
-	}
-	return aliases, dot
-}
 
-func isRuntimeJobType(expr ast.Expr, aliases map[string]bool, dotRuntime, inRuntimePackage bool) bool {
-	switch typed := expr.(type) {
-	case *ast.SelectorExpr:
-		alias, ok := typed.X.(*ast.Ident)
-		return ok && aliases[alias.Name] && typed.Sel.Name == "Job"
-	case *ast.Ident:
-		return typed.Name == "Job" && (dotRuntime || inRuntimePackage)
-	default:
-		return false
-	}
-}
 
 func hasPlanField(literal *ast.CompositeLit) bool {
 	for _, element := range literal.Elts {
@@ -239,6 +218,94 @@ func TestAssignsPlanFieldArmsTheCensus(t *testing.T) {
 		})
 		if got != tc.want {
 			t.Fatalf("assignsPlanField(%q) = %v, want %v", tc.src, got, tc.want)
+		}
+	}
+}
+
+// planFieldAllowlist names the types that legitimately carry Plan/PlanInto and are
+// NOT a delivered runtime.Job: the payload and request shapes the mailbox itself
+// owns, plus the runtime's own request struct. Everything else that sets those
+// fields is reported by the census.
+//
+// This is an ALLOWLIST on purpose. The previous design asked "is this a
+// runtime.Job?" and exempted everything it could not identify, which is fail-open:
+// three review rounds bypassed it with a spelling it did not know, most recently a
+// type alias. Inverting the default means a new type, a rename or an alias shows up
+// as a census failure naming itself — a maintainer then decides whether it belongs
+// here. Adding a name to this list is a deliberate act with a diff; being invisible
+// to the census was not.
+var planFieldAllowlist = map[string]bool{
+	"JobPayload":             true, // internal/workflow/mailbox.go — the persisted payload
+	"JobRequest":             true, // internal/workflow/mailbox.go — the enqueue request
+	"RuntimeContractRequest": true, // internal/runtime/preflight.go — preflight scoping
+	// Surfaced BY the inversion, and exactly the decision it exists to force: both
+	// have a field literally named Plan that has nothing to do with plan mode.
+	// groomApplyResult.Plan is a plan-file PATH (string); DelegationTimeoutDefaults.Plan
+	// is a DURATION. The old name-plus-type matcher never saw either, because it only
+	// looked at runtime.Job; the new one sees every Plan field and asks. Listing them
+	// here is a deliberate act with a diff, which is the point.
+	"groomApplyResult":           true, // internal/cli/memory_groom.go — Plan is a file path
+	"DelegationTimeoutDefaults":  true, // internal/workflow — Plan is a timeout duration
+}
+
+// planFieldTypeIsAllowlisted reports whether a composite literal's type is one of
+// the shapes allowed to carry plan fields without being a census producer. An
+// unrecognised or unnamed type is NOT allowlisted, so it is reported.
+func planFieldTypeIsAllowlisted(expr ast.Expr, pkgName string) bool {
+	switch typed := expr.(type) {
+	case *ast.SelectorExpr:
+		// pkg.Type{...} — judge on the type name; a qualified runtime.Job is
+		// deliberately absent from the allowlist and therefore reported.
+		return planFieldAllowlist[typed.Sel.Name]
+	case *ast.Ident:
+		return planFieldAllowlist[typed.Name]
+	case *ast.StarExpr:
+		return planFieldTypeIsAllowlisted(typed.X, pkgName)
+	case *ast.ParenExpr:
+		return planFieldTypeIsAllowlisted(typed.X, pkgName)
+	default:
+		// Unnamed, generic-instantiated, array/map element literals and anything
+		// else the walk cannot name: NOT allowlisted. Fail closed.
+		return false
+	}
+}
+
+// TestPlanFieldCensusFailsClosedOnUnknownTypes proves the inversion. Each fixture is
+// parsed from source and run through the same predicates the census uses, so a
+// spelling that bypasses the census must also bypass this test — which is the
+// property the three earlier bypasses all lacked.
+func TestPlanFieldCensusFailsClosedOnUnknownTypes(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want bool // want == reported by the census
+	}{
+		{"qualified runtime.Job", "_ = runtime.Job{Plan: true}", true},
+		{"TYPE ALIAS — the round-5 bypass", "_ = censusJobAlias{Plan: true, PlanInto: \"@smol\"}", true},
+		{"alias of an alias", "_ = deeperAlias{PlanInto: \"x\"}", true},
+		{"bare Ident under dot-import", "_ = Job{Plan: true}", true},
+		{"pointer literal", "_ = &runtime.Job{Plan: true}", true},
+		{"unknown local type", "_ = someShim{Plan: true}", true},
+		{"allowlisted payload", "_ = JobPayload{Plan: true}", false},
+		{"allowlisted request", "_ = JobRequest{PlanInto: \"x\"}", false},
+		{"allowlisted qualified", "_ = runtime.RuntimeContractRequest{Plan: true}", false},
+		{"no plan field at all", "_ = runtime.Job{Prompt: \"x\"}", false},
+	}
+	for _, tc := range cases {
+		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package workflow\nfunc f() {\n"+tc.src+"\n}\n", 0)
+		if err != nil {
+			t.Fatalf("%s: parse: %v", tc.name, err)
+		}
+		var reported bool
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if ok && hasPlanField(lit) && !planFieldTypeIsAllowlisted(lit.Type, "workflow") {
+				reported = true
+			}
+			return true
+		})
+		if reported != tc.want {
+			t.Fatalf("%s: reported=%v, want %v (src: %s)", tc.name, reported, tc.want, tc.src)
 		}
 	}
 }

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -19,13 +19,22 @@ import (
 // pointed out it claimed them three lines above the list of constructions the census
 // is known to miss, which is the overclaim this file exists to not commit.
 //
+// SCOPE OF THE WALK: every package-scope declaration and every function body,
+// including function literals held in package-level vars. An earlier version read
+// only FuncDecl bodies, so a reviewer's `var _ = runtime.Job{Plan: true}` and a
+// package-level func literal assigning job.PlanInto both compiled green while the
+// header claimed no such construction existed.
+//
 // WHAT IT ACTUALLY PROVES, with every exemption named:
 //
 //   - No composite literal setting Plan or PlanInto BY KEY exists outside
 //     Mailbox.deliver, EXCEPT literals whose type is on planFieldAllowlist and
 //     resolves to its owning package (five shapes that legitimately carry such a
 //     field, listed there with reasons).
-//   - No assignment to a .Plan or .PlanInto selector exists outside Mailbox.deliver.
+//   - No assignment to a .Plan or .PlanInto selector exists outside Mailbox.deliver,
+//     EXCEPT symbols in planAssignExemptions. This arm matches a selector NAME and has
+//     no type information, so it cannot tell whose Plan field it sees; each exemption
+//     is named there with a reason.
 //   - No declaration BORROWING an allowlisted type name exists outside its owner,
 //     EXCEPT a non-alias definition of an unrelated type, and EXCEPT an alias whose
 //     target planCarryingTarget cannot see as plan-carrying. Both exceptions are
@@ -96,6 +105,19 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 // census while the helper's own unit test stayed green — a test of a helper proves
 // the helper, not that anything CALLS it. TestPlanFieldCensusWiresEveryArm pins the
 // wiring, so deleting an arm now fails a test instead of going quiet.
+// planAssignExemptions names symbols whose `.Plan` / `.PlanInto` assignment is not a
+// runtime.Job write. The assignment arm matches a SELECTOR NAME and has no type
+// information, so unlike the composite-literal arm it cannot tell whose Plan field it
+// is looking at. Widening the walk to package-scope initializers surfaced this one
+// immediately, which is the arm's limit doing its job: an exemption here is a
+// maintainer decision with a diff and a reason, never a silent skip.
+var planAssignExemptions = map[string]string{
+	// deps.Plan is a *tui.TrainRunPlan for the SkillOpt confirm screen — a UI plan
+	// object, unrelated to runtime plan mode. Lives inside a package-level var holding
+	// a func literal, which is why the body-only walk never saw it.
+	"internal/cli/skillopt_trainrun_tui.go::var runSkillOptTrainRunConfirmTUI": "tui.TrainRunPlan, not runtime plan mode",
+}
+
 func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 	var got []string
 	pkgPath := planFieldPackagePath(rel)
@@ -116,21 +138,22 @@ func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 			}
 		}
 	}
-	for _, declaration := range parsed.Decls {
-		function, ok := declaration.(*ast.FuncDecl)
-		if !ok || function.Body == nil {
-			continue
-		}
-		ast.Inspect(function.Body, func(node ast.Node) bool {
+	// One inspector, driven over EVERY declaration's expressions rather than only
+	// function bodies. A reviewer compiled three package-scope probes that the
+	// body-only walk left green: `var _ = runtime.Job{Plan: true}`, a package-level
+	// function literal assigning job.PlanInto, and one declaring
+	// `type JobPayload = runtime.Job`. None were among the documented limits, so the
+	// header's three guarantees were false as written — a walker that reads only
+	// bodies cannot claim "no ... exists".
+	inspect := func(node ast.Node, symbol string) {
+		ast.Inspect(node, func(node ast.Node) bool {
 			switch n := node.(type) {
 			case *ast.CompositeLit:
 				// FAIL-CLOSED. This used to ask "is the literal's type runtime.Job?"
 				// and return false when it could not tell — so every type spelling
 				// the matcher did not recognise was silently exempt. Three review
 				// rounds walked past it that way, most recently with
-				// `type X = runtime.Job` (a plain refactor idiom, not an exotic act):
-				// the matcher compares the type NAME syntactically, so an alias under
-				// any other name was invisible and hasPlanField was never consulted.
+				// `type X = runtime.Job` (a plain refactor idiom, not an exotic act).
 				//
 				// The question is inverted: ANY composite literal that sets Plan or
 				// PlanInto is reported unless its type is on an explicit allowlist of
@@ -139,7 +162,7 @@ func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 				// safe direction: the failure mode becomes "the census names something
 				// you must add to the allowlist", not "the census went quiet".
 				if hasPlanField(n) && !planFieldTypeIsAllowlisted(n.Type, pkgPath, imports) {
-					got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+					got = append(got, filepath.ToSlash(rel)+"::"+symbol)
 				}
 			case *ast.AssignStmt:
 				// job.Plan = true — the composite-literal scan alone missed this, and
@@ -147,22 +170,50 @@ func planFieldProducersInFile(rel string, parsed *ast.File) []string {
 				// delivered it straight past the mailbox gate while this test still
 				// passed. A seam guard that recognises only one syntax for writing a
 				// field is not a seam guard.
-				if assignsPlanField(n) {
-					got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+				if entry := filepath.ToSlash(rel) + "::" + symbol; assignsPlanField(n) {
+					if _, exempt := planAssignExemptions[entry]; !exempt {
+						got = append(got, entry)
+					}
 				}
 			case *ast.TypeSpec:
-				// A function-local `type JobPayload = runtime.Job` SHADOWS the real
-				// type, so a bare literal under that name satisfies the owning-package
-				// test above and would be exempt while producing a genuine
-				// runtime.Job. Declaring an allowlisted name anywhere inside a body is
-				// therefore reported: the allowlist grants exemption to five specific
-				// types, not to their spellings.
+				// A body-scoped `type JobPayload = runtime.Job` SHADOWS the real type,
+				// so a bare literal under that name satisfies the owning-package test
+				// and would be exempt while producing a genuine runtime.Job.
 				if declaresAllowlistedName(n, pkgPath, true, imports) {
-					got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+					got = append(got, filepath.ToSlash(rel)+"::"+symbol)
 				}
 			}
 			return true
 		})
+	}
+	for _, declaration := range parsed.Decls {
+		switch decl := declaration.(type) {
+		case *ast.FuncDecl:
+			if decl.Body != nil {
+				inspect(decl.Body, functionSymbol(decl))
+			}
+		case *ast.GenDecl:
+			// var/const initializers at package scope, including any function literal
+			// inside them. TYPE specs are handled by the pass above, which uses the
+			// package-scope rule; re-inspecting them here would apply the body rule and
+			// report the five canonical declarations.
+			if decl.Tok == token.TYPE {
+				continue
+			}
+			for _, spec := range decl.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				name := "package-scope"
+				if len(value.Names) > 0 {
+					name = "var " + value.Names[0].Name
+				}
+				for _, expression := range value.Values {
+					inspect(expression, name)
+				}
+			}
+		}
 	}
 	return got
 }

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -43,6 +44,8 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		pkgPath := planFieldPackagePath(rel)
+		imports := planFieldImportPaths(parsed)
 		for _, declaration := range parsed.Decls {
 			function, ok := declaration.(*ast.FuncDecl)
 			if !ok || function.Body == nil {
@@ -65,7 +68,7 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 					// an alias now defaults to REPORTED. That is noisier and it is the
 					// safe direction: the failure mode becomes "the census names something
 					// you must add to the allowlist", not "the census went quiet".
-					if hasPlanField(n) && !planFieldTypeIsAllowlisted(n.Type, parsed.Name.Name) {
+					if hasPlanField(n) && !planFieldTypeIsAllowlisted(n.Type, pkgPath, imports) {
 						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
 					}
 				case *ast.AssignStmt:
@@ -75,6 +78,16 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 					// passed. A seam guard that recognises only one syntax for writing a
 					// field is not a seam guard.
 					if assignsPlanField(n) {
+						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+					}
+				case *ast.TypeSpec:
+					// A function-local `type JobPayload = runtime.Job` SHADOWS the real
+					// type, so a bare literal under that name satisfies the owning-package
+					// test above and would be exempt while producing a genuine
+					// runtime.Job. Declaring an allowlisted name anywhere inside a body is
+					// therefore reported: the allowlist grants exemption to five specific
+					// types, not to their spellings.
+					if declaresAllowlistedName(n) {
 						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
 					}
 				}
@@ -232,52 +245,110 @@ func TestAssignsPlanFieldArmsTheCensus(t *testing.T) {
 // as a census failure naming itself — a maintainer then decides whether it belongs
 // here. Adding a name to this list is a deliberate act with a diff; being invisible
 // to the census was not.
-// planFieldAllowlist maps a type to the PACKAGE that owns it. Keying on the bare
-// type name was itself fail-open: a reviewer showed that `other.JobPayload{Plan:true}`
-// was exempted, and `type JobPayload = runtime.Job` in any other package would be
-// too — recreating the very type-alias bypass this inversion was written to close,
-// now under five borrowed names. The qualifier is part of the identity, so it is part
-// of the key.
+// planFieldAllowlist maps a type to the IMPORT PATH of the package that owns it.
+// Keying on the bare type name was fail-open (`other.JobPayload{Plan:true}` was
+// exempt); keying on the qualifier's LOCAL name was still fail-open, because an
+// import alias is an arbitrary local name a producer chooses for itself:
 //
-// This is an ALLOWLIST on purpose. The design before the inversion asked "is this a
-// runtime.Job?" and exempted everything it could not identify; three review rounds
-// walked past it with a spelling it did not know. Defaulting to REPORTED means a new
-// type, a rename or an alias names itself in a census failure and a maintainer
-// decides. Adding an entry here is a deliberate act with a diff; being invisible was
-// not.
+//	import workflow "github.com/gitmoot/gitmoot/internal/censusshim" // type JobPayload = runtime.Job
+//	_ = workflow.JobPayload{Plan: true}                              // exempt, and a real producer
+//
+// A reviewer built exactly that as compiled code in the tree and the census stayed
+// green. The remedy needs no type resolution: parsed.Imports already maps every
+// qualifier to its import PATH, so identity is available for the asking. A
+// qualifier that cannot be resolved to a path is NOT allowlisted, so an unusual
+// import form costs a census failure rather than an exemption.
 var planFieldAllowlist = map[string]string{
-	"JobPayload":             "workflow", // internal/workflow/mailbox.go — the persisted payload
-	"JobRequest":             "workflow", // internal/workflow/mailbox.go — the enqueue request
-	"RuntimeContractRequest": "runtime",  // internal/runtime/preflight.go — preflight scoping
+	"JobPayload":             "github.com/gitmoot/gitmoot/internal/workflow", // mailbox.go — the persisted payload
+	"JobRequest":             "github.com/gitmoot/gitmoot/internal/workflow", // mailbox.go — the enqueue request
+	"RuntimeContractRequest": "github.com/gitmoot/gitmoot/internal/runtime",  // preflight.go — preflight scoping
 	// Surfaced BY the inversion, and exactly the decision it exists to force: both
 	// have a field literally named Plan that has nothing to do with plan mode.
 	// groomApplyResult.Plan is a plan-file PATH (string); DelegationTimeoutDefaults.Plan
 	// is a DURATION. The pre-inversion matcher never saw either.
-	"groomApplyResult":          "cli",      // internal/cli/memory_groom.go — Plan is a file path
-	"DelegationTimeoutDefaults": "workflow", // internal/workflow — Plan is a timeout duration
+	"groomApplyResult":          "github.com/gitmoot/gitmoot/internal/cli",      // memory_groom.go — Plan is a file path
+	"DelegationTimeoutDefaults": "github.com/gitmoot/gitmoot/internal/workflow", // Plan is a timeout duration
+}
+
+// planFieldModulePath is this module's path, so a file's own package identity can be
+// derived from its position in the tree without loading type information.
+const planFieldModulePath = "github.com/gitmoot/gitmoot"
+
+// planFieldPackagePath returns the import path of the package containing a file at
+// repo-relative path rel.
+func planFieldPackagePath(rel string) string {
+	dir := filepath.ToSlash(filepath.Dir(rel))
+	if dir == "." {
+		return planFieldModulePath
+	}
+	return planFieldModulePath + "/" + dir
+}
+
+// planFieldImportPaths maps each qualifier a file can write to the import path it
+// resolves to. A dot-import has no qualifier and is deliberately absent, so a bare
+// name arriving that way is checked against the file's OWN package and reported. A
+// named import uses its alias; otherwise the path's last element is the qualifier,
+// which is wrong only when a package name differs from its directory — and that
+// case fails CLOSED, because the qualifier then resolves to nothing.
+func planFieldImportPaths(parsed *ast.File) map[string]string {
+	paths := make(map[string]string, len(parsed.Imports))
+	for _, spec := range parsed.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		name := ""
+		if spec.Name != nil {
+			name = spec.Name.Name
+		} else if index := strings.LastIndex(path, "/"); index >= 0 {
+			name = path[index+1:]
+		} else {
+			name = path
+		}
+		// No skip for "." or "_": neither is a legal selector qualifier, so a dot- or
+		// blank-import entry can never be looked up. A guard for it was untestable by
+		// construction — the same dead-branch shape as the deleted StarExpr case.
+		paths[name] = path
+	}
+	return paths
+}
+
+// declaresAllowlistedName reports whether a type declaration borrows an allowlisted
+// name. A function-local `type JobPayload = runtime.Job` shadows the real type, so a
+// bare literal under that name passes the owning-package test while producing a
+// genuine runtime.Job. The exemption belongs to five specific types, not to their
+// spellings, so any body-scoped declaration of one of those names is reported.
+func declaresAllowlistedName(spec *ast.TypeSpec) bool {
+	if spec == nil || spec.Name == nil {
+		return false
+	}
+	_, listed := planFieldAllowlist[spec.Name.Name]
+	return listed
 }
 
 // planFieldTypeIsAllowlisted reports whether a composite literal's type is one of
 // the shapes allowed to carry plan fields without being a census producer. An
-// unrecognised or unnamed type is NOT allowlisted, so it is reported.
-func planFieldTypeIsAllowlisted(expr ast.Expr, pkgName string) bool {
+// unrecognised or unnamed type is NOT allowlisted, so it is reported. pkgPath is the
+// import path of the file's own package and imports maps its qualifiers to paths.
+func planFieldTypeIsAllowlisted(expr ast.Expr, pkgPath string, imports map[string]string) bool {
 	switch typed := expr.(type) {
 	case *ast.SelectorExpr:
-		// pkg.Type{...}. The QUALIFIER must be the package that owns the type — an
-		// import alias is compared by its local name, which is the strongest check a
-		// source-level census can make without full type resolution. A same-named
-		// type from any other package is reported, so a borrowed name cannot buy an
-		// exemption.
+		// pkg.Type{...}. The qualifier is a LOCAL name the producer chooses, so it is
+		// resolved through the file's imports to a package PATH before comparison. An
+		// alias that borrows the owner's name (`import workflow ".../censusshim"`)
+		// therefore buys nothing, and a qualifier absent from the import table — a
+		// package whose name differs from its directory, say — resolves to "" and is
+		// reported rather than assumed.
 		qualifier, ok := typed.X.(*ast.Ident)
 		if !ok {
 			return false
 		}
 		owner, listed := planFieldAllowlist[typed.Sel.Name]
-		return listed && qualifier.Name == owner
+		return listed && imports[qualifier.Name] == owner
 	case *ast.Ident:
-		// Bare Type{...} — only exempt when the FILE's package is the owning one.
+		// Bare Type{...} — only exempt when the FILE's own package owns the name.
 		owner, listed := planFieldAllowlist[typed.Name]
-		return listed && pkgName == owner
+		return listed && pkgPath == owner
 	// No *ast.StarExpr or *ast.ParenExpr case: Go has no syntax that puts either in
 	// CompositeLit.Type. '&runtime.Job{...}' parses the & OUTSIDE the literal, so the
 	// type is still a SelectorExpr, and element literals inside a slice or map carry
@@ -299,53 +370,130 @@ func planFieldTypeIsAllowlisted(expr ast.Expr, pkgName string) bool {
 // spelling that bypasses the census must also bypass this test — which is the
 // property the three earlier bypasses all lacked.
 func TestPlanFieldCensusFailsClosedOnUnknownTypes(t *testing.T) {
+	const defaultImports = "import (\n\t\"github.com/gitmoot/gitmoot/internal/runtime\"\n\tworkflow \"github.com/gitmoot/gitmoot/internal/workflow\"\n)\n"
 	cases := []struct {
-		name string
-		src  string
-		want bool // want == reported by the census
+		name    string
+		imports string // when empty, defaultImports; a case owns its import block so the
+		pkg     string // qualifier resolution under test is the file's own, not a fixed map;
+		src     string // pkg is the file's repo-relative path, defaulting to the owning one
+		want    bool   // want == reported by the census
 	}{
-		{"qualified runtime.Job", "_ = runtime.Job{Plan: true}", true},
-		{"TYPE ALIAS — the round-5 bypass", "_ = censusJobAlias{Plan: true, PlanInto: \"@smol\"}", true},
-		{"alias of an alias", "_ = deeperAlias{PlanInto: \"x\"}", true},
-		{"bare Ident under dot-import", "_ = Job{Plan: true}", true},
-		{"pointer literal", "_ = &runtime.Job{Plan: true}", true},
-		{"unknown local type", "_ = someShim{Plan: true}", true},
-		{"allowlisted payload", "_ = JobPayload{Plan: true}", false},
-		{"allowlisted request", "_ = JobRequest{PlanInto: \"x\"}", false},
-		{"allowlisted qualified", "_ = runtime.RuntimeContractRequest{Plan: true}", false},
-		{"no plan field at all", "_ = runtime.Job{Prompt: \"x\"}", false},
+		{"qualified runtime.Job", "", "", "_ = runtime.Job{Plan: true}", true},
+		{"TYPE ALIAS — the round-5 bypass", "", "", "_ = censusJobAlias{Plan: true, PlanInto: \"@smol\"}", true},
+		{"alias of an alias", "", "", "_ = deeperAlias{PlanInto: \"x\"}", true},
+		{"bare Ident under dot-import", "", "", "_ = Job{Plan: true}", true},
+		{"pointer literal", "", "", "_ = &runtime.Job{Plan: true}", true},
+		{"unknown local type", "", "", "_ = someShim{Plan: true}", true},
+		{"allowlisted payload", "", "", "_ = JobPayload{Plan: true}", false},
+		{"allowlisted request", "", "", "_ = JobRequest{PlanInto: \"x\"}", false},
+		{"allowlisted qualified", "", "", "_ = runtime.RuntimeContractRequest{Plan: true}", false},
+		{"no plan field at all", "", "", "_ = runtime.Job{Prompt: \"x\"}", false},
 		// SAME-NAME IMPOSTOR CONTROLS. Keying the allowlist on the bare type name was
 		// fail-open: a borrowed name from any other package bought an exemption, which
 		// recreated the type-alias bypass under five allowlisted names. The qualifier
 		// is now part of the identity, so each of these must be REPORTED.
-		{"impostor: foreign JobPayload", "_ = other.JobPayload{Plan: true}", true},
-		{"impostor: foreign JobRequest", "_ = shim.JobRequest{PlanInto: \"x\"}", true},
-		{"impostor: foreign RuntimeContractRequest", "_ = fake.RuntimeContractRequest{Plan: true}", true},
-		{"impostor: foreign groomApplyResult", "_ = other.groomApplyResult{Plan: true}", true},
-		{"impostor: bare allowlisted name in the WRONG package", "_ = RuntimeContractRequest{Plan: true}", true},
-		{"correct qualifier still exempt", "_ = workflow.JobPayload{Plan: true}", false},
+		{"impostor: foreign JobPayload", "", "", "_ = other.JobPayload{Plan: true}", true},
+		{"impostor: foreign JobRequest", "", "", "_ = shim.JobRequest{PlanInto: \"x\"}", true},
+		{"impostor: foreign RuntimeContractRequest", "", "", "_ = fake.RuntimeContractRequest{Plan: true}", true},
+		{"impostor: foreign groomApplyResult", "", "", "_ = other.groomApplyResult{Plan: true}", true},
+		{"impostor: bare allowlisted name in the WRONG package", "", "", "_ = RuntimeContractRequest{Plan: true}", true},
+		{"correct qualifier still exempt", "", "", "_ = workflow.JobPayload{Plan: true}", false},
 		// DEFAULT-BRANCH CONTROLS. A reviewer showed that making the default branch
 		// return true survived the earlier fixtures, because none of them reached it:
 		// every case named a type. These do, so the fail-closed default is now armed.
-		{"generic instantiation", "_ = Wrapper[runtime.Job]{Plan: true}", true},
-		{"map element literal", "_ = map[string]runtime.Job{\"k\": {Plan: true}}", true},
-		{"slice element literal", "_ = []runtime.Job{{PlanInto: \"x\"}}", true},
+		{"generic instantiation", "", "", "_ = Wrapper[runtime.Job]{Plan: true}", true},
+		{"map element literal", "", "", "_ = map[string]runtime.Job{\"k\": {Plan: true}}", true},
+		{"slice element literal", "", "", "_ = []runtime.Job{{PlanInto: \"x\"}}", true},
+		// IMPORT-ALIAS IDENTITY. Comparing the qualifier's LOCAL name was still
+		// fail-open: the alias is chosen by the producer, so borrowing the owner's name
+		// bought the exemption back. A reviewer proved it with compiled code in the
+		// tree. Identity is the import PATH, and these three fix the meaning of that.
+		{
+			name:    "alias BORROWING the owner's name is reported",
+			imports: "import workflow \"github.com/gitmoot/gitmoot/internal/censusshim\"\n",
+			pkg:     "",
+			src:     "_ = workflow.JobPayload{Plan: true}",
+			want:    true,
+		},
+		{
+			name:    "legitimate differing alias for the real owner stays exempt",
+			imports: "import wf \"github.com/gitmoot/gitmoot/internal/workflow\"\n",
+			pkg:     "",
+			src:     "_ = wf.JobPayload{Plan: true}",
+			want:    false,
+		},
+		{
+			name:    "dot-import into a NON-owning package is reported",
+			imports: "import . \"github.com/gitmoot/gitmoot/internal/workflow\"\n",
+			pkg:     "internal/cli/x.go",
+			src:     "_ = JobPayload{Plan: true}",
+			want:    true,
+		},
+		{
+			name:    "qualifier absent from the import table is reported",
+			imports: "import \"github.com/gitmoot/gitmoot/internal/runtime\"\n",
+			pkg:     "",
+			src:     "_ = workflow.JobPayload{Plan: true}",
+			want:    true,
+		},
 	}
 	for _, tc := range cases {
-		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package workflow\nfunc f() {\n"+tc.src+"\n}\n", 0)
+		imports := tc.imports
+		if imports == "" {
+			imports = defaultImports
+		}
+		pkg := tc.pkg
+		if pkg == "" {
+			pkg = "internal/workflow/x.go"
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package workflow\n"+imports+"func f() {\n"+tc.src+"\n}\n", 0)
 		if err != nil {
 			t.Fatalf("%s: parse: %v", tc.name, err)
 		}
+		// The predicate runs against the fixture's OWN resolved imports, so a fixture
+		// cannot pass by borrowing a map the production walk would never build.
+		resolved := planFieldImportPaths(file)
 		var reported bool
 		ast.Inspect(file, func(n ast.Node) bool {
 			lit, ok := n.(*ast.CompositeLit)
-			if ok && hasPlanField(lit) && !planFieldTypeIsAllowlisted(lit.Type, "workflow") {
+			if ok && hasPlanField(lit) && !planFieldTypeIsAllowlisted(lit.Type, planFieldPackagePath(pkg), resolved) {
 				reported = true
 			}
 			return true
 		})
 		if reported != tc.want {
 			t.Fatalf("%s: reported=%v, want %v (src: %s)", tc.name, reported, tc.want, tc.src)
+		}
+	}
+}
+
+// TestDeclaresAllowlistedNameArmsTheShadowBranch pins the local-shadow arm of the
+// census. Without a fixture the branch is an assertion about a defect nobody
+// reproduced; with one, deleting it fails a test rather than going quiet.
+func TestDeclaresAllowlistedNameArmsTheShadowBranch(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{"local alias shadowing an allowlisted name", "type JobPayload = runtime.Job", true},
+		{"local alias of a second allowlisted name", "type JobRequest = runtime.Job", true},
+		{"local definition, not an alias, still borrows the name", "type groomApplyResult struct{ Plan bool }", true},
+		{"unrelated local type", "type somethingElse = runtime.Job", false},
+	} {
+		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package workflow\nfunc f() {\n"+tc.src+"\n_ = 0\n}\n", 0)
+		if err != nil {
+			t.Fatalf("%s: parse: %v", tc.name, err)
+		}
+		var got bool
+		ast.Inspect(file, func(n ast.Node) bool {
+			if spec, ok := n.(*ast.TypeSpec); ok && declaresAllowlistedName(spec) {
+				got = true
+			}
+			return true
+		})
+		if got != tc.want {
+			t.Fatalf("%s: declaresAllowlistedName = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -37,7 +37,7 @@ import (
 //     resolves to its owning package (five shapes that legitimately carry such a
 //     field, listed there with reasons).
 //   - No assignment to a .Plan or .PlanInto selector exists outside Mailbox.deliver,
-//     EXCEPT symbols in planAssignExemptions. This arm matches a selector NAME and has
+//     EXCEPT the exact WRITES named in planAssignExemptions, keyed file::symbol::receiver.field. This arm matches a selector NAME and has
 //     no type information, so it cannot tell whose Plan field it sees; each exemption
 //     is named there with a reason.
 //   - No declaration BORROWING an allowlisted type name exists outside its owner,
@@ -326,39 +326,13 @@ func planAssignSelectors(assign *ast.AssignStmt) []string {
 	return selectors
 }
 
-func assignsPlanField(assign *ast.AssignStmt) bool {
-	for _, lhs := range assign.Lhs {
-		if selectorNamesPlanField(lhs) {
-			return true
-		}
-	}
-	return false
-}
-
-// selectorNamesPlanField peels *, & and ( ) wrappers off an expression and reports
-// whether what remains selects Plan or PlanInto.
-func selectorNamesPlanField(expr ast.Expr) bool {
-	for {
-		switch e := expr.(type) {
-		case *ast.ParenExpr:
-			expr = e.X
-		case *ast.StarExpr:
-			expr = e.X
-		case *ast.UnaryExpr:
-			if e.Op != token.AND {
-				return false
-			}
-			expr = e.X
-		case *ast.SelectorExpr:
-			return e.Sel != nil && (e.Sel.Name == "Plan" || e.Sel.Name == "PlanInto")
-		default:
-			return false
-		}
-	}
-}
-
 // TestAssignsPlanFieldArmsTheCensus makes the assignment detector's RESULT
-// load-bearing. The census test alone did not: mutations making assignsPlanField
+// load-bearing — and it drives the function PRODUCTION CALLS. It used to exercise
+// assignsPlanField/selectorNamesPlanField, which my round-15 fix orphaned by adding a
+// SECOND peeler for the production path: both reviewers found these thirteen fixtures
+// had become false assurance, and codex proved it by regressing production to the
+// first LHS only while all three census tests stayed green. The duplicate is deleted;
+// planAssignSelectors is the only assignment detector, so a mutation to it fails here. The census test alone did not: mutations making assignsPlanField
 // always return false, or dropping PlanInto recognition, both left it green,
 // because no fixture in the tree exercised the assignment path. A detector nobody
 // tests is a detector that silently stops detecting — which is precisely how the
@@ -367,11 +341,20 @@ func selectorNamesPlanField(expr ast.Expr) bool {
 //
 // Each case is parsed from source, so the fixtures are the real syntax a producer
 // would write rather than hand-built AST nodes that could drift from the parser.
+func assignsPlanField(assign *ast.AssignStmt) bool {
+	return len(planAssignSelectors(assign)) > 0
+}
+
 func TestAssignsPlanFieldArmsTheCensus(t *testing.T) {
 	cases := []struct {
 		src  string
 		want bool
 	}{
+		// The plan write is NOT the first LHS. Without this, restricting production to
+		// assign.Lhs[:1] survived every fixture — the multi-LHS cases all happened to put
+		// the plan field first, so they proved nothing about the loop.
+		{"var x int; var j runtime.Job; x, j.Plan = 1, true; _, _ = x, j", true},
+		{"var x, y int; x, y = 1, 2; _, _ = x, y", false},
 		{"job.Plan = true", true},
 		{"job.PlanInto = x", true},
 		{"delivery.Plan, delivery.PlanInto = a, b", true},

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -156,15 +156,89 @@ func functionSymbol(function *ast.FuncDecl) string {
 // scan alone left this syntax invisible, so a producer could construct a
 // runtime.Job, set the plan primitives on the next line, and never appear in the
 // seam census the test exists to pin.
+//
+// The LHS is UNWRAPPED before matching. A first version compared the bare node to
+// *ast.SelectorExpr, and a reviewer walked straight past it with
+// `*(&delivery.Plan) = true` — an ast.StarExpr wrapping a unary & of the selector,
+// which reaches the same field and looked like nothing. Recognising one spelling of
+// a write is exactly the defect this helper was added to fix, so it must not
+// reproduce it one level down. Deref, address-of and parens are all peeled.
 func assignsPlanField(assign *ast.AssignStmt) bool {
 	for _, lhs := range assign.Lhs {
-		selector, ok := lhs.(*ast.SelectorExpr)
-		if !ok {
-			continue
-		}
-		if selector.Sel != nil && (selector.Sel.Name == "Plan" || selector.Sel.Name == "PlanInto") {
+		if selectorNamesPlanField(lhs) {
 			return true
 		}
 	}
 	return false
+}
+
+// selectorNamesPlanField peels *, & and ( ) wrappers off an expression and reports
+// whether what remains selects Plan or PlanInto.
+func selectorNamesPlanField(expr ast.Expr) bool {
+	for {
+		switch e := expr.(type) {
+		case *ast.ParenExpr:
+			expr = e.X
+		case *ast.StarExpr:
+			expr = e.X
+		case *ast.UnaryExpr:
+			if e.Op != token.AND {
+				return false
+			}
+			expr = e.X
+		case *ast.SelectorExpr:
+			return e.Sel != nil && (e.Sel.Name == "Plan" || e.Sel.Name == "PlanInto")
+		default:
+			return false
+		}
+	}
+}
+
+// TestAssignsPlanFieldArmsTheCensus makes the assignment detector's RESULT
+// load-bearing. The census test alone did not: mutations making assignsPlanField
+// always return false, or dropping PlanInto recognition, both left it green,
+// because no fixture in the tree exercised the assignment path. A detector nobody
+// tests is a detector that silently stops detecting — which is precisely how the
+// composite-literal-only version survived until a reviewer mutated production code
+// to walk past it.
+//
+// Each case is parsed from source, so the fixtures are the real syntax a producer
+// would write rather than hand-built AST nodes that could drift from the parser.
+func TestAssignsPlanFieldArmsTheCensus(t *testing.T) {
+	cases := []struct {
+		src  string
+		want bool
+	}{
+		{"job.Plan = true", true},
+		{"job.PlanInto = x", true},
+		{"delivery.Plan, delivery.PlanInto = a, b", true},
+		{"p.Plan = true", true},
+		// The forms a reviewer used to bypass the first version.
+		{"*(&delivery.Plan) = true", true},
+		{"*pj.PlanInto = s", true},
+		{"(delivery.Plan) = true", true},
+		{"*(&(delivery.PlanInto)) = s", true},
+		// Must NOT fire: unrelated fields, and a plan-shaped name that is not a field write.
+		{"job.Model = m", false},
+		{"job.Prompt = p", false},
+		{"Plan = true", false},
+		{"m[\"Plan\"] = true", false},
+		{"job.PlanModeSomething = x", false},
+	}
+	for _, tc := range cases {
+		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package p\nfunc f() {\n"+tc.src+"\n}\n", 0)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.src, err)
+		}
+		var got bool
+		ast.Inspect(file, func(n ast.Node) bool {
+			if assign, ok := n.(*ast.AssignStmt); ok && assignsPlanField(assign) {
+				got = true
+			}
+			return true
+		})
+		if got != tc.want {
+			t.Fatalf("assignsPlanField(%q) = %v, want %v", tc.src, got, tc.want)
+		}
+	}
 }

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -44,56 +44,7 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		pkgPath := planFieldPackagePath(rel)
-		imports := planFieldImportPaths(parsed)
-		for _, declaration := range parsed.Decls {
-			function, ok := declaration.(*ast.FuncDecl)
-			if !ok || function.Body == nil {
-				continue
-			}
-			ast.Inspect(function.Body, func(node ast.Node) bool {
-				switch n := node.(type) {
-				case *ast.CompositeLit:
-					// FAIL-CLOSED. This used to ask "is the literal's type runtime.Job?"
-					// and return false when it could not tell — so every type spelling
-					// the matcher did not recognise was silently exempt. Three review
-					// rounds walked past it that way, most recently with
-					// `type X = runtime.Job` (a plain refactor idiom, not an exotic act):
-					// the matcher compares the type NAME syntactically, so an alias under
-					// any other name was invisible and hasPlanField was never consulted.
-					//
-					// The question is inverted: ANY composite literal that sets Plan or
-					// PlanInto is reported unless its type is on an explicit allowlist of
-					// types that legitimately carry those fields. A new type, a rename, or
-					// an alias now defaults to REPORTED. That is noisier and it is the
-					// safe direction: the failure mode becomes "the census names something
-					// you must add to the allowlist", not "the census went quiet".
-					if hasPlanField(n) && !planFieldTypeIsAllowlisted(n.Type, pkgPath, imports) {
-						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
-					}
-				case *ast.AssignStmt:
-					// job.Plan = true — the composite-literal scan alone missed this, and
-					// a compiled mutant that built a runtime.Job then set Plan AFTERWARDS
-					// delivered it straight past the mailbox gate while this test still
-					// passed. A seam guard that recognises only one syntax for writing a
-					// field is not a seam guard.
-					if assignsPlanField(n) {
-						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
-					}
-				case *ast.TypeSpec:
-					// A function-local `type JobPayload = runtime.Job` SHADOWS the real
-					// type, so a bare literal under that name satisfies the owning-package
-					// test above and would be exempt while producing a genuine
-					// runtime.Job. Declaring an allowlisted name anywhere inside a body is
-					// therefore reported: the allowlist grants exemption to five specific
-					// types, not to their spellings.
-					if declaresAllowlistedName(n) {
-						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
-					}
-				}
-				return true
-			})
-		}
+		got = append(got, planFieldProducersInFile(rel, parsed)...)
 		return nil
 	})
 	if err != nil {
@@ -103,6 +54,67 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 	if !slices.Equal(got, want) {
 		t.Fatalf("runtime.Job plan producers = %v, want exactly %v; route every producer through the deliver-time plan gate", got, want)
 	}
+}
+
+// planFieldProducersInFile is the census's per-file scan, extracted so a test can
+// drive it directly. A reviewer showed why that matters: the compiled mutation
+// `if false && declaresAllowlistedName(n)` disconnected the shadow arm from the
+// census while the helper's own unit test stayed green — a test of a helper proves
+// the helper, not that anything CALLS it. TestPlanFieldCensusWiresEveryArm pins the
+// wiring, so deleting an arm now fails a test instead of going quiet.
+func planFieldProducersInFile(rel string, parsed *ast.File) []string {
+	var got []string
+	pkgPath := planFieldPackagePath(rel)
+	imports := planFieldImportPaths(parsed)
+	for _, declaration := range parsed.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Body == nil {
+			continue
+		}
+		ast.Inspect(function.Body, func(node ast.Node) bool {
+			switch n := node.(type) {
+			case *ast.CompositeLit:
+				// FAIL-CLOSED. This used to ask "is the literal's type runtime.Job?"
+				// and return false when it could not tell — so every type spelling
+				// the matcher did not recognise was silently exempt. Three review
+				// rounds walked past it that way, most recently with
+				// `type X = runtime.Job` (a plain refactor idiom, not an exotic act):
+				// the matcher compares the type NAME syntactically, so an alias under
+				// any other name was invisible and hasPlanField was never consulted.
+				//
+				// The question is inverted: ANY composite literal that sets Plan or
+				// PlanInto is reported unless its type is on an explicit allowlist of
+				// types that legitimately carry those fields. A new type, a rename, or
+				// an alias now defaults to REPORTED. That is noisier and it is the
+				// safe direction: the failure mode becomes "the census names something
+				// you must add to the allowlist", not "the census went quiet".
+				if hasPlanField(n) && !planFieldTypeIsAllowlisted(n.Type, pkgPath, imports) {
+					got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+				}
+			case *ast.AssignStmt:
+				// job.Plan = true — the composite-literal scan alone missed this, and
+				// a compiled mutant that built a runtime.Job then set Plan AFTERWARDS
+				// delivered it straight past the mailbox gate while this test still
+				// passed. A seam guard that recognises only one syntax for writing a
+				// field is not a seam guard.
+				if assignsPlanField(n) {
+					got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+				}
+			case *ast.TypeSpec:
+				// A function-local `type JobPayload = runtime.Job` SHADOWS the real
+				// type, so a bare literal under that name satisfies the owning-package
+				// test above and would be exempt while producing a genuine
+				// runtime.Job. Declaring an allowlisted name anywhere inside a body is
+				// therefore reported: the allowlist grants exemption to five specific
+				// types, not to their spellings.
+				if declaresAllowlistedName(n, pkgPath) {
+					got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+				}
+			}
+			return true
+		})
+	}
+	return got
 }
 
 func shouldSkipPlanProducerDir(rel string) bool {
@@ -318,12 +330,17 @@ func planFieldImportPaths(parsed *ast.File) map[string]string {
 // bare literal under that name passes the owning-package test while producing a
 // genuine runtime.Job. The exemption belongs to five specific types, not to their
 // spellings, so any body-scoped declaration of one of those names is reported.
-func declaresAllowlistedName(spec *ast.TypeSpec) bool {
+func declaresAllowlistedName(spec *ast.TypeSpec, pkgPath string) bool {
 	if spec == nil || spec.Name == nil {
 		return false
 	}
-	_, listed := planFieldAllowlist[spec.Name.Name]
-	return listed
+	owner, listed := planFieldAllowlist[spec.Name.Name]
+	// Only inside the OWNING package. A reviewer showed the unrestricted form failing
+	// the census on a compiled internal/cli helper declaring an unrelated
+	// `JobRequest struct{ Value string }` — no plan field, no relation to runtime.Job.
+	// Outside the owner a bare literal is already reported by the package test above,
+	// so the shadow arm adds nothing there and only blocks innocent code.
+	return listed && pkgPath == owner
 }
 
 // planFieldTypeIsAllowlisted reports whether a composite literal's type is one of
@@ -430,6 +447,22 @@ func TestPlanFieldCensusFailsClosedOnUnknownTypes(t *testing.T) {
 			want:    true,
 		},
 		{
+			// Full-path identity, not the last element: another module may own a
+			// directory called workflow, and comparing basenames would exempt it.
+			name:    "same basename at a DIFFERENT module path is reported",
+			imports: "import workflow \"github.com/other/project/internal/workflow\"\n",
+			src:     "_ = workflow.JobPayload{Plan: true}",
+			want:    true,
+		},
+		{
+			// The Ident arm needs the same distinction: a file whose OWN package merely
+			// ends in "workflow" does not own internal/workflow's types.
+			name: "bare name in a package sharing only the basename is reported",
+			pkg:  "internal/other/workflow/x.go",
+			src:  "_ = JobPayload{Plan: true}",
+			want: true,
+		},
+		{
 			name:    "qualifier absent from the import table is reported",
 			imports: "import \"github.com/gitmoot/gitmoot/internal/runtime\"\n",
 			pkg:     "",
@@ -473,13 +506,17 @@ func TestPlanFieldCensusFailsClosedOnUnknownTypes(t *testing.T) {
 func TestDeclaresAllowlistedNameArmsTheShadowBranch(t *testing.T) {
 	for _, tc := range []struct {
 		name string
+		pkg  string
 		src  string
 		want bool
 	}{
-		{"local alias shadowing an allowlisted name", "type JobPayload = runtime.Job", true},
-		{"local alias of a second allowlisted name", "type JobRequest = runtime.Job", true},
-		{"local definition, not an alias, still borrows the name", "type groomApplyResult struct{ Plan bool }", true},
-		{"unrelated local type", "type somethingElse = runtime.Job", false},
+		{"local alias shadowing an allowlisted name", "internal/workflow/x.go", "type JobPayload = runtime.Job", true},
+		{"local alias of a second allowlisted name", "internal/workflow/x.go", "type JobRequest = runtime.Job", true},
+		{"local definition, not an alias, still borrows the name", "internal/cli/x.go", "type groomApplyResult struct{ Plan bool }", true},
+		// OVER-REPORT CONTROL. The unrestricted form failed the census on a compiled
+		// internal/cli helper declaring an unrelated JobRequest with no plan field.
+		{"allowlisted name declared OUTSIDE its owning package", "internal/cli/x.go", "type JobRequest struct{ Value string }", false},
+		{"unrelated local type", "internal/workflow/x.go", "type somethingElse = runtime.Job", false},
 	} {
 		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package workflow\nfunc f() {\n"+tc.src+"\n_ = 0\n}\n", 0)
 		if err != nil {
@@ -487,13 +524,68 @@ func TestDeclaresAllowlistedNameArmsTheShadowBranch(t *testing.T) {
 		}
 		var got bool
 		ast.Inspect(file, func(n ast.Node) bool {
-			if spec, ok := n.(*ast.TypeSpec); ok && declaresAllowlistedName(spec) {
+			if spec, ok := n.(*ast.TypeSpec); ok && declaresAllowlistedName(spec, planFieldPackagePath(tc.pkg)) {
 				got = true
 			}
 			return true
 		})
 		if got != tc.want {
 			t.Fatalf("%s: declaresAllowlistedName = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestPlanFieldCensusWiresEveryArm pins that the census REACHES each arm, which the
+// per-helper tests cannot show. A reviewer disconnected the shadow arm with
+// `if false && declaresAllowlistedName(n)` and all three existing tests stayed green:
+// a helper test proves the helper, never the call. Each case below fails if its arm
+// is unwired, so an arm cannot be deleted or short-circuited silently.
+func TestPlanFieldCensusWiresEveryArm(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rel  string
+		src  string
+		want []string
+	}{
+		{
+			name: "composite-literal arm",
+			rel:  "internal/cli/x.go",
+			src:  "func f() { _ = runtime.Job{Plan: true} }",
+			want: []string{"internal/cli/x.go::f"},
+		},
+		{
+			name: "assignment arm",
+			rel:  "internal/cli/x.go",
+			src:  "func f() { var j runtime.Job; j.Plan = true; _ = j }",
+			want: []string{"internal/cli/x.go::f"},
+		},
+		{
+			name: "shadow arm, inside the owning package",
+			rel:  "internal/workflow/x.go",
+			src:  "func f() { type JobPayload = runtime.Job; _ = 0 }",
+			want: []string{"internal/workflow/x.go::f"},
+		},
+		{
+			name: "import-alias arm",
+			rel:  "internal/workflow/x.go",
+			src:  "func f() { _ = workflow.JobPayload{Plan: true} }",
+			want: []string{"internal/workflow/x.go::f"},
+		},
+		{
+			name: "clean file reports nothing",
+			rel:  "internal/cli/x.go",
+			src:  "func f() { _ = runtime.Job{Prompt: \"x\"} }",
+			want: nil,
+		},
+	} {
+		const imports = "import (\n\t\"github.com/gitmoot/gitmoot/internal/runtime\"\n\tworkflow \"github.com/gitmoot/gitmoot/internal/censusshim\"\n)\n"
+		file, err := parser.ParseFile(token.NewFileSet(), "x.go", "package p\n"+imports+tc.src+"\n", 0)
+		if err != nil {
+			t.Fatalf("%s: parse: %v", tc.name, err)
+		}
+		got := planFieldProducersInFile(tc.rel, file)
+		if !slices.Equal(got, tc.want) {
+			t.Fatalf("%s: producers = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }

--- a/internal/workflow/runtime_job_plan_seam_test.go
+++ b/internal/workflow/runtime_job_plan_seam_test.go
@@ -52,11 +52,22 @@ func TestRuntimeJobPlanFieldsHaveSingleGatedProducer(t *testing.T) {
 				continue
 			}
 			ast.Inspect(function.Body, func(node ast.Node) bool {
-				literal, ok := node.(*ast.CompositeLit)
-				if !ok || !isRuntimeJobType(literal.Type, runtimeAliases, dotRuntime, inRuntimePackage) || !hasPlanField(literal) {
-					return true
+				switch n := node.(type) {
+				case *ast.CompositeLit:
+					// runtime.Job{..., Plan: true, ...}
+					if isRuntimeJobType(n.Type, runtimeAliases, dotRuntime, inRuntimePackage) && hasPlanField(n) {
+						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+					}
+				case *ast.AssignStmt:
+					// job.Plan = true — the composite-literal scan alone missed this, and
+					// a compiled mutant that built a runtime.Job then set Plan AFTERWARDS
+					// delivered it straight past the mailbox gate while this test still
+					// passed. A seam guard that recognises only one syntax for writing a
+					// field is not a seam guard.
+					if assignsPlanField(n) {
+						got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
+					}
 				}
-				got = append(got, filepath.ToSlash(rel)+"::"+functionSymbol(function))
 				return true
 			})
 		}
@@ -138,4 +149,22 @@ func functionSymbol(function *ast.FuncDecl) string {
 		return name.Name + "." + function.Name.Name
 	}
 	return function.Name.Name
+}
+
+// assignsPlanField reports whether a statement writes Plan or PlanInto through a
+// selector, e.g. `job.Plan = true` or `delivery.PlanInto = x`. The composite-literal
+// scan alone left this syntax invisible, so a producer could construct a
+// runtime.Job, set the plan primitives on the next line, and never appear in the
+// seam census the test exists to pin.
+func assignsPlanField(assign *ast.AssignStmt) bool {
+	for _, lhs := range assign.Lhs {
+		selector, ok := lhs.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		if selector.Sel != nil && (selector.Sel.Name == "Plan" || selector.Sel.Name == "PlanInto") {
+			return true
+		}
+	}
+	return false
 }

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -798,9 +798,16 @@ an omp seat:
   the run, the envelope is complete and only the final answer is missing, so the
   parser reads the FINAL assistant message rather than the last one that carried
   text — an earlier work note is never handed back as the job's answer.
-- **All four `--policy` values pass the same explicit `--approval-mode=yolo`.**
-  omp's undeclared tools default to the `exec` tier, so `always-ask` would make
-  every headless tool call throw. Read-only stays enforced Gitmoot-side (the
+- **All four `--policy` values pass the same explicit `--approval-mode=yolo`,**
+  for **determinism** — omitting the flag would inherit whatever
+  `tools.approvalMode` the host config carries. It is *not* because `always-ask`
+  is unusable: measured on omp 17.2.4 headless, `read`/`grep`/`glob` succeed and
+  only `bash`/`write` are refused, and the process exits 0 with a full
+  `agent_end`, so `always-ask` **restricts** omp rather than breaking it. Mapping
+  autonomy policy onto the approval mode therefore remains an open option
+  (gitmoot#1479); it is simply not what the adapter does today. Read-only stays
+  enforced Gitmoot-side (the same fail-closed implement refusal Kimi uses), not by
+  the runtime flag.
   same fail-closed implement refusal Kimi uses), not by the runtime flag.
 - **omp is in no cross-family group.** An omp implement job's cross-family
   review is *refused loudly* (a `cross_family_review_failed` job event) rather

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -808,7 +808,6 @@ an omp seat:
   (gitmoot#1479); it is simply not what the adapter does today. Read-only stays
   enforced Gitmoot-side (the same fail-closed implement refusal Kimi uses), not by
   the runtime flag.
-  same fail-closed implement refusal Kimi uses), not by the runtime flag.
 - **omp is in no cross-family group.** An omp implement job's cross-family
   review is *refused loudly* (a `cross_family_review_failed` job event) rather
   than silently skipped, because scoring an opaque router as a family would

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -738,10 +738,15 @@ the daemon runs under. What that changes in practice:
   the envelope is complete and only the final answer is missing — fails loudly
   rather than reporting an empty success.
 - **All four `--policy` values pass the same explicit `--approval-mode=yolo`,**
-  because omp's undeclared tools default to the `exec` tier and `always-ask`
-  would make every headless tool call throw. Read-only stays enforced
-  Gitmoot-side (the same fail-closed implement refusal Kimi uses), not by the
-  runtime flag.
+  for **determinism** — omitting the flag would inherit whatever
+  `tools.approvalMode` the host config carries. It is *not* because `always-ask`
+  is unusable: measured on omp 17.2.4 headless, `read`/`grep`/`glob` succeed and
+  only `bash`/`write` are refused, and the process exits 0 with a full
+  `agent_end`, so `always-ask` **restricts** omp rather than breaking it. Mapping
+  autonomy policy onto the approval mode therefore remains an open option
+  (gitmoot#1479); it is simply not what the adapter does today. Read-only stays
+  enforced Gitmoot-side (the same fail-closed implement refusal Kimi uses), not by
+  the runtime flag.
 - **omp is in no cross-family group.** An omp implement job's cross-family
   review is refused *loudly* (a `cross_family_review_failed` job event) instead
   of silently skipped, because scoring an opaque router as a model family would

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -258,20 +258,27 @@ omp ships a `--plan-yolo` mode and the adapter passes it — but only when the j
 asks for it. A job payload carrying `plan: true` runs
 `--plan-yolo`; adding `plan_into: "<model>"` also emits
 `--plan-yolo-into <model>`, pinning the model the execution phase runs on (omp's
-own default target is the `smol` role). `plan_into` without `plan` is rejected
-before dispatch, because omp only accepts the pair.
+declared default target is the `smol` role). `plan_into` must be one non-flag
+model selector without internal whitespace or control characters. An unpaired
+or malformed target is rejected before dispatch.
 
-Plan mode is **workflow shape**, not permission: omp starts read-only,
-auto-approves the *model's own* plan on its first resolve call, and then
-**auto-executes** it. `--approval-mode` is untouched and stays `yolo` for plan
-and non-plan runs alike — mapping plan mode onto the approval tier would brick
-the runtime rather than restrict it.
+Plan mode is **workflow shape**, not permission. On `omp/17.2.4`, the
+reproducible check `omp --version && omp --help` declares that `--plan-yolo`
+starts in read-only plan mode, auto-approves the model's plan on its first
+resolve call, then executes it, and that `--plan-yolo-into` selects the execution
+model. This is omp's versioned CLI declaration, not internal behavior Gitmoot
+can observe. Gitmoot verifies that the installed binary lists the flags and
+records the requested plan shape. `--approval-mode` is untouched and stays
+`yolo` for plan and non-plan runs alike — mapping plan mode onto the approval
+tier would brick the runtime rather than restrict it.
 
 Only the omp runtime implements plan mode. A plan request routed to any other
 runtime **fails loudly at dispatch** instead of quietly running as an ordinary
 implementation, and the resolved shape is echoed into the job payload as
 `plan_mode` (`plan` or `plan-into:<model>`) so a reader can tell a plan run from
-a normal one without re-deriving it from the argv.
+a normal one without re-deriving it from the argv. Runtime preflight evaluates
+the two plan flags only for a plan request, so an older omp CLI that lacks those
+optional flags can still run ordinary non-plan jobs.
 
 Note that this is omp's plan-first discipline *inside one run*; it is **not**
 Gitmoot's plan gate, where approval remains an explicit human act.

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -235,12 +235,25 @@ have been billed for a message whose `message_end` never reached stdout.
 | `auto` (default) | `--approval-mode=yolo` | same |
 
 Every policy passes the **same explicit** `--approval-mode=yolo`, and that is
-deliberate. omp's default tool tier is `exec` and its read/grep/ls tools declare
-no tier at all, so under `always-ask` every headless tool call throws ("requires
-approval but no interactive UI available") — a policy-to-approval mapping would
-brick the runtime rather than restrict it. Omitting the flag instead would
-inherit whatever approval mode the host config carries, which is not
-deterministic across machines.
+deliberate — for **determinism**, not because a policy mapping is impossible.
+Omitting the flag would inherit whatever approval mode the host config carries,
+which is not deterministic across machines.
+
+:::caution Corrected
+An earlier version of this page claimed that `always-ask` "would brick the runtime
+rather than restrict it", because omp's read/grep/ls tools declare no permission
+tier and every headless call would throw. **That was wrong.** Measured against
+omp 17.2.4 headless with stdin closed and no host pre-approvals: `read`, `grep`
+and read-on-a-directory all succeed (`isError:false`); `bash` and `write` return
+`isError:true` with *"requires approval but no interactive UI available"* and the
+write does not land; the process still exits `0` with a full `agent_end` envelope
+the adapter parses. So `always-ask` **restricts** omp to read-only tools and
+terminates cleanly — which is what a read-only policy wants. omp 17.2.4 has no
+`ls` tool at all. Mapping autonomy policy onto `--approval-mode` remains an open
+option for [#1479](https://github.com/gitmoot/gitmoot/issues/1479); it is simply
+not what the adapter does today, and this page must not be cited as a reason it
+cannot be.
+:::
 
 Read-only therefore stays enforced **Gitmoot-side**, exactly as it is for Kimi:
 the `implement` **capability** is refused at `agent start` and `agent subscribe`
@@ -262,26 +275,42 @@ declared default target is the `smol` role). `plan_into` must be one non-flag
 model selector without internal whitespace or control characters. An unpaired
 or malformed target is rejected before dispatch.
 
-Plan mode is **workflow shape**, not permission. On `omp/17.2.4`, the
-reproducible check `omp --version && omp --help` declares that `--plan-yolo`
-starts in read-only plan mode, auto-approves the model's plan on its first
-resolve call, then executes it, and that `--plan-yolo-into` selects the execution
-model. This is omp's versioned CLI declaration, not internal behavior Gitmoot
-can observe. Gitmoot verifies that the installed binary lists the flags and
-records the requested plan shape. `--approval-mode` is untouched and stays
-`yolo` for plan and non-plan runs alike — mapping plan mode onto the approval
-tier would brick the runtime rather than restrict it.
+Plan mode is **workflow shape** — plan first, then auto-execute — and it is a
+separate field from the autonomy policy so the two are not conflated into one
+overloaded knob. **Separate is not independent:** plan mode ends in an
+implementation phase, and upstream omp *adds* the `write` tool to the active set
+while plan mode is armed rather than removing it. A plan request is therefore a
+**write request**, and the dispatch gate requires the same write-granting policy
+(`workspace-write` or `danger-full-access`) that an `implement` job requires. A
+plan-mode job on an `auto`/empty or `read-only` seat is refused — without that
+check, plan mode was a write bypass, because the implement-job gate keys on job
+type and never sees an `ask` job carrying a plan.
+
+On `omp/17.2.4`, `omp --version && omp --help` declares that `--plan-yolo` starts
+in read-only plan mode, auto-approves the model's plan on its first resolve call,
+then executes it, and that `--plan-yolo-into` selects the execution model. That is
+omp's versioned CLI declaration; the tool-set behavior above is what its source
+actually does. `--approval-mode` stays `yolo` for plan and non-plan runs alike.
+
+**The execution phase is a model switch.** Left unset, omp resolves
+`--plan-yolo-into` to its cheap `@smol` role, so the job's model would plan and a
+different model would write the code. Gitmoot therefore resolves the target
+itself: an explicit `plan_into` wins, otherwise the job's effective model carries
+through. The payload's `plan_mode` records the resolved target —
+`plan-into:<model>`, or `plan-into:<runtime-default>` in the one case where no
+model is resolvable — so the evidence always says which model implemented, and
+never a bare `plan` that cannot.
 
 Only the omp runtime implements plan mode. A plan request routed to any other
 runtime **fails loudly at dispatch** instead of quietly running as an ordinary
-implementation, and the resolved shape is echoed into the job payload as
-`plan_mode` (`plan` or `plan-into:<model>`) so a reader can tell a plan run from
-a normal one without re-deriving it from the argv. Runtime preflight evaluates
-the two plan flags only for a plan request, so an older omp CLI that lacks those
-optional flags can still run ordinary non-plan jobs.
+implementation. Runtime preflight evaluates the two plan flags only for a plan
+request, so an older omp CLI that lacks those optional flags can still run
+ordinary non-plan jobs.
 
-Note that this is omp's plan-first discipline *inside one run*; it is **not**
-Gitmoot's plan gate, where approval remains an explicit human act.
+Note that this is omp's plan-first discipline *inside one run*. Gitmoot's own plan
+step is separate and, per the owner ruling of 2026-08-14, **also auto-executes**:
+a plan proceeds into its implementation and stops only when it needs a
+confirmation or an answer from its parent seat or the owner.
 
 ### Capabilities
 

--- a/website/docs/reference/runtime-adapters.md
+++ b/website/docs/reference/runtime-adapters.md
@@ -54,6 +54,7 @@ Every delivery — and `agent start` — builds one argument vector:
 ```sh
 omp -p --mode=json --approval-mode=yolo --no-session \
     [--add-dir <path>]… [--model <M>] [--thinking <level>] [--max-time <s>] \
+    [--plan-yolo [--plan-yolo-into <M>]] \
     [@<staged>/prompt.md] -- '<single prompt token>'
 ```
 
@@ -80,6 +81,9 @@ Each fixed element is load-bearing:
   would become multiple separately billed turns, a prompt starting with `-`
   would be read as an unknown flag (exit 2), and one starting with `@` would be
   read as a file attachment. `--` disables all of that for the value after it.
+- `--plan-yolo` appears **if and only if** the job asked for plan mode, and
+  `--plan-yolo-into <M>` only alongside it. See
+  [Plan mode](#plan-mode) below.
 
 The adapter resolves `omp` on `PATH` *before* spawning anything, so a daemon
 that cannot see the binary reports a PATH problem instead of a parse error.
@@ -248,11 +252,29 @@ by runtime **name** and wraps only Claude and Kimi, so no omp process is ever
 confined by it. omp separately does not advertise `produce`, which is why it
 never reaches the produce-stage wrapper either.)
 
-omp ships a `--plan-yolo` mode; the v1 adapter never passes it. When a
-plan-first omp runtime does land it will be a **separate** registered runtime,
-and it is worth stating plainly that `--plan-yolo` auto-approves the *model's
-own* plan. That is plan-first discipline inside one run; it is **not** Gitmoot's
-plan gate, where approval remains an explicit human act.
+### Plan mode
+
+omp ships a `--plan-yolo` mode and the adapter passes it — but only when the job
+asks for it. A job payload carrying `plan: true` runs
+`--plan-yolo`; adding `plan_into: "<model>"` also emits
+`--plan-yolo-into <model>`, pinning the model the execution phase runs on (omp's
+own default target is the `smol` role). `plan_into` without `plan` is rejected
+before dispatch, because omp only accepts the pair.
+
+Plan mode is **workflow shape**, not permission: omp starts read-only,
+auto-approves the *model's own* plan on its first resolve call, and then
+**auto-executes** it. `--approval-mode` is untouched and stays `yolo` for plan
+and non-plan runs alike — mapping plan mode onto the approval tier would brick
+the runtime rather than restrict it.
+
+Only the omp runtime implements plan mode. A plan request routed to any other
+runtime **fails loudly at dispatch** instead of quietly running as an ordinary
+implementation, and the resolved shape is echoed into the job payload as
+`plan_mode` (`plan` or `plan-into:<model>`) so a reader can tell a plan run from
+a normal one without re-deriving it from the argv.
+
+Note that this is omp's plan-first discipline *inside one run*; it is **not**
+Gitmoot's plan gate, where approval remains an explicit human act.
 
 ### Capabilities
 

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1773,12 +1773,22 @@ omp -p --mode=json --approval-mode=yolo --no-session \
 ```
 
 `--plan-yolo` appears if and only if the job asked for plan mode (`plan` /
-`plan_into` on the job payload): omp plans the work first and then
-auto-executes that plan, with `--plan-yolo-into` pinning the model the execution
-phase runs on. It is orthogonal to `--approval-mode`, which stays `yolo` for
-every job, plan or not. `plan_into` without `plan` and a plan request routed to
-any non-omp runtime are both refused before dispatch — a plan-gated brief never
-silently degrades into an ordinary implementation.
+`plan_into` on the job payload), with `--plan-yolo-into` pinning the model the
+execution phase runs on. `plan_into` must be one non-flag model selector with no
+internal whitespace or control characters. It is orthogonal to
+`--approval-mode`, which stays `yolo` for every job, plan or not. `plan_into`
+without `plan`, malformed targets, and a plan request routed to any non-omp
+runtime are refused before dispatch — a plan-gated brief never silently
+degrades into an ordinary implementation. Runtime preflight requires the two
+plan flags only for plan requests; an ordinary omp job does not require them.
+
+This behavior description is grounded in a versioned CLI declaration, not an
+internal transition Gitmoot can observe. On `omp/17.2.4`, run
+`omp --version && omp --help`: the help declares that `--plan-yolo` starts in
+read-only plan mode, auto-approves the model's plan on its first resolve call,
+then executes it, and that `--plan-yolo-into` selects the execution model with
+the `smol` role as the default. Gitmoot verifies the installed flags and records
+the requested plan shape; it cannot verify omp's internal phase transitions.
 
 Startup stores the session id from the NDJSON header line, but delivery never
 uses it: omp is stateless in v1 and never passes `--resume`, `--continue`, or

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -10863,9 +10863,11 @@ an omp seat:
   parser reads the FINAL assistant message rather than the last one that carried
   text — an earlier work note is never handed back as the job's answer.
 - **All four `--policy` values pass the same explicit `--approval-mode=yolo`.**
-  omp's undeclared tools default to the `exec` tier, so `always-ask` would make
-  every headless tool call throw. Read-only stays enforced Gitmoot-side (the
-  same fail-closed implement refusal Kimi uses), not by the runtime flag.
+  for determinism — omitting the flag inherits the host's `tools.approvalMode`.
+  NOT because `always-ask` is unusable: measured on omp 17.2.4 headless,
+  read/grep/glob succeed, only bash/write are refused, and the process exits 0
+  with a full `agent_end`. Read-only stays enforced Gitmoot-side (the same
+  fail-closed implement refusal Kimi uses), not by the runtime flag.
 - **omp is in no cross-family group.** An omp implement job's cross-family
   review is *refused loudly* (a `cross_family_review_failed` job event) rather
   than silently skipped, because scoring an opaque router as a family would

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -1768,8 +1768,17 @@ builder, so no flag can appear on one path and go missing on the other:
 ```sh
 omp -p --mode=json --approval-mode=yolo --no-session \
     [--add-dir <path>]… [--model <M>] [--thinking <level>] [--max-time <s>] \
+    [--plan-yolo [--plan-yolo-into <M>]] \
     [@<staged>/prompt.md] -- '<single prompt token>'
 ```
+
+`--plan-yolo` appears if and only if the job asked for plan mode (`plan` /
+`plan_into` on the job payload): omp plans the work first and then
+auto-executes that plan, with `--plan-yolo-into` pinning the model the execution
+phase runs on. It is orthogonal to `--approval-mode`, which stays `yolo` for
+every job, plan or not. `plan_into` without `plan` and a plan request routed to
+any non-omp runtime are both refused before dispatch — a plan-gated brief never
+silently degrades into an ordinary implementation.
 
 Startup stores the session id from the NDJSON header line, but delivery never
 uses it: omp is stateless in v1 and never passes `--resume`, `--continue`, or


### PR DESCRIPTION
Closes the capability half of #1479.

## What was wrong

The omp runtime adapter shipped with **autonomy hardcoded on**. Every dispatch passed `--approval-mode=yolo` regardless of the job's policy (`internal/runtime/omp.go`), and the v1 flag policy explicitly **rejected** `--plan-yolo`. That was a deliberate v1 scope cut — plan support was deferred to "PR 2." PR 2 was never written, and six follow-up issues were filed the same week.

Since then an omp-harness coordinator seat runs on `gitmoot/gitmoot`, so plan-capable dispatch stopped being hypothetical.

## What this adds

**A closed capability set, not a downgrade.** `SupportsPlanMode(runtime)` returns true for `omp` only. Codex, claude, kimi and shell are **refused** rather than silently stripped of the plan request — a caller asking for something the runtime cannot do gets an error, not a surprise.

**The gate fires at both boundaries.** A plan request is validated at `enqueue`, then **again at `deliver`** after any `runtime_override` resolves. That second check is the load-bearing one: an override can move a job onto a non-capable runtime *after* it passed enqueue, and without the re-check it would dispatch a plan request to a runtime that can't honour it.

**`plan_into` depends on `plan`.** Requesting the shape without the primitive is refused even on omp, so there is no half-configured plan state.

**The normal path is untouched.** A job with no plan primitives produces no plan argv and records no `PlanMode` evidence. `PlanMode` is durable evidence on `Result`, mirroring the existing `autonomy_policy` field rather than inventing a second convention.

## What this deliberately does **not** do

`--approval-mode=yolo` **stays unconditional.** Mapping autonomy policy onto that flag would brick the runtime: omp's `read`/`grep`/`ls` tools declare no permission tier, so under `always-ask` every headless tool call throws. I verified that against the adapter rather than assuming it, and the constraint is now written at the call site instead of living in someone's memory.

This is why the PR is titled *dispatch surface* and not *plan mode*. It makes the engine able to refuse impossible plan requests and to carry the primitives when they are legal. **It does not decide policy** — whether a plan-gated dispatch means "plan then stop for approval" or "plan then auto-execute" is an open question on #1401/#1487 and is intentionally not encoded here.

## Verification

- `go build ./...` clean, `go vet` clean
- `go test ./internal/runtime/ ./internal/workflow/` — both pass
- **`go generate ./...` produces zero changes** — the generated-artifact contract in the CI gate is satisfied, checked before opening rather than after

**Guard proven by mutation, not by assertion.** I removed one deny-list entry and injected the exact defect the guard exists to catch (`if plan {` -> `if true {`, emitting the plan flag unconditionally). That produced **7 failures** across `TestOmpDeliverFreshArgv` — `minimal`, `unknown_effort_drops_the_flag`, `model_and_effort_precedence`, `agent_defaults_reach_the_argv_with_an_empty_job`, `runtime_registry_defaults_apply_when_neither_agent_nor_job_pins_one`, `the_job_overrides_both_the_agent_default_and_the_registry_default`. Restored, re-verified green. The new guard is a strict superset of the ban it replaced — the old list did not catch flag-presence-when-wrong, only absence-when-required.

New tests: `TestMailboxEnqueueRejectsImpossiblePlanRequest`, `TestMailboxDeliverPlanGate` (5 subtests incl. `plan_on_a_runtime_override_that_cannot_plan`, `plan_into_without_plan_is_refused_even_on_omp`, `a_normal_job_carries_no_plan_primitives_and_records_no_evidence`), `TestMailboxRunPersistsPlanEvidence`.

## One honest caveat, since it bounds what this closes

**No CLI path reaches this capability yet.** The only non-test writers of `Plan` are `mailbox.go:599` and `:1472` — both internal plumbing. `gitmoot agent run` cannot request plan mode. I found that by trying to drive an end-to-end shell-runtime E2E and failing to construct one, which is worth stating plainly: **#1479 must not be presented as closing plan mode.** #1425 owes the CLI access path and folds naturally with this.

That is the #1246 shape — an implemented feature nothing can reach — and I would rather name it here than let the issue close on a green test suite.

## Pre-existing red, not from this change

The full suite has one failure, `TestResolveBlockedTTLShapeTolerantNoPhantom`. It is **not mine**: it fails identically on a pristine clone at the same commit with zero edits, and it lives in `internal/cli`, which this PR does not touch (`internal/runtime` + `internal/workflow` only). Root cause is a test that reads this host's `/root/.gitmoot/config.toml` instead of the empty home it claims to test — filed separately as #1510 rather than folded in here, which would have widened this PR past its approval.

## Deploy notes

Engine-only capability change; no config, no migration, no daemon restart required for correctness. Two binaries on the host share this code (`gitmoot` and `gitmoot-dashboard-web`), so a deploy should refresh both per the runbook.
