### PR TITLE
Gitmoot: IMPLEMENT gitmoot#1530 — stop minting a new review

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -104,9 +104,10 @@ type localAgentDispatchRequest struct {
 	// the task owning (repo, branch) even though that task's registered checkout
 	// HEAD differs from the requested head (#1530): a fix-worktree leg pushed the
 	// branch from an independent clone and left the registered checkout behind.
-	// dispatchLocalAgentJob records it as a review_task_head_divergence job event
-	// once the job row exists, so the rebind stays visible instead of silent. It
-	// is set by prepareLocalReviewTask and never persisted in the job payload.
+	// dispatchLocalAgentJob inserts it atomically with the queued job as a
+	// review_task_head_divergence event, so a runnable review can never exist
+	// without the required audit. It is set by prepareLocalReviewTask and never
+	// persisted in the job payload.
 	ReviewTaskHeadDivergence string
 }
 
@@ -351,6 +352,10 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if !request.Background {
 		effectiveRuntimeAtEnqueue = effectiveAgent.Runtime
 	}
+	var requiredEvents []db.JobEvent
+	if divergence := strings.TrimSpace(request.ReviewTaskHeadDivergence); divergence != "" {
+		requiredEvents = append(requiredEvents, db.JobEvent{Kind: "review_task_head_divergence", Message: divergence})
+	}
 	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(request.Home), OrgPolicy: orgPolicy}).Enqueue(ctx, workflow.JobRequest{
 		ID:                     jobID,
 		Agent:                  agent.Name,
@@ -375,6 +380,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		RuntimeOverride:        overrideRuntime,
 		RuntimeOverrideRef:     overrideRef,
 		EffectiveRuntime:       effectiveRuntimeAtEnqueue,
+		RequiredEvents:         requiredEvents,
 		Cockpit:                request.Cockpit,
 		CockpitSession:         request.CockpitSession,
 		SkipNativeReviewFanout: request.SkipNativeReviewFanout,
@@ -412,14 +418,6 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	}
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
 		return localAgentJobOutput{}, err
-	}
-	// #1530: a review that rebound to the branch-owning task despite a diverged
-	// registered-checkout HEAD must stay visible — a silent rebind would hide the
-	// exact state #1530 is about. The event names both SHAs.
-	if divergence := strings.TrimSpace(request.ReviewTaskHeadDivergence); divergence != "" {
-		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "review_task_head_divergence", Message: divergence}); err != nil {
-			return localAgentJobOutput{}, err
-		}
 	}
 	// Emit the #739 read-only isolation outcome now that the job row exists (job
 	// events carry a JobID FK). Allocated → observable worktree:<path> key; a

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -100,6 +100,14 @@ type localAgentDispatchRequest struct {
 	// DispatchWarning surfaces advisory pre-delivery checks to the operator. It
 	// is deliberately not persisted in the job payload.
 	DispatchWarning func(string)
+	// ReviewTaskHeadDivergence, when non-empty, records that a review rebound to
+	// the task owning (repo, branch) even though that task's registered checkout
+	// HEAD differs from the requested head (#1530): a fix-worktree leg pushed the
+	// branch from an independent clone and left the registered checkout behind.
+	// dispatchLocalAgentJob records it as a review_task_head_divergence job event
+	// once the job row exists, so the rebind stays visible instead of silent. It
+	// is set by prepareLocalReviewTask and never persisted in the job payload.
+	ReviewTaskHeadDivergence string
 }
 
 var promptCommitTokenRE = regexp.MustCompile(`\b[0-9a-fA-F]{7,64}\b`)
@@ -404,6 +412,14 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	}
 	if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "route_selected", Message: routeSelectedMessage(request)}); err != nil {
 		return localAgentJobOutput{}, err
+	}
+	// #1530: a review that rebound to the branch-owning task despite a diverged
+	// registered-checkout HEAD must stay visible — a silent rebind would hide the
+	// exact state #1530 is about. The event names both SHAs.
+	if divergence := strings.TrimSpace(request.ReviewTaskHeadDivergence); divergence != "" {
+		if err := store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "review_task_head_divergence", Message: divergence}); err != nil {
+			return localAgentJobOutput{}, err
+		}
 	}
 	// Emit the #739 read-only isolation outcome now that the job row exists (job
 	// events carry a JobID FK). Allocated → observable worktree:<path> key; a
