### PR TITLE
Gitmoot: IMPLEMENT gitmoot/gitmoot issue #1560 — "job-associated subprocess routes

### DIFF
--- a/internal/cli/agent_action_fixpass_793_test.go
+++ b/internal/cli/agent_action_fixpass_793_test.go
@@ -576,7 +576,7 @@ func TestDaemonImplementationFinalizerPrefersValidatedPullRequest(t *testing.T) 
 		ValidatedPullRequest: true, HeadSHA: fixture.headSHA, TaskID: fixture.task.ID,
 		Result: &workflow.AgentResult{Decision: "implemented", Summary: "fix pass complete"},
 	}
-	finalized, err := (daemonImplementationFinalizer{Store: fixture.store, GitHub: gh}).FinalizeImplementation(ctx, db.Job{ID: "fix-pass", Agent: "lead", Type: "implement"}, payload)
+	finalized, err := (newHostDaemonImplementationFinalizer(fixture.store, gh)).FinalizeImplementation(ctx, db.Job{ID: "fix-pass", Agent: "lead", Type: "implement"}, payload)
 	if err != nil {
 		t.Fatalf("FinalizeImplementation: %v", err)
 	}
@@ -610,7 +610,7 @@ func TestDaemonImplementationFinalizerPayloadlessUsesBranchFallback(t *testing.T
 		Repo: "owner/repo", Branch: fixture.task.Branch, TaskID: fixture.task.ID,
 		Result: &workflow.AgentResult{Decision: "implemented", Summary: "ordinary implementation"},
 	}
-	finalized, err := (daemonImplementationFinalizer{Store: fixture.store, GitHub: gh}).FinalizeImplementation(ctx, db.Job{ID: "ordinary", Agent: "lead", Type: "implement"}, payload)
+	finalized, err := (newHostDaemonImplementationFinalizer(fixture.store, gh)).FinalizeImplementation(ctx, db.Job{ID: "ordinary", Agent: "lead", Type: "implement"}, payload)
 	if err != nil {
 		t.Fatalf("FinalizeImplementation: %v", err)
 	}
@@ -647,7 +647,7 @@ func TestDaemonImplementationFinalizerRevalidatesBoundPullRequest(t *testing.T) 
 				ValidatedPullRequest: true, HeadSHA: fixture.headSHA, TaskID: fixture.task.ID,
 				Result: &workflow.AgentResult{Decision: "implemented", Summary: "fix pass complete"},
 			}
