### PR TITLE
Gitmoot: IMPLEMENT gitmoot/gitmoot issue #1552 — "retire the #906/#930

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,6 @@ name: CI
 #     internal/db 2 ways, internal/workflow 4 ways, and internal/daemon 1 way. Each runner downloads
 #     the package bundle and executes from the package directory, preserving Go
 #     test-binary working-directory semantics without recompiling.
-#   - TIMINGS: PRs use the newest non-expired main timing artifact (up to 30
-#     days old) for deterministic LPT balancing. A PR's test set almost never
-#     matches main's exactly, so the timings are RECONCILED against the current
-#     test list (new tests weighted at the median, vanished rows dropped) rather
-#     than discarded — demanding an exact match meant LPT never ran (#930). Only a
-#     missing or corrupt artifact falls back loudly to Stage 1's deterministic
-#     alternation. Coverage never depends on the timings: the shard union is
-#     asserted against the compiled binary's own -test.list. Successful pushes to
-#     main publish fresh per-test timings for subsequent PRs.
 
 on:
   push:
@@ -53,7 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.diff.outputs.code }}
-      timings_run_id: ${{ steps.timings.outputs.timings_run_id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,46 +65,6 @@ jobs:
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
             echo "dep-only diff — race lanes will be skipped"
-          fi
-
-      - name: Find latest main race timings
-        id: timings
-        if: github.event_name == 'pull_request' && steps.diff.outputs.code == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          response="$RUNNER_TEMP/race-timing-artifacts.json"
-          if ! curl --fail --silent --show-error \
-            --header "Authorization: Bearer $GH_TOKEN" \
-            --header "Accept: application/vnd.github+json" \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/artifacts?name=race-test-timings&per_page=100" \
-            --output "$response"; then
-            echo "::warning::could not query main race timings; deterministic fallback will be used"
-            echo "timings_run_id=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          cutoff=$(date -u -d '30 days ago' '+%Y-%m-%dT%H:%M:%SZ')
-          if ! run_id=$(jq -r --arg cutoff "$cutoff" '
-            [
-              .artifacts[]
-              | select(.expired == false)
-              | select(.created_at >= $cutoff)
-              | select(.workflow_run.head_branch == "main")
-            ]
-            | sort_by(.created_at)
-            | last
-            | .workflow_run.id // empty
-          ' "$response"); then
-            echo "::warning::could not parse main race timing metadata; deterministic fallback will be used"
-            run_id=""
-          fi
-          echo "timings_run_id=$run_id" >> "$GITHUB_OUTPUT"
-          if [ -n "$run_id" ]; then
-            echo "using race timings from main workflow run $run_id"
-          else
-            echo "no fresh main race timing artifact; deterministic fallback will be used"
           fi
 
   build-test:
@@ -189,18 +139,6 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Download latest main race timings
-        id: download-timings
-        if: needs.changes.outputs.timings_run_id != ''
-        continue-on-error: true
-        uses: actions/download-artifact@v4
-        with:
-          name: race-test-timings
-          path: ${{ runner.temp }}/main-race-timings
-          github-token: ${{ github.token }}
-          repository: ${{ github.repository }}
-          run-id: ${{ needs.changes.outputs.timings_run_id }}
-
       - name: Compile once and partition
         env:
           PACKAGE: ${{ matrix.package }}
@@ -219,31 +157,10 @@ jobs:
             "$bundle/$PACKAGE.test" -test.list '.*'
           ) > "$bundle/tests.list"
 
-          args=(
-            --tests "$bundle/tests.list"
-            --shards "$SHARDS"
+          scripts/partition-race-tests.sh \
+            --tests "$bundle/tests.list" \
+            --shards "$SHARDS" \
             --out-dir "$bundle/partitions"
-          )
-          timings="$RUNNER_TEMP/main-race-timings/race-test-timings.tsv"
-          if [ -s "$timings" ]; then
-            args+=(--timings "$timings" --package "internal/$PACKAGE")
-          else
-            echo "main timings unavailable; using deterministic alternation"
-          fi
-
-          set +e
-          scripts/partition-race-tests.sh "${args[@]}"
-          status=$?
-          set -e
-          if [ "$status" -eq 2 ]; then
-            echo "::warning::main timings are missing or corrupt for internal/$PACKAGE; using deterministic alternation"
-            scripts/partition-race-tests.sh \
-              --tests "$bundle/tests.list" \
-              --shards "$SHARDS" \
-              --out-dir "$bundle/partitions"
-          elif [ "$status" -ne 0 ]; then
-            exit "$status"
-          fi
 
       - name: Upload race binary and shard plan
         uses: actions/upload-artifact@v4
@@ -308,75 +225,11 @@ jobs:
           total=$(wc -l < "$bundle/tests.list" | tr -d ' ')
           echo "running internal/$PACKAGE shard $SHARD: $count of $total tests"
 
-          timing="$RUNNER_TEMP/race-timing-$PACKAGE-$SHARD.json"
           (
             cd "internal/$PACKAGE"
             "$binary" \
               -test.v=test2json \
               -test.run="$run_regex" \
               -test.timeout=20m 2>&1 \
-              | "$test2json" -p "internal/$PACKAGE" -t \
-              | tee "$timing"
+              | "$test2json" -p "internal/$PACKAGE" -t
           )
-
-      - name: Upload raw per-test timings
-        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
-        with:
-          name: race-timing-${{ matrix.package }}-${{ matrix.shard }}
-          path: ${{ runner.temp }}/race-timing-${{ matrix.package }}-${{ matrix.shard }}.json
-          if-no-files-found: error
-          retention-days: 7
-
-  race-timings:
-    name: publish race timings
-    needs: race
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download raw timing shards
-        uses: actions/download-artifact@v4
-        with:
-          pattern: race-timing-*
-          path: ${{ runner.temp }}/race-timing-shards
-          merge-multiple: true
-
-      - name: Build per-test timing table
-        run: |
-          shopt -s nullglob
-          files=("$RUNNER_TEMP"/race-timing-shards/*.json)
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "no raw timing shards downloaded" >&2
-            exit 1
-          fi
-
-          jq -sr '
-            [
-              .[]
-              | select(
-                  (.Action == "pass" or .Action == "skip")
-                  and .Test != null
-                  and .Elapsed != null
-                )
-              | select((.Test | contains("/")) | not)
-              | select(.Test | test("^(Test|Fuzz|Example)"))
-              | [.Package, .Test, (.Elapsed | tostring)]
-            ]
-            | sort_by(.[0], .[1])
-            | .[]
-            | @tsv
-          ' "${files[@]}" > "$RUNNER_TEMP/race-test-timings.tsv"
-          if [ ! -s "$RUNNER_TEMP/race-test-timings.tsv" ]; then
-            echo "timing table is empty" >&2
-            exit 1
-          fi
-          awk -F '\t' '{ count[$1]++ } END { for (package in count) print package ": " count[package] " tests" }' \
-            "$RUNNER_TEMP/race-test-timings.tsv" | sort
-
-      - name: Publish main race timings
-        uses: actions/upload-artifact@v4
-        with:
-          name: race-test-timings
-          path: ${{ runner.temp }}/race-test-timings.tsv
-          if-no-files-found: error
-          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ go vet ./...
 go test -timeout 25m ./...
 
 # Race gate is scoped (not ./...). Use CI's package shard counts and its
-# deterministic fallback partitioner so no growing package hits one monolithic
+# deterministic alternating partitioner so no growing package hits one monolithic
 # timeout. Each compiled binary covers every package test exactly once.
 (
   set -e

--- a/scripts/partition-race-tests.sh
+++ b/scripts/partition-race-tests.sh
@@ -5,15 +5,12 @@ export LC_ALL=C
 
 usage() {
   cat <<'EOF'
-Usage: partition-race-tests.sh --tests FILE --shards N --out-dir DIR [--timings FILE --package NAME]
+Usage: partition-race-tests.sh --tests FILE --shards N --out-dir DIR
 
-Partitions the current top-level Go test list into N shards. With timings, it
-uses deterministic longest-processing-time-first balancing. Without timings,
-it uses the Stage 1 alternating split (line number modulo shard count).
+Partitions the current top-level Go test list into N shards using the
+deterministic alternating split (line number modulo shard count).
 
-Exit status 2 means the optional timings are malformed or do not exactly match
-the current test list. Callers may retry without --timings. Any coverage
-assertion failure uses status 1 and must remain a hard failure.
+Any coverage assertion failure uses status 1 and must remain a hard failure.
 EOF
 }
 
@@ -22,14 +19,7 @@ fail() {
   exit 1
 }
 
-timings_invalid() {
-  echo "partition-race-tests: unusable timings: $*" >&2
-  exit 2
-}
-
 tests_file=""
-timings_file=""
-package=""
 shards=""
 out_dir=""
 
@@ -38,16 +28,6 @@ while [[ $# -gt 0 ]]; do
     --tests)
       [[ $# -ge 2 ]] || fail "--tests requires a value"
       tests_file="$2"
-      shift 2
-      ;;
-    --timings)
-      [[ $# -ge 2 ]] || fail "--timings requires a value"
-      timings_file="$2"
-      shift 2
-      ;;
-    --package)
-      [[ $# -ge 2 ]] || fail "--package requires a value"
-      package="$2"
       shift 2
       ;;
     --shards)
@@ -74,9 +54,6 @@ done
 [[ -f "$tests_file" ]] || fail "test list does not exist: $tests_file"
 [[ "$shards" =~ ^[1-9][0-9]*$ ]] || fail "--shards must be a positive integer"
 [[ -n "$out_dir" ]] || fail "--out-dir is required"
-if [[ -n "$timings_file" && -z "$package" ]]; then
-  fail "--package is required with --timings"
-fi
 
 work_dir="$(mktemp -d "${TMPDIR:-/tmp}/gitmoot-race-partition.XXXXXX")"
 cleanup() { rm -rf "$work_dir"; }
@@ -128,115 +105,16 @@ for ((shard = 0; shard < shards; shard++)); do
   : >"$out_dir/shard-$shard.tests"
 done
 
+# Alternation: awk NR starts at one, so the first test goes to shard 1 (or
+# shard 0 when there is only one shard).
+awk -v shards="$shards" -v out="$out_dir" '
+  { print > (out "/shard-" (NR % shards) ".tests") }
+' "$current_tests"
 mode="alternation"
-if [[ -n "$timings_file" ]]; then
-  [[ -f "$timings_file" ]] || timings_invalid "file does not exist: $timings_file"
 
-  package_timings="$work_dir/package-timings"
-  if ! awk -F '\t' -v package="$package" '
-    NF != 3 { exit 1 }
-    $1 == "" || $2 == "" || $3 !~ /^[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?$/ { exit 1 }
-    $1 == package { print $2 "\t" $3 }
-  ' "$timings_file" >"$package_timings"; then
-    timings_invalid "expected tab-separated package, test, elapsed rows"
-  fi
-  [[ -s "$package_timings" ]] || timings_invalid "no rows for package $package"
-
-  timing_names="$work_dir/timing-names.sorted"
-  cut -f1 "$package_timings" | sort >"$timing_names"
-  timing_duplicates="$work_dir/timing-names.duplicates"
-  uniq -d "$timing_names" >"$timing_duplicates"
-
-  # A duplicate row makes a test's weight ambiguous — that is a corrupt artifact,
-  # not a stale one, so it stays fatal.
-  if [[ -s "$timing_duplicates" ]]; then
-    echo "partition-race-tests: unusable timings: duplicate rows for package $package" >&2
-    sed 's/^/    /' "$timing_duplicates" >&2
-    exit 2
-  fi
-
-  # RECONCILE the timings against the CURRENT test list rather than demanding they
-  # match it (#930). Requiring an exact match meant any PR that added, renamed, or
-  # deleted a single test fell back to alternation — which is nearly every PR, so
-  # LPT balancing effectively never ran. Instead:
-  #   - a test with a recorded time keeps it;
-  #   - a test that is NEW here (no recorded time) gets the median of the known
-  #     times, so it is scheduled as a typical test rather than a free one;
-  #   - a recorded time for a test that no longer exists is dropped.
-  # Coverage is guaranteed downstream regardless: the shard-union assertion below
-  # compares the partition against the compiled binary's own -test.list, so a
-  # stale artifact can never drop or duplicate a test.
-  missing="$work_dir/timing-names.missing"
-  unknown="$work_dir/timing-names.unknown"
-  comm -23 "$sorted_tests" "$timing_names" >"$missing"
-  comm -13 "$sorted_tests" "$timing_names" >"$unknown"
-
-  reconciled="$work_dir/package-timings.reconciled"
-  awk -F '\t' -v current="$sorted_tests" '
-    BEGIN {
-      while ((getline line < current) > 0) {
-        if (line != "") present[line] = 1
-      }
-      close(current)
-    }
-    # keep only rows for tests that still exist
-    ($1 in present) { recorded[$1] = $2; n++; times[n] = $2 + 0 }
-    END {
-      # median of the known times is the weight for tests we have never timed
-      default_weight = 0
-      if (n > 0) {
-        # insertion sort: n is a few thousand at most, and this keeps the script
-        # dependency-free (no sort subprocess mid-stream).
-        for (i = 2; i <= n; i++) {
-          v = times[i]
-          for (j = i - 1; j >= 1 && times[j] > v; j--) times[j + 1] = times[j]
-          times[j + 1] = v
-        }
-        default_weight = (n % 2) ? times[(n + 1) / 2] : (times[n / 2] + times[n / 2 + 1]) / 2
-      }
-      while ((getline test < current) > 0) {
-        if (test == "") continue
-        print test "\t" ((test in recorded) ? recorded[test] : default_weight)
-      }
-      close(current)
-    }
-  ' "$package_timings" >"$reconciled"
-  package_timings="$reconciled"
-
-  new_count=$(grep -c . "$missing" || true)
-  dropped_count=$(grep -c . "$unknown" || true)
-  if [[ "$new_count" -gt 0 || "$dropped_count" -gt 0 ]]; then
-    echo "partition-race-tests: reconciled timings for $package: ${new_count} new test(s) weighted at the median, ${dropped_count} stale row(s) dropped" >&2
-  fi
-
-  # LPT: longest tests first, test name as the stable duration tiebreak, then
-  # assign to the lowest-load shard (lowest shard number breaks load ties).
-  sorted_timings="$work_dir/package-timings.sorted"
-  sort -t $'\t' -k2,2gr -k1,1 "$package_timings" >"$sorted_timings"
-  awk -F '\t' -v shards="$shards" -v out="$out_dir" '
-    BEGIN {
-      for (i = 0; i < shards; i++) load[i] = 0
-    }
-    {
-      selected = 0
-      for (i = 1; i < shards; i++) {
-        if (load[i] < load[selected]) selected = i
-      }
-      print $1 >> (out "/shard-" selected ".tests")
-      load[selected] += $2
-    }
-  ' "$sorted_timings"
-  mode="lpt"
-else
-  # Preserve Stage 1 exactly: awk NR starts at one, so the first test goes to
-  # shard 1 (or shard 0 when there is only one shard).
-  awk -v shards="$shards" -v out="$out_dir" '
-    { print > (out "/shard-" (NR % shards) ".tests") }
-  ' "$current_tests"
-fi
-
-# Coverage is checked from the current package list, never from the timings.
-# A coverage mismatch is status 1 so CI cannot turn it into a timing fallback.
+# Coverage is checked from the current package list: every test must be
+# assigned to exactly one shard, with no extras. A coverage mismatch is
+# status 1 and must remain a hard failure.
 assigned="$work_dir/assigned"
 for ((shard = 0; shard < shards; shard++)); do
   cat "$out_dir/shard-$shard.tests" >>"$assigned"

--- a/scripts/partition-race-tests_test.sh
+++ b/scripts/partition-race-tests_test.sh
@@ -32,88 +32,13 @@ ok  	example/package	0.001s
 EOF
 grep '^Test' "$WORK/tests.list" | sort >"$WORK/expected.sorted"
 
-# Deliberately shuffled; equal durations prove test-name tie-breaking.
-cat >"$WORK/timings.tsv" <<'EOF'
-example/package	TestGamma	4
-example/package	TestEpsilon	1
-example/package	TestBeta	10
-example/package	TestDelta	4
-example/package	TestAlpha	10
-EOF
-
-"$PARTITION" \
-  --tests "$WORK/tests.list" \
-  --timings "$WORK/timings.tsv" \
-  --package example/package \
-  --shards 2 \
-  --out-dir "$WORK/lpt-one"
-assert_coverage "$WORK/lpt-one"
-[[ "$(cat "$WORK/lpt-one/mode")" == "lpt" ]] || fail "timed partition did not select LPT"
-diff -u <(printf 'TestAlpha\nTestDelta\nTestEpsilon\n') "$WORK/lpt-one/shard-0.tests"
-diff -u <(printf 'TestBeta\nTestGamma\n') "$WORK/lpt-one/shard-1.tests"
-
-"$PARTITION" \
-  --tests "$WORK/tests.list" \
-  --timings "$WORK/timings.tsv" \
-  --package example/package \
-  --shards 2 \
-  --out-dir "$WORK/lpt-two" >/dev/null
-diff -ru "$WORK/lpt-one" "$WORK/lpt-two"
-
 "$PARTITION" \
   --tests "$WORK/tests.list" \
   --shards 2 \
-  --out-dir "$WORK/fallback" >/dev/null
-assert_coverage "$WORK/fallback"
-[[ "$(cat "$WORK/fallback/mode")" == "alternation" ]] || fail "missing timings did not select alternation"
-diff -u <(printf 'TestBeta\nTestDelta\n') "$WORK/fallback/shard-0.tests"
-diff -u <(printf 'TestAlpha\nTestGamma\nTestEpsilon\n') "$WORK/fallback/shard-1.tests"
-
-# A PARTIALLY stale artifact is the normal case, not an error: nearly every PR
-# adds, renames, or deletes a test. Demanding an exact match meant LPT balancing
-# effectively never ran (#930). The timings must be reconciled against the current
-# list instead — new tests weighted at the median, vanished rows dropped — and the
-# partition must still balance and still cover every test exactly once.
-cat >"$WORK/stale.tsv" <<'EOF'
-example/package	TestAlpha	10
-example/package	TestBeta	9
-example/package	TestGamma	8
-example/package	TestDelta	7
-example/package	TestRemoved	6
-EOF
-"$PARTITION" \
-  --tests "$WORK/tests.list" \
-  --timings "$WORK/stale.tsv" \
-  --package example/package \
-  --shards 2 \
-  --out-dir "$WORK/stale" >"$WORK/stale.stdout" 2>"$WORK/stale.stderr"
-assert_coverage "$WORK/stale"
-[[ "$(cat "$WORK/stale/mode")" == "lpt" ]] || fail "a partially stale artifact fell back to $(cat "$WORK/stale/mode"); LPT must still run"
-grep -q 'reconciled timings' "$WORK/stale.stderr" || fail "reconciliation was not reported"
-grep -q '1 new test(s)' "$WORK/stale.stderr" || fail "the new test was not counted"
-grep -q '1 stale row(s) dropped' "$WORK/stale.stderr" || fail "the vanished test's row was not dropped"
-# TestEpsilon is new here: it must be scheduled at the median of the known times
-# (8), not as a free test — a zero-weight test would pile onto the loaded shard.
-grep -qx 'TestEpsilon' "$WORK/stale/shard-0.tests" "$WORK/stale/shard-1.tests" ||
-  fail "the new test was not assigned to any shard"
-
-# A duplicate row makes a test's weight ambiguous: that is a CORRUPT artifact, not
-# a stale one, and must stay fatal rather than silently pick a weight.
-cat >"$WORK/dupe.tsv" <<'EOF'
-example/package	TestAlpha	10
-example/package	TestAlpha	3
-example/package	TestBeta	9
-EOF
-set +e
-"$PARTITION" \
-  --tests "$WORK/tests.list" \
-  --timings "$WORK/dupe.tsv" \
-  --package example/package \
-  --shards 2 \
-  --out-dir "$WORK/dupe" >"$WORK/dupe.stdout" 2>"$WORK/dupe.stderr"
-status=$?
-set -e
-[[ "$status" -eq 2 ]] || fail "duplicate timing rows returned $status, want 2"
-grep -q 'duplicate rows' "$WORK/dupe.stderr" || fail "duplicate rows were not reported"
+  --out-dir "$WORK/alternation" >/dev/null
+assert_coverage "$WORK/alternation"
+[[ "$(cat "$WORK/alternation/mode")" == "alternation" ]] || fail "partition did not select alternation"
+diff -u <(printf 'TestBeta\nTestDelta\n') "$WORK/alternation/shard-0.tests"
+diff -u <(printf 'TestAlpha\nTestGamma\nTestEpsilon\n') "$WORK/alternation/shard-1.tests"
 
 echo "partition-race-tests test: PASS"


### PR DESCRIPTION
WHAT:
Retired the #906/#930 per-test timing + LPT machinery per issue #1552. Deleted: ci.yml 'Upload raw per-test timings' step, the entire race-timings publish job, the changes job's timings_run_id output + 'Find latest main race timings' step, the race-build 'Download latest main race timings' step, the timings/exit-2 block in 'Compile once and partition' (now ONE unconditional call with --tests/--shards/--out-dir, ci.yml:160-163), and the TIMINGS header paragraph. Also removed the `tee "$timing"` in the race-run step (ci.yml:228-235) — its only consumer was the deleted upload step; noted since it was not on the explicit REMOVE list. partition-race-tests.sh: removed --timings/--package flags, timings_invalid + exit-2 semantics, and the reconcile+LPT branch; alternation awk and coverage assertion untouched (coverage block now at scripts/partition-race-tests.sh:118-137). partition-race-tests_test.sh: removed LPT/reconcile/duplicate cases, kept the alternation case (renamed out-dir 'fallback'->'alternation'). KEPT intact: both shard matrices (cli×8/pipeline×4/db×2/workflow×4/daemon×1; 19 race-run entries), compile -> -test.list -> -race lanes, alternation awk, coverage assertion, and the #1554 '-timeout 25m' (ci.yml:110, verified by read-back). ACCEPTANCE EVIDENCE: (1) scripts/partition-race-tests_test.sh -> 'partition-race-tests test: PASS'. (2) FAIL-CLOSED MUTATION PROVEN: extracted the coverage block verbatim (sed -n '118,137p', anchor census: 'COVERAGE ASSERTION FAILED' occurs exactly 1x in the script; repo tree never mutated — shards doctored in /tmp scratch only). Command: /tmp/coverage-mutation-harness.sh (wraps the extracted block; control run on pristine shards exited 0; then dropped TestBeta from shard-0.tests). Mutated exit code: 1, message: 'partition-race-tests: COVERAGE ASSERTION FAILED / tests not assigned: / TestBeta'. (An earlier harness attempt reused its work dir across control+mutation runs so the block fired on stale appended state — confounded, discarded; final run used fresh work dirs per invocation and the assertion fired solely on the dropped test.) (3) Check count: changes(1)+build-test(1)+race-build(5)+race(19)=26 on PRs; main pushes previously had 27 (the removed race-timings job was the 27th, main-only). Union counts before vs after (old script from git HEAD vs new script, same tests.list per package, CI shard counts): cli 2161->2161, pipeline 105->105, db 362->362, workflow 776->776, daemon 130->130 (total 3534); assignment lists byte-identical via diff, so no test silently dropped or moved. (4) Lines removed per file (git diff --numstat, +/-): ci.yml +4/-151, partition-race-tests.sh +12/-134, partition-race-tests_test.sh +5/-80; total 21 insertions, 365 deletions (issue estimated ~300-330; the extra ~35 is the tee removal, the usage/comment rewrite, and the test-file rewrite). (5) ci.yml parses: python3 yaml.safe_load OK; resolved Test step run line read back as 'go test -timeout 25m ./...' (ci.yml:110). Also: go build ./... && go vet ./... OK; AGENTS.md race-gate recipe already uses only base args, no doc update needed; grep confirms zero remaining 'timing'/'lpt' references in ci.yml and the scripts.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-27caa166

RESULTS:
- scripts/partition-race-tests_test.sh -> PASS
- fail-closed mutation: dropped TestBeta from generated shard-0.tests, extracted coverage block exited 1 with 'COVERAGE ASSERTION FAILED / tests not assigned: TestBeta' (control on pristine shards exited 0; anchor census 1)
- union-count comparison old (git HEAD) vs new script on real per-package go test -list output: 3534 tests, identical unions and byte-identical assignments for all 5 packages
- python3 yaml.safe_load(.github/workflows/ci.yml) -> OK
- go build ./... && go vet ./... -> OK (no Go code changed; smoke only)

RISK:
Review the generated diff before merging.

TASK:
adhoc-27caa166

AGENTS:
- wave-impl-b

RAW FINAL REVIEW OUTPUT:
````text
Retired the #906/#930 per-test timing + LPT machinery per issue #1552. Deleted: ci.yml 'Upload raw per-test timings' step, the entire race-timings publish job, the changes job's timings_run_id output + 'Find latest main race timings' step, the race-build 'Download latest main race timings' step, the timings/exit-2 block in 'Compile once and partition' (now ONE unconditional call with --tests/--shards/--out-dir, ci.yml:160-163), and the TIMINGS header paragraph. Also removed the `tee "$timing"` in the race-run step (ci.yml:228-235) — its only consumer was the deleted upload step; noted since it was not on the explicit REMOVE list. partition-race-tests.sh: removed --timings/--package flags, timings_invalid + exit-2 semantics, and the reconcile+LPT branch; alternation awk and coverage assertion untouched (coverage block now at scripts/partition-race-tests.sh:118-137). partition-race-tests_test.sh: removed LPT/reconcile/duplicate cases, kept the alternation case (renamed out-dir 'fallback'->'alternation'). KEPT intact: both shard matrices (cli×8/pipeline×4/db×2/workflow×4/daemon×1; 19 race-run entries), compile -> -test.list -> -race lanes, alternation awk, coverage assertion, and the #1554 '-timeout 25m' (ci.yml:110, verified by read-back). ACCEPTANCE EVIDENCE: (1) scripts/partition-race-tests_test.sh -> 'partition-race-tests test: PASS'. (2) FAIL-CLOSED MUTATION PROVEN: extracted the coverage block verbatim (sed -n '118,137p', anchor census: 'COVERAGE ASSERTION FAILED' occurs exactly 1x in the script; repo tree never mutated — shards doctored in /tmp scratch only). Command: /tmp/coverage-mutation-harness.sh (wraps the extracted block; control run on pristine shards exited 0; then dropped TestBeta from shard-0.tests). Mutated exit code: 1, message: 'partition-race-tests: COVERAGE ASSERTION FAILED / tests not assigned: / TestBeta'. (An earlier harness attempt reused its work dir across control+mutation runs so the block fired on stale appended state — confounded, discarded; final run used fresh work dirs per invocation and the assertion fired solely on the dropped test.) (3) Check count: changes(1)+build-test(1)+race-build(5)+race(19)=26 on PRs; main pushes previously had 27 (the removed race-timings job was the 27th, main-only). Union counts before vs after (old script from git HEAD vs new script, same tests.list per package, CI shard counts): cli 2161->2161, pipeline 105->105, db 362->362, workflow 776->776, daemon 130->130 (total 3534); assignment lists byte-identical via diff, so no test silently dropped or moved. (4) Lines removed per file (git diff --numstat, +/-): ci.yml +4/-151, partition-race-tests.sh +12/-134, partition-race-tests_test.sh +5/-80; total 21 insertions, 365 deletions (issue estimated ~300-330; the extra ~35 is the tee removal, the usage/comment rewrite, and the test-file rewrite). (5) ci.yml parses: python3 yaml.safe_load OK; resolved Test step run line read back as 'go test -timeout 25m ./...' (ci.yml:110). Also: go build ./... && go vet ./... OK; AGENTS.md race-gate recipe already uses only base args, no doc update needed; grep confirms zero remaining 'timing'/'lpt' references in ci.yml and the scripts.
````
