### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1523 — resolve the fix-job branch with

### DIFF
--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -319,6 +319,13 @@ const (
 // implementationFinalizationTargetFor resolves the durable task fields required
 // to deliver an implementation. The advance preflight and the finalizer both
 // call this predicate so an early refusal cannot drift from the late backstop.
+//
+// The delivery branch is resolved once, with the same FixWorktree override the
+// worktree path uses: for a fix job the PAYLOAD owns the branch — advance-created
+// fix jobs bind to the reviewing job's task, and review tasks (review-pr-<n>-<hash>)
+// legitimately carry no branch (#1523) — while for any other job the TASK owns it.
+// The returned task copy carries the resolved branch so the finalizer pushes and
+// opens the pull request for exactly the branch this predicate validated.
 func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, phase implementationFinalizationPhase) (implementationFinalizationTarget, error) {
 	switch phase {
 	case implementationFinalizationBeforeRun, implementationFinalizationAfterRun:
@@ -343,6 +350,16 @@ func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, j
 	if payload.FixWorktree {
 		worktreePath = strings.TrimSpace(payload.WorktreePath)
 	}
+	// One resolved branch, used at both branch sites below: a FixWorktree job
+	// takes the payload's branch, any other job takes the task's. The
+	// missing-branch refusal and the current-branch comparison must read the
+	// same value — the comparison is what makes a wrong payload branch fail
+	// closed against the checkout's actual branch instead of silently
+	// delivering to the wrong branch.
+	branchName := strings.TrimSpace(task.Branch)
+	if payload.FixWorktree {
+		branchName = strings.TrimSpace(payload.Branch)
+	}
 	if worktreePath == "" {
 		branch := firstNonEmpty(strings.TrimSpace(task.Branch), strings.TrimSpace(payload.Branch), "<branch>")
 		return implementationFinalizationTarget{}, blockedResultDelivery(fmt.Sprintf(
@@ -350,35 +367,42 @@ func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, j
 			task.ID, task.ID, payload.Repo, job.Agent, branch,
 		))
 	}
-	if strings.TrimSpace(task.Branch) == "" {
-		branch := firstNonEmpty(strings.TrimSpace(payload.Branch), "<branch>")
+	if branchName == "" {
+		advice := firstNonEmpty(strings.TrimSpace(payload.Branch), strings.TrimSpace(task.Branch), "<branch>")
+		// Name the source the resolution actually consulted so the refusal is
+		// true for the case that produced it: a fix job resolves the branch
+		// from its payload, any other job from the task.
+		missing := fmt.Sprintf("implementation task %s has no branch", task.ID)
+		if payload.FixWorktree {
+			missing = fmt.Sprintf("implementation fix job for task %s carries no payload branch", task.ID)
+		}
 		if payload.PullRequest > 0 {
 			recoveryWorktree := firstNonEmpty(strings.TrimSpace(task.WorktreePath), worktreePath)
 			return implementationFinalizationTarget{}, blockedResultDelivery(fmt.Sprintf(
-				"implementation task %s has no branch; cannot push or open a pull request; inspect or stash local changes, then run `git -C %q fetch origin refs/pull/%d/head` and `git -C %q reset --hard FETCH_HEAD`; retry with `gitmoot agent implement %s \"Address the requested changes.\" --repo %s --task %s --pr %d --branch %s`",
-				task.ID, recoveryWorktree, payload.PullRequest, recoveryWorktree, job.Agent, payload.Repo, task.ID, payload.PullRequest, branch,
+				"%s; cannot push or open a pull request; inspect or stash local changes, then run `git -C %q fetch origin refs/pull/%d/head` and `git -C %q reset --hard FETCH_HEAD`; retry with `gitmoot agent implement %s \"Address the requested changes.\" --repo %s --task %s --pr %d --branch %s`",
+				missing, recoveryWorktree, payload.PullRequest, recoveryWorktree, job.Agent, payload.Repo, task.ID, payload.PullRequest, advice,
 			))
 		}
 		return implementationFinalizationTarget{}, blockedResultDelivery(fmt.Sprintf(
-			"implementation task %s has no branch; cannot push or open a pull request; inspect or stash local changes, then rerun with `gitmoot task run %s --repo %s --owner %s --branch %s`",
-			task.ID, task.ID, payload.Repo, job.Agent, branch,
+			"%s; cannot push or open a pull request; inspect or stash local changes, then rerun with `gitmoot task run %s --repo %s --owner %s --branch %s`",
+			missing, task.ID, payload.Repo, job.Agent, advice,
 		))
 	}
 	git := gitutil.Client{Dir: worktreePath}
-	branch, err := git.CurrentBranch(ctx)
+	currentBranch, err := git.CurrentBranch(ctx)
 	if err != nil {
 		if phase == implementationFinalizationAfterRun {
 			return implementationFinalizationTarget{}, fmt.Errorf("resolve implementation branch: %w", err)
 		}
 		return implementationFinalizationTarget{}, blockedResultDelivery(fmt.Sprintf(
 			"implementation task %s worktree %q has no usable current branch (%v); expected branch %s; refusing to run or deliver from an unverifiable checkout",
-			task.ID, worktreePath, err, task.Branch,
+			task.ID, worktreePath, err, branchName,
 		))
 	}
-	if branch != task.Branch {
+	if currentBranch != branchName {
 		return implementationFinalizationTarget{}, blockedResultDelivery(fmt.Sprintf(
 			"implementation task %s worktree %q is on branch %s, not %s; refusing to run or deliver from the wrong checkout",
-			task.ID, worktreePath, branch, task.Branch,
+			task.ID, worktreePath, currentBranch, branchName,
 		))
 	}
 	if phase == implementationFinalizationBeforeRun {
@@ -386,7 +410,7 @@ func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, j
 		if expectedHead == "" {
 			return implementationFinalizationTarget{}, blockedResultDelivery(fmt.Sprintf(
 				"implementation task %s fix worktree %q has no dispatch head SHA; cannot prove the checkout is current before running the model; refresh pull request #%d metadata and retry with `gitmoot agent implement %s \"Address the requested changes.\" --repo %s --task %s --pr %d --branch %s --head-sha <sha>`",
-				task.ID, worktreePath, payload.PullRequest, job.Agent, payload.Repo, task.ID, payload.PullRequest, task.Branch,
+				task.ID, worktreePath, payload.PullRequest, job.Agent, payload.Repo, task.ID, payload.PullRequest, branchName,
 			))
 		}
 		head, err := git.HeadSHA(ctx)
@@ -405,7 +429,7 @@ func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, j
 		}
 		recovery := fmt.Sprintf(
 			"inspect or stash local changes, then run `git -C %q fetch origin %s` and `git -C %q reset --hard %s` before retrying",
-			worktreePath, task.Branch, worktreePath, expectedHead,
+			worktreePath, branchName, worktreePath, expectedHead,
 		)
 		currentIncludesDispatchHead, err := git.IsAncestor(ctx, expectedHead, head)
 		if err != nil {
@@ -418,6 +442,11 @@ func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, j
 			))
 		}
 	}
+	// Hand the finalizer the resolved branch: the returned task copy carries
+	// branchName so every downstream delivery step (push, pull request,
+	// payload) targets exactly the branch validated above, even when the
+	// stored task legitimately owns none (#1523).
+	task.Branch = branchName
 	return implementationFinalizationTarget{Task: task, WorktreePath: worktreePath}, nil
 }
 

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -356,6 +356,14 @@ func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, j
 	// same value — the comparison is what makes a wrong payload branch fail
 	// closed against the checkout's actual branch instead of silently
 	// delivering to the wrong branch.