-			_, err := (daemonImplementationFinalizer{Store: fixture.store, GitHub: gh}).FinalizeImplementation(context.Background(), db.Job{ID: "fix-pass", Agent: "lead", Type: "implement"}, payload)
+			_, err := (newHostDaemonImplementationFinalizer(fixture.store, gh)).FinalizeImplementation(context.Background(), db.Job{ID: "fix-pass", Agent: "lead", Type: "implement"}, payload)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("FinalizeImplementation error = %v, want %q", err, tt.want)
 			}

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -176,19 +176,11 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	var foregroundAdapterFactory foregroundRuntimeAdapterFactory
 	execBackend, err := localAgentDispatchExecBackendFor(request.Home)
 	if err != nil {
-		if !request.Background {
-			return localAgentJobOutput{}, err
-		}
-		// Preserve background dispatch's durable fail-loud contract: invalid
-		// configuration is recorded by the claiming worker on the queued job. The
-		// ingress-only checkout preparation is explicitly host-side in this case;
-		// the invalid selection can never reach job execution.
-		request.jobRunner = subprocess.ExecRunner{}
-	} else {
-		request.jobRunner, err = jobSubprocessRunnerForBackend(execBackend)
-		if err != nil {
-			return localAgentJobOutput{}, err
-		}
+		return localAgentJobOutput{}, err
+	}
+	request.jobRunner, err = jobSubprocessRunnerForBackend(execBackend)
+	if err != nil {
+		return localAgentJobOutput{}, err
 	}
 	if !request.Background {
 		foregroundAdapterFactory, err = foregroundRuntimeAdapterFactoryFor(execBackend)

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -18,6 +18,7 @@ import (
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -124,6 +125,17 @@ type localAgentDispatchRequest struct {
 	// without the required audit. It is set by prepareLocalReviewTask and never
 	// persisted in the job payload.
 	ReviewTaskHeadDivergence string
+	jobRunner                subprocess.Runner
+}
+
+func localDispatchJobRunner(request localAgentDispatchRequest) subprocess.Runner {
+	if request.jobRunner != nil {
+		return request.jobRunner
+	}
+	// Direct helper callers are operator-side setup and tests, not admitted job
+	// execution. dispatchLocalAgentJob always installs the resolved backend runner
+	// before reaching these helpers.
+	return subprocess.ExecRunner{}
 }
 
 var promptCommitTokenRE = regexp.MustCompile(`\b[0-9a-fA-F]{7,64}\b`)
@@ -157,19 +169,29 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if err != nil {
 		return localAgentJobOutput{}, err
 	}
-	// Foreground dispatch bypasses jobWorker.run, so resolve its execution
-	// backend here before any durable dispatch state or runtime side effect. The
-	// background path deliberately leaves resolution to the claiming worker,
-	// which records a loud terminal failure for an invalid queued selection.
+	// Dispatch performs checkout and git preparation before enqueue, so resolve
+	// the execution backend before any of those job-associated subprocesses.
+	// The claiming worker resolves it again from the durable payload/config at
+	// execution time; this ingress decision governs only pre-enqueue work.
 	var foregroundAdapterFactory foregroundRuntimeAdapterFactory
-	var foregroundExecBackend execbackend.Backend
-	if !request.Background {
-		var resolveErr error
-		foregroundExecBackend, resolveErr = localAgentDispatchExecBackendFor(request.Home)
-		if resolveErr != nil {
-			return localAgentJobOutput{}, resolveErr
+	execBackend, err := localAgentDispatchExecBackendFor(request.Home)
+	if err != nil {
+		if !request.Background {
+			return localAgentJobOutput{}, err
 		}
-		foregroundAdapterFactory, err = foregroundRuntimeAdapterFactoryFor(foregroundExecBackend)
+		// Preserve background dispatch's durable fail-loud contract: invalid
+		// configuration is recorded by the claiming worker on the queued job. The
+		// ingress-only checkout preparation is explicitly host-side in this case;
+		// the invalid selection can never reach job execution.
+		request.jobRunner = subprocess.ExecRunner{}
+	} else {
+		request.jobRunner, err = jobSubprocessRunnerForBackend(execBackend)
+		if err != nil {
+			return localAgentJobOutput{}, err
+		}
+	}
+	if !request.Background {
+		foregroundAdapterFactory, err = foregroundRuntimeAdapterFactoryFor(execBackend)
 		if err != nil {
 			return localAgentJobOutput{}, err
 		}
@@ -236,7 +258,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			}
 		}
 		if base != "" {
-			request.ImplementBase, err = resolveLocalImplementBase(ctx, paths, record, base)
+			request.ImplementBase, err = resolveLocalImplementBaseForRunner(ctx, paths, record, base, localDispatchJobRunner(request))
 			if err != nil {
 				return localAgentJobOutput{}, err
 			}
@@ -297,14 +319,14 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		// workflow engine also owns job-associated subprocesses (produce checks and
 		// result observation). Stamp the same resolved decision on the effective
 		// foreground agent so those routes cannot silently default back to Local.
-		effectiveAgent.ExecBackend = string(foregroundExecBackend)
+		effectiveAgent.ExecBackend = string(execBackend)
 	}
 	if readOnlyImplementationBlocked(request.Action, effectiveAgent) {
 		return enqueuePermissionBlockedLocalAgentJob(ctx, store, request, repo.FullName(), record.DefaultBranch, agent.Name, overrideRuntime, overrideRef, orgPolicy)
 	}
 	var foregroundContract *runtime.RuntimeContractResult
 	if !request.Background {
-		result, err := runtimeContractPreflightForBackend(foregroundExecBackend, func() runtime.RuntimeContractResult {
+		result, err := runtimeContractPreflightForBackend(execBackend, func() runtime.RuntimeContractResult {
 			return localRuntimeContractPreflight(ctx, effectiveAgent)
 		})
 		if err != nil {
@@ -342,7 +364,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		// the canonical checkout with its inherited dispatch head before its
 		// committed-tip worktree clears that head. Only review scans its newly
 		// allocated exact-head checkout below.
-		promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, gitutil.Client{Dir: checkoutPath}, request.Instructions, request.HeadSHA)
+		promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, jobGitClient(checkoutPath, localDispatchJobRunner(request)), request.Instructions, request.HeadSHA)
 	}
 	// A --recipe routes this coordinator to a named built-in recipe template's
 	// prompt (resolved from the installed-template store) without rebinding the
@@ -373,7 +395,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			return localAgentJobOutput{}, errors.New("allocate exact-head review worktree: no worktree was allocated")
 		}
 		checkoutPath = readOnlyWorktreePath
-		promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, gitutil.Client{Dir: checkoutPath}, request.Instructions, request.HeadSHA)
+		promptHeadWarnings = dispatchPromptHeadContradictionWarnings(ctx, jobGitClient(checkoutPath, localDispatchJobRunner(request)), request.Instructions, request.HeadSHA)
 	}
 	if readOnlyWorktreePath != "" {
 		if request.Action != "review" {
@@ -444,7 +466,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		// from the (possibly cancelled) request context so removal still runs; the
 		// reactive pool-isolation path defends its own allocation the same way.
 		if readOnlyWorktreePath != "" {
-			_ = gitutil.Client{Dir: record.CheckoutPath}.RemoveWorktreeForce(context.WithoutCancel(ctx), readOnlyWorktreePath)
+			_ = jobGitClient(record.CheckoutPath, localDispatchJobRunner(request)).RemoveWorktreeForce(context.WithoutCancel(ctx), readOnlyWorktreePath)
 		}
 		return localAgentJobOutput{}, err
 	}
@@ -610,7 +632,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		handled := false
 		if overrideRuntime == "" {
 			var abErr error
-			handled, abErr = maybeRunLiveAB(runCtx, store, request, agent, job, adapter, managed.OK, foregroundExecBackend)
+			handled, abErr = maybeRunLiveAB(runCtx, store, request, agent, job, adapter, managed.OK, execBackend)
 			if abErr != nil {
 				recordRuntimeOutcome(abErr)
 				return localAgentJobOutput{}, foregroundAskTimeoutError(runCtx, jobTimeout, abErr)
@@ -635,7 +657,7 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 		if paths, err := pathsFromFlag(request.Home); err == nil {
 			workflowHome = paths.Home
 		}
-		engine := daemonWorkflowEngine(store, newAgentDispatchGitHubClient(checkoutPath), checkoutPath, workflowHome)
+		engine := daemonWorkflowEngineForRunner(store, newAgentDispatchGitHubClient(checkoutPath), checkoutPath, workflowHome, localDispatchJobRunner(request))
 		if _, err := engine.RunJob(runCtx, job.ID, effectiveAgent, adapter); err != nil {
 			if out, ok, _ := recoverAdvanceErrorOutput(ctx, store, job.ID, request, err); ok {
 				recordRuntimeOutcome(nil)
@@ -919,7 +941,7 @@ func prepareLocalReviewTask(ctx context.Context, store *db.Store, repo github.Re
 				return localAgentDispatchRequest{}, disposedReviewTaskError(task)
 			}
 			if strings.TrimSpace(task.WorktreePath) != "" {
-				head, headErr := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
+				head, headErr := jobGitClient(task.WorktreePath, localDispatchJobRunner(request)).HeadSHA(ctx)
 				if headErr != nil {
 					return localAgentDispatchRequest{}, headErr
 				}
@@ -1008,7 +1030,7 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 	baseSHA := strings.TrimSpace(request.ImplementBase)
 	deferImplicitPRBase := request.PullRequest > 0 && !request.ImplementBaseResolved && baseSHA == ""
 	if !request.ImplementBaseResolved && !deferImplicitPRBase {
-		baseSHA, err = resolveLocalImplementBase(ctx, paths, record, baseSHA)
+		baseSHA, err = resolveLocalImplementBaseForRunner(ctx, paths, record, baseSHA, localDispatchJobRunner(request))
 		if err != nil {
 			return db.Task{}, localAgentDispatchRequest{}, err
 		}
@@ -1043,7 +1065,7 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 					Number:  int64(request.PullRequest),
 					HeadRef: branchHint,
 					HeadSHA: request.HeadSHA,
-				}); err != nil {
+				}, localDispatchJobRunner(request)); err != nil {
 					return db.Task{}, localAgentDispatchRequest{}, err
 				}
 			}
@@ -1059,13 +1081,13 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 			if strings.TrimSpace(existing.WorktreePath) != "" && taskWorktreeHasLiveProcess(existing.WorktreePath) {
 				return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("branch %s has a live process still inside task worktree %s; wait for it to exit or stop the orphaned implementer before retrying implement", branchHint, existing.WorktreePath)
 			}
-			if dirty, err := taskWorktreeDirty(ctx, existing); err != nil {
+			if dirty, err := taskWorktreeDirtyWithRunner(ctx, existing, localDispatchJobRunner(request)); err != nil {
 				return db.Task{}, localAgentDispatchRequest{}, err
 			} else if dirty {
 				if baseSHA != "" {
 					handled, blockErr := (workflow.Engine{Store: store}).ReconcileDirtyTaskWorktreeLineage(
 						ctx,
-						gitutil.Client{Dir: record.CheckoutPath},
+						jobGitClient(record.CheckoutPath, localDispatchJobRunner(request)),
 						existing,
 						existing.WorktreePath,
 						baseSHA,
@@ -1126,7 +1148,7 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 			return db.Task{}, localAgentDispatchRequest{}, pathErr
 		}
 		if task.Branch != branch || strings.TrimSpace(task.WorktreePath) == "" || task.WorktreePath != expectedWorktree {
-			baseSHA, err = resolveLocalImplementBase(ctx, paths, record, "")
+			baseSHA, err = resolveLocalImplementBaseForRunner(ctx, paths, record, "", localDispatchJobRunner(request))
 			if err != nil {
 				return db.Task{}, localAgentDispatchRequest{}, err
 			}
@@ -1144,11 +1166,11 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 		LineageUnknown: deferImplicitPRBase && baseSHA == "",
 		Owner:          owner,
 		Checkout:       record.CheckoutPath,
-	}, gitutil.Client{Dir: record.CheckoutPath})
+	}, jobGitClient(record.CheckoutPath, localDispatchJobRunner(request)))
 	if err != nil {
 		return db.Task{}, localAgentDispatchRequest{}, err
 	}
-	headSHA, err := (gitutil.Client{Dir: started.WorktreePath}).HeadSHA(ctx)
+	headSHA, err := jobGitClient(started.WorktreePath, localDispatchJobRunner(request)).HeadSHA(ctx)
 	if err != nil {
 		return db.Task{}, localAgentDispatchRequest{}, fmt.Errorf("resolve task worktree head: %w", err)
 	}
@@ -1199,7 +1221,7 @@ func bindLocalImplementRequestToPullRequest(ctx context.Context, store *db.Store
 	case workflow.TaskAwaitingHumanMerge:
 		return localAgentDispatchRequest{}, fmt.Errorf("task %s is awaiting a human merge decision; implement fix-pass is refused until it resolves", task.ID)
 	}
-	if err := validateFixPassTaskWorktreeHead(ctx, task, pr); err != nil {
+	if err := validateFixPassTaskWorktreeHead(ctx, task, pr, localDispatchJobRunner(request)); err != nil {
 		return localAgentDispatchRequest{}, err
 	}
 	request.Branch = headBranch
@@ -1210,7 +1232,7 @@ func bindLocalImplementRequestToPullRequest(ctx context.Context, store *db.Store
 	return request, nil
 }
 
-func validateFixPassTaskWorktreeHead(ctx context.Context, task db.Task, pr github.PullRequest) error {
+func validateFixPassTaskWorktreeHead(ctx context.Context, task db.Task, pr github.PullRequest, runner subprocess.Runner) error {
 	path := strings.TrimSpace(task.WorktreePath)
 	expectedBranch := strings.TrimSpace(pr.HeadRef)
 	expectedHead := strings.TrimSpace(pr.HeadSHA)
@@ -1221,7 +1243,7 @@ func validateFixPassTaskWorktreeHead(ctx context.Context, task db.Task, pr githu
 	if expectedHead == "" {
 		return fmt.Errorf("pull request #%d returned no head SHA; cannot prove task worktree %s is current; %s", pr.Number, path, guidance)
 	}
-	git := gitutil.Client{Dir: path}
+	git := jobGitClient(path, runner)
 	branch, err := git.CurrentBranch(ctx)
 	if err != nil {
 		return fmt.Errorf("inspect task worktree branch for pull request #%d: %w; %s", pr.Number, err, guidance)
@@ -1240,6 +1262,10 @@ func validateFixPassTaskWorktreeHead(ctx context.Context, task db.Task, pr githu
 // start from. A CLI value wins over [workflow].implement_base. With neither set,
 // HEAD preserves checkout-following behavior after the stale-feature guard.
 func resolveLocalImplementBase(ctx context.Context, paths config.Paths, record db.Repo, requested string) (string, error) {
+	return resolveLocalImplementBaseForRunner(ctx, paths, record, requested, subprocess.ExecRunner{})
+}
+
+func resolveLocalImplementBaseForRunner(ctx context.Context, paths config.Paths, record db.Repo, requested string, runner subprocess.Runner) (string, error) {
 	base := strings.TrimSpace(requested)
 	if base == "" {
 		configured, err := config.LoadImplementBase(paths)
@@ -1248,7 +1274,7 @@ func resolveLocalImplementBase(ctx context.Context, paths config.Paths, record d
 		}
 		base = strings.TrimSpace(configured)
 	}
-	git := gitutil.Client{Dir: record.CheckoutPath}
+	git := jobGitClient(record.CheckoutPath, runner)
 	if base == "" {
 		if err := guardImplicitImplementBase(ctx, git, record.DefaultBranch); err != nil {
 			return "", err
@@ -1689,7 +1715,7 @@ func resolveLocalAgentRepo(ctx context.Context, store *db.Store, repoFlag string
 	// This prevents an ephemeral cwd from becoming repo.CheckoutPath without
 	// silently rebasing local ask/review behavior onto the stored default branch.
 	if strings.TrimSpace(repoFlag) == "" {
-		if cwdRecord, cwdErr := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: "."}); cwdErr == nil {
+		if cwdRecord, cwdErr := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(".")); cwdErr == nil {
 			record.DefaultBranch = cwdRecord.DefaultBranch
 		}
 	}
@@ -1700,7 +1726,7 @@ func localAgentTargetRepo(ctx context.Context, repoFlag string) (github.Reposito
 	if strings.TrimSpace(repoFlag) != "" {
 		return daemon.ParseRepository(repoFlag)
 	}
-	remote, err := (gitutil.Client{Dir: "."}).OriginRemote(ctx)
+	remote, err := (gitutil.NewHostClient(".")).OriginRemote(ctx)
 	if err != nil {
 		return github.Repository{}, fmt.Errorf("infer repo from current checkout: %w", err)
 	}
@@ -1772,7 +1798,7 @@ func maybeAllocateDispatchReadOnlyWorktree(ctx context.Context, store *db.Store,
 			return "", errors.New("review read-only worktree requires a head SHA")
 		}
 	}
-	git := gitutil.Client{Dir: checkout}
+	git := jobGitClient(checkout, localDispatchJobRunner(request))
 	path, err := allocateDispatchReadOnlyWorktree(ctx, store, paths.Home, repo, checkout, jobID, "readonly-seat", 0, baseRef, workflow.ReadOnlyWorktreeDispatchLockWaitBudget, git)
 	if err == nil || strings.TrimSpace(request.Action) != "review" {
 		return path, err

--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -904,7 +904,11 @@ func prepareLocalReviewDispatchRequest(ctx context.Context, store *db.Store, rec
 		return localAgentDispatchRequest{}, errors.New("agent review requires --pr number")
 	}
 	if strings.TrimSpace(request.Branch) == "" || strings.TrimSpace(request.HeadSHA) == "" {
-		pr, err := newAgentDispatchGitHubClient(record.CheckoutPath).GetPullRequest(ctx, repo, int64(request.PullRequest))
+		pr, err := jobGitHubClient(
+			record.CheckoutPath,
+			newAgentDispatchGitHubClient(record.CheckoutPath),
+			localDispatchJobRunner(request),
+		).GetPullRequest(ctx, repo, int64(request.PullRequest))
 		if err != nil {
 			return localAgentDispatchRequest{}, fmt.Errorf("resolve pull request #%d: %w", request.PullRequest, err)
 		}
@@ -1176,7 +1180,11 @@ func prepareLocalImplementDispatchRequest(ctx context.Context, store *db.Store, 
 }
 
 func bindLocalImplementRequestToPullRequest(ctx context.Context, store *db.Store, record db.Repo, repo github.Repository, request localAgentDispatchRequest) (localAgentDispatchRequest, error) {
-	pr, err := newAgentDispatchGitHubClient(record.CheckoutPath).GetPullRequest(ctx, repo, int64(request.PullRequest))
+	pr, err := jobGitHubClient(
+		record.CheckoutPath,
+		newAgentDispatchGitHubClient(record.CheckoutPath),
+		localDispatchJobRunner(request),
+	).GetPullRequest(ctx, repo, int64(request.PullRequest))
 	if err != nil {
 		return localAgentDispatchRequest{}, fmt.Errorf("resolve pull request #%d for implement fix-pass: %w", request.PullRequest, err)
 	}

--- a/internal/cli/agent_dispatch_readonly_worktree_test.go
+++ b/internal/cli/agent_dispatch_readonly_worktree_test.go
@@ -121,7 +121,7 @@ func TestDispatchReviewAllocatesDistinctExactHeadWorktrees(t *testing.T) {
 	var scannerInputs []scannerInput
 	originalScanner := dispatchPromptHeadContradictionWarnings
 	dispatchPromptHeadContradictionWarnings = func(_ context.Context, git gitutil.Client, _ string, head string) []string {
-		scannerInputs = append(scannerInputs, scannerInput{dir: git.Dir, head: head})
+		scannerInputs = append(scannerInputs, scannerInput{dir: git.Dir(), head: head})
 		return nil
 	}
 	t.Cleanup(func() { dispatchPromptHeadContradictionWarnings = originalScanner })
@@ -203,7 +203,7 @@ func TestDispatchAskScannerKeepsCanonicalCheckoutAndInheritedHead(t *testing.T) 
 	var gotDir, gotHead string
 	originalScanner := dispatchPromptHeadContradictionWarnings
 	dispatchPromptHeadContradictionWarnings = func(_ context.Context, git gitutil.Client, _ string, head string) []string {
-		gotDir, gotHead = git.Dir, head
+		gotDir, gotHead = git.Dir(), head
 		return nil
 	}
 	t.Cleanup(func() { dispatchPromptHeadContradictionWarnings = originalScanner })
@@ -382,7 +382,7 @@ func readonlyReviewWorktreeGitCheckout(t *testing.T) (string, string, string) {
 
 func readonlyWorktreeHead(t *testing.T, dir string) string {
 	t.Helper()
-	head, err := (gitutil.Client{Dir: dir}).HeadSHA(context.Background())
+	head, err := (gitutil.NewHostClient(dir)).HeadSHA(context.Background())
 	if err != nil {
 		t.Fatalf("HeadSHA(%s): %v", dir, err)
 	}

--- a/internal/cli/agent_dispatch_test.go
+++ b/internal/cli/agent_dispatch_test.go
@@ -600,7 +600,7 @@ func TestReviewDispatchLeadRoutesChangesRequestedFixToImplementer(t *testing.T) 
 			seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
 			seedDaemonWorkerAgentWithPolicy(t, store, "reviewer", runtime.ShellRuntime, "true", []string{"review"}, "owner/repo", runtime.AutonomyPolicyReadOnly)
 			seedDaemonWorkerAgentWithPolicy(t, store, "implementer", runtime.ShellRuntime, "true", []string{"implement"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
-			head, err := (gitutil.Client{Dir: checkout}).HeadSHA(context.Background())
+			head, err := (gitutil.NewHostClient(checkout)).HeadSHA(context.Background())
 			if err != nil {
 				t.Fatalf("HeadSHA returned error: %v", err)
 			}
@@ -688,7 +688,7 @@ func reviewLeadRefusalStore(t *testing.T) reviewLeadRefusalFixture {
 	store := daemonWorkerStore(t)
 	checkout := createDaemonWorkerGitCheckout(t, "main")
 	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
-	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(context.Background())
+	head, err := (gitutil.NewHostClient(checkout)).HeadSHA(context.Background())
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}

--- a/internal/cli/agent_implement_base_test.go
+++ b/internal/cli/agent_implement_base_test.go
@@ -419,7 +419,7 @@ func TestResolveLocalAgentRepoPreservesRegisteredDefaultBranch(t *testing.T) {
 	if record.DefaultBranch != "main" {
 		t.Fatalf("default branch = %q, want registered main", record.DefaultBranch)
 	}
-	if branch, err := (gitutil.Client{Dir: checkout}).CurrentBranch(ctx); err != nil || branch != "feature/stale" {
+	if branch, err := (gitutil.NewHostClient(checkout)).CurrentBranch(ctx); err != nil || branch != "feature/stale" {
 		t.Fatalf("checkout branch = %q err=%v, want feature/stale", branch, err)
 	}
 }

--- a/internal/cli/agent_prompt_head_warning_test.go
+++ b/internal/cli/agent_prompt_head_warning_test.go
@@ -384,7 +384,7 @@ func TestPromptHeadWarningNamesBothCommitsAndWinner(t *testing.T) {
 
 func promptHeadWarnings(t *testing.T, checkout string, prompt string, head string) []string {
 	t.Helper()
-	return promptHeadContradictionWarnings(context.Background(), gitutil.Client{Dir: checkout}, prompt, head)
+	return promptHeadContradictionWarnings(context.Background(), gitutil.NewHostClient(checkout), prompt, head)
 }
 
 func promptHeadWarningRepository(t *testing.T) (checkout string, ancestor string, head string, divergent string) {
@@ -417,7 +417,7 @@ func writePromptHeadFixture(t *testing.T, checkout string, contents string, mess
 
 func promptHeadFixtureSHA(t *testing.T, checkout string) string {
 	t.Helper()
-	sha, err := (gitutil.Client{Dir: checkout}).HeadSHA(context.Background())
+	sha, err := (gitutil.NewHostClient(checkout)).HeadSHA(context.Background())
 	if err != nil {
 		t.Fatalf("HeadSHA: %v", err)
 	}

--- a/internal/cli/agent_review_task_identity_test.go
+++ b/internal/cli/agent_review_task_identity_test.go
@@ -97,7 +97,7 @@ func c1ReviewRepository(t *testing.T) (repoDir string, oldHead string, newHead s
 	runGit(t, repoDir, "add", "README.md")
 	runGit(t, repoDir, "commit", "-m", "round one")
 	var err error
-	oldHead, err = (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	oldHead, err = (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil || oldHead == "" {
 		t.Fatalf("round-one head = %q, err=%v", oldHead, err)
 	}
@@ -106,7 +106,7 @@ func c1ReviewRepository(t *testing.T) (repoDir string, oldHead string, newHead s
 	}
 	runGit(t, repoDir, "add", "README.md")
 	runGit(t, repoDir, "commit", "-m", "round two")
-	newHead, err = (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	newHead, err = (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil || newHead == "" || newHead == oldHead {
 		t.Fatalf("round heads old=%q new=%q err=%v", oldHead, newHead, err)
 	}
@@ -157,7 +157,7 @@ func evaluateC1GateScenario(t *testing.T, implementTaskID string, reviewTaskID s
 			ReviewRound: "review-2", Result: &workflow.AgentResult{Decision: "approved", Summary: "round two approved"},
 		})
 	}
-	decision, err := (daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout}).Evaluate(context.Background(), request)
+	decision, err := (newHostDaemonMergeGate(store, gh, checkout, "")).Evaluate(context.Background(), request)
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}
@@ -358,7 +358,7 @@ func TestFixWorktreeStrandReviewBindsImplementTaskE2E(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(fixWorktree, "fix.txt"), []byte("fix\n"), 0o644); err != nil {
 		t.Fatalf("write fix change: %v", err)
 	}
-	if _, err := (daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}).FinalizeImplementation(
+	if _, err := (newHostDaemonImplementationFinalizer(store, github.NoopClient{})).FinalizeImplementation(
 		ctx, db.Job{ID: "fix-leg", Agent: "implementer", Type: "implement"}, workflow.JobPayload{
 			Repo: "owner/repo", Branch: branch, PullRequest: 1530, TaskID: "adhoc-impl",
 			FixWorktree: true, WorktreePath: fixWorktree,

--- a/internal/cli/agent_test.go
+++ b/internal/cli/agent_test.go
@@ -727,7 +727,7 @@ func TestPrepareLocalReviewDispatchRequestBindsBranchOwningTaskWithoutWorktree(t
 	}
 	runGit(t, repoDir, "add", "README.md")
 	runGit(t, repoDir, "commit", "-m", "feature")
-	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -766,7 +766,7 @@ func TestPrepareLocalReviewDispatchRequestBindsBranchOwningTaskWithoutWorktree(t
 	if request.ReviewTaskHeadDivergence != "" {
 		t.Fatalf("worktree-less bind recorded a divergence note %q; want none", request.ReviewTaskHeadDivergence)
 	}
-	branch, err := (gitutil.Client{Dir: repoDir}).CurrentBranch(ctx)
+	branch, err := (gitutil.NewHostClient(repoDir)).CurrentBranch(ctx)
 	if err != nil {
 		t.Fatalf("CurrentBranch returned error: %v", err)
 	}
@@ -807,7 +807,7 @@ func TestPrepareLocalReviewDispatchRequestBindsTaskWithStaleCheckout(t *testing.
 	}
 	runGit(t, repoDir, "add", "README.md")
 	runGit(t, repoDir, "commit", "-m", "old feature")
-	oldHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	oldHead, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("old HeadSHA returned error: %v", err)
 	}
@@ -817,7 +817,7 @@ func TestPrepareLocalReviewDispatchRequestBindsTaskWithStaleCheckout(t *testing.
 	}
 	runGit(t, repoDir, "add", "README.md")
 	runGit(t, repoDir, "commit", "-m", "new feature")
-	newHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	newHead, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("new HeadSHA returned error: %v", err)
 	}
@@ -844,7 +844,7 @@ func TestPrepareLocalReviewDispatchRequestBindsTaskWithStaleCheckout(t *testing.
 	}
 	// Fixture pin: the registered checkout must genuinely sit BEHIND the
 	// requested head (the fix-worktree strand), or this test proves nothing.
-	staleHead, err := (gitutil.Client{Dir: staleWorktree}).HeadSHA(ctx)
+	staleHead, err := (gitutil.NewHostClient(staleWorktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("stale HeadSHA returned error: %v", err)
 	}
@@ -940,7 +940,7 @@ func TestPrepareLocalReviewTaskRejectsDisposedTask(t *testing.T) {
 			writeFile(t, filepath.Join(repoDir, "README.md"), "review\n")
 			runGit(t, repoDir, "add", "README.md")
 			runGit(t, repoDir, "commit", "-m", "review head")
-			head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+			head, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -980,7 +980,7 @@ func TestPrepareLocalReviewTaskReusesNonDismissedMatchingHead(t *testing.T) {
 	writeFile(t, filepath.Join(repoDir, "README.md"), "review\n")
 	runGit(t, repoDir, "add", "README.md")
 	runGit(t, repoDir, "commit", "-m", "review head")
-	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1023,7 +1023,7 @@ func TestPrepareLocalReviewTaskMintsIdentityWhenNoTaskOwnsBranch(t *testing.T) {
 	writeFile(t, filepath.Join(repoDir, "README.md"), "review\n")
 	runGit(t, repoDir, "add", "README.md")
 	runGit(t, repoDir, "commit", "-m", "review head")
-	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/ask_diff_precleanup.go
+++ b/internal/cli/ask_diff_precleanup.go
@@ -224,9 +224,7 @@ func (s *readOnlyWorktreeGitSandbox) run(ctx context.Context, label string, args
 	var stderr boundedCountingBuffer
 	stderr.limit = 4096
 	cmdArgs := append([]string{"--no-optional-locks", "-c", "core.fsmonitor=false", "-c", "core.hooksPath=" + os.DevNull}, args...)
-	result, err := runReadOnlyWorktreeGit(ctx, s.runner, s.env, s.worktree, cmdArgs...)
-	_, _ = out.Write([]byte(result.Stdout))
-	_, _ = stderr.Write([]byte(result.Stderr))
+	err := runReadOnlyWorktreeGit(ctx, s.runner, s.env, s.worktree, out, &stderr, cmdArgs...)
 	if err != nil {
 		detail := strings.TrimSpace(stderr.String())
 		if detail != "" {
@@ -250,9 +248,7 @@ func runReadOnlyWorktreeMetadataGitOutput(ctx context.Context, runner subprocess
 	var stdout, stderr boundedCountingBuffer
 	stdout.limit = 64 << 10
 	stderr.limit = 4096
-	result, err := runReadOnlyWorktreeGit(ctx, runner, env, worktree, cmdArgs...)
-	_, _ = stdout.Write([]byte(result.Stdout))
-	_, _ = stderr.Write([]byte(result.Stderr))
+	err := runReadOnlyWorktreeGit(ctx, runner, env, worktree, &stdout, &stderr, cmdArgs...)
 	if err != nil {
 		detail := strings.TrimSpace(stderr.String())
 		if detail != "" {
@@ -267,15 +263,15 @@ func runReadOnlyWorktreeMetadataGitOutput(ctx context.Context, runner subprocess
 	return value, nil
 }
 
-func runReadOnlyWorktreeGit(ctx context.Context, runner subprocess.Runner, env []string, worktree string, args ...string) (subprocess.Result, error) {
+func runReadOnlyWorktreeGit(ctx context.Context, runner subprocess.Runner, env []string, worktree string, stdout, stderr io.Writer, args ...string) error {
 	if runner == nil {
-		return subprocess.Result{}, errors.New("read-only worktree diff has no subprocess runner")
+		return errors.New("read-only worktree diff has no subprocess runner")
 	}
 	envRunner, ok := runner.(subprocess.ExactEnvRunner)
 	if !ok {
-		return subprocess.Result{}, errors.New("read-only worktree diff subprocess runner does not support exact environment isolation")
+		return errors.New("read-only worktree diff subprocess runner does not support exact environment isolation")
 	}
-	return envRunner.RunExactEnv(ctx, worktree, env, "git", args...)
+	return envRunner.RunExactEnv(ctx, worktree, env, stdout, stderr, "git", args...)
 }
 
 func sanitizedReadOnlyWorktreeGitEnv(tempHome string) []string {

--- a/internal/cli/ask_diff_precleanup.go
+++ b/internal/cli/ask_diff_precleanup.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -47,6 +47,10 @@ func composeBeforeReadOnlyWorktreeCleanupHooks(hooks ...beforeReadOnlyWorktreeCl
 // payload JSON so it remains available after synchronous worktree disposal
 // without creating a second file-retention lifecycle.
 func askReviewDiffPrecleanupHook(store *db.Store) beforeReadOnlyWorktreeCleanupHook {
+	return askReviewDiffPrecleanupHookForRunner(store, subprocess.ExecRunner{})
+}
+
+func askReviewDiffPrecleanupHookForRunner(store *db.Store, runner subprocess.Runner) beforeReadOnlyWorktreeCleanupHook {
 	return func(ctx context.Context, jobID, jobType string, payload workflow.JobPayload) error {
 		if store == nil ||
 			(strings.TrimSpace(jobType) != "ask" && strings.TrimSpace(jobType) != "review") ||
@@ -54,7 +58,7 @@ func askReviewDiffPrecleanupHook(store *db.Store) beforeReadOnlyWorktreeCleanupH
 			return nil
 		}
 
-		snapshot, truncated, captureErr := captureReadOnlyWorktreeDiff(ctx, payload.WorktreePath)
+		snapshot, truncated, captureErr := captureReadOnlyWorktreeDiffForRunner(ctx, payload.WorktreePath, runner)
 		job, loadErr := store.GetJob(ctx, jobID)
 		if loadErr != nil {
 			return errors.Join(captureErr, fmt.Errorf("load job before persisting read-only worktree diff: %w", loadErr))
@@ -85,10 +89,14 @@ func askReviewDiffPrecleanupHook(store *db.Store) beforeReadOnlyWorktreeCleanupH
 }
 
 func captureReadOnlyWorktreeDiff(ctx context.Context, worktree string) (string, bool, error) {
+	return captureReadOnlyWorktreeDiffForRunner(ctx, worktree, subprocess.ExecRunner{})
+}
+
+func captureReadOnlyWorktreeDiffForRunner(ctx context.Context, worktree string, runner subprocess.Runner) (string, bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, readOnlyWorktreeDiffTimeout)
 	defer cancel()
 
-	sandbox, err := newReadOnlyWorktreeGitSandbox(ctx, worktree)
+	sandbox, err := newReadOnlyWorktreeGitSandbox(ctx, worktree, runner)
 	if err != nil {
 		return "", false, err
 	}
@@ -126,9 +134,10 @@ type readOnlyWorktreeGitSandbox struct {
 	dir      string
 	worktree string
 	env      []string
+	runner   subprocess.Runner
 }
 
-func newReadOnlyWorktreeGitSandbox(ctx context.Context, worktree string) (*readOnlyWorktreeGitSandbox, error) {
+func newReadOnlyWorktreeGitSandbox(ctx context.Context, worktree string, runner subprocess.Runner) (*readOnlyWorktreeGitSandbox, error) {
 	worktree = filepath.Clean(strings.TrimSpace(worktree))
 	if !filepath.IsAbs(worktree) {
 		absolute, err := filepath.Abs(worktree)
@@ -141,7 +150,7 @@ func newReadOnlyWorktreeGitSandbox(ctx context.Context, worktree string) (*readO
 	if err != nil {
 		return nil, fmt.Errorf("create isolated git metadata: %w", err)
 	}
-	sandbox := &readOnlyWorktreeGitSandbox{dir: temp, worktree: worktree}
+	sandbox := &readOnlyWorktreeGitSandbox{dir: temp, worktree: worktree, runner: runner}
 	ok := false
 	defer func() {
 		if !ok {
@@ -150,19 +159,19 @@ func newReadOnlyWorktreeGitSandbox(ctx context.Context, worktree string) (*readO
 	}()
 
 	baseEnv := sanitizedReadOnlyWorktreeGitEnv(temp)
-	head, err := runReadOnlyWorktreeMetadataGit(ctx, baseEnv, worktree, "resolve HEAD", "rev-parse", "--verify", "HEAD")
+	head, err := runReadOnlyWorktreeMetadataGit(ctx, runner, baseEnv, worktree, "resolve HEAD", "rev-parse", "--verify", "HEAD")
 	if err != nil {
 		return nil, err
 	}
-	indexPath, err := runReadOnlyWorktreeMetadataGit(ctx, baseEnv, worktree, "resolve index", "rev-parse", "--git-path", "index")
+	indexPath, err := runReadOnlyWorktreeMetadataGit(ctx, runner, baseEnv, worktree, "resolve index", "rev-parse", "--git-path", "index")
 	if err != nil {
 		return nil, err
 	}
-	sharedIndexPath, err := runOptionalReadOnlyWorktreeMetadataGit(ctx, baseEnv, worktree, "resolve shared index", "rev-parse", "--shared-index-path")
+	sharedIndexPath, err := runOptionalReadOnlyWorktreeMetadataGit(ctx, runner, baseEnv, worktree, "resolve shared index", "rev-parse", "--shared-index-path")
 	if err != nil {
 		return nil, err
 	}
-	objectsPath, err := runReadOnlyWorktreeMetadataGit(ctx, baseEnv, worktree, "resolve object database", "rev-parse", "--git-path", "objects")
+	objectsPath, err := runReadOnlyWorktreeMetadataGit(ctx, runner, baseEnv, worktree, "resolve object database", "rev-parse", "--git-path", "objects")
 	if err != nil {
 		return nil, err
 	}
@@ -215,12 +224,10 @@ func (s *readOnlyWorktreeGitSandbox) run(ctx context.Context, label string, args
 	var stderr boundedCountingBuffer
 	stderr.limit = 4096
 	cmdArgs := append([]string{"--no-optional-locks", "-c", "core.fsmonitor=false", "-c", "core.hooksPath=" + os.DevNull}, args...)
-	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
-	cmd.Dir = s.worktree
-	cmd.Env = s.env
-	cmd.Stdout = out
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	result, err := runReadOnlyWorktreeGit(ctx, s.runner, s.env, s.worktree, cmdArgs...)
+	_, _ = out.Write([]byte(result.Stdout))
+	_, _ = stderr.Write([]byte(result.Stderr))
+	if err != nil {
 		detail := strings.TrimSpace(stderr.String())
 		if detail != "" {
 			return nil, fmt.Errorf("%s in %s: %w: %s", label, s.worktree, err, detail)
@@ -230,25 +237,23 @@ func (s *readOnlyWorktreeGitSandbox) run(ctx context.Context, label string, args
 	return out, nil
 }
 
-func runReadOnlyWorktreeMetadataGit(ctx context.Context, env []string, worktree, label string, args ...string) (string, error) {
-	return runReadOnlyWorktreeMetadataGitOutput(ctx, env, worktree, label, false, args...)
+func runReadOnlyWorktreeMetadataGit(ctx context.Context, runner subprocess.Runner, env []string, worktree, label string, args ...string) (string, error) {
+	return runReadOnlyWorktreeMetadataGitOutput(ctx, runner, env, worktree, label, false, args...)
 }
 
-func runOptionalReadOnlyWorktreeMetadataGit(ctx context.Context, env []string, worktree, label string, args ...string) (string, error) {
-	return runReadOnlyWorktreeMetadataGitOutput(ctx, env, worktree, label, true, args...)
+func runOptionalReadOnlyWorktreeMetadataGit(ctx context.Context, runner subprocess.Runner, env []string, worktree, label string, args ...string) (string, error) {
+	return runReadOnlyWorktreeMetadataGitOutput(ctx, runner, env, worktree, label, true, args...)
 }
 
-func runReadOnlyWorktreeMetadataGitOutput(ctx context.Context, env []string, worktree, label string, allowEmpty bool, args ...string) (string, error) {
+func runReadOnlyWorktreeMetadataGitOutput(ctx context.Context, runner subprocess.Runner, env []string, worktree, label string, allowEmpty bool, args ...string) (string, error) {
 	cmdArgs := append([]string{"--no-optional-locks", "-c", "core.fsmonitor=false", "-c", "core.hooksPath=" + os.DevNull}, args...)
-	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
-	cmd.Dir = worktree
-	cmd.Env = env
 	var stdout, stderr boundedCountingBuffer
 	stdout.limit = 64 << 10
 	stderr.limit = 4096
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
+	result, err := runReadOnlyWorktreeGit(ctx, runner, env, worktree, cmdArgs...)
+	_, _ = stdout.Write([]byte(result.Stdout))
+	_, _ = stderr.Write([]byte(result.Stderr))
+	if err != nil {
 		detail := strings.TrimSpace(stderr.String())
 		if detail != "" {
 			return "", fmt.Errorf("%s in %s: %w: %s", label, worktree, err, detail)
@@ -260,6 +265,17 @@ func runReadOnlyWorktreeMetadataGitOutput(ctx context.Context, env []string, wor
 		return "", fmt.Errorf("%s in %s returned invalid metadata", label, worktree)
 	}
 	return value, nil
+}
+
+func runReadOnlyWorktreeGit(ctx context.Context, runner subprocess.Runner, env []string, worktree string, args ...string) (subprocess.Result, error) {
+	if runner == nil {
+		return subprocess.Result{}, errors.New("read-only worktree diff has no subprocess runner")
+	}
+	envRunner, ok := runner.(subprocess.ExactEnvRunner)
+	if !ok {
+		return subprocess.Result{}, errors.New("read-only worktree diff subprocess runner does not support exact environment isolation")
+	}
+	return envRunner.RunExactEnv(ctx, worktree, env, "git", args...)
 }
 
 func sanitizedReadOnlyWorktreeGitEnv(tempHome string) []string {

--- a/internal/cli/ask_diff_precleanup_test.go
+++ b/internal/cli/ask_diff_precleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,8 +13,34 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
+
+type floodingExactEnvRunner struct {
+	total int
+}
+
+func (f floodingExactEnvRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
+	return subprocess.Result{}, errors.New("unexpected plain subprocess run")
+}
+
+func (f floodingExactEnvRunner) LookPath(file string) (string, error) {
+	return file, nil
+}
+
+func (f floodingExactEnvRunner) RunExactEnv(_ context.Context, _ string, _ []string, stdout, _ io.Writer, _ string, _ ...string) error {
+	chunk := []byte(strings.Repeat("x", 32<<10))
+	for written := 0; written < f.total; written += len(chunk) {
+		remaining := f.total - written
+		if remaining < len(chunk) {
+			_, _ = stdout.Write(chunk[:remaining])
+			continue
+		}
+		_, _ = stdout.Write(chunk)
+	}
+	return nil
+}
 
 func TestComposeBeforeReadOnlyWorktreeCleanupHooksRunsEveryHook(t *testing.T) {
 	firstErr := errors.New("first collector failed")
@@ -37,6 +64,25 @@ func TestComposeBeforeReadOnlyWorktreeCleanupHooksRunsEveryHook(t *testing.T) {
 	}
 	if got := strings.Join(calls, ","); got != "first,second" {
 		t.Fatalf("collector calls = %q, want first,second", got)
+	}
+}
+
+func TestReadOnlyWorktreeDiffRunnerBoundsOutputWhileRunning(t *testing.T) {
+	const total = readOnlyWorktreeDiffMaxBytes * 3
+	sandbox := readOnlyWorktreeGitSandbox{
+		worktree: t.TempDir(),
+		runner:   floodingExactEnvRunner{total: total},
+	}
+
+	out, err := sandbox.run(context.Background(), "capture diff", "diff")
+	if err != nil {
+		t.Fatalf("sandbox run: %v", err)
+	}
+	if len(out.String()) != readOnlyWorktreeDiffMaxBytes {
+		t.Fatalf("buffered bytes = %d, want cap %d", len(out.String()), readOnlyWorktreeDiffMaxBytes)
+	}
+	if out.dropped != total-readOnlyWorktreeDiffMaxBytes {
+		t.Fatalf("dropped bytes = %d, want %d", out.dropped, total-readOnlyWorktreeDiffMaxBytes)
 	}
 }
 

--- a/internal/cli/daemon_checkout.go
+++ b/internal/cli/daemon_checkout.go
@@ -14,6 +14,7 @@ import (
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -33,7 +34,11 @@ func mergeGateCheckout(ctx context.Context, store *db.Store, repo string, fallba
 }
 
 func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload workflow.JobPayload, agent runtime.Agent) (string, error) {
-	checkout, err := w.resolveJobCheckout(ctx, job, payload)
+	return w.defaultCheckoutForRunner(ctx, job, payload, agent, subprocess.ExecRunner{})
+}
+
+func (w jobWorker) defaultCheckoutForRunner(ctx context.Context, job db.Job, payload workflow.JobPayload, agent runtime.Agent, runner subprocess.Runner) (string, error) {
+	checkout, err := w.resolveJobCheckoutForRunner(ctx, job, payload, runner)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +54,7 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 		// validateImplementationLock stays UNCONDITIONAL — the branch lock, not this
 		// identity guard, is the designed mutation-safety mechanism (#413).
 		if !isWorktreeLessDelegationChild(payload) {
-			if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
+			if err := w.validateTargetCheckoutForRunner(ctx, payload, checkout, runner); err != nil {
 				return "", err
 			}
 		}
@@ -59,7 +64,7 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 	case "review":
 		switch {
 		case payload.PullRequest > 0 && strings.TrimSpace(payload.TaskID) != "":
-			if err := w.validateReviewCheckout(ctx, payload, checkout); err != nil {
+			if err := w.validateReviewCheckoutForRunner(ctx, payload, checkout, runner); err != nil {
 				// #684: the PR branch commonly advances between enqueue and execution
 				// in an active dev loop, leaving the checkout on a NEWER head than the
 				// one the review was pinned to. Re-target the review to the checkout's
@@ -67,7 +72,7 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 				// does) when the PR is still open, instead of failing on the mismatch.
 				// A closed/merged PR, a dirty tree, or any other checkout error keeps
 				// the existing terminal / deferral path.
-				if resynced, resyncErr := w.resyncReviewHead(ctx, job, payload, checkout, err); resyncErr != nil {
+				if resynced, resyncErr := w.resyncReviewHeadForRunner(ctx, job, payload, checkout, runner, err); resyncErr != nil {
 					return "", resyncErr
 				} else if resynced {
 					return checkout, nil
@@ -86,7 +91,7 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 			// Same worktree-less delegation child escape as the implement arm; a
 			// review is read-only ⇒ running it against the shared checkout is
 			// trivially safe (#413).
-			if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
+			if err := w.validateTargetCheckoutForRunner(ctx, payload, checkout, runner); err != nil {
 				return "", err
 			}
 		}
@@ -101,7 +106,7 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 		// issue ask — and a branch-only PR-less CLI ask — run against the
 		// registered checkout as-is.
 		if payload.PullRequest > 0 && strings.TrimSpace(payload.Branch) != "" {
-			if err := w.validateTargetCheckout(ctx, payload, checkout); err != nil {
+			if err := w.validateTargetCheckoutForRunner(ctx, payload, checkout, runner); err != nil {
 				return "", err
 			}
 		}
@@ -110,6 +115,10 @@ func (w jobWorker) defaultCheckout(ctx context.Context, job db.Job, payload work
 }
 
 func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload workflow.JobPayload) (string, error) {
+	return w.resolveJobCheckoutForRunner(ctx, job, payload, subprocess.ExecRunner{})
+}
+
+func (w jobWorker) resolveJobCheckoutForRunner(ctx context.Context, job db.Job, payload workflow.JobPayload, runner subprocess.Runner) (string, error) {
 	if payload.FixWorktree {
 		checkout, err := normalizeTaskWorktreePath(payload.WorktreePath)
 		if err != nil {
@@ -122,7 +131,7 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 		if err != nil {
 			return "", err
 		}
-		if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
+		if err := preflightDaemonRepoCheckoutWithRunner(ctx, repo, checkout, runner); err != nil {
 			return "", err
 		}
 		return checkout, nil
@@ -135,11 +144,11 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 	if err != nil {
 		return "", err
 	}
-	checkout, err := w.healRegisteredRepoCheckout(ctx, job, repo, repoRecord)
+	checkout, err := w.healRegisteredRepoCheckoutForRunner(ctx, job, repo, repoRecord, runner)
 	if err != nil {
 		return "", err
 	}
-	if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
+	if err := preflightDaemonRepoCheckoutWithRunner(ctx, repo, checkout, runner); err != nil {
 		return "", err
 	}
 	taskCheckout, ok, err := w.taskWorktreeCheckout(ctx, payload)
@@ -148,7 +157,7 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 	}
 	if ok {
 		checkout = taskCheckout
-		if err := preflightDaemonRepoCheckout(ctx, repo, checkout); err != nil {
+		if err := preflightDaemonRepoCheckoutWithRunner(ctx, repo, checkout, runner); err != nil {
 			return "", err
 		}
 	}
@@ -156,8 +165,12 @@ func (w jobWorker) resolveJobCheckout(ctx context.Context, job db.Job, payload w
 }
 
 func (w jobWorker) healRegisteredRepoCheckout(ctx context.Context, job db.Job, repo github.Repository, record db.Repo) (string, error) {
+	return w.healRegisteredRepoCheckoutForRunner(ctx, job, repo, record, subprocess.ExecRunner{})
+}
+
+func (w jobWorker) healRegisteredRepoCheckoutForRunner(ctx context.Context, job db.Job, repo github.Repository, record db.Repo, runner subprocess.Runner) (string, error) {
 	checkout := strings.TrimSpace(record.CheckoutPath)
-	resolved, healed, err := resolveRegisteredRepoRecord(ctx, w.Store, repo, record)
+	resolved, healed, err := resolveRegisteredRepoRecordWithRunner(ctx, w.Store, repo, record, runner)
 	if err != nil {
 		return "", err
 	}
@@ -231,7 +244,11 @@ func normalizeTaskWorktreePath(path string) (string, error) {
 }
 
 func (w jobWorker) validateTargetCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {
-	git := gitutil.Client{Dir: checkout}
+	return w.validateTargetCheckoutForRunner(ctx, payload, checkout, subprocess.ExecRunner{})
+}
+
+func (w jobWorker) validateTargetCheckoutForRunner(ctx context.Context, payload workflow.JobPayload, checkout string, runner subprocess.Runner) error {
+	git := jobGitClient(checkout, runner)
 	// A fix-round checkout is an independent writable clone attached to the real
 	// task branch. Its allocator bound HEAD to the fetched branch tip at dispatch;
 	// validate branch identity and cleanliness here without comparing the inherited
@@ -339,7 +356,11 @@ func isWorktreeLessDelegationChild(payload workflow.JobPayload) bool {
 }
 
 func (w jobWorker) validateReviewCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {
-	git := gitutil.Client{Dir: checkout}
+	return w.validateReviewCheckoutForRunner(ctx, payload, checkout, subprocess.ExecRunner{})
+}
+
+func (w jobWorker) validateReviewCheckoutForRunner(ctx context.Context, payload workflow.JobPayload, checkout string, runner subprocess.Runner) error {
+	git := jobGitClient(checkout, runner)
 	clean, err := git.WorktreeClean(ctx)
 	if err != nil {
 		return err
@@ -418,6 +439,10 @@ func (w jobWorker) reviewPullRequestOpen(ctx context.Context, repo string, numbe
 // returns true so defaultCheckout proceeds with the review. Every declined case
 // returns false so the caller's existing error path runs byte-identically.
 func (w jobWorker) resyncReviewHead(ctx context.Context, job db.Job, payload workflow.JobPayload, checkout string, cause error) (bool, error) {
+	return w.resyncReviewHeadForRunner(ctx, job, payload, checkout, subprocess.ExecRunner{}, cause)
+}
+
+func (w jobWorker) resyncReviewHeadForRunner(ctx context.Context, job db.Job, payload workflow.JobPayload, checkout string, runner subprocess.Runner, cause error) (bool, error) {
 	if !isReviewHeadMismatch(cause) {
 		return false, nil
 	}
@@ -443,11 +468,11 @@ func (w jobWorker) resyncReviewHead(ctx context.Context, job db.Job, payload wor
 	// a detached-HEAD worktree (CurrentBranch errors) is a legitimate #684 target and
 	// is left to proceed. We deliberately do NOT gate on head == pr.HeadSHA because the
 	// PR-watcher can lag the push, which is exactly the drift #684 exists to tolerate.
-	if b, err := (gitutil.Client{Dir: checkout}).CurrentBranch(ctx); err == nil &&
+	if b, err := jobGitClient(checkout, runner).CurrentBranch(ctx); err == nil &&
 		strings.TrimSpace(b) != strings.TrimSpace(payload.Branch) {
 		return false, nil
 	}
-	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	head, err := jobGitClient(checkout, runner).HeadSHA(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/internal/cli/daemon_checkout.go
+++ b/internal/cli/daemon_checkout.go
@@ -164,10 +164,6 @@ func (w jobWorker) resolveJobCheckoutForRunner(ctx context.Context, job db.Job, 
 	return checkout, nil
 }
 
-func (w jobWorker) healRegisteredRepoCheckout(ctx context.Context, job db.Job, repo github.Repository, record db.Repo) (string, error) {
-	return w.healRegisteredRepoCheckoutForRunner(ctx, job, repo, record, subprocess.ExecRunner{})
-}
-
 func (w jobWorker) healRegisteredRepoCheckoutForRunner(ctx context.Context, job db.Job, repo github.Repository, record db.Repo, runner subprocess.Runner) (string, error) {
 	checkout := strings.TrimSpace(record.CheckoutPath)
 	resolved, healed, err := resolveRegisteredRepoRecordWithRunner(ctx, w.Store, repo, record, runner)
@@ -355,10 +351,6 @@ func isWorktreeLessDelegationChild(payload workflow.JobPayload) bool {
 	return strings.TrimSpace(payload.DelegationID) != "" && strings.TrimSpace(payload.WorktreePath) == ""
 }
 
-func (w jobWorker) validateReviewCheckout(ctx context.Context, payload workflow.JobPayload, checkout string) error {
-	return w.validateReviewCheckoutForRunner(ctx, payload, checkout, subprocess.ExecRunner{})
-}
-
 func (w jobWorker) validateReviewCheckoutForRunner(ctx context.Context, payload workflow.JobPayload, checkout string, runner subprocess.Runner) error {
 	git := jobGitClient(checkout, runner)
 	clean, err := git.WorktreeClean(ctx)
@@ -438,10 +430,6 @@ func (w jobWorker) reviewPullRequestOpen(ctx context.Context, repo string, numbe
 // comment carry the new head) and records a review_head_resynced event, then
 // returns true so defaultCheckout proceeds with the review. Every declined case
 // returns false so the caller's existing error path runs byte-identically.
-func (w jobWorker) resyncReviewHead(ctx context.Context, job db.Job, payload workflow.JobPayload, checkout string, cause error) (bool, error) {
-	return w.resyncReviewHeadForRunner(ctx, job, payload, checkout, subprocess.ExecRunner{}, cause)
-}
-
 func (w jobWorker) resyncReviewHeadForRunner(ctx context.Context, job db.Job, payload workflow.JobPayload, checkout string, runner subprocess.Runner, cause error) (bool, error) {
 	if !isReviewHeadMismatch(cause) {
 		return false, nil

--- a/internal/cli/daemon_housekeeping_resilience_test.go
+++ b/internal/cli/daemon_housekeeping_resilience_test.go
@@ -99,7 +99,7 @@ func TestSkippedDelegationWorktreeReclaimFailureDoesNotBlockDispatch(t *testing.
 	}); err != nil {
 		t.Fatalf("add skipped cleanup marker: %v", err)
 	}
-	baseWorkflowFactory := h.worker.WorkflowFactory
+	baseWorkflowFactory := h.worker.defaultWorkflow
 	var factoryCalls atomic.Int32
 	h.worker.WorkflowFactory = func(checkout string) workflow.Engine {
 		// A nil store makes the selected item's real reclaim operation fail at

--- a/internal/cli/daemon_lifecycle.go
+++ b/internal/cli/daemon_lifecycle.go
@@ -21,10 +21,10 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
-	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/presence"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -377,7 +377,7 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 			// Resolve [merge_gate] inside daemonMergeGate for every evaluation so a
 			// live auto_merge flip both re-arms parked tasks and changes their next
 			// gate decision without a daemon restart.
-			MergeGate: newDaemonMergeGate(store, gh, checkout, resolvedHome),
+			MergeGate: newDaemonMergeGate(store, gh, checkout, resolvedHome, subprocess.ExecRunner{}),
 			// Registry default model/effort fallbacks, home-aware and fail-open — see
 			// daemonWorkflowEngine. Empty by default => byte-identical.
 			RuntimeDefaultModel:  runtimeDefaultModelResolver(*home),
@@ -1072,7 +1072,11 @@ func preflightDaemonRepoStart(ctx context.Context, home string, repo github.Repo
 }
 
 func preflightDaemonRepoCheckout(ctx context.Context, repo github.Repository, workDir string) error {
-	_, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: workDir})
+	return preflightDaemonRepoCheckoutWithRunner(ctx, repo, workDir, subprocess.ExecRunner{})
+}
+
+func preflightDaemonRepoCheckoutWithRunner(ctx context.Context, repo github.Repository, workDir string, runner subprocess.Runner) error {
+	_, err := repoRecordForCheckout(ctx, repo, jobGitClient(workDir, runner))
 	return err
 }
 

--- a/internal/cli/daemon_lifecycle.go
+++ b/internal/cli/daemon_lifecycle.go
@@ -394,18 +394,8 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		applyReviewPolicy(&engine, *home)
 		wireReviewRiskSignals(&engine, gh)
 		fmt.Fprintf(stdout, "watching %s every %s\n", repo.FullName(), poll.String())
-		return runSingleRepoSupervisor(ctx, *home, daemon.Daemon{
-			Repo:                    repo,
-			PollInterval:            *poll,
-			Store:                   store,
-			GitHub:                  gh,
-			Workflow:                &engine,
-			WatchIssues:             *watchIssues,
-			EscalationTTL:           resolveEscalationTTL(*home),
-			RevertDetectionEnabled:  resolveRevertDetectionEnabled(*home),
-			ObservePermissionPolicy: resolvePermissionPolicyObservationEnabled(*home),
-			AutoMergeEnabled:        autoMergeEnabledResolver(*home),
-		}, store, live, session, stdout)
+		supervisor := newSingleRepoSupervisorDaemon(repo, store, gh, engine, *home, resolvedHome, checkout, stdout, *poll, *watchIssues)
+		return runSingleRepoSupervisor(ctx, *home, supervisor, store, live, session, stdout)
 	})
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return 0
@@ -415,6 +405,41 @@ func runDaemonRun(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+func newSingleRepoSupervisorDaemon(
+	repo github.Repository,
+	store *db.Store,
+	gh github.Client,
+	engine workflow.Engine,
+	rawHome string,
+	resolvedHome string,
+	checkout string,
+	stdout io.Writer,
+	pollInterval time.Duration,
+	watchIssues bool,
+) daemon.Daemon {
+	return daemon.Daemon{
+		Repo:         repo,
+		PollInterval: pollInterval,
+		Store:        store,
+		GitHub:       gh,
+		Workflow:     &engine,
+		WorkflowForJob: func(_ context.Context, job db.Job) (*workflow.Engine, error) {
+			runner, err := defaultJobWorker(store, stdout, rawHome).subprocessRunnerForJob(job)
+			if err != nil {
+				return nil, err
+			}
+			jobEngine := engine
+			jobEngine.MergeGate = newDaemonMergeGate(store, gh, checkout, resolvedHome, runner)
+			return &jobEngine, nil
+		},
+		WatchIssues:             watchIssues,
+		EscalationTTL:           resolveEscalationTTL(rawHome),
+		RevertDetectionEnabled:  resolveRevertDetectionEnabled(rawHome),
+		ObservePermissionPolicy: resolvePermissionPolicyObservationEnabled(rawHome),
+		AutoMergeEnabled:        autoMergeEnabledResolver(rawHome),
+	}
 }
 
 func runDaemonStop(args []string, stdout, stderr io.Writer) int {

--- a/internal/cli/daemon_merge_gate_active_job_test.go
+++ b/internal/cli/daemon_merge_gate_active_job_test.go
@@ -57,7 +57,7 @@ func TestDaemonMergeGateHoldsWhileImplementJobActiveOnBranch(t *testing.T) {
 		ID: "fix-round-running", Agent: "implementer", Type: "implement", State: string(workflow.JobRunning),
 	}, workflow.JobPayload{Repo: request.Repo, Branch: request.Branch, TaskID: request.TaskID})
 
-	decision, err := (daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout}).Evaluate(context.Background(), request)
+	decision, err := (newHostDaemonMergeGate(store, gh, checkout, "")).Evaluate(context.Background(), request)
 	if err != nil {
 		t.Fatalf("Evaluate returned error: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestDaemonMergeGateHoldsHumanMergeRequestWhileJobActiveOnBranch(t *testing.
 		ID: "fix-round-running", Agent: "implementer", Type: "implement", State: string(workflow.JobRunning),
 	}, workflow.JobPayload{Repo: request.Repo, Branch: request.Branch, TaskID: request.TaskID})
 
-	decision, err := (daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout}).Evaluate(context.Background(), request)
+	decision, err := (newHostDaemonMergeGate(store, gh, checkout, "")).Evaluate(context.Background(), request)
 	if err != nil {
 		t.Fatalf("Evaluate returned error: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestDaemonMergeGateDefaultPreservesMergePathWhenMandatoryGatePasses(t *test
 		t.Fatalf("Initialize config: %v", err)
 	}
 
-	decision, err := (daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout, Home: paths.Home}).Evaluate(context.Background(), request)
+	decision, err := (newHostDaemonMergeGate(store, gh, checkout, paths.Home)).Evaluate(context.Background(), request)
 	if err != nil {
 		t.Fatalf("Evaluate returned error: %v", err)
 	}
@@ -139,7 +139,7 @@ scope = ["owner/repo"]
 	if _, err := config.LoadOrg(paths); err != nil {
 		t.Fatalf("LoadOrg: %v", err)
 	}
-	gate := daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout, Home: paths.Home}
+	gate := newHostDaemonMergeGate(store, gh, checkout, paths.Home)
 	renderedReason := ""
 	for attempt := 0; attempt < 2; attempt++ {
 		decision, err := gate.Evaluate(context.Background(), request)
@@ -202,7 +202,7 @@ func TestDaemonMergeGateKillSwitchDoesNotEscalate(t *testing.T) {
 	if err := os.WriteFile(paths.ConfigFile, []byte(config.DefaultConfig(paths)+"\n[merge_gate]\nauto_merge = false\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	decision, err := (daemonMergeGate{Store: store, GitHub: gh, FallbackCheckout: checkout, Home: paths.Home}).Evaluate(context.Background(), request)
+	decision, err := (newHostDaemonMergeGate(store, gh, checkout, paths.Home)).Evaluate(context.Background(), request)
 	if err != nil || !decision.LeaveOpen || decision.Reason.IsGateMiss() {
 		t.Fatalf("decision = %+v, err=%v", decision, err)
 	}

--- a/internal/cli/daemon_reclaim_resilience_test.go
+++ b/internal/cli/daemon_reclaim_resilience_test.go
@@ -67,7 +67,7 @@ func TestAgedWorktreeReclaimFailureDoesNotBlockDispatch(t *testing.T) {
 		fakeReclaimWorktreeManager: fakeReclaimWorktreeManager{branches: map[string]bool{}},
 		err:                        reclaimErr,
 	}
-	baseWorkflowFactory := worker.WorkflowFactory
+	baseWorkflowFactory := worker.defaultWorkflow
 	worker.WorkflowFactory = func(parentCheckout string) workflow.Engine {
 		engine := baseWorkflowFactory(parentCheckout)
 		engine.DelegationCheckout = checkout
@@ -102,7 +102,7 @@ func TestForceRemoveWorktreeUsesOwningCheckout(t *testing.T) {
 	owner := createDaemonWorkerGitCheckout(t, "main")
 	unrelated := createDaemonWorkerGitCheckout(t, "main")
 	worktreePath := filepath.Join(t.TempDir(), "foreign-owner")
-	if err := (gitutil.Client{Dir: owner}).AddDetachedWorktree(ctx, worktreePath, "HEAD"); err != nil {
+	if err := (gitutil.NewHostClient(owner)).AddDetachedWorktree(ctx, worktreePath, "HEAD"); err != nil {
 		t.Fatalf("create owner worktree: %v", err)
 	}
 
@@ -113,7 +113,7 @@ func TestForceRemoveWorktreeUsesOwningCheckout(t *testing.T) {
 		t.Fatalf("unrelated-checkout control arm err=%v output=%q, want not-a-working-tree failure", err, output)
 	}
 
-	if err := (gitutil.Client{Dir: unrelated}).RemoveWorktreeForce(ctx, worktreePath); err != nil {
+	if err := (gitutil.NewHostClient(unrelated)).RemoveWorktreeForce(ctx, worktreePath); err != nil {
 		t.Fatalf("force remove through owning checkout: %v", err)
 	}
 	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
@@ -140,7 +140,7 @@ func TestGitClientErrorIncludesBoundedStderr(t *testing.T) {
 		result: subprocess.Result{Stderr: "\n  " + cause + strings.Repeat("x", 10_000) + "\n"},
 		err:    errors.New("exit status 128"),
 	}
-	err := (gitutil.Client{Runner: runner, Dir: "/repo"}).RemoveWorktreeForce(context.Background(), "/worktree")
+	err := (gitutil.NewClient("/repo", runner)).RemoveWorktreeForce(context.Background(), "/worktree")
 	if err == nil || !strings.Contains(err.Error(), cause) {
 		t.Fatalf("git error = %v, want trimmed stderr cause", err)
 	}

--- a/internal/cli/daemon_result.go
+++ b/internal/cli/daemon_result.go
@@ -304,7 +304,11 @@ func (w jobWorker) finalizeTimedOutJob(ctx context.Context, job db.Job, payload 
 	reason := fmt.Sprintf("job %s exceeded its run deadline: %v", job.ID, cause)
 	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
-	engine := w.WorkflowFactory(w.delegationParentCheckout(writeCtx, job))
+	runner, err := w.subprocessRunnerForJob(job)
+	if err != nil {
+		return false, err
+	}
+	engine := w.workflowForJob(w.delegationParentCheckout(writeCtx, job), runner)
 	return engine.FinalizeTimedOutJob(writeCtx, job.ID, reason, string(detailBytes))
 }
 
@@ -319,7 +323,11 @@ func (w jobWorker) finalizeTimedOutJob(ctx context.Context, job db.Job, payload 
 // Returns whether the child was finalized.
 func (w jobWorker) finalizeTimedOutDelegationChild(ctx context.Context, job db.Job, cause error) (bool, error) {
 	reason := fmt.Sprintf("delegation child %s ended without a result: %v", job.ID, cause)
-	engine := w.WorkflowFactory(w.delegationParentCheckout(ctx, job))
+	runner, err := w.subprocessRunnerForJob(job)
+	if err != nil {
+		return false, err
+	}
+	engine := w.workflowForJob(w.delegationParentCheckout(ctx, job), runner)
 	return engine.FinalizeTimedOutDelegationChild(ctx, job.ID, reason)
 }
 

--- a/internal/cli/daemon_scheduler.go
+++ b/internal/cli/daemon_scheduler.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
-	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/transcript"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -830,7 +830,11 @@ func reclaimSkippedDelegationWorktrees(ctx context.Context, worker jobWorker, re
 				continue
 			}
 		}
-		engine := worker.WorkflowFactory(worker.delegationParentCheckout(ctx, job))
+		runner, err := worker.subprocessRunnerForJob(job)
+		if err != nil {
+			return err
+		}
+		engine := worker.workflowForJob(worker.delegationParentCheckout(ctx, job), runner)
 		if err := engine.ReclaimTerminalDelegationWorktree(ctx, jobID); err != nil {
 			writeLine(worker.Stdout, "job %s skipped delegation worktree reclaim failed: %v", job.ID, err)
 		}
@@ -870,7 +874,11 @@ func reclaimAgedTerminalDelegationWorktrees(ctx context.Context, worker jobWorke
 				continue
 			}
 		}
-		engine := worker.WorkflowFactory(worker.delegationParentCheckout(ctx, job))
+		runner, err := worker.subprocessRunnerForJob(job)
+		if err != nil {
+			return err
+		}
+		engine := worker.workflowForJob(worker.delegationParentCheckout(ctx, job), runner)
 		if err := engine.ReclaimAgedTerminalDelegationWorktree(ctx, jobID, now.Add(-ttl)); err != nil {
 			return err
 		}
@@ -1499,6 +1507,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 		runtimeKey   string
 		worktreePath string
 		repoCheckout string
+		runner       subprocess.Runner
 		// payloadBeforeIsolation is the job's payload as it was before an
 		// isolation worktree was allocated and written into it; non-empty only
 		// for isolation-dispatched jobs.
@@ -1564,7 +1573,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 		// the add (in allocatePoolIsolationWorktree) and this remove run on the
 		// dispatcher goroutine under the tick's per-repo lock, so they never race.
 		if f.worktreePath != "" && f.repoCheckout != "" {
-			_ = gitutil.Client{Dir: f.repoCheckout}.RemoveWorktreeForce(context.WithoutCancel(ctx), f.worktreePath)
+			_ = jobGitClient(f.repoCheckout, f.runner).RemoveWorktreeForce(context.WithoutCancel(ctx), f.worktreePath)
 		}
 		if f.err != nil && firstErr == nil && !errors.Is(f.err, errRuntimeSessionBusy) {
 			firstErr = f.err
@@ -1729,7 +1738,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 						// host-cap or double-dispatch refusal must not strand it on a
 						// reaped path.
 						_ = worker.Store.UpdateJobPayload(context.WithoutCancel(ctx), iso.job.ID, payloadBeforeIsolation)
-						_ = gitutil.Client{Dir: iso.repoCheckout}.RemoveWorktreeForce(context.WithoutCancel(ctx), iso.worktreePath)
+						_ = jobGitClient(iso.repoCheckout, iso.runner).RemoveWorktreeForce(context.WithoutCancel(ctx), iso.worktreePath)
 						continue
 					}
 					inflightCheckouts[iso.checkoutKey] = true
@@ -1745,7 +1754,7 @@ func runQueuedJobsForRepoPoolTracked(ctx context.Context, worker jobWorker, limi
 					running++
 					dispatched++
 					go func() {
-						done <- finished{jobID: iso.job.ID, checkoutKey: iso.checkoutKey, runtimeKey: iso.runtimeKey, worktreePath: iso.worktreePath, repoCheckout: iso.repoCheckout, payloadBeforeIsolation: payloadBeforeIsolation, err: runPoolJobRecovered(ctx, worker, iso.job)}
+						done <- finished{jobID: iso.job.ID, checkoutKey: iso.checkoutKey, runtimeKey: iso.runtimeKey, worktreePath: iso.worktreePath, repoCheckout: iso.repoCheckout, runner: iso.runner, payloadBeforeIsolation: payloadBeforeIsolation, err: runPoolJobRecovered(ctx, worker, iso.job)}
 					}()
 				}
 			}
@@ -1801,6 +1810,7 @@ type poolIsolatedDispatch struct {
 	runtimeKey   string
 	worktreePath string
 	repoCheckout string
+	runner       subprocess.Runner
 }
 
 // allocatePoolIsolationWorktree creates a detached read-only worktree for a
@@ -1818,7 +1828,11 @@ func (w jobWorker) allocatePoolIsolationWorktree(ctx context.Context, job db.Job
 	if err != nil || strings.TrimSpace(repoRecord.CheckoutPath) == "" {
 		return poolIsolatedDispatch{}, false, err
 	}
-	client := gitutil.Client{Dir: repoRecord.CheckoutPath}
+	runner, err := w.subprocessRunnerForJob(job)
+	if err != nil {
+		return poolIsolatedDispatch{}, false, err
+	}
+	client := jobGitClient(repoRecord.CheckoutPath, runner)
 	// #739: route through the shared read-only allocator so this reactive top-level
 	// isolation path resolves the ref to HEAD (a committed tip that is always
 	// resolvable — NOT the stale current branch the researchers flagged), holds the
@@ -1864,6 +1878,7 @@ func (w jobWorker) allocatePoolIsolationWorktree(ctx context.Context, job db.Job
 		runtimeKey:   queuedJobRuntimeResourceKey(ctx, w.Store, job),
 		worktreePath: path,
 		repoCheckout: repoRecord.CheckoutPath,
+		runner:       runner,
 	}, true, nil
 }
 

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -877,7 +877,7 @@ func TestRunQueuedJobsRefreshesImplementedHeadBeforeReviewDispatch(t *testing.T)
 	runGit(t, checkout, "commit", "-m", "initial")
 	runGit(t, checkout, "branch", "-m", "task-1")
 	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
-	oldHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	oldHead, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -921,7 +921,7 @@ func TestRunQueuedJobsRefreshesImplementedHeadBeforeReviewDispatch(t *testing.T)
 		t.Fatalf("runQueuedJobs returned error: %v", err)
 	}
 
-	newHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	newHead, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -1921,7 +1921,7 @@ func TestRunQueuedJobsUsesTaskWorktreeForImplement(t *testing.T) {
 	checkout := createDaemonWorkerGitCheckout(t, "main")
 	worktree := filepath.Join(t.TempDir(), "task-1")
 	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
-	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(worktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -1976,7 +1976,7 @@ func TestRunQueuedJobsResumesSelfDirtyTaskWorktree(t *testing.T) {
 	checkout := createDaemonWorkerGitCheckout(t, "main")
 	worktree := filepath.Join(t.TempDir(), "task-resume")
 	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-resume", worktree, "main")
-	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(worktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -2094,7 +2094,7 @@ func TestRunQueuedJobsResumesDelegatedImplementWithOriginalBranchLock(t *testing
 	checkout := createDaemonWorkerGitCheckout(t, "main")
 	worktree := filepath.Join(t.TempDir(), "task-1")
 	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
-	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(worktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -2164,7 +2164,7 @@ func TestRunQueuedJobsUsesTaskWorktreeForReview(t *testing.T) {
 	checkout := createDaemonWorkerGitCheckout(t, "main")
 	worktree := filepath.Join(t.TempDir(), "task-1")
 	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
-	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(worktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -2205,7 +2205,7 @@ func TestRunQueuedJobsKeepsReviewOnRegisteredCheckoutWithoutTaskWorktree(t *test
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	checkout := createDaemonWorkerGitCheckout(t, "task-1")
-	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -2365,7 +2365,7 @@ func TestRunQueuedJobsFailsReviewOnWrongCheckoutBranchBeforeDelivery(t *testing.
 	runGit(t, checkout, "commit", "-m", "initial")
 	runGit(t, checkout, "branch", "-m", "main")
 	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
-	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -3271,7 +3271,7 @@ func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *t
 	runGit(t, checkout, "commit", "-m", "initial")
 	runGit(t, checkout, "branch", "-m", "task-1")
 	runGit(t, checkout, "remote", "add", "origin", "https://github.com/owner/repo.git")
-	oldHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	oldHead, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -3280,7 +3280,7 @@ func TestRetryPendingJobAdvancementsRefreshesImplementedHeadBeforePreflight(t *t
 	}
 	runGit(t, checkout, "add", "README.md")
 	runGit(t, checkout, "commit", "-m", "implement")
-	newHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	newHead, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -953,11 +953,12 @@ type registeredRepoPoller struct {
 	// PollOnce may mutate the shared checkout, which used to be excluded by the
 	// per-repo lock being held for entire job runs. nil (legacy/test callers)
 	// behaves as always-idle.
-	Inflight          *inflightJobTracker
-	IdleGraceTicks    int
-	IdleMaxMultiplier int
-	GitHubClient      func(checkout string) github.Client
-	WorkflowFactory   func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
+	Inflight           *inflightJobTracker
+	IdleGraceTicks     int
+	IdleMaxMultiplier  int
+	GitHubClient       func(checkout string) github.Client
+	WorkflowFactory    func(store *db.Store, gh github.Client, checkout string) *workflow.Engine
+	JobWorkflowFactory func(context.Context, *db.Store, github.Client, string, db.Job) (*workflow.Engine, error)
 }
 
 // defaultRegisteredRepoPoller wires the registered-repo supervisor's per-tick
@@ -976,6 +977,20 @@ type registeredRepoPoller struct {
 // no-op: resolveEscalationTTL("") returns the default and daemonWorkflowEngine("")
 // leaves ArtifactRoot/Home/EventSink unset.
 func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdout io.Writer, rawHome, resolvedRoot string) registeredRepoPoller {
+	configureWorkflow := func(engine workflow.Engine, store *db.Store) *workflow.Engine {
+		// Apply only the escalate_human notifier handle from policy (#340),
+		// keeping the budget/inlining knobs out of this path so its existing
+		// behavior is unchanged. The notifier itself is already wired by
+		// daemonWorkflowEngine; this just sets the configured @-handle.
+		// orchestratePolicy reads via jobWorker.ConfigHome, which is ALWAYS the
+		// RAW --home (#459) so it never re-resolves into a phantom doubled home.
+		if notifier, ok := engine.EscalationNotifier.(*daemonEscalationNotifier); ok && notifier != nil {
+			if policy, err := defaultJobWorker(store, stdout, rawHome).orchestratePolicy(); err == nil {
+				notifier.Handle = policy.EscalationHandle
+			}
+		}
+		return &engine
+	}
 	return registeredRepoPoller{
 		Store:                   store,
 		Workers:                 workers,
@@ -989,19 +1004,14 @@ func defaultRegisteredRepoPoller(store *db.Store, workers int, dryRun bool, stdo
 		IdleMaxMultiplier:       config.DefaultDaemonIdleMaxMultiplier,
 		GitHubClient:            func(checkout string) github.Client { return github.NewClient(checkout) },
 		WorkflowFactory: func(store *db.Store, gh github.Client, checkout string) *workflow.Engine {
-			engine := daemonWorkflowEngine(store, gh, checkout, resolvedRoot)
-			// Apply only the escalate_human notifier handle from policy (#340),
-			// keeping the budget/inlining knobs out of this path so its existing
-			// behavior is unchanged. The notifier itself is already wired by
-			// daemonWorkflowEngine; this just sets the configured @-handle.
-			// orchestratePolicy reads via jobWorker.ConfigHome, which is ALWAYS the
-			// RAW --home (#459) so it never re-resolves into a phantom doubled home.
-			if notifier, ok := engine.EscalationNotifier.(*daemonEscalationNotifier); ok && notifier != nil {
-				if policy, err := defaultJobWorker(store, stdout, rawHome).orchestratePolicy(); err == nil {
-					notifier.Handle = policy.EscalationHandle
-				}
+			return configureWorkflow(daemonWorkflowEngine(store, gh, checkout, resolvedRoot), store)
+		},
+		JobWorkflowFactory: func(_ context.Context, store *db.Store, gh github.Client, checkout string, job db.Job) (*workflow.Engine, error) {
+			runner, err := defaultJobWorker(store, stdout, rawHome).subprocessRunnerForJob(job)
+			if err != nil {
+				return nil, err
 			}
-			return &engine
+			return configureWorkflow(daemonWorkflowEngineForRunner(store, gh, checkout, resolvedRoot, runner), store), nil
 		},
 	}
 }
@@ -1221,10 +1231,16 @@ func (p registeredRepoPoller) pollRepo(ctx context.Context, repoRecord db.Repo, 
 		recoveryOnly = true
 	}
 	d := daemon.Daemon{
-		Repo:                    repo,
-		Store:                   store,
-		GitHub:                  gh,
-		Workflow:                engine,
+		Repo:     repo,
+		Store:    store,
+		GitHub:   gh,
+		Workflow: engine,
+		WorkflowForJob: func(ctx context.Context, job db.Job) (*workflow.Engine, error) {
+			if p.JobWorkflowFactory == nil {
+				return engine, nil
+			}
+			return p.JobWorkflowFactory(ctx, store, gh, repoRecord.CheckoutPath, job)
+		},
 		WatchIssues:             p.WatchIssues,
 		EscalationTTL:           p.EscalationTTL,
 		RevertDetectionEnabled:  p.RevertDetectionEnabled,

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -52,9 +52,11 @@ type jobWorker struct {
 	// elapsed-only progress without replacing their fake.
 	OutputAdapterFactory func(runtime.Agent, string, io.Writer) (workflow.DeliveryAdapter, error)
 	StartAdapterFactory  func(execbackend.Backend, string, string) (runtime.Adapter, error)
-	CheckoutValidator    func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
-	WorkflowFactory      func(string) workflow.Engine
-	CommenterFactory     func(string) github.Client
+	// CheckoutValidator and WorkflowFactory are test overrides. Production leaves
+	// them nil so checkoutForJob/workflowForJob must consume the resolved runner.
+	CheckoutValidator func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error)
+	WorkflowFactory   func(string) workflow.Engine
+	CommenterFactory  func(string) github.Client
 	// UsePool selects the opt-in continuous worker-pool scheduler (#394,
 	// --scheduler=pool) over the default per-tick wg.Wait() barrier.
 	UsePool bool
@@ -161,8 +163,6 @@ func defaultJobWorker(store *db.Store, stdout io.Writer, home ...string) jobWork
 	worker.AdapterFactory = worker.defaultAdapter
 	worker.OutputAdapterFactory = worker.outputAdapter
 	worker.StartAdapterFactory = worker.defaultStartAdapter
-	worker.CheckoutValidator = worker.defaultCheckout
-	worker.WorkflowFactory = worker.defaultWorkflow
 	worker.AuthProbe = worker.defaultAuthProbe
 	worker.RuntimePreflight = runtime.DefaultRuntimeContractChecker().CheckRequest
 	worker.QuotaWake = newQuotaRoleUnavailableWakeClient()
@@ -181,24 +181,6 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	if err != nil {
 		return w.finishQueuedJob(ctx, job, workflow.JobFailed, err)
 	}
-	// Review-to-fix jobs are the implementation jobs created by workflow
-	// advancement. They are explicitly marked FixWorktree; ordinary task runs,
-	// local implement dispatches, and delegation legs may legitimately be PR-less
-	// and must not inherit this delivery gate. Check the same durable target the
-	// finalizer will use before agent lookup, checkout setup, or adapter delivery.
-	if job.Type == "implement" && payload.FixWorktree {
-		if _, err := implementationFinalizationTargetFor(ctx, w.Store, job, payload, implementationFinalizationBeforeRun); err != nil {
-			err = fmt.Errorf("validate implementation target before model run: %w", err)
-			if !resultDeliveryFailed(err) {
-				return w.retryImplementationPreflight(ctx, job, payload, err)
-			}
-			if finishErr := w.finishQueuedJob(ctx, job, workflow.JobBlocked, err); finishErr != nil {
-				return finishErr
-			}
-			_ = w.postJobResultComment(ctx, job.ID, runtime.Agent{Name: job.Agent}, "", err)
-			return nil
-		}
-	}
 	// Resolve WHERE the runtime executes before any path can construct or start
 	// an adapter. In particular, ephemeral jobs materialize and start a host
 	// runtime below, so delaying this decision until after agent lookup would let
@@ -212,13 +194,39 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		_ = w.postJobResultComment(ctx, job.ID, runtime.Agent{Name: job.Agent}, "", err)
 		return nil
 	}
+	jobRunner, err := jobSubprocessRunnerForBackend(execBackend)
+	if err != nil {
+		if finishErr := w.finishQueuedJob(ctx, job, workflow.JobFailed, err); finishErr != nil {
+			return finishErr
+		}
+		_ = w.postJobResultComment(ctx, job.ID, runtime.Agent{Name: job.Agent}, "", err)
+		return nil
+	}
+	// Review-to-fix jobs are the implementation jobs created by workflow
+	// advancement. They are explicitly marked FixWorktree; ordinary task runs,
+	// local implement dispatches, and delegation legs may legitimately be PR-less
+	// and must not inherit this delivery gate. Check the same durable target the
+	// finalizer will use before agent lookup, checkout setup, or adapter delivery.
+	if job.Type == "implement" && payload.FixWorktree {
+		if _, err := implementationFinalizationTargetForRunner(ctx, w.Store, job, payload, implementationFinalizationBeforeRun, jobRunner); err != nil {
+			err = fmt.Errorf("validate implementation target before model run: %w", err)
+			if !resultDeliveryFailed(err) {
+				return w.retryImplementationPreflight(ctx, job, payload, err)
+			}
+			if finishErr := w.finishQueuedJob(ctx, job, workflow.JobBlocked, err); finishErr != nil {
+				return finishErr
+			}
+			_ = w.postJobResultComment(ctx, job.ID, runtime.Agent{Name: job.Agent}, "", err)
+			return nil
+		}
+	}
 	// An ephemeral child carries an inline worker spec instead of a
 	// pre-registered agent. Materialize a throwaway agent + runtime session
 	// from the spec before the normal flow runs (which assumes the agent
 	// already exists via GetAgent below), and register a cleanup defer so the
 	// worker is auto-disposed on every exit path — success, failure, or block.
 	if payload.Ephemeral != nil {
-		if err := w.startEphemeralWorker(ctx, job, payload, execBackend); err != nil {
+		if err := w.startEphemeralWorker(ctx, job, payload, execBackend, jobRunner); err != nil {
 			if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "ephemeral_worker_failed", Message: err.Error()}); eventErr != nil {
 				return eventErr
 			}
@@ -345,9 +353,9 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 		}
 		return nil
 	}
-	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
+	checkout, err := w.checkoutForJob(ctx, job, payload, agent, jobRunner)
 	if err != nil {
-		if resumedCheckout, resumedPayload, ok := w.resumeSelfDirtyWorktree(ctx, job, payload, agent, err); ok {
+		if resumedCheckout, resumedPayload, ok := w.resumeSelfDirtyWorktreeForRunner(ctx, job, payload, agent, err, jobRunner); ok {
 			checkout, payload, err = resumedCheckout, resumedPayload, nil
 		} else {
 			// Checkout-contention deferral (#532 slice C): a NON-delegation job whose
@@ -707,7 +715,7 @@ func (w jobWorker) run(ctx context.Context, job db.Job) error {
 	if warningRecorded {
 		adapter = w.observePermissionPolicyEffects(adapter, job.ID, checkout)
 	}
-	engine := w.WorkflowFactory(checkout)
+	engine := w.workflowForJob(checkout, jobRunner)
 	// Wire the PRE-TERMINAL operational-blocker deferrer (#532 slice E) on the LIVE
 	// worker (not the WorkflowFactory-captured copy) so it observes this worker's
 	// EventSink for the first-class job.deferred emit. When a delivery-seam failure
@@ -1848,6 +1856,10 @@ type tempWorkerStartResult struct {
 }
 
 func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload workflow.JobPayload, backend execbackend.Backend, original runtime.Agent, checkout string, policy config.ParallelSessionPolicy, reason string, observePermissionPolicy bool) error {
+	jobRunner, err := jobSubprocessRunnerForBackend(backend)
+	if err != nil {
+		return err
+	}
 	started, err := w.startTempWorker(ctx, job, payload, backend, original, checkout)
 	if err != nil {
 		if eventErr := w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "temp_worker_failed", Message: err.Error()}); eventErr != nil {
@@ -2020,7 +2032,7 @@ func (w jobWorker) runWithTempWorker(ctx context.Context, job db.Job, payload wo
 	if observePermissionPolicy {
 		adapter = w.observePermissionPolicyEffects(adapter, delegatedJob.ID, checkout)
 	}
-	engine := w.WorkflowFactory(checkout)
+	engine := w.workflowForJob(checkout, jobRunner)
 	_, err = engine.RunJob(runCtx, delegatedJob.ID, started.Agent, adapter)
 	stopKillPending()
 	if err != nil {
@@ -2238,7 +2250,7 @@ func (w jobWorker) startTempWorker(ctx context.Context, job db.Job, payload work
 // already the engine-assigned "-ephemeral-" name; callers register a deferred
 // cleanupTempWorker to auto-dispose the worker on every exit path. The worker
 // runs read-only unless the spec opts into a writable autonomy policy.
-func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload workflow.JobPayload, backend execbackend.Backend) (err error) {
+func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload workflow.JobPayload, backend execbackend.Backend, jobRunner subprocess.Runner) (err error) {
 	spec := payload.Ephemeral
 	if spec == nil {
 		return errors.New("ephemeral worker requires a spec")
@@ -2290,7 +2302,7 @@ func (w jobWorker) startEphemeralWorker(ctx context.Context, job db.Job, payload
 	// Normalize the stored policy back onto the in-memory agent so the runtime
 	// session is started with the same sandbox the rest of run will use.
 	ephemeralAgent.AutonomyPolicy = runtime.NormalizeStoredAutonomyPolicy(ephemeralAgent.AutonomyPolicy)
-	checkout, err := w.CheckoutValidator(ctx, job, payload, ephemeralAgent)
+	checkout, err := w.checkoutForJob(ctx, job, payload, ephemeralAgent, jobRunner)
 	if err != nil {
 		return err
 	}
@@ -2748,16 +2760,25 @@ func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
 		return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "advance_retry_skipped", Message: err.Error()})
 	}
 	agent := runtimeAgent(dbAgent)
-	if refreshed, ok, err := w.refreshImplementedPayloadForRetry(ctx, job, payload); err != nil {
+	jobBackend, jobBackendPresent := payload.ExecBackendOverride()
+	backend, err := daemonJobExecBackendFor(w, jobBackend, jobBackendPresent)
+	if err != nil {
+		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry backend resolution failed: "+err.Error())
+	}
+	jobRunner, err := jobSubprocessRunnerForBackend(backend)
+	if err != nil {
+		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry backend consumption failed: "+err.Error())
+	}
+	if refreshed, ok, err := w.refreshImplementedPayloadForRetry(ctx, job, payload, jobRunner); err != nil {
 		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry refresh failed: "+err.Error())
 	} else if ok {
 		payload = refreshed
 	}
-	checkout, err := w.CheckoutValidator(ctx, job, payload, agent)
+	checkout, err := w.checkoutForJob(ctx, job, payload, agent, jobRunner)
 	if err != nil {
 		return w.recordAdvanceRetryOnce(ctx, job.ID, "post-delivery workflow retry preflight failed: "+err.Error())
 	}
-	engine := w.WorkflowFactory(checkout)
+	engine := w.workflowForJob(checkout, jobRunner)
 	if err := engine.AdvanceJob(ctx, job.ID); err != nil {
 		var awaiting workflow.AwaitingHumanError
 		if errors.As(err, &awaiting) {
@@ -2776,15 +2797,15 @@ func (w jobWorker) advanceJob(ctx context.Context, job db.Job) error {
 	return engine.ReconcileTerminalDrivingJob(ctx, job.ID)
 }
 
-func (w jobWorker) refreshImplementedPayloadForRetry(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, bool, error) {
+func (w jobWorker) refreshImplementedPayloadForRetry(ctx context.Context, job db.Job, payload workflow.JobPayload, runner subprocess.Runner) (workflow.JobPayload, bool, error) {
 	if job.Type != "implement" || payload.Result == nil || payload.Result.Decision != "implemented" {
 		return payload, false, nil
 	}
-	checkout, err := w.resolveJobCheckout(ctx, job, payload)
+	checkout, err := w.resolveJobCheckoutForRunner(ctx, job, payload, runner)
 	if err != nil {
 		return workflow.JobPayload{}, false, err
 	}
-	payload, err = refreshDaemonJobPayload(ctx, w.Store, checkout, job, payload)
+	payload, err = refreshDaemonJobPayloadForRunner(ctx, w.Store, checkout, job, payload, runner)
 	if err != nil {
 		return workflow.JobPayload{}, false, err
 	}
@@ -2965,9 +2986,27 @@ func (w jobWorker) defaultStartAdapter(backend execbackend.Backend, runtimeName 
 }
 
 func (w jobWorker) defaultWorkflow(checkout string) workflow.Engine {
-	engine := daemonWorkflowEngine(w.Store, github.NewClient(checkout), checkout, w.workflowHome())
+	return w.defaultWorkflowForRunner(checkout, subprocess.ExecRunner{})
+}
+
+func (w jobWorker) defaultWorkflowForRunner(checkout string, runner subprocess.Runner) workflow.Engine {
+	engine := daemonWorkflowEngineForRunner(w.Store, github.NewClient(checkout), checkout, w.workflowHome(), runner)
 	w.applyOrchestratePolicy(&engine)
 	return engine
+}
+
+func (w jobWorker) checkoutForJob(ctx context.Context, job db.Job, payload workflow.JobPayload, agent runtime.Agent, runner subprocess.Runner) (string, error) {
+	if w.CheckoutValidator != nil {
+		return w.CheckoutValidator(ctx, job, payload, agent)
+	}
+	return w.defaultCheckoutForRunner(ctx, job, payload, agent, runner)
+}
+
+func (w jobWorker) workflowForJob(checkout string, runner subprocess.Runner) workflow.Engine {
+	if w.WorkflowFactory != nil {
+		return w.WorkflowFactory(checkout)
+	}
+	return w.defaultWorkflowForRunner(checkout, runner)
 }
 
 // applyOrchestratePolicy sets the engine's opt-in [orchestrate] fields — the

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -14,6 +14,7 @@ import (
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -21,10 +22,10 @@ import (
 // at compile time so the engine's runtime type-assertions can never silently fall
 // back (which would skip read-only-fanout or #332 integration worktrees).
 var (
-	_ workflow.WorktreeManager            = gitutil.Client{}
-	_ workflow.ReadOnlyWorktreeManager    = gitutil.Client{}
-	_ workflow.IntegrationWorktreeManager = gitutil.Client{}
-	_ workflow.WorktreeCommitter          = gitutil.Client{}
+	_ workflow.WorktreeManager            = (*gitutil.Client)(nil)
+	_ workflow.ReadOnlyWorktreeManager    = (*gitutil.Client)(nil)
+	_ workflow.IntegrationWorktreeManager = (*gitutil.Client)(nil)
+	_ workflow.WorktreeCommitter          = (*gitutil.Client)(nil)
 )
 
 // daemonWorkflowEngine builds the per-tick/per-repo workflow.Engine. Its `home`
@@ -36,13 +37,17 @@ var (
 // of which re-resolve — so handing it the raw --home would misplace delegation
 // artifacts and the event-sink config probe.
 func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, home string) workflow.Engine {
+	return daemonWorkflowEngineForRunner(store, gh, checkout, home, subprocess.ExecRunner{})
+}
+
+func daemonWorkflowEngineForRunner(store *db.Store, gh github.Client, checkout string, home string, runner subprocess.Runner) workflow.Engine {
 	engine := workflow.Engine{
 		Store:                   store,
 		RequireWorkflowPolicy:   requireWorkflowPolicyResolverRoot(home),
 		OrgPolicy:               orgPolicyResolverRoot(home),
 		ProduceCheckDir:         checkout,
-		MergeGate:               newDaemonMergeGate(store, gh, checkout, home),
-		ImplementationFinalizer: daemonImplementationFinalizer{Store: store, GitHub: gh, FallbackCheckout: checkout},
+		MergeGate:               newDaemonMergeGate(store, gh, checkout, home, runner),
+		ImplementationFinalizer: daemonImplementationFinalizer{Store: store, GitHub: gh, FallbackCheckout: checkout, Runner: runner},
 		// escalate_human (#340): @-tag the human on the tree's PR/issue when a leg
 		// pauses awaiting a decision. Best-effort and nil-safe in the engine; the
 		// handle is filled in from policy by applyOrchestratePolicy.
@@ -105,7 +110,7 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// no config NO verifier leg runs and NO hard row is written — byte-identical. A
 		// slow suite / unprovisionable sandbox never blocks or fails the merge; promotion
 		// stays manual.
-		HardVerifierDispatcher: daemonHardVerifierDispatcher(store, checkout, home),
+		HardVerifierDispatcher: daemonHardVerifierDispatcherForRunner(store, checkout, home, runner),
 		// Off-by-default agent persistent memory (#626, Phase 1 observation mode):
 		// when at least one agent is enrolled ([agents.<name>].memory = true) and the
 		// global kill switch is off, the engine's Mailbox injects a "Prior learnings"
@@ -131,7 +136,7 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 		// to the documented default warn on any load error.
 		ResultCheckMode: resultChecksMode(home),
 		PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
-			return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
+			return refreshDaemonJobPayloadForRunner(ctx, store, checkout, job, payload, runner)
 		},
 		// Gate the #484 canary ROUTING seam on the SAME policy.CanaryEnabled() the
 		// OutcomeHarvester's regression comparator above is gated on, so both seams
@@ -165,9 +170,9 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 	if strings.TrimSpace(home) != "" && strings.TrimSpace(checkout) != "" {
 		engine.Home = home
 		engine.DelegationCheckout = checkout
-		engine.DelegationWorktrees = gitutil.Client{Dir: checkout}
+		engine.DelegationWorktrees = jobGitClient(checkout, runner)
 		engine.FixWorktreeAllocator = func(ctx context.Context, request workflow.FixWorktreeRequest) (workflow.FixWorktreeAllocation, error) {
-			return allocateFixWorktree(ctx, store, home, checkout, request)
+			return allocateFixWorktreeForRunner(ctx, store, home, checkout, request, runner)
 		}
 	}
 	return engine
@@ -301,6 +306,11 @@ type daemonImplementationFinalizer struct {
 	Store            *db.Store
 	GitHub           github.Client
 	FallbackCheckout string
+	Runner           subprocess.Runner
+}
+
+func newHostDaemonImplementationFinalizer(store *db.Store, gh github.Client) daemonImplementationFinalizer {
+	return daemonImplementationFinalizer{Store: store, GitHub: gh, Runner: subprocess.ExecRunner{}}
 }
 
 type implementationFinalizationTarget struct {
@@ -327,6 +337,10 @@ const (
 // The returned task copy carries the resolved branch so the finalizer pushes and
 // opens the pull request for exactly the branch this predicate validated.
 func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, phase implementationFinalizationPhase) (implementationFinalizationTarget, error) {
+	return implementationFinalizationTargetForRunner(ctx, store, job, payload, phase, subprocess.ExecRunner{})
+}
+
+func implementationFinalizationTargetForRunner(ctx context.Context, store *db.Store, job db.Job, payload workflow.JobPayload, phase implementationFinalizationPhase, runner subprocess.Runner) (implementationFinalizationTarget, error) {
 	switch phase {
 	case implementationFinalizationBeforeRun, implementationFinalizationAfterRun:
 	default:
@@ -396,7 +410,7 @@ func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, j
 			missing, task.ID, payload.Repo, job.Agent, advice,
 		))
 	}
-	git := gitutil.Client{Dir: worktreePath}
+	git := jobGitClient(worktreePath, runner)
 	currentBranch, err := git.CurrentBranch(ctx)
 	if err != nil {
 		if phase == implementationFinalizationAfterRun {
@@ -459,13 +473,13 @@ func implementationFinalizationTargetFor(ctx context.Context, store *db.Store, j
 }
 
 func (f daemonImplementationFinalizer) FinalizeImplementation(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
-	target, err := implementationFinalizationTargetFor(ctx, f.Store, job, payload, implementationFinalizationAfterRun)
+	target, err := implementationFinalizationTargetForRunner(ctx, f.Store, job, payload, implementationFinalizationAfterRun, f.Runner)
 	if err != nil {
 		return payload, err
 	}
 	task := target.Task
 	worktreePath := target.WorktreePath
-	git := gitutil.Client{Dir: worktreePath}
+	git := jobGitClient(worktreePath, f.Runner)
 	validatedPR, hasValidatedPR, err := f.revalidateImplementationPullRequest(ctx, payload, task, worktreePath)
 	if err != nil {
 		return payload, err
@@ -730,13 +744,18 @@ type daemonMergeGate struct {
 	// Home is the resolved <home>/.gitmoot root (or raw --home) used to load the
 	// [merge_gate] policy (#596). Empty uses the default mandatory review-and-CI
 	// merge gate.
-	Home string
+	Home   string
+	Runner subprocess.Runner
 }
 
-func newDaemonMergeGate(store *db.Store, gh github.Client, checkout, home string) daemonMergeGate {
+func newDaemonMergeGate(store *db.Store, gh github.Client, checkout, home string, runner subprocess.Runner) daemonMergeGate {
 	return daemonMergeGate{
-		Store: store, GitHub: gh, FallbackCheckout: checkout, Home: home,
+		Store: store, GitHub: gh, FallbackCheckout: checkout, Home: home, Runner: runner,
 	}
+}
+
+func newHostDaemonMergeGate(store *db.Store, gh github.Client, checkout, home string) daemonMergeGate {
+	return newDaemonMergeGate(store, gh, checkout, home, subprocess.ExecRunner{})
 }
 
 func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeRequest) (workflow.MergeDecision, error) {
@@ -782,7 +801,7 @@ func (g daemonMergeGate) Evaluate(ctx context.Context, request workflow.MergeReq
 	if err != nil {
 		return workflow.MergeDecision{}, err
 	}
-	gate := newDaemonPolicyMergeGate(g.Store, g.githubClient(checkout), checkout)
+	gate := newDaemonPolicyMergeGateForRunner(g.Store, g.githubClient(checkout), checkout, g.Runner)
 	applyResolvedMergeGatePolicy(&gate, policy)
 	// The check above minimizes but does not eliminate the enqueue-to-merge race:
 	// gate.Evaluate still performs review/CI reads before the squash merge, so a job
@@ -914,22 +933,30 @@ func (g daemonMergeGate) githubClient(checkout string) github.Client {
 }
 
 func newDaemonPolicyMergeGate(store *db.Store, gh github.Client, checkout string) workflow.PolicyMergeGate {
+	return newDaemonPolicyMergeGateForRunner(store, gh, checkout, subprocess.ExecRunner{})
+}
+
+func newDaemonPolicyMergeGateForRunner(store *db.Store, gh github.Client, checkout string, runner subprocess.Runner) workflow.PolicyMergeGate {
 	return workflow.PolicyMergeGate{
 		Store:        store,
 		GitHub:       gh,
-		Git:          gitutil.Client{Dir: checkout},
-		Worktrees:    gitutil.Client{Dir: checkout},
+		Git:          jobGitClient(checkout, runner),
+		Worktrees:    jobGitClient(checkout, runner),
 		CheckoutPath: checkout,
 		DeleteBranch: true,
 	}
 }
 
 func refreshDaemonJobPayload(ctx context.Context, store *db.Store, checkout string, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
+	return refreshDaemonJobPayloadForRunner(ctx, store, checkout, job, payload, subprocess.ExecRunner{})
+}
+
+func refreshDaemonJobPayloadForRunner(ctx context.Context, store *db.Store, checkout string, job db.Job, payload workflow.JobPayload, runner subprocess.Runner) (workflow.JobPayload, error) {
 	if job.Type != "implement" || payload.Result == nil || payload.Result.Decision != "implemented" {
 		return payload, nil
 	}
 	if !payloadHasTaskWorktree(ctx, store, payload) {
-		head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+		head, err := jobGitClient(checkout, runner).HeadSHA(ctx)
 		if err != nil {
 			return workflow.JobPayload{}, err
 		}

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -41,6 +41,7 @@ func daemonWorkflowEngine(store *db.Store, gh github.Client, checkout string, ho
 }
 
 func daemonWorkflowEngineForRunner(store *db.Store, gh github.Client, checkout string, home string, runner subprocess.Runner) workflow.Engine {
+	gh = jobGitHubClient(checkout, gh, runner)
 	engine := workflow.Engine{
 		Store:                   store,
 		RequireWorkflowPolicy:   requireWorkflowPolicyResolverRoot(home),
@@ -164,7 +165,7 @@ func daemonWorkflowEngineForRunner(store *db.Store, gh github.Client, checkout s
 		engine.ArtifactRoot = home
 		engine.BeforeReadOnlyWorktreeCleanup = composeBeforeReadOnlyWorktreeCleanupHooks(
 			pipeline.PipelineServiceArtifactPrecleanupHook(store, config.Paths{Home: home}),
-			askReviewDiffPrecleanupHook(store),
+			askReviewDiffPrecleanupHookForRunner(store, runner),
 		)
 	}
 	if strings.TrimSpace(home) != "" && strings.TrimSpace(checkout) != "" {
@@ -605,13 +606,7 @@ func (f daemonImplementationFinalizer) FinalizeImplementation(ctx context.Contex
 }
 
 func (f daemonImplementationFinalizer) githubClient(checkout string) github.Client {
-	if f.GitHub == nil {
-		return github.NewClient(checkout)
-	}
-	if _, ok := f.GitHub.(*github.GhClient); ok {
-		return github.NewClient(checkout)
-	}
-	return f.GitHub
+	return jobGitHubClient(checkout, f.GitHub, f.Runner)
 }
 
 func (f daemonImplementationFinalizer) revalidateImplementationPullRequest(ctx context.Context, payload workflow.JobPayload, task db.Task, worktreePath string) (github.PullRequest, bool, error) {
@@ -923,13 +918,7 @@ func nativeMergeGateDisabled() bool {
 }
 
 func (g daemonMergeGate) githubClient(checkout string) github.Client {
-	if g.GitHub == nil {
-		return github.NewClient(checkout)
-	}
-	if _, ok := g.GitHub.(*github.GhClient); ok {
-		return github.NewClient(checkout)
-	}
-	return g.GitHub
+	return jobGitHubClient(checkout, g.GitHub, g.Runner)
 }
 
 func newDaemonPolicyMergeGate(store *db.Store, gh github.Client, checkout string) workflow.PolicyMergeGate {

--- a/internal/cli/daemon_workflow_test.go
+++ b/internal/cli/daemon_workflow_test.go
@@ -36,7 +36,7 @@ func TestRefreshDaemonJobPayloadPreservesTaskWorktreeHeadForFinalizer(t *testing
 	runGit(t, checkout, "branch", "-m", "main")
 	runGit(t, checkout, "push", "-u", "origin", "main")
 	runGit(t, checkout, "worktree", "add", "-b", "task-1", worktree, "main")
-	oldHead, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	oldHead, err := (gitutil.NewHostClient(worktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestRefreshDaemonJobPayloadPreservesTaskWorktreeHeadForFinalizer(t *testing
 	}
 	runGit(t, worktree, "add", "feature.txt")
 	runGit(t, worktree, "commit", "-m", "agent self commit")
-	newHead, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	newHead, err := (gitutil.NewHostClient(worktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestRefreshDaemonJobPayloadPreservesTaskWorktreeHeadForFinalizer(t *testing
 	if refreshed.HeadSHA != oldHead {
 		t.Fatalf("refreshed head = %q, want original %q", refreshed.HeadSHA, oldHead)
 	}
-	finalized, err := (daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}).FinalizeImplementation(ctx, db.Job{ID: "job-implement-worktree", Agent: "lead", Type: "implement"}, refreshed)
+	finalized, err := (newHostDaemonImplementationFinalizer(store, github.NoopClient{})).FinalizeImplementation(ctx, db.Job{ID: "job-implement-worktree", Agent: "lead", Type: "implement"}, refreshed)
 	if err != nil {
 		t.Fatalf("FinalizeImplementation returned error: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestDaemonImplementationFinalizerCommitsBeforeReusingExistingPullRequest(t 
 	if err := store.UpsertPullRequest(ctx, db.PullRequest{RepoFullName: "owner/repo", Number: 12, URL: "https://github.com/owner/repo/pull/12", HeadBranch: "task-1", BaseBranch: "main", HeadSHA: "old", State: "open"}); err != nil {
 		t.Fatalf("UpsertPullRequest returned error: %v", err)
 	}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	finalizer := newHostDaemonImplementationFinalizer(store, github.NoopClient{})
 	payload := workflow.JobPayload{
 		Repo:      "owner/repo",
 		Branch:    "task-1",
@@ -138,14 +138,14 @@ func TestDaemonImplementationFinalizerCommitsBeforeReusingExistingPullRequest(t 
 	if finalized.PullRequest != 12 {
 		t.Fatalf("pull request = %d, want 12", finalized.PullRequest)
 	}
-	clean, err := (gitutil.Client{Dir: repoDir}).WorktreeClean(ctx)
+	clean, err := (gitutil.NewHostClient(repoDir)).WorktreeClean(ctx)
 	if err != nil {
 		t.Fatalf("WorktreeClean returned error: %v", err)
 	}
 	if !clean {
 		t.Fatal("worktree still has uncommitted changes")
 	}
-	localHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	localHead, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestDaemonImplementationFinalizerAdoptsExistingPullRequestViaEnsure(t *test
 		HeadRef: "task-1",
 		BaseRef: "main",
 	}}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	finalizer := newHostDaemonImplementationFinalizer(store, gh)
 	payload := workflow.JobPayload{
 		Repo:      "owner/repo",
 		Branch:    "task-1",
@@ -279,7 +279,7 @@ func TestDaemonImplementationFinalizerPersistsSkipFanoutBeforeOpeningPR(t *testi
 		HeadRef: "task-1",
 		BaseRef: "main",
 	}}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	finalizer := newHostDaemonImplementationFinalizer(store, gh)
 	payload := workflow.JobPayload{
 		Repo:                   "owner/repo",
 		Branch:                 "task-1",
@@ -336,7 +336,7 @@ func TestDaemonImplementationFinalizerPersistsSkipFanoutOnNoChangeReFinalize(t *
 	}
 	runGit(t, repoDir, "add", "feature.txt")
 	runGit(t, repoDir, "commit", "-m", "work")
-	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -354,7 +354,7 @@ func TestDaemonImplementationFinalizerPersistsSkipFanoutOnNoChangeReFinalize(t *
 	}
 	// Clean worktree + PR already attached + head unchanged ⇒ the no-changes early
 	// return. NoopClient: no PR-open call is expected on this path.
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	finalizer := newHostDaemonImplementationFinalizer(store, github.NoopClient{})
 	payload := workflow.JobPayload{
 		Repo:                   "owner/repo",
 		Branch:                 "task-1",
@@ -401,7 +401,7 @@ func TestDaemonImplementationFinalizerPushesAlreadyCommittedWork(t *testing.T) {
 	runGit(t, repoDir, "branch", "-m", "main")
 	runGit(t, repoDir, "push", "-u", "origin", "main")
 	runGit(t, repoDir, "switch", "-c", "task-1")
-	oldHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	oldHead, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -422,7 +422,7 @@ func TestDaemonImplementationFinalizerPushesAlreadyCommittedWork(t *testing.T) {
 	if err := store.UpsertPullRequest(ctx, db.PullRequest{RepoFullName: "owner/repo", Number: 12, URL: "https://github.com/owner/repo/pull/12", HeadBranch: "task-1", BaseBranch: "main", HeadSHA: oldHead, State: "open"}); err != nil {
 		t.Fatalf("UpsertPullRequest returned error: %v", err)
 	}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	finalizer := newHostDaemonImplementationFinalizer(store, github.NoopClient{})
 	payload := workflow.JobPayload{
 		Repo:      "owner/repo",
 		Branch:    "task-1",
@@ -438,7 +438,7 @@ func TestDaemonImplementationFinalizerPushesAlreadyCommittedWork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FinalizeImplementation returned error: %v", err)
 	}
-	localHead, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	localHead, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -480,7 +480,7 @@ func TestDaemonImplementationFinalizerBlocksWrongBranch(t *testing.T) {
 	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	finalizer := newHostDaemonImplementationFinalizer(store, github.NoopClient{})
 	payload := workflow.JobPayload{
 		Repo:      "owner/repo",
 		Branch:    "task-1",
@@ -518,7 +518,7 @@ func TestDaemonImplementationFinalizerAllowsAlreadyFinalizedPullRequest(t *testi
 	runGit(t, repoDir, "branch", "-m", "main")
 	runGit(t, repoDir, "push", "-u", "origin", "main")
 	runGit(t, repoDir, "switch", "-c", "task-1")
-	head, err := (gitutil.Client{Dir: repoDir}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(repoDir)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -531,7 +531,7 @@ func TestDaemonImplementationFinalizerAllowsAlreadyFinalizedPullRequest(t *testi
 	if err := store.UpsertTask(ctx, db.Task{ID: "task-1", RepoFullName: "owner/repo", GoalID: "goal-1", Title: "Task 1", State: string(workflow.TaskImplementing), Branch: "task-1", WorktreePath: repoDir}); err != nil {
 		t.Fatalf("UpsertTask returned error: %v", err)
 	}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}
+	finalizer := newHostDaemonImplementationFinalizer(store, github.NoopClient{})
 	payload := workflow.JobPayload{
 		Repo:        "owner/repo",
 		Branch:      "task-1",
@@ -762,7 +762,7 @@ func TestDaemonImplementationFinalizerPersistsSkipFanoutWhenExecutorIsDelegatedW
 		HeadRef: "task-busy",
 		BaseRef: "main",
 	}}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	finalizer := newHostDaemonImplementationFinalizer(store, gh)
 	payload := workflow.JobPayload{
 		Repo:                   "owner/repo",
 		Branch:                 "task-busy",
@@ -862,7 +862,7 @@ func TestDaemonImplementationFinalizerPreservesPrearmedSkipFanoutWhenPayloadIsFa
 		HeadRef: "task-fixround",
 		BaseRef: "main",
 	}}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	finalizer := newHostDaemonImplementationFinalizer(store, gh)
 	payload := workflow.JobPayload{
 		Repo:                   "owner/repo",
 		Branch:                 "task-fixround",

--- a/internal/cli/draft_pr_test.go
+++ b/internal/cli/draft_pr_test.go
@@ -82,7 +82,7 @@ func TestImplementationFinalizerOpensForgePullRequestInRequestedMode(t *testing.
 				TaskTitle: fixture.task.Title, LeadAgent: "lead", PullRequestReady: request.PullRequestReady,
 				Result: &workflow.AgentResult{Decision: "implemented", Summary: "done"},
 			}
-			finalized, err := (daemonImplementationFinalizer{Store: fixture.store, GitHub: gh}).FinalizeImplementation(
+			finalized, err := (newHostDaemonImplementationFinalizer(fixture.store, gh)).FinalizeImplementation(
 				context.Background(), db.Job{ID: "implement", Agent: "lead", Type: "implement"}, payload,
 			)
 			if err != nil {

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -159,7 +159,8 @@ func TestExecBackendLocalExplicitDaemonE2E(t *testing.T) {
 
 // TestExecBackendUnknownFailsLoudDaemonE2E is ACCEPTANCE 3: an unknown
 // backend — "e2b" (not implemented until P5) and the typo "loca" — FAILS LOUD
-// at dispatch naming the value AND the allowed set; the job never runs.
+// at background dispatch naming the value AND the allowed set; no pre-enqueue
+// git preparation or job execution is allowed to run on the host.
 func TestExecBackendUnknownFailsLoudDaemonE2E(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -170,46 +171,43 @@ func TestExecBackendUnknownFailsLoudDaemonE2E(t *testing.T) {
 		{name: "explicit blank", value: ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
 			marker := filepath.Join(t.TempDir(), "must-not-run")
 			home, store := effectiveRuntimeE2EHome(t, runtimeOverrideShellScript(marker))
 			execBackendAppendConfig(t, home, "\n[remote_exec]\nbackend = \""+tc.value+"\"\n")
-			jobID := execBackendDispatchAsk(t, home)
-			execBackendRunOneTick(t, home, store)
+
+			var out, errBuf bytes.Buffer
+			code := Run([]string{
+				"agent", "ask", "shell-asker", "exec backend background probe",
+				"--home", home,
+				"--repo", "owner/repo",
+				"--background",
+				"--json",
+			}, &out, &errBuf)
+			if code == 0 {
+				t.Fatalf("background ask exit = 0, output=%s; want loud backend refusal", out.String())
+			}
 
 			if _, err := os.Stat(marker); !os.IsNotExist(err) {
 				t.Fatalf("adapter ran with an unknown backend (marker err=%v)", err)
 			}
-			job, err := store.GetJob(ctx, jobID)
+			jobs, err := store.ListJobs(context.Background())
 			if err != nil {
-				t.Fatalf("GetJob: %v", err)
+				t.Fatalf("ListJobs: %v", err)
 			}
-			if job.State != string(workflow.JobFailed) {
-				t.Fatalf("job state = %q, want failed", job.State)
-			}
-			events, err := store.ListJobEvents(ctx, jobID)
-			if err != nil {
-				t.Fatalf("ListJobEvents: %v", err)
-			}
-			var failedMessage string
-			for _, event := range events {
-				if event.Kind == "running" {
-					t.Fatalf("job reached running with an unknown backend: %+v", event)
-				}
-				if event.Kind == string(workflow.JobFailed) {
-					failedMessage = event.Message
-				}
+			if len(jobs) != 0 {
+				t.Fatalf("jobs = %+v, want no enqueued row after background preflight refusal", jobs)
 			}
 			// The loud error must name the offending value AND the allowed set
 			// AND its config source — not just be a non-zero exit.
+			failedMessage := errBuf.String()
 			if !strings.Contains(failedMessage, `"`+tc.value+`"`) {
-				t.Fatalf("failed event = %q, want it to name %q", failedMessage, tc.value)
+				t.Fatalf("dispatch error = %q, want it to name %q", failedMessage, tc.value)
 			}
 			if !strings.Contains(failedMessage, "allowed: local") {
-				t.Fatalf("failed event = %q, want the allowed set named", failedMessage)
+				t.Fatalf("dispatch error = %q, want the allowed set named", failedMessage)
 			}
 			if !strings.Contains(failedMessage, "[remote_exec].backend") {
-				t.Fatalf("failed event = %q, want the config key named", failedMessage)
+				t.Fatalf("dispatch error = %q, want the config key named", failedMessage)
 			}
 		})
 	}

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -479,6 +479,75 @@ func TestP2GapEveryJobSubprocessRouteRefusesLocalFallback(t *testing.T) {
 	}
 }
 
+func TestP2GapSupervisorAdvanceResolvesJobSubprocessRunner(t *testing.T) {
+	home, paths, store := heartbeatLoopE2EHome(t)
+	poller := defaultRegisteredRepoPoller(store, 1, false, io.Discard, home, paths.Home)
+	checkout := t.TempDir()
+	repoRecord := db.Repo{Owner: "owner", Name: "repo", CheckoutPath: checkout, PollInterval: "30s"}
+	if err := store.UpsertRepo(context.Background(), repoRecord); err != nil {
+		t.Fatalf("upsert repo: %v", err)
+	}
+	if err := store.UpsertTask(context.Background(), db.Task{
+		ID: "task-p2-supervisor", RepoFullName: repoRecord.FullName(), GoalID: "goal-p2",
+		Title: "P2 supervisor", State: string(workflow.TaskReviewing), Branch: "task-p2",
+	}); err != nil {
+		t.Fatalf("upsert task: %v", err)
+	}
+	if err := store.UpsertPullRequest(context.Background(), db.PullRequest{
+		RepoFullName: repoRecord.FullName(), Number: 7, HeadBranch: "task-p2",
+		BaseBranch: "main", HeadSHA: "p2-head", State: "open",
+	}); err != nil {
+		t.Fatalf("upsert pull request: %v", err)
+	}
+	payload := workflow.JobPayload{
+		Repo: repoRecord.FullName(), Branch: "task-p2", PullRequest: 7,
+		HeadSHA: "p2-head", TaskID: "task-p2-supervisor", ExecBackend: "p2-probe",
+		LeadAgent: "lead", ReviewRound: "round-p2", Reviewers: []string{"audit"},
+		Result: &workflow.AgentResult{Decision: "approved", Summary: "probe"},
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	job := db.Job{
+		ID:      "p2-supervisor-advance",
+		Type:    "review",
+		State:   string(workflow.JobSucceeded),
+		Payload: string(encoded),
+	}
+	if err := store.CreateJobWithEvent(context.Background(), job, db.JobEvent{
+		JobID: job.ID, Kind: string(workflow.JobSucceeded), Message: "probe",
+	}); err != nil {
+		t.Fatalf("create review job: %v", err)
+	}
+	poller.GitHubClient = func(string) github.Client {
+		return &cliPollFakeGitHub{pulls: []github.PullRequest{{
+			Number: 7, Title: "P2 supervisor", State: "open", HeadRef: "task-p2", BaseRef: "main", HeadSHA: "p2-head",
+		}}}
+	}
+
+	previousResolver := daemonJobExecBackendFor
+	var resolvedName string
+	var resolvedPresent bool
+	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, error) {
+		resolvedName = name
+		resolvedPresent = present
+		return execbackend.Backend("p2-probe"), nil
+	}
+	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
+
+	result, err := poller.pollRepo(context.Background(), repoRecord, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("poll repo persistence error: %v", err)
+	}
+	if !strings.Contains(result.LastError, "p2-probe") {
+		t.Fatalf("supervisor job workflow error = %q, want fail-closed p2-probe refusal", result.LastError)
+	}
+	if resolvedName != "p2-probe" || !resolvedPresent {
+		t.Fatalf("supervisor resolved name=%q present=%v, want stored p2-probe override", resolvedName, resolvedPresent)
+	}
+}
+
 // TestJobCheckoutRouteConsumesResolvedSubprocessRunner pins the production
 // checkoutForJob call site. Replacing defaultCheckoutForRunner with the
 // host-only defaultCheckout wrapper compiles, but ignores this resolved runner

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -65,8 +65,9 @@ func (r *p2ProbeSubprocessRunner) RunEnv(ctx context.Context, dir string, _ []st
 	return r.Run(ctx, dir, command, args...)
 }
 
-func (r *p2ProbeSubprocessRunner) RunExactEnv(ctx context.Context, dir string, _ []string, command string, args ...string) (subprocess.Result, error) {
-	return r.Run(ctx, dir, command, args...)
+func (r *p2ProbeSubprocessRunner) RunExactEnv(ctx context.Context, dir string, _ []string, _, _ io.Writer, command string, args ...string) error {
+	_, err := r.Run(ctx, dir, command, args...)
+	return err
 }
 
 func (r *p2ProbeSubprocessRunner) LookPath(string) (string, error) {

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -6,6 +6,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
 	"path/filepath"
@@ -44,6 +47,22 @@ var execBackendLocalEventKindBaseline = []string{
 	"advance_started",
 	"delegation_worktree_removed",
 	"advance_completed",
+}
+
+var errP2ProbeSubprocessReached = errors.New("p2-probe subprocess runner reached")
+
+type p2ProbeSubprocessRunner struct {
+	calls int
+}
+
+func (r *p2ProbeSubprocessRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
+	r.calls++
+	return subprocess.Result{}, errP2ProbeSubprocessReached
+}
+
+func (r *p2ProbeSubprocessRunner) LookPath(string) (string, error) {
+	r.calls++
+	return "", errP2ProbeSubprocessReached
 }
 
 // execBackendDispatchAsk enqueues a background shell ask and returns its job id.
@@ -347,6 +366,180 @@ func TestP2GapJobSubprocessRoutesRefuseLocalFallback(t *testing.T) {
 	}
 	if _, err := jobSubprocessRunnerForBackend(execbackend.Backend("p2-probe")); err == nil {
 		t.Fatal("p2-probe inherited the local job subprocess runner")
+	}
+}
+
+// TestP2GapEveryJobSubprocessRouteRefusesLocalFallback drives the stored-job
+// selector through every subprocess route shape. A future backend may parse as
+// implemented, but it cannot reach checkout, git, or verifier execution until
+// Consume has a corresponding runner builder.
+func TestP2GapEveryJobSubprocessRouteRefusesLocalFallback(t *testing.T) {
+	const backend = execbackend.Backend("p2-probe")
+	job := db.Job{
+		ID:      "p2-job-subprocess-route",
+		Type:    "ask",
+		Payload: `{"repo":"owner/repo","sender":"local","instructions":"probe","exec_backend":"p2-probe"}`,
+	}
+	payload := workflow.JobPayload{
+		Repo:         "owner/repo",
+		FixWorktree:  true,
+		WorktreePath: t.TempDir(),
+	}
+	worker := jobWorker{}
+
+	previousResolver := daemonJobExecBackendFor
+	var resolvedName string
+	var resolvedPresent bool
+	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, error) {
+		resolvedName = name
+		resolvedPresent = present
+		return backend, nil
+	}
+	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
+
+	routeRunner := func() (subprocess.Runner, error) {
+		return worker.subprocessRunnerForJob(job)
+	}
+	routes := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "stored payload resolver",
+			run: func() error {
+				_, err := routeRunner()
+				return err
+			},
+		},
+		{
+			name: "default checkout",
+			run: func() error {
+				runner, err := routeRunner()
+				if err != nil {
+					return err
+				}
+				_, err = worker.defaultCheckoutForRunner(context.Background(), job, payload, runtime.Agent{}, runner)
+				return err
+			},
+		},
+		{
+			name: "checkout resolution",
+			run: func() error {
+				runner, err := routeRunner()
+				if err != nil {
+					return err
+				}
+				_, err = worker.resolveJobCheckoutForRunner(context.Background(), job, payload, runner)
+				return err
+			},
+		},
+		{
+			name: "git client",
+			run: func() error {
+				runner, err := routeRunner()
+				if err != nil {
+					return err
+				}
+				_, err = jobGitClient(t.TempDir(), runner).HeadSHA(context.Background())
+				return err
+			},
+		},
+		{
+			name: "hard verifier",
+			run: func() error {
+				runner, err := routeRunner()
+				if err != nil {
+					return err
+				}
+				_ = daemonHardVerifierDispatcherForRunner(nil, t.TempDir(), t.TempDir(), runner)
+				return errors.New("future backend reached hard verifier construction")
+			},
+		},
+	}
+	for _, route := range routes {
+		t.Run(route.name, func(t *testing.T) {
+			err := route.run()
+			if err == nil || !strings.Contains(err.Error(), string(backend)) {
+				t.Fatalf("route error = %v, want fail-closed refusal naming %q", err, backend)
+			}
+		})
+	}
+	if resolvedName != string(backend) || !resolvedPresent {
+		t.Fatalf("subprocessRunnerForJob resolved name=%q present=%v, want stored override %q present", resolvedName, resolvedPresent, backend)
+	}
+}
+
+// TestJobCheckoutRouteConsumesResolvedSubprocessRunner pins the production
+// checkoutForJob call site. Replacing defaultCheckoutForRunner with the
+// host-only defaultCheckout wrapper compiles, but ignores this resolved runner
+// and makes the test fail by executing git locally.
+func TestJobCheckoutRouteConsumesResolvedSubprocessRunner(t *testing.T) {
+	ctx := context.Background()
+	_, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	runner := &p2ProbeSubprocessRunner{}
+	worker := jobWorker{Store: store}
+	_, err := worker.checkoutForJob(
+		ctx,
+		db.Job{ID: "p2-checkout-route", Type: "ask"},
+		workflow.JobPayload{Repo: "owner/repo"},
+		runtime.Agent{},
+		runner,
+	)
+	if !errors.Is(err, errP2ProbeSubprocessReached) {
+		t.Fatalf("checkout error = %v, want resolved p2-probe runner refusal", err)
+	}
+	if runner.calls == 0 {
+		t.Fatal("checkout route ignored the resolved p2-probe subprocess runner")
+	}
+}
+
+// TestJobSubprocessProductionRoutesDoNotCallHostWrappers binds the package
+// contract to every production call site. The wrappers remain for focused
+// legacy tests only; using one from non-test code would silently substitute an
+// ExecRunner and bypass the resolved backend.
+func TestJobSubprocessProductionRoutesDoNotCallHostWrappers(t *testing.T) {
+	forbidden := map[string]struct{}{
+		"defaultCheckout":            {},
+		"resolveJobCheckout":         {},
+		"healRegisteredRepoCheckout": {},
+		"validateTargetCheckout":     {},
+		"validateReviewCheckout":     {},
+		"resyncReviewHead":           {},
+	}
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	var violations []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			call, ok := node.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if _, blocked := forbidden[selector.Sel.Name]; blocked {
+				violations = append(violations, fset.Position(selector.Sel.Pos()).String())
+			}
+			return true
+		})
+	}
+	if len(violations) != 0 {
+		t.Fatalf("production job subprocess routes call host-only wrappers: %v", violations)
 	}
 }
 

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/execbackend"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -58,6 +59,14 @@ type p2ProbeSubprocessRunner struct {
 func (r *p2ProbeSubprocessRunner) Run(context.Context, string, string, ...string) (subprocess.Result, error) {
 	r.calls++
 	return subprocess.Result{}, errP2ProbeSubprocessReached
+}
+
+func (r *p2ProbeSubprocessRunner) RunEnv(ctx context.Context, dir string, _ []string, command string, args ...string) (subprocess.Result, error) {
+	return r.Run(ctx, dir, command, args...)
+}
+
+func (r *p2ProbeSubprocessRunner) RunExactEnv(ctx context.Context, dir string, _ []string, command string, args ...string) (subprocess.Result, error) {
+	return r.Run(ctx, dir, command, args...)
 }
 
 func (r *p2ProbeSubprocessRunner) LookPath(string) (string, error) {
@@ -495,18 +504,68 @@ func TestJobCheckoutRouteConsumesResolvedSubprocessRunner(t *testing.T) {
 	}
 }
 
+func TestReadOnlyDiffRouteConsumesResolvedSubprocessRunner(t *testing.T) {
+	runner := &p2ProbeSubprocessRunner{}
+	if _, _, err := captureReadOnlyWorktreeDiffForRunner(context.Background(), t.TempDir(), runner); !errors.Is(err, errP2ProbeSubprocessReached) {
+		t.Fatalf("diff capture error = %v, want resolved p2-probe runner refusal", err)
+	}
+	if runner.calls == 0 {
+		t.Fatal("read-only diff route ignored the resolved p2-probe subprocess runner")
+	}
+}
+
+func TestJobGitHubClientConsumesResolvedSubprocessRunner(t *testing.T) {
+	runner := &p2ProbeSubprocessRunner{}
+	source := &github.GhClient{
+		MaxRetries: 1,
+		Limiter:    github.NewRateLimiter(github.RateLimiterConfig{}),
+	}
+	client := jobGitHubClient(t.TempDir(), source, runner)
+	if err := client.Ping(context.Background()); !errors.Is(err, errP2ProbeSubprocessReached) {
+		t.Fatalf("GitHub client error = %v, want resolved p2-probe runner refusal", err)
+	}
+	if runner.calls == 0 {
+		t.Fatal("job GitHub client ignored the resolved p2-probe subprocess runner")
+	}
+}
+
+func TestDaemonWorkflowGitHubRoutesConsumeResolvedSubprocessRunner(t *testing.T) {
+	runner := &p2ProbeSubprocessRunner{}
+	source := &github.GhClient{
+		MaxRetries: 1,
+		Limiter:    github.NewRateLimiter(github.RateLimiterConfig{}),
+	}
+	checkout := t.TempDir()
+	engine := daemonWorkflowEngineForRunner(nil, source, checkout, "", runner)
+	finalizer, ok := engine.ImplementationFinalizer.(daemonImplementationFinalizer)
+	if !ok {
+		t.Fatalf("implementation finalizer = %T, want daemonImplementationFinalizer", engine.ImplementationFinalizer)
+	}
+	if err := finalizer.githubClient(checkout).Ping(context.Background()); !errors.Is(err, errP2ProbeSubprocessReached) {
+		t.Fatalf("finalizer GitHub error = %v, want resolved p2-probe runner refusal", err)
+	}
+	gate, ok := engine.MergeGate.(daemonMergeGate)
+	if !ok {
+		t.Fatalf("merge gate = %T, want daemonMergeGate", engine.MergeGate)
+	}
+	if err := gate.githubClient(checkout).Ping(context.Background()); !errors.Is(err, errP2ProbeSubprocessReached) {
+		t.Fatalf("merge-gate GitHub error = %v, want resolved p2-probe runner refusal", err)
+	}
+}
+
 // TestJobSubprocessProductionRoutesDoNotCallHostWrappers binds the package
 // contract to every production call site. The wrappers remain for focused
 // legacy tests only; using one from non-test code would silently substitute an
 // ExecRunner and bypass the resolved backend.
 func TestJobSubprocessProductionRoutesDoNotCallHostWrappers(t *testing.T) {
 	forbidden := map[string]struct{}{
-		"defaultCheckout":            {},
-		"resolveJobCheckout":         {},
-		"healRegisteredRepoCheckout": {},
-		"validateTargetCheckout":     {},
-		"validateReviewCheckout":     {},
-		"resyncReviewHead":           {},
+		"defaultCheckout":             {},
+		"resolveJobCheckout":          {},
+		"healRegisteredRepoCheckout":  {},
+		"validateTargetCheckout":      {},
+		"validateReviewCheckout":      {},
+		"resyncReviewHead":            {},
+		"askReviewDiffPrecleanupHook": {},
 	}
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -534,6 +593,16 @@ func TestJobSubprocessProductionRoutesDoNotCallHostWrappers(t *testing.T) {
 			}
 			if _, blocked := forbidden[selector.Sel.Name]; blocked {
 				violations = append(violations, fset.Position(selector.Sel.Pos()).String())
+			}
+			if pkg, ok := selector.X.(*ast.Ident); ok && pkg.Name == "exec" &&
+				(selector.Sel.Name == "Command" || selector.Sel.Name == "CommandContext") && len(call.Args) != 0 {
+				commandArg := call.Args[0]
+				if selector.Sel.Name == "CommandContext" && len(call.Args) > 1 {
+					commandArg = call.Args[1]
+				}
+				if literal, ok := commandArg.(*ast.BasicLit); ok && (literal.Value == `"git"` || literal.Value == `"gh"`) {
+					violations = append(violations, fset.Position(selector.Sel.Pos()).String())
+				}
 			}
 			return true
 		})

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -548,6 +548,51 @@ func TestP2GapSupervisorAdvanceResolvesJobSubprocessRunner(t *testing.T) {
 	}
 }
 
+func TestP2GapSingleRepoSupervisorAdvanceResolvesJobSubprocessRunner(t *testing.T) {
+	home, paths, store := heartbeatLoopE2EHome(t)
+	payload, err := json.Marshal(workflow.JobPayload{ExecBackend: "p2-probe"})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	previousResolver := daemonJobExecBackendFor
+	var resolvedName string
+	var resolvedPresent bool
+	daemonJobExecBackendFor = func(_ jobWorker, name string, present bool) (execbackend.Backend, error) {
+		resolvedName = name
+		resolvedPresent = present
+		return execbackend.Backend("p2-probe"), nil
+	}
+	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
+
+	checkout := t.TempDir()
+	supervisor := newSingleRepoSupervisorDaemon(
+		github.Repository{Owner: "owner", Name: "repo"},
+		store,
+		&cliPollFakeGitHub{},
+		workflow.Engine{Store: store},
+		home,
+		paths.Home,
+		checkout,
+		io.Discard,
+		30*time.Second,
+		false,
+	)
+	if supervisor.WorkflowForJob == nil {
+		t.Fatal("single-repo supervisor has no job-specific workflow factory")
+	}
+	_, err = supervisor.WorkflowForJob(context.Background(), db.Job{
+		ID:      "p2-single-repo-supervisor",
+		Payload: string(payload),
+	})
+	if err == nil || !strings.Contains(err.Error(), "p2-probe") {
+		t.Fatalf("single-repo supervisor workflow error = %v, want fail-closed p2-probe refusal", err)
+	}
+	if resolvedName != "p2-probe" || !resolvedPresent {
+		t.Fatalf("single-repo supervisor resolved name=%q present=%v, want stored p2-probe override", resolvedName, resolvedPresent)
+	}
+}
+
 // TestJobCheckoutRouteConsumesResolvedSubprocessRunner pins the production
 // checkoutForJob call site. Replacing defaultCheckoutForRunner with the
 // host-only defaultCheckout wrapper compiles, but ignores this resolved runner

--- a/internal/cli/execbackend_e2e_test.go
+++ b/internal/cli/execbackend_e2e_test.go
@@ -302,11 +302,26 @@ func TestExecBackendResolvedNonLocalCannotRunLocallyDaemonE2E(t *testing.T) {
 	}
 	t.Cleanup(func() { daemonJobExecBackendFor = previousResolver })
 
-	execBackendRunOneTick(t, home, store)
+	checkoutCalls := 0
+	worker := defaultJobWorker(store, io.Discard, home)
+	worker.CheckoutValidator = func(context.Context, db.Job, workflow.JobPayload, runtime.Agent) (string, error) {
+		checkoutCalls++
+		return t.TempDir(), nil
+	}
+	job, err := store.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("GetJob before run: %v", err)
+	}
+	if err := worker.run(ctx, job); err != nil {
+		t.Fatalf("worker run: %v", err)
+	}
+	if checkoutCalls != 0 {
+		t.Fatalf("checkout validation calls = %d, want zero before non-local runner refusal", checkoutCalls)
+	}
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Fatalf("daemon adapter ran locally for a resolved non-local backend (marker err=%v)", err)
 	}
-	job, err := store.GetJob(ctx, jobID)
+	job, err = store.GetJob(ctx, jobID)
 	if err != nil {
 		t.Fatalf("GetJob: %v", err)
 	}
@@ -321,6 +336,19 @@ func TestExecBackendResolvedNonLocalCannotRunLocallyDaemonE2E(t *testing.T) {
 	failedMessages := execBackendEvents(t, store, jobID)
 	if len(failedMessages) != 1 || !strings.Contains(failedMessages[0], `"p2-probe"`) || !strings.Contains(failedMessages[0], "no execution implementation") {
 		t.Fatalf("failed events = %q, want resolved backend and missing daemon implementation named", failedMessages)
+	}
+}
+
+// TestP2GapJobSubprocessRoutesRefuseLocalFallback pins the one consumption
+// seam used before job-associated checkout and git work. The P2 overlay adds
+// p2-probe to the implemented registry; a compile-valid mutation that maps it
+// to ExecRunner must make this test fail rather than execute on the host.
+func TestP2GapJobSubprocessRoutesRefuseLocalFallback(t *testing.T) {
+	if backend, err := execbackend.ParseImplemented("p2-probe"); err == nil {
+		t.Fatalf("%s became implemented; add its job subprocess runner before updating this guard", backend)
+	}
+	if _, err := jobSubprocessRunnerForBackend(execbackend.Backend("p2-probe")); err == nil {
+		t.Fatal("p2-probe inherited the local job subprocess runner")
 	}
 }
 

--- a/internal/cli/execbackend_subprocess.go
+++ b/internal/cli/execbackend_subprocess.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/execbackend"
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
+	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
@@ -53,4 +54,14 @@ var _ subprocess.Runner = localJobSubprocessRunner{}
 
 func jobGitClient(dir string, runner subprocess.Runner) gitutil.Client {
 	return gitutil.NewClient(dir, runner)
+}
+
+func jobGitHubClient(dir string, client github.Client, runner subprocess.Runner) github.Client {
+	if gh, ok := client.(*github.GhClient); ok {
+		return gh.WithRunner(dir, runner)
+	}
+	if client != nil {
+		return client
+	}
+	return github.NewClientWithRunner(dir, runner)
 }

--- a/internal/cli/execbackend_subprocess.go
+++ b/internal/cli/execbackend_subprocess.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+	gitutil "github.com/gitmoot/gitmoot/internal/git"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
+)
+
+type localJobSubprocessRunner struct {
+	subprocess.ExecRunner
+}
+
+func (localJobSubprocessRunner) grouped() subprocess.Runner {
+	return subprocess.GroupRunner{}
+}
+
+type groupedJobSubprocessRunner interface {
+	grouped() subprocess.Runner
+}
+
+func (w jobWorker) subprocessRunnerForJob(job db.Job) (subprocess.Runner, error) {
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		return nil, err
+	}
+	name, present := payload.ExecBackendOverride()
+	backend, err := daemonJobExecBackendFor(w, name, present)
+	if err != nil {
+		return nil, err
+	}
+	return jobSubprocessRunnerForBackend(backend)
+}
+
+// jobSubprocessRunnerForBackend is the single consumption seam for
+// job-associated git, checkout, and verifier subprocesses. Local preserves the
+// pre-#1560 host runner; a future backend must add its positional builder to
+// execbackend.Consume before any job subprocess can use it.
+func jobSubprocessRunnerForBackend(backend execbackend.Backend) (subprocess.Runner, error) {
+	return execbackend.Consume(backend, func() (subprocess.Runner, error) {
+		return localJobSubprocessRunner{}, nil
+	})
+}
+
+func jobGroupedSubprocessRunner(runner subprocess.Runner) subprocess.Runner {
+	if grouped, ok := runner.(groupedJobSubprocessRunner); ok {
+		return grouped.grouped()
+	}
+	return runner
+}
+
+var _ subprocess.Runner = localJobSubprocessRunner{}
+
+func jobGitClient(dir string, runner subprocess.Runner) gitutil.Client {
+	return gitutil.NewClient(dir, runner)
+}

--- a/internal/cli/fix_worktree.go
+++ b/internal/cli/fix_worktree.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
-	gitutil "github.com/gitmoot/gitmoot/internal/git"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -20,7 +20,11 @@ import (
 // registered checkout already has that branch checked out; an independent clone
 // has its own refs and HEAD, so the fix can commit and push without touching the
 // owner's index, files, or current branch.
-func allocateFixWorktree(ctx context.Context, store *db.Store, home string, checkout string, request workflow.FixWorktreeRequest) (allocation workflow.FixWorktreeAllocation, retErr error) {
+func allocateFixWorktree(ctx context.Context, store *db.Store, home string, checkout string, request workflow.FixWorktreeRequest) (workflow.FixWorktreeAllocation, error) {
+	return allocateFixWorktreeForRunner(ctx, store, home, checkout, request, subprocess.ExecRunner{})
+}
+
+func allocateFixWorktreeForRunner(ctx context.Context, store *db.Store, home string, checkout string, request workflow.FixWorktreeRequest, runner subprocess.Runner) (allocation workflow.FixWorktreeAllocation, retErr error) {
 	if store == nil {
 		return allocation, errors.New("fix worktree store is required")
 	}
@@ -44,7 +48,7 @@ func allocateFixWorktree(ctx context.Context, store *db.Store, home string, chec
 		// interrupted pre-enqueue allocation and must be recreated from a fresh fetch
 		// rather than silently reusing a potentially stale head.
 		if _, jobErr := store.GetJob(ctx, request.JobID); jobErr == nil {
-			branchAtPath, branchErr := (gitutil.Client{Dir: path}).CurrentBranch(ctx)
+			branchAtPath, branchErr := jobGitClient(path, runner).CurrentBranch(ctx)
 			if branchErr == nil && branchAtPath == branch {
 				return allocation, nil
 			}
@@ -59,7 +63,7 @@ func allocateFixWorktree(ctx context.Context, store *db.Store, home string, chec
 		return allocation, fmt.Errorf("inspect fix worktree %s: %w", path, err)
 	}
 
-	source := gitutil.Client{Dir: checkout}
+	source := jobGitClient(checkout, runner)
 	remoteURL, err := source.OriginRemoteConfigured(ctx)
 	if err != nil {
 		return allocation, fmt.Errorf("resolve fix worktree origin: %w", err)
@@ -92,7 +96,7 @@ func allocateFixWorktree(ctx context.Context, store *db.Store, home string, chec
 			_ = os.RemoveAll(path)
 		}
 	}()
-	clone := gitutil.Client{Dir: path}
+	clone := jobGitClient(path, runner)
 	if err := clone.SetRemoteURL(ctx, "origin", remoteURL); err != nil {
 		return allocation, fmt.Errorf("bind fix worktree origin: %w", err)
 	}

--- a/internal/cli/fix_worktree_test.go
+++ b/internal/cli/fix_worktree_test.go
@@ -127,7 +127,7 @@ func TestReviewFixRunsInPerJobBranchWorktree(t *testing.T) {
 	worker := defaultJobWorker(fixture.store, &workerOutput, fixture.rawHome)
 	worker.AdapterFactory = func(_ runtime.Agent, checkout string) (workflow.DeliveryAdapter, error) {
 		executionDir = checkout
-		executionBranch, _ = (gitutil.Client{Dir: checkout}).CurrentBranch(ctx)
+		executionBranch, _ = (gitutil.NewHostClient(checkout)).CurrentBranch(ctx)
 		return adapter, nil
 	}
 	worker.CommenterFactory = func(string) github.Client { return github.NoopClient{} }
@@ -161,7 +161,7 @@ func TestReviewFixWorktreeCanCommitAndPushBranchHead(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(allocation.Path, "fix.txt"), []byte("fixed\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	git := gitutil.Client{Dir: allocation.Path}
+	git := gitutil.NewHostClient(allocation.Path)
 	if err := git.CommitAll(ctx, "fix round"); err != nil {
 		t.Fatalf("CommitAll: %v", err)
 	}

--- a/internal/cli/hard_verifier.go
+++ b/internal/cli/hard_verifier.go
@@ -308,11 +308,11 @@ func (p cloneSandboxProvisioner) Provision(ctx context.Context, ref string) (str
 // holds every object it needs (hardlinked wholesale) and checks out by raw SHA, so a
 // severed origin never reduces what a verifier can read.
 func (p cloneSandboxProvisioner) cloneDetached(ctx context.Context, dest string, ref string) error {
-	source := git.Client{Runner: p.runner, Dir: p.base}
+	source := git.NewClient(p.base, p.runner)
 	if err := source.CloneLocalNoCheckout(ctx, dest); err != nil {
 		return err
 	}
-	clone := git.Client{Runner: p.runner, Dir: dest}
+	clone := git.NewClient(dest, p.runner)
 	if err := clone.CheckoutDetach(ctx, ref); err != nil {
 		return err
 	}

--- a/internal/cli/implementation_advance_preflight_test.go
+++ b/internal/cli/implementation_advance_preflight_test.go
@@ -89,7 +89,7 @@ func TestAdvanceImplementationPreflightBlocksBeforeModelAndKeepsResultHonest(t *
 				t.Fatal("documented reset remedy did not clear the preflight refusal")
 			}
 			if test.mode == "divergent" {
-				git := gitutil.Client{Dir: result.fixWorktree}
+				git := gitutil.NewHostClient(result.fixWorktree)
 				currentAncestorDispatch, err := git.IsAncestor(context.Background(), result.currentHead, result.expectedHead)
 				if err != nil {
 					t.Fatalf("compare divergent current head with dispatch head: %v", err)
@@ -1043,7 +1043,7 @@ func TestDaemonImplementationFinalizerKeepsMissingBranchBackstop(t *testing.T) {
 		Repo: "owner/repo", PullRequest: 12, TaskID: "task-backstop",
 		FixWorktree: true, WorktreePath: t.TempDir(), Result: &workflow.AgentResult{Decision: "implemented"},
 	}
-	_, err := (daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}).FinalizeImplementation(ctx, db.Job{ID: "late-backstop", Agent: "lead", Type: "implement"}, payload)
+	_, err := (newHostDaemonImplementationFinalizer(store, github.NoopClient{})).FinalizeImplementation(ctx, db.Job{ID: "late-backstop", Agent: "lead", Type: "implement"}, payload)
 	var blocked workflow.BlockedError
 	if !errors.As(err, &blocked) || !blocked.ResultDeliveryFailed || !strings.Contains(err.Error(), "carries no payload branch") {
 		t.Fatalf("FinalizeImplementation error = %v, want delivery-blocked missing-branch backstop", err)

--- a/internal/cli/implementation_fixworktree_branch_test.go
+++ b/internal/cli/implementation_fixworktree_branch_test.go
@@ -76,7 +76,7 @@ func TestFixWorktreeFinalizerDeliversPayloadBranchWhenTaskHasNone(t *testing.T) 
 		Repo: "owner/repo", Branch: branch, PullRequest: 1523, TaskID: "review-pr-1523-deadbeef",
 		FixWorktree: true, WorktreePath: fixWorktree, Result: &workflow.AgentResult{Decision: "implemented"},
 	}
-	delivered, err := (daemonImplementationFinalizer{Store: store, GitHub: github.NoopClient{}}).FinalizeImplementation(
+	delivered, err := (newHostDaemonImplementationFinalizer(store, github.NoopClient{})).FinalizeImplementation(
 		ctx, db.Job{ID: "fix-delivers", Agent: "lead", Type: "implement"}, payload)
 	if err != nil {
 		t.Fatalf("FinalizeImplementation returned error: %v", err)

--- a/internal/cli/job_resume_worktree.go
+++ b/internal/cli/job_resume_worktree.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
-	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -19,6 +19,10 @@ import (
 // pre-flight guard; every predicate miss or probe/persistence error returns false
 // so jobWorker.run takes the existing checkout-contention path unchanged.
 func (w jobWorker) resumeSelfDirtyWorktree(ctx context.Context, job db.Job, payload workflow.JobPayload, agent runtime.Agent, cause error) (string, workflow.JobPayload, bool) {
+	return w.resumeSelfDirtyWorktreeForRunner(ctx, job, payload, agent, cause, subprocess.ExecRunner{})
+}
+
+func (w jobWorker) resumeSelfDirtyWorktreeForRunner(ctx context.Context, job db.Job, payload workflow.JobPayload, agent runtime.Agent, cause error, runner subprocess.Runner) (string, workflow.JobPayload, bool) {
 	kind, _ := classifyCheckoutContention(cause)
 	if kind != checkoutContentionDirty || cause == nil || !strings.Contains(cause.Error(), "has uncommitted changes") {
 		return "", payload, false
@@ -57,7 +61,7 @@ func (w jobWorker) resumeSelfDirtyWorktree(ctx context.Context, job db.Job, payl
 	if expectedHead == "" {
 		return "", payload, false
 	}
-	head, err := (gitutil.Client{Dir: resolvedCheckout}).HeadSHA(ctx)
+	head, err := jobGitClient(resolvedCheckout, runner).HeadSHA(ctx)
 	if err != nil || head != expectedHead {
 		return "", payload, false
 	}

--- a/internal/cli/job_resume_worktree_test.go
+++ b/internal/cli/job_resume_worktree_test.go
@@ -38,7 +38,7 @@ func newSelfDirtyResumeFixtureWithLockOwner(t *testing.T, jobID string, lockOwne
 	checkout := createDaemonWorkerGitCheckout(t, "main")
 	worktree := filepath.Join(t.TempDir(), "task-resume")
 	runDaemonWorkerGit(t, checkout, "worktree", "add", "-b", "task-resume", worktree, "main")
-	head, err := (gitutil.Client{Dir: worktree}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(worktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestResumeSelfDirtySkipsWrongHeadWhileDirty(t *testing.T) {
 	if payload.HeadSHA != fixture.head {
 		t.Fatalf("fallback payload head = %q, want original %q", payload.HeadSHA, fixture.head)
 	}
-	actualHead, err := (gitutil.Client{Dir: fixture.worktree}).HeadSHA(ctx)
+	actualHead, err := (gitutil.NewHostClient(fixture.worktree)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestResumeSelfDirtySkipsDirtyByOther(t *testing.T) {
 	ctx := context.Background()
 	store := daemonWorkerStore(t)
 	checkout := createDaemonWorkerGitCheckout(t, "main")
-	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}

--- a/internal/cli/permission_policy_effects.go
+++ b/internal/cli/permission_policy_effects.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/permissionpolicy"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -59,7 +58,11 @@ func (w jobWorker) capturePermissionPolicyEffects(ctx context.Context, jobID, ch
 		if w.PermissionPolicyEffectGit != nil {
 			git = w.PermissionPolicyEffectGit(checkout)
 		} else {
-			git = gitutil.Client{Dir: checkout}
+			runner, runnerErr := w.subprocessRunnerForJob(job)
+			if runnerErr != nil {
+				return fmt.Errorf("resolve permission-policy effect runner: %w", runnerErr)
+			}
+			git = jobGitClient(checkout, runner)
 		}
 	}
 	captureCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), permissionPolicyEffectCaptureTimeout)

--- a/internal/cli/pipeline_auto_merge_e2e_test.go
+++ b/internal/cli/pipeline_auto_merge_e2e_test.go
@@ -90,7 +90,7 @@ func TestPipelineAutoMergeShellRuntimeE2E(t *testing.T) {
 	}
 	runDaemonWorkerGit(t, implPayload.WorktreePath, "add", "auto.txt")
 	runDaemonWorkerGit(t, implPayload.WorktreePath, "commit", "-m", "auto merge fixture")
-	head, err := (gitutil.Client{Dir: implPayload.WorktreePath}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(implPayload.WorktreePath)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA: %v", err)
 	}

--- a/internal/cli/pipeline_enqueue.go
+++ b/internal/cli/pipeline_enqueue.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
-	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
 
@@ -36,6 +36,15 @@ func pipelineStageCheckoutPath(ctx context.Context, store *db.Store, repo string
 func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueuer {
 	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home), OrgPolicy: orgPolicyResolver(home)}
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
+		var runner subprocess.Runner = subprocess.ExecRunner{}
+		backend, backendErr := localAgentDispatchExecBackendFor(home)
+		if backendErr == nil {
+			var err error
+			runner, err = jobSubprocessRunnerForBackend(backend)
+			if err != nil {
+				return db.Job{}, err
+			}
+		}
 		// #1011 service shell stages are an explicit fail-CLOSED exception to the
 		// generic read-only allocator below. Their run row is authoritative: every
 		// service-triggered shell command gets a detached worktree, and a missing
@@ -65,7 +74,7 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 			if !errors.Is(getErr, sql.ErrNoRows) {
 				return db.Job{}, getErr
 			}
-			request, worktreePath, worktreeErr = allocatePipelineServiceShellWorktree(ctx, store, home, request)
+			request, worktreePath, worktreeErr = allocatePipelineServiceShellWorktreeForRunner(ctx, store, home, request, runner)
 			if worktreeErr != nil {
 				return db.Job{}, fmt.Errorf("allocate service shell stage detached worktree: %w", worktreeErr)
 			}
@@ -91,9 +100,9 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 		isolateShell := !serviceShell && pipelineShellStageReadOnlyWorktreeEligible(request)
 		if !serviceShell {
 			if isolateShell {
-				request, worktreePath, worktreeErr = allocatePipelineShellStageReadOnlyWorktree(ctx, store, home, request)
+				request, worktreePath, worktreeErr = allocatePipelineShellStageReadOnlyWorktreeForRunner(ctx, store, home, request, runner)
 			} else {
-				request, worktreePath, worktreeErr = allocatePipelineStageReadOnlyWorktree(ctx, store, home, request)
+				request, worktreePath, worktreeErr = allocatePipelineStageReadOnlyWorktreeForRunner(ctx, store, home, request, runner)
 			}
 		}
 		if strings.TrimSpace(request.Action) == "produce" && strings.TrimSpace(request.WorktreePath) == "" {
@@ -122,7 +131,7 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 		// task recover` is the operator escape hatch). The two allocators are mutually
 		// exclusive — read-only eligibility excludes the implement action.
 		var writableErr error
-		request, writableErr = allocatePipelineStageWritableWorktree(ctx, store, home, request)
+		request, writableErr = allocatePipelineStageWritableWorktreeForRunner(ctx, store, home, request, runner)
 		if writableErr != nil {
 			return db.Job{}, writableErr
 		}
@@ -139,7 +148,7 @@ func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueue
 			if worktreePath != "" {
 				rollbackCtx := context.WithoutCancel(ctx)
 				if checkout := pipelineStageCheckoutPath(rollbackCtx, store, request.Repo); checkout != "" {
-					_ = gitutil.Client{Dir: checkout}.RemoveWorktreeForce(rollbackCtx, worktreePath)
+					_ = jobGitClient(checkout, runner).RemoveWorktreeForce(rollbackCtx, worktreePath)
 				}
 			}
 			return db.Job{}, err
@@ -182,6 +191,10 @@ func pipelineServiceShellStage(ctx context.Context, store *db.Store, request wor
 }
 
 func allocatePipelineServiceShellWorktree(ctx context.Context, store *db.Store, home string, request workflow.JobRequest) (workflow.JobRequest, string, error) {
+	return allocatePipelineServiceShellWorktreeForRunner(ctx, store, home, request, subprocess.ExecRunner{})
+}
+
+func allocatePipelineServiceShellWorktreeForRunner(ctx context.Context, store *db.Store, home string, request workflow.JobRequest, runner subprocess.Runner) (workflow.JobRequest, string, error) {
 	checkout := pipelineStageCheckoutPath(ctx, store, request.Repo)
 	if checkout == "" {
 		return request, "", nil
@@ -191,7 +204,7 @@ func allocatePipelineServiceShellWorktree(ctx context.Context, store *db.Store, 
 		return request, "", err
 	}
 	path, err := workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, request.Repo, checkout, request.ID,
-		"pipeline-service-stage", 0, "", workflow.ReadOnlyWorktreeDispatchLockWaitBudget, gitutil.Client{Dir: checkout})
+		"pipeline-service-stage", 0, "", workflow.ReadOnlyWorktreeDispatchLockWaitBudget, jobGitClient(checkout, runner))
 	if err != nil {
 		return request, "", err
 	}
@@ -286,6 +299,10 @@ func pipelineShellStageReadOnlyWorktreeEligible(request workflow.JobRequest) boo
 // Unlike agent isolation, shell commands receive the live managed checkout through
 // GITMOOT_CHECKOUT and do not get prose appended to their fixed instructions.
 func allocatePipelineShellStageReadOnlyWorktree(ctx context.Context, store *db.Store, home string, request workflow.JobRequest) (workflow.JobRequest, string, error) {
+	return allocatePipelineShellStageReadOnlyWorktreeForRunner(ctx, store, home, request, subprocess.ExecRunner{})
+}
+
+func allocatePipelineShellStageReadOnlyWorktreeForRunner(ctx context.Context, store *db.Store, home string, request workflow.JobRequest, runner subprocess.Runner) (workflow.JobRequest, string, error) {
 	checkout := pipelineStageCheckoutPath(ctx, store, request.Repo)
 	if checkout == "" {
 		return request, "", nil // repo not managed/checked out yet — serialize as before
@@ -294,7 +311,7 @@ func allocatePipelineShellStageReadOnlyWorktree(ctx context.Context, store *db.S
 	if err != nil {
 		return request, "", err
 	}
-	path, err := workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, request.Repo, checkout, request.ID, "pipeline-stage", 0, "", workflow.ReadOnlyWorktreeDispatchLockWaitBudget, gitutil.Client{Dir: checkout})
+	path, err := workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, request.Repo, checkout, request.ID, "pipeline-stage", 0, "", workflow.ReadOnlyWorktreeDispatchLockWaitBudget, jobGitClient(checkout, runner))
 	if err != nil {
 		return request, "", err
 	}
@@ -318,6 +335,10 @@ func allocatePipelineShellStageReadOnlyWorktree(ctx context.Context, store *db.S
 // genuine allocation failure returns the request unchanged with the error so the
 // caller enqueues on the shared checkout and emits a loud skip event.
 func allocatePipelineStageReadOnlyWorktree(ctx context.Context, store *db.Store, home string, request workflow.JobRequest) (workflow.JobRequest, string, error) {
+	return allocatePipelineStageReadOnlyWorktreeForRunner(ctx, store, home, request, subprocess.ExecRunner{})
+}
+
+func allocatePipelineStageReadOnlyWorktreeForRunner(ctx context.Context, store *db.Store, home string, request workflow.JobRequest, runner subprocess.Runner) (workflow.JobRequest, string, error) {
 	if !pipelineStageReadOnlyWorktreeEligible(request) {
 		return request, "", nil
 	}
@@ -333,7 +354,7 @@ func allocatePipelineStageReadOnlyWorktree(ctx context.Context, store *db.Store,
 	// existing review checkout validation proves HEAD == payload.HeadSHA. Other
 	// read-only stages keep the empty-ref behavior (the checkout's committed tip).
 	baseRef := strings.TrimSpace(request.HeadSHA)
-	path, err := workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, request.Repo, checkout, request.ID, "pipeline-stage", 0, baseRef, workflow.ReadOnlyWorktreeDispatchLockWaitBudget, gitutil.Client{Dir: checkout})
+	path, err := workflow.AllocateReadOnlyWorktree(ctx, store, paths.Home, request.Repo, checkout, request.ID, "pipeline-stage", 0, baseRef, workflow.ReadOnlyWorktreeDispatchLockWaitBudget, jobGitClient(checkout, runner))
 	if err != nil {
 		return request, "", err
 	}
@@ -391,6 +412,10 @@ func pipelineStageImplementWorktreeEligible(request workflow.JobRequest) bool {
 // false — the task worktree is durable (disposed by the task lifecycle, not the #739
 // read-only cleanup).
 func allocatePipelineStageWritableWorktree(ctx context.Context, store *db.Store, home string, request workflow.JobRequest) (workflow.JobRequest, error) {
+	return allocatePipelineStageWritableWorktreeForRunner(ctx, store, home, request, subprocess.ExecRunner{})
+}
+
+func allocatePipelineStageWritableWorktreeForRunner(ctx context.Context, store *db.Store, home string, request workflow.JobRequest, runner subprocess.Runner) (workflow.JobRequest, error) {
 	if !pipelineStageImplementWorktreeEligible(request) {
 		return request, nil
 	}
@@ -432,6 +457,7 @@ func allocatePipelineStageWritableWorktree(ctx context.Context, store *db.Store,
 		GoalID:       request.GoalID,
 		TaskTitle:    request.TaskTitle,
 		RepoFlag:     request.Repo,
+		jobRunner:    runner,
 	}
 	task, dispatch, err := prepareLocalImplementDispatchRequest(ctx, store, record, repo, dispatch)
 	if err != nil {

--- a/internal/cli/pipeline_enqueue.go
+++ b/internal/cli/pipeline_enqueue.go
@@ -36,14 +36,13 @@ func pipelineStageCheckoutPath(ctx context.Context, store *db.Store, repo string
 func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueuer {
 	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home), OrgPolicy: orgPolicyResolver(home)}
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
-		var runner subprocess.Runner = subprocess.ExecRunner{}
-		backend, backendErr := localAgentDispatchExecBackendFor(home)
-		if backendErr == nil {
-			var err error
-			runner, err = jobSubprocessRunnerForBackend(backend)
-			if err != nil {
-				return db.Job{}, err
-			}
+		backend, err := localAgentDispatchExecBackendFor(home)
+		if err != nil {
+			return db.Job{}, err
+		}
+		runner, err := jobSubprocessRunnerForBackend(backend)
+		if err != nil {
+			return db.Job{}, err
 		}
 		// #1011 service shell stages are an explicit fail-CLOSED exception to the
 		// generic read-only allocator below. Their run row is authoritative: every

--- a/internal/cli/pipeline_review_binding_813_test.go
+++ b/internal/cli/pipeline_review_binding_813_test.go
@@ -257,12 +257,12 @@ func TestPipelineSourceReviewWorktreePinnedToBoundHead(t *testing.T) {
 	}
 	runDaemonWorkerGit(t, checkout, "add", "feature.txt")
 	runDaemonWorkerGit(t, checkout, "commit", "-m", "feature head")
-	head, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA(feature): %v", err)
 	}
 	runDaemonWorkerGit(t, checkout, "checkout", "main")
-	mainHead, err := (gitutil.Client{Dir: checkout}).HeadSHA(ctx)
+	mainHead, err := (gitutil.NewHostClient(checkout)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA(main): %v", err)
 	}
@@ -288,7 +288,7 @@ func TestPipelineSourceReviewWorktreePinnedToBoundHead(t *testing.T) {
 	if !payload.ReadOnlyWorktree || strings.TrimSpace(payload.WorktreePath) == "" {
 		t.Fatalf("review worktree payload = %+v, want detached read-only worktree", payload)
 	}
-	gotHead, err := (gitutil.Client{Dir: payload.WorktreePath}).HeadSHA(ctx)
+	gotHead, err := (gitutil.NewHostClient(payload.WorktreePath)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA(review worktree): %v", err)
 	}
@@ -334,7 +334,7 @@ func TestPipelineSourceReviewEnqueueReplayAdoptsExistingJob(t *testing.T) {
 	}
 	runDaemonWorkerGit(t, implPayload.WorktreePath, "add", "replay.txt")
 	runDaemonWorkerGit(t, implPayload.WorktreePath, "commit", "-m", "replay head")
-	head, err := (gitutil.Client{Dir: implPayload.WorktreePath}).HeadSHA(ctx)
+	head, err := (gitutil.NewHostClient(implPayload.WorktreePath)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA(impl): %v", err)
 	}
@@ -382,7 +382,7 @@ func TestPipelineSourceReviewEnqueueReplayAdoptsExistingJob(t *testing.T) {
 	if strings.TrimSpace(createdPayload.WorktreePath) == "" {
 		t.Fatal("interrupted review job has no pinned worktree")
 	}
-	createdHead, err := (gitutil.Client{Dir: createdPayload.WorktreePath}).HeadSHA(ctx)
+	createdHead, err := (gitutil.NewHostClient(createdPayload.WorktreePath)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA(interrupted review worktree): %v", err)
 	}
@@ -486,7 +486,7 @@ stages:
 			}
 			runDaemonWorkerGit(t, implPayload.WorktreePath, "add", "change.txt")
 			runDaemonWorkerGit(t, implPayload.WorktreePath, "commit", "-m", "pipeline implementation")
-			head, err := (gitutil.Client{Dir: implPayload.WorktreePath}).HeadSHA(ctx)
+			head, err := (gitutil.NewHostClient(implPayload.WorktreePath)).HeadSHA(ctx)
 			if err != nil {
 				t.Fatalf("HeadSHA(impl): %v", err)
 			}

--- a/internal/cli/pipeline_shell_isolation_test.go
+++ b/internal/cli/pipeline_shell_isolation_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gitmoot/gitmoot/internal/db"
+	"github.com/gitmoot/gitmoot/internal/execbackend"
 	"github.com/gitmoot/gitmoot/internal/pipeline"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 )
@@ -192,6 +195,40 @@ func TestPipelineForkedShellIsolationEventWindowsE2E(t *testing.T) {
 	}
 }
 
+func TestPipelineStageEnqueueBackendResolutionFailureFailsClosed(t *testing.T) {
+	ctx := context.Background()
+	_, _, store := heartbeatLoopE2EHome(t)
+	checkout := createDaemonWorkerGitCheckout(t, "main")
+	seedDaemonWorkerRepo(t, store, "owner/repo", checkout)
+	brokenHome := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(brokenHome, []byte("force backend config resolution failure\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wantErr := func() error {
+		_, err := localAgentDispatchExecBackendFor(brokenHome)
+		return err
+	}()
+	if wantErr == nil {
+		t.Fatal("broken home unexpectedly resolved an execution backend")
+	}
+	request := pipeline.PipelineStageJobRequest(
+		db.Pipeline{Name: "backend-resolution-failure", Repo: "owner/repo"},
+		pipeline.Stage{ID: "run", Cmd: "printf ok", Isolate: true},
+		db.PipelineRun{ID: "backend-resolution-failure-run", Trigger: "manual"},
+		0, "", pipeline.PipelineStagePRBinding{}, false,
+	)
+	beforeWorktrees := gitOutput(t, checkout, "worktree", "list", "--porcelain")
+	if _, err := newPipelineStageEnqueuer(store, brokenHome)(ctx, request); err == nil || err.Error() != wantErr.Error() {
+		t.Fatalf("enqueue error = %v, want backend resolution error %v", err, wantErr)
+	}
+	if _, err := store.GetJob(ctx, request.ID); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("backend resolution failure created job %q: %v", request.ID, err)
+	}
+	if afterWorktrees := gitOutput(t, checkout, "worktree", "list", "--porcelain"); afterWorktrees != beforeWorktrees {
+		t.Fatalf("backend resolution failure mutated git worktrees:\nbefore:\n%s\nafter:\n%s", beforeWorktrees, afterWorktrees)
+	}
+}
+
 func TestPipelineShellIsolationAllocationFailureFallsOpenE2E(t *testing.T) {
 	ctx := context.Background()
 	home, _, store := heartbeatLoopE2EHome(t)
@@ -209,6 +246,11 @@ func TestPipelineShellIsolationAllocationFailureFallsOpenE2E(t *testing.T) {
 	if err := os.WriteFile(brokenHome, []byte("force worktree parent creation failure\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	previousResolver := localAgentDispatchExecBackendFor
+	localAgentDispatchExecBackendFor = func(string) (execbackend.Backend, error) {
+		return execbackend.Local, nil
+	}
+	t.Cleanup(func() { localAgentDispatchExecBackendFor = previousResolver })
 
 	enqueue := newPipelineStageEnqueuer(store, brokenHome)
 	if err := runPipelineScanOnce(ctx, store, enqueue, now); err != nil {

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -18,6 +18,7 @@ import (
 	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
 	"github.com/gitmoot/gitmoot/internal/pathutil"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
 func runRepo(args []string, stdout, stderr io.Writer) int {
@@ -142,7 +143,7 @@ func runRepoAdd(args []string, stdout, stderr io.Writer) int {
 		}
 		writeLine(stderr, "WARN: %s", repoCheckoutHealMessage(repo.FullName(), healedFrom, record.CheckoutPath))
 	}
-	client := gitutil.Client{Dir: record.CheckoutPath}
+	client := gitutil.NewHostClient(record.CheckoutPath)
 	primary, err := client.PrimaryWorktree(context.Background())
 	if err != nil {
 		fmt.Fprintf(stderr, "repo add: resolve primary worktree: %v\n", err)
@@ -451,7 +452,7 @@ func inspectRegisteredRepoCheckout(ctx context.Context, store *db.Store, record 
 	if err != nil {
 		return db.Repo{}, false, false, err
 	}
-	linked, err := (gitutil.Client{Dir: resolved.CheckoutPath}).IsLinkedWorktree(ctx)
+	linked, err := (gitutil.NewHostClient(resolved.CheckoutPath)).IsLinkedWorktree(ctx)
 	if err != nil {
 		return db.Repo{}, false, false, err
 	}
@@ -475,14 +476,18 @@ func resolveRepoRecord(ctx context.Context, store *db.Store, repo github.Reposit
 }
 
 func resolveRegisteredRepoRecord(ctx context.Context, store *db.Store, repo github.Repository, existing db.Repo) (db.Repo, bool, error) {
+	return resolveRegisteredRepoRecordWithRunner(ctx, store, repo, existing, subprocess.ExecRunner{})
+}
+
+func resolveRegisteredRepoRecordWithRunner(ctx context.Context, store *db.Store, repo github.Repository, existing db.Repo, runner subprocess.Runner) (db.Repo, bool, error) {
 	checkout := strings.TrimSpace(existing.CheckoutPath)
 	var checkoutErr error
 	if checkout != "" {
-		resolved, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: checkout})
+		resolved, err := repoRecordForCheckout(ctx, repo, jobGitClient(checkout, runner))
 		if err == nil {
 			primary := strings.TrimSpace(existing.PrimaryCheckoutPath)
 			if primary == "" {
-				primary, err = (gitutil.Client{Dir: checkout}).PrimaryWorktree(ctx)
+				primary, err = jobGitClient(checkout, runner).PrimaryWorktree(ctx)
 				if err != nil {
 					return db.Repo{}, false, fmt.Errorf("resolve primary worktree for %s: %w", repo.FullName(), err)
 				}
@@ -495,7 +500,7 @@ func resolveRegisteredRepoRecord(ctx context.Context, store *db.Store, repo gith
 					if err != nil {
 						return db.Repo{}, false, err
 					}
-					return resolveRegisteredRepoRecord(ctx, store, repo, current)
+					return resolveRegisteredRepoRecordWithRunner(ctx, store, repo, current, runner)
 				}
 			}
 			resolved.PrimaryCheckoutPath = primary
@@ -510,16 +515,16 @@ func resolveRegisteredRepoRecord(ctx context.Context, store *db.Store, repo gith
 	if primary == "" || sameCheckoutPath(primary, checkout) {
 		return db.Repo{}, false, fmt.Errorf("registered checkout %s for %s is unusable and no distinct primary checkout is available: %w", checkout, repo.FullName(), checkoutErr)
 	}
-	resolved, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: primary})
+	resolved, err := repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
 	if err != nil {
 		return db.Repo{}, false, fmt.Errorf("registered checkout %s for %s is unusable (%v); verify primary checkout %s: %w", checkout, repo.FullName(), checkoutErr, primary, err)
 	}
-	primary, err = (gitutil.Client{Dir: resolved.CheckoutPath}).PrimaryWorktree(ctx)
+	primary, err = jobGitClient(resolved.CheckoutPath, runner).PrimaryWorktree(ctx)
 	if err != nil {
 		return db.Repo{}, false, fmt.Errorf("resolve primary worktree for %s from %s: %w", repo.FullName(), resolved.CheckoutPath, err)
 	}
 	if !sameCheckoutPath(primary, resolved.CheckoutPath) {
-		resolved, err = repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: primary})
+		resolved, err = repoRecordForCheckout(ctx, repo, jobGitClient(primary, runner))
 		if err != nil {
 			return db.Repo{}, false, fmt.Errorf("verify resolved primary checkout %s for %s: %w", primary, repo.FullName(), err)
 		}
@@ -535,7 +540,7 @@ func resolveRegisteredRepoRecord(ctx context.Context, store *db.Store, repo gith
 		if err != nil {
 			return db.Repo{}, false, err
 		}
-		return resolveRegisteredRepoRecord(ctx, store, repo, current)
+		return resolveRegisteredRepoRecordWithRunner(ctx, store, repo, current, runner)
 	}
 	log.Printf("WARNING: %s", repoCheckoutHealMessage(repo.FullName(), checkout, resolved.CheckoutPath))
 	return resolved, true, nil
@@ -559,7 +564,7 @@ func repoRecordFromPath(ctx context.Context, repo github.Repository, path string
 	if err != nil {
 		return db.Repo{}, err
 	}
-	return repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: checkout})
+	return repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(checkout))
 }
 
 // repoRecordFromStablePath resolves an operator/cwd-provided checkout but pins
@@ -570,7 +575,7 @@ func repoRecordFromStablePath(ctx context.Context, repo github.Repository, path 
 	if err != nil {
 		return db.Repo{}, err
 	}
-	client := gitutil.Client{Dir: checkout}
+	client := gitutil.NewHostClient(checkout)
 	record, err := repoRecordForCheckout(ctx, repo, client)
 	if err != nil {
 		return db.Repo{}, err
@@ -587,7 +592,7 @@ func repoRecordFromStablePath(ctx context.Context, repo github.Repository, path 
 	if !linked || sameCheckoutPath(record.CheckoutPath, primary) {
 		return record, nil
 	}
-	primaryRecord, err := repoRecordForCheckout(ctx, repo, gitutil.Client{Dir: primary})
+	primaryRecord, err := repoRecordForCheckout(ctx, repo, gitutil.NewHostClient(primary))
 	if err != nil {
 		return db.Repo{}, fmt.Errorf("verify primary checkout: %w", err)
 	}

--- a/internal/cli/trace_harvest_daemon.go
+++ b/internal/cli/trace_harvest_daemon.go
@@ -144,6 +144,10 @@ func daemonDeterministicCheckerDispatcher(store *db.Store, gh github.Client, che
 // cannot escape into the live checkout (reusing gitmoot's single-binary git tooling, no
 // external sandbox dep).
 func daemonHardVerifierDispatcher(store *db.Store, checkout string, home string) workflow.HardVerifierDispatcher {
+	return daemonHardVerifierDispatcherForRunner(store, checkout, home, localJobSubprocessRunner{})
+}
+
+func daemonHardVerifierDispatcherForRunner(store *db.Store, checkout string, home string, runner subprocess.Runner) workflow.HardVerifierDispatcher {
 	if store == nil {
 		return nil
 	}
@@ -157,11 +161,11 @@ func daemonHardVerifierDispatcher(store *db.Store, checkout string, home string)
 		// grandchildren (a `go test` spawns test binaries, `npm test` spawns node), so
 		// the leg's bounded context can never leave an orphaned suite running. The
 		// short-lived git clone/checkout calls keep the plain ExecRunner (no grandchildren).
-		runner: subprocess.GroupRunner{},
+		runner: jobGroupedSubprocessRunner(runner),
 		sandbox: cloneSandboxProvisioner{
 			base:   checkout,
 			home:   home,
-			runner: subprocess.ExecRunner{},
+			runner: runner,
 			// store backs the checkout-mutation lock that serializes the sandbox clone's
 			// base read against concurrent real jobs on the same daemon checkout (#617).
 			store: store,

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -23,8 +23,8 @@ import (
 	"github.com/gitmoot/gitmoot/internal/config"
 	"github.com/gitmoot/gitmoot/internal/daemon"
 	"github.com/gitmoot/gitmoot/internal/db"
-	gitutil "github.com/gitmoot/gitmoot/internal/git"
 	"github.com/gitmoot/gitmoot/internal/github"
+	"github.com/gitmoot/gitmoot/internal/subprocess"
 	"github.com/gitmoot/gitmoot/internal/workflow"
 	"github.com/gitmoot/gitmoot/skills"
 )
@@ -403,6 +403,14 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 	var started db.Task
 	var startedJob db.Job
 	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
+		backend, err := localAgentDispatchExecBackendFor(*home)
+		if err != nil {
+			return err
+		}
+		runner, err := jobSubprocessRunnerForBackend(backend)
+		if err != nil {
+			return err
+		}
 		task, err := store.GetTask(context.Background(), taskID)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -457,7 +465,7 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 			candidate := task
 			candidate.RepoFullName = requestRepo
 			candidate.Branch = requestBranch
-			headSHA, err := (gitutil.Client{Dir: candidate.WorktreePath}).HeadSHA(context.Background())
+			headSHA, err := jobGitClient(candidate.WorktreePath, runner).HeadSHA(context.Background())
 			if err != nil {
 				return fmt.Errorf("resolve task worktree head: %w", err)
 			}
@@ -469,14 +477,14 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 				startedJob = active
 				return nil
 			}
-			dirty, err := taskWorktreeDirty(context.Background(), candidate)
+			dirty, err := taskWorktreeDirtyWithRunner(context.Background(), candidate, runner)
 			if err != nil {
 				return err
 			}
 			if dirty {
 				handled, blockErr := (workflow.Engine{Store: store}).ReconcileDirtyTaskWorktreeLineage(
 					context.Background(),
-					gitutil.Client{Dir: checkout},
+					jobGitClient(checkout, runner),
 					candidate,
 					candidate.WorktreePath,
 					*base,
@@ -500,11 +508,11 @@ func runTaskRun(args []string, stdout, stderr io.Writer) int {
 			BaseBranch: *base,
 			Owner:      *owner,
 			Checkout:   checkout,
-		}, gitutil.Client{Dir: checkout})
+		}, jobGitClient(checkout, runner))
 		if err != nil {
 			return err
 		}
-		headSHA, err := (gitutil.Client{Dir: started.WorktreePath}).HeadSHA(context.Background())
+		headSHA, err := jobGitClient(started.WorktreePath, runner).HeadSHA(context.Background())
 		if err != nil {
 			return fmt.Errorf("resolve task worktree head: %w", err)
 		}
@@ -904,7 +912,15 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 	}
 	var output taskRecoverOutput
 	if err := withStoreAndPaths(*home, func(paths config.Paths, store *db.Store) error {
-		payload, err := recoverTaskImplementation(context.Background(), store, taskID, strings.TrimSpace(*repo), strings.TrimSpace(*owner), *skipFanout, nil)
+		backend, err := localAgentDispatchExecBackendFor(*home)
+		if err != nil {
+			return err
+		}
+		runner, err := jobSubprocessRunnerForBackend(backend)
+		if err != nil {
+			return err
+		}
+		payload, err := recoverTaskImplementationForRunner(context.Background(), store, taskID, strings.TrimSpace(*repo), strings.TrimSpace(*owner), *skipFanout, nil, runner)
 		if err != nil {
 			return err
 		}
@@ -948,6 +964,10 @@ func runTaskRecover(args []string, stdout, stderr io.Writer) int {
 }
 
 func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID string, repoFlag string, owner string, skipFanout bool, gh github.Client) (workflow.JobPayload, error) {
+	return recoverTaskImplementationForRunner(ctx, store, taskID, repoFlag, owner, skipFanout, gh, subprocess.ExecRunner{})
+}
+
+func recoverTaskImplementationForRunner(ctx context.Context, store *db.Store, taskID string, repoFlag string, owner string, skipFanout bool, gh github.Client, runner subprocess.Runner) (workflow.JobPayload, error) {
 	task, err := store.GetTask(ctx, strings.TrimSpace(taskID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1020,17 +1040,17 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 			_, _ = store.ReleaseLockWithEvent(ctx, lock, db.BranchLockEvent{Kind: "released", Message: "released after failed task recover"})
 		}
 	}()
-	headSHA, err := (gitutil.Client{Dir: task.WorktreePath}).HeadSHA(ctx)
+	headSHA, err := jobGitClient(task.WorktreePath, runner).HeadSHA(ctx)
 	if err != nil {
 		return workflow.JobPayload{}, fmt.Errorf("resolve task worktree head: %w", err)
 	}
 	payloadHead := headSHA
-	if dirty, err := taskWorktreeDirty(ctx, task); err != nil {
+	if dirty, err := taskWorktreeDirtyWithRunner(ctx, task, runner); err != nil {
 		return workflow.JobPayload{}, err
 	} else if !dirty {
 		baseHead := previousTaskImplementHeadSHA(ctx, store, task.ID, requestRepo, task.Branch, headSHA)
 		if strings.TrimSpace(baseHead) == "" {
-			baseHead, err = taskRecoverBaseHead(ctx, store, task, requestRepo)
+			baseHead, err = taskRecoverBaseHeadForRunner(ctx, store, task, requestRepo, runner)
 			if err != nil {
 				return workflow.JobPayload{}, err
 			}
@@ -1083,7 +1103,7 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 	}, db.JobEvent{Kind: string(workflow.JobRunning), Message: "task recovery started"}); err != nil {
 		return workflow.JobPayload{}, err
 	}
-	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh}
+	finalizer := daemonImplementationFinalizer{Store: store, GitHub: gh, Runner: runner}
 	finalized, err := finalizer.FinalizeImplementation(ctx, job, payload)
 	if err != nil {
 		state := string(workflow.JobFailed)
@@ -1113,10 +1133,14 @@ func recoverTaskImplementation(ctx context.Context, store *db.Store, taskID stri
 }
 
 func taskWorktreeDirty(ctx context.Context, task db.Task) (bool, error) {
+	return taskWorktreeDirtyWithRunner(ctx, task, subprocess.ExecRunner{})
+}
+
+func taskWorktreeDirtyWithRunner(ctx context.Context, task db.Task, runner subprocess.Runner) (bool, error) {
 	if strings.TrimSpace(task.WorktreePath) == "" {
 		return false, nil
 	}
-	status, err := (gitutil.Client{Dir: task.WorktreePath}).StatusPorcelain(ctx)
+	status, err := jobGitClient(task.WorktreePath, runner).StatusPorcelain(ctx)
 	if err != nil {
 		return false, fmt.Errorf("inspect task worktree %s: %w", task.WorktreePath, err)
 	}
@@ -1231,6 +1255,10 @@ func previousTaskImplementHeadSHA(ctx context.Context, store *db.Store, taskID s
 }
 
 func taskRecoverBaseHead(ctx context.Context, store *db.Store, task db.Task, repo string) (string, error) {
+	return taskRecoverBaseHeadForRunner(ctx, store, task, repo, subprocess.ExecRunner{})
+}
+
+func taskRecoverBaseHeadForRunner(ctx context.Context, store *db.Store, task db.Task, repo string, runner subprocess.Runner) (string, error) {
 	record, err := store.GetRepo(ctx, repo)
 	if err != nil {
 		return "", err
@@ -1239,7 +1267,7 @@ func taskRecoverBaseHead(ctx context.Context, store *db.Store, task db.Task, rep
 	if base == "" {
 		base = "main"
 	}
-	git := gitutil.Client{Dir: task.WorktreePath}
+	git := jobGitClient(task.WorktreePath, runner)
 	var lastErr error
 	for _, rev := range []string{base, "origin/" + base} {
 		sha, err := git.RevParse(ctx, rev)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -44,7 +44,11 @@ type Daemon struct {
 	Store        *db.Store
 	GitHub       github.Client
 	Workflow     *workflow.Engine
-	Sleep        func(context.Context, time.Duration) error
+	// WorkflowForJob optionally resolves the workflow engine used to advance a
+	// completed job. Supervisors use it to bind job-associated subprocess seams
+	// to the backend stored on that job; nil preserves the static Workflow.
+	WorkflowForJob func(context.Context, db.Job) (*workflow.Engine, error)
+	Sleep          func(context.Context, time.Duration) error
 	// Now is an injectable clock (test seam). It defaults to time.Now and is used
 	// to seed/advance the #566 issue-comment `since` cursor deterministically.
 	Now func() time.Time
@@ -1130,7 +1134,17 @@ func (d Daemon) reconcileReviewingPullRequest(ctx context.Context, pull github.P
 		if payload.Result == nil {
 			continue
 		}
-		if err := d.Workflow.AdvanceJob(ctx, job.ID); err != nil {
+		engine := d.Workflow
+		if d.WorkflowForJob != nil {
+			engine, err = d.WorkflowForJob(ctx, job)
+			if err != nil {
+				return fmt.Errorf("resolve workflow for job %q: %w", job.ID, err)
+			}
+			if engine == nil {
+				return fmt.Errorf("resolve workflow for job %q: workflow is nil", job.ID)
+			}
+		}
+		if err := engine.AdvanceJob(ctx, job.ID); err != nil {
 			var blocked workflow.BlockedError
 			if errors.As(err, &blocked) {
 				return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -93,7 +93,7 @@ type RemoteBranchChecker interface {
 type gitRemoteBranchChecker struct{}
 
 func (gitRemoteBranchChecker) RemoteBranches(ctx context.Context, checkout string, branches []string) (map[string]struct{}, error) {
-	return (gitutil.Client{Dir: checkout}).RemoteBranches(ctx, branches)
+	return (gitutil.NewHostClient(checkout)).RemoteBranches(ctx, branches)
 }
 
 func (d Daemon) Run(ctx context.Context) error {

--- a/internal/daemon/poll_path_projection_test.go
+++ b/internal/daemon/poll_path_projection_test.go
@@ -257,7 +257,14 @@ func TestReconcileReviewingPullRequestAdvancesAmongLargeNonReviewPayload(t *test
 
 	gate := &fakeWorkflowMergeGate{decision: workflow.MergeDecision{Ready: true}}
 	engine := workflow.Engine{Store: store, MergeGate: gate}
-	d := Daemon{Repo: repo, Store: store, Workflow: &engine}
+	resolvedJobID := ""
+	d := Daemon{
+		Repo: repo, Store: store, Workflow: &engine,
+		WorkflowForJob: func(_ context.Context, job db.Job) (*workflow.Engine, error) {
+			resolvedJobID = job.ID
+			return &engine, nil
+		},
+	}
 
 	if err := d.reconcileReviewingPullRequest(ctx, reviewPull("abc123"), nil); err != nil {
 		t.Fatalf("reconcileReviewingPullRequest returned error: %v", err)
@@ -268,6 +275,9 @@ func TestReconcileReviewingPullRequestAdvancesAmongLargeNonReviewPayload(t *test
 	}
 	if task.State != string(workflow.TaskReadyToMerge) {
 		t.Fatalf("task state = %q, want ready_to_merge (review advanced despite large non-review payload)", task.State)
+	}
+	if resolvedJobID != "review-audit-task-007-review-1" {
+		t.Fatalf("workflow resolved for job %q, want completed review job", resolvedJobID)
 	}
 	if len(gate.requests) != 1 || gate.requests[0].HeadSHA != "abc123" {
 		t.Fatalf("merge gate requests = %+v, want one for head abc123", gate.requests)

--- a/internal/db/store_tasks.go
+++ b/internal/db/store_tasks.go
@@ -28,13 +28,13 @@ func (s *Store) UpsertRepoForce(ctx context.Context, repo Repo) error {
 func (s *Store) upsertRepo(ctx context.Context, repo Repo, force bool) error {
 	fullName := repo.Owner + "/" + repo.Name
 	if strings.TrimSpace(repo.CheckoutPath) != "" && strings.TrimSpace(repo.PrimaryCheckoutPath) == "" {
-		if primary, err := (gitutil.Client{Dir: repo.CheckoutPath}).PrimaryWorktree(ctx); err == nil {
+		if primary, err := (gitutil.NewHostClient(repo.CheckoutPath)).PrimaryWorktree(ctx); err == nil {
 			repo.PrimaryCheckoutPath = primary
 		}
 	}
 	if !force && strings.TrimSpace(repo.CheckoutPath) != "" {
 		if existing, err := s.GetRepo(ctx, fullName); err == nil && shouldProtectRepoCheckout(existing, repo.CheckoutPath) {
-			if linked, linkErr := (gitutil.Client{Dir: repo.CheckoutPath}).IsLinkedWorktree(ctx); linkErr == nil && linked {
+			if linked, linkErr := (gitutil.NewHostClient(repo.CheckoutPath)).IsLinkedWorktree(ctx); linkErr == nil && linked {
 				log.Printf("WARNING: keeping registered checkout for %s at %s; refusing linked worktree %s (use gitmoot repo add --force to override)", fullName, existing.CheckoutPath, repo.CheckoutPath)
 				repo.CheckoutPath = ""
 				repo.PrimaryCheckoutPath = ""

--- a/internal/execbackend/execbackend.go
+++ b/internal/execbackend/execbackend.go
@@ -16,10 +16,23 @@
 // P2 extends Consume with a required positional builder, that signature change
 // will make its existing callers fail to compile until they supply it. Adapter
 // builds without a selector retain the Local default. Job-associated git,
-// GitHub CLI, checkout, verifier, and read-only-diff subprocesses consume the
-// resolved runner through Consume and fail closed when the backend has no
-// execution implementation. Operator tooling and daemon supervision/session
-// paths that do not execute a job deliberately retain host-side runners.
+// GitHub CLI, verifier, and read-only-diff subprocesses consume the resolved
+// runner through Consume and fail closed when the backend has no execution
+// implementation. Operator tooling and daemon supervision/session paths
+// deliberately retain host-side runners.
+//
+// ONE KNOWN EXCEPTION, tracked by #1560: the supervisor provisions a job's
+// worktrees on the HOST even though it executes no agent runtime.
+// daemon_supervision.go's WorkflowFactory builds the engine via the
+// ExecRunner{} variant of daemonWorkflowEngine, which binds
+// engine.DelegationWorktrees and engine.FixWorktreeAllocator to that host
+// runner (daemon_workflow.go:174-176); AdvanceJob (daemon/daemon.go:1133) then
+// reaches AllocateIntegrationWorktree (engine_delegation.go:733) for returned
+// delegations. So "supervision" is not a safe proxy for "not job-associated":
+// this path is supervision AND performs job-associated checkout provisioning.
+// Gating it before P2 lands a second backend is #1560. Note the current guard,
+// TestJobSubprocessProductionRoutesDoNotCallHostWrappers, does NOT detect this
+// route.
 package execbackend
 
 import (

--- a/internal/execbackend/execbackend.go
+++ b/internal/execbackend/execbackend.go
@@ -15,9 +15,9 @@
 // ParseImplemented alone still compiles and then fails closed at consumption. If
 // P2 extends Consume with a required positional builder, that signature change
 // will make its existing callers fail to compile until they supply it. Adapter
-// builds without a selector retain the Local default. Selection does not yet gate
-// job-associated subprocess execution; closing that gap before P2 is tracked by
-// #1560.
+// builds without a selector retain the Local default. Job-associated subprocess
+// execution consumes its resolved selection through Consume and fails closed
+// when the backend has no execution implementation.
 package execbackend
 
 import (

--- a/internal/execbackend/execbackend.go
+++ b/internal/execbackend/execbackend.go
@@ -15,12 +15,11 @@
 // ParseImplemented alone still compiles and then fails closed at consumption. If
 // P2 extends Consume with a required positional builder, that signature change
 // will make its existing callers fail to compile until they supply it. Adapter
-// builds without a selector retain the Local default. Job-associated subprocess
-// execution is PARTIALLY gated: the git seam resolves its runner through Consume
-// and fails closed, but engine constructors still pass a host runner explicitly
-// (internal/cli/daemon_workflow.go, daemon_worker.go, internal/workflow) and two
-// git calls bypass the seam via raw exec (internal/cli/ask_diff_precleanup.go).
-// Closing those before P2 lands a second backend is tracked by #1560.
+// builds without a selector retain the Local default. Job-associated git,
+// GitHub CLI, checkout, verifier, and read-only-diff subprocesses consume the
+// resolved runner through Consume and fail closed when the backend has no
+// execution implementation. Operator tooling and daemon supervision/session
+// paths that do not execute a job deliberately retain host-side runners.
 package execbackend
 
 import (

--- a/internal/execbackend/execbackend.go
+++ b/internal/execbackend/execbackend.go
@@ -19,20 +19,10 @@
 // GitHub CLI, verifier, and read-only-diff subprocesses consume the resolved
 // runner through Consume and fail closed when the backend has no execution
 // implementation. Operator tooling and daemon supervision/session paths
-// deliberately retain host-side runners.
-//
-// ONE KNOWN EXCEPTION, tracked by #1560: the supervisor provisions a job's
-// worktrees on the HOST even though it executes no agent runtime.
-// daemon_supervision.go's WorkflowFactory builds the engine via the
-// ExecRunner{} variant of daemonWorkflowEngine, which binds
-// engine.DelegationWorktrees and engine.FixWorktreeAllocator to that host
-// runner (daemon_workflow.go:174-176); AdvanceJob (daemon/daemon.go:1133) then
-// reaches AllocateIntegrationWorktree (engine_delegation.go:733) for returned
-// delegations. So "supervision" is not a safe proxy for "not job-associated":
-// this path is supervision AND performs job-associated checkout provisioning.
-// Gating it before P2 lands a second backend is #1560. Note the current guard,
-// TestJobSubprocessProductionRoutesDoNotCallHostWrappers, does NOT detect this
-// route.
+// deliberately retain host-side runners. When supervision advances a completed
+// job, it resolves that job's stored backend and rebuilds the workflow engine
+// through the same Consume-backed runner seam before any delegation worktree or
+// other job-associated subprocess can execute.
 package execbackend
 
 import (

--- a/internal/execbackend/execbackend.go
+++ b/internal/execbackend/execbackend.go
@@ -16,8 +16,11 @@
 // P2 extends Consume with a required positional builder, that signature change
 // will make its existing callers fail to compile until they supply it. Adapter
 // builds without a selector retain the Local default. Job-associated subprocess
-// execution consumes its resolved selection through Consume and fails closed
-// when the backend has no execution implementation.
+// execution is PARTIALLY gated: the git seam resolves its runner through Consume
+// and fails closed, but engine constructors still pass a host runner explicitly
+// (internal/cli/daemon_workflow.go, daemon_worker.go, internal/workflow) and two
+// git calls bypass the seam via raw exec (internal/cli/ask_diff_precleanup.go).
+// Closing those before P2 lands a second backend is tracked by #1560.
 package execbackend
 
 import (

--- a/internal/git/client.go
+++ b/internal/git/client.go
@@ -14,9 +14,25 @@ import (
 )
 
 type Client struct {
-	Runner subprocess.Runner
-	Dir    string
+	runner subprocess.Runner
+	dir    string
 }
+
+// NewClient binds every git command to an explicit subprocess runner. Job paths
+// pass a backend-resolved runner; operator tooling that intentionally executes
+// on the host uses NewHostClient.
+func NewClient(dir string, runner subprocess.Runner) Client {
+	return Client{runner: runner, dir: dir}
+}
+
+// NewHostClient explicitly selects host execution for non-job CLI and daemon
+// administration paths.
+func NewHostClient(dir string) Client {
+	return NewClient(dir, subprocess.ExecRunner{})
+}
+
+// Dir returns the checkout directory bound to this client.
+func (c Client) Dir() string { return c.dir }
 
 const maxGitErrorStderrRunes = 4096
 
@@ -87,7 +103,7 @@ func (c Client) AddDetachedWorktree(ctx context.Context, path string, ref string
 	return err
 }
 
-// CloneLocalNoCheckout makes an INDEPENDENT local clone of this repo (c.Dir) into
+// CloneLocalNoCheckout makes an INDEPENDENT local clone of this repo (c.dir) into
 // dest via `git clone --local --no-checkout`. Because the source is local, git
 // HARDLINKS everything under objects/ (fast, space-cheap) and copies refs, but the
 // clone gets its OWN git directory: its own object DB directory, refs, config, HEAD,
@@ -105,7 +121,7 @@ func (c Client) CloneLocalNoCheckout(ctx context.Context, dest string) error {
 	if err != nil {
 		return err
 	}
-	src := strings.TrimSpace(c.Dir)
+	src := strings.TrimSpace(c.dir)
 	if src == "" {
 		return errors.New("clone source (client dir) is required")
 	}
@@ -224,10 +240,10 @@ func (c Client) RemoveWorktreeForce(ctx context.Context, path string) error {
 		return err
 	}
 	owner, ownerErr := worktreeOwnerCheckout(path)
-	if ownerErr != nil || filepath.Clean(owner) == filepath.Clean(c.Dir) {
+	if ownerErr != nil || filepath.Clean(owner) == filepath.Clean(c.dir) {
 		return err
 	}
-	_, err = (Client{Runner: c.Runner, Dir: owner}).run(ctx, "worktree", "remove", "--force", path)
+	_, err = NewClient(owner, c.runner).run(ctx, "worktree", "remove", "--force", path)
 	return err
 }
 
@@ -265,7 +281,7 @@ func (c Client) MergeBranches(ctx context.Context, dir string, branches []string
 	if strings.TrimSpace(message) == "" {
 		message = "Gitmoot integration merge"
 	}
-	git := Client{Dir: dir, Runner: c.Runner}
+	git := NewClient(dir, c.runner)
 	for _, branch := range branches {
 		if err := validateBranch(branch); err != nil {
 			return err
@@ -294,7 +310,7 @@ func (c Client) CommitWorktree(ctx context.Context, dir string, message string) 
 	if strings.TrimSpace(message) == "" {
 		message = "Gitmoot delegation commit"
 	}
-	git := Client{Dir: dir, Runner: c.Runner}
+	git := NewClient(dir, c.runner)
 	if _, err := git.run(ctx, "add", "-A"); err != nil {
 		return false, err
 	}
@@ -369,7 +385,7 @@ func (c Client) Root(ctx context.Context) (string, error) {
 	return root, nil
 }
 
-// IsLinkedWorktree reports whether c.Dir is a linked worktree rather than the
+// IsLinkedWorktree reports whether c.dir is a linked worktree rather than the
 // primary checkout. Git 2.31 added --path-format=absolute; older versions fall
 // back to resolving git-dir/common-dir relative to the client directory.
 func (c Client) IsLinkedWorktree(ctx context.Context) (bool, error) {
@@ -431,7 +447,7 @@ func (c Client) absoluteGitPath(path string) (string, error) {
 		return "", errors.New("git path is empty")
 	}
 	if !filepath.IsAbs(path) {
-		base := strings.TrimSpace(c.Dir)
+		base := strings.TrimSpace(c.dir)
 		if base == "" {
 			base = "."
 		}
@@ -484,7 +500,7 @@ func (c Client) WorktreeCleanAt(ctx context.Context, path string) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	return (Client{Runner: c.Runner, Dir: path}).WorktreeClean(ctx)
+	return NewClient(path, c.runner).WorktreeClean(ctx)
 }
 
 func (c Client) StatusPorcelain(ctx context.Context) (string, error) {
@@ -524,7 +540,7 @@ func (c Client) HeadSHAAt(ctx context.Context, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return (Client{Runner: c.Runner, Dir: path}).HeadSHA(ctx)
+	return NewClient(path, c.runner).HeadSHA(ctx)
 }
 
 func (c Client) RevParse(ctx context.Context, rev string) (string, error) {
@@ -627,11 +643,10 @@ func (c Client) UpdateBase(ctx context.Context, remote string, branch string) er
 }
 
 func (c Client) run(ctx context.Context, args ...string) (subprocess.Result, error) {
-	runner := c.Runner
-	if runner == nil {
-		runner = subprocess.ExecRunner{}
+	if c.runner == nil {
+		return subprocess.Result{}, errors.New("git subprocess runner is required")
 	}
-	result, err := runner.Run(ctx, c.Dir, "git", args...)
+	result, err := c.runner.Run(ctx, c.dir, "git", args...)
 	if err != nil {
 		if stderr := boundedGitErrorStderr(result.Stderr); stderr != "" {
 			return result, fmt.Errorf("git %s: %w (stderr: %s)", strings.Join(args, " "), err, stderr)
@@ -651,7 +666,7 @@ func boundedGitErrorStderr(stderr string) string {
 }
 
 // worktreeOwnerCheckout resolves the repository that owns a linked worktree
-// from the worktree's gitdir pointer, even when Client.Dir is a different clone.
+// from the worktree's gitdir pointer, even when Client.dir is a different clone.
 func worktreeOwnerCheckout(path string) (string, error) {
 	data, err := os.ReadFile(filepath.Join(path, ".git"))
 	if err != nil {

--- a/internal/git/client_test.go
+++ b/internal/git/client_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestClientUsesSharedSubprocessRunner(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{}, {Stdout: "task-1\n"}, {}, {Stdout: "/repo\n"}, {Stdout: "https://github.com/gitmoot/gitmoot.git\n"}, {}, {}, {}}}
-	client := Client{Runner: runner, Dir: "/repo"}
+	client := NewClient("/repo", runner)
 
 	if err := client.CreateBranch(context.Background(), "task-1", "main"); err != nil {
 		t.Fatalf("CreateBranch returned error: %v", err)
@@ -66,9 +66,16 @@ func TestClientUsesSharedSubprocessRunner(t *testing.T) {
 	runner.wantArgs(t, 8, "git", "pull", "--ff-only", "origin", "main")
 }
 
+func TestClientRequiresSubprocessRunner(t *testing.T) {
+	client := NewClient(t.TempDir(), nil)
+	if _, err := client.HeadSHA(context.Background()); err == nil || !strings.Contains(err.Error(), "git subprocess runner is required") {
+		t.Fatalf("HeadSHA error = %v, want required-runner refusal", err)
+	}
+}
+
 func TestClientStatusPorcelainDisablesOptionalLocks(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: " M file.go\n"}}}
-	status, err := (Client{Runner: runner, Dir: "/repo"}).StatusPorcelain(context.Background())
+	status, err := (NewClient("/repo", runner)).StatusPorcelain(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +119,7 @@ func TestClientIsLinkedWorktree(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			runner := &fakeRunner{results: tc.results, errs: tc.errs}
-			linked, err := (Client{Runner: runner, Dir: "/repo"}).IsLinkedWorktree(context.Background())
+			linked, err := (NewClient("/repo", runner)).IsLinkedWorktree(context.Background())
 			if err != nil {
 				t.Fatalf("IsLinkedWorktree returned error: %v", err)
 			}
@@ -128,7 +135,7 @@ func TestClientIsLinkedWorktree(t *testing.T) {
 
 func TestClientPrimaryWorktree(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "worktree /repo\nHEAD abc\nbranch refs/heads/main\n\nworktree /repo-linked\nHEAD def\nbranch refs/heads/task\n"}}}
-	primary, err := (Client{Runner: runner, Dir: "/repo-linked"}).PrimaryWorktree(context.Background())
+	primary, err := (NewClient("/repo-linked", runner)).PrimaryWorktree(context.Background())
 	if err != nil {
 		t.Fatalf("PrimaryWorktree returned error: %v", err)
 	}
@@ -143,7 +150,7 @@ func TestClientPrimaryWorktreeSkipsBareAndFallsBackToSelf(t *testing.T) {
 		{Stdout: "worktree /repo.git\nbare\n"},
 		{Stdout: "/repo-linked\n"},
 	}}
-	primary, err := (Client{Runner: runner, Dir: "/repo-linked"}).PrimaryWorktree(context.Background())
+	primary, err := (NewClient("/repo-linked", runner)).PrimaryWorktree(context.Background())
 	if err != nil {
 		t.Fatalf("PrimaryWorktree returned error: %v", err)
 	}
@@ -157,7 +164,7 @@ func TestClientPrimaryWorktreeSkipsBareAndFallsBackToSelf(t *testing.T) {
 func TestClientRejectsUnsafeBranchNames(t *testing.T) {
 	for _, branch := range []string{"", " task", "task ", "-bad", "bad branch", "bad..branch", "bad.lock", "HEAD:main", "bad~branch", "bad^branch", "bad?branch", "bad[branch", "bad\\branch", "bad@{branch", "/bad", "bad/", "bad//branch"} {
 		t.Run(branch, func(t *testing.T) {
-			if err := (Client{}).CreateBranch(context.Background(), branch, "main"); err == nil {
+			if err := (NewClient("", nil)).CreateBranch(context.Background(), branch, "main"); err == nil {
 				t.Fatal("CreateBranch accepted unsafe branch")
 			}
 		})
@@ -166,7 +173,7 @@ func TestClientRejectsUnsafeBranchNames(t *testing.T) {
 
 func TestClientWorktreeCommandConstruction(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{}, {}, {}, {}}}
-	client := Client{Runner: runner, Dir: "/repo"}
+	client := NewClient("/repo", runner)
 
 	if err := client.AddWorktree(context.Background(), "task-1", "/worktrees/task-1", "main"); err != nil {
 		t.Fatalf("AddWorktree returned error: %v", err)
@@ -192,41 +199,41 @@ func TestClientWorktreeCommandConstruction(t *testing.T) {
 }
 
 func TestClientAddWorktreeRejectsInvalidInput(t *testing.T) {
-	if err := (Client{}).AddWorktree(context.Background(), "bad branch", "/tmp/wt", "main"); err == nil {
+	if err := (NewClient("", nil)).AddWorktree(context.Background(), "bad branch", "/tmp/wt", "main"); err == nil {
 		t.Fatal("AddWorktree accepted unsafe branch")
 	}
-	if err := (Client{}).AddExistingBranchWorktree(context.Background(), "bad branch", "/tmp/wt"); err == nil {
+	if err := (NewClient("", nil)).AddExistingBranchWorktree(context.Background(), "bad branch", "/tmp/wt"); err == nil {
 		t.Fatal("AddExistingBranchWorktree accepted unsafe branch")
 	}
-	if _, err := (Client{}).BranchExists(context.Background(), "bad branch"); err == nil {
+	if _, err := (NewClient("", nil)).BranchExists(context.Background(), "bad branch"); err == nil {
 		t.Fatal("BranchExists accepted unsafe branch")
 	}
-	if err := (Client{}).AddWorktree(context.Background(), "task-1", "", "main"); err == nil {
+	if err := (NewClient("", nil)).AddWorktree(context.Background(), "task-1", "", "main"); err == nil {
 		t.Fatal("AddWorktree accepted empty path")
 	}
-	if err := (Client{}).AddExistingBranchWorktree(context.Background(), "task-1", " "); err == nil {
+	if err := (NewClient("", nil)).AddExistingBranchWorktree(context.Background(), "task-1", " "); err == nil {
 		t.Fatal("AddExistingBranchWorktree accepted empty path")
 	}
-	if err := (Client{}).RemoveWorktree(context.Background(), " "); err == nil {
+	if err := (NewClient("", nil)).RemoveWorktree(context.Background(), " "); err == nil {
 		t.Fatal("RemoveWorktree accepted empty path")
 	}
-	if err := (Client{}).RemoveWorktreeForce(context.Background(), " "); err == nil {
+	if err := (NewClient("", nil)).RemoveWorktreeForce(context.Background(), " "); err == nil {
 		t.Fatal("RemoveWorktreeForce accepted empty path")
 	}
-	if err := (Client{}).AddDetachedWorktree(context.Background(), "", "main"); err == nil {
+	if err := (NewClient("", nil)).AddDetachedWorktree(context.Background(), "", "main"); err == nil {
 		t.Fatal("AddDetachedWorktree accepted empty path")
 	}
-	if err := (Client{}).AddDetachedWorktree(context.Background(), "/tmp/wt", " "); err == nil {
+	if err := (NewClient("", nil)).AddDetachedWorktree(context.Background(), "/tmp/wt", " "); err == nil {
 		t.Fatal("AddDetachedWorktree accepted empty ref")
 	}
-	if err := (Client{}).AddDetachedWorktree(context.Background(), "/tmp/wt", "-bad"); err == nil {
+	if err := (NewClient("", nil)).AddDetachedWorktree(context.Background(), "/tmp/wt", "-bad"); err == nil {
 		t.Fatal("AddDetachedWorktree accepted ref starting with '-'")
 	}
 }
 
 func TestClientDetachedAndForceRemoveCommandConstruction(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{}, {}, {}}}
-	client := Client{Runner: runner, Dir: "/repo"}
+	client := NewClient("/repo", runner)
 	if err := client.AddDetachedWorktree(context.Background(), "/worktrees/d1", "main"); err != nil {
 		t.Fatalf("AddDetachedWorktree returned error: %v", err)
 	}
@@ -255,7 +262,7 @@ func TestClientRemoveWorktreeForceSmoke(t *testing.T) {
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "init")
 
-	client := Client{Dir: dir}
+	client := NewHostClient(dir)
 	wt := filepath.Join(t.TempDir(), "detached")
 	if err := client.AddDetachedWorktree(context.Background(), wt, "HEAD"); err != nil {
 		t.Fatalf("AddDetachedWorktree returned error: %v", err)
@@ -278,7 +285,7 @@ func TestClientRemoveWorktreeForceSmoke(t *testing.T) {
 
 func TestClientMergeBranchesCommandConstruction(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{}, {}}}
-	client := Client{Runner: runner, Dir: "/repo"}
+	client := NewClient("/repo", runner)
 	if err := client.MergeBranches(context.Background(), "/wt/integration", []string{"legA", "legB"}, "integrate"); err != nil {
 		t.Fatalf("MergeBranches returned error: %v", err)
 	}
@@ -288,7 +295,7 @@ func TestClientMergeBranchesCommandConstruction(t *testing.T) {
 
 func TestClientMergeBranchesAbortsAndNamesConflictingBranch(t *testing.T) {
 	runner := &fakeRunner{errs: []error{nil, errors.New("CONFLICT")}}
-	client := Client{Runner: runner, Dir: "/repo"}
+	client := NewClient("/repo", runner)
 	err := client.MergeBranches(context.Background(), "/wt/integration", []string{"legA", "legB"}, "integrate")
 	if err == nil {
 		t.Fatal("expected error when a leg merge conflicts")
@@ -300,10 +307,10 @@ func TestClientMergeBranchesAbortsAndNamesConflictingBranch(t *testing.T) {
 	if len(last) < 3 || last[1] != "merge" || last[2] != "--abort" {
 		t.Fatalf("expected a 'merge --abort' after conflict, got %v", last)
 	}
-	if err := (Client{}).MergeBranches(context.Background(), " ", []string{"legA"}, "m"); err == nil {
+	if err := (NewClient("", nil)).MergeBranches(context.Background(), " ", []string{"legA"}, "m"); err == nil {
 		t.Fatal("MergeBranches accepted an empty dir")
 	}
-	if err := (Client{Runner: &fakeRunner{}}).MergeBranches(context.Background(), "/wt", []string{"bad branch"}, "m"); err == nil {
+	if err := (NewClient("", &fakeRunner{})).MergeBranches(context.Background(), "/wt", []string{"bad branch"}, "m"); err == nil {
 		t.Fatal("MergeBranches accepted an unsafe branch name")
 	}
 }
@@ -337,7 +344,7 @@ func TestClientMergeBranchesSmoke(t *testing.T) {
 	runGit(t, dir, "commit", "-m", "legB")
 	runGit(t, dir, "checkout", "main")
 
-	client := Client{Dir: dir}
+	client := NewHostClient(dir)
 	wt := filepath.Join(t.TempDir(), "integration")
 	if err := client.AddDetachedWorktree(context.Background(), wt, "main"); err != nil {
 		t.Fatalf("AddDetachedWorktree returned error: %v", err)
@@ -367,7 +374,7 @@ func TestClientCommitWorktreeSmoke(t *testing.T) {
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "base")
 
-	client := Client{Dir: dir}
+	client := NewHostClient(dir)
 	// Clean worktree -> no commit.
 	committed, err := client.CommitWorktree(context.Background(), dir, "noop")
 	if err != nil {
@@ -394,14 +401,14 @@ func TestClientCommitWorktreeSmoke(t *testing.T) {
 	if !clean {
 		t.Fatal("worktree should be clean after CommitWorktree")
 	}
-	if _, err := (Client{}).CommitWorktree(context.Background(), " ", "m"); err == nil {
+	if _, err := (NewClient("", nil)).CommitWorktree(context.Background(), " ", "m"); err == nil {
 		t.Fatal("CommitWorktree accepted an empty dir")
 	}
 }
 
 func TestClientBranchExistsReturnsFalseForMissingBranch(t *testing.T) {
 	runner := &fakeRunner{errs: []error{errors.New("exit status 1")}}
-	exists, err := (Client{Runner: runner, Dir: "/repo"}).BranchExists(context.Background(), "missing")
+	exists, err := (NewClient("/repo", runner)).BranchExists(context.Background(), "missing")
 	if err != nil {
 		t.Fatalf("BranchExists returned error: %v", err)
 	}
@@ -413,7 +420,7 @@ func TestClientBranchExistsReturnsFalseForMissingBranch(t *testing.T) {
 
 func TestClientRemoteBranchesBatchesExactRefs(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "abc\trefs/heads/feature/one\ndef\trefs/heads/unrequested\n"}}}
-	branches, err := (Client{Runner: runner, Dir: "/repo"}).RemoteBranches(context.Background(), []string{"feature/one", "feature/two"})
+	branches, err := (NewClient("/repo", runner)).RemoteBranches(context.Background(), []string{"feature/one", "feature/two"})
 	if err != nil {
 		t.Fatalf("RemoteBranches: %v", err)
 	}
@@ -421,14 +428,14 @@ func TestClientRemoteBranchesBatchesExactRefs(t *testing.T) {
 		t.Fatalf("branches = %v", branches)
 	}
 	runner.wantArgs(t, 0, "git", "ls-remote", "--heads", "origin", "refs/heads/feature/one", "refs/heads/feature/two")
-	if _, err := (Client{}).RemoteBranches(context.Background(), []string{"bad branch"}); err == nil {
+	if _, err := (NewClient("", nil)).RemoteBranches(context.Background(), []string{"bad branch"}); err == nil {
 		t.Fatal("RemoteBranches accepted unsafe branch")
 	}
 }
 
 func TestClientHeadSHA(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "abc123\n"}}}
-	sha, err := (Client{Runner: runner, Dir: "/repo"}).HeadSHA(context.Background())
+	sha, err := (NewClient("/repo", runner)).HeadSHA(context.Background())
 	if err != nil {
 		t.Fatalf("HeadSHA returned error: %v", err)
 	}
@@ -440,7 +447,7 @@ func TestClientHeadSHA(t *testing.T) {
 
 func TestClientRevParse(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "def456\n"}}}
-	sha, err := (Client{Runner: runner, Dir: "/repo"}).RevParse(context.Background(), "origin/main")
+	sha, err := (NewClient("/repo", runner)).RevParse(context.Background(), "origin/main")
 	if err != nil {
 		t.Fatalf("RevParse returned error: %v", err)
 	}
@@ -455,7 +462,7 @@ func TestClientRevParse(t *testing.T) {
 // before ever invoking git (no runner call). Mirrors validateBranch's dash guard.
 func TestClientRevParseRejectsDashRev(t *testing.T) {
 	runner := &fakeRunner{}
-	if _, err := (Client{Runner: runner, Dir: "/repo"}).RevParse(context.Background(), "--upload-pack=evil"); err == nil {
+	if _, err := (NewClient("/repo", runner)).RevParse(context.Background(), "--upload-pack=evil"); err == nil {
 		t.Fatal("RevParse accepted a rev starting with '-', want an error")
 	}
 	if len(runner.calls) != 0 {
@@ -465,18 +472,18 @@ func TestClientRevParseRejectsDashRev(t *testing.T) {
 
 func TestClientFetchRemote(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{}}}
-	if err := (Client{Runner: runner, Dir: "/repo"}).FetchRemote(context.Background(), "origin"); err != nil {
+	if err := (NewClient("/repo", runner)).FetchRemote(context.Background(), "origin"); err != nil {
 		t.Fatalf("FetchRemote returned error: %v", err)
 	}
 	runner.wantArgs(t, 0, "git", "fetch", "origin")
-	if err := (Client{}).FetchRemote(context.Background(), "-unsafe"); err == nil {
+	if err := (NewClient("", nil)).FetchRemote(context.Background(), "-unsafe"); err == nil {
 		t.Fatal("FetchRemote accepted an unsafe remote")
 	}
 }
 
 func TestClientBehindCount(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "12\n"}}}
-	count, err := (Client{Runner: runner, Dir: "/repo"}).BehindCount(context.Background(), "origin/main")
+	count, err := (NewClient("/repo", runner)).BehindCount(context.Background(), "origin/main")
 	if err != nil {
 		t.Fatalf("BehindCount returned error: %v", err)
 	}
@@ -488,10 +495,10 @@ func TestClientBehindCount(t *testing.T) {
 
 func TestClientBehindCountRejectsInvalidOutput(t *testing.T) {
 	runner := &fakeRunner{results: []subprocess.Result{{Stdout: "many\n"}}}
-	if _, err := (Client{Runner: runner, Dir: "/repo"}).BehindCount(context.Background(), "origin/main"); err == nil {
+	if _, err := (NewClient("/repo", runner)).BehindCount(context.Background(), "origin/main"); err == nil {
 		t.Fatal("BehindCount accepted non-numeric output")
 	}
-	if _, err := (Client{}).BehindCount(context.Background(), "-unsafe"); err == nil {
+	if _, err := (NewClient("", nil)).BehindCount(context.Background(), "-unsafe"); err == nil {
 		t.Fatal("BehindCount accepted an unsafe ref")
 	}
 }
@@ -510,7 +517,7 @@ func TestClientIsAncestor(t *testing.T) {
 	}
 	runGit(t, dir, "add", "history.txt")
 	runGit(t, dir, "commit", "-m", "base")
-	client := Client{Dir: dir}
+	client := NewHostClient(dir)
 	base, err := client.HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA base: %v", err)
@@ -561,7 +568,7 @@ func TestClientCommitExistsDistinguishesMissingObject(t *testing.T) {
 	}
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "initial")
-	client := Client{Dir: dir}
+	client := NewHostClient(dir)
 	head, err := client.HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA: %v", err)
@@ -576,7 +583,7 @@ func TestClientCommitExistsDistinguishesMissingObject(t *testing.T) {
 
 func TestClientCommitExistsPropagatesRepositoryFailure(t *testing.T) {
 	runner := &fakeRunner{errs: []error{errors.New("object database unavailable")}}
-	present, err := (Client{Runner: runner, Dir: "/repo"}).CommitExists(context.Background(), "deadbeef")
+	present, err := (NewClient("/repo", runner)).CommitExists(context.Background(), "deadbeef")
 	if err == nil || present {
 		t.Fatalf("CommitExists(repository failure) = %t, %v", present, err)
 	}
@@ -597,7 +604,7 @@ func TestClientCreateBranchSmoke(t *testing.T) {
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "init")
 
-	client := Client{Dir: dir}
+	client := NewHostClient(dir)
 	if err := client.CreateBranch(context.Background(), "task-branch", "main"); err != nil {
 		t.Fatalf("CreateBranch returned error: %v", err)
 	}
@@ -624,7 +631,7 @@ func TestClientWorktreeCleanSmoke(t *testing.T) {
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "init")
 
-	client := Client{Dir: dir}
+	client := NewHostClient(dir)
 	clean, err := client.WorktreeClean(context.Background())
 	if err != nil {
 		t.Fatalf("WorktreeClean returned error: %v", err)
@@ -659,7 +666,7 @@ func TestClientAddExistingBranchWorktreeRefusesCheckedOutBranchSmoke(t *testing.
 	runGit(t, dir, "commit", "-m", "init")
 	runGit(t, dir, "switch", "-c", "task-branch")
 
-	client := Client{Dir: dir}
+	client := NewHostClient(dir)
 	err := client.AddExistingBranchWorktree(context.Background(), "task-branch", filepath.Join(dir, "task-worktree"))
 	if err == nil {
 		t.Fatal("AddExistingBranchWorktree allowed a branch already checked out in the main worktree")

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -462,7 +462,8 @@ type GhClient struct {
 	// uses the package-global DefaultLimiter() so every GhClient constructed via
 	// NewClient shares one budget + one secondary-rate-limit backoff window. Tests
 	// set it to an isolated limiter (fake clock) to exercise smoothing/backoff.
-	Limiter *RateLimiter
+	Limiter        *RateLimiter
+	runnerRequired bool
 
 	mutateMu sync.Mutex
 	statsMu  sync.Mutex
@@ -471,6 +472,26 @@ type GhClient struct {
 
 func NewClient(dir string) *GhClient {
 	return &GhClient{Dir: dir}
+}
+
+func NewClientWithRunner(dir string, runner subprocess.Runner) *GhClient {
+	return &GhClient{Dir: dir, Runner: runner, runnerRequired: true}
+}
+
+// WithRunner returns an equivalent client bound to dir and runner. Runtime
+// counters and mutexes are intentionally fresh; policy seams are preserved.
+func (c *GhClient) WithRunner(dir string, runner subprocess.Runner) *GhClient {
+	if c == nil {
+		return NewClientWithRunner(dir, runner)
+	}
+	return &GhClient{
+		Runner:         runner,
+		Dir:            dir,
+		Sleep:          c.Sleep,
+		MaxRetries:     c.MaxRetries,
+		Limiter:        c.Limiter,
+		runnerRequired: true,
+	}
 }
 
 func (c *GhClient) Ping(ctx context.Context) error {
@@ -1533,6 +1554,9 @@ func (c *GhClient) runRequest(ctx context.Context, mutate bool, conditional bool
 
 	runner := c.Runner
 	if runner == nil {
+		if c.runnerRequired {
+			return subprocess.Result{}, errors.New("GitHub client requires an explicit subprocess runner")
+		}
 		runner = subprocess.ExecRunner{}
 	}
 	retries := c.MaxRetries

--- a/internal/plugincontext/plugincontext.go
+++ b/internal/plugincontext/plugincontext.go
@@ -160,7 +160,7 @@ func quoteContextValue(value string) string {
 }
 
 func detectRepo(ctx context.Context, cwd string, runner subprocess.Runner) repoInfo {
-	client := gitutil.Client{Dir: cwd, Runner: runner}
+	client := gitutil.NewClient(cwd, runner)
 	root, err := client.Root(ctx)
 	if err != nil {
 		return repoInfo{}

--- a/internal/subprocess/runner.go
+++ b/internal/subprocess/runner.go
@@ -38,7 +38,7 @@ type EnvRunner interface {
 // this seam when omitted variables must stay absent.
 type ExactEnvRunner interface {
 	Runner
-	RunExactEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error)
+	RunExactEnv(ctx context.Context, dir string, env []string, stdout, stderr io.Writer, command string, args ...string) error
 }
 
 // PIDCallback is invoked after a subprocess has started successfully and before
@@ -114,8 +114,8 @@ func (ExecRunner) RunEnv(ctx context.Context, dir string, env []string, command 
 	return RunEnv(ctx, dir, env, command, args...)
 }
 
-func (ExecRunner) RunExactEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error) {
-	return RunExactEnv(ctx, dir, env, command, args...)
+func (ExecRunner) RunExactEnv(ctx context.Context, dir string, env []string, stdout, stderr io.Writer, command string, args ...string) error {
+	return RunExactEnv(ctx, dir, env, stdout, stderr, command, args...)
 }
 
 func (ExecRunner) RunEnvWithPID(ctx context.Context, dir string, env []string, onPID PIDCallback, command string, args ...string) (Result, error) {
@@ -434,24 +434,17 @@ func RunEnv(ctx context.Context, dir string, extraEnv []string, command string, 
 	}, err
 }
 
-// RunExactEnv runs like Run with exactly env. Unlike RunEnv, omitted host
-// variables are not inherited.
-func RunExactEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error) {
+// RunExactEnv runs with exactly env and streams output into the supplied
+// writers. Unlike RunEnv, omitted host variables are not inherited. Callers
+// retain control over buffering so bounded writers can cap memory while the
+// subprocess is running.
+func RunExactEnv(ctx context.Context, dir string, env []string, stdout, stderr io.Writer, command string, args ...string) error {
 	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Dir = dir
 	cmd.Env = append([]string(nil), env...)
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	err := cmd.Run()
-	return Result{
-		Command: command,
-		Args:    args,
-		Stdout:  stdout.String(),
-		Stderr:  stderr.String(),
-	}, err
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
 }
 
 // RunEnvWithPID is RunEnv with an additive callback invoked after a successful

--- a/internal/subprocess/runner.go
+++ b/internal/subprocess/runner.go
@@ -33,6 +33,14 @@ type EnvRunner interface {
 	RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error)
 }
 
+// ExactEnvRunner runs with exactly the supplied environment instead of
+// inheriting the host environment. Security-sensitive subprocess setup uses
+// this seam when omitted variables must stay absent.
+type ExactEnvRunner interface {
+	Runner
+	RunExactEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error)
+}
+
 // PIDCallback is invoked after a subprocess has started successfully and before
 // its runner blocks waiting for completion.
 type PIDCallback func(pid int)
@@ -104,6 +112,10 @@ func (ExecRunner) LookPath(file string) (string, error) {
 
 func (ExecRunner) RunEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error) {
 	return RunEnv(ctx, dir, env, command, args...)
+}
+
+func (ExecRunner) RunExactEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error) {
+	return RunExactEnv(ctx, dir, env, command, args...)
 }
 
 func (ExecRunner) RunEnvWithPID(ctx context.Context, dir string, env []string, onPID PIDCallback, command string, args ...string) (Result, error) {
@@ -408,6 +420,26 @@ func RunEnv(ctx context.Context, dir string, extraEnv []string, command string, 
 	if len(extraEnv) > 0 {
 		cmd.Env = append(os.Environ(), extraEnv...)
 	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return Result{
+		Command: command,
+		Args:    args,
+		Stdout:  stdout.String(),
+		Stderr:  stderr.String(),
+	}, err
+}
+
+// RunExactEnv runs like Run with exactly env. Unlike RunEnv, omitted host
+// variables are not inherited.
+func RunExactEnv(ctx context.Context, dir string, env []string, command string, args ...string) (Result, error) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Dir = dir
+	cmd.Env = append([]string(nil), env...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/subprocess/runner_test.go
+++ b/internal/subprocess/runner_test.go
@@ -29,10 +29,13 @@ func TestExecRunnerRunExactEnvDoesNotInheritHost(t *testing.T) {
 	}
 
 	t.Setenv("GITMOOT_EXACT_ENV_AMBIENT", "must-not-leak")
-	result, err := (ExecRunner{}).RunExactEnv(
+	var stdout, stderr bytes.Buffer
+	err := (ExecRunner{}).RunExactEnv(
 		context.Background(),
 		"",
 		[]string{"GITMOOT_EXACT_ENV_VALUE=exact"},
+		&stdout,
+		&stderr,
 		"sh",
 		"-c",
 		`printf '%s|%s' "$GITMOOT_EXACT_ENV_VALUE" "${GITMOOT_EXACT_ENV_AMBIENT-unset}"`,
@@ -40,8 +43,11 @@ func TestExecRunnerRunExactEnvDoesNotInheritHost(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunExactEnv returned error: %v", err)
 	}
-	if result.Stdout != "exact|unset" {
-		t.Fatalf("stdout = %q, want exact environment without ambient variables", result.Stdout)
+	if stdout.String() != "exact|unset" {
+		t.Fatalf("stdout = %q, want exact environment without ambient variables", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
 	}
 }
 

--- a/internal/subprocess/runner_test.go
+++ b/internal/subprocess/runner_test.go
@@ -23,6 +23,28 @@ func TestRunCapturesStdout(t *testing.T) {
 	}
 }
 
+func TestExecRunnerRunExactEnvDoesNotInheritHost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell command differs on windows")
+	}
+
+	t.Setenv("GITMOOT_EXACT_ENV_AMBIENT", "must-not-leak")
+	result, err := (ExecRunner{}).RunExactEnv(
+		context.Background(),
+		"",
+		[]string{"GITMOOT_EXACT_ENV_VALUE=exact"},
+		"sh",
+		"-c",
+		`printf '%s|%s' "$GITMOOT_EXACT_ENV_VALUE" "${GITMOOT_EXACT_ENV_AMBIENT-unset}"`,
+	)
+	if err != nil {
+		t.Fatalf("RunExactEnv returned error: %v", err)
+	}
+	if result.Stdout != "exact|unset" {
+		t.Fatalf("stdout = %q, want exact environment without ambient variables", result.Stdout)
+	}
+}
+
 func TestGroupRunnerPIDCaptureReportsStartedProcess(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("PID assertion uses a POSIX shell")

--- a/internal/workflow/worktree_test.go
+++ b/internal/workflow/worktree_test.go
@@ -446,7 +446,7 @@ func TestEngineAllocateTaskWorktreeRecutsCleanOffLineageWorktree(t *testing.T) {
 	if task.WorktreePath != path {
 		t.Fatalf("task worktree = %q, want %q", task.WorktreePath, path)
 	}
-	newHead, err := (gitutil.Client{Dir: path}).HeadSHA(ctx)
+	newHead, err := (gitutil.NewHostClient(path)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA re-cut worktree: %v", err)
 	}
@@ -477,7 +477,7 @@ func TestEngineAllocateTaskWorktreeBlocksDirtyOffLineageWorktree(t *testing.T) {
 			t.Fatalf("blocked reason %q missing %q", blocked.Reason, want)
 		}
 	}
-	headAfter, err := (gitutil.Client{Dir: path}).HeadSHA(ctx)
+	headAfter, err := (gitutil.NewHostClient(path)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA preserved worktree: %v", err)
 	}
@@ -938,7 +938,7 @@ func setupOffLineageTaskWorktree(t *testing.T, dirty bool) (context.Context, *db
 	}
 	runWorktreeGit(t, path, "add", "stale.txt")
 	runWorktreeGit(t, path, "commit", "-m", "stale branch")
-	oldHead, err := (gitutil.Client{Dir: path}).HeadSHA(ctx)
+	oldHead, err := (gitutil.NewHostClient(path)).HeadSHA(ctx)
 	if err != nil {
 		t.Fatalf("HeadSHA stale worktree: %v", err)
 	}
@@ -949,7 +949,7 @@ func setupOffLineageTaskWorktree(t *testing.T, dirty bool) (context.Context, *db
 	runWorktreeGit(t, checkout, "add", "current.txt")
 	runWorktreeGit(t, checkout, "commit", "-m", "advance base")
 	runWorktreeGit(t, checkout, "push", "origin", "main")
-	baseHead, err := (gitutil.Client{Dir: checkout}).RevParse(ctx, "origin/main")
+	baseHead, err := (gitutil.NewHostClient(checkout)).RevParse(ctx, "origin/main")
 	if err != nil {
 		t.Fatalf("RevParse origin/main: %v", err)
 	}
@@ -978,7 +978,7 @@ func setupOffLineageTaskWorktree(t *testing.T, dirty bool) (context.Context, *db
 		Owner:      "lead",
 		Checkout:   checkout,
 	}
-	return ctx, store, testEngine(store), gitutil.Client{Dir: checkout}, request, path, oldHead, baseHead
+	return ctx, store, testEngine(store), gitutil.NewHostClient(checkout), request, path, oldHead, baseHead
 }
 
 func runWorktreeGit(t *testing.T, dir string, args ...string) {


### PR DESCRIPTION
WHAT:
Implemented #1560: job-associated git, checkout, pipeline staging, task recovery, permission observation, and verifier subprocesses now consume the resolved execution backend. GITMoot-COC

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-ea7c0bd6

RESULTS:
- go build ./... passed.
- go vet ./... passed.
- go generate ./... completed without generated drift; git diff --check passed.
- go test ./internal/db/ ./internal/git/ ./internal/subprocess/ -count=1 -timeout 25m passed.
- Full internal/cli with only the three known #1526 tests skipped passed.
- Unfiltered internal/cli reproduced only TestResolveBlockedTTLShapeTolerantNoPhantom, TestApplyMergeGatePolicyEmptyHomeIsNoop, and TestDaemonWorkflowEngineNilHarvesterByDefault.
- P2 baseline regex matched exactly one test and passed. Fixed-string mutation anchors for AllowedNames and ParseImplemented each had census 1. The compile-valid go test -overlay registry mutation failed the guard as intended.

RISK:
Review the generated diff before merging.

TASK:
adhoc-ea7c0bd6

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented #1560: job-associated git, checkout, pipeline staging, task recovery, permission observation, and verifier subprocesses now consume the resolved execution backend. GITMoot-COC
````