@@ -864,13 +880,31 @@ func prepareLocalReviewTask(ctx context.Context, store *db.Store, repo github.Re
 				if headErr != nil {
 					return localAgentDispatchRequest{}, headErr
 				}
-				if head == request.HeadSHA {
-					request.TaskID = task.ID
-					request.GoalID = firstNonEmpty(request.GoalID, task.GoalID)
-					request.TaskTitle = firstNonEmpty(request.TaskTitle, task.Title)
-					return request, nil
+				if head != request.HeadSHA {
+					// #1530: the disk-HEAD comparison was a proxy for "same unit of
+					// work", but the engine advances and deletes worktrees
+					// independently of the task row — a fix-worktree leg pushes the
+					// branch from an independent clone and leaves the registered
+					// checkout legitimately behind. A review never reads this
+					// checkout (it runs in its own exact-head read-only worktree),
+					// so the task owning (repo, branch) IS the same unit of work:
+					// bind attribution to it and record the divergence, rather
+					// than minting a review-pr-* identity the merge gate cannot
+					// attribute to any implement job. This rebind affects review
+					// attribution ONLY: every implement path that consumes
+					// task.WorktreePath re-validates the checkout independently
+					// (validateFixPassTaskWorktreeHead at dispatch, and the daemon
+					// pre-flight "checkout head is ..." guard deferred by the
+					// checkout-contention classifier).
+					request.ReviewTaskHeadDivergence = fmt.Sprintf(
+						"review rebound to task %s owning branch %s although its registered checkout HEAD %s differs from the requested head %s (#1530); the review runs in an exact-head read-only worktree, so the rebind affects attribution only",
+						task.ID, request.Branch, head, request.HeadSHA)
 				}
 			}
+			request.TaskID = task.ID
+			request.GoalID = firstNonEmpty(request.GoalID, task.GoalID)
+			request.TaskTitle = firstNonEmpty(request.TaskTitle, task.Title)
+			return request, nil
 		} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return localAgentDispatchRequest{}, err
 		}

--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -162,3 +162,212 @@ func evaluateC1GateScenario(t *testing.T, implementTaskID string, reviewTaskID s
 	}
 	return decision
 }