+	//
+	// The unconditional FixWorktree override depends on the producer side:
+	// allocateFixWorktree (fix_worktree.go) hard-errors "fix worktree branch
+	// is required" on a blank branch before dispatchFix ever sets
+	// FixWorktree=true, so a fix job cannot reach this predicate with an empty
+	// payload.Branch that would clobber a valid task.Branch.
+	// TestAllocateFixWorktreeRejectsBlankBranch enforces that guard; if it
+	// fails, re-check this override before trusting it.
 	branchName := strings.TrimSpace(task.Branch)
 	if payload.FixWorktree {
 		branchName = strings.TrimSpace(payload.Branch)

--- a/internal/cli/fix_worktree_test.go
+++ b/internal/cli/fix_worktree_test.go
@@ -81,6 +81,27 @@ func (f fixWorktreeFixture) allocate(t *testing.T, jobID string) workflow.FixWor
 	return allocation
 }
 
+// #1523 (review follow-up): the finalizer's branch resolution in
+// implementationFinalizationTargetFor unconditionally overrides the delivery
+// branch with payload.Branch for a FixWorktree job. That override is only safe
+// because this producer-side guard hard-errors on a blank branch BEFORE
+// dispatchFix ever sets FixWorktree=true — otherwise an empty payload.Branch
+// would clobber a valid task.Branch and newly refuse work that previously
+// succeeded. This test asserts the rejection by its observable behaviour so
+// removing the guard breaks here instead of silently widening the predicate's
+// exposure.
+func TestAllocateFixWorktreeRejectsBlankBranch(t *testing.T) {
+	store := daemonWorkerStore(t)
+	for _, branch := range []string{"", "   "} {
+		_, err := allocateFixWorktree(context.Background(), store, t.TempDir(), t.TempDir(), workflow.FixWorktreeRequest{
+			JobID: "fix-blank-branch", Repo: "owner/repo", Branch: branch,
+		})
+		if err == nil || !strings.Contains(err.Error(), "fix worktree branch is required") {
+			t.Fatalf("allocateFixWorktree with branch %q: err = %v, want \"fix worktree branch is required\"", branch, err)
+		}
+	}
+}
+
 func TestReviewFixRunsInPerJobBranchWorktree(t *testing.T) {
 	ctx := context.Background()
 	fixture := newFixWorktreeFixture(t)

--- a/internal/cli/implementation_advance_preflight_test.go
+++ b/internal/cli/implementation_advance_preflight_test.go
@@ -42,9 +42,9 @@ func TestImplementationFinalizationTargetRejectsEveryMissingField(t *testing.T) 
 		},
 		{
 			name:    "branch",
-			payload: workflow.JobPayload{Repo: "owner/repo", Branch: "feature/fix", PullRequest: 1514, TaskID: "task-1", FixWorktree: true, WorktreePath: "/tmp/fix"},
+			payload: workflow.JobPayload{Repo: "owner/repo", PullRequest: 1514, TaskID: "task-1", FixWorktree: true, WorktreePath: "/tmp/fix"},
 			task:    &db.Task{ID: "task-1", RepoFullName: "owner/repo", WorktreePath: "/tmp/stale-task"},
-			want:    "no branch",
+			want:    "carries no payload branch",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -1040,12 +1040,12 @@ func TestDaemonImplementationFinalizerKeepsMissingBranchBackstop(t *testing.T) {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
 	payload := workflow.JobPayload{
-		Repo: "owner/repo", Branch: "feature/fix", PullRequest: 12, TaskID: "task-backstop",
+		Repo: "owner/repo", PullRequest: 12, TaskID: "task-backstop",
 		FixWorktree: true, WorktreePath: t.TempDir(), Result: &workflow.AgentResult{Decision: "implemented"},
 	}
 	_, err := (daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}).FinalizeImplementation(ctx, db.Job{ID: "late-backstop", Agent: "lead", Type: "implement"}, payload)
 	var blocked workflow.BlockedError
-	if !errors.As(err, &blocked) || !blocked.ResultDeliveryFailed || !strings.Contains(err.Error(), "no branch") {
+	if !errors.As(err, &blocked) || !blocked.ResultDeliveryFailed || !strings.Contains(err.Error(), "carries no payload branch") {
 		t.Fatalf("FinalizeImplementation error = %v, want delivery-blocked missing-branch backstop", err)
 	}
 }
@@ -1079,7 +1079,7 @@ func TestImplementationFinalizationTargetClassifiesBranchLookupByPhase(t *testin
 	if err := store.UpsertTask(ctx, db.Task{ID: "task-branch-error", RepoFullName: "owner/repo", Branch: "feature/fix", WorktreePath: worktree}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
-	payload := workflow.JobPayload{Repo: "owner/repo", TaskID: "task-branch-error", FixWorktree: true, WorktreePath: worktree}
+	payload := workflow.JobPayload{Repo: "owner/repo", Branch: "feature/fix", TaskID: "task-branch-error", FixWorktree: true, WorktreePath: worktree}
 	job := db.Job{ID: "advance-branch-error", Agent: "lead", Type: "implement"}
 
 	for _, test := range []struct {

--- a/internal/cli/implementation_fixworktree_branch_test.go
+++ b/internal/cli/implementation_fixworktree_branch_test.go
@@ -53,7 +53,11 @@ func TestFixWorktreeFinalizerDeliversPayloadBranchWhenTaskHasNone(t *testing.T) 
 	// The review task legitimately owns no branch; it only points at the
 	// registered checkout. The fix payload carries both the fix worktree and
 	// the branch.
-	if err := store.UpsertTask(ctx, db.Task{ID: "review-pr-1523-deadbeef", RepoFullName: "owner/repo", WorktreePath: registered}); err != nil {
+	reviewTask := db.Task{ID: "review-pr-1523-deadbeef", RepoFullName: "owner/repo", WorktreePath: registered}
+	if strings.TrimSpace(reviewTask.Branch) != "" {
+		t.Fatalf("review task branch = %q, want empty so the payload override is required", reviewTask.Branch)
+	}
+	if err := store.UpsertTask(ctx, reviewTask); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
 	// An open pull request record lets the finalizer adopt it instead of
@@ -162,12 +166,15 @@ func TestImplementationFinalizationTargetOrdinaryJobTaskBranchWins(t *testing.T)
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	worktree := createDaemonWorkerGitCheckout(t, "feature/task-branch")
-	if err := store.UpsertTask(ctx, db.Task{ID: "task-ordinary", RepoFullName: "owner/repo", Branch: "feature/task-branch", WorktreePath: worktree}); err != nil {
+	task := db.Task{ID: "task-ordinary", RepoFullName: "owner/repo", Branch: "feature/task-branch", WorktreePath: worktree}
+	payload := workflow.JobPayload{Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: task.ID}
+	if payload.Branch == task.Branch {
+		t.Fatalf("ordinary fixture branches are equal at %q; payload must conflict so task precedence is observable", task.Branch)
+	}
+	if err := store.UpsertTask(ctx, task); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
-	target, err := implementationFinalizationTargetFor(ctx, store, db.Job{ID: "ordinary", Agent: "lead", Type: "implement"}, workflow.JobPayload{
-		Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: "task-ordinary",
-	}, implementationFinalizationAfterRun)
+	target, err := implementationFinalizationTargetFor(ctx, store, db.Job{ID: "ordinary", Agent: "lead", Type: "implement"}, payload, implementationFinalizationAfterRun)
 	if err != nil {
 		t.Fatalf("implementationFinalizationTargetFor returned error: %v", err)
 	}
@@ -187,10 +194,11 @@ func TestImplementationFinalizationTargetRefusesCheckoutOffResolvedBranch(t *tes
 	store := daemonWorkerStore(t)
 	worktree := createDaemonWorkerGitCheckout(t, "feature/task-branch")
 	for _, test := range []struct {
-		name    string
-		task    db.Task
-		payload workflow.JobPayload
-		want    []string
+		name           string
+		task           db.Task
+		payload        workflow.JobPayload
+		want           []string
+		branchlessTask bool
 	}{
 		{
 			// Risk 1: the payload branch is wrong for this checkout even
@@ -213,10 +221,14 @@ func TestImplementationFinalizationTargetRefusesCheckoutOffResolvedBranch(t *tes
 				Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: "task-guard-2",
 				FixWorktree: true, WorktreePath: worktree,
 			},
-			want: []string{"is on branch feature/task-branch, not feature/payload-branch", "refusing to run or deliver from the wrong checkout"},
+			want:           []string{"is on branch feature/task-branch, not feature/payload-branch", "refusing to run or deliver from the wrong checkout"},
+			branchlessTask: true,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			if test.branchlessTask && strings.TrimSpace(test.task.Branch) != "" {
+				t.Fatalf("task branch = %q, want empty so the branchless-task guard lane remains distinct", test.task.Branch)
+			}
 			if err := store.UpsertTask(ctx, test.task); err != nil {
 				t.Fatalf("UpsertTask returned error: %v", err)
 			}
@@ -242,15 +254,22 @@ func TestImplementationFinalizationTargetFixWorktreeOverridesAreSymmetric(t *tes
 	store := daemonWorkerStore(t)
 	realWorktree := createDaemonWorkerGitCheckout(t, "feature/fix")
 	staleWorktree := t.TempDir() // not a git checkout at all
-	if err := store.UpsertTask(ctx, db.Task{
+	staleTask := db.Task{
 		ID: "task-stale", RepoFullName: "owner/repo",
 		Branch: "feature/stale", WorktreePath: staleWorktree,
-	}); err != nil {
-		t.Fatalf("UpsertTask returned error: %v", err)
 	}
 	payload := workflow.JobPayload{
 		Repo: "owner/repo", Branch: "feature/fix", TaskID: "task-stale",
 		FixWorktree: true, WorktreePath: realWorktree,
+	}
+	if staleTask.Branch == payload.Branch {
+		t.Fatalf("stale task branch = payload branch %q; branch override is no longer required by the fixture", payload.Branch)
+	}
+	if staleTask.WorktreePath == payload.WorktreePath {
+		t.Fatalf("stale task worktree = payload worktree %q; worktree override is no longer required by the fixture", payload.WorktreePath)
+	}
+	if err := store.UpsertTask(ctx, staleTask); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
 	}
 	job := db.Job{ID: "symmetry", Agent: "lead", Type: "implement"}
 

--- a/internal/cli/implementation_fixworktree_branch_test.go
+++ b/internal/cli/implementation_fixworktree_branch_test.go
@@ -1,0 +1,337 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+// #1523: a FixWorktree job resolves its delivery branch from the payload (its
+// task is typically a branchless review task), exactly the way it already
+// resolves the worktree path. These tests pin the symmetric override, the
+// fail-closed current-branch guard, and the refusal-message accuracy.
+
+func lsRemoteHead(t *testing.T, dir, remote, branch string) string {
+	t.Helper()
+	fields := strings.Fields(runGitOutput(t, dir, "ls-remote", remote, "refs/heads/"+branch))
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// Acceptance 1: FixWorktree job, task.Branch empty, payload.Branch set ->
+// DELIVERS; the remote moves.
+func TestFixWorktreeFinalizerDeliversPayloadBranchWhenTaskHasNone(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	const branch = "feature/fix-delivery"
+	registered := createDaemonWorkerGitCheckout(t, "main")
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runDaemonWorkerGit(t, filepath.Dir(remote), "init", "--bare", remote)
+	runDaemonWorkerGit(t, registered, "remote", "set-url", "origin", remote)
+	runDaemonWorkerGit(t, registered, "push", "-u", "origin", "main")
+	runDaemonWorkerGit(t, registered, "switch", "-c", branch)
+	runDaemonWorkerGit(t, registered, "push", "-u", "origin", branch)
+	beforeRemote := lsRemoteHead(t, registered, "origin", branch)
+	if beforeRemote == "" {
+		t.Fatal("fixture remote branch is empty before delivery")
+	}
+	fixWorktree := filepath.Join(t.TempDir(), "fix-worktree")
+	runDaemonWorkerGit(t, filepath.Dir(fixWorktree), "clone", "--branch", branch, remote, fixWorktree)
+	configureTestGit(t, fixWorktree)
+	seedDaemonWorkerRepo(t, store, "owner/repo", registered)
+	// The review task legitimately owns no branch; it only points at the
+	// registered checkout. The fix payload carries both the fix worktree and
+	// the branch.
+	if err := store.UpsertTask(ctx, db.Task{ID: "review-pr-1523-deadbeef", RepoFullName: "owner/repo", WorktreePath: registered}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	// An open pull request record lets the finalizer adopt it instead of
+	// calling GitHub; the push under test happens before that step either way.
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo", Number: 1523, URL: "https://example.invalid/pull/1523",
+		HeadBranch: branch, BaseBranch: "main", State: "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest returned error: %v", err)
+	}
+	// The completed fix: an uncommitted change sitting in the fix worktree.
+	if err := os.WriteFile(filepath.Join(fixWorktree, "fix.txt"), []byte("fix\n"), 0o644); err != nil {
+		t.Fatalf("write fix change: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo: "owner/repo", Branch: branch, PullRequest: 1523, TaskID: "review-pr-1523-deadbeef",
+		FixWorktree: true, WorktreePath: fixWorktree, Result: &workflow.AgentResult{Decision: "implemented"},
+	}
+	delivered, err := (daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}).FinalizeImplementation(
+		ctx, db.Job{ID: "fix-delivers", Agent: "lead", Type: "implement"}, payload)
+	if err != nil {
+		t.Fatalf("FinalizeImplementation returned error: %v", err)
+	}
+	localHead := strings.TrimSpace(runGitOutput(t, fixWorktree, "rev-parse", "HEAD"))
+	afterRemote := lsRemoteHead(t, registered, "origin", branch)
+	if afterRemote == beforeRemote {
+		t.Fatalf("remote head did not move: still %s", afterRemote)
+	}
+	if afterRemote != localHead {
+		t.Fatalf("remote head = %s, want pushed fix worktree head %s", afterRemote, localHead)
+	}
+	if delivered.Branch != branch {
+		t.Fatalf("delivered payload branch = %q, want %q", delivered.Branch, branch)
+	}
+	if delivered.PullRequest != 1523 {
+		t.Fatalf("delivered payload pull request = %d, want 1523", delivered.PullRequest)
+	}
+}
+
+// Acceptance 2: FixWorktree job with neither task.Branch nor payload.Branch
+// refuses BEFORE the model runs — zero adapter calls.
+func TestFixWorktreePreflightRefusesWhenNeitherTaskNorPayloadHasBranch(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	checkout := createDaemonWorkerGitCheckout(t, "feature/reviewed")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	seedDaemonWorkerAgent(t, store, "lead", runtime.ShellRuntime, "unused", []string{"implement"}, "owner/repo")
+	if err := store.UpsertTask(ctx, db.Task{ID: "review-pr-1523-branchless", RepoFullName: "owner/repo", WorktreePath: checkout}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	enqueueDaemonWorkerJob(t, store, workflow.JobRequest{
+		ID: "fix-neither-branch", Agent: "lead", Action: "implement", Repo: "owner/repo",
+		PullRequest: 1523, TaskID: "review-pr-1523-branchless",
+		WorktreePath: checkout, FixWorktree: true, // no Branch anywhere
+	})
+	adapter := &cliWorkerFakeAdapter{output: resultJSON("implemented")}
+	worker := defaultJobWorker(store, io.Discard)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		return checkout, nil
+	}
+	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
+		return adapter, nil
+	}
+	worker.WorkflowFactory = func(string) workflow.Engine { return workflow.Engine{Store: store} }
+	job, err := store.GetJob(ctx, "fix-neither-branch")
+	if err != nil {
+		t.Fatalf("GetJob returned error: %v", err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatalf("worker.run returned error: %v", err)
+	}
+	if adapter.calls != 0 {
+		t.Fatalf("adapter calls = %d, want zero: branchless fix job must refuse before the model runs", adapter.calls)
+	}
+	after, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("GetJob after run returned error: %v", err)
+	}
+	if after.State != string(workflow.JobBlocked) {
+		t.Fatalf("job state = %q, want blocked", after.State)
+	}
+	jobEvents, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents returned error: %v", err)
+	}
+	message := ""
+	for _, event := range jobEvents {
+		if event.Kind == string(workflow.JobBlocked) {
+			message = event.Message
+		}
+	}
+	if !strings.Contains(message, "carries no payload branch") {
+		t.Fatalf("blocked message = %q, want it to name the missing payload branch", message)
+	}
+	if !strings.Contains(message, "--branch <branch>") {
+		t.Fatalf("blocked message = %q, want the placeholder advice, not a fabricated value", message)
+	}
+	if strings.Contains(message, "--branch feature/") {
+		t.Fatalf("blocked message = %q prints a usable branch value while refusing for a missing branch", message)
+	}
+}
+
+// Acceptance 3: an ordinary (non-fix) job still takes the task's branch; the
+// payload branch is not consulted.
+func TestImplementationFinalizationTargetOrdinaryJobTaskBranchWins(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worktree := createDaemonWorkerGitCheckout(t, "feature/task-branch")
+	if err := store.UpsertTask(ctx, db.Task{ID: "task-ordinary", RepoFullName: "owner/repo", Branch: "feature/task-branch", WorktreePath: worktree}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	target, err := implementationFinalizationTargetFor(ctx, store, db.Job{ID: "ordinary", Agent: "lead", Type: "implement"}, workflow.JobPayload{
+		Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: "task-ordinary",
+	}, implementationFinalizationAfterRun)
+	if err != nil {
+		t.Fatalf("implementationFinalizationTargetFor returned error: %v", err)
+	}
+	if target.Task.Branch != "feature/task-branch" {
+		t.Fatalf("resolved branch = %q, want the task branch for an ordinary job", target.Task.Branch)
+	}
+	if target.WorktreePath != worktree {
+		t.Fatalf("resolved worktree = %q, want the task worktree for an ordinary job", target.WorktreePath)
+	}
+}
+
+// Acceptance 4: a checkout sitting on a different branch than the RESOLVED one
+// still refuses — the fail-closed guard reads the resolved value, so a wrong
+// payload.Branch cannot silently deliver.
+func TestImplementationFinalizationTargetRefusesCheckoutOffResolvedBranch(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	worktree := createDaemonWorkerGitCheckout(t, "feature/task-branch")
+	for _, test := range []struct {
+		name    string
+		task    db.Task
+		payload workflow.JobPayload
+		want    []string
+	}{
+		{
+			// Risk 1: the payload branch is wrong for this checkout even
+			// though the checkout matches the task. Resolution prefers the
+			// payload for a fix job, so the guard must refuse.
+			name: "payload branch wins and the checkout does not match it",
+			task: db.Task{ID: "task-guard", RepoFullName: "owner/repo", Branch: "feature/task-branch", WorktreePath: worktree},
+			payload: workflow.JobPayload{
+				Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: "task-guard",
+				FixWorktree: true, WorktreePath: worktree,
+			},
+			want: []string{"is on branch feature/task-branch, not feature/payload-branch", "refusing to run or deliver from the wrong checkout"},
+		},
+		{
+			// Branchless review task: the guard compares against the payload
+			// branch, not against the task's empty branch.
+			name: "branchless task still guards the payload branch",
+			task: db.Task{ID: "task-guard-2", RepoFullName: "owner/repo", WorktreePath: worktree},
+			payload: workflow.JobPayload{
+				Repo: "owner/repo", Branch: "feature/payload-branch", TaskID: "task-guard-2",
+				FixWorktree: true, WorktreePath: worktree,
+			},
+			want: []string{"is on branch feature/task-branch, not feature/payload-branch", "refusing to run or deliver from the wrong checkout"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := store.UpsertTask(ctx, test.task); err != nil {
+				t.Fatalf("UpsertTask returned error: %v", err)
+			}
+			_, err := implementationFinalizationTargetFor(ctx, store, db.Job{ID: "guard", Agent: "lead", Type: "implement"}, test.payload, implementationFinalizationAfterRun)
+			var blocked workflow.BlockedError
+			if !errors.As(err, &blocked) || !blocked.ResultDeliveryFailed {
+				t.Fatalf("error = %v, want result-delivery BlockedError", err)
+			}
+			for _, want := range test.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %q, want %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+// Acceptance 5: symmetry guard. The task points at a stale worktree and a
+// stale branch; the payload points at the real fix worktree and its branch.
+// Removing EITHER override independently fails the subtest named for it.
+func TestImplementationFinalizationTargetFixWorktreeOverridesAreSymmetric(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	realWorktree := createDaemonWorkerGitCheckout(t, "feature/fix")
+	staleWorktree := t.TempDir() // not a git checkout at all
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-stale", RepoFullName: "owner/repo",
+		Branch: "feature/stale", WorktreePath: staleWorktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask returned error: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo: "owner/repo", Branch: "feature/fix", TaskID: "task-stale",
+		FixWorktree: true, WorktreePath: realWorktree,
+	}
+	job := db.Job{ID: "symmetry", Agent: "lead", Type: "implement"}
+
+	target, err := implementationFinalizationTargetFor(ctx, store, job, payload, implementationFinalizationAfterRun)
+	if err != nil {
+		t.Fatalf("implementationFinalizationTargetFor returned error: %v", err)
+	}
+	t.Run("worktree path override", func(t *testing.T) {
+		if target.WorktreePath != realWorktree {
+			t.Fatalf("resolved worktree = %q, want the payload fix worktree %q", target.WorktreePath, realWorktree)
+		}
+	})
+	t.Run("branch override", func(t *testing.T) {
+		if target.Task.Branch != "feature/fix" {
+			t.Fatalf("resolved branch = %q, want the payload branch %q", target.Task.Branch, "feature/fix")
+		}
+	})
+}
+
+// Acceptance 6: message accuracy. A refusal that fires must be TRUE for the
+// case that produced it and must not print a usable --branch value while
+// claiming no branch exists.
+func TestImplementationFinalizationMissingBranchMessageIsAccurate(t *testing.T) {
+	ctx := context.Background()
+	store := daemonWorkerStore(t)
+	job := db.Job{ID: "message", Agent: "lead", Type: "implement"}
+
+	t.Run("fix job names the payload and prints only the placeholder", func(t *testing.T) {
+		if err := store.UpsertTask(ctx, db.Task{ID: "task-msg-fix", RepoFullName: "owner/repo", WorktreePath: t.TempDir()}); err != nil {
+			t.Fatalf("UpsertTask returned error: %v", err)
+		}
+		_, err := implementationFinalizationTargetFor(ctx, store, job, workflow.JobPayload{
+			Repo: "owner/repo", TaskID: "task-msg-fix", FixWorktree: true, WorktreePath: t.TempDir(),
+		}, implementationFinalizationBeforeRun)
+		var blocked workflow.BlockedError
+		if !errors.As(err, &blocked) || !blocked.ResultDeliveryFailed {
+			t.Fatalf("error = %v, want result-delivery BlockedError", err)
+		}
+		if !strings.Contains(err.Error(), "carries no payload branch") {
+			t.Fatalf("error = %q, want the refusal to name the missing payload branch", err)
+		}
+		if !strings.Contains(err.Error(), "--branch <branch>") {
+			t.Fatalf("error = %q, want placeholder advice, not a fabricated branch", err)
+		}
+	})
+
+	t.Run("ordinary job still refuses and the task claim is true", func(t *testing.T) {
+		if err := store.UpsertTask(ctx, db.Task{ID: "task-msg-ordinary", RepoFullName: "owner/repo", WorktreePath: t.TempDir()}); err != nil {
+			t.Fatalf("UpsertTask returned error: %v", err)
+		}
+		_, err := implementationFinalizationTargetFor(ctx, store, job, workflow.JobPayload{
+			Repo: "owner/repo", Branch: "feature/hint", TaskID: "task-msg-ordinary",
+		}, implementationFinalizationBeforeRun)
+		var blocked workflow.BlockedError
+		if !errors.As(err, &blocked) || !blocked.ResultDeliveryFailed {
+			t.Fatalf("error = %v, want result-delivery BlockedError", err)
+		}
+		// The claim "task has no branch" is true here, and the printed
+		// --branch value is rerun advice: the payload branch was NOT usable
+		// for delivery in this ordinary job, which is exactly why the
+		// refusal fired.
+		if !strings.Contains(err.Error(), "implementation task task-msg-ordinary has no branch") {
+			t.Fatalf("error = %q, want the true missing-task-branch claim", err)
+		}
+		if !strings.Contains(err.Error(), "--branch feature/hint") {
+			t.Fatalf("error = %q, want the rerun advice to carry the known branch hint", err)
+		}
+	})
+
+	t.Run("fix job with a payload branch produces no refusal at all", func(t *testing.T) {
+		worktree := createDaemonWorkerGitCheckout(t, "feature/has-branch")
+		if err := store.UpsertTask(ctx, db.Task{ID: "task-msg-ok", RepoFullName: "owner/repo", WorktreePath: t.TempDir()}); err != nil {
+			t.Fatalf("UpsertTask returned error: %v", err)
+		}
+		head := strings.TrimSpace(runGitOutput(t, worktree, "rev-parse", "HEAD"))
+		_, err := implementationFinalizationTargetFor(ctx, store, job, workflow.JobPayload{
+			Repo: "owner/repo", Branch: "feature/has-branch", HeadSHA: head, TaskID: "task-msg-ok",
+			FixWorktree: true, WorktreePath: worktree,
+		}, implementationFinalizationBeforeRun)
+		if err != nil {
+			t.Fatalf("the case the old message lied about must now resolve, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
WHAT:
#1523 fixed: implementationFinalizationTargetFor (internal/cli/daemon_workflow.go:353) now resolves the delivery branch ONCE with the same FixWorktree override the worktree path already used — for a fix job the PAYLOAD wins (advance-created fix jobs bind to branchless review-pr-<n>-<hash> tasks), for any other job the TASK wins — and that single value feeds BOTH sites: the missing-branch refusal and the current-branch comparison. The returned task copy carries the resolved branch so the finalizer pushes/opens the PR for exactly the validated branch. Refusal messages now name the source actually consulted (fix job: 'carries no payload branch'; ordinary job: 'task has no branch') and print only rerun advice, never a value that would have delivered. Acceptance lanes: (1) FixWorktree job, task.Branch empty, payload.Branch set → DELIVERS, remote moved (ls-remote before/after differ, equals pushed head); (2) neither set → blocked BEFORE the model, adapter.calls=0; (3) ordinary job → task branch wins; (4) checkout off the resolved branch → still refuses, incl. the risk-1 arm where the checkout matches the task but NOT the payload (fail-closed on resolved value proven); (5) symmetry guard: one named test whose worktree/branch subtests fail if either override is removed; (6) message accuracy: refusal is true for the case that produced it, placeholder-only advice, and the case the old message lied about now produces no refusal. FALSIFICATION (surgical, per lane): lane1 payload.Branch removed → FAILS with the exact old-bug signature; lane2 branch supplied (+head, +lock) → adapter.calls=1, FAILS; lane3 task.Branch removed → FAILS; lane4 checkout matched to resolved branch → both subtests FAIL (err=nil); lane6 payload branch removed from the no-refusal contrast → FAILS. MUTATIONS (anchor census printed, fixed-string grep, all exactly 1, apply+build verified, 0 NOT COUNTED): M1 branch-override arm removed (census 1→0) → killed 4 named tests (delivery, guard both subtests, symmetry, message contrast); M2 worktree-override arm removed (1→0) → killed symmetry test; M3 site-2 reads raw task.Branch (1) → killed payload_branch_wins guard subtest + delivery; M4 message string reverted (1) → killed 4 named tests. All restored, censuses back to 1, tests green. UNPRIVILEGED-UID: go test -c as root, executed via `setpriv --reuid=nobody --regid=nogroup --clear-groups env HOME=/tmp/nobody-home-1523 TMPDIR=/tmp/nobody-tmp-1523 /tmp/cli-1523.test -test.run 'TestFixWorktree|TestImplementationFinalization|TestDaemonImplementationFinalizerKeepsMissingBranchBackstop|TestAdvanceImplementationPreflight' -test.count=1` → PASS. GATE: go build ./... OK; go vet ./... OK; go generate ./... produced no diff beyond this change; gofmt clean on touched files. FULL PACKAGE (2 runs, budget 2): only failures are gitmoot#1526's three live-home tests (TestResolveBlockedTTLShapeTolerantNoPhantom/empty, TestApplyMergeGatePolicyEmptyHomeIsNoop, TestDaemonWorkflowEngineNilHarvesterByDefault) — pre-existing, reproduced standalone, not mine; TestDaemonStopStopsUntrackedFlockHolder passes. .text at identical flags (CGO_ENABLED=0 -trimpath -buildvcs=false): main ca69923e sha256 af488f50262f671b9386fcd7098c29e3b60d44ccbc7d90b3a820e91c12c8304b vs head 5615ec87cb7127b741477d6149618f641c11148cd67e398383bb55fa2ae37924 → DIFFERS, a deploy is owed after merge (expected: production code changed). PUSH/PR: `git rev-parse origin/feat/1523-fixworktree-branch-override` does NOT exist yet — the job harness explicitly instructed 'do not run git commit or git push; Gitmoot commits and delivers your changes after you finish', which conflicts with the brief's draft-PR step; I followed the harness and left delivery (the very code path fixed here) to it. Out of scope honored: dispatchFix task binding (#1519-adjacent) untouched, no new evidence surfaced; current-branch guard strengthened, not weakened; no other task.* reads changed.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-40c97110

RESULTS:
- go build ./... + go vet ./... + go generate ./... (no diff) + gofmt — clean
- targeted: -run 'TestFixWorktree|TestImplementationFinalization|TestDaemonImplementationFinalizer|TestAdvanceImplementationPreflight|TestOrdinaryImplementation' — ok 11.6s
- targeted: -run 'Finaliz|FixWorktree|FixPass|Draft|Advance' — ok 29.9s
- full package ./internal/cli/ twice (656s/663s): only #1526's three live-home tests red — not mine
- falsification: 5 fixture-level lane strips, each failed the named lane; 4 production mutations (M1-M4), anchor census exactly 1 each, apply+build verified, each killed its named tests; 0 NOT COUNTED
- unprivileged-UID: setpriv --reuid=nobody with isolated HOME/TMPDIR on the compiled test binary — PASS
- TestDaemonStopStopsUntrackedFlockHolder standalone — ok
- .text sha256 main af488f50…8304b vs head 5615ec87…7924 — DIFFERS, deploy owed

RISK:
Review the generated diff before merging.

TASK:
adhoc-40c97110

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
#1523 fixed: implementationFinalizationTargetFor (internal/cli/daemon_workflow.go:353) now resolves the delivery branch ONCE with the same FixWorktree override the worktree path already used — for a fix job the PAYLOAD wins (advance-created fix jobs bind to branchless review-pr-<n>-<hash> tasks), for any other job the TASK wins — and that single value feeds BOTH sites: the missing-branch refusal and the current-branch comparison. The returned task copy carries the resolved branch so the finalizer pushes/opens the PR for exactly the validated branch. Refusal messages now name the source actually consulted (fix job: 'carries no payload branch'; ordinary job: 'task has no branch') and print only rerun advice, never a value that would have delivered. Acceptance lanes: (1) FixWorktree job, task.Branch empty, payload.Branch set → DELIVERS, remote moved (ls-remote before/after differ, equals pushed head); (2) neither set → blocked BEFORE the model, adapter.calls=0; (3) ordinary job → task branch wins; (4) checkout off the resolved branch → still refuses, incl. the risk-1 arm where the checkout matches the task but NOT the payload (fail-closed on resolved value proven); (5) symmetry guard: one named test whose worktree/branch subtests fail if either override is removed; (6) message accuracy: refusal is true for the case that produced it, placeholder-only advice, and the case the old message lied about now produces no refusal. FALSIFICATION (surgical, per lane): lane1 payload.Branch removed → FAILS with the exact old-bug signature; lane2 branch supplied (+head, +lock) → adapter.calls=1, FAILS; lane3 task.Branch removed → FAILS; lane4 checkout matched to resolved branch → both subtests FAIL (err=nil); lane6 payload branch removed from the no-refusal contrast → FAILS. MUTATIONS (anchor census printed, fixed-string grep, all exactly 1, apply+build verified, 0 NOT COUNTED): M1 branch-override arm removed (census 1→0) → killed 4 named tests (delivery, guard both subtests, symmetry, message contrast); M2 worktree-override arm removed (1→0) → killed symmetry test; M3 site-2 reads raw task.Branch (1) → killed payload_branch_wins guard subtest + delivery; M4 message string reverted (1) → killed 4 named tests. All restored, censuses back to 1, tests green. UNPRIVILEGED-UID: go test -c as root, executed via `setpriv --reuid=nobody --regid=nogroup --clear-groups env HOME=/tmp/nobody-home-1523 TMPDIR=/tmp/nobody-tmp-1523 /tmp/cli-1523.test -test.run 'TestFixWorktree|TestImplementationFinalization|TestDaemonImplementationFinalizerKeepsMissingBranchBackstop|TestAdvanceImplementationPreflight' -test.count=1` → PASS. GATE: go build ./... OK; go vet ./... OK; go generate ./... produced no diff beyond this change; gofmt clean on touched files. FULL PACKAGE (2 runs, budget 2): only failures are gitmoot#1526's three live-home tests (TestResolveBlockedTTLShapeTolerantNoPhantom/empty, TestApplyMergeGatePolicyEmptyHomeIsNoop, TestDaemonWorkflowEngineNilHarvesterByDefault) — pre-existing, reproduced standalone, not mine; TestDaemonStopStopsUntrackedFlockHolder passes. .text at identical flags (CGO_ENABLED=0 -trimpath -buildvcs=false): main ca69923e sha256 af488f50262f671b9386fcd7098c29e3b60d44ccbc7d90b3a820e91c12c8304b vs head 5615ec87cb7127b741477d6149618f641c11148cd67e398383bb55fa2ae37924 → DIFFERS, a deploy is owed after merge (expected: production code changed). PUSH/PR: `git rev-parse origin/feat/1523-fixworktree-branch-override` does NOT exist yet — the job harness explicitly instructed 'do not run git commit or git push; Gitmoot commits and delivers your changes after you finish', which conflicts with the brief's draft-PR step; I followed the harness and left delivery (the very code path fixed here) to it. Out of scope honored: dispatchFix task binding (#1519-adjacent) untouched, no new evidence surfaced; current-branch guard strengthened, not weakened; no other task.* reads changed.
````
