### PR TITLE
Gitmoot: IMPLEMENT gitmoot/gitmoot issue #1570 — result observation is

### DIFF
--- a/internal/cli/agent_dispatch.go
+++ b/internal/cli/agent_dispatch.go
@@ -414,7 +414,12 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 	if divergence := strings.TrimSpace(request.ReviewTaskHeadDivergence); divergence != "" {
 		requiredEvents = append(requiredEvents, db.JobEvent{Kind: "review_task_head_divergence", Message: divergence})
 	}
-	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(request.Home), OrgPolicy: orgPolicy}).Enqueue(ctx, workflow.JobRequest{
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("local agent enqueue"))
+	mailbox.CanaryEnabled = canaryRoutingEnabled(request.Home)
+	mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(request.Home)
+	mailbox.RequireWorkflowPolicy = requireWorkflowPolicyResolver(request.Home)
+	mailbox.OrgPolicy = orgPolicy
+	job, err := mailbox.Enqueue(ctx, workflow.JobRequest{
 		ID:                     jobID,
 		Agent:                  agent.Name,
 		Action:                 request.Action,
@@ -634,7 +639,9 @@ func dispatchLocalAgentJob(ctx context.Context, store *db.Store, request localAg
 			// Wire the home-aware registry defaults so a foreground ask with no
 			// agent/job model or effort pin honors the runtime's defaults too.
 			// Fail-open/empty by default; an agent/job pin wins.
-			mailbox := workflow.Mailbox{Store: store, RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RuntimeDefaultEffort: runtimeDefaultEffortResolver(request.Home)}
+			mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("foreground ask delivery"))
+			mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(request.Home)
+			mailbox.RuntimeDefaultEffort = runtimeDefaultEffortResolver(request.Home)
 			if _, err := mailbox.Run(runCtx, job.ID, effectiveAgent, adapter); err != nil {
 				recordRuntimeOutcome(err)
 				return localAgentJobOutput{}, foregroundAskTimeoutError(runCtx, jobTimeout, err)
@@ -783,7 +790,12 @@ func buildLocalAgentJobOutput(latest db.Job, request localAgentDispatchRequest) 
 }
 
 func enqueuePermissionBlockedLocalAgentJob(ctx context.Context, store *db.Store, request localAgentDispatchRequest, repo string, defaultBranch string, agentName string, overrideRuntime string, overrideRef string, orgPolicy func(string) workflow.OrgEnforcement) (localAgentJobOutput, error) {
-	job, err := (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(request.Home), RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(request.Home), OrgPolicy: orgPolicy}).Enqueue(ctx, workflow.JobRequest{
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("permission-blocked local agent enqueue"))
+	mailbox.CanaryEnabled = canaryRoutingEnabled(request.Home)
+	mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(request.Home)
+	mailbox.RequireWorkflowPolicy = requireWorkflowPolicyResolver(request.Home)
+	mailbox.OrgPolicy = orgPolicy
+	job, err := mailbox.Enqueue(ctx, workflow.JobRequest{
 		ID:             localAgentJobID(request.Action, agentName),
 		Agent:          agentName,
 		Action:         request.Action,

--- a/internal/cli/agent_dispatch_live_ab.go
+++ b/internal/cli/agent_dispatch_live_ab.go
@@ -137,7 +137,10 @@ func maybeRunLiveAB(ctx context.Context, store *db.Store, request localAgentDisp
 	//    Mailbox.Run path so the job/result are identical to a plain ask.
 	championAgent := runtimeAgent(agent)
 	championAgent.ExecBackend = string(backend)
-	championResult, runErr := (workflow.Mailbox{Store: store, RuntimeDefaultModel: runtimeDefaultModelResolver(request.Home), RuntimeDefaultEffort: runtimeDefaultEffortResolver(request.Home)}).Run(ctx, job.ID, championAgent, adapter)
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("live A/B ask delivery"))
+	mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(request.Home)
+	mailbox.RuntimeDefaultEffort = runtimeDefaultEffortResolver(request.Home)
+	championResult, runErr := mailbox.Run(ctx, job.ID, championAgent, adapter)
 	if runErr != nil {
 		// The primary ask itself failed — surface it exactly as the non-intercepted
 		// path would (the caller propagates the same error).

--- a/internal/cli/agent_dispatch_live_ab_test.go
+++ b/internal/cli/agent_dispatch_live_ab_test.go
@@ -105,7 +105,7 @@ func liveABFixture(t *testing.T, championPulls int) (string, *db.Store, localAge
 		Instructions: "Plan the migration.",
 		Home:         home,
 	}
-	job, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+	job, err := (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(ctx, workflow.JobRequest{
 		ID:           "ask-planner-bot",
 		Agent:        "planner-bot",
 		Action:       "ask",

--- a/internal/cli/canary_e2e_test.go
+++ b/internal/cli/canary_e2e_test.go
@@ -167,11 +167,9 @@ func TestCanaryLifecycleE2E(t *testing.T) {
 
 		// ROUTING LEG: sample=0.5. Draws below the sample resolve the CANARY snapshot;
 		// draws at/above resolve the CHAMPION. Proves routing genuinely splits traffic.
-		mb := workflow.Mailbox{
-			Store:         store,
-			CanaryEnabled: true,
-			CanaryRand:    scriptedDraws(t, 0.10, 0.20, 0.30, 0.80),
-		}
+		mb := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("canary routing enqueue test"))
+		mb.CanaryEnabled = true
+		mb.CanaryRand = scriptedDraws(t, 0.10, 0.20, 0.30, 0.80)
 		canaryJobs := routeAndAssertSplit(t, mb, agentName, "rollback", championCommit, canaryCommit, []routeCase{
 			{pr: 101, canary: true}, {pr: 102, canary: true}, {pr: 103, canary: true}, {pr: 104, canary: false},
 		})
@@ -234,11 +232,9 @@ func TestCanaryLifecycleE2E(t *testing.T) {
 		// Champion baseline: strong real-CI positives within the window.
 		seedAutoTraceFeedback(t, store, "planner", championID, "a", 3)
 
-		mb := workflow.Mailbox{
-			Store:         store,
-			CanaryEnabled: true,
-			CanaryRand:    scriptedDraws(t, 0.05, 0.15, 0.25, 0.95),
-		}
+		mb := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("canary routing enqueue test"))
+		mb.CanaryEnabled = true
+		mb.CanaryRand = scriptedDraws(t, 0.05, 0.15, 0.25, 0.95)
 		canaryJobs := routeAndAssertSplit(t, mb, agentName, "graduate", championCommit, canaryCommit, []routeCase{
 			{pr: 301, canary: true}, {pr: 302, canary: true}, {pr: 303, canary: true}, {pr: 304, canary: false},
 		})
@@ -342,11 +338,9 @@ func TestCanaryLifecycleE2E(t *testing.T) {
 		// [events] config), so the rollback is asserted on store-observable state
 		// rather than emitted events — the event assertions live in the hand-wired
 		// rollback subtest above.
-		mb := workflow.Mailbox{
-			Store:         store,
-			CanaryEnabled: canaryRoutingEnabled(home),
-			CanaryRand:    scriptedDraws(t, 0.10, 0.20, 0.30, 0.80),
-		}
+		mb := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("canary routing enqueue test"))
+		mb.CanaryEnabled = canaryRoutingEnabled(home)
+		mb.CanaryRand = scriptedDraws(t, 0.10, 0.20, 0.30, 0.80)
 		canaryJobs := routeAndAssertSplit(t, mb, agentName, "wired", championCommit, canaryCommit, []routeCase{
 			{pr: 701, canary: true}, {pr: 702, canary: true}, {pr: 703, canary: true}, {pr: 704, canary: false},
 		})
@@ -397,11 +391,9 @@ func TestCanaryLifecycleE2E(t *testing.T) {
 		store, championID, canaryID, _, canaryCommit, agentName := canaryE2EFixture(t)
 		seedAutoTraceFeedback(t, store, "planner", championID, "a", 3)
 
-		mb := workflow.Mailbox{
-			Store:         store,
-			CanaryEnabled: true,
-			CanaryRand:    scriptedDraws(t, 0.0, 0.0, 0.0, 0.0),
-		}
+		mb := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("canary routing enqueue test"))
+		mb.CanaryEnabled = true
+		mb.CanaryRand = scriptedDraws(t, 0.0, 0.0, 0.0, 0.0)
 		var canaryJobs []workflow.JobPayload
 		for i := 0; i < 4; i++ {
 			_, payload := enqueueImplement(t, mb, agentName, 500+i, fmt.Sprintf("race-job-%d", i))

--- a/internal/cli/daemon_advance_blocked_test.go
+++ b/internal/cli/daemon_advance_blocked_test.go
@@ -175,8 +175,8 @@ func TestBlockedAdvanceDoesNotAbortQueuedJobPass(t *testing.T) {
 		}
 		return &cliWorkerFakeAdapter{output: resultJSON(decision)}, nil
 	}
-	worker.WorkflowFactory = func(string) workflow.Engine {
-		return workflow.Engine{Store: store, ImplementationFinalizer: selectiveBlockedFinalizer{blockedJobID: "a-blocked"}}
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout), ImplementationFinalizer: selectiveBlockedFinalizer{blockedJobID: "a-blocked"}}
 	}
 
 	runErr := runQueuedJobsForRepo(ctx, worker, 1, "", "")

--- a/internal/cli/daemon_advance_blocked_test.go
+++ b/internal/cli/daemon_advance_blocked_test.go
@@ -176,7 +176,7 @@ func TestBlockedAdvanceDoesNotAbortQueuedJobPass(t *testing.T) {
 		return &cliWorkerFakeAdapter{output: resultJSON(decision)}, nil
 	}
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
-		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout), ImplementationFinalizer: selectiveBlockedFinalizer{blockedJobID: "a-blocked"}}
+		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(store, checkout), ImplementationFinalizer: selectiveBlockedFinalizer{blockedJobID: "a-blocked"}}
 	}
 
 	runErr := runQueuedJobsForRepo(ctx, worker, 1, "", "")

--- a/internal/cli/daemon_checkout.go
+++ b/internal/cli/daemon_checkout.go
@@ -44,13 +44,11 @@ func (w jobWorker) defaultCheckoutForRunner(ctx context.Context, job db.Job, pay
 	}
 	switch job.Type {
 	case "implement":
-		// A worktree-less delegation child (delegation leg, empty WorktreePath)
-		// can only resolve the registered shared checkout, which sits on `main`,
-		// never its inherited coordinator branch — so validating that checkout
-		// against payload.Branch would reject it with "checkout branch is main, not
-		// job branch <X>". Skip the branch-identity guard for that child only (the
-		// engine's delegation_worktree_skipped fallback runs it against the shared
-		// checkout and still holds its branch lock); mirror the #389 ask-arm escape.
+		// A delegation child with an empty WorktreePath either resolves a compatible
+		// task-table worktree (validated by taskWorktreeCheckout) or falls back to the
+		// registered shared checkout, which may sit on `main` rather than the inherited
+		// coordinator branch. Preserve the branch-identity escape for this payload
+		// shape; delivery observation separately distinguishes the effective source.
 		// validateImplementationLock stays UNCONDITIONAL — the branch lock, not this
 		// identity guard, is the designed mutation-safety mechanism (#413).
 		if !isWorktreeLessDelegationChild(payload) {
@@ -88,9 +86,9 @@ func (w jobWorker) defaultCheckoutForRunner(ctx context.Context, job db.Job, pay
 			// default-branch checkout ("checkout branch is main, not job branch "),
 			// wedging the heartbeat at the worker before the engine ever sees it.
 		case !isWorktreeLessDelegationChild(payload):
-			// Same worktree-less delegation child escape as the implement arm; a
-			// review is read-only ⇒ running it against the shared checkout is
-			// trivially safe (#413).
+			// Same empty-payload-worktree escape as the implement arm; a review is
+			// read-only, while taskWorktreeCheckout has already checked any task-table
+			// source against the payload's repo and branch (#413).
 			if err := w.validateTargetCheckoutForRunner(ctx, payload, checkout, runner); err != nil {
 				return "", err
 			}
@@ -333,32 +331,37 @@ func isDelegationWorktreeChild(payload workflow.JobPayload) bool {
 	return strings.TrimSpace(payload.DelegationID) != "" && strings.TrimSpace(payload.WorktreePath) != ""
 }
 
-// isWorktreeLessDelegationChild is the exact complement of
-// isDelegationWorktreeChild: a delegation child (it carries a delegation id — a
-// delegation *leg*, NOT just a ParentJobID, which continuations also carry with
-// an empty DelegationID and which route through the `ask` arm) that has no
-// allocated worktree path. With no worktree it can only resolve the repo's
-// registered shared checkout, which sits on `main` — never the inherited
-// coordinator branch (delegationRequest sets Branch: payload.Branch) — so
-// validating that checkout against payload.Branch would reject it with
-// "checkout branch is main, not job branch <X>". A wrong-branch *task* worktree
-// is already rejected upstream at taskWorktreeCheckout, so WorktreePath == ""
-// cleanly means "the shared registered checkout is the only resolution."
-// defaultCheckout's implement/review arms skip the validateTargetCheckout branch
-// guard for such a child (the branch lock, not this identity guard, is the
-// designed mutation-safety mechanism); see #389 (the ask-arm precedent) and #413.
+// isWorktreeLessDelegationChild reports the payload shape of a delegation child
+// with no per-delegation worktree. A TaskID may still resolve an effective
+// task-table worktree, so callers deciding whether the job truly used the shared
+// checkout must also consult taskWorktreeCheckout.
 func isWorktreeLessDelegationChild(payload workflow.JobPayload) bool {
 	return strings.TrimSpace(payload.DelegationID) != "" && strings.TrimSpace(payload.WorktreePath) == ""
 }
 
 // deliveryWorktreeResolver injects the checkout already resolved by the worker
-// into workflow's result-delivery seam. The one shape that deliberately does
-// not observe that shared checkout is selected by its own predicate, never by a
-// generic empty-path check, and receives a persisted typed marker.
-func deliveryWorktreeResolver(checkout string) workflow.DeliveryWorktreeResolver {
+// into workflow's result-delivery seam. A payload without a per-delegation path
+// may still have an effective task-table worktree, so exclusion is based on that
+// resolved source rather than payload.WorktreePath alone.
+func deliveryWorktreeResolver(store *db.Store, checkout string) workflow.DeliveryWorktreeResolver {
 	checkout = strings.TrimSpace(checkout)
-	return func(_ context.Context, _ db.Job, payload workflow.JobPayload) (workflow.DeliveryWorktreeResolution, error) {
+	return func(ctx context.Context, _ db.Job, payload workflow.JobPayload) (workflow.DeliveryWorktreeResolution, error) {
 		if isWorktreeLessDelegationChild(payload) {
+			if strings.TrimSpace(payload.TaskID) != "" {
+				if store == nil {
+					return workflow.DeliveryWorktreeResolution{}, errors.New("resolve delivery task worktree: store is nil")
+				}
+				taskCheckout, ok, err := (jobWorker{Store: store}).taskWorktreeCheckout(ctx, payload)
+				if err != nil {
+					return workflow.DeliveryWorktreeResolution{}, fmt.Errorf("resolve delivery task worktree: %w", err)
+				}
+				if ok {
+					if !sameCheckoutPath(taskCheckout, checkout) {
+						return workflow.DeliveryWorktreeResolution{}, fmt.Errorf("resolved delivery checkout %q differs from task worktree %q", checkout, taskCheckout)
+					}
+					return workflow.DeliveryWorktreeResolution{Path: checkout}, nil
+				}
+			}
 			return workflow.DeliveryWorktreeResolution{ExcludedSource: workflow.ResultObservationSourceWorktreeLessDelegationChild}, nil
 		}
 		if checkout == "" {

--- a/internal/cli/daemon_checkout.go
+++ b/internal/cli/daemon_checkout.go
@@ -351,6 +351,23 @@ func isWorktreeLessDelegationChild(payload workflow.JobPayload) bool {
 	return strings.TrimSpace(payload.DelegationID) != "" && strings.TrimSpace(payload.WorktreePath) == ""
 }
 
+// deliveryWorktreeResolver injects the checkout already resolved by the worker
+// into workflow's result-delivery seam. The one shape that deliberately does
+// not observe that shared checkout is selected by its own predicate, never by a
+// generic empty-path check, and receives a persisted typed marker.
+func deliveryWorktreeResolver(checkout string) workflow.DeliveryWorktreeResolver {
+	checkout = strings.TrimSpace(checkout)
+	return func(_ context.Context, _ db.Job, payload workflow.JobPayload) (workflow.DeliveryWorktreeResolution, error) {
+		if isWorktreeLessDelegationChild(payload) {
+			return workflow.DeliveryWorktreeResolution{ExcludedSource: workflow.ResultObservationSourceWorktreeLessDelegationChild}, nil
+		}
+		if checkout == "" {
+			return workflow.DeliveryWorktreeResolution{}, errors.New("resolved job checkout is empty")
+		}
+		return workflow.DeliveryWorktreeResolution{Path: checkout}, nil
+	}
+}
+
 func (w jobWorker) validateReviewCheckoutForRunner(ctx context.Context, payload workflow.JobPayload, checkout string, runner subprocess.Runner) error {
 	git := jobGitClient(checkout, runner)
 	clean, err := git.WorktreeClean(ctx)

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -441,9 +441,10 @@ func TestRunQueuedJobsPreservesAdvanceRetryForPostDeliveryPermissionError(t *tes
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
 		return adapter, nil
 	}
-	worker.WorkflowFactory = func(string) workflow.Engine {
+	worker.WorkflowFactory = func(resolvedCheckout string) workflow.Engine {
 		return workflow.Engine{
-			Store: store,
+			Store:                   store,
+			ResolveDeliveryWorktree: deliveryWorktreeResolver(resolvedCheckout),
 			PayloadRefresher: func(context.Context, db.Job, workflow.JobPayload) (workflow.JobPayload, error) {
 				return workflow.JobPayload{}, errors.New("permission denied while refreshing implemented head")
 			},
@@ -843,8 +844,8 @@ func TestRunQueuedJobsDefersJobsEnqueuedByCurrentSnapshot(t *testing.T) {
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
 		return adapter, nil
 	}
-	worker.WorkflowFactory = func(string) workflow.Engine {
-		return workflow.Engine{Store: store, RequiredReviewers: []string{"reviewer"}}
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout), RequiredReviewers: []string{"reviewer"}}
 	}
 
 	if err := runQueuedJobsForRepo(ctx, worker, 2, "", ""); err != nil {
@@ -1211,8 +1212,8 @@ func TestRunQueuedJobsDelegatesBusyRuntimeToTempWorker(t *testing.T) {
 	worker.AdapterFactory = func(runtime.Agent, string) (workflow.DeliveryAdapter, error) {
 		return deliveryAdapter, nil
 	}
-	worker.WorkflowFactory = func(string) workflow.Engine {
-		return workflow.Engine{Store: store}
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout)}
 	}
 
 	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
@@ -2021,8 +2022,8 @@ func TestRunQueuedJobsResumesSelfDirtyTaskWorktree(t *testing.T) {
 		adapterCheckout = checkout
 		return adapter, nil
 	}
-	worker.WorkflowFactory = func(string) workflow.Engine {
-		return workflow.Engine{Store: store}
+	worker.WorkflowFactory = func(checkout string) workflow.Engine {
+		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout)}
 	}
 
 	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
@@ -2131,7 +2132,8 @@ func TestRunQueuedJobsResumesDelegatedImplementWithOriginalBranchLock(t *testing
 	}
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
 		return workflow.Engine{
-			Store: store,
+			Store:                   store,
+			ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout),
 			PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 				return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 			},

--- a/internal/cli/daemon_scheduler_test.go
+++ b/internal/cli/daemon_scheduler_test.go
@@ -444,7 +444,7 @@ func TestRunQueuedJobsPreservesAdvanceRetryForPostDeliveryPermissionError(t *tes
 	worker.WorkflowFactory = func(resolvedCheckout string) workflow.Engine {
 		return workflow.Engine{
 			Store:                   store,
-			ResolveDeliveryWorktree: deliveryWorktreeResolver(resolvedCheckout),
+			ResolveDeliveryWorktree: deliveryWorktreeResolver(store, resolvedCheckout),
 			PayloadRefresher: func(context.Context, db.Job, workflow.JobPayload) (workflow.JobPayload, error) {
 				return workflow.JobPayload{}, errors.New("permission denied while refreshing implemented head")
 			},
@@ -845,7 +845,7 @@ func TestRunQueuedJobsDefersJobsEnqueuedByCurrentSnapshot(t *testing.T) {
 		return adapter, nil
 	}
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
-		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout), RequiredReviewers: []string{"reviewer"}}
+		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(store, checkout), RequiredReviewers: []string{"reviewer"}}
 	}
 
 	if err := runQueuedJobsForRepo(ctx, worker, 2, "", ""); err != nil {
@@ -1213,7 +1213,7 @@ func TestRunQueuedJobsDelegatesBusyRuntimeToTempWorker(t *testing.T) {
 		return deliveryAdapter, nil
 	}
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
-		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout)}
+		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(store, checkout)}
 	}
 
 	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
@@ -2023,7 +2023,7 @@ func TestRunQueuedJobsResumesSelfDirtyTaskWorktree(t *testing.T) {
 		return adapter, nil
 	}
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
-		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout)}
+		return workflow.Engine{Store: store, ResolveDeliveryWorktree: deliveryWorktreeResolver(store, checkout)}
 	}
 
 	if err := runQueuedJobsForRepo(ctx, worker, 1, "", ""); err != nil {
@@ -2133,7 +2133,7 @@ func TestRunQueuedJobsResumesDelegatedImplementWithOriginalBranchLock(t *testing
 	worker.WorkflowFactory = func(checkout string) workflow.Engine {
 		return workflow.Engine{
 			Store:                   store,
-			ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout),
+			ResolveDeliveryWorktree: deliveryWorktreeResolver(store, checkout),
 			PayloadRefresher: func(ctx context.Context, job db.Job, payload workflow.JobPayload) (workflow.JobPayload, error) {
 				return refreshDaemonJobPayload(ctx, store, checkout, job, payload)
 			},

--- a/internal/cli/daemon_supervision.go
+++ b/internal/cli/daemon_supervision.go
@@ -362,7 +362,11 @@ type heartbeatEnqueuer func(ctx context.Context, request workflow.JobRequest) (d
 // construction so a heartbeat job is indistinguishable from a normal background
 // job once enqueued.
 func newHeartbeatEnqueuer(store *db.Store, home string) heartbeatEnqueuer {
-	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home), OrgPolicy: orgPolicyResolver(home)}
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("heartbeat enqueue"))
+	mailbox.CanaryEnabled = canaryRoutingEnabled(home)
+	mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(home)
+	mailbox.RequireWorkflowPolicy = requireWorkflowPolicyResolver(home)
+	mailbox.OrgPolicy = orgPolicyResolver(home)
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
 		return mailbox.Enqueue(ctx, request)
 	}

--- a/internal/cli/daemon_test.go
+++ b/internal/cli/daemon_test.go
@@ -140,7 +140,7 @@ func runMidFlightEnqueueScenario(t *testing.T, usePool bool) string {
 	adapter := &cliWorkerFakeAdapter{output: poolSchedulerAskResult}
 	adapter.onDeliver = func() {
 		once.Do(func() {
-			_, enqErr = (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
+			_, enqErr = (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(ctx, workflow.JobRequest{ID: "job-b", Agent: "audit", Action: "ask", Repo: "owner/repo-b", Branch: "main", PullRequest: 2})
 		})
 	}
 	worker := poolSchedulerWorker(t, store, adapter, usePool)
@@ -624,7 +624,7 @@ func seedDaemonWorkerAgentWithPolicy(t *testing.T, store *db.Store, name string,
 
 func enqueueDaemonWorkerJob(t *testing.T, store *db.Store, request workflow.JobRequest) {
 	t.Helper()
-	if _, err := (workflow.Mailbox{Store: store}).Enqueue(context.Background(), request); err != nil {
+	if _, err := (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(context.Background(), request); err != nil {
 		t.Fatalf("Enqueue returned error: %v", err)
 	}
 }

--- a/internal/cli/daemon_worker.go
+++ b/internal/cli/daemon_worker.go
@@ -2116,7 +2116,12 @@ func (w jobWorker) queueTempWorkerMergeBack(ctx context.Context, completedJobID 
 			"Do not edit files, create commits, open pull requests, or dispatch more agents unless the summary explicitly requires follow-up.",
 		},
 	}
-	if _, err := (workflow.Mailbox{Store: w.Store, CanaryEnabled: canaryRoutingEnabled(w.workflowHome()), RuntimeDefaultModel: runtimeDefaultModelResolver(w.workflowHome()), RequireWorkflowPolicy: requireWorkflowPolicyResolver(w.workflowHome()), OrgPolicy: orgPolicyResolver(w.workflowHome())}).Enqueue(ctx, request); err != nil {
+	mailbox := workflow.NewMailbox(w.Store, workflow.UnavailableDeliveryWorktreeResolver("temporary worker merge-back enqueue"))
+	mailbox.CanaryEnabled = canaryRoutingEnabled(w.workflowHome())
+	mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(w.workflowHome())
+	mailbox.RequireWorkflowPolicy = requireWorkflowPolicyResolver(w.workflowHome())
+	mailbox.OrgPolicy = orgPolicyResolver(w.workflowHome())
+	if _, err := mailbox.Enqueue(ctx, request); err != nil {
 		return err
 	}
 	return w.Store.AddJobEvent(ctx, db.JobEvent{JobID: completedJob.ID, Kind: "temp_worker_merge_back_queued", Message: fmt.Sprintf("queued summary merge-back job %s for %s", mergeBackID, original.Name)})

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -44,6 +44,7 @@ func daemonWorkflowEngineForRunner(store *db.Store, gh github.Client, checkout s
 	gh = jobGitHubClient(checkout, gh, runner)
 	engine := workflow.Engine{
 		Store:                   store,
+		ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout),
 		RequireWorkflowPolicy:   requireWorkflowPolicyResolverRoot(home),
 		OrgPolicy:               orgPolicyResolverRoot(home),
 		ProduceCheckDir:         checkout,

--- a/internal/cli/daemon_workflow.go
+++ b/internal/cli/daemon_workflow.go
@@ -44,7 +44,7 @@ func daemonWorkflowEngineForRunner(store *db.Store, gh github.Client, checkout s
 	gh = jobGitHubClient(checkout, gh, runner)
 	engine := workflow.Engine{
 		Store:                   store,
-		ResolveDeliveryWorktree: deliveryWorktreeResolver(checkout),
+		ResolveDeliveryWorktree: deliveryWorktreeResolver(store, checkout),
 		RequireWorkflowPolicy:   requireWorkflowPolicyResolverRoot(home),
 		OrgPolicy:               orgPolicyResolverRoot(home),
 		ProduceCheckDir:         checkout,

--- a/internal/cli/delivery_worktree_observation_test.go
+++ b/internal/cli/delivery_worktree_observation_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gitmoot/gitmoot/internal/db"
 	"github.com/gitmoot/gitmoot/internal/execbackend"
 	"github.com/gitmoot/gitmoot/internal/runtime"
 	"github.com/gitmoot/gitmoot/internal/workflow"
@@ -21,7 +22,7 @@ func TestDeliveryWorktreeObservationHydratesOrdinaryImplementCheckout(t *testing
 	store := openCLIJobStore(t, t.TempDir())
 	defer store.Close()
 
-	mailbox := workflow.NewMailbox(store, deliveryWorktreeResolver(checkout))
+	mailbox := workflow.NewMailbox(store, deliveryWorktreeResolver(store, checkout))
 	var importedInto string
 	mailbox.CollectChangeSet = func(context.Context, execbackend.Backend, string) (*execbackend.ChangeSet, error) {
 		return &execbackend.ChangeSet{}, nil
@@ -74,11 +75,14 @@ func TestDeliveryWorktreeObservationMarksWorktreeLessDelegationChild(t *testing.
 	checkout := deliveryObservationRepo(t)
 	store := openCLIJobStore(t, t.TempDir())
 	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{ID: "shared-checkout-task", RepoFullName: "gitmoot/gitmoot"}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
 
-	mailbox := workflow.NewMailbox(store, deliveryWorktreeResolver(checkout))
+	mailbox := workflow.NewMailbox(store, deliveryWorktreeResolver(store, checkout))
 	if _, err := mailbox.Enqueue(ctx, workflow.JobRequest{
 		ID: "worktree-less-child-observation", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot",
-		ParentJobID: "parent", DelegationID: "child",
+		TaskID: "shared-checkout-task", ParentJobID: "parent", DelegationID: "child",
 	}); err != nil {
 		t.Fatalf("Enqueue: %v", err)
 	}
@@ -104,6 +108,58 @@ func TestDeliveryWorktreeObservationMarksWorktreeLessDelegationChild(t *testing.
 	}
 	if observation.Divergent || observation.Error != "" {
 		t.Fatalf("excluded observation = %+v, want a typed non-error marker", observation)
+	}
+}
+
+func TestDeliveryWorktreeObservationUsesTaskWorktreeForDelegationChild(t *testing.T) {
+	ctx := context.Background()
+	checkout := deliveryObservationRepo(t)
+	if err := os.WriteFile(filepath.Join(checkout, "task.go"), []byte("package task\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+	if err := store.UpsertTask(ctx, db.Task{
+		ID: "task-worktree", RepoFullName: "gitmoot/gitmoot", WorktreePath: checkout,
+	}); err != nil {
+		t.Fatalf("UpsertTask: %v", err)
+	}
+
+	mailbox := workflow.NewMailbox(store, deliveryWorktreeResolver(store, checkout))
+	if _, err := mailbox.Enqueue(ctx, workflow.JobRequest{
+		ID: "task-worktree-child-observation", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot",
+		TaskID: "task-worktree", ParentJobID: "parent", DelegationID: "child",
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	adapter := &cliWorkerFakeAdapter{output: deliveryObservationResult("updated task.go")}
+	if _, err := mailbox.Run(ctx, "task-worktree-child-observation", runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime}, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "task-worktree-child-observation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.WorktreePath != "" {
+		t.Fatalf("persisted WorktreePath = %q, want empty task-backed delegation payload", payload.WorktreePath)
+	}
+	observation := payload.ResultObservation
+	if observation == nil {
+		t.Fatal("task-worktree delegation child persisted a nil observation")
+	}
+	if observation.Source != workflow.ResultObservationSourceWorktreeDiff {
+		t.Fatalf("observation source = %q, want %q", observation.Source, workflow.ResultObservationSourceWorktreeDiff)
+	}
+	if got, want := fmt.Sprint(observation.TouchedFiles), "[task.go]"; got != want {
+		t.Fatalf("touched files = %s, want %s", got, want)
+	}
+	if observation.Divergent || observation.Error != "" {
+		t.Fatalf("task-worktree observation = %+v, want clean matching observation", observation)
 	}
 }
 

--- a/internal/cli/delivery_worktree_observation_test.go
+++ b/internal/cli/delivery_worktree_observation_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gitmoot/gitmoot/internal/execbackend"
+	"github.com/gitmoot/gitmoot/internal/runtime"
+	"github.com/gitmoot/gitmoot/internal/workflow"
+)
+
+func TestDeliveryWorktreeObservationHydratesOrdinaryImplementCheckout(t *testing.T) {
+	ctx := context.Background()
+	checkout := deliveryObservationRepo(t)
+	if err := os.WriteFile(filepath.Join(checkout, "ordinary.go"), []byte("package ordinary\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+
+	mailbox := workflow.NewMailbox(store, deliveryWorktreeResolver(checkout))
+	var importedInto string
+	mailbox.CollectChangeSet = func(context.Context, execbackend.Backend, string) (*execbackend.ChangeSet, error) {
+		return &execbackend.ChangeSet{}, nil
+	}
+	mailbox.ApplyChangeSet = func(_ context.Context, worktree string, _ execbackend.ChangeSet) error {
+		importedInto = worktree
+		return nil
+	}
+	if _, err := mailbox.Enqueue(ctx, workflow.JobRequest{
+		ID: "ordinary-observation", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot",
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	adapter := &cliWorkerFakeAdapter{output: deliveryObservationResult("updated ordinary.go")}
+	if _, err := mailbox.Run(ctx, "ordinary-observation", runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime}, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "ordinary-observation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if payload.WorktreePath != "" {
+		t.Fatalf("persisted WorktreePath = %q, want unchanged empty payload field", payload.WorktreePath)
+	}
+	if importedInto != checkout {
+		t.Fatalf("change set imported into %q, want resolved checkout %q", importedInto, checkout)
+	}
+	observation := payload.ResultObservation
+	if observation == nil {
+		t.Fatal("persisted result_observation is nil; ordinary implement observation did not run")
+	}
+	if observation.Source != workflow.ResultObservationSourceWorktreeDiff {
+		t.Fatalf("observation source = %q, want %q", observation.Source, workflow.ResultObservationSourceWorktreeDiff)
+	}
+	if got, want := fmt.Sprint(observation.TouchedFiles), "[ordinary.go]"; got != want {
+		t.Fatalf("touched files = %s, want %s", got, want)
+	}
+	if observation.Divergent || observation.Error != "" {
+		t.Fatalf("ordinary observation = %+v, want clean matching observation", observation)
+	}
+}
+
+func TestDeliveryWorktreeObservationMarksWorktreeLessDelegationChild(t *testing.T) {
+	ctx := context.Background()
+	checkout := deliveryObservationRepo(t)
+	store := openCLIJobStore(t, t.TempDir())
+	defer store.Close()
+
+	mailbox := workflow.NewMailbox(store, deliveryWorktreeResolver(checkout))
+	if _, err := mailbox.Enqueue(ctx, workflow.JobRequest{
+		ID: "worktree-less-child-observation", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot",
+		ParentJobID: "parent", DelegationID: "child",
+	}); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	adapter := &cliWorkerFakeAdapter{output: deliveryObservationResult("updated imaginary.go")}
+	if _, err := mailbox.Run(ctx, "worktree-less-child-observation", runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime}, adapter); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	job, err := store.GetJob(ctx, "worktree-less-child-observation")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := daemonJobPayload(job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := payload.ResultObservation
+	if observation == nil {
+		t.Fatal("excluded worktree-less delegation child persisted a nil observation")
+	}
+	if observation.Source != workflow.ResultObservationSourceWorktreeLessDelegationChild {
+		t.Fatalf("observation source = %q, want %q", observation.Source, workflow.ResultObservationSourceWorktreeLessDelegationChild)
+	}
+	if observation.Divergent || observation.Error != "" {
+		t.Fatalf("excluded observation = %+v, want a typed non-error marker", observation)
+	}
+}
+
+func deliveryObservationRepo(t *testing.T) string {
+	t.Helper()
+	checkout := t.TempDir()
+	runGit(t, checkout, "init")
+	runGit(t, checkout, "config", "user.email", "tests@gitmoot.local")
+	runGit(t, checkout, "config", "user.name", "Gitmoot Tests")
+	if err := os.WriteFile(filepath.Join(checkout, "ordinary.go"), []byte("package original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, checkout, "add", "ordinary.go")
+	runGit(t, checkout, "commit", "-m", "base")
+	return checkout
+}
+
+func deliveryObservationResult(change string) string {
+	return fmt.Sprintf(`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[%q],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`, change)
+}

--- a/internal/cli/memory_test.go
+++ b/internal/cli/memory_test.go
@@ -609,7 +609,7 @@ func TestMemoryReplayReportsInjectionDelta(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 	// Create a real job in the store whose instructions match.
-	if _, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+	if _, err := (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(ctx, workflow.JobRequest{
 		ID: "job-1", Agent: "builder", Action: "implement", Repo: "acme/widget",
 		Instructions: "investigate the flaky arm64 runner",
 	}); err != nil {

--- a/internal/cli/org_test.go
+++ b/internal/cli/org_test.go
@@ -656,7 +656,9 @@ func TestOrgPreflightEnqueueParity(t *testing.T) {
 			}
 			store := openCLIJobStore(t, t.TempDir())
 			defer store.Close()
-			job, err := (workflow.Mailbox{Store: store, OrgPolicy: fixedOrgPolicy(policy)}).Enqueue(context.Background(), workflow.JobRequest{ID: "parity", Agent: "agent", Action: "ask", Repo: tt.repo, OperatorOrigin: true, ActingOrgRole: tt.role})
+			mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("org enqueue test"))
+			mailbox.OrgPolicy = fixedOrgPolicy(policy)
+			job, err := mailbox.Enqueue(context.Background(), workflow.JobRequest{ID: "parity", Agent: "agent", Action: "ask", Repo: tt.repo, OperatorOrigin: true, ActingOrgRole: tt.role})
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("enqueue err=%v, shared err=%v", err, decisionErr)
 			}

--- a/internal/cli/pipeline_engine_test_compat_test.go
+++ b/internal/cli/pipeline_engine_test_compat_test.go
@@ -52,7 +52,7 @@ func newTestPipeline(t *testing.T, store *db.Store, name, specYAML string) (db.P
 }
 
 func testStageEnqueuer(store *db.Store) pipeline.PipelineStageEnqueuer {
-	mailbox := workflow.Mailbox{Store: store}
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
 		return mailbox.Enqueue(ctx, request)
 	}

--- a/internal/cli/pipeline_enqueue.go
+++ b/internal/cli/pipeline_enqueue.go
@@ -34,7 +34,11 @@ func pipelineStageCheckoutPath(ctx context.Context, store *db.Store, repo string
 // indistinguishable from a normal background job once enqueued (the runner agent
 // carries no template, so canary never actually samples).
 func newPipelineStageEnqueuer(store *db.Store, home string) pipelineStageEnqueuer {
-	mailbox := workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home), OrgPolicy: orgPolicyResolver(home)}
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("pipeline stage enqueue"))
+	mailbox.CanaryEnabled = canaryRoutingEnabled(home)
+	mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(home)
+	mailbox.RequireWorkflowPolicy = requireWorkflowPolicyResolver(home)
+	mailbox.OrgPolicy = orgPolicyResolver(home)
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
 		backend, err := localAgentDispatchExecBackendFor(home)
 		if err != nil {

--- a/internal/cli/plan_mode_dispatch_e2e_test.go
+++ b/internal/cli/plan_mode_dispatch_e2e_test.go
@@ -89,7 +89,7 @@ func TestPlanModeDaemonDispatchE2E(t *testing.T) {
 		seedDaemonWorkerAgentWithPolicy(t, store, "planner", runtime.OmpRuntime, "fresh:plan-e2e", []string{"ask"}, "owner/repo", runtime.AutonomyPolicyWorkspaceWrite)
 
 		const jobID = "plan-shell-override"
-		_, err = (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+		_, err = (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(ctx, workflow.JobRequest{
 			ID:                 jobID,
 			Agent:              "planner",
 			Action:             "ask",

--- a/internal/cli/reliability_batch_e2e_test.go
+++ b/internal/cli/reliability_batch_e2e_test.go
@@ -359,7 +359,7 @@ func TestDefaultCheckoutDeclinesResyncWhenNoLocalPRRecordE2E(t *testing.T) {
 	runDaemonWorkerGit(t, checkout, "commit", "-m", "advance the branch")
 
 	// Deliberately DO NOT UpsertPullRequest: the store has no evidence the PR is live.
-	if _, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+	if _, err := (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(ctx, workflow.JobRequest{
 		ID:          "review-no-pr-1",
 		Agent:       "reviewer",
 		Action:      "review",

--- a/internal/cli/review_head_resync_test.go
+++ b/internal/cli/review_head_resync_test.go
@@ -75,7 +75,7 @@ func TestDefaultCheckoutResyncsReviewHeadWhenPRIsOpen(t *testing.T) {
 	}
 
 	// A queued review job pinned to the now-stale head.
-	if _, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+	if _, err := (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(ctx, workflow.JobRequest{
 		ID:          "workflow-review-1",
 		Agent:       "reviewer",
 		Action:      "review",
@@ -154,7 +154,7 @@ func TestDefaultCheckoutFailsReviewHeadMismatchWhenPRClosed(t *testing.T) {
 		t.Fatalf("UpsertPullRequest returned error: %v", err)
 	}
 
-	if _, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+	if _, err := (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(ctx, workflow.JobRequest{
 		ID:          "workflow-review-2",
 		Agent:       "reviewer",
 		Action:      "review",
@@ -245,7 +245,7 @@ func TestDefaultCheckoutDeclinesResyncWhenCheckoutOnWrongBranch(t *testing.T) {
 
 	// The queued review is pinned to the feat/x branch + its stale head, but its task
 	// worktree is gone so it resolves the shared checkout (which is on main).
-	if _, err := (workflow.Mailbox{Store: store}).Enqueue(ctx, workflow.JobRequest{
+	if _, err := (workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))).Enqueue(ctx, workflow.JobRequest{
 		ID:          "workflow-review-3",
 		Agent:       "reviewer",
 		Action:      "review",

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -1377,7 +1377,12 @@ func enqueueTaskRunImplementJob(ctx context.Context, store *db.Store, task db.Ta
 	} else if !errors.Is(err, sql.ErrNoRows) {
 		return db.Job{}, err
 	}
-	return (workflow.Mailbox{Store: store, CanaryEnabled: canaryRoutingEnabled(home), RuntimeDefaultModel: runtimeDefaultModelResolver(home), RequireWorkflowPolicy: requireWorkflowPolicyResolver(home), OrgPolicy: fixedOrgPolicy(orgPolicy)}).Enqueue(ctx, request)
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("task run enqueue"))
+	mailbox.CanaryEnabled = canaryRoutingEnabled(home)
+	mailbox.RuntimeDefaultModel = runtimeDefaultModelResolver(home)
+	mailbox.RequireWorkflowPolicy = requireWorkflowPolicyResolver(home)
+	mailbox.OrgPolicy = fixedOrgPolicy(orgPolicy)
+	return mailbox.Enqueue(ctx, request)
 }
 
 func findActiveTaskRunJob(ctx context.Context, store *db.Store, request workflow.JobRequest) (db.Job, bool, error) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2206,7 +2206,12 @@ func (d Daemon) enqueueJob(ctx context.Context, request workflow.JobRequest) (db
 		requireWorkflowPolicy = d.Workflow.RequireWorkflowPolicy
 		orgPolicy = d.Workflow.OrgPolicy
 	}
-	job, err := (workflow.Mailbox{Store: d.Store, CanaryEnabled: canaryEnabled, RuntimeDefaultModel: runtimeDefaultModel, RequireWorkflowPolicy: requireWorkflowPolicy, OrgPolicy: orgPolicy}).Enqueue(ctx, request)
+	mailbox := workflow.NewMailbox(d.Store, workflow.UnavailableDeliveryWorktreeResolver("daemon comment enqueue"))
+	mailbox.CanaryEnabled = canaryEnabled
+	mailbox.RuntimeDefaultModel = runtimeDefaultModel
+	mailbox.RequireWorkflowPolicy = requireWorkflowPolicy
+	mailbox.OrgPolicy = orgPolicy
+	job, err := mailbox.Enqueue(ctx, request)
 	return job, true, err
 }
 

--- a/internal/pipeline/pipeline_advance_test.go
+++ b/internal/pipeline/pipeline_advance_test.go
@@ -53,7 +53,7 @@ func newTestPipeline(t *testing.T, store *db.Store, name, specYAML string) (db.P
 // agent (Mailbox tolerates a missing agent) — the unit tests exercise the
 // advancer's decision logic, not the worker.
 func testStageEnqueuer(store *db.Store) PipelineStageEnqueuer {
-	mailbox := workflow.Mailbox{Store: store}
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))
 	return func(ctx context.Context, request workflow.JobRequest) (db.Job, error) {
 		return mailbox.Enqueue(ctx, request)
 	}

--- a/internal/pipeline/pipeline_orchestrate_wait_758_test.go
+++ b/internal/pipeline/pipeline_orchestrate_wait_758_test.go
@@ -43,7 +43,7 @@ stages:
 // see exactly what the engine would have persisted.
 func seedContinuationJob(t *testing.T, store *db.Store, id, parentID, rootID string) {
 	t.Helper()
-	mailbox := workflow.Mailbox{Store: store}
+	mailbox := workflow.NewMailbox(store, workflow.UnavailableDeliveryWorktreeResolver("test enqueue-only mailbox"))
 	if _, err := mailbox.Enqueue(context.Background(), workflow.JobRequest{
 		ID:          id,
 		Agent:       "planner",

--- a/internal/workflow/draft_pr_intent_test.go
+++ b/internal/workflow/draft_pr_intent_test.go
@@ -8,7 +8,7 @@ import (
 func TestEnqueuePersistsPullRequestReadyOptOut(t *testing.T) {
 	store := openEngineStore(t)
 	seedAgent(t, store, "builder", []string{"implement"}, "owner/repo")
-	job, err := (Mailbox{Store: store}).Enqueue(context.Background(), JobRequest{
+	job, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(context.Background(), JobRequest{
 		ID: "implement-ready", Agent: "builder", Action: "implement", Repo: "owner/repo",
 		Branch: "task-ready", TaskID: "task-ready", Instructions: "implement",
 		PullRequestReady: true,

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -16,6 +16,10 @@ import (
 
 type Engine struct {
 	Store *db.Store
+	// ResolveDeliveryWorktree is the injected CLI-owned checkout-resolution seam
+	// used after an implement delivery. The workflow package must not import cli;
+	// daemonWorkflowEngine wires the effective checkout selected by the worker.
+	ResolveDeliveryWorktree DeliveryWorktreeResolver
 	// RequireWorkflowPolicy is passed to every mailbox the engine creates so
 	// continuations and delegation enqueue share the same home-aware policy.
 	RequireWorkflowPolicy func(repo string) RequireWorkflowPolicy

--- a/internal/workflow/engine_fanout_intent_1277_test.go
+++ b/internal/workflow/engine_fanout_intent_1277_test.go
@@ -148,7 +148,7 @@ func TestIntentSurvivesContinuationThenImplementChild(t *testing.T) {
 	store := openEngineStore(t)
 	seedAgent(t, store, "coordinator", []string{"ask", "review"}, "gitmoot/gitmoot")
 	seedAgent(t, store, "impl", []string{"implement"}, "gitmoot/gitmoot")
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	root, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:                     "root-coordinator",
@@ -215,7 +215,7 @@ func TestEnqueueWithoutParentDoesNotInventIntent(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "impl", []string{"implement"}, "gitmoot/gitmoot")
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	job, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:           "plain-root",

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1082,7 +1082,7 @@ func TestEngineRunJobAdvancesCompletedResult(t *testing.T) {
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:          "implement-job",
 		Agent:       "lead",
 		Action:      "implement",
@@ -1125,7 +1125,7 @@ func TestEngineRunJobWrapsPostSuccessAdvanceError(t *testing.T) {
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"implemented","summary":"opened PR","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:          "implement-job",
 		Agent:       "lead",
 		Action:      "implement",
@@ -1172,7 +1172,7 @@ func TestEngineRunJobDeliveryFailureStaysRaw(t *testing.T) {
 	agent := runtime.Agent{Name: "lead", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "lead"}
 	// A delivery error before the result is stored.
 	adapter := &fakeDelivery{err: errors.New("runtime exploded")}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:        "implement-job",
 		Agent:     "lead",
 		Action:    "implement",
@@ -1301,7 +1301,7 @@ func TestEngineRunJobPreflightsPolicyBeforeDelivery(t *testing.T) {
 			delivered = true
 		},
 	}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:          "implement-job",
 		Agent:       "lead",
 		Action:      "implement",
@@ -2338,7 +2338,8 @@ func openEngineStore(t *testing.T) *db.Store {
 
 func testEngine(store *db.Store) Engine {
 	return Engine{
-		Store: store,
+		Store:                   store,
+		ResolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test engine explicit no worktree"),
 		JobID: func(request JobRequest) string {
 			parts := []string{request.Action, request.Agent, request.TaskID}
 			if request.ReviewRound != "" {

--- a/internal/workflow/engine_types.go
+++ b/internal/workflow/engine_types.go
@@ -123,7 +123,16 @@ func (e Engine) now() time.Time {
 // path is byte-identical. The hook maps the terminal JobState to the event_type,
 // resolves root_id from the payload, and ships a redacted event fire-and-forget.
 func (e Engine) mailbox() Mailbox {
-	mb := Mailbox{Store: e.Store, RequireWorkflowPolicy: e.RequireWorkflowPolicy, OrgPolicy: e.OrgPolicy, CanaryEnabled: e.CanaryEnabled, deferBlocker: e.BlockerDeferrer, RuntimeDefaultModel: e.RuntimeDefaultModel, RuntimeDefaultEffort: e.RuntimeDefaultEffort, routerContextEnabled: e.RouterContextEnabled, resultCheckMode: normalizeResultCheckMode(e.ResultCheckMode), produceCheckDir: e.ProduceCheckDir}
+	mb := NewMailbox(e.Store, e.ResolveDeliveryWorktree)
+	mb.RequireWorkflowPolicy = e.RequireWorkflowPolicy
+	mb.OrgPolicy = e.OrgPolicy
+	mb.CanaryEnabled = e.CanaryEnabled
+	mb.deferBlocker = e.BlockerDeferrer
+	mb.RuntimeDefaultModel = e.RuntimeDefaultModel
+	mb.RuntimeDefaultEffort = e.RuntimeDefaultEffort
+	mb.routerContextEnabled = e.RouterContextEnabled
+	mb.resultCheckMode = normalizeResultCheckMode(e.ResultCheckMode)
+	mb.produceCheckDir = e.ProduceCheckDir
 	// Wire the off-by-default memory hooks (#626). When e.Memory is nil (every
 	// non-enrolled path) both hooks stay nil, so Run's prompt assembly and terminal
 	// path are byte-identical. The hooks themselves also no-op when the executor

--- a/internal/workflow/event_sink_test.go
+++ b/internal/workflow/event_sink_test.go
@@ -62,7 +62,7 @@ func TestEngineEmitsJobFinishedOnSucceededTerminal(t *testing.T) {
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:        "review-job",
 		Agent:     "audit",
 		Action:    "review",
@@ -107,7 +107,7 @@ func TestEngineEmitsJobFailedOnFailedDecision(t *testing.T) {
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"failed","summary":"could not finish","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:        "review-job",
 		Agent:     "audit",
 		Action:    "review",
@@ -156,7 +156,7 @@ func TestEngineEmitsJobFailedOnDeliveryFailure(t *testing.T) {
 	// A delivery error: Deliver returns an error, so Mailbox.Run takes the m.fail
 	// branch and never reaches finishWithPayload.
 	adapter := &fakeDelivery{err: errors.New("codex transport failure")}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:        "review-job",
 		Agent:     "audit",
 		Action:    "review",
@@ -211,7 +211,7 @@ func TestEngineEmitsJobFailedOnMalformedOutputAfterRepair(t *testing.T) {
 	// Two un-parseable outputs: the first triggers the repair retry, the second
 	// (also malformed) drives m.fail -> finish with a parse error.
 	adapter := &fakeDelivery{outputs: []string{"not json", "still not json"}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:        "review-job",
 		Agent:     "audit",
 		Action:    "review",
@@ -308,7 +308,7 @@ func TestEngineNilSinkIsByteIdentical(t *testing.T) {
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:     "review-job",
 		Agent:  "audit",
 		Action: "review",
@@ -346,7 +346,7 @@ func TestEngineSlowSinkDoesNotDeadlockEngine(t *testing.T) {
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:     "review-job",
 		Agent:  "audit",
 		Action: "review",

--- a/internal/workflow/failure_diagnostics_test.go
+++ b/internal/workflow/failure_diagnostics_test.go
@@ -19,7 +19,7 @@ func shellCrashAgent(script string) runtime.Agent {
 func TestMailboxRunCapturesCrashDiagnosticsOnNonZeroExit(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := shellCrashAgent(`echo "api_key=super-secret-crash-value" >&2; echo "runtime exploded" >&2; exit 7`)
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-crash", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
@@ -75,7 +75,7 @@ func TestMailboxRunCapturesCrashDiagnosticsOnNonZeroExit(t *testing.T) {
 func TestMailboxRunCrashDiagnosticsStreamingPhase(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := shellCrashAgent(`echo "partial stdout"; echo "died mid-stream" >&2; exit 3`)
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-stream", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
@@ -111,7 +111,7 @@ func TestMailboxRunCrashDiagnosticsStreamingPhase(t *testing.T) {
 func TestMailboxRunRecordsResultParseDiagnostics(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := shellCrashAgent(`echo "no envelope from me"; echo "warned on stderr" >&2`)
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-parse", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
@@ -150,7 +150,7 @@ func TestMailboxRunRecordsResultParseDiagnostics(t *testing.T) {
 func TestMailboxRunSuccessStoresNoFailureDiagnostics(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := shellCrashAgent(`echo '{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`)
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-ok", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {
@@ -182,7 +182,7 @@ func TestMailboxRunSuccessStoresNoFailureDiagnostics(t *testing.T) {
 func TestMailboxRunClearsStaleFailureDiagnosticsOnRetry(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := shellCrashAgent(`echo '{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}'`)
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-retry", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot"}); err != nil {

--- a/internal/workflow/gates_resume_test.go
+++ b/internal/workflow/gates_resume_test.go
@@ -14,7 +14,7 @@ import (
 func TestMailboxRunRecordsGatesFromNeeds(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"blocked","summary":"needs credentials","findings":[],"changes_made":[],"tests_run":[],"needs":["API key","R2 token"],"delegations":[]}}`,
@@ -47,7 +47,7 @@ func TestMailboxRunRecordsGatesFromNeeds(t *testing.T) {
 func TestMailboxRunBlockedWithoutNeedsRecordsNoGates(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"blocked","summary":"blocked","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,

--- a/internal/workflow/mailbox.go
+++ b/internal/workflow/mailbox.go
@@ -32,7 +32,12 @@ import (
 const maxRepairAttempts = 2
 
 type Mailbox struct {
-	Store *db.Store
+	store *db.Store
+	// resolveDeliveryWorktree is required by NewMailbox. For implement delivery
+	// it resolves the effective host checkout already selected by the CLI, or
+	// returns an explicit typed exclusion. It is private so production callers
+	// cannot recreate the old optional-field failure with a keyed struct literal.
+	resolveDeliveryWorktree DeliveryWorktreeResolver
 	// CollectChangeSet is the P2a host-import seam. A non-local backend wires a
 	// collector here once it owns an instance lifecycle (P2b); nil preserves the
 	// local backend byte-for-byte. It is consulted once after the delivery sequence
@@ -137,6 +142,52 @@ type Mailbox struct {
 	// produceCheckTimeout bounds each trusted check command. Zero uses the
 	// production default; tests may inject a short timeout.
 	produceCheckTimeout time.Duration
+}
+
+// DeliveryWorktreeResolution is the CLI-owned answer to "where did this job
+// actually run?" Exactly one of Path or ExcludedSource must be populated.
+type DeliveryWorktreeResolution struct {
+	Path           string
+	ExcludedSource string
+}
+
+// DeliveryWorktreeResolver injects checkout resolution into workflow without
+// introducing the forbidden workflow -> cli import.
+type DeliveryWorktreeResolver func(context.Context, db.Job, JobPayload) (DeliveryWorktreeResolution, error)
+
+// NewMailbox requires every construction site to state its delivery-worktree
+// policy. Use UnavailableDeliveryWorktreeResolver at enqueue-only/ask-only sites;
+// it errors loudly if an implement delivery ever reaches that context.
+func NewMailbox(store *db.Store, resolver DeliveryWorktreeResolver) Mailbox {
+	return Mailbox{store: store, resolveDeliveryWorktree: resolver}
+}
+
+// UnavailableDeliveryWorktreeResolver is the explicit sentinel for construction
+// sites that cannot perform implement delivery. Unlike a nil/default resolver,
+// accidental use fails visibly instead of silently suppressing observation.
+func UnavailableDeliveryWorktreeResolver(site string) DeliveryWorktreeResolver {
+	return func(context.Context, db.Job, JobPayload) (DeliveryWorktreeResolution, error) {
+		return DeliveryWorktreeResolution{}, fmt.Errorf("delivery worktree resolution is unavailable at %s", strings.TrimSpace(site))
+	}
+}
+
+// PayloadDeliveryWorktreeResolver is the explicit policy for contexts whose
+// payload already owns the effective checkout (notably focused workflow tests).
+var PayloadDeliveryWorktreeResolver DeliveryWorktreeResolver = func(_ context.Context, _ db.Job, payload JobPayload) (DeliveryWorktreeResolution, error) {
+	path := strings.TrimSpace(payload.WorktreePath)
+	if path == "" {
+		return DeliveryWorktreeResolution{}, errors.New("payload has no delivery worktree path")
+	}
+	return DeliveryWorktreeResolution{Path: path}, nil
+}
+
+// ExcludedDeliveryWorktreeResolver is an explicit sentinel for a context that
+// intentionally does not observe implement worktrees. Production exclusions
+// should normally be selected by a shape-specific CLI predicate instead.
+func ExcludedDeliveryWorktreeResolver(source string) DeliveryWorktreeResolver {
+	return func(context.Context, db.Job, JobPayload) (DeliveryWorktreeResolution, error) {
+		return DeliveryWorktreeResolution{ExcludedSource: strings.TrimSpace(source)}, nil
+	}
 }
 
 // PipelineKeyAccess is the persisted, names-only authorization for one pipeline
@@ -531,7 +582,7 @@ type DeliveryAdapter interface {
 }
 
 func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error) {
-	if m.Store == nil {
+	if m.store == nil {
 		return db.Job{}, errors.New("mailbox store is required")
 	}
 	if err := validateJobRequest(request); err != nil {
@@ -576,7 +627,7 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 	skipNativeReviewFanout := request.SkipNativeReviewFanout
 	pullRequestReady := request.PullRequestReady
 	if (!skipNativeReviewFanout || !pullRequestReady) && strings.TrimSpace(request.ParentJobID) != "" {
-		if parent, parentErr := m.Store.GetJob(ctx, strings.TrimSpace(request.ParentJobID)); parentErr == nil {
+		if parent, parentErr := m.store.GetJob(ctx, strings.TrimSpace(request.ParentJobID)); parentErr == nil {
 			if parentPayload, parseErr := unmarshalPayload(parent.Payload); parseErr == nil {
 				if parentPayload.SkipNativeReviewFanout {
 					skipNativeReviewFanout = true
@@ -686,18 +737,18 @@ func (m Mailbox) Enqueue(ctx context.Context, request JobRequest) (db.Job, error
 	if err != nil {
 		return db.Job{}, err
 	}
-	if err := m.Store.CreateJobWithEvent(ctx, job, db.JobEvent{JobID: job.ID, Kind: string(JobQueued), Message: "job queued"}, request.RequiredEvents...); err != nil {
+	if err := m.store.CreateJobWithEvent(ctx, job, db.JobEvent{JobID: job.ID, Kind: string(JobQueued), Message: "job queued"}, request.RequiredEvents...); err != nil {
 		return db.Job{}, err
 	}
 	if autolabeled {
-		if err := m.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "workflow_autolabeled", Message: fmt.Sprintf("auto-filed under %s (require_workflow=auto for %s; pass --workflow to name your initiative)", strings.TrimSpace(request.WorkflowID), strings.TrimSpace(request.Repo))}); err != nil {
+		if err := m.store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "workflow_autolabeled", Message: fmt.Sprintf("auto-filed under %s (require_workflow=auto for %s; pass --workflow to name your initiative)", strings.TrimSpace(request.WorkflowID), strings.TrimSpace(request.Repo))}); err != nil {
 			// The queued job is durable. Never turn a successful enqueue into a
 			// rejection because an advisory follow-up event could not be written.
 			fmt.Fprintf(os.Stderr, "gitmoot: add workflow_autolabeled event for %s: %v\n", job.ID, err)
 		}
 	}
 	if orgWarning != "" {
-		if err := m.Store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "org_scope_violation", Message: orgWarning}); err != nil {
+		if err := m.store.AddJobEvent(ctx, db.JobEvent{JobID: job.ID, Kind: "org_scope_violation", Message: orgWarning}); err != nil {
 			// The queued job is durable. An advisory warning event must never undo it.
 			fmt.Fprintf(os.Stderr, "gitmoot: add org_scope_violation event for %s: %v\n", job.ID, err)
 		}
@@ -875,7 +926,7 @@ func (m Mailbox) resolveEnqueueModel(ctx context.Context, request JobRequest) (s
 		agent.Runtime = strings.TrimSpace(request.Ephemeral.Runtime)
 		agent.Model = request.Ephemeral.Model
 	} else {
-		stored, err := m.Store.GetAgent(ctx, request.Agent)
+		stored, err := m.store.GetAgent(ctx, request.Agent)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return "", err
 		}
@@ -896,7 +947,7 @@ func (m Mailbox) resolveEnqueueModel(ctx context.Context, request JobRequest) (s
 }
 
 func (m Mailbox) templateSnapshot(ctx context.Context, agentName string) (db.AgentTemplate, error) {
-	agent, err := m.Store.GetAgent(ctx, agentName)
+	agent, err := m.store.GetAgent(ctx, agentName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return db.AgentTemplate{}, nil
@@ -906,7 +957,7 @@ func (m Mailbox) templateSnapshot(ctx context.Context, agentName string) (db.Age
 	if strings.TrimSpace(agent.TemplateID) == "" {
 		return db.AgentTemplate{}, nil
 	}
-	template, err := m.Store.GetAgentTemplateReference(ctx, agent.TemplateID)
+	template, err := m.store.GetAgentTemplateReference(ctx, agent.TemplateID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return db.AgentTemplate{}, fmt.Errorf("agent %q references missing template %q", agent.Name, agent.TemplateID)
@@ -949,7 +1000,7 @@ func (m Mailbox) routeCanary(ctx context.Context, agentTemplateRef string, champ
 	if versionRef != "" && versionRef != "current" {
 		return db.AgentTemplate{}, false
 	}
-	canary, found, err := m.Store.GetActiveCanaryVersion(ctx, templateID)
+	canary, found, err := m.store.GetActiveCanaryVersion(ctx, templateID)
 	if err != nil || !found {
 		return db.AgentTemplate{}, false
 	}
@@ -964,7 +1015,7 @@ func (m Mailbox) routeCanary(ctx context.Context, agentTemplateRef string, champ
 	// (canary.ID is "templateID@vN"), so its distinct ResolvedCommit/Content flow
 	// into the payload unchanged and the #465 harvester attributes the outcome to
 	// the canary version. A resolve error falls back to the champion (never break).
-	snap, err := m.Store.GetAgentTemplateReference(ctx, canary.ID)
+	snap, err := m.store.GetAgentTemplateReference(ctx, canary.ID)
 	if err != nil || strings.TrimSpace(snap.VersionID) == "" {
 		return db.AgentTemplate{}, false
 	}
@@ -1058,14 +1109,14 @@ func resumedSelfDirtyWorktreeNotice() string {
 }
 
 func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, adapter DeliveryAdapter) (AgentResult, error) {
-	if m.Store == nil {
+	if m.store == nil {
 		return AgentResult{}, errors.New("mailbox store is required")
 	}
 	if adapter == nil {
 		return AgentResult{}, errors.New("delivery adapter is required")
 	}
 
-	job, err := m.Store.GetJob(ctx, jobID)
+	job, err := m.store.GetJob(ctx, jobID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return AgentResult{}, fmt.Errorf("job %q not found", jobID)
@@ -1288,8 +1339,21 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			return AgentResult{}, parseErr
 		}
 	}
-	if err := m.importDeliveryChangeSet(ctx, job, payload, execBackend); err != nil {
-		return AgentResult{}, err
+	var deliveryWorktree DeliveryWorktreeResolution
+	if strings.EqualFold(strings.TrimSpace(job.Type), "implement") {
+		var resolveErr error
+		deliveryWorktree, resolveErr = m.deliveryWorktree(ctx, job, payload)
+		if resolveErr != nil {
+			message := fmt.Sprintf("delivery worktree resolution failed: %v", resolveErr)
+			_ = m.addEvent(ctx, job.ID, "delivery_worktree_resolution_failed", message)
+			_ = m.fail(ctx, job.ID, message)
+			return AgentResult{}, errors.New(message)
+		}
+		if deliveryWorktree.ExcludedSource == "" {
+			if err := m.importDeliveryChangeSet(ctx, job, deliveryWorktree.Path, execBackend); err != nil {
+				return AgentResult{}, err
+			}
+		}
 	}
 
 	// A produce stage may declare a trusted deterministic check. Run it only after
@@ -1394,7 +1458,11 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	}
 	payload.Result = &result
 	if strings.EqualFold(strings.TrimSpace(job.Type), "implement") {
-		payload.ResultObservation = observeResultChanges(ctx, payload.WorktreePath, result, execBackend)
+		if deliveryWorktree.ExcludedSource != "" {
+			payload.ResultObservation = excludedResultObservation(deliveryWorktree.ExcludedSource, result)
+		} else {
+			payload.ResultObservation = observeResultChanges(ctx, deliveryWorktree.Path, result, execBackend)
+		}
 	}
 	// #526 deterministic binary-checklist audit of the parsed result. The worktree
 	// observation above is recorded in every mode. Off (the zero value and "off")
@@ -1419,7 +1487,7 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 			if rootID == "" {
 				rootID = job.ID
 			}
-			_ = m.Store.RecordResultCheckFailures(ctx, job.ID, rootID, job.Type, toDBResultCheckFailures(failed))
+			_ = m.store.RecordResultCheckFailures(ctx, job.ID, rootID, job.Type, toDBResultCheckFailures(failed))
 			if mode == ResultChecksBlock {
 				// Persist the payload (carrying ResultChecks + Result) BEFORE failing so
 				// the job-detail surface shows exactly which checks failed, then map the
@@ -1451,7 +1519,27 @@ func (m Mailbox) Run(ctx context.Context, jobID string, agent runtime.Agent, ada
 	return result, nil
 }
 
-func (m Mailbox) importDeliveryChangeSet(ctx context.Context, job db.Job, payload JobPayload, backend execbackend.Backend) error {
+func (m Mailbox) deliveryWorktree(ctx context.Context, job db.Job, payload JobPayload) (DeliveryWorktreeResolution, error) {
+	if m.resolveDeliveryWorktree == nil {
+		return DeliveryWorktreeResolution{}, errors.New("mailbox has no delivery worktree resolver")
+	}
+	resolution, err := m.resolveDeliveryWorktree(ctx, job, payload)
+	if err != nil {
+		return DeliveryWorktreeResolution{}, err
+	}
+	resolution.Path = strings.TrimSpace(resolution.Path)
+	resolution.ExcludedSource = strings.TrimSpace(resolution.ExcludedSource)
+	switch {
+	case resolution.Path != "" && resolution.ExcludedSource != "":
+		return DeliveryWorktreeResolution{}, errors.New("delivery worktree resolver returned both a path and an exclusion source")
+	case resolution.Path == "" && resolution.ExcludedSource == "":
+		return DeliveryWorktreeResolution{}, errors.New("delivery worktree resolver returned neither a path nor an exclusion source")
+	default:
+		return resolution, nil
+	}
+}
+
+func (m Mailbox) importDeliveryChangeSet(ctx context.Context, job db.Job, worktree string, backend execbackend.Backend) error {
 	if !strings.EqualFold(strings.TrimSpace(job.Type), "implement") || m.CollectChangeSet == nil {
 		return nil
 	}
@@ -1461,7 +1549,7 @@ func (m Mailbox) importDeliveryChangeSet(ctx context.Context, job db.Job, payloa
 		if apply == nil {
 			apply = execbackend.ImportChangeSet
 		}
-		err = apply(ctx, payload.WorktreePath, *changes)
+		err = apply(ctx, worktree, *changes)
 	}
 	if err == nil {
 		return nil
@@ -1607,7 +1695,7 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 		// (fresh/single-use, and every non-codex runtime) skips the delta table
 		// entirely and records the count verbatim (#664).
 		if result.CumulativeUsage && agent.RuntimeRef != "" && agent.RuntimeRef != runtime.LastRef {
-			inTok, outTok, _ = m.Store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+agent.RuntimeRef, result.InputTokens, result.OutputTokens)
+			inTok, outTok, _ = m.store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+agent.RuntimeRef, result.InputTokens, result.OutputTokens)
 		} else if result.CumulativeUsage {
 			inTok, outTok = 0, 0
 		} else if agent.Runtime == runtime.CodexRuntime && result.RefreshedRuntimeRef != "" && result.RefreshedRuntimeRef != runtime.LastRef {
@@ -1623,13 +1711,13 @@ func (m Mailbox) deliver(ctx context.Context, adapter DeliveryAdapter, agent run
 			// (turn1+turn2)-turn1 = turn2. The returned delta is discarded; the verbatim
 			// UpdateJobUsage below records this turn. Errors are swallowed like the delta
 			// call — usage accounting never fails a delivery.
-			_, _, _ = m.Store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+result.RefreshedRuntimeRef, result.InputTokens, result.OutputTokens)
+			_, _, _ = m.store.RecordRuntimeSessionUsageDelta(ctx, agent.Runtime+":"+result.RefreshedRuntimeRef, result.InputTokens, result.OutputTokens)
 		}
 		// Only persist when a positive count remains so runtimes that report nothing
 		// (e.g. the shell runtime) or a delta that resolved to 0 leave the columns at
 		// their 0 default rather than taking a no-op write.
 		if inTok > 0 || outTok > 0 {
-			_ = m.Store.UpdateJobUsage(ctx, job.ID, inTok, outTok)
+			_ = m.store.UpdateJobUsage(ctx, job.ID, inTok, outTok)
 		}
 	}
 	diag := failureDiagnosticsFromSession(result.SessionDiag)
@@ -1662,7 +1750,7 @@ func (m Mailbox) persistRefreshedRuntimeRef(ctx context.Context, jobID string, a
 	if refreshedRef == "" || refreshedRef == agent.RuntimeRef {
 		return
 	}
-	_ = m.Store.UpdateAgentRuntimeRef(ctx, agent.Name, refreshedRef)
+	_ = m.store.UpdateAgentRuntimeRef(ctx, agent.Name, refreshedRef)
 	_ = m.addEvent(ctx, jobID, "session_refresh_retry", fmt.Sprintf("re-pinned agent %q to fresh runtime session after dead-session self-heal", agent.Name))
 }
 
@@ -1671,19 +1759,19 @@ func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, messa
 	defer cancel()
 	var transitioned bool
 	var err error
-	if job, loadErr := m.Store.GetJob(writeCtx, jobID); loadErr == nil {
+	if job, loadErr := m.store.GetJob(writeCtx, jobID); loadErr == nil {
 		if payload, payloadErr := unmarshalPayload(job.Payload); payloadErr == nil {
 			clearRuntimeIdentity(&payload)
 			message = terminalMessageWithDiagnostics(state, message, payload.FailureDiagnostics)
 			if encoded, encodeErr := marshalPayload(payload); encodeErr == nil {
-				transitioned, err = m.Store.TransitionJobStatePayloadWithEvent(writeCtx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
+				transitioned, err = m.store.TransitionJobStatePayloadWithEvent(writeCtx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
 					JobID: jobID, Kind: string(state), Message: message,
 				})
 			}
 		}
 	}
 	if err == nil && !transitioned {
-		transitioned, err = m.Store.TransitionJobStateWithEvent(writeCtx, jobID, string(JobRunning), string(state), db.JobEvent{
+		transitioned, err = m.store.TransitionJobStateWithEvent(writeCtx, jobID, string(JobRunning), string(state), db.JobEvent{
 			JobID: jobID, Kind: string(state), Message: message,
 		})
 	}
@@ -1691,7 +1779,7 @@ func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, messa
 		return err
 	}
 	if !transitioned {
-		latest, getErr := m.Store.GetJob(writeCtx, jobID)
+		latest, getErr := m.store.GetJob(writeCtx, jobID)
 		if getErr != nil {
 			return getErr
 		}
@@ -1722,7 +1810,7 @@ func (m Mailbox) finish(ctx context.Context, jobID string, state JobState, messa
 // so synthesize a transient Result from it (in-memory only — never persisted).
 // On any load error it returns a minimal payload so the emit still fires.
 func (m Mailbox) loadTerminalEmitPayload(ctx context.Context, jobID, message string) JobPayload {
-	job, err := m.Store.GetJob(ctx, jobID)
+	job, err := m.store.GetJob(ctx, jobID)
 	if err != nil {
 		return JobPayload{Result: &AgentResult{Summary: strings.TrimSpace(message)}}
 	}
@@ -1745,7 +1833,7 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 	if err != nil {
 		return err
 	}
-	transitioned, err := m.Store.TransitionJobStatePayloadWithEvent(writeCtx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
+	transitioned, err := m.store.TransitionJobStatePayloadWithEvent(writeCtx, jobID, string(JobRunning), string(state), encoded, db.JobEvent{
 		JobID:   jobID,
 		Kind:    string(state),
 		Message: message,
@@ -1758,7 +1846,7 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 		return err
 	}
 	if !transitioned {
-		latest, getErr := m.Store.GetJob(writeCtx, jobID)
+		latest, getErr := m.store.GetJob(writeCtx, jobID)
 		if getErr != nil {
 			return getErr
 		}
@@ -1786,7 +1874,7 @@ func (m Mailbox) finishWithPayload(ctx context.Context, jobID string, state JobS
 	// pipeline advancer never folds, and a double execution once the run is
 	// properly resumed.
 	if state == JobBlocked && payload.Result != nil && len(payload.Result.Needs) > 0 && payload.Sender != PipelineJobSender {
-		if _, gateErr := m.Store.RecordJobGates(writeCtx, jobID, payload.Result.Needs); gateErr == nil {
+		if _, gateErr := m.store.RecordJobGates(writeCtx, jobID, payload.Result.Needs); gateErr == nil {
 			_ = m.addEvent(writeCtx, jobID, "gates_recorded", fmt.Sprintf("recorded %d resumable gate(s) from needs", len(payload.Result.Needs)))
 		}
 	}
@@ -1810,7 +1898,7 @@ func terminalMessageWithDiagnostics(state JobState, message string, diag *Failur
 }
 
 func (m Mailbox) ensureRunning(ctx context.Context, jobID string) error {
-	latest, err := m.Store.GetJob(ctx, jobID)
+	latest, err := m.store.GetJob(ctx, jobID)
 	if err != nil {
 		return err
 	}
@@ -1829,7 +1917,7 @@ func (m Mailbox) claim(ctx context.Context, job db.Job) error {
 	// that lets the daemon recover this job immediately after a reboot, and
 	// runner_pid is recorded for observability only. Off Linux BootID() is "", so
 	// the row is identity-less and only the existing age/lease recovery applies.
-	claimed, err := m.Store.ClaimRunningJob(ctx, job.ID, string(JobQueued), string(JobRunning), db.JobEvent{
+	claimed, err := m.store.ClaimRunningJob(ctx, job.ID, string(JobQueued), string(JobRunning), db.JobEvent{
 		JobID:   job.ID,
 		Kind:    string(JobRunning),
 		Message: "job started",
@@ -1838,7 +1926,7 @@ func (m Mailbox) claim(ctx context.Context, job db.Job) error {
 		return err
 	}
 	if !claimed {
-		latest, getErr := m.Store.GetJob(ctx, job.ID)
+		latest, getErr := m.store.GetJob(ctx, job.ID)
 		if getErr != nil {
 			return getErr
 		}
@@ -1861,7 +1949,7 @@ func terminalWriteContext(runCtx context.Context) (context.Context, context.Canc
 }
 
 func (m Mailbox) addEvent(ctx context.Context, jobID string, kind string, message string) error {
-	return m.Store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: kind, Message: message})
+	return m.store.AddJobEvent(ctx, db.JobEvent{JobID: jobID, Kind: kind, Message: message})
 }
 
 func (m Mailbox) savePayload(ctx context.Context, jobID string, payload JobPayload) error {
@@ -1869,7 +1957,7 @@ func (m Mailbox) savePayload(ctx context.Context, jobID string, payload JobPaylo
 	if err != nil {
 		return err
 	}
-	return m.Store.UpdateJobPayload(ctx, jobID, encoded)
+	return m.store.UpdateJobPayload(ctx, jobID, encoded)
 }
 
 func (p JobPayload) prompt(action string) prompts.JobPrompt {

--- a/internal/workflow/mailbox_plan_test.go
+++ b/internal/workflow/mailbox_plan_test.go
@@ -20,7 +20,7 @@ const planResultJSON = `{"gitmoot_result":{"decision":"approved","summary":"done
 func TestMailboxEnqueueRejectsImpossiblePlanRequest(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	cases := map[string]struct {
 		request  JobRequest
@@ -86,7 +86,7 @@ func TestMailboxEnqueueRejectsImpossiblePlanRequest(t *testing.T) {
 // convention-only behaviour #1479 exists to remove.
 func TestMailboxDeliverPlanGate(t *testing.T) {
 	ctx := context.Background()
-	mailbox := Mailbox{Store: openTestStore(t)}
+	mailbox := Mailbox{store: openTestStore(t), resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	job := db.Job{ID: "job-plan-gate", Type: "ask"}
 
 	cases := map[string]struct {
@@ -211,7 +211,7 @@ func TestMailboxDeliverPlanGate(t *testing.T) {
 func TestMailboxRunPersistsPlanEvidence(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID: "job-plan-run", Agent: "planner", Action: "ask", Repo: "owner/repo",
 		Plan: true, PlanInto: "@smol",

--- a/internal/workflow/mailbox_resume_worktree_test.go
+++ b/internal/workflow/mailbox_resume_worktree_test.go
@@ -12,7 +12,7 @@ import (
 func TestMailboxRunPrependsResumeNotice(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	const output = `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
 
 	run := func(t *testing.T, id string, resumed bool) (string, string) {

--- a/internal/workflow/mailbox_runtime_override_test.go
+++ b/internal/workflow/mailbox_runtime_override_test.go
@@ -23,7 +23,7 @@ import (
 func TestMailboxRunSkipsRefreshedRefPersistForRuntimeOverride(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	defaultRef := "codex-default-session"
 	if err := store.UpsertAgent(ctx, db.Agent{
 		Name:       "shipper",
@@ -82,7 +82,7 @@ func TestMailboxRunSkipsRefreshedRefPersistForRuntimeOverride(t *testing.T) {
 func TestMailboxEnqueuePersistsRuntimeOverride(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	job, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:                 "job-override",
@@ -111,7 +111,7 @@ func TestMailboxEnqueuePersistsRuntimeOverride(t *testing.T) {
 func TestMailboxRunThreadsShellEnvironment(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	env := []string{"GITMOOT_TRIGGER_BODY=first\n第二", "GITMOOT_TRIGGER_SUBJECT=Snowman ☃"}
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-shell-env", Agent: "runner", Action: "ask", Repo: "owner/repo", RuntimeOverride: runtime.ShellRuntime, RuntimeOverrideRef: "printf ok", ShellEnv: env}); err != nil {
 		t.Fatal(err)
@@ -129,7 +129,7 @@ func TestMailboxRunThreadsShellEnvironment(t *testing.T) {
 func TestMailboxPipelineInputEnvDeliveryNeverEntersPromptOrFreeFormResult(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	const sentinel = "SERVICE_INPUT_SENTINEL_1011"
 	inputEnv := []string{"GITMOOT_INPUT_APP_NAME=" + sentinel, "GITMOOT_INPUT_COUNT=3"}
 	const resultJSON = `{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`
@@ -198,7 +198,7 @@ func TestMailboxPipelineInputEnvDeliveryNeverEntersPromptOrFreeFormResult(t *tes
 }
 
 func TestMailboxRejectsUnreservedPipelineInputEnv(t *testing.T) {
-	mailbox := Mailbox{Store: openTestStore(t)}
+	mailbox := Mailbox{store: openTestStore(t), resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	for _, env := range [][]string{{"PATH=/tmp"}, {"GITMOOT_PIPELINE_NAME=x"}, {"GITMOOT_INPUT_app=x"}, {"GITMOOT_INPUT_APP=x", "GITMOOT_INPUT_APP=y"}} {
 		if _, err := mailbox.Enqueue(context.Background(), JobRequest{ID: "bad-input-env", Agent: "runner", Action: "ask", Repo: "owner/repo", PipelineInputEnv: env}); err == nil {
 			t.Fatalf("Enqueue accepted pipeline input env %#v", env)
@@ -219,7 +219,7 @@ func TestMailboxShellUpstreamContextPersistsAcrossReopenAndDelivery(t *testing.T
 		RuntimeOverride: runtime.ShellRuntime, RuntimeOverrideRef: "printf ok",
 		ShellUpstreamContext: contextJSON,
 	}
-	job, err := (Mailbox{Store: store}).Enqueue(ctx, request)
+	job, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,14 +249,14 @@ func TestMailboxShellUpstreamContextPersistsAcrossReopenAndDelivery(t *testing.T
 
 	adapter := &fakeDelivery{outputs: []string{`{"gitmoot_result":{"decision":"approved","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}}
 	agent := runtime.Agent{Name: "runner", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "owner/repo", Role: "runner"}
-	if _, err := (Mailbox{Store: store}).Run(ctx, job.ID, agent, adapter); err != nil {
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Run(ctx, job.ID, agent, adapter); err != nil {
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(adapter.shellUpstreamContexts, []string{contextJSON}) {
 		t.Fatalf("delivered contexts = %#v", adapter.shellUpstreamContexts)
 	}
 
-	plain, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{ID: "job-shell-plain", Agent: "runner", Action: "ask", Repo: "owner/repo", RuntimeOverride: runtime.ShellRuntime, RuntimeOverrideRef: "printf ok"})
+	plain, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{ID: "job-shell-plain", Agent: "runner", Action: "ask", Repo: "owner/repo", RuntimeOverride: runtime.ShellRuntime, RuntimeOverrideRef: "printf ok"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +268,7 @@ func TestMailboxShellUpstreamContextPersistsAcrossReopenAndDelivery(t *testing.T
 func TestMailboxShellUpstreamContextFailureRedactsPersistedTempPath(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	secretTempPrefix := filepath.Join(t.TempDir(), "operator-private-temp")
 	t.Setenv("TMPDIR", secretTempPrefix) // Deliberately absent: CreateTemp must fail.
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
@@ -307,7 +307,7 @@ func TestMailboxShellUpstreamContextFailureRedactsPersistedTempPath(t *testing.T
 func TestMailboxEnqueueRejectsInvalidRuntimeOverride(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	freshRef, err := runtime.NewFreshRef()
 	if err != nil {
 		t.Fatalf("NewFreshRef returned error: %v", err)

--- a/internal/workflow/mailbox_test.go
+++ b/internal/workflow/mailbox_test.go
@@ -40,7 +40,7 @@ func TestTerminalWriteContextSurvivesRunCancellationAndHasGraceDeadline(t *testi
 func TestMailboxFailPersistsAfterRunContextDeadline(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	job, err := mailbox.Enqueue(ctx, JobRequest{
 		ID: "job-terminal-write", Agent: "audit", Action: "review", Repo: "gitmoot/gitmoot",
 	})
@@ -67,7 +67,7 @@ func TestMailboxFailPersistsAfterRunContextDeadline(t *testing.T) {
 func TestMailboxEnqueueCreatesQueuedJobAndEvent(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	job, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:          "job-1",
@@ -107,7 +107,7 @@ func TestMailboxEnqueueCreatesQueuedJobAndEvent(t *testing.T) {
 func TestMailboxPersistsActingOrgRoleProvenance(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	job, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	job, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID: "org-role-job", Agent: "audit", Action: "ask", Repo: "gitmoot/gitmoot", ActingOrgRole: " owner ",
 	})
 	if err != nil {
@@ -125,7 +125,7 @@ func TestMailboxPersistsActingOrgRoleProvenance(t *testing.T) {
 func TestMailboxPersistsRuntimeIdentityUntilTerminal(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID: "pid-job", Agent: "worker", Action: "ask", Repo: "gitmoot/gitmoot",
 	}); err != nil {
@@ -172,7 +172,7 @@ func TestMailboxKeepsRuntimePIDThroughProduceCheckUntilTerminal(t *testing.T) {
 	dir := t.TempDir()
 	started := filepath.Join(dir, "check.started")
 	release := filepath.Join(dir, "check.release")
-	mailbox := Mailbox{Store: store, produceCheckTimeout: 5 * time.Second}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), produceCheckTimeout: 5 * time.Second}
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID: "produce-pid-window", Agent: "producer", Action: "produce", Repo: "owner/repo",
 		Sender: PipelineJobSender, WorktreePath: dir, WritablePaths: []string{dir},
@@ -232,7 +232,7 @@ func TestMailboxProduceCheckRetriesSameSessionAndRecordsTokens(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
 	dir := t.TempDir()
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID: "produce-1", Agent: "producer", Action: "produce", Repo: "owner/repo",
 		Sender: PipelineJobSender, WorktreePath: dir, WritablePaths: []string{dir}, Check: "test -s artifact.json || { echo ghp_abcdefghijklmnopqrstuvwxyz0123456789; exit 1; }", CheckRetries: 1,
@@ -282,7 +282,7 @@ func TestMailboxProduceCheckRetriesSameSessionAndRecordsTokens(t *testing.T) {
 func TestMailboxProduceCheckExhaustionFails(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	dir := t.TempDir()
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "produce-fail", Agent: "producer", Action: "produce", Repo: "owner/repo", Sender: PipelineJobSender, WorktreePath: dir, WritablePaths: []string{dir}, Check: "echo nope >&2; exit 1"}); err != nil {
 		t.Fatalf("Enqueue: %v", err)
@@ -360,7 +360,7 @@ func TestProduceCheckNonLocalBackendCannotRunLocally(t *testing.T) {
 }
 
 func TestMailboxRejectsProduceOutsidePipelineSender(t *testing.T) {
-	mailbox := Mailbox{Store: openTestStore(t)}
+	mailbox := Mailbox{store: openTestStore(t), resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	_, err := mailbox.Enqueue(context.Background(), JobRequest{ID: "bad-produce", Agent: "p", Action: "produce", Repo: "owner/repo", Sender: "user"})
 	if err == nil || !strings.Contains(err.Error(), "reserved for pipeline stages") {
 		t.Fatalf("Enqueue error = %v", err)
@@ -368,7 +368,7 @@ func TestMailboxRejectsProduceOutsidePipelineSender(t *testing.T) {
 }
 
 func TestMailboxRejectsProduceGrantsOnNonProduceRequests(t *testing.T) {
-	mailbox := Mailbox{Store: openTestStore(t)}
+	mailbox := Mailbox{store: openTestStore(t), resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	cases := []struct {
 		name string
 		req  JobRequest
@@ -393,7 +393,7 @@ func TestMailboxRejectsProduceGrantsOnNonProduceRequests(t *testing.T) {
 }
 
 func TestMailboxPersistsProduceReadablePaths(t *testing.T) {
-	mailbox := Mailbox{Store: openTestStore(t)}
+	mailbox := Mailbox{store: openTestStore(t), resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	job, err := mailbox.Enqueue(context.Background(), JobRequest{
 		ID:            "produce-readable",
 		Agent:         "producer",
@@ -419,7 +419,7 @@ func TestMailboxPersistsProduceReadablePaths(t *testing.T) {
 func TestMailboxEnqueuePersistsDelegationMetadata(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	job, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:              "job-child",
@@ -458,7 +458,7 @@ func TestMailboxEnqueuePersistsDelegationMetadata(t *testing.T) {
 func TestMailboxEnqueuePersistsEphemeralSpec(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:           "job-ephemeral",
@@ -506,7 +506,7 @@ func TestMailboxClaimStampsRunnerBootID(t *testing.T) {
 	}
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	job, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-claim", Agent: "audit", Action: "ask", Repo: "gitmoot/gitmoot"})
 	if err != nil {
@@ -544,7 +544,7 @@ func TestMailboxClaimStampsRunnerBootID(t *testing.T) {
 func TestMailboxEnqueuePersistsModel(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:     "job-model",
@@ -588,7 +588,7 @@ func TestMailboxEnqueuePersistsResolvedModel(t *testing.T) {
 			t.Fatalf("UpsertAgent(%s): %v", agent.Name, err)
 		}
 	}
-	mailbox := Mailbox{Store: store, RuntimeDefaultModel: func(runtimeName string) string {
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RuntimeDefaultModel: func(runtimeName string) string {
 		if runtimeName == runtime.KimiRuntime {
 			return "k3"
 		}
@@ -650,7 +650,7 @@ func TestMailboxEnqueuePersistsResolvedModel(t *testing.T) {
 func TestMailboxEnqueueOmitsEmptyModel(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:     "job-no-model",
@@ -673,7 +673,7 @@ func TestMailboxEnqueueOmitsEmptyModel(t *testing.T) {
 func TestMailboxEnqueuePersistsPhase(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:     "job-phase",
@@ -704,7 +704,7 @@ func TestMailboxEnqueuePersistsPhase(t *testing.T) {
 func TestMailboxEnqueueOmitsEmptyPhase(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:     "job-no-phase",
@@ -727,7 +727,7 @@ func TestMailboxEnqueueOmitsEmptyPhase(t *testing.T) {
 func TestMailboxRunDeliversModelAndEffortOverrides(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
@@ -756,7 +756,7 @@ func TestMailboxRunDeliversModelAndEffortOverrides(t *testing.T) {
 func TestMailboxRunThreadsRuntimeDefaultModel(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store, RuntimeDefaultModel: func(rt string) string {
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RuntimeDefaultModel: func(rt string) string {
 		if rt == runtime.ShellRuntime {
 			return "gpt-5.5"
 		}
@@ -783,7 +783,7 @@ func TestMailboxRunThreadsRuntimeDefaultModel(t *testing.T) {
 func TestMailboxRunThreadsRuntimeDefaultEffort(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store, RuntimeDefaultEffort: func(rt string) string {
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RuntimeDefaultEffort: func(rt string) string {
 		if rt == runtime.CodexRuntime {
 			return "high"
 		}
@@ -812,7 +812,7 @@ func TestMailboxRunThreadsRuntimeDefaultEffort(t *testing.T) {
 func TestMailboxRunNilRuntimeDefaultHookByteIdentical(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{okDeliveryResult}}
 
@@ -840,7 +840,7 @@ const okDeliveryResult = `{"gitmoot_result":{"decision":"implemented","summary":
 func TestMailboxDeliverDeltasCumulativeUsage(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "planner", Runtime: runtime.CodexRuntime, RuntimeRef: "019f3041-cfed-7e82-8766-b5ca75cf92da", RepoScope: "gitmoot/gitmoot", Role: "implementer"}
 	adapter := &fakeDelivery{
 		outputs:      []string{okDeliveryResult, okDeliveryResult},
@@ -887,7 +887,7 @@ func TestMailboxDeliverDeltasCumulativeUsage(t *testing.T) {
 func TestMailboxDeliverRecordsNonCumulativeVerbatim(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: "fresh-thread-xyz", RepoScope: "gitmoot/gitmoot", Role: "implementer"}
 	adapter := &fakeDelivery{
 		outputs:      []string{okDeliveryResult, okDeliveryResult},
@@ -929,7 +929,7 @@ func TestMailboxDeliverCumulativeAmbiguousRefContributesZero(t *testing.T) {
 		t.Run("ref="+ref, func(t *testing.T) {
 			ctx := context.Background()
 			store := openTestStore(t)
-			mailbox := Mailbox{Store: store}
+			mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 			agent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: ref, RepoScope: "gitmoot/gitmoot", Role: "implementer"}
 			adapter := &fakeDelivery{
 				outputs:      []string{okDeliveryResult},
@@ -966,7 +966,7 @@ func TestMailboxDeliverCumulativeAmbiguousRefContributesZero(t *testing.T) {
 func TestMailboxDeliverSeedsBaselineForAdoptedThread(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: "fresh:codex-solo", RepoScope: "gitmoot/gitmoot", Role: "implementer"}
 	adapter := &fakeDelivery{
 		outputs: []string{
@@ -1010,7 +1010,7 @@ func TestMailboxDeliverSeedsBaselineForAdoptedThread(t *testing.T) {
 func TestMailboxDeliverDoesNotSeedBaselineWithoutAdoptedThread(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	freshRef := "fresh:codex-single"
 	agent := runtime.Agent{Name: "impl", Runtime: runtime.CodexRuntime, RuntimeRef: freshRef, RepoScope: "gitmoot/gitmoot", Role: "implementer"}
 	adapter := &fakeDelivery{
@@ -1048,7 +1048,7 @@ func TestMailboxDeliverDoesNotSeedBaselineWithoutAdoptedThread(t *testing.T) {
 func TestMailboxEnqueuePersistsRootJobID(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:        "job-child",
@@ -1077,7 +1077,7 @@ func TestMailboxEnqueuePersistsRootJobID(t *testing.T) {
 func TestMailboxEnqueueSnapshotsAgentTemplate(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if err := store.UpsertAgentTemplate(ctx, db.AgentTemplate{
 		ID:             "thermo",
 		Name:           "Thermo",
@@ -1168,7 +1168,7 @@ func TestMailboxEnqueueSnapshotsAgentTemplate(t *testing.T) {
 func TestMailboxEnqueueAppliesTemplateOverride(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	// The agent carries its own template; a --recipe override should win over it
 	// in the enqueued payload without rebinding the agent's identity.
 	if err := store.UpsertAgentTemplate(ctx, db.AgentTemplate{
@@ -1247,7 +1247,7 @@ func TestMailboxEnqueueAppliesTemplateOverride(t *testing.T) {
 func TestMailboxRunIncludesTemplateSnapshotInPrompt(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"approved","summary":"clean","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
@@ -1308,7 +1308,7 @@ func TestUnmarshalPayloadMapsLegacyPresetSnapshot(t *testing.T) {
 func TestMailboxRunStoresResultAndSucceeds(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["mailbox"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`,
@@ -1343,7 +1343,7 @@ func TestMailboxRunStoresResultAndSucceeds(t *testing.T) {
 func TestMailboxRunUsesAdapterSummaryWhenAvailable(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ClaudeRuntime, RuntimeRef: runtime.LastRef, RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{
 		outputs: []string{`{"result":"wrapped by runtime"}`},
@@ -1371,7 +1371,7 @@ func TestMailboxRunUsesAdapterSummaryWhenAvailable(t *testing.T) {
 func TestMailboxRunPersistsRefreshedRuntimeRef(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	oldRef := "550e8400-e29b-41d4-a716-446655440002"
 	newRef := "550e8400-e29b-41d4-a716-446655440099"
 	if err := store.UpsertAgent(ctx, db.Agent{
@@ -1429,7 +1429,7 @@ func TestMailboxRunPersistsRefreshedRuntimeRef(t *testing.T) {
 func TestMailboxRunRepairRetryResumesRefreshedRef(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	oldRef := "550e8400-e29b-41d4-a716-446655440002"
 	newRef := "550e8400-e29b-41d4-a716-446655440099"
 	if err := store.UpsertAgent(ctx, db.Agent{
@@ -1473,7 +1473,7 @@ func TestMailboxRunRepairRetryResumesRefreshedRef(t *testing.T) {
 func TestMailboxRunFreshRefRepairUsesConcreteSessionWithoutPersisting(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	freshRef := "fresh:council-codex"
 	concreteRef := "codex-thread-123"
 	if err := store.UpsertAgent(ctx, db.Agent{
@@ -1530,7 +1530,7 @@ func TestMailboxRunFreshRefRepairUsesConcreteSessionWithoutPersisting(t *testing
 func TestMailboxRunEphemeralRefAdoptedButNotPersisted(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	concreteRef := "claude-ephemeral-session-1"
 	if err := store.UpsertAgent(ctx, db.Agent{
 		Name:       "coordinator",
@@ -1595,7 +1595,7 @@ func TestMailboxRunEphemeralRefAdoptedButNotPersisted(t *testing.T) {
 func TestMailboxRunEphemeralRefStaysFreshAcrossJobs(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if err := store.UpsertAgent(ctx, db.Agent{
 		Name:       "coordinator",
 		Role:       "agent",
@@ -1644,7 +1644,7 @@ func TestMailboxRunEphemeralRefStaysFreshAcrossJobs(t *testing.T) {
 func TestMailboxRunNoRefreshLeavesRefUnchanged(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	oldRef := "550e8400-e29b-41d4-a716-446655440002"
 	if err := store.UpsertAgent(ctx, db.Agent{
 		Name:       "shipper",
@@ -1688,7 +1688,7 @@ func TestMailboxRunNoRefreshLeavesRefUnchanged(t *testing.T) {
 func TestMailboxRunRetriesMalformedOutputOnce(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		"review complete, no json",
@@ -1724,7 +1724,7 @@ func TestMailboxRunRetriesMalformedOutputOnce(t *testing.T) {
 func TestMailboxRunSalvagesMissingEnvelopeAfterSecondRepair(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		"findings posted, no json",
@@ -1771,7 +1771,7 @@ func TestMailboxRunSalvagesMissingEnvelopeAfterSecondRepair(t *testing.T) {
 func TestMailboxRunFailsAfterExhaustingRepairs(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		"no json here",
@@ -1800,7 +1800,7 @@ func TestMailboxRunFailsAfterExhaustingRepairs(t *testing.T) {
 func TestMailboxRunMarksBlockedDecision(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"blocked","summary":"needs credentials","findings":[],"changes_made":[],"tests_run":[],"needs":["GITHUB_TOKEN"],"delegations":[]}}`,
@@ -1824,7 +1824,7 @@ func TestMailboxRunMarksBlockedDecision(t *testing.T) {
 func TestMailboxRunRejectsNonQueuedJob(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"approved","summary":"should not run","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
@@ -1857,7 +1857,7 @@ func TestMailboxRunRejectsNonQueuedJob(t *testing.T) {
 func TestMailboxRunPreservesCancellationDuringDelivery(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{
 		outputs: []string{
@@ -1888,7 +1888,7 @@ func TestMailboxRunPreservesCancellationDuringDelivery(t *testing.T) {
 func TestMailboxRunSkipsRepairAfterCancellation(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "audit", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "reviewer"}
 	adapter := &fakeDelivery{
 		outputs: []string{"malformed"},
@@ -2025,7 +2025,7 @@ func (f *fakeDelivery) Deliver(_ context.Context, agent runtime.Agent, job runti
 func TestMailboxEnqueuePersistsCockpitFields(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:             "job-cockpit",
@@ -2132,7 +2132,7 @@ func enqueueAndResolve(t *testing.T, mailbox Mailbox, jobID string) JobPayload {
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: jobID, Agent: "planner-agent", Action: "ask", Repo: "o/r"}); err != nil {
 		t.Fatalf("Enqueue %s: %v", jobID, err)
 	}
-	stored, err := mailbox.Store.GetJob(ctx, jobID)
+	stored, err := mailbox.store.GetJob(ctx, jobID)
 	if err != nil {
 		t.Fatalf("GetJob %s: %v", jobID, err)
 	}
@@ -2149,7 +2149,7 @@ func enqueueAndResolve(t *testing.T, mailbox Mailbox, jobID string) JobPayload {
 func TestMailboxCanaryRoutingHitsCanary(t *testing.T) {
 	store := openTestStore(t)
 	seedCanaryAgent(t, store, 1.0)
-	mailbox := Mailbox{Store: store, CanaryEnabled: true, CanaryRand: func() float64 { return 0.0 }}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), CanaryEnabled: true, CanaryRand: func() float64 { return 0.0 }}
 	payload := enqueueAndResolve(t, mailbox, "job-canary")
 	if payload.TemplateResolvedCommit != "commit-v2" || payload.TemplateContent != "v2 content" {
 		t.Fatalf("draw below sample must route to canary, got commit=%q content=%q", payload.TemplateResolvedCommit, payload.TemplateContent)
@@ -2164,7 +2164,7 @@ func TestMailboxCanaryRoutingHitsCanary(t *testing.T) {
 func TestMailboxCanaryRoutingMissesCanary(t *testing.T) {
 	store := openTestStore(t)
 	seedCanaryAgent(t, store, 0.5)
-	mailbox := Mailbox{Store: store, CanaryEnabled: true, CanaryRand: func() float64 { return 0.9 }}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), CanaryEnabled: true, CanaryRand: func() float64 { return 0.9 }}
 	payload := enqueueAndResolve(t, mailbox, "job-champ")
 	if payload.TemplateResolvedCommit != "commit-v1" || payload.TemplateContent != "v1 content" {
 		t.Fatalf("draw at/above sample must route to champion, got commit=%q content=%q", payload.TemplateResolvedCommit, payload.TemplateContent)
@@ -2182,7 +2182,7 @@ func TestMailboxCanaryDisabledIgnoresLiveCanary(t *testing.T) {
 	seedCanaryAgent(t, store, 1.0)
 	// CanaryEnabled defaults false; a forced-hit rng would route if the gate were
 	// open, so resolving the champion proves the gate short-circuits before the draw.
-	mailbox := Mailbox{Store: store, CanaryRand: func() float64 { return 0.0 }}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), CanaryRand: func() float64 { return 0.0 }}
 	payload := enqueueAndResolve(t, mailbox, "job-gated")
 	if payload.TemplateResolvedCommit != "commit-v1" || payload.TemplateContent != "v1 content" {
 		t.Fatalf("canary disabled must resolve champion, got commit=%q content=%q", payload.TemplateResolvedCommit, payload.TemplateContent)
@@ -2204,8 +2204,8 @@ func TestMailboxCanaryOffByDefaultByteIdentical(t *testing.T) {
 	}
 	// Default mailbox (nil CanaryRand) and a forced-hit mailbox must resolve the SAME
 	// champion snapshot when no canary row exists.
-	def := enqueueAndResolve(t, Mailbox{Store: store}, "job-default")
-	forced := enqueueAndResolve(t, Mailbox{Store: store, CanaryRand: func() float64 { return 0.0 }}, "job-forced")
+	def := enqueueAndResolve(t, Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}, "job-default")
+	forced := enqueueAndResolve(t, Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), CanaryRand: func() float64 { return 0.0 }}, "job-forced")
 	if def.TemplateResolvedCommit != "commit-v1" || def.TemplateContent != "v1 content" {
 		t.Fatalf("default resolution changed: %+v", def)
 	}
@@ -2220,7 +2220,7 @@ func TestMailboxCanaryOffByDefaultByteIdentical(t *testing.T) {
 func TestMailboxCanaryRoutingConcurrent(t *testing.T) {
 	store := openTestStore(t)
 	seedCanaryAgent(t, store, 0.5)
-	mailbox := Mailbox{Store: store, CanaryEnabled: true} // real global rng — concurrency-safe
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), CanaryEnabled: true} // real global rng — concurrency-safe
 	const n = 40
 	errs := make(chan error, n)
 	for i := 0; i < n; i++ {

--- a/internal/workflow/memory_controller_test.go
+++ b/internal/workflow/memory_controller_test.go
@@ -39,7 +39,7 @@ func runMemJob(t *testing.T, store *db.Store, ctrl *MemoryController, output, in
 func runMemJobWithID(t *testing.T, store *db.Store, ctrl *MemoryController, jobID, output, instructions string) string {
 	t.Helper()
 	ctx := context.Background()
-	mb := Mailbox{Store: store}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if ctrl != nil {
 		mb.injectMemory = ctrl.injectBlock
 		mb.recordMemory = ctrl.record

--- a/internal/workflow/org_test.go
+++ b/internal/workflow/org_test.go
@@ -25,7 +25,7 @@ func testOrgPolicy(enforce string) func(string) OrgEnforcement {
 
 func TestMailboxOrgScopeGate(t *testing.T) {
 	ctx, store := context.Background(), openTestStore(t)
-	mb := Mailbox{Store: store, OrgPolicy: testOrgPolicy("block"), RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{} }}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), OrgPolicy: testOrgPolicy("block"), RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{} }}
 	job, err := mb.Enqueue(ctx, JobRequest{ID: "ok", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local", OperatorOrigin: true, ActingOrgRole: "OWNER"})
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +58,7 @@ func TestMailboxOrgScopeGate(t *testing.T) {
 
 func TestMailboxOrgWarnAndMalformed(t *testing.T) {
 	ctx, store := context.Background(), openTestStore(t)
-	warn := Mailbox{Store: store, OrgPolicy: testOrgPolicy("warn")}
+	warn := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), OrgPolicy: testOrgPolicy("warn")}
 	job, err := warn.Enqueue(ctx, JobRequest{ID: "warn", Agent: "a", Action: "ask", Repo: "other/repo", Sender: "local", OperatorOrigin: true, ActingOrgRole: "owner"})
 	if err != nil {
 		t.Fatal(err)
@@ -70,7 +70,7 @@ func TestMailboxOrgWarnAndMalformed(t *testing.T) {
 	if len(events) != 2 || events[1].Kind != "org_scope_violation" {
 		t.Fatalf("events=%+v", events)
 	}
-	bad := Mailbox{Store: store, OrgPolicy: func(string) OrgEnforcement { return OrgEnforcement{LoadErr: errors.New("bad org toml")} }}
+	bad := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), OrgPolicy: func(string) OrgEnforcement { return OrgEnforcement{LoadErr: errors.New("bad org toml")} }}
 	if _, err := bad.Enqueue(ctx, JobRequest{ID: "bad-automated", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local"}); err != nil {
 		t.Fatalf("automated malformed config: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestOrgScopeDecisionEnqueueParity(t *testing.T) {
 				t.Fatalf("decision violation=%q err=%v", violation, decisionErr)
 			}
 			store := openTestStore(t)
-			job, enqueueErr := (Mailbox{Store: store, OrgPolicy: fixedOrgPolicyForTest(policy)}).Enqueue(ctx, JobRequest{ID: "parity", Agent: "a", Action: "ask", Repo: tt.repo, OperatorOrigin: true, ActingOrgRole: tt.role})
+			job, enqueueErr := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), OrgPolicy: fixedOrgPolicyForTest(policy)}).Enqueue(ctx, JobRequest{ID: "parity", Agent: "a", Action: "ask", Repo: tt.repo, OperatorOrigin: true, ActingOrgRole: tt.role})
 			if (enqueueErr != nil) != tt.wantErr {
 				t.Fatalf("enqueue err=%v, decision err=%v", enqueueErr, decisionErr)
 			}

--- a/internal/workflow/pipeline_leaf_test.go
+++ b/internal/workflow/pipeline_leaf_test.go
@@ -17,7 +17,7 @@ const delegatingResult = `{"gitmoot_result":{"decision":"approved","summary":"do
 func TestMailboxRunStripsPipelineStageDelegations(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "pipeline-x-runner", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "pipeline-runner"}
 	adapter := &fakeDelivery{outputs: []string{delegatingResult}}
 
@@ -49,7 +49,7 @@ func TestMailboxRunStripsPipelineStageDelegations(t *testing.T) {
 func TestMailboxRunKeepsNonPipelineDelegations(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "coord", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "coordinator"}
 	adapter := &fakeDelivery{outputs: []string{delegatingResult}}
 
@@ -85,7 +85,7 @@ const askingResult = `{"gitmoot_result":{"decision":"approved","summary":"done",
 func TestMailboxRunStripsPipelineStageHumanQuestions(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "pipeline-x-runner", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "pipeline-runner"}
 	adapter := &fakeDelivery{outputs: []string{askingResult}}
 
@@ -122,7 +122,7 @@ func TestMailboxRunStripsPipelineStageHumanQuestions(t *testing.T) {
 func TestMailboxRunKeepsNonPipelineHumanQuestions(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "coord", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "coordinator"}
 	adapter := &fakeDelivery{outputs: []string{askingResult}}
 
@@ -156,7 +156,7 @@ const blockedNeedsResult = `{"gitmoot_result":{"decision":"blocked","summary":"m
 func TestMailboxRunSkipsJobGatesForPipelineStages(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "pipeline-x-runner", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "pipeline-runner"}
 	adapter := &fakeDelivery{outputs: []string{blockedNeedsResult}}
 
@@ -190,7 +190,7 @@ func TestMailboxRunSkipsJobGatesForPipelineStages(t *testing.T) {
 func TestMaybeResumeOnGatesClearedRefusesPipelineStages(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	agent := runtime.Agent{Name: "pipeline-x-runner", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "pipeline-runner"}
 	adapter := &fakeDelivery{outputs: []string{blockedNeedsResult}}
 

--- a/internal/workflow/pipeline_orchestrate_758_test.go
+++ b/internal/workflow/pipeline_orchestrate_758_test.go
@@ -38,7 +38,7 @@ func TestPipelineOrchestrateStageFansOutUnderStageJob(t *testing.T) {
 	// dispatchDelegations' preflight rejects the set before enqueuing any child.
 	seedAgent(t, store, "orch-child", []string{"review"}, orchestrateStageRepo)
 
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	const stageID = "prun-orch-1-stage-a0"
 	// Enqueue the orchestrate stage job exactly as pipelineStageJobRequest does: the
 	// pipeline sender, the OrchestrateStage authorization flag, and RootJobID = its
@@ -119,7 +119,7 @@ func TestNonOrchestratePipelineStageStillStripsDelegations(t *testing.T) {
 	engine := testEngine(store)
 	seedAgent(t, store, "orch-child", []string{"review"}, orchestrateStageRepo)
 
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	const stageID = "prun-leaf-1-stage-a0"
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
 		ID:        stageID,

--- a/internal/workflow/preset_delivery.go
+++ b/internal/workflow/preset_delivery.go
@@ -112,10 +112,10 @@ func (m Mailbox) usePresetReference(ctx context.Context, agent runtime.Agent, pa
 	if !decidePresetReference(presetDeliveryInputsWithState(base, true)) {
 		return false
 	}
-	if m.Store == nil {
+	if m.store == nil {
 		return false
 	}
-	has, err := m.Store.HasPresetSessionState(ctx, agent.Runtime, agent.RuntimeRef, presetID, payload.TemplateResolvedCommit)
+	has, err := m.store.HasPresetSessionState(ctx, agent.Runtime, agent.RuntimeRef, presetID, payload.TemplateResolvedCommit)
 	if err != nil || !has {
 		return false
 	}
@@ -141,7 +141,7 @@ func presetDeliveryInputsWithState(in presetDeliveryInputs, hasState bool) prese
 // effectiveRef is the session the NEXT job will resume: the refreshed ref when a
 // delivery re-pinned the session, else the agent's current ref.
 func (m Mailbox) recordPresetSessionState(ctx context.Context, agent runtime.Agent, payload JobPayload, effectiveRef string, referenceUsed bool) {
-	if m.Store == nil || referenceUsed {
+	if m.store == nil || referenceUsed {
 		return
 	}
 	mode := normalizePresetDeliveryMode(agent.PresetDelivery)
@@ -156,5 +156,5 @@ func (m Mailbox) recordPresetSessionState(ctx context.Context, agent runtime.Age
 	if !isConcreteSessionRef(effectiveRef) {
 		return
 	}
-	_ = m.Store.RecordPresetSessionState(ctx, agent.Runtime, effectiveRef, presetID, payload.TemplateResolvedCommit)
+	_ = m.store.RecordPresetSessionState(ctx, agent.Runtime, effectiveRef, presetID, payload.TemplateResolvedCommit)
 }

--- a/internal/workflow/preset_delivery_e2e_test.go
+++ b/internal/workflow/preset_delivery_e2e_test.go
@@ -35,7 +35,7 @@ func presetJobPayload(t *testing.T) string {
 func TestPresetDeliveryReferencedFiresOnlyWithPriorState(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	// A shell agent with a concrete, resumable session ref (a command) in
 	// referenced mode. referenced trusts the operator and fires on any runtime once
 	// state exists.
@@ -98,7 +98,7 @@ func TestPresetDeliveryReferencedFiresOnlyWithPriorState(t *testing.T) {
 func TestPresetDeliveryFullModeAlwaysSendsFullEvenWithState(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	// Pre-seed a matching state row: a full agent must ignore it entirely.
 	if err := store.RecordPresetSessionState(ctx, runtime.ShellRuntime, "printf ok", "thermo", "abc123"); err != nil {
 		t.Fatalf("seed RecordPresetSessionState: %v", err)
@@ -136,7 +136,7 @@ func TestPresetDeliveryFullModeAlwaysSendsFullEvenWithState(t *testing.T) {
 func TestPresetDeliveryAutoRequiresPersistedRuntime(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	// Shell leg: auto must NOT shorten (shell is not a persisted runtime).
 	if err := store.RecordPresetSessionState(ctx, runtime.ShellRuntime, "printf ok", "thermo", "abc123"); err != nil {
 		t.Fatalf("seed shell state: %v", err)
@@ -177,7 +177,7 @@ func TestPresetDeliveryAutoRequiresPersistedRuntime(t *testing.T) {
 func TestPresetDeliveryReferencedFallsBackOnCommitMismatch(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	// Marker recorded at an old commit; the job snapshots a newer commit.
 	if err := store.RecordPresetSessionState(ctx, runtime.ShellRuntime, "printf ok", "thermo", "old000"); err != nil {
 		t.Fatalf("seed state: %v", err)

--- a/internal/workflow/require_workflow_test.go
+++ b/internal/workflow/require_workflow_test.go
@@ -12,7 +12,7 @@ import (
 func TestMailboxRequireWorkflow(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mb := Mailbox{Store: store, RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "auto"} }}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "auto"} }}
 	job, err := mb.Enqueue(ctx, JobRequest{ID: "auto", Agent: "A_bad name", Action: "ask", Repo: "owner/repo", Sender: "local"})
 	if err != nil {
 		t.Fatal(err)
@@ -35,7 +35,7 @@ func TestMailboxRequireWorkflow(t *testing.T) {
 func TestMailboxRequireWorkflowStrictRejectsBeforeCreation(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mb := Mailbox{Store: store, RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "strict"} }}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "strict"} }}
 	_, err := mb.Enqueue(ctx, JobRequest{ID: "strict", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "local"})
 	if err == nil || !strings.Contains(err.Error(), "pass --workflow") {
 		t.Fatalf("err=%v", err)
@@ -68,7 +68,7 @@ func TestMailboxRequireWorkflowConfigCompatibility(t *testing.T) {
 			}
 			ctx := context.Background()
 			store := openTestStore(t)
-			mb := Mailbox{Store: store, RequireWorkflowPolicy: func(repo string) RequireWorkflowPolicy {
+			mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RequireWorkflowPolicy: func(repo string) RequireWorkflowPolicy {
 				policy := cfg.For(repo)
 				return RequireWorkflowPolicy{Enabled: policy.Enabled, Mode: policy.Mode}
 			}}
@@ -96,7 +96,7 @@ func TestMailboxRequireWorkflowConfigCompatibility(t *testing.T) {
 func TestMailboxRequireWorkflowExcludesInternalProducers(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mb := Mailbox{Store: store, RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "strict"} }}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "strict"} }}
 	for _, request := range []JobRequest{
 		{ID: "pipeline", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: PipelineJobSender},
 		{ID: "heartbeat", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "heartbeat"},
@@ -112,7 +112,7 @@ func TestMailboxRequireWorkflowExcludesInternalProducers(t *testing.T) {
 func TestMailboxRequireWorkflowPolicyExemptions(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mb := Mailbox{Store: store, RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "strict"} }}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RequireWorkflowPolicy: func(string) RequireWorkflowPolicy { return RequireWorkflowPolicy{Enabled: true, Mode: "strict"} }}
 	for _, request := range []JobRequest{
 		{ID: "engine", Agent: "a", Action: "review", Repo: "owner/repo", Sender: "lead", PolicyExempt: "exempt"},
 		{ID: "comment", Agent: "a", Action: "ask", Repo: "owner/repo", Sender: "operator", PolicyExempt: "auto-only"},

--- a/internal/workflow/result_checks.go
+++ b/internal/workflow/result_checks.go
@@ -157,7 +157,7 @@ func RunResultChecks(in ResultCheckInput) []ResultCheck {
 				Pass:        madePass,
 				Explanation: explain(madePass, "the implement job reports decision \"implemented\" but changes_made[] is empty"),
 			})
-			if in.Observation != nil && in.Observation.Error == "" {
+			if in.Observation != nil && in.Observation.Source == ResultObservationSourceWorktreeDiff && in.Observation.Error == "" {
 				invalidBindings := invalidCapturedBindingClaims(in.Observation.Changes, in.Observation.TouchedFiles)
 				consistent := !in.Observation.Divergent && len(invalidBindings) == 0
 				checks = append(checks, ResultCheck{

--- a/internal/workflow/result_checks_mailbox_test.go
+++ b/internal/workflow/result_checks_mailbox_test.go
@@ -22,7 +22,7 @@ func TestMailboxRunResultChecksOffIsByteIdentical(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
 	// Off (the zero value): no audit runs at all.
-	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksOff}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), resultCheckMode: ResultChecksOff}
 	adapter := &fakeDelivery{outputs: []string{vagueImplementResult}}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-off", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot"}); err != nil {
@@ -69,7 +69,7 @@ func TestMailboxRunResultChecksOffIsByteIdentical(t *testing.T) {
 func TestMailboxRunResultChecksWarnSurfacesButSucceeds(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksWarn}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), resultCheckMode: ResultChecksWarn}
 	adapter := &fakeDelivery{outputs: []string{vagueImplementResult}}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-warn", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot"}); err != nil {
@@ -133,7 +133,7 @@ func TestMailboxRunResultChecksWarnSurfacesButSucceeds(t *testing.T) {
 func TestMailboxRunResultChecksBlockFailsLikeContractViolation(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksBlock}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), resultCheckMode: ResultChecksBlock}
 	adapter := &fakeDelivery{outputs: []string{vagueImplementResult}}
 
 	if _, err := mailbox.Enqueue(ctx, JobRequest{ID: "job-block", Agent: "audit", Action: "implement", Repo: "gitmoot/gitmoot"}); err != nil {
@@ -189,7 +189,7 @@ func TestMailboxRunResultChecksWarnCleanResultIsQuiet(t *testing.T) {
 	// audit only fires on genuine failures, not on every job.
 	ctx := context.Background()
 	store := openTestStore(t)
-	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksWarn}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), resultCheckMode: ResultChecksWarn}
 	clean := `{"gitmoot_result":{"decision":"implemented","summary":"implemented X","findings":[],"changes_made":["added foo.go"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
 	adapter := &fakeDelivery{outputs: []string{clean}}
 

--- a/internal/workflow/result_observation.go
+++ b/internal/workflow/result_observation.go
@@ -14,7 +14,10 @@ import (
 	"github.com/gitmoot/gitmoot/internal/subprocess"
 )
 
-const ResultObservationSourceWorktreeDiff = "worktree_git_diff"
+const (
+	ResultObservationSourceWorktreeDiff                = "worktree_git_diff"
+	ResultObservationSourceWorktreeLessDelegationChild = "excluded_worktree_less_delegation_child"
+)
 
 var resultClaimLineSuffix = regexp.MustCompile(`:\d+(?:(?::|-)\d+)?$`)
 
@@ -127,12 +130,38 @@ type ResultObservation struct {
 	Error            string              `json:"error,omitempty"`
 }
 
+// excludedResultObservation records that a caller deliberately excluded a job
+// shape from worktree observation. Keeping the exclusion typed and persisted
+// makes it distinguishable from a completed observation with no divergence.
+func excludedResultObservation(source string, result AgentResult) *ResultObservation {
+	return &ResultObservation{
+		Source:           strings.TrimSpace(source),
+		TouchedFiles:     []string{},
+		Changes:          reportedChangeObservations(result.ChangesMade),
+		ClaimedOnlyFiles: []string{},
+		UnclaimedFiles:   []string{},
+		UnboundClaims:    []string{},
+		Divergent:        false,
+	}
+}
+
 // observeResultChanges captures the worktree diff and binds it to the result.
-// A nil observation means the engine has no owned worktree from which to read.
+// Callers must resolve or explicitly exclude the delivery worktree before this
+// function is reached; an empty path is therefore recorded as an observation
+// error rather than disappearing as nil.
 func observeResultChanges(ctx context.Context, worktree string, result AgentResult, backend execbackend.Backend) *ResultObservation {
 	worktree = strings.TrimSpace(worktree)
 	if worktree == "" {
-		return nil
+		return &ResultObservation{
+			Source:           ResultObservationSourceWorktreeDiff,
+			TouchedFiles:     []string{},
+			Changes:          reportedChangeObservations(result.ChangesMade),
+			ClaimedOnlyFiles: []string{},
+			UnclaimedFiles:   []string{},
+			UnboundClaims:    []string{},
+			Divergent:        false,
+			Error:            "observe worktree diff: resolved delivery worktree is empty",
+		}
 	}
 	files, err := execbackend.Consume(backend, func() ([]string, error) {
 		return changedWorktreeFiles(ctx, worktree)

--- a/internal/workflow/result_observation_test.go
+++ b/internal/workflow/result_observation_test.go
@@ -252,7 +252,7 @@ func TestMailboxResultObservationFlowsIntoOffWarnBlockGate(t *testing.T) {
 			ctx := context.Background()
 			store := openTestStore(t)
 			repo := observationTestRepo(t)
-			mailbox := Mailbox{Store: store, resultCheckMode: tc.mode}
+			mailbox := Mailbox{store: store, resolveDeliveryWorktree: PayloadDeliveryWorktreeResolver, resultCheckMode: tc.mode}
 			output := `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["updated absent.go"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
 			adapter := &fakeDelivery{outputs: []string{output}}
 			jobID := "observe-" + string(tc.mode)
@@ -296,7 +296,7 @@ func TestMailboxResultObservationFlagsUnclaimedDiffFile(t *testing.T) {
 	writeObservationFile(t, repo, "claimed.go", "package changed\n")
 	writeObservationFile(t, repo, "unmentioned.go", "package changed\n")
 
-	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksWarn}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: PayloadDeliveryWorktreeResolver, resultCheckMode: ResultChecksWarn}
 	output := `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["updated claimed.go"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
 	adapter := &fakeDelivery{outputs: []string{output}}
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
@@ -327,7 +327,7 @@ func TestMailboxObservationGapRecordsWithoutRefusingPersistence(t *testing.T) {
 	ctx := context.Background()
 	store := openTestStore(t)
 	notGit := t.TempDir()
-	mailbox := Mailbox{Store: store, resultCheckMode: ResultChecksBlock}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: PayloadDeliveryWorktreeResolver, resultCheckMode: ResultChecksBlock}
 	output := `{"gitmoot_result":{"decision":"implemented","summary":"done","findings":[],"changes_made":["updated foo.go"],"tests_run":["go test ./..."],"needs":[],"delegations":[]}}`
 	adapter := &fakeDelivery{outputs: []string{output}}
 	if _, err := mailbox.Enqueue(ctx, JobRequest{
@@ -359,7 +359,8 @@ func TestMailboxImportsChangeSetBeforeResultObservation(t *testing.T) {
 	store := openTestStore(t)
 	host, sandbox, changes := observationChangeSet(t, "claimed.go", "package imported\n")
 	mailbox := Mailbox{
-		Store: store,
+		store:                   store,
+		resolveDeliveryWorktree: PayloadDeliveryWorktreeResolver,
 		CollectChangeSet: func(context.Context, execbackend.Backend, string) (*execbackend.ChangeSet, error) {
 			return &changes, nil
 		},
@@ -396,7 +397,8 @@ func TestMailboxMalformedRedeliveryImportsFinalCumulativeChangeSet(t *testing.T)
 	base := strings.TrimSpace(runObservationGit(t, host, "rev-parse", "HEAD"))
 	collections := 0
 	mailbox := Mailbox{
-		Store: store,
+		store:                   store,
+		resolveDeliveryWorktree: PayloadDeliveryWorktreeResolver,
 		CollectChangeSet: func(context.Context, execbackend.Backend, string) (*execbackend.ChangeSet, error) {
 			collections++
 			changes, err := execbackend.BuildChangeSet(context.Background(), sandbox, base)
@@ -437,7 +439,8 @@ func TestMailboxImportFailureStopsBeforeObservation(t *testing.T) {
 	store := openTestStore(t)
 	host, _, changes := observationChangeSet(t, "claimed.go", "package imported\n")
 	mailbox := Mailbox{
-		Store: store,
+		store:                   store,
+		resolveDeliveryWorktree: PayloadDeliveryWorktreeResolver,
 		CollectChangeSet: func(context.Context, execbackend.Backend, string) (*execbackend.ChangeSet, error) {
 			return &changes, nil
 		},

--- a/internal/workflow/routing_telemetry.go
+++ b/internal/workflow/routing_telemetry.go
@@ -24,7 +24,7 @@ const maxRouterContextRows = 9
 // been applied to agent.Runtime by the caller); tokens are re-read from the job
 // row where the delivery persisted them (0 for a runtime that reports none).
 func (m Mailbox) recordRoutingTelemetry(ctx context.Context, job db.Job, agent runtime.Agent, payload JobPayload, result AgentResult, state JobState, duration time.Duration) {
-	if m.Store == nil {
+	if m.store == nil {
 		return
 	}
 	// Use the delivery resolver so telemetry cannot drift from the runtime's model
@@ -46,10 +46,10 @@ func (m Mailbox) recordRoutingTelemetry(ctx context.Context, job db.Job, agent r
 	// delegation budget's view (deliver() accumulates usage onto the job row). A
 	// read error just leaves tokens at 0 — advisory only.
 	var inTok, outTok int
-	if fresh, err := m.Store.GetJob(ctx, job.ID); err == nil {
+	if fresh, err := m.store.GetJob(ctx, job.ID); err == nil {
 		inTok, outTok = fresh.InputTokens, fresh.OutputTokens
 	}
-	_ = m.Store.InsertRoutingTelemetry(ctx, db.RoutingTelemetry{
+	_ = m.store.InsertRoutingTelemetry(ctx, db.RoutingTelemetry{
 		JobID:          job.ID,
 		Repo:           payload.Repo,
 		Action:         job.Type,
@@ -79,10 +79,10 @@ func (m Mailbox) recordRoutingTelemetry(ctx context.Context, job db.Job, agent r
 // knob AND on the job being a top-level (coordinator) job, so with the knob off no
 // query runs and the prompt is byte-identical.
 func (m Mailbox) buildRouterContextBlock(ctx context.Context, payload JobPayload) string {
-	if m.Store == nil {
+	if m.store == nil {
 		return ""
 	}
-	rows, err := m.Store.ListRoutingTelemetry(ctx, db.RoutingTelemetryFilter{Repo: strings.TrimSpace(payload.Repo)})
+	rows, err := m.store.ListRoutingTelemetry(ctx, db.RoutingTelemetryFilter{Repo: strings.TrimSpace(payload.Repo)})
 	if err != nil || len(rows) == 0 {
 		return ""
 	}

--- a/internal/workflow/routing_telemetry_test.go
+++ b/internal/workflow/routing_telemetry_test.go
@@ -23,7 +23,7 @@ func TestRoutingTelemetryRecordsRuntimeDefaultModel(t *testing.T) {
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`,
 	}}
-	m := Mailbox{Store: store, RuntimeDefaultModel: func(rt string) string {
+	m := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), RuntimeDefaultModel: func(rt string) string {
 		if rt == runtime.ShellRuntime {
 			return "gpt-5.5"
 		}
@@ -57,7 +57,7 @@ func TestRoutingTelemetryRecordsAdapterFailure(t *testing.T) {
 	seedAgent(t, store, "flaky", []string{"implement"}, "gitmoot/gitmoot")
 	agent := runtime.Agent{Name: "flaky", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "agent"}
 	adapter := &fakeDelivery{err: errors.New("adapter boom")}
-	m := Mailbox{Store: store}
+	m := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if _, err := m.Enqueue(ctx, JobRequest{ID: "flaky-job", Agent: "flaky", Action: "implement", Repo: "gitmoot/gitmoot", Branch: "task-1", TaskID: "task-1", TaskTitle: "Flaky"}); err != nil {
 		t.Fatalf("Enqueue error: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestRunJobRecordsRoutingTelemetry(t *testing.T) {
 	adapter := &fakeDelivery{outputs: []string{
 		`{"gitmoot_result":{"decision":"approved","summary":"looks good","findings":[],"changes_made":[],"tests_run":["go test"],"needs":[],"delegations":[]}}`,
 	}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID:        "review-job",
 		Agent:     "audit",
 		Action:    "review",
@@ -135,7 +135,7 @@ func TestRunJobRecordsRoutingTelemetry(t *testing.T) {
 func TestRoutingTelemetryFailureIsSwallowed(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
-	m := Mailbox{Store: store}
+	m := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	// Close the underlying DB so every telemetry query errors.
 	if err := store.Close(); err != nil {
 		t.Fatalf("Close error: %v", err)
@@ -176,10 +176,10 @@ func TestRouterContextOffByDefaultIdenticalPrompt(t *testing.T) {
 
 	// OFF (default construction): prompt has no router block.
 	offAdapter := &fakeDelivery{outputs: []string{`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, req); err != nil {
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, req); err != nil {
 		t.Fatalf("Enqueue off error: %v", err)
 	}
-	if _, err := (Mailbox{Store: store}).Run(ctx, "coord", agent, offAdapter); err != nil {
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Run(ctx, "coord", agent, offAdapter); err != nil {
 		t.Fatalf("Run off error: %v", err)
 	}
 	if len(offAdapter.prompts) != 1 {
@@ -194,10 +194,10 @@ func TestRouterContextOffByDefaultIdenticalPrompt(t *testing.T) {
 	onReq := req
 	onReq.ID = "coord2"
 	onAdapter := &fakeDelivery{outputs: []string{`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, onReq); err != nil {
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, onReq); err != nil {
 		t.Fatalf("Enqueue on error: %v", err)
 	}
-	if _, err := (Mailbox{Store: store, routerContextEnabled: true}).Run(ctx, "coord2", agent, onAdapter); err != nil {
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), routerContextEnabled: true}).Run(ctx, "coord2", agent, onAdapter); err != nil {
 		t.Fatalf("Run on error: %v", err)
 	}
 	if len(onAdapter.prompts) != 1 {
@@ -233,14 +233,14 @@ func TestRouterContextSkippedForDelegationChild(t *testing.T) {
 		t.Fatalf("seed telemetry error: %v", err)
 	}
 	agent := runtime.Agent{Name: "worker", Runtime: runtime.ShellRuntime, RuntimeRef: "printf ok", RepoScope: "gitmoot/gitmoot", Role: "agent"}
-	if _, err := (Mailbox{Store: store}).Enqueue(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).Enqueue(ctx, JobRequest{
 		ID: "child", Agent: "worker", Action: "review", Repo: "gitmoot/gitmoot", Branch: "task-1", TaskID: "task-1", TaskTitle: "Child",
 		ParentJobID: "some-parent", DelegationID: "d1",
 	}); err != nil {
 		t.Fatalf("Enqueue child error: %v", err)
 	}
 	adapter := &fakeDelivery{outputs: []string{`{"gitmoot_result":{"decision":"approved","summary":"ok","findings":[],"changes_made":[],"tests_run":[],"needs":[],"delegations":[]}}`}}
-	if _, err := (Mailbox{Store: store, routerContextEnabled: true}).Run(ctx, "child", agent, adapter); err != nil {
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree"), routerContextEnabled: true}).Run(ctx, "child", agent, adapter); err != nil {
 		t.Fatalf("Run child error: %v", err)
 	}
 	if strings.Contains(adapter.prompts[0], "Observed routing performance") {

--- a/internal/workflow/session_job.go
+++ b/internal/workflow/session_job.go
@@ -69,7 +69,7 @@ func ParseSessionJobDisplayEvent(event db.JobEvent) (SessionJobDisplayEvent, boo
 // result and move the job to its terminal state; lifecycle maintenance separately
 // cancels a genuinely orphaned session row.
 func (m Mailbox) OpenExternalJob(ctx context.Context, request JobRequest) (db.Job, error) {
-	if m.Store == nil {
+	if m.store == nil {
 		return db.Job{}, errors.New("mailbox store is required")
 	}
 	if err := validateJobRequest(request); err != nil {
@@ -117,7 +117,7 @@ func (m Mailbox) OpenExternalJob(ctx context.Context, request JobRequest) (db.Jo
 	if displayEvent, ok := sessionJobDisplayEvent(job.ID, request.HeadSHA); ok {
 		events = append(events, displayEvent)
 	}
-	if err := m.Store.CreateExternallyDrivenJobWithEvent(ctx, job, events[0], events[1:]...); err != nil {
+	if err := m.store.CreateExternallyDrivenJobWithEvent(ctx, job, events[0], events[1:]...); err != nil {
 		return db.Job{}, err
 	}
 	return job, nil
@@ -145,14 +145,14 @@ func (m Mailbox) CloseExternalJob(ctx context.Context, jobID string, result Agen
 // transition share one transaction, so a terminal session row cannot lose usage
 // that was part of the accepted close operation.
 func (m Mailbox) CloseExternalJobWithUsage(ctx context.Context, jobID string, result AgentResult, prOverride int, headSHAOverride, branchOverride string, usage ExternalJobUsage) (db.Job, error) {
-	if m.Store == nil {
+	if m.store == nil {
 		return db.Job{}, errors.New("mailbox store is required")
 	}
 	if _, ok := allowedSet(ResultDecisions)[result.Decision]; !ok {
 		return db.Job{}, fmt.Errorf("unsupported decision %q; want one of %s", result.Decision, strings.Join(ResultDecisions, ", "))
 	}
 
-	job, err := m.Store.GetJob(ctx, jobID)
+	job, err := m.store.GetJob(ctx, jobID)
 	if err != nil {
 		return db.Job{}, err
 	}
@@ -188,7 +188,7 @@ func (m Mailbox) CloseExternalJobWithUsage(ctx context.Context, jobID string, re
 	if displayEvent, ok := sessionJobDisplayEvent(jobID, headSHAOverride); ok {
 		extraEvents = append(extraEvents, displayEvent)
 	}
-	transitioned, err := m.Store.TransitionJobStatePayloadUsageWithEvent(ctx, jobID, string(JobRunning), string(state), encoded,
+	transitioned, err := m.store.TransitionJobStatePayloadUsageWithEvent(ctx, jobID, string(JobRunning), string(state), encoded,
 		strings.TrimSpace(usage.Model), usage.InputTokens, usage.OutputTokens, db.JobEvent{
 			JobID:   jobID,
 			Kind:    string(state),
@@ -198,7 +198,7 @@ func (m Mailbox) CloseExternalJobWithUsage(ctx context.Context, jobID string, re
 		return db.Job{}, err
 	}
 	if !transitioned {
-		latest, getErr := m.Store.GetJob(ctx, jobID)
+		latest, getErr := m.store.GetJob(ctx, jobID)
 		if getErr != nil {
 			return db.Job{}, getErr
 		}
@@ -210,7 +210,7 @@ func (m Mailbox) CloseExternalJobWithUsage(ctx context.Context, jobID string, re
 	if m.emitTerminal != nil {
 		m.emitTerminal(ctx, jobID, state, payload)
 	}
-	return m.Store.GetJob(ctx, jobID)
+	return m.store.GetJob(ctx, jobID)
 }
 
 // OpenExternalJob records a session job's clock-in through the engine's Mailbox so

--- a/internal/workflow/session_job_test.go
+++ b/internal/workflow/session_job_test.go
@@ -20,7 +20,7 @@ func TestOpenExternalJobCreatesRunningNoQueue(t *testing.T) {
 	store := openEngineStore(t)
 	seedAgent(t, store, "lead", []string{"ask"}, "gitmoot/gitmoot")
 
-	job, err := (Mailbox{Store: store}).OpenExternalJob(ctx, JobRequest{
+	job, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).OpenExternalJob(ctx, JobRequest{
 		ID:      "session-ask-lead-1",
 		Agent:   "lead",
 		Action:  "ask",
@@ -160,7 +160,7 @@ func TestCloseExternalJobRecordsPRAndBranch(t *testing.T) {
 	store := openEngineStore(t)
 	seedAgent(t, store, "lead", []string{"review"}, "gitmoot/gitmoot")
 
-	if _, err := (Mailbox{Store: store}).OpenExternalJob(ctx, JobRequest{
+	if _, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).OpenExternalJob(ctx, JobRequest{
 		ID:     "session-review",
 		Agent:  "lead",
 		Action: "review",
@@ -168,7 +168,7 @@ func TestCloseExternalJobRecordsPRAndBranch(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("OpenExternalJob returned error: %v", err)
 	}
-	closed, err := (Mailbox{Store: store}).CloseExternalJob(ctx, "session-review", AgentResult{
+	closed, err := (Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}).CloseExternalJob(ctx, "session-review", AgentResult{
 		Decision: "approved",
 		Summary:  "reviewed",
 	}, 42, "reviewed-head", "feat/x")
@@ -196,7 +196,7 @@ func TestCloseExternalReviewPersistsReportedGrade(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "lead", []string{"review"}, "gitmoot/gitmoot")
-	mb := Mailbox{Store: store}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	if _, err := mb.OpenExternalJob(ctx, JobRequest{
 		ID:     "session-review-grade",
@@ -229,7 +229,7 @@ func TestCloseExternalJobErrors(t *testing.T) {
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "lead", []string{"ask"}, "gitmoot/gitmoot")
-	mb := Mailbox{Store: store}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 
 	// Unknown id.
 	if _, err := mb.CloseExternalJob(ctx, "nope", AgentResult{Decision: "approved"}, 0, "", ""); err == nil {
@@ -269,7 +269,7 @@ func TestCloseExternalJobAfterGhostReaperReturnsCleanAlreadyClosedError(t *testi
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "lead", []string{"ask"}, "gitmoot/gitmoot")
-	mb := Mailbox{Store: store}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if _, err := mb.OpenExternalJob(ctx, JobRequest{
 		ID:         "session-race",
 		Agent:      "lead",
@@ -316,7 +316,7 @@ func TestRetryJobRefusesSessionJob(t *testing.T) {
 	store := openEngineStore(t)
 	seedAgent(t, store, "lead", []string{"implement"}, "gitmoot/gitmoot")
 
-	mb := Mailbox{Store: store}
+	mb := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	if _, err := mb.OpenExternalJob(ctx, JobRequest{ID: "sess-retry", Agent: "lead", Action: "implement", Repo: "gitmoot/gitmoot"}); err != nil {
 		t.Fatalf("OpenExternalJob returned error: %v", err)
 	}

--- a/internal/workflow/workflow_id_test.go
+++ b/internal/workflow/workflow_id_test.go
@@ -79,7 +79,7 @@ func TestMailboxRejectsInvalidWorkflowIDAndExternalJobPersistsValidID(t *testing
 	ctx := context.Background()
 	store := openEngineStore(t)
 	seedAgent(t, store, "coord", []string{"ask"}, "acme/widget")
-	mailbox := Mailbox{Store: store}
+	mailbox := Mailbox{store: store, resolveDeliveryWorktree: ExcludedDeliveryWorktreeResolver("test_explicit_no_worktree")}
 	_, err := mailbox.Enqueue(ctx, JobRequest{ID: "bad", Agent: "coord", Action: "ask", Repo: "acme/widget", WorkflowID: "Bad_ID"})
 	if err == nil || !strings.Contains(err.Error(), "invalid workflow id") {
 		t.Fatalf("invalid enqueue error = %v", err)

--- a/skills/gitmoot/references/CLI.md
+++ b/skills/gitmoot/references/CLI.md
@@ -2547,10 +2547,13 @@ contract-hygiene audit that catches results that are technically valid but vague
 or missing evidence. Each check is a yes/no question with an explanation, e.g.:
 
 - **implement** — a result whose decision is `implemented` must list its
-  `changes_made` and its `tests_run`. When the engine owns a job worktree, it
-  also persists `payload.result_observation` from the worktree diff and fails
-  `implement-changes-observed` if a claim names a path absent from the diff, a
-  claim names no file path, or the diff contains a path no claim mentions.
+  `changes_made` and its `tests_run`. The engine resolves the effective checkout
+  selected by the worker, persists `payload.result_observation` from its diff,
+  and fails `implement-changes-observed` if a claim names a path absent from the
+  diff, a claim names no file path, or the diff contains a path no claim
+  mentions. A worktree-less delegation child instead persists the typed source
+  `excluded_worktree_less_delegation_child`; exclusion is observable and is not
+  graded as diff evidence.
 - **review** — a `changes_requested` review must carry `findings` (evidence).
 - **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
   actionable.

--- a/skills/gitmoot/references/RESULT_CONTRACT.md
+++ b/skills/gitmoot/references/RESULT_CONTRACT.md
@@ -552,10 +552,14 @@ work was available. Produce remains a leaf, so its delegations are stripped.
 - Do not claim tests were run unless they were actually run.
 - Do not claim files were changed unless they were actually changed. Name
   repo-relative file paths in each `changes_made` entry. At result persistence,
-  an engine-run implement job with an owned worktree records
-  `payload.result_observation`: the files in `git diff HEAD` plus untracked
-  files, each claim's path binding, claimed-only paths, and diff files no claim
-  mentions. A claim that names a repo-relative path is graded `observed` only
+  an ordinary engine-run implement job resolves the effective checkout selected
+  by the worker and records `payload.result_observation`: the files in
+  `git diff HEAD` plus untracked files, each claim's path binding, claimed-only
+  paths, and diff files no claim mentions. A worktree-less delegation child is
+  deliberately not graded against the shared registered checkout; it records a
+  typed observation whose source is
+  `excluded_worktree_less_delegation_child`, rather than omitting the field. A
+  claim that names a repo-relative path is graded `observed` only
   when both its claimed path and per-change observation bind to that exact
   normalized path in `touched_files`. If capture membership is absent or
   indeterminate, the grade remains `reported`. A unique-basename match may

--- a/website/docs/reference/cli.md
+++ b/website/docs/reference/cli.md
@@ -2312,10 +2312,13 @@ contract-hygiene audit that catches results that are technically valid but vague
 or missing evidence. Each check is a yes/no question with an explanation:
 
 - **implement** — a result whose decision is `implemented` must list its
-  `changes_made` and its `tests_run`. When the engine owns a job worktree, it
-  also persists `payload.result_observation` from the worktree diff and fails
-  `implement-changes-observed` if a claim names a path absent from the diff, a
-  claim names no file path, or the diff contains a path no claim mentions.
+  `changes_made` and its `tests_run`. The engine resolves the effective checkout
+  selected by the worker, persists `payload.result_observation` from its diff,
+  and fails `implement-changes-observed` if a claim names a path absent from the
+  diff, a claim names no file path, or the diff contains a path no claim
+  mentions. A worktree-less delegation child instead persists the typed source
+  `excluded_worktree_less_delegation_child`; exclusion is observable and is not
+  graded as diff evidence.
 - **review** — a `changes_requested` review must carry `findings` (evidence).
 - **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
   actionable.

--- a/website/docs/reference/result-contract.md
+++ b/website/docs/reference/result-contract.md
@@ -45,10 +45,14 @@ The `decision` field reports the outcome of the job:
 The narrative and evidence fields are reporting-only. Do not claim tests were run
 in `tests_run` unless they were actually run, and do not list files in
 `changes_made` unless they were actually changed. Name repo-relative file paths
-in each `changes_made` entry. At result persistence, an engine-run implement job
-with an owned worktree records `payload.result_observation`: the files in
-`git diff HEAD` plus untracked files, each claim's path binding, claimed-only
-paths, and diff files no claim mentions. A claim that names a repo-relative path
+in each `changes_made` entry. At result persistence, an ordinary engine-run
+implement job resolves the effective checkout selected by the worker and records
+`payload.result_observation`: the files in `git diff HEAD` plus untracked files,
+each claim's path binding, claimed-only paths, and diff files no claim mentions.
+A worktree-less delegation child is deliberately not graded against the shared
+registered checkout; it records a typed observation whose source is
+`excluded_worktree_less_delegation_child`, rather than omitting the field. A
+claim that names a repo-relative path
 is graded `observed` only when both its claimed path and per-change observation
 bind to that exact normalized path in `touched_files`. If capture membership is
 absent or indeterminate, the grade remains `reported`. A unique-basename match

--- a/website/static/llms-full.txt
+++ b/website/static/llms-full.txt
@@ -12648,10 +12648,13 @@ contract-hygiene audit that catches results that are technically valid but vague
 or missing evidence. Each check is a yes/no question with an explanation, e.g.:
 
 - **implement** — a result whose decision is `implemented` must list its
-  `changes_made` and its `tests_run`. When the engine owns a job worktree, it
-  also persists `payload.result_observation` from the worktree diff and fails
-  `implement-changes-observed` if a claim names a path absent from the diff, a
-  claim names no file path, or the diff contains a path no claim mentions.
+  `changes_made` and its `tests_run`. The engine resolves the effective checkout
+  selected by the worker, persists `payload.result_observation` from its diff,
+  and fails `implement-changes-observed` if a claim names a path absent from the
+  diff, a claim names no file path, or the diff contains a path no claim
+  mentions. A worktree-less delegation child instead persists the typed source
+  `excluded_worktree_less_delegation_child`; exclusion is observable and is not
+  graded as diff evidence.
 - **review** — a `changes_requested` review must carry `findings` (evidence).
 - **ask** — the answer (`summary`/`artifact_body`) must be non-empty and
   actionable.
@@ -17361,10 +17364,14 @@ work was available. Produce remains a leaf, so its delegations are stripped.
 - Do not claim tests were run unless they were actually run.
 - Do not claim files were changed unless they were actually changed. Name
   repo-relative file paths in each `changes_made` entry. At result persistence,
-  an engine-run implement job with an owned worktree records
-  `payload.result_observation`: the files in `git diff HEAD` plus untracked
-  files, each claim's path binding, claimed-only paths, and diff files no claim
-  mentions. A claim that names a repo-relative path is graded `observed` only
+  an ordinary engine-run implement job resolves the effective checkout selected
+  by the worker and records `payload.result_observation`: the files in
+  `git diff HEAD` plus untracked files, each claim's path binding, claimed-only
+  paths, and diff files no claim mentions. A worktree-less delegation child is
+  deliberately not graded against the shared registered checkout; it records a
+  typed observation whose source is
+  `excluded_worktree_less_delegation_child`, rather than omitting the field. A
+  claim that names a repo-relative path is graded `observed` only
   when both its claimed path and per-change observation bind to that exact
   normalized path in `touched_files`. If capture membership is absent or
   indeterminate, the grade remains `reported`. A unique-basename match may


### PR DESCRIPTION
WHAT:
Implemented #1570 with a required delivery-worktree resolver seam and verified persisted observation for ordinary implement jobs.

WHY:
Gitmoot finalized this implementation from a task worktree.

CHANGES:
- Committed changes from /root/.gitmoot/worktrees/gitmoot--gitmoot/adhoc-5ec929f9

RESULTS:
- go build ./... passed.
- go generate ./... produced an identical before/after working diff.
- go vet ./... passed.
- go test -count=1 -timeout 25m ./internal/workflow passed.
- Both new internal/cli firing tests passed normally and under -race.
- Mutation proof: ordinary anchor census 1, baseline -run matches 1, mutant compiled with exit 0 and test failed; excluded anchor census 1, baseline -run matches 1, mutant compiled with exit 0 and test failed.
- npm install && npm run build passed for the Docusaurus website.
- Isolated destination job local-implement-observation-probe-18cd1c3ce74bd2a9 persisted a non-null clean result_observation.
- Full package testing passed outside internal/cli; the final internal/cli run retained only the three base-reproduced failures listed in findings.

RISK:
Review the generated diff before merging.

TASK:
adhoc-5ec929f9

AGENTS:
- wave-impl

RAW FINAL REVIEW OUTPUT:
````text
Implemented #1570 with a required delivery-worktree resolver seam and verified persisted observation for ordinary implement jobs.
````