+
+// #1530 acceptance 2 + 5, driven through the REAL dispatch path
+// (dispatchLocalAgentJob): a review dispatched at a head the branch-owning
+// task's registered checkout has NOT reached must still bind to that task,
+// record a review_task_head_divergence job event naming BOTH SHAs, and mint no
+// review-pr-* identity. The matching-head subtest pins the unchanged case: a
+// bind without divergence records no event.
+func TestDispatchReviewRebindsOwningTaskOnHeadDivergence(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		diverged      bool
+		wantEvent     bool
+		wantEventSHAa string // filled from fixture heads
+		wantEventSHAb string
+	}{
+		{name: "diverged head binds and records the divergence", diverged: true, wantEvent: true},
+		{name: "matching head binds without a divergence event", diverged: false, wantEvent: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, home := blockerE2EHome(t)
+			checkout, firstHead, secondHead := readonlyReviewWorktreeGitCheckout(t)
+			seedReviewDispatchFixture(t, store, checkout)
+			replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+				return diskFilesystemUsage{TotalBytes: 20 << 30, FreeBytes: 10 << 30}, nil
+			})
+			// The implement task owns (repo, branch); its registered checkout is a
+			// worktree pinned at the FIRST head — the strand a fix-worktree leg
+			// leaves behind when it pushes from an independent clone.
+			taskWorktree := filepath.Join(t.TempDir(), "task-worktree")
+			runGit(t, checkout, "worktree", "add", "--detach", taskWorktree, firstHead)
+			if got := readonlyWorktreeHead(t, taskWorktree); got != firstHead || firstHead == secondHead {
+				t.Fatalf("fixture pin failed: task worktree head=%q first=%q second=%q", got, firstHead, secondHead)
+			}
+			if err := store.UpsertTask(ctx, db.Task{
+				ID: "adhoc-impl", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Implement the fix",
+				State: string(workflow.TaskPullRequestOpen), Branch: "feature/review", WorktreePath: taskWorktree,
+			}); err != nil {
+				t.Fatalf("UpsertTask: %v", err)
+			}
+			dispatchHead := firstHead
+			if tc.diverged {
+				dispatchHead = secondHead
+			}
+			out, err := dispatchLocalAgentJob(ctx, store, reviewDispatchRequest(home, dispatchHead))
+			if err != nil {
+				t.Fatalf("dispatchLocalAgentJob: %v", err)
+			}
+			job, err := store.GetJob(ctx, out.JobID)
+			if err != nil {
+				t.Fatalf("GetJob: %v", err)
+			}
+			payload, err := daemonJobPayload(job)
+			if err != nil {
+				t.Fatalf("daemonJobPayload: %v", err)
+			}
+			if payload.TaskID != "adhoc-impl" {
+				t.Fatalf("review payload TaskID=%q, want rebound to the branch-owning task %q", payload.TaskID, "adhoc-impl")
+			}
+			events, err := store.ListJobEvents(ctx, job.ID)
+			if err != nil {
+				t.Fatalf("ListJobEvents: %v", err)
+			}
+			divergence := ""
+			for _, event := range events {
+				if event.Kind == "review_task_head_divergence" {
+					divergence = event.Message
+				}
+			}
+			if !tc.wantEvent {
+				if divergence != "" {
+					t.Fatalf("matching-head bind recorded a divergence event %q; want none", divergence)
+				}
+			} else {
+				for _, fragment := range []string{"adhoc-impl", firstHead, secondHead} {
+					if !strings.Contains(divergence, fragment) {
+						t.Fatalf("divergence event = %q, want it to name %q", divergence, fragment)
+					}
+				}
+			}
+			tasks, err := store.ListTasks(ctx)
+			if err != nil {
+				t.Fatalf("ListTasks: %v", err)
+			}
+			for _, task := range tasks {
+				if strings.HasPrefix(task.ID, "review-pr-") {
+					t.Fatalf("minted a fresh review identity %q despite the owning-task rebind", task.ID)
+				}
+			}
+		})
+	}
+}
+
+// #1530 acceptance 6: the measured strand end to end on an isolated home with
+// the shell runtime. A fix-worktree implement leg pushes the PR branch from an
+// independent clone (through the real implementation finalizer) and the clone is
+// removed; the implement task's registered checkout stays behind. The next
+// review must bind to the implement task — not mint review-pr-* — so the merge
+// gate can attribute it.
+func TestFixWorktreeStrandReviewBindsImplementTaskE2E(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	const branch = "feature/fix-strand"
+	registered := createDaemonWorkerGitCheckout(t, "main")
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runDaemonWorkerGit(t, filepath.Dir(remote), "init", "--bare", remote)
+	// origin stays the GitHub remote (dispatch repo resolution requires it); the
+	// bare repo stands in for the forge and is reached through a second remote.
+	runDaemonWorkerGit(t, registered, "remote", "add", "forge", remote)
+	runDaemonWorkerGit(t, registered, "switch", "-c", branch)
+	runDaemonWorkerGit(t, registered, "push", "-u", "forge", branch)
+	runDaemonWorkerGit(t, registered, "switch", "main")
+	strandedHead := strings.TrimSpace(runGitOutput(t, registered, "rev-parse", "forge/"+branch))
+	// The implement task's registered checkout: a linked worktree on the PR
+	// branch at the pre-fix head.
+	taskWorktree := filepath.Join(t.TempDir(), "task-worktree")
+	runDaemonWorkerGit(t, registered, "worktree", "add", taskWorktree, branch)
+	seedReviewDispatchFixture(t, store, registered)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "adhoc-impl", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Implement the fix",
+		State: string(workflow.TaskPullRequestOpen), Branch: branch, WorktreePath: taskWorktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+	if err := store.UpsertPullRequest(ctx, db.PullRequest{
+		RepoFullName: "owner/repo", Number: 1530, URL: "https://example.invalid/pull/1530",
+		HeadBranch: branch, BaseBranch: "main", State: "open",
+	}); err != nil {
+		t.Fatalf("UpsertPullRequest: %v", err)
+	}
+	// The fix-worktree leg: an independent clone that commits and pushes through
+	// the real finalizer, then is removed — exactly the engine's
+	// delegation_worktree_removed cleanup. Nothing advances the task's
+	// registered checkout.
+	fixWorktree := filepath.Join(t.TempDir(), "fix-worktree")
+	runDaemonWorkerGit(t, filepath.Dir(fixWorktree), "clone", "--branch", branch, remote, fixWorktree)
+	configureTestGit(t, fixWorktree)
+	if err := os.WriteFile(filepath.Join(fixWorktree, "fix.txt"), []byte("fix\n"), 0o644); err != nil {
+		t.Fatalf("write fix change: %v", err)
+	}
+	if _, err := (daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}).FinalizeImplementation(
+		ctx, db.Job{ID: "fix-leg", Agent: "implementer", Type: "implement"}, workflow.JobPayload{
+			Repo: "owner/repo", Branch: branch, PullRequest: 1530, TaskID: "adhoc-impl",
+			FixWorktree: true, WorktreePath: fixWorktree,
+			Result: &workflow.AgentResult{Decision: "implemented"},
+		}); err != nil {
+		t.Fatalf("FinalizeImplementation (fix-worktree leg): %v", err)
+	}
+	advancedHead := lsRemoteHead(t, registered, "forge", branch)
+	if advancedHead == "" || advancedHead == strandedHead {
+		t.Fatalf("fix leg did not advance the branch: remote head=%q stranded=%q", advancedHead, strandedHead)
+	}
+	if err := os.RemoveAll(fixWorktree); err != nil {
+		t.Fatalf("remove fix worktree: %v", err)
+	}
+	// Fixture pin: the registered checkout is genuinely stranded BEHIND the PR
+	// head. Without this the rebind below is vacuous.
+	if got := readonlyWorktreeHead(t, taskWorktree); got != strandedHead {
+		t.Fatalf("registered checkout moved: head=%q, want stranded at %q", got, strandedHead)
+	}
+	// Make the advanced head reachable from the registered checkout so the
+	// exact-head review worktree allocation can resolve it.
+	runDaemonWorkerGit(t, registered, "fetch", "forge")
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{TotalBytes: 20 << 30, FreeBytes: 10 << 30}, nil
+	})
+
+	out, err := dispatchLocalAgentJob(ctx, store, localAgentDispatchRequest{
+		RepoFlag: "owner/repo", Agent: "reviewer", LeadAgent: "implementer",
+		Action: "review", Instructions: "Review the advanced head.", Background: true,
+		PullRequest: 1530, Branch: branch, HeadSHA: advancedHead, Home: home,
+	})
+	if err != nil {
+		t.Fatalf("dispatchLocalAgentJob: %v", err)
+	}
+	job, err := store.GetJob(ctx, out.JobID)
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatalf("daemonJobPayload: %v", err)
+	}
+	if payload.TaskID != "adhoc-impl" {
+		t.Fatalf("review payload TaskID=%q, want the implement task %q; a review-pr-* mint is the #1530 defect", payload.TaskID, "adhoc-impl")
+	}
+	events, err := store.ListJobEvents(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("ListJobEvents: %v", err)
+	}
+	divergence := ""
+	for _, event := range events {
+		if event.Kind == "review_task_head_divergence" {
+			divergence = event.Message
+		}
+	}
+	for _, fragment := range []string{"adhoc-impl", strandedHead, advancedHead} {
+		if !strings.Contains(divergence, fragment) {
+			t.Fatalf("divergence event = %q, want it to name %q", divergence, fragment)
+		}
+	}
+	// The merge gate can now attribute the review round to the implement job:
+	// with the rebound identity at the advanced head, the independence check
+	// resolves the implementer and merges.
+	decision := evaluateC1GateScenario(t, payload.TaskID, payload.TaskID, strandedHead, advancedHead, payload.TaskID, "reviewer", true)
+	if !decision.Merged {
+		t.Fatalf("merge gate could not attribute the rebound review: %+v", decision)
+	}
+}

--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -226,17 +226,21 @@ func TestDispatchReviewRebindsOwningTaskOnHeadDivergence(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ListJobEvents: %v", err)
 			}
-			divergence := ""
+			var divergenceEvents []db.JobEvent
 			for _, event := range events {
 				if event.Kind == "review_task_head_divergence" {
-					divergence = event.Message
+					divergenceEvents = append(divergenceEvents, event)
 				}
 			}
 			if !tc.wantEvent {
-				if divergence != "" {
-					t.Fatalf("matching-head bind recorded a divergence event %q; want none", divergence)
+				if len(divergenceEvents) != 0 {
+					t.Fatalf("matching-head bind recorded divergence events %+v; want none", divergenceEvents)
 				}
 			} else {
+				if len(divergenceEvents) != 1 {
+					t.Fatalf("diverged-head bind recorded %d divergence events; want 1: %+v", len(divergenceEvents), divergenceEvents)
+				}
+				divergence := divergenceEvents[0].Message
 				for _, fragment := range []string{"adhoc-impl", firstHead, secondHead} {
 					if !strings.Contains(divergence, fragment) {
 						t.Fatalf("divergence event = %q, want it to name %q", divergence, fragment)

--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -298,6 +298,13 @@ func TestDispatchReviewDivergenceEventFailureRollsBackEnqueue(t *testing.T) {
 	if len(jobs) != 0 {
 		t.Fatalf("required divergence event failure left runnable jobs: %+v", jobs)
 	}
+	var eventCount int
+	if err := raw.QueryRow(`SELECT COUNT(*) FROM job_events`).Scan(&eventCount); err != nil {
+		t.Fatalf("count job events after rollback: %v", err)
+	}
+	if eventCount != 0 {
+		t.Fatalf("required divergence event failure left %d partial audit events; want 0", eventCount)
+	}
 }
 
 // #1530 acceptance 6: the measured strand end to end on an isolated home with

--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -252,6 +253,50 @@ func TestDispatchReviewRebindsOwningTaskOnHeadDivergence(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDispatchReviewDivergenceEventFailureRollsBackEnqueue(t *testing.T) {
+	ctx := context.Background()
+	store, home := blockerE2EHome(t)
+	checkout, firstHead, secondHead := readonlyReviewWorktreeGitCheckout(t)
+	seedReviewDispatchFixture(t, store, checkout)
+	replaceDiskGuardMeasurement(t, func(string) (diskFilesystemUsage, error) {
+		return diskFilesystemUsage{TotalBytes: 20 << 30, FreeBytes: 10 << 30}, nil
+	})
+	taskWorktree := filepath.Join(t.TempDir(), "task-worktree")
+	runGit(t, checkout, "worktree", "add", "--detach", taskWorktree, firstHead)
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "adhoc-impl", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Implement the fix",
+		State: string(workflow.TaskPullRequestOpen), Branch: "feature/review", WorktreePath: taskWorktree,
+	}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", store.DatabasePath())
+	if err != nil {
+		t.Fatalf("open raw sqlite: %v", err)
+	}
+	defer raw.Close()
+	if _, err := raw.Exec(`CREATE TRIGGER reject_review_task_head_divergence
+		BEFORE INSERT ON job_events
+		WHEN NEW.kind = 'review_task_head_divergence'
+		BEGIN
+			SELECT RAISE(FAIL, 'forced divergence event failure');
+		END`); err != nil {
+		t.Fatalf("create divergence event rejection trigger: %v", err)
+	}
+
+	out, err := dispatchLocalAgentJob(ctx, store, reviewDispatchRequest(home, secondHead))
+	if err == nil || !strings.Contains(err.Error(), "forced divergence event failure") {
+		t.Fatalf("dispatchLocalAgentJob output=%+v err=%v, want required-event failure", out, err)
+	}
+	jobs, err := store.ListJobs(ctx)
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("required divergence event failure left runnable jobs: %+v", jobs)
 	}
 }
 

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -707,7 +707,7 @@ func TestWorkflowOrchestrationGuardAllowsCommitQuestions(t *testing.T) {
 	}
 }
 
-func TestPrepareLocalReviewDispatchRequestCreatesBranchlessReviewTask(t *testing.T) {
+func TestPrepareLocalReviewDispatchRequestBindsBranchOwningTaskWithoutWorktree(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
 	repoDir := t.TempDir()
@@ -735,9 +735,9 @@ func TestPrepareLocalReviewDispatchRequestCreatesBranchlessReviewTask(t *testing
 
 	store := openCLIJobStore(t, home)
 	defer store.Close()
-	// An implement task may already own the PR head branch. Review task creation
-	// must keep its branch empty rather than violate tasks(repo,branch)'s partial
-	// unique index or overwrite the canonical implement task.
+	// An implement task may already own the PR head branch. The review must bind
+	// to it (#1530) — never mint a second task row for the same (repo, branch),
+	// which the tasks(repo,branch) partial unique index would reject anyway.
 	if err := store.UpsertTask(ctx, db.Task{ID: "implement-12", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Implement PR #12", State: string(workflow.TaskImplementing), Branch: "feature/review"}); err != nil {
 		t.Fatalf("UpsertTask(implement): %v", err)
 	}
@@ -754,8 +754,16 @@ func TestPrepareLocalReviewDispatchRequestCreatesBranchlessReviewTask(t *testing
 	if err != nil {
 		t.Fatalf("prepareLocalReviewDispatchRequest returned error: %v", err)
 	}
-	if request.TaskID == "" {
-		t.Fatal("request.TaskID is empty")
+	if request.TaskID != "implement-12" {
+		t.Fatalf("request.TaskID = %q, want bound to the branch-owning task %q", request.TaskID, "implement-12")
+	}
+	if request.GoalID != "goal-1" || request.TaskTitle != "Implement PR #12" {
+		t.Fatalf("rebind dropped task metadata: request=%+v", request)
+	}
+	// No worktree means no disk HEAD to compare, so there is no divergence to
+	// record — the note is specifically for a stranded registered checkout.
+	if request.ReviewTaskHeadDivergence != "" {
+		t.Fatalf("worktree-less bind recorded a divergence note %q; want none", request.ReviewTaskHeadDivergence)
 	}
 	branch, err := (gitutil.Client{Dir: repoDir}).CurrentBranch(ctx)
 	if err != nil {
@@ -764,15 +772,13 @@ func TestPrepareLocalReviewDispatchRequestCreatesBranchlessReviewTask(t *testing
 	if branch != "main" {
 		t.Fatalf("registered checkout branch = %q, want main", branch)
 	}
-	task, err := store.GetTask(ctx, request.TaskID)
+	// No review-pr-* row minted; the implement task row is untouched.
+	tasks, err := store.ListTasks(ctx)
 	if err != nil {
-		t.Fatalf("GetTask returned error: %v", err)
+		t.Fatalf("ListTasks returned error: %v", err)
 	}
-	if task.WorktreePath != "" || task.State != string(workflow.TaskReviewing) {
-		t.Fatalf("task = %+v, want reviewing lifecycle row with no shared worktree", task)
-	}
-	if task.ID == "implement-12" || task.Branch != "" {
-		t.Fatalf("review task = %+v, want distinct branchless review-pr task", task)
+	if len(tasks) != 1 || tasks[0].ID != "implement-12" {
+		t.Fatalf("tasks = %+v, want only the pre-existing implement task", tasks)
 	}
 	implementTask, err := store.GetTask(ctx, "implement-12")
 	if err != nil || implementTask.State != string(workflow.TaskImplementing) || implementTask.Branch != "feature/review" {
@@ -780,7 +786,7 @@ func TestPrepareLocalReviewDispatchRequestCreatesBranchlessReviewTask(t *testing
 	}
 }
 
-func TestPrepareLocalReviewDispatchRequestDoesNotBindStaleReviewTask(t *testing.T) {
+func TestPrepareLocalReviewDispatchRequestBindsTaskWithStaleCheckout(t *testing.T) {
 	ctx := context.Background()
 	home := t.TempDir()
 	repoDir := t.TempDir()
@@ -835,15 +841,40 @@ func TestPrepareLocalReviewDispatchRequestDoesNotBindStaleReviewTask(t *testing.
 	if err != nil {
 		t.Fatalf("prepareLocalReviewDispatchRequest returned error: %v", err)
 	}
-	if request.TaskID == "stale-review" {
-		t.Fatalf("reused stale taskID=%q", request.TaskID)
-	}
+	// Fixture pin: the registered checkout must genuinely sit BEHIND the
+	// requested head (the fix-worktree strand), or this test proves nothing.
 	staleHead, err := (gitutil.Client{Dir: staleWorktree}).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("stale HeadSHA returned error: %v", err)
 	}
-	if staleHead != oldHead {
-		t.Fatalf("stale worktree head = %q, want %q", staleHead, oldHead)
+	if staleHead != oldHead || staleHead == newHead {
+		t.Fatalf("fixture not stranded: stale worktree head = %q, want %q behind requested %q", staleHead, oldHead, newHead)
+	}
+	// #1530: the task owning (repo, branch) is the same unit of work even when
+	// its registered checkout is behind — bind to it, never mint review-pr-*.
+	if request.TaskID != "stale-review" {
+		t.Fatalf("request.TaskID=%q, want rebound to the branch-owning task %q", request.TaskID, "stale-review")
+	}
+	if request.GoalID != "goal-1" || request.TaskTitle != "Stale review" {
+		t.Fatalf("rebind dropped task metadata: request=%+v", request)
+	}
+	divergence := request.ReviewTaskHeadDivergence
+	for _, fragment := range []string{"stale-review", oldHead, newHead} {
+		if !strings.Contains(divergence, fragment) {
+			t.Fatalf("divergence note = %q, want it to name %q", divergence, fragment)
+		}
+	}
+	tasks, err := store.ListTasks(ctx)
+	if err != nil {
+		t.Fatalf("ListTasks returned error: %v", err)
+	}
+	for _, task := range tasks {
+		if strings.HasPrefix(task.ID, "review-pr-") {
+			t.Fatalf("minted a fresh review identity %q despite the owning task rebound", task.ID)
+		}
+	}
+	if len(tasks) != 1 || tasks[0].ID != "stale-review" {
+		t.Fatalf("tasks=%+v, want only the pre-existing owning task", tasks)
 	}
 }
 
@@ -859,6 +890,17 @@ func TestPrepareLocalReviewTaskRejectsDisposedTask(t *testing.T) {
 			task: db.Task{ID: "dismissed-by-branch", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed), Branch: "feature/review"},
 			setRequest: func(request *localAgentDispatchRequest) {
 				request.Branch = "feature/review"
+			},
+			wantError: []string{"is dismissed", "task recover"},
+		},
+		{
+			// #1530: the rebind-on-divergence must NOT precede the disposal
+			// refusal — a disposed task is refused whether or not the heads match.
+			name: "diverged head worktree",
+			task: db.Task{ID: "dismissed-diverged-by-branch", RepoFullName: "owner/repo", State: string(workflow.TaskDismissed), Branch: "feature/review"},
+			setRequest: func(request *localAgentDispatchRequest) {
+				request.Branch = "feature/review"
+				request.HeadSHA = strings.Repeat("0", 40)
 			},
 			wantError: []string{"is dismissed", "task recover"},
 		},
@@ -958,9 +1000,53 @@ func TestPrepareLocalReviewTaskReusesNonDismissedMatchingHead(t *testing.T) {
 	if request.TaskID != "reviewing-task" || request.GoalID != "goal-1" || request.TaskTitle != "Review" {
 		t.Fatalf("request=%+v", request)
 	}
+	if request.ReviewTaskHeadDivergence != "" {
+		t.Fatalf("matching-head bind recorded a divergence note %q; divergence is only for a mismatched head", request.ReviewTaskHeadDivergence)
+	}
 	task, err := store.GetTask(ctx, "reviewing-task")
 	if err != nil || task.State != string(workflow.TaskReviewing) {
 		t.Fatalf("task=%+v err=%v", task, err)
+	}
+}
+
+// #1530 acceptance 3: mint review-pr-%d-%s ONLY when no task owns (repo,
+// branch). This test fails if the rebind widens past the owning-task condition
+// (e.g. binding when GetTaskByRepoBranch found nothing).
+func TestPrepareLocalReviewTaskMintsIdentityWhenNoTaskOwnsBranch(t *testing.T) {
+	ctx := context.Background()
+	home := t.TempDir()
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "gitmoot@example.com")
+	runGit(t, repoDir, "config", "user.name", "Gitmoot")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "review\n")
+	runGit(t, repoDir, "add", "README.md")
+	runGit(t, repoDir, "commit", "-m", "review head")
+	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, home)
+	defer store.Close()
+	// A task on a DIFFERENT branch must not capture this review's identity.
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "other-branch-task", RepoFullName: "owner/repo", State: string(workflow.TaskImplementing),
+		Branch: "feature/other", WorktreePath: repoDir,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	request, err := prepareLocalReviewTask(ctx, store,
+		github.Repository{Owner: "owner", Name: "repo"},
+		localAgentDispatchRequest{Home: home, PullRequest: 12, Branch: "feature/review", HeadSHA: head})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantID := fmt.Sprintf("review-pr-%d-%s", 12, shortHash("owner/repo"))
+	if request.TaskID != wantID {
+		t.Fatalf("request.TaskID=%q, want minted %q when no task owns the branch", request.TaskID, wantID)
+	}
+	if request.ReviewTaskHeadDivergence != "" {
+		t.Fatalf("mint path recorded a divergence note %q; no owning task means no rebind", request.ReviewTaskHeadDivergence)
 	}
 }
 

--- a/internal/db/store_jobs.go
+++ b/internal/db/store_jobs.go
@@ -74,7 +74,7 @@ func (s *Store) CreateJob(ctx context.Context, job Job) error {
 	return err
 }
 
-func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent) error {
+func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent, additionalEvents ...JobEvent) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
@@ -98,6 +98,12 @@ func (s *Store) CreateJobWithEvent(ctx context.Context, job Job, event JobEvent)
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, event.JobID, event.Kind, event.Message); err != nil {
 		return err
+	}
+	for _, additional := range additionalEvents {
+		additional.JobID = job.ID
+		if _, err := tx.ExecContext(ctx, `INSERT INTO job_events(job_id, kind, message) VALUES (?, ?, ?)`, additional.JobID, additional.Kind, additional.Message); err != nil {
+			return err
+		}
 	}
 	if err := resolveAwaitedReviewFactTx(ctx, tx, job.ID, job.Agent, job.Type, job.State, job.Payload, time.Now().UTC()); err != nil {
 		return err

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -235,6 +235,10 @@ type JobRequest struct {
 	// resolved runtime inline. Background callers leave it empty; a foreground
 	// job later deferred to a worker is re-recorded at actual execution time.
 	EffectiveRuntime string
+	// RequiredEvents are inserted in the same transaction as the queued job and
+	// its standard queued event. Enqueue fails and rolls back the job if any
+	// required audit event cannot be persisted.
+	RequiredEvents []db.JobEvent
 	// ShellEnv carries pipeline trigger inputs and stage metadata as exact
 	// KEY=value entries to a shell runtime job. It is empty for every non-pipeline
 	// and non-shell job.
@@ -663,7 +667,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 	if err != nil {
 		return db.Job{}, err
 	}
-	if err := m.Store.CreateJobWithEvent(ctx, job, db.JobEvent{JobID: job.ID, Kind: string(JobQueued), Message: "job queued"}); err != nil {
+	if err := m.Store.CreateJobWithEvent(ctx, job, db.JobEvent{JobID: job.ID, Kind: string(JobQueued), Message: "job queued"}, request.RequiredEvents...); err != nil {
 		return db.Job{}, err
 	}
 	if autolabeled {


### PR DESCRIPTION
WHAT:
#1530 fixed: prepareLocalReviewTask now binds a review to the task owning (repo, branch) even when the registered checkout HEAD diverges (the fix-worktree strand), recording a review_task_head_divergence job event naming both SHAs; review-pr-* is minted only when no task owns the branch. Rebind is attribution-only: reviews run in exact-head read-only worktrees, and every implement path consuming task.WorktreePath still validates the checkout independently (validateFixPassTaskWorktreeHead, AllocateTaskWorktree lineage re-cut, daemon pre-flight 'checkout head is' + contention classifier). Production delta: internal/cli/agent_dispatch.go +39/-5. Tests: anchor census 7 (baseline -test.list count verified); mutation A (rebind reverted) fails exactly the 4 tests named for the new behavior while the 3 anchors pass; mutation B (event block removed) fails exactly the 2 event assertions. Acceptance 6 E2E drives a real finalizer push from an independent clone on an isolated /tmp home with shell-runtime agents, pins the stranded checkout, and shows the rebound review merging through the gate scenario. Gate: build/vet/generate clean; internal/workflow green; internal/cli green except 3 empty-home host confounds proven to fail identically on unmodified base 0b95ac2d. Draft PR not opened: job footer forbids commit/push and states Gitmoot delivers the changes.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-804dea56

RESULTS:
- go build -buildvcs=false ./... && go vet ./... && go generate ./... (diff hash identical before/after generate)
- go test -timeout 25m ./internal/workflow/ — ok (263.8s)
- go test -timeout 25m ./internal/cli/ — only the 3 pre-existing host confounds fail
- 7-test anchor suite: baseline -test.list count = 7; all pass on the fix
- Mutation A (rebind reverted): 4 fix-named tests FAIL, 3 anchors PASS
- Mutation B (divergence event block removed): both event assertions FAIL, binding assertions PASS

RISK:
Review the generated diff before merging.

TASK:
adhoc-804dea56

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
#1530 fixed: prepareLocalReviewTask now binds a review to the task owning (repo, branch) even when the registered checkout HEAD diverges (the fix-worktree strand), recording a review_task_head_divergence job event naming both SHAs; review-pr-* is minted only when no task owns the branch. Rebind is attribution-only: reviews run in exact-head read-only worktrees, and every implement path consuming task.WorktreePath still validates the checkout independently (validateFixPassTaskWorktreeHead, AllocateTaskWorktree lineage re-cut, daemon pre-flight 'checkout head is' + contention classifier). Production delta: internal/cli/agent_dispatch.go +39/-5. Tests: anchor census 7 (baseline -test.list count verified); mutation A (rebind reverted) fails exactly the 4 tests named for the new behavior while the 3 anchors pass; mutation B (event block removed) fails exactly the 2 event assertions. Acceptance 6 E2E drives a real finalizer push from an independent clone on an isolated /tmp home with shell-runtime agents, pins the stranded checkout, and shows the rebound review merging through the gate scenario. Gate: build/vet/generate clean; internal/workflow green; internal/cli green except 3 empty-home host confounds proven to fail identically on unmodified base 0b95ac2d. Draft PR not opened: job footer forbids commit/push and states Gitmoot delivers the changes.
````
